### PR TITLE
Update BSF detector to pass port and timeout to script

### DIFF
--- a/opennms-provision/opennms-detector-bsf/src/main/java/org/opennms/netmgt/provision/detector/bsf/client/BSFClient.java
+++ b/opennms-provision/opennms-detector-bsf/src/main/java/org/opennms/netmgt/provision/detector/bsf/client/BSFClient.java
@@ -101,6 +101,8 @@ public class BSFClient implements Client<BSFRequest, BSFResponse> {
                 // bsfManager.declareBean("node_label", svc.getNodeLabel(), String.class);
                 bsfManager.declareBean("svc_name", m_serviceName, String.class);
                 bsfManager.declareBean("results", m_results, HashMap.class);
+                bsfManager.declareBean("port", port, Integer.class);
+                bsfManager.declareBean("timeout", timeout, Integer.class);
 
                 for (final Entry<String, Object> entry : map.entrySet()) {
                     bsfManager.declareBean(entry.getKey(), entry.getValue(), String.class);


### PR DESCRIPTION
Send the port and timeout to the Beanshell script when using the BSF detector. Useful if you recycle the same detection script on multiple ports.
