### PR TITLE
NMS-8837: improve nb alarm mappings

### DIFF
--- a/opennms-alarms/api/src/main/java/org/opennms/netmgt/alarmd/api/support/AbstractNorthbounder.java
+++ b/opennms-alarms/api/src/main/java/org/opennms/netmgt/alarmd/api/support/AbstractNorthbounder.java
@@ -28,10 +28,24 @@
 
 package org.opennms.netmgt.alarmd.api.support;
 
+import java.io.Serializable;
+import java.io.StringWriter;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBElement;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Marshaller;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.namespace.QName;
+
+import org.opennms.core.utils.StringUtils;
 import org.opennms.netmgt.alarmd.api.NorthboundAlarm;
 import org.opennms.netmgt.alarmd.api.NorthboundAlarm.AlarmType;
 import org.opennms.netmgt.alarmd.api.NorthboundAlarm.x733ProbableCause;
@@ -71,7 +85,19 @@ public abstract class AbstractNorthbounder implements Northbounder, Runnable, St
 
     /** The retry interval. */
     private long m_retryInterval = 1000;
-
+    
+    //JAXBContexts are thread safe, but marshalers are not
+    /** JAXBContext for EventParms class */
+    private static JAXBContext ONMS_EVENT_PARM_CONTEXT = initOnmsEventParameterContext();
+    
+    private static JAXBContext initOnmsEventParameterContext() {
+        try {
+            return JAXBContext.newInstance(EventParms.class);
+        } catch (JAXBException e) {
+            throw new RuntimeException(e);
+        }
+    }
+    
     /**
      * Instantiates a new abstract northbounder.
      *
@@ -256,17 +282,22 @@ public abstract class AbstractNorthbounder implements Northbounder, Runnable, St
     protected Map<String, Object> createMapping(NorthboundAlarm alarm) {
         Map<String, Object> mapping;
         mapping = new HashMap<String, Object>();
-        mapping.put("ackUser", alarm.getAckUser());
-        mapping.put("appDn", alarm.getAppDn());
-        mapping.put("logMsg", alarm.getLogMsg());
-        mapping.put("description", alarm.getDesc());
-        mapping.put("objectInstance", alarm.getObjectInstance());
-        mapping.put("objectType", alarm.getObjectType());
-        mapping.put("ossKey", alarm.getOssKey());
-        mapping.put("ossState", alarm.getOssState());
-        mapping.put("ticketId", alarm.getTicketId());
-        mapping.put("alarmUei", alarm.getUei());
-        mapping.put("ackTime", nullSafeToString(alarm.getAckTime(), ""));
+        String defaultMapping = "";
+        mapping.put("ackUser", nullSafeToString(alarm.getAckUser(), defaultMapping));
+        mapping.put("appDn", nullSafeToString(alarm.getAppDn(), defaultMapping));
+        mapping.put("logMsg", nullSafeToString(alarm.getLogMsg(), defaultMapping));
+        mapping.put("description", nullSafeToString(alarm.getDesc(), defaultMapping));
+        mapping.put("objectInstance", nullSafeToString(alarm.getObjectInstance(), defaultMapping));
+        mapping.put("objectType", nullSafeToString(alarm.getObjectType(), defaultMapping));
+        mapping.put("ossKey", nullSafeToString(alarm.getOssKey(),defaultMapping));
+        mapping.put("ossState", nullSafeToString(alarm.getOssState(), defaultMapping));
+        mapping.put("ticketId", nullSafeToString(alarm.getTicketId(), defaultMapping));
+        mapping.put("ticketState", nullSafeToString(alarm.getTicketState(), defaultMapping));
+        mapping.put("alarmUei", nullSafeToString(alarm.getUei(), defaultMapping));
+        mapping.put("alarmKey", nullSafeToString(alarm.getAlarmKey(), defaultMapping));
+        mapping.put("clearKey", nullSafeToString(alarm.getClearKey(), defaultMapping));
+        mapping.put("operInstruct", nullSafeToString(alarm.getOperInst(), defaultMapping));
+        mapping.put("ackTime", nullSafeToString(alarm.getAckTime(), defaultMapping));
 
         AlarmType alarmType = alarm.getAlarmType() == null ? AlarmType.NOTIFICATION : alarm.getAlarmType();
         mapping.put("alarmType", alarmType.name());
@@ -274,10 +305,10 @@ public abstract class AbstractNorthbounder implements Northbounder, Runnable, St
         String count = alarm.getCount() == null ? "1" : alarm.getCount().toString();
         mapping.put("count", count);
 
-        mapping.put("firstOccurrence", nullSafeToString(alarm.getFirstOccurrence(), ""));
+        mapping.put("firstOccurrence", nullSafeIso8601String(alarm.getFirstOccurrence(), defaultMapping));
         mapping.put("alarmId", alarm.getId().toString());
-        mapping.put("ipAddr", nullSafeToString(alarm.getIpAddr(), ""));
-        mapping.put("lastOccurrence", nullSafeToString(alarm.getLastOccurrence(), ""));
+        mapping.put("ipAddr", nullSafeToString(alarm.getIpAddr(), defaultMapping));
+        mapping.put("lastOccurrence", nullSafeIso8601String(alarm.getLastOccurrence(), defaultMapping));
 
         if (alarm.getNodeId() != null) {
             LOG.debug("Adding nodeId: " + alarm.getNodeId().toString());
@@ -300,19 +331,20 @@ public abstract class AbstractNorthbounder implements Northbounder, Runnable, St
         String service = alarm.getService() == null ? "" : alarm.getService();
         mapping.put("ifService", service);
 
-        mapping.put("severity", nullSafeToString(alarm.getSeverity(), ""));
-        mapping.put("ticketState", nullSafeToString(alarm.getTicketState(), ""));
+        mapping.put("severity", nullSafeToString(alarm.getSeverity(), defaultMapping));
+        mapping.put("ticketState", nullSafeToString(alarm.getTicketState(), defaultMapping));
 
-        mapping.put("x733AlarmType", alarm.getX733Type());
+        mapping.put("x733AlarmType", nullSafeToString(alarm.getX733Type(), defaultMapping));
         try {
-            mapping.put("x733ProbableCause", nullSafeToString(x733ProbableCause.get(alarm.getX733Cause()), ""));
+            mapping.put("x733ProbableCause", nullSafeToString(x733ProbableCause.get(alarm.getX733Cause()), defaultMapping));
         } catch (Exception e) {
             LOG.info("Exception caught setting X733 Cause: {}", alarm.getX733Cause(), e);
-            mapping.put("x733ProbableCause", nullSafeToString(x733ProbableCause.other, ""));
+            mapping.put("x733ProbableCause", nullSafeToString(x733ProbableCause.other, defaultMapping));
         }
 
         buildParmMappings(alarm, mapping);
-
+        // Get all event parms serialized to XML
+        buildParmMappingXml(alarm, mapping);
         return mapping;
     }
 
@@ -329,7 +361,14 @@ public abstract class AbstractNorthbounder implements Northbounder, Runnable, St
         }
         return defaultString;
     }
-
+    
+    private String nullSafeIso8601String(Date d, String defaultString) {
+        if(d != null) {
+            defaultString = StringUtils.iso8601LocalOffsetString(d);
+        }
+        return defaultString;
+    }
+    
     /**
      * Builds the parameters mappings.
      *
@@ -348,5 +387,50 @@ public abstract class AbstractNorthbounder implements Northbounder, Runnable, St
             parmOffset++;
         }
     }
-
+    
+    /**
+     * Builds an XML representation of parameter mappings.
+     * @param alarm the alarm
+     * @param mapping the mapping
+     */
+    private void buildParmMappingXml(final NorthboundAlarm alarm,
+            final Map<String, Object> mapping) {
+        List<OnmsEventParameter> parms = alarm.getEventParametersCollection();
+        EventParms eventParms = new EventParms(parms);
+        try {
+            JAXBElement<EventParms> rootElement = new JAXBElement<EventParms>(new QName("eventParms"), EventParms.class, eventParms);
+            StringWriter sw = new StringWriter();
+            Marshaller marshaller = ONMS_EVENT_PARM_CONTEXT.createMarshaller();
+            marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
+            marshaller.setProperty(Marshaller.JAXB_FRAGMENT, true);
+            marshaller.marshal(rootElement, sw);
+            LOG.debug("Adding eventParmsXML mapping with contents {}.", sw);
+            mapping.put("eventParmsXml", sw);
+        } catch (JAXBException e) {
+            LOG.error("Error marshalling event params to XML for alarm ID: {}", alarm.getId(), e);
+        }
+    }
+    
+    /**
+     * wraps a list of OnmsEventParameters for XML serialization purposes
+     * @author <a href="mailto:dschlenk@convergeone.com">David Schlenk</a>
+     *
+     */
+    @XmlRootElement(name="eventParms")
+    private static class EventParms implements Serializable {
+        public EventParms () {
+            super();
+        }
+        private List<OnmsEventParameter> m_eventParm = new ArrayList<OnmsEventParameter>();
+        
+        public EventParms(List<OnmsEventParameter> eventParm) {
+            this.m_eventParm = eventParm;
+        }
+        public List<OnmsEventParameter> getParm(){
+            return m_eventParm;
+        }
+        public void setParm(List<OnmsEventParameter> parms){
+            m_eventParm = parms;
+        }
+    }
 }

--- a/opennms-alarms/jms-northbounder/pom.xml
+++ b/opennms-alarms/jms-northbounder/pom.xml
@@ -89,5 +89,10 @@
       <artifactId>org.opennms.core.test-api.services</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+    	<groupId>org.opennms.core.test-api</groupId>
+    	<artifactId>org.opennms.core.test-api.xml</artifactId>
+    	<scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/opennms-alarms/jms-northbounder/src/test/java/org/opennms/netmgmt/alarmd/northbounder/jms/JmsNorthBounderTest.java
+++ b/opennms-alarms/jms-northbounder/src/test/java/org/opennms/netmgmt/alarmd/northbounder/jms/JmsNorthBounderTest.java
@@ -29,6 +29,8 @@
 package org.opennms.netmgmt.alarmd.northbounder.jms;
 
 import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Date;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
@@ -45,6 +47,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.opennms.core.test.MockLogAppender;
 import org.opennms.core.test.OpenNMSJUnit4ClassRunner;
+import org.opennms.core.utils.StringUtils;
 import org.opennms.netmgt.alarmd.api.NorthboundAlarm;
 import org.opennms.netmgt.alarmd.northbounder.jms.JmsDestination;
 import org.opennms.netmgt.alarmd.northbounder.jms.JmsNorthbounder;
@@ -53,6 +56,7 @@ import org.opennms.netmgt.alarmd.northbounder.jms.JmsNorthbounderConfigDao;
 import org.opennms.netmgt.dao.mock.MockMonitoringLocationDao;
 import org.opennms.netmgt.dao.mock.MockNodeDao;
 import org.opennms.netmgt.model.OnmsAlarm;
+import org.opennms.netmgt.model.OnmsEvent;
 import org.opennms.netmgt.model.OnmsIpInterface;
 import org.opennms.netmgt.model.OnmsNode;
 import org.opennms.netmgt.model.OnmsSnmpInterface;
@@ -232,7 +236,192 @@ public class JmsNorthBounderTest {
             i++;
         }
     }
+    @Test
+    public void testAlarmMappingNoParams() throws Exception {
+        String xml = generateMappingConfigXml();
 
+        Resource resource = new ByteArrayResource(xml.getBytes());
+
+        JmsNorthbounderConfigDao dao = new JmsNorthbounderConfigDao();
+        dao.setConfigResource(resource);
+        dao.afterPropertiesSet();
+
+        JmsNorthbounderConfig config = dao.getConfig();
+
+        List<JmsDestination> destinations = config.getDestinations();
+
+        List<JmsNorthbounder> nbis = new LinkedList<JmsNorthbounder>();
+
+        for (JmsDestination jmsDestination : destinations) {
+            JmsNorthbounder nbi = new JmsNorthbounder(
+                                                      config,
+                                                      m_jmsNorthbounderConnectionFactory,
+                                                      jmsDestination);
+            nbi.afterPropertiesSet();
+            nbis.add(nbi);
+        }
+
+        List<NorthboundAlarm> alarms = new LinkedList<NorthboundAlarm>();
+        OnmsNode node = new OnmsNode(null, NODE_LABEL);
+        node.setForeignSource("TestGroup");
+        node.setForeignId("2");
+        node.setId(m_nodeDao.getNextNodeId());
+        OnmsIpInterface ip = new OnmsIpInterface("127.0.0.1", node);
+        InetAddress ia = null;
+        try {
+            ia = InetAddress.getByName("127.0.0.1");
+        } catch (UnknownHostException e){ }
+        m_nodeDao.save(node);
+        m_nodeDao.flush();
+        // TX via NBIs
+        for (JmsNorthbounder nbi : nbis) {
+            OnmsEvent event = new OnmsEvent(5, "uei.uei.org/uei", new Date(),
+                "eventhost", "eventsource", ia,
+                null, "eventssnmphost", null,
+                "eventsnmp", null, new Date(),
+                "eventdescr", "eventloggroup", "eventlogmsg",
+                4, null, null,
+                0, "operinstruct",
+                null, null,
+                null, null,
+                "tticketid", 1,
+                null, null, null,
+                null, null, null,
+                null, node,
+                null, null,
+                null);
+            OnmsAlarm alarm = new OnmsAlarm(9, event.getEventUei(), null, 1, 4, new Date(), event);
+            alarm.setNode(node);
+            alarm.setDescription(event.getEventDescr());
+            alarm.setApplicationDN("applicationDN");
+            alarm.setLogMsg(event.getEventLogMsg());
+            alarm.setManagedObjectInstance("managedObjectInstance");
+            alarm.setManagedObjectType("managedObjectType");
+            alarm.setOssPrimaryKey("ossPrimaryKey");
+            alarm.setQosAlarmState("qosAlarmState");
+            alarm.setTTicketId("tticketId");
+            alarm.setReductionKey("reductionKey");
+            alarm.setClearKey("clearKey");
+            alarm.setOperInstruct("operInstruct");
+            alarm.setAlarmType(1);
+            alarm.setFirstEventTime(new Date(0));
+            alarm.setIpAddr(ia);
+            alarm.setX733AlarmType(NorthboundAlarm.x733AlarmType.get(1).name());
+            alarm.setX733ProbableCause(NorthboundAlarm.x733ProbableCause.get(1).getId());
+            NorthboundAlarm a = new NorthboundAlarm(alarm);
+            alarms.add(a);
+            nbi.forwardAlarms(alarms);
+        }
+
+        Thread.sleep(100);
+
+        // Let's become a consumer and receive the message
+        Message m = m_template.receive("MappingTestQueue");
+        String escapedResponse = "ackUser:  appDn: applicationDN logMsg: eventlogmsg objectInstance: managedObjectInstance objectType: managedObjectType ossKey: ossPrimaryKey\n" +
+                " ossState: qosAlarmState ticketId: tticketId alarmUei: uei.uei.org/uei alarmKey: reductionKey clearKey: clearKey description: eventdescr operInstruct: operInstruct ackTime: \n" +
+                " alarmType: PROBLEM count: 1 alarmId: 9 ipAddr: 127.0.0.1 lastOccurrence:  nodeId: 1\n" +
+                " nodeLabel: schlazor distPoller: 00000000-0000-0000-0000-000000000000 ifService:  severity: WARNING ticketState:  x733AlarmType: other\n"+
+                " x733ProbableCause: other firstOccurrence: " + StringUtils.iso8601LocalOffsetString(new Date(0)) + " lastOccurrence  eventParmsXml: <eventParms/>";
+        String response = ((TextMessage)m).getText();
+        Assert.assertEquals("Contents of message\n'" + response + "'\n not equals\n'" + escapedResponse+"'.", response, escapedResponse);
+    }
+    @Test
+    public void testAlarmMappings() throws Exception {
+        String xml = generateMappingConfigXml();
+
+        Resource resource = new ByteArrayResource(xml.getBytes());
+
+        JmsNorthbounderConfigDao dao = new JmsNorthbounderConfigDao();
+        dao.setConfigResource(resource);
+        dao.afterPropertiesSet();
+
+        JmsNorthbounderConfig config = dao.getConfig();
+
+        List<JmsDestination> destinations = config.getDestinations();
+
+        List<JmsNorthbounder> nbis = new LinkedList<JmsNorthbounder>();
+
+        for (JmsDestination jmsDestination : destinations) {
+            JmsNorthbounder nbi = new JmsNorthbounder(
+                                                      config,
+                                                      m_jmsNorthbounderConnectionFactory,
+                                                      jmsDestination);
+            nbi.afterPropertiesSet();
+            nbis.add(nbi);
+        }
+
+        List<NorthboundAlarm> alarms = new LinkedList<NorthboundAlarm>();
+        OnmsNode node = new OnmsNode(null, NODE_LABEL);
+        node.setForeignSource("TestGroup");
+        node.setForeignId("2");
+        node.setId(m_nodeDao.getNextNodeId());
+        OnmsIpInterface ip = new OnmsIpInterface("127.0.0.1", node);
+        InetAddress ia = null;
+        try {
+            ia = InetAddress.getByName("127.0.0.1");
+        } catch (UnknownHostException e){ }
+        m_nodeDao.save(node);
+        m_nodeDao.flush();
+        // TX via NBIs
+        for (JmsNorthbounder nbi : nbis) {
+            String eventparms = "syslogmessage=Dec 22 2015 20:12:57.1 UTC :  %UC_CTI-3-CtiProviderOpenFailure: %[CTIconnectionId%61232238][ Login User Id%61pguser][Reason code.%61-1932787616][UNKNOWN_PARAMNAME:IPAddress%61172.17.12.73][UNKNOWN_PARAMNAME:IPv6Address%61][App ID%61Cisco CTIManager][Cluster ID%61SplkCluster][Node ID%61splkcucm6p]: CTI application failed to open provider%59 application startup failed(string,text);severity=Error(string,text);timestamp=Dec 22 14:13:21(string,text);process=229250(string,text);service=local7(string,text)";
+            OnmsEvent event = new OnmsEvent(5, "uei.uei.org/uei", new Date(),
+                "eventhost", "eventsource", ia,
+                null, "eventssnmphost", null,
+                "eventsnmp", eventparms, new Date(),
+                "eventdescr", "eventloggroup", "eventlogmsg",
+                4, null, null,
+                0, "operinstruct",
+                null, null,
+                null, null,
+                "tticketid", 1,
+                null, null, null,
+                null, null, null,
+                null, node,
+                null, null,
+                null);
+            OnmsAlarm alarm = new OnmsAlarm(9, event.getEventUei(), null, 1, 4, new Date(), event);
+            alarm.setNode(node);
+            alarm.setDescription(event.getEventDescr());
+            alarm.setApplicationDN("applicationDN");
+            alarm.setLogMsg(event.getEventLogMsg());
+            alarm.setManagedObjectInstance("managedObjectInstance");
+            alarm.setManagedObjectType("managedObjectType");
+            alarm.setOssPrimaryKey("ossPrimaryKey");
+            alarm.setQosAlarmState("qosAlarmState");
+            alarm.setTTicketId("tticketId");
+            alarm.setReductionKey("reductionKey");
+            alarm.setClearKey("clearKey");
+            alarm.setOperInstruct("operInstruct");
+            alarm.setAlarmType(1);
+            alarm.setFirstEventTime(new Date(0));
+            alarm.setIpAddr(ia);
+            alarm.setEventParms(eventparms);
+            alarm.setX733AlarmType(NorthboundAlarm.x733AlarmType.get(1).name());
+            alarm.setX733ProbableCause(NorthboundAlarm.x733ProbableCause.get(1).getId());
+            NorthboundAlarm a = new NorthboundAlarm(alarm);
+            alarms.add(a);
+            nbi.forwardAlarms(alarms);
+        }
+
+        Thread.sleep(100);
+
+        // Let's become a consumer and receive the message
+        Message m = m_template.receive("MappingTestQueue");
+        String escapedResponse = "ackUser:  appDn: applicationDN logMsg: eventlogmsg objectInstance: managedObjectInstance objectType: managedObjectType ossKey: ossPrimaryKey\n" +
+                " ossState: qosAlarmState ticketId: tticketId alarmUei: uei.uei.org/uei alarmKey: reductionKey clearKey: clearKey description: eventdescr operInstruct: operInstruct ackTime: \n" +
+                " alarmType: PROBLEM count: 1 alarmId: 9 ipAddr: 127.0.0.1 lastOccurrence:  nodeId: 1\n" +
+                " nodeLabel: schlazor distPoller: 00000000-0000-0000-0000-000000000000 ifService:  severity: WARNING ticketState:  x733AlarmType: other\n"+
+                " x733ProbableCause: other firstOccurrence: " + StringUtils.iso8601LocalOffsetString(new Date(0)) + " lastOccurrence  eventParmsXml: <eventParms>\n" +
+                "    <parm name=\"syslogmessage\" value=\"Dec 22 2015 20:12:57.1 UTC :  %UC_CTI-3-CtiProviderOpenFailure: %[CTIconnectionId%61232238][ Login User Id%61pguser][Reason code.%61-1932787616][UNKNOWN_PARAMNAME:IPAddress%61172.17.12.73][UNKNOWN_PARAMNAME:IPv6Address%61][App ID%61Cisco CTIManager][Cluster ID%61SplkCluster][Node ID%61splkcucm6p]: CTI application failed to open provider%59 application startup failed\" type=\"string\"/>\n" +
+                "    <parm name=\"severity\" value=\"Error\" type=\"string\"/>\n" +
+                "    <parm name=\"timestamp\" value=\"Dec 22 14:13:21\" type=\"string\"/>\n" +
+                "    <parm name=\"process\" value=\"229250\" type=\"string\"/>\n" +
+                "    <parm name=\"service\" value=\"local7\" type=\"string\"/>\n" +
+                "</eventParms>";
+        String response = ((TextMessage)m).getText();
+        Assert.assertEquals("Contents of message\n'" + response + "'\n not equals\n'" + escapedResponse+"'.", response, escapedResponse);
+    }
     /**
      * Generate configuration XML.
      *
@@ -254,6 +443,26 @@ public class JmsNorthBounderTest {
                 + "   </destination>\n"
                 + "   <uei>uei.opennms.org/nodes/nodeDown</uei>\n"
                 + "   <uei>uei.opennms.org/nodes/nodeUp</uei>\n"
+                + "</jms-northbounder-config>\n" + "";
+    }
+    
+    private String generateMappingConfigXml() {
+        return "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n"
+                + "<jms-northbounder-config>\n"
+                + "  <enabled>true</enabled>\n"
+                + "  <nagles-delay>1000</nagles-delay>\n"
+                + "  <batch-size>30</batch-size>\n"
+                + "  <queue-size>30000</queue-size>\n"
+                + "  <message-format>ackUser: ${ackUser} appDn: ${appDn} logMsg: ${logMsg} objectInstance: ${objectInstance} objectType: ${objectType} ossKey: ${ossKey}\n"
+                + " ossState: ${ossState} ticketId: ${ticketId} alarmUei: ${alarmUei} alarmKey: ${alarmKey} clearKey: ${clearKey} description: ${description} operInstruct: ${operInstruct} ackTime: ${ackTime}\n"
+                + " alarmType: ${alarmType} count: ${count} alarmId: ${alarmId} ipAddr: ${ipAddr} lastOccurrence: ${lastOccurrence} nodeId: ${nodeId}\n"
+                + " nodeLabel: ${nodeLabel} distPoller: ${distPoller} ifService: ${ifService} severity: ${severity} ticketState: ${ticketState} x733AlarmType: ${x733AlarmType}\n"
+                + " x733ProbableCause: ${x733ProbableCause} firstOccurrence: ${firstOccurrence} lastOccurrence ${lastOccurrence} eventParmsXml: ${eventParmsXml}</message-format>\n"
+                + "  <destination>\n"
+                + "    <jms-destination>MappingTestQueue</jms-destination>\n"
+                + "    <send-as-object-message>false</send-as-object-message>\n"
+                + "    <first-occurence-only>false</first-occurence-only>"
+                + "   </destination>\n"
                 + "</jms-northbounder-config>\n" + "";
     }
 }


### PR DESCRIPTION
Some fields of NorthboundAlarm that are interesting to us are not currently available for replacement. Furthermore, Date fields are currently being converted to string via Date.toString(), which is less than ideal and especially annoying when you aren't sure of the timezone of the JVM in which OpenNMS is running.

This PR depends on/includes the patches re: ISO-8601 strings in #1084 / HZN-924. 
- JIRA: http://issues.opennms.org/browse/NMS-8837
- Bamboo: http://bamboo.internal.opennms.com:8085/browse/OPENNMS-ONMS1073
