### PR TITLE
NMS-8028: Add event definition for postfix syslog message TLS disabled

### DIFF
--- a/opennms-base-assembly/src/main/filtered/etc/events/Postfix.syslog.events.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/events/Postfix.syslog.events.xml
@@ -16,8 +16,24 @@
         <logmsg dest="logndisplay">
             &lt;p&gt;Postfix: Obsolete database file %parm[databaseName]% on node %nodelabel%&lt;/p&gt;
         </logmsg>
-        <severity>Minor</severity>
+        <severity>Warning</severity>
         <alarm-data reduction-key="%uei%:%dpname%:%nodeid%:%parm[databaseName]%" alarm-type="3" auto-clean="false"/>
+    </event>
+    <event>
+        <uei>uei.opennms.org/vendor/postfix/syslog/postfix/TLSDisabled</uei>
+        <event-label>Postfix-defined event: TLS support disabled</event-label>
+        <descr>
+            &lt;p&gt;TLS support has been disabled in postfix on node %nodelabel%. Most probably because of a configuration error.&lt;br&gt;
+            Message: %parm[syslogmessage]% &lt;br&gt;
+            Process: %parm[process]% &lt;br&gt;
+            PID: %parm[processid]%
+            &lt;/p&gt;
+        </descr>
+        <logmsg dest="logndisplay">
+            &lt;p&gt;Postfix: TLS support disabled on node %nodelabel%&lt;/p&gt;
+        </logmsg>
+        <severity>Warning</severity>
+        <alarm-data reduction-key="%uei%:%dpname%:%nodeid%" alarm-type="3" auto-clean="false"/>
     </event>
     <!-- End syslog event definitions for Postfix  -->
 </events>

--- a/opennms-base-assembly/src/main/filtered/etc/syslog/Postfix.syslog.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/syslog/Postfix.syslog.xml
@@ -9,5 +9,10 @@
             <parameter-assignment matching-group="1" parameter-name="databaseName"/>
             <parameter-assignment matching-group="1" parameter-name="sourceFile"/>
         </ueiMatch>
+        <ueiMatch>
+            <process-match expression="^postfix.*$"/>
+            <match type="substr" expression="disabling TLS support"/>
+            <uei>uei.opennms.org/vendor/postfix/syslog/postfix/TLSDisabled</uei>
+        </ueiMatch>
     </ueiList>
 </syslogd-configuration-group>


### PR DESCRIPTION
Added an event definition for a postfix related syslog message indicating that expected/configuring TLS support has been disabled.

Also lowered severity of event uei.opennms.org/vendor/postfix/syslog/postfix/obsoleteDatabase from Minor to Warning, which seems more appropriate.

JIRA: http://issues.opennms.org/browse/NMS-8028
Bamboo: http://bamboo.internal.opennms.com:8085/browse/OPENNMS-ONMS401-1