### PR TITLE
NMS-8779: Installer script doesn't work with PostgreSQL 9.6

### DIFF
--- a/core/schema/src/main/java/org/opennms/core/schema/Migrator.java
+++ b/core/schema/src/main/java/org/opennms/core/schema/Migrator.java
@@ -334,7 +334,7 @@ public class Migrator {
         try {
             c = m_adminDataSource.getConnection();
             st = c.createStatement();
-            st.execute("CREATE USER " + migration.getDatabaseUser() + " WITH PASSWORD '" + migration.getDatabasePassword() + "' CREATEDB CREATEUSER");
+            st.execute("CREATE USER " + migration.getDatabaseUser() + " WITH PASSWORD '" + migration.getDatabasePassword() + "'");
         } catch (final SQLException e) {
             throw new MigrationException("an error occurred creating the OpenNMS user", e);
         } finally {

--- a/pom.xml
+++ b/pom.xml
@@ -1374,7 +1374,7 @@
     <paxExamVersion>4.8.0</paxExamVersion>
     <paxSwissboxVersion>1.8.2</paxSwissboxVersion>
     <protobufVersion>2.6.1</protobufVersion>
-    <postgresqlVersion>9.4.1208</postgresqlVersion>
+    <postgresqlVersion>9.4.1211</postgresqlVersion>
     <powermockVersion>1.6.4</powermockVersion>
     <oroVersion>2.0.8</oroVersion>
     <osgiVersion>5.0.0</osgiVersion>


### PR DESCRIPTION
* JIRA: http://issues.opennms.org/browse/NMS-8779
* Bamboo: http://bamboo.internal.opennms.com:8085/browse/OPENNMS-ONMS1020

The "CREATE USER" statement used to have "CREATEDB CREATEUSER". CREATEUSER has to be replaced with CREATEROLE.

Now, neither of those flags are required for the opennms user because the database is created by the provided superuser, as you can see in the Migrator class. For this reason, they have been removed. OpenNMS works as expected.

The JDBC driver has been updated to avoid issues with the installer.