### PR TITLE
NMS-8813: Address SNMP4J's InterruptedExceptions

### DIFF
--- a/core/snmp/api/src/main/java/org/opennms/netmgt/snmp/SnmpUtils.java
+++ b/core/snmp/api/src/main/java/org/opennms/netmgt/snmp/SnmpUtils.java
@@ -121,37 +121,35 @@ public abstract class SnmpUtils {
 
         final List<SnmpValue> results = new ArrayList<SnmpValue>();
         
-        SnmpWalker walker=SnmpUtils.createWalker(agentConfig, name, new ColumnTracker(oid) {
-   
+        try(SnmpWalker walker=SnmpUtils.createWalker(agentConfig, name, new ColumnTracker(oid) {
             @Override
             protected void storeResult(SnmpResult res) {
                 results.add(res.getValue());
             }
-           
-        });
-        walker.start();
-        walker.waitFor();
+        })) {
+            walker.start();
+            walker.waitFor();
+        }
         return results;
     }
-    
+
     public static Map<SnmpInstId, SnmpValue> getOidValues(SnmpAgentConfig agentConfig, String name, SnmpObjId oid) 
 	throws InterruptedException {
 
         final Map<SnmpInstId, SnmpValue> results = new LinkedHashMap<SnmpInstId, SnmpValue>();
         
-        SnmpWalker walker=SnmpUtils.createWalker(agentConfig, name, new ColumnTracker(oid) {
-   
+        try(SnmpWalker walker=SnmpUtils.createWalker(agentConfig, name, new ColumnTracker(oid) {
             @Override
             protected void storeResult(SnmpResult res) {
                 results.put(res.getInstance(), res.getValue());
             }
-           
-        });
-	walker.start();
-	walker.waitFor();
+        })) {
+            walker.start();
+            walker.waitFor();
+        }
         return results;
     }
-    
+
     public static void setConfig(Properties config) {
         sm_config = config;
     }

--- a/core/snmp/api/src/main/java/org/opennms/netmgt/snmp/SnmpWalker.java
+++ b/core/snmp/api/src/main/java/org/opennms/netmgt/snmp/SnmpWalker.java
@@ -28,19 +28,13 @@
 
 package org.opennms.netmgt.snmp;
 
-import java.io.Closeable;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+public abstract class SnmpWalker implements AutoCloseable {
 
-public abstract class SnmpWalker implements Closeable {
-	
-	private static final transient Logger LOG = LoggerFactory.getLogger(SnmpWalker.class);
-    
     protected abstract static class WalkerPduBuilder extends PduBuilder {
         protected WalkerPduBuilder(int maxVarsPerPdu) {
             super(maxVarsPerPdu);
@@ -169,11 +163,6 @@ public abstract class SnmpWalker implements Closeable {
 
     private void finish() {
         signal();
-        try {
-            close();
-        } catch (IOException e) {
-            LOG.error("{}: Unexpected Error occured closing SNMP session for: {}", getName(), m_address, e);
-        }
         // Trigger the callback after the latch was decreased and the session was closed.
         if (m_callback != null) {
             Throwable t = null;
@@ -189,7 +178,7 @@ public abstract class SnmpWalker implements Closeable {
     }
 
     @Override
-    public abstract void close() throws IOException;
+    public abstract void close();
 
     public final String getName() {
         return m_name;
@@ -207,7 +196,7 @@ public abstract class SnmpWalker implements Closeable {
     public void waitFor() throws InterruptedException {
         m_signal.await();
     }
-    
+
     public boolean waitFor(long timeout) throws InterruptedException {
         return m_signal.await(timeout, TimeUnit.MILLISECONDS);
         /*

--- a/core/snmp/impl-mock/src/main/java/org/opennms/netmgt/snmp/mock/MockSnmpWalker.java
+++ b/core/snmp/impl-mock/src/main/java/org/opennms/netmgt/snmp/mock/MockSnmpWalker.java
@@ -166,7 +166,7 @@ public class MockSnmpWalker extends SnmpWalker {
     }
 
     @Override
-    public void close() throws IOException {
+    public void close() {
         m_executor.shutdown();
     }
 

--- a/core/snmp/impl-snmp4j/pom.xml
+++ b/core/snmp/impl-snmp4j/pom.xml
@@ -42,7 +42,6 @@
     <dependency>
       <groupId>org.opennms.core.snmp</groupId>
       <artifactId>org.opennms.core.snmp.api</artifactId>
-      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>commons-lang</groupId>

--- a/core/snmp/impl-snmp4j/src/main/java/org/opennms/netmgt/snmp/snmp4j/Snmp4JWalker.java
+++ b/core/snmp/impl-snmp4j/src/main/java/org/opennms/netmgt/snmp/snmp4j/Snmp4JWalker.java
@@ -231,9 +231,13 @@ public class Snmp4JWalker extends SnmpWalker {
     }
 
     @Override
-    public void close() throws IOException {
+    public void close() {
         if (m_session != null) {
-            m_session.close();
+            try {
+                m_session.close();
+            } catch (IOException e) {
+                LOG.error("{}: Unexpected Error occured closing SNMP session for: {}", getName(), m_agentConfig, e);
+            }
             m_session = null;
         }
     }

--- a/core/snmp/integration-tests/src/test/java/org/opennms/netmgt/snmp/SnmpTrackerIT.java
+++ b/core/snmp/integration-tests/src/test/java/org/opennms/netmgt/snmp/SnmpTrackerIT.java
@@ -178,12 +178,13 @@ public class SnmpTrackerIT implements InitializingBean {
         config.setVersion(SnmpAgentConfig.VERSION2C);
         config.setMaxVarsPerPdu(maxVarsPerPdu);
         config.setMaxRepetitions(maxRepetitions);
-        final SnmpWalker walker = SnmpUtils.createWalker(config, "test", c);
-        assertNotNull(walker);
-        walker.start();
-        walker.waitFor();
+        try(final SnmpWalker walker = SnmpUtils.createWalker(config, "test", c)) {
+            assertNotNull(walker);
+            walker.start();
+            walker.waitFor();
+        }
     }
-    
+
     @Override
     public void afterPropertiesSet() throws Exception {
         BeanUtils.assertAutowiring(this);

--- a/core/snmp/integration-tests/src/test/java/org/opennms/netmgt/snmp/mock/MockSnmpStrategyTest.java
+++ b/core/snmp/integration-tests/src/test/java/org/opennms/netmgt/snmp/mock/MockSnmpStrategyTest.java
@@ -223,9 +223,10 @@ public class MockSnmpStrategyTest {
     public void testTracker() throws Exception {
         final CountingColumnTracker ct = new CountingColumnTracker(SnmpObjId.get(".1.3.5.1.1"));
 
-        SnmpWalker walker = walk(ct, 10, 3);
-        walker.start();
-        walker.waitFor();
+        try(SnmpWalker walker = walk(ct, 10, 3)) {
+            walker.start();
+            walker.waitFor();
+        }
         assertEquals("number of columns returned must match test data", Long.valueOf(9).longValue(), ct.getCount());
     }
 
@@ -234,20 +235,22 @@ public class MockSnmpStrategyTest {
         final CountingColumnTracker ct = new CountingColumnTracker(SnmpObjId.get(".1.3.5.1.1"));
         final SnmpAgentConfig sac = getAgentConfig();
         sac.setPort(12345);
-        final SnmpWalker walker = SnmpUtils.createWalker(sac, "test", ct);
-        assertNotNull(walker);
-        walker.start();
-        walker.waitFor();
+        try(final SnmpWalker walker = SnmpUtils.createWalker(sac, "test", ct)) {
+            assertNotNull(walker);
+            walker.start();
+            walker.waitFor();
+        }
         assertEquals("it should match no columns (timeout)", Long.valueOf(0).longValue(), ct.getCount());
     }
 
     @Test
     public void testCallbackOnTrackerSuccess() throws Exception {
         final CountingColumnTracker ct = new CountingColumnTracker(SnmpObjId.get(".1.3.5.1.1"));
-        final SnmpWalker walker = walk(ct, 10, 3);
-        final CompletableFuture<Long> future = toCompletableFuture(ct, walker);
-        walker.start();
-        assertEquals("number of columns returned must match test data", Long.valueOf(9), future.get());
+        try(final SnmpWalker walker = walk(ct, 10, 3)) {
+            final CompletableFuture<Long> future = toCompletableFuture(ct, walker);
+            walker.start();
+            assertEquals("number of columns returned must match test data", Long.valueOf(9), future.get());
+        }
     }
 
     @Test
@@ -258,10 +261,11 @@ public class MockSnmpStrategyTest {
         final CountingColumnTracker ct = new CountingColumnTracker(SnmpObjId.get(".1.3.5.1.1"));
         final SnmpAgentConfig sac = getAgentConfig();
         sac.setPort(12345);
-        final SnmpWalker walker = SnmpUtils.createWalker(sac, "test", ct);
-        walker.start();
-        final CompletableFuture<Long> future = toCompletableFuture(ct, walker);
-        future.get();
+        try(final SnmpWalker walker = SnmpUtils.createWalker(sac, "test", ct)) {
+            walker.start();
+            final CompletableFuture<Long> future = toCompletableFuture(ct, walker);
+            future.get();
+        }
     }
 
     private static CompletableFuture<Long> toCompletableFuture(CountingColumnTracker ct, SnmpWalker walker) {

--- a/core/snmp/proxy-rpc-tests/src/test/java/org/opennms/netmgt/snmp/proxy/common/LocationAwareSnmpClientIT.java
+++ b/core/snmp/proxy-rpc-tests/src/test/java/org/opennms/netmgt/snmp/proxy/common/LocationAwareSnmpClientIT.java
@@ -152,9 +152,10 @@ public class LocationAwareSnmpClientIT extends CamelBlueprintTest {
     public void canWalkIpAddressTableDirectly() throws InterruptedException {
         // Gather the list of IP addresses
         final IPAddressGatheringTracker tracker = new IPAddressGatheringTracker();
-        SnmpWalker walker = SnmpUtils.createWalker(agentConfig, tracker.getDescription(), tracker);
-        walker.start();
-        walker.waitFor();
+        try(SnmpWalker walker = SnmpUtils.createWalker(agentConfig, tracker.getDescription(), tracker)) {
+            walker.start();
+            walker.waitFor();
+        }
         ExpectedResults.compareToKnownIpAddressList(tracker.getIpAddresses());
 
         // Now determine their interface indices using a different type of tracker
@@ -163,9 +164,10 @@ public class LocationAwareSnmpClientIT extends CamelBlueprintTest {
             ipAddrs.add(new SnmpInstId(InetAddressUtils.toOid(InetAddressUtils.addr(ipAddr))));
         }
         IpAddrTable ipAddrTable = new IpAddrTable(agentConfig.getAddress(), ipAddrs);
-        walker = SnmpUtils.createWalker(agentConfig, "ipAddrTable", ipAddrTable);
-        walker.start();
-        walker.waitFor();
+        try(SnmpWalker walker = SnmpUtils.createWalker(agentConfig, "ipAddrTable", ipAddrTable)) {
+            walker.start();
+            walker.waitFor();
+        }
         ExpectedResults.compareToKnownIfIndices(ipAddrTable.getIfIndices());
     }
 

--- a/core/test-api/lib/src/main/java/org/opennms/core/test/MockLogAppender.java
+++ b/core/test-api/lib/src/main/java/org/opennms/core/test/MockLogAppender.java
@@ -203,6 +203,7 @@ public class MockLogAppender {
         setProperty(MockLogger.LOG_KEY_PREFIX + "org.quartz", "INFO");
         setProperty(MockLogger.LOG_KEY_PREFIX + "org.snmp4j", "ERROR");
         setProperty(MockLogger.LOG_KEY_PREFIX + "org.snmp4j.agent", "ERROR");
+        setProperty(MockLogger.LOG_KEY_PREFIX + "org.snmp4j.transport", "WARN");
         setProperty(MockLogger.LOG_KEY_PREFIX + "org.springframework", "INFO");
         setProperty(MockLogger.LOG_KEY_PREFIX + "org.springframework.beans.factory.support", "WARN");
         setProperty(MockLogger.LOG_KEY_PREFIX + "org.springframework.context.support", "WARN");

--- a/features/juniper-tca-collector/src/main/java/org/opennms/netmgt/collectd/tca/TcaCollectionSet.java
+++ b/features/juniper-tca-collector/src/main/java/org/opennms/netmgt/collectd/tca/TcaCollectionSet.java
@@ -153,14 +153,15 @@ public class TcaCollectionSet extends AbstractCollectionSet {
 	protected void collect() throws CollectionException {
 		try {
 			TcaData tracker = new TcaData(m_agent.getAddress());
-			SnmpWalker walker = SnmpUtils.createWalker(m_agent.getAgentConfig(), "TcaCollector for " + m_agent.getHostAddress(), tracker);
-			walker.start();
-			LOG.debug("collect: successfully instantiated TCA Collector for {}", m_agent.getHostAddress());
+			try(SnmpWalker walker = SnmpUtils.createWalker(m_agent.getAgentConfig(), "TcaCollector for " + m_agent.getHostAddress(), tracker)) {
+    			walker.start();
+    			LOG.debug("collect: successfully instantiated TCA Collector for {}", m_agent.getHostAddress());
 
-			walker.waitFor();
-			LOG.info("collect: node TCA query for address {} complete.", m_agent.getHostAddress());
+    			walker.waitFor();
+    			LOG.info("collect: node TCA query for address {} complete.", m_agent.getHostAddress());
 
-			verifySuccessfulWalk(walker);
+    			verifySuccessfulWalk(walker);
+			}
 			process(tracker);
 
 			m_status = ServiceCollector.COLLECTION_SUCCEEDED;

--- a/features/juniper-tca-collector/src/test/java/org/opennms/netmgt/collectd/tca/TcaDataIT.java
+++ b/features/juniper-tca-collector/src/test/java/org/opennms/netmgt/collectd/tca/TcaDataIT.java
@@ -105,10 +105,11 @@ public class TcaDataIT implements InitializingBean {
 		InetAddress localhost = InetAddressUtils.getInetAddress(TEST_IP_ADDRESS);
 		SnmpAgentConfig agentConfig = SnmpPeerFactory.getInstance().getAgentConfig(localhost);
 		TcaData data = new TcaData(localhost);
-		SnmpWalker walker = SnmpUtils.createWalker(agentConfig, "TcaCollector for " + localhost, data);
-		walker.start();
-		walker.waitFor();
-		Assert.assertFalse(walker.failed());
+		try(SnmpWalker walker = SnmpUtils.createWalker(agentConfig, "TcaCollector for " + localhost, data)) {
+	        walker.start();
+	        walker.waitFor();
+	        Assert.assertFalse(walker.failed());
+		}
 		Assert.assertFalse(data.isEmpty());
 		Assert.assertEquals(2, data.getEntries().size());
 	}

--- a/features/nrtg/protocolcollector/tca/src/main/java/org/opennms/nrtg/protocolcollector/tca/internal/TcaProtocolCollector.java
+++ b/features/nrtg/protocolcollector/tca/src/main/java/org/opennms/nrtg/protocolcollector/tca/internal/TcaProtocolCollector.java
@@ -133,16 +133,16 @@ public class TcaProtocolCollector implements ProtocolCollector {
 
         CollectionTracker tracker = new AggregateTracker(trackers);
 
-        SnmpWalker walker = m_snmpStrategy.createWalker(snmpAgentConfig, "SnmpProtocolCollector for " + snmpAgentConfig.getAddress(), tracker);
-
-        walker.start();
-        try {
-            walker.waitFor();
-        } catch (InterruptedException e) {
-            // TODO What should we do here
+        try(SnmpWalker walker = m_snmpStrategy.createWalker(snmpAgentConfig, "SnmpProtocolCollector for " + snmpAgentConfig.getAddress(), tracker)) {
+            walker.start();
+            try {
+                walker.waitFor();
+            } catch (InterruptedException e) {
+                logger.error("Interuppted while waiting for collector. Results may be incomplete.", e);
+            }
         }
+
         return collectionJob;
-        
     }
 
     /*

--- a/features/poller/monitors/core/src/main/java/org/opennms/netmgt/poller/monitors/HostResourceSwRunMonitor.java
+++ b/features/poller/monitors/core/src/main/java/org/opennms/netmgt/poller/monitors/HostResourceSwRunMonitor.java
@@ -182,13 +182,15 @@ public class HostResourceSwRunMonitor extends SnmpMonitorStrategy {
             tracker.startAttempt();
 
             TableTracker tableTracker = new TableTracker(callback, serviceNameOidId, serviceStatusOidId);
-            SnmpWalker walker = SnmpUtils.createWalker(agentConfig, "HostResourceSwRunMonitor", tableTracker);
-            walker.start();
-            walker.waitFor();
-            String error = walker.getErrorMessage();
-            if (error != null && !error.trim().equals("")) {
-                LOG.warn(error);
-                return PollStatus.unavailable(error);
+            try(SnmpWalker walker = SnmpUtils.createWalker(agentConfig, "HostResourceSwRunMonitor", tableTracker)) {
+                walker.start();
+                walker.waitFor();
+
+                String error = walker.getErrorMessage();
+                if (error != null && !error.trim().equals("")) {
+                    LOG.warn(error);
+                    return PollStatus.unavailable(error);
+                }
             }
 
             // Iterate over the list of running services

--- a/features/poller/monitors/core/src/main/java/org/opennms/netmgt/poller/monitors/NetScalerGroupHealthMonitor.java
+++ b/features/poller/monitors/core/src/main/java/org/opennms/netmgt/poller/monitors/NetScalerGroupHealthMonitor.java
@@ -95,9 +95,10 @@ public class NetScalerGroupHealthMonitor extends SnmpMonitorStrategy {
                 }
             };
             TableTracker tracker = new TableTracker(callback, groupStateOid);
-            SnmpWalker walker = SnmpUtils.createWalker(agentConfig, "NetScalerGroupHealthMonitor", tracker);
-            walker.start();
-            walker.waitFor();
+            try (SnmpWalker walker = SnmpUtils.createWalker(agentConfig, "NetScalerGroupHealthMonitor", tracker)) {
+                walker.start();
+                walker.waitFor();
+            }
 
             int totalServers = hostResults.size();
             if (totalServers == 0) {

--- a/opennms-provision/opennms-snmp-scanners/src/main/java/org/opennms/netmgt/provision/scan/snmp/AbstractSnmpScanner.java
+++ b/opennms-provision/opennms-snmp-scanners/src/main/java/org/opennms/netmgt/provision/scan/snmp/AbstractSnmpScanner.java
@@ -118,14 +118,11 @@ public class AbstractSnmpScanner implements Scanner {
         }
 
         SnmpAgentConfig agentConfig = m_snmpAgentConfigFactory.getAgentConfig(agentAddress, null);
-        
-        SnmpWalker walker = SnmpUtils.createWalker(agentConfig, getName(), createCollectionTracker(context));
-        walker.start();
-        
-        walker.waitFor();
-        
-        
-        
+
+        try(SnmpWalker walker = SnmpUtils.createWalker(agentConfig, getName(), createCollectionTracker(context))) {
+            walker.start();
+            walker.waitFor();
+        }
     }
 
     /**

--- a/opennms-services/src/test/java/org/opennms/netmgt/collectd/SnmpCollectorITCase.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/collectd/SnmpCollectorITCase.java
@@ -316,6 +316,10 @@ public abstract class SnmpCollectorITCase extends OpenNMSITCase {
     }
 
     protected void waitForSignal() throws InterruptedException {
-        m_walker.waitFor();
+        try {
+            m_walker.waitFor();
+        } finally {
+            m_walker.close();
+        }
     }
 }


### PR DESCRIPTION
JIRA: https://issues.opennms.org/browse/NMS-8813

Here we address the root cause of the InterruptedException we have observed while using SNMP4J. The problem was due to the fact that we attempted to close the session within the callback thread, which prevented the SNMP4J library from cleanly closing the session, and logging the interrupted warning.

Calls to SnmpUtils.createWalker() now require an explicit close on the caller's behalf, which can be done using a `try-with-resources` block for synchronous calls, or a reaper thread when using asynchronous calls. To the best of my knowledge, all existing calls have been updated to use either of these and close the session.

