### PR TITLE
NMS-7470: Update ticket.id  after creating a new JIRA issue

### DIFF
--- a/features/ticketing/jira-integration/src/main/java/org/opennms/netmgt/ticketer/jira/JiraTicketerPlugin.java
+++ b/features/ticketing/jira-integration/src/main/java/org/opennms/netmgt/ticketer/jira/JiraTicketerPlugin.java
@@ -50,6 +50,7 @@ import com.atlassian.jira.rest.client.JiraRestClient;
 import com.atlassian.jira.rest.client.JiraRestClientFactory;
 import com.atlassian.jira.rest.client.NullProgressMonitor;
 import com.atlassian.jira.rest.client.auth.AnonymousAuthenticationHandler;
+import com.atlassian.jira.rest.client.domain.BasicIssue;
 import com.atlassian.jira.rest.client.domain.Comment;
 import com.atlassian.jira.rest.client.domain.Issue;
 import com.atlassian.jira.rest.client.domain.Transition;
@@ -61,7 +62,7 @@ import com.atlassian.jira.rest.client.internal.jersey.JerseyJiraRestClientFactor
  * OpenNMS Trouble Ticket Plugin API implementation for Atlassian JIRA.
  * This implementation relies on the JIRA REST interface and is compatible
  * with JIRA 5.0+.
- * 
+ *
  * @see http://www.atlassian.com/software/jira/overview
  * @see http://docs.atlassian.com/jira-rest-java-client/1.0/apidocs/
  *
@@ -121,7 +122,7 @@ public class JiraTicketerPlugin implements Plugin {
             ticket.setState(getStateFromId(issue.getStatus().getName()));
 
             return ticket;
-        } else { 
+        } else {
             return null;
         }
     }
@@ -198,7 +199,10 @@ public class JiraTicketerPlugin implements Plugin {
             builder.setDescription(ticket.getDetails());
             builder.setDueDate(new DateTime(Calendar.getInstance()));
 
-            jira.getIssueClient().createIssue(builder.build(), new NullProgressMonitor());
+            BasicIssue createdIssue = jira.getIssueClient().createIssue(builder.build(), new NullProgressMonitor());
+            LOG.info("created ticket " + createdIssue);
+
+            ticket.setId(createdIssue.getKey());
 
         } else {
             // Otherwise update the existing ticket


### PR DESCRIPTION
The id field of org.opennms.api.integration.ticketing.Ticket object is updated with the JIRA issue id obtained
from the getIssueClient().createIssue call. Seems this was linking was missed out.
This allows the JIRA Issue id to appear in the Alarm Detail page. 
Once the JIRA issue id appears in the alarm page, I found that clicking on the Issue automatically leads me to the JIRA website issue page.

JIRA: http://issues.opennms.org/browse/NMS-7470

Todo:
- [x] Signed [OCA](http://www.opennms.org/documentation/ContributorAgreement.pdf)
- [x] Review
- [x] Pass tests
- [x] Merge to develop and close JIRA issue
