### PR TITLE
NMS-8885: Fix checknsc NoClassDefFoundError for LoggerFactory

### DIFF
--- a/opennms-base-assembly/src/main/filtered/bin/checknsc
+++ b/opennms-base-assembly/src/main/filtered/bin/checknsc
@@ -5,12 +5,15 @@ OPENNMS_BINDIR="${install.bin.dir}"
 
 SERVICES_JAR=`ls -1 "$OPENNMS_HOME"/lib/*.jar | grep org.opennms.protocols.nsclient- | head -n 1`
 UTIL_JAR=`ls -1 "$OPENNMS_HOME"/lib/*.jar | grep opennms-util- | head -n 1`
-LOG4J_JAR=`ls -1 "$OPENNMS_HOME"/lib/*.jar | grep log4j- | head -n 1`
+LOG4J_JAR=`ls -1 "$OPENNMS_HOME"/lib/log4j-*.jar | head -n 1`
+SLF4J_API_JAR=`ls -1 "$OPENNMS_HOME"/lib/slf4j-api*.jar | head -n 1`
+SLF4J_L4J_JAR=`ls -1 "$OPENNMS_HOME"/lib/log4j-over-slf4j-*.jar | head -n 1`
 COMMONS_CLI_JAR=`ls -1 "$OPENNMS_HOME"/lib/commons-cli-*.jar | head -n 1`
 
 exec "$OPENNMS_BINDIR"/runjava -r -- \
 	-Xmx256m \
 	-Dlog4j.configurationFile="$OPENNMS_HOME"/etc/log4j2-tools.xml \
-	-cp "$SERVICES_JAR:$UTIL_JAR:$LOG4J_JAR:$COMMONS_CLI_JAR" \
+	-cp "$SERVICES_JAR:$UTIL_JAR:$LOG4J_JAR:$SLF4J_API_JAR:$SLF4J_L4J_JAR:$COMMONS_CLI_JAR" \
 	org.opennms.protocols.nsclient.CheckNsc \
 	"$@"
+  


### PR DESCRIPTION
Add SLF4J API and SLF4J Log4J libraries to class path call.

* JIRA: http://issues.opennms.org/browse/NMS-8885

