### PR TITLE
NMS-8907: Fix invalid graph templates (Second Phase)

### DIFF
--- a/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/aix-graph.properties
+++ b/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/aix-graph.properties
@@ -5,8 +5,7 @@
 ##
 ##################################################
 
-reports=aix.teaser, \
-aix.cpuUtilization, \
+reports=aix.cpuUtilization, \
 aix.procNum, \
 aix.subsystems, \
 aix.subservers, \
@@ -27,27 +26,9 @@ aix.fs.inodepct
 ##### Reports for AIX (IBM) Systems
 #####
 
-report.aix.teaser.name=You Could Get More From This AIX System
-report.aix.teaser.propertiesValues=aixSysObjectID
-report.aix.teaser.columns=
-report.aix.teaser.type=nodeSnmp
-report.aix.teaser.command=--title="You Could Get More From This AIX System" \
- COMMENT:"If you are reading this, then OpenNMS is unable to retrieve\\n" \
- COMMENT:"some useful statistics from this AIX system, probably because\\n" \
- COMMENT:"the SNMP MIB view configured on the AIX system does not permit\\n" \
- COMMENT:"OpenNMS to access the objects in the IBM-AIX-MIB, including\\n" \
- COMMENT:"aggregate CPU utilization, Subsystems and Subservers, Volume\\n" \
- COMMENT:"Groups, Paging Spaces, Print Queues, and Filesystems.\\n" \
- COMMENT:"\\n" \
- COMMENT:"Ask your AIX administrator to remove the VACM_VIEW exclusion\\n" \
- COMMENT:"for OID .1.3.6.1.4.1.2.6.191 and, if this is an AIX 5.2 or 5.3\\n" \
- COMMENT:"system upgraded from AIX 5.1 or earlier, to move from snmpdv1\\n" \
- COMMENT:"to snmpdv3ne (you can still use SNMPv1).\\n"
-
 report.aix.cpuUtilization.name=Aggregate CPU Utilization (AIX)
 report.aix.cpuUtilization.columns=aixSeCPUUtilization, aixSeCPUThreshold
 report.aix.cpuUtilization.type=nodeSnmp
-report.aix.cpuUtilization.suppress=aix.teaser
 report.aix.cpuUtilization.command=--title="Aggregate CPU Utilization (AIX)" \
  --units-exponent 0 \
  --vertical-label="Percent" \

--- a/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/ejn-graph.properties
+++ b/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/ejn-graph.properties
@@ -66,9 +66,9 @@ report.ejnggsn.apn.bits.command=--title="APN {ApnName} Traffic" \
  GPRINT:rawbitsOut:AVERAGE:"Avg  \\: %8.2lf %s" \
  GPRINT:rawbitsOut:MIN:"Min  \\: %8.2lf %s" \
  GPRINT:rawbitsOut:MAX:"Max  \\: %8.2lf %s\\n" \
- GPRINT:inSum:AVERAGE:"  Tot Down  \\: %8.2lf %s" \
- GPRINT:outSum:AVERAGE:" Tot Up  \\: %8.2lf %s" \
- GPRINT:totSum:AVERAGE:" Tot  \\: %8.2lf %s\\n"
+ GPRINT:inSum:"  Tot Down  \\: %8.2lf %s" \
+ GPRINT:outSum:" Tot Up  \\: %8.2lf %s" \
+ GPRINT:totSum:" Tot  \\: %8.2lf %s\\n"
 
 report.ejnggsn.apn.users.name=GGSN APN Active PDP Contexts
 report.ejnggsn.apn.users.columns=ApnActivePdpContext
@@ -385,6 +385,6 @@ report.ejnggsn.bits.command=--title="GGSN Bits In/Out" \
  GPRINT:rawbitsIn:AVERAGE:"Avg  \\: %8.2lf %s" \
  GPRINT:rawbitsIn:MIN:"Min  \\: %8.2lf %s" \
  GPRINT:rawbitsIn:MAX:"Max  \\: %8.2lf %s\\n" \
- GPRINT:inSum:AVERAGE:"  Tot In  \\: %8.2lf %s" \
- GPRINT:outSum:AVERAGE:" Tot Out  \\: %8.2lf %s" \
- GPRINT:totSum:AVERAGE:" Tot  \\: %8.2lf %s\\n"
+ GPRINT:inSum:"  Tot In  \\: %8.2lf %s" \
+ GPRINT:outSum:" Tot Out  \\: %8.2lf %s" \
+ GPRINT:totSum:" Tot  \\: %8.2lf %s\\n"

--- a/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/fortinet-fortigate-application-v5.2-graph.properties
+++ b/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/fortinet-fortigate-application-v5.2-graph.properties
@@ -23,7 +23,8 @@ fortinet.fgAppSuStatsEntry, \
 fortinet.fgAppVoIPStatsEntry, \
 fortinet.fgAppP2PStatsEntry, \
 fortinet.fgAppIMStatsEntry, \
-fortinet.fgApFTPStatsEntry, \
+fortinet.fgApFTPStatsEntry.stats, \
+fortinet.fgApFTPStatsEntry.connection, \
 fortinet.fgWebChDskStsEntry, \
 fortinet.fgWebCacheDiskUsage
 
@@ -363,11 +364,11 @@ report.fortinet.fgAppIMStatsEntry.command=--title="Fortigate IM Statistics for V
  GPRINT:val4:MIN:"Min \\: %10.2lf" \
  GPRINT:val4:MAX:"Max \\: %10.2lf\\n"
 
-report.fortinet.fgApFTPStatsEntry.name=Fortigate FTP Proxy Statistics
-report.fortinet.fgApFTPStatsEntry.columns=fgApFTPReqProcessed
-report.fortinet.fgApFTPStatsEntry.type=fgApFTPStatsEntry
-report.fortinet.fgApFTPStatsEntry.propertiesValues=fgAppSuIndex
-report.fortinet.fgApFTPStatsEntry.command=--title="Fortigate FTP Proxy Statistics for Virtual Domain: {fgAppSuIndex}" \
+report.fortinet.fgApFTPStatsEntry.stats.name=Fortigate FTP Proxy Statistics
+report.fortinet.fgApFTPStatsEntry.stats.columns=fgApFTPReqProcessed
+report.fortinet.fgApFTPStatsEntry.stats.type=fgApFTPStatsEntry
+report.fortinet.fgApFTPStatsEntry.stats.propertiesValues=fgAppSuIndex
+report.fortinet.fgApFTPStatsEntry.stats.command=--title="Fortigate FTP Proxy Statistics for Virtual Domain: {fgAppSuIndex}" \
  --vertical-label="number" \
  DEF:val1={rrd1}:fgApFTPReqProcessed:AVERAGE \
  AREA:val1#cc0000:"requests" \
@@ -375,10 +376,10 @@ report.fortinet.fgApFTPStatsEntry.command=--title="Fortigate FTP Proxy Statistic
  GPRINT:val1:MIN:"Min \\: %10.2lf" \
  GPRINT:val1:MAX:"Max \\: %10.2lf\\n"
 
-report.fortinet.fgApFTPStatsEntry.name=Fortigate FTP Proxy Connections Statistics
-report.fortinet.fgApFTPStatsEntry.columns=fgApFTPMaxConnections, fgApFTPConnections
-report.fortinet.fgApFTPStatsEntry.type=nodeSnmp
-report.fortinet.fgApFTPStatsEntry.command=--title="Fortigate FTP Proxy Connections Statistics" \
+report.fortinet.fgApFTPStatsEntry.connection.name=Fortigate FTP Proxy Connections Statistics
+report.fortinet.fgApFTPStatsEntry.connection.columns=fgApFTPMaxConnections, fgApFTPConnections
+report.fortinet.fgApFTPStatsEntry.connection.type=nodeSnmp
+report.fortinet.fgApFTPStatsEntry.connection.command=--title="Fortigate FTP Proxy Connections Statistics" \
  --vertical-label="number" \
  DEF:val1={rrd1}:fgApFTPMaxConnections:AVERAGE \
  DEF:val2={rrd2}:fgApFTPConnections:AVERAGE \

--- a/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/framerelay-graph.properties
+++ b/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/framerelay-graph.properties
@@ -37,9 +37,9 @@ report.framerelay.bits.command=--title="Bits In/Out of DLCI {frDlci}" \
  GPRINT:rawbitsOut:AVERAGE:"Avg  \\: %8.2lf %s" \
  GPRINT:rawbitsOut:MIN:"Min  \\: %8.2lf %s" \
  GPRINT:rawbitsOut:MAX:"Max  \\: %8.2lf %s\\n" \
- GPRINT:inSum:AVERAGE:"  Tot In  \\: %8.2lf %s" \
- GPRINT:outSum:AVERAGE:" Tot Out  \\: %8.2lf %s" \
- GPRINT:totSum:AVERAGE:" Tot  \\: %8.2lf %s\\n"
+ GPRINT:inSum:"  Tot In  \\: %8.2lf %s" \
+ GPRINT:outSum:" Tot Out  \\: %8.2lf %s" \
+ GPRINT:totSum:" Tot  \\: %8.2lf %s\\n"
 
 report.framerelay.frames.name=Frames In/Out
 report.framerelay.frames.columns=frReceivedFrames,frSentFrames

--- a/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/juniper-graph.properties
+++ b/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/juniper-graph.properties
@@ -303,7 +303,7 @@ report.juniperj.mem.command=--title="Memory Usage (Juniper)" \
  GPRINT:val1:MAX:"Max  \\: %8.0lf\\n"
 
 report.juniperj.uptime.name=fwdd Uptime (Juniper J-Series)
-report.juniperj.uptime.columns=junFwddUptime 
+report.juniperj.uptime.columns=junFwddUptime
 report.juniperj.uptime.type=nodeSnmp
 report.juniperj.uptime.command=--title="fwdd Uptime" \
  --vertical-label="Days" \

--- a/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/mcast-graph.properties
+++ b/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/mcast-graph.properties
@@ -223,9 +223,9 @@ report.mcast.ietf.ipmroute.bits.command=--title="Multicast Bits In/Out" \
  GPRINT:rawbitsOut:AVERAGE:"Avg  \\: %8.2lf %s" \
  GPRINT:rawbitsOut:MIN:"Min  \\: %8.2lf %s" \
  GPRINT:rawbitsOut:MAX:"Max  \\: %8.2lf %s\\n" \
- GPRINT:inSum:AVERAGE:"  Tot In  \\: %8.2lf %s" \
- GPRINT:outSum:AVERAGE:" Tot Out  \\: %8.2lf %s" \
- GPRINT:totSum:AVERAGE:" Tot  \\: %8.2lf %s\\n"
+ GPRINT:inSum:"  Tot In  \\: %8.2lf %s" \
+ GPRINT:outSum:" Tot Out  \\: %8.2lf %s" \
+ GPRINT:totSum:" Tot  \\: %8.2lf %s\\n"
 
 report.mcast.ietf.ipmroute.HCbits.name=Multicast Bits In/Out
 report.mcast.ietf.ipmroute.HCbits.columns=ifHCInMcastOctets,ifHCOutMcastOctets
@@ -253,9 +253,9 @@ report.mcast.ietf.ipmroute.HCbits.command=--title="Multicast Bits In/Out (High S
  GPRINT:rawbitsOut:AVERAGE:"Avg  \\: %8.2lf %s" \
  GPRINT:rawbitsOut:MIN:"Min  \\: %8.2lf %s" \
  GPRINT:rawbitsOut:MAX:"Max  \\: %8.2lf %s\\n" \
- GPRINT:inSum:AVERAGE:"  Tot In  \\: %8.2lf %s" \
- GPRINT:outSum:AVERAGE:" Tot Out  \\: %8.2lf %s" \
- GPRINT:totSum:AVERAGE:" Tot  \\: %8.2lf %s\\n"
+ GPRINT:inSum:"  Tot In  \\: %8.2lf %s" \
+ GPRINT:outSum:" Tot Out  \\: %8.2lf %s" \
+ GPRINT:totSum:" Tot  \\: %8.2lf %s\\n"
 
 # IGMP-STD-MIB - IETF
 
@@ -406,9 +406,9 @@ report.mcast.cisco.HCbits.command=--title="IP Multicast Bits In/Out (Cisco, High
  GPRINT:rawbitsOut:AVERAGE:"Avg  \\: %8.2lf %s" \
  GPRINT:rawbitsOut:MIN:"Min  \\: %8.2lf %s" \
  GPRINT:rawbitsOut:MAX:"Max  \\: %8.2lf %s\\n" \
- GPRINT:inSum:AVERAGE:"  Tot In  \\: %8.2lf %s" \
- GPRINT:outSum:AVERAGE:" Tot Out  \\: %8.2lf %s" \
- GPRINT:totSum:AVERAGE:" Tot  \\: %8.2lf %s\\n"
+ GPRINT:inSum:"  Tot In  \\: %8.2lf %s" \
+ GPRINT:outSum:" Tot Out  \\: %8.2lf %s" \
+ GPRINT:totSum:" Tot  \\: %8.2lf %s\\n"
 
 report.mcast.cisco.packets.name=Multicast Packets In/Out (Cisco)
 report.mcast.cisco.packets.columns=csIpMRIfInMCPkt,csIpMRIfOutMCPkt

--- a/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/pfsense-graph.properties
+++ b/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/pfsense-graph.properties
@@ -261,7 +261,7 @@ report.pfSense.tableaddrcount.name=pfSense Table Address Count
 report.pfSense.tableaddrcount.columns=pftTblCount
 report.pfSense.tableaddrcount.propertiesValues=pftTblDescr
 report.pfSense.tableaddrcount.type=nodeSnmp
-report.pfSense.tableaddrcount.command=--title="pfSense Table Address Count: {pftTblDescr}"
+report.pfSense.tableaddrcount.command=--title="pfSense Table Address Count: {pftTblDescr}" \
  --vertical-label=Addresses \
  DEF:count={rrd1}:pftTblCount:AVERAGE \
  AREA:count#0000ff:"Current" \

--- a/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/snmp-informant-graph.properties
+++ b/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/snmp-informant-graph.properties
@@ -320,9 +320,9 @@ report.sinf.net.bits.command=--title="Bits Per Second (SNMP Informant)" \
  GPRINT:rawbitsOut:AVERAGE:"Avg  \\: %8.2lf %s" \
  GPRINT:rawbitsOut:MIN:"Min  \\: %8.2lf %s" \
  GPRINT:rawbitsOut:MAX:"Max  \\: %8.2lf %s\\n" \
- GPRINT:inSum:AVERAGE:"  Tot In  \\: %8.2lf %s" \
- GPRINT:outSum:AVERAGE:" Tot Out  \\: %8.2lf %s" \
- GPRINT:totSum:AVERAGE:" Tot  \\: %8.2lf %s\\n"
+ GPRINT:inSum:"  Tot In  \\: %8.2lf %s" \
+ GPRINT:outSum:" Tot Out  \\: %8.2lf %s" \
+ GPRINT:totSum:" Tot  \\: %8.2lf %s\\n"
 
 report.sinf.net.utilization.name=InOut Traffic (SNMP Informant)
 report.sinf.net.utilization.columns=netBytesRcvdPerSec,netBytesSentPerSec,netCurrentBandwidth
@@ -631,9 +631,9 @@ report.ainf.net.bits.command=--title="Bits Per Second (SNMP Informant Advanced)"
  GPRINT:rawbitsOut:AVERAGE:"Avg  \\: %8.2lf %s" \
  GPRINT:rawbitsOut:MIN:"Min  \\: %8.2lf %s" \
  GPRINT:rawbitsOut:MAX:"Max  \\: %8.2lf %s\\n" \
- GPRINT:inSum:AVERAGE:"  Tot In  \\: %8.2lf %s" \
- GPRINT:outSum:AVERAGE:" Tot Out  \\: %8.2lf %s" \
- GPRINT:totSum:AVERAGE:" Tot  \\: %8.2lf %s\\n"
+ GPRINT:inSum:"  Tot In  \\: %8.2lf %s" \
+ GPRINT:outSum:" Tot Out  \\: %8.2lf %s" \
+ GPRINT:totSum:" Tot  \\: %8.2lf %s\\n"
 
 report.ainf.net.utilization.name=InOut Traffic (SNMP Informant Adv)
 report.ainf.net.utilization.columns=ainBytesRcvdPerSec,ainBytesSentPerSec,ainCurrentBandwidth


### PR DESCRIPTION
Fix invalid graph templates.

* JIRA: http://issues.opennms.org/browse/NMS-8907
* Bamboo: Do not worry, we add a link to our continuous integration system here

The only pending templates to fix are the big DS and invalid DS, as that requires changes on *datacollection-config.xml files.

Remaining errors:

* ERROR(fortinet.fgApFTPStatsEntry.connection): Invalid DS fgApFTPMaxConnections (it has more than 19 characters)
* ERROR(fortinet.fgWebChDskStsEntry): Invalid DS fgWebCacheDiskMisses (it has more than 19 characters)
* ERROR(netapp.diskio): Invalid DS naMiscLowDiskReadBytes (it has more than 19 characters)

A new PR against release-19.0.0 will be created to fix the invalid DS once this one is merged.

All the errors fixed so far have been verified against latest RRDtool 1.5.x. If someone notice errors when using JRobin or Backshift, then those libraries have to be fixed to be 100% compliant with RRDtool.