### PR TITLE
NMS-8906: Make the Jira Ticketer Plugin work with https secured jira instances

### DIFF
--- a/features/ticketing/jira-client/dependency-reduced-pom.xml
+++ b/features/ticketing/jira-client/dependency-reduced-pom.xml
@@ -51,8 +51,8 @@
         <extensions>true</extensions>
         <configuration>
           <instructions>
-            <Import-Package>org.joda.time,org.joda.time.format;version=${jodaTimeVersion},javax.ws.rs,javax.ws.rs.core,javax.ws.rs.ext,javax.net.ssl,javax.naming,org.apache.commons.logging,org.springframework.beans.factory</Import-Package>
-            <Export-Package>com.atlassian.jira.rest.client.api,com.atlassian.jira.rest.client.auth,com.atlassian.jira.rest.client.api.domain,com.atlassian.jira.rest.client.api.domain.input,com.atlassian.jira.rest.client.internal.async,com.atlassian.util.concurrent</Export-Package>
+            <Import-Package>javax.security.auth,javax.security.auth.x500,org.joda.time,org.joda.time.format;version=${jodaTimeVersion},javax.ws.rs,javax.ws.rs.core,javax.ws.rs.ext,javax.net.ssl,javax.naming,javax.naming.ldap,javax.naming.directory,org.apache.commons.logging,org.springframework.beans.factory</Import-Package>
+            <Export-Package>com.atlassian.jira.rest.client.api,com.atlassian.jira.rest.client.auth,com.atlassian.jira.rest.client.api.domain,com.atlassian.jira.rest.client.api.domain.input,com.atlassian.jira.rest.client.internal.async,com.atlassian.util.concurrent,com.atlassian.httpclient.apache.httpcomponents</Export-Package>
           </instructions>
           <unpackBundle>true</unpackBundle>
         </configuration>

--- a/features/ticketing/jira-client/pom.xml
+++ b/features/ticketing/jira-client/pom.xml
@@ -57,8 +57,8 @@
             <extensions>true</extensions>
             <configuration>
                 <instructions>
-                    <Import-Package>org.joda.time,org.joda.time.format;version=${jodaTimeVersion},javax.ws.rs,javax.ws.rs.core,javax.ws.rs.ext,javax.net.ssl,javax.naming,org.apache.commons.logging,org.springframework.beans.factory</Import-Package>
-                    <Export-Package>com.atlassian.jira.rest.client.api,com.atlassian.jira.rest.client.auth,com.atlassian.jira.rest.client.api.domain,com.atlassian.jira.rest.client.api.domain.input,com.atlassian.jira.rest.client.internal.async,com.atlassian.util.concurrent</Export-Package>
+                    <Import-Package>javax.security.auth,javax.security.auth.x500,org.joda.time,org.joda.time.format;version=${jodaTimeVersion},javax.ws.rs,javax.ws.rs.core,javax.ws.rs.ext,javax.net.ssl,javax.naming,javax.naming.ldap,javax.naming.directory,org.apache.commons.logging,org.springframework.beans.factory</Import-Package>
+                    <Export-Package>com.atlassian.jira.rest.client.api,com.atlassian.jira.rest.client.auth,com.atlassian.jira.rest.client.api.domain,com.atlassian.jira.rest.client.api.domain.input,com.atlassian.jira.rest.client.internal.async,com.atlassian.util.concurrent,com.atlassian.httpclient.apache.httpcomponents</Export-Package>
                 </instructions>
                 <unpackBundle>true</unpackBundle>
             </configuration>


### PR DESCRIPTION
* JIRA: https://issues.opennms.org/browse/NMS-8906

Please merge AFTER PR https://github.com/OpenNMS/opennms/pull/1161

To verify if this works, install the `jira-troubleticketer` plugin and afterwards type in the following command in the Karaf Shell: `jira:list-projects -h https://issues.opennms.org -a`

This should list all projects visible to an anonymous (or not logged in) user.
