### PR TITLE
NMS-8200 only attempt to set ulimit if it is higher than current

### DIFF
--- a/opennms-base-assembly/src/main/filtered/bin/install
+++ b/opennms-base-assembly/src/main/filtered/bin/install
@@ -6,11 +6,17 @@ OPENNMS_BINDIR="${install.bin.dir}"
 RUNAS="root"
 
 ULIMIT=`which ulimit 2>/dev/null`
-if [ -n $ULIMIT ]; then
-	for SIZE in 1024 2048 4096 8192 unlimited; do
-		ulimit -n "$SIZE" >/dev/null 2>&1
-		if [ $? -gt 0 ]; then
+if [ -n $ULIMIT ] && [ -x $ULIMIT ]; then
+	for SIZE in 1024 2048 4096 8192 16384 20480; do
+		let CURRENT=`ulimit -n`
+		if [ $CURRENT = "unlimited" ]; then
 			break
+		fi
+		if [ $CURRENT -lt $SIZE ]; then
+			ulimit -n $SIZE >/dev/null 2>&1
+			if [ $? -gt 0 ]; then
+				break
+			fi
 		fi
 	done
 fi

--- a/opennms-base-assembly/src/main/filtered/bin/install
+++ b/opennms-base-assembly/src/main/filtered/bin/install
@@ -5,8 +5,9 @@ OPENNMS_BINDIR="${install.bin.dir}"
 
 RUNAS="root"
 
-ULIMIT=`which ulimit 2>/dev/null`
-if [ -n $ULIMIT ] && [ -x $ULIMIT ]; then
+# if we have ulimit, attempt to raise it
+ulimit -a >/dev/null 2>&1
+if [ $? -eq 0 ]; then
 	for SIZE in 1024 2048 4096 8192 16384 20480; do
 		let CURRENT=`ulimit -n`
 		if [ $CURRENT = "unlimited" ]; then


### PR DESCRIPTION
This patch changes the $OPENNMS_HOME/bin/install script to only attempt a ulimit -n call to raise the ulimit if the number is higher than the current value.

* JIRA: http://issues.opennms.org/browse/NMS-8200
* Bamboo: http://bamboo.internal.opennms.com:8085/browse/OPENNMS-ONMS859
