### PR TITLE
Fix for issue NMS-7917

### DIFF
--- a/features/vaadin-dashlets/dashlet-alarms/src/main/java/org/opennms/features/vaadin/dashboard/dashlets/AlarmDetailsDashlet.java
+++ b/features/vaadin-dashlets/dashlet-alarms/src/main/java/org/opennms/features/vaadin/dashboard/dashlets/AlarmDetailsDashlet.java
@@ -212,23 +212,24 @@ public class AlarmDetailsDashlet extends AbstractDashlet {
                     refresh();
                 }
 
-
                 @Override
                 public void refresh() {
                     List<OnmsAlarm> alarms = getAlarms();
 
-                    if (alarms.size()>0) {
-                        List<Integer> alarmIds = new LinkedList<Integer>();
+                    List<Integer> alarmIds = new LinkedList<Integer>();
 
+                    if (alarms.size() > 0) {
                         for (OnmsAlarm onmsAlarm : alarms) {
                             alarmIds.add(onmsAlarm.getId());
                         }
-
-                        List<Restriction> restrictions = new LinkedList<Restriction>();
-                        restrictions.add(new InRestriction("id", alarmIds));
-
-                        ((OnmsDaoContainer) m_alarmTable.getContainerDataSource()).setRestrictions(restrictions);
+                    } else {
+                        alarmIds.add(0);
                     }
+
+                    List<Restriction> restrictions = new LinkedList<Restriction>();
+                    restrictions.add(new InRestriction("id", alarmIds));
+
+                    ((OnmsDaoContainer<?, ?>) m_alarmTable.getContainerDataSource()).setRestrictions(restrictions);
 
                     setBoosted(checkBoosted(alarms));
 


### PR DESCRIPTION
Fix for issue NMS-7917: In the case an Alarm Dashlet's filter criteria returned an empty set of alarmIds the restriction was not correctly applied to the AlarmRepository instance. Now the empty set will be replaced by a set containing only the integer zero (0), so no alarms will match which is the correct expected behavior.

Bamboo: http://bamboo.internal.opennms.com:8085/browse/OPENNMS-ONMS194
Jira: http://issues.opennms.org/browse/NMS-7917