### PR TITLE
NMS-8179: Interpret ifIndex as 32-bit unsigned ints.

### DIFF
--- a/opennms-services/src/main/java/org/opennms/netmgt/collectd/IfInfo.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/collectd/IfInfo.java
@@ -266,7 +266,7 @@ public final class IfInfo extends SnmpCollectionResource {
      */
     @Override
     public String getInstance() {
-        return Integer.toString(getIndex()); //For interfaces, use ifIndex as it's unique within a node (by definition)
+        return Integer.toUnsignedString(getIndex()); //For interfaces, use ifIndex as it's unique within a node (by definition)
     }
 
     @Override


### PR DESCRIPTION
Collect data from some non-conforming IF-MIB agents, which use ifIndex >= 2^31.

JIRA: http://issues.opennms.org/browse/NMS-8179
Bamboo: ?