### PR TITLE
Updated camel-test-blueprint to 2.15.6 without updating the rest of Camel

### DIFF
--- a/dependencies/camel-test/pom.xml
+++ b/dependencies/camel-test/pom.xml
@@ -13,6 +13,44 @@
   <dependencies>
     <dependency>
       <groupId>org.apache.camel</groupId>
+      <artifactId>camel-blueprint</artifactId>
+      <version>${camelVersion}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>javax.xml.bind</groupId>
+          <artifactId>jaxb-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.sun.xml.bind</groupId>
+          <artifactId>jaxb-impl</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.camel</groupId>
+      <artifactId>camel-core-osgi</artifactId>
+      <version>${camelVersion}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>javax.xml.bind</groupId>
+          <artifactId>jaxb-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.sun.xml.bind</groupId>
+          <artifactId>jaxb-impl</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.camel</groupId>
       <artifactId>camel-test</artifactId>
       <version>${camelVersion}</version>
       <exclusions>
@@ -33,7 +71,17 @@
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-test-blueprint</artifactId>
-      <version>${camelVersion}</version>
+      <!--
+        We're overriding the version here so that the
+        Camel blueprint tests are more reliable.
+
+        https://issues.apache.org/jira/browse/CAMEL-8948
+
+        We also have to add all of the transitive deps
+        of camel-test-blueprint so that ${camelVersion}
+        of those deps is used instead of the 2.15.6 version.
+      -->
+      <version>2.15.6</version>
       <exclusions>
         <exclusion>
           <groupId>javax.xml.bind</groupId>

--- a/features/amqp/alarm-northbounder/src/test/java/org/opennms/features/amqp/alarmnorthbounder/AMQPAlarmNorthbounderBlueprintTest.java
+++ b/features/amqp/alarm-northbounder/src/test/java/org/opennms/features/amqp/alarmnorthbounder/AMQPAlarmNorthbounderBlueprintTest.java
@@ -28,8 +28,8 @@
 
 package org.opennms.features.amqp.alarmnorthbounder;
 
-import java.util.Dictionary;
 import java.util.List;
+import java.util.Properties;
 
 import org.apache.camel.BeanInject;
 import org.junit.Ignore;
@@ -59,9 +59,8 @@ public class AMQPAlarmNorthbounderBlueprintTest extends CamelBlueprintTest {
         return "OSGI-INF/blueprint/blueprint-alarm-northbounder.xml";
     }
 
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     @Override
-    protected String useOverridePropertiesWithConfigAdmin(Dictionary props) {
+    protected String setConfigAdminInitialConfiguration(Properties props) {
         props.put("destination", "mock:destination");
 
         // Return the PID

--- a/features/amqp/event-forwarder/src/test/java/org/opennms/features/amqp/eventforwarder/AMQPEventForwarderBlueprintTest.java
+++ b/features/amqp/event-forwarder/src/test/java/org/opennms/features/amqp/eventforwarder/AMQPEventForwarderBlueprintTest.java
@@ -30,6 +30,7 @@ package org.opennms.features.amqp.eventforwarder;
 
 import java.util.Dictionary;
 import java.util.Map;
+import java.util.Properties;
 
 import org.apache.camel.BeanInject;
 import org.apache.camel.util.KeyValueHolder;
@@ -61,9 +62,8 @@ public class AMQPEventForwarderBlueprintTest extends CamelBlueprintTest {
         return "OSGI-INF/blueprint/blueprint-event-forwarder.xml";
     }
 
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     @Override
-    protected String useOverridePropertiesWithConfigAdmin(Dictionary props) {
+    protected String setConfigAdminInitialConfiguration(Properties props) {
         props.put("destination", "mock:destination");
      
         // Return the PID

--- a/features/amqp/event-receiver/src/test/java/org/opennms/features/amqp/eventreceiver/AMQPEventReceiverBlueprintTest.java
+++ b/features/amqp/event-receiver/src/test/java/org/opennms/features/amqp/eventreceiver/AMQPEventReceiverBlueprintTest.java
@@ -31,6 +31,7 @@ package org.opennms.features.amqp.eventreceiver;
 import java.util.Dictionary;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 
 import org.apache.camel.BeanInject;
 import org.apache.camel.util.KeyValueHolder;
@@ -65,9 +66,8 @@ public class AMQPEventReceiverBlueprintTest extends CamelBlueprintTest {
         return "OSGI-INF/blueprint/blueprint-event-receiver.xml";
     }
 
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     @Override
-    protected String useOverridePropertiesWithConfigAdmin(Dictionary props) {
+    protected String setConfigAdminInitialConfiguration(Properties props) {
         props.put("source", "direct:source");
      
         // Return the PID

--- a/features/events/traps/src/test/java/org/opennms/netmgt/trapd/TrapdListenerBlueprintIT.java
+++ b/features/events/traps/src/test/java/org/opennms/netmgt/trapd/TrapdListenerBlueprintIT.java
@@ -70,12 +70,10 @@ public class TrapdListenerBlueprintIT extends CamelBlueprintTest {
 	/**
 	 * This method overrides the blueprint property and sets port to 10514 instead of 162
 	 */
-	@SuppressWarnings({"rawtypes", "unchecked"})
 	@Override
-	protected String useOverridePropertiesWithConfigAdmin(Dictionary props) throws Exception {
-		// TODO: Check that this port is available before using it
+	protected String setConfigAdminInitialConfiguration(Properties props) {
 		m_port = getAvailablePort(10500, 10900);
-		props.put(PORT_NAME, m_port);
+		props.put(PORT_NAME, String.valueOf(m_port));
 		return PERSISTANCE_ID;
 	}
 

--- a/features/minion/core/impl/src/test/java/org/opennms/features/minion/HeartBeatMinionBluePrintIT.java
+++ b/features/minion/core/impl/src/test/java/org/opennms/features/minion/HeartBeatMinionBluePrintIT.java
@@ -38,6 +38,7 @@ import org.apache.camel.component.seda.SedaComponent;
 import org.apache.camel.util.KeyValueHolder;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.opennms.core.camel.JmsQueueNameFactory;
 import org.opennms.core.test.OpenNMSJUnit4ClassRunner;
 import org.opennms.core.test.camel.CamelBlueprintTest;
 import org.opennms.core.xml.JaxbUtils;
@@ -83,8 +84,8 @@ public class HeartBeatMinionBluePrintIT extends CamelBlueprintTest {
 
     @Test
     public void testHeartBeat() throws Exception {
-
-        MockEndpoint heartBeatqueue = getMockEndpoint("mock:queuingservice:heartBeat",
+        JmsQueueNameFactory factory = new JmsQueueNameFactory("Minion", "Heartbeat");
+        MockEndpoint heartBeatqueue = getMockEndpoint("mock:queuingservice:" + factory.getName(),
                                                       false);
         heartBeatqueue.setExpectedMessageCount(1);
 


### PR DESCRIPTION
This will give us the bugfixes from Camel 2.15 (to stop the Camel tests from flapping) without any compatibility breakages.

* Bamboo: http://bamboo.internal.opennms.com:8085/browse/OPENNMS-ONMS823