### PR TITLE
NMS-8098: Unwrapped exceptions to make nicer PSM failure reasons

### DIFF
--- a/features/poller/api/src/main/java/org/opennms/netmgt/poller/PollStatus.java
+++ b/features/poller/api/src/main/java/org/opennms/netmgt/poller/PollStatus.java
@@ -45,6 +45,8 @@ import javax.persistence.Transient;
 public class PollStatus implements Serializable {
     private static final long serialVersionUID = 3L;
 
+    public static final String PROPERTY_RESPONSE_TIME = "response-time";
+
     private Date m_timestamp = new Date();
 
     /**
@@ -445,7 +447,7 @@ public class PollStatus implements Serializable {
      */
     @Column(name="responseTime", nullable=true)
     public Double getResponseTime() {
-        Number val = getProperty("response-time");
+        Number val = getProperty(PROPERTY_RESPONSE_TIME);
         return (val == null ? null : val.doubleValue());
     	
     }
@@ -458,9 +460,9 @@ public class PollStatus implements Serializable {
      */
     public void setResponseTime(final Double responseTime) {
         if (responseTime == null) {
-            m_properties.remove("response-time");
+            m_properties.remove(PROPERTY_RESPONSE_TIME);
         } else {
-            m_properties.put("response-time", responseTime);
+            m_properties.put(PROPERTY_RESPONSE_TIME, responseTime);
         }
     }
 

--- a/features/poller/remote/src/main/java/org/opennms/netmgt/poller/remote/support/DefaultPollerBackEnd.java
+++ b/features/poller/remote/src/main/java/org/opennms/netmgt/poller/remote/support/DefaultPollerBackEnd.java
@@ -102,9 +102,6 @@ import org.springframework.util.Assert;
 public class DefaultPollerBackEnd implements PollerBackEnd, SpringServiceDaemon {
     private static final Logger LOG = LoggerFactory.getLogger(DefaultPollerBackEnd.class);
 
-    /** Constant <code>DEFAULT_BASENAME="response-time"</code> */
-    public static final String DEFAULT_BASENAME = "response-time";
-
     public static final int HEARTBEAT_STEP_MULTIPLIER = 2;
 
     private static class SimplePollerConfiguration implements PollerConfiguration, Serializable {
@@ -668,7 +665,7 @@ public class DefaultPollerBackEnd implements PollerBackEnd, SpringServiceDaemon 
 
         String dsName = getServiceParameter(svc, "ds-name");
         if (dsName == null) {
-            dsName = DEFAULT_BASENAME;
+            dsName = PollStatus.PROPERTY_RESPONSE_TIME;
         }
 
         String rrdBaseName = getServiceParameter(svc, "rrd-base-name");

--- a/opennms-services/src/main/java/org/opennms/netmgt/poller/monitors/BSFMonitor.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/poller/monitors/BSFMonitor.java
@@ -236,8 +236,8 @@ public class BSFMonitor extends AbstractServiceMonitor {
                         throw new RuntimeException("Invalid run-type '" + runType + "'");
                     }
                     long endTime = System.currentTimeMillis();
-                    if (!times.containsKey("response-time")) {
-                        times.put("response-time", endTime - startTime);
+                    if (!times.containsKey(PollStatus.PROPERTY_RESPONSE_TIME)) {
+                        times.put(PollStatus.PROPERTY_RESPONSE_TIME, endTime - startTime);
                     }
                     
                     if (STATUS_UNKNOWN.equals(results.get("status"))) {

--- a/opennms-services/src/main/java/org/opennms/netmgt/poller/monitors/StrafePingMonitor.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/poller/monitors/StrafePingMonitor.java
@@ -144,7 +144,7 @@ final public class StrafePingMonitor extends AbstractServiceMonitor {
             }
             returnval.put("loss", CollectionMath.countNull(responseTimes));
             returnval.put("median", CollectionMath.median(responseTimes));
-            returnval.put("response-time", CollectionMath.average(responseTimes));
+            returnval.put(PollStatus.PROPERTY_RESPONSE_TIME, CollectionMath.average(responseTimes));
 
             serviceStatus.setProperties(returnval);
         } catch (Throwable e) {

--- a/opennms-services/src/main/java/org/opennms/netmgt/poller/monitors/TrivialTimeMonitor.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/poller/monitors/TrivialTimeMonitor.java
@@ -188,7 +188,7 @@ final public class TrivialTimeMonitor extends AbstractServiceMonitor {
             skewProps.put("skew", skew);
 	    LOG.debug("persistSkew: Persisting time skew (value = {}) for this node", skew);
         }
-        skewProps.put("response-time", responseTime);
+        skewProps.put(PollStatus.PROPERTY_RESPONSE_TIME, responseTime);
         serviceStatus.setProperties(skewProps);
     }
 

--- a/opennms-services/src/main/java/org/opennms/netmgt/poller/pollables/LatencyStoringServiceMonitorAdaptor.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/poller/pollables/LatencyStoringServiceMonitorAdaptor.java
@@ -68,9 +68,6 @@ public class LatencyStoringServiceMonitorAdaptor implements ServiceMonitor {
 
     private static final Logger LOG = LoggerFactory.getLogger(LatencyStoringServiceMonitorAdaptor.class);
 
-    /** Constant <code>DEFAULT_BASENAME="response-time"</code> */
-    public static final String DEFAULT_BASENAME = "response-time";
-
     public static final int HEARTBEAT_STEP_MULTIPLIER = 2;
 
     private ServiceMonitor m_serviceMonitor;
@@ -133,13 +130,13 @@ public class LatencyStoringServiceMonitorAdaptor implements ServiceMonitor {
 
     private void storeResponseTime(MonitoredService svc, Map<String, Number> entries, Map<String,Object> parameters) {
         String rrdPath     = ParameterMap.getKeyedString(parameters, "rrd-repository", null);
-        String dsName      = ParameterMap.getKeyedString(parameters, "ds-name", DEFAULT_BASENAME);
+        String dsName      = ParameterMap.getKeyedString(parameters, "ds-name", PollStatus.PROPERTY_RESPONSE_TIME);
         String rrdBaseName = ParameterMap.getKeyedString(parameters, "rrd-base-name", dsName);
         String thresholds  = ParameterMap.getKeyedString(parameters, "thresholding-enabled", "false");
 
-        if (!entries.containsKey(dsName) && entries.containsKey(DEFAULT_BASENAME)) {
-            entries.put(dsName, entries.get(DEFAULT_BASENAME));
-            entries.remove(DEFAULT_BASENAME);
+        if (!entries.containsKey(dsName) && entries.containsKey(PollStatus.PROPERTY_RESPONSE_TIME)) {
+            entries.put(dsName, entries.get(PollStatus.PROPERTY_RESPONSE_TIME));
+            entries.remove(PollStatus.PROPERTY_RESPONSE_TIME);
         }
 
         if (thresholds.equalsIgnoreCase("true")) {

--- a/opennms-services/src/test/java/org/opennms/netmgt/poller/monitors/PageSequenceMonitorIT.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/poller/monitors/PageSequenceMonitorIT.java
@@ -28,6 +28,7 @@
 
 package org.opennms.netmgt.poller.monitors;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -103,6 +104,7 @@ public class PageSequenceMonitorIT {
         setPageSequenceParam("localhost");
         PollStatus googleStatus = m_monitor.poll(getHttpService("localhost"), m_params);
         assertTrue("Expected available but was "+googleStatus+": reason = "+googleStatus.getReason(), googleStatus.isAvailable());
+        assertTrue("Expected a DS called 'response-time' but did not find one", googleStatus.getProperties().containsKey(PollStatus.PROPERTY_RESPONSE_TIME));
     }
 
     @Test
@@ -111,7 +113,10 @@ public class PageSequenceMonitorIT {
         m_params.put("timeout", "500");
         m_params.put("retries", "0");
         PollStatus notLikely = m_monitor.poll(getHttpService("bogus", InetAddressUtils.addr("1.1.1.1")), m_params);
-        assertTrue("should not be available", notLikely.isUnavailable());
+        assertTrue("Should not be available", notLikely.isUnavailable());
+        // Check to make sure that the connection message is nice
+        assertEquals("Connect to 1.1.1.1:10342 [/1.1.1.1] failed: connect timed out", notLikely.getReason());
+        assertTrue("Expected a DS called 'response-time' but did not find one", notLikely.getProperties().containsKey(PollStatus.PROPERTY_RESPONSE_TIME));
     }
 
     private void setPageSequenceParam(String virtualHost) {
@@ -141,6 +146,7 @@ public class PageSequenceMonitorIT {
         try {
             PollStatus googleStatus = m_monitor.poll(getHttpService("scgi.ebay.com"), m_params);
             assertTrue("Expected available but was "+googleStatus+": reason = "+googleStatus.getReason(), googleStatus.isAvailable());
+            assertTrue("Expected a DS called 'response-time' but did not find one", googleStatus.getProperties().containsKey(PollStatus.PROPERTY_RESPONSE_TIME));
         } finally {
             // Print some debug output if necessary
         }
@@ -175,6 +181,7 @@ public class PageSequenceMonitorIT {
         try {
             PollStatus googleStatus = m_monitor.poll(getHttpService("scgi.ebay.com"), m_params);
             assertTrue("Expected available but was "+googleStatus+": reason = "+googleStatus.getReason(), googleStatus.isAvailable());
+            assertTrue("Expected a DS called 'response-time' but did not find one", googleStatus.getProperties().containsKey(PollStatus.PROPERTY_RESPONSE_TIME));
         } finally {
             // Print some debug output if necessary
         }
@@ -188,6 +195,7 @@ public class PageSequenceMonitorIT {
         try {
             PollStatus googleStatus = m_monitor.poll(getHttpService("scgi.ebay.com"), m_params);
             assertTrue("Expected available but was "+googleStatus+": reason = "+googleStatus.getReason(), googleStatus.isAvailable());
+            assertTrue("Expected a DS called 'response-time' but did not find one", googleStatus.getProperties().containsKey(PollStatus.PROPERTY_RESPONSE_TIME));
         } finally {
             // Print some debug output if necessary
         }
@@ -211,7 +219,7 @@ public class PageSequenceMonitorIT {
 
         PollStatus status = m_monitor.poll(getHttpService("localhost"), m_params);
         assertTrue("Expected available but was "+status+": reason = "+status.getReason(), status.isAvailable());
-
+        assertTrue("Expected a DS called 'response-time' but did not find one", status.getProperties().containsKey(PollStatus.PROPERTY_RESPONSE_TIME));
     }
 
     @Test
@@ -224,6 +232,7 @@ public class PageSequenceMonitorIT {
 
         PollStatus status = m_monitor.poll(getHttpService("www.opennms.com"), m_params);
         assertTrue("Expected available but was "+status+": reason = "+status.getReason(), status.isAvailable());
+        assertTrue("Expected a DS called 'response-time' but did not find one", status.getProperties().containsKey(PollStatus.PROPERTY_RESPONSE_TIME));
     }
 
     @Test
@@ -237,6 +246,7 @@ public class PageSequenceMonitorIT {
 
         PollStatus status = m_monitor.poll(getHttpService("www.opennms.com"), m_params);
         assertTrue("Expected unavailable but was "+status+": reason = "+status.getReason(), status.isDown());
+        assertTrue("Expected a DS called 'response-time' but did not find one", status.getProperties().containsKey(PollStatus.PROPERTY_RESPONSE_TIME));
     }
 
     @Test
@@ -261,6 +271,7 @@ public class PageSequenceMonitorIT {
 
         PollStatus status = m_monitor.poll(getHttpService("localhost"), m_params);
         assertTrue("Expected available but was "+status+": reason = "+status.getReason(), status.isAvailable());
+        assertTrue("Expected a DS called 'response-time' but did not find one", status.getProperties().containsKey(PollStatus.PROPERTY_RESPONSE_TIME));
     }
 
     @Test
@@ -299,6 +310,7 @@ public class PageSequenceMonitorIT {
         try {
             PollStatus status = m_monitor.poll(getHttpService("localhost"), m_params);
             assertTrue("Expected available but was "+status+": reason = "+status.getReason(), status.isAvailable());
+            assertTrue("Expected a DS called 'response-time' but did not find one", status.getProperties().containsKey(PollStatus.PROPERTY_RESPONSE_TIME));
         } finally {
             // Print some debug output if necessary
         }
@@ -332,6 +344,7 @@ public class PageSequenceMonitorIT {
         try {
             PollStatus status = m_monitor.poll(getHttpService("localhost"), params);
             assertTrue("Expected available but was "+status+": reason = "+status.getReason(), status.isAvailable());
+            assertTrue("Expected a DS called 'response-time' but did not find one", status.getProperties().containsKey(PollStatus.PROPERTY_RESPONSE_TIME));
         } finally {
             // Print some debug output if necessary
         }
@@ -357,6 +370,7 @@ public class PageSequenceMonitorIT {
 
         PollStatus status = m_monitor.poll(getHttpService("localhost"), m_params);
         assertTrue("Expected available but was "+status+": reason = "+status.getReason(), status.isAvailable());
+        assertTrue("Expected a DS called 'response-time' but did not find one", status.getProperties().containsKey(PollStatus.PROPERTY_RESPONSE_TIME));
     }
 
     @Test
@@ -379,6 +393,8 @@ public class PageSequenceMonitorIT {
 
         PollStatus status = m_monitor.poll(getHttpService("localhost"), m_params);
         assertTrue("Expected down but was "+status+": reason = "+status.getReason(), status.isDown());
+        assertEquals("Failed to find '/opensadfnms/' in Location: header at http://127.0.0.1:10342/opennms/j_spring_security_check", status.getReason());
+        assertTrue("Expected a DS called 'response-time' but did not find one", status.getProperties().containsKey(PollStatus.PROPERTY_RESPONSE_TIME));
     }
 
     @Test
@@ -396,6 +412,7 @@ public class PageSequenceMonitorIT {
         assertTrue("Expected three DSes", (3 == status.getProperties().size()));
         assertTrue("Expected a DS called 'test1' but did not find one", status.getProperties().containsKey("test1"));
         assertTrue("Expected a DS called 'test2' but did not find one", status.getProperties().containsKey("test2"));
+        assertTrue("Expected a DS called 'response-time' but did not find one", status.getProperties().containsKey(PollStatus.PROPERTY_RESPONSE_TIME));
     }
 
     @Test
@@ -409,6 +426,7 @@ public class PageSequenceMonitorIT {
 
         PollStatus status = m_monitor.poll(getHttpService("localhost"), m_params);
         assertTrue("Expected available but was "+status+": reason = "+status.getReason(), status.isAvailable());
+        assertTrue("Expected a DS called 'response-time' but did not find one", status.getProperties().containsKey(PollStatus.PROPERTY_RESPONSE_TIME));
     }
 
     @Test
@@ -422,5 +440,6 @@ public class PageSequenceMonitorIT {
 
         PollStatus status = m_monitor.poll(getHttpService("localhost"), m_params);
         assertTrue("Expected available but was "+status+": reason = "+status.getReason(), status.isAvailable());
+        assertTrue("Expected a DS called 'response-time' but did not find one", status.getProperties().containsKey(PollStatus.PROPERTY_RESPONSE_TIME));
     }
 }

--- a/opennms-services/src/test/java/org/opennms/netmgt/threshd/LatencyThresholdingSetIT.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/threshd/LatencyThresholdingSetIT.java
@@ -72,6 +72,7 @@ import org.opennms.netmgt.filter.FilterDaoFactory;
 import org.opennms.netmgt.filter.api.FilterDao;
 import org.opennms.netmgt.mock.MockNetwork;
 import org.opennms.netmgt.model.events.EventBuilder;
+import org.opennms.netmgt.poller.PollStatus;
 import org.opennms.netmgt.rrd.RrdRepository;
 import org.opennms.netmgt.xml.event.Event;
 import org.opennms.netmgt.xml.event.Parm;
@@ -307,8 +308,8 @@ public class LatencyThresholdingSetIT implements TemporaryDatabaseAware<MockData
             attributes.put("ping" + i, 2 * i);
         }
         attributes.put("loss", 60.0);
-        attributes.put("response-time", 100.0);
         attributes.put("median", 100.0);
+        attributes.put(PollStatus.PROPERTY_RESPONSE_TIME, 100.0);
         assertTrue(thresholdingSet.hasThresholds(attributes));
         List<Event> triggerEvents = thresholdingSet.applyThresholds("StrafePing", attributes);
         assertTrue(triggerEvents.size() == 1);

--- a/protocols/selenium-monitor/src/main/java/org/opennms/netmgt/poller/monitors/SeleniumMonitor.java
+++ b/protocols/selenium-monitor/src/main/java/org/opennms/netmgt/poller/monitors/SeleniumMonitor.java
@@ -83,12 +83,12 @@ public class SeleniumMonitor extends AbstractServiceMonitor {
     		try {
     	        
                 Map<String, Number> responseTimes = new HashMap<String, Number>();
-                responseTimes.put("response-time", Double.NaN);
+                responseTimes.put(PollStatus.PROPERTY_RESPONSE_TIME, Double.NaN);
                 
                 tracker.startAttempt();
                 Result result = runTest( getBaseUrl(parameters, svc), getTimeout(parameters), createGroovyClass( seleniumTestFilename ) );
                 double responseTime = tracker.elapsedTimeInMillis();
-                responseTimes.put("response-time", responseTime);
+                responseTimes.put(PollStatus.PROPERTY_RESPONSE_TIME, responseTime);
                 
                 if(result.wasSuccessful()) {
                     serviceStatus = PollStatus.available();


### PR DESCRIPTION
The PSM was catching an httpclient exception and always returning failure message "I/O Error" even though the root cause exceptions provided more precise failure codes. I added code to unwrap the exceptions so that the failure codes are more useful.

I also added a catch(Throwable) to the main PSM poll() method so that it's more resilient to unexpected exceptions (like config typos, etc).

* JIRA: http://issues.opennms.org/browse/NMS-8098
* Bamboo: http://bamboo.internal.opennms.com:8085/browse/OPENNMS-ONMS646/latest