### PR TITLE
NMS-8739: top 20 nodes by I/O wait

### DIFF
--- a/opennms-base-assembly/src/main/filtered/etc/database-reports.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/database-reports.xml
@@ -7,35 +7,40 @@
                 report-service="availabilityReportService" description="standard opennms report in calendar format" />
         <report id="defaultClassicReport" display-name="Default classic report"
                 report-service="availabilityReportService" description="standard opennms report in tabular format" />
-        <report id="Early-Morning-Report" display-name="Early morning report" online="true" 
+        <report id="Early-Morning-Report" display-name="Early morning report" online="true"
                 report-service="jasperReportService" description="Global overview of outages, notifications and events in last 24 hours" />
-        <report id="Response-Time-Summary-Report" display-name="Response Time Summary for node" online="true" 
+        <report id="Response-Time-Summary-Report" display-name="Response Time Summary for node" online="true"
                 report-service="jasperReportService" description="Response Time by node across one or more surveillance categories. Note: % can be used as a place holder for any string literal" />
-        <report id="Node-Availability-Report" display-name="Availability by node" online="true" 
+        <report id="Node-Availability-Report" display-name="Availability by node" online="true"
                 report-service="jasperReportService" description="Availability by node across one or more surveillance categories. Note: % can be used as a place holder for any string literal" />
-        <report id="Availability-Summary-Report" display-name="Availability Summary -Default configuration for past 7 Days" online="true" 
+        <report id="Availability-Summary-Report" display-name="Availability Summary -Default configuration for past 7 Days" online="true"
                 report-service="jasperReportService" description="Availability summary across one or more surveillance categories. Note: % can be used as a place holder for any string literal" />
-        <report id="Response-Time-Report" display-name="Response time by node" online="true" 
+        <report id="Response-Time-Report" display-name="Response time by node" online="true"
                 report-service="jasperReportService" description="Response time by node across one or more surveillance categories. Note: % can be used as a place holder for any string literal" />
-        <report id="Serial-Interface-Utilization-Summary" display-name="Serial Interface Utilization Summary" online="true" 
+        <report id="Serial-Interface-Utilization-Summary" display-name="Serial Interface Utilization Summary" online="true"
                 report-service="jasperReportService" description="Serial Interface Utilization Summary" />
-        <report id="Total-Bytes-Transferred-By-Interface" display-name="Total Bytes Transferred by Interface " online="true" 
+        <report id="Total-Bytes-Transferred-By-Interface" display-name="Total Bytes Transferred by Interface " online="true"
                 report-service="jasperReportService" description="Total Bytes Transferred by Interface" />
-        <report id="Average-Peak-Traffic-Rates" display-name="Average and Peak Traffic rates for Nodes by Interface" online="true" 
+        <report id="Average-Peak-Traffic-Rates" display-name="Average and Peak Traffic rates for Nodes by Interface" online="true"
                 report-service="jasperReportService" description="Average and Peak Traffic rates for Nodes by Interface" />
-        <report id="Interface-Availability-Report" display-name="Interface Availability Report" online="true" 
+        <report id="Interface-Availability-Report" display-name="Interface Availability Report" online="true"
                 report-service="jasperReportService" description="Interface Availability Report, show interface availability for interfaces with outages within time range" />
-        <report id="Snmp-Interface-Oper-Availability" display-name="Snmp Interface Availability Report" online="true" 
+        <report id="Snmp-Interface-Oper-Availability" display-name="Snmp Interface Availability Report" online="true"
                 report-service="jasperReportService" description="Snmp Interface Availability Report, shows availability for snmp interfaces with interfaceOperDown outages within the time range" />
-        <report id="AssetMangementMaintExpired" display-name="Maintenance contracts expired" online="true" 
+        <report id="AssetMangementMaintExpired" display-name="Maintenance contracts expired" online="true"
                 report-service="jasperReportService" description="Asset management report shows all maintenance contracts expired." />
-        <report id="AssetMangementMaintStrategy" display-name="Maintenance contracts strategy" online="true" 
+        <report id="AssetMangementMaintStrategy" display-name="Maintenance contracts strategy" online="true"
                 report-service="jasperReportService" description="Asset management report focused on maintenance strategy.Forecast and overview for 12 month and informations about age of nodes and maintenance contracts" />
-        <report id="Event-Analysis" display-name="Event Analysis report" online="true" 
+        <report id="Event-Analysis" display-name="Event Analysis report" online="true"
                 report-service="jasperReportService" description="Analyse events based on events source and quantity by nodes." />
 <!--    The following report expects that storeByGroup is enabled -->
 <!--
-        <report id="DiskUsageForCTX" display-name="C: Disk Usage for CTX servers" online="true" 
+        <report id="DiskUsageForCTX" display-name="C: Disk Usage for CTX servers" online="true"
                 report-service="jasperReportService" description="C: Disk Usage for CTX servers" />
+-->
+<!--    The following report expects that storeByForeignSource is enabled -->
+<!--
+        <report id="Top20-IOWait" display-name="TOP 20 nodes by I/O Wait" online="true"
+                report-service="jasperReportService" description="TOP 20 nodes by I/O Wait" />
 -->
 </database-reports>

--- a/opennms-base-assembly/src/main/filtered/etc/jasper-reports.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/jasper-reports.xml
@@ -16,5 +16,6 @@
         <report id="AssetMangementMaintExpired" template="AssetManagementMaintExpired.jrxml" engine="jdbc" />
         <report id="AssetMangementMaintStrategy" template="AssetManagementMaintStrategy.jrxml" engine="jdbc" />
         <report id="Event-Analysis" template="EventAnalysis.jrxml" engine="jdbc" />
-        <report id="DiskUsageForCTX" template="DiskUsageForCTX.jrxml" engine="jdbc" /> 
+        <report id="DiskUsageForCTX" template="DiskUsageForCTX.jrxml" engine="jdbc" />
+        <report id="Top20-IOWait" template="TopIOWait.jrxml" engine="jdbc" />
 </jasper-reports>

--- a/opennms-base-assembly/src/main/filtered/etc/report-templates/TopIOWait.jrxml
+++ b/opennms-base-assembly/src/main/filtered/etc/report-templates/TopIOWait.jrxml
@@ -1,0 +1,271 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created with Jaspersoft Studio version 6.1.1.final using JasperReports Library version 6.1.1  -->
+<!-- 2016-09-14T12:01:14 -->
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="Average and Peak Traffic Rates" pageWidth="595" pageHeight="842" whenNoDataType="NoDataSection" columnWidth="555" leftMargin="20" rightMargin="20" topMargin="20" bottomMargin="20" uuid="dd0c0584-c0b6-4860-a6fd-62182c4d11a5">
+	<property name="ireport.zoom" value="1.2100000000000006"/>
+	<property name="ireport.x" value="0"/>
+	<property name="ireport.y" value="0"/>
+	<property name="com.jaspersoft.studio.unit." value="pixel"/>
+	<property name="com.jaspersoft.studio.data.sql.tables" value=""/>
+	<property name="com.jaspersoft.studio.data.defaultdataadapter" value="opennms"/>
+	<template><![CDATA[$P{ONMS_REPORT_DIR} + "/assets/styles/defaultStyles.jrtx"]]></template>
+	<style name="Report_Title" forecolor="#000000" fontSize="20"/>
+	<style name="Report_Subtitle" forecolor="#000000" vTextAlign="Middle" vImageAlign="Middle" fontSize="10" isBold="false" isItalic="true" isUnderline="false" isStrikeThrough="false"/>
+	<style name="Table_Detail" hTextAlign="Left" hImageAlign="Left" vTextAlign="Middle" vImageAlign="Middle" fontName="SansSerif" fontSize="10" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false"/>
+	<style name="Table_Grid" mode="Transparent" forecolor="#FFFFFF" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false">
+		<pen lineWidth="0.0" lineColor="#FFFFFF"/>
+		<box>
+			<bottomPen lineWidth="1.0"/>
+		</box>
+		<conditionalStyle>
+			<conditionExpression><![CDATA[new Boolean($V{style_helper_COUNT}%new Integer("5") == new Integer("0"))]]></conditionExpression>
+			<style mode="Opaque" forecolor="#999999">
+				<box>
+					<bottomPen lineWidth="1.0"/>
+				</box>
+			</style>
+		</conditionalStyle>
+	</style>
+	<style name="Page_Footer" fontSize="10" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false"/>
+	<style name="Table_Header" isBold="true" isItalic="false" isUnderline="false" isStrikeThrough="false"/>
+	<style name="Table_Header_BG" mode="Opaque" backcolor="#CCFFCC"/>
+	<style name="Table_Surveillance_Cat" forecolor="#000000" vTextAlign="Middle" vImageAlign="Middle" fontSize="10" isBold="true" isItalic="false" isUnderline="false" isStrikeThrough="false"/>
+	<style name="Table_Surveillance_Cat_BG" mode="Opaque" backcolor="#DFDFDF"/>
+	<style name="Table_Surveillance_Cat_Footer_BG" mode="Transparent" backcolor="#FFFFFF">
+		<pen lineWidth="1.0" lineStyle="Double"/>
+	</style>
+	<style name="Table_Surveillance_Cat_Footer" hTextAlign="Center" hImageAlign="Center" vTextAlign="Middle" vImageAlign="Middle" fontSize="10" isBold="true" isItalic="false" isUnderline="false" isStrikeThrough="false">
+		<box>
+			<bottomPen lineWidth="0.0" lineStyle="Double" lineColor="#000000"/>
+		</box>
+	</style>
+	<style name="Table_Surveillance_Cat_Footer_Line" hTextAlign="Center" hImageAlign="Center" vTextAlign="Middle" vImageAlign="Middle" isBold="true" isItalic="false" isUnderline="false" isStrikeThrough="false">
+		<box>
+			<bottomPen lineWidth="2.0" lineStyle="Double" lineColor="#000000"/>
+		</box>
+	</style>
+	<style name="Surveillance_Category_Group" mode="Opaque" backcolor="#CCFFCC" hTextAlign="Left" hImageAlign="Left" vTextAlign="Middle" vImageAlign="Middle" fontSize="12" isBold="true" isItalic="false" isUnderline="false" isStrikeThrough="false"/>
+	<style name="Node_Group" mode="Opaque" backcolor="#DFDFDF" hTextAlign="Left" hImageAlign="Left" vTextAlign="Middle" vImageAlign="Middle" fontSize="10" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false"/>
+	<style name="table">
+		<box>
+			<pen lineWidth="1.0" lineColor="#000000"/>
+		</box>
+	</style>
+	<style name="table_TH" mode="Opaque" backcolor="#F0F8FF">
+		<box>
+			<topPen lineWidth="0.5" lineColor="#000000"/>
+			<bottomPen lineWidth="0.5" lineColor="#000000"/>
+		</box>
+	</style>
+	<style name="table_CH" mode="Opaque" backcolor="#BFE1FF">
+		<box>
+			<topPen lineWidth="0.5" lineColor="#000000"/>
+			<bottomPen lineWidth="0.5" lineColor="#000000"/>
+		</box>
+	</style>
+	<style name="table_TD" mode="Opaque" backcolor="#FFFFFF">
+		<box>
+			<topPen lineWidth="0.5" lineColor="#000000"/>
+			<bottomPen lineWidth="0.5" lineColor="#000000"/>
+		</box>
+	</style>
+	<style name="style1"/>
+	<style name="Interface_Header" hTextAlign="Center" hImageAlign="Center" vTextAlign="Middle" vImageAlign="Middle" isBold="true" isItalic="false" isUnderline="false" isStrikeThrough="false"/>
+	<parameter name="ONMS_REPORT_DIR" class="java.lang.String" isForPrompting="false">
+		<parameterDescription><![CDATA[The directory where all reports can be found]]></parameterDescription>
+		<defaultValueExpression><![CDATA["/opt/opennms/etc/report-templates"]]></defaultValueExpression>
+	</parameter>
+	<parameter name="COMPANY_LOGO" class="java.lang.String" isForPrompting="false">
+		<defaultValueExpression><![CDATA[$P{ONMS_REPORT_DIR} + "/assets/images/company-logo.png"]]></defaultValueExpression>
+	</parameter>
+	<parameter name="SUBREPORT_DIR" class="java.lang.String" isForPrompting="false">
+		<defaultValueExpression><![CDATA[$P{ONMS_REPORT_DIR} + "/subreports/"]]></defaultValueExpression>
+	</parameter>
+	<queryString>
+		<![CDATA[select
+n.nodeid, n.nodelabel, n.nodesyscontact, n.nodesysdescription, n.nodesyslocation, d.value
+from
+	node n, 
+	(select * from statisticsreport order by id desc limit 1) s,
+	statisticsreportdata d,
+    resourcereference r
+where
+	s.id=d.reportid
+	and s.name='TopN_IOWait'
+	and d.resourceid=r.id
+	and r.resourceid='nodeSource['||n.foreignsource||'%3A'||n.foreignid||'].nodeSnmp[]'
+order by d.value desc]]>
+	</queryString>
+	<field name="nodeid" class="java.lang.Integer"/>
+	<field name="nodelabel" class="java.lang.String"/>
+	<field name="nodesyscontact" class="java.lang.String"/>
+	<field name="nodesysdescription" class="java.lang.String"/>
+	<field name="nodesyslocation" class="java.lang.String"/>
+	<field name="value" class="java.lang.Double"/>
+	<background>
+		<band splitType="Stretch"/>
+	</background>
+	<title>
+		<band height="4" splitType="Stretch"/>
+	</title>
+	<pageHeader>
+		<band height="80" splitType="Stretch">
+			<staticText>
+				<reportElement style="Title" x="0" y="0" width="355" height="30" uuid="e2bbd5aa-7bb3-4da8-9975-db0696053b3e">
+					<property name="local_mesure_unitwidth" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+					<property name="local_mesure_unitheight" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.height" value="px"/>
+				</reportElement>
+				<textElement verticalAlignment="Middle">
+					<font size="20" isBold="true"/>
+				</textElement>
+				<text><![CDATA[Top 20 nodes by I/O Wait]]></text>
+			</staticText>
+			<image>
+				<reportElement x="360" y="0" width="194" height="50" uuid="7a2e4fd9-7cb3-4ee0-a739-39549ded3164">
+					<property name="local_mesure_unitwidth" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+					<property name="local_mesure_unitheight" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.height" value="px"/>
+				</reportElement>
+				<imageExpression><![CDATA[$P{COMPANY_LOGO}]]></imageExpression>
+			</image>
+			<staticText>
+				<reportElement x="0" y="30" width="354" height="30" uuid="49028b4e-cd3b-4a4f-b33c-f70c20e4a543"/>
+				<text><![CDATA[Average for the last 24 hours.]]></text>
+			</staticText>
+		</band>
+	</pageHeader>
+	<columnHeader>
+		<band height="19" splitType="Stretch">
+			<line>
+				<reportElement x="0" y="0" width="555" height="1" uuid="c5cc50fc-34f3-4f66-a76a-c648728b32a8">
+					<property name="local_mesure_unitx" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.x" value="px"/>
+					<property name="local_mesure_unitwidth" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<graphicElement>
+					<pen lineWidth="1.5"/>
+				</graphicElement>
+			</line>
+			<staticText>
+				<reportElement x="0" y="1" width="140" height="18" uuid="405bc934-e220-4d23-a4bd-64377740d5ca"/>
+				<textElement textAlignment="Center">
+					<font isBold="true"/>
+				</textElement>
+				<text><![CDATA[Node Label]]></text>
+			</staticText>
+			<staticText>
+				<reportElement x="140" y="1" width="280" height="18" uuid="42f8b403-c7e6-4aa3-9936-749fac94cb66"/>
+				<textElement textAlignment="Center">
+					<font isBold="true"/>
+				</textElement>
+				<text><![CDATA[Node details]]></text>
+			</staticText>
+			<staticText>
+				<reportElement x="440" y="1" width="114" height="18" uuid="b68e8040-9386-4658-b857-dc354a53b2dc"/>
+				<textElement textAlignment="Right">
+					<font isBold="true"/>
+				</textElement>
+				<text><![CDATA[ I/O Wait (raw)]]></text>
+			</staticText>
+		</band>
+	</columnHeader>
+	<detail>
+		<band height="22" splitType="Stretch">
+			<textField>
+				<reportElement x="0" y="0" width="140" height="16" uuid="27a3911b-2cb4-4f8c-8113-cd87a3b7ddca"/>
+				<textFieldExpression><![CDATA[$F{nodelabel}]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="140" y="0" width="280" height="16" forecolor="#9C9C9C" uuid="ee591f75-53af-49d4-96aa-ef1022246013"/>
+				<textFieldExpression><![CDATA[$F{nodesysdescription}]]></textFieldExpression>
+			</textField>
+			<textField pattern="#0">
+				<reportElement x="440" y="0" width="114" height="16" uuid="127ebdb6-ffa0-4571-bfb9-ce004b14b246"/>
+				<textElement textAlignment="Right"/>
+				<textFieldExpression><![CDATA[$F{value}]]></textFieldExpression>
+			</textField>
+		</band>
+	</detail>
+	<columnFooter>
+		<band height="259" splitType="Stretch">
+			<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
+			<lineChart>
+				<chart evaluationTime="Report">
+					<reportElement x="0" y="0" width="554" height="258" uuid="1418a549-330a-4a9e-87fb-0d2448131ef4"/>
+					<chartTitle/>
+					<chartSubtitle/>
+					<chartLegend/>
+				</chart>
+				<categoryDataset>
+					<categorySeries>
+						<seriesExpression><![CDATA["I/O WAIT"]]></seriesExpression>
+						<categoryExpression><![CDATA[$F{nodelabel}]]></categoryExpression>
+						<valueExpression><![CDATA[$F{value}]]></valueExpression>
+						<labelExpression><![CDATA[$F{nodelabel}]]></labelExpression>
+					</categorySeries>
+				</categoryDataset>
+				<linePlot>
+					<plot labelRotation="45.0"/>
+					<categoryAxisFormat labelRotation="45.0">
+						<axisFormat/>
+					</categoryAxisFormat>
+					<valueAxisFormat>
+						<axisFormat/>
+					</valueAxisFormat>
+				</linePlot>
+			</lineChart>
+		</band>
+	</columnFooter>
+	<pageFooter>
+		<band height="35" splitType="Stretch">
+			<property name="local_mesure_unitheight" value="pixel"/>
+			<property name="com.jaspersoft.studio.unit.height" value="px"/>
+			<line>
+				<reportElement x="0" y="10" width="554" height="1" uuid="ec45ea9b-d9e4-4343-9cf9-512b9db8e881"/>
+				<graphicElement>
+					<pen lineWidth="1.5"/>
+				</graphicElement>
+			</line>
+			<textField>
+				<reportElement style="Paging-Footer" x="451" y="13" width="80" height="20" uuid="eb684bd0-d9e6-4a31-a516-b4edf17125d7"/>
+				<textElement textAlignment="Right"/>
+				<textFieldExpression><![CDATA["Page "+$V{PAGE_NUMBER}+" of"]]></textFieldExpression>
+			</textField>
+			<textField evaluationTime="Report">
+				<reportElement style="Paging-Footer" x="531" y="13" width="24" height="20" uuid="647f6ab1-e658-4c3c-b0d7-356b2366cba4"/>
+				<textFieldExpression><![CDATA[" " + $V{PAGE_NUMBER}]]></textFieldExpression>
+			</textField>
+			<textField pattern="yyyy/MM/dd HH:mm:ss">
+				<reportElement style="Creation-Date" x="0" y="13" width="355" height="20" uuid="25086ab7-3068-458e-8feb-e35e07b2b9e5">
+					<property name="local_mesure_unitwidth" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
+				<textFieldExpression><![CDATA[new java.util.Date()]]></textFieldExpression>
+			</textField>
+		</band>
+	</pageFooter>
+	<noData>
+		<band height="155">
+			<line>
+				<reportElement x="0" y="80" width="555" height="1" uuid="3904dc8d-463e-4824-b19c-5663db0bc38a">
+					<property name="local_mesure_unity" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<graphicElement>
+					<pen lineWidth="1.5"/>
+				</graphicElement>
+			</line>
+			<textField>
+				<reportElement x="0" y="85" width="555" height="59" uuid="5fa4caf7-f9b2-4ab4-8570-ecd5b55057fa">
+					<property name="local_mesure_unity" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.y" value="px"/>
+				</reportElement>
+				<textFieldExpression><![CDATA["There is no data for this report yet."]]></textFieldExpression>
+			</textField>
+		</band>
+	</noData>
+</jasperReport>

--- a/opennms-base-assembly/src/main/filtered/etc/statsd-configuration.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/statsd-configuration.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <statistics-daemon-configuration
-  xmlns:this="http://www.opennms.org/xsd/config/statsd" 
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+  xmlns:this="http://www.opennms.org/xsd/config/statsd"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://www.opennms.org/xsd/config/statsd http://www.opennms.org/xsd/config/statistics-daemon-configuration.xsd ">
 
   <!--
@@ -26,7 +26,19 @@
       <parameter key="attributeMatch" value="ifInOctets"/>
     </packageReport>
   </package>
-  
+
+  <package name="IOWAITReports">
+    <packageReport name="TopN_IOWait" description="Top 20 iowait across all nodes"
+                   schedule="0 17 10 * * ?" retainInterval="2592000000"
+                   status="off">
+      <parameter key="count" value="20"/>
+      <parameter key="consolidationFunction" value="AVERAGE"/>
+      <parameter key="relativeTime" value="YESTERDAY"/>
+      <parameter key="resourceTypeMatch" value="nodeSnmp"/>
+      <parameter key="attributeMatch" value="CpuRawWait"/>
+    </packageReport>
+  </package>
+
   <package name="ResponseTimeReports">
     <packageReport name="Top10_Response_Weekly" description="Weekly Top 10 responses across all nodes"
                    schedule="0 0 0 ? * MON" retainInterval="2592000000"
@@ -37,7 +49,7 @@
       <parameter key="resourceTypeMatch" value="responseTime"/>
       <parameter key="attributeMatch" value="icmp"/>
     </packageReport>
-    
+
     <packageReport name="Top10_Response_This_Month" description="This Month Top 10 responses across all nodes"
                    schedule="0 0 0 L * ?" retainInterval="2592000000"
                    status="off">
@@ -47,7 +59,7 @@
       <parameter key="resourceTypeMatch" value="responseTime"/>
       <parameter key="attributeMatch" value="icmp"/>
     </packageReport>
-    
+
     <packageReport name="Top10_Response_Last_Month" description="Last Month Top 10 responses across all nodes"
                    schedule="0 0 0 1 * ?" retainInterval="2592000000"
                    status="off">
@@ -57,7 +69,7 @@
       <parameter key="resourceTypeMatch" value="responseTime"/>
       <parameter key="attributeMatch" value="icmp"/>
     </packageReport>
-    
+
     <packageReport name="Top10_Response_This_Year" description="This Year Top 10 responses across all nodes"
                    schedule="0 0 0 1 * ?" retainInterval="2592000000"
                    status="off">
@@ -68,8 +80,8 @@
       <parameter key="attributeMatch" value="icmp"/>
     </packageReport>
   </package>
-  
-  
+
+
   <report name="TopN_InOctets" class-name="org.opennms.netmgt.dao.support.TopNAttributeStatisticVisitor"/>
   <report name="Top10_Response_Weekly" class-name="org.opennms.netmgt.dao.support.TopNAttributeStatisticVisitor"/>
   <report name="Top10_Response_This_Month" class-name="org.opennms.netmgt.dao.support.TopNAttributeStatisticVisitor"/>


### PR DESCRIPTION
See issue [NMS-8739](http://issues.opennms.org/browse/NMS-8739).

A simple jasper reports that shows the top 20 nodes by I/O Wait.
Works for net-snmp nodes (sorry, no windows) and requires that Store By Foreign Source is enabled.

Crafted with love in Fulda by me and @indigo423 
- JIRA: http://issues.opennms.org/browse/NMS-8739
