### PR TITLE
NMS-8786: Fixed a typo that prevented the JnxOpTemp graph to be displayed

### DIFF
--- a/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/juniper-graph.properties
+++ b/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/juniper-graph.properties
@@ -111,8 +111,8 @@ report.juniper.jnxOpTableTemp.command=--title="Juniper Temperature on {jnxOpDesc
  AREA:tempavg#fcaf3e \
  LINE1:tempavg#f57900:"Temperature " \
  GPRINT:tempavg:AVERAGE:" Avg  \\: %8.2lf %s" \
- GPRINT:tempmin:MIN:" Min  \\: %8.2lf %s" \
- GPRINT:tempmax:MAX:" Max  \\: %8.2lf %s\\n"
+ GPRINT:tempavg:MIN:" Min  \\: %8.2lf %s" \
+ GPRINT:tempavg:MAX:" Max  \\: %8.2lf %s\\n"
 
 report.juniper.bufferPoolUtil.name=Buffer Utilization (Juniper)
 report.juniper.bufferPoolUtil.columns=juniperBufferFeb,juniperBufferFpc0


### PR DESCRIPTION
* JIRA: http://issues.opennms.org/browse/NMS-8786
* Bamboo: Do not worry, we add a link to our continuous integration system here