### PR TITLE
NMS-6731: Provisioning guide has broken images

### DIFF
--- a/opennms-doc/guide-admin/src/asciidoc/text/provisioning.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/provisioning.adoc
@@ -435,11 +435,11 @@ Using the Provisioning Groups Web-UI, three nodes are created given a single IP 
 Navigate to the Admin Menu and click Provisioning Groups Menu from the list of Admin options and create the group _Bronze_.
 
 .Creating a new Provisioning Group
-image:../images/provisioning/00006.jpeg[Image]
+image:../images/provisioning/00006.jpeg[]
 
 Clicking the _Add New Group_ button will create the group and will redisplay the page including this new group among the list of any group(s) that have already been created.
 
-image:../images/provisioning/00028.jpeg[Image]
+image:../images/provisioning/00028.jpeg[]
 
 NOTE: At this point, the XML structure for holding the new provisioning group (a.k.a. an import requisition) has been persisted to the '$OPENNMS_ETC/imports/pending' directory.
 
@@ -447,21 +447,21 @@ Clicking the _Edit_ link will bring you to the screen where you can begin the pr
 Click the Add Node button will begin the node entity creation process fill in the node label and click the _Save_ button.
 
 .Creating a new Node definition in the Provisioning Group
-image:../images/provisioning/00026.jpeg[Image]
+image:../images/provisioning/00026.jpeg[]
 
 At this point, the provisioning group contains the basic structure of a node entity but it is not complete until the interface(s) and interface service(s) have been defined.
 After having clicked the _Save_ button, as we did above presents, in the Web-UI, the options _Add Interface_, _Add Node Category_, and _Add Node Asset_.
 Click the _Add Interface_ link to add an interface entity to the node.
 
 .Adding an Interface to the node definition
-image:../images/provisioning/00009.jpeg[Image]
+image:../images/provisioning/00009.jpeg[]
 
 Enter the IP address for this interface entity, a description, and specify the Primary attribute as `P` (Primary), `S` (Secondary), `N` (Not collected), or `C` (Collected) and click the save button.
 Now the node entity has an interface for which services can be defined for which the Web-UI now presents the _Add Service_ link.
 Add two services (ICMP, SNMP) via this link.
 
 .A complete node definition with all _required_ elements defined.
-image:../images/provisioning/00007.jpeg[Image]
+image:../images/provisioning/00007.jpeg[]
 
 Now the node entity definition contains all the _required_ elements necessary for importing this requisition into OpenNMS.
 At this point, all the interfaces that are required for the node should be added.
@@ -470,7 +470,7 @@ For example, NAT interfaces should be specified there are services that they pro
 Two more node definitions will be added for the benefit of this example.
 
 .The completed requisition for the example Bronze Provisioning Group
-image:../images/provisioning/00021.jpeg[Image]
+image:../images/provisioning/00021.jpeg[]
 
 This set of nodes represents an import requisition for the _Bronze_ provisioning group.
 As this requisition is being edited via the WebUI, changes are being persisted into the OpenNMS configuration directory '$OPENNMS_etc/imports/' pending as an XML file having the name 'bronze.xml'.
@@ -483,7 +483,7 @@ The details of the “Bronze” group now indicates that there are 3 nodes in th
 Additionally, you can see that time the requisition was last modified and the time it last imported are given (the time stamps are stored as attributes inside the requisition and are not the file system time stamps).
 These details are indicative of how well the DB represents what is in the requisition.
 
-image:../images/provisioning/00013.jpeg[Image]
+image:../images/provisioning/00013.jpeg[]
 
 NOTE: You can tell that this is a pending requisition for 2 reasons: 1) there are 3 nodes defined and 0 nodes in the DB, 2) the requisition has been modified since the last import (in this case _never_).
 
@@ -502,7 +502,7 @@ A few SNMP packets are sent and received to get the SNMP details of the node and
 Upon receipt of these packets (or not) each node is inserted as a DB transaction.
 
 .The nodes are now added to OpenNMS and are under management.
-image:../images/provisioning/000014.png[Image]
+image:../images/provisioning/000014.png[]
 
 Following the import of a node with thousands of interfaces, you will be able to refresh the Interface table browser on the Node page and see that interfaces and services are being discovered and added in the background.
 This is the discovery component of directed discovery.
@@ -522,18 +522,18 @@ Each element in the Web-UI has an associated Edit icon
 Click this icon to change the IP address for barbrady.opennms.org, click save, and then Click the Done button.
 
 .Changing the IP address of _barbrady.opennms.org_ from 10.1.1.2 to 192.168.1.1
-image:../images/provisioning/00027.jpeg[Image]
+image:../images/provisioning/00027.jpeg[]
 
 The Web-UI will return you to the _Provisioning Groups_ screen where you will see that there are the time stamp showing that the requisition’s last modification is more recent that the last import time.
 
 .The Provisioning Group must be re-imported
-image:../images/provisioning/000012.png[Image]
+image:../images/provisioning/000012.png[]
 
 This provides an indication that the group must be re-imported for the changes made to the requisition to take effect.
 The IP Interface will be simply updated and all the required events (messages) will be sent to communicate this change within OpenNMS.
 
 .The IP interface for barbrady.opennms.org is immediately updated
-image:../images/provisioning/000008.png[Image]
+image:../images/provisioning/000008.png[]
 
 ==== Deleting a Node
 
@@ -541,13 +541,13 @@ _Barbrady_ has not been behaving, as one might expect, so it is time to remove h
 Edit the provisioning group, click the delete button next to the node _barbrady.opennms.org_, click the _Done_ button.
 
 .Bronze Provisioning Group definition indicates a node has been removed and requires an import to delete the node entity from the OpenNMS system
-image:../images/provisioning/000010.png[Image]
+image:../images/provisioning/000010.png[]
 
 Click the Import button for the Bronze group and the Barbrady node and its interfaces, services, and any other related data will be immediately deleted from the OpenNMS system.
 All the required Events (messages) will be sent by Provisiond to provide indication to the OpenNMS system that the node Barbrady has been deleted.
 
 .Barbrady has been deleted
-image:../images/provisioning/000011.png[Image]
+image:../images/provisioning/000011.png[]
 
 ==== Deleting all the Nodes
 
@@ -559,7 +559,7 @@ Well it can’t be undone from the Web-UI and can only be undone if you’ve bee
 If you’ve made a mistake, before you re-import the requisition, restore the 'Bronze.xml' requisition from your backup copy to the '$OPENNMS_ETC/imports' directory.
 
 .All node definitions have been removed from the Bronze requisition. The Web-UI indicates an import is now required to remove them from OpenNMS.
-image:../images/provisioning/000019.png[Image]
+image:../images/provisioning/000019.png[]
 
 Clicking the _Import_ button will cause the _Audit Phase_ of _Provisiond_ to determine that all the nodes from the _Bronze_ group (foreign source) should be deleted from the DB and will create _Delete_ operations.
 At this point, if you are satisfied that the nodes have been deleted and that you will no longer require nodes to be defined in this Group, you will see that the _Delete Nodes_ button has now changed to the _Delete Group_ button.
@@ -581,15 +581,17 @@ This example will demonstrate how to create a foreign source definition and how 
 First let’s simply provision the node and let the default foreign source definition apply.
 
 .The node definition used for the Advanced Provisioning Example
-image:../images/provisioning/00025.jpeg[Image]
+image:../images/provisioning/00025.jpeg[]
 
 Following the import, All the IP and SNMP interfaces, in addition to the interface specified in the requisition, have been discovered and added to the node entity.
 The default foreign source definition has no polices for controlling which interfaces that are discovered either get persisted or managed by OpenNMS.
 
-image:../images/provisioning/000005.png[Image]
+image:../images/provisioning/000005.png[]
 
 .Logical and Physical interface and Service entities directed and discovered by Provisiond.
-image:../images/provisioning/000002.png[Image]image:images/provisioning/000018.png[Image]
+image:../images/provisioning/000002.png[]
+
+image:../images/provisioning/000018.png[]
 
 ===== Service Detection
 
@@ -603,13 +605,13 @@ By navigating to the Provisioning Groups screen in the OpenNMS Web-UI and clicki
 The policies determine entity persistence and/or set attributes on the discovered entities that control OpenNMS’ management behaviors.
 
 .When creating a new foreign source definition, the default definition is used as a template.
-image:../images/provisioning/000017.png[Image]
+image:../images/provisioning/000017.png[]
 
 In this UI, new Detectors can be added, changed, and removed.
 For this example, we will remove detection of all services accept ICMP and DNS, change the timeout of ICMP detection, and a new Service detection for OpenNMS Web-UI.
 
 .Custom foreign source definition created for NMS Provisioning Group (foreign source).
-image:../images/provisioning/00022.jpeg[Image]
+image:../images/provisioning/00022.jpeg[]
 
 Click the Done button and re-import the NMS Provisioning Group.
 During this and any subsequent re-imports or re- scans, the OpenNMS detector will be active, and the detectors that have been removed will no longer test for the related services for the interfaces on nodes managed in the provisioning group (requisition), however, the currently detected services will not be removed.
@@ -645,7 +647,7 @@ This action will automatically add all the parameters required for the policy.
 The two required parameters for this policy are action and matchBehavior.
 
 .The action parameter can be set to _DO_NOT_PERSIST_, _Manage_, or _UnManage_.
-image:../images/provisioning/00001.jpeg[Image]
+image:../images/provisioning/00001.jpeg[]
 
 .Creating a policy to prevent persistence of 10 network IP interfaces.
 
@@ -662,7 +664,7 @@ The _value_ for either of the optional parameters can be an exact or regular exp
 As in most configurations in OpenNMS where regular expression matching can be optionally applied, prefix the value with the `~` character.
 
 .Example Matching IP Interface Policy to not Persist 10 Network addresses
-image:../images/provisioning/00023.jpeg[Image]
+image:../images/provisioning/00023.jpeg[]
 
 Any subsequent scan of the node or re-imports of NMS provisioning group will force this policy to be applied.
 IP Interface entities that already exist that match this policy will not be deleted.
@@ -675,7 +677,7 @@ Again, click the Add Policy button and let’s call this policy _noMgt192168s_.
 Again, choose the Mach IP Interface policy and this time set the action to _UNMANAGE_.
 
 .Policy to not manage IP interfaces from 192.168 networks
-image:../images/provisioning/00015.jpeg[Image]
+image:../images/provisioning/00015.jpeg[]
 
 NOTE: The _UNMANAGE_ behavior will be applied to existing interfaces.
 
@@ -689,7 +691,7 @@ Let’s call it: _noAAL5s_.
 We’ll use Match SNMP Interface class for each policy and add a parameter with _ifType_ as the key and _49_ as the value.
 
 .Matching SNMP Interface Policy example for Persistence and Data Collection
-image:../images/provisioning/00003.jpeg[Image]
+image:../images/provisioning/00003.jpeg[]
 
 NOTE: At the appropriate time during the scanning phase, Provisiond will
 evaluate the policies in the foreign source definition and take
@@ -706,7 +708,7 @@ Edit the required _category_ key and set the value to `Cisco`.
 Add a policy parameter and choose the _sysObjectId_ key with a value `~^\.1\.3\.6\.1\.4\.1\.9\..*`.
 
 .Example: Node Category setting policy
-image:../images/provisioning/00020.jpeg[Image]
+image:../images/provisioning/00020.jpeg[]
 
 ==== New Import Capabilities
 
@@ -760,11 +762,11 @@ This means that you don't have to restart OpenNMS every time you update the conf
 The Provisioning Groups Web-UI had been updated to expose the ability to add Node Asset data in an import requisition.
 Click the _Add Node Asset_ link and you can select from a drop down list all the possible node asset attributes that can be defined.
 
-image:../images/provisioning/00024.jpeg[Image]
+image:../images/provisioning/00024.jpeg[]
 
 After an import, you can navigate to the _Node Page_ and click the _Asset Info_ link and see the asset data that was just provided in the requisition.
 
-image:../images/provisioning/000004.png[Image]
+image:../images/provisioning/000004.png[]
 
 ==== External Requisition Sources
 

--- a/opennms-doc/pom.xml
+++ b/opennms-doc/pom.xml
@@ -73,7 +73,7 @@
           <headerFooter>true</headerFooter>
           <sourceDirectory>${asciidoc.source.directory}</sourceDirectory>
           <outputDirectory>${asciidoc.output.directory}</outputDirectory>
-          <imagesDir>./</imagesDir>
+          <imagesDir>images</imagesDir>
           <attributes>
             <opennms-version>${project.version}</opennms-version>
           </attributes>


### PR DESCRIPTION
- Removed same link reference for all images in Provisioning guide
- Added image directory to main pom.xml of the opennms-doc module
