### PR TITLE
HZN-475: Cleanup graph definitions

### DIFF
--- a/opennms-base-assembly/src/main/filtered/etc/jmx-datacollection-config.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/jmx-datacollection-config.xml
@@ -342,11 +342,17 @@
                 <attrib name="Value" alias="cpctPendingTasks" type="gauge"/>
             </mbean>
 
-            <!-- Dropped Messages -->
-            <mbean name="org.apache.cassandra.metrics.DroppedMessage"
-                   objectname="org.apache.cassandra.metrics:type=DroppedMessage,scope=BINARY,name=Dropped">
-                <attrib name="Count" alias="drpdMsgBinary" type="gauge"/>
+            <!-- Storage -->
+            <mbean name="org.apache.cassandra.metrics.Storage"
+                   objectname="org.apache.cassandra.metrics:type=Storage,name=Load">
+                <attrib name="Count" alias="strgLoad" type="counter"/>
             </mbean>
+            <mbean name="org.apache.cassandra.metrics.Storage"
+                   objectname="org.apache.cassandra.metrics:type=Storage,name=Exceptions">
+                <attrib name="Count" alias="strgExceptions" type="counter"/>
+            </mbean>
+
+            <!-- Dropped Messages -->
             <mbean name="org.apache.cassandra.metrics.DroppedMessage"
                    objectname="org.apache.cassandra.metrics:type=DroppedMessage,scope=READ,name=Dropped">
                 <attrib name="Count" alias="drpdMsgRead" type="gauge"/>
@@ -364,34 +370,12 @@
                 <attrib name="Count" alias="drpdMsgRangeSlice" type="gauge"/>
             </mbean>
             <mbean name="org.apache.cassandra.metrics.DroppedMessage"
-                   objectname="org.apache.cassandra.metrics:type=DroppedMessage,scope=_TRACE,name=Dropped">
-                <attrib name="Count" alias="drpdMsgTrace" type="gauge"/>
-            </mbean>
-            <mbean name="org.apache.cassandra.metrics.DroppedMessage"
-                   objectname="org.apache.cassandra.metrics:type=DroppedMessage,scope=COUNTER_MUTATION,name=Dropped">
-                <attrib name="Count" alias="drpdMsgCntrMutation" type="gauge"/>
-            </mbean>
-            <mbean name="org.apache.cassandra.metrics.DroppedMessage"
                    objectname="org.apache.cassandra.metrics:type=DroppedMessage,scope=MUTATION,name=Dropped">
                 <attrib name="Count" alias="drpdMsgMutation" type="gauge"/>
             </mbean>
             <mbean name="org.apache.cassandra.metrics.DroppedMessage"
                    objectname="org.apache.cassandra.metrics:type=DroppedMessage,scope=PAGED_RANGE,name=Dropped">
                 <attrib name="Count" alias="drpdMsgPagedRange" type="gauge"/>
-            </mbean>
-
-            <!-- Storage -->
-            <mbean name="org.apache.cassandra.metrics.Storage"
-                   objectname="org.apache.cassandra.metrics:type=Storage,name=Load">
-                <attrib name="Count" alias="strgLoad" type="counter"/>
-            </mbean>
-            <mbean name="org.apache.cassandra.metrics.Storage"
-                   objectname="org.apache.cassandra.metrics:type=Storage,name=Exceptions">
-                <attrib name="Count" alias="strgExceptions" type="counter"/>
-            </mbean>
-            <mbean name="org.apache.cassandra.metrics.Storage"
-                   objectname="org.apache.cassandra.metrics:type=Storage,name=TotalHints">
-                <attrib name="Count" alias="strgTotalHints" type="counter"/>
             </mbean>
 
             <!-- ThreadPools :: MemtableFlushWriter -->
@@ -408,8 +392,8 @@
                  <attrib name="Value" alias="tpIntMemTblFlsWrPt" type="gauge"/>
             </mbean>
             <mbean name="org.apache.cassandra.metrics.ThreadPools"
-                   objectname="org.apache.cassandra.metrics:type=ThreadPools,path=internal,scope=MemtableFlushWriter,name=TotalBlockedTasks">
-                 <attrib name="Count" alias="tpIntMemTblFlsWrTbt" type="counter"/>
+                   objectname="org.apache.cassandra.metrics:type=ThreadPools,path=internal,scope=MemtableFlushWriter,name=CompletedTasks">
+                <attrib name="Count" alias="tpIntMemTblFlsWrCt" type="counter"/>
             </mbean>
 
             <!-- ThreadPools :: MemtablePostFlush -->
@@ -426,26 +410,8 @@
                  <attrib name="Value" alias="tpIntMemTblPoFlsPt" type="gauge"/>
             </mbean>
             <mbean name="org.apache.cassandra.metrics.ThreadPools"
-                   objectname="org.apache.cassandra.metrics:type=ThreadPools,path=internal,scope=MemtablePostFlush,name=TotalBlockedTasks">
-                 <attrib name="Count" alias="tpIntMemTblPoFlsTbt" type="counter"/>
-            </mbean>
-
-            <!-- ThreadPools :: MemtableReclaimMemory -->
-            <mbean name="org.apache.cassandra.metrics.ThreadPools"
-                   objectname="org.apache.cassandra.metrics:type=ThreadPools,path=internal,scope=MemtableReclaimMemory,name=ActiveTasks">
-                 <attrib name="Value" alias="tpIntMemTblReMemAt" type="gauge"/>
-            </mbean>
-            <mbean name="org.apache.cassandra.metrics.ThreadPools"
-                   objectname="org.apache.cassandra.metrics:type=ThreadPools,path=internal,scope=MemtableReclaimMemory,name=CurrentlyBlockedTasks">
-                  <attrib name="Count" alias="tpIntMemTblReMemCbt" type="counter"/>
-            </mbean>
-            <mbean name="org.apache.cassandra.metrics.ThreadPools"
-                   objectname="org.apache.cassandra.metrics:type=ThreadPools,path=internal,scope=MemtableReclaimMemory,name=PendingTasks">
-                 <attrib name="Value" alias="tpIntMemTblReMemPt" type="gauge"/>
-            </mbean>
-            <mbean name="org.apache.cassandra.metrics.ThreadPools"
-                   objectname="org.apache.cassandra.metrics:type=ThreadPools,path=internal,scope=MemtableReclaimMemory,name=TotalBlockedTasks">
-                  <attrib name="Count" alias="tpIntMemTblReMemTbt" type="counter"/>
+                   objectname="org.apache.cassandra.metrics:type=ThreadPools,path=internal,scope=MemtablePostFlush,name=CompletedTasks">
+                <attrib name="Count" alias="tpIntMemTblPoFlsCt" type="counter"/>
             </mbean>
 
             <!-- ThreadPools :: AntiEntropyStage -->
@@ -465,10 +431,6 @@
                    objectname="org.apache.cassandra.metrics:type=ThreadPools,path=internal,scope=AntiEntropyStage,name=CompletedTasks">
                   <attrib name="Value" alias="tpIntAntiEntStgeCt" type="gauge"/>
             </mbean>
-            <mbean name="org.apache.cassandra.metrics.ThreadPools"
-                   objectname="org.apache.cassandra.metrics:type=ThreadPools,path=internal,scope=AntiEntropyStage,name=TotalBlockedTasks">
-                  <attrib name="Count" alias="tpIntAntiEntStgeTbt" type="counter"/>
-            </mbean>
 
             <!-- ThreadPools :: GossipStage -->
             <mbean name="org.apache.cassandra.metrics.ThreadPools"
@@ -486,10 +448,6 @@
             <mbean name="org.apache.cassandra.metrics.ThreadPools"
                    objectname="org.apache.cassandra.metrics:type=ThreadPools,path=internal,scope=GossipStage,name=CompletedTasks">
                   <attrib name="Value" alias="tpIntGosStgeCt" type="gauge"/>
-            </mbean>
-            <mbean name="org.apache.cassandra.metrics.ThreadPools"
-                   objectname="org.apache.cassandra.metrics:type=ThreadPools,path=internal,scope=GossipStage,name=TotalBlockedTasks">
-                <attrib name="Value" alias="tpIntGosStgeTbt" type="gauge"/>
             </mbean>
 
             <!-- ThreadPools :: MigrationStage -->
@@ -509,10 +467,6 @@
                    objectname="org.apache.cassandra.metrics:type=ThreadPools,path=internal,scope=MigrationStage,name=CompletedTasks">
                   <attrib name="Value" alias="tpIntMigStgeCt" type="gauge"/>
             </mbean>
-            <mbean name="org.apache.cassandra.metrics.ThreadPools"
-                   objectname="org.apache.cassandra.metrics:type=ThreadPools,path=internal,scope=MigrationStage,name=TotalBlockedTasks">
-                  <attrib name="Count" alias="tpIntMigStgeTbt" type="counter"/>
-            </mbean>
 
             <!-- ThreadPools :: MiscStage -->
             <mbean name="org.apache.cassandra.metrics.ThreadPools"
@@ -530,10 +484,6 @@
             <mbean name="org.apache.cassandra.metrics.ThreadPools"
                    objectname="org.apache.cassandra.metrics:type=ThreadPools,path=internal,scope=MiscStage,name=CompletedTasks">
                   <attrib name="Value" alias="tpIntMiscStgeCt" type="gauge"/>
-            </mbean>
-            <mbean name="org.apache.cassandra.metrics.ThreadPools"
-                   objectname="org.apache.cassandra.metrics:type=ThreadPools,path=internal,scope=MiscStage,name=TotalBlockedTasks">
-                  <attrib name="Count" alias="tpIntMiscStgeTbt" type="counter"/>
             </mbean>
 
             <!-- ThreadPools :: MutationStage -->
@@ -553,10 +503,6 @@
                    objectname="org.apache.cassandra.metrics:type=ThreadPools,path=request,scope=MutationStage,name=CompletedTasks">
                  <attrib name="Value" alias="tpMutStgeCt" type="gauge"/>
             </mbean>
-            <mbean name="org.apache.cassandra.metrics.ThreadPools"
-                   objectname="org.apache.cassandra.metrics:type=ThreadPools,path=request,scope=MutationStage,name=TotalBlockedTasks">
-                 <attrib name="Value" alias="tpMutStgeTbt" type="counter"/>
-            </mbean>
 
             <!-- ThreadPools :: ReadStage -->
             <mbean name="org.apache.cassandra.metrics.ThreadPools"
@@ -574,10 +520,6 @@
             <mbean name="org.apache.cassandra.metrics.ThreadPools"
                    objectname="org.apache.cassandra.metrics:type=ThreadPools,path=request,scope=ReadStage,name=PendingTasks">
                  <attrib name="Value" alias="tpReadStagePt" type="gauge"/>
-            </mbean>
-            <mbean name="org.apache.cassandra.metrics.ThreadPools"
-                   objectname="org.apache.cassandra.metrics:type=ThreadPools,path=request,scope=ReadStage,name=TotalBlockedTasks">
-                 <attrib name="Value" alias="tpReadStageTbt" type="counter"/>
             </mbean>
 
             <!-- ThreadPools :: RequestResponseStage -->
@@ -597,10 +539,6 @@
                    objectname="org.apache.cassandra.metrics:type=ThreadPools,path=request,scope=RequestResponseStage,name=PendingTasks">
                 <attrib name="Value" alias="tpReqRespStgePt" type="gauge"/>
             </mbean>
-            <mbean name="org.apache.cassandra.metrics.ThreadPools"
-                   objectname="org.apache.cassandra.metrics:type=ThreadPools,path=request,scope=RequestResponseStage,name=TotalBlockedTasks">
-                <attrib name="Value" alias="tpReqRespStgeTbt" type="counter"/>
-            </mbean>
 
             <!-- ThreadPools :: ReadRepairStage -->
             <mbean name="org.apache.cassandra.metrics.ThreadPools"
@@ -609,19 +547,15 @@
             </mbean>
             <mbean name="org.apache.cassandra.metrics.ThreadPools"
                    objectname="org.apache.cassandra.metrics:type=ThreadPools,path=request,scope=ReadRepairStage,name=CurrentlyBlockedTasks">
-                <attrib name="Count" alias="tpReqRespStgeCbt" type="counter"/>
+                <attrib name="Count" alias="tpReadRepairStgeCbt" type="counter"/>
             </mbean>
             <mbean name="org.apache.cassandra.metrics.ThreadPools"
                    objectname="org.apache.cassandra.metrics:type=ThreadPools,path=request,scope=ReadRepairStage,name=CompletedTasks">
-                <attrib name="Value" alias="tpReqRespStgeCt" type="gauge"/>
+                <attrib name="Value" alias="tpReadRepairStgeCt" type="gauge"/>
             </mbean>
             <mbean name="org.apache.cassandra.metrics.ThreadPools"
                    objectname="org.apache.cassandra.metrics:type=ThreadPools,path=request,scope=ReadRepairStage,name=PendingTasks">
-                <attrib name="Value" alias="tpReqRespStgePt" type="gauge"/>
-            </mbean>
-            <mbean name="org.apache.cassandra.metrics.ThreadPools"
-                   objectname="org.apache.cassandra.metrics:type=ThreadPools,path=request,scope=ReadRepairStage,name=TotalBlockedTasks">
-                <attrib name="Count" alias="tpReqRespStgeTbt" type="counter"/>
+                <attrib name="Value" alias="tpReadRepairStgePt" type="gauge"/>
             </mbean>
         </mbeans>
     </jmx-collection>
@@ -681,7 +615,6 @@
             </mbean>
             <mbean name="org.apache.cassandra.metrics.Keyspace"
                    objectname="org.apache.cassandra.metrics:type=Keyspace,keyspace=newts,name=RangeLatency">
-                <attrib name="Count" alias="rangeLtncy" type="gauge"/>
                 <attrib name="99thPercentile" alias="rangeLtncy99" type="gauge"/>
             </mbean>
             <mbean name="org.apache.cassandra.metrics.Keyspace"

--- a/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/cassandra21x-graph.properties
+++ b/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/cassandra21x-graph.properties
@@ -1,17 +1,17 @@
 reports=cassandra.metrics.Client, \
 cassandra.metrics.Compaction.Bytes, \
 cassandra.metrics.Compaction.Tasks, \
+cassandra.metrics.Storage.Load, \
+cassandra.metrics.Storage.Exceptions, \
 cassandra.metrics.DroppedMessages, \
-cassandra.metrics.Storage, \
 cassandra.metrics.ThreadPools.internal.MemtableFlushWriter, \
 cassandra.metrics.ThreadPools.internal.MemtablePostFlush, \
-cassandra.metrics.ThreadPools.internal.MemtableReclaimMemory, \
 cassandra.metrics.ThreadPools.internal.AntiEntropyStage, \
 cassandra.metrics.ThreadPools.internal.GossipStage, \
 cassandra.metrics.ThreadPools.internal.MigrationStage, \
 cassandra.metrics.ThreadPools.internal.MiscStage, \
 cassandra.metrics.ThreadPools.MutationStage, \
-cassandra.metrics.ThreadPools.ReadStage, \
+cassandra.metrics.ThreadPools.request.ReadStage, \
 cassandra.metrics.ThreadPools.RequestResponseStage, \
 cassandra.metrics.ThreadPools.ReadRepairStage
 
@@ -19,28 +19,26 @@ report.cassandra.metrics.Client.name=Cassandra Client Connections
 report.cassandra.metrics.Client.columns=clntConNativeClnts, clntConThriftClnts
 report.cassandra.metrics.Client.type=interfaceSnmp
 report.cassandra.metrics.Client.command=--title="Cassandra Client Connections" \
- --vertical-label="Number" \
+ --vertical-label="Clients" \
  DEF:val1={rrd1}:clntConNativeClnts:AVERAGE \
  DEF:val2={rrd2}:clntConThriftClnts:AVERAGE \
- AREA:val1#edd400 \
- LINE2:val1#c4a000:"Connected Native Clients" \
+ AREA:val1#cc0000:"Connected Native Clients" \
  GPRINT:val1:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:val1:MIN:" Min \\: %8.2lf %s" \
  GPRINT:val1:MAX:" Max \\: %8.2lf %s\\n" \
- AREA:val2#f57900 \
- LINE2:val2#ce5c00:"Connected Thrift Clients" \
+ STACK:val2#f57900:"Connected Thrift Clients" \
  GPRINT:val2:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:val2:MIN:" Min \\: %8.2lf %s" \
  GPRINT:val2:MAX:" Max \\: %8.2lf %s\\n"
 
-report.cassandra.metrics.Compaction.Bytes.name=Cassandra Compaction Bytes
+report.cassandra.metrics.Compaction.Bytes.name=Cassandra Compaction
 report.cassandra.metrics.Compaction.Bytes.columns=cpctBytesCompacted
 report.cassandra.metrics.Compaction.Bytes.type=interfaceSnmp
-report.cassandra.metrics.Compaction.Bytes.command=--title="Cassandra Compaction Bytes" \
+report.cassandra.metrics.Compaction.Bytes.command=--title="Cassandra Compaction" \
  --vertical-label="Bytes" \
  DEF:val1={rrd1}:cpctBytesCompacted:AVERAGE \
- AREA:val1#edd400 \
- LINE2:val1#c4a000:"Bytes Compacted" \
+ AREA:val1#babdb6 \
+ LINE1.5:val1#888a85:"Bytes Compacted" \
  GPRINT:val1:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:val1:MIN:" Min \\: %8.2lf %s" \
  GPRINT:val1:MAX:" Max \\: %8.2lf %s\\n"
@@ -49,404 +47,315 @@ report.cassandra.metrics.Compaction.Tasks.name=Cassandra Compaction Tasks
 report.cassandra.metrics.Compaction.Tasks.columns=cpctPendingTasks, cpctCompletedTasks
 report.cassandra.metrics.Compaction.Tasks.type=interfaceSnmp
 report.cassandra.metrics.Compaction.Tasks.command=--title="Cassandra Compaction Tasks" \
- --vertical-label="Number" \
+ --vertical-label="Tasks" \
  DEF:val1={rrd1}:cpctPendingTasks:AVERAGE \
  DEF:val2={rrd2}:cpctCompletedTasks:AVERAGE \
- AREA:val1#edd400 \
- LINE2:val1#c4a000:"Compaction Tasks Pending  " \
+ AREA:val1#cc0000:"Compaction Tasks Pending  " \
  GPRINT:val1:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:val1:MIN:" Min \\: %8.2lf %s" \
  GPRINT:val1:MAX:" Max \\: %8.2lf %s\\n" \
- AREA:val2#f57900 \
- LINE2:val2#ce5c00:"Compaction Tasks Completed" \
+ STACK:val2#f57900:"Compaction Tasks Completed" \
  GPRINT:val2:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:val2:MIN:" Min \\: %8.2lf %s" \
  GPRINT:val2:MAX:" Max \\: %8.2lf %s\\n"
 
+report.cassandra.metrics.Storage.Load.name=Cassandra Storage Load
+report.cassandra.metrics.Storage.Load.columns=strgLoad
+report.cassandra.metrics.Storage.Load.type=interfaceSnmp
+report.cassandra.metrics.Storage.Load.command=--title="Cassandra Storage Load" \
+ --vertical-label="Bytes" \
+ DEF:val1={rrd1}:strgLoad:AVERAGE \
+ AREA:val1#babdb6 \
+ LINE1.5:val1#888a85:"Storage Load " \
+ GPRINT:val1:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:val1:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:val1:MAX:" Max \\: %8.2lf %s\\n"
+
+report.cassandra.metrics.Storage.Exceptions.name=Cassandra Exceptions
+report.cassandra.metrics.Storage.Exceptions.columns=strgExceptions
+report.cassandra.metrics.Storage.Exceptions.type=interfaceSnmp
+report.cassandra.metrics.Storage.Exceptions.command=--title="Cassandra Exceptions" \
+ --vertical-label="Exceptions" \
+ DEF:val1={rrd1}:strgExceptions:AVERAGE \
+ LINE1.5:val1#3465a4:"Unhandled Exceptions " \
+ GPRINT:val1:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:val1:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:val1:MAX:" Max \\: %8.2lf %s\\n"
+
 report.cassandra.metrics.DroppedMessages.name=Cassandra Dropped Messages
-report.cassandra.metrics.DroppedMessages.columns=drpdMsgBinary, drpdMsgRead, drpdMsgReadRepair, drpdMsgReqResp, drpdMsgRangeSlice, drpdMsgTrace, drpdMsgCntrMutation, drpdMsgMutation
+report.cassandra.metrics.DroppedMessages.columns=drpdMsgRead, drpdMsgReadRepair, drpdMsgReqResp, drpdMsgRangeSlice, drpdMsgMutation
 report.cassandra.metrics.DroppedMessages.type=interfaceSnmp
 report.cassandra.metrics.DroppedMessages.command=--title="Cassandra Dropped Messages" \
- --vertical-label="Number of Dropped Messages" \
- DEF:val1={rrd1}:drpdMsgBinary:AVERAGE \
- DEF:val2={rrd2}:drpdMsgRead:AVERAGE \
- DEF:val3={rrd3}:drpdMsgReadRepair:AVERAGE \
- DEF:val4={rrd4}:drpdMsgReqResp:AVERAGE \
- DEF:val5={rrd5}:drpdMsgRangeSlice:AVERAGE \
- DEF:val6={rrd6}:drpdMsgTrace:AVERAGE \
- DEF:val7={rrd7}:drpdMsgCntrMutation:AVERAGE \
- DEF:val8={rrd8}:drpdMsgMutation:AVERAGE \
- LINE1.5:val1#edd400:"Binary           " \
+ --vertical-label="Dropped Messages" \
+ DEF:val1={rrd1}:drpdMsgRead:AVERAGE \
+ DEF:val2={rrd2}:drpdMsgReadRepair:AVERAGE \
+ DEF:val3={rrd3}:drpdMsgReqResp:AVERAGE \
+ DEF:val4={rrd4}:drpdMsgRangeSlice:AVERAGE \
+ DEF:val5={rrd5}:drpdMsgMutation:AVERAGE \
+ LINE1.5:val1#f57900:"Read             " \
  GPRINT:val1:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:val1:MIN:" Min \\: %8.2lf %s" \
  GPRINT:val1:MAX:" Max \\: %8.2lf %s\\n" \
- LINE1.5:val2#f57900:"Read             " \
+ LINE1.5:val2#cc0000:"Read Repair      " \
  GPRINT:val2:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:val2:MIN:" Min \\: %8.2lf %s" \
  GPRINT:val2:MAX:" Max \\: %8.2lf %s\\n" \
- LINE1.5:val3#c17d11:"Read Repair      " \
+ LINE1.5:val3#4e9a06:"Request Response " \
  GPRINT:val3:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:val3:MIN:" Min \\: %8.2lf %s" \
  GPRINT:val3:MAX:" Max \\: %8.2lf %s\\n" \
- LINE1.5:val4#73d216:"Request Response " \
+ LINE1.5:val4#3465a4:"Range Slice      " \
  GPRINT:val4:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:val4:MIN:" Min \\: %8.2lf %s" \
  GPRINT:val4:MAX:" Max \\: %8.2lf %s\\n" \
- LINE1.5:val5#3465a4:"Range Slice      " \
+ LINE1.5:val5#5c3566:"Message Mutation " \
  GPRINT:val5:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:val5:MIN:" Min \\: %8.2lf %s" \
- GPRINT:val5:MAX:" Max \\: %8.2lf %s\\n" \
- LINE1.5:val6#ad7fa8:"Trace            " \
- GPRINT:val6:AVERAGE:" Avg \\: %8.2lf %s" \
- GPRINT:val6:MIN:" Min \\: %8.2lf %s" \
- GPRINT:val6:MAX:" Max \\: %8.2lf %s\\n" \
- LINE1.5:val7#555753:"Counter Mutation " \
- GPRINT:val7:AVERAGE:" Avg \\: %8.2lf %s" \
- GPRINT:val7:MIN:" Min \\: %8.2lf %s" \
- GPRINT:val7:MAX:" Max \\: %8.2lf %s\\n" \
- LINE1.5:val8#5c3566:"Message Mutation " \
- GPRINT:val8:AVERAGE:" Avg \\: %8.2lf %s" \
- GPRINT:val8:MIN:" Min \\: %8.2lf %s" \
- GPRINT:val8:MAX:" Max \\: %8.2lf %s\\n"
-
-report.cassandra.metrics.Storage.name=Cassandra Storage
-report.cassandra.metrics.Storage.columns=strgLoad, strgExceptions, strgTotalHints
-report.cassandra.metrics.Storage.type=interfaceSnmp
-report.cassandra.metrics.Storage.command=--title="Cassandra Storage" \
- --vertical-label="Number" \
- DEF:val1={rrd1}:strgLoad:AVERAGE \
- DEF:val2={rrd2}:strgExceptions:AVERAGE \
- DEF:val3={rrd3}:strgTotalHints:AVERAGE \
- LINE1.5:val1#75507b:"Load        " \
- GPRINT:val1:AVERAGE:" Avg \\: %8.2lf %s" \
- GPRINT:val1:MIN:" Min \\: %8.2lf %s" \
- GPRINT:val1:MAX:" Max \\: %8.2lf %s\\n" \
- LINE1.5:val2#75507b:"Exceptions  " \
- GPRINT:val2:AVERAGE:" Avg \\: %8.2lf %s" \
- GPRINT:val2:MIN:" Min \\: %8.2lf %s" \
- GPRINT:val2:MAX:" Max \\: %8.2lf %s\\n" \
- LINE1.5:val3#75507b:"Total Hints " \
- GPRINT:val3:AVERAGE:" Avg \\: %8.2lf %s" \
- GPRINT:val3:MIN:" Min \\: %8.2lf %s" \
- GPRINT:val3:MAX:" Max \\: %8.2lf %s\\n"
+ GPRINT:val5:MAX:" Max \\: %8.2lf %s\\n"
 
 report.cassandra.metrics.ThreadPools.internal.MemtableFlushWriter.name=Cassandra Thread Pool Memtable Flush Writer
-report.cassandra.metrics.ThreadPools.internal.MemtableFlushWriter.columns=tpIntMemTblFlsWrAt, tpIntMemTblFlsWrCbt, tpIntMemTblFlsWrTbt
+report.cassandra.metrics.ThreadPools.internal.MemtableFlushWriter.columns=tpIntMemTblFlsWrAt, tpIntMemTblFlsWrCbt
 report.cassandra.metrics.ThreadPools.internal.MemtableFlushWriter.type=interfaceSnmp
 report.cassandra.metrics.ThreadPools.internal.MemtableFlushWriter.command=--title="Cassandra Thread Pool Memtable Flush Writer" \
- --vertical-label="Number" \
+ --vertical-label="Tasks" \
  DEF:val1={rrd1}:tpIntMemTblFlsWrAt:AVERAGE \
  DEF:val2={rrd2}:tpIntMemTblFlsWrCbt:AVERAGE \
- DEF:val3={rrd3}:tpIntMemTblFlsWrTbt:AVERAGE \
- LINE1.5:val1#75507b:"Active Tasks            " \
+ LINE1.5:val1#cc0000:"Active Tasks            " \
  GPRINT:val1:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:val1:MIN:" Min \\: %8.2lf %s" \
  GPRINT:val1:MAX:" Max \\: %8.2lf %s\\n" \
- LINE1.5:val2#75507b:"Currently Blocked Tasks " \
+ LINE1.5:val2#f57900:"Currently Blocked Tasks " \
  GPRINT:val2:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:val2:MIN:" Min \\: %8.2lf %s" \
- GPRINT:val2:MAX:" Max \\: %8.2lf %s\\n" \
- LINE1.5:val3#75507b:"Total Blocked Tasks     " \
- GPRINT:val3:AVERAGE:" Avg \\: %8.2lf %s" \
- GPRINT:val3:MIN:" Min \\: %8.2lf %s" \
- GPRINT:val3:MAX:" Max \\: %8.2lf %s\\n"
+ GPRINT:val2:MAX:" Max \\: %8.2lf %s\\n"
 
 report.cassandra.metrics.ThreadPools.internal.MemtablePostFlush.name=Cassandra Thread Pool Memtable Post Flush Writer
-report.cassandra.metrics.ThreadPools.internal.MemtablePostFlush.columns=tpIntMemTblPoFlsAt, tpIntMemTblPoFlsCbt, tpIntMemTblPoFlsPt, tpIntMemTblPoFlsTbt
+report.cassandra.metrics.ThreadPools.internal.MemtablePostFlush.columns=tpIntMemTblPoFlsAt, tpIntMemTblPoFlsCbt, tpIntMemTblPoFlsPt
 report.cassandra.metrics.ThreadPools.internal.MemtablePostFlush.type=interfaceSnmp
 report.cassandra.metrics.ThreadPools.internal.MemtablePostFlush.command=--title="Cassandra Thread Pool Memtable Post Flush Writer" \
- --vertical-label="Number" \
+ --vertical-label="Tasks" \
  DEF:val1={rrd1}:tpIntMemTblPoFlsAt:AVERAGE \
  DEF:val2={rrd2}:tpIntMemTblPoFlsCbt:AVERAGE \
  DEF:val3={rrd3}:tpIntMemTblPoFlsPt:AVERAGE \
- DEF:val4={rrd4}:tpIntMemTblPoFlsTbt:AVERAGE \
- LINE1.5:val1#75507b:"Active Tasks            " \
+ LINE1.5:val1#cc0000:"Active Tasks            " \
  GPRINT:val1:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:val1:MIN:" Min \\: %8.2lf %s" \
  GPRINT:val1:MAX:" Max \\: %8.2lf %s\\n" \
- LINE1.5:val2#75507b:"Currently Blocked Tasks " \
+ LINE1.5:val2#f57900:"Currently Blocked Tasks " \
  GPRINT:val2:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:val2:MIN:" Min \\: %8.2lf %s" \
  GPRINT:val2:MAX:" Max \\: %8.2lf %s\\n" \
- LINE1.5:val3#75507b:"Pending Tasks           " \
+ LINE1.5:val3#3465a4:"Pending Tasks           " \
  GPRINT:val3:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:val3:MIN:" Min \\: %8.2lf %s" \
- GPRINT:val3:MAX:" Max \\: %8.2lf %s\\n" \
- LINE1.5:val4#75507b:"Total Blocked Tasks     " \
- GPRINT:val4:AVERAGE:" Avg \\: %8.2lf %s" \
- GPRINT:val4:MIN:" Min \\: %8.2lf %s" \
- GPRINT:val4:MAX:" Max \\: %8.2lf %s\\n"
-
-report.cassandra.metrics.ThreadPools.internal.MemtableReclaimMemory.name=Cassandra Thread Pool Memtable Reclaim Memory
-report.cassandra.metrics.ThreadPools.internal.MemtableReclaimMemory.columns=tpIntMemTblReMemAt, tpIntMemTblReMemCbt, tpIntMemTblReMemPt, tpIntMemTblReMemTbt
-report.cassandra.metrics.ThreadPools.internal.MemtableReclaimMemory.type=interfaceSnmp
-report.cassandra.metrics.ThreadPools.internal.MemtableReclaimMemory.command=--title="Cassandra Thread Pool Memtable Reclaim Memory" \
- --vertical-label="Number" \
- DEF:val1={rrd1}:tpIntMemTblReMemAt:AVERAGE \
- DEF:val2={rrd2}:tpIntMemTblReMemCbt:AVERAGE \
- DEF:val3={rrd3}:tpIntMemTblReMemPt:AVERAGE \
- DEF:val4={rrd4}:tpIntMemTblReMemTbt:AVERAGE \
- LINE1.5:val1#75507b:"Active Tasks            " \
- GPRINT:val1:AVERAGE:" Avg \\: %8.2lf %s" \
- GPRINT:val1:MIN:" Min \\: %8.2lf %s" \
- GPRINT:val1:MAX:" Max \\: %8.2lf %s\\n" \
- LINE1.5:val2#75507b:"Currently Blocked Tasks " \
- GPRINT:val2:AVERAGE:" Avg \\: %8.2lf %s" \
- GPRINT:val2:MIN:" Min \\: %8.2lf %s" \
- GPRINT:val2:MAX:" Max \\: %8.2lf %s\\n" \
- LINE1.5:val3#75507b:"Pending Tasks           " \
- GPRINT:val3:AVERAGE:" Avg \\: %8.2lf %s" \
- GPRINT:val3:MIN:" Min \\: %8.2lf %s" \
- GPRINT:val3:MAX:" Max \\: %8.2lf %s\\n" \
- LINE1.5:val4#75507b:"Total Blocked Tasks     " \
- GPRINT:val4:AVERAGE:" Avg \\: %8.2lf %s" \
- GPRINT:val4:MIN:" Min \\: %8.2lf %s" \
- GPRINT:val4:MAX:" Max \\: %8.2lf %s\\n"
+ GPRINT:val3:MAX:" Max \\: %8.2lf %s\\n"
 
 report.cassandra.metrics.ThreadPools.internal.AntiEntropyStage.name=Thread Pool Internal Anti-Entropy Stage
-report.cassandra.metrics.ThreadPools.internal.AntiEntropyStage.columns=tpIntAntiEntStgeAt, tpIntAntiEntStgeCbt, tpIntAntiEntStgePt, tpIntAntiEntStgeCt, tpIntAntiEntStgeTbt
+report.cassandra.metrics.ThreadPools.internal.AntiEntropyStage.columns=tpIntAntiEntStgeAt, tpIntAntiEntStgeCbt, tpIntAntiEntStgePt, tpIntAntiEntStgeCt
 report.cassandra.metrics.ThreadPools.internal.AntiEntropyStage.type=interfaceSnmp
 report.cassandra.metrics.ThreadPools.internal.AntiEntropyStage.command=--title="Thread Pool Internal Anti-Entropy Stage" \
- --vertical-label="Number" \
+ --vertical-label="Tasks" \
  DEF:val1={rrd1}:tpIntAntiEntStgeAt:AVERAGE \
  DEF:val2={rrd2}:tpIntAntiEntStgeCbt:AVERAGE \
  DEF:val3={rrd3}:tpIntAntiEntStgePt:AVERAGE \
  DEF:val4={rrd4}:tpIntAntiEntStgeCt:AVERAGE \
- DEF:val5={rrd5}:tpIntAntiEntStgeTbt:AVERAGE \
- LINE1.5:val1#75507b:"Active Tasks            " \
+ LINE1.5:val1#cc0000:"Active Tasks            " \
  GPRINT:val1:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:val1:MIN:" Min \\: %8.2lf %s" \
  GPRINT:val1:MAX:" Max \\: %8.2lf %s\\n" \
- LINE1.5:val2#75507b:"Currently Blocked Tasks " \
+ LINE1.5:val2#f57900:"Currently Blocked Tasks " \
  GPRINT:val2:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:val2:MIN:" Min \\: %8.2lf %s" \
  GPRINT:val2:MAX:" Max \\: %8.2lf %s\\n" \
- LINE1.5:val3#75507b:"Pending Tasks           " \
+ LINE1.5:val3#3465a4:"Pending Tasks           " \
  GPRINT:val3:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:val3:MIN:" Min \\: %8.2lf %s" \
  GPRINT:val3:MAX:" Max \\: %8.2lf %s\\n" \
- LINE1.5:var4#75507b:"Completed Tasks         " \
+ LINE1.5:val4#4e9a06:"Completed Tasks         " \
  GPRINT:val4:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:val4:MIN:" Min \\: %8.2lf %s" \
- GPRINT:val4:MAX:" Max \\: %8.2lf %s\\n" \
- LINE1.5:var5#75507b:"Total Blocked Tasks     " \
- GPRINT:val5:AVERAGE:" Avg \\: %8.2lf %s" \
- GPRINT:val5:MIN:" Min \\: %8.2lf %s" \
- GPRINT:val5:MAX:" Max \\: %8.2lf %s\\n"
+ GPRINT:val4:MAX:" Max \\: %8.2lf %s\\n"
 
 report.cassandra.metrics.ThreadPools.internal.GossipStage.name=Thread Pool Internal Gossip Stage
-report.cassandra.metrics.ThreadPools.internal.GossipStage.columns=tpIntGosStgeAt, tpIntGosStgeCbt, tpIntGosStgePt, tpIntGosStgeCt, tpIntGosStgeTbt
+report.cassandra.metrics.ThreadPools.internal.GossipStage.columns=tpIntGosStgeAt, tpIntGosStgeCbt, tpIntGosStgePt, tpIntGosStgeCt
 report.cassandra.metrics.ThreadPools.internal.GossipStage.type=interfaceSnmp
 report.cassandra.metrics.ThreadPools.internal.GossipStage.command=--title="Thread Pool Internal Gossip Stage" \
- --vertical-label="Number" \
+ --vertical-label="Tasks" \
  DEF:val1={rrd1}:tpIntGosStgeAt:AVERAGE \
  DEF:val2={rrd2}:tpIntGosStgeCbt:AVERAGE \
  DEF:val3={rrd3}:tpIntGosStgePt:AVERAGE \
  DEF:val4={rrd4}:tpIntGosStgeCt:AVERAGE \
- DEF:val5={rrd5}:tpIntGosStgeTbt:AVERAGE \
- LINE1.5:val1#75507b:"Active Tasks            " \
+ LINE1.5:val1#cc0000:"Active Tasks            " \
  GPRINT:val1:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:val1:MIN:" Min \\: %8.2lf %s" \
  GPRINT:val1:MAX:" Max \\: %8.2lf %s\\n" \
- LINE1.5:val2#75507b:"Currently Blocked Tasks " \
+ LINE1.5:val2#f57900:"Currently Blocked Tasks " \
  GPRINT:val2:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:val2:MIN:" Min \\: %8.2lf %s" \
  GPRINT:val2:MAX:" Max \\: %8.2lf %s\\n" \
- LINE1.5:val3#75507b:"Pending Tasks           " \
+ LINE1.5:val3#3465a4:"Pending Tasks           " \
  GPRINT:val3:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:val3:MIN:" Min \\: %8.2lf %s" \
  GPRINT:val3:MAX:" Max \\: %8.2lf %s\\n" \
- LINE1.5:var4#75507b:"Completed Tasks         " \
+ LINE1.5:val4#4e9a06:"Completed Tasks         " \
  GPRINT:val4:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:val4:MIN:" Min \\: %8.2lf %s" \
- GPRINT:val4:MAX:" Max \\: %8.2lf %s\\n" \
- LINE1.5:var5#75507b:"Total Blocked Tasks     " \
- GPRINT:val5:AVERAGE:" Avg \\: %8.2lf %s" \
- GPRINT:val5:MIN:" Min \\: %8.2lf %s" \
- GPRINT:val5:MAX:" Max \\: %8.2lf %s\\n"
+ GPRINT:val4:MAX:" Max \\: %8.2lf %s\\n"
 
 report.cassandra.metrics.ThreadPools.internal.MigrationStage.name=Thread Pool Internal Migration Stage
-report.cassandra.metrics.ThreadPools.internal.MigrationStage.columns=tpIntMigStgeAt, tpIntMigStgeCbt, tpIntMigStgePt, tpIntMigStgeCt, tpIntMigStgeTbt
+report.cassandra.metrics.ThreadPools.internal.MigrationStage.columns=tpIntMigStgeAt, tpIntMigStgeCbt, tpIntMigStgePt, tpIntMigStgeCt
 report.cassandra.metrics.ThreadPools.internal.MigrationStage.type=interfaceSnmp
 report.cassandra.metrics.ThreadPools.internal.MigrationStage.command=--title="Thread Pool Internal Migration Stage" \
- --vertical-label="Number" \
+ --vertical-label="Tasks" \
  DEF:val1={rrd1}:tpIntMigStgeAt:AVERAGE \
  DEF:val2={rrd2}:tpIntMigStgeCbt:AVERAGE \
  DEF:val3={rrd3}:tpIntMigStgePt:AVERAGE \
  DEF:val4={rrd4}:tpIntMigStgeCt:AVERAGE \
- DEF:val5={rrd5}:tpIntMigStgeTbt:AVERAGE \
- LINE1.5:val1#75507b:"Active Tasks            " \
+ LINE1.5:val1#cc0000:"Active Tasks            " \
  GPRINT:val1:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:val1:MIN:" Min \\: %8.2lf %s" \
  GPRINT:val1:MAX:" Max \\: %8.2lf %s\\n" \
- LINE1.5:val2#75507b:"Currently Blocked Tasks " \
+ LINE1.5:val2#f57900:"Currently Blocked Tasks " \
  GPRINT:val2:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:val2:MIN:" Min \\: %8.2lf %s" \
  GPRINT:val2:MAX:" Max \\: %8.2lf %s\\n" \
- LINE1.5:val3#75507b:"Pending Tasks           " \
+ LINE1.5:val3#3465a4:"Pending Tasks           " \
  GPRINT:val3:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:val3:MIN:" Min \\: %8.2lf %s" \
  GPRINT:val3:MAX:" Max \\: %8.2lf %s\\n" \
- LINE1.5:var4#75507b:"Completed Tasks         " \
+ LINE1.5:val4#4e9a06:"Completed Tasks         " \
  GPRINT:val4:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:val4:MIN:" Min \\: %8.2lf %s" \
- GPRINT:val4:MAX:" Max \\: %8.2lf %s\\n" \
- LINE1.5:var5#75507b:"Total Blocked Tasks     " \
- GPRINT:val5:AVERAGE:" Avg \\: %8.2lf %s" \
- GPRINT:val5:MIN:" Min \\: %8.2lf %s" \
- GPRINT:val5:MAX:" Max \\: %8.2lf %s\\n"
+ GPRINT:val4:MAX:" Max \\: %8.2lf %s\\n"
 
 report.cassandra.metrics.ThreadPools.internal.MiscStage.name=Thread Pool Internal Misc Stage
-report.cassandra.metrics.ThreadPools.internal.MiscStage.columns=tpIntMiscStgeAt, tpIntMiscStgeCbt, tpIntMiscStgePt, tpIntMiscStgeCt, tpIntMiscStgeTbt
+report.cassandra.metrics.ThreadPools.internal.MiscStage.columns=tpIntMiscStgeAt, tpIntMiscStgeCbt, tpIntMiscStgePt, tpIntMiscStgeCt
 report.cassandra.metrics.ThreadPools.internal.MiscStage.type=interfaceSnmp
 report.cassandra.metrics.ThreadPools.internal.MiscStage.command=--title="Thread Pool Internal Misc Stage" \
- --vertical-label="Number" \
+ --vertical-label="Tasks" \
  DEF:val1={rrd1}:tpIntMiscStgeAt:AVERAGE \
  DEF:val2={rrd2}:tpIntMiscStgeCbt:AVERAGE \
  DEF:val3={rrd3}:tpIntMiscStgePt:AVERAGE \
  DEF:val4={rrd4}:tpIntMiscStgeCt:AVERAGE \
- DEF:val5={rrd5}:tpIntMiscStgeTbt:AVERAGE \
- LINE1.5:val1#75507b:"Active Tasks            " \
+ LINE1.5:val1#cc0000:"Active Tasks            " \
  GPRINT:val1:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:val1:MIN:" Min \\: %8.2lf %s" \
  GPRINT:val1:MAX:" Max \\: %8.2lf %s\\n" \
- LINE1.5:val2#75507b:"Currently Blocked Tasks " \
+ LINE1.5:val2#f57900:"Currently Blocked Tasks " \
  GPRINT:val2:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:val2:MIN:" Min \\: %8.2lf %s" \
  GPRINT:val2:MAX:" Max \\: %8.2lf %s\\n" \
- LINE1.5:val3#75507b:"Pending Tasks           " \
+ LINE1.5:val3#3465a4:"Pending Tasks           " \
  GPRINT:val3:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:val3:MIN:" Min \\: %8.2lf %s" \
  GPRINT:val3:MAX:" Max \\: %8.2lf %s\\n" \
- LINE1.5:var4#75507b:"Completed Tasks         " \
+ LINE1.5:val4#4e9a06:"Completed Tasks         " \
  GPRINT:val4:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:val4:MIN:" Min \\: %8.2lf %s" \
- GPRINT:val4:MAX:" Max \\: %8.2lf %s\\n" \
- LINE1.5:var5#75507b:"Total Blocked Tasks     " \
- GPRINT:val5:AVERAGE:" Avg \\: %8.2lf %s" \
- GPRINT:val5:MIN:" Min \\: %8.2lf %s" \
- GPRINT:val5:MAX:" Max \\: %8.2lf %s\\n"
+ GPRINT:val4:MAX:" Max \\: %8.2lf %s\\n"
 
 report.cassandra.metrics.ThreadPools.MutationStage.name=Thread Pool Mutation Stage
-report.cassandra.metrics.ThreadPools.MutationStage.columns=tpMutStgeAt, tpMutStgeCbt, tpMutStgePt, tpMutStgeCt, tpMutStgeTbt
+report.cassandra.metrics.ThreadPools.MutationStage.columns=tpMutStgeAt, tpMutStgeCbt, tpMutStgePt, tpMutStgeCt
 report.cassandra.metrics.ThreadPools.MutationStage.type=interfaceSnmp
 report.cassandra.metrics.ThreadPools.MutationStage.command=--title="Thread Pool Mutation Stage" \
- --vertical-label="Number" \
+ --vertical-label="Tasks" \
  DEF:val1={rrd1}:tpMutStgeAt:AVERAGE \
  DEF:val2={rrd2}:tpMutStgeCbt:AVERAGE \
  DEF:val3={rrd3}:tpMutStgePt:AVERAGE \
  DEF:val4={rrd4}:tpMutStgeCt:AVERAGE \
- DEF:val5={rrd5}:tpMutStgeTbt:AVERAGE \
- LINE1.5:val1#75507b:"Active Tasks            " \
+ LINE1.5:val1#cc0000:"Active Tasks            " \
  GPRINT:val1:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:val1:MIN:" Min \\: %8.2lf %s" \
  GPRINT:val1:MAX:" Max \\: %8.2lf %s\\n" \
- LINE1.5:val2#75507b:"Currently Blocked Tasks " \
+ LINE1.5:val2#f57900:"Currently Blocked Tasks " \
  GPRINT:val2:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:val2:MIN:" Min \\: %8.2lf %s" \
  GPRINT:val2:MAX:" Max \\: %8.2lf %s\\n" \
- LINE1.5:val3#75507b:"Pending Tasks           " \
+ LINE1.5:val3#3465a4:"Pending Tasks           " \
  GPRINT:val3:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:val3:MIN:" Min \\: %8.2lf %s" \
  GPRINT:val3:MAX:" Max \\: %8.2lf %s\\n" \
- LINE1.5:var4#75507b:"Completed Tasks         " \
+ LINE1.5:val4#4e9a06:"Completed Tasks         " \
  GPRINT:val4:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:val4:MIN:" Min \\: %8.2lf %s" \
- GPRINT:val4:MAX:" Max \\: %8.2lf %s\\n" \
- LINE1.5:var5#75507b:"Total Blocked Tasks     " \
- GPRINT:val5:AVERAGE:" Avg \\: %8.2lf %s" \
- GPRINT:val5:MIN:" Min \\: %8.2lf %s" \
- GPRINT:val5:MAX:" Max \\: %8.2lf %s\\n"
+ GPRINT:val4:MAX:" Max \\: %8.2lf %s\\n"
 
-report.cassandra.metrics.ThreadPools.ReadStage.name=Thread Pool Read Stage
-report.cassandra.metrics.ThreadPools.ReadStage.columns=tpReadStageAt, tpReadStageCbt, tpReadStagePt, tpReadStageCt, tpReadStageTbt
-report.cassandra.metrics.ThreadPools.ReadStage.type=interfaceSnmp
-report.cassandra.metrics.ThreadPools.ReadStage.command=--title="Thread Pool Read Stage" \
- --vertical-label="Number" \
+report.cassandra.metrics.ThreadPools.request.ReadStage.name=Thread Pool Read Stage
+report.cassandra.metrics.ThreadPools.request.ReadStage.columns=tpReadStageAt, tpReadStageCbt, tpReadStagePt, tpReadStageCt
+report.cassandra.metrics.ThreadPools.request.ReadStage.type=interfaceSnmp
+report.cassandra.metrics.ThreadPools.request.ReadStage.command=--title="Thread Pool Read Stage" \
+ --vertical-label="Tasks" \
  DEF:val1={rrd1}:tpReadStageAt:AVERAGE \
  DEF:val2={rrd2}:tpReadStageCbt:AVERAGE \
  DEF:val3={rrd3}:tpReadStagePt:AVERAGE \
  DEF:val4={rrd4}:tpReadStageCt:AVERAGE \
- DEF:val5={rrd5}:tpReadStageTbt:AVERAGE \
- LINE1.5:val1#75507b:"Active Tasks            " \
+ LINE1.5:val1#cc0000:"Active Tasks            " \
  GPRINT:val1:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:val1:MIN:" Min \\: %8.2lf %s" \
  GPRINT:val1:MAX:" Max \\: %8.2lf %s\\n" \
- LINE1.5:val2#75507b:"Currently Blocked Tasks " \
+ LINE1.5:val2#f57900:"Currently Blocked Tasks " \
  GPRINT:val2:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:val2:MIN:" Min \\: %8.2lf %s" \
  GPRINT:val2:MAX:" Max \\: %8.2lf %s\\n" \
- LINE1.5:val3#75507b:"Pending Tasks           " \
+ LINE1.5:val3#3465a4:"Pending Tasks           " \
  GPRINT:val3:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:val3:MIN:" Min \\: %8.2lf %s" \
  GPRINT:val3:MAX:" Max \\: %8.2lf %s\\n" \
- LINE1.5:var4#75507b:"Completed Tasks         " \
+ LINE1.5:val4#4e9a06:"Completed Tasks         " \
  GPRINT:val4:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:val4:MIN:" Min \\: %8.2lf %s" \
- GPRINT:val4:MAX:" Max \\: %8.2lf %s\\n" \
- LINE1.5:var5#75507b:"Total Blocked Tasks     " \
- GPRINT:val5:AVERAGE:" Avg \\: %8.2lf %s" \
- GPRINT:val5:MIN:" Min \\: %8.2lf %s" \
- GPRINT:val5:MAX:" Max \\: %8.2lf %s\\n"
+ GPRINT:val4:MAX:" Max \\: %8.2lf %s\\n"
 
 report.cassandra.metrics.ThreadPools.RequestResponseStage.name=Thread Pool Request Response Stage
-report.cassandra.metrics.ThreadPools.RequestResponseStage.columns=tpReqRespStgeAt, tpReqRespStgeCbt, tpReqRespStgePt, tpReqRespStgeCt, tpReqRespStgeTbt
+report.cassandra.metrics.ThreadPools.RequestResponseStage.columns=tpReqRespStgeAt, tpReqRespStgeCbt, tpReqRespStgePt, tpReqRespStgeCt
 report.cassandra.metrics.ThreadPools.RequestResponseStage.type=interfaceSnmp
 report.cassandra.metrics.ThreadPools.RequestResponseStage.command=--title="Thread Pool Request Response Stage" \
- --vertical-label="Number" \
+ --vertical-label="Tasks" \
  DEF:val1={rrd1}:tpReqRespStgeAt:AVERAGE \
  DEF:val2={rrd2}:tpReqRespStgeCbt:AVERAGE \
  DEF:val3={rrd3}:tpReqRespStgePt:AVERAGE \
  DEF:val4={rrd4}:tpReqRespStgeCt:AVERAGE \
- DEF:val5={rrd5}:tpReqRespStgeTbt:AVERAGE \
- LINE1.5:val1#75507b:"Active Tasks            " \
+ LINE1.5:val1#cc0000:"Active Tasks            " \
  GPRINT:val1:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:val1:MIN:" Min \\: %8.2lf %s" \
  GPRINT:val1:MAX:" Max \\: %8.2lf %s\\n" \
- LINE1.5:val2#75507b:"Currently Blocked Tasks " \
+ LINE1.5:val2#f57900:"Currently Blocked Tasks " \
  GPRINT:val2:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:val2:MIN:" Min \\: %8.2lf %s" \
  GPRINT:val2:MAX:" Max \\: %8.2lf %s\\n" \
- LINE1.5:val3#75507b:"Pending Tasks           " \
+ LINE1.5:val3#3465a4:"Pending Tasks           " \
  GPRINT:val3:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:val3:MIN:" Min \\: %8.2lf %s" \
  GPRINT:val3:MAX:" Max \\: %8.2lf %s\\n" \
- LINE1.5:var4#75507b:"Completed Tasks         " \
+ LINE1.5:val4#4e9a06:"Completed Tasks         " \
  GPRINT:val4:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:val4:MIN:" Min \\: %8.2lf %s" \
- GPRINT:val4:MAX:" Max \\: %8.2lf %s\\n" \
- LINE1.5:var5#75507b:"Total Blocked Tasks     " \
- GPRINT:val5:AVERAGE:" Avg \\: %8.2lf %s" \
- GPRINT:val5:MIN:" Min \\: %8.2lf %s" \
- GPRINT:val5:MAX:" Max \\: %8.2lf %s\\n"
+ GPRINT:val4:MAX:" Max \\: %8.2lf %s\\n"
 
 report.cassandra.metrics.ThreadPools.ReadRepairStage.name=Thread Pool Read Repair Stage
-report.cassandra.metrics.ThreadPools.ReadRepairStage.columns=tpReadRepairStgeAt, tpReadRepairStgeCbt, tpReadRepairStgePt, tpReadRepairStgeCt, tpReadRepairStgeTbt
+report.cassandra.metrics.ThreadPools.ReadRepairStage.columns=tpReadRepairStgeAt, tpReadRepairStgeCbt, tpReadRepairStgePt, tpReadRepairStgeCt
 report.cassandra.metrics.ThreadPools.ReadRepairStage.type=interfaceSnmp
 report.cassandra.metrics.ThreadPools.ReadRepairStage.command=--title="Thread Pool Read Repair Stage" \
- --vertical-label="Number" \
+ --vertical-label="Tasks" \
  DEF:val1={rrd1}:tpReadRepairStgeAt:AVERAGE \
  DEF:val2={rrd2}:tpReadRepairStgeCbt:AVERAGE \
  DEF:val3={rrd3}:tpReadRepairStgePt:AVERAGE \
  DEF:val4={rrd4}:tpReadRepairStgeCt:AVERAGE \
- DEF:val5={rrd5}:tpReadRepairStgeTbt:AVERAGE \
- LINE1.5:val1#75507b:"Active Tasks            " \
+ LINE1.5:val1#cc0000:"Active Tasks            " \
  GPRINT:val1:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:val1:MIN:" Min \\: %8.2lf %s" \
  GPRINT:val1:MAX:" Max \\: %8.2lf %s\\n" \
- LINE1.5:val2#75507b:"Currently Blocked Tasks " \
+ LINE1.5:val2#f57900:"Currently Blocked Tasks " \
  GPRINT:val2:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:val2:MIN:" Min \\: %8.2lf %s" \
  GPRINT:val2:MAX:" Max \\: %8.2lf %s\\n" \
- LINE1.5:val3#75507b:"Pending Tasks           " \
+ LINE1.5:val3#3465a4:"Pending Tasks           " \
  GPRINT:val3:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:val3:MIN:" Min \\: %8.2lf %s" \
  GPRINT:val3:MAX:" Max \\: %8.2lf %s\\n" \
- LINE1.5:var4#75507b:"Completed Tasks         " \
+ LINE1.5:val4#4e9a06:"Completed Tasks         " \
  GPRINT:val4:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:val4:MIN:" Min \\: %8.2lf %s" \
- GPRINT:val4:MAX:" Max \\: %8.2lf %s\\n" \
- LINE1.5:var5#75507b:"Total Blocked Tasks     " \
- GPRINT:val5:AVERAGE:" Avg \\: %8.2lf %s" \
- GPRINT:val5:MIN:" Min \\: %8.2lf %s" \
- GPRINT:val5:MAX:" Max \\: %8.2lf %s\\n"
+ GPRINT:val4:MAX:" Max \\: %8.2lf %s\\n"
+
+

--- a/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/cassandra21x-newts-graph.properties
+++ b/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/cassandra21x-newts-graph.properties
@@ -1,14 +1,13 @@
 reports=cassandra.metrics.keyspace.newts.AllMemtables.DataSize, \
-cassandra.metrics.keyspace.newts.AllMemtables.Counter, \
+cassandra.metrics.keyspace.newts.Memtables.Switch.Counter, \
+cassandra.metrics.keyspace.newts.Memtables.Columns.Counter, \
 cassandra.metrics.keyspace.newts.Memtable.DataSize, \
-cassandra.metrics.keyspace.newts.TotalLatency, \
-cassandra.metrics.keyspace.newts.RangeLatency, \
-cassandra.metrics.keyspace.newts.CommitTotalLatency, \
-cassandra.metrics.keyspace.newts.TotalLatency, \
-cassandra.metrics.keyspace.newts.RangeLatency, \
-cassandra.metrics.keyspace.newts.CommitTotalLatency, \
-cassandra.metrics.keyspace.newts.TotalLatency, \
-cassandra.metrics.keyspace.newts.OffHeapMemoryUsed, \
+cassandra.metrics.keyspace.newts.rwLatency, \
+cassandra.metrics.keyspace.newts.RangeLatency.99th, \
+cassandra.metrics.keyspace.newts.Latency, \
+cassandra.metrics.keyspace.newts.Bloom.Disk, \
+cassandra.metrics.keyspace.newts.Bloom.Memory, \
+cassandra.metrics.keyspace.newts.MemoryUsed, \
 cassandra.metrics.keyspace.newts.pending, \
 cassandra.metrics.keyspace.newts.DiskSpace
 
@@ -16,11 +15,11 @@ report.cassandra.metrics.keyspace.newts.AllMemtables.DataSize.name=All Memtables
 report.cassandra.metrics.keyspace.newts.AllMemtables.DataSize.columns=alMemTblLiDaSi, alMemTblOffHeapDaSi, alMemTblOnHeapDaSi
 report.cassandra.metrics.keyspace.newts.AllMemtables.DataSize.type=interfaceSnmp
 report.cassandra.metrics.keyspace.newts.AllMemtables.DataSize.command=--title="All Memtables Data Size" \
- --vertical-label="Size" \
+ --vertical-label="Bytes" \
  DEF:val1={rrd1}:alMemTblLiDaSi:AVERAGE \
  DEF:val2={rrd2}:alMemTblOffHeapDaSi:AVERAGE \
  DEF:val3={rrd3}:alMemTblOnHeapDaSi:AVERAGE \
- LINE1.5:val1#ef2929:"Live Data Size          " \
+ LINE1.5:val1#3465a4:"Live Data Size          " \
  GPRINT:val1:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:val1:MIN:" Min \\: %8.2lf %s" \
  GPRINT:val1:MAX:" Max \\: %8.2lf %s\\n" \
@@ -28,36 +27,42 @@ report.cassandra.metrics.keyspace.newts.AllMemtables.DataSize.command=--title="A
  GPRINT:val2:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:val2:MIN:" Min \\: %8.2lf %s" \
  GPRINT:val2:MAX:" Max \\: %8.2lf %s\\n" \
- LINE1.5:val3#edd400:"On-Heap Data Size       " \
+ LINE1.5:val3#c17d11:"On-Heap Data Size       " \
  GPRINT:val3:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:val3:MIN:" Min \\: %8.2lf %s" \
  GPRINT:val3:MAX:" Max \\: %8.2lf %s\\n"
 
-report.cassandra.metrics.keyspace.newts.AllMemtables.Counter.name=All Memtables Counter
-report.cassandra.metrics.keyspace.newts.AllMemtables.Counter.columns=memTblSwitchCount, memTblColumnsCnt
-report.cassandra.metrics.keyspace.newts.AllMemtables.Counter.type=interfaceSnmp
-report.cassandra.metrics.keyspace.newts.AllMemtables.Counter.command=--title="All Memtables Counter" \
- --vertical-label="Number" \
+report.cassandra.metrics.keyspace.newts.Memtables.Switch.Counter.name=All Memtables Switch Counter
+report.cassandra.metrics.keyspace.newts.Memtables.Switch.Counter.columns=memTblSwitchCount
+report.cassandra.metrics.keyspace.newts.Memtables.Switch.Counter.type=interfaceSnmp
+report.cassandra.metrics.keyspace.newts.Memtables.Switch.Counter.command=--title="All Memtables Switch Counter" \
+ --vertical-label="Number of Times" \
  DEF:val1={rrd1}:memTblSwitchCount:AVERAGE \
- DEF:val2={rrd2}:memTblColumnsCnt:AVERAGE \
- LINE1.5:val1#75507b:"Switch Counter  " \
+ LINE1.5:val1#3465a4:"Switch Counter  " \
  GPRINT:val1:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:val1:MIN:" Min \\: %8.2lf %s" \
- GPRINT:val1:MAX:" Max \\: %8.2lf %s\\n" \
- LINE1.5:val2#75507b:"Columns Counter " \
- GPRINT:val2:AVERAGE:" Avg \\: %8.2lf %s" \
- GPRINT:val2:MIN:" Min \\: %8.2lf %s" \
- GPRINT:val2:MAX:" Max \\: %8.2lf %s\\n"
+ GPRINT:val1:MAX:" Max \\: %8.2lf %s\\n"
+
+report.cassandra.metrics.keyspace.newts.Memtables.Columns.Counter.name=All Memtables Columns Counter
+report.cassandra.metrics.keyspace.newts.Memtables.Columns.Counter.columns=memTblColumnsCnt
+report.cassandra.metrics.keyspace.newts.Memtables.Columns.Counter.type=interfaceSnmp
+report.cassandra.metrics.keyspace.newts.Memtables.Columns.Counter.command=--title="All Memtables Columns Counter" \
+ --vertical-label="Columns" \
+ DEF:val1={rrd1}:memTblColumnsCnt:AVERAGE \
+ LINE1.5:val1#3465a4:"Columns " \
+ GPRINT:val1:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:val1:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:val1:MAX:" Max \\: %8.2lf %s\\n"
 
 report.cassandra.metrics.keyspace.newts.Memtable.DataSize.name=Newts Memtable Data Size
 report.cassandra.metrics.keyspace.newts.Memtable.DataSize.columns=memTblLiveDaSi, memTblOffHeapDaSi, memTblOnHeapDaSi
 report.cassandra.metrics.keyspace.newts.Memtable.DataSize.type=interfaceSnmp
 report.cassandra.metrics.keyspace.newts.Memtable.DataSize.command=--title="Newts Memtable Data Size" \
- --vertical-label="Size" \
+ --vertical-label="Bytes" \
  DEF:val1={rrd1}:memTblLiveDaSi:AVERAGE \
  DEF:val2={rrd2}:memTblOffHeapDaSi:AVERAGE \
  DEF:val3={rrd3}:memTblOnHeapDaSi:AVERAGE \
- LINE1.5:val1#ef2929:"Live Data Size     " \
+ LINE1.5:val1#3465a4:"Live Data Size     " \
  GPRINT:val1:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:val1:MIN:" Min \\: %8.2lf %s" \
  GPRINT:val1:MAX:" Max \\: %8.2lf %s\\n" \
@@ -65,47 +70,42 @@ report.cassandra.metrics.keyspace.newts.Memtable.DataSize.command=--title="Newts
  GPRINT:val2:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:val2:MIN:" Min \\: %8.2lf %s" \
  GPRINT:val2:MAX:" Max \\: %8.2lf %s\\n" \
- LINE1.5:val2#edd400:"On-Heap Data Size " \
+ LINE1.5:val2#c17d11:"On-Heap Data Size  " \
  GPRINT:val2:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:val2:MIN:" Min \\: %8.2lf %s" \
  GPRINT:val2:MAX:" Max \\: %8.2lf %s\\n"
 
-report.cassandra.metrics.keyspace.newts.TotalLatency.name=Newts Total Latency
-report.cassandra.metrics.keyspace.newts.TotalLatency.columns=keyspace.newts.ReadTotalLatency, keyspace.newts.WriteTotalLatency
-report.cassandra.metrics.keyspace.newts.TotalLatency.type=interfaceSnmp
-report.cassandra.metrics.keyspace.newts.TotalLatency.command=--title="Newts Read Total Latency" \
+report.cassandra.metrics.keyspace.newts.rwLatency.name=Newts Read and Write Latency
+report.cassandra.metrics.keyspace.newts.rwLatency.columns=readTotLtncy, writeTotLtncy
+report.cassandra.metrics.keyspace.newts.rwLatency.type=interfaceSnmp
+report.cassandra.metrics.keyspace.newts.rwLatency.command=--title="Newts Read and Write Latency" \
  --vertical-label="micro seconds" \
- DEF:val1={rrd1}:keyspace.newts.ReadTotalLatency:AVERAGE \
- DEF:val2={rrd2}:keyspace.newts.WriteTotalLatency:AVERAGE \
- LINE1.5:val1#75507b:"Read Total Latency  " \
+ DEF:val1={rrd1}:readTotLtncy:AVERAGE \
+ DEF:val2={rrd2}:writeTotLtncy:AVERAGE \
+ LINE1.5:val1#73d216:"Read Total Latency  " \
  GPRINT:val1:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:val1:MIN:" Min \\: %8.2lf %s" \
  GPRINT:val1:MAX:" Max \\: %8.2lf %s\\n" \
- LINE1.5:val2#75507b:"Write Total Latency " \
+ LINE1.5:val2#3465a4:"Write Total Latency " \
  GPRINT:val2:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:val2:MIN:" Min \\: %8.2lf %s" \
  GPRINT:val2:MAX:" Max \\: %8.2lf %s\\n"
 
-report.cassandra.metrics.keyspace.newts.RangeLatency.name=Newts Range Latency
-report.cassandra.metrics.keyspace.newts.RangeLatency.columns=rangeLtncy, rangeLtncy99
-report.cassandra.metrics.keyspace.newts.RangeLatency.type=interfaceSnmp
-report.cassandra.metrics.keyspace.newts.RangeLatency.command=--title="Newts Range Latency" \
+report.cassandra.metrics.keyspace.newts.RangeLatency.99th.name=Newts Range Latency 99th Percentile
+report.cassandra.metrics.keyspace.newts.RangeLatency.99th.columns=rangeLtncy99
+report.cassandra.metrics.keyspace.newts.RangeLatency.99th.type=interfaceSnmp
+report.cassandra.metrics.keyspace.newts.RangeLatency.99th.command=--title="Newts Range Latency 99th Percentile" \
  --vertical-label="micro seconds" \
- DEF:val1={rrd1}:rangeLtncy:AVERAGE \
- DEF:val2={rrd2}:rangeLtncy99:AVERAGE \
- LINE1.5:val1#3465a4:"Range Latency               " \
+ DEF:val1={rrd1}:rangeLtncy99:AVERAGE \
+ LINE1.5:val1#3465a4:"Range Latency 99 Percentile " \
  GPRINT:val1:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:val1:MIN:" Min \\: %8.2lf %s" \
- GPRINT:val1:MAX:" Max \\: %8.2lf %s\\n" \
- LINE1.5:val2#75507b:"Range Latency 99 Percentile " \
- GPRINT:val2:AVERAGE:" Avg \\: %8.2lf %s" \
- GPRINT:val2:MIN:" Min \\: %8.2lf %s" \
- GPRINT:val2:MAX:" Max \\: %8.2lf %s\\n"
+ GPRINT:val1:MAX:" Max \\: %8.2lf %s\\n"
 
-report.cassandra.metrics.keyspace.newts.CommitTotalLatency.name=Commit Total Latency
-report.cassandra.metrics.keyspace.newts.CommitTotalLatency.columns=casCommitTotLtncy, casPrepareTotLtncy, casProposeTotLtncy
-report.cassandra.metrics.keyspace.newts.CommitTotalLatency.type=interfaceSnmp
-report.cassandra.metrics.keyspace.newts.CommitTotalLatency.command=--title="Commit Total Latency" \
+report.cassandra.metrics.keyspace.newts.Latency.name=Newts Latency
+report.cassandra.metrics.keyspace.newts.Latency.columns=casCommitTotLtncy, casPrepareTotLtncy, casProposeTotLtncy
+report.cassandra.metrics.keyspace.newts.Latency.type=interfaceSnmp
+report.cassandra.metrics.keyspace.newts.Latency.command=--title="Newts Latency" \
  --vertical-label="micro seconds" \
  DEF:val1={rrd1}:casCommitTotLtncy:AVERAGE \
  DEF:val2={rrd2}:casPrepareTotLtncy:AVERAGE \
@@ -114,43 +114,51 @@ report.cassandra.metrics.keyspace.newts.CommitTotalLatency.command=--title="Comm
  GPRINT:val1:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:val1:MIN:" Min \\: %8.2lf %s" \
  GPRINT:val1:MAX:" Max \\: %8.2lf %s\\n" \
- LINE1.5:val2#3465a4:"Preprare Total Latency " \
+ STACK:val2#3465a4:"Preprare Total Latency " \
  GPRINT:val2:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:val2:MIN:" Min \\: %8.2lf %s" \
  GPRINT:val2:MAX:" Max \\: %8.2lf %s\\n" \
- LINE1.5:val3#75507b:"Propose Total Latency  " \
+ STACK:val3#75507b:"Propose Total Latency  " \
  GPRINT:val3:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:val3:MIN:" Min \\: %8.2lf %s" \
  GPRINT:val3:MAX:" Max \\: %8.2lf %s\\n"
 
-report.cassandra.metrics.keyspace.newts.TotalLatency.name=Bloom Filter Disk and Memory
-report.cassandra.metrics.keyspace.newts.TotalLatency.columns=blmFltrDskSpcUsed, blmFltrOffHeapMemUs
-report.cassandra.metrics.keyspace.newts.TotalLatency.type=interfaceSnmp
-report.cassandra.metrics.keyspace.newts.TotalLatency.command=--title="Bloom Filter Disk and Memory" \
- --vertical-label="micro seconds" \
+report.cassandra.metrics.keyspace.newts.Bloom.Disk.name=Bloom Filter Disk Usage
+report.cassandra.metrics.keyspace.newts.Bloom.Disk.columns=blmFltrDskSpcUsed
+report.cassandra.metrics.keyspace.newts.Bloom.Disk.type=interfaceSnmp
+report.cassandra.metrics.keyspace.newts.Bloom.Disk.command=--title="Bloom Filter Disk Usage" \
+ --vertical-label="Bytes" \
  DEF:val1={rrd1}:blmFltrDskSpcUsed:AVERAGE \
- DEF:val2={rrd2}:blmFltrOffHeapMemUs:AVERAGE \
- LINE1.5:val1#f57900:"Disk Space Used      " \
+ AREA:val1#babdb6 \
+ LINE1.5:val1#888a85:"Disk Space Used      " \
  GPRINT:val1:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:val1:MIN:" Min \\: %8.2lf %s" \
- GPRINT:val1:MAX:" Max \\: %8.2lf %s\\n" \
- LINE1.5:val2#75507b:"Off-Heap Memory Used " \
- GPRINT:val2:AVERAGE:" Avg \\: %8.2lf %s" \
- GPRINT:val2:MIN:" Min \\: %8.2lf %s" \
- GPRINT:val2:MAX:" Max \\: %8.2lf %s\\n"
+ GPRINT:val1:MAX:" Max \\: %8.2lf %s\\n"
 
-report.cassandra.metrics.keyspace.newts.OffHeapMemoryUsed.name=Off-Heap Memory
-report.cassandra.metrics.keyspace.newts.OffHeapMemoryUsed.columns=cmpMetaOffHeapMemUs, idxSumOffHeapMemUs
-report.cassandra.metrics.keyspace.newts.OffHeapMemoryUsed.type=interfaceSnmp
-report.cassandra.metrics.keyspace.newts.OffHeapMemoryUsed.command=--title="Off-Heap Memory" \
- --vertical-label="Size" \
+report.cassandra.metrics.keyspace.newts.Bloom.Memory.name=Bloom Filter Memory Usage
+report.cassandra.metrics.keyspace.newts.Bloom.Memory.columns=blmFltrOffHeapMemUs
+report.cassandra.metrics.keyspace.newts.Bloom.Memory.type=interfaceSnmp
+report.cassandra.metrics.keyspace.newts.Bloom.Memory.command=--title="Bloom Filter Memory Usage" \
+ --vertical-label="Bytes" \
+ DEF:val1={rrd1}:blmFltrOffHeapMemUs:AVERAGE \
+ AREA:val1#babdb6 \
+ LINE1.5:val1#888a85:"Off-Heap Memory Used " \
+ GPRINT:val1:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:val1:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:val1:MAX:" Max \\: %8.2lf %s\\n"
+
+report.cassandra.metrics.keyspace.newts.MemoryUsed.name=Newts Memory Used
+report.cassandra.metrics.keyspace.newts.MemoryUsed.columns=cmpMetaOffHeapMemUs, idxSumOffHeapMemUs
+report.cassandra.metrics.keyspace.newts.MemoryUsed.type=interfaceSnmp
+report.cassandra.metrics.keyspace.newts.MemoryUsed.command=--title="Newts Memory Used" \
+ --vertical-label="Bytes" \
  DEF:val1={rrd1}:cmpMetaOffHeapMemUs:AVERAGE \
  DEF:val2={rrd2}:idxSumOffHeapMemUs:AVERAGE \
  LINE1.5:val1#f57900:"Compression Metadata Off-Heap Memory Used " \
  GPRINT:val1:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:val1:MIN:" Min \\: %8.2lf %s" \
  GPRINT:val1:MAX:" Max \\: %8.2lf %s\\n" \
- LINE1.5:val2#75507b:"Index Summary Off-Heap Memory Used        " \
+ LINE1.5:val2#3465a4:"Index Summary Off-Heap Memory Used        " \
  GPRINT:val2:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:val2:MIN:" Min \\: %8.2lf %s" \
  GPRINT:val2:MAX:" Max \\: %8.2lf %s\\n"
@@ -159,14 +167,14 @@ report.cassandra.metrics.keyspace.newts.pending.name=Newts Pending
 report.cassandra.metrics.keyspace.newts.pending.columns=pendingCompactions, pendingFlushes
 report.cassandra.metrics.keyspace.newts.pending.type=interfaceSnmp
 report.cassandra.metrics.keyspace.newts.pending.command=--title="Newts Pending" \
- --vertical-label="Number" \
+ --vertical-label="Tasks" \
  DEF:val1={rrd1}:pendingCompactions:AVERAGE \
  DEF:val2={rrd2}:pendingFlushes:AVERAGE \
  LINE1.5:val1#f57900:"Pending Compactions " \
  GPRINT:val1:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:val1:MIN:" Min \\: %8.2lf %s" \
  GPRINT:val1:MAX:" Max \\: %8.2lf %s\\n" \
- LINE1.5:val2#75507b:"Pending Flushes     " \
+ LINE1.5:val2#3465a4:"Pending Flushes     " \
  GPRINT:val2:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:val2:MIN:" Min \\: %8.2lf %s" \
  GPRINT:val2:MAX:" Max \\: %8.2lf %s\\n"
@@ -175,14 +183,14 @@ report.cassandra.metrics.keyspace.newts.DiskSpace.name=Newts Disk Space
 report.cassandra.metrics.keyspace.newts.DiskSpace.columns=totalDiskSpaceUsed, liveDiskSpaceUsed
 report.cassandra.metrics.keyspace.newts.DiskSpace.type=interfaceSnmp
 report.cassandra.metrics.keyspace.newts.DiskSpace.command=--title="Newts Disk Space" \
- --vertical-label="Size" \
+ --vertical-label="Bytes" \
  DEF:val1={rrd1}:totalDiskSpaceUsed:AVERAGE \
  DEF:val2={rrd2}:liveDiskSpaceUsed:AVERAGE \
  LINE1.5:val1#f57900:"Total Disk Space Used " \
  GPRINT:val1:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:val1:MIN:" Min \\: %8.2lf %s" \
  GPRINT:val1:MAX:" Max \\: %8.2lf %s\\n" \
- LINE1.5:val2#75507b:"Live Disk Space Used  " \
+ LINE1.5:val2#3465a4:"Live Disk Space Used  " \
  GPRINT:val2:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:val2:MIN:" Min \\: %8.2lf %s" \
  GPRINT:val2:MAX:" Max \\: %8.2lf %s\\n"

--- a/opennms-doc/guide-admin/src/asciidoc/text/operation/newts/cassandra21x.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/operation/newts/cassandra21x.adoc
@@ -1,105 +1,197 @@
 
 // Allow GitHub image rendering
 :imagesdir: ../../../images
-==== Cassandra Metrics
+==== Cassandra Monitoring
 
-This section describes some of the metrics _OpenNMS_ collects for monitoring _Apache Cassandra_ v2.1.x.
-By default the category `Cassandra21x` is used to enable the data collection on a node.
-Also, the service name `JMX-Cassandra` is used to bind this data collection to a node's interface.
+This section describes some of the metrics _OpenNMS_ collects for monitoring an _Cassandra_ database infrastructure.
+To enable the data collection, the node has to be in the _Surveillance Category_ named _Cassandra21_.
+
+The data collection is bound to the agent IP interface with the service name _JMX-Cassandra_.
 The _JMXCollector_ is used to retrieve the _MBean_ entities from the _Cassandra_ node.
 
-===== Thread pools
+===== Client Connections
 
-_Apache Cassandra_ is based on _Staged Event Driven Architecture_ (SEDA).
-This separates different operations in stages and these stages are loosely coupled using a messaging service.
-Each of these components use queues and thread pools to group and execute their tasks.
-_OpenNMS_ collects the data for the following thread pools:
-
-* AntiEntropyStage
-* CacheCleanupExecutor
-* CommitLogArchiver
-* CompactionExecutor
-* GossipStage
-* HintedHandoff
-* InternalResponseStage
-* MemtableFlushWriter
-* MemtablePostFlush
-* MemtableReclaimMemory
-* MigrationStage
-* MiscStage
-* PendingRangeCalculator
-* Sampler
-* ValidationExecutor
-* CounterMutationStage
-* MutationStage
-* ReadRepairStage
-* ReadStage
-* RequestResponseStage
-* Native-Transport-Requests
-
-For each of these the following metrics are collected by _OpenNMS_:
+The number of active client connections from `org.apache.cassandra.metrics.Client` are collected:
 
 [options="header, autowidth"]
 |===
-| Name | Description
-| `ActiveTasks` | Tasks that are currently running
-| `CompletedTasks` | Tasks that have been completed
-| `CurrentlyBlockedTasks` | Tasks that have been blocked due to a full queue
-| `PendingTasks` | Tasks queued for execution
-| `TotalBlockedTasks` | Number of tasks that have been blocked in total
-|===
-
-===== Message dropped
-
-Load shedding is part of the _Apache Cassandra_ architecture.
-The number of dropped messages in the different message queues are good indicators whether a cluster can handle its load:
-
-* COUNTER_MUTATION
-* MUTATION
-* PAGED_RANGE
-* RANGE_SLICE
-* READ
-* READ_REPAIR
-* REQUEST_RESPONSE
-* _TRACE
-* BINARY
-
-===== Compaction manager
-
-The following compaction manager metrics are monitored by _OpenNMS_:
-
-[options="header, autowidth"]
-|===
-| Name | Description
-| `BytesCompacted` | Number of bytes compacted since node started
-| `CompletedTasks` | Estimated number of completed compaction tasks
-| `PendingTasks` | Estimated number of pending compaction tasks
-| `TotalCompactionsCompleted` | Total number of completed compaction tasks
-|===
-
-===== Storage
-
-The following storage metrics are collected by _OpenNMS_:
-
-[options="header, autowidth"]
-|===
-| Name | Description
-| `Load` | Total disk space (in bytes) used by this node
-| `Exceptions` | Number of unhandled exceptions since start of this _Cassandra_ instance
-| `TotalHints` | The number of hints since the node was started
-| `TotalHintsInProgress` | Number of hints currently active on this node
-|===
-
-===== Client connections
-
-The number of client connections are also collected:
-
-[options="header, autowidth"]
-|===
-| Name | Description
+| Name                     | Description
 | `connectedNativeClients` | Metrics for connected native clients
 | `connectedThriftClients` | Metrics for connected thrift clients
 |===
+
+===== Compaction Bytes
+
+The following compaction manager metrics from `org.apache.cassandra.metrics.Compaction` are collected:
+
+[options="header, autowidth"]
+|===
+| Name             | Description
+| `BytesCompacted` | Number of bytes compacted since node started
+|===
+
+===== Compaction Tasks
+
+The following compaction manager metrics from `org.apache.cassandra.metrics.Compaction` are collected:
+
+[options="header, autowidth"]
+|===
+| Name             | Description
+| `CompletedTasks` | Estimated number of completed compaction tasks
+| `PendingTasks`   | Estimated number of pending compaction tasks
+|===
+
+===== Storage Load
+
+The following storage load metrics from `org.apache.cassandra.metrics.Storage` are collected:
+
+[options="header, autowidth"]
+|===
+| Name   | Description
+| `Load` | Total disk space (in bytes) used by this node
+|===
+
+===== Storage Exceptions
+
+The following storage exception metrics from `org.apache.cassandra.metrics.Storage` are collected:
+
+[options="header, autowidth"]
+|===
+| Name         | Description
+| `Exceptions` | Number of unhandled exceptions since start of this _Cassandra_ instance
+|===
+
+===== Dropped Messages
+
+Measurement of messages that were _DROPPABLE_.
+These ran after a given timeout set per message type so was thrown away.
+In _JMX_ these are accessible via `org.apache.cassandra.metrics.DroppedMessage`.
+The number of dropped messages in the different message queues are good indicators whether a cluster can handle its load.
+
+[options="header, autowidth"]
+|===
+| Name               | Stage                  | Description
+| `Mutation`         | _MutationStage_        | If a write message is processed after its timeout (write_request_timeout_in_ms) it either sent a failure to the client or it met its requested consistency level and will relay on hinted handoff and read repairs to do the mutation if it succeeded.
+| `Counter_Mutation` | _MutationStage_        | If a write message is processed after its timeout (write_request_timeout_in_ms) it either sent a failure to the client or it met its requested consistency level and will relay on hinted handoff and read repairs to do the mutation if it succeeded.
+| `Read_Repair`      | _MutationStage_        | Times out after write_request_timeout_in_ms.
+| `Read`             | _ReadStage_            | Times out after read_request_timeout_in_ms.
+                                                No point in servicing reads after that point since it would of returned error to client.
+| `Range_Slice`      | _ReadStage_            | Times out after range_request_timeout_in_ms.
+| `Request_Response` | _RequestResponseStage_ | Times out after request_timeout_in_ms.
+                                                Response was completed and sent back but not before the timeout
+|===
+
+===== Thread pools
+
+_Apache Cassandra_ is based on a so called _Staged Event Driven Architecture_ (SEDA).
+This seperates different operations in stages and these stages are loosely coupled using a messaging service.
+Each of these components use queues and thread pools to group and execute their tasks.
+The documentation for _Cassandra_ Thread pool monitoring is originated from link:http://www.pythian.com/blog/guide-to-cassandra-thread-pools[Pythian Guide to Cassandra Thread Pools].
+
+.Collected metrics for Thread Pools
+[options="header, autowidth"]
+|===
+| Name                    | Description
+| `ActiveTasks`           | Tasks that are currently running
+| `CompletedTasks`        | Tasks that have been completed
+| `CurrentlyBlockedTasks` | Tasks that have been blocked due to a full queue
+| `PendingTasks`          | Tasks queued for execution
+|===
+
+====== Memtable FlushWriter
+
+Sort and write _memtables_ to disk from `org.apache.cassandra.metrics.ThreadPools`.
+A vast majority of time this backing up is from over running disk capability.
+The sorting can cause issues as well however.
+In the case of sorting being a problem, it is usually accompanied with high load but a small amount of actual flushes (seen in cfstats).
+Can be from huge rows with large column names, i.e. something inserting many large values into a _CQL_ collection.
+If overrunning disk capabilities, it is recommended to add nodes or tune the configuration.
+
+TIP: Alerts: pending > 15 || blocked > 0
+
+====== Memtable Post Flusher
+
+Operations after flushing the _memtable_.
+Discard commit log files that have had all data in them in _sstables_.
+Flushing non-cf backed secondary indexes.
+
+TIP: Alerts: pending > 15 || blocked > 0
+
+====== Anti Entropy Stage
+
+Repairing consistency.
+Handle repair messages like merkle tree transfer (from Validation compaction) and streaming.
+
+TIP: Alerts: pending > 15 || blocked > 0
+
+====== Gossip Stage
+
+Post 2.0.3 there should no longer be issue with pending tasks.
+Instead monitor logs for a message:
+
+[source]
+----
+Gossip stage has {} pending tasks; skipping status check ...
+----
+
+Before that change, in particular older versions of 1.2, with a lot of nodes (100+) while using vnodes can cause a lot of CPU intensive work that caused the stage to get behind.
+Been known to of been caused with out of sync schemas.
+Check _NTP_ working correctly and attempt `nodetool resetlocalschema` or the more drastic deleting of system column family folder.
+
+TIP: Alerts: pending > 15 || blocked > 0
+
+====== Migration Stage
+
+Making schema changes
+
+TIP: Alerts: pending > 15 || blocked > 0
+
+====== MiscStage
+
+Snapshotting, replicating data after node remove completed.
+
+TIP: Alerts: pending > 15 || blocked > 0
+
+====== Mutation Stage
+
+Performing a local including:
+
+* insert/updates
+* Schema merges
+* commit log replays
+* hints in progress
+
+Similar to ReadStage, an increase in pending tasks here can be caused by disk issues, over loading a system, or poor tuning. If messages are backed up in this stage, you can add nodes, tune hardware and configuration, or update the data model and use case.
+
+TIP: Alerts: pending > 15 || blocked > 0
+
+====== Read Stage
+
+Performing a local read.
+Also includes deserializing data from row cache.
+If there are pending values this can cause increased read latency.
+This can spike due to disk problems, poor tuning, or over loading your cluster.
+In many cases (not disk failure) this is resolved by adding nodes or tuning the system.
+
+TIP: Alerts: pending > 15 || blocked > 0
+
+====== Request Response Stage
+
+When a response to a request is received this is the stage used to execute any callbacks that were created with the original request.
+
+TIP: Alerts: pending > 15 || blocked > 0
+
+====== Read Repair Stage
+
+Performing read repairs.
+Chance of them occurring is configurable per column family with `read_repair_chance`.
+More likely to back up if using `CL.ONE` (and to lesser possibly other `non-CL.ALL` queries) for reads and using multiple data centers.
+It will then be kicked off asynchronously outside of the queries feedback loop.
+Note that this is not very likely to be a problem since does not happen on all queries and is fast providing good connectivity between replicas.
+The repair being droppable also means that after `write_request_timeout_in_ms` it will be thrown away which further mitigates this.
+If pending grows attempt to lower the rate for high read `CFs`.
+
+TIP: Alerts: pending > 15 || blocked > 0
 
 ===== JVM Metrics
 

--- a/opennms-doc/guide-admin/src/asciidoc/text/operation/newts/newts.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/operation/newts/newts.adoc
@@ -1,46 +1,116 @@
 
 // Allow GitHub image rendering
 :imagesdir: ../../../images
-==== Newts Metrics
+==== Newts Monitoring
 
-This section describes some of the metrics _OpenNMS_ collects for monitoring the _Newts_ keyspace on an _Apache Cassandra_ node.
-The category `Newts` is used to enable the data collection on a node.
-Also, the service name `JMX-Cassandra-Newts` is used to bind this data collection to a node's interface.
+This section describes the metrics _OpenNMS_ collects for monitoring the _Newts_ keyspace from `org.apache.cassandra.metrics.Keyspace` on an _Cassandra_ node.
+To enable the data collection, the node has to be in the _Surveillance Categories_ named _Cassandra21_ and _Newts_.
+
+The data collection is bound to the agent IP interface with the service name _JMX-Cassandra-Newts_.
 The _JMXCollector_ is used to retrieve the _MBean_ entities from the _Cassandra_ node.
 
-===== Newts Keyspace Metrics
+===== All Memory Table Data Size
 
-The following metrics will be collected by _OpenNMS_:
+[options="header, autowidth"]
+|===
+| Name                          | Description
+| `AllMemtablesLiveDataSize`    | Total amount of live data stored in the memtables (2i and pending flush memtables included) that resides off-heap, excluding any data structure overhead
+| `AllMemtablesOffHeapDataSize` | Total amount of data stored in the memtables (2i and pending flush memtables included) that resides off-heap.
+| `AllMemtablesOnHeapDataSize`  | Total amount of data stored in the memtables (2i and pending flush memtables included) that resides on-heap.
+|===
 
-* AllMemtablesLiveDataSize
-* AllMemtablesOffHeapDataSize
-* AllMemtablesOnHeapDataSize
-* BloomFilterDiskSpaceUsed
-* BloomFilterOffHeapMemoryUsed
-* CasCommitLatency
-* CasCommitTotalLatency
-* CasPrepareLatency
-* CasPrepareTotalLatency
-* CasProposeLatency
-* CasProposeTotalLatency
-* ColUpdateTimeDeltaHistogram
-* CompressionMetadataOffHeapMemoryUsed
-* IndexSummaryOffHeapMemoryUsed
-* LiveDiskSpaceUsed
-* LiveScannedHistogram
-* MemtableColumnsCount
-* MemtableLiveDataSize
-* MemtableOffHeapDataSize
-* MemtableOnHeapDataSize
-* MemtableSwitchCount
-* PendingCompactions
-* PendingFlushes
-* RangeLatency
-* RangeTotalLatency
-* ReadLatency
-* ReadTotalLatency
-* SSTablesPerReadHistogram
-* TombstoneScannedHistogram
-* TotalDiskSpaceUsed
-* WriteLatency
-* WriteTotalLatency
+===== Memtable Switch Count
+
+[options="header, autowidth"]
+|===
+| Name                  | Description
+| `MemtableSwitchCount` | Number of times flush has resulted in the memtable being switched out.
+|===
+
+===== Memtable Columns Count
+
+[options="header, autowidth"]
+|===
+| Name                   | Description
+| `MemtableColumnsCount` | Total number of columns present in the memtable.
+|===
+
+===== Memory Table Data Size
+
+[options="header, autowidth"]
+|===
+| Name                      | Description
+| `MemtableLiveDataSize`    | Total amount of live data stored in the memtable, excluding any data structure overhead
+| `MemtableOffHeapDataSize` | Total amount of data stored in the memtable that resides off-heap, including column related overhead and partitions overwritten.
+| `MemtableOnHeapDataSize`  | Total amount of data stored in the memtable that resides on-heap, including column related overhead and partitions overwritten.
+|===
+
+===== Read and Write Latency
+
+[options="header, autowidth"]
+|===
+| Name                | Description
+| `ReadTotalLatency`  | Local read metrics.
+| `WriteTotalLatency` | Local write metrics.
+|===
+
+===== Range Latency
+
+[options="header, autowidth"]
+|===
+| Name                           | Description
+| `RangeLatency 99th Percentile` | Local range slice metrics 99th percentile.
+|===
+
+====== Latency
+
+[options="header, autowidth"]
+|===
+| Name                     | Description
+| `CasCommitTotalLatency`  |
+| `CasPrepareTotalLatency` |
+| `CasProposeTotalLatency` |
+|===
+
+===== Bloom Filter Disk Space
+
+[options="header, autowidth"]
+|===
+| Name                       | Description
+| `BloomFilterDiskSpaceUsed` | Disk space used by bloom filter
+|===
+
+===== Bloom Filter Off Heap Memory
+
+[options="header, autowidth"]
+|===
+| Name                           | Description
+| `BloomFilterOffHeapMemoryUsed` | Off heap memory used by bloom filter
+|===
+
+===== Newts Memory Used
+
+[options="header, autowidth"]
+|===
+| Name                                   | Description
+| `CompressionMetadataOffHeapMemoryUsed` | Off heap memory used by compression meta data
+| `IndexSummaryOffHeapMemoryUsed`        | Off heap memory used by index summary
+|===
+
+===== Pending
+
+[options="header, autowidth"]
+|===
+| Name                 | Description
+| `PendingCompactions` | Estimate of number of pending compactions for this column family
+| `PendingFlushes`     | Estimated number of tasks pending for this column family
+|===
+
+===== Disk Space
+
+[options="header, autowidth"]
+|===
+| Name                 | Description
+| `TotalDiskSpaceUsed` | Total disk space used by _SSTables_ belonging to this column family including obsolete ones waiting to be garbage collected.
+| `LiveDiskSpaceUsed`  | Disk space used by _SSTables_ belonging to this column family
+|===


### PR DESCRIPTION
Cleaned up graph definitions for monitoring Apache Cassandra and Newts keyspace.
Changed stacking and legend colors for graph definitions and added documentation
for all specific metrics. Metric documentation is oriented on graph definitions.

JIRA: http://issues.opennms.org/browse/HZN-475
Bamboo: http://bamboo.internal.opennms.com:8085/browse/OPENNMS-ONMS184-7