### PR TITLE
HZN-568: Final changes to get Minion Syslogd working...?

### DIFF
--- a/container/features/pom.xml
+++ b/container/features/pom.xml
@@ -213,6 +213,7 @@
             <feature>opennms-syslogd-listener-javanet</feature>
             <feature>opennms-syslogd-listener-camel-netty</feature>
             <feature>opennms-syslogd-listener-nio</feature>
+            <feature>opennms-syslogd-handler-default</feature>
             <feature>opennms-syslogd-handler-kafka</feature>
             <feature>opennms-syslogd-handler-minion</feature>
             <!-- <feature>opennms-webapp</feature> -->

--- a/container/karaf/src/main/filtered-resources/etc/custom.properties
+++ b/container/karaf/src/main/filtered-resources/etc/custom.properties
@@ -29,6 +29,7 @@ karaf.systemBundlesStartLevel=50
 #
 
 org.osgi.framework.system.packages.extra=org.apache.karaf.branding,\
+        sun.misc,\
         sun.net.spi.nameservice,\
         javax.jms;version=1.1.0,\
         javax.servlet;javax.servlet.annotation;javax.servlet.descriptor;javax.servlet.http;javax.servlet.resources;version=2.6,\

--- a/features/jmx-config-generator/pom.xml
+++ b/features/jmx-config-generator/pom.xml
@@ -30,12 +30,14 @@
                 <groupId>org.opennms.maven.plugins</groupId>
                 <artifactId>features-maven-plugin</artifactId>
                 <configuration>
+                    <features>
+                        <feature>guava</feature>
+                        <feature>commons-io</feature>
+                    </features>
                     <bundles>
                         <bundle>mvn:org.opennms.features/jmxconfiggenerator/${project.version}</bundle>
-                        <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.jaxb-impl/2.2.6_1</bundle>
                         <bundle>wrap:mvn:args4j/args4j/${args4jVersion}</bundle>
                         <bundle>wrap:mvn:org.jvnet.opendmk/jmxremote_optional/${jmxremote.optional.version}</bundle>
-                        <bundle>mvn:com.google.guava/guava/${guavaVersion}</bundle>
                         <bundle>mvn:org.apache.velocity/velocity/${velocity.version}</bundle>
                     </bundles>
                 </configuration>
@@ -95,11 +97,13 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
             <version>${slf4jVersion}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>args4j</groupId>
@@ -114,17 +118,20 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
+            <!-- Provided by a Karaf feature -->
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
+            <!-- Provided by a Karaf feature -->
+            <scope>provided</scope>
         </dependency>
 
         <!-- Testing -->
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <scope>test</scope>
         </dependency>
     </dependencies>
     <pluginRepositories>

--- a/features/vaadin-dashboard/src/main/java/org/opennms/features/vaadin/dashboard/config/DashletSelector.java
+++ b/features/vaadin-dashboard/src/main/java/org/opennms/features/vaadin/dashboard/config/DashletSelector.java
@@ -87,7 +87,7 @@ public class DashletSelector implements BundleActivator {
      */
     public void bind(DashletFactory dashletFactory) {
         if (dashletFactory != null) {
-            LoggerFactory.getLogger(DashletSelector.class).warn("bind service " + dashletFactory.getClass().getName());
+            LoggerFactory.getLogger(DashletSelector.class).info("bind service " + dashletFactory.getClass().getName());
 
             m_serviceInterfaceMap.put(dashletFactory.getName(), dashletFactory);
             fireServiceListChangedListeners();
@@ -103,7 +103,7 @@ public class DashletSelector implements BundleActivator {
      */
     public void unbind(DashletFactory dashletFactory) {
         if (dashletFactory != null) {
-            LoggerFactory.getLogger(DashletSelector.class).warn("unbind service " + dashletFactory.getClass().getName());
+            LoggerFactory.getLogger(DashletSelector.class).info("unbind service " + dashletFactory.getClass().getName());
 
             m_serviceInterfaceMap.remove(dashletFactory.getName());
             fireServiceListChangedListeners();

--- a/features/vaadin-jmxconfiggenerator/pom.xml
+++ b/features/vaadin-jmxconfiggenerator/pom.xml
@@ -66,20 +66,16 @@
             <classifier>sources</classifier>
             <scope>provided</scope>
         </dependency>
+       <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
         <dependency>
             <groupId>org.opennms.features</groupId>
             <artifactId>jmxconfiggenerator</artifactId>
             <version>${project.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>javax.xml.bind</groupId>
-                    <artifactId>jaxb-api</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.sun.xml.bind</groupId>
-                    <artifactId>jaxb-impl</artifactId>
-                </exclusion>
-            </exclusions>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.opennms.dependencies</groupId>

--- a/opennms-full-assembly/src/main/filtered-resources/etc/org.apache.karaf.features.cfg
+++ b/opennms-full-assembly/src/main/filtered-resources/etc/org.apache.karaf.features.cfg
@@ -14,7 +14,6 @@ featuresBoot=karaf-framework,ssh,config,features,management,\
   deployer,\
   opennms-jaas-login-module,\
   datachoices, \
-  opennms-syslogd-handler-default,\
   opennms-topology-runtime-browsers,\
   opennms-topology-runtime-linkd,\
   opennms-topology-runtime-simple,\

--- a/opennms-full-assembly/src/main/filtered-resources/etc/org.apache.karaf.features.cfg
+++ b/opennms-full-assembly/src/main/filtered-resources/etc/org.apache.karaf.features.cfg
@@ -14,6 +14,7 @@ featuresBoot=karaf-framework,ssh,config,features,management,\
   deployer,\
   opennms-jaas-login-module,\
   datachoices, \
+  opennms-syslogd-handler-default,\
   opennms-topology-runtime-browsers,\
   opennms-topology-runtime-linkd,\
   opennms-topology-runtime-simple,\


### PR DESCRIPTION
The Syslog receiver blueprint was missing from the OpenNMS feature repository. This feature was added and also added to featuresBoot so that it's installed by default on OpenNMS.

* JIRA: http://issues.opennms.org/browse/HZN-568
* Bamboo: http://bamboo.internal.opennms.com:8085/browse/OPENNMS-ONMS682