### PR TITLE
NMS-8776: Store reponse times by location.

### DIFF
--- a/core/test-api/services/src/main/java/org/opennms/netmgt/poller/mock/MockMonitoredService.java
+++ b/core/test-api/services/src/main/java/org/opennms/netmgt/poller/mock/MockMonitoredService.java
@@ -36,13 +36,19 @@ import org.opennms.netmgt.poller.MonitoredService;
 public class MockMonitoredService implements MonitoredService {
     private final int m_nodeId;
     private String m_nodeLabel;
+    private final String m_nodeLocation;
     private final String m_ipAddr;
     private final String m_svcName;
     private InetAddress m_inetAddr;
 
     public MockMonitoredService(int nodeId, String nodeLabel, InetAddress inetAddress, String svcName) {
+        this(nodeId, nodeLabel, null, inetAddress, svcName);
+    }
+
+    public MockMonitoredService(int nodeId, String nodeLabel, String nodeLocation, InetAddress inetAddress, String svcName) {
         m_nodeId = nodeId;
         m_nodeLabel = nodeLabel;
+        m_nodeLocation = nodeLocation;
         m_inetAddr = inetAddress;
         m_svcName = svcName;
         m_ipAddr = InetAddressUtils.str(m_inetAddr);
@@ -74,7 +80,7 @@ public class MockMonitoredService implements MonitoredService {
 
     @Override
     public String getNodeLocation() {
-        return null;
+        return m_nodeLocation;
     }
 
     @Override

--- a/opennms-dao-api/src/main/java/org/opennms/netmgt/dao/api/MonitoringLocationDao.java
+++ b/opennms-dao-api/src/main/java/org/opennms/netmgt/dao/api/MonitoringLocationDao.java
@@ -28,6 +28,7 @@
 
 package org.opennms.netmgt.dao.api;
 
+import org.opennms.netmgt.model.OnmsNode;
 import org.opennms.netmgt.model.monitoringLocations.OnmsMonitoringLocation;
 
 /**
@@ -40,6 +41,28 @@ import org.opennms.netmgt.model.monitoringLocations.OnmsMonitoringLocation;
 public interface MonitoringLocationDao extends OnmsDao<OnmsMonitoringLocation, String> {
 
 	public static final String DEFAULT_MONITORING_LOCATION_ID = "Default";
+
+	/**
+	 * Returns <b>true</b> if the given location name is <b>null</b> or the system default.
+	 *
+	 * @param locationName
+	 * @return
+	 */
+	public static boolean isDefaultLocationName(String locationName) {
+		return locationName == null || DEFAULT_MONITORING_LOCATION_ID.equals(locationName);
+	}
+
+	/**
+	 * Returns the name to which the given node is associated, or null if the if node
+	 * is associated to either the default location, or no location.
+	 *
+	 * @param node
+	 * @return
+	 */
+	public static String getLocationNameOrNullIfDefault(OnmsNode node) {
+		final String locationName = node.getLocation() != null ? node.getLocation().getLocationName() : null;
+		return isDefaultLocationName(locationName) ? null : locationName;
+	}
 
 	OnmsMonitoringLocation getDefaultLocation();
 }

--- a/opennms-dao/src/main/java/org/opennms/netmgt/dao/support/ResponseTimeResourceType.java
+++ b/opennms-dao/src/main/java/org/opennms/netmgt/dao/support/ResponseTimeResourceType.java
@@ -36,6 +36,7 @@ import java.util.Set;
 import org.opennms.core.utils.InetAddressUtils;
 import org.opennms.core.utils.LazySet;
 import org.opennms.netmgt.dao.api.IpInterfaceDao;
+import org.opennms.netmgt.dao.api.MonitoringLocationDao;
 import org.opennms.netmgt.dao.api.ResourceStorageDao;
 import org.opennms.netmgt.model.OnmsAttribute;
 import org.opennms.netmgt.model.OnmsIpInterface;
@@ -108,6 +109,9 @@ public final class ResponseTimeResourceType implements OnmsResourceType {
         // Grab the node entity
         final OnmsNode node = ResourceTypeUtils.getNodeFromResource(parent);
 
+        // Determine the location name
+        final String locationName = MonitoringLocationDao.getLocationNameOrNullIfDefault(node);
+
         // Grab the interface
         final OnmsIpInterface matchingIf = m_ipInterfaceDao.get(node, ipAddress);
         if (matchingIf == null) {
@@ -116,13 +120,13 @@ public final class ResponseTimeResourceType implements OnmsResourceType {
         }
 
         // Verify the path
-        final ResourcePath path = getInterfacePath(ipAddress);
+        final ResourcePath path = getInterfacePath(locationName, ipAddress);
         if (!m_resourceStorageDao.exists(path, 0)) {
             throw new ObjectRetrievalFailureException(OnmsResource.class, "No metrics found in parent path '" + parent.getPath() + "'");
         }
 
         // Create the resource
-        final OnmsResource resource = createResource(matchingIf, ipAddress, path);
+        final OnmsResource resource = createResource(locationName, matchingIf, ipAddress, path);
         resource.setParent(parent);
         return resource;
     }
@@ -135,14 +139,17 @@ public final class ResponseTimeResourceType implements OnmsResourceType {
         // Grab the node entity
         final OnmsNode node = ResourceTypeUtils.getNodeFromResource(parent);
 
+        // Determine the location name
+        final String locationName = MonitoringLocationDao.getLocationNameOrNullIfDefault(node);
+
         // Verify the existence of the individual interfaces
         final LinkedList<OnmsResource> resources = new LinkedList<OnmsResource>();
         for (final OnmsIpInterface i : node.getIpInterfaces()) {
             String ipAddr = InetAddressUtils.str(i.getIpAddress());
 
-            final ResourcePath path = getInterfacePath(ipAddr);
+            final ResourcePath path = getInterfacePath(locationName, ipAddr);
             if (m_resourceStorageDao.exists(path, 0)) {
-                resources.add(createResource(i, ipAddr, path));
+                resources.add(createResource(locationName, i, ipAddr, path));
                 if (stopAfterFirst) {
                     break;
                 }
@@ -151,15 +158,21 @@ public final class ResponseTimeResourceType implements OnmsResourceType {
         return resources;
     }
 
-    private OnmsResource createResource(final OnmsIpInterface ipInterface, final String ipAddr, final ResourcePath path) {
+    private OnmsResource createResource(final String location, final OnmsIpInterface ipInterface, final String ipAddr, final ResourcePath path) {
     	final LazyResourceAttributeLoader loader = new LazyResourceAttributeLoader(m_resourceStorageDao, path);
     	final Set<OnmsAttribute> set = new LazySet<OnmsAttribute>(loader);
-    	final OnmsResource resource = new OnmsResource(ipAddr, ipAddr, this, set, path);
+        final OnmsResource resource = new OnmsResource(ipAddr, ipAddr, this, set, path);
     	resource.setEntity(ipInterface);
         return resource;
     }
 
-    private static ResourcePath getInterfacePath(String ipAddr) {
-        return new ResourcePath(ResourceTypeUtils.RESPONSE_DIRECTORY, ipAddr);
+    private static ResourcePath getInterfacePath(final String location, final String ipAddr) {
+        if (location == null) {
+            return new ResourcePath(ResourceTypeUtils.RESPONSE_DIRECTORY, ipAddr);
+        } else {
+            return new ResourcePath(ResourceTypeUtils.RESPONSE_DIRECTORY, ResourcePath.sanitize(location), ipAddr);
+        }
     }
+
+
 }

--- a/opennms-model/src/main/java/org/opennms/netmgt/model/ResourcePath.java
+++ b/opennms-model/src/main/java/org/opennms/netmgt/model/ResourcePath.java
@@ -6,6 +6,7 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.regex.Pattern;
 
 /**
  * An abstract path used to represent a resource or its parent.
@@ -17,6 +18,9 @@ import java.util.List;
  * @author jwhite
  */
 public class ResourcePath implements Iterable<String>, Comparable<ResourcePath> {
+
+    private static final Pattern SANITIZE_PATH_PATTERN = Pattern.compile("[^a-zA-Z0-9.-]");
+    private static final String SANITIZE_PATH_PLACEHOLDER = "_";
 
     private final List<String> m_elements = new ArrayList<String>();
 
@@ -172,4 +176,10 @@ public class ResourcePath implements Iterable<String>, Comparable<ResourcePath> 
         return this.toString().compareTo(other.toString());
     }
 
+    public static String sanitize(String path) {
+        if (path == null) {
+            return null;
+        }
+        return SANITIZE_PATH_PATTERN.matcher(path).replaceAll(SANITIZE_PATH_PLACEHOLDER);
+    }
 }

--- a/opennms-model/src/test/java/org/opennms/netmgt/model/ResourcePathTest.java
+++ b/opennms-model/src/test/java/org/opennms/netmgt/model/ResourcePathTest.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2016-2016 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2016 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.model;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class ResourcePathTest {
+
+    @Test
+    public void canSanitizePath() {
+        assertEquals("abc123", ResourcePath.sanitize("abc123"));
+        assertEquals("My_Path_", ResourcePath.sanitize("My Path!"));
+        assertEquals("_________", ResourcePath.sanitize("¯\\_(ツ)_/¯"));
+    }
+}

--- a/opennms-services/src/main/java/org/opennms/netmgt/poller/LatencyCollectionResource.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/poller/LatencyCollectionResource.java
@@ -39,6 +39,8 @@ import org.opennms.netmgt.collection.api.CollectionResource;
 import org.opennms.netmgt.collection.api.CollectionSetVisitor;
 import org.opennms.netmgt.collection.api.ServiceParameters;
 import org.opennms.netmgt.collection.api.TimeKeeper;
+import org.opennms.netmgt.dao.api.MonitoringLocationDao;
+import org.opennms.netmgt.model.ResourcePath;
 
 import com.google.common.collect.Maps;
 
@@ -52,6 +54,7 @@ public class LatencyCollectionResource implements CollectionResource {
 
     private final String m_serviceName;
     private final String m_ipAddress;
+    private final String m_location;
     private final Map<AttributeGroupType, AttributeGroup> m_attributeGroups = Maps.newLinkedHashMap();
 
     /**
@@ -59,10 +62,12 @@ public class LatencyCollectionResource implements CollectionResource {
      *
      * @param serviceName a {@link java.lang.String} object.
      * @param ipAddress a {@link java.lang.String} object.
+     * @param location a {@link java.lang.String} object.
      */
-    public LatencyCollectionResource(String serviceName, String ipAddress) {
+    public LatencyCollectionResource(String serviceName, String ipAddress, String location) {
         m_serviceName = serviceName;
         m_ipAddress = ipAddress;
+        m_location = location;
     }
 
     /**
@@ -176,13 +181,17 @@ public class LatencyCollectionResource implements CollectionResource {
 
     @Override
     public Path getPath() {
-        return Paths.get(m_ipAddress);
+        if (MonitoringLocationDao.isDefaultLocationName(m_location)) {
+            return Paths.get(m_ipAddress);
+        } else {
+            return Paths.get(ResourcePath.sanitize(m_location), m_ipAddress);
+        }
     }
 
     /** {@inheritDoc} */
     @Override
     public String toString() {
-        return m_serviceName + "@" + m_ipAddress;
+        return String.format("%s on %s at %s", m_serviceName, m_ipAddress, m_location);
     }
 
     @Override

--- a/opennms-services/src/main/java/org/opennms/netmgt/poller/pollables/LatencyStoringServiceMonitorAdaptor.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/poller/pollables/LatencyStoringServiceMonitorAdaptor.java
@@ -130,7 +130,7 @@ public class LatencyStoringServiceMonitorAdaptor implements ServiceMonitorAdapto
             if (m_thresholdingSet == null) {
                 RrdRepository repository = new RrdRepository();
                 repository.setRrdBaseDir(new File(rrdPath));
-                m_thresholdingSet = new LatencyThresholdingSet(service.getNodeId(), service.getIpAddr(), service.getSvcName(), repository, m_resourceStorageDao);
+                m_thresholdingSet = new LatencyThresholdingSet(service.getNodeId(), service.getIpAddr(), service.getSvcName(), service.getNodeLocation(), repository, m_resourceStorageDao);
             }
             LinkedHashMap<String, Double> attributes = new LinkedHashMap<String, Double>();
             for (String ds : entries.keySet()) {
@@ -170,7 +170,7 @@ public class LatencyStoringServiceMonitorAdaptor implements ServiceMonitorAdapto
         // 2) If multiple entries are present, the DSs are created in the same order that they
         //    appear in the map
 
-        LatencyCollectionResource latencyResource = new LatencyCollectionResource(service.getSvcName(), service.getIpAddr());
+        LatencyCollectionResource latencyResource = new LatencyCollectionResource(service.getSvcName(), service.getIpAddr(), service.getNodeLocation());
         for (final Entry<String, Number> entry : entries.entrySet()) {
             final String ds = entry.getKey();
             final Number value = entry.getValue() != null ? entry.getValue() : Double.NaN;

--- a/opennms-services/src/main/java/org/opennms/netmgt/threshd/LatencyThresholdingSet.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/threshd/LatencyThresholdingSet.java
@@ -51,6 +51,8 @@ import org.opennms.netmgt.xml.event.Event;
  */
 public class LatencyThresholdingSet extends ThresholdingSet {
 
+    private final String m_location;
+
     private final ResourceStorageDao m_resourceStorageDao;
 
     /**
@@ -62,9 +64,10 @@ public class LatencyThresholdingSet extends ThresholdingSet {
      * @param repository a {@link org.opennms.netmgt.rrd.RrdRepository} object.
      * @param interval a long.
      */
-    public LatencyThresholdingSet(int nodeId, String hostAddress, String serviceName, RrdRepository repository, ResourceStorageDao resourceStorageDao) {
+    public LatencyThresholdingSet(int nodeId, String hostAddress, String serviceName, String location, RrdRepository repository, ResourceStorageDao resourceStorageDao) {
         super(nodeId, hostAddress, serviceName, repository);
         m_resourceStorageDao = resourceStorageDao;
+        m_location = location;
     }
 
     /*
@@ -92,7 +95,7 @@ public class LatencyThresholdingSet extends ThresholdingSet {
      */
     /** {@inheritDoc} */
     public List<Event> applyThresholds(String svcName, Map<String, Double> attributes) {
-        LatencyCollectionResource latencyResource = new LatencyCollectionResource(svcName, m_hostAddress);
+        LatencyCollectionResource latencyResource = new LatencyCollectionResource(svcName, m_hostAddress, m_location);
         LatencyCollectionAttributeType latencyType = new LatencyCollectionAttributeType();
         Map<String, CollectionAttribute> attributesMap = new HashMap<String, CollectionAttribute>();
         for (final Entry<String, Double> entry : attributes.entrySet()) {

--- a/opennms-services/src/test/java/org/opennms/netmgt/poller/pollables/LatencyStoringServiceMonitorAdaptorIT.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/poller/pollables/LatencyStoringServiceMonitorAdaptorIT.java
@@ -57,6 +57,7 @@ import org.opennms.netmgt.config.PollOutagesConfigFactory;
 import org.opennms.netmgt.config.PollerConfig;
 import org.opennms.netmgt.config.poller.Package;
 import org.opennms.netmgt.config.poller.Rrd;
+import org.opennms.netmgt.dao.api.MonitoringLocationDao;
 import org.opennms.netmgt.dao.api.ResourceStorageDao;
 import org.opennms.netmgt.dao.mock.MockEventIpcManager;
 import org.opennms.netmgt.events.api.EventConstants;
@@ -224,6 +225,7 @@ public class LatencyStoringServiceMonitorAdaptorIT implements TemporaryDatabaseA
         expect(svc.getNodeId()).andReturn(1);
         expect(svc.getIpAddr()).andReturn("127.0.0.1").atLeastOnce();
         expect(svc.getSvcName()).andReturn("ICMP").atLeastOnce();
+        expect(svc.getNodeLocation()).andReturn(MonitoringLocationDao.DEFAULT_MONITORING_LOCATION_ID).atLeastOnce();
 
         ServiceMonitor service = new MockServiceMonitor(rtValues);
 

--- a/opennms-services/src/test/java/org/opennms/netmgt/poller/pollables/LatencyStoringServiceMonitorAdaptorPersistenceTest.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/poller/pollables/LatencyStoringServiceMonitorAdaptorPersistenceTest.java
@@ -30,6 +30,7 @@ package org.opennms.netmgt.poller.pollables;
 
 import java.io.File;
 import java.net.InetAddress;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -43,6 +44,7 @@ import org.junit.rules.TemporaryFolder;
 import org.opennms.core.test.MockLogAppender;
 import org.opennms.netmgt.collection.persistence.rrd.RrdPersisterFactory;
 import org.opennms.netmgt.config.poller.Package;
+import org.opennms.netmgt.dao.api.MonitoringLocationDao;
 import org.opennms.netmgt.dao.support.FilesystemResourceStorageDao;
 import org.opennms.netmgt.mock.MockNetwork;
 import org.opennms.netmgt.mock.MockPollerConfig;
@@ -91,6 +93,22 @@ public class LatencyStoringServiceMonitorAdaptorPersistenceTest {
 
     @Test
     public void canPersistsLatencySamples() throws Exception {
+        // No location - the path in the response time folder should be the IP address
+        persistAndVerifyLatencySamples(null, Paths.get("192.168.1.5"));
+
+        // Default location - the path in the response time folder should be the IP address
+        persistAndVerifyLatencySamples(MonitoringLocationDao.DEFAULT_MONITORING_LOCATION_ID, Paths.get("192.168.1.5"));
+
+        // Non-default location - the path in the response time folder should be the location name, and then the IP address
+        final String nonDefaultLocation = "not_" + MonitoringLocationDao.DEFAULT_MONITORING_LOCATION_ID;
+        persistAndVerifyLatencySamples(nonDefaultLocation, Paths.get(nonDefaultLocation, "192.168.1.5"));
+
+        // Location with special characters
+        final String someLocation = "TOG @ Pittsboro, NC";
+        persistAndVerifyLatencySamples(someLocation, Paths.get("TOG___Pittsboro__NC", "192.168.1.5"));
+    }
+
+    private void persistAndVerifyLatencySamples(String locationName, Path pathToResourceInResponseTime) throws Exception {
         PollStatus pollStatus = PollStatus.get(PollStatus.SERVICE_AVAILABLE, 42.1);
         // For the purposes of this test, it's important the attributes are not added in lexicographical order
         Map<String, Number> props = new LinkedHashMap<String,Number>(pollStatus.getProperties());
@@ -110,7 +128,7 @@ public class LatencyStoringServiceMonitorAdaptorPersistenceTest {
         LatencyStoringServiceMonitorAdaptor lssma = new LatencyStoringServiceMonitorAdaptor(
                 pollerConfig, pkg, m_persisterFactory, m_resourceStorageDao);
 
-        MonitoredService monitoredService = new MockMonitoredService(3, "Firewall",
+        MonitoredService monitoredService = new MockMonitoredService(3, "Firewall", locationName,
                 InetAddress.getByName("192.168.1.5"), "SMTP");
 
         Map<String, Object> params = Maps.newHashMap();
@@ -120,8 +138,7 @@ public class LatencyStoringServiceMonitorAdaptorPersistenceTest {
         EasyMock.expect(m_rrdStrategy.getDefaultFileExtension()).andReturn(".jrb").atLeastOnce();
 
         m_rrdStrategy.createDefinition(EasyMock.eq("192.168.1.5"),
-                EasyMock.eq(getResponseTimeRoot().toPath()
-                .resolve(Paths.get("192.168.1.5")).toString()),
+                EasyMock.eq(getResponseTimeRoot().toPath().resolve(pathToResourceInResponseTime).toString()),
                 EasyMock.eq("smtp-base"),
                 EasyMock.anyInt(),
                 EasyMock.anyObject(),
@@ -132,7 +149,7 @@ public class LatencyStoringServiceMonitorAdaptorPersistenceTest {
         EasyMock.expectLastCall().once();
 
         m_rrdStrategy.openFile(EasyMock.eq(getResponseTimeRoot().toPath()
-                .resolve(Paths.get("192.168.1.5", "smtp-base.jrb")).toString()));
+                .resolve(pathToResourceInResponseTime.resolve("smtp-base.jrb")).toString()));
         EasyMock.expectLastCall().andReturn(null).once();
 
         // This is the important bit, the order of the values should match the order there were inserted above
@@ -146,6 +163,9 @@ public class LatencyStoringServiceMonitorAdaptorPersistenceTest {
 
         // Verify
         EasyMock.verify(m_rrdStrategy);
+
+        // Reset
+        EasyMock.reset(m_rrdStrategy);
     }
 
     public File getResponseTimeRoot() {

--- a/opennms-services/src/test/java/org/opennms/netmgt/threshd/LatencyThresholdingSetIT.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/threshd/LatencyThresholdingSetIT.java
@@ -266,7 +266,7 @@ public class LatencyThresholdingSetIT implements TemporaryDatabaseAware<MockData
     public void testBug3488() throws Exception {
         String ipAddress = "127.0.0.1";
         setupSnmpInterfaceDatabase(m_db, ipAddress, null);
-        LatencyThresholdingSet thresholdingSet = new LatencyThresholdingSet(1, ipAddress, "HTTP", getRepository(), m_resourceStorageDao);
+        LatencyThresholdingSet thresholdingSet = new LatencyThresholdingSet(1, ipAddress, "HTTP", null, getRepository(), m_resourceStorageDao);
         assertTrue(thresholdingSet.hasThresholds()); // Global Test
         Map<String, Double> attributes = new HashMap<String, Double>();
         attributes.put("http", 200.0);
@@ -296,7 +296,7 @@ public class LatencyThresholdingSetIT implements TemporaryDatabaseAware<MockData
         String ipAddress = "127.0.0.1";
         String ifName = "eth0";
         setupSnmpInterfaceDatabase(m_db, ipAddress, ifName);
-        LatencyThresholdingSet thresholdingSet = new LatencyThresholdingSet(1, ipAddress, "StrafePing", getRepository(), m_resourceStorageDao);
+        LatencyThresholdingSet thresholdingSet = new LatencyThresholdingSet(1, ipAddress, "StrafePing", null, getRepository(), m_resourceStorageDao);
         assertTrue(thresholdingSet.hasThresholds());
         Map<String, Double> attributes = new HashMap<String, Double>();
         for (double i=1; i<21; i++) {
@@ -328,7 +328,7 @@ public class LatencyThresholdingSetIT implements TemporaryDatabaseAware<MockData
         String ifName = "lo0";
         setupSnmpInterfaceDatabase(m_db, "127.0.0.1", ifName);
 
-        LatencyThresholdingSet thresholdingSet = new LatencyThresholdingSet(1, "127.0.0.1", "HTTP", getRepository(), m_resourceStorageDao);
+        LatencyThresholdingSet thresholdingSet = new LatencyThresholdingSet(1, "127.0.0.1", "HTTP", null, getRepository(), m_resourceStorageDao);
         assertTrue(thresholdingSet.hasThresholds()); // Global Test
         Map<String, Double> attributes = new HashMap<String, Double>();
         attributes.put("http", 90.0);
@@ -382,7 +382,7 @@ public class LatencyThresholdingSetIT implements TemporaryDatabaseAware<MockData
         String ifName = "lo0";
         setupSnmpInterfaceDatabase(m_db, "127.0.0.1", ifName);
 
-        LatencyThresholdingSet thresholdingSet = new LatencyThresholdingSet(1, "127.0.0.1", "HTTP", getRepository(), m_resourceStorageDao);
+        LatencyThresholdingSet thresholdingSet = new LatencyThresholdingSet(1, "127.0.0.1", "HTTP", null, getRepository(), m_resourceStorageDao);
         assertTrue(thresholdingSet.hasThresholds()); // Global Test
         Map<String, Double> attributes = new HashMap<String, Double>();
         attributes.put("http", 90.0);


### PR DESCRIPTION
JIRA: https://issues.opennms.org/browse/NMS-8776

With this patch, response times for nodes in a non-default location are now stored in `$OPENNMS_HOME/share/rrd/response/$LOCATION/$IP/`. Response times for nodes in the default location continue to be stored in `$OPENNMS_HOME/share/rrd/response/$IP/`
