### PR TITLE
HZN-372: Fix a typo in juniper.jnxOpTableBuff title

### DIFF
--- a/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/juniper-graph.properties
+++ b/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/juniper-graph.properties
@@ -105,7 +105,7 @@ report.juniper.jnxOpTableLoad.command=--title="Juniper: Load Average on {jnxOpDe
 report.juniper.jnxOpTableBuff.name=Juniper Buffer Utilization
 report.juniper.jnxOpTableBuff.columns=jnxOpBuff
 report.juniper.jnxOpTableBuff.type=jnxOperatingTable
-report.juniper.jnxOpTableLoad.propertiesValues=jnxOpDescr
+report.juniper.jnxOpTableBuff.propertiesValues=jnxOpDescr
 report.juniper.jnxOpTableBuff.command=--title="Juniper: Buffer Utilization on {jnxOpDescr}" \
  DEF:val1={rrd1}:jnxOpBuff:AVERAGE \
  DEF:minVal1={rrd1}:jnxOpBuff:MIN \


### PR DESCRIPTION
because of a typo, report.juniper.jnxOpTableBuff.propertiesValues wasn't correctly set, therefore variable {jnxOpDescr} in juniper.jnxOpTableBuff title wasn't corretly resolved.