### PR TITLE
NMS-8803, HZN-811: Load Minion listeners from featuresBoot, fix zkclient

### DIFF
--- a/container/features/src/main/resources/features.xml
+++ b/container/features/src/main/resources/features.xml
@@ -802,6 +802,8 @@
 
       <feature>dropwizard-metrics</feature>
       <feature>lmax-disruptor</feature>
+      <!-- HZN-811: Missing dependency on zkclient, can be removed when we upgrade to Camel 2.16.0+ -->
+      <bundle dependency="true">wrap:mvn:com.101tec/zkclient/0.3$Bundle-Version=0.3&amp;Export-Package=*;-noimport:=true;version="0.3"</bundle>
 
       <feature>opennms-core</feature>
       <feature>opennms-core-camel</feature>
@@ -847,20 +849,28 @@
       <feature>opennms-syslogd</feature>
       -->
 
-      <bundle>blueprint:mvn:org.opennms.features.events/org.opennms.features.events.syslog/${project.version}/xml/blueprint-syslog-handler-default</bundle>
+      <!-- Naked blueprint bundles don't work in featuresBoot on Karaf 2.4.X so we have to wrap them in a JAR -->
+      <!-- <bundle>blueprint:mvn:org.opennms.features.events/org.opennms.features.events.syslog/${project.version}/xml/blueprint-syslog-handler-default</bundle> -->
+      <bundle>mvn:org.opennms.features.events/org.opennms.features.events.syslog/${project.version}/jar/blueprint-syslog-handler-default</bundle>
     </feature>
 
     <!-- TODO: Rename this. It's more of an Dominion-side syslog connection handler... -->
     <feature name="opennms-syslogd-handler-kafka-default" description="OpenNMS :: Syslogd :: Handler :: Kafka :: Default" version="${project.version}">
       <feature>camel-blueprint</feature>
+      <feature>camel-kafka</feature>
       <feature>opennms-core-camel</feature>
+
+      <!-- HZN-811: Missing dependency on zkclient, can be removed when we upgrade to Camel 2.16.0+ -->
+      <bundle dependency="true">wrap:mvn:com.101tec/zkclient/0.3$Bundle-Version=0.3&amp;Export-Package=*;-noimport:=true;version="0.3"</bundle>
 
       <!--
       These classes are in the system classpath inside OpenNMS
       <feature>opennms-syslogd</feature>
       -->
 
-      <bundle>blueprint:mvn:org.opennms.features.events/org.opennms.features.events.syslog/${project.version}/xml/blueprint-syslog-handler-kafka-default</bundle>
+      <!-- Naked blueprint bundles don't work in featuresBoot on Karaf 2.4.X so we have to wrap them in a JAR -->
+      <!-- <bundle>blueprint:mvn:org.opennms.features.events/org.opennms.features.events.syslog/${project.version}/xml/blueprint-syslog-handler-kafka-default</bundle> -->
+      <bundle>mvn:org.opennms.features.events/org.opennms.features.events.syslog/${project.version}/jar/blueprint-syslog-handler-kafka-default</bundle>
     </feature>
 
     <!-- TrapD feature -->
@@ -872,6 +882,9 @@
       <feature>camel-kafka</feature>
       <feature>camel-netty</feature>
       <feature version="${guavaVersion}">guava</feature>
+
+      <!-- HZN-811: Missing dependency on zkclient, can be removed when we upgrade to Camel 2.16.0+ -->
+      <bundle dependency="true">wrap:mvn:com.101tec/zkclient/0.3$Bundle-Version=0.3&amp;Export-Package=*;-noimport:=true;version="0.3"</bundle>
 
       <feature>opennms-core</feature>
       <feature>opennms-core-camel</feature>
@@ -904,20 +917,28 @@
       <feature>opennms-trapd</feature>
       -->
 
-      <bundle>blueprint:mvn:org.opennms.features.events/org.opennms.features.events.traps/${project.version}/xml/blueprint-trapd-handler-default</bundle>
+      <!-- Naked blueprint bundles don't work in featuresBoot on Karaf 2.4.X so we have to wrap them in a JAR -->
+      <!-- <bundle>blueprint:mvn:org.opennms.features.events/org.opennms.features.events.traps/${project.version}/xml/blueprint-trapd-handler-default</bundle> -->
+      <bundle>mvn:org.opennms.features.events/org.opennms.features.events.traps/${project.version}/jar/blueprint-trapd-handler-default</bundle>
     </feature>
 
     <!-- TODO: Rename this. It's more of an Dominion-side trap message handler... -->
     <feature name="opennms-trapd-handler-kafka-default" description="OpenNMS :: Trapd :: Handler :: Kafka :: Default" version="${project.version}">
       <feature>camel-blueprint</feature>
+      <feature>camel-kafka</feature>
       <feature>opennms-core-camel</feature>
+
+      <!-- HZN-811: Missing dependency on zkclient, can be removed when we upgrade to Camel 2.16.0+ -->
+      <bundle dependency="true">wrap:mvn:com.101tec/zkclient/0.3$Bundle-Version=0.3&amp;Export-Package=*;-noimport:=true;version="0.3"</bundle>
 
       <!--
       These classes are in the system classpath inside OpenNMS
       <feature>opennms-trapd</feature>
       -->
 
-      <bundle>blueprint:mvn:org.opennms.features.events/org.opennms.features.events.traps/${project.version}/xml/blueprint-trapd-handler-kafka-default</bundle>
+      <!-- Naked blueprint bundles don't work in featuresBoot on Karaf 2.4.X so we have to wrap them in a JAR -->
+      <!-- <bundle>blueprint:mvn:org.opennms.features.events/org.opennms.features.events.traps/${project.version}/xml/blueprint-trapd-handler-kafka-default</bundle> -->
+      <bundle>mvn:org.opennms.features.events/org.opennms.features.events.traps/${project.version}/jar/blueprint-trapd-handler-kafka-default</bundle>
     </feature>
 
     <feature name="tsrm-troubleticketer" version="${project.version}" description="OpenNMS :: Features :: Ticketing :: Tivoli Service Request Manager (TSRM)">

--- a/features/events/syslog/pom.xml
+++ b/features/events/syslog/pom.xml
@@ -81,6 +81,91 @@
           </execution>
         </executions>
       </plugin>
+      <!-- Copy all of the blueprint files into the target directory -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-resources-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>copy-blueprints</id>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${project.build.directory}/blueprints/OSGI-INF/blueprint</outputDirectory>
+              <resources>
+                <resource>
+                  <directory>${project.basedir}</directory>
+                  <filtering>false</filtering>
+                  <includes>
+                    <include>blueprint*.xml</include>
+                  </includes>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <!-- Wrap the blueprints that we need in featuresBoot on OpenNMS in JAR files -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>blueprint-syslog-handler-default</id>
+            <phase>package</phase>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+            <configuration>
+              <archive>
+                <manifestEntries>
+                  <Bundle-ManifestVersion>2</Bundle-ManifestVersion>
+                  <Bundle-SymbolicName>
+                    org.opennms.features.events.syslog.blueprint-syslog-handler-default
+                  </Bundle-SymbolicName>
+                  <Bundle-Version>${opennms.osgi.version}</Bundle-Version>
+                  <DynamicImport-Package>*</DynamicImport-Package>
+                  <!-- Avoid carriage returns here -->
+                  <Import-Package>org.apache.camel,org.opennms.core.camel,org.opennms.netmgt.syslogd</Import-Package>
+                </manifestEntries>
+              </archive>
+              <classifier>blueprint-syslog-handler-default</classifier>
+              <classesDirectory>${project.build.directory}/blueprints</classesDirectory>
+              <includes>
+                <include>OSGI-INF/blueprint/blueprint-syslog-handler-default.xml</include>
+              </includes>
+            </configuration>
+          </execution>
+          <execution>
+            <id>blueprint-syslog-handler-kafka-default</id>
+            <phase>package</phase>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+            <configuration>
+              <archive>
+                <manifestEntries>
+                  <Bundle-ManifestVersion>2</Bundle-ManifestVersion>
+                  <Bundle-SymbolicName>
+                    org.opennms.features.events.syslog.blueprint-syslog-handler-kafka-default
+                  </Bundle-SymbolicName>
+                  <Bundle-Version>${opennms.osgi.version}</Bundle-Version>
+                  <DynamicImport-Package>*</DynamicImport-Package>
+                  <!-- Avoid carriage returns here -->
+                  <Import-Package>org.apache.camel,org.opennms.core.camel,org.opennms.netmgt.syslogd</Import-Package>
+                </manifestEntries>
+              </archive>
+              <classifier>blueprint-syslog-handler-kafka-default</classifier>
+              <classesDirectory>${project.build.directory}/blueprints</classesDirectory>
+              <includes>
+                <include>OSGI-INF/blueprint/blueprint-syslog-handler-kafka-default.xml</include>
+              </includes>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
   <dependencies>

--- a/features/events/traps/pom.xml
+++ b/features/events/traps/pom.xml
@@ -73,6 +73,91 @@
           </execution>
         </executions>
       </plugin>
+      <!-- Copy all of the blueprint files into the target directory -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-resources-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>copy-blueprints</id>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${project.build.directory}/blueprints/OSGI-INF/blueprint</outputDirectory>
+              <resources>
+                <resource>
+                  <directory>${project.basedir}</directory>
+                  <filtering>false</filtering>
+                  <includes>
+                    <include>blueprint*.xml</include>
+                  </includes>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <!-- Wrap the blueprints that we need in featuresBoot on OpenNMS in JAR files -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>blueprint-trapd-handler-default</id>
+            <phase>package</phase>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+            <configuration>
+              <archive>
+                <manifestEntries>
+                  <Bundle-ManifestVersion>2</Bundle-ManifestVersion>
+                  <Bundle-SymbolicName>
+                    org.opennms.features.events.traps.blueprint-trapd-handler-default
+                  </Bundle-SymbolicName>
+                  <Bundle-Version>${opennms.osgi.version}</Bundle-Version>
+                  <DynamicImport-Package>*</DynamicImport-Package>
+                  <!-- Avoid carriage returns here -->
+                  <Import-Package>org.apache.camel,org.opennms.core.camel,org.opennms.netmgt.trapd</Import-Package>
+                </manifestEntries>
+              </archive>
+              <classifier>blueprint-trapd-handler-default</classifier>
+              <classesDirectory>${project.build.directory}/blueprints</classesDirectory>
+              <includes>
+                <include>OSGI-INF/blueprint/blueprint-trapd-handler-default.xml</include>
+              </includes>
+            </configuration>
+          </execution>
+          <execution>
+            <id>blueprint-trapd-handler-kafka-default</id>
+            <phase>package</phase>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+            <configuration>
+              <archive>
+                <manifestEntries>
+                  <Bundle-ManifestVersion>2</Bundle-ManifestVersion>
+                  <Bundle-SymbolicName>
+                    org.opennms.features.events.traps.blueprint-trapd-handler-kafka-default
+                  </Bundle-SymbolicName>
+                  <Bundle-Version>${opennms.osgi.version}</Bundle-Version>
+                  <DynamicImport-Package>*</DynamicImport-Package>
+                  <!-- Avoid carriage returns here -->
+                  <Import-Package>org.apache.camel,org.opennms.core.camel,org.opennms.netmgt.trapd</Import-Package>
+                </manifestEntries>
+              </archive>
+              <classifier>blueprint-trapd-handler-kafka-default</classifier>
+              <classesDirectory>${project.build.directory}/blueprints</classesDirectory>
+              <includes>
+                <include>OSGI-INF/blueprint/blueprint-trapd-handler-kafka-default.xml</include>
+              </includes>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
   <dependencies>

--- a/opennms-full-assembly/src/main/filtered-resources/etc/org.apache.karaf.features.cfg
+++ b/opennms-full-assembly/src/main/filtered-resources/etc/org.apache.karaf.features.cfg
@@ -18,11 +18,13 @@ featuresBoot=karaf-framework,ssh,config,features,management,\
   opennms-events-commands, \
   opennms-icmp-commands, \
   opennms-snmp-commands, \
+  opennms-syslogd-handler-default,\
   opennms-topology-runtime-browsers,\
   opennms-topology-runtime-linkd,\
   opennms-topology-runtime-vmware,\
   opennms-topology-runtime-application,\
   opennms-topology-runtime-bsm,\
+  opennms-trapd-handler-default,\
   opennms-provisioning-shell,\
   opennms-poller-shell,\
   opennms-topology-runtime-graphml,\

--- a/smoke-test/src/test/java/org/opennms/smoketest/minion/SyslogTest.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/minion/SyslogTest.java
@@ -36,7 +36,6 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertThat;
 
 import java.io.IOException;
-import java.io.PrintStream;
 import java.net.DatagramPacket;
 import java.net.DatagramSocket;
 import java.net.Inet4Address;
@@ -64,7 +63,6 @@ import org.opennms.smoketest.utils.HibernateDaoFactory;
 import org.opennms.test.system.api.NewTestEnvironment.ContainerAlias;
 import org.opennms.test.system.api.TestEnvironment;
 import org.opennms.test.system.api.TestEnvironmentBuilder;
-import org.opennms.test.system.api.utils.SshClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -104,26 +102,6 @@ public class SyslogTest {
     @Before
     public void checkForDocker() {
         Assume.assumeTrue(OpenNMSSeleniumTestCase.isDockerEnabled());
-    }
-
-    @Before
-    public void enableSyslog() throws Exception {
-        // Install the handler on the OpenNMS system (this should probably be installed by default)
-        final InetSocketAddress sshAddr = minionSystem.getServiceAddress(ContainerAlias.OPENNMS, 8101);
-        try (
-                final SshClient sshClient = new SshClient(sshAddr, "admin", "admin");
-        ) {
-            PrintStream pipe = sshClient.openShell();
-            // Install the syslog and trap handler features
-            pipe.println("features:install opennms-syslogd-handler-default opennms-trapd-handler-default");
-            pipe.println("features:list -i");
-            pipe.println("logout");
-            try {
-                await().atMost(2, MINUTES).until(sshClient.isShellClosedCallable());
-            } finally {
-                LOG.info("Karaf output:\n{}", sshClient.getStdout());
-            }
-        }
     }
 
     @Before

--- a/smoke-test/src/test/java/org/opennms/smoketest/minion/TrapTest.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/minion/TrapTest.java
@@ -32,7 +32,6 @@ import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 
-import java.io.PrintStream;
 import java.net.InetSocketAddress;
 import java.util.Date;
 import java.util.concurrent.Callable;
@@ -57,7 +56,6 @@ import org.opennms.smoketest.utils.HibernateDaoFactory;
 import org.opennms.test.system.api.NewTestEnvironment.ContainerAlias;
 import org.opennms.test.system.api.TestEnvironment;
 import org.opennms.test.system.api.TestEnvironmentBuilder;
-import org.opennms.test.system.api.utils.SshClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -100,24 +98,6 @@ public class TrapTest {
     @Test
     public void canReceiveTraps() throws Exception {
         Date startOfTest = new Date();
-
-        // Install the handler on the OpenNMS system (this should probably be installed by default)
-        final InetSocketAddress sshAddr = minionSystem.getServiceAddress(ContainerAlias.OPENNMS, 8101);
-        try (
-            final SshClient sshClient = new SshClient(sshAddr, "admin", "admin");
-        ) {
-            PrintStream pipe = sshClient.openShell();
-            // Install the syslog and trap handler features
-            pipe.println("features:install opennms-syslogd-handler-default opennms-trapd-handler-default");
-            pipe.println("features:list -i");
-            pipe.println("list");
-            pipe.println("logout");
-            try {
-                await().atMost(2, MINUTES).until(sshClient.isShellClosedCallable());
-            } finally {
-                LOG.info("Karaf output:\n{}", sshClient.getStdout());
-            }
-        }
 
         final InetSocketAddress trapAddr = minionSystem.getServiceAddress(ContainerAlias.MINION, 1162, "udp");
 


### PR DESCRIPTION
Wrapped blueprints for syslog and trap listeners in JARs so that they can be loaded from featuresBoot. Fixed missing zkclient dependency from camel-karaf.

* JIRA: http://issues.opennms.org/browse/NMS-8803
* JIRA: http://issues.opennms.org/browse/HZN-811
* Bamboo: http://bamboo.internal.opennms.com:8085/browse/OPENNMS-ONMS1142