### PR TITLE
HZN-935: Allow multiple events to be expanded in parallel.

### DIFF
--- a/features/events/daemon/src/main/java/org/opennms/netmgt/eventd/AbstractEventUtil.java
+++ b/features/events/daemon/src/main/java/org/opennms/netmgt/eventd/AbstractEventUtil.java
@@ -316,7 +316,7 @@ public abstract class AbstractEventUtil implements EventUtil {
 
 	private static EventUtil m_instance = null; 
 
-	public static EventUtil getInstance() {
+	public static synchronized EventUtil getInstance() {
 		if (m_instance == null) {
 			return BeanUtils.getBean("eventDaemonContext", "eventUtil", EventUtil.class);
 		} else {

--- a/features/events/daemon/src/main/resources/META-INF/opennms/applicationContext-eventDaemon.xml
+++ b/features/events/daemon/src/main/resources/META-INF/opennms/applicationContext-eventDaemon.xml
@@ -40,6 +40,7 @@
   <bean id="eventExpander" class="org.opennms.netmgt.eventd.EventExpander">
     <constructor-arg ref="eventdMetricRegistry"/>
     <property name="eventConfDao" ref="eventConfDao"/>
+    <property name="eventUtil" ref="eventUtil"/>
   </bean>
 
   <bean id="eventParmRegexFilter" class="org.opennms.netmgt.eventd.processor.EventParmRegexFilterProcessor">

--- a/features/events/daemon/src/test/java/org/opennms/netmgt/eventd/processor/EventExpanderTest.java
+++ b/features/events/daemon/src/test/java/org/opennms/netmgt/eventd/processor/EventExpanderTest.java
@@ -28,14 +28,17 @@
 
 package org.opennms.netmgt.eventd.processor;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 import java.util.HashMap;
 import java.util.Map;
 
 import org.easymock.EasyMock;
+import org.junit.After;
+import org.junit.Test;
 import org.opennms.netmgt.config.api.EventConfDao;
-import org.opennms.netmgt.eventd.AbstractEventUtil;
 import org.opennms.netmgt.eventd.EventExpander;
 import org.opennms.netmgt.eventd.EventUtil;
 import org.opennms.netmgt.model.events.EventBuilder;
@@ -49,18 +52,18 @@ import com.codahale.metrics.MetricRegistry;
  * 
  * @author <a href="mailto:dj@opennms.org">DJ Gregor</a>
  */
-public class EventExpanderTest extends TestCase {
+public class EventExpanderTest {
     private EasyMockUtils m_mocks = new EasyMockUtils();
     
     private EventConfDao m_eventConfDao = m_mocks.createMock(EventConfDao.class);
+    private EventUtil m_eventUtil = m_mocks.createMock(EventUtil.class);
 
-    @Override
-    protected void runTest() throws Throwable {
-        super.runTest();
-        
+    @After
+    public void tearDown() {
         m_mocks.verifyAll();
     }
-    
+
+    @Test
     public void testAfterPropertiesSetWithNoEventConfDao() {
         m_mocks.replayAll();
         
@@ -77,15 +80,18 @@ public class EventExpanderTest extends TestCase {
 
         ta.verifyAnticipated();
     }
-    
+
+    @Test
     public void testAfterPropertiesSet() {
         m_mocks.replayAll();
 
         EventExpander expander = new EventExpander(new MetricRegistry());
         expander.setEventConfDao(m_eventConfDao);
+        expander.setEventUtil(m_eventUtil);
         expander.afterPropertiesSet();
     }
-    
+
+    @Test
     public void testExpandEventWithNoDaoMatches() {
 
         String uei = "uei.opennms.org/internal/capsd/snmpConflictsWithDb";
@@ -94,6 +100,7 @@ public class EventExpanderTest extends TestCase {
 
         EventExpander expander = new EventExpander(new MetricRegistry());
         expander.setEventConfDao(m_eventConfDao);
+        expander.setEventUtil(m_eventUtil);
         expander.afterPropertiesSet();
         
         Event event = builder.getEvent();
@@ -112,6 +119,7 @@ public class EventExpanderTest extends TestCase {
         //assertTrue("event description should contain '" + matchText + "'", event.getDescr().contains(matchText));
     }
 
+    @Test
     public void testOptionalParameters() {
         String uei = "uei.opennms.org/testEventWithOptionalParameters";
         EventBuilder builder = new EventBuilder(uei, "something");
@@ -120,6 +128,7 @@ public class EventExpanderTest extends TestCase {
 
         EventExpander expander = new EventExpander(new MetricRegistry());
         expander.setEventConfDao(m_eventConfDao);
+        expander.setEventUtil(m_eventUtil);
         expander.afterPropertiesSet();
 
         org.opennms.netmgt.xml.eventconf.Event eventConfig = new org.opennms.netmgt.xml.eventconf.Event();
@@ -136,10 +145,8 @@ public class EventExpanderTest extends TestCase {
 
         EasyMock.expect(m_eventConfDao.findByEvent(event)).andReturn(eventConfig);
         EasyMock.expect(m_eventConfDao.isSecureTag(EasyMock.anyObject())).andReturn(true).anyTimes();
-        EventUtil eventUtil = m_mocks.createMock(EventUtil.class);
-        EasyMock.expect(eventUtil.expandParms("%parm[#1]%", event, new HashMap<String,Map<String,String>>())).andReturn("Vaadin");
+        EasyMock.expect(m_eventUtil.expandParms("%parm[#1]%", event, new HashMap<String,Map<String,String>>())).andReturn("Vaadin");
         m_mocks.replayAll();
-        AbstractEventUtil.setInstance(eventUtil);
 
         expander.expandEvent(event);
 

--- a/opennms-config-model/src/main/java/org/opennms/netmgt/xml/eventconf/Events.java
+++ b/opennms-config-model/src/main/java/org/opennms/netmgt/xml/eventconf/Events.java
@@ -37,6 +37,7 @@ import java.io.Serializable;
 import java.io.StringWriter;
 import java.io.Writer;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.Iterator;
@@ -419,22 +420,21 @@ public class Events implements Serializable {
 	
 	public Event findFirstMatchingEvent(org.opennms.netmgt.xml.event.Event matchingEvent) {
 		String key = m_partition.group(matchingEvent);
-		SortedSet<Event> potentialMatches = new TreeSet<Event>(m_nullPartitionedEvents);
+		Collection<Event> potentialMatches = m_nullPartitionedEvents;
 		if (key != null) {
 			List<Event> events = m_partitionedEvents.get(key);
 			if (events != null) {
+			    potentialMatches = new TreeSet<Event>(m_nullPartitionedEvents);
 			    potentialMatches.addAll(events);
 			}
 		}
-			
-			
-		
+
 		for(Event event : potentialMatches) {
 			if (event.matches(matchingEvent)) {
 				return event;
 			}
 		}
-		
+
 		for(Entry<String, Events> loadedEvents : m_loadedEventFiles.entrySet()) {
 			Events subEvents = loadedEvents.getValue();
 			Event event = subEvents.findFirstMatchingEvent(matchingEvent);
@@ -442,7 +442,7 @@ public class Events implements Serializable {
 				return event;
 			}
 		}
-		
+
 		return null;
 	}
 	

--- a/opennms-dao-mock/src/main/resources/META-INF/opennms/applicationContext-mockEventd.xml
+++ b/opennms-dao-mock/src/main/resources/META-INF/opennms/applicationContext-mockEventd.xml
@@ -55,9 +55,12 @@
 		<property name="eventIpcBroadcaster" ref="eventIpcManagerImpl" />
 	</bean>
 
+	<bean id="eventUtil" class="org.opennms.netmgt.eventd.EventUtilDaoImpl" />
+
 	<bean id="eventExpander" class="org.opennms.netmgt.eventd.EventExpander">
 		<constructor-arg ref="eventdMetricRegistry"/>
 		<property name="eventConfDao" ref="eventConfDao" />
+		<property name="eventUtil" ref="eventUtil"/>
 	</bean>
 
 	<bean id="eventWriter" class="org.opennms.netmgt.dao.mock.MockEventWriter">

--- a/opennms-services/src/test/java/org/opennms/netmgt/mock/OpenNMSITCase.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/mock/OpenNMSITCase.java
@@ -162,7 +162,8 @@ public class OpenNMSITCase {
             if (isStartEventd()) {
                 m_eventdIpcMgr = new EventIpcManagerDefaultImpl(m_registry);
 
-                AbstractEventUtil.setInstance(new EventUtilJdbcImpl());
+                EventUtilJdbcImpl eventUtil = new EventUtilJdbcImpl();
+                AbstractEventUtil.setInstance(eventUtil);
 
                 JdbcEventdServiceManager eventdServiceManager = new JdbcEventdServiceManager();
                 eventdServiceManager.setDataSource(m_db);
@@ -179,6 +180,7 @@ public class OpenNMSITCase {
                 
                 EventExpander eventExpander = new EventExpander(m_registry);
                 eventExpander.setEventConfDao(eventConfDao);
+                eventExpander.setEventUtil(eventUtil);
                 eventExpander.afterPropertiesSet();
 
                 JdbcEventWriter jdbcEventWriter = new JdbcEventWriter();


### PR DESCRIPTION
Here we remove the synchronized statement from expandEvent(Event) and set the EventUtil instead as a member variable instead of always accessing via the singleton, which allows for multiple events to be expanded in parallel.

As far as a I can tell, there is no need to make expandEvent(Event) synchronized, since all of the work that is being performed is thread safe.

* JIRA: https://issues.opennms.org/browse/HZN-935
* Bamboo: http://bamboo.internal.opennms.com:8085/browse/OPENNMS-ONMS1086
