### PR TITLE
NMS-7997: Background of notifications bell icon is too dark

### DIFF
--- a/opennms-webapp/src/main/scss/opennms-theme.scss
+++ b/opennms-webapp/src/main/scss/opennms-theme.scss
@@ -198,7 +198,7 @@ a:focus {
   color:#000;
 }
 .text-success {
-  color:$color_green_leaf_approx;
+  color:$color_success;
 }
 .text-info {
   color:$color_opennms;

--- a/opennms-webapp/src/main/scss/properties.scss
+++ b/opennms-webapp/src/main/scss/properties.scss
@@ -26,6 +26,7 @@ $color_bright_red_approx: #a20200;
 $color_alizarin_crimson_approx: #a40000;
 $color_lima_approx: #4c9d29;
 
+$color_success: #94bf7c;
 $color_opennms: #4c9d29;
 $color_opennms_light: #5acc29;
 


### PR DESCRIPTION
Add property to which represents success color and use in notification bell when Notifications are turned on. The color is based on the up indication color of outages and the availability time line for services.

JIRA: http://issues.opennms.org/browse/NMS-7997
Bamboo: http://bamboo.internal.opennms.com:8085/browse/OPENNMS-ONMS289