### PR TITLE
NMS-6404: Add support for publishing events on the bus via REST.

### DIFF
--- a/opennms-base-assembly/src/main/resources/contrib/send-event.py
+++ b/opennms-base-assembly/src/main/resources/contrib/send-event.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python
+
+"""send-event.py: Send events to OpenNMS via the REST API."""
+
+import datetime
+from lxml import etree as ET
+import urllib2
+import base64
+
+class EventParameter:
+    """An OpenNMS parameter"""
+    def __init__(self, name, value):
+        self.name = name
+        self.value = value
+
+class Event:
+    """An OpenNMS event"""
+    def __init__(self, uei):
+        self.uei = uei
+        self.interface = None
+        self.source = "python_send_event"
+        self.host = "localhost"
+        self.time = None
+        self.parameters = []
+
+    def add_parameter(self, name, value):
+        self.parameters.append(EventParameter(name, value))
+    
+    def to_xml(self):
+        # Create the Event XML
+        root = ET.Element('event')
+
+        # UEI
+        ET.SubElement(root, "uei").text = self.uei
+
+        # Source
+        ET.SubElement(root, "source").text = self.source
+
+        # Time, expected format: "Monday, February 18, 2002 3:01:58 PM EST"
+        time = self.time if self.time is not None else datetime.datetime.utcnow()
+        ET.SubElement(root, "time").text = time.strftime("%A, %B %d, %Y %I:%M:%S %p UTC")
+
+        # Host
+        ET.SubElement(root, "host").text = self.host
+
+        # Parameters
+        if len(self.parameters) > 0:
+            parms_el = ET.SubElement(root, "parms")
+            for parameter in self.parameters:
+                parm_el = ET.SubElement(parms_el, "parm")
+                ET.SubElement(parm_el, "parmName").text = ET.CDATA(parameter.name)
+                ET.SubElement(parm_el, "value", type="string", encoding="text").text = ET.CDATA(parameter.value)
+
+        return ET.tostring(root, pretty_print=True)
+
+def send_event(event):
+    r = urllib2.Request("http://localhost:8980/opennms/rest/events", data=event.to_xml(), headers={'Content-Type': 'application/xml'})
+    b64 = base64.encodestring("{}:{}".format("admin", "admin")).rstrip()
+    r.add_header("Authorization", "Basic {}".format(b64))
+    u = urllib2.urlopen(r)
+    response = u.read()
+
+e = Event("uei.opennms.org/internal/discovery/newSuspect")
+e.add_parameter("key", "value")
+print "Sending event: {}".format(e.to_xml())
+send_event(e)
+

--- a/opennms-doc/guide-development/src/asciidoc/text/rest/events.adoc
+++ b/opennms-doc/guide-development/src/asciidoc/text/rest/events.adoc
@@ -21,3 +21,15 @@ _PUT_ requires form data using `application/x-www-form-urlencoded` as a Content-
 | `/events/{id}?ack=''(true;false)`      | Acknowledges (or unacknowledges) an event.
 | `/events?x=y&...&ack=''(true;false)`   | Acknowledges (or unacknowledges) the matching events.
 |===
+
+===== POSTs (Adding Data)
+
+POST requires XML (application/xml) or JSON (application/json) as its Content-Type.
+
+TIP: See `${OPENNMS_HOME}/share/xsds/event.xsd` for the reference schema.
+
+[options="header", cols="5,10"]
+|===
+| Resource                                        | Description
+| `/events`                                       | Publish an event on the event bus.
+|===

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/EventRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/EventRestService.java
@@ -34,6 +34,7 @@ import java.util.Date;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.FormParam;
 import javax.ws.rs.GET;
+import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -51,6 +52,7 @@ import org.joda.time.format.ISODateTimeFormat;
 import org.opennms.core.criteria.Alias.JoinType;
 import org.opennms.core.criteria.CriteriaBuilder;
 import org.opennms.netmgt.dao.api.EventDao;
+import org.opennms.netmgt.events.api.EventIpcManager;
 import org.opennms.netmgt.model.OnmsEvent;
 import org.opennms.netmgt.model.OnmsEventCollection;
 import org.opennms.web.rest.support.MultivaluedMapImpl;
@@ -66,6 +68,9 @@ public class EventRestService extends OnmsRestService {
 
     @Autowired
     private EventDao m_eventDao;
+
+    @Autowired
+    private EventIpcManager m_eventForwarder;
 
     /**
      * <p>
@@ -256,6 +261,14 @@ public class EventRestService extends OnmsRestService {
             event.setEventAckUser(null);
         }
         m_eventDao.save(event);
+    }
+
+    @POST
+    @Consumes({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
+    @Transactional
+    public Response publishEvent(final org.opennms.netmgt.xml.event.Event event) {
+        m_eventForwarder.sendNow(event);
+        return Response.ok().build();
     }
 
     private static CriteriaBuilder getCriteriaBuilder(final MultivaluedMap<String, String> params) {


### PR DESCRIPTION
Included a sample python script in contrib/ that can be used to generate
and publish events via REST.

JIRA: http://issues.opennms.org/browse/NMS-6404
Bamboo: http://bamboo.internal.opennms.com:8085/browse/OPENNMS-ONMS466-2