### PR TITLE
NMS-8637: The categories ReST end point returns HTTP 500 when querying it with a browser.

### DIFF
--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/CategoryRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/CategoryRestService.java
@@ -135,6 +135,7 @@ public class CategoryRestService extends OnmsRestService {
 
     @GET
     @Path("/{categoryName}")
+    @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
     public OnmsCategory getCategory(@PathParam("categoryName") final String categoryName) {
         OnmsCategory category = m_categoryDao.findByName(categoryName);
         if (category == null) throw getException(Response.Status.NOT_FOUND, "Category with name '{}' was not found.", categoryName);
@@ -155,6 +156,7 @@ public class CategoryRestService extends OnmsRestService {
 
     @GET
     @Path("/")
+    @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
     public OnmsCategoryCollection listCategories() {
         return new OnmsCategoryCollection(new ArrayList<OnmsCategory>(m_categoryDao.findAll()));
     }
@@ -185,6 +187,7 @@ public class CategoryRestService extends OnmsRestService {
 
     @GET
     @Path("/groups/{groupName}")
+    @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
     public OnmsCategoryCollection listCategoriesForGroup(@Context final ResourceContext context, @PathParam("groupName") final String groupName) {
         return context.getResource(GroupRestService.class).listCategories(groupName);
     }


### PR DESCRIPTION
The categories ReST end point returns HTTP 500 when querying it with a browser.

* JIRA: http://issues.opennms.org/browse/NMS-8637
* Bamboo: http://bamboo.internal.opennms.com:8085/browse/OPENNMS-ONMS916

**NOTE: For foundation/Meridian-2015 the fix has to be manually ported because the ReST API lives in opennms-webapp instead of opennms-webapp-rest. I'm planning to do this when this is merged into foundation-2016.**