### PR TITLE
NMS-8374:  The logic to find event definitions confuses the Event Translator when translating SNMP Traps

### DIFF
--- a/opennms-config-model/src/main/castor/translator-configuration.xsd
+++ b/opennms-config-model/src/main/castor/translator-configuration.xsd
@@ -102,6 +102,7 @@
 			<sequence>
 				<element ref="this:assignment" minOccurs="0" maxOccurs="unbounded" />
 			</sequence>
+			<attribute name="preserve-snmp-data" type="boolean" use="optional" default="false"/>
 		</complexType>
 	</element>
 </schema>

--- a/opennms-config/src/main/java/org/opennms/netmgt/config/EventTranslatorConfigFactory.java
+++ b/opennms-config/src/main/java/org/opennms/netmgt/config/EventTranslatorConfigFactory.java
@@ -437,6 +437,9 @@ public final class EventTranslatorConfigFactory implements EventTranslatorConfig
             clonedEvent.setSeverity(null);
             /* the reasoning for alarmData and severity also applies to description (see NMS-4038). */
             clonedEvent.setDescr(null);
+            if (!m_mapping.isPreserveSnmpData()) { // NMS-8374
+                clonedEvent.setSnmp(null);
+            }
             return clonedEvent;
         }
 


### PR DESCRIPTION
The logic to find event definitions confuses the Event Translator when translating SNMP Traps

* JIRA: http://issues.opennms.org/browse/NMS-8374
* Bamboo: http://bamboo.internal.opennms.com:8085/browse/OPENNMS-ONMS665