### PR TITLE
NMS-8376: Better synchronization in Poller event processing

### DIFF
--- a/opennms-services/src/main/java/org/opennms/netmgt/poller/pollables/DbPollEvent.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/poller/pollables/DbPollEvent.java
@@ -39,9 +39,8 @@ import java.util.Date;
  */
 public class DbPollEvent extends PollEvent {
     
-    int m_eventId;
-    String m_uei;
-    Date m_date;
+    private final int m_eventId;
+    private final Date m_date;
     
     /**
      * <p>Constructor for DbPollEvent.</p>

--- a/opennms-services/src/main/java/org/opennms/netmgt/poller/pollables/PollEvent.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/poller/pollables/PollEvent.java
@@ -38,9 +38,9 @@ import java.util.Date;
  * @author <a href="mailto:brozow@opennms.org">Mathew Brozowski</a>
  * @version $Id: $
  */
-abstract public class PollEvent {
+public abstract class PollEvent {
     
-    Scope m_scope;
+    private final Scope m_scope;
     
     /**
      * <p>Constructor for PollEvent.</p>
@@ -56,7 +56,7 @@ abstract public class PollEvent {
      *
      * @return a {@link org.opennms.netmgt.poller.pollables.Scope} object.
      */
-    public Scope getScope() {
+    public final Scope getScope() {
         return m_scope;
     }
 


### PR DESCRIPTION
The DefaultPollerContext was using synchronized() blocks to control access to the list of pending event updates. This commit changes the code to use ConcurrentLinkedQueue so that block-level synchronization isn't necessary and improves the synchronization inside the onEvent() method so that it iterates less and also uses ConcurrentLinkedQueue inside PendingPollEvent.

* JIRA: http://issues.opennms.org/browse/NMS-8376
* Bamboo: http://bamboo.internal.opennms.com:8085/browse/OPENNMS-ONMS793