### PR TITLE
NMS-7358: IllegalArgument on ipnettomediatable

### DIFF
--- a/opennms-services/src/main/java/org/opennms/netmgt/enlinkd/snmp/IpNetToMediaTableTracker.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/enlinkd/snmp/IpNetToMediaTableTracker.java
@@ -145,7 +145,8 @@ public class IpNetToMediaTableTracker extends TableTracker
 	                // This is the normal case that most agents conform to: the value is an ASCII 
 	                // string representing the colon-separated MAC address. We just need to reformat 
 	                // it to remove the colons and convert it into a 12-character string.
-	                return normalizeMacAddress(getValue(IPNETTOMEDIA_TABLE_PHYSADDR).toDisplayString());
+	                String mac = getValue(IPNETTOMEDIA_TABLE_PHYSADDR).toDisplayString();
+	                return mac == null || mac.trim().isEmpty() ? null : normalizeMacAddress(mac);
 	            }
 		    } catch (IllegalArgumentException e) {
 		        LOG.warn("IllegalArgument on ipnettomediatable", e);

--- a/opennms-services/src/main/java/org/opennms/netmgt/linkd/snmp/IpNetToMediaTableEntry.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/linkd/snmp/IpNetToMediaTableEntry.java
@@ -165,7 +165,8 @@ public final class IpNetToMediaTableEntry extends SnmpStore {
                     // This is the normal case that most agents conform to: the value is an ASCII 
                     // string representing the colon-separated MAC address. We just need to reformat 
                     // it to remove the colons and convert it into a 12-character string.
-                    return normalizeMacAddress(getDisplayString(IpNetToMediaTableEntry.INTM_PHYSADDR));
+                    String mac = getValue(IpNetToMediaTableEntry.INTM_PHYSADDR).toDisplayString();
+                    return mac == null || mac.trim().isEmpty() ? null : normalizeMacAddress(mac);
                 }
 	    } catch (IllegalArgumentException e) {
 	        LOG.warn("IllegalArgumentException", e);


### PR DESCRIPTION
java.lang.IllegalArgumentException: Cannot decode MAC address: ''

Method normalizeMacAddress can't handle empty values.
Each function calling normalizeMacAddress must handle invalid values before calling normalizeMacAddress.

JIRA: http://issues.opennms.org/browse/NMS-7358

Todo:
- [x] OCA listed: http://www.opennms.org/wiki/Executed_contributor_agreements
- [x] OCA signed: http://www.opennms.org/documentation/ContributorAgreement.pdf
- [x] Code review
- [ ] Pass tests
- [ ] Merged to develop and close JIRA issue