### PR TITLE
NMS-7966: NPE when generating eventconf from a MIB with recursive TCs in notification varbind

### DIFF
--- a/features/mib-compiler/src/test/java/org/opennms/features/mibcompiler/JsmiMibParserTest.java
+++ b/features/mib-compiler/src/test/java/org/opennms/features/mibcompiler/JsmiMibParserTest.java
@@ -171,6 +171,20 @@ public class JsmiMibParserTest {
     }
 
     /**
+     * Test generate events from a semi-invalid MIB.
+     *
+     * @throws Exception the exception
+     */
+    @Test
+    public void testRecursiveTextualConvention() throws Exception {
+        if (parser.parseMib(new File(MIB_DIR, "NORTEL-NMI-CONFIG-NOTI-MIB.txt"))) {
+            Events events = parser.getEvents("uei.opennms.org/vendor/Nortel/traps/");
+            Assert.assertNotNull(events);
+            System.out.println(JaxbUtils.marshal(events));
+        }
+    }
+
+    /**
      * Test generate events from traps.
      */
     @Test

--- a/features/mib-compiler/src/test/resources/NORTEL-GENERIC-MIB.txt
+++ b/features/mib-compiler/src/test/resources/NORTEL-GENERIC-MIB.txt
@@ -1,0 +1,101 @@
+
+NORTEL-GENERIC-MIB 
+
+DEFINITIONS ::= BEGIN
+
+   IMPORTS
+       nortel
+           FROM NORTEL-MIB
+       MODULE-IDENTITY, OBJECT-IDENTITY
+           FROM SNMPv2-SMI;
+
+
+   nortelGenericMIBs  MODULE-IDENTITY
+       LAST-UPDATED "9906240000Z"
+       ORGANIZATION "Nortel Networks"
+       CONTACT-INFO
+              "   Jingdong Liu 
+
+                Postal: Nortel Networks
+                        P. O. Box 3511, Station C
+                        Ottawa, Ontario
+                        CANADA
+                        K1Y 4H7
+
+                Email:  jingdong@nortelnetworks.com"
+
+       DESCRIPTION
+               "This module represents the top-level MIB branch for some 
+                of the generic MIBs that are common to NortelNetworks products." 
+
+       -- Revision history
+
+       REVISION "9906240000Z"
+       DESCRIPTION
+                " The fourth version of this MIB module. 
+                  Module name changed.
+                  
+                  Revisions introduced by Shobana Sundaram."
+
+    
+       REVISION "9905310000Z"
+       DESCRIPTION
+                " The third version of this MIB module. 
+                  Contact info updated and Revision history added."
+                  
+
+ 
+       REVISION "9904120000Z"
+       DESCRIPTION
+                " The second version of this MIB module. 
+                  Contact info introduced and Revision history added.
+                  Object description improved."
+
+
+       REVISION "9903220000Z"
+       DESCRIPTION
+                " The first version of this MIB module."
+
+
+       ::= { nortel 29 }
+
+
+       nortelNetworkManagementInterfaceMIBs  OBJECT-IDENTITY
+           STATUS         current
+           DESCRIPTION    
+                  "This OID represents the Network Management Interface (NMI)
+                   branch for the Nortel Networks's generic MIBs suite. 
+                   Nortel NMI is an umbrella to include various generic MIBs 
+                   that can be implemented by Nortel devices to 
+                   interface to a carrier grade Network Management System (NMS). 
+
+                   This branch currently consists of MIBs to support carrier
+                   grade alarm surveillance. Characteristics of such a system
+                   as applicable to this interface are 
+                         - reliable and accurate alarm service 
+                         - capability to summarise currently outstanding alarms
+                         - no stuck alarms, no need to age out / manually clear alarms
+                         - standards based open interface to alarms 
+
+                   For future revisions of the Nortel NMI MIBs, it is 
+                   mandatory to ensure that the changes are backward 
+                   compatible. It is very IMPORTANT to follow the 
+                   SMI rules at RFC 1902 to ensure that no 
+                   non-backward compatible changes are made
+                   as multiple applications use this for various purposes.
+                   This MIB is entensible, but the current set of variables
+                   cannot be modified. 
+
+
+                   "
+
+           ::=  { nortelGenericMIBs 1 }
+
+
+ -- additional generic MIBs can be registered here
+
+
+
+END
+
+

--- a/features/mib-compiler/src/test/resources/NORTEL-MIB.txt
+++ b/features/mib-compiler/src/test/resources/NORTEL-MIB.txt
@@ -1,0 +1,23 @@
+NORTEL-MIB DEFINITIONS ::= BEGIN
+   IMPORTS 
+       enterprises, MODULE-IDENTITY
+	   FROM SNMPv2-SMI;
+
+   nortel MODULE-IDENTITY
+       LAST-UPDATED "9903010000Z"
+       ORGANIZATION "Northern Telecom Ltd."
+       CONTACT-INFO
+               "        Edward Ersil
+
+	        Postal: Bell-Northern Research Ltd.
+		        P. O. Box 3511, Station C
+		        Ottawa, Ontario
+		        CANADA
+		        K1Y 4H7
+		
+		Email:  eersil@nortelnetworks.com"
+       DESCRIPTION
+               "The Northern Telecom top-level MIB definition."
+       ::= { enterprises 562 } 
+END
+

--- a/features/mib-compiler/src/test/resources/NORTEL-NMI-CONFIG-NOTI-MIB.txt
+++ b/features/mib-compiler/src/test/resources/NORTEL-NMI-CONFIG-NOTI-MIB.txt
@@ -1,0 +1,281 @@
+NORTEL-NMI-CONFIG-NOTI-MIB 
+
+DEFINITIONS ::= BEGIN
+
+   IMPORTS
+       nortelNMInotificationsMIB,
+       nortelNMIcurrentTxNotificationSequenceNum,
+       nortelNMInotifyNeType,
+       nortelNMInotifyNeName,
+       nortelNMInotifyNeAdminState,
+       nortelNMInotifyNeOperState,
+       nortelNMInotifyNeUnknownStatus
+           FROM  NORTEL-NMI-NOTIFICATIONS-MIB 
+                                   
+       NortelNMItimeStampDef
+           FROM NORTEL-NMI-TC-MIB
+
+       nortelNMInotificationGroups
+           FROM NORTEL-NMI-GROUPS-MIB
+       DisplayString
+           FROM SNMPv2-TC
+       NOTIFICATION-GROUP
+           FROM SNMPv2-CONF
+       MODULE-IDENTITY, OBJECT-IDENTITY, 
+       OBJECT-TYPE, NOTIFICATION-TYPE,
+       IpAddress
+           FROM SNMPv2-SMI;
+
+
+   nortelNMIconfigNotiMIB  MODULE-IDENTITY
+       LAST-UPDATED "9906240000Z"
+       ORGANIZATION "Nortel Networks"
+       CONTACT-INFO
+              "   Jingdong Liu
+
+                Postal: Nortel Networks
+                        P. O. Box 3511, Station C
+                        Ottawa, Ontario
+                        CANADA
+                        K1Y 4H7
+
+                Email:  jingdong@nortelnetworks.com"
+
+
+       DESCRIPTION
+               "This module contains the configuration management related
+                notifications for the Nortel NMI."
+
+       -- Revision history
+
+
+       REVISION "9906240000Z"
+       DESCRIPTION
+                " The fourth version of this MIB module.
+                  Module-identity oid assignment changed.
+                  NE IP address added as a varbind to the
+                  attribute change notification.
+
+                  Revisions introduced by Shobana Sundaram."
+
+       REVISION "9905310000Z"
+       DESCRIPTION
+                " The third version of this MIB module.
+                  Contact info updated and Revision history added.
+                "
+
+
+       REVISION "9904120000Z"
+       DESCRIPTION
+                " The second version of this MIB module.
+                  Contact info updated and Revision history added."
+
+       REVISION "9903220000Z"
+       DESCRIPTION
+                " The first version of this MIB module."
+
+
+       ::= { nortelNMInotificationsMIB 3  }
+
+  -- all notifications OIDs would be prefixed with a zero OID to 
+  -- facilate snmp v1<->v2 conversion
+
+  nortelNMIconfigNotiPrefix  OBJECT-IDENTITY
+           STATUS         current
+           DESCRIPTION
+                  "This OID represents the prefix branch for all Nortel NMI 
+                   configuration  Notifications.
+                   The last but one sub identifier in the OID of any 
+                   Notification must have the value zero to facilitate 
+                   v2<-->v1 conversion." 
+           ::=  {nortelNMIconfigNotiMIB  0 }
+ 
+
+   nortelNMIconfigNotiVarbinds OBJECT-IDENTITY
+           STATUS         current
+           DESCRIPTION
+                  "This OID represents the branch which contains varbinds to 
+                   configuration management related notifications." 
+           ::=  {nortelNMIconfigNotiMIB  1 }
+
+
+  -- The following variables belong to the accessible-for-notify clause and
+  -- are defined here mainly to be included as varbinds to notifications.
+  -- No other protocol operations will be supported for these
+
+ 
+          nortelNMInotifyNeDeEnrolTime  OBJECT-TYPE
+              SYNTAX NortelNMItimeStampDef 
+              MAX-ACCESS  accessible-for-notify
+              STATUS  current
+              DESCRIPTION
+                 "This variable represents the time at which the NE for 
+                  formally deenrolled. 
+                  NortelNMItimeStampDef textual convention is defined at the
+                  NORTEL-NMI-TC-MIB."
+
+              ::= { nortelNMIconfigNotiVarbinds  1 }
+
+
+         nortelNMInotifyNeEnrolTime  OBJECT-TYPE
+              SYNTAX   NortelNMItimeStampDef 
+              MAX-ACCESS  accessible-for-notify
+              STATUS  current
+              DESCRIPTION
+                 "This variable represents the time at which the NE was formally
+                  enrolled in the EMS management domain.
+                  NortelNMItimeStampDef textual convention is defined at the
+                  NORTEL-NMI-TC-MIB."
+
+              ::= { nortelNMIconfigNotiVarbinds  2 }
+
+
+
+         nortelNMInotifyNeIPaddress OBJECT-TYPE
+              SYNTAX  IpAddress
+              MAX-ACCESS  accessible-for-notify 
+              STATUS  current
+              DESCRIPTION
+                "This variable represents the IP address of the Network Element,
+                 with which an NMS can reach through to the Network element
+                 directly."
+
+              ::= { nortelNMIconfigNotiVarbinds 3 }
+
+
+         nortelNMInotifyNeVersionInfo OBJECT-TYPE
+              SYNTAX  DisplayString (SIZE(1..255))
+              MAX-ACCESS  accessible-for-notify 
+              STATUS  current
+              DESCRIPTION
+                 "This variable contains the version information of Network Element.
+                  Software / Hardware version data can be filled in as values as
+                  appropriate to the NE in context."
+
+              ::= { nortelNMIconfigNotiVarbinds  4 }
+
+
+         nortelNMInotifyNeVendorName OBJECT-TYPE
+              SYNTAX  DisplayString  (SIZE(1..255))
+              MAX-ACCESS  accessible-for-notify 
+              STATUS  current
+              DESCRIPTION
+                  "This variable contains the Network Element vendor name."
+
+              ::= { nortelNMIconfigNotiVarbinds  5 }
+
+
+         nortelNMInotifyNeLocationName OBJECT-TYPE
+              SYNTAX  DisplayString  (SIZE(1..255))
+              MAX-ACCESS  accessible-for-notify 
+              STATUS  current
+              DESCRIPTION
+                  "This variable represents the location information of 
+                   Network Element. An example could be the Common
+                   Language Location Identifier (CLLI) of the NE." 
+
+              ::= { nortelNMIconfigNotiVarbinds  6 }
+
+
+          nortelNMInotifyNeDataChangeTime  OBJECT-TYPE
+              SYNTAX NortelNMItimeStampDef 
+              MAX-ACCESS  accessible-for-notify
+              STATUS  current
+              DESCRIPTION
+                 "This variable represents the time at which a certain
+                  NE attribute was modified. "
+
+              ::= { nortelNMIconfigNotiVarbinds 7 }
+
+           
+
+       -- Configuration events 
+
+         nortelNMIneEnrolNotification  NOTIFICATION-TYPE
+                          OBJECTS { nortelNMIcurrentTxNotificationSequenceNum, 
+                                    nortelNMInotifyNeType,
+                                    nortelNMInotifyNeName,
+                                    nortelNMInotifyNeEnrolTime,
+
+                                    nortelNMInotifyNeIPaddress,
+                                    nortelNMInotifyNeVersionInfo,
+                                    nortelNMInotifyNeVendorName,
+                                    nortelNMInotifyNeLocationName,
+                                   
+                                    nortelNMInotifyNeAdminState,
+                                    nortelNMInotifyNeOperState,
+                                    nortelNMInotifyNeUnknownStatus                         
+                                  }
+            STATUS  current
+            DESCRIPTION
+              "This notification indicates that an NE has been enrolled into the 
+               EMS management domain. The varbinds include all the 
+               key attributes required by the NMS."
+
+          ::= { nortelNMIconfigNotiPrefix  11 }
+
+
+
+         nortelNMIneDeEnrolNotification  NOTIFICATION-TYPE
+                          OBJECTS { nortelNMIcurrentTxNotificationSequenceNum, 
+                                    nortelNMInotifyNeType,
+                                    nortelNMInotifyNeName,
+                                    nortelNMInotifyNeDeEnrolTime
+                                  }
+            STATUS  current
+            DESCRIPTION
+              "This notification indicates that an NE has been deenrolled from the 
+               EMS management domain."
+
+          ::= { nortelNMIconfigNotiPrefix  12 }
+
+
+         nortelNMIneAttributeChangeNotification NOTIFICATION-TYPE
+                          OBJECTS { nortelNMIcurrentTxNotificationSequenceNum,
+                                    nortelNMInotifyNeType,
+                                    nortelNMInotifyNeName,
+                                    nortelNMInotifyNeDataChangeTime,
+
+                                    nortelNMInotifyNeVersionInfo,
+                                    nortelNMInotifyNeVendorName,
+                                    nortelNMInotifyNeLocationName,
+                                    nortelNMInotifyNeIPaddress
+                                  }
+            STATUS  current
+            DESCRIPTION
+              "This notification indicates that an NE attribute has been changed. 
+               The modified value of the specific attribute would be included as 
+               the varbind in the actual Notification PDU. We currently support 
+               changes to version information, vendor name and location name and
+               the NE Reach through IP address."
+
+          ::= { nortelNMIconfigNotiPrefix  13 }
+
+-- Notification group definitions
+
+     nortelNMIneRegistrationNotificationGroup  NOTIFICATION-GROUP
+           NOTIFICATIONS  {
+                          nortelNMIneEnrolNotification,
+                          nortelNMIneDeEnrolNotification
+                          }
+           STATUS   current
+           DESCRIPTION
+                " Nortel NMI NE registration notifications group."
+           ::= { nortelNMInotificationGroups 1}
+
+
+     nortelNMIneAttrChangeNotificationGroup  NOTIFICATION-GROUP
+           NOTIFICATIONS  {
+                          nortelNMIneAttributeChangeNotification
+                          }
+           STATUS   current
+           DESCRIPTION
+                " Nortel NMI NE attribute change notification group."
+           ::= { nortelNMInotificationGroups 2}
+
+
+
+
+END
+
+

--- a/features/mib-compiler/src/test/resources/NORTEL-NMI-CONFORMANCE-MIB.txt
+++ b/features/mib-compiler/src/test/resources/NORTEL-NMI-CONFORMANCE-MIB.txt
@@ -1,0 +1,54 @@
+NORTEL-NMI-CONFORMANCE-MIB 
+
+DEFINITIONS ::= BEGIN
+
+   IMPORTS
+       nortelNetworkManagementInterfaceMIBs 
+           FROM  NORTEL-GENERIC-MIB
+       MODULE-IDENTITY
+           FROM SNMPv2-SMI;
+
+   nortelNMIconformanceMIBs  MODULE-IDENTITY
+       LAST-UPDATED "9906240000Z"
+       ORGANIZATION "Nortel Networks"
+       CONTACT-INFO
+              "   Jingdong Liu
+
+                Postal: Nortel Networks
+                        P. O. Box 3511, Station C
+                        Ottawa, Ontario
+                        CANADA
+                        K1Y 4H7
+
+                Email:  jingdong@nortelnetworks.com"
+
+
+       DESCRIPTION
+               "This module contains the branches for the Nortel 
+                NetworkManagementInterface (NMI) conformance group. " 
+   
+       -- Revision history
+
+
+       REVISION "9906240000Z"
+       DESCRIPTION
+                " The second version of this MIB module.
+                  Module-identity OID assignment modified.
+
+                  Revisions introduced by Shobana Sundaram."
+
+
+
+       REVISION "9905310000Z"
+       DESCRIPTION
+                " The first version of this MIB module."
+
+
+
+       ::= { nortelNetworkManagementInterfaceMIBs  2 }
+
+
+
+END
+
+

--- a/features/mib-compiler/src/test/resources/NORTEL-NMI-GROUPS-MIB.txt
+++ b/features/mib-compiler/src/test/resources/NORTEL-NMI-GROUPS-MIB.txt
@@ -1,0 +1,62 @@
+
+NORTEL-NMI-GROUPS-MIB 
+
+DEFINITIONS ::= BEGIN
+
+   IMPORTS
+       nortelNMIconformanceMIBs 
+           FROM NORTEL-NMI-CONFORMANCE-MIB 
+
+       MODULE-IDENTITY, OBJECT-IDENTITY
+           FROM SNMPv2-SMI;
+
+   nortelNMImibGroups  MODULE-IDENTITY
+       LAST-UPDATED "9906240000Z"
+       ORGANIZATION "Nortel Networks"
+       CONTACT-INFO
+              "   Jingdong Liu
+
+                Postal: Nortel Networks
+                        P. O. Box 3511, Station C
+                        Ottawa, Ontario
+                        CANADA
+                        K1Y 4H7
+
+                Email:  jingdong@nortelnetworks.com"
+
+
+       DESCRIPTION
+               "This module contains the object group definitions 
+                for the Network Management Interface (NMI) MIBs. " 
+   
+       -- Revision history
+
+       REVISION "9906240000Z"
+       DESCRIPTION
+                " The first version of this MIB module.
+
+                  Revisions introduced by Shobana Sundaram."
+
+
+       ::= { nortelNMIconformanceMIBs 1 }
+
+
+     nortelNMIobjectGroups OBJECT-IDENTITY
+           STATUS         current
+           DESCRIPTION
+                  "This OID represents the branch for the object 
+                   group definitions."
+           ::=  { nortelNMImibGroups 1 }
+
+
+     nortelNMInotificationGroups OBJECT-IDENTITY
+           STATUS         current
+           DESCRIPTION
+                  "This OID represents the branch for the notification 
+                   group definitions."
+           ::=  { nortelNMImibGroups 2 }
+
+
+END
+
+

--- a/features/mib-compiler/src/test/resources/NORTEL-NMI-NOTIFICATIONS-MIB.txt
+++ b/features/mib-compiler/src/test/resources/NORTEL-NMI-NOTIFICATIONS-MIB.txt
@@ -1,0 +1,204 @@
+
+NORTEL-NMI-NOTIFICATIONS-MIB 
+
+DEFINITIONS ::= BEGIN
+
+   IMPORTS
+       nortelNetworkManagementInterfaceMIBs 
+           FROM NORTEL-GENERIC-MIB 
+   
+       NortelNMIneType,  
+       NortelNMIadminState, NortelNMIoperState,
+       NortelNMIunknownStatusValue
+           FROM NORTEL-NMI-TC-MIB
+
+       DisplayString
+           FROM SNMPv2-TC
+                                
+       MODULE-IDENTITY, OBJECT-IDENTITY, 
+       OBJECT-TYPE, Unsigned32
+           FROM SNMPv2-SMI;
+
+
+   nortelNMInotificationsMIB  MODULE-IDENTITY
+       LAST-UPDATED "9907190000Z"
+       ORGANIZATION "Nortel Networks"
+       CONTACT-INFO
+              "   Jingdong Liu
+
+                Postal: Nortel Networks
+                        P. O. Box 3511, Station C
+                        Ottawa, Ontario
+                        CANADA
+                        K1Y 4H7
+
+                Email:  jingdong@nortelnetworks.com"
+
+
+       DESCRIPTION
+               "This module contains the notification branches for 
+                the Nortel NMI along with the definition of the 
+                notification sequence number variable." 
+
+       -- Revision history
+       REVISION "9907190000Z"
+       DESCRIPTION
+                "Add ASCII string limitations for NE name / componentID, etc."
+
+       REVISION "9906240000Z"
+       DESCRIPTION
+                " The fourth version of this MIB module.
+                  Module-identity oid assignment changed.
+            
+                  Revisions introduced by Shobana Sundaram."
+
+
+       REVISION "9905310000Z"
+       DESCRIPTION
+                " The third version of this MIB module.
+                  Contact info updated and Revision history added.
+            
+                  Revisions introduced by Shobana Sundaram."
+
+
+       REVISION "9904120000Z"
+       DESCRIPTION
+                " The second version of this MIB module.
+                  Contact info updated and Revision history added."
+
+       REVISION "9903220000Z"
+       DESCRIPTION
+                " The first version of this MIB module."
+
+
+       ::= { nortelNetworkManagementInterfaceMIBs 6 }
+
+
+   nortelNMIcurrentTxNotificationSequenceNum  OBJECT-TYPE
+      SYNTAX   Unsigned32
+       MAX-ACCESS  read-only
+       STATUS  current
+       DESCRIPTION
+          "This variable represents the sequence number of the 
+           Notifications and is incremented by one whenever a 
+           notification is emitted from the agent.  This would be 
+           included as a varbind for all notifications and this value
+           when read indicates the sequence number of the last 
+           transmitted trap. " 
+
+        ::= { nortelNMInotificationsMIB 1 }
+
+   nortelNMIcommonNotiVarbinds OBJECT-IDENTITY
+           STATUS         current
+           DESCRIPTION
+                  "This OID represents the branch for varbinds that are 
+                   common to all categories of Nortel NMI Notifications."
+           ::=  { nortelNMInotificationsMIB 2 }
+
+ 
+   nortelNMIconfigNotiMIB OBJECT-IDENTITY
+           STATUS         current
+           DESCRIPTION
+                  "This OID represents the branch for all configuration 
+                   related Nortel NMI Notifications."
+           ::=  { nortelNMInotificationsMIB 3 }
+
+ 
+   nortelNMIfaultNotiMIB OBJECT-IDENTITY
+           STATUS         current
+           DESCRIPTION
+                  "This OID represents the branch for all fault management 
+                   related Nortel NMI Notifications."
+           ::=  { nortelNMInotificationsMIB 4 }
+
+   nortelNMIinfoNotiMIB OBJECT-IDENTITY
+           STATUS         current
+           DESCRIPTION
+                  "This OID represents the branch for all informational log 
+                   related Nortel NMI Notifications."
+           ::=  { nortelNMInotificationsMIB 5 }
+
+
+
+
+  -- The following variables belong to the accessible-for-notify clause and
+  -- are defined here mainly to be included as varbinds to notifications.
+  -- No other protocol operations will be supported for these
+
+
+         nortelNMInotifyNeType  OBJECT-TYPE
+              SYNTAX NortelNMIneType
+              MAX-ACCESS  accessible-for-notify
+              STATUS  current
+              DESCRIPTION
+                 "This variable represents the type of the NE that is being
+                  enrolled into the network management domain. 
+                  NortelNMIneType textual
+                  convention is defined at the NORTEL-NMI-TC-MIB."
+
+              ::= { nortelNMIcommonNotiVarbinds  1 }
+
+
+         nortelNMInotifyNeName  OBJECT-TYPE
+              SYNTAX  DisplayString (SIZE(1..32))
+              MAX-ACCESS  accessible-for-notify
+              STATUS  current
+              DESCRIPTION
+                 "This variable represents the name of the NE that
+                  is being enrolled into the network management domain.
+                  This name should uniquely identify the NE in the EMS
+                  domain across all NE types.
+                  The NeName string should be a single word, can only contain 
+                  alphanumeric characters and underscores. No commas, spaces, 
+                  slashes, hyphens, or dollar signs is allowed."
+
+              ::= { nortelNMIcommonNotiVarbinds  2 }
+
+
+         nortelNMInotifyNeAdminState OBJECT-TYPE
+              SYNTAX  NortelNMIadminState
+              MAX-ACCESS  accessible-for-notify
+              STATUS  current
+              DESCRIPTION
+                 "This variable presents the administratively assigned
+                  state (ITU-T X.731) of the NE. The textual convention 
+                  NortelNMIadminState defined at NORTEL-NMI-TC-MIB."
+
+              ::= { nortelNMIcommonNotiVarbinds  3 }
+
+
+         nortelNMInotifyNeOperState OBJECT-TYPE
+              SYNTAX  NortelNMIoperState
+              MAX-ACCESS  accessible-for-notify
+              STATUS  current
+              DESCRIPTION
+                 "This variable presents the current operational state
+                  (ITU-T X.731) of the NE."
+
+              ::= { nortelNMIcommonNotiVarbinds  4 }
+
+
+        nortelNMInotifyNeUnknownStatus OBJECT-TYPE
+              SYNTAX  NortelNMIunknownStatusValue
+              MAX-ACCESS  accessible-for-notify
+              STATUS  current
+              DESCRIPTION
+
+                 "This variable presents the NE unknown Status Values as 
+                  per (ITU-T X.731). The textual convention 
+                  NortelNMIunknownStatusValue defined at NORTEL-NMI-TC-MIB
+                  is of type Truthvalue (SNMPv2-TC)."
+
+              ::= { nortelNMIcommonNotiVarbinds  5 }
+
+
+
+
+
+
+
+
+
+END
+
+

--- a/features/mib-compiler/src/test/resources/NORTEL-NMI-TC-MIB.txt
+++ b/features/mib-compiler/src/test/resources/NORTEL-NMI-TC-MIB.txt
@@ -1,0 +1,265 @@
+NORTEL-NMI-TC-MIB 
+
+DEFINITIONS ::= BEGIN
+
+   IMPORTS
+       MODULE-IDENTITY, Unsigned32
+           FROM SNMPv2-SMI
+       TEXTUAL-CONVENTION, DisplayString, TruthValue
+           FROM SNMPv2-TC
+       nortelNetworkManagementInterfaceMIBs 
+           FROM NORTEL-GENERIC-MIB;
+
+   nortelNMItextConvMIB MODULE-IDENTITY
+       LAST-UPDATED "9907190000Z"
+       ORGANIZATION "Nortel Networks"
+       CONTACT-INFO
+               "   Jingdong Liu 
+
+                Postal: Nortel Networks
+                        P. O. Box 3511, Station C
+                        Ottawa, Ontario
+                        CANADA
+                        K1Y 4H7
+
+                Email:  jingdong@nortelnetworks.com"
+
+       DESCRIPTION
+               "This module contains the definitions of some proprietary
+                textual conventions for the Nortel generic 
+                NetworkManagementInterface (NMI) mibs. " 
+   
+
+       -- Revision history
+       REVISION "9907190000Z"
+       DESCRIPTION
+                " Change the description of NortelNMIneType.
+                  Revision introduced by Jingdong LIU."
+
+
+       REVISION "9906240000Z"
+       DESCRIPTION
+                " The fourth version of this MIB module. 
+                  Module-Identity OID assignment changed.
+                  Comments modified."
+
+       REVISION "9905310000Z"
+       DESCRIPTION
+                " The third version of this MIB module. 
+                  Contact info updated and Revision history added.
+                  Syntaxes changed to 
+
+                         - NortelNMIneType 
+                         - NortelNMIadminState 
+                         - NortelNMIoperState 
+
+
+                  Revisions introduced by Shobana Sundaram. "
+                           
+
+       REVISION "9904120000Z"
+       DESCRIPTION
+                " The second version of this MIB module. 
+                  Contact info updated and Revision history added.
+                  Comments modified."
+
+       REVISION "9903220000Z"
+       DESCRIPTION
+                " The first version of this MIB module."
+
+
+       ::= { nortelNetworkManagementInterfaceMIBs 3 }
+
+
+  -- Textual conventions
+
+
+   NortelNMItimeStampDef  ::=  TEXTUAL-CONVENTION
+     STATUS         current
+     DESCRIPTION
+             " Represents the time in seconds since the reference epoch,
+               zero hours:zero minutes:zero seconds, 
+               Coordinated Universal Time (UTC),
+               January 1, 1970. This timestamp definition would be used to 
+               accurately reflect the time of occurrence of various 
+               events at the Nortel Network Management Interface (NMI)." 
+     SYNTAX        Unsigned32 
+
+ 
+
+   NortelNMIneType   ::=  TEXTUAL-CONVENTION
+     STATUS         current
+     DESCRIPTION
+             " Represents the various possible NE types
+               that are monitored via the Nortel NMI MIBs.
+               The NeType string should be a single word, can only contain 
+               alphanumeric characters and underscores. No commas, spaces, 
+               slashes, hyphens, or dollar signs is allowed."
+
+     SYNTAX          DisplayString (SIZE(1..32)) 
+                      
+
+   NortelNMIadminState  ::=  TEXTUAL-CONVENTION
+     STATUS         current
+     DESCRIPTION
+             " Represents the various possible administrative states 
+               (ITU-T X.731) that are monitored via the Nortel NMI MIBs."
+     SYNTAX         INTEGER
+                       {
+                        locked(1),
+                        shuttingDown(2),
+                        unlocked(3)
+                       }
+
+
+   NortelNMIoperState  ::=  TEXTUAL-CONVENTION
+     STATUS         current
+     DESCRIPTION
+             " Represents the possible values of operational states 
+               (ITU-T X.731) that are monitored via the Nortel NMI MIBs."
+     SYNTAX         INTEGER
+                       {
+                        disabled(1),
+                        enabled(2)
+                       }
+
+
+   NortelNMIunknownStatusValue  ::=  TEXTUAL-CONVENTION
+     STATUS         current
+     DESCRIPTION
+             " Represents the unknown status value to be true / false (ITU-T X.731). 
+               This indicates whether the  management system is able to
+               maintain OAM communications with the managed entity or not."
+     SYNTAX         TruthValue 
+                    --  INTEGER {true(1), false(2)} 
+
+
+
+   NortelNMIalarmProblemCategory  ::=  TEXTUAL-CONVENTION
+     STATUS         current
+     DESCRIPTION
+             " Represents the alarm problem category values (ITU-T X.733)." 
+     SYNTAX         INTEGER
+                       {
+                        communications(1),
+                        qualityOfService(2),
+                        processingError(3),
+                        equipment(4),
+                        environmental(5)
+                       }
+
+
+
+  NortelNMInotificationTypes    ::=  TEXTUAL-CONVENTION
+     STATUS         current
+     DESCRIPTION
+             " Represents the type of Notification to be traps or Informs. 
+               Inform PDUs get acknowledgements / responses while traps don't." 
+     SYNTAX         INTEGER
+                       {
+                         trap(1),
+                         inform(2)
+                       }                                                     
+
+
+
+   NortelNMIalarmProbableCause   ::=  TEXTUAL-CONVENTION
+     STATUS         current
+     DESCRIPTION
+             " Represents the probable cause values for the alarms as per
+               (ITU-T X.733, X.736)." 
+     SYNTAX         INTEGER
+                       {
+                        -- ITU-T X.733 probable causes 57 values 
+
+                        adapterError (1),
+                        applicationSubsystemFailure (2),
+                        bandwidthReduced (3),
+                        callEstablishmentError (4),
+                        communicationsProtocolError (5),
+                        communicationsSubsystemFailure (6),
+                        configurationOrCustomizationError (7),
+                        congestion (8),
+                        corruptData (9),
+                        cpuCyclesLimitExceeded (10),
+                        dataSetOrModemError (11),
+                        degradedSignal (12),
+                        dteDCEInterfaceError (13),
+                        enclosureDoorOpen (14),
+                        equipmentMalfunction (15),
+                        excessiveVibration (16),
+                        fileError (17),
+                        fireDetected (18),
+                        floodDetected (19),
+                        framingError (20),
+                        heatingOrVentilationOrCoolingSystemProblem (21),
+                        humidityUnacceptable (22),
+                        inputOutputDeviceError (23),
+                        inputDeviceError (24),
+                        lANError (25),
+                        leakDetected (26),
+                        localNodeTransmissionError (27),
+                        lossOfFrame (28),
+                        lossOfSignal (29),
+                        materialSupplyExhausted (30),
+                        multiplexerProblem (31),
+                        outOfMemory (32),
+                        ouputDeviceError (33),
+                        performanceDegraded (34),
+                        powerProblem (35),
+                        pressureUnacceptable (36),
+                        processorProblem (37),
+                        pumpFailure (38),
+                        queueSizeExceeded (39),
+                        receiveFailure (40),
+                        receiverFailure (41),
+                        remoteNodeTransmissionError (42),
+                        resourceAtOrNearingCapacity (43),
+                        responseTimeExecessive (44),
+                        retransmissionRateExcessive (45),
+                        softwareError (46),
+                        softwareProgramAbnormallyTerminated (47),
+                        softwareProgramError (48),
+                        storageCapacityProblem (49),
+                        temperatureUnacceptable (50),
+                        thresholdCrossed (51),
+                        timingProblem (52),
+                        toxicLeakDetected (53),
+                        transmitFailure (54),
+                        transmitterFailure (55),
+                        underlyingResourceUnavailable (56),
+                        versionMismatch (57),
+
+
+                        -- Probable cause values 58 to 100 are currently unused
+
+                        -- ITU-T X.736 probable causes 18 values
+
+                        authenticationFailure (101),
+                        breachOfConfidentiality (102),
+                        cableTamper (103),
+                        delayedInformation (104),
+                        denialOfService (105),
+                        duplicateInformation (106),
+                        informationMissing (107),
+                        informationModificationDetected (108),
+                        informationOutOfSequence (109),
+                        intrusionDetection (110),
+                        keyExpired (111),
+                        nonRepudiationFailure (112),
+                        outOfHoursActivity (113),
+                        outOfService (114),
+                        proceduralError (115),
+                        unauthorizedAccessAttempt (116),
+                        unexpectedInformation (117),
+                        unspecifiedReason (118)
+                        
+                       
+
+ 
+                       }                                                     
+
+
+
+END
+


### PR DESCRIPTION
Fixes NPE when generating eventconf from a MIB with recursive TCs in notification varbind.

JIRA: http://issues.opennms.org/browse/NMS-7966
Bamboo: http://bamboo.internal.opennms.com:8085/browse/OPENNMS-ONMS254