### PR TITLE
NMS-8294: Fetch all of the node hierarchy inside Scriptd

### DIFF
--- a/opennms-dao/src/main/java/org/opennms/netmgt/dao/hibernate/NodeDaoHibernate.java
+++ b/opennms-dao/src/main/java/org/opennms/netmgt/dao/hibernate/NodeDaoHibernate.java
@@ -147,6 +147,7 @@ public class NodeDaoHibernate extends AbstractDaoHibernate<OnmsNode, Integer> im
                                            + "left join fetch n.assetRecord "
                                            + "where n.id = ?", id);
 
+        initialize(node.getCategories());
         initialize(node.getIpInterfaces());
         for (OnmsIpInterface i : node.getIpInterfaces()) {
             initialize(i.getMonitoredServices());

--- a/opennms-services/src/main/java/org/opennms/netmgt/scriptd/Executor.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/scriptd/Executor.java
@@ -278,7 +278,9 @@ final class Executor implements Runnable, PausableFiber {
                 if (event.hasNodeid()) {
                     Long nodeLong = event.getNodeid();
                     Integer nodeInt = Integer.valueOf(nodeLong.intValue());
-                    node = m_nodeDao.get(nodeInt);
+                    // NMS-8294: Initialize the entire node hierarchy so that
+                    // BSF scripts can execute outside of a transaction
+                    node = m_nodeDao.getHierarchy(nodeInt);
                     m_mgr.registerBean("node", node);
                 }
 


### PR DESCRIPTION
Avoid LazyInitializationException by using getHierarchy() instead of get().

* JIRA: http://issues.opennms.org/browse/NMS-8294
* Bamboo: http://bamboo.internal.opennms.com:8085/browse/OPENNMS-ONMS820