### PR TITLE
Adding support for the "storeByForeignSource" feature of OpenNMS

### DIFF
--- a/integrations/opennms-jasper-extensions/src/main/java/org/opennms/netmgt/jasper/resource/ResourceQuery.java
+++ b/integrations/opennms-jasper-extensions/src/main/java/org/opennms/netmgt/jasper/resource/ResourceQuery.java
@@ -31,12 +31,18 @@ package org.opennms.netmgt.jasper.resource;
 import java.io.File;
 import java.util.Arrays;
 
+import org.opennms.netmgt.jasper.helper.JRobinDirectoryUtil;
+
 public class ResourceQuery {
     private String m_rrdDir;
     private String m_node;
     private String m_resourceName;
+    private String m_foriegnSource;
+    private String m_foriegnId;
     private String[] m_filters;
     private String[] m_strProperties;
+
+    private JRobinDirectoryUtil m_dirUtil = new JRobinDirectoryUtil();
 
     public ResourceQuery() {
     }
@@ -65,9 +71,26 @@ public class ResourceQuery {
     public void setFilters(String[] filters) {
         m_filters = Arrays.copyOf(filters, filters.length);
     }
+    public String getForeignSource() {
+        return m_foreignSource;
+    }
+    public void setForeignSource(String foreignSource) {
+        m_foreignSource = foreignSource;
+    }
+    public String getForeignId() {
+        return m_foreignId;
+    }
+    public void setForeignId(String foreignId) {
+        m_foreignId = foreignId;
+    }
     
     public String constructBasePath() {
-        return getRrdDir() + File.separator + getNodeId() + File.separator + getResourceName();
+        if (m_dirUtil.isStoreByForeignSource()) {
+            return getRrdDir() + File.separator + getNodeId() + File.separator + getResourceName();
+        }
+        else {
+            return m_dirUtil.getNodeLevelResourceDirectory(getRrdDir(), getNodeId(), getForeignSource(), getForeignId()) + File.separator + getResourceName();
+        }
     }
 
     public String[] getStringProperties() {

--- a/integrations/opennms-jasper-extensions/src/main/java/org/opennms/netmgt/jasper/resource/ResourceQuery.java
+++ b/integrations/opennms-jasper-extensions/src/main/java/org/opennms/netmgt/jasper/resource/ResourceQuery.java
@@ -85,7 +85,7 @@ public class ResourceQuery {
     }
     
     public String constructBasePath() {
-        if (m_dirUtil.isStoreByForeignSource()) {
+        if (!m_dirUtil.isStoreByForeignSource()) {
             return getRrdDir() + File.separator + getNodeId() + File.separator + getResourceName();
         }
         else {

--- a/integrations/opennms-jasper-extensions/src/main/java/org/opennms/netmgt/jasper/resource/ResourceQuery.java
+++ b/integrations/opennms-jasper-extensions/src/main/java/org/opennms/netmgt/jasper/resource/ResourceQuery.java
@@ -37,8 +37,8 @@ public class ResourceQuery {
     private String m_rrdDir;
     private String m_node;
     private String m_resourceName;
-    private String m_foriegnSource;
-    private String m_foriegnId;
+    private String m_foreignSource;
+    private String m_foreignId;
     private String[] m_filters;
     private String[] m_strProperties;
 

--- a/integrations/opennms-jasper-extensions/src/main/java/org/opennms/netmgt/jasper/resource/ResourceQueryCommandParser.java
+++ b/integrations/opennms-jasper-extensions/src/main/java/org/opennms/netmgt/jasper/resource/ResourceQueryCommandParser.java
@@ -75,6 +75,10 @@ public class ResourceQueryCommandParser{
             processFilters(command);
         }else if(command.toLowerCase().contains("string")) {
             processStringProperties(command);
+        }else if(command.toLowerCase().contains("foreignsource")) {
+            processForeignSource(command);
+        }else if(command.toLowerCase().contains("foreignid")) {
+            processForeignId(command);
         }
     }
 
@@ -105,6 +109,16 @@ public class ResourceQueryCommandParser{
     private void processRrdDir(String command) {
         String value = command.substring(command.toLowerCase().indexOf("rrddir") + "rrdDir".length(), command.length());
         getCurrentQuery().setRrdDir(value.trim());
+    }
+
+    private void processForeignSource(String command) {
+        String value = command.substring(command.toLowerCase().indexOf("foreignsource") + "foreignsource".length(), command.length());
+        getCurrentQuery().setForeignSource(value.trim());
+    }
+
+    private void processForeignId(String command) {
+        String value = command.substring(command.toLowerCase().indexOf("foreignid") + "foreignid".length(), command.length());
+        getCurrentQuery().setForeignId(value.trim());
     }
 
 

--- a/integrations/opennms-jasper-extensions/src/test/java/org/opennms/netmgt/jasper/resource/ResourceQueryParserTest.java
+++ b/integrations/opennms-jasper-extensions/src/test/java/org/opennms/netmgt/jasper/resource/ResourceQueryParserTest.java
@@ -61,7 +61,7 @@ public class ResourceQueryParserTest {
         assertEquals("someForeignId", rQuery.getForeignId());
 
         System.setProperty("org.opennms.rrd.storeByForeignSource", "true");
-        assertTrue(rQuery.constructBasePath().matches(".*src/test/resources/share/rrd/snmp/fs/someForeignSource/someForeignId"))
+        assertTrue(rQuery.constructBasePath().matches(".*src/test/resources/share/rrd/snmp/fs/someForeignSource/someForeignId"));
 
         System.setProperty("org.opennms.rrd.storeByForeignSource", "false");
         assertTrue(rQuery.constructBasePath().matches(".*src/test/resources/share/rrd/snmp/10"));

--- a/integrations/opennms-jasper-extensions/src/test/java/org/opennms/netmgt/jasper/resource/ResourceQueryParserTest.java
+++ b/integrations/opennms-jasper-extensions/src/test/java/org/opennms/netmgt/jasper/resource/ResourceQueryParserTest.java
@@ -47,6 +47,19 @@ public class ResourceQueryParserTest {
         assertEquals("10", rQuery.getNodeId());
         assertEquals("nsVpnMonitor", rQuery.getResourceName());
     }
+
+    @Test
+    public void testCommandParsingWithForeignSource() {
+        ResourceQueryCommandParser parser = new ResourceQueryCommandParser();
+        ResourceQuery rQuery = parser.parseQueryCommand(getResourceQueryWithForeignSource());
+
+        assertNotNull(rQuery);
+        assertTrue(rQuery.getRrdDir().matches(".*src/test/resources/share/rrd/snmp"));
+        assertEquals("10", rQuery.getNodeId());
+        assertEquals("nsVpnMonitor", rQuery.getResourceName());
+        assertEquals("someForeignSource", rQuery.getForeignSource());
+        assertEquals("someForeignId", rQuery.getForeignId())
+    }
     
     @Test
     public void testCommandParsingWithFilter() {
@@ -90,6 +103,10 @@ public class ResourceQueryParserTest {
     
     private String getResourceQuery() {
         return "--rrdDir /Users/thedesloge/git/opennms/integrations/opennms-jasper-extensions/src/test/resources/share/rrd/snmp  --nodeid 10 --resourceType nsVpnMonitor";
+    }
+
+    private String getResourceQueryWithForeignSource() {
+        return "--rrdDir /Users/thedesloge/git/opennms/integrations/opennms-jasper-extensions/src/test/resources/share/rrd/snmp  --nodeid 10 --resourceType nsVpnMonitor --foreignsource someForeignSource --foreignid someForeignId";
     }
     
     private String getResourceQueryWithFilter() {

--- a/integrations/opennms-jasper-extensions/src/test/java/org/opennms/netmgt/jasper/resource/ResourceQueryParserTest.java
+++ b/integrations/opennms-jasper-extensions/src/test/java/org/opennms/netmgt/jasper/resource/ResourceQueryParserTest.java
@@ -61,10 +61,10 @@ public class ResourceQueryParserTest {
         assertEquals("someForeignId", rQuery.getForeignId());
 
         System.setProperty("org.opennms.rrd.storeByForeignSource", "true");
-        assertTrue(rQuery.constructBasePath().matches(".*src/test/resources/share/rrd/snmp/fs/someForeignSource/someForeignId"));
+        assertTrue(rQuery.constructBasePath().matches(".*src/test/resources/share/rrd/snmp/fs/someForeignSource/someForeignId/nsVpnMonitor"));
 
         System.setProperty("org.opennms.rrd.storeByForeignSource", "false");
-        assertTrue(rQuery.constructBasePath().matches(".*src/test/resources/share/rrd/snmp/10"));
+        assertTrue(rQuery.constructBasePath().matches(".*src/test/resources/share/rrd/snmp/10/nsVpnMonitor"));
     }
     
     @Test

--- a/integrations/opennms-jasper-extensions/src/test/java/org/opennms/netmgt/jasper/resource/ResourceQueryParserTest.java
+++ b/integrations/opennms-jasper-extensions/src/test/java/org/opennms/netmgt/jasper/resource/ResourceQueryParserTest.java
@@ -58,7 +58,13 @@ public class ResourceQueryParserTest {
         assertEquals("10", rQuery.getNodeId());
         assertEquals("nsVpnMonitor", rQuery.getResourceName());
         assertEquals("someForeignSource", rQuery.getForeignSource());
-        assertEquals("someForeignId", rQuery.getForeignId())
+        assertEquals("someForeignId", rQuery.getForeignId());
+
+        System.setProperty("org.opennms.rrd.storeByForeignSource", "true");
+        assertTrue(rQuery.constructBasePath().matches(".*src/test/resources/share/rrd/snmp/fs/someForeignSource/someForeignId"))
+
+        System.setProperty("org.opennms.rrd.storeByForeignSource", "false");
+        assertTrue(rQuery.constructBasePath().matches(".*src/test/resources/share/rrd/snmp/10"));
     }
     
     @Test


### PR DESCRIPTION
- Accepting arguments "--foreignsource" and "--foreignid" in
  ResourceQuery.java and ResourceQueryCommandParser.java, get and
  set functions
- If "storeByForeignSource" is not enabled the constructBasePath()
  function returns the same as before (for compatibility reasons)
  in ResourceQuery.java
- If "storeByForeignSource" is enabled the function
  getNodeLevelResourceDirectory from the JRobinDirectoryUtil class
  is called to return the node level resource directory. The
  resource name is then appended to it in ResourceQuery.java

The contribution is made strictly by observation, I am not in anyway experiencing problems based on the storeByForeignSource functionality with Jasper reports. 

Todo:
- [x] Signed OCA
- [ ] Create JIRA issue
- [ ] Code review
- [ ] Merge and close JIRA issue