### PR TITLE
NMS-7948: Fix wiring typos for JMS Northbounder targetConnectionFactory,brokerURL, username, and password properties

### DIFF
--- a/opennms-alarms/jms-northbounder/src/main/resources/META-INF/opennms/component-dao.xml
+++ b/opennms-alarms/jms-northbounder/src/main/resources/META-INF/opennms/component-dao.xml
@@ -8,12 +8,12 @@
 	">
 	<bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer" />
 	<bean name="m_jmsNorthbounderConnectionFactory" class="org.springframework.jms.connection.CachingConnectionFactory">
-		<property name="targetConnectionFactory" ref="${opennms.alarms.northbound.jms.connectionFactoryImplRef:activemqConnectionFactory}"></property>
+		<property name="targetConnectionFactory" ref="${opennms.alarms.northbound.jms.connectionFactoryImplRef}"></property>
 	</bean>
 	<bean name="activemqConnectionFactory" class="org.apache.activemq.ActiveMQConnectionFactory">
-		<property name="brokerURL" value="${opennms.alarms.northbound.jms.activemq.brokerURL:vm://localhost}"/>
-		<property name="userName" value="${opennms.alarms.northbound.jms.activemq.userName:}"/>
-		<property name="password" value="${opennms.alarms.northbound.jms.activemq.password:}"/>
+		<property name="brokerURL" value="${opennms.alarms.northbound.jms.activemq.brokerURL}"/>
+		<property name="userName" value="${opennms.alarms.northbound.jms.activemq.userName}"/>
+		<property name="password" value="${opennms.alarms.northbound.jms.activemq.password}"/>
 	</bean>
 	<bean name="jmsNorthbounderConfigDao" class="org.opennms.netmgt.alarmd.northbounder.jms.JmsNorthbounderConfigDao">
       <property name="configResource" value="file:${opennms.home}/etc/jms-northbounder-configuration.xml" />


### PR DESCRIPTION
Issue link: http://issues.opennms.org/browse/NMS-7948