### PR TITLE
NMS-6736: IMAP poller does not work with NGINX

### DIFF
--- a/opennms-services/src/main/java/org/opennms/netmgt/poller/monitors/ImapMonitor.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/poller/monitors/ImapMonitor.java
@@ -108,7 +108,7 @@ final public class ImapMonitor extends AbstractServiceMonitor {
     /**
      * The BYE response received from the server in response to the logout
      */
-    private static String IMAP_BYE_RESPONSE_PREFIX = "* BYE ";
+    private static String IMAP_BYE_RESPONSE_PREFIX = "* BYE";
 
     /**
      * The LOGOUT response received from the server in response to the logout


### PR DESCRIPTION
- Improve IMAP monitor to be able to deal with NGINX

JIRA: http://issues.opennms.org/browse/NMS-6736

Todo:
- [ ] Sign OCA
- [ ] Pass IMAP monitor unit tests
- [ ] 4-eye review
- [ ] Close JIRA issue
