### PR TITLE
HZN-878: Updated database-schema.xml to make location filterable

### DIFF
--- a/opennms-base-assembly/src/main/filtered/etc/database-schema.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/database-schema.xml
@@ -1,20 +1,10 @@
 <?xml version="1.0"?>
 <database-schema>
 
-	<table name="distPoller" visible="false">
-		<column name="dpNumber"/>
-		<column name="dpName"/>
-		<column name="dpIP"/>
-		<column name="dpComment"/>
-		<column name="dpDiscLimit"/>
-		<column name="dpAdminState"/>
-		<column name="dpRunState"/>
-	</table>
-
 	<table name="node">
 		<join column="nodeID" table="ipInterface" table-column="nodeID"/>
 		<column name="nodeID"/>
-		<column name="dpName" visible="false"/>
+		<column name="location"/>
 		<column name="nodeCreateTime"/>
 		<column name="nodeParentID"/>
 		<column name="nodeType"/>
@@ -24,6 +14,10 @@
 		<column name="nodeSysLocation"/>
 		<column name="nodeSysContact"/>
 		<column name="nodeLabel"/>
+		<column name="nodeLabelSource"/>
+		<column name="nodeNetbiosName"/>
+		<column name="nodeDomainName"/>
+		<column name="operatingSystem"/>
 		<column name="foreignSource"/>
 		<column name="foreignID"/>
 	</table>
@@ -57,7 +51,6 @@
 		<join column="id" table="ipInterface" table-column="snmpinterfaceid"/>
 		<column name="id" visible="false"/>
 		<column name="nodeID" visible="false"/>
-		<column name="ipAddr" visible="false"/>
 		<column name="snmpIpAdEntNetMask"/>
 		<column name="snmpPhysAddr"/>
 		<column name="snmpIfIndex"/>
@@ -67,7 +60,8 @@
 		<column name="snmpIfAlias"/>
 		<column name="snmpIfAdminStatus"/>
 		<column name="snmpIfOperStatus"/>
-		<column name="snmpcollect"/>
+		<column name="snmpCollect"/>
+		<column name="snmpPoll"/>
 	</table>
 
 	<table name="service">


### PR DESCRIPTION
The database-schema.xml file that is used by JdbcFilterDao had not been updated with the location changes. This update means that you can do ```(location == 'My Location')``` as part of a poller filter rule now.

* JIRA: http://issues.opennms.org/browse/HZN-878
* Bamboo: http://bamboo.internal.opennms.com:8085/browse/OPENNMS-ONMS977