### PR TITLE
NMS-7772: Fix missing import package.

### DIFF
--- a/features/jmx-config-generator-webui/pom.xml
+++ b/features/jmx-config-generator-webui/pom.xml
@@ -32,6 +32,7 @@
                         <Vaadin-Application>org.opennms.features.jmxconfiggenerator.webui.JmxConfigGeneratorApplication</Vaadin-Application>
                         <Vaadin-Alias>/${project.artifactId}</Vaadin-Alias>
                         <Include-Resource>src/main/webapp,{maven-resources}</Include-Resource>
+                        <Import-Package>*;com.vaadin.data.util.converter;</Import-Package>
                     </instructions>
                 </configuration>
             </plugin>


### PR DESCRIPTION
Here the missing fix for NMS-7772.
This will however only fix the "next button exception" and not fix the validation errors.
This is addressed in a different issue and will be fixed later (http://issues.opennms.org/browse/HZN-330).

* JIRA: http://issues.opennms.org/browse/NMS-7772
* Bamboo: http://bamboo.internal.opennms.com:8085/browse/OPENNMS-ONMS78