### PR TITLE
BSM-144: Update the header of the Ops Board to use the same styling as the rest of the application

### DIFF
--- a/features/themes/dashboard-theme/src/main/java/VAADIN/themes/dashboard/styles.css
+++ b/features/themes/dashboard-theme/src/main/java/VAADIN/themes/dashboard/styles.css
@@ -49,8 +49,15 @@
     border-width: 0 0 1px;
 }
 
-.dashboard .logo {
-    padding: 10px 0px 0px 10px;
+#onmslogo {
+    background:url(/opennms/images/horizon_logo.svg) no-repeat;
+    display:block;
+    height:44px;
+    width:130px;
+    overflow:hidden;
+    text-indent:100%;
+    white-space:nowrap;
+    margin: 10px 0px 0px 10px;
 }
 
 .dashboard .wallboard-board {

--- a/features/themes/dashboard-theme/src/main/java/VAADIN/themes/dashboard/styles.css
+++ b/features/themes/dashboard-theme/src/main/java/VAADIN/themes/dashboard/styles.css
@@ -44,8 +44,13 @@
 }
 
 .dashboard .header {
-    background: #fff;
-    border-bottom: 2px solid #ccc;
+    background-color: #dddddd;
+    border-color: #dddddd;
+    border-width: 0 0 1px;
+}
+
+.dashboard .logo {
+    padding: 10px 0px 0px 10px;
 }
 
 .dashboard .wallboard-board {

--- a/features/vaadin-dashboard/src/main/java/org/opennms/features/vaadin/dashboard/ui/HeaderLayout.java
+++ b/features/vaadin-dashboard/src/main/java/org/opennms/features/vaadin/dashboard/ui/HeaderLayout.java
@@ -36,12 +36,12 @@ import org.opennms.features.vaadin.dashboard.ui.wallboard.WallboardView;
 import com.vaadin.data.Property;
 import com.vaadin.navigator.View;
 import com.vaadin.navigator.ViewChangeListener;
-import com.vaadin.server.ExternalResource;
 import com.vaadin.shared.ui.MarginInfo;
+import com.vaadin.shared.ui.label.ContentMode;
 import com.vaadin.ui.Alignment;
 import com.vaadin.ui.Button;
 import com.vaadin.ui.HorizontalLayout;
-import com.vaadin.ui.Link;
+import com.vaadin.ui.Label;
 import com.vaadin.ui.NativeSelect;
 import com.vaadin.ui.UI;
 
@@ -73,11 +73,11 @@ public class HeaderLayout extends HorizontalLayout implements ViewChangeListener
         /**
          * Adding the logo
          */
-        Link link = new Link(null, new ExternalResource("/opennms/index.jsp"));
-        link.setIcon(new ExternalResource("/opennms/images/horizon_logo.svg"));
+        Label link = new Label();
+        link.setContentMode(ContentMode.HTML);
+        link.setValue("<a href=\"/opennms/index.jsp\" id=\"onmslogo\"></a>");
         addComponent(link);
         setExpandRatio(link, 1.0f);
-        link.addStyleName("logo");
 
         /**
          * Adding the selection box

--- a/features/vaadin-dashboard/src/main/java/org/opennms/features/vaadin/dashboard/ui/HeaderLayout.java
+++ b/features/vaadin-dashboard/src/main/java/org/opennms/features/vaadin/dashboard/ui/HeaderLayout.java
@@ -28,16 +28,22 @@
 
 package org.opennms.features.vaadin.dashboard.ui;
 
-import com.vaadin.data.Property;
-import com.vaadin.navigator.View;
-import com.vaadin.navigator.ViewChangeListener;
-import com.vaadin.server.ExternalResource;
-import com.vaadin.server.ThemeResource;
-import com.vaadin.ui.*;
 import org.opennms.features.vaadin.dashboard.config.ui.WallboardProvider;
 import org.opennms.features.vaadin.dashboard.model.Wallboard;
 import org.opennms.features.vaadin.dashboard.ui.dashboard.DashboardView;
 import org.opennms.features.vaadin.dashboard.ui.wallboard.WallboardView;
+
+import com.vaadin.data.Property;
+import com.vaadin.navigator.View;
+import com.vaadin.navigator.ViewChangeListener;
+import com.vaadin.server.ExternalResource;
+import com.vaadin.shared.ui.MarginInfo;
+import com.vaadin.ui.Alignment;
+import com.vaadin.ui.Button;
+import com.vaadin.ui.HorizontalLayout;
+import com.vaadin.ui.Link;
+import com.vaadin.ui.NativeSelect;
+import com.vaadin.ui.UI;
 
 /**
  * The top heading layout for the wallboard view.
@@ -59,17 +65,19 @@ public class HeaderLayout extends HorizontalLayout implements ViewChangeListener
          * Setting up the layout
          */
         addStyleName("header");
-        setMargin(true);
+        setMargin(new MarginInfo(false,true,false,false));
         setSpacing(true);
         setWidth("100%");
+        setHeight(64, Unit.PIXELS);
 
         /**
          * Adding the logo
          */
         Link link = new Link(null, new ExternalResource("/opennms/index.jsp"));
-        link.setIcon(new ThemeResource("img/logo.png"));
+        link.setIcon(new ExternalResource("/opennms/images/horizon_logo.svg"));
         addComponent(link);
         setExpandRatio(link, 1.0f);
+        link.addStyleName("logo");
 
         /**
          * Adding the selection box


### PR DESCRIPTION
Bamboo: http://bamboo.internal.opennms.com:8085/browse/OPENNMS-ONMS479
Jira: http://issues.opennms.org/browse/BSM-144

I did an implementation without using the OnmsHeaderProvider because 
the Ops Board/Panel has its own input fields and make no use of the original 
OpenNMS menu bar.