### PR TITLE
NMS-8911: Update TemporaryDatabaseExecutionListener to use HikariCP during tests

### DIFF
--- a/core/db/src/main/castor/opennms-datasources.xsd
+++ b/core/db/src/main/castor/opennms-datasources.xsd
@@ -27,7 +27,7 @@
       <documentation>Database connection pool configuration.</documentation>
     </annotation>
     <complexType>
-      <attribute name="factory" type="string" use="optional" default="org.opennms.core.db.C3P0ConnectionFactory">
+      <attribute name="factory" type="string" use="optional" default="org.opennms.core.db.HikariCPConnectionFactory">
         <annotation><documentation>The connection pool implementation to use.</documentation></annotation>
       </attribute>
       <attribute name="idleTimeout" type="int" use="optional" default="600">

--- a/core/db/src/main/java/org/opennms/core/db/HikariCPConnectionFactory.java
+++ b/core/db/src/main/java/org/opennms/core/db/HikariCPConnectionFactory.java
@@ -205,7 +205,19 @@ public class HikariCPConnectionFactory extends BaseConnectionFactory {
      */
     @Override
     public void setIdleTimeout(final int idleTimeout) {
-        m_pool.setIdleTimeout(idleTimeout);
+        m_pool.setIdleTimeout(idleTimeout * 1000L);
+    }
+
+    /**
+     * Set the maximum lifetime of the connections in the pool (in milliseconds)
+     * which forces occasional connection recycling. This will probably only be 
+     * used inside tests although it might be a good idea to do it in production
+     * as well to reset server-side query caches and metrics.
+     * 
+     * @param maxLifetimeMs
+     */
+    public void setMaxLifetime(final int maxLifetimeMs) {
+        m_pool.setMaxLifetime(maxLifetimeMs);
     }
 
     /* (non-Javadoc)

--- a/core/test-api/db/src/main/java/org/opennms/core/test/db/TemporaryDatabaseExecutionListener.java
+++ b/core/test-api/db/src/main/java/org/opennms/core/test/db/TemporaryDatabaseExecutionListener.java
@@ -44,8 +44,8 @@ import javax.sql.DataSource;
 
 import org.junit.Test;
 import org.junit.internal.MethodSorter;
-import org.opennms.core.db.C3P0ConnectionFactory;
 import org.opennms.core.db.DataSourceFactory;
+import org.opennms.core.db.HikariCPConnectionFactory;
 import org.opennms.core.db.XADataSourceFactory;
 import org.opennms.core.test.db.annotations.JUnitTemporaryDatabase;
 import org.opennms.netmgt.config.opennmsDataSources.JdbcDataSource;
@@ -244,9 +244,10 @@ public class TemporaryDatabaseExecutionListener extends AbstractTestExecutionLis
 
         m_database = m_databases.remove();
 
-        // We should pool connections to simulate the behavior of OpenNMS where we use c3p0,
-        // but we also need to be able to shut down the connection pool reliably after tests
-        // complete which c3p0 isn't great at. So make it configurable.
+        // We should pool connections to simulate the behavior of OpenNMS,
+        // but we also need to be able to shut down the connection pool reliably
+        // after tests complete. Some connection pools aren't great at this
+        // so make it configurable.
         //
         if (jtd.poolConnections()) {
             JdbcDataSource ds = new JdbcDataSource();
@@ -256,7 +257,7 @@ public class TemporaryDatabaseExecutionListener extends AbstractTestExecutionLis
             ds.setUrl(System.getProperty(TemporaryDatabase.URL_PROPERTY, TemporaryDatabase.DEFAULT_URL) + m_database.getTestDatabase());
             ds.setClassName(System.getProperty(TemporaryDatabase.DRIVER_PROPERTY, TemporaryDatabase.DEFAULT_DRIVER));
 
-            C3P0ConnectionFactory pool = new C3P0ConnectionFactory(ds);
+            HikariCPConnectionFactory pool = new HikariCPConnectionFactory(ds);
 
             DataSourceFactory.setInstance(pool);
         } else {

--- a/core/test-api/db/src/main/java/org/opennms/core/test/db/TemporaryDatabaseExecutionListener.java
+++ b/core/test-api/db/src/main/java/org/opennms/core/test/db/TemporaryDatabaseExecutionListener.java
@@ -258,6 +258,9 @@ public class TemporaryDatabaseExecutionListener extends AbstractTestExecutionLis
             ds.setClassName(System.getProperty(TemporaryDatabase.DRIVER_PROPERTY, TemporaryDatabase.DEFAULT_DRIVER));
 
             HikariCPConnectionFactory pool = new HikariCPConnectionFactory(ds);
+            // NMS-8911: Reduce the max connection lifetime so that HikariCP recycles 
+            // connections more aggressively during tests
+            pool.setMaxLifetime(500);
 
             DataSourceFactory.setInstance(pool);
         } else {

--- a/features/alarm-change-notifier/main-module/src/test/resources/opennms-datasources.xml
+++ b/features/alarm-change-notifier/main-module/src/test/resources/opennms-datasources.xml
@@ -5,7 +5,7 @@
   http://www.opennms.org/xsd/config/opennms-datasources.xsd ">
 
   <!-- TEST FILE FOR LOADING ALARMCHANGE NOTIFIER WITH DATABASE INFORMATION -->
-  <connection-pool factory="org.opennms.core.db.C3P0ConnectionFactory"
+  <connection-pool factory="org.opennms.core.db.HikariCPConnectionFactory"
     idleTimeout="600"
     loginTimeout="3"
     minPool="50"


### PR DESCRIPTION
Happy turkey day!

* JIRA: https://issues.opennms.org/browse/NMS-8911
* Bamboo: http://bamboo.internal.opennms.com:8085/browse/OPENNMS-ONMS1156


