### PR TITLE
NMS-8912: Can't save cached requisition associated with HTTP when scheduling the import through provisiond-configuration.xml

### DIFF
--- a/opennms-provision/opennms-provision-persistence/src/test/resources/org/opennms/netmgt/provision/persist/emptyContext.xml
+++ b/opennms-provision/opennms-provision-persistence/src/test/resources/org/opennms/netmgt/provision/persist/emptyContext.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans-4.0.xsd">
+</beans>


### PR DESCRIPTION
Can't save cached requisition associated with HTTP when scheduling the import through provisiond-configuration.xml

* JIRA: http://issues.opennms.org/browse/NMS-8912
* Bamboo: http://bamboo.internal.opennms.com:8085/browse/OPENNMS-ONMS1171

I tested the solution on a VM running Meridian 2016, and on my machine running release-19.0.0