### PR TITLE
NMS-7106: If a target node is rebooted the RRD/JRB files contains spikes because the sysUpTime check is not working.

### DIFF
--- a/opennms-services/src/main/java/org/opennms/netmgt/threshd/ThresholdingVisitor.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/threshd/ThresholdingVisitor.java
@@ -85,8 +85,6 @@ public class ThresholdingVisitor extends AbstractCollectionSetVisitor {
 
 	private Date m_collectionTimestamp;
 
-	private boolean m_counterReset = false;
-
     /**
      * Static method create must be used to create new ThresholdingVisitor instance.
      * Is static because successful creation depends on thresholding-enabled parameter.
@@ -125,7 +123,7 @@ public class ThresholdingVisitor extends AbstractCollectionSetVisitor {
     }
     
     public void setCounterReset(boolean counterReset) {
-        m_counterReset = counterReset;
+        m_thresholdingSet.setCounterReset(counterReset);
     }
 
     public boolean hasThresholds() {


### PR DESCRIPTION
Maybe we should rename that issue because the sysUpTime detection was working. The problem is only related with thresholds.

* JIRA: http://issues.opennms.org/browse/NMS-7106
* Bamboo: http://bamboo.internal.opennms.com:8085/browse/OPENNMS-ONMS1021

The sysUpTime check was working, and that was preventing the persistence of the current collection-set if a restart was detected. This is crucial for avoiding spikes. Now, the counters cache was not reinitialized which is the reason of this change.

The fix was tested on my lab and it works as expected.