### PR TITLE
NMS-7331: Fix outage timeline does not show all outages in timeframe

### DIFF
--- a/opennms-webapp/src/main/java/org/opennms/web/rest/OnmsRestService.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/rest/OnmsRestService.java
@@ -105,12 +105,18 @@ public class OnmsRestService {
 	    m_writeLock.unlock();
 	}
 
+
 	protected void applyQueryFilters(final MultivaluedMap<String,String> p, final CriteriaBuilder builder) {
+		this.applyQueryFilters(p, builder, DEFAULT_LIMIT);
+	}
+
+	protected void applyQueryFilters(final MultivaluedMap<String,String> p, final CriteriaBuilder builder, final Integer defaultLimit) {
+
 		final MultivaluedMap<String, String> params = new MultivaluedMapImpl();
 	    params.putAll(p);
 
 	    builder.distinct();
-	    builder.limit(DEFAULT_LIMIT);
+	    builder.limit(defaultLimit);
 
 	    // not sure why we remove this, but that's what the old query filter code did, I presume there's a reason  :)
 	    params.remove("_dc");


### PR DESCRIPTION
JIRA: http://issues.opennms.org/browse/NMS-7331

- Removed default limit applied to criteria used to query outages in
  timeline.
- Added filter for outages started after end of timeline.
- Refactored some duplicated code.

Todo:
- [x] Review code
- [ ] Merge to develop
- [ ] Merge to release candidate 14.0.4
- [ ] Close JIRA issue