### PR TITLE
NMS-8550: Pollerd configuration files

### DIFF
--- a/opennms-doc/guide-admin/src/asciidoc/index.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/index.adoc
@@ -183,13 +183,13 @@ include::text/operation/newts/cassandra-newts-jmx.adoc[]
 
 [[ga-opennms-operation-daemon-config-files]]
 === Daemon Configuration Files
+include::text/operation/daemon-config-files/introduction.adoc[]
 include::text/operation/daemon-config-files/notifd.adoc[]
+include::text/operation/daemon-config-files/pollerd.adoc[]
 
 [[ga-ticketing]]
 == Ticketing
 include::text/ticketing/introduction.adoc[]
-
-// JIRA Ticketer
 include::text/ticketing/jira.adoc[]
 
 [[ga-rmi]]

--- a/opennms-doc/guide-admin/src/asciidoc/text/operation/daemon-config-files/introduction.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/operation/daemon-config-files/introduction.adoc
@@ -1,0 +1,6 @@
+
+// Allow GitHub image rendering
+:imagesdir: ../../../images
+
+Configuration changes require a restart of OpenNMS and some daemons are able to reload configuration changes triggered by a daemon reload event.
+This section gives an overview about all daemons and the related configuration files and which can be reloaded without restarting OpenNMS.

--- a/opennms-doc/guide-admin/src/asciidoc/text/operation/daemon-config-files/pollerd.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/operation/daemon-config-files/pollerd.adoc
@@ -1,0 +1,23 @@
+
+// Allow GitHub image rendering
+:imagesdir: ../../../images
+
+[[ga-opennms-operation-daemon-config-files-pollerd]]
+==== Pollerd
+
+[options="header, autowidth"]
+|===
+| Internal Daemon Name | Reload Event
+| _Pollerd_            | `uei.opennms.org/internal/reloadDaemonConfig -p 'daemonName Pollerd'`
+|===
+
+.Pollerd configuration file overview
+[options="header, autowidth"]
+|===
+| File                        | Restart Required | Reload Event | Description
+| `poller-configuration.xml`  | yes              | yes          | Restart is required in case new monitors are created or removed.
+                                                                  Reload Event loads changed configuration parameters of existing monitors.
+| `response-graph.properties` | no               | no           | Graph definition for response time graphs from monitors
+| `poll-outages.xml`          | ?                | ?            | ?
+| `poller-config.properties`  | ?                | ?            | ?
+|===

--- a/opennms-doc/guide-admin/src/asciidoc/text/operation/daemon-config-files/pollerd.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/operation/daemon-config-files/pollerd.adoc
@@ -18,5 +18,5 @@
 | `poller-configuration.xml`  | yes              | yes          | Restart is required in case new monitors are created or removed.
                                                                   Reload Event loads changed configuration parameters of existing monitors.
 | `response-graph.properties` | no               | no           | Graph definition for response time graphs from monitors
-| `poll-outages.xml`          | ?                | ?            | ?
+| `poll-outages.xml`          | no               | yes          | Can be reloaded with `uei.opennms.org/internal/schedOutagesChanged`
 |===

--- a/opennms-doc/guide-admin/src/asciidoc/text/operation/daemon-config-files/pollerd.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/operation/daemon-config-files/pollerd.adoc
@@ -19,5 +19,4 @@
                                                                   Reload Event loads changed configuration parameters of existing monitors.
 | `response-graph.properties` | no               | no           | Graph definition for response time graphs from monitors
 | `poll-outages.xml`          | ?                | ?            | ?
-| `poller-config.properties`  | ?                | ?            | ?
 |===


### PR DESCRIPTION
Initialize structure for configuration reload events. Create initial documentation for Pollerd related configuration files and if a restart is required or not.
- JIRA: http://issues.opennms.org/browse/NMS-8550
- Bamboo: Do not worry, we add a link to our continuous integration system here
