### PR TITLE
NMS-6744 Fix format issues in template for monitors

### DIFF
--- a/opennms-doc/guide-admin/src/asciidoc/text/poller/_template-monitors.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/poller/_template-monitors.adoc
@@ -1,28 +1,26 @@
 
-// Please keep first line an empty line to make sure, the ToC can be build correctly
+// REMOVE ME!! Please keep first line an empty line to make sure, the ToC can be build correctly
 === Name of the Monitor. Normally the name of the class without .java
 
-A summary what the monitor is doing. +
-When is the monitor up or down.
+A summary what the monitor is doing. When is the monitor up or down.
 
 ==== Monitor facts
 
 [options="autowidth"]
 |===
-| Class Name | `Name of the monitor class which has to be used in the poller-configuration.xml`
+| Class Name     | `Name of the monitor class which has to be used in the poller-configuration.xml`
 | Remote Enabled | true or false if the monitor can be used by the OpenNMS remote poller
 |===
 
 ==== Configuration and Usage
 
-.Monitor specific parameters for the {monitorname}
+.Monitor specific parameters for the <MONITORNAME-HERE>
 [options="header, autowidth"]
 |===
-| Parameter | Description                                    | Required | Default value
-| `my parameter 1` | This is a placeholder for the first +
-                     rquired monitor parameter description.  | required | `-`
-| `my parameter 2` | This is a placeholder for the second +
-                     optional monitor parameter description. | optional | `default value`
+| Parameter        | Description                                                                                        | Required | Default value
+| `my parameter 1` | This is a placeholder for the first required monitor parameter description. If you have a very
+                     long description make a soft break at line 120                                                     | required | `-`
+| `my parameter 2` | This is a placeholder for the second optional monitor parameter description.                       | optional | `default value`
 |===
 
 This is optional just if you can use variables in the configuration
@@ -37,7 +35,8 @@ This is optional just if you can use variables in the configuration
 |===
 
 ==== Examples
-Some example configuration how to configure the monitor in the `poller-configuration.xml`
+Some example configuration how to configure the monitor in the 'poller-configuration.xml'.
+
 [source, xml]
 ----
 <parameter key="args" value="-i {variable3} -t ${variable2}"/>


### PR DESCRIPTION
- Added hint to remove first comment line
- Added format example in very long table descriptions
- Fixed file and path format from ``to ''
- Removed {monitorname} as AsciiDoc variable and replaced with a neutral place holder
