### PR TITLE
NMS-8063: Update asciidoc dependencies to latest 1.5.3

### DIFF
--- a/opennms-doc/asciidoctor-default.css
+++ b/opennms-doc/asciidoctor-default.css
@@ -328,6 +328,20 @@ select {
     width: 100%;
 }
 
+object, svg {
+    display: inline-block;
+    vertical-align: middle;
+}
+
+.center {
+    margin-left: auto;
+    margin-right: auto;
+}
+
+.spread {
+    width: 100%;
+}
+
 p.lead, .paragraph.lead > p, #preamble > .sectionbody > .paragraph:first-of-type p {
     font-size: 1.21875em;
     line-height: 1.6;
@@ -860,6 +874,11 @@ p a > code:hover {
     list-style-type: none;
 }
 
+#toc li {
+    line-height: 1.3334;
+    margin-top: 0.3334em;
+}
+
 #toc a {
     text-decoration: none;
 }
@@ -901,6 +920,7 @@ p a > code:hover {
 
     #toc.toc2 #toctitle {
         margin-top: 0;
+        margin-bottom: 0.8rem;
         font-size: 1.2em;
     }
 
@@ -1385,10 +1405,6 @@ table.tableblock td > .paragraph:last-child p > p:last-child, table.tableblock t
     margin-bottom: 0;
 }
 
-table.spread {
-    width: 100%;
-}
-
 table.tableblock, th.tableblock, td.tableblock {
     border: 0 solid #dedede;
 }
@@ -1586,13 +1602,14 @@ ol.lowergreek {
     background: none;
 }
 
-td.hdlist1 {
-    padding-right: .75em;
-    font-weight: bold;
-}
-
 td.hdlist1, td.hdlist2 {
     vertical-align: top;
+    padding: 0 0.625em;
+}
+
+td.hdlist1 {
+    font-weight: bold;
+    padding-bottom: 1.25em;
 }
 
 .literalblock + .colist, .listingblock + .colist {
@@ -1653,18 +1670,24 @@ td.hdlist1, td.hdlist2 {
 
 a.image {
     text-decoration: none;
+    display: inline-block;
 }
 
-span.footnote, span.footnoteref {
-    vertical-align: super;
+a.image object {
+    pointer-events: none;
+}
+
+sup.footnote, sup.footnoteref {
     font-size: 0.875em;
+    position: static;
+    vertical-align: super;
 }
 
-span.footnote a, span.footnoteref a {
+sup.footnote a, sup.footnoteref a {
     text-decoration: none;
 }
 
-span.footnote a:active, span.footnoteref a:active {
+sup.footnote a:active, sup.footnoteref a:active {
     text-decoration: underline;
 }
 
@@ -1677,17 +1700,17 @@ span.footnote a:active, span.footnoteref a:active {
 #footnotes hr {
     width: 20%;
     min-width: 6.25em;
-    margin: -.25em 0 .75em 0;
+    margin: -0.25em 0 0.75em 0;
     border-width: 1px 0 0 0;
 }
 
 #footnotes .footnote {
-    padding: 0 0.375em;
-    line-height: 1.3;
+    padding: 0 0.375em 0 0.225em;
+    line-height: 1.3334;
     font-size: 0.875em;
     margin-left: 1.2em;
-    text-indent: -1.2em;
-    margin-bottom: .2em;
+    text-indent: -1.05em;
+    margin-bottom: 0.2em;
 }
 
 #footnotes .footnote a:first-of-type {
@@ -1945,23 +1968,19 @@ b.conum * {
     display: none;
 }
 
-h1, h2 {
-    letter-spacing: -0.01em;
-}
-
-dt, th.tableblock, td.content {
+dt, th.tableblock, td.content, div.footnote {
     text-rendering: optimizeLegibility;
 }
 
-p, td.content {
+h1, h2, p, td.content, span.alt {
     letter-spacing: -0.01em;
 }
 
-p strong, td.content strong {
+p strong, td.content strong, div.footnote strong {
     letter-spacing: -0.005em;
 }
 
-p, blockquote, dt, td.content {
+p, blockquote, dt, td.content, span.alt {
     font-size: 1.0625rem;
 }
 
@@ -2015,7 +2034,7 @@ p {
         content: " (" attr(title) ")";
     }
 
-    pre, blockquote, tr, img {
+    pre, blockquote, tr, img, object, svg {
         page-break-inside: avoid;
     }
 
@@ -2023,8 +2042,8 @@ p {
         display: table-header-group;
     }
 
-    img {
-        max-width: 100% !important;
+    svg {
+        max-width: 100%;
     }
 
     p, blockquote, dt, td.content {

--- a/opennms-doc/default-theme.yml
+++ b/opennms-doc/default-theme.yml
@@ -1,42 +1,41 @@
 font:
   catalog:
-    NotoSerif:
-      normal: notoserif-regular-latin.ttf
-      bold: notoserif-bold-latin.ttf
-      italic: notoserif-italic-latin.ttf
-      bold_italic: notoserif-bolditalic-latin.ttf
-    # NOTE currently, callout numbers don't work with LiberationMono
-    #LiberationMono:
-    #  normal: liberationmono-regular-latin.ttf
-    #  bold: liberationmono-bold-latin.ttf
-    #  italic: liberationmono-italic-latin.ttf
-    #  bold_italic: liberationmono-bolditalic-latin.ttf
-    Mplus1mn:
+    # Noto Serif supports Latin, Latin-1 Supplement, Latin Extended-A, Greek, Cyrillic, Vietnamese & an assortment of symbols
+    Noto Serif:
+      normal: notoserif-regular-subset.ttf
+      bold: notoserif-bold-subset.ttf
+      italic: notoserif-italic-subset.ttf
+      bold_italic: notoserif-bold_italic-subset.ttf
+    # M+ 1mn supports ASCII and the circled numbers used for conums
+    M+ 1mn:
       normal: mplus1mn-regular-ascii-conums.ttf
       bold: mplus1mn-bold-ascii.ttf
       italic: mplus1mn-italic-ascii.ttf
-      bold_italic: mplus1mn-bolditalic-ascii.ttf
-    Mplus1pMultilingual:
-      normal: mplus1p-regular-multilingual.ttf
-      bold: mplus1p-regular-multilingual.ttf
-      italic: mplus1p-regular-multilingual.ttf
-      bold_italic: mplus1p-regular-multilingual.ttf
-    #FontAwesome:
-    #  normal: fontawesome-regular.ttf
+      bold_italic: mplus1mn-bold_italic-ascii.ttf
+    # M+ 1p supports Latin, Latin-1 Supplement, Latin Extended, Greek, Cyrillic, Vietnamese, Japanese & an assortment of symbols
+    # It also provides arrows for ->, <-, => and <= replacements in case these glyphs are missing from font
+    M+ 1p Fallback:
+      normal: mplus1p-regular-fallback.ttf
+      bold: mplus1p-regular-fallback.ttf
+      italic: mplus1p-regular-fallback.ttf
+      bold_italic: mplus1p-regular-fallback.ttf
   fallbacks:
-    # NOTE M+ 1p doesn't support all CJK characters, but it at least has some coverage
-    - Mplus1pMultilingual
-brand:
-  primary_color: 428bca
+    - M+ 1p Fallback
 page:
   background_color: ffffff
   layout: portrait
-  # multiply inches by 72 to get pt values
-  margin: [0.5 * 72, 0.67 * 72, 0.67 * 72, 0.67 * 72]
-  size: a4
+  margin: [0.5in, 0.67in, 0.67in, 0.67in]
+  size: A4
 base:
+  align: justify
+  # color as hex string (leading # is optional)
   font_color: 333333
-  font_family: NotoSerif
+  # color as RGB array
+  #font_color: [51, 51, 51]
+  # color as CMYK array (approximated)
+  #font_color: [0, 0, 0, 0.92]
+  #font_color: [0, 0, 0, 92%]
+  font_family: Noto Serif
   # choose one of these font_size/line_height_length combinations
   #font_size: 14
   #line_height_length: 20
@@ -44,142 +43,205 @@ base:
   #line_height_length: 18
   #font_size: 11.2
   #line_height_length: 16
-  font_size: 8.5
+  font_size: 10.5
   #line_height_length: 15
-  # correct line height for NotoSerif metrics
+  # correct line height for Noto Serif metrics
   line_height_length: 12
   #font_size: 11.25
   #line_height_length: 18
   line_height: $base_line_height_length / $base_font_size
   font_size_large: round($base_font_size * 1.25)
   font_size_small: round($base_font_size * 0.85)
+  font_size_min: $base_font_size * 0.75
   font_style: normal
-  align: justify
+  border_color: eeeeee
   border_radius: 4
   border_width: 0.5
-  border_color: eeeeee
 # FIXME vertical_rhythm is weird; we should think in terms of ems
 #vertical_rhythm: $base_line_height_length * 2 / 3
-# correct line height for NotoSerif metrics
+# correct line height for Noto Serif metrics (comes with built-in line height)
 vertical_rhythm: $base_line_height_length
 horizontal_rhythm: $base_line_height_length
-link_font_color: $brand_primary_color
+# QUESTION should vertical_spacing be block_spacing instead?
+vertical_spacing: $vertical_rhythm
+link:
+  font_color: 428bca
+# literal is currently used for inline monospaced in prose and table cells
+literal:
+  font_color: b12146
+  font_family: M+ 1mn
 heading:
+  #font_color: 181818
   font_color: $base_font_color
   font_family: $base_font_family
-  # h1 is used for document title
-  font_size_h1: floor($base_font_size * 2.6)
-  # h2 is used for chapter title
-  font_size_h2: floor($base_font_size * 2.15)
-  font_size_h3: round($base_font_size * 1.7)
-  font_size_h4: $base_font_size_large
-  font_size_h5: $base_font_size
-  font_size_h6: $base_font_size_small
   font_style: bold
+  # h1 is used for part titles
+  h1_font_size: floor($base_font_size * 2.6)
+  # h2 is used for chapter titles
+  h2_font_size: floor($base_font_size * 2.15)
+  h3_font_size: round($base_font_size * 1.7)
+  h4_font_size: $base_font_size_large
+  h5_font_size: $base_font_size
+  h6_font_size: $base_font_size_small
   #line_height: 1.4
-  # correct line height for NotoSerif metrics
-  line_height: 1.2
-  margin_top: $vertical_rhythm * 0.2
-  margin_bottom: $vertical_rhythm * 0.8
-#prose:
-#  margin_top: 0
-#  margin_bottom: $vertical_rhythm 
+  # correct line height for Noto Serif metrics (comes with built-in line height)
+  line_height: 1
+  margin_top: $vertical_rhythm * 0.4
+  margin_bottom: $vertical_rhythm * 0.9
+title_page:
+  align: right
+  logo:
+    top: 10%
+  title:
+    top: 55%
+    font_size: $heading_h1_font_size
+    font_color: 999999
+    line_height: 0.9
+  subtitle:
+    font_size: $heading_h3_font_size
+    font_style: bold_italic
+    line_height: 1
+  authors:
+    margin_top: $base_font_size * 1.25
+    font_size: $base_font_size_large
+    font_color: 181818
+  revision:
+    margin_top: $base_font_size * 1.25
 block:
-  #margin_top: 0
-  #margin_bottom: $vertical_rhythm
-  padding: [$vertical_rhythm, $vertical_rhythm * 1.25, $vertical_rhythm, $vertical_rhythm * 1.25]
+  margin_top: 0
+  margin_bottom: $vertical_rhythm
+caption:
+  align: left
+  font_style: italic
+  # FIXME perhaps set line_height instead of / in addition to margins?
+  margin_inside: $vertical_rhythm / 3
+  #margin_inside: $vertical_rhythm / 4
+  margin_outside: 0
+lead:
+  font_size: $base_font_size_large
+  line_height: 1.4
+abstract:
+  font_color: 5c6266
+  font_size: $lead_font_size
+  line_height: $lead_line_height
+  font_style: italic
+  first_line_font_style: bold
+admonition:
+  border_color: $base_border_color
+  border_width: $base_border_width
+  padding: [0, $horizontal_rhythm, 0, $horizontal_rhythm]
+#  icon:
+#    tip:
+#      name: fa-lightbulb-o
+#      stroke_color: 111111
+#      size: 24
+blockquote:
+  font_color: $base_font_color
+  font_size: $base_font_size_large
+  border_color: $base_border_color
+  border_width: 5
+  padding: [$vertical_rhythm / 2, $horizontal_rhythm, $vertical_rhythm / -2, $horizontal_rhythm + $blockquote_border_width / 2]
+  cite_font_size: $base_font_size_small
+  cite_font_color: 999999
 # code is used for source blocks (perhaps change to source or listing?)
 code:
   font_color: $base_font_color
-  #font_family: LiberationMono
-  #font_size: floor($base_font_size * 0.9)
-  #font_size: 10
-  #padding: [9.5, 9.5, 9.5, 9.5]
-  # LiberationMono carries extra gap below line
-  #padding: [10, 10, 7.5, 10]
-  #line_height: 1.45
-  font_family: Mplus1mn
+  font_family: $literal_font_family
   font_size: ceil($base_font_size)
-  #padding: [$base_font_size, $code_font_size, $base_font_size, $code_font_size]
   padding: $code_font_size
   line_height: 1.25
   background_color: f5f5f5
   border_color: cccccc
   border_radius: $base_border_radius
   border_width: 0.75
-# literal is currently used for inline monospaced in prose and table cells
-literal:
-  #font_color: c7254e
-  font_color: b12146
-  font_family: $code_font_family
-blockquote:
-  font_color: $base_font_color
-  font_size: $base_font_size_large
-  border_width: 5
-  border_color: $base_border_color
-  cite_font_size: $base_font_size_small
-  cite_font_color: 999999
-sidebar:
-  border_color: ffffff
-  border_radius: $base_border_radius
-  border_width: $base_border_width
-  background_color: eeeeee
-  title_font_color: $heading_font_color
-  title_font_family: $heading_font_family
-  title_font_size: $heading_font_size_h4
-  title_font_style: $heading_font_style
-  title_align: center
+conum:
+  font_family: M+ 1mn
+  font_color: $literal_font_color
+  font_size: $base_font_size
+  line_height: 4 / 3
 example:
   border_color: $base_border_color
   border_radius: $base_border_radius
   border_width: 0.75
   background_color: transparent
-admonition:
-  border_color: $base_border_color
-  border_width: $base_border_width
-caption:
-  font_style: italic
-  align: left
-  # FIXME perhaps set line_height instead of / in addition to margins?
-  margin_inside: $vertical_rhythm * 0.25
-  margin_outside: 0
-conum:
-  font_family: Mplus1mn
-  font_color: $literal_font_color
-  font_size: $code_font_size
+  # FIXME reenable margin bottom once margin collapsing is implemented
+  padding: [$vertical_rhythm, $horizontal_rhythm, 0, $horizontal_rhythm]
 image:
-  align_default: left
-  scaled_width_default: 0.5
-lead:
-  # QUESTION what about $base_font_size_large?
-  #font_size: floor($base_line_height_length * 0.8)
-  #font_size: floor($base_font_size * 1.15)
-  #line_height: 1.3
-  font_size: $base_font_size_large
-  line_height: 1.4
-abstract:
-  #font_color: 404040
-  font_color: 5c6266
-  font_size: $lead_font_size
-  line_height: $lead_line_height
-  font_style: italic
+  align: left
+prose:
+  margin_top: 0
+  margin_bottom: $vertical_rhythm
+sidebar:
+  border_color: $page_background_color
+  border_radius: $base_border_radius
+  border_width: $base_border_width
+  background_color: eeeeee
+  # FIXME reenable margin bottom once margin collapsing is implemented
+  padding: [$vertical_rhythm, $vertical_rhythm * 1.25, 0, $vertical_rhythm * 1.25]
+  title:
+    align: center
+    font_color: $heading_font_color
+    font_family: $heading_font_family
+    font_size: $heading_h4_font_size
+    font_style: $heading_font_style
 thematic_break:
   border_color: $base_border_color
+  border_style: solid
+  border_width: $base_border_width
   margin_top: $vertical_rhythm * 0.5
   margin_bottom: $vertical_rhythm * 1.5
 description_list:
   term_font_style: italic
+  term_spacing: $vertical_rhythm / 4
   description_indent: $horizontal_rhythm * 1.25
 outline_list:
-  indent: $horizontal_rhythm * 1.25
+  indent: $horizontal_rhythm * 1.5
+  # NOTE item_spacing applies to list items that do not have complex content
+  item_spacing: $vertical_rhythm / 2
+  #marker_font_color: 404040
 table:
-  background_color: transparent
-  background_color_alt: f9f9f9
+  background_color: $page_background_color
+  #head_background_color: <hex value>
+  #head_font_color: $base_font_color
+  head_font_style: bold
+  even_row_background_color: f9f9f9
+  #odd_row_background_color: <hex value>
+  foot_background_color: f0f0f0
   border_color: dddddd
   border_width: $base_border_width
   # HACK accounting for line-height
   cell_padding: [3, 3, 6, 3]
+toc:
+  dot_leader_color: dddddd
+  #dot_leader_content: '. '
+  indent: $horizontal_rhythm
+  line_height: 1.4
+# NOTE In addition to footer, header is also supported
 footer:
   font_size: $base_font_size_small
   font_color: $base_font_color
+  # NOTE if background_color is set, background and border will span width of page
   border_color: dddddd
+  border_width: 0.25
+  height: $base_line_height_length * 2.5
+  line_height: 1
+  padding: [$base_line_height_length / 2, 1, 0, 1]
+  vertical_align: top
+  #image_vertical_align: <alignment> or <number>
+  # additional attributes for content:
+  # * {page-count}
+  # * {page-number}
+  # * {document-title}
+  # * {document-subtitle}
+  # * {chapter-title}
+  # * {section-title}
+  # * {section-or-chapter-title}
+  recto_content:
+    #right: '{section-or-chapter-title} | {page-number}'
+    #right: '{document-title} | {page-number}'
+    right: '{page-number}'
+    #center: '{page-number}'
+  verso_content:
+    #left: '{page-number} | {chapter-title}'
+    left: '{page-number}'
+    #center: '{page-number}'

--- a/pom.xml
+++ b/pom.xml
@@ -1215,9 +1215,9 @@
     <oldAsmVersion>99.99.99-exclude-and-use-org.ow2.asm.asm-all-instead</oldAsmVersion>
     <args4jVersion>2.32</args4jVersion>
     <asmVersion>5.0.4</asmVersion>
-    <asciidoctorVersion>1.5.2.1</asciidoctorVersion>
-    <asciidoctorjVersion>1.5.2</asciidoctorjVersion>
-    <asciidoctorjPdfVersion>1.5.0-alpha.6</asciidoctorjPdfVersion>
+    <asciidoctorVersion>1.5.3</asciidoctorVersion>
+    <asciidoctorjVersion>1.5.3.2</asciidoctorjVersion>
+    <asciidoctorjPdfVersion>1.5.0-alpha.10.1</asciidoctorjPdfVersion>
     <activemqVersion>5.10.0</activemqVersion>
     <atomikosVersion>3.9.2</atomikosVersion>
     <camelVersion>2.14.1</camelVersion>
@@ -1251,7 +1251,7 @@
     <jerseyVersion>1.19</jerseyVersion>
     <jerseyContribVersion>1.19</jerseyContribVersion>
     <jodaTimeVersion>2.1</jodaTimeVersion>
-    <jrubyVersion>9.0.0.0</jrubyVersion>
+    <jrubyVersion>9.0.4.0</jrubyVersion>
     <jsoupVersion>1.7.2</jsoupVersion>
     <karafVersion>2.4.0</karafVersion>
     <karafPaxExamVersion>2.3.9</karafPaxExamVersion>


### PR DESCRIPTION
Updated the asciidoc framework dependencies to latest versions.

- asciidoctor 1.5.2.1 > 1.5.3
- asciidoctorj 1.5.2 > 1.5.3.2
- asciidoctorjpdf 1.5.0-alpha.6 > 1.5.0-alpha.10.1
- jruby 9.0.0.0 > 9.0.4.0

Default themes in CSS and PDF yaml styles are updated.

JIRA: http://issues.opennms.org/browse/NMS-8063
Bamboo: http://bamboo.internal.opennms.com:8085/browse/OPENNMS-ONMS351