### PR TITLE
HZN-563: Improve flexibility to the syslog alarm northbounder

### DIFF
--- a/features/ncs/ncs-northbounder/src/main/java/org/opennms/netmgt/ncs/northbounder/NCSNorthbounder.java
+++ b/features/ncs/ncs-northbounder/src/main/java/org/opennms/netmgt/ncs/northbounder/NCSNorthbounder.java
@@ -34,7 +34,6 @@ import java.io.OutputStreamWriter;
 import java.net.URI;
 import java.security.GeneralSecurityException;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -102,7 +101,7 @@ public class NCSNorthbounder extends AbstractNorthbounder {
 
         if(m_config.getAcceptableUeis() != null && m_config.getAcceptableUeis().size() != 0 && !m_config.getAcceptableUeis().contains(alarm.getUei())) return false;
 
-        Map<String, String> alarmParms = getParameterMap(alarm.getEventParms());
+        final Map<String, String> alarmParms = alarm.getParameters();
 
         // in order to determine the service we need to have the following parameters set in the events
         if (!alarmParms.containsKey(COMPONENT_TYPE)) return false;
@@ -132,40 +131,13 @@ public class NCSNorthbounder extends AbstractNorthbounder {
     private ServiceAlarm toServiceAlarm(NorthboundAlarm alarm) {
         AlarmType alarmType = alarm.getAlarmType();
 
-        Map<String, String> alarmParms = getParameterMap(alarm.getEventParms());
+        final Map<String, String> alarmParms = alarm.getParameters();
 
         String id = alarmParms.get(COMPONENT_FOREIGN_SOURCE)+":"+alarmParms.get(COMPONENT_FOREIGN_ID);
         String name = alarmParms.get(COMPONENT_NAME);
 
         return new ServiceAlarm(id, name, alarmType == AlarmType.PROBLEM ? "Down" : "Up");
     }
-
-    Map<String, String> getParameterMap(String parmString) {
-
-        Map<String, String> parmMap = new HashMap<String, String>();
-
-        String[] parms = parmString.split(";");
-
-        for(String parm : parms) {
-            if (parm.endsWith("(string,text)")) {
-                // we only include string valued keys in the map
-                parm = parm.substring(0, parm.length()-"(string,text)".length());
-
-                int eq = parm.indexOf('=');
-                if (0 < eq && eq < parm.length()) {
-                    String key = parm.substring(0, eq);
-                    String val = parm.substring(eq+1);
-                    parmMap.put(key, val);
-                }
-            }
-        }
-
-        return parmMap;
-
-    }
-
-
-
 
     @Override
     public void forwardAlarms(List<NorthboundAlarm> alarms) throws NorthbounderException {

--- a/opennms-alarms/api/src/main/java/org/opennms/netmgt/alarmd/api/Northbounder.java
+++ b/opennms-alarms/api/src/main/java/org/opennms/netmgt/alarmd/api/Northbounder.java
@@ -48,4 +48,5 @@ public interface Northbounder {
     
     public String getName();
     
+    public void reloadConfig();
 }

--- a/opennms-alarms/api/src/main/java/org/opennms/netmgt/alarmd/api/support/AbstractNorthbounder.java
+++ b/opennms-alarms/api/src/main/java/org/opennms/netmgt/alarmd/api/support/AbstractNorthbounder.java
@@ -68,6 +68,7 @@ public abstract class AbstractNorthbounder implements Northbounder, Runnable,
     protected AbstractNorthbounder(String name) {
         m_name = name;
         m_queue = new AlarmQueue<NorthboundAlarm>(this);
+        LOG.debug("Creating Northbounder instance {}", getName());
     }
 
     @Override

--- a/opennms-alarms/api/src/main/java/org/opennms/netmgt/alarmd/api/support/AbstractNorthbounder.java
+++ b/opennms-alarms/api/src/main/java/org/opennms/netmgt/alarmd/api/support/AbstractNorthbounder.java
@@ -135,6 +135,10 @@ public abstract class AbstractNorthbounder implements Northbounder, Runnable,
     protected void onStop() {
     }
 
+    /** Override this to perform actions when reloading the configuration. **/
+    public void reloadConfig() {
+    }
+
     @Override
     public final void stop() throws NorthbounderException {
         this.onStop();

--- a/opennms-alarms/api/src/main/java/org/opennms/netmgt/alarmd/api/support/AbstractNorthbounder.java
+++ b/opennms-alarms/api/src/main/java/org/opennms/netmgt/alarmd/api/support/AbstractNorthbounder.java
@@ -29,17 +29,15 @@
 package org.opennms.netmgt.alarmd.api.support;
 
 import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.lang.StringUtils;
 import org.opennms.netmgt.alarmd.api.NorthboundAlarm;
 import org.opennms.netmgt.alarmd.api.NorthboundAlarm.AlarmType;
 import org.opennms.netmgt.alarmd.api.NorthboundAlarm.x733ProbableCause;
 import org.opennms.netmgt.alarmd.api.Northbounder;
 import org.opennms.netmgt.alarmd.api.NorthbounderException;
-import org.opennms.netmgt.dao.api.NodeDao;
+import org.opennms.netmgt.xml.event.Parm;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -62,7 +60,6 @@ public abstract class AbstractNorthbounder implements Northbounder, Runnable,
     private static final Logger LOG = LoggerFactory.getLogger(AbstractNorthbounder.class);
     private final String m_name;
     private final AlarmQueue<NorthboundAlarm> m_queue;
-    protected NodeDao m_nodeDao;
     
     private volatile boolean m_stopped = true;
 
@@ -71,14 +68,6 @@ public abstract class AbstractNorthbounder implements Northbounder, Runnable,
     protected AbstractNorthbounder(String name) {
         m_name = name;
         m_queue = new AlarmQueue<NorthboundAlarm>(this);
-    }
-
-    public NodeDao getNodeDao() {
-        return m_nodeDao;
-    }
-
-    public void setNodeDao(NodeDao nodeDao) {
-        m_nodeDao = nodeDao;
     }
 
     @Override
@@ -222,11 +211,16 @@ public abstract class AbstractNorthbounder implements Northbounder, Runnable,
         if (alarm.getNodeId() != null) {
             LOG.debug("Adding nodeId: " + alarm.getNodeId().toString());
             mapping.put("nodeId", alarm.getNodeId().toString());
-            String nodeLabel = m_nodeDao.getLabelForId(alarm.getNodeId());
-            mapping.put("nodeLabel", nodeLabel == null ? "?" : nodeLabel);
+            mapping.put("nodeLabel", alarm.getNodeLabel() == null ? "?" : alarm.getNodeLabel());
+            mapping.put("nodeSysObjectId", alarm.getNodeSysObjectId() == null ? "?" : alarm.getNodeSysObjectId());
+            mapping.put("foreignSource", alarm.getForeignSource() == null ? "?" : alarm.getForeignSource());
+            mapping.put("foreignId", alarm.getForeignId() == null ? "?" : alarm.getForeignId());
         } else {
             mapping.put("nodeId", "");
             mapping.put("nodeLabel", "");
+            mapping.put("nodeSysObjectId", "");
+            mapping.put("foreignSource", "");
+            mapping.put("foreignId", "");
         }
 
         String poller = alarm.getPoller() == null ? "localhost"
@@ -265,54 +259,16 @@ public abstract class AbstractNorthbounder implements Northbounder, Runnable,
         return defaultString;
     }
 
-    private void buildParmMappings(final NorthboundAlarm alarm,
-            final Map<String, Object> mapping) {
-        List<EventParm<?>> parmCollection = new LinkedList<EventParm<?>>();
-        String parms = alarm.getEventParms();
-        if (parms == null)
+    private void buildParmMappings(final NorthboundAlarm alarm, final Map<String, Object> mapping) {
+        if (alarm.getParameters().isEmpty()) {
             return;
-
-        char separator = ';';
-        String[] parmArray = StringUtils.split(parms, separator);
-        for (String string : parmArray) {
-
-            char nameValueDelim = '=';
-            String[] nameValueArray = StringUtils.split(string,
-                                                        nameValueDelim);
-            String parmName = nameValueArray[0];
-            String parmValue = StringUtils.split(nameValueArray[1], '(')[0];
-
-            EventParm<String> eventParm = new EventParm<String>(parmName,
-                                                                parmValue);
-            parmCollection.add(eventParm);
         }
-
-        for (int i = 0; i < parmCollection.size(); i++) {
-            EventParm<?> parm = parmCollection.get(i);
-            Integer parmOffset = i + 1;
+        int parmOffset = 1;
+        for (Parm parm : alarm.getEventParametersCollection()) {
             mapping.put("parm[name-#" + parmOffset + "]", parm.getParmName());
-            mapping.put("parm[#" + parmOffset + "]",
-                        parm.getParmValue().toString());
-            mapping.put("parm[" + parm.getParmName() + "]",
-                        parm.getParmValue().toString());
-        }
-    }
-
-    private static class EventParm<T extends Object> {
-        private String m_parmName;
-        private T m_parmValue;
-
-        EventParm(String name, T value) {
-            m_parmName = name;
-            m_parmValue = value;
-        }
-
-        public String getParmName() {
-            return m_parmName;
-        }
-
-        public T getParmValue() {
-            return (T) m_parmValue;
+            mapping.put("parm[#" + parmOffset + "]", parm.getValue().getContent());
+            mapping.put("parm[" + parm.getParmName() + "]", parm.getValue().getContent());
+            parmOffset++;
         }
     }
 

--- a/opennms-alarms/daemon/src/main/java/org/opennms/netmgt/alarmd/AlarmPersisterImpl.java
+++ b/opennms-alarms/daemon/src/main/java/org/opennms/netmgt/alarmd/AlarmPersisterImpl.java
@@ -95,6 +95,10 @@ public class AlarmPersisterImpl implements AlarmPersister {
             }
         }
         
+        if (alarm.getNodeId() != null) {
+            alarm.getNode().getForeignSource(); // This should trigger the lazy loading of the node object, to properly populate the NorthboundAlarm class.
+        }
+
         return alarm;
     }
 

--- a/opennms-alarms/daemon/src/main/java/org/opennms/netmgt/alarmd/Alarmd.java
+++ b/opennms-alarms/daemon/src/main/java/org/opennms/netmgt/alarmd/Alarmd.java
@@ -118,6 +118,7 @@ public class Alarmd implements SpringServiceDaemon, DisposableBean {
     				if (parm.getValue().getContent().contains(nbi.getName())) {
     					LOG.debug("Handling reload event for NBI: {}", nbi.getName());
     					LOG.debug("Reloading NBI configuration for interface {} not yet implemented.", nbi.getName());
+    					nbi.reloadConfig();
     					return;
     				}
     			}

--- a/opennms-alarms/daemon/src/main/java/org/opennms/netmgt/alarmd/Alarmd.java
+++ b/opennms-alarms/daemon/src/main/java/org/opennms/netmgt/alarmd/Alarmd.java
@@ -81,7 +81,8 @@ public class Alarmd implements SpringServiceDaemon, DisposableBean {
     public void onEvent(Event e) {
     	
     	if (e.getUei().equals("uei.opennms.org/internal/reloadDaemonConfig")) {
-    		return;
+           handleReloadEvent(e);
+           return;
     	}
     	
         OnmsAlarm alarm = m_persister.persist(e);
@@ -96,7 +97,6 @@ public class Alarmd implements SpringServiceDaemon, DisposableBean {
         
     }
 
-    @EventHandler(uei = "uei.opennms.org/internal/reloadDaemonConfig")
     private void handleReloadEvent(Event e) {
     	LOG.info("Received reload configuration event: {}", e);
 

--- a/opennms-alarms/daemon/src/test/java/org/opennms/netmgt/alarmd/AlarmdIT.java
+++ b/opennms-alarms/daemon/src/test/java/org/opennms/netmgt/alarmd/AlarmdIT.java
@@ -118,10 +118,15 @@ public class AlarmdIT implements TemporaryDatabaseAware<MockDatabase>, Initializ
             return m_alarms;
         }
 
-		@Override
-		public String getName() {
-			return "MockNorthbounder";
-		}
+        @Override
+        public String getName() {
+            return "MockNorthbounder";
+        }
+
+        @Override
+        public void reloadConfig() {
+        }
+
     }
 
     private MockNetwork m_mockNetwork = new MockNetwork();

--- a/opennms-alarms/jms-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/jms/JmsNorthbounderManager.java
+++ b/opennms-alarms/jms-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/jms/JmsNorthbounderManager.java
@@ -77,7 +77,6 @@ public class JmsNorthbounderManager implements InitializingBean,
                                                       config,
                                                       m_jmsNorthbounderConnectionFactory,
                                                       jmsDestination);
-            nbi.setNodeDao(m_nodeDao);
             nbi.afterPropertiesSet();
             m_registrations.put(nbi.getName(),
                                 m_serviceRegistry.register(nbi,

--- a/opennms-alarms/jms-northbounder/src/test/java/org/opennms/netmgmt/alarmd/northbounder/jms/JmsNorthBounderTest.java
+++ b/opennms-alarms/jms-northbounder/src/test/java/org/opennms/netmgmt/alarmd/northbounder/jms/JmsNorthBounderTest.java
@@ -126,7 +126,6 @@ public class JmsNorthBounderTest {
                                                       config,
                                                       m_jmsNorthbounderConnectionFactory,
                                                       jmsDestination);
-            nbi.setNodeDao(m_nodeDao);
             nbi.afterPropertiesSet();
             nbis.add(nbi);
         }

--- a/opennms-alarms/syslog-northbounder/pom.xml
+++ b/opennms-alarms/syslog-northbounder/pom.xml
@@ -37,9 +37,9 @@
       <artifactId>opennms-dao</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.syslog4j</groupId>
+      <groupId>org.graylog2</groupId>
       <artifactId>syslog4j</artifactId>
-      <version>0.9.30-ONMS-1.0</version>
+      <version>0.9.53</version>
       <exclusions>
         <exclusion>
           <groupId>commons-pool</groupId>

--- a/opennms-alarms/syslog-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/syslog/SyslogDestination.java
+++ b/opennms-alarms/syslog-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/syslog/SyslogDestination.java
@@ -38,179 +38,365 @@ import javax.xml.bind.annotation.XmlType;
 import org.opennms.netmgt.alarmd.api.Destination;
 
 /**
- * Configuration for the various Syslog hosts to receive alarms via Syslog\
- * 
+ * Configuration for the various Syslog hosts to receive alarms via Syslog.
+ *
  * @author <a href="mailto:david@opennms.org>David Hustace</a>
  */
 @XmlRootElement(name = "syslog-destination")
 @XmlAccessorType(XmlAccessType.FIELD)
 public class SyslogDestination implements Destination {
 
-    /**
-	 * 
-	 */
+    /** The Constant serialVersionUID. */
     private static final long serialVersionUID = 1L;
 
+    /**
+     * The Enumeration SyslogProtocol.
+     */
     @XmlType
     @XmlEnum(String.class)
     public static enum SyslogProtocol {
-        UDP("udp"), TCP("tcp");
 
+        /** The UDP Syslog Protocol. */
+        UDP("udp"),
+        /** The TCP Syslog Protocol. */
+        TCP("tcp");
+
+        /** The m_id. */
         private String m_id;
 
+        /**
+         * Instantiates a new Syslog protocol.
+         *
+         * @param id the id
+         */
         SyslogProtocol(String id) {
             m_id = id;
         }
 
+        /**
+         * Gets the id.
+         *
+         * @return the id
+         */
         public String getId() {
             return m_id;
         }
     }
 
+    /**
+     * The Enumeration SyslogFacility.
+     */
     @XmlType
     @XmlEnum(String.class)
     public static enum SyslogFacility {
-        KERN("KERN"), USER("USER"), MAIL("MAIL"), DAEMON("DAEMON"), AUTH(
-                "AUTH"), SYSLOG("SYSLOG"), LPR("LPR"), NEWS("NEWS"), UUCP(
-                "UUCP"), CRON("CRON"), AUTHPRIV("AUTHPRIV"), FTP("FTP"), LOCAL0(
-                "LOCAL0"), LOCAL1("LOCAL1"), LOCAL2("LOCAL2"), LOCAL3(
-                "LOCAL3"), LOCAL4("LOCAL4"), LOCAL5("LOCAL5"), LOCAL6(
-                "LOCAL6"), LOCAL7("LOCAL7"), ;
 
+        /** The Kernel Syslog Facility. */
+        KERN("KERN"), 
+        /** The User Syslog Facility. */
+        USER("USER"), 
+        /** The Mail Syslog Facility. */
+        MAIL("MAIL"), 
+        /** The Daemon Syslog Facility. */
+        DAEMON("DAEMON"), 
+        /** The Authentication Syslog Facility. */
+        AUTH("AUTH"), 
+        /** The Syslog Syslog Facility. */
+        SYSLOG("SYSLOG"), 
+        /** The LPR Syslog Facility. */
+        LPR("LPR"), 
+        /** The News Syslog Facility. */
+        NEWS("NEWS"), 
+        /** The UUCP Syslog Facility. */
+        UUCP("UUCP"), 
+        /** The CRON Syslog Facility. */
+        CRON("CRON"), 
+        /** The Authpriv Syslog Facility. */
+        AUTHPRIV("AUTHPRIV"), 
+        /** The FTP Syslog Facility. */
+        FTP("FTP"), 
+        /** The LOCAL0 Syslog Facility. */
+        LOCAL0("LOCAL0"), 
+        /** The LOCAL1 Syslog Facility. */
+        LOCAL1("LOCAL1"), 
+        /** The LOCAL2 Syslog Facility. */
+        LOCAL2("LOCAL2"), 
+        /** The LOCAL3 Syslog Facility. */
+        LOCAL3("LOCAL3"), 
+        /** The LOCAL4 Syslog Facility. */
+        LOCAL4("LOCAL4"), 
+        /** The LOCAL5 Syslog Facility. */
+        LOCAL5("LOCAL5"), 
+        /** The LOCAL6 Syslog Facility. */
+        LOCAL6("LOCAL6"), 
+        /** The LOCAL7 Syslog Facility. */
+        LOCAL7("LOCAL7"), ;
+
+        /** The ID. */
         private String m_id;
 
+        /**
+         * Instantiates a new Syslog facility.
+         *
+         * @param facility the facility
+         */
         SyslogFacility(String facility) {
             m_id = facility;
         }
 
+        /**
+         * Gets the id.
+         *
+         * @return the id
+         */
         public String getId() {
             return m_id;
         }
     }
 
+    /** The destination name. */
     @XmlElement(name = "destination-name", required = true)
     private String m_destinationName;
 
+    /** The target Syslog receiver host. */
     @XmlElement(name = "host", defaultValue = "localhost", required = false)
     private String m_host = "localhost";
 
+    /** The target Syslog receiver port. */
     @XmlElement(name = "port", defaultValue = "514", required = false)
     private int m_port = 514;
 
+    /** The target Syslog receiver protocol. */
     @XmlElement(name = "ip-protocol", defaultValue = "udp", required = false)
     private SyslogProtocol m_protocol = SyslogProtocol.UDP;
 
+    /** The target Syslog receiver facility. */
     @XmlElement(name = "facility", defaultValue = "USER", required = false)
     private SyslogFacility m_facility = SyslogFacility.USER;
 
+    /** The message char set. */
     @XmlElement(name = "char-set", defaultValue = "UTF-8", required = false)
     private String m_charSet = "UTF-8";
 
+    /** The max message length. */
     @XmlElement(name = "max-message-length", defaultValue = "1024", required = false)
     private int m_maxMessageLength = 1024;
 
+    /** The send local name flag. */
     @XmlElement(name = "send-local-name", defaultValue = "true", required = false)
     private boolean m_sendLocalName = true;
 
+    /** The send local time flag. */
     @XmlElement(name = "send-local-time", defaultValue = "true", required = false)
     private boolean m_sendLocalTime = true;
 
+    /** The truncate message flag. */
     @XmlElement(name = "truncate-message", defaultValue = "false", required = false)
     private boolean m_truncateMessage = false;
 
+    /** The first occurrence only flag. */
     @XmlElement(name = "first-occurrence-only", defaultValue = "false", required = false)
     private boolean m_firstOccurrenceOnly = false;
 
+    /**
+     * Instantiates a new Syslog destination.
+     */
     public SyslogDestination() {
     }
 
-    public SyslogDestination(String name, SyslogProtocol protocol,
-            SyslogFacility facility) {
+    /**
+     * Instantiates a new Syslog destination.
+     *
+     * @param name the name
+     * @param protocol the protocol
+     * @param facility the facility
+     */
+    public SyslogDestination(String name, SyslogProtocol protocol, SyslogFacility facility) {
         m_destinationName = name;
         m_protocol = protocol;
         m_facility = facility;
     }
 
+    /* (non-Javadoc)
+     * @see org.opennms.netmgt.alarmd.api.Destination#getName()
+     */
     public String getName() {
         return m_destinationName;
     }
 
+    /**
+     * Sets the name.
+     *
+     * @param name the new name
+     */
     public void setName(String name) {
         m_destinationName = name;
     }
 
+    /**
+     * Gets the host.
+     *
+     * @return the host
+     */
     public String getHost() {
         return m_host;
     }
 
+    /**
+     * Sets the host.
+     *
+     * @param m_host the new host
+     */
     public void setHost(String m_host) {
         this.m_host = m_host;
     }
 
+    /**
+     * Gets the port.
+     *
+     * @return the port
+     */
     public int getPort() {
         return m_port;
     }
 
+    /**
+     * Sets the port.
+     *
+     * @param m_port the new port
+     */
     public void setPort(int m_port) {
         this.m_port = m_port;
     }
 
+    /**
+     * Gets the protocol.
+     *
+     * @return the protocol
+     */
     public SyslogProtocol getProtocol() {
         return m_protocol;
     }
 
+    /**
+     * Sets the protocol.
+     *
+     * @param m_protocol the new protocol
+     */
     public void setProtocol(SyslogProtocol m_protocol) {
         this.m_protocol = m_protocol;
     }
 
+    /**
+     * Gets the facility.
+     *
+     * @return the facility
+     */
     public SyslogFacility getFacility() {
         return m_facility;
     }
 
+    /**
+     * Gets the char set.
+     *
+     * @return the char set
+     */
     public String getCharSet() {
         return m_charSet;
     }
 
+    /**
+     * Sets the char set.
+     *
+     * @param charSet the new char set
+     */
     public void setCharSet(String charSet) {
         m_charSet = charSet;
     }
 
+    /**
+     * Gets the max message length.
+     *
+     * @return the max message length
+     */
     public int getMaxMessageLength() {
         return m_maxMessageLength;
     }
 
+    /**
+     * Sets the max message length.
+     *
+     * @param maxMessageLength the new max message length
+     */
     public void setMaxMessageLength(int maxMessageLength) {
         m_maxMessageLength = maxMessageLength;
     }
 
+    /**
+     * Checks if is send local name flag.
+     *
+     * @return true, if is send local name flag
+     */
     public boolean isSendLocalName() {
         return m_sendLocalName;
     }
 
+    /**
+     * Sets the send local name flag.
+     *
+     * @param sendLocalName the new send local name flag
+     */
     public void setSendLocalName(boolean sendLocalName) {
         m_sendLocalName = sendLocalName;
     }
 
+    /**
+     * Checks if is send local time flag.
+     *
+     * @return true, if is send local time flag
+     */
     public boolean isSendLocalTime() {
         return m_sendLocalTime;
     }
 
+    /**
+     * Sets the send local time flag.
+     *
+     * @param sendLocalTime the new send local time flag
+     */
     public void setSendLocalTime(boolean sendLocalTime) {
         m_sendLocalTime = sendLocalTime;
     }
 
+    /**
+     * Checks if is truncate message flag.
+     *
+     * @return true, if is truncate message flag
+     */
     public boolean isTruncateMessage() {
         return m_truncateMessage;
     }
 
+    /**
+     * Sets the truncate message flag.
+     *
+     * @param truncateMessage the new truncate message flag
+     */
     public void setTruncateMessage(boolean truncateMessage) {
         m_truncateMessage = truncateMessage;
     }
 
+    /* (non-Javadoc)
+     * @see org.opennms.netmgt.alarmd.api.Destination#isFirstOccurrenceOnly()
+     */
     public boolean isFirstOccurrenceOnly() {
         return m_firstOccurrenceOnly;
     }
 
+    /**
+     * Sets the first occurrence only.
+     *
+     * @param firstOccurrenceOnly the new first occurrence only
+     */
     public void setFirstOccurrenceOnly(boolean firstOccurrenceOnly) {
         m_firstOccurrenceOnly = firstOccurrenceOnly;
     }

--- a/opennms-alarms/syslog-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/syslog/SyslogDestination.java
+++ b/opennms-alarms/syslog-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/syslog/SyslogDestination.java
@@ -28,6 +28,8 @@
 
 package org.opennms.netmgt.alarmd.northbounder.syslog;
 
+import java.util.List;
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
@@ -36,6 +38,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
 import org.opennms.netmgt.alarmd.api.Destination;
+import org.opennms.netmgt.alarmd.api.NorthboundAlarm;
 
 /**
  * Configuration for the various Syslog hosts to receive alarms via Syslog.
@@ -196,6 +199,10 @@ public class SyslogDestination implements Destination {
     /** The first occurrence only flag. */
     @XmlElement(name = "first-occurrence-only", defaultValue = "false", required = false)
     private boolean m_firstOccurrenceOnly = false;
+
+    /** The filters. */
+    @XmlElement(name = "filter", required = false)
+    private List<SyslogFilter> m_filters;
 
     /**
      * Instantiates a new Syslog destination.
@@ -401,4 +408,55 @@ public class SyslogDestination implements Destination {
         m_firstOccurrenceOnly = firstOccurrenceOnly;
     }
 
+    /**
+     * Gets the filters.
+     *
+     * @return the filters
+     */
+    public List<SyslogFilter> getFilters() {
+        return m_filters;
+    }
+
+    /**
+     * Sets the filters.
+     *
+     * @param filters the new filters
+     */
+    public void setFilters(List<SyslogFilter> filters) {
+        this.m_filters = filters;
+    }
+
+    /**
+     * Pass filter.
+     *
+     * @param alarm the alarm
+     * @return true, if successful
+     */
+    public boolean passFilter(NorthboundAlarm alarm) {
+        if (m_filters != null) {
+            for (SyslogFilter filter : m_filters) {
+                if (filter.passFilter(alarm)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Gets the custom message format.
+     *
+     * @param alarm the alarm
+     * @return the custom message format
+     */
+    public String getCustomMessageFormat(NorthboundAlarm alarm) {
+        if (m_filters != null) {
+            for (SyslogFilter filter : m_filters) {
+                if (filter.getMessageFormat() != null && filter.passFilter(alarm)) {
+                    return filter.getMessageFormat();
+                }
+            }
+        }
+        return null;
+    }
 }

--- a/opennms-alarms/syslog-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/syslog/SyslogFilter.java
+++ b/opennms-alarms/syslog-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/syslog/SyslogFilter.java
@@ -58,8 +58,8 @@ public class SyslogFilter {
     @XmlAttribute(name="enabled", required=false)
     private boolean m_enabled = true;
 
-    @XmlElement(name="name", required=true)
-    private String m_name;
+    @XmlElement(name="name", required=false)
+    private String m_name = "Undefined";
 
     @XmlElement(name="rule", required=true)
     private String m_rule = "localhost";
@@ -67,7 +67,7 @@ public class SyslogFilter {
     @XmlElement(name="destination", required=true)
     private String m_destination;
 
-    @XmlElement(name="message-format", required=true)
+    @XmlElement(name="message-format", required=false)
     private String m_messageFormat;
 
     public SyslogFilter() {

--- a/opennms-alarms/syslog-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/syslog/SyslogFilter.java
+++ b/opennms-alarms/syslog-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/syslog/SyslogFilter.java
@@ -61,16 +61,12 @@ public class SyslogFilter {
     private boolean m_enabled = true;
 
     /** The filter name. */
-    @XmlElement(name="name", required=false)
+    @XmlAttribute(name="name", required=false)
     private String m_name = "Undefined";
 
     /** The filter rule. */
     @XmlElement(name="rule", required=true)
     private String m_rule = "localhost";
-
-    /** The target destination name. */
-    @XmlElement(name="destination", required=true)
-    private String m_destination;
 
     /** The m_message format. */
     @XmlElement(name="message-format", required=false)
@@ -87,13 +83,13 @@ public class SyslogFilter {
      *
      * @param name the name
      * @param rule the rule
-     * @param destination the destination
+     * @param messageFormat the message format
      */
-    public SyslogFilter(String name, String rule, String destination) {
+    public SyslogFilter(String name, String rule, String messageFormat) {
         super();
         this.m_name = name;
         this.m_rule = rule;
-        this.m_destination = destination;
+        this.m_messageFormat = messageFormat;
     }
 
     /**
@@ -121,15 +117,6 @@ public class SyslogFilter {
      */
     public String getRule() {
         return m_rule;
-    }
-
-    /**
-     * Gets the target destination.
-     *
-     * @return the target destination
-     */
-    public String getDestination() {
-        return m_destination;
     }
 
     /**
@@ -166,15 +153,6 @@ public class SyslogFilter {
      */
     public void setRule(String rule) {
         this.m_rule = rule;
-    }
-
-    /**
-     * Sets the target destination.
-     *
-     * @param m_destination the new target destination
-     */
-    public void setDestination(String destination) {
-        this.m_destination = destination;
     }
 
     /**

--- a/opennms-alarms/syslog-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/syslog/SyslogFilter.java
+++ b/opennms-alarms/syslog-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/syslog/SyslogFilter.java
@@ -1,0 +1,139 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2013-2014 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.alarmd.northbounder.syslog;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import org.opennms.netmgt.alarmd.api.NorthboundAlarm;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.expression.Expression;
+import org.springframework.expression.ExpressionParser;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+
+/**
+ * Configuration for the various filters to change the behavior of the forrwarder.
+ * 
+ * @author <a href="agalue@opennms.org>Alejandro Galue</a>
+ */
+@XmlRootElement(name = "syslog-filter")
+@XmlAccessorType(XmlAccessType.FIELD)
+public class SyslogFilter {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SyslogFilter.class);
+
+    @XmlAttribute(name="enabled", required=false)
+    private boolean m_enabled = true;
+
+    @XmlElement(name="name", required=true)
+    private String m_name;
+
+    @XmlElement(name="rule", required=true)
+    private String m_rule = "localhost";
+
+    @XmlElement(name="destination", required=true)
+    private String m_destination;
+
+    @XmlElement(name="message-format", required=true)
+    private String m_messageFormat;
+
+    public SyslogFilter() {
+    }
+
+    public SyslogFilter(String name, String rule, String destination) {
+        super();
+        this.m_name = name;
+        this.m_rule = rule;
+        this.m_destination = destination;
+    }
+
+    public boolean isEnabled() {
+        return m_enabled;
+    }
+
+    public String getName() {
+        return m_name;
+    }
+
+    public String getRule() {
+        return m_rule;
+    }
+
+    public String getDestination() {
+        return m_destination;
+    }
+
+    public void setEnabled(boolean m_enabled) {
+        this.m_enabled = m_enabled;
+    }
+
+    public void setName(String m_name) {
+        this.m_name = m_name;
+    }
+
+    public void seRule(String m_rule) {
+        this.m_rule = m_rule;
+    }
+
+    public void setDestination(String m_destination) {
+        this.m_destination = m_destination;
+    }
+
+    public String getMessageFormat() {
+        return m_messageFormat;
+    }
+
+    public void setMessageFormat(String messageFormat) {
+        this.m_messageFormat = messageFormat;
+    }
+
+    public boolean passFilter(NorthboundAlarm alarm) {
+        if (!isEnabled()) {
+            return false;
+        }
+        StandardEvaluationContext context = new StandardEvaluationContext(alarm);
+        ExpressionParser parser = new SpelExpressionParser();
+        Expression exp = parser.parseExpression(getRule());
+        boolean passed = false;
+        try {
+            passed = (Boolean)exp.getValue(context, Boolean.class);
+        } catch (Exception e) {
+            LOG.warn("passFilter: can't evaluate expression {} for alarm {} because: {}", getRule(), alarm.getUei(), e.getMessage());
+        }
+        LOG.debug("passFilter: checking {} ? {}", getRule(), passed);
+        return passed;
+    }
+}

--- a/opennms-alarms/syslog-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/syslog/SyslogFilter.java
+++ b/opennms-alarms/syslog-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/syslog/SyslogFilter.java
@@ -45,7 +45,7 @@ import org.springframework.expression.spel.standard.SpelExpressionParser;
 import org.springframework.expression.spel.support.StandardEvaluationContext;
 
 /**
- * Configuration for the various filters to change the behavior of the forrwarder.
+ * Configuration for the various filters to change the behavior of the forwarder.
  * 
  * @author <a href="agalue@opennms.org>Alejandro Galue</a>
  */
@@ -53,26 +53,42 @@ import org.springframework.expression.spel.support.StandardEvaluationContext;
 @XmlAccessorType(XmlAccessType.FIELD)
 public class SyslogFilter {
 
+    /** The Constant LOG. */
     private static final Logger LOG = LoggerFactory.getLogger(SyslogFilter.class);
 
+    /** The enabled flag. */
     @XmlAttribute(name="enabled", required=false)
     private boolean m_enabled = true;
 
+    /** The filter name. */
     @XmlElement(name="name", required=false)
     private String m_name = "Undefined";
 
+    /** The filter rule. */
     @XmlElement(name="rule", required=true)
     private String m_rule = "localhost";
 
+    /** The target destination name. */
     @XmlElement(name="destination", required=true)
     private String m_destination;
 
+    /** The m_message format. */
     @XmlElement(name="message-format", required=false)
     private String m_messageFormat;
 
+    /**
+     * Instantiates a new Syslog filter.
+     */
     public SyslogFilter() {
     }
 
+    /**
+     * Instantiates a new Syslog filter.
+     *
+     * @param name the name
+     * @param rule the rule
+     * @param destination the destination
+     */
     public SyslogFilter(String name, String rule, String destination) {
         super();
         this.m_name = name;
@@ -80,46 +96,102 @@ public class SyslogFilter {
         this.m_destination = destination;
     }
 
+    /**
+     * Checks if the rule is enabled.
+     *
+     * @return true, if is enabled
+     */
     public boolean isEnabled() {
         return m_enabled;
     }
 
+    /**
+     * Gets the filter name.
+     *
+     * @return the filter name
+     */
     public String getName() {
         return m_name;
     }
 
+    /**
+     * Gets the filter rule.
+     *
+     * @return the filter rule
+     */
     public String getRule() {
         return m_rule;
     }
 
+    /**
+     * Gets the target destination.
+     *
+     * @return the target destination
+     */
     public String getDestination() {
         return m_destination;
     }
 
-    public void setEnabled(boolean m_enabled) {
-        this.m_enabled = m_enabled;
-    }
-
-    public void setName(String m_name) {
-        this.m_name = m_name;
-    }
-
-    public void seRule(String m_rule) {
-        this.m_rule = m_rule;
-    }
-
-    public void setDestination(String m_destination) {
-        this.m_destination = m_destination;
-    }
-
+    /**
+     * Gets the message format.
+     *
+     * @return the message format
+     */
     public String getMessageFormat() {
         return m_messageFormat;
     }
 
+    /**
+     * Sets the enabled flag.
+     *
+     * @param enabled the new enabled
+     */
+    public void setEnabled(boolean enabled) {
+        this.m_enabled = enabled;
+    }
+
+    /**
+     * Sets the filter name.
+     *
+     * @param name the new name
+     */
+    public void setName(String name) {
+        this.m_name = name;
+    }
+
+    /**
+     * Sets the filter rule.
+     *
+     * @param rule the rule
+     */
+    public void setRule(String rule) {
+        this.m_rule = rule;
+    }
+
+    /**
+     * Sets the target destination.
+     *
+     * @param m_destination the new target destination
+     */
+    public void setDestination(String destination) {
+        this.m_destination = destination;
+    }
+
+    /**
+     * Sets the message format.
+     *
+     * @param messageFormat the new message format
+     */
     public void setMessageFormat(String messageFormat) {
         this.m_messageFormat = messageFormat;
     }
 
+    /**
+     * Pass filter.
+     *
+     * @param alarm the alarm
+     * @return true, if successful
+     */
     public boolean passFilter(NorthboundAlarm alarm) {
         if (!isEnabled()) {
             return false;

--- a/opennms-alarms/syslog-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/syslog/SyslogFilter.java
+++ b/opennms-alarms/syslog-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/syslog/SyslogFilter.java
@@ -66,7 +66,7 @@ public class SyslogFilter {
 
     /** The filter rule. */
     @XmlElement(name="rule", required=true)
-    private String m_rule = "localhost";
+    private String m_rule;
 
     /** The m_message format. */
     @XmlElement(name="message-format", required=false)

--- a/opennms-alarms/syslog-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/syslog/SyslogNorthbounder.java
+++ b/opennms-alarms/syslog-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/syslog/SyslogNorthbounder.java
@@ -55,8 +55,7 @@ import org.springframework.beans.factory.InitializingBean;
  * 
  * @author <a href="mailto:david@opennms.org>David Hustace</a>
  */
-public class SyslogNorthbounder extends AbstractNorthbounder implements
-InitializingBean {
+public class SyslogNorthbounder extends AbstractNorthbounder implements InitializingBean {
 
     /** The Constant LOG. */
     private static final Logger LOG = LoggerFactory.getLogger(SyslogNorthbounder.class);
@@ -98,6 +97,15 @@ InitializingBean {
         setNaglesDelay(getConfig().getNaglesDelay());
         setMaxBatchSize(getConfig().getBatchSize());
         setMaxPreservedAlarms(getConfig().getQueueSize());
+    }
+
+    /* (non-Javadoc)
+     * @see org.opennms.netmgt.alarmd.api.support.AbstractNorthbounder#onStop()
+     */
+    @Override
+    protected void onStop() {
+        Syslog.destroyInstance(getName());
+        super.onStop();
     }
 
     /**

--- a/opennms-alarms/syslog-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/syslog/SyslogNorthbounder.java
+++ b/opennms-alarms/syslog-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/syslog/SyslogNorthbounder.java
@@ -211,7 +211,12 @@ public class SyslogNorthbounder extends AbstractNorthbounder implements
         LOG.info("Reloading configuration for {}.", getName());
         m_configDao.reload();
         final String destinationName = m_destination.getName();
-        m_destination = getConfig().getDestination(destinationName);
+        SyslogDestination destination = getConfig().getDestination(destinationName);
+        if (destination == null) {
+            LOG.error("Aborting the reload operation because the destination {} can't be found on the configuration file.", destinationName);
+            return;
+        }
+        m_destination = destination;
         LOG.info("Destroying Syslog Northbound Instance {}.", destinationName);
         Syslog.destroyInstance(destinationName);
         createNorthboundInstance();

--- a/opennms-alarms/syslog-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/syslog/SyslogNorthbounder.java
+++ b/opennms-alarms/syslog-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/syslog/SyslogNorthbounder.java
@@ -205,11 +205,14 @@ public class SyslogNorthbounder extends AbstractNorthbounder implements
     /* (non-Javadoc)
      * @see org.opennms.netmgt.alarmd.api.support.AbstractNorthbounder#reloadConfig()
      */
+    // TODO If the content of the destination was not changed, ignore the request and log a message
     @Override
     public void reloadConfig() {
+        LOG.info("Reloading configuration for {}.", getName());
         m_configDao.reload();
         final String destinationName = m_destination.getName();
         m_destination = getConfig().getDestination(destinationName);
+        LOG.info("Destroying Syslog Northbound Instance {}.", destinationName);
         Syslog.destroyInstance(destinationName);
         createNorthboundInstance();
     }
@@ -222,7 +225,7 @@ public class SyslogNorthbounder extends AbstractNorthbounder implements
      */
     private void createNorthboundInstance() throws SyslogRuntimeException {
 
-        LOG.info("Creating Syslog Northbound Instance:{}",
+        LOG.info("Creating Syslog Northbound Instance {}",
                  m_destination.getName());
 
         String instName = m_destination.getName();

--- a/opennms-alarms/syslog-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/syslog/SyslogNorthbounderConfig.java
+++ b/opennms-alarms/syslog-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/syslog/SyslogNorthbounderConfig.java
@@ -69,6 +69,9 @@ public class SyslogNorthbounderConfig implements Serializable {
     @XmlElement(name = "uei", required = false)
     private List<String> m_ueis;
 
+    @XmlElement(name = "filter", required = false)
+    private List<SyslogFilter> m_filters;
+
     // Getters & Setters
     public List<SyslogDestination> getDestinations() {
         return m_destinations;
@@ -124,6 +127,14 @@ public class SyslogNorthbounderConfig implements Serializable {
 
     public void setEnabled(Boolean enabled) {
         m_enabled = enabled;
+    }
+
+    public List<SyslogFilter> getFilters() {
+        return m_filters;
+    }
+
+    public void setFilters(List<SyslogFilter> filters) {
+        this.m_filters = filters;
     }
 
     public SyslogDestination getDestination(String destinationName) {

--- a/opennms-alarms/syslog-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/syslog/SyslogNorthbounderConfig.java
+++ b/opennms-alarms/syslog-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/syslog/SyslogNorthbounderConfig.java
@@ -76,10 +76,6 @@ public class SyslogNorthbounderConfig implements Serializable {
     @XmlElement(name = "uei", required = false)
     private List<String> m_ueis;
 
-    /** The filters. */
-    @XmlElement(name = "filter", required = false)
-    private List<SyslogFilter> m_filters;
-
     /**
      * Gets the destinations.
      *
@@ -123,23 +119,6 @@ public class SyslogNorthbounderConfig implements Serializable {
      */
     public String getMessageFormat() {
         return m_messageFormat;
-    }
-
-    /**
-     * Gets the message format for destination.
-     *
-     * @param destinationName the destination name
-     * @return the message format for destination
-     */
-    public String getMessageFormatForDestination(String destinationName) {
-        if (getFilters() != null) {
-            for (SyslogFilter filter : getFilters()) {
-                if (filter.getDestination().equals(destinationName) && filter.getMessageFormat() != null) {
-                    return filter.getMessageFormat();
-                }
-            }
-        }
-        return getMessageFormat();
     }
 
     /**
@@ -221,24 +200,6 @@ public class SyslogNorthbounderConfig implements Serializable {
      */
     public void setEnabled(Boolean enabled) {
         m_enabled = enabled;
-    }
-
-    /**
-     * Gets the filters.
-     *
-     * @return the filters
-     */
-    public List<SyslogFilter> getFilters() {
-        return m_filters;
-    }
-
-    /**
-     * Sets the filters.
-     *
-     * @param filters the new filters
-     */
-    public void setFilters(List<SyslogFilter> filters) {
-        this.m_filters = filters;
     }
 
     /**

--- a/opennms-alarms/syslog-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/syslog/SyslogNorthbounderConfig.java
+++ b/opennms-alarms/syslog-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/syslog/SyslogNorthbounderConfig.java
@@ -93,6 +93,17 @@ public class SyslogNorthbounderConfig implements Serializable {
         return m_messageFormat;
     }
 
+    public String getMessageFormatForDestination(String destinationName) {
+        if (getFilters() != null) {
+            for (SyslogFilter filter : getFilters()) {
+                if (filter.getDestination().equals(destinationName) && filter.getMessageFormat() != null) {
+                    return filter.getMessageFormat();
+                }
+            }
+        }
+        return getMessageFormat();
+    }
+
     public void setMessageFormat(String messageFormat) {
         m_messageFormat = messageFormat;
     }

--- a/opennms-alarms/syslog-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/syslog/SyslogNorthbounderConfig.java
+++ b/opennms-alarms/syslog-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/syslog/SyslogNorthbounderConfig.java
@@ -37,8 +37,7 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
 /**
- * Configuration for Syslog NBI implementation. FIXME: This needs lots of
- * work.
+ * Configuration for Syslog NBI implementation.
  * 
  * @author <a mailto:david@opennms.org>David Hustace</a>
  */
@@ -46,53 +45,92 @@ import javax.xml.bind.annotation.XmlRootElement;
 @XmlAccessorType(XmlAccessType.FIELD)
 public class SyslogNorthbounderConfig implements Serializable {
 
+    /** The Constant serialVersionUID. */
     private static final long serialVersionUID = 1L;
 
+    /** The enabled. */
     @XmlElement(name = "enabled", required = false, defaultValue = "false")
     private Boolean m_enabled;
 
+    /** The nagles delay. */
     @XmlElement(name = "nagles-delay", required = false, defaultValue = "1000")
     private Integer m_naglesDelay = 1000;
 
+    /** The batch size. */
     @XmlElement(name = "batch-size", required = false, defaultValue = "100")
     private Integer m_batchSize = 100;
 
+    /** The queue size. */
     @XmlElement(name = "queue-size", required = false, defaultValue = "300000")
     private Integer m_queueSize = 300000;
 
+    /** The message format. */
     @XmlElement(name = "message-format", required = false, defaultValue = "ALARM ID:${alarmId} NODE:${nodeLabel} ${logMsg}")
     private String m_messageFormat = "ALARM ID:${alarmId} NODE:${nodeLabel} ${logMsg}";
 
+    /** The destinations. */
     @XmlElement(name = "destination")
     private List<SyslogDestination> m_destinations;
 
+    /** The UEIs. */
     @XmlElement(name = "uei", required = false)
     private List<String> m_ueis;
 
+    /** The filters. */
     @XmlElement(name = "filter", required = false)
     private List<SyslogFilter> m_filters;
 
-    // Getters & Setters
+    /**
+     * Gets the destinations.
+     *
+     * @return the destinations
+     */
     public List<SyslogDestination> getDestinations() {
         return m_destinations;
     }
 
+    /**
+     * Sets the destinations.
+     *
+     * @param destinations the new destinations
+     */
     public void setDestinations(List<SyslogDestination> destinations) {
         m_destinations = destinations;
     }
 
+    /**
+     * Gets the UEIs.
+     *
+     * @return the UEIs
+     */
     public List<String> getUeis() {
         return m_ueis;
     }
 
+    /**
+     * Sets the UEIs.
+     *
+     * @param ueis the new UEIs
+     */
     public void setUeis(List<String> ueis) {
         m_ueis = ueis;
     }
 
+    /**
+     * Gets the message format.
+     *
+     * @return the message format
+     */
     public String getMessageFormat() {
         return m_messageFormat;
     }
 
+    /**
+     * Gets the message format for destination.
+     *
+     * @param destinationName the destination name
+     * @return the message format for destination
+     */
     public String getMessageFormatForDestination(String destinationName) {
         if (getFilters() != null) {
             for (SyslogFilter filter : getFilters()) {
@@ -104,50 +142,111 @@ public class SyslogNorthbounderConfig implements Serializable {
         return getMessageFormat();
     }
 
+    /**
+     * Sets the message format.
+     *
+     * @param messageFormat the new message format
+     */
     public void setMessageFormat(String messageFormat) {
         m_messageFormat = messageFormat;
     }
 
+    /**
+     * Gets the nagles delay.
+     *
+     * @return the nagles delay
+     */
     public Integer getNaglesDelay() {
         return m_naglesDelay;
     }
 
+    /**
+     * Sets the nagles delay.
+     *
+     * @param naglesDelay the new nagles delay
+     */
     public void setNaglesDelay(Integer naglesDelay) {
         m_naglesDelay = naglesDelay;
     }
 
+    /**
+     * Gets the batch size.
+     *
+     * @return the batch size
+     */
     public Integer getBatchSize() {
         return m_batchSize;
     }
 
+    /**
+     * Sets the batch size.
+     *
+     * @param batchSize the new batch size
+     */
     public void setBatchSize(Integer batchSize) {
         m_batchSize = batchSize;
     }
 
+    /**
+     * Gets the queue size.
+     *
+     * @return the queue size
+     */
     public Integer getQueueSize() {
         return m_queueSize;
     }
 
+    /**
+     * Sets the queue size.
+     *
+     * @param alarmQueueSize the new queue size
+     */
     public void setQueueSize(Integer alarmQueueSize) {
         m_queueSize = alarmQueueSize;
     }
 
+    /**
+     * Checks if is enabled.
+     *
+     * @return the boolean
+     */
     public Boolean isEnabled() {
         return m_enabled;
     }
 
+    /**
+     * Sets the enabled.
+     *
+     * @param enabled the new enabled
+     */
     public void setEnabled(Boolean enabled) {
         m_enabled = enabled;
     }
 
+    /**
+     * Gets the filters.
+     *
+     * @return the filters
+     */
     public List<SyslogFilter> getFilters() {
         return m_filters;
     }
 
+    /**
+     * Sets the filters.
+     *
+     * @param filters the new filters
+     */
     public void setFilters(List<SyslogFilter> filters) {
         this.m_filters = filters;
     }
 
+    /**
+     * Gets the destination.
+     *
+     * @param destinationName the destination name
+     * @return the destination
+     */
     public SyslogDestination getDestination(String destinationName) {
         SyslogDestination destination = null;
         for (SyslogDestination dest : m_destinations) {

--- a/opennms-alarms/syslog-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/syslog/SyslogNorthbounderConfigDao.java
+++ b/opennms-alarms/syslog-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/syslog/SyslogNorthbounderConfigDao.java
@@ -41,16 +41,14 @@ public class SyslogNorthbounderConfigDao extends AbstractJaxbConfigDao<SyslogNor
      * Instantiates a new Syslog northbounder configiguration DAO.
      */
     public SyslogNorthbounderConfigDao() {
-        super(SyslogNorthbounderConfig.class,
-              "Config for Syslog Northbounder");
+        super(SyslogNorthbounderConfig.class, "Config for Syslog Northbounder");
     }
 
     /* (non-Javadoc)
      * @see org.opennms.core.xml.AbstractJaxbConfigDao#translateConfig(java.lang.Object)
      */
     @Override
-    protected SyslogNorthbounderConfig translateConfig(
-            SyslogNorthbounderConfig config) {
+    protected SyslogNorthbounderConfig translateConfig( SyslogNorthbounderConfig config) {
         return config;
     }
 

--- a/opennms-alarms/syslog-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/syslog/SyslogNorthbounderConfigDao.java
+++ b/opennms-alarms/syslog-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/syslog/SyslogNorthbounderConfigDao.java
@@ -30,25 +30,45 @@ package org.opennms.netmgt.alarmd.northbounder.syslog;
 
 import org.opennms.core.xml.AbstractJaxbConfigDao;
 
-public class SyslogNorthbounderConfigDao
-        extends
-        AbstractJaxbConfigDao<SyslogNorthbounderConfig, SyslogNorthbounderConfig> {
+/**
+ * The Class SyslogNorthbounderConfigDao.
+ * 
+ * @author <a href="mailto:david@opennms.org>David Hustace</a>
+ */
+public class SyslogNorthbounderConfigDao extends AbstractJaxbConfigDao<SyslogNorthbounderConfig, SyslogNorthbounderConfig> {
 
+    /**
+     * Instantiates a new Syslog northbounder configiguration DAO.
+     */
     public SyslogNorthbounderConfigDao() {
         super(SyslogNorthbounderConfig.class,
               "Config for Syslog Northbounder");
     }
 
+    /* (non-Javadoc)
+     * @see org.opennms.core.xml.AbstractJaxbConfigDao#translateConfig(java.lang.Object)
+     */
     @Override
     protected SyslogNorthbounderConfig translateConfig(
             SyslogNorthbounderConfig config) {
         return config;
     }
 
+    /**
+     * Gets the Syslog northbounder configuration.
+     *
+     * @return the configuration object
+     */
     public SyslogNorthbounderConfig getConfig() {
         return getContainer().getObject();
     }
 
+    /**
+     * Gets the Syslog destination.
+     *
+     * @param syslogDestinationName the Syslog destination name
+     * @return the Syslog destination
+     */
     public SyslogDestination getSyslogDestination(String syslogDestinationName) {
         for (SyslogDestination dest : getConfig().getDestinations()) {
             if (dest.getName().equals(syslogDestinationName)) {
@@ -58,6 +78,9 @@ public class SyslogNorthbounderConfigDao
         return null;
     }
 
+    /**
+     * Reload.
+     */
     public void reload() {
         getContainer().reload();
     }

--- a/opennms-alarms/syslog-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/syslog/SyslogNorthbounderConfigDao.java
+++ b/opennms-alarms/syslog-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/syslog/SyslogNorthbounderConfigDao.java
@@ -49,4 +49,16 @@ public class SyslogNorthbounderConfigDao
         return getContainer().getObject();
     }
 
+    public SyslogDestination getSyslogDestination(String syslogDestinationName) {
+        for (SyslogDestination dest : getConfig().getDestinations()) {
+            if (dest.getName().equals(syslogDestinationName)) {
+                return dest;
+            }
+        }
+        return null;
+    }
+
+    public void reload() {
+        getContainer().reload();
+    }
 }

--- a/opennms-alarms/syslog-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/syslog/SyslogNorthbounderManager.java
+++ b/opennms-alarms/syslog-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/syslog/SyslogNorthbounderManager.java
@@ -33,46 +33,134 @@ import java.util.Map;
 
 import org.opennms.core.soa.Registration;
 import org.opennms.core.soa.ServiceRegistry;
+import org.opennms.netmgt.alarmd.api.NorthboundAlarm;
 import org.opennms.netmgt.alarmd.api.Northbounder;
+import org.opennms.netmgt.alarmd.api.NorthbounderException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.util.Assert;
 
-public class SyslogNorthbounderManager implements InitializingBean,
-        DisposableBean {
+/**
+ * The Class SyslogNorthbounderManager.
+ * 
+ * @author <a href="mailto:david@opennms.org>David Hustace</a>
+ * @author <a href="agalue@opennms.org>Alejandro Galue</a>
+ */
+public class SyslogNorthbounderManager implements InitializingBean, Northbounder, DisposableBean {
 
+    /** The Constant LOG. */
+    private static final Logger LOG = LoggerFactory.getLogger(SyslogNorthbounderManager.class);
+
+    /** The service registry. */
     @Autowired
     private ServiceRegistry m_serviceRegistry;
 
+    /** The Syslog northbounder configuration DAO. */
     @Autowired
     private SyslogNorthbounderConfigDao m_configDao;
 
+    /** The registrations map. */
     private Map<String, Registration> m_registrations = new HashMap<String, Registration>();
 
+    /**
+     * After properties set.
+     *
+     * @throws Exception the exception
+     */
     @Override
     public void afterPropertiesSet() throws Exception {
-
         Assert.notNull(m_configDao);
         Assert.notNull(m_serviceRegistry);
 
-        SyslogNorthbounderConfig config = m_configDao.getConfig();
+        // Registering itself as a northbounder
+        m_registrations.put(getName(), m_serviceRegistry.register(this, Northbounder.class));
 
-        for (SyslogDestination syslogDestination : config.getDestinations()) {
-            SyslogNorthbounder nbi = new SyslogNorthbounder(m_configDao,
-                                                            syslogDestination.getName());
-            nbi.afterPropertiesSet();
-            m_registrations.put(nbi.getName(),
-                                m_serviceRegistry.register(nbi,
-                                                           Northbounder.class));
-        }
-
+        // Registering each destination as a northbounder
+        registerNorthnounders();
     }
 
+    /**
+     * Register northnounders.
+     *
+     * @throws Exception the exception
+     */
+    private void registerNorthnounders() throws Exception {
+        for (SyslogDestination syslogDestination : m_configDao.getConfig().getDestinations()) {
+            LOG.info("Registering syslog northbound configuration for destination {}.", syslogDestination.getName());
+            SyslogNorthbounder nbi = new SyslogNorthbounder(m_configDao, syslogDestination.getName());
+            nbi.afterPropertiesSet();
+            m_registrations.put(nbi.getName(), m_serviceRegistry.register(nbi, Northbounder.class));
+        }
+    }
+
+    /**
+     * Destroy.
+     *
+     * @throws Exception the exception
+     */
     @Override
     public void destroy() throws Exception {
         for (Registration r : m_registrations.values()) {
             r.unregister();
+        }
+    }
+
+    /**
+     * Start.
+     *
+     * @throws NorthbounderException the northbounder exception
+     */
+    @Override
+    public void start() throws NorthbounderException {
+        // There is no need to do something here. Only the reload method will be implemented
+    }
+
+    /**
+     * On alarm.
+     *
+     * @param alarm the alarm
+     * @throws NorthbounderException the northbounder exception
+     */
+    @Override
+    public void onAlarm(NorthboundAlarm alarm) throws NorthbounderException {
+        // There is no need to do something here. Only the reload method will be implemented        
+    }
+
+    /**
+     * Stop.
+     *
+     * @throws NorthbounderException the northbounder exception
+     */
+    @Override
+    public void stop() throws NorthbounderException {
+        // There is no need to do something here. Only the reload method will be implemented
+    }
+
+    /**
+     * Gets the name.
+     *
+     * @return the name
+     */
+    @Override
+    public String getName() {
+        return SyslogNorthbounder.NBI_NAME;
+    }
+
+    /**
+     * Reloads the configuration.
+     */
+    @Override
+    public void reloadConfig() {
+        m_configDao.reload();
+        LOG.info("Reloading syslog northbound configuration.");
+        m_registrations.forEach((k,v) -> { if (k != getName()) v.unregister();});
+        try {
+            registerNorthnounders();
+        } catch (Exception e) {
+            LOG.error("Can't reload the syslog northbound configuration", e);
         }
     }
 

--- a/opennms-alarms/syslog-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/syslog/SyslogNorthbounderManager.java
+++ b/opennms-alarms/syslog-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/syslog/SyslogNorthbounderManager.java
@@ -29,7 +29,6 @@
 package org.opennms.netmgt.alarmd.northbounder.syslog;
 
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import org.opennms.core.soa.Registration;
@@ -64,10 +63,9 @@ public class SyslogNorthbounderManager implements InitializingBean,
 
         SyslogNorthbounderConfig config = m_configDao.getConfig();
 
-        List<SyslogDestination> destinations = config.getDestinations();
-        for (SyslogDestination syslogDestination : destinations) {
-            SyslogNorthbounder nbi = new SyslogNorthbounder(config,
-                                                            syslogDestination);
+        for (SyslogDestination syslogDestination : config.getDestinations()) {
+            SyslogNorthbounder nbi = new SyslogNorthbounder(m_configDao,
+                                                            syslogDestination.getName());
             nbi.afterPropertiesSet();
             m_registrations.put(nbi.getName(),
                                 m_serviceRegistry.register(nbi,

--- a/opennms-alarms/syslog-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/syslog/SyslogNorthbounderManager.java
+++ b/opennms-alarms/syslog-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/syslog/SyslogNorthbounderManager.java
@@ -68,7 +68,6 @@ public class SyslogNorthbounderManager implements InitializingBean,
         for (SyslogDestination syslogDestination : destinations) {
             SyslogNorthbounder nbi = new SyslogNorthbounder(config,
                                                             syslogDestination);
-            nbi.setNodeDao(m_nodeDao);
             nbi.afterPropertiesSet();
             m_registrations.put(nbi.getName(),
                                 m_serviceRegistry.register(nbi,

--- a/opennms-alarms/syslog-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/syslog/SyslogNorthbounderManager.java
+++ b/opennms-alarms/syslog-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/syslog/SyslogNorthbounderManager.java
@@ -34,7 +34,6 @@ import java.util.Map;
 import org.opennms.core.soa.Registration;
 import org.opennms.core.soa.ServiceRegistry;
 import org.opennms.netmgt.alarmd.api.Northbounder;
-import org.opennms.netmgt.dao.api.NodeDao;
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -49,15 +48,11 @@ public class SyslogNorthbounderManager implements InitializingBean,
     @Autowired
     private SyslogNorthbounderConfigDao m_configDao;
 
-    @Autowired
-    private NodeDao m_nodeDao;
-
     private Map<String, Registration> m_registrations = new HashMap<String, Registration>();
 
     @Override
     public void afterPropertiesSet() throws Exception {
 
-        Assert.notNull(m_nodeDao);
         Assert.notNull(m_configDao);
         Assert.notNull(m_serviceRegistry);
 

--- a/opennms-alarms/syslog-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/syslog/SyslogNorthbounderManager.java
+++ b/opennms-alarms/syslog-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/syslog/SyslogNorthbounderManager.java
@@ -103,9 +103,7 @@ public class SyslogNorthbounderManager implements InitializingBean, Northbounder
      */
     @Override
     public void destroy() throws Exception {
-        for (Registration r : m_registrations.values()) {
-            r.unregister();
-        }
+        m_registrations.values().forEach(r -> unregister(r));
     }
 
     /**
@@ -156,7 +154,7 @@ public class SyslogNorthbounderManager implements InitializingBean, Northbounder
     public void reloadConfig() {
         m_configDao.reload();
         LOG.info("Reloading syslog northbound configuration.");
-        m_registrations.forEach((k,v) -> { if (k != getName()) v.unregister();});
+        m_registrations.forEach((k,v) -> { if (k != getName()) unregister(v);});
         try {
             registerNorthnounders();
         } catch (Exception e) {
@@ -164,4 +162,16 @@ public class SyslogNorthbounderManager implements InitializingBean, Northbounder
         }
     }
 
+    /**
+     * Unregister.
+     *
+     * @param reg the registration object
+     */
+    public void unregister(Registration reg) {
+        // Invalidate the Northbounder implementation (to be sure it won't listen for more alarms).
+        reg.unregister();
+
+        // Shutdown the Syslog target
+        reg.getProvider(Northbounder.class).stop();
+    }
 }

--- a/opennms-alarms/syslog-northbounder/src/test/java/org/opennms/netmgt/alarmd/northbounder/syslog/SyslogConfigDaoTest.java
+++ b/opennms-alarms/syslog-northbounder/src/test/java/org/opennms/netmgt/alarmd/northbounder/syslog/SyslogConfigDaoTest.java
@@ -43,175 +43,187 @@ import org.springframework.core.io.ByteArrayResource;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.io.Resource;
 
+/**
+ * The Test Class for SyslogNorthbounderConfigDao.
+ */
 public class SyslogConfigDaoTest {
-	
-	String xml = "" +
-			"<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n" + 
-			"<syslog-northbounder-config>" +
-			"  <enabled>true</enabled>" +
-			"  <nagles-delay>10000</nagles-delay>" +
-			"  <batch-size>10</batch-size>" +
-			"  <queue-size>100</queue-size>" +
-			"  <message-format>ALARM ID:${alarmId} NODE:${nodeLabel}</message-format>" +
-			">\n" +
-			"  <destination>" +
-			"    <destination-name>test-host</destination-name>" +
-			"    <host>127.0.0.2</host>" +
-			"    <port>10514</port>" +
-			"    <ip-protocol>TCP</ip-protocol>" +
-			"    <facility>LOCAL0</facility>" +
-			"    <max-message-length>512</max-message-length>" +
-			"    <send-local-name>false</send-local-name>" +
-			"    <send-local-time>false</send-local-time>" +
-			"    <truncate-message>true</truncate-message>" +
-			">\n" +
-			"   </destination>" +
-			"	<uei>uei.opennms.org/nodes/nodeDown</uei>\n" +
-			"	<uei>uei.opennms.org/nodes/nodeUp</uei>\n" +
-			"</syslog-northbounder-config>\n" +
-			"";
-	
-	String xmlNoUeis = "" +
-			"<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n" + 
-			"<syslog-northbounder-config>" +
-			"  <enabled>true</enabled>" +
-			"  <nagles-delay>10000</nagles-delay>" +
-			"  <batch-size>10</batch-size>" +
-			"  <queue-size>100</queue-size>" +
-			"  <message-format>ALARM ID:${alarmId} NODE:${nodeLabel}</message-format>" +
-			">\n" +
-			"  <destination>" +
-			"    <destination-name>test-host</destination-name>" +
-			"    <host>127.0.0.2</host>" +
-			"    <port>10514</port>" +
-			"    <ip-protocol>TCP</ip-protocol>" +
-			"    <facility>LOCAL0</facility>" +
-			"    <max-message-length>512</max-message-length>" +
-			"    <send-local-name>false</send-local-name>" +
-			"    <send-local-time>false</send-local-time>" +
-			"    <truncate-message>true</truncate-message>" +
-			"    <first-occurrence-only>true</first-occurrence-only>" +
-			">\n" +
-			"   </destination>" +
-			"</syslog-northbounder-config>\n" +
-			"";
 
-	 String xmlWithFilters = "" +
-                       "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n" + 
-                       "<syslog-northbounder-config>" +
-                       "  <enabled>true</enabled>" +
-                       "  <nagles-delay>10000</nagles-delay>" +
-                       "  <batch-size>10</batch-size>" +
-                       "  <queue-size>100</queue-size>" +
-                       "  <message-format>ALARM ID:${alarmId} NODE:${nodeLabel}</message-format>" +
-                       ">\n" +
-                       "  <destination>" +
-                       "    <destination-name>test-host</destination-name>" +
-                       "    <host>127.0.0.2</host>" +
-                       "    <port>10514</port>" +
-                       "    <ip-protocol>TCP</ip-protocol>" +
-                       "    <facility>LOCAL0</facility>" +
-                       "    <max-message-length>512</max-message-length>" +
-                       "    <send-local-name>false</send-local-name>" +
-                       "    <send-local-time>false</send-local-time>" +
-                       "    <truncate-message>true</truncate-message>" +
-                       "    <first-occurrence-only>true</first-occurrence-only>" +
-                       ">\n" +
-                       "   </destination>" +
-                       "   <filter>" +
-                       "     <name>filter-1</name>" +
-                       "     <destination>test-host</destination>" +
-                       "     <message-format>ALARM ${alarmId} ON node ${nodeLabel}@${foreignSource}</message-format>" +
-                       "   </filter>" +
-                       "   <filter enabled=\"false\">" +
-                       "     <name>filter-2</name>" +
-                       "     <destination>test-host</destination>" +
-                       "   </filter>" +
-                       "</syslog-northbounder-config>\n" +
-                       "";
+    /** The XML. */
+    String xml = "" +
+            "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n" + 
+            "<syslog-northbounder-config>" +
+            "  <enabled>true</enabled>" +
+            "  <nagles-delay>10000</nagles-delay>" +
+            "  <batch-size>10</batch-size>" +
+            "  <queue-size>100</queue-size>" +
+            "  <message-format>ALARM ID:${alarmId} NODE:${nodeLabel}</message-format>" +
+            ">\n" +
+            "  <destination>" +
+            "    <destination-name>test-host</destination-name>" +
+            "    <host>127.0.0.2</host>" +
+            "    <port>10514</port>" +
+            "    <ip-protocol>TCP</ip-protocol>" +
+            "    <facility>LOCAL0</facility>" +
+            "    <max-message-length>512</max-message-length>" +
+            "    <send-local-name>false</send-local-name>" +
+            "    <send-local-time>false</send-local-time>" +
+            "    <truncate-message>true</truncate-message>" +
+            ">\n" +
+            "   </destination>" +
+            "	<uei>uei.opennms.org/nodes/nodeDown</uei>\n" +
+            "	<uei>uei.opennms.org/nodes/nodeUp</uei>\n" +
+            "</syslog-northbounder-config>\n" +
+            "";
 
-	@Test
-	public void testLoad() throws InterruptedException {
-		
-		Resource resource = new ByteArrayResource(xml.getBytes());
-				
-		SyslogNorthbounderConfigDao dao = new SyslogNorthbounderConfigDao();
-		dao.setConfigResource(resource);
-		dao.afterPropertiesSet();
-		
-		SyslogNorthbounderConfig config = dao.getConfig();
-		
-		assertNotNull(config);
-		
-		assertEquals(true, config.isEnabled());
-		assertEquals(new Integer("10000"), config.getNaglesDelay());
-		assertEquals(new Integer(10), config.getBatchSize());
-		assertEquals(new Integer(100), config.getQueueSize());
-		assertEquals("ALARM ID:${alarmId} NODE:${nodeLabel}", config.getMessageFormat());
-		
-		SyslogDestination syslogDestination = config.getDestinations().get(0);
-		assertNotNull(syslogDestination);
-		assertEquals("test-host", syslogDestination.getName());
-		assertEquals("127.0.0.2", syslogDestination.getHost());
-		assertEquals(10514, syslogDestination.getPort());
-		assertEquals(SyslogDestination.SyslogProtocol.TCP, syslogDestination.getProtocol());
-		assertEquals(SyslogDestination.SyslogFacility.LOCAL0, syslogDestination.getFacility());
-		assertEquals(512, syslogDestination.getMaxMessageLength());
-		assertEquals(false, syslogDestination.isSendLocalName());
-		assertEquals(false, syslogDestination.isSendLocalTime());
-		assertEquals(true, syslogDestination.isTruncateMessage());
-		
-		assertEquals(false, syslogDestination.isFirstOccurrenceOnly());
-		
-		assertEquals("uei.opennms.org/nodes/nodeDown", config.getUeis().get(0));
-		assertEquals("uei.opennms.org/nodes/nodeUp", config.getUeis().get(1));
-		
-	}
+    /** The XML no UEIs. */
+    String xmlNoUeis = "" +
+            "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n" + 
+            "<syslog-northbounder-config>" +
+            "  <enabled>true</enabled>" +
+            "  <nagles-delay>10000</nagles-delay>" +
+            "  <batch-size>10</batch-size>" +
+            "  <queue-size>100</queue-size>" +
+            "  <message-format>ALARM ID:${alarmId} NODE:${nodeLabel}</message-format>" +
+            ">\n" +
+            "  <destination>" +
+            "    <destination-name>test-host</destination-name>" +
+            "    <host>127.0.0.2</host>" +
+            "    <port>10514</port>" +
+            "    <ip-protocol>TCP</ip-protocol>" +
+            "    <facility>LOCAL0</facility>" +
+            "    <max-message-length>512</max-message-length>" +
+            "    <send-local-name>false</send-local-name>" +
+            "    <send-local-time>false</send-local-time>" +
+            "    <truncate-message>true</truncate-message>" +
+            "    <first-occurrence-only>true</first-occurrence-only>" +
+            ">\n" +
+            "   </destination>" +
+            "</syslog-northbounder-config>\n" +
+            "";
 
-	@Test
-	public void testLoadNoUeis() {
-		Resource resource = new ByteArrayResource(xmlNoUeis.getBytes());
-		
-		SyslogNorthbounderConfigDao dao = new SyslogNorthbounderConfigDao();
-		dao.setConfigResource(resource);
-		
-		dao.afterPropertiesSet();
-		
-		SyslogNorthbounderConfig config = dao.getConfig();
-		
-		assertNotNull(config);
-		assertEquals(null, config.getUeis());
-		assertTrue(config.getDestinations().get(0).isFirstOccurrenceOnly());
-		
-	}
+    /** The XML with filters. */
+    String xmlWithFilters = "" +
+            "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n" + 
+            "<syslog-northbounder-config>" +
+            "  <enabled>true</enabled>" +
+            "  <nagles-delay>10000</nagles-delay>" +
+            "  <batch-size>10</batch-size>" +
+            "  <queue-size>100</queue-size>" +
+            "  <message-format>ALARM ID:${alarmId} NODE:${nodeLabel}</message-format>" +
+            ">\n" +
+            "  <destination>" +
+            "    <destination-name>test-host</destination-name>" +
+            "    <host>127.0.0.2</host>" +
+            "    <port>10514</port>" +
+            "    <ip-protocol>TCP</ip-protocol>" +
+            "    <facility>LOCAL0</facility>" +
+            "    <max-message-length>512</max-message-length>" +
+            "    <send-local-name>false</send-local-name>" +
+            "    <send-local-time>false</send-local-time>" +
+            "    <truncate-message>true</truncate-message>" +
+            "    <first-occurrence-only>true</first-occurrence-only>" +
+            ">\n" +
+            "   </destination>" +
+            "   <filter>" +
+            "     <name>filter-1</name>" +
+            "     <destination>test-host</destination>" +
+            "     <message-format>ALARM ${alarmId} ON node ${nodeLabel}@${foreignSource}</message-format>" +
+            "   </filter>" +
+            "   <filter enabled=\"false\">" +
+            "     <name>filter-2</name>" +
+            "     <destination>test-host</destination>" +
+            "   </filter>" +
+            "</syslog-northbounder-config>\n" +
+            "";
 
-	@Test
-	public void testFiltersAndReload() throws Exception {
-	    File configFile = new File("target/syslog-northbounder-test.xml");
-	    FileWriter writer = new FileWriter(configFile);
-	    writer.write(xmlWithFilters);
-	    writer.close();
-	    Resource resource = new FileSystemResource(configFile);
+    /**
+     * Test load.
+     *
+     * @throws InterruptedException the interrupted exception
+     */
+    @Test
+    public void testLoad() throws InterruptedException {
+        Resource resource = new ByteArrayResource(xml.getBytes());
 
-	    SyslogNorthbounderConfigDao dao = new SyslogNorthbounderConfigDao();
-	    dao.setConfigResource(resource);
+        SyslogNorthbounderConfigDao dao = new SyslogNorthbounderConfigDao();
+        dao.setConfigResource(resource);
+        dao.afterPropertiesSet();
 
-	    dao.afterPropertiesSet();
+        SyslogNorthbounderConfig config = dao.getConfig();
+        assertNotNull(config);
 
-	    assertNotNull(dao.getConfig());
-	    assertEquals(2, dao.getConfig().getFilters().size());
-	    assertEquals(true, dao.getConfig().getFilters().get(0).isEnabled());
-	    assertEquals(false, dao.getConfig().getFilters().get(1).isEnabled());
-	    assertTrue(dao.getConfig().getMessageFormatForDestination("test-host").contains("foreignSource"));
-	    assertFalse(dao.getConfig().getMessageFormatForDestination("blah-blah").contains("foreignSource"));
+        assertEquals(true, config.isEnabled());
+        assertEquals(new Integer("10000"), config.getNaglesDelay());
+        assertEquals(new Integer(10), config.getBatchSize());
+        assertEquals(new Integer(100), config.getQueueSize());
+        assertEquals("ALARM ID:${alarmId} NODE:${nodeLabel}", config.getMessageFormat());
 
-	    writer = new FileWriter(configFile);
-	    writer.write(xmlNoUeis);
-	    writer.close();
-	    dao.reload();
+        SyslogDestination syslogDestination = config.getDestinations().get(0);
+        assertNotNull(syslogDestination);
+        assertEquals("test-host", syslogDestination.getName());
+        assertEquals("127.0.0.2", syslogDestination.getHost());
+        assertEquals(10514, syslogDestination.getPort());
+        assertEquals(SyslogDestination.SyslogProtocol.TCP, syslogDestination.getProtocol());
+        assertEquals(SyslogDestination.SyslogFacility.LOCAL0, syslogDestination.getFacility());
+        assertEquals(512, syslogDestination.getMaxMessageLength());
+        assertEquals(false, syslogDestination.isSendLocalName());
+        assertEquals(false, syslogDestination.isSendLocalTime());
+        assertEquals(true, syslogDestination.isTruncateMessage());
 
-	    assertNull(dao.getConfig().getFilters());
-	    configFile.delete();
-	}
+        assertEquals(false, syslogDestination.isFirstOccurrenceOnly());
+
+        assertEquals("uei.opennms.org/nodes/nodeDown", config.getUeis().get(0));
+        assertEquals("uei.opennms.org/nodes/nodeUp", config.getUeis().get(1));
+    }
+
+    /**
+     * Test load no UEIs.
+     */
+    @Test
+    public void testLoadNoUeis() {
+        Resource resource = new ByteArrayResource(xmlNoUeis.getBytes());
+
+        SyslogNorthbounderConfigDao dao = new SyslogNorthbounderConfigDao();
+        dao.setConfigResource(resource);
+        dao.afterPropertiesSet();
+
+        SyslogNorthbounderConfig config = dao.getConfig();
+        assertNotNull(config);
+        assertEquals(null, config.getUeis());
+        assertTrue(config.getDestinations().get(0).isFirstOccurrenceOnly());
+    }
+
+    /**
+     * Test filters and reload.
+     *
+     * @throws Exception the exception
+     */
+    @Test
+    public void testFiltersAndReload() throws Exception {
+        File configFile = new File("target/syslog-northbounder-test.xml");
+        FileWriter writer = new FileWriter(configFile);
+        writer.write(xmlWithFilters);
+        writer.close();
+        Resource resource = new FileSystemResource(configFile);
+
+        SyslogNorthbounderConfigDao dao = new SyslogNorthbounderConfigDao();
+        dao.setConfigResource(resource);
+        dao.afterPropertiesSet();
+
+        assertNotNull(dao.getConfig());
+        assertEquals(2, dao.getConfig().getFilters().size());
+        assertEquals(true, dao.getConfig().getFilters().get(0).isEnabled());
+        assertEquals(false, dao.getConfig().getFilters().get(1).isEnabled());
+        assertTrue(dao.getConfig().getMessageFormatForDestination("test-host").contains("foreignSource"));
+        assertFalse(dao.getConfig().getMessageFormatForDestination("blah-blah").contains("foreignSource"));
+
+        writer = new FileWriter(configFile);
+        writer.write(xmlNoUeis);
+        writer.close();
+        dao.reload();
+
+        assertNull(dao.getConfig().getFilters());
+        configFile.delete();
+    }
 
 }

--- a/opennms-alarms/syslog-northbounder/src/test/java/org/opennms/netmgt/alarmd/northbounder/syslog/SyslogFilterTest.java
+++ b/opennms-alarms/syslog-northbounder/src/test/java/org/opennms/netmgt/alarmd/northbounder/syslog/SyslogFilterTest.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2013-2015 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2015 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+package org.opennms.netmgt.alarmd.northbounder.syslog;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.opennms.netmgt.alarmd.api.NorthboundAlarm;
+import org.opennms.netmgt.model.OnmsAlarm;
+
+/**
+ * The Class SyslogFilterTest.
+ * 
+ * @author <a href="agalue@opennms.org>Alejandro Galue</a>
+ */
+public class SyslogFilterTest {
+
+    /**
+     * Test filter parsing.
+     *
+     * @throws Exception the exception
+     */
+    @Test
+    public void testFilterParsing() throws Exception {
+        OnmsAlarm onmsAlarm = new OnmsAlarm();
+        onmsAlarm.setEventParms("user=agalue(string,text);passwd=0nmsRules(string,text);");
+        onmsAlarm.setUei("uei.opennms.org/junit/test");
+        NorthboundAlarm alarm = new NorthboundAlarm(onmsAlarm);
+        SyslogFilter filter = new SyslogFilter("test", "uei matches '^uei\\.opennms\\.org.*' and parameters['user'] == 'agalue'", "localhost");
+        Assert.assertTrue(filter.passFilter(alarm));
+    }
+
+}

--- a/opennms-alarms/syslog-northbounder/src/test/java/org/opennms/netmgt/alarmd/northbounder/syslog/SyslogNorthBounderTest.java
+++ b/opennms-alarms/syslog-northbounder/src/test/java/org/opennms/netmgt/alarmd/northbounder/syslog/SyslogNorthBounderTest.java
@@ -102,10 +102,10 @@ public class SyslogNorthBounderTest {
     protected MockNodeDao m_nodeDao;
 
     /** The Syslog Server. */
-    public SyslogServerIF m_server;
+    private SyslogServerIF m_server;
 
     /** The Test LOG stream. */
-    public TestPrintStream m_logStream;
+    protected TestPrintStream m_logStream;
 
     /**
      * Needed a String based OutputStream class for the Syslog4j eventhandler interface.

--- a/opennms-alarms/syslog-northbounder/src/test/java/org/opennms/netmgt/alarmd/northbounder/syslog/SyslogNorthBounderTest.java
+++ b/opennms-alarms/syslog-northbounder/src/test/java/org/opennms/netmgt/alarmd/northbounder/syslog/SyslogNorthBounderTest.java
@@ -200,7 +200,6 @@ public class SyslogNorthBounderTest {
         
         for (SyslogDestination syslogDestination : destinations) {
             SyslogNorthbounder nbi = new SyslogNorthbounder(config, syslogDestination);
-            nbi.setNodeDao(m_nodeDao);
             nbi.afterPropertiesSet();
             nbis.add(nbi);
         }

--- a/opennms-alarms/syslog-northbounder/src/test/java/org/opennms/netmgt/alarmd/northbounder/syslog/SyslogNorthBounderTest.java
+++ b/opennms-alarms/syslog-northbounder/src/test/java/org/opennms/netmgt/alarmd/northbounder/syslog/SyslogNorthBounderTest.java
@@ -55,12 +55,12 @@ import org.opennms.netmgt.model.OnmsSeverity;
 import org.opennms.netmgt.model.OnmsSnmpInterface;
 import org.opennms.netmgt.model.PrimaryType;
 import org.opennms.test.JUnitConfigurationEnvironment;
-import org.productivity.java.syslog4j.server.SyslogServer;
-import org.productivity.java.syslog4j.server.SyslogServerConfigIF;
-import org.productivity.java.syslog4j.server.SyslogServerEventHandlerIF;
-import org.productivity.java.syslog4j.server.SyslogServerIF;
-import org.productivity.java.syslog4j.server.impl.event.printstream.PrintStreamSyslogServerEventHandler;
-import org.productivity.java.syslog4j.server.impl.net.udp.UDPNetSyslogServerConfig;
+import org.graylog2.syslog4j.server.SyslogServer;
+import org.graylog2.syslog4j.server.SyslogServerConfigIF;
+import org.graylog2.syslog4j.server.SyslogServerEventHandlerIF;
+import org.graylog2.syslog4j.server.SyslogServerIF;
+import org.graylog2.syslog4j.server.impl.event.printstream.PrintStreamSyslogServerEventHandler;
+import org.graylog2.syslog4j.server.impl.net.udp.UDPNetSyslogServerConfig;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.core.io.Resource;
@@ -193,13 +193,11 @@ public class SyslogNorthBounderTest {
         dao.afterPropertiesSet();
 
         SyslogNorthbounderConfig config = dao.getConfig();
-        
-        List<SyslogDestination> destinations = config.getDestinations();
 
         List<SyslogNorthbounder> nbis = new LinkedList<SyslogNorthbounder>();
         
-        for (SyslogDestination syslogDestination : destinations) {
-            SyslogNorthbounder nbi = new SyslogNorthbounder(config, syslogDestination);
+        for (SyslogDestination syslogDestination : config.getDestinations()) {
+            SyslogNorthbounder nbi = new SyslogNorthbounder(dao, syslogDestination.getName());
             nbi.afterPropertiesSet();
             nbis.add(nbi);
         }

--- a/opennms-alarms/syslog-northbounder/src/test/java/org/opennms/netmgt/alarmd/northbounder/syslog/SyslogNorthBounderTest.java
+++ b/opennms-alarms/syslog-northbounder/src/test/java/org/opennms/netmgt/alarmd/northbounder/syslog/SyslogNorthBounderTest.java
@@ -67,8 +67,8 @@ import org.springframework.core.io.Resource;
 import org.springframework.test.context.ContextConfiguration;
 
 /**
- * Tests the Syslog North Bound Interface
- * 
+ * Tests the Syslog North Bound Interface.
+ *
  * @author <a href="mailto:david@opennms.org">David Hustace</a>
  */
 @RunWith(OpenNMSJUnit4ClassRunner.class)
@@ -81,41 +81,61 @@ import org.springframework.test.context.ContextConfiguration;
 // TODO:Would be great to do something like the following annotation...
 // @JUnitSyslogServer(port=8514)
 public class SyslogNorthBounderTest {
-    
+
+    /** The Constant SERVER_HOST. */
     private static final String SERVER_HOST = "127.0.0.1";
+
+    /** The Constant MESSAGE_LENGTH. */
     public static final int MESSAGE_LENGTH = 1024;
+
+    /** The Constant SERVER_PORT. */
     private static final int SERVER_PORT = 8514;
+
+    /** The Constant SERVER_PROTOCOL. */
     private static final String SERVER_PROTOCOL = "UDP";
+
+    /** The Constant FACILITY. */
     private static final String FACILITY = "LOCAL0";
 
+    /** The Node DAO. */
     @Autowired
     protected MockNodeDao m_nodeDao;
 
+    /** The Syslog Server. */
     public SyslogServerIF m_server;
+
+    /** The Test LOG stream. */
     public TestPrintStream m_logStream;
 
     /**
-     * Needed a String based OutputStream class for the Syslog4j eventhandler
-     * interface.
+     * Needed a String based OutputStream class for the Syslog4j eventhandler interface.
      * 
      * @author <a href="mailto:david@opennms.org">David Hustace</a>
      * 
      */
     class StringOutputStream extends OutputStream {
 
+        /** The string buffer. */
         StringBuilder m_buf = new StringBuilder(MESSAGE_LENGTH);
 
+        /* (non-Javadoc)
+         * @see java.io.OutputStream#write(int)
+         */
         @Override
         synchronized public void write(int inByte) throws IOException {
             m_buf.append((char) inByte);
         }
 
+        /**
+         * Gets the string.
+         *
+         * @return the string
+         */
         synchronized public String getString() {
             String buffer = m_buf.toString();
             m_buf.setLength(0);
             return buffer;
         }
-
     }
 
     /**
@@ -129,13 +149,24 @@ public class SyslogNorthBounderTest {
      */
     class TestPrintStream extends PrintStream {
 
+        /** The string output stream. */
         private StringOutputStream m_out;
 
+        /**
+         * Instantiates a new test print stream.
+         *
+         * @param out the out
+         */
         public TestPrintStream(StringOutputStream out) {
             super(out);
             m_out = out;
         }
 
+        /**
+         * Read stream.
+         *
+         * @return the string
+         */
         public String readStream() {
             return m_out.getString();
         }
@@ -143,12 +174,12 @@ public class SyslogNorthBounderTest {
 
     /**
      * Getting ready for tests.
-     * @throws InterruptedException 
+     *
+     * @throws InterruptedException the interrupted exception
      */
     @Before
     public void startServer() throws InterruptedException {
         MockLogAppender.setupLogging();
-        
 
         SyslogServerConfigIF serverConfig = new UDPNetSyslogServerConfig(SERVER_HOST, SERVER_PORT);
         serverConfig.setShutdownWait(0);
@@ -156,10 +187,8 @@ public class SyslogNorthBounderTest {
         SyslogServerEventHandlerIF eventHandler = new PrintStreamSyslogServerEventHandler(m_logStream);
         serverConfig.addEventHandler(eventHandler);
         m_server = SyslogServer.createThreadedInstance("test-udp", serverConfig);
-        
-        
         m_server.initialize("udp", serverConfig);
-        
+
         //Need this sleep, found a deadlock in the server.
         Thread.sleep(100);
         m_server.run();
@@ -167,7 +196,8 @@ public class SyslogNorthBounderTest {
 
     /**
      * Cleans up the Syslog server after each test runs.
-     * @throws InterruptedException 
+     *
+     * @throws InterruptedException the interrupted exception
      */
     @After
     public void stopServer() throws InterruptedException {
@@ -175,19 +205,17 @@ public class SyslogNorthBounderTest {
         MockLogAppender.assertNoErrorOrGreater();
     }
 
-    
     /**
      * This tests forwarding of 7 alarms, one for each OpenNMS severity to
      * verify the LOG_LEVEL agrees with the Severity based on our algorithm.
-     * @throws Exception 
+     *
+     * @throws Exception the exception
      */
     @Test
     public void testForwardAlarms() throws Exception {
-        
         String xml = generateConfigXml();
-        
         Resource resource = new ByteArrayResource(xml.getBytes());
-        
+
         SyslogNorthbounderConfigDao dao = new SyslogNorthbounderConfigDao();
         dao.setConfigResource(resource);
         dao.afterPropertiesSet();
@@ -195,7 +223,7 @@ public class SyslogNorthBounderTest {
         SyslogNorthbounderConfig config = dao.getConfig();
 
         List<SyslogNorthbounder> nbis = new LinkedList<SyslogNorthbounder>();
-        
+
         for (SyslogDestination syslogDestination : config.getDestinations()) {
             SyslogNorthbounder nbi = new SyslogNorthbounder(dao, syslogDestination.getName());
             nbi.afterPropertiesSet();
@@ -204,19 +232,19 @@ public class SyslogNorthBounderTest {
 
         int j = 7;
         List<NorthboundAlarm> alarms = new LinkedList<NorthboundAlarm>();
-        
+
         OnmsNode node = new OnmsNode("p-brane");
         node.setForeignSource("TestGroup");
         node.setForeignId("1");
         node.setId(m_nodeDao.getNextNodeId());
-        
+
         OnmsSnmpInterface snmpInterface = new OnmsSnmpInterface(node, 1);
         snmpInterface.setId(1);
         snmpInterface.setIfAlias("Connection to OpenNMS Wifi");
         snmpInterface.setIfDescr("en1");
         snmpInterface.setIfName("en1/0");
         snmpInterface.setPhysAddr("00:00:00:00:00:01");
-        
+
         Set<OnmsIpInterface> ipInterfaces = new LinkedHashSet<OnmsIpInterface>(j);
         InetAddress address = InetAddress.getByName("10.0.1.1");
         OnmsIpInterface onmsIf = new OnmsIpInterface(address, node);
@@ -225,14 +253,13 @@ public class SyslogNorthBounderTest {
         onmsIf.setIfIndex(1);
         onmsIf.setIpHostName("p-brane");
         onmsIf.setIsSnmpPrimary(PrimaryType.PRIMARY);
-        
+
         ipInterfaces.add(onmsIf);
-        
+
         node.setIpInterfaces(ipInterfaces);
         m_nodeDao.save(node);
         m_nodeDao.flush();
         for (SyslogNorthbounder nbi : nbis) {
-
             for (int i = 1; i <=j; ++i) {
                 OnmsAlarm onmsAlarm = new OnmsAlarm();
                 onmsAlarm.setId(i);
@@ -274,11 +301,11 @@ public class SyslogNorthBounderTest {
         }
 
         Assert.assertTrue("Log messages sent: 7, Log messages received: " + messages.size(), 7 == messages.size());
-        
+
         for (String message : messages) {
             System.out.println(message);
         }
-        
+
         int i = 0;
         for (String message : messages) {
             if (i == 0) {
@@ -316,6 +343,11 @@ public class SyslogNorthBounderTest {
 
     }
 
+    /**
+     * Generates configuration XML.
+     *
+     * @return the string
+     */
     private String generateConfigXml() {
         return "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n" + 
                 "<syslog-northbounder-config>\n" + 

--- a/opennms-alarms/syslog-northbounder/src/test/java/org/opennms/netmgt/alarmd/northbounder/syslog/SyslogNorthBounderTest.java
+++ b/opennms-alarms/syslog-northbounder/src/test/java/org/opennms/netmgt/alarmd/northbounder/syslog/SyslogNorthBounderTest.java
@@ -89,7 +89,7 @@ public class SyslogNorthBounderTest {
     private static final String FACILITY = "LOCAL0";
 
     @Autowired
-    private MockNodeDao m_nodeDao;
+    protected MockNodeDao m_nodeDao;
 
     public SyslogServerIF m_server;
     public TestPrintStream m_logStream;

--- a/opennms-alarms/syslog-northbounder/src/test/java/org/opennms/netmgt/alarmd/northbounder/syslog/SyslogNorthBounderWithFiltersTest.java
+++ b/opennms-alarms/syslog-northbounder/src/test/java/org/opennms/netmgt/alarmd/northbounder/syslog/SyslogNorthBounderWithFiltersTest.java
@@ -1,0 +1,176 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2013-2014 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.alarmd.northbounder.syslog;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.StringReader;
+import java.net.InetAddress;
+import java.util.LinkedHashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+import org.opennms.netmgt.alarmd.api.NorthboundAlarm;
+import org.opennms.netmgt.model.OnmsAlarm;
+import org.opennms.netmgt.model.OnmsIpInterface;
+import org.opennms.netmgt.model.OnmsNode;
+import org.opennms.netmgt.model.OnmsSnmpInterface;
+import org.opennms.netmgt.model.PrimaryType;
+
+import org.springframework.core.io.FileSystemResource;
+
+/**
+ * Tests the Syslog North Bound Interface with filters.
+ *
+ * @author <a href="agalue@opennms.org">Alejandro Galue</a>
+ */
+public class SyslogNorthBounderWithFiltersTest extends SyslogNorthBounderTest {
+
+    /* (non-Javadoc)
+     * @see org.opennms.netmgt.alarmd.northbounder.syslog.SyslogNorthBounderTest#testForwardAlarms()
+     */
+    @Test
+    @Override
+    public void testForwardAlarms() throws Exception {
+        // Initialize the configuration
+        File configFile = new File("target/syslog-northbounder-config.xml");
+        FileUtils.copyFile(new File("src/test/resources/syslog-northbounder-config1.xml"), configFile);
+
+        // Initialize the configuration DAO
+        SyslogNorthbounderConfigDao dao = new SyslogNorthbounderConfigDao();
+        dao.setConfigResource(new FileSystemResource(configFile));
+        dao.afterPropertiesSet();
+
+        // Initialize the Syslog northbound interfaces
+        List<SyslogNorthbounder> nbis = new LinkedList<SyslogNorthbounder>();
+        for (SyslogDestination syslogDestination : dao.getConfig().getDestinations()) {
+            SyslogNorthbounder nbi = new SyslogNorthbounder(dao, syslogDestination.getName());
+            nbi.afterPropertiesSet();
+            nbis.add(nbi);
+        }
+
+        // Add a sample node to the database
+        OnmsNode node = new OnmsNode("agalue");
+        node.setForeignSource("TestGroup");
+        node.setForeignId("1");
+        node.setId(m_nodeDao.getNextNodeId());
+        OnmsSnmpInterface snmpInterface = new OnmsSnmpInterface(node, 1);
+        snmpInterface.setId(1);
+        snmpInterface.setIfAlias("Connection to OpenNMS Wifi");
+        snmpInterface.setIfDescr("en1");
+        snmpInterface.setIfName("en1/0");
+        snmpInterface.setPhysAddr("00:00:00:00:00:01");
+        Set<OnmsIpInterface> ipInterfaces = new LinkedHashSet<OnmsIpInterface>();
+        InetAddress address = InetAddress.getByName("10.0.1.1");
+        OnmsIpInterface onmsIf = new OnmsIpInterface(address, node);
+        onmsIf.setSnmpInterface(snmpInterface);
+        onmsIf.setId(1);
+        onmsIf.setIfIndex(1);
+        onmsIf.setIpHostName("agalue");
+        onmsIf.setIsSnmpPrimary(PrimaryType.PRIMARY);
+        ipInterfaces.add(onmsIf);
+        node.setIpInterfaces(ipInterfaces);
+        m_nodeDao.save(node);
+        m_nodeDao.flush();
+
+        // Create a sample Alarm
+        OnmsAlarm onmsAlarm = new OnmsAlarm();
+        onmsAlarm.setId(10);
+        onmsAlarm.setUei("uei.opennms.org/nodes/interfaceDown");
+        onmsAlarm.setNode(node);
+        onmsAlarm.setSeverityId(6);
+        onmsAlarm.setIpAddr(address);
+        onmsAlarm.setCounter(1);
+        onmsAlarm.setLogMsg("Interface Down");
+        onmsAlarm.setEventParms("owner=agalue(String,text)");
+        NorthboundAlarm nbAlarm = new NorthboundAlarm(onmsAlarm);
+        List<NorthboundAlarm> alarms = new LinkedList<NorthboundAlarm>();
+        alarms.add(nbAlarm);
+
+        // Verify filters and send alarms to the northbound interfaces
+        for (SyslogNorthbounder nbi : nbis) {
+            Assert.assertTrue(nbi.accepts(nbAlarm));
+            nbi.forwardAlarms(alarms);
+        }
+
+        Thread.sleep(100); // Induce a delay (based on the parent code)
+
+        // Extract the log messages and verify the content
+        BufferedReader reader = new BufferedReader(new StringReader(m_logStream.readStream()));
+        List<String> messages = getMessagesFromBuffer(reader);
+        Assert.assertTrue("Log messages sent: 2, Log messages received: " + messages.size(), 2 == messages.size());
+        Assert.assertTrue(messages.get(0).contains("ALARM 10 FROM NODE agalue@TestGroup"));
+        Assert.assertTrue(messages.get(1).contains("ALARM 10 FROM INTERFACE /10.0.1.1"));
+        reader.close();
+
+        // Replace the configuration (to test the reload operation)
+        FileUtils.copyFile(new File("src/test/resources/syslog-northbounder-config2.xml"), configFile);
+
+        // Verify filters and send alarms to the northbound interfaces if they accept the alarms
+        for (SyslogNorthbounder nbi : nbis) {
+            nbi.reloadConfig();
+            if (nbi.accepts(nbAlarm)) {
+                nbi.forwardAlarms(alarms);
+            }
+        }
+
+        // Extract the log messages and verify the content
+        reader = new BufferedReader(new StringReader(m_logStream.readStream()));
+        messages = getMessagesFromBuffer(reader);
+        Assert.assertTrue("Log messages sent: 1, Log messages received: " + messages.size(), 1 == messages.size());
+        Assert.assertTrue(messages.get(0).contains("ALARM ID:10 NODE:agalue;"));
+        reader.close();
+
+        // Remove the temporary configuration file
+        configFile.delete();
+    }
+
+    /**
+     * Gets the messages from buffer.
+     *
+     * @param reader the reader
+     * @return the messages from buffer
+     * @throws Exception the exception
+     */
+    private List<String> getMessagesFromBuffer(BufferedReader reader) throws Exception {
+        List<String> messages = new LinkedList<String>();
+        String line = null;
+        while ((line = reader.readLine()) != null) {
+            messages.add(line);
+            Thread.sleep(10);
+        }
+        return messages;
+    }
+
+}

--- a/opennms-alarms/syslog-northbounder/src/test/java/org/opennms/netmgt/alarmd/northbounder/syslog/SyslogNorthBounderWithFiltersTest.java
+++ b/opennms-alarms/syslog-northbounder/src/test/java/org/opennms/netmgt/alarmd/northbounder/syslog/SyslogNorthBounderWithFiltersTest.java
@@ -134,24 +134,6 @@ public class SyslogNorthBounderWithFiltersTest extends SyslogNorthBounderTest {
         Assert.assertTrue(messages.get(1).contains("ALARM 10 FROM INTERFACE /10.0.1.1"));
         reader.close();
 
-        // Replace the configuration (to test the reload operation)
-        FileUtils.copyFile(new File("src/test/resources/syslog-northbounder-config2.xml"), configFile);
-
-        // Verify filters and send alarms to the northbound interfaces if they accept the alarms
-        for (SyslogNorthbounder nbi : nbis) {
-            nbi.reloadConfig();
-            if (nbi.accepts(nbAlarm)) {
-                nbi.forwardAlarms(alarms);
-            }
-        }
-
-        // Extract the log messages and verify the content
-        reader = new BufferedReader(new StringReader(m_logStream.readStream()));
-        messages = getMessagesFromBuffer(reader);
-        Assert.assertTrue("Log messages sent: 1, Log messages received: " + messages.size(), 1 == messages.size());
-        Assert.assertTrue(messages.get(0).contains("ALARM ID:10 NODE:agalue;"));
-        reader.close();
-
         // Remove the temporary configuration file
         configFile.delete();
     }

--- a/opennms-alarms/syslog-northbounder/src/test/resources/syslog-northbounder-config1.xml
+++ b/opennms-alarms/syslog-northbounder/src/test/resources/syslog-northbounder-config1.xml
@@ -1,0 +1,51 @@
+<syslog-northbounder-config>
+
+  <enabled>true</enabled>
+  <nagles-delay>1000</nagles-delay>
+  <batch-size>100</batch-size>
+  <queue-size>300000</queue-size>
+
+  <message-format>ALARM ID:${alarmId} NODE:${nodeLabel}; ${logMsg}</message-format>
+
+  <destination>
+    <destination-name>localTest1</destination-name>
+    <host>127.0.0.1</host>
+    <port>8514</port>
+    <ip-protocol>UDP</ip-protocol>
+    <facility>LOCAL0</facility>
+    <max-message-length>1024</max-message-length>
+    <send-local-name>true</send-local-name>
+    <send-local-time>true</send-local-time>
+    <truncate-message>false</truncate-message>
+  </destination>
+  <destination>
+    <destination-name>localTest2</destination-name>
+    <host>127.0.0.1</host>
+    <port>8514</port>
+    <ip-protocol>UDP</ip-protocol>
+    <facility>LOCAL0</facility>
+    <max-message-length>1024</max-message-length>
+    <send-local-name>true</send-local-name>
+    <send-local-time>true</send-local-time>
+    <truncate-message>false</truncate-message>
+  </destination>
+
+  <filter>
+    <name>Filter 1 : Match Node</name>
+    <rule>parameters['owner'] == 'agalue' and uei matches '^.*interfaceDown$'</rule>
+    <destination>localTest1</destination>
+    <message-format>ALARM ${alarmId} FROM NODE ${nodeLabel}@${foreignSource}: ${logMsg}</message-format>
+  </filter>
+  <filter>
+    <name>Filter 2 : Match Interface</name>
+    <rule>ipAddr.hostAddress == '10.0.1.1'</rule>
+    <destination>localTest2</destination>
+    <message-format>ALARM ${alarmId} FROM INTERFACE ${ipAddr}: ${logMsg}</message-format>
+  </filter>
+  <filter enabled="false">
+    <name>Disabled Filter</name>
+    <rule>uei matches '^.*nodeDown$'</rule>
+    <destination>localTest2</destination>
+  </filter>
+
+</syslog-northbounder-config>

--- a/opennms-alarms/syslog-northbounder/src/test/resources/syslog-northbounder-config1.xml
+++ b/opennms-alarms/syslog-northbounder/src/test/resources/syslog-northbounder-config1.xml
@@ -17,7 +17,12 @@
     <send-local-name>true</send-local-name>
     <send-local-time>true</send-local-time>
     <truncate-message>false</truncate-message>
+    <filter name="Filter 1 : Match Node">
+      <rule>parameters['owner'] == 'agalue' and uei matches '^.*interfaceDown$'</rule>
+      <message-format>ALARM ${alarmId} FROM NODE ${nodeLabel}@${foreignSource}: ${logMsg}</message-format>
+    </filter>
   </destination>
+
   <destination>
     <destination-name>localTest2</destination-name>
     <host>127.0.0.1</host>
@@ -28,24 +33,13 @@
     <send-local-name>true</send-local-name>
     <send-local-time>true</send-local-time>
     <truncate-message>false</truncate-message>
+    <filter name="Filter 2 : Match Interface">
+      <rule>ipAddr.hostAddress == '10.0.1.1'</rule>
+      <message-format>ALARM ${alarmId} FROM INTERFACE ${ipAddr}: ${logMsg}</message-format>
+    </filter>
+    <filter name="Disabled Filter" enabled="false">
+      <rule>uei matches '^.*nodeDown$'</rule>
+    </filter>
   </destination>
-
-  <filter>
-    <name>Filter 1 : Match Node</name>
-    <rule>parameters['owner'] == 'agalue' and uei matches '^.*interfaceDown$'</rule>
-    <destination>localTest1</destination>
-    <message-format>ALARM ${alarmId} FROM NODE ${nodeLabel}@${foreignSource}: ${logMsg}</message-format>
-  </filter>
-  <filter>
-    <name>Filter 2 : Match Interface</name>
-    <rule>ipAddr.hostAddress == '10.0.1.1'</rule>
-    <destination>localTest2</destination>
-    <message-format>ALARM ${alarmId} FROM INTERFACE ${ipAddr}: ${logMsg}</message-format>
-  </filter>
-  <filter enabled="false">
-    <name>Disabled Filter</name>
-    <rule>uei matches '^.*nodeDown$'</rule>
-    <destination>localTest2</destination>
-  </filter>
 
 </syslog-northbounder-config>

--- a/opennms-alarms/syslog-northbounder/src/test/resources/syslog-northbounder-config2.xml
+++ b/opennms-alarms/syslog-northbounder/src/test/resources/syslog-northbounder-config2.xml
@@ -17,7 +17,11 @@
     <send-local-name>true</send-local-name>
     <send-local-time>true</send-local-time>
     <truncate-message>false</truncate-message>
+    <filter name="Filter 1 : Match Node">
+      <rule>parameters['owner'] == 'agalue' and uei matches '^.*interfaceDown$'</rule>
+    </filter>
   </destination>
+
   <destination>
     <destination-name>localTest2</destination-name>
     <host>127.0.0.1</host>
@@ -28,18 +32,10 @@
     <send-local-name>true</send-local-name>
     <send-local-time>true</send-local-time>
     <truncate-message>false</truncate-message>
+    <filter name="Filter 2 : Match Interface" enabled="false">
+      <rule>ipAddr.hostAddress == '10.0.1.1'</rule>
+      <message-format>ALARM ${alarmId} FROM INTERFACE ${ipAddr}: ${logMsg}</message-format>
+    </filter>
   </destination>
-
-  <filter>
-    <name>Filter 1 : Match Node</name>
-    <rule>parameters['owner'] == 'agalue' and uei matches '^.*interfaceDown$'</rule>
-    <destination>localTest1</destination>
-  </filter>
-  <filter enabled="false">
-    <name>Filter 2 : Match Interface</name>
-    <rule>ipAddr.hostAddress == '10.0.1.1'</rule>
-    <destination>localTest2</destination>
-    <message-format>ALARM ${alarmId} FROM INTERFACE ${ipAddr}: ${logMsg}</message-format>
-  </filter>
 
 </syslog-northbounder-config>

--- a/opennms-alarms/syslog-northbounder/src/test/resources/syslog-northbounder-config2.xml
+++ b/opennms-alarms/syslog-northbounder/src/test/resources/syslog-northbounder-config2.xml
@@ -1,0 +1,45 @@
+<syslog-northbounder-config>
+
+  <enabled>true</enabled>
+  <nagles-delay>1000</nagles-delay>
+  <batch-size>100</batch-size>
+  <queue-size>300000</queue-size>
+
+  <message-format>ALARM ID:${alarmId} NODE:${nodeLabel}; ${logMsg}</message-format>
+
+  <destination>
+    <destination-name>localTest1</destination-name>
+    <host>127.0.0.1</host>
+    <port>8514</port>
+    <ip-protocol>UDP</ip-protocol>
+    <facility>LOCAL0</facility>
+    <max-message-length>1024</max-message-length>
+    <send-local-name>true</send-local-name>
+    <send-local-time>true</send-local-time>
+    <truncate-message>false</truncate-message>
+  </destination>
+  <destination>
+    <destination-name>localTest2</destination-name>
+    <host>127.0.0.1</host>
+    <port>8514</port>
+    <ip-protocol>UDP</ip-protocol>
+    <facility>LOCAL0</facility>
+    <max-message-length>1024</max-message-length>
+    <send-local-name>true</send-local-name>
+    <send-local-time>true</send-local-time>
+    <truncate-message>false</truncate-message>
+  </destination>
+
+  <filter>
+    <name>Filter 1 : Match Node</name>
+    <rule>parameters['owner'] == 'agalue' and uei matches '^.*interfaceDown$'</rule>
+    <destination>localTest1</destination>
+  </filter>
+  <filter enabled="false">
+    <name>Filter 2 : Match Interface</name>
+    <rule>ipAddr.hostAddress == '10.0.1.1'</rule>
+    <destination>localTest2</destination>
+    <message-format>ALARM ${alarmId} FROM INTERFACE ${ipAddr}: ${logMsg}</message-format>
+  </filter>
+
+</syslog-northbounder-config>


### PR DESCRIPTION
This set of code changes provide the ability to apply powerful filters over the syslog northbound destinations, as well as the ability to reload the configuration.

The reload feature has some limitations due to the way the syslog northbound interface was implemented. Because each declared destination is going to be an independent implementation of the Northbounder interface, you cannot rename, add or remove destinations without restart OpenNMS. But, you can change the internal settings of any destination like IP, port, protocol, etc.

Of course, all the filters will be reloaded properly.

The code has JUnit tests to validate all the features introduced, and all of them has been tested on a lab environment.

JIRA: http://issues.opennms.org/browse/HZN-563
Bamboo: http://bamboo.internal.opennms.com:8085/browse/OPENNMS-ONMS337