### PR TITLE
NMS-8892: Add newest supported version number for PostgreSQL

### DIFF
--- a/opennms-doc/guide-install/src/asciidoc/text/opennms/introduction.adoc
+++ b/opennms-doc/guide-install/src/asciidoc/text/opennms/introduction.adoc
@@ -20,7 +20,7 @@ Installing _OpenNMS_ requires the following prerequisites:
 * A configured <<gi-install-opennms-repo-releases, Yum or APT Package Repository>> for your platform (Linux only)
 * Internet access to download and verify _OpenNMS_ packages from the Yum or APT package repositories
 * <<gi-install-oracle-java, Oracle Java SE Development Kit 8>> environment
-* PostgreSQL database version 9.1 until 9.6
+* PostgreSQL database version 9.1 or higher, it has only been tested with PostgreSQL 9.1 through 9.6
 * A time-series database engine to persist long-term performance data:
 ** JRobin: The default choice. JRobin is included inside OpenNMS and doesn't require additional software to be installed.
 ** <<gi-rrdtool-time-series-database, RRDtool>>: A higher performance, file-based database.

--- a/opennms-doc/guide-install/src/asciidoc/text/opennms/introduction.adoc
+++ b/opennms-doc/guide-install/src/asciidoc/text/opennms/introduction.adoc
@@ -6,7 +6,7 @@
 == Installation Overview
 
 The _OpenNMS_ platform can be installed in several ways.
-This guide describes the installation of the platform on _Red Hat Enterprise Linux (RHEL)_-based, _Debian_-based and _Microsoft Windows_ 
+This guide describes the installation of the platform on _Red Hat Enterprise Linux (RHEL)_-based, _Debian_-based and _Microsoft Windows_
 operating systems. The following abbreviations will be used to refer to the following operating systems:
 
 * _RHEL_: Red Hat Enterprise Linux 6 or higher, CentOS 6 or higher, Fedora 20 or higher
@@ -20,7 +20,7 @@ Installing _OpenNMS_ requires the following prerequisites:
 * A configured <<gi-install-opennms-repo-releases, Yum or APT Package Repository>> for your platform (Linux only)
 * Internet access to download and verify _OpenNMS_ packages from the Yum or APT package repositories
 * <<gi-install-oracle-java, Oracle Java SE Development Kit 8>> environment
-* PostgreSQL database version 9.1 or higher
+* PostgreSQL database version 9.1 until 9.6
 * A time-series database engine to persist long-term performance data:
 ** JRobin: The default choice. JRobin is included inside OpenNMS and doesn't require additional software to be installed.
 ** <<gi-rrdtool-time-series-database, RRDtool>>: A higher performance, file-based database.


### PR DESCRIPTION
Added PostgreSQL version 9.6 as newest supported version in the install guide.

* JIRA: http://issues.opennms.org/browse/NMS-8892