### PR TITLE
NMS-7998: Enable deletion of requisitioned entities by default

### DIFF
--- a/opennms-base-assembly/src/main/filtered/etc/opennms.properties
+++ b/opennms-base-assembly/src/main/filtered/etc/opennms.properties
@@ -448,7 +448,7 @@ smslib.serial.polling=true
 # from there.  To reenable this deletion you can set this to true.
 # NOTE: if you do this then the object will be recreated when the provisioning group is
 # next imported/synchronized
-#org.opennms.provisiond.enableDeletionOfRequisitionedEntities=false
+org.opennms.provisiond.enableDeletionOfRequisitionedEntities=true
 
 # This property is used to control the rescan scheduling existing nodes in
 # the database when Provisiond starts. The default value is true.


### PR DESCRIPTION
Allow to delete requisitioned monitoring entities by default. Otherwise you just get a scheduled for deletion event and nothing happens.

JIRA: http://issues.opennms.org/browse/NMS-7998
Bamboo: http://bamboo.internal.opennms.com:8085/browse/OPENNMS-ONMS295