### PR TITLE
NMS-7220: Documentation update asciidoctor-maven-plugin

### DIFF
--- a/opennms-doc/guide-all/src/asciidoc/.placeholder
+++ b/opennms-doc/guide-all/src/asciidoc/.placeholder
@@ -1,0 +1,1 @@
+Directory is required by asciidoctor-maven-plugin

--- a/opennms-doc/src/asciidoc/.placeholder
+++ b/opennms-doc/src/asciidoc/.placeholder
@@ -1,0 +1,1 @@
+Directory is required by asciidoctor-maven-plugin

--- a/pom.xml
+++ b/pom.xml
@@ -1099,7 +1099,7 @@
     <!-- dependency versions -->
     <oldAsmVersion>99.99.99-exclude-and-use-org.ow2.asm.asm-all-instead</oldAsmVersion>
     <asmVersion>5.0.3</asmVersion>
-    <asciidoctorVersion>0.1.4</asciidoctorVersion>
+    <asciidoctorVersion>1.5.0</asciidoctorVersion>
     <activemqVersion>5.10.0</activemqVersion>
     <atomikosVersion>3.9.2</atomikosVersion>
     <camelVersion>2.13.2</camelVersion>


### PR DESCRIPTION
JIRA: http://issues.opennms.org/browse/NMS-7220
- Updated from version 0.1.4 to 1.5.0
- Created placeholder to keep asciidoc directories in git which are required by asciidoctor maven plugin
