### PR TITLE
HZN-776: Add JMX collections and graphs for remaining Minion metrics

### DIFF
--- a/opennms-base-assembly/src/main/filtered/etc/jmx-datacollection-config.d/kafka.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/jmx-datacollection-config.d/kafka.xml
@@ -9,6 +9,7 @@
             <rra>RRA:MIN:0.5:288:366</rra>
         </rrd>
         <mbeans>
+
             <mbean name="JVM Memory" objectname="java.lang:type=OperatingSystem">
                 <attrib name="FreePhysicalMemorySize" alias="FreeMemory" type="gauge"/>
                 <attrib name="TotalPhysicalMemorySize" alias="TotalMemory" type="gauge"/>
@@ -21,7 +22,7 @@
                 <attrib name="DaemonThreadCount" alias="DaemonThreadCount" type="gauge"/>
                 <attrib name="CurrentThreadCpuTime" alias="CurThreadCpuTime" type="gauge"/>
             </mbean>
-             <mbean name="JVM GarbageCollector:MarkSweepCompact" objectname="java.lang:type=GarbageCollector,name=MarkSweepCompact">
+            <mbean name="JVM GarbageCollector:MarkSweepCompact" objectname="java.lang:type=GarbageCollector,name=MarkSweepCompact">
                 <attrib name="CollectionCount" alias="MSCCollCnt" type="counter"/>
                 <attrib name="CollectionTime" alias="MSCCollTime" type="counter"/>
                 <comp-attrib name="LastGcInfo" type="Composite" alias="MSCLastGcInfo">
@@ -30,26 +31,24 @@
                     <comp-member name="endTime" type="gauge" alias="MSCEndTime"/>
                 </comp-attrib>
             </mbean>
-            
-            
-               <!-- TODO: NMS-8545: Add Kafka JMX metrics to this configuration -->
-      <mbean name="Syslog Bytes In PerSecond Metrics" objectname="kafka.server:type=BrokerTopicMetrics,name=BytesInPerSec,topic=syslog">
-            <attrib name="Count" alias="syslogInBytesCount" type="gauge"/>
-        </mbean>
-        
-       <mbean name="Syslog Bytes Out PerSecond Metrics" objectname="kafka.server:type=BrokerTopicMetrics,name=BytesOutPerSec,topic=syslog">
-            <attrib name="Count" alias="syslogOutBytesCount" type="gauge"/>
-        </mbean>
-        
-        <mbean name="Trap Bytes In PerSecond Metrics" objectname="kafka.server:type=BrokerTopicMetrics,name=BytesInPerSec,topic=trapd">
-            <attrib name="Count" alias="trapInBytesCount" type="gauge"/>
-        </mbean>
-        
-        <mbean name="Trap Bytes Out PerSecond Metrics" objectname="kafka.server:type=BrokerTopicMetrics,name=BytesOutPerSec,topic=trapd">
-            <attrib name="Count" alias="trapOutBytesCount" type="gauge"/>
-        </mbean>
-            
-      </mbeans>
-        
+
+            <!-- TODO: NMS-8545: Add Kafka JMX metrics to this configuration -->
+            <mbean name="Syslog Bytes In per Second" objectname="kafka.server:type=BrokerTopicMetrics,name=BytesInPerSec,topic=syslog">
+                <attrib name="Count" alias="syslogInBytesCount" type="gauge"/>
+            </mbean>
+
+            <mbean name="Syslog Bytes Out per Second" objectname="kafka.server:type=BrokerTopicMetrics,name=BytesOutPerSec,topic=syslog">
+                <attrib name="Count" alias="syslogOutBytesCount" type="gauge"/>
+            </mbean>
+
+            <mbean name="Trap Bytes In per Second" objectname="kafka.server:type=BrokerTopicMetrics,name=BytesInPerSec,topic=trapd">
+                <attrib name="Count" alias="trapInBytesCount" type="gauge"/>
+            </mbean>
+
+            <mbean name="Trap Bytes Out per Second" objectname="kafka.server:type=BrokerTopicMetrics,name=BytesOutPerSec,topic=trapd">
+                <attrib name="Count" alias="trapOutBytesCount" type="gauge"/>
+            </mbean>
+
+        </mbeans>
     </jmx-collection>
 </jmx-datacollection-config>

--- a/opennms-base-assembly/src/main/filtered/etc/jmx-datacollection-config.d/kafka.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/jmx-datacollection-config.d/kafka.xml
@@ -30,9 +30,26 @@
                     <comp-member name="endTime" type="gauge" alias="MSCEndTime"/>
                 </comp-attrib>
             </mbean>
-        </mbeans>
-
-        <!-- TODO: NMS-8545: Add Kafka JMX metrics to this configuration -->
-
+            
+            
+               <!-- TODO: NMS-8545: Add Kafka JMX metrics to this configuration -->
+      <mbean name="Syslog Bytes In PerSecond Metrics" objectname="kafka.server:type=BrokerTopicMetrics,name=BytesInPerSec,topic=syslog">
+            <attrib name="Count" alias="syslogInBytesCount" type="gauge"/>
+        </mbean>
+        
+       <mbean name="Syslog Bytes Out PerSecond Metrics" objectname="kafka.server:type=BrokerTopicMetrics,name=BytesOutPerSec,topic=syslog">
+            <attrib name="Count" alias="syslogOutBytesCount" type="gauge"/>
+        </mbean>
+        
+        <mbean name="Trap Bytes In PerSecond Metrics" objectname="kafka.server:type=BrokerTopicMetrics,name=BytesInPerSec,topic=trapd">
+            <attrib name="Count" alias="trapInBytesCount" type="gauge"/>
+        </mbean>
+        
+        <mbean name="Trap Bytes Out PerSecond Metrics" objectname="kafka.server:type=BrokerTopicMetrics,name=BytesOutPerSec,topic=trapd">
+            <attrib name="Count" alias="trapOutBytesCount" type="gauge"/>
+        </mbean>
+            
+      </mbeans>
+        
     </jmx-collection>
 </jmx-datacollection-config>

--- a/opennms-base-assembly/src/main/filtered/etc/jmx-datacollection-config.d/minion.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/jmx-datacollection-config.d/minion.xml
@@ -120,14 +120,30 @@
             </mbean>
 
 
+            <!-- Route stats for RPC.Server.Detect -->
+            <mbean name="Provisioning Detectors RPC Server" objectname="org.apache.camel:context=org.opennms.core.ipc.rpc.camel-impl,type=routes,name=&quot;RPC.Server.Detect&quot;">
+                <attrib name="ExchangesCompleted" alias="DetectComplete" type="counter"/>
+                <attrib name="ExchangesFailed" alias="DetectFailed" type="counter"/>
+                <attrib name="ExchangesTotal" alias="DetectTotal" type="counter"/>
+                <attrib name="MaxProcessingTime" alias="DetectMaxProc" type="gauge"/>
+                <attrib name="MeanProcessingTime" alias="DetectMeanProc" type="gauge"/>
+                <attrib name="MinProcessingTime" alias="DetectMinProc" type="gauge"/>
+                <attrib name="LastProcessingTime" alias="DetectLastProc" type="gauge"/>
+                <attrib name="TotalProcessingTime" alias="DetectTotProc" type="counter"/>
+            </mbean>
+
+
             <!-- TODO: Collect route stats for RPC.Server.Discover (when available) -->
 
 
-            <!-- TODO: Collect route stats for RPC.Server.Detect -->
+            <!-- TODO: Collect route stats for RPC.Server.DNS (when available) -->
+
+
+            <!-- TODO: Collect route stats for RPC.Server.Poll (when available) -->
 
 
             <!-- Route stats for RPC.Server.SNMP -->
-            <mbean name="SNMP RPC Server" objectname="org.apache.camel:context=org.opennms.core.rpc.camel-impl,type=routes,name=&quot;RPC.Server.SNMP&quot;">
+            <mbean name="SNMP RPC Server" objectname="org.apache.camel:context=org.opennms.core.ipc.rpc.camel-impl,type=routes,name=&quot;RPC.Server.SNMP&quot;">
                 <attrib name="ExchangesCompleted" alias="SnmpComplete" type="counter"/>
                 <attrib name="ExchangesFailed" alias="SnmpFailed" type="counter"/>
                 <attrib name="ExchangesTotal" alias="SnmpTotal" type="counter"/>
@@ -137,9 +153,6 @@
                 <attrib name="LastProcessingTime" alias="SnmpLastProc" type="gauge"/>
                 <attrib name="TotalProcessingTime" alias="SnmpTotProc" type="counter"/>
             </mbean>
-
-
-            <!-- TODO: Collect route stats for RPC.Server.Poll (when available) -->
 
 
             <!--

--- a/opennms-base-assembly/src/main/filtered/etc/poller-configuration.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/poller-configuration.xml
@@ -250,6 +250,15 @@
       <parameter key="password" value="admin"/>
       <parameter key="rrd-repository" value="${install.share.dir}/rrd/response" />
     </service>
+    <service name="JMX-Kafka" interval="300000" user-defined="false" status="on">
+      <parameter key="port" value="9999"/>
+      <parameter key="retry" value="2"/>
+      <parameter key="timeout" value="3000"/>
+      <parameter key="factory" value="PASSWORD-CLEAR"/>
+      <parameter key="username" value="admin"/>
+      <parameter key="password" value="admin"/>
+      <parameter key="rrd-repository" value="${install.share.dir}/rrd/response" />
+    </service>
     <service name="VMwareCim-HostSystem" interval="300000" user-defined="false" status="on">
       <parameter key="retry" value="2"/>
       <parameter key="timeout" value="3000"/>
@@ -330,6 +339,7 @@
   <monitor service="Windows-Task-Scheduler" class-name="org.opennms.netmgt.poller.monitors.Win32ServiceMonitor" />
   <monitor service="OpenNMS-JVM" class-name="org.opennms.netmgt.poller.monitors.Jsr160Monitor" />
   <monitor service="JMX-Minion" class-name="org.opennms.netmgt.poller.monitors.Jsr160Monitor" />
+  <monitor service="JMX-Kafka" class-name="org.opennms.netmgt.poller.monitors.Jsr160Monitor" />
   <monitor service="VMwareCim-HostSystem" class-name="org.opennms.netmgt.poller.monitors.VmwareCimMonitor"/>
   <monitor service="VMware-ManagedEntity" class-name="org.opennms.netmgt.poller.monitors.VmwareMonitor"/>
   <monitor service="MS-RDP" class-name="org.opennms.netmgt.poller.monitors.TcpMonitor" />

--- a/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/bluecoat-sgproxy-graph.properties
+++ b/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/bluecoat-sgproxy-graph.properties
@@ -69,7 +69,7 @@ report.sgProxy.workers.command=--title="Client-Server Workers" \
  STACK:ServerConnections#0000ff:"ServerConnections" \
  GPRINT:ServerConnections:AVERAGE:"Avg \\: %8.2lf %s" \
  GPRINT:ServerConnections:MIN:"Min \\: %8.2lf %s" \
- GPRINT:ServerConnections:MAX:"Max \\: %8.2lf %s\\n" 
+ GPRINT:ServerConnections:MAX:"Max \\: %8.2lf %s\\n"
 
 report.sgProxy.client.connections.name=ProxySG Client Workers
 report.sgProxy.client.connections.columns=ClientConnections,ClientConnectionsAc,ClientConnectionsId
@@ -92,7 +92,7 @@ report.sgProxy.client.connections.command=--title="Client Workers" \
  STACK:ClientConnectionsId#ff0000:"ClientConnectionsId" \
  GPRINT:ClientConnectionsId:AVERAGE:"Avg \\: %8.2lf %s" \
  GPRINT:ClientConnectionsId:MIN:"Min \\: %8.2lf %s" \
- GPRINT:ClientConnectionsId:MAX:"Max \\: %8.2lf %s\\n" 
+ GPRINT:ClientConnectionsId:MAX:"Max \\: %8.2lf %s\\n"
 
 report.sgProxy.server.connections.name=ProxySG Server Workers
 report.sgProxy.server.connections.columns=ServerConnections,ServerConnectionsAc,ServerConnectionsId
@@ -133,7 +133,7 @@ report.sgProxy.cpu.command=--title="CPU Usage" \
  STACK:CpuIdlePerCent#00ff00:"CpuIdlePerCent" \
  GPRINT:CpuIdlePerCent:AVERAGE:"Avg \\: %8.2lf %s" \
  GPRINT:CpuIdlePerCent:MIN:"Min \\: %8.2lf %s" \
- GPRINT:CpuIdlePerCent:MAX:"Max \\: %8.2lf %s\\n" \
+ GPRINT:CpuIdlePerCent:MAX:"Max \\: %8.2lf %s\\n"
 
 report.sgProxy.cache.name=ProxySG Cache
 report.sgProxy.cache.columns=ByteRateHit,ByteRatePartialHit,ByteRateMiss

--- a/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/checkpoint-graph.properties
+++ b/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/checkpoint-graph.properties
@@ -40,7 +40,7 @@ report.checkpoint.pktsAccepted.command=--title="Packets Accepted" \
  LINE2:accepted#0000ff:"Accepted" \
  GPRINT:accepted:AVERAGE:" Avg  \\: %8.2lf %s" \
  GPRINT:accepted:MIN:"Min  \\: %8.2lf %s" \
- GPRINT:accepted:MAX:"Max  \\: %8.2lf %s\\n" \
+ GPRINT:accepted:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.checkpoint.pktsDropped.name=Packets Dropped (CheckPoint)
 report.checkpoint.pktsDropped.columns=pktsDropped
@@ -51,7 +51,7 @@ report.checkpoint.pktsDropped.command=--title="Packets Dropped" \
  LINE2:dropped#0000ff:"Dropped" \
  GPRINT:dropped:AVERAGE:" Avg  \\: %8.2lf %s" \
  GPRINT:dropped:MIN:"Min  \\: %8.2lf %s" \
- GPRINT:dropped:MAX:"Max  \\: %8.2lf %s\\n" \
+ GPRINT:dropped:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.checkpoint.pktsLogged.name=Packets Logged (CheckPoint)
 report.checkpoint.pktsLogged.columns=pktsLogged
@@ -62,7 +62,7 @@ report.checkpoint.pktsLogged.command=--title="Packets Logged" \
  LINE2:logged#0000ff:"Logged" \
  GPRINT:logged:AVERAGE:" Avg  \\: %8.2lf %s" \
  GPRINT:logged:MIN:"Min  \\: %8.2lf %s" \
- GPRINT:logged:MAX:"Max  \\: %8.2lf %s\\n" \
+ GPRINT:logged:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.checkpoint.pktsRejected.name=Packets Rejected (CheckPoint)
 report.checkpoint.pktsRejected.columns=pktsRejected
@@ -73,7 +73,7 @@ report.checkpoint.pktsRejected.command=--title="Packets Rejected" \
  LINE2:rejected#0000ff:"Rejected" \
  GPRINT:rejected:AVERAGE:" Avg  \\: %8.2lf %s" \
  GPRINT:rejected:MIN:"Min  \\: %8.2lf %s" \
- GPRINT:rejected:MAX:"Max  \\: %8.2lf %s\\n" \
+ GPRINT:rejected:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.checkpoint.pktsEncrypted.name=Packets Encrypted and Decrypted (CheckPoint)
 report.checkpoint.pktsEncrypted.columns=cpvEncPackets, cpvDecPackets

--- a/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/cisco-graph.properties
+++ b/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/cisco-graph.properties
@@ -702,7 +702,7 @@ report.cisco.css.hits.command=--title="Hits per Second" --height 150 --width 600
  LINE1:fixedHits#0000ff:"Hits  " \
  GPRINT:fixedHits:AVERAGE:"Avg\\: %8.2lf %s" \
  GPRINT:fixedHits:MIN:"Min\\: %8.2lf %s" \
- GPRINT:fixedHits:MAX:"Max\\: %8.2lf %s\\n" 
+ GPRINT:fixedHits:MAX:"Max\\: %8.2lf %s\\n"
 
 report.cisco.css.bytes.name=CSS Bytes
 report.cisco.css.bytes.height=150
@@ -716,7 +716,7 @@ report.cisco.css.bytes.command=--title="Bytes per Second" --height 150 --width 6
  LINE1:Bytes#0000ff:"Bytes/second  " \
  GPRINT:Bytes:AVERAGE:"Avg\\: %8.2lf %s" \
  GPRINT:Bytes:MIN:"Min\\: %8.2lf %s" \
- GPRINT:Bytes:MAX:"Max\\: %8.2lf %s\\n" 
+ GPRINT:Bytes:MAX:"Max\\: %8.2lf %s\\n"
 
 report.cisco.css.redirects.name=CSS Redirects 
 report.cisco.css.redirects.height=150
@@ -729,7 +729,7 @@ report.cisco.css.redirects.command=--title="Redirects per Second" --height 150 -
  LINE1:Redirs#0000ff:"Redirects  " \
  GPRINT:Redirs:AVERAGE:"Avg\\: %8.2lf %s" \
  GPRINT:Redirs:MIN:"Min\\: %8.2lf %s" \
- GPRINT:Redirs:MAX:"Max\\: %8.2lf %s\\n" 
+ GPRINT:Redirs:MAX:"Max\\: %8.2lf %s\\n"
 
 report.cisco.css.sorries.name=CSS Sorries 
 report.cisco.css.sorries.height=150
@@ -742,7 +742,7 @@ report.cisco.css.sorries.command=--title="Sorries per Second" --height 150 --wid
  LINE1:Redirs#0000ff:"Sorries  " \
  GPRINT:Redirs:AVERAGE:"Avg\\: %8.2lf %s" \
  GPRINT:Redirs:MIN:"Min\\: %8.2lf %s" \
- GPRINT:Redirs:MAX:"Max\\: %8.2lf %s\\n" 
+ GPRINT:Redirs:MAX:"Max\\: %8.2lf %s\\n"
 
 report.cisco.docs.macchan.name=Cable Modem (MacChannel) Users
 report.cisco.docs.macchan.columns=MacCmTotal,MacCmActive,MacCmReg

--- a/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/ciscoNexus-graph.properties
+++ b/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/ciscoNexus-graph.properties
@@ -142,4 +142,5 @@ report.cisco.nexus.env.command=--title="Environmental Status of {entPhysicalName
  LINE1:entSensor#f57900:"Temperature" \
  GPRINT:entSensor:AVERAGE:" Avg  \\: %8.2lf %s" \
  GPRINT:entSensor:MIN:"Min  \\: %8.2lf %s" \
- GPRINT:entSensor:MAX:"Max  \\: %8.2lf %s\\n"  
+ GPRINT:entSensor:MAX:"Max  \\: %8.2lf %s\\n"
+

--- a/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/clavister-graph.properties
+++ b/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/clavister-graph.properties
@@ -294,7 +294,7 @@ report.clavister.ipsec.info.command=--title="Clavister IPsec Informational Excha
  LINE2:clvIPsecInfoFailed#a40000:"Failed" \
  GPRINT:clvIPsecInfoFailed:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:clvIPsecInfoFailed:MIN:"Min \\: %8.2lf %s" \
- GPRINT:clvIPsecInfoFailed:MAX:"Max \\: %8.2lf %s\\n" \
+ GPRINT:clvIPsecInfoFailed:MAX:"Max \\: %8.2lf %s\\n"
 
 report.clavister.ipsec.bits.name=Clavister IPsec Bits In/Out
 report.clavister.ipsec.bits.columns=clvIPsecInOctComp,clvIPsecInOctUncomp,clvIPsecOutOctComp,clvIPsecOutOctUncom
@@ -798,7 +798,7 @@ report.clavister.vlan.untaggedpkts.command=--title="Clavister VLAN Untagged Pack
  COMMENT:"  Total" \
  GPRINT:total:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:total:MIN:"Min \\: %8.2lf %s" \
- GPRINT:total:MAX:"Max \\: %8.2lf %s\\n" \
+ GPRINT:total:MAX:"Max \\: %8.2lf %s\\n"
 
 report.clavister.vlan.untaggedocts.name=Clavister VLAN Untagged Bytes
 report.clavister.vlan.untaggedocts.columns=clvIfVlUntInOctets,clvIfVlUntOutOctets,clvIfVlUntTotOctets
@@ -823,7 +823,7 @@ report.clavister.vlan.untaggedocts.command=--title="Clavister VLAN Untagged Byte
  COMMENT:"  Total" \
  GPRINT:total:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:total:MIN:"Min \\: %8.2lf %s" \
- GPRINT:total:MAX:"Max \\: %8.2lf %s\\n" \
+ GPRINT:total:MAX:"Max \\: %8.2lf %s\\n"
 
 #
 #clvDHCPRelayRuleTable
@@ -1172,7 +1172,7 @@ report.clavister.system.connpersec.command=--title="Clavister System Connections
  LINE1:closedInv#3465a4:"Closed" \
  GPRINT:closed:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:closed:MIN:"Min \\: %8.2lf %s" \
- GPRINT:closed:MAX:"Max \\: %8.2lf %s\\n" \
+ GPRINT:closed:MAX:"Max \\: %8.2lf %s\\n"
 
 report.clavister.system.hcfwdbits.name=Clavister System Bits Forwarded (High Speed)
 report.clavister.system.hcfwdbits.columns=clvSysHCFwdBits

--- a/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/ejn-graph.properties
+++ b/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/ejn-graph.properties
@@ -80,7 +80,7 @@ report.ejnggsn.apn.users.command=--title="APN {ApnName} Active PDP Contexts" \
  LINE2:active#0000ff:"PDP Contexts" \
  GPRINT:active:AVERAGE:"Avg \\: %8.2lf %s" \
  GPRINT:active:MIN:"Min  \\: %8.2lf %s" \
- GPRINT:active:MAX:"Max  \\: %8.2lf %s\\n" 
+ GPRINT:active:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.ejnggsn.apn.ippool.name=GGSN APN Available IPs
 report.ejnggsn.apn.ippool.columns=ApnFreePoolIps

--- a/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/f5-graph.properties
+++ b/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/f5-graph.properties
@@ -130,7 +130,7 @@ report.bigip.lvsconns.command=--title="Virtual Server Current Connections (F5)" 
  LINE2:curConns#4e9a06:"Current " \
  GPRINT:curConns:AVERAGE:"Avg  \\: %8.2lf %s" \
  GPRINT:curConns:MIN:"Min  \\: %8.2lf %s" \
- GPRINT:curConns:MAX:"Max  \\: %8.2lf %s\\n" \
+ GPRINT:curConns:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.bigip.nonodeerrs.name=LTM Virtual Server No Node Errors
 report.bigip.nonodeerrs.columns=vsNoNodeErrs

--- a/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/hwg-graph.properties
+++ b/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/hwg-graph.properties
@@ -36,13 +36,12 @@ report.sensTable.sensValue.command=--title="The Value Reported by {sensName} in 
  LINE2:var#000000:"Value" \
  GPRINT:var:AVERAGE:"Avg\\: %8.2lf %s" \
  GPRINT:var:MIN:"Min\\: %8.2lf %s" \
- GPRINT:var:MAX:"Max\\: %8.2lf %s\n" \
+ GPRINT:var:MAX:"Max\\: %8.2lf %s\\n" \
  LINE2:max#A00000:"Max  " \
  GPRINT:max:AVERAGE:"Avg\\: %8.2lf %s" \
  GPRINT:max:MIN:"Min\\: %8.2lf %s" \
- GPRINT:max:MAX:"Max\\: %8.2lf %s\n" \
+ GPRINT:max:MAX:"Max\\: %8.2lf %s\\n" \
  LINE2:min#0000A0:"Min  " \
  GPRINT:min:AVERAGE:"Avg\\: %8.2lf %s" \
  GPRINT:min:MIN:"Min\\: %8.2lf %s" \
- GPRINT:min:MAX:"Max\\: %8.2lf %s\n
-
+ GPRINT:min:MAX:"Max\\: %8.2lf %s\\n"

--- a/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/ipunity-graph.properties
+++ b/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/ipunity-graph.properties
@@ -589,7 +589,7 @@ report.ipunity.sip.methodDetail.command=--title="SIP Method Detail ({applDescrip
  STACK:infoOutInv#ff7200:"INFO    " \
  GPRINT:infoOut:AVERAGE:" Avg  \\: %8.2lf %s" \
  GPRINT:infoOut:MIN:" Min  \\: %8.2lf %s" \
- GPRINT:infoOut:MAX:" Max  \\: %8.2lf %s\\n" \
+ GPRINT:infoOut:MAX:" Max  \\: %8.2lf %s\\n"
 
 report.ipunity.sip.statusCodeDetail.name=SIP Status Detail (IP Unity)
 report.ipunity.sip.statusCodeDetail.columns=ipuSIPInfoClsIn,ipuSIPInfoClsOut,ipuSIPSuccClsIn,ipuSIPSuccClsOut,ipuSIPRedirClsIn,ipuSIPRedirClsOut,ipuSIPReqFailClsIn,ipuSIPReqFailClsOut,ipuSIPSrvFailClsIn,ipuSIPSrvFailClsOut,ipuSIPGblFailClsIn,ipuSIPGblFailClsOut

--- a/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/jboss-graph.properties
+++ b/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/jboss-graph.properties
@@ -119,7 +119,7 @@ report.jboss.grp.time.command=--title="HTTP Global Request Processor - Time" \
  LINE2:proc#0000ff:"ProcessTime" \
  GPRINT:proc:AVERAGE:" Avg  \\: %6.2lf %s" \
  GPRINT:proc:MIN:"Min  \\: %6.2lf %s" \
- GPRINT:proc:MAX:"Max  \\: %6.2lf %s\\n" \
+ GPRINT:proc:MAX:"Max  \\: %6.2lf %s\\n"
 
 report.jboss.http.tp.name=Http Thread Pool
 report.jboss.http.tp.columns=BusyThreads, Threads

--- a/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/juniper-graph.properties
+++ b/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/juniper-graph.properties
@@ -386,5 +386,5 @@ report.ive.connections.command=--title="Juniper IVE Users" \
  LINE2:iveConcurrentUsers#ff0000:"iveConcurrentUsers" \
  GPRINT:iveConcurrentUsers:AVERAGE:"Avg \\: %8.2lf %s" \
  GPRINT:iveConcurrentUsers:MIN:"Min \\: %8.2lf %s" \
- GPRINT:iveConcurrentUsers:MAX:"Max \\: %8.2lf %s\\n" 
+ GPRINT:iveConcurrentUsers:MAX:"Max \\: %8.2lf %s\\n"
 

--- a/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/kafka-graphs.properties
+++ b/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/kafka-graphs.properties
@@ -13,7 +13,7 @@ report.kafka.syslogBytesCount.command=--title="Sylog Kafka Incoming bytes" \
  LINE2:syslogInBytesCount#c4a000:"SylogKafkaIn/Out" \
  GPRINT:syslogInBytesCount:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:syslogInBytesCount:MIN:" Min \\: %8.2lf %s" \
- GPRINT:syslogInBytesCount:MAX:" Max \\: %8.2lf %s\\n" \
+ GPRINT:syslogInBytesCount:MAX:" Max \\: %8.2lf %s\\n"
  
 
 report.kafka.syslogOutBytesCount.name=Syslog out bytes 
@@ -25,7 +25,7 @@ report.kafka.syslogOutBytesCount.command=--title="Sylog Kafka Outgoing Bytes" \
  LINE2:syslogOutBytesCount#c4a000:"SylogKafkaIn/Out" \
  GPRINT:syslogOutBytesCount:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:syslogOutBytesCount:MIN:" Min \\: %8.2lf %s" \
- GPRINT:syslogOutBytesCount:MAX:" Max \\: %8.2lf %s\\n" \
+ GPRINT:syslogOutBytesCount:MAX:" Max \\: %8.2lf %s\\n"
 
 report.kafka.trapInBytesCount.name=Trap In bytes
 report.kafka.trapInBytesCount.columns=trapInBytesCount
@@ -36,7 +36,7 @@ report.kafka.trapInBytesCount.command=--title="Trap Kafka Incoming bytes Metrics
  LINE2:trapInBytesCount#c4a000:"SylogKafkaIn/Out" \
  GPRINT:trapInBytesCount:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:trapInBytesCount:MIN:" Min \\: %8.2lf %s" \
- GPRINT:trapInBytesCount:MAX:" Max \\: %8.2lf %s\\n" \
+ GPRINT:trapInBytesCount:MAX:" Max \\: %8.2lf %s\\n"
  
 
 report.kafka.trapOutBytesCount.name=Trap out bytes 
@@ -48,6 +48,5 @@ report.kafka.trapOutBytesCount.command=--title="Trap Kafka Outgoing Bytes" \
  LINE2:trapOutBytesCount#c4a000:"SylogKafkaIn/Out" \
  GPRINT:trapOutBytesCount:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:trapOutBytesCount:MIN:" Min \\: %8.2lf %s" \
- GPRINT:trapOutBytesCount:MAX:" Max \\: %8.2lf %s\\n" \
-
+ GPRINT:trapOutBytesCount:MAX:" Max \\: %8.2lf %s\\n"
 

--- a/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/kafka-graphs.properties
+++ b/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/kafka-graphs.properties
@@ -1,0 +1,53 @@
+reports=kafka.syslogBytesCount, \
+kafka.syslogOutBytesCount, \
+kafka.trapInBytesCount, \
+kafka.trapOutBytesCount
+
+
+report.kafka.syslogBytesCount.name=Syslog In bytes
+report.kafka.syslogBytesCount.columns=syslogInBytesCount
+report.kafka.syslogBytesCount.type=interfaceSnmp
+report.kafka.syslogBytesCount.command=--title="Sylog Kafka In bytes Metrics" \
+ DEF:syslogInBytesCount={rrd1}:syslogInBytesCount:AVERAGE \
+ AREA:syslogInBytesCount#edd400 \
+ LINE2:syslogInBytesCount#c4a000:"SylogKafkaIn/Out" \
+ GPRINT:syslogInBytesCount:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:syslogInBytesCount:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:syslogInBytesCount:MAX:" Max \\: %8.2lf %s\\n" \
+ 
+
+report.kafka.syslogOutBytesCount.name=Syslog out bytes 
+report.kafka.syslogOutBytesCount.columns=syslogOutBytesCount
+report.kafka.syslogOutBytesCount.type=interfaceSnmp
+report.kafka.syslogOutBytesCount.command=--title="Sylog Kafka Out Bytes" \
+ DEF:syslogOutBytesCount={rrd1}:syslogOutBytesCount:AVERAGE \
+ AREA:syslogOutBytesCount#edd400 \
+ LINE2:syslogOutBytesCount#c4a000:"SylogKafkaIn/Out" \
+ GPRINT:syslogOutBytesCount:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:syslogOutBytesCount:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:syslogOutBytesCount:MAX:" Max \\: %8.2lf %s\\n" \
+
+report.kafka.trapInBytesCount.name=Trap In bytes
+report.kafka.trapInBytesCount.columns=trapInBytesCount
+report.kafka.trapInBytesCount.type=interfaceSnmp
+report.kafka.trapInBytesCount.command=--title="Trap Kafka In bytes Metrics" \
+ DEF:trapInBytesCount={rrd1}:trapInBytesCount:AVERAGE \
+ AREA:trapInBytesCount#edd400 \
+ LINE2:trapInBytesCount#c4a000:"SylogKafkaIn/Out" \
+ GPRINT:trapInBytesCount:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:trapInBytesCount:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:trapInBytesCount:MAX:" Max \\: %8.2lf %s\\n" \
+ 
+
+report.kafka.trapOutBytesCount.name=Trap out bytes 
+report.kafka.trapOutBytesCount.columns=trapOutBytesCount
+report.kafka.trapOutBytesCount.type=interfaceSnmp
+report.kafka.trapOutBytesCount.command=--title="Trap Kafka Out Bytes" \
+ DEF:trapOutBytesCount={rrd1}:trapOutBytesCount:AVERAGE \
+ AREA:trapOutBytesCount#edd400 \
+ LINE2:trapOutBytesCount#c4a000:"SylogKafkaIn/Out" \
+ GPRINT:trapOutBytesCount:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:trapOutBytesCount:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:trapOutBytesCount:MAX:" Max \\: %8.2lf %s\\n" \
+
+

--- a/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/kafka-graphs.properties
+++ b/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/kafka-graphs.properties
@@ -7,7 +7,7 @@ kafka.trapOutBytesCount
 report.kafka.syslogBytesCount.name=Syslog In bytes
 report.kafka.syslogBytesCount.columns=syslogInBytesCount
 report.kafka.syslogBytesCount.type=interfaceSnmp
-report.kafka.syslogBytesCount.command=--title="Sylog Kafka In bytes Metrics" \
+report.kafka.syslogBytesCount.command=--title="Sylog Kafka Incoming bytes" \
  DEF:syslogInBytesCount={rrd1}:syslogInBytesCount:AVERAGE \
  AREA:syslogInBytesCount#edd400 \
  LINE2:syslogInBytesCount#c4a000:"SylogKafkaIn/Out" \
@@ -19,7 +19,7 @@ report.kafka.syslogBytesCount.command=--title="Sylog Kafka In bytes Metrics" \
 report.kafka.syslogOutBytesCount.name=Syslog out bytes 
 report.kafka.syslogOutBytesCount.columns=syslogOutBytesCount
 report.kafka.syslogOutBytesCount.type=interfaceSnmp
-report.kafka.syslogOutBytesCount.command=--title="Sylog Kafka Out Bytes" \
+report.kafka.syslogOutBytesCount.command=--title="Sylog Kafka Outgoing Bytes" \
  DEF:syslogOutBytesCount={rrd1}:syslogOutBytesCount:AVERAGE \
  AREA:syslogOutBytesCount#edd400 \
  LINE2:syslogOutBytesCount#c4a000:"SylogKafkaIn/Out" \
@@ -30,7 +30,7 @@ report.kafka.syslogOutBytesCount.command=--title="Sylog Kafka Out Bytes" \
 report.kafka.trapInBytesCount.name=Trap In bytes
 report.kafka.trapInBytesCount.columns=trapInBytesCount
 report.kafka.trapInBytesCount.type=interfaceSnmp
-report.kafka.trapInBytesCount.command=--title="Trap Kafka In bytes Metrics" \
+report.kafka.trapInBytesCount.command=--title="Trap Kafka Incoming bytes Metrics" \
  DEF:trapInBytesCount={rrd1}:trapInBytesCount:AVERAGE \
  AREA:trapInBytesCount#edd400 \
  LINE2:trapInBytesCount#c4a000:"SylogKafkaIn/Out" \
@@ -42,7 +42,7 @@ report.kafka.trapInBytesCount.command=--title="Trap Kafka In bytes Metrics" \
 report.kafka.trapOutBytesCount.name=Trap out bytes 
 report.kafka.trapOutBytesCount.columns=trapOutBytesCount
 report.kafka.trapOutBytesCount.type=interfaceSnmp
-report.kafka.trapOutBytesCount.command=--title="Trap Kafka Out Bytes" \
+report.kafka.trapOutBytesCount.command=--title="Trap Kafka Outgoing Bytes" \
  DEF:trapOutBytesCount={rrd1}:trapOutBytesCount:AVERAGE \
  AREA:trapOutBytesCount#edd400 \
  LINE2:trapOutBytesCount#c4a000:"SylogKafkaIn/Out" \

--- a/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/lmsensors-graph.properties
+++ b/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/lmsensors-graph.properties
@@ -20,7 +20,7 @@ report.lmsensors.temp.command=--title="Temperature on {lms-tempdevice}" \
   LINE1:btemp#f57900:"Temperature\\:" \
   GPRINT:btemp:AVERAGE:" Avg  \\: %8.2lf %s" \
   GPRINT:btemp:MIN:"Min  \\: %8.2lf %s" \
-  GPRINT:btemp:MAX:"Max  \\: %8.2lf %s\\n" \
+  GPRINT:btemp:MAX:"Max  \\: %8.2lf %s\\n"
  
 report.lmsensors.fan.name=lmSensors Fan Sensor
 report.lmsensors.fan.columns=lms-fan
@@ -31,7 +31,7 @@ report.lmsensors.fan.command=--title="Fan Speed on {lms-fandevice}" \
   LINE2:dfan#0000ff:"Fan Speed\\:" \
   GPRINT:dfan:AVERAGE:" Avg  \\: %8.2lf %s" \
   GPRINT:dfan:MIN:"Min  \\: %8.2lf %s" \
-  GPRINT:dfan:MAX:"Max  \\: %8.2lf %s\\n" \
+  GPRINT:dfan:MAX:"Max  \\: %8.2lf %s\\n"
  
 report.lmsensors.volt.name=lmSensors Volt Sensor
 report.lmsensors.volt.columns=lms-volt
@@ -43,5 +43,5 @@ report.lmsensors.volt.command=--title="Volt on {lms-voltdevice}" \
   LINE2:bvolt#0000ff:"Volt Speed\\:" \
   GPRINT:bvolt:AVERAGE:" Avg  \\: %8.2lf %s" \
   GPRINT:bvolt:MIN:"Min  \\: %8.2lf %s" \
-  GPRINT:bvolt:MAX:"Max  \\: %8.2lf %s\\n" \
+  GPRINT:bvolt:MAX:"Max  \\: %8.2lf %s\\n"
 

--- a/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/microsoft-sql-graph.properties
+++ b/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/microsoft-sql-graph.properties
@@ -71,7 +71,7 @@ report.mssqlhitratios.command=--title="MSSQL Hit Ratios" \
  LINE2:logcache#FF0000:"Log Cache \\:" \
  GPRINT:logcache:AVERAGE:"Avg\\:%4.1lf" \
  GPRINT:logcache:MAX:"Max\\:%4.1lf" \
- GPRINT:logcache:MIN:"Min\\:%4.1lf" \
+ GPRINT:logcache:MIN:"Min\\:%4.1lf"
 
 report.mssqllockwaittime.name=MSSQL Lock Wait Time
 report.mssqllockwaittime.columns=sqllockavgwaittime

--- a/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/mikrotik-graph.properties
+++ b/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/mikrotik-graph.properties
@@ -91,7 +91,7 @@ report.mikrotik.wlstatrssi.command=--title="Wireless Station RSSI" \
  AREA:rssi#00ff00:"SigLevel " \
  GPRINT:rssi:AVERAGE:"Avg  \\: %8.2lf %s" \
  GPRINT:rssi:MIN:"Min  \\: %8.2lf %s" \
- GPRINT:rssi:MAX:"Max  \\: %8.2lf %s\\n" \
+ GPRINT:rssi:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.mikrotik.wlrtabrssi.name=Mikrotik Remote Station Signal Level
 report.mikrotik.wlrtabrssi.columns=mtxrWlRtabStrength
@@ -102,7 +102,7 @@ report.mikrotik.wlrtabrssi.command=--title="Wireless Station RSSI" \
  AREA:rssi#00ff00:"SigLevel " \
  GPRINT:rssi:AVERAGE:"Avg  \\: %8.2lf %s" \
  GPRINT:rssi:MIN:"Min  \\: %8.2lf %s" \
- GPRINT:rssi:MAX:"Max  \\: %8.2lf %s\\n" \
+ GPRINT:rssi:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.mikrotik.wlrtabbit.name=Mikrotik Remote Wls Link Rate
 report.mikrotik.wlrtabbit.columns=mtxrWlRtabRxRate,mtxrWlRtabTxRate

--- a/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/mysql-graph.properties
+++ b/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/mysql-graph.properties
@@ -116,7 +116,7 @@ report.mysql.slow.queries.command=--title="MySQL Slow Queries" \
  LINE2:slow#0000ff:"Slow Queries" \
  GPRINT:slow:AVERAGE:"Avg  \\: %8.2lf %s" \
  GPRINT:slow:MIN:"Min  \\: %8.2lf %s" \
- GPRINT:slow:MAX:"Max  \\: %8.2lf %s\\n" \
+ GPRINT:slow:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.mysql.queries.name=MySQL Queries
 report.mysql.queries.columns=MyComDelete,MyComDeleteMulti,MyComInsert,MyComInsertSelect,MyComUpdate,MyComUpdateMulti,MyComSelect,MyQuestions
@@ -162,7 +162,7 @@ report.mysql.queries.command=--title="MySQL Queries" \
  LINE2:questions#000000:"Questions     " \
  GPRINT:questions:AVERAGE:"Avg  \\: %8.2lf %s" \
  GPRINT:questions:MIN:"Min  \\: %8.2lf %s" \
- GPRINT:questions:MAX:"Max  \\: %8.2lf %s\\n" \
+ GPRINT:questions:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.mysql.key.reads.name=MySQL Key Reads
 report.mysql.key.reads.columns=MyKeyReads,MyKeyReadReqs
@@ -178,7 +178,7 @@ report.mysql.key.reads.command=--title="MySQL Key Reads" \
  LINE2:readreqs#000000:"Read Requests  " \
  GPRINT:readreqs:AVERAGE:"Avg  \\: %8.2lf %s" \
  GPRINT:readreqs:MIN:"Min  \\: %8.2lf %s" \
- GPRINT:readreqs:MAX:"Max  \\: %8.2lf %s\\n" \
+ GPRINT:readreqs:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.mysql.key.writes.name=MySQL Key Writes
 report.mysql.key.writes.columns=MyKeyWrites,MyKeyWriteReqs

--- a/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/opennms-graph.properties
+++ b/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/opennms-graph.properties
@@ -164,7 +164,7 @@ report.onms.collectd.threadpool.command=--title="OpenNMS Collectd ThreadPool" \
  LINE2:max#9A27F1:"Maximum Active" \
  GPRINT:max:AVERAGE:"Avg\\: %5.0lf\" \
  GPRINT:max:MIN:"Min\\: %5.0lf" \
- GPRINT:max:MAX:"Max\\: %5.0lf\\n" \
+ GPRINT:max:MAX:"Max\\: %5.0lf\\n"
 
 report.onms.collectd.completedRatio.name=OpenNMS Collectd Task Completion Ratio
 report.onms.collectd.completedRatio.columns=ONMSCollectTasksTot,ONMSCollectTasksCpt

--- a/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/opennms-minion-graph.properties
+++ b/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/opennms-minion-graph.properties
@@ -1,4 +1,8 @@
 reports=\
+OpenNMS.Minion.RPC.Server.Detect.Exchanges, \
+OpenNMS.Minion.RPC.Server.Detect.ProcessingTime, \
+OpenNMS.Minion.RPC.Server.SNMP.Exchanges, \
+OpenNMS.Minion.RPC.Server.SNMP.ProcessingTime, \
 OpenNMS.Minion.Syslogd.Listener.Exchanges, \
 OpenNMS.Minion.Syslogd.Marshaller.Exchanges, \
 OpenNMS.Minion.Syslogd.JMS.Exchanges, \
@@ -11,14 +15,12 @@ OpenNMS.Minion.Trapd.Kafka.Exchanges, \
 OpenNMS.Minion.Trapd.JMS.ProcessingTime, \
 OpenNMS.Minion.Trapd.Kafka.ProcessingTime
 
-#OpenNMS.Minion.RPC.Server.Detect.Exchanges, \
-#OpenNMS.Minion.RPC.Server.Detect.ProcessingTime, \
 #OpenNMS.Minion.RPC.Server.Discover.Exchanges, \
 #OpenNMS.Minion.RPC.Server.Discover.ProcessingTime, \
+#OpenNMS.Minion.RPC.Server.DNS.Exchanges, \
+#OpenNMS.Minion.RPC.Server.DNS.ProcessingTime, \
 #OpenNMS.Minion.RPC.Server.Poll.Exchanges, \
 #OpenNMS.Minion.RPC.Server.Poll.ProcessingTime, \
-#OpenNMS.Minion.RPC.Server.SNMP.Exchanges, \
-#OpenNMS.Minion.RPC.Server.SNMP.ProcessingTime, \
 
 
 ###########################################
@@ -28,6 +30,7 @@ OpenNMS.Minion.Trapd.Kafka.ProcessingTime
 #report.REPORT_NAME.columns=METRICComplete, METRICFailed
 #report.REPORT_NAME.type=interfaceSnmp
 #report.REPORT_NAME.command=--title="METRIC Exchanges" \
+# --vertical-label="Messages per second" \
 # DEF:complete={rrd1}:METRICComplete:AVERAGE \
 # DEF:failed={rrd2}:METRICFailed:AVERAGE \
 # AREA:failed#EF343B:"Failed Messages    " \
@@ -37,7 +40,79 @@ OpenNMS.Minion.Trapd.Kafka.ProcessingTime
 # STACK:complete#8DC63F:"Successful Messages" \
 # GPRINT:complete:AVERAGE:" Avg \\: %8.2lf %s" \
 # GPRINT:complete:MIN:" Min \\: %8.2lf %s" \
-# GPRINT:complete:MAX:" Max \\: %8.2lf %s\\n" \
+# GPRINT:complete:MAX:" Max \\: %8.2lf %s\\n"
+
+
+###########################################
+## OpenNMS.Minion.RPC.Server.Detect.Exchanges
+###########################################
+report.OpenNMS.Minion.RPC.Server.Detect.Exchanges.name=Provisioning Detection Messages Received
+report.OpenNMS.Minion.RPC.Server.Detect.Exchanges.columns=DetectComplete, DetectFailed
+report.OpenNMS.Minion.RPC.Server.Detect.Exchanges.type=interfaceSnmp
+report.OpenNMS.Minion.RPC.Server.Detect.Exchanges.command=--title="Provisioning Detection Messages Received" \
+ --vertical-label="Messages per second" \
+ DEF:complete={rrd1}:DetectComplete:AVERAGE \
+ DEF:failed={rrd2}:DetectFailed:AVERAGE \
+ AREA:failed#EF343B:"Failed Messages    " \
+ GPRINT:failed:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:failed:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:failed:MAX:" Max \\: %8.2lf %s\\n" \
+ STACK:complete#8DC63F:"Successful Messages" \
+ GPRINT:complete:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:complete:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:complete:MAX:" Max \\: %8.2lf %s\\n"
+
+###########################################
+## OpenNMS.Minion.RPC.Server.Detect.ProcessingTime
+###########################################
+report.OpenNMS.Minion.RPC.Server.Detect.ProcessingTime.name=Provisioning Detection Processing Time
+report.OpenNMS.Minion.RPC.Server.Detect.ProcessingTime.columns=DetectLastProc, DetectMeanProc
+report.OpenNMS.Minion.RPC.Server.Detect.ProcessingTime.type=interfaceSnmp
+report.OpenNMS.Minion.RPC.Server.Detect.ProcessingTime.command=--title="Provisioning Detection Processing Time" \
+ --vertical-label="Seconds per message" \
+ DEF:mqLast={rrd1}:DetectLastProc:AVERAGE \
+ DEF:mqMean={rrd2}:DetectMeanProc:AVERAGE \
+ CDEF:mqLastSec=mqLast,1000,/ \
+ AREA:mqLastSec#73d216:"Process via JMS" \
+ GPRINT:mqLastSec:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:mqLastSec:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:mqLastSec:MAX:" Max \\: %8.2lf %s\\n"
+
+
+###########################################
+## OpenNMS.Minion.RPC.Server.SNMP.Exchanges
+###########################################
+report.OpenNMS.Minion.RPC.Server.SNMP.Exchanges.name=SNMP Messages Received
+report.OpenNMS.Minion.RPC.Server.SNMP.Exchanges.columns=SnmpComplete, SnmpFailed
+report.OpenNMS.Minion.RPC.Server.SNMP.Exchanges.type=interfaceSnmp
+report.OpenNMS.Minion.RPC.Server.SNMP.Exchanges.command=--title="SNMP Messages Received" \
+ --vertical-label="Messages per second" \
+ DEF:complete={rrd1}:SnmpComplete:AVERAGE \
+ DEF:failed={rrd2}:SnmpFailed:AVERAGE \
+ AREA:failed#EF343B:"Failed Messages    " \
+ GPRINT:failed:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:failed:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:failed:MAX:" Max \\: %8.2lf %s\\n" \
+ STACK:complete#8DC63F:"Successful Messages" \
+ GPRINT:complete:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:complete:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:complete:MAX:" Max \\: %8.2lf %s\\n"
+
+###########################################
+## OpenNMS.Minion.RPC.Server.SNMP.ProcessingTime
+###########################################
+report.OpenNMS.Minion.RPC.Server.SNMP.ProcessingTime.name=SNMP Processing Time
+report.OpenNMS.Minion.RPC.Server.SNMP.ProcessingTime.columns=SnmpLastProc, SnmpMeanProc
+report.OpenNMS.Minion.RPC.Server.SNMP.ProcessingTime.type=interfaceSnmp
+report.OpenNMS.Minion.RPC.Server.SNMP.ProcessingTime.command=--title="SNMP Processing Time" \
+ --vertical-label="Seconds per message" \
+ DEF:mqLast={rrd1}:SnmpLastProc:AVERAGE \
+ DEF:mqMean={rrd2}:SnmpMeanProc:AVERAGE \
+ CDEF:mqLastSec=mqLast,1000,/ \
+ AREA:mqLastSec#73d216:"Process via JMS" \
+ GPRINT:mqLastSec:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:mqLastSec:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:mqLastSec:MAX:" Max \\: %8.2lf %s\\n"
 
 
 ###########################################
@@ -47,6 +122,7 @@ report.OpenNMS.Minion.Syslogd.Listener.Exchanges.name=Syslog Messages Received
 report.OpenNMS.Minion.Syslogd.Listener.Exchanges.columns=SlogListComplete, SlogListFailed
 report.OpenNMS.Minion.Syslogd.Listener.Exchanges.type=interfaceSnmp
 report.OpenNMS.Minion.Syslogd.Listener.Exchanges.command=--title="Syslog Messages Received" \
+ --vertical-label="Messages per second" \
  DEF:complete={rrd1}:SlogListComplete:AVERAGE \
  DEF:failed={rrd2}:SlogListFailed:AVERAGE \
  AREA:failed#EF343B:"Failed Messages    " \
@@ -56,7 +132,7 @@ report.OpenNMS.Minion.Syslogd.Listener.Exchanges.command=--title="Syslog Message
  STACK:complete#8DC63F:"Successful Messages" \
  GPRINT:complete:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:complete:MIN:" Min \\: %8.2lf %s" \
- GPRINT:complete:MAX:" Max \\: %8.2lf %s\\n" \
+ GPRINT:complete:MAX:" Max \\: %8.2lf %s\\n"
 
 ###########################################
 ## OpenNMS.Minion.Syslogd.Marshaller.Exchanges
@@ -65,6 +141,7 @@ report.OpenNMS.Minion.Syslogd.Marshaller.Exchanges.name=Syslog Messages Processe
 report.OpenNMS.Minion.Syslogd.Marshaller.Exchanges.columns=SlogMarComplete, SlogMarFailed
 report.OpenNMS.Minion.Syslogd.Marshaller.Exchanges.type=interfaceSnmp
 report.OpenNMS.Minion.Syslogd.Marshaller.Exchanges.command=--title="Syslog Messages Processed" \
+ --vertical-label="Messages per second" \
  DEF:complete={rrd1}:SlogMarComplete:AVERAGE \
  DEF:failed={rrd2}:SlogMarFailed:AVERAGE \
  AREA:failed#EF343B:"Failed Messages    " \
@@ -74,7 +151,7 @@ report.OpenNMS.Minion.Syslogd.Marshaller.Exchanges.command=--title="Syslog Messa
  STACK:complete#8DC63F:"Successful Messages" \
  GPRINT:complete:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:complete:MIN:" Min \\: %8.2lf %s" \
- GPRINT:complete:MAX:" Max \\: %8.2lf %s\\n" \
+ GPRINT:complete:MAX:" Max \\: %8.2lf %s\\n"
 
 ###########################################
 ## OpenNMS.Minion.Syslogd.JMS.Exchanges
@@ -83,6 +160,7 @@ report.OpenNMS.Minion.Syslogd.JMS.Exchanges.name=Syslog Messages Sent via JMS
 report.OpenNMS.Minion.Syslogd.JMS.Exchanges.columns=SlogJmsComplete, SlogJmsFailed
 report.OpenNMS.Minion.Syslogd.JMS.Exchanges.type=interfaceSnmp
 report.OpenNMS.Minion.Syslogd.JMS.Exchanges.command=--title="Syslog Messages Sent via JMS" \
+ --vertical-label="Messages per second" \
  DEF:complete={rrd1}:SlogJmsComplete:AVERAGE \
  DEF:failed={rrd2}:SlogJmsFailed:AVERAGE \
  AREA:failed#EF343B:"Failed Messages    " \
@@ -92,7 +170,7 @@ report.OpenNMS.Minion.Syslogd.JMS.Exchanges.command=--title="Syslog Messages Sen
  STACK:complete#8DC63F:"Successful Messages" \
  GPRINT:complete:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:complete:MIN:" Min \\: %8.2lf %s" \
- GPRINT:complete:MAX:" Max \\: %8.2lf %s\\n" \
+ GPRINT:complete:MAX:" Max \\: %8.2lf %s\\n"
 
 ###########################################
 ## OpenNMS.Minion.Syslogd.Kafka.Exchanges
@@ -101,6 +179,7 @@ report.OpenNMS.Minion.Syslogd.Kafka.Exchanges.name=Syslog Messages Sent via Kafk
 report.OpenNMS.Minion.Syslogd.Kafka.Exchanges.columns=SlogKafComplete, SlogKafFailed
 report.OpenNMS.Minion.Syslogd.Kafka.Exchanges.type=interfaceSnmp
 report.OpenNMS.Minion.Syslogd.Kafka.Exchanges.command=--title="Syslog Messages Sent via Kafka" \
+ --vertical-label="Messages per second" \
  DEF:complete={rrd1}:SlogKafComplete:AVERAGE \
  DEF:failed={rrd2}:SlogKafFailed:AVERAGE \
  AREA:failed#EF343B:"Failed Messages    " \
@@ -110,7 +189,7 @@ report.OpenNMS.Minion.Syslogd.Kafka.Exchanges.command=--title="Syslog Messages S
  STACK:complete#8DC63F:"Successful Messages" \
  GPRINT:complete:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:complete:MIN:" Min \\: %8.2lf %s" \
- GPRINT:complete:MAX:" Max \\: %8.2lf %s\\n" \
+ GPRINT:complete:MAX:" Max \\: %8.2lf %s\\n"
 
 ###########################################
 ## OpenNMS.Minion.Syslogd.JMS.ProcessingTime
@@ -119,6 +198,7 @@ report.OpenNMS.Minion.Syslogd.JMS.ProcessingTime.name=Syslog Message Processing 
 report.OpenNMS.Minion.Syslogd.JMS.ProcessingTime.columns=SlogListLastProc, SlogListMeanProc, SlogMarLastProc, SlogMarMeanProc, SlogJmsLastProc, SlogJmsMeanProc
 report.OpenNMS.Minion.Syslogd.JMS.ProcessingTime.type=interfaceSnmp
 report.OpenNMS.Minion.Syslogd.JMS.ProcessingTime.command=--title="Syslog Message Processing Time" \
+ --vertical-label="Seconds per message" \
  DEF:listLast={rrd1}:SlogListLastProc:AVERAGE \
  DEF:listMean={rrd2}:SlogListMeanProc:AVERAGE \
  DEF:marLast={rrd3}:SlogMarLastProc:AVERAGE \
@@ -139,7 +219,7 @@ report.OpenNMS.Minion.Syslogd.JMS.ProcessingTime.command=--title="Syslog Message
  STACK:mqLastSec#73d216:"Send via JMS  " \
  GPRINT:mqLastSec:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:mqLastSec:MIN:" Min \\: %8.2lf %s" \
- GPRINT:mqLastSec:MAX:" Max \\: %8.2lf %s\\n" \
+ GPRINT:mqLastSec:MAX:" Max \\: %8.2lf %s\\n"
 
 ###########################################
 ## OpenNMS.Minion.Syslogd.Kafka.ProcessingTime
@@ -148,6 +228,7 @@ report.OpenNMS.Minion.Syslogd.Kafka.ProcessingTime.name=Syslog Message Processin
 report.OpenNMS.Minion.Syslogd.Kafka.ProcessingTime.columns=SlogListLastProc, SlogListMeanProc, SlogMarLastProc, SlogMarMeanProc, SlogKafLastProc, SlogKafMeanProc
 report.OpenNMS.Minion.Syslogd.Kafka.ProcessingTime.type=interfaceSnmp
 report.OpenNMS.Minion.Syslogd.Kafka.ProcessingTime.command=--title="Syslog Message Processing Time" \
+ --vertical-label="Seconds per message" \
  DEF:listLast={rrd1}:SlogListLastProc:AVERAGE \
  DEF:listMean={rrd2}:SlogListMeanProc:AVERAGE \
  DEF:marLast={rrd3}:SlogMarLastProc:AVERAGE \
@@ -168,7 +249,7 @@ report.OpenNMS.Minion.Syslogd.Kafka.ProcessingTime.command=--title="Syslog Messa
  STACK:mqLastSec#73d216:"Send via Kafka" \
  GPRINT:mqLastSec:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:mqLastSec:MIN:" Min \\: %8.2lf %s" \
- GPRINT:mqLastSec:MAX:" Max \\: %8.2lf %s\\n" \
+ GPRINT:mqLastSec:MAX:" Max \\: %8.2lf %s\\n"
 
  
 ###########################################
@@ -178,6 +259,7 @@ report.OpenNMS.Minion.Trapd.Marshaller.Exchanges.name=SNMP Trap Messages Process
 report.OpenNMS.Minion.Trapd.Marshaller.Exchanges.columns=TrapMarComplete, TrapMarFailed
 report.OpenNMS.Minion.Trapd.Marshaller.Exchanges.type=interfaceSnmp
 report.OpenNMS.Minion.Trapd.Marshaller.Exchanges.command=--title="SNMP Trap Messages Processed" \
+ --vertical-label="Messages per second" \
  DEF:complete={rrd1}:TrapMarComplete:AVERAGE \
  DEF:failed={rrd2}:TrapMarFailed:AVERAGE \
  AREA:failed#EF343B:"Failed Messages    " \
@@ -187,7 +269,7 @@ report.OpenNMS.Minion.Trapd.Marshaller.Exchanges.command=--title="SNMP Trap Mess
  STACK:complete#8DC63F:"Successful Messages" \
  GPRINT:complete:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:complete:MIN:" Min \\: %8.2lf %s" \
- GPRINT:complete:MAX:" Max \\: %8.2lf %s\\n" \
+ GPRINT:complete:MAX:" Max \\: %8.2lf %s\\n"
 
 ###########################################
 ## OpenNMS.Minion.Trapd.JMS.Exchanges
@@ -196,6 +278,7 @@ report.OpenNMS.Minion.Trapd.JMS.Exchanges.name=SNMP Trap Messages Sent via JMS
 report.OpenNMS.Minion.Trapd.JMS.Exchanges.columns=TrapJmsComplete, TrapJmsFailed
 report.OpenNMS.Minion.Trapd.JMS.Exchanges.type=interfaceSnmp
 report.OpenNMS.Minion.Trapd.JMS.Exchanges.command=--title="SNMP Trap Messages Sent via JMS" \
+ --vertical-label="Messages per second" \
  DEF:complete={rrd1}:TrapJmsComplete:AVERAGE \
  DEF:failed={rrd2}:TrapJmsFailed:AVERAGE \
  AREA:failed#EF343B:"Failed Messages    " \
@@ -205,7 +288,7 @@ report.OpenNMS.Minion.Trapd.JMS.Exchanges.command=--title="SNMP Trap Messages Se
  STACK:complete#8DC63F:"Successful Messages" \
  GPRINT:complete:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:complete:MIN:" Min \\: %8.2lf %s" \
- GPRINT:complete:MAX:" Max \\: %8.2lf %s\\n" \
+ GPRINT:complete:MAX:" Max \\: %8.2lf %s\\n"
 
 ###########################################
 ## OpenNMS.Minion.Trapd.Kafka.Exchanges
@@ -214,6 +297,7 @@ report.OpenNMS.Minion.Trapd.Kafka.Exchanges.name=SNMP Trap Messages Sent via Kaf
 report.OpenNMS.Minion.Trapd.Kafka.Exchanges.columns=TrapKafComplete, TrapKafFailed
 report.OpenNMS.Minion.Trapd.Kafka.Exchanges.type=interfaceSnmp
 report.OpenNMS.Minion.Trapd.Kafka.Exchanges.command=--title="SNMP Trap Messages Sent via Kafka" \
+ --vertical-label="Messages per second" \
  DEF:complete={rrd1}:TrapKafComplete:AVERAGE \
  DEF:failed={rrd2}:TrapKafFailed:AVERAGE \
  AREA:failed#EF343B:"Failed Messages    " \
@@ -223,7 +307,7 @@ report.OpenNMS.Minion.Trapd.Kafka.Exchanges.command=--title="SNMP Trap Messages 
  STACK:complete#8DC63F:"Successful Messages" \
  GPRINT:complete:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:complete:MIN:" Min \\: %8.2lf %s" \
- GPRINT:complete:MAX:" Max \\: %8.2lf %s\\n" \
+ GPRINT:complete:MAX:" Max \\: %8.2lf %s\\n"
 
 ###########################################
 ## OpenNMS.Minion.Trapd.JMS.ProcessingTime
@@ -232,6 +316,7 @@ report.OpenNMS.Minion.Trapd.JMS.ProcessingTime.name=SNMP Trap Message Processing
 report.OpenNMS.Minion.Trapd.JMS.ProcessingTime.columns=TrapMarLastProc, TrapMarMeanProc, TrapJmsLastProc, TrapJmsMeanProc
 report.OpenNMS.Minion.Trapd.JMS.ProcessingTime.type=interfaceSnmp
 report.OpenNMS.Minion.Trapd.JMS.ProcessingTime.command=--title="SNMP Trap Message Processing Time" \
+ --vertical-label="Seconds per message" \
  DEF:marLast={rrd1}:TrapMarLastProc:AVERAGE \
  DEF:marMean={rrd2}:TrapMarMeanProc:AVERAGE \
  DEF:mqLast={rrd3}:TrapJmsLastProc:AVERAGE \
@@ -245,7 +330,7 @@ report.OpenNMS.Minion.Trapd.JMS.ProcessingTime.command=--title="SNMP Trap Messag
  STACK:mqLastSec#73d216:"Send via JMS  " \
  GPRINT:mqLastSec:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:mqLastSec:MIN:" Min \\: %8.2lf %s" \
- GPRINT:mqLastSec:MAX:" Max \\: %8.2lf %s\\n" \
+ GPRINT:mqLastSec:MAX:" Max \\: %8.2lf %s\\n"
 
 ###########################################
 ## OpenNMS.Minion.Trapd.Kafka.ProcessingTime
@@ -254,6 +339,7 @@ report.OpenNMS.Minion.Trapd.Kafka.ProcessingTime.name=SNMP Trap Message Processi
 report.OpenNMS.Minion.Trapd.Kafka.ProcessingTime.columns=TrapMarLastProc, TrapMarMeanProc, TrapKafLastProc, TrapKafMeanProc
 report.OpenNMS.Minion.Trapd.Kafka.ProcessingTime.type=interfaceSnmp
 report.OpenNMS.Minion.Trapd.Kafka.ProcessingTime.command=--title="SNMP Trap Message Processing Time" \
+ --vertical-label="Seconds per message" \
  DEF:marLast={rrd1}:TrapMarLastProc:AVERAGE \
  DEF:marMean={rrd2}:TrapMarMeanProc:AVERAGE \
  DEF:mqLast={rrd3}:TrapKafLastProc:AVERAGE \
@@ -267,4 +353,4 @@ report.OpenNMS.Minion.Trapd.Kafka.ProcessingTime.command=--title="SNMP Trap Mess
  STACK:mqLastSec#73d216:"Send via Kafka" \
  GPRINT:mqLastSec:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:mqLastSec:MIN:" Min \\: %8.2lf %s" \
- GPRINT:mqLastSec:MAX:" Max \\: %8.2lf %s\\n" \
+ GPRINT:mqLastSec:MAX:" Max \\: %8.2lf %s\\n"

--- a/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/opennms-minion-graph.properties
+++ b/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/opennms-minion-graph.properties
@@ -3,17 +3,13 @@ OpenNMS.Minion.Syslogd.Listener.Exchanges, \
 OpenNMS.Minion.Syslogd.Marshaller.Exchanges, \
 OpenNMS.Minion.Syslogd.JMS.Exchanges, \
 OpenNMS.Minion.Syslogd.Kafka.Exchanges, \
+OpenNMS.Minion.Syslogd.JMS.ProcessingTime, \
+OpenNMS.Minion.Syslogd.Kafka.ProcessingTime, \
 OpenNMS.Minion.Trapd.Marshaller.Exchanges, \
 OpenNMS.Minion.Trapd.JMS.Exchanges, \
-OpenNMS.Minion.Trapd.Kafka.Exchanges
-
-#OpenNMS.Minion.Syslogd.Listener.ProcessingTime, \
-#OpenNMS.Minion.Syslogd.Marshaller.ProcessingTime, \
-#OpenNMS.Minion.Syslogd.JMS.ProcessingTime, \
-#OpenNMS.Minion.Syslogd.Kafka.ProcessingTime, \
-#OpenNMS.Minion.Trapd.Marshaller.ProcessingTime, \
-#OpenNMS.Minion.Trapd.JMS.ProcessingTime, \
-#OpenNMS.Minion.Trapd.Kafka.ProcessingTime
+OpenNMS.Minion.Trapd.Kafka.Exchanges, \
+OpenNMS.Minion.Trapd.JMS.ProcessingTime, \
+OpenNMS.Minion.Trapd.Kafka.ProcessingTime
 
 #OpenNMS.Minion.RPC.Server.Detect.Exchanges, \
 #OpenNMS.Minion.RPC.Server.Detect.ProcessingTime, \
@@ -116,8 +112,65 @@ report.OpenNMS.Minion.Syslogd.Kafka.Exchanges.command=--title="Syslog Messages S
  GPRINT:complete:MIN:" Min \\: %8.2lf %s" \
  GPRINT:complete:MAX:" Max \\: %8.2lf %s\\n" \
 
+###########################################
+## OpenNMS.Minion.Syslogd.JMS.ProcessingTime
+###########################################
+report.OpenNMS.Minion.Syslogd.JMS.ProcessingTime.name=Syslog Message Processing Time
+report.OpenNMS.Minion.Syslogd.JMS.ProcessingTime.columns=SlogListLastProc, SlogListMeanProc, SlogMarLastProc, SlogMarMeanProc, SlogJmsLastProc, SlogJmsMeanProc
+report.OpenNMS.Minion.Syslogd.JMS.ProcessingTime.type=interfaceSnmp
+report.OpenNMS.Minion.Syslogd.JMS.ProcessingTime.command=--title="Syslog Message Processing Time" \
+ DEF:listLast={rrd1}:SlogListLastProc:AVERAGE \
+ DEF:listMean={rrd2}:SlogListMeanProc:AVERAGE \
+ DEF:marLast={rrd3}:SlogMarLastProc:AVERAGE \
+ DEF:marMean={rrd4}:SlogMarMeanProc:AVERAGE \
+ DEF:mqLast={rrd5}:SlogJmsLastProc:AVERAGE \
+ DEF:mqMean={rrd6}:SlogJmsMeanProc:AVERAGE \
+ CDEF:listLastSec=listLast,1000,/ \
+ CDEF:marLastSec=marLast,1000,/ \
+ CDEF:mqLastSec=mqLast,1000,/ \
+ AREA:listLastSec#ad7fa8:"Receive       " \
+ GPRINT:listLastSec:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:listLastSec:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:listLastSec:MAX:" Max \\: %8.2lf %s\\n" \
+ STACK:marLastSec#729fcf:"Process       " \
+ GPRINT:marLastSec:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:marLastSec:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:marLastSec:MAX:" Max \\: %8.2lf %s\\n" \
+ STACK:mqLastSec#73d216:"Send via JMS  " \
+ GPRINT:mqLastSec:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:mqLastSec:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:mqLastSec:MAX:" Max \\: %8.2lf %s\\n" \
 
+###########################################
+## OpenNMS.Minion.Syslogd.Kafka.ProcessingTime
+###########################################
+report.OpenNMS.Minion.Syslogd.Kafka.ProcessingTime.name=Syslog Message Processing Time
+report.OpenNMS.Minion.Syslogd.Kafka.ProcessingTime.columns=SlogListLastProc, SlogListMeanProc, SlogMarLastProc, SlogMarMeanProc, SlogKafLastProc, SlogKafMeanProc
+report.OpenNMS.Minion.Syslogd.Kafka.ProcessingTime.type=interfaceSnmp
+report.OpenNMS.Minion.Syslogd.Kafka.ProcessingTime.command=--title="Syslog Message Processing Time" \
+ DEF:listLast={rrd1}:SlogListLastProc:AVERAGE \
+ DEF:listMean={rrd2}:SlogListMeanProc:AVERAGE \
+ DEF:marLast={rrd3}:SlogMarLastProc:AVERAGE \
+ DEF:marMean={rrd4}:SlogMarMeanProc:AVERAGE \
+ DEF:mqLast={rrd5}:SlogKafLastProc:AVERAGE \
+ DEF:mqMean={rrd6}:SlogKafMeanProc:AVERAGE \
+ CDEF:listLastSec=listLast,1000,/ \
+ CDEF:marLastSec=marLast,1000,/ \
+ CDEF:mqLastSec=mqLast,1000,/ \
+ AREA:listLastSec#ad7fa8:"Receive       " \
+ GPRINT:listLastSec:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:listLastSec:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:listLastSec:MAX:" Max \\: %8.2lf %s\\n" \
+ STACK:marLastSec#729fcf:"Process       " \
+ GPRINT:marLastSec:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:marLastSec:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:marLastSec:MAX:" Max \\: %8.2lf %s\\n" \
+ STACK:mqLastSec#73d216:"Send via Kafka" \
+ GPRINT:mqLastSec:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:mqLastSec:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:mqLastSec:MAX:" Max \\: %8.2lf %s\\n" \
 
+ 
 ###########################################
 ## OpenNMS.Minion.Trapd.Marshaller.Exchanges
 ###########################################
@@ -171,3 +224,47 @@ report.OpenNMS.Minion.Trapd.Kafka.Exchanges.command=--title="SNMP Trap Messages 
  GPRINT:complete:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:complete:MIN:" Min \\: %8.2lf %s" \
  GPRINT:complete:MAX:" Max \\: %8.2lf %s\\n" \
+
+###########################################
+## OpenNMS.Minion.Trapd.JMS.ProcessingTime
+###########################################
+report.OpenNMS.Minion.Trapd.JMS.ProcessingTime.name=SNMP Trap Message Processing Time
+report.OpenNMS.Minion.Trapd.JMS.ProcessingTime.columns=TrapMarLastProc, TrapMarMeanProc, TrapJmsLastProc, TrapJmsMeanProc
+report.OpenNMS.Minion.Trapd.JMS.ProcessingTime.type=interfaceSnmp
+report.OpenNMS.Minion.Trapd.JMS.ProcessingTime.command=--title="SNMP Trap Message Processing Time" \
+ DEF:marLast={rrd1}:TrapMarLastProc:AVERAGE \
+ DEF:marMean={rrd2}:TrapMarMeanProc:AVERAGE \
+ DEF:mqLast={rrd3}:TrapJmsLastProc:AVERAGE \
+ DEF:mqMean={rrd4}:TrapJmsMeanProc:AVERAGE \
+ CDEF:marLastSec=marLast,1000,/ \
+ CDEF:mqLastSec=mqLast,1000,/ \
+ AREA:marLastSec#729fcf:"Process       " \
+ GPRINT:marLastSec:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:marLastSec:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:marLastSec:MAX:" Max \\: %8.2lf %s\\n" \
+ STACK:mqLastSec#73d216:"Send via JMS  " \
+ GPRINT:mqLastSec:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:mqLastSec:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:mqLastSec:MAX:" Max \\: %8.2lf %s\\n" \
+
+###########################################
+## OpenNMS.Minion.Trapd.Kafka.ProcessingTime
+###########################################
+report.OpenNMS.Minion.Trapd.Kafka.ProcessingTime.name=SNMP Trap Message Processing Time
+report.OpenNMS.Minion.Trapd.Kafka.ProcessingTime.columns=TrapMarLastProc, TrapMarMeanProc, TrapKafLastProc, TrapKafMeanProc
+report.OpenNMS.Minion.Trapd.Kafka.ProcessingTime.type=interfaceSnmp
+report.OpenNMS.Minion.Trapd.Kafka.ProcessingTime.command=--title="SNMP Trap Message Processing Time" \
+ DEF:marLast={rrd1}:TrapMarLastProc:AVERAGE \
+ DEF:marMean={rrd2}:TrapMarMeanProc:AVERAGE \
+ DEF:mqLast={rrd3}:TrapKafLastProc:AVERAGE \
+ DEF:mqMean={rrd4}:TrapKafMeanProc:AVERAGE \
+ CDEF:marLastSec=marLast,1000,/ \
+ CDEF:mqLastSec=mqLast,1000,/ \
+ AREA:marLastSec#729fcf:"Process       " \
+ GPRINT:marLastSec:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:marLastSec:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:marLastSec:MAX:" Max \\: %8.2lf %s\\n" \
+ STACK:mqLastSec#73d216:"Send via Kafka" \
+ GPRINT:mqLastSec:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:mqLastSec:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:mqLastSec:MAX:" Max \\: %8.2lf %s\\n" \

--- a/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/paloalto-graph.properties
+++ b/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/paloalto-graph.properties
@@ -32,7 +32,7 @@ report.paloalto.envt.command=--title="Environmental Status of {panentPhysicalNam
  COMMENT:"\\n" \
  GPRINT:currentSessions:AVERAGE:"Avg \\: %1.0lf" \
  GPRINT:currentSessions:MIN:"Min \\: %1.0lf" \
- GPRINT:currentSessions:MAX:"Max \\: %1.0lf \\n" 
+ GPRINT:currentSessions:MAX:"Max \\: %1.0lf \\n"
 
 report.paloalto.session.util.name=Chassis Sessions (Palo Alto)
 report.paloalto.session.util.columns=panSessionUtil
@@ -153,7 +153,7 @@ report.paloalto.lc.vdisk.command=--title="Log Collector Disk Usage" \
  LINE2:vdisk4MB#f0000f:"Disk 4" \
  GPRINT:vdisk4MB:AVERAGE:"Avg \\: %1.0lf" \
  GPRINT:vdisk4MB:MIN:"Min \\: %1.0lf" \
- GPRINT:vdisk4MB:MAX:"Max \\: %1.0lf \\n" 
+ GPRINT:vdisk4MB:MAX:"Max \\: %1.0lf \\n"
 
 
 report.paloalto.lc.age.name=PaloAlto Log Collector Log Age

--- a/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/postgresql-graph.properties
+++ b/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/postgresql-graph.properties
@@ -60,7 +60,7 @@ report.pgsql.dbsize.command=--title="PostgreSQL DB Size - {datname}" \
  AREA:size#7EE600:"DB Size" \
  GPRINT:size:AVERAGE:" Avg\\: %8.2lf %s" \
  GPRINT:size:MIN:"Min\\: %8.2lf %s" \
- GPRINT:size:MAX:"Max\\: %8.2lf %s\\n" 
+ GPRINT:size:MAX:"Max\\: %8.2lf %s\\n"
 
 report.pgsql.dbbackends.name=PostgreSQL DB Backends
 report.pgsql.dbbackends.type=pgDatabase
@@ -76,7 +76,7 @@ report.pgsql.dbbackends.command=--title="PostgreSQL DB Backends - {datname}" \
  AREA:size#7EE600:"Backends" \
  GPRINT:size:AVERAGE:" Avg\\: %8.2lf %s" \
  GPRINT:size:MIN:"Min\\: %8.2lf %s" \
- GPRINT:size:MAX:"Max\\: %8.2lf %s\\n" 
+ GPRINT:size:MAX:"Max\\: %8.2lf %s\\n"
 
 
 report.pgsql.tssize.name=PostgreSQL Tablespace Size
@@ -93,5 +93,5 @@ report.pgsql.tssize.command=--title="PostgreSQL Tablespace Size - {spcname}" \
  AREA:size#7EE600:"Tablespace Size" \
  GPRINT:size:AVERAGE:" Avg\\: %8.2lf %s" \
  GPRINT:size:MIN:"Min\\: %8.2lf %s" \
- GPRINT:size:MAX:"Max\\: %8.2lf %s\\n" 
+ GPRINT:size:MAX:"Max\\: %8.2lf %s\\n"
 

--- a/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/riverbed-steelhead-graph.properties
+++ b/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/riverbed-steelhead-graph.properties
@@ -260,7 +260,7 @@ report.riverbed.steelhead.cpuStats.command=--title="Riverbed Steelhead CPU Stats
  STACK:idle#a0ffa0:"Idle  " \
  GPRINT:idle:AVERAGE:"Avg  \\: %8.2lf" \
  GPRINT:idle:MIN:"Min  \\: %8.2lf" \
- GPRINT:idle:MAX:"Max  \\: %8.2lf" \
+ GPRINT:idle:MAX:"Max  \\: %8.2lf"
 
 report.riverbed.steelhead.portBandwidth.name=Riverbed Steelhead Port Bandwidth
 report.riverbed.steelhead.portBandwidth.columns=rbshBwPortInLan,rbshBwPortInWan,rbshBwPortOutLan,rbshBwPortOutWan

--- a/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/sofaware-embeddedngx-graph.properties
+++ b/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/sofaware-embeddedngx-graph.properties
@@ -78,7 +78,7 @@ report.sofaware.embeddedngx.storageFirm.command=--title="SofaWare Embedded NGX F
  LINE2:firmTot#000000:"Total" \
  GPRINT:firmTot:AVERAGE:"Avg  \\: %8.2lf %s" \
  GPRINT:firmTot:MIN:"Min  \\: %8.2lf %s" \
- GPRINT:firmTot:MAX:"Max  \\: %8.2lf %s" 
+ GPRINT:firmTot:MAX:"Max  \\: %8.2lf %s"
 
 report.sofaware.embeddedngx.storageCF.name=SofaWare Embedded NGX CF Storage
 report.sofaware.embeddedngx.storageCF.columns=swStorageCFTot,swStorageCFFree
@@ -96,7 +96,7 @@ report.sofaware.embeddedngx.storageCF.command=--title="SofaWare Embedded NGX CF 
  LINE2:cfTot#000000:"Total" \
  GPRINT:cfTot:AVERAGE:"Avg  \\: %8.2lf %s" \
  GPRINT:cfTot:MIN:"Min  \\: %8.2lf %s" \
- GPRINT:cfTot:MAX:"Max  \\: %8.2lf %s" 
+ GPRINT:cfTot:MAX:"Max  \\: %8.2lf %s"
 
 report.sofaware.embeddedngx.licenses.name=SofaWare Embedded NGX Licenses
 report.sofaware.embeddedngx.licenses.columns=swLicenseUsedNodes

--- a/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/vmware-cim-graph-simple.properties
+++ b/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/vmware-cim-graph-simple.properties
@@ -25,7 +25,7 @@ DEF:xxx={rrd1}:CurrentReading:AVERAGE \
 LINE2:xxx#0000ff:"CurrentReading" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" 
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmwareCim.SensorOther.name=SensorOther
 report.vmwareCim.SensorOther.columns=CurrentReading
@@ -37,7 +37,7 @@ DEF:xxx={rrd1}:CurrentReading:AVERAGE \
 LINE2:xxx#0000ff:"CurrentReading" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" 
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmwareCim.SensorTemperature.name=SensorTemperature
 report.vmwareCim.SensorTemperature.columns=CurrentReading
@@ -49,7 +49,7 @@ DEF:xxx={rrd1}:CurrentReading:AVERAGE \
 LINE2:xxx#0000ff:"CurrentReading" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" 
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmwareCim.SensorVoltage.name=SensorVoltage
 report.vmwareCim.SensorVoltage.columns=CurrentReading
@@ -61,7 +61,7 @@ DEF:xxx={rrd1}:CurrentReading:AVERAGE \
 LINE2:xxx#0000ff:"CurrentReading" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" 
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmwareCim.SensorCurrent.name=SensorCurrent
 report.vmwareCim.SensorCurrent.columns=CurrentReading
@@ -73,7 +73,7 @@ DEF:xxx={rrd1}:CurrentReading:AVERAGE \
 LINE2:xxx#0000ff:"CurrentReading" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" 
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmwareCim.SensorCounter.name=SensorCounter
 report.vmwareCim.SensorCounter.columns=CurrentReading
@@ -87,7 +87,7 @@ AREA:xxx#729fcf \
 LINE1:xxx#3465a4:"CurrentReading" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" 
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmwareCim.SensorTachometer.name=SensorTachometer
 report.vmwareCim.SensorTachometer.columns=CurrentReading
@@ -99,7 +99,7 @@ DEF:xxx={rrd1}:CurrentReading:AVERAGE \
 LINE2:xxx#0000ff:"CurrentReading" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" 
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmwareCim.SensorSwitch.name=SensorSwitch
 report.vmwareCim.SensorSwitch.columns=CurrentReading
@@ -111,7 +111,7 @@ DEF:xxx={rrd1}:CurrentReading:AVERAGE \
 LINE2:xxx#0000ff:"CurrentReading" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" 
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmwareCim.SensorLock.name=SensorLock
 report.vmwareCim.SensorLock.columns=CurrentReading
@@ -123,7 +123,7 @@ DEF:xxx={rrd1}:CurrentReading:AVERAGE \
 LINE2:xxx#0000ff:"CurrentReading" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" 
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmwareCim.SensorHumidity.name=SensorHumidity
 report.vmwareCim.SensorHumidity.columns=CurrentReading
@@ -135,7 +135,7 @@ DEF:xxx={rrd1}:CurrentReading:AVERAGE \
 LINE2:xxx#0000ff:"CurrentReading" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" 
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmwareCim.SensorSmokeDetection.name=SensorSmokeDetection
 report.vmwareCim.SensorSmokeDetection.columns=CurrentReading
@@ -147,7 +147,7 @@ DEF:xxx={rrd1}:CurrentReading:AVERAGE \
 LINE2:xxx#0000ff:"CurrentReading" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" 
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmwareCim.SensorPresence.name=SensorPresence
 report.vmwareCim.SensorPresence.columns=CurrentReading
@@ -159,7 +159,7 @@ DEF:xxx={rrd1}:CurrentReading:AVERAGE \
 LINE2:xxx#0000ff:"CurrentReading" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" 
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmwareCim.SensorAirFlow.name=SensorAirFlow
 report.vmwareCim.SensorAirFlow.columns=CurrentReading
@@ -171,7 +171,7 @@ DEF:xxx={rrd1}:CurrentReading:AVERAGE \
 LINE2:xxx#0000ff:"CurrentReading" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" 
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmwareCim.SensorPowerConsumption.name=SensorPowerConsumption
 report.vmwareCim.SensorPowerConsumption.columns=CurrentReading
@@ -183,7 +183,7 @@ DEF:xxx={rrd1}:CurrentReading:AVERAGE \
 LINE2:xxx#0000ff:"CurrentReading" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" 
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmwareCim.SensorPowerProduction.name=SensorPowerProduction
 report.vmwareCim.SensorPowerProduction.columns=CurrentReading
@@ -195,7 +195,7 @@ DEF:xxx={rrd1}:CurrentReading:AVERAGE \
 LINE2:xxx#0000ff:"CurrentReading" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" 
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmwareCim.SensorPressure.name=SensorPressure
 report.vmwareCim.SensorPressure.columns=CurrentReading
@@ -207,5 +207,5 @@ DEF:xxx={rrd1}:CurrentReading:AVERAGE \
 LINE2:xxx#0000ff:"CurrentReading" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" 
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 

--- a/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/vmware3-graph-simple.properties
+++ b/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/vmware3-graph-simple.properties
@@ -136,7 +136,7 @@ DEF:xxx={rrd1}:CpuIdleSum:AVERAGE \
 LINE2:xxx#0000ff:"CpuIdleSum" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.CpuUsageNon.name=CpuUsageNon
 report.vmware3.CpuUsageNon.columns=CpuUsageNon
@@ -148,7 +148,7 @@ DEF:xxx={rrd1}:CpuUsageNon:AVERAGE \
 LINE2:xxx#0000ff:"CpuUsageNon" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.CpuUsedSum.name=CpuUsedSum
 report.vmware3.CpuUsedSum.columns=CpuUsedSum
@@ -160,7 +160,7 @@ DEF:xxx={rrd1}:CpuUsedSum:AVERAGE \
 LINE2:xxx#0000ff:"CpuUsedSum" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.CpuRdCyAvg.name=CpuRdCyAvg
 report.vmware3.CpuRdCyAvg.columns=CpuRdCyAvg
@@ -171,7 +171,7 @@ DEF:xxx={rrd1}:CpuRdCyAvg:AVERAGE \
 LINE2:xxx#0000ff:"CpuRdCyAvg" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.CpuUsageNon.name=CpuUsageNon
 report.vmware3.CpuUsageNon.columns=CpuUsageNon
@@ -182,7 +182,7 @@ DEF:xxx={rrd1}:CpuUsageNon:AVERAGE \
 LINE2:xxx#0000ff:"CpuUsageNon" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.CpuUsagemhzNon.name=CpuUsagemhzNon
 report.vmware3.CpuUsagemhzNon.columns=CpuUsagemhzNon
@@ -193,7 +193,7 @@ DEF:xxx={rrd1}:CpuUsagemhzNon:AVERAGE \
 LINE2:xxx#0000ff:"CpuUsagemhzNon" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.DiskUsageNon.name=DiskUsageNon
 report.vmware3.DiskUsageNon.columns=DiskUsageNon
@@ -204,7 +204,7 @@ DEF:xxx={rrd1}:DiskUsageNon:AVERAGE \
 LINE2:xxx#0000ff:"DiskUsageNon" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.MemActiveNon.name=MemActiveNon
 report.vmware3.MemActiveNon.columns=MemActiveNon
@@ -215,7 +215,7 @@ DEF:xxx={rrd1}:MemActiveNon:AVERAGE \
 LINE2:xxx#0000ff:"MemActiveNon" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.MemConsumedNon.name=MemConsumedNon
 report.vmware3.MemConsumedNon.columns=MemConsumedNon
@@ -226,7 +226,7 @@ DEF:xxx={rrd1}:MemConsumedNon:AVERAGE \
 LINE2:xxx#0000ff:"MemConsumedNon" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.MemGrantedNon.name=MemGrantedNon
 report.vmware3.MemGrantedNon.columns=MemGrantedNon
@@ -237,7 +237,7 @@ DEF:xxx={rrd1}:MemGrantedNon:AVERAGE \
 LINE2:xxx#0000ff:"MemGrantedNon" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.MemHeapNon.name=MemHeapNon
 report.vmware3.MemHeapNon.columns=MemHeapNon
@@ -248,7 +248,7 @@ DEF:xxx={rrd1}:MemHeapNon:AVERAGE \
 LINE2:xxx#0000ff:"MemHeapNon" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.MemHeapfreeNon.name=MemHeapfreeNon
 report.vmware3.MemHeapfreeNon.columns=MemHeapfreeNon
@@ -259,7 +259,7 @@ DEF:xxx={rrd1}:MemHeapfreeNon:AVERAGE \
 LINE2:xxx#0000ff:"MemHeapfreeNon" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.MemOdNon.name=MemOdNon
 report.vmware3.MemOdNon.columns=MemOdNon
@@ -270,7 +270,7 @@ DEF:xxx={rrd1}:MemOdNon:AVERAGE \
 LINE2:xxx#0000ff:"MemOdNon" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.MemRdCyAvg.name=MemRdCyAvg
 report.vmware3.MemRdCyAvg.columns=MemRdCyAvg
@@ -281,7 +281,7 @@ DEF:xxx={rrd1}:MemRdCyAvg:AVERAGE \
 LINE2:xxx#0000ff:"MemRdCyAvg" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.MemSharedNon.name=MemSharedNon
 report.vmware3.MemSharedNon.columns=MemSharedNon
@@ -292,7 +292,7 @@ DEF:xxx={rrd1}:MemSharedNon:AVERAGE \
 LINE2:xxx#0000ff:"MemSharedNon" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.MemSharedcommonNon.name=MemSharedcommonNon
 report.vmware3.MemSharedcommonNon.columns=MemSharedcommonNon
@@ -303,7 +303,7 @@ DEF:xxx={rrd1}:MemSharedcommonNon:AVERAGE \
 LINE2:xxx#0000ff:"MemSharedcommonNon" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.MemSpinNon.name=MemSpinNon
 report.vmware3.MemSpinNon.columns=MemSpinNon
@@ -314,7 +314,7 @@ DEF:xxx={rrd1}:MemSpinNon:AVERAGE \
 LINE2:xxx#0000ff:"MemSpinNon" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.MemSpoutNon.name=MemSpoutNon
 report.vmware3.MemSpoutNon.columns=MemSpoutNon
@@ -325,7 +325,7 @@ DEF:xxx={rrd1}:MemSpoutNon:AVERAGE \
 LINE2:xxx#0000ff:"MemSpoutNon" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.MemSpusedNon.name=MemSpusedNon
 report.vmware3.MemSpusedNon.columns=MemSpusedNon
@@ -336,7 +336,7 @@ DEF:xxx={rrd1}:MemSpusedNon:AVERAGE \
 LINE2:xxx#0000ff:"MemSpusedNon" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.MemStateLat.name=MemStateLat
 report.vmware3.MemStateLat.columns=MemStateLat
@@ -347,7 +347,7 @@ DEF:xxx={rrd1}:MemStateLat:AVERAGE \
 LINE2:xxx#0000ff:"MemStateLat" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.MemSysUsageNon.name=MemSysUsageNon
 report.vmware3.MemSysUsageNon.columns=MemSysUsageNon
@@ -358,7 +358,7 @@ DEF:xxx={rrd1}:MemSysUsageNon:AVERAGE \
 LINE2:xxx#0000ff:"MemSysUsageNon" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.MemUdNon.name=MemUdNon
 report.vmware3.MemUdNon.columns=MemUdNon
@@ -369,7 +369,7 @@ DEF:xxx={rrd1}:MemUdNon:AVERAGE \
 LINE2:xxx#0000ff:"MemUdNon" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.MemUsageNon.name=MemUsageNon
 report.vmware3.MemUsageNon.columns=MemUsageNon
@@ -380,7 +380,7 @@ DEF:xxx={rrd1}:MemUsageNon:AVERAGE \
 LINE2:xxx#0000ff:"MemUsageNon" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.MemVmmemctlNon.name=MemVmmemctlNon
 report.vmware3.MemVmmemctlNon.columns=MemVmmemctlNon
@@ -391,7 +391,7 @@ DEF:xxx={rrd1}:MemVmmemctlNon:AVERAGE \
 LINE2:xxx#0000ff:"MemVmmemctlNon" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.MemZeroNon.name=MemZeroNon
 report.vmware3.MemZeroNon.columns=MemZeroNon
@@ -402,7 +402,7 @@ DEF:xxx={rrd1}:MemZeroNon:AVERAGE \
 LINE2:xxx#0000ff:"MemZeroNon" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.NetUsageNon.name=NetUsageNon
 report.vmware3.NetUsageNon.columns=NetUsageNon
@@ -413,7 +413,7 @@ DEF:xxx={rrd1}:NetUsageNon:AVERAGE \
 LINE2:xxx#0000ff:"NetUsageNon" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.ResCpuActav15Lat.name=ResCpuActav15Lat
 report.vmware3.ResCpuActav15Lat.columns=ResCpuActav15Lat
@@ -424,7 +424,7 @@ DEF:xxx={rrd1}:ResCpuActav15Lat:AVERAGE \
 LINE2:xxx#0000ff:"ResCpuActav15Lat" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.ResCpuActav1Lat.name=ResCpuActav1Lat
 report.vmware3.ResCpuActav1Lat.columns=ResCpuActav1Lat
@@ -435,7 +435,7 @@ DEF:xxx={rrd1}:ResCpuActav1Lat:AVERAGE \
 LINE2:xxx#0000ff:"ResCpuActav1Lat" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.ResCpuActav5Lat.name=ResCpuActav5Lat
 report.vmware3.ResCpuActav5Lat.columns=ResCpuActav5Lat
@@ -446,7 +446,7 @@ DEF:xxx={rrd1}:ResCpuActav5Lat:AVERAGE \
 LINE2:xxx#0000ff:"ResCpuActav5Lat" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.ResCpuActpk15Lat.name=ResCpuActpk15Lat
 report.vmware3.ResCpuActpk15Lat.columns=ResCpuActpk15Lat
@@ -457,7 +457,7 @@ DEF:xxx={rrd1}:ResCpuActpk15Lat:AVERAGE \
 LINE2:xxx#0000ff:"ResCpuActpk15Lat" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.ResCpuActpk1Lat.name=ResCpuActpk1Lat
 report.vmware3.ResCpuActpk1Lat.columns=ResCpuActpk1Lat
@@ -468,7 +468,7 @@ DEF:xxx={rrd1}:ResCpuActpk1Lat:AVERAGE \
 LINE2:xxx#0000ff:"ResCpuActpk1Lat" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.ResCpuActpk5Lat.name=ResCpuActpk5Lat
 report.vmware3.ResCpuActpk5Lat.columns=ResCpuActpk5Lat
@@ -479,7 +479,7 @@ DEF:xxx={rrd1}:ResCpuActpk5Lat:AVERAGE \
 LINE2:xxx#0000ff:"ResCpuActpk5Lat" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.ResCpuMaxLd15Lat.name=ResCpuMaxLd15Lat
 report.vmware3.ResCpuMaxLd15Lat.columns=ResCpuMaxLd15Lat
@@ -490,7 +490,7 @@ DEF:xxx={rrd1}:ResCpuMaxLd15Lat:AVERAGE \
 LINE2:xxx#0000ff:"ResCpuMaxLd15Lat" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.ResCpuMaxLd1Lat.name=ResCpuMaxLd1Lat
 report.vmware3.ResCpuMaxLd1Lat.columns=ResCpuMaxLd1Lat
@@ -501,7 +501,7 @@ DEF:xxx={rrd1}:ResCpuMaxLd1Lat:AVERAGE \
 LINE2:xxx#0000ff:"ResCpuMaxLd1Lat" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.ResCpuMaxLd5Lat.name=ResCpuMaxLd5Lat
 report.vmware3.ResCpuMaxLd5Lat.columns=ResCpuMaxLd5Lat
@@ -512,7 +512,7 @@ DEF:xxx={rrd1}:ResCpuMaxLd5Lat:AVERAGE \
 LINE2:xxx#0000ff:"ResCpuMaxLd5Lat" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.ResCpuRunav15Lat.name=ResCpuRunav15Lat
 report.vmware3.ResCpuRunav15Lat.columns=ResCpuRunav15Lat
@@ -523,7 +523,7 @@ DEF:xxx={rrd1}:ResCpuRunav15Lat:AVERAGE \
 LINE2:xxx#0000ff:"ResCpuRunav15Lat" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.ResCpuRunav1Lat.name=ResCpuRunav1Lat
 report.vmware3.ResCpuRunav1Lat.columns=ResCpuRunav1Lat
@@ -534,7 +534,7 @@ DEF:xxx={rrd1}:ResCpuRunav1Lat:AVERAGE \
 LINE2:xxx#0000ff:"ResCpuRunav1Lat" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.ResCpuRunav5Lat.name=ResCpuRunav5Lat
 report.vmware3.ResCpuRunav5Lat.columns=ResCpuRunav5Lat
@@ -545,7 +545,7 @@ DEF:xxx={rrd1}:ResCpuRunav5Lat:AVERAGE \
 LINE2:xxx#0000ff:"ResCpuRunav5Lat" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.ResCpuRunpk15Lat.name=ResCpuRunpk15Lat
 report.vmware3.ResCpuRunpk15Lat.columns=ResCpuRunpk15Lat
@@ -556,7 +556,7 @@ DEF:xxx={rrd1}:ResCpuRunpk15Lat:AVERAGE \
 LINE2:xxx#0000ff:"ResCpuRunpk15Lat" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.ResCpuRunpk1Lat.name=ResCpuRunpk1Lat
 report.vmware3.ResCpuRunpk1Lat.columns=ResCpuRunpk1Lat
@@ -567,7 +567,7 @@ DEF:xxx={rrd1}:ResCpuRunpk1Lat:AVERAGE \
 LINE2:xxx#0000ff:"ResCpuRunpk1Lat" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.ResCpuRunpk5Lat.name=ResCpuRunpk5Lat
 report.vmware3.ResCpuRunpk5Lat.columns=ResCpuRunpk5Lat
@@ -578,7 +578,7 @@ DEF:xxx={rrd1}:ResCpuRunpk5Lat:AVERAGE \
 LINE2:xxx#0000ff:"ResCpuRunpk5Lat" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.ResCpuSeCtLat.name=ResCpuSeCtLat
 report.vmware3.ResCpuSeCtLat.columns=ResCpuSeCtLat
@@ -589,7 +589,7 @@ DEF:xxx={rrd1}:ResCpuSeCtLat:AVERAGE \
 LINE2:xxx#0000ff:"ResCpuSeCtLat" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.ResCpuSePeriodLat.name=ResCpuSePeriodLat
 report.vmware3.ResCpuSePeriodLat.columns=ResCpuSePeriodLat
@@ -600,7 +600,7 @@ DEF:xxx={rrd1}:ResCpuSePeriodLat:AVERAGE \
 LINE2:xxx#0000ff:"ResCpuSePeriodLat" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.SysUptimeLat.name=SysUptimeLat
 report.vmware3.SysUptimeLat.columns=SysUptimeLat
@@ -611,7 +611,7 @@ DEF:xxx={rrd1}:SysUptimeLat:AVERAGE \
 LINE2:xxx#0000ff:"SysUptimeLat" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.MgtAgtMemUsedAvg.name=MgtAgtMemUsedAvg
 report.vmware3.MgtAgtMemUsedAvg.columns=MgtAgtMemUsedAvg
@@ -623,7 +623,7 @@ DEF:xxx={rrd1}:MgtAgtMemUsedAvg:AVERAGE \
 LINE2:xxx#0000ff:"MgtAgtMemUsedAvg" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.MgtAgtSpInAvg.name=MgtAgtSpInAvg
 report.vmware3.MgtAgtSpInAvg.columns=MgtAgtSpInAvg
@@ -635,7 +635,7 @@ DEF:xxx={rrd1}:MgtAgtSpInAvg:AVERAGE \
 LINE2:xxx#0000ff:"MgtAgtSpInAvg" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.MgtAgtSpOutAvg.name=MgtAgtSpOutAvg
 report.vmware3.MgtAgtSpOutAvg.columns=MgtAgtSpOutAvg
@@ -647,7 +647,7 @@ DEF:xxx={rrd1}:MgtAgtSpOutAvg:AVERAGE \
 LINE2:xxx#0000ff:"MgtAgtSpOutAvg" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.MgtAgtSpUsedAvg.name=MgtAgtSpUsedAvg
 report.vmware3.MgtAgtSpUsedAvg.columns=MgtAgtSpUsedAvg
@@ -659,7 +659,7 @@ DEF:xxx={rrd1}:MgtAgtSpUsedAvg:AVERAGE \
 LINE2:xxx#0000ff:"MgtAgtSpUsedAvg" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.NetPacketsRxSum.name=NetPacketsRxSum
 report.vmware3.NetPacketsRxSum.columns=NetPacketsRxSum
@@ -671,7 +671,7 @@ DEF:xxx={rrd1}:NetPacketsRxSum:AVERAGE \
 LINE2:xxx#0000ff:"NetPacketsRxSum" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.NetPacketsTxSum.name=NetPacketsTxSum
 report.vmware3.NetPacketsTxSum.columns=NetPacketsTxSum
@@ -683,7 +683,7 @@ DEF:xxx={rrd1}:NetPacketsTxSum:AVERAGE \
 LINE2:xxx#0000ff:"NetPacketsTxSum" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.NetReceivedAvg.name=NetReceivedAvg
 report.vmware3.NetReceivedAvg.columns=NetReceivedAvg
@@ -695,7 +695,7 @@ DEF:xxx={rrd1}:NetReceivedAvg:AVERAGE \
 LINE2:xxx#0000ff:"NetReceivedAvg" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.NetTransmittedAvg.name=NetTransmittedAvg
 report.vmware3.NetTransmittedAvg.columns=NetTransmittedAvg
@@ -707,7 +707,7 @@ DEF:xxx={rrd1}:NetTransmittedAvg:AVERAGE \
 LINE2:xxx#0000ff:"NetTransmittedAvg" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.DiskBusResetsSum.name=DiskBusResetsSum
 report.vmware3.DiskBusResetsSum.columns=DiskBusResetsSum
@@ -719,7 +719,7 @@ DEF:xxx={rrd1}:DiskBusResetsSum:AVERAGE \
 LINE2:xxx#0000ff:"DiskBusResetsSum" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.DiskCsAdSum.name=DiskCsAdSum
 report.vmware3.DiskCsAdSum.columns=DiskCsAdSum
@@ -731,7 +731,7 @@ DEF:xxx={rrd1}:DiskCsAdSum:AVERAGE \
 LINE2:xxx#0000ff:"DiskCsAdSum" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.DiskCsSum.name=DiskCsSum
 report.vmware3.DiskCsSum.columns=DiskCsSum
@@ -743,7 +743,7 @@ DEF:xxx={rrd1}:DiskCsSum:AVERAGE \
 LINE2:xxx#0000ff:"DiskCsSum" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.DiskDeLyAvg.name=DiskDeLyAvg
 report.vmware3.DiskDeLyAvg.columns=DiskDeLyAvg
@@ -755,7 +755,7 @@ DEF:xxx={rrd1}:DiskDeLyAvg:AVERAGE \
 LINE2:xxx#0000ff:"DiskDeLyAvg" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.DiskDeRdLyAvg.name=DiskDeRdLyAvg
 report.vmware3.DiskDeRdLyAvg.columns=DiskDeRdLyAvg
@@ -767,7 +767,7 @@ DEF:xxx={rrd1}:DiskDeRdLyAvg:AVERAGE \
 LINE2:xxx#0000ff:"DiskDeRdLyAvg" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.DiskDeWeLyAvg.name=DiskDeWeLyAvg
 report.vmware3.DiskDeWeLyAvg.columns=DiskDeWeLyAvg
@@ -779,7 +779,7 @@ DEF:xxx={rrd1}:DiskDeWeLyAvg:AVERAGE \
 LINE2:xxx#0000ff:"DiskDeWeLyAvg" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.DiskKlLyAvg.name=DiskKlLyAvg
 report.vmware3.DiskKlLyAvg.columns=DiskKlLyAvg
@@ -791,7 +791,7 @@ DEF:xxx={rrd1}:DiskKlLyAvg:AVERAGE \
 LINE2:xxx#0000ff:"DiskKlLyAvg" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.DiskKlRdLyAvg.name=DiskKlRdLyAvg
 report.vmware3.DiskKlRdLyAvg.columns=DiskKlRdLyAvg
@@ -803,7 +803,7 @@ DEF:xxx={rrd1}:DiskKlRdLyAvg:AVERAGE \
 LINE2:xxx#0000ff:"DiskKlRdLyAvg" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.DiskKlWeLyAvg.name=DiskKlWeLyAvg
 report.vmware3.DiskKlWeLyAvg.columns=DiskKlWeLyAvg
@@ -815,7 +815,7 @@ DEF:xxx={rrd1}:DiskKlWeLyAvg:AVERAGE \
 LINE2:xxx#0000ff:"DiskKlWeLyAvg" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.DiskNrRdSum.name=DiskNrRdSum
 report.vmware3.DiskNrRdSum.columns=DiskNrRdSum
@@ -827,7 +827,7 @@ DEF:xxx={rrd1}:DiskNrRdSum:AVERAGE \
 LINE2:xxx#0000ff:"DiskNrRdSum" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.DiskNrWeSum.name=DiskNrWeSum
 report.vmware3.DiskNrWeSum.columns=DiskNrWeSum
@@ -839,7 +839,7 @@ DEF:xxx={rrd1}:DiskNrWeSum:AVERAGE \
 LINE2:xxx#0000ff:"DiskNrWeSum" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.DiskQeLyAvg.name=DiskQeLyAvg
 report.vmware3.DiskQeLyAvg.columns=DiskQeLyAvg
@@ -851,7 +851,7 @@ DEF:xxx={rrd1}:DiskQeLyAvg:AVERAGE \
 LINE2:xxx#0000ff:"DiskQeLyAvg" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.DiskQeRdLyAvg.name=DiskQeRdLyAvg
 report.vmware3.DiskQeRdLyAvg.columns=DiskQeRdLyAvg
@@ -863,7 +863,7 @@ DEF:xxx={rrd1}:DiskQeRdLyAvg:AVERAGE \
 LINE2:xxx#0000ff:"DiskQeRdLyAvg" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.DiskQeWeLyAvg.name=DiskQeWeLyAvg
 report.vmware3.DiskQeWeLyAvg.columns=DiskQeWeLyAvg
@@ -875,7 +875,7 @@ DEF:xxx={rrd1}:DiskQeWeLyAvg:AVERAGE \
 LINE2:xxx#0000ff:"DiskQeWeLyAvg" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.DiskRdAvg.name=DiskRdAvg
 report.vmware3.DiskRdAvg.columns=DiskRdAvg
@@ -887,7 +887,7 @@ DEF:xxx={rrd1}:DiskRdAvg:AVERAGE \
 LINE2:xxx#0000ff:"DiskRdAvg" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.DiskTlLyAvg.name=DiskTlLyAvg
 report.vmware3.DiskTlLyAvg.columns=DiskTlLyAvg
@@ -899,7 +899,7 @@ DEF:xxx={rrd1}:DiskTlLyAvg:AVERAGE \
 LINE2:xxx#0000ff:"DiskTlLyAvg" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.DiskTlRdLyAvg.name=DiskTlRdLyAvg
 report.vmware3.DiskTlRdLyAvg.columns=DiskTlRdLyAvg
@@ -911,7 +911,7 @@ DEF:xxx={rrd1}:DiskTlRdLyAvg:AVERAGE \
 LINE2:xxx#0000ff:"DiskTlRdLyAvg" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.DiskTlWeLyAvg.name=DiskTlWeLyAvg
 report.vmware3.DiskTlWeLyAvg.columns=DiskTlWeLyAvg
@@ -923,7 +923,7 @@ DEF:xxx={rrd1}:DiskTlWeLyAvg:AVERAGE \
 LINE2:xxx#0000ff:"DiskTlWeLyAvg" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.DiskWeAvg.name=DiskWeAvg
 report.vmware3.DiskWeAvg.columns=DiskWeAvg
@@ -935,7 +935,7 @@ DEF:xxx={rrd1}:DiskWeAvg:AVERAGE \
 LINE2:xxx#0000ff:"DiskWeAvg" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.SysReCpuUsageNon.name=SysReCpuUsageNon
 report.vmware3.SysReCpuUsageNon.columns=SysReCpuUsageNon
@@ -947,7 +947,7 @@ DEF:xxx={rrd1}:SysReCpuUsageNon:AVERAGE \
 LINE2:xxx#0000ff:"SysReCpuUsageNon" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.CpuExtraSum.name=CpuExtraSum
 report.vmware3.CpuExtraSum.columns=CpuExtraSum
@@ -959,7 +959,7 @@ DEF:xxx={rrd1}:CpuExtraSum:AVERAGE \
 LINE2:xxx#0000ff:"CpuExtraSum" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.CpuGuaranteedLat.name=CpuGuaranteedLat
 report.vmware3.CpuGuaranteedLat.columns=CpuGuaranteedLat
@@ -971,7 +971,7 @@ DEF:xxx={rrd1}:CpuGuaranteedLat:AVERAGE \
 LINE2:xxx#0000ff:"CpuGuaranteedLat" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.CpuRdySum.name=CpuRdySum
 report.vmware3.CpuRdySum.columns=CpuRdySum
@@ -983,7 +983,7 @@ DEF:xxx={rrd1}:CpuRdySum:AVERAGE \
 LINE2:xxx#0000ff:"CpuRdySum" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.CpuSystemSum.name=CpuSystemSum
 report.vmware3.CpuSystemSum.columns=CpuSystemSum
@@ -995,7 +995,7 @@ DEF:xxx={rrd1}:CpuSystemSum:AVERAGE \
 LINE2:xxx#0000ff:"CpuSystemSum" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.CpuUsagemhzNon.name=CpuUsagemhzNon
 report.vmware3.CpuUsagemhzNon.columns=CpuUsagemhzNon
@@ -1007,7 +1007,7 @@ DEF:xxx={rrd1}:CpuUsagemhzNon:AVERAGE \
 LINE2:xxx#0000ff:"CpuUsagemhzNon" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.CpuUsedSum.name=CpuUsedSum
 report.vmware3.CpuUsedSum.columns=CpuUsedSum
@@ -1019,7 +1019,7 @@ DEF:xxx={rrd1}:CpuUsedSum:AVERAGE \
 LINE2:xxx#0000ff:"CpuUsedSum" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.CpuWaitSum.name=CpuWaitSum
 report.vmware3.CpuWaitSum.columns=CpuWaitSum
@@ -1031,7 +1031,7 @@ DEF:xxx={rrd1}:CpuWaitSum:AVERAGE \
 LINE2:xxx#0000ff:"CpuWaitSum" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.CpuUsageNon.name=CpuUsageNon
 report.vmware3.CpuUsageNon.columns=CpuUsageNon
@@ -1042,7 +1042,7 @@ DEF:xxx={rrd1}:CpuUsageNon:AVERAGE \
 LINE2:xxx#0000ff:"CpuUsageNon" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.CpuUsagemhzNon.name=CpuUsagemhzNon
 report.vmware3.CpuUsagemhzNon.columns=CpuUsagemhzNon
@@ -1053,7 +1053,7 @@ DEF:xxx={rrd1}:CpuUsagemhzNon:AVERAGE \
 LINE2:xxx#0000ff:"CpuUsagemhzNon" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.DiskUsageNon.name=DiskUsageNon
 report.vmware3.DiskUsageNon.columns=DiskUsageNon
@@ -1064,7 +1064,7 @@ DEF:xxx={rrd1}:DiskUsageNon:AVERAGE \
 LINE2:xxx#0000ff:"DiskUsageNon" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.MemActiveNon.name=MemActiveNon
 report.vmware3.MemActiveNon.columns=MemActiveNon
@@ -1075,7 +1075,7 @@ DEF:xxx={rrd1}:MemActiveNon:AVERAGE \
 LINE2:xxx#0000ff:"MemActiveNon" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.MemConsumedNon.name=MemConsumedNon
 report.vmware3.MemConsumedNon.columns=MemConsumedNon
@@ -1086,7 +1086,7 @@ DEF:xxx={rrd1}:MemConsumedNon:AVERAGE \
 LINE2:xxx#0000ff:"MemConsumedNon" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.MemGrantedNon.name=MemGrantedNon
 report.vmware3.MemGrantedNon.columns=MemGrantedNon
@@ -1097,7 +1097,7 @@ DEF:xxx={rrd1}:MemGrantedNon:AVERAGE \
 LINE2:xxx#0000ff:"MemGrantedNon" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.MemOdNon.name=MemOdNon
 report.vmware3.MemOdNon.columns=MemOdNon
@@ -1108,7 +1108,7 @@ DEF:xxx={rrd1}:MemOdNon:AVERAGE \
 LINE2:xxx#0000ff:"MemOdNon" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.MemSharedNon.name=MemSharedNon
 report.vmware3.MemSharedNon.columns=MemSharedNon
@@ -1119,7 +1119,7 @@ DEF:xxx={rrd1}:MemSharedNon:AVERAGE \
 LINE2:xxx#0000ff:"MemSharedNon" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.MemSpTtNon.name=MemSpTtNon
 report.vmware3.MemSpTtNon.columns=MemSpTtNon
@@ -1130,7 +1130,7 @@ DEF:xxx={rrd1}:MemSpTtNon:AVERAGE \
 LINE2:xxx#0000ff:"MemSpTtNon" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.MemSpinNon.name=MemSpinNon
 report.vmware3.MemSpinNon.columns=MemSpinNon
@@ -1141,7 +1141,7 @@ DEF:xxx={rrd1}:MemSpinNon:AVERAGE \
 LINE2:xxx#0000ff:"MemSpinNon" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.MemSpoutNon.name=MemSpoutNon
 report.vmware3.MemSpoutNon.columns=MemSpoutNon
@@ -1152,7 +1152,7 @@ DEF:xxx={rrd1}:MemSpoutNon:AVERAGE \
 LINE2:xxx#0000ff:"MemSpoutNon" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.MemSppedNon.name=MemSppedNon
 report.vmware3.MemSppedNon.columns=MemSppedNon
@@ -1163,7 +1163,7 @@ DEF:xxx={rrd1}:MemSppedNon:AVERAGE \
 LINE2:xxx#0000ff:"MemSppedNon" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.MemUsageNon.name=MemUsageNon
 report.vmware3.MemUsageNon.columns=MemUsageNon
@@ -1174,7 +1174,7 @@ DEF:xxx={rrd1}:MemUsageNon:AVERAGE \
 LINE2:xxx#0000ff:"MemUsageNon" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.MemVmmemctlNon.name=MemVmmemctlNon
 report.vmware3.MemVmmemctlNon.columns=MemVmmemctlNon
@@ -1185,7 +1185,7 @@ DEF:xxx={rrd1}:MemVmmemctlNon:AVERAGE \
 LINE2:xxx#0000ff:"MemVmmemctlNon" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.MemVmmemctlTtNon.name=MemVmmemctlTtNon
 report.vmware3.MemVmmemctlTtNon.columns=MemVmmemctlTtNon
@@ -1196,7 +1196,7 @@ DEF:xxx={rrd1}:MemVmmemctlTtNon:AVERAGE \
 LINE2:xxx#0000ff:"MemVmmemctlTtNon" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.MemZeroNon.name=MemZeroNon
 report.vmware3.MemZeroNon.columns=MemZeroNon
@@ -1207,7 +1207,7 @@ DEF:xxx={rrd1}:MemZeroNon:AVERAGE \
 LINE2:xxx#0000ff:"MemZeroNon" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.NetUsageNon.name=NetUsageNon
 report.vmware3.NetUsageNon.columns=NetUsageNon
@@ -1218,7 +1218,7 @@ DEF:xxx={rrd1}:NetUsageNon:AVERAGE \
 LINE2:xxx#0000ff:"NetUsageNon" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.ResCpuActav15Lat.name=ResCpuActav15Lat
 report.vmware3.ResCpuActav15Lat.columns=ResCpuActav15Lat
@@ -1229,7 +1229,7 @@ DEF:xxx={rrd1}:ResCpuActav15Lat:AVERAGE \
 LINE2:xxx#0000ff:"ResCpuActav15Lat" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.ResCpuActav1Lat.name=ResCpuActav1Lat
 report.vmware3.ResCpuActav1Lat.columns=ResCpuActav1Lat
@@ -1240,7 +1240,7 @@ DEF:xxx={rrd1}:ResCpuActav1Lat:AVERAGE \
 LINE2:xxx#0000ff:"ResCpuActav1Lat" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.ResCpuActav5Lat.name=ResCpuActav5Lat
 report.vmware3.ResCpuActav5Lat.columns=ResCpuActav5Lat
@@ -1251,7 +1251,7 @@ DEF:xxx={rrd1}:ResCpuActav5Lat:AVERAGE \
 LINE2:xxx#0000ff:"ResCpuActav5Lat" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.ResCpuActpk15Lat.name=ResCpuActpk15Lat
 report.vmware3.ResCpuActpk15Lat.columns=ResCpuActpk15Lat
@@ -1262,7 +1262,7 @@ DEF:xxx={rrd1}:ResCpuActpk15Lat:AVERAGE \
 LINE2:xxx#0000ff:"ResCpuActpk15Lat" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.ResCpuActpk1Lat.name=ResCpuActpk1Lat
 report.vmware3.ResCpuActpk1Lat.columns=ResCpuActpk1Lat
@@ -1273,7 +1273,7 @@ DEF:xxx={rrd1}:ResCpuActpk1Lat:AVERAGE \
 LINE2:xxx#0000ff:"ResCpuActpk1Lat" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.ResCpuActpk5Lat.name=ResCpuActpk5Lat
 report.vmware3.ResCpuActpk5Lat.columns=ResCpuActpk5Lat
@@ -1284,7 +1284,7 @@ DEF:xxx={rrd1}:ResCpuActpk5Lat:AVERAGE \
 LINE2:xxx#0000ff:"ResCpuActpk5Lat" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.ResCpuMaxLd15Lat.name=ResCpuMaxLd15Lat
 report.vmware3.ResCpuMaxLd15Lat.columns=ResCpuMaxLd15Lat
@@ -1295,7 +1295,7 @@ DEF:xxx={rrd1}:ResCpuMaxLd15Lat:AVERAGE \
 LINE2:xxx#0000ff:"ResCpuMaxLd15Lat" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.ResCpuMaxLd1Lat.name=ResCpuMaxLd1Lat
 report.vmware3.ResCpuMaxLd1Lat.columns=ResCpuMaxLd1Lat
@@ -1306,7 +1306,7 @@ DEF:xxx={rrd1}:ResCpuMaxLd1Lat:AVERAGE \
 LINE2:xxx#0000ff:"ResCpuMaxLd1Lat" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.ResCpuMaxLd5Lat.name=ResCpuMaxLd5Lat
 report.vmware3.ResCpuMaxLd5Lat.columns=ResCpuMaxLd5Lat
@@ -1317,7 +1317,7 @@ DEF:xxx={rrd1}:ResCpuMaxLd5Lat:AVERAGE \
 LINE2:xxx#0000ff:"ResCpuMaxLd5Lat" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.ResCpuRunav15Lat.name=ResCpuRunav15Lat
 report.vmware3.ResCpuRunav15Lat.columns=ResCpuRunav15Lat
@@ -1328,7 +1328,7 @@ DEF:xxx={rrd1}:ResCpuRunav15Lat:AVERAGE \
 LINE2:xxx#0000ff:"ResCpuRunav15Lat" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.ResCpuRunav1Lat.name=ResCpuRunav1Lat
 report.vmware3.ResCpuRunav1Lat.columns=ResCpuRunav1Lat
@@ -1339,7 +1339,7 @@ DEF:xxx={rrd1}:ResCpuRunav1Lat:AVERAGE \
 LINE2:xxx#0000ff:"ResCpuRunav1Lat" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.ResCpuRunav5Lat.name=ResCpuRunav5Lat
 report.vmware3.ResCpuRunav5Lat.columns=ResCpuRunav5Lat
@@ -1350,7 +1350,7 @@ DEF:xxx={rrd1}:ResCpuRunav5Lat:AVERAGE \
 LINE2:xxx#0000ff:"ResCpuRunav5Lat" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.ResCpuRunpk15Lat.name=ResCpuRunpk15Lat
 report.vmware3.ResCpuRunpk15Lat.columns=ResCpuRunpk15Lat
@@ -1361,7 +1361,7 @@ DEF:xxx={rrd1}:ResCpuRunpk15Lat:AVERAGE \
 LINE2:xxx#0000ff:"ResCpuRunpk15Lat" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.ResCpuRunpk1Lat.name=ResCpuRunpk1Lat
 report.vmware3.ResCpuRunpk1Lat.columns=ResCpuRunpk1Lat
@@ -1372,7 +1372,7 @@ DEF:xxx={rrd1}:ResCpuRunpk1Lat:AVERAGE \
 LINE2:xxx#0000ff:"ResCpuRunpk1Lat" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.ResCpuRunpk5Lat.name=ResCpuRunpk5Lat
 report.vmware3.ResCpuRunpk5Lat.columns=ResCpuRunpk5Lat
@@ -1383,7 +1383,7 @@ DEF:xxx={rrd1}:ResCpuRunpk5Lat:AVERAGE \
 LINE2:xxx#0000ff:"ResCpuRunpk5Lat" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.ResCpuSeCtLat.name=ResCpuSeCtLat
 report.vmware3.ResCpuSeCtLat.columns=ResCpuSeCtLat
@@ -1394,7 +1394,7 @@ DEF:xxx={rrd1}:ResCpuSeCtLat:AVERAGE \
 LINE2:xxx#0000ff:"ResCpuSeCtLat" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.ResCpuSePeriodLat.name=ResCpuSePeriodLat
 report.vmware3.ResCpuSePeriodLat.columns=ResCpuSePeriodLat
@@ -1405,7 +1405,7 @@ DEF:xxx={rrd1}:ResCpuSePeriodLat:AVERAGE \
 LINE2:xxx#0000ff:"ResCpuSePeriodLat" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.SysHeartbeatSum.name=SysHeartbeatSum
 report.vmware3.SysHeartbeatSum.columns=SysHeartbeatSum
@@ -1416,7 +1416,7 @@ DEF:xxx={rrd1}:SysHeartbeatSum:AVERAGE \
 LINE2:xxx#0000ff:"SysHeartbeatSum" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.SysUptimeLat.name=SysUptimeLat
 report.vmware3.SysUptimeLat.columns=SysUptimeLat
@@ -1427,7 +1427,7 @@ DEF:xxx={rrd1}:SysUptimeLat:AVERAGE \
 LINE2:xxx#0000ff:"SysUptimeLat" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.NetPacketsRxSum.name=NetPacketsRxSum
 report.vmware3.NetPacketsRxSum.columns=NetPacketsRxSum
@@ -1439,7 +1439,7 @@ DEF:xxx={rrd1}:NetPacketsRxSum:AVERAGE \
 LINE2:xxx#0000ff:"NetPacketsRxSum" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.NetPacketsTxSum.name=NetPacketsTxSum
 report.vmware3.NetPacketsTxSum.columns=NetPacketsTxSum
@@ -1451,7 +1451,7 @@ DEF:xxx={rrd1}:NetPacketsTxSum:AVERAGE \
 LINE2:xxx#0000ff:"NetPacketsTxSum" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.NetReceivedAvg.name=NetReceivedAvg
 report.vmware3.NetReceivedAvg.columns=NetReceivedAvg
@@ -1463,7 +1463,7 @@ DEF:xxx={rrd1}:NetReceivedAvg:AVERAGE \
 LINE2:xxx#0000ff:"NetReceivedAvg" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.NetTransmittedAvg.name=NetTransmittedAvg
 report.vmware3.NetTransmittedAvg.columns=NetTransmittedAvg
@@ -1475,7 +1475,7 @@ DEF:xxx={rrd1}:NetTransmittedAvg:AVERAGE \
 LINE2:xxx#0000ff:"NetTransmittedAvg" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.DiskBusResetsSum.name=DiskBusResetsSum
 report.vmware3.DiskBusResetsSum.columns=DiskBusResetsSum
@@ -1487,7 +1487,7 @@ DEF:xxx={rrd1}:DiskBusResetsSum:AVERAGE \
 LINE2:xxx#0000ff:"DiskBusResetsSum" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.DiskCsAdSum.name=DiskCsAdSum
 report.vmware3.DiskCsAdSum.columns=DiskCsAdSum
@@ -1499,7 +1499,7 @@ DEF:xxx={rrd1}:DiskCsAdSum:AVERAGE \
 LINE2:xxx#0000ff:"DiskCsAdSum" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.DiskCsSum.name=DiskCsSum
 report.vmware3.DiskCsSum.columns=DiskCsSum
@@ -1511,7 +1511,7 @@ DEF:xxx={rrd1}:DiskCsSum:AVERAGE \
 LINE2:xxx#0000ff:"DiskCsSum" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.DiskNrRdSum.name=DiskNrRdSum
 report.vmware3.DiskNrRdSum.columns=DiskNrRdSum
@@ -1523,7 +1523,7 @@ DEF:xxx={rrd1}:DiskNrRdSum:AVERAGE \
 LINE2:xxx#0000ff:"DiskNrRdSum" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.DiskNrWeSum.name=DiskNrWeSum
 report.vmware3.DiskNrWeSum.columns=DiskNrWeSum
@@ -1535,7 +1535,7 @@ DEF:xxx={rrd1}:DiskNrWeSum:AVERAGE \
 LINE2:xxx#0000ff:"DiskNrWeSum" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.DiskRdAvg.name=DiskRdAvg
 report.vmware3.DiskRdAvg.columns=DiskRdAvg
@@ -1547,7 +1547,7 @@ DEF:xxx={rrd1}:DiskRdAvg:AVERAGE \
 LINE2:xxx#0000ff:"DiskRdAvg" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware3.DiskWeAvg.name=DiskWeAvg
 report.vmware3.DiskWeAvg.columns=DiskWeAvg
@@ -1559,5 +1559,5 @@ DEF:xxx={rrd1}:DiskWeAvg:AVERAGE \
 LINE2:xxx#0000ff:"DiskWeAvg" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 

--- a/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/vmware4-graph-simple.properties
+++ b/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/vmware4-graph-simple.properties
@@ -165,7 +165,7 @@ DEF:xxx={rrd1}:CpuIdleSum:AVERAGE \
 LINE2:xxx#0000ff:"CpuIdleSum" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.CpuUsageNon.name=CpuUsageNon
 report.vmware4.CpuUsageNon.columns=CpuUsageNon
@@ -177,7 +177,7 @@ DEF:xxx={rrd1}:CpuUsageNon:AVERAGE \
 LINE2:xxx#0000ff:"CpuUsageNon" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.CpuUsedSum.name=CpuUsedSum
 report.vmware4.CpuUsedSum.columns=CpuUsedSum
@@ -189,7 +189,7 @@ DEF:xxx={rrd1}:CpuUsedSum:AVERAGE \
 LINE2:xxx#0000ff:"CpuUsedSum" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.CpuRdCyAvg.name=CpuRdCyAvg
 report.vmware4.CpuRdCyAvg.columns=CpuRdCyAvg
@@ -200,7 +200,7 @@ DEF:xxx={rrd1}:CpuRdCyAvg:AVERAGE \
 LINE2:xxx#0000ff:"CpuRdCyAvg" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.CpuUsagemhzNon.name=CpuUsagemhzNon
 report.vmware4.CpuUsagemhzNon.columns=CpuUsagemhzNon
@@ -211,7 +211,7 @@ DEF:xxx={rrd1}:CpuUsagemhzNon:AVERAGE \
 LINE2:xxx#0000ff:"CpuUsagemhzNon" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.DiskMaxTlLyLat.name=DiskMaxTlLyLat
 report.vmware4.DiskMaxTlLyLat.columns=DiskMaxTlLyLat
@@ -222,7 +222,7 @@ DEF:xxx={rrd1}:DiskMaxTlLyLat:AVERAGE \
 LINE2:xxx#0000ff:"DiskMaxTlLyLat" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.DiskUsageNon.name=DiskUsageNon
 report.vmware4.DiskUsageNon.columns=DiskUsageNon
@@ -233,7 +233,7 @@ DEF:xxx={rrd1}:DiskUsageNon:AVERAGE \
 LINE2:xxx#0000ff:"DiskUsageNon" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.MemActiveNon.name=MemActiveNon
 report.vmware4.MemActiveNon.columns=MemActiveNon
@@ -244,7 +244,7 @@ DEF:xxx={rrd1}:MemActiveNon:AVERAGE \
 LINE2:xxx#0000ff:"MemActiveNon" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.MemConsumedNon.name=MemConsumedNon
 report.vmware4.MemConsumedNon.columns=MemConsumedNon
@@ -255,7 +255,7 @@ DEF:xxx={rrd1}:MemConsumedNon:AVERAGE \
 LINE2:xxx#0000ff:"MemConsumedNon" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.MemGrantedNon.name=MemGrantedNon
 report.vmware4.MemGrantedNon.columns=MemGrantedNon
@@ -266,7 +266,7 @@ DEF:xxx={rrd1}:MemGrantedNon:AVERAGE \
 LINE2:xxx#0000ff:"MemGrantedNon" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.MemHeapNon.name=MemHeapNon
 report.vmware4.MemHeapNon.columns=MemHeapNon
@@ -277,7 +277,7 @@ DEF:xxx={rrd1}:MemHeapNon:AVERAGE \
 LINE2:xxx#0000ff:"MemHeapNon" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.MemHeapfreeNon.name=MemHeapfreeNon
 report.vmware4.MemHeapfreeNon.columns=MemHeapfreeNon
@@ -288,7 +288,7 @@ DEF:xxx={rrd1}:MemHeapfreeNon:AVERAGE \
 LINE2:xxx#0000ff:"MemHeapfreeNon" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.MemOdNon.name=MemOdNon
 report.vmware4.MemOdNon.columns=MemOdNon
@@ -299,7 +299,7 @@ DEF:xxx={rrd1}:MemOdNon:AVERAGE \
 LINE2:xxx#0000ff:"MemOdNon" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.MemRdCyAvg.name=MemRdCyAvg
 report.vmware4.MemRdCyAvg.columns=MemRdCyAvg
@@ -310,7 +310,7 @@ DEF:xxx={rrd1}:MemRdCyAvg:AVERAGE \
 LINE2:xxx#0000ff:"MemRdCyAvg" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.MemSharedNon.name=MemSharedNon
 report.vmware4.MemSharedNon.columns=MemSharedNon
@@ -321,7 +321,7 @@ DEF:xxx={rrd1}:MemSharedNon:AVERAGE \
 LINE2:xxx#0000ff:"MemSharedNon" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.MemSharedcommonNon.name=MemSharedcommonNon
 report.vmware4.MemSharedcommonNon.columns=MemSharedcommonNon
@@ -332,7 +332,7 @@ DEF:xxx={rrd1}:MemSharedcommonNon:AVERAGE \
 LINE2:xxx#0000ff:"MemSharedcommonNon" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.MemSpinNon.name=MemSpinNon
 report.vmware4.MemSpinNon.columns=MemSpinNon
@@ -343,7 +343,7 @@ DEF:xxx={rrd1}:MemSpinNon:AVERAGE \
 LINE2:xxx#0000ff:"MemSpinNon" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.MemSpinReAvg.name=MemSpinReAvg
 report.vmware4.MemSpinReAvg.columns=MemSpinReAvg
@@ -354,7 +354,7 @@ DEF:xxx={rrd1}:MemSpinReAvg:AVERAGE \
 LINE2:xxx#0000ff:"MemSpinReAvg" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.MemSpoutNon.name=MemSpoutNon
 report.vmware4.MemSpoutNon.columns=MemSpoutNon
@@ -365,7 +365,7 @@ DEF:xxx={rrd1}:MemSpoutNon:AVERAGE \
 LINE2:xxx#0000ff:"MemSpoutNon" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.MemSpoutReAvg.name=MemSpoutReAvg
 report.vmware4.MemSpoutReAvg.columns=MemSpoutReAvg
@@ -376,7 +376,7 @@ DEF:xxx={rrd1}:MemSpoutReAvg:AVERAGE \
 LINE2:xxx#0000ff:"MemSpoutReAvg" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.MemSpusedNon.name=MemSpusedNon
 report.vmware4.MemSpusedNon.columns=MemSpusedNon
@@ -387,7 +387,7 @@ DEF:xxx={rrd1}:MemSpusedNon:AVERAGE \
 LINE2:xxx#0000ff:"MemSpusedNon" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.MemStateLat.name=MemStateLat
 report.vmware4.MemStateLat.columns=MemStateLat
@@ -398,7 +398,7 @@ DEF:xxx={rrd1}:MemStateLat:AVERAGE \
 LINE2:xxx#0000ff:"MemStateLat" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.MemSysUsageNon.name=MemSysUsageNon
 report.vmware4.MemSysUsageNon.columns=MemSysUsageNon
@@ -409,7 +409,7 @@ DEF:xxx={rrd1}:MemSysUsageNon:AVERAGE \
 LINE2:xxx#0000ff:"MemSysUsageNon" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.MemUdNon.name=MemUdNon
 report.vmware4.MemUdNon.columns=MemUdNon
@@ -420,7 +420,7 @@ DEF:xxx={rrd1}:MemUdNon:AVERAGE \
 LINE2:xxx#0000ff:"MemUdNon" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.MemUsageNon.name=MemUsageNon
 report.vmware4.MemUsageNon.columns=MemUsageNon
@@ -431,7 +431,7 @@ DEF:xxx={rrd1}:MemUsageNon:AVERAGE \
 LINE2:xxx#0000ff:"MemUsageNon" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.MemVmmemctlNon.name=MemVmmemctlNon
 report.vmware4.MemVmmemctlNon.columns=MemVmmemctlNon
@@ -442,7 +442,7 @@ DEF:xxx={rrd1}:MemVmmemctlNon:AVERAGE \
 LINE2:xxx#0000ff:"MemVmmemctlNon" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.MemZeroNon.name=MemZeroNon
 report.vmware4.MemZeroNon.columns=MemZeroNon
@@ -453,7 +453,7 @@ DEF:xxx={rrd1}:MemZeroNon:AVERAGE \
 LINE2:xxx#0000ff:"MemZeroNon" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.NetTransmittedAvg.name=NetTransmittedAvg
 report.vmware4.NetTransmittedAvg.columns=NetTransmittedAvg
@@ -464,7 +464,7 @@ DEF:xxx={rrd1}:NetTransmittedAvg:AVERAGE \
 LINE2:xxx#0000ff:"NetTransmittedAvg" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.NetUsageNon.name=NetUsageNon
 report.vmware4.NetUsageNon.columns=NetUsageNon
@@ -475,7 +475,7 @@ DEF:xxx={rrd1}:NetUsageNon:AVERAGE \
 LINE2:xxx#0000ff:"NetUsageNon" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.ResCpuActav15Lat.name=ResCpuActav15Lat
 report.vmware4.ResCpuActav15Lat.columns=ResCpuActav15Lat
@@ -486,7 +486,7 @@ DEF:xxx={rrd1}:ResCpuActav15Lat:AVERAGE \
 LINE2:xxx#0000ff:"ResCpuActav15Lat" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.ResCpuActav1Lat.name=ResCpuActav1Lat
 report.vmware4.ResCpuActav1Lat.columns=ResCpuActav1Lat
@@ -497,7 +497,7 @@ DEF:xxx={rrd1}:ResCpuActav1Lat:AVERAGE \
 LINE2:xxx#0000ff:"ResCpuActav1Lat" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.ResCpuActav5Lat.name=ResCpuActav5Lat
 report.vmware4.ResCpuActav5Lat.columns=ResCpuActav5Lat
@@ -508,7 +508,7 @@ DEF:xxx={rrd1}:ResCpuActav5Lat:AVERAGE \
 LINE2:xxx#0000ff:"ResCpuActav5Lat" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.ResCpuActpk15Lat.name=ResCpuActpk15Lat
 report.vmware4.ResCpuActpk15Lat.columns=ResCpuActpk15Lat
@@ -519,7 +519,7 @@ DEF:xxx={rrd1}:ResCpuActpk15Lat:AVERAGE \
 LINE2:xxx#0000ff:"ResCpuActpk15Lat" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.ResCpuActpk1Lat.name=ResCpuActpk1Lat
 report.vmware4.ResCpuActpk1Lat.columns=ResCpuActpk1Lat
@@ -530,7 +530,7 @@ DEF:xxx={rrd1}:ResCpuActpk1Lat:AVERAGE \
 LINE2:xxx#0000ff:"ResCpuActpk1Lat" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.ResCpuActpk5Lat.name=ResCpuActpk5Lat
 report.vmware4.ResCpuActpk5Lat.columns=ResCpuActpk5Lat
@@ -541,7 +541,7 @@ DEF:xxx={rrd1}:ResCpuActpk5Lat:AVERAGE \
 LINE2:xxx#0000ff:"ResCpuActpk5Lat" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.ResCpuMaxLd15Lat.name=ResCpuMaxLd15Lat
 report.vmware4.ResCpuMaxLd15Lat.columns=ResCpuMaxLd15Lat
@@ -552,7 +552,7 @@ DEF:xxx={rrd1}:ResCpuMaxLd15Lat:AVERAGE \
 LINE2:xxx#0000ff:"ResCpuMaxLd15Lat" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.ResCpuMaxLd1Lat.name=ResCpuMaxLd1Lat
 report.vmware4.ResCpuMaxLd1Lat.columns=ResCpuMaxLd1Lat
@@ -563,7 +563,7 @@ DEF:xxx={rrd1}:ResCpuMaxLd1Lat:AVERAGE \
 LINE2:xxx#0000ff:"ResCpuMaxLd1Lat" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.ResCpuMaxLd5Lat.name=ResCpuMaxLd5Lat
 report.vmware4.ResCpuMaxLd5Lat.columns=ResCpuMaxLd5Lat
@@ -574,7 +574,7 @@ DEF:xxx={rrd1}:ResCpuMaxLd5Lat:AVERAGE \
 LINE2:xxx#0000ff:"ResCpuMaxLd5Lat" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.ResCpuRunav15Lat.name=ResCpuRunav15Lat
 report.vmware4.ResCpuRunav15Lat.columns=ResCpuRunav15Lat
@@ -585,7 +585,7 @@ DEF:xxx={rrd1}:ResCpuRunav15Lat:AVERAGE \
 LINE2:xxx#0000ff:"ResCpuRunav15Lat" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.ResCpuRunav1Lat.name=ResCpuRunav1Lat
 report.vmware4.ResCpuRunav1Lat.columns=ResCpuRunav1Lat
@@ -596,7 +596,7 @@ DEF:xxx={rrd1}:ResCpuRunav1Lat:AVERAGE \
 LINE2:xxx#0000ff:"ResCpuRunav1Lat" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.ResCpuRunav5Lat.name=ResCpuRunav5Lat
 report.vmware4.ResCpuRunav5Lat.columns=ResCpuRunav5Lat
@@ -607,7 +607,7 @@ DEF:xxx={rrd1}:ResCpuRunav5Lat:AVERAGE \
 LINE2:xxx#0000ff:"ResCpuRunav5Lat" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.ResCpuRunpk15Lat.name=ResCpuRunpk15Lat
 report.vmware4.ResCpuRunpk15Lat.columns=ResCpuRunpk15Lat
@@ -618,7 +618,7 @@ DEF:xxx={rrd1}:ResCpuRunpk15Lat:AVERAGE \
 LINE2:xxx#0000ff:"ResCpuRunpk15Lat" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.ResCpuRunpk1Lat.name=ResCpuRunpk1Lat
 report.vmware4.ResCpuRunpk1Lat.columns=ResCpuRunpk1Lat
@@ -629,7 +629,7 @@ DEF:xxx={rrd1}:ResCpuRunpk1Lat:AVERAGE \
 LINE2:xxx#0000ff:"ResCpuRunpk1Lat" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.ResCpuRunpk5Lat.name=ResCpuRunpk5Lat
 report.vmware4.ResCpuRunpk5Lat.columns=ResCpuRunpk5Lat
@@ -640,7 +640,7 @@ DEF:xxx={rrd1}:ResCpuRunpk5Lat:AVERAGE \
 LINE2:xxx#0000ff:"ResCpuRunpk5Lat" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.ResCpuSeCtLat.name=ResCpuSeCtLat
 report.vmware4.ResCpuSeCtLat.columns=ResCpuSeCtLat
@@ -651,7 +651,7 @@ DEF:xxx={rrd1}:ResCpuSeCtLat:AVERAGE \
 LINE2:xxx#0000ff:"ResCpuSeCtLat" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.ResCpuSePeriodLat.name=ResCpuSePeriodLat
 report.vmware4.ResCpuSePeriodLat.columns=ResCpuSePeriodLat
@@ -662,7 +662,7 @@ DEF:xxx={rrd1}:ResCpuSePeriodLat:AVERAGE \
 LINE2:xxx#0000ff:"ResCpuSePeriodLat" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.SysUptimeLat.name=SysUptimeLat
 report.vmware4.SysUptimeLat.columns=SysUptimeLat
@@ -673,7 +673,7 @@ DEF:xxx={rrd1}:SysUptimeLat:AVERAGE \
 LINE2:xxx#0000ff:"SysUptimeLat" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.MgtAgtMemUsedAvg.name=MgtAgtMemUsedAvg
 report.vmware4.MgtAgtMemUsedAvg.columns=MgtAgtMemUsedAvg
@@ -685,7 +685,7 @@ DEF:xxx={rrd1}:MgtAgtMemUsedAvg:AVERAGE \
 LINE2:xxx#0000ff:"MgtAgtMemUsedAvg" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.MgtAgtSpInAvg.name=MgtAgtSpInAvg
 report.vmware4.MgtAgtSpInAvg.columns=MgtAgtSpInAvg
@@ -697,7 +697,7 @@ DEF:xxx={rrd1}:MgtAgtSpInAvg:AVERAGE \
 LINE2:xxx#0000ff:"MgtAgtSpInAvg" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.MgtAgtSpOutAvg.name=MgtAgtSpOutAvg
 report.vmware4.MgtAgtSpOutAvg.columns=MgtAgtSpOutAvg
@@ -709,7 +709,7 @@ DEF:xxx={rrd1}:MgtAgtSpOutAvg:AVERAGE \
 LINE2:xxx#0000ff:"MgtAgtSpOutAvg" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.MgtAgtSpUsedAvg.name=MgtAgtSpUsedAvg
 report.vmware4.MgtAgtSpUsedAvg.columns=MgtAgtSpUsedAvg
@@ -721,7 +721,7 @@ DEF:xxx={rrd1}:MgtAgtSpUsedAvg:AVERAGE \
 LINE2:xxx#0000ff:"MgtAgtSpUsedAvg" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.NetDroppedRxSum.name=NetDroppedRxSum
 report.vmware4.NetDroppedRxSum.columns=NetDroppedRxSum
@@ -733,7 +733,7 @@ DEF:xxx={rrd1}:NetDroppedRxSum:AVERAGE \
 LINE2:xxx#0000ff:"NetDroppedRxSum" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.NetDroppedTxSum.name=NetDroppedTxSum
 report.vmware4.NetDroppedTxSum.columns=NetDroppedTxSum
@@ -745,7 +745,7 @@ DEF:xxx={rrd1}:NetDroppedTxSum:AVERAGE \
 LINE2:xxx#0000ff:"NetDroppedTxSum" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.NetPacketsRxSum.name=NetPacketsRxSum
 report.vmware4.NetPacketsRxSum.columns=NetPacketsRxSum
@@ -757,7 +757,7 @@ DEF:xxx={rrd1}:NetPacketsRxSum:AVERAGE \
 LINE2:xxx#0000ff:"NetPacketsRxSum" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.NetPacketsTxSum.name=NetPacketsTxSum
 report.vmware4.NetPacketsTxSum.columns=NetPacketsTxSum
@@ -769,7 +769,7 @@ DEF:xxx={rrd1}:NetPacketsTxSum:AVERAGE \
 LINE2:xxx#0000ff:"NetPacketsTxSum" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.NetReceivedAvg.name=NetReceivedAvg
 report.vmware4.NetReceivedAvg.columns=NetReceivedAvg
@@ -781,7 +781,7 @@ DEF:xxx={rrd1}:NetReceivedAvg:AVERAGE \
 LINE2:xxx#0000ff:"NetReceivedAvg" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.NetTransmittedAvg.name=NetTransmittedAvg
 report.vmware4.NetTransmittedAvg.columns=NetTransmittedAvg
@@ -793,7 +793,7 @@ DEF:xxx={rrd1}:NetTransmittedAvg:AVERAGE \
 LINE2:xxx#0000ff:"NetTransmittedAvg" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.DiskBusResetsSum.name=DiskBusResetsSum
 report.vmware4.DiskBusResetsSum.columns=DiskBusResetsSum
@@ -805,7 +805,7 @@ DEF:xxx={rrd1}:DiskBusResetsSum:AVERAGE \
 LINE2:xxx#0000ff:"DiskBusResetsSum" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.DiskCsAdSum.name=DiskCsAdSum
 report.vmware4.DiskCsAdSum.columns=DiskCsAdSum
@@ -817,7 +817,7 @@ DEF:xxx={rrd1}:DiskCsAdSum:AVERAGE \
 LINE2:xxx#0000ff:"DiskCsAdSum" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.DiskCsSum.name=DiskCsSum
 report.vmware4.DiskCsSum.columns=DiskCsSum
@@ -829,7 +829,7 @@ DEF:xxx={rrd1}:DiskCsSum:AVERAGE \
 LINE2:xxx#0000ff:"DiskCsSum" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.DiskDeLyAvg.name=DiskDeLyAvg
 report.vmware4.DiskDeLyAvg.columns=DiskDeLyAvg
@@ -841,7 +841,7 @@ DEF:xxx={rrd1}:DiskDeLyAvg:AVERAGE \
 LINE2:xxx#0000ff:"DiskDeLyAvg" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.DiskDeRdLyAvg.name=DiskDeRdLyAvg
 report.vmware4.DiskDeRdLyAvg.columns=DiskDeRdLyAvg
@@ -853,7 +853,7 @@ DEF:xxx={rrd1}:DiskDeRdLyAvg:AVERAGE \
 LINE2:xxx#0000ff:"DiskDeRdLyAvg" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.DiskDeWeLyAvg.name=DiskDeWeLyAvg
 report.vmware4.DiskDeWeLyAvg.columns=DiskDeWeLyAvg
@@ -865,7 +865,7 @@ DEF:xxx={rrd1}:DiskDeWeLyAvg:AVERAGE \
 LINE2:xxx#0000ff:"DiskDeWeLyAvg" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.DiskKlLyAvg.name=DiskKlLyAvg
 report.vmware4.DiskKlLyAvg.columns=DiskKlLyAvg
@@ -877,7 +877,7 @@ DEF:xxx={rrd1}:DiskKlLyAvg:AVERAGE \
 LINE2:xxx#0000ff:"DiskKlLyAvg" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.DiskKlRdLyAvg.name=DiskKlRdLyAvg
 report.vmware4.DiskKlRdLyAvg.columns=DiskKlRdLyAvg
@@ -889,7 +889,7 @@ DEF:xxx={rrd1}:DiskKlRdLyAvg:AVERAGE \
 LINE2:xxx#0000ff:"DiskKlRdLyAvg" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.DiskKlWeLyAvg.name=DiskKlWeLyAvg
 report.vmware4.DiskKlWeLyAvg.columns=DiskKlWeLyAvg
@@ -901,7 +901,7 @@ DEF:xxx={rrd1}:DiskKlWeLyAvg:AVERAGE \
 LINE2:xxx#0000ff:"DiskKlWeLyAvg" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.DiskNrRdSum.name=DiskNrRdSum
 report.vmware4.DiskNrRdSum.columns=DiskNrRdSum
@@ -913,7 +913,7 @@ DEF:xxx={rrd1}:DiskNrRdSum:AVERAGE \
 LINE2:xxx#0000ff:"DiskNrRdSum" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.DiskNrWeSum.name=DiskNrWeSum
 report.vmware4.DiskNrWeSum.columns=DiskNrWeSum
@@ -925,7 +925,7 @@ DEF:xxx={rrd1}:DiskNrWeSum:AVERAGE \
 LINE2:xxx#0000ff:"DiskNrWeSum" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.DiskQeLyAvg.name=DiskQeLyAvg
 report.vmware4.DiskQeLyAvg.columns=DiskQeLyAvg
@@ -937,7 +937,7 @@ DEF:xxx={rrd1}:DiskQeLyAvg:AVERAGE \
 LINE2:xxx#0000ff:"DiskQeLyAvg" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.DiskQeRdLyAvg.name=DiskQeRdLyAvg
 report.vmware4.DiskQeRdLyAvg.columns=DiskQeRdLyAvg
@@ -949,7 +949,7 @@ DEF:xxx={rrd1}:DiskQeRdLyAvg:AVERAGE \
 LINE2:xxx#0000ff:"DiskQeRdLyAvg" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.DiskQeWeLyAvg.name=DiskQeWeLyAvg
 report.vmware4.DiskQeWeLyAvg.columns=DiskQeWeLyAvg
@@ -961,7 +961,7 @@ DEF:xxx={rrd1}:DiskQeWeLyAvg:AVERAGE \
 LINE2:xxx#0000ff:"DiskQeWeLyAvg" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.DiskRdAvg.name=DiskRdAvg
 report.vmware4.DiskRdAvg.columns=DiskRdAvg
@@ -973,7 +973,7 @@ DEF:xxx={rrd1}:DiskRdAvg:AVERAGE \
 LINE2:xxx#0000ff:"DiskRdAvg" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.DiskTlLyAvg.name=DiskTlLyAvg
 report.vmware4.DiskTlLyAvg.columns=DiskTlLyAvg
@@ -985,7 +985,7 @@ DEF:xxx={rrd1}:DiskTlLyAvg:AVERAGE \
 LINE2:xxx#0000ff:"DiskTlLyAvg" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.DiskTlRdLyAvg.name=DiskTlRdLyAvg
 report.vmware4.DiskTlRdLyAvg.columns=DiskTlRdLyAvg
@@ -997,7 +997,7 @@ DEF:xxx={rrd1}:DiskTlRdLyAvg:AVERAGE \
 LINE2:xxx#0000ff:"DiskTlRdLyAvg" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.DiskTlWeLyAvg.name=DiskTlWeLyAvg
 report.vmware4.DiskTlWeLyAvg.columns=DiskTlWeLyAvg
@@ -1009,7 +1009,7 @@ DEF:xxx={rrd1}:DiskTlWeLyAvg:AVERAGE \
 LINE2:xxx#0000ff:"DiskTlWeLyAvg" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.DiskWeAvg.name=DiskWeAvg
 report.vmware4.DiskWeAvg.columns=DiskWeAvg
@@ -1021,7 +1021,7 @@ DEF:xxx={rrd1}:DiskWeAvg:AVERAGE \
 LINE2:xxx#0000ff:"DiskWeAvg" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.SysDiskUsageLat.name=SysDiskUsageLat
 report.vmware4.SysDiskUsageLat.columns=SysDiskUsageLat
@@ -1033,7 +1033,7 @@ DEF:xxx={rrd1}:SysDiskUsageLat:AVERAGE \
 LINE2:xxx#0000ff:"SysDiskUsageLat" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.SysReCpuAcMaxLat.name=SysReCpuAcMaxLat
 report.vmware4.SysReCpuAcMaxLat.columns=SysReCpuAcMaxLat
@@ -1045,7 +1045,7 @@ DEF:xxx={rrd1}:SysReCpuAcMaxLat:AVERAGE \
 LINE2:xxx#0000ff:"SysReCpuAcMaxLat" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.SysReCpuAcMinLat.name=SysReCpuAcMinLat
 report.vmware4.SysReCpuAcMinLat.columns=SysReCpuAcMinLat
@@ -1057,7 +1057,7 @@ DEF:xxx={rrd1}:SysReCpuAcMinLat:AVERAGE \
 LINE2:xxx#0000ff:"SysReCpuAcMinLat" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.SysReCpuAcSsLat.name=SysReCpuAcSsLat
 report.vmware4.SysReCpuAcSsLat.columns=SysReCpuAcSsLat
@@ -1069,7 +1069,7 @@ DEF:xxx={rrd1}:SysReCpuAcSsLat:AVERAGE \
 LINE2:xxx#0000ff:"SysReCpuAcSsLat" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.SysReCpuAct1Lat.name=SysReCpuAct1Lat
 report.vmware4.SysReCpuAct1Lat.columns=SysReCpuAct1Lat
@@ -1081,7 +1081,7 @@ DEF:xxx={rrd1}:SysReCpuAct1Lat:AVERAGE \
 LINE2:xxx#0000ff:"SysReCpuAct1Lat" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.SysReCpuAct5Lat.name=SysReCpuAct5Lat
 report.vmware4.SysReCpuAct5Lat.columns=SysReCpuAct5Lat
@@ -1093,7 +1093,7 @@ DEF:xxx={rrd1}:SysReCpuAct5Lat:AVERAGE \
 LINE2:xxx#0000ff:"SysReCpuAct5Lat" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.SysReCpuMaxLd1Lat.name=SysReCpuMaxLd1Lat
 report.vmware4.SysReCpuMaxLd1Lat.columns=SysReCpuMaxLd1Lat
@@ -1105,7 +1105,7 @@ DEF:xxx={rrd1}:SysReCpuMaxLd1Lat:AVERAGE \
 LINE2:xxx#0000ff:"SysReCpuMaxLd1Lat" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.SysReCpuMaxLd5Lat.name=SysReCpuMaxLd5Lat
 report.vmware4.SysReCpuMaxLd5Lat.columns=SysReCpuMaxLd5Lat
@@ -1117,7 +1117,7 @@ DEF:xxx={rrd1}:SysReCpuMaxLd5Lat:AVERAGE \
 LINE2:xxx#0000ff:"SysReCpuMaxLd5Lat" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.SysReCpuRun1Lat.name=SysReCpuRun1Lat
 report.vmware4.SysReCpuRun1Lat.columns=SysReCpuRun1Lat
@@ -1129,7 +1129,7 @@ DEF:xxx={rrd1}:SysReCpuRun1Lat:AVERAGE \
 LINE2:xxx#0000ff:"SysReCpuRun1Lat" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.SysReCpuRun5Lat.name=SysReCpuRun5Lat
 report.vmware4.SysReCpuRun5Lat.columns=SysReCpuRun5Lat
@@ -1141,7 +1141,7 @@ DEF:xxx={rrd1}:SysReCpuRun5Lat:AVERAGE \
 LINE2:xxx#0000ff:"SysReCpuRun5Lat" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.SysReCpuUsageNon.name=SysReCpuUsageNon
 report.vmware4.SysReCpuUsageNon.columns=SysReCpuUsageNon
@@ -1153,7 +1153,7 @@ DEF:xxx={rrd1}:SysReCpuUsageNon:AVERAGE \
 LINE2:xxx#0000ff:"SysReCpuUsageNon" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.SysReMemAcMaxLat.name=SysReMemAcMaxLat
 report.vmware4.SysReMemAcMaxLat.columns=SysReMemAcMaxLat
@@ -1165,7 +1165,7 @@ DEF:xxx={rrd1}:SysReMemAcMaxLat:AVERAGE \
 LINE2:xxx#0000ff:"SysReMemAcMaxLat" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.SysReMemAcMinLat.name=SysReMemAcMinLat
 report.vmware4.SysReMemAcMinLat.columns=SysReMemAcMinLat
@@ -1177,7 +1177,7 @@ DEF:xxx={rrd1}:SysReMemAcMinLat:AVERAGE \
 LINE2:xxx#0000ff:"SysReMemAcMinLat" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.SysReMemAcSsLat.name=SysReMemAcSsLat
 report.vmware4.SysReMemAcSsLat.columns=SysReMemAcSsLat
@@ -1189,7 +1189,7 @@ DEF:xxx={rrd1}:SysReMemAcSsLat:AVERAGE \
 LINE2:xxx#0000ff:"SysReMemAcSsLat" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.SysReMemCowLat.name=SysReMemCowLat
 report.vmware4.SysReMemCowLat.columns=SysReMemCowLat
@@ -1201,7 +1201,7 @@ DEF:xxx={rrd1}:SysReMemCowLat:AVERAGE \
 LINE2:xxx#0000ff:"SysReMemCowLat" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.SysReMemMappedLat.name=SysReMemMappedLat
 report.vmware4.SysReMemMappedLat.columns=SysReMemMappedLat
@@ -1213,7 +1213,7 @@ DEF:xxx={rrd1}:SysReMemMappedLat:AVERAGE \
 LINE2:xxx#0000ff:"SysReMemMappedLat" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.SysReMemOdLat.name=SysReMemOdLat
 report.vmware4.SysReMemOdLat.columns=SysReMemOdLat
@@ -1225,7 +1225,7 @@ DEF:xxx={rrd1}:SysReMemOdLat:AVERAGE \
 LINE2:xxx#0000ff:"SysReMemOdLat" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.SysReMemSharedLat.name=SysReMemSharedLat
 report.vmware4.SysReMemSharedLat.columns=SysReMemSharedLat
@@ -1237,7 +1237,7 @@ DEF:xxx={rrd1}:SysReMemSharedLat:AVERAGE \
 LINE2:xxx#0000ff:"SysReMemSharedLat" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.SysReMemSppedLat.name=SysReMemSppedLat
 report.vmware4.SysReMemSppedLat.columns=SysReMemSppedLat
@@ -1249,7 +1249,7 @@ DEF:xxx={rrd1}:SysReMemSppedLat:AVERAGE \
 LINE2:xxx#0000ff:"SysReMemSppedLat" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.SysReMemTdLat.name=SysReMemTdLat
 report.vmware4.SysReMemTdLat.columns=SysReMemTdLat
@@ -1261,7 +1261,7 @@ DEF:xxx={rrd1}:SysReMemTdLat:AVERAGE \
 LINE2:xxx#0000ff:"SysReMemTdLat" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.SysReMemZeroLat.name=SysReMemZeroLat
 report.vmware4.SysReMemZeroLat.columns=SysReMemZeroLat
@@ -1273,7 +1273,7 @@ DEF:xxx={rrd1}:SysReMemZeroLat:AVERAGE \
 LINE2:xxx#0000ff:"SysReMemZeroLat" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.CpuRdySum.name=CpuRdySum
 report.vmware4.CpuRdySum.columns=CpuRdySum
@@ -1285,7 +1285,7 @@ DEF:xxx={rrd1}:CpuRdySum:AVERAGE \
 LINE2:xxx#0000ff:"CpuRdySum" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.CpuSpwaitSum.name=CpuSpwaitSum
 report.vmware4.CpuSpwaitSum.columns=CpuSpwaitSum
@@ -1297,7 +1297,7 @@ DEF:xxx={rrd1}:CpuSpwaitSum:AVERAGE \
 LINE2:xxx#0000ff:"CpuSpwaitSum" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.CpuSystemSum.name=CpuSystemSum
 report.vmware4.CpuSystemSum.columns=CpuSystemSum
@@ -1309,7 +1309,7 @@ DEF:xxx={rrd1}:CpuSystemSum:AVERAGE \
 LINE2:xxx#0000ff:"CpuSystemSum" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.CpuUsagemhzNon.name=CpuUsagemhzNon
 report.vmware4.CpuUsagemhzNon.columns=CpuUsagemhzNon
@@ -1321,7 +1321,7 @@ DEF:xxx={rrd1}:CpuUsagemhzNon:AVERAGE \
 LINE2:xxx#0000ff:"CpuUsagemhzNon" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.CpuUsedSum.name=CpuUsedSum
 report.vmware4.CpuUsedSum.columns=CpuUsedSum
@@ -1333,7 +1333,7 @@ DEF:xxx={rrd1}:CpuUsedSum:AVERAGE \
 LINE2:xxx#0000ff:"CpuUsedSum" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.CpuWaitSum.name=CpuWaitSum
 report.vmware4.CpuWaitSum.columns=CpuWaitSum
@@ -1345,7 +1345,7 @@ DEF:xxx={rrd1}:CpuWaitSum:AVERAGE \
 LINE2:xxx#0000ff:"CpuWaitSum" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.CpuRdySum.name=CpuRdySum
 report.vmware4.CpuRdySum.columns=CpuRdySum
@@ -1356,7 +1356,7 @@ DEF:xxx={rrd1}:CpuRdySum:AVERAGE \
 LINE2:xxx#0000ff:"CpuRdySum" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.CpuUsageNon.name=CpuUsageNon
 report.vmware4.CpuUsageNon.columns=CpuUsageNon
@@ -1367,7 +1367,7 @@ DEF:xxx={rrd1}:CpuUsageNon:AVERAGE \
 LINE2:xxx#0000ff:"CpuUsageNon" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.CpuUsagemhzNon.name=CpuUsagemhzNon
 report.vmware4.CpuUsagemhzNon.columns=CpuUsagemhzNon
@@ -1378,7 +1378,7 @@ DEF:xxx={rrd1}:CpuUsagemhzNon:AVERAGE \
 LINE2:xxx#0000ff:"CpuUsagemhzNon" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.DiskRdAvg.name=DiskRdAvg
 report.vmware4.DiskRdAvg.columns=DiskRdAvg
@@ -1389,7 +1389,7 @@ DEF:xxx={rrd1}:DiskRdAvg:AVERAGE \
 LINE2:xxx#0000ff:"DiskRdAvg" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.DiskUsageNon.name=DiskUsageNon
 report.vmware4.DiskUsageNon.columns=DiskUsageNon
@@ -1400,7 +1400,7 @@ DEF:xxx={rrd1}:DiskUsageNon:AVERAGE \
 LINE2:xxx#0000ff:"DiskUsageNon" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.MemActiveNon.name=MemActiveNon
 report.vmware4.MemActiveNon.columns=MemActiveNon
@@ -1411,7 +1411,7 @@ DEF:xxx={rrd1}:MemActiveNon:AVERAGE \
 LINE2:xxx#0000ff:"MemActiveNon" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.MemConsumedNon.name=MemConsumedNon
 report.vmware4.MemConsumedNon.columns=MemConsumedNon
@@ -1422,7 +1422,7 @@ DEF:xxx={rrd1}:MemConsumedNon:AVERAGE \
 LINE2:xxx#0000ff:"MemConsumedNon" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.MemGrantedNon.name=MemGrantedNon
 report.vmware4.MemGrantedNon.columns=MemGrantedNon
@@ -1433,7 +1433,7 @@ DEF:xxx={rrd1}:MemGrantedNon:AVERAGE \
 LINE2:xxx#0000ff:"MemGrantedNon" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.MemOdNon.name=MemOdNon
 report.vmware4.MemOdNon.columns=MemOdNon
@@ -1444,7 +1444,7 @@ DEF:xxx={rrd1}:MemOdNon:AVERAGE \
 LINE2:xxx#0000ff:"MemOdNon" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.MemSharedNon.name=MemSharedNon
 report.vmware4.MemSharedNon.columns=MemSharedNon
@@ -1455,7 +1455,7 @@ DEF:xxx={rrd1}:MemSharedNon:AVERAGE \
 LINE2:xxx#0000ff:"MemSharedNon" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.MemSpTtNon.name=MemSpTtNon
 report.vmware4.MemSpTtNon.columns=MemSpTtNon
@@ -1466,7 +1466,7 @@ DEF:xxx={rrd1}:MemSpTtNon:AVERAGE \
 LINE2:xxx#0000ff:"MemSpTtNon" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.MemSpinNon.name=MemSpinNon
 report.vmware4.MemSpinNon.columns=MemSpinNon
@@ -1477,7 +1477,7 @@ DEF:xxx={rrd1}:MemSpinNon:AVERAGE \
 LINE2:xxx#0000ff:"MemSpinNon" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.MemSpinReAvg.name=MemSpinReAvg
 report.vmware4.MemSpinReAvg.columns=MemSpinReAvg
@@ -1488,7 +1488,7 @@ DEF:xxx={rrd1}:MemSpinReAvg:AVERAGE \
 LINE2:xxx#0000ff:"MemSpinReAvg" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.MemSpoutNon.name=MemSpoutNon
 report.vmware4.MemSpoutNon.columns=MemSpoutNon
@@ -1499,7 +1499,7 @@ DEF:xxx={rrd1}:MemSpoutNon:AVERAGE \
 LINE2:xxx#0000ff:"MemSpoutNon" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.MemSpoutReAvg.name=MemSpoutReAvg
 report.vmware4.MemSpoutReAvg.columns=MemSpoutReAvg
@@ -1510,7 +1510,7 @@ DEF:xxx={rrd1}:MemSpoutReAvg:AVERAGE \
 LINE2:xxx#0000ff:"MemSpoutReAvg" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.MemSppedNon.name=MemSppedNon
 report.vmware4.MemSppedNon.columns=MemSppedNon
@@ -1521,7 +1521,7 @@ DEF:xxx={rrd1}:MemSppedNon:AVERAGE \
 LINE2:xxx#0000ff:"MemSppedNon" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.MemUsageNon.name=MemUsageNon
 report.vmware4.MemUsageNon.columns=MemUsageNon
@@ -1532,7 +1532,7 @@ DEF:xxx={rrd1}:MemUsageNon:AVERAGE \
 LINE2:xxx#0000ff:"MemUsageNon" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.MemVmmemctlNon.name=MemVmmemctlNon
 report.vmware4.MemVmmemctlNon.columns=MemVmmemctlNon
@@ -1543,7 +1543,7 @@ DEF:xxx={rrd1}:MemVmmemctlNon:AVERAGE \
 LINE2:xxx#0000ff:"MemVmmemctlNon" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.MemVmmemctlTtNon.name=MemVmmemctlTtNon
 report.vmware4.MemVmmemctlTtNon.columns=MemVmmemctlTtNon
@@ -1554,7 +1554,7 @@ DEF:xxx={rrd1}:MemVmmemctlTtNon:AVERAGE \
 LINE2:xxx#0000ff:"MemVmmemctlTtNon" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.MemZeroNon.name=MemZeroNon
 report.vmware4.MemZeroNon.columns=MemZeroNon
@@ -1565,7 +1565,7 @@ DEF:xxx={rrd1}:MemZeroNon:AVERAGE \
 LINE2:xxx#0000ff:"MemZeroNon" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.NetReceivedAvg.name=NetReceivedAvg
 report.vmware4.NetReceivedAvg.columns=NetReceivedAvg
@@ -1576,7 +1576,7 @@ DEF:xxx={rrd1}:NetReceivedAvg:AVERAGE \
 LINE2:xxx#0000ff:"NetReceivedAvg" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.NetUsageNon.name=NetUsageNon
 report.vmware4.NetUsageNon.columns=NetUsageNon
@@ -1587,7 +1587,7 @@ DEF:xxx={rrd1}:NetUsageNon:AVERAGE \
 LINE2:xxx#0000ff:"NetUsageNon" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.ResCpuActav15Lat.name=ResCpuActav15Lat
 report.vmware4.ResCpuActav15Lat.columns=ResCpuActav15Lat
@@ -1598,7 +1598,7 @@ DEF:xxx={rrd1}:ResCpuActav15Lat:AVERAGE \
 LINE2:xxx#0000ff:"ResCpuActav15Lat" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.ResCpuActav1Lat.name=ResCpuActav1Lat
 report.vmware4.ResCpuActav1Lat.columns=ResCpuActav1Lat
@@ -1609,7 +1609,7 @@ DEF:xxx={rrd1}:ResCpuActav1Lat:AVERAGE \
 LINE2:xxx#0000ff:"ResCpuActav1Lat" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.ResCpuActav5Lat.name=ResCpuActav5Lat
 report.vmware4.ResCpuActav5Lat.columns=ResCpuActav5Lat
@@ -1620,7 +1620,7 @@ DEF:xxx={rrd1}:ResCpuActav5Lat:AVERAGE \
 LINE2:xxx#0000ff:"ResCpuActav5Lat" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.ResCpuActpk15Lat.name=ResCpuActpk15Lat
 report.vmware4.ResCpuActpk15Lat.columns=ResCpuActpk15Lat
@@ -1631,7 +1631,7 @@ DEF:xxx={rrd1}:ResCpuActpk15Lat:AVERAGE \
 LINE2:xxx#0000ff:"ResCpuActpk15Lat" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.ResCpuActpk1Lat.name=ResCpuActpk1Lat
 report.vmware4.ResCpuActpk1Lat.columns=ResCpuActpk1Lat
@@ -1642,7 +1642,7 @@ DEF:xxx={rrd1}:ResCpuActpk1Lat:AVERAGE \
 LINE2:xxx#0000ff:"ResCpuActpk1Lat" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.ResCpuActpk5Lat.name=ResCpuActpk5Lat
 report.vmware4.ResCpuActpk5Lat.columns=ResCpuActpk5Lat
@@ -1653,7 +1653,7 @@ DEF:xxx={rrd1}:ResCpuActpk5Lat:AVERAGE \
 LINE2:xxx#0000ff:"ResCpuActpk5Lat" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.ResCpuMaxLd15Lat.name=ResCpuMaxLd15Lat
 report.vmware4.ResCpuMaxLd15Lat.columns=ResCpuMaxLd15Lat
@@ -1664,7 +1664,7 @@ DEF:xxx={rrd1}:ResCpuMaxLd15Lat:AVERAGE \
 LINE2:xxx#0000ff:"ResCpuMaxLd15Lat" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.ResCpuMaxLd1Lat.name=ResCpuMaxLd1Lat
 report.vmware4.ResCpuMaxLd1Lat.columns=ResCpuMaxLd1Lat
@@ -1675,7 +1675,7 @@ DEF:xxx={rrd1}:ResCpuMaxLd1Lat:AVERAGE \
 LINE2:xxx#0000ff:"ResCpuMaxLd1Lat" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.ResCpuMaxLd5Lat.name=ResCpuMaxLd5Lat
 report.vmware4.ResCpuMaxLd5Lat.columns=ResCpuMaxLd5Lat
@@ -1686,7 +1686,7 @@ DEF:xxx={rrd1}:ResCpuMaxLd5Lat:AVERAGE \
 LINE2:xxx#0000ff:"ResCpuMaxLd5Lat" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.ResCpuRunav15Lat.name=ResCpuRunav15Lat
 report.vmware4.ResCpuRunav15Lat.columns=ResCpuRunav15Lat
@@ -1697,7 +1697,7 @@ DEF:xxx={rrd1}:ResCpuRunav15Lat:AVERAGE \
 LINE2:xxx#0000ff:"ResCpuRunav15Lat" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.ResCpuRunav1Lat.name=ResCpuRunav1Lat
 report.vmware4.ResCpuRunav1Lat.columns=ResCpuRunav1Lat
@@ -1708,7 +1708,7 @@ DEF:xxx={rrd1}:ResCpuRunav1Lat:AVERAGE \
 LINE2:xxx#0000ff:"ResCpuRunav1Lat" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.ResCpuRunav5Lat.name=ResCpuRunav5Lat
 report.vmware4.ResCpuRunav5Lat.columns=ResCpuRunav5Lat
@@ -1719,7 +1719,7 @@ DEF:xxx={rrd1}:ResCpuRunav5Lat:AVERAGE \
 LINE2:xxx#0000ff:"ResCpuRunav5Lat" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.ResCpuRunpk15Lat.name=ResCpuRunpk15Lat
 report.vmware4.ResCpuRunpk15Lat.columns=ResCpuRunpk15Lat
@@ -1730,7 +1730,7 @@ DEF:xxx={rrd1}:ResCpuRunpk15Lat:AVERAGE \
 LINE2:xxx#0000ff:"ResCpuRunpk15Lat" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.ResCpuRunpk1Lat.name=ResCpuRunpk1Lat
 report.vmware4.ResCpuRunpk1Lat.columns=ResCpuRunpk1Lat
@@ -1741,7 +1741,7 @@ DEF:xxx={rrd1}:ResCpuRunpk1Lat:AVERAGE \
 LINE2:xxx#0000ff:"ResCpuRunpk1Lat" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.ResCpuRunpk5Lat.name=ResCpuRunpk5Lat
 report.vmware4.ResCpuRunpk5Lat.columns=ResCpuRunpk5Lat
@@ -1752,7 +1752,7 @@ DEF:xxx={rrd1}:ResCpuRunpk5Lat:AVERAGE \
 LINE2:xxx#0000ff:"ResCpuRunpk5Lat" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.ResCpuSeCtLat.name=ResCpuSeCtLat
 report.vmware4.ResCpuSeCtLat.columns=ResCpuSeCtLat
@@ -1763,7 +1763,7 @@ DEF:xxx={rrd1}:ResCpuSeCtLat:AVERAGE \
 LINE2:xxx#0000ff:"ResCpuSeCtLat" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.ResCpuSePeriodLat.name=ResCpuSePeriodLat
 report.vmware4.ResCpuSePeriodLat.columns=ResCpuSePeriodLat
@@ -1774,7 +1774,7 @@ DEF:xxx={rrd1}:ResCpuSePeriodLat:AVERAGE \
 LINE2:xxx#0000ff:"ResCpuSePeriodLat" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.SysHeartbeatSum.name=SysHeartbeatSum
 report.vmware4.SysHeartbeatSum.columns=SysHeartbeatSum
@@ -1785,7 +1785,7 @@ DEF:xxx={rrd1}:SysHeartbeatSum:AVERAGE \
 LINE2:xxx#0000ff:"SysHeartbeatSum" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.SysUptimeLat.name=SysUptimeLat
 report.vmware4.SysUptimeLat.columns=SysUptimeLat
@@ -1796,7 +1796,7 @@ DEF:xxx={rrd1}:SysUptimeLat:AVERAGE \
 LINE2:xxx#0000ff:"SysUptimeLat" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.NetPacketsRxSum.name=NetPacketsRxSum
 report.vmware4.NetPacketsRxSum.columns=NetPacketsRxSum
@@ -1808,7 +1808,7 @@ DEF:xxx={rrd1}:NetPacketsRxSum:AVERAGE \
 LINE2:xxx#0000ff:"NetPacketsRxSum" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.NetPacketsTxSum.name=NetPacketsTxSum
 report.vmware4.NetPacketsTxSum.columns=NetPacketsTxSum
@@ -1820,7 +1820,7 @@ DEF:xxx={rrd1}:NetPacketsTxSum:AVERAGE \
 LINE2:xxx#0000ff:"NetPacketsTxSum" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.NetReceivedAvg.name=NetReceivedAvg
 report.vmware4.NetReceivedAvg.columns=NetReceivedAvg
@@ -1832,7 +1832,7 @@ DEF:xxx={rrd1}:NetReceivedAvg:AVERAGE \
 LINE2:xxx#0000ff:"NetReceivedAvg" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.NetTransmittedAvg.name=NetTransmittedAvg
 report.vmware4.NetTransmittedAvg.columns=NetTransmittedAvg
@@ -1844,7 +1844,7 @@ DEF:xxx={rrd1}:NetTransmittedAvg:AVERAGE \
 LINE2:xxx#0000ff:"NetTransmittedAvg" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.DiskBusResetsSum.name=DiskBusResetsSum
 report.vmware4.DiskBusResetsSum.columns=DiskBusResetsSum
@@ -1856,7 +1856,7 @@ DEF:xxx={rrd1}:DiskBusResetsSum:AVERAGE \
 LINE2:xxx#0000ff:"DiskBusResetsSum" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.DiskCsAdSum.name=DiskCsAdSum
 report.vmware4.DiskCsAdSum.columns=DiskCsAdSum
@@ -1868,7 +1868,7 @@ DEF:xxx={rrd1}:DiskCsAdSum:AVERAGE \
 LINE2:xxx#0000ff:"DiskCsAdSum" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.DiskCsSum.name=DiskCsSum
 report.vmware4.DiskCsSum.columns=DiskCsSum
@@ -1880,7 +1880,7 @@ DEF:xxx={rrd1}:DiskCsSum:AVERAGE \
 LINE2:xxx#0000ff:"DiskCsSum" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.DiskNrRdSum.name=DiskNrRdSum
 report.vmware4.DiskNrRdSum.columns=DiskNrRdSum
@@ -1892,7 +1892,7 @@ DEF:xxx={rrd1}:DiskNrRdSum:AVERAGE \
 LINE2:xxx#0000ff:"DiskNrRdSum" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.DiskNrWeSum.name=DiskNrWeSum
 report.vmware4.DiskNrWeSum.columns=DiskNrWeSum
@@ -1904,7 +1904,7 @@ DEF:xxx={rrd1}:DiskNrWeSum:AVERAGE \
 LINE2:xxx#0000ff:"DiskNrWeSum" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.DiskRdAvg.name=DiskRdAvg
 report.vmware4.DiskRdAvg.columns=DiskRdAvg
@@ -1916,7 +1916,7 @@ DEF:xxx={rrd1}:DiskRdAvg:AVERAGE \
 LINE2:xxx#0000ff:"DiskRdAvg" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware4.DiskWeAvg.name=DiskWeAvg
 report.vmware4.DiskWeAvg.columns=DiskWeAvg
@@ -1928,5 +1928,5 @@ DEF:xxx={rrd1}:DiskWeAvg:AVERAGE \
 LINE2:xxx#0000ff:"DiskWeAvg" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
-GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n" \
+GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 

--- a/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/xmp-graph.properties
+++ b/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/xmp-graph.properties
@@ -116,7 +116,7 @@ report.xmp.diskstats.command=--title="Disk Reads/Writes" \
  LINE2:w#00ff00:"Disk Writes" \
  GPRINT:w:AVERAGE:"Avg \\: %10.2lf %s" \
  GPRINT:w:MIN:"Min \\: %10.2lf %s" \
- GPRINT:w:MAX:"Max \\: %10.2lf %s\\n" 
+ GPRINT:w:MAX:"Max \\: %10.2lf %s\\n"
 
 report.xmp.diskkb.name=Disk KB I/O 
 report.xmp.diskkb.columns=diskReadKB, diskWriteKB
@@ -131,7 +131,7 @@ report.xmp.diskkb.command=--title="Disk KB I/O" \
  LINE2:w#00ff00:"Disk Write (KB)" \
  GPRINT:w:AVERAGE:"Avg \\: %10.2lf %s" \
  GPRINT:w:MIN:"Min \\: %10.2lf %s" \
- GPRINT:w:MAX:"Max \\: %10.2lf %s\\n" 
+ GPRINT:w:MAX:"Max \\: %10.2lf %s\\n"
 
 report.xmp.xmpdsz.name=Process Sizes
 report.xmp.xmpdsz.suppress=xmp.xmpdrss

--- a/opennms-dao/src/test/java/org/opennms/netmgt/dao/support/PropertiesGraphDaoIT.java
+++ b/opennms-dao/src/test/java/org/opennms/netmgt/dao/support/PropertiesGraphDaoIT.java
@@ -175,6 +175,11 @@ public class PropertiesGraphDaoIT extends PropertiesGraphDaoITCase {
     public void testLoadSnmpGraphProperties() throws Exception {
         PropertiesGraphDao dao = createPropertiesGraphDao(s_emptyMap, s_emptyMap);
         dao.loadProperties("foo", new FileSystemResource(ConfigurationTestUtils.getFileForConfigFile("snmp-graph.properties")));
+        for (PrefabGraph graph : dao.getAllPrefabGraphs()) {
+            if (!graph.getCommand().trim().equals(graph.getCommand())) {
+                fail("Prefab graph contains extra whitespace: " + graph.getCommand());
+            }
+        }
     }
 
     @Test

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/config/JmxDataCollectionConfigResourceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/config/JmxDataCollectionConfigResourceIT.java
@@ -91,7 +91,7 @@ public class JmxDataCollectionConfigResourceIT extends AbstractSpringJerseyRestT
 
         assertEquals("jmx-minion", config.getJmxCollection("jmx-minion").getName());
         assertEquals(300, config.getJmxCollection("jmx-minion").getRrd().getStep());
-        assertEquals(11, config.getJmxCollection("jmx-minion").getMbeanCount());
+        assertEquals(12, config.getJmxCollection("jmx-minion").getMbeanCount());
 
         assertEquals("jmx-cassandra30x", config.getJmxCollection("jmx-cassandra30x").getName());
         assertEquals(300, config.getJmxCollection("jmx-cassandra30x").getRrd().getStep());


### PR DESCRIPTION
This PR contains work to wrap up the Minion data collections. It includes processing time metrics for syslog and trap metrics and will also contain route metrics for the RPC services when it is complete.

* JIRA: http://issues.opennms.org/browse/HZN-776
* Bamboo: http://bamboo.internal.opennms.com:8085/browse/OPENNMS-DEL56