### PR TITLE
NMS-7579: Remove unnecessary output from opennms-doc modules

### DIFF
--- a/opennms-doc/guide-admin/pom.xml
+++ b/opennms-doc/guide-admin/pom.xml
@@ -20,6 +20,13 @@
                     <skipAssembly>false</skipAssembly>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.asciidoctor</groupId>
+                <artifactId>asciidoctor-maven-plugin</artifactId>
+                <configuration>
+                    <sourceDocumentName>index.adoc</sourceDocumentName>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/opennms-doc/guide-development/pom.xml
+++ b/opennms-doc/guide-development/pom.xml
@@ -20,6 +20,13 @@
                     <skipAssembly>false</skipAssembly>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.asciidoctor</groupId>
+                <artifactId>asciidoctor-maven-plugin</artifactId>
+                <configuration>
+                    <sourceDocumentName>index.adoc</sourceDocumentName>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/opennms-doc/guide-doc/pom.xml
+++ b/opennms-doc/guide-doc/pom.xml
@@ -20,6 +20,13 @@
                     <skipAssembly>false</skipAssembly>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.asciidoctor</groupId>
+                <artifactId>asciidoctor-maven-plugin</artifactId>
+                <configuration>
+                    <sourceDocumentName>index.adoc</sourceDocumentName>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/opennms-doc/guide-install/pom.xml
+++ b/opennms-doc/guide-install/pom.xml
@@ -20,6 +20,13 @@
                     <skipAssembly>false</skipAssembly>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.asciidoctor</groupId>
+                <artifactId>asciidoctor-maven-plugin</artifactId>
+                <configuration>
+                    <sourceDocumentName>index.adoc</sourceDocumentName>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/opennms-doc/guide-user/pom.xml
+++ b/opennms-doc/guide-user/pom.xml
@@ -20,6 +20,13 @@
                     <skipAssembly>false</skipAssembly>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.asciidoctor</groupId>
+                <artifactId>asciidoctor-maven-plugin</artifactId>
+                <configuration>
+                    <sourceDocumentName>index.adoc</sourceDocumentName>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/opennms-doc/releasenotes/pom.xml
+++ b/opennms-doc/releasenotes/pom.xml
@@ -20,6 +20,13 @@
                     <skipAssembly>false</skipAssembly>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.asciidoctor</groupId>
+                <artifactId>asciidoctor-maven-plugin</artifactId>
+                <configuration>
+                    <sourceDocumentName>index.adoc</sourceDocumentName>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
- Set source document name in guide-admin
- Set source document name in guide-development
- Set source document name in guide-doc
- Set source document name in guide-install
- Set source document name in guide-user
- Set source document name in releasenotes

Each maven module generates only one index.html and one index.pdf and all other HTML and PDF files are removed.

JIRA: http://issues.opennms.org/browse/NMS-7579

Todo:
- [x] Review for deploy and packaging
- [x] Merge to develop and close JIRA issue
