### PR TITLE
Added post-integration-test cleanup of Karaf feature repositories

### DIFF
--- a/core/test-api/karaf/pom.xml
+++ b/core/test-api/karaf/pom.xml
@@ -51,7 +51,7 @@
               <useRepositoryLayout>true</useRepositoryLayout>
               <excludeTypes>tar.gz</excludeTypes>
               <excludeGroupIds>org.opennms</excludeGroupIds>
-              <outputDirectory>target/paxexam/test-repo</outputDirectory>
+              <outputDirectory>${project.build.directory}/paxexam/test-repo</outputDirectory>
             </configuration>
           </execution>
         </executions>
@@ -149,6 +149,26 @@
             </goals>
           </execution>
         </executions>
+      </plugin>
+      <plugin> 
+        <artifactId>maven-clean-plugin</artifactId> 
+        <executions> 
+          <execution> 
+            <id>cleanup-integration-tests</id> 
+            <phase>post-integration-test</phase> 
+            <goals> 
+              <goal>clean</goal> 
+            </goals> 
+            <configuration> 
+              <excludeDefaultDirectories>true</excludeDefaultDirectories> 
+              <filesets> 
+                <fileset> 
+                  <directory>${project.build.directory}/paxexam/test-repo</directory> 
+                </fileset> 
+              </filesets> 
+            </configuration> 
+          </execution> 
+        </executions> 
       </plugin>
     </plugins>
   </build>

--- a/integration-tests/config/pom.xml
+++ b/integration-tests/config/pom.xml
@@ -30,7 +30,7 @@
               <excludeTypes>tar.gz</excludeTypes>
               <!-- TODO: Remove this when we add tests for OpenNMS features -->
               <excludeGroupIds>org.opennms</excludeGroupIds>
-              <outputDirectory>target/paxexam/test-repo</outputDirectory>
+              <outputDirectory>${project.build.directory}/paxexam/test-repo</outputDirectory>
             </configuration>
           </execution>
         </executions>
@@ -63,6 +63,26 @@
               <goal>integration-test</goal>
               <goal>verify</goal>
             </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <artifactId>maven-clean-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>cleanup-integration-tests</id>
+            <phase>post-integration-test</phase>
+            <goals>
+              <goal>clean</goal>
+            </goals>
+            <configuration>
+              <excludeDefaultDirectories>true</excludeDefaultDirectories>
+              <filesets>
+                <fileset>
+                  <directory>${project.build.directory}/paxexam/test-repo</directory>
+                </fileset>
+              </filesets>
+            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/opennms-full-assembly/pom.xml
+++ b/opennms-full-assembly/pom.xml
@@ -308,10 +308,30 @@
                 <feature>opennms-discovery-distPollerDaoMinion</feature>
 
               </features>
-              <repository>target/features-repo</repository>
+              <repository>${project.build.directory}/features-repo</repository>
             </configuration>
           </execution>
         </executions>
+      </plugin>
+      <plugin> 
+        <artifactId>maven-clean-plugin</artifactId> 
+        <executions> 
+          <execution> 
+            <id>cleanup-integration-tests</id> 
+            <phase>post-integration-test</phase> 
+            <goals> 
+              <goal>clean</goal> 
+            </goals> 
+            <configuration> 
+              <excludeDefaultDirectories>true</excludeDefaultDirectories> 
+              <filesets> 
+                <fileset> 
+                  <directory>${project.build.directory}/features-repo</directory> 
+                </fileset> 
+              </filesets> 
+            </configuration> 
+          </execution> 
+        </executions> 
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
A lot of space is taken up by Karaf feature repositories that are built for integration tests. These repositories can be removed after the `package` and `integration-test` phases. This saves several hundred megabytes of disk space when running the build.

* Bamboo: http://bamboo.internal.opennms.com:8085/browse/OPENNMS-ONMS685
