### PR TITLE
NMS-8790: The search page for events is not working as expected

### DIFF
--- a/opennms-webapp/src/main/java/org/opennms/web/event/EventQueryServlet.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/event/EventQueryServlet.java
@@ -210,9 +210,9 @@ public class EventQueryServlet extends HttpServlet {
             Map<String, Object> paramAdditions = new HashMap<String, Object>();
             paramAdditions.put("filter", filterStrings);
 
-            queryString = WebSecurityUtils.sanitizeString(Util.makeQueryString(request, paramAdditions, IGNORE_LIST));
+            queryString = Util.makeQueryString(request, paramAdditions, IGNORE_LIST);
         } else {
-            queryString = WebSecurityUtils.sanitizeString(Util.makeQueryString(request, IGNORE_LIST));
+            queryString = Util.makeQueryString(request, IGNORE_LIST);
         }
 
         response.sendRedirect(redirectUrl + "?" + queryString);


### PR DESCRIPTION
The search page for events is not working as expected

* JIRA: http://issues.opennms.org/browse/NMS-8790
* Bamboo: Do not worry, we add a link to our continuous integration system here

The fix was verified on a VM running Meridian 2016.1.3