### PR TITLE
NMS-8653: Show availability box for the primary interface if the node has more than 10 interfaces.

### DIFF
--- a/opennms-webapp/src/main/webapp/element/node.jsp
+++ b/opennms-webapp/src/main/webapp/element/node.jsp
@@ -332,14 +332,12 @@ function confirmAssetEdit() {
       <a href="<c:out value="${hardwareLink}"/>">Hardware Info</a>
     </li>
 
-    <c:if test="${fn:length( model.intfs ) >= 10}">
-      <c:url var="intfAvailabilityLink" value="element/availability.jsp">
-        <c:param name="node" value="${model.id}"/>
-      </c:url>
-      <li>
-        <a href="<c:out value="${intfAvailabilityLink}"/>">Availability</a>
-      </li>
-    </c:if>
+    <c:url var="intfAvailabilityLink" value="element/availability.jsp">
+      <c:param name="node" value="${model.id}"/>
+    </c:url>
+    <li>
+      <a href="<c:out value="${intfAvailabilityLink}"/>">Availability</a>
+    </li>
 
     <c:if test="${! empty model.statusSite}">
       <c:url var="siteLink" value="siteStatusView.htm">

--- a/opennms-webapp/src/main/webapp/includes/nodeAvailability-box.jsp
+++ b/opennms-webapp/src/main/webapp/includes/nodeAvailability-box.jsp
@@ -117,9 +117,11 @@
 
     <%  if (overallRtcValue >= 0) { %>
        <% Interface[] availIntfs = NetworkElementFactory.getInstance(getServletContext()).getActiveInterfacesOnNode(nodeId); %>
+       <% boolean oversized = availIntfs.length > 10; %>
            
         <% for( int i=0; i < availIntfs.length; i++ ) { %>
           <% Interface intf = availIntfs[i]; %>
+          <% if (oversized && ! "P".equals(intf.getIsSnmpPrimary())) { continue; } %>
           <% String ipAddr = intf.getIpAddress(); %>
           
           <c:url var="interfaceLink" value="element/interface.jsp">


### PR DESCRIPTION
Show availability box for the primary interface if the node has more than 10 interfaces.

* JIRA: http://issues.opennms.org/browse/NMS-8653
* Bamboo: http://bamboo.internal.opennms.com:8085/browse/OPENNMS-ONMS1102

The solution was tested on VM running Meridian 2016.