### PR TITLE
NMS-8267: Create documentation for SNMP detector with two examples

### DIFF
--- a/opennms-doc/guide-admin/src/asciidoc/index.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/index.adoc
@@ -132,7 +132,7 @@ include::text/performance-data-collection/collectors/wsman/detector.adoc[]
 include::text/events/events.adoc[]
 include::text/events/forward-elasticsearch.adoc[]
 
-[ga-provisioning]
+[[ga-provisioning]]
 == Provisioning
 include::text/provisioning/introduction.adoc[]
 include::text/provisioning/concepts.adoc[]
@@ -146,6 +146,10 @@ include::text/provisioning/integration.adoc[]
 include::text/provisioning/single-node.adoc[]
 include::text/provisioning/fine-grained.adoc[]
 include::text/provisioning/api-examples.adoc[]
+
+[[ga-provisioning-detectors]]
+=== Service Detectors
+include::text/provisioning/detectors/SnmpDetector.adoc[]
 
 [[ga-database-reports]]
 == Database Reports

--- a/opennms-doc/guide-admin/src/asciidoc/text/provisioning/detectors/SnmpDetector.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/provisioning/detectors/SnmpDetector.adoc
@@ -1,0 +1,74 @@
+
+// Allow GitHub image rendering
+:imagesdir: ../../../images
+
+==== SNMP Detector
+
+This detector is used to find and assigns services based on _SNMP_.
+The detector binds a service with a given _Service Name_ when a particular _SNMP OID_ as scalar or table matches a given criteria.
+
+===== Detector facts
+
+[options="autowidth"]
+|===
+| Implementation | `org.opennms.netmgt.provision.detector.snmp.SnmpDetector`
+|===
+
+===== Configuration and Usage
+
+.Parameters for the SNMP detector
+[options="header, autowidth"]
+|===
+| Parameter   | Description                                                                                              | Required | Default value
+| `oid`       | _SNMP OID_ for scalar or table to detect the service.                                                    | required | `.1.3.6.1.2.1.1.2.0`
+| `retry`     | Number of retries to detect the service.                                                                 | optional | _agent config_
+| `timeout`   | Timeout in milliseconds to wait for a response from the _SNMP_ agent.                                    | optional | _agent config_
+| `vbvalue`   | expected return value to detect the service; if not specified the service is detected if the _SNMP OID_
+                returned any kind of valid value.                                                                        | optional | `-`
+| `hex`       | Set `true` if the data is from type _HEX-String_.                                                        | optional | `false`
+| `isTable`   | Set `true` if detector should evaluate _SNMP tables_.                                                    | optional | `false`
+| `matchType` | Set match type to evaluate the expected value in the SNMP table. +
+                _EXIST_: the expected `vbalue` is ignored, service detected if the given table under _OID_ exist +
+                _ALL_: all values in the table must match against expected `vbalue` to detect service +
+                _ANY_: at least on value in the table must match against expected `vbalue` to detect service +
+                _NONE_: None of the values should match against expected value to detect service
+|===
+
+===== Example for SNMP scalar value
+
+We have _Dell_ server farm and want to monitor the global server status provided by the _OpenManage Server Administrator_.
+Global status is provided by a scalar _OID_ `.1.3.6.1.4.1.674.10892.1.200.10.1.2.1`.
+The service should be automatically detected if the server supports this _OID_.
+
+For provisioning we have a requisition named _Server_ which contains all server of our data center.
+A _Detector_ with the name _Dell-OMSA-Global-State_ for this requisition is created with the following parameter:
+
+.Parameters for the SNMP detector
+[options="header, autowidth"]
+|===
+| Parameter | Value
+| `Name`    | `Dell-OMSA-Global-State`
+| `oid`     | `.1.3.6.1.4.1.674.10892.1.200.10.1.2.1`
+|===
+
+When you synchronize the requisition _Server_ the service _Dell-OMSA-Global-State_ will be detected when they support the given _SNMP OID_.
+
+===== Example using SNMP tables
+
+We have a _HP_ server farm and want to monitor the status of logical drives over _SNMP_ provided from _HP Insight Manager_.
+The status for logical drives is provided in a _SNMP Table_ under `.1.3.6.1.4.1.232.3.2.3.1.1.4`.
+The service should be automatically assigned to all servers exposing the given _SNMP OID_.
+
+For provisioning we have a requisition named _Server_ which contains all server of our data center.
+A _Detector_ with the name _HP-Insight-Drive-Logical_ for this requisition is created with the following parameter:
+
+.Parameters for the SNMP detector
+[options="header, autowidth"]
+|===
+| Parameter | Value
+| `Name`    | `HP-Insight-Drive-Logical`
+| `oid`     | `.1.3.6.1.4.1.232.3.2.3.1.1.4`
+| `isTable` | `true`
+|===
+
+When you synchronize the requisition _Server_ the service _HP-Insight-Drive-Logical_ will be detected when they support the given _SNMP OID_ table.

--- a/opennms-doc/guide-admin/src/asciidoc/text/provisioning/detectors/SnmpDetector.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/provisioning/detectors/SnmpDetector.adoc
@@ -53,7 +53,7 @@ A _Detector_ with the name _Dell-OMSA-Global-State_ for this requisition is crea
 | `oid`     | `.1.3.6.1.4.1.674.10892.1.200.10.1.2.1`
 |===
 
-When you synchronize the requisition _Server_ the service _Dell-OMSA-Global-State_ will be detected when they support the given _SNMP OID_.
+When the requisition _Server_ is synchronized the service _Dell-OMSA-Global-State_ will be detected in case they support the given _SNMP OID_.
 
 ===== Example using SNMP tables
 
@@ -73,4 +73,4 @@ A _Detector_ with the name _HP-Insight-Drive-Logical_ for this requisition is cr
 | `isTable` | `true`
 |===
 
-When you synchronize the requisition _Server_ the service _HP-Insight-Drive-Logical_ will be detected when they support the given _SNMP OID_ table.
+When the requisition _Server_ is synchronized the service _HP-Insight-Drive-Logical_ will be detected in case they support the given _SNMP OID_ table.

--- a/opennms-doc/guide-admin/src/asciidoc/text/provisioning/detectors/SnmpDetector.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/provisioning/detectors/SnmpDetector.adoc
@@ -19,19 +19,21 @@ The detector binds a service with a given _Service Name_ when a particular _SNMP
 .Parameters for the SNMP detector
 [options="header, autowidth"]
 |===
-| Parameter   | Description                                                                                              | Required | Default value
-| `oid`       | _SNMP OID_ for scalar or table to detect the service.                                                    | required | `.1.3.6.1.2.1.1.2.0`
-| `retry`     | Number of retries to detect the service.                                                                 | optional | _agent config_
-| `timeout`   | Timeout in milliseconds to wait for a response from the _SNMP_ agent.                                    | optional | _agent config_
+| Parameter   | Description                                                                                             | Required | Default value
+| `oid`       | _SNMP OID_ for scalar or table to detect the service.                                                   | required | `.1.3.6.1.2.1.1.2.0`
+| `retry`     | Number of retries to detect the service.                                                                | optional | _agent config_
+| `timeout`   | Timeout in milliseconds to wait for a response from the _SNMP_ agent.                                   | optional | _agent config_
 | `vbvalue`   | expected return value to detect the service; if not specified the service is detected if the _SNMP OID_
-                returned any kind of valid value.                                                                        | optional | `-`
-| `hex`       | Set `true` if the data is from type _HEX-String_.                                                        | optional | `false`
-| `isTable`   | Set `true` if detector should evaluate _SNMP tables_.                                                    | optional | `false`
+                returned any kind of valid value.
+                The `vbvalue` is evaluated as
+                link:https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html[Java Regular Expression].   | optional | `-`
+| `hex`       | Set `true` if the data is from type _HEX-String_.                                                       | optional | `false`
+| `isTable`   | Set `true` if detector should evaluate _SNMP tables_.                                                   | optional | `false`
 | `matchType` | Set match type to evaluate the expected value in the SNMP table. +
                 _EXIST_: the expected `vbalue` is ignored, service detected if the given table under _OID_ exist +
                 _ALL_: all values in the table must match against expected `vbalue` to detect service +
-                _ANY_: at least on value in the table must match against expected `vbalue` to detect service +
-                _NONE_: None of the values should match against expected value to detect service
+                _ANY_: at least one value in the table must match against expected `vbalue` to detect service +
+                _NONE_: None of the values should match against expected value to detect service                        | optional | `EXIST`
 |===
 
 ===== Example for SNMP scalar value

--- a/opennms-doc/guide-admin/src/asciidoc/text/provisioning/detectors/_template-detector.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/provisioning/detectors/_template-detector.adoc
@@ -1,0 +1,30 @@
+
+// Allow GitHub image rendering
+:imagesdir: ../../../images
+
+==== Name of the Detector
+
+A summary what the detector is doing.
+
+===== Detector facts
+
+[options="autowidth"]
+|===
+| Implementation | `Name of the detector class`
+|===
+
+===== Configuration and Usage
+
+.Parameters for the <DETECTOR-NAME-HERE>
+[options="header, autowidth"]
+|===
+| Parameter        | Description                                                                                        | Required | Default value
+| `my parameter 1` | This is a placeholder for the first required monitor parameter description. If you have a very
+                     long description make a soft break at line 120                                                     | required | `-`
+| `my parameter 2` | This is a placeholder for the second optional monitor parameter description.                       | optional | `default value`
+|===
+
+
+===== Examples
+
+A simple short real world example how to use this detector.


### PR DESCRIPTION
Create documentation for the SNMP detector with two short examples for table and scalar OID. Also created a template for new detectors to have similar structure.

* JIRA: http://issues.opennms.org/browse/NMS-8267
* Bamboo: http://bamboo.internal.opennms.com:8085/browse/OPENNMS-ONMS584


