### PR TITLE
HZN-366: Added collection for monitoring CPU usage for Juniper SRX devices

### DIFF
--- a/opennms-base-assembly/src/main/filtered/etc/datacollection/juniper.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/datacollection/juniper.xml
@@ -52,9 +52,10 @@
         <mibObj oid=".1.3.6.1.4.1.4874.2.2.2.1.9.4.1.4" instance="juniSystemTempIndex" alias="juniSTPhysicalIndex" type="string" />
       </group>
 
-      <group name="juniper-srx-router" ifType="all">
+      <group name="juniper-spu-monitor" ifType="all">
         <mibObj oid=".1.3.6.1.4.1.2636.3.39.1.12.1.1.1.11" instance="jnxJsSPUMonitoringObjectsTable" alias="juniSPUMonNodeDescr"    type="string" />
-        <mibObj oid=".1.3.6.1.4.1.2636.3.39.1.12.1.1.1.6"  instance="jnxJsSPUMonitoringObjectsTable" alias="juniSPUMonCurrFlow"    type="Gauge32" />
+        <mibObj oid=".1.3.6.1.4.1.2636.3.39.1.12.1.1.1.4"  instance="jnxJsSPUMonitoringObjectsTable" alias="jnxJsSPUMonCPUUsage"    type="Gauge32" />
+        <mibObj oid=".1.3.6.1.4.1.2636.3.39.1.12.1.1.1.6"  instance="jnxJsSPUMonitoringObjectsTable" alias="juniSPUMonCurrFlow"     type="Gauge32" />
         <mibObj oid=".1.3.6.1.4.1.2636.3.39.1.12.1.1.1.7"  instance="jnxJsSPUMonitoringObjectsTable" alias="juniSPUMonMaxFlow"      type="Gauge32" />
       </group>
 
@@ -158,10 +159,17 @@
         </collect>
       </systemDef>
 
-      <systemDef name="Juniper SRX-Routers">
+      <systemDef name="Juniper SRX240 Routers">
         <sysoidMask>.1.3.6.1.4.1.2636.1.1.1.2.39</sysoidMask>
         <collect>
-          <includeGroup>juniper-srx-router</includeGroup>
+          <includeGroup>juniper-spu-monitor</includeGroup>
+        </collect>
+      </systemDef>
+
+      <systemDef name="Juniper SRX220 Routers">
+        <sysoidMask>.1.3.6.1.4.1.2636.1.1.1.2.58</sysoidMask>
+        <collect>
+          <includeGroup>juniper-spu-monitor</includeGroup>
         </collect>
       </systemDef>
 

--- a/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/juniper-graph.properties
+++ b/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/juniper-graph.properties
@@ -123,14 +123,38 @@ report.srx.spuCPUMonitor.columns=jnxJsSPUMonCPUUsage
 report.srx.spuCPUMonitor.type=jnxJsSPUMonitoringObjectsTable
 report.srx.spuCPUMonitor.propertiesValues=juniSPUMonNodeDescr
 report.srx.spuCPUMonitor.command=--title="SPU CPU Usage on node {juniSPUMonNodeDescr}" \
- --vertical-label="CPU Usage" \
- DEF:cpuUsage={rrd1}:jnxJsSPUMonCPUUsage:AVERAGE \
- LINE2:cpuUsage#0000ff:"CPU Usage" \
+ --vertical-label="percent" \
+ --lower-limit 0 \
+ --upper-limit 105 \
+ DEF:dpercent={rrd1}:jnxJsSPUMonCPUUsage:AVERAGE \
+ CDEF:dpercent10=0,dpercent,GT,0,dpercent,IF \
+ CDEF:dpercent20=10,dpercent,GT,0,dpercent,IF \
+ CDEF:dpercent30=20,dpercent,GT,0,dpercent,IF \
+ CDEF:dpercent40=30,dpercent,GT,0,dpercent,IF \
+ CDEF:dpercent50=40,dpercent,GT,0,dpercent,IF \
+ CDEF:dpercent60=50,dpercent,GT,0,dpercent,IF \
+ CDEF:dpercent70=60,dpercent,GT,0,dpercent,IF \
+ CDEF:dpercent80=70,dpercent,GT,0,dpercent,IF \
+ CDEF:dpercent90=80,dpercent,GT,0,dpercent,IF \
+ CDEF:dpercent100=90,dpercent,GT,0,dpercent,IF \
  COMMENT:"\\n" \
+ COMMENT:"CPU usage graph colors\\n" \
+ AREA:dpercent10#5ca53f:" 0-10%" \
+ AREA:dpercent20#75b731:"11-20%" \
+ AREA:dpercent30#90c22f:"21-30%" \
+ AREA:dpercent40#b8d029:"31-40%" \
+ AREA:dpercent50#e4e11e:"41-50%" \
  COMMENT:"\\n" \
- GPRINT:cpuUsage:AVERAGE:"Avg \\: %2.1lf%s%%" \
- GPRINT:cpuUsage:MIN:"Min \\: %2.1lf%s%%" \
- GPRINT:cpuUsage:MAX:"Max \\: %2.1lf%s%%\\n"
+ AREA:dpercent60#fee610:"51-60%" \
+ AREA:dpercent70#f4bd1b:"61-70%" \
+ AREA:dpercent80#eaa322:"71-80%" \
+ AREA:dpercent90#de6822:"81-90%" \
+ AREA:dpercent100#d94c20:"91-100%" \
+ COMMENT:"\\n" \
+ LINE1:dpercent#46683b:"CPU usage in %" \
+ GPRINT:dpercent:AVERAGE:"Avg \\: %7.3lf%s" \
+ GPRINT:dpercent:MIN:"Min \\: %7.3lf%s" \
+ GPRINT:dpercent:MAX:"Max \\: %7.3lf%s\\n"
 
 #####
 ##### Juniper ERX reports

--- a/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/juniper-graph.properties
+++ b/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/juniper-graph.properties
@@ -17,6 +17,7 @@ erx.subscribers, \
 erx.systemmodule, \
 erx.temp, \
 srx.spuFlowMonitor, \
+srx.spuCPUMonitor, \
 ive.connections
 
 ######
@@ -116,6 +117,20 @@ report.srx.spuFlowMonitor.command=--title="Sessions used on node {juniSPUMonNode
  GPRINT:percentSessions:MIN:"(%2.1lf%s%%)" \
  GPRINT:currentSessions:MAX:"Max \\: %1.0lf" \
  GPRINT:percentSessions:MAX:"(%2.1lf%s%%)\\n"
+
+report.srx.spuCPUMonitor.name=Juniper SRX SPU CPU Usage
+report.srx.spuCPUMonitor.columns=jnxJsSPUMonCPUUsage
+report.srx.spuCPUMonitor.type=jnxJsSPUMonitoringObjectsTable
+report.srx.spuCPUMonitor.propertiesValues=juniSPUMonNodeDescr
+report.srx.spuCPUMonitor.command=--title="SPU CPU Usage on node {juniSPUMonNodeDescr}" \
+ --vertical-label="CPU Usage" \
+ DEF:cpuUsage={rrd1}:jnxJsSPUMonCPUUsage:AVERAGE \
+ LINE2:cpuUsage#0000ff:"CPU Usage" \
+ COMMENT:"\\n" \
+ COMMENT:"\\n" \
+ GPRINT:cpuUsage:AVERAGE:"Avg \\: %2.1lf%s%%" \
+ GPRINT:cpuUsage:MIN:"Min \\: %2.1lf%s%%" \
+ GPRINT:cpuUsage:MAX:"Max \\: %2.1lf%s%%\\n"
 
 #####
 ##### Juniper ERX reports


### PR DESCRIPTION
Also added SystemDef for SRX220 Juniper devices, and renamed the corresponding group as it more seems related to SPU's (Service Processing units) than SRX devices.

See also http://issues.opennms.org/browse/HZN-366
Bamboo test: http://bamboo.internal.opennms.com:8085/browse/OPENNMS-ONMS70

See also http://www.juniper.net/techpubs/en_US/release-independent/junos/topics/reference/general/spc-srx5k-spc-4-15-320.html and http://www.juniper.net/documentation/en_US/junos12.1/topics/concept/security-low-latency-firewall-overview.html for more info on SPU

Cyrille