### PR TITLE
NMS-8838: fix ability to skip ping tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1204,8 +1204,8 @@
     <!--
       This is on by default now that root is not required for pinging.
       If you have issues with this, see https://wiki.opennms.org/wiki/ICMP for enabling non-root ping.
-    -->
-    <runPingTests>true</runPingTests>
+      However, we need to set the default in a profile (NMS-8838).
+    <runPingTests>true</runPingTests> -->
 
     <build.skip.tarball>false</build.skip.tarball>
 
@@ -1563,6 +1563,17 @@
           </plugin>
         </plugins>
       </build>
+    </profile>
+    <profile>
+      <id>default-runPingTests</id>
+      <activation>
+        <property>
+          <name>!runPingTests</name>
+        </property>
+      </activation>
+      <properties>
+        <runPingTests>true</runPingTests>
+      </properties>
     </profile>
   </profiles>
   <dependencyManagement>


### PR DESCRIPTION
For reasons I don't understand, maven's not respecting MAVEN_OPTS when the property is specified in a parent POM. The workaround is to only set it to a default value when it isn't defined in MAVEN_OPTS using a profile.

* JIRA: http://issues.opennms.org/browse/NMS-8838
* Bamboo: Do not worry, we add a link to our continuous integration system here