### PR TITLE
NMS-8097: Fix Oracle Java install guide

### DIFF
--- a/opennms-doc/guide-install/src/asciidoc/text/java/debian.adoc
+++ b/opennms-doc/guide-install/src/asciidoc/text/java/debian.adoc
@@ -7,16 +7,18 @@
 
 This section describes how to install _Oracle Java 8_ on a _Debian-based_ system like _Debian 8_ or _Ubuntu 14.04 LTS_.
 
-.Install add-apt-repository package
+.Add Java repository from webupd8 maintainer
 [source, bash]
 ----
-apt-get install -y python-software-properties
+su -
+echo "deb http://ppa.launchpad.net/webupd8team/java/ubuntu trusty main" | tee /etc/apt/sources.list.d/webupd8team-java.list
+echo "deb-src http://ppa.launchpad.net/webupd8team/java/ubuntu trusty main" | tee -a /etc/apt/sources.list.d/webupd8team-java.list
 ----
 
-.Add Java repository from webud8 maintainer
+.Add repository key server and update repository
 [source, bash]
 ----
-add-apt-repository ppa:webupd8team/java
+apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys EEA14886
 apt-get update
 ----
 


### PR DESCRIPTION
It is not possible since Java 1.8.0 b72 to install with add-apt-repository. Updated the install guide to create source.list file manually.

JIRA: http://issues.opennms.org/browse/NMS-8097
Bamboo: http://bamboo.internal.opennms.com:8085/browse/OPENNMS-ONMS435