### PR TITLE
NMS-8742: Add documentation for Mattermost/Slack notifications

### DIFF
--- a/opennms-doc/guide-admin/src/asciidoc/index.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/index.adoc
@@ -125,6 +125,14 @@ include::text/performance-data-collection/collectors/wsman/detector.adoc[]
 == Events
 include::text/events.adoc[]
 
+[[ga-notifications]]
+== Notifications
+include::text/notifications/introduction.adoc[]
+include::text/notifications/getting-started.adoc[]
+include::text/notifications/concepts.adoc[]
+include::text/notifications/strategies/mattermost.adoc[]
+include::text/notifications/strategies/slack.adoc[]
+
 [ga-provisioning]
 == Provisioning
 include::text/provisioning/introduction.adoc[]

--- a/opennms-doc/guide-admin/src/asciidoc/index.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/index.adoc
@@ -130,6 +130,7 @@ include::text/events.adoc[]
 include::text/notifications/introduction.adoc[]
 include::text/notifications/getting-started.adoc[]
 include::text/notifications/concepts.adoc[]
+include::text/notifications/bonus-strategies.adoc[]
 include::text/notifications/strategies/mattermost.adoc[]
 include::text/notifications/strategies/slack.adoc[]
 

--- a/opennms-doc/guide-admin/src/asciidoc/text/notifications/bonus-strategies.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/notifications/bonus-strategies.adoc
@@ -1,0 +1,8 @@
+
+// Allow GitHub image rendering
+:imagesdir: ../../images
+
+[[ga-notifications-bonus-strategies]]
+=== Bonus Notification Methods
+
+A handful of newer notification methods are included in {opennms-product-name} but currently require manual steps to activate.

--- a/opennms-doc/guide-admin/src/asciidoc/text/notifications/concepts.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/notifications/concepts.adoc
@@ -1,0 +1,115 @@
+
+// Allow GitHub image rendering
+:imagesdir: ../images
+
+[[ga-notifications-concepts]]
+=== Concepts
+
+_Notifications_ are how {opennms-product-name} informs users about an event that happened in the network, without the users having to log in and look at the UI.
+The core concepts required to understand notifications are:
+
+* Events and UEIs
+* Users, Groups, and On-Call Roles
+* Duty Schedules
+* Destination Paths
+* Notification Commands
+
+These concepts fit together to form an _Event Notification Definition_.
+Also related, but presently only loosely coupled to notifications, are _Alarms_ and _Acknowledgments_.
+
+==== Events and UEIs
+
+As discussed in the chapter on <<ga-events>>, events are central to the operation of {opennms-product-name}.
+Almost everything that happens in the system is the result of, or the cause of, one or more events; Every notification is triggered by exactly one event.
+A good understanding of events is therefore essential to a working knowledge of notifications.
+
+Every event has a _UEI_ (Uniform Event Identifier), a string uniquely identifying the event's type.
+UEIs are typically formatted in the style of a URI, but the only requirement is that they start with the string `uei.`.
+Most notifications are triggered by an exact UEI match (though they may also be triggered with partial UEI matches using regular expression syntax).
+
+==== Users, Groups, and On-Call Roles
+
+_Users_ are entities with login accounts in the {opennms-product-name} system.
+Ideally each user corresponds to a person.
+They are used to control access to the web UI, but also carry contact information (e-mail addresses, phone numbers, etc.) for the people they represent.
+A user may receive a notification either individually or as part of a _Group_ or _On-Call Role_.
+Each user has several technology-specific contact fields, which must be filled if the user is to receive notifications by the associated method.
+
+_Groups_ are lists of users.
+A group may receive a notification, which is often a more convenient way to operate than on individual user.
+
+_On-Call Roles_ are an overlay on top of groups, designed to enable {opennms-product-name} to target the appropriate user or users according to a calendar configuration.
+
+==== Duty Schedules
+
+Every _User_ and _Group_ may have a _Duty Schedule_, which specifies that user's (or group's) weekly schedule for receiving notifications.
+If a notification should be delivered to an individual user, but that user is not on duty at the time, the notification will never be delivered to that user.
+In the case of notifications targeting a user via a group, the logic differs slightly.
+If the group is on duty at the time the notification is created, then all users who are also on duty will be notified.
+If the group is on duty, but no member user is currently on duty, then the notification will be queued and sent to the next user who comes on duty.
+If the group is off duty at the time the notification is created, then the notification will never be sent.
+
+==== Destination Paths
+
+A _Destination Path_ is a named, reusable set of rules for sending notifications.
+Every destination path has an initial step and zero or more escalation steps.
+
+Each step in a destination path has an associated delay which defaults to zero seconds. The initial step's delay is called the _initial delay_, while an escalation step's delay is simply called its _delay_.
+
+Each step has one or more _targets_.
+A target may be a user, a group, an on-call role, or a one-off e-mail address.
+
+NOTE: While it may be tempting to use one-off e-mail addresses any time an individual user is to be targeted, it's a good idea to reserve one-off e-mail addresses for special cases. 
+If a user changes her e-mail address, for instance, you'll need to update in every destination path where it appears.
+The use of one-off e-mail addresses is meant for situations where a vendor or other external entity is assisting with troubleshooting in the short term.
+
+When a step targets one or more groups, a delay may also be specified for each group.
+The default is zero seconds, in which case all group members are notified simultaneously.
+If a longer delay is set, the group members will be notified in alphabetical order of their usernames.
+
+IMPORTANT: Avoid using the same name for a group and a user.
+The destination path configuration does not distinguish between users and groups at the step level, so the behavior is undefined if you have both a user and a group named `admin`.
+It is for this reason that the default administrators group is called `Admin` (with a capital `A`) -- case matters.
+
+Within a step, each target is associated with one or more notification commands.
+If multiple commands are selected, they will execute simultaneously.
+
+Each step also has an _auto-notify_ switch, which may be set to `off`, `on`, or `auto`.
+This switch specifies the logic used when deciding whether or not to send a notice for an auto-acknowledged notification to a target that was not on duty at the time the notification was first created.
+If `off`, notices will never be sent to such a target; if `on`, they will always be sent; if `auto`, the system employs heuristics aimed at "doing the right thing".
+
+==== Notification Commands
+
+A _Notification Command_ is a named, reusable execution profile for a Java class or external program command used to convey notices to targets.
+The following notification commands are included in the default configuration:
+
+`callHomePhone`, `callMobilePhone`, and `callWorkPhone`::
+    Ring one of the phone numbers configured in the user's contact information.
+    All three are implemented using the in-process Asterisk notification strategy, and differ only in which contact field is used.
+
+`ircCat`::
+    Conveys a notice to an instance of the _IRCcat_ Internet Relay Chat bot.
+    Implemented by the in-process IRCcat notification strategy.
+
+`javaEmail` and `javaPagerEmail`::
+    By far the most commonly used commands, these deliver a notice to a user's `email` or `pagerEmail` contact field value.
+    By configuring a user's `pagerEmail` contact field value to target an email-to-SMS gateway, SMS notifications are trivially easy to configure.
+    Both are implemented using the in-process JavaMail notification strategy.
+
+`microblogDM`, `microblogReply`, and `microblogUpdate`::
+    Sends a notice to a user as a direct message, at a user via an at-reply, or to everybody as an update via a microblog service with a Twitter v1-compatible API.
+    Each command is implemented with a separate, in-process notification strategy.
+
+`numericPage` and `textPage`::
+    Sends a notice to a user's numeric or alphanumeric pager.
+    Implemented as an external command using the `qpage` utility.
+
+`xmppGroupMessage` and `xmppMessage`::
+    Sends a message to an XMPP group or user.
+    Implemented with the in-process XMPP notification strategy.
+
+Notification commands are customizable and extensible by editing the `notificationCommands.xml` file.
+
+NOTE: Use external binary notification commands sparingly to avoid fork-bombing your {opennms-product-name} system.
+Originally, all notification commands were external.
+Today only the `numericPage` and `textPage` commands use external programs to do their work. 

--- a/opennms-doc/guide-admin/src/asciidoc/text/notifications/getting-started.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/notifications/getting-started.adoc
@@ -1,0 +1,41 @@
+
+// Allow GitHub image rendering
+:imagesdir: ../images
+
+[[ga-notifications-getting-started]]
+=== Getting Started
+
+The status of notifications is indicated by an icon at the top right of the web UI's navigation bar.
+{opennms-product-name} installs with notifications globally disabled by default.
+
+==== Enabling Notifications
+
+To enable notifications in {opennms-product-name}, log in to the web UI as a user with administrator privileges. Hover over the user icon and click the _Configure OpenNMS_ link.
+The controls for global notification status appear in the top-level configuration menu as _Notification Status_.
+Click the _On_ radio button and then the _Update_ button.
+Notifications are now globally enabled.
+
+NOTE: The web workflow above is functionally equivalent to editing the `notifd-configuration.xml` file and setting `status="on"` in the top-level `notifd-configuration` element.
+This configuration file change is picked up on the fly with no need to restart or send an event.
+
+==== Configuring Destination Paths
+
+To configure notification destination paths in {opennms-product-name}, navigate to _Configure OpenNMS_ and, in the _Event Management_ section, choose _Configure Notifications_.
+In the resulting dialog choose _Configure Destination Paths_.
+
+NOTE: The destination paths configuration is stored in the `destinationPaths.xml` file.
+Changes to this file are picked up on the fly with no need to restart or send an event.
+
+// TODO: Document destination path editor
+
+==== Configuring Event Notifications
+
+To configure notifications for individual events in {opennms-product-name}, navigate to _Configure OpenNMS_ and, in the _Event Management section, choose _Configure Notifications_.
+Then choose _Configure Event Notifications_.
+
+NOTE: The event notification configuration is stored in the `notifications.xml` file.
+Changes to this file are picked up on the fly with no need to restart or send an event.
+
+// TODO: Document event notification editor
+
+// TODO: Document path-outage feature

--- a/opennms-doc/guide-admin/src/asciidoc/text/notifications/introduction.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/notifications/introduction.adoc
@@ -1,0 +1,20 @@
+
+// Allow GitHub image rendering
+:imagesdir: ../../images
+
+[[ga-notifications-introduction]]
+=== Introduction
+
+{opennms-product-name} uses notifications to make users aware of an event. Common notification methods are email and paging, but notification mechanisms also exist for:
+
+* Arbitrary HTTP GET and POST operations
+* Arbitrary external commands
+* Asterisk call origination
+* IRCcat Internet Relay Chat bot
+* SNMP Traps
+* Slack, Mattermost, and other API-compatible team chat platforms
+* Twitter, GNU Social, and other API-compatible microblog services
+* User-provided scripts in any JSR-223 compatible language
+* XMPP
+
+The notification daemon _Notifd_ creates and sends notifications according to configured rules when selected events occur in {opennms-product-name}.

--- a/opennms-doc/guide-admin/src/asciidoc/text/notifications/strategies/mattermost.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/notifications/strategies/mattermost.adoc
@@ -1,0 +1,38 @@
+
+// Allow GitHub image rendering
+:imagesdir: ../images
+
+[[ga-notifications-strategy-mattermost]]
+==== Mattermost
+
+If your organization uses the Mattermost team communications platform, you can configure {opennms-product-name} to send notices to any Mattermost channel via an incoming webhook.
+You must configure an incoming webhook in your Mattermost team and do a bit of manual configuration to your {opennms-product-name} instance.
+
+First, add the following bit of XML to the `notificationCommands.xml` configuration file (no customization should be needed):
+
+[source, xml]
+----
+<command binary="false">
+  <name>mattermost</name>
+  <execute>org.opennms.netmgt.notifd.MattermostNotificationStrategy</execute>
+  <comment>class for sending messages to a Mattermost team channel for notifications</comment>
+  <argument streamed="false">
+    <switch>-subject</switch>
+  </argument>    
+  <argument streamed="false">
+    <switch>-tm</switch>
+  </argument>
+</command>
+----
+
+Then create a new file called `mattermost.properties` in the `opennms.properties.d` directory with the following contents (customizing values as appropriate):
+
+[source, properties]
+----
+org.opennms.netmgt.notifd.mattermost.webhookURL=https://mattermost.example.com/hooks/bf980352b5f7232efe721dbf0626bee1
+org.opennms.netmgt.notifd.mattermost.username=OpenNMS_Bot
+org.opennms.netmgt.notifd.mattermost.iconURL=https://assets.example.com/icons/opennmsbot.png
+org.opennms.netmgt.notifd.mattermost.channel=NetOps
+----
+
+Restart OpenNMS so that the `mattermost.properties` file will be loaded. Your new `mattermost` notification command is now available for use in a destination path.

--- a/opennms-doc/guide-admin/src/asciidoc/text/notifications/strategies/slack.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/notifications/strategies/slack.adoc
@@ -1,0 +1,42 @@
+
+// Allow GitHub image rendering
+:imagesdir: ../images
+
+[[ga-notifications-strategy-slack]]
+==== Slack Notifications
+
+If your organization uses the Slack team communications platform, you can configure {opennms-product-name} to send notices to any Slack channel via an incoming webhook.
+You must configure an incoming webhook in your Slack team and do a bit of manual configuration to your {opennms-product-name} instance.
+
+First, add the following bit of XML to the `notificationCommands.xml` configuration file (no customization should be needed):
+
+[source, xml]
+----
+<command binary="false">
+  <name>slack</name>
+  <execute>org.opennms.netmgt.notifd.SlackNotificationStrategy</execute>
+  <comment>class for sending messages to a Slack team channel for notifications</comment>
+  <argument streamed="false">
+    <switch>-subject</switch>
+  </argument>    
+  <argument streamed="false">
+    <switch>-tm</switch>
+  </argument>
+</command>
+----
+
+Then create a new file called `slack.properties` in the `opennms.properties.d` directory with the following contents (customizing values as appropriate):
+
+[source, properties]
+----
+org.opennms.netmgt.notifd.slack.webhookURL= https://hooks.slack.com/services/AEJ7IIYAI/XOOTH3EOD/c3fc4a662c8e07fe072aeeec
+org.opennms.netmgt.notifd.slack.username=OpenNMS_Bot
+
+org.opennms.netmgt.notifd.slack.iconURL=https://assets.example.com/icons/opennmsbot.png
+# or:
+# org.opennms.netmgt.notifd.slack.iconEmoji=:metal:
+
+org.opennms.netmgt.notifd.slack.channel=NetOps
+----
+
+Restart OpenNMS so that the `slack.properties` file will be loaded. Your new `slack` notification command is now available for use in a destination path.


### PR DESCRIPTION
* JIRA: https://issues.opennms.org/browse/NMS-8742

In order to have a place to hang these docs, I wrote a (rather basic) new chapter on notifications for the admin guide.  It needs fleshing out, but it's useful in its present form.