### PR TITLE
NMS-5915: Change HTTP client code to retry on any exception

### DIFF
--- a/core/web/src/main/java/org/opennms/core/web/HttpClientWrapper.java
+++ b/core/web/src/main/java/org/opennms/core/web/HttpClientWrapper.java
@@ -415,7 +415,7 @@ public class HttpClientWrapper implements Closeable {
                 requestConfigBuilder.setConnectTimeout(m_connectionTimeout);
             }
             if (m_retries != null) {
-                httpClientBuilder.setRetryHandler(new HttpRequestRetryOnExceptionHandler(m_retries, true));
+                httpClientBuilder.setRetryHandler(new HttpRequestRetryOnExceptionHandler(m_retries, false));
             }
             if (m_sslContext.size() != 0) {
                 configureSSLContext(httpClientBuilder);

--- a/core/web/src/main/java/org/opennms/core/web/HttpClientWrapper.java
+++ b/core/web/src/main/java/org/opennms/core/web/HttpClientWrapper.java
@@ -1,3 +1,31 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2014-2016 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2016 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
 package org.opennms.core.web;
 
 import java.io.Closeable;
@@ -45,7 +73,6 @@ import org.apache.http.impl.auth.BasicScheme;
 import org.apache.http.impl.client.BasicCookieStore;
 import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.DefaultHttpRequestRetryHandler;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.client.LaxRedirectStrategy;
 import org.apache.http.impl.conn.BasicHttpClientConnectionManager;
@@ -388,7 +415,7 @@ public class HttpClientWrapper implements Closeable {
                 requestConfigBuilder.setConnectTimeout(m_connectionTimeout);
             }
             if (m_retries != null) {
-                httpClientBuilder.setRetryHandler(new DefaultHttpRequestRetryHandler(m_retries, false));
+                httpClientBuilder.setRetryHandler(new HttpRequestRetryOnExceptionHandler(m_retries, true));
             }
             if (m_sslContext.size() != 0) {
                 configureSSLContext(httpClientBuilder);

--- a/core/web/src/main/java/org/opennms/core/web/HttpRequestRetryOnExceptionHandler.java
+++ b/core/web/src/main/java/org/opennms/core/web/HttpRequestRetryOnExceptionHandler.java
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2013-2016 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2016 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.core.web;
+
+import java.util.Collections;
+
+import org.apache.http.impl.client.DefaultHttpRequestRetryHandler;
+
+/**
+ * This retry handler uses an empty list of "non-retryable" exceptions so that
+ * if any exception is thrown during the HTTP operation, the operation will
+ * still be retried.
+ * 
+ * @author Seth
+ * @author Alejandro
+ *
+ */
+public class HttpRequestRetryOnExceptionHandler extends DefaultHttpRequestRetryHandler {
+
+	/**
+	 * Calls {@link HttpRequestRetryOnExceptionHandler(int, boolean, Collection<Class<? extends IOException>>)}
+	 * with {@link Collections#emptyList()} as the third argument.
+	 * 
+	 * @param retryCount
+	 * @param requestSentRetryEnabled
+	 */
+	public HttpRequestRetryOnExceptionHandler(int retryCount, boolean requestSentRetryEnabled) {
+		super(retryCount, requestSentRetryEnabled, Collections.emptyList());
+	}
+}


### PR DESCRIPTION
Because we are a network management framework, we want to retry operations even if low-level protocol exceptions have been thrown. The solution proposed by Alejandro has been incorporated into the httpclient API since this bug was opened and because Ben wrote the HttpClientWrapper class a few years ago, this retry logic will be applied in most places that we use httpclient (PSM, HttpCollector, etc).

* JIRA: http://issues.opennms.org/browse/NMS-5915
* Bamboo: http://bamboo.internal.opennms.com:8085/browse/OPENNMS-ONMS645