### PR TITLE
NMS-7658: Error debian init script

### DIFF
--- a/debian/opennms-server.opennms.init
+++ b/debian/opennms-server.opennms.init
@@ -43,7 +43,7 @@ if [ -z "$JAVA_HOME" ]; then
 			JAVA_HOME="$dir"
 			break
 		fi
-	fi
+    done	
 fi
 
 # Check for JAVA_HOME

--- a/debian/opennms-server.opennms.init
+++ b/debian/opennms-server.opennms.init
@@ -43,7 +43,7 @@ if [ -z "$JAVA_HOME" ]; then
 			JAVA_HOME="$dir"
 			break
 		fi
-    done	
+    done
 fi
 
 # Check for JAVA_HOME


### PR DESCRIPTION
Fixed error in for loop line 46. Close for loop with "done" instead of "fi".