### PR TITLE
 NMS-4763: Add WMI Terminal Service session metrics for Win2K8

### DIFF
--- a/opennms-base-assembly/src/main/filtered/etc/wmi-datacollection-config.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/wmi-datacollection-config.xml
@@ -2,11 +2,11 @@
 <wmi-datacollection-config rrdRepository="${install.share.dir}/rrd/snmp/">
     <wmi-collection name="default">
         <rrd step="300">
-		  <rra>RRA:AVERAGE:0.5:1:2016</rra>
-		  <rra>RRA:AVERAGE:0.5:12:1488</rra>
-		  <rra>RRA:AVERAGE:0.5:288:366</rra>
-		  <rra>RRA:MAX:0.5:288:366</rra>
-		  <rra>RRA:MIN:0.5:288:366</rra>
+            <rra>RRA:AVERAGE:0.5:1:2016</rra>
+            <rra>RRA:AVERAGE:0.5:12:1488</rra>
+            <rra>RRA:AVERAGE:0.5:288:366</rra>
+            <rra>RRA:MAX:0.5:288:366</rra>
+            <rra>RRA:MIN:0.5:288:366</rra>
         </rrd>
 
         <wpms>


### PR DESCRIPTION
- Renamed existing WMI group for Windows 2003 Server from win32_terminalservices to win32_terminalservices2003
- Added new WMI group for Windows 2008 with win32_terminalservices2008 which provides terminal service metrics in a new WMI class Win32_PerfFormattedData_TermService_TerminalServices

JIRA: http://issues.opennms.org/browse/NMS-4763

Todo: 
- [x] XML formatting
- [x] Run configTesterTest
- [x] Run integration-tests
- [x] Close JIRA issue with merge
