### PR TITLE
NMS-7750: Fix for Cannot edit some Asset Info fields

### DIFF
--- a/opennms-webapp/src/test/java/org/opennms/gwt/web/ui/asset/AssetServiceImplIT.java
+++ b/opennms-webapp/src/test/java/org/opennms/gwt/web/ui/asset/AssetServiceImplIT.java
@@ -37,6 +37,7 @@ import java.util.Date;
 import java.util.HashSet;
 
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -44,6 +45,7 @@ import org.opennms.core.test.OpenNMSJUnit4ClassRunner;
 import org.opennms.core.test.db.TemporaryDatabaseExecutionListener;
 import org.opennms.core.test.db.annotations.JUnitTemporaryDatabase;
 import org.opennms.core.utils.WebSecurityUtils;
+import org.opennms.gwt.web.ui.asset.client.AssetService;
 import org.opennms.gwt.web.ui.asset.server.AssetServiceImpl;
 import org.opennms.gwt.web.ui.asset.shared.AssetCommand;
 import org.opennms.netmgt.dao.DatabasePopulator;
@@ -55,6 +57,8 @@ import org.opennms.netmgt.model.OnmsNode;
 import org.opennms.test.JUnitConfigurationEnvironment;
 import org.opennms.test.OpenNMSConfigurationExecutionListener;
 import org.opennms.web.api.Authentication;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.BeanUtils;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -80,14 +84,15 @@ import org.springframework.test.context.transaction.TransactionalTestExecutionLi
 @ContextConfiguration(locations = {
 		"classpath:/META-INF/opennms/applicationContext-commonConfigs.xml",
 		"classpath:/META-INF/opennms/applicationContext-soa.xml",
-	        "classpath:/META-INF/opennms/applicationContext-mockDao.xml",
-		"classpath*:/META-INF/opennms/component-dao.xml"})
+        "classpath:/META-INF/opennms/applicationContext-mockDao.xml",
+		"classpath*:/META-INF/opennms/component-dao.xml",
+		"classpath:/applicationContext-asset-test.xml"
+		})
 @JUnitConfigurationEnvironment
 @JUnitTemporaryDatabase
-public class AssetServiceImplTest implements InitializingBean {
+public class AssetServiceImplIT implements InitializingBean {
 
-	@Autowired
-	private DistPollerDao m_distPollerDao;
+    private static final Logger LOG = LoggerFactory.getLogger(AssetServiceImplIT.class);
 
 	@Autowired
 	private NodeDao m_nodeDao;
@@ -98,7 +103,8 @@ public class AssetServiceImplTest implements InitializingBean {
 	@Autowired
 	private DatabasePopulator m_databasePopulator;
 
-	// private SecurityContextService m_securityContextService;
+	@Autowired
+	private AssetService m_assetService;
 
 	private final GrantedAuthority ROLE_ADMIN = new SimpleGrantedAuthority(Authentication.ROLE_ADMIN);
 	
@@ -112,23 +118,7 @@ public class AssetServiceImplTest implements InitializingBean {
 	private final String PASS = "r0c|<Z";
 	
 	private User validAdmin;
-	
-	/*
-	private User invalidAdmin;
-	
-	private User validProvision;
-	
-	private User invalidProvision;
-	
-	private User validUser;
-	
-	private User invalidUser;
-	
-	private User validPower;
-	
-	private User invalidPower;
-	*/
-	
+
 	private org.springframework.security.core.Authentication m_auth;
 
 	private SecurityContext m_context;
@@ -182,8 +172,7 @@ public class AssetServiceImplTest implements InitializingBean {
 
 	@Test
 	public void testCreateAndGets() {
-		OnmsNode onmsNode = new OnmsNode(m_distPollerDao.load("localhost"));
-		onmsNode.setLabel("myNode");
+		OnmsNode onmsNode = new OnmsNode();
 		m_nodeDao.save(onmsNode);
 		OnmsAssetRecord assetRecord = onmsNode.getAssetRecord();
 		assetRecord.setAssetNumber("imported-id: 7");
@@ -199,9 +188,8 @@ public class AssetServiceImplTest implements InitializingBean {
 	}
 
 	@Test
-	public void testAssetServiceImpl() {
-		OnmsNode onmsNode = new OnmsNode(m_distPollerDao.load("localhost"));
-		onmsNode.setLabel("myNode");
+	public void testAssetServiceImpl() throws Exception {
+        OnmsNode onmsNode = new OnmsNode();
 		m_nodeDao.save(onmsNode);
 		OnmsAssetRecord assetRecord = onmsNode.getAssetRecord();
 		assetRecord.setAssetNumber("imported-id: " + onmsNode.getId());
@@ -211,59 +199,24 @@ public class AssetServiceImplTest implements InitializingBean {
 		m_assetRecordDao.update(assetRecord);
 		m_assetRecordDao.flush();
 
-		onmsNode = new OnmsNode(m_distPollerDao.load("localhost"));
-		onmsNode.setLabel("myNode2");
+		onmsNode = new OnmsNode();
 		m_nodeDao.save(onmsNode);
 		assetRecord = onmsNode.getAssetRecord();
 		assetRecord.setAssetNumber("imported-id: 23");
 		assetRecord.setAdmin("mediummario");
-                assetRecord.getGeolocation().setAddress1("youraddress");
+		assetRecord.getGeolocation().setAddress1("youraddress");
 		assetRecord.getGeolocation().setZip("yourzip");
 		m_assetRecordDao.update(assetRecord);
 		m_assetRecordDao.flush();
 
-		AssetServiceImpl assetServiceImpl = new AssetServiceImpl();
-		assetServiceImpl.setNodeDao(m_nodeDao);
-		assetServiceImpl.setAssetRecordDao(m_assetRecordDao);
-
-		System.out.println("AssetCommand: "
-				+ assetServiceImpl.getAssetByNodeId(onmsNode.getId()).toString());
-		System.out.println("Suggestions: "
-				+ assetServiceImpl.getAssetSuggestions());
-		assertTrue("Test save or update by admin.", assetServiceImpl.getAssetByNodeId(onmsNode.getId()).getAllowModify());
+		LOG.info("AssetCommand: {}", m_assetService.getAssetByNodeId(onmsNode.getId()).toString());
+		LOG.info("Suggestions: {}", m_assetService.getAssetSuggestions());
+		assertTrue("Test save or update by admin.", m_assetService.getAssetByNodeId(onmsNode.getId()).getAllowModify());
 	}
-
-//	@Test
-//	public void successAllowModifyAssetByAdmin() {
-//		AssetServiceImpl assetServiceImpl = new AssetServiceImpl();
-//		assetServiceImpl.setNodeDao(m_nodeDao);
-//		assetServiceImpl.setAssetRecordDao(m_assetRecordDao);
-//		m_auth = new PreAuthenticatedAuthenticationToken(
-//				validAdmin, new Object());
-//		m_context.setAuthentication(m_auth);
-//		SecurityContextHolder.setContext(m_context);
-//		m_securityContextService = new SpringSecurityContextService();
-//		assertTrue("Test save or update by admin.", assetServiceImpl.getAssetByNodeId(7).getAllowModify());
-//	}
-//
-//	@Test
-//	public void failAllowModifyAssetByAdmin() {
-//		AssetServiceImpl assetServiceImpl = new AssetServiceImpl();
-//		assetServiceImpl.setNodeDao(m_nodeDao);
-//		assetServiceImpl.setAssetRecordDao(m_assetRecordDao);
-//		m_auth = new PreAuthenticatedAuthenticationToken(
-//				invalidAdmin, new Object());
-//		m_context.setAuthentication(m_auth);
-//		SecurityContextHolder.setContext(m_context);
-//		m_securityContextService = new SpringSecurityContextService();
-//		assertFalse("Test save or update by admin.", assetServiceImpl.getAssetByNodeId(7).getAllowModify());
-//	}
-	
 	
 	@Test
-	public void testSaveOrUpdate() {
-		OnmsNode onmsNode = new OnmsNode(m_distPollerDao.load("localhost"));
-		onmsNode.setLabel("myNode");
+	public void testSaveOrUpdate() throws Exception {
+		OnmsNode onmsNode = new OnmsNode();
 		m_nodeDao.save(onmsNode);
 		OnmsAssetRecord assetRecord = onmsNode.getAssetRecord();
 		assetRecord.setAssetNumber("imported-id: " + onmsNode.getId());
@@ -282,14 +235,9 @@ public class AssetServiceImplTest implements InitializingBean {
 		AssetCommand assetCommand = new AssetCommand();
 		BeanUtils.copyProperties(assetRecord, assetCommand);
 
-		System.out.println("AssetCommand (Source): " + assetCommand);
-		System.out.println("Asset to Save (Target): " + assetRecord);
-
-		AssetServiceImpl assetServiceImpl = new AssetServiceImpl();
-		assetServiceImpl.setNodeDao(m_nodeDao);
-		assetServiceImpl.setAssetRecordDao(m_assetRecordDao);
-		System.out.println();
-		assertTrue(assetServiceImpl.saveOrUpdateAssetByNodeId(onmsNode.getId(), assetCommand));
+		LOG.info("AssetCommand (Source): " + assetCommand);
+		LOG.info("Asset to Save (Target): " + assetRecord);
+		assertTrue(m_assetService.saveOrUpdateAssetByNodeId(onmsNode.getId(), assetCommand));
 		
 		OnmsAssetRecord updated = m_assetRecordDao.get(assetRecord.getId());
 		assertEquals(assetRecord.getGeolocation().getAddress1(), updated.getGeolocation().getAddress1());
@@ -302,9 +250,56 @@ public class AssetServiceImplTest implements InitializingBean {
 	}
 
 	@Test
-	public void testAssetSuggestion() {
-		OnmsNode onmsNode = new OnmsNode(m_distPollerDao.load("localhost"));
-		onmsNode.setLabel("your Node");
+	public void saveOrUpdateAssetByNodeIdForGeolocationTest() throws Exception {
+		// save part
+		final AssetCommand firstAssetCommand = new AssetCommand();
+		firstAssetCommand.setAddress1("Street 1");
+		firstAssetCommand.setAddress2("Street 2");
+		firstAssetCommand.setCity("Bursa");
+		firstAssetCommand.setCountry("Turkey");
+		firstAssetCommand.setLatitude(13.0f);
+		firstAssetCommand.setLongitude(14.0f);
+		firstAssetCommand.setState("N.a.");
+		firstAssetCommand.setZip("0123456789");
+
+		final int nodeId = 3;
+		boolean isSaved = m_assetService.saveOrUpdateAssetByNodeId(nodeId, firstAssetCommand);
+		Assert.assertTrue(isSaved);
+
+		OnmsAssetRecord assetRecord = m_assetRecordDao.findByNodeId(nodeId);
+		Assert.assertNotNull(assetRecord);
+		Assert.assertTrue(assetRecord.getAddress1().equals(firstAssetCommand.getAddress1()));
+		Assert.assertTrue(assetRecord.getAddress2().equals(firstAssetCommand.getAddress2()));
+		Assert.assertTrue(assetRecord.getCity().equals(firstAssetCommand.getCity()));
+		Assert.assertTrue(assetRecord.getCountry().equals(firstAssetCommand.getCountry()));
+		Assert.assertTrue(assetRecord.getLatitude().equals(firstAssetCommand.getLatitude()));
+		Assert.assertTrue(assetRecord.getLongitude().equals(firstAssetCommand.getLongitude()));
+		Assert.assertTrue(assetRecord.getState().equals(firstAssetCommand.getState()));
+		Assert.assertTrue(assetRecord.getZip().equals(firstAssetCommand.getZip()));
+
+		// update part
+		final AssetCommand secondAssetCommand = new AssetCommand();
+		secondAssetCommand.setAddress1("Street 1");
+		secondAssetCommand.setAddress2("Street 2");
+		secondAssetCommand.setCity("Hamburg");
+		secondAssetCommand.setCountry("Germany");
+		secondAssetCommand.setLatitude(13.0f);
+		secondAssetCommand.setLongitude(14.0f);
+		secondAssetCommand.setState("N.a.");
+		secondAssetCommand.setZip("0123456789");
+
+		isSaved = m_assetService.saveOrUpdateAssetByNodeId(nodeId, secondAssetCommand);
+		Assert.assertTrue(isSaved);
+
+		OnmsAssetRecord secondAssetRecord = m_assetRecordDao.findByNodeId(nodeId);
+
+		Assert.assertTrue(secondAssetRecord.getCity().equals(secondAssetCommand.getCity()));
+		Assert.assertFalse(secondAssetRecord.getCity().equals(firstAssetCommand.getCity()));
+	}
+
+	@Test
+	public void testAssetSuggestion() throws Exception {
+	OnmsNode onmsNode = new OnmsNode();
 		onmsNode.setSysObjectId("mySysOid");
 		m_nodeDao.save(onmsNode);
 		OnmsAssetRecord assetRecord = onmsNode.getAssetRecord();
@@ -315,8 +310,7 @@ public class AssetServiceImplTest implements InitializingBean {
 		m_assetRecordDao.update(assetRecord);
 		m_assetRecordDao.flush();
 
-		onmsNode = new OnmsNode(m_distPollerDao.load("localhost"));
-		onmsNode.setLabel("his Node");
+		onmsNode = new OnmsNode();
 		m_nodeDao.save(onmsNode);
 		assetRecord = onmsNode.getAssetRecord();
 		assetRecord.setAssetNumber("imported-id: 999");
@@ -326,10 +320,7 @@ public class AssetServiceImplTest implements InitializingBean {
 		m_assetRecordDao.update(assetRecord);
 		m_assetRecordDao.flush();
 
-		AssetServiceImpl assetServiceImpl = new AssetServiceImpl();
-		assetServiceImpl.setNodeDao(m_nodeDao);
-		assetServiceImpl.setAssetRecordDao(m_assetRecordDao);
-		System.out.println("Asset: " + assetServiceImpl.getAssetByNodeId(onmsNode.getId()));
+		LOG.info("Asset: " + m_assetService.getAssetByNodeId(onmsNode.getId()));
 	}
 
 	@Test

--- a/opennms-webapp/src/test/resources/applicationContext-asset-test.xml
+++ b/opennms-webapp/src/test/resources/applicationContext-asset-test.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:context="http://www.springframework.org/schema/context"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+						http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-2.5.xsd">
+
+<context:annotation-config />
+
+    <bean id="nodeDao" class="org.opennms.netmgt.dao.mock.MockNodeDao" />
+    
+    <bean id="assetRecordDao" class="org.opennms.netmgt.dao.mock.MockAssetRecordDao" />
+    
+    <bean id="assetService" class="org.opennms.gwt.web.ui.asset.server.AssetServiceImpl" >
+ 		<property name="nodeDao" ref="nodeDao" />
+ 		<property name="assetRecordDao" ref="assetRecordDao" />
+    </bean>
+
+</beans>


### PR DESCRIPTION
- All asset Info fields where transferred over the network correctly
- The issue was with the backend processing
- Some fields where lost due attribute incompatibility of AssetCommand and OnmsAssetRecord classes
  when using BeanUtils.copyProperties method
- Fixed it by get those fields in a seperate step 