### PR TITLE
NMS-7911: Neutralize Opsboard and Wallboard Dashlet titles 

### DIFF
--- a/features/themes/dashboard-theme/src/main/java/VAADIN/themes/dashboard/styles.css
+++ b/features/themes/dashboard-theme/src/main/java/VAADIN/themes/dashboard/styles.css
@@ -355,3 +355,8 @@ td.onms { font-size: 100%; }
     overflow-y: hidden !important;
     overflow-x: auto;
 }
+
+.v-panel-caption,
+.v-panel-caption-light {
+    color: #464f52;
+}


### PR DESCRIPTION
The title for Dashlets in Opsboard and Wallboard where color red and indicated NOC users there is a problem in this Dashlet they have to look into. The title color has no monitoring functionality and the color is neutralized.

* JIRA: http://issues.opennms.org/browse/NMS-7911
* Bamboo: http://bamboo.internal.opennms.com:8085/browse/OPENNMS-ONMS1099

