### PR TITLE
Added systemDef's for Cisco ASA5585-SSP10, ASA5585-SSP20, ASA5585-SSP40,...

### DIFF
--- a/opennms-base-assembly/src/main/filtered/etc/datacollection/cisco.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/datacollection/cisco.xml
@@ -980,6 +980,46 @@
         </collect>
       </systemDef>
 
+      <systemDef name="Cisco ASA5585Ssp10">
+        <sysoid>.1.3.6.1.4.1.9.1.1194</sysoid>
+        <collect>
+          <includeGroup>cisco-pix</includeGroup>
+          <includeGroup>cisco-cike</includeGroup>
+          <includeGroup>cisco-cipsec</includeGroup>
+          <includeGroup>cisco-memory</includeGroup>
+        </collect>
+      </systemDef>
+
+      <systemDef name="Cisco ASA5585Ssp20">
+        <sysoid>.1.3.6.1.4.1.9.1.1195</sysoid>
+        <collect>
+          <includeGroup>cisco-pix</includeGroup>
+          <includeGroup>cisco-cike</includeGroup>
+          <includeGroup>cisco-cipsec</includeGroup>
+          <includeGroup>cisco-memory</includeGroup>
+        </collect>
+      </systemDef>
+
+      <systemDef name="Cisco ASA5585Ssp40">
+        <sysoid>.1.3.6.1.4.1.9.1.1196</sysoid>
+        <collect>
+          <includeGroup>cisco-pix</includeGroup>
+          <includeGroup>cisco-cike</includeGroup>
+          <includeGroup>cisco-cipsec</includeGroup>
+          <includeGroup>cisco-memory</includeGroup>
+        </collect>
+      </systemDef>
+
+      <systemDef name="Cisco ASA5585Ssp60">
+        <sysoid>.1.3.6.1.4.1.9.1.1197</sysoid>
+        <collect>
+          <includeGroup>cisco-pix</includeGroup>
+          <includeGroup>cisco-cike</includeGroup>
+          <includeGroup>cisco-cipsec</includeGroup>
+          <includeGroup>cisco-memory</includeGroup>
+        </collect>
+      </systemDef>
+
       <systemDef name="Cisco Routers">
         <sysoidMask>.1.3.6.1.4.1.9.1.</sysoidMask>
         <collect>

--- a/opennms-base-assembly/src/main/filtered/etc/datacollection/ciscoNexus.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/datacollection/ciscoNexus.xml
@@ -93,6 +93,15 @@
         </collect>
       </systemDef>
 
+      <systemDef name="Cisco Nexus 7009"><!-- Nexus7000 9 slot N7K chassis -->
+        <sysoid>.1.3.6.1.4.1.9.12.3.1.3.932</sysoid>
+        <collect>
+          <includeGroup>cisco-nx-process-index</includeGroup>
+          <includeGroup>mib2-X-interfaces</includeGroup>
+          <includeGroup>cisco-nx-environmental</includeGroup>
+        </collect>
+      </systemDef>
+
       <systemDef name="Cisco Nexus 7010"><!-- Nexus7000 10 slot N7K chassis -->
         <sysoid>.1.3.6.1.4.1.9.12.3.1.3.612</sysoid>
         <collect>


### PR DESCRIPTION
New sysDefs for ASA5585-SSP10, ASA5585-SSP20, ASA5585-SSP40, ASA5585-SSP60, and Cisco Nexus 7009

--petew
