### PR TITLE
NMS-8708: Make sure Trapd config isn't reloaded unnecessarily

### DIFF
--- a/core/snmp/api/src/main/java/org/opennms/netmgt/snmp/SnmpV3User.java
+++ b/core/snmp/api/src/main/java/org/opennms/netmgt/snmp/SnmpV3User.java
@@ -131,4 +131,16 @@ public class SnmpV3User {
             Objects.equals(getPrivPassPhrase(), that.getPrivPassPhrase()) &&
             Objects.equals(getPrivProtocol(), that.getPrivProtocol());
     }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+            .append("authPassPhrase", authPassPhrase)
+            .append("authProtocol", authProtocol)
+            .append("engineId", engineId)
+            .append("privPassPhrase", privPassPhrase)
+            .append("privProtocol", privProtocol)
+            .append("securityName", securityName)
+            .toString();
+    }
 }

--- a/core/snmp/api/src/main/java/org/opennms/netmgt/snmp/SnmpV3User.java
+++ b/core/snmp/api/src/main/java/org/opennms/netmgt/snmp/SnmpV3User.java
@@ -28,6 +28,8 @@
 
 package org.opennms.netmgt.snmp;
 
+import java.util.Objects;
+
 public class SnmpV3User {
 
     private String engineId;
@@ -106,4 +108,27 @@ public class SnmpV3User {
         this.privProtocol = privacyProtocol;
     }
 
+    @Override
+    public int hashCode() {
+        return Objects.hash(authPassPhrase, authProtocol, engineId, privPassPhrase, privProtocol);
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (o == null) {
+            return false;
+        }
+        if (o == this) {
+            return true;
+        }
+        if (this.getClass() != o.getClass()) {
+            return false;
+        }
+        final SnmpV3User that = (SnmpV3User)o;
+        return Objects.equals(getAuthPassPhrase(), that.getAuthPassPhrase()) &&
+            Objects.equals(getAuthProtocol(), that.getAuthProtocol()) &&
+            Objects.equals(getEngineId(), that.getEngineId()) &&
+            Objects.equals(getPrivPassPhrase(), that.getPrivPassPhrase()) &&
+            Objects.equals(getPrivProtocol(), that.getPrivProtocol());
+    }
 }

--- a/core/snmp/api/src/main/java/org/opennms/netmgt/snmp/SnmpV3User.java
+++ b/core/snmp/api/src/main/java/org/opennms/netmgt/snmp/SnmpV3User.java
@@ -121,15 +121,16 @@ public class SnmpV3User {
         if (o == this) {
             return true;
         }
-        if (this.getClass() != o.getClass()) {
+        if (o instanceof SnmpV3User) {
+            final SnmpV3User that = (SnmpV3User)o;
+            return Objects.equals(getAuthPassPhrase(), that.getAuthPassPhrase()) &&
+                Objects.equals(getAuthProtocol(), that.getAuthProtocol()) &&
+                Objects.equals(getEngineId(), that.getEngineId()) &&
+                Objects.equals(getPrivPassPhrase(), that.getPrivPassPhrase()) &&
+                Objects.equals(getPrivProtocol(), that.getPrivProtocol());
+        } else {
             return false;
         }
-        final SnmpV3User that = (SnmpV3User)o;
-        return Objects.equals(getAuthPassPhrase(), that.getAuthPassPhrase()) &&
-            Objects.equals(getAuthProtocol(), that.getAuthProtocol()) &&
-            Objects.equals(getEngineId(), that.getEngineId()) &&
-            Objects.equals(getPrivPassPhrase(), that.getPrivPassPhrase()) &&
-            Objects.equals(getPrivProtocol(), that.getPrivProtocol());
     }
 
     @Override

--- a/features/events/traps/pom.xml
+++ b/features/events/traps/pom.xml
@@ -162,6 +162,10 @@
     </dependency>
     <dependency>
       <groupId>org.opennms.core.test-api</groupId>
+      <artifactId>org.opennms.core.test-api.http</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.opennms.core.test-api</groupId>
       <artifactId>org.opennms.core.test-api.services</artifactId>
     </dependency>
     <dependency>

--- a/features/events/traps/src/test/java/org/opennms/netmgt/trapd/TrapReceiverImplTest.java
+++ b/features/events/traps/src/test/java/org/opennms/netmgt/trapd/TrapReceiverImplTest.java
@@ -1,0 +1,150 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2016 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2016 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.trapd;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.opennms.netmgt.config.TrapdConfig;
+import org.opennms.netmgt.config.trapd.Snmpv3User;
+import org.opennms.netmgt.config.trapd.TrapdConfiguration;
+import org.opennms.netmgt.snmp.SnmpV3User;
+
+import com.google.common.collect.Lists;
+
+public class TrapReceiverImplTest {
+
+    private CustomTrapdConfig initialConfig;
+
+    private class CustomTrapdConfig implements TrapdConfig {
+
+        private List<SnmpV3User> snmpUsers = Lists.newArrayList();
+        private String snmpAddress;
+        private int snmpTrapPort;
+
+        @Override
+        public String getSnmpTrapAddress() {
+            return snmpAddress;
+        }
+
+        @Override
+        public int getSnmpTrapPort() {
+            return snmpTrapPort;
+        }
+
+        @Override
+        public boolean getNewSuspectOnTrap() {
+            return false;
+        }
+
+        @Override
+        public List<SnmpV3User> getSnmpV3Users() {
+            return snmpUsers;
+        }
+
+        @Override
+        public void onUpdate(TrapdConfiguration config) {
+
+        }
+
+        public void setSnmpUsers(List<SnmpV3User> snmpUsers) {
+            this.snmpUsers = snmpUsers;
+        }
+
+        public void setSnmpAddress(String snmpAddress) {
+            this.snmpAddress = snmpAddress;
+        }
+
+        public void setSnmpTrapPort(int snmpTrapPort) {
+            this.snmpTrapPort = snmpTrapPort;
+        }
+    }
+
+    @Before
+    public void setUp() {
+        initialConfig = new CustomTrapdConfig();
+        initialConfig.setSnmpTrapPort(1162);
+        initialConfig.setSnmpAddress("localhost");
+    }
+
+    @Test
+    public void verifyCheckForTrapdConfigurationChange() throws Exception {
+        TrapReceiverImpl impl = new TrapReceiverImpl(initialConfig);
+
+        // Empty config should be different
+        TrapdConfiguration config = new TrapdConfiguration();
+        Assert.assertEquals(Boolean.TRUE, impl.checkForTrapdConfigurationChange(config));
+
+        // Equal config should not be different
+        config.setSnmpTrapPort(initialConfig.getSnmpTrapPort());
+        config.setSnmpTrapAddress(initialConfig.getSnmpTrapAddress());
+        Assert.assertEquals(Boolean.FALSE, impl.checkForTrapdConfigurationChange(config));
+
+        // Add a user, should result in a difference
+        config.getSnmpv3UserCollection().add(createUser("MD5", "0p3nNMSv3", "some-engine-id", "DES", "0p3nNMSv3", "some-security-name"));
+        Assert.assertEquals(Boolean.TRUE, impl.checkForTrapdConfigurationChange(config));
+        impl.setTrapdConfig(config); // update and verify that it now is equal
+        Assert.assertEquals(Boolean.FALSE, impl.checkForTrapdConfigurationChange(config));
+
+        // Adding another user should also result in a difference
+        config.getSnmpv3UserCollection().add(createUser("MD5", "0p3nNMSv3", "some-engine-id", "DES", "0p3nNMSv3", "some-security-name-2"));
+        Assert.assertEquals(Boolean.TRUE, impl.checkForTrapdConfigurationChange(config));
+        impl.setTrapdConfig(config); // update and verify that it now is equal
+        Assert.assertEquals(Boolean.FALSE, impl.checkForTrapdConfigurationChange(config));
+
+        // Adding another copy of an existing user will NOT trigger an update, the first entry found in the list will be used
+        config.getSnmpv3UserCollection().add(createUser("MD5", "0p3nNMSv3", "some-engine-id", "DES", "0p3nNMSv3", "some-security-name"));
+        Assert.assertEquals(Boolean.FALSE, impl.checkForTrapdConfigurationChange(config));
+
+        // Editing a user should result in a difference
+        config.getSnmpv3UserCollection().get(0).setPrivacyProtocol("AES");
+        Assert.assertEquals(Boolean.TRUE, impl.checkForTrapdConfigurationChange(config));
+        impl.setTrapdConfig(config); // update and verify that it now is equal
+        Assert.assertEquals(Boolean.FALSE, impl.checkForTrapdConfigurationChange(config));
+
+    }
+
+    private static Snmpv3User createUser(String authProtocol,
+                                         String autoPassPhrase,
+                                         String engineId,
+                                         String privatcyProtocol,
+                                         String privacyPassPhrase,
+                                         String securityName) {
+        Snmpv3User user = new Snmpv3User();
+        user.setAuthProtocol(authProtocol);
+        user.setAuthPassphrase(autoPassPhrase);
+        user.setEngineId(engineId);
+        user.setPrivacyPassphrase(privacyPassPhrase);
+        user.setPrivacyProtocol(privatcyProtocol);
+        user.setSecurityName(securityName);
+        return user;
+    }
+}

--- a/features/events/traps/src/test/java/org/opennms/netmgt/trapd/TrapdListenerBlueprintIT.java
+++ b/features/events/traps/src/test/java/org/opennms/netmgt/trapd/TrapdListenerBlueprintIT.java
@@ -31,18 +31,27 @@ package org.opennms.netmgt.trapd;
 import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.util.Dictionary;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.camel.ProducerTemplate;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.impl.DefaultCamelContext;
 import org.apache.camel.util.KeyValueHolder;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.opennms.core.camel.JaxbUtilsUnmarshalProcessor;
 import org.opennms.core.test.OpenNMSJUnit4ClassRunner;
 import org.opennms.core.test.camel.CamelBlueprintTest;
+import org.opennms.core.test.http.annotations.JUnitHttpServer;
 import org.opennms.core.utils.InetAddressUtils;
 import org.opennms.minion.core.api.RestClient;
+import org.opennms.netmgt.config.trapd.TrapdConfiguration;
 import org.opennms.netmgt.snmp.SnmpObjId;
 import org.opennms.netmgt.snmp.SnmpTrapBuilder;
 import org.opennms.netmgt.snmp.SnmpUtils;
@@ -67,11 +76,11 @@ public class TrapdListenerBlueprintIT extends CamelBlueprintTest {
 	private final TrapNotificationLatch m_handler = new TrapNotificationLatch(3);
 
 	private int m_port;
-	
+
 	private String trapConfiguration  = "<?xml version='1.0'?>"
-                + "<trapd-configuration xmlns='http://xmlns.opennms.org/xsd/config/trapd' snmp-trap-address='127.0.0.1' snmp-trap-port='10500' new-suspect-on-trap='true'>"
-                + "<snmpv3-user security-name='opennms' security-level='0' auth-protocol='MD5' auth-passphrase='0p3nNMSv3' privacy-protocol='DES' privacy-passphrase='0p3nNMSv3' />"
-                + "</trapd-configuration>";
+			+ "<trapd-configuration xmlns='http://xmlns.opennms.org/xsd/config/trapd' snmp-trap-address='127.0.0.1' snmp-trap-port='10500' new-suspect-on-trap='true'>"
+			+ "<snmpv3-user security-name='opennms' security-level='0' auth-protocol='MD5' auth-passphrase='0p3nNMSv3' privacy-protocol='DES' privacy-passphrase='0p3nNMSv3' />"
+			+ "</trapd-configuration>";
 
 	/**
 	 * This method overrides the blueprint property and sets port to 10514 instead of 162
@@ -95,21 +104,21 @@ public class TrapdListenerBlueprintIT extends CamelBlueprintTest {
 	@SuppressWarnings("rawtypes")
 	@Override
 	protected void addServicesOnStartup(Map<String, KeyValueHolder<Object, Dictionary>> services) {
-        RestClient client = new RestClient() {
-            @Override
-            public void ping() throws Exception {
-                // TODO Auto-generated method stub
+		RestClient client = new RestClient() {
+			@Override
+			public void ping() throws Exception {
+				// TODO Auto-generated method stub
 
-            }
+			}
 
-            @Override
-            public String getSnmpV3Users() throws Exception {
-                return trapConfiguration;
-            }
-        };
-	    
-	   services.put(RestClient.class.getName(), new KeyValueHolder<Object, Dictionary>(client, new Properties()));
-	   services.put(TrapNotificationHandler.class.getName(), new KeyValueHolder<Object, Dictionary>(m_handler, new Properties()));
+			@Override
+			public String getSnmpV3Users() throws Exception {
+				return trapConfiguration;
+			}
+		};
+
+		services.put(RestClient.class.getName(), new KeyValueHolder<Object, Dictionary>(client, new Properties()));
+		services.put(TrapNotificationHandler.class.getName(), new KeyValueHolder<Object, Dictionary>(m_handler, new Properties()));
 	}
 
 	// The location of our Blueprint XML files to be used for testing
@@ -140,7 +149,7 @@ public class TrapdListenerBlueprintIT extends CamelBlueprintTest {
 		public TrapNotification getLast() {
 			return m_last;
 		}
-}
+	}
 
 	@Test
 	public void testTrapd() throws Exception {
@@ -163,7 +172,7 @@ public class TrapdListenerBlueprintIT extends CamelBlueprintTest {
 		if (!m_handler.getLatch().await(30, TimeUnit.SECONDS)) {
 			fail("Countdown latch failed");
 		}
-		
+
 		TrapNotification notification = m_handler.getLast();
 		notification.setTrapProcessor(new TrapProcessor() {
 
@@ -221,7 +230,105 @@ public class TrapdListenerBlueprintIT extends CamelBlueprintTest {
 				assertEquals(new TrapIdentity(SnmpObjId.get(".1.3.6.1.4.1.5813"), 1, 0).toString(), trapIdentity.toString());
 			}
 		});
-		
+
 		notification.getTrapProcessor();
 	}
+
+	private static TrapdConfigBean getTrapConfiguration() {
+		TrapdConfigBean trapConfiguration = new TrapdConfigBean();
+		trapConfiguration.setSnmpTrapPort(10514);
+		trapConfiguration.setSnmpTrapAddress("127.0.0.1");
+		trapConfiguration.setNewSuspectOnTrap(false);
+		return trapConfiguration;
+	}
+
+	@Test
+	@JUnitHttpServer(port = 10500)
+	public void testRouteWithoutSnmpV3Users() throws Exception {
+		DefaultCamelContext camelContext = new DefaultCamelContext();
+		camelContext.addRoutes(new RouteBuilder() {
+			@Override
+			public void configure() throws Exception {
+				JaxbUtilsUnmarshalProcessor jaxbUnmarshaller = new JaxbUtilsUnmarshalProcessor(TrapdConfiguration.class);
+				TrapReceiverImpl trapReceiver = new TrapReceiverImpl(getTrapConfiguration());
+				from("http://localhost:10500/trapd-configuration-withoutSnmpV3Users.html").bean(jaxbUnmarshaller).bean(TrapdConfigBean.class,
+						"onUpdate").bean(trapReceiver, "setTrapdConfig").to("mock:result");
+			}
+		});
+		camelContext.start();
+
+		MockEndpoint mockEndPoint = camelContext.getEndpoint("mock:result", MockEndpoint.class);
+		mockEndPoint.expectedMessageCount(1);
+
+		ProducerTemplate producerTemplate = camelContext.createProducerTemplate();
+		producerTemplate.start();
+
+		mockEndPoint.assertIsSatisfied();
+
+		producerTemplate.stop();
+		camelContext.stop();
+	}
+
+	@Test
+	@JUnitHttpServer(port = 10500)
+	public void testRouteWithSnmpV3Users() throws Exception {
+
+		DefaultCamelContext camelContext = new DefaultCamelContext();
+		camelContext.addRoutes(new RouteBuilder() {
+			@Override
+			public void configure() throws Exception {
+				JaxbUtilsUnmarshalProcessor jaxbUnmarshaller = new JaxbUtilsUnmarshalProcessor(TrapdConfiguration.class);
+				TrapReceiverImpl trapReceiver = new TrapReceiverImpl(getTrapConfiguration());
+				from("http://localhost:10500/trapd-configuration-withSnmpV3Users.html").bean(jaxbUnmarshaller).bean(TrapdConfigBean.class,
+						"onUpdate").bean(trapReceiver, "setTrapdConfig").to("mock:result");
+			}
+		});
+		camelContext.start();
+
+		MockEndpoint mockEndPoint = camelContext.getEndpoint("mock:result", MockEndpoint.class);
+		mockEndPoint.expectedMessageCount(1);
+
+		ProducerTemplate producerTemplate = camelContext.createProducerTemplate();
+		producerTemplate.start();
+
+		mockEndPoint.assertIsSatisfied();
+
+		producerTemplate.stop();
+		camelContext.stop();
+	}
+
+	@Test
+	@JUnitHttpServer(port = 10500)
+	public void testRouteWithSnmpV3UsersMultipleTimes() throws Exception {
+		DefaultCamelContext camelContext = new DefaultCamelContext();
+		Set<Object> uniqueExchangesRouted = new HashSet<Object>();
+		camelContext.addRoutes(new RouteBuilder() {
+			@Override
+			public void configure() throws Exception {
+				JaxbUtilsUnmarshalProcessor jaxbUnmarshaller = new JaxbUtilsUnmarshalProcessor(TrapdConfiguration.class);
+				TrapReceiverImpl trapReciever = new TrapReceiverImpl(getTrapConfiguration());
+				from("timer:mytimer?period=100")
+				.to("http://localhost:10500/trapd-configuration-withSnmpV3Users.html")
+				.bean(jaxbUnmarshaller)
+				.bean(TrapdConfigBean.class, "onUpdate")
+				.bean(trapReciever, "setTrapdConfig").to("mock:result");
+			}
+		});
+		camelContext.start();
+
+		MockEndpoint mockEndPoint = camelContext.getEndpoint("mock:result", MockEndpoint.class);
+
+		if (mockEndPoint.getExchanges().toArray().length == 10) {
+			uniqueExchangesRouted.add(mockEndPoint.getExchanges().toArray());
+			assertEquals(1, uniqueExchangesRouted);
+		}
+		ProducerTemplate producerTemplate = camelContext.createProducerTemplate();
+		producerTemplate.start();
+
+		mockEndPoint.assertIsSatisfied();
+
+		producerTemplate.stop();
+		camelContext.stop();
+	}
+
 }

--- a/features/events/traps/src/test/resources/trapd-configuration-withSnmpV3Users.html
+++ b/features/events/traps/src/test/resources/trapd-configuration-withSnmpV3Users.html
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<trapd-configuration xmlns="http://xmlns.opennms.org/xsd/config/trapd"
+	snmp-trap-address="*" snmp-trap-port="162" new-suspect-on-trap="true">
+	<snmpv3-user security-name="opennms" security-level="0"
+		auth-protocol="MD5" auth-passphrase="0p3nNMSv3" privacy-protocol="DES"
+		privacy-passphrase="0p3nNMSv3" />
+</trapd-configuration>

--- a/features/events/traps/src/test/resources/trapd-configuration-withoutSnmpV3Users.html
+++ b/features/events/traps/src/test/resources/trapd-configuration-withoutSnmpV3Users.html
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<trapd-configuration xmlns="http://xmlns.opennms.org/xsd/config/trapd"
+	snmp-trap-address="*" snmp-trap-port="162" new-suspect-on-trap="true"/>
+


### PR DESCRIPTION
Added equals()/hashCode() and Map comparison to make sure that the collection isn't reloaded when it has not changed. There are also some additional tests for the new code.

* JIRA: http://issues.opennms.org/browse/NMS-8708
* Bamboo: http://bamboo.internal.opennms.com:8085/browse/OPENNMS-ONMS1136