### PR TITLE
NMS-8671: SNMP `error-status` Bug Fixes and Enhancements

### DIFF
--- a/core/snmp/api/src/main/java/org/opennms/netmgt/snmp/CollectionTracker.java
+++ b/core/snmp/api/src/main/java/org/opennms/netmgt/snmp/CollectionTracker.java
@@ -99,7 +99,19 @@ public abstract class CollectionTracker implements Collectable {
             m_parent.reportNoSuchNameErr(msg);
         }
     }
-    
+
+    protected void reportFatalErr(final ErrorStatusException ex) {
+        if (m_parent != null) {
+            m_parent.reportFatalErr(ex);
+        }
+    }
+
+    protected void reportNonFatalErr(final ErrorStatus status) {
+        if (m_parent != null) {
+            m_parent.reportNonFatalErr(status);
+        }
+    }
+
     @Override
     public CollectionTracker getCollectionTracker() {
         return this;

--- a/core/snmp/api/src/main/java/org/opennms/netmgt/snmp/ColumnTracker.java
+++ b/core/snmp/api/src/main/java/org/opennms/netmgt/snmp/ColumnTracker.java
@@ -123,10 +123,10 @@ public class ColumnTracker extends CollectionTracker {
                     return true;
                 } else if (status.isFatal()) {
                     final ErrorStatusException ex = new ErrorStatusException(status, "Unexpected error processing next oid after "+m_last+". Aborting!");
-                    LOG.debug("Fatal Error: {}", status, ex);
+                    reportFatalErr(ex);
                     throw ex;
                 } else if (status != ErrorStatus.NO_ERROR) {
-                    LOG.warn("Non-fatal error encountered: {}. {}", status, status.retry()? "Retrying." : "Giving up.");
+                    reportNonFatalErr(status);
                     return status.retry();
                 }
                 return false;

--- a/core/snmp/api/src/main/java/org/opennms/netmgt/snmp/ErrorStatus.java
+++ b/core/snmp/api/src/main/java/org/opennms/netmgt/snmp/ErrorStatus.java
@@ -31,157 +31,214 @@ package org.opennms.netmgt.snmp;
 public enum ErrorStatus {
     NO_ERROR {
         @Override public boolean isFatal() {
-            return false;
+            return FATAL_NO_ERROR;
         }
         @Override public boolean retry() {
-            return false;
+            return RETRY_NO_ERROR;
         }
     },
     TOO_BIG {
         @Override public boolean isFatal() {
-            return false;
+            return FATAL_TOO_BIG;
         }
         @Override public boolean retry() {
-            return true;
+            return RETRY_TOO_BIG;
         }
     },
     NO_SUCH_NAME {
         @Override public boolean isFatal() {
-            return false;
+            return FATAL_NO_SUCH_NAME;
         }
         @Override public boolean retry() {
-            return true;
+            return RETRY_NO_SUCH_NAME;
         }
     },
     BAD_VALUE {
         @Override public boolean isFatal() {
-            return false; // should be true (OpenNMS doesn't do sets), but fall through for bad agents
+            return FATAL_BAD_VALUE;
         }
         @Override public boolean retry() {
-            return false;
+            return RETRY_BAD_VALUE;
         }
     },
     READ_ONLY {
         @Override public boolean isFatal() {
-            return false; // should be true (OpenNMS doesn't do sets), but fall through for bad agents
+            return FATAL_READ_ONLY;
         }
         @Override public boolean retry() {
-            return false;
+            return RETRY_READ_ONLY;
         }
     },
     GEN_ERR {
         @Override public boolean isFatal() {
-            return false;
+            return FATAL_GEN_ERR;
         }
         @Override public boolean retry() {
-            return true;
+            return RETRY_GEN_ERR;
         }
     },
     NO_ACCESS {
         @Override public boolean isFatal() {
-            return false;
+            return FATAL_NO_ACCESS;
         }
         @Override public boolean retry() {
-            return true;
+            return RETRY_NO_ACCESS;
         }
     },
     WRONG_TYPE {
         @Override public boolean isFatal() {
-            return false; // should be true (OpenNMS doesn't do sets), but fall through for bad agents
+            return FATAL_WRONG_TYPE;
         }
         @Override public boolean retry() {
-            return false;
+            return RETRY_WRONG_TYPE;
         }
     },
     WRONG_LENGTH {
         @Override public boolean isFatal() {
-            return false; // should be true (OpenNMS doesn't do sets), but fall through for bad agents
+            return FATAL_WRONG_LENGTH;
         }
         @Override public boolean retry() {
-            return false;
+            return RETRY_WRONG_LENGTH;
         }
     },
     WRONG_ENCODING {
         @Override public boolean isFatal() {
-            return false; // should be true (OpenNMS doesn't do sets), but fall through for bad agents
+            return FATAL_WRONG_ENCODING;
         }
         @Override public boolean retry() {
-            return false;
+            return RETRY_WRONG_ENCODING;
         }
     },
     WRONG_VALUE {
         @Override public boolean isFatal() {
-            return false; // should be true (OpenNMS doesn't do sets), but fall through for bad agents
+            return FATAL_WRONG_VALUE;
         }
         @Override public boolean retry() {
-            return false;
+            return RETRY_WRONG_VALUE;
         }
     },
     NO_CREATION {
         @Override public boolean isFatal() {
-            return false; // should be true (OpenNMS doesn't do sets), but fall through for bad agents
+            return FATAL_NO_CREATION;
         }
         @Override public boolean retry() {
-            return false;
+            return RETRY_NO_CREATION;
         }
     },
     INCONSISTENT_VALUE {
         @Override public boolean isFatal() {
-            return false; // should be true (OpenNMS doesn't do sets), but fall through for bad agents
+            return FATAL_INCONSISTENT_VALUE;
         }
         @Override public boolean retry() {
-            return false;
+            return RETRY_INCONSISTENT_VALUE;
         }
     },
     RESOURCE_UNAVAILABLE {
         @Override public boolean isFatal() {
-            return false; // should be true (OpenNMS doesn't do sets), but fall through for bad agents
+            return FATAL_RESOURCE_UNAVAILABLE;
         }
         @Override public boolean retry() {
-            return false;
+            return RETRY_RESOURCE_UNAVAILABLE;
         }
     },
     COMMIT_FAILED {
         @Override public boolean isFatal() {
-            return false; // should be true (OpenNMS doesn't do sets), but fall through for bad agents
+            return FATAL_COMMIT_FAILED;
         }
         @Override public boolean retry() {
-            return false;
+            return RETRY_COMMIT_FAILED;
         }
     },
     UNDO_FAILED {
         @Override public boolean isFatal() {
-            return false; // should be true (OpenNMS doesn't do sets), but fall through for bad agents
+            return FATAL_UNDO_FAILED;
         }
         @Override public boolean retry() {
-            return false;
+            return RETRY_UNDO_FAILED;
         }
     },
     AUTHORIZATION_ERROR {
         @Override public boolean isFatal() {
-            return false;
+            return FATAL_AUTHORIZATION_ERROR;
         }
         @Override public boolean retry() {
-            return true;
+            return RETRY_AUTHORIZATION_ERROR;
         }
     },
     NOT_WRITABLE {
         @Override public boolean isFatal() {
-            return false; // should be true (OpenNMS doesn't do sets), but fall through for bad agents
+            return FATAL_NOT_WRITABLE;
         }
         @Override public boolean retry() {
-            return false;
+            return RETRY_NOT_WRITABLE;
         }
     },
     INCONSISTENT_NAME {
         @Override public boolean isFatal() {
-            return false; // should be true (OpenNMS doesn't do sets), but fall through for bad agents
+            return FATAL_INCONSISTENT_NAME;
         }
         @Override public boolean retry() {
-            return false;
+            return RETRY_INCONSISTENT_NAME;
         }
     };
-    
+
+    private static final boolean FATAL_NO_ERROR = Boolean.valueOf(System.getProperty("org.opennms.netmgt.snmp.errorStatus.0.fatal", "false"));
+    private static final boolean RETRY_NO_ERROR = Boolean.valueOf(System.getProperty("org.opennms.netmgt.snmp.errorStatus.0.retry", "false"));
+
+    private static final boolean FATAL_TOO_BIG = Boolean.valueOf(System.getProperty("org.opennms.netmgt.snmp.errorStatus.1.fatal", "false"));
+    private static final boolean RETRY_TOO_BIG = Boolean.valueOf(System.getProperty("org.opennms.netmgt.snmp.errorStatus.1.retry", "true"));
+
+    private static final boolean FATAL_NO_SUCH_NAME = Boolean.valueOf(System.getProperty("org.opennms.netmgt.snmp.errorStatus.2.fatal", "false"));
+    private static final boolean RETRY_NO_SUCH_NAME = Boolean.valueOf(System.getProperty("org.opennms.netmgt.snmp.errorStatus.2.retry", "true"));
+
+    private static final boolean FATAL_BAD_VALUE = Boolean.valueOf(System.getProperty("org.opennms.netmgt.snmp.errorStatus.3.fatal", "false"));
+    private static final boolean RETRY_BAD_VALUE = Boolean.valueOf(System.getProperty("org.opennms.netmgt.snmp.errorStatus.3.retry", "false"));
+
+    private static final boolean FATAL_READ_ONLY = Boolean.valueOf(System.getProperty("org.opennms.netmgt.snmp.errorStatus.4.fatal", "false"));
+    private static final boolean RETRY_READ_ONLY = Boolean.valueOf(System.getProperty("org.opennms.netmgt.snmp.errorStatus.4.retry", "false"));
+
+    private static final boolean FATAL_GEN_ERR = Boolean.valueOf(System.getProperty("org.opennms.netmgt.snmp.errorStatus.5.fatal", "false"));
+    private static final boolean RETRY_GEN_ERR = Boolean.valueOf(System.getProperty("org.opennms.netmgt.snmp.errorStatus.5.retry", "true"));
+
+    private static final boolean FATAL_NO_ACCESS = Boolean.valueOf(System.getProperty("org.opennms.netmgt.snmp.errorStatus.6.fatal", "false"));
+    private static final boolean RETRY_NO_ACCESS = Boolean.valueOf(System.getProperty("org.opennms.netmgt.snmp.errorStatus.6.retry", "true"));
+
+    private static final boolean FATAL_WRONG_TYPE = Boolean.valueOf(System.getProperty("org.opennms.netmgt.snmp.errorStatus.7.fatal", "false"));
+    private static final boolean RETRY_WRONG_TYPE = Boolean.valueOf(System.getProperty("org.opennms.netmgt.snmp.errorStatus.7.retry", "false"));
+
+    private static final boolean FATAL_WRONG_LENGTH = Boolean.valueOf(System.getProperty("org.opennms.netmgt.snmp.errorStatus.8.fatal", "false"));
+    private static final boolean RETRY_WRONG_LENGTH = Boolean.valueOf(System.getProperty("org.opennms.netmgt.snmp.errorStatus.8.retry", "false"));
+
+    private static final boolean FATAL_WRONG_ENCODING = Boolean.valueOf(System.getProperty("org.opennms.netmgt.snmp.errorStatus.9.fatal", "false"));
+    private static final boolean RETRY_WRONG_ENCODING = Boolean.valueOf(System.getProperty("org.opennms.netmgt.snmp.errorStatus.9.retry", "false"));
+
+    private static final boolean FATAL_WRONG_VALUE = Boolean.valueOf(System.getProperty("org.opennms.netmgt.snmp.errorStatus.10.fatal", "false"));
+    private static final boolean RETRY_WRONG_VALUE = Boolean.valueOf(System.getProperty("org.opennms.netmgt.snmp.errorStatus.10.retry", "false"));
+
+    private static final boolean FATAL_NO_CREATION = Boolean.valueOf(System.getProperty("org.opennms.netmgt.snmp.errorStatus.11.fatal", "false"));
+    private static final boolean RETRY_NO_CREATION = Boolean.valueOf(System.getProperty("org.opennms.netmgt.snmp.errorStatus.11.retry", "false"));
+
+    private static final boolean FATAL_INCONSISTENT_VALUE = Boolean.valueOf(System.getProperty("org.opennms.netmgt.snmp.errorStatus.12.fatal", "false"));
+    private static final boolean RETRY_INCONSISTENT_VALUE = Boolean.valueOf(System.getProperty("org.opennms.netmgt.snmp.errorStatus.12.retry", "false"));
+
+    private static final boolean FATAL_RESOURCE_UNAVAILABLE = Boolean.valueOf(System.getProperty("org.opennms.netmgt.snmp.errorStatus.13.fatal", "false"));
+    private static final boolean RETRY_RESOURCE_UNAVAILABLE = Boolean.valueOf(System.getProperty("org.opennms.netmgt.snmp.errorStatus.13.retry", "false"));
+
+    private static final boolean FATAL_COMMIT_FAILED = Boolean.valueOf(System.getProperty("org.opennms.netmgt.snmp.errorStatus.14.fatal", "false"));
+    private static final boolean RETRY_COMMIT_FAILED = Boolean.valueOf(System.getProperty("org.opennms.netmgt.snmp.errorStatus.14.retry", "false"));
+
+    private static final boolean FATAL_UNDO_FAILED = Boolean.valueOf(System.getProperty("org.opennms.netmgt.snmp.errorStatus.15.fatal", "false"));
+    private static final boolean RETRY_UNDO_FAILED = Boolean.valueOf(System.getProperty("org.opennms.netmgt.snmp.errorStatus.15.retry", "false"));
+
+    private static final boolean FATAL_AUTHORIZATION_ERROR = Boolean.valueOf(System.getProperty("org.opennms.netmgt.snmp.errorStatus.16.fatal", "false"));
+    private static final boolean RETRY_AUTHORIZATION_ERROR = Boolean.valueOf(System.getProperty("org.opennms.netmgt.snmp.errorStatus.16.retry", "true"));
+
+    private static final boolean FATAL_NOT_WRITABLE = Boolean.valueOf(System.getProperty("org.opennms.netmgt.snmp.errorStatus.17.fatal", "false"));
+    private static final boolean RETRY_NOT_WRITABLE = Boolean.valueOf(System.getProperty("org.opennms.netmgt.snmp.errorStatus.17.retry", "false"));
+
+    private static final boolean FATAL_INCONSISTENT_NAME = Boolean.valueOf(System.getProperty("org.opennms.netmgt.snmp.errorStatus.18.fatal", "false"));
+    private static final boolean RETRY_INCONSISTENT_NAME = Boolean.valueOf(System.getProperty("org.opennms.netmgt.snmp.errorStatus.18.retry", "false"));
+
     /**
      * Whether or not this error status should be fatal (ie, throw an exception).
      */

--- a/core/snmp/api/src/main/java/org/opennms/netmgt/snmp/ErrorStatus.java
+++ b/core/snmp/api/src/main/java/org/opennms/netmgt/snmp/ErrorStatus.java
@@ -55,18 +55,18 @@ public enum ErrorStatus {
     },
     BAD_VALUE {
         @Override public boolean isFatal() {
-            return false;
+            return false; // should be true (OpenNMS doesn't do sets), but fall through for bad agents
         }
         @Override public boolean retry() {
-            return true;
+            return false;
         }
     },
     READ_ONLY {
         @Override public boolean isFatal() {
-            return false;
+            return false; // should be true (OpenNMS doesn't do sets), but fall through for bad agents
         }
         @Override public boolean retry() {
-            return true;
+            return false;
         }
     },
     GEN_ERR {
@@ -87,74 +87,74 @@ public enum ErrorStatus {
     },
     WRONG_TYPE {
         @Override public boolean isFatal() {
-            return true;
+            return false; // should be true (OpenNMS doesn't do sets), but fall through for bad agents
         }
         @Override public boolean retry() {
-            return true;
+            return false;
         }
     },
     WRONG_LENGTH {
         @Override public boolean isFatal() {
-            return true;
+            return false; // should be true (OpenNMS doesn't do sets), but fall through for bad agents
         }
         @Override public boolean retry() {
-            return true;
+            return false;
         }
     },
     WRONG_ENCODING {
         @Override public boolean isFatal() {
-            return true;
+            return false; // should be true (OpenNMS doesn't do sets), but fall through for bad agents
         }
         @Override public boolean retry() {
-            return true;
+            return false;
         }
     },
     WRONG_VALUE {
         @Override public boolean isFatal() {
-            return true;
+            return false; // should be true (OpenNMS doesn't do sets), but fall through for bad agents
         }
         @Override public boolean retry() {
-            return true;
+            return false;
         }
     },
     NO_CREATION {
         @Override public boolean isFatal() {
-            return false;
+            return false; // should be true (OpenNMS doesn't do sets), but fall through for bad agents
         }
         @Override public boolean retry() {
-            return true;
+            return false;
         }
     },
     INCONSISTENT_VALUE {
         @Override public boolean isFatal() {
-            return false;
+            return false; // should be true (OpenNMS doesn't do sets), but fall through for bad agents
         }
         @Override public boolean retry() {
-            return true;
+            return false;
         }
     },
     RESOURCE_UNAVAILABLE {
         @Override public boolean isFatal() {
-            return false;
+            return false; // should be true (OpenNMS doesn't do sets), but fall through for bad agents
         }
         @Override public boolean retry() {
-            return true;
+            return false;
         }
     },
     COMMIT_FAILED {
         @Override public boolean isFatal() {
-            return false;
+            return false; // should be true (OpenNMS doesn't do sets), but fall through for bad agents
         }
         @Override public boolean retry() {
-            return true;
+            return false;
         }
     },
     UNDO_FAILED {
         @Override public boolean isFatal() {
-            return false;
+            return false; // should be true (OpenNMS doesn't do sets), but fall through for bad agents
         }
         @Override public boolean retry() {
-            return true;
+            return false;
         }
     },
     AUTHORIZATION_ERROR {
@@ -167,18 +167,18 @@ public enum ErrorStatus {
     },
     NOT_WRITABLE {
         @Override public boolean isFatal() {
-            return false;
+            return false; // should be true (OpenNMS doesn't do sets), but fall through for bad agents
         }
         @Override public boolean retry() {
-            return true;
+            return false;
         }
     },
     INCONSISTENT_NAME {
         @Override public boolean isFatal() {
-            return false;
+            return false; // should be true (OpenNMS doesn't do sets), but fall through for bad agents
         }
         @Override public boolean retry() {
-            return true;
+            return false;
         }
     };
     

--- a/opennms-doc/guide-admin/src/asciidoc/index.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/index.adoc
@@ -209,3 +209,7 @@ include::text/plugin-manager/internal-plugins-repository.adoc[]
 include::text/plugins/introduction.adoc[]
 include::text/plugins/alarm-change-notifier.adoc[]
 include::text/plugins/opennms-es-rest.adoc[]
+
+[[ga-special-cases-and-workarounds]]
+== Special Cases and Workarounds
+include::text/workarounds/snmp.adoc[]

--- a/opennms-doc/guide-admin/src/asciidoc/text/workarounds/snmp.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/workarounds/snmp.adoc
@@ -1,0 +1,41 @@
+
+=== Overriding SNMP Client Behavior
+
+By default, the SNMP subsystem in {opennms-product-name} does not treat _any_ link:https://tools.ietf.org/html/rfc3416[RFC 3416] `error-status` as fatal.  Instead, it will attempt to continue the request, if possible.  However, only a subset of errors will cause {opennms-product-name}'s SNMP client to attempt retries.  The default SNMP `error-status` handling behavior is as follows:
+
+.Default SNMP Error Status Behavior
+[options="header, autowidth"]
+|===
+| `error-status`          | Fatal? | Retry?
+| noError(0)              | false  | false
+| tooBig(1)               | false  | true
+| noSuchName(2)           | false  | true
+| badValue(3)             | false  | false
+| readOnly(4)             | false  | false
+| genErr(5)               | false  | true
+| noAccess(6)             | false  | true
+| wrongType(7)            | false  | false
+| wrongLength(8)          | false  | false
+| wrongEncoding(9)        | false  | false
+| wrongValue(10)          | false  | false
+| noCreation(11)          | false  | false
+| inconsistentValue(12)   | false  | false
+| resourceUnavailable(13) | false  | false
+| commitFailed(14)        | false  | false
+| undoFailed(15)          | false  | false
+| authorizationError(16)  | false  | true
+| notWritable(17)         | false  | false
+| inconsistentName(18)    | false  | false
+|===
+
+You can override this behavior by setting a property inside `${OPENNMS_HOME}/etc/opennms.properties` in the form:
+
+`org.opennms.netmgt.snmp.errorStatus._[statusCode]_._[type]_`
+
+For example, to make `authorizationError(16)` abort and not retry, you would set:
+
+[source,properties]
+----
+org.opennms.netmgt.snmp.errorStatus.16.fatal=true
+org.opennms.netmgt.snmp.errorStatus.16.retry=false
+----

--- a/opennms-provision/opennms-provisiond/src/main/java/org/opennms/netmgt/provision/service/snmp/SnmpTable.java
+++ b/opennms-provision/opennms-provisiond/src/main/java/org/opennms/netmgt/provision/service/snmp/SnmpTable.java
@@ -38,6 +38,8 @@ import java.util.TreeMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.opennms.netmgt.snmp.AggregateTracker;
+import org.opennms.netmgt.snmp.ErrorStatus;
+import org.opennms.netmgt.snmp.ErrorStatusException;
 import org.opennms.netmgt.snmp.NamedSnmpVar;
 import org.opennms.netmgt.snmp.SnmpInstId;
 import org.opennms.netmgt.snmp.SnmpObjId;
@@ -118,6 +120,16 @@ public abstract class SnmpTable<T extends SnmpTableEntry> extends AggregateTrack
         LOG.warn("Error retrieving {} from {}. {}", msg, m_tableName, m_address);
     }
     
+    @Override
+    protected void reportFatalErr(final ErrorStatusException ex) {
+        LOG.warn("Error retrieving {} from {}. {}", m_tableName, m_address, ex.getMessage(), ex);
+    }
+
+    @Override
+    protected void reportNonFatalErr(final ErrorStatus status) {
+        LOG.info("Non-fatal error ({}) encountered retrieving {} from {}. {}", status, m_tableName, m_address, status.retry()? "Retrying." : "Giving up.");
+    }
+
     /**
      * <p>getEntry</p>
      *

--- a/opennms-provision/opennms-provisiond/src/main/java/org/opennms/netmgt/provision/service/snmp/SystemGroup.java
+++ b/opennms-provision/opennms-provisiond/src/main/java/org/opennms/netmgt/provision/service/snmp/SystemGroup.java
@@ -31,14 +31,16 @@ package org.opennms.netmgt.provision.service.snmp;
 
 import java.net.InetAddress;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.opennms.netmgt.model.OnmsNode;
 import org.opennms.netmgt.provision.service.operations.ScanResource;
 import org.opennms.netmgt.snmp.AggregateTracker;
+import org.opennms.netmgt.snmp.ErrorStatus;
+import org.opennms.netmgt.snmp.ErrorStatusException;
 import org.opennms.netmgt.snmp.NamedSnmpVar;
 import org.opennms.netmgt.snmp.SnmpResult;
 import org.opennms.netmgt.snmp.SnmpStore;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * <P>
@@ -271,13 +273,23 @@ public final class SystemGroup extends AggregateTracker {
     /** {@inheritDoc} */
     @Override
     protected void reportGenErr(String msg) {
-        LOG.warn("Error retrieving systemGroup from {}. {}", msg, m_address);
+        LOG.warn("Error retrieving systemGroup from {}. {}", m_address, msg);
     }
 
     /** {@inheritDoc} */
     @Override
     protected void reportNoSuchNameErr(String msg) {
-        LOG.info("Error retrieving systemGroup from {}. {}", msg, m_address);
+        LOG.info("Error retrieving systemGroup from {}. {}", m_address, msg);
+    }
+
+    @Override
+    protected void reportFatalErr(final ErrorStatusException ex) {
+        LOG.warn("Error retrieving systemGroup from {}. {}", m_address, ex.getMessage(), ex);
+    }
+
+    @Override
+    protected void reportNonFatalErr(final ErrorStatus status) {
+        LOG.info("Error ({}) retrieving systemGroup from {}. {}", status, m_address, status.retry()? "Retrying." : "Giving up.");
     }
 
     /**

--- a/opennms-services/src/main/java/org/opennms/netmgt/capsd/snmp/SnmpTable.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/capsd/snmp/SnmpTable.java
@@ -36,6 +36,8 @@ import java.util.Map;
 import java.util.TreeMap;
 
 import org.opennms.netmgt.snmp.AggregateTracker;
+import org.opennms.netmgt.snmp.ErrorStatus;
+import org.opennms.netmgt.snmp.ErrorStatusException;
 import org.opennms.netmgt.snmp.NamedSnmpVar;
 import org.opennms.netmgt.snmp.SnmpInstId;
 import org.opennms.netmgt.snmp.SnmpObjId;
@@ -123,6 +125,16 @@ public abstract class SnmpTable<T extends SnmpStore> extends AggregateTracker im
     @Override
     protected void reportNoSuchNameErr(String msg) {
         LOG.info("Error retrieving {} from {}. {}", m_tableName, m_address, msg);
+    }
+
+    @Override
+    protected void reportFatalErr(final ErrorStatusException ex) {
+        LOG.warn("Error retrieving {} from {}. {}", m_tableName, m_address, ex.getMessage(), ex);
+    }
+
+    @Override
+    protected void reportNonFatalErr(final ErrorStatus status) {
+        LOG.info("Non-fatal error ({}) encountered: {}", status, status.retry()? "Retrying." : "Giving up.");
     }
 
     @Override

--- a/opennms-services/src/main/java/org/opennms/netmgt/collectd/SnmpIfCollector.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/collectd/SnmpIfCollector.java
@@ -37,6 +37,8 @@ import java.util.TreeMap;
 import org.opennms.core.utils.InetAddressUtils;
 import org.opennms.netmgt.collection.api.CollectionSet;
 import org.opennms.netmgt.snmp.AggregateTracker;
+import org.opennms.netmgt.snmp.ErrorStatus;
+import org.opennms.netmgt.snmp.ErrorStatusException;
 import org.opennms.netmgt.snmp.SnmpInstId;
 import org.opennms.netmgt.snmp.SnmpResult;
 import org.slf4j.Logger;
@@ -144,6 +146,16 @@ public class SnmpIfCollector extends AggregateTracker {
     @Override
     protected void reportTooBigErr(String msg) {
         LOG.info("{} : request tooBig. {}", m_primaryIf, msg);
+    }
+
+    @Override
+    protected void reportFatalErr(final ErrorStatusException ex) {
+        LOG.warn("{} : fatal error. {}", m_primaryIf, ex.getMessage(), ex);
+    }
+
+    @Override
+    protected void reportNonFatalErr(final ErrorStatus status) {
+        LOG.info("{} : non-fatal error ({}) encountered: {}", m_primaryIf, status, status.retry()? "Retrying." : "Giving up.");
     }
 
     /** {@inheritDoc} */

--- a/opennms-services/src/main/java/org/opennms/netmgt/collectd/SnmpNodeCollector.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/collectd/SnmpNodeCollector.java
@@ -33,6 +33,8 @@ import java.util.Collection;
 
 import org.opennms.core.utils.InetAddressUtils;
 import org.opennms.netmgt.snmp.AggregateTracker;
+import org.opennms.netmgt.snmp.ErrorStatus;
+import org.opennms.netmgt.snmp.ErrorStatusException;
 import org.opennms.netmgt.snmp.SnmpResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -107,6 +109,16 @@ public class SnmpNodeCollector extends AggregateTracker {
     @Override
     protected void reportNoSuchNameErr(String msg) {
         LOG.info("noSuchName collecting data for node {}: {}", m_primaryIf, msg);
+    }
+
+    @Override
+    protected void reportFatalErr(final ErrorStatusException ex) {
+        LOG.warn("Fatal error collecting data for node {}: {}", m_primaryIf, ex.getMessage(), ex);
+    }
+
+    @Override
+    protected void reportNonFatalErr(final ErrorStatus status) {
+        LOG.info("Non-fatal error ({}) collecting data for node {}: {}", status, m_primaryIf, status.retry()? "Retrying." : "Giving up.");
     }
 
     /** {@inheritDoc} */

--- a/opennms-services/src/main/java/org/opennms/netmgt/enlinkd/snmp/CdpGlobalGroupTracker.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/enlinkd/snmp/CdpGlobalGroupTracker.java
@@ -28,15 +28,17 @@
 
 package org.opennms.netmgt.enlinkd.snmp;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.opennms.netmgt.model.CdpElement;
 import org.opennms.netmgt.model.CdpElement.CdpGlobalDeviceIdFormat;
 import org.opennms.netmgt.model.OspfElement.TruthValue;
 import org.opennms.netmgt.snmp.AggregateTracker;
+import org.opennms.netmgt.snmp.ErrorStatus;
+import org.opennms.netmgt.snmp.ErrorStatusException;
 import org.opennms.netmgt.snmp.NamedSnmpVar;
 import org.opennms.netmgt.snmp.SnmpResult;
 import org.opennms.netmgt.snmp.SnmpStore;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * <P>Dot1dBaseGroup holds the dot1dBridge.dot1dBase group properties
@@ -143,12 +145,22 @@ public final class CdpGlobalGroupTracker extends AggregateTracker
 
     /** {@inheritDoc} */
     protected void reportGenErr(final String msg) {
-        LOG.warn("Error retrieving systemGroup: {}", msg);
+        LOG.warn("Error retrieving CDP global group: {}", msg);
     }
 
     /** {@inheritDoc} */
     protected void reportNoSuchNameErr(final String msg) {
-        LOG.info("Error retrieving systemGroup: {}", msg);
+        LOG.info("Error retrieving CDP global group: {}", msg);
+    }
+
+    @Override
+    protected void reportFatalErr(final ErrorStatusException ex) {
+        LOG.warn("Fatal error retrieving CDP global group: {}", ex.getMessage(), ex);
+    }
+
+    @Override
+    protected void reportNonFatalErr(final ErrorStatus status) {
+        LOG.info("Non-fatal error ({}) retrieving CDP global group: {}", status, status.retry()? "Retrying." : "Giving up.");
     }
 
     /**

--- a/opennms-services/src/main/java/org/opennms/netmgt/enlinkd/snmp/CiscoVtpTracker.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/enlinkd/snmp/CiscoVtpTracker.java
@@ -28,13 +28,13 @@
 
 package org.opennms.netmgt.enlinkd.snmp;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import org.opennms.netmgt.snmp.AggregateTracker;
+import org.opennms.netmgt.snmp.ErrorStatusException;
 import org.opennms.netmgt.snmp.NamedSnmpVar;
 import org.opennms.netmgt.snmp.SnmpResult;
 import org.opennms.netmgt.snmp.SnmpStore;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public final class CiscoVtpTracker extends AggregateTracker
 {
@@ -96,6 +96,11 @@ public final class CiscoVtpTracker extends AggregateTracker
     /** {@inheritDoc} */
     protected void reportNoSuchNameErr(final String msg) {
         LOG.info("Error retrieving vtpVersion: {}", msg);
+    }
+
+    @Override
+    protected void reportFatalErr(final ErrorStatusException ex) {
+        LOG.warn("Error retrieving vtpVersion: {}", ex.getMessage(), ex);
     }
 
     /**

--- a/opennms-services/src/main/java/org/opennms/netmgt/enlinkd/snmp/Dot1dBaseTracker.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/enlinkd/snmp/Dot1dBaseTracker.java
@@ -28,17 +28,17 @@
 
 package org.opennms.netmgt.enlinkd.snmp;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import org.opennms.netmgt.model.BridgeElement;
 import org.opennms.netmgt.model.BridgeElement.BridgeDot1dBaseType;
 import org.opennms.netmgt.model.BridgeElement.BridgeDot1dStpProtocolSpecification;
-
 import org.opennms.netmgt.snmp.AggregateTracker;
+import org.opennms.netmgt.snmp.ErrorStatus;
+import org.opennms.netmgt.snmp.ErrorStatusException;
 import org.opennms.netmgt.snmp.NamedSnmpVar;
 import org.opennms.netmgt.snmp.SnmpResult;
 import org.opennms.netmgt.snmp.SnmpStore;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * <P>Dot1dBase holds the dot1dBridge.dot1dBase group properties
@@ -186,12 +186,22 @@ public final class Dot1dBaseTracker extends AggregateTracker
 
     /** {@inheritDoc} */
     protected void reportGenErr(final String msg) {
-        LOG.warn("Error retrieving do1dbase: {}", msg);
+        LOG.warn("Error retrieving dot1dbase: {}", msg);
     }
 
     /** {@inheritDoc} */
     protected void reportNoSuchNameErr(final String msg) {
-        LOG.info("Error retrieving do1dbase: {}", msg);
+        LOG.info("Error retrieving dot1dbase: {}", msg);
+    }
+
+    @Override
+    protected void reportFatalErr(final ErrorStatusException ex) {
+        LOG.warn("Error retrieving dot1dbase: {}", ex.getMessage(), ex);
+    }
+
+    @Override
+    protected void reportNonFatalErr(final ErrorStatus status) {
+        LOG.info("Non-fatal error ({}) retrieving dot1dbase: {}", status, status.retry()? "Retrying." : "Giving up.");
     }
 
     /**

--- a/opennms-services/src/main/java/org/opennms/netmgt/enlinkd/snmp/IsisSysObjectGroupTracker.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/enlinkd/snmp/IsisSysObjectGroupTracker.java
@@ -31,6 +31,8 @@ package org.opennms.netmgt.enlinkd.snmp;
 import org.opennms.netmgt.model.IsIsElement;
 import org.opennms.netmgt.model.IsIsElement.IsisAdminState;
 import org.opennms.netmgt.snmp.AggregateTracker;
+import org.opennms.netmgt.snmp.ErrorStatus;
+import org.opennms.netmgt.snmp.ErrorStatusException;
 import org.opennms.netmgt.snmp.NamedSnmpVar;
 import org.opennms.netmgt.snmp.SnmpResult;
 import org.opennms.netmgt.snmp.SnmpStore;
@@ -129,6 +131,16 @@ public final class IsisSysObjectGroupTracker extends AggregateTracker {
     @Override
     protected void reportNoSuchNameErr(String msg) {
         LOG.info("Error retrieving isisSysObject: {}", msg);
+    }
+
+    @Override
+    protected void reportFatalErr(final ErrorStatusException ex) {
+        LOG.warn("Error retrieving isisSysObject: {}", ex.getMessage(), ex);
+    }
+
+    @Override
+    protected void reportNonFatalErr(final ErrorStatus status) {
+        LOG.info("Non-fatal error ({}) retrieving isisSysObject: {}", status, status.retry()? "Retrying." : "Giving up.");
     }
 
     public IsIsElement getIsisElement() {

--- a/opennms-services/src/main/java/org/opennms/netmgt/enlinkd/snmp/LldpLocalGroupTracker.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/enlinkd/snmp/LldpLocalGroupTracker.java
@@ -32,6 +32,8 @@ import org.opennms.core.utils.LldpUtils;
 import org.opennms.core.utils.LldpUtils.LldpChassisIdSubType;
 import org.opennms.netmgt.model.LldpElement;
 import org.opennms.netmgt.snmp.AggregateTracker;
+import org.opennms.netmgt.snmp.ErrorStatus;
+import org.opennms.netmgt.snmp.ErrorStatusException;
 import org.opennms.netmgt.snmp.NamedSnmpVar;
 import org.opennms.netmgt.snmp.SnmpResult;
 import org.opennms.netmgt.snmp.SnmpStore;
@@ -260,12 +262,22 @@ public final class LldpLocalGroupTracker extends AggregateTracker {
 
     /** {@inheritDoc} */
     protected void reportGenErr(String msg) {
-        LOG.warn("Error retrieving lldpLocalGroup: {}",msg);
+        LOG.warn("Error retrieving LLDP local group: {}",msg);
     }
 
     /** {@inheritDoc} */
     protected void reportNoSuchNameErr(String msg) {
-        LOG.info("Error retrieving lldpLocalGroup: {}",msg);
+        LOG.info("Error retrieving LLDP local group: {}",msg);
+    }
+
+    @Override
+    protected void reportFatalErr(final ErrorStatusException ex) {
+        LOG.warn("Error retrieving LLDP local group: {}", ex.getMessage(), ex);
+    }
+
+    @Override
+    protected void reportNonFatalErr(final ErrorStatus status) {
+        LOG.info("Non-fatal error ({}) retrieving LLDP local group: {}", status, status.retry()? "Retrying." : "Giving up.");
     }
 
     public LldpElement getLldpElement() {

--- a/opennms-services/src/main/java/org/opennms/netmgt/enlinkd/snmp/OspfGeneralGroupTracker.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/enlinkd/snmp/OspfGeneralGroupTracker.java
@@ -34,6 +34,8 @@ import org.opennms.netmgt.model.OspfElement;
 import org.opennms.netmgt.model.OspfElement.Status;
 import org.opennms.netmgt.model.OspfElement.TruthValue;
 import org.opennms.netmgt.snmp.AggregateTracker;
+import org.opennms.netmgt.snmp.ErrorStatus;
+import org.opennms.netmgt.snmp.ErrorStatusException;
 import org.opennms.netmgt.snmp.NamedSnmpVar;
 import org.opennms.netmgt.snmp.SnmpResult;
 import org.opennms.netmgt.snmp.SnmpStore;
@@ -193,12 +195,22 @@ public final class OspfGeneralGroupTracker extends AggregateTracker {
 
     /** {@inheritDoc} */
     protected void reportGenErr(String msg) {
-        LOG.warn("Error retrieving OspfGeneralGroup: {}",msg);
+        LOG.warn("Error retrieving OSPF general group: {}",msg);
     }
 
     /** {@inheritDoc} */
     protected void reportNoSuchNameErr(String msg) {
-        LOG.info("Error retrieving OspfGeneralGroup: {}",msg);
+        LOG.info("Error retrieving OSPF general group: {}",msg);
+    }
+
+    @Override
+    protected void reportFatalErr(final ErrorStatusException ex) {
+        LOG.warn("Error retrieving OSPF general group: {}", ex.getMessage(), ex);
+    }
+
+    @Override
+    protected void reportNonFatalErr(final ErrorStatus status) {
+        LOG.info("Non-fatal error ({}) retrieving OSPF general group: {}", status, status.retry()? "Retrying." : "Giving up.");
     }
 
 }


### PR DESCRIPTION
This PR adds a few bug fixes and enhancements on top of the previous work done for [NMS-8671](https://issues.opennms.org/browse/NMS-8671).

* Change any `SET*`-related errors to be non-fatal, but to have 0 retries.  They are basically always going to be invalid in our case since OpenNMS doesn't perform any SETs, but we will generally want to continue without bailing to see if we can get more data despite a non-compliant response from an agent.
* Add `reportFatalErr()` and `reportNonFatalErr()` log methods to the `CollectionTracker` API so that all logging happens on the thread that is processing the request.
* Change the `ErrorStatus` handling to be configurable (sane defaults, but now it is possible to override the global SNMP client behavior to handle `error-status` responses in a different way).
* Add a "Special Cases and Workarounds" section to the documentation, and document the `error-status` customization there.

* JIRA: http://issues.opennms.org/browse/NMS-8671

The default SNMP error-status handlers perform as follows:
    
| error-status            | Fatal? | Retry? |
|---|---|---|
| noError(0)              | false  | false  |
| tooBig(1)               | false  | true   |
| noSuchName(2)           | false  | true   |
| badValue(3)             | false  | false  |
| readOnly(4)             | false  | false  |
| genErr(5)               | false  | true   |
| noAccess(6)             | false  | true   |
| wrongType(7)            | false  | false  |
| wrongLength(8)          | false  | false  |
| wrongEncoding(9)        | false  | false  |
| wrongValue(10)          | false  | false  |
| noCreation(11)          | false  | false  |
| inconsistentValue(12)   | false  | false  |
| resourceUnavailable(13) | false  | false  |
| commitFailed(14)        | false  | false  |
| undoFailed(15)          | false  | false  |
| authorizationError(16)  | false  | true   |
| notWritable(17)         | false  | false  |
| inconsistentName(18)    | false  | false  |
   
You can override this behavior by setting a property inside `${OPENNMS_HOME}/etc/opennms.properties` in the form:
    
```properties
org.opennms.netmgt.snmp.errorStatus.[statusCode].[type]
```
    
For example, to make authorizationError(16) throw an exception and not retry, you would set:

```properties
org.opennms.netmgt.snmp.errorStatus.16.fatal=true
org.opennms.netmgt.snmp.errorStatus.16.retry=false
```