### PR TITLE
NMS-8076: Added links to local, offline docs to webapp

### DIFF
--- a/debian/opennms-doc.links
+++ b/debian/opennms-doc.links
@@ -1,1 +1,2 @@
-/usr/share/doc/opennms				/usr/share/opennms/docs
+/usr/share/doc/opennms /usr/share/opennms/docs
+/usr/share/doc/opennms /usr/share/opennms/jetty-webapps/opennms/docs

--- a/opennms-webapp/src/main/webapp/WEB-INF/jsp/support/index.jsp
+++ b/opennms-webapp/src/main/webapp/WEB-INF/jsp/support/index.jsp
@@ -43,6 +43,26 @@ session="true"
   <jsp:param name="breadcrumb" value="Support" />
 </jsp:include>
 
+<script type="text/javascript">
+  // Shorthand for 'onload'
+  $(function() {
+    // Check to see if the URL provided by the opennms-docs package is present on the system.
+    // If so, display the links to the offline docs symlinked from /usr/share/doc/opennms-${version}.
+    $.ajax({
+      url: 'docs/guide-install/index.html',
+      method: 'HEAD',
+      error: function()
+      {
+        $('#online-documentation').css("display", "inline-block");
+      },
+      success: function()
+      {
+        $('#offline-documentation').css("display", "inline-block");
+      }
+    });
+  });
+</script>
+
 <div class="row">
 <div class="col-md-6">
     <c:choose>
@@ -185,11 +205,37 @@ session="true"
   <div class="panel-body">
     <ul class="list-unstyled">
       <li><a href="support/about.jsp">About the OpenNMS Web Console</a></li>
-      <li><a href="http://www.opennms.org/documentation/ReleaseNotesStable.html#whats-new">Release Notes</a></li>
-      <li><a href="http://www.opennms.org/wiki/">Online Documentation</a></li>
+      <li><a href="http://docs.opennms.org/opennms/releases/latest/releasenotes/releasenotes.html">Release Notes</a></li>
     </ul>
   </div>
   </div>
+
+  <div class="panel panel-default">
+  <div class="panel-heading">
+    <h3 class="panel-title">Documentation</h3>
+  </div>
+  <div class="panel-body">
+    <span id="online-documentation" style="display:none;">
+    <ul class="list-unstyled">
+      <li><a href="http://docs.opennms.org/opennms/releases/latest/guide-install/guide-install.html">Installation Guide</a></li>
+      <li><a href="http://docs.opennms.org/opennms/releases/latest/guide-user/guide-user.html">Users Guide</a></li>
+      <li><a href="http://docs.opennms.org/opennms/releases/latest/guide-admin/guide-admin.html">Administrators Guide</a></li>
+      <li><a href="http://docs.opennms.org/opennms/releases/latest/guide-development/guide-development.html">Developers Guide</a></li>
+      <li><a href="http://www.opennms.org/wiki/">Online Wiki Documentation</a></li>
+    </ul>
+    </span>
+    <span id="offline-documentation" style="display:none;">
+    <ul class="list-unstyled">
+      <li><a href="docs/guide-install/index.html">Installation Guide</a></li>
+      <li><a href="docs/guide-user/index.html">Users Guide</a></li>
+      <li><a href="docs/guide-admin/index.html">Administrators Guide</a></li>
+      <li><a href="docs/guide-development/index.html">Developers Guide</a></li>
+      <li><a href="http://www.opennms.org/wiki/">Online Wiki Documentation</a></li>
+    </ul>
+    </span>
+  </div>
+  </div>
+
   <div class="panel panel-default">
   <div class="panel-heading">
   	<h3 class="panel-title">Other Support Options</h3>

--- a/opennms-webapp/src/main/webapp/WEB-INF/web.xml
+++ b/opennms-webapp/src/main/webapp/WEB-INF/web.xml
@@ -402,6 +402,45 @@
     <load-on-startup>0</load-on-startup>
   </servlet>
 
+  <servlet>
+    <servlet-name>docsDirectory</servlet-name>
+    <servlet-class>org.eclipse.jetty.servlet.DefaultServlet</servlet-class>
+    <!--
+      Allow aliases for the /docs directory so that it can be
+      symlinked into the webapp
+    -->
+    <init-param>
+      <param-name>aliases</param-name>
+      <param-value>true</param-value>
+    </init-param>
+    <init-param>
+      <param-name>dirAllowed</param-name>
+      <param-value>false</param-value> <!-- NMS-3475 -->
+    </init-param>
+    <init-param>
+      <param-name>welcomeServlets</param-name>
+      <param-value>false</param-value>
+    </init-param>
+    <init-param>
+      <param-name>redirectWelcome</param-name>
+      <param-value>false</param-value>
+    </init-param>
+    <init-param>
+      <param-name>gzip</param-name>
+      <param-value>true</param-value>
+    </init-param>
+    <init-param>
+      <param-name>useFileMappedBuffer</param-name>
+      <param-value>true</param-value>
+    </init-param>
+    <load-on-startup>0</load-on-startup>
+  </servlet>
+
+   <servlet-mapping>
+     <servlet-name>docsDirectory</servlet-name>
+     <url-pattern>/docs</url-pattern>
+   </servlet-mapping>
+
   <!--  servlet that gwt rpc requests get mapped to -->
    <servlet>
      <servlet-name>gwtDispatcher</servlet-name>

--- a/smoke-test/src/test/java/org/opennms/smoketest/SupportPageIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/SupportPageIT.java
@@ -49,12 +49,23 @@ public class SupportPageIT extends OpenNMSSeleniumTestCase {
 
     @Test
     public void testAllLinksArePresent() throws Exception {
-        assertEquals(3, countElementsMatchingCss("h3.panel-title"));
+        assertEquals(4, countElementsMatchingCss("h3.panel-title"));
         final String[] links = new String[] {
                 "the OpenNMS.com support page",
                 "About the OpenNMS Web Console",
                 "Release Notes",
-                "Online Documentation",
+                // Online docs links
+                "Installation Guide",
+                "Users Guide",
+                "Administrators Guide",
+                "Developers Guide",
+                "Online Wiki Documentation",
+                // Offline docs links
+                "Installation Guide",
+                "Users Guide",
+                "Administrators Guide",
+                "Developers Guide",
+                "Online Wiki Documentation",
                 "Generate a System Report",
                 "Open a Bug or Enhancement Request",
                 "Chat with Developers on IRC"

--- a/tools/packages/opennms/opennms.spec
+++ b/tools/packages/opennms/opennms.spec
@@ -884,6 +884,15 @@ else
 	echo "done"
 fi
 
+printf -- "- making symlink for $ROOT_INST/jetty-webapps/%{servletdir}/docs... "
+if [ -e "$ROOT_INST/jetty-webapps/%{servletdir}/docs" ] && [ ! -L "$ROOT_INST/jetty-webapps/%{servletdir}/docs" ]; then
+  echo "failed: $ROOT_INST/jetty-webapps/%{servletdir}/docs is a real directory, but it should be a symlink to %{_docdir}/%{name}-%{version}."
+else
+  rm -rf "$ROOT_INST/jetty-webapps/%{servletdir}/docs"
+  ln -sf "%{_docdir}/%{name}-%{version}" "$ROOT_INST/jetty-webapps/%{servletdir}/docs"
+  echo "done"
+fi
+
 %postun -p /bin/bash docs
 ROOT_INST="$RPM_INSTALL_PREFIX0"
 SHARE_INST="$RPM_INSTALL_PREFIX1"
@@ -896,6 +905,12 @@ if [ "$1" = 0 ]; then
 	if [ -L "$ROOT_INST/docs" ]; then
 		rm -f "$ROOT_INST/docs"
 	fi
+fi
+
+if [ "$1" = 0 ]; then
+  if [ -L "$ROOT_INST/jetty-webapps/%{servletdir}/docs" ]; then
+    rm -f "$ROOT_INST/jetty-webapps/%{servletdir}/docs"
+  fi
 fi
 
 %post -p /bin/bash core


### PR DESCRIPTION
These changes will add links to the online docs to the "Help/Support" page. If you install the opennms-docs package, the links will redirect to local copies of the docs so that you don't need internet access to view them.

* JIRA: http://issues.opennms.org/browse/NMS-8076
* Bamboo: http://bamboo.internal.opennms.com:8085/browse/OPENNMS-ONMS675