### PR TITLE
NMS-6945: Make servlet-dependencies provided, so remote-poller-jnlp does...

### DIFF
--- a/features/poller/remote/pom.xml
+++ b/features/poller/remote/pom.xml
@@ -30,10 +30,12 @@
       <artifactId>quartz-dependencies</artifactId>
       <type>pom</type>
     </dependency>
+    <!-- MVR: We do not use servlet-dependencies here, because that would
+    pull in a bunch of other dependencies like jetty-jsp we do not want here.
+    See issue #NMS-6945 for more details -->
     <dependency>
-      <groupId>org.opennms.dependencies</groupId>
-      <artifactId>servlet-dependencies</artifactId>
-      <type>pom</type>
+      <groupId>javax.servlet</groupId>
+      <artifactId>servlet-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.opennms.dependencies</groupId>


### PR DESCRIPTION
... not transitive depend on javax.servlet and co.

Bamboo: http://bamboo.internal.opennms.com:8085/browse/OPENNMS-NMS115
Jira: http://issues.opennms.org/browse/NMS-6945
