### PR TITLE
Fixed status values inside JDBCMonitor and WebMonitor

### DIFF
--- a/opennms-services/src/main/java/org/opennms/netmgt/poller/monitors/JolokiaBeanMonitor.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/poller/monitors/JolokiaBeanMonitor.java
@@ -254,7 +254,7 @@ final public class JolokiaBeanMonitor extends AbstractServiceMonitor {
                 LOGGER.debug(reason, e);
                 serviceStatus = PollStatus.unavailable(reason);
             } catch (J4pException e) {
-                String reason = "J4pExecptin during Jolokia monitor call: "+ e.getMessage();
+                String reason = J4pException.class.getSimpleName() + " during Jolokia monitor call: "+ e.getMessage();
                 LOGGER.debug(reason, e);
                 serviceStatus = PollStatus.unavailable(reason);
             }

--- a/opennms-services/src/main/java/org/opennms/netmgt/poller/monitors/WebMonitor.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/poller/monitors/WebMonitor.java
@@ -166,10 +166,16 @@ public class WebMonitor extends AbstractServiceMonitor {
 
         } catch (IOException e) {
             LOG.info(e.getMessage());
+            pollStatus = PollStatus.unavailable(e.getMessage());
         } catch (URISyntaxException e) {
             LOG.info(e.getMessage());
-        } catch (GeneralSecurityException gse) {
-            LOG.error("Unable to set SSL trust to allow self-signed certificates", gse);
+            pollStatus = PollStatus.unavailable(e.getMessage());
+        } catch (GeneralSecurityException e) {
+            LOG.error("Unable to set SSL trust to allow self-signed certificates", e);
+            pollStatus = PollStatus.unavailable("Unable to set SSL trust to allow self-signed certificates");
+        } catch (Throwable e) {
+            LOG.error("Unexpected exception while running " + getClass().getName(), e);
+            pollStatus = PollStatus.unavailable("Unexpected exception: " + e.getMessage());
         } finally {
             IOUtils.closeQuietly(clientWrapper);
         }

--- a/opennms-util/src/main/java/org/opennms/core/utils/DBTools.java
+++ b/opennms-util/src/main/java/org/opennms/core/utils/DBTools.java
@@ -69,6 +69,11 @@ public class DBTools {
     public static final String DEFAULT_JDBC_DRIVER = "com.sybase.jdbc2.jdbc.SybDriver";
 
     /**
+     * PostgreSQL JDBC driver
+     */
+    public static final String POSTGRESQL_JDBC_DRIVER = "org.postgresql.Driver";
+
+    /**
      * Default user to use when connecting to the database. Defaults to 'sa'
      */
     public static final String DEFAULT_DATABASE_USER = "sa";


### PR DESCRIPTION
Fixes:
- If JDBCMonitor is configured with a mismatching JDBC driver and URL, it always returns "Available"
- WebMonitor returns "Available" when an exception (including connect exceptions, timeouts, etc) happens during polling

Bamboo: http://bamboo.internal.opennms.com:8085/browse/OPENNMS-ONMS722/