### PR TITLE
NMS-8044: Link support for Microsoft RDP on node page

### DIFF
--- a/opennms-base-assembly/src/main/filtered/etc/poller-configuration.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/poller-configuration.xml
@@ -268,7 +268,13 @@
       <parameter key="timeout" value="3000"/>
       <parameter key="ignoreStandBy" value="false"/>
     </service>
-
+    <service name="MS-RDP" interval="300000" user-defined="false" status="on">
+      <parameter key="retry" value="1" />
+      <parameter key="banner" value="*" />
+      <parameter key="port" value="3389" />
+      <parameter key="timeout" value="3000" />
+    </service>
+ 
     <downtime interval="30000" begin="0" end="300000" /><!-- 30s, 0, 5m -->
     <downtime interval="300000" begin="300000" end="43200000" /><!-- 5m, 5m, 12h -->
     <downtime interval="600000" begin="43200000" end="432000000" /><!-- 10m, 12h, 5d -->
@@ -333,4 +339,5 @@
   <monitor service="OpenNMS-JVM" class-name="org.opennms.netmgt.poller.monitors.Jsr160Monitor" />
   <monitor service="VMwareCim-HostSystem" class-name="org.opennms.netmgt.poller.monitors.VmwareCimMonitor"/>
   <monitor service="VMware-ManagedEntity" class-name="org.opennms.netmgt.poller.monitors.VmwareMonitor"/>
+  <monitor service="MS-RDP" class-name="org.opennms.netmgt.poller.monitors.TcpMonitor" />
 </poller-configuration>

--- a/opennms-provision/opennms-provision-persistence/src/main/resources/org/opennms/netmgt/provision/persist/default-foreign-source.xml
+++ b/opennms-provision/opennms-provision-persistence/src/main/resources/org/opennms/netmgt/provision/persist/default-foreign-source.xml
@@ -48,5 +48,8 @@
 			<parameter key="type" value="default"/>
 			<parameter key="object" value="org.apache.cassandra.db:type=ColumnFamilies,keyspace=newts,columnfamily=samples"/>
 		</detector>
+		<detector name="MS-RDP" class="org.opennms.netmgt.provision.detector.simple.TcpDetector">
+			<parameter key="port" value="3389"/>
+		</detector>
 	</detectors>
 </foreign-source>

--- a/opennms-webapp/src/main/webapp/element/node.jsp
+++ b/opennms-webapp/src/main/webapp/element/node.jsp
@@ -67,6 +67,7 @@
     private int m_sshServiceId;
     private int m_httpServiceId;
     private int m_dellServiceId;
+    private int m_rdpServiceId;
     private int m_snmpServiceId;
     private ResourceService m_resourceService;
 	private AssetModel m_model = new AssetModel();
@@ -95,6 +96,13 @@
         } catch (Throwable e) {
             throw new ServletException("Could not determine the Dell-OpenManage service ID", e);
         }
+
+        try {
+            m_rdpServiceId = NetworkElementFactory.getInstance(getServletContext()).getServiceIdFromName("MS-RDP");
+        } catch (Throwable e) {
+            throw new ServletException("Could not determine the Mirosoft Remote Desktop service ID", e);
+        }
+
 
         try {
             m_snmpServiceId = NetworkElementFactory.getInstance(getServletContext()).getServiceIdFromName("SNMP");
@@ -162,6 +170,7 @@
     links.addAll(createLinkForService(nodeId, m_sshServiceId, "SSH", "ssh://", "", getServletContext()));
     links.addAll(createLinkForService(nodeId, m_httpServiceId, "HTTP", "http://", "/", getServletContext()));
     links.addAll(createLinkForService(nodeId, m_dellServiceId, "OpenManage", "https://", ":1311", getServletContext()));
+    links.addAll(createLinkForService(nodeId, m_rdpServiceId, "Microsoft RDP", "rdp://", ":3389", getServletContext()));
     nodeModel.put("links", links);
 
     Asset asset = m_model.getAsset(nodeId);


### PR DESCRIPTION
The OpenNMS node page provides links for customized URL handler for example for ssh://, telnet://. The node page is extended to support also Microsoft RDP protocol with rdp://. The link is generated based on the MS-RDP service. To allow easier integration a default TCP detector and a TCP monitor for MS-RDP service is created.

JIRA: http://issues.opennms.org/browse/NMS-8044
Bamboo: http://bamboo.internal.opennms.com:8085/browse/OPENNMS-ONMS402