### PR TITLE
HZN-931: only reinitialize SNMPv3 users on update

### DIFF
--- a/features/events/traps/blueprint-trapd-listener.xml
+++ b/features/events/traps/blueprint-trapd-listener.xml
@@ -36,7 +36,7 @@
             <bean ref="restClient" method="getSnmpV3Users"/>
             <bean ref="unmarshaller" />
             <to uri="bean:trapdConfig?method=onUpdate" />
-            <bean ref="trapReceiver" method="setTrapdConfig" />
+            <bean ref="trapReceiver" method="setSnmpV3Users" />
         </route>
     </camelContext>
 


### PR DESCRIPTION
This PR makes it so the trapdConfig SNMPv3 user update code *only* updates the SNMPv3 user list, rather than consuming all of the `TrapdConfiguration`.  This keeps the Minion from attempting to reinitialize the SNMP listener with the hostname and port coming from the OpenNMS host, rather than its own config.

* JIRA: http://issues.opennms.org/browse/HZN-931