### PR TITLE
NMS-7277: Fix WMI instance name

### DIFF
--- a/opennms-wmi/src/main/java/org/opennms/netmgt/collectd/wmi/WmiMultiInstanceCollectionResource.java
+++ b/opennms-wmi/src/main/java/org/opennms/netmgt/collectd/wmi/WmiMultiInstanceCollectionResource.java
@@ -71,6 +71,8 @@ public class WmiMultiInstanceCollectionResource extends WmiCollectionResource {
     @Override
     public File getResourceDir(final RrdRepository repository) {
         String resourcePath = m_resourceType.getStorageStrategy().getRelativePathForAttribute(getParent(), getInterfaceLabel());
+        //WMI instances can have special characters in them. See NMS-6924.
+        resourcePath.replaceAll("\\s+", "_").replaceAll(":", "_").replaceAll("\\\\", "_").replaceAll("[\\[\\]]", "_");
         File resourceDir = new File(repository.getRrdBaseDir(), resourcePath);
         LOG.debug("getResourceDir: {}", resourceDir);
         return resourceDir;

--- a/opennms-wmi/src/main/java/org/opennms/netmgt/collectd/wmi/WmiMultiInstanceCollectionResource.java
+++ b/opennms-wmi/src/main/java/org/opennms/netmgt/collectd/wmi/WmiMultiInstanceCollectionResource.java
@@ -72,7 +72,7 @@ public class WmiMultiInstanceCollectionResource extends WmiCollectionResource {
     public File getResourceDir(final RrdRepository repository) {
         String resourcePath = m_resourceType.getStorageStrategy().getRelativePathForAttribute(getParent(), getInterfaceLabel());
         //WMI instances can have special characters in them. See NMS-6924.
-        resourcePath.replaceAll("\\s+", "_").replaceAll(":", "_").replaceAll("\\\\", "_").replaceAll("[\\[\\]]", "_");
+        resourcePath = resourcePath.replaceAll("\\s+", "_").replaceAll(":", "_").replaceAll("\\\\", "_").replaceAll("[\\[\\]]", "_");
         File resourceDir = new File(repository.getRrdBaseDir(), resourcePath);
         LOG.debug("getResourceDir: {}", resourceDir);
         return resourceDir;


### PR DESCRIPTION
Naming of WMI resources is now similar to how it used to be, which makes instances of things like wmiPhysicalDisk and wmiLogicalDisk  work again. 

JIRA: http://issues.opennms.org/browse/NMS-7277

Todo:
- [ ] Test WMI stats in 1.12.9 then upgrade to 14.0.4
- [ ] Code review
- [ ] Pass unit tests
- [ ] Merge to develop
- [ ] Merge to release candidate for 14.0.4
- [ ] Close JIRA issue