### PR TITLE
NMS-8697: merge the XML collector into the core package

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -152,6 +152,8 @@ Package: opennms-common
 Architecture: all
 Depends: ${perl:Depends}, libdbi-perl, libdbd-pg-perl, libgetopt-mixed-perl
 Recommends: libnet-snmp-perl, libxml2-utils, libwww-perl, libxml-twig-perl
+Conflicts: opennms-plugin-protocol-xml (<<${binary:Version})
+Replaces: opennms-plugin-protocol-xml (<<${binary:Version})
 Description: Enterprise-grade Open-source Network Management Platform (Common Files)
  OpenNMS is an enterprise-grade network management system written in Java.
  .
@@ -167,7 +169,8 @@ Description: Enterprise-grade Open-source Network Management Platform (Common Fi
 Package: libopennms-java
 Architecture: all
 Depends: oracle-java8-installer | openjdk-8-jre | java8-runtime | java8-runtime-headless, jicmp (>= 2.0.0), jicmp6 (>= 2.0.0)
-Replaces: opennms-common (<< 1.3.0), libicmp-jni (<< 1.3.0)
+Conflicts: opennms-plugin-protocol-xml (<<${binary:Version})
+Replaces: opennms-common (<< 1.3.0), libicmp-jni (<< 1.3.0), opennms-plugin-protocol-xml (<<${binary:Version})
 Description: Enterprise-grade Open-source Network Management Platform (OpenNMS Libraries)
  OpenNMS is an enterprise-grade network management system written in Java.
  .
@@ -225,7 +228,7 @@ Description: Enterprise-grade Open-source Network Management Platform (Contrib)
 
 Package: opennms-plugins
 Architecture: all
-Depends: opennms-plugin-northbounder-jms (=${binary:Version}), opennms-plugin-provisioning-dns (=${binary:Version}), opennms-plugin-provisioning-rancid (=${binary:Version}), opennms-plugin-provisioning-snmp-asset (=${binary:Version}), opennms-plugin-provisioning-snmp-hardware-inventory (=${binary:Version}), opennms-plugin-protocol-cifs (=${binary:Version}), opennms-plugin-protocol-dhcp (=${binary:Version}), opennms-plugin-protocol-nsclient (=${binary:Version}), opennms-plugin-protocol-radius (=${binary:Version}), opennms-plugin-protocol-xml (=${binary:Version}), opennms-plugin-protocol-xmp (=${binary:Version}), opennms-plugin-collector-vtdxml-handler (=${binary:Version}), opennms-plugin-ticketer-jira (=${binary:Version}), opennms-plugin-ticketer-otrs (=${binary:Version}), opennms-plugin-ticketer-rt (=${binary:Version})
+Depends: opennms-plugin-northbounder-jms (=${binary:Version}), opennms-plugin-provisioning-dns (=${binary:Version}), opennms-plugin-provisioning-rancid (=${binary:Version}), opennms-plugin-provisioning-snmp-asset (=${binary:Version}), opennms-plugin-provisioning-snmp-hardware-inventory (=${binary:Version}), opennms-plugin-protocol-cifs (=${binary:Version}), opennms-plugin-protocol-dhcp (=${binary:Version}), opennms-plugin-protocol-nsclient (=${binary:Version}), opennms-plugin-protocol-radius (=${binary:Version}), opennms-plugin-protocol-xmp (=${binary:Version}), opennms-plugin-collector-vtdxml-handler (=${binary:Version}), opennms-plugin-ticketer-jira (=${binary:Version}), opennms-plugin-ticketer-otrs (=${binary:Version}), opennms-plugin-ticketer-rt (=${binary:Version})
 Description: Enterprise-grade Open-source Network Management Platform (All Plugins)
  OpenNMS is an enterprise-grade network management system written in Java.
  .
@@ -379,21 +382,6 @@ Description: Enterprise-grade Open-source Network Management Platform (RADIUS Pr
  .
  This package provides RADIUS support for capability scanning, provisiond,
  polling, and Spring Security authentication.
-
-Package: opennms-plugin-protocol-xml
-Architecture: all
-Depends: opennms-server (=${binary:Version})
-Replaces: libopennms-java (<<${binary:Version}), opennms-common (<<${binary:Version})
-Description: Enterprise-grade Open-source Network Management Platform (XML Collection Support)
- OpenNMS is an enterprise-grade network management system written in Java.
- .
- OpenNMS can monitor various network services to determine status and service
- level availability.  Data collection is performed using protocols such as SNMP
- to generate reports and alert on thresholds.  An extensible event management
- and notification system handles both internally and externally generated
- events (such as SNMP traps), and generates notices via email, pager, SMS, etc.
- .
- This package provides support for data collection from XML data.
 
 Package: opennms-plugin-protocol-xmp
 Architecture: all

--- a/debian/rules
+++ b/debian/rules
@@ -123,13 +123,11 @@ install: build
 	##
 	## Setup the protocol packages
 	##
-	install -d -m 755 debian/opennms-plugin-protocol-{cifs,dhcp,nsclient,radius,xml,xmp}/usr/share/java/opennms
-	install -d -m 755 debian/opennms-plugin-protocol-{cifs,dhcp,nsclient,radius,xml,xmp}/usr/share/opennms/contrib
-	install -d -m 755 debian/opennms-plugin-protocol-{cifs,dhcp,nsclient,radius,xml,xmp}/etc/opennms
-	install -d -m 755 debian/opennms-plugin-protocol-{cifs,dhcp,nsclient,radius,xml,xmp}/var/lib/opennms/etc-pristine
-	install -d -m 755 debian/opennms-plugin-protocol-{cifs,dhcp,nsclient,radius,xml,xmp}/var/lib/opennms/xsds
-	install -d -m 755 debian/opennms-plugin-protocol-xml/etc/opennms/xml-datacollection
-	install -d -m 755 debian/opennms-plugin-protocol-xml/etc/opennms/examples/3gpp-juniper/{datacollection,xml-datacollection,snmp-graph.properties.d}
+	install -d -m 755 debian/opennms-plugin-protocol-{cifs,dhcp,nsclient,radius,xmp}/usr/share/java/opennms
+	install -d -m 755 debian/opennms-plugin-protocol-{cifs,dhcp,nsclient,radius,xmp}/usr/share/opennms/contrib
+	install -d -m 755 debian/opennms-plugin-protocol-{cifs,dhcp,nsclient,radius,xmp}/etc/opennms
+	install -d -m 755 debian/opennms-plugin-protocol-{cifs,dhcp,nsclient,radius,xmp}/var/lib/opennms/etc-pristine
+	install -d -m 755 debian/opennms-plugin-protocol-{cifs,dhcp,nsclient,radius,xmp}/var/lib/opennms/xsds
 	
 	# Setup Juniper TCA collector
 	install -d -m 755 debian/opennms-plugin-collector-juniper-tca/usr/share/java/opennms
@@ -175,17 +173,6 @@ install: build
 	mv debian/temp/lib/jradius-*.jar                                                           debian/opennms-plugin-protocol-radius/usr/share/java/opennms/
 	mv debian/temp/lib/gnu-crypto*.jar                                                         debian/opennms-plugin-protocol-radius/usr/share/java/opennms/
 	mv debian/temp/lib/*radius*.jar                                                            debian/opennms-plugin-protocol-radius/usr/share/java/opennms/
-	
-	# XML
-	install -d -m 755 debian/opennms-plugin-protocol-xml/var/lib/opennms/etc-pristine/xml-datacollection
-	mv debian/temp/lib/org.opennms.protocols.xml-*.jar                                         debian/opennms-plugin-protocol-xml/usr/share/java/opennms/
-	mv debian/temp/etc/xml-datacollection-config.xml                                           debian/opennms-plugin-protocol-xml/etc/opennms/
-	mv debian/temp/etc/examples/3gpp-juniper/xml-datacollection-config.xml                     debian/opennms-plugin-protocol-xml/etc/opennms/examples/3gpp-juniper/
-	mv debian/temp/etc/examples/3gpp-juniper/datacollection/3gpp*                              debian/opennms-plugin-protocol-xml/etc/opennms/examples/3gpp-juniper/datacollection/
-	mv debian/temp/etc/examples/3gpp-juniper/xml-datacollection/3gpp*                          debian/opennms-plugin-protocol-xml/etc/opennms/examples/3gpp-juniper/xml-datacollection/
-	mv debian/temp/etc/examples/3gpp-juniper/snmp-graph.properties.d/3gpp*                     debian/opennms-plugin-protocol-xml/etc/opennms/examples/3gpp-juniper/snmp-graph.properties.d/
-	mv debian/temp/contrib/xml-collector/3gpp*                                                 debian/opennms-plugin-protocol-xml/usr/share/opennms/contrib/
-	mv debian/opennms-common/var/lib/opennms/etc-pristine/xml-datacollection-config.xml        debian/opennms-plugin-protocol-xml/var/lib/opennms/etc-pristine/
 	
 	# VTD-XML
 	install -d -m 755 debian/opennms-plugin-collector-vtdxml-handler/usr/share/java/opennms

--- a/tools/packages/opennms/opennms.spec
+++ b/tools/packages/opennms/opennms.spec
@@ -96,6 +96,7 @@ Requires:	jicmp6 >= 2.0.0
 Requires(pre):	%{jdk}
 Requires:	%{jdk}
 Obsoletes:	opennms < 1.3.11
+Obsoletes: opennms-plugin-protocol-xml
 
 %description core
 The core backend.  This package contains the main daemon responsible
@@ -239,8 +240,6 @@ Requires(pre):	%{name}-plugin-protocol-nsclient
 Requires:	%{name}-plugin-protocol-nsclient
 Requires(pre):	%{name}-plugin-protocol-radius
 Requires:	%{name}-plugin-protocol-radius
-Requires(pre):	%{name}-plugin-protocol-xml
-Requires:	%{name}-plugin-protocol-xml
 Requires(pre):	%{name}-plugin-protocol-xmp
 Requires:	%{name}-plugin-protocol-xmp
 Requires(pre):	%{name}-plugin-collector-vtdxml-handler
@@ -439,19 +438,6 @@ monitor, and Spring Security authorization mechanism for RADIUS.
 %{extrainfo2}
 
 
-%package plugin-protocol-xml
-Summary:	XML Collector
-Group:		Applications/System
-Requires(pre):	%{name}-core = %{version}-%{release}
-Requires:	%{name}-core = %{version}-%{release}
-
-%description plugin-protocol-xml
-The XML protocol plugin provides a collector for XML data.
-
-%{extrainfo}
-%{extrainfo2}
-
-
 %package plugin-protocol-xmp
 Summary:	XMP Poller
 Group:		Applications/System
@@ -482,8 +468,8 @@ The Juniper JCA collector provides a collector plugin for Collectd to collect da
 Summary:	VTD-XML Collection Handler
 Group:		Applications/System
 License:	GPL
-Requires(pre):	%{name}-plugin-protocol-xml = %{version}-%{release}
-Requires:	%{name}-plugin-protocol-xml = %{version}-%{release}
+Requires(pre):	%{name}-core = %{version}-%{release}
+Requires:	%{name}-core = %{version}-%{release}
 
 %description plugin-collector-vtdxml-handler
 The XML Collection Handler for Standard and 3GPP XMLs based on VTD-XML.
@@ -624,7 +610,6 @@ find %{buildroot}%{instprefix}/etc ! -type d | \
 	grep -v '%{_sysconfdir}/sysconfig/opennms-remote-poller' | \
 	grep -v 'ncs-northbounder-configuration.xml' | \
 	grep -v 'drools-engine.d/ncs' | \
-	grep -v '3gpp' | \
 	grep -v 'dhcpd-configuration.xml' | \
 	grep -v 'jira.properties' | \
 	grep -v 'jms-northbounder-configuration.xml' | \
@@ -636,7 +621,6 @@ find %{buildroot}%{instprefix}/etc ! -type d | \
 	grep -v '/rt.properties' | \
 	grep -v 'snmp-asset-adapter-configuration.xml' | \
 	grep -v 'snmp-hardware-inventory-adapter-configuration.xml' | \
-	grep -v 'xml-datacollection-config.xml' | \
 	grep -v 'xmp-config.xml' | \
 	grep -v 'xmp-datacollection-config.xml' | \
 	grep -v 'tca-datacollection-config.xml' | \
@@ -648,7 +632,6 @@ find %{buildroot}%{sharedir}/etc-pristine ! -type d | \
 	grep -v 'ncs-northbounder-configuration.xml' | \
 	grep -v 'ncs.xml' | \
 	grep -v 'drools-engine.d/ncs' | \
-	grep -v '3gpp' | \
 	grep -v 'dhcpd-configuration.xml' | \
 	grep -v 'jira.properties' | \
 	grep -v 'jms-northbounder-configuration.xml' | \
@@ -660,7 +643,6 @@ find %{buildroot}%{sharedir}/etc-pristine ! -type d | \
 	grep -v '/rt.properties' | \
 	grep -v 'snmp-asset-adapter-configuration.xml' | \
 	grep -v 'snmp-hardware-inventory-adapter-configuration.xml' | \
-	grep -v 'xml-datacollection-config.xml' | \
 	grep -v 'xmp-config.xml' | \
 	grep -v 'xmp-datacollection-config.xml' | \
 	grep -v 'tca-datacollection-config.xml' | \
@@ -684,7 +666,6 @@ find %{buildroot}%{sharedir} ! -type d | \
 	sort >> %{_tmppath}/files.main
 find %{buildroot}%{instprefix}/contrib ! -type d | \
 	sed -e "s|^%{buildroot}|%attr(755,root,root) |" | \
-	grep -v 'xml-collector' | \
 	sort >> %{_tmppath}/files.main
 find %{buildroot}%{instprefix}/lib ! -type d | \
 	sed -e "s|^%{buildroot}|%attr(755,root,root) |" | \
@@ -701,7 +682,6 @@ find %{buildroot}%{instprefix}/lib ! -type d | \
 	grep -v 'org.opennms.protocols.dhcp' | \
 	grep -v 'org.opennms.protocols.nsclient' | \
 	grep -v 'org.opennms.protocols.radius' | \
-	grep -v 'org.opennms.protocols.xml' | \
 	grep -v 'org.opennms.protocols.xmp' | \
 	grep -v 'opennms-vtdxml-collector-handler' | \
 	grep -v 'provisioning-adapter' | \
@@ -870,16 +850,6 @@ rm -rf %{buildroot}
 %{instprefix}/lib/gnu-crypto*.jar
 %{instprefix}/lib/jradius-*.jar
 %{instprefix}/lib/org.opennms.protocols.radius*.jar
-
-%files plugin-protocol-xml
-%defattr(664 root root 775)
-%config(noreplace) %{instprefix}/etc/xml-*.xml
-%config(noreplace) %{instprefix}/etc/examples/3gpp-juniper/xml-*.xml
-%config(noreplace) %{instprefix}/etc/examples/3gpp-juniper/*datacollection*/3gpp*
-%config(noreplace) %{instprefix}/etc/examples/3gpp-juniper/snmp-graph.properties.d/3gpp*
-%{instprefix}/lib/org.opennms.protocols.xml-*.jar
-%attr(755,root,root) %{instprefix}/contrib/xml-collector/3gpp*
-%{sharedir}/etc-pristine/xml-*.xml
 
 %files plugin-protocol-xmp
 %defattr(664 root root 775)


### PR DESCRIPTION
This PR merges the XML plugin into `opennms-core` in the packaging, since the new elasticsearch changes mean the default configs point to the xml plugin class.

I have confirmed that upgrades from 18 to this branch work properly even if the XML plugin is installed, on both debian and centos systems.

I'd appreciate it if someone would eyeball this and let me know if anything looks odd, but I think everything's good.

* JIRA: http://issues.opennms.org/browse/NMS-8697
