### PR TITLE
NMS-8880 do not update node labels when IP has not changed on rescan

### DIFF
--- a/opennms-provision/opennms-provisiond/src/main/java/org/opennms/netmgt/provision/service/DefaultProvisionService.java
+++ b/opennms-provision/opennms-provisiond/src/main/java/org/opennms/netmgt/provision/service/DefaultProvisionService.java
@@ -253,6 +253,14 @@ public class DefaultProvisionService implements ProvisionService, InitializingBe
                 primary = node.getIpInterfaces().iterator().next();
             }
 
+            final InetAddress primaryAddr = primary.getIpAddress();
+            final String primaryHostname = getHostnameResolver().getHostname(primaryAddr);
+
+            if (primaryHostname == null && node.getLabel() != null && NodeLabelSource.HOSTNAME.equals((node.getLabelSource()))) {
+                LOG.warn("Previous node label source for address {} was hostname, but it does not currently resolve.  Skipping update.", InetAddressUtils.str(primaryAddr));
+                return;
+            }
+
             for (final OnmsIpInterface iface : node.getIpInterfaces()) {
                 final InetAddress addr = iface.getIpAddress();
                 final String ipAddress = str(addr);
@@ -276,7 +284,7 @@ public class DefaultProvisionService implements ProvisionService, InitializingBe
                 }
             }
         } else {
-            LOG.debug("updateNodeHostname: skipping update. source = {}", node.getLabelSource());
+            LOG.debug("Node label source ({}) is not host or address. Skipping update.", node.getLabelSource());
         }
     }
 


### PR DESCRIPTION
This PR fixes node label updates on rescan, when the node is temporarily unreachable or cannot be resolved.

* JIRA: http://issues.opennms.org/browse/NMS-8880
