### PR TITLE
NMS-5069: Monitor disk space on more Net-SNMP devices and include in threshold package

### DIFF
--- a/opennms-base-assembly/src/main/filtered/etc/datacollection/netsnmp.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/datacollection/netsnmp.xml
@@ -163,6 +163,7 @@
         <collect>
           <includeGroup>mib2-host-resources-system</includeGroup>
           <includeGroup>mib2-host-resources-memory</includeGroup>
+          <includeGroup>mib2-host-resources-storage</includeGroup>
           <includeGroup>mib2-X-interfaces</includeGroup>
           <includeGroup>mib2-X-interfaces-pkts</includeGroup>
           <includeGroup>net-snmp-disk</includeGroup>

--- a/opennms-base-assembly/src/main/filtered/etc/threshd-configuration.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/threshd-configuration.xml
@@ -14,7 +14,7 @@
 	</package>
 	
 	<package name="hrstorage">
-		<filter>IPADDR != '0.0.0.0' &amp; (nodeSysOID LIKE '.1.3.6.1.4.1.311.%' | nodeSysOID LIKE '.1.3.6.1.4.1.2.3.1.2.1.1.3.%')</filter>	 
+		<filter>IPADDR != '0.0.0.0' &amp; (nodeSysOID LIKE '.1.3.6.1.4.1.311.%' | nodeSysOID LIKE '.1.3.6.1.4.1.2.3.1.2.1.1.3.%' | nodeSysOID LIKE '.1.3.6.1.4.1.8072.%')</filter>	 
 		<include-range begin="1.1.1.1" end="254.254.254.254"/>
 		<include-range begin="::1" end="ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff" />
 		


### PR DESCRIPTION
Include Net-SNMP (OID 1.3.6.1.4.1.8072) devices (such as Linux sytems) in the hrstorage threshold package and collect mib2-host-resources-storage data for Net-SNMP devices as this is a more reliable way of getting disk space data than using the net-snmp-disk MIB.

This change allows disk space to be monitored successfully on more devices. Examples are given in the JIRA ticket.

JIRA: http://issues.opennms.org/browse/NMS-5069
