### PR TITLE
NMS-7934: Fix it so that syslog 'Info' events match eventconf

### DIFF
--- a/opennms-services/src/main/java/org/opennms/netmgt/syslogd/SyslogSeverity.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/syslogd/SyslogSeverity.java
@@ -35,7 +35,7 @@ public enum SyslogSeverity {
     ERROR(3, "error conditions"),
     WARNING(4, "warning conditions"),
     NOTICE(5, "normal but significant condition"),
-    INFORMATIONAL(6, "informational messages"),
+    INFO(6, "informational messages"),
     DEBUG(7, "debug-level messages"),
     ALL(8, "all levels"),
     UNKNOWN(99, "unknown");

--- a/opennms-services/src/test/java/org/opennms/netmgt/syslogd/SyslogMessageTest.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/syslogd/SyslogMessageTest.java
@@ -77,7 +77,7 @@ public class SyslogMessageTest {
         final SyslogMessage message = parser.parse();
 
         assertEquals(SyslogFacility.KERNEL, message.getFacility());
-        assertEquals(SyslogSeverity.INFORMATIONAL, message.getSeverity());
+        assertEquals(SyslogSeverity.INFO, message.getSeverity());
         assertEquals("test", message.getMessageID());
         assertEquals("127.0.0.1", message.getHostName());
         assertEquals("OpenNMS", message.getProcessName());
@@ -187,7 +187,7 @@ public class SyslogMessageTest {
         final Date date = new Date(1167609600000L);
 
         assertEquals(SyslogFacility.KERNEL, message.getFacility());
-        assertEquals(SyslogSeverity.INFORMATIONAL, message.getSeverity());
+        assertEquals(SyslogSeverity.INFO, message.getSeverity());
         assertEquals("test", message.getMessageID());
         assertEquals(date, message.getDate());
         assertEquals("127.0.0.1", message.getHostName());
@@ -204,7 +204,7 @@ public class SyslogMessageTest {
         final Date date = new Date(1167609600000L);
 
         assertEquals(SyslogFacility.KERNEL, message.getFacility());
-        assertEquals(SyslogSeverity.INFORMATIONAL, message.getSeverity());
+        assertEquals(SyslogSeverity.INFO, message.getSeverity());
         assertEquals("test", message.getMessageID());
         assertEquals(date, message.getDate());
         assertEquals("127.0.0.1", message.getHostName());


### PR DESCRIPTION
Changed 'Informational' back to 'Info'.

* JIRA: http://issues.opennms.org/browse/NMS-7934
* Bamboo: http://bamboo.internal.opennms.com:8085/browse/OPENNMS-ONMS958