### PR TITLE
NMS-8077: Add Netgear ProSafe Smart Switch SNMP trap and syslog definitions and events

### DIFF
--- a/integration-tests/config/src/test/java/org/opennms/netmgt/config/WillItUnmarshalCoverageMetaIT.java
+++ b/integration-tests/config/src/test/java/org/opennms/netmgt/config/WillItUnmarshalCoverageMetaIT.java
@@ -125,6 +125,7 @@ public class WillItUnmarshalCoverageMetaIT {
 
         ignoreFile(new File(getDaemonEtcDirectory(), "syslog/ApacheHTTPD.syslog.xml"));
         ignoreFile(new File(getDaemonEtcDirectory(), "syslog/LinuxKernel.syslog.xml"));
+        ignoreFile(new File(getDaemonEtcDirectory(), "syslog/NetgearProsafeSmartSwitch.syslog.xml"));
         ignoreFile(new File(getDaemonEtcDirectory(), "syslog/OpenSSH.syslog.xml"));
         ignoreFile(new File(getDaemonEtcDirectory(), "syslog/Procmail.syslog.xml"));
         ignoreFile(new File(getDaemonEtcDirectory(), "syslog/POSIX.syslog.xml"));

--- a/opennms-base-assembly/src/main/filtered/etc/eventconf.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/eventconf.xml
@@ -172,6 +172,8 @@
   <event-file>events/NetApp.events.xml</event-file>
   <event-file>events/Netbotz.events.xml</event-file>
   <event-file>events/Netgear.events.xml</event-file>
+  <event-file>events/NetgearProsafeSmartSwitch.events.xml</event-file>
+  <event-file>events/NetgearProsafeSmartSwitch.syslog.events.xml</event-file>
   <event-file>events/Netscreen.events.xml</event-file>
   <event-file>events/NetSNMP.events.xml</event-file>
   <event-file>events/Nokia.events.xml</event-file>

--- a/opennms-base-assembly/src/main/filtered/etc/events/NetgearProsafeSmartSwitch.events.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/events/NetgearProsafeSmartSwitch.events.xml
@@ -1,0 +1,389 @@
+<!-- Define traps sent by NetGear ProSafe Smart Switch line
+     {iso(1) identified-organization(3) dod(6) internet(1) private(4) enterprise(1) netgear(4526) ng700smartswitch(11) agentSwitching(1)
+     see NetGear-provided ng_switching.my MIB file (last updated 17 Mar 2008 12:00:00 GMT) included on switch CD
+-->
+
+<events xmlns="http://xmlns.opennms.org/xsd/eventconf">
+<event>
+	<mask>
+		<maskelement>
+			<mename>id</mename>
+			<mevalue>.1.3.6.1.4.1.4526.11.1</mevalue>
+		</maskelement>
+		<maskelement>
+			<mename>generic</mename>
+			<mevalue>6</mevalue>
+		</maskelement>
+		<maskelement>
+			<mename>specific</mename>
+			<mevalue>1</mevalue>
+		</maskelement>
+	</mask>
+	<uei>uei.opennms.org/vendor/netgear/traps/multipleUsersTrap</uei>
+	<event-label>NETGEAR-SWITCHING-MIB defined trap event: multipleUsersTrap</event-label>
+	<descr>
+&lt;p&gt;trapMgrMultipleUsersLogTrap.&lt;/p&gt;&lt;table&gt;&lt;/table&gt;
+	</descr>
+		<logmsg dest='logndisplay'>&lt;p&gt;
+			Netgear Event: multipleUsersTrap trap received&lt;/p&gt;
+		</logmsg>
+	<severity>Warning</severity>
+</event>
+<event>
+	<mask>
+		<maskelement>
+			<mename>id</mename>
+			<mevalue>.1.3.6.1.4.1.4526.11.1</mevalue>
+		</maskelement>
+		<maskelement>
+			<mename>generic</mename>
+			<mevalue>6</mevalue>
+		</maskelement>
+		<maskelement>
+			<mename>specific</mename>
+			<mevalue>2</mevalue>
+		</maskelement>
+	</mask>
+	<uei>uei.opennms.org/vendor/netgear/traps/broadcastStormStartTrap</uei>
+	<event-label>NETGEAR-SWITCHING-MIB defined trap event: broadcastStormStartTrap</event-label>
+	<descr>
+&lt;p&gt;trapMgrBCastStormStartLogTrap.&lt;/p&gt;&lt;table&gt;&lt;/table&gt;
+	</descr>
+		<logmsg dest='logndisplay'>&lt;p&gt;
+			Netgear Event: broadcastStormStartTrap trap received&lt;/p&gt;
+		</logmsg>
+	<severity>Warning</severity>
+</event>
+<event>
+	<mask>
+		<maskelement>
+			<mename>id</mename>
+			<mevalue>.1.3.6.1.4.1.4526.11.1</mevalue>
+		</maskelement>
+		<maskelement>
+			<mename>generic</mename>
+			<mevalue>6</mevalue>
+		</maskelement>
+		<maskelement>
+			<mename>specific</mename>
+			<mevalue>3</mevalue>
+		</maskelement>
+	</mask>
+	<uei>uei.opennms.org/vendor/netgear/traps/broadcastStormEndTrap</uei>
+	<event-label>NETGEAR-SWITCHING-MIB defined trap event: broadcastStormEndTrap</event-label>
+	<descr>
+&lt;p&gt;trapMgrBCastStormEndLogTrap.&lt;/p&gt;&lt;table&gt;&lt;/table&gt;
+	</descr>
+		<logmsg dest='logndisplay'>&lt;p&gt;
+			Netgear Event: broadcastStormEndTrap trap received&lt;/p&gt;
+		</logmsg>
+	<severity>Cleared</severity>
+</event>
+<event>
+	<mask>
+		<maskelement>
+			<mename>id</mename>
+			<mevalue>.1.3.6.1.4.1.4526.11.1</mevalue>
+		</maskelement>
+		<maskelement>
+			<mename>generic</mename>
+			<mevalue>6</mevalue>
+		</maskelement>
+		<maskelement>
+			<mename>specific</mename>
+			<mevalue>4</mevalue>
+		</maskelement>
+	</mask>
+	<uei>uei.opennms.org/vendor/netgear/traps/linkFailureTrap</uei>
+	<event-label>NETGEAR-SWITCHING-MIB defined trap event: linkFailureTrap</event-label>
+	<descr>
+&lt;p&gt;trapMgrLinkFailureLogTrap.&lt;/p&gt;&lt;table&gt;&lt;/table&gt;
+	</descr>
+		<logmsg dest='logndisplay'>&lt;p&gt;
+			Netgear Event: linkFailureTrap trap received&lt;/p&gt;
+		</logmsg>
+	<severity>Minor</severity>
+</event>
+<event>
+	<mask>
+		<maskelement>
+			<mename>id</mename>
+			<mevalue>.1.3.6.1.4.1.4526.11.1</mevalue>
+		</maskelement>
+		<maskelement>
+			<mename>generic</mename>
+			<mevalue>6</mevalue>
+		</maskelement>
+		<maskelement>
+			<mename>specific</mename>
+			<mevalue>5</mevalue>
+		</maskelement>
+	</mask>
+	<uei>uei.opennms.org/vendor/netgear/traps/vlanRequestFailureTrap</uei>
+	<event-label>NETGEAR-SWITCHING-MIB defined trap event: vlanRequestFailureTrap</event-label>
+	<descr>
+&lt;p&gt;trapMgrVlanRequestFailureLogTrap&lt;/p&gt;&lt;table&gt;
+	&lt;tr&gt;&lt;td&gt;&lt;b&gt;
+
+	dot1qVlanIndex&lt;/b&gt;&lt;/td&gt;&lt;td&gt;
+	%parm[#1]%;&lt;/td&gt;&lt;td&gt;&lt;p;&gt;&lt;/p&gt;&lt;/td;&gt;&lt;/tr&gt;&lt;/table&gt;
+	</descr>
+		<logmsg dest='logndisplay'>&lt;p&gt;
+			Netgear Event: vlanRequestFailureTrap trap received 
+			dot1qVlanIndex=%parm[#1]%&lt;/p&gt;
+		</logmsg>
+	<severity>Warning</severity>
+</event>
+<event>
+	<mask>
+		<maskelement>
+			<mename>id</mename>
+			<mevalue>.1.3.6.1.4.1.4526.11.1</mevalue>
+		</maskelement>
+		<maskelement>
+			<mename>generic</mename>
+			<mevalue>6</mevalue>
+		</maskelement>
+		<maskelement>
+			<mename>specific</mename>
+			<mevalue>6</mevalue>
+		</maskelement>
+	</mask>
+	<uei>uei.opennms.org/vendor/netgear/traps/vlanDeleteLastTrap</uei>
+	<event-label>NETGEAR-SWITCHING-MIB defined trap event: vlanDeleteLastTrap</event-label>
+	<descr>
+&lt;p&gt;trapMgrLastVlanDeleteLastLogTrap&lt;/p&gt;&lt;table&gt;
+	&lt;tr&gt;&lt;td&gt;&lt;b&gt;
+
+	dot1qVlanIndex&lt;/b&gt;&lt;/td&gt;&lt;td&gt;
+	%parm[#1]%;&lt;/td&gt;&lt;td&gt;&lt;p;&gt;&lt;/p&gt;&lt;/td;&gt;&lt;/tr&gt;&lt;/table&gt;
+	</descr>
+		<logmsg dest='logndisplay'>&lt;p&gt;
+			Netgear Event: vlanDeleteLastTrap trap received 
+			dot1qVlanIndex=%parm[#1]%&lt;/p&gt;
+		</logmsg>
+	<severity>Warning</severity>
+</event>
+<event>
+	<mask>
+		<maskelement>
+			<mename>id</mename>
+			<mevalue>.1.3.6.1.4.1.4526.11.1</mevalue>
+		</maskelement>
+		<maskelement>
+			<mename>generic</mename>
+			<mevalue>6</mevalue>
+		</maskelement>
+		<maskelement>
+			<mename>specific</mename>
+			<mevalue>7</mevalue>
+		</maskelement>
+	</mask>
+	<uei>uei.opennms.org/vendor/netgear/traps/vlanDefaultCfgFailureTrap</uei>
+	<event-label>NETGEAR-SWITCHING-MIB defined trap event: vlanDefaultCfgFailureTrap</event-label>
+	<descr>
+&lt;p&gt;trapMgrDefaultVlanCfgFailureLogTrap&lt;/p&gt;&lt;table&gt;
+	&lt;tr&gt;&lt;td&gt;&lt;b&gt;
+
+	dot1qVlanIndex&lt;/b&gt;&lt;/td&gt;&lt;td&gt;
+	%parm[#1]%;&lt;/td&gt;&lt;td&gt;&lt;p;&gt;&lt;/p&gt;&lt;/td;&gt;&lt;/tr&gt;&lt;/table&gt;
+	</descr>
+		<logmsg dest='logndisplay'>&lt;p&gt;
+			Netgear Event: vlanDefaultCfgFailureTrap trap received 
+			dot1qVlanIndex=%parm[#1]%&lt;/p&gt;
+		</logmsg>
+	<severity>Warning</severity>
+</event>
+<event>
+	<mask>
+		<maskelement>
+			<mename>id</mename>
+			<mevalue>.1.3.6.1.4.1.4526.11.1</mevalue>
+		</maskelement>
+		<maskelement>
+			<mename>generic</mename>
+			<mevalue>6</mevalue>
+		</maskelement>
+		<maskelement>
+			<mename>specific</mename>
+			<mevalue>8</mevalue>
+		</maskelement>
+	</mask>
+	<uei>uei.opennms.org/vendor/netgear/traps/vlanRestoreFailureTrap</uei>
+	<event-label>NETGEAR-SWITCHING-MIB defined trap event: vlanRestoreFailureTrap</event-label>
+	<descr>
+&lt;p&gt;trapMgrVlanRestoreFailureLogTrap&lt;/p&gt;&lt;table&gt;
+	&lt;tr&gt;&lt;td&gt;&lt;b&gt;
+
+	dot1qVlanIndex&lt;/b&gt;&lt;/td&gt;&lt;td&gt;
+	%parm[#1]%;&lt;/td&gt;&lt;td&gt;&lt;p;&gt;&lt;/p&gt;&lt;/td;&gt;&lt;/tr&gt;&lt;/table&gt;
+	</descr>
+		<logmsg dest='logndisplay'>&lt;p&gt;
+			Netgear Event: vlanRestoreFailureTrap trap received 
+			dot1qVlanIndex=%parm[#1]%&lt;/p&gt;
+		</logmsg>
+	<severity>Warning</severity>
+</event>
+<event>
+	<mask>
+		<maskelement>
+			<mename>id</mename>
+			<mevalue>.1.3.6.1.4.1.4526.11.1</mevalue>
+		</maskelement>
+		<maskelement>
+			<mename>generic</mename>
+			<mevalue>6</mevalue>
+		</maskelement>
+		<maskelement>
+			<mename>specific</mename>
+			<mevalue>9</mevalue>
+		</maskelement>
+	</mask>
+	<uei>uei.opennms.org/vendor/netgear/traps/fanFailureTrap</uei>
+	<event-label>NETGEAR-SWITCHING-MIB defined trap event: fanFailureTrap</event-label>
+	<descr>
+&lt;p&gt;trapMgrFanFailureLogTrap.&lt;/p&gt;&lt;table&gt;&lt;/table&gt;
+	</descr>
+		<logmsg dest='logndisplay'>&lt;p&gt;
+			Netgear Event: fanFailureTrap trap received&lt;/p&gt;
+		</logmsg>
+	<severity>Minor</severity>
+</event>
+<event>
+	<mask>
+		<maskelement>
+			<mename>id</mename>
+			<mevalue>.1.3.6.1.4.1.4526.11.1</mevalue>
+		</maskelement>
+		<maskelement>
+			<mename>generic</mename>
+			<mevalue>6</mevalue>
+		</maskelement>
+		<maskelement>
+			<mename>specific</mename>
+			<mevalue>10</mevalue>
+		</maskelement>
+	</mask>
+	<uei>uei.opennms.org/vendor/netgear/traps/stpInstanceNewRootTrap</uei>
+	<event-label>NETGEAR-SWITCHING-MIB defined trap event: stpInstanceNewRootTrap</event-label>
+	<descr>
+&lt;p&gt;trapMgrStpInstanceNewRootTrap&lt;/p&gt;&lt;table&gt;
+	&lt;tr&gt;&lt;td&gt;&lt;b&gt;
+
+	agentStpMstId&lt;/b&gt;&lt;/td&gt;&lt;td&gt;
+	%parm[#1]%;&lt;/td&gt;&lt;td&gt;&lt;p;&gt;&lt;/p&gt;&lt;/td;&gt;&lt;/tr&gt;&lt;/table&gt;
+	</descr>
+		<logmsg dest='logndisplay'>&lt;p&gt;
+			Netgear Event: stpInstanceNewRootTrap trap received 
+			agentStpMstId=%parm[#1]%&lt;/p&gt;
+		</logmsg>
+	<severity>Normal</severity>
+</event>
+<event>
+	<mask>
+		<maskelement>
+			<mename>id</mename>
+			<mevalue>.1.3.6.1.4.1.4526.11.1</mevalue>
+		</maskelement>
+		<maskelement>
+			<mename>generic</mename>
+			<mevalue>6</mevalue>
+		</maskelement>
+		<maskelement>
+			<mename>specific</mename>
+			<mevalue>11</mevalue>
+		</maskelement>
+	</mask>
+	<uei>uei.opennms.org/vendor/netgear/traps/stpInstanceTopologyChangeTrap</uei>
+	<event-label>NETGEAR-SWITCHING-MIB defined trap event: stpInstanceTopologyChangeTrap</event-label>
+	<descr>
+&lt;p&gt;trapMgrStpInstanceTopologyChange&lt;/p&gt;&lt;table&gt;
+	&lt;tr&gt;&lt;td&gt;&lt;b&gt;
+
+	agentStpMstId&lt;/b&gt;&lt;/td&gt;&lt;td&gt;
+	%parm[#1]%;&lt;/td&gt;&lt;td&gt;&lt;p;&gt;&lt;/p&gt;&lt;/td;&gt;&lt;/tr&gt;&lt;/table&gt;
+	</descr>
+		<logmsg dest='logndisplay'>&lt;p&gt;
+			Netgear Event: stpInstanceTopologyChangeTrap trap received 
+			agentStpMstId=%parm[#1]%&lt;/p&gt;
+		</logmsg>
+	<severity>Normal</severity>
+</event>
+<event>
+	<mask>
+		<maskelement>
+			<mename>id</mename>
+			<mevalue>.1.3.6.1.4.1.4526.11.1</mevalue>
+		</maskelement>
+		<maskelement>
+			<mename>generic</mename>
+			<mevalue>6</mevalue>
+		</maskelement>
+		<maskelement>
+			<mename>specific</mename>
+			<mevalue>12</mevalue>
+		</maskelement>
+	</mask>
+	<uei>uei.opennms.org/vendor/netgear/traps/powerSupplyStatusChangeTrap</uei>
+	<event-label>NETGEAR-SWITCHING-MIB defined trap event: powerSupplyStatusChangeTrap</event-label>
+	<descr>
+&lt;p&gt;powerSupplyStatusChangeTrap&lt;/p&gt;&lt;table&gt;&lt;/table&gt;
+	</descr>
+		<logmsg dest='logndisplay'>&lt;p&gt;
+			Netgear Event: powerSupplyStatusChangeTrap trap received&lt;/p&gt;
+		</logmsg>
+	<severity>Minor</severity>
+</event>
+<event>
+	<mask>
+		<maskelement>
+			<mename>id</mename>
+			<mevalue>.1.3.6.1.4.1.4526.11.1</mevalue>
+		</maskelement>
+		<maskelement>
+			<mename>generic</mename>
+			<mevalue>6</mevalue>
+		</maskelement>
+		<maskelement>
+			<mename>specific</mename>
+			<mevalue>13</mevalue>
+		</maskelement>
+	</mask>
+	<uei>uei.opennms.org/vendor/netgear/traps/failedUserLoginTrap</uei>
+	<event-label>NETGEAR-SWITCHING-MIB defined trap event: failedUserLoginTrap</event-label>
+	<descr>
+&lt;p&gt;failedUserLoginTrap&lt;/p&gt;&lt;table&gt;&lt;/table&gt;
+	</descr>
+		<logmsg dest='logndisplay'>&lt;p&gt;
+			Netgear Event: failedUserLoginTrap trap received&lt;/p&gt;
+		</logmsg>
+	<severity>Warning</severity>
+</event>
+<event>
+        <mask>
+                <maskelement>
+                        <mename>id</mename>
+                        <mevalue>.1.3.6.1.4.1.4526.11.1</mevalue>
+                </maskelement>
+                <maskelement>
+                        <mename>generic</mename>
+                        <mevalue>6</mevalue>
+                </maskelement>
+                <maskelement>
+                        <mename>specific</mename>
+                        <mevalue>14</mevalue>
+                </maskelement>
+        </mask>
+        <uei>uei.opennms.org/vendor/netgear/traps/userLockoutTrap</uei>
+        <event-label>NETGEAR-SWITCHING-MIB defined trap event: userLockoutTrap</event-label>
+        <descr>
+&lt;p&gt;userLockoutTrap&lt;/p&gt;&lt;table&gt;&lt;/table&gt;
+        </descr>
+                <logmsg dest='logndisplay'>&lt;p&gt;
+                        Netgear Event: userLockoutTrap trap received&lt;/p&gt;
+                </logmsg>
+        <severity>Warning</severity>
+</event>
+
+<!-- End of data -->
+</events>

--- a/opennms-base-assembly/src/main/filtered/etc/events/NetgearProsafeSmartSwitch.events.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/events/NetgearProsafeSmartSwitch.events.xml
@@ -77,7 +77,7 @@
 		<logmsg dest='logndisplay'>&lt;p&gt;
 			Netgear Event: broadcastStormEndTrap trap received&lt;/p&gt;
 		</logmsg>
-	<severity>Cleared</severity>
+	<severity>Normal</severity>
 </event>
 <event>
 	<mask>

--- a/opennms-base-assembly/src/main/filtered/etc/events/NetgearProsafeSmartSwitch.syslog.events.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/events/NetgearProsafeSmartSwitch.syslog.events.xml
@@ -1,0 +1,498 @@
+<events>
+
+<!--
+Netgear Prosafe Smart Switch syslog events
+
+Event severities are listed in the order from least important to most important
+-->
+
+  <!-- Debug level syslog messages -->
+  <event>
+    <uei>uei.opennms.org/vendor/netgear/syslog/prosafesmartswitch/Debug/NTPServerVersionNotCompatible</uei>
+    <event-label>Netgear debug syslog message event: NTPServerVersionNotCompatible</event-label>
+    <descr>
+       &lt;p&gt;The interface %interface% generated a syslog message: NTPServerVersionNotCompatible&lt;br&gt;
+       Node ID: %nodeid%&lt;br&gt;
+       Host: %nodelabel%&lt;br&gt;
+       Interface: %interface% &lt;br&gt;
+       Syslog severity: %parm[severity]% &lt;br&gt;
+       OpenNMS severity: %severity% &lt;br&gt;
+       Message: %parm[syslogmessage]% &lt;br&gt;
+       Process: %parm[process]% &lt;br&gt;
+       PID: %parm[processid]%
+       &lt;/p&gt;
+     </descr>
+     <logmsg dest='logndisplay'>
+       &lt;p&gt;A Netgear debug syslog message has been received&lt;/p&gt;
+       Message: %parm[process]%: %parm[syslogmessage]% &lt;br&gt;
+     </logmsg>
+     <severity>Normal</severity>
+  </event>
+  <!-- catch-all event for other Debug syslog messages -->
+  <event>
+    <uei>~uei\.opennms\.org/vendor/netgear/syslog/prosafesmartswitch/Debug/.*</uei>
+    <event-label>Netgear debug syslog message event: syslogMessage</event-label>
+    <descr>
+       &lt;p&gt;The interface %interface% generated a syslog message.&lt;br&gt;
+       Node ID: %nodeid%&lt;br&gt;
+       Host: %nodelabel%&lt;br&gt;
+       Interface: %interface% &lt;br&gt;
+       Syslog severity: %parm[severity]% &lt;br&gt;
+       OpenNMS severity: %severity% &lt;br&gt;
+       Message: %parm[syslogmessage]% &lt;br&gt;
+       Process: %parm[process]% &lt;br&gt;
+       PID: %parm[processid]%
+       &lt;/p&gt;
+     </descr>
+     <logmsg dest='logndisplay'>
+       &lt;p&gt;A Netgear debug syslog message has been received&lt;/p&gt;
+       Message: %parm[process]%: %parm[syslogmessage]% &lt;br&gt;
+     </logmsg>
+     <severity>Normal</severity>
+  </event>
+
+  <!-- Informational level syslog messages -->
+  <event>
+    <uei>uei.opennms.org/vendor/netgear/syslog/prosafesmartswitch/Informational/WebConsoleLogin</uei>
+    <event-label>Netgear informational syslog message event: WebConsoleLogin</event-label>
+    <descr>
+       &lt;p&gt;The interface %interface% generated a syslog message: WebConsoleLogin&lt;br&gt;
+       Username: %parm[userName]%&lt;br&gt;
+       Source IP: %parm[sourceIP]%&lt;br&gt;
+       Destination IP: %parm[destinationIP]%&lt;br&gt;
+       &lt;br&gt;
+       Node ID: %nodeid%&lt;br&gt;
+       Host: %nodelabel%&lt;br&gt;
+       Interface: %interface% &lt;br&gt;
+       Syslog severity: %parm[severity]% &lt;br&gt;
+       OpenNMS severity: %severity% &lt;br&gt;
+       Message: %parm[syslogmessage]% &lt;br&gt;
+       Process: %parm[process]% &lt;br&gt;
+       PID: %parm[processid]%
+       &lt;/p&gt;
+     </descr>
+     <logmsg dest='logndisplay'>
+       &lt;p&gt;A Netgear informational syslog message WebConsoleLogin has been received&lt;/p&gt;
+       Message: %parm[process]%: %parm[syslogmessage]% &lt;br&gt;
+     </logmsg>
+     <severity>Normal</severity>
+  </event>
+  <event>
+    <uei>uei.opennms.org/vendor/netgear/syslog/prosafesmartswitch/Informational/WebConsoleLogout</uei>
+    <event-label>Netgear informational syslog message event: WebConsoleLogout</event-label>
+    <descr>
+       &lt;p&gt;The interface %interface% generated a syslog message: WebConsoleLogout&lt;br&gt;
+       Username: %parm[userName]%&lt;br&gt;
+       Source IP: %parm[sourceIP]%&lt;br&gt;
+       Destination IP: %parm[destinationIP]%&lt;br&gt;
+       &lt;br&gt;
+       Node ID: %nodeid%&lt;br&gt;
+       Host: %nodelabel%&lt;br&gt;
+       Interface: %interface% &lt;br&gt;
+       Syslog severity: %parm[severity]% &lt;br&gt;
+       OpenNMS severity: %severity% &lt;br&gt;
+       Message: %parm[syslogmessage]% &lt;br&gt;
+       Process: %parm[process]% &lt;br&gt;
+       PID: %parm[processid]%
+       &lt;/p&gt;
+     </descr>
+     <logmsg dest='logndisplay'>
+       &lt;p&gt;A Netgear informational syslog message WebConsoleLogout has been received&lt;/p&gt;
+       Message: %parm[process]%: %parm[syslogmessage]% &lt;br&gt;
+     </logmsg>
+     <severity>Normal</severity>
+  </event>
+  <event>
+    <uei>uei.opennms.org/vendor/netgear/syslog/prosafesmartswitch/Informational/PortStatusLinkUp</uei>
+    <event-label>Netgear informational syslog message event: PortStatusLinkUp</event-label>
+    <descr>
+       &lt;p&gt;The interface %interface% generated a syslog message: PortStatusLinkUp&lt;br&gt;
+       Port name: %parm[portName]%&lt;br&gt;
+       &lt;br&gt;
+       Node ID: %nodeid%&lt;br&gt;
+       Host: %nodelabel%&lt;br&gt;
+       Interface: %interface% &lt;br&gt;
+       Syslog severity: %parm[severity]% &lt;br&gt;
+       OpenNMS severity: %severity% &lt;br&gt;
+       Message: %parm[syslogmessage]% &lt;br&gt;
+       Process: %parm[process]% &lt;br&gt;
+       PID: %parm[processid]%
+       &lt;/p&gt;
+     </descr>
+     <logmsg dest='logndisplay'>
+       &lt;p&gt;A Netgear informational syslog message PortStatusLinkUp has been received&lt;/p&gt;
+       Message: %parm[process]%: %parm[syslogmessage]% &lt;br&gt;
+     </logmsg>
+     <severity>Normal</severity>
+  </event>
+  <event>
+    <uei>uei.opennms.org/vendor/netgear/syslog/prosafesmartswitch/Informational/DHCPAddressRenewed</uei>
+    <event-label>Netgear informational syslog message event: DHCPAddressRenewed</event-label>
+    <descr>
+       &lt;p&gt;The interface %interface% generated a syslog message: DHCPAddressRenewed&lt;br&gt;
+       Node ID: %nodeid%&lt;br&gt;
+       Host: %nodelabel%&lt;br&gt;
+       Interface: %interface% &lt;br&gt;
+       Syslog severity: %parm[severity]% &lt;br&gt;
+       OpenNMS severity: %severity% &lt;br&gt;
+       Message: %parm[syslogmessage]% &lt;br&gt;
+       Process: %parm[process]% &lt;br&gt;
+       PID: %parm[processid]%
+       &lt;/p&gt;
+     </descr>
+     <logmsg dest='logndisplay'>
+       &lt;p&gt;A Netgear informational syslog message DHCPAddressRenewed has been received&lt;/p&gt;
+       Message: %parm[process]%: %parm[syslogmessage]% &lt;br&gt;
+     </logmsg>
+     <severity>Normal</severity>
+  </event>
+  <!-- catch-all event for other Informational syslog messages -->
+  <event>
+    <uei>~uei\.opennms\.org/vendor/netgear/syslog/prosafesmartswitch/Informational/.*</uei>
+    <event-label>Netgear informational syslog message event: syslogMessage</event-label>
+    <descr>
+       &lt;p&gt;The interface %interface% generated a syslog message.&lt;br&gt;
+       Node ID: %nodeid%&lt;br&gt;
+       Host: %nodelabel%&lt;br&gt;
+       Interface: %interface% &lt;br&gt;
+       Syslog severity: %parm[severity]% &lt;br&gt;
+       OpenNMS severity: %severity% &lt;br&gt;
+       Message: %parm[syslogmessage]% &lt;br&gt;
+       Process: %parm[process]% &lt;br&gt;
+       PID: %parm[processid]%
+       &lt;/p&gt;
+     </descr>
+     <logmsg dest='logndisplay'>
+       &lt;p&gt;A Netgear informational syslog message has been received&lt;/p&gt;
+       Message: %parm[process]%: %parm[syslogmessage]% &lt;br&gt;
+     </logmsg>
+     <severity>Normal</severity>
+  </event>
+
+  <!-- Notice level syslog messages -->
+  <event>
+    <uei>uei.opennms.org/vendor/netgear/syslog/prosafesmartswitch/Notice/FirmwareCopyCompletedSuccessfully</uei>
+    <event-label>Netgear notice syslog message event: FirmwareCopyCompletedSuccessfully</event-label>
+    <descr>
+       &lt;p&gt;The interface %interface% generated a syslog message: FirmwareCopyCompletedSuccessfully&lt;br&gt;
+       Node ID: %nodeid%&lt;br&gt;
+       Host: %nodelabel%&lt;br&gt;
+       Interface: %interface% &lt;br&gt;
+       Syslog severity: %parm[severity]% &lt;br&gt;
+       OpenNMS severity: %severity% &lt;br&gt;
+       Message: %parm[syslogmessage]% &lt;br&gt;
+       Process: %parm[process]% &lt;br&gt;
+       PID: %parm[processid]%
+       &lt;/p&gt;
+     </descr>
+     <logmsg dest='logndisplay'>
+       &lt;p&gt;A Netgear notice syslog message FirmwareCopyCompletedSuccessfully has been received&lt;/p&gt;
+       Message: %parm[process]%: %parm[syslogmessage]% &lt;br&gt;
+     </logmsg>
+     <severity>Normal</severity>
+  </event>
+  <event>
+    <uei>uei.opennms.org/vendor/netgear/syslog/prosafesmartswitch/Notice/SwitchConfigUpdateStart</uei>
+    <event-label>Netgear notice syslog message event: SwitchConfigUpdateStart</event-label>
+    <descr>
+       &lt;p&gt;The interface %interface% generated a syslog message: SwitchConfigUpdateStart&lt;br&gt;
+       Node ID: %nodeid%&lt;br&gt;
+       Host: %nodelabel%&lt;br&gt;
+       Interface: %interface% &lt;br&gt;
+       Syslog severity: %parm[severity]% &lt;br&gt;
+       OpenNMS severity: %severity% &lt;br&gt;
+       Message: %parm[syslogmessage]% &lt;br&gt;
+       Process: %parm[process]% &lt;br&gt;
+       PID: %parm[processid]%
+       &lt;/p&gt;
+     </descr>
+     <logmsg dest='suppress'>
+       &lt;p&gt;A Netgear notice syslog message SwitchConfigUpdateStart has been received&lt;/p&gt;
+       Message: %parm[process]%: %parm[syslogmessage]% &lt;br&gt;
+     </logmsg>
+     <severity>Normal</severity>
+  </event>
+  <event>
+    <uei>uei.opennms.org/vendor/netgear/syslog/prosafesmartswitch/Notice/SwitchConfigUpdateEnd</uei>
+    <event-label>Netgear notice syslog message event: SwitchConfigUpdateEnd</event-label>
+    <descr>
+       &lt;p&gt;The interface %interface% generated a syslog message: SwitchConfigUpdateEnd&lt;br&gt;
+       Node ID: %nodeid%&lt;br&gt;
+       Host: %nodelabel%&lt;br&gt;
+       Interface: %interface% &lt;br&gt;
+       Syslog severity: %parm[severity]% &lt;br&gt;
+       OpenNMS severity: %severity% &lt;br&gt;
+       Message: %parm[syslogmessage]% &lt;br&gt;
+       Process: %parm[process]% &lt;br&gt;
+       PID: %parm[processid]%
+       &lt;/p&gt;
+     </descr>
+     <logmsg dest='logndisplay'>
+       &lt;p&gt;A Netgear notice syslog message SwitchConfigUpdateEnd has been received&lt;/p&gt;
+       Message: %parm[process]%: %parm[syslogmessage]% &lt;br&gt;
+     </logmsg>
+     <severity>Normal</severity>
+  </event>
+  <!-- catch-all event for other Notice syslog messages -->
+  <event>
+    <uei>~uei\.opennms\.org/vendor/netgear/syslog/prosafesmartswitch/Notice/.*</uei>
+    <event-label>Netgear notice syslog message event: syslogMessage</event-label>
+    <descr>
+       &lt;p&gt;The interface %interface% generated a syslog message.&lt;br&gt;
+       Node ID: %nodeid%&lt;br&gt;
+       Host: %nodelabel%&lt;br&gt;
+       Interface: %interface% &lt;br&gt;
+       Syslog severity: %parm[severity]% &lt;br&gt;
+       OpenNMS severity: %severity% &lt;br&gt;
+       Message: %parm[syslogmessage]% &lt;br&gt;
+       Process: %parm[process]% &lt;br&gt;
+       PID: %parm[processid]%
+       &lt;/p&gt;
+     </descr>
+     <logmsg dest='logndisplay'>
+       &lt;p&gt;A Netgear notice syslog message has been received&lt;/p&gt;
+       Message: %parm[process]%: %parm[syslogmessage]% &lt;br&gt;
+     </logmsg>
+     <severity>Normal</severity>
+  </event>
+
+  <!-- Warning level syslog messages -->
+  <event>
+    <uei>uei.opennms.org/vendor/netgear/syslog/prosafesmartswitch/Warning/EnergyEfficientEthernetStateTrue</uei>
+    <event-label>Netgear warning syslog message event: EnergyEfficientEthernetStateTrue</event-label>
+    <descr>
+       &lt;p&gt;The interface %interface% generated a syslog message: EnergyEfficientEthernetStateTrue&lt;br&gt;
+       Port name: %parm[portName]%&lt;br&gt;
+       &lt;br&gt;
+       Node ID: %nodeid%&lt;br&gt;
+       Host: %nodelabel%&lt;br&gt;
+       Interface: %interface% &lt;br&gt;
+       Syslog severity: %parm[severity]% &lt;br&gt;
+       OpenNMS severity: %severity% &lt;br&gt;
+       Message: %parm[syslogmessage]% &lt;br&gt;
+       Process: %parm[process]% &lt;br&gt;
+       PID: %parm[processid]%
+       &lt;/p&gt;
+     </descr>
+     <logmsg dest='logndisplay'>
+       &lt;p&gt;A Netgear warning syslog message EnergyEfficientEthernetStateTrue has been received&lt;/p&gt;
+       Message: %parm[process]%: %parm[syslogmessage]% &lt;br&gt;
+     </logmsg>
+     <severity>Normal</severity>
+  </event>
+  <event>
+    <uei>uei.opennms.org/vendor/netgear/syslog/prosafesmartswitch/Warning/EnergyEfficientEthernetStateFalse</uei>
+    <event-label>Netgear warning syslog message event: EnergyEfficientEthernetStateFalse</event-label>
+    <descr>
+       &lt;p&gt;The interface %interface% generated a syslog message: EnergyEfficientEthernetStateFalse&lt;br&gt;
+       Port name: %parm[portName]%&lt;br&gt;
+       &lt;br&gt;
+       Node ID: %nodeid%&lt;br&gt;
+       Host: %nodelabel%&lt;br&gt;
+       Interface: %interface% &lt;br&gt;
+       Syslog severity: %parm[severity]% &lt;br&gt;
+       OpenNMS severity: %severity% &lt;br&gt;
+       Message: %parm[syslogmessage]% &lt;br&gt;
+       Process: %parm[process]% &lt;br&gt;
+       PID: %parm[processid]%
+       &lt;/p&gt;
+     </descr>
+     <logmsg dest='logndisplay'>
+       &lt;p&gt;A Netgear warning syslog message EnergyEfficientEthernetStateFalse has been received&lt;/p&gt;
+       Message: %parm[process]%: %parm[syslogmessage]% &lt;br&gt;
+     </logmsg>
+     <severity>Normal</severity>
+  </event>
+  <event>
+    <uei>uei.opennms.org/vendor/netgear/syslog/prosafesmartswitch/Warning/PortSTPStatusForwarding</uei>
+    <event-label>Netgear warning syslog message event: PortSTPStatusForwarding</event-label>
+    <descr>
+       &lt;p&gt;The interface %interface% generated a syslog message: PortSTPStatusForwarding&lt;br&gt;
+       Port name: %parm[portName]%&lt;br&gt;
+       Instance number: %parm[instanceNumber]%&lt;br&gt;
+       &lt;br&gt;
+       Node ID: %nodeid%&lt;br&gt;
+       Host: %nodelabel%&lt;br&gt;
+       Interface: %interface% &lt;br&gt;
+       Syslog severity: %parm[severity]% &lt;br&gt;
+       OpenNMS severity: %severity% &lt;br&gt;
+       Message: %parm[syslogmessage]% &lt;br&gt;
+       Process: %parm[process]% &lt;br&gt;
+       PID: %parm[processid]%
+       &lt;/p&gt;
+     </descr>
+     <logmsg dest='logndisplay'>
+       &lt;p&gt;A Netgear warning syslog message PortSTPStatusForwarding has been received&lt;/p&gt;
+       Message: %parm[process]%: %parm[syslogmessage]% &lt;br&gt;
+     </logmsg>
+     <severity>Normal</severity>
+  </event>
+  <event>
+    <uei>uei.opennms.org/vendor/netgear/syslog/prosafesmartswitch/Warning/PortStatusLinkDown</uei>
+    <event-label>Netgear warning syslog message event: PortStatusLinkDown</event-label>
+    <descr>
+       &lt;p&gt;The interface %interface% generated a syslog message: PortStatusLinkDown&lt;br&gt;
+       Port name: %parm[portName]%&lt;br&gt;
+       &lt;br&gt;
+       Node ID: %nodeid%&lt;br&gt;
+       Host: %nodelabel%&lt;br&gt;
+       Interface: %interface% &lt;br&gt;
+       Syslog severity: %parm[severity]% &lt;br&gt;
+       OpenNMS severity: %severity% &lt;br&gt;
+       Message: %parm[syslogmessage]% &lt;br&gt;
+       Process: %parm[process]% &lt;br&gt;
+       PID: %parm[processid]%
+       &lt;/p&gt;
+     </descr>
+     <logmsg dest='logndisplay'>
+       &lt;p&gt;A Netgear warning syslog message PortStatusLinkDown has been received&lt;/p&gt;
+       Message: %parm[process]%: %parm[syslogmessage]% &lt;br&gt;
+     </logmsg>
+     <severity>Minor</severity>
+  </event>
+  <event>
+    <uei>uei.opennms.org/vendor/netgear/syslog/prosafesmartswitch/Warning/WebConsoleLoginFailure</uei>
+    <event-label>Netgear warning syslog message event: WebConsoleLoginFailure</event-label>
+    <descr>
+       &lt;p&gt;The interface %interface% generated a syslog message: WebConsoleLoginFailure&lt;br&gt;
+       Username: %parm[userName]%&lt;br&gt;
+       Source IP: %parm[sourceIP]%&lt;br&gt;
+       Destination IP: %parm[destinationIP]%&lt;br&gt;
+       &lt;br&gt;
+       Node ID: %nodeid%&lt;br&gt;
+       Host: %nodelabel%&lt;br&gt;
+       Interface: %interface% &lt;br&gt;
+       Syslog severity: %parm[severity]% &lt;br&gt;
+       OpenNMS severity: %severity% &lt;br&gt;
+       Message: %parm[syslogmessage]% &lt;br&gt;
+       Process: %parm[process]% &lt;br&gt;
+       PID: %parm[processid]%
+       &lt;/p&gt;
+     </descr>
+     <logmsg dest='logndisplay'>
+       &lt;p&gt;A Netgear warning syslog message WebConsoleLoginFailure has been received&lt;/p&gt;
+       Message: %parm[process]%: %parm[syslogmessage]% &lt;br&gt;
+     </logmsg>
+     <severity>Warning</severity>
+  </event>
+
+  <!-- catch-all event for other Warning syslog messages -->
+  <event>
+    <uei>~uei\.opennms\.org/vendor/netgear/syslog/prosafesmartswitch/Warning/.*</uei>
+    <event-label>Netgear warning syslog message event: syslogMessage</event-label>
+    <descr>
+       &lt;p&gt;The interface %interface% generated a syslog message.&lt;br&gt;
+       Node ID: %nodeid%&lt;br&gt;
+       Host: %nodelabel%&lt;br&gt;
+       Interface: %interface% &lt;br&gt;
+       Syslog severity: %parm[severity]% &lt;br&gt;
+       OpenNMS severity: %severity% &lt;br&gt;
+       Message: %parm[syslogmessage]% &lt;br&gt;
+       Process: %parm[process]% &lt;br&gt;
+       PID: %parm[processid]%
+       &lt;/p&gt;
+     </descr>
+     <logmsg dest='logndisplay'>
+       &lt;p&gt;A Netgear warning syslog message has been received&lt;/p&gt;
+       Message: %parm[process]%: %parm[syslogmessage]% &lt;br&gt;
+     </logmsg>
+     <severity>Warning</severity>
+  </event>
+
+  <!-- Error level syslog messages -->
+  <!-- catch-all event for other Error syslog messages -->
+  <event>
+    <uei>~uei\.opennms\.org/vendor/netgear/syslog/prosafesmartswitch/Error/.*</uei>
+    <event-label>Netgear error syslog message event: syslogMessage</event-label>
+    <descr>
+       &lt;p&gt;The interface %interface% generated a syslog message.&lt;br&gt;
+       Node ID: %nodeid%&lt;br&gt;
+       Host: %nodelabel%&lt;br&gt;
+       Interface: %interface% &lt;br&gt;
+       Syslog severity: %parm[severity]% &lt;br&gt;
+       OpenNMS severity: %severity% &lt;br&gt;
+       Message: %parm[syslogmessage]% &lt;br&gt;
+       Process: %parm[process]% &lt;br&gt;
+       PID: %parm[processid]%
+       &lt;/p&gt;
+     </descr>
+     <logmsg dest='logndisplay'>
+       &lt;p&gt;A Netgear error syslog message has been received&lt;/p&gt;
+       Message: %parm[process]%: %parm[syslogmessage]% &lt;br&gt;
+     </logmsg>
+     <severity>Warning</severity>
+  </event>
+
+  <!-- Critical level syslog messages -->
+  <!-- catch-all event for other Critical syslog messages -->
+  <event>
+    <uei>~uei\.opennms\.org/vendor/netgear/syslog/prosafesmartswitch/Critical/.*</uei>
+    <event-label>Netgear critical syslog message event: syslogMessage</event-label>
+    <descr>
+       &lt;p&gt;The interface %interface% generated a syslog message.&lt;br&gt;
+       Node ID: %nodeid%&lt;br&gt;
+       Host: %nodelabel%&lt;br&gt;
+       Interface: %interface% &lt;br&gt;
+       Syslog severity: %parm[severity]% &lt;br&gt;
+       OpenNMS severity: %severity% &lt;br&gt;
+       Message: %parm[syslogmessage]% &lt;br&gt;
+       Process: %parm[process]% &lt;br&gt;
+       PID: %parm[processid]%
+       &lt;/p&gt;
+     </descr>
+     <logmsg dest='logndisplay'>
+       &lt;p&gt;A Netgear critical syslog message has been received&lt;/p&gt;
+       Message: %parm[process]%: %parm[syslogmessage]% &lt;br&gt;
+     </logmsg>
+     <severity>Minor</severity>
+  </event>
+
+  <!-- Alert level syslog messages -->
+  <!-- catch-all event for other Alert syslog messages -->
+  <event>
+    <uei>~uei\.opennms\.org/vendor/netgear/syslog/prosafesmartswitch/Alert/.*</uei>
+    <event-label>Netgear alert syslog message event: syslogMessage</event-label>
+    <descr>
+       &lt;p&gt;The interface %interface% generated a syslog message.&lt;br&gt;
+       Node ID: %nodeid%&lt;br&gt;
+       Host: %nodelabel%&lt;br&gt;
+       Interface: %interface% &lt;br&gt;
+       Syslog severity: %parm[severity]% &lt;br&gt;
+       OpenNMS severity: %severity% &lt;br&gt;
+       Message: %parm[syslogmessage]% &lt;br&gt;
+       Process: %parm[process]% &lt;br&gt;
+       PID: %parm[processid]%
+       &lt;/p&gt;
+     </descr>
+     <logmsg dest='logndisplay'>
+       &lt;p&gt;A Netgear alert syslog message has been received&lt;/p&gt;
+       Message: %parm[process]%: %parm[syslogmessage]% &lt;br&gt;
+     </logmsg>
+     <severity>Minor</severity>
+  </event>
+
+  <!-- Emergency level syslog messages -->
+  <!-- catch-all event for other Emergency syslog messages -->
+  <event>
+    <uei>~uei\.opennms\.org/vendor/netgear/syslog/prosafesmartswitch/Emergency/.*</uei>
+    <event-label>Netgear emergency syslog message event: syslogMessage</event-label>
+    <descr>
+       &lt;p&gt;The interface %interface% generated a syslog message.&lt;br&gt;
+       Node ID: %nodeid%&lt;br&gt;
+       Host: %nodelabel%&lt;br&gt;
+       Interface: %interface% &lt;br&gt;
+       Syslog severity: %parm[severity]% &lt;br&gt;
+       OpenNMS severity: %severity% &lt;br&gt;
+       Message: %parm[syslogmessage]% &lt;br&gt;
+       Process: %parm[process]% &lt;br&gt;
+       PID: %parm[processid]%
+       &lt;/p&gt;
+     </descr>
+     <logmsg dest='logndisplay'>
+       &lt;p&gt;A Netgear emergency syslog message has been received&lt;/p&gt;
+       Message: %parm[process]%: %parm[syslogmessage]% &lt;br&gt;
+     </logmsg>
+     <severity>Major</severity>
+  </event>
+
+</events>

--- a/opennms-base-assembly/src/main/filtered/etc/events/NetgearProsafeSmartSwitch.syslog.events.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/events/NetgearProsafeSmartSwitch.syslog.events.xml
@@ -28,28 +28,6 @@ Event severities are listed in the order from least important to most important
      </logmsg>
      <severity>Warning</severity>
   </event>
-  <!-- catch-all event for other Debug syslog messages -->
-  <event>
-    <uei>~uei\.opennms\.org/vendor/netgear/syslog/prosafesmartswitch/Debug/.*</uei>
-    <event-label>Netgear debug syslog message event: syslogMessage</event-label>
-    <descr>
-       &lt;p&gt;The interface %interface% generated a syslog message.&lt;br&gt;
-       Node ID: %nodeid%&lt;br&gt;
-       Host: %nodelabel%&lt;br&gt;
-       Interface: %interface% &lt;br&gt;
-       Syslog severity: %parm[severity]% &lt;br&gt;
-       OpenNMS severity: %severity% &lt;br&gt;
-       Message: %parm[syslogmessage]% &lt;br&gt;
-       Process: %parm[process]% &lt;br&gt;
-       PID: %parm[processid]%
-       &lt;/p&gt;
-     </descr>
-     <logmsg dest='logndisplay'>
-       &lt;p&gt;A Netgear debug syslog message has been received&lt;/p&gt;
-       Message: %parm[process]%: %parm[syslogmessage]% &lt;br&gt;
-     </logmsg>
-     <severity>Normal</severity>
-  </event>
 
   <!-- Informational level syslog messages -->
   <event>
@@ -146,28 +124,6 @@ Event severities are listed in the order from least important to most important
      </logmsg>
      <severity>Normal</severity>
   </event>
-  <!-- catch-all event for other Informational syslog messages -->
-  <event>
-    <uei>~uei\.opennms\.org/vendor/netgear/syslog/prosafesmartswitch/Informational/.*</uei>
-    <event-label>Netgear informational syslog message event: syslogMessage</event-label>
-    <descr>
-       &lt;p&gt;The interface %interface% generated a syslog message.&lt;br&gt;
-       Node ID: %nodeid%&lt;br&gt;
-       Host: %nodelabel%&lt;br&gt;
-       Interface: %interface% &lt;br&gt;
-       Syslog severity: %parm[severity]% &lt;br&gt;
-       OpenNMS severity: %severity% &lt;br&gt;
-       Message: %parm[syslogmessage]% &lt;br&gt;
-       Process: %parm[process]% &lt;br&gt;
-       PID: %parm[processid]%
-       &lt;/p&gt;
-     </descr>
-     <logmsg dest='logndisplay'>
-       &lt;p&gt;A Netgear informational syslog message has been received&lt;/p&gt;
-       Message: %parm[process]%: %parm[syslogmessage]% &lt;br&gt;
-     </logmsg>
-     <severity>Normal</severity>
-  </event>
 
   <!-- Notice level syslog messages -->
   <event>
@@ -229,28 +185,6 @@ Event severities are listed in the order from least important to most important
      </descr>
      <logmsg dest='logndisplay'>
        &lt;p&gt;A Netgear notice syslog message SwitchConfigUpdateEnd has been received&lt;/p&gt;
-       Message: %parm[process]%: %parm[syslogmessage]% &lt;br&gt;
-     </logmsg>
-     <severity>Normal</severity>
-  </event>
-  <!-- catch-all event for other Notice syslog messages -->
-  <event>
-    <uei>~uei\.opennms\.org/vendor/netgear/syslog/prosafesmartswitch/Notice/.*</uei>
-    <event-label>Netgear notice syslog message event: syslogMessage</event-label>
-    <descr>
-       &lt;p&gt;The interface %interface% generated a syslog message.&lt;br&gt;
-       Node ID: %nodeid%&lt;br&gt;
-       Host: %nodelabel%&lt;br&gt;
-       Interface: %interface% &lt;br&gt;
-       Syslog severity: %parm[severity]% &lt;br&gt;
-       OpenNMS severity: %severity% &lt;br&gt;
-       Message: %parm[syslogmessage]% &lt;br&gt;
-       Process: %parm[process]% &lt;br&gt;
-       PID: %parm[processid]%
-       &lt;/p&gt;
-     </descr>
-     <logmsg dest='logndisplay'>
-       &lt;p&gt;A Netgear notice syslog message has been received&lt;/p&gt;
        Message: %parm[process]%: %parm[syslogmessage]% &lt;br&gt;
      </logmsg>
      <severity>Normal</severity>
@@ -376,60 +310,17 @@ Event severities are listed in the order from least important to most important
      <severity>Warning</severity>
   </event>
 
-  <!-- catch-all event for other Warning syslog messages -->
-  <event>
-    <uei>~uei\.opennms\.org/vendor/netgear/syslog/prosafesmartswitch/Warning/.*</uei>
-    <event-label>Netgear warning syslog message event: syslogMessage</event-label>
-    <descr>
-       &lt;p&gt;The interface %interface% generated a syslog message.&lt;br&gt;
-       Node ID: %nodeid%&lt;br&gt;
-       Host: %nodelabel%&lt;br&gt;
-       Interface: %interface% &lt;br&gt;
-       Syslog severity: %parm[severity]% &lt;br&gt;
-       OpenNMS severity: %severity% &lt;br&gt;
-       Message: %parm[syslogmessage]% &lt;br&gt;
-       Process: %parm[process]% &lt;br&gt;
-       PID: %parm[processid]%
-       &lt;/p&gt;
-     </descr>
-     <logmsg dest='logndisplay'>
-       &lt;p&gt;A Netgear warning syslog message has been received&lt;/p&gt;
-       Message: %parm[process]%: %parm[syslogmessage]% &lt;br&gt;
-     </logmsg>
-     <severity>Warning</severity>
-  </event>
-
   <!-- Error level syslog messages -->
-  <!-- catch-all event for other Error syslog messages -->
-  <event>
-    <uei>~uei\.opennms\.org/vendor/netgear/syslog/prosafesmartswitch/Error/.*</uei>
-    <event-label>Netgear error syslog message event: syslogMessage</event-label>
-    <descr>
-       &lt;p&gt;The interface %interface% generated a syslog message.&lt;br&gt;
-       Node ID: %nodeid%&lt;br&gt;
-       Host: %nodelabel%&lt;br&gt;
-       Interface: %interface% &lt;br&gt;
-       Syslog severity: %parm[severity]% &lt;br&gt;
-       OpenNMS severity: %severity% &lt;br&gt;
-       Message: %parm[syslogmessage]% &lt;br&gt;
-       Process: %parm[process]% &lt;br&gt;
-       PID: %parm[processid]%
-       &lt;/p&gt;
-     </descr>
-     <logmsg dest='logndisplay'>
-       &lt;p&gt;A Netgear error syslog message has been received&lt;/p&gt;
-       Message: %parm[process]%: %parm[syslogmessage]% &lt;br&gt;
-     </logmsg>
-     <severity>Warning</severity>
-  </event>
+  <!-- none entered at this time -->
 
   <!-- Critical level syslog messages -->
-  <!-- catch-all event for other Critical syslog messages -->
   <event>
-    <uei>~uei\.opennms\.org/vendor/netgear/syslog/prosafesmartswitch/Critical/.*</uei>
-    <event-label>Netgear critical syslog message event: syslogMessage</event-label>
+    <uei>uei.opennms.org/vendor/netgear/syslog/prosafesmartswitch/Critical/SwitchBootingUp</uei>
+    <event-label>Netgear critical syslog message event: SwitchBootingUp</event-label>
     <descr>
-       &lt;p&gt;The interface %interface% generated a syslog message.&lt;br&gt;
+       &lt;p&gt;The interface %interface% generated a syslog message: SwitchBootingUp&lt;br&gt;
+       &lt;p&gt;This is a normal event to receive on switch startup.&lt;br&gt;
+       &lt;br&gt;
        Node ID: %nodeid%&lt;br&gt;
        Host: %nodelabel%&lt;br&gt;
        Interface: %interface% &lt;br&gt;
@@ -441,58 +332,16 @@ Event severities are listed in the order from least important to most important
        &lt;/p&gt;
      </descr>
      <logmsg dest='logndisplay'>
-       &lt;p&gt;A Netgear critical syslog message has been received&lt;/p&gt;
+       &lt;p&gt;A Netgear critical syslog message SwitchBootingUp has been received&lt;/p&gt;
        Message: %parm[process]%: %parm[syslogmessage]% &lt;br&gt;
      </logmsg>
-     <severity>Minor</severity>
+     <severity>Normal</severity>
   </event>
 
   <!-- Alert level syslog messages -->
-  <!-- catch-all event for other Alert syslog messages -->
-  <event>
-    <uei>~uei\.opennms\.org/vendor/netgear/syslog/prosafesmartswitch/Alert/.*</uei>
-    <event-label>Netgear alert syslog message event: syslogMessage</event-label>
-    <descr>
-       &lt;p&gt;The interface %interface% generated a syslog message.&lt;br&gt;
-       Node ID: %nodeid%&lt;br&gt;
-       Host: %nodelabel%&lt;br&gt;
-       Interface: %interface% &lt;br&gt;
-       Syslog severity: %parm[severity]% &lt;br&gt;
-       OpenNMS severity: %severity% &lt;br&gt;
-       Message: %parm[syslogmessage]% &lt;br&gt;
-       Process: %parm[process]% &lt;br&gt;
-       PID: %parm[processid]%
-       &lt;/p&gt;
-     </descr>
-     <logmsg dest='logndisplay'>
-       &lt;p&gt;A Netgear alert syslog message has been received&lt;/p&gt;
-       Message: %parm[process]%: %parm[syslogmessage]% &lt;br&gt;
-     </logmsg>
-     <severity>Minor</severity>
-  </event>
+  <!-- none entered at this time -->
 
   <!-- Emergency level syslog messages -->
-  <!-- catch-all event for other Emergency syslog messages -->
-  <event>
-    <uei>~uei\.opennms\.org/vendor/netgear/syslog/prosafesmartswitch/Emergency/.*</uei>
-    <event-label>Netgear emergency syslog message event: syslogMessage</event-label>
-    <descr>
-       &lt;p&gt;The interface %interface% generated a syslog message.&lt;br&gt;
-       Node ID: %nodeid%&lt;br&gt;
-       Host: %nodelabel%&lt;br&gt;
-       Interface: %interface% &lt;br&gt;
-       Syslog severity: %parm[severity]% &lt;br&gt;
-       OpenNMS severity: %severity% &lt;br&gt;
-       Message: %parm[syslogmessage]% &lt;br&gt;
-       Process: %parm[process]% &lt;br&gt;
-       PID: %parm[processid]%
-       &lt;/p&gt;
-     </descr>
-     <logmsg dest='logndisplay'>
-       &lt;p&gt;A Netgear emergency syslog message has been received&lt;/p&gt;
-       Message: %parm[process]%: %parm[syslogmessage]% &lt;br&gt;
-     </logmsg>
-     <severity>Major</severity>
-  </event>
+  <!-- none entered at this time -->
 
 </events>

--- a/opennms-base-assembly/src/main/filtered/etc/events/NetgearProsafeSmartSwitch.syslog.events.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/events/NetgearProsafeSmartSwitch.syslog.events.xml
@@ -26,7 +26,7 @@ Event severities are listed in the order from least important to most important
        &lt;p&gt;A Netgear debug syslog message has been received&lt;/p&gt;
        Message: %parm[process]%: %parm[syslogmessage]% &lt;br&gt;
      </logmsg>
-     <severity>Normal</severity>
+     <severity>Warning</severity>
   </event>
   <!-- catch-all event for other Debug syslog messages -->
   <event>

--- a/opennms-base-assembly/src/main/filtered/etc/syslog/NetgearProsafeSmartSwitch.syslog.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/syslog/NetgearProsafeSmartSwitch.syslog.xml
@@ -1,0 +1,218 @@
+<?xml version="1.0"?>
+
+<!--
+Netgear Prosafe Smart Switch syslog events
+
+Event severities are listed in the order from least important to most important
+
+Note: These switches send syslog messages in a format that doesn't parse correctly with the default OpenNMS syslog parsing string (as of the end of 2016).
+      This was worked around by having the switches send syslog messages to a rsyslog server on a Linux server and having the rsyslog server forward
+      the messages to OpenNMS in RFC5424 format (with OpenNMS configured to use the syslog parser org.opennms.netmgt.syslogd.Rfc5424SyslogParser).
+      For more information, see the OpenNMS wiki page http://www.opennms.org/wiki/Syslogd
+
+Tested using Netgear ProSafe Smart Switch, model GS752TP
+-->
+
+<syslogd-configuration-group>
+    <ueiList>
+
+        <!-- Debug level syslog messages -->
+        <ueiMatch>
+            <facility>local7</facility>
+            <severity>Debug</severity>
+            <process-match expression="^%SNTP-D-NTPBADVER$" />
+            <match type="regex" expression="^NTP server version not compatible$" />
+            <uei>uei.opennms.org/vendor/netgear/syslog/prosafesmartswitch/Debug/NTPServerVersionNotCompatible</uei>
+        </ueiMatch>
+        <!-- catch-all event for other Debug syslog messages -->
+        <ueiMatch>
+            <facility>local7</facility>
+            <severity>Debug</severity>
+            <process-match expression="^%.*$" />
+            <match type="regex" expression=".*" />
+            <uei>uei.opennms.org/vendor/netgear/syslog/prosafesmartswitch/Debug/unknownMessage</uei>
+        </ueiMatch>
+
+        <!-- Informational level syslog messages -->
+        <ueiMatch>
+            <facility>local7</facility>
+            <severity>Informational</severity>
+            <process-match expression="^%AAA-I-CONNECT$" />
+            <match type="regex" expression="^New http connection for user (.+), source ([0-9.]+) destination ([0-9.]+) ACCEPTED$" />
+            <uei>uei.opennms.org/vendor/netgear/syslog/prosafesmartswitch/Informational/WebConsoleLogin</uei>
+            <parameter-assignment matching-group="1" parameter-name="userName" />
+            <parameter-assignment matching-group="2" parameter-name="sourceIP" />
+            <parameter-assignment matching-group="3" parameter-name="destinationIP" />
+        </ueiMatch>
+        <ueiMatch>
+            <facility>local7</facility>
+            <severity>Informational</severity>
+            <process-match expression="^%AAA-I-DISCONNECT$" />
+            <match type="regex" expression="^http connection for user (.+), source ([0-9.]+) destination ([0-9.]+) TERMINATED$" />
+            <uei>uei.opennms.org/vendor/netgear/syslog/prosafesmartswitch/Informational/WebConsoleLogout</uei>
+            <parameter-assignment matching-group="1" parameter-name="userName" />
+            <parameter-assignment matching-group="2" parameter-name="sourceIP" />
+            <parameter-assignment matching-group="3" parameter-name="destinationIP" />
+        </ueiMatch>
+        <ueiMatch>
+            <facility>local7</facility>
+            <severity>Informational</severity>
+            <process-match expression="^%LINK-I-Up$" />
+            <match type="regex" expression="^(.*)$" />
+            <uei>uei.opennms.org/vendor/netgear/syslog/prosafesmartswitch/Informational/PortStatusLinkUp</uei>
+            <parameter-assignment matching-group="1" parameter-name="portName" />
+        </ueiMatch>
+        <ueiMatch>
+            <facility>local7</facility>
+            <severity>Informational</severity>
+            <process-match expression="^%BOOTP_DHCP_CL-I-DHCPRENEWED$" />
+            <match type="substr" expression="The device has been renewed the configuration on interface$" />
+            <uei>uei.opennms.org/vendor/netgear/syslog/prosafesmartswitch/Informational/DHCPAddressRenewed</uei>
+        </ueiMatch>
+        <!-- catch-all event for other Informational syslog messages -->
+        <ueiMatch>
+            <facility>local7</facility>
+            <severity>Informational</severity>
+            <process-match expression="^%.*$" />
+            <match type="regex" expression=".*" />
+            <uei>uei.opennms.org/vendor/netgear/syslog/prosafesmartswitch/Informational/unknownMessage</uei>
+        </ueiMatch>
+
+        <!-- Notice level syslog messages -->
+        <ueiMatch>
+            <facility>local7</facility>
+            <severity>Notice</severity>
+            <process-match expression="^%COPY-N-TRAP$" />
+            <match type="substr" expression="The copy operation was completed successfully" />
+            <uei>uei.opennms.org/vendor/netgear/syslog/prosafesmartswitch/Notice/FirmwareCopyCompletedSuccessfully</uei>
+        </ueiMatch>
+        <ueiMatch>
+            <facility>local7</facility>
+            <severity>Notice</severity>
+            <process-match expression="^%COPY-N-LOGGINGFILECOPY$" />
+            <match type="substr" expression="start log messages related to file copy operations" />
+            <uei>uei.opennms.org/vendor/netgear/syslog/prosafesmartswitch/Notice/SwitchConfigUpdateEnd</uei>
+        </ueiMatch>
+        <ueiMatch>
+            <facility>local7</facility>
+            <severity>Notice</severity>
+            <process-match expression="^%COPY-N-LOGGINGFILECOPYSTOP$" />
+            <match type="substr" expression="stop log messages related to file copy operations" />
+            <uei>uei.opennms.org/vendor/netgear/syslog/prosafesmartswitch/Notice/SwitchConfigUpdateStart</uei>  <!-- this message is sent BEFORE the COPY-N-LOGGINGFILECOPY message -->
+        </ueiMatch>
+        <!-- catch-all event for other Notice syslog messages -->
+        <ueiMatch>
+            <facility>local7</facility>
+            <severity>Notice</severity>
+            <process-match expression="^%.*$" />
+            <match type="regex" expression=".*" />
+            <uei>uei.opennms.org/vendor/netgear/syslog/prosafesmartswitch/Notice/unknownMessage</uei>
+        </ueiMatch>
+
+        <!-- Warning level syslog messages -->
+        <ueiMatch>
+            <facility>local7</facility>
+            <severity>Warning</severity>
+            <process-match expression="^%NT_GREEN-W-EeeLldpSingleNeighbour$" />
+            <match type="regex" expression="^Single LLDP neighbour on port (.*) - EEE operational state can be TRUE$" />
+            <uei>uei.opennms.org/vendor/netgear/syslog/prosafesmartswitch/Warning/EnergyEfficientEthernetStateTrue</uei>
+            <parameter-assignment matching-group="1" parameter-name="portName" />
+        </ueiMatch>
+        <ueiMatch>
+            <facility>local7</facility>
+            <severity>Warning</severity>
+            <process-match expression="^%NT_GREEN-W-EeeLldpMultiNeighbours$" />
+            <match type="regex" expression="^Multiple LLDP neighbours on port (.*) - EEE operational state is FALSE$" />
+            <uei>uei.opennms.org/vendor/netgear/syslog/prosafesmartswitch/Warning/EnergyEfficientEthernetStateFalse</uei>
+            <parameter-assignment matching-group="1" parameter-name="portName" />
+        </ueiMatch>
+        <ueiMatch>
+            <facility>local7</facility>
+            <severity>Warning</severity>
+            <process-match expression="^%STP-W-PORTSTATUS$" />
+            <match type="regex" expression="^(.*) of instance ([0-9.]+): STP status Forwarding$" />
+            <uei>uei.opennms.org/vendor/netgear/syslog/prosafesmartswitch/Warning/PortSTPStatusForwarding</uei>
+            <parameter-assignment matching-group="1" parameter-name="portName" />
+            <parameter-assignment matching-group="2" parameter-name="instanceNumber" />
+        </ueiMatch>
+        <ueiMatch>
+            <facility>local7</facility>
+            <severity>Warning</severity>
+            <process-match expression="^%BOOTP_DHCP_CL-W-FLNMEEMPTY$" />
+            <match type="substr" expression="No option 67 in the DHCP packet. Unable to start autoconfiguration." />
+            <uei>uei.opennms.org/vendor/netgear/syslog/prosafesmartswitch/Warning/UnableToStartDHCPAutoconfiguration</uei>
+        </ueiMatch>
+        <ueiMatch>
+            <facility>local7</facility>
+            <severity>Warning</severity>
+            <process-match expression="^%LINK-W-Down$" />
+            <match type="regex" expression="^(.*)$" />
+            <uei>uei.opennms.org/vendor/netgear/syslog/prosafesmartswitch/Warning/PortStatusLinkDown</uei>
+            <parameter-assignment matching-group="1" parameter-name="portName" />
+        </ueiMatch>
+        <ueiMatch>
+            <facility>local7</facility>
+            <severity>Warning</severity>
+            <process-match expression="^%AAA-W-REJECT$" />
+            <match type="regex" expression="^New http connection for user (.+), source ([0-9.]+) destination ([0-9.]+)  REJECTED$" /> <!-- two spaces needed -->
+            <uei>uei.opennms.org/vendor/netgear/syslog/prosafesmartswitch/Warning/WebConsoleLoginFailure</uei>
+            <parameter-assignment matching-group="1" parameter-name="userName" />
+            <parameter-assignment matching-group="2" parameter-name="sourceIP" />
+            <parameter-assignment matching-group="3" parameter-name="destinationIP" />
+        </ueiMatch>
+        <!-- catch-all event for other Warning syslog messages -->
+        <ueiMatch>
+            <facility>local7</facility>
+            <severity>Warning</severity>
+            <process-match expression="^%.*$" />
+            <match type="regex" expression=".*" />
+            <uei>uei.opennms.org/vendor/netgear/syslog/prosafesmartswitch/Warning/unknownMessage</uei>
+        </ueiMatch>
+
+        <!-- Error level syslog messages -->
+        <!-- catch-all event for other Error syslog messages -->
+        <ueiMatch>
+            <facility>local7</facility>
+            <severity>Error</severity>
+            <process-match expression="^%.*$" />
+            <match type="regex" expression=".*" />
+            <uei>uei.opennms.org/vendor/netgear/syslog/prosafesmartswitch/Error/unknownMessage</uei>
+        </ueiMatch>
+
+        <!-- Critical level syslog messages -->
+        <ueiMatch>
+            <severity>Critical</severity>
+            <process-match expression="^%UNKN$" />
+            <match type="substr" expression="Event(0x0)" />
+            <uei>uei.opennms.org/vendor/netgear/syslog/prosafesmartswitch/Critical/SwitchBootingUp</uei>
+        </ueiMatch>
+        <!-- catch-all event for other Critical syslog messages -->
+        <ueiMatch>
+            <facility>local7</facility>
+            <severity>Critical</severity>
+            <process-match expression="^%.*$" />
+            <match type="regex" expression=".*" />
+            <uei>uei.opennms.org/vendor/netgear/syslog/prosafesmartswitch/Critical/unknownMessage</uei>
+        </ueiMatch>
+
+        <!-- Alert level syslog messages -->
+        <!-- catch-all event for other Alert syslog messages -->
+        <ueiMatch>
+            <facility>local7</facility>
+            <severity>Alert</severity>
+            <process-match expression="^%.*$" />
+            <match type="regex" expression=".*" />
+            <uei>uei.opennms.org/vendor/netgear/syslog/prosafesmartswitch/Alert/unknownMessage</uei>
+        </ueiMatch>
+
+        <!-- Emergency level syslog messages -->
+        <!-- catch-all event for other Emergency syslog messages -->
+        <ueiMatch>
+            <facility>local7</facility>
+            <severity>Emergency</severity>
+            <process-match expression="^%.*$" />
+            <match type="regex" expression=".*" />
+            <uei>uei.opennms.org/vendor/netgear/syslog/prosafesmartswitch/Emergency/unknownMessage</uei>
+        </ueiMatch>
+    </ueiList>
+</syslogd-configuration-group>

--- a/opennms-base-assembly/src/main/filtered/etc/syslog/NetgearProsafeSmartSwitch.syslog.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/syslog/NetgearProsafeSmartSwitch.syslog.xml
@@ -24,14 +24,6 @@ Tested using Netgear ProSafe Smart Switch, model GS752TP
             <match type="regex" expression="^NTP server version not compatible$" />
             <uei>uei.opennms.org/vendor/netgear/syslog/prosafesmartswitch/Debug/NTPServerVersionNotCompatible</uei>
         </ueiMatch>
-        <!-- catch-all event for other Debug syslog messages -->
-        <ueiMatch>
-            <facility>local7</facility>
-            <severity>Debug</severity>
-            <process-match expression="^%.*$" />
-            <match type="regex" expression=".*" />
-            <uei>uei.opennms.org/vendor/netgear/syslog/prosafesmartswitch/Debug/unknownMessage</uei>
-        </ueiMatch>
 
         <!-- Informational level syslog messages -->
         <ueiMatch>
@@ -69,14 +61,6 @@ Tested using Netgear ProSafe Smart Switch, model GS752TP
             <match type="substr" expression="The device has been renewed the configuration on interface$" />
             <uei>uei.opennms.org/vendor/netgear/syslog/prosafesmartswitch/Informational/DHCPAddressRenewed</uei>
         </ueiMatch>
-        <!-- catch-all event for other Informational syslog messages -->
-        <ueiMatch>
-            <facility>local7</facility>
-            <severity>Informational</severity>
-            <process-match expression="^%.*$" />
-            <match type="regex" expression=".*" />
-            <uei>uei.opennms.org/vendor/netgear/syslog/prosafesmartswitch/Informational/unknownMessage</uei>
-        </ueiMatch>
 
         <!-- Notice level syslog messages -->
         <ueiMatch>
@@ -99,14 +83,6 @@ Tested using Netgear ProSafe Smart Switch, model GS752TP
             <process-match expression="^%COPY-N-LOGGINGFILECOPYSTOP$" />
             <match type="substr" expression="stop log messages related to file copy operations" />
             <uei>uei.opennms.org/vendor/netgear/syslog/prosafesmartswitch/Notice/SwitchConfigUpdateStart</uei>  <!-- this message is sent BEFORE the COPY-N-LOGGINGFILECOPY message -->
-        </ueiMatch>
-        <!-- catch-all event for other Notice syslog messages -->
-        <ueiMatch>
-            <facility>local7</facility>
-            <severity>Notice</severity>
-            <process-match expression="^%.*$" />
-            <match type="regex" expression=".*" />
-            <uei>uei.opennms.org/vendor/netgear/syslog/prosafesmartswitch/Notice/unknownMessage</uei>
         </ueiMatch>
 
         <!-- Warning level syslog messages -->
@@ -160,24 +136,9 @@ Tested using Netgear ProSafe Smart Switch, model GS752TP
             <parameter-assignment matching-group="2" parameter-name="sourceIP" />
             <parameter-assignment matching-group="3" parameter-name="destinationIP" />
         </ueiMatch>
-        <!-- catch-all event for other Warning syslog messages -->
-        <ueiMatch>
-            <facility>local7</facility>
-            <severity>Warning</severity>
-            <process-match expression="^%.*$" />
-            <match type="regex" expression=".*" />
-            <uei>uei.opennms.org/vendor/netgear/syslog/prosafesmartswitch/Warning/unknownMessage</uei>
-        </ueiMatch>
 
         <!-- Error level syslog messages -->
-        <!-- catch-all event for other Error syslog messages -->
-        <ueiMatch>
-            <facility>local7</facility>
-            <severity>Error</severity>
-            <process-match expression="^%.*$" />
-            <match type="regex" expression=".*" />
-            <uei>uei.opennms.org/vendor/netgear/syslog/prosafesmartswitch/Error/unknownMessage</uei>
-        </ueiMatch>
+	<!-- none entered at this time -->
 
         <!-- Critical level syslog messages -->
         <ueiMatch>
@@ -186,33 +147,12 @@ Tested using Netgear ProSafe Smart Switch, model GS752TP
             <match type="substr" expression="Event(0x0)" />
             <uei>uei.opennms.org/vendor/netgear/syslog/prosafesmartswitch/Critical/SwitchBootingUp</uei>
         </ueiMatch>
-        <!-- catch-all event for other Critical syslog messages -->
-        <ueiMatch>
-            <facility>local7</facility>
-            <severity>Critical</severity>
-            <process-match expression="^%.*$" />
-            <match type="regex" expression=".*" />
-            <uei>uei.opennms.org/vendor/netgear/syslog/prosafesmartswitch/Critical/unknownMessage</uei>
-        </ueiMatch>
 
         <!-- Alert level syslog messages -->
-        <!-- catch-all event for other Alert syslog messages -->
-        <ueiMatch>
-            <facility>local7</facility>
-            <severity>Alert</severity>
-            <process-match expression="^%.*$" />
-            <match type="regex" expression=".*" />
-            <uei>uei.opennms.org/vendor/netgear/syslog/prosafesmartswitch/Alert/unknownMessage</uei>
-        </ueiMatch>
+	<!-- none entered at this time -->
 
         <!-- Emergency level syslog messages -->
-        <!-- catch-all event for other Emergency syslog messages -->
-        <ueiMatch>
-            <facility>local7</facility>
-            <severity>Emergency</severity>
-            <process-match expression="^%.*$" />
-            <match type="regex" expression=".*" />
-            <uei>uei.opennms.org/vendor/netgear/syslog/prosafesmartswitch/Emergency/unknownMessage</uei>
-        </ueiMatch>
+	<!-- none entered at this time -->
+
     </ueiList>
 </syslogd-configuration-group>

--- a/opennms-base-assembly/src/main/filtered/etc/syslogd-configuration.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/syslogd-configuration.xml
@@ -37,6 +37,7 @@
 
     <import-file>syslog/ApacheHTTPD.syslog.xml</import-file>
     <import-file>syslog/LinuxKernel.syslog.xml</import-file>
+    <import-file>syslog/NetgearProsafeSmartSwitch.syslog.xml</import-file>
     <import-file>syslog/OpenSSH.syslog.xml</import-file>
     <import-file>syslog/Procmail.syslog.xml</import-file>
     <import-file>syslog/Postfix.syslog.xml</import-file>


### PR DESCRIPTION
This is a request to merge NetGear ProSafe Smart Switch SNMP traps and syslog definitions and events.

JIRA: http://issues.opennms.org/browse/NMS-8077
Bamboo: http://bamboo.internal.opennms.com:8085/browse/OPENNMS-ONMS427-2