### PR TITLE
HZN-618: be more aggressive about stopping Karaf

### DIFF
--- a/tools/packages/minion/minion.init
+++ b/tools/packages/minion/minion.init
@@ -21,13 +21,42 @@ DESC="Minion"
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 MINION_HOME="@INSTPREFIX@"
 SYSCONFDIR="@SYSCONFDIR@"
+STOP_TIMEOUT=10
+STOP_WAIT=5
+
+export NAME DESC PATH
 
 if [ -e "${SYSCONFDIR}/minion" ]; then
+	# shellcheck disable=SC1090,SC1091
 	. "${SYSCONFDIR}/minion"
 fi
 
 is_running() {
 	"$MINION_HOME"/bin/status >/dev/null 2>&1
+}
+
+get_root_pid() {
+	ROOT_INSTANCE_PID=0
+	if [ -f "${MINION_HOME}/instances/instance.properties" ];
+	then
+		ROOT_INSTANCE_PID=$(sed -n -e '/item.0.pid/ s/.*\= *//p' "${MINION_HOME}/instances/instance.properties")
+	fi
+	echo "$ROOT_INSTANCE_PID"
+}
+
+stop_minion() {
+	"$MINION_HOME"/bin/stop >/dev/null
+}
+
+kill_minion() {
+	SIGNAL="$1"
+	if [ -z "$SIGNAL" ]; then
+		SIGNAL="-15"
+	fi
+	PID=$(get_root_pid)
+	if [ "$PID" -gt 0 ]; then
+		kill $SIGNAL "$PID"
+	fi
 }
 
 case "$1" in
@@ -44,20 +73,40 @@ case "$1" in
 
 	stop)
 		if is_running; then
-			echo -n "Stopping $DESC: "
-			"$MINION_HOME"/bin/stop >/dev/null
-			RETVAL="$?"
-			if [ $RETVAL -eq 0 ]; then
-				echo "OK"
+			printf "Stopping %s: " "$DESC"
+			STOP_ATTEMPTS=0
+			while [ $STOP_ATTEMPTS -lt $STOP_TIMEOUT ]; do
+				stop_minion
+				if is_running; then
+					STOP_ATTEMPTS="$((STOP_ATTEMPTS + 1))"
+					sleep $STOP_WAIT
+				else
+					echo "OK"
+					exit 0
+				fi
+			done
+			echo "FAILED"
+
+			printf "Killing %s: " "$DESC"
+			kill_minion
+			if is_running; then
+				echo "FAILED"
 			else
+				echo "OK"
+				exit 0
+			fi
+
+			printf "Force-killing %s: " "$DESC"
+			kill_minion -9
+			if is_running; then
 				echo "FAILED"
 				exit 1
 			fi
-
+			echo "OK"
 			exit 0
 		else
 			echo "$DESC is not running."
-			exit 1
+			exit 0 # LSB specifies calling "stop" on a stopped service is still a success
 		fi
 		;;
 

--- a/tools/packages/minion/minion.init
+++ b/tools/packages/minion/minion.init
@@ -21,7 +21,7 @@ DESC="Minion"
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 MINION_HOME="@INSTPREFIX@"
 SYSCONFDIR="@SYSCONFDIR@"
-STOP_TIMEOUT=10
+STOP_RETRIES=10
 STOP_WAIT=5
 
 export NAME DESC PATH
@@ -75,7 +75,7 @@ case "$1" in
 		if is_running; then
 			printf "Stopping %s: " "$DESC"
 			STOP_ATTEMPTS=0
-			while [ $STOP_ATTEMPTS -lt $STOP_TIMEOUT ]; do
+			while [ $STOP_ATTEMPTS -lt $STOP_RETRIES ]; do
 				stop_minion
 				if is_running; then
 					STOP_ATTEMPTS="$((STOP_ATTEMPTS + 1))"


### PR DESCRIPTION
This PR does a cleaner version of the stop/kill/kill-9 procedure that the OpenNMS init script uses for making sure `stop` really stops.

* JIRA: http://issues.opennms.org/browse/HZN-618
* Bamboo: http://bamboo.internal.opennms.com:8085/browse/OPENNMS-ONMS998


