### PR TITLE
Service monitors for tables found in UCD-SNMP-MIB

### DIFF
--- a/opennms-services/src/main/java/org/opennms/netmgt/poller/monitors/DskTableMonitor.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/poller/monitors/DskTableMonitor.java
@@ -179,14 +179,7 @@ final public class DskTableMonitor extends SnmpMonitorStrategy {
 
             //Check the arraylist and construct return value
             if (errorStringReturn.size() > 0) {
-              String errormsg="";
-              int j = 0;
-              while (errorStringReturn.size() > j) {
-                errormsg+=errorStringReturn.get(j);
-                if (j < (errorStringReturn.size()-1)) { errormsg+= "\n"; }
-                j++;
-              }
-              return PollStatus.unavailable(errormsg);
+              return PollStatus.unavailable(errorStringReturn.toString());
             }
             else {
               return status;

--- a/opennms-services/src/main/java/org/opennms/netmgt/poller/monitors/LaTableMonitor.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/poller/monitors/LaTableMonitor.java
@@ -179,14 +179,7 @@ final public class LaTableMonitor extends SnmpMonitorStrategy {
 
             //Check the arraylist and construct return value
             if (errorStringReturn.size() > 0) {
-              String errormsg="";
-              int j = 0;
-              while (errorStringReturn.size() > j) {
-                errormsg+=errorStringReturn.get(j);
-                if (j < (errorStringReturn.size()-1)) { errormsg+= "\n"; }
-                j++;
-              }
-              return PollStatus.unavailable(errormsg);
+              return PollStatus.unavailable(errorStringReturn.toString());
             }
             else {
               return status;

--- a/opennms-services/src/main/java/org/opennms/netmgt/poller/monitors/LogMatchTableMonitor.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/poller/monitors/LogMatchTableMonitor.java
@@ -184,14 +184,7 @@ final public class LogMatchTableMonitor extends SnmpMonitorStrategy {
 
             //Check the arraylist and construct return value
             if (errorStringReturn.size() > 0) {
-              String errormsg="";
-              int j = 0;
-              while (errorStringReturn.size() > j) {
-                errormsg+=errorStringReturn.get(j);
-                if (j < (errorStringReturn.size()-1)) { errormsg+= "\n"; }
-                j++;
-              }
-              return PollStatus.unavailable(errormsg);
+              return PollStatus.unavailable(errorStringReturn.toString());
             }
             else {
               return status;

--- a/opennms-services/src/main/java/org/opennms/netmgt/poller/monitors/PrTableMonitor.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/poller/monitors/PrTableMonitor.java
@@ -179,14 +179,7 @@ final public class PrTableMonitor extends SnmpMonitorStrategy {
 
             //Check the arraylist and construct return value
             if (errorStringReturn.size() > 0) {
-              String errormsg="";
-              int j = 0;
-              while (errorStringReturn.size() > j) {
-                errormsg+=errorStringReturn.get(j);
-                if (j < (errorStringReturn.size()-1)) { errormsg+= "\n"; }
-                j++;
-              }
-              return PollStatus.unavailable(errormsg);
+              return PollStatus.unavailable(errorStringReturn.toString());
             }
             else {
               return status;


### PR DESCRIPTION
While most of these could be monitored via a configured threshold, there are a few situations where a "set it and forget it" service monitor would be helpful. Sites with existing configurations for net-snmp should find these useful. The main inspiration for these is that at my site, we have existing configurations for net-snmp process, disk, load and logfile watching, that are managed by puppet, with different thresholds/configs set per machine role. Wanted to migrate from a trap based approach that has been working for years to a service based approach that requires minimal configuration on the onms side. Shamelessly based off the DiskUsageMonitor.
