### PR TITLE
NMS-8940: Remove the urls from wsdl2java config

### DIFF
--- a/features/ticketing/remedy-integration/pom.xml
+++ b/features/ticketing/remedy-integration/pom.xml
@@ -20,10 +20,6 @@
 					</execution>
 				</executions>
 				<configuration>
-					<urls>
-						<url>file:///${project.basedir}/src/main/wsdl/HPD_IncidentInterface_WS.wsdl</url>
-						<url>file:///${project.basedir}/src/main/wsdl/HPD_IncidentInterface_Create_WS.wsdl</url>
-					</urls>
 					<packageSpace>
 						org.opennms.integration.remedy.ticketservice
 					</packageSpace>


### PR DESCRIPTION
This should prevent the long filename failures in Bamboo.

* JIRA: http://issues.opennms.org/browse/NMS-8940
* Bamboo: http://bamboo.internal.opennms.com:8085/browse/OPENNMS-ONMS1191