### PR TITLE
Vacuumd doesn't listen for uei.opennms.org/internal/reloadDaemonConfig events

### DIFF
--- a/opennms-services/src/main/java/org/opennms/netmgt/vacuumd/Vacuumd.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/vacuumd/Vacuumd.java
@@ -115,6 +115,7 @@ public class Vacuumd extends AbstractServiceDaemon implements Runnable, EventLis
             LOG.info("Loading the configuration file.");
             VacuumdConfigFactory.init();
             getEventManager().addEventListener(this, EventConstants.RELOAD_VACUUMD_CONFIG_UEI);
+            getEventManager().addEventListener(this, EventConstants.RELOAD_DAEMON_CONFIG_UEI);
 
             initializeDataSources();
         } catch (Throwable ex) {


### PR DESCRIPTION
Fixed by adding the listener, the event is already handled properly. Added a test case to verify.
