### PR TITLE
NMS-8393: changes to address clickjacking vulnerability

### DIFF
--- a/opennms-jetty/pom.xml
+++ b/opennms-jetty/pom.xml
@@ -91,6 +91,11 @@
       <version>${jettyVersion}</version>
     </dependency>
     <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-rewrite</artifactId>
+      <version>${jettyVersion}</version>
+    </dependency>
+    <dependency>
       <groupId>org.eclipse.jdt.core.compiler</groupId>
       <artifactId>ecj</artifactId>
       <scope>runtime</scope>

--- a/opennms-jetty/src/main/resources/org/opennms/netmgt/jetty/jetty.xml
+++ b/opennms-jetty/src/main/resources/org/opennms/netmgt/jetty/jetty.xml
@@ -71,10 +71,35 @@
 	</Call>
 	-->
 
+
+    <!-- Note #1 To set X-Frame-Options uncomment here and uncomment #2 below  -->
+    <!-- Settings for X-Frame-Options to avoid clickjacking                    -->
+    <!-- 
+    <New id="RewriteHandler" class="org.eclipse.jetty.rewrite.handler.RewriteHandler">
+       <Set name="rules">
+        	<Array type="org.eclipse.jetty.rewrite.handler.Rule">
+        		<Item>
+                   <New id="header" class="org.eclipse.jetty.rewrite.handler.HeaderPatternRule">
+                      <Set name="pattern">*</Set>
+                      <Set name="name">X-Frame-Options</Set>
+                      <Set name="value">SAMEORIGIN</Set>
+                   </New>
+			    </Item>
+			  </Array>
+       </Set>
+     </New>
+    -->
+
 	<Set name="handler">
 		<New id="Handlers" class="org.eclipse.jetty.server.handler.HandlerCollection">
 			<Set name="handlers">
 			 <Array type="org.eclipse.jetty.server.Handler">
+			   <!-- Note #2 Uncomment to set X-Frame-Options with #1 above  -->
+               <!-- 
+                 <Item>
+                     <Ref id="RewriteHandler"/>
+                 </Item>
+               -->
 				 <Item>
 					 <New id="Contexts" class="org.eclipse.jetty.server.handler.ContextHandlerCollection"/>
 				 </Item>

--- a/pom.xml
+++ b/pom.xml
@@ -3298,6 +3298,11 @@
         <artifactId>jetty-all-server</artifactId>
         <version>${jettyVersion}</version>
       </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-rewrite</artifactId>
+        <version>${jettyVersion}</version>
+      </dependency>
       <!-- Make sure that this version matches the version from Jetty -->
       <dependency>
         <groupId>org.eclipse.jetty.orbit</groupId>


### PR DESCRIPTION
This issue addresses a perceived cross scripting  'clickjacking' vulnerability described in  http://issues.opennms.org/browse/NMS-8393

This change is needed for an enterprise customer who has tested this patch against meridian 2015 and will be upgrading to meridian 2016

User instructions for configuring the patch are also described on the OpenNMS wiki at
https://www.opennms.org/wiki/Nessus_Security_Fixes

This patch simply adds the required jetty-rewrite jar to the opennms/lib directory and additional options in the /etc/examples/jetty.xml. This makes it easier for the user to apply this configuration but by default this feature is not turned on. The user must follow the instructions in https://www.opennms.org/wiki/Nessus_Security_Fixes to uncomment the relevant sections in jetty.xml

This fix has been tested in production with no perceived issues but it is not enabled by default as there may be unforeseen impacts to the UI or on users who embed OpenNMS screens as x-frames in other pages.

* JIRA:  http://issues.opennms.org/browse/NMS-8393
* Bamboo: http://bamboo.internal.opennms.com:8085/browse/OPENNMS-ONMS725-2


