### PR TITLE
NMS-6746: Improve readability SnmpMonitor

### DIFF
--- a/opennms-doc/guide-admin/src/asciidoc/text/poller/SnmpMonitor.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/poller/SnmpMonitor.adoc
@@ -17,7 +17,8 @@ See the ``Operating mode selection'' and ``Monitor specific parameters for the S
     | walk       | match-all                                                  | Operating mode
 .3+^|`true`      | `true`                                                     | tabular, all values must match
     | `false`    | tabular, any value must match
-    | `count`    | tabular, between `minimum` and `maximum` values must match
+    | `count`    | specifies that the value of at least minimum and at most
+                   maximum objects encountered in
 .3+^|`false`     | `true`                                                     | scalar
     | `false`    | scalar
     | `count`    | tabular, between `minimum` and `maximum` values must match
@@ -152,7 +153,7 @@ If the cpqHeThermalDegradedAction is set to shutdown(3) the
 system will be shutdown if the failed(4) condition occurs."
 ----
 
-The SnmpMonitor is configrued to test if the fan status returns _ok(2)_ and the the service is marked as _up_.
+The SnmpMonitor is configured to test if the fan status returns _ok(2)_. If so, the service is marked as _up_.
 Any other value indicates a problem with the thermal fan status and marks the service _down_.
 
 .Example SnmpMonitor as HP InsightManager fan monitor in poller-configuration.xml
@@ -173,11 +174,11 @@ Any other value indicates a problem with the thermal fan status and marks the se
 <4> Encode _MIB_ status in the reason code to give more detailed information if the service goes down
 
 ==== Example test SNMP table with all matching values
-The second mode shows how to  monitor values of a whole SNMP table.
+The second mode shows how to monitor values of a whole SNMP table.
 As a practical use case the status of a set of physical drives is monitored.
 This example configuration shows the status monitoring from the http://h18013.www1.hp.com/products/servers/management/hpsim/mibkit.html[CPQIDA-MIB].
 
-We use as an scalar object id the physical drive status given by the following tabular OID:
+We use as a scalar object id the physical drive status given by the following tabular OID:
 
  cpqDaPhyDrvStatus .1.3.6.1.4.1.232.3.2.5.1.1.6
 


### PR DESCRIPTION
- Table for Operation mode reformatted in source
- Description table shortened
- Operator description added force line breaks
- Changed snmp-config.xml format as file
- Reformatted examples and the used OIDs
- Renamed the example service from All_Static_Routes to All-Static-Routes to look less like source code
