### PR TITLE
High Speed utilization graph should use ifHighSpeed instead of ifSpeed

### DIFF
--- a/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/mib2-graph.properties
+++ b/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/mib2-graph.properties
@@ -623,7 +623,7 @@ report.mib2.HCtraffic-inout.name=InOut Traffic (High Speed)
 report.mib2.HCtraffic-inout.suppress=mib2.traffic-inout
 report.mib2.HCtraffic-inout.columns=ifHCInOctets,ifHCOutOctets
 report.mib2.HCtraffic-inout.type=interfaceSnmp
-report.mib2.HCtraffic-inout.propertiesValues=ifSpeed
+report.mib2.HCtraffic-inout.propertiesValues=ifHighSpeed
 report.mib2.HCtraffic-inout.command=--title="In/Out Traffic Utilization (High Speed)" \
  --vertical-label="Percent utilization" \
  DEF:octIn={rrd1}:ifHCInOctets:AVERAGE \
@@ -632,12 +632,12 @@ report.mib2.HCtraffic-inout.command=--title="In/Out Traffic Utilization (High Sp
  DEF:octOut={rrd2}:ifHCOutOctets:AVERAGE \
  DEF:minOctOut={rrd2}:ifHCOutOctets:MIN \
  DEF:maxOctOut={rrd2}:ifHCOutOctets:MAX \
- CDEF:percentIn=octIn,8,*,{ifSpeed},/,100,* \
- CDEF:minPercentIn=minOctIn,8,*,{ifSpeed},/,100,* \
- CDEF:maxPercentIn=maxOctIn,8,*,{ifSpeed},/,100,* \
- CDEF:percentOut=octOut,8,*,{ifSpeed},/,100,* \
- CDEF:minPercentOut=minOctOut,8,*,{ifSpeed},/,100,* \
- CDEF:maxPercentOut=maxOctOut,8,*,{ifSpeed},/,100,* \
+ CDEF:percentIn=octIn,8,*,1000000,/,{ifHighSpeed},/,100,* \
+ CDEF:minPercentIn=minOctIn,8,*,1000000,/,{ifHighSpeed},/,100,* \
+ CDEF:maxPercentIn=maxOctIn,8,*,1000000,/,{ifHighSpeed},/,100,* \
+ CDEF:percentOut=octOut,8,*,1000000,/,{ifHighSpeed},/,100,* \
+ CDEF:minPercentOut=minOctOut,8,*,1000000,/,{ifHighSpeed},/,100,* \
+ CDEF:maxPercentOut=maxOctOut,8,*,1000000,/,{ifHighSpeed},/,100,* \
  CDEF:percentOutNeg=0,percentOut,- \
  AREA:percentIn#73d216 \
  LINE1:percentIn#4e9a06:"In " \


### PR DESCRIPTION
The graph uses ifSpeed and give incorrect results when the interface speed is above 4Gbps.

This PR switches to ifHighSpeed.