### PR TITLE
HZN-926: Deprecate the getAgentConfig without location

### DIFF
--- a/core/snmp/commands/src/main/java/org/opennms/netmgt/snmp/commands/WalkCommand.java
+++ b/core/snmp/commands/src/main/java/org/opennms/netmgt/snmp/commands/WalkCommand.java
@@ -71,7 +71,7 @@ public class WalkCommand extends OsgiCommandSupport {
         final List<SnmpObjId> snmpObjIds = m_oids.stream()
                     .map(oid -> SnmpObjId.get(oid))
                     .collect(Collectors.toList());
-        final SnmpAgentConfig agent = snmpAgentConfigFactory.getAgentConfig(InetAddress.getByName(m_host));
+        final SnmpAgentConfig agent = snmpAgentConfigFactory.getAgentConfig(InetAddress.getByName(m_host), m_location);
         final CompletableFuture<List<SnmpResult>> future = locationAwareSnmpClient.walk(agent, snmpObjIds)
             .withDescription("snmp:walk")
             .withLocation(m_location)

--- a/features/nrtg/web/src/main/java/org/opennms/nrtg/web/internal/NrtController.java
+++ b/features/nrtg/web/src/main/java/org/opennms/nrtg/web/internal/NrtController.java
@@ -54,6 +54,7 @@ import org.opennms.netmgt.model.OnmsResource;
 import org.opennms.netmgt.model.PrefabGraph;
 import org.opennms.netmgt.model.ResourcePath;
 import org.opennms.netmgt.model.RrdGraphAttribute;
+import org.opennms.netmgt.model.monitoringLocations.OnmsMonitoringLocation;
 import org.opennms.netmgt.snmp.SnmpAgentConfig;
 import org.opennms.nrtg.api.NrtBroker;
 import org.opennms.nrtg.api.model.CollectionJob;
@@ -254,7 +255,9 @@ public class NrtController {
             //I know....
             if (protocol.equals("SNMP") || protocol.equals("TCA")) {
                 collectionJob.setNetInterface(protocol);
-                final SnmpAgentConfig snmpAgentConfig = m_snmpAgentConfigFactory.getAgentConfig(node.getPrimaryInterface().getIpAddress());
+                OnmsMonitoringLocation location = node.getLocation();
+                String locationName = (location == null) ? null : location.getLocationName();
+                final SnmpAgentConfig snmpAgentConfig = m_snmpAgentConfigFactory.getAgentConfig(node.getPrimaryInterface().getIpAddress(), locationName);
                 collectionJob.setProtocolConfiguration(snmpAgentConfig.toProtocolConfigString());
                 collectionJob.setNetInterface(node.getPrimaryInterface().getIpAddress().getHostAddress());
                 collectionJobs.add(collectionJob);

--- a/integrations/opennms-snmp-asset-provisioning-adapter/src/main/java/org/opennms/netmgt/provision/SnmpAssetProvisioningAdapter.java
+++ b/integrations/opennms-snmp-asset-provisioning-adapter/src/main/java/org/opennms/netmgt/provision/SnmpAssetProvisioningAdapter.java
@@ -141,9 +141,8 @@ public class SnmpAssetProvisioningAdapter extends SimplerQueuedProvisioningAdapt
 		});
 
 		SnmpAgentConfig agentConfig = null;
-		agentConfig = m_snmpConfigDao.getAgentConfig(ipaddress);
-
-		String locationName = node.getLocation() != null ? node.getLocation().getLocationName() : null;
+        String locationName = node.getLocation() != null ? node.getLocation().getLocationName() : null;
+        agentConfig = m_snmpConfigDao.getAgentConfig(ipaddress, locationName);
 
 		final OnmsAssetRecord asset = node.getAssetRecord();
 		m_config.getReadLock().lock();
@@ -266,9 +265,9 @@ public class SnmpAssetProvisioningAdapter extends SimplerQueuedProvisioningAdapt
 			}
 		});
 
-		final SnmpAgentConfig agentConfig = m_snmpConfigDao.getAgentConfig(ipaddress);
 
-		final String locationName = node.getLocation() != null ? node.getLocation().getLocationName() : null;
+        final String locationName = node.getLocation() != null ? node.getLocation().getLocationName() : null;
+        final SnmpAgentConfig agentConfig = m_snmpConfigDao.getAgentConfig(ipaddress, locationName);
 
 		final OnmsAssetRecord asset = node.getAssetRecord();
 		m_config.getReadLock().lock();

--- a/integrations/opennms-snmp-hardware-inventory-provisioning-adapter/src/main/java/org/opennms/netmgt/provision/SnmpHardwareInventoryProvisioningAdapter.java
+++ b/integrations/opennms-snmp-hardware-inventory-provisioning-adapter/src/main/java/org/opennms/netmgt/provision/SnmpHardwareInventoryProvisioningAdapter.java
@@ -52,6 +52,7 @@ import org.opennms.netmgt.model.OnmsHwEntity;
 import org.opennms.netmgt.model.OnmsIpInterface;
 import org.opennms.netmgt.model.OnmsNode;
 import org.opennms.netmgt.model.events.EventBuilder;
+import org.opennms.netmgt.model.monitoringLocations.OnmsMonitoringLocation;
 import org.opennms.netmgt.provision.snmp.EntityPhysicalTableRow;
 import org.opennms.netmgt.provision.snmp.EntityPhysicalTableTracker;
 import org.opennms.netmgt.snmp.SnmpAgentConfig;
@@ -172,7 +173,9 @@ public class SnmpHardwareInventoryProvisioningAdapter extends SimplerQueuedProvi
                 LOG.warn("Skiping hardware discover because the node {} doesn't support SNMP", nodeId);
                 return;
             }
-            SnmpAgentConfig agentConfig = m_snmpConfigDao.getAgentConfig(ipAddress);
+            OnmsMonitoringLocation location = node.getLocation();
+            String locationName = (location == null) ? null : location.getLocationName();
+            SnmpAgentConfig agentConfig = m_snmpConfigDao.getAgentConfig(ipAddress, locationName);
             final OnmsHwEntity newRoot = getRootEntity(agentConfig, node);
             newRoot.setNode(node);
             final OnmsHwEntity currentRoot = m_hwEntityDao.findRootByNodeId(node.getId());

--- a/opennms-config-api/src/main/java/org/opennms/netmgt/config/api/SnmpAgentConfigFactory.java
+++ b/opennms-config-api/src/main/java/org/opennms/netmgt/config/api/SnmpAgentConfigFactory.java
@@ -37,9 +37,8 @@ public interface SnmpAgentConfigFactory {
      * <p>getAgentConfig</p>
      *
      * @param address a {@link java.net.InetAddress} object.
+     * @param location a {@link java.lang.String} object.
      * @return a {@link org.opennms.netmgt.snmp.SnmpAgentConfig} object.
      */
-    public SnmpAgentConfig getAgentConfig(InetAddress address);
-
     public SnmpAgentConfig getAgentConfig(InetAddress address, String location);
 }

--- a/opennms-provision/opennms-detector-simple/src/test/java/org/opennms/netmgt/provision/detector/AnAgentConfigFactory.java
+++ b/opennms-provision/opennms-detector-simple/src/test/java/org/opennms/netmgt/provision/detector/AnAgentConfigFactory.java
@@ -40,20 +40,14 @@ import org.opennms.netmgt.snmp.SnmpAgentConfig;
  */
 public class AnAgentConfigFactory implements SnmpAgentConfigFactory {
 
-    @Override
-    public SnmpAgentConfig getAgentConfig(final InetAddress address) {
-    	final SnmpAgentConfig agentConfig = new SnmpAgentConfig(address);
-        agentConfig.setVersion(SnmpAgentConfig.DEFAULT_VERSION);
-        return agentConfig;
+    public void define(final SnmpEventInfo info) {
     }
-
-	public void define(final SnmpEventInfo info) {
-	}
 
     @Override
     public SnmpAgentConfig getAgentConfig(InetAddress address, String location) {
-        // TODO Auto-generated method stub
-        return null;
+        final SnmpAgentConfig agentConfig = new SnmpAgentConfig(address);
+        agentConfig.setVersion(SnmpAgentConfig.DEFAULT_VERSION);
+        return agentConfig;
     }
 
 }

--- a/opennms-provision/opennms-provisiond/src/main/java/org/opennms/netmgt/provision/service/NodeInfoScan.java
+++ b/opennms-provision/opennms-provisiond/src/main/java/org/opennms/netmgt/provision/service/NodeInfoScan.java
@@ -95,7 +95,8 @@ final class NodeInfoScan implements RunInBatch {
     }
 
     private SnmpAgentConfig getAgentConfig(InetAddress primaryAddress) {
-        return getAgentConfigFactory().getAgentConfig(primaryAddress);
+        return getAgentConfigFactory().getAgentConfig(primaryAddress,
+                (m_location == null) ? null : m_location.getLocationName());
     }
 
     private SnmpAgentConfigFactory getAgentConfigFactory() {

--- a/opennms-provision/opennms-provisiond/src/main/java/org/opennms/netmgt/provision/service/NodeScan.java
+++ b/opennms-provision/opennms-provisiond/src/main/java/org/opennms/netmgt/provision/service/NodeScan.java
@@ -546,7 +546,8 @@ public class NodeScan implements Scan {
                 Assert.notNull(getAgentConfigFactory(), "agentConfigFactory was not injected");
 
                 try {
-                    final SnmpAgentConfig agentConfig = getAgentConfigFactory().getAgentConfig(getAgentAddress());
+                    String locationName = node.getLocation()== null ? null : node.getLocation().getLocationName();
+                    final SnmpAgentConfig agentConfig = getAgentConfigFactory().getAgentConfig(getAgentAddress(), locationName);
                     m_provisionService.getLocationAwareSnmpClient().walk(agentConfig, tracker)
                         .withDescription("IP address tables")
                         .withLocation(getLocationName())
@@ -577,7 +578,8 @@ public class NodeScan implements Scan {
 
         public void detectPhysicalInterfaces(final BatchTask currentPhase) {
             if (isAborted()) { return; }
-            final SnmpAgentConfig agentConfig = getAgentConfigFactory().getAgentConfig(getAgentAddress());
+            String locationName = getLocation()== null ? null : getLocation().getLocationName();
+            final SnmpAgentConfig agentConfig = getAgentConfigFactory().getAgentConfig(getAgentAddress(), locationName);
             Assert.notNull(getAgentConfigFactory(), "agentConfigFactory was not injected");
 
             final PhysInterfaceTableTracker physIfTracker = new PhysInterfaceTableTracker() {

--- a/opennms-provision/opennms-snmp-scanners/src/main/java/org/opennms/netmgt/provision/scan/snmp/AbstractSnmpScanner.java
+++ b/opennms-provision/opennms-snmp-scanners/src/main/java/org/opennms/netmgt/provision/scan/snmp/AbstractSnmpScanner.java
@@ -116,8 +116,8 @@ public class AbstractSnmpScanner implements Scanner {
         if (agentAddress == null) {
             return;
         }
-        
-        SnmpAgentConfig agentConfig = m_snmpAgentConfigFactory.getAgentConfig(agentAddress);
+
+        SnmpAgentConfig agentConfig = m_snmpAgentConfigFactory.getAgentConfig(agentAddress, null);
         
         SnmpWalker walker = SnmpUtils.createWalker(agentConfig, getName(), createCollectionTracker(context));
         walker.start();

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/config/AgentConfigurationResource.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/config/AgentConfigurationResource.java
@@ -61,6 +61,7 @@ import org.opennms.netmgt.filter.api.FilterDao;
 import org.opennms.netmgt.model.OnmsIpInterface;
 import org.opennms.netmgt.model.OnmsMonitoredService;
 import org.opennms.netmgt.model.OnmsNode;
+import org.opennms.netmgt.model.monitoringLocations.OnmsMonitoringLocation;
 import org.opennms.netmgt.snmp.SnmpAgentConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -231,7 +232,10 @@ public class AgentConfigurationResource implements InitializingBean {
                 if (sysObjectId != null) {
                     parameters.put("sysObjectId", sysObjectId);
                 }
-                final SnmpAgentConfig config = m_agentConfigFactory.getAgentConfig(ipAddress);
+                OnmsMonitoringLocation location = (node == null) ? null : node.getLocation();
+                String locationName = (location == null) ? null : location.getLocationName();
+
+                final SnmpAgentConfig config = m_agentConfigFactory.getAgentConfig(ipAddress, locationName);
                 if (config != null) {
                     port = config.getPort();
                 }

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/config/AgentConfigurationResourceTest.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/config/AgentConfigurationResourceTest.java
@@ -154,10 +154,6 @@ public class AgentConfigurationResourceTest {
     }
     
     private static final class TestSnmpConfigDao implements SnmpAgentConfigFactory {
-        @Override
-        public SnmpAgentConfig getAgentConfig(final InetAddress address) {
-            return new SnmpAgentConfig(address, getDefaults());
-        }
 
         private static SnmpConfiguration getDefaults() {
             final SnmpConfiguration config = new SnmpConfiguration();
@@ -167,8 +163,7 @@ public class AgentConfigurationResourceTest {
 
         @Override
         public SnmpAgentConfig getAgentConfig(InetAddress address, String location) {
-            // TODO Auto-generated method stub
-            return null;
+            return new SnmpAgentConfig(address, getDefaults());
         }
     }
 }


### PR DESCRIPTION
HZN-926: Deprecate the SnmpAgentConfigFactory.getAgentConfig(InetAddress) method


* JIRA: http://issues.opennms.org/browse/HZN-926
* Bamboo: http://bamboo.internal.opennms.com:8085/browse/OPENNMS-ONMS1055