### PR TITLE
NMS-8545: Add Kafka JMX collections and graph definitions

### DIFF
--- a/opennms-base-assembly/src/main/filtered/etc/jmx-datacollection-config.d/kafka.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/jmx-datacollection-config.d/kafka.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<jmx-datacollection-config rrdRepository="${install.share.dir}/rrd/snmp/">
+<jmx-datacollection-config rrdRepository="/Users/ps044221/Desktop/workspace/jira-HZN-776/opennms/target/opennms-19.0.0-SNAPSHOT/share/rrd/snmp/">
     <jmx-collection name="jmx-kafka">
         <rrd step="300">
             <rra>RRA:AVERAGE:0.5:1:2016</rra>
@@ -48,8 +48,136 @@
         <mbean name="Trap Bytes Out PerSecond Metrics" objectname="kafka.server:type=BrokerTopicMetrics,name=BytesOutPerSec,topic=trapd">
             <attrib name="Count" alias="trapOutBytesCount" type="gauge"/>
         </mbean>
-            
-      </mbeans>
+
+        <mbean name="Syslog Message InPerSec" objectname="kafka.server:type=BrokerTopicMetrics,name=MessagesInPerSec,topic=syslog">
+            <attrib name="Count" alias="smsgCount" type="gauge"/>
+        </mbean>
+
+        <mbean name="Trap Message InPerSec" objectname="kafka.server:type=BrokerTopicMetrics,name=MessagesInPerSec,topic=trapd">
+            <attrib name="Count" alias="tmsgCount" type="gauge"/>
+        </mbean>
+
+        <mbean name="UnderReplicatedPartitions" objectname="kafka.server:type=ReplicaManager,name=UnderReplicatedPartitions">
+            <attrib name="Value" alias="ReplicValue" type="gauge"/>
+        </mbean>
+        
+        <mbean name="ReplicaManager LeaderCount" objectname="kafka.server:type=ReplicaManager,name=LeaderCount">
+            <attrib name="Value" alias="lcCount" type="gauge"/>
+        </mbean>
+
+        <mbean name="Produce Count" objectname="kafka.network:type=RequestMetrics,name=LocalTimeMs,request=Produce">
+            <attrib name="Count" alias="pCount" type="gauge"/>
+        </mbean>
+
+        <mbean name="Fetch Consumer" objectname="kafka.network:type=RequestMetrics,name=LocalTimeMs,request=FetchConsumer">
+            <attrib name="Count" alias="fcCount" type="gauge"/>
+        </mbean>
+
+        <mbean name="Fetch Follower" objectname="kafka.network:type=RequestMetrics,name=LocalTimeMs,request=FetchFollower">
+            <attrib name="Count" alias="ffCount" type="gauge"/>
+        </mbean>
+        
+        <mbean name="Active ControllerCount" objectname="kafka.controller:type=KafkaController,name=ActiveControllerCount">
+            <attrib name="Value" alias="accValue" type="gauge"/>
+        </mbean>
+
+        <mbean name="Leader ElectionRate And TimeMs" objectname="kafka.controller:type=ControllerStats,name=LeaderElectionRateAndTimeMs">
+            <attrib name="Count" alias="leCount" type="gauge"/>
+        </mbean>
+        
+        <mbean name="Unclean LeaderElectionsPerSec" objectname="kafka.controller:type=ControllerStats,name=UncleanLeaderElectionsPerSec">
+            <attrib name="Count" alias="uleCount" type="gauge"/>
+        </mbean>
+        
+        <mbean name="Partition Count" objectname="kafka.server:type=ReplicaManager,name=PartitionCount">
+            <attrib name="Value" alias="pcValue" type="gauge"/>
+        </mbean>
+        
+        <mbean name="Leader Count" objectname="kafka.server:type=ReplicaManager,name=LeaderCount">
+            <attrib name="Value" alias="lcValue" type="gauge"/>
+        </mbean>
+                
+        <mbean name="Isr ShrinksPerSec" objectname="kafka.server:type=ReplicaManager,name=IsrShrinksPerSec">
+            <attrib name="Count" alias="isCount" type="gauge"/>
+        </mbean>
+        
+        <mbean name="Isr ExpandsPerSec" objectname="kafka.server:type=ReplicaManager,name=IsrExpandsPerSec">
+            <attrib name="Count" alias="iseCount" type="gauge"/>
+        </mbean>
+        
+        <mbean name="Replica Fetcher Manager" objectname="kafka.server:type=ReplicaFetcherManager,name=MaxLag,clientId=Replica">
+            <attrib name="Value" alias="rfmValue" type="gauge"/>
+        </mbean>
+        
+        <mbean name="Fetch PurgatorySize" objectname="kafka.server:type=DelayedOperationPurgatory,name=PurgatorySize,delayedOperation=Fetch">
+            <attrib name="Value" alias="fpsValue" type="gauge"/>
+        </mbean>
+        
+        <mbean name="Produce PurgatorySize" objectname="kafka.server:type=DelayedOperationPurgatory,name=PurgatorySize,delayedOperation=Produce">
+            <attrib name="Value" alias="ppsValue" type="gauge"/>
+        </mbean>
+        
+       <mbean name="Produce Request total time" objectname="kafka.network:type=RequestMetrics,name=TotalTimeMs,request=Produce">
+            <attrib name="Count" alias="psttCount" type="gauge"/>
+        </mbean>
+        
+       <mbean name="FetchConsumer Request total time" objectname="kafka.network:type=RequestMetrics,name=TotalTimeMs,request=FetchConsumer">
+            <attrib name="Count" alias="fcrttCount" type="gauge"/>
+       </mbean>
+        
+       <mbean name="FetchFollower Request total time" objectname="kafka.network:type=RequestMetrics,name=TotalTimeMs,request=FetchFollower">
+            <attrib name="Count" alias="ffrttCount" type="gauge"/>
+       </mbean>
+        
+        <mbean name="Produce Request Queue time" objectname="kafka.network:type=RequestMetrics,name=RequestQueueTimeMs,request=Produce">
+            <attrib name="Count" alias="psqtCount" type="gauge"/>
+        </mbean>
+        
+        <mbean name="FetchConsumer Queue time" objectname="kafka.network:type=RequestMetrics,name=RequestQueueTimeMs,request=FetchConsumer">
+            <attrib name="Count" alias="fcqtCount" type="gauge"/>
+        </mbean>
+        
+       <mbean name="FetchFollower Queue time" objectname="kafka.network:type=RequestMetrics,name=RequestQueueTimeMs,request=FetchFollower">
+            <attrib name="Count" alias="ffqtCount" type="gauge"/>
+       </mbean> 
+        
+       <mbean name="Produce Local time" objectname="kafka.network:type=RequestMetrics,name=LocalTimeMs,request=Produce">
+            <attrib name="Count" alias="pltCount" type="gauge"/>
+       </mbean>
+      
+       <mbean name="FetchConsumer Local time" objectname="kafka.network:type=RequestMetrics,name=LocalTimeMs,request=FetchConsumer">
+            <attrib name="Count" alias="fcltCount" type="gauge"/>
+       </mbean>
+      
+       <mbean name="FetchFollower Local time" objectname="kafka.network:type=RequestMetrics,name=LocalTimeMs,request=FetchFollower">
+            <attrib name="Count" alias="ffltCount" type="gauge"/>
+       </mbean>      
+       
+       <mbean name="Produce Remote time" objectname="kafka.network:type=RequestMetrics,name=RemoteTimeMs,request=Produce">
+            <attrib name="Count" alias="prtCount" type="gauge"/>
+       </mbean>
+      
+       <mbean name="FetchConsumer Remote time" objectname="kafka.network:type=RequestMetrics,name=RemoteTimeMs,request=FetchConsumer">
+            <attrib name="Count" alias="fcrtCount" type="gauge"/>
+       </mbean>
+      
+       <mbean name="FetchFollower Remote time" objectname="kafka.network:type=RequestMetrics,name=RemoteTimeMs,request=FetchFollower">
+            <attrib name="Count" alias="ffrtCount" type="gauge"/>
+       </mbean> 
+       
+      <mbean name="Produce ResponseSendTime" objectname="kafka.network:type=RequestMetrics,name=ResponseSendTimeMs,request=Produce">
+            <attrib name="Count" alias="prstCount" type="gauge"/>
+       </mbean>
+      
+       <mbean name="FetchConsumer ResponseSendTime" objectname="kafka.network:type=RequestMetrics,name=ResponseSendTimeMs,request=FetchConsumer">
+            <attrib name="Count" alias="fcrstCount" type="gauge"/>
+       </mbean>
+      
+       <mbean name="FetchFollower ResponseSendTime" objectname="kafka.network:type=RequestMetrics,name=ResponseSendTimeMs,request=FetchFollower">
+            <attrib name="Count" alias="ffrstCount" type="gauge"/>
+       </mbean> 
+        
+     </mbeans>
         
     </jmx-collection>
 </jmx-datacollection-config>

--- a/opennms-base-assembly/src/main/filtered/etc/jmx-datacollection-config.d/kafka.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/jmx-datacollection-config.d/kafka.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<jmx-datacollection-config rrdRepository="/Users/ps044221/Desktop/workspace/jira-HZN-776/opennms/target/opennms-19.0.0-SNAPSHOT/share/rrd/snmp/">
+<jmx-datacollection-config rrdRepository="${install.share.dir}/rrd/snmp/">
     <jmx-collection name="jmx-kafka">
         <rrd step="300">
             <rra>RRA:AVERAGE:0.5:1:2016</rra>

--- a/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/kafka-graphs.properties
+++ b/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/kafka-graphs.properties
@@ -1,13 +1,43 @@
 reports=kafka.syslogBytesCount, \
 kafka.syslogOutBytesCount, \
 kafka.trapInBytesCount, \
-kafka.trapOutBytesCount
-
+kafka.trapOutBytesCount, \
+kafka.ReplicValue, \
+kafka.smsgCount, \
+kafka.tmsgCount, \
+kafka.lcCount, \
+kafka.fcCount, \
+kafka.pCount, \
+kafka.ffcount, \
+kafka.accValue, \
+kafka.leCount, \
+kafka.uleCount, \
+kafka.pcValue, \
+kafka.lcValue, \
+kafka.isCount, \
+kafka.iseCount, \
+kafka.rfmValue, \
+kafka.fpsValue, \
+kafka.ppsValue, \
+kafka.psttCount, \
+kafka.fcrttCount, \
+kafka.ffrttCount, \
+kafak.psqtCount,  \
+kafka.fcqtCount, \
+kafka.ffqtCount, \
+kafak.pltCount, \
+kafak.fcltCount, \
+kafak.prtCount, \
+kafka.fcrtCount, \
+kafka.ffrtCount, \
+kafak.prstCount, \
+kafka.fcrstCount, \
+kafak.ffrstCount
 
 report.kafka.syslogBytesCount.name=Syslog In bytes
 report.kafka.syslogBytesCount.columns=syslogInBytesCount
 report.kafka.syslogBytesCount.type=interfaceSnmp
-report.kafka.syslogBytesCount.command=--title="Sylog Kafka In bytes Metrics" \
+report.kafka.syslogBytesCount.command=--title="Sylog Kafka Incoming bytes Metrics" \
  DEF:syslogInBytesCount={rrd1}:syslogInBytesCount:AVERAGE \
  AREA:syslogInBytesCount#edd400 \
  LINE2:syslogInBytesCount#c4a000:"SylogKafkaIn/Out" \
@@ -19,7 +49,7 @@ report.kafka.syslogBytesCount.command=--title="Sylog Kafka In bytes Metrics" \
 report.kafka.syslogOutBytesCount.name=Syslog out bytes 
 report.kafka.syslogOutBytesCount.columns=syslogOutBytesCount
 report.kafka.syslogOutBytesCount.type=interfaceSnmp
-report.kafka.syslogOutBytesCount.command=--title="Sylog Kafka Out Bytes" \
+report.kafka.syslogOutBytesCount.command=--title="Sylog Kafka Outgoing Bytes" \
  DEF:syslogOutBytesCount={rrd1}:syslogOutBytesCount:AVERAGE \
  AREA:syslogOutBytesCount#edd400 \
  LINE2:syslogOutBytesCount#c4a000:"SylogKafkaIn/Out" \
@@ -30,14 +60,13 @@ report.kafka.syslogOutBytesCount.command=--title="Sylog Kafka Out Bytes" \
 report.kafka.trapInBytesCount.name=Trap In bytes
 report.kafka.trapInBytesCount.columns=trapInBytesCount
 report.kafka.trapInBytesCount.type=interfaceSnmp
-report.kafka.trapInBytesCount.command=--title="Trap Kafka In bytes Metrics" \
+report.kafka.trapInBytesCount.command=--title="Trap Kafka Incoming bytes Metrics" \
  DEF:trapInBytesCount={rrd1}:trapInBytesCount:AVERAGE \
  AREA:trapInBytesCount#edd400 \
  LINE2:trapInBytesCount#c4a000:"SylogKafkaIn/Out" \
  GPRINT:trapInBytesCount:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:trapInBytesCount:MIN:" Min \\: %8.2lf %s" \
  GPRINT:trapInBytesCount:MAX:" Max \\: %8.2lf %s\\n" \
- 
 
 report.kafka.trapOutBytesCount.name=Trap out bytes 
 report.kafka.trapOutBytesCount.columns=trapOutBytesCount
@@ -50,4 +79,376 @@ report.kafka.trapOutBytesCount.command=--title="Trap Kafka Out Bytes" \
  GPRINT:trapOutBytesCount:MIN:" Min \\: %8.2lf %s" \
  GPRINT:trapOutBytesCount:MAX:" Max \\: %8.2lf %s\\n" \
 
+report.kafka.smsgCount.name=smsgCount
+report.kafka.smsgCount.columns=smsgCount
+report.kafka.smsgCount.type=interfaceSnmp
+report.kafka.smsgCount.command=--title="Syslog Message InPerSec" \
+ DEF:smsgCount={rrd1}:smsgCount:AVERAGE \
+ AREA:smsgCount#edd400 \
+ LINE2:smsgCount#c4a000:"Syslog Message InPerSec" \
+ GPRINT:smsgCount:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:smsgCount:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:smsgCount:MAX:" Max \\: %8.2lf %s\\n" \
 
+report.kafka.tmsgCount.name=tmsgCount
+report.kafka.tmsgCount.columns=tmsgCount
+report.kafka.tmsgCount.type=interfaceSnmp
+report.kafka.tmsgCount.command=--title="Trap Message InPerSec" \
+ DEF:tmsgCount={rrd1}:tmsgCount:AVERAGE \
+ AREA:tmsgCount#edd400 \
+ LINE2:tmsgCount#c4a000:"Trap Message InPerSec" \
+ GPRINT:tmsgCount:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:tmsgCount:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:tmsgCount:MAX:" Max \\: %8.2lf %s\\n" \
+ 
+
+report.kafka.ReplicValue.name=UnderReplicatedPartitions
+report.kafka.ReplicValue.columns=ReplicValue
+report.kafka.ReplicValue.type=interfaceSnmp
+report.kafka.ReplicValue.command=--title="UnderReplicatedPartitions" \
+ DEF:ReplicValue={rrd1}:ReplicValue:AVERAGE \
+ AREA:ReplicValue#edd400 \
+ LINE2:ReplicValue#c4a000:"ReplicValue" \
+ GPRINT:ReplicValue:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:ReplicValue:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:ReplicValue:MAX:" Max \\: %8.2lf %s\\n" \
+
+report.kafka.lcCount.name=lcCount
+report.kafka.lcCount.columns=lcCount
+report.kafka.lcCount.type=interfaceSnmp
+report.kafka.lcCount.command=--title="ReplicaManager LeaderCount" \
+ DEF:lcCount={rrd1}:lcCount:AVERAGE \
+ AREA:lcCount#edd400 \
+ LINE2:lcCount#c4a000:"lcCount" \
+ GPRINT:lcCount:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:lcCount:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:lcCount:MAX:" Max \\: %8.2lf %s\\n" \
+
+
+report.kafka.pCount.name=pCount
+report.kafka.pCount.columns=pCount
+report.kafka.pCount.type=interfaceSnmp
+report.kafka.pCount.command=--title="Produce Count" \
+ DEF:pCount={rrd1}:pCount:AVERAGE \
+ AREA:pCount#edd400 \
+ LINE2:pCount#c4a000:"Produce Count" \
+ GPRINT:pCount:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:pCount:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:pCount:MAX:" Max \\: %8.2lf %s\\n" \
+
+report.kafka.fcCount.name=fcCount
+report.kafka.fcCount.columns=fcCount
+report.kafka.fcCount.type=interfaceSnmp
+report.kafka.fcCount.command=--title="FetchConsumer Count" \
+ DEF:fcCount={rrd1}:fcCount:AVERAGE \
+ AREA:fcCount#edd400 \
+ LINE2:fcCount#c4a000:"fetch consumer Count" \
+ GPRINT:fcCount:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:fcCount:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:fcCount:MAX:" Max \\: %8.2lf %s\\n" \
+
+
+report.kafka.ffCount.name=ffCount
+report.kafka.ffCount.columns=ffCount
+report.kafka.ffCount.type=interfaceSnmp
+report.kafka.ffCount.command=--title="Fetch Follower Count" \
+ DEF:ffCount={rrd1}:ffCount:AVERAGE \
+ AREA:ffCount#edd400 \
+ LINE2:ffCount#c4a000:"Fetch Follower Count" \
+ GPRINT:ffCount:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:ffCount:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:ffCount:MAX:" Max \\: %8.2lf %s\\n" \
+
+
+report.kafka.accValue.name=accValue
+report.kafka.accValue.columns=accValue
+report.kafka.accValue.type=interfaceSnmp
+report.kafka.accValue.command=--title="Active ControllerCount" \
+ DEF:accValue={rrd1}:accValue:AVERAGE \
+ AREA:accValue#edd400 \
+ LINE2:accValue#c4a000:"accValue" \
+ GPRINT:accValue:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:accValue:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:accValue:MAX:" Max \\: %8.2lf %s\\n" \
+ 
+ 
+report.kafka.leCount.name=leCount
+report.kafka.leCount.columns=leCount
+report.kafka.leCount.type=interfaceSnmp
+report.kafka.leCount.command=--title="Leader ElectionRate And TimeMs" \
+ DEF:leCount={rrd1}:leCount:AVERAGE \
+ AREA:leCount#edd400 \
+ LINE2:leCount#c4a000:"leCount" \
+ GPRINT:leCount:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:leCount:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:leCount:MAX:" Max \\: %8.2lf %s\\n" \
+ 
+
+report.kafka.uleCount.name=uleCount
+report.kafka.uleCount.columns=uleCount
+report.kafka.uleCount.type=interfaceSnmp
+report.kafka.uleCount.command=--title="Unclean LeaderElectionsPerSec" \
+ DEF:uleCount={rrd1}:uleCount:AVERAGE \
+ AREA:uleCount#edd400 \
+ LINE2:uleCount#c4a000:"uleCount" \
+ GPRINT:uleCount:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:uleCount:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:uleCount:MAX:" Max \\: %8.2lf %s\\n" \
+ 
+ 
+report.kafka.pcValue.name=pcValue
+report.kafka.pcValue.columns=pcValue
+report.kafka.pcValue.type=interfaceSnmp
+report.kafka.pcValue.command=--title="Partition Count" \
+ DEF:pcValue={rrd1}:pcValue:AVERAGE \
+ AREA:pcValue#edd400 \
+ LINE2:pcValue#c4a000:"pcValue" \
+ GPRINT:pcValue:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:pcValue:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:pcValue:MAX:" Max \\: %8.2lf %s\\n" \
+ 
+report.kafka.lcValue.name=lcValue
+report.kafka.lcValue.columns=lcValue
+report.kafka.lcValue.type=interfaceSnmp
+report.kafka.lcValue.command=--title="Leader Count" \
+ DEF:lcValue={rrd1}:lcValue:AVERAGE \
+ AREA:lcValue#edd400 \
+ LINE2:lcValue#c4a000:"lcValue" \
+ GPRINT:lcValue:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:lcValue:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:lcValue:MAX:" Max \\: %8.2lf %s\\n" \
+ 
+report.kafka.isCount.name=isCount
+report.kafka.isCount.columns=isCount
+report.kafka.isCount.type=interfaceSnmp
+report.kafka.isCount.command=--title="Isr ShrinksPerSec" \
+ DEF:isCount={rrd1}:isCount:AVERAGE \
+ AREA:isCount#edd400 \
+ LINE2:isCount#c4a000:"isCount" \
+ GPRINT:isCount:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:isCount:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:isCount:MAX:" Max \\: %8.2lf %s\\n" \
+ 
+report.kafka.iseCount.name=iseCount
+report.kafka.iseCount.columns=iseCount
+report.kafka.iseCount.type=interfaceSnmp
+report.kafka.iseCount.command=--title="Isr ExpandsPerSec" \
+ DEF:iseCount={rrd1}:iseCount:AVERAGE \
+ AREA:iseCount#edd400 \
+ LINE2:iseCount#c4a000:"iseCount" \
+ GPRINT:iseCount:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:iseCount:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:iseCount:MAX:" Max \\: %8.2lf %s\\n" \
+ 
+ 
+report.kafka.rfmValue.name=rfmValue
+report.kafka.rfmValue.columns=rfmValue
+report.kafka.rfmValue.type=interfaceSnmp
+report.kafka.rfmValue.command=--title="Replica Fetcher Manager" \
+ DEF:rfmValue={rrd1}:rfmValue:AVERAGE \
+ AREA:rfmValue#edd400 \
+ LINE2:rfmValue#c4a000:"iseCount" \
+ GPRINT:rfmValue:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:rfmValue:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:rfmValue:MAX:" Max \\: %8.2lf %s\\n" \
+ 
+report.kafka.fpsValue.name=fpsValue
+report.kafka.fpsValue.columns=fpsValue
+report.kafka.fpsValue.type=interfaceSnmp
+report.kafka.fpsValue.command=--title="Fetch Purgatory Size" \
+ DEF:fpsValue={rrd1}:fpsValue:AVERAGE \
+ AREA:fpsValue#edd400 \
+ LINE2:fpsValue#c4a000:"fpsValue" \
+ GPRINT:fpsValue:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:fpsValue:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:fpsValue:MAX:" Max \\: %8.2lf %s\\n" \
+ 
+report.kafka.ppsValue.name=ppsValue
+report.kafka.ppsValue.columns=ppsValue
+report.kafka.ppsValue.type=interfaceSnmp
+report.kafka.ppsValue.command=--title="Produce Purgatory Size" \
+ DEF:ppsValue={rrd1}:ppsValue:AVERAGE \
+ AREA:ppsValue#edd400 \
+ LINE2:ppsValue#c4a000:"ppsValue" \
+ GPRINT:ppsValue:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:ppsValue:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:ppsValue:MAX:" Max \\: %8.2lf %s\\n" \
+ 
+ 
+report.kafka.psttCount.name=psttCount
+report.kafka.psttCount.columns=psttCount
+report.kafka.psttCount.type=interfaceSnmp
+report.kafka.psttCount.command=--title="Produce Request total time" \
+ DEF:psttCount={rrd1}:psttCount:AVERAGE \
+ AREA:psttCount#edd400 \
+ LINE2:psttCount#c4a000:"psttCount" \
+ GPRINT:psttCount:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:psttCount:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:psttCount:MAX:" Max \\: %8.2lf %s\\n" \
+ 
+ 
+report.kafka.fcrttCount.name=fcrttCount
+report.kafka.fcrttCount.columns=fcrttCount
+report.kafka.fcrttCount.type=interfaceSnmp
+report.kafka.fcrttCount.command=--title="FetchConsumer Request total time" \
+ DEF:fcrttCount={rrd1}:fcrttCount:AVERAGE \
+ AREA:fcrttCount#edd400 \
+ LINE2:fcrttCount#c4a000:"fcrttCount" \
+ GPRINT:fcrttCount:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:fcrttCount:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:fcrttCount:MAX:" Max \\: %8.2lf %s\\n" \
+ 
+ 
+report.kafka.ffrttCount.name=ffrttCount
+report.kafka.ffrttCount.columns=ffrttCount
+report.kafka.ffrttCount.type=interfaceSnmp
+report.kafka.ffrttCount.command=--title="FetchFollower Request total time" \
+ DEF:ffrttCount={rrd1}:ffrttCount:AVERAGE \
+ AREA:ffrttCount#edd400 \
+ LINE2:ffrttCount#c4a000:"ffrttCount" \
+ GPRINT:ffrttCount:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:ffrttCount:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:ffrttCount:MAX:" Max \\: %8.2lf %s\\n" \
+ 
+ 
+report.kafka.psqtCount.name=psqtCount
+report.kafka.psqtCount.columns=psqtCount
+report.kafka.psqtCount.type=interfaceSnmp
+report.kafka.psqtCount.command=--title="Produce Request Queue time" \
+ DEF:psqtCount={rrd1}:psqtCount:AVERAGE \
+ AREA:psqtCount#edd400 \
+ LINE2:psqtCount#c4a000:"psqtCount" \
+ GPRINT:psqtCount:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:psqtCount:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:psqtCount:MAX:" Max \\: %8.2lf %s\\n" \
+ 
+ 
+report.kafka.fcqtCount.name=fcqtCount
+report.kafka.fcqtCount.columns=fcqtCount
+report.kafka.fcqtCount.type=interfaceSnmp
+report.kafka.fcqtCount.command=--title="FetchConsumer Queue time" \
+ DEF:fcqtCount={rrd1}:fcqtCount:AVERAGE \
+ AREA:fcqtCount#edd400 \
+ LINE2:fcqtCount#c4a000:"fcqtCount" \
+ GPRINT:fcqtCount:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:fcqtCount:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:fcqtCount:MAX:" Max \\: %8.2lf %s\\n" \
+ 
+ 
+report.kafka.ffqtCount.name=ffqtCount
+report.kafka.ffqtCount.columns=ffqtCount
+report.kafka.ffqtCount.type=interfaceSnmp
+report.kafka.ffqtCount.command=--title="FetchFollower Queue time" \
+ DEF:ffqtCount={rrd1}:ffqtCount:AVERAGE \
+ AREA:ffqtCount#edd400 \
+ LINE2:ffqtCount#c4a000:"ffqtCount" \
+ GPRINT:ffqtCount:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:ffqtCount:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:ffqtCount:MAX:" Max \\: %8.2lf %s\\n" \
+ 
+ 
+ 
+report.kafka.pltCount.name=pltCount
+report.kafka.pltCount.columns=pltCount
+report.kafka.pltCount.type=interfaceSnmp
+report.kafka.pltCount.command=--title="Produce Local time" \
+ DEF:pltCount={rrd1}:pltCount:AVERAGE \
+ AREA:pltCount#edd400 \
+ LINE2:pltCount#c4a000:"pltCount" \
+ GPRINT:pltCount:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:pltCount:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:pltCount:MAX:" Max \\: %8.2lf %s\\n" \
+ 
+ 
+report.kafka.fcltCount.name=fcltCount
+report.kafka.fcltCount.columns=fcltCount
+report.kafka.fcltCount.type=interfaceSnmp
+report.kafka.fcltCount.command=--title="FetchConsumer Local time" \
+ DEF:fcltCount={rrd1}:fcltCount:AVERAGE \
+ AREA:fcltCount#edd400 \
+ LINE2:fcltCount#c4a000:"fcltCount" \
+ GPRINT:fcltCount:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:fcltCount:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:fcltCount:MAX:" Max \\: %8.2lf %s\\n" \
+ 
+ 
+report.kafka.ffltCount.name=ffltCount
+report.kafka.ffltCount.columns=ffltCount
+report.kafka.ffltCount.type=interfaceSnmp
+report.kafka.ffltCount.command=--title="FetchConsumer Local time" \
+ DEF:ffltCount={rrd1}:ffltCount:AVERAGE \
+ AREA:ffltCount#edd400 \
+ LINE2:ffltCount#c4a000:"ffltCount" \
+ GPRINT:ffltCount:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:ffltCount:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:ffltCount:MAX:" Max \\: %8.2lf %s\\n" \
+ 
+ 
+report.kafka.prtCount.name=prtCount
+report.kafka.prtCount.columns=prtCount
+report.kafka.prtCount.type=interfaceSnmp
+report.kafka.prtCount.command=--title="Produce Remote time" \
+ DEF:prtCount={rrd1}:prtCount:AVERAGE \
+ AREA:prtCount#edd400 \
+ LINE2:prtCount#c4a000:"prtCount" \
+ GPRINT:prtCount:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:prtCount:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:prtCount:MAX:" Max \\: %8.2lf %s\\n" \
+ 
+ 
+report.kafka.fcrtCount.name=fcrtCount
+report.kafka.fcrtCount.columns=fcrtCount
+report.kafka.fcrtCount.type=interfaceSnmp
+report.kafka.fcrtCount.command=--title="FetchConsumer Remote time" \
+ DEF:fcrtCount={rrd1}:fcrtCount:AVERAGE \
+ AREA:fcrtCount#edd400 \
+ LINE2:fcrtCount#c4a000:"fcrtCount" \
+ GPRINT:fcrtCount:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:fcrtCount:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:fcrtCount:MAX:" Max \\: %8.2lf %s\\n" \
+ 
+ 
+report.kafka.ffrtCount.name=ffrtCount
+report.kafka.ffrtCount.columns=ffrtCount
+report.kafka.ffrtCount.type=interfaceSnmp
+report.kafka.ffrtCount.command=--title="FetchConsumer Remote time" \
+ DEF:ffrtCount={rrd1}:ffrtCount:AVERAGE \
+ AREA:ffrtCount#edd400 \
+ LINE2:ffrtCount#c4a000:"ffrtCount" \
+ GPRINT:ffrtCount:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:ffrtCount:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:ffrtCount:MAX:" Max \\: %8.2lf %s\\n" \
+ 
+ 
+report.kafka.prstCount.name=prstCount
+report.kafka.prstCount.columns=prstCount
+report.kafka.prstCount.type=interfaceSnmp
+report.kafka.prstCount.command=--title="Produce ResponseSendTimeMs" \
+ DEF:prstCount={rrd1}:prstCount:AVERAGE \
+ AREA:prstCount#edd400 \
+ LINE2:prstCount#c4a000:"prstCount" \
+ GPRINT:prstCount:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:prstCount:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:prstCount:MAX:" Max \\: %8.2lf %s\\n" \
+ 
+report.kafka.fcrstCount.name=fcrstCount
+report.kafka.fcrstCount.columns=fcrstCount
+report.kafka.fcrstCount.type=interfaceSnmp
+report.kafka.fcrstCount.command=--title="FetchConsumer ResponseSendTime" \
+ DEF:fcrstCount={rrd1}:fcrstCount:AVERAGE \
+ AREA:fcrstCount#edd400 \
+ LINE2:fcrstCount#c4a000:"fcrstCount" \
+ GPRINT:fcrstCount:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:fcrstCount:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:fcrstCount:MAX:" Max \\: %8.2lf %s\\n" \
+ 
+report.kafka.ffrstCount.name=ffrstCount
+report.kafka.ffrstCount.columns=ffrstCount
+report.kafka.ffrstCount.type=interfaceSnmp
+report.kafka.ffrstCount.command=--title="FetchFollower ResponseSendTime" \
+ DEF:ffrstCount={rrd1}:ffrstCount:AVERAGE \
+ AREA:ffrstCount#edd400 \
+ LINE2:ffrstCount#c4a000:"ffrstCount" \
+ GPRINT:ffrstCount:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:ffrstCount:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:ffrstCount:MAX:" Max \\: %8.2lf %s\\n" \


### PR DESCRIPTION
In the user guide for Apache Kafka, they spell out all of the crucial JMX metrics for the system in section 6.6 of:

https://kafka.apache.org/081/ops.html

We should create JMX collection/graph definitions for these metrics.

* JIRA: http://issues.opennms.org/browse/NMS-8545
* Bamboo: http://bamboo.internal.opennms.com:8085/browse/OPENNMS-DEL62

