### PR TITLE
NMS-8814: Provisioning UI: The filtered list of nodes is not updated after removing a node.

### DIFF
--- a/opennms-webapp/src/main/webapp/js/onms-requisitions/scripts/controllers/Requisition.js
+++ b/opennms-webapp/src/main/webapp/js/onms-requisitions/scripts/controllers/Requisition.js
@@ -200,6 +200,15 @@
           RequisitionsService.startTiming();
           RequisitionsService.deleteNode(node).then(
             function() { // success
+              var index = -1;
+              for(var i = 0; i < $scope.filteredNodes.length; i++) {
+                if ($scope.filteredNodes[i].foreignId === node.foreignId) {
+                  index = i;
+                }
+              }
+              if (index > -1) {
+                $scope.filteredNodes.splice(index,1);
+              }
               growl.success('The node ' + node.nodeLabel + ' has been deleted.');
             },
             $scope.errorHandler


### PR DESCRIPTION
Provisioning UI: The filtered list of nodes is not updated after removing a node.

* JIRA: http://issues.opennms.org/browse/NMS-8814
* Bamboo: Do not worry, we add a link to our continuous integration system here

The solution was verified on my testing environment.