### PR TITLE
NMS-8008: separate opennms source tarball into separate package(s)

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -8,6 +8,7 @@ Standards-Version: 3.7.3
 Package: opennms
 Architecture: all
 Depends: opennms-db (=${binary:Version}), opennms-server (=${binary:Version}), opennms-webapp-jetty (=${binary:Version})
+Recommends: opennms-source (=${binary:Version})
 Suggests: opennms-doc
 Description: Enterprise-grade Open-source Network Management Platform (Full Install)
  OpenNMS is an enterprise-grade network management system written in Java.
@@ -20,6 +21,21 @@ Description: Enterprise-grade Open-source Network Management Platform (Full Inst
  .
  This package provides the components needed for a reasonable default
  installation of OpenNMS.
+
+Package: opennms-source
+Architecture: all
+Depends: opennms-webapp-jetty (=${binary:Version})
+Description: Enterprise-grade Open-source Network Management Platform (Source)
+ OpenNMS is an enterprise-grade network management system written in Java.
+ .
+ OpenNMS can monitor various network services to determine status and service
+ level availability.  Data collection is performed using protocols such as SNMP
+ to generate reports and alert on thresholds.  An extensible event management
+ and notification system handles both internally and externally generated
+ events (such as SNMP traps), and generates notices via email, pager, SMS, etc.
+ .
+ This package contains the source tarball to be installed alongside the web UI
+ for AGPL-compliance.
 
 Package: opennms-db
 Architecture: all

--- a/debian/opennms-source.dirs
+++ b/debian/opennms-source.dirs
@@ -1,0 +1,1 @@
+usr/share/opennms/jetty-webapps/opennms/source

--- a/debian/rules
+++ b/debian/rules
@@ -315,6 +315,13 @@ install: build
 	rm -rf debian/temp/contrib/remote-poller
 
 	##
+	## Setup the opennms-source package
+	##
+	install -d -m 755 debian/opennms-source/usr/share/opennms/jetty-webapps/opennms
+	mv debian/temp/jetty-webapps/opennms/source debian/opennms-source/usr/share/opennms/jetty-webapps/opennms/
+	find debian/opennms-webapp-jetty/usr/share/opennms/jetty-webapps/opennms* -type f -execdir chmod 644 {} \;
+
+	##
 	## Setup the opennms-webapp-jetty package
 	##
 	install -m 644 debian/opennms-webapp-jetty.overrides debian/opennms-webapp-jetty/usr/share/lintian/overrides/opennms-webapp-jetty

--- a/tools/packages/opennms/opennms.spec
+++ b/tools/packages/opennms/opennms.spec
@@ -66,6 +66,8 @@ Requires:		%{name}-core        = %{version}-%{release}
 Requires(pre):		postgresql-server  >= 9.1
 Requires:		postgresql-server  >= 9.1
 
+Recommends:		%{name}-source      = %{version}-%{release}
+
 # don't worry about buildrequires, the shell script will bomb quick  =)
 #BuildRequires:		%{jdk}
 
@@ -114,6 +116,17 @@ If you wish to install them to an alternate location, use the --relocate rpm
 option, like so:
 
   rpm -i --relocate %{logdir}=/mnt/netapp/%{name}-logs %{name}-core.rpm
+
+%{extrainfo}
+%{extrainfo2}
+
+
+%package source
+Summary:	Source for the %{_descr} network management platform
+Group:		Applications/System
+
+%description source
+This package contains the source tarball for %{_descr}, for AGPL compliance.
 
 %{extrainfo}
 %{extrainfo2}
@@ -696,6 +709,7 @@ find $RPM_BUILD_ROOT%{instprefix}/etc $RPM_BUILD_ROOT%{instprefix}/lib $RPM_BUIL
 # jetty
 find $RPM_BUILD_ROOT%{jettydir} ! -type d | \
 	sed -e "s,^$RPM_BUILD_ROOT,," | \
+	grep -v '/opennms/source/' | \
 	grep -v '/WEB-INF/[^/]*\.xml$' | \
 	grep -v '/WEB-INF/[^/]*\.properties$' | \
 	grep -v '/WEB-INF/jsp/alarm/ncs' | \
@@ -756,6 +770,10 @@ rm -rf $RPM_BUILD_ROOT
 %dir %{sharedir}/etc-pristine/drools-engine.d/ncs
 %{sharedir}/etc-pristine/drools-engine.d/ncs/*
 %{sharedir}/etc-pristine/ncs-northbounder-configuration.xml
+
+%files source
+%defattr(644 root root 755)
+%{jettydir}/opennms/source/*
 
 %files webapp-jetty -f %{_tmppath}/files.jetty
 %defattr(644 root root 755)


### PR DESCRIPTION
This package separates out the opennms source tarball (packaged for GPL-compliance) into a separate package to make the default install smaller.

* JIRA: http://issues.opennms.org/browse/NMS-8008
* Bamboo: http://bamboo.internal.opennms.com:8085/browse/OPENNMS-ONMS864
