### PR TITLE
NMS-8155: Missing node/interface information in an event after sending an event with send-event ui.

### DIFF
--- a/opennms-webapp/src/main/webapp/admin/postevent.jsp
+++ b/opennms-webapp/src/main/webapp/admin/postevent.jsp
@@ -71,7 +71,7 @@
     }
 
     String intface = StringUtils.trimToEmpty(request.getParameter("interface"));
-    if (StringUtils.isNotBlank(host)) {
+    if (StringUtils.isNotBlank(intface)) {
         event.setInterface(intface);
     }
 


### PR DESCRIPTION
Missing node/interface information in an event after sending an event with send-event ui.

* JIRA: http://issues.opennms.org/browse/NMS-8155
* Bamboo: http://bamboo.internal.opennms.com:8085/browse/OPENNMS-ONMS802

The nodeId was correct, I only found a problem with the interface (i.e. the IP address). I verified the solution with latest snapshot of Meridian-2016.