### PR TITLE
NMS-8926: Fix calculation errors in 2 jasper reports

### DIFF
--- a/opennms-base-assembly/src/main/filtered/etc/report-templates/TotalBytesTransferredByInterface.jrxml
+++ b/opennms-base-assembly/src/main/filtered/etc/report-templates/TotalBytesTransferredByInterface.jrxml
@@ -43,10 +43,6 @@ new GregorianCalendar(new GregorianCalendar().get(Calendar.YEAR), new GregorianC
 		<parameterDescription><![CDATA[The URL of the Measurements API]]></parameterDescription>
 		<defaultValueExpression><![CDATA["http://localhost:8980/opennms/rest/measurements"]]></defaultValueExpression>
 	</parameter>
-	<parameter name="MEASUREMENT_INTERVAL" class="java.lang.Integer">
-		<parameterDescription><![CDATA[The time interval between two measurement samples]]></parameterDescription>
-		<defaultValueExpression><![CDATA[300]]></defaultValueExpression>
-	</parameter>
 	<parameter name="MEASUREMENT_USERNAME" class="java.lang.String">
 		<parameterDescription><![CDATA[The username to use to authenticate against the Measurement API]]></parameterDescription>
 		<defaultValueExpression><![CDATA["admin"]]></defaultValueExpression>

--- a/opennms-base-assembly/src/main/filtered/etc/report-templates/TotalBytesTransferredByInterface.jrxml
+++ b/opennms-base-assembly/src/main/filtered/etc/report-templates/TotalBytesTransferredByInterface.jrxml
@@ -43,6 +43,10 @@ new GregorianCalendar(new GregorianCalendar().get(Calendar.YEAR), new GregorianC
 		<parameterDescription><![CDATA[The URL of the Measurements API]]></parameterDescription>
 		<defaultValueExpression><![CDATA["http://localhost:8980/opennms/rest/measurements"]]></defaultValueExpression>
 	</parameter>
+	<parameter name="MEASUREMENT_INTERVAL" class="java.lang.Integer">
+		<parameterDescription><![CDATA[The time interval between two measurement samples]]></parameterDescription>
+		<defaultValueExpression><![CDATA[300]]></defaultValueExpression>
+	</parameter>
 	<parameter name="MEASUREMENT_USERNAME" class="java.lang.String">
 		<parameterDescription><![CDATA[The username to use to authenticate against the Measurement API]]></parameterDescription>
 		<defaultValueExpression><![CDATA["admin"]]></defaultValueExpression>

--- a/opennms-base-assembly/src/main/filtered/etc/report-templates/subreports/PeakTraffic_subreport.jrxml
+++ b/opennms-base-assembly/src/main/filtered/etc/report-templates/subreports/PeakTraffic_subreport.jrxml
@@ -75,17 +75,17 @@
 	<field name="OutOctets" class="java.lang.Double">
 		<fieldDescription><![CDATA[]]></fieldDescription>
 	</field>
-	<variable name="ifInOctets_Average" class="java.lang.Double" calculation="Average">
-		<variableExpression><![CDATA[$F{InOctets}]]></variableExpression>
+	<variable name="ifInBits_Average" class="java.lang.Double" calculation="Average">
+		<variableExpression><![CDATA[$F{InOctets} * 8]]></variableExpression>
 	</variable>
-	<variable name="ifOutOctets_Average" class="java.lang.Double" calculation="Average">
-		<variableExpression><![CDATA[$F{OutOctets}]]></variableExpression>
+	<variable name="ifOutBits_Average" class="java.lang.Double" calculation="Average">
+		<variableExpression><![CDATA[$F{OutOctets} * 8]]></variableExpression>
 	</variable>
-	<variable name="ifInOctets_Peak" class="java.lang.Double" calculation="Highest">
-		<variableExpression><![CDATA[$F{InOctets}]]></variableExpression>
+	<variable name="ifInBits_Peak" class="java.lang.Double" calculation="Highest">
+		<variableExpression><![CDATA[$F{InOctets} * 8]]></variableExpression>
 	</variable>
-	<variable name="ifOutOctets_Peak" class="java.lang.Double" calculation="Highest">
-		<variableExpression><![CDATA[$F{OutOctets}]]></variableExpression>
+	<variable name="ifOutBits_Peak" class="java.lang.Double" calculation="Highest">
+		<variableExpression><![CDATA[$F{OutOctets} * 8]]></variableExpression>
 	</variable>
 	<filterExpression><![CDATA[!$F{InOctets}.isNaN() && !$F{OutOctets}.isNaN()]]></filterExpression>
 	<background>
@@ -100,14 +100,14 @@
 					<property name="local_mesure_unitx" value="pixel"/>
 					<property name="com.jaspersoft.studio.unit.x" value="px"/>
 				</reportElement>
-				<textFieldExpression><![CDATA[$V{ifOutOctets_Peak}]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$V{ifOutBits_Peak}]]></textFieldExpression>
 			</textField>
 			<textField pattern="#,##0.00">
 				<reportElement style="Detail" x="113" y="4" width="123" height="20" uuid="4269bf48-156f-4447-bed0-83f3c048cb8f">
 					<property name="local_mesure_unitx" value="pixel"/>
 					<property name="com.jaspersoft.studio.unit.x" value="px"/>
 				</reportElement>
-				<textFieldExpression><![CDATA[$V{ifInOctets_Average}]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$V{ifInBits_Average}]]></textFieldExpression>
 			</textField>
 			<textField pattern="#,##0.00">
 				<reportElement style="Detail" x="329" y="4" width="120" height="20" uuid="d15a4671-5e26-4d42-af3a-e7e39da81b11">
@@ -116,7 +116,7 @@
 					<property name="local_mesure_unitx" value="pixel"/>
 					<property name="com.jaspersoft.studio.unit.x" value="px"/>
 				</reportElement>
-				<textFieldExpression><![CDATA[$V{ifOutOctets_Average}]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$V{ifOutBits_Average}]]></textFieldExpression>
 			</textField>
 			<textField>
 				<reportElement style="Detail" x="3" y="4" width="110" height="20" uuid="5ca6f441-c070-481f-8d2f-8e4a0dd763f8">
@@ -131,7 +131,7 @@
 					<property name="local_mesure_unitx" value="pixel"/>
 					<property name="com.jaspersoft.studio.unit.x" value="px"/>
 				</reportElement>
-				<textFieldExpression><![CDATA[$V{ifInOctets_Peak}]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$V{ifInBits_Peak}]]></textFieldExpression>
 			</textField>
 		</band>
 	</summary>

--- a/opennms-base-assembly/src/main/filtered/etc/report-templates/subreports/TotalBytesTransferredByInterface_subreport1.jrxml
+++ b/opennms-base-assembly/src/main/filtered/etc/report-templates/subreports/TotalBytesTransferredByInterface_subreport1.jrxml
@@ -13,6 +13,7 @@
 	<parameter name="MEASUREMENT_URL" class="java.lang.String"/>
 	<parameter name="MEASUREMENT_USERNAME" class="java.lang.String"/>
 	<parameter name="MEASUREMENT_PASSWORD" class="java.lang.String"/>
+	<parameter name="MEASUREMENT_INTERVAL" class="java.lang.Integer"/>
 	<parameter name="nodeid" class="java.lang.Integer"/>
 	<parameter name="foreignsource" class="java.lang.String"/>
 	<parameter name="foreignid" class="java.lang.String"/>
@@ -38,7 +39,7 @@
 		<defaultValueExpression><![CDATA[org.opennms.netmgt.jasper.helper.MeasurementsHelper.getNodeOrNodeSourceDescriptor(String.valueOf($P{nodeid}), $P{foreignsource}, $P{foreignid})]]></defaultValueExpression>
 	</parameter>
 	<queryString language="measurement">
-		<![CDATA[<query-request step="300000" start="$P{startDateTime}" end="$P{endDateTime}" maxrows="5000">
+		<![CDATA[<query-request step="String.valueOf($P{MEASUREMENT_INTERVAL} * 1000)" start="$P{startDateTime}" end="$P{endDateTime}" maxrows="5000">
   <source aggregation="AVERAGE" label="IfInOctets" attribute="ifHCInOctets" fallback-attribute="ifInOctets" transient="false" resourceId="$P{nodeResourceDescriptor}.interfaceSnmp[$P{interface}]"/>
   <source aggregation="AVERAGE" label="IfOutOctets" attribute="ifHCOutOctets" fallback-attribute="ifOutOctets" transient="false" resourceId="$P{nodeResourceDescriptor}.interfaceSnmp[$P{interface}]"/>
 </query-request>]]>
@@ -51,7 +52,7 @@
 	</field>
 	<sortField name="IfInOctets"/>
 	<variable name="received_SUM" class="java.lang.Double" calculation="Sum">
-		<variableExpression><![CDATA[$F{IfInOctets}]]></variableExpression>
+		<variableExpression><![CDATA[$F{IfInOctets} * String.valueOf($P{MEASUREMENT_INTERVAL})]]></variableExpression>
 	</variable>
 	<variable name="RECEIVED_BYTES_TOTAL" class="java.lang.Double">
 		<variableExpression><![CDATA[$V{received_SUM}]]></variableExpression>
@@ -60,7 +61,7 @@
 		<variableExpression><![CDATA[$V{RECEIVED_BYTES_TOTAL} * 8]]></variableExpression>
 	</variable>
 	<variable name="transmitted_SUM" class="java.lang.Double" calculation="Sum">
-		<variableExpression><![CDATA[$F{IfOutOctets}]]></variableExpression>
+		<variableExpression><![CDATA[$F{IfOutOctets} * String.valueOf($P{MEASUREMENT_INTERVAL})]]></variableExpression>
 	</variable>
 	<variable name="TRANSMITTED_BYTES_TOTAL" class="java.lang.Double">
 		<variableExpression><![CDATA[$V{transmitted_SUM}]]></variableExpression>

--- a/opennms-base-assembly/src/main/filtered/etc/report-templates/subreports/TotalBytesTransferredByInterface_subreport1.jrxml
+++ b/opennms-base-assembly/src/main/filtered/etc/report-templates/subreports/TotalBytesTransferredByInterface_subreport1.jrxml
@@ -52,7 +52,7 @@
 	</field>
 	<sortField name="IfInOctets"/>
 	<variable name="received_SUM" class="java.lang.Double" calculation="Sum">
-		<variableExpression><![CDATA[$F{IfInOctets} * String.valueOf($P{MEASUREMENT_INTERVAL})]]></variableExpression>
+		<variableExpression><![CDATA[$F{IfInOctets} * $P{MEASUREMENT_INTERVAL}]]></variableExpression>
 	</variable>
 	<variable name="RECEIVED_BYTES_TOTAL" class="java.lang.Double">
 		<variableExpression><![CDATA[$V{received_SUM}]]></variableExpression>
@@ -61,7 +61,7 @@
 		<variableExpression><![CDATA[$V{RECEIVED_BYTES_TOTAL} * 8]]></variableExpression>
 	</variable>
 	<variable name="transmitted_SUM" class="java.lang.Double" calculation="Sum">
-		<variableExpression><![CDATA[$F{IfOutOctets} * String.valueOf($P{MEASUREMENT_INTERVAL})]]></variableExpression>
+		<variableExpression><![CDATA[$F{IfOutOctets} * $P{MEASUREMENT_INTERVAL}]]></variableExpression>
 	</variable>
 	<variable name="TRANSMITTED_BYTES_TOTAL" class="java.lang.Double">
 		<variableExpression><![CDATA[$V{transmitted_SUM}]]></variableExpression>

--- a/opennms-base-assembly/src/main/filtered/etc/report-templates/subreports/TotalBytesTransferredByInterface_subreport1.jrxml
+++ b/opennms-base-assembly/src/main/filtered/etc/report-templates/subreports/TotalBytesTransferredByInterface_subreport1.jrxml
@@ -13,7 +13,13 @@
 	<parameter name="MEASUREMENT_URL" class="java.lang.String"/>
 	<parameter name="MEASUREMENT_USERNAME" class="java.lang.String"/>
 	<parameter name="MEASUREMENT_PASSWORD" class="java.lang.String"/>
-	<parameter name="MEASUREMENT_INTERVAL" class="java.lang.Integer"/>
+	<parameter name="MEASUREMENT_INTERVAL" class="java.lang.Integer" isForPrompting="false">
+		<parameterDescription><![CDATA[The time interval between two measurement samples]]></parameterDescription>
+		<defaultValueExpression><![CDATA[300]]></defaultValueExpression>
+	</parameter>
+	<parameter name="MEASUREMENT_INTERVAL_millisecond" class="java.lang.Long" isForPrompting="false">
+		<defaultValueExpression><![CDATA[$P{MEASUREMENT_INTERVAL} * 1000]]></defaultValueExpression>
+	</parameter>
 	<parameter name="nodeid" class="java.lang.Integer"/>
 	<parameter name="foreignsource" class="java.lang.String"/>
 	<parameter name="foreignid" class="java.lang.String"/>
@@ -39,7 +45,7 @@
 		<defaultValueExpression><![CDATA[org.opennms.netmgt.jasper.helper.MeasurementsHelper.getNodeOrNodeSourceDescriptor(String.valueOf($P{nodeid}), $P{foreignsource}, $P{foreignid})]]></defaultValueExpression>
 	</parameter>
 	<queryString language="measurement">
-		<![CDATA[<query-request step="String.valueOf($P{MEASUREMENT_INTERVAL} * 1000)" start="$P{startDateTime}" end="$P{endDateTime}" maxrows="5000">
+		<![CDATA[<query-request step="$P{MEASUREMENT_INTERVAL_millisecond}" start="$P{startDateTime}" end="$P{endDateTime}" maxrows="5000">
   <source aggregation="AVERAGE" label="IfInOctets" attribute="ifHCInOctets" fallback-attribute="ifInOctets" transient="false" resourceId="$P{nodeResourceDescriptor}.interfaceSnmp[$P{interface}]"/>
   <source aggregation="AVERAGE" label="IfOutOctets" attribute="ifHCOutOctets" fallback-attribute="ifOutOctets" transient="false" resourceId="$P{nodeResourceDescriptor}.interfaceSnmp[$P{interface}]"/>
 </query-request>]]>


### PR DESCRIPTION
PeakTraffic_subreport.jrxml was mixing up bits and Bytes
TotalBytesTransferredByInterface_subreport1.jrxml was doing a sum of "bytes per seconds" whereas it must do a sum of "bytes"

Caution: Make sure your Bamboo stuff tests jasper reports compilation as I didn't do it (beucase too time-consuming and https://issues.opennms.org/browse/NMS-4552)

* JIRA: https://issues.opennms.org/browse/NMS-8926
* Bamboo: Do not worry, we add a link to our continuous integration system here

