### PR TITLE
NMS-8304: An error on threshd-configuration.xml breaks Collectd when reloading thresholds configuration

### DIFF
--- a/opennms-services/src/main/java/org/opennms/netmgt/threshd/ThresholdingSet.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/threshd/ThresholdingSet.java
@@ -376,13 +376,13 @@ public class ThresholdingSet {
                 defaultThresholdsDao.afterPropertiesSet();
             } catch (Throwable t) {
                 LOG.error("initThresholdsDao: Could not initialize DefaultThresholdsDao", t);
-                throw new RuntimeException("Could not initialize DefaultThresholdsDao: " + t, t);
+                return;
             }
             try {
                 ThreshdConfigFactory.init();
             } catch (Throwable t) {
                 LOG.error("initThresholdsDao: Could not initialize ThreshdConfigFactory", t);
-                throw new RuntimeException("Could not initialize ThreshdConfigFactory: " + t, t);
+                return;
             }
             m_thresholdsDao = defaultThresholdsDao;
         }


### PR DESCRIPTION
* JIRA: http://issues.opennms.org/browse/NMS-8304
* Bamboo: http://bamboo.internal.opennms.com:8085/browse/OPENNMS-ONMS620

An error on threshd-configuration.xml breaks Collectd when reloading
thresholds configuration.

It doesn't make sense to thrown a runtime exception if the ThresholdingSet is not able to load (or reload) the thresholds configuration. If there is an error with the config, the thresholding processor should use whatever it already has in memory, otherwise this exception will hang Collectd which is a very bad side effect.

I tested the solution on my lab and it works as expected (i.e. only an exception will be logged to collectd.log and Collectd continues to work properly).