### PR TITLE
NMS-8929: Upgrade Zookeeper inside camel-kafka

### DIFF
--- a/container/features/src/main/resources/features.xml
+++ b/container/features/src/main/resources/features.xml
@@ -87,7 +87,7 @@
       <bundle>mvn:org.opennms.features.amqp/org.opennms.features.amqp.alarm-northbounder/${project.version}</bundle>
     </feature>
 
-    <!-- need to override camel-elasticsearch because it pulls an elasticsearch version that does not work -->
+    <!-- need to override camel-elasticsearch because it pulls in an elasticsearch version that does not work -->
     <feature name='onms-camel-elasticsearch' version='${camelVersion}' resolver='(obr)' start-level='50'>
       <feature version='${camelVersion}'>camel-core</feature>
       <feature version="${guavaVersion}">guava</feature>
@@ -105,6 +105,21 @@
       <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.lucene-sandbox/4.6.1_1</bundle>
       <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.elasticsearch/1.0.0_4</bundle>
       <bundle>mvn:org.apache.camel/camel-elasticsearch/${camelVersion}</bundle>
+    </feature>
+
+    <!-- need to override camel-kafka because it pulls in a Zookeeper version that has bad OSGi metadata -->
+    <feature name='onms-camel-kafka' version='${camelVersion}' resolver='(obr)' start-level='50'>
+      <bundle dependency="true">mvn:org.scala-lang/scala-library/2.10.4</bundle>
+      <!-- NMS-8929: Upgrade Zookeeper to fix bug https://issues.apache.org/jira/browse/ZOOKEEPER-2056 -->
+      <!-- <bundle dependency="true">mvn:org.apache.zookeeper/zookeeper/3.4.6</bundle> -->
+      <bundle dependency="true">mvn:org.apache.zookeeper/zookeeper/3.4.7</bundle>
+      <bundle dependency="true">wrap:mvn:com.yammer.metrics/metrics-core/2.2.0$Bundle-Version=2.2.0&amp;Export-Package=*;-noimport:=true;version="2.2.0"</bundle>
+      <bundle dependency="true">wrap:mvn:com.yammer.metrics/metrics-annotation/2.2.0$Bundle-Version=2.2.0&amp;Export-Package=*;-noimport:=true;version="2.2.0"</bundle>
+      <bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.kafka_2.10/0.8.1_1</bundle>
+      <!-- HZN-811: Missing dependency on zkclient, can be removed when we upgrade to Camel 2.16.0+ -->
+      <bundle dependency="true">wrap:mvn:com.101tec/zkclient/0.3$Bundle-Version=0.3&amp;Export-Package=*;-noimport:=true;version="0.3"</bundle>
+      <feature version="2.14.1">camel-core</feature>
+      <bundle>mvn:org.apache.camel/camel-kafka/2.14.1</bundle>
     </feature>
 
     <feature name="opennms-elasticsearch-event-forwarder" description="OpenNMS :: Features :: Elasticsearch :: Event Forwarder" version="${project.version}">
@@ -797,14 +812,12 @@
       <feature>activemq-camel</feature>
       <feature>camel-core</feature>
       <feature>camel-http</feature>
-      <feature>camel-kafka</feature>
+      <feature>onms-camel-kafka</feature>
       <feature>camel-netty</feature>
       <feature version="${guavaVersion}">guava</feature>
 
       <feature>dropwizard-metrics</feature>
       <feature>lmax-disruptor</feature>
-      <!-- HZN-811: Missing dependency on zkclient, can be removed when we upgrade to Camel 2.16.0+ -->
-      <bundle dependency="true">wrap:mvn:com.101tec/zkclient/0.3$Bundle-Version=0.3&amp;Export-Package=*;-noimport:=true;version="0.3"</bundle>
 
       <feature>opennms-core</feature>
       <feature>opennms-core-camel</feature>
@@ -858,11 +871,8 @@
     <!-- TODO: Rename this. It's more of an Dominion-side syslog connection handler... -->
     <feature name="opennms-syslogd-handler-kafka-default" description="OpenNMS :: Syslogd :: Handler :: Kafka :: Default" version="${project.version}">
       <feature>camel-blueprint</feature>
-      <feature>camel-kafka</feature>
+      <feature>onms-camel-kafka</feature>
       <feature>opennms-core-camel</feature>
-
-      <!-- HZN-811: Missing dependency on zkclient, can be removed when we upgrade to Camel 2.16.0+ -->
-      <bundle dependency="true">wrap:mvn:com.101tec/zkclient/0.3$Bundle-Version=0.3&amp;Export-Package=*;-noimport:=true;version="0.3"</bundle>
 
       <!--
       These classes are in the system classpath inside OpenNMS
@@ -880,12 +890,9 @@
       <feature>activemq-camel</feature>
       <feature>camel-core</feature>
       <feature>camel-http</feature>
-      <feature>camel-kafka</feature>
+      <feature>onms-camel-kafka</feature>
       <feature>camel-netty</feature>
       <feature version="${guavaVersion}">guava</feature>
-
-      <!-- HZN-811: Missing dependency on zkclient, can be removed when we upgrade to Camel 2.16.0+ -->
-      <bundle dependency="true">wrap:mvn:com.101tec/zkclient/0.3$Bundle-Version=0.3&amp;Export-Package=*;-noimport:=true;version="0.3"</bundle>
 
       <feature>opennms-core</feature>
       <feature>opennms-core-camel</feature>
@@ -926,11 +933,8 @@
     <!-- TODO: Rename this. It's more of an Dominion-side trap message handler... -->
     <feature name="opennms-trapd-handler-kafka-default" description="OpenNMS :: Trapd :: Handler :: Kafka :: Default" version="${project.version}">
       <feature>camel-blueprint</feature>
-      <feature>camel-kafka</feature>
+      <feature>onms-camel-kafka</feature>
       <feature>opennms-core-camel</feature>
-
-      <!-- HZN-811: Missing dependency on zkclient, can be removed when we upgrade to Camel 2.16.0+ -->
-      <bundle dependency="true">wrap:mvn:com.101tec/zkclient/0.3$Bundle-Version=0.3&amp;Export-Package=*;-noimport:=true;version="0.3"</bundle>
 
       <!--
       These classes are in the system classpath inside OpenNMS


### PR DESCRIPTION
The version of Zookeeper that comes with Camel 2.14 has bad OSGi metadata so we need to upgrade it one micro version.

* JIRA: http://issues.opennms.org/browse/NMS-8929
* Bamboo: http://bamboo.internal.opennms.com:8085/browse/OPENNMS-ONMS1193