### PR TITLE
NMS-7999 bump commons-collections to 3.2.2

### DIFF
--- a/container/features/src/main/resources/features.xml
+++ b/container/features/src/main/resources/features.xml
@@ -183,7 +183,7 @@
       <bundle dependency="true">wrap:mvn:antlr/antlr/2.7.7</bundle>
       <bundle dependency="true">wrap:mvn:dom4j/dom4j/1.6.1</bundle>
       <bundle dependency="true">wrap:mvn:javax.transaction/jta/1.1</bundle>
-      <bundle dependency="true">mvn:commons-collections/commons-collections/3.2.1</bundle>
+      <bundle dependency="true">mvn:commons-collections/commons-collections/3.2.2</bundle>
       <bundle>wrap:mvn:org.hibernate.javax.persistence/hibernate-jpa-2.0-api/1.0.1.Final</bundle>
       <bundle>wrap:mvn:org.hibernate/hibernate-core/3.6.10.Final$Export-Package=org.hibernate*;version="3.6.10"</bundle>
       <bundle>wrap:mvn:org.hibernate/hibernate-commons-annotations/3.2.0.Final</bundle>

--- a/container/karaf/src/main/filtered-resources/features/features.xml
+++ b/container/karaf/src/main/filtered-resources/features/features.xml
@@ -394,7 +394,7 @@
     <feature name="spring-struts" description="Spring 3.1.x Struts support" version="3.1.4.RELEASE">
         <feature version="[3.1.4.RELEASE,3.2)">spring-web</feature>
         <feature>war</feature>
-        <bundle dependency="true" start-level="30">mvn:commons-collections/commons-collections/3.2.1</bundle>
+        <bundle dependency="true" start-level="30">mvn:commons-collections/commons-collections/3.2.2</bundle>
         <bundle dependency="true" start-level="30">mvn:commons-beanutils/commons-beanutils/1.9.2</bundle>
         <bundle dependency="true" start-level="30">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.struts/1.3.10_1</bundle>
         <bundle start-level="30">mvn:org.springframework/spring-struts/3.1.4.RELEASE</bundle>
@@ -470,7 +470,7 @@
     <feature name="spring-struts" description="Spring 3.2.x Struts support" version="3.2.9.RELEASE_1">
         <feature version="[3.2.9.RELEASE_1,3.3)">spring-web</feature>
         <feature>war</feature>
-        <bundle dependency="true" start-level="30">mvn:commons-collections/commons-collections/3.2.1</bundle>
+        <bundle dependency="true" start-level="30">mvn:commons-collections/commons-collections/3.2.2</bundle>
         <bundle dependency="true" start-level="30">mvn:commons-beanutils/commons-beanutils/1.9.2</bundle>
         <bundle dependency="true" start-level="30">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.struts/1.3.10_1</bundle>
         <bundle start-level="30">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.spring-struts/3.2.9.RELEASE_1</bundle>

--- a/pom.xml
+++ b/pom.xml
@@ -1224,7 +1224,7 @@
     <cloverVersion>3.2.0</cloverVersion>
     <commonsBeanutilsVersion>1.8.3</commonsBeanutilsVersion>
     <commonsCodecVersion>1.9</commonsCodecVersion>
-    <commonsCollectionsVersion>3.2.1</commonsCollectionsVersion>
+    <commonsCollectionsVersion>3.2.2</commonsCollectionsVersion>
     <commonsConfigurationVersion>1.6</commonsConfigurationVersion>
     <commonsCsvVersion>1.1</commonsCsvVersion>
     <commonsDigesterVersion>2.1</commonsDigesterVersion>


### PR DESCRIPTION
This is test-building right now: http://bamboo.internal.opennms.com:8085/browse/OPENNMS-ONMS291-1/

In my personal test-build of this, everything got overridden properly, the only commons-collections jar in lib is 3.2.2.  Note that we will end up with commons-collections 3.2.1 *and* 3.2.2 in the system/ tree because there are external bundle dependencies that haven't been updated, but at runtime only the 3.2.2 version is loaded:

    opennms> list | grep -i collections
    [ 151] [Active     ] [            ] [   80] Apache Commons Collections (3.2.2)

I don't think this can be avoided without duplicating a bunch of upstream features, which is obviously a horrible idea.