### PR TITLE
NMS-8771: The Alarms Details widget on the OpsBoard shows the text on green instead of black

### DIFF
--- a/features/themes/dashboard-theme/src/main/java/VAADIN/themes/dashboard/styles.css
+++ b/features/themes/dashboard-theme/src/main/java/VAADIN/themes/dashboard/styles.css
@@ -280,12 +280,12 @@
     :: Ops Board/Panel styles
     -------------------------------------------------- */
 
-.alert-details-dashlet .onms-table{
+.alert-details-dashlet.onms-table{
     border-collapse: collapse;
     width: 100%;
     margin-top: 0;
     margin-bottom: 10px;
-    color:#000000;
+    color: #000000;
 }
 
 .alert-details-dashlet .onms { padding-left: 20px; background-position: top left; background-repeat: repeat-y; }


### PR DESCRIPTION
* JIRA: https://issues.opennms.org/browse/NMS-8771
* Bamboo: http://bamboo.internal.opennms.com:8085/browse/OPENNMS-ONMS1096