### PR TITLE
NMS-8275: Fixed SQL restriction inside outage foreign source filters

### DIFF
--- a/opennms-webapp/src/main/java/org/opennms/web/outage/OutageUtil.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/outage/OutageUtil.java
@@ -95,7 +95,7 @@ public abstract class OutageUtil extends Object {
         if (type.equals(NodeFilter.TYPE)) {
             filter = new NodeFilter(WebSecurityUtils.safeParseInt(value), servletContext);
         } else if (type.equals(ForeignSourceFilter.TYPE)) {
-            filter = new ForeignSourceFilter(value, servletContext);
+            filter = new ForeignSourceFilter(value);
         } else if (type.equals(InterfaceFilter.TYPE)) {
             filter = new InterfaceFilter(value);
         } else if (type.equals(ServiceFilter.TYPE)) {
@@ -103,7 +103,7 @@ public abstract class OutageUtil extends Object {
         } else if (type.equals(OutageIdFilter.TYPE)) {
             filter = new OutageIdFilter(WebSecurityUtils.safeParseInt(value));
         } else if (type.equals(NegativeForeignSourceFilter.TYPE)) {
-            filter = new NegativeForeignSourceFilter(value, servletContext);
+            filter = new NegativeForeignSourceFilter(value);
         } else if (type.equals(NegativeNodeFilter.TYPE)) {
             filter = new NegativeNodeFilter(WebSecurityUtils.safeParseInt(value), servletContext);
         } else if (type.equals(NegativeInterfaceFilter.TYPE)) {

--- a/opennms-webapp/src/main/java/org/opennms/web/outage/filter/ForeignSourceFilter.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/outage/filter/ForeignSourceFilter.java
@@ -52,20 +52,20 @@ public class ForeignSourceFilter extends EqualsFilter<String> {
      *
      * @param foreignSource a {@link java.lang.String} object.
      */
-    public ForeignSourceFilter(String foreignSource, ServletContext servletContext) {
-        super(TYPE, SQLType.STRING, "OUTAGES.NODEID", "NODE.foreignSource", foreignSource);
+    public ForeignSourceFilter(String foreignSource) {
+        super(TYPE, SQLType.STRING, "OUTAGES.IFSERVICEID", "NODE.foreignSource", foreignSource);
     }
 
     /** {@inheritDoc} */
     @Override
     public String getSQLTemplate() {
-        return " " + getSQLFieldName() + " in (SELECT DISTINCT NODE.nodeID FROM NODE WHERE NODE.foreignSource=%s)";
+        return " " + getSQLFieldName() + " IN (SELECT DISTINCT ifservices.id FROM ifservices, ipinterface, node WHERE ifservices.ipinterfaceid = ipinterface.id AND ipinterface.nodeid = node.nodeid AND node.foreignSource=%s)";
     }
 
     /** {@inheritDoc} */
     @Override
     public Criterion getCriterion() {
-        return Restrictions.sqlRestriction(" {alias}.nodeid in (SELECT DISTINCT NODE.nodeID FROM NODE WHERE NODE.foreignSource=?)", getValue(), StringType.INSTANCE);
+        return Restrictions.sqlRestriction(" {alias}.ifserviceid IN (SELECT DISTINCT ifservices.id FROM ifservices, ipinterface, node WHERE ifservices.ipinterfaceid = ipinterface.id AND ipinterface.nodeid = node.nodeid AND node.foreignSource=?)", getValue(), StringType.INSTANCE);
     }
 
     /**

--- a/opennms-webapp/src/main/java/org/opennms/web/outage/filter/NegativeForeignSourceFilter.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/outage/filter/NegativeForeignSourceFilter.java
@@ -28,8 +28,6 @@
 
 package org.opennms.web.outage.filter;
 
-import javax.servlet.ServletContext;
-
 import org.hibernate.criterion.Criterion;
 import org.hibernate.criterion.Restrictions;
 import org.hibernate.type.StringType;
@@ -52,20 +50,20 @@ public class NegativeForeignSourceFilter extends EqualsFilter<String> {
      *
      * @param foreignSource a {@link java.lang.String} object.
      */
-    public NegativeForeignSourceFilter(String foreignSource, ServletContext servletContext) {
-        super(TYPE, SQLType.STRING, "OUTAGES.NODEID", "NODE.foreignSource", foreignSource);
+    public NegativeForeignSourceFilter(String foreignSource) {
+        super(TYPE, SQLType.STRING, "OUTAGES.IFSERVICEID", "NODE.foreignSource", foreignSource);
     }
 
     /** {@inheritDoc} */
     @Override
     public String getSQLTemplate() {
-        return " " + getSQLFieldName() + " not in (SELECT DISTINCT NODE.nodeID FROM NODE WHERE NODE.foreignSource=%s)";
+        return " " + getSQLFieldName() + " NOT IN (SELECT DISTINCT ifservices.id FROM ifservices, ipinterface, node WHERE ifservices.ipinterfaceid = ipinterface.id AND ipinterface.nodeid = node.nodeid AND node.foreignSource=%s)";
     }
 
     /** {@inheritDoc} */
     @Override
     public Criterion getCriterion() {
-        return Restrictions.sqlRestriction(" {alias}.nodeid not in (SELECT DISTINCT NODE.nodeID FROM NODE WHERE NODE.foreignSource=?)", getValue(), StringType.INSTANCE);
+        return Restrictions.sqlRestriction(" {alias}.ifserviceid NOT IN (SELECT DISTINCT ifservices.id FROM ifservices, ipinterface, node WHERE ifservices.ipinterfaceid = ipinterface.id AND ipinterface.nodeid = node.nodeid AND node.foreignSource=?)", getValue(), StringType.INSTANCE);
     }
 
     /**

--- a/opennms-webapp/src/main/webapp/WEB-INF/jsp/outage/list.jsp
+++ b/opennms-webapp/src/main/webapp/WEB-INF/jsp/outage/list.jsp
@@ -141,10 +141,10 @@
               <% OnmsNode node = NetworkElementFactory.getInstance(getServletContext()).getNode(outages[i].getNodeId()); %>
               <% if(node.getForeignSource() != null) { %>
               <%=node.getForeignSource()%>
-              <% Filter foreignSourceFilter = new ForeignSourceFilter(node.getForeignSource(), getServletContext()); %>
+              <% Filter foreignSourceFilter = new ForeignSourceFilter(node.getForeignSource()); %>
               <% if( !parms.filters.contains(foreignSourceFilter) ) { %>
                   <a href="<%=OutageUtil.makeLink( request, parms, foreignSourceFilter, true)%>" title="Show only outages for this foreign source"><%=ZOOM_IN_ICON%></a>
-                  <a href="<%=OutageUtil.makeLink( request, parms, new NegativeForeignSourceFilter(node.getForeignSource(), getServletContext()), true)%>" title="Do not show outages for this foreign source"><%=DISCARD_ICON%></a>
+                  <a href="<%=OutageUtil.makeLink( request, parms, new NegativeForeignSourceFilter(node.getForeignSource()), true)%>" title="Do not show outages for this foreign source"><%=DISCARD_ICON%></a>
               <% } %>
               <% } else { %>
                 &nbsp;


### PR DESCRIPTION
Fixed SQL for outage foreign source filters that was broken after we removed the nodeid column from the outages table. Added tests for the code (and the node ID filters while I was in there).

* JIRA: http://issues.opennms.org/browse/NMS-8275
* Bamboo: TBD