### PR TITLE
Install guide cleanup

### DIFF
--- a/opennms-doc/guide-install/src/asciidoc/index.adoc
+++ b/opennms-doc/guide-install/src/asciidoc/index.adoc
@@ -14,8 +14,9 @@
 :revdate: {last-update-label} {docdatetime}
 :version-label!:
 
-// Installation Guide for opennms-product-name
+// Installation Guide for {opennms-product-name}
 include::text/opennms/introduction.adoc[]
+include::text/opennms/repository.adoc[]
 include::text/opennms/rhel.adoc[]
 include::text/opennms/debian.adoc[]
 include::text/opennms/windows.adoc[]

--- a/opennms-doc/guide-install/src/asciidoc/text/java/debian.adoc
+++ b/opennms-doc/guide-install/src/asciidoc/text/java/debian.adoc
@@ -3,7 +3,7 @@
 :imagesdir: ../../images
 
 [[gi-install-oracle-java-debian]]
-=== Setup on _Debian-based_ systems
+=== Debian
 
 This section describes how to install _Oracle Java 8_ on a _Debian-based_ system like _Debian 8_ or _Ubuntu 14.04 LTS_.
 

--- a/opennms-doc/guide-install/src/asciidoc/text/java/debian.adoc
+++ b/opennms-doc/guide-install/src/asciidoc/text/java/debian.adoc
@@ -5,7 +5,7 @@
 [[gi-install-oracle-java-debian]]
 === Debian
 
-This section describes how to install _Oracle Java 8_ on a _Debian-based_ system like _Debian 8_ or _Ubuntu 14.04 LTS_.
+This section describes how to install _Oracle Java SE Development Kit 8_ on a _Debian-based_ system like _Debian 8_ or _Ubuntu 14.04 LTS_.
 
 .Add Java repository from webupd8 maintainer
 [source, bash]
@@ -22,7 +22,7 @@ apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys EEA14886
 apt-get update
 ----
 
-.Install Oracle Java 8 installer
+.Install Oracle Java SE Development Kit 8
 [source, bash]
 ----
 apt-get install -y oracle-java8-installer

--- a/opennms-doc/guide-install/src/asciidoc/text/java/environment.adoc
+++ b/opennms-doc/guide-install/src/asciidoc/text/java/environment.adoc
@@ -5,16 +5,16 @@
 [[gi-install-env]]
 === Java Environment
 
-To provide _Java_, applications use the `$JAVA_HOME` environment variable.
+To locate the _Java_ system files, applications typically use the `$JAVA_HOME` environment variable.
 The environment can be set for a specific user or globally for the whole system on boot time.
 
 .Example path to Java on RHEL, Debian and Microsoft Windows systems
 * RHEL: `/usr/java/jdk1.8.0_51`
 * Debian: `/usr/lib/jvm/java-8-oracle`
-* Windows Server 2012: `C:\Program Files\Java\jre1.8.0_51`
+* Microsoft Windows: `C:\Program Files\Java\jre1.8.0_51`
 
 [[gi-install-env-linux]]
-==== Set Java home in Linux
+==== Set JAVA_HOME on Linux
 
 .Option 1: Set the Java environment for the current user
 [source, bash]
@@ -31,7 +31,7 @@ export JAVA_HOME=/path/to/java
 ----
 
 [[gi-install-env-windows]]
-==== Set Java home in Windows Server 2012
+==== Set JAVA_HOME on Microsoft Windows
 
 .Option 1: Set JAVA_HOME as user specific system variable
 [source]

--- a/opennms-doc/guide-install/src/asciidoc/text/java/introduction.adoc
+++ b/opennms-doc/guide-install/src/asciidoc/text/java/introduction.adoc
@@ -3,9 +3,9 @@
 :imagesdir: ../../images
 
 [[gi-install-oracle-java]]
-== Oracle Java Development Kit 8
+== Oracle Java SE Development Kit 8
 
-Installing the _Oracle Java Development Kit 8_ (_JDK8_) requires installation packages provided by _Oracle_ 
+Installing the _Oracle Java SE Development Kit 8_ (_JDK8_) requires installation packages provided by _Oracle_ 
 or a 3rd-party maintainer for _Debian_-based Linux distributions.
 The following tools should be installed to follow this installation manual:
 
@@ -15,5 +15,5 @@ The following tools should be installed to follow this installation manual:
 * Editing text, e.g. `vi`, `nano` or `joe`
 * Internet access
 
-WARNING: By downloading the _Oracle Java Development Kit 8 RPM_ installer, you will accept the license agreement 
+WARNING: By downloading the _Oracle Java SE Development Kit 8_ RPM installer, you will accept the license agreement 
 from _Oracle_ which can be found on the link:https://www.java.com/en/download/faq/distribution.xml[Java distribution] web site.

--- a/opennms-doc/guide-install/src/asciidoc/text/java/introduction.adoc
+++ b/opennms-doc/guide-install/src/asciidoc/text/java/introduction.adoc
@@ -3,16 +3,17 @@
 :imagesdir: ../../images
 
 [[gi-install-oracle-java]]
-== Installing Oracle Java Environment
+== Oracle Java Development Kit 8
 
-Installing _Oracle Java 8_ requires external installation packages.
-These packages are provided from _Oracle_ or 3rd party maintainer for the _Debian_ and _Ubuntu-based_ _Linux Distributions_.
+Installing the _Oracle Java Development Kit 8_ (_JDK8_) requires installation packages provided by _Oracle_ 
+or a 3rd-party maintainer for _Debian_-based Linux distributions.
 The following tools should be installed to follow this installation manual:
 
-* download files and tools with `wget` and `curl`
-* extract archives with `tar`
-* text manipulation with `sed`
-* Editor, e.g. `vi`, `nano` or `joe`
-* internet access
+* Download files and tools with `wget` and `curl`
+* Extract archives with `tar`
+* Text manipulation with `sed`
+* Editing text, e.g. `vi`, `nano` or `joe`
+* Internet access
 
-WARNING: By downloading the _Oracle Java 8 RPM_ installer you'll accept the license agreement from _Oracle_ which can be found on the link:https://www.java.com/en/download/faq/distribution.xml[Java distribution] web site.
+WARNING: By downloading the _Oracle Java Development Kit 8 RPM_ installer, you will accept the license agreement 
+from _Oracle_ which can be found on the link:https://www.java.com/en/download/faq/distribution.xml[Java distribution] web site.

--- a/opennms-doc/guide-install/src/asciidoc/text/java/rhel.adoc
+++ b/opennms-doc/guide-install/src/asciidoc/text/java/rhel.adoc
@@ -5,7 +5,7 @@
 [[gi-install-oracle-java-rhel]]
 === RHEL
 
-This section describes how to install _Oracle Java 8_ on a _RPM-based_ system like _Red Hat Enterprise Linux 7_ or _CentOS 7.1_.
+This section describes how to install _Oracle Java SE Development Kit 8_ on a _RPM-based_ system like _Red Hat Enterprise Linux 7_ or _CentOS 7.1_.
 
 .Download Oracle JDK RPM
 [source, bash]

--- a/opennms-doc/guide-install/src/asciidoc/text/java/rhel.adoc
+++ b/opennms-doc/guide-install/src/asciidoc/text/java/rhel.adoc
@@ -3,7 +3,7 @@
 :imagesdir: ../../images
 
 [[gi-install-oracle-java-rhel]]
-=== Setup on RHEL-based systems
+=== RHEL
 
 This section describes how to install _Oracle Java 8_ on a _RPM-based_ system like _Red Hat Enterprise Linux 7_ or _CentOS 7.1_.
 

--- a/opennms-doc/guide-install/src/asciidoc/text/java/windows-server.adoc
+++ b/opennms-doc/guide-install/src/asciidoc/text/java/windows-server.adoc
@@ -5,9 +5,9 @@
 [[gi-install-oracle-java-windows]]
 === Microsoft Windows
 
-This section describes how to install _Oracle Java 8_ on a system running the _Microsoft Windows Server 2012_ operating system.
+This section describes how to install _Oracle Java SE Development Kit 8_ on a system running the _Microsoft Windows Server 2012_ operating system.
 
-.Download the Microsoft Windows Java 8 installer with PowerShell or a browser
+.Download the Microsoft Windows Java SE Development Kit 8 installer with PowerShell or a browser
 [source]
 ----
 cd C:\Users\Administrator\Downloads

--- a/opennms-doc/guide-install/src/asciidoc/text/java/windows-server.adoc
+++ b/opennms-doc/guide-install/src/asciidoc/text/java/windows-server.adoc
@@ -3,7 +3,7 @@
 :imagesdir: ../../images
 
 [[gi-install-oracle-java-windows]]
-=== Setup on Windows Server
+=== Microsoft Windows
 
 This section describes how to install _Oracle Java 8_ on a system running the _Microsoft Windows Server 2012_ operating system.
 

--- a/opennms-doc/guide-install/src/asciidoc/text/newts/cassandra-debian.adoc
+++ b/opennms-doc/guide-install/src/asciidoc/text/newts/cassandra-debian.adoc
@@ -3,7 +3,7 @@
 :imagesdir: ../../images
 
 [[gi-install-cassandra-debian]]
-==== Installing on Debian-based systems
+==== Debian
 
 This section describes how to install the latest _Cassandra 2.1.x_ release on a _Debian_-based system for _Newts_.
 The first step is to add the _DataStax_ community repository and install the required _GPG Key_ to verify the integrity of the _DEB packages_.

--- a/opennms-doc/guide-install/src/asciidoc/text/newts/cassandra-rhel.adoc
+++ b/opennms-doc/guide-install/src/asciidoc/text/newts/cassandra-rhel.adoc
@@ -3,7 +3,7 @@
 :imagesdir: ../../images
 
 [[gi-install-cassandra-rhel]]
-==== Installing on RHEL-based systems
+==== RHEL
 
 This section describes how to install the latest _Cassandra 2.1.x_ release on a _RHEL_ based systems for _Newts_.
 The first step is to add the _DataStax_ community repository and install the required _GPG Key_ to verify the integrity of the _RPM packages_.

--- a/opennms-doc/guide-install/src/asciidoc/text/newts/cassandra-windows.adoc
+++ b/opennms-doc/guide-install/src/asciidoc/text/newts/cassandra-windows.adoc
@@ -3,7 +3,7 @@
 :imagesdir: ../../images
 
 [[gi-install-cassandra-windows]]
-==== Installing on Windows Server systems
+==== Microsoft Windows
 
 This section describes how to install the latest _Cassandra 2.1.x_ release on a _Microsoft Windows Server_ based systems for _Newts_.
 The first step is to download the graphical installer and register _Cassandra_ as a _Windows Service_ so it can be manged through the _Service Manager_.

--- a/opennms-doc/guide-install/src/asciidoc/text/newts/introduction.adoc
+++ b/opennms-doc/guide-install/src/asciidoc/text/newts/introduction.adoc
@@ -3,7 +3,7 @@
 :imagesdir: ../../images
 
 [[gi-install-ts-newts]]
-== Installing Time Series database Newts
+== Newts
 
 link:http://newts.io/[Newts] is a time-series data store based on link:http://cassandra.apache.org/[Apache Cassandra].
 _Newts_ is a persistence strategy, that can be used as an alternative to link:http://www.opennms.org/wiki/JRobin[JRobin] or link:http://oss.oetiker.ch/rrdtool/[RRDtool].

--- a/opennms-doc/guide-install/src/asciidoc/text/opennms/debian.adoc
+++ b/opennms-doc/guide-install/src/asciidoc/text/opennms/debian.adoc
@@ -3,7 +3,7 @@
 :imagesdir: ../../images
 
 [[gi-install-opennms-debian]]
-=== Install on Debian-based systems
+=== Debian
 
 IMPORTANT: This guide does not apply to OpenNMS Meridian, which can be installed only on Red Hat Enterprise Linux or CentOS systems.
 
@@ -57,6 +57,8 @@ The following packages will be automatically installed:
 * _jdk1.8_: _Oracle Java 8_ environment from _OpenNMS_ respository
 * _postgresql_: _PostgreSQL_ database server from distribution repository
 * _postgresql-libs_: _PostgreSQL_ database from distribution repository
+
+TIP: Verify the version of the _OpenNMS_ packages that was installed with `apt-cache show opennms`.
 
 With the successful installed packages the _OpenNMS_ platform is installed in the following directory structure:
 

--- a/opennms-doc/guide-install/src/asciidoc/text/opennms/debian.adoc
+++ b/opennms-doc/guide-install/src/asciidoc/text/opennms/debian.adoc
@@ -10,41 +10,17 @@ IMPORTANT: This guide does not apply to OpenNMS Meridian, which can be installed
 This section describes how to install the _OpenNMS_ platform on _Ubuntu 14.04 LTS_.
 The setup process is described in the following steps:
 
-. Install _OpenNMS_ apt repository server with GPG key to verify packages
 . Installation of the _opennms_ meta package which handles all dependencies
 . Initialize _PostgreSQL_ database and configure access
 . Initialize _OpenNMS_ and first start of the application
 
-[[gi-install-opennms-deb-repo]]
-==== Setup OpenNMS Debian repository
-
-_OpenNMS_ can be installed with Installation of stable repository and GPG key
-
-.Installation of _OpenNMS Debian_ repository
-[source, shell]
-----
-deb http://debian.opennms.org stable main
-deb-src http://debian.opennms.org stable main
-----
-
-.Installation of repository GPG key
-[source, shell]
-----
-wget -O - http://debian.opennms.org/OPENNMS-GPG-KEY | apt-key add -
-----
-
-.Update apt repository cache
-[source, shell]
-----
-apt-get update
-----
-
 [[gi-install-opennms-deb-package]]
-==== Install OpenNMS package
+==== Install OpenNMS
 
 .Installation of the full application with all dependencies like PostgreSQL and Java
 [source, shell]
 ----
+apt-get update
 apt-get install -y opennms
 ----
 

--- a/opennms-doc/guide-install/src/asciidoc/text/opennms/introduction.adoc
+++ b/opennms-doc/guide-install/src/asciidoc/text/opennms/introduction.adoc
@@ -19,14 +19,14 @@ Installing _OpenNMS_ requires the following prerequisites:
 
 * A configured <<gi-install-opennms-repo-releases, Yum or APT Package Repository>> for your platform (Linux only)
 * Internet access to download and verify _OpenNMS_ packages from the Yum or APT package repositories
-* <<gi-install-oracle-java, Oracle Java Development Kit 8>> environment
+* <<gi-install-oracle-java, Oracle Java SE Development Kit 8>> environment
 * PostgreSQL database version 9.1 or higher
 * A time-series database engine to persist long-term performance data:
 ** JRobin: The default choice. JRobin is included inside OpenNMS and doesn't require additional software to be installed.
 ** <<gi-rrdtool-time-series-database, RRDtool>>: A higher performance, file-based database.
 ** <<gi-install-ts-newts, Newts>>: The highest performance solution. Newts uses an Apache Cassandra database for clustered scalability.
 
-NOTE: _OpenJDK 8_ can be used, but for production and critical environments _Oracle Java 8_ is recommended.
+NOTE: _OpenJDK 8_ can be used, but for production and critical environments _Oracle Java SE Development Kit 8_ is recommended.
 
 [NOTE]
 ====

--- a/opennms-doc/guide-install/src/asciidoc/text/opennms/introduction.adoc
+++ b/opennms-doc/guide-install/src/asciidoc/text/opennms/introduction.adoc
@@ -3,92 +3,41 @@
 :imagesdir: ../../images
 
 [[gi-basic-install-opennms]]
-== Basic Installation of OpenNMS
+== Installation Overview
 
 The _OpenNMS_ platform can be installed in several ways.
-This guide describes the installation of the platform on _RHEL-_, _Debian-_ and _Microsoft Windows_ based operation systems.
-Installable pre-compiled software packages are provided through _RPM_ and _Debian_ repository servers.
-Running _OpenNMS_ requires the following components:
+This guide describes the installation of the platform on _Red Hat Enterprise Linux (RHEL)_-based, _Debian_-based and _Microsoft Windows_ 
+operating systems. The following abbreviations will be used to refer to the following operating systems:
 
-* Internet access to download and verify installation packages from public repository server
-* Installed <<gi-install-oracle-java, Oracle Java 8>> environment
-* PostgreSQL 9.1+ data base
-* Set link to section which describes to install with RRDTool.
-  Optional link:http://oss.oetiker.ch/rrdtool/[RRDtool] to persist long term performance data
+* _RHEL_: Red Hat Enterprise Linux 6 or higher, CentOS 6 or higher, Fedora 20 or higher
+* _Debian_: Debian 7 or higher, Ubuntu 14.04 or higher
+* _Microsoft Windows_: Windows 8.1, Windows Server 2012, Windows 10
+
+Installable, precompiled software packages are provided through _RHEL Yum_ and _Debian APT_ repository servers and from the
+link:https://sourceforge.net/projects/opennms/files/OpenNMS/[OpenNMS Sourceforge project page].
+Installing _OpenNMS_ requires the following prerequisites:
+
+* A configured <<gi-install-opennms-repo-releases, Yum or APT Package Repository>> for your platform (Linux only)
+* Internet access to download and verify _OpenNMS_ packages from the Yum or APT package repositories
+* <<gi-install-oracle-java, Oracle Java Development Kit 8>> environment
+* PostgreSQL database version 9.1 or higher
+* A time-series database engine to persist long-term performance data:
+** JRobin: The default choice. JRobin is included inside OpenNMS and doesn't require additional software to be installed.
+** <<gi-rrdtool-time-series-database, RRDtool>>: A higher performance, file-based database.
+** <<gi-install-ts-newts, Newts>>: The highest performance solution. Newts uses an Apache Cassandra database for clustered scalability.
 
 NOTE: _OpenJDK 8_ can be used, but for production and critical environments _Oracle Java 8_ is recommended.
 
-NOTE: `${OPENNMS_HOME}` is referred to the path _OpenNMS_ is installed to.
-      On _RHEL-based_ systems it is `/opt/opennms` on _Debian-based_ systems it is `/usr/share/opennms`.
-      The environment in _Microsoft Windows_ can refer to `C:\Program Files\opennms`
+[NOTE]
+====
+`${OPENNMS_HOME}` will be used to refer to the path where _OpenNMS_ is installed. It is different
+depending on your platform:
+
+* _RHEL_: `/opt/opennms`
+* _Debian_: `/usr/share/opennms`
+* _Microsoft Windows_: `C:\Program Files\opennms`
+====
 
 With the _opennms_ meta package all dependencies needed for the components mentioned above are maintained.
 The following sections describe how to install _OpenNMS_ on a single system.
-Dependencies for _Java_ and the _PostgreSQL_ data base are maintained with the _opennms_ meta installation package.
-
-[[gi-install-opennms-repo-releases]]
-=== Repositories for Releases
-
-Installation packages are available for different releases of _OpenNMS_.
-The configuration of the repository decides which _OpenNMS_ release will be installed.
-
-The following releases are available for installation:
-
-._OpenNMS_ release name convention
-[options="header, autowidth"]
-|===
-| Release                   | Description
-| `stable`                  | Latest stable release
-| `testing`                 | Release candidate for next stable
-| `snapshot`                | Latest successful develop build
-| `branches/${BRANCH-NAME}` | Install from a specific branch name, e.g. `branches/features-newts` installs the repository for the _Newts_ development branch.
-                              Branches can be found in http://yum.opennms.org/branches/ or http://debian.opennms.org/dists/branches/
-|===
-
-To install a different release the repository files have to be installed and manually modified.
-
-==== Specific Release on RHEL-based system
-
-.Installation of release specific repositories
-[source, shell]
-----
-rpm -Uvh http://yum.opennms.org/repofiles/opennms-repo-${RELEASE}-rhel7.noarch.rpm<1>
-rpm --import http://yum.opennms.org/OPENNMS-GPG-KEY
-----
-
-<1> Replace `${RELEASE}` with a release name like `testing` or `snapshot`.
-
-Install _OpenNMS_ with _YUM_ following the normal installation procedure.
-
-.Installation of the full _OpenNMS_ application with all dependencies
-[source, shell]
-----
-yum install opennms
-----
-
-TIP: Verify the release of _OpenNMS_ packages with `yum info opennms`.
-
-==== Specific Release on Debian-based system
-
-Create a new apt source file (eg: `/etc/apt/sources.list.d/opennms.list`), and add the following 2 lines:
-
-.Package repository configuration for Debian-based systems
-[source, shell]
-----
-deb http://debian.opennms.org ${RELEASE} main <1>
-deb-src http://debian.opennms.org ${RELEASE} main <1>
-----
-
-<1> Replace `${RELEASE}` with a release name like `testing` or `snapshot`.
-
-Import the packages' authentication key with the following command:
-
-.GPG key import for Debian-based systems
-[source, shell]
-----
-wget -O - http://debian.opennms.org/OPENNMS-GPG-KEY | apt-key add -
-----
-
-Run `apt-get update` and install _OpenNMS_ with _apt_ following the normal installation procedure.
-
-TIP: Verify the release of _OpenNMS_ packages with `apt-cache show opennms`.
+Dependencies for _Java_ and the _PostgreSQL_ database are maintained with the _opennms_ meta installation package.

--- a/opennms-doc/guide-install/src/asciidoc/text/opennms/repository.adoc
+++ b/opennms-doc/guide-install/src/asciidoc/text/opennms/repository.adoc
@@ -1,0 +1,58 @@
+
+// Allow GitHub image rendering
+:imagesdir: ../../images
+
+[[gi-install-opennms-repo-releases]]
+== Yum/APT Package Repositories
+
+Installation packages are available for different releases of _OpenNMS_. You need to choose which
+release you would like to run and then configure your package repository to point to that release.
+Configuring a package repository will enable you to install and update the software by using
+standard Linux software update tools like _yum_ and _apt_.
+
+The following package repositories are available:
+
+._OpenNMS_ package repositories
+[options="header, autowidth"]
+|===
+| Release                   | Description
+| `stable`                  | Latest stable release. This version is recommended for all users.
+| `testing`                 | Release candidate for the next stable release.
+| `snapshot`                | Latest successful development build, the "nightly" build.
+| `branches/${BRANCH-NAME}` | Install from a specific branch name for testing a specific feature that is under development.
+                              Available branches can be found in http://yum.opennms.org/branches/ or http://debian.opennms.org/dists/branches/.
+|===
+
+To install a different release the repository files have to be installed and manually modified.
+
+=== RHEL Yum Repository
+
+.Install the configuration for a package repository
+[source, shell]
+----
+rpm -Uvh http://yum.opennms.org/repofiles/opennms-repo-${RELEASE}-rhel7.noarch.rpm <1>
+rpm --import http://yum.opennms.org/OPENNMS-GPG-KEY
+----
+
+<1> Replace `${RELEASE}` with a release name like `stable` (recommended), `testing`, or `snapshot`.
+
+=== Debian APT Repository
+
+Create a new apt source file (eg: `/etc/apt/sources.list.d/opennms.list`), and add the following 2 lines:
+
+.Package repository configuration for Debian-based systems
+[source, shell]
+----
+deb http://debian.opennms.org ${RELEASE} main <1>
+deb-src http://debian.opennms.org ${RELEASE} main <1>
+----
+
+<1> Replace `${RELEASE}` with a release name like `stable` (recommended), `testing`, or `snapshot`.
+
+Import the packages' authentication key with the following command:
+
+.GPG key import for Debian-based systems
+[source, shell]
+----
+wget -O - http://debian.opennms.org/OPENNMS-GPG-KEY | apt-key add -
+----

--- a/opennms-doc/guide-install/src/asciidoc/text/opennms/repository.adoc
+++ b/opennms-doc/guide-install/src/asciidoc/text/opennms/repository.adoc
@@ -5,10 +5,9 @@
 [[gi-install-opennms-repo-releases]]
 == Yum/APT Package Repositories
 
-Installation packages are available for different releases of _OpenNMS_. You need to choose which
-release you would like to run and then configure your package repository to point to that release.
-Configuring a package repository will enable you to install and update the software by using
-standard Linux software update tools like _yum_ and _apt_.
+Installation packages are available for different releases of _OpenNMS_.
+You need to choose which release you would like to run and then configure your package repository to point to that release.
+Configuring a package repository will enable you to install and update the software by using standard Linux software update tools like _yum_ and _apt_.
 
 The following package repositories are available:
 

--- a/opennms-doc/guide-install/src/asciidoc/text/opennms/rhel.adoc
+++ b/opennms-doc/guide-install/src/asciidoc/text/opennms/rhel.adoc
@@ -2,8 +2,11 @@
 // Allow GitHub image rendering
 :imagesdir: ../../images
 
+[[gi-install-opennms]]
+== OpenNMS
+
 [[gi-install-opennms-rhel]]
-=== Installing on RHEL-based system
+=== RHEL
 
 This section describes how to install the _OpenNMS_ platform on _CentOS 7.1_.
 The setup process is described in the following steps:
@@ -41,6 +44,8 @@ The following packages will be automatically installed:
 * _jdk1.8_: _Oracle Java 8_ environment from _OpenNMS_ respository
 * _postgresql_: _PostgreSQL_ database server from distribution repository
 * _postgresql-libs_: _PostgreSQL_ database from distribution repository
+
+TIP: Verify the version of the _OpenNMS_ packages that was installed with `yum info opennms`.
 
 With the successful installed packages the _OpenNMS_ platform is installed in the following directory structure:
 

--- a/opennms-doc/guide-install/src/asciidoc/text/opennms/rhel.adoc
+++ b/opennms-doc/guide-install/src/asciidoc/text/opennms/rhel.adoc
@@ -5,29 +5,21 @@
 [[gi-install-opennms]]
 == OpenNMS
 
+After configuring the package repository, you are ready to install the _OpenNMS_ packages,
+configure the database, and initialize the _OpenNMS_ platform.
+
 [[gi-install-opennms-rhel]]
 === RHEL
 
 This section describes how to install the _OpenNMS_ platform on _CentOS 7.1_.
 The setup process is described in the following steps:
 
-. Install _OpenNMS_ _YUM_ repository server with GPG key to verify packages
 . Installation of the _opennms_ meta package which handles all dependencies
 . Initialize _PostgreSQL_ database and configure access
 . Initialize _OpenNMS_ and first start of the application
 
-[[gi-install-opennms-yum-repo]]
-==== Setup OpenNMS YUM repository
-
-.Installation of stable repository and GPG key
-[source, shell]
-----
-rpm -Uvh http://yum.opennms.org/repofiles/opennms-repo-stable-rhel7.noarch.rpm
-rpm --import http://yum.opennms.org/OPENNMS-GPG-KEY
-----
-
 [[gi-install-opennms-rhel-package]]
-==== Install OpenNMS package
+==== Install OpenNMS
 
 .Installation of the full application with all dependencies like PostgreSQL and Java
 [source, shell]
@@ -41,7 +33,7 @@ The following packages will be automatically installed:
 * _jicmp6_ and _jicmp_: _Java_ bridge to allow sending _ICMP messages_ from _OpenNMS_ repository.
 * _opennms-core_: _OpenNMS_ core services, e.g. _Provisiond_, _Pollerd_ and _Collectd_ from _OpenNMS_ repository.
 * _opennms-webapp-jetty_: _OpenNMS_ web application from _OpenNMS_ repository
-* _jdk1.8_: _Oracle Java 8_ environment from _OpenNMS_ respository
+* _jdk1.8_: _Oracle Java SE Development Kit 8_ environment from _OpenNMS_ respository
 * _postgresql_: _PostgreSQL_ database server from distribution repository
 * _postgresql-libs_: _PostgreSQL_ database from distribution repository
 

--- a/opennms-doc/guide-install/src/asciidoc/text/opennms/windows.adoc
+++ b/opennms-doc/guide-install/src/asciidoc/text/opennms/windows.adoc
@@ -3,7 +3,7 @@
 :imagesdir: ../../images
 
 [[gi-install-opennms-windows]]
-=== Install on Microsoft Windows Systems
+=== Microsoft Windows
 
 IMPORTANT: This guide does not apply to OpenNMS Meridian, which can be installed only on Red Hat Enterprise Linux or CentOS systems.
 

--- a/opennms-doc/guide-install/src/asciidoc/text/opennms/windows.adoc
+++ b/opennms-doc/guide-install/src/asciidoc/text/opennms/windows.adoc
@@ -25,7 +25,7 @@ The setup process is described in the following steps:
 . First start of the _OpenNMS_ application
 
 [[gi-install-opennms-deb-prepare-pg]]
-==== Installation PostgreSQL
+==== Install PostgreSQL
 
 _PostgreSQL_ is available for _Microsoft Windows_ and latest version can be downloaded from link:http://www.enterprisedb.com/products-services-training/pgdownload#windows[Download PostgreSQL] page.
 Follow the on-screen instructions of the graphical installer.

--- a/opennms-doc/guide-install/src/asciidoc/text/r/debian.adoc
+++ b/opennms-doc/guide-install/src/asciidoc/text/r/debian.adoc
@@ -3,7 +3,7 @@
 :imagesdir: ../../images
 
 [[gi-install-r-debian]]
-=== Installing on Debian-based systems
+=== Debian
 
 This section describes how to install _R_ on a _Debian_-based system.
 

--- a/opennms-doc/guide-install/src/asciidoc/text/r/introduction.adoc
+++ b/opennms-doc/guide-install/src/asciidoc/text/r/introduction.adoc
@@ -3,12 +3,13 @@
 :imagesdir: ../../images
 
 [[gi-install-r]]
-== Installing R
+== R Statistics System
 
 link:https://www.r-project.org/[R] is a free software environment for statistical computing and graphics.
-_OpenNMS_ can leverage the power of _R_ for forecasting and advanced numerical computations of time series data.
+_OpenNMS_ can leverage the power of _R_ for forecasting and advanced calculations on collected time series data.
 
-_OpenNMS_ interfaces with _R_ via _stdin_ and _stdout_, and for this reason, _R_ must be installed on the same host.
+_OpenNMS_ interfaces with _R_ via _stdin_ and _stdout_, and for this reason, _R_ must be installed on the same host
+as _OpenNMS_.
 Note that installing _R_ is optional, and not required by any of the core components.
 
 IMPORTANT: The _R_ integration is not currently supported on _Microsoft Windows_ systems.

--- a/opennms-doc/guide-install/src/asciidoc/text/r/rhel.adoc
+++ b/opennms-doc/guide-install/src/asciidoc/text/r/rhel.adoc
@@ -3,7 +3,7 @@
 :imagesdir: ../../images
 
 [[gi-install-r-rhel]]
-=== Installing on RHEL-based systems
+=== RHEL
 
 This section describes how to install _R_ on a _RHEL_ based system.
 

--- a/opennms-doc/guide-install/src/asciidoc/text/rrdtool/installation.adoc
+++ b/opennms-doc/guide-install/src/asciidoc/text/rrdtool/installation.adoc
@@ -65,7 +65,7 @@ NOTE: With OpenNMS 17.0.0 it is preferred to use _jrrd2_ instead of _jrrd_.
       The _jrrd2_ module is improved for performance by adding multithreading capabilities.
 
 [[gi-rrdtool-configure-opennms]]
-=== Configuration of OpenNMS
+=== Configure {opennms-product-name}
 
 To configure _OpenNMS_ to use _RRDtool_ instead of _JRobin_ configure the following properties in `rrd-configuration.properties`.
 

--- a/opennms-doc/guide-install/src/asciidoc/text/rrdtool/installation.adoc
+++ b/opennms-doc/guide-install/src/asciidoc/text/rrdtool/installation.adoc
@@ -3,16 +3,16 @@
 :imagesdir: ../../images
 
 [[gi-rrdtool-time-series-database]]
-== RRDtool as Time Series Database
+== RRDtool
 
-In most _Open Source_ application link:http://oss.oetiker.ch/rrdtool[RRDtool] is often used and is the de-facto open standard for _Time Series Data_.
-The basic installation of _OpenNMS_ comes with _JRobin_ enabled and it is possible to persist _Time Series Data_ in _RRDtool_.
+In most _Open Source_ applications, link:http://oss.oetiker.ch/rrdtool[RRDtool] is often used and is the de-facto open standard for _Time Series Data_.
+The basic installation of _OpenNMS_ comes with _JRobin_ but it is simple to switch the system to use _RRDtool_ to persist _Time Series Data_.
 This section describes how to install _RRDtool_, the _jrrd2_ _OpenNMS Java Interface_ and how to configure _OpenNMS_ to use it.
+_RRDtool_ can be installed from the official package repositories provided by _RHEL_ and _Debian_ based _Linux_ distributions.
+
 
 [[gi-rrdtool-install]]
-=== RRDtool Installation
-
-_RRDtool_ can be installed from the official package repositories provided by _RHEL_ and _Debian_ based _Linux_ distributions.
+=== RHEL
 
 .Installation on RHEL/CentOS
 [source, shell]
@@ -20,14 +20,28 @@ _RRDtool_ can be installed from the official package repositories provided by _R
 yum install rrdtool
 ----
 
+[[gi-rrdtool-install-debian]]
+=== Debian
+
 .Installation of RRDtool on Debian/Ubuntu
 [source, shell]
 ----
 apt-get install rrdtool
 ----
 
+[[gi-rrdtool-install-source]]
+=== Source
+
+If you want the latest version of RRDtool, you may want to compile it from source. Instructions for doing so are at 
+link:https://oss.oetiker.ch/rrdtool/doc/rrdbuild.en.html[rrdbuild].
+
+IMPORTANT: The latest version of RRDtool may not always be compatible with the version of _OpenNMS_ that you want to run.
+           Please ask about RRDtool support on the discussion lists or chat rooms if you have any problems running a
+           new version of RRDtool.
+
 NOTE: If you want to install the latest _RRDtool_ from source, make sure the `rrdtool` binary is in search path.
-      To make the setup easier, you can link the binary to `/usr/bin/rrdtool` which is the location _OpenNMS_ will expect the executable binary.
+      To make the setup easier, you can link the binary to `/usr/bin/rrdtool` which is the location where _OpenNMS_ will expect
+      to find the executable binary.
 
 [[gi-jrrd2-install]]
 === Install jrrd2 Interface


### PR DESCRIPTION
General cleanup in the install guide:
* Made language in some sections more natural.
* Made section headers more terse so that they look better and are easier to read in the table of contents.
* Made the terminology more uniform between sections.
* Got rid of excess "Installing..." and "Setup..." terms which are redundant since this is an installation guide.
* Moved the yum/apt repo instructions to a separate adoc file.

Bamboo: http://bamboo.internal.opennms.com:8085/browse/OPENNMS-ONMS676