### PR TITLE
HZN-550: Use only first value in X-Forwarded-Host

### DIFF
--- a/opennms-web-api/src/main/java/org/opennms/web/api/Util.java
+++ b/opennms-web-api/src/main/java/org/opennms/web/api/Util.java
@@ -164,9 +164,13 @@ public abstract class Util extends Object {
      */
     public static String getHostHeader(final HttpServletRequest request) {
         for (int i = 0; i < hostHeaders.length; ++i) {
-        	final String ret = request.getHeader(hostHeaders[i]);
-            if (ret != null) {
-                return ret;
+            // Get the first value in the header (support for proxy-chaining)
+            final String header = request.getHeader(hostHeaders[i]);
+            if (header != null) {
+                final String[] values = header.split(", *");
+                if (values.length >= 1) {
+                    return values[0];
+                }
             }
         }
         return request.getServerName() + ":" + Integer.toString(request.getServerPort());

--- a/opennms-web-api/src/test/java/org/opennms/web/api/UtilTest.java
+++ b/opennms-web-api/src/test/java/org/opennms/web/api/UtilTest.java
@@ -10,6 +10,8 @@ import junit.framework.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import org.springframework.mock.web.MockHttpServletRequest;
+
 public class UtilTest {
 
     @Before
@@ -27,5 +29,48 @@ public class UtilTest {
     @Test
     public void testFormatDateToUIStringNull()  {
         Assert.assertEquals("", Util.formatDateToUIString(null));
+    }
+
+    @Test
+    public void testDirectHostHeader() {
+        final MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setServerName("direct.example.org");
+        request.setServerPort(1234);
+
+        final String host = Util.getHostHeader(request);
+
+        Assert.assertEquals("direct.example.org:1234", host);
+    }
+
+    @Test
+    public void testForwardedHostHeader() {
+        final MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("X-Forwarded-Host", "first.example.org");
+
+        final String host = Util.getHostHeader(request);
+
+        Assert.assertEquals("first.example.org", host);
+    }
+
+    @Test
+    public void testMultivaluedForwardedHostHeader() {
+        final MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("X-Forwarded-Host", "first.example.org, second.example.org, third.example.org");
+
+        final String host = Util.getHostHeader(request);
+
+        Assert.assertEquals("first.example.org", host);
+    }
+
+    @Test
+    public void testMultipleForwardedHostHeader() {
+        final MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("X-Forwarded-Host", "first.example.org");
+        request.addHeader("X-Forwarded-Host", "second.example.org");
+        request.addHeader("X-Forwarded-Host", "third.example.org");
+
+        final String host = Util.getHostHeader(request);
+
+        Assert.assertEquals("first.example.org", host);
     }
 }


### PR DESCRIPTION
The header can contain multiple values in the case of proxy chaining.
The first value is the on of the outer-most proxy.

JIRA: http://jira.opennms.org/browse/HZN-550
Bamboo: http://bamboo.internal.opennms.com:8085/browse/OPENNMS-ONMS312