### PR TITLE
HZN-726: Changed ActiveMQ broker to only listen for vm://localhost

### DIFF
--- a/features/discovery/blueprint-discovery.xml
+++ b/features/discovery/blueprint-discovery.xml
@@ -56,9 +56,9 @@
 		<argument ref="eventForwarder" />
 	</bean>
 
-	<bean id="discovery-activemq" class="org.apache.activemq.camel.component.ActiveMQComponent">
+	<bean id="activemq" class="org.apache.activemq.camel.component.ActiveMQComponent">
 		<!-- TODO: HZN-490 Add configurable ActiveMQ URI -->
-		<property name="brokerURL" value="tcp://localhost:61616" />
+		<property name="brokerURL" value="vm://localhost?create=false" />
 		<!-- TODO: HZN-490 Add configurable authentication -->
 		<!--
 		<property name="userName" value="karaf" />

--- a/features/discovery/src/main/resources/META-INF/opennms/applicationContext-discovery.xml
+++ b/features/discovery/src/main/resources/META-INF/opennms/applicationContext-discovery.xml
@@ -58,7 +58,7 @@
 
   <bean id="activemq" class="org.apache.activemq.camel.component.ActiveMQComponent">
     <!-- TODO: HZN-490 Add configurable ActiveMQ URI -->
-    <property name="brokerURL" value="tcp://localhost:61616" />
+    <property name="brokerURL" value="vm://localhost?create=false" />
     <!-- TODO: HZN-490 Add configurable authentication -->
     <!--
     <property name="userName" value="karaf" />

--- a/features/discovery/src/test/java/org/opennms/netmgt/discovery/DiscoveryBlueprintIT.java
+++ b/features/discovery/src/test/java/org/opennms/netmgt/discovery/DiscoveryBlueprintIT.java
@@ -29,10 +29,8 @@
 package org.opennms.netmgt.discovery;
 
 import java.net.InetAddress;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Dictionary;
-import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
@@ -70,7 +68,6 @@ import org.opennms.netmgt.events.api.EventForwarder;
 import org.opennms.netmgt.events.api.EventIpcManager;
 import org.opennms.netmgt.icmp.Pinger;
 import org.opennms.netmgt.model.OnmsDistPoller;
-import org.opennms.netmgt.model.discovery.IPPollRange;
 import org.opennms.netmgt.model.events.EventBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -169,7 +166,7 @@ public class DiscoveryBlueprintIT extends CamelBlueprintTestSupport {
     @BeforeClass
     public static void startActiveMQ() throws Exception {
         m_broker = new BrokerService();
-        m_broker.addConnector("tcp://127.0.0.1:61616");
+        m_broker.addConnector("vm://localhost");
         m_broker.start();
     }
 
@@ -180,7 +177,7 @@ public class DiscoveryBlueprintIT extends CamelBlueprintTestSupport {
         }
     }
 
-    @Test
+    @Test(timeout=60000)
     public void testDiscover() throws Exception {
 
         /*
@@ -189,7 +186,7 @@ public class DiscoveryBlueprintIT extends CamelBlueprintTestSupport {
          */
         SimpleRegistry registry = new SimpleRegistry();
         CamelContext mockDiscoverer = new DefaultCamelContext(registry);
-        mockDiscoverer.addComponent("activemq", ActiveMQComponent.activeMQComponent("tcp://127.0.0.1:61616"));
+        mockDiscoverer.addComponent("activemq", ActiveMQComponent.activeMQComponent("vm://localhost?create=false"));
         mockDiscoverer.addRoutes(new RouteBuilder() {
             @Override
             public void configure() throws Exception {
@@ -252,7 +249,7 @@ public class DiscoveryBlueprintIT extends CamelBlueprintTestSupport {
         mockDiscoverer.stop();
     }
     
-    @Test
+    @Test(timeout=60000)
     public void testDiscoverToTestTimeout() throws Exception {
 
         /*
@@ -261,7 +258,7 @@ public class DiscoveryBlueprintIT extends CamelBlueprintTestSupport {
          */
         SimpleRegistry registry = new SimpleRegistry();
         CamelContext mockDiscoverer = new DefaultCamelContext(registry);
-        mockDiscoverer.addComponent("activemq", ActiveMQComponent.activeMQComponent("tcp://127.0.0.1:61616"));
+        mockDiscoverer.addComponent("activemq", ActiveMQComponent.activeMQComponent("vm://localhost?create=false"));
         mockDiscoverer.addRoutes(new RouteBuilder() {
             @Override
             public void configure() throws Exception {

--- a/features/events/syslog/blueprint-syslog-handler-default.xml
+++ b/features/events/syslog/blueprint-syslog-handler-default.xml
@@ -15,7 +15,7 @@
 
 	<cm:property-placeholder id="syslogHandlerDefaultProperties" persistent-id="org.opennms.netmgt.syslog.handler.default" update-strategy="none">
 		<cm:default-properties>
-			<cm:property name="brokerUri" value="tcp://127.0.0.1:61616" />
+			<cm:property name="brokerUri" value="vm://localhost?create=false" />
 		</cm:default-properties>
 	</cm:property-placeholder>
 

--- a/features/events/syslog/blueprint-syslog-handler-minion.xml
+++ b/features/events/syslog/blueprint-syslog-handler-minion.xml
@@ -13,12 +13,6 @@
 		http://aries.apache.org/schemas/blueprint-ext/blueprint-ext-1.1.xsd
 ">
 
-	<cm:property-placeholder id="syslogHandlerMinionProperties" persistent-id="org.opennms.netmgt.syslog.handler.minion" update-strategy="none">
-		<cm:default-properties>
-			<cm:property name="brokerUri" value="tcp://127.0.0.1:61716" />
-		</cm:default-properties>
-	</cm:property-placeholder>
-
 	<bean id="syslogConnectionHandlerCamel" class="org.opennms.netmgt.syslogd.SyslogConnectionHandlerCamelImpl">
 		<argument value="seda:handleMessage"/>
 	</bean>
@@ -30,25 +24,17 @@
 		<argument value="org.opennms.netmgt.syslogd.SyslogConnection" />
 	</bean>
 
-	<bean id="activemq" class="org.apache.activemq.camel.component.ActiveMQComponent">
-		<!-- TODO: HZN-490 Add configurable ActiveMQ URI -->
-		<property name="brokerURL" value="${brokerUri}" />
-		<!-- TODO: HZN-490 Add configurable authentication -->
-		<!--
-		<property name="userName" value="karaf" />
-		<property name="password" value="karaf" />
-		-->
-	</bean>
+	<!-- ActiveMQ component provided by minion-core -->
+	<reference id="queuingservice" interface="org.apache.camel.Component" filter="(alias=opennms.broker)"/>
 
 	<camelContext id="syslogConnectionHandlerMinion" xmlns="http://camel.apache.org/schema/blueprint">
-		<propertyPlaceholder id="properties" location="blueprint:syslogHandlerMinionProperties" />
 		<route id="handleMessage">
 			<from uri="seda:handleMessage" />
 			<convertBodyTo type="org.opennms.netmgt.syslogd.SyslogConnection"/>
 			<!-- Marshal the message to XML -->
 			<bean ref="marshaller"/>
 			<!-- Broadcast the message over ActiveMQ -->
-			<to uri="activemq:broadcastSyslog?disableReplyTo=true"/>
+			<to uri="queuingservice:broadcastSyslog?disableReplyTo=true"/>
 		</route>
 	</camelContext>
 

--- a/features/events/syslog/src/test/java/org/opennms/netmgt/syslogd/SyslogdHandlerDefaultIT.java
+++ b/features/events/syslog/src/test/java/org/opennms/netmgt/syslogd/SyslogdHandlerDefaultIT.java
@@ -111,7 +111,8 @@ public class SyslogdHandlerDefaultIT extends CamelBlueprintTestSupport {
 	@BeforeClass
 	public static void startActiveMQ() throws Exception {
 		m_broker = new BrokerService();
-		m_broker.addConnector("tcp://127.0.0.1:61616");
+		//m_broker.addConnector("tcp://127.0.0.1:61616");
+		m_broker.addConnector("vm://localhost");
 		m_broker.start();
 	}
 
@@ -122,7 +123,7 @@ public class SyslogdHandlerDefaultIT extends CamelBlueprintTestSupport {
 		}
 	}
 
-	@Test
+	@Test(timeout=60000)
 	public void testSyslogd() throws Exception {
 		// Expect one SyslogConnection message to be broadcast on the messaging channel
 		MockEndpoint broadcastSyslog = getMockEndpoint("mock:activemq:broadcastSyslog", false);

--- a/opennms-base-assembly/src/main/filtered/etc/opennms-activemq.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/opennms-activemq.xml
@@ -131,7 +131,15 @@
         -->
         <transportConnectors>
             <transportConnector name="vm" uri="vm://localhost"/>
-            <!-- DOS protection, limit concurrent connections to 1000 and frame size to 100MB -->
+
+            <!-- Uncomment this line to allow external TCP connections -->
+            <!-- 
+              WARNING: Access to port 61616 should be firewalled to prevent unauthorized injection 
+              tof data into OpenNMS when this port is open. 
+            -->
+            <!-- <transportConnector name="openwire" uri="tcp://0.0.0.0:61616?useJmx=false&amp;maximumConnections=1000&amp;wireformat.maxFrameSize=104857600"/> -->
+
+            <!-- Uncomment this line to allow localhost TCP connections (for testing purposes) -->
             <!-- <transportConnector name="openwire" uri="tcp://127.0.0.1:61616?useJmx=false&amp;maximumConnections=1000&amp;wireformat.maxFrameSize=104857600"/> -->
         </transportConnectors>
 

--- a/opennms-base-assembly/src/main/filtered/etc/opennms-activemq.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/opennms-activemq.xml
@@ -130,8 +130,9 @@
             http://activemq.apache.org/configuring-transports.html
         -->
         <transportConnectors>
+            <transportConnector name="vm" uri="vm://localhost"/>
             <!-- DOS protection, limit concurrent connections to 1000 and frame size to 100MB -->
-            <transportConnector name="openwire" uri="tcp://127.0.0.1:61616?useJmx=false&amp;maximumConnections=1000&amp;wireformat.maxFrameSize=104857600"/>
+            <!-- <transportConnector name="openwire" uri="tcp://127.0.0.1:61616?useJmx=false&amp;maximumConnections=1000&amp;wireformat.maxFrameSize=104857600"/> -->
         </transportConnectors>
 
         <!-- destroy the spring context on shutdown to stop jetty -->

--- a/opennms-doc/guide-install/src/asciidoc/text/minion/introduction.adoc
+++ b/opennms-doc/guide-install/src/asciidoc/text/minion/introduction.adoc
@@ -5,21 +5,30 @@
 [[gi-install-minion]]
 == Installing Minion
 
-_Minion_ enables enterprises with the ability to create a globally distributed and scalable monitoring fabric.
+_Minion_ gives enterprises the ability to create a globally distributed, scalable monitoring fabric.
 
-IMPORTANT: Support for _Minion_ is currently experimental and packages are only available for RHEL based systems.
+IMPORTANT: Support for _Minion_ is currently _experimental_ and packages are only available for RHEL based systems.
 
-NOTE: Before attempting to setup _Minion_ you must have an instance of _OpenNMS_ setup using the same version of the packages.
+NOTE: Before attempting to setup _Minion_, you must have an instance of _OpenNMS_ set up using the same version of the packages.
 
-A _Minion_ can be installed on the same system as _OpenNMS_ or on other system systems provided that it can communicate with:
+_Minion_ can be installed on the same system as _OpenNMS_ or on other systems provided that it can communicate with:
 
 . The OpenNMS REST interface
 . The ActiveMQ broker used by OpenNMS
 
-_OpenNMS_ embeds an _ActiveMQ_ broker which is used by default, however the port is bound to `127.0.0.1`.
-In order to make the _ActiveMQ_ broker accessible remotely, must edit `$OPENNMS_HOME/etc/opennms-activemq.xml` and configure the `transportConnector` to bind to `0.0.0.0` (or another suitable address):
+_OpenNMS_ embeds an _ActiveMQ_ broker which, by default, cannot be accessed remotely via the network.
+In order to make the _ActiveMQ_ broker accessible remotely, you must edit `$OPENNMS_HOME/etc/opennms-activemq.xml` and 
+uncomment the `transportConnector` with the `tcp://0.0.0.0:61616` URI.
 
 [source,xml]
 ----
+<!-- Uncomment this line to allow external TCP connections -->
+<!-- 
+  WARNING: Access to port 61616 should be firewalled to prevent unauthorized injection 
+  of data into OpenNMS when this port is open.
+-->
 <transportConnector name="openwire" uri="tcp://0.0.0.0:61616?useJmx=false&amp;maximumConnections=1000&amp;wireformat.maxFrameSize=104857600"/>
 ----
+
+If you wish to restrict ActiveMQ connections to only one particular external IP address, you can change `0.0.0.0` to that
+desired IP address.


### PR DESCRIPTION
This commit changes the OpenNMS-side JMS connections to run over the vm://localhost connector instead of TCP. The TCP port will be disabled by default. I also fixed the Syslog Minion code to use the shared JMS connection from minion-core.

* JIRA: http://issues.opennms.org/browse/HZN-726
* Bamboo: http://bamboo.internal.opennms.com:8085/browse/OPENNMS-ONMS669
