### PR TITLE
NMS-8846: update ticket ID and state via REST

### DIFF
--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/AlarmRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/AlarmRestService.java
@@ -44,6 +44,8 @@ import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.SecurityContext;
 import javax.ws.rs.core.UriInfo;
 
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.EnumUtils;
 import org.opennms.core.criteria.CriteriaBuilder;
 import org.opennms.netmgt.dao.api.AcknowledgmentDao;
 import org.opennms.netmgt.dao.api.AlarmDao;
@@ -51,6 +53,7 @@ import org.opennms.netmgt.model.AckAction;
 import org.opennms.netmgt.model.OnmsAcknowledgment;
 import org.opennms.netmgt.model.OnmsAlarm;
 import org.opennms.netmgt.model.OnmsAlarmCollection;
+import org.opennms.netmgt.model.TroubleTicketState;
 import org.opennms.netmgt.model.alarm.AlarmSummary;
 import org.opennms.netmgt.model.alarm.AlarmSummaryCollection;
 import org.opennms.web.api.Authentication;
@@ -149,6 +152,7 @@ public class AlarmRestService extends AlarmRestServiceBase {
         writeLock();
 
         try {
+            boolean isProcessAck = true;
             if (alarmId == null) {
                 return getBadRequestResponse("Unable to determine alarm ID to update based on query path.");
             }
@@ -161,7 +165,10 @@ public class AlarmRestService extends AlarmRestServiceBase {
             formProperties.remove("clear");
             final String ackUserValue = formProperties.getFirst("ackUser");
             formProperties.remove("ackUser");
-
+            final String ticketIdValue = formProperties.getFirst("ticketId");
+            formProperties.remove("ticketId");
+            final String ticketStateValue = formProperties.getFirst("ticketState");
+            formProperties.remove("ticketState");
             final OnmsAlarm alarm = m_alarmDao.get(alarmId);
             if (alarm == null) {
                 return getBadRequestResponse("Unable to locate alarm with ID '" + alarmId + "'");
@@ -186,10 +193,20 @@ public class AlarmRestService extends AlarmRestServiceBase {
                 if (Boolean.parseBoolean(clearValue)) {
                     acknowledgement.setAckAction(AckAction.CLEAR);
                 }
+            } else if (StringUtils.isNotBlank(ticketIdValue)) {
+                isProcessAck = false;
+                alarm.setTTicketId(ticketIdValue);
+            } else if (EnumUtils.isValidEnum(TroubleTicketState.class, ticketStateValue)) {
+                isProcessAck = false;
+                alarm.setTTicketState(TroubleTicketState.valueOf(ticketStateValue));
             } else {
                 return getBadRequestResponse("Must supply one of the 'ack', 'escalate', or 'clear' parameters, set to either 'true' or 'false'.");
             }
-            m_ackDao.processAck(acknowledgement);
+            if (isProcessAck) {
+                m_ackDao.processAck(acknowledgement);
+            } else {
+                m_alarmDao.saveOrUpdate(alarm);
+            }
             return Response.noContent().build();
         } finally {
             writeUnlock();

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/AlarmRestServiceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/AlarmRestServiceIT.java
@@ -229,6 +229,14 @@ public class AlarmRestServiceIT extends AbstractSpringJerseyRestTestCase {
         xml = sendRequest(GET, "/alarms/" + alarmId, 200);
         assertTrue(xml.contains("severity=\"NORMAL\""));
 
+        sendPut("/alarms/" + alarmId, "ticketId=12345", 204);
+        xml = sendRequest(GET, "/alarms/" + alarmId, 200);
+        assertTrue(xml.contains("<troubleTicket>12345</troubleTicket>"));
+
+        sendPut("/alarms/" + alarmId, "ticketState=UPDATE_PENDING", 204);
+        xml = sendRequest(GET, "/alarms/" + alarmId, 200);
+        sendPut("/alarms/" + alarmId, "ticketState=UPDATE_PENDING", 204);
+
         alarm = getLastAlarm();
         alarm.setSeverity(OnmsSeverity.MAJOR);
         alarm.setAlarmAckTime(null);


### PR DESCRIPTION
tiny patch that lets us set ticket ID and state on an alarm via REST. (Full use case: emit alarms via the JMS NBI that get processed into tickets, then use this to make a poor (wo)man's bidirectional ticket integration)
- JIRA: http://issues.opennms.org/browse/NMS-8846
- Bamboo: http://bamboo.internal.opennms.com:8085/browse/OPENNMS-ONMS1072-1