### PR TITLE
NMS-8796: replace all - in resource names to _.

### DIFF
--- a/opennms-services/src/main/java/org/opennms/netmgt/collectd/PersistRegexSelectorStrategy.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/collectd/PersistRegexSelectorStrategy.java
@@ -71,7 +71,7 @@ public class PersistRegexSelectorStrategy implements PersistenceSelectorStrategy
         @Override
         public void visitAttribute(CollectionAttribute attribute) {
             if (StringAttributeType.supportsType(attribute.getType()))
-                context.setVariable(attribute.getName(), attribute.getStringValue());
+                context.setVariable(attribute.getName().replace('-','_'), attribute.getStringValue());
         }
 
         public StandardEvaluationContext getEvaluationContext() {


### PR DESCRIPTION
NMS-8796: Fix PersistRegexSelectorStrategy by transforming all resource names when we add them to the context variable map.

This lets you use something like the following in a resourceType (where ns-dskPath is written as ns_dskPath):

``` xml
      <persistenceSelectorStrategy class="org.opennms.netmgt.collectd.PersistRegexSelectorStrategy">
        <parameter key="match-expression" value="not(#ns_dskPath matches '^(/dev/shm|/run|/sys/fs/cgroup|/tmp).*')" />
      </persistenceSelectorStrategy>
```
- JIRA: http://issues.opennms.org/browse/NMS-8796
- Bamboo: Do not worry, we add a link to our continuous integration system here
