### PR TITLE
NMS-8112: init script "configtest" exit value is always 1

### DIFF
--- a/opennms-base-assembly/src/main/filtered/bin/opennms
+++ b/opennms-base-assembly/src/main/filtered/bin/opennms
@@ -851,8 +851,16 @@ case "$COMMAND" in
 
 	configtest)
 		$opennms_echo "Validating XML files: \c"
-		checkXmlFiles || exit $?
-		echo "PASSED"
+		checkXmlFiles
+		ret=$?
+		case $ret in
+			0)
+				echo "PASSED"
+				;;
+			*)
+				# nothing
+				;;
+		esac
 		;;
 
 	pause)


### PR DESCRIPTION
Propagate return value from checkXmlFiles() to init script exit value,
so "configtest" exits with 0 for success and non-zero for failure.