### PR TITLE
NMS-7750: Fix for Cannot edit some Asset Info fields

### DIFF
--- a/opennms-webapp/src/main/java/org/opennms/gwt/web/ui/asset/server/AssetServiceImpl.java
+++ b/opennms-webapp/src/main/java/org/opennms/gwt/web/ui/asset/server/AssetServiceImpl.java
@@ -53,6 +53,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.BeanUtils;
 import org.springframework.beans.BeanWrapper;
 import org.springframework.beans.BeanWrapperImpl;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.google.gwt.user.server.rpc.RemoteServiceServlet;
@@ -322,31 +323,14 @@ public class AssetServiceImpl extends RemoteServiceServlet implements AssetServi
         m_onmsAssetRecord = m_onmsNode.getAssetRecord();
         OnmsGeolocation geolocation = m_onmsAssetRecord.getGeolocation();
 
-        logger.debug("gelocation before: {}", geolocation);
-
         // copy the transfer object for rpc back to the hibernate model
+        logger.trace("gelocation before: {}", geolocation);
         final AssetCommand sanitizeBeanStringProperties = sanitizeBeanStringProperties(assetCommand, m_allowHtmlFields);
-        
-        // logger.debug("nodeId: '{}' sanitized assetCommand: '{}'", nodeId, sanitizeBeanStringProperties);
-
         BeanUtils.copyProperties(sanitizeBeanStringProperties, m_onmsAssetRecord);
-
-        geolocation = m_onmsAssetRecord.getGeolocation();
-        logger.debug("gelocation after: {}", geolocation);
-
-        // logger.debug("copyProperties finished");
-
-        if (geolocation == null) {
-            geolocation = new OnmsGeolocation();
-            m_onmsAssetRecord.setGeolocation(geolocation);
-        }
-        
-        // logger.debug("geolocation: {}", geolocation);
-
-        geolocation.setLongitude(sanitizeBeanStringProperties.getLongitude());
-        geolocation.setLatitude(sanitizeBeanStringProperties.getLatitude());
-
-        logger.debug("OnmsAssetRecord: '{}'", m_onmsAssetRecord);
+        geolocation = extractGeolocation(sanitizeBeanStringProperties);
+        logger.trace("gelocation after: {}", geolocation);
+        m_onmsAssetRecord.setGeolocation(geolocation);
+        logger.trace("OnmsAssetRecord: '{}'", m_onmsAssetRecord);
 
         // set the last modified user from logged in user
         m_onmsAssetRecord.setLastModifiedBy(m_securityContext.getUsername());
@@ -357,9 +341,9 @@ public class AssetServiceImpl extends RemoteServiceServlet implements AssetServi
 
         // try to persist the asset record from the web ui
         try {
-            logger.debug("OnmsNode '{}'", m_onmsNode.toString());
-            logger.debug("AssetRecordDao to update '{}'", m_assetRecordDao.toString());
-            logger.debug("OnmsAssetRecord to update '{}'", m_onmsAssetRecord.toString());
+            logger.trace("OnmsNode '{}'", m_onmsNode.toString());
+            logger.trace("AssetRecordDao to update '{}'", m_assetRecordDao.toString());
+            logger.trace("OnmsAssetRecord to update '{}'", m_onmsAssetRecord.toString());
 
             m_assetRecordDao.saveOrUpdate(m_onmsAssetRecord);
             isSaved = true;
@@ -367,53 +351,35 @@ public class AssetServiceImpl extends RemoteServiceServlet implements AssetServi
             // TODO: Catch exception and show error in web user interface
             isSaved = false;
             logger.error("Problem during saving or updating assets '{}'", e.getMessage());
-            e.printStackTrace();
         }
-
-        // save was successful
         return isSaved;
     }
 
-    /**
-     * <p>
-     * getAssetRecordDao
-     * </p>
-     *
-     * @return assetRecordDao a {@link org.opennms.netmgt.model.OnmsAssetRecord}
-     */
+    private OnmsGeolocation extractGeolocation(AssetCommand sanitizeBeanStringProperties) {
+        OnmsGeolocation geoLocation = new OnmsGeolocation();
+        geoLocation.setAddress1(sanitizeBeanStringProperties.getAddress1());
+        geoLocation.setAddress2(sanitizeBeanStringProperties.getAddress2());
+        geoLocation.setCity(sanitizeBeanStringProperties.getCity());
+        geoLocation.setCountry(sanitizeBeanStringProperties.getCountry());
+        geoLocation.setLatitude(sanitizeBeanStringProperties.getLatitude());
+        geoLocation.setLongitude(sanitizeBeanStringProperties.getLongitude());
+        geoLocation.setState(sanitizeBeanStringProperties.getState());
+        geoLocation.setZip(sanitizeBeanStringProperties.getZip());
+        return geoLocation;
+    }
+
     public AssetRecordDao getAssetRecordDao() {
         return m_assetRecordDao;
     }
 
-    /**
-     * <p>
-     * setAssetRecordDao
-     * </p>
-     *
-     * @param m_assetRecordDao a {@link org.opennms.netmgt.model.OnmsAssetRecord}
-     */
     public void setAssetRecordDao(AssetRecordDao assetRecordDao) {
         m_assetRecordDao = assetRecordDao;
     }
 
-    /**
-     * <p>
-     * getNodeDao
-     * </p>
-     *
-     * @return m_nodeDao a {@link org.opennms.netmgt.dao.api.NodeDao}
-     */
     public NodeDao getNodeDao() {
         return m_nodeDao;
     }
 
-    /**
-     * <p>
-     * setNodeDao
-     * </p>
-     *
-     * @param m_nodeDao a {@link org.opennms.netmgt.dao.api.NodeDao}
-     */
     public void setNodeDao(NodeDao nodeDao) {
         m_nodeDao = nodeDao;
     }

--- a/opennms-webapp/src/test/java/org/opennms/gwt/web/ui/asset/AssetServiceImplIT.java
+++ b/opennms-webapp/src/test/java/org/opennms/gwt/web/ui/asset/AssetServiceImplIT.java
@@ -1,0 +1,330 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2011-2014 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.gwt.web.ui.asset;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+import java.util.HashSet;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.opennms.core.test.OpenNMSJUnit4ClassRunner;
+import org.opennms.core.test.db.annotations.JUnitTemporaryDatabase;
+import org.opennms.core.utils.WebSecurityUtils;
+import org.opennms.gwt.web.ui.asset.client.AssetService;
+import org.opennms.gwt.web.ui.asset.server.AssetServiceImpl;
+import org.opennms.gwt.web.ui.asset.shared.AssetCommand;
+import org.opennms.netmgt.dao.DatabasePopulator;
+import org.opennms.netmgt.dao.api.AssetRecordDao;
+import org.opennms.netmgt.dao.api.NodeDao;
+import org.opennms.netmgt.model.OnmsAssetRecord;
+import org.opennms.netmgt.model.OnmsNode;
+import org.opennms.test.JUnitConfigurationEnvironment;
+import org.opennms.web.api.Authentication;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.BeanUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.context.SecurityContextImpl;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
+import org.springframework.test.context.ContextConfiguration;
+
+@RunWith(OpenNMSJUnit4ClassRunner.class)
+@ContextConfiguration(locations = {
+        "classpath:/META-INF/opennms/applicationContext-commonConfigs.xml",
+        "classpath:/META-INF/opennms/applicationContext-minimal-conf.xml",
+        "classpath:/META-INF/opennms/applicationContext-soa.xml",
+        "classpath:/META-INF/opennms/applicationContext-mockDao.xml",
+        "classpath*:/META-INF/opennms/component-dao.xml",
+        "classpath*:/applicationContext-asset-test.xml"})
+@JUnitConfigurationEnvironment
+@JUnitTemporaryDatabase
+public class AssetServiceImplIT {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AssetServiceImplIT.class);
+
+    @Autowired
+    private NodeDao m_nodeDao;
+
+    @Autowired
+    private AssetRecordDao m_assetRecordDao;
+
+    @Autowired
+    private DatabasePopulator m_databasePopulator;
+
+    @Autowired
+    private AssetService m_assetService;
+
+    private final GrantedAuthority ROLE_ADMIN = new SimpleGrantedAuthority(Authentication.ROLE_ADMIN);
+
+    private final String USERNAME = "opennms";
+
+    private final String PASS = "r0c|<Z";
+    
+    private User validAdmin;
+
+    private org.springframework.security.core.Authentication m_auth;
+
+    private SecurityContext m_context;
+
+    @Before
+    public void setUp() {
+        org.opennms.core.spring.BeanUtils.assertAutowiring(this);
+        m_databasePopulator.populateDatabase();
+        m_context = new SecurityContextImpl();
+        
+        validAdmin = new User(USERNAME, PASS, true, true, true, true,
+                Arrays.asList(new GrantedAuthority[] { ROLE_ADMIN }));
+
+        m_auth = new PreAuthenticatedAuthenticationToken(validAdmin, new Object());
+        m_context.setAuthentication(m_auth);
+        SecurityContextHolder.setContext(m_context);
+        // m_securityContextService = new SpringSecurityContextService();
+    }
+
+    @After
+    public void tearDown() {
+        for (final OnmsNode node : m_nodeDao.findAll()) {
+            m_nodeDao.delete(node);
+        }
+        m_nodeDao.flush();
+    }
+
+    @Test
+    public void testCreateAndGets() {
+        OnmsNode onmsNode = new OnmsNode();
+        m_nodeDao.save(onmsNode);
+        OnmsAssetRecord assetRecord = onmsNode.getAssetRecord();
+        assetRecord.setAssetNumber("imported-id: 7");
+        m_assetRecordDao.update(assetRecord);
+        m_assetRecordDao.flush();
+
+        // Test findAll method
+        Collection<OnmsAssetRecord> assetRecords = m_assetRecordDao.findAll();
+        assertEquals(7, assetRecords.size());
+
+        // Test countAll method
+        assertEquals(7, m_assetRecordDao.countAll());
+    }
+
+    @Test
+    public void testAssetServiceImpl() throws Exception {
+        OnmsNode onmsNode = new OnmsNode();
+        m_nodeDao.save(onmsNode);
+        OnmsAssetRecord assetRecord = onmsNode.getAssetRecord();
+        assetRecord.setAssetNumber("imported-id: " + onmsNode.getId());
+        assetRecord.setAdmin("supermario");
+        assetRecord.getGeolocation().setAddress1("my address");
+        assetRecord.getGeolocation().setZip("myzip");
+        m_assetRecordDao.update(assetRecord);
+        m_assetRecordDao.flush();
+
+        onmsNode = new OnmsNode();
+        m_nodeDao.save(onmsNode);
+        assetRecord = onmsNode.getAssetRecord();
+        assetRecord.setAssetNumber("imported-id: 23");
+        assetRecord.setAdmin("mediummario");
+        assetRecord.getGeolocation().setAddress1("youraddress");
+        assetRecord.getGeolocation().setZip("yourzip");
+        m_assetRecordDao.update(assetRecord);
+        m_assetRecordDao.flush();
+
+        LOG.info("AssetCommand: {}", m_assetService.getAssetByNodeId(onmsNode.getId()).toString());
+        LOG.info("Suggestions: {}", m_assetService.getAssetSuggestions());
+        assertTrue("Test save or update by admin.", m_assetService.getAssetByNodeId(onmsNode.getId()).getAllowModify());
+    }
+
+    @Test
+    public void testSaveOrUpdate() throws Exception {
+        OnmsNode onmsNode = new OnmsNode();
+        m_nodeDao.save(onmsNode);
+        OnmsAssetRecord assetRecord = onmsNode.getAssetRecord();
+        assetRecord.setAssetNumber("imported-id: " + onmsNode.getId());
+        assetRecord.setAdmin("supermario");
+        assetRecord.setLastModifiedDate(new Date());
+        assetRecord.getGeolocation().setAddress1("220 Chatham Business Drive");
+                assetRecord.getGeolocation().setCity("Pittsboro");
+                assetRecord.getGeolocation().setState("NC");
+                assetRecord.getGeolocation().setZip("27312");
+                assetRecord.getGeolocation().setCountry("US");
+                assetRecord.getGeolocation().setLatitude(35.717582f);
+                assetRecord.getGeolocation().setLongitude(-79.161800f);
+        m_assetRecordDao.update(assetRecord);
+        m_assetRecordDao.flush();
+
+        AssetCommand assetCommand = new AssetCommand();
+        BeanUtils.copyProperties(assetRecord, assetCommand);
+
+        LOG.info("AssetCommand (Source): " + assetCommand);
+        LOG.info("Asset to Save (Target): " + assetRecord);
+        assertTrue(m_assetService.saveOrUpdateAssetByNodeId(onmsNode.getId(), assetCommand));
+        
+        OnmsAssetRecord updated = m_assetRecordDao.get(assetRecord.getId());
+        assertEquals(assetRecord.getGeolocation().getAddress1(), updated.getGeolocation().getAddress1());
+                assertEquals(assetRecord.getGeolocation().getState(), updated.getGeolocation().getState());
+                assertEquals(assetRecord.getGeolocation().getCity(), updated.getGeolocation().getCity());
+                assertEquals(assetRecord.getGeolocation().getZip(), updated.getGeolocation().getZip());
+                assertEquals(assetRecord.getGeolocation().getCountry(), updated.getGeolocation().getCountry());
+                assertEquals(assetRecord.getGeolocation().getLongitude(), updated.getGeolocation().getLongitude());
+                assertEquals(assetRecord.getGeolocation().getLatitude(), updated.getGeolocation().getLatitude());
+    }
+
+    @Test
+    public void saveOrUpdateAssetByNodeIdForGeolocationTest() throws Exception {
+        // save part
+        final AssetCommand firstAssetCommand = new AssetCommand();
+        firstAssetCommand.setAddress1("Street 1");
+        firstAssetCommand.setAddress2("Street 2");
+        firstAssetCommand.setCity("Stuttgart");
+        firstAssetCommand.setCountry("Germany");
+        firstAssetCommand.setLatitude(13.0f);
+        firstAssetCommand.setLongitude(14.0f);
+        firstAssetCommand.setState("N.a.");
+        firstAssetCommand.setZip("0123456789");
+
+        final int nodeId = 3;
+        boolean isSaved = m_assetService.saveOrUpdateAssetByNodeId(nodeId, firstAssetCommand);
+        Assert.assertTrue(isSaved);
+
+        OnmsAssetRecord assetRecord = m_assetRecordDao.findByNodeId(nodeId);
+        Assert.assertNotNull(assetRecord);
+        Assert.assertTrue(assetRecord.getAddress1().equals(firstAssetCommand.getAddress1()));
+        Assert.assertTrue(assetRecord.getAddress2().equals(firstAssetCommand.getAddress2()));
+        Assert.assertTrue(assetRecord.getCity().equals(firstAssetCommand.getCity()));
+        Assert.assertTrue(assetRecord.getCountry().equals(firstAssetCommand.getCountry()));
+        Assert.assertTrue(assetRecord.getLatitude().equals(firstAssetCommand.getLatitude()));
+        Assert.assertTrue(assetRecord.getLongitude().equals(firstAssetCommand.getLongitude()));
+        Assert.assertTrue(assetRecord.getState().equals(firstAssetCommand.getState()));
+        Assert.assertTrue(assetRecord.getZip().equals(firstAssetCommand.getZip()));
+
+        // update part
+        final AssetCommand secondAssetCommand = new AssetCommand();
+        secondAssetCommand.setAddress1("Street 1");
+        secondAssetCommand.setAddress2("Street 2");
+        secondAssetCommand.setCity("Berlin");
+        secondAssetCommand.setCountry("Germany");
+        secondAssetCommand.setLatitude(13.0f);
+        secondAssetCommand.setLongitude(14.0f);
+        secondAssetCommand.setState("N.a.");
+        secondAssetCommand.setZip("0123456789");
+
+        isSaved = m_assetService.saveOrUpdateAssetByNodeId(nodeId, secondAssetCommand);
+        Assert.assertTrue(isSaved);
+
+        OnmsAssetRecord secondAssetRecord = m_assetRecordDao.findByNodeId(nodeId);
+
+        Assert.assertTrue(secondAssetRecord.getCity().equals(secondAssetCommand.getCity()));
+        Assert.assertFalse(firstAssetCommand.getCity().equals(secondAssetCommand.getCity()));
+        Assert.assertFalse(secondAssetRecord.getCity().equals(firstAssetCommand.getCity()));
+    }
+
+    @Test
+    public void testAssetSuggestion() throws Exception {
+    OnmsNode onmsNode = new OnmsNode();
+        onmsNode.setSysObjectId("mySysOid");
+        m_nodeDao.save(onmsNode);
+        OnmsAssetRecord assetRecord = onmsNode.getAssetRecord();
+        assetRecord.setAssetNumber("imported-id: 666");
+        assetRecord.setAdmin("medium mario");
+        assetRecord.setLastModifiedDate(new Date());
+        assetRecord.getGeolocation().setZip("his zip");
+        m_assetRecordDao.update(assetRecord);
+        m_assetRecordDao.flush();
+
+        onmsNode = new OnmsNode();
+        m_nodeDao.save(onmsNode);
+        assetRecord = onmsNode.getAssetRecord();
+        assetRecord.setAssetNumber("imported-id: 999");
+        assetRecord.setAdmin("super mario");
+        assetRecord.setLastModifiedDate(new Date());
+        assetRecord.getGeolocation().setZip("your zip");
+        m_assetRecordDao.update(assetRecord);
+        m_assetRecordDao.flush();
+
+        LOG.info("Asset: " + m_assetService.getAssetByNodeId(onmsNode.getId()));
+    }
+
+    @Test
+    public void testBasicBeanSanitizer() {
+        CommandBeanMockup bean = new CommandBeanMockup();
+        bean = (CommandBeanMockup) AssetServiceImpl
+                .sanitizeBeanStringProperties(bean, null);
+
+        assertTrue("Script property is sanitized",
+                WebSecurityUtils.sanitizeString("<script>foo</script>", false)
+                        .equals(bean.getScript()));
+        assertTrue("Script property is not sanitized with Html allowed",
+                !WebSecurityUtils.sanitizeString("<script>foo</script>", true)
+                        .equals(bean.getScript()));
+
+        assertTrue("HtmlTable is sanitized and html removed", WebSecurityUtils
+                .sanitizeString("<table>", false).equals(bean.getHtmlTable()));
+        assertTrue(
+                "Not, HtmlTable is sanitized with Html allowed",
+                !WebSecurityUtils.sanitizeString("<table>", true).equals(
+                        bean.getHtmlTable()));
+    }
+
+    @Test
+    public void testBeanSanitizerWithHtmlAllowList() {
+        CommandBeanMockup bean = new CommandBeanMockup();
+        HashSet<String> set = new HashSet<String>();
+        set.add("htmltable");
+        bean = (CommandBeanMockup) AssetServiceImpl
+                .sanitizeBeanStringProperties(bean, set);
+
+        assertTrue("Script property is sanitized no Html allowed",
+                WebSecurityUtils.sanitizeString("<script>foo</script>", false)
+                        .equals(bean.getScript()));
+        assertTrue("Not, Script property is sanitized with Html allowed",
+                !WebSecurityUtils.sanitizeString("<script>foo</script>", true)
+                        .equals(bean.getScript()));
+
+        assertTrue(
+                "HtmlTable is sanitzied with Html allowed so, no changes",
+                WebSecurityUtils.sanitizeString("<table>", true).equals(
+                        bean.getHtmlTable()));
+        assertTrue(
+                "Not, HtmlTable is sanitized and html removed",
+                !WebSecurityUtils.sanitizeString("<table>", false).equals(
+                        bean.getHtmlTable()));
+    }
+}

--- a/opennms-webapp/src/test/resources/applicationContext-asset-test.xml
+++ b/opennms-webapp/src/test/resources/applicationContext-asset-test.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+		  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		  xmlns:tx="http://www.springframework.org/schema/tx"
+		  xmlns:context="http://www.springframework.org/schema/context"
+		  xmlns:util="http://www.springframework.org/schema/util"
+		  xmlns:aop="http://www.springframework.org/schema/aop"
+		  xmlns:jdbc="http://www.springframework.org/schema/jdbc" 
+		  xmlns:onmsgi="http://xmlns.opennms.org/xsd/spring/onms-osgi"
+		  xsi:schemaLocation="
+		  http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
+		  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
+		  http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
+		  http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.0.xsd
+		  http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-4.0.xsd
+		  http://xmlns.opennms.org/xsd/spring/onms-osgi http://xmlns.opennms.org/xsd/spring/onms-osgi.xsd">
+
+		<context:annotation-config/>
+	
+		<bean id="nodeDao" class="org.opennms.netmgt.dao.mock.MockNodeDao"/>
+		
+		<bean id="assetRecordDao" class="org.opennms.netmgt.dao.mock.MockAssetRecordDao"/>
+		
+		<bean id="assetService" class="org.opennms.gwt.web.ui.asset.server.AssetServiceImpl">
+			<property name="nodeDao" ref="nodeDao"/>
+			<property name="assetRecordDao" ref="assetRecordDao"/>
+		</bean>
+
+</beans>


### PR DESCRIPTION
- All asset info where transferred correctly
- The error occurred in the processing logic in the backend due to incompatibility of attributes of     AssetCommand and OnmsAssetRecord classes while using BeanUtils.copyProperties method
- Fixed the issue by copying those lost attributes in a seperate step