### PR TITLE
NMS-8552: Added documentation for Eventd's configuration files

### DIFF
--- a/opennms-doc/guide-admin/src/asciidoc/index.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/index.adoc
@@ -184,6 +184,7 @@ include::text/operation/newts/cassandra-newts-jmx.adoc[]
 [[ga-opennms-operation-daemon-config-files]]
 === Daemon Configuration Files
 include::text/operation/daemon-config-files/introduction.adoc[]
+include::text/operation/daemon-config-files/eventd.adoc[]
 include::text/operation/daemon-config-files/notifd.adoc[]
 include::text/operation/daemon-config-files/pollerd.adoc[]
 

--- a/opennms-doc/guide-admin/src/asciidoc/text/operation/daemon-config-files/eventd.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/operation/daemon-config-files/eventd.adoc
@@ -1,0 +1,21 @@
+
+// Allow GitHub image rendering
+:imagesdir: ../../../images
+
+[[ga-opennms-operation-daemon-config-files-eventd]]
+==== Eventd
+
+[options="header, autowidth"]
+|===
+| Internal Daemon Name | Reload Event
+| _Eventd_            | `uei.opennms.org/internal/reloadDaemonConfig -p 'daemonName Eventd'`
+|===
+
+.Eventd configuration file overview
+[options="header, autowidth"]
+|===
+| File                        | Restart Required | Reload Event | Description
+| `eventd-configuration.xml`  | yes              | no           | Configure generic behavior of _Eventd_, i.e. _TCP_ and _UDP_ port numbers with _IP addresses_ to listen for _Events_ and socket timeouts.
+| `eventconf.xml`             | no               | yes          | Main configuration file for _Eventd_.
+| `events/*`                  | no               | yes          | Out-of-the-box, all files in this folder are included via `include` directives in `eventconf.xml`.
+|===


### PR DESCRIPTION
* JIRA: http://issues.opennms.org/browse/NMS-8552

Add daemon configuration files for Eventd and describe which files require system restart or can be reloaded with a daemon reload event.

