### PR TITLE
NMS-8129: Disallow restricted characters from foreign source and foreign ID

### DIFF
--- a/opennms-base-assembly/src/main/filtered/bin/provision.pl
+++ b/opennms-base-assembly/src/main/filtered/bin/provision.pl
@@ -236,6 +236,9 @@ sub cmd_requisition {
 	if ($command eq 'list') {
 		cmd_list($foreign_source);
 	} elsif (is_add($command)) {
+		if ($foreign_source =~ /[\/\\?:&*'"]/) {
+			pod2usage(-exitval => 1, -message => "Error: foreign source cannot contain :, /, \\, ?, &, *, ', \"", -verbose => 0);
+		}
 		my $xml = get_element('model-import');
 		my $root = $xml->root;
 		$root->{'att'}->{'foreign-source'} = $foreign_source;
@@ -311,6 +314,9 @@ sub cmd_node {
 	}
 
 	if (is_add($command)) {
+		if ($foreign_id =~ /[\/\\?:&*'"]/) {
+			pod2usage(-exitval => 1, -message => "Error: foreign id cannot contain :, /, \\, ?, &, *, ', \"", -verbose => 0);
+		}
 		my $node_label = shift @args;
 		if (not defined $node_label or $node_label eq "") {
 			pod2usage(-exitval => 1, -message => "Error: You must specify a node label!", -verbose => 0);

--- a/opennms-webapp/src/main/webapp/admin/ng-requisitions/app/scripts/controllers/Requisitions.js
+++ b/opennms-webapp/src/main/webapp/admin/ng-requisitions/app/scripts/controllers/Requisitions.js
@@ -187,6 +187,17 @@
     $scope.add = function() {
       bootbox.prompt('Please enter the name for the new requisition', function(foreignSource) {
         if (foreignSource) {
+          // Validate Requisition
+          if (foreignSource.match(/[\/\\?:&*'"]/)) {
+            bootbox.alert("Can't add the requisition " + foreignSource + " because the following characters are invalid:<br/>:, /, \\, ?, &, *, ', \"");
+            return;
+          }
+          var r = $scope.requisitionsData.getRequisition(foreignSource);
+          if (r != null) {
+            bootbox.alert("Can't add the requisition " + foreignSource+ " because there is already a requisition with that name");
+            return;
+          }
+          // Create Requisition
           RequisitionsService.addRequisition(foreignSource).then(
             function(r) { // success
               growl.success('The requisition ' + r.foreignSource + ' has been created.');

--- a/opennms-webapp/src/main/webapp/admin/ng-requisitions/app/scripts/directives/requisitionConstraints.js
+++ b/opennms-webapp/src/main/webapp/admin/ng-requisitions/app/scripts/directives/requisitionConstraints.js
@@ -104,11 +104,11 @@
       link: function(scope, element, attrs, ctrl) {
         ctrl.$parsers.unshift(function(foreignId) {
           var found = scope.foreignIdBlackList != null && scope.foreignIdBlackList.indexOf(foreignId) != -1;
-          if (found) {
-            ctrl.$setValidity('unique', false);
+          if (found || foreignId.match(/[\/\\?:&*'"]/)) {
+            ctrl.$setValidity('valid', false);
             return undefined;
           } else {
-            ctrl.$setValidity('unique', true);
+            ctrl.$setValidity('valid', true);
             return foreignId;
           }
         });

--- a/opennms-webapp/src/main/webapp/admin/ng-requisitions/app/views/node-basic.html
+++ b/opennms-webapp/src/main/webapp/admin/ng-requisitions/app/views/node-basic.html
@@ -9,7 +9,7 @@
       <button class="btn btn-default" type="button" ng-click="generateForeignId(nodeForm.foreignId)" ng-disabled="!isNew"><span class="glyphicon glyphicon-tag"/> Auto-generate</button>
     </span>
   </div>
-  <p ng-show="nodeForm.foreignId.$invalid" class="help-block">Foreign ID is required and must be unique within the requisition.</p>
+  <p ng-show="nodeForm.foreignId.$invalid" class="help-block">Foreign ID is required and must be unique within the requisition, and it cannot contain, :, /, \, ?, &amp;, *, ', "</p>
 </div>
 <div class="form-group" ng-class="{ 'has-error' : nodeForm.nodeLabel.$invalid }">
   <label class="control-label" for="nodeLabel">Node Label</label>


### PR DESCRIPTION

* JIRA: http://issues.opennms.org/browse/NMS-8129
* Bamboo: http://bamboo.internal.opennms.com:8085/browse/OPENNMS-ONMS643

Disallow restricted characters from foreign source and foreign ID.
In terms of the WebUI and provision.pl, you won't be able to add a
requisition or node with invalid characters on the foreign source
or the foreign id.

The only thing that is not covered is adding these kind of validation to the ReST API itself. The reason why I'm not adding this is because there is no way to know if you're adding or updating an existing entity, and some of the developers pointed out that some users might have foreign-source or foreign-id fields with invalid characters. I think this is not possible because during my tests, I cannot synchronize a requisition that has invalid characters on the requisition's name or any of the foreign IDs, but who knows. For this reason, I only added the validation when "adding" requisitions or nodes through the WebUI or provision.pl (which are independent from the update operation).

I'm open to additional suggestions here.