### PR TITLE
NMS-8096: Fixed log level of messages in JMXDetector

### DIFF
--- a/core/jmx/impl/src/main/java/org/opennms/netmgt/jmx/impl/connection/connectors/Jsr160ConnectionFactory.java
+++ b/core/jmx/impl/src/main/java/org/opennms/netmgt/jmx/impl/connection/connectors/Jsr160ConnectionFactory.java
@@ -63,9 +63,9 @@ public abstract class Jsr160ConnectionFactory {
      * @param propertiesMap a {@link java.util.Map} object.
      * @param address a {@link java.net.InetAddress} object.
      * @return a {@link org.opennms.netmgt.provision.support.jmx.connectors.Jsr160ConnectionWrapper} object.
-     * @throws IOException 
+     * @throws MalformedURLException, IOException 
      */
-    public static JmxServerConnectionWrapper getMBeanServerConnection(Map<String,?> propertiesMap, InetAddress address) throws IOException {
+    public static JmxServerConnectionWrapper getMBeanServerConnection(Map<String,?> propertiesMap, InetAddress address) throws MalformedURLException, IOException {
         String factory  = ParameterMap.getKeyedString( propertiesMap, "factory", "STANDARD");
         int    port     = ParameterMap.getKeyedInteger(propertiesMap, "port",     1099);
         String protocol = ParameterMap.getKeyedString( propertiesMap, "protocol", "rmi");

--- a/opennms-provision/opennms-detector-jmx/src/main/java/org/opennms/netmgt/provision/detector/jmx/AbstractJsr160Detector.java
+++ b/opennms-provision/opennms-detector-jmx/src/main/java/org/opennms/netmgt/provision/detector/jmx/AbstractJsr160Detector.java
@@ -31,6 +31,7 @@ package org.opennms.netmgt.provision.detector.jmx;
 import java.io.IOException;
 import java.net.ConnectException;
 import java.net.InetAddress;
+import java.net.MalformedURLException;
 import java.util.Map;
 
 import org.opennms.core.spring.BeanUtils;
@@ -43,7 +44,6 @@ import org.opennms.netmgt.jmx.connection.JmxServerConnector;
 import org.opennms.netmgt.jmx.impl.connection.connectors.Jsr160ConnectionFactory;
 import org.opennms.netmgt.jmx.impl.connection.connectors.PlatformMBeanServerConnector;
 
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 
 /**
@@ -82,7 +82,7 @@ public abstract class AbstractJsr160Detector extends JMXDetector {
      * @throws IOException 
      */
     @Override
-    protected JmxServerConnectionWrapper connect(final InetAddress address, final int port, final int timeout) throws IOException {
+    protected JmxServerConnectionWrapper connect(final InetAddress address, final int port, final int timeout) throws MalformedURLException, IOException {
         if (m_jmxConfigDao == null) {
             m_jmxConfigDao = BeanUtils.getBean("daoContext", "jmxConfigDao", JmxConfigDao.class);
         }

--- a/opennms-provision/opennms-detector-jmx/src/main/java/org/opennms/netmgt/provision/detector/jmx/JMXDetector.java
+++ b/opennms-provision/opennms-detector-jmx/src/main/java/org/opennms/netmgt/provision/detector/jmx/JMXDetector.java
@@ -28,26 +28,24 @@
 
 package org.opennms.netmgt.provision.detector.jmx;
 
-import org.opennms.core.spring.BeanUtils;
-import org.opennms.core.utils.InetAddressUtils;
-import org.opennms.netmgt.dao.jmx.JmxConfigDao;
-import org.opennms.netmgt.jmx.connection.JmxServerConnectionWrapper;
-import org.opennms.netmgt.provision.support.SyncAbstractDetector;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import org.opennms.core.utils.InetAddressUtils;
-
-import javax.management.InstanceNotFoundException;
-import javax.management.MalformedObjectNameException;
-import javax.management.ObjectName;
-
 import java.io.IOException;
 import java.io.InterruptedIOException;
 import java.net.ConnectException;
 import java.net.InetAddress;
+import java.net.MalformedURLException;
 import java.net.NoRouteToHostException;
 import java.net.PortUnreachableException;
+
+import javax.management.InstanceNotFoundException;
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
+import javax.naming.NameNotFoundException;
+
+import org.opennms.core.utils.InetAddressUtils;
+import org.opennms.netmgt.jmx.connection.JmxServerConnectionWrapper;
+import org.opennms.netmgt.provision.support.SyncAbstractDetector;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -87,7 +85,7 @@ public abstract class JMXDetector extends SyncAbstractDetector {
         super(serviceName, port, timeout, retries);
     }
 
-    abstract protected JmxServerConnectionWrapper connect(final InetAddress address, final int port, final int timeout) throws ConnectException, IOException;
+    abstract protected JmxServerConnectionWrapper connect(final InetAddress address, final int port, final int timeout) throws ConnectException, IOException, MalformedURLException;
 
     /** {@inheritDoc} */
     @Override
@@ -131,7 +129,48 @@ public abstract class JMXDetector extends SyncAbstractDetector {
             } catch (InstanceNotFoundException e) {
                 LOG.info("isServiceDetected: {}: Object instance {} does not exists on address {} port {} within timeout: {} attempt: {}", getServiceName(), m_object, ipAddr, port, timeout, attempts, e);
             } catch (IOException e) {
-                LOG.error("isServiceDetected: {}: An unexpected I/O exception occured contacting address {} port {}",getServiceName(), ipAddr, port, e);
+                // NMS-8096: Because the JMX connections wrap lower-level exceptions in an IOException,
+                // we need to unwrap the exceptions to provide INFO log messages about failures
+
+                boolean loggedIt = false;
+
+                // Unwrap exception
+                Throwable cause = e.getCause();
+                while (cause != null && loggedIt == false) {
+                    if (cause instanceof ConnectException) {
+                        // Connection refused!! Continue to retry.
+                        LOG.info("isServiceDetected: {}: Unable to connect to address: {} port {}, attempt #{}",getServiceName(), ipAddr, port, attempts, e);
+                        loggedIt = true;
+                    } else if (cause instanceof NoRouteToHostException) {
+                        // No Route to host!!!
+                        LOG.info("isServiceDetected: {}: No route to address {} was available", getServiceName(), ipAddr, e);
+                        loggedIt = true;
+                    } else if (cause instanceof PortUnreachableException) {
+                        // Port unreachable
+                        LOG.info("isServiceDetected: {}: Port unreachable while connecting to address {} port {} within timeout: {} attempt: {}", getServiceName(), ipAddr, port, timeout, attempts, e);
+                        loggedIt = true;
+                    } else if (cause instanceof InterruptedIOException) {
+                        // Expected exception
+                        LOG.info("isServiceDetected: {}: Did not connect to address {} port {} within timeout: {} attempt: {}", getServiceName(), ipAddr, port, timeout, attempts, e);
+                        loggedIt = true;
+                    } else if (cause instanceof NameNotFoundException) {
+                        LOG.info("isServiceDetected: {}: Name {} not found on address {} port {} within timeout: {} attempt: {}", getServiceName(), m_object, ipAddr, port, timeout, attempts, e);
+                        loggedIt = true;
+                    } else if (cause instanceof MalformedObjectNameException) {
+                        LOG.info("isServiceDetected: {}: Object instance {} is not valid on address {} port {} within timeout: {} attempt: {}", getServiceName(), m_object, ipAddr, port, timeout, attempts, e);
+                        loggedIt = true;
+                    } else if (cause instanceof InstanceNotFoundException) {
+                        LOG.info("isServiceDetected: {}: Object instance {} does not exists on address {} port {} within timeout: {} attempt: {}", getServiceName(), m_object, ipAddr, port, timeout, attempts, e);
+                        loggedIt = true;
+                    }
+
+                    cause = cause.getCause();
+                }
+
+                if (!loggedIt) {
+                    // If none of the causes are an expected type, log an error
+                    LOG.error("isServiceDetected: {}: An unexpected I/O exception occured contacting address {} port {}",getServiceName(), ipAddr, port, e);
+                }
             } catch (Throwable t) {
                 LOG.error("isServiceDetected: {}: Unexpected error trying to detect {} on address {} port {}", getServiceName(), getServiceName(), ipAddr, port, t);
             }

--- a/opennms-provision/opennms-detector-jmx/src/test/java/org/opennms/netmgt/provision/detector/JBossDetectorTest.java
+++ b/opennms-provision/opennms-detector-jmx/src/test/java/org/opennms/netmgt/provision/detector/JBossDetectorTest.java
@@ -32,6 +32,7 @@ import static org.junit.Assert.assertNotNull;
 
 import java.rmi.RemoteException;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -58,6 +59,11 @@ public class JBossDetectorTest implements InitializingBean {
     @Before
     public void setUp() throws RemoteException{
         MockLogAppender.setupLogging();
+    }
+
+    @After
+    public void tearDown() {
+        MockLogAppender.assertNoErrorOrGreater();
     }
 
     @Test(timeout=20000)

--- a/opennms-provision/opennms-detector-jmx/src/test/java/org/opennms/netmgt/provision/detector/Jsr160DetectorTest.java
+++ b/opennms-provision/opennms-detector-jmx/src/test/java/org/opennms/netmgt/provision/detector/Jsr160DetectorTest.java
@@ -106,6 +106,7 @@ public class Jsr160DetectorTest implements InitializingBean {
     @After
     public void tearDown() throws IOException{
         m_connectorServer.stop();
+        MockLogAppender.assertNoErrorOrGreater();
     }
 
     @Test(timeout=20000)

--- a/opennms-provision/opennms-detector-jmx/src/test/java/org/opennms/netmgt/provision/detector/Jsr160DetectorWiringTest.java
+++ b/opennms-provision/opennms-detector-jmx/src/test/java/org/opennms/netmgt/provision/detector/Jsr160DetectorWiringTest.java
@@ -31,6 +31,7 @@ package org.opennms.netmgt.provision.detector;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -57,6 +58,11 @@ public class Jsr160DetectorWiringTest implements ApplicationContextAware {
     @Before
     public void setUp() {
         MockLogAppender.setupLogging();
+    }
+
+    @After
+    public void tearDown() {
+        MockLogAppender.assertNoErrorOrGreater();
     }
 
     private void testWiredDetector(Class<? extends ServiceDetector> detectorClass) {

--- a/opennms-provision/opennms-detector-jmx/src/test/java/org/opennms/netmgt/provision/detector/MX4JDetectorTest.java
+++ b/opennms-provision/opennms-detector-jmx/src/test/java/org/opennms/netmgt/provision/detector/MX4JDetectorTest.java
@@ -50,6 +50,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.opennms.core.spring.BeanUtils;
+import org.opennms.core.test.MockLogAppender;
 import org.opennms.netmgt.config.jmx.JmxConfig;
 import org.opennms.netmgt.provision.detector.jmx.MX4JDetector;
 import org.springframework.beans.factory.InitializingBean;
@@ -83,6 +84,7 @@ public class MX4JDetectorTest implements InitializingBean {
     @Before
     public void setUp() throws IOException {
         assertNotNull(m_detector);
+        MockLogAppender.setupLogging();
 
         JMXServiceURL url = new JMXServiceURL("service:jmx:rmi:///jndi/rmi://localhost:9999/server");
 
@@ -107,6 +109,7 @@ public class MX4JDetectorTest implements InitializingBean {
     public void testDetectorSuccess() throws IOException{
         m_detector.init();
         assertTrue(m_detector.isServiceDetected(InetAddress.getLocalHost()));
+        MockLogAppender.assertNoErrorOrGreater();
     }
 
     @Test(timeout=20000)
@@ -114,6 +117,7 @@ public class MX4JDetectorTest implements InitializingBean {
         m_detector.setPort(9000);
         m_detector.init();
         assertFalse(m_detector.isServiceDetected(InetAddress.getLocalHost()));
+        MockLogAppender.assertNoErrorOrGreater();
     }
 
     @Test(timeout=20000)
@@ -121,5 +125,7 @@ public class MX4JDetectorTest implements InitializingBean {
         m_detector.setUrlPath("wrongpath");
         m_detector.init();
         assertFalse(m_detector.isServiceDetected(InetAddress.getLocalHost()));
+        // Do not assert this because an error is logged
+        //MockLogAppender.assertNoErrorOrGreater();
     }
 }


### PR DESCRIPTION
Changed a detection failure message from ERROR to INFO. Added unit test assertions for logging levels.

* JIRA: http://issues.opennms.org/browse/NMS-8096
* Bamboo: http://bamboo.internal.opennms.com:8085/browse/OPENNMS-ONMS635