### PR TITLE
NMS-8823: Outage ReST service forNode use case calculates dates incorrectly

### DIFF
--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/OutageRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/OutageRestService.java
@@ -31,10 +31,12 @@ package org.opennms.web.rest.v1;
 import java.util.Date;
 import java.util.List;
 
+import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
@@ -44,12 +46,14 @@ import javax.ws.rs.core.UriInfo;
 
 import org.opennms.core.criteria.Alias.JoinType;
 import org.opennms.core.criteria.CriteriaBuilder;
-import org.opennms.core.criteria.restrictions.Restrictions;
 import org.opennms.netmgt.dao.api.OutageDao;
 import org.opennms.netmgt.model.OnmsOutage;
 import org.opennms.netmgt.model.OnmsOutageCollection;
 import org.opennms.netmgt.model.outage.OutageSummary;
 import org.opennms.netmgt.model.outage.OutageSummaryCollection;
+import org.opennms.web.rest.support.MultivaluedMapImpl;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -73,6 +77,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Component("outageRestService")
 @Path("outages")
 public class OutageRestService extends OnmsRestService {
+    private static final Logger LOG = LoggerFactory.getLogger(OutageRestService.class);
 
     @Autowired
     private OutageDao m_outageDao;
@@ -147,25 +152,48 @@ public class OutageRestService extends OnmsRestService {
      * <p>forNodeId</p>
      *
      * @param nodeId a int.
+     * @param dateRange a long.
+     * @param startTs a java.lang.Long.
+     * @param endTs a java.lang.Long.
      * @return a {@link org.opennms.netmgt.model.OnmsOutageCollection} object.
      */
     @GET
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
     @Transactional
     @Path("forNode/{nodeId}")
-    public OnmsOutageCollection forNodeId(@Context final UriInfo uriInfo, @PathParam("nodeId") final int nodeId) {
+    public OnmsOutageCollection forNodeId(@Context final UriInfo uriInfo,
+            @PathParam("nodeId") final int nodeId,
+            @DefaultValue("604800000") @QueryParam("dateRange") final long dateRange,
+            @QueryParam("start") final Long startTs,
+            @QueryParam("end") final Long endTs) {
 
         final CriteriaBuilder builder = new CriteriaBuilder(OnmsOutage.class);
         builder.eq("node.id", nodeId);
-        final Date d = new Date(System.currentTimeMillis() - (60 * 60 * 24 * 7));
-        builder.or(Restrictions.isNull("ifRegainedService"), Restrictions.gt("ifRegainedService", d));
 
         builder.alias("monitoredService", "monitoredService");
         builder.alias("monitoredService.ipInterface", "ipInterface");
         builder.alias("monitoredService.ipInterface.node", "node");
         builder.alias("monitoredService.serviceType", "serviceType");
 
-        applyQueryFilters(uriInfo.getQueryParameters(), builder);
+        final MultivaluedMap<String, String> params = new MultivaluedMapImpl();
+        params.putAll(uriInfo.getQueryParameters());
+
+        if (startTs != null && endTs != null) {
+            params.remove("start");
+            params.remove("end");
+            final Date start = new Date(startTs);
+            final Date end = new Date(endTs);
+            LOG.debug("Getting all outages from {} to {} for node {}", start, end, nodeId);
+            builder.gt("ifLostService", start);
+            builder.lt("ifLostService", end);
+        } else {
+            params.remove("dateRange");
+            final Date start = new Date(System.currentTimeMillis() - dateRange);
+            LOG.debug("Getting all outgae from {} to current date for node {}", start, nodeId);
+            builder.gt("ifLostService", start);
+        }
+
+        applyQueryFilters(params, builder);
 
         builder.orderBy("id").desc();
 

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/OutageRestServiceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/OutageRestServiceIT.java
@@ -32,6 +32,8 @@ import static org.junit.Assert.assertEquals;
 
 import java.io.FileInputStream;
 import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
 
 import javax.servlet.ServletContext;
 import javax.ws.rs.core.MediaType;
@@ -237,7 +239,7 @@ public class OutageRestServiceIT extends AbstractSpringJerseyRestTestCase {
         jsonRequest.addHeader("Accept", MediaType.APPLICATION_JSON);
         String json = sendRequest(jsonRequest, 200);
         JSONObject restObject = new JSONObject(json);
-        Assert.assertEquals(0, restObject.getJSONArray("outage").length());
+        Assert.assertEquals(2, restObject.getJSONArray("outage").length()); // 2 outstanding
 
         // Test a range with outages
         long start = 1436846400000l;
@@ -259,7 +261,18 @@ public class OutageRestServiceIT extends AbstractSpringJerseyRestTestCase {
         jsonRequest.setQueryString("start=1436932800000&end=1437019200000");
         json = sendRequest(jsonRequest, 200);
         restObject = new JSONObject(json);
-        Assert.assertEquals(0, restObject.getJSONArray("outage").length());
+        Assert.assertEquals(2, restObject.getJSONArray("outage").length()); // 2 outstanding
+    }
+
+    @Test
+    @JUnitTemporaryDatabase
+    public void testIPhone() throws Exception {
+        final Map<String, Object> parameters = new HashMap<String, Object>();
+        parameters.put("limit", "50");
+        parameters.put("orderBy", "ifLostService");
+        parameters.put("order", "desc");
+        String xml = sendRequest(GET, "/outages/forNode/1", parameters, 200);
+        Assert.assertTrue(xml.contains("SNMP"));
     }
 
     @Test

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/OutageRestServiceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/OutageRestServiceIT.java
@@ -231,6 +231,39 @@ public class OutageRestServiceIT extends AbstractSpringJerseyRestTestCase {
 
     @Test
     @JUnitTemporaryDatabase
+    public void testGetOutagesForNode() throws Exception {
+        // Test last week (no outages)
+        MockHttpServletRequest jsonRequest = createRequest(m_context, GET, "/outages/forNode/1");
+        jsonRequest.addHeader("Accept", MediaType.APPLICATION_JSON);
+        String json = sendRequest(jsonRequest, 200);
+        JSONObject restObject = new JSONObject(json);
+        Assert.assertEquals(0, restObject.getJSONArray("outage").length());
+
+        // Test a range with outages
+        long start = 1436846400000l;
+        long end = 1436932800000l;
+        jsonRequest = createRequest(m_context, GET, "/outages/forNode/1");
+        jsonRequest.addHeader("Accept", MediaType.APPLICATION_JSON);
+        jsonRequest.setQueryString("start=" + start + "&end=" + end);
+        json = sendRequest(jsonRequest, 200);
+        restObject = new JSONObject(json);
+        for (int i=0; i < restObject.getJSONArray("outage").length(); i++) {
+            JSONObject obj = restObject.getJSONArray("outage").getJSONObject(i);
+            Assert.assertTrue(obj.getLong("ifLostService") > start);
+            Assert.assertTrue(obj.getLong("ifLostService") < end);
+        }
+
+        // Test a range without outages
+        jsonRequest = createRequest(m_context, GET, "/outages/forNode/1");
+        jsonRequest.addHeader("Accept", MediaType.APPLICATION_JSON);
+        jsonRequest.setQueryString("start=1436932800000&end=1437019200000");
+        json = sendRequest(jsonRequest, 200);
+        restObject = new JSONObject(json);
+        Assert.assertEquals(0, restObject.getJSONArray("outage").length());
+    }
+
+    @Test
+    @JUnitTemporaryDatabase
     public void testOutagesJson() throws Exception {
         String url = "/outages";
 


### PR DESCRIPTION
Outage ReST service forNode use case calculates dates incorrectly

* JIRA: http://issues.opennms.org/browse/NMS-8823
* Bamboo: http://bamboo.internal.opennms.com:8085/browse/OPENNMS-ONMS1082
