### PR TITLE
NMS-8767: Revert Discovery behavior back to create non-provisioned nodes

### DIFF
--- a/features/discovery/src/main/java/org/opennms/netmgt/discovery/actors/RangeChunker.java
+++ b/features/discovery/src/main/java/org/opennms/netmgt/discovery/actors/RangeChunker.java
@@ -112,8 +112,12 @@ public class RangeChunker {
         final double packetsPerSecond = (config.getPacketsPerSecond() > 0.0) ? config.getPacketsPerSecond() : DiscoveryConfigFactory.DEFAULT_PACKETS_PER_SECOND;
 
         // If the foreign source for the discovery config is not set than use 
-        // the default foreign source
-        final String foreignSourceFromConfig = (config.getForeignSource() == null || "".equals(config.getForeignSource().trim())) ? "default" : config.getForeignSource().trim();
+        // a value of null so that non-requisitioned nodes are created.
+        //
+        // TODO: Use the "default" foreign source instead so that we can move
+        // away from using non-requisitioned nodes.
+        //
+        final String foreignSourceFromConfig = (config.getForeignSource() == null || "".equals(config.getForeignSource().trim())) ? null : config.getForeignSource().trim();
 
         // If the monitoring location for the discovery config is not set than use 
         // the default localhost location
@@ -193,8 +197,8 @@ public class RangeChunker {
         Preconditions.checkState(BigInteger.ONE.equals(address.getAddressRange().size()));
         return range != null && 
             new IPAddress(range.getAddressRange().getEnd()).isPredecessorOf(new IPAddress(address.getAddressRange().getEnd())) &&
-            range.getForeignSource().equals(address.getForeignSource()) &&
-            range.getLocation().equals(address.getLocation()) &&
+            Objects.equals(range.getForeignSource(), address.getForeignSource()) &&
+            Objects.equals(range.getLocation(), address.getLocation()) &&
             range.getRetries() == address.getRetries() &&
             range.getTimeout() == address.getTimeout();
     }

--- a/features/discovery/src/main/java/org/opennms/netmgt/discovery/messages/DiscoveryJob.java
+++ b/features/discovery/src/main/java/org/opennms/netmgt/discovery/messages/DiscoveryJob.java
@@ -67,7 +67,9 @@ public class DiscoveryJob implements Serializable {
      */
     public DiscoveryJob(List<IPPollRange> ranges, String foreignSource, String location, double packetsPerSecond) {
         m_ranges = Preconditions.checkNotNull(ranges, "ranges argument");
-        m_foreignSource = Preconditions.checkNotNull(foreignSource, "foreignSource argument");
+        // NMS-8767: Allow null foreignSources so that Provisiond will create non-provisioned nodes
+        //m_foreignSource = Preconditions.checkNotNull(foreignSource, "foreignSource argument");
+        m_foreignSource = foreignSource;
         m_location = Preconditions.checkNotNull(location, "location argument");
         m_packetsPerSecond = packetsPerSecond > 0.0 ? packetsPerSecond : DiscoveryConfigFactory.DEFAULT_PACKETS_PER_SECOND;
 

--- a/features/discovery/src/main/java/org/opennms/netmgt/discovery/messages/DiscoveryResults.java
+++ b/features/discovery/src/main/java/org/opennms/netmgt/discovery/messages/DiscoveryResults.java
@@ -43,7 +43,9 @@ public class DiscoveryResults implements Serializable {
 
     public DiscoveryResults(Map<InetAddress, Long> responses, String foreignSource, String location) {
         m_responses = Preconditions.checkNotNull(responses, "ranges argument");
-        m_foreignSource = Preconditions.checkNotNull(foreignSource, "foreignSource argument");
+        // NMS-8767: Allow null foreignSources so that Provisiond will create non-provisioned nodes
+        //m_foreignSource = Preconditions.checkNotNull(foreignSource, "foreignSource argument");
+        m_foreignSource = foreignSource;
         m_location = Preconditions.checkNotNull(location, "location argument");
     }
 


### PR DESCRIPTION
These changes allow Discovery to generate newSuspect events without foreignSource parameters so that non-provisioned nodes can be created. It will also include an upgrade script that will convert any nodes in the "default" requisition into non-provisioned nodes.

* JIRA: http://issues.opennms.org/browse/NMS-8767
* Bamboo: http://bamboo.internal.opennms.com:8085/browse/OPENNMS-ONMS1029
