### PR TITLE
Fix for Bug NMS-7854 - Event Translator Issues

### DIFF
--- a/opennms-config/src/main/java/org/opennms/netmgt/config/EventTranslatorConfigFactory.java
+++ b/opennms-config/src/main/java/org/opennms/netmgt/config/EventTranslatorConfigFactory.java
@@ -429,14 +429,18 @@ public final class EventTranslatorConfigFactory implements EventTranslatorConfig
 
         private Event cloneEvent(Event srcEvent) {
             Event clonedEvent = EventTranslatorConfigFactory.cloneEvent(srcEvent);
-            /* since alarmData and severity are computed based on translated information in 
-             * eventd using the data from eventconf, we unset it here to eventd
+            /* Since several fields are computed based on translated information in 
+             * eventd using the data from eventconf, we unset them here to eventd
              * can reset to the proper new settings.
              */ 
             clonedEvent.setAlarmData(null);
             clonedEvent.setSeverity(null);
-            /* the reasoning for alarmData and severity also applies to description (see NMS-4038). */
             clonedEvent.setDescr(null);
+            clonedEvent.setLogmsg(null);
+            clonedEvent.setOperinstruct(null);
+            clonedEvent.setMask(null);
+            clonedEvent.setSnmp(null);
+            LOG.debug("cloneEvent: {}", clonedEvent);
             return clonedEvent;
         }
 


### PR DESCRIPTION
* JIRA: http://issues.opennms.org/browse/NMS-7854

Translated events with a new UEI do not receive the description, severity and alarm-data of the new event if new UEI's eventconf is present after original UEI's eventconf.

The workaround of reordering the event definitions work for non-trap events. For traps events, there are some unwanted results that are affecting other components like the Passive Status Keeper.

For this reason, several fields (specially snmp) have to be set to null when cloning the original event to avoid surprises.

I tested the proposed patch on my testing environment, and now the passive status keeper works as expected when translating SNMP traps.