### PR TITLE
NMS-8360: If the persistence layer is not available or unresponsive the WebUI becomes unavailable or extremely slow and key components stop working	

### DIFF
--- a/opennms-webapp/src/main/java/org/opennms/web/controller/GraphResultsController.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/controller/GraphResultsController.java
@@ -62,7 +62,7 @@ import java.util.List;
  * @since 1.8.1
  */
 public class GraphResultsController extends AbstractController implements InitializingBean {
-    private static Logger logger = LoggerFactory.getLogger(GraphResultsController.class);
+    private static Logger LOG = LoggerFactory.getLogger(GraphResultsController.class);
     
     private GraphResultsService m_graphResultsService;
     
@@ -227,10 +227,14 @@ public class GraphResultsController extends AbstractController implements Initia
             reports = getSuggestedReports(resourceIds[0], matching);
         }
 
-        GraphResults model = m_graphResultsService.findResults(resourceIds, reports, startLong, endLong, relativeTime);
-        
-        ModelAndView modelAndView = new ModelAndView("/graph/results", "results", model);
-
+        ModelAndView modelAndView = null;
+        try {
+            GraphResults model = m_graphResultsService.findResults(resourceIds, reports, startLong, endLong, relativeTime);
+            modelAndView = new ModelAndView("/graph/results", "results", model);
+        } catch (Exception e) {
+            LOG.warn("Can't get graph results", e);
+            modelAndView = new ModelAndView("/graph/results-error");
+        }
         modelAndView.addObject("loggedIn", request.getRemoteUser() != null);
 
         return modelAndView;

--- a/opennms-webapp/src/main/webapp/WEB-INF/jsp/graph/results-error.jsp
+++ b/opennms-webapp/src/main/webapp/WEB-INF/jsp/graph/results-error.jsp
@@ -1,0 +1,62 @@
+<%--
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2006-2014 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+--%>
+
+<%@page language="java"
+        contentType="text/html"
+        session="true"
+        %>
+
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/functions" prefix="fn" %>
+
+<c:import url="/includes/bootstrap.jsp">
+    <c:param name="title" value="Resource Graph Results" />
+    <c:param name="headTitle" value="Results" />
+    <c:param name="headTitle" value="Resource Graphs" />
+    <c:param name="headTitle" value="Reports" />
+    <c:param name="breadcrumb" value="<a href='report/index.jsp'>Reports</a>" />
+    <c:param name="breadcrumb" value="<a href='graph/index.jsp'>Resource Graphs</a>"/>
+    <c:param name="breadcrumb" value="Results" />
+    <c:param name="scrollSpy" value="#results-sidebar" />
+    <c:param name="meta"       value="<meta http-equiv='X-UA-Compatible' content='IE=Edge' />"/>
+    <c:param name="renderGraphs" value="true" />
+</c:import>
+
+<div class="row">
+  <div class="col-md-12 text-center">
+    <h4>Can't generate graphs. Maybe one of the provided resource IDs don't have metrics associated.</h4>
+  </div> <!-- column -->
+</div> <!-- row -->
+
+<c:if test="${showFootnote1 == true}">
+    <jsp:include page="/includes/footnote1.jsp" flush="false" />
+</c:if>
+<jsp:include page="/includes/bootstrap-footer.jsp" flush="false" />

--- a/opennms-webapp/src/main/webapp/element/availability.jsp
+++ b/opennms-webapp/src/main/webapp/element/availability.jsp
@@ -54,7 +54,6 @@
         org.opennms.web.asset.AssetModel,
         org.opennms.web.element.*,
         org.opennms.web.navigate.*,
-        org.opennms.web.svclayer.api.ResourceService,
         org.springframework.util.StringUtils,
         org.springframework.web.context.WebApplicationContext,
         org.springframework.web.context.support.WebApplicationContextUtils"
@@ -69,7 +68,6 @@
     private int m_httpServiceId;
     private int m_dellServiceId;
     private int m_snmpServiceId;
-    private ResourceService m_resourceService;
     private AssetModel m_model = new AssetModel();
 
 	public void init() throws ServletException {
@@ -102,9 +100,6 @@
         } catch (Throwable e) {
             throw new ServletException("Could not determine the SNMP service ID", e);
         }
-
-		final WebApplicationContext webAppContext = WebApplicationContextUtils.getRequiredWebApplicationContext(getServletContext());
-		m_resourceService = (ResourceService) webAppContext.getBean("resourceService", ResourceService.class);
     }
 
 	public static String getStatusStringWithDefault(OnmsNode node_db) {
@@ -177,7 +172,6 @@
     nodeModel.put("isis",    EnLinkdElementFactory.getInstance(getServletContext()).getIsisElement(nodeId));
     nodeModel.put("bridges", EnLinkdElementFactory.getInstance(getServletContext()).getBridgeElements(nodeId));
 
-    nodeModel.put("resources", m_resourceService.findNodeChildResources(node_db));
     nodeModel.put("criticalPath", PathOutageManagerDaoImpl.getInstance().getPrettyCriticalPath(nodeId));
     nodeModel.put("noCriticalPath", PathOutageManager.NO_CRITICAL_PATH);
     nodeModel.put("admin", request.isUserInRole(Authentication.ROLE_ADMIN));

--- a/opennms-webapp/src/main/webapp/element/interface.jsp
+++ b/opennms-webapp/src/main/webapp/element/interface.jsp
@@ -40,19 +40,14 @@
             org.opennms.netmgt.model.OnmsResource,
             org.opennms.web.api.Authentication,
             org.opennms.web.element.*,
-            org.opennms.web.svclayer.api.ResourceService,
             org.opennms.core.utils.InetAddressUtils,
-            org.opennms.netmgt.dao.hibernate.IfLabelDaoImpl,
-            org.springframework.web.context.WebApplicationContext,
-            org.springframework.web.context.support.WebApplicationContextUtils"
+            org.opennms.netmgt.dao.hibernate.IfLabelDaoImpl"
 %>
 <%@taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 
 
 <%!protected int telnetServiceId;
   protected int httpServiceId;
-  private WebApplicationContext m_webAppContext;
-  private ResourceService m_resourceService;
   
   public void init() throws ServletException {
     try {
@@ -67,8 +62,6 @@
     catch( Exception e ) {
       throw new ServletException( "Could not determine the HTTP service ID", e );
     }
-    m_webAppContext = WebApplicationContextUtils.getRequiredWebApplicationContext(getServletContext());
-    m_resourceService = (ResourceService) m_webAppContext.getBean("resourceService", ResourceService.class);
   }%>
 
 <%
@@ -182,21 +175,25 @@ if (request.isUserInRole( Authentication.ROLE_ADMIN )) {
     } else {
       ifLabel = IfLabelDaoImpl.getInstance().getIfLabel(nodeId, InetAddressUtils.addr(ipAddr));
     }
-    List<OnmsResource> resources = m_resourceService.findNodeChildResources(node);
-    for (OnmsResource resource : resources) {
-      if (resource.getName().equals(ipAddr) || resource.getName().equals(ifLabel)) {
-        %>
-          <c:url var="graphLink" value="graph/results.htm">
-            <c:param name="reports" value="all"/>
-            <c:param name="resourceId" value="<%=resource.getId()%>"/>
-          </c:url>
-          <li>
-            <a href="<c:out value="${graphLink}"/>"><c:out value="<%=resource.getResourceType().getLabel()%>"/> Graphs</a>
-          </li>
-        <% 
-      }
-    }
+    // TODO In order to show the following links only when there are metrics, an inexpensive
+    //      method has to be implemented on either ResourceService or ResourceDao
+    String ipaddrResourceId = OnmsResource.createResourceId("node", Integer.toString(nodeId), "responseTime", ipAddr);
+    String snmpintfResourceId = OnmsResource.createResourceId("node", Integer.toString(nodeId), "interfaceSnmp", ifLabel);
   %>
+    <c:url var="ipaddrGraphLink" value="graph/results.htm">
+      <c:param name="reports" value="all"/>
+      <c:param name="resourceId" value="<%=ipaddrResourceId%>"/>
+    </c:url>
+    <li>
+      <a href="<c:out value="${ipaddrGraphLink}"/>">Response Time Graphs</a>
+    </li>
+    <c:url var="snmpintfGraphLink" value="graph/results.htm">
+      <c:param name="reports" value="all"/>
+      <c:param name="resourceId" value="<%=snmpintfResourceId%>"/>
+    </c:url>
+    <li>
+      <a href="<c:out value="${snmpintfGraphLink}"/>">SNMP Interface Data Graphs</a>
+    </li>
   <% if (request.isUserInRole( Authentication.ROLE_ADMIN )) { %>
     <li>
       <a href="admin/deleteInterface" onClick="return doDelete()">Delete</a>

--- a/opennms-webapp/src/main/webapp/element/linkednode.jsp
+++ b/opennms-webapp/src/main/webapp/element/linkednode.jsp
@@ -52,8 +52,7 @@
 		org.opennms.netmgt.model.OnmsNode,
 		org.opennms.core.utils.WebSecurityUtils,
 		org.opennms.web.element.*,
-		org.opennms.web.api.Authentication,
-		org.opennms.web.svclayer.api.ResourceService
+		org.opennms.web.api.Authentication
 	"
 %>
 

--- a/opennms-webapp/src/main/webapp/element/node.jsp
+++ b/opennms-webapp/src/main/webapp/element/node.jsp
@@ -54,7 +54,6 @@
         org.opennms.web.asset.AssetModel,
         org.opennms.web.element.*,
         org.opennms.web.navigate.*,
-        org.opennms.web.svclayer.api.ResourceService,
         org.springframework.util.StringUtils,
         org.springframework.web.context.WebApplicationContext,
         org.springframework.web.context.support.WebApplicationContextUtils"
@@ -68,7 +67,6 @@
     private int m_httpServiceId;
     private int m_dellServiceId;
     private int m_snmpServiceId;
-    private ResourceService m_resourceService;
 	private AssetModel m_model = new AssetModel();
 
 	public void init() throws ServletException {
@@ -103,7 +101,6 @@
         }
 
 		final WebApplicationContext webAppContext = WebApplicationContextUtils.getRequiredWebApplicationContext(getServletContext());
-		m_resourceService = (ResourceService) webAppContext.getBean("resourceService", ResourceService.class);
     }
 
 	public static String getStatusStringWithDefault(OnmsNode node_db) {
@@ -176,7 +173,6 @@
     nodeModel.put("isis",    EnLinkdElementFactory.getInstance(getServletContext()).getIsisElement(nodeId));
     nodeModel.put("bridges", EnLinkdElementFactory.getInstance(getServletContext()).getBridgeElements(nodeId));
 
-    nodeModel.put("resources", m_resourceService.findNodeChildResources(node_db));
     nodeModel.put("criticalPath", PathOutageManagerDaoImpl.getInstance().getPrettyCriticalPath(nodeId));
     nodeModel.put("noCriticalPath", PathOutageManagerDaoImpl.NO_CRITICAL_PATH);
     nodeModel.put("admin", request.isUserInRole(Authentication.ROLE_ADMIN));
@@ -360,16 +356,17 @@ function confirmAssetEdit() {
       </li>
     </c:forEach>
     
-    <c:if test="${! empty model.resources}">
-      <c:url var="resourceGraphsUrl" value="graph/chooseresource.htm">
-        <c:param name="parentResourceType" value="${model.parentResType}"/>
-        <c:param name="parentResource" value="${model.parentRes}"/>
-        <c:param name="reports" value="all"/>
-      </c:url>
-      <li>
-        <a href="<c:out value="${resourceGraphsUrl}"/>">Resource Graphs</a>
-      </li>
-    </c:if>
+    <%-- TODO In order to show the following link only when there are metrics, an
+              inexpensive method has to be implemented on either ResourceService
+              or ResourceDao --%>
+    <c:url var="resourceGraphsUrl" value="graph/chooseresource.htm">
+      <c:param name="parentResourceType" value="${model.parentResType}"/>
+      <c:param name="parentResource" value="${model.parentRes}"/>
+      <c:param name="reports" value="all"/>
+    </c:url>
+    <li>
+      <a href="<c:out value="${resourceGraphsUrl}"/>">Resource Graphs</a>
+    </li>
     
     <c:if test="${model.admin}">
       <c:url var="rescanLink" value="element/rescan.jsp">

--- a/opennms-webapp/src/main/webapp/element/snmpinterface.jsp
+++ b/opennms-webapp/src/main/webapp/element/snmpinterface.jsp
@@ -39,22 +39,9 @@
     org.opennms.netmgt.dao.api.IfLabel,
     org.opennms.web.api.Authentication,
     org.opennms.web.element.*,
-    org.opennms.web.svclayer.api.ResourceService,
-    org.opennms.netmgt.dao.hibernate.IfLabelDaoImpl,
-    org.springframework.web.context.WebApplicationContext,
-    org.springframework.web.context.support.WebApplicationContextUtils"
+    org.opennms.netmgt.dao.hibernate.IfLabelDaoImpl"
 %>
 <%@taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
-
-<%!
-  private WebApplicationContext m_webAppContext;
-  private ResourceService m_resourceService;
-  
-  public void init() throws ServletException {
-    m_webAppContext = WebApplicationContextUtils.getRequiredWebApplicationContext(getServletContext());
-    m_resourceService = (ResourceService) m_webAppContext.getBean("resourceService", ResourceService.class);
-  }
-%>
 
 <%
   Interface intf_db = ElementUtil.getSnmpInterfaceByParams(request, getServletContext());
@@ -119,26 +106,21 @@ if (request.isUserInRole( Authentication.ROLE_ADMIN )) {
   <%
     String ifLabel;
     if (ifIndex != -1) {
+      // TODO In order to show the following link only when there are metrics, an inexpensive
+      //      method has to be implemented on either ResourceService or ResourceDao
       ifLabel = IfLabelDaoImpl.getInstance().getIfLabelfromSnmpIfIndex(nodeId, ifIndex);
-    } else {
-      ifLabel = IfLabel.NO_IFLABEL;
-    }
-    List<OnmsResource> resources = m_resourceService.findNodeChildResources(node);
-    for (OnmsResource resource : resources) {
-      if (resource.getName().equals(ipAddr) || resource.getName().equals(ifLabel)) {
-        %>
-          <c:url var="graphLink" value="graph/results.htm">
-            <c:param name="reports" value="all"/>
-            <c:param name="resourceId" value="<%=resource.getId()%>"/>
-          </c:url>
-          <li>
-            <a href="<c:out value="${graphLink}"/>"><c:out value="<%=resource.getResourceType().getLabel()%>"/> Graphs</a>
-          </li>
-        <% 
-      }
-    }
+      String resourceId = OnmsResource.createResourceId("node", Integer.toString(nodeId), "interfaceSnmp", ifLabel);
   %>
-  <% if (request.isUserInRole( Authentication.ROLE_ADMIN )) { %>
+    <c:url var="graphLink" value="graph/results.htm">
+      <c:param name="reports" value="all"/>
+      <c:param name="resourceId" value="<%=resourceId%>"/>
+    </c:url>
+    <li>
+      <a href="<c:out value="${graphLink}"/>">SNMP Interface Data Graphs</a>
+    </li>
+   <% 
+    }
+    if (request.isUserInRole( Authentication.ROLE_ADMIN )) { %>
     <li>
       <a href="admin/deleteInterface" onClick="return doDelete()">Delete</a>
     </li>


### PR DESCRIPTION
If the persistence layer is not available or unresponsive the WebUI becomes unavailable or extremely slow and key components stop working

* JIRA: http://issues.opennms.org/browse/NMS-8360
* Bamboo: http://bamboo.internal.opennms.com:8085/browse/OPENNMS-ONMS740

I decided to just catch any exception thrown by GraphResultsService inside GraphResultsController and redirect the output to an error page, instead of trying to make DefaultGraphResultsService more error prone as the implementation is complicated.

I tested the solution myself and it works as expected.

The reason why I'm catching exceptions on GraphResultsController is because not necessarily all the SNMP interfaces will have graphs, and the link is now forced to appear on snmpinterface.jsp. A similar reasoning applies to interface.jsp (as not necessarily Pollerd is storing response time metrics for a given IP address).

Now, node.jsp, interface.jsp, availability.jsp and snmpinterface.jsp are not related with ResourceDao.

In the future, we should have an inexpensive method to check if a given resource has metrics or not, without the need of physically checking the storage (especially when Newts/Cassandra is enabled).