### PR TITLE
Changed unmarshalling integration test to use parametrized unit tests and a separate coverage test

### DIFF
--- a/integration-tests/src/test/java/org/opennms/netmgt/config/WillItUnmarshalCoverageMetaTest.java
+++ b/integration-tests/src/test/java/org/opennms/netmgt/config/WillItUnmarshalCoverageMetaTest.java
@@ -1,3 +1,31 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2009-2012 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2012 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
 package org.opennms.netmgt.config;
 
 import com.google.common.base.Function;

--- a/integration-tests/src/test/java/org/opennms/netmgt/config/WillItUnmarshalTest.java
+++ b/integration-tests/src/test/java/org/opennms/netmgt/config/WillItUnmarshalTest.java
@@ -1,3 +1,31 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2009-2012 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2012 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
 package org.opennms.netmgt.config;
 
 import java.io.File;


### PR DESCRIPTION
The famous WillItUnmarshall unit test now uses some parametrized test magic to make the integration tests for the configuration files more easy and avoids adding multiple lines of code for each new configuration file.

Using this method, a new configuration file can be added by adding one single line of code and a new test instance for this file is created automagically.

This also moves the test coverage mechanism for the old version to a separate class, testing the coverage of the WillItUnmarshall test without making assumptions on the test execution order as the current version does. This meta test also uses the parametrized test feature to provide a test instance for each file in the /etc directories checking the coverage for this file and providing a clean test failure if the file is not covered and allowing easy debugging of test failures. 
