### PR TITLE
NMS-8456: Tweaked performance of syslog Camel routes

### DIFF
--- a/features/discovery/src/main/resources/META-INF/opennms/applicationContext-discovery.xml
+++ b/features/discovery/src/main/resources/META-INF/opennms/applicationContext-discovery.xml
@@ -124,7 +124,7 @@
 
     <!-- Default localhost location queue -->
     <route id="localhostLocationDiscoveryRoute">
-      <from uri="activemq:Location-localhost" />
+      <from uri="activemq:Location-localhost?concurrentConsumers=8" />
       <log loggingLevel="INFO" message="applicationContext-discovery.xml: Executing DiscoveryJob" />
       <log loggingLevel="INFO" message="applicationContext-discovery.xml: ${body}" />
       <bean ref="discoverer" />

--- a/features/events/syslog/blueprint-syslog-handler-default.xml
+++ b/features/events/syslog/blueprint-syslog-handler-default.xml
@@ -52,15 +52,22 @@
 		<propertyPlaceholder id="properties" location="blueprint:syslogHandlerDefaultProperties" />
 
 		<route id="receiveSyslogConnection">
-			<from uri="activemq:broadcastSyslog"/>
+			<from uri="activemq:broadcastSyslog?concurrentConsumers=8"/>
+			<!-- No performance improvement with asyncConsumer -->
+			<!-- <from uri="activemq:broadcastSyslog?asyncConsumer=true&amp;concurrentConsumers=8"/> -->
+			<to uri="seda:unmarshalMessage"/>
+		</route>
+
+		<route id="unmarshalSyslogConnection">
+			<from uri="seda:unmarshalMessage?concurrentConsumers=8"/>
 			<process ref="unmarshaller"/>
 			<!-- Update the SyslogdConfig on the message to the local config value -->
 			<bean ref="syslogdConfigProcessor"/>
 			<to uri="seda:syslogHandler"/>
 		</route>
 
-		<route id="syslogHandler">
-			<from uri="seda:syslogHandler"/>
+		<route id="handleSyslogConnection">
+			<from uri="seda:syslogHandler?concurrentConsumers=8"/>
 			<!-- 
 				Pass the message to the default handler which will convert it into
 				an event and broadcast the event.

--- a/features/events/syslog/blueprint-syslog-handler-minion.xml
+++ b/features/events/syslog/blueprint-syslog-handler-minion.xml
@@ -28,13 +28,21 @@
 	<reference id="queuingservice" interface="org.apache.camel.Component" filter="(alias=opennms.broker)"/>
 
 	<camelContext id="syslogConnectionHandlerMinion" xmlns="http://camel.apache.org/schema/blueprint">
-		<route id="handleMessage">
-			<from uri="seda:handleMessage" />
-			<convertBodyTo type="org.opennms.netmgt.syslogd.SyslogConnection"/>
+		<route id="syslogHandleMessage">
+			<from uri="seda:handleMessage?concurrentConsumers=4" />
 			<!-- Marshal the message to XML -->
 			<bean ref="marshaller"/>
+			<to uri="seda:sendMessage"/>
+		</route>
+		<route id="syslogSendMessage">
+			<!-- Concurrent consumers gives a performance boost here because we have pooled connections to the JMS broker -->
+			<from uri="seda:sendMessage?concurrentConsumers=4"/>
 			<!-- Broadcast the message over ActiveMQ -->
-			<to uri="queuingservice:broadcastSyslog?disableReplyTo=true"/>
+			<!--
+				Turn off persistent messages to avoid the latency penalty: 
+				http://activemq.apache.org/async-sends.html
+			-->
+			<to uri="queuingservice:broadcastSyslog?deliveryPersistent=false"/>
 		</route>
 	</camelContext>
 

--- a/features/events/syslog/src/test/java/org/opennms/netmgt/syslogd/SyslogdHandlerMinionIT.java
+++ b/features/events/syslog/src/test/java/org/opennms/netmgt/syslogd/SyslogdHandlerMinionIT.java
@@ -120,7 +120,6 @@ public class SyslogdHandlerMinionIT extends CamelBlueprintTestSupport {
 	public void testSyslogd() throws Exception {
 		// Expect one SyslogConnection message to be broadcast on the messaging channel
 		MockEndpoint broadcastSyslog = getMockEndpoint("mock:queuingservice:broadcastSyslog", false);
-		broadcastSyslog.setExpectedMessageCount(1);
 
 		// Create a mock SyslogdConfig
 		SyslogConfigBean config = new SyslogConfigBean();
@@ -132,9 +131,48 @@ public class SyslogdHandlerMinionIT extends CamelBlueprintTestSupport {
 		config.setMatchingGroupMessage(8);
 		config.setDiscardUei("DISCARD-MATCHING-MESSAGES");
 
+		int numberOfMessages = 20;
+		SyslogConnection[] conns = new SyslogConnection[numberOfMessages];
+		for (int i = 0; i < numberOfMessages; i++) {
+			conns[i] = new SyslogConnection(InetAddressUtils.ONE_TWENTY_SEVEN, 2000, ByteBuffer.wrap("<34>main: 2010-08-19 localhost foo0: load test 0 on tty1\0".getBytes("US-ASCII")), config);
+		}
+
+		broadcastSyslog.setExpectedMessageCount(numberOfMessages);
+
+		// Warm up (open JMS connections, etc)
+		long startTime = System.currentTimeMillis();
+		for (int i = 0; i < numberOfMessages; i++) {
+			template.asyncSendBody("seda:handleMessage", conns[i]);
+		}
+		long endTime = System.currentTimeMillis();
+		LOG.info("Warm-up messages took {}ms", endTime - startTime);
+		assertMockEndpointsSatisfied();
+		resetMocks();
+
+
+		numberOfMessages = 5000;
+		conns = new SyslogConnection[numberOfMessages];
+		for (int i = 0; i < numberOfMessages; i++) {
+			conns[i] = new SyslogConnection(InetAddressUtils.ONE_TWENTY_SEVEN, 2000, ByteBuffer.wrap("<34>main: 2010-08-19 localhost foo0: load test 0 on tty1\0".getBytes("US-ASCII")), config);
+		}
+
+		broadcastSyslog.setExpectedMessageCount(numberOfMessages);
+
 		// Send a SyslogConnection to seda:handleMessage
-		template.requestBody("seda:handleMessage", new SyslogConnection(InetAddressUtils.ONE_TWENTY_SEVEN, 2000, ByteBuffer.wrap("<34>main: 2010-08-19 localhost foo0: load test 0 on tty1\0".getBytes("US-ASCII")), config));
+		startTime = System.currentTimeMillis();
+		for (int i = 0; i < numberOfMessages; i++) {
+			template.asyncSendBody("seda:handleMessage", conns[i]);
+		}
+		endTime = System.currentTimeMillis();
+		LOG.info("Test messages took {}ms", endTime - startTime);
 
 		assertMockEndpointsSatisfied();
+
+		endTime = System.currentTimeMillis();
+		LOG.info(
+			"Message transmission took {}ms ({} events per second)", 
+			endTime - startTime, 
+			Math.round((double)numberOfMessages / ((double)(endTime - startTime) / 1000.0))
+		);
 	}
 }


### PR DESCRIPTION
Disabled "persistent" JMS messages for syslog to avoid request-reply cycle for each message. Added concurrentConsumers to seda and activemq endpoints to thread the message handling. Verified that all routes are executing asynchronously.

* JIRA: http://issues.opennms.org/browse/NMS-8456
* Bamboo: http://bamboo.internal.opennms.com:8085/browse/OPENNMS-ONMS766