### PR TITLE
HZN-523: Requisitions with a space in the name are no longer readable

### DIFF
--- a/opennms-provision/opennms-provision-persistence/src/main/java/org/opennms/netmgt/provision/persist/AbstractForeignSourceRepository.java
+++ b/opennms-provision/opennms-provision-persistence/src/main/java/org/opennms/netmgt/provision/persist/AbstractForeignSourceRepository.java
@@ -39,6 +39,7 @@ import org.opennms.core.utils.ConfigFileConstants;
 import org.opennms.core.xml.JaxbUtils;
 import org.opennms.netmgt.provision.persist.foreignsource.ForeignSource;
 import org.opennms.netmgt.provision.persist.requisition.Requisition;
+import org.opennms.netmgt.provision.persist.requisition.RequisitionNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.io.ClassPathResource;
@@ -46,9 +47,9 @@ import org.springframework.core.io.Resource;
 import org.springframework.util.Assert;
 
 public abstract class AbstractForeignSourceRepository implements ForeignSourceRepository {
-    
+
     private static final Logger LOG = LoggerFactory.getLogger(AbstractForeignSourceRepository.class);
-    
+
     /**
      * <p>Constructor for AbstractForeignSourceRepository.</p>
      */
@@ -59,7 +60,7 @@ public abstract class AbstractForeignSourceRepository implements ForeignSourceRe
     @Override
     public Requisition importResourceRequisition(final Resource resource) throws ForeignSourceRepositoryException {
         Assert.notNull(resource);
- 
+
         LOG.debug("importing requisition from {}", resource);
         final Requisition requisition = JaxbUtils.unmarshal(Requisition.class, resource);
         requisition.setResource(resource);
@@ -129,30 +130,26 @@ public abstract class AbstractForeignSourceRepository implements ForeignSourceRe
         Requisition req = getRequisition(foreignSource);
         return (req == null ? null : req.getNodeRequistion(foreignId));
     }
-    
+
     @Override
     public void validate(final ForeignSource foreignSource) throws ForeignSourceRepositoryException {
-        /*
-    	final String name = foreignSource.getName();
-		if (name.contains(":")) {
-    		throw new ForeignSourceRepositoryException("Foreign Source (" + name + ") cannot contain a colon!");
-    	}
-         */
+        final String name = foreignSource.getName();
+        if (name.contains("/")) {
+            throw new ForeignSourceRepositoryException("Foreign Source (" + name + ") contains invalid characters. ('/' is forbidden.)");
+        }
     }
-    
+
     @Override
     public void validate(final Requisition requisition) throws ForeignSourceRepositoryException {
-        /*
-    	final String foreignSource = requisition.getForeignSource();
-		if (foreignSource.contains(":")) {
-    		throw new ForeignSourceRepositoryException("Foreign Source (" + foreignSource + ") cannot contain a colon!");
-    	}
-    	for (final RequisitionNode node : requisition.getNodes()) {
-    		final String foreignId = node.getForeignId();
-			if (foreignId.contains(":")) {
-        		throw new ForeignSourceRepositoryException("Foreign ID (" + foreignId + ") for node " + node.getNodeLabel() + " in Foreign Source " + foreignSource + " cannot contain a colon!");
-    		}
-    	}
-         */
+        final String foreignSource = requisition.getForeignSource();
+        if (foreignSource.contains("/")) {
+            throw new ForeignSourceRepositoryException("Foreign Source (" + foreignSource + ") contains invalid characters. ('/' is forbidden.)");
+        }
+        for (final RequisitionNode node : requisition.getNodes()) {
+            final String foreignId = node.getForeignId();
+            if (foreignId.contains("/")) {
+                throw new ForeignSourceRepositoryException("Foreign ID (" + foreignId + ") for node " + node.getNodeLabel() + " in Foreign Source " + foreignSource + " contains invalid characters. '/' is forbidden.)");
+            }
+        }
     }
 }

--- a/opennms-provision/opennms-provision-persistence/src/main/java/org/opennms/netmgt/provision/persist/AbstractForeignSourceRepository.java
+++ b/opennms-provision/opennms-provision-persistence/src/main/java/org/opennms/netmgt/provision/persist/AbstractForeignSourceRepository.java
@@ -152,4 +152,14 @@ public abstract class AbstractForeignSourceRepository implements ForeignSourceRe
             }
         }
     }
+
+    @Override
+    public void clear() throws ForeignSourceRepositoryException {
+        for (final Requisition req : getRequisitions()) {
+            if (req != null) delete(req);
+        }
+        for (final ForeignSource fs : getForeignSources()) {
+            if (fs != null) delete(fs);
+        }
+    }
 }

--- a/opennms-provision/opennms-provision-persistence/src/main/java/org/opennms/netmgt/provision/persist/CachingForeignSourceRepository.java
+++ b/opennms-provision/opennms-provision-persistence/src/main/java/org/opennms/netmgt/provision/persist/CachingForeignSourceRepository.java
@@ -120,7 +120,10 @@ public class CachingForeignSourceRepository extends AbstractForeignSourceReposit
 						for (final String dirtyForeignSource : m_dirtyForeignSources) {
 							final ForeignSource fs = getForeignSourceMap().get(dirtyForeignSource);
 							if (fs == null) {
-								m_foreignSourceRepository.delete(fs);
+								final ForeignSource current = m_foreignSourceRepository.getForeignSource(dirtyForeignSource);
+								if (current != null) {
+	                                                                m_foreignSourceRepository.delete(current);
+								}
 							} else {
 								m_foreignSourceRepository.save(fs);
 							}
@@ -134,7 +137,10 @@ public class CachingForeignSourceRepository extends AbstractForeignSourceReposit
 						for (final String dirtyRequisition : m_dirtyRequisitions) {
 							final Requisition r = getRequisitionMap().get(dirtyRequisition);
 							if (r == null) {
-								m_foreignSourceRepository.delete(r);
+								final Requisition current = m_foreignSourceRepository.getRequisition(dirtyRequisition);
+								if (current != null) {
+	                                                                m_foreignSourceRepository.delete(r);
+								}
 							} else {
 								m_foreignSourceRepository.save(r);
 							}

--- a/opennms-provision/opennms-provision-persistence/src/main/java/org/opennms/netmgt/provision/persist/CachingForeignSourceRepository.java
+++ b/opennms-provision/opennms-provision-persistence/src/main/java/org/opennms/netmgt/provision/persist/CachingForeignSourceRepository.java
@@ -430,4 +430,15 @@ public class CachingForeignSourceRepository extends AbstractForeignSourceReposit
     public void flush() throws ForeignSourceRepositoryException {
         getRefreshRunnable().run();
     }
+
+    @Override
+    public void clear() throws ForeignSourceRepositoryException {
+        cleanCache();
+        writeLock();
+        try {
+            m_foreignSourceRepository.clear();
+        } finally {
+            writeUnlock();
+        }
+    }
 }

--- a/opennms-provision/opennms-provision-persistence/src/main/java/org/opennms/netmgt/provision/persist/DirectoryWatcher.java
+++ b/opennms-provision/opennms-provision-persistence/src/main/java/org/opennms/netmgt/provision/persist/DirectoryWatcher.java
@@ -212,7 +212,8 @@ public class DirectoryWatcher<T> implements Runnable, Closeable {
      * @return the file names
      */
     public Set<String> getFileNames() {
-        return new LinkedHashSet<String>(Arrays.asList(m_directory.list()));
+        final String[] list = m_directory.list();
+        return new LinkedHashSet<String>(Arrays.asList(list));
     }
 
     /**

--- a/opennms-provision/opennms-provision-persistence/src/main/java/org/opennms/netmgt/provision/persist/ForeignSourceRepository.java
+++ b/opennms-provision/opennms-provision-persistence/src/main/java/org/opennms/netmgt/provision/persist/ForeignSourceRepository.java
@@ -191,4 +191,11 @@ public interface ForeignSourceRepository {
      * @throws ForeignSourceRepositoryException
      */
     void flush() throws ForeignSourceRepositoryException;
+
+    /**
+     * Delete all requisitions and foreign source definitions and return to defaults.
+     *
+     * @throws ForeignSourceRepositoryException
+     */
+    void clear() throws ForeignSourceRepositoryException;
 }

--- a/opennms-provision/opennms-provision-persistence/src/main/java/org/opennms/netmgt/provision/persist/FusedForeignSourceRepository.java
+++ b/opennms-provision/opennms-provision-persistence/src/main/java/org/opennms/netmgt/provision/persist/FusedForeignSourceRepository.java
@@ -272,6 +272,14 @@ public class FusedForeignSourceRepository extends AbstractForeignSourceRepositor
     @Override
     public void flush() throws ForeignSourceRepositoryException {
         // Unnecessary, there is no caching/delayed writes in FusedForeignSourceRepository
+        m_pendingForeignSourceRepository.flush();
+        m_deployedForeignSourceRepository.flush();
     }
 
+    @Override
+    public void clear() throws ForeignSourceRepositoryException {
+        m_pendingForeignSourceRepository.clear();
+        m_deployedForeignSourceRepository.clear();
+        super.clear();
+    }
 }

--- a/opennms-provision/opennms-provision-persistence/src/main/java/org/opennms/netmgt/provision/persist/QueueingForeignSourceRepository.java
+++ b/opennms-provision/opennms-provision-persistence/src/main/java/org/opennms/netmgt/provision/persist/QueueingForeignSourceRepository.java
@@ -47,9 +47,9 @@ import org.springframework.core.io.Resource;
 import org.springframework.util.Assert;
 
 public class QueueingForeignSourceRepository implements ForeignSourceRepository, InitializingBean {
-    
+
     private static final Logger LOG = LoggerFactory.getLogger(QueueingForeignSourceRepository.class);
-    
+
     private final ConcurrentMap<String,Requisition> m_pendingRequisitions     = new ConcurrentHashMap<String,Requisition>();
     private final ConcurrentMap<String,ForeignSource> m_pendingForeignSources = new ConcurrentHashMap<String,ForeignSource>();
     ForeignSourceRepository m_repository = null;
@@ -88,7 +88,7 @@ public class QueueingForeignSourceRepository implements ForeignSourceRepository,
     public ForeignSourceRepository getForeignSourceRepository() {
         return m_repository;
     }
-    
+
     public void setForeignSourceRepository(final ForeignSourceRepository fsr) {
         m_repository = fsr;
     }
@@ -203,6 +203,16 @@ public class QueueingForeignSourceRepository implements ForeignSourceRepository,
     @Override
     public void validate(final Requisition requisition) throws ForeignSourceRepositoryException {
         m_repository.validate(requisition);
+    }
+
+    @Override
+    public void clear() throws ForeignSourceRepositoryException {
+        for (final Requisition req : getRequisitions()) {
+            if (req != null) delete(req);
+        }
+        for (final ForeignSource fs : getForeignSources()) {
+            if (fs != null) delete(fs);
+        }
     }
 
     private final class QueuePersistRunnable implements Runnable {

--- a/opennms-provision/opennms-provision-persistence/src/main/java/org/opennms/netmgt/provision/persist/QueueingForeignSourceRepository.java
+++ b/opennms-provision/opennms-provision-persistence/src/main/java/org/opennms/netmgt/provision/persist/QueueingForeignSourceRepository.java
@@ -116,6 +116,7 @@ public class QueueingForeignSourceRepository implements ForeignSourceRepository,
     @Override
     public void save(final ForeignSource foreignSource) throws ForeignSourceRepositoryException {
         LOG.debug("Queueing save of foreign source {}", foreignSource.getName());
+        validate(foreignSource);
         m_pendingForeignSources.put(foreignSource.getName(), foreignSource);
         m_executor.execute(new QueuePersistRunnable());
     }

--- a/opennms-provision/opennms-provision-persistence/src/test/java/org/opennms/netmgt/provision/persist/CachingForeignSourceRepositoryTest.java
+++ b/opennms-provision/opennms-provision-persistence/src/test/java/org/opennms/netmgt/provision/persist/CachingForeignSourceRepositoryTest.java
@@ -56,6 +56,8 @@ public class CachingForeignSourceRepositoryTest extends ForeignSourceRepositoryT
     @Before
     public void setUp() {
         m_defaultForeignSourceName = "imported:";
+        m_foreignSourceRepository.clear();
+        m_foreignSourceRepository.flush();
     }
 
     private Requisition createRequisition() throws Exception {

--- a/opennms-provision/opennms-provision-persistence/src/test/java/org/opennms/netmgt/provision/persist/FastFilesystemForeignSourceRepositoryTest.java
+++ b/opennms-provision/opennms-provision-persistence/src/test/java/org/opennms/netmgt/provision/persist/FastFilesystemForeignSourceRepositoryTest.java
@@ -41,6 +41,7 @@ import java.util.UUID;
 
 import org.apache.commons.io.FileUtils;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.opennms.core.xml.JaxbUtils;
@@ -53,8 +54,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.core.io.FileSystemResource;
 
-import junit.framework.Assert;
-
 public class FastFilesystemForeignSourceRepositoryTest extends ForeignSourceRepositoryTestCase {
     private String m_defaultForeignSourceName;
     private File m_requisitionDirectory;
@@ -65,9 +64,13 @@ public class FastFilesystemForeignSourceRepositoryTest extends ForeignSourceRepo
 
     @Before
     public void setUp() throws Exception {
-        m_defaultForeignSourceName = "imported:";
         m_requisitionDirectory = new File("target/opennms-home/etc/imports/pending");
         m_requisitionDirectory.mkdirs();
+
+        m_defaultForeignSourceName = "imported:";
+        m_foreignSourceRepository.clear();
+        m_foreignSourceRepository.flush();
+
         FileUtils.copyFile(new File("src/test/resources/requisition-test.xml"), getRequisitionFile());
     }
 

--- a/opennms-provision/opennms-provision-persistence/src/test/java/org/opennms/netmgt/provision/persist/FilesystemForeignSourceRepositoryTest.java
+++ b/opennms-provision/opennms-provision-persistence/src/test/java/org/opennms/netmgt/provision/persist/FilesystemForeignSourceRepositoryTest.java
@@ -57,6 +57,8 @@ public class FilesystemForeignSourceRepositoryTest extends ForeignSourceReposito
     @Before
     public void setUp() {
         m_defaultForeignSourceName = "imported:";
+        m_foreignSourceRepository.clear();
+        m_foreignSourceRepository.flush();
     }
 
     private Requisition createRequisition() throws Exception {

--- a/opennms-provision/opennms-provision-persistence/src/test/java/org/opennms/netmgt/provision/persist/FusedForeignSourceRepositoryTest.java
+++ b/opennms-provision/opennms-provision-persistence/src/test/java/org/opennms/netmgt/provision/persist/FusedForeignSourceRepositoryTest.java
@@ -84,22 +84,8 @@ public class FusedForeignSourceRepositoryTest extends ForeignSourceRepositoryTes
         MockLogAppender.setupLogging(props);
 
         System.err.println("setUp()");
-        /* 
-         * since we share the filesystem with other tests, best
-         * to make sure it's totally clean here.
-         */
-        for (final ForeignSource fs : m_pending.getForeignSources()) {
-            m_pending.delete(fs);
-        }
-        for (final ForeignSource fs : m_active.getForeignSources()) {
-            m_active.delete(fs);
-        }
-        for (final Requisition r : m_pending.getRequisitions()) {
-            m_pending.delete(r);
-        }
-        for (final Requisition r : m_active.getRequisitions()) {
-            m_active.delete(r);
-        }
+        m_pending.clear();
+        m_active.clear();
         
         FileUtils.deleteDirectory(new File("target/opennms-home/etc/imports/pending"));
 

--- a/opennms-provision/opennms-provision-persistence/src/test/java/org/opennms/netmgt/provision/persist/QueueingForeignSourceRepositoryTest.java
+++ b/opennms-provision/opennms-provision-persistence/src/test/java/org/opennms/netmgt/provision/persist/QueueingForeignSourceRepositoryTest.java
@@ -56,6 +56,7 @@ public class QueueingForeignSourceRepositoryTest extends ForeignSourceRepository
     @Before
     public void setUp() {
         m_defaultForeignSourceName = "imported:";
+        m_foreignSourceRepository.clear();
     }
 
     private Requisition createRequisition() throws Exception {

--- a/opennms-provision/opennms-provision-persistence/src/test/java/org/opennms/netmgt/provision/persist/RequisitionTest.java
+++ b/opennms-provision/opennms-provision-persistence/src/test/java/org/opennms/netmgt/provision/persist/RequisitionTest.java
@@ -35,7 +35,7 @@ public class RequisitionTest implements InitializingBean, ApplicationContextAwar
     public void setUp() throws Exception {
         if (m_repositories != null) {
             for (final ForeignSourceRepository fsr : m_repositories.values()) {
-                fsr.resetDefaultForeignSource();
+                fsr.clear();
                 fsr.flush();
             }
         }

--- a/opennms-provision/opennms-provision-persistence/src/test/java/org/opennms/netmgt/provision/persist/RequisitionTest.java
+++ b/opennms-provision/opennms-provision-persistence/src/test/java/org/opennms/netmgt/provision/persist/RequisitionTest.java
@@ -1,0 +1,130 @@
+package org.opennms.netmgt.provision.persist;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.net.URL;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.opennms.core.test.OpenNMSJUnit4ClassRunner;
+import org.opennms.netmgt.provision.persist.foreignsource.ForeignSource;
+import org.opennms.netmgt.provision.persist.requisition.Requisition;
+import org.opennms.test.JUnitConfigurationEnvironment;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.test.context.ContextConfiguration;
+
+@RunWith(OpenNMSJUnit4ClassRunner.class)
+@ContextConfiguration(locations={
+        "classpath:/testForeignSourceContext.xml"
+})
+@JUnitConfigurationEnvironment
+public class RequisitionTest implements InitializingBean, ApplicationContextAware {
+    private static final Logger LOG = LoggerFactory.getLogger(RequisitionTest.class);
+
+    private Map<String, ForeignSourceRepository> m_repositories;
+
+    @Before
+    public void setUp() throws Exception {
+        if (m_repositories != null) {
+            for (final ForeignSourceRepository fsr : m_repositories.values()) {
+                fsr.resetDefaultForeignSource();
+                fsr.flush();
+            }
+        }
+        LOG.info("Test context prepared.");
+    }
+
+    interface RepositoryTest<T> {
+        void test(T t);
+    }
+
+    protected <T> void runTest(final RepositoryTest<ForeignSourceRepository> rt) {
+        m_repositories.entrySet().stream().forEach(entry -> {
+            final String bundleName = entry.getKey();
+            final ForeignSourceRepository fsr = entry.getValue();
+            LOG.info("=== " + bundleName + " ===");
+            fsr.resetDefaultForeignSource();
+            fsr.flush();
+            rt.test(fsr);
+        });
+    }
+
+    @Test
+    public void testCreateSimpleRequisition() {
+        runTest(
+                fsr -> {
+                    Requisition req = fsr.importResourceRequisition(new ClassPathResource("/requisition-test.xml"));
+                    fsr.save(req);
+                    fsr.flush();
+                    req = fsr.getRequisition("imported:");
+                    assertNotNull(req);
+                    assertEquals(2, req.getNodeCount());
+                }
+        );
+    }
+
+    @Test
+    public void testCreateSimpleForeignSource() {
+        runTest(
+                fsr -> {
+                    ForeignSource fs = fsr.getForeignSource("blah");
+                    fs.setDefault(false);
+                    fsr.save(fs);
+                    fsr.flush();
+                    fs = fsr.getForeignSource("blah");
+                    assertNotNull(fs);
+                    assertNotNull(fs.getScanInterval());
+                }
+        );
+    }
+
+    @Test
+    public void testRequisitionWithSpace() {
+        runTest(
+                fsr -> {
+                    final Requisition req = fsr.importResourceRequisition(new ClassPathResource("/requisition-test.xml"));
+                    req.setForeignSource("foo bar");
+                    fsr.save(req);
+                    fsr.flush();
+                    final Requisition saved = fsr.getRequisition("foo bar");
+                    assertNotNull(saved);
+                    assertEquals(req, saved);
+                }
+        );
+    }
+
+    @Test
+    public void testForeignSourceWithSpace() {
+        runTest(
+                fsr -> {
+                    final ForeignSource fs = fsr.getForeignSource("foo bar");
+                    fs.setDefault(false);
+                    fsr.save(fs);
+                    fsr.flush();
+                    final ForeignSource saved = fsr.getForeignSource("foo bar");
+                    assertNotNull(saved);
+                    assertEquals(fs, saved);
+                }
+        );
+    }
+
+    @Override
+    public void setApplicationContext(final ApplicationContext context) throws BeansException {
+        m_repositories = context.getBeansOfType(ForeignSourceRepository.class);
+    }
+
+    @Override
+    public void afterPropertiesSet() throws Exception {
+        assertNotNull(m_repositories);
+    }
+}

--- a/opennms-web-api/src/main/java/org/opennms/web/svclayer/support/DefaultRequisitionAccessService.java
+++ b/opennms-web-api/src/main/java/org/opennms/web/svclayer/support/DefaultRequisitionAccessService.java
@@ -438,12 +438,16 @@ public class DefaultRequisitionAccessService implements RequisitionAccessService
 
             final ForeignSourceRepository pendingForeignSourceRepository = getPendingForeignSourceRepository();
             final String foreignSource = getForeignSource();
+            LOG.debug("createSnapshot(): foreignSource = {}", foreignSource);
 
             final Requisition pending = pendingForeignSourceRepository.getRequisition(foreignSource);
+            LOG.debug("createSnapshot(): pending = {}", pending);
+
             final Requisition deployed = getDeployedForeignSourceRepository().getRequisition(foreignSource);
+            LOG.debug("createSnapshot(): deployed = {}", deployed);
 
             final URL activeUrl;
-            final XMLGregorianCalendar pendingDateStamp = pending.getDateStamp();
+            final XMLGregorianCalendar pendingDateStamp = pending == null? null : pending.getDateStamp();
 
             if (pending == null || (deployed != null && deployed.getDateStamp().compare(pendingDateStamp) > -1)) {
                 activeUrl = getDeployedForeignSourceRepository().getRequisitionURL(foreignSource);


### PR DESCRIPTION
URL-handling changed in the ReST API in 17, most likely related to the move to CXF.

These changes add some unit tests to validate behavior across all the ForeignSourceRepository implementations, as well as handling the new %20 in URLs.  In the case where the import URL has a %20 in it, Provisiond checks if it's a valid file, and if not, tries translating it and loads that instead.

JIRA: http://issues.opennms.org/browse/HZN-523
Bamboo: http://bamboo.internal.opennms.com:8085/browse/OPENNMS-ONMS284