### PR TITLE
NMS-8671 - handle SNMP error-status > 5

### DIFF
--- a/core/snmp/api/src/main/java/org/opennms/netmgt/snmp/CollectionTracker.java
+++ b/core/snmp/api/src/main/java/org/opennms/netmgt/snmp/CollectionTracker.java
@@ -30,12 +30,6 @@ package org.opennms.netmgt.snmp;
 
 
 public abstract class CollectionTracker implements Collectable {
-    
-    public static final int NO_ERR = 0;
-    public static final int TOO_BIG_ERR = 1;
-    public static final int NO_SUCH_NAME_ERR = 2;
-    public static final int GEN_ERR = 5;
-
     private CollectionTracker m_parent;
     private boolean m_failed = false;
     private boolean m_timedOut = false;

--- a/core/snmp/api/src/main/java/org/opennms/netmgt/snmp/ErrorStatus.java
+++ b/core/snmp/api/src/main/java/org/opennms/netmgt/snmp/ErrorStatus.java
@@ -1,0 +1,198 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2016 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.snmp;
+
+public enum ErrorStatus {
+    NO_ERROR {
+        @Override public boolean isFatal() {
+            return false;
+        }
+        @Override public boolean retry() {
+            return false;
+        }
+    },
+    TOO_BIG {
+        @Override public boolean isFatal() {
+            return false;
+        }
+        @Override public boolean retry() {
+            return true;
+        }
+    },
+    NO_SUCH_NAME {
+        @Override public boolean isFatal() {
+            return false;
+        }
+        @Override public boolean retry() {
+            return true;
+        }
+    },
+    BAD_VALUE {
+        @Override public boolean isFatal() {
+            return false;
+        }
+        @Override public boolean retry() {
+            return true;
+        }
+    },
+    READ_ONLY {
+        @Override public boolean isFatal() {
+            return false;
+        }
+        @Override public boolean retry() {
+            return true;
+        }
+    },
+    GEN_ERR {
+        @Override public boolean isFatal() {
+            return false;
+        }
+        @Override public boolean retry() {
+            return true;
+        }
+    },
+    NO_ACCESS {
+        @Override public boolean isFatal() {
+            return false;
+        }
+        @Override public boolean retry() {
+            return true;
+        }
+    },
+    WRONG_TYPE {
+        @Override public boolean isFatal() {
+            return true;
+        }
+        @Override public boolean retry() {
+            return true;
+        }
+    },
+    WRONG_LENGTH {
+        @Override public boolean isFatal() {
+            return true;
+        }
+        @Override public boolean retry() {
+            return true;
+        }
+    },
+    WRONG_ENCODING {
+        @Override public boolean isFatal() {
+            return true;
+        }
+        @Override public boolean retry() {
+            return true;
+        }
+    },
+    WRONG_VALUE {
+        @Override public boolean isFatal() {
+            return true;
+        }
+        @Override public boolean retry() {
+            return true;
+        }
+    },
+    NO_CREATION {
+        @Override public boolean isFatal() {
+            return false;
+        }
+        @Override public boolean retry() {
+            return true;
+        }
+    },
+    INCONSISTENT_VALUE {
+        @Override public boolean isFatal() {
+            return false;
+        }
+        @Override public boolean retry() {
+            return true;
+        }
+    },
+    RESOURCE_UNAVAILABLE {
+        @Override public boolean isFatal() {
+            return false;
+        }
+        @Override public boolean retry() {
+            return true;
+        }
+    },
+    COMMIT_FAILED {
+        @Override public boolean isFatal() {
+            return false;
+        }
+        @Override public boolean retry() {
+            return true;
+        }
+    },
+    UNDO_FAILED {
+        @Override public boolean isFatal() {
+            return false;
+        }
+        @Override public boolean retry() {
+            return true;
+        }
+    },
+    AUTHORIZATION_ERROR {
+        @Override public boolean isFatal() {
+            return false;
+        }
+        @Override public boolean retry() {
+            return true;
+        }
+    },
+    NOT_WRITABLE {
+        @Override public boolean isFatal() {
+            return false;
+        }
+        @Override public boolean retry() {
+            return true;
+        }
+    },
+    INCONSISTENT_NAME {
+        @Override public boolean isFatal() {
+            return false;
+        }
+        @Override public boolean retry() {
+            return true;
+        }
+    };
+    
+    /**
+     * Whether or not this error status should be fatal (ie, throw an exception).
+     */
+    public abstract boolean isFatal();
+    
+    /**
+     * Whether or not a retry should be attempted upon receiving this error code.
+     */
+    public abstract boolean retry();
+
+    public static ErrorStatus fromStatus(final int status) {
+        return ErrorStatus.values()[status];
+    }
+}

--- a/core/snmp/api/src/main/java/org/opennms/netmgt/snmp/ErrorStatusException.java
+++ b/core/snmp/api/src/main/java/org/opennms/netmgt/snmp/ErrorStatusException.java
@@ -1,7 +1,7 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2002-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2016 The OpenNMS Group, Inc.
  * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
@@ -26,31 +26,21 @@
  *     http://www.opennms.com/
  *******************************************************************************/
 
-package org.opennms.netmgt.snmp.mock;
+package org.opennms.netmgt.snmp;
 
-public class ResponsePdu extends TestPdu {
-    private int m_errorStatus;
-    private int m_errorIndex;
+public class ErrorStatusException extends IllegalStateException {
+    private static final long serialVersionUID = 1L;
 
-    public ResponsePdu() {
-        super();
-    }
-    
-    public int getErrorStatus() {
-        return m_errorStatus;
-    }
-    
-    void setErrorStatus(int errorStatus) {
-        m_errorStatus = errorStatus;
-    }
-    
-    public int getErrorIndex() {
-        return m_errorIndex;
-    }
-    
-    void setErrorIndex(int errorIndex) {
-        m_errorIndex = errorIndex;
+    public ErrorStatusException(final ErrorStatus status) {
+        super("SNMP error-status: " + status.toString() + "(" + status.ordinal() + ")");
     }
 
-    
+    public ErrorStatusException(final ErrorStatus status, final Throwable t) {
+        super("SNMP error-status: " + status.toString() + "(" + status.ordinal() + ")", t);
+    }
+
+    public ErrorStatusException(final ErrorStatus status, final String message) {
+        super("SNMP error-status: " + status.toString() + "(" + status.ordinal() + "): " + message);
+    }
+
 }

--- a/core/snmp/api/src/main/java/org/opennms/netmgt/snmp/internal/ServiceBasedStrategyResolver.java
+++ b/core/snmp/api/src/main/java/org/opennms/netmgt/snmp/internal/ServiceBasedStrategyResolver.java
@@ -56,7 +56,8 @@ public class ServiceBasedStrategyResolver implements StrategyResolver {
 	public void onBind(SnmpStrategy strategy, Map<String, String> props) {
 		String key = props.get("implementation");
 		if (key == null) {
-			LOG.error("SnmpStrategy class published as service with out 'implementation' key.  Ignoring.");
+			LOG.error("SnmpStrategy class '{}' published as service with out 'implementation' key.  Ignoring.", strategy.getClass());
+			return;
 		}
 		m_strategies.put(key, strategy);
 	}

--- a/core/snmp/impl-mock/src/main/java/org/opennms/netmgt/snmp/mock/MockSnmpWalker.java
+++ b/core/snmp/impl-mock/src/main/java/org/opennms/netmgt/snmp/mock/MockSnmpWalker.java
@@ -36,6 +36,7 @@ import java.util.concurrent.Executors;
 
 import org.opennms.core.concurrent.LogPreservingThreadFactory;
 import org.opennms.netmgt.snmp.CollectionTracker;
+import org.opennms.netmgt.snmp.ErrorStatus;
 import org.opennms.netmgt.snmp.SnmpAgentAddress;
 import org.opennms.netmgt.snmp.SnmpAgentConfig;
 import org.opennms.netmgt.snmp.SnmpObjId;
@@ -198,8 +199,8 @@ public class MockSnmpWalker extends SnmpWalker {
 	            }
 
 	            List<MockVarBind> responses = new ArrayList<MockVarBind>(m_oids.size());
-	            		
-	            int errorStatus = 0;
+
+	            ErrorStatus errorStatus = ErrorStatus.NO_ERROR;
 	            int errorIndex = 0;
 	            int index = 1; // snmp index start at 1
 	            for (final SnmpObjId oid : m_oids) {
@@ -207,8 +208,8 @@ public class MockSnmpWalker extends SnmpWalker {
 	            	if (nextOid == null) {
 	            		LOG.debug("No OID following {}", oid);
 	            		if (m_snmpVersion == SnmpAgentConfig.VERSION1) {
-	            			if (errorStatus == 0) { // for V1 only record the index of the first failing varbind
-	            				errorStatus = CollectionTracker.NO_SUCH_NAME_ERR;
+	            			if (errorStatus == ErrorStatus.NO_ERROR) { // for V1 only record the index of the first failing varbind
+	            				errorStatus = ErrorStatus.NO_SUCH_NAME;
 	            				errorIndex = index;
 	            			}
 	            		}
@@ -219,7 +220,7 @@ public class MockSnmpWalker extends SnmpWalker {
 	            	index++;
 	            }
 
-	            if (!processErrors(errorStatus, errorIndex)) {
+	            if (!processErrors(errorStatus.ordinal(), errorIndex)) {
 	            	LOG.debug("Responding with PDU of size {}.", responses.size());
 	            	for(MockVarBind vb : responses) {
 	                	processResponse(vb.getOid(), vb.getValue());

--- a/core/snmp/integration-tests/src/test/java/org/opennms/netmgt/snmp/mock/AgentGenErrException.java
+++ b/core/snmp/integration-tests/src/test/java/org/opennms/netmgt/snmp/mock/AgentGenErrException.java
@@ -28,11 +28,13 @@
 
 package org.opennms.netmgt.snmp.mock;
 
+import org.opennms.netmgt.snmp.ErrorStatus;
+
 public class AgentGenErrException extends AgentIndexException {
 	private static final long serialVersionUID = -6448390962070702289L;
 
 	public AgentGenErrException(int errorIndex) {
-        super(ResponsePdu.GEN_ERR, errorIndex);
+        super(ErrorStatus.GEN_ERR.ordinal(), errorIndex);
     }
 
 }

--- a/core/snmp/integration-tests/src/test/java/org/opennms/netmgt/snmp/mock/AgentNoSuchNameException.java
+++ b/core/snmp/integration-tests/src/test/java/org/opennms/netmgt/snmp/mock/AgentNoSuchNameException.java
@@ -28,11 +28,13 @@
 
 package org.opennms.netmgt.snmp.mock;
 
+import org.opennms.netmgt.snmp.ErrorStatus;
+
 public class AgentNoSuchNameException extends AgentIndexException {
 	private static final long serialVersionUID = -7868872214755378790L;
 
 	public AgentNoSuchNameException(int errorIndex) {
-        super(ResponsePdu.NO_SUCH_NAME_ERR, errorIndex);
+        super(ErrorStatus.NO_SUCH_NAME.ordinal(), errorIndex);
     }
     
 

--- a/core/snmp/integration-tests/src/test/java/org/opennms/netmgt/snmp/mock/RequestPdu.java
+++ b/core/snmp/integration-tests/src/test/java/org/opennms/netmgt/snmp/mock/RequestPdu.java
@@ -31,6 +31,7 @@ package org.opennms.netmgt.snmp.mock;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.opennms.netmgt.snmp.ErrorStatus;
 import org.opennms.netmgt.snmp.SnmpObjId;
 
 abstract public class RequestPdu extends TestPdu {
@@ -106,7 +107,7 @@ abstract public class RequestPdu extends TestPdu {
 
     protected ResponsePdu handleTooBig(TestAgent agent, ResponsePdu resp) {
         resp.setVarBinds(new TestVarBindList());
-        resp.setErrorStatus(ResponsePdu.TOO_BIG_ERR);
+        resp.setErrorStatus(ErrorStatus.TOO_BIG.ordinal());
         resp.setErrorIndex(0); // errorIndex uses indices starting at 1
         return resp;
     }

--- a/core/snmp/integration-tests/src/test/java/org/opennms/netmgt/snmp/mock/TestAgentTest.java
+++ b/core/snmp/integration-tests/src/test/java/org/opennms/netmgt/snmp/mock/TestAgentTest.java
@@ -31,10 +31,11 @@ package org.opennms.netmgt.snmp.mock;
 import java.util.NoSuchElementException;
 import java.util.Properties;
 
-import junit.framework.TestCase;
-
+import org.opennms.netmgt.snmp.ErrorStatus;
 import org.opennms.netmgt.snmp.SnmpObjId;
 import org.opennms.netmgt.snmp.SnmpValue;
+
+import junit.framework.TestCase;
 
 public class TestAgentTest extends TestCase {
     
@@ -210,7 +211,7 @@ public class TestAgentTest extends TestCase {
         
         ResponsePdu resp = m_agent.send(get);
         
-        assertEquals(ResponsePdu.TOO_BIG_ERR, resp.getErrorStatus());
+        assertEquals(ErrorStatus.TOO_BIG.ordinal(), resp.getErrorStatus());
         assertEquals(0, resp.getErrorIndex());
     }
 
@@ -226,7 +227,7 @@ public class TestAgentTest extends TestCase {
         
         ResponsePdu resp = m_agent.send(get);
         
-        assertEquals(ResponsePdu.NO_SUCH_NAME_ERR, resp.getErrorStatus());
+        assertEquals(ErrorStatus.NO_SUCH_NAME.ordinal(), resp.getErrorStatus());
         assertEquals(2, resp.getErrorIndex());
         
     }
@@ -242,7 +243,7 @@ public class TestAgentTest extends TestCase {
         
         ResponsePdu resp = m_agent.send(get);
         
-        assertEquals(ResponsePdu.NO_SUCH_NAME_ERR, resp.getErrorStatus());
+        assertEquals(ErrorStatus.NO_SUCH_NAME.ordinal(), resp.getErrorStatus());
         assertEquals(2, resp.getErrorIndex());
     }
 
@@ -285,7 +286,7 @@ public class TestAgentTest extends TestCase {
         
         ResponsePdu resp = m_agent.send(get);
         
-        assertEquals(ResponsePdu.GEN_ERR, resp.getErrorStatus());
+        assertEquals(ErrorStatus.GEN_ERR.ordinal(), resp.getErrorStatus());
         assertEquals(2, resp.getErrorIndex());
     }
     
@@ -303,7 +304,7 @@ public class TestAgentTest extends TestCase {
         
         ResponsePdu resp = m_agent.send(get);
         
-        assertEquals(ResponsePdu.GEN_ERR, resp.getErrorStatus());
+        assertEquals(ErrorStatus.GEN_ERR.ordinal(), resp.getErrorStatus());
         assertEquals(2, resp.getErrorIndex());
     }
 
@@ -320,7 +321,7 @@ public class TestAgentTest extends TestCase {
         
         ResponsePdu resp = m_agent.send(get);
         
-        assertEquals(ResponsePdu.GEN_ERR, resp.getErrorStatus());
+        assertEquals(ErrorStatus.GEN_ERR.ordinal(), resp.getErrorStatus());
         assertEquals(1, resp.getErrorIndex());
     }
     
@@ -328,7 +329,7 @@ public class TestAgentTest extends TestCase {
 
     private void validateGetResponse(GetPdu get, ResponsePdu resp) {
         assertNotNull(resp);
-        assertEquals(ResponsePdu.NO_ERR, resp.getErrorStatus());
+        assertEquals(ErrorStatus.NO_ERROR.ordinal(), resp.getErrorStatus());
         // determine if errors are expected
         
         
@@ -360,7 +361,7 @@ public class TestAgentTest extends TestCase {
         
         ResponsePdu resp = m_agent.send(pdu);
         
-        assertEquals(ResponsePdu.NO_SUCH_NAME_ERR, resp.getErrorStatus());
+        assertEquals(ErrorStatus.NO_SUCH_NAME.ordinal(), resp.getErrorStatus());
         assertEquals(2, resp.getErrorIndex());
     }
 
@@ -389,7 +390,7 @@ public class TestAgentTest extends TestCase {
         
         ResponsePdu resp = m_agent.send(get);
         
-        assertEquals(ResponsePdu.GEN_ERR, resp.getErrorStatus());
+        assertEquals(ErrorStatus.GEN_ERR.ordinal(), resp.getErrorStatus());
         assertEquals(2, resp.getErrorIndex());
     }
 
@@ -407,12 +408,12 @@ public class TestAgentTest extends TestCase {
         
         ResponsePdu resp = m_agent.send(get);
         
-        assertEquals(ResponsePdu.GEN_ERR, resp.getErrorStatus());
+        assertEquals(ErrorStatus.GEN_ERR.ordinal(), resp.getErrorStatus());
         assertEquals(2, resp.getErrorIndex());
     }
    private void validateNextResponse(NextPdu pdu, ResponsePdu resp) {
         assertNotNull(resp);
-        assertEquals(ResponsePdu.NO_ERR, resp.getErrorStatus());
+        assertEquals(ErrorStatus.NO_ERROR.ordinal(), resp.getErrorStatus());
         assertEquals(pdu.size(), resp.size());
         for(int i = 0; i < resp.size(); i++) {
             verifyNextVarBind(pdu.getVarBindAt(i).getObjId(), resp.getVarBindAt(i));
@@ -525,7 +526,7 @@ public class TestAgentTest extends TestCase {
         
         ResponsePdu resp = m_agent.send(pdu);
         
-        assertEquals(ResponsePdu.GEN_ERR, resp.getErrorStatus());
+        assertEquals(ErrorStatus.GEN_ERR.ordinal(), resp.getErrorStatus());
         assertEquals(2, resp.getErrorIndex());
     }
 
@@ -546,14 +547,14 @@ public class TestAgentTest extends TestCase {
         
         ResponsePdu resp = m_agent.send(pdu);
         
-        assertEquals(ResponsePdu.GEN_ERR, resp.getErrorStatus());
+        assertEquals(ErrorStatus.GEN_ERR.ordinal(), resp.getErrorStatus());
         assertEquals(4, resp.getErrorIndex());
     }
 
 
     private void validateBulkResponse(BulkPdu pdu, ResponsePdu resp) {
         assertNotNull(resp);
-        assertEquals(ResponsePdu.NO_ERR, resp.getErrorStatus());
+        assertEquals(ErrorStatus.NO_ERROR.ordinal(), resp.getErrorStatus());
         
         int nonRepeaters = pdu.getNonRepeaters();
         int repeaters = (pdu.size() - nonRepeaters);


### PR DESCRIPTION
This PR changes the SNMP tracker code to handle handle all known `error-status` codes from [RFC 3416](https://tools.ietf.org/html/rfc3416).

For the most part it treats the write-related responses as fatal (throwing an exception) but attempts retry for most other errors, in the hopes they may be transient.

While I have tested this with a few simple (mostly Linux-based) devices, I'd love a second set of eyes to not only look through the patches, but give this branch a shot and confirm I don't do anything heinous.

There is probably more refactoring that could be done to reduce duplicate code between the `AggregateTracker`, `ColumnTracker`, and `SingleInstanceTracker` classes, but I didn't attempt more rearranging for the sake of keeping the changes small.  The only change that touches more code was changing the various hardcoded codes from `static int constant`s to a single `enum` that is referenced throughout.

* JIRA: http://issues.opennms.org/browse/NMS-8671