### PR TITLE
NMS-8386: Requisitioning UI fails to load in modern browsers if used behind a proxy

### DIFF
--- a/opennms-webapp/src/main/webapp/admin/ng-requisitions/app/basehref.jsp
+++ b/opennms-webapp/src/main/webapp/admin/ng-requisitions/app/basehref.jsp
@@ -1,6 +1,5 @@
-<%@ page contentType="text/html;charset=UTF-8" language="java" %>
-<%@ page import="org.opennms.web.api.Util" %>
+<%@ page contentType="text/javascript; charset=UTF-8" pageEncoding="UTF-8" language="java" %>
 <%
-final String baseHref = Util.calculateUrlBase(request);
+final String baseHref = org.opennms.web.api.Util.calculateUrlBase(request);
 %>
 window.ONMS_BASE_HREF='<%=baseHref%>';


### PR DESCRIPTION
* JIRA: http://issues.opennms.org/browse/NMS-8386
* Bamboo: http://bamboo.internal.opennms.com:8085/browse/OPENNMS-ONMS689

Requisitioning UI fails to load in modern browsers if used behind a proxy.

I tested it with curl and the content-type is now reported correctly.