### PR TITLE
NMS-7485: fix queued logging output.

### DIFF
--- a/opennms-base-assembly/src/main/filtered/etc/rrd-configuration.properties
+++ b/opennms-base-assembly/src/main/filtered/etc/rrd-configuration.properties
@@ -152,11 +152,11 @@
 
 
 #
-# This property defines which log4j category to use when printing the queue
+# This property defines which log4j2 routing prefix to use when printing the queue
 # statistics
 #
 # The default setting is for the queueing daemon
-#org.opennms.rrd.queuing.category=OpenNMS.Queued
+#org.opennms.rrd.queuing.category=queued
 
 #
 # The following constants are related to how long a write thread lingers before

--- a/opennms-rrd/opennms-rrd-api/src/main/java/org/opennms/netmgt/rrd/QueuingRrdStrategy.java
+++ b/opennms-rrd/opennms-rrd-api/src/main/java/org/opennms/netmgt/rrd/QueuingRrdStrategy.java
@@ -93,7 +93,7 @@ import org.slf4j.LoggerFactory;
  * org.opennms.rrd.queuing.modulus: (default 10000) the number of updates the
  * get enqueued between statistics output
  *
- * org.opennms.rrd.queuing.category: (default "OpenNMS.Queued") the log category
+ * org.opennms.rrd.queuing.category: (default "queued") the log routing prefix
  * to place the statistics output in
  *
  *

--- a/opennms-rrd/opennms-rrd-api/src/main/resources/org/opennms/netmgt/rrd/rrd-configuration.xml
+++ b/opennms-rrd/opennms-rrd-api/src/main/resources/org/opennms/netmgt/rrd/rrd-configuration.xml
@@ -18,7 +18,7 @@
 				<prop key="org.opennms.rrd.queuing.sigHighWaterMark">0</prop>
 				<prop key="org.opennms.rrd.queuing.queueHighWaterMark">0</prop>
 				<prop key="org.opennms.rrd.queuing.modulus">10000</prop>
-				<prop key="org.opennms.rrd.queuing.category">OpenNMS.Queued</prop>
+				<prop key="org.opennms.rrd.queuing.category">queued</prop>
 				<prop key="org.opennms.rrd.queuing.maxInsigUpdateSeconds">0</prop>
 				<prop key="org.opennms.rrd.queuing.writethread.sleepTime">50</prop>
 				<prop key="org.opennms.rrd.queuing.writethread.exitDelay">60000</prop>


### PR DESCRIPTION
Queued logs should go to queued.log like they did in 1.12.

JIRA: http://issues.opennms.org/browse/NMS-7485

Todo:
- [ ] Review
- [ ] Pass unit tests
- [ ] Merge to develop 