### PR TITLE
NMS-8724: Add aliases so outage REST service can filter on event properties

### DIFF
--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/OutageRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/OutageRestService.java
@@ -130,6 +130,8 @@ public class OutageRestService extends OnmsRestService {
         builder.alias("ipInterface.node", "node", JoinType.LEFT_JOIN);
         builder.alias("ipInterface.snmpInterface", "snmpInterface", JoinType.LEFT_JOIN);
         builder.alias("monitoredService.serviceType", "serviceType", JoinType.LEFT_JOIN);
+        builder.alias("serviceLostEvent", "serviceLostEvent", JoinType.LEFT_JOIN);
+        builder.alias("serviceRegainedEvent", "serviceRegainedEvent", JoinType.LEFT_JOIN);
 
         applyQueryFilters(uriInfo.getQueryParameters(), builder);
 

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/OutageRestServiceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/OutageRestServiceIT.java
@@ -208,6 +208,25 @@ public class OutageRestServiceIT extends AbstractSpringJerseyRestTestCase {
         LOG.debug(json);
         restObject = new JSONObject(json);
         assertEquals(3, restObject.getJSONArray("outage").length());
+
+        // Check serviceRegainedEvent filters
+        jsonRequest = createRequest(m_context, GET, "/outages");
+        jsonRequest.addHeader("Accept", MediaType.APPLICATION_JSON);
+        jsonRequest.setQueryString("comparator=lt&serviceRegainedEvent.eventSeverity=2"); // OnmsSeverity.CLEARED
+        json = sendRequest(jsonRequest, 200);
+        LOG.debug(json);
+        // There is one test outage that has been resolved
+        restObject = new JSONObject(json);
+        assertEquals(1, restObject.getJSONArray("outage").length());
+
+        jsonRequest = createRequest(m_context, GET, "/outages");
+        jsonRequest.addHeader("Accept", MediaType.APPLICATION_JSON);
+        jsonRequest.setQueryString("comparator=like&serviceRegainedEvent.eventLogMsg=Test%25");
+        json = sendRequest(jsonRequest, 200);
+        LOG.debug(json);
+        // There is one test outage that has been resolved
+        restObject = new JSONObject(json);
+        assertEquals(1, restObject.getJSONArray("outage").length());
     }
 
     @Test

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/OutageRestServiceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/OutageRestServiceIT.java
@@ -28,6 +28,8 @@
 
 package org.opennms.web.rest.v1;
 
+import static org.junit.Assert.assertEquals;
+
 import java.io.FileInputStream;
 import java.util.Date;
 
@@ -52,8 +54,11 @@ import org.opennms.netmgt.model.OnmsDistPoller;
 import org.opennms.netmgt.model.OnmsEvent;
 import org.opennms.netmgt.model.OnmsMonitoredService;
 import org.opennms.netmgt.model.OnmsOutage;
+import org.opennms.netmgt.model.OnmsSeverity;
 import org.opennms.test.JUnitConfigurationEnvironment;
 import org.skyscreamer.jsonassert.JSONAssert;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.test.context.ContextConfiguration;
@@ -77,6 +82,8 @@ import org.springframework.test.context.web.WebAppConfiguration;
 @JUnitConfigurationEnvironment
 @JUnitTemporaryDatabase
 public class OutageRestServiceIT extends AbstractSpringJerseyRestTestCase {
+
+    private static final Logger LOG = LoggerFactory.getLogger(OutageRestServiceIT.class);
 
     @Autowired
     private ApplicationDao applicationDao;
@@ -111,6 +118,7 @@ public class OutageRestServiceIT extends AbstractSpringJerseyRestTestCase {
             public void onPopulate(DatabasePopulator populator, ApplicationDao dao) {
                 OnmsDistPoller distPoller = populator.getDistPollerDao().whoami();
                 outageEvent = populator.buildEvent(distPoller);
+                outageEvent.setEventSeverity(OnmsSeverity.MINOR.getId());
                 outageEvent.setEventCreateTime(new Date(1436881548292L));
                 outageEvent.setEventTime(new Date(1436881548292L));
                 populator.getEventDao().save(outageEvent);
@@ -158,13 +166,48 @@ public class OutageRestServiceIT extends AbstractSpringJerseyRestTestCase {
     @JUnitTemporaryDatabase
     public void testGetAllOutages() throws Exception {
         String xml = sendRequest(GET, "/outages", 200);
+        Assert.assertNotNull(xml);
 
         MockHttpServletRequest jsonRequest = createRequest(m_context, GET, "/outages");
         jsonRequest.addHeader("Accept", MediaType.APPLICATION_JSON);
         String json = sendRequest(jsonRequest, 200);
-
-        Assert.assertNotNull(xml);
         Assert.assertNotNull(json);
+    }
+
+    @Test
+    @JUnitTemporaryDatabase
+    public void testOutageSearches() throws Exception {
+        MockHttpServletRequest jsonRequest = createRequest(m_context, GET, "/outages");
+        jsonRequest.addHeader("Accept", MediaType.APPLICATION_JSON);
+        jsonRequest.setQueryString("ipInterface.ipAddress=192.168.1.2");
+        String json = sendRequest(jsonRequest, 200);
+        LOG.debug(json);
+        JSONObject restObject = new JSONObject(json);
+        assertEquals(1, restObject.getJSONArray("outage").length());
+
+        jsonRequest = createRequest(m_context, GET, "/outages");
+        jsonRequest.addHeader("Accept", MediaType.APPLICATION_JSON);
+        jsonRequest.setQueryString("comparator=ge&serviceLostEvent.eventSeverity=5"); // OnmsSeverity.MINOR
+        json = sendRequest(jsonRequest, 200);
+        LOG.debug(json);
+        restObject = new JSONObject(json);
+        assertEquals(1, restObject.getJSONArray("outage").length());
+
+        jsonRequest = createRequest(m_context, GET, "/outages");
+        jsonRequest.addHeader("Accept", MediaType.APPLICATION_JSON);
+        jsonRequest.setQueryString("comparator=lt&serviceLostEvent.eventSeverity=2"); // OnmsSeverity.CLEARED
+        json = sendRequest(jsonRequest, 200);
+        LOG.debug(json);
+        restObject = new JSONObject(json);
+        assertEquals(2, restObject.getJSONArray("outage").length());
+
+        jsonRequest = createRequest(m_context, GET, "/outages");
+        jsonRequest.addHeader("Accept", MediaType.APPLICATION_JSON);
+        jsonRequest.setQueryString("comparator=like&serviceLostEvent.eventLogMsg=Test%25");
+        json = sendRequest(jsonRequest, 200);
+        LOG.debug(json);
+        restObject = new JSONObject(json);
+        assertEquals(3, restObject.getJSONArray("outage").length());
     }
 
     @Test


### PR DESCRIPTION
Pretty self-explanatory. :)

* JIRA: http://issues.opennms.org/browse/NMS-8724
* Bamboo: http://bamboo.internal.opennms.com:8085/browse/OPENNMS-ONMS973