### PR TITLE
NMS-7553: Add Juniper SRX flow performance monitoring and default thresholds

### DIFF
--- a/opennms-base-assembly/src/main/filtered/etc/datacollection/juniper.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/datacollection/juniper.xml
@@ -12,10 +12,10 @@
       <storageStrategy class="org.opennms.netmgt.dao.support.IndexStorageStrategy"/>
     </resourceType>
 
-    <resourceType name="jnxJsSPUMonitoringObjectsTable" label="Juniper SRX SPU Monitoring" resourceLabel="${jnxJsSPUMonitoringNodeDescr}">
+    <resourceType name="jnxJsSPUMonitoringObjectsTable" label="Juniper SRX SPU Monitoring" resourceLabel="${juniSPUMonNodeDescr}">
       <persistenceSelectorStrategy class="org.opennms.netmgt.collectd.PersistAllSelectorStrategy"/>
       <storageStrategy class="org.opennms.netmgt.dao.support.SiblingColumnStorageStrategy">
-        <parameter key="sibling-column-name" value="jnxJsSPUMonitoringNodeDescr"/>
+        <parameter key="sibling-column-name" value="juniSPUMonNodeDescr"/>
       </storageStrategy>
     </resourceType>
 
@@ -53,9 +53,9 @@
       </group>
 
       <group name="juniper-srx-router" ifType="all">
-        <mibObj oid=".1.3.6.1.4.1.2636.3.39.1.12.1.1.1.11" instance="jnxJsSPUMonitoringObjectsTable" alias="jnxJsSPUMonitoringNodeDescr"          type="string" />
-        <mibObj oid=".1.3.6.1.4.1.2636.3.39.1.12.1.1.1.6"  instance="jnxJsSPUMonitoringObjectsTable" alias="jnxJsSPUMonitoringCurrentFlowSession" type="Gauge32" />
-        <mibObj oid=".1.3.6.1.4.1.2636.3.39.1.12.1.1.1.7"  instance="jnxJsSPUMonitoringObjectsTable" alias="jnxJsSPUMonitoringMaxFlowSession"     type="Gauge32" />
+        <mibObj oid=".1.3.6.1.4.1.2636.3.39.1.12.1.1.1.11" instance="jnxJsSPUMonitoringObjectsTable" alias="juniSPUMonNodeDescr"    type="string" />
+        <mibObj oid=".1.3.6.1.4.1.2636.3.39.1.12.1.1.1.6"  instance="jnxJsSPUMonitoringObjectsTable" alias="juniSPUMongCurrFlow"    type="Gauge32" />
+        <mibObj oid=".1.3.6.1.4.1.2636.3.39.1.12.1.1.1.7"  instance="jnxJsSPUMonitoringObjectsTable" alias="juniSPUMonMaxFlow"      type="Gauge32" />
       </group>
 
       <group name="juniper-jrouter" ifType="ignore">

--- a/opennms-base-assembly/src/main/filtered/etc/datacollection/juniper.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/datacollection/juniper.xml
@@ -12,6 +12,14 @@
       <storageStrategy class="org.opennms.netmgt.dao.support.IndexStorageStrategy"/>
     </resourceType>
 
+    <resourceType name="jnxJsSPUMonitoringObjectsTable" label="Juniper SRX SPU Monitoring" resourceLabel="${jnxJsSPUMonitoringNodeDescr}">
+      <persistenceSelectorStrategy class="org.opennms.netmgt.collectd.PersistAllSelectorStrategy"/>
+      <storageStrategy class="org.opennms.netmgt.dao.support.SiblingColumnStorageStrategy">
+        <parameter key="sibling-column-name" value="jnxJsSPUMonitoringNodeDescr"/>
+      </storageStrategy>
+    </resourceType>
+
+
       <!-- Juniper MIBs -->
       <group name="juniper-router" ifType="ignore">
         <mibObj oid=".1.3.6.1.4.1.2636.3.1.13.1.8.6.1.0"  instance="0" alias="juniperCpuFeb"     type="gauge32" />
@@ -42,6 +50,12 @@
       <group name="juniper-erx-temperature" ifType="all">
         <mibObj oid=".1.3.6.1.4.1.4874.2.2.2.1.9.4.1.3" instance="juniSystemTempIndex" alias="juniSTValue"         type="integer" />
         <mibObj oid=".1.3.6.1.4.1.4874.2.2.2.1.9.4.1.4" instance="juniSystemTempIndex" alias="juniSTPhysicalIndex" type="string" />
+      </group>
+
+      <group name="juniper-srx-router" ifType="all">
+        <mibObj oid=".1.3.6.1.4.1.2636.3.39.1.12.1.1.1.11" instance="jnxJsSPUMonitoringObjectsTable" alias="jnxJsSPUMonitoringNodeDescr"          type="string" />
+        <mibObj oid=".1.3.6.1.4.1.2636.3.39.1.12.1.1.1.6"  instance="jnxJsSPUMonitoringObjectsTable" alias="jnxJsSPUMonitoringCurrentFlowSession" type="Gauge32" />
+        <mibObj oid=".1.3.6.1.4.1.2636.3.39.1.12.1.1.1.7"  instance="jnxJsSPUMonitoringObjectsTable" alias="jnxJsSPUMonitoringMaxFlowSession"     type="Gauge32" />
       </group>
 
       <group name="juniper-jrouter" ifType="ignore">
@@ -141,6 +155,13 @@
           <includeGroup>juniper-erx-temperature</includeGroup>
           <includeGroup>mib2-X-interfaces</includeGroup>
           <includeGroup>mib2-X-interfaces-pkts</includeGroup>
+        </collect>
+      </systemDef>
+
+      <systemDef name="Juniper SRX-Routers">
+        <sysoidMask>.1.3.6.1.4.1.2636.1.1.1.2.39</sysoidMask>
+        <collect>
+          <includeGroup>juniper-srx-router</includeGroup>
         </collect>
       </systemDef>
 

--- a/opennms-base-assembly/src/main/filtered/etc/datacollection/juniper.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/datacollection/juniper.xml
@@ -54,7 +54,7 @@
 
       <group name="juniper-srx-router" ifType="all">
         <mibObj oid=".1.3.6.1.4.1.2636.3.39.1.12.1.1.1.11" instance="jnxJsSPUMonitoringObjectsTable" alias="juniSPUMonNodeDescr"    type="string" />
-        <mibObj oid=".1.3.6.1.4.1.2636.3.39.1.12.1.1.1.6"  instance="jnxJsSPUMonitoringObjectsTable" alias="juniSPUMongCurrFlow"    type="Gauge32" />
+        <mibObj oid=".1.3.6.1.4.1.2636.3.39.1.12.1.1.1.6"  instance="jnxJsSPUMonitoringObjectsTable" alias="juniSPUMonCurrFlow"    type="Gauge32" />
         <mibObj oid=".1.3.6.1.4.1.2636.3.39.1.12.1.1.1.7"  instance="jnxJsSPUMonitoringObjectsTable" alias="juniSPUMonMaxFlow"      type="Gauge32" />
       </group>
 

--- a/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/juniper-graph.properties
+++ b/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/juniper-graph.properties
@@ -99,13 +99,13 @@ report.juniper.temp.command=--title="Current Temperature" \
 #####
 
 report.srx.spuFlowMonitor.name=Juniper SRX Flows
-report.srx.spuFlowMonitor.columns=jnxJsSPUMonitoringCurrentFlowSession,jnxJsSPUMonitoringMaxFlowSession
+report.srx.spuFlowMonitor.columns=juniSPUMongCurrFlow,juniSPUMonMaxFlow
 report.srx.spuFlowMonitor.type=jnxJsSPUMonitoringObjectsTable
-report.srx.spuFlowMonitor.propertiesValues=jnxJsSPUMonitoringNodeDescr
-report.srx.spuFlowMonitor.command=--title="Sessions used" \
+report.srx.spuFlowMonitor.propertiesValues=juniSPUMonNodeDescr
+report.srx.spuFlowMonitor.command=--title="Sessions used on node {juniSPUMonNodeDescr}" \
  --vertical-label="Sessions" \
- DEF:currentSessions={rrd1}:jnxJsSPUMonitoringC:AVERAGE \
- DEF:maxSessions={rrd2}:jnxJsSPUMonitoringM:MAX \
+ DEF:currentSessions={rrd1}:juniSPUMongCurrFlow:AVERAGE \
+ DEF:maxSessions={rrd2}:juniSPUMonMaxFlow:MAX \
  CDEF:percentSessions=currentSessions,maxSessions,/,100,* \
  LINE2:currentSessions#0000ff:"Sessions" \
  COMMENT:"\\n" \

--- a/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/juniper-graph.properties
+++ b/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/juniper-graph.properties
@@ -16,6 +16,7 @@ juniperj.temp, \
 erx.subscribers, \
 erx.systemmodule, \
 erx.temp, \
+srx.spuFlowMonitor, \
 ive.connections
 
 ######
@@ -92,6 +93,29 @@ report.juniper.temp.command=--title="Current Temperature" \
  GPRINT:val3:AVERAGE:" Avg  \\: %8.2lf %s" \
  GPRINT:val3:MIN:"Min  \\: %8.2lf %s" \
  GPRINT:val3:MAX:"Max  \\: %8.2lf %s\\n"
+
+#####
+##### Juniper SRX reports
+#####
+
+report.srx.spuFlowMonitor.name=Juniper SRX Flows
+report.srx.spuFlowMonitor.columns=jnxJsSPUMonitoringCurrentFlowSession,jnxJsSPUMonitoringMaxFlowSession
+report.srx.spuFlowMonitor.type=jnxJsSPUMonitoringObjectsTable
+report.srx.spuFlowMonitor.propertiesValues=jnxJsSPUMonitoringNodeDescr
+report.srx.spuFlowMonitor.command=--title="Sessions used" \
+ --vertical-label="Sessions" \
+ DEF:currentSessions={rrd1}:jnxJsSPUMonitoringC:AVERAGE \
+ DEF:maxSessions={rrd2}:jnxJsSPUMonitoringM:MAX \
+ CDEF:percentSessions=currentSessions,maxSessions,/,100,* \
+ LINE2:currentSessions#0000ff:"Sessions" \
+ COMMENT:"\\n" \
+ COMMENT:"\\n" \
+ GPRINT:currentSessions:AVERAGE:"Avg \\: %1.0lf" \
+ GPRINT:percentSessions:AVERAGE:"(%2.1lf%s%%)" \
+ GPRINT:currentSessions:MIN:"Min \\: %1.0lf" \
+ GPRINT:percentSessions:MIN:"(%2.1lf%s%%)" \
+ GPRINT:currentSessions:MAX:"Max \\: %1.0lf" \
+ GPRINT:percentSessions:MAX:"(%2.1lf%s%%)\\n"
 
 #####
 ##### Juniper ERX reports

--- a/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/juniper-graph.properties
+++ b/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/juniper-graph.properties
@@ -99,12 +99,12 @@ report.juniper.temp.command=--title="Current Temperature" \
 #####
 
 report.srx.spuFlowMonitor.name=Juniper SRX Flows
-report.srx.spuFlowMonitor.columns=juniSPUMongCurrFlow,juniSPUMonMaxFlow
+report.srx.spuFlowMonitor.columns=juniSPUMonCurrFlow,juniSPUMonMaxFlow
 report.srx.spuFlowMonitor.type=jnxJsSPUMonitoringObjectsTable
 report.srx.spuFlowMonitor.propertiesValues=juniSPUMonNodeDescr
 report.srx.spuFlowMonitor.command=--title="Sessions used on node {juniSPUMonNodeDescr}" \
  --vertical-label="Sessions" \
- DEF:currentSessions={rrd1}:juniSPUMongCurrFlow:AVERAGE \
+ DEF:currentSessions={rrd1}:juniSPUMonCurrFlow:AVERAGE \
  DEF:maxSessions={rrd2}:juniSPUMonMaxFlow:MAX \
  CDEF:percentSessions=currentSessions,maxSessions,/,100,* \
  LINE2:currentSessions#0000ff:"Sessions" \

--- a/opennms-base-assembly/src/main/filtered/etc/threshd-configuration.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/threshd-configuration.xml
@@ -33,6 +33,16 @@
 		</service>
 	</package>
 
+	<package name="juniper-srx">
+		<filter>IPADDR != '0.0.0.0' &amp; nodeSysOID LIKE '.1.3.6.1.4.1.2636.1.1.1.2.39'</filter>
+		<include-range begin="1.1.1.1" end="254.254.254.254"/>
+		<include-range begin="::1" end="ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"/>
+
+		<service name="SNMP" interval="300000" user-defined="false" status="on">
+			<parameter key="thresholding-group" value="juniper-srx"/>
+		</service>
+	</package>
+
 	<package name="netsnmp">
 		<filter>IPADDR != '0.0.0.0' &amp; (nodeSysOID LIKE '.1.3.6.1.4.1.2021.%' | nodeSysOID LIKE '.1.3.6.1.4.1.8072.%')</filter>	 
 		<include-range begin="1.1.1.1" end="254.254.254.254"/>

--- a/opennms-base-assembly/src/main/filtered/etc/thresholds.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/thresholds.xml
@@ -34,7 +34,7 @@
 
         <group name="juniper-srx"
                         rrdRepository = "${install.share.dir}/rrd/snmp/">
-                        <expression description="Trigger a warning event when the number of tracked sessions of a Juniper SRX router exceeds 90% of its capacity." type="high" expression="jnxJsSPUMonitoringCurrentFlowSession / jnxJsSPUMonitoringMaxFlowSession * 100.0" ds-type="node" ds-label="" value="90.0" rearm="75.0" trigger="2"/>
+                        <expression description="Trigger a warning event when the number of tracked sessions of a Juniper SRX router exceeds 90% of its capacity." type="high" expression="juniSPUMonCurrFlow / juniSPUMonMaxFlow * 100.0" ds-type="node" ds-label="" value="90.0" rearm="75.0" trigger="2"/>
         </group>
         
         <group name="netsnmp"

--- a/opennms-base-assembly/src/main/filtered/etc/thresholds.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/thresholds.xml
@@ -31,6 +31,11 @@
                 <threshold type="high" ds-name="cvmTempStatusValue" ds-type="ciscoEnvMonTemperatureStatusIndex" ds-label="cvmTempStatusDescr" value="55.0" rearm="50.0" trigger="3"/>
                 <threshold type="relativeChange" ds-name="cvmTempStatusValue" ds-type="ciscoEnvMonTemperatureStatusIndex" ds-label="cvmTempStatusDescr" value="0.2" rearm="0.0" trigger="1"/>
         </group>
+
+        <group name="juniper-srx"
+                        rrdRepository = "${install.share.dir}/rrd/snmp/">
+                        <expression description="Trigger a warning event when the number of tracked sessions of a Juniper SRX router exceeds 90% of its capacity." type="high" expression="jnxJsSPUMonitoringCurrentFlowSession / jnxJsSPUMonitoringMaxFlowSession * 100.0" ds-type="node" ds-label="" value="90.0" rearm="75.0" trigger="2"/>
+        </group>
         
         <group name="netsnmp"
         		rrdRepository = "${install.share.dir}/rrd/snmp/">


### PR DESCRIPTION
Added configuration to collect, graph and threshold on Juniper SRX router's jnxJsSPUMonitoringCurrentFlowSession OID.

Background: 

When the number of tracked sessions reach the router's maximu capacity, the router starts to drop arbitrary sessions (not necessarly inactive ones) when needed to stay below the maximum. This, obviously, creates strange network issues.

This can easily happen if you forget to define a timeout for some kind of UDP sessions.

JIRA: http://issues.opennms.org/browse/NMS-7553
Bamboo: http://bamboo.internal.opennms.com:8085/browse/OPENNMS-NMS258

Todo:
- [x] Review
- [x] Pass unit tests
- [ ] Merge to develop 