### PR TITLE
NMS-6331: When using storeByFS a provisioning group cannot contain whitespace

### DIFF
--- a/core/lib/src/main/java/org/opennms/core/utils/StringUtils.java
+++ b/core/lib/src/main/java/org/opennms/core/utils/StringUtils.java
@@ -124,11 +124,6 @@ public abstract class StringUtils {
 
         private void onChar(char c) {
             if (c == '"') {
-                if(m_isInQuotes) {
-                    // Reset the segment if we reach another quote
-                    // while we're in quotes
-                    resetSegment();
-                }
                 m_isInQuotes = !m_isInQuotes; // Toggle
             } else if (isWhitespace(c)) {
                 if (!m_isInQuotes) {

--- a/core/lib/src/test/java/org/opennms/core/utils/StringUtilsTest.java
+++ b/core/lib/src/test/java/org/opennms/core/utils/StringUtilsTest.java
@@ -72,6 +72,16 @@ public class StringUtilsTest {
                 }, actual);
     }
 
+    // Check NMS-6331 for more details.
+    @Test
+    public void testRrdPathWithSpaces() {
+        String arg = "/usr/bin/rrdtool graph - --start 1463938619 --end 1464025019 --title=\"fwdd Uptime\" DEF:time=\"snmp/fs/The OpenNMS Office/Main Router/juniper-fwdd-process.rrd\":junFwddUptime:AVERAGE";
+        String[] actual = StringUtils.createCommandArray(arg);
+        assertArrayEquals(new String[]{
+                "/usr/bin/rrdtool", "graph", "-", "--start", "1463938619", "--end", "1464025019", "--title=fwdd Uptime", "DEF:time=snmp/fs/The OpenNMS Office/Main Router/juniper-fwdd-process.rrd:junFwddUptime:AVERAGE"
+                }, actual);
+    }
+
     @Test
     public void testWindowsPaths() {
     	if (File.separatorChar != '\\') return;
@@ -87,7 +97,7 @@ public class StringUtilsTest {
     		assertFalse(falseString, StringUtils.isLocalWindowsPath(falseString));
     	}
     }
-    
+
     private void testCreateCmdArray(String[] expected, String arg) {
         String[] actual = StringUtils.createCommandArray(arg);
         assertArrayEquals(expected, actual);

--- a/opennms-dao/src/test/java/org/opennms/netmgt/dao/support/DefaultRrdDaoTest.java
+++ b/opennms-dao/src/test/java/org/opennms/netmgt/dao/support/DefaultRrdDaoTest.java
@@ -163,7 +163,7 @@ public class DefaultRrdDaoTest extends TestCase {
                 "-",
                 "--start=" + (start / 1000),
                 "--end=" + (end / 1000),
-                "DEF:ds=" + escapedFile + ":ifInOctets:AVERAGE",
+                "DEF:ds=\"" + escapedFile + "\":ifInOctets:AVERAGE",
                 "PRINT:ds:AVERAGE:\"%le\""
         };
         String commandString = StringUtils.arrayToDelimitedString(command, " ");

--- a/opennms-rrd/opennms-rrd-api/src/main/java/org/opennms/netmgt/rrd/RrdFileConstants.java
+++ b/opennms-rrd/opennms-rrd-api/src/main/java/org/opennms/netmgt/rrd/RrdFileConstants.java
@@ -157,7 +157,7 @@ public class RrdFileConstants {
 
     public static String escapeForGraphing(final String path) {
     	final Matcher matcher = GRAPHING_ESCAPE_PATTERN.matcher(path);
-    	return matcher.replaceAll("\\\\$1");
+    	return '"' + matcher.replaceAll("\\\\$1") + '"'; // To avoid NMS-6331, put double quotes around the DS path.
     }
 
 }

--- a/opennms-rrd/opennms-rrd-jrobin/src/main/java/org/opennms/netmgt/rrd/jrobin/JRobinRrdStrategy.java
+++ b/opennms-rrd/opennms-rrd-jrobin/src/main/java/org/opennms/netmgt/rrd/jrobin/JRobinRrdStrategy.java
@@ -588,7 +588,7 @@ public class JRobinRrdStrategy implements RrdStrategy<RrdDef,RrdDb> {
                 String[] def = splitDef(definition);
                 String[] ds = def[0].split("=");
                 // LOG.debug("ds = {}", Arrays.toString(ds));
-                final String replaced = ds[1].replaceAll("\\\\(.)", "$1");
+                final String replaced = ds[1].replaceAll("\\\\(.)", "$1").replaceAll("\"", ""); // Removing double quotes because of NMS-6331 and changes on RrdFileConstants
                 // LOG.debug("replaced = {}", replaced);
 
                 final File dsFile;


### PR DESCRIPTION
When using storeByFS a provisioning group cannot contain whitespace

* JIRA: http://issues.opennms.org/browse/NMS-6331
* Bamboo: http://bamboo.internal.opennms.com:8085/browse/OPENNMS-ONMS756

