### PR TITLE
NMS-7978: Add threshold description and whitespace changes to match how the OpenNMS web GUI generates XML files

### DIFF
--- a/opennms-base-assembly/src/main/filtered/etc/eventconf.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/eventconf.xml
@@ -10,6 +10,7 @@
     </security>
   </global>
 
+  <!-- Be cautious changing the order of event files as events are processed in top-to-bottom file list order with the first found event match winning; blank lines are present to divide up the logical sections of the events -->
   <event-file>events/opennms.events.xml</event-file>
   <event-file>events/Translator.default.events.xml</event-file>
   

--- a/opennms-base-assembly/src/main/filtered/etc/thresholds.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/thresholds.xml
@@ -1,70 +1,123 @@
-<?xml version="1.0"?>
-<thresholding-config>
-        <group name="mib2"
-                rrdRepository = "${install.share.dir}/rrd/snmp/">
-                <threshold type="high" ds-name="tcpInErrors" ds-type="node" ds-label="" value="1" rearm="0" trigger="1"/>
-                <expression type="high" expression="ifInErrors + ifOutErrors" ds-type="if" ds-label="ifName" value="1" rearm="0" trigger="2"/>
-                <expression type="high" expression="ifInDiscards + ifOutDiscards" ds-type="if" ds-label="ifName" value="1" rearm="0" trigger="2"/>
-                <expression type="high" expression="ifInOctets * 8 / 1000000 / ifHighSpeed * 100" ds-type="if" ds-label="ifName" value="90.0" rearm="75.0" trigger="3">
-                  <resource-filter field="ifHighSpeed">^[1-9]+[0-9]*$</resource-filter>
-                </expression>
-                <expression type="high" expression="ifOutOctets * 8 / 1000000 / ifHighSpeed * 100" ds-type="if" ds-label="ifName" value="90.0" rearm="75.0" trigger="3">
-                  <resource-filter field="ifHighSpeed">^[1-9]+[0-9]*$</resource-filter>
-                </expression>
-        </group>
-        
-        <group name="hrstorage"
-        		rrdRepository = "${install.share.dir}/rrd/snmp/">
-        		<expression type="high" expression="hrStorageUsed / hrStorageSize * 100.0" ds-type="hrStorageIndex" ds-label="hrStorageDescr" value="90.0" rearm="75.0" trigger="2">
-        		  <resource-filter field="hrStorageType">^\.1\.3\.6\.1\.2\.1\.25\.2\.1\.4$</resource-filter>
-        		</expression>
-        		<expression description="Trigger a warning event when the percentage of disk space used on any disk of type hrStorageFixedDisk (e.g. a locally attached or USB-attached hard disk) increases by a relative 33.3% compared to its most recent previous measurement (e.g. there is suddenly less free space)" type="relativeChange" expression="hrStorageUsed / hrStorageSize * 100.0" ds-type="hrStorageIndex" ds-label="hrStorageDescr" value="1.333" rearm="0.0" trigger="1">
-        		  <resource-filter field="hrStorageType">^\.1\.3\.6\.1\.2\.1\.25\.2\.1\.4$</resource-filter>
-        		</expression>
-
-		</group>
-		
-        <group name="cisco"
-                rrdRepository = "${install.share.dir}/rrd/snmp/">
-                <threshold type="high" ds-name="avgBusy5"  ds-type="node" ds-label="" value="80" rearm="50" trigger="3"/>
-                <threshold type="relativeChange" ds-name="cscoMemPoolUtl5Min"  ds-type="ciscoMemoryPoolType" ds-label="cscoMemoryPoolName" value="0.25" rearm="0.0" trigger="1"/>
-                <threshold type="high" ds-name="cvmTempStatusValue" ds-type="ciscoEnvMonTemperatureStatusIndex" ds-label="cvmTempStatusDescr" value="55.0" rearm="50.0" trigger="3"/>
-                <threshold type="relativeChange" ds-name="cvmTempStatusValue" ds-type="ciscoEnvMonTemperatureStatusIndex" ds-label="cvmTempStatusDescr" value="0.2" rearm="0.0" trigger="1"/>
-        </group>
-
-        <group name="juniper-srx"
-                        rrdRepository = "${install.share.dir}/rrd/snmp/">
-                        <expression description="Trigger a warning event when the number of tracked sessions of a Juniper SRX router exceeds 90% of its capacity." type="high" expression="juniSPUMonCurrFlow / juniSPUMonMaxFlow * 100.0" ds-type="node" ds-label="" value="90.0" rearm="75.0" trigger="2"/>
-        </group>
-        
-        <group name="netsnmp"
-        		rrdRepository = "${install.share.dir}/rrd/snmp/">
-        		<threshold type="high" ds-name="ns-dskPercent" ds-type="dskIndex" ds-label="ns-dskPath" value="90.0" rearm="75.0" trigger="2"/>
-        		<threshold type="high" ds-name="ns-dskPercentNode" ds-type="dskIndex" ds-label="ns-dskPath" value="90.0" rearm="75.0" trigger="2">
-        			<!-- Filter out special filesystems. See bug http://issues.opennms.org/browse/NMS-5116 -->
-        			<resource-filter field="ns-dskPath">^(?:(?!(/proc|/sys|/dev/pts)).)+$</resource-filter>
-        		</threshold>
-        		<threshold description="Trigger an alert when the percentage of disk space used on any disk increases by a relative 33.3% compared to its most recent previous measurement (that is, there is suddenly less free space)" type="relativeChange" ds-name="ns-dskPercent" ds-type="dskIndex" ds-label="ns-dskPath" value="1.333" rearm="0.0" trigger="1"/>
-        		<threshold description="Trigger an alert when the percentage of inodes used on any disk increases by a relative 33.3% compared to its most recent previous measurement (that is, there are suddenly fewer free inodes)" type="relativeChange" ds-name="ns-dskPercentNode" ds-type="dskIndex" ds-label="ns-dskPath" value="1.333" rearm="0.0" trigger="1"/>
-        		<expression type="high" expression="loadavg5 / 100.0" ds-type="node" ds-label="" value="10.0" rearm="7.5" trigger="2"/>
-        		<expression type="low" expression="memAvailSwap / memTotalSwap * 100.0" ds-type="node" ds-label="" value="10.0" rearm="15.0" trigger="2"> 
-        		    <resource-filter field="memTotalSwap">^[1-9]+[.0-9]*$</resource-filter>
-        		</expression>
-        </group>
-        
-        <group name="netsnmp-memory-linux"
-        		rrdRepository = "${install.share.dir}/rrd/snmp/">
-        		<expression type="low" expression="(memAvailReal + memCached) / memTotalReal * 100.0" ds-type="node" ds-label="" value="5.0" rearm="10.0" trigger="2"/>
-        </group>
-
-        <group name="netsnmp-memory-nonlinux"
-        		rrdRepository = "${install.share.dir}/rrd/snmp/">
-        		<expression type="low" expression="memAvailReal / memTotalReal * 100.0" ds-type="node" ds-label="" value="5.0" rearm="10.0" trigger="2"/>
-        </group>
- 
-		<group name="coffee"
-				rrdRepository = "${install.share.dir}/rrd/snmp/">
-				<expression type="low" expression ="coffeePotLevel / coffeePotCapacity * 100.0" ds-type="node" ds-label="" value="25.0" rearm="100.0" trigger="1"/>
-		</group>
-
+<?xml version="1.0" encoding="UTF-8"?>
+<thresholding-config xmlns="http://xmlns.opennms.org/xsd/config/thresholding-config">
+    <group name="mib2" rrdRepository="${install.share.dir}/rrd/snmp/">
+        <threshold
+            description="Trigger an alert if one or more incoming packets on the whole node were not received due to an error for one measurement interval"
+            type="high" ds-type="node" value="1.0" rearm="0.0"
+            trigger="1" filterOperator="or" ds-name="tcpInErrors"/>
+        <expression
+            description="Trigger an alert if one or more incoming or outgoing packets on an interface were not transmitted due to error for two consecutive measurement intervals"
+            type="high" ds-type="if" value="1.0" rearm="0.0" trigger="2"
+            ds-label="ifName" filterOperator="or" expression="ifInErrors + ifOutErrors"/>
+        <expression
+            description="Trigger an alert if one or more incoming or outgoing packets on an interface were discarded even though no errors were detected (possibly to free up buffer space) for two consecutive measurement intervals"
+            type="high" ds-type="if" value="1.0" rearm="0.0" trigger="2"
+            ds-label="ifName" filterOperator="or" expression="ifInDiscards + ifOutDiscards"/>
+        <expression
+            description="Trigger an alert if incoming usage of any interface reaches or goes above 90% of its maximum speed for three consecutive measurement intervals (only for interfaces that have a maximum speed value defined)"
+            type="high" ds-type="if" value="90.0" rearm="75.0"
+            trigger="3" ds-label="ifName" filterOperator="or" expression="ifInOctets * 8 / 1000000 / ifHighSpeed * 100">
+            <resource-filter field="ifHighSpeed">^[1-9]+[0-9]*$</resource-filter>
+        </expression>
+        <expression
+            description="Trigger an alert if outgoing usage of an interface reaches or goes above 90% of its maximum speed for three consecutive measurement intervals (only for interfaces that have a maximum speed value defined)"
+            type="high" ds-type="if" value="90.0" rearm="75.0"
+            trigger="3" ds-label="ifName" filterOperator="or" expression="ifOutOctets * 8 / 1000000 / ifHighSpeed * 100">
+            <resource-filter field="ifHighSpeed">^[1-9]+[0-9]*$</resource-filter>
+        </expression>
+    </group>
+    <group name="hrstorage" rrdRepository="${install.share.dir}/rrd/snmp/">
+        <expression
+            description="Trigger an alert when the percentage of disk space used reaches or goes above 90% for two consecutive measurement intervals (only for disks of type hrStorageFixedDisk, such as a locally attached or USB-attached hard disk)"
+            type="high" ds-type="hrStorageIndex" value="90.0"
+            rearm="75.0" trigger="2" ds-label="hrStorageDescr"
+            filterOperator="or" expression="hrStorageUsed / hrStorageSize * 100.0">
+            <resource-filter field="hrStorageType">^\.1\.3\.6\.1\.2\.1\.25\.2\.1\.4$</resource-filter>
+        </expression>
+        <expression
+            description="Trigger an alert when the percentage of disk space used increases by a relative 33.3% compared to its most recent previous measurement (e.g. there is suddenly less free space) (only for disks of type hrStorageFixedDisk, such as a locally attached or USB-attached hard disk)"
+            type="relativeChange" ds-type="hrStorageIndex" value="1.333"
+            rearm="0.0" trigger="1" ds-label="hrStorageDescr"
+            filterOperator="or" expression="hrStorageUsed / hrStorageSize * 100.0">
+            <resource-filter field="hrStorageType">^\.1\.3\.6\.1\.2\.1\.25\.2\.1\.4$</resource-filter>
+        </expression>
+    </group>
+    <group name="cisco" rrdRepository="${install.share.dir}/rrd/snmp/">
+        <threshold
+            description="Trigger an alert when the five minute exponentially-decayed moving average of the CPU busy percentage metric on a Cisco device reaches or goes above 80% for three measurement intervals"
+            type="high" ds-type="node" value="80.0" rearm="50.0"
+            trigger="3" filterOperator="or" ds-name="avgBusy5"/>
+        <threshold
+            description="Trigger an alert when the five minute memory pool percentage utilization metric on a Cisco device increases by 25% in one measurement interval"
+            type="relativeChange" ds-type="ciscoMemoryPoolType"
+            value="0.25" rearm="0.0" trigger="1"
+            ds-label="cscoMemoryPoolName" filterOperator="or" ds-name="cscoMemPoolUtl5Min"/>
+        <threshold
+            description="Trigger an alert when the temperature metric on a Cisco device reaches or goes above 55 degrees Celcius for three measurement intervals"
+            type="high" ds-type="ciscoEnvMonTemperatureStatusIndex"
+            value="55.0" rearm="50.0" trigger="3"
+            ds-label="cvmTempStatusDescr" filterOperator="or" ds-name="cvmTempStatusValue"/>
+        <threshold
+            description="Trigger an alert when the temperature metric on a Cisco device increases by 20% in one measurement interval"
+            type="relativeChange"
+            ds-type="ciscoEnvMonTemperatureStatusIndex" value="0.2"
+            rearm="0.0" trigger="1" ds-label="cvmTempStatusDescr"
+            filterOperator="or" ds-name="cvmTempStatusValue"/>
+    </group>
+    <group name="juniper-srx" rrdRepository="${install.share.dir}/rrd/snmp/">
+        <expression
+            description="Trigger an alert when the number of tracked sessions of a Juniper SRX router exceeds 90% of its capacity for two consecutive measurement intervals"
+            type="high" ds-type="node" value="90.0" rearm="75.0"
+            trigger="2" filterOperator="or" expression="juniSPUMonCurrFlow / juniSPUMonMaxFlow * 100.0"/>
+    </group>
+    <group name="netsnmp" rrdRepository="${install.share.dir}/rrd/snmp/">
+        <threshold
+            description="Trigger an alert when the percentage of disk space used on any disk reaches or goes above 90% full for two consecutive measurement intervals"
+            type="high" ds-type="dskIndex" value="90.0" rearm="75.0"
+            trigger="2" ds-label="ns-dskPath" filterOperator="or" ds-name="ns-dskPercent"/>
+        <threshold
+            description="Trigger an alert when the percentage of inodes used on any disk (excluding the specified special paths) reaches or goes above 90% for two consecutive measurement intervals"
+            type="high" ds-type="dskIndex" value="90.0" rearm="75.0"
+            trigger="2" ds-label="ns-dskPath" filterOperator="or" ds-name="ns-dskPercentNode">
+            <resource-filter field="ns-dskPath">^(?:(?!(/proc|/sys|/dev/pts)).)+$</resource-filter>
+        </threshold>
+        <threshold
+            description="Trigger an alert when the percentage of disk space used on any disk increases by a relative 33.3% compared to its most recent previous measurement (that is, there is suddenly less free space)"
+            type="relativeChange" ds-type="dskIndex" value="1.333"
+            rearm="0.0" trigger="1" ds-label="ns-dskPath"
+            filterOperator="or" ds-name="ns-dskPercent"/>
+        <threshold
+            description="Trigger an alert when the percentage of inodes used on any disk increases by a relative 33.3% compared to its most recent previous measurement (that is, there are suddenly fewer free inodes)"
+            type="relativeChange" ds-type="dskIndex" value="1.333"
+            rearm="0.0" trigger="1" ds-label="ns-dskPath"
+            filterOperator="or" ds-name="ns-dskPercentNode"/>
+        <expression
+            description="Trigger an alert when the five minute CPU load average metric reaches or goes above 10 for two consecutive measurement intervals"
+            type="high" ds-type="node" value="10.0" rearm="7.5"
+            trigger="2" filterOperator="or" expression="loadavg5 / 100.0"/>
+        <expression
+            description="Trigger an alert when the amount of available swap space reaches or goes below 10% of the total amount of swap space for two consecutive measurement intervals (only for systems that have a total swap space value defined)"
+            type="low" ds-type="node" value="10.0" rearm="15.0"
+            trigger="2" filterOperator="or" expression="memAvailSwap / memTotalSwap * 100.0">
+            <resource-filter field="memTotalSwap">^[1-9]+[.0-9]*$</resource-filter>
+        </expression>
+    </group>
+    <group name="netsnmp-memory-linux" rrdRepository="${install.share.dir}/rrd/snmp/">
+        <expression
+            description="Trigger an alert when the sum of the amount of unused real/physical memory plus the amount of real/virtual memory currently allocated as cached memory expressed as a percentage of total system memory reaches or goes below 5% for two consecutive measurement intervals"
+            type="low" ds-type="node" value="5.0" rearm="10.0"
+            trigger="2" filterOperator="or" expression="(memAvailReal + memCached) / memTotalReal * 100.0"/>
+    </group>
+    <group name="netsnmp-memory-nonlinux" rrdRepository="${install.share.dir}/rrd/snmp/">
+        <expression
+            description="Trigger an alert when the amount of unused real/physical memory expressed as a percentage of total system memory reaches or goes below 5% for two consecutive measurement intervals"
+            type="low" ds-type="node" value="5.0" rearm="10.0"
+            trigger="2" filterOperator="or" expression="memAvailReal / memTotalReal * 100.0"/>
+    </group>
+    <group name="coffee" rrdRepository="${install.share.dir}/rrd/snmp/">
+        <expression
+            description="Trigger an alert when the coffee pot level reaches or goes below 25% in one measurement interval"
+            type="low" ds-type="node" value="25.0" rearm="100.0"
+            trigger="1" filterOperator="or" expression="coffeePotLevel / coffeePotCapacity * 100.0"/>
+    </group>
 </thresholding-config>


### PR DESCRIPTION
This is a proposed patch that does the following:

1. thresholds.xml
  * Add descriptions to all thresholds to add documentation on what each threshold is for
  * Change whitespace and ordering to match how the OpenNMS web UI generates the file; I used the web GUI to open each threshold in the editor and then saved it WITH NO CHANGES (other than the description) to get OpenNMS just to rewrite the file formatting. The issue here is it is much easier to diff a new version of the file with the one in production if the whitespace and XML formatting match how the GUI edits the file.

2. eventconf.xml
  * Added a comment about file ordering for documentation purposes
  * Remove extraneous blank lines

JIRA: http://issues.opennms.org/browse/NMS-7978
Bamboo: http://bamboo.internal.opennms.com:8085/browse/OPENNMS-ONMS400-1