### PR TITLE
NMS-8004: Install iplike stored procedure

### DIFF
--- a/opennms-doc/guide-install/src/asciidoc/text/opennms/debian.adoc
+++ b/opennms-doc/guide-install/src/asciidoc/text/opennms/debian.adoc
@@ -95,6 +95,7 @@ The next step is creating an _opennms_ database user with password and configure
 su - postgres
 createuser -P opennms
 createdb -O opennms opennms
+psql -c "ALTER USER opennms WITH SUPERUSER;"
 exit
 ----
 
@@ -134,7 +135,7 @@ vi ${OPENNMS_HOME}/etc/opennms-datasources.xml
 _OpenNMS_ is now configured to access the database.
 It is required to set the _Java_ environment running _OpenNMS_ and initialize the database schema.
 
-.Configuration of _Java_ environment for _OpenNMS_ 
+.Configuration of _Java_ environment for _OpenNMS_
 [source, shell]
 ----
 ${OPENNMS_HOME}/bin/runjava -s
@@ -147,6 +148,18 @@ ${OPENNMS_HOME}/bin/install -dis
 ----
 
 NOTE: It is not necessary to add _OpenNMS_ to the run level manually, it is automatically added after setup.
+
+Running _OpenNMS_ doesn't require super user permissions.
+They are necessary for installing the _IPLIKE_ stored procedure during the database initialization.
+For operation the _OpenNMS_ database user can be restricted to a normal user.
+
+.Lockdown database permissions
+[source, shell]
+----
+su - postgres
+psql -c "ALTER ROLE opennms NOSUPERUSER;"
+psql -c "ALTER ROLE opennms NOCREATEDB;"
+----
 
 .Startup _OpenNMS_
 [source, shell]

--- a/opennms-doc/guide-install/src/asciidoc/text/opennms/rhel.adoc
+++ b/opennms-doc/guide-install/src/asciidoc/text/opennms/rhel.adoc
@@ -94,6 +94,7 @@ The next step is creating an _opennms_ database user with password and configure
 su - postgres
 createuser -P opennms
 createdb -O opennms opennms
+psql -c "ALTER USER opennms WITH SUPERUSER;"
 exit
 ----
 
@@ -133,7 +134,7 @@ vi ${OPENNMS_HOME}/etc/opennms-datasources.xml
                     database-name="opennms"
                     class-name="org.postgresql.Driver"
                     url="jdbc:postgresql://localhost:5432/opennms"
-                    user-name="** YOUR-OPENNMS-USERNAME **"<1> 
+                    user-name="** YOUR-OPENNMS-USERNAME **"<1>
                     password="** YOUR-OPENNMS-PASSWORD **" /><2>
 
 <jdbc-data-source name="opennms-admin"
@@ -155,7 +156,7 @@ vi ${OPENNMS_HOME}/etc/opennms-datasources.xml
 _OpenNMS_ is now configured to access the database.
 It is required to set the _Java_ environment running _OpenNMS_ and initialize the database schema.
 
-.Configuration of _Java_ environment for _OpenNMS_ 
+.Configuration of _Java_ environment for _OpenNMS_
 [source, shell]
 ----
 ${OPENNMS_HOME}/bin/runjava -s
@@ -171,6 +172,18 @@ ${OPENNMS_HOME}/bin/install -dis
 [source, shell]
 ----
 systemctl enable opennms
+----
+
+Running _OpenNMS_ doesn't require super user permissions.
+They are necessary for installing the _IPLIKE_ stored procedure during the database initialization.
+For operation the _OpenNMS_ database user can be restricted to a normal user.
+
+.Lockdown database permissions
+[source, shell]
+----
+su - postgres
+psql -c "ALTER ROLE opennms NOSUPERUSER;"
+psql -c "ALTER ROLE opennms NOCREATEDB;"
 ----
 
 .Startup _OpenNMS_


### PR DESCRIPTION
Create user for OpenNMS Postgres database and add super user permission to allow installation of C language stored procedure IPLIKE with `./install -dis`. After first start of OpenNMS the opennms user is locked down to a normal user removing super user role and removing possibility to create other databases.

JIRA: http://issues.opennms.org/browse/NMS-8004
Bamboo: http://bamboo.internal.opennms.com:8085/browse/OPENNMS-ONMS294