### PR TITLE
NMS-8597: Make the gwt.openlayers.url and gwt.openlayers.custom.attri…

### DIFF
--- a/features/remote-poller-gwt/src/main/java/org/opennms/features/poller/remote/gwt/client/OpenLayersMapPanel.java
+++ b/features/remote-poller-gwt/src/main/java/org/opennms/features/poller/remote/gwt/client/OpenLayersMapPanel.java
@@ -176,7 +176,7 @@ public class OpenLayersMapPanel extends Composite implements MapPanel {
 
         XYZOptions xyzOptions = new XYZOptions();
         xyzOptions.setSphericalMercator(true);
-        xyzOptions.setAttribution("Default tiles courtesy of <a href=\"http://open.mapquest.co.uk/\">MapQuest</a>");
+        xyzOptions.setAttribution(getAttribution());
         XYZ x = new XYZ("OpenStreetMap", getLayerUrl(), xyzOptions);
         x.setIsBaseLayer(true);
         x.setIsVisible(true);
@@ -320,6 +320,10 @@ public class OpenLayersMapPanel extends Composite implements MapPanel {
 
     private native String getLayerUrl() /*-{
         return $wnd.openlayersUrl;
+    }-*/;
+
+    private native String getAttribution() /*-{
+        return $wnd.openlayersAttribution;
     }-*/;
 
     /**

--- a/features/vaadin-node-maps/src/main/java/org/opennms/features/vaadin/nodemaps/internal/InvalidConfigurationWindow.java
+++ b/features/vaadin-node-maps/src/main/java/org/opennms/features/vaadin/nodemaps/internal/InvalidConfigurationWindow.java
@@ -1,0 +1,94 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2016 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2016 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.features.vaadin.nodemaps.internal;
+
+import java.io.IOException;
+
+import org.apache.commons.io.IOUtils;
+
+import com.google.common.base.Strings;
+import com.vaadin.shared.ui.label.ContentMode;
+import com.vaadin.ui.Alignment;
+import com.vaadin.ui.Button;
+import com.vaadin.ui.Label;
+import com.vaadin.ui.UI;
+import com.vaadin.ui.VerticalLayout;
+import com.vaadin.ui.Window;
+
+public class InvalidConfigurationWindow extends Window {
+
+    public InvalidConfigurationWindow() {
+        setModal(true);
+        setResizable(false);
+        setWidth(500, Unit.PIXELS);
+        setHeight(250, Unit.PIXELS);
+        setCaption("Configuration Error");
+
+        final Button btnClose = new Button("OK", new Button.ClickListener() {
+            @Override
+            public void buttonClick(Button.ClickEvent event) {
+                close();
+            }
+        });
+        final String errorMessage = getErrorLabel();
+        final Label label = new Label(errorMessage, ContentMode.HTML);
+
+        VerticalLayout rootLayout = new VerticalLayout();
+        rootLayout.setSpacing(true);
+        rootLayout.setMargin(true);
+        rootLayout.addComponent(label);
+        rootLayout.addComponent(btnClose);
+        rootLayout.setExpandRatio(label, 1.0f);
+        rootLayout.setComponentAlignment(btnClose, Alignment.BOTTOM_RIGHT);
+
+        setContent(rootLayout);
+        center();
+    }
+
+    public void open() {
+        UI.getCurrent().addWindow(this);
+    }
+
+    private String getErrorLabel() {
+        try {
+            String errorTemplate = IOUtils.toString(getClass().getResourceAsStream("/error-configuration.txt"), "UTF-8");
+            String problems = "";
+            if (Strings.isNullOrEmpty(NodeMapConfiguration.getTileServerUrl())) {
+                problems = "<li>No <i>gwt.openlayers.url</i> property defined</li>";
+            }
+            if (Strings.isNullOrEmpty(NodeMapConfiguration.getTileLayerAttribution())) {
+                problems += "<li>No <i>gwt.openlayers.options.attribution</i> property defined</li>";
+            }
+            String errorMessage = errorTemplate.replace("{problems}", problems);
+            return errorMessage;
+        } catch (IOException e) {
+            return "Error determining error message: " + e.getMessage();
+        }
+    }
+}

--- a/features/vaadin-node-maps/src/main/java/org/opennms/features/vaadin/nodemaps/internal/NodeMapComponent.java
+++ b/features/vaadin-node-maps/src/main/java/org/opennms/features/vaadin/nodemaps/internal/NodeMapComponent.java
@@ -66,6 +66,8 @@ public class NodeMapComponent extends AbstractComponent {
 
     public NodeMapComponent() {
         registerRpc(m_rpc);
+        getState().tileServerUrl = NodeMapConfiguration.getTileServerUrl();
+        getState().tileLayerOptions = NodeMapConfiguration.getTileLayerOptions();
     }
 
     protected NodeIdSelectionRpc getRpc() {

--- a/features/vaadin-node-maps/src/main/java/org/opennms/features/vaadin/nodemaps/internal/NodeMapConfiguration.java
+++ b/features/vaadin-node-maps/src/main/java/org/opennms/features/vaadin/nodemaps/internal/NodeMapConfiguration.java
@@ -1,0 +1,102 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2016 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2016 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.features.vaadin.nodemaps.internal;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+import org.opennms.features.vaadin.nodemaps.internal.gwt.client.Option;
+
+import com.google.common.base.Strings;
+
+/**
+ * Configuration object introduced to address NMS-8597 and reduce possible merge conflicts.
+ */
+public class NodeMapConfiguration {
+
+    private static final String URL_KEY = "gwt.openlayers.url";
+
+    private static final String OPTIONS_KEY_PREFIX = "gwt.openlayers.options";
+
+    public static String getTileServerUrl() {
+        final String url = System.getProperty(URL_KEY);
+        return sanitizeForVaadin(url);
+    }
+
+    /**
+     * Returns the layer options for the tile layer defined in opennms.properties.
+     * See http://leafletjs.com/reference.html#tilelayer-options for more details.
+     *
+     * @return the layer options for the tile layer defined in opennms.properties.
+     */
+    public static List<Option> getTileLayerOptions() {
+        final Properties properties = System.getProperties();
+        final Map<String, String> options = new HashMap<>();
+        for (Object objectKey : properties.keySet()) {
+            String key = (String) objectKey;
+            if (key.startsWith(OPTIONS_KEY_PREFIX)) {
+                final String optionsKey = key.substring(OPTIONS_KEY_PREFIX.length() + 1);
+                final String optionsValue = properties.getProperty(key);
+                options.put(optionsKey, sanitizeForVaadin(optionsValue));
+            }
+        }
+        final List<Option> optionsList = new ArrayList<>();
+        for (Map.Entry<String, String> eachEntry : options.entrySet()) {
+            optionsList.add(new Option(eachEntry.getKey(), eachEntry.getValue()));
+        }
+        return optionsList;
+    }
+
+    private static String sanitizeForVaadin(String input) {
+        if (Strings.isNullOrEmpty(input)) {
+            return input;
+        }
+        // The input may contain ${variable} statements, which must be converted to {variable} in order to work
+        // with the vaadin gwt abstraction.
+        return input.replaceAll("\\$\\{", "{");
+    }
+
+    public static boolean isValid() {
+        return !Strings.isNullOrEmpty(getTileServerUrl()) && !Strings.isNullOrEmpty(getTileLayerAttribution());
+
+    }
+
+    /**
+     * Returns the 'attribution' tile layer option.
+     * See http://leafletjs.com/reference.html#tilelayer-options for more details.
+     *
+     * @return the 'attribution' tile layer option.
+     */
+    static String getTileLayerAttribution() {
+        return System.getProperty(OPTIONS_KEY_PREFIX + ".attribution");
+    }
+}

--- a/features/vaadin-node-maps/src/main/java/org/opennms/features/vaadin/nodemaps/internal/NodeMapsApplication.java
+++ b/features/vaadin-node-maps/src/main/java/org/opennms/features/vaadin/nodemaps/internal/NodeMapsApplication.java
@@ -285,6 +285,11 @@ public class NodeMapsApplication extends UI {
         createMapPanel(vaadinRequest.getParameter("search"));
         createRootLayout();
         addRefresher();
+
+        // Notify the user if no tileserver url or options are set
+        if (!NodeMapConfiguration.isValid()) {
+            new InvalidConfigurationWindow().open();
+        }
     }
 
     private void createMapPanel(final String searchString) {

--- a/features/vaadin-node-maps/src/main/java/org/opennms/features/vaadin/nodemaps/internal/gwt/client/Option.java
+++ b/features/vaadin-node-maps/src/main/java/org/opennms/features/vaadin/nodemaps/internal/gwt/client/Option.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2013-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2016 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2016 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -28,23 +28,41 @@
 
 package org.opennms.features.vaadin.nodemaps.internal.gwt.client;
 
-import java.util.ArrayList;
-import java.util.LinkedList;
-import java.util.List;
+import java.io.Serializable;
 
-import com.vaadin.shared.AbstractComponentState;
+public class Option implements Serializable {
 
-/**
- * @author Marcus Hellberg (marcus@vaadin.com)
- */
-public class NodeMapState extends AbstractComponentState {
-    private static final long serialVersionUID = -476104177779046228L;
-    public String searchString;
-    public List<MapNode> nodes = new LinkedList<MapNode>();
-    public List<Integer> nodeIds = new ArrayList<Integer>();
-    public int minimumSeverity;
-    public boolean groupByState = true;
-    public int maxClusterRadius = 350;
-    public List<Option> tileLayerOptions = new ArrayList<>();
-    public String tileServerUrl;
+    private String key;
+
+    private String value;
+
+    public Option() {
+    }
+
+    public Option(String key, String value) {
+        this.key = key;
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    public String getKey() {
+
+        return key;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    @Override
+    public String toString() {
+        return "Option[key=" + key + ", value=" + value + "]";
+    }
 }

--- a/features/vaadin-node-maps/src/main/java/org/opennms/features/vaadin/nodemaps/internal/gwt/client/ui/NodeMapConnector.java
+++ b/features/vaadin-node-maps/src/main/java/org/opennms/features/vaadin/nodemaps/internal/gwt/client/ui/NodeMapConnector.java
@@ -109,6 +109,11 @@ public class NodeMapConnector extends AbstractComponentConnector implements HasH
         if (stateChangeEvent.hasPropertyChanged("groupByState")) {
             getWidget().setGroupByState(getState().groupByState);
         }
+        if (!getWidget().isInitialized()
+                && stateChangeEvent.hasPropertyChanged("tileServerUrl")
+                && stateChangeEvent.hasPropertyChanged("tileLayerOptions")) {
+            getWidget().initialize(getState());
+        }
     }
 
     private void updateNodes() {

--- a/features/vaadin-node-maps/src/main/java/org/opennms/features/vaadin/nodemaps/internal/gwt/client/ui/NodeMapWidget.java
+++ b/features/vaadin-node-maps/src/main/java/org/opennms/features/vaadin/nodemaps/internal/gwt/client/ui/NodeMapWidget.java
@@ -37,7 +37,6 @@ import java.util.logging.Logger;
 import org.discotools.gwt.leaflet.client.Options;
 import org.discotools.gwt.leaflet.client.controls.zoom.Zoom;
 import org.discotools.gwt.leaflet.client.controls.zoom.ZoomOptions;
-import org.discotools.gwt.leaflet.client.crs.epsg.EPSG3857;
 import org.discotools.gwt.leaflet.client.layers.ILayer;
 import org.discotools.gwt.leaflet.client.layers.raster.TileLayer;
 import org.discotools.gwt.leaflet.client.map.MapOptions;
@@ -48,8 +47,10 @@ import org.opennms.features.vaadin.nodemaps.internal.gwt.client.AlarmSeverity;
 import org.opennms.features.vaadin.nodemaps.internal.gwt.client.ComponentTracker;
 import org.opennms.features.vaadin.nodemaps.internal.gwt.client.JSNodeMarker;
 import org.opennms.features.vaadin.nodemaps.internal.gwt.client.Map;
+import org.opennms.features.vaadin.nodemaps.internal.gwt.client.NodeMapState;
 import org.opennms.features.vaadin.nodemaps.internal.gwt.client.NodeMarker;
 import org.opennms.features.vaadin.nodemaps.internal.gwt.client.OpenNMSEventManager;
+import org.opennms.features.vaadin.nodemaps.internal.gwt.client.Option;
 import org.opennms.features.vaadin.nodemaps.internal.gwt.client.event.ApplicationInitializedEvent;
 import org.opennms.features.vaadin.nodemaps.internal.gwt.client.event.ApplicationInitializedEventHandler;
 import org.opennms.features.vaadin.nodemaps.internal.gwt.client.event.FilteredMarkersUpdatedEvent;
@@ -95,6 +96,8 @@ public class NodeMapWidget extends AbsolutePanel implements MarkerProvider, Filt
 
     private SimplePanel m_mapPanel = new SimplePanel();
 
+    private boolean initialized = false;
+
     public NodeMapWidget() {
         m_eventManager = new OpenNMSEventManager();
         m_eventManager.addHandler(FilteredMarkersUpdatedEvent.TYPE, this);
@@ -135,15 +138,6 @@ public class NodeMapWidget extends AbsolutePanel implements MarkerProvider, Filt
 
                     m_filter = new MarkerFilterImpl("", AlarmSeverity.NORMAL, m_eventManager, m_componentTracker);
                     m_markerContainer = new MarkerContainer(m_filter, m_eventManager, m_componentTracker);
-
-                    m_filter.onLoad();
-                    m_markerContainer.onLoad();
-
-                    Scheduler.get().scheduleDeferred(new ScheduledCommand() {
-                        @Override public void execute() {
-                            initializeMap(m_div.getId());
-                        }
-                    });
                 } else {
                     LOG.info("NodeMapwidget.onDetach()");
                     if (m_markerContainer != null) m_markerContainer.onUnload();
@@ -152,15 +146,25 @@ public class NodeMapWidget extends AbsolutePanel implements MarkerProvider, Filt
                 }
             }
         });
-        LOG.info("NodeMapWidget(): initialized");
     }
 
-    private void initializeMap(final String divId) {
+    public void initialize(final NodeMapState state) {
         LOG.info("NodeMapWidget.initializeMap()");
 
-        createMap(divId);
-        // createGoogleLayer();
-        addTileLayer();
+        // Defer actual initialization until after the browser
+        // event loop because otherwise Vaadin isn't done setting
+        // up yet.
+        Scheduler.get().scheduleDeferred(new ScheduledCommand() {
+            @Override public void execute() {
+                doInitialization(state);
+            }
+        });
+    }
+
+    private void doInitialization(final NodeMapState state) {
+        // layers
+        createMap(m_div.getId());
+        addTileLayer(state.tileServerUrl, state.tileLayerOptions);
         addMarkerLayer();
 
         // overlay controls
@@ -168,20 +172,16 @@ public class NodeMapWidget extends AbsolutePanel implements MarkerProvider, Filt
         addAlarmControl();
         addZoomControl();
 
+        m_filter.onLoad();
+        m_markerContainer.onLoad();
         m_searchControl.focusInput();
         m_componentTracker.ready(getClass());
+        initialized = true;
         LOG.info("NodeMapWidget.initializeMap(): finished");
     }
 
-    @SuppressWarnings("unused")
-    private void createGoogleLayer() {
-        final EPSG3857 projection = new EPSG3857();
-        final Options googleOptions = new Options();
-        googleOptions.setProperty("crs", projection);
-
-        LOG.info("NodeMapWidget.createGoogleLayer(): adding Google layer");
-        m_layer = new GoogleLayer("SATELLITE", googleOptions);
-        m_map.addLayer(m_layer, true);
+    public boolean isInitialized() {
+        return initialized;
     }
 
     private void createMap(final String divId) {
@@ -193,16 +193,16 @@ public class NodeMapWidget extends AbsolutePanel implements MarkerProvider, Filt
         m_map = new Map(divId, options);
     }
 
-    private void addTileLayer() {
-        LOG.info("NodeMapWidget.addTileLayer()");
-        final String attribution = "Map data &copy; <a tabindex=\"-1\" href=\"http://openstreetmap.org\">OpenStreetMap</a> contributors, <a tabindex=\"-1\" href=\"http://creativecommons.org/licenses/by-sa/2.0/\">CC-BY-SA</a>, Tiles &copy; <a tabindex=\"-1\" href=\"http://www.mapquest.com/\" target=\"_blank\">MapQuest</a> <img src=\"http://developer.mapquest.com/content/osm/mq_logo.png\" />";
-        final String url = "http://otile{s}.mqcdn.com/tiles/1.0.0/{type}/{z}/{x}/{y}.png";
+    private void addTileLayer(String tileUrl, List<Option> optionsList) {
+        LOG.info("NodeMapWidget.setTileLayer(String, Option...) start");
+        LOG.info("NodeMapWidget.setTileLayer tileServerUrl: " + tileUrl + "," + optionsList);
         final Options tileOptions = new Options();
-        tileOptions.setProperty("attribution", attribution);
-        tileOptions.setProperty("subdomains", "1234");
-        tileOptions.setProperty("type", "osm");
-        m_layer = new TileLayer(url, tileOptions);
+        for (Option eachOption : optionsList) {
+            tileOptions.setProperty(eachOption.getKey(), eachOption.getValue());
+        }
+        m_layer = new TileLayer(tileUrl, tileOptions);
         m_map.addLayer(m_layer, true);
+        LOG.info("NodeMapWidget.setTileLayer(String, Option...) end");
     }
 
 
@@ -309,9 +309,13 @@ public class NodeMapWidget extends AbsolutePanel implements MarkerProvider, Filt
 
     private void clearExistingMarkers() {
         LOG.info("NodeMapWidget.clearExistingMarkers()");
-        m_markerClusterGroup.clearLayers();
-        for (int i = 0; i < m_stateClusterGroups.length; i++) {
-            m_stateClusterGroups[i].clearLayers();
+        if (m_markerClusterGroup != null) {
+            m_markerClusterGroup.clearLayers();
+        }
+        if (m_stateClusterGroups != null) {
+            for (int i = 0; i < m_stateClusterGroups.length; i++) {
+                m_stateClusterGroups[i].clearLayers();
+            }
         }
     }
 
@@ -444,8 +448,10 @@ public class NodeMapWidget extends AbsolutePanel implements MarkerProvider, Filt
     private final void destroyMap() {
         if (m_markerClusterGroup != null) {
             m_markerClusterGroup.clearLayers();
-            for (int i = 0; i < m_stateClusterGroups.length; i++) {
-                m_stateClusterGroups[i].clearLayers();
+            if (m_stateClusterGroups != null) {
+                for (int i = 0; i < m_stateClusterGroups.length; i++) {
+                    m_stateClusterGroups[i].clearLayers();
+                }
             }
         }
         if (m_map != null) {

--- a/features/vaadin-node-maps/src/main/resources/error-configuration.txt
+++ b/features/vaadin-node-maps/src/main/resources/error-configuration.txt
@@ -1,0 +1,7 @@
+The Geographical Map is not configured correctly.<br/>
+The following problems occurred:
+<ul>
+{problems}
+</ul>
+
+Please define the above properties in opennms.properties.<br/>

--- a/opennms-base-assembly/src/main/filtered/etc/opennms.properties
+++ b/opennms-base-assembly/src/main/filtered/etc/opennms.properties
@@ -488,11 +488,9 @@ gwt.geocoder.email=
 # The tile server URL to use for OpenLayers.  This can be any mapnik-style tile server URL.
 # (Sorry, no support for multiple URLs yet.)
 
-# OpenStreetMap tile server
-# gwt.openlayers.url=http://a.tile.openstreetmap.org/${z}/${x}/${y}.png
-
-# Open MapQuest tile server
-gwt.openlayers.url=http://otile1.mqcdn.com/tiles/1.0.0/osm/${z}/${x}/${y}.png
+# OpenNMS default tile server
+gwt.openlayers.url=https://tiles.opennms.org/${z}/${x}/${y}.png
+gwt.openlayers.options.attribution=Map data &copy; <a tabindex="-1" target="_blank" href="http://openstreetmap.org/copyright">OpenStreetMap</a> contributors under <a tabindex="-1" target="_blank" href="http://opendatacommons.org/licenses/odbl/">ODbL</a>, <a tabindex="-1" target="_blank" href="http://creativecommons.org/licenses/by-sa/2.0/">CC BY-SA 2.0</a>
 
 ###### UI DISPLAY OPTIONS ######
 


### PR DESCRIPTION
This issue makes the tileserver url and the tile layer attribution properties configurable.
In addition the missing configuration for the node maps is added.

Please try out both, the Node Maps and the Remote Poller Maps, as on my local system the Node Maps looks weird (not centered when first visited), but I do not know if it is a new issue or already existed before.

Before testing this, please clear your browser cache.

* JIRA: http://issues.opennms.org/browse/NMS-8597
* BAMBOO: http://bamboo.internal.opennms.com:8085/browse/OPENNMS-ONMS862