### PR TITLE
NMS-8813: Suppress SNMP4J's InterruptedExceptions

### DIFF
--- a/opennms-base-assembly/src/main/filtered/etc/log4j2.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/log4j2.xml
@@ -144,6 +144,9 @@
     <logger name="com.datastax.driver" additivity="false" level="INFO">
       <appender-ref ref="RoutingAppender"/>
     </logger>
+    <logger name="org.snmp4j.transport" additivity="false" level="ERROR">
+      <appender-ref ref="RoutingAppender"/>
+    </logger>
 
     <!-- Allow any message to pass through the root logger -->
     <root level="DEBUG">


### PR DESCRIPTION
JIRA: https://issues.opennms.org/browse/NMS-8813

Here we decrease the log level on `org.snmp4j.transport` in order to suppress the non-fatal interrupted warnings. This is a new log message added in SNMP4J 2.4.x, which we pulled in NMS-8226.

Addressing the root cause requires more code changes then I'm comfortable with doing in 2016.1.4 or 18.0.3, so I suggest we revert this and address it in 19.0.0 instead.
