### PR TITLE
Revert "Fix for Bug NMS-7854 - Event Translator Issues"

### DIFF
--- a/opennms-config/src/main/java/org/opennms/netmgt/config/EventTranslatorConfigFactory.java
+++ b/opennms-config/src/main/java/org/opennms/netmgt/config/EventTranslatorConfigFactory.java
@@ -429,18 +429,14 @@ public final class EventTranslatorConfigFactory implements EventTranslatorConfig
 
         private Event cloneEvent(Event srcEvent) {
             Event clonedEvent = EventTranslatorConfigFactory.cloneEvent(srcEvent);
-            /* Since several fields are computed based on translated information in 
-             * eventd using the data from eventconf, we unset them here to eventd
+            /* since alarmData and severity are computed based on translated information in 
+             * eventd using the data from eventconf, we unset it here to eventd
              * can reset to the proper new settings.
              */ 
             clonedEvent.setAlarmData(null);
             clonedEvent.setSeverity(null);
+            /* the reasoning for alarmData and severity also applies to description (see NMS-4038). */
             clonedEvent.setDescr(null);
-            clonedEvent.setLogmsg(null);
-            clonedEvent.setOperinstruct(null);
-            clonedEvent.setMask(null);
-            clonedEvent.setSnmp(null);
-            LOG.debug("cloneEvent: {}", clonedEvent);
             return clonedEvent;
         }
 


### PR DESCRIPTION
According to @jeffgdotorg, the Event Translator was designed to generate an enhanced copy of the original event:

_When an event is published on the event bus for which ET has configuration, it clones the event and changes the event's attributes (fields and parameters) as defined by the administrator in the translator configuration._

For this reason, the solution is against its the original design, but this mean, the Event Translator CANNOT be used to generate Passive Status Change events based on SNMP Traps. For this use case, only Scriptd can be used for now.