### PR TITLE
NMS-7638: make node map cluster radius configurable

### DIFF
--- a/features/vaadin-node-maps/src/main/java/org/opennms/features/vaadin/nodemaps/internal/MapWidgetComponent.java
+++ b/features/vaadin-node-maps/src/main/java/org/opennms/features/vaadin/nodemaps/internal/MapWidgetComponent.java
@@ -38,7 +38,6 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 
-import com.github.wolfie.refresher.Refresher;
 import org.opennms.core.criteria.CriteriaBuilder;
 import org.opennms.core.criteria.restrictions.Restrictions;
 import org.opennms.features.geocoder.Coordinates;
@@ -61,6 +60,8 @@ import org.slf4j.LoggerFactory;
 import org.springframework.transaction.TransactionStatus;
 import org.springframework.transaction.support.TransactionCallbackWithoutResult;
 import org.springframework.transaction.support.TransactionOperations;
+
+import com.github.wolfie.refresher.Refresher;
 
 /**
  * @author Marcus Hellberg (marcus@vaadin.com)
@@ -338,5 +339,9 @@ public class MapWidgetComponent extends NodeMapComponent implements GeoAssetProv
 
     public void setSearchString(final String searchString) {
         getState().searchString = searchString;
+    }
+
+    public void setMaxClusterRadius(final Integer radius) {
+        getState().maxClusterRadius = radius;
     }
 }

--- a/features/vaadin-node-maps/src/main/java/org/opennms/features/vaadin/nodemaps/internal/NodeMapsApplication.java
+++ b/features/vaadin-node-maps/src/main/java/org/opennms/features/vaadin/nodemaps/internal/NodeMapsApplication.java
@@ -256,6 +256,10 @@ public class NodeMapsApplication extends UI {
         Assert.notNull(m_alarmTable);
         Assert.notNull(m_nodeTable);
 
+        final String searchString = vaadinRequest.getParameter("search");
+        final Integer maxClusterRadius = Integer.getInteger("gwt.maxClusterRadius", 350);
+        LOG.info("Starting search string: {}, max cluster radius: {}", searchString, maxClusterRadius);
+
         m_alarmTable.setVaadinApplicationContext(context);
         final EventProxy eventProxy = new EventProxy() {
             @Override public <T> void fireEvent(final T eventObject) {
@@ -282,14 +286,15 @@ public class NodeMapsApplication extends UI {
         m_alarmTable.setEventProxy(eventProxy);
         m_nodeTable.setEventProxy(eventProxy);
 
-        createMapPanel(vaadinRequest.getParameter("search"));
+        createMapPanel(searchString, maxClusterRadius);
         createRootLayout();
         addRefresher();
     }
 
-    private void createMapPanel(final String searchString) {
+    private void createMapPanel(final String searchString, final int maxClusterRadius) {
         m_mapWidgetComponent.setSearchString(searchString);
         m_mapWidgetComponent.setSizeFull();
+        m_mapWidgetComponent.setMaxClusterRadius(maxClusterRadius);
     }
 
     private void createRootLayout() {

--- a/features/vaadin-node-maps/src/main/java/org/opennms/features/vaadin/nodemaps/internal/gwt/client/NodeMapState.java
+++ b/features/vaadin-node-maps/src/main/java/org/opennms/features/vaadin/nodemaps/internal/gwt/client/NodeMapState.java
@@ -38,10 +38,11 @@ import com.vaadin.shared.AbstractComponentState;
  * @author Marcus Hellberg (marcus@vaadin.com)
  */
 public class NodeMapState extends AbstractComponentState {
-    private static final long serialVersionUID = -476104177779046228L;
+    private static final long serialVersionUID = 7166424509065088284L;
     public String searchString;
     public List<MapNode> nodes = new LinkedList<MapNode>();
     public List<Integer> nodeIds = new ArrayList<Integer>();
     public int minimumSeverity;
     public boolean groupByState = true;
+    public int maxClusterRadius = 350;
 }

--- a/features/vaadin-node-maps/src/main/java/org/opennms/features/vaadin/nodemaps/internal/gwt/client/ui/NodeMapConnector.java
+++ b/features/vaadin-node-maps/src/main/java/org/opennms/features/vaadin/nodemaps/internal/gwt/client/ui/NodeMapConnector.java
@@ -63,6 +63,7 @@ public class NodeMapConnector extends AbstractComponentConnector implements HasH
     private Map<String, Icon> m_icons;
 
     private NodeIdSelectionRpc m_rpc = RpcProxy.create(NodeIdSelectionRpc.class, this);
+    private int m_maxClusterRadius;
 
     public NodeMapConnector() {
         initializeIcons();
@@ -78,6 +79,10 @@ public class NodeMapConnector extends AbstractComponentConnector implements HasH
 
         // Handle all common Vaadin features first
         super.onStateChanged(stateChangeEvent);
+
+        if (stateChangeEvent.hasPropertyChanged("maxClusterRadius")) {
+            getWidget().setMaxClusterRadius(getState().maxClusterRadius);
+        }
 
         if (stateChangeEvent.hasPropertyChanged("searchString")) {
             final String searchString = getState().searchString;

--- a/features/vaadin-node-maps/src/main/java/org/opennms/features/vaadin/nodemaps/internal/gwt/client/ui/NodeMapWidget.java
+++ b/features/vaadin-node-maps/src/main/java/org/opennms/features/vaadin/nodemaps/internal/gwt/client/ui/NodeMapWidget.java
@@ -89,6 +89,7 @@ public class NodeMapWidget extends AbsolutePanel implements MarkerProvider, Filt
     private MarkerFilterImpl m_filter;
     private NodeIdSelectionRpc m_clientToServerRpc;
     private boolean m_groupByState;
+    private int m_maxClusterRadius;
 
     private OpenNMSEventManager m_eventManager;
     private ComponentTracker m_componentTracker;
@@ -209,6 +210,10 @@ public class NodeMapWidget extends AbsolutePanel implements MarkerProvider, Filt
     private void addMarkerLayer() {
         LOG.info("NodeMapWidget.addMarkerLayer()");
 
+        if (m_markerClusterGroup != null) {
+            m_map.removeLayer(m_markerClusterGroup);
+        }
+
         final Options markerClusterOptions = new Options();
         markerClusterOptions.setProperty("zoomToBoundsOnClick", false);
         markerClusterOptions.setProperty("iconCreateFunction", new IconCreateCallback());
@@ -222,11 +227,13 @@ public class NodeMapWidget extends AbsolutePanel implements MarkerProvider, Filt
 
         m_stateClusterGroups = new MarkerClusterGroup[52];
 
+        LOG.info("Creating marker cluster with maximum cluster radius " + m_maxClusterRadius);
+
         final Options[] stateClusterOptions = new Options[m_stateClusterGroups.length];
         for (int i = 0; i < m_stateClusterGroups.length; i++) {
             //stateClusterOptions[i] = new Options();
             stateClusterOptions[i] = markerClusterOptions;
-            stateClusterOptions[i].setProperty("maxClusterRadius", 350);
+            stateClusterOptions[i].setProperty("maxClusterRadius", m_maxClusterRadius > 0? m_maxClusterRadius:350);
             stateClusterOptions[i].setProperty("inUs", true);
             stateClusterOptions[i].setProperty("stateID", i);
             stateClusterOptions[i].setProperty("stateData", StatesData.getPolygonInfo(i, StatesData.getInstance()));
@@ -483,5 +490,14 @@ public class NodeMapWidget extends AbsolutePanel implements MarkerProvider, Filt
     public void setGroupByState(final boolean groupByState) {
         m_groupByState = groupByState;
         LOG.info("NodeMapWidget.setGroupByState(): group by state: " + (groupByState? "yes":"no"));
+    }
+
+    public void setMaxClusterRadius(final int maxClusterRadius) {
+        if (m_maxClusterRadius != maxClusterRadius) {
+            m_maxClusterRadius = maxClusterRadius;
+            if (m_map != null) {
+                addMarkerLayer();
+            }
+        }
     }
 }

--- a/opennms-base-assembly/src/main/filtered/etc/opennms.properties
+++ b/opennms-base-assembly/src/main/filtered/etc/opennms.properties
@@ -524,6 +524,9 @@ gwt.geocoder.email=
 # Open MapQuest tile server
 gwt.openlayers.url=http://otile1.mqcdn.com/tiles/1.0.0/osm/${z}/${x}/${y}.png
 
+# The radius, in pixels, that the maps will cluster nodes together at a particular zoom level.
+gwt.maxClusterRadius=350
+
 ###### UI DISPLAY OPTIONS ######
 
 # This value allows you to show or hide the Acknowledge event button. This is only


### PR DESCRIPTION
This PR adds support for making the cluster radius configurable in node geomaps.  You can set it by changing `gwt.maxClusterRadius` in `opennms.properties`.

bamboo: http://bamboo.internal.opennms.com:8085/browse/OPENNMS-ONMS785-1/
JIRA: http://issues.opennms.org/browse/NMS-7638