### PR TITLE
NMS-8874 - fix iphostname setting on node rescan

### DIFF
--- a/opennms-provision/opennms-provisiond/src/main/java/org/opennms/netmgt/provision/service/DefaultProvisionService.java
+++ b/opennms-provision/opennms-provisiond/src/main/java/org/opennms/netmgt/provision/service/DefaultProvisionService.java
@@ -229,7 +229,6 @@ public class DefaultProvisionService implements ProvisionService, InitializingBe
     @Transactional
     @Override
     public void updateNode(final OnmsNode node, String rescanExisting) {
-
         final OnmsNode dbNode = m_nodeDao.getHierarchy(node.getId());
 
         // on an update, leave categories alone, let the NodeScan handle applying requisitioned categories
@@ -254,20 +253,30 @@ public class DefaultProvisionService implements ProvisionService, InitializingBe
                 primary = node.getIpInterfaces().iterator().next();
             }
 
-            if (primary != null) {
-                LOG.debug("Node Label was set by hostname or address.  Re-resolving.");
-                final InetAddress addr = primary.getIpAddress();
+            for (final OnmsIpInterface iface : node.getIpInterfaces()) {
+                final InetAddress addr = iface.getIpAddress();
                 final String ipAddress = str(addr);
                 final String hostname = getHostnameResolver().getHostname(addr);
 
-                if (hostname == null || ipAddress.equals(hostname)) {
-                    node.setLabel(ipAddress);
-                    node.setLabelSource(NodeLabelSource.ADDRESS);
+                if (iface.equals(primary)) {
+                    LOG.debug("Node Label was set by hostname or address.  Re-setting.");
+                    if (hostname == null || ipAddress.equals(hostname)) {
+                        node.setLabel(ipAddress);
+                        node.setLabelSource(NodeLabelSource.ADDRESS);
+                    } else {
+                        node.setLabel(hostname);
+                        node.setLabelSource(NodeLabelSource.HOSTNAME);
+                    }
+                }
+
+                if (hostname == null) {
+                    iface.setIpHostName(ipAddress);
                 } else {
-                    node.setLabel(hostname);
-                    node.setLabelSource(NodeLabelSource.HOSTNAME);
+                    iface.setIpHostName(hostname);
                 }
             }
+        } else {
+            LOG.debug("updateNodeHostname: skipping update. source = {}", node.getLabelSource());
         }
     }
 

--- a/opennms-provision/opennms-provisiond/src/main/java/org/opennms/netmgt/provision/service/DefaultProvisionService.java
+++ b/opennms-provision/opennms-provisiond/src/main/java/org/opennms/netmgt/provision/service/DefaultProvisionService.java
@@ -258,7 +258,7 @@ public class DefaultProvisionService implements ProvisionService, InitializingBe
                 LOG.debug("Node Label was set by hostname or address.  Re-resolving.");
                 final InetAddress addr = primary.getIpAddress();
                 final String ipAddress = str(addr);
-                final String hostname = m_hostnameResolver.getHostname(addr);
+                final String hostname = getHostnameResolver().getHostname(addr);
 
                 if (hostname == null || ipAddress.equals(hostname)) {
                     node.setLabel(ipAddress);
@@ -1358,7 +1358,7 @@ public class DefaultProvisionService implements ProvisionService, InitializingBe
                 // TODO: Associate location with node if necessary
                 final OnmsNode node = new OnmsNode();
 
-                final String hostname = m_hostnameResolver.getHostname(addr(ipAddress));
+                final String hostname = getHostnameResolver().getHostname(addr(ipAddress));
                 if (hostname == null || ipAddress.equals(hostname)) {
                     node.setLabel(ipAddress);
                     node.setLabelSource(NodeLabelSource.ADDRESS);

--- a/opennms-provision/opennms-provisiond/src/test/java/org/opennms/netmgt/provision/service/NewSuspectScanIT.java
+++ b/opennms-provision/opennms-provisiond/src/test/java/org/opennms/netmgt/provision/service/NewSuspectScanIT.java
@@ -384,9 +384,11 @@ public class NewSuspectScanIT extends ProvisioningITCase implements Initializing
             assertEquals(1, getNodeDao().countAll());
 
             //Verify node info
-            assertEquals(Integer.valueOf(nextNodeId), getNodeDao().findAll().iterator().next().getId());
-            assertEquals("oldNodeLabel", getNodeDao().findAll().iterator().next().getLabel());
-            assertEquals(NodeLabelSource.HOSTNAME, getNodeDao().findAll().iterator().next().getLabelSource());
+            final OnmsNode beforeNode = getNodeDao().findAll().iterator().next();
+            assertEquals(Integer.valueOf(nextNodeId), beforeNode.getId());
+            assertEquals("oldNodeLabel", beforeNode.getLabel());
+            assertEquals(NodeLabelSource.HOSTNAME, beforeNode.getLabelSource());
+            assertEquals("oldNodeLabel", beforeNode.getIpInterfaces().iterator().next().getIpHostName());
 
             //Verify ipinterface count
             assertEquals("Unexpected number of interfaces found: " + getInterfaceDao().findAll(), 1, getInterfaceDao().countAll());
@@ -409,9 +411,11 @@ public class NewSuspectScanIT extends ProvisioningITCase implements Initializing
             final ForceRescanScan rescan = m_provisioner.createForceRescanScan(nextNodeId);
             runScan(rescan);
 
-            assertEquals(Integer.valueOf(nextNodeId), getNodeDao().findAll().iterator().next().getId());
-            assertEquals("newNodeLabel", getNodeDao().findAll().iterator().next().getLabel());
-            assertEquals(NodeLabelSource.HOSTNAME, getNodeDao().findAll().iterator().next().getLabelSource());
+            final OnmsNode afterNode = getNodeDao().findAll().iterator().next();
+            assertEquals(Integer.valueOf(nextNodeId), afterNode.getId());
+            assertEquals("newNodeLabel", afterNode.getLabel());
+            assertEquals(NodeLabelSource.HOSTNAME, afterNode.getLabelSource());
+            assertEquals("newNodeLabel", afterNode.getIpInterfaces().iterator().next().getIpHostName());
         } finally {
             m_provisionService.setHostnameResolver(new DefaultHostnameResolver());
         }


### PR DESCRIPTION
This PR changes the provisiond scan to:

1. fix rescans of nodes to update the iphostname
2. change the update to set the iphostname on _all_ interfaces, rather than just the primary

* JIRA: http://issues.opennms.org/browse/NMS-8874
