### PR TITLE
NMS-8092: Add OpenWrt syslog and related event definitions

### DIFF
--- a/integration-tests/config/src/test/java/org/opennms/netmgt/config/WillItUnmarshalCoverageMetaIT.java
+++ b/integration-tests/config/src/test/java/org/opennms/netmgt/config/WillItUnmarshalCoverageMetaIT.java
@@ -126,6 +126,7 @@ public class WillItUnmarshalCoverageMetaIT {
         ignoreFile(new File(getDaemonEtcDirectory(), "syslog/ApacheHTTPD.syslog.xml"));
         ignoreFile(new File(getDaemonEtcDirectory(), "syslog/LinuxKernel.syslog.xml"));
         ignoreFile(new File(getDaemonEtcDirectory(), "syslog/OpenSSH.syslog.xml"));
+        ignoreFile(new File(getDaemonEtcDirectory(), "syslog/OpenWrt.syslog.xml"));
         ignoreFile(new File(getDaemonEtcDirectory(), "syslog/Procmail.syslog.xml"));
         ignoreFile(new File(getDaemonEtcDirectory(), "syslog/POSIX.syslog.xml"));
         ignoreFile(new File(getDaemonEtcDirectory(), "syslog/Postfix.syslog.xml"));

--- a/opennms-base-assembly/src/main/filtered/etc/eventconf.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/eventconf.xml
@@ -179,6 +179,7 @@
   <event-file>events/Novell.events.xml</event-file>
   <event-file>events/OpenNMSMIB.events.xml</event-file>
   <event-file>events/OpenSSH.syslog.events.xml</event-file>
+  <event-file>events/OpenWrt.syslog.events.xml</event-file>
   <event-file>events/Oracle.events.xml</event-file>
   <event-file>events/OSPF.events.xml</event-file>
   <event-file>events/Overland.events.xml</event-file>

--- a/opennms-base-assembly/src/main/filtered/etc/events/OpenWrt.syslog.events.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/events/OpenWrt.syslog.events.xml
@@ -1,0 +1,190 @@
+<events xmlns="http://xmlns.opennms.org/xsd/eventconf">
+
+<!--
+
+OpenWrt (the Linux distribution) and other OpenWrt software package syslog events
+
+-->
+
+  <!-- core OS -->
+  <event>
+    <uei>uei.opennms.org/vendor/openwrt/syslog/SystemStarting</uei>
+    <event-label>OpenWrt sysinit event: SystemStarting</event-label>
+    <descr>
+       &lt;p&gt;The interface %interface% generated a syslog message.&lt;br&gt;
+       Node ID: %nodeid%&lt;br&gt;
+       Host: %nodelabel%&lt;br&gt;
+       Interface: %interface% &lt;br&gt;
+       Syslog severity: %parm[severity]% &lt;br&gt;
+       OpenNMS severity: %severity% &lt;br&gt;
+       Message: %parm[syslogmessage]% &lt;br&gt;
+       Process: %parm[process]% &lt;br&gt;
+       PID: %parm[processid]%
+       &lt;/p&gt;
+     </descr>
+     <logmsg dest='logndisplay'>
+       &lt;p&gt;An OpenWrt sysinit syslog message has been received&lt;/p&gt;
+       Message: %parm[process]%: %parm[syslogmessage]% &lt;br&gt;
+     </logmsg>
+     <severity>Normal</severity>
+  </event>
+  <event>
+    <uei>uei.opennms.org/vendor/openwrt/syslog/SystemStopping</uei>
+    <event-label>OpenWrt sysinit event: SystemStopping</event-label>
+    <descr>
+       &lt;p&gt;The interface %interface% generated a syslog message.&lt;br&gt;
+       Node ID: %nodeid%&lt;br&gt;
+       Host: %nodelabel%&lt;br&gt;
+       Interface: %interface% &lt;br&gt;
+       Syslog severity: %parm[severity]% &lt;br&gt;
+       OpenNMS severity: %severity% &lt;br&gt;
+       Message: %parm[syslogmessage]% &lt;br&gt;
+       Process: %parm[process]% &lt;br&gt;
+       PID: %parm[processid]%
+       &lt;/p&gt;
+     </descr>
+     <logmsg dest='logndisplay'>
+       &lt;p&gt;An OpenWrt sysinit syslog message has been received&lt;/p&gt;
+       Message: %parm[process]%: %parm[syslogmessage]% &lt;br&gt;
+     </logmsg>
+     <severity>Normal</severity>
+  </event>
+
+  <!-- ddns-scripts package -->
+  <event>
+    <uei>uei.opennms.org/vendor/openwrt/syslog/ddns-scripts/DDNSIPUpdateFailed</uei>
+    <event-label>OpenWrt ddns-scripts event: DDNSIPUpdateFailed</event-label>
+    <descr>
+       &lt;p&gt;The interface %interface% generated a syslog message.&lt;br&gt;
+       Node ID: %nodeid%&lt;br&gt;
+       Host: %nodelabel%&lt;br&gt;
+       Interface: %interface% &lt;br&gt;
+       Syslog severity: %parm[severity]% &lt;br&gt;
+       OpenNMS severity: %severity% &lt;br&gt;
+       Message: %parm[syslogmessage]% &lt;br&gt;
+       Process: %parm[process]% &lt;br&gt;
+       PID: %parm[processid]%
+       &lt;/p&gt;
+     </descr>
+     <logmsg dest='logndisplay'>
+       &lt;p&gt;An OpenWrt ddns-scripts syslog message has been received&lt;/p&gt;
+       Message: %parm[process]%: %parm[syslogmessage]% &lt;br&gt;
+     </logmsg>
+     <severity>Warning</severity>
+  </event>
+  <event>
+    <uei>uei.opennms.org/vendor/openwrt/syslog/ddns-scripts/DDNSIPUpdateSuccessful</uei>
+    <event-label>OpenWrt ddns-scripts event: DDNSIPUpdateSuccessful</event-label>
+    <descr>
+       &lt;p&gt;The interface %interface% generated a syslog message.&lt;br&gt;
+       Node ID: %nodeid%&lt;br&gt;
+       Host: %nodelabel%&lt;br&gt;
+       Interface: %interface% &lt;br&gt;
+       Syslog severity: %parm[severity]% &lt;br&gt;
+       OpenNMS severity: %severity% &lt;br&gt;
+       Message: %parm[syslogmessage]% &lt;br&gt;
+       Process: %parm[process]% &lt;br&gt;
+       PID: %parm[processid]%
+       &lt;/p&gt;
+     </descr>
+     <logmsg dest='logndisplay'>
+       &lt;p&gt;An OpenWrt ddns-scripts syslog message has been received&lt;/p&gt;
+       Message: %parm[process]%: %parm[syslogmessage]% &lt;br&gt;
+     </logmsg>
+     <severity>Normal</severity>
+  </event>
+
+  <!-- mwan3 package -->
+  <event>
+    <uei>uei.opennms.org/vendor/openwrt/syslog/mwan3/LostPingsOnInterface</uei>
+    <event-label>OpenWrt mwan3 event: Lost pings on interface</event-label>
+    <descr>
+       &lt;p&gt;The interface %interface% generated a syslog message.&lt;br&gt;
+       Interface name: %parm[interfaceName]%&lt;br&gt;
+       &lt;br&gt;
+       Node ID: %nodeid%&lt;br&gt;
+       Host: %nodelabel%&lt;br&gt;
+       Interface: %interface% &lt;br&gt;
+       Syslog severity: %parm[severity]% &lt;br&gt;
+       OpenNMS severity: %severity% &lt;br&gt;
+       Message: %parm[syslogmessage]% &lt;br&gt;
+       Process: %parm[process]% &lt;br&gt;
+       PID: %parm[processid]%
+       &lt;/p&gt;
+     </descr>
+     <logmsg dest='logndisplay'>
+       &lt;p&gt;An OpenWrt mwan3 syslog message has been received&lt;/p&gt;
+       Message: %parm[process]%: %parm[syslogmessage]% &lt;br&gt;
+     </logmsg>
+     <severity>Warning</severity>
+  </event>
+  <event>
+    <uei>uei.opennms.org/vendor/openwrt/syslog/mwan3/OnlineInterface</uei>
+    <event-label>OpenWrt mwan3 event: OnlineInterface</event-label>
+    <descr>
+       &lt;p&gt;The interface %interface% generated a syslog message.&lt;br&gt;
+       Interface name: %parm[interfaceName]%&lt;br&gt;
+       &lt;br&gt;
+       Node ID: %nodeid%&lt;br&gt;
+       Host: %nodelabel%&lt;br&gt;
+       Interface: %interface% &lt;br&gt;
+       Syslog severity: %parm[severity]% &lt;br&gt;
+       OpenNMS severity: %severity% &lt;br&gt;
+       Message: %parm[syslogmessage]% &lt;br&gt;
+       Process: %parm[process]% &lt;br&gt;
+       PID: %parm[processid]%
+       &lt;/p&gt;
+     </descr>
+     <logmsg dest='logndisplay'>
+       &lt;p&gt;An OpenWrt mwan3 syslog message has been received&lt;/p&gt;
+       Message: %parm[process]%: %parm[syslogmessage]% &lt;br&gt;
+     </logmsg>
+     <severity>Normal</severity>
+  </event>
+  <event>
+    <uei>uei.opennms.org/vendor/openwrt/syslog/mwan3/OfflineInterface</uei>
+    <event-label>OpenWrt mwan3 event: OfflineInterface</event-label>
+    <descr>
+       &lt;p&gt;The interface %interface% generated a syslog message.&lt;br&gt;
+       Interface name: %parm[interfaceName]%&lt;br&gt;
+       &lt;br&gt;
+       Node ID: %nodeid%&lt;br&gt;
+       Host: %nodelabel%&lt;br&gt;
+       Interface: %interface% &lt;br&gt;
+       Syslog severity: %parm[severity]% &lt;br&gt;
+       OpenNMS severity: %severity% &lt;br&gt;
+       Message: %parm[syslogmessage]% &lt;br&gt;
+       Process: %parm[process]% &lt;br&gt;
+       PID: %parm[processid]%
+       &lt;/p&gt;
+     </descr>
+     <logmsg dest='logndisplay'>
+       &lt;p&gt;An OpenWrt mwan3 syslog message has been received&lt;/p&gt;
+       Message: %parm[process]%: %parm[syslogmessage]% &lt;br&gt;
+     </logmsg>
+     <severity>Minor</severity>
+  </event>
+  <!-- mwan3 catchall -->
+  <event>
+    <uei>~uei\.opennms\.org/vendor/openwrt/syslog/mwan3/Informational/.*</uei>
+    <event-label>OpenWrt mwan3 event: syslogMessage</event-label>
+    <descr>
+       &lt;p&gt;The interface %interface% generated a syslog message.&lt;br&gt;
+       Node ID: %nodeid%&lt;br&gt;
+       Host: %nodelabel%&lt;br&gt;
+       Interface: %interface% &lt;br&gt;
+       Syslog severity: %parm[severity]% &lt;br&gt;
+       OpenNMS severity: %severity% &lt;br&gt;
+       Message: %parm[syslogmessage]% &lt;br&gt;
+       Process: %parm[process]% &lt;br&gt;
+       PID: %parm[processid]%
+       &lt;/p&gt;
+     </descr>
+     <logmsg dest='logndisplay'>
+       &lt;p&gt;An OpenWrt mwan3 syslog message has been received&lt;/p&gt;
+       Message: %parm[process]%: %parm[syslogmessage]% &lt;br&gt;
+     </logmsg>
+     <severity>Indeterminate</severity>
+  </event>
+
+</events>

--- a/opennms-base-assembly/src/main/filtered/etc/syslog/OpenWrt.syslog.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/syslog/OpenWrt.syslog.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0"?>
+
+<!--
+
+OpenWrt (the Linux distribution) and other OpenWrt software package syslog messages
+
+-->
+
+<syslogd-configuration-group>
+    <ueiList>
+
+        <!-- core OS syslog messages -->
+
+        <!-- system startup -->
+        <ueiMatch>
+            <!-- OpenWrt 12.09 version: this ifup message is used as proxy for system startup as the more relevant system startup log messages appear before remote syslogging is working -->
+            <severity>Notice</severity>
+            <process-match expression="^ifup$" />
+            <match type="substr" expression="Enabling Router Solicitations on loopback" />
+            <uei>uei.opennms.org/vendor/openwrt/syslog/SystemStarting</uei>
+        </ueiMatch>
+        <ueiMatch>
+            <!-- OpenWrt 14.07 version: this logread message is used as proxy for system startup as the more relevant system startup log messages appear before remote syslogging has started -->
+            <severity>Emergency</severity>
+            <process-match expression="logread" />
+            <match type="substr" expression="Logread connected to" />
+            <uei>uei.opennms.org/vendor/openwrt/syslog/SystemStarting</uei>
+        </ueiMatch>
+        <ueiMatch>
+            <!-- OpenWrt 15.05 version -->
+            <severity>Informational</severity>
+            <process-match expression="^procd$" />
+            <match type="substr" expression="init complete" />
+            <uei>uei.opennms.org/vendor/openwrt/syslog/SystemStarting</uei>
+        </ueiMatch>
+
+        <!-- system shutdown -->
+        <ueiMatch>
+            <!-- OpenWrt 12.09 version -->
+            <severity>Informational</severity>
+            <process-match expression="^init$" />
+            <match type="substr" expression="/etc/init.d/rcS K shutdown" />
+            <uei>uei.opennms.org/vendor/openwrt/syslog/SystemStopping</uei>
+        </ueiMatch>
+        <ueiMatch>
+            <!-- OpenWrt 14.07 version: this syslog shutdown message is used as proxy for system shutdown as the more relevant system shutdown log messages appear after remote syslogging h
+as stopped -->
+            <severity>Emergency</severity>
+            <process-match expression="^syslog$" />
+            <match type="substr" expression="shutdown" />
+            <uei>uei.opennms.org/vendor/openwrt/syslog/SystemStopping</uei>
+        </ueiMatch>
+        <ueiMatch>
+            <!-- OpenWrt 15.05 version -->
+            <severity>Informational</severity>
+            <process-match expression="^procd$" />
+            <match type="substr" expression="shutdown" />
+            <uei>uei.opennms.org/vendor/openwrt/syslog/SystemStopping</uei>
+        </ueiMatch>
+
+        <!-- package ddns-scripts syslog messages -->
+        <ueiMatch>
+            <process-match expression="^ddns-scripts-.*$" />
+            <match type="substr" expression="failed" />
+            <uei>uei.opennms.org/vendor/openwrt/syslog/ddns-scripts/DDNSIPUpdateFailed</uei>
+        </ueiMatch>
+        <ueiMatch>
+            <process-match expression="^ddns-scripts-.*$" />
+            <match type="substr" expression="successful" />
+            <uei>uei.opennms.org/vendor/openwrt/syslog/ddns-scripts/DDNSIPUpdateSuccessful</uei>
+        </ueiMatch>
+
+        <!-- package mwan3 syslog messages -->
+        <ueiMatch>
+            <severity>Informational</severity>
+            <process-match expression="^mwan3track$" />
+            <match type="regex" expression="^Lost [0-9]+ ping\(s\) on interface (.*)$" />
+            <uei>uei.opennms.org/vendor/openwrt/syslog/mwan3/LostPingsOnInterface</uei>
+            <parameter-assignment matching-group="1" parameter-name="interfaceName" />
+        </ueiMatch>
+        <ueiMatch>
+            <severity>Informational</severity>
+            <process-match expression="^mwan3track" />
+            <match type="regex" expression="^Interface (.*) is online$" />
+            <uei>uei.opennms.org/vendor/openwrt/syslog/mwan3/OnlineInterface</uei>
+            <parameter-assignment matching-group="1" parameter-name="interfaceName" />
+        </ueiMatch>
+        <ueiMatch>
+            <severity>Informational</severity>
+            <process-match expression="^mwan3track$" />
+            <match type="regex" expression="^Interface (.*) is offline$" />
+            <uei>uei.opennms.org/vendor/openwrt/syslog/mwan3/OfflineInterface</uei>
+            <parameter-assignment matching-group="1" parameter-name="interfaceName" />
+        </ueiMatch>
+
+        <!-- The only syslog sending mechanism OpenWrt has is to send ALL syslog messages to a remote syslog server. This results in a high
+             volume of syslog messages being received and stored in OpenNMS. To avoid this, the statement below will discard (and not save)
+             all syslog messages received from the specified devices below (other than those already captured above).
+               OpenWrt 12.09: list the device by its hostname (lowercase)
+               OpenWrt 14.07 and later: list the device by the source IP address it uses to send the syslog packet -->
+        <ueiMatch>
+            <hostname-match expression="(openwrt01|192\.0\.2\.1).*" />
+            <match type="regex" expression=".*" />
+            <uei>DISCARD-MATCHING-MESSAGES</uei>
+        </ueiMatch>
+
+    </ueiList>
+</syslogd-configuration-group>

--- a/opennms-base-assembly/src/main/filtered/etc/syslogd-configuration.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/syslogd-configuration.xml
@@ -38,6 +38,7 @@
     <import-file>syslog/ApacheHTTPD.syslog.xml</import-file>
     <import-file>syslog/LinuxKernel.syslog.xml</import-file>
     <import-file>syslog/OpenSSH.syslog.xml</import-file>
+    <import-file>syslog/OpenWrt.syslog.xml</import-file>
     <import-file>syslog/Procmail.syslog.xml</import-file>
     <import-file>syslog/Postfix.syslog.xml</import-file>
     <import-file>syslog/Sudo.syslog.xml</import-file>


### PR DESCRIPTION
This is a pull request for the addition of syslog messages and related events for OpenWrt (a Linux distribution for routers and other embedded devices) and various OpenWrt packages that also report status through syslog.

JIRA: http://issues.opennms.org/browse/NMS-8092
Bamboo: http://bamboo.internal.opennms.com:8085/browse/OPENNMS-ONMS426-2

