### PR TITLE
Fix for NMS-4041; specify only TABLE object type when changing owning

### DIFF
--- a/core/db-install/src/main/java/org/opennms/core/db/install/InstallerDb.java
+++ b/core/db-install/src/main/java/org/opennms/core/db/install/InstallerDb.java
@@ -2011,7 +2011,8 @@ public class InstallerDb {
      * @throws java.sql.SQLException if any.
      */
     public void databaseSetUser() throws SQLException {
-    	final ResultSet rs = getAdminConnection().getMetaData().getTables(null, "public", "%", null);
+    	final String[] tableTypes = {"TABLE"};
+    	final ResultSet rs = getAdminConnection().getMetaData().getTables(null, "public", "%", tableTypes);
         final HashSet<String> objects = new HashSet<String>();
         while (rs.next()) {
             objects.add(rs.getString("TABLE_NAME"));


### PR DESCRIPTION
user during database install. Allows use of PG tuning options that
install some non-table objects in the default template. 

Please apply to 1.12 branch as well. Thanks!
