### PR TITLE
Make RMI Bind to Localhost By Default

### DIFF
--- a/features/poller/remote/src/main/resources/META-INF/opennms/applicationContext-exportedPollerBackEnd-rmi.xml
+++ b/features/poller/remote/src/main/resources/META-INF/opennms/applicationContext-exportedPollerBackEnd-rmi.xml
@@ -23,6 +23,7 @@
       <props>
         <prop key="opennms.poller.server.serverPort">1199</prop>
         <prop key="opennms.poller.server.registryPort">1099</prop>
+        <prop key="opennms.poller.server.serverHost">localhost</prop>
       </props>
     </property>
     <!-- 
@@ -37,6 +38,10 @@
     <property name="systemPropertiesModeName" value="SYSTEM_PROPERTIES_MODE_OVERRIDE" />
   </bean>
 
+  <bean id="rmiSocketFactory" class="org.opennms.bootstrap.HostRMIServerSocketFactory">
+    <property name="host" value="${opennms.poller.server.serverHost}" />
+  </bean>
+
   <bean id="pollerBackEnd-rmi" class="org.springframework.remoting.rmi.RmiServiceExporter">
     <qualifier value="rmi" />
     <property name="service" ref="backend" />
@@ -44,5 +49,6 @@
     <property name="serviceName" value="pollerBackEnd" />
     <property name="servicePort" value="${opennms.poller.server.serverPort}" />
     <property name="registryPort" value="${opennms.poller.server.registryPort}" />
+    <property name="clientSocketFactory" ref="rmiSocketFactory" />
   </bean>
 </beans>

--- a/features/themes/onms-default-theme/.gitignore
+++ b/features/themes/onms-default-theme/.gitignore
@@ -1,1 +1,2 @@
 src/main/java/VAADIN/themes/opennms/styles.css
+src/main/java/VAADIN/themes/opennms/styles.css.map

--- a/opennms-bootstrap/src/main/java/org/opennms/bootstrap/Bootstrap.java
+++ b/opennms-bootstrap/src/main/java/org/opennms/bootstrap/Bootstrap.java
@@ -38,6 +38,7 @@ import java.lang.reflect.Method;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.rmi.server.RMISocketFactory;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
@@ -321,11 +322,11 @@ public abstract class Bootstrap {
         executeClass(classToExec, classToExecMethod, classToExecArgs, false);
     }
 
-    protected static void executeClass(final String classToExec, final String classToExecMethod, final String[] classToExecArgs, boolean appendClasspath) throws MalformedURLException, ClassNotFoundException, NoSuchMethodException {
+    protected static void executeClass(final String classToExec, final String classToExecMethod, final String[] classToExecArgs, boolean appendClasspath) throws ClassNotFoundException, NoSuchMethodException, IOException {
         executeClass(classToExec, classToExecMethod, classToExecArgs, appendClasspath, false);
     }
 
-    protected static void executeClass(final String classToExec, final String classToExecMethod, final String[] classToExecArgs, boolean appendClasspath, final boolean recurse) throws MalformedURLException, ClassNotFoundException, NoSuchMethodException {
+    protected static void executeClass(final String classToExec, final String classToExecMethod, final String[] classToExecArgs, boolean appendClasspath, final boolean recurse) throws ClassNotFoundException, NoSuchMethodException, IOException {
         String dir = System.getProperty("opennms.classpath");
         if (dir == null) {
             dir = System.getProperty(OPENNMS_HOME_PROPERTY) + File.separator
@@ -352,6 +353,8 @@ public abstract class Bootstrap {
 
         final ClassLoader cl = Bootstrap.loadClasses(dir, recurse, appendClasspath);
 
+        configureRMI(cl);
+
         if (classToExec != null) {
             final String className = classToExec;
             final Class<?>[] classes = new Class[] { classToExecArgs.getClass() };
@@ -374,6 +377,17 @@ public abstract class Bootstrap {
             Thread bootstrapper = new Thread(execer, "Main");
             bootstrapper.setContextClassLoader(cl);
             bootstrapper.start();
+        }
+    }
+
+    private static void configureRMI(final ClassLoader cl) throws IOException {
+        final String host = System.getProperty("opennms.poller.server.serverHost", "localhost");
+        if ("localhost".equals(host) || "127.0.0.1".equals(host) || "::1".equals(host)) {
+            if (System.getProperty("java.rmi.server.hostname") == null) {
+                System.setProperty("java.rmi.server.hostname", host);
+            }
+            final HostRMIServerSocketFactory sf = new HostRMIServerSocketFactory("localhost");
+            RMISocketFactory.setSocketFactory(sf);
         }
     }
 

--- a/opennms-bootstrap/src/main/java/org/opennms/bootstrap/HostRMIServerSocketFactory.java
+++ b/opennms-bootstrap/src/main/java/org/opennms/bootstrap/HostRMIServerSocketFactory.java
@@ -1,0 +1,43 @@
+package org.opennms.bootstrap;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.rmi.server.RMIClientSocketFactory;
+import java.rmi.server.RMIServerSocketFactory;
+import java.rmi.server.RMISocketFactory;
+
+public class HostRMIServerSocketFactory extends RMISocketFactory implements RMIServerSocketFactory, RMIClientSocketFactory {
+    private String m_host;
+
+    public HostRMIServerSocketFactory() {
+    }
+
+    public HostRMIServerSocketFactory(final String host) {
+        m_host = host;
+    }
+
+    @Override
+    public ServerSocket createServerSocket(final int port) throws IOException {
+        final InetAddress address;
+        if ("localhost".equals(m_host)) {
+            address = InetAddress.getLoopbackAddress();
+        } else {
+            address = InetAddress.getByName(m_host);
+        }
+        return new ServerSocket(port, -1, address);
+    }
+
+    @Override
+    public Socket createSocket(final String host, final int port) throws IOException {
+        return RMISocketFactory.getDefaultSocketFactory().createSocket(host, port);
+    }
+
+    public String getHost() {
+        return m_host;
+    }
+    public void setHost(final String host) {
+        m_host = host;
+    }
+}

--- a/opennms-full-assembly/src/main/filtered-resources/etc/org.apache.karaf.management.cfg
+++ b/opennms-full-assembly/src/main/filtered-resources/etc/org.apache.karaf.management.cfg
@@ -1,0 +1,67 @@
+################################################################################
+#
+#    Licensed to the Apache Software Foundation (ASF) under one or more
+#    contributor license agreements.  See the NOTICE file distributed with
+#    this work for additional information regarding copyright ownership.
+#    The ASF licenses this file to You under the Apache License, Version 2.0
+#    (the "License"); you may not use this file except in compliance with
+#    the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+################################################################################
+
+#
+# The properties in this file define the configuration of Apache Karaf's JMX Management
+#
+
+#
+# Port number for RMI registry connection
+#
+rmiRegistryPort = 1099
+
+#
+# Host for RMI registry
+#
+rmiRegistryHost = localhost
+
+#
+# Port number for RMI server connection
+#
+rmiServerPort = 44444
+
+#
+# Host for RMI server
+#
+rmiServerHost = localhost
+
+#
+# Name of the JAAS realm used for authentication
+#
+jmxRealm = karaf
+
+#
+# The service URL for the JMXConnectorServer
+#
+serviceUrl = service:jmx:rmi://${rmiServerHost}:${rmiServerPort}/jndi/rmi://${rmiRegistryHost}:${rmiRegistryPort}/karaf-${karaf.name}
+
+#
+# Whether any threads started for the JMXConnectorServer should be started as daemon threads
+#
+daemon = true
+
+#
+# Whether the JMXConnectorServer should be started in a separate thread
+#
+threaded = true
+
+#
+# The ObjectName used to register the JMXConnectorServer
+#
+objectName = connector:name=rmi


### PR DESCRIPTION
This pull implements a custom socket factory to coerce the RMI server into binding only to localhost by default.  Additionally, it provides a default karaf configuration that uses `localhost` for RMI server and client connections.

You can override the bind port by setting the `opennms.poller.server.serverHost` property in `$OPENNMS_HOME/etc/opennms.conf`:

```
# old behavior, listen on all interfaces
ADDITIONAL_MANAGER_OPTIONS="-Dopennms.poller.server.serverHost=0.0.0.0"

# bind to a specific IP
ADDITIONAL_MANAGER_OPTIONS="-Dopennms.poller.server.serverHost=192.168.0.1"
```