### PR TITLE
NMS-7655: Documentation fixes to normalize italic and monospace fonts

### DIFF
--- a/opennms-doc/guide-admin/src/asciidoc/text/poller/BSFMonitor.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/poller/BSFMonitor.adoc
@@ -38,22 +38,22 @@ _BSFMonitor_ also grants access to a selection of _OpenNMS_ internal methods and
 .Beans which can be used in the script
 [options="header, autowidth"]
 |===
-| Variable      | Type                          | Description
-| `map`         | Map<String, Object>           | The _map_ contains all various parameters passed to the monitor
-                                                  from the service definition it the 'poller-configuration.xml' file.
-| `ip_addr`     | String                        | The IP address that is currently being polled.
-| `node_id`     | int                           | The Node ID of the node the `ip_addr` belongs to.
-| `node_label`  | String                        | The Node Label of the node the `ip_addr` and service belongs to.
-| `svc_name`    | String                        | The name of the service that is being polled.
+| Variable      | Type                            | Description
+| `map`         | _Map<String, Object>_           | The _map_ contains all various parameters passed to the monitor
+                                                    from the service definition it the `poller-configuration.xml` file.
+| `ip_addr`     | _String_                        | The IP address that is currently being polled.
+| `node_id`     | _int_                           | The Node ID of the node the `ip_addr` belongs to.
+| `node_label`  | _String_                        | The Node Label of the node the `ip_addr` and service belongs to.
+| `svc_name`    | _String_                        | The name of the service that is being polled.
 | `bsf_monitor` | _BSFMonitor_                    | The instance of the _BSFMonitor_ object calling the script.
-                                                  Useful for logging via its +log(String sev, String fmt, Object... args)+ method.
-| `results`     | HashMap<String, String>       | The script is expected to put its results into this object.
-                                                  The status indication should be set into the entry with key `status`.
-                                                  If the status is not `OK`, a key `reason` should contain a description of the problem.
-| `times`       | LinkedHashMap<String, Number> | The script is expected to put one or more response times into this object.
+                                                    Useful for logging via its +log(String sev, String fmt, Object... args)+ method.
+| `results`     | _HashMap<String, String>_       | The script is expected to put its results into this object.
+                                                    The status indication should be set into the entry with key `status`.
+                                                    If the status is not `OK`, a key `reason` should contain a description of the problem.
+| `times`       | _LinkedHashMap<String, Number>_ | The script is expected to put one or more response times into this object.
 |===
 
-Additionally every parameter added to the service definition in 'poller-configuration.xml' is available as a _String_ object in the script.
+Additionally every parameter added to the service definition in `poller-configuration.xml` is available as a _String_ object in the script.
 The key attribute of the parameter represents the name of the _String_ object and the value attribute represents the value of the _String_ object.
 
 NOTE: Please keep in mind, that these parameters are also accessible via the _map_ bean.
@@ -69,10 +69,10 @@ The following status codes are defined:
 [options="header, autowidth"]
 |===
 | Code  | Description
-| `OK`  | Service is available
-| `UNK` | Service status unknown
-| `UNR` | Service is unresponsive
-| `NOK` | Service is unavailable
+| _OK_  | Service is available
+| _UNK_ | Service status unknown
+| _UNR_ | Service is unresponsive
+| _NOK_ | Service is unavailable
 |===
 
 ===== Response time tracking
@@ -80,7 +80,7 @@ The following status codes are defined:
 By default the _BSFMonitor_ tracks the whole time the script file consumes as the response time.
 If the response time should be persisted the response time add the following parameters:
 
-.RRD response time tracking for this service in 'poller-configuration.xml'
+.RRD response time tracking for this service in `poller-configuration.xml`
 [source, xml]
 ----
 <!-- where in the filesystem response times are stored -->
@@ -129,7 +129,7 @@ The _BSF_ supports many languages, the following table provides the required set
 
 ===== Example Bean Shell
 
-._BeanShell_ example 'poller-configuration.xml'
+._BeanShell_ example `poller-configuration.xml`
 [source, xml]
 ----
 <service name="MinimalBeanShell" interval="300000" user-defined="true" status="on">
@@ -140,7 +140,7 @@ The _BSF_ supports many languages, the following table provides the required set
 <monitor service="MinimalBeanShell" class-name="org.opennms.netmgt.poller.monitors.BSFMonitor" />
 ----
 
-.BeanShell example 'MinimalBeanShell.bsh' script file
+.BeanShell example `MinimalBeanShell.bsh` script file
 [source, java]
 ----
 bsf_monitor.log("ERROR", "Starting MinimalBeanShell.bsf", null);
@@ -156,10 +156,10 @@ if (testFile.exists()) {
 ===== Example Groovy
 
 To use the Groovy language an additional library is required.
-Copy a compatible +groovy-all.jar+ into to 'opennms/lib' folder and restart _OpenNMS_.
+Copy a compatible +groovy-all.jar+ into to `opennms/lib` folder and restart _OpenNMS_.
 That makes _Groovy_ available for the _BSFMonitor_.
 
-._Groovy_ example 'poller-configuration.xml' with default `run-type` set to `eval`
+._Groovy_ example `poller-configuration.xml` with default `run-type` set to `eval`
 [source, xml]
 ----
 <service name="MinimalGroovy" interval="300000" user-defined="true" status="on">
@@ -170,7 +170,7 @@ That makes _Groovy_ available for the _BSFMonitor_.
 <monitor service="MinimalGroovy" class-name="org.opennms.netmgt.poller.monitors.BSFMonitor" />
 ----
 
-._Groovy_ example 'MinimalGroovy.groovy' script file for `run-type` `eval`
+._Groovy_ example `MinimalGroovy.groovy` script file for `run-type` `eval`
 [source, java]
 ----
 bsf_monitor.log("ERROR", "Starting MinimalGroovy.groovy", null);
@@ -183,7 +183,7 @@ if (testFile.exists()) {
 }
 ----
 
-.Groovy example 'poller-configuration.xml' with `run-type` set to `exec`
+.Groovy example `poller-configuration.xml` with `run-type` set to `exec`
 [source, xml]
 ----
 <service name="MinimalGroovy" interval="300000" user-defined="true" status="on">
@@ -195,7 +195,7 @@ if (testFile.exists()) {
 <monitor service="MinimalGroovy" class-name="org.opennms.netmgt.poller.monitors.BSFMonitor" />
 ----
 
-._Groovy_ example 'MinimalGroovy.groovy' script file for `run-type` set to `exec`
+._Groovy_ example `MinimalGroovy.groovy` script file for `run-type` set to `exec`
 [source, java]
 ----
 bsf_monitor.log("ERROR", "Starting MinimalGroovy", null);
@@ -211,10 +211,10 @@ if (testFile.exists()) {
 ===== Example Jython
 
 To use the _Jython_ (_Java_ implementation of _Python_) language an additional library is required.
-Copy a compatible `jython-x.y.z.jar` into the 'opennms/lib' folder and restart _OpenNMS_.
+Copy a compatible `jython-x.y.z.jar` into the `opennms/lib` folder and restart _OpenNMS_.
 That makes _Jython_ available for the _BSFMonitor_.
 
-.Jython example 'poller-configuration.xml' with `run-type` `exec`
+.Jython example `poller-configuration.xml` with `run-type` `exec`
 [source, xml]
 ----
 <service name="MinimalJython" interval="300000" user-defined="true" status="on">
@@ -226,7 +226,7 @@ That makes _Jython_ available for the _BSFMonitor_.
 <monitor service="MinimalJython" class-name="org.opennms.netmgt.poller.monitors.BSFMonitor" />
 ----
 
-._Jython_ example 'MinimalJython.py' script file for `run-type` set to `exec`
+._Jython_ example `MinimalJython.py` script file for `run-type` set to `exec`
 [source, python]
 ----
 from java.io import File
@@ -247,7 +247,7 @@ NOTE: As profit that this is really _Python_, notice the substitution of _Python
 
 The following example references all beans that are exposed to the script, including a custom parameter.
 
-._Groovy_ example 'poller-configuration.xml'
+._Groovy_ example `poller-configuration.xml`
 [source, xml]
 ----
 <service name="MinimalGroovy" interval="30000" user-defined="true" status="on">

--- a/opennms-doc/guide-admin/src/asciidoc/text/poller/CiscoIpSlaMonitor.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/poller/CiscoIpSlaMonitor.adoc
@@ -33,9 +33,9 @@ If the _RTT_LATEST_OPERSENSE_ returns with _overThreshold(3)_ the service is mar
 |===
 | Parameter       | Description                                                                                         | Required | Default value
 | `retry`         | Number of retries to get the information from the SNMP agent before the service is marked as
-                    _down_.                                                                                             | optional | from 'snmp-config.xml'
-| `timeout`       | Time in milliseconds to wait for the result from the SNMP agent before making the next attempt.     | optional | from 'snmp-config.xml'
-| `admin-tag`     | The `tag` attribute from your IP SLA configuration you want to monitor.                             | required | `-`
+                    _down_.                                                                                             | optional | from `snmp-config.xml`
+| `timeout`       | Time in milliseconds to wait for the result from the SNMP agent before making the next attempt.     | optional | from `snmp-config.xml`
+| `admin-tag`     | The `tag` attribute from your _IP SLA_ configuration you want to monitor.                           | required | `-`
 | `ignore-thresh` | Boolean indicates if just the status or configured threshold should be monitored.                   | required | ``
 |===
 
@@ -78,7 +78,7 @@ WARNING: It´s not possible to reconfigure an IP SLA entry.
          If you want to change parameters, you have to delete the whole configuration and reconfigure it with your new parameters.
          Backup your Cisco configuration manually or take a look at http://www.shrubbery.net/rancid/[RANCID].
 
-To monitor both of the entries the configuration in 'poller-configuration.xml' requires two service definition entries:
+To monitor both of the entries the configuration in `poller-configuration.xml` requires two service definition entries:
 
 [source, xml]
 ----

--- a/opennms-doc/guide-admin/src/asciidoc/text/poller/CiscoPingMibMonitor.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/poller/CiscoPingMibMonitor.adoc
@@ -39,7 +39,7 @@ The `packet-count` and `packet-timeout` parameters instead service this purpose 
 * One or more _Cisco_ devices running an _IOS_ image of recent vintage; any 12.2 or later image is probably fine.
 Even very low-end devices appear to support the CISCO-PING-MIB.
 * The _IOS_ devices that will perform the remote pings must be configured with an _SNMP write community_ string whose source address access-list includes the address of the OpenNMS server and whose MIB view (if any) includes the OID of the _ciscoPingTable_.
-* The corresponding _SNMP write community_ string must be specified in the `write-community` attribute of either the top-level `<snmp-config>` element of 'snmp-config.xml' or a `<definition>` child element that applies to the _SNMP-primary_ interface of the _IOS_ device(s) that will perform the remote pings.
+* The corresponding _SNMP write community_ string must be specified in the `write-community` attribute of either the top-level `<snmp-config>` element of `snmp-config.xml` or a `<definition>` child element that applies to the _SNMP-primary_ interface of the _IOS_ device(s) that will perform the remote pings.
 
 ===== Scalability concerns
 
@@ -68,11 +68,11 @@ _IOS_ seems to clean up entries in this table within a manner of minutes after t
 |===
 | Parameter                     | Description                                                                           | Required | Default value
 | `timeout`                     | A timeout, in milliseconds, that should override the SNMP timeout specified in
-                                  'snmp-config.xml'. Do not use without a very good reason to do so.                    | optional | from 'snmp-config.xml'
+                                  `snmp-config.xml`. Do not use without a very good reason to do so.                    | optional | from `snmp-config.xml`
 | `retry`                       | Number of retries to attempt if the initial attempt times out. Overrides the
-                                  equivalent value from 'snmp-config.xml'. Do not use unless really needed.             | optional | from 'snmp-config.xml'
+                                  equivalent value from `snmp-config.xml`. Do not use unless really needed.             | optional | from `snmp-config.xml`
 | `version`                     | SNMP protocol version (1, 2c, or 3) to use for operations performed by this service
-                                  monitor. Do not use with out a very good reason to do so.                             | optional | from 'snmp-config.xml'
+                                  monitor. Do not use with out a very good reason to do so.                             | optional | from `snmp-config.xml`
 | `packet-count`                | Number of ping packets that the remote _IOS_ device should send.                      | optional | `5`
 | `packet-size`                 | Size, in bytes, of each ping packet that the remote _IOS_ device should send.         | optional | `100`
 | `packet-timeout`              | Timeout, in milliseconds, of each ping packet sent by the remote _IOS_ device.        | optional | `2000`
@@ -170,7 +170,7 @@ Some or all of the Bar Limited CPE routers may be non-Cisco devices in this scen
 To meet this requirement, our approach is to configure Bar Limited's premise routers to be in the surveillance categories Customer_Bar, CPE, and Routers, and to use a filter to create a poller package that applies only to those routers.
 This time, though, we will use the special value `${ipaddr}` not in the `proxy-ip-addr` parameter but in the `target-ip-addr` parameter so that the remote pings will be performed for each Bar CPE router.
 Since we want the same _IOS_ device 20.11.5.11 to ping the CPE routers, we statically list that value for the `proxy-ip-addr` address.
-Example 'poller-configuration.xml' additions
+Example `poller-configuration.xml` additions
 
 [source, xml]
 ----

--- a/opennms-doc/guide-admin/src/asciidoc/text/poller/CitrixMonitor.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/poller/CitrixMonitor.adoc
@@ -1,7 +1,7 @@
 
 ==== CitrixMonitor
 
-This monitor is used to test if a Citrix(R) Server or XenApp Server(R) is providing the ICA protocol on TCP 1494.
+This monitor is used to test if a Citrix(R) Server or XenApp Server(R) is providing the _Independent Computing Architecture_ (_ICA_) protocol on TCP 1494.
 The monitor opens a TCP socket and tests the greeting banner returns with `ICA`, otherwise the service is unavailable.
 
 ===== Monitor facts
@@ -17,19 +17,19 @@ The monitor opens a TCP socket and tests the greeting banner returns with `ICA`,
 .Monitor specific parameters for the CitrixMonitor
 [options="header, autowidth"]
 |===
-| Parameter | Description                                    | Required | Default value
-| `retry` | Amount of attempts opening a connection and try to get the greeting banner before the service goes down | optional | `0`
-| `timeout` | Time to wait retrieving the greeting banner `ICA` from TCP connectiona before trying a next attempt. | optional | `3000 ms`
-| `port` | TCP port where ICA is listening. | optional | `1494`
+| Parameter | Description                                                                                             | Required | Default value
+| `retry`   | Amount of attempts opening a connection and try to get the greeting banner before the service goes down | optional | `0`
+| `timeout` | Time to wait retrieving the greeting banner `ICA` from TCP connection before trying a next attempt.     | optional | `3000 ms`
+| `port`    | TCP port where the _ICA_ protocol is listening.                                                         | optional | `1494`
 |===
 
-WARNING: If you have configure the _Metaframe Presentation Server Client_ using _Session Reliability_,  the TCP port is `2598` instead of `1494`.
+WARNING: If you have configure the _Metaframe Presentation Server Client_ using _Session Reliability_, the TCP port is 2598 instead of 1494.
 You can find additional information on http://support.citrix.com/article/CTX104147[CTX104147].
 It is not verified if the monitor works in this case.
 
 ===== Examples
 
-The following example configures OpenNMS to monitor the ICA protocol on TCP `1494` with 2 retries and waiting 5 seconds for each retry.
+The following example configures OpenNMS to monitor the ICA protocol on TCP 1494 with 2 retries and waiting 5 seconds for each retry.
 [source, xml]
 ----
 <service name="Citrix-TCP-ICA" interval="300000" user-defined="false" status="on">

--- a/opennms-doc/guide-admin/src/asciidoc/text/poller/DhcpMonitor.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/poller/DhcpMonitor.adoc
@@ -7,8 +7,8 @@ This monitor is used to monitor the availability and functionality of http://en.
 This monitor has two parts, the first one is the monitor class _DhcpMonitor_ executed by _Pollerd_ and the second part is a background daemon _Dhcpd_ running inside the OpenNMS JVM and listening for DHCP responses.
 A DHCP server is tested by sending a _DISCOVER_ message.
 If the DHCP server responds with an _OFFER_ the service is marked as up.
-The _Dhcpd_ background daemon is disabled by default and has to be activated in 'service-configuration.xml' in OpenNMS by setting `service enabled="true"`.
-The behavior for testing the DHCP server can be modified in the 'dhcp-configuration.xml' configuration file.
+The _Dhcpd_ background daemon is disabled by default and has to be activated in `service-configuration.xml` in OpenNMS by setting `service enabled="true"`.
+The behavior for testing the DHCP server can be modified in the `dhcp-configuration.xml` configuration file.
 
 IMPORTANT: It is required to install the `opennms-plugin-protocol-dhcp` before you can use this feature.
 
@@ -17,7 +17,7 @@ IMPORTANT: It is required to install the `opennms-plugin-protocol-dhcp` before y
 {apt-get,yum} install opennms-plugin-protocol-dhcp
 ----
 
-If you try to start OpenNMS without the _opennms-plugin-protocol-dhcp_ you will see the following error message in 'output.log':
+If you try to start OpenNMS without the _opennms-plugin-protocol-dhcp_ you will see the following error message in `output.log`:
 
 ----
 An error occurred while attempting to start the "OpenNMS:Name=Dhcpd" service (class org.opennms.netmgt.dhcpd.jmx.Dhcpd).  Shutting down and exiting.
@@ -36,7 +36,7 @@ CAUTION: Make sure no DHCP client is running on the OpenNMS server and using por
 | Remote Enabled | false
 |===
 
-.Service monitor parameters configured in 'poller-configuration.xml'
+.Service monitor parameters configured in `poller-configuration.xml`
 [options="header, autowidth"]
 |===
 | Parameter        | Description                                                                                    | Required | Default value
@@ -49,7 +49,7 @@ CAUTION: Make sure no DHCP client is running on the OpenNMS server and using por
 
 ===== _Dhcpd_ configuration
 
-._Dhcpd_ parameters in 'dhcp-configuration.xml'.
+._Dhcpd_ parameters in `dhcp-configuration.xml`.
 [options="autowidth"]
 |===
 | Parameter          | Description                                                                       | Required           | Default value
@@ -90,10 +90,10 @@ image::poller/02_02_dhcp-monitor-messages-unicast.png[]
 
 ===== Example testing DHCP server in the same subnet
 
-Example configuration how to configure the monitor in the 'poller-configuration.xml'.
+Example configuration how to configure the monitor in the `poller-configuration.xml`.
 The monitor will try to send in maximum 3 _DISCOVER_ messages and waits 3 seconds for the DHCP server _OFFER_ message.
 
-.Step 1: Configure a DHCP service in 'poller-configuration.xml'
+.Step 1: Configure a DHCP service in `poller-configuration.xml`
 [source, xml]
 ----
 <service name="DHCP" interval="300000" user-defined="false" status="on">
@@ -107,7 +107,7 @@ The monitor will try to send in maximum 3 _DISCOVER_ messages and waits 3 second
 <monitor service="DHCP" class-name="org.opennms.protocols.dhcp.monitor.DhcpMonitor"/>
 ----
 
-.Step 2: Enable the OpenNMS _Dhcpd_ daemon in 'service-configuration.xml'
+.Step 2: Enable the OpenNMS _Dhcpd_ daemon in `service-configuration.xml`
 [source, xml]
 ----
 <service enabled="true">
@@ -133,7 +133,7 @@ The monitor will try to send in maximum 3 _DISCOVER_ messages and waits 3 second
 
 ===== Example testing DHCP server in a different subnet in extended mode
 
-You can use the same monitor in 'poller-configuration.xml' as in the example above.
+You can use the same monitor in `poller-configuration.xml` as in the example above.
 
 .Configure _Dhcpd_ to test DHCP server in a different subnet. The OFFER from the DHCP server is sent to `myIpAddress`.
 [source, xml]

--- a/opennms-doc/guide-admin/src/asciidoc/text/poller/DiskUsageMonitor.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/poller/DiskUsageMonitor.adoc
@@ -31,18 +31,18 @@ Out-of-box support for _HOST-RESOURCES-MIB_ among commercial _Unix_ operating sy
 | `disk`       | A pattern that a storage's description (_hrStorageDescr_) must match to be taken into account.     | required | `-`
 | `free`       | The minimum amount of free space that storages matching the criteria must have available.
                  This parameter is evaluated as a percent of the storage's reported maximum capacity.               | optional | `15`
-| `match-type` | The way how the pattern specified by the `disk` parameter must be compared to storages' description
+| `match-type` | The way how the pattern specified by the `disk` parameter must be compared to storages description
                  Must be one of the following symbolic operators: +
                  `endswith`   : The `disk` parameter's value is evaluated as a string that storages' description
                                 must end with; +
-                 `exact`      : The disk` parameter's value is evaluated as a string that storages" description
+                 `exact`      : The `disk` parameter's value is evaluated as a string that storages" description
                                 must exactly match; +
                  `regex`      : The `disk` parameter's value is evaluated as a regular expression that storages'
                                 description must match; +
                  `startswith` : The `disk` parameter's value is evaluated as a string that storages' description
                                 must start with. +
                  Note: Comparisons are case-sensitive                                                               | optional | `exact`
-| `port`       | Destination port where the SNMP requests shall be sent.                                            | optional | `from snmp-config.xml'
+| `port`       | Destination port where the SNMP requests shall be sent.                                            | optional | `from snmp-config.xml`
 | `retries`    | Deprecated.
                  Same as `retry`.
                  Parameter `retry` takes precedence when both are set.                                              | optional | `from snmp-config.xml`

--- a/opennms-doc/guide-admin/src/asciidoc/text/poller/HostResourceSwRunMonitor.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/poller/HostResourceSwRunMonitor.adoc
@@ -52,7 +52,7 @@ Out-of-box support for _HOST-RESOURCES-MIB_ among commercial _Unix_ operating sy
 ===== Examples
 
 The following example shows how to monitor the process called _httpd_ running on a server using this monitor.
-The configuration in 'poller-configuration.xml' has to be defined as the following:
+The configuration in `poller-configuration.xml` has to be defined as the following:
 [source, xml]
 ----
 <service name="Process-httpd" interval="300000" user-defined="false" status="on">

--- a/opennms-doc/guide-admin/src/asciidoc/text/poller/JCifsMonitor.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/poller/JCifsMonitor.adoc
@@ -73,7 +73,7 @@ TIP: Please consider, if you are accessing shares with Mac OSX you have some sid
 
 This example shows how to configure the _JCifsMonitor_ to test if a file share is available over a network.
 For this example we have access to a share for error logs and we want to get an outage if we have any error log files in our folder.
-The share is named 'log'.
+The share is named _log_.
 The service should go back to normal if the error log file is deleted and the folder is empty.
 
 .JCifsMonitor configuration to test that a shared folder is empty

--- a/opennms-doc/guide-admin/src/asciidoc/text/poller/JDBCMonitor.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/poller/JDBCMonitor.adoc
@@ -26,8 +26,7 @@ It is based on the http://www.oracle.com/technetwork/java/javase/jdbc/index.html
 | `retries`  | How many retries should be performed before failing the test       | optional | `0`
 |===
 
-NOTE: The +OPENNMS_JDBC_HOSTNAME+ is replaced in the +url+ parameter the IP or resolved hostname of the interface the monitored service is assigned to.
-
+NOTE: The _OPENNMS_JDBC_HOSTNAME_ is replaced in the _url_ parameter with the IP or resolved hostname of the interface the monitored service is assigned to.
 
 ===== Provide the database driver
 

--- a/opennms-doc/guide-admin/src/asciidoc/text/poller/JDBCQueryMonitor.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/poller/JDBCQueryMonitor.adoc
@@ -50,11 +50,11 @@ NOTE: The +OPENNMS_JDBC_HOSTNAME+ is replaced in the +url+ parameter with the IP
 |===
 | Parameter | XML entity to use in XML configs
 | `=`       | `=`
-| `<`       | `&lt;`
-| `>`       | `&gt;`
+| `<`       | `&amp;lt;`
+| `>`       | `&amp;gt;`
 | `!=`      | `!=`
-| `<=`      | `&lt;=`
-| `>=`      | `&gt;=`
+| `<=`      | `&amp;lt;=`
+| `>=`      | `&amp;gt;=`
 |===
 
 ===== Evaluating the action - operator - operand

--- a/opennms-doc/guide-admin/src/asciidoc/text/poller/JDBCStoredProcedureMonitor.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/poller/JDBCStoredProcedureMonitor.adoc
@@ -30,7 +30,7 @@ It is based on the http://www.oracle.com/technetwork/java/javase/jdbc/index.html
 | `schema`           | Name of the database schema in which the stored procedure is       | optional | `test`
 |===
 
-NOTE: The +OPENNMS_JDBC_HOSTNAME+ is replaced in the +url+ parameter the IP or resolved hostname of the interface the monitored service is assigned to.
+NOTE: The _OPENNMS_JDBC_HOSTNAME_ is replaced in the _url_ parameter with the IP or resolved hostname of the interface the monitored service is assigned to.
 
 
 ===== Provide the database driver
@@ -48,7 +48,7 @@ This may be tricky or impossible when using the _Java Webstart Remote Poller_, b
 The following example checks a stored procedure added to the _PostgreSQL_ database used by OpenNMS.
 The stored procedure returns true as long as less than 250000 events are in the events table of OpenNMS.
 
-Stored procedure
+.Stored procedure which is used in the monitor
 [source, sql]
 ----
 CREATE OR REPLACE FUNCTION eventlimit_sp() RETURNS boolean AS

--- a/opennms-doc/guide-admin/src/asciidoc/text/poller/MemcachedMonitor.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/poller/MemcachedMonitor.adoc
@@ -51,7 +51,7 @@ The following metrics are collected:
 
 ===== Examples
 
-The following example shows a configuration in the 'poller-configuration.xml'.
+The following example shows a configuration in the `poller-configuration.xml`.
 
 [source, xml]
 ----

--- a/opennms-doc/guide-admin/src/asciidoc/text/poller/NetScalerGroupHealthMonitor.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/poller/NetScalerGroupHealthMonitor.adoc
@@ -38,7 +38,7 @@ CAUTION: This monitor is not checking the loadbalanced service it self.
 The following example checks a server group called _central_webfront_http_.
 If at least 70% of the servers are active, the service is up.
 If less then 70% of the servers are active the service is down.
-A configuration like the following can be used for the example in the 'poller-configuration.xml'.
+A configuration like the following can be used for the example in the `poller-configuration.xml`.
 
 [source, xml]
 ----

--- a/opennms-doc/guide-admin/src/asciidoc/text/poller/OmsaStorageMonitor.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/poller/OmsaStorageMonitor.adoc
@@ -67,16 +67,16 @@ Monitor specific parameters for the OmsaStorageMonitor
 | Parameter           | Description                                                                                     | Required | Default value
 | `virtualDiskNumber` | The disk index of your RAID array                                                               | optional | `1`
 | `retry`             | Amount of attempts opening a connection and try to get the greeting banner before the service
-                        goes down.                                                                                      | optional | `from snmp-config.xml`
+                        goes down.                                                                                      | optional | from `snmp-config.xml`
 | `timeout`           | Time in milliseconds to wait before receiving the
-                        SNMP response.                                                                                  | optional | `from snmp-config.xml`
-| `port`              | The TCP port OpenManage is listening                                                            | optional | `from snmp-config.xml`
+                        SNMP response.                                                                                  | optional | from `snmp-config.xml`
+| `port`              | The TCP port OpenManage is listening                                                            | optional | from `snmp-config.xml`
 |===
 
 
 ===== Examples
 
-Some example configuration how to configure the monitor in the 'poller-configuration.xml'.
+Some example configuration how to configure the monitor in the `poller-configuration.xml`.
 
 The RAID array monitor for your first array is configured with `virtualDiskNumber = 1` and can look like this:
 [source, xml]

--- a/opennms-doc/guide-admin/src/asciidoc/text/poller/OpenManageChassisMonitor.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/poller/OpenManageChassisMonitor.adoc
@@ -21,9 +21,9 @@ As this monitor uses SNMP, the queried nodes must have proper SNMP configuration
 [options="header, autowidth"]
 |===
 | Parameter | Description                                                        | Required | Default value
-| `port`    | The port to which connection shall be tried.                       | optional | `from snmp-config.xml`
-| `retry`   | Number of polls to attempt.                                        | optional | `from snmp-config.xml`
-| `timeout` | Time (in milliseconds) to wait before receiving the SNMP response. | optional | `from snmp-config.xml`
+| `port`    | The port to which connection shall be tried.                       | optional | from `snmp-config.xml`
+| `retry`   | Number of polls to attempt.                                        | optional | from `snmp-config.xml`
+| `timeout` | Time (in milliseconds) to wait before receiving the SNMP response. | optional | from `snmp-config.xml`
 |===
 
 ===== Examples

--- a/opennms-doc/guide-admin/src/asciidoc/text/poller/PrTableMonitor.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/poller/PrTableMonitor.adoc
@@ -34,12 +34,12 @@ ____
 [options="header, autowidth"]
 |===
 | Parameter | Description                                                        | Required | Default value
-| `port`    | The port to which connection shall be tried.                       | optional | from 'snmp-config.xml'
-| `retry`   | Number of polls to attempt.                                        | optional | from 'snmp-config.xml'
+| `port`    | The port to which connection shall be tried.                       | optional | from `snmp-config.xml`
+| `retry`   | Number of polls to attempt.                                        | optional | from `snmp-config.xml`
 | `retries` | *Deprecated*.
               Same as `retry`.
-              Parameter `retry` takes precedence if both are set.                | optional | from 'snmp-config.xml'
-| `timeout` | Time in milliseconds to wait before receiving the SNMP response.   | optional | from 'snmp-config.xml'
+              Parameter `retry` takes precedence if both are set.                | optional | from `snmp-config.xml`
+| `timeout` | Time in milliseconds to wait before receiving the SNMP response.   | optional | from `snmp-config.xml`
 |===
 
 ===== Examples

--- a/opennms-doc/guide-admin/src/asciidoc/text/poller/SmbMonitor.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/poller/SmbMonitor.adoc
@@ -34,7 +34,7 @@ WARNING: Microsoft deprecated the usage of _NetBIOS_.
 
 ===== Examples
 
-Some example configuration how to configure the monitor in the 'poller-configuration.xml'.
+Some example configuration how to configure the monitor in the `poller-configuration.xml`.
 
 [source, xml]
 ----

--- a/opennms-doc/guide-admin/src/asciidoc/text/poller/SnmpMonitor.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/poller/SnmpMonitor.adoc
@@ -67,10 +67,10 @@ It is currently not possible for the Remote Poller to have access to the SNMP co
                             and the monitored value is non-null.                                                       | optional | `-`
 | `operator`        | The operator to be used for comparing the monitored object against the `operand` parameter.
                       Must be one of the following symbolic operators: +
-                      `&lt;` (<): Less than. Both operand and observed object value must be numeric. +
-                      `&gt;` (>): Greater than. Both operand and observed object value must be numeric. +
-                      `&lt;=` (<=): Less than or equal to. Both operand and observed object value must be numeric. +
-                      `&gt;=` (>=): Greater than or equal to. Both operand and observed object value must be numeric. +
+                      `&amp;lt;` (<): Less than. Both operand and observed object value must be numeric. +
+                      `&amp;gt;` (>): Greater than. Both operand and observed object value must be numeric. +
+                      `&amp;lt;=` (<=): Less than or equal to. Both operand and observed object value must be numeric. +
+                      `&amp;gt;=` (>=): Greater than or equal to. Both operand and observed object value must be numeric. +
                       `=`: Equal to. Applied in numeric context if both operand and observed object value are numeric,
                            otherwise in string context as a case-sensitive exact match. +
                       `!=`: Not equal to. Applied in numeric context if both operand and observed object value are
@@ -78,16 +78,16 @@ It is currently not possible for the Remote Poller to have access to the SNMP co
                       `~`:  Regular expression match. Always applied in string context. +
                       Note: Comparison will always succeed if either the `operand` or `operator` parameter isn't set
                             and the monitored value is non-null.
-                      Keep in mind that you need to escape all < and > characters as XML entities (`&lt;` and `&gt;`
+                      Keep in mind that you need to escape all < and > characters as XML entities (`&amp;lt;` and `&amp;gt;`
                       respectively)                                                                                    | optional | `-`
-| `port`            | Destination port where the SNMP requests shall be sent.                                          | optional | from 'snmp-config.xml'
+| `port`            | Destination port where the SNMP requests shall be sent.                                          | optional | from `snmp-config.xml`
 | `reason-template` | A user-provided template used for the monitor's reason code if the service is unvailable.
                       Defaults to a reasonable value if unset.
                       See below for an explanation of the possible template parameters.                                | optional | depends on operation mode
 
-| `retry`           | Number of polls to attempt.                                                                      | optional | from 'snmp-config.xml'
-| `retries`         | *Deprecated* Same as `retry`. Parameter `retry` takes precedence if both are set.              | optional | from 'snmp-config.xml'
-| `timeout`         | Timeout in milliseconds for retrieving the object's value.                                       | optional | from 'snmp-config.xml'
+| `retry`           | Number of polls to attempt.                                                                      | optional | from `snmp-config.xml`
+| `retries`         | *Deprecated* Same as `retry`. Parameter `retry` takes precedence if both are set.                | optional | from `snmp-config.xml`
+| `timeout`         | Timeout in milliseconds for retrieving the object's value.                                       | optional | from `snmp-config.xml`
 | `walk`            | `false`: Sets the monitor to poll for a scalar object unless if the `match-all` parameter is set
                       to `count`, in which case the `match-all` parameter takes precedence. +
                       `true`: Sets the monitor to poll for a tabular object where the `match-all` parameter defines how

--- a/opennms-doc/guide-admin/src/asciidoc/text/poller/StrafePingMonitor.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/poller/StrafePingMonitor.adoc
@@ -24,14 +24,14 @@ image::poller/01_strafeping.png[]
 Monitor specific parameters for the StrafePingMonitor
 [options="header, autowidth"]
 |===
-| Parameter           | Description                                                                              | Required | Default value
-| `timeout`           | Time in milliseconds to wait before assuming that a packet has not responded             | optional | `800`
-| `retry`             | The number of retries to attempt when a packet fails to respond in the given timeout     | optional | `2`
-| `ping-count`        | The number of pings to attempt each interval                                             | required | `20`
-| `failure-ping-count`| The number of pings that need to fail for the service to be considered down              | required | `20`
-| `wait-interval`     | Time in milliseconds to wait between each _ICMP_ _echo-request_ packet                   | required | `50`
+| Parameter           | Description                                                                                | Required | Default value
+| `timeout`           | Time in milliseconds to wait before assuming that a packet has not responded               | optional | `800`
+| `retry`             | The number of retries to attempt when a packet fails to respond in the given timeout       | optional | `2`
+| `ping-count`        | The number of pings to attempt each interval                                               | required | `20`
+| `failure-ping-count`| The number of pings that need to fail for the service to be considered down                | required | `20`
+| `wait-interval`     | Time in milliseconds to wait between each _ICMP_ _echo-request_ packet                     | required | `50`
 | `rrd-repository`    | The location to write _RRD data_. Generally, you will not want to change this from default | required | `$OPENNMS_HOME/share/rrd/response`
-| `rrd-base-name`     | The name of the RRD file to write (minus the extension, `.rrd` or `.jrb`)                | required | `strafeping`
+| `rrd-base-name`     | The name of the RRD file to write (minus the extension, `.rrd` or `.jrb`)                  | required | `strafeping`
 |===
 
 

--- a/opennms-doc/guide-admin/src/asciidoc/text/poller/SystemExecuteMonitor.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/poller/SystemExecuteMonitor.adoc
@@ -21,13 +21,11 @@ If the banner is not available in the output the status is determined as down.
 .Monitor specific parameters for the SystemExecuteMonitor
 [options="header, autowidth"]
 |===
-| Parameter | Description                                      | Required | Default value
-| `script`  | The system-call to execute.                      | required | `-`
-| `args`    | The arguments to hand over to the system-call. +
-              It supports variable replacement, see below.     | optional | `-`
-| `banner`  | A string that is match against the output of +
-              the system-call. If the output contains the +
-              banner, the service is determined as _UP_.       | optional | `-`
+| Parameter | Description                                                                                               | Required | Default value
+| `script`  | The system-call to execute.                                                                               | required | `-`
+| `args`    | The arguments to hand over to the system-call. It supports variable replacement, see below.               | optional | `-`
+| `banner`  | A string that is match against the output of the system-call. If the output contains the banner, the
+              service is determined as _UP_.                                                                            | optional | `-`
 |===
 
 The parameter `args` supports variable replacement for the following set of variables.

--- a/opennms-doc/guide-admin/src/asciidoc/text/poller/VmwareCimMonitor.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/poller/VmwareCimMonitor.adoc
@@ -9,7 +9,7 @@ IMPORTANT: This monitor is only executed if the host is in power state _on_.
 IMPORTANT: This monitor requires to import hosts with _Provisiond_ and the _VMware_ import.
            OpenNMS requires network access to _VMware vCenter_ and the hosts.
            To get the sensor data the credentials from _vmware-config.xml_ for the responsible _vCenter_ is used.
-           The following asset fields are filled from _Provisiond_ and is provided by _VMware_ import feature: 
+           The following asset fields are filled from _Provisiond_ and is provided by _VMware_ import feature:
            _VMware Management Server_, _VMware Managed Entity Type_ and the _foreignId_ which contains an internal _VMware vCenter Identifier_.
 
 The global health status is evaluated by testing all available host sensors and evaluating the state of each sensor.
@@ -50,11 +50,11 @@ state can be changed see the `ignoreStandBy` configuration parameter.
 | Parameter       | Description                                                    | Required | Default value
 | `retry`         | Number of retries before the service is marked as down.        | optional | `0`
 | `timeout`       | Time in milliseconds to wait collecting the _CIM_ sensor data. | optional | `3000`
-| `ignoreStandBy` | Treat power state _standBy_ as _up_.                           | optional | `false` 
+| `ignoreStandBy` | Treat power state _standBy_ as _up_.                           | optional | `false`
 |===
 
 ===== Examples
-Some example configuration how to configure the monitor in the _poller-configuration.xml_.
+Some example configuration how to configure the monitor in the `poller-configuration.xml`.
 
 [source, xml]
 ----

--- a/opennms-doc/guide-admin/src/asciidoc/text/poller/VmwareMonitor.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/poller/VmwareMonitor.adoc
@@ -27,11 +27,11 @@ CAUTION: The information for the status of a virtual machine is collected from t
 | Parameter       | Description                                                                        | Required | Default value
 | `retry`         | Number of retries before the service is marked as _down_.                          | optional | `0`
 | `timeout`       | Time in milliseconds to wait for the _vCenter_ to get the power state information. | optional | `3000`
-| `ignoreStandBy` | Treat power state _standBy_ as _up_.                                               | optional | `false` 
+| `ignoreStandBy` | Treat power state _standBy_ as _up_.                                               | optional | `false`
 |===
 
 ===== Examples
-Some example configuration how to configure the monitor in the _poller-configuration.xml_.
+Some example configuration how to configure the monitor in the `poller-configuration.xml`.
 
 [source, xml]
 ----

--- a/opennms-doc/guide-admin/src/asciidoc/text/poller/_template-monitors.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/poller/_template-monitors.adoc
@@ -36,7 +36,7 @@ This is optional just if you can use variables in the configuration
 
 ===== Examples
 
-Some example configuration how to configure the monitor in the 'poller-configuration.xml'.
+Some example configuration how to configure the monitor in the `poller-configuration.xml`.
 
 [source, xml]
 ----

--- a/opennms-doc/guide-admin/src/asciidoc/text/provisioning.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/provisioning.adoc
@@ -131,7 +131,7 @@ The policies for an auto-discovered node or nodes from provisioning groups that 
 
 Contained in the libraries of the Provisioning service is the "template" or default foreign source.
 The template stored in the library is used until the OpenNMS admin user alters the default from the _Provisioning Groups_ WebUI.
-Upon edit, this template is exported to the OpenNMS 'etc/' directory with the file name: 'default-foreign-source.xml'.
+Upon edit, this template is exported to the OpenNMS `etc/` directory with the file name: `default-foreign-source.xml.
 
 [source, xml]
 ----
@@ -181,7 +181,7 @@ This, is equivalent of entering a single IP address in the screen with the conve
 See the _Quick Node Add_ feature below for more details about this capability.
 
 This screen sets up SNMP within OpenNMS for agents listening on IP addresses 10.1.1.1 through 10.254.254.254.
-These settings are optimized into the 'snmp-configuration.xml' file.
+These settings are optimized into the `snmp-configuration.xml` file.
 Optimization means that the minimal configuration possible will be written.
 Any IP addresses already configured that are eclipsed by this range will be removed.
 Here is the resulting configuration.
@@ -380,10 +380,10 @@ A quick way to test if zone transfers are working is:
 
 .Configuration
 
-The configuration of the Provisoning system has moved from a properties file ('model-importer.properties') to an XML based configuration container.
+The configuration of the Provisoning system has moved from a properties file (`model-importer.properties`) to an XML based configuration container.
 The configuration is now extensible to allow the definition of 0 or more import requisitions each with their own cron based schedule for automatic importing from various sources (intended for integration with external URL such as http and this new dns protocol handler.
 
-A default configuration is provided in the OpenNMS 'etc/' directory and is called: 'provisiond-configuration.xml'.
+A default configuration is provided in the OpenNMS `etc/` directory and is called: `provisiond-configuration.xml`.
 This default configuration has an example for scheduling an import from a DNS server running on the localhost requesting nodes from the zone, localhost and will be imported once per day at the stroke of midnight.
 Not very practical but is a good example.
 
@@ -474,7 +474,7 @@ Two more node definitions will be added for the benefit of this example.
 image:../images/provisioning/00021.jpeg[]
 
 This set of nodes represents an import requisition for the _Bronze_ provisioning group.
-As this requisition is being edited via the WebUI, changes are being persisted into the OpenNMS configuration directory '$OPENNMS_etc/imports/' pending as an XML file having the name 'bronze.xml'.
+As this requisition is being edited via the WebUI, changes are being persisted into the OpenNMS configuration directory '$OPENNMS_etc/imports/' pending as an XML file having the name `bronze.xml`.
 
 NOTE: The name of the XML file containing the import requisition is the same as the provisioning group name.
 Therefore naming your provisioning group without the use of spaces makes them easier to manage on the file system.
@@ -557,7 +557,7 @@ From the main _Admin/Provisioning Groups_ screen in the Web-UI, click the _Delet
 This button deletes all the nodes defined in the Bronze requisition.
 It is very important to note that once this is done, it cannot be undone!
 Well it can’t be undone from the Web-UI and can only be undone if you’ve been good about keeping a backup copy of your '$OPENMS_ETC/' directory tree.
-If you’ve made a mistake, before you re-import the requisition, restore the 'Bronze.xml' requisition from your backup copy to the '$OPENNMS_ETC/imports' directory.
+If you’ve made a mistake, before you re-import the requisition, restore the `Bronze.xml` requisition from your backup copy to the '$OPENNMS_ETC/imports' directory.
 
 .All node definitions have been removed from the Bronze requisition. The Web-UI indicates an import is now required to remove them from OpenNMS.
 image:../images/provisioning/000019.png[]
@@ -718,10 +718,10 @@ So, in addition to provisioning the basic node, interface, service, and node cat
 
 ====== Provisiond Configuration
 
-The configuration of the Provisioning system has moved from a properties file ('model-importer.properties') to an XML based configuration container.
+The configuration of the Provisioning system has moved from a properties file (`model-importer.properties`) to an XML based configuration container.
 The configuration is now extensible to allow the definition of 0 or more import requisitions each with their own _Cron_ based schedule for automatic importing from various sources (intended for integration with external URL such as HTTP and this new DNS protocol handler.
 
-A default configuration is provided in the OpenNMS 'etc/' directory and is called: 'provisiond-configuration.xml'.
+A default configuration is provided in the OpenNMS `etc/` directory and is called: `provisiond-configuration.xml`.
 This default configuration has an example for scheduling an import from a DNS server running on the localhost requesting nodes from the zone, localhost and will be imported once per day at the stroke of midnight. Not very practical but is a good example.
 
 [source,xml]
@@ -781,7 +781,7 @@ CAUTION: <need further documentation>
 
 The new Provisioning service in OpenNMS is continuously improving and adapting to the needs of the community.
 One of the most recent enhancements to the system is built upon the very flexible and extensible API of referencing an import requisition's location via a URL.
-Most commmonly, these URLs are files on the file system (i.e. 'file:/opt/opennms/etc/' 'imports/<my-provisioning-group.xml>') as requisitions created by the Provisioning Groups UI. However, these same requistions for adding, updating, and deleting nodes (based on the original model importer) can also come from URLs specifying the HTTP protocol: http://myinventory.server.org/nodes.cgi)
+Most commmonly, these URLs are files on the file system (i.e. `file:/opt/opennms/etc/imports/<my-provisioning-group.xml>`) as requisitions created by the Provisioning Groups UI. However, these same requistions for adding, updating, and deleting nodes (based on the original model importer) can also come from URLs specifying the HTTP protocol: http://myinventory.server.org/nodes.cgi)
 
 Now, using Java's extensible protocol handling specification, a new protocol handler was created so that a URL can be specified for requesting a Zone Transfer (_AXFR_) request from a DNS server.
 The _A records_ are recorded and used to build an import requisition.
@@ -830,7 +830,7 @@ Currently, OpenNMS supports the following adapters:
 
 The Opposite end of _Provisiond_ integration from the DNS Requisition Import, is the _DDNS adapter_.
 This adapter uses the _dynamic DNS protocol_ to update a DNS system as nodes are provisioned into OpenNMS.
-To configure this adapter, edit the 'opennms.properties' file and set the `importer.adapter.dns.server property`:
+To configure this adapter, edit the `opennms.properties` file and set the `importer.adapter.dns.server property`:
 
  importer.adapter.dns.server=192.168.1.1
 
@@ -868,7 +868,7 @@ Here is an example:
 
 NOTE: The XML can be imbedded in the `curl` command option `-d` or be referenced from a file if the `@` prefix is used with the file name as in this case.
 
-The XML file: 'customer-a.foreign-source.xml':
+The XML file: `customer-a.foreign-source.xml`:
 
 [source, xml]
 ----
@@ -891,24 +891,33 @@ The XML file: 'customer-a.foreign-source.xml':
 
 Here is an example `curl` command used to create the foreign source with the above foreign source specification above:
 
- curl -v -u admin:admin -X POST -H 'Content-type: application/xml' -d '@customer-a.foreign-source.xml' http://localhost:8980/opennms/rest/foreignSources
+[source, bash]
+----
+curl -v -u admin:admin -X POST -H 'Content-type: application/xml' -d '@customer-a.foreign-source.xml' http://localhost:8980/opennms/rest/foreignSources
+----
 
 Now that you’ve created the foreign source, it needs to be deployed by Provisiond.
 Here an the example using the `curl` command to deploy the foreign source:
 
- curl -v -u admin:admin http://localhost:8980/opennms/rest/foreignSources/pending/customer-a/deploy -X PUT
+[source, bash]
+----
+curl -v -u admin:admin http://localhost:8980/opennms/rest/foreignSources/pending/customer-a/deploy -X PUT
+----
 
 NOTE: The current API doesn’t strictly follow the ReST design guidelines and will be updated in a later release.
 
 ===== Step 2 - Update the SNMP configuration
 
 The implementation only supports a _PUT_ request because it is an implied "Update" of the configuration since it requires an IP address and all IPs have a default configuration.
-This request is is passed to the SNMP configuration factory in OpenNMS for optimization of the configuration store 'snmp-config.xml'.
+This request is is passed to the SNMP configuration factory in OpenNMS for optimization of the configuration store `snmp-config.xml`.
 This example changes the community string for the IP address 10.1.1.1 to `yRuSonoZ`.
 
 NOTE: Community string is the only required element
 
- curl -v -X PUT -H "Content-Type: application/xml" -H "Accept: application/xml" -d <snmp-info><community>yRuSonoZ</community><port>161</port><retries>1</retries><timeout>2000</timeout><version>v2c</version></snmp-info>" -u admin:admin http://localhost:8980/opennms/rest/snmpConfig/10.1.1.1
+[source, bash]
+----
+curl -v -X PUT -H "Content-Type: application/xml" -H "Accept: application/xml" -d <snmp-info><community>yRuSonoZ</community><port>161</port><retries>1</retries><timeout>2000</timeout><version>v2c</version></snmp-info>" -u admin:admin http://localhost:8980/opennms/rest/snmpConfig/10.1.1.1
+----
 
 ===== Step 3 - Create/Update the Requisition
 
@@ -918,9 +927,12 @@ There is a direct relationship between the foreign- source attribute in the requ
 Also, typically, the name of the provisioning group will also be the same.
 In the following example, the ReST API will automatically create a provisioning group based on the value foreign-source attribute specified in the XML requisition.
 
- curl -X POST -H "Content-Type: application/xml" -d "<?xml version="1.0" encoding="UTF-8"?><model-import xmlns="http://xmlns.opennms.org/xsd/config/model-import" date-stamp="2009-03-07T17:56:53.123-05:00" last-import="2009-03-07T17:56:53.117-05:00" foreign-source="customer-a"><node node-label="p-brane" foreign-id="1" ><interface ip-addr="10.0.1.3" descr="en1" status="1" snmp-primary="P"><monitored-service service-name="ICMP"/><monitored-service service-name="SNMP"/></interface><category name="Production"/><category name="Routers"/></node><node node-label="m-brane" foreign-id="1" ><interface ip-addr="10.0.1.4" descr="en1" status="1" snmp-primary="P"><monitored-service service-name="ICMP"/><monitored-service service-name="SNMP"/></interface><category name="Production"/><category name="Routers"/></node></model-import>" -u admin:admin http://localhost:8980/opennms/rest/requisitions
+[source, bash]
+----
+curl -X POST -H "Content-Type: application/xml" -d "<?xml version="1.0" encoding="UTF-8"?><model-import xmlns="http://xmlns.opennms.org/xsd/config/model-import" date-stamp="2009-03-07T17:56:53.123-05:00" last-import="2009-03-07T17:56:53.117-05:00" foreign-source="customer-a"><node node-label="p-brane" foreign-id="1" ><interface ip-addr="10.0.1.3" descr="en1" status="1" snmp-primary="P"><monitored-service service-name="ICMP"/><monitored-service service-name="SNMP"/></interface><category name="Production"/><category name="Routers"/></node><node node-label="m-brane" foreign-id="1" ><interface ip-addr="10.0.1.4" descr="en1" status="1" snmp-primary="P"><monitored-service service-name="ICMP"/><monitored-service service-name="SNMP"/></interface><category name="Production"/><category name="Routers"/></node></model-import>" -u admin:admin http://localhost:8980/opennms/rest/requisitions
+----
 
-A provisioning group file called 'etc/imports/customer-a.xml' will be found on the OpenNMS system following the successful completion of this `curl` command and will also be visible via the WebUI.
+A provisioning group file called `etc/imports/customer-a.xml` will be found on the OpenNMS system following the successful completion of this `curl` command and will also be visible via the WebUI.
 
 NOTE: _Add_, _Update_, _Delete_ operations are handled via the ReST API in the same manner as described in detailed specification.
 
@@ -967,7 +979,7 @@ This command will create a new requisition (provisioning group) in the '/opt/ope
 It will be an empty requisition (provisioning group).
 Empty meaning there will be the import definition only with no nodes.
 
-IMPORTANT: Notice that the group is in the 'pending' directory.
+IMPORTANT: Notice that the group is in the `pending` directory.
 This allows you to iteratively create the group and then later actually import/provide the nodes in the group into OpenNMS.
 This hands all adds/changes/deletes at once.
 So, you could be making changes all day and then at night either have a schedule in OpenNMS that imports the group automatically or you can send a command through the REST service from WAVE to have the pending group imported/reimported.
@@ -985,7 +997,10 @@ $ cat /opt/opennms/etc/imports/pending/customer1.xml
 
 You can also get a list of all existing provisioning groups (import requisitions) with the `list` option of the `provision.pl` script:
 
- /opt/opennms/bin/provision.pl list
+[source, bash]
+----
+/opt/opennms/bin/provision.pl list
+----
 
 ==== Add a Node to an Existing Provisioning Group
 
@@ -995,7 +1010,10 @@ Note, that you could create the resulting XML in WAVE and send the entire group 
 
 ===== Create the Node Element
 
- /opt/opennms/bin/provision.pl node add customer1 1 node-a
+[source, bash]
+----
+/opt/opennms/bin/provision.pl node add customer1 1 node-a
+----
 
 This command creates a node element in the provisioning group (a.k.a requisition) _customer1_ called _node-a_ using the scripts _node_ option.
 Note it has no interfaces or services, yet.
@@ -1011,9 +1029,12 @@ Note it has no interfaces or services, yet.
 
 ===== Add a Interface Element to that Node
 
- /opt/opennms/bin/provision.pl interface add customer1 1 127.0.0.1
+[source, bash]
+----
+/opt/opennms/bin/provision.pl interface add customer1 1 127.0.0.1
+----
 
-This command adds an interface element to the node element using the _interface_ option to the 'provision.pl' command and it can now be seen in the pending requisition:
+This command adds an interface element to the node element using the _interface_ option to the `provision.pl` command and it can now be seen in the pending requisition:
 
 [source, xml]
 ----
@@ -1028,8 +1049,11 @@ This command adds an interface element to the node element using the _interface_
 
 ===== Add a Couple of Services to that Interface
 
- /opt/opennms/bin/provision.pl service add customer1 1 127.0.0.1 ICMP
- /opt/opennms/bin/provision.pl service add customer1 1 127.0.0.1 SNMP
+[source, bash]
+----
+/opt/opennms/bin/provision.pl service add customer1 1 127.0.0.1 ICMP
+/opt/opennms/bin/provision.pl service add customer1 1 127.0.0.1 SNMP
+----
 
 This adds the 2 services to the specified 127.0.0.1 interface and is now in the pending XML document.
 
@@ -1053,7 +1077,10 @@ This is covered in the docs we provided.
 
 ===== Set the Primary SNMP Interface
 
- /opt/opennms/bin/provision.pl interface set customer1 1 127.0.0.1 snmp-primary P
+[source, bash]
+----
+/opt/opennms/bin/provision.pl interface set customer1 1 127.0.0.1 snmp-primary P
+----
 
 This sets the 127.0.0.1 interface to be the Primary SNMP interface:
 
@@ -1099,7 +1126,10 @@ They will be created on the fly during the import if they do not already exist.
 
 ===== Setting Asset Fields on a Node
 
- /opt/opennms/bin/provision.pl asset add customer1 1 serialnumber 9999
+[source, bash]
+----
+/opt/opennms/bin/provision.pl asset add customer1 1 serialnumber 9999
+----
 
 This will add value of `9999` to the asset field: _serialnumber_:
 
@@ -1121,12 +1151,14 @@ This will add value of `9999` to the asset field: _serialnumber_:
 ----
 
 .Deploy the Import Requisition (Creating the Group)
-
- /opt/opennms/bin/provision.pl requisition import customer1
+[source, bash]
+----
+/opt/opennms/bin/provision.pl requisition import customer1
+----
 
 This will cause OpenNMS Provisiond to import the pending requisition.
-The XML document will moved from the '/opt/' 'opennms/imports/pending' directory to the '/opt/opennms/imports' directory.
-The philosophy is that the XML document in the 'imports/' directory should be reflective of what is actually supposed to be in the DB.
+The XML document will moved from the `/opt/` `opennms/imports/pending` directory to the `/opt/opennms/imports` directory.
+The philosophy is that the XML document in the `imports/` directory should be reflective of what is actually supposed to be in the DB.
 
 CAUTION: The behavior changed. Mixing ReST and UI is dangerous.
 
@@ -1135,12 +1167,18 @@ CAUTION: The behavior changed. Mixing ReST and UI is dangerous.
 Very much the same as the add, accept, a single delete command and a re-import is required.
 What happens is that the audit phase is run by Provisiond (this is detailed in the docs we sent) and it will be determined that a node has been removed from the group (requisition) and the node will be deleted from the DB and all services will stop activities related to it.
 
- /opt/opennms/bin/provision.pl node delete customer1 1 node-a
- /opt/opennms/bin/provision.pl requisition import customer1
+[source, bash]
+----
+/opt/opennms/bin/provision.pl node delete customer1 1 node-a
+/opt/opennms/bin/provision.pl requisition import customer1
+----
 
 This, also, will create a copy of the currently deployed requisition, remove the node-a node element, and place it in the pending directory, so it too must be deployed so that the node is removed from the provisioning group.
 
- /opt/opennms/bin/provision.pl requisition import customer1
+[source, bash]
+----
+/opt/opennms/bin/provision.pl requisition import customer1
+----
 
 This completes the life cycle of managing a node element, iteratively, in a import requisition.
 
@@ -1148,7 +1186,7 @@ This completes the life cycle of managing a node element, iteratively, in a impo
 
 .List the Nodes in a Provisioning Group
 
-The 'provision.pl' script doesn't supply this feature but you can get it via the REST API. Here is an example using `curl`:
+The `provision.pl` script doesn't supply this feature but you can get it via the REST API. Here is an example using `curl`:
 
 [source, bash]
 ----

--- a/opennms-doc/guide-admin/src/asciidoc/text/webui/opsboard/dashlet/alarm-detail.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/webui/opsboard/dashlet/alarm-detail.adoc
@@ -7,12 +7,12 @@ This _Alarm-Details Dashlet_ shows a table with alarms and some detailed informa
 [options="header, autowidth"]
 |===
 | Field             | Description
-| 'Alarm ID'        | OpenNMS ID for the alarm
-| 'Severity'        | Alarm severity (Cleared, Indeterminate, Normal, Warning, Minor, Major, Critical)
-| 'Node label'      | Node label of the node where the alarm occurred
-| 'Alarm count'     | Alarm count based on reduction key for deduplication
-| 'Last Event Time' | Last time the alarm occurred
-| 'Log Message'     | Reason and detailed log message of the alarm
+| _Alarm ID_        | OpenNMS ID for the alarm
+| _Severity_        | Alarm severity (Cleared, Indeterminate, Normal, Warning, Minor, Major, Critical)
+| _Node label_      | Node label of the node where the alarm occurred
+| _Alarm count_     | Alarm count based on reduction key for deduplication
+| _Last Event Time_ | Last time the alarm occurred
+| _Log Message_     | Reason and detailed log message of the alarm
 |===
 
 The _Alarm Details Dashlet_ can be configured with the following parameters.

--- a/opennms-doc/guide-admin/src/asciidoc/text/webui/opsboard/dashlet/alarms.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/webui/opsboard/dashlet/alarms.adoc
@@ -7,9 +7,9 @@ This _Alarms Dashlet_ shows a table with a short alarm description.
 [options="header, autowidth"]
 |===
 | Field        | Description
-| 'Time'       | Absolute time since the alarm appeared
-| 'Node label' | Node label of the node where the alarm occurred
-| 'UEI'        | OpenNMS _Unique Event Identifier_ for this alarm
+| _Time_       | Absolute time since the alarm appeared
+| _Node label_ | Node label of the node where the alarm occurred
+| _UEI_        | OpenNMS _Unique Event Identifier_ for this alarm
 |===
 
 The _Alarms Dashlet_ can be configured with the following parameters.

--- a/opennms-doc/guide-admin/src/asciidoc/text/webui/opsboard/dashlet/criteria-builder.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/webui/opsboard/dashlet/criteria-builder.adoc
@@ -12,24 +12,24 @@ It is possible to combine multiple _Criteria_ to display just a subset of inform
 | Restriction | Property           | Value 1   | Value 2  | Description
 | `Asc`       | -                  | -         | -        | ascending order
 | `Desc`      | -                  | -         | -        | descending order
-| `Between`   | database attribute | 'String'  | 'String' | Subset of data between value 1 and value 2
-| `Contains`  | database attribute | 'String'  | -        | Select all data which contains a given text string in a given database attribute
+| `Between`   | database attribute | _String_  | _String_ | Subset of data between value 1 and value 2
+| `Contains`  | database attribute | _String_  | -        | Select all data which contains a given text string in a given database attribute
 | `Distinct`  | database attribute | -         | -        | Select a single instance
-| `Eq`        | database attribute | 'String'  | -        | Select data where attribute equals (`==`) a given text string
-| `Ge`        | database attribute | 'String'  | -        | Select data where attribute is greater equals than (`>=`) a given text value
-| `Gt`        | database attribute | 'String'  | -        | Select data where attribute is greater than (`>`) a given text value
-| `Ilike`     | database attribute | 'String'  | -        | 'unknown'
-| `In`        | database attribute | 'String'  | -        | 'unknown'
-| `Iplike`    | database attribute | 'String'  | -        | Select data where attribute matches an given IPLIKE expression
+| `Eq`        | database attribute | _String_  | -        | Select data where attribute equals (`==`) a given text string
+| `Ge`        | database attribute | _String_  | -        | Select data where attribute is greater equals than (`>=`) a given text value
+| `Gt`        | database attribute | _String_  | -        | Select data where attribute is greater than (`>`) a given text value
+| `Ilike`     | database attribute | _String_  | -        | _unknown_
+| `In`        | database attribute | _String_  | -        | _unknown_
+| `Iplike`    | database attribute | _String_  | -        | Select data where attribute matches an given IPLIKE expression
 | `IsNull`    | database attribute | -         | -        | Select data where attribute is null
 | `IsNotNull` | database attribute | -         | -        | Select data where attribute is *not* null
 | `IsNotNull` | database attribute | -         | -        | Select data where attribute is *not* null
-| `Le`        | database attribute | 'String'  | -        | Select data where attribute is less equals than (`<=`) a given text value
-| `Lt`        | database attribute | 'String'  | -        | Select data where attribute is less than (`<`) a given text value
-| `Le`        | database attribute | 'String'  | -        | Select data where attribute is less equals than (`<=`) a given text value
-| `Like`      | database attribute | 'String'  | -        | Select data where attribute is like a given text value similar to SQL `like`
-| `Limit`     | -                  | 'Integer' | -        | Limit the result set by a given number
-| `Ne`        | database attribute | 'String'  | -        | Select data where attribute is not equals (`!=`) a given text value
-| `Not`       | database attribute | 'String'  | -        | 'unknown difference between `Ne`'
+| `Le`        | database attribute | _String_  | -        | Select data where attribute is less equals than (`<=`) a given text value
+| `Lt`        | database attribute | _String_  | -        | Select data where attribute is less than (`<`) a given text value
+| `Le`        | database attribute | _String_  | -        | Select data where attribute is less equals than (`<=`) a given text value
+| `Like`      | database attribute | _String_  | -        | Select data where attribute is like a given text value similar to SQL `like`
+| `Limit`     | -                  | _Integer_ | -        | Limit the result set by a given number
+| `Ne`        | database attribute | _String_  | -        | Select data where attribute is not equals (`!=`) a given text value
+| `Not`       | database attribute | _String_  | -        | _unknown_ difference between `Ne`
 | `OrderBy`   | database attribute | -         | -        | Order the result set by a given attribute
 |===

--- a/opennms-doc/guide-admin/src/asciidoc/text/webui/opsboard/introduction.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/webui/opsboard/introduction.adoc
@@ -21,7 +21,7 @@ image::webui/opsboard/02_opsboard-concept.png[]
 === Configuration
 
 To create and configure _Ops Boards_ administration permissions are required.
-The configuration section is in admin area of OpenNMS and named 'Ops Board Config Web Ui'.
+The configuration section is in admin area of OpenNMS and named _Ops Board Config Web Ui_.
 
 .Navigation to the _Ops Board_ configuration
 image::webui/opsboard/03_admin-configure-opsboard.png[]
@@ -36,16 +36,16 @@ image::webui/opsboard/04_add-dashlet.png[]
  3. Add a _Dashlet_ to show OpenNMS monitoring information
  4. Show a preview of the whole _Ops Board_
  5. List of available _Dashlets_
- 6. 'Priority' for this _Dashlet_ in _Ops Board_ rotation, lower priority means it will be displayed more often
- 7. 'Duration' in seconds for this _Dashlet_ in the _Ops Board_ rotation
- 8. Change 'Priority' if the _Dashlet_ is in alert state, this is optional and maybe not available in all _Dashlets_
- 9. Change 'Duration' if the _Dashlet_ is in alert state, it is optional and maybe not available in all _Dashlets_
+ 6. _Priority_ for this _Dashlet_ in _Ops Board_ rotation, lower priority means it will be displayed more often
+ 7. _Duration_ in seconds for this _Dashlet_ in the _Ops Board_ rotation
+ 8. Change _Priority_ if the _Dashlet_ is in alert state, this is optional and maybe not available in all _Dashlets_
+ 9. Change _Duration_ if the _Dashlet_ is in alert state, it is optional and maybe not available in all _Dashlets_
  10. Configuration properties for this _Dashlet_
  11. Remove this _Dashlet_ from the _Ops Board_
  12. Order _Dashlets_ for the rotation on the _Ops Board_ and the tile view in the _Ops Panel_
  13. Show a preview for the whole _Ops Board_
 
-The configured _Ops Board_ can be used by navigating in the main menu to 'Dashboard -> Ops Board'.
+The configured _Ops Board_ can be used by navigating in the main menu to _Dashboard -> Ops Board_.
 
 .Navigation to use the _Ops Board_
 image::webui/opsboard/05_opsboard-user.png[]

--- a/opennms-doc/guide-user/src/asciidoc/text/surveillance-view.adoc
+++ b/opennms-doc/guide-user/src/asciidoc/text/surveillance-view.adoc
@@ -27,7 +27,7 @@ image::surveillance-view/01_surveillance-view.png[]
 This _Surveillance View_ model also builds the foundation of the <<user-guide-dashboard, Dashboard View>>.
 
 
-==== Default Surveillance View Configuration
+=== Default Surveillance View Configuration
 
 _Surveillance Views_ are defined in the `surveillance-views.xml` file.
 This file resides in the _OpenNMS_ `etc` directory.
@@ -107,4 +107,4 @@ The first matching item wins:
 
 . Surveillance View name equal to the user name they used when logging into OpenNMS.
 . Surveillance View name equal to the user's assigned OpenNMS group name
-. Surveillance View name equal to the 'default-view' attribute in the surveillance-views.xml configuration file.
+. Surveillance View name equal to the `default-view` attribute in the `surveillance-views.xml` configuration file.


### PR DESCRIPTION
- Normalized tables
- Fixed file name convention to monospace
- Remove ' and replace with _ to have italic font
- Normalized file names to monospace font
- Normalized tables