### PR TITLE
NMS-7712: Migrate documentation from opennms.properties

### DIFF
--- a/opennms-base-assembly/src/main/filtered/etc/opennms.properties
+++ b/opennms-base-assembly/src/main/filtered/etc/opennms.properties
@@ -1,346 +1,101 @@
-#
-# This properties file allows you to set global properties for the opennms
-# application.  These properties will be set as system properties at the
-# beginning of Java startup.  Any properties set on the Java command-line
-# with -Dproperty=value will be overridden by these values.
-#
 
-# ###### ICMP ######
-# OpenNMS provides three ICMP implementations. JICMP (legacy, IPv4-only),
-# JNA (supports both IPv4 and IPv6), and JICMP6.
-#
-# The JICMP implementation is what has traditionally been used in OpenNMS
-# since 1.0, uses JNI.  It requires you to install a separate package
-# (JICMP) which contains a shared library for interfacing with your system's
-# ICMP APIs.
-#
-# The JICMP6 core library is a version of the JICMP codebase which can speak
-# ICMPv6, instead of ICMPv4. The OpeNMS JICMP6 pinger supports both ICMPv4
-# and ICMPv6.  It delegates all ICMPv4 ping requests to the original JICMP
-# JniPinger above and uses the JICMP6 library for ICMPv6 packets.  This is
-# the default for OpenNMS 1.9.90 and up.
-#
-# Finally, the JNA implementation is written from the ground up to support
-# IPv4 and IPv6, and takes advantage of the JNA project's ability to access
-# native APIs without needing to distribute separate shared libraries.  It
-# is, however, not as performant as the JICMP6 pinger, so it is not
-# recommended unless you are in an environment which requires it.  This is
-# the default ICMP implementation used in the remote poller, since it does
-# not rely on any external native code to be installed outside of the JVM.
-#
-# To use the JNI ICMPv4 interface only, use the following property setting:
+### Documentation:
+### http://docs.opennms.org/OpenNMS/${project.version}/documentation/guide-admin/index.html#file-opennms-properties
+
+### General
+
+#org.opennms.security.disableLoginSuccessEvent=false
+opennms.bin.dir=${install.bin.dir}
+java.awt.headless=true
+#org.opennms.utils.propertiesCache.enableCheckFileModified=false
+
+### ICMP
+
 #org.opennms.netmgt.icmp.pingerClass=org.opennms.netmgt.icmp.jni.JniPinger
-#
-# To use the JNA ICMPv4/ICMPv6 implementation, use the following property:
 #org.opennms.netmgt.icmp.pingerClass=org.opennms.netmgt.icmp.jna.JnaPinger
-#
-# The default is set to use the JNI ICMPv4/ICMPv6 interface like so:
 #org.opennms.netmgt.icmp.pingerClass=org.opennms.netmgt.icmp.jni6.Jni6Pinger
-
-# By default, OpenNMS will start up if either ICMPv4 *or* ICMPv6 are
-# available and initialize properly.  If you wish to force IPv4 or IPv6
-# explicitly, set one or both of these properties to true.
-#
 #org.opennms.netmgt.icmp.requireV4=detect
 #org.opennms.netmgt.icmp.requireV6=detect
 
-# ###### SNMP ######
-# OpenNMS provides two different SNMP implementations.  JoeSNMP is the
-# original OpenNMS # SNMP Library and provides SNMP v1 and v2 support.
-# SNMP4J is a new 100% Java SNMP library # that provides support for SNMP
-# v1, v2 and v3.
-#
-# To enable the JoeSnmp library uncomment the following line.
+### SNMP
+
 #org.opennms.snmp.strategyClass=org.opennms.netmgt.snmp.joesnmp.JoeSnmpStrategy
-#
-# The SNMP4J library is currently the default.  But can also be set with
-# the following line.
-#
-# Default:
 #org.opennms.snmp.strategyClass=org.opennms.netmgt.snmp.snmp4j.Snmp4JStrategy
-#
-
-# The world is full of buggy SNMP agents.  We can work around many of their
-# quirks by extending various SMI classes from SNMP4J.  The following property
-# must be set in order for any of these workarounds to be enabled.
 org.snmp4j.smisyntaxes=opennms-snmp4j-smisyntaxes.properties
-
-# When debugging SNMP problems when using the SNMP4J library, it may be
-# helpful to receive runtime exceptions from SNMP4J. These exceptions almost
-# always indicate a problem with an SNMP agent. Any that we don't catch will
-# end up in output.log, so they're disabled by default, but they may provide
-# more information (albeit without timestamps) than the messages that SNMP4J
-# logs (see snmp4j.LogFactory)
 org.opennms.snmp.snmp4j.forwardRuntimeExceptions=false
-
-# By default, SNMP4J does not do any logging internally, but it's easy to
-# enable.  See log4j.properties to adjust log levels for these messages.
 snmp4j.LogFactory=org.snmp4j.log.Log4jLogFactory
-
-# Net-SNMP agents prior to release 5.4.1 on 64-bit platforms exhibit a bug
-# that causes the discovery of a node's interfaces to fail. A workaround has
-# been made that helps SNMP4J cope with this bug. If for some reason you need
-# to disable this workaround, comment out the following line.
 org.opennms.snmp.workarounds.allow64BitIpAddress=true
-
-# DrayTek Corporation, Router Model: Vigor2820 Series devices with a
-# sysObjectID of .1.3.6.1.4.1.7367 sometimes present objects from the
-# ipAddrTable with an instance ID of "0". To substitute a valid (though still
-# dodgy) value of "0.0.0.0" when we encounter one of these, set the following
-# property to true.
 org.opennms.snmp.workarounds.allowZeroLengthIpAddress=true
-
-# Some SNMP agents claim to support SNMPv2c, but either completely fail to
-# respond to GET-BULK requests or return bad responses to them under some
-# conditions. To disable the use of GET-BULK PDUs globally in the SNMP4J
-# strategy, set this property to true. This change will adversely affect the
-# efficiency of SNMP data collection from agents that properly support
-# GET-BULK.
 org.opennms.snmp.snmp4j.noGetBulk=false
-
-# Some buggy SNMP agents fail to exclude Counter64 objects from view when
-# responding to SNMPv1 requests (as mandated by RFC3584 § 4.2.2.1). To relax
-# handling of v1 responses to permit Counter64 varbinds rather than discarding
-# them as ill-formed (per the same RFC), set this property to true.
 org.opennms.snmp.snmp4j.allowSNMPv2InV1=false
 
-# ###### DATA COLLECTION ######
-# On very large systems the OpenNMS default mechanism of storing one data
-# source per RRD file can be very I/O Intensive.  Many I/O subsystems fail
-# to keep up with the vast amounts of data that OpenNMS can collect in this
-# situation.  We have found that in those situations having fewer large files
-# with multiple data sources in each performs better than many smaller files,
-# each with a single data source.  This option enables all of the data sources
-# belonging to a single collection group to be stored together in a single
-# file.  To enable this setting uncomment the below line and change it to
-# 'true'.
-#
-# Default: false
-org.opennms.rrd.storeByGroup=false
+### Data Collection
 
-# By default, data collected for a node with nodeId n is stored in the
-# directory ${rrd.base.dir}/snmp/n . If the node is deleted and re-added,
-# it will receive a new nodeId, and subsequent data will be stored in a
-# new directory. This can create problems in data continuity if a large number
-# of nodes get deleted and re-added either accidentally or intentionally.
-# This option enables an alternate storage location for nodes that are
-# provisioned (ie they have a foreignSource and foreignId defined) If
-# storeByForeignSource is set to true, a provisioned node will have its
-# data stored by foreignSource/ForeignId rather than nodeId. For example,
-# a node with foreignSource/foreignId "mysource/12345" will have its data
-# stored in ${rrd.base.dir}/snmp/fs/mysource/12345 . With this
-# option enabled, data collection will continue to use the same storage
-# location as long as the foreignSource/foreignId is not redefined, regardless
-# of how many times the node may be deleted and re-added.
-#
-# Default: false
-org.opennms.rrd.storeByForeignSource=false
-
-# RRD base directory
-rrd.base.dir=${install.share.dir}/rrd
-
-# RRD binary path (only used if the JniRrdStrategy is used)
-rrd.binary=${install.rrdtool.bin}
-
-# Format rule used when setting the datasource value for threshold events
-# (check NMS-3473).
-# In order to properly use scientific notation for the datasource's value,
-# change the format rule to something like this '##.##E0' to avoid NMS-4126.
-#
-# Default: ##.##
-#org.opennms.threshd.value.decimalformat=##.##
-
-# Specifies the amount of time to wait (expressed in milliseconds) until the
-# reload container physically checks if the datacollection-config.xml file
-# has been changed.
-#
-# Default: 30 seconds
 #org.opennms.snmp.dataCollectionConfig.reloadCheckInterval=30000
+org.opennms.rrd.storeByGroup=false
+org.opennms.rrd.storeByForeignSource=false
+rrd.base.dir=${install.share.dir}/rrd
+rrd.binary=${install.rrdtool.bin}
+#org.opennms.netmgt.collectd.SnmpCollector.forceRescan=false
+#org.opennms.netmgt.collectd.SnmpCollector.limitCollectionToInstances=false
+#org.opennms.threshd.value.decimalformat=##.##
+#org.opennms.collectd.instrumentationClass=org.opennms.netmgt.collectd.DefaultCollectdInstrumentation
 
-#
-# Collectd Instrumentation class
-# org.opennms.collectd.instrumentationClass=org.opennms.netmgt.collectd.DefaultCollectdInstrumentation
+### Trouble Ticketing
 
-# Enable an aggresive validation against the last modification time of the strings.properties files.
-# This is useful only if the OpenNMS WebUI is running on a different server.
-# Check NMS-5806 for more details.
-#
-# Default: false
-#org.opennms.utils.propertiesCache.enableCheckFileModified=false
-
-
-###### TROUBLE TICKETING ######
-# The ticketer responsible for creating tickets from the Alarm details and passing these
-# to the ticket plugin.
 opennms.ticketer.servicelayer=org.opennms.netmgt.ticketd.DefaultTicketerServiceLayer
-
-# The ticket plugin implementation to use to create tickets via the Alarm details
-# pages (if configured).  The NullTicketerPlugin just does nothing when attempting
-# to create tickets.
-# NOTE: if you enable a trouble-ticketing plugin here, you must also edit
-# $OPENNMS_HOME/jetty-webapps/opennms/WEB-INF/configuration.properties
 opennms.ticketer.plugin=org.opennms.netmgt.ticketd.NullTicketerPlugin
 
-# Comment out the NullTicketerPlugin line above and uncomment one of the 
-# sections below to enable OtrsTicketerPlugin
-# You will need to adjust alarmTroubleTicketLinkTemplate URL
-
-# OTRS version 3.0.x and earlier
-# Requires the OpenNMS module for OTRS installed in the OTRS server
-
+# Enable OTRS ticketing
 #opennms.ticketer.plugin=org.opennms.netmgt.ticketer.otrs.OtrsTicketerPlugin
-#opennms.alarmTroubleTicketLinkTemplate = <a href="http://localhost/otrs/index.pl?Action=AgentTicketZoom&TicketID=${id}">${id}</a>
-#opennms.alarmTroubleTicketEnabled = true
+#opennms.alarmTroubleTicketEnabled=true
+#opennms.alarmTroubleTicketLinkTemplate=<a href="http://localhost/otrs/index.pl?Action=AgentTicketZoom&TicketNumber=\${id}">\${id}</a>
 
-# OTRS version 3.1.x and later
-
-# Uses the OTRS Generic Ticket Connector and do not require any additional
-# Modules to be installed in OTRS.
-
-#opennms.ticketer.plugin=org.opennms.netmgt.ticketer.otrs31.Otrs31TicketerPlugin
-#opennms.alarmTroubleTicketLinkTemplate = <a href="http://localhost/otrs/index.pl?Action=AgentTicketZoom&TicketNumber=\${id}">\${id}</a>
-#opennms.alarmTroubleTicketEnabled = true
-
-# Comment out the NullTicketerPlugin line above and uncomment the lines below
-# to enable RtTicketerPlugin
-# You will need to adjust alarmTroubleTicketLinkTemplate to suit your RT Base URL
-
+# Enable RT ticketing
 #opennms.ticketer.plugin=org.opennms.netmgt.ticketer.rt.RtTicketerPlugin
-#opennms.alarmTroubleTicketEnabled = true
-#opennms.alarmTroubleTicketLinkTemplate = <a href="http://localhost/Ticket/Display.html?id=\${id}">\${id}</a>
+#opennms.alarmTroubleTicketEnabled=true
+#opennms.alarmTroubleTicketLinkTemplate=<a href="http://localhost/Ticket/Display.html?id=\${id}">\${id}</a>
 
-# Comment out the NullTicketerPlugin line above and uncomment the lines below
-# to enable RemedyTicketerPlugin
-# You will need to adjust alarmTroubleTicketLinkTemplate to suit your Remedy Base URL
-# The following settings are for locale it_IT
-
+# Enable Remedy ticketing
 #opennms.ticketer.plugin=org.opennms.netmgt.ticketer.remedy.RemedyTicketerPlugin
-#opennms.alarmTroubleTicketEnabled = true
-#opennms.alarmTroubleTicketLinkTemplate = <a href="http://172.20.0.76:8180/arsys/servlet/ViewFormServlet?form=HPD:Help%20Desk&server=itts3h&qual='Incident ID*%2B'=%22\${id}%22">\${id}</a>
+#opennms.alarmTroubleTicketEnabled=true
+#opennms.alarmTroubleTicketLinkTemplate=<a href="http://172.20.0.76:8180/arsys/servlet/ViewFormServlet?form=HPD:Help%20Desk&server=itts3h&qual='Incident ID*%2B'=%22\${id}%22">\${id}</a>
 
-###### MISCELLANEOUS ######
+### RTC IPC
 
-distributed.layoutApplicationsVertically=false
-opennms.bin.dir=${install.bin.dir}
-java.awt.headless=true
-
-# findByServiceType query
-# org.opennms.dao.ipinterface.findByServiceType=select distinct ipIf from OnmsIpInterface as ipIf join ipIf.monitoredServices as monSvc where monSvc.serviceType.name = ?
-
-# If you change the above query to load the snmpInterfaces along with the if and node data then set this true
-# org.opennms.netmgt.collectd.DefaultCollectionAgent.loadSnmpDataOnInit=false
-
-###### REPORTING ######
-opennms.report.template.dir=${install.dir}/etc
-opennms.report.dir=${install.share.dir}/reports
-opennms.report.logo=${install.webapps.dir}/images/logo.gif
-ksc.default.graphsPerLine=1
-
-###### EVENTD IPC ######
-# The hostname or IP address of the OpenNMS server where events should be sent.
-# Default: 127.0.0.1
+opennms.rtc-client.http-post.base-url=http://localhost:8980/opennms/rtc/post
+opennms.rtc-client.http-post.username=rtc
+opennms.rtc-client.http-post.password=rtc
 #opennms.rtc.event.proxy.host=127.0.0.1
-
-# The TCP port for the eventd TCP receiver where events should be sent.
-# Default: 5817
 #opennms.rtc.event.proxy.port=5817
-
-# The timeout in milliseconds the proxy will wait to complete a TCP connection.
-# Default: 2000
 #opennms.rtc.event.proxy.timeout=2000
 
-###### RANCID INTEGRATION ######
-# Set to true the followiing property to enable the integration to Rancid in the WEB UI.
-# The default value is false (ie links are not created to rancid jsp pages into opennms gui)
-# opennms.rancidIntegrationEnabled = false
-#
-# set to true the following property to use only RancidAdapter to write Clogin
-# info in Rancid .cloginrc file
-# opennms.rancidIntegrationUseOnlyRancidAdapter = false
+### Map IPC
 
-###### RTC IPC ######
-# The base of a URL that RTC clients use when creating a RTC subscription URL.
-# If you are using Tomcat instead of the built-in Jetty, change this in
-# WEB-INF/configuration.properties instead.
-opennms.rtc-client.http-post.base-url = http://localhost:8980/opennms/rtc/post
+opennms.map-client.http-post.url=http://localhost:8980/opennms/map/post
+opennms.map-client.http-post.username=map
+opennms.map-client.http-post.password=map
 
-# The username the RTC uses when authenticating itself in an HTTP POST.
-opennms.rtc-client.http-post.username = rtc
+### Jetty
 
-# The password the RTC uses when authenticating itself in an HTTP POST.
-opennms.rtc-client.http-post.password = rtc
-
-###### MAP IPC ######
-# The base of a URL that Map System clients use when creating a Map subscription URL.
-# If you are using Tomcat instead of the built-in Jetty, change this in
-# WEB-INF/configuration.properties instead.
-opennms.map-client.http-post.url = http://localhost:8980/opennms/map/post
-
-# The username the Map System uses when authenticating itself in an HTTP POST.
-opennms.map-client.http-post.username = map
-
-# The password the Map System uses when authenticating itself in an HTTP POST.
-opennms.map-client.http-post.password = map
-
-###### JETTY WEB UI ######
-# If you are using Jetty, this is the port to listen on
-org.opennms.netmgt.jetty.port = 8980
-# If you want Jetty with AJP support, this is the port to listen on
-#org.opennms.netmgt.jetty.ajp-port = 8981
-# By default, Jetty will listen on all interfaces. You can set a specific
-# bind address here. If you set this to a value other than 127.0.0.1,
-# you will need to update the rtc-client and map-client URLs above.
-#org.opennms.netmgt.jetty.host = 127.0.0.1
-#
-# This enables NCSA style request logging in ${opennm.home}/logs
-#
-# Uncomment this and change to true to enable this
+org.opennms.netmgt.jetty.port=8980
+#org.opennms.netmgt.jetty.ajp-port=8981
+#org.opennms.netmgt.jetty.host=127.0.0.1
 #org.opennms.netmgt.jetty.enableRequestLogging=false
-
-# This sets the maximum size for a form submission in jetty.
-# The default value is 200000 bytes.  Setting it to -1 disables
-# the form limit
-# In 1.8 or earlier set
 #org.mortbay.jetty.Request.maxFormContentSize=200000
-#
-# in 1.9 or later set
 #org.eclipse.jetty.server.Request.maxFormContentSize=200000
-
-# This sets the request header size for jetty.
-# The default value is 4000 bytes.
 #org.opennms.netmgt.jetty.requestHeaderSize=4000
-
-# This sets the maximum number of items that can be in web forms (like the
-# Provisioning web UI)
 org.eclipse.jetty.server.Request.maxFormKeys=2000
+#opennms.web.base-url=https://%x%c/
 
-###### JETTY HTTPS SUPPORT ######
-# Details: http://www.opennms.org/index.php/Standalone_HTTPS_with_Jetty
-# If you want Jetty to provide an HTTPS listener, this is the port to listen on
-# Note that setting this property does NOT disable the plain HTTP listener,
-# which is required by Rtcd to post realtime status updates.  If you do not
-# wish to allow unsecured HTTP access to the OpenNMS web UI, you must set
-# org.opennms.netmgt.jetty.host above or use firewall rules to accomplish this.
-#org.opennms.netmgt.jetty.https-port = 8443
-# By default, if configured for HTTPS, Jetty will listen on all interfaces.
-# You can set a specific bind address here.
-#org.opennms.netmgt.jetty.https-host = 127.0.0.1
-## To set the keystore file from which Jetty will retrieve its SSL key,
-## change the value of this property.  Note that the jetty.properties
-## distributed with OpenNMS should never be used in production.
-#org.opennms.netmgt.jetty.https-keystore = ${install.dir}/etc/jetty.keystore
-## To change the keystore password used to access the keystore specified
-## in the https-keystore property above, uncomment and change this property
-#org.opennms.netmgt.jetty.https-keystorepassword = changeit
-## To change the key password used to access the Jetty SSL key (which is stored
-## in the keystore specified by the https-keystore property), uncomment and
-## change this property.
-#org.opennms.netmgt.jetty.https-keypassword = changeit
-## To specify a particular SSL certificate alias in the keystore, set this
-## property. Otherwise, the first certificate that is found will be used.
-#org.opennms.netmgt.jetty.https-cert-alias = opennms-jetty-certificate
-## To exclude specific SSL/TLS cipher suites from use, set this property to a
-## colon-separated list of suite names. Whitespace surrounding colons is OK.
+### Jetty HTTPS
+
+#org.opennms.netmgt.jetty.https-port=8443
+#org.opennms.netmgt.jetty.https-host=127.0.0.1
+#org.opennms.netmgt.jetty.https-keystore=${install.dir}/etc/jetty.keystore
+#org.opennms.netmgt.jetty.https-keystorepassword=changeit
+#org.opennms.netmgt.jetty.https-keypassword=changeit
+#org.opennms.netmgt.jetty.https-cert-alias=opennms-jetty-certificate
 #org.opennms.netmgt.jetty.https-exclude-cipher-suites=SSL_DHE_DSS_WITH_DES_CBC_SHA: \
 #  SSL_DHE_RSA_EXPORT_WITH_DES40_CBC_SHA:SSL_DHE_DSS_EXPORT_WITH_DES40_CBC_SHA: \
 #  SSL_DHE_RSA_WITH_DES_CBC_SHA:SSL_RSA_EXPORT_WITH_DES40_CBC_SHA: \
@@ -348,391 +103,87 @@ org.eclipse.jetty.server.Request.maxFormKeys=2000
 #  SSL_RSA_WITH_DES_CBC_SHA:TLS_DHE_RSA_EXPORT_WITH_DES40_CBC_SHA: \
 #  TLS_RSA_EXPORT_WITH_DES40_CBC_SHA:TLS_RSA_WITH_DES_CBC_SHA
 
-# If OpenNMS is setting an incorrect HTML <base> tag, you can override
-# its idea of the local URL here. The URL must end with a '/'. The following
-# substitutions are available:
-# %s: scheme (http, https)
-# %h, %p: host and port from the Host: header
-# %x: host and port from the X-Forwarded-Host, X-Host or Host header
-# %c: context path (without trailing slash)
-#
-# You can use this to get Jetty working behind an Apache/SSL proxy.
-# Set the base-url to https://%x%c/ and include in your Apache SSL vhost:
-#     <Location /opennms>
-#         ProxyPass http://127.0.0.1:8980/opennms
-#         ProxyPassReverse http://127.0.0.1:8980/opennms
-#     </Location>
-#
-#opennms.web.base-url = https://%x%c/
+### Provisiond
 
-###### ASTERISK AGI SUPPORT ######
-# If you are using the built-in Asterisk Gateway Interface (AGI) server
-# to integrate with an external Asterisk server, you will need to set
-# this property to an IP address on the OpenNMS server that is reachable
-# from the Asterisk server.  Note that the value of this property has no
-# bearing on the address to which the AGI server listens -- it is used only
-# as a hint to allow the Asterisk server to reach us.
-#org.opennms.netmgt.asterisk.agi.listenAddress = 127.0.0.1
-
-# To tell the built-in AGI server to listen on a port other than the default
-# of 4573, change the value of this property.  Be sure to update any static
-# fastagi:// URLs in your Asterisk dialplan accordingly.
-#org.opennms.netmgt.asterisk.agi.listenPort = 4573
-
-# The built-in AGI server services requests out of a thread pool whose default
-# size is 10 threads.  Systems that make heavy use of this facility may need
-# to increase this value.
-#org.opennms.netmgt.asterisk.agi.maxPoolSize = 10
-
-###### HTML STRIPPING IN ASSET FIELDS ######
-# By default, all scripts and HTML markup are stripped from the values submitted for node
-# asset information. This measure is to protect against cross-site scripting and other types
-# of attacks on the web UI. To allow markup (but still not scripts) in certain asset fields,
-# set this property's value to a comma-separated list of asset field names. A full list of field
-# names can be obtained by exporting all asset data to a CSV file from the web UI.
-#
-# This example would allow HTML markup in the Comments and Description fields.
-#opennms.assets.allowHtmlFields = comments, description
-
-#Control sending force rescans from the SNMP Collector.  The default is now
-#false and used to be true.
-#org.opennms.netmgt.collectd.SnmpCollector.forceRescan = false
-
-
-#
-# For systems with very large numbers of interfaces we may be unable to collect all the
-# data by scanning the entire table in the specified time interval.  If only a few instances
-# are being collected then we can limit the collection to only those instances and save collection
-# time but possible 'getting' confused by instance changes
-# Set this to true to enable instance limiting
-#org.opennms.netmgt.collectd.SnmpCollector.limitCollectionToInstances=false
-
-#
-# This property is for enabling acl support in the webapp.  With ACLs enabled then Nodes, Alarms, Events etc
-# are filtered according to the authorzied groups list on onms categories.  In other words.  For a user to
-# set the events, outages etc for a particular node then that user has to be authorized for a category that the node
-# belongs to
-#org.opennms.web.aclsEnabled=false
-
-# IP address of the DNS server that the DnsProvisioningAdapter
-# should send dynamic DNS updates to
 importer.adapter.dns.server=127.0.0.1
-
-
-
-###### ASYNC DETECTOR SETUP ######
-# This property defines how many current async detetion attempts can be created at any given time.
-#
-# Setting this to zero removes any limits on the number of concurrent connection attempts.
 #org.opennms.netmgt.provision.maxConcurrentConnections=0
-
-##### SMS GATEWAY SETUP ######
-# This property tells the RXTX JNI library extend its range and load any of these ports in its default setup if they exist
-# by default RXTX doesn't load any non ttyS ports.
-gnu.io.SerialPorts=/dev/ttyACM0:/dev/ttyACM1:/dev/ttyACM2:/dev/ttyACM3:/dev/ttyACM4:/dev/ttyACM5
-
-# This property is to make sure that the phone will poll under Linux. If you are Linux and this is commented out
-# you will get a phone timed out exception
-smslib.serial.polling=true
-
-###### PROVISIOND OPTIONS ######
-#
-# This property is used to enable/disable the handling of new suspect events
-# in provisiond along with periodic scanning of discovered nodes.  The default
-# setting is true (See org.opennms.netmgt.provision.service.ProvisionService)
 #org.opennms.provisiond.enableDiscovery=true
-
-# Prior to 1.10 it was possible to delete entities that have been provisioned as
-# part of a provisioning group.  In 1.10 we have disabled this so that in order to
-# delete these entities you have to go back to the provisioning group and delete them
-# from there.  To reenable this deletion you can set this to true.
-# NOTE: if you do this then the object will be recreated when the provisioning group is
-# next imported/synchronized
 #org.opennms.provisiond.enableDeletionOfRequisitionedEntities=false
-
-# This property is used to control the rescan scheduling existing nodes in
-# the database when Provisiond starts. The default value is true.
-# There are situations like distributed environments, where OpenNMS is deployed across
-# multiple servers, on which this feature must be disabled to avoid continuity issues.
-# In this scenario, most likely the inventory of nodes should not be managed by all OpenNMS instances.
 #org.opennms.provisiond.scheduleRescanForExistingNodes=true
-
-# Use this property to disable rescans of existing nodes following
-# an import (synchronize) of a provisioning group (requistion).  Default
-# behavior has always been true.
 #org.opennms.provisiond.scheduleRescanForUpdatedNodes=true
-
-# Use this property to change the strategy used for managing deployed/pending requisitions.
-# Tested strategies:
-# - file (default)
-# Experimental strategies:
-# - fastFile (recommended for fastest response, at expenses of memory resources)
-# - fused
-# - fastFused
-# - queueing
-# - fastQueueing
-# - caching
-# - fastCaching
 #org.opennms.provisiond.repositoryImplementation=file
 
-###### MAPPING AND GEOCODING ######
+### Web UI
 
-# the map implementation to use
-# current choices are: GoogleMaps, Mapquest, OpenLayers
-gwt.maptype=OpenLayers
-
-# The API key to use for the remote monitor map
-gwt.apikey=
-
-# The class options to use for geocoding.  Choices are:
-
-# (Google maps API)
-#gwt.geocoder.class=org.opennms.features.poller.remote.gwt.server.geocoding.GoogleMapsGeocoder
-
-# (Mapquest API)
-#gwt.geocoder.class=org.opennms.features.poller.remote.gwt.server.geocoding.MapquestGeocoder
-
-# (OpenStreetMaps API)
-#gwt.geocoder.class=org.opennms.features.poller.remote.gwt.server.geocoding.NominatimGeocoder
-
-# (always return OpenNMS World HQ)
-gwt.geocoder.class=org.opennms.features.poller.remote.gwt.server.geocoding.NullGeocoder
-
-# The rate at which to make requests, for geocoders that support it.
-gwt.geocoder.rate=10
-
-# The referer to use when making geocoding requests, for geocoders that support it.
-# For MapQuest, the value you set here will need to be allowed in your AppKeys manager:
-#   http://developer.mapquest.com/web/info/account/app-keys
-gwt.geocoder.referer=http://localhost/
-
-# The minimum quality level to require before rejecting a geocoding request.
-# This is currently only used by MapQuest. Choices are (least to most specific):
-# COUNTRY, STATE, ZIP, COUNTY, ZIP_EXTENDED, CITY, STREET, INTERSECTION, ADDRESS, POINT
-gwt.geocoder.minimumQuality=ZIP
-
-# The email address to report as when making geocoding requests.
-# This is currently only used by Nominatim, and MUST be set!
-gwt.geocoder.email=
-
-# The tile server URL to use for OpenLayers.  This can be any mapnik-style tile server URL.
-# (Sorry, no support for multiple URLs yet.)
-
-# OpenStreetMap tile server
-# gwt.openlayers.url=http://a.tile.openstreetmap.org/${z}/${x}/${y}.png
-
-# Open MapQuest tile server
-gwt.openlayers.url=http://otile1.mqcdn.com/tiles/1.0.0/osm/${z}/${x}/${y}.png
-
-###### UI DISPLAY OPTIONS ######
-
-# This value allows you to show or hide the Acknowledge event button. This is only
-# here for those who still acknowledge events. We are moving away from this and
-# towards acknowledging alarms instead of events. Default is false
+#opennms.assets.allowHtmlFields=comments, description
+#org.opennms.web.aclsEnabled=false
 opennms.eventlist.acknowledge=false
-
-# This value allows you to configure whether or not the total event count is shown
-# in the event list in the web UI.  Setting this to 'true' can cause severe performance
-# issues for larger installations.
 opennms.eventlist.showCount=false
-
-# This value allows you to set the number of nodes with outages to display on the front
-# page in the OpenNMS web UI. Default 12
 #opennms.nodesWithOutages.count=12
-
-# This value allows you to enable/disable the nodes with outages box on the front
-# page in the OpenNMS web UI. Default: true
 #opennms.nodesWithOutages.show=true
-
-# This value allows you to set the number of nodes with problems to display on the front
-# page in the OpenNMS web UI. Default: 16
 #opennms.nodesWithProblems.count=16
-
-# This value allows you to enable/disable the nodes with problems box on the front
-# page in the OpenNMS web UI. Default: true
-#
 #opennms.nodesWithProblems.show=true
-
-# This value allows you to enable/disable the status bar resume at the top of the node
-# page in the OpenNMS web UI. Default: false
-#
 #opennms.nodeStatusBar.show=false
-
-# This value disables the sending of successful login events.  The default is to send the
-# event.  Change this value to true to disable the publishing of this event.
-#org.opennms.security.disableLoginSuccessEvent=false
-
-
-###### REMOTE POLLER ######
-
-#### SERVER SETTINGS ####
-
-# This setting is the minimum amount of time between reloads of a remote poller configuration
-# in milliseconds because of global changes.  This value should never be set
-# less the 300000 (5 minutes) except to set it to zero which means never only reload the
-# configuration if the location monitors status has been set to CONFIG_CHANGED.
-#opennms.pollerBackend.minimumConfigurationReloadInterval=300000
-#
-# This is the amount of time in milliseconds after which a remote poller is considered
-# disconnected if it has not communicated with this OpenNMS system.
-#opennms.pollerBackend.disconnectedTimeout=600000
-#
-# Specify the RMI ports when using the legacy RMI IPC interface
-#opennms.poller.server.serverPort=1199
-#opennms.poller.server.registryPort=1099
-
-#### REMOTE SETTINGS ####
-
-# All settings on the remote pollers are controlled via command-line options. Look at these
-# wiki pages for more details.
-#
-# http://www.opennms.org/wiki/Remote_Polling
-# http://www.opennms.org/wiki/Remote_Poller_Design_Overview
-
-
-###### JasperReports Properties ######
-# Defines the Version of the Jasperreports library
-org.opennms.jasperReportsVersion=${jasperreportsVersion}
-
-# Define if duplicates are ignored when using pie charts within a JasperReport template (*.jrxml) file.
-# See http://jasperreports.sourceforge.net/config.reference.html for more details.
-net.sf.jasperreports.chart.pie.ignore.duplicated.key=true
-
-###### Web Console - Front Page ######
-# This value controls the content that will be displayed in the middle box of the front page.
-# The default is the view of SLM/RTC categories: /includes/categories-box.jsp.
-# You can also use a comma-seperated list of files to include more than one content file.
-# Uncomment the following line to display the widget for the surveillance view from the dashboard.
-# (It uses the same rules for the dashboard)
 #org.opennms.web.console.centerUrl=/surveillance-box.jsp
 
-
-###### REMOTE POLLER MONITOR CLASS EXCLUSIONS ######
-# This setting enables OpenNMS to exclude all references to certain services from the
-# poller configuration that it sends to the remote location monitors. This is necessary
-# when monitor classes are in use that are not included in the remote poller builds.
-# Without this setting, the remote poller will crash on startup (see issue NMS-5777)
-# even if none of the problematic services appears in any package. If you create custom
-# services, you may need to add them to this list.
-excludeServiceMonitorsFromRemotePoller=DHCP,NSClient,RadiusAuth,XMP
-
-###### DASHBOARD/SURVEILLANCE VIEW IMPLEMENTATION ######
-# OpenNMS provides two different dashboard/surveillance view implementations. The GWT
-# variant is the original. Later, the UI was rewitten using the VAADIN framework. So, the
-# two valid options fpr this option are 'vaadin' or 'gwt'. The VAADIN implementation is
-# the default one. Please note that the GWT version is deprecated and will be removed in
-# future versions.
+### Dashboard and Surveillance View
 #org.opennms.dashboard.implementation=gwt
-
-###### DASHBOARD LANDING PAGE ######
-# This setting controls whether users will be redirected to the dashboard page after
-# a successful login. The two valid options for this are 'true' or 'false' which is
-# the default value.
 #org.opennms.dashboard.redirect=false
 
-###### Time Series Strategy ####
-# Use this property to set the strategy used to persist and retrieve time series metrics:
-# Supported values are:
-#   rrd (default)
-#   newts
-#org.opennms.timeseries.strategy=rrd
+### Graphing
 
-###### Graphing #####
-# Use this property to set the graph rendering engine type.  If set to 'auto', attempt
-# to choose the appropriate backend depending on org.opennms.timeseries.strategy above.
-# Supported values are:
-#   auto (default)
-#   png
-#   placeholder
-#   backshift
-#org.opennms.web.graphs.engine=auto
+#org.opennms.web.graphs.engine=png
 
-###### Newts #####
-# Use these properties to configure persistence using Newts
-# Note that Newts must be enabled using the 'org.opennms.timeseries.strategy' property
-# for these to take effect.
-#
-#org.opennms.newts.config.hostname=localhost
-#org.opennms.newts.config.keyspace=newts
-#org.opennms.newts.config.port=9042
-#org.opennms.newts.config.username=cassandra
-#org.opennms.newts.config.password=cassandra
-#org.opennms.newts.config.read_consistency=ONE
-#org.opennms.newts.config.write_consistency=ANY
-# Depends the Cassandra cluster's batch_size_fail_threshold_in_kb property
-#org.opennms.newts.config.max_batch_size=16
-#org.opennms.newts.config.ring_buffer_size=8192
-# One year in seconds
-#org.opennms.newts.config.ttl=31540000
-# Seven days in seconds
-#org.opennms.newts.config.resource_shard=604800
-# Local In-Memory cache (default)
-#org.opennms.newts.config.cache.strategy=org.opennms.netmgt.newts.support.GuavaSearchableResourceMetadataCache
-#org.opennms.newts.config.cache.max_entries=8192
-# External Redis cache
-#org.opennms.newts.config.cache.strategy=org.opennms.netmgt.newts.support.RedisResourceMetadataCache
-#org.opennms.newts.config.cache.redis_hostname=localhost
-#org.opennms.newts.config.cache.redis_port=6379
+### Mapping and Geocoding
 
-###### HEATMAP ######
-# The following options are used to configure the default behaviour of the
-# heatmap visualization of outages and alarms.
-#
-# There exist two modes for operating the heatmap. Valid options
-# are 'alarms' and 'outages'. The default is 'alarms'.
-#org.opennms.heatmap.defaultMode=alarms
-#
-# The heatmap will work with categories or foreign sources. The
-# default heatmap can be set here by choosing 'categories',
-# 'foreignSources' or 'monitoredServices'. The default is 'categories'.
-#org.opennms.heatmap.defaultHeatmap=categories
-#
-# The following option is used to filter for categories to be displayed in
-# the heatmap. This option uses the Java regular expression syntax. The default
-# is '.*' so all categories will be displayed.
-#org.opennms.heatmap.categoryFilter=.*
-#
-# The following option is used to filter for foreign sources to be displayed in
-# the heatmap. This option uses the Java regular expression syntax. The default
-# is '.*' so all foreign sources will be displayed.
-#org.opennms.heatmap.foreignSourceFilter=.*
-#
-# The following option is used to filter for services to be displayed in
-# the heatmap. This option uses the Java regular expression syntax. The default
-# is '.*' so all services will be displayed.
-#org.opennms.heatmap.serviceFilter=.*
-#
-# You can use negative lookahead expressions for excluding categories you wish
-# not to be displayed in the heatmap, e.g. by using an expression like '^(?!XY).*'
-# you can filter out entities with names starting with 'XY'.
-#
-# The next option configures whether only unacknowledged alarms will be taken into
-# account when generating the alarm-based heatmap.
-#org.opennms.heatmap.onlyUnacknowledged=false
+gwt.maptype=OpenLayers
+gwt.apikey=
 
-# ###### GRAFANA BOX ######
-# This setting controls whether a grafana box showing the available dashboards is
-# placed on the landing page. The two valid options for this are 'true' or 'false'
-# which is the default value.
-#org.opennms.grafanaBox.show=false
-#
-# If the box is enabled you also need to specify hostname of the grafana server
-#org.opennms.grafanaBox.hostname=localhost
-#
-# And also the port of the grafana server
-#org.opennms.grafanaBox.port=3000
-#
-# The API key is needed for the ReST calls to work
-#org.opennms.grafanaBox.apiKey=
-#
-# When a tag is specified only dashboards with this given tag
-# will be displayed. When no tag is given all dashboards will
-# be displayed.
-#org.opennms.grafanaBox.tag=
-#
-# The protocol for the ReST call can also be specified
-#org.opennms.grafanaBox.protocol=http
-#
-# Timeouts for contacting the grafana server
-#org.opennms.grafanaBox.connectionTimeout=500
-#org.opennms.grafanaBox.soTimeout=500
+# Use Google Maps Geocoder
+#gwt.geocoder.class=org.opennms.features.poller.remote.gwt.server.geocoding.GoogleMapsGeocoder
+
+# Use Mapquest Geocoder
+#gwt.geocoder.class=org.opennms.features.poller.remote.gwt.server.geocoding.MapquestGeocoder
+
+# Use OpenStreet Geocoder
+#gwt.geocoder.class=org.opennms.features.poller.remote.gwt.server.geocoding.NominatimGeocoder
+gwt.geocoder.class=org.opennms.features.poller.remote.gwt.server.geocoding.NullGeocoder
+gwt.geocoder.rate=10
+gwt.geocoder.referer=http://localhost/
+gwt.geocoder.minimumQuality=ZIP
+gwt.geocoder.email=
+#gwt.openlayers.url=http://a.tile.openstreetmap.org/${z}/${x}/${y}.png
+gwt.openlayers.url=http://otile1.mqcdn.com/tiles/1.0.0/osm/${z}/${x}/${y}.png
+
+### Remote Poller
+
+distributed.layoutApplicationsVertically=false
+#opennms.pollerBackend.minimumConfigurationReloadInterval=300000
+#opennms.pollerBackend.disconnectedTimeout=600000
+#opennms.poller.server.serverPort=1199
+#opennms.poller.server.registryPort=1099
+excludeServiceMonitorsFromRemotePoller=DHCP,NSClient,RadiusAuth,XMP
+
+### Reporting
+
+org.opennms.jasperReportsVersion=5.6.1
+opennms.report.template.dir=${install.dir}/etc
+opennms.report.dir=${install.share.dir}/reports
+opennms.report.logo=${install.webapps.dir}/images/logo.gif
+ksc.default.graphsPerLine=1
+
+### Rancid Integration
+
+#opennms.rancidIntegrationEnabled=false
+#opennms.rancidIntegrationUseOnlyRancidAdapter=false
+
+### Asterisk AGI Support
+
+#org.opennms.netmgt.asterisk.agi.listenAddress=127.0.0.1
+#org.opennms.netmgt.asterisk.agi.listenPort=4573
+#org.opennms.netmgt.asterisk.agi.maxPoolSize=10
+
+### SMS Gateway Setup
+
+gnu.io.SerialPorts=/dev/ttyACM0:/dev/ttyACM1:/dev/ttyACM2:/dev/ttyACM3:/dev/ttyACM4:/dev/ttyACM5
+smslib.serial.polling=true

--- a/opennms-doc/guide-admin/src/asciidoc/index.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/index.adoc
@@ -144,6 +144,10 @@ include::text/enlinkd/layer-3-discovery.adoc[]
 include::text/enlinkd/layer-3/ospf-discovery.adoc[]
 include::text/enlinkd/layer-3/is-is-discovery.adoc[]
 
+// Description for configuration files
+== Configuration files
+include::text/config-files/opennms.properties.adoc[]
+
 [[ga-opennms-operation]]
 == Operation
 include::text/operation/ssl/ssl.adoc[]

--- a/opennms-doc/guide-admin/src/asciidoc/text/config-files/_template.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/config-files/_template.adoc
@@ -1,0 +1,23 @@
+
+// REMOVE ME!! Please keep first line an empty line to make sure, the ToC can be build correctly
+==== File: {name-of-the-configuration-file}
+
+A short summary what is the configuration file is doing
+
+[options="autowidth"]
+|===
+| Type             | e.g. Java property file with key value pairs or XML file with XSD
+| Location         | `path where the configuration file is located`
+| Restart required | yes or no
+|===
+
+===== Section or Property description
+
+[options="header, autowidth"]
+|===
+| Property | `org.opennms.netmgt.icmp.requireV4` +
+             `org.opennms.netmgt.icmp.requireV6`
+2+|By default, OpenNMS will start up if either _ICMPv4_ *or* _ICMPv6_ are available and initialize properly.
+   If you wish to force _IPv4_ or _IPv6_ explicitly, set one or both of these properties to `detect`.
+| Default | Not set
+|===

--- a/opennms-doc/guide-admin/src/asciidoc/text/config-files/opennms.properties.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/config-files/opennms.properties.adoc
@@ -1,0 +1,433 @@
+
+[[file-opennms-properties]]
+=== File: opennms.properties
+
+This properties file allows you to set global properties for the opennms application.
+These properties will be set as system properties at the beginning of Java startup.
+Any properties set on the Java command-line with `-Dproperty=value` will be overridden by these values.
+
+[options="autowidth"]
+|===
+| Type             | Java property file with key value pairs
+| Location         | `${OPENNMS_HOME}/etc`
+| Restart required | yes
+|===
+
+[[ga-opennms-properties-general]]
+==== General
+
+[options="header, autowidth"]
+|===
+| Name                                            | Default              | Description
+| `opennms.bin.dir`                               | `${install.bin.dir}` | Path to _OpenNMS_ binary files
+| `java.awt.headless`                             | `true`               | Run _JVM_ in headless mode.
+| `org.opennms.web.aclsEnabled`                   | `false`              | This property is for enabling _ACL_ support in the webapp.
+| `org.opennms.security.disableLoginSuccessEvent` | `false`              | This value disables the sending of successful login events.
+                                                                           The default is to send the event.
+                                                                           Change this value to true to disable the publishing of this event.
+|===
+
+[[ga-opennms-properties-icmp]]
+==== ICMP
+
+[options="header, autowidth"]
+|===
+| Name                                  | Default                                   | Description
+| `org.opennms.netmgt.icmp.pingerClass` | `org.opennms.netmgt.icmp.jni6.Jni6Pinger` | *_JNI JICMP_ legacy IPv4-only* +
+                                                                                      The _JICMP_ implementation is what has traditionally been used in _OpenNMS_ since 1.0, uses _JNI_.
+                                                                                      It requires you to install a separate package _JICMP_ which contains a shared library for interfacing with your system's _ICMP APIs_. +
+                                                                                      Usage: `org.opennms.netmgt.icmp.jni.JniPinger` +
+                                                                                      +
+                                                                                      *_JNI JICMP6_* +
+                                                                                      The _JICMP6_ core library is a version of the _JICMP_ codebase which can speak _ICMPv6_, instead of _ICMPv4_.
+                                                                                      The _OpenNMS JICMP6 pinger_ supports both _ICMPv4_ and _ICMPv6_.
+                                                                                      It delegates all _ICMPv4_ ping requests to the original _JICMP JniPinger_ above and uses the _JICMP6_ library for _ICMPv6_ packets.
+                                                                                      This is the default for OpenNMS 1.9.90 and up. +
+                                                                                      Usage: `org.opennms.netmgt.icmp.jni6.Jni6Pinger`
+                                                                                      +
+                                                                                      *_JNA ICMPv4/ICMPv6_* +
+                                                                                      The _JNA_ implementation is written from the ground up to support _IPv4_ and _IPv6_, and takes advantage of the _JNA_ project's ability to access native _APIs_ without needing to distribute separate shared libraries.
+                                                                                      It is, however, not as performant as the _JICMP6 pinger_, so it is not recommended unless you are in an environment which requires it.
+                                                                                      This is the default _ICMP_ implementation used in the _Remote Poller_, since it does not rely on any external native code to be installed outside of the _JVM_. +
+                                                                                      Usage: `org.opennms.netmgt.icmp.jna.JnaPinger`
+| `org.opennms.netmgt.icmp.requireV4` +
+  `org.opennms.netmgt.icmp.requireV6`   | `detect`                                  | By default, _OpenNMS_ will start up if either _ICMPv4_ *or* _ICMPv6_ are available and initialize properly.
+                                                                                      If you wish to force _IPv4_ or _IPv6_ explicitly, set one or both of these properties to `true`.
+|===
+
+[[ga-opennms-properties-snmp]]
+==== SNMP
+
+[options="header, autowidth"]
+|===
+| Name                                                    | Default                                         | Description
+| `org.opennms.snmp.strategyClass`                        | `org.opennms.netmgt.snmp.snmp4j.Snmp4JStrategy` | *_JoeSNMP_* +
+                                                                                                              The original _OpenNMS_ _SNMP_ Library and provides _SNMP_ _v1_ and _v2_ support. +
+                                                                                                              Usage: `org.opennms.netmgt.snmp.joesnmp.JoeSnmpStrategy` +
+                                                                                                              +
+                                                                                                              *_SNMP4J_* +
+                                                                                                              This is a new 100% _Java_ _SNMP_ library that provides support for _SNMP_ _v1_, _v2_ and _v3_. +
+                                                                                                              Usage: `org.opennms.netmgt.snmp.snmp4j.Snmp4JStrategy`
+| `org.snmp4j.smisyntaxes`                                | `opennms-snmp4j-smisyntaxes.properties`         | The world is full of buggy _SNMP_ agents.
+                                                                                                              We can work around many of their quirks by extending various _SMI_ classes from _SNMP4J_.
+                                                                                                              The following property must be set in order for any of these workarounds to be enabled.
+| `snmp4j.LogFactory`                                     | `org.snmp4j.log.Log4jLogFactory`                | By default, _SNMP4J_ does not do any logging internally, but it's easy to enable.
+                                                                                                              See `log4j.properties` to adjust log levels for these messages.
+| `org.opennms.snmp.snmp4j.allowSNMPv2InV1`               | `false`                                         | Some buggy _SNMP_ agents fail to exclude _Counter64_ objects from view when responding to _SNMPv1_ requests (as mandated by RFC3584 § 4.2.2.1).
+                                                                                                              To relax handling of _v1_ responses to permit _Counter64_ _varbinds_ rather than discarding them as ill-formed (per the same RFC), set this property to `true`.
+| `org.opennms.snmp.snmp4j.forwardRuntimeExceptions`      | `false`                                         | When debugging _SNMP_ problems when using the _SNMP4J_ library, it may be helpful to receive runtime exceptions from _SNMP4J_.
+                                                                                                              These exceptions almost always indicate a problem with an _SNMP_ agent.
+                                                                                                              Any that we don't catch will end up in `output.log`, so they're disabled by default, but they may provide more information (albeit without timestamps) than the messages that _SNMP4J_ logs (see `snmp4j.LogFactory`)
+| `org.opennms.snmp.snmp4j.noGetBulk`                     | `false`                                         | Some _SNMP_ agents claim to support _SNMPv2c_, but either completely fail to respond to _GET-BULK_ requests or return bad responses to them under some conditions.
+                                                                                                              To disable the use of _GET-BULK PDUs_ globally in the _SNMP4J_ strategy, set this property to `true`.
+                                                                                                              This change will adversely affect the efficiency of _SNMP_ data collection from agents that properly support _GET-BULK_.
+| `org.opennms.snmp.workarounds.allow64BitIpAddress`      | `true`                                          | _Net-SNMP_ agents prior to release 5.4.1 on 64-bit platforms exhibit a bug that causes the discovery of a node's interfaces to fail.
+                                                                                                              A workaround has been made that helps _SNMP4J_ cope with this bug.
+| `org.opennms.snmp.workarounds.allowZeroLengthIpAddress` | `true`                                          | _DrayTek Corporation_, Router Model: _Vigor2820_ Series devices with a _sysObjectID_ of _.1.3.6.1.4.1.7367_ sometimes present objects from the _ipAddrTable_ with an instance ID of "0".
+                                                                                                              To substitute a valid (though still dodgy) value of "0.0.0.0" when we encounter one of these, set the following property to `true`.
+|===
+
+[[ga-opennms-properties-data-collection]]
+==== Data Collection
+
+[options="header, autowidth"]
+|===
+| Name                                                                   | Default                                                      | Description
+| `org.opennms.rrd.storeByGroup`                                         | `false`                                                      | On very large systems the _OpenNMS_ default mechanism of storing one data source per _RRD_ file can be very _I/O_ Intensive.
+                                                                                                                                          Many _I/O_ subsystems fail to keep up with the vast amounts of data that _OpenNMS_ can collect in this situation.
+                                                                                                                                          We have found that in those situations having fewer large files with multiple data sources in each performs better than many smaller files, each with a single data source.
+                                                                                                                                          This option enables all of the data sources belonging to a single collection group to be stored together in a single file.
+| `org.opennms.rrd.storeByForeignSource`                                 | `false`                                                      | By default, data collected for a node with _nodeId n_ is stored in the directory `${rrd.base.dir}/snmp/n`.
+                                                                                                                                          If the node is deleted and re-added, it will receive a new _nodeId_, and subsequent data will be stored in a new directory.
+                                                                                                                                          This can create problems in data continuity if a large number of nodes get deleted and re-added either accidentally or intentionally.
+                                                                                                                                          This option enables an alternate storage location for nodes that are provisioned (i.e. they have a _foreignSource_ and _foreignId_ defined).
+                                                                                                                                          If `storeByForeignSource` is set to `true`, a provisioned node will have its data stored by _foreignSource/ForeignId_ rather than _nodeId_. +
+                                                                                                                                          For example, a node with _foreignSource/foreignId_ `mysource/12345` will have its data stored in `${rrd.base.dir}/snmp/fs/mysource/12345`.
+                                                                                                                                          With this option enabled, data collection will continue to use the same storage location as long as the _foreignSource/foreignId_ is not redefined, regardless of how many times the node may be deleted and re-added.
+| `rrd.base.dir`                                                         | `${install.share.dir}/rrd`                                   | Path to _RRD_ base directory
+| `rrd.binary`                                                           | `${install.rrdtool.bin}`                                     | _RRD_ binary path only used if the _JniRrdStrategy_ is used.
+| `org.opennms.snmp.dataCollectionConfig.reloadCheckInterval`            | `30000`                                                      | Specifies the amount of time to wait (in milliseconds) until the reload container physically checks if the `datacollection-config.xml` file has been changed.
+| `org.opennms.collectd.instrumentationClass`                            | `org.opennms.netmgt.collectd.DefaultCollectdInstrumentation` | Collectd Instrumentation class
+| `org.opennms.netmgt.collectd.SnmpCollector.forceRescan`                | `false`                                                      | Control sending force rescans from the _SNMP Collector_.
+| `org.opennms.netmgt.collectd.SnmpCollector.limitCollectionToInstances` | `false`                                                      | For systems with very large numbers of interfaces we may be unable to collect all the data by scanning the entire table in the specified time interval.
+                                                                                                                                          If only a few instances are being collected then we can limit the collection to only those instances and save collection time but possible 'getting' confused by instance changes.
+                                                                                                                                          Set this to `true` to enable instance limiting
+| `org.opennms.utils.propertiesCache.enableCheckFileModified`            | `false`                                                      | Enable an aggressive validation against the last modification time of the strings.properties files.
+                                                                                                                                          This is useful only if the _OpenNMS WebUI_ is running on a different server.
+                                                                                                                                          Check link:http://issues.opennms.org/browse/NMS-5806[NMS-5806] for more details.
+| `org.opennms.threshd.value.decimalformat`                              | `\\##.##`                                                    | Format rule used when setting the datasource value for threshold events check link:http://issues.opennms.org/browse/NMS-3473[NMS-3473].
+                                                                                                                                          In order to properly use scientific notation for the datasource's value, change the format rule to something like this `\\##.##E0` to avoid link:http://issues.opennms.org/browse/NMS-4126[NMS-4126].
+|===
+
+[[ga-opennms-properties-trouble-ticketing]]
+==== Trouble Ticketing
+
+[options="header, autowidth"]
+|===
+| Name                                     | Default                                                  | Description
+| `opennms.ticketer.servicelayer`          | `org.opennms.netmgt.ticketd.DefaultTicketerServiceLayer` | The _ticketer_ responsible for creating tickets from the _Alarm_ details and passing these to the ticket plugin.
+| `opennms.ticketer.plugin`                | `org.opennms.netmgt.ticketd.NullTicketerPlugin`          | The ticket plugin implementation to use to create tickets via the _Alarm details pages_ (if configured).
+                                                                                                        The _NullTicketerPlugin_ just does nothing when attempting to create tickets.
+                                                                                                        If you enable a trouble-ticketing plugin here, you must also edit `$OPENNMS_HOME/jetty-webapps/opennms/WEB-INF/configuration.properties`
+| `opennms.alarmTroubleTicketEnabled`      | _not set_ `disabled`                                     | Enable or disable the _Alarm Trouble Ticket_ integration.
+| `opennms.ticketer.plugin`                | `org.opennms.netmgt.ticketd.NullTicketerPlugin`          | The ticket plugin implementation to use to create tickets via the _Alarm details pages_ (if configured).
+                                                                                                        The _NullTicketerPlugin_ just does nothing when attempting to create tickets.
+                                                                                                        If you enable a trouble-ticketing plugin here, you must also edit `$OPENNMS_HOME/jetty-webapps/opennms/WEB-INF/configuration.properties` +
+                                                                                                        +
+                                                                                                        *_OtrsTicketerPlugin_* +
+                                                                                                        You will need to adjust _alarmTroubleTicketLinkTemplate_ to suit your _OTRS Base URL_.
+                                                                                                        Note that you will need to install the _OpenNMS_ module for _OTRS_ in your _OTRS server_. +
+                                                                                                        Usage: `org.opennms.netmgt.ticketer.otrs.OtrsTicketerPlugin` +
+                                                                                                        +
+                                                                                                        *_RemedyTicketerPlugin_* +
+                                                                                                        You will need to adjust _alarmTroubleTicketLinkTemplate_ to suit your _Remedy Base URL_. +
+                                                                                                        Usage: `org.opennms.netmgt.ticketer.remedy.RemedyTicketerPlugin`
+| `opennms.alarmTroubleTicketLinkTemplate` | _not set_                                                | *_OTRS Trouble Ticket Link Template_* +
+                                                                                                        Set the trouble ticket link template for _OTRS_ with `<a href="http://localhost/otrs/index.pl?Action=AgentTicketZoom&TicketNumber=\${id}">\${id}</a>` +
+                                                                                                        +
+                                                                                                        *_Remedy Trouble Ticket Link Template_* +
+                                                                                                        Set the trouble ticket link template for _Remedy_ with `<a href="http://127.0.0.1:8180/arsys/servlet/ViewFormServlet?form=HPD:Help%20Desk&server=itts3h&qual='Incident ID*%2B'=%22\${id}%22">\${id}</a>`
+|===
+
+[[ga-opennms-properties-rtc-ipc]]
+==== RTC IPC
+
+[options="header, autowidth"]
+|===
+| Name                                    | Default                                  | Description
+| `opennms.rtc.event.proxy.host`          | `127.0.0.1`                              | The hostname or IP address of the _OpenNMS_ server where events should be sent.
+| `opennms.rtc.event.proxy.port`          | `5817`                                   | The _TCP_ port for the _Eventd_ _TCP_ receiver where events should be sent.
+| `opennms.rtc.event.proxy.timeout`       | `2000`                                   | The timeout in milliseconds the proxy will wait to complete a _TCP_ connection.
+| `opennms.rtc-client.http-post.base-url` | `http://localhost:8980/opennms/rtc/post` | The base of a _URL_ that _RTC_ clients use when creating a _RTC_ subscription _URL_.
+                                                                                       If you are using _Tomcat_ instead of the built-in _Jetty_, change this in `WEB-INF/configuration.properties` instead.
+| `opennms.rtc-client.http-post.username` | `rtc`                                    | The username the _RTC_ uses when authenticating itself in an _HTTP POST_.
+| `opennms.rtc-client.http-post.password` | `rtc`                                    | The password the _RTC_ uses when authenticating itself in an _HTTP POST_.
+|===
+
+[[ga-opennms-properties-map-ipc]]
+==== Map IPC
+
+[options="header, autowidth"]
+|===
+| Name                                    | Default                                  | Description
+| `opennms.map-client.http-post.url`      | `http://localhost:8980/opennms/map/post` | The base of a _URL_ that _Map System_ clients use when creating a _Map_ subscription _URL_.
+                                                                                       If you are using _Tomcat_ instead of the built-in _Jetty_, change this in `WEB-INF/configuration.properties` instead.
+| `opennms.map-client.http-post.username` | `map`                                    | The username the _Map System_ uses when authenticating itself in an _HTTP POST_.
+| `opennms.map-client.http-post.password` | `map`                                    | The password the _Map System_ uses when authenticating itself in an _HTTP POST_.
+|===
+
+[[ga-opennms-properties-jetty]]
+==== Jetty
+
+[options="header, autowidth"]
+|===
+| Name                                                  | Default                   | Description
+| `org.opennms.netmgt.jetty.port`                       | `8980`                    | _Jetty_ web server port to listen on
+| `org.opennms.netmgt.jetty.ajp-port`                   | `8981`                    | If you want _Jetty_ with _AJP_ support, this is the port to listen on.
+| `org.opennms.netmgt.jetty.host`                       | _not set, all interfaces_ | By default, _Jetty_ will listen on all interfaces.
+                                                                                      You can set a specific bind address here.
+                                                                                      If you set this to a value other than `127.0.0.1`, you will need to update the _rtc-client_ and _map-client_ _URLs_ above.
+| `org.opennms.netmgt.jetty.enableRequestLogging`       | `false`                   | This enables _NCSA_ style request logging in `${opennm.home}/logs`
+| `org.eclipse.jetty.server.Request.maxFormContentSize` | `200000`                  | This sets the maximum size for a form submission in _Jetty_.
+                                                                                      The default value is 200.000 bytes.
+                                                                                      Setting it to `-1` disables the form limit.
+| `org.eclipse.jetty.server.Request.maxFormKeys`        | `2000`                    | This sets the maximum number of items that can be in web forms (like the Provisioning web UI).
+| `org.opennms.netmgt.jetty.requestHeaderSize`          | `4000`                    | This sets the request header size for _Jetty_.
+                                                                                      The default value is 4.000 bytes.
+| `opennms.web.base-url`                                | `http://%x%c/`            | If _OpenNMS_ is setting an incorrect _HTML <base> tag_, you can override its idea of the local _URL_ here.
+                                                                                      The _URL_ must end with a `/`.
+                                                                                      The following substitutions are available: +
+                                                                                      `%s`: scheme (http, https) +
+                                                                                      `%h`, `%p`: host and port from the _Host: header_ +
+                                                                                      `%x`: host and port from the _X-Forwarded-Host_, _X-Host_ or _Host header_ +
+                                                                                      `%c`: context path (without trailing slash) +
+                                                                                      You can use this to get _Jetty_ working behind an _Apache/SSL proxy_.
+                                                                                      Set the _base-url_ to `https://%x%c/` and include in your _Apache SSL vhost_: +
+                                                                                      `<Location /opennms>
+                                                                                          ProxyPass http://127.0.0.1:8980/opennms
+                                                                                          ProxyPassReverse http://127.0.0.1:8980/opennms
+                                                                                      </Location>`
+|===
+
+[[ga-opennms-properties-jetty-https]]
+==== Jetty HTTPS
+
+[options="header, autowidth"]
+|===
+| Name                                                           | Default     | Description
+| `org.opennms.netmgt.jetty.https-port`                          | _not set_   | If you want Jetty to provide an HTTPS listener, this is the port to listen on.
+                                                                                 Suggested value is `8443` to avoid conflicts with existing web server but can be different.
+                                                                                 Configuring details can be found on the link:http://www.opennms.org/index.php/Standalone_HTTPS_with_Jetty[Standalone HTTPS with Jetty].
+                                                                                 Note that setting this property does *not* disable the plain _HTTP_ listener, which is required by _Rtcd_ to post realtime status updates.
+                                                                                 If you do not wish to allow unsecured _HTTP_ access to the OpenNMS web UI, you must set `org.opennms.netmgt.jetty.host` or use firewall rules to accomplish this.
+| `org.opennms.netmgt.jetty.https-host`                          | _not set_   | By default, if configured for _HTTPS_, Jetty will listen on all interfaces.
+    You can set a specific bind address like `127.0.0.1` here.
+| `org.opennms.netmgt.jetty.https-keystore`                      | _not set_   | To set the _keystore_ file from which Jetty will retrieve its _SSL_ key, change the value of this property.
+                                                                                 Note that the `jetty.properties` distributed with _OpenNMS_ should never be used in production.
+| `org.opennms.netmgt.jetty.https-keystorepassword`              | _not set_   | To change the _keystore_ password used to access the _keystore_ specified in the _https-keystore_ property.
+| `org.opennms.netmgt.jetty.https-keypassword`                   | _not set_   | To change the key password used to access the _Jetty_ _SSL_ key (which is stored in the _keystore_ specified by the _https-keystore_ property).
+| `org.opennms.netmgt.jetty.https-cert-alias`                    | _not set_   | To specify a particular _SSL_ certificate alias in the _keystore_, set this property.
+                                                                                 Otherwise, the first certificate that is found will be used.
+                                                                                 A suggested default value could be `opennms-jetty-certificate`
+| `org.opennms.netmgt.jetty.https-exclude-cipher-suites`         | _not set_   | To exclude specific SSL/TLS cipher suites from use, set this property to a colon-separated list of suite names.
+                                                                                 Whitespace surrounding colons is OK.
+                                                                                 Example list with an exclude list for cipher suites: +
+                                                                                 `SSL_DHE_DSS_WITH_DES_CBC_SHA: \
+                                                                                 SSL_DHE_RSA_EXPORT_WITH_DES40_CBC_SHA:SSL_DHE_DSS_EXPORT_WITH_DES40_CBC_SHA: \
+                                                                                 SSL_DHE_RSA_WITH_DES_CBC_SHA:SSL_RSA_EXPORT_WITH_DES40_CBC_SHA: \
+                                                                                 SSL_RSA_EXPORT_WITH_RC4_40_MD5:SSL_RSA_WITH_3DES_EDE_CBC_SHA: \
+                                                                                 SSL_RSA_WITH_DES_CBC_SHA:TLS_DHE_RSA_EXPORT_WITH_DES40_CBC_SHA: \
+                                                                                 TLS_RSA_EXPORT_WITH_DES40_CBC_SHA:TLS_RSA_WITH_DES_CBC_SHA`
+| `org.opennms.provisiond.enableDiscovery`                       | `true`      | This property is used to enable/disable the handling of _new suspect events_ in _Provisiond_ along with periodic scanning of discovered nodes.
+| `org.opennms.provisiond.enableDeletionOfRequisitionedEntities` | `false`     | Prior to 1.10 it was possible to delete entities that have been provisioned as part of a provisioning group.
+                                                                                 In 1.10 we have disabled this so that in order to delete these entities you have to go back to the provisioning group and delete them from there.
+                                                                                 To reenable this deletion you can set this to `true`.
+                                                                                 NOTE: If you do this then the object will be recreated when the provisioning group is next imported/synchronized.
+| `org.opennms.provisiond.scheduleRescanForExistingNodes`        | `true`      | This property is used to control the rescan scheduling existing nodes in the database when _Provisiond_ starts.
+                                                                                 There are situations like distributed environments, where _OpenNMS_ is deployed across multiple servers, on which this feature must be disabled to avoid continuity issues.
+                                                                                 In this scenario, most likely the inventory of nodes should not be managed by all _OpenNMS_ instances.
+| `org.opennms.provisiond.scheduleRescanForUpdatedNodes`         | `true`      | Use this property to disable rescans of existing nodes following an import (synchronize) of a provisioning group (requistion).
+| `org.opennms.provisiond.repositoryImplementation`              | `files`     | Use this property to change the strategy used for managing deployed/pending requisitions. Tested strategies: +
+                                                                                 `file` default +
+                                                                                 `fastFile` recommended for fastest response, at expense of memory resources +
+                                                                                 Experimental strategies: +
+                                                                                 `fused` +
+                                                                                 `fastFused` +
+                                                                                 `queueing` +
+                                                                                 `fastQueueing` +
+                                                                                 `caching` +
+                                                                                 `fastCaching`
+| `importer.adapter.dns.server`                                  | `127.0.0.1` | IP address of the _DNS_ server that the _DnsProvisioningAdapter_ should send dynamic _DNS_ updates to.
+| `org.opennms.netmgt.provision.maxConcurrentConnections`        | `0`         | This property defines how many current async detetion attempts can be created at any given time.
+                                                                                 Setting this to zero removes any limits on the number of concurrent connection attempts.
+|===
+
+[[ga-opennms-properties-webui]]
+==== Web UI
+
+[options="header, autowidth"]
+|===
+| Name                                | Default                        | Description
+| `org.opennms.web.console.centerUrl` | `/includes/categories-box.jsp` | This value controls the content that will be displayed in the middle box of the front page.
+                                                                         The default is the view of _SLM/RTC_ categories.
+                                                                         To use the _Surveillance View_ set this value to `/surveillance-box.jsp`.
+| `opennms.eventlist.acknowledge`     | `false`                        | This value allows you to show or hide the Acknowledge event button.
+                                                                         This is only here for those who still acknowledge events.
+                                                                         We are moving away from this and towards acknowledging alarms instead of events.
+| `opennms.eventlist.showCount`       | `false`                        | This value allows you to configure whether or not the total event count is shown in the event list in the _Web UI_.
+                                                                         Setting this to 'true' can cause severe performance issues for larger installations.
+| `opennms.nodesWithOutages.count`    | `12`                           | This value allows you to set the number of nodes with outages to display on the front page in the _Web UI_.
+| `opennms.nodesWithOutages.show`     | `true`                         | This value allows you to enable/disable the nodes with outages box on the front page in the _Web UI_.
+| `opennms.nodesWithProblems.count`   | `16`                           | This value allows you to set the number of nodes with problems to display on the front page in the _Web UI_.
+| `opennms.nodesWithProblems.show`    | `true`                         | This value allows you to enable/disable the nodes with problems box on the front page in the _Web UI_.
+| `opennms.nodeStatusBar.show`        | `false`                        | This value allows you to enable/disable the status bar resume at the top of the node page in the _Web UI_.
+| `opennms.assets.allowHtmlFields`    | _not set_                      | By default, all scripts and _HTML_ markup are stripped from the values submitted for node asset information.
+                                                                         This measure is to protect against cross-site scripting and other types of attacks on the _Web UI_.
+                                                                         To allow markup (but still not scripts) in certain asset fields, set this property's value to a comma-separated list of asset field names.
+                                                                         A full list of field names can be obtained by exporting all asset data to a _CSV_ file from the _Web UI_.
+                                                                         This value would allow _HTML_ markup in the _Comments_ and _Description_ fields: `comments, description`.
+|===
+
+[[ga-opennms-properties-dashboard-surveillance-view]]
+==== Dashboard and Surveillance View
+
+[options="header, autowidth"]
+|===
+| Name                                   | Default  | Description
+| `org.opennms.dashboard.implementation` | `vaadin` | _OpenNMS_ provides two different dashboard/surveillance view implementations.
+                                                      The _GWT_ variant is the original.
+                                                      Later, the _UI_ was rewritten using the _Vaadin framework_.
+                                                      So, the two valid options for this option are `vaadin` or `gwt`.
+                                                      Please note that the _GWT_ version is deprecated and will be removed in future versions.
+| `org.opennms.dashboard.redirect`       | `true`   | This setting controls whether users will be redirected to the dashboard page after a successful login.
+                                                      The two valid options for this are `true` or `false` which is the default value.
+|===
+
+[[ga-opennms-properties-graphing]]
+==== Graphing
+
+[options="header, autowidth"]
+|===
+| Name                            | Default | Description
+| `org.opennms.web.graphs.engine` | `png`   | Use this property to set the graph rendering engine type.
+                                              Supported values are: +
+                                              `png` (default) +
+                                              `placeholder` +
+                                              `backshift`
+|===
+
+[[ga-opennms-properties-mapping-geocoding]]
+==== Mapping and Geocoding
+
+[options="header, autowidth"]
+|===
+| Name                          | Default                                                                | Description
+| `gwt.maptype`                 | `OpenLayers`                                                           | The map implementation to use current choices are: `GoogleMaps`, `Mapquest`, `OpenLayers`
+| `gwt.apikey`                  | _not set_                                                              | The API key to use for the remote monitor map
+| `gwt.apikey`                  | _not set_                                                              | The API key to use for the remote monitor map
+| `gwt.geocoder.class`          | `org.opennms.features.poller.remote.gwt.server.geocoding.NullGeocoder` | _*Google Maps API*_: `org.opennms.features.poller.remote.gwt.server.geocoding.GoogleMapsGeocoder` +
+                                                                                                           _*MapQuest API*_: `org.opennms.features.poller.remote.gwt.server.geocoding.MapquestGeocoder` +
+                                                                                                           _*OpenStreetMaps API*_: `org.opennms.features.poller.remote.gwt.server.geocoding.NominatimGeocoder` +
+                                                                                                           _*NullGoecoder*_ (always return OpenNMS World HQ): `org.opennms.features.poller.remote.gwt.server.geocoding.NullGeocoder`
+| `gwt.geocoder.rate`           | `10`                                                                   | The rate at which to make requests, for geocoders that support it.
+| `gwt.geocoder.referer`        | `http://localhost/`                                                    | The referer to use when making geocoding requests, for geocoders that support it.
+                                                                                                           For _MapQuest_, the value you set here will need to be allowed in your _AppKeys_ manager: http://developer.mapquest.com/web/info/account/app-keys
+| `gwt.geocoder.minimumQuality` | `ZIP`                                                                  | The minimum quality level to require before rejecting a geocoding request.
+                                                                                                           This is currently only used by _MapQuest_.
+                                                                                                           Choices are least to most specific: `COUNTRY`, `STATE`, `ZIP`, `COUNTY`, `ZIP_EXTENDED`, `CITY`, `STREET`, `INTERSECTION`, `ADDRESS`, `POINT`
+| `gwt.geocoder.email`          | _not set_                                                              | The email address to report as when making geocoding requests.
+                                                                                                           This is currently only used by _Nominatim_, and *MUST* be set!
+| `gwt.openlayers.url`          | `http://otile1.mqcdn.com/tiles/1.0.0/osm/${z}/${x}/${y}.png`           | The tile server _URL_ to use for _OpenLayers_.
+                                                                                                           This can be any mapnik-style tile server _URL_.
+                                                                                                           There is no support for multiple _URLs_ yet. +
+                                                                                                           Open MapQuest tile server: `http://otile1.mqcdn.com/tiles/1.0.0/osm/${z}/${x}/${y}.png` +
+                                                                                                           OpenStreetMap tile server: `http://a.tile.openstreetmap.org/${z}/${x}/${y}.png`
+|===
+
+[[ga-opennms-properties-remote-poller]]
+==== Remote Poller
+
+[options="header, autowidth"]
+|===
+| Name                                                       | Default                                                                | Description
+| `distributed.layoutApplicationsVertically`                 | `false`                        | -
+| `opennms.pollerBackend.minimumConfigurationReloadInterval` | `300000`                       | This setting is the minimum amount of time between reloads of a remote poller configuration in milliseconds because of global changes.
+                                                                                                This value should never be set less the `300000` (5 minutes) except to set it to zero which means never only reload the configuration if the location monitors status has been set to `CONFIG_CHANGED`.
+| `opennms.pollerBackend.disconnectedTimeout`                | `600000`                       | This is the amount of time in milliseconds after which a _Remote Poller_ is considered disconnected if it has not communicated with this _OpenNMS_ system.
+| `opennms.poller.server.serverPort`                         | `1199`                         | Specify the _RMI_ server port when using the legacy _RMI IPC_ interface.
+| `opennms.poller.server.registryPort`                       | `1099`                         | Specify the _RMI_ registry port when using the legacy _RMI IPC_ interface.
+| `excludeServiceMonitorsFromRemotePoller`                   | `DHCP,NSClient,RadiusAuth,XMP` | This setting enables _OpenNMS_ to exclude all references to certain services from the poller configuration that it sends to the remote location monitors.
+                                                                                                This is necessary when monitor classes are in use that are not included in the remote poller builds.
+                                                                                                Without this setting, the remote poller will crash on startup (see issue link:http://issues.opennms.org/browse/NMS-5777[NMS-5777]) even if none of the problematic services appears in any package.
+                                                                                                If you create custom services, you may need to add them to this list.
+|===
+
+[[ga-opennms-properties-reporting]]
+==== Reporting
+
+[options="header, autowidth"]
+|===
+| Name                               | Default                                  | Description
+| `org.opennms.jasperReportsVersion` | `5.6.1`                                  | Version of the _JasperReport_ libraries in _OpenNMS_.
+| `opennms.report.template.dir`      | `${install.dir}/etc`                     | Path to report template directory.
+| `opennms.report.dir`               | `${install.share.dir}/reports`           | Path to reports directory.
+| `opennms.report.logo`              | `${install.webapps.dir}/images/logo.gif` | Path to report logo.
+| `ksc.default.graphsPerLine`        | `1`                                      | Number of performance graphs per KSC report line.
+|===
+
+[[ga-opennms-properties-heatmap]]
+==== Heatmap
+
+[options="header, autowidth"]
+|===
+| Name                                       | Default                 | Description
+| `org.opennms.heatmap.defaultMode`          | `alarms`                | There exist two options for using the heatmap: `alarms` and `outages`.
+                                                                         This option configures which are displayed per default.
+| `org.opennms.heatmap.defaultHeatmap`       | `categories`            | This option defines which _Heatmap_ is displayed by default.
+                                                                         The two valid options are `categories` or `foreignSources`.
+| `org.opennms.heatmap.categoryFilter`       | `.*`                    | The following option is used to filter for categories to be displayed in the _Heatmap_.
+                                                                         This option uses the Java regular expression syntax.
+                                                                         The default is `.*` so all categories will be displayed.
+| `org.opennms.heatmap.foreignSourceFilter`  | `.*`                    | The following option is used to filter for foreign sources
+                                                                         to be displayed in the _Heatmap_. This option uses the Java regular expression syntax.
+                                                                         The default is `.*` so all foreign sources will be displayed.
+| `org.opennms.heatmap.onlyUnacknowledged`   | `false`                 | This option configures whether only unacknowledged alarms will be taken into account when generating the alarm-based version of the _Heatmap_.
+| `org.opennms.web.console.centerUrl`        | `/surveillance-box.jsp` | You can also place the _Heatmap_ on the landing page by setting this option to `/heatmap/heatmap-box.jsp`.
+|===
+
+[[ga-opennms-properties-rancid]]
+==== Rancid Integration
+
+[options="header, autowidth"]
+|===
+| Name                                            | Default | Description
+| `opennms.rancidIntegrationEnabled`              | `false` | Set to `true` the following property to enable the integration to _Rancid_ in the _WEB UI_.
+                                                              The default value is `false` (i.e. links are not created to rancid jsp pages into opennms gui)
+| `opennms.rancidIntegrationUseOnlyRancidAdapter` | `false` | Set to `true` the following property to use only _RancidAdapter_ to write _Clogin_ info in _Rancid_ `.cloginrc` file
+|===
+
+[[ga-opennms-properties-asterisk-agi]]
+==== Asterisk AGI Support
+
+[options="header, autowidth"]
+|===
+| Name                                            | Default   | Description
+| `org.opennms.netmgt.asterisk.agi.listenAddress` | _not set_ | If you are using the built-in _Asterisk Gateway Interface (AGI)_ server to integrate with an external _Asterisk_ server, you will need to set this property to an IP address on the _OpenNMS_ server that is reachable from the _Asterisk_ server.
+                                                                Note that the value of this property has no bearing on the address to which the _AGI_ server listens -- it is used only as a hint to allow the _Asterisk_ server to reach us (.e.g. `127.0.0.1`).
+| `org.opennms.netmgt.asterisk.agi.listenPort`    | _not set_ | To tell the built-in _AGI_ server to listen on a port other than the default of `4573`, change the value of this property.
+                                                                Be sure to update any static `fastagi://` _URLs_ in your _Asterisk dialplan_ accordingly.
+| `org.opennms.netmgt.asterisk.agi.maxPoolSize`   | _not set_ | The built-in _AGI_ server services requests out of a thread pool whose default size is `10` threads.
+                                                                Systems that make heavy use of this facility may need to increase this value.
+|===
+
+[[ga-opennms-properties-sms-gateway]]
+==== SMS Gateway Setup
+
+[options="header, autowidth"]
+|===
+| Name                    | Default   | Description
+| `gnu.io.SerialPorts`    | _not set_ | This property tells the _RXTX JNI_ library extend its range and load any of these ports in its default setup if they exist by default _RXTX_ doesn't load any non _ttyS_ ports.
+                                        Example value: `/dev/ttyACM0:/dev/ttyACM1:/dev/ttyACM2:/dev/ttyACM3:/dev/ttyACM4:/dev/ttyACM5`
+| `smslib.serial.polling` | `true`    | This property is to make sure that the phone will poll under _Linux_.
+                                        If you are _Linux_ and this is commented out you will get a phone timed out exception.
+|===


### PR DESCRIPTION
Migrated all documentation from opennms.properties to Admin guide. The described default values are set in the opennms.properties. For the reason the properties are used in several parts of OpenNMS they are ordered in sections which are reflected also in the documentation part.

JIRA: http://issues.opennms.org/browse/NMS-7712