### PR TITLE
NMS-8690: The ReST end point /foreignSourcesConfig/assets contains invalid fields

### DIFF
--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/ForeignSourceConfigRestServiceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/ForeignSourceConfigRestServiceIT.java
@@ -105,6 +105,10 @@ public class ForeignSourceConfigRestServiceIT extends AbstractSpringJerseyRestTe
         Assert.assertNotNull(list);
         Assert.assertFalse(list.isEmpty());
         Assert.assertTrue(list.getElements().contains("address1"));
+        Assert.assertFalse(list.getElements().contains("id"));
+        Assert.assertFalse(list.getElements().contains("class"));
+        Assert.assertFalse(list.getElements().contains("node"));
+        Assert.assertFalse(list.getElements().contains("geolocation"));
     }
 
     /**


### PR DESCRIPTION
The ReST end point /foreignSourcesConfig/assets contains invalid fields

* JIRA: http://issues.opennms.org/browse/NMS-8690
* Bamboo: http://bamboo.internal.opennms.com:8085/browse/OPENNMS-ONMS962