### PR TITLE
NMS-8711: Update searchboxes placeholder and documentation for IPv6

### DIFF
--- a/features/minion/repository/pom.xml
+++ b/features/minion/repository/pom.xml
@@ -119,6 +119,11 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.opennms.features.minion.heartbeat</groupId>
+            <artifactId>org.opennms.features.minion.heartbeat.producer</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.opennms</groupId>
             <artifactId>opennms-detector-bsf</artifactId>
         </dependency>


### PR DESCRIPTION
From @StCyr: Updated searchboxes placeholder and documentation to explicitly mention it's possible to search for IPv6 addresses.

* JIRA: http://issues.opennms.org/browse/NMS-8711
* Bamboo: http://bamboo.internal.opennms.com:8085/browse/OPENNMS-ONMS985