### PR TITLE
NMS-7985: Change mirrors to DigitalOcean global caches

### DIFF
--- a/opennms-doc/guide-install/src/asciidoc/text/opennms/debian.adoc
+++ b/opennms-doc/guide-install/src/asciidoc/text/opennms/debian.adoc
@@ -21,14 +21,14 @@ _OpenNMS_ can be installed with Installation of stable repository and GPG key
 .Installation of _OpenNMS Debian_ repository
 [source, shell]
 ----
-deb http://debian.opennms.org stable main
-deb-src http://debian.opennms.org stable main
+deb http://debian.mirrors.opennms.org stable main
+deb-src http://debian.mirrors.opennms.org stable main
 ----
 
 .Installation of repository GPG key
 [source, shell]
 ----
-wget -O - http://debian.opennms.org/OPENNMS-GPG-KEY | apt-key add -
+wget -O - http://debian.mirrors.opennms.org/OPENNMS-GPG-KEY | apt-key add -
 ----
 
 .Update apt repository cache

--- a/opennms-doc/guide-install/src/asciidoc/text/opennms/introduction.adoc
+++ b/opennms-doc/guide-install/src/asciidoc/text/opennms/introduction.adoc
@@ -42,9 +42,9 @@ The following releases are available for installation:
 | `testing`  | Release candidate for next stable
 | `snapshot` | Latest successful develop build
 | `branches/${BRANCH-NAME}` | Install from a specific branch name, e.g. `branches/features-newts` installs the repository for the _Newts_ development branch.
-                              Branches can be found in http://yum.opennms.org/branches/ or http://debian.opennms.org/dists/branches/
+                              Branches can be found in http://yum.mirrors.opennms.org/branches/ or http://debian.mirrors.opennms.org/dists/branches/
 | `branches/${RELEASE}`     | Install a specific release, e.g. `branches/release-14.0.3`.
-                              This release branches are also found in http://yum.opennms.org/branches/ or http://debian.opennms.org/dists/branches/
+                              This release branches are also found in http://yum.mirrors.opennms.org/branches/ or http://debian.mirrors.opennms.org/dists/branches/
 |===
 
 To install a different release the repository files have to be installed and manually modified.
@@ -54,8 +54,8 @@ To install a different release the repository files have to be installed and man
 .Installation of release specific repositories
 [source, shell]
 ----
-rpm -Uvh http://yum.opennms.org/repofiles/opennms-repo-${RELEASE}-rhel7.noarch.rpm<1>
-rpm --import http://yum.opennms.org/OPENNMS-GPG-KEY
+rpm -Uvh http://yum.mirrors.opennms.org/repofiles/opennms-repo-${RELEASE}-rhel7.noarch.rpm<1>
+rpm --import http://yum.mirrors.opennms.org/OPENNMS-GPG-KEY
 ----
 
 <1> Replace `${RELEASE}` with a release name like `testing` or `snapshot`.
@@ -77,8 +77,8 @@ Create a new apt source file (eg: `/etc/apt/sources.list.d/opennms.list`), and a
 .Package repository configuration for Debian-based systems
 [source, shell]
 ----
-deb http://debian.opennms.org ${RELEASE} main <1>
-deb-src http://debian.opennms.org ${RELEASE} main <1>
+deb http://debian.mirrors.opennms.org ${RELEASE} main <1>
+deb-src http://debian.mirrors.opennms.org ${RELEASE} main <1>
 ----
 
 <1> Replace `${RELEASE}` with a release name like `testing` or `snapshot`.
@@ -88,7 +88,7 @@ Import the packages' authentication key with the following command:
 .GPG key import for Debian-based systems
 [source, shell]
 ----
-wget -O - http://debian.opennms.org/OPENNMS-GPG-KEY | apt-key add -
+wget -O - http://debian.mirrors.opennms.org/OPENNMS-GPG-KEY | apt-key add -
 ----
 
 Run `apt-get update` and install _OpenNMS_ with _apt_ following the normal installation procedure.

--- a/opennms-doc/guide-install/src/asciidoc/text/opennms/rhel.adoc
+++ b/opennms-doc/guide-install/src/asciidoc/text/opennms/rhel.adoc
@@ -19,8 +19,8 @@ The setup process is described in the following steps:
 .Installation of stable repository and GPG key
 [source, shell]
 ----
-rpm -Uvh http://yum.opennms.org/repofiles/opennms-repo-stable-rhel7.noarch.rpm
-rpm --import http://yum.opennms.org/OPENNMS-GPG-KEY
+rpm -Uvh http://yum.mirrors.opennms.org/repofiles/opennms-repo-stable-rhel7.noarch.rpm
+rpm --import http://yum.mirrors.opennms.org/OPENNMS-GPG-KEY
 ----
 
 [[gi-install-opennms-rhel-package]]


### PR DESCRIPTION
Changed install guide to point to new Digital Ocean global mirrors on yum.mirrors.opennms.org and debian.mirrors.opennms.org.