### PR TITLE
NMS-8879: Updating assets/categories through ReST affects Forced Unmanaged services.

### DIFF
--- a/opennms-services/src/main/java/org/opennms/netmgt/poller/QueryManagerDaoImpl.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/poller/QueryManagerDaoImpl.java
@@ -43,6 +43,7 @@ import org.opennms.core.criteria.Alias.JoinType;
 import org.opennms.core.criteria.Criteria;
 import org.opennms.core.criteria.restrictions.AnyRestriction;
 import org.opennms.core.criteria.restrictions.EqRestriction;
+import org.opennms.core.criteria.restrictions.NeRestriction;
 import org.opennms.core.criteria.restrictions.NullRestriction;
 import org.opennms.core.utils.InetAddressUtils;
 import org.opennms.netmgt.dao.api.EventDao;
@@ -174,6 +175,7 @@ public class QueryManagerDaoImpl implements QueryManager {
             new Alias("ipInterface.node", "node", JoinType.LEFT_JOIN)
         }));
         criteria.addRestriction(new EqRestriction("node.id", nodeId));
+        criteria.addRestriction(new NeRestriction("status", "F")); // Ignore forced-unmanaged
         for (OnmsMonitoredService service : m_monitoredServiceDao.findMatching(criteria)) {
             servicemap.add(new String[] { service.getIpAddressAsString(), service.getServiceName() });
         }

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/AssetRecordResource.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/AssetRecordResource.java
@@ -129,7 +129,7 @@ public class AssetRecordResource extends OnmsRestService {
         }
         if (modified) {
             LOG.debug("updateAssetRecord: assetRecord {} updated", assetRecord);
-            m_assetRecordDao.update(assetRecord);
+            m_assetRecordDao.saveOrUpdate(assetRecord);
             try {
                 sendEvent(EventConstants.ASSET_INFO_CHANGED_EVENT_UEI, node.getId());
             } catch (EventProxyException e) {

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/AssetRecordResource.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/AssetRecordResource.java
@@ -40,6 +40,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 
+import org.opennms.netmgt.dao.api.AssetRecordDao;
 import org.opennms.netmgt.dao.api.NodeDao;
 import org.opennms.netmgt.events.api.EventConstants;
 import org.opennms.netmgt.events.api.EventProxy;
@@ -68,6 +69,9 @@ public class AssetRecordResource extends OnmsRestService {
 
     @Autowired
     private NodeDao m_nodeDao;
+
+    @Autowired
+    private AssetRecordDao m_assetRecordDao;
 
     @Autowired
     @Qualifier("eventProxy")
@@ -111,7 +115,7 @@ public class AssetRecordResource extends OnmsRestService {
         if (assetRecord.getGeolocation() == null) {
             assetRecord.setGeolocation(new OnmsGeolocation());
         }
-        LOG.debug("updateAssetRecord: updating category {}", assetRecord);
+        LOG.debug("updateAssetRecord: updating asset {}", assetRecord);
         boolean modified = false;
         BeanWrapper wrapper = PropertyAccessorFactory.forBeanPropertyAccess(assetRecord);
         wrapper.registerCustomEditor(Date.class, new ISO8601DateEditor());
@@ -125,7 +129,7 @@ public class AssetRecordResource extends OnmsRestService {
         }
         if (modified) {
             LOG.debug("updateAssetRecord: assetRecord {} updated", assetRecord);
-            m_nodeDao.saveOrUpdate(node);
+            m_assetRecordDao.update(assetRecord);
             try {
                 sendEvent(EventConstants.ASSET_INFO_CHANGED_EVENT_UEI, node.getId());
             } catch (EventProxyException e) {


### PR DESCRIPTION
Updating assets/categories through ReST affects Forced Unmanaged services.

* JIRA: http://issues.opennms.org/browse/NMS-8879
* Bamboo: http://bamboo.internal.opennms.com:8085/browse/OPENNMS-ONMS1105

The solution has been tested on a VM running Meridian 2016.