### PR TITLE
NMS-7284: Fix images path in admin guide for GitHub preview

### DIFF
--- a/opennms-doc/guide-admin/src/asciidoc/text/poller/DhcpMonitor.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/poller/DhcpMonitor.adoc
@@ -1,3 +1,5 @@
+// Allow GitHub image rendering
+:imagesdir: ../../images
 
 === DhcpMonitor
 

--- a/opennms-doc/guide-admin/src/asciidoc/text/poller/StrafePingMonitor.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/poller/StrafePingMonitor.adoc
@@ -1,3 +1,5 @@
+// Allow GitHub image rendering
+:imagesdir: ../../images
 
 === StrafePingMonitor
 This monitor is used to monitor http://en.wikipedia.org/wiki/Packet_delay_variation[packet delay variation] to a specific endpoint using _ICMP_.

--- a/opennms-doc/guide-admin/src/asciidoc/text/provisioning.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/provisioning.adoc
@@ -1,3 +1,5 @@
+// Allow GitHub image rendering
+:imagesdir: ../../images
 
 [opennms-provisioning]
 = OpenNMS Provisioning

--- a/opennms-doc/guide-admin/src/asciidoc/text/provisioning.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/provisioning.adoc
@@ -1,5 +1,5 @@
 // Allow GitHub image rendering
-:imagesdir: ../../images
+:imagesdir: ../images
 
 [opennms-provisioning]
 = OpenNMS Provisioning


### PR DESCRIPTION
- Added images path for screenshot to StrafePing
- Added images path for communication schema to DhcpMonitor
- Added images path for screenshots in Provisioning

JIRA: http://issues.opennms.org/browse/NMS-7284

Todo:
- [x] 4-eye review
- [x] Close JIRA issue