### PR TITLE
BSM-114: Delete orphan reduce and map functions

### DIFF
--- a/features/bsm/persistence/api/src/main/java/org/opennms/netmgt/bsm/persistence/api/BusinessServiceEdgeEntity.java
+++ b/features/bsm/persistence/api/src/main/java/org/opennms/netmgt/bsm/persistence/api/BusinessServiceEdgeEntity.java
@@ -43,6 +43,7 @@ import javax.persistence.Inheritance;
 import javax.persistence.InheritanceType;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+import javax.persistence.OneToOne;
 import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
 import javax.persistence.Transient;
@@ -127,7 +128,7 @@ public class BusinessServiceEdgeEntity implements EdgeEntity {
         m_weight = weight;
     }
 
-    @ManyToOne(cascade = {CascadeType.ALL})
+    @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true)
     @JoinColumn(name = "bsm_map_id")
     public AbstractMapFunctionEntity getMapFunction() {
         return m_mapFunction;

--- a/features/bsm/persistence/api/src/main/java/org/opennms/netmgt/bsm/persistence/api/BusinessServiceEntity.java
+++ b/features/bsm/persistence/api/src/main/java/org/opennms/netmgt/bsm/persistence/api/BusinessServiceEntity.java
@@ -45,6 +45,7 @@ import javax.persistence.JoinTable;
 import javax.persistence.ManyToOne;
 import javax.persistence.MapKeyColumn;
 import javax.persistence.OneToMany;
+import javax.persistence.OneToOne;
 import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
 import javax.persistence.Transient;
@@ -162,7 +163,7 @@ public class BusinessServiceEntity {
                 .collect(Collectors.toSet());
     }
 
-    @ManyToOne(cascade = CascadeType.ALL)
+    @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true)
     @JoinColumn(name = "bsm_reduce_id")
     public AbstractReductionFunctionEntity getReductionFunction() {
         return m_reductionFunction;

--- a/features/bsm/persistence/impl/src/main/resources/changelog.xml
+++ b/features/bsm/persistence/impl/src/main/resources/changelog.xml
@@ -143,4 +143,12 @@
             <column name="friendlyname" type="varchar(255)"/>
         </addColumn>
     </changeSet>
+    <changeSet author="mvrueden" id="18.0.0-bsm-map-reduce-cleanup">
+        <delete tableName="bsm_reduce">
+            <where>id not in(select distinct bsm_reduce_id from bsm_service)</where>
+        </delete>
+        <delete tableName="bsm_map">
+            <where>id not in(select distinct bsm_map_id from bsm_service_edge)</where>
+        </delete>
+    </changeSet>
 </databaseChangeLog>

--- a/features/bsm/persistence/impl/src/test/java/org/opennms/netmgt/bsm/persistence/BusinessServiceDaoIT.java
+++ b/features/bsm/persistence/impl/src/test/java/org/opennms/netmgt/bsm/persistence/BusinessServiceDaoIT.java
@@ -52,6 +52,7 @@ import org.opennms.netmgt.bsm.persistence.api.functions.map.IdentityEntity;
 import org.opennms.netmgt.bsm.persistence.api.functions.map.IgnoreEntity;
 import org.opennms.netmgt.bsm.persistence.api.functions.reduce.HighestSeverityEntity;
 import org.opennms.netmgt.bsm.persistence.api.functions.reduce.ReductionFunctionDao;
+import org.opennms.netmgt.bsm.persistence.api.functions.reduce.ThresholdEntity;
 import org.opennms.netmgt.bsm.test.BsmDatabasePopulator;
 import org.opennms.netmgt.bsm.test.BusinessServiceEntityBuilder;
 import org.opennms.netmgt.dao.api.MonitoredServiceDao;
@@ -275,7 +276,7 @@ public class BusinessServiceDaoIT {
         Criteria criteria = new CriteriaBuilder(BusinessServiceEntity.class).toCriteria();
         // verify that root entity is merged
         //assertEquals(1, m_businessServiceDao.findMatching(criteria).size());
-        // verify that coundMatching also works
+        // verify that countMatching also works
         assertEquals(1, m_businessServiceDao.countMatching(criteria));
 
     }

--- a/features/bsm/persistence/impl/src/test/java/org/opennms/netmgt/bsm/persistence/BusinessServiceEdgeDaoIT.java
+++ b/features/bsm/persistence/impl/src/test/java/org/opennms/netmgt/bsm/persistence/BusinessServiceEdgeDaoIT.java
@@ -47,6 +47,7 @@ import org.opennms.netmgt.bsm.persistence.api.BusinessServiceEdgeDao;
 import org.opennms.netmgt.bsm.persistence.api.BusinessServiceEntity;
 import org.opennms.netmgt.bsm.persistence.api.IPServiceEdgeEntity;
 import org.opennms.netmgt.bsm.persistence.api.functions.map.IdentityEntity;
+import org.opennms.netmgt.bsm.persistence.api.functions.map.IgnoreEntity;
 import org.opennms.netmgt.bsm.persistence.api.functions.map.MapFunctionDao;
 import org.opennms.netmgt.bsm.persistence.api.functions.reduce.HighestSeverityEntity;
 import org.opennms.netmgt.bsm.persistence.api.functions.reduce.ReductionFunctionDao;
@@ -150,6 +151,6 @@ public class BusinessServiceEdgeDaoIT {
 
         // Delete an edge
         m_businessServiceEdgeDao.delete(edge);
-        assertEquals(0, m_businessServiceEdgeDao.countAll()); 
+        assertEquals(0, m_businessServiceEdgeDao.countAll());
     }
 }

--- a/features/bsm/service/api/src/main/java/org/opennms/netmgt/bsm/service/BusinessServiceManager.java
+++ b/features/bsm/service/api/src/main/java/org/opennms/netmgt/bsm/service/BusinessServiceManager.java
@@ -106,6 +106,8 @@ public interface BusinessServiceManager extends NodeManager {
 
     void setReductionKeyEdges(BusinessService businessService, Set<ReductionKeyEdge> reductionKeyEdges);
 
+    void removeEdge(BusinessService businessService, Edge edge);
+
     /**
      * This returns the actual graph of the underlying {@link BusinessServiceStateMachine}.
      *
@@ -115,4 +117,7 @@ public interface BusinessServiceManager extends NodeManager {
      */
     BusinessServiceGraph getGraph();
 
+    void setMapFunction(Edge edge, MapFunction mapFunction);
+
+    void setReduceFunction(BusinessService businessService, ReductionFunction reductionFunction);
 }

--- a/features/bsm/service/api/src/main/java/org/opennms/netmgt/bsm/service/model/BusinessService.java
+++ b/features/bsm/service/api/src/main/java/org/opennms/netmgt/bsm/service/model/BusinessService.java
@@ -70,8 +70,8 @@ public interface BusinessService extends ReadOnlyBusinessService {
 
     void addChildEdge(BusinessService child, MapFunction mapFunction, int weight);
 
-    void setEdges(Edge.Type edgeType, Set<? extends Edge> edges);
-    
+    void removeEdge(Edge edge);
+
     Set<ReductionKeyEdge> getReductionKeyEdges();
     
     Set<IpServiceEdge> getIpServiceEdges();

--- a/features/bsm/service/impl/src/main/java/org/opennms/netmgt/bsm/service/internal/BusinessServiceImpl.java
+++ b/features/bsm/service/impl/src/main/java/org/opennms/netmgt/bsm/service/internal/BusinessServiceImpl.java
@@ -125,8 +125,7 @@ public class BusinessServiceImpl implements BusinessService {
 
     @Override
     public void setReduceFunction(ReductionFunction reductionFunction) {
-        AbstractReductionFunctionEntity reductionFunctionEntity = new ReduceFunctionMapper().toPersistenceFunction(reductionFunction);
-        getEntity().setReductionFunction(reductionFunctionEntity);
+        m_manager.setReduceFunction(this, reductionFunction);
     }
 
     @Override
@@ -231,19 +230,8 @@ public class BusinessServiceImpl implements BusinessService {
         return Sets.newTreeSet();
     }
 
-    @SuppressWarnings("unchecked")
     @Override
-    public void setEdges(Edge.Type edgeType, Set<? extends Edge> edges) {
-        switch (edgeType) {
-            case CHILD_SERVICE:
-                setChildEdges((Set<ChildEdge>)edges);
-                break;
-            case IP_SERVICE:
-                setIpServiceEdges((Set<IpServiceEdge>)edges);
-                break;
-            case REDUCTION_KEY:
-                setReductionKeyEdges((Set<ReductionKeyEdge>)edges);
-                break;
-        }
+    public void removeEdge(final Edge edge) {
+        m_manager.removeEdge(this, edge);
     }
 }

--- a/features/bsm/service/impl/src/main/java/org/opennms/netmgt/bsm/service/internal/BusinessServiceManagerImpl.java
+++ b/features/bsm/service/impl/src/main/java/org/opennms/netmgt/bsm/service/internal/BusinessServiceManagerImpl.java
@@ -42,6 +42,10 @@ import org.opennms.netmgt.bsm.persistence.api.BusinessServiceEdgeEntity;
 import org.opennms.netmgt.bsm.persistence.api.BusinessServiceEntity;
 import org.opennms.netmgt.bsm.persistence.api.IPServiceEdgeEntity;
 import org.opennms.netmgt.bsm.persistence.api.SingleReductionKeyEdgeEntity;
+import org.opennms.netmgt.bsm.persistence.api.functions.map.AbstractMapFunctionEntity;
+import org.opennms.netmgt.bsm.persistence.api.functions.map.MapFunctionDao;
+import org.opennms.netmgt.bsm.persistence.api.functions.reduce.AbstractReductionFunctionEntity;
+import org.opennms.netmgt.bsm.persistence.api.functions.reduce.ReductionFunctionDao;
 import org.opennms.netmgt.bsm.service.BusinessServiceManager;
 import org.opennms.netmgt.bsm.service.BusinessServiceSearchCriteria;
 import org.opennms.netmgt.bsm.service.BusinessServiceStateMachine;
@@ -90,6 +94,12 @@ public class BusinessServiceManagerImpl implements BusinessServiceManager {
 
     @Autowired
     private MonitoredServiceDao monitoredServiceDao;
+
+    @Autowired
+    private MapFunctionDao mapFunctionDao;
+
+    @Autowired
+    private ReductionFunctionDao reductionFunctionDao;
 
     @Autowired
     private BusinessServiceStateMachine businessServiceStateMachine;
@@ -320,6 +330,14 @@ public class BusinessServiceManagerImpl implements BusinessServiceManager {
         return true;
     }
 
+    @Override
+    public void removeEdge(final BusinessService businessService, final Edge edge) {
+        final BusinessServiceEntity businessServiceEntity = getBusinessServiceEntity(businessService);
+        final BusinessServiceEdgeEntity edgeEntity = getBusinessServiceEdgeEntity(edge);
+
+        businessServiceEntity.removeEdge(edgeEntity);
+    }
+
     private boolean checkDescendantForLoop(final BusinessServiceEntity parent,
                                            final BusinessServiceEntity descendant) {
         if (parent.equals(descendant)) {
@@ -406,6 +424,38 @@ public class BusinessServiceManagerImpl implements BusinessServiceManager {
     public BusinessServiceGraph getGraph() {
         // Do not instantiate a new instance, or the status is not set
         return businessServiceStateMachine.getGraph();
+    }
+
+    @Override
+    public void setMapFunction(final Edge edge, final MapFunction mapFunction) {
+        // This is a workaround for a hibernate bug which does not remove
+        // orphan elements if the element is replaced using the setter. See:
+        // https://hibernate.atlassian.net/browse/HHH-6484
+        final BusinessServiceEdgeEntity edgeEntity = this.getBusinessServiceEdgeEntity(edge);
+
+        final AbstractMapFunctionEntity prevMapFunctionEntity = edgeEntity.getMapFunction();
+        if (prevMapFunctionEntity != null && prevMapFunctionEntity.getId() != null) {
+            this.mapFunctionDao.delete(prevMapFunctionEntity);
+        }
+
+        final AbstractMapFunctionEntity mapFunctionEntity = new MapFunctionMapper().toPersistenceFunction(mapFunction);
+        edgeEntity.setMapFunction(mapFunctionEntity);
+    }
+
+    @Override
+    public void setReduceFunction(final BusinessService businessService, final ReductionFunction reductionFunction) {
+        // This is a workaround for a hibernate bug which does not remove
+        // orphan elements if the element is replaced using the setter. See:
+        // https://hibernate.atlassian.net/browse/HHH-6484
+        final BusinessServiceEntity entity = this.getBusinessServiceEntity(businessService);
+
+        final AbstractReductionFunctionEntity prevReduceFunctionEntity = entity.getReductionFunction();
+        if (prevReduceFunctionEntity != null && prevReduceFunctionEntity.getId() != null) {
+            this.reductionFunctionDao.delete(prevReduceFunctionEntity);
+        }
+
+        final AbstractReductionFunctionEntity reduceFunctionEntity = new ReduceFunctionMapper().toPersistenceFunction(reductionFunction);
+        entity.setReductionFunction(reduceFunctionEntity);
     }
 
     protected BusinessServiceDao getDao() {

--- a/features/bsm/service/impl/src/main/java/org/opennms/netmgt/bsm/service/internal/edge/AbstractEdge.java
+++ b/features/bsm/service/impl/src/main/java/org/opennms/netmgt/bsm/service/internal/edge/AbstractEdge.java
@@ -77,8 +77,7 @@ public abstract class AbstractEdge<T extends BusinessServiceEdgeEntity> implemen
 
     @Override
     public void setMapFunction(MapFunction mapFunction) {
-        AbstractMapFunctionEntity mapFunctionEntity = new MapFunctionMapper().toPersistenceFunction(mapFunction);
-        getEntity().setMapFunction(mapFunctionEntity);
+        m_manager.setMapFunction(this, mapFunction);
     }
 
     @Override

--- a/features/bsm/vaadin-adminpage/src/main/java/org/opennms/netmgt/bsm/vaadin/adminpage/BusinessServiceEdgeEditWindow.java
+++ b/features/bsm/vaadin-adminpage/src/main/java/org/opennms/netmgt/bsm/vaadin/adminpage/BusinessServiceEdgeEditWindow.java
@@ -332,9 +332,7 @@ public class BusinessServiceEdgeEditWindow extends Window {
              * in the case edge is not null, remove the old object...
              */
             if (edge != null) {
-                Set<? extends Edge> edges = businessService.getEdges(edge.getType());
-                edges.remove(edge);
-                businessService.setEdges(edge.getType(), edges);
+                businessService.removeEdge(edge);
             }
 
             /**


### PR DESCRIPTION
The persistence layer is (due to an hibernate bug) not able to delete
oprhan map function instances and reduce function instances. To work
around, the service layer ensures they are deleted.

JIRA: http://issues.opennms.org/browse/BSM-114
Bamboo: http://bamboo.internal.opennms.com:8085/browse/OPENNMS-ONMS543