### PR TITLE
HZN-459: Evaluate possibilities to defer between ifHcInOctets and ifInOctets

### DIFF
--- a/features/measurements/api/src/main/java/org/opennms/netmgt/measurements/model/Source.java
+++ b/features/measurements/api/src/main/java/org/opennms/netmgt/measurements/model/Source.java
@@ -64,6 +64,12 @@ public class Source {
     private String attribute;
 
     /**
+     * fallback Attribute name.
+     * i.e. ifInOctets
+     */
+    private String fallbackAttribute;
+
+    /**
      * Data source name. Typically the same as the attribute name, but may differ
      * if an attribute contains multiple data sources.
      *
@@ -123,6 +129,15 @@ public class Source {
 
     public void setAttribute(final String attribute) {
         this.attribute = attribute;
+    }
+
+    @XmlAttribute(name = "fallback-attribute")
+    public String getFallbackAttribute() {
+        return this.fallbackAttribute;
+    }
+
+    public void setFallbackAttribute(final String fallbackAttribute) {
+        this.fallbackAttribute = fallbackAttribute;
     }
 
     @XmlAttribute(name = "datasource")

--- a/features/measurements/impl/src/main/java/org/opennms/netmgt/measurements/impl/AbstractRrdBasedFetchStrategy.java
+++ b/features/measurements/impl/src/main/java/org/opennms/netmgt/measurements/impl/AbstractRrdBasedFetchStrategy.java
@@ -44,6 +44,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import com.google.common.base.Strings;
 import com.google.common.collect.Maps;
 
 /**
@@ -79,8 +80,15 @@ public abstract class AbstractRrdBasedFetchStrategy implements MeasurementFetchS
             }
 
             // Grab the attribute
-            final RrdGraphAttribute rrdGraphAttribute = resource
-                    .getRrdGraphAttributes().get(source.getAttribute());
+            RrdGraphAttribute rrdGraphAttribute = resource.getRrdGraphAttributes().get(source.getAttribute());
+
+            if (rrdGraphAttribute == null && !Strings.isNullOrEmpty(source.getFallbackAttribute())) {
+                LOG.error("No attribute with name '{}', using fallback-attribute with name '{}'", source.getAttribute(), source.getFallbackAttribute());
+                source.setAttribute(source.getFallbackAttribute());
+                source.setFallbackAttribute(null);
+                rrdGraphAttribute = resource.getRrdGraphAttributes().get(source.getAttribute());
+            }
+
             if (rrdGraphAttribute == null) {
                 LOG.error("No attribute with name: {}", source.getAttribute());
                 return null;

--- a/features/measurements/rest/src/main/java/org/opennms/web/rest/v1/MeasurementsRestService.java
+++ b/features/measurements/rest/src/main/java/org/opennms/web/rest/v1/MeasurementsRestService.java
@@ -67,6 +67,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.collect.RowSortedTable;
 
@@ -134,6 +135,7 @@ public class MeasurementsRestService {
             @DefaultValue("0") @QueryParam("end") final long end,
             @DefaultValue("300000") @QueryParam("step") final long step,
             @DefaultValue("0") @QueryParam("maxrows") final int maxrows,
+            @DefaultValue("") @QueryParam("fallback-attribute") final String fallbackAttribute,
             @DefaultValue("AVERAGE") @QueryParam("aggregation") final String aggregation) {
 
         QueryRequest request = new QueryRequest();
@@ -151,6 +153,7 @@ public class MeasurementsRestService {
 
         // Use the attribute name as the datasource and label
         Source source = new Source(attribute, resourceId, attribute, attribute, false);
+        source.setFallbackAttribute(fallbackAttribute);
         source.setAggregation(aggregation);
         request.setSources(Lists.newArrayList(source));
 

--- a/features/newts/src/main/java/org/opennms/netmgt/measurements/impl/NewtsFetchStrategy.java
+++ b/features/newts/src/main/java/org/opennms/netmgt/measurements/impl/NewtsFetchStrategy.java
@@ -60,6 +60,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Optional;
+import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
@@ -135,8 +136,15 @@ public class NewtsFetchStrategy implements MeasurementFetchStrategy {
                 Utils.convertStringAttributesToConstants(source.getLabel(), resource.getStringPropertyAttributes(), constants);
 
                 // Grab the attribute that matches the source
-                final RrdGraphAttribute rrdGraphAttribute = resource
-                        .getRrdGraphAttributes().get(source.getAttribute());
+                RrdGraphAttribute rrdGraphAttribute = resource.getRrdGraphAttributes().get(source.getAttribute());
+
+                if (rrdGraphAttribute == null && !Strings.isNullOrEmpty(source.getFallbackAttribute())) {
+                    LOG.error("No attribute with name '{}', using fallback-attribute with name '{}'", source.getAttribute(), source.getFallbackAttribute());
+                    source.setAttribute(source.getFallbackAttribute());
+                    source.setFallbackAttribute(null);
+                    rrdGraphAttribute = resource.getRrdGraphAttributes().get(source.getAttribute());
+                }
+
                 if (rrdGraphAttribute == null) {
                     LOG.error("No attribute with name: {}", source.getAttribute());
                     return null;

--- a/opennms-doc/guide-development/src/asciidoc/text/rest/measurements.adoc
+++ b/opennms-doc/guide-development/src/asciidoc/text/rest/measurements.adoc
@@ -15,12 +15,13 @@ The following table shows all supported query string parameters and their defaul
 
 [options="header"]
 |===
-| name        | default   | comment
-| start       | -14400000 | Timestamp in milliseconds. If < 0, the effective value will be (end + start).
-| end         | 0         | Timestamp in milliseconds. If <= 0, the effective value will be the current timestamp.
-| step        | 300000    | Requested time interval between rows. Actual step may differ. Set to 1 for maximum accuracy.
-| maxrows     | 0         | When using the measurements to render a graph, this should be set to the graph's pixel width.
-| aggregation | AVERAGE   | Consolidation function used. Can typically be `AVERAGE`, `MIN` or `MAX`. Depends on `RRA` definitions.
+| name               | default   | comment
+| start              | -14400000 | Timestamp in milliseconds. If < 0, the effective value will be (end + start).
+| end                | 0         | Timestamp in milliseconds. If <= 0, the effective value will be the current timestamp.
+| step               | 300000    | Requested time interval between rows. Actual step may differ. Set to 1 for maximum accuracy.
+| maxrows            | 0         | When using the measurements to render a graph, this should be set to the graph's pixel width.
+| aggregation        | AVERAGE   | Consolidation function used. Can typically be `AVERAGE`, `MIN` or `MAX`. Depends on `RRA` definitions.
+| fallback-attribute |           | Secondary attribute that will be queried in the case the primary attribute does not exist.
 |===
 
 ===== Usage examples with curl


### PR DESCRIPTION
HZN-459: Evaluate possibilities to defer between ifHcInOctets and ifInOctets
Introduced an fallback-attribute parameter in the Source model to allow to query for 
a secondary attribute if the primary one does not exist.

Jira: http://issues.opennms.org/browse/HZN-459
Bamboo: http://bamboo.internal.opennms.com:8085/browse/OPENNMS-ONMS195-3