### PR TITLE
HZN-617: make sure the minion RPMs clean up after themselves on uninstall

### DIFF
--- a/tools/packages/minion/minion.spec
+++ b/tools/packages/minion/minion.spec
@@ -224,3 +224,19 @@ rm -rf %{minionrepoprefix}/.local
 %post features-default
 # Remove the directory used as the local Maven repo cache
 rm -rf %{minionrepoprefix}/.local
+
+%preun -p /bin/bash container
+ROOT_INST="${RPM_INSTALL_PREFIX0}"
+[ -z "${ROOT_INST}" ] && ROOT_INST="%{minioninstprefix}"
+
+if [ "$1" = 0 ] && [ -x "%{_initrddir}/minion" ]; then
+	%{_initrddir}/minion stop || :
+fi
+
+%postun -p /bin/bash container
+ROOT_INST="${RPM_INSTALL_PREFIX0}"
+[ -z "${ROOT_INST}" ] && ROOT_INST="%{minioninstprefix}"
+
+if [ "$1" = 0 ] && [ -n "${ROOT_INST}" ] && [ -d "${ROOT_INST}" ]; then
+	rm -rf "${ROOT_INST}" || echo "WARNING: failed to delete ${ROOT_INST}. You may have to clean it up yourself."
+fi


### PR DESCRIPTION
This PR makes the opennms-minion-container RPM clean out /opt/minion on uninstall.

* JIRA: http://issues.opennms.org/browse/HZN-617
* Bamboo: http://bamboo.internal.opennms.com:8085/browse/OPENNMS-ONMS995


