### PR TITLE
HZN-882: use /etc/sysconfig for setting Minion options

### DIFF
--- a/tools/packages/minion/minion.init
+++ b/tools/packages/minion/minion.init
@@ -20,6 +20,11 @@ NAME="minion"
 DESC="Minion"
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 MINION_HOME="@INSTPREFIX@"
+SYSCONFDIR="@SYSCONFDIR@"
+
+if [ -e "${SYSCONFDIR}/minion" ]; then
+	. "${SYSCONFDIR}/minion"
+fi
 
 is_running() {
 	"$MINION_HOME"/bin/status >/dev/null 2>&1

--- a/tools/packages/minion/minion.spec
+++ b/tools/packages/minion/minion.spec
@@ -155,8 +155,11 @@ rm -rf %{buildroot}%{minioninstprefix}/demos
 
 # Copy over the run script
 mkdir -p %{buildroot}%{_initrddir}
-sed -e 's,@INSTPREFIX@,%{minioninstprefix},g' %{_builddir}/%{_name}-%{version}-%{release}/tools/packages/minion/minion.init > "%{buildroot}%{_initrddir}"/minion
+sed -e 's,@INSTPREFIX@,%{minioninstprefix},g' -e 's,@SYSCONFDIR@,%{_sysconfdir}/sysconfig,g'  %{_builddir}/%{_name}-%{version}-%{release}/tools/packages/minion/minion.init > "%{buildroot}%{_initrddir}"/minion
 chmod 755 "%{buildroot}%{_initrddir}"/minion
+
+install -d -m 755 %{buildroot}%{_sysconfdir}/sysconfig
+install -m 644 "%{_builddir}/%{_name}-%{version}-%{release}/tools/packages/minion/minion.sysconfig" "%{buildroot}%{_sysconfdir}/sysconfig/minion"
 
 # Extract the core repository
 mkdir -p %{buildroot}%{minionrepoprefix}/core
@@ -195,6 +198,7 @@ rm -rf %{buildroot}
 %files container -f %{_tmppath}/files.container
 %defattr(664 root root 775)
 %attr(755,root,root) %{_initrddir}/minion
+%attr(644,root,root) %config(noreplace) %{_sysconfdir}/sysconfig/minion
 %attr(644,root,root) %{minioninstprefix}/etc/featuresBoot.d/.readme
 
 %post container

--- a/tools/packages/minion/minion.sysconfig
+++ b/tools/packages/minion/minion.sysconfig
@@ -1,0 +1,34 @@
+# OpenNMS Minion Startup Configuration
+
+# minimum amount of memory for the Minion Karaf container to allocate
+# export JAVA_MIN_MEM=128M
+
+# maximum amount of memory for the Minion Karaf container to allocate
+# export JAVA_MAX_MEM=512M
+
+# maximum number of file descriptors to allocate
+# export MAX_FD=maximum
+
+# the root directory of the Java enviroment
+# export JAVA_HOME=
+
+# the path to the Java executable (defaults to $JAVA_HOME/bin/java)
+# export JAVA=
+
+# extra debugging options to pass to Java on startup
+# export JAVA_DEBUG_OPTS="-Xms${JAVA_MIN_MEM} -Xmx${JAVA_MAX_MEM} -XX:+UnlockDiagnosticVMOptions -XX:+UnsyncloadClass "
+
+# the port to use when debugging Java
+# export JAVA_DEBUG_PORT=
+
+# other options to pass to Java on startup
+# export JAVA_OPTS=
+
+# extra libraries or paths to add to the Java class path
+# export CLASSPATH=
+
+# uncomment to enable debugging in the Minion Karaf container
+# export KARAF_DEBUG=TRUE
+
+# additional locations to look for native libraries
+# export LD_LIBRARY_PATH=


### PR DESCRIPTION
This PR adds an `/etc/sysconfig/minion` file which mirrors the Karaf startup environment variables used for overriding various options on launch.

* JIRA: https://issues.opennms.org/browse/HZN-882
* Bamboo: http://bamboo.internal.opennms.com:8085/browse/OPENNMS-ONMS996


