### PR TITLE
NMS-8895: Jetty logging behavior has changed

### DIFF
--- a/core/logging-api/src/main/java/org/opennms/core/logging/Logging.java
+++ b/core/logging-api/src/main/java/org/opennms/core/logging/Logging.java
@@ -28,6 +28,7 @@
 
 package org.opennms.core.logging;
 
+import java.io.Closeable;
 import java.util.Map;
 import java.util.concurrent.Callable;
 
@@ -71,6 +72,28 @@ public abstract class Logging {
         } finally {
             Logging.setContextMap(mdc);
         }
+    }
+
+    /**
+     * An adapter to restore the MDC context when done.
+     */
+    public static class MDCCloseable implements Closeable {
+        private final Map<String, String> mdc;
+
+        private MDCCloseable(Map<String, String> mdc) {
+            this.mdc = mdc;
+        }
+
+        @Override
+        public void close() {
+            Logging.setContextMap(mdc);
+        }
+    }
+
+    public static MDCCloseable withPrefixCloseable(final String prefix) {
+        final Map<String, String> mdc = Logging.getCopyOfContextMap();
+        Logging.putPrefix(prefix);
+        return new MDCCloseable(mdc);
     }
 
     public static Runnable preserve(final Runnable runnable) {

--- a/opennms-jetty/src/main/java/org/opennms/netmgt/jetty/MDCHandler.java
+++ b/opennms-jetty/src/main/java/org/opennms/netmgt/jetty/MDCHandler.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2016-2016 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2016 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.jetty;
+
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.handler.HandlerWrapper;
+import org.opennms.core.logging.Logging;
+
+public class MDCHandler extends HandlerWrapper {
+
+    @Override
+    public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException {
+        try(Logging.MDCCloseable closeable = Logging.withPrefixCloseable("web")) {
+            super.handle(target,baseRequest,request,response);
+        }
+    }
+}

--- a/opennms-jetty/src/main/resources/org/opennms/netmgt/jetty/jetty.xml
+++ b/opennms-jetty/src/main/resources/org/opennms/netmgt/jetty/jetty.xml
@@ -143,25 +143,29 @@
     <Arg><Ref refid="Server"/></Arg>
   </Call>
 
+  <New id="Handlers" class="org.eclipse.jetty.server.handler.HandlerCollection">
+      <Set name="handlers">
+       <Array type="org.eclipse.jetty.server.Handler">
+         <!-- Note #2 Uncomment to set X-Frame-Options with #1 above  -->
+         <!--
+           <Item>
+             <Ref id="RewriteHandler"/>
+           </Item>
+         -->
+           <Item>
+               <New id="Contexts" class="org.eclipse.jetty.server.handler.ContextHandlerCollection"/>
+           </Item>
+           <Item>
+               <New id="DefaultHandler" class="org.eclipse.jetty.server.handler.DefaultHandler"/>
+           </Item>
+       </Array>
+      </Set>
+  </New>
+
   <Set name="handler">
-        <New id="Handlers" class="org.eclipse.jetty.server.handler.HandlerCollection">
-            <Set name="handlers">
-             <Array type="org.eclipse.jetty.server.Handler">
-               <!-- Note #2 Uncomment to set X-Frame-Options with #1 above  -->
-               <!-- 
-                 <Item>
-                   <Ref id="RewriteHandler"/>
-                 </Item>
-               -->
-                 <Item>
-                     <New id="Contexts" class="org.eclipse.jetty.server.handler.ContextHandlerCollection"/>
-                 </Item>
-                 <Item>
-                     <New id="DefaultHandler" class="org.eclipse.jetty.server.handler.DefaultHandler"/>
-                 </Item>
-             </Array>
-            </Set>
-        </New>
+    <New id="mdcHandler" class="org.opennms.netmgt.jetty.MDCHandler">
+      <Set name="handler"><Ref id="Handlers" /></Set>
+    </New>
   </Set>
 
   <New id="DeploymentManager" class="org.eclipse.jetty.deploy.DeploymentManager">


### PR DESCRIPTION
JIRA: https://issues.opennms.org/browse/NMS-8895

With the upgrade to Jetty 9.3.x, log statements from servlets, and errors from JSP pages no longer appear in web.log as they used to. 

This patch restores the behavior we've gotten used to with Jetty 8.4.x by setting the log prefix to 'web' before all of the handlers are executed.


