### PR TITLE
HZN-568: More final changes to get Minion Syslogd working :)

### DIFF
--- a/container/features/src/main/resources/features.xml
+++ b/container/features/src/main/resources/features.xml
@@ -735,6 +735,11 @@
       <feature>camel-blueprint</feature>
       <feature>camel-http</feature>
 
+      <!--
+      These classes are in the system classpath inside OpenNMS
+      <feature>opennms-syslogd</feature>
+      -->
+
       <bundle dependency="true">mvn:org.opennms.core/org.opennms.core.camel/${project.version}</bundle>
 
       <bundle>blueprint:mvn:org.opennms.features.events/org.opennms.features.events.syslog/${project.version}/xml/blueprint-syslog-handler-default</bundle>

--- a/container/features/src/main/resources/features.xml
+++ b/container/features/src/main/resources/features.xml
@@ -729,9 +729,13 @@
     </feature>
 
     <!-- TODO: Rename this. It's more of an Dominion-side syslog connection handler... -->
+    <!-- TODO: We can't use the opennms-core-camel feature here because it pulls in artifacts that conflict with the system classpath -->
     <feature name="opennms-syslogd-handler-default" description="OpenNMS :: Syslogd :: Handler :: Default" version="${project.version}">
+      <feature>activemq-camel</feature>
       <feature>camel-blueprint</feature>
-      <feature>opennms-syslogd</feature>
+      <feature>camel-http</feature>
+
+      <bundle dependency="true">mvn:org.opennms.core/org.opennms.core.camel/${project.version}</bundle>
 
       <bundle>blueprint:mvn:org.opennms.features.events/org.opennms.features.events.syslog/${project.version}/xml/blueprint-syslog-handler-default</bundle>
     </feature>

--- a/container/karaf/src/main/filtered-resources/etc/custom.properties
+++ b/container/karaf/src/main/filtered-resources/etc/custom.properties
@@ -729,6 +729,7 @@ org.osgi.framework.system.packages.extra=org.apache.karaf.branding,\
         org.opennms.netmgt.provision.persist.requisition;version=${opennms.osgi.version},\
         org.opennms.netmgt.rrd;version=${opennms.osgi.version},\
         org.opennms.netmgt.snmp;version=${opennms.osgi.version},\
+        org.opennms.netmgt.syslogd;version=${opennms.osgi.version},\
         org.opennms.netmgt.ticketd;version=${opennms.osgi.version},\
         org.opennms.netmgt.xml.event;version=${opennms.osgi.version},\
         org.opennms.netmgt.xml.eventconf;version=${opennms.osgi.version},\

--- a/features/events/syslog/blueprint-syslog-handler-default.xml
+++ b/features/events/syslog/blueprint-syslog-handler-default.xml
@@ -53,7 +53,7 @@
 
 		<route id="receiveSyslogConnection">
 			<from uri="activemq:broadcastSyslog"/>
-			<bean ref="unmarshaller"/>
+			<process ref="unmarshaller"/>
 			<!-- Update the SyslogdConfig on the message to the local config value -->
 			<bean ref="syslogdConfigProcessor"/>
 			<to uri="seda:syslogHandler"/>

--- a/features/events/syslog/src/main/java/org/opennms/netmgt/syslogd/SyslogConnection.java
+++ b/features/events/syslog/src/main/java/org/opennms/netmgt/syslogd/SyslogConnection.java
@@ -160,10 +160,12 @@ public class SyslogConnection implements Callable<Callable<?>> {
 
             return new SyslogProcessor(re.getEvent(), m_config.getNewSuspectOnMessage());
 
-        } catch (final UnsupportedEncodingException e1) {
-            LOG.debug("Failure to convert package", e1);
+        } catch (final UnsupportedEncodingException e) {
+            LOG.info("Failure to convert package", e);
         } catch (final MessageDiscardedException e) {
-            LOG.debug("Message discarded, returning without enqueueing event.", e);
+            LOG.info("Message discarded, returning without enqueueing event.", e);
+        } catch (final Throwable e) {
+            LOG.error("Unexpected exception while processing SyslogConnection", e);
         }
         return null;
     }

--- a/features/events/syslog/src/main/java/org/opennms/netmgt/syslogd/SyslogConnection.java
+++ b/features/events/syslog/src/main/java/org/opennms/netmgt/syslogd/SyslogConnection.java
@@ -122,6 +122,7 @@ public class SyslogConnection implements Callable<Callable<?>> {
 
     @XmlAttribute
     public byte[] getBytes() {
+        m_bytes.rewind();
         byte[] retval = new byte[m_bytes.remaining()];
         m_bytes.get(retval);
         m_bytes.rewind();

--- a/features/events/syslog/src/test/resources/etc/syslogd-cisco-configuration.xml
+++ b/features/events/syslog/src/test/resources/etc/syslogd-cisco-configuration.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<syslogd-configuration>
+    <configuration
+            syslog-port="10514"
+            new-suspect-on-message="false"
+            parser="org.opennms.netmgt.syslogd.CustomSyslogParser"
+            forwarding-regexp="^((.+?) (.*))\r?\n?$"
+            matching-group-host="2"
+            matching-group-message="3"
+            discard-uei="DISCARD-MATCHING-MESSAGES"
+            />
+
+    <ueiList>
+        <ueiMatch>
+            <match type="regex" expression="%SEC-6-IPACCESSLOGP:\s+list\s+(\w+)\s+denied\s+(\w+)\s+([0-9a-fA-F.:]{3,})\((\d+)\)\s+-&gt;\s+([0-9a-fA-F.:]{3,})\((\d+)\),\s+(\d+)\s+packets?" />
+            <uei>uei.opennms.org/vendor/cisco/syslog/SEC-6-IPACCESSLOGP/aclDeniedIPTraffic</uei>
+            <parameter-assignment matching-group="1" parameter-name="aclName" />
+            <parameter-assignment matching-group="2" parameter-name="ipProto" />
+            <parameter-assignment matching-group="3" parameter-name="srcAddress" />
+            <parameter-assignment matching-group="4" parameter-name="srcPort" />
+            <parameter-assignment matching-group="5" parameter-name="dstAddress" />
+            <parameter-assignment matching-group="6" parameter-name="dstPort" />
+            <parameter-assignment matching-group="7" parameter-name="packetCount" />
+        </ueiMatch>
+    </ueiList>
+
+</syslogd-configuration>


### PR DESCRIPTION
The opennms-syslogd-handler-default feature on OpenNMS installed some OSGi bundles that conflicted with classes in the system classpath. These changes should resolve that problem and hopefully get the Minion system tests working.

* JIRA: http://issues.opennms.org/browse/HZN-568
* Bamboo: http://bamboo.internal.opennms.com:8085/browse/OPENNMS-ONMS682
