### PR TITLE
HZN-478: Use measurement API in statsd instead of old RRD DAOs

### DIFF
--- a/opennms-dao/pom.xml
+++ b/opennms-dao/pom.xml
@@ -147,6 +147,10 @@
       <artifactId>opennms-rrd-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.opennms.features.measurements</groupId>
+      <artifactId>org.opennms.features.measurements.api</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.opennms.features.collection</groupId>
       <artifactId>org.opennms.features.collection.api</artifactId>
     </dependency>

--- a/opennms-services/src/main/java/org/opennms/netmgt/statsd/BaseReportInstance.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/statsd/BaseReportInstance.java
@@ -38,6 +38,7 @@ import org.opennms.netmgt.dao.support.ResourceAttributeFilteringResourceVisitor;
 import org.opennms.netmgt.dao.support.ResourceTypeFilteringResourceVisitor;
 import org.opennms.netmgt.dao.support.ResourceWalker;
 import org.opennms.netmgt.dao.support.RrdStatisticAttributeVisitor;
+import org.opennms.netmgt.measurements.api.MeasurementFetchStrategy;
 import org.opennms.netmgt.model.AttributeStatistic;
 import org.opennms.netmgt.model.AttributeStatisticVisitorWithResults;
 import org.springframework.beans.factory.InitializingBean;
@@ -78,13 +79,8 @@ public abstract class BaseReportInstance extends AbstractReportInstance implemen
         getWalker().setResourceDao(resourceDao);
     }
 
-    /**
-     * <p>setRrdDao</p>
-     *
-     * @param rrdDao a {@link org.opennms.netmgt.dao.api.RrdDao} object.
-     */
-    public void setRrdDao(RrdDao rrdDao) {
-        m_rrdVisitor.setRrdDao(rrdDao);
+    public void setFetchStrategy(MeasurementFetchStrategy fetchStrategy) {
+        m_rrdVisitor.setFetchStrategy(fetchStrategy);
     }
 
     /**

--- a/opennms-services/src/main/java/org/opennms/netmgt/statsd/ReportDefinition.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/statsd/ReportDefinition.java
@@ -33,6 +33,7 @@ import org.opennms.netmgt.dao.api.NodeDao;
 import org.opennms.netmgt.dao.api.ResourceDao;
 import org.opennms.netmgt.dao.api.RrdDao;
 import org.opennms.netmgt.filter.api.FilterDao;
+import org.opennms.netmgt.measurements.api.MeasurementFetchStrategy;
 import org.opennms.netmgt.model.AttributeStatisticVisitorWithResults;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.dao.DataAccessResourceFailureException;
@@ -246,14 +247,14 @@ public class ReportDefinition implements InitializingBean {
      * <p>createReport</p>
      *
      * @param resourceDao a {@link org.opennms.netmgt.dao.api.ResourceDao} object.
-     * @param rrdDao a {@link org.opennms.netmgt.dao.api.RrdDao} object.
+     * @param fetchStrategy an object.
      * @param filterDao a {@link org.opennms.netmgt.filter.api.FilterDao} object.
      * @return a {@link org.opennms.netmgt.statsd.ReportInstance} object.
      * @throws java.lang.Exception if any.
      */
-    public ReportInstance createReport(NodeDao nodeDao, ResourceDao resourceDao, RrdDao rrdDao, FilterDao filterDao) throws Exception {
+    public ReportInstance createReport(NodeDao nodeDao, ResourceDao resourceDao, MeasurementFetchStrategy fetchStrategy, FilterDao filterDao) throws Exception {
         Assert.notNull(resourceDao, "resourceDao argument must not be null");
-        Assert.notNull(rrdDao, "rrdDao argument must not be null");
+        Assert.notNull(fetchStrategy, "fetchStrategy argument must not be null");
         Assert.notNull(filterDao, "filterDao argument must not be null");
         
         AttributeStatisticVisitorWithResults visitor;
@@ -268,7 +269,7 @@ public class ReportDefinition implements InitializingBean {
             FilteredReportInstance thisReport = new FilteredReportInstance(visitor);
             thisReport.setNodeDao(nodeDao);
             thisReport.setResourceDao(resourceDao);
-            thisReport.setRrdDao(rrdDao);
+            thisReport.setFetchStrategy(fetchStrategy);
             thisReport.setFilterDao(filterDao);
             thisReport.setFilter(getReport().getPackage().getFilter());
             
@@ -276,7 +277,7 @@ public class ReportDefinition implements InitializingBean {
         } else {
             UnfilteredReportInstance thisReport = new UnfilteredReportInstance(visitor); 
             thisReport.setResourceDao(resourceDao);
-            thisReport.setRrdDao(rrdDao);
+            thisReport.setFetchStrategy(fetchStrategy);
             
             report = thisReport;
         }

--- a/opennms-services/src/main/java/org/opennms/netmgt/statsd/Statsd.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/statsd/Statsd.java
@@ -33,12 +33,12 @@ import java.text.ParseException;
 import org.opennms.netmgt.daemon.SpringServiceDaemon;
 import org.opennms.netmgt.dao.api.NodeDao;
 import org.opennms.netmgt.dao.api.ResourceDao;
-import org.opennms.netmgt.dao.api.RrdDao;
 import org.opennms.netmgt.events.api.EventConstants;
 import org.opennms.netmgt.events.api.EventForwarder;
 import org.opennms.netmgt.events.api.annotations.EventHandler;
 import org.opennms.netmgt.events.api.annotations.EventListener;
 import org.opennms.netmgt.filter.api.FilterDao;
+import org.opennms.netmgt.measurements.api.MeasurementFetchStrategy;
 import org.opennms.netmgt.model.events.EventBuilder;
 import org.opennms.netmgt.model.events.EventUtils;
 import org.opennms.netmgt.xml.event.Event;
@@ -74,8 +74,7 @@ public class Statsd implements SpringServiceDaemon {
     @Autowired
     private ResourceDao m_resourceDao;
 
-    @Autowired
-    private RrdDao m_rrdDao;
+    private MeasurementFetchStrategy m_fetchStrategy;
 
     @Autowired
     private FilterDao m_filterDao;
@@ -226,7 +225,7 @@ public class Statsd implements SpringServiceDaemon {
     public void runReport(ReportDefinition reportDef) throws Throwable {
         final ReportInstance report;
         try {
-            report = reportDef.createReport(m_nodeDao, m_resourceDao, m_rrdDao, m_filterDao);
+            report = reportDef.createReport(m_nodeDao, m_resourceDao, m_fetchStrategy, m_filterDao);
         } catch (Throwable t) {
             LOG.error("Could not create a report instance for report definition {}", reportDef, t);
             throw t;
@@ -261,7 +260,7 @@ public class Statsd implements SpringServiceDaemon {
     public void afterPropertiesSet() throws Exception {
         Assert.state(m_nodeDao != null, "property nodeDao must be set to a non-null value");
         Assert.state(m_resourceDao != null, "property resourceDao must be set to a non-null value");
-        Assert.state(m_rrdDao != null, "property rrdDao must be set to a non-null value");
+        Assert.state(m_fetchStrategy != null, "property fetchStrategy must be set to a non-null value");
         Assert.state(m_filterDao != null, "property filterDao must be set to a non-null value");
         Assert.state(m_transactionTemplate != null, "property transactionTemplate must be set to a non-null value");
         Assert.state(m_reportPersister != null, "property reportPersister must be set to a non-null value");
@@ -286,13 +285,12 @@ public class Statsd implements SpringServiceDaemon {
         return m_resourceDao;
     }
 
-    /**
-     * <p>getRrdDao</p>
-     *
-     * @return a {@link org.opennms.netmgt.dao.api.RrdDao} object.
-     */
-    public RrdDao getRrdDao() {
-        return m_rrdDao;
+    public MeasurementFetchStrategy getFetchStrategy() {
+        return m_fetchStrategy;
+    }
+
+    public void setFetchStrategy(final MeasurementFetchStrategy fetchStrategy) {
+        this.m_fetchStrategy = fetchStrategy;
     }
 
     /**

--- a/opennms-services/src/main/resources/META-INF/opennms/applicationContext-statisticsDaemon.xml
+++ b/opennms-services/src/main/resources/META-INF/opennms/applicationContext-statisticsDaemon.xml
@@ -35,6 +35,9 @@
       <property name="eventForwarder">
         <onmsgi:reference interface="org.opennms.netmgt.events.api.EventForwarder"/>
       </property>
+        <property name="fetchStrategy">
+            <onmsgi:reference interface="org.opennms.netmgt.measurements.api.MeasurementFetchStrategy"/>
+        </property>
     </bean>
 
     <bean id="daemonListener" class="org.opennms.netmgt.events.api.AnnotationBasedEventListenerAdapter">

--- a/opennms-services/src/test/java/org/opennms/netmgt/statsd/ReportDefinitionTest.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/statsd/ReportDefinitionTest.java
@@ -45,6 +45,9 @@ import org.opennms.netmgt.dao.api.ResourceDao;
 import org.opennms.netmgt.dao.api.RrdDao;
 import org.opennms.netmgt.dao.support.BottomNAttributeStatisticVisitor;
 import org.opennms.netmgt.filter.api.FilterDao;
+import org.opennms.netmgt.measurements.api.FetchResults;
+import org.opennms.netmgt.measurements.api.MeasurementFetchStrategy;
+import org.opennms.netmgt.measurements.model.Source;
 import org.opennms.netmgt.mock.MockResourceType;
 import org.opennms.netmgt.model.AttributeStatisticVisitorWithResults;
 import org.opennms.netmgt.model.ExternalValueAttribute;
@@ -64,7 +67,7 @@ public class ReportDefinitionTest extends TestCase {
     private EasyMockUtils m_mocks = new EasyMockUtils();
     private NodeDao m_nodeDao = m_mocks.createMock(NodeDao.class);
     private ResourceDao m_resourceDao = m_mocks.createMock(ResourceDao.class);
-    private RrdDao m_rrdDao = m_mocks.createMock(RrdDao.class);
+    private MeasurementFetchStrategy m_fetchStrategy = m_mocks.createMock(MeasurementFetchStrategy.class);
     private FilterDao m_filterDao = m_mocks.createMock(FilterDao.class);
     
     @Override
@@ -107,7 +110,7 @@ public class ReportDefinitionTest extends TestCase {
         ReportDefinition def = createReportDefinition();
         def.setResourceAttributeKey("ifSpeed");
         def.setResourceAttributeValueMatch("100000000");
-        ReportInstance report = def.createReport(m_nodeDao, m_resourceDao, m_rrdDao, m_filterDao);
+        ReportInstance report = def.createReport(m_nodeDao, m_resourceDao, m_fetchStrategy, m_filterDao);
 
         m_mocks.replayAll();
         
@@ -127,7 +130,7 @@ public class ReportDefinitionTest extends TestCase {
         ReportDefinition def = createReportDefinition();
         def.setResourceAttributeKey("ifSpeed");
         def.setResourceAttributeValueMatch("100000000");
-        ReportInstance report = def.createReport(m_nodeDao, m_resourceDao, m_rrdDao, m_filterDao);
+        ReportInstance report = def.createReport(m_nodeDao, m_resourceDao, m_fetchStrategy, m_filterDao);
 
         m_mocks.replayAll();
         
@@ -153,9 +156,24 @@ public class ReportDefinitionTest extends TestCase {
         ReportDefinition def = createReportDefinition();
         def.setResourceAttributeKey(externalValueAttribute.getName());
         def.setResourceAttributeValueMatch(externalValueAttribute.getValue());
-        ReportInstance report = def.createReport(m_nodeDao, m_resourceDao, m_rrdDao, m_filterDao);
+        ReportInstance report = def.createReport(m_nodeDao, m_resourceDao, m_fetchStrategy, m_filterDao);
 
-        EasyMock.expect(m_rrdDao.getPrintValue(rrdAttribute, def.getConsolidationFunction(), report.getStartTime(), report.getEndTime())).andReturn(1.0);
+        rrdAttribute.setResource(new OnmsResource("1", "Node One", resourceType, Collections.singleton(rrdAttribute), ResourcePath.get("foo")));
+        Source source = new Source();
+        source.setLabel("result");
+        source.setResourceId(rrdAttribute.getResource().getId());
+        source.setAttribute(rrdAttribute.getName());
+        source.setAggregation("AVERAGE");
+        FetchResults results = new FetchResults(new long[] {report.getStartTime()},
+                                                Collections.singletonMap("result", new double[] {100.0}),
+                                                report.getEndTime() - report.getStartTime(),
+                                                Collections.emptyMap());
+        EasyMock.expect(m_fetchStrategy.fetch(report.getStartTime(),
+                                              report.getEndTime(),
+                                              (int) (report.getEndTime() - report.getStartTime()),
+                                              1,
+                                              Collections.singletonList(source)))
+                .andReturn(results);
 
         m_mocks.replayAll();
         
@@ -183,7 +201,7 @@ public class ReportDefinitionTest extends TestCase {
         def.getReport().getPackage().setFilter("");
         def.setResourceAttributeKey("ifSpeed");
         def.setResourceAttributeValueMatch("100000000");
-        ReportInstance report = def.createReport(m_nodeDao, m_resourceDao, m_rrdDao, m_filterDao);
+        ReportInstance report = def.createReport(m_nodeDao, m_resourceDao, m_fetchStrategy, m_filterDao);
 
         SortedMap<Integer,String> sortedNodeMap = new TreeMap<Integer, String>();
         sortedNodeMap.put(node.getId(), node.getLabel());
@@ -220,7 +238,7 @@ public class ReportDefinitionTest extends TestCase {
         def.getReport().getPackage().setFilter("");
         def.setResourceAttributeKey(externalValueAttribute.getName());
         def.setResourceAttributeValueMatch(externalValueAttribute.getValue());
-        ReportInstance report = def.createReport(m_nodeDao, m_resourceDao, m_rrdDao, m_filterDao);
+        ReportInstance report = def.createReport(m_nodeDao, m_resourceDao, m_fetchStrategy, m_filterDao);
 
         SortedMap<Integer,String> sortedNodeMap = new TreeMap<Integer, String>();
         sortedNodeMap.put(node.getId(), node.getLabel());
@@ -228,7 +246,22 @@ public class ReportDefinitionTest extends TestCase {
 
         EasyMock.expect(m_resourceDao.getResourceForNode(node)).andReturn(resource);
 
-        EasyMock.expect(m_rrdDao.getPrintValue(rrdAttribute, def.getConsolidationFunction(), report.getStartTime(), report.getEndTime())).andReturn(1.0);
+        Source source = new Source();
+        source.setLabel("result");
+        source.setResourceId(resource.getId());
+        source.setAttribute(rrdAttribute.getName());
+        source.setAggregation("AVERAGE");
+        FetchResults results = new FetchResults(new long[] {report.getStartTime()},
+                                                Collections.singletonMap("result", new double[] {100.0}),
+                                                report.getEndTime() - report.getStartTime(),
+                                                Collections.emptyMap());
+        EasyMock.expect(m_fetchStrategy.fetch(report.getStartTime(),
+                                              report.getEndTime(),
+                                              (int) (report.getEndTime() - report.getStartTime()),
+                                              1,
+                                              Collections.singletonList(source)))
+                .andReturn(results);
+
 
         m_mocks.replayAll();
         

--- a/pom.xml
+++ b/pom.xml
@@ -2439,6 +2439,11 @@
         <version>${project.version}</version>
       </dependency>
       <dependency>
+        <groupId>org.opennms.features.measurements</groupId>
+        <artifactId>org.opennms.features.measurements.api</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
         <groupId>org.opennms</groupId>
         <artifactId>opennms-site</artifactId>
         <version>${project.version}</version>


### PR DESCRIPTION
Statsd failed to work with NewTS as it's using the RRD DAO directly and tries to access the (non existing) RRD Files on disk.

This changes the resource visitors used by statsd to use the measurement API instead of the RRD DOA to gether the statistic values.

Issue: http://issues.opennms.org/browse/HZN-478
Bamboo: http://bamboo.internal.opennms.com:8085/browse/OPENNMS-ONMS212-2