### PR TITLE
New sshd syslogd ueimatch definition

### DIFF
--- a/opennms-base-assembly/src/main/filtered/etc/events/OpenSSH.syslog.events.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/events/OpenSSH.syslog.events.xml
@@ -47,6 +47,25 @@
         <alarm-data reduction-key="%uei%:%dpname%:%nodeid%:%interface%:%parm[user]%" alarm-type="3" auto-clean="false" />
     </event>
     <event>
+        <uei>uei.opennms.org/vendor/openssh/syslog/sshd/authenticationRefused</uei>
+        <event-label>OpenSSH-defined event: authentication refused</event-label>
+        <descr>
+            &lt;p&gt;The OpenSSH sshd daemon refused to perform an authentication. It may happens, for example, when the OpenSSH server uses public key based authentication, and the authorized_keys file does not have the proper permissions and ownership. &lt;br&gt;
+            Reason: %parm[errorMessage]%&lt;br&gt;
+            Host: %nodelabel%&lt;br&gt;
+            Interface: %interface% &lt;br&gt;
+            Message: %parm[syslogmessage]% &lt;br&gt;
+            Process: %parm[process]% &lt;br&gt;
+            PID: %parm[processid]%
+            &lt;/p&gt;
+        </descr>
+        <logmsg dest='logndisplay'>
+            &lt;p&gt;OpenSSH server on node %nodelabel% refused to perform some authentication &lt;/p&gt;
+        </logmsg>
+        <severity>Warning</severity>
+        <alarm-data reduction-key="%uei%:%dpname%:%nodeid%:%interface%" alarm-type="3" auto-clean="false" />
+    </event>
+    <event>
         <uei>uei.opennms.org/vendor/openssh/syslog/sshd/bindFailure</uei>
         <event-label>OpenSSH-defined event: Socket bind failure</event-label>
         <descr>

--- a/opennms-base-assembly/src/main/filtered/etc/syslog/OpenSSH.syslog.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/syslog/OpenSSH.syslog.xml
@@ -34,6 +34,12 @@
         </ueiMatch>
         <ueiMatch>
             <process-match expression="^sshd$" />
+            <match type="regex" expression="^Authentication refused: (.*)$" />
+            <uei>uei.opennms.org/vendor/openssh/syslog/sshd/authenticationRefused</uei>
+                <parameter-assignment matching-group="1" parameter-name="errorMessage" />
+        </ueiMatch>
+        <ueiMatch>
+            <process-match expression="^sshd$" />
             <match type="substr" expression="Cannot bind any address." />
             <uei>uei.opennms.org/vendor/openssh/syslog/sshd/totalBindFailure</uei>
         </ueiMatch>


### PR DESCRIPTION
This patch adds a new ueiMatch definition for sshd syslog messages.

Forgive me if I could not fully test this patch, as the correct regex for me must start by '^.*?' and not '^' (see bug http://issues.opennms.org/browse/NMS-6539).

I did test the '^.*?Authentication refused...' regular expression tough.

Cyrille Bollu
