### PR TITLE
HZN-573

### DIFF
--- a/opennms-alarms/api/src/main/java/org/opennms/netmgt/alarmd/api/NorthboundAlarm.java
+++ b/opennms-alarms/api/src/main/java/org/opennms/netmgt/alarmd/api/NorthboundAlarm.java
@@ -38,6 +38,7 @@ import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlElementWrapper;
 import javax.xml.bind.annotation.XmlRootElement;
 
 import org.opennms.core.utils.InetAddressUtils;
@@ -45,6 +46,7 @@ import org.opennms.core.xml.ValidateUsing;
 import org.opennms.netmgt.events.api.EventParameterUtils;
 import org.opennms.netmgt.model.OnmsAlarm;
 import org.opennms.netmgt.model.OnmsDistPoller;
+import org.opennms.netmgt.model.OnmsEventParameter;
 import org.opennms.netmgt.model.OnmsSeverity;
 import org.opennms.netmgt.model.TroubleTicketState;
 import org.opennms.netmgt.xml.event.Parm;
@@ -56,6 +58,7 @@ import org.opennms.netmgt.xml.event.Parm;
  * FIXME: Most of these fields are not implemented waiting on above fix to be completed.
  * 
  * @author <a href="mailto:david@opennms.org">David Hustace</a>
+ * @author <a href="mailto:agalue@opennms.org">Alejandro Galue</a>
  */
 @XmlRootElement(name="northbound-alarm")
 @ValidateUsing("northbound-alarm.xsd")
@@ -613,7 +616,7 @@ public class NorthboundAlarm implements Preservable {
     @XmlElement(name="object-type")
     private String m_objectType;
 
-    /** The operator instructions */
+    /**  The operator instructions. */
     @XmlElement(name="operator-instructions")
     private String m_operInst;
 
@@ -668,13 +671,18 @@ public class NorthboundAlarm implements Preservable {
     /** The event parameters map. */
     private Map<String,String> m_eventParametersMap = new HashMap<String,String>();
 
-    /** The m_event parameters collection. */
-    private List<Parm> m_eventParametersCollection = new ArrayList<Parm>();
+    /** The event parameters collection. */
+    @XmlElementWrapper(name="parameters")
+    @XmlElement(name="parameter")
+    private List<OnmsEventParameter> m_eventParametersCollection = new ArrayList<OnmsEventParameter>();
 
     /** The preserved flag. */
     @XmlElement(name="preserved", defaultValue="false")
     private volatile boolean m_preserved = false;
 
+    /**
+     * Instantiates a new northbound alarm.
+     */
     public NorthboundAlarm() {
         // No-arg constructore required by JAXB
     }
@@ -765,8 +773,8 @@ public class NorthboundAlarm implements Preservable {
         }
 
         if (alarm.getEventParms() != null) {
-            m_eventParametersCollection.addAll(EventParameterUtils.decode(alarm.getEventParms()));
-            for (Parm parm : m_eventParametersCollection) {
+            for (Parm parm : EventParameterUtils.decode(alarm.getEventParms())) {
+                m_eventParametersCollection.add(new OnmsEventParameter(parm));
                 m_eventParametersMap.put(parm.getParmName(), parm.getValue().getContent());
             }
         }
@@ -1047,7 +1055,7 @@ public class NorthboundAlarm implements Preservable {
      *
      * @return the event parameters collection
      */
-    public List<Parm> getEventParametersCollection() {
+    public List<OnmsEventParameter> getEventParametersCollection() {
         return m_eventParametersCollection;
     }
 
@@ -1112,147 +1120,327 @@ public class NorthboundAlarm implements Preservable {
         return m_foreignId;
     }
 
+    /**
+     * Sets the id.
+     *
+     * @param id the new id
+     */
     public void setId(Integer id) {
         m_id = id;
     }
 
+    /**
+     * Sets the uei.
+     *
+     * @param uei the new uei
+     */
     public void setUei(String uei) {
         m_uei = uei;
     }
 
+    /**
+     * Sets the node id.
+     *
+     * @param nodeId the new node id
+     */
     public void setNodeId(Integer nodeId) {
         m_nodeId = nodeId;
     }
 
+    /**
+     * Sets the node label.
+     *
+     * @param nodeLabel the new node label
+     */
     public void setNodeLabel(String nodeLabel) {
         m_nodeLabel = nodeLabel;
     }
 
+    /**
+     * Sets the node sys object id.
+     *
+     * @param nodeSysObjectId the new node sys object id
+     */
     public void setNodeSysObjectId(String nodeSysObjectId) {
         m_nodeSysObjectId = nodeSysObjectId;
     }
 
+    /**
+     * Sets the foreign source.
+     *
+     * @param foreignSource the new foreign source
+     */
     public void setForeignSource(String foreignSource) {
         m_foreignSource = foreignSource;
     }
 
+    /**
+     * Sets the foreign id.
+     *
+     * @param foreignId the new foreign id
+     */
     public void setForeignId(String foreignId) {
         m_foreignId = foreignId;
     }
 
+    /**
+     * Sets the ack time.
+     *
+     * @param ackTime the new ack time
+     */
     public void setAckTime(Date ackTime) {
         m_ackTime = ackTime;
     }
 
+    /**
+     * Sets the ack user.
+     *
+     * @param ackUser the new ack user
+     */
     public void setAckUser(String ackUser) {
         m_ackUser = ackUser;
     }
 
+    /**
+     * Sets the alarm type.
+     *
+     * @param alarmType the new alarm type
+     */
     public void setAlarmType(AlarmType alarmType) {
         m_alarmType = alarmType;
     }
 
+    /**
+     * Sets the app dn.
+     *
+     * @param appDn the new app dn
+     */
     public void setAppDn(String appDn) {
         m_appDn = appDn;
     }
 
+    /**
+     * Sets the clear key.
+     *
+     * @param clearKey the new clear key
+     */
     public void setClearKey(String clearKey) {
         m_clearKey = clearKey;
     }
 
+    /**
+     * Sets the count.
+     *
+     * @param count the new count
+     */
     public void setCount(Integer count) {
         m_count = count;
     }
 
+    /**
+     * Sets the desc.
+     *
+     * @param desc the new desc
+     */
     public void setDesc(String desc) {
-       m_desc = desc;
+        m_desc = desc;
     }
 
+    /**
+     * Sets the poller.
+     *
+     * @param poller the new poller
+     */
     public void setPoller(OnmsDistPoller poller) {
         m_poller = poller;
     }
 
+    /**
+     * Sets the first occurrence.
+     *
+     * @param firstOccurrence the new first occurrence
+     */
     public void setFirstOccurrence(Date firstOccurrence) {
         m_firstOccurrence = firstOccurrence;
     }
 
+    /**
+     * Sets the ip addr.
+     *
+     * @param ipAddr the new ip addr
+     */
     public void setIpAddr(String ipAddr) {
         m_ipAddr = ipAddr;
     }
 
+    /**
+     * Sets the last occurrence.
+     *
+     * @param lastOccurrence the new last occurrence
+     */
     public void setLastOccurrence(Date lastOccurrence) {
         m_lastOccurrence = lastOccurrence;
     }
 
+    /**
+     * Sets the log msg.
+     *
+     * @param logMsg the new log msg
+     */
     public void setLogMsg(String logMsg) {
         m_logMsg = logMsg;
     }
 
+    /**
+     * Sets the object instance.
+     *
+     * @param objectInstance the new object instance
+     */
     public void setObjectInstance(String objectInstance) {
         m_objectInstance = objectInstance;
     }
 
+    /**
+     * Sets the object type.
+     *
+     * @param objectType the new object type
+     */
     public void setObjectType(String objectType) {
         m_objectType = objectType;
     }
 
+    /**
+     * Sets the oper inst.
+     *
+     * @param operInst the new oper inst
+     */
     public void setOperInst(String operInst) {
         m_operInst = operInst;
     }
 
+    /**
+     * Sets the oss key.
+     *
+     * @param ossKey the new oss key
+     */
     public void setOssKey(String ossKey) {
         m_ossKey = ossKey;
     }
 
+    /**
+     * Sets the oss state.
+     *
+     * @param ossState the new oss state
+     */
     public void setOssState(String ossState) {
         m_ossState = ossState;
     }
 
+    /**
+     * Sets the alarm key.
+     *
+     * @param alarmKey the new alarm key
+     */
     public void setAlarmKey(String alarmKey) {
         m_alarmKey = alarmKey;
     }
 
+    /**
+     * Sets the service.
+     *
+     * @param service the new service
+     */
     public void setService(String service) {
         m_service = service;
     }
 
+    /**
+     * Sets the severity.
+     *
+     * @param severity the new severity
+     */
     public void setSeverity(OnmsSeverity severity) {
         m_severity = severity;
     }
 
+    /**
+     * Sets the suppressed.
+     *
+     * @param suppressed the new suppressed
+     */
     public void setSuppressed(Date suppressed) {
         m_suppressed = suppressed;
     }
 
+    /**
+     * Sets the suppressed until.
+     *
+     * @param suppressedUntil the new suppressed until
+     */
     public void setSuppressedUntil(Date suppressedUntil) {
         m_suppressedUntil = suppressedUntil;
     }
 
+    /**
+     * Sets the suppressed by.
+     *
+     * @param suppressedBy the new suppressed by
+     */
     public void setSuppressedBy(String suppressedBy) {
         m_suppressedBy = suppressedBy;
     }
 
+    /**
+     * Sets the ticket id.
+     *
+     * @param ticketId the new ticket id
+     */
     public void setTicketId(String ticketId) {
         m_ticketId = ticketId;
     }
 
+    /**
+     * Sets the ticket state.
+     *
+     * @param ticketState the new ticket state
+     */
     public void setTicketState(TroubleTicketState ticketState) {
         m_ticketState = ticketState;
     }
 
+    /**
+     * Sets the x733 type.
+     *
+     * @param x733Type the new x733 type
+     */
     public void setx733Type(String x733Type) {
         m_x733Type = x733Type;
     }
 
+    /**
+     * Sets the x733 cause.
+     *
+     * @param x733Cause the new x733 cause
+     */
     public void setx733Cause(int x733Cause) {
         m_x733Cause = x733Cause;
     }
 
+    /**
+     * Sets the event parameters map.
+     *
+     * @param eventParametersMap the event parameters map
+     */
     public void setEventParametersMap(Map<String, String> eventParametersMap) {
         m_eventParametersMap = eventParametersMap;
     }
 
-    public void setEventParametersCollection(List<Parm> eventParametersCollection) {
+    /**
+     * Sets the event parameters collection.
+     *
+     * @param eventParametersCollection the new event parameters collection
+     */
+    public void setEventParametersCollection(List<OnmsEventParameter> eventParametersCollection) {
         m_eventParametersCollection = eventParametersCollection;
     }
 
@@ -1264,6 +1452,9 @@ public class NorthboundAlarm implements Preservable {
         return String.format("NorthboundAlarm[id=%d, uei='%s', nodeId=%d]", m_id, m_uei, m_nodeId);
     }
 
+    /* (non-Javadoc)
+     * @see java.lang.Object#hashCode()
+     */
     @Override
     public int hashCode() {
         final int prime = 31;
@@ -1308,6 +1499,9 @@ public class NorthboundAlarm implements Preservable {
         return result;
     }
 
+    /* (non-Javadoc)
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
     @Override
     public boolean equals(Object obj) {
         if (this == obj)

--- a/opennms-alarms/api/src/main/java/org/opennms/netmgt/alarmd/api/support/AbstractNorthbounder.java
+++ b/opennms-alarms/api/src/main/java/org/opennms/netmgt/alarmd/api/support/AbstractNorthbounder.java
@@ -37,7 +37,7 @@ import org.opennms.netmgt.alarmd.api.NorthboundAlarm.AlarmType;
 import org.opennms.netmgt.alarmd.api.NorthboundAlarm.x733ProbableCause;
 import org.opennms.netmgt.alarmd.api.Northbounder;
 import org.opennms.netmgt.alarmd.api.NorthbounderException;
-import org.opennms.netmgt.xml.event.Parm;
+import org.opennms.netmgt.model.OnmsEventParameter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -340,10 +340,10 @@ public abstract class AbstractNorthbounder implements Northbounder, Runnable, St
             return;
         }
         int parmOffset = 1;
-        for (Parm parm : alarm.getEventParametersCollection()) {
-            mapping.put("parm[name-#" + parmOffset + "]", parm.getParmName());
-            mapping.put("parm[#" + parmOffset + "]", parm.getValue().getContent());
-            mapping.put("parm[" + parm.getParmName() + "]", parm.getValue().getContent());
+        for (OnmsEventParameter parm : alarm.getEventParametersCollection()) {
+            mapping.put("parm[name-#" + parmOffset + "]", parm.getName());
+            mapping.put("parm[#" + parmOffset + "]", parm.getValue());
+            mapping.put("parm[" + parm.getName() + "]", parm.getValue());
             parmOffset++;
         }
     }

--- a/opennms-alarms/api/src/main/resources/xsds/northbound-alarm.xsd
+++ b/opennms-alarms/api/src/main/resources/xsds/northbound-alarm.xsd
@@ -35,6 +35,13 @@
          <xsd:element name="ticket-state" type="ns0:troubleTicketState" minOccurs="0"/>
          <xsd:element name="x733-type" type="xsd:string" minOccurs="0"/>
          <xsd:element name="x733-cause" type="xsd:int"/>
+         <xsd:element name="parameters" minOccurs="0">
+            <xsd:complexType>
+               <xsd:sequence>
+                  <xsd:element name="parameter" type="ns0:onmsEventParameter" minOccurs="0" maxOccurs="unbounded"/>
+               </xsd:sequence>
+            </xsd:complexType>
+         </xsd:element>
          <xsd:element name="preserved" type="xsd:boolean" default="false"/>
       </xsd:sequence>
       <xsd:attribute name="id" type="xsd:int"/>
@@ -80,5 +87,12 @@
          <xsd:enumeration value="CANCEL_FAILED"/>
       </xsd:restriction>
    </xsd:simpleType>
+
+   <xsd:complexType name="onmsEventParameter">
+      <xsd:sequence/>
+      <xsd:attribute name="name" type="xsd:string"/>
+      <xsd:attribute name="value" type="xsd:string"/>
+      <xsd:attribute name="type" type="xsd:string"/>
+   </xsd:complexType>
 
 </xsd:schema>

--- a/opennms-alarms/api/src/test/java/org/opennms/netmgt/alarmd/api/NorthboundAlarmTest.java
+++ b/opennms-alarms/api/src/test/java/org/opennms/netmgt/alarmd/api/NorthboundAlarmTest.java
@@ -87,6 +87,7 @@ public class NorthboundAlarmTest extends XmlTestNoCastor<NorthboundAlarm> {
                      "<ticket-state>OPEN</ticket-state>\n" +
                      "<x733-type>type</x733-type>\n" +
                      "<x733-cause>1</x733-cause>\n" +
+                     "<parameters/>\n" +
                      "<preserved>true</preserved>\n" +
                     "</northbound-alarm>"
                 }

--- a/opennms-alarms/snmptrap-northbounder/src/test/resources/etc/snmptrap-northbound/my-mappings-01.xml
+++ b/opennms-alarms/snmptrap-northbounder/src/test/resources/etc/snmptrap-northbound/my-mappings-01.xml
@@ -6,7 +6,7 @@
 		<varbind>
 			<oid>.1.2.3.4.5.6.7.8.1</oid>
 			<type>Int32</type>
-			<value>eventParametersCollection[0].value.content</value>
+			<value>eventParametersCollection[0].value</value>
 		</varbind>
 		<varbind>
 			<oid>.1.2.3.4.5.6.7.8.2</oid>

--- a/opennms-alarms/snmptrap-northbounder/src/test/resources/etc/snmptrap-northbounder-config.xml
+++ b/opennms-alarms/snmptrap-northbounder/src/test/resources/etc/snmptrap-northbounder-config.xml
@@ -20,7 +20,7 @@
 				<varbind>
 					<oid>.1.2.3.4.5.6.7.8.1</oid>
 					<type>Int32</type>
-					<value>eventParametersCollection[0].value.content</value>
+					<value>eventParametersCollection[0].value</value>
 				</varbind>
 				<varbind>
 					<oid>.1.2.3.4.5.6.7.8.2</oid>

--- a/opennms-base-assembly/src/main/filtered/etc/snmptrap-northbounder-configuration.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/snmptrap-northbounder-configuration.xml
@@ -90,7 +90,7 @@
 				<varbind>
 					<oid>.1.2.3.4.5.6.7.8.1</oid>
 					<type>Int32</type>
-					<value>eventParametersCollection[2].value.content</value> <!-- Value of the third parameter -->
+					<value>eventParametersCollection[2].value</value> <!-- Value of the third parameter -->
 				</varbind>
 				<varbind>
 					<oid>.1.2.3.4.5.6.7.8.2</oid>

--- a/opennms-dao/src/test/java/org/opennms/netmgt/dao/EventDaoIT.java
+++ b/opennms-dao/src/test/java/org/opennms/netmgt/dao/EventDaoIT.java
@@ -40,9 +40,11 @@ import org.junit.runner.RunWith;
 import org.opennms.core.spring.BeanUtils;
 import org.opennms.core.test.OpenNMSJUnit4ClassRunner;
 import org.opennms.core.test.db.annotations.JUnitTemporaryDatabase;
+import org.opennms.core.xml.JaxbUtils;
 import org.opennms.netmgt.dao.api.DistPollerDao;
 import org.opennms.netmgt.dao.api.EventDao;
 import org.opennms.netmgt.dao.api.NodeDao;
+import org.opennms.netmgt.events.api.EventParameterUtils;
 import org.opennms.netmgt.model.OnmsAlarm;
 import org.opennms.netmgt.model.OnmsEvent;
 import org.opennms.netmgt.model.OnmsIpInterface;
@@ -119,6 +121,7 @@ public class EventDaoIT implements InitializingBean {
         OnmsAlarm alarm = new OnmsAlarm();
 	    event.setAlarm(alarm);
         event.setIpAddr(iface.getIpAddress());
+        event.setEventParms("label=node(string,text);ds=(memAvailReal + memCached) / memTotalReal * 100.0(string,text);description=(memAvailReal + memCached) / memTotalReal * 100.0(string,text);value=4.7(string,text);instance=node(string,text);instanceLabel=node(string,text);resourceId=node[70].nodeSnmp[](string,text);threshold=5.0(string,text);trigger=2(string,text);rearm=10.0(string,text)");
         m_eventDao.save(event);
        
         OnmsEvent newEvent = m_eventDao.load(event.getId());
@@ -126,6 +129,8 @@ public class EventDaoIT implements InitializingBean {
         assertNotNull(newEvent.getServiceType());
         assertEquals(service.getNodeId(), newEvent.getNode().getId());
         assertEquals(event.getIpAddr(), newEvent.getIpAddr());
+        
+        System.err.println(JaxbUtils.marshal(event));
     }
 
     @Test

--- a/opennms-model/src/main/java/org/opennms/netmgt/model/OnmsAlarm.java
+++ b/opennms-model/src/main/java/org/opennms/netmgt/model/OnmsAlarm.java
@@ -32,7 +32,9 @@ import java.io.Serializable;
 import java.net.InetAddress;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
@@ -53,6 +55,7 @@ import javax.persistence.TemporalType;
 import javax.persistence.Transient;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlElementWrapper;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlTransient;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
@@ -62,6 +65,7 @@ import org.hibernate.ObjectNotFoundException;
 import org.hibernate.annotations.Filter;
 import org.hibernate.annotations.Type;
 import org.opennms.core.network.InetAddressXmlAdapter;
+import org.opennms.netmgt.events.api.EventParameterUtils;
 import org.springframework.core.style.ToStringCreator;
 
 /**
@@ -784,10 +788,20 @@ public class OnmsAlarm implements Acknowledgeable, Serializable {
      *
      * @return a {@link java.lang.String} object.
      */
-    @XmlElement(name="parms")
-    @Column(name="eventParms", length=1024)
+    @XmlTransient
+    @Column(name="eventParms")
     public String getEventParms() {
-        return this.m_eventParms;
+            return m_eventParms;
+    }
+
+    @Transient
+    @XmlElementWrapper(name="parameters")
+    @XmlElement(name="parameter")
+    public List<OnmsEventParameter> getEventParameters() {
+        if (m_eventParms == null) {
+            return null;
+        }
+        return EventParameterUtils.decode(m_eventParms).stream().map(p -> new OnmsEventParameter(p)).collect(Collectors.toList());
     }
 
     /**

--- a/opennms-model/src/main/java/org/opennms/netmgt/model/OnmsEvent.java
+++ b/opennms-model/src/main/java/org/opennms/netmgt/model/OnmsEvent.java
@@ -32,7 +32,9 @@ import java.io.Serializable;
 import java.net.InetAddress;
 import java.util.Date;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -49,6 +51,7 @@ import javax.persistence.TemporalType;
 import javax.persistence.Transient;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlElementWrapper;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlTransient;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
@@ -59,6 +62,7 @@ import org.hibernate.ObjectNotFoundException;
 import org.hibernate.annotations.Filter;
 import org.hibernate.annotations.Type;
 import org.opennms.core.network.InetAddressXmlAdapter;
+import org.opennms.netmgt.events.api.EventParameterUtils;
 import org.springframework.core.style.ToStringCreator;
 
 /**
@@ -542,12 +546,22 @@ public class OnmsEvent extends OnmsEntity implements Serializable {
 	 *
 	 * @return a {@link java.lang.String} object.
 	 */
-	@XmlElement(name="parms")
-	@Column(name="eventParms", length=1024)
+	@XmlTransient
+	@Column(name="eventParms")
 	public String getEventParms() {
 		return m_eventParms;
 	}
 
+        @Transient
+	@XmlElementWrapper(name="parameters")
+        @XmlElement(name="parameter")
+	public List<OnmsEventParameter> getEventParameters() {
+	    if (m_eventParms == null) {
+	        return null;
+	    }
+	    return EventParameterUtils.decode(m_eventParms).stream().map(p -> new OnmsEventParameter(p)).collect(Collectors.toList());
+	}
+	
 	/**
 	 * <p>setEventParms</p>
 	 *

--- a/opennms-model/src/main/java/org/opennms/netmgt/model/OnmsEventParameter.java
+++ b/opennms-model/src/main/java/org/opennms/netmgt/model/OnmsEventParameter.java
@@ -1,0 +1,128 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2002-2016 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2016 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+package org.opennms.netmgt.model;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import org.opennms.netmgt.xml.event.Parm;
+
+/**
+ * The Class OnmsEventParameter.
+ * 
+ * @author <a href="mailto:agalue@opennms.org">Alejandro Galue</a>
+ */
+@XmlRootElement(name="parameter")
+@XmlAccessorType(XmlAccessType.FIELD)
+public class OnmsEventParameter {
+
+    /** The name. */
+    @XmlAttribute(name="name")
+    private String name;
+
+    /** The value. */
+    @XmlAttribute(name="value")
+    private String value;
+
+    /** The type. */
+    @XmlAttribute(name="type")
+    private String type;
+
+    /**
+     * Instantiates a new OpenNMS event parameter.
+     */
+    public OnmsEventParameter() {}
+
+    /**
+     * Instantiates a new OpenNMS event parameter.
+     *
+     * @param parm the Event parameter object
+     */
+    public OnmsEventParameter(Parm parm) {
+        name = parm.getParmName();
+        value = parm.getValue().getContent();
+        type = parm.getValue().getType();
+    }
+
+    /**
+     * Gets the name.
+     *
+     * @return the name
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Gets the value.
+     *
+     * @return the value
+     */
+    public String getValue() {
+        return value;
+    }
+
+    /**
+     * Sets the name.
+     *
+     * @param name the new name
+     */
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+     * Sets the value.
+     *
+     * @param value the new value
+     */
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    /**
+     * Gets the type.
+     *
+     * @return the type
+     */
+    public String getType() {
+        return type;
+    }
+
+    /**
+     * Sets the type.
+     *
+     * @param type the new type
+     */
+    public void setType(String type) {
+        this.type = type;
+    }
+
+}

--- a/opennms-webapp-rest/src/test/resources/v1/alarms.json
+++ b/opennms-webapp-rest/src/test/resources/v1/alarms.json
@@ -20,7 +20,9 @@
                 "logMessage": "Test Event Log Message", 
                 "nodeId": 1, 
                 "nodeLabel": "node1", 
-                "parms": "testParm=HelloWorld(string,text)", 
+                "parameters": [
+                    {"name": "testParm", "value": "HelloWorld", "type":"string" }
+                ],
                 "serviceType": {
                     "id": 1, 
                     "name": "ICMP"
@@ -37,7 +39,9 @@
             "nodeId": 1, 
             "nodeLabel": "node1", 
             "ossPrimaryKey": null, 
-            "parms": "testParm=HelloWorld(string,text)", 
+            "parameters": [
+                {"name": "testParm", "value": "HelloWorld", "type":"string" }
+            ],
             "qosAlarmState": null, 
             "serviceType": {
                 "id": 1, 

--- a/opennms-webapp-rest/src/test/resources/v1/outages.json
+++ b/opennms-webapp-rest/src/test/resources/v1/outages.json
@@ -36,7 +36,9 @@
                 "logMessage": "Test Event Log Message", 
                 "nodeId": 1, 
                 "nodeLabel": "node1", 
-                "parms": "testParm=HelloWorld(string,text)", 
+                "parameters": [
+                    {"name": "testParm", "value": "HelloWorld", "type":"string" }
+                ],
                 "serviceType": {
                     "id": 1,
                     "name": "ICMP"
@@ -58,7 +60,9 @@
                 "logMessage": "Test Event Log Message", 
                 "nodeId": 1, 
                 "nodeLabel": "node1", 
-                "parms": "testParm=HelloWorld(string,text)", 
+                "parameters": [
+                    {"name": "testParm", "value": "HelloWorld", "type":"string" }
+                ],
                 "serviceType": {
                     "id": 1,
                     "name": "ICMP"

--- a/opennms-webapp-rest/src/test/resources/v1/stats_alarms.json
+++ b/opennms-webapp-rest/src/test/resources/v1/stats_alarms.json
@@ -23,7 +23,9 @@
                 "logMessage": "Test event 2 (log)", 
                 "nodeId": 1, 
                 "nodeLabel": "node1", 
-                "parms": "test=parm(string,text)", 
+                "parameters": [
+                    {"name": "test", "value": "parm", "type":"string" }
+                ],
                 "serviceType": {
                     "id": 1, 
                     "name": "ICMP"
@@ -40,7 +42,9 @@
             "nodeId": 1, 
             "nodeLabel": "node1", 
             "ossPrimaryKey": null, 
-            "parms": "test=parm(string,text)", 
+            "parameters": [
+                {"name": "test", "value": "parm", "type":"string" }
+            ],
             "qosAlarmState": null, 
             "serviceType": {
                 "id": 1, 
@@ -74,7 +78,9 @@
                 "logMessage": "Test event 5 (log)", 
                 "nodeId": 1, 
                 "nodeLabel": "node1", 
-                "parms": "test=parm(string,text)", 
+                "parameters": [
+                    {"name": "test", "value": "parm", "type":"string" }
+                ],
                 "serviceType": {
                     "id": 1, 
                     "name": "ICMP"
@@ -91,7 +97,9 @@
             "nodeId": 1, 
             "nodeLabel": "node1", 
             "ossPrimaryKey": null, 
-            "parms": "test=parm(string,text)", 
+            "parameters": [
+                {"name": "test", "value": "parm", "type":"string" }
+            ],
             "qosAlarmState": null, 
             "serviceType": {
                 "id": 1, 
@@ -127,7 +135,9 @@
                 "logMessage": "Test event 0 (log)", 
                 "nodeId": 1, 
                 "nodeLabel": "node1", 
-                "parms": "test=parm(string,text)", 
+                "parameters": [
+                    {"name": "test", "value": "parm", "type":"string" }
+                ],
                 "serviceType": {
                     "id": 1, 
                     "name": "ICMP"
@@ -144,7 +154,9 @@
             "nodeId": 1, 
             "nodeLabel": "node1", 
             "ossPrimaryKey": null, 
-            "parms": "test=parm(string,text)", 
+            "parameters": [
+                {"name": "test", "value": "parm", "type":"string" }
+            ],
             "qosAlarmState": null, 
             "serviceType": {
                 "id": 1, 
@@ -178,7 +190,9 @@
                 "logMessage": "Test event 3 (log)", 
                 "nodeId": 1, 
                 "nodeLabel": "node1", 
-                "parms": "test=parm(string,text)", 
+                "parameters": [
+                    {"name": "test", "value": "parm", "type":"string" }
+                ],
                 "serviceType": {
                     "id": 1, 
                     "name": "ICMP"
@@ -195,7 +209,9 @@
             "nodeId": 1, 
             "nodeLabel": "node1", 
             "ossPrimaryKey": null, 
-            "parms": "test=parm(string,text)", 
+            "parameters": [
+                {"name": "test", "value": "parm", "type":"string" }
+            ],
             "qosAlarmState": null, 
             "serviceType": {
                 "id": 1, 


### PR DESCRIPTION
Exposing the event/alarm parameters on OnmsEvent, OnmsAlarm and NorthboundAlarm as a discrete list of parameters when generating their respective XML/JSON representation, instead of using the unusable encoded list of parameters stored on the database.

The solution has been tested on a VM and works as expected.

JIRA: http://issues.opennms.org/browse/HZN-573
Bamboo: http://bamboo.internal.opennms.com:8085/browse/OPENNMS-ONMS422