### PR TITLE
Removed setCreationTime() from EventBuilder

### DIFF
--- a/core/snmp/api/src/main/java/org/opennms/netmgt/snmp/BasicTrapProcessor.java
+++ b/core/snmp/api/src/main/java/org/opennms/netmgt/snmp/BasicTrapProcessor.java
@@ -46,6 +46,7 @@ public class BasicTrapProcessor implements TrapProcessor, Serializable {
 
     private String m_location;
     private String m_community;
+    private long m_creationTime;
     private long m_timeStamp;
     private String m_version;
     private InetAddress m_agentAddress;
@@ -69,6 +70,15 @@ public class BasicTrapProcessor implements TrapProcessor, Serializable {
     @Override
     public void setCommunity(String community) {
         m_community = community;
+    }
+
+    public long getCreationTime() {
+        return m_creationTime;
+    }
+
+    @Override
+    public void setCreationTime(long creationTime) {
+        m_creationTime = creationTime;
     }
 
     public long getTimeStamp() {

--- a/core/snmp/api/src/main/java/org/opennms/netmgt/snmp/TrapProcessor.java
+++ b/core/snmp/api/src/main/java/org/opennms/netmgt/snmp/TrapProcessor.java
@@ -34,10 +34,17 @@ import org.opennms.netmgt.snmp.SnmpValue;
 
 public interface TrapProcessor {
 
+    void setCreationTime(long creationTime);
+
     void setLocation(String location);
 
     void setCommunity(String community);
 
+    /**
+     * Set the SNMP TimeTicks value to the sysUpTime of the agent that
+     * generated the trap. Note that the units for this value are 1/100ths
+     * of a second instead of milliseconds.
+     */
     void setTimeStamp(long timeStamp);
 
     void setVersion(String version);

--- a/core/test-api/db/src/main/java/org/opennms/core/test/db/MockDatabase.java
+++ b/core/test-api/db/src/main/java/org/opennms/core/test/db/MockDatabase.java
@@ -34,6 +34,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.util.Collection;
+import java.util.Date;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -268,8 +269,9 @@ public class MockDatabase extends TemporaryDatabasePostgreSQL implements EventWr
     public void writeEvent(Event e) {
         Integer eventId = getNextEventId();
         
-        if (e.getCreationTime() == null) 
-            e.setCreationTime(e.getTime());
+        if (e.getCreationTime() == null) {
+            e.setCreationTime(new Date());
+        }
         
         Object[] values = {
                 eventId,

--- a/features/elasticsearch/event-forwarder/src/main/java/org/opennms/features/elasticsearch/eventforwarder/internal/ESHeaders.java
+++ b/features/elasticsearch/event-forwarder/src/main/java/org/opennms/features/elasticsearch/eventforwarder/internal/ESHeaders.java
@@ -162,9 +162,10 @@ public class ESHeaders {
     private void populateBodyFromEvent(Map<String,Object> body, Event event) {
         body.put("id",event.getDbid());
         body.put("eventuei",event.getUei());
-        body.put("@timestamp", event.getCreationTime());
+        Date eventTime = event.getTime();
+        body.put("@timestamp", eventTime);
         Calendar cal=Calendar.getInstance();
-        cal.setTime(event.getCreationTime());
+        cal.setTime(eventTime);
         body.put("dow", cal.get(Calendar.DAY_OF_WEEK));
         body.put("hour", cal.get(Calendar.HOUR_OF_DAY));
         body.put("dom", cal.get(Calendar.DAY_OF_MONTH)); // this is not present in the original sql-based tool https://github.com/unicolet/opennms-events/blob/master/sql/opennms_events.sql#L26

--- a/features/elasticsearch/event-forwarder/src/test/java/org/opennms/netmgt/elasticsearch/eventforwarder/ElasticsearchNorthbounderIT.java
+++ b/features/elasticsearch/event-forwarder/src/test/java/org/opennms/netmgt/elasticsearch/eventforwarder/ElasticsearchNorthbounderIT.java
@@ -139,7 +139,6 @@ public class ElasticsearchNorthbounderIT extends CamelBlueprintTest {
 
         final EventBuilder eb = new EventBuilder( EventConstants.NEW_SUSPECT_INTERFACE_EVENT_UEI, "OpenNMS.Discovery" );
         eb.setTime(date);
-        eb.setCreationTime(date);
         eb.setInterface( InetAddress.getByName( ipAddress ) );
         eb.setHost( InetAddressUtils.getLocalHostName() );
         eb.addParam("RTT", 0);

--- a/features/events/syslog/src/main/java/org/opennms/netmgt/syslogd/ConvertToEvent.java
+++ b/features/events/syslog/src/main/java/org/opennms/netmgt/syslogd/ConvertToEvent.java
@@ -171,7 +171,7 @@ public class ConvertToEvent {
 
         bldr.setDistPoller(systemId);
 
-        bldr.setCreationTime(message.getDate());
+        bldr.setTime(message.getDate());
 
         // Set event host
         bldr.setHost(InetAddressUtils.getLocalHostName());

--- a/features/events/traps/src/main/java/org/opennms/netmgt/trapd/EventCreator.java
+++ b/features/events/traps/src/main/java/org/opennms/netmgt/trapd/EventCreator.java
@@ -31,6 +31,7 @@ package org.opennms.netmgt.trapd;
 import static org.opennms.core.utils.InetAddressUtils.str;
 
 import java.net.InetAddress;
+import java.util.Date;
 
 import org.opennms.core.utils.InetAddressUtils;
 import org.opennms.netmgt.dao.api.InterfaceToNodeCache;
@@ -84,6 +85,8 @@ public class EventCreator implements TrapProcessor {
     @Override
     public void setTimeStamp(long timeStamp) {
         m_eventBuilder.setSnmpTimeStamp(timeStamp);
+        Date date = new Date(timeStamp);
+        m_eventBuilder.setTime(date);
     }
 
     /** {@inheritDoc} */

--- a/features/events/traps/src/main/java/org/opennms/netmgt/trapd/EventCreator.java
+++ b/features/events/traps/src/main/java/org/opennms/netmgt/trapd/EventCreator.java
@@ -83,10 +83,14 @@ public class EventCreator implements TrapProcessor {
 
     /** {@inheritDoc} */
     @Override
+    public void setCreationTime(long creationTime) {
+        m_eventBuilder.setTime(new Date(creationTime));
+    }
+
+    /** {@inheritDoc} */
+    @Override
     public void setTimeStamp(long timeStamp) {
         m_eventBuilder.setSnmpTimeStamp(timeStamp);
-        Date date = new Date(timeStamp);
-        m_eventBuilder.setTime(date);
     }
 
     /** {@inheritDoc} */

--- a/features/events/traps/src/test/java/org/opennms/netmgt/trapd/TrapdListenerBlueprintIT.java
+++ b/features/events/traps/src/test/java/org/opennms/netmgt/trapd/TrapdListenerBlueprintIT.java
@@ -160,6 +160,11 @@ public class TrapdListenerBlueprintIT extends CamelBlueprintTest {
 			}
 
 			@Override
+			public void setCreationTime(long creationTime) {
+				// TODO: Assert something?
+			}
+
+			@Override
 			public void setTimeStamp(long timeStamp) {
 				// TODO: Assert something?
 			}

--- a/features/opennms-es-rest/main-module/pom.xml
+++ b/features/opennms-es-rest/main-module/pom.xml
@@ -1,4 +1,3 @@
-
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <parent>
     <groupId>org.opennms.plugins</groupId>

--- a/features/opennms-es-rest/main-module/src/main/java/org/opennms/plugins/elasticsearch/rest/EventToIndex.java
+++ b/features/opennms-es-rest/main-module/src/main/java/org/opennms/plugins/elasticsearch/rest/EventToIndex.java
@@ -446,11 +446,11 @@ public class EventToIndex {
 		body.put("eventuei",event.getUei());
 
 		Calendar cal=Calendar.getInstance();
-		if (event.getCreationTime()==null) {
+		if (event.getTime()==null) {
 			if(LOG.isDebugEnabled()) LOG.debug("using local time because no event creation time for event.toString: "+ event.toString());
 			cal.setTime(new Date());
 
-		} else 	cal.setTime(event.getCreationTime()); // javax.xml.bind.DatatypeConverter.parseDateTime("2010-01-01T12:00:00Z");
+		} else 	cal.setTime(event.getTime()); // javax.xml.bind.DatatypeConverter.parseDateTime("2010-01-01T12:00:00Z");
 
 
 		body.put("@timestamp", DatatypeConverter.printDateTime(cal));
@@ -636,14 +636,14 @@ public class EventToIndex {
 		// set alarm cleared time if an alarm clear event
 		if(ALARM_CLEARED_EVENT.equals(event.getUei())){
 			Calendar alarmClearCal=Calendar.getInstance();
-			alarmClearCal.setTime(event.getCreationTime());
+			alarmClearCal.setTime(event.getTime());
 			body.put(ALARM_CLEAR_TIME, DatatypeConverter.printDateTime(alarmClearCal));
 		}
 
 		// set alarm deleted time if an alarm clear event
 		if(ALARM_DELETED_EVENT.equals(event.getUei())){
 			Calendar alarmDeletionCal=Calendar.getInstance();
-			alarmDeletionCal.setTime(event.getCreationTime());
+			alarmDeletionCal.setTime(event.getTime());
 			body.put(ALARM_DELETED_TIME, DatatypeConverter.printDateTime(alarmDeletionCal));
 		}
 

--- a/features/opennms-es-rest/main-module/src/test/java/org/opennms/plugins/elasticsearch/test/RawEventToIndexTest.java
+++ b/features/opennms-es-rest/main-module/src/test/java/org/opennms/plugins/elasticsearch/test/RawEventToIndexTest.java
@@ -149,7 +149,6 @@ public class RawEventToIndexTest {
 
 			//raw json="{"alarmid":806,"eventuei":"uei.opennms.org/nodes/nodeLostService","nodeid":36,"ipaddr":"142.34.5.19","serviceid":2,"reductionkey":"uei.opennms.org/nodes/nodeLostService::36:142.34.5.19:HTTP","alarmtype":1,"counter":1,"severity":5,"lasteventid":7003,"firsteventtime":"2016-07-27 22:20:52.282+01","lasteventtime":"2016-07-27 22:20:52.282+01","firstautomationtime":null,"lastautomationtime":null,"description":"<p>A HTTP outage was identified on interface\n      142.34.5.19.</p> <p>A new Outage record has been\n      created and service level availability calculations will be\n      impacted until this outage is resolved.</p>","logmsg":"HTTP outage identified on interface 142.34.5.19 with reason code: Unknown.","operinstruct":null,"tticketid":null,"tticketstate":null,"mouseovertext":null,"suppresseduntil":"2016-07-27 22:20:52.282+01","suppresseduser":null,"suppressedtime":"2016-07-27 22:20:52.282+01","alarmackuser":null,"alarmacktime":null,"managedobjectinstance":null,"managedobjecttype":null,"applicationdn":null,"ossprimarykey":null,"x733alarmtype":null,"x733probablecause":0,"qosalarmstate":null,"clearkey":null,"ifindex":null,"eventparms":"eventReason=Unknown(string,text)","stickymemo":null,"systemid":"00000000-0000-0000-0000-000000000000"}";
 
-			eb.setCreationTime(new Date());
 			eb.setUei("uei.opennms.org/nodes/nodeLostService");
 			eb.setNodeid(36);
 			InetAddress ipAddress = InetAddressUtils.getInetAddress("142.34.5.19");

--- a/opennms-alarms/daemon/src/test/java/org/opennms/netmgt/alarmd/AlarmLifecycleEventsIT.java
+++ b/opennms-alarms/daemon/src/test/java/org/opennms/netmgt/alarmd/AlarmLifecycleEventsIT.java
@@ -179,7 +179,6 @@ public class AlarmLifecycleEventsIT implements TemporaryDatabaseAware<MockDataba
     private void sendNodeUpEvent(long nodeId) {
         EventBuilder builder = new EventBuilder(EventConstants.NODE_UP_EVENT_UEI, "test");
         Date currentTime = new Date();
-        builder.setCreationTime(currentTime);
         builder.setTime(currentTime);
         builder.setNodeid(nodeId);
         builder.setSeverity("Normal");
@@ -199,7 +198,6 @@ public class AlarmLifecycleEventsIT implements TemporaryDatabaseAware<MockDataba
     private void sendNodeDownEvent(long nodeId) {
         EventBuilder builder = new EventBuilder(EventConstants.NODE_DOWN_EVENT_UEI, "test");
         Date currentTime = new Date();
-        builder.setCreationTime(currentTime);
         builder.setTime(currentTime);
         builder.setNodeid(nodeId);
         builder.setSeverity("Major");

--- a/opennms-model/src/main/java/org/opennms/netmgt/model/events/EventBuilder.java
+++ b/opennms-model/src/main/java/org/opennms/netmgt/model/events/EventBuilder.java
@@ -81,7 +81,6 @@ public class EventBuilder {
         m_event = new Event();
         setUei(uei);
         setTime(date);
-        setCreationTime(date);
         setSource(source);
     }
 
@@ -94,7 +93,6 @@ public class EventBuilder {
         m_event = event;
         Date now = new Date();
         setTime(now);
-        setCreationTime(now);
     }
 
     /**
@@ -103,6 +101,10 @@ public class EventBuilder {
      * @return a {@link org.opennms.netmgt.xml.event.Event} object.
      */
     public Event getEvent() {
+        // The creation time has been used as the time when the event
+        // is stored in the database so update it right before we return
+        // the event object.
+        m_event.setCreationTime(new Date());
         return m_event;
     }
 
@@ -121,17 +123,6 @@ public class EventBuilder {
     public EventBuilder setTime(final Date date) {
        m_event.setTime(date);
        return this;
-    }
-    
-    /**
-     * <p>setCreationTime</p>
-     *
-     * @param date a {@link java.util.Date} object.
-     * @return a {@link org.opennms.netmgt.model.events.EventBuilder} object.
-     */
-    public EventBuilder setCreationTime(final Date date) {
-        m_event.setCreationTime(date);
-        return this;
     }
 
     /**

--- a/opennms-services/src/main/java/org/opennms/netmgt/scriptd/helper/AlarmEventSynchronization.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/scriptd/helper/AlarmEventSynchronization.java
@@ -94,6 +94,9 @@ public class AlarmEventSynchronization implements EventSynchronization {
 
         // alarm creation time
         if (alarm.getFirstEventTime() != null) {
+        	// TODO: This is incorrect. The creation time represents
+        	// the time that the event was stored in the database, not
+        	// the original timestamp of the event.
         	event.setCreationTime(alarm.getFirstEventTime());
         }
 

--- a/opennms-services/src/test/java/org/opennms/netmgt/poller/mock/MockPollContext.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/poller/mock/MockPollContext.java
@@ -118,7 +118,6 @@ public class MockPollContext implements PollContext, EventListener {
     @Override
     public Event createEvent(String uei, int nodeId, InetAddress address, String svcName, Date date, String reason) {
         EventBuilder e = MockEventUtil.createEventBuilder("Test", uei, nodeId, (address == null ? null : InetAddressUtils.str(address)), svcName, reason);
-        e.setCreationTime(date);
         e.setTime(date);
         return e.getEvent();
     }

--- a/smoke-test/src/test/java/org/opennms/smoketest/minion/SyslogTest.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/minion/SyslogTest.java
@@ -131,7 +131,9 @@ public class SyslogTest {
         // Parsing the message correctly relies on the customized syslogd-configuration.xml that is part of the OpenNMS image
         Criteria criteria = new CriteriaBuilder(OnmsEvent.class)
                 .eq("eventUei", "uei.opennms.org/vendor/cisco/syslog/SEC-6-IPACCESSLOGP/aclDeniedIPTraffic")
-                .ge("eventTime", startOfTest)
+                // eventCreateTime is the storage time of the event in the database so 
+                // it should be after the start of this test
+                .ge("eventCreateTime", startOfTest)
                 .toCriteria();
 
         await().atMost(1, MINUTES).pollInterval(5, SECONDS).until(DaoUtils.countMatchingCallable(eventDao, criteria), greaterThan(0));

--- a/tests/mock-elements/src/main/java/org/opennms/netmgt/mock/MockEventUtil.java
+++ b/tests/mock-elements/src/main/java/org/opennms/netmgt/mock/MockEventUtil.java
@@ -539,7 +539,6 @@ public abstract class MockEventUtil {
     public static EventBuilder createEventBuilder(String source, String uei) {
         EventBuilder builder = new EventBuilder(uei, source);
         Date currentTime = new Date();
-        builder.setCreationTime(currentTime);
         builder.setTime(currentTime);
         return builder;
     }


### PR DESCRIPTION
This partially addresses NMS-8755 so that events generated from traps and syslogs have timestamps that correspond to the time that the event was received.

* JIRA: http://issues.opennms.org/browse/NMS-8755
* Bamboo: http://bamboo.internal.opennms.com:8085/browse/OPENNMS-ONMS999