### PR TITLE
Fix NMS-7969: JMS alarm northbounder always indicates message sent

### DIFF
--- a/opennms-alarms/jms-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/jms/JmsNorthbounder.java
+++ b/opennms-alarms/jms-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/jms/JmsNorthbounder.java
@@ -152,11 +152,11 @@ public class JmsNorthbounder extends AbstractNorthbounder implements
                                         }
 
                                     });
+                    LOG.debug("Sent message.");
                 } catch (JmsException e) {
                     LOG.error("Unable to send alarm to JMS NB because "
                             + e.getLocalizedMessage());
                 }
-                LOG.debug("Sent message.");
             }
         }
     }


### PR DESCRIPTION
Reopening this pull request against release-17.0.0.