### PR TITLE
HZN-545 upgrade tasks for 17

### DIFF
--- a/core/upgrade/src/test/java/org/opennms/upgrade/implementations/ServiceConfigMigratorOfflineTest.java
+++ b/core/upgrade/src/test/java/org/opennms/upgrade/implementations/ServiceConfigMigratorOfflineTest.java
@@ -28,16 +28,25 @@
 
 package org.opennms.upgrade.implementations;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
 import java.io.File;
+import java.util.Arrays;
+import java.util.Collection;
 
 import org.apache.commons.io.FileUtils;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
 import org.opennms.core.utils.ConfigFileConstants;
 import org.opennms.core.xml.JaxbUtils;
 import org.opennms.netmgt.config.ServiceConfigFactory;
+import org.opennms.netmgt.config.service.Service;
 import org.opennms.netmgt.config.service.ServiceConfiguration;
 
 /**
@@ -45,7 +54,19 @@ import org.opennms.netmgt.config.service.ServiceConfiguration;
  * 
  * @author Alejandro Galue <agalue@opennms.org>
  */
+@RunWith(Parameterized.class)
 public class ServiceConfigMigratorOfflineTest {
+    private final String m_testFile;
+    private final int m_totalBefore;
+    private final int m_totalAfter;
+    private final int m_enabledAfter;
+
+    public ServiceConfigMigratorOfflineTest(final String testFile, final int totalBefore, final int totalAfter, final int enabledAfter) {
+        m_testFile = testFile;
+        m_totalBefore = totalBefore;
+        m_totalAfter = totalAfter;
+        m_enabledAfter = enabledAfter;
+    }
 
     /**
      * Sets up the test.
@@ -56,6 +77,7 @@ public class ServiceConfigMigratorOfflineTest {
     public void setUp() throws Exception {
         FileUtils.copyDirectory(new File("src/test/resources/etc"), new File("target/home/etc"));
         System.setProperty("opennms.home", "target/home");
+        FileUtils.copyFile(new File(m_testFile), new File("target/home/etc/service-configuration.xml"));
     }
 
     /**
@@ -68,28 +90,56 @@ public class ServiceConfigMigratorOfflineTest {
         FileUtils.deleteDirectory(new File("target/home"));
     }
 
+    @Parameters
+    public static Collection<Object[]> params() {
+        return Arrays.asList(new Object[][] {
+            // service config, total, enabled
+            { "target/home/etc/service-configuration-1.8.17.xml",  30, 39, 28 },
+            { "target/home/etc/service-configuration-1.10.14.xml", 29, 39, 28 },
+            { "target/home/etc/service-configuration-1.12.9.xml",  26, 38, 27 },
+            { "target/home/etc/service-configuration-14.0.3.xml",  38, 38, 27 },
+            { "target/home/etc/service-configuration-15.0.2.xml",  38, 38, 27 },
+            { "target/home/etc/service-configuration-16.0.4.xml",  37, 38, 27 }
+        });
+    }
+
     /**
      * Test fixing the configuration file.
      *
      * @throws Exception the exception
      */
     @Test
-    public void testFixingConfig() throws Exception {
-        ServiceConfigMigratorOffline migrator = new ServiceConfigMigratorOffline();
-        migrator.execute();
-
-        // Checking parsing the fixed file (it should contain all the services)
+    public void testUpgradeConfig() throws Exception {
         File cfgFile = ConfigFileConstants.getFile(ConfigFileConstants.SERVICE_CONF_FILE_NAME);
         ServiceConfiguration cfg = JaxbUtils.unmarshal(ServiceConfiguration.class, cfgFile);
 
-        // Do not change this value: the config file behind this test should always contain
-        // the content for OpenNMS 14.0.0, regardless of whether or not services are added,
-        // changed, or removed in the latest version.
-        Assert.assertEquals(38, cfg.getServiceCount());
+        // check the total and active services before doing the upgrade
+        assertEquals(m_totalBefore, cfg.getServiceCount());
 
-        // Checking Service Factory (it should return only the enabled services)
-        ServiceConfigFactory factory = new ServiceConfigFactory();
-        Assert.assertEquals(27, factory.getServices().length);
+        // perform the upgrade
+        final ServiceConfigMigratorOffline migrator = new ServiceConfigMigratorOffline();
+        migrator.execute();
+
+        // confirm the total and active services after the upgrade
+        cfg = JaxbUtils.unmarshal(ServiceConfiguration.class, cfgFile);
+        final ServiceConfigFactory factory = new ServiceConfigFactory();
+        Assert.assertEquals(m_totalAfter, cfg.getServiceCount());
+        Assert.assertEquals(m_enabledAfter, factory.getServices().length);
+
+        for (final Service svc : cfg.getServiceCollection()) {
+            if ("OpenNMS:Name=Linkd".equals(svc.getName())) {
+                assertFalse(svc.isEnabled());
+            };
+            if ("OpenNMS:Name=Xmlrpcd".equals(svc.getName())) {
+                assertFalse(svc.isEnabled());
+            };
+            if ("OpenNMS:Name=XmlrpcProvisioner".equals(svc.getName())) {
+                assertFalse(svc.isEnabled());
+            };
+            if ("OpenNMS:Name=AccessPointMonitor".equals(svc.getName())) {
+                assertFalse(svc.isEnabled());
+            };
+        }
     }
 
 }

--- a/core/upgrade/src/test/resources/etc/service-configuration-1.10.14.xml
+++ b/core/upgrade/src/test/resources/etc/service-configuration-1.10.14.xml
@@ -1,0 +1,374 @@
+<?xml version="1.0"?>
+<!-- NOTE!!!!!!!!!!!!!!!!!!!
+The order in which these services are specified is important - for example, Eventd
+will need to come up last so that none of the event topic subcribers loose any event.
+
+When splitting services to run on mutiple VMs, the order of the services should be
+maintained
+-->
+<service-configuration>
+  <service>
+    <name>:Name=XSLTProcessor</name>
+    <class-name>mx4j.tools.adaptor.http.XSLTProcessor</class-name>
+  </service>
+  <service>
+    <name>:Name=HttpAdaptor</name>
+    <class-name>mx4j.tools.adaptor.http.HttpAdaptor</class-name>
+    <attribute>
+      <name>Port</name>
+      <value type="java.lang.Integer">8180</value>
+    </attribute>
+    <attribute>
+      <name>Host</name>
+      <value type="java.lang.String">127.0.0.1</value>
+    </attribute>
+    <attribute>
+      <name>ProcessorName</name>
+      <value type="javax.management.ObjectName">:Name=XSLTProcessor</value>
+    </attribute>
+    <attribute>
+      <name>AuthenticationMethod</name>
+      <value type="java.lang.String">basic</value>
+    </attribute>
+    <invoke at="start" pass="0" method="addAuthorization">
+      <argument type="java.lang.String">admin</argument>
+      <argument type="java.lang.String">admin</argument>
+    </invoke>
+    <invoke at="start" pass="0" method="start"/>
+  </service>
+  <service>
+    <name>:Name=HttpAdaptorMgmt</name>
+    <class-name>mx4j.tools.adaptor.http.HttpAdaptor</class-name>
+    <attribute>
+      <name>Port</name>
+      <value type="java.lang.Integer">8181</value>
+    </attribute>
+    <attribute>
+      <name>Host</name>
+      <value type="java.lang.String">127.0.0.1</value>
+    </attribute>
+    <attribute>
+      <name>AuthenticationMethod</name>
+      <value type="java.lang.String">basic</value>
+    </attribute>
+    <invoke at="start" pass="0" method="addAuthorization">
+      <argument type="java.lang.String">manager</argument>
+      <argument type="java.lang.String">manager</argument>
+    </invoke>
+    <invoke at="start" pass="0" method="start"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Manager</name>
+    <class-name>org.opennms.netmgt.vmmgr.Manager</class-name>
+    <invoke at="stop" pass="1" method="doSystemExit"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=TestLoadLibraries</name>
+    <class-name>org.opennms.netmgt.vmmgr.Manager</class-name>
+    <invoke at="start" pass="0" method="doTestLoadLibraries"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Eventd</name>
+    <class-name>org.opennms.netmgt.eventd.jmx.Eventd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Trapd</name>
+    <class-name>org.opennms.netmgt.trapd.jmx.Trapd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Queued</name>
+    <class-name>org.opennms.netmgt.queued.jmx.Queued</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <!--  Dhcpd is now distributed separately. You will need to ensure
+        it is installed before you enable it here. -->
+  <!-- 
+  <service>
+    <name>OpenNMS:Name=Dhcpd</name>
+    <class-name>org.opennms.netmgt.dhcpd.jmx.Dhcpd</class-name>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+ -->
+   <service>
+    <name>OpenNMS:Name=Actiond</name>
+    <class-name>org.opennms.netmgt.actiond.jmx.Actiond</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Capsd</name>
+    <class-name>org.opennms.netmgt.capsd.jmx.Capsd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Notifd</name>
+    <class-name>org.opennms.netmgt.notifd.jmx.Notifd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Scriptd</name>
+    <class-name>org.opennms.netmgt.scriptd.jmx.Scriptd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Rtcd</name>
+    <class-name>org.opennms.netmgt.rtc.jmx.Rtcd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Pollerd</name>
+    <class-name>org.opennms.netmgt.poller.jmx.Pollerd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=PollerBackEnd</name>
+    <class-name>org.opennms.netmgt.poller.jmx.RemotePollerBackEnd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+<!--
+  <service>
+     <name>OpenNMS:Name=SnmpPoller</name>
+     <class-name>org.opennms.netmgt.snmpinterfacepoller.jmx.SnmpPollerd</class-name>
+     <invoke at="start" pass="0" method="init"/>
+     <invoke at="start" pass="1" method="start"/>
+     <invoke at="status" pass="0" method="status"/>
+     <invoke at="stop" pass="0" method="stop"/>
+  </service>
+-->
+  <service>
+    <name>OpenNMS:Name=Ticketer</name>
+    <class-name>org.opennms.netmgt.ticketd.jmx.TroubleTicketer</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Collectd</name>
+    <class-name>org.opennms.netmgt.collectd.jmx.Collectd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Threshd</name>
+    <class-name>org.opennms.netmgt.threshd.jmx.Threshd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Discovery</name>
+    <class-name>org.opennms.netmgt.discovery.jmx.Discovery</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Vacuumd</name>
+    <class-name>org.opennms.netmgt.vacuumd.jmx.Vacuumd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=EventTranslator</name>
+    <class-name>org.opennms.netmgt.translator.jmx.EventTranslator</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=PassiveStatusd</name>
+    <class-name>org.opennms.netmgt.passive.jmx.PassiveStatusd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Statsd</name>
+    <class-name>org.opennms.netmgt.statsd.jmx.Statsd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Provisiond</name>
+    <class-name>org.opennms.netmgt.daemon.SimpleSpringContextJmxServiceDaemon</class-name>
+    <attribute>
+      <name>LoggingPrefix</name>
+      <value type="java.lang.String">Provisiond</value>
+    </attribute>
+    <attribute>
+      <name>SpringContext</name>
+      <value type="java.lang.String">provisiondContext</value>
+    </attribute>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Reportd</name>
+    <class-name>org.opennms.netmgt.daemon.SimpleSpringContextJmxServiceDaemon</class-name>
+    <attribute>
+      <name>LoggingPrefix</name>
+      <value type="java.lang.String">Reportd</value>
+    </attribute>
+    <attribute>
+      <name>SpringContext</name>
+      <value type="java.lang.String">reportdContext</value>
+    </attribute>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+
+  <service>
+    <name>OpenNMS:Name=Alarmd</name>
+    <class-name>org.opennms.netmgt.daemon.SimpleSpringContextJmxServiceDaemon</class-name>
+    <attribute>
+      <name>LoggingPrefix</name>
+      <value type="java.lang.String">Alarmd</value>
+    </attribute>
+    <attribute>
+      <name>SpringContext</name>
+      <value type="java.lang.String">alarmdContext</value>
+    </attribute>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=AsteriskGateway</name>
+    <class-name>org.opennms.netmgt.asterisk.agi.jmx.AsteriskGateway</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Ackd</name>
+    <class-name>org.opennms.netmgt.daemon.SimpleSpringContextJmxServiceDaemon</class-name>
+    <attribute>
+      <name>LoggingPrefix</name>
+      <value type="java.lang.String">Ackd</value>
+    </attribute>
+    <attribute>
+      <name>SpringContext</name>
+      <value type="java.lang.String">ackdContext</value>
+    </attribute>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=JettyServer</name>
+    <class-name>org.opennms.netmgt.jetty.jmx.JettyServer</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+<!--
+  <service>
+    <name>OpenNMS:Name=Linkd</name>
+    <class-name>org.opennms.netmgt.linkd.jmx.Linkd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Importer</name>
+    <class-name>org.opennms.netmgt.importer.jmx.ImporterService</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Correlator</name>
+    <class-name>org.opennms.netmgt.correlation.jmx.Correlator</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Tl1d</name>
+    <class-name>org.opennms.netmgt.tl1d.jmx.Tl1d</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Syslogd</name>
+    <class-name>org.opennms.netmgt.syslogd.jmx.Syslogd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Xmlrpcd</name>
+    <class-name>org.opennms.netmgt.xmlrpcd.jmx.Xmlrpcd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=XmlrpcProvisioner</name>
+    <class-name>org.opennms.netmgt.xmlrpcd.jmx.Provisioner</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+-->
+</service-configuration>

--- a/core/upgrade/src/test/resources/etc/service-configuration-1.12.9.xml
+++ b/core/upgrade/src/test/resources/etc/service-configuration-1.12.9.xml
@@ -1,0 +1,386 @@
+<?xml version="1.0"?>
+<!-- NOTE!!!!!!!!!!!!!!!!!!!
+The order in which these services are specified is important - for example, Eventd
+will need to come up last so that none of the event topic subcribers loose any event.
+
+When splitting services to run on mutiple VMs, the order of the services should be
+maintained
+-->
+<service-configuration>
+  <service>
+    <name>:Name=XSLTProcessor</name>
+    <class-name>mx4j.tools.adaptor.http.XSLTProcessor</class-name>
+  </service>
+  <service>
+    <name>:Name=HttpAdaptor</name>
+    <class-name>mx4j.tools.adaptor.http.HttpAdaptor</class-name>
+    <attribute>
+      <name>Port</name>
+      <value type="java.lang.Integer">8180</value>
+    </attribute>
+    <attribute>
+      <name>Host</name>
+      <value type="java.lang.String">127.0.0.1</value>
+    </attribute>
+    <attribute>
+      <name>ProcessorName</name>
+      <value type="javax.management.ObjectName">:Name=XSLTProcessor</value>
+    </attribute>
+    <attribute>
+      <name>AuthenticationMethod</name>
+      <value type="java.lang.String">basic</value>
+    </attribute>
+    <invoke at="start" pass="0" method="addAuthorization">
+      <argument type="java.lang.String">admin</argument>
+      <argument type="java.lang.String">admin</argument>
+    </invoke>
+    <invoke at="start" pass="0" method="start"/>
+  </service>
+  <service>
+    <name>:Name=HttpAdaptorMgmt</name>
+    <class-name>mx4j.tools.adaptor.http.HttpAdaptor</class-name>
+    <attribute>
+      <name>Port</name>
+      <value type="java.lang.Integer">8181</value>
+    </attribute>
+    <attribute>
+      <name>Host</name>
+      <value type="java.lang.String">127.0.0.1</value>
+    </attribute>
+    <attribute>
+      <name>AuthenticationMethod</name>
+      <value type="java.lang.String">basic</value>
+    </attribute>
+    <invoke at="start" pass="0" method="addAuthorization">
+      <argument type="java.lang.String">manager</argument>
+      <argument type="java.lang.String">manager</argument>
+    </invoke>
+    <invoke at="start" pass="0" method="start"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Manager</name>
+    <class-name>org.opennms.netmgt.vmmgr.Manager</class-name>
+    <invoke at="stop" pass="1" method="doSystemExit"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=TestLoadLibraries</name>
+    <class-name>org.opennms.netmgt.vmmgr.Manager</class-name>
+    <invoke at="start" pass="0" method="doTestLoadLibraries"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Eventd</name>
+    <class-name>org.opennms.netmgt.eventd.jmx.Eventd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Trapd</name>
+    <class-name>org.opennms.netmgt.trapd.jmx.Trapd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Queued</name>
+    <class-name>org.opennms.netmgt.queued.jmx.Queued</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <!--  Dhcpd is now distributed separately. You will need to ensure
+        it is installed before you enable it here. -->
+  <!-- 
+  <service>
+    <name>OpenNMS:Name=Dhcpd</name>
+    <class-name>org.opennms.netmgt.dhcpd.jmx.Dhcpd</class-name>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+ -->
+   <service>
+    <name>OpenNMS:Name=Actiond</name>
+    <class-name>org.opennms.netmgt.actiond.jmx.Actiond</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <!--
+  <service>
+    <name>OpenNMS:Name=Capsd</name>
+    <class-name>org.opennms.netmgt.capsd.jmx.Capsd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  -->
+  <service>
+    <name>OpenNMS:Name=Notifd</name>
+    <class-name>org.opennms.netmgt.notifd.jmx.Notifd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Scriptd</name>
+    <class-name>org.opennms.netmgt.scriptd.jmx.Scriptd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Rtcd</name>
+    <class-name>org.opennms.netmgt.rtc.jmx.Rtcd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Pollerd</name>
+    <class-name>org.opennms.netmgt.poller.jmx.Pollerd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=PollerBackEnd</name>
+    <class-name>org.opennms.netmgt.poller.jmx.RemotePollerBackEnd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+<!--
+  <service>
+     <name>OpenNMS:Name=SnmpPoller</name>
+     <class-name>org.opennms.netmgt.snmpinterfacepoller.jmx.SnmpPollerd</class-name>
+     <invoke at="start" pass="0" method="init"/>
+     <invoke at="start" pass="1" method="start"/>
+     <invoke at="status" pass="0" method="status"/>
+     <invoke at="stop" pass="0" method="stop"/>
+  </service>
+-->
+  <service>
+    <name>OpenNMS:Name=Ticketer</name>
+    <class-name>org.opennms.netmgt.ticketd.jmx.TroubleTicketer</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Collectd</name>
+    <class-name>org.opennms.netmgt.collectd.jmx.Collectd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <!--
+  <service>
+    <name>OpenNMS:Name=Threshd</name>
+    <class-name>org.opennms.netmgt.threshd.jmx.Threshd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  -->
+  <service>
+    <name>OpenNMS:Name=Discovery</name>
+    <class-name>org.opennms.netmgt.discovery.jmx.Discovery</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Vacuumd</name>
+    <class-name>org.opennms.netmgt.vacuumd.jmx.Vacuumd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=EventTranslator</name>
+    <class-name>org.opennms.netmgt.translator.jmx.EventTranslator</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=PassiveStatusd</name>
+    <class-name>org.opennms.netmgt.passive.jmx.PassiveStatusd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Statsd</name>
+    <class-name>org.opennms.netmgt.statsd.jmx.Statsd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Provisiond</name>
+    <class-name>org.opennms.netmgt.daemon.SimpleSpringContextJmxServiceDaemon</class-name>
+    <attribute>
+      <name>LoggingPrefix</name>
+      <value type="java.lang.String">Provisiond</value>
+    </attribute>
+    <attribute>
+      <name>SpringContext</name>
+      <value type="java.lang.String">provisiondContext</value>
+    </attribute>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Reportd</name>
+    <class-name>org.opennms.netmgt.daemon.SimpleSpringContextJmxServiceDaemon</class-name>
+    <attribute>
+      <name>LoggingPrefix</name>
+      <value type="java.lang.String">Reportd</value>
+    </attribute>
+    <attribute>
+      <name>SpringContext</name>
+      <value type="java.lang.String">reportdContext</value>
+    </attribute>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+
+  <service>
+    <name>OpenNMS:Name=Alarmd</name>
+    <class-name>org.opennms.netmgt.daemon.SimpleSpringContextJmxServiceDaemon</class-name>
+    <attribute>
+      <name>LoggingPrefix</name>
+      <value type="java.lang.String">Alarmd</value>
+    </attribute>
+    <attribute>
+      <name>SpringContext</name>
+      <value type="java.lang.String">alarmdContext</value>
+    </attribute>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Ackd</name>
+    <class-name>org.opennms.netmgt.daemon.SimpleSpringContextJmxServiceDaemon</class-name>
+    <attribute>
+      <name>LoggingPrefix</name>
+      <value type="java.lang.String">Ackd</value>
+    </attribute>
+    <attribute>
+      <name>SpringContext</name>
+      <value type="java.lang.String">ackdContext</value>
+    </attribute>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=JettyServer</name>
+    <class-name>org.opennms.netmgt.jetty.jmx.JettyServer</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+<!--
+  <service>
+    <name>OpenNMS:Name=Linkd</name>
+    <class-name>org.opennms.netmgt.linkd.jmx.Linkd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Importer</name>
+    <class-name>org.opennms.netmgt.importer.jmx.ImporterService</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Correlator</name>
+    <class-name>org.opennms.netmgt.correlation.jmx.Correlator</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Tl1d</name>
+    <class-name>org.opennms.netmgt.tl1d.jmx.Tl1d</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Syslogd</name>
+    <class-name>org.opennms.netmgt.syslogd.jmx.Syslogd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Xmlrpcd</name>
+    <class-name>org.opennms.netmgt.xmlrpcd.jmx.Xmlrpcd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=XmlrpcProvisioner</name>
+    <class-name>org.opennms.netmgt.xmlrpcd.jmx.Provisioner</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=AsteriskGateway</name>
+    <class-name>org.opennms.netmgt.asterisk.agi.jmx.AsteriskGateway</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=AccessPointMonitor</name>
+    <class-name>org.opennms.netmgt.accesspointmonitor.jmx.AccessPointMonitor</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+-->
+</service-configuration>

--- a/core/upgrade/src/test/resources/etc/service-configuration-1.8.17.xml
+++ b/core/upgrade/src/test/resources/etc/service-configuration-1.8.17.xml
@@ -1,0 +1,370 @@
+<?xml version="1.0"?>
+<!-- NOTE!!!!!!!!!!!!!!!!!!!
+The order in which these services are specified is important - for example, Eventd
+will need to come up last so that none of the event topic subcribers loose any event.
+
+When splitting services to run on mutiple VMs, the order of the services should be
+maintained
+-->
+<service-configuration>
+  <service>
+    <name>:Name=XSLTProcessor</name>
+    <class-name>mx4j.tools.adaptor.http.XSLTProcessor</class-name>
+  </service>
+  <service>
+    <name>:Name=HttpAdaptor</name>
+    <class-name>mx4j.tools.adaptor.http.HttpAdaptor</class-name>
+    <attribute>
+      <name>Port</name>
+      <value type="java.lang.Integer">8180</value>
+    </attribute>
+    <attribute>
+      <name>Host</name>
+      <value type="java.lang.String">127.0.0.1</value>
+    </attribute>
+    <attribute>
+      <name>ProcessorName</name>
+      <value type="javax.management.ObjectName">:Name=XSLTProcessor</value>
+    </attribute>
+    <attribute>
+      <name>AuthenticationMethod</name>
+      <value type="java.lang.String">basic</value>
+    </attribute>
+    <invoke at="start" pass="0" method="addAuthorization">
+      <argument type="java.lang.String">admin</argument>
+      <argument type="java.lang.String">admin</argument>
+    </invoke>
+    <invoke at="start" pass="0" method="start"/>
+  </service>
+  <service>
+    <name>:Name=HttpAdaptorMgmt</name>
+    <class-name>mx4j.tools.adaptor.http.HttpAdaptor</class-name>
+    <attribute>
+      <name>Port</name>
+      <value type="java.lang.Integer">8181</value>
+    </attribute>
+    <attribute>
+      <name>Host</name>
+      <value type="java.lang.String">127.0.0.1</value>
+    </attribute>
+    <attribute>
+      <name>AuthenticationMethod</name>
+      <value type="java.lang.String">basic</value>
+    </attribute>
+    <invoke at="start" pass="0" method="addAuthorization">
+      <argument type="java.lang.String">manager</argument>
+      <argument type="java.lang.String">manager</argument>
+    </invoke>
+    <invoke at="start" pass="0" method="start"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Manager</name>
+    <class-name>org.opennms.netmgt.vmmgr.Manager</class-name>
+    <invoke at="stop" pass="1" method="doSystemExit"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=TestLoadLibraries</name>
+    <class-name>org.opennms.netmgt.vmmgr.Manager</class-name>
+    <invoke at="start" pass="0" method="doTestLoadLibraries"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Eventd</name>
+    <class-name>org.opennms.netmgt.eventd.jmx.Eventd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Trapd</name>
+    <class-name>org.opennms.netmgt.trapd.jmx.Trapd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Queued</name>
+    <class-name>org.opennms.netmgt.queued.jmx.Queued</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Dhcpd</name>
+    <class-name>org.opennms.netmgt.dhcpd.jmx.Dhcpd</class-name>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Actiond</name>
+    <class-name>org.opennms.netmgt.actiond.jmx.Actiond</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Capsd</name>
+    <class-name>org.opennms.netmgt.capsd.jmx.Capsd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Notifd</name>
+    <class-name>org.opennms.netmgt.notifd.jmx.Notifd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Scriptd</name>
+    <class-name>org.opennms.netmgt.scriptd.jmx.Scriptd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Rtcd</name>
+    <class-name>org.opennms.netmgt.rtc.jmx.Rtcd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Pollerd</name>
+    <class-name>org.opennms.netmgt.poller.jmx.Pollerd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=PollerBackEnd</name>
+    <class-name>org.opennms.netmgt.poller.jmx.RemotePollerBackEnd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+<!--
+  <service>
+     <name>OpenNMS:Name=SnmpPoller</name>
+     <class-name>org.opennms.netmgt.snmpinterfacepoller.jmx.SnmpPollerd</class-name>
+     <invoke at="start" pass="0" method="init"/>
+     <invoke at="start" pass="1" method="start"/>
+     <invoke at="status" pass="0" method="status"/>
+     <invoke at="stop" pass="0" method="stop"/>
+  </service>
+-->
+  <service>
+    <name>OpenNMS:Name=Ticketer</name>
+    <class-name>org.opennms.netmgt.ticketd.jmx.TroubleTicketer</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Collectd</name>
+    <class-name>org.opennms.netmgt.collectd.jmx.Collectd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Threshd</name>
+    <class-name>org.opennms.netmgt.threshd.jmx.Threshd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Discovery</name>
+    <class-name>org.opennms.netmgt.discovery.jmx.Discovery</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Vacuumd</name>
+    <class-name>org.opennms.netmgt.vacuumd.jmx.Vacuumd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=EventTranslator</name>
+    <class-name>org.opennms.netmgt.translator.jmx.EventTranslator</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=PassiveStatusd</name>
+    <class-name>org.opennms.netmgt.passive.jmx.PassiveStatusd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Statsd</name>
+    <class-name>org.opennms.netmgt.statsd.jmx.Statsd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Provisiond</name>
+    <class-name>org.opennms.netmgt.daemon.SimpleSpringContextJmxServiceDaemon</class-name>
+    <attribute>
+      <name>LoggingPrefix</name>
+      <value type="java.lang.String">Provisiond</value>
+    </attribute>
+    <attribute>
+      <name>SpringContext</name>
+      <value type="java.lang.String">provisiondContext</value>
+    </attribute>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Reportd</name>
+    <class-name>org.opennms.netmgt.daemon.SimpleSpringContextJmxServiceDaemon</class-name>
+    <attribute>
+      <name>LoggingPrefix</name>
+      <value type="java.lang.String">Reportd</value>
+    </attribute>
+    <attribute>
+      <name>SpringContext</name>
+      <value type="java.lang.String">reportdContext</value>
+    </attribute>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+
+  <service>
+    <name>OpenNMS:Name=Alarmd</name>
+    <class-name>org.opennms.netmgt.daemon.SimpleSpringContextJmxServiceDaemon</class-name>
+    <attribute>
+      <name>LoggingPrefix</name>
+      <value type="java.lang.String">Alarmd</value>
+    </attribute>
+    <attribute>
+      <name>SpringContext</name>
+      <value type="java.lang.String">alarmdContext</value>
+    </attribute>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=AsteriskGateway</name>
+    <class-name>org.opennms.netmgt.asterisk.agi.jmx.AsteriskGateway</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Ackd</name>
+    <class-name>org.opennms.netmgt.daemon.SimpleSpringContextJmxServiceDaemon</class-name>
+    <attribute>
+      <name>LoggingPrefix</name>
+      <value type="java.lang.String">Ackd</value>
+    </attribute>
+    <attribute>
+      <name>SpringContext</name>
+      <value type="java.lang.String">ackdContext</value>
+    </attribute>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=JettyServer</name>
+    <class-name>org.opennms.netmgt.jetty.jmx.JettyServer</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+<!--
+  <service>
+    <name>OpenNMS:Name=Linkd</name>
+    <class-name>org.opennms.netmgt.linkd.jmx.Linkd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Importer</name>
+    <class-name>org.opennms.netmgt.importer.jmx.ImporterService</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Correlator</name>
+    <class-name>org.opennms.netmgt.correlation.jmx.Correlator</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Tl1d</name>
+    <class-name>org.opennms.netmgt.tl1d.jmx.Tl1d</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Syslogd</name>
+    <class-name>org.opennms.netmgt.syslogd.jmx.Syslogd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Xmlrpcd</name>
+    <class-name>org.opennms.netmgt.xmlrpcd.jmx.Xmlrpcd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=XmlrpcProvisioner</name>
+    <class-name>org.opennms.netmgt.xmlrpcd.jmx.Provisioner</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+-->
+</service-configuration>

--- a/core/upgrade/src/test/resources/etc/service-configuration-14.0.3.xml
+++ b/core/upgrade/src/test/resources/etc/service-configuration-14.0.3.xml
@@ -1,0 +1,369 @@
+<?xml version="1.0"?>
+<!-- NOTE!!!!!!!!!!!!!!!!!!!
+The order in which these services are specified is important - for example, Eventd
+will need to come up last so that none of the event topic subcribers loose any event.
+
+When splitting services to run on mutiple VMs, the order of the services should be
+maintained
+-->
+<service-configuration xmlns="http://xmlns.opennms.org/xsd/config/vmmgr">
+  <service>
+    <name>:Name=XSLTProcessor</name>
+    <class-name>mx4j.tools.adaptor.http.XSLTProcessor</class-name>
+  </service>
+  <service>
+    <name>:Name=HttpAdaptor</name>
+    <class-name>mx4j.tools.adaptor.http.HttpAdaptor</class-name>
+    <attribute>
+      <name>Port</name>
+      <value type="java.lang.Integer">8180</value>
+    </attribute>
+    <attribute>
+      <name>Host</name>
+      <value type="java.lang.String">127.0.0.1</value>
+    </attribute>
+    <attribute>
+      <name>ProcessorName</name>
+      <value type="javax.management.ObjectName">:Name=XSLTProcessor</value>
+    </attribute>
+    <attribute>
+      <name>AuthenticationMethod</name>
+      <value type="java.lang.String">basic</value>
+    </attribute>
+    <invoke at="start" pass="0" method="addAuthorization">
+      <argument type="java.lang.String">admin</argument>
+      <argument type="java.lang.String">admin</argument>
+    </invoke>
+    <invoke at="start" pass="0" method="start"/>
+  </service>
+  <service>
+    <name>:Name=HttpAdaptorMgmt</name>
+    <class-name>mx4j.tools.adaptor.http.HttpAdaptor</class-name>
+    <attribute>
+      <name>Port</name>
+      <value type="java.lang.Integer">8181</value>
+    </attribute>
+    <attribute>
+      <name>Host</name>
+      <value type="java.lang.String">127.0.0.1</value>
+    </attribute>
+    <attribute>
+      <name>AuthenticationMethod</name>
+      <value type="java.lang.String">basic</value>
+    </attribute>
+    <invoke at="start" pass="0" method="addAuthorization">
+      <argument type="java.lang.String">manager</argument>
+      <argument type="java.lang.String">manager</argument>
+    </invoke>
+    <invoke at="start" pass="0" method="start"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Manager</name>
+    <class-name>org.opennms.netmgt.vmmgr.Manager</class-name>
+    <invoke at="stop" pass="1" method="doSystemExit"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=TestLoadLibraries</name>
+    <class-name>org.opennms.netmgt.vmmgr.Manager</class-name>
+    <invoke at="start" pass="0" method="doTestLoadLibraries"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Eventd</name>
+    <class-name>org.opennms.netmgt.eventd.jmx.Eventd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Trapd</name>
+    <class-name>org.opennms.netmgt.trapd.jmx.Trapd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Queued</name>
+    <class-name>org.opennms.netmgt.queued.jmx.Queued</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <!--  Dhcpd is now distributed separately. You will need to ensure
+        it is installed before you enable it here. -->
+  <service enabled="false">
+    <name>OpenNMS:Name=Dhcpd</name>
+    <class-name>org.opennms.netmgt.dhcpd.jmx.Dhcpd</class-name>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Actiond</name>
+    <class-name>org.opennms.netmgt.actiond.jmx.Actiond</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service enabled="false">
+    <name>OpenNMS:Name=Capsd</name>
+    <class-name>org.opennms.netmgt.capsd.jmx.Capsd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Notifd</name>
+    <class-name>org.opennms.netmgt.notifd.jmx.Notifd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Scriptd</name>
+    <class-name>org.opennms.netmgt.scriptd.jmx.Scriptd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Rtcd</name>
+    <class-name>org.opennms.netmgt.rtc.jmx.Rtcd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Pollerd</name>
+    <class-name>org.opennms.netmgt.poller.jmx.Pollerd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=PollerBackEnd</name>
+    <class-name>org.opennms.netmgt.poller.remote.jmx.RemotePollerBackEnd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service enabled="false">
+     <name>OpenNMS:Name=SnmpPoller</name>
+     <class-name>org.opennms.netmgt.snmpinterfacepoller.jmx.SnmpPollerd</class-name>
+     <invoke at="start" pass="0" method="init"/>
+     <invoke at="start" pass="1" method="start"/>
+     <invoke at="status" pass="0" method="status"/>
+     <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=EnhancedLinkd</name>
+    <class-name>org.opennms.netmgt.enlinkd.jmx.EnhancedLinkd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Ticketer</name>
+    <class-name>org.opennms.netmgt.ticketd.jmx.TroubleTicketer</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Collectd</name>
+    <class-name>org.opennms.netmgt.collectd.jmx.Collectd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Discovery</name>
+    <class-name>org.opennms.netmgt.discovery.jmx.Discovery</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Vacuumd</name>
+    <class-name>org.opennms.netmgt.vacuumd.jmx.Vacuumd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=EventTranslator</name>
+    <class-name>org.opennms.netmgt.translator.jmx.EventTranslator</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=PassiveStatusd</name>
+    <class-name>org.opennms.netmgt.passive.jmx.PassiveStatusd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Statsd</name>
+    <class-name>org.opennms.netmgt.statsd.jmx.Statsd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Provisiond</name>
+    <class-name>org.opennms.netmgt.daemon.SimpleSpringContextJmxServiceDaemon</class-name>
+    <attribute>
+      <name>LoggingPrefix</name>
+      <value type="java.lang.String">provisiond</value>
+    </attribute>
+    <attribute>
+      <name>SpringContext</name>
+      <value type="java.lang.String">provisiondContext</value>
+    </attribute>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Reportd</name>
+    <class-name>org.opennms.netmgt.daemon.SimpleSpringContextJmxServiceDaemon</class-name>
+    <attribute>
+      <name>LoggingPrefix</name>
+      <value type="java.lang.String">reportd</value>
+    </attribute>
+    <attribute>
+      <name>SpringContext</name>
+      <value type="java.lang.String">reportdContext</value>
+    </attribute>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Alarmd</name>
+    <class-name>org.opennms.netmgt.daemon.SimpleSpringContextJmxServiceDaemon</class-name>
+    <attribute>
+      <name>LoggingPrefix</name>
+      <value type="java.lang.String">alarmd</value>
+    </attribute>
+    <attribute>
+      <name>SpringContext</name>
+      <value type="java.lang.String">alarmdContext</value>
+    </attribute>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Ackd</name>
+    <class-name>org.opennms.netmgt.daemon.SimpleSpringContextJmxServiceDaemon</class-name>
+    <attribute>
+      <name>LoggingPrefix</name>
+      <value type="java.lang.String">ackd</value>
+    </attribute>
+    <attribute>
+      <name>SpringContext</name>
+      <value type="java.lang.String">ackdContext</value>
+    </attribute>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=JettyServer</name>
+    <class-name>org.opennms.netmgt.jetty.jmx.JettyServer</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service enabled="false">
+    <name>OpenNMS:Name=Linkd</name>
+    <class-name>org.opennms.netmgt.linkd.jmx.Linkd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service enabled="false">
+    <name>OpenNMS:Name=Correlator</name>
+    <class-name>org.opennms.netmgt.correlation.jmx.Correlator</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service enabled="false">
+    <name>OpenNMS:Name=Tl1d</name>
+    <class-name>org.opennms.netmgt.tl1d.jmx.Tl1d</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service enabled="false">
+    <name>OpenNMS:Name=Syslogd</name>
+    <class-name>org.opennms.netmgt.syslogd.jmx.Syslogd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service enabled="false">
+    <name>OpenNMS:Name=Xmlrpcd</name>
+    <class-name>org.opennms.netmgt.xmlrpcd.jmx.Xmlrpcd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service enabled="false">
+    <name>OpenNMS:Name=XmlrpcProvisioner</name>
+    <class-name>org.opennms.netmgt.xmlrpcd.jmx.Provisioner</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service enabled="false">
+    <name>OpenNMS:Name=AsteriskGateway</name>
+    <class-name>org.opennms.netmgt.asterisk.agi.jmx.AsteriskGateway</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <!--  AccessPointMonitor is now distributed separately. You will need to ensure
+        it is installed before you enable it here. -->
+  <service enabled="false">
+    <name>OpenNMS:Name=AccessPointMonitor</name>
+    <class-name>org.opennms.netmgt.accesspointmonitor.jmx.AccessPointMonitor</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+</service-configuration>

--- a/core/upgrade/src/test/resources/etc/service-configuration-15.0.2.xml
+++ b/core/upgrade/src/test/resources/etc/service-configuration-15.0.2.xml
@@ -1,0 +1,369 @@
+<?xml version="1.0"?>
+<!-- NOTE!!!!!!!!!!!!!!!!!!!
+The order in which these services are specified is important - for example, Eventd
+will need to come up last so that none of the event topic subcribers loose any event.
+
+When splitting services to run on mutiple VMs, the order of the services should be
+maintained
+-->
+<service-configuration xmlns="http://xmlns.opennms.org/xsd/config/vmmgr">
+  <service>
+    <name>:Name=XSLTProcessor</name>
+    <class-name>mx4j.tools.adaptor.http.XSLTProcessor</class-name>
+  </service>
+  <service>
+    <name>:Name=HttpAdaptor</name>
+    <class-name>mx4j.tools.adaptor.http.HttpAdaptor</class-name>
+    <attribute>
+      <name>Port</name>
+      <value type="java.lang.Integer">8180</value>
+    </attribute>
+    <attribute>
+      <name>Host</name>
+      <value type="java.lang.String">127.0.0.1</value>
+    </attribute>
+    <attribute>
+      <name>ProcessorName</name>
+      <value type="javax.management.ObjectName">:Name=XSLTProcessor</value>
+    </attribute>
+    <attribute>
+      <name>AuthenticationMethod</name>
+      <value type="java.lang.String">basic</value>
+    </attribute>
+    <invoke at="start" pass="0" method="addAuthorization">
+      <argument type="java.lang.String">admin</argument>
+      <argument type="java.lang.String">admin</argument>
+    </invoke>
+    <invoke at="start" pass="0" method="start"/>
+  </service>
+  <service>
+    <name>:Name=HttpAdaptorMgmt</name>
+    <class-name>mx4j.tools.adaptor.http.HttpAdaptor</class-name>
+    <attribute>
+      <name>Port</name>
+      <value type="java.lang.Integer">8181</value>
+    </attribute>
+    <attribute>
+      <name>Host</name>
+      <value type="java.lang.String">127.0.0.1</value>
+    </attribute>
+    <attribute>
+      <name>AuthenticationMethod</name>
+      <value type="java.lang.String">basic</value>
+    </attribute>
+    <invoke at="start" pass="0" method="addAuthorization">
+      <argument type="java.lang.String">manager</argument>
+      <argument type="java.lang.String">manager</argument>
+    </invoke>
+    <invoke at="start" pass="0" method="start"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Manager</name>
+    <class-name>org.opennms.netmgt.vmmgr.Manager</class-name>
+    <invoke at="stop" pass="1" method="doSystemExit"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=TestLoadLibraries</name>
+    <class-name>org.opennms.netmgt.vmmgr.Manager</class-name>
+    <invoke at="start" pass="0" method="doTestLoadLibraries"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Eventd</name>
+    <class-name>org.opennms.netmgt.eventd.jmx.Eventd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Trapd</name>
+    <class-name>org.opennms.netmgt.trapd.jmx.Trapd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Queued</name>
+    <class-name>org.opennms.netmgt.queued.jmx.Queued</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <!--  Dhcpd is now distributed separately. You will need to ensure
+        it is installed before you enable it here. -->
+  <service enabled="false">
+    <name>OpenNMS:Name=Dhcpd</name>
+    <class-name>org.opennms.netmgt.dhcpd.jmx.Dhcpd</class-name>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Actiond</name>
+    <class-name>org.opennms.netmgt.actiond.jmx.Actiond</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service enabled="false">
+    <name>OpenNMS:Name=Capsd</name>
+    <class-name>org.opennms.netmgt.capsd.jmx.Capsd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Notifd</name>
+    <class-name>org.opennms.netmgt.notifd.jmx.Notifd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Scriptd</name>
+    <class-name>org.opennms.netmgt.scriptd.jmx.Scriptd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Rtcd</name>
+    <class-name>org.opennms.netmgt.rtc.jmx.Rtcd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Pollerd</name>
+    <class-name>org.opennms.netmgt.poller.jmx.Pollerd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=PollerBackEnd</name>
+    <class-name>org.opennms.netmgt.poller.remote.jmx.RemotePollerBackEnd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service enabled="false">
+     <name>OpenNMS:Name=SnmpPoller</name>
+     <class-name>org.opennms.netmgt.snmpinterfacepoller.jmx.SnmpPollerd</class-name>
+     <invoke at="start" pass="0" method="init"/>
+     <invoke at="start" pass="1" method="start"/>
+     <invoke at="status" pass="0" method="status"/>
+     <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=EnhancedLinkd</name>
+    <class-name>org.opennms.netmgt.enlinkd.jmx.EnhancedLinkd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Ticketer</name>
+    <class-name>org.opennms.netmgt.ticketd.jmx.TroubleTicketer</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Collectd</name>
+    <class-name>org.opennms.netmgt.collectd.jmx.Collectd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Discovery</name>
+    <class-name>org.opennms.netmgt.discovery.jmx.Discovery</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Vacuumd</name>
+    <class-name>org.opennms.netmgt.vacuumd.jmx.Vacuumd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=EventTranslator</name>
+    <class-name>org.opennms.netmgt.translator.jmx.EventTranslator</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=PassiveStatusd</name>
+    <class-name>org.opennms.netmgt.passive.jmx.PassiveStatusd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Statsd</name>
+    <class-name>org.opennms.netmgt.statsd.jmx.Statsd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Provisiond</name>
+    <class-name>org.opennms.netmgt.daemon.SimpleSpringContextJmxServiceDaemon</class-name>
+    <attribute>
+      <name>LoggingPrefix</name>
+      <value type="java.lang.String">provisiond</value>
+    </attribute>
+    <attribute>
+      <name>SpringContext</name>
+      <value type="java.lang.String">provisiondContext</value>
+    </attribute>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Reportd</name>
+    <class-name>org.opennms.netmgt.daemon.SimpleSpringContextJmxServiceDaemon</class-name>
+    <attribute>
+      <name>LoggingPrefix</name>
+      <value type="java.lang.String">reportd</value>
+    </attribute>
+    <attribute>
+      <name>SpringContext</name>
+      <value type="java.lang.String">reportdContext</value>
+    </attribute>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Alarmd</name>
+    <class-name>org.opennms.netmgt.daemon.SimpleSpringContextJmxServiceDaemon</class-name>
+    <attribute>
+      <name>LoggingPrefix</name>
+      <value type="java.lang.String">alarmd</value>
+    </attribute>
+    <attribute>
+      <name>SpringContext</name>
+      <value type="java.lang.String">alarmdContext</value>
+    </attribute>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Ackd</name>
+    <class-name>org.opennms.netmgt.daemon.SimpleSpringContextJmxServiceDaemon</class-name>
+    <attribute>
+      <name>LoggingPrefix</name>
+      <value type="java.lang.String">ackd</value>
+    </attribute>
+    <attribute>
+      <name>SpringContext</name>
+      <value type="java.lang.String">ackdContext</value>
+    </attribute>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=JettyServer</name>
+    <class-name>org.opennms.netmgt.jetty.jmx.JettyServer</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service enabled="false">
+    <name>OpenNMS:Name=Linkd</name>
+    <class-name>org.opennms.netmgt.linkd.jmx.Linkd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service enabled="false">
+    <name>OpenNMS:Name=Correlator</name>
+    <class-name>org.opennms.netmgt.correlation.jmx.Correlator</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service enabled="false">
+    <name>OpenNMS:Name=Tl1d</name>
+    <class-name>org.opennms.netmgt.tl1d.jmx.Tl1d</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service enabled="false">
+    <name>OpenNMS:Name=Syslogd</name>
+    <class-name>org.opennms.netmgt.syslogd.jmx.Syslogd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service enabled="false">
+    <name>OpenNMS:Name=Xmlrpcd</name>
+    <class-name>org.opennms.netmgt.xmlrpcd.jmx.Xmlrpcd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service enabled="false">
+    <name>OpenNMS:Name=XmlrpcProvisioner</name>
+    <class-name>org.opennms.netmgt.xmlrpcd.jmx.Provisioner</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service enabled="false">
+    <name>OpenNMS:Name=AsteriskGateway</name>
+    <class-name>org.opennms.netmgt.asterisk.agi.jmx.AsteriskGateway</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <!--  AccessPointMonitor is now distributed separately. You will need to ensure
+        it is installed before you enable it here. -->
+  <service enabled="false">
+    <name>OpenNMS:Name=AccessPointMonitor</name>
+    <class-name>org.opennms.netmgt.accesspointmonitor.jmx.AccessPointMonitor</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+</service-configuration>

--- a/core/upgrade/src/test/resources/etc/service-configuration-16.0.4.xml
+++ b/core/upgrade/src/test/resources/etc/service-configuration-16.0.4.xml
@@ -1,0 +1,361 @@
+<?xml version="1.0"?>
+<!-- NOTE!!!!!!!!!!!!!!!!!!!
+The order in which these services are specified is important - for example, Eventd
+will need to come up last so that none of the event topic subcribers loose any event.
+
+When splitting services to run on mutiple VMs, the order of the services should be
+maintained
+-->
+<service-configuration xmlns="http://xmlns.opennms.org/xsd/config/vmmgr">
+  <service>
+    <name>:Name=XSLTProcessor</name>
+    <class-name>mx4j.tools.adaptor.http.XSLTProcessor</class-name>
+  </service>
+  <service>
+    <name>:Name=HttpAdaptor</name>
+    <class-name>mx4j.tools.adaptor.http.HttpAdaptor</class-name>
+    <attribute>
+      <name>Port</name>
+      <value type="java.lang.Integer">8180</value>
+    </attribute>
+    <attribute>
+      <name>Host</name>
+      <value type="java.lang.String">127.0.0.1</value>
+    </attribute>
+    <attribute>
+      <name>ProcessorName</name>
+      <value type="javax.management.ObjectName">:Name=XSLTProcessor</value>
+    </attribute>
+    <attribute>
+      <name>AuthenticationMethod</name>
+      <value type="java.lang.String">basic</value>
+    </attribute>
+    <invoke at="start" pass="0" method="addAuthorization">
+      <argument type="java.lang.String">admin</argument>
+      <argument type="java.lang.String">admin</argument>
+    </invoke>
+    <invoke at="start" pass="0" method="start"/>
+  </service>
+  <service>
+    <name>:Name=HttpAdaptorMgmt</name>
+    <class-name>mx4j.tools.adaptor.http.HttpAdaptor</class-name>
+    <attribute>
+      <name>Port</name>
+      <value type="java.lang.Integer">8181</value>
+    </attribute>
+    <attribute>
+      <name>Host</name>
+      <value type="java.lang.String">127.0.0.1</value>
+    </attribute>
+    <attribute>
+      <name>AuthenticationMethod</name>
+      <value type="java.lang.String">basic</value>
+    </attribute>
+    <invoke at="start" pass="0" method="addAuthorization">
+      <argument type="java.lang.String">manager</argument>
+      <argument type="java.lang.String">manager</argument>
+    </invoke>
+    <invoke at="start" pass="0" method="start"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Manager</name>
+    <class-name>org.opennms.netmgt.vmmgr.Manager</class-name>
+    <invoke at="stop" pass="1" method="doSystemExit"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=TestLoadLibraries</name>
+    <class-name>org.opennms.netmgt.vmmgr.Manager</class-name>
+    <invoke at="start" pass="0" method="doTestLoadLibraries"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Eventd</name>
+    <class-name>org.opennms.netmgt.eventd.jmx.Eventd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Trapd</name>
+    <class-name>org.opennms.netmgt.trapd.jmx.Trapd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Queued</name>
+    <class-name>org.opennms.netmgt.queued.jmx.Queued</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <!--  Dhcpd is now distributed separately. You will need to ensure
+        it is installed before you enable it here. -->
+  <service enabled="false">
+    <name>OpenNMS:Name=Dhcpd</name>
+    <class-name>org.opennms.netmgt.dhcpd.jmx.Dhcpd</class-name>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Actiond</name>
+    <class-name>org.opennms.netmgt.actiond.jmx.Actiond</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Notifd</name>
+    <class-name>org.opennms.netmgt.notifd.jmx.Notifd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Scriptd</name>
+    <class-name>org.opennms.netmgt.scriptd.jmx.Scriptd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Rtcd</name>
+    <class-name>org.opennms.netmgt.rtc.jmx.Rtcd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Pollerd</name>
+    <class-name>org.opennms.netmgt.poller.jmx.Pollerd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=PollerBackEnd</name>
+    <class-name>org.opennms.netmgt.poller.remote.jmx.RemotePollerBackEnd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service enabled="false">
+     <name>OpenNMS:Name=SnmpPoller</name>
+     <class-name>org.opennms.netmgt.snmpinterfacepoller.jmx.SnmpPollerd</class-name>
+     <invoke at="start" pass="0" method="init"/>
+     <invoke at="start" pass="1" method="start"/>
+     <invoke at="status" pass="0" method="status"/>
+     <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=EnhancedLinkd</name>
+    <class-name>org.opennms.netmgt.enlinkd.jmx.EnhancedLinkd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Ticketer</name>
+    <class-name>org.opennms.netmgt.ticketd.jmx.TroubleTicketer</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Collectd</name>
+    <class-name>org.opennms.netmgt.collectd.jmx.Collectd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Discovery</name>
+    <class-name>org.opennms.netmgt.discovery.jmx.Discovery</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Vacuumd</name>
+    <class-name>org.opennms.netmgt.vacuumd.jmx.Vacuumd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=EventTranslator</name>
+    <class-name>org.opennms.netmgt.translator.jmx.EventTranslator</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=PassiveStatusd</name>
+    <class-name>org.opennms.netmgt.passive.jmx.PassiveStatusd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Statsd</name>
+    <class-name>org.opennms.netmgt.statsd.jmx.Statsd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Provisiond</name>
+    <class-name>org.opennms.netmgt.daemon.SimpleSpringContextJmxServiceDaemon</class-name>
+    <attribute>
+      <name>LoggingPrefix</name>
+      <value type="java.lang.String">provisiond</value>
+    </attribute>
+    <attribute>
+      <name>SpringContext</name>
+      <value type="java.lang.String">provisiondContext</value>
+    </attribute>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Reportd</name>
+    <class-name>org.opennms.netmgt.daemon.SimpleSpringContextJmxServiceDaemon</class-name>
+    <attribute>
+      <name>LoggingPrefix</name>
+      <value type="java.lang.String">reportd</value>
+    </attribute>
+    <attribute>
+      <name>SpringContext</name>
+      <value type="java.lang.String">reportdContext</value>
+    </attribute>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Alarmd</name>
+    <class-name>org.opennms.netmgt.daemon.SimpleSpringContextJmxServiceDaemon</class-name>
+    <attribute>
+      <name>LoggingPrefix</name>
+      <value type="java.lang.String">alarmd</value>
+    </attribute>
+    <attribute>
+      <name>SpringContext</name>
+      <value type="java.lang.String">alarmdContext</value>
+    </attribute>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Ackd</name>
+    <class-name>org.opennms.netmgt.daemon.SimpleSpringContextJmxServiceDaemon</class-name>
+    <attribute>
+      <name>LoggingPrefix</name>
+      <value type="java.lang.String">ackd</value>
+    </attribute>
+    <attribute>
+      <name>SpringContext</name>
+      <value type="java.lang.String">ackdContext</value>
+    </attribute>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=JettyServer</name>
+    <class-name>org.opennms.netmgt.jetty.jmx.JettyServer</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service enabled="false">
+    <name>OpenNMS:Name=Linkd</name>
+    <class-name>org.opennms.netmgt.linkd.jmx.Linkd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service enabled="false">
+    <name>OpenNMS:Name=Correlator</name>
+    <class-name>org.opennms.netmgt.correlation.jmx.Correlator</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service enabled="false">
+    <name>OpenNMS:Name=Tl1d</name>
+    <class-name>org.opennms.netmgt.tl1d.jmx.Tl1d</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service enabled="false">
+    <name>OpenNMS:Name=Syslogd</name>
+    <class-name>org.opennms.netmgt.syslogd.jmx.Syslogd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service enabled="false">
+    <name>OpenNMS:Name=Xmlrpcd</name>
+    <class-name>org.opennms.netmgt.xmlrpcd.jmx.Xmlrpcd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service enabled="false">
+    <name>OpenNMS:Name=XmlrpcProvisioner</name>
+    <class-name>org.opennms.netmgt.xmlrpcd.jmx.Provisioner</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service enabled="false">
+    <name>OpenNMS:Name=AsteriskGateway</name>
+    <class-name>org.opennms.netmgt.asterisk.agi.jmx.AsteriskGateway</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <!--  AccessPointMonitor is now distributed separately. You will need to ensure
+        it is installed before you enable it here. -->
+  <service enabled="false">
+    <name>OpenNMS:Name=AccessPointMonitor</name>
+    <class-name>org.opennms.netmgt.accesspointmonitor.jmx.AccessPointMonitor</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+</service-configuration>

--- a/tools/packages/opennms/opennms.spec
+++ b/tools/packages/opennms/opennms.spec
@@ -242,6 +242,26 @@ external JMS listener.
 %{extrainfo2}
 
 
+%package plugin-provisioning-map
+Summary:	Obsolete: Map Provisioning Adapter
+Group:		Applications/System
+Requires(pre):	%{name}-core = %{version}-%{release}
+Requires:	%{name}-core = %{version}-%{release}
+
+%description plugin-provisioning-map
+The map provisioning adapter is no longer part of OpenNMS.
+
+
+%package plugin-provisioning-link
+Summary:	Obsolete: Link Provisioning Adapter
+Group:		Applications/System
+Requires(pre):	%{name}-core = %{version}-%{release}
+Requires:	%{name}-core = %{version}-%{release}
+
+%description plugin-provisioning-link
+The map provisioning adapter is no longer part of OpenNMS.
+
+
 %package plugin-provisioning-dns
 Summary:	DNS Provisioning Adapter
 Group:		Applications/System


### PR DESCRIPTION
* Put map and link provisioning adapter packages back in, but empty, for upgrading. (see [here](http://paste.opennms.eu/?3bdd8e3d42e02e3a#qLMk8MEJZz6DsuIW+kAlsrfRLmA8oTHLpZNAfqvf1h8=) for the failure)
* Make the migrator disable Linkd, Xmlrpcd, XmlrpcProvisioner, and AccessPointMonitor if they are enabled since they no longer exist in OpenNMS 17.
* Update the tests to check service-configuration.xml upgrades from 1.8 through 16.