### PR TITLE
HZN-372: jnxOperatingTable datacollection not correctly made

### DIFF
--- a/opennms-base-assembly/src/main/filtered/etc/datacollection/juniper.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/datacollection/juniper.xml
@@ -12,6 +12,15 @@
       <storageStrategy class="org.opennms.netmgt.collection.support.IndexStorageStrategy"/>
     </resourceType>
 
+    <resourceType name="jnxOperatingTable" label="Juniper general monitoring" resourceLabel="${jnxOpDescr}">
+        <persistenceSelectorStrategy class="org.opennms.netmgt.collection.support.PersistRegexSelectorStrategy">
+            <parameter key="match-expression" value="#jnxOpDescr matches 'Routing Engine'" />
+        </persistenceSelectorStrategy>
+        <storageStrategy class="org.opennms.netmgt.dao.support.SiblingColumnStorageStrategy">
+            <parameter key="sibling-column-name" value="jnxOpDescr"/>
+        </storageStrategy>
+    </resourceType>
+
     <resourceType name="jnxJsSPUMonitoringObjectsTable" label="Juniper SRX SPU Monitoring" resourceLabel="${juniSPUMonNodeDescr}">
       <persistenceSelectorStrategy class="org.opennms.netmgt.collection.support.PersistAllSelectorStrategy"/>
       <storageStrategy class="org.opennms.netmgt.dao.support.SiblingColumnStorageStrategy">
@@ -21,18 +30,14 @@
 
 
       <!-- Juniper MIBs -->
-      <group name="juniper-router" ifType="ignore">
-        <mibObj oid=".1.3.6.1.4.1.2636.3.1.13.1.8.6.1.0"  instance="0" alias="juniperCpuFeb"     type="gauge32" />
-        <mibObj oid=".1.3.6.1.4.1.2636.3.1.13.1.8.7.1.0"  instance="0" alias="juniperCpuFpc0"    type="gauge32" />
-        <mibObj oid=".1.3.6.1.4.1.2636.3.1.13.1.8.7.2.0"  instance="0" alias="juniperCpuFpc1"    type="gauge32" />
-        <mibObj oid=".1.3.6.1.4.1.2636.3.1.13.1.8.9.1.0"  instance="0" alias="juniperCpuRe"      type="gauge32" />
-        <mibObj oid=".1.3.6.1.4.1.2636.3.1.13.1.7.6.1.0"  instance="0" alias="juniperTempFeb"    type="gauge32" />
-        <mibObj oid=".1.3.6.1.4.1.2636.3.1.13.1.7.7.1.0"  instance="0" alias="juniperTempFpc0"   type="gauge32" />
-        <mibObj oid=".1.3.6.1.4.1.2636.3.1.13.1.7.7.2.0"  instance="0" alias="juniperTempFpc1"   type="gauge32" />
-        <mibObj oid=".1.3.6.1.4.1.2636.3.1.13.1.7.9.1.0"  instance="0" alias="juniperTempRe"     type="gauge32" />
-        <mibObj oid=".1.3.6.1.4.1.2636.3.1.13.1.11.6.1.0" instance="0" alias="juniperBufferFeb"  type="gauge32" />
-        <mibObj oid=".1.3.6.1.4.1.2636.3.1.13.1.11.7.1.0" instance="0" alias="juniperBufferFpc0" type="gauge32" />
-        <mibObj oid=".1.3.6.1.4.1.2636.3.1.13.1.11.7.2.0" instance="0" alias="juniperBufferFpc1" type="gauge32" />
+      <group name="juniper-router" ifType="all">
+        <mibObj oid=".1.3.6.1.4.1.2636.3.1.13.1.5"  instance="jnxOperatingTable" alias="jnxOpDescr"     type="string" />
+        <mibObj oid=".1.3.6.1.4.1.2636.3.1.13.1.8"  instance="jnxOperatingTable" alias="jnxOpCpu"       type="gauge32" />
+        <mibObj oid=".1.3.6.1.4.1.2636.3.1.13.1.7"  instance="jnxOperatingTable" alias="jnxOpTemp"      type="gauge32" />
+        <mibObj oid=".1.3.6.1.4.1.2636.3.1.13.1.11" instance="jnxOperatingTable" alias="jnxOpBuff"      type="gauge32" />
+        <mibObj oid=".1.3.6.1.4.1.2636.3.1.13.1.20" instance="jnxOperatingTable" alias="jnxOpLoad1Min"  type="gauge32" />
+        <mibObj oid=".1.3.6.1.4.1.2636.3.1.13.1.21" instance="jnxOperatingTable" alias="jnxOpLoad5Min"  type="gauge32" />
+        <mibObj oid=".1.3.6.1.4.1.2636.3.1.13.1.22" instance="jnxOperatingTable" alias="jnxOpLoad15Min" type="gauge32" />
       </group>
 
       <group name="juniper-erx-router" ifType="ignore">

--- a/opennms-base-assembly/src/main/filtered/etc/datacollection/juniper.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/datacollection/juniper.xml
@@ -14,10 +14,11 @@
 
     <resourceType name="jnxOperatingTable" label="Juniper general monitoring" resourceLabel="${jnxOpDescr}">
         <persistenceSelectorStrategy class="org.opennms.netmgt.collection.support.PersistRegexSelectorStrategy">
-            <parameter key="match-expression" value="#jnxOpDescr matches 'Routing Engine'" />
+            <parameter key="match-expression" value="(#jnxOpDescr matches '^.*Routing Engine.*$')" />
         </persistenceSelectorStrategy>
         <storageStrategy class="org.opennms.netmgt.dao.support.SiblingColumnStorageStrategy">
             <parameter key="sibling-column-name" value="jnxOpDescr"/>
+            <parameter key="replace-all" value="s/\s//" />
         </storageStrategy>
     </resourceType>
 

--- a/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/juniper-graph.properties
+++ b/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/juniper-graph.properties
@@ -8,6 +8,10 @@
 reports=juniper.bufferPoolUtil, \
 juniper.cpu, \
 juniper.temp, \
+juniper.jnxOpTableCPU, \
+juniper.jnxOpTableLoad, \
+juniper.jnxOpTableBuff, \
+juniper.jnxOpTableTemp, \
 juniperj.mem, \
 juniperj.uptime, \
 juniperj.fwddUtil, \
@@ -23,6 +27,108 @@ ive.connections
 ######
 ###### Reports for Juniper devices
 ######
+
+report.juniper.jnxOpTableCPU.name=Juniper CPU usage
+report.juniper.jnxOpTableCPU.columns=jnxOpCpu
+report.juniper.jnxOpTableCPU.type=jnxOperatingTable
+report.juniper.jnxOpTableCPU.propertiesValues=jnxOpDescr
+report.juniper.jnxOpTableCPU.command=--title="Juniper: CPU usage on {jnxOpDescr}" \
+ --vertical-label="percent" \
+ --lower-limit 0 \
+ --upper-limit 105 \
+ DEF:dpercent={rrd1}:jnxOpCpu:AVERAGE \
+ CDEF:dpercent10=0,dpercent,GT,0,dpercent,IF \
+ CDEF:dpercent20=10,dpercent,GT,0,dpercent,IF \
+ CDEF:dpercent30=20,dpercent,GT,0,dpercent,IF \
+ CDEF:dpercent40=30,dpercent,GT,0,dpercent,IF \
+ CDEF:dpercent50=40,dpercent,GT,0,dpercent,IF \
+ CDEF:dpercent60=50,dpercent,GT,0,dpercent,IF \
+ CDEF:dpercent70=60,dpercent,GT,0,dpercent,IF \
+ CDEF:dpercent80=70,dpercent,GT,0,dpercent,IF \
+ CDEF:dpercent90=80,dpercent,GT,0,dpercent,IF \
+ CDEF:dpercent100=90,dpercent,GT,0,dpercent,IF \
+ COMMENT:"\\n" \
+ COMMENT:"CPU usage graph colors\\n" \
+ AREA:dpercent10#5ca53f:" 0-10%" \
+ AREA:dpercent20#75b731:"11-20%" \
+ AREA:dpercent30#90c22f:"21-30%" \
+ AREA:dpercent40#b8d029:"31-40%" \
+ AREA:dpercent50#e4e11e:"41-50%" \
+ COMMENT:"\\n" \
+ AREA:dpercent60#fee610:"51-60%" \
+ AREA:dpercent70#f4bd1b:"61-70%" \
+ AREA:dpercent80#eaa322:"71-80%" \
+ AREA:dpercent90#de6822:"81-90%" \
+ AREA:dpercent100#d94c20:"91-100%" \
+ COMMENT:"\\n" \
+ LINE1:dpercent#46683b:"CPU usage in %" \
+ GPRINT:dpercent:AVERAGE:"Avg \\: %7.3lf%s" \
+ GPRINT:dpercent:MIN:"Min \\: %7.3lf%s" \
+ GPRINT:dpercent:MAX:"Max \\: %7.3lf%s\\n"
+
+report.juniper.jnxOpTableLoad.name=Juniper Load Average
+report.juniper.jnxOpTableLoad.columns=jnxOpLoad1Min, jnxOpLoad5Min, jnxOpLoad15Min
+report.juniper.jnxOpTableLoad.type=jnxOperatingTable
+report.juniper.jnxOpTableLoad.propertiesValues=jnxOpDescr
+report.juniper.jnxOpTableLoad.command=--title="Juniper: Load Average on {jnxOpDescr}" --units-exponent=0 \
+ DEF:avg1={rrd1}:jnxOpLoad1Min:AVERAGE \
+ DEF:minAvg1={rrd1}:jnxOpLoad1Min:MIN \
+ DEF:maxAvg1={rrd1}:jnxOpLoad1Min:MAX \
+ DEF:avg5={rrd2}:jnxOpLoad5Min:AVERAGE \
+ DEF:minAvg5={rrd2}:jnxOpLoad5Min:MIN \
+ DEF:maxAvg5={rrd2}:jnxOpLoad5Min:MAX \
+ DEF:avg15={rrd3}:jnxOpLoad15Min:AVERAGE \
+ DEF:minAvg15={rrd3}:jnxOpLoad15Min:MIN \
+ DEF:maxAvg15={rrd3}:jnxOpLoad15Min:MAX \
+ CDEF:float1=avg1,100,/ \
+ CDEF:minFloat1=minAvg1,100,/ \
+ CDEF:maxFloat1=maxAvg1,100,/ \
+ CDEF:float5=avg5,100,/ \
+ CDEF:minFloat5=minAvg5,100,/ \
+ CDEF:maxFloat5=maxAvg5,100,/ \
+ CDEF:float15=avg15,100,/ \
+ CDEF:minFloat15=minAvg15,100,/ \
+ CDEF:maxFloat15=maxAvg15,100,/ \
+ AREA:float1#babdb6:"1  minute" \
+ GPRINT:float1:AVERAGE:"Avg \\: %10.2lf" \
+ GPRINT:float1:MIN:"Min \\: %10.2lf" \
+ GPRINT:float1:MAX:"Max \\: %10.2lf\\n" \
+ AREA:float5#888a85:"5  minute" \
+ GPRINT:float5:AVERAGE:"Avg \\: %10.2lf" \
+ GPRINT:float5:MIN:"Min \\: %10.2lf" \
+ GPRINT:float5:MAX:"Max \\: %10.2lf\\n" \
+ LINE2:float15#a40000:"15 minute" \
+ GPRINT:float15:AVERAGE:"Avg \\: %10.2lf" \
+ GPRINT:float15:MIN:"Min \\: %10.2lf" \
+ GPRINT:float15:MAX:"Max \\: %10.2lf\\n"
+
+report.juniper.jnxOpTableBuff.name=Juniper Buffer Utilization
+report.juniper.jnxOpTableBuff.columns=jnxOpBuff
+report.juniper.jnxOpTableBuff.type=jnxOperatingTable
+report.juniper.jnxOpTableLoad.propertiesValues=jnxOpDescr
+report.juniper.jnxOpTableBuff.command=--title="Juniper: Buffer Utilization on {jnxOpDescr}" \
+ DEF:val1={rrd1}:jnxOpBuff:AVERAGE \
+ DEF:minVal1={rrd1}:jnxOpBuff:MIN \
+ DEF:maxVal1={rrd1}:jnxOpBuff:MAX \
+ LINE2:val1#0000ff:"Buffer utilization " \
+ GPRINT:val1:AVERAGE:" Avg  \\: %8.2lf %s" \
+ GPRINT:val1:MIN:"Min  \\: %8.2lf %s" \
+ GPRINT:val1:MAX:"Max  \\: %8.2lf %s\\n"
+
+report.juniper.jnxOpTableTemp.name=Juniper Temperature
+report.juniper.jnxOpTableTemp.columns=jnxOpTemp
+report.juniper.jnxOpTableTemp.type=jnxOperatingTable
+report.juniper.jnxOpTableTemp.propertiesValues=jnxOpDescr
+report.juniper.jnxOpTableTemp.command=--title="Juniper Temperature on {jnxOpDescr}" \
+ --vertical-label="Celsius degrees" \
+ DEF:tempavg={rrd1}:jnxOpTemp:AVERAGE \
+ DEF:tempmin={rrd1}:jnxOpTemp:MIN \
+ DEF:tempmax={rrd1}:jnxOpTemp:MAX \
+ AREA:tempavg#fcaf3e \
+ LINE1:tempavg#f57900:"Temperature " \
+ GPRINT:tempavg:AVERAGE:" Avg  \\: %8.2lf %s" \
+ GPRINT:tempmin:MIN:" Min  \\: %8.2lf %s" \
+ GPRINT:tempmax:MAX:" Max  \\: %8.2lf %s\\n"
 
 report.juniper.bufferPoolUtil.name=Buffer Utilization (Juniper)
 report.juniper.bufferPoolUtil.columns=juniperBufferFeb,juniperBufferFpc0


### PR DESCRIPTION
JIRA: http://issues.opennms.org/browse/HZN-372
Bamboo: http://bamboo.internal.opennms.com:8085/browse/OPENNMS-ONMS90

Created a new resourceType named "jnxOperatingTable" for juniper's snmp data collection.
Also, changed the juniper-router group to make use of this resourceType.

Caution, this PR is not working atm. But, I need your help to go further.

1st: 

I wonder if changing the juniper-router group is the correct way to go. Indeed, it will probably break current data collection of this group. So, maybe I should create a brand new group for this collection, and leave both groups active for a moment. Also the jnxOperatingTable is also available for juniper switches, so the name "juniper-router" is a little bit misleading.

2nd: 

The collection simply doesn't work atm. I've traced down the issue to be due to the match-expression not matching. Ie: I keep getting "o.o.n.c.PersistRegexSelectorStrategy: shouldPersist: checking #jnxOpDescr matches 'Routing Engine' ? false" logs. But I have no idea why. 

