### PR TITLE
NMS-8189: Fix interface status indication in node detail page

### DIFF
--- a/features/node-page-list/src/main/java/org/opennms/features/node/list/gwt/client/IpInterfaceTable.java
+++ b/features/node-page-list/src/main/java/org/opennms/features/node/list/gwt/client/IpInterfaceTable.java
@@ -51,7 +51,7 @@ public class IpInterfaceTable extends CellTable<IpInterface> {
 
         setBordered(true);
         setCondensed(true);
-        setStriped(true);
+        setStriped(false);
         setHover(true);
 
         setRowStyles(new RowStyles<IpInterface>() {

--- a/features/node-page-list/src/main/java/org/opennms/features/node/list/gwt/client/PhysicalInterfaceTable.java
+++ b/features/node-page-list/src/main/java/org/opennms/features/node/list/gwt/client/PhysicalInterfaceTable.java
@@ -57,7 +57,7 @@ public class PhysicalInterfaceTable extends CellTable<PhysicalInterface> {
 
         setBordered(true);
         setCondensed(true);
-        setStriped(true);
+        setStriped(false);
         setHover(true);
 
         setRowStyles(new RowStyles<PhysicalInterface>() {

--- a/opennms-webapp/src/main/scss/opennms-theme.scss
+++ b/opennms-webapp/src/main/scss/opennms-theme.scss
@@ -625,10 +625,6 @@ a.list-group-item.active:focus {
   color: #fff;
   background-color: $color_green_leaf_approx;
 }
-.table>thead>tr>td.info, .table>tbody>tr>td.info, .table>tfoot>tr>td.info, .table>thead>tr>th.info, .table>tbody>tr>th.info, .table>tfoot>tr>th.info, .table>thead>tr.info>td, .table>tbody>tr.info>td, .table>tfoot>tr.info>td, .table>thead>tr.info>th, .table>tbody>tr.info>th, .table>tfoot>tr.info>th {
-  color: #fff;
-  background-color: #5BDBC7;
-}
 .table>thead>tr>td.warning, .table>tbody>tr>td.warning, .table>tfoot>tr>td.warning, .table>thead>tr>th.warning, .table>tbody>tr>th.warning, .table>tfoot>tr>th.warning, .table>thead>tr.warning>td, .table>tbody>tr.warning>td, .table>tfoot>tr.warning>td, .table>thead>tr.warning>th, .table>tbody>tr.warning>th, .table>tfoot>tr.warning>th {
   color: #fff;
   background-color: #FFBF00;


### PR DESCRIPTION
Removed striped table layout from IP interface and physical interface table which overwrite the status indication for physical interfaces and IP interfaces.

* JIRA: http://issues.opennms.org/browse/NMS-8189
* Bamboo: http://bamboo.internal.opennms.com:8085/browse/OPENNMS-ONMS598
