### PR TITLE
Partial code for Karaf ITs with the system classpath

### DIFF
--- a/container/features/pom.xml
+++ b/container/features/pom.xml
@@ -339,7 +339,12 @@
       <groupId>org.opennms.features</groupId>
       <artifactId>org.opennms.features.discovery</artifactId>
       <version>${project.version}</version>
-      <type>pom</type>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.opennms.features.events</groupId>
+      <artifactId>org.opennms.features.events.syslog</artifactId>
+      <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/container/features/src/main/resources/features.xml
+++ b/container/features/src/main/resources/features.xml
@@ -699,9 +699,9 @@
 
       <feature>opennms-core</feature>
       <feature>opennms-core-camel</feature>
+      <feature>opennms-core-daemon</feature>
       <feature>opennms-core-db</feature>
       <feature>opennms-config</feature>
-      <feature>opennms-core-daemon</feature>
       <feature>opennms-dao-api</feature>
 
       <bundle>mvn:org.opennms.features.events/org.opennms.features.events.syslog/${project.version}</bundle>

--- a/core/test-api/karaf/src/main/java/org/opennms/core/test/karaf/KarafTestCase.java
+++ b/core/test-api/karaf/src/main/java/org/opennms/core/test/karaf/KarafTestCase.java
@@ -30,6 +30,7 @@ package org.opennms.core.test.karaf;
 
 import static org.ops4j.pax.exam.CoreOptions.maven;
 import static org.ops4j.pax.exam.CoreOptions.provision;
+import static org.ops4j.pax.exam.CoreOptions.systemPackages;
 import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.debugConfiguration;
 import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.editConfigurationFilePut;
 import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.karafDistributionConfiguration;
@@ -59,6 +60,7 @@ import org.ops4j.pax.exam.Option;
 import org.ops4j.pax.exam.ProbeBuilder;
 import org.ops4j.pax.exam.TestProbeBuilder;
 import org.ops4j.pax.exam.karaf.options.LogLevelOption;
+import org.ops4j.pax.exam.options.MavenUrlReference;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.Constants;
 import org.osgi.framework.ServiceReference;
@@ -137,11 +139,7 @@ public abstract class KarafTestCase {
         Option[] options = new Option[]{
             // Use Karaf as the container
             karafDistributionConfiguration().frameworkUrl(
-                maven()
-                    .groupId("org.apache.karaf")
-                    .artifactId("apache-karaf")
-                    .type("tar.gz")
-                    .version(getKarafVersion()))
+                getFrameworkUrl())
                 .karafVersion(getKarafVersion())
                 .name("Apache Karaf")
                 .unpackDirectory(new File("target/paxexam/")
@@ -208,7 +206,33 @@ public abstract class KarafTestCase {
             options = Arrays.copyOf(options, options.length + 1);
             options[options.length -1] = debugConfiguration("8889", true);
         }
+
+        String[] systemPackages = getSystemPackages();
+        if (systemPackages.length > 0) {
+            options = Arrays.copyOf(options, options.length + 1);
+            options[options.length -1] = systemPackages(systemPackages);
+        }
+
         return options;
+    }
+
+    /**
+     * Use the vanilla Apache Karaf container. Override this method to use
+     * a different Karaf-compatible framework artifact.
+     */
+    protected MavenUrlReference getFrameworkUrl() {
+        return maven()
+                .groupId("org.apache.karaf")
+                .artifactId("apache-karaf")
+                .type("tar.gz")
+                .version(getKarafVersion());
+    }
+
+    /**
+     * Override this method to add system packages to the test container.
+     */
+    protected String[] getSystemPackages() {
+        return new String[0];
     }
 
     protected void addFeaturesUrl(String url) {

--- a/opennms-full-assembly/pom.xml
+++ b/opennms-full-assembly/pom.xml
@@ -168,6 +168,12 @@
             <goals>
               <goal>testCompile</goal>
             </goals>
+            <configuration>
+              <source>1.8</source>
+              <target>1.8</target>
+              <encoding>UTF-8</encoding>
+              <optimize>true</optimize>
+            </configuration>
           </execution>
         </executions>
       </plugin> 

--- a/opennms-full-assembly/src/test/java/org/opennms/assemblies/karaf/FeaturesBootKarafIT.java
+++ b/opennms-full-assembly/src/test/java/org/opennms/assemblies/karaf/FeaturesBootKarafIT.java
@@ -1,0 +1,103 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2014-2015 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2015 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.assemblies.karaf;
+
+import static org.ops4j.pax.exam.CoreOptions.maven;
+
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.ops4j.pax.exam.junit.PaxExam;
+import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
+import org.ops4j.pax.exam.spi.reactors.PerMethod;
+
+@RunWith(PaxExam.class)
+@ExamReactorStrategy(PerMethod.class)
+@Ignore("This doesn't work because of problems with the system classpath")
+public class FeaturesBootKarafIT extends OnmsKarafTestCase {
+
+	/**
+	 * This test attempts to install all features from the OpenNMS
+	 * featuresBoot list in:
+	 * 
+	 * src/main/filtered-resources/etc/org.apache.karaf.features.cfg
+	 */
+	@Test
+	public void testInstallAllOpenNMSFeatures() {
+		addFeaturesUrl(maven().groupId("org.opennms.container").artifactId("karaf").version("19.0.0-SNAPSHOT").type("xml").classifier("features").getURL());
+		addFeaturesUrl(maven().groupId("org.opennms.karaf").artifactId("opennms").version("19.0.0-SNAPSHOT").type("xml").classifier("features").getURL());
+
+		for (String feature : new String[] {
+			"karaf-framework",
+			"ssh",
+			"config",
+			"features",
+			"management",
+			"http",
+			"http-whiteboard",
+			"kar",
+			"deployer",
+			"opennms-jaas-login-module",
+			"datachoices",
+			"opennms-topology-runtime-browsers",
+			"opennms-topology-runtime-linkd",
+			"opennms-topology-runtime-simple",
+			"opennms-topology-runtime-vmware",
+			"opennms-topology-runtime-application",
+			"opennms-topology-runtime-bsm",
+			"osgi-nrtg-local",
+			"vaadin-node-maps",
+			"vaadin-snmp-events-and-metrics",
+			"vaadin-dashboard",
+			"dashlet-summary",
+			"dashlet-alarms",
+			"dashlet-bsm",
+			"dashlet-map",
+			"dashlet-image",
+			"dashlet-charts",
+			"dashlet-rtc",
+			"dashlet-rrd",
+			"dashlet-ksc",
+			"dashlet-topology",
+			"dashlet-url",
+			"dashlet-surveillance",
+			"vaadin-surveillance-views",
+			"vaadin-jmxconfiggenerator",
+			"vaadin-opennms-pluginmanager",
+			"vaadin-adminpage",
+			"org.opennms.features.bsm.shell-commands"
+		}) {
+			System.out.println("Installing feature: " + feature);
+			installFeature(feature);
+			System.out.println("Installed feature: " + feature);
+		}
+
+		System.out.println(executeCommand("features:list -i"));
+	}
+}

--- a/opennms-full-assembly/src/test/java/org/opennms/assemblies/karaf/OnmsKarafTestCase.java
+++ b/opennms-full-assembly/src/test/java/org/opennms/assemblies/karaf/OnmsKarafTestCase.java
@@ -1,0 +1,88 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2014-2015 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2015 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.assemblies.karaf;
+
+import static org.ops4j.pax.exam.CoreOptions.maven;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Properties;
+import java.util.stream.Collectors;
+
+import org.opennms.core.test.karaf.KarafTestCase;
+import org.ops4j.pax.exam.options.MavenUrlReference;
+
+/**
+ * @deprecated This test base class doesn't work because our Karaf 
+ * container artifact:
+ * 
+ * mvn:org.opennms.container/karaf/${version}/tar.gz
+ * 
+ * isn't packaged with a top-level product directory like the Apache Karaf
+ * tar.gz artifacts are.
+ */
+public class OnmsKarafTestCase extends KarafTestCase {
+
+	/**
+	 * Use the OpenNMS-modified Karaf container.
+	 */
+	@Override
+	protected MavenUrlReference getFrameworkUrl() {
+		return maven()
+				.groupId("org.opennms.container")
+				.artifactId("karaf")
+				.type("tar.gz")
+				.version("19.0.0-SNAPSHOT");
+	}
+
+	/**
+	 * Fetch the OpenNMS system classpath from our modified custom.properties file.
+	 */
+	@Override
+	protected String[] getSystemPackages() {
+		Properties customProperties = new Properties();
+		try {
+			customProperties.load(new FileInputStream("../container/karaf/src/main/filtered-resources/etc/custom.properties"));
+		} catch (IOException e) {
+			System.err.println("Unexpected error while trying to load system properties");
+			e.printStackTrace();
+			return new String[0];
+		}
+
+		String classpath =  customProperties.getProperty("org.osgi.framework.system.packages.extra");
+		System.out.println("System classpath: " + classpath);
+		return Arrays.stream(classpath.split(","))
+			// Remove all of the version constraints
+			.map(s -> {
+				return s.replaceAll(";.*$", "");
+			})
+			.collect(Collectors.toList()).toArray(new String[0]);
+	}
+}


### PR DESCRIPTION
Addition of not-yet-working integration test code that runs with the OpenNMS system classpath. Also fixed a dependency monkey failure.

* Bamboo: http://bamboo.internal.opennms.com:8085/browse/OPENNMS-ONMS699
