### PR TITLE
NMS-8485: dockerized smoke tests

### DIFF
--- a/smoke-test/pom.xml
+++ b/smoke-test/pom.xml
@@ -52,6 +52,27 @@
             </execution>
           </executions>
         </plugin>
+        <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
+        <plugin>
+          <groupId>org.eclipse.m2e</groupId>
+          <artifactId>lifecycle-mapping</artifactId>
+          <version>1.0.0</version>
+          <configuration>
+            <lifecycleMappingMetadata>
+              <pluginExecutions>
+                <pluginExecution>
+                  <pluginExecutionFilter>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-antrun-plugin</artifactId>
+                    <versionRange>[1.8,)</versionRange>
+                    <goals><goal>run</goal></goals>
+                  </pluginExecutionFilter>
+                  <action><ignore></ignore></action>
+                </pluginExecution>
+              </pluginExecutions>
+            </lifecycleMappingMetadata>
+          </configuration>
+        </plugin>
       </plugins>
     </pluginManagement>
     <plugins>
@@ -107,6 +128,7 @@
             https://jira.atlassian.com/browse/BAM-15446
           -->
           <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
+          <forkCount>2</forkCount>
         </configuration>
         <executions>
           <execution>
@@ -189,6 +211,16 @@
       <groupId>org.opennms.core</groupId>
       <artifactId>org.opennms.core.web</artifactId>
       <version>${project.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.httpcomponents</groupId>
+          <artifactId>httpcore-osgi</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.httpcomponents</groupId>
+          <artifactId>httpclient-osgi</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.opennms.core</groupId>
@@ -198,7 +230,7 @@
     <dependency>
       <groupId>org.opennms.smoke</groupId>
       <artifactId>org.opennms.smoke.test-api</artifactId>
-      <version>1-SNAPSHOT</version>
+      <version>2-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>

--- a/smoke-test/src/test/java/org/opennms/smoketest/AssetsPageIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/AssetsPageIT.java
@@ -39,7 +39,7 @@ import org.junit.runners.MethodSorters;
 public class AssetsPageIT extends OpenNMSSeleniumTestCase {
     @Before
     public void setUp() throws Exception {
-        m_driver.get(BASE_URL + "opennms/asset/index.jsp");
+        m_driver.get(getBaseUrl() + "opennms/asset/index.jsp");
     }
 
     @Test

--- a/smoke-test/src/test/java/org/opennms/smoketest/DatabaseReportIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/DatabaseReportIT.java
@@ -35,16 +35,8 @@ import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import com.google.common.base.Throwables;
-import com.google.common.io.ByteStreams;
-
-import io.netty.handler.codec.http.HttpResponse;
-import net.lightbody.bmp.BrowserMobProxy;
-import net.lightbody.bmp.BrowserMobProxyServer;
-import net.lightbody.bmp.client.ClientUtil;
-import net.lightbody.bmp.filters.ResponseFilter;
-import net.lightbody.bmp.util.HttpMessageContents;
-import net.lightbody.bmp.util.HttpMessageInfo;
+import org.apache.cxf.helpers.FileUtils;
+import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
@@ -58,6 +50,17 @@ import org.openqa.selenium.remote.CapabilityType;
 import org.openqa.selenium.remote.DesiredCapabilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Throwables;
+import com.google.common.io.ByteStreams;
+
+import io.netty.handler.codec.http.HttpResponse;
+import net.lightbody.bmp.BrowserMobProxy;
+import net.lightbody.bmp.BrowserMobProxyServer;
+import net.lightbody.bmp.client.ClientUtil;
+import net.lightbody.bmp.filters.ResponseFilter;
+import net.lightbody.bmp.util.HttpMessageContents;
+import net.lightbody.bmp.util.HttpMessageInfo;
 
 /**
  * Verifies that the database reports can be generated without any exceptions.
@@ -166,6 +169,11 @@ public class DatabaseReportIT extends OpenNMSSeleniumTestCase {
         if (page > 1) {
             findElementByLink(Integer.toString(page)).click();
         }
+    }
+
+    @After
+    public void after() {
+        FileUtils.removeDir(new File("target/reports"));
     }
 
     @Test

--- a/smoke-test/src/test/java/org/opennms/smoketest/DistributedMapIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/DistributedMapIT.java
@@ -41,7 +41,7 @@ import org.openqa.selenium.By;
 public class DistributedMapIT extends OpenNMSSeleniumTestCase {
     @Before
     public void setUp() throws Exception {
-        m_driver.get(BASE_URL + "opennms/RemotePollerMap/index.jsp");
+        m_driver.get(getBaseUrl() + "opennms/RemotePollerMap/index.jsp");
     }
 
     @Test

--- a/smoke-test/src/test/java/org/opennms/smoketest/EventsPageIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/EventsPageIT.java
@@ -38,7 +38,7 @@ import org.openqa.selenium.By;
 public class EventsPageIT extends OpenNMSSeleniumTestCase {
     @Before
     public void setUp() throws Exception {
-        m_driver.get(BASE_URL + "opennms/event/list");
+        m_driver.get(getBaseUrl() + "opennms/event/list");
     }
 
     @Test
@@ -67,7 +67,7 @@ public class EventsPageIT extends OpenNMSSeleniumTestCase {
 
     @Test
     public void testNodeIdNotFoundPage() throws InterruptedException {
-        m_driver.get(BASE_URL + "opennms/event/detail.jsp?id=999999999");
+        m_driver.get(getBaseUrl() + "opennms/event/detail.jsp?id=999999999");
         m_driver.findElement(By.xpath("//p[text()='Event not found in database.']"));
     }
 

--- a/smoke-test/src/test/java/org/opennms/smoketest/ForecastIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/ForecastIT.java
@@ -34,7 +34,7 @@ public class ForecastIT extends OpenNMSSeleniumTestCase {
     @Test
     public void canLoadGraph() throws Exception {
         // Request a known graph with an invalid resource id
-        m_driver.get(BASE_URL + "opennms/graph/forecast.jsp?resourceId=node[999].nodeSnmp[]&report=mib2.tcpopen");
+        m_driver.get(getBaseUrl() + "opennms/graph/forecast.jsp?resourceId=node[999].nodeSnmp[]&report=mib2.tcpopen");
         // The graph should be rendered
         findElementByXpath("//div[@class='flot-datatable-tabs']");
         // It won't have any data, but this is sufficient to very that all of the required

--- a/smoke-test/src/test/java/org/opennms/smoketest/NRTGraphIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/NRTGraphIT.java
@@ -34,7 +34,7 @@ public class NRTGraphIT extends OpenNMSSeleniumTestCase {
     @Test
     public void canLoadGraph() throws Exception {
         // Request a known graph with an invalid resource id
-        m_driver.get(BASE_URL + "opennms/graph/nrtg.jsp?resourceId=node[999].nodeSnmp[]&report=mib2.tcpopen");
+        m_driver.get(getBaseUrl() + "opennms/graph/nrtg.jsp?resourceId=node[999].nodeSnmp[]&report=mib2.tcpopen");
         // The graph should be rendered
         findElementByXpath("//div[@class='flot-datatable-tabs']");
         // It won't have any data, but this is sufficient to very that all of the required

--- a/smoke-test/src/test/java/org/opennms/smoketest/OSGIPluginManagerIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/OSGIPluginManagerIT.java
@@ -45,11 +45,11 @@ public class OSGIPluginManagerIT extends OpenNMSSeleniumTestCase {
 
     @Test
     public void canListProducts() throws ClientProtocolException, IOException, InterruptedException {
-        assertEquals(Integer.valueOf(200), doRequest(new HttpGet(OpenNMSSeleniumTestCase.BASE_URL + "/opennms/licencemgr/rest/v1-0/product-pub/list")));
+        assertEquals(Integer.valueOf(200), doRequest(new HttpGet(getBaseUrl() + "/opennms/licencemgr/rest/v1-0/product-pub/list")));
     }
 
     @Test
     public void canListFeatures() throws ClientProtocolException, IOException, InterruptedException {
-        assertEquals(Integer.valueOf(200), doRequest(new HttpGet(OpenNMSSeleniumTestCase.BASE_URL + "/opennms/featuremgr/rest/v1-0/features-list")));
+        assertEquals(Integer.valueOf(200), doRequest(new HttpGet(getBaseUrl() + "/opennms/featuremgr/rest/v1-0/features-list")));
     }
 }

--- a/smoke-test/src/test/java/org/opennms/smoketest/OsgiUrlPatternResponseIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/OsgiUrlPatternResponseIT.java
@@ -1,14 +1,8 @@
 package org.opennms.smoketest;
 
-import static org.opennms.smoketest.OpenNMSSeleniumTestCase.BASIC_AUTH_PASSWORD;
-import static org.opennms.smoketest.OpenNMSSeleniumTestCase.BASIC_AUTH_USERNAME;
-import static org.opennms.smoketest.OpenNMSSeleniumTestCase.OPENNMS_WEB_HOST;
-import static org.opennms.smoketest.OpenNMSSeleniumTestCase.OPENNMS_WEB_PORT;
-
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URL;
-import java.util.Base64;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -19,7 +13,7 @@ import org.slf4j.LoggerFactory;
  * Tests if sites with /osgi/* context can be registered.
  * See #NMS-7785 for details.
  */
-public class OsgiUrlPatternResponseIT {
+public class OsgiUrlPatternResponseIT extends OpenNMSSeleniumTestCase {
 
     private static final Logger LOG = LoggerFactory.getLogger(OsgiUrlPatternResponseIT.class);
 
@@ -34,7 +28,7 @@ public class OsgiUrlPatternResponseIT {
         };
 
         for (final String eachPath : paths) {
-            final String urlString = String.format("http://%s:%s/opennms/osgi/%s", OPENNMS_WEB_HOST, OPENNMS_WEB_PORT, eachPath);
+            final String urlString = String.format("http://%s:%s/opennms/osgi/%s", getServerAddress(), getServerHttpPort(), eachPath);
             LOG.info("Verifying url '{}' ...", urlString);
 
             final URL url = new URL(urlString);
@@ -60,12 +54,6 @@ public class OsgiUrlPatternResponseIT {
             Assert.assertEquals(errorMessage, 200, connection.getResponseCode());
             LOG.info("OK");
         }
-    }
-
-    private String createBasicAuthHeader() {
-        final String pass = String.format("%s:%s", BASIC_AUTH_USERNAME, BASIC_AUTH_PASSWORD);
-        final String basicAuthHeader = "Basic " + new String(Base64.getEncoder().encode(pass.getBytes()));
-        return basicAuthHeader;
     }
 
 }

--- a/smoke-test/src/test/java/org/opennms/smoketest/ProvisioningIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/ProvisioningIT.java
@@ -46,7 +46,7 @@ public class ProvisioningIT extends OpenNMSSeleniumTestCase {
 
     @Override
     protected void provisioningPage() {
-        m_driver.get(BASE_URL + "opennms/admin/provisioningGroups.htm");
+        m_driver.get(getBaseUrl() + "opennms/admin/provisioningGroups.htm");
     }
 
     @Before
@@ -96,6 +96,7 @@ public class ProvisioningIT extends OpenNMSSeleniumTestCase {
     @Test
     public void testRequisitionUI() throws Exception {
         final WebElement form = findElementByXpath("//form[@name='takeAction']");
+        form.findElement(By.cssSelector("input[type=text][name=groupName]")).click();
         form.findElement(By.cssSelector("input[type=text][name=groupName]")).sendKeys(REQUISITION_NAME);
         form.submit();
 
@@ -134,7 +135,7 @@ public class ProvisioningIT extends OpenNMSSeleniumTestCase {
         // wait for the node scanning to complete
         Thread.sleep(5000);
 
-        m_driver.get(BASE_URL + "opennms/element/node.jsp?node="+ REQUISITION_NAME + ":" + NODE_LABEL);
+        m_driver.get(getBaseUrl() + "opennms/element/node.jsp?node="+ REQUISITION_NAME + ":" + NODE_LABEL);
         findElementByXpath("//h3[text()='Availability']");
 
         wait.until(ExpectedConditions.elementToBeClickable(By.linkText("ICMP")));

--- a/smoke-test/src/test/java/org/opennms/smoketest/ProvisioningNewUIIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/ProvisioningNewUIIT.java
@@ -36,9 +36,7 @@ import org.junit.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.Keys;
 import org.openqa.selenium.NoSuchElementException;
-import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
-import org.openqa.selenium.support.ui.ExpectedCondition;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 
 /**
@@ -146,9 +144,9 @@ public class ProvisioningNewUIIT extends OpenNMSSeleniumTestCase {
         // Add node to a requisition
         clickId("add-node", false);
         wait.until(ExpectedConditions.visibilityOfElementLocated(By.id("nodeLabel"))).clear();
-        findElementById("nodeLabel").sendKeys(NODE_LABEL);
+        enterText(By.id("nodeLabel"), NODE_LABEL);
         wait.until(ExpectedConditions.visibilityOfElementLocated(By.id("foreignId"))).clear();
-        findElementById("foreignId").sendKeys(NODE_FOREIGNID);
+        enterText(By.id("foreignId"), NODE_FOREIGNID);
         saveNode();
 
         // Add an IP Interface
@@ -202,25 +200,17 @@ public class ProvisioningNewUIIT extends OpenNMSSeleniumTestCase {
         WebElement modal = findModal();
         modal.findElement(By.xpath("//div/button[text()='Yes']")).click();
         waitForModalClose();
-        wait.until(new ExpectedCondition<Boolean>() {
-            @Override
-            public Boolean apply(final WebDriver input) {
-                final boolean ret = (getNodesInRequisition(REQUISITION_NAME) == 1 && getNodesInDatabase(REQUISITION_NAME) == 1);
-                try {
-                    clickId("refresh", false);
-                    clickId("refreshDeployedStats", false);
-                } catch (final InterruptedException e) {
-                }
-                return ret;
-            }
-        });
+        wait.until(new WaitForNodesInRequisition(REQUISITION_NAME, 1));
+        wait.until(new WaitForNodesInDatabase(REQUISITION_NAME, 1));
+        clickId("refresh", false);
+        clickId("refreshDeployedStats", false);
         wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//h4[text()='Requisition " + REQUISITION_NAME + " (1 defined, 1 deployed)']")));
 
         // Go to the requisitions page
         clickId("go-back", false);
 
         // Wait until the node has been added to the database, using the ReST API
-        m_driver.get(BASE_URL + "opennms/rest/nodes/" + REQUISITION_NAME + ":" + NODE_FOREIGNID + "/ipinterfaces/" + NODE_IPADDR + "/services/ICMP");
+        m_driver.get(getBaseUrl() + "opennms/rest/nodes/" + REQUISITION_NAME + ":" + NODE_FOREIGNID + "/ipinterfaces/" + NODE_IPADDR + "/services/ICMP");
         m_driver.manage().timeouts().implicitlyWait(2000, TimeUnit.MILLISECONDS);
         try {
             for (int i=0; i<30; i++) {
@@ -237,7 +227,7 @@ public class ProvisioningNewUIIT extends OpenNMSSeleniumTestCase {
         }
 
         // Open the nodes list page
-        m_driver.get(BASE_URL + "opennms/");
+        m_driver.get(getBaseUrl() + "opennms/");
         clickMenuItem("Info", "Nodes", "element/nodeList.htm");
 
         try {

--- a/smoke-test/src/test/java/org/opennms/smoketest/QuickAddNodeIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/QuickAddNodeIT.java
@@ -69,17 +69,31 @@ public class QuickAddNodeIT extends OpenNMSSeleniumTestCase {
         deleteTestRequisition();
     }
 
+    private boolean textFieldsReady() {
+        try {
+            return REQUISITION_NAME.equals(waitForElement(By.id("foreignSource")).getAttribute("value")) &&
+                    NODE_IPADDR.equals(waitForElement(By.id("ipAddress")).getAttribute("value")) &&
+                    NODE_LABEL.equals(waitForElement(By.id("nodeLabel")).getAttribute("value"));
+        } catch (final Exception e) {
+            return false;
+        }
+    }
+
     @Test
     public void testQuickAddNode() throws Exception {
         adminPage();
         clickMenuItem("name=nav-admin-top", "Quick-Add Node", "admin/ng-requisitions/app/quick-add-node.jsp");
 
-        // Basic fields
-        findElementByCss("input#foreignSource");
-        Thread.sleep(1000);
-        enterTextAutocomplete(By.id("foreignSource"), REQUISITION_NAME);
-        enterText(By.id("ipAddress"), NODE_IPADDR);
-        enterText(By.id("nodeLabel"), NODE_LABEL);
+        Thread.sleep(5000);
+
+        long end = System.currentTimeMillis() + LOAD_TIMEOUT;
+        do {
+            // Basic fields
+            findElementByCss("input#foreignSource");
+            enterTextAutocomplete(By.id("foreignSource"), REQUISITION_NAME);
+            enterText(By.id("ipAddress"), NODE_IPADDR);
+            enterText(By.id("nodeLabel"), NODE_LABEL);
+        } while (!textFieldsReady() && System.currentTimeMillis() < end);
 
         // Add a category to the node
         findElementById("add-category").click();
@@ -94,6 +108,7 @@ public class QuickAddNodeIT extends OpenNMSSeleniumTestCase {
 
     protected WebElement enterTextAutocomplete(final By selector, final CharSequence... text) throws InterruptedException {
         final WebElement element = m_driver.findElement(selector);
+        element.clear();
         element.click();
         Thread.sleep(500);
         element.sendKeys(text);

--- a/smoke-test/src/test/java/org/opennms/smoketest/UserIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/UserIT.java
@@ -47,7 +47,7 @@ public class UserIT extends OpenNMSSeleniumTestCase {
 
     @Before
     public void setUp() throws Exception {
-        m_driver.get(BASE_URL + "opennms/account/selfService/index.jsp");
+        m_driver.get(getBaseUrl() + "opennms/account/selfService/index.jsp");
     }
 
     @Test


### PR DESCRIPTION
This pull request switches the smoke tests in foundation-2016 to use docker containers to run OpenNMS and PostgreSQL, rather than relying on a locally-installed OpenNMS when bamboo runs.

Note that by default, the tests will still run the old way (assuming 127.0.0.1:8980 is an OpenNMS system).  To enable dockerized tests, pass -Dorg.opennms.smoketest.docker=true on the maven command-line.

```
../compile.pl -Dorg.opennms.smoketest.docker=true -t verify
```

This branch uses the [newer smoke-test API branch, version 2-SNAPSHOT](https://github.com/OpenNMS/smoke-tests/blob/2/test-api/src/main/java/org/opennms/smoketest/OpenNMSSeleniumTestCase.java).

* JIRA: http://issues.opennms.org/browse/NMS-8485
* Bamboo:http://bamboo.internal.opennms.com:8085/browse/OPENNMS-DST0-17/

