### PR TITLE
Improve BSFMonitor and BSFNotificationStrategy performance

### DIFF
--- a/opennms-services/src/main/java/org/opennms/netmgt/notifd/BSFNotificationStrategy.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/notifd/BSFNotificationStrategy.java
@@ -71,6 +71,7 @@ public class BSFNotificationStrategy implements NotificationStrategy {
         String fileName = getFileName();
         String lang = getLangClass();
         String engine = getBsfEngine();
+        String runType = getBsfRunType();
         String[] extensions = getFileExtensions();
 
         LOG.info("Loading notification script from file '{}'", fileName);
@@ -98,7 +99,13 @@ public class BSFNotificationStrategy implements NotificationStrategy {
                 checkAberrantScriptBehaviors(code);
 
                 // Execute the script
-                bsfManager.exec(lang, "BSFNotificationStrategy", 0, 0, code);
+                if("eval".equals(runType)){
+                    results.put("status", bsfManager.eval(lang, "BSFNotificationStrategy", 0, 0, code).toString());  
+                }else if("exec".equals(runType)){
+                    bsfManager.exec(lang, "BSFNotificationStrategy", 0, 0, code);
+                }else{
+                    LOG.warn("Invalid run-type parameter value '{}' for BSF notification script '{}'. Only 'eval' and 'exec' are supported.", runType, scriptFile);
+                }
 
                 // Check whether the script finished successfully
                 if ("OK".equals(results.get("status"))) {
@@ -240,6 +247,15 @@ public class BSFNotificationStrategy implements NotificationStrategy {
         if (exts == null) return null;
         return exts.split(",");
     }
+
+    private String getBsfRunType() {
+        String runType = getSwitchValue("run-type");
+        if(runType == null){
+            runType = "exec";
+        }
+        return runType;
+    }
+
 
     private void retrieveParams() {
         for (Argument arg : m_arguments) {

--- a/opennms-services/src/main/java/org/opennms/netmgt/notifd/BSFNotificationStrategy.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/notifd/BSFNotificationStrategy.java
@@ -53,6 +53,7 @@ import org.opennms.netmgt.model.notifd.NotificationStrategy;
 
 /**
  * @author <A HREF="mailto:jeffg@opennms.org">Jeff Gehlbach</A>
+ * @author <A HREF="mailto:dschlenk@converge-one.com</A>
  * @author <A HREF="http://www.opennms.org">OpenNMS</A>
  *
  */
@@ -61,48 +62,57 @@ public class BSFNotificationStrategy implements NotificationStrategy {
 
     private List<Argument> m_arguments;
     private Map<String,String> m_notifParams = new HashMap<String,String>();
-
-    /* (non-Javadoc)
-     * @see org.opennms.netmgt.notifd.NotificationStrategy#send(java.util.List)
+    
+    
+    /* 
+     * Since instances of this class are short lived (unlike BSFMonitor) we need to
+     * make a static instance and synchronize access to it to
+     * take advantage of caching script engines. If this becomes a bottleneck
+     * perhaps a small pool of managers would help.
      */
-    @Override
-    public int send(List<Argument> arguments) {
-        m_arguments = arguments;
-        String fileName = getFileName();
-        String lang = getLangClass();
-        String engine = getBsfEngine();
-        String runType = getBsfRunType();
-        String[] extensions = getFileExtensions();
+    private static BSFManager s_bsfManager;
+    static {
+        LOG.debug("creating static BSFManager");
+        s_bsfManager = new BSFManager();
+    }
+    
+    private static synchronized int executeScript(String fileName, BSFNotificationStrategy obj){
+        String lang = obj.getLangClass();
+        String engine = obj.getBsfEngine();
+        String runType = obj.getBsfRunType();
+        String[] extensions = obj.getFileExtensions();
 
         LOG.info("Loading notification script from file '{}'", fileName);
         File scriptFile = new File(fileName);
-        BSFManager bsfManager = new BSFManager();
-        int returnCode = -1;
-
+        int ret = -1;
         try {
 
             if(lang==null) lang = BSFManager.getLangFromFilename(fileName);
 
             // Declare some beans that can be used inside the script                    
             HashMap<String,String> results = new HashMap<String,String>();
-            bsfManager.declareBean("results", results, Map.class);
-            declareBeans(bsfManager);
+            s_bsfManager.declareBean("results", results, Map.class);
+            declareBeans(obj);
 
             if(engine != null && lang != null && extensions != null && extensions.length > 0 ){
-                BSFManager.registerScriptingEngine(lang, engine, extensions);
+              //We register the scripting engine again no matter what since  
+                //BSFManager doesn't let us know what engine is currently registered
+                //for this language and it might not be the same as what we want. 
+                LOG.debug("Registering scripting engine '{}' for '{}'", engine, lang);
+                BSFManager.registerScriptingEngine(lang,engine,extensions);
             }
 
             if(scriptFile.exists() && scriptFile.canRead()){   
                 String code = IOUtils.getStringFromReader(new InputStreamReader(new FileInputStream(scriptFile), "UTF-8"));
 
                 // Check foot before firing
-                checkAberrantScriptBehaviors(code);
+                obj.checkAberrantScriptBehaviors(code);
 
                 // Execute the script
                 if("eval".equals(runType)){
-                    results.put("status", bsfManager.eval(lang, "BSFNotificationStrategy", 0, 0, code).toString());  
+                    results.put("status", s_bsfManager.eval(lang, "BSFNotificationStrategy", 0, 0, code).toString());  
                 }else if("exec".equals(runType)){
-                    bsfManager.exec(lang, "BSFNotificationStrategy", 0, 0, code);
+                    s_bsfManager.exec(lang, "BSFNotificationStrategy", 0, 0, code);
                 }else{
                     LOG.warn("Invalid run-type parameter value '{}' for BSF notification script '{}'. Only 'eval' and 'exec' are supported.", runType, scriptFile);
                 }
@@ -110,40 +120,51 @@ public class BSFNotificationStrategy implements NotificationStrategy {
                 // Check whether the script finished successfully
                 if ("OK".equals(results.get("status"))) {
                     LOG.info("Execution succeeded and successful status passed back for script '{}'", scriptFile);
-                    returnCode = 0;
+                    ret = 0;
                 } else {
                     LOG.warn("Execution succeeded for script '{}', but script did not indicate successful notification by putting an entry into the 'results' bean with key 'status' and value 'OK'", scriptFile);
-                    returnCode = -1;
+                    ret = -1;
                 }
             } else {
                 LOG.warn("Cannot locate or read BSF script file '{}'. Returning failure indication.", fileName);
-                returnCode = -1;
+                ret = -1;
             }
         } catch (BSFException e) {
             LOG.warn("Execution of script '{}' failed with BSFException: {}", scriptFile, e.getMessage(), e);
-            returnCode = -1;
+            ret = -1;
         } catch (FileNotFoundException e){
             LOG.warn("Could not find BSF script file '{}'.", fileName);
-            returnCode = -1;
+            ret = -1;
         } catch (IOException e) {
             LOG.warn("Execution of script '{}' failed with IOException: {}", scriptFile, e.getMessage(), e);
-            returnCode = -1;
+            ret = -1;
         } catch (Throwable e) {
             // Catch any RuntimeException throws
             LOG.warn("Execution of script '{}' failed with unexpected throwable: {}", scriptFile, e.getMessage(), e);
-            returnCode = -1;
+            ret = -1;
         } finally { 
-            bsfManager.terminate();
+            undeclareBean("results");
+            undeclareBeans(obj);
         }
-
+        LOG.debug("Finished running BSF script notification.");
+        return ret;
+    }
+    /* (non-Javadoc)
+     * @see org.opennms.netmgt.notifd.NotificationStrategy#send(java.util.List)
+     */
+    @Override
+    public int send(List<Argument> arguments) {
+        m_arguments = arguments;
+        String fileName = getFileName();
+        int returnCode = executeScript(fileName, this);
         return returnCode;
     }
 
-    private void declareBeans(BSFManager bsfManager) throws BSFException {
+    private static void declareBeans(BSFNotificationStrategy obj) throws BSFException {
         NodeDao nodeDao = Notifd.getInstance().getNodeDao();
         Integer nodeId;
         try {
-            nodeId = Integer.valueOf(m_notifParams.get(NotificationManager.PARAM_NODE));
+            nodeId = Integer.valueOf(obj.m_notifParams.get(NotificationManager.PARAM_NODE));
         } catch (NumberFormatException nfe) {
             nodeId = null;
         }
@@ -166,35 +187,73 @@ public class BSFNotificationStrategy implements NotificationStrategy {
             foreignId = node.getForeignId();
         }
 
-        bsfManager.declareBean("bsf_notif_strategy", this, BSFNotificationStrategy.class);
+        s_bsfManager.declareBean("bsf_notif_strategy", obj, BSFNotificationStrategy.class);
         
-        retrieveParams();
-        bsfManager.declareBean("notif_params", m_notifParams, Map.class);
+        obj.retrieveParams();
+        s_bsfManager.declareBean("logger", LOG, Logger.class);
+        s_bsfManager.declareBean("notif_params", obj.m_notifParams, Map.class);
 
-        bsfManager.declareBean("node_label", nodeLabel, String.class);
-        bsfManager.declareBean("foreign_source", foreignSource, String.class);
-        bsfManager.declareBean("foreign_id", foreignId, String.class);
-        bsfManager.declareBean("node_assets", assets, OnmsAssetRecord.class);
-        bsfManager.declareBean("node_categories", categories, List.class);
-        bsfManager.declareBean("node", node, OnmsNode.class);
+        s_bsfManager.declareBean("node_label", nodeLabel, String.class);
+        s_bsfManager.declareBean("foreign_source", foreignSource, String.class);
+        s_bsfManager.declareBean("foreign_id", foreignId, String.class);
+        s_bsfManager.declareBean("node_assets", assets, OnmsAssetRecord.class);
+        s_bsfManager.declareBean("node_categories", categories, List.class);
+        s_bsfManager.declareBean("node", node, OnmsNode.class);
 
-        for (Argument arg : m_arguments) {
-            if (NotificationManager.PARAM_TEXT_MSG.equals(arg.getSwitch())) bsfManager.declareBean("text_message", arg.getValue(), String.class);
-            if (NotificationManager.PARAM_NUM_MSG.equals(arg.getSwitch())) bsfManager.declareBean("numeric_message", arg.getValue(), String.class);
-            if (NotificationManager.PARAM_NODE.equals(arg.getSwitch())) bsfManager.declareBean("node_id", arg.getValue(), String.class);
-            if (NotificationManager.PARAM_INTERFACE.equals(arg.getSwitch())) bsfManager.declareBean("ip_addr", arg.getValue(), String.class);
-            if (NotificationManager.PARAM_SERVICE.equals(arg.getSwitch())) bsfManager.declareBean("svc_name", arg.getValue(), String.class);
-            if (NotificationManager.PARAM_SUBJECT.equals(arg.getSwitch())) bsfManager.declareBean("subject", arg.getValue(), String.class);
-            if (NotificationManager.PARAM_EMAIL.equals(arg.getSwitch())) bsfManager.declareBean("email", arg.getValue(), String.class);
-            if (NotificationManager.PARAM_PAGER_EMAIL.equals(arg.getSwitch())) bsfManager.declareBean("pager_email", arg.getValue(), String.class);
-            if (NotificationManager.PARAM_XMPP_ADDRESS.equals(arg.getSwitch())) bsfManager.declareBean("xmpp_address", arg.getValue(), String.class);
-            if (NotificationManager.PARAM_TEXT_PAGER_PIN.equals(arg.getSwitch())) bsfManager.declareBean("text_pin", arg.getValue(), String.class);
-            if (NotificationManager.PARAM_NUM_PAGER_PIN.equals(arg.getSwitch())) bsfManager.declareBean("numeric_pin", arg.getValue(), String.class);
-            if (NotificationManager.PARAM_WORK_PHONE.equals(arg.getSwitch())) bsfManager.declareBean("work_phone", arg.getValue(), String.class);
-            if (NotificationManager.PARAM_HOME_PHONE.equals(arg.getSwitch())) bsfManager.declareBean("home_phone", arg.getValue(), String.class);
-            if (NotificationManager.PARAM_MOBILE_PHONE.equals(arg.getSwitch())) bsfManager.declareBean("mobile_phone", arg.getValue(), String.class);
-            if (NotificationManager.PARAM_TUI_PIN.equals(arg.getSwitch())) bsfManager.declareBean("phone_pin", arg.getValue(), String.class);
-            if (NotificationManager.PARAM_MICROBLOG_USERNAME.equals(arg.getSwitch())) bsfManager.declareBean("microblog_username", arg.getValue(), String.class);
+        for (Argument arg : obj.m_arguments) {
+            if (NotificationManager.PARAM_TEXT_MSG.equals(arg.getSwitch())) s_bsfManager.declareBean("text_message", arg.getValue(), String.class);
+            if (NotificationManager.PARAM_NUM_MSG.equals(arg.getSwitch())) s_bsfManager.declareBean("numeric_message", arg.getValue(), String.class);
+            if (NotificationManager.PARAM_NODE.equals(arg.getSwitch())) s_bsfManager.declareBean("node_id", arg.getValue(), String.class);
+            if (NotificationManager.PARAM_INTERFACE.equals(arg.getSwitch())) s_bsfManager.declareBean("ip_addr", arg.getValue(), String.class);
+            if (NotificationManager.PARAM_SERVICE.equals(arg.getSwitch())) s_bsfManager.declareBean("svc_name", arg.getValue(), String.class);
+            if (NotificationManager.PARAM_SUBJECT.equals(arg.getSwitch())) s_bsfManager.declareBean("subject", arg.getValue(), String.class);
+            if (NotificationManager.PARAM_EMAIL.equals(arg.getSwitch())) s_bsfManager.declareBean("email", arg.getValue(), String.class);
+            if (NotificationManager.PARAM_PAGER_EMAIL.equals(arg.getSwitch())) s_bsfManager.declareBean("pager_email", arg.getValue(), String.class);
+            if (NotificationManager.PARAM_XMPP_ADDRESS.equals(arg.getSwitch())) s_bsfManager.declareBean("xmpp_address", arg.getValue(), String.class);
+            if (NotificationManager.PARAM_TEXT_PAGER_PIN.equals(arg.getSwitch())) s_bsfManager.declareBean("text_pin", arg.getValue(), String.class);
+            if (NotificationManager.PARAM_NUM_PAGER_PIN.equals(arg.getSwitch())) s_bsfManager.declareBean("numeric_pin", arg.getValue(), String.class);
+            if (NotificationManager.PARAM_WORK_PHONE.equals(arg.getSwitch())) s_bsfManager.declareBean("work_phone", arg.getValue(), String.class);
+            if (NotificationManager.PARAM_HOME_PHONE.equals(arg.getSwitch())) s_bsfManager.declareBean("home_phone", arg.getValue(), String.class);
+            if (NotificationManager.PARAM_MOBILE_PHONE.equals(arg.getSwitch())) s_bsfManager.declareBean("mobile_phone", arg.getValue(), String.class);
+            if (NotificationManager.PARAM_TUI_PIN.equals(arg.getSwitch())) s_bsfManager.declareBean("phone_pin", arg.getValue(), String.class);
+            if (NotificationManager.PARAM_MICROBLOG_USERNAME.equals(arg.getSwitch())) s_bsfManager.declareBean("microblog_username", arg.getValue(), String.class);
+        }
+    }
+    
+    private static void undeclareBean( String beanName){
+        try{
+            s_bsfManager.undeclareBean(beanName);
+        }catch(BSFException e) {
+            LOG.warn("Unable to undeclareBean '{}'", beanName);
+        }
+    }
+    private static void undeclareBeans(BSFNotificationStrategy obj) {
+        undeclareBean("logger");
+        undeclareBean("bsf_notif_strategy");
+        undeclareBean("notif_params");
+        undeclareBean("node_label");
+        undeclareBean("foreign_source");
+        undeclareBean("foreign_id");
+        undeclareBean("node_assets");
+        undeclareBean("node_categories");
+        undeclareBean("node");
+        for (Argument arg : obj.m_arguments) {
+            if (NotificationManager.PARAM_TEXT_MSG.equals(arg.getSwitch())) undeclareBean("text_message");
+            if (NotificationManager.PARAM_NUM_MSG.equals(arg.getSwitch())) undeclareBean("numeric_message");
+            if (NotificationManager.PARAM_NODE.equals(arg.getSwitch())) undeclareBean("node_id");
+            if (NotificationManager.PARAM_INTERFACE.equals(arg.getSwitch())) undeclareBean("ip_addr");
+            if (NotificationManager.PARAM_SERVICE.equals(arg.getSwitch())) undeclareBean("svc_name");
+            if (NotificationManager.PARAM_SUBJECT.equals(arg.getSwitch())) undeclareBean("subject");
+            if (NotificationManager.PARAM_EMAIL.equals(arg.getSwitch())) undeclareBean("email");
+            if (NotificationManager.PARAM_PAGER_EMAIL.equals(arg.getSwitch())) undeclareBean("pager_email");
+            if (NotificationManager.PARAM_XMPP_ADDRESS.equals(arg.getSwitch())) undeclareBean("xmpp_address");
+            if (NotificationManager.PARAM_TEXT_PAGER_PIN.equals(arg.getSwitch())) undeclareBean("text_pin");
+            if (NotificationManager.PARAM_NUM_PAGER_PIN.equals(arg.getSwitch())) undeclareBean("numeric_pin");
+            if (NotificationManager.PARAM_WORK_PHONE.equals(arg.getSwitch())) undeclareBean("work_phone");
+            if (NotificationManager.PARAM_HOME_PHONE.equals(arg.getSwitch())) undeclareBean("home_phone");
+            if (NotificationManager.PARAM_MOBILE_PHONE.equals(arg.getSwitch())) undeclareBean("mobile_phone");
+            if (NotificationManager.PARAM_TUI_PIN.equals(arg.getSwitch())) undeclareBean("phone_pin");
+            if (NotificationManager.PARAM_MICROBLOG_USERNAME.equals(arg.getSwitch())) undeclareBean("microblog_username");
         }
     }
 


### PR DESCRIPTION
BSF performance has always been terrible since scripts are compiled and executed fresh each time. These patches will allow BSF engines that cache to actually cache by making BSFManager instances long running. I've verified that it works by patching groovy's CachingGroovyEngine to store some cache hit/miss stats and taking thread dumps at various points in time. Drops the load on a host monitoring a lot of hosts each with many services monitored by a groovy script from ~3-5 to ~0.25-0.75. 