### PR TITLE
NMS-7600: Build for PDF documentation fail on FreeBSD

### DIFF
--- a/opennms-doc/pom.xml
+++ b/opennms-doc/pom.xml
@@ -71,7 +71,7 @@
                     </dependency>
                     <dependency>
                         <groupId>org.jruby</groupId>
-                        <artifactId>jruby</artifactId>
+                        <artifactId>jruby-complete</artifactId>
                         <version>${jrubyVersion}</version>
                     </dependency>
                 </dependencies>

--- a/opennms-doc/pom.xml
+++ b/opennms-doc/pom.xml
@@ -69,8 +69,12 @@
                         <artifactId>asciidoctorj</artifactId>
                         <version>${asciidoctorjVersion}</version>
                     </dependency>
+                    <dependency>
+                        <groupId>org.jruby</groupId>
+                        <artifactId>jruby</artifactId>
+                        <version>${jrubyVersion}</version>
+                    </dependency>
                 </dependencies>
-
                 <executions>
                     <execution>
                         <id>output-html</id>

--- a/pom.xml
+++ b/pom.xml
@@ -1180,7 +1180,7 @@
     <asmVersion>5.0.3</asmVersion>
     <asciidoctorVersion>1.5.2.1</asciidoctorVersion>
     <asciidoctorjVersion>1.5.2</asciidoctorjVersion>
-    <asciidoctorjPdfVersion>1.5.0-alpha.7</asciidoctorjPdfVersion>
+    <asciidoctorjPdfVersion>1.5.0-alpha.6</asciidoctorjPdfVersion>
     <activemqVersion>5.10.0</activemqVersion>
     <atomikosVersion>3.9.2</atomikosVersion>
     <camelVersion>2.14.1</camelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -1178,9 +1178,9 @@
     <!-- dependency versions -->
     <oldAsmVersion>99.99.99-exclude-and-use-org.ow2.asm.asm-all-instead</oldAsmVersion>
     <asmVersion>5.0.3</asmVersion>
-    <asciidoctorVersion>1.5.2</asciidoctorVersion>
+    <asciidoctorVersion>1.5.2.1</asciidoctorVersion>
     <asciidoctorjVersion>1.5.2</asciidoctorjVersion>
-    <asciidoctorjPdfVersion>1.5.0-alpha.6</asciidoctorjPdfVersion>
+    <asciidoctorjPdfVersion>1.5.0-alpha.7</asciidoctorjPdfVersion>
     <activemqVersion>5.10.0</activemqVersion>
     <atomikosVersion>3.9.2</atomikosVersion>
     <camelVersion>2.14.1</camelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -1208,6 +1208,7 @@
     <jasperreportsVersion>5.6.1</jasperreportsVersion>
     <jettyVersion>8.1.10.v20130312</jettyVersion>
     <jodaTimeVersion>2.1</jodaTimeVersion>
+    <jrubyVersion>9.0.0.0.rc1</jrubyVersion>
     <karafVersion>2.4.0</karafVersion>
     <karafPaxExamVersion>2.3.9</karafPaxExamVersion>
     <felixVersion>2.3.0</felixVersion>


### PR DESCRIPTION
Adding JRuby 9000 dependency to the asciidoc maven plugin to provide a proper JRuby version.

JIRA: http://issues.opennms.org/browse/NMS-7600

Todo: 
- [x] Verify if this fixes the problem on FreeBSD with OpenJDK 8
- [x] Merge to develop and resolve JIRA issue