### PR TITLE
NMS-8498: Explain the behavior of the step size when using the Measurements API

### DIFF
--- a/features/newts/src/main/java/org/opennms/netmgt/measurements/impl/NewtsFetchStrategy.java
+++ b/features/newts/src/main/java/org/opennms/netmgt/measurements/impl/NewtsFetchStrategy.java
@@ -91,7 +91,7 @@ public class NewtsFetchStrategy implements MeasurementFetchStrategy {
 
     private static final Logger LOG = LoggerFactory.getLogger(NewtsFetchStrategy.class);
 
-    public static final long MIN_STEP_MS = Long.getLong("org.opennms.newts.query.minimum_step", 30*1000);
+    public static final long MIN_STEP_MS = Long.getLong("org.opennms.newts.query.minimum_step", 5*60*1000);
 
     public static final int INTERVAL_DIVIDER = Integer.getInteger("org.opennms.newts.query.interval_divider", 2);
 
@@ -383,7 +383,7 @@ public class NewtsFetchStrategy implements MeasurementFetchStrategy {
         long effectiveHeartbeat = heartbeat != null ? heartbeat : DEFAULT_HEARTBEAT_MS;
         if (effectiveInterval < effectiveHeartbeat) {
             if (effectiveHeartbeat % effectiveInterval != 0) {
-                effectiveHeartbeat += effectiveHeartbeat % effectiveInterval;
+                effectiveHeartbeat += effectiveInterval - (effectiveHeartbeat % effectiveInterval);
             } else {
                 // Existing heartbeat is valid
             }

--- a/features/newts/src/test/java/org/opennms/netmgt/measurements/impl/NewtsFetchStrategyTest.java
+++ b/features/newts/src/test/java/org/opennms/netmgt/measurements/impl/NewtsFetchStrategyTest.java
@@ -184,24 +184,24 @@ public class NewtsFetchStrategyTest {
         replay();
 
         // Supply sane values and make sure the same values are returned
-        LateAggregationParams lag = NewtsFetchStrategy.getLagParams(30*1000L, 15*1000L, 450*1000L);
-        assertEquals(30*1000L, lag.step);
-        assertEquals(15*1000L, lag.interval);
+        LateAggregationParams lag = NewtsFetchStrategy.getLagParams(300*1000L, 150*1000L, 450*1000L);
+        assertEquals(300*1000L, lag.step);
+        assertEquals(150*1000L, lag.interval);
         assertEquals(450*1000L, lag.heartbeat);
 
         // Supply a step that is not a multiple of the interval, make sure this is corrected
-        lag = NewtsFetchStrategy.getLagParams(31*1000L, 15*1000L, 450*1000L);
-        assertEquals(31000L, lag.step);
-        assertEquals(15500L, lag.interval);
-        assertEquals(450500L, lag.heartbeat);
+        lag = NewtsFetchStrategy.getLagParams(310*1000L, 150*1000L, 450*1000L);
+        assertEquals(310000L, lag.step);
+        assertEquals(155000L, lag.interval);
+        assertEquals(465000L, lag.heartbeat);
 
         // Supply an interval that is much larger than the step
-        lag = NewtsFetchStrategy.getLagParams(30*1000L, 150*1000L, 4500*1000L);
-        assertEquals(30*1000L, lag.step);
+        lag = NewtsFetchStrategy.getLagParams(300*1000L, 1500*1000L, 45000*1000L);
+        assertEquals(300*1000L, lag.step);
         // Interval should be reduced
-        assertEquals(15*1000L, lag.interval);
+        assertEquals(150*1000L, lag.interval);
         // But the hearbeat should stay the same
-        assertEquals(4500*1000L, lag.heartbeat);
+        assertEquals(45000*1000L, lag.heartbeat);
     }
 
     public Source createMockResource(final String label, final String attr, final String node) {

--- a/opennms-doc/guide-admin/src/asciidoc/text/operation/newts/configuration.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/operation/newts/configuration.adoc
@@ -48,7 +48,7 @@ The following properties, found in `${OPENNMS_HOME}/etc/opennms.properties`, can
 | `org.opennms.newts.config.writer_threads`       | `16`                 | Number of threads used to pull samples from the ring buffer and insert them into Newts.
 | `org.opennms.newts.config.ttl`                  | `31540000`           | Number of seconds after which samples will automatically be deleted. Defaults to one year.
 | `org.opennms.newts.config.resource_shard`       | `604800`             | Duration in seconds for which samples will be stored at the same key. Defaults to 7 days in seconds.
-| `org.opennms.newts.query.minimum_step`          | `30000`              | Minimum step size in milliseconds. Used to prevent large queries.
+| `org.opennms.newts.query.minimum_step`          | `300000`             | Minimum step size in milliseconds. Used to prevent large queries.
 | `org.opennms.newts.query.interval_divider`      | `2`                  | If no interval is specified in the query, the step will be divided into this many intervals when aggregating values.
 | `org.opennms.newts.query.heartbeat`             | `450000`             | Duration in milliseconds. Used when no heartbeat is specified. Should generally be 1.5x your largest collection interval.
 | `org.opennms.newts.query.parallelism`           | Number of cores      | Maximum number of threads that can be used to compute aggregates. Defaults to the number of available cores.

--- a/opennms-doc/guide-development/src/asciidoc/text/rest/measurements.adoc
+++ b/opennms-doc/guide-development/src/asciidoc/text/rest/measurements.adoc
@@ -1,7 +1,8 @@
 ==== Measurements API
 
-The _Measurements API_ can be used to retrieve collected values stored in _RRD_ (or _JRB_) files.
-Note that all units of time are expressed in milliseconds.
+The _Measurements API_ can be used to retrieve collected values stored in _RRD_ (or _JRB_) files and in _Newts_.
+
+NOTE: Unless specific otherwise, all unit of time are expressed in milliseconds.
 
 ===== GETs (Reading Data)
 
@@ -19,16 +20,26 @@ The following table shows all supported query string parameters and their defaul
 | start              | -14400000 | Timestamp in milliseconds.
 
                                    If > 0, the timestamp is relative to the UNIX epoch (January 1st 1970 00:00:00 AM).
-                                   
+
                                    If < 0, the timestamp is relative to the `end` option (i.e.: default value is 4 hours ago).
 | end                | 0         | Timestamp in milliseconds. If \<= 0, the effective value will be the current timestamp.
-| step               | 300000    | Requested time interval between rows. Actual step may differ. Set to 1 for maximum accuracy.
+| step               | 300000    | Requested time interval between rows. Actual step may differ.
 | maxrows            | 0         | When using the measurements to render a graph, this should be set to the graph's pixel width.
-| interval           | null      | Duration in milliseconds, used by strategies that implement late aggregation.
-| heartbeat          | null      | Duration in milliseconds, used by strategies that implement late aggregation.
 | aggregation        | AVERAGE   | Consolidation function used. Can typically be `AVERAGE`, `MIN` or `MAX`. Depends on `RRA` definitions.
 | fallback-attribute |           | Secondary attribute that will be queried in the case the primary attribute does not exist.
 |===
+
+====== Step sizes
+
+The behavior of the `step` parameter changes based on time series strategy that is being used.
+
+When using persistence strategies based on _RRD_, the available step sizes are limited to those defined by the _RRA_ when the file was created.
+The effective step size used will be one that covers the requested period, and is closest to the requested step size.
+For maximum accuracy, use a step size of 1.
+
+When using _Newts_, the step size can be set arbitrarily since the aggregation is performed at the time of request.
+In order to help prevent large requests, we limit to the step size of a minimum of 5 minutes, the default collection rate.
+This value can be decreased by setting the `org.opennms.newts.query.minimum_step` system property.
 
 ===== Usage examples with curl
 


### PR DESCRIPTION
I've increased the minimum step size to 300 seconds when using Newts, which coincides with the default collection interval.

I've also improved the explanation of the step size handling, please comment if any of this is not clear.

JIRA: https://issues.opennms.org/browse/NMS-8498
Bamboo: http://bamboo.internal.opennms.com:8085/browse/OPENNMS-ONMS1090