### PR TITLE
HZN-185: Document Installation on Debian-based system

### DIFF
--- a/opennms-doc/guide-install/src/asciidoc/index.adoc
+++ b/opennms-doc/guide-install/src/asciidoc/index.adoc
@@ -4,13 +4,16 @@
 :lang: en
 :icons: font
 :toc: left
-:toclevels: 8
+:toclevels: 3
 :numbered:
 
+[[gi]]
 = Installation Guide
-:author: Copyright (c) 2014 The OpenNMS Group, Inc.
-:revnumber: OpenNMS v{opennms-version}
+:author: Copyright (c) 2015 The OpenNMS Group, Inc.
+:revnumber: OpenNMS {opennms-version}
 :revdate: {last-update-label} {docdatetime}
 :version-label!:
 
-// include::text/myFile.adoc[]
+// Installation Guide for OpenNMS
+include::text/opennms/introduction.adoc[]
+include::text/opennms/debian.adoc[]

--- a/opennms-doc/guide-install/src/asciidoc/text/opennms/debian.adoc
+++ b/opennms-doc/guide-install/src/asciidoc/text/opennms/debian.adoc
@@ -8,7 +8,7 @@
 This section describes how to install the _OpenNMS_ platform on _Ubuntu 14.04 LTS_.
 The setup process is described in the following steps:
 
-. Install OpenNMS YUM repository server with GPG key to verify packages
+. Install OpenNMS apt repository server with GPG key to verify packages
 . Installation of the _opennms_ meta package which handles all dependencies
 . Initialize _PostgreSQL_ database and configure access
 . Initialize _OpenNMS_ and first start of the application

--- a/opennms-doc/guide-install/src/asciidoc/text/opennms/debian.adoc
+++ b/opennms-doc/guide-install/src/asciidoc/text/opennms/debian.adoc
@@ -38,7 +38,7 @@ apt-get update
 [[gi-install-opennms-deb-package]]
 ==== Install OpenNMS package
 
-.Installation of the full application including all dependencies like _PostgreSQL_ or _Java_
+.Installation of the full application including all dependencies like _PostgreSQL_ and _Java_
 [source, shell]
 ----
 apt-get install -y opennms

--- a/opennms-doc/guide-install/src/asciidoc/text/opennms/debian.adoc
+++ b/opennms-doc/guide-install/src/asciidoc/text/opennms/debian.adoc
@@ -17,20 +17,20 @@ The setup process is described in the following steps:
 ==== Setup OpenNMS Debian repository
 
 .Content of the new _OpenNMS Debian_ repository file `/etc/apt/sources.list.d/opennms.list`
-[source, bash]
+[source, shell]
 ----
 deb http://debian.opennms.org stable main
 deb-src http://debian.opennms.org stable main
 ----
 
 .Install _GPG_ key to verify _DEB_ packages
-[source, bash]
+[source, shell]
 ----
 wget -O - http://debian.opennms.org/OPENNMS-GPG-KEY | apt-key add -
 ----
 
 .Update apt repository cache
-[source, bash]
+[source, shell]
 ----
 apt-get update
 ----
@@ -71,6 +71,7 @@ With the successful installed packages the _OpenNMS_ platform is installed in th
    ├── logs -> /var/log/opennms
    ├── share -> /var/lib/opennms
    └── system
+----
 
 [[gi-install-opennms-deb-prepare-pg]]
 ==== Prepare PostgreSQL

--- a/opennms-doc/guide-install/src/asciidoc/text/opennms/debian.adoc
+++ b/opennms-doc/guide-install/src/asciidoc/text/opennms/debian.adoc
@@ -1,0 +1,151 @@
+
+// Allow GitHub image rendering
+:imagesdir: ../../images
+
+[[gi-install-opennms-debian]]
+=== Install on Debian-based systems
+
+This section describes how to install the _OpenNMS_ platform on _Ubuntu 14.04 LTS_.
+The setup process is described in the following steps:
+
+. Install OpenNMS YUM repository server with GPG key to verify packages
+. Installation of the _opennms_ meta package which handles all dependencies
+. Initialize _PostgreSQL_ database and configure access
+. Initialize _OpenNMS_ and first start of the application
+
+[[gi-install-opennms-deb-repo]]
+==== Setup OpenNMS Debian repository
+
+.Content of the new _OpenNMS Debian_ repository file `/etc/apt/sources.list.d/opennms.list`
+[source, bash]
+----
+deb http://debian.opennms.org stable main
+deb-src http://debian.opennms.org stable main
+----
+
+.Install _GPG_ key to verify _DEB_ packages
+[source, bash]
+----
+wget -O - http://debian.opennms.org/OPENNMS-GPG-KEY | apt-key add -
+----
+
+.Update apt repository cache
+[source, bash]
+----
+apt-get update
+----
+
+[[gi-install-opennms-deb-package]]
+==== Install OpenNMS package
+
+.Installation of the full application including all dependencies like _PostgreSQL_ or _Java_
+[source, shell]
+----
+apt-get install -y opennms
+----
+
+The following packages will be automatically installed:
+
+* _opennms_: The platform meta package which handles all dependencies from _OpenNMS_ repository.
+* _jicmp6_ and _jicmp_: _Java_ bridge to allow sending _ICMP messages_ from _OpenNMS_ repository.
+* _opennms-core_: _OpenNMS_ core services, e.g. _Provisiond_, _Pollerd_ and _Collectd_ from _OpenNMS_ repository.
+* _opennms-webapp-jetty_: _OpenNMS_ web application from _OpenNMS_ repository
+* _jdk1.8_: _Oracle Java 8_ environment from _OpenNMS_ respository
+* _postgresql_: _PostgreSQL_ database server from distribution repository
+* _postgresql-libs_: _PostgreSQL_ database from distribution repository
+
+With the successful installed packages the _OpenNMS_ platform is installed in the following directory structure:
+
+[source, shell]
+----
+[root@localhost /usr/share/opennms]# tree -L 2
+.
+└── opennms
+   ├── bin
+   ├── data
+   ├── deploy
+   ├── etc -> /etc/opennms
+   ├── instances
+   ├── jetty-webapps
+   ├── lib -> ../java/opennms
+   ├── logs -> /var/log/opennms
+   ├── share -> /var/lib/opennms
+   └── system
+
+[[gi-install-opennms-deb-prepare-pg]]
+==== Prepare PostgreSQL
+
+The _Debian_ package installs also _PostgreSQL_ database and is already initialized and added in the runlevel configuration.
+It is only necessary to start the _PostgreSQL_ database without a restart.
+
+[source, shell]
+----
+service postgresql start
+----
+
+The next step is creating an _opennms_ database user with password and configure the authentication method.
+
+.Create database user _opennms_ and a database _opennms_ with the owner of the created user.
+[source, shell]
+----
+su - postgres
+createuser -P opennms
+createdb -O opennms opennms
+----
+
+NOTE: It is not necessary to change the authentication method in `pg_hba.conf`, it is by default set to `md5` for localhost connections.
+
+.Configure the authentication credentials in the _OpenNMS_ data configuration.
+[source, shell]
+----
+vi ${OPENNMS_HOME}/etc/opennms-datasource.xml
+----
+
+.Add the username and password in *both* sections
+[source, xml]
+----
+<jdbc-data-source name="opennms"
+                    database-name="opennms"
+                    class-name="org.postgresql.Driver"
+                    url="jdbc:postgresql://localhost:5432/opennms"
+                    user-name="** YOUR-OPENNMS-USERNAME **"
+                    password="** YOUR-OPENNMS-PASSWORD **" />
+
+<jdbc-data-source name="opennms-admin"
+                    database-name="template1"
+                    class-name="org.postgresql.Driver"
+                    url="jdbc:postgresql://localhost:5432/template1"
+                    user-name="** YOUR-OPENNMS-USERNAME **"
+                    password="** YOUR-OPENNMS-PASSWORD **" />
+----
+
+[[gi-install-opennms-deb-init]]
+==== Initialize OpenNMS
+
+_OpenNMS_ is now configured to access the database.
+It is required to set the _Java_ environment running _OpenNMS_ and initialize the database schema.
+
+.Set _Java_ environment
+[source, shell]
+----
+${OPENNMS_HOME}/bin/runjava -s
+----
+
+.Initialize database and detect path to libraries
+[source, shell]
+----
+${OPENNMS_HOME}/bin/install -dis
+----
+
+NOTE: It is not necessary to add _OpenNMS_ to the run level manually, it is automatically added after setup.
+
+.Start _OpenNMS_ without restarting the system
+[source, shell]
+----
+service opennms start
+----
+
+You can now access the web application on http://<ip-or-fqdn-of-your-server>:8980/opennms.
+The default login user is _admin_ and the password is initialized to _admin_.
+
+IMPORTANT: Change the default admin password to a secure password immediately.

--- a/opennms-doc/guide-install/src/asciidoc/text/opennms/debian.adoc
+++ b/opennms-doc/guide-install/src/asciidoc/text/opennms/debian.adoc
@@ -16,7 +16,7 @@ The setup process is described in the following steps:
 [[gi-install-opennms-deb-repo]]
 ==== Setup OpenNMS Debian repository
 
-.Content of the new _OpenNMS Debian_ repository file `/etc/apt/sources.list.d/opennms.list`
+.Create a new file `/etc/apt/sources.list.d/opennms.list` for the _OpenNMS Debian_ repository.
 [source, shell]
 ----
 deb http://debian.opennms.org stable main

--- a/opennms-doc/guide-install/src/asciidoc/text/opennms/debian.adoc
+++ b/opennms-doc/guide-install/src/asciidoc/text/opennms/debian.adoc
@@ -109,16 +109,21 @@ vi ${OPENNMS_HOME}/etc/opennms-datasource.xml
                     database-name="opennms"
                     class-name="org.postgresql.Driver"
                     url="jdbc:postgresql://localhost:5432/opennms"
-                    user-name="** YOUR-OPENNMS-USERNAME **"
-                    password="** YOUR-OPENNMS-PASSWORD **" />
+                    user-name="** YOUR-OPENNMS-USERNAME **"<1>
+                    password="** YOUR-OPENNMS-PASSWORD **" /><2>
 
 <jdbc-data-source name="opennms-admin"
                     database-name="template1"
                     class-name="org.postgresql.Driver"
                     url="jdbc:postgresql://localhost:5432/template1"
-                    user-name="** YOUR-OPENNMS-USERNAME **"
-                    password="** YOUR-OPENNMS-PASSWORD **" />
+                    user-name="** YOUR-OPENNMS-USERNAME **"<3>
+                    password="** YOUR-OPENNMS-PASSWORD **" /><4>
 ----
+
+<1> Set the user name to access the _OpenNMS_ database table
+<2> Set the password to access the _OpenNMS_ database table
+<3> Set the user name for administrative changes of the _OpenNMS_ database table
+<4> Set the password for administrative changes of the _OpenNMS_ database table
 
 [[gi-install-opennms-deb-init]]
 ==== Initialize OpenNMS

--- a/opennms-doc/guide-install/src/asciidoc/text/opennms/debian.adoc
+++ b/opennms-doc/guide-install/src/asciidoc/text/opennms/debian.adoc
@@ -16,14 +16,16 @@ The setup process is described in the following steps:
 [[gi-install-opennms-deb-repo]]
 ==== Setup OpenNMS Debian repository
 
-.Create a new file `/etc/apt/sources.list.d/opennms.list` for the _OpenNMS Debian_ repository.
+_OpenNMS_ can be installed with Installation of stable repository and GPG key
+
+.Installation of _OpenNMS Debian_ repository
 [source, shell]
 ----
 deb http://debian.opennms.org stable main
 deb-src http://debian.opennms.org stable main
 ----
 
-.Install _GPG_ key to verify _DEB_ packages
+.Installation of repository GPG key
 [source, shell]
 ----
 wget -O - http://debian.opennms.org/OPENNMS-GPG-KEY | apt-key add -
@@ -38,7 +40,7 @@ apt-get update
 [[gi-install-opennms-deb-package]]
 ==== Install OpenNMS package
 
-.Installation of the full application including all dependencies like _PostgreSQL_ and _Java_
+.Installation of the full application with all dependencies like PostgreSQL and Java
 [source, shell]
 ----
 apt-get install -y opennms
@@ -79,6 +81,7 @@ With the successful installed packages the _OpenNMS_ platform is installed in th
 The _Debian_ package installs also _PostgreSQL_ database and is already initialized and added in the runlevel configuration.
 It is only necessary to start the _PostgreSQL_ database without a restart.
 
+.Startup PostgreSQL database
 [source, shell]
 ----
 service postgresql start
@@ -86,7 +89,7 @@ service postgresql start
 
 The next step is creating an _opennms_ database user with password and configure the authentication method.
 
-.Create database user _opennms_ and a database _opennms_ with the owner of the created user.
+.Accounting and database management for _OpenNMS_
 [source, shell]
 ----
 su - postgres
@@ -96,13 +99,12 @@ createdb -O opennms opennms
 
 NOTE: It is not necessary to change the authentication method in `pg_hba.conf`, it is by default set to `md5` for localhost connections.
 
-.Configure the authentication credentials in the _OpenNMS_ data configuration.
 [source, shell]
 ----
 vi ${OPENNMS_HOME}/etc/opennms-datasource.xml
 ----
 
-.Add the username and password in *both* sections
+.Configuration for database authentication in _OpenNMS_
 [source, xml]
 ----
 <jdbc-data-source name="opennms"
@@ -131,13 +133,13 @@ vi ${OPENNMS_HOME}/etc/opennms-datasource.xml
 _OpenNMS_ is now configured to access the database.
 It is required to set the _Java_ environment running _OpenNMS_ and initialize the database schema.
 
-.Set _Java_ environment
+.Configuration of _Java_ environment for _OpenNMS_ 
 [source, shell]
 ----
 ${OPENNMS_HOME}/bin/runjava -s
 ----
 
-.Initialize database and detect path to libraries
+.Initialization of database and system libraries
 [source, shell]
 ----
 ${OPENNMS_HOME}/bin/install -dis
@@ -145,7 +147,7 @@ ${OPENNMS_HOME}/bin/install -dis
 
 NOTE: It is not necessary to add _OpenNMS_ to the run level manually, it is automatically added after setup.
 
-.Start _OpenNMS_ without restarting the system
+.Startup _OpenNMS_
 [source, shell]
 ----
 service opennms start

--- a/opennms-doc/guide-install/src/asciidoc/text/opennms/debian.adoc
+++ b/opennms-doc/guide-install/src/asciidoc/text/opennms/debian.adoc
@@ -8,7 +8,7 @@
 This section describes how to install the _OpenNMS_ platform on _Ubuntu 14.04 LTS_.
 The setup process is described in the following steps:
 
-. Install OpenNMS apt repository server with GPG key to verify packages
+. Install _OpenNMS_ apt repository server with GPG key to verify packages
 . Installation of the _opennms_ meta package which handles all dependencies
 . Initialize _PostgreSQL_ database and configure access
 . Initialize _OpenNMS_ and first start of the application

--- a/opennms-doc/guide-install/src/asciidoc/text/opennms/introduction.adoc
+++ b/opennms-doc/guide-install/src/asciidoc/text/opennms/introduction.adoc
@@ -69,8 +69,8 @@ gpgcheck=1
 gpgkey=file:///etc/yum.repos.d/OPENNMS-GPG-KEY
 ----
 
-<1> Change description in this example from `stable` to `snapshot`
-<2> Change the _URL_ to use _RPM_ packages in subdirectory `snapshot` instead of `stable`
+<1> Changed description in this example from `stable` to `snapshot`
+<2> Changed the _URL_ to use _RPM_ packages in subdirectory `snapshot` instead of `stable`
 
 Install _OpenNMS_ with _YUM_ following the normal installation procedure.
 
@@ -88,6 +88,6 @@ deb http://debian.opennms.eu snapshot main <1>
 deb-src http://debian.opennms.eu snapshot main <1>
 ----
 
-<1> Change repository path in this example from `stable` to `snapshot`
+<1> Changed repository path in this example from `stable` to `snapshot`
 
 Run `apt-get update`and install _OpenNMS_ with _apt_ following the normal installation procedure.

--- a/opennms-doc/guide-install/src/asciidoc/text/opennms/introduction.adoc
+++ b/opennms-doc/guide-install/src/asciidoc/text/opennms/introduction.adoc
@@ -51,7 +51,7 @@ To install a different release the repository files have to be installed and man
 
 ==== Specific Release on RHEL-based system
 
-.RHEL-based system change the repository base URL in the file
+.Change the directory in the base URL to select a release to install
 [source, shell]
 ----
 [opennms-stable-common]

--- a/opennms-doc/guide-install/src/asciidoc/text/opennms/introduction.adoc
+++ b/opennms-doc/guide-install/src/asciidoc/text/opennms/introduction.adoc
@@ -1,0 +1,93 @@
+
+// Allow GitHub image rendering
+:imagesdir: ../../images
+
+[[gi-basic-install-opennms]]
+== Basic Installation of OpenNMS
+
+The _OpenNMS_ platform can be installed in several ways.
+This guide describes the installation of the platform on _RHEL-_, _Debian-_ and _Microsoft Windows_ based operation systems.
+Installable pre-compiled software packages are provided through _RPM_ and _Debian_ repository servers.
+Running _OpenNMS_ requires the following components:
+
+* Internet access to download and verify installation packages from public repository server
+* Installed <<gi-install-oracle-java, Oracle Java 8>> environment
+* PostgreSQL 9.1+ data base
+* Set link to section which describes to install with RRDTool.
+  Optional link:http://oss.oetiker.ch/rrdtool/[RRDtool] to persist long term performance data
+
+NOTE: _OpenJDK 8_ can be used, but for production and critical environment _Oracle Java 8_ is recommended.
+
+NOTE: `${OPENNMS_HOME}` is referred to the path _OpenNMS_ is installed to.
+      On _RHEL-based_ systems it is `/opt/opennms` on _Debian-based_ systems it is `/usr/share/opennms`.
+      The environment in _Microsoft Windows_ can refer to `C:\Program Files\opennms`
+
+With an _opennms_ meta package all dependencies for the components mentioned above are maintained.
+The following sections describe to install _OpenNMS_ on a single system.
+Dependencies for _Java_ and the _PostgreSQL_ data base are maintained with the _opennms_ meta installation package.
+
+[[gi-install-opennms-repo-releases]]
+=== Repositories for Releases
+
+Installation packages are available for different releases of _OpenNMS_.
+The configuration of the repository decides which _OpenNMS_ release will be installed.
+
+The following release are available to be installed
+
+.Names used in repositories to install different _OpenNMS_ releases.
+[options="header, autowidth"]
+|===
+| Release    | Description
+| `stable`   | Latest stable release
+| `testing`  | Release candidate for next stable
+| `snapshot` | Latest successful develop build
+| `branches/${BRANCH-NAME}` | Install from a specific branch name, e.g. `branches/features-newts` installs the repository for the _Newts_ development branch.
+                              Branches can be found in http://yum.opennms.org/branches/ or http://debian.opennms.org/dists/branches/
+| `branches/${RELEASE}`     | Install a specific release, e.g. `branches/release-14.0.3`.
+                              This release branches are also found in http://yum.opennms.org/branches/ or http://debian.opennms.org/dists/branches/
+|===
+
+To install a different release the repository files have to be installed and manually modified.
+
+==== Specific Release on RHEL-based system
+
+.RHEL-based system change the repository base URL in the file
+[source, shell]
+----
+[opennms-stable-common]
+name=RPMs Common to All OpenNMS Architectures (snapshot)<1>
+baseurl=http://yum.opennms.org/snapshot/common<2>
+failovermethod=roundrobin
+gpgcheck=1
+gpgkey=file:///etc/yum.repos.d/OPENNMS-GPG-KEY
+
+[opennms-stable-rhel7]
+name=RedHat Enterprise Linux 7.x and CentOS 7.x (snapshot)<1>
+baseurl=http://yum.opennms.org/snapshot/rhel7<2>
+failovermethod=roundrobin
+gpgcheck=1
+gpgkey=file:///etc/yum.repos.d/OPENNMS-GPG-KEY
+----
+
+<1> Change description in this example from `stable` to `snapshot`
+<2> Change the _URL_ to use _RPM_ packages in subdirectory `snapshot` instead of `stable`
+
+Install _OpenNMS_ with _YUM_ following the normal installation procedure.
+
+==== Specific Release on Debian-based system
+
+.Change the _Debian_ repository file
+[source, shell]
+----
+vi /etc/apt/sources.list.d/opennms.list
+----
+
+[source, shell]
+----
+deb http://debian.opennms.eu snapshot main <1>
+deb-src http://debian.opennms.eu snapshot main <1>
+----
+
+<1> Change repository path in this example from `stable` to `snapshot`
+
+Run `apt-get update`and install _OpenNMS_ with _apt_ following the normal installation procedure.

--- a/opennms-doc/guide-install/src/asciidoc/text/opennms/introduction.adoc
+++ b/opennms-doc/guide-install/src/asciidoc/text/opennms/introduction.adoc
@@ -34,7 +34,7 @@ The configuration of the repository decides which _OpenNMS_ release will be inst
 
 The following release are available to be installed
 
-.Names used in repositories to install different _OpenNMS_ releases.
+._OpenNMS_ release name convention
 [options="header, autowidth"]
 |===
 | Release    | Description
@@ -51,37 +51,33 @@ To install a different release the repository files have to be installed and man
 
 ==== Specific Release on RHEL-based system
 
-.Change the directory in the base URL to select a release to install
+.Installation of release specific repositories
 [source, shell]
 ----
-[opennms-stable-common]
-name=RPMs Common to All OpenNMS Architectures (snapshot)<1>
-baseurl=http://yum.opennms.org/snapshot/common<2>
-failovermethod=roundrobin
-gpgcheck=1
-gpgkey=file:///etc/yum.repos.d/OPENNMS-GPG-KEY
-
-[opennms-stable-rhel7]
-name=RedHat Enterprise Linux 7.x and CentOS 7.x (snapshot)<1>
-baseurl=http://yum.opennms.org/snapshot/rhel7<2>
-failovermethod=roundrobin
-gpgcheck=1
-gpgkey=file:///etc/yum.repos.d/OPENNMS-GPG-KEY
+rpm -Uvh http://yum.opennms.org/repofiles/opennms-repo-${RELEASE}-rhel7.noarch.rpm<1>
+rpm --import http://yum.opennms.org/OPENNMS-GPG-KEY
 ----
 
-<1> Changed description in this example from `stable` to `snapshot`
-<2> Changed the _URL_ to use _RPM_ packages in subdirectory `snapshot` instead of `stable`
+<1> Replace `${RELEASE}` with a release name like `testing` or `snapshot`.
 
 Install _OpenNMS_ with _YUM_ following the normal installation procedure.
 
+.Installation of the full _OpenNMS_ application with all dependencies
+[source, shell]
+----
+yum install opennms
+----
+
+TIP: Verify the release of _OpenNMS_ packages with `yum info opennms`.
+
 ==== Specific Release on Debian-based system
 
-.Change the _Debian_ repository file
 [source, shell]
 ----
 vi /etc/apt/sources.list.d/opennms.list
 ----
 
+.Package repository configuration for RHEL-based systems
 [source, shell]
 ----
 deb http://debian.opennms.eu snapshot main <1>
@@ -91,3 +87,5 @@ deb-src http://debian.opennms.eu snapshot main <1>
 <1> Changed repository path in this example from `stable` to `snapshot`
 
 Run `apt-get update`and install _OpenNMS_ with _apt_ following the normal installation procedure.
+
+TIP: Verify the release of _OpenNMS_ packages with `apt-cache show opennms`.

--- a/opennms-doc/guide-install/src/asciidoc/text/placeholder.adoc
+++ b/opennms-doc/guide-install/src/asciidoc/text/placeholder.adoc
@@ -1,1 +1,0 @@
-placeholder for git


### PR DESCRIPTION
Create installation description to install OpenNMS on a Debian based system.
The setup describes the installation with the opennms meta package which handles
all dependencies like JICMP, PostgreSQL and Oracle Java.

Created generic introduction about the overall installation workflow and how
different releases can be installed.

JIRA: http://issues.opennms.org/browse/HZN-185
Bamboo: http://bamboo.internal.opennms.com:8085/browse/OPENNMS-ONMS119/latest