### PR TITLE
NMS-8718: vmwarecimquery and vmwareconfigbuilder tools is not working

### DIFF
--- a/opennms-base-assembly/src/main/filtered/bin/vmwarecimquery
+++ b/opennms-base-assembly/src/main/filtered/bin/vmwarecimquery
@@ -3,12 +3,12 @@
 OPENNMS_HOME="${install.dir}"
 OPENNMS_BINDIR="${install.bin.dir}"
 
-VIJAVA_JAR=`ls -1 "$OPENNMS_HOME"/lib/vijava-*.jar | head -n 1`
+YAVIJAVA_JAR=`ls -1 "$OPENNMS_HOME"/lib/yavijava-*.jar | head -n 1`
 VMWARE_JAR=`ls -1 "$OPENNMS_HOME"/lib/opennms-vmware-*.jar | head -n 1`
 DOM4J_JAR=`ls -1 "$OPENNMS_HOME"/lib/dom4j-*.jar | head -n 1`
 COMMONS_CLI_JAR=`ls -1 "$OPENNMS_HOME"/lib/commons-cli-*.jar | head -n 1`
 SLF4J_API_JAR=`ls -1 "$OPENNMS_HOME"/lib/slf4j-api*.jar | head -n 1`
-SLF4J_L4J_JAR=`ls -1 "$OPENNMS_HOME"/lib/slf4j-log4j*.jar | head -n 1`
+SLF4J_L4J_JAR=`ls -1 "$OPENNMS_HOME"/lib/log4j-over-slf4j-*.jar | head -n 1`
 LOG4J_JAR=`ls -1 "$OPENNMS_HOME"/lib/log4j-*.jar | head -n 1`
 CIM_JAR=`ls -1 "$OPENNMS_HOME"/lib/sblimCIMClient-*.jar | head -n 1`
 SLP_JAR=`ls -1 "$OPENNMS_HOME"/lib/sblimSLPClient-*.jar | head -n 1`
@@ -17,6 +17,6 @@ exec "$OPENNMS_BINDIR"/runjava -r -- \
 	-Xmx256m \
 	-Dopennms.home="$OPENNMS_HOME" \
 	-Dlog4j.configurationFile="$OPENNMS_HOME"/etc/log4j2-tools.xml \
-	-cp "$VIJAVA_JAR:$VMWARE_JAR:$JCIFS_JAR:$DOM4J_JAR:$CIM_JAR:$SLP_JAR:$SLF4J_API_JAR:$SLF4J_L4J_JAR:$LOG4J_JAR:$COMMONS_CLI_JAR" \
+	-cp "$YAVIJAVA_JAR:$VMWARE_JAR:$JCIFS_JAR:$DOM4J_JAR:$CIM_JAR:$SLP_JAR:$SLF4J_API_JAR:$SLF4J_L4J_JAR:$LOG4J_JAR:$COMMONS_CLI_JAR" \
 	org.opennms.protocols.vmware.VmwareCimQuery \
 	"$@"

--- a/opennms-base-assembly/src/main/filtered/bin/vmwareconfigbuilder
+++ b/opennms-base-assembly/src/main/filtered/bin/vmwareconfigbuilder
@@ -4,8 +4,10 @@ OPENNMS_HOME="${install.dir}"
 OPENNMS_BINDIR="${install.bin.dir}"
 OPENNMS_SHAREDIR="${install.share.dir}"
 
-VIJAVA_JAR=`ls -1 "$OPENNMS_HOME"/lib/vijava-*.jar | head -n 1`
+YAVIJAVA_JAR=`ls -1 "$OPENNMS_HOME"/lib/yavijava-*.jar | head -n 1`
 VMWARE_JAR=`ls -1 "$OPENNMS_HOME"/lib/opennms-vmware-*.jar | head -n 1`
+SLF4J_API_JAR=`ls -1 "$OPENNMS_HOME"/lib/slf4j-api*.jar | head -n 1`
+SLF4J_L4J_JAR=`ls -1 "$OPENNMS_HOME"/lib/log4j-over-slf4j-*.jar | head -n 1`
 DOM4J_JAR=`ls -1 "$OPENNMS_HOME"/lib/dom4j-*.jar | head -n 1`
 COMMONS_CLI_JAR=`ls -1 "$OPENNMS_HOME"/lib/commons-cli-*.jar | head -n 1`
 
@@ -13,7 +15,7 @@ exec "$OPENNMS_BINDIR"/runjava -r -- \
 	-Xmx256m \
 	-Dopennms.home="$OPENNMS_HOME" \
 	-Dlog4j.configurationFile="$OPENNMS_HOME"/etc/log4j2-tools.xml \
-	-cp "$VIJAVA_JAR:$VMWARE_JAR:$JCIFS_JAR:$DOM4J_JAR:$COMMONS_CLI_JAR" \
+	-cp "$YAVIJAVA_JAR:$VMWARE_JAR:$JCIFS_JAR:$SLF4J_API_JAR:$SLF4J_L4J_JAR:$DOM4J_JAR:$COMMONS_CLI_JAR" \
 	org.opennms.protocols.vmware.VmwareConfigBuilder \
 	-rrdRepository "$OPENNMS_SHAREDIR"/rrd/snmp \
 	"$@"


### PR DESCRIPTION
* JIRA: http://issues.opennms.org/browse/NMS-8718

Changed include from vijava against yavijava library and included libraries in class path for SLF4J logging.