### PR TITLE
remove junit version overrides, accept the parent-pom version

### DIFF
--- a/core/daemon/pom.xml
+++ b/core/daemon/pom.xml
@@ -146,7 +146,6 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.11</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/dependencies/pax-exam/pom.xml
+++ b/dependencies/pax-exam/pom.xml
@@ -63,7 +63,6 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <!-- <version>4.11</version> -->
     </dependency>
 
     <!-- Pax Exam features.xml -->

--- a/opennms-config-tester/pom.xml
+++ b/opennms-config-tester/pom.xml
@@ -40,7 +40,6 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.11</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
This is just a small patch to make sure we're using the same (4.12) JUnit everywhere.  There were a few places in the code that used to override to a *newer* version (at the time, 4.11) back when we were forced to use an old version for historical reasons.  Now those overrides are out-of-date.  ;)

No JIRA issue since it's a small change, but it passed in Bamboo already.