### PR TITLE
HZN-825: Besides nodeID also support foreignSource and foreignId on a GraphMLVertex

### DIFF
--- a/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.graphml/src/main/java/org/opennms/features/topology/plugins/topo/graphml/GraphMLMetaTopologyProvider.java
+++ b/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.graphml/src/main/java/org/opennms/features/topology/plugins/topo/graphml/GraphMLMetaTopologyProvider.java
@@ -38,6 +38,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import org.opennms.features.graphml.model.GraphML;
@@ -50,6 +51,7 @@ import org.opennms.features.topology.api.support.VertexHopGraphProvider;
 import org.opennms.features.topology.api.topo.GraphProvider;
 import org.opennms.features.topology.api.topo.MetaTopologyProvider;
 import org.opennms.features.topology.api.topo.VertexRef;
+import org.opennms.features.topology.plugins.topo.graphml.internal.GraphMLServiceAccessor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -61,10 +63,16 @@ import com.google.common.collect.Maps;
 public class GraphMLMetaTopologyProvider implements MetaTopologyProvider {
     private static final Logger LOG = LoggerFactory.getLogger(GraphMLTopologyProvider.class);
 
+    private final GraphMLServiceAccessor m_serviceAccessor;
+
     private File graphMLFile;
     private final Map<String, GraphProvider> graphsByNamespace = Maps.newLinkedHashMap();
     private final Map<String, GraphMLTopologyProvider> rawGraphsByNamespace = Maps.newLinkedHashMap();
     private final Map<VertexRef, List<VertexRef>> oppositeVertices = Maps.newLinkedHashMap();
+
+    public GraphMLMetaTopologyProvider(GraphMLServiceAccessor serviceAccessor) {
+        m_serviceAccessor = Objects.requireNonNull(serviceAccessor);
+    }
 
     private VertexRef getVertex(GraphMLNode node) {
         return graphsByNamespace.values().stream()
@@ -89,7 +97,7 @@ public class GraphMLMetaTopologyProvider implements MetaTopologyProvider {
             validate(graphML);
 
             for (GraphMLGraph eachGraph : graphML.getGraphs()) {
-                final GraphMLTopologyProvider topoProvider = new GraphMLTopologyProvider(eachGraph);
+                final GraphMLTopologyProvider topoProvider = new GraphMLTopologyProvider(eachGraph, m_serviceAccessor);
                 final VertexHopGraphProvider vertexHopGraphProvider = new VertexHopGraphProvider(topoProvider);
                 graphsByNamespace.put(topoProvider.getVertexNamespace(), vertexHopGraphProvider);
                 rawGraphsByNamespace.put(topoProvider.getVertexNamespace(), topoProvider);

--- a/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.graphml/src/main/java/org/opennms/features/topology/plugins/topo/graphml/GraphMLProperties.java
+++ b/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.graphml/src/main/java/org/opennms/features/topology/plugins/topo/graphml/GraphMLProperties.java
@@ -37,6 +37,8 @@ public interface GraphMLProperties {
     String LABEL = "label";
     String LOCKED = "locked";
     String NODE_ID = "nodeID";
+    String FOREIGN_SOURCE = "foreignSource";
+    String FOREIGN_ID = "foreignID";
     String SELECTED = "selected";
     String STYLE_NAME = "styleName";
     String TOOLTIP_TEXT = "tooltipText";

--- a/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.graphml/src/main/java/org/opennms/features/topology/plugins/topo/graphml/GraphMLTopologyProvider.java
+++ b/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.graphml/src/main/java/org/opennms/features/topology/plugins/topo/graphml/GraphMLTopologyProvider.java
@@ -108,10 +108,10 @@ public class GraphMLTopologyProvider extends AbstractTopologyProvider implements
     }
 
     private void setNodeIdForVertex(GraphMLVertex vertex) {
-        if (Objects.isNull(vertex)) {
+        if (vertex == null) {
             return;
         }
-        if (Objects.isNull(vertex.getNodeID())) {
+        if (vertex.getNodeID() == null) {
             String foreignSource = (String) vertex.getProperties().get(GraphMLProperties.FOREIGN_SOURCE);
             String foreignId = (String) vertex.getProperties().get(GraphMLProperties.FOREIGN_ID);
             if (!Strings.isNullOrEmpty(foreignSource) && !Strings.isNullOrEmpty(foreignId)) {

--- a/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.graphml/src/main/java/org/opennms/features/topology/plugins/topo/graphml/GraphMLTopologyProvider.java
+++ b/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.graphml/src/main/java/org/opennms/features/topology/plugins/topo/graphml/GraphMLTopologyProvider.java
@@ -119,10 +119,10 @@ public class GraphMLTopologyProvider extends AbstractTopologyProvider implements
                 if (onmsNode != null) {
                     vertex.setNodeID(onmsNode.getId());
                 } else {
-                    LOG.warn("no node found for the given foreignSource ({}) and foreignId ({})", foreignSource, foreignId);
+                    LOG.warn("No node found for the given foreignSource ({}) and foreignId ({}).", foreignSource, foreignId);
                 }
             } else {
-                LOG.warn("nodeId is null, foreignSource ({}) and foreignId ({}) must be set both", foreignSource, foreignId);
+                LOG.warn("The given nodeId is null. In order to resolve the nodeId a foreignSource ({}) and foreignId ({}) must be set.", foreignSource, foreignId);
             }
         }
     }

--- a/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.graphml/src/main/java/org/opennms/features/topology/plugins/topo/graphml/GraphMLTopologyProvider.java
+++ b/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.graphml/src/main/java/org/opennms/features/topology/plugins/topo/graphml/GraphMLTopologyProvider.java
@@ -47,9 +47,12 @@ import org.opennms.features.topology.api.topo.Defaults;
 import org.opennms.features.topology.api.topo.GraphProvider;
 import org.opennms.features.topology.api.topo.TopologyProviderInfo;
 import org.opennms.features.topology.api.topo.VertexRef;
+import org.opennms.features.topology.plugins.topo.graphml.internal.GraphMLServiceAccessor;
+import org.opennms.netmgt.model.OnmsNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 
@@ -57,6 +60,8 @@ public class GraphMLTopologyProvider extends AbstractTopologyProvider implements
 
     protected static final String DEFAULT_DESCRIPTION = "This Topology Provider visualizes a predefined GraphML graph.";
     private static final Logger LOG = LoggerFactory.getLogger(GraphMLTopologyProvider.class);
+
+    private final GraphMLServiceAccessor m_serviceAccessor;
 
     private static TopologyProviderInfo createTopologyProviderInfo(GraphMLGraph graph) {
         String name = graph.getProperty(GraphMLProperties.LABEL, graph.getId());
@@ -70,10 +75,28 @@ public class GraphMLTopologyProvider extends AbstractTopologyProvider implements
     private final List<String> focusIds;
     private final Boolean requiresStatusProvider;
 
-    public GraphMLTopologyProvider(GraphMLGraph graph) {
+    public GraphMLTopologyProvider(GraphMLGraph graph, GraphMLServiceAccessor serviceAccessor) {
         super(graph.getProperty(GraphMLProperties.NAMESPACE));
+
+        m_serviceAccessor = serviceAccessor;
+
         for (GraphMLNode graphMLNode : graph.getNodes()) {
             GraphMLVertex newVertex = new GraphMLVertex(this.getVertexNamespace(), graphMLNode);
+
+            if (newVertex.getNodeID() == null &&
+                    !Strings.isNullOrEmpty((String) newVertex.getProperties().get(GraphMLProperties.FOREIGN_SOURCE)) &&
+                    !Strings.isNullOrEmpty((String) newVertex.getProperties().get(GraphMLProperties.FOREIGN_ID))
+                    ) {
+
+                OnmsNode onmsNode = m_serviceAccessor.getNodeDao().findByForeignId(
+                        (String) newVertex.getProperties().get(GraphMLProperties.FOREIGN_SOURCE),
+                        (String) newVertex.getProperties().get(GraphMLProperties.FOREIGN_ID));
+
+                if (onmsNode != null) {
+                    newVertex.setNodeID(onmsNode.getId());
+                }
+            }
+
             addVertices(newVertex);
         }
         for (org.opennms.features.graphml.model.GraphMLEdge eachEdge : graph.getEdges()) {

--- a/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.graphml/src/main/java/org/opennms/features/topology/plugins/topo/graphml/internal/GraphMLMetaTopologyFactory.java
+++ b/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.graphml/src/main/java/org/opennms/features/topology/plugins/topo/graphml/internal/GraphMLMetaTopologyFactory.java
@@ -93,7 +93,7 @@ public class GraphMLMetaTopologyFactory implements ManagedServiceFactory {
 			}
 
 			// Expose the MetaTopologyProvider
-			final GraphMLMetaTopologyProvider metaTopologyProvider = new GraphMLMetaTopologyProvider();
+			final GraphMLMetaTopologyProvider metaTopologyProvider = new GraphMLMetaTopologyProvider(m_serviceAccessor);
 			metaTopologyProvider.setTopologyLocation(location);
 			metaTopologyProvider.load();
 			registerService(pid, MetaTopologyProvider.class, metaTopologyProvider, metaData);

--- a/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.graphml/src/test/java/org/opennms/features/topology/plugins/topo/graphml/GraphMLEdgeStatusProviderIT.java
+++ b/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.graphml/src/test/java/org/opennms/features/topology/plugins/topo/graphml/GraphMLEdgeStatusProviderIT.java
@@ -29,6 +29,7 @@
 package org.opennms.features.topology.plugins.topo.graphml;
 
 import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertThat;
@@ -49,6 +50,7 @@ import org.opennms.features.graphml.model.GraphMLReader;
 import org.opennms.features.topology.api.topo.Criteria;
 import org.opennms.features.topology.api.topo.EdgeRef;
 import org.opennms.features.topology.api.topo.Status;
+import org.opennms.features.topology.api.topo.VertexRef;
 import org.opennms.features.topology.plugins.topo.graphml.internal.GraphMLServiceAccessor;
 import org.opennms.netmgt.dao.DatabasePopulator;
 import org.opennms.netmgt.dao.api.NodeDao;
@@ -105,7 +107,7 @@ public class GraphMLEdgeStatusProviderIT {
         serviceAccessor.setMeasurementsService(request -> new QueryResponse());
 
         final GraphMLGraph graph = GraphMLReader.read(getClass().getResourceAsStream("/test-graph2.xml")).getGraphs().get(0);
-        final GraphMLTopologyProvider topologyProvider = new GraphMLTopologyProvider(graph);
+        final GraphMLTopologyProvider topologyProvider = new GraphMLTopologyProvider(graph, serviceAccessor);
         final GraphMLEdgeStatusProvider provider = new GraphMLEdgeStatusProvider(
                 topologyProvider,
                 new ScriptEngineManager(),
@@ -118,6 +120,12 @@ public class GraphMLEdgeStatusProviderIT {
         // Calculating the status executes some tests defined int the according scripts as a side effect
         final EdgeRef edgeRef = topologyProvider.getEdge("acme:regions", "center_north");
         final Map<EdgeRef, Status> status = provider.getStatusForEdges(topologyProvider, ImmutableList.of(edgeRef), new Criteria[0]);
+
+        // Checking nodeID creation for vertices with only foreignSource/foreignID set
+        final VertexRef vertexRef = topologyProvider.getVertex("acme:regions", "west");
+        assertThat(vertexRef, is(notNullValue()));
+        assertThat(vertexRef, is(instanceOf(GraphMLVertex.class)));
+        assertThat(((GraphMLVertex) vertexRef).getNodeID(), is(4));
 
         // Testing status merging from two scripts
         assertThat(status, is(notNullValue()));

--- a/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.graphml/src/test/java/org/opennms/features/topology/plugins/topo/graphml/GraphMLMetaTopologyProviderTest.java
+++ b/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.graphml/src/test/java/org/opennms/features/topology/plugins/topo/graphml/GraphMLMetaTopologyProviderTest.java
@@ -42,6 +42,7 @@ import org.junit.rules.TemporaryFolder;
 import org.opennms.features.topology.api.topo.Defaults;
 import org.opennms.features.topology.api.topo.GraphProvider;
 import org.opennms.features.topology.api.topo.Vertex;
+import org.opennms.features.topology.plugins.topo.graphml.internal.GraphMLServiceAccessor;
 
 import com.google.common.io.Files;
 import com.google.common.io.Resources;
@@ -58,7 +59,7 @@ public class GraphMLMetaTopologyProviderTest {
         Resources.asByteSource(Resources.getResource("test-graph.xml")).copyTo(Files.asByteSink(graphXml));
 
         // Initialize the meta topology provider
-        final GraphMLMetaTopologyProvider metaTopoProvider = new GraphMLMetaTopologyProvider();
+        final GraphMLMetaTopologyProvider metaTopoProvider = new GraphMLMetaTopologyProvider(new GraphMLServiceAccessor());
         metaTopoProvider.setTopologyLocation(graphXml.getAbsolutePath());
         metaTopoProvider.load();
 

--- a/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.graphml/src/test/java/org/opennms/features/topology/plugins/topo/graphml/GraphMLSearchProviderTest.java
+++ b/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.graphml/src/test/java/org/opennms/features/topology/plugins/topo/graphml/GraphMLSearchProviderTest.java
@@ -43,6 +43,7 @@ import org.opennms.features.topology.app.internal.ProviderManager;
 import org.opennms.features.topology.app.internal.VEProviderGraphContainer;
 import org.opennms.features.topology.app.internal.gwt.client.SearchSuggestion;
 import org.opennms.features.topology.app.internal.ui.SearchBox;
+import org.opennms.features.topology.plugins.topo.graphml.internal.GraphMLServiceAccessor;
 import org.opennms.osgi.OnmsServiceManager;
 
 public class GraphMLSearchProviderTest {
@@ -52,7 +53,7 @@ public class GraphMLSearchProviderTest {
         GraphMLGraph graph = new GraphMLGraph();
         graph.setProperty(GraphMLProperties.NAMESPACE, "namespace1:graph1");
 
-        GraphMLTopologyProvider topologyProvider = new GraphMLTopologyProvider(graph);
+        GraphMLTopologyProvider topologyProvider = new GraphMLTopologyProvider(graph, new GraphMLServiceAccessor());
         GraphMLSearchProvider searchProvider = new GraphMLSearchProvider(topologyProvider);
         Assert.assertEquals(true, searchProvider.contributesTo("namespace1:graph1"));
         Assert.assertEquals(true, searchProvider.contributesTo("namespace1:graph2"));
@@ -62,7 +63,7 @@ public class GraphMLSearchProviderTest {
 
     @Test
     public void canSearchAllSearchProviders() {
-        final GraphMLMetaTopologyProvider metaTopologyProvider = new GraphMLMetaTopologyProvider();
+        final GraphMLMetaTopologyProvider metaTopologyProvider = new GraphMLMetaTopologyProvider(new GraphMLServiceAccessor());
         metaTopologyProvider.setTopologyLocation("target/test-classes/test-graph.xml");
         metaTopologyProvider.load();
         Assert.assertNotNull(metaTopologyProvider.getDefaultGraphProvider());

--- a/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.graphml/src/test/java/org/opennms/features/topology/plugins/topo/graphml/GraphMLVertexStatusProviderTest.java
+++ b/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.graphml/src/test/java/org/opennms/features/topology/plugins/topo/graphml/GraphMLVertexStatusProviderTest.java
@@ -42,6 +42,7 @@ import org.opennms.features.topology.api.topo.Criteria;
 import org.opennms.features.topology.api.topo.DefaultVertexRef;
 import org.opennms.features.topology.api.topo.Status;
 import org.opennms.features.topology.api.topo.VertexRef;
+import org.opennms.features.topology.plugins.topo.graphml.internal.GraphMLServiceAccessor;
 import org.opennms.netmgt.model.OnmsSeverity;
 import org.opennms.netmgt.model.alarm.AlarmSummary;
 
@@ -53,7 +54,7 @@ public class GraphMLVertexStatusProviderTest {
     @Test
     public void testStatusProvider() throws InvalidGraphException {
         GraphML graphML = GraphMLReader.read(getClass().getResourceAsStream("/test-graph.xml"));
-        GraphMLTopologyProvider topologyProvider = new GraphMLTopologyProvider(graphML.getGraphs().get(0));
+        GraphMLTopologyProvider topologyProvider = new GraphMLTopologyProvider(graphML.getGraphs().get(0), new GraphMLServiceAccessor());
         GraphMLVertexStatusProvider statusProvider = new GraphMLVertexStatusProvider(topologyProvider.getVertexNamespace(), nodeIds -> Lists.newArrayList(
                 createSummary(1, "North", OnmsSeverity.WARNING, 1),
                 createSummary(2, "West", OnmsSeverity.MINOR, 2),

--- a/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.graphml/src/test/resources/test-graph2.xml
+++ b/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.graphml/src/test/resources/test-graph2.xml
@@ -8,6 +8,8 @@
     <key id="namespace" for="graph" attr.name="namespace" attr.type="string"></key>
     <key id="preferred-layout" for="graph" attr.name="preferred-layout" attr.type="string"></key>
     <key id="nodeID" for="node" attr.name="nodeID" attr.type="int"></key>
+    <key id="foreignSource" for="node" attr.name="foreignSource" attr.type="string"></key>
+    <key id="foreignID" for="node" attr.name="foreignID" attr.type="string"></key>
     <graph id="regions" edgedefault="undirected">
         <data key="namespace">acme:regions</data>
         <node id="center">
@@ -20,6 +22,8 @@
         </node>
         <node id="west">
             <data key="label">West</data>
+            <data key="foreignSource">imported:</data>
+            <data key="foreignID">4</data>
         </node>
         <node id="south">
             <data key="label">South</data>


### PR DESCRIPTION

* JIRA: http://issues.opennms.org/browse/HZN-825
* Bamboo: http://bamboo.internal.opennms.com:8085/browse/OPENNMS-ONMS833

Please note that the related documentation changes were made in the branch jira/HZN-801.


