### PR TITLE
HZN-481: Cassandra version bump

### DIFF
--- a/opennms-doc/guide-install/src/asciidoc/text/newts/cassandra-debian.adoc
+++ b/opennms-doc/guide-install/src/asciidoc/text/newts/cassandra-debian.adoc
@@ -33,7 +33,7 @@ wget -O - http://debian.datastax.com/debian/repo_key | apt-key add -
 [source, bash]
 ----
 apt-get update
-apt-get install dsc21=2.1.8-1 cassandra=2.1.8
+apt-get install dsc21=2.1.10-1 cassandra=2.1.10
 ----
 
 The _Cassandra_ service is added to the runlevel configuration and is automatically started after installing the package.

--- a/opennms-doc/guide-install/src/asciidoc/text/newts/cassandra-windows.adoc
+++ b/opennms-doc/guide-install/src/asciidoc/text/newts/cassandra-windows.adoc
@@ -14,7 +14,7 @@ NOTE: This description was built on _Windows Server 2012_.
 [source]
 ----
 cd C:\Users\Administrator\Downloads
-Invoke-WebRequest http://downloads.datastax.com/community/datastax-community-64bit_2.1.8.msi -Outfile datastax-community-64bit_2.1.8.msi
+Invoke-WebRequest http://downloads.datastax.com/community/datastax-community-64bit_2.1.10.msi -Outfile datastax-community-64bit_2.1.10.msi
 ----
 
 Run the Windows Installer file from _PowerShell_ or through _Windows Explorer_ and follow the setup wizard to install.


### PR DESCRIPTION
Bumped version for Apache Cassandra in install guide from 2.1.8 to 2.1.10.

JIRA: http://issues.opennms.org/browse/HZN-481
Bamboo: http://bamboo.internal.opennms.com:8085/browse/OPENNMS-ONMS199