### PR TITLE
Fixing debian init script to warn on error

### DIFF
--- a/debian/opennms-server.opennms.init
+++ b/debian/opennms-server.opennms.init
@@ -54,12 +54,14 @@ export JAVA_HOME
 case "$1" in
   start)
 	echo -n "Starting $DESC: $NAME"
-	$DAEMON start > /dev/null
+	DAEMON_MESSAGES=$($DAEMON start)
+	# hide message if opennms says it's ok
+	echo $OUTPUT | grep -v "Starting OpenNMS: ok"
 	echo "."
 	;;
   stop)
 	echo -n "Stopping $DESC: $NAME"
-	$DAEMON stop > /dev/null
+	DAEMON_MESSAGES=$($DAEMON stop)
 	rm -f /var/run/$NAME.pid
 	echo "."
 	;;


### PR DESCRIPTION
Because it's actually calling another startup script, the normal way of
starting up can mask errors and make it hard to troubleshoot.

This should output the original failure if the underlying script gives
an error.

Example error:

```
Starting OpenNMS:
WARNING!  The following file(s) contain the
'non-ip-snmp-primary' or 'non-ip-interfaces' attributes,
which were deprecated in OpenNMS 1.10 and removed in
OpenNMS 1.11.

Please check your import files and remove the deprecated
attributes, and restart.

failed
```
