### PR TITLE
HZN-474: Newts attributes RRDtool and JRobin compatible

### DIFF
--- a/opennms-base-assembly/src/main/filtered/etc/jmx-datacollection-config.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/jmx-datacollection-config.xml
@@ -315,307 +315,307 @@
             <!-- Clients -->
             <mbean name="org.apache.cassandra.metrics.Client"
                    objectname="org.apache.cassandra.metrics:type=Client,name=connectedNativeClients">
-                <attrib name="Value" alias="Client.connectedNativeClients" type="gauge"/>
+                <attrib name="Value" alias="clntConNativeClnts" type="gauge"/>
             </mbean>
             <mbean name="org.apache.cassandra.metrics.Client"
                    objectname="org.apache.cassandra.metrics:type=Client,name=connectedThriftClients">
-                <attrib name="Value" alias="Client.connectedThriftClients" type="gauge"/>
+                <attrib name="Value" alias="clntConThriftClnts" type="gauge"/>
             </mbean>
 
             <!-- Compaction -->
             <mbean name="org.apache.cassandra.metrics.Compaction"
                    objectname="org.apache.cassandra.metrics:type=Compaction,name=BytesCompacted">
-                <attrib name="Count" alias="Compaction.BytesCompacted" type="counter"/>
+                <attrib name="Count" alias="cpctBytesCompacted" type="counter"/>
             </mbean>
             <mbean name="org.apache.cassandra.metrics.Compaction"
                    objectname="org.apache.cassandra.metrics:type=Compaction,name=CompletedTasks">
-                <attrib name="Value" alias="Compaction.CompletedTasks" type="counter"/>
+                <attrib name="Value" alias="cpctCompletedTasks" type="counter"/>
             </mbean>
             <mbean name="org.apache.cassandra.metrics.Compaction"
                    objectname="org.apache.cassandra.metrics:type=Compaction,name=PendingTasks">
-                <attrib name="Value" alias="Compaction.PendingTasks" type="gauge"/>
+                <attrib name="Value" alias="cpctPendingTasks" type="gauge"/>
             </mbean>
 
             <!-- Dropped Messages -->
             <mbean name="org.apache.cassandra.metrics.DroppedMessage"
                    objectname="org.apache.cassandra.metrics:type=DroppedMessage,scope=BINARY,name=Dropped">
-                <attrib name="Count" alias="DroppedMessage.BINARY.Dropped" type="gauge"/>
+                <attrib name="Count" alias="drpdMsgBinary" type="gauge"/>
             </mbean>
             <mbean name="org.apache.cassandra.metrics.DroppedMessage"
                    objectname="org.apache.cassandra.metrics:type=DroppedMessage,scope=READ,name=Dropped">
-                <attrib name="Count" alias="DroppedMessage.READ.Dropped" type="gauge"/>
+                <attrib name="Count" alias="drpdMsgRead" type="gauge"/>
             </mbean>
             <mbean name="org.apache.cassandra.metrics.DroppedMessage"
                    objectname="org.apache.cassandra.metrics:type=DroppedMessage,scope=READ_REPAIR,name=Dropped">
-                <attrib name="Count" alias="DroppedMessage.READ_REPAIR.Dropped" type="gauge"/>
+                <attrib name="Count" alias="drpdMsgReadRepair" type="gauge"/>
             </mbean>
             <mbean name="org.apache.cassandra.metrics.DroppedMessage"
                    objectname="org.apache.cassandra.metrics:type=DroppedMessage,scope=REQUEST_RESPONSE,name=Dropped">
-                <attrib name="Count" alias="DroppedMessage.REQUEST_RESPONSE.Dropped" type="gauge"/>
+                <attrib name="Count" alias="drpdMsgReqResp" type="gauge"/>
             </mbean>
             <mbean name="org.apache.cassandra.metrics.DroppedMessage"
                    objectname="org.apache.cassandra.metrics:type=DroppedMessage,scope=RANGE_SLICE,name=Dropped">
-                <attrib name="Count" alias="DroppedMessage.RANGE_SLICE.Dropped" type="gauge"/>
+                <attrib name="Count" alias="drpdMsgRangeSlice" type="gauge"/>
             </mbean>
             <mbean name="org.apache.cassandra.metrics.DroppedMessage"
                    objectname="org.apache.cassandra.metrics:type=DroppedMessage,scope=_TRACE,name=Dropped">
-                <attrib name="Count" alias="DroppedMessage.TRACE.Dropped" type="gauge"/>
+                <attrib name="Count" alias="drpdMsgTrace" type="gauge"/>
             </mbean>
             <mbean name="org.apache.cassandra.metrics.DroppedMessage"
                    objectname="org.apache.cassandra.metrics:type=DroppedMessage,scope=COUNTER_MUTATION,name=Dropped">
-                <attrib name="Count" alias="DroppedMessage.COUNTER_MUTATION.Dropped" type="gauge"/>
+                <attrib name="Count" alias="drpdMsgCntrMutation" type="gauge"/>
             </mbean>
             <mbean name="org.apache.cassandra.metrics.DroppedMessage"
                    objectname="org.apache.cassandra.metrics:type=DroppedMessage,scope=MUTATION,name=Dropped">
-                <attrib name="Count" alias="DroppedMessage.MUTATION.Dropped" type="gauge"/>
+                <attrib name="Count" alias="drpdMsgMutation" type="gauge"/>
             </mbean>
             <mbean name="org.apache.cassandra.metrics.DroppedMessage"
                    objectname="org.apache.cassandra.metrics:type=DroppedMessage,scope=PAGED_RANGE,name=Dropped">
-                <attrib name="Count" alias="DroppedMessage.PAGED_RANGE.Dropped" type="gauge"/>
+                <attrib name="Count" alias="drpdMsgPagedRange" type="gauge"/>
             </mbean>
 
             <!-- Storage -->
             <mbean name="org.apache.cassandra.metrics.Storage"
                    objectname="org.apache.cassandra.metrics:type=Storage,name=Load">
-                <attrib name="Count" alias="Storage.Load" type="counter"/>
+                <attrib name="Count" alias="strgLoad" type="counter"/>
             </mbean>
             <mbean name="org.apache.cassandra.metrics.Storage"
                    objectname="org.apache.cassandra.metrics:type=Storage,name=Exceptions">
-                <attrib name="Count" alias="Storage.Exceptions" type="counter"/>
+                <attrib name="Count" alias="strgExceptions" type="counter"/>
             </mbean>
             <mbean name="org.apache.cassandra.metrics.Storage"
                    objectname="org.apache.cassandra.metrics:type=Storage,name=TotalHints">
-                <attrib name="Count" alias="Storage.TotalHints" type="counter"/>
+                <attrib name="Count" alias="strgTotalHints" type="counter"/>
             </mbean>
 
             <!-- ThreadPools :: MemtableFlushWriter -->
             <mbean name="org.apache.cassandra.metrics.ThreadPools"
                    objectname="org.apache.cassandra.metrics:type=ThreadPools,path=internal,scope=MemtableFlushWriter,name=ActiveTasks">
-                 <attrib name="Value" alias="ThreadPools.internal.MemtableFlushWriter.ActiveTasks" type="gauge"/>
+                 <attrib name="Value" alias="tpIntMemTblFlsWrAt" type="gauge"/>
             </mbean>
             <mbean name="org.apache.cassandra.metrics.ThreadPools"
                    objectname="org.apache.cassandra.metrics:type=ThreadPools,path=internal,scope=MemtableFlushWriter,name=CurrentlyBlockedTasks">
-                <attrib name="Count" alias="ThreadPools.internal.MemtableFlushWriter.CurrentlyBlockedTasks" type="counter"/>
+                <attrib name="Count" alias="tpIntMemTblFlsWrCbt" type="counter"/>
             </mbean>
             <mbean name="org.apache.cassandra.metrics.ThreadPools"
                    objectname="org.apache.cassandra.metrics:type=ThreadPools,path=internal,scope=MemtableFlushWriter,name=PendingTasks">
-                 <attrib name="Value" alias="ThreadPools.internal.MemtableFlushWriter.CurrentlyBlockedTasks" type="gauge"/>
+                 <attrib name="Value" alias="tpIntMemTblFlsWrPt" type="gauge"/>
             </mbean>
             <mbean name="org.apache.cassandra.metrics.ThreadPools"
                    objectname="org.apache.cassandra.metrics:type=ThreadPools,path=internal,scope=MemtableFlushWriter,name=TotalBlockedTasks">
-                 <attrib name="Count" alias="ThreadPools.internal.MemtableFlushWriter.TotalBlockedTasks" type="counter"/>
+                 <attrib name="Count" alias="tpIntMemTblFlsWrTbt" type="counter"/>
             </mbean>
 
             <!-- ThreadPools :: MemtablePostFlush -->
             <mbean name="org.apache.cassandra.metrics.ThreadPools"
                    objectname="org.apache.cassandra.metrics:type=ThreadPools,path=internal,scope=MemtablePostFlush,name=ActiveTasks">
-                 <attrib name="Value" alias="ThreadPools.internal.MemtablePostFlush.ActiveTasks" type="gauge"/>
+                 <attrib name="Value" alias="tpIntMemTblPoFlsAt" type="gauge"/>
             </mbean>
             <mbean name="org.apache.cassandra.metrics.ThreadPools"
                    objectname="org.apache.cassandra.metrics:type=ThreadPools,path=internal,scope=MemtablePostFlush,name=CurrentlyBlockedTasks">
-                 <attrib name="Count" alias="ThreadPools.internal.MemtablePostFlush.CurrentlyBlockedTasks" type="counter"/>
+                 <attrib name="Count" alias="tpIntMemTblPoFlsCbt" type="counter"/>
             </mbean>
             <mbean name="org.apache.cassandra.metrics.ThreadPools"
                    objectname="org.apache.cassandra.metrics:type=ThreadPools,path=internal,scope=MemtablePostFlush,name=PendingTasks">
-                 <attrib name="Value" alias="ThreadPools.internal.MemtablePostFlush.PendingTasks" type="gauge"/>
+                 <attrib name="Value" alias="tpIntMemTblPoFlsPt" type="gauge"/>
             </mbean>
             <mbean name="org.apache.cassandra.metrics.ThreadPools"
                    objectname="org.apache.cassandra.metrics:type=ThreadPools,path=internal,scope=MemtablePostFlush,name=TotalBlockedTasks">
-                 <attrib name="Count" alias="ThreadPools.internal.MemtablePostFlush.TotalBlockedTasks" type="counter"/>
+                 <attrib name="Count" alias="tpIntMemTblPoFlsTbt" type="counter"/>
             </mbean>
 
             <!-- ThreadPools :: MemtableReclaimMemory -->
             <mbean name="org.apache.cassandra.metrics.ThreadPools"
                    objectname="org.apache.cassandra.metrics:type=ThreadPools,path=internal,scope=MemtableReclaimMemory,name=ActiveTasks">
-                 <attrib name="Value" alias="ThreadPools.internal.MemtableReclaimMemory.ActiveTasks" type="gauge"/>
+                 <attrib name="Value" alias="tpIntMemTblReMemAt" type="gauge"/>
             </mbean>
             <mbean name="org.apache.cassandra.metrics.ThreadPools"
                    objectname="org.apache.cassandra.metrics:type=ThreadPools,path=internal,scope=MemtableReclaimMemory,name=CurrentlyBlockedTasks">
-                  <attrib name="Count" alias="ThreadPools.internal.MemtableReclaimMemory.CurrentlyBlockedTasks" type="counter"/>
+                  <attrib name="Count" alias="tpIntMemTblReMemCbt" type="counter"/>
             </mbean>
             <mbean name="org.apache.cassandra.metrics.ThreadPools"
                    objectname="org.apache.cassandra.metrics:type=ThreadPools,path=internal,scope=MemtableReclaimMemory,name=PendingTasks">
-                 <attrib name="Value" alias="ThreadPools.internal.MemtableReclaimMemory.PendingTasks" type="gauge"/>
+                 <attrib name="Value" alias="tpIntMemTblReMemPt" type="gauge"/>
             </mbean>
             <mbean name="org.apache.cassandra.metrics.ThreadPools"
                    objectname="org.apache.cassandra.metrics:type=ThreadPools,path=internal,scope=MemtableReclaimMemory,name=TotalBlockedTasks">
-                  <attrib name="Count" alias="ThreadPools.internal.MemtableReclaimMemory.TotalBlockedTasks" type="counter"/>
+                  <attrib name="Count" alias="tpIntMemTblReMemTbt" type="counter"/>
             </mbean>
 
             <!-- ThreadPools :: AntiEntropyStage -->
             <mbean name="org.apache.cassandra.metrics.ThreadPools"
                    objectname="org.apache.cassandra.metrics:type=ThreadPools,path=internal,scope=AntiEntropyStage,name=ActiveTasks">
-                  <attrib name="Value" alias="ThreadPools.internal.AntiEntropyStage.ActiveTasks" type="gauge"/>
+                  <attrib name="Value" alias="tpIntAntiEntStgeAt" type="gauge"/>
             </mbean>
             <mbean name="org.apache.cassandra.metrics.ThreadPools"
                    objectname="org.apache.cassandra.metrics:type=ThreadPools,path=internal,scope=AntiEntropyStage,name=CurrentlyBlockedTasks">
-                  <attrib name="Count" alias="ThreadPools.internal.AntiEntropyStage.CurrentlyBlockedTasks" type="counter"/>
+                  <attrib name="Count" alias="tpIntAntiEntStgeCbt" type="counter"/>
             </mbean>
             <mbean name="org.apache.cassandra.metrics.ThreadPools"
                    objectname="org.apache.cassandra.metrics:type=ThreadPools,path=internal,scope=AntiEntropyStage,name=PendingTasks">
-                  <attrib name="Value" alias="ThreadPools.internal.AntiEntropyStage.PendingTasks" type="gauge"/>
+                  <attrib name="Value" alias="tpIntAntiEntStgePt" type="gauge"/>
             </mbean>
             <mbean name="org.apache.cassandra.metrics.ThreadPools"
                    objectname="org.apache.cassandra.metrics:type=ThreadPools,path=internal,scope=AntiEntropyStage,name=CompletedTasks">
-                  <attrib name="Value" alias="ThreadPools.internal.AntiEntropyStage.CompletedTasks" type="gauge"/>
+                  <attrib name="Value" alias="tpIntAntiEntStgeCt" type="gauge"/>
             </mbean>
             <mbean name="org.apache.cassandra.metrics.ThreadPools"
                    objectname="org.apache.cassandra.metrics:type=ThreadPools,path=internal,scope=AntiEntropyStage,name=TotalBlockedTasks">
-                  <attrib name="Count" alias="ThreadPools.internal.AntiEntropyStage.TotalBlockedTasks" type="counter"/>
+                  <attrib name="Count" alias="tpIntAntiEntStgeTbt" type="counter"/>
             </mbean>
 
             <!-- ThreadPools :: GossipStage -->
             <mbean name="org.apache.cassandra.metrics.ThreadPools"
                    objectname="org.apache.cassandra.metrics:type=ThreadPools,path=internal,scope=GossipStage,name=ActiveTasks">
-                  <attrib name="Value" alias="ThreadPools.internal.GossipStage.ActiveTasks" type="gauge"/>
+                  <attrib name="Value" alias="tpIntGosStgeAt" type="gauge"/>
             </mbean>
             <mbean name="org.apache.cassandra.metrics.ThreadPools"
                    objectname="org.apache.cassandra.metrics:type=ThreadPools,path=internal,scope=GossipStage,name=CurrentlyBlockedTasks">
-                  <attrib name="Count" alias="ThreadPools.internal.GossipStage.CurrentlyBlockedTasks" type="counter"/>
+                  <attrib name="Count" alias="tpIntGosStgeCbt" type="counter"/>
             </mbean>
             <mbean name="org.apache.cassandra.metrics.ThreadPools"
                    objectname="org.apache.cassandra.metrics:type=ThreadPools,path=internal,scope=GossipStage,name=PendingTasks">
-                  <attrib name="Value" alias="ThreadPools.internal.GossipStage.PendingTasks" type="gauge"/>
+                  <attrib name="Value" alias="tpIntGosStgePt" type="gauge"/>
             </mbean>
             <mbean name="org.apache.cassandra.metrics.ThreadPools"
                    objectname="org.apache.cassandra.metrics:type=ThreadPools,path=internal,scope=GossipStage,name=CompletedTasks">
-                  <attrib name="Value" alias="ThreadPools.internal.GossipStage.CompletedTasks" type="gauge"/>
+                  <attrib name="Value" alias="tpIntGosStgeCt" type="gauge"/>
             </mbean>
             <mbean name="org.apache.cassandra.metrics.ThreadPools"
-                   objectname="org.apache.cassandra.metrics:type=ThreadPools,path=internal,scope=GossipStage,name=CompletedTasks">
-                  <attrib name="Count" alias="ThreadPools.internal.GossipStage.CompletedTasks" type="counter"/>
+                   objectname="org.apache.cassandra.metrics:type=ThreadPools,path=internal,scope=GossipStage,name=TotalBlockedTasks">
+                <attrib name="Value" alias="tpIntGosStgeTbt" type="gauge"/>
             </mbean>
 
             <!-- ThreadPools :: MigrationStage -->
             <mbean name="org.apache.cassandra.metrics.ThreadPools"
                    objectname="org.apache.cassandra.metrics:type=ThreadPools,path=internal,scope=MigrationStage,name=ActiveTasks">
-                  <attrib name="Value" alias="ThreadPools.internal.MigrationStage.ActiveTasks" type="gauge"/>
+                  <attrib name="Value" alias="tpIntMigStgeAt" type="gauge"/>
             </mbean>
             <mbean name="org.apache.cassandra.metrics.ThreadPools"
                    objectname="org.apache.cassandra.metrics:type=ThreadPools,path=internal,scope=MigrationStage,name=CurrentlyBlockedTasks">
-                  <attrib name="Count" alias="ThreadPools.internal.MigrationStage.CurrentlyBlockedTasks" type="counter"/>
+                  <attrib name="Count" alias="tpIntMigStgeCbt" type="counter"/>
             </mbean>
             <mbean name="org.apache.cassandra.metrics.ThreadPools"
                    objectname="org.apache.cassandra.metrics:type=ThreadPools,path=internal,scope=MigrationStage,name=PendingTasks">
-                  <attrib name="Value" alias="ThreadPools.internal.MigrationStage.PendingTasks" type="gauge"/>
+                  <attrib name="Value" alias="tpIntMigStgePt" type="gauge"/>
             </mbean>
             <mbean name="org.apache.cassandra.metrics.ThreadPools"
                    objectname="org.apache.cassandra.metrics:type=ThreadPools,path=internal,scope=MigrationStage,name=CompletedTasks">
-                  <attrib name="Value" alias="ThreadPools.internal.MigrationStage.CompletedTasks" type="gauge"/>
+                  <attrib name="Value" alias="tpIntMigStgeCt" type="gauge"/>
             </mbean>
             <mbean name="org.apache.cassandra.metrics.ThreadPools"
                    objectname="org.apache.cassandra.metrics:type=ThreadPools,path=internal,scope=MigrationStage,name=TotalBlockedTasks">
-                  <attrib name="Count" alias="ThreadPools.internal.MigrationStage.TotalBlockedTasks" type="counter"/>
+                  <attrib name="Count" alias="tpIntMigStgeTbt" type="counter"/>
             </mbean>
 
             <!-- ThreadPools :: MiscStage -->
             <mbean name="org.apache.cassandra.metrics.ThreadPools"
                    objectname="org.apache.cassandra.metrics:type=ThreadPools,path=internal,scope=MiscStage,name=ActiveTasks">
-                  <attrib name="Value" alias="ThreadPools.internal.MiscStage.ActiveTasks" type="gauge"/>
+                  <attrib name="Value" alias="tpIntMiscStgeAt" type="gauge"/>
             </mbean>
             <mbean name="org.apache.cassandra.metrics.ThreadPools"
                    objectname="org.apache.cassandra.metrics:type=ThreadPools,path=internal,scope=MiscStage,name=CurrentlyBlockedTasks">
-                  <attrib name="Count" alias="ThreadPools.internal.MiscStage.CurrentlyBlockedTasks" type="counter"/>
+                  <attrib name="Count" alias="tpIntMiscStgeCbt" type="counter"/>
             </mbean>
             <mbean name="org.apache.cassandra.metrics.ThreadPools"
                    objectname="org.apache.cassandra.metrics:type=ThreadPools,path=internal,scope=MiscStage,name=PendingTasks">
-                  <attrib name="Value" alias="ThreadPools.internal.MiscStage.PendingTasks" type="gauge"/>
+                  <attrib name="Value" alias="tpIntMiscStgePt" type="gauge"/>
             </mbean>
             <mbean name="org.apache.cassandra.metrics.ThreadPools"
                    objectname="org.apache.cassandra.metrics:type=ThreadPools,path=internal,scope=MiscStage,name=CompletedTasks">
-                  <attrib name="Value" alias="ThreadPools.internal.MiscStage.CompletedTasks" type="gauge"/>
+                  <attrib name="Value" alias="tpIntMiscStgeCt" type="gauge"/>
             </mbean>
             <mbean name="org.apache.cassandra.metrics.ThreadPools"
                    objectname="org.apache.cassandra.metrics:type=ThreadPools,path=internal,scope=MiscStage,name=TotalBlockedTasks">
-                  <attrib name="Count" alias="ThreadPools.internal.MiscStage.TotalBlockedTasks" type="counter"/>
+                  <attrib name="Count" alias="tpIntMiscStgeTbt" type="counter"/>
             </mbean>
 
             <!-- ThreadPools :: MutationStage -->
             <mbean name="org.apache.cassandra.metrics.ThreadPools"
                    objectname="org.apache.cassandra.metrics:type=ThreadPools,path=request,scope=MutationStage,name=ActiveTasks">
-                 <attrib name="Value" alias="ThreadPools.MutationStage.ActiveTasks" type="gauge"/>
+                 <attrib name="Value" alias="tpMutStgeAt" type="gauge"/>
             </mbean>
             <mbean name="org.apache.cassandra.metrics.ThreadPools"
                    objectname="org.apache.cassandra.metrics:type=ThreadPools,path=request,scope=MutationStage,name=CurrentlyBlockedTasks">
-                 <attrib name="Value" alias="ThreadPools.MutationStage.CurrentlyBlockedTasks" type="counter"/>
+                 <attrib name="Value" alias="tpMutStgeCbt" type="counter"/>
             </mbean>
             <mbean name="org.apache.cassandra.metrics.ThreadPools"
                    objectname="org.apache.cassandra.metrics:type=ThreadPools,path=request,scope=MutationStage,name=PendingTasks">
-                 <attrib name="Value" alias="ThreadPools.MutationStage.PendingTasks" type="gauge"/>
+                 <attrib name="Value" alias="tpMutStgePt" type="gauge"/>
             </mbean>
             <mbean name="org.apache.cassandra.metrics.ThreadPools"
                    objectname="org.apache.cassandra.metrics:type=ThreadPools,path=request,scope=MutationStage,name=CompletedTasks">
-                 <attrib name="Value" alias="ThreadPools.MutationStage.CompletedTasks" type="gauge"/>
+                 <attrib name="Value" alias="tpMutStgeCt" type="gauge"/>
             </mbean>
             <mbean name="org.apache.cassandra.metrics.ThreadPools"
                    objectname="org.apache.cassandra.metrics:type=ThreadPools,path=request,scope=MutationStage,name=TotalBlockedTasks">
-                 <attrib name="Value" alias="ThreadPools.MutationStage.TotalBlockedTasks" type="counter"/>
+                 <attrib name="Value" alias="tpMutStgeTbt" type="counter"/>
             </mbean>
 
             <!-- ThreadPools :: ReadStage -->
             <mbean name="org.apache.cassandra.metrics.ThreadPools"
                    objectname="org.apache.cassandra.metrics:type=ThreadPools,path=request,scope=ReadStage,name=ActiveTasks">
-                 <attrib name="Value" alias="ThreadPools.ReadStage.ActiveTasks" type="gauge"/>
+                 <attrib name="Value" alias="tpReadStageAt" type="gauge"/>
             </mbean>
             <mbean name="org.apache.cassandra.metrics.ThreadPools"
                    objectname="org.apache.cassandra.metrics:type=ThreadPools,path=request,scope=ReadStage,name=CurrentlyBlockedTasks">
-                 <attrib name="Value" alias="ThreadPools.ReadStage.CurrentlyBlockedTasks" type="counter"/>
+                 <attrib name="Value" alias="tpReadStageCbt" type="counter"/>
             </mbean>
             <mbean name="org.apache.cassandra.metrics.ThreadPools"
                    objectname="org.apache.cassandra.metrics:type=ThreadPools,path=request,scope=ReadStage,name=CompletedTasks">
-                 <attrib name="Value" alias="ThreadPools.ReadStage.CompletedTasks" type="gauge"/>
+                 <attrib name="Value" alias="tpReadStageCt" type="gauge"/>
             </mbean>
             <mbean name="org.apache.cassandra.metrics.ThreadPools"
                    objectname="org.apache.cassandra.metrics:type=ThreadPools,path=request,scope=ReadStage,name=PendingTasks">
-                 <attrib name="Value" alias="ThreadPools.ReadStage.PendingTasks" type="gauge"/>
+                 <attrib name="Value" alias="tpReadStagePt" type="gauge"/>
             </mbean>
             <mbean name="org.apache.cassandra.metrics.ThreadPools"
                    objectname="org.apache.cassandra.metrics:type=ThreadPools,path=request,scope=ReadStage,name=TotalBlockedTasks">
-                 <attrib name="Value" alias="ThreadPools.ReadStage.TotalBlockedTasks" type="counter"/>
+                 <attrib name="Value" alias="tpReadStageTbt" type="counter"/>
             </mbean>
 
             <!-- ThreadPools :: RequestResponseStage -->
             <mbean name="org.apache.cassandra.metrics.ThreadPools"
                    objectname="org.apache.cassandra.metrics:type=ThreadPools,path=request,scope=RequestResponseStage,name=ActiveTasks">
-                <attrib name="Value" alias="ThreadPools.RequestResponseStage.ActiveTasks" type="gauge"/>
+                <attrib name="Value" alias="tpReqRespStgeAt" type="gauge"/>
             </mbean>
             <mbean name="org.apache.cassandra.metrics.ThreadPools"
                    objectname="org.apache.cassandra.metrics:type=ThreadPools,path=request,scope=RequestResponseStage,name=CurrentlyBlockedTasks">
-                <attrib name="Value" alias="ThreadPools.RequestResponseStage.CurrentlyBlockedTasks" type="counter"/>
+                <attrib name="Value" alias="tpReqRespStgeCbt" type="counter"/>
             </mbean>
             <mbean name="org.apache.cassandra.metrics.ThreadPools"
                    objectname="org.apache.cassandra.metrics:type=ThreadPools,path=request,scope=RequestResponseStage,name=CompletedTasks">
-                <attrib name="Value" alias="ThreadPools.RequestResponseStage.CompletedTasks" type="gauge"/>
+                <attrib name="Value" alias="tpReqRespStgeCt" type="gauge"/>
             </mbean>
             <mbean name="org.apache.cassandra.metrics.ThreadPools"
                    objectname="org.apache.cassandra.metrics:type=ThreadPools,path=request,scope=RequestResponseStage,name=PendingTasks">
-                <attrib name="Value" alias="ThreadPools.RequestResponseStage.PendingTasks" type="gauge"/>
+                <attrib name="Value" alias="tpReqRespStgePt" type="gauge"/>
             </mbean>
             <mbean name="org.apache.cassandra.metrics.ThreadPools"
                    objectname="org.apache.cassandra.metrics:type=ThreadPools,path=request,scope=RequestResponseStage,name=TotalBlockedTasks">
-                <attrib name="Value" alias="ThreadPools.RequestResponseStage.TotalBlockedTasks" type="counter"/>
+                <attrib name="Value" alias="tpReqRespStgeTbt" type="counter"/>
             </mbean>
 
             <!-- ThreadPools :: ReadRepairStage -->
             <mbean name="org.apache.cassandra.metrics.ThreadPools"
                    objectname="org.apache.cassandra.metrics:type=ThreadPools,path=request,scope=ReadRepairStage,name=ActiveTasks">
-                <attrib name="Value" alias="ThreadPools.ReadRepairStage.ActiveTasks" type="gauge"/>
+                <attrib name="Value" alias="tpReadRepairStgeAt" type="gauge"/>
             </mbean>
             <mbean name="org.apache.cassandra.metrics.ThreadPools"
                    objectname="org.apache.cassandra.metrics:type=ThreadPools,path=request,scope=ReadRepairStage,name=CurrentlyBlockedTasks">
-                <attrib name="Count" alias="ThreadPools.ReadRepairStage.CurrentlyBlockedTasks" type="counter"/>
+                <attrib name="Count" alias="tpReqRespStgeCbt" type="counter"/>
             </mbean>
             <mbean name="org.apache.cassandra.metrics.ThreadPools"
                    objectname="org.apache.cassandra.metrics:type=ThreadPools,path=request,scope=ReadRepairStage,name=CompletedTasks">
-                <attrib name="Value" alias="ThreadPools.ReadRepairStage.CompletedTasks" type="gauge"/>
+                <attrib name="Value" alias="tpReqRespStgeCt" type="gauge"/>
             </mbean>
             <mbean name="org.apache.cassandra.metrics.ThreadPools"
                    objectname="org.apache.cassandra.metrics:type=ThreadPools,path=request,scope=ReadRepairStage,name=PendingTasks">
-                <attrib name="Value" alias="ThreadPools.ReadRepairStage.PendingTasks" type="gauge"/>
+                <attrib name="Value" alias="tpReqRespStgePt" type="gauge"/>
             </mbean>
             <mbean name="org.apache.cassandra.metrics.ThreadPools"
                    objectname="org.apache.cassandra.metrics:type=ThreadPools,path=request,scope=ReadRepairStage,name=TotalBlockedTasks">
-                <attrib name="Count" alias="ThreadPools.ReadRepairStage.TotalBlockedTasks" type="counter"/>
+                <attrib name="Count" alias="tpReqRespStgeTbt" type="counter"/>
             </mbean>
         </mbeans>
     </jmx-collection>
@@ -632,107 +632,107 @@
             <!-- Newts :: AllMemmtables -->
             <mbean name="org.apache.cassandra.metrics.Keyspace"
                    objectname="org.apache.cassandra.metrics:type=Keyspace,keyspace=newts,name=AllMemtablesLiveDataSize">
-                <attrib name="Value" alias="keyspace.newts.AllMemtablesLiveDataSize" type="gauge"/>
+                <attrib name="Value" alias="alMemTblLiDaSi" type="gauge"/>
             </mbean>
             <mbean name="org.apache.cassandra.metrics.Keyspace"
                    objectname="org.apache.cassandra.metrics:type=Keyspace,keyspace=newts,name=AllMemtablesOffHeapDataSize">
-                <attrib name="Value" alias="keyspace.newts.AllMemtablesOffHeapDataSize" type="gauge"/>
+                <attrib name="Value" alias="alMemTblOffHeapDaSi" type="gauge"/>
             </mbean>
             <mbean name="org.apache.cassandra.metrics.Keyspace"
                    objectname="org.apache.cassandra.metrics:type=Keyspace,keyspace=newts,name=AllMemtablesOnHeapDataSize">
-                <attrib name="Value" alias="keyspace.newts.AllMemtablesOnHeapDataSize" type="gauge"/>
+                <attrib name="Value" alias="alMemTblOnHeapDaSi" type="gauge"/>
             </mbean>
 
             <!-- Memtable :: Count -->
             <mbean name="org.apache.cassandra.metrics.Keyspace"
                    objectname="org.apache.cassandra.metrics:type=Keyspace,keyspace=newts,name=MemtableSwitchCount">
-                <attrib name="Value" alias="keyspace.newts.MemtableSwitchCount" type="gauge"/>
+                <attrib name="Value" alias="memTblSwitchCount" type="gauge"/>
             </mbean>
 
             <mbean name="org.apache.cassandra.metrics.Keyspace"
                    objectname="org.apache.cassandra.metrics:type=Keyspace,keyspace=newts,name=MemtableColumnsCount">
-                <attrib name="Value" alias="keyspace.newts.MemtableColumnsCount" type="gauge"/>
+                <attrib name="Value" alias="memTblColumnsCnt" type="gauge"/>
             </mbean>
 
             <!-- Memtable :: Sizes -->
             <mbean name="org.apache.cassandra.metrics.Keyspace"
                    objectname="org.apache.cassandra.metrics:type=Keyspace,keyspace=newts,name=MemtableLiveDataSize">
-                <attrib name="Value" alias="keyspace.newts.MemtableLiveDataSize" type="gauge"/>
+                <attrib name="Value" alias="memTblLiveDaSi" type="gauge"/>
             </mbean>
             <mbean name="org.apache.cassandra.metrics.Keyspace"
                    objectname="org.apache.cassandra.metrics:type=Keyspace,keyspace=newts,name=MemtableOffHeapDataSize">
-                <attrib name="Value" alias="keyspace.newts.MemtableOffHeapDataSize" type="gauge"/>
+                <attrib name="Value" alias="memTblOffHeapDaSi" type="gauge"/>
             </mbean>
             <mbean name="org.apache.cassandra.metrics.Keyspace"
                    objectname="org.apache.cassandra.metrics:type=Keyspace,keyspace=newts,name=MemtableOnHeapDataSize">
-                <attrib name="Value" alias="keyspace.newts.MemtableOffHeapDataSize" type="gauge"/>
+                <attrib name="Value" alias="memTblOnHeapDaSi" type="gauge"/>
             </mbean>
 
             <!-- Latency -->
             <mbean name="org.apache.cassandra.metrics.Keyspace"
                    objectname="org.apache.cassandra.metrics:type=Keyspace,keyspace=newts,name=ReadTotalLatency">
-                <attrib name="Count" alias="keyspace.newts.ReadTotalLatency" type="counter"/>
+                <attrib name="Count" alias="readTotLtncy" type="counter"/>
             </mbean>
             <mbean name="org.apache.cassandra.metrics.Keyspace"
                    objectname="org.apache.cassandra.metrics:type=Keyspace,keyspace=newts,name=RangeLatency">
-                <attrib name="Count" alias="keyspace.newts.RangeLatency" type="gauge"/>
-                <attrib name="99thPercentile" alias="keyspace.newts.RangeLatency.99thpercentile" type="gauge"/>
+                <attrib name="Count" alias="rangeLtncy" type="gauge"/>
+                <attrib name="99thPercentile" alias="rangeLtncy99" type="gauge"/>
             </mbean>
             <mbean name="org.apache.cassandra.metrics.Keyspace"
             objectname="org.apache.cassandra.metrics:type=Keyspace,keyspace=newts,name=WriteTotalLatency">
-                <attrib name="Count" alias="keyspace.newts.WriteTotalLatency" type="counter"/>
+                <attrib name="Count" alias="writeTotLtncy" type="counter"/>
             </mbean>
             <mbean name="org.apache.cassandra.metrics.Keyspace"
                    objectname="org.apache.cassandra.metrics:type=Keyspace,keyspace=newts,name=CasCommitTotalLatency">
-                <attrib name="Count" alias="keyspace.newts.CasCommitTotalLatency" type="counter"/>
+                <attrib name="Count" alias="casCommitTotLtncy" type="counter"/>
             </mbean>
             <mbean name="org.apache.cassandra.metrics.Keyspace"
                    objectname="org.apache.cassandra.metrics:type=Keyspace,keyspace=newts,name=CasPrepareTotalLatency">
-                <attrib name="Count" alias="keyspace.newts.CasPrepareTotalLatency" type="counter"/>
+                <attrib name="Count" alias="casPrepareTotLtncy" type="counter"/>
             </mbean>
             <mbean name="org.apache.cassandra.metrics.Keyspace"
                    objectname="org.apache.cassandra.metrics:type=Keyspace,keyspace=newts,name=CasProposeTotalLatency">
-                <attrib name="Count" alias="keyspace.newts.CasProposeTotalLatency" type="counter"/>
+                <attrib name="Count" alias="casProposeTotLtncy" type="counter"/>
             </mbean>
 
             <!-- Bloom Filter -->
             <mbean name="org.apache.cassandra.metrics.Keyspace"
             objectname="org.apache.cassandra.metrics:type=Keyspace,keyspace=newts,name=BloomFilterDiskSpaceUsed">
-                <attrib name="Value" alias="keyspace.newts.BloomFilterDiskSpaceUsed" type="gauge"/>
+                <attrib name="Value" alias="blmFltrDskSpcUsed" type="gauge"/>
             </mbean>
             <mbean name="org.apache.cassandra.metrics.Keyspace"
             objectname="org.apache.cassandra.metrics:type=Keyspace,keyspace=newts,name=BloomFilterOffHeapMemoryUsed">
-                <attrib name="Value" alias="keyspace.newts.BloomFilterOffHeapMemoryUsed" type="gauge"/>
+                <attrib name="Value" alias="blmFltrOffHeapMemUs" type="gauge"/>
             </mbean>
 
             <!-- Memory Used -->
             <mbean name="org.apache.cassandra.metrics.Keyspace"
                    objectname="org.apache.cassandra.metrics:type=Keyspace,keyspace=newts,name=CompressionMetadataOffHeapMemoryUsed">
-                <attrib name="Value" alias="keyspace.newts.CompressionMetadataOffHeapMemoryUsed" type="gauge"/>
+                <attrib name="Value" alias="cmpMetaOffHeapMemUs" type="gauge"/>
             </mbean>
             <mbean name="org.apache.cassandra.metrics.Keyspace"
                    objectname="org.apache.cassandra.metrics:type=Keyspace,keyspace=newts,name=IndexSummaryOffHeapMemoryUsed">
-                <attrib name="Value" alias="keyspace.newts.IndexSummaryOffHeapMemoryUsed" type="gauge"/>
+                <attrib name="Value" alias="idxSumOffHeapMemUs" type="gauge"/>
             </mbean>
 
             <!-- Pending -->
             <mbean name="org.apache.cassandra.metrics.Keyspace"
                    objectname="org.apache.cassandra.metrics:type=Keyspace,keyspace=newts,name=PendingCompactions">
-                <attrib name="Value" alias="keyspace.newts.PendingCompactions" type="gauge"/>
+                <attrib name="Value" alias="pendingCompactions" type="gauge"/>
             </mbean>
             <mbean name="org.apache.cassandra.metrics.Keyspace"
                    objectname="org.apache.cassandra.metrics:type=Keyspace,keyspace=newts,name=PendingFlushes">
-                <attrib name="Value" alias="keyspace.newts.PendingFlushes" type="gauge"/>
+                <attrib name="Value" alias="pendingFlushes" type="gauge"/>
             </mbean>
 
             <!-- Disk Space -->
             <mbean name="org.apache.cassandra.metrics.Keyspace"
                    objectname="org.apache.cassandra.metrics:type=Keyspace,keyspace=newts,name=TotalDiskSpaceUsed">
-                <attrib name="Value" alias="keyspace.newts.TotalDiskSpaceUsed" type="gauge"/>
+                <attrib name="Value" alias="totalDiskSpaceUsed" type="gauge"/>
             </mbean>
             <mbean name="org.apache.cassandra.metrics.Keyspace"
                    objectname="org.apache.cassandra.metrics:type=Keyspace,keyspace=newts,name=LiveDiskSpaceUsed">
-                <attrib name="Value" alias="keyspace.newts.LiveDiskSpaceUsed" type="gauge"/>
+                <attrib name="Value" alias="liveDiskSpaceUsed" type="gauge"/>
             </mbean>
         </mbeans>
     </jmx-collection>

--- a/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/cassandra21x-graph.properties
+++ b/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/cassandra21x-graph.properties
@@ -16,12 +16,12 @@ cassandra.metrics.ThreadPools.RequestResponseStage, \
 cassandra.metrics.ThreadPools.ReadRepairStage
 
 report.cassandra.metrics.Client.name=Cassandra Client Connections
-report.cassandra.metrics.Client.columns=Client.connectedNativeClients, Client.connectedThriftClients
+report.cassandra.metrics.Client.columns=clntConNativeClnts, clntConThriftClnts
 report.cassandra.metrics.Client.type=interfaceSnmp
 report.cassandra.metrics.Client.command=--title="Cassandra Client Connections" \
  --vertical-label="Number" \
- DEF:val1={rrd1}:Client.connectedNativeClients:AVERAGE \
- DEF:val2={rrd2}:Client.connectedThriftClients:AVERAGE \
+ DEF:val1={rrd1}:clntConNativeClnts:AVERAGE \
+ DEF:val2={rrd2}:clntConThriftClnts:AVERAGE \
  AREA:val1#edd400 \
  LINE2:val1#c4a000:"Connected Native Clients" \
  GPRINT:val1:AVERAGE:" Avg \\: %8.2lf %s" \
@@ -34,11 +34,11 @@ report.cassandra.metrics.Client.command=--title="Cassandra Client Connections" \
  GPRINT:val2:MAX:" Max \\: %8.2lf %s\\n"
 
 report.cassandra.metrics.Compaction.Bytes.name=Cassandra Compaction Bytes
-report.cassandra.metrics.Compaction.Bytes.columns=Compaction.BytesCompacted
+report.cassandra.metrics.Compaction.Bytes.columns=cpctBytesCompacted
 report.cassandra.metrics.Compaction.Bytes.type=interfaceSnmp
 report.cassandra.metrics.Compaction.Bytes.command=--title="Cassandra Compaction Bytes" \
  --vertical-label="Bytes" \
- DEF:val1={rrd1}:Compaction.BytesCompacted:AVERAGE \
+ DEF:val1={rrd1}:cpctBytesCompacted:AVERAGE \
  AREA:val1#edd400 \
  LINE2:val1#c4a000:"Bytes Compacted" \
  GPRINT:val1:AVERAGE:" Avg \\: %8.2lf %s" \
@@ -46,12 +46,12 @@ report.cassandra.metrics.Compaction.Bytes.command=--title="Cassandra Compaction 
  GPRINT:val1:MAX:" Max \\: %8.2lf %s\\n"
 
 report.cassandra.metrics.Compaction.Tasks.name=Cassandra Compaction Tasks
-report.cassandra.metrics.Compaction.Tasks.columns=Compaction.PendingTasks, Compaction.CompletedTasks
+report.cassandra.metrics.Compaction.Tasks.columns=cpctPendingTasks, cpctCompletedTasks
 report.cassandra.metrics.Compaction.Tasks.type=interfaceSnmp
 report.cassandra.metrics.Compaction.Tasks.command=--title="Cassandra Compaction Tasks" \
  --vertical-label="Number" \
- DEF:val1={rrd1}:Compaction.PendingTasks:AVERAGE \
- DEF:val2={rrd2}:Compaction.CompletedTasks:AVERAGE \
+ DEF:val1={rrd1}:cpctPendingTasks:AVERAGE \
+ DEF:val2={rrd2}:cpctCompletedTasks:AVERAGE \
  AREA:val1#edd400 \
  LINE2:val1#c4a000:"Compaction Tasks Pending  " \
  GPRINT:val1:AVERAGE:" Avg \\: %8.2lf %s" \
@@ -64,17 +64,18 @@ report.cassandra.metrics.Compaction.Tasks.command=--title="Cassandra Compaction 
  GPRINT:val2:MAX:" Max \\: %8.2lf %s\\n"
 
 report.cassandra.metrics.DroppedMessages.name=Cassandra Dropped Messages
-report.cassandra.metrics.DroppedMessages.columns=DroppedMessage.BINARY.Dropped, DroppedMessage.READ.Dropped, DroppedMessage.READ_REPAIR.Dropped, REQUEST_RESPONSE.Dropped, DroppedMessage.RANGE_SLICE.Dropped, DroppedMessage.TRACE.Dropped, DroppedMessage.COUNTER_MUTATION.Dropped
+report.cassandra.metrics.DroppedMessages.columns=drpdMsgBinary, drpdMsgRead, drpdMsgReadRepair, drpdMsgReqResp, drpdMsgRangeSlice, drpdMsgTrace, drpdMsgCntrMutation, drpdMsgMutation
 report.cassandra.metrics.DroppedMessages.type=interfaceSnmp
 report.cassandra.metrics.DroppedMessages.command=--title="Cassandra Dropped Messages" \
  --vertical-label="Number of Dropped Messages" \
- DEF:val1={rrd1}:DroppedMessage.BINARY.Dropped:AVERAGE \
- DEF:val2={rrd2}:DroppedMessage.READ.Dropped:AVERAGE \
- DEF:val3={rrd3}:DroppedMessage.READ_REPAIR.Dropped:AVERAGE \
- DEF:val4={rrd4}:DroppedMessage.REQUEST_RESPONSE.Dropped:AVERAGE \
- DEF:val5={rrd5}:DroppedMessage.RANGE_SLICE.Dropped:AVERAGE \
- DEF:val6={rrd6}:DroppedMessage.TRACE.Dropped:AVERAGE \
- DEF:val7={rrd7}:DroppedMessage.COUNTER_MUTATION.Dropped:AVERAGE \
+ DEF:val1={rrd1}:drpdMsgBinary:AVERAGE \
+ DEF:val2={rrd2}:drpdMsgRead:AVERAGE \
+ DEF:val3={rrd3}:drpdMsgReadRepair:AVERAGE \
+ DEF:val4={rrd4}:drpdMsgReqResp:AVERAGE \
+ DEF:val5={rrd5}:drpdMsgRangeSlice:AVERAGE \
+ DEF:val6={rrd6}:drpdMsgTrace:AVERAGE \
+ DEF:val7={rrd7}:drpdMsgCntrMutation:AVERAGE \
+ DEF:val8={rrd8}:drpdMsgMutation:AVERAGE \
  LINE1.5:val1#edd400:"Binary           " \
  GPRINT:val1:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:val1:MIN:" Min \\: %8.2lf %s" \
@@ -95,23 +96,27 @@ report.cassandra.metrics.DroppedMessages.command=--title="Cassandra Dropped Mess
  GPRINT:val5:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:val5:MIN:" Min \\: %8.2lf %s" \
  GPRINT:val5:MAX:" Max \\: %8.2lf %s\\n" \
- LINE1.5:val6#75507b:"Trace            " \
+ LINE1.5:val6#ad7fa8:"Trace            " \
  GPRINT:val6:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:val6:MIN:" Min \\: %8.2lf %s" \
  GPRINT:val6:MAX:" Max \\: %8.2lf %s\\n" \
- LINE1.5:val6#555753:"Counter Mutation " \
- GPRINT:val6:AVERAGE:" Avg \\: %8.2lf %s" \
- GPRINT:val6:MIN:" Min \\: %8.2lf %s" \
- GPRINT:val6:MAX:" Max \\: %8.2lf %s\\n"
+ LINE1.5:val7#555753:"Counter Mutation " \
+ GPRINT:val7:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:val7:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:val7:MAX:" Max \\: %8.2lf %s\\n" \
+ LINE1.5:val8#5c3566:"Message Mutation " \
+ GPRINT:val8:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:val8:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:val8:MAX:" Max \\: %8.2lf %s\\n"
 
 report.cassandra.metrics.Storage.name=Cassandra Storage
-report.cassandra.metrics.Storage.columns=Storage.Load, Storage.Exceptions, Storage.TotalHints
+report.cassandra.metrics.Storage.columns=strgLoad, strgExceptions, strgTotalHints
 report.cassandra.metrics.Storage.type=interfaceSnmp
 report.cassandra.metrics.Storage.command=--title="Cassandra Storage" \
  --vertical-label="Number" \
- DEF:val1={rrd1}:Storage.Load:AVERAGE \
- DEF:val2={rrd2}:Storage.Exceptions:AVERAGE \
- DEF:val3={rrd3}:Storage.TotalHints:AVERAGE \
+ DEF:val1={rrd1}:strgLoad:AVERAGE \
+ DEF:val2={rrd2}:strgExceptions:AVERAGE \
+ DEF:val3={rrd3}:strgTotalHints:AVERAGE \
  LINE1.5:val1#75507b:"Load        " \
  GPRINT:val1:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:val1:MIN:" Min \\: %8.2lf %s" \
@@ -126,13 +131,13 @@ report.cassandra.metrics.Storage.command=--title="Cassandra Storage" \
  GPRINT:val3:MAX:" Max \\: %8.2lf %s\\n"
 
 report.cassandra.metrics.ThreadPools.internal.MemtableFlushWriter.name=Cassandra Thread Pool Memtable Flush Writer
-report.cassandra.metrics.ThreadPools.internal.MemtableFlushWriter.columns=ThreadPools.internal.MemtableFlushWriter.ActiveTasks, ThreadPools.internal.MemtableFlushWriter.CurrentlyBlockedTasks, ThreadPools.internal.MemtableFlushWriter.TotalBlockedTasks
+report.cassandra.metrics.ThreadPools.internal.MemtableFlushWriter.columns=tpIntMemTblFlsWrAt, tpIntMemTblFlsWrCbt, tpIntMemTblFlsWrTbt
 report.cassandra.metrics.ThreadPools.internal.MemtableFlushWriter.type=interfaceSnmp
 report.cassandra.metrics.ThreadPools.internal.MemtableFlushWriter.command=--title="Cassandra Thread Pool Memtable Flush Writer" \
  --vertical-label="Number" \
- DEF:val1={rrd1}:ThreadPools.internal.MemtableFlushWriter.ActiveTasks:AVERAGE \
- DEF:val2={rrd2}:ThreadPools.internal.MemtableFlushWriter.CurrentlyBlockedTasks:AVERAGE \
- DEF:val3={rrd3}:ThreadPools.internal.MemtableFlushWriter.TotalBlockedTasks:AVERAGE \
+ DEF:val1={rrd1}:tpIntMemTblFlsWrAt:AVERAGE \
+ DEF:val2={rrd2}:tpIntMemTblFlsWrCbt:AVERAGE \
+ DEF:val3={rrd3}:tpIntMemTblFlsWrTbt:AVERAGE \
  LINE1.5:val1#75507b:"Active Tasks            " \
  GPRINT:val1:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:val1:MIN:" Min \\: %8.2lf %s" \
@@ -147,14 +152,14 @@ report.cassandra.metrics.ThreadPools.internal.MemtableFlushWriter.command=--titl
  GPRINT:val3:MAX:" Max \\: %8.2lf %s\\n"
 
 report.cassandra.metrics.ThreadPools.internal.MemtablePostFlush.name=Cassandra Thread Pool Memtable Post Flush Writer
-report.cassandra.metrics.ThreadPools.internal.MemtablePostFlush.columns=ThreadPools.internal.MemtablePostFlush.ActiveTasks, ThreadPools.internal.MemtablePostFlush.CurrentlyBlockedTasks, ThreadPools.internal.MemtablePostFlush.PendingTasks, ThreadPools.internal.MemtablePostFlush.TotalBlockedTasks
+report.cassandra.metrics.ThreadPools.internal.MemtablePostFlush.columns=tpIntMemTblPoFlsAt, tpIntMemTblPoFlsCbt, tpIntMemTblPoFlsPt, tpIntMemTblPoFlsTbt
 report.cassandra.metrics.ThreadPools.internal.MemtablePostFlush.type=interfaceSnmp
 report.cassandra.metrics.ThreadPools.internal.MemtablePostFlush.command=--title="Cassandra Thread Pool Memtable Post Flush Writer" \
  --vertical-label="Number" \
- DEF:val1={rrd1}:ThreadPools.internal.MemtablePostFlush.ActiveTasks:AVERAGE \
- DEF:val2={rrd2}:ThreadPools.internal.MemtablePostFlush.CurrentlyBlockedTasks:AVERAGE \
- DEF:val3={rrd3}:ThreadPools.internal.MemtablePostFlush.PendingTasks:AVERAGE \
- DEF:val4={rrd4}:ThreadPools.internal.MemtablePostFlush.TotalBlockedTasks:AVERAGE \
+ DEF:val1={rrd1}:tpIntMemTblPoFlsAt:AVERAGE \
+ DEF:val2={rrd2}:tpIntMemTblPoFlsCbt:AVERAGE \
+ DEF:val3={rrd3}:tpIntMemTblPoFlsPt:AVERAGE \
+ DEF:val4={rrd4}:tpIntMemTblPoFlsTbt:AVERAGE \
  LINE1.5:val1#75507b:"Active Tasks            " \
  GPRINT:val1:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:val1:MIN:" Min \\: %8.2lf %s" \
@@ -173,14 +178,14 @@ report.cassandra.metrics.ThreadPools.internal.MemtablePostFlush.command=--title=
  GPRINT:val4:MAX:" Max \\: %8.2lf %s\\n"
 
 report.cassandra.metrics.ThreadPools.internal.MemtableReclaimMemory.name=Cassandra Thread Pool Memtable Reclaim Memory
-report.cassandra.metrics.ThreadPools.internal.MemtableReclaimMemory.columns=ThreadPools.internal.MemtableReclaimMemory.ActiveTasks, ThreadPools.internal.MemtableReclaimMemory.CurrentlyBlockedTasks, ThreadPools.internal.MemtableReclaimMemory.PendingTasks, ThreadPools.internal.MemtableReclaimMemory.TotalBlockedTasks
+report.cassandra.metrics.ThreadPools.internal.MemtableReclaimMemory.columns=tpIntMemTblReMemAt, tpIntMemTblReMemCbt, tpIntMemTblReMemPt, tpIntMemTblReMemTbt
 report.cassandra.metrics.ThreadPools.internal.MemtableReclaimMemory.type=interfaceSnmp
 report.cassandra.metrics.ThreadPools.internal.MemtableReclaimMemory.command=--title="Cassandra Thread Pool Memtable Reclaim Memory" \
  --vertical-label="Number" \
- DEF:val1={rrd1}:ThreadPools.internal.MemtableReclaimMemory.ActiveTasks:AVERAGE \
- DEF:val2={rrd2}:ThreadPools.internal.MemtableReclaimMemory.CurrentlyBlockedTasks:AVERAGE \
- DEF:val3={rrd3}:ThreadPools.internal.MemtableReclaimMemory.PendingTasks:AVERAGE \
- DEF:val4={rrd4}:ThreadPools.internal.MemtableReclaimMemory.TotalBlockedTasks:AVERAGE \
+ DEF:val1={rrd1}:tpIntMemTblReMemAt:AVERAGE \
+ DEF:val2={rrd2}:tpIntMemTblReMemCbt:AVERAGE \
+ DEF:val3={rrd3}:tpIntMemTblReMemPt:AVERAGE \
+ DEF:val4={rrd4}:tpIntMemTblReMemTbt:AVERAGE \
  LINE1.5:val1#75507b:"Active Tasks            " \
  GPRINT:val1:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:val1:MIN:" Min \\: %8.2lf %s" \
@@ -199,15 +204,15 @@ report.cassandra.metrics.ThreadPools.internal.MemtableReclaimMemory.command=--ti
  GPRINT:val4:MAX:" Max \\: %8.2lf %s\\n"
 
 report.cassandra.metrics.ThreadPools.internal.AntiEntropyStage.name=Thread Pool Internal Anti-Entropy Stage
-report.cassandra.metrics.ThreadPools.internal.AntiEntropyStage.columns=ThreadPools.internal.AntiEntropyStage.ActiveTasks, ThreadPools.internal.AntiEntropyStage.CurrentlyBlockedTasks, ThreadPools.internal.AntiEntropyStage.PendingTasks, ThreadPools.internal.AntiEntropyStage.CompletedTasks, ThreadPools.internal.AntiEntropyStage.TotalBlockedTasks
+report.cassandra.metrics.ThreadPools.internal.AntiEntropyStage.columns=tpIntAntiEntStgeAt, tpIntAntiEntStgeCbt, tpIntAntiEntStgePt, tpIntAntiEntStgeCt, tpIntAntiEntStgeTbt
 report.cassandra.metrics.ThreadPools.internal.AntiEntropyStage.type=interfaceSnmp
 report.cassandra.metrics.ThreadPools.internal.AntiEntropyStage.command=--title="Thread Pool Internal Anti-Entropy Stage" \
  --vertical-label="Number" \
- DEF:val1={rrd1}:ThreadPools.internal.AntiEntropyStage.ActiveTasks:AVERAGE \
- DEF:val2={rrd2}:ThreadPools.internal.AntiEntropyStage.CurrentlyBlockedTasks:AVERAGE \
- DEF:val3={rrd3}:ThreadPools.internal.AntiEntropyStage.PendingTasks:AVERAGE \
- DEF:val4={rrd4}:ThreadPools.internal.AntiEntropyStage.CompletedTasks:AVERAGE \
- DEF:val5={rrd5}:ThreadPools.internal.AntiEntropyStage.TotalBlockedTasks:AVERAGE \
+ DEF:val1={rrd1}:tpIntAntiEntStgeAt:AVERAGE \
+ DEF:val2={rrd2}:tpIntAntiEntStgeCbt:AVERAGE \
+ DEF:val3={rrd3}:tpIntAntiEntStgePt:AVERAGE \
+ DEF:val4={rrd4}:tpIntAntiEntStgeCt:AVERAGE \
+ DEF:val5={rrd5}:tpIntAntiEntStgeTbt:AVERAGE \
  LINE1.5:val1#75507b:"Active Tasks            " \
  GPRINT:val1:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:val1:MIN:" Min \\: %8.2lf %s" \
@@ -230,15 +235,15 @@ report.cassandra.metrics.ThreadPools.internal.AntiEntropyStage.command=--title="
  GPRINT:val5:MAX:" Max \\: %8.2lf %s\\n"
 
 report.cassandra.metrics.ThreadPools.internal.GossipStage.name=Thread Pool Internal Gossip Stage
-report.cassandra.metrics.ThreadPools.internal.GossipStage.columns=ThreadPools.internal.GossipStage.ActiveTasks, ThreadPools.internal.GossipStage.CurrentlyBlockedTasks, ThreadPools.internal.GossipStage.PendingTasks, ThreadPools.internal.GossipStage.CompletedTasks, ThreadPools.internal.GossipStage.TotalBlockedTasks
+report.cassandra.metrics.ThreadPools.internal.GossipStage.columns=tpIntGosStgeAt, tpIntGosStgeCbt, tpIntGosStgePt, tpIntGosStgeCt, tpIntGosStgeTbt
 report.cassandra.metrics.ThreadPools.internal.GossipStage.type=interfaceSnmp
 report.cassandra.metrics.ThreadPools.internal.GossipStage.command=--title="Thread Pool Internal Gossip Stage" \
  --vertical-label="Number" \
- DEF:val1={rrd1}:ThreadPools.internal.GossipStage.ActiveTasks:AVERAGE \
- DEF:val2={rrd2}:ThreadPools.internal.GossipStage.CurrentlyBlockedTasks:AVERAGE \
- DEF:val3={rrd3}:ThreadPools.internal.GossipStage.PendingTasks:AVERAGE \
- DEF:val4={rrd4}:ThreadPools.internal.GossipStage.CompletedTasks:AVERAGE \
- DEF:val5={rrd5}:ThreadPools.internal.GossipStage.TotalBlockedTasks:AVERAGE \
+ DEF:val1={rrd1}:tpIntGosStgeAt:AVERAGE \
+ DEF:val2={rrd2}:tpIntGosStgeCbt:AVERAGE \
+ DEF:val3={rrd3}:tpIntGosStgePt:AVERAGE \
+ DEF:val4={rrd4}:tpIntGosStgeCt:AVERAGE \
+ DEF:val5={rrd5}:tpIntGosStgeTbt:AVERAGE \
  LINE1.5:val1#75507b:"Active Tasks            " \
  GPRINT:val1:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:val1:MIN:" Min \\: %8.2lf %s" \
@@ -261,15 +266,15 @@ report.cassandra.metrics.ThreadPools.internal.GossipStage.command=--title="Threa
  GPRINT:val5:MAX:" Max \\: %8.2lf %s\\n"
 
 report.cassandra.metrics.ThreadPools.internal.MigrationStage.name=Thread Pool Internal Migration Stage
-report.cassandra.metrics.ThreadPools.internal.MigrationStage.columns=ThreadPools.internal.MigrationStage.ActiveTasks, ThreadPools.internal.MigrationStage.CurrentlyBlockedTasks, ThreadPools.internal.MigrationStage.PendingTasks, ThreadPools.internal.MigrationStage.CompletedTasks, ThreadPools.internal.MigrationStage.TotalBlockedTasks
+report.cassandra.metrics.ThreadPools.internal.MigrationStage.columns=tpIntMigStgeAt, tpIntMigStgeCbt, tpIntMigStgePt, tpIntMigStgeCt, tpIntMigStgeTbt
 report.cassandra.metrics.ThreadPools.internal.MigrationStage.type=interfaceSnmp
 report.cassandra.metrics.ThreadPools.internal.MigrationStage.command=--title="Thread Pool Internal Migration Stage" \
  --vertical-label="Number" \
- DEF:val1={rrd1}:ThreadPools.internal.MigrationStage.ActiveTasks:AVERAGE \
- DEF:val2={rrd2}:ThreadPools.internal.MigrationStage.CurrentlyBlockedTasks:AVERAGE \
- DEF:val3={rrd3}:ThreadPools.internal.MigrationStage.PendingTasks:AVERAGE \
- DEF:val4={rrd4}:ThreadPools.internal.MigrationStage.CompletedTasks:AVERAGE \
- DEF:val5={rrd5}:ThreadPools.internal.MigrationStage.TotalBlockedTasks:AVERAGE \
+ DEF:val1={rrd1}:tpIntMigStgeAt:AVERAGE \
+ DEF:val2={rrd2}:tpIntMigStgeCbt:AVERAGE \
+ DEF:val3={rrd3}:tpIntMigStgePt:AVERAGE \
+ DEF:val4={rrd4}:tpIntMigStgeCt:AVERAGE \
+ DEF:val5={rrd5}:tpIntMigStgeTbt:AVERAGE \
  LINE1.5:val1#75507b:"Active Tasks            " \
  GPRINT:val1:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:val1:MIN:" Min \\: %8.2lf %s" \
@@ -292,15 +297,15 @@ report.cassandra.metrics.ThreadPools.internal.MigrationStage.command=--title="Th
  GPRINT:val5:MAX:" Max \\: %8.2lf %s\\n"
 
 report.cassandra.metrics.ThreadPools.internal.MiscStage.name=Thread Pool Internal Misc Stage
-report.cassandra.metrics.ThreadPools.internal.MiscStage.columns=ThreadPools.internal.MiscStage.ActiveTasks, ThreadPools.internal.MiscStage.CurrentlyBlockedTasks, ThreadPools.internal.MiscStage.PendingTasks, ThreadPools.internal.MiscStage.CompletedTasks, ThreadPools.internal.MiscStage.TotalBlockedTasks
+report.cassandra.metrics.ThreadPools.internal.MiscStage.columns=tpIntMiscStgeAt, tpIntMiscStgeCbt, tpIntMiscStgePt, tpIntMiscStgeCt, tpIntMiscStgeTbt
 report.cassandra.metrics.ThreadPools.internal.MiscStage.type=interfaceSnmp
 report.cassandra.metrics.ThreadPools.internal.MiscStage.command=--title="Thread Pool Internal Misc Stage" \
  --vertical-label="Number" \
- DEF:val1={rrd1}:ThreadPools.internal.MiscStage.ActiveTasks:AVERAGE \
- DEF:val2={rrd2}:ThreadPools.internal.MiscStage.CurrentlyBlockedTasks:AVERAGE \
- DEF:val3={rrd3}:ThreadPools.internal.MiscStage.PendingTasks:AVERAGE \
- DEF:val4={rrd4}:ThreadPools.internal.MiscStage.CompletedTasks:AVERAGE \
- DEF:val5={rrd5}:ThreadPools.internal.MiscStage.TotalBlockedTasks:AVERAGE \
+ DEF:val1={rrd1}:tpIntMiscStgeAt:AVERAGE \
+ DEF:val2={rrd2}:tpIntMiscStgeCbt:AVERAGE \
+ DEF:val3={rrd3}:tpIntMiscStgePt:AVERAGE \
+ DEF:val4={rrd4}:tpIntMiscStgeCt:AVERAGE \
+ DEF:val5={rrd5}:tpIntMiscStgeTbt:AVERAGE \
  LINE1.5:val1#75507b:"Active Tasks            " \
  GPRINT:val1:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:val1:MIN:" Min \\: %8.2lf %s" \
@@ -323,15 +328,15 @@ report.cassandra.metrics.ThreadPools.internal.MiscStage.command=--title="Thread 
  GPRINT:val5:MAX:" Max \\: %8.2lf %s\\n"
 
 report.cassandra.metrics.ThreadPools.MutationStage.name=Thread Pool Mutation Stage
-report.cassandra.metrics.ThreadPools.MutationStage.columns=ThreadPools.MutationStage.ActiveTasks, ThreadPools.MutationStage.CurrentlyBlockedTasks, ThreadPools.MutationStage.PendingTasks, ThreadPools.MutationStage.CompletedTasks, ThreadPools.MutationStage.TotalBlockedTasks
+report.cassandra.metrics.ThreadPools.MutationStage.columns=tpMutStgeAt, tpMutStgeCbt, tpMutStgePt, tpMutStgeCt, tpMutStgeTbt
 report.cassandra.metrics.ThreadPools.MutationStage.type=interfaceSnmp
 report.cassandra.metrics.ThreadPools.MutationStage.command=--title="Thread Pool Mutation Stage" \
  --vertical-label="Number" \
- DEF:val1={rrd1}:ThreadPools.MutationStage.ActiveTasks:AVERAGE \
- DEF:val2={rrd2}:ThreadPools.MutationStage.CurrentlyBlockedTasks:AVERAGE \
- DEF:val3={rrd3}:ThreadPools.MutationStage.PendingTasks:AVERAGE \
- DEF:val4={rrd4}:ThreadPools.MutationStage.CompletedTasks:AVERAGE \
- DEF:val5={rrd5}:ThreadPools.MutationStage.TotalBlockedTasks:AVERAGE \
+ DEF:val1={rrd1}:tpMutStgeAt:AVERAGE \
+ DEF:val2={rrd2}:tpMutStgeCbt:AVERAGE \
+ DEF:val3={rrd3}:tpMutStgePt:AVERAGE \
+ DEF:val4={rrd4}:tpMutStgeCt:AVERAGE \
+ DEF:val5={rrd5}:tpMutStgeTbt:AVERAGE \
  LINE1.5:val1#75507b:"Active Tasks            " \
  GPRINT:val1:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:val1:MIN:" Min \\: %8.2lf %s" \
@@ -354,15 +359,15 @@ report.cassandra.metrics.ThreadPools.MutationStage.command=--title="Thread Pool 
  GPRINT:val5:MAX:" Max \\: %8.2lf %s\\n"
 
 report.cassandra.metrics.ThreadPools.ReadStage.name=Thread Pool Read Stage
-report.cassandra.metrics.ThreadPools.ReadStage.columns=ThreadPools.ReadStage.ActiveTasks, ThreadPools.ReadStage.CurrentlyBlockedTasks, ThreadPools.ReadStage.CompletedTasks, ThreadPools.ReadStage.PendingTasks, ThreadPools.ReadStage.TotalBlockedTasks
+report.cassandra.metrics.ThreadPools.ReadStage.columns=tpReadStageAt, tpReadStageCbt, tpReadStagePt, tpReadStageCt, tpReadStageTbt
 report.cassandra.metrics.ThreadPools.ReadStage.type=interfaceSnmp
 report.cassandra.metrics.ThreadPools.ReadStage.command=--title="Thread Pool Read Stage" \
  --vertical-label="Number" \
- DEF:val1={rrd1}:ThreadPools.ReadStage.ActiveTasks:AVERAGE \
- DEF:val2={rrd2}:ThreadPools.ReadStage.CurrentlyBlockedTasks:AVERAGE \
- DEF:val3={rrd3}:ThreadPools.ReadStage.CompletedTasks:AVERAGE \
- DEF:val4={rrd4}:ThreadPools.ReadStage.PendingTasks:AVERAGE \
- DEF:val5={rrd5}:ThreadPools.ReadStage.TotalBlockedTasks:AVERAGE \
+ DEF:val1={rrd1}:tpReadStageAt:AVERAGE \
+ DEF:val2={rrd2}:tpReadStageCbt:AVERAGE \
+ DEF:val3={rrd3}:tpReadStagePt:AVERAGE \
+ DEF:val4={rrd4}:tpReadStageCt:AVERAGE \
+ DEF:val5={rrd5}:tpReadStageTbt:AVERAGE \
  LINE1.5:val1#75507b:"Active Tasks            " \
  GPRINT:val1:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:val1:MIN:" Min \\: %8.2lf %s" \
@@ -385,15 +390,15 @@ report.cassandra.metrics.ThreadPools.ReadStage.command=--title="Thread Pool Read
  GPRINT:val5:MAX:" Max \\: %8.2lf %s\\n"
 
 report.cassandra.metrics.ThreadPools.RequestResponseStage.name=Thread Pool Request Response Stage
-report.cassandra.metrics.ThreadPools.RequestResponseStage.columns=ThreadPools.RequestResponseStage.ActiveTasks, ThreadPools.RequestResponseStage.CurrentlyBlockedTasks, ThreadPools.RequestResponseStage.CompletedTasks, ThreadPools.RequestResponseStage.PendingTasks, ThreadPools.RequestResponseStage.TotalBlockedTasks
+report.cassandra.metrics.ThreadPools.RequestResponseStage.columns=tpReqRespStgeAt, tpReqRespStgeCbt, tpReqRespStgePt, tpReqRespStgeCt, tpReqRespStgeTbt
 report.cassandra.metrics.ThreadPools.RequestResponseStage.type=interfaceSnmp
 report.cassandra.metrics.ThreadPools.RequestResponseStage.command=--title="Thread Pool Request Response Stage" \
  --vertical-label="Number" \
- DEF:val1={rrd1}:ThreadPools.RequestResponseStage.ActiveTasks:AVERAGE \
- DEF:val2={rrd2}:ThreadPools.RequestResponseStage.CurrentlyBlockedTasks:AVERAGE \
- DEF:val3={rrd3}:ThreadPools.RequestResponseStage.CompletedTasks:AVERAGE \
- DEF:val4={rrd4}:ThreadPools.RequestResponseStage.PendingTasks:AVERAGE \
- DEF:val5={rrd5}:ThreadPools.RequestResponseStage.TotalBlockedTasks:AVERAGE \
+ DEF:val1={rrd1}:tpReqRespStgeAt:AVERAGE \
+ DEF:val2={rrd2}:tpReqRespStgeCbt:AVERAGE \
+ DEF:val3={rrd3}:tpReqRespStgePt:AVERAGE \
+ DEF:val4={rrd4}:tpReqRespStgeCt:AVERAGE \
+ DEF:val5={rrd5}:tpReqRespStgeTbt:AVERAGE \
  LINE1.5:val1#75507b:"Active Tasks            " \
  GPRINT:val1:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:val1:MIN:" Min \\: %8.2lf %s" \
@@ -416,15 +421,15 @@ report.cassandra.metrics.ThreadPools.RequestResponseStage.command=--title="Threa
  GPRINT:val5:MAX:" Max \\: %8.2lf %s\\n"
 
 report.cassandra.metrics.ThreadPools.ReadRepairStage.name=Thread Pool Read Repair Stage
-report.cassandra.metrics.ThreadPools.ReadRepairStage.columns=ThreadPools.ReadRepairStage.ActiveTasks, ThreadPools.ReadRepairStage.CurrentlyBlockedTasks, ThreadPools.ReadRepairStage.CompletedTasks, ThreadPools.ReadRepairStage.PendingTasks, ThreadPools.ReadRepairStage.TotalBlockedTasks
+report.cassandra.metrics.ThreadPools.ReadRepairStage.columns=tpReadRepairStgeAt, tpReadRepairStgeCbt, tpReadRepairStgePt, tpReadRepairStgeCt, tpReadRepairStgeTbt
 report.cassandra.metrics.ThreadPools.ReadRepairStage.type=interfaceSnmp
 report.cassandra.metrics.ThreadPools.ReadRepairStage.command=--title="Thread Pool Read Repair Stage" \
  --vertical-label="Number" \
- DEF:val1={rrd1}:ThreadPools.ReadRepairStage.ActiveTasks:AVERAGE \
- DEF:val2={rrd2}:ThreadPools.ReadRepairStage.CurrentlyBlockedTasks:AVERAGE \
- DEF:val3={rrd3}:ThreadPools.ReadRepairStage.CompletedTasks:AVERAGE \
- DEF:val4={rrd4}:ThreadPools.ReadRepairStage.PendingTasks:AVERAGE \
- DEF:val5={rrd5}:ThreadPools.ReadRepairStage.TotalBlockedTasks:AVERAGE \
+ DEF:val1={rrd1}:tpReadRepairStgeAt:AVERAGE \
+ DEF:val2={rrd2}:tpReadRepairStgeCbt:AVERAGE \
+ DEF:val3={rrd3}:tpReadRepairStgePt:AVERAGE \
+ DEF:val4={rrd4}:tpReadRepairStgeCt:AVERAGE \
+ DEF:val5={rrd5}:tpReadRepairStgeTbt:AVERAGE \
  LINE1.5:val1#75507b:"Active Tasks            " \
  GPRINT:val1:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:val1:MIN:" Min \\: %8.2lf %s" \

--- a/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/newts-cassandra21x-graph.properties
+++ b/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/newts-cassandra21x-graph.properties
@@ -13,14 +13,14 @@ cassandra.metrics.keyspace.newts.pending, \
 cassandra.metrics.keyspace.newts.DiskSpace
 
 report.cassandra.metrics.keyspace.newts.AllMemtables.DataSize.name=All Memtables Data Size
-report.cassandra.metrics.keyspace.newts.AllMemtables.DataSize.columns=keyspace.newts.AllMemtablesLiveDataSize, keyspace.newts.AllMemtablesOffHeapDataSize, keyspace.newts.AllMemtablesOnHeapDataSize
+report.cassandra.metrics.keyspace.newts.AllMemtables.DataSize.columns=alMemTblLiDaSi, alMemTblOffHeapDaSi, alMemTblOnHeapDaSi
 report.cassandra.metrics.keyspace.newts.AllMemtables.DataSize.type=interfaceSnmp
 report.cassandra.metrics.keyspace.newts.AllMemtables.DataSize.command=--title="All Memtables Data Size" \
  --vertical-label="Size" \
- DEF:val1={rrd1}:keyspace.newts.AllMemtablesLiveDataSize:AVERAGE \
- DEF:val2={rrd2}:keyspace.newts.AllMemtablesOffHeapDataSize:AVERAGE \
- DEF:val3={rrd3}:keyspace.newts.AllMemtablesOnHeapDataSize:AVERAGE \
- LINE1.5:val1#75507b:"Live Data Size          " \
+ DEF:val1={rrd1}:alMemTblLiDaSi:AVERAGE \
+ DEF:val2={rrd2}:alMemTblOffHeapDaSi:AVERAGE \
+ DEF:val3={rrd3}:alMemTblOnHeapDaSi:AVERAGE \
+ LINE1.5:val1#ef2929:"Live Data Size          " \
  GPRINT:val1:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:val1:MIN:" Min \\: %8.2lf %s" \
  GPRINT:val1:MAX:" Max \\: %8.2lf %s\\n" \
@@ -28,18 +28,18 @@ report.cassandra.metrics.keyspace.newts.AllMemtables.DataSize.command=--title="A
  GPRINT:val2:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:val2:MIN:" Min \\: %8.2lf %s" \
  GPRINT:val2:MAX:" Max \\: %8.2lf %s\\n" \
- LINE1.5:val3#75507b:"Pending Tasks           " \
+ LINE1.5:val3#edd400:"On-Heap Data Size       " \
  GPRINT:val3:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:val3:MIN:" Min \\: %8.2lf %s" \
  GPRINT:val3:MAX:" Max \\: %8.2lf %s\\n"
 
 report.cassandra.metrics.keyspace.newts.AllMemtables.Counter.name=All Memtables Counter
-report.cassandra.metrics.keyspace.newts.AllMemtables.Counter.columns=keyspace.newts.MemtableSwitchCount, keyspace.newts.MemtableColumnsCount
+report.cassandra.metrics.keyspace.newts.AllMemtables.Counter.columns=memTblSwitchCount, memTblColumnsCnt
 report.cassandra.metrics.keyspace.newts.AllMemtables.Counter.type=interfaceSnmp
 report.cassandra.metrics.keyspace.newts.AllMemtables.Counter.command=--title="All Memtables Counter" \
  --vertical-label="Number" \
- DEF:val1={rrd1}:keyspace.newts.MemtableSwitchCount:AVERAGE \
- DEF:val2={rrd2}:keyspace.newts.MemtableColumnsCount:AVERAGE \
+ DEF:val1={rrd1}:memTblSwitchCount:AVERAGE \
+ DEF:val2={rrd2}:memTblColumnsCnt:AVERAGE \
  LINE1.5:val1#75507b:"Switch Counter  " \
  GPRINT:val1:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:val1:MIN:" Min \\: %8.2lf %s" \
@@ -50,17 +50,22 @@ report.cassandra.metrics.keyspace.newts.AllMemtables.Counter.command=--title="Al
  GPRINT:val2:MAX:" Max \\: %8.2lf %s\\n"
 
 report.cassandra.metrics.keyspace.newts.Memtable.DataSize.name=Newts Memtable Data Size
-report.cassandra.metrics.keyspace.newts.Memtable.DataSize.columns=keyspace.newts.MemtableLiveDataSize, keyspace.newts.MemtableOffHeapDataSize
+report.cassandra.metrics.keyspace.newts.Memtable.DataSize.columns=memTblLiveDaSi, memTblOffHeapDaSi, memTblOnHeapDaSi
 report.cassandra.metrics.keyspace.newts.Memtable.DataSize.type=interfaceSnmp
 report.cassandra.metrics.keyspace.newts.Memtable.DataSize.command=--title="Newts Memtable Data Size" \
  --vertical-label="Size" \
- DEF:val1={rrd1}:keyspace.newts.MemtableLiveDataSize:AVERAGE \
- DEF:val2={rrd2}:keyspace.newts.MemtableColumnsCount:AVERAGE \
- LINE1.5:val1#75507b:"Live Data Size     " \
+ DEF:val1={rrd1}:memTblLiveDaSi:AVERAGE \
+ DEF:val2={rrd2}:memTblOffHeapDaSi:AVERAGE \
+ DEF:val3={rrd3}:memTblOnHeapDaSi:AVERAGE \
+ LINE1.5:val1#ef2929:"Live Data Size     " \
  GPRINT:val1:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:val1:MIN:" Min \\: %8.2lf %s" \
  GPRINT:val1:MAX:" Max \\: %8.2lf %s\\n" \
  LINE1.5:val2#75507b:"Off-Heap Data Size " \
+ GPRINT:val2:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:val2:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:val2:MAX:" Max \\: %8.2lf %s\\n" \
+ LINE1.5:val2#edd400:"On-Heap Data Size " \
  GPRINT:val2:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:val2:MIN:" Min \\: %8.2lf %s" \
  GPRINT:val2:MAX:" Max \\: %8.2lf %s\\n"
@@ -82,13 +87,13 @@ report.cassandra.metrics.keyspace.newts.TotalLatency.command=--title="Newts Read
  GPRINT:val2:MAX:" Max \\: %8.2lf %s\\n"
 
 report.cassandra.metrics.keyspace.newts.RangeLatency.name=Newts Range Latency
-report.cassandra.metrics.keyspace.newts.RangeLatency.columns=keyspace.newts.RangeLatency, keyspace.newts.RangeLatency.99thpercentile
+report.cassandra.metrics.keyspace.newts.RangeLatency.columns=rangeLtncy, rangeLtncy99
 report.cassandra.metrics.keyspace.newts.RangeLatency.type=interfaceSnmp
 report.cassandra.metrics.keyspace.newts.RangeLatency.command=--title="Newts Range Latency" \
  --vertical-label="micro seconds" \
- DEF:val1={rrd1}:keyspace.newts.RangeLatency:AVERAGE \
- DEF:val2={rrd2}:keyspace.newts.RangeLatency.99thpercentile:AVERAGE \
- LINE1.5:val1#75507b:"Range Latency               " \
+ DEF:val1={rrd1}:rangeLtncy:AVERAGE \
+ DEF:val2={rrd2}:rangeLtncy99:AVERAGE \
+ LINE1.5:val1#3465a4:"Range Latency               " \
  GPRINT:val1:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:val1:MIN:" Min \\: %8.2lf %s" \
  GPRINT:val1:MAX:" Max \\: %8.2lf %s\\n" \
@@ -98,18 +103,18 @@ report.cassandra.metrics.keyspace.newts.RangeLatency.command=--title="Newts Rang
  GPRINT:val2:MAX:" Max \\: %8.2lf %s\\n"
 
 report.cassandra.metrics.keyspace.newts.CommitTotalLatency.name=Commit Total Latency
-report.cassandra.metrics.keyspace.newts.CommitTotalLatency.columns=keyspace.newts.CasCommitTotalLatency, keyspace.newts.CasPrepareTotalLatency, keyspace.newts.CasProposeTotalLatency
+report.cassandra.metrics.keyspace.newts.CommitTotalLatency.columns=casCommitTotLtncy, casPrepareTotLtncy, casProposeTotLtncy
 report.cassandra.metrics.keyspace.newts.CommitTotalLatency.type=interfaceSnmp
 report.cassandra.metrics.keyspace.newts.CommitTotalLatency.command=--title="Commit Total Latency" \
  --vertical-label="micro seconds" \
- DEF:val1={rrd1}:keyspace.newts.CasCommitTotalLatency:AVERAGE \
- DEF:val2={rrd2}:keyspace.newts.CasPrepareTotalLatency:AVERAGE \
- DEF:val3={rrd3}:keyspace.newts.CasProposeTotalLatency:AVERAGE \
- LINE1.5:val1#75507b:"Commit Total Latency   " \
+ DEF:val1={rrd1}:casCommitTotLtncy:AVERAGE \
+ DEF:val2={rrd2}:casPrepareTotLtncy:AVERAGE \
+ DEF:val3={rrd3}:casProposeTotLtncy:AVERAGE \
+ LINE1.5:val1#f57900:"Commit Total Latency   " \
  GPRINT:val1:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:val1:MIN:" Min \\: %8.2lf %s" \
  GPRINT:val1:MAX:" Max \\: %8.2lf %s\\n" \
- LINE1.5:val2#75507b:"Preprare Total Latency " \
+ LINE1.5:val2#3465a4:"Preprare Total Latency " \
  GPRINT:val2:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:val2:MIN:" Min \\: %8.2lf %s" \
  GPRINT:val2:MAX:" Max \\: %8.2lf %s\\n" \
@@ -119,13 +124,13 @@ report.cassandra.metrics.keyspace.newts.CommitTotalLatency.command=--title="Comm
  GPRINT:val3:MAX:" Max \\: %8.2lf %s\\n"
 
 report.cassandra.metrics.keyspace.newts.TotalLatency.name=Bloom Filter Disk and Memory
-report.cassandra.metrics.keyspace.newts.TotalLatency.columns=keyspace.newts.BloomFilterDiskSpaceUsed, keyspace.newts.BloomFilterOffHeapMemoryUsed
+report.cassandra.metrics.keyspace.newts.TotalLatency.columns=blmFltrDskSpcUsed, blmFltrOffHeapMemUs
 report.cassandra.metrics.keyspace.newts.TotalLatency.type=interfaceSnmp
 report.cassandra.metrics.keyspace.newts.TotalLatency.command=--title="Bloom Filter Disk and Memory" \
  --vertical-label="micro seconds" \
- DEF:val1={rrd1}:keyspace.newts.BloomFilterDiskSpaceUsed:AVERAGE \
- DEF:val2={rrd2}:keyspace.newts.BloomFilterOffHeapMemoryUsed:AVERAGE \
- LINE1.5:val1#75507b:"Disk Space Used      " \
+ DEF:val1={rrd1}:blmFltrDskSpcUsed:AVERAGE \
+ DEF:val2={rrd2}:blmFltrOffHeapMemUs:AVERAGE \
+ LINE1.5:val1#f57900:"Disk Space Used      " \
  GPRINT:val1:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:val1:MIN:" Min \\: %8.2lf %s" \
  GPRINT:val1:MAX:" Max \\: %8.2lf %s\\n" \
@@ -135,13 +140,13 @@ report.cassandra.metrics.keyspace.newts.TotalLatency.command=--title="Bloom Filt
  GPRINT:val2:MAX:" Max \\: %8.2lf %s\\n"
 
 report.cassandra.metrics.keyspace.newts.OffHeapMemoryUsed.name=Off-Heap Memory
-report.cassandra.metrics.keyspace.newts.OffHeapMemoryUsed.columns=keyspace.newts.CompressionMetadataOffHeapMemoryUsed, keyspace.newts.IndexSummaryOffHeapMemoryUsed
+report.cassandra.metrics.keyspace.newts.OffHeapMemoryUsed.columns=cmpMetaOffHeapMemUs, idxSumOffHeapMemUs
 report.cassandra.metrics.keyspace.newts.OffHeapMemoryUsed.type=interfaceSnmp
 report.cassandra.metrics.keyspace.newts.OffHeapMemoryUsed.command=--title="Off-Heap Memory" \
  --vertical-label="Size" \
- DEF:val1={rrd1}:keyspace.newts.CompressionMetadataOffHeapMemoryUsed:AVERAGE \
- DEF:val2={rrd2}:keyspace.newts.IndexSummaryOffHeapMemoryUsed:AVERAGE \
- LINE1.5:val1#75507b:"Compression Metadata Off-Heap Memory Used " \
+ DEF:val1={rrd1}:cmpMetaOffHeapMemUs:AVERAGE \
+ DEF:val2={rrd2}:idxSumOffHeapMemUs:AVERAGE \
+ LINE1.5:val1#f57900:"Compression Metadata Off-Heap Memory Used " \
  GPRINT:val1:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:val1:MIN:" Min \\: %8.2lf %s" \
  GPRINT:val1:MAX:" Max \\: %8.2lf %s\\n" \
@@ -151,13 +156,13 @@ report.cassandra.metrics.keyspace.newts.OffHeapMemoryUsed.command=--title="Off-H
  GPRINT:val2:MAX:" Max \\: %8.2lf %s\\n"
 
 report.cassandra.metrics.keyspace.newts.pending.name=Newts Pending
-report.cassandra.metrics.keyspace.newts.pending.columns=keyspace.newts.PendingCompactions, keyspace.newts.PendingFlushes
+report.cassandra.metrics.keyspace.newts.pending.columns=pendingCompactions, pendingFlushes
 report.cassandra.metrics.keyspace.newts.pending.type=interfaceSnmp
 report.cassandra.metrics.keyspace.newts.pending.command=--title="Newts Pending" \
  --vertical-label="Number" \
- DEF:val1={rrd1}:keyspace.newts.PendingCompactions:AVERAGE \
- DEF:val2={rrd2}:keyspace.newts.PendingFlushes:AVERAGE \
- LINE1.5:val1#75507b:"Pending Compactions " \
+ DEF:val1={rrd1}:pendingCompactions:AVERAGE \
+ DEF:val2={rrd2}:pendingFlushes:AVERAGE \
+ LINE1.5:val1#f57900:"Pending Compactions " \
  GPRINT:val1:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:val1:MIN:" Min \\: %8.2lf %s" \
  GPRINT:val1:MAX:" Max \\: %8.2lf %s\\n" \
@@ -167,13 +172,13 @@ report.cassandra.metrics.keyspace.newts.pending.command=--title="Newts Pending" 
  GPRINT:val2:MAX:" Max \\: %8.2lf %s\\n"
 
 report.cassandra.metrics.keyspace.newts.DiskSpace.name=Newts Disk Space
-report.cassandra.metrics.keyspace.newts.DiskSpace.columns=keyspace.newts.TotalDiskSpaceUsed, keyspace.newts.LiveDiskSpaceUsed
+report.cassandra.metrics.keyspace.newts.DiskSpace.columns=totalDiskSpaceUsed, liveDiskSpaceUsed
 report.cassandra.metrics.keyspace.newts.DiskSpace.type=interfaceSnmp
 report.cassandra.metrics.keyspace.newts.DiskSpace.command=--title="Newts Disk Space" \
  --vertical-label="Size" \
- DEF:val1={rrd1}:keyspace.newts.TotalDiskSpaceUsed:AVERAGE \
- DEF:val2={rrd2}:keyspace.newts.LiveDiskSpaceUsed:AVERAGE \
- LINE1.5:val1#75507b:"Total Disk Space Used " \
+ DEF:val1={rrd1}:totalDiskSpaceUsed:AVERAGE \
+ DEF:val2={rrd2}:liveDiskSpaceUsed:AVERAGE \
+ LINE1.5:val1#f57900:"Total Disk Space Used " \
  GPRINT:val1:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:val1:MIN:" Min \\: %8.2lf %s" \
  GPRINT:val1:MAX:" Max \\: %8.2lf %s\\n" \


### PR DESCRIPTION
Refactored Cassandra and Newts keyspace specific attributes to be compatible with RRDtool and JRobin matching maximum 19 character limit. Refactoring covers JMX data collection configuration for Cassandra generic metrics and Newts specific metrics including the RRD graph definition templates.

JIRA: http://issues.opennms.org/browse/HZN-474
Bamboo: http://bamboo.internal.opennms.com:8085/browse/OPENNMS-ONMS182-3/