### PR TITLE
NMS-7529: Event replacement items that contain '%' characters can result in broken notification text

### DIFF
--- a/features/events/daemon/src/main/java/org/opennms/netmgt/eventd/AbstractEventUtil.java
+++ b/features/events/daemon/src/main/java/org/opennms/netmgt/eventd/AbstractEventUtil.java
@@ -925,7 +925,7 @@ public abstract class AbstractEventUtil implements EventUtil {
 
 				// If there's any whitespace in between the % signs, then do not try to 
 				// expand it with a parameter value
-				if (parm.matches("(?s).*\\s(?s).*")) {
+				if (parm.matches(".*\\s(?s).*")) {
 					ret.append(PERCENT);
 					tempInp = tempInp.substring(1);
 		                        LOG.debug("skipping parm: " + parm + " because whitespace found in value");

--- a/features/events/daemon/src/main/java/org/opennms/netmgt/eventd/AbstractEventUtil.java
+++ b/features/events/daemon/src/main/java/org/opennms/netmgt/eventd/AbstractEventUtil.java
@@ -912,6 +912,7 @@ public abstract class AbstractEventUtil implements EventUtil {
 
 		// check input string to see if it has any %xxx% substring
 		while ((tempInp != null) && ((index1 = tempInp.indexOf(PERCENT)) != -1)) {
+		    LOG.debug("checking input " + tempInp);
 			// copy till first %
 			ret.append(tempInp.substring(0, index1));
 			tempInp = tempInp.substring(index1);
@@ -920,18 +921,19 @@ public abstract class AbstractEventUtil implements EventUtil {
 			if (index2 != -1) {
 				// Get the value between the %s
 				String parm = tempInp.substring(1, index2);
-				// m_logger.debug("parm: " + parm + " found in value");
+				LOG.debug("parm: " + parm + " found in value");
 
 				// If there's any whitespace in between the % signs, then do not try to 
 				// expand it with a parameter value
 				if (parm.matches(".*\\s.*")) {
 					ret.append(PERCENT);
 					tempInp = tempInp.substring(1);
+		                        LOG.debug("skipping parm: " + parm + " because whitespace found found in value");
 					continue;
 				}
 
 				String parmVal = getValueOfParm(parm, event);
-				// m_logger.debug("value of parm: " + parmVal);
+				LOG.debug("value of parm: " + parmVal);
 
 				if (parmVal != null) {
 					if (decode != null && decode.containsKey(parm) && decode.get(parm).containsKey(parmVal)) {
@@ -951,6 +953,7 @@ public abstract class AbstractEventUtil implements EventUtil {
 				}
 			}
 			else {
+			    LOG.debug("didn't find second '%' so I'm breaking?");
 				break;
 			}
 		}

--- a/features/events/daemon/src/main/java/org/opennms/netmgt/eventd/AbstractEventUtil.java
+++ b/features/events/daemon/src/main/java/org/opennms/netmgt/eventd/AbstractEventUtil.java
@@ -912,7 +912,7 @@ public abstract class AbstractEventUtil implements EventUtil {
 
 		// check input string to see if it has any %xxx% substring
 		while ((tempInp != null) && ((index1 = tempInp.indexOf(PERCENT)) != -1)) {
-		    LOG.debug("checking input " + tempInp);
+		        LOG.debug("checking input " + tempInp);
 			// copy till first %
 			ret.append(tempInp.substring(0, index1));
 			tempInp = tempInp.substring(index1);
@@ -925,10 +925,10 @@ public abstract class AbstractEventUtil implements EventUtil {
 
 				// If there's any whitespace in between the % signs, then do not try to 
 				// expand it with a parameter value
-				if (parm.matches(".*\\s.*")) {
+				if (parm.matches("(?s).*\\s(?s).*")) {
 					ret.append(PERCENT);
 					tempInp = tempInp.substring(1);
-		                        LOG.debug("skipping parm: " + parm + " because whitespace found found in value");
+		                        LOG.debug("skipping parm: " + parm + " because whitespace found in value");
 					continue;
 				}
 
@@ -953,7 +953,6 @@ public abstract class AbstractEventUtil implements EventUtil {
 				}
 			}
 			else {
-			    LOG.debug("didn't find second '%' so I'm breaking?");
 				break;
 			}
 		}

--- a/features/events/daemon/src/test/java/org/opennms/netmgt/eventd/EventUtilTest.java
+++ b/features/events/daemon/src/test/java/org/opennms/netmgt/eventd/EventUtilTest.java
@@ -128,6 +128,54 @@ public class EventUtilTest {
     }
     
     /**
+     * Test method for ignoring things that aren't params because of whitespace across lines.
+     */
+    @Test
+    public void testLineWhitespaceParms(){
+        String testString = "%uei%:"+
+                " #description#\n"+
+                "<p>The interface 172.17.12.251 generated a Syslog Message.<br>\n"+
+                " Node ID: 0<br>\n"+
+                " Host: Unknown<br>\n"+
+                " Interface: 172.17.12.251 <br>\n"+
+                " Message: 172.17.12.251: Mar 5 20:48:35.644: %SSH-4-SSH2_UNEXPECTED_MSG: Unexpected message type has arrived. Terminating the connection <br>\n"+
+                " Process: 304806 <br>\n"+
+                " PID: \n"+
+                " </p>\n"+
+                "#/description#\n"+
+                "41\n"+
+                "Unknown\n"+
+                "172.17.12.251\n"+
+                "Warning\n"+
+                "Thursday, March 5, 2015 2:48:47 PM CST\n"+
+                ".\n"+
+                "uei.opennms.org/syslogd/local7/Warning\n"+
+                "syslogmessage=\"172.17.12.251: Mar 5 20:48:35.644: %SSH-4-SSH2_UNEXPECTED_MSG: Unexpected message type has arrived. Terminating the connection\" severity=\"Warning\" timestamp=\"Mar 05 14:48:47\" process=\"304806\" service=\"local7\""
+                + ":%dpname%:%nodeid%";
+        String newString = AbstractEventUtil.getInstance().expandParms(testString, m_bgpBkTnEvent);
+        String validString = "http://uei.opennms.org/standards/rfc1657/traps/bgpBackwardTransition:" +
+                " #description#\n"+
+                "<p>The interface 172.17.12.251 generated a Syslog Message.<br>\n"+
+                " Node ID: 0<br>\n"+
+                " Host: Unknown<br>\n"+
+                " Interface: 172.17.12.251 <br>\n"+
+                " Message: 172.17.12.251: Mar 5 20:48:35.644: %SSH-4-SSH2_UNEXPECTED_MSG: Unexpected message type has arrived. Terminating the connection <br>\n"+
+                " Process: 304806 <br>\n"+
+                " PID: \n"+
+                " </p>\n"+
+                "#/description#\n"+
+                "41\n"+
+                "Unknown\n"+
+                "172.17.12.251\n"+
+                "Warning\n"+
+                "Thursday, March 5, 2015 2:48:47 PM CST\n"+
+                ".\n"+
+                "uei.opennms.org/syslogd/local7/Warning\n"+
+                "syslogmessage=\"172.17.12.251: Mar 5 20:48:35.644: %SSH-4-SSH2_UNEXPECTED_MSG: Unexpected message type has arrived. Terminating the connection\" severity=\"Warning\" timestamp=\"Mar 05 14:48:47\" process=\"304806\" service=\"local7\""
+                + "::1";
+        assertEquals(validString, newString);
+    }
+    /**
      * Test method for extracting parm names rather than parm values
      */
     @Test


### PR DESCRIPTION
Should be cherry-pickable to other branches. Includes a unit test and I ran the other eventd tests successfully as well. 

JIRA: http://issues.opennms.org/browse/NMS-7529
Bamboo: http://bamboo.internal.opennms.com:8085/browse/OPENNMS-NMS260

Todo:
- [ ] Pass unit tests
- [ ] Review pull request
- [ ] Merge to develop