### PR TITLE
NMS-8616: Add caution section for wrong DNS A Resource Record

### DIFF
--- a/opennms-doc/guide-install/src/asciidoc/text/opennms/introduction.adoc
+++ b/opennms-doc/guide-install/src/asciidoc/text/opennms/introduction.adoc
@@ -26,6 +26,10 @@ Installing _OpenNMS_ requires the following prerequisites:
 ** <<gi-rrdtool-time-series-database, RRDtool>>: A higher performance, file-based database.
 ** <<gi-install-ts-newts, Newts>>: The highest performance solution. Newts uses an Apache Cassandra database for clustered scalability.
 
+CAUTION: Please make sure your DNS settings are correct.
+         In case there is a wrong _A Resource Record_ of the hostname of the server can prevent OpenNMS from start.
+         There will be an exception cause no security manager can be initialized and a _RMI class loader disabled_ is shown.
+
 NOTE: _OpenJDK 8_ can be used, but for production and critical environments _Oracle Java SE Development Kit 8_ is recommended.
 
 [NOTE]

--- a/opennms-doc/guide-install/src/asciidoc/text/opennms/introduction.adoc
+++ b/opennms-doc/guide-install/src/asciidoc/text/opennms/introduction.adoc
@@ -26,9 +26,9 @@ Installing _OpenNMS_ requires the following prerequisites:
 ** <<gi-rrdtool-time-series-database, RRDtool>>: A higher performance, file-based database.
 ** <<gi-install-ts-newts, Newts>>: The highest performance solution. Newts uses an Apache Cassandra database for clustered scalability.
 
-CAUTION: Please make sure your DNS settings for the OpenNMS server is correct.
-         In case there is a wrong _A Resource Record_ for the server, OpenNMS might not start correctly.
-         The reason is the security manager cannot be initialized and a _RMI class loader disabled_ exception is shown.
+CAUTION: Please make sure your DNS settings for the OpenNMS server are correct.
+         In case there is an incorrect or missing _A Resource Record_ for the server, OpenNMS might not start correctly.
+         The reason is that the Java security manager cannot be initialized and an _RMI class loader disabled_ exception will be shown.
 
 NOTE: _OpenJDK 8_ can be used, but for production and critical environments _Oracle Java SE Development Kit 8_ is recommended.
 

--- a/opennms-doc/guide-install/src/asciidoc/text/opennms/introduction.adoc
+++ b/opennms-doc/guide-install/src/asciidoc/text/opennms/introduction.adoc
@@ -26,9 +26,9 @@ Installing _OpenNMS_ requires the following prerequisites:
 ** <<gi-rrdtool-time-series-database, RRDtool>>: A higher performance, file-based database.
 ** <<gi-install-ts-newts, Newts>>: The highest performance solution. Newts uses an Apache Cassandra database for clustered scalability.
 
-CAUTION: Please make sure your DNS settings are correct.
-         In case there is a wrong _A Resource Record_ of the hostname of the server, it can prevent OpenNMS from start.
-         There will be an error message cause no security manager can be initialized and a _RMI class loader disabled_ exception is shown.
+CAUTION: Please make sure your DNS settings for the OpenNMS server is correct.
+         In case there is a wrong _A Resource Record_ for the server, OpenNMS might not start correctly.
+         The reason is the security manager cannot be initialized and a _RMI class loader disabled_ exception is shown.
 
 NOTE: _OpenJDK 8_ can be used, but for production and critical environments _Oracle Java SE Development Kit 8_ is recommended.
 

--- a/opennms-doc/guide-install/src/asciidoc/text/opennms/introduction.adoc
+++ b/opennms-doc/guide-install/src/asciidoc/text/opennms/introduction.adoc
@@ -27,8 +27,8 @@ Installing _OpenNMS_ requires the following prerequisites:
 ** <<gi-install-ts-newts, Newts>>: The highest performance solution. Newts uses an Apache Cassandra database for clustered scalability.
 
 CAUTION: Please make sure your DNS settings are correct.
-         In case there is a wrong _A Resource Record_ of the hostname of the server can prevent OpenNMS from start.
-         There will be an exception cause no security manager can be initialized and a _RMI class loader disabled_ is shown.
+         In case there is a wrong _A Resource Record_ of the hostname of the server, it can prevent OpenNMS from start.
+         There will be an error message cause no security manager can be initialized and a _RMI class loader disabled_ exception is shown.
 
 NOTE: _OpenJDK 8_ can be used, but for production and critical environments _Oracle Java SE Development Kit 8_ is recommended.
 


### PR DESCRIPTION
Give users a hint to verify DNS A record settings. Wrong A record settings can prevent OpenNMS from start and a exception is shown.
- JIRA: http://issues.opennms.org/browse/NMS-8616
- Bamboo: 
