### PR TITLE
encode the '+' character in eventAckTime example.

### DIFF
--- a/opennms-doc/guide-development/src/asciidoc/text/rest/rest-api.adoc
+++ b/opennms-doc/guide-development/src/asciidoc/text/rest/rest-api.adoc
@@ -60,6 +60,6 @@ Take `/events` as an example.
 | `/events?id=100&comparator=gt`                                                     | would return the first 10 events with an id greater than 100
 | `/events?eventAckTime=notnull`                                                     | would return the first 10 events that have a non-null Ack time (i.e. those that have been acknowledged)
 | `/events?eventAckTime=notnull&id=100&comparator=gt&limit=20`                       | would return the first 20 events that have a non-null Ack time and an id greater than 100.  Note that the notnull value causes the comparator to be ignored for eventAckTime
-| `/events?eventAckTime=2008-07-28T04:41:30.530+12:00&id=100&comparator=gt&limit=20` | would return the first 20 events that have were acknowledged after 28th July 2008 at 4:41am (+12:00), and an id greater than 100.  Note that the same comparator applies to both property comparisons.
+| `/events?eventAckTime=2008-07-28T04:41:30.530%2B12:00&id=100&comparator=gt&limit=20` | would return the first 20 events that have were acknowledged after 28th July 2008 at 4:41am (+12:00), and an id greater than 100.  Note that the same comparator applies to both property comparisons. Also note that you must URL encode the plus sign when using GET.
 | `/events?orderBy=id&order=desc`                                                    | would return the 10 latest events inserted (probably, unless you've been messing with the id's)
 |===


### PR DESCRIPTION
CCE occurs if you don't URL encode the plus sign when using GET.

I already fixed the Wiki.