### PR TITLE
HZN-347: Expose Newts metrics via JMX

### DIFF
--- a/features/newts/src/main/resources/META-INF/opennms/applicationContext-newts.xml
+++ b/features/newts/src/main/resources/META-INF/opennms/applicationContext-newts.xml
@@ -72,6 +72,20 @@
 
   <bean id="metricRegistry" class="com.codahale.metrics.MetricRegistry" />
 
+  <bean id="metricRegistryJmxReporterBuilder" class="com.codahale.metrics.JmxReporter" factory-method="forRegistry">
+      <constructor-arg ref="metricRegistry"/>
+  </bean>
+
+  <bean id="metricRegistryDomainedJmxReporterBuilder" factory-bean="metricRegistryJmxReporterBuilder" factory-method="inDomain">
+      <constructor-arg value="org.opennms.newts"/>
+  </bean>
+
+  <bean id="metricRegistryJmxReporter"
+        factory-bean="metricRegistryDomainedJmxReporterBuilder"
+        factory-method="build"
+        init-method="start"
+        destroy-method="stop" />
+
   <bean id="cassandraSession" class="org.opennms.newts.cassandra.CassandraSession" depends-on="cassandra.port" />
 
   <bean id="cassandraSearcher" class="org.opennms.newts.cassandra.search.CassandraSearcher" />


### PR DESCRIPTION
Added a metric reporter which exposes all newts specific metrics via JMX.

Issue: http://issues.opennms.org/browse/HZN-347
Bamboo: http://bamboo.internal.opennms.com:8085/browse/OPENNMS-ONMS127