### PR TITLE
NMS-8296: Be able to re-order the policies on a requisition through the UI

### DIFF
--- a/opennms-webapp/src/main/webapp/admin/ng-requisitions/app/index.jsp
+++ b/opennms-webapp/src/main/webapp/admin/ng-requisitions/app/index.jsp
@@ -74,6 +74,7 @@
     <jsp:param name="script" value='<script type="text/javascript" src="scripts/services/Synchronize.js"></script>' />
     <jsp:param name="script" value='<script type="text/javascript" src="scripts/filters/startFrom.js"></script>' />
     <jsp:param name="script" value='<script type="text/javascript" src="scripts/directives/requisitionConstraints.js"></script>' />
+    <jsp:param name="script" value='<script type="text/javascript" src="scripts/controllers/Move.js"></script>' />
     <jsp:param name="script" value='<script type="text/javascript" src="scripts/controllers/QuickAddNode.js"></script>' />
     <jsp:param name="script" value='<script type="text/javascript" src="scripts/controllers/QuickAddNodeModal.js"></script>' />
     <jsp:param name="script" value='<script type="text/javascript" src="scripts/controllers/CloneForeignSource.js"></script>' />

--- a/opennms-webapp/src/main/webapp/admin/ng-requisitions/app/scripts/controllers/ForeignSource.js
+++ b/opennms-webapp/src/main/webapp/admin/ng-requisitions/app/scripts/controllers/ForeignSource.js
@@ -287,6 +287,37 @@
     };
 
     /**
+    * @description Opens the modal window to move a policy
+    *
+    * @name ForeignSourceController:moveDetector
+    * @ngdoc method
+    * @methodOf ForeignSourceController
+    * @param {object} policy The policy object to move
+    */
+    $scope.movePolicy = function(policy) {
+      var form = this.fsForm;
+      var pos = $scope.indexOfPolicy(policy);
+      var max = $scope.foreignSourceDef.policies.length - 1;
+      $uibModal.open({
+        backdrop: 'static',
+        keyboard: false,
+        size: 'sm',
+        controller: 'MoveController',
+        templateUrl: 'views/move.html',
+        resolve: {
+          label: function() { return policy.name },
+          position: function() { return pos },
+          maximum: function() { return max }
+        }
+      }).result.then(function(dst) {
+        form.$dirty = true;
+        $scope.foreignSourceDef.policies.splice(pos, 1);
+        $scope.foreignSourceDef.policies.splice(dst, 0, policy);
+
+      });
+    };
+
+    /**
     * @description Removes a policy
     *
     * @name ForeignSourceController:removePolicy
@@ -341,6 +372,37 @@
         if (isNew) {
           $scope.foreignSourceDef.detectors.pop();
         }
+      });
+    };
+
+    /**
+    * @description Opens the modal window to move a detector
+    *
+    * @name ForeignSourceController:moveDetector
+    * @ngdoc method
+    * @methodOf ForeignSourceController
+    * @param {object} detector The detector object to move
+    */
+    $scope.moveDetector = function(detector) {
+      var form = this.fsForm;
+      var pos = $scope.indexOfDetector(detector);
+      var max = $scope.foreignSourceDef.detectors.length - 1;
+      $uibModal.open({
+        backdrop: 'static',
+        keyboard: false,
+        size: 'sm',
+        controller: 'MoveController',
+        templateUrl: 'views/move.html',
+        resolve: {
+          label: function() { return detector.name },
+          position: function() { return pos },
+          maximum: function() { return max }
+        }
+      }).result.then(function(dst) {
+        form.$dirty = true;
+        $scope.foreignSourceDef.detectors.splice(pos, 1);
+        $scope.foreignSourceDef.detectors.splice(dst, 0, detector);
+
       });
     };
 

--- a/opennms-webapp/src/main/webapp/admin/ng-requisitions/app/scripts/controllers/Move.js
+++ b/opennms-webapp/src/main/webapp/admin/ng-requisitions/app/scripts/controllers/Move.js
@@ -1,0 +1,104 @@
+/**
+* @author Alejandro Galue <agalue@opennms.org>
+* @copyright 2014 The OpenNMS Group, Inc.
+*/
+
+(function() {
+
+  'use strict';
+
+  angular.module('onms-requisitions')
+
+  /**
+  * @ngdoc controller
+  * @name MoveController
+  * @module onms-requisitions
+  *
+  * @requires $controller Angular controller
+  * @requires $scope Angular local scope
+  * @requires $uibModalInstance Angular UI modal instance
+  * @requires label The label to show in front of the input field
+  * @requires position The current value of the position
+  * @requires maximum The maximum value allowed
+  *
+  * @description The controller for manage the modal dialog for move a table row
+  */
+  .controller('MoveController', ['$controller', '$scope', '$uibModalInstance', 'label', 'position', 'maximum', function($controller, $scope, $uibModalInstance, label, position, maximum) {
+
+    /**
+    * @description The label for the input field.
+    *
+    * @ngdoc property
+    * @name MoveController#label
+    * @propertyOf MoveController
+    * @returns {string} The label
+    */
+    $scope.label = label;
+
+    /**
+    * @description The current position.
+    *
+    * @ngdoc property
+    * @name MoveController#position
+    * @propertyOf MoveController
+    * @returns {integer} The position value
+    */
+    $scope.position = position;
+
+    /**
+    * @description The maximum value allowed for the position.
+    *
+    * @ngdoc property
+    * @name MoveController#maximum
+    * @propertyOf MoveController
+    * @returns {integer} The maximum value
+    */
+    $scope.maximum = maximum;
+
+    /**
+    * @description Adds 1 from position
+    *
+    * @name MoveController:add
+    * @ngdoc method
+    * @methodOf MoveController
+    */
+    $scope.add = function() {
+      $scope.position++;
+    };
+
+    /**
+    * @description Substracts 1 from position
+    *
+    * @name MoveController:substract
+    * @ngdoc method
+    * @methodOf MoveController
+    */
+    $scope.substract = function() {
+      $scope.position--;
+    };
+
+    /**
+    * @description Closes the modal operation
+    *
+    * @name MoveController:move
+    * @ngdoc method
+    * @methodOf MoveController
+    */
+    $scope.move = function() {
+      $uibModalInstance.close($scope.position);
+    };
+
+    /**
+    * @description Cancels current modal operation
+    *
+    * @name MoveController:cancel
+    * @ngdoc method
+    * @methodOf MoveController
+    */
+    $scope.cancel = function() {
+      $uibModalInstance.dismiss('cancel');
+    };
+
+  }]);
+
+}());

--- a/opennms-webapp/src/main/webapp/admin/ng-requisitions/app/views/foreignsource.html
+++ b/opennms-webapp/src/main/webapp/admin/ng-requisitions/app/views/foreignsource.html
@@ -110,6 +110,9 @@
                       <button type="button" class="btn btn-default btn-xs" uib-tooltip="Edit the detector" ng-click="editDetector(detector)">
                         <span class="glyphicon glyphicon-pencil"/>
                       </button>
+                      <button type="button" class="btn btn-default btn-xs" uib-tooltip="Move the detector" ng-click="moveDetector(detector)">
+                        <span class="glyphicon glyphicon-move"/>
+                      </button>
                       <button type="button" class="btn btn-default btn-xs" uib-tooltip="Remove the detector" ng-click="removeDetector(detector)">
                         <span class="glyphicon glyphicon-trash"/>
                       </button>
@@ -166,6 +169,9 @@
                     <span class="pull-right">
                       <button type="button" class="btn btn-default btn-xs" uib-tooltip="Edit the policy" ng-click="editPolicy(policy)">
                         <span class="glyphicon glyphicon-pencil"></span>
+                      </button>
+                      <button type="button" class="btn btn-default btn-xs" uib-tooltip="Move the policy" ng-click="movePolicy(policy)">
+                        <span class="glyphicon glyphicon-move"></span>
                       </button>
                       <button type="button" class="btn btn-default btn-xs" uib-tooltip="Remove the policy" ng-click="removePolicy(policy)">
                         <span class="glyphicon glyphicon-trash"></span>

--- a/opennms-webapp/src/main/webapp/admin/ng-requisitions/app/views/move.html
+++ b/opennms-webapp/src/main/webapp/admin/ng-requisitions/app/views/move.html
@@ -1,0 +1,30 @@
+<!-- Author: Alejandro Galue <agalue@opennms.org> -->
+
+<div class="modal-header">
+  <h3 class="modal-title">Move</h3>
+</div>
+
+<div class="modal-body">
+  <form name="moveForm">
+    <label class="control-label">{{ label }}</label>
+    <div class="input-group">
+      <span class="input-group-btn">
+        <button type="button" class="btn btn-default btn-number" ng-disabled="position == 0 || moveForm.$invalid" ng-click="substract()">
+          <span class="glyphicon glyphicon-minus"></span>
+        </button>
+      </span>
+      <input type="text" ng-model="position" class="form-control input-number" ng-pattern="/\d+/" required>
+      <span class="input-group-btn">
+        <button type="button" class="btn btn-default btn-number" ng-disabled="position == maximum || moveForm.$invalid" ng-click="add()">
+          <span class="glyphicon glyphicon-plus"></span>
+        </button>
+      </span>
+    </div>
+    <p class="help-block">Choose a index between 0 and {{ maximum }}.</p>
+  </form>
+</div>
+
+<div class="modal-footer">
+  <button type="button" class="btn btn-success" id="save-detector" ng-click="move()" ng-disabled="position > maximum || moveForm.$invalid">Move</button>
+  <button type="button" class="btn btn-default" id="cancel-detector" ng-click="cancel()">Cancel</button>
+</div>


### PR DESCRIPTION
* JIRA: http://issues.opennms.org/browse/NMS-8296
* Bamboo: http://bamboo.internal.opennms.com:8085/browse/OPENNMS-ONMS621

I ended up by implementing a very simple but useful way to move elements on angular tables that have pagination and filter components.

This is intended to re-order the detectors or policies on a foreign source definition. The elements will be applied in the exact same order they are defined, so order is important, specially for policies.