### PR TITLE
NMS-8146: "show interfaces" link doesn't remember SNMP MIB-2 attribute filter.

### DIFF
--- a/opennms-webapp/src/main/webapp/WEB-INF/jsp/element/nodeList.jsp
+++ b/opennms-webapp/src/main/webapp/WEB-INF/jsp/element/nodeList.jsp
@@ -137,6 +137,11 @@
     <c:if test="${command.service != null}">
       <c:param name="service" value="${command.service}"/>
     </c:if>
+    <c:if test="${command.mib2Parm != null}">
+      <c:param name="mib2Parm" value="${command.mib2Parm}"/>
+      <c:param name="mib2ParmValue" value="${command.mib2ParmValue}"/>
+      <c:param name="mib2ParmMatchType" value="${command.mib2ParmMatchType}"/>
+    </c:if>
     <c:if test="${command.snmpParm != null}">
       <c:param name="snmpParm" value="${command.snmpParm}"/>
       <c:param name="snmpParmValue" value="${command.snmpParmValue}"/>


### PR DESCRIPTION
PRELIMINARY ADVISORY: I don't know exactly why it works, but it works.

You can test the fix by modifying the corresponding .jsp file on a running OpenNMS instance (and restarting it).

JIRA: http://issues.opennms.org/browse/NMS-8146
Bamboo: http://bamboo.internal.opennms.com:8085/browse/OPENNMS-ONMS586-1