### PR TITLE
NMS-6287: [RFC] - Use the same format for confs as opennms writes

### DIFF
--- a/opennms-base-assembly/src/main/filtered/etc/collectd-configuration.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/collectd-configuration.xml
@@ -1,148 +1,128 @@
-<?xml version="1.0"?>
-<?castor class-name="org.opennms.netmgt.collectd.CollectdConfiguration"?>
-<collectd-configuration
-        threads="50">
-
-    <package name="cassandra21x">
-        <filter><![CDATA[(IPADDR != '0.0.0.0') & (categoryName == 'Cassandra21x')]]></filter>
-        <service name="JMX-Cassandra" interval="300000" user-defined="false" status="on">
-            <parameter key="port" value="7199"/>
-            <parameter key="retry" value="2"/>
-            <parameter key="timeout" value="3000"/>
-            <parameter key="protocol" value="rmi"/>
-            <parameter key="urlPath" value="/jmxrmi"/>
-            <parameter key="rrd-base-name" value="cassandra21x"/>
-            <parameter key="ds-name" value="cassandra21x"/>
-            <parameter key="friendly-name" value="cassandra21x"/>
-            <parameter key="collection" value="cassandra21x"/>
-            <parameter key="thresholding-enabled" value="true"/>
-            <parameter key="factory" value="PASSWORD-CLEAR"/>
-            <parameter key="username" value="cassandra-username"/>
-            <parameter key="password" value="cassandra-password"/>
-        </service>
-    </package>
-
-    <package name="cassandra21x-newts">
-        <filter><![CDATA[(IPADDR != '0.0.0.0') & (catincCassandra21x& catincNewts)]]></filter>
-        <service name="JMX-Cassandra-Newts" interval="300000" user-defined="false" status="on">
-            <parameter key="port" value="7199"/>
-            <parameter key="retry" value="2"/>
-            <parameter key="timeout" value="3000"/>
-            <parameter key="protocol" value="rmi"/>
-            <parameter key="urlPath" value="/jmxrmi"/>
-            <parameter key="rrd-base-name" value="cassandra21x-newts"/>
-            <parameter key="ds-name" value="cassandra21x-newts"/>
-            <parameter key="friendly-name" value="cassandra21x-newts"/>
-            <parameter key="collection" value="cassandra21x-newts"/>
-            <parameter key="thresholding-enabled" value="true"/>
-            <parameter key="factory" value="PASSWORD-CLEAR"/>
-            <parameter key="username" value="cassandra-username"/>
-            <parameter key="password" value="cassandra-password"/>
-        </service>
-    </package>
-
-    <package name="vmware3">
-        <filter><![CDATA[(IPADDR != '0.0.0.0') & (categoryName == 'VMware3')]]></filter>
-        <service name="VMware-VirtualMachine" interval="300000" user-defined="false" status="on">
-            <parameter key="collection" value="default-VirtualMachine3"/>
-            <parameter key="thresholding-enabled" value="true"/>
-        </service>
-
-        <service name="VMware-HostSystem" interval="300000" user-defined="false" status="on">
-            <parameter key="collection" value="default-HostSystem3"/>
-            <parameter key="thresholding-enabled" value="true"/>
-        </service>
-        <service name="VMwareCim-HostSystem" interval="300000" user-defined="false" status="on">
-            <parameter key="collection" value="default-ESX-HostSystem"/>
-            <parameter key="thresholding-enabled" value="true"/>
-        </service>
-    </package>
-
-    <package name="vmware4">
-        <filter><![CDATA[(IPADDR != '0.0.0.0') & (categoryName == 'VMware4')]]></filter>
-        <service name="VMware-VirtualMachine" interval="300000" user-defined="false" status="on">
-            <parameter key="collection" value="default-VirtualMachine4"/>
-            <parameter key="thresholding-enabled" value="true"/>
-        </service>
-
-        <service name="VMware-HostSystem" interval="300000" user-defined="false" status="on">
-            <parameter key="collection" value="default-HostSystem4"/>
-            <parameter key="thresholding-enabled" value="true"/>
-        </service>
-        <service name="VMwareCim-HostSystem" interval="300000" user-defined="false" status="on">
-            <parameter key="collection" value="default-ESX-HostSystem"/>
-            <parameter key="thresholding-enabled" value="true"/>
-        </service>
-    </package>
-
-    <package name="vmware5">
-        <filter><![CDATA[(IPADDR != '0.0.0.0') & (categoryName == 'VMware5')]]></filter>
-        <service name="VMware-VirtualMachine" interval="300000" user-defined="false" status="on">
-            <parameter key="collection" value="default-VirtualMachine5"/>
-            <parameter key="thresholding-enabled" value="true"/>
-        </service>
-
-        <service name="VMware-HostSystem" interval="300000" user-defined="false" status="on">
-            <parameter key="collection" value="default-HostSystem5"/>
-            <parameter key="thresholding-enabled" value="true"/>
-        </service>
-        <service name="VMwareCim-HostSystem" interval="300000" user-defined="false" status="on">
-            <parameter key="collection" value="default-ESX-HostSystem"/>
-            <parameter key="thresholding-enabled" value="true"/>
-        </service>
-    </package>
-
-    <package name="example1">
-        <filter>IPADDR != '0.0.0.0'</filter>
-        <include-range begin="1.1.1.1" end="254.254.254.254"/>
-        <include-range begin="::1" end="ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"/>
-
-        <service name="SNMP" interval="300000" user-defined="false" status="on">
-            <parameter key="collection" value="default"/>
-            <parameter key="thresholding-enabled" value="true"/>
-        </service>
-
-        <service name="WMI" interval="300000" user-defined="false" status="off">
-            <parameter key="collection" value="default"/>
-            <parameter key="thresholding-enabled" value="true"/>
-        </service>
-
-        <service name="WS-Man" interval="300000" user-defined="false" status="on">
-            <parameter key="collection" value="default"/>
-            <parameter key="thresholding-enabled" value="true"/>
-        </service>
-
-        <service name="OpenNMS-JVM" interval="300000" user-defined="false" status="on">
-            <parameter key="port" value="18980"/>
-            <parameter key="retry" value="2"/>
-            <parameter key="timeout" value="3000"/>
-            <parameter key="rrd-base-name" value="java"/>
-            <parameter key="collection" value="jsr160"/>
-            <parameter key="thresholding-enabled" value="true"/>
-            <parameter key="ds-name" value="opennms-jvm"/>
-            <parameter key="friendly-name" value="opennms-jvm"/>
-        </service>
-
-        <service name="PostgreSQL" interval="300000" user-defined="false" status="on">
-            <parameter key="collection" value="PostgreSQL"/>
-            <parameter key="thresholding-enabled" value="true"/>
-            <parameter key="driver" value="org.postgresql.Driver"/>
-            <parameter key="user" value="postgres"/>
-            <parameter key="password" value="postgres"/>
-            <parameter key="url" value="jdbc:postgresql://OPENNMS_JDBC_HOSTNAME:5432/opennms"/>
-        </service>
-    </package>
-
-
-    <collector service="JMX-Cassandra" class-name="org.opennms.netmgt.collectd.Jsr160Collector"/>
-    <collector service="JMX-Cassandra-Newts" class-name="org.opennms.netmgt.collectd.Jsr160Collector"/>
-    <collector service="SNMP" class-name="org.opennms.netmgt.collectd.SnmpCollector"/>
-    <collector service="WMI" class-name="org.opennms.netmgt.collectd.WmiCollector"/>
-    <collector service="WS-Man" class-name="org.opennms.netmgt.collectd.WsManCollector"/>
-    <collector service="OpenNMS-JVM" class-name="org.opennms.netmgt.collectd.Jsr160Collector"/>
-    <collector service="VMware-VirtualMachine" class-name="org.opennms.netmgt.collectd.VmwareCollector"/>
-    <collector service="VMware-HostSystem" class-name="org.opennms.netmgt.collectd.VmwareCollector"/>
-    <collector service="VMwareCim-HostSystem" class-name="org.opennms.netmgt.collectd.VmwareCimCollector"/>
-    <collector service="PostgreSQL" class-name="org.opennms.netmgt.collectd.JdbcCollector"/>
+<collectd-configuration xmlns="http://xmlns.opennms.org/xsd/config/collectd" threads="50">
+   <package name="cassandra21x" remote="false">
+      <filter>(IPADDR != '0.0.0.0') &amp; (categoryName == 'Cassandra21x')</filter>
+      <service name="JMX-Cassandra" interval="300000" user-defined="false" status="on">
+         <parameter key="port" value="7199"/>
+         <parameter key="retry" value="2"/>
+         <parameter key="timeout" value="3000"/>
+         <parameter key="protocol" value="rmi"/>
+         <parameter key="urlPath" value="/jmxrmi"/>
+         <parameter key="rrd-base-name" value="cassandra21x"/>
+         <parameter key="ds-name" value="cassandra21x"/>
+         <parameter key="friendly-name" value="cassandra21x"/>
+         <parameter key="collection" value="cassandra21x"/>
+         <parameter key="thresholding-enabled" value="true"/>
+         <parameter key="factory" value="PASSWORD-CLEAR"/>
+         <parameter key="username" value="cassandra-username"/>
+         <parameter key="password" value="cassandra-password"/>
+      </service>
+   </package>
+   <package name="cassandra21x-newts" remote="false">
+      <filter>(IPADDR != '0.0.0.0') &amp; (catincCassandra21x&amp; catincNewts)</filter>
+      <service name="JMX-Cassandra-Newts" interval="300000" user-defined="false" status="on">
+         <parameter key="port" value="7199"/>
+         <parameter key="retry" value="2"/>
+         <parameter key="timeout" value="3000"/>
+         <parameter key="protocol" value="rmi"/>
+         <parameter key="urlPath" value="/jmxrmi"/>
+         <parameter key="rrd-base-name" value="cassandra21x-newts"/>
+         <parameter key="ds-name" value="cassandra21x-newts"/>
+         <parameter key="friendly-name" value="cassandra21x-newts"/>
+         <parameter key="collection" value="cassandra21x-newts"/>
+         <parameter key="thresholding-enabled" value="true"/>
+         <parameter key="factory" value="PASSWORD-CLEAR"/>
+         <parameter key="username" value="cassandra-username"/>
+         <parameter key="password" value="cassandra-password"/>
+      </service>
+   </package>
+   <package name="vmware3" remote="false">
+      <filter>(IPADDR != '0.0.0.0') &amp; (categoryName == 'VMware3')</filter>
+      <service name="VMware-VirtualMachine" interval="300000" user-defined="false" status="on">
+         <parameter key="collection" value="default-VirtualMachine3"/>
+         <parameter key="thresholding-enabled" value="true"/>
+      </service>
+      <service name="VMware-HostSystem" interval="300000" user-defined="false" status="on">
+         <parameter key="collection" value="default-HostSystem3"/>
+         <parameter key="thresholding-enabled" value="true"/>
+      </service>
+      <service name="VMwareCim-HostSystem" interval="300000" user-defined="false" status="on">
+         <parameter key="collection" value="default-ESX-HostSystem"/>
+         <parameter key="thresholding-enabled" value="true"/>
+      </service>
+   </package>
+   <package name="vmware4" remote="false">
+      <filter>(IPADDR != '0.0.0.0') &amp; (categoryName == 'VMware4')</filter>
+      <service name="VMware-VirtualMachine" interval="300000" user-defined="false" status="on">
+         <parameter key="collection" value="default-VirtualMachine4"/>
+         <parameter key="thresholding-enabled" value="true"/>
+      </service>
+      <service name="VMware-HostSystem" interval="300000" user-defined="false" status="on">
+         <parameter key="collection" value="default-HostSystem4"/>
+         <parameter key="thresholding-enabled" value="true"/>
+      </service>
+      <service name="VMwareCim-HostSystem" interval="300000" user-defined="false" status="on">
+         <parameter key="collection" value="default-ESX-HostSystem"/>
+         <parameter key="thresholding-enabled" value="true"/>
+      </service>
+   </package>
+   <package name="vmware5" remote="false">
+      <filter>(IPADDR != '0.0.0.0') &amp; (categoryName == 'VMware5')</filter>
+      <service name="VMware-VirtualMachine" interval="300000" user-defined="false" status="on">
+         <parameter key="collection" value="default-VirtualMachine5"/>
+         <parameter key="thresholding-enabled" value="true"/>
+      </service>
+      <service name="VMware-HostSystem" interval="300000" user-defined="false" status="on">
+         <parameter key="collection" value="default-HostSystem5"/>
+         <parameter key="thresholding-enabled" value="true"/>
+      </service>
+      <service name="VMwareCim-HostSystem" interval="300000" user-defined="false" status="on">
+         <parameter key="collection" value="default-ESX-HostSystem"/>
+         <parameter key="thresholding-enabled" value="true"/>
+      </service>
+   </package>
+   <package name="example1" remote="false">
+      <filter>IPADDR != '0.0.0.0'</filter>
+      <include-range begin="1.1.1.1" end="254.254.254.254"/>
+      <include-range begin="::1" end="ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"/>
+      <service name="SNMP" interval="300000" user-defined="false" status="on">
+         <parameter key="collection" value="default"/>
+         <parameter key="thresholding-enabled" value="true"/>
+      </service>
+      <service name="WMI" interval="300000" user-defined="false" status="off">
+         <parameter key="collection" value="default"/>
+         <parameter key="thresholding-enabled" value="true"/>
+      </service>
+      <service name="WS-Man" interval="300000" user-defined="false" status="on">
+         <parameter key="collection" value="default"/>
+         <parameter key="thresholding-enabled" value="true"/>
+      </service>
+      <service name="OpenNMS-JVM" interval="300000" user-defined="false" status="on">
+         <parameter key="port" value="18980"/>
+         <parameter key="retry" value="2"/>
+         <parameter key="timeout" value="3000"/>
+         <parameter key="rrd-base-name" value="java"/>
+         <parameter key="collection" value="jsr160"/>
+         <parameter key="thresholding-enabled" value="true"/>
+         <parameter key="ds-name" value="opennms-jvm"/>
+         <parameter key="friendly-name" value="opennms-jvm"/>
+      </service>
+      <service name="PostgreSQL" interval="300000" user-defined="false" status="on">
+         <parameter key="collection" value="PostgreSQL"/>
+         <parameter key="thresholding-enabled" value="true"/>
+         <parameter key="driver" value="org.postgresql.Driver"/>
+         <parameter key="user" value="postgres"/>
+         <parameter key="password" value="postgres"/>
+         <parameter key="url" value="jdbc:postgresql://OPENNMS_JDBC_HOSTNAME:5432/opennms"/>
+      </service>
+   </package>
+   <collector service="JMX-Cassandra" class-name="org.opennms.netmgt.collectd.Jsr160Collector"/>
+   <collector service="JMX-Cassandra-Newts" class-name="org.opennms.netmgt.collectd.Jsr160Collector"/>
+   <collector service="SNMP" class-name="org.opennms.netmgt.collectd.SnmpCollector"/>
+   <collector service="WMI" class-name="org.opennms.netmgt.collectd.WmiCollector"/>
+   <collector service="WS-Man" class-name="org.opennms.netmgt.collectd.WsManCollector"/>
+   <collector service="OpenNMS-JVM" class-name="org.opennms.netmgt.collectd.Jsr160Collector"/>
+   <collector service="VMware-VirtualMachine" class-name="org.opennms.netmgt.collectd.VmwareCollector"/>
+   <collector service="VMware-HostSystem" class-name="org.opennms.netmgt.collectd.VmwareCollector"/>
+   <collector service="VMwareCim-HostSystem" class-name="org.opennms.netmgt.collectd.VmwareCimCollector"/>
+   <collector service="PostgreSQL" class-name="org.opennms.netmgt.collectd.JdbcCollector"/>
 </collectd-configuration>
-

--- a/opennms-base-assembly/src/main/filtered/etc/datacollection-config.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/datacollection-config.xml
@@ -1,103 +1,95 @@
-<?xml version="1.0"?>
-<datacollection-config rrdRepository="${install.share.dir}/rrd/snmp/">
-    <snmp-collection name="default" snmpStorageFlag="select">
-        <rrd step="300">
-            <rra>RRA:AVERAGE:0.5:1:2016</rra>
-            <rra>RRA:AVERAGE:0.5:12:1488</rra>
-            <rra>RRA:AVERAGE:0.5:288:366</rra>
-            <rra>RRA:MAX:0.5:288:366</rra>
-            <rra>RRA:MIN:0.5:288:366</rra>
-        </rrd>
-
-        <include-collection dataCollectionGroup="MIB2"/>
-        <include-collection dataCollectionGroup="3Com"/>
-        <include-collection dataCollectionGroup="Acme Packet"/>
-        <include-collection dataCollectionGroup="AKCP sensorProbe"/>
-        <include-collection dataCollectionGroup="Alvarion"/>
-        <include-collection dataCollectionGroup="APC"/>
-        <include-collection dataCollectionGroup="Ascend"/>
-        <include-collection dataCollectionGroup="Asterisk"/>
-        <include-collection dataCollectionGroup="Bluecat"/>
-        <include-collection dataCollectionGroup="Bluecoat"/>
-        <include-collection dataCollectionGroup="Bridgewave"/>
-        <include-collection dataCollectionGroup="Brocade"/>
-        <include-collection dataCollectionGroup="Checkpoint"/>
-        <include-collection dataCollectionGroup="Ceragon"/>
-        <include-collection dataCollectionGroup="Cisco"/>
-        <include-collection dataCollectionGroup="Cisco Nexus"/>
-        <include-collection dataCollectionGroup="CLAVISTER"/>
-        <include-collection dataCollectionGroup="Colubris"/>
-        <include-collection dataCollectionGroup="Concord"/>
-        <include-collection dataCollectionGroup="Cyclades"/>
-        <include-collection dataCollectionGroup="Dell"/>
-        <include-collection dataCollectionGroup="Ericsson"/>
-        <include-collection dataCollectionGroup="Equallogic"/>
-        <include-collection dataCollectionGroup="Extreme Networks"/>
-        <include-collection dataCollectionGroup="F5"/>
-        <include-collection dataCollectionGroup="Fortinet-Fortigate-Application-v5.2"/>
-        <include-collection dataCollectionGroup="Fortinet-Fortigate-ExplicitProxy-v5.2"/>
-        <include-collection dataCollectionGroup="Fortinet-Fortigate-HA-v5.2"/>
-        <include-collection dataCollectionGroup="Fortinet-Fortigate-System-v5.2"/>
-        <include-collection dataCollectionGroup="Fortinet-Fortigate-Security-v5.2"/>
-        <include-collection dataCollectionGroup="Force10"/>
-        <include-collection dataCollectionGroup="Foundry Networks"/>
-        <include-collection dataCollectionGroup="HP"/>
-        <include-collection dataCollectionGroup="HWg"/>
-        <include-collection dataCollectionGroup="IBM"/>
-        <include-collection dataCollectionGroup="IP Unity"/>
-        <include-collection dataCollectionGroup="Juniper"/>
-        <include-collection dataCollectionGroup="Konica"/>
-        <include-collection dataCollectionGroup="Kyocera"/>
-        <include-collection dataCollectionGroup="Lexmark"/>
-        <include-collection dataCollectionGroup="Liebert"/>
-        <include-collection dataCollectionGroup="Makelsan"/>
-        <include-collection dataCollectionGroup="MGE"/>
-        <include-collection dataCollectionGroup="Microsoft"/>
-        <include-collection dataCollectionGroup="Mikrotik"/>
-        <include-collection dataCollectionGroup="Network Appliance"/>
-        <include-collection dataCollectionGroup="Netbotz"/>
-        <include-collection dataCollectionGroup="NetEnforcer"/>
-        <include-collection dataCollectionGroup="Netscaler"/>
-        <include-collection dataCollectionGroup="Net-SNMP"/>
-        <include-collection dataCollectionGroup="Nortel"/>
-        <include-collection dataCollectionGroup="Novell"/>
-        <include-collection dataCollectionGroup="PaloAlto"/>
-        <include-collection dataCollectionGroup="pfSense"/>
-        <include-collection dataCollectionGroup="Powerware"/>
-        <include-collection dataCollectionGroup="PostgreSQL-JDBC"/>
-        <include-collection dataCollectionGroup="Printers"/>
-        <include-collection dataCollectionGroup="Riverbed"/>
-        <include-collection dataCollectionGroup="Routers"/>
-        <include-collection dataCollectionGroup="Savin or Ricoh Printers"/>
-        <include-collection dataCollectionGroup="ServerTech"/>
-        <include-collection dataCollectionGroup="SNMP-Informant"/>
-        <include-collection dataCollectionGroup="SofaWare"/>
-        <include-collection dataCollectionGroup="Sonicwall"/>
-        <include-collection dataCollectionGroup="SUN Microsystems"/>
-        <include-collection dataCollectionGroup="Trango"/>
-        <include-collection dataCollectionGroup="WMI"/>
-        <include-collection dataCollectionGroup="XMP"/>
-        <include-collection dataCollectionGroup="Zertico"/>
-        <include-collection dataCollectionGroup="Zeus"/>
-        <include-collection dataCollectionGroup="VMware3"/>
-        <include-collection dataCollectionGroup="VMware4"/>
-        <include-collection dataCollectionGroup="VMware5"/>
-        <include-collection dataCollectionGroup="VMware-Cim"/>
-    </snmp-collection>
-
-    <!-- We need a dedicated collection with a different RRD setup for EJN equipment because
-  the data in the EJN SNMP MIB is only updated once every 15 min by default or alternatively
-  once every 3 min with the hidden "set services epg pgw snmp update-every-three-minutes"
-  config option -->
-    <snmp-collection name="ejn" snmpStorageFlag="select">
-        <rrd step="180">
-            <rra>RRA:AVERAGE:0.5:1:3360</rra>
-            <rra>RRA:AVERAGE:0.5:20:1488</rra>
-            <rra>RRA:AVERAGE:0.5:480:366</rra>
-            <rra>RRA:MAX:0.5:480:366</rra>
-            <rra>RRA:MIN:0.5:480:366</rra>
-        </rrd>
-
-        <include-collection dataCollectionGroup="ejn"/>
-    </snmp-collection>
+<datacollection-config xmlns="http://xmlns.opennms.org/xsd/config/datacollection" rrdRepository="/opt/opennms/share/rrd/snmp/">
+   <snmp-collection name="default" snmpStorageFlag="select">
+      <rrd step="300">
+         <rra>RRA:AVERAGE:0.5:1:2016</rra>
+         <rra>RRA:AVERAGE:0.5:12:1488</rra>
+         <rra>RRA:AVERAGE:0.5:288:366</rra>
+         <rra>RRA:MAX:0.5:288:366</rra>
+         <rra>RRA:MIN:0.5:288:366</rra>
+      </rrd>
+      <include-collection dataCollectionGroup="MIB2"/>
+      <include-collection dataCollectionGroup="3Com"/>
+      <include-collection dataCollectionGroup="Acme Packet"/>
+      <include-collection dataCollectionGroup="AKCP sensorProbe"/>
+      <include-collection dataCollectionGroup="Alvarion"/>
+      <include-collection dataCollectionGroup="APC"/>
+      <include-collection dataCollectionGroup="Ascend"/>
+      <include-collection dataCollectionGroup="Asterisk"/>
+      <include-collection dataCollectionGroup="Bluecat"/>
+      <include-collection dataCollectionGroup="Bluecoat"/>
+      <include-collection dataCollectionGroup="Bridgewave"/>
+      <include-collection dataCollectionGroup="Brocade"/>
+      <include-collection dataCollectionGroup="Checkpoint"/>
+      <include-collection dataCollectionGroup="Ceragon"/>
+      <include-collection dataCollectionGroup="Cisco"/>
+      <include-collection dataCollectionGroup="Cisco Nexus"/>
+      <include-collection dataCollectionGroup="CLAVISTER"/>
+      <include-collection dataCollectionGroup="Colubris"/>
+      <include-collection dataCollectionGroup="Concord"/>
+      <include-collection dataCollectionGroup="Cyclades"/>
+      <include-collection dataCollectionGroup="Dell"/>
+      <include-collection dataCollectionGroup="Ericsson"/>
+      <include-collection dataCollectionGroup="Equallogic"/>
+      <include-collection dataCollectionGroup="Extreme Networks"/>
+      <include-collection dataCollectionGroup="F5"/>
+      <include-collection dataCollectionGroup="Fortinet-Fortigate-Application-v5.2"/>
+      <include-collection dataCollectionGroup="Fortinet-Fortigate-ExplicitProxy-v5.2"/>
+      <include-collection dataCollectionGroup="Fortinet-Fortigate-HA-v5.2"/>
+      <include-collection dataCollectionGroup="Fortinet-Fortigate-System-v5.2"/>
+      <include-collection dataCollectionGroup="Fortinet-Fortigate-Security-v5.2"/>
+      <include-collection dataCollectionGroup="Force10"/>
+      <include-collection dataCollectionGroup="Foundry Networks"/>
+      <include-collection dataCollectionGroup="HP"/>
+      <include-collection dataCollectionGroup="HWg"/>
+      <include-collection dataCollectionGroup="IBM"/>
+      <include-collection dataCollectionGroup="IP Unity"/>
+      <include-collection dataCollectionGroup="Juniper"/>
+      <include-collection dataCollectionGroup="Konica"/>
+      <include-collection dataCollectionGroup="Kyocera"/>
+      <include-collection dataCollectionGroup="Lexmark"/>
+      <include-collection dataCollectionGroup="Liebert"/>
+      <include-collection dataCollectionGroup="Makelsan"/>
+      <include-collection dataCollectionGroup="MGE"/>
+      <include-collection dataCollectionGroup="Microsoft"/>
+      <include-collection dataCollectionGroup="Mikrotik"/>
+      <include-collection dataCollectionGroup="Network Appliance"/>
+      <include-collection dataCollectionGroup="Netbotz"/>
+      <include-collection dataCollectionGroup="NetEnforcer"/>
+      <include-collection dataCollectionGroup="Netscaler"/>
+      <include-collection dataCollectionGroup="Net-SNMP"/>
+      <include-collection dataCollectionGroup="Nortel"/>
+      <include-collection dataCollectionGroup="Novell"/>
+      <include-collection dataCollectionGroup="PaloAlto"/>
+      <include-collection dataCollectionGroup="pfSense"/>
+      <include-collection dataCollectionGroup="Powerware"/>
+      <include-collection dataCollectionGroup="PostgreSQL-JDBC"/>
+      <include-collection dataCollectionGroup="Printers"/>
+      <include-collection dataCollectionGroup="Riverbed"/>
+      <include-collection dataCollectionGroup="Routers"/>
+      <include-collection dataCollectionGroup="Savin or Ricoh Printers"/>
+      <include-collection dataCollectionGroup="ServerTech"/>
+      <include-collection dataCollectionGroup="SNMP-Informant"/>
+      <include-collection dataCollectionGroup="SofaWare"/>
+      <include-collection dataCollectionGroup="Sonicwall"/>
+      <include-collection dataCollectionGroup="SUN Microsystems"/>
+      <include-collection dataCollectionGroup="Trango"/>
+      <include-collection dataCollectionGroup="WMI"/>
+      <include-collection dataCollectionGroup="XMP"/>
+      <include-collection dataCollectionGroup="Zertico"/>
+      <include-collection dataCollectionGroup="Zeus"/>
+      <include-collection dataCollectionGroup="VMware3"/>
+      <include-collection dataCollectionGroup="VMware4"/>
+      <include-collection dataCollectionGroup="VMware5"/>
+      <include-collection dataCollectionGroup="VMware-Cim"/>
+   </snmp-collection>
+   <snmp-collection name="ejn" snmpStorageFlag="select">
+      <rrd step="180">
+         <rra>RRA:AVERAGE:0.5:1:3360</rra>
+         <rra>RRA:AVERAGE:0.5:20:1488</rra>
+         <rra>RRA:AVERAGE:0.5:480:366</rra>
+         <rra>RRA:MAX:0.5:480:366</rra>
+         <rra>RRA:MIN:0.5:480:366</rra>
+      </rrd>
+      <include-collection dataCollectionGroup="ejn"/>
+   </snmp-collection>
 </datacollection-config>

--- a/opennms-base-assembly/src/main/filtered/etc/destinationPaths.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/destinationPaths.xml
@@ -1,14 +1,14 @@
-<?xml version="1.0"?>
-<destinationPaths>
+<?xml version="1.0" encoding="UTF-8"?>
+<destinationPaths xmlns="http://xmlns.opennms.org/xsd/destinationPaths">
     <header>
         <rev>1.2</rev>
-        <created>Wednesday, February 6, 2002 10:10:00 AM EST</created>
+        <created>Thursday, December 8, 2016 7:30:54 PM GMT</created>
         <mstation>localhost</mstation>
     </header>
-    <path name="Email-Admin">
-        <target>
-                <name>Admin</name>
-                <command>javaEmail</command>
+    <path name="Email-Admin" initial-delay="0s">
+        <target interval="0s">
+            <name>Admin</name>
+            <command>javaEmail</command>
         </target>
     </path>
 </destinationPaths>

--- a/opennms-base-assembly/src/main/filtered/etc/discovery-configuration.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/discovery-configuration.xml
@@ -1,6 +1,7 @@
-<discovery-configuration packets-per-second="1"
-	initial-sleep-time="30000" restart-sleep-time="86400000"
-	retries="1" timeout="2000">
+<?xml version="1.0" encoding="UTF-8"?>
+<discovery-configuration
+    xmlns="http://xmlns.opennms.org/xsd/config/discovery"
+    packets-per-second="1.0" initial-sleep-time="30000" restart-sleep-time="86400000">
 
     <!-- see examples/discovery-configuration.xml for options
     <include-range>

--- a/opennms-base-assembly/src/main/filtered/etc/groups.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/groups.xml
@@ -1,20 +1,20 @@
-<?xml version="1.0"?>
-<groupinfo  xmlns="http://xmlns.opennms.org/xsd/groups">
-	<header>
-		<rev>1.3</rev>
-		<created>Wednesday, February 6, 2002 10:10:00 AM EST</created>
-		<mstation>dhcp-219.internal.opennms.org</mstation>
-	</header>
-	<groups>
-		<group>
-			<name>Admin</name>
-			<comments>The administrators</comments>
-			<user>admin</user>
-		</group>
-		<group>
-			<name>Remoting Users</name>
-			<comments>Users with access for submitting remote poller management data.</comments>
-			<user>remoting</user>
-		</group>
-	</groups>
+<?xml version="1.0" encoding="UTF-8"?>
+<groupinfo xmlns="http://xmlns.opennms.org/xsd/groups">
+    <header>
+        <rev>1.3</rev>
+        <created>Thursday, December 8, 2016 6:52:49 PM GMT</created>
+        <mstation>dhcp-219.internal.opennms.org</mstation>
+    </header>
+    <groups>
+        <group>
+            <name>Admin</name>
+            <comments>The administrators</comments>
+            <user>admin</user>
+        </group>
+        <group>
+            <name>Remoting Users</name>
+            <comments>Users with access for submitting remote poller management data.</comments>
+            <user>remoting</user>
+        </group>
+    </groups>
 </groupinfo>

--- a/opennms-base-assembly/src/main/filtered/etc/notifd-configuration.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/notifd-configuration.xml
@@ -1,50 +1,46 @@
-<?xml version="1.0"?>
-<notifd-configuration 
-        status="off"
-	match-all="true">
-        
-	<auto-acknowledge resolution-prefix="RESOLVED: " 
-                          uei="uei.opennms.org/nodes/serviceResponsive" 
-                          acknowledge="uei.opennms.org/nodes/serviceUnresponsive">
-                          <match>nodeid</match>
-                          <match>interfaceid</match>
-                          <match>serviceid</match>
-        </auto-acknowledge>
-	
-        <auto-acknowledge resolution-prefix="RESOLVED: " 
-                          uei="uei.opennms.org/nodes/nodeRegainedService" 
-                          acknowledge="uei.opennms.org/nodes/nodeLostService">
-                          <match>nodeid</match>
-                          <match>interfaceid</match>
-                          <match>serviceid</match>
-        </auto-acknowledge>
-        
-        <auto-acknowledge resolution-prefix="RESOLVED: " 
-                          uei="uei.opennms.org/nodes/interfaceUp" 
-                          acknowledge="uei.opennms.org/nodes/interfaceDown">
-                          <match>nodeid</match>
-                          <match>interfaceid</match>
-        </auto-acknowledge>
-        
-        <auto-acknowledge resolution-prefix="RESOLVED: " 
-                          uei="uei.opennms.org/nodes/nodeUp" 
-                          acknowledge="uei.opennms.org/nodes/nodeDown">
-                          <match>nodeid</match>
-        </auto-acknowledge>
-        
-        <auto-acknowledge resolution-prefix="RESOLVED: "
-                          uei="uei.opennms.org/correlation/remote/wideSpreadOutageResolved"
-                          acknowledge="uei.opennms.org/correlation/remote/wideSpreadOutage">
-                          <match xmlns="">nodeid</match>
-                          <match xmlns="">interfaceid</match>
-                          <match xmlns="">serviceid</match>
-        </auto-acknowledge>
-        
-        <queue>
-                <queue-id>default</queue-id>
-                <interval>20s</interval>
-                <handler-class>
-                        <name>org.opennms.netmgt.notifd.DefaultQueueHandler</name>
-                </handler-class>
-        </queue>
+<?xml version="1.0" encoding="UTF-8"?>
+<notifd-configuration xmlns="http://xmlns.opennms.org/xsd/config/notifd"
+    status="off" pages-sent="SELECT * FROM notifications"
+    next-notif-id="SELECT nextval('notifynxtid')"
+    next-user-notif-id="SELECT nextval('userNotifNxtId')"
+    next-group-id="SELECT nextval('notifygrpid')"
+    service-id-sql="SELECT serviceID from service where serviceName = ?"
+    outstanding-notices-sql="SELECT notifyid FROM notifications where notifyId = ? AND respondTime is not null"
+    acknowledge-id-sql="SELECT notifyid FROM notifications WHERE eventuei=? AND nodeid=? AND interfaceid=? AND serviceid=?"
+    acknowledge-update-sql="UPDATE notifications SET answeredby=?, respondtime=? WHERE notifyId=?"
+    match-all="true" email-address-command="javaEmail">
+    <auto-acknowledge resolution-prefix="RESOLVED: "
+        uei="uei.opennms.org/nodes/serviceResponsive" acknowledge="uei.opennms.org/nodes/serviceUnresponsive">
+        <match>nodeid</match>
+        <match>interfaceid</match>
+        <match>serviceid</match>
+    </auto-acknowledge>
+    <auto-acknowledge resolution-prefix="RESOLVED: "
+        uei="uei.opennms.org/nodes/nodeRegainedService" acknowledge="uei.opennms.org/nodes/nodeLostService">
+        <match>nodeid</match>
+        <match>interfaceid</match>
+        <match>serviceid</match>
+    </auto-acknowledge>
+    <auto-acknowledge resolution-prefix="RESOLVED: "
+        uei="uei.opennms.org/nodes/interfaceUp" acknowledge="uei.opennms.org/nodes/interfaceDown">
+        <match>nodeid</match>
+        <match>interfaceid</match>
+    </auto-acknowledge>
+    <auto-acknowledge resolution-prefix="RESOLVED: "
+        uei="uei.opennms.org/nodes/nodeUp" acknowledge="uei.opennms.org/nodes/nodeDown">
+        <match>nodeid</match>
+    </auto-acknowledge>
+    <auto-acknowledge resolution-prefix="RESOLVED: "
+        uei="uei.opennms.org/correlation/remote/wideSpreadOutageResolved" acknowledge="uei.opennms.org/correlation/remote/wideSpreadOutage">
+        <match>nodeid</match>
+        <match>interfaceid</match>
+        <match>serviceid</match>
+    </auto-acknowledge>
+    <queue>
+        <queue-id>default</queue-id>
+        <interval>20s</interval>
+        <handler-class>
+            <name>org.opennms.netmgt.notifd.DefaultQueueHandler</name>
+        </handler-class>
+    </queue>
 </notifd-configuration>

--- a/opennms-base-assembly/src/main/filtered/etc/notifications.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/notifications.xml
@@ -1,11 +1,11 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <notifications xmlns="http://xmlns.opennms.org/xsd/notifications">
     <header>
         <rev>1.2</rev>
-        <created>Wednesday, February 6, 2002 10:10:00 AM EST</created>
+        <created>Thursday, December 8, 2016 7:24:50 PM GMT</created>
         <mstation>localhost</mstation>
     </header>
-    <notification name="interfaceDown" status="on">
+    <notification name="interfaceDown" status="on" writeable="yes">
         <uei>uei.opennms.org/nodes/interfaceDown</uei>
         <rule>IPADDR != '0.0.0.0'</rule>
         <destinationPath>Email-Admin</destinationPath>
@@ -17,7 +17,7 @@ until this outage is resolved.
         <subject>Notice #%noticeid%: %interfaceresolve% (%interface%) on node %nodelabel% down.</subject>
         <numeric-message>111-%noticeid%</numeric-message>
     </notification>
-    <notification name="nodeDown" status="on">
+    <notification name="nodeDown" status="on" writeable="yes">
         <uei>uei.opennms.org/nodes/nodeDown</uei>
         <rule>IPADDR != '0.0.0.0'</rule>
         <destinationPath>Email-Admin</destinationPath>
@@ -28,7 +28,7 @@ be impacted until this outage is resolved.
         <subject>Notice #%noticeid%: node %nodelabel% down.</subject>
         <numeric-message>111-%noticeid%</numeric-message>
     </notification>
-    <notification name="nodeLostService" status="on">
+    <notification name="nodeLostService" status="on" writeable="yes">
         <uei>uei.opennms.org/nodes/nodeLostService</uei>
         <rule>IPADDR != '0.0.0.0'</rule>
         <destinationPath>Email-Admin</destinationPath>
@@ -38,7 +38,7 @@ on node %nodelabel% failed at %time%.
         <subject>Notice #%noticeid%: %service% down on %interfaceresolve% (%interface%) on node %nodelabel%.</subject>
         <numeric-message>111-%noticeid%</numeric-message>
     </notification>
-    <notification name="nodeAdded" status="on">
+    <notification name="nodeAdded" status="on" writeable="yes">
         <uei>uei.opennms.org/nodes/nodeAdded</uei>
         <rule>IPADDR != '0.0.0.0'</rule>
         <destinationPath>Email-Admin</destinationPath>
@@ -47,16 +47,16 @@ on node %nodelabel% failed at %time%.
         <subject>Notice #%noticeid%: %parm[nodelabel]% discovered.</subject>
         <numeric-message>111-%noticeid%</numeric-message>
     </notification>
-    <notification name="interfaceDeleted" status="on">
+    <notification name="interfaceDeleted" status="on" writeable="yes">
         <uei>uei.opennms.org/nodes/interfaceDeleted</uei>
         <rule>IPADDR != '0.0.0.0'</rule>
         <destinationPath>Email-Admin</destinationPath>
         <text-message>Due to extended downtime or operator action, the interface %interfaceresolve% (%interface%) 
-on node %nodelabel% has been deleted from OpenNMS&apos;s polling database.</text-message>
+on node %nodelabel% has been deleted from OpenNMS's polling database.</text-message>
         <subject>Notice #%noticeid%: [OpenNMS] %interfaceresolve% (%interface%) on node %nodelabel% deleted.</subject>
         <numeric-message>111-%noticeid%</numeric-message>
     </notification>
-    <notification name="High Threshold" status="off">
+    <notification name="High Threshold" status="off" writeable="yes">
         <uei>uei.opennms.org/threshold/highThresholdExceeded</uei>
         <description>A monitored device has hit a high threshold</description>
         <rule>IPADDR != '0.0.0.0'</rule>
@@ -64,7 +64,7 @@ on node %nodelabel% has been deleted from OpenNMS&apos;s polling database.</text
         <text-message>A Threshold has been exceeded on node: %nodelabel%, interface:%interface%. The parameter %parm[ds]% reached a value of %parm[value]% while the threshold is %parm[threshold]%. This alert will be rearmed when %parm[ds]% reaches %parm[rearm]%.</text-message>
         <subject>Notice #%noticeid%: High Threshold for %parm[ds]% on node %nodelabel%.</subject>
     </notification>
-    <notification name="Low Threshold" status="off">
+    <notification name="Low Threshold" status="off" writeable="yes">
         <uei>uei.opennms.org/threshold/lowThresholdExceeded</uei>
         <description>A monitored device has hit a low threshold</description>
         <rule>IPADDR != '0.0.0.0'</rule>
@@ -72,7 +72,7 @@ on node %nodelabel% has been deleted from OpenNMS&apos;s polling database.</text
         <text-message>A Threshold has been exceeded on node: %nodelabel%, interface:%interface%. The parameter %parm[ds]% reached a value of %parm[value]% while the threshold is %parm[threshold]%. This alert will be rearmed when %parm[ds]% reaches %parm[rearm]%.</text-message>
         <subject>Notice #%noticeid%: Low Threshold for %parm[ds]% on node %nodelabel%.</subject>
     </notification>
-    <notification name="Low Threshold Rearmed" status="off">
+    <notification name="Low Threshold Rearmed" status="off" writeable="yes">
         <uei>uei.opennms.org/threshold/lowThresholdRearmed</uei>
         <description>A monitored device has recovered from a low threshold</description>
         <rule>IPADDR != '0.0.0.0'</rule>
@@ -80,7 +80,7 @@ on node %nodelabel% has been deleted from OpenNMS&apos;s polling database.</text
         <text-message>A Threshold has returned to normal on node: %nodelabel%, interface:%interface%. The parameter %parm[ds]% reached a value of %parm[value]% with a rearm threshold of %parm[rearm]%. This threshold for this alert was %parm[threshold]%.</text-message>
         <subject>Notice #%noticeid%: Low Threshold Rearmed for %parm[ds]% on node %nodelabel%.</subject>
     </notification>
-    <notification name="High Threshold Rearmed" status="off">
+    <notification name="High Threshold Rearmed" status="off" writeable="yes">
         <uei>uei.opennms.org/threshold/highThresholdRearmed</uei>
         <description>A monitored device has recovered from a high threshold</description>
         <rule>IPADDR != '0.0.0.0'</rule>
@@ -88,5 +88,4 @@ on node %nodelabel% has been deleted from OpenNMS&apos;s polling database.</text
         <text-message>A Threshold has returned to normal on node: %nodelabel%, interface:%interface%. The parameter %parm[ds]% reached a value of %parm[value]% with a rearm threshold of %parm[rearm]%. This threshold for this alert was %parm[threshold]%.</text-message>
         <subject>Notice #%noticeid%: High Threshold Rearmed for %parm[ds]% on node %nodelabel%.</subject>
     </notification>
-
 </notifications>

--- a/opennms-base-assembly/src/main/filtered/etc/poll-outages.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/poll-outages.xml
@@ -1,4 +1,1 @@
-<?xml version="1.0"?>
-<outages>
-</outages>
-
+<outages xmlns="http://xmlns.opennms.org/xsd/config/poller/outages"/>

--- a/opennms-base-assembly/src/main/filtered/etc/poller-configuration.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/poller-configuration.xml
@@ -1,343 +1,322 @@
-<?xml version="1.0"?>
-<?castor class-name="org.opennms.netmgt.poller.PollerConfiguration"?>
-<poller-configuration threads="30" 
-                      pathOutageEnabled="false"
-                      serviceUnresponsiveEnabled="false"> 
-
-  <node-outage status="on">
-    <critical-service name="ICMP" />
-  </node-outage>
-
-  <package name="cassandra21x">
-    <filter><![CDATA[(IPADDR != '0.0.0.0') & (categoryName == 'Cassandra21x')]]></filter>
-    <rrd step="300">
-      <rra>RRA:AVERAGE:0.5:1:2016</rra>
-      <rra>RRA:AVERAGE:0.5:12:1488</rra>
-      <rra>RRA:AVERAGE:0.5:288:366</rra>
-      <rra>RRA:MAX:0.5:288:366</rra>
-      <rra>RRA:MIN:0.5:288:366</rra>
-    </rrd>
-    <service name="JMX-Cassandra" interval="300000" user-defined="false" status="on">
-      <parameter key="port" value="7199"/>
-      <parameter key="retry" value="2"/>
-      <parameter key="timeout" value="3000"/>
-      <parameter key="protocol" value="rmi"/>
-      <parameter key="urlPath" value="/jmxrmi"/>
-      <parameter key="ds-name" value="cassandra21x"/>
-      <parameter key="friendly-name" value="cassandra21x"/>
-      <parameter key="collection" value="cassandra21x"/>
-      <parameter key="thresholding-enabled" value="true"/>
-      <parameter key="factory" value="PASSWORD-CLEAR"/>
-      <parameter key="username" value="cassandra-username"/>
-      <parameter key="password" value="cassandra-password"/>
-      <parameter key="rrd-repository" value="${install.share.dir}/rrd/response" />
-      <parameter key="beans.storage" value="org.apache.cassandra.db:type=StorageService"/>
-      <parameter key="tests.operational" value="storage.OperationMode == 'NORMAL'"/>
-      <parameter key="tests.joined" value="storage.Joined"/>
-      <parameter key="tests.unreachables" value="empty(storage.UnreachableNodes)"/>
-    </service>
-    <downtime interval="30000" begin="0" end="300000" /><!-- 30s, 0, 5m -->
-    <downtime interval="300000" begin="300000" end="43200000" /><!-- 5m, 5m, 12h -->
-    <downtime interval="600000" begin="43200000" end="432000000" /><!-- 10m, 12h, 5d -->
-    <downtime begin="432000000" delete="true" /><!-- anything after 5 days delete -->
-  </package>
-
-  <package name="cassandra21x-newts">
-    <filter><![CDATA[(IPADDR != '0.0.0.0') & (catincCassandra21x & catincNewts)]]></filter>
-    <rrd step="300">
-      <rra>RRA:AVERAGE:0.5:1:2016</rra>
-      <rra>RRA:AVERAGE:0.5:12:1488</rra>
-      <rra>RRA:AVERAGE:0.5:288:366</rra>
-      <rra>RRA:MAX:0.5:288:366</rra>
-      <rra>RRA:MIN:0.5:288:366</rra>
-    </rrd>
-    <service name="JMX-Cassandra-Newts" interval="300000" user-defined="false" status="on">
-      <parameter key="port" value="7199"/>
-      <parameter key="retry" value="2"/>
-      <parameter key="timeout" value="3000"/>
-      <parameter key="protocol" value="rmi"/>
-      <parameter key="urlPath" value="/jmxrmi"/>
-      <parameter key="rrd-base-name" value="cassandra21x-newts"/>
-      <parameter key="ds-name" value="cassandra21x-newts"/>
-      <parameter key="friendly-name" value="cassandra21x-newts"/>
-      <parameter key="collection" value="cassandra21x-newts"/>
-      <parameter key="thresholding-enabled" value="true"/>
-      <parameter key="factory" value="PASSWORD-CLEAR"/>
-      <parameter key="username" value="cassandra-username"/>
-      <parameter key="password" value="cassandra-password"/>
-      <parameter key="rrd-repository" value="${install.share.dir}/rrd/response" />
-      <parameter key="beans.samples" value="org.apache.cassandra.db:type=ColumnFamilies,keyspace=newts,columnfamily=samples"/>
-      <parameter key="tests.samples" value="samples.ColumnFamilyName == 'samples'"/>
-      <parameter key="beans.terms" value="org.apache.cassandra.db:type=ColumnFamilies,keyspace=newts,columnfamily=terms"/>
-      <parameter key="tests.terms" value="terms.ColumnFamilyName == 'terms'"/>
-      <parameter key="beans.resource_attributes" value="org.apache.cassandra.db:type=ColumnFamilies,keyspace=newts,columnfamily=resource_attributes"/>
-      <parameter key="tests.resource_attributes" value="resource_attributes.ColumnFamilyName == 'resource_attributes'"/>
-      <parameter key="beans.resource_metrics" value="org.apache.cassandra.db:type=ColumnFamilies,keyspace=newts,columnfamily=resource_metrics"/>
-      <parameter key="tests.resource_metrics" value="resource_metrics.ColumnFamilyName == 'resource_metrics'"/>
-    </service>
-    <downtime interval="30000" begin="0" end="300000" /><!-- 30s, 0, 5m -->
-    <downtime interval="300000" begin="300000" end="43200000" /><!-- 5m, 5m, 12h -->
-    <downtime interval="600000" begin="43200000" end="432000000" /><!-- 10m, 12h, 5d -->
-    <downtime begin="432000000" delete="true" /><!-- anything after 5 days delete -->
-  </package>
-
-  <package name="example1">
-    <filter>IPADDR != '0.0.0.0'</filter>
-    <include-range begin="1.1.1.1" end="254.254.254.254" />
-    <include-range begin="::1" end="ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff" />
-    <rrd step="300">
-      <rra>RRA:AVERAGE:0.5:1:2016</rra>
-      <rra>RRA:AVERAGE:0.5:12:1488</rra>
-      <rra>RRA:AVERAGE:0.5:288:366</rra>
-      <rra>RRA:MAX:0.5:288:366</rra>
-      <rra>RRA:MIN:0.5:288:366</rra>
-    </rrd>
-    <service name="ICMP" interval="300000" user-defined="false" status="on">
-      <parameter key="retry" value="2" />
-      <parameter key="timeout" value="3000" />
-      <parameter key="rrd-repository" value="${install.share.dir}/rrd/response" />
-      <parameter key="rrd-base-name" value="icmp" />
-      <parameter key="ds-name" value="icmp" />
-    </service>
-    <service name="DNS" interval="300000" user-defined="false" status="on">
-      <parameter key="retry" value="2" />
-      <parameter key="timeout" value="5000" />
-      <parameter key="port" value="53" />
-      <parameter key="lookup" value="localhost" />
-      <parameter key="fatal-response-codes" value="2,3,5" /><!-- ServFail, NXDomain, Refused -->
-      <parameter key="rrd-repository" value="${install.share.dir}/rrd/response" />
-      <parameter key="rrd-base-name" value="dns" />
-      <parameter key="ds-name" value="dns" />
-    </service>
-    <service name="SMTP" interval="300000" user-defined="false" status="on">
-      <parameter key="retry" value="1" />
-      <parameter key="timeout" value="3000" />
-      <parameter key="port" value="25" />
-      <parameter key="rrd-repository" value="${install.share.dir}/rrd/response" />
-      <parameter key="rrd-base-name" value="smtp" />
-      <parameter key="ds-name" value="smtp" />
-    </service>
-    <service name="FTP" interval="300000" user-defined="false" status="on">
-      <parameter key="retry" value="1" />
-      <parameter key="timeout" value="3000" />
-      <parameter key="port" value="21" />
-      <parameter key="userid" value="" />
-      <parameter key="password" value="" />
-    </service>
-    <service name="SNMP" interval="300000" user-defined="false" status="on">
-      <parameter key="oid" value=".1.3.6.1.2.1.1.2.0" />
-    </service>
-    <service name="HTTP" interval="300000" user-defined="false" status="on">
-      <parameter key="retry" value="1" />
-      <parameter key="timeout" value="3000" />
-      <parameter key="port" value="80" />
-      <parameter key="url" value="/" />
-      <parameter key="rrd-repository" value="${install.share.dir}/rrd/response" />
-      <parameter key="rrd-base-name" value="http" />
-      <parameter key="ds-name" value="http" />
-    </service>
-    <service name="HTTP-8080" interval="300000" user-defined="false" status="on">
-      <parameter key="retry" value="1" />
-      <parameter key="timeout" value="3000" />
-      <parameter key="port" value="8080" />
-      <parameter key="url" value="/" />
-      <parameter key="rrd-repository" value="${install.share.dir}/rrd/response" />
-      <parameter key="rrd-base-name" value="http-8080" />
-      <parameter key="ds-name" value="http-8080" />
-    </service>
-    <service name="HTTP-8000" interval="300000" user-defined="false" status="on">
-      <parameter key="retry" value="1" />
-      <parameter key="timeout" value="3000" />
-      <parameter key="port" value="8000" />
-      <parameter key="url" value="/" />
-      <parameter key="rrd-repository" value="${install.share.dir}/rrd/response" />
-      <parameter key="rrd-base-name" value="http-8000" />
-      <parameter key="ds-name" value="http-8000" />
-    </service>
-    <service name="HTTPS" interval="300000" user-defined="false" status="on">
-      <parameter key="retry" value="1" />
-      <parameter key="timeout" value="5000" />
-      <parameter key="port" value="443" />
-      <parameter key="url" value="/" />
-    </service>
-    <service name="HypericAgent" interval="300000" user-defined="false" status="on">
-      <parameter key="retry" value="1" />
-      <parameter key="timeout" value="2200" />
-      <parameter key="port" value="2144" />
-    </service>
-    <service name="HypericHQ" interval="300000" user-defined="false" status="on">
-      <parameter key="retry" value="1" />
-      <parameter key="timeout" value="3000" />
-      <parameter key="rrd-repository" value="${install.share.dir}/rrd/response" />
-      <parameter key="rrd-base-name" value="hyperic-hq" />
-      <parameter key="ds-name" value="hyperic-hq" />
-      <parameter key="page-sequence">
-        <page-sequence>
-          <page path="/Login.do" port="7080" successMatch="(HQ Login)|(Sign in to Hyperic HQ)" />
-          <page path="/j_security_check.do" port="7080" method="POST"
-            failureMatch="(?s)(The username or password provided does not match our records)|(You are not signed in)" failureMessage="HQ Login in Failed"
-            successMatch="HQ Dashboard">
-            <parameter key="j_username" value="hqadmin" />
-            <parameter key="j_password" value="hqadmin" />
-          </page>
-          <page path="/Logout.do" port="7080" successMatch="HQ Login" />
-        </page-sequence>
-      </parameter>
-    </service>
-    <service name="MySQL" interval="300000" user-defined="false" status="on">
-      <parameter key="retry" value="1" />
-      <parameter key="timeout" value="3000" />
-      <parameter key="port" value="3306" />
-      <parameter key="banner" value="*" />
-    </service>
-    <service name="SQLServer" interval="300000" user-defined="false" status="on">
-      <parameter key="retry" value="1" />
-      <parameter key="timeout" value="3000" />
-      <parameter key="port" value="1433" />
-      <parameter key="banner" value="*" />
-    </service>
-    <service name="Oracle" interval="300000" user-defined="false" status="on">
-      <parameter key="retry" value="1" />
-      <parameter key="timeout" value="3000" />
-      <parameter key="port" value="1521" />
-      <parameter key="banner" value="*" />
-    </service>
-    <service name="Postgres" interval="300000" user-defined="false" status="on">
-      <parameter key="retry" value="1" />
-      <parameter key="banner" value="*" />
-      <parameter key="port" value="5432" />
-      <parameter key="timeout" value="3000" />
-    </service>
-    <service name="SSH" interval="300000" user-defined="false" status="on">
-      <parameter key="retry" value="1" />
-      <parameter key="banner" value="SSH" />
-      <parameter key="port" value="22" />
-      <parameter key="timeout" value="3000" />
-      <parameter key="rrd-repository" value="${install.share.dir}/rrd/response" />
-      <parameter key="rrd-base-name" value="ssh" />
-      <parameter key="ds-name" value="ssh" />
-    </service>
-    <service name="IMAP" interval="300000" user-defined="false" status="on">
-      <parameter key="retry" value="1" />
-      <parameter key="port" value="143" />
-      <parameter key="timeout" value="3000" />
-    </service>
-    <service name="POP3" interval="300000" user-defined="false" status="on">
-      <parameter key="retry" value="1" />
-      <parameter key="port" value="110" />
-      <parameter key="timeout" value="3000" />
-      <parameter key="rrd-repository" value="${install.share.dir}/rrd/response" />
-      <parameter key="rrd-base-name" value="pop3" />
-      <parameter key="ds-name" value="pop3" />
-    </service>
-    <service name="NRPE" interval="300000" user-defined="false" status="on">
-      <parameter key="retry" value="3" />
-      <parameter key="timeout" value="3000" />
-      <parameter key="port" value="5666" />
-      <parameter key="command" value="_NRPE_CHECK" />
-      <parameter key="padding" value="2" />
-      <parameter key="rrd-repository" value="${install.share.dir}/rrd/response" />
-      <parameter key="ds-name" value="nrpe" />
-    </service>
-    <service name="NRPE-NoSSL" interval="300000" user-defined="false" status="on">
-      <parameter key="retry" value="3" />
-      <parameter key="timeout" value="3000" />
-      <parameter key="port" value="5666" />
-      <parameter key="command" value="_NRPE_CHECK" />
-      <parameter key="usessl" value="false" />
-      <parameter key="padding" value="2" />
-      <parameter key="rrd-repository" value="${install.share.dir}/rrd/response" />
-      <parameter key="ds-name" value="nrpe" />
-    </service>
-    <service name="Windows-Task-Scheduler" interval="300000" user-defined="false" status="on">
-      <parameter key="service-name" value="Task Scheduler" />
-    </service>
-    <service name="OpenNMS-JVM" interval="300000" user-defined="false" status="on">
-      <parameter key="port" value="18980"/>
-      <parameter key="retry" value="2"/>
-      <parameter key="timeout" value="3000"/>
-      <parameter key="rrd-repository" value="${install.share.dir}/rrd/response" />
-    </service>
-    <service name="VMwareCim-HostSystem" interval="300000" user-defined="false" status="on">
-      <parameter key="retry" value="2"/>
-      <parameter key="timeout" value="3000"/>
-      <parameter key="ignoreStandBy" value="false"/>
-    </service>
-    <service name="VMware-ManagedEntity" interval="300000" user-defined="false" status="on">
-      <parameter key="retry" value="2"/>
-      <parameter key="timeout" value="3000"/>
-      <parameter key="ignoreStandBy" value="false"/>
-    </service>
-    <service name="MS-RDP" interval="300000" user-defined="false" status="on">
-      <parameter key="retry" value="1" />
-      <parameter key="banner" value="*" />
-      <parameter key="port" value="3389" />
-      <parameter key="timeout" value="3000" />
-    </service>
- 
-    <downtime interval="30000" begin="0" end="300000" /><!-- 30s, 0, 5m -->
-    <downtime interval="300000" begin="300000" end="43200000" /><!-- 5m, 5m, 12h -->
-    <downtime interval="600000" begin="43200000" end="432000000" /><!-- 10m, 12h, 5d -->
-    <downtime begin="432000000" delete="true" /><!-- anything after 5 days delete -->
-
-  </package>
-
-  <!-- Moved StrafePing to its own package.  This allows for more flexible configuration of which interfaces
-    will have StrafePing statistical analysis rather than being on for or off for all interfaces.  Change
-    this package's filter / ranges for directing the StrafePinger to choice interfaces.  Note: Strafing all
-    of your network interface may create high loads on the NMS file system.  -->
-
-  <package name="strafer">
-    <filter>IPADDR != '0.0.0.0'</filter>
-    <include-range begin="10.1.1.1" end="10.1.1.10" />
-    <!-- <include-range begin="::1" end="ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff" /> -->
-    <rrd step="300">
-      <rra>RRA:AVERAGE:0.5:1:2016</rra>
-      <rra>RRA:AVERAGE:0.5:12:1488</rra>
-      <rra>RRA:AVERAGE:0.5:288:366</rra>
-      <rra>RRA:MAX:0.5:288:366</rra>
-      <rra>RRA:MIN:0.5:288:366</rra>
-    </rrd>
-    <service name="StrafePing" interval="300000" user-defined="false" status="on">
-      <parameter key="retry" value="0" />
-      <parameter key="timeout" value="3000" />
-      <parameter key="ping-count" value="20" />
-      <parameter key="failure-ping-count" value="20" />
-      <parameter key="wait-interval" value="50" />
-      <parameter key="rrd-repository" value="${install.share.dir}/rrd/response" />
-      <parameter key="rrd-base-name" value="strafeping" />
-    </service>
-    <downtime interval="300000" begin="0" end="432000000"/><!-- 5m, 0, 5d -->
-    <downtime begin="432000000" delete="true" /><!-- anything after 5 days delete -->
-  </package>
-
-
-  <monitor service="JMX-Cassandra" class-name="org.opennms.netmgt.poller.monitors.Jsr160Monitor" />
-  <monitor service="JMX-Cassandra-Newts" class-name="org.opennms.netmgt.poller.monitors.Jsr160Monitor" />
-  <monitor service="ICMP" class-name="org.opennms.netmgt.poller.monitors.IcmpMonitor" />
-  <monitor service="StrafePing" class-name="org.opennms.netmgt.poller.monitors.StrafePingMonitor" />
-  <monitor service="HTTP" class-name="org.opennms.netmgt.poller.monitors.HttpMonitor" />
-  <monitor service="HTTP-8080" class-name="org.opennms.netmgt.poller.monitors.HttpMonitor" />
-  <monitor service="HTTP-8000" class-name="org.opennms.netmgt.poller.monitors.HttpMonitor" />
-  <monitor service="HTTPS" class-name="org.opennms.netmgt.poller.monitors.HttpsMonitor" />
-  <monitor service="HypericAgent" class-name="org.opennms.netmgt.poller.monitors.TcpMonitor" />
-  <monitor service="HypericHQ" class-name="org.opennms.netmgt.poller.monitors.PageSequenceMonitor" />
-  <monitor service="SMTP" class-name="org.opennms.netmgt.poller.monitors.SmtpMonitor" />
-  <monitor service="DNS" class-name="org.opennms.netmgt.poller.monitors.DnsMonitor" />
-  <monitor service="FTP" class-name="org.opennms.netmgt.poller.monitors.FtpMonitor" />
-  <monitor service="SNMP" class-name="org.opennms.netmgt.poller.monitors.SnmpMonitor" />
-  <monitor service="Oracle" class-name="org.opennms.netmgt.poller.monitors.TcpMonitor" />
-  <monitor service="Postgres" class-name="org.opennms.netmgt.poller.monitors.TcpMonitor" />
-  <monitor service="MySQL" class-name="org.opennms.netmgt.poller.monitors.TcpMonitor" />
-  <monitor service="SQLServer" class-name="org.opennms.netmgt.poller.monitors.TcpMonitor" />
-  <monitor service="SSH" class-name="org.opennms.netmgt.poller.monitors.SshMonitor" />
-  <monitor service="IMAP" class-name="org.opennms.netmgt.poller.monitors.ImapMonitor" />
-  <monitor service="POP3" class-name="org.opennms.netmgt.poller.monitors.Pop3Monitor" />
-  <monitor service="NRPE" class-name="org.opennms.netmgt.poller.monitors.NrpeMonitor" />
-  <monitor service="NRPE-NoSSL" class-name="org.opennms.netmgt.poller.monitors.NrpeMonitor" />
-  <monitor service="Windows-Task-Scheduler" class-name="org.opennms.netmgt.poller.monitors.Win32ServiceMonitor" />
-  <monitor service="OpenNMS-JVM" class-name="org.opennms.netmgt.poller.monitors.Jsr160Monitor" />
-  <monitor service="VMwareCim-HostSystem" class-name="org.opennms.netmgt.poller.monitors.VmwareCimMonitor"/>
-  <monitor service="VMware-ManagedEntity" class-name="org.opennms.netmgt.poller.monitors.VmwareMonitor"/>
-  <monitor service="MS-RDP" class-name="org.opennms.netmgt.poller.monitors.TcpMonitor" />
+<poller-configuration xmlns="http://xmlns.opennms.org/xsd/config/poller" threads="30" nextOutageId="SELECT nextval('outageNxtId')" serviceUnresponsiveEnabled="false" pathOutageEnabled="false">
+   <node-outage status="on" pollAllIfNoCriticalServiceDefined="true">
+      <critical-service name="ICMP"/>
+   </node-outage>
+   <package name="cassandra21x">
+      <filter>(IPADDR != '0.0.0.0') &amp; (categoryName == 'Cassandra21x')</filter>
+      <rrd step="300">
+         <rra>RRA:AVERAGE:0.5:1:2016</rra>
+         <rra>RRA:AVERAGE:0.5:12:1488</rra>
+         <rra>RRA:AVERAGE:0.5:288:366</rra>
+         <rra>RRA:MAX:0.5:288:366</rra>
+         <rra>RRA:MIN:0.5:288:366</rra>
+      </rrd>
+      <service name="JMX-Cassandra" interval="300000" user-defined="false" status="on">
+         <parameter key="port" value="7199"/>
+         <parameter key="retry" value="2"/>
+         <parameter key="timeout" value="3000"/>
+         <parameter key="protocol" value="rmi"/>
+         <parameter key="urlPath" value="/jmxrmi"/>
+         <parameter key="ds-name" value="cassandra21x"/>
+         <parameter key="friendly-name" value="cassandra21x"/>
+         <parameter key="collection" value="cassandra21x"/>
+         <parameter key="thresholding-enabled" value="true"/>
+         <parameter key="factory" value="PASSWORD-CLEAR"/>
+         <parameter key="username" value="cassandra-username"/>
+         <parameter key="password" value="cassandra-password"/>
+         <parameter key="rrd-repository" value="/opt/opennms/share/rrd/response"/>
+         <parameter key="beans.storage" value="org.apache.cassandra.db:type=StorageService"/>
+         <parameter key="tests.operational" value="storage.OperationMode == 'NORMAL'"/>
+         <parameter key="tests.joined" value="storage.Joined"/>
+         <parameter key="tests.unreachables" value="empty(storage.UnreachableNodes)"/>
+      </service>
+      <downtime begin="0" end="300000" interval="30000"/>
+      <downtime begin="300000" end="43200000" interval="300000"/>
+      <downtime begin="43200000" end="432000000" interval="600000"/>
+      <downtime begin="432000000" delete="true"/>
+   </package>
+   <package name="cassandra21x-newts">
+      <filter>(IPADDR != '0.0.0.0') &amp; (catincCassandra21x &amp; catincNewts)</filter>
+      <rrd step="300">
+         <rra>RRA:AVERAGE:0.5:1:2016</rra>
+         <rra>RRA:AVERAGE:0.5:12:1488</rra>
+         <rra>RRA:AVERAGE:0.5:288:366</rra>
+         <rra>RRA:MAX:0.5:288:366</rra>
+         <rra>RRA:MIN:0.5:288:366</rra>
+      </rrd>
+      <service name="JMX-Cassandra-Newts" interval="300000" user-defined="false" status="on">
+         <parameter key="port" value="7199"/>
+         <parameter key="retry" value="2"/>
+         <parameter key="timeout" value="3000"/>
+         <parameter key="protocol" value="rmi"/>
+         <parameter key="urlPath" value="/jmxrmi"/>
+         <parameter key="rrd-base-name" value="cassandra21x-newts"/>
+         <parameter key="ds-name" value="cassandra21x-newts"/>
+         <parameter key="friendly-name" value="cassandra21x-newts"/>
+         <parameter key="collection" value="cassandra21x-newts"/>
+         <parameter key="thresholding-enabled" value="true"/>
+         <parameter key="factory" value="PASSWORD-CLEAR"/>
+         <parameter key="username" value="cassandra-username"/>
+         <parameter key="password" value="cassandra-password"/>
+         <parameter key="rrd-repository" value="/opt/opennms/share/rrd/response"/>
+         <parameter key="beans.samples" value="org.apache.cassandra.db:type=ColumnFamilies,keyspace=newts,columnfamily=samples"/>
+         <parameter key="tests.samples" value="samples.ColumnFamilyName == 'samples'"/>
+         <parameter key="beans.terms" value="org.apache.cassandra.db:type=ColumnFamilies,keyspace=newts,columnfamily=terms"/>
+         <parameter key="tests.terms" value="terms.ColumnFamilyName == 'terms'"/>
+         <parameter key="beans.resource_attributes" value="org.apache.cassandra.db:type=ColumnFamilies,keyspace=newts,columnfamily=resource_attributes"/>
+         <parameter key="tests.resource_attributes" value="resource_attributes.ColumnFamilyName == 'resource_attributes'"/>
+         <parameter key="beans.resource_metrics" value="org.apache.cassandra.db:type=ColumnFamilies,keyspace=newts,columnfamily=resource_metrics"/>
+         <parameter key="tests.resource_metrics" value="resource_metrics.ColumnFamilyName == 'resource_metrics'"/>
+      </service>
+      <downtime begin="0" end="300000" interval="30000"/>
+      <downtime begin="300000" end="43200000" interval="300000"/>
+      <downtime begin="43200000" end="432000000" interval="600000"/>
+      <downtime begin="432000000" delete="true"/>
+   </package>
+   <package name="example1">
+      <filter>IPADDR != '0.0.0.0'</filter>
+      <include-range begin="1.1.1.1" end="254.254.254.254"/>
+      <include-range begin="::1" end="ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"/>
+      <rrd step="300">
+         <rra>RRA:AVERAGE:0.5:1:2016</rra>
+         <rra>RRA:AVERAGE:0.5:12:1488</rra>
+         <rra>RRA:AVERAGE:0.5:288:366</rra>
+         <rra>RRA:MAX:0.5:288:366</rra>
+         <rra>RRA:MIN:0.5:288:366</rra>
+      </rrd>
+      <service name="ICMP" interval="300000" user-defined="false" status="on">
+         <parameter key="retry" value="2"/>
+         <parameter key="timeout" value="3000"/>
+         <parameter key="rrd-repository" value="/opt/opennms/share/rrd/response"/>
+         <parameter key="rrd-base-name" value="icmp"/>
+         <parameter key="ds-name" value="icmp"/>
+      </service>
+      <service name="DNS" interval="300000" user-defined="false" status="on">
+         <parameter key="retry" value="2"/>
+         <parameter key="timeout" value="5000"/>
+         <parameter key="port" value="53"/>
+         <parameter key="lookup" value="localhost"/>
+         <parameter key="fatal-response-codes" value="2,3,5"/>
+         <parameter key="rrd-repository" value="/opt/opennms/share/rrd/response"/>
+         <parameter key="rrd-base-name" value="dns"/>
+         <parameter key="ds-name" value="dns"/>
+      </service>
+      <service name="SMTP" interval="300000" user-defined="false" status="on">
+         <parameter key="retry" value="1"/>
+         <parameter key="timeout" value="3000"/>
+         <parameter key="port" value="25"/>
+         <parameter key="rrd-repository" value="/opt/opennms/share/rrd/response"/>
+         <parameter key="rrd-base-name" value="smtp"/>
+         <parameter key="ds-name" value="smtp"/>
+      </service>
+      <service name="FTP" interval="300000" user-defined="false" status="on">
+         <parameter key="retry" value="1"/>
+         <parameter key="timeout" value="3000"/>
+         <parameter key="port" value="21"/>
+         <parameter key="userid" value=""/>
+         <parameter key="password" value=""/>
+      </service>
+      <service name="SNMP" interval="300000" user-defined="false" status="on">
+         <parameter key="oid" value=".1.3.6.1.2.1.1.2.0"/>
+      </service>
+      <service name="HTTP" interval="300000" user-defined="false" status="on">
+         <parameter key="retry" value="1"/>
+         <parameter key="timeout" value="3000"/>
+         <parameter key="port" value="80"/>
+         <parameter key="url" value="/"/>
+         <parameter key="rrd-repository" value="/opt/opennms/share/rrd/response"/>
+         <parameter key="rrd-base-name" value="http"/>
+         <parameter key="ds-name" value="http"/>
+      </service>
+      <service name="HTTP-8080" interval="300000" user-defined="false" status="on">
+         <parameter key="retry" value="1"/>
+         <parameter key="timeout" value="3000"/>
+         <parameter key="port" value="8080"/>
+         <parameter key="url" value="/"/>
+         <parameter key="rrd-repository" value="/opt/opennms/share/rrd/response"/>
+         <parameter key="rrd-base-name" value="http-8080"/>
+         <parameter key="ds-name" value="http-8080"/>
+      </service>
+      <service name="HTTP-8000" interval="300000" user-defined="false" status="on">
+         <parameter key="retry" value="1"/>
+         <parameter key="timeout" value="3000"/>
+         <parameter key="port" value="8000"/>
+         <parameter key="url" value="/"/>
+         <parameter key="rrd-repository" value="/opt/opennms/share/rrd/response"/>
+         <parameter key="rrd-base-name" value="http-8000"/>
+         <parameter key="ds-name" value="http-8000"/>
+      </service>
+      <service name="HTTPS" interval="300000" user-defined="false" status="on">
+         <parameter key="retry" value="1"/>
+         <parameter key="timeout" value="5000"/>
+         <parameter key="port" value="443"/>
+         <parameter key="url" value="/"/>
+      </service>
+      <service name="HypericAgent" interval="300000" user-defined="false" status="on">
+         <parameter key="retry" value="1"/>
+         <parameter key="timeout" value="2200"/>
+         <parameter key="port" value="2144"/>
+      </service>
+      <service name="HypericHQ" interval="300000" user-defined="false" status="on">
+         <parameter key="retry" value="1"/>
+         <parameter key="timeout" value="3000"/>
+         <parameter key="rrd-repository" value="/opt/opennms/share/rrd/response"/>
+         <parameter key="rrd-base-name" value="hyperic-hq"/>
+         <parameter key="ds-name" value="hyperic-hq"/>
+         <parameter key="page-sequence">
+            <page-sequence xmlns="">
+               <page disable-ssl-verification="true" host="${ipaddr}" http-version="1.1" method="GET" path="/Login.do" port="7080" response-range="100-399" scheme="http" successMatch="(HQ Login)|(Sign in to Hyperic HQ)" xmlns=""/>
+               <page disable-ssl-verification="true" failureMatch="(?s)(The username or password provided does not match our records)|(You are not signed in)" failureMessage="HQ Login in Failed" host="${ipaddr}" http-version="1.1" method="POST" path="/j_security_check.do" port="7080" response-range="100-399" scheme="http" successMatch="HQ Dashboard" xmlns="">
+                  <parameter key="j_username" value="hqadmin" xmlns=""/>
+                  <parameter key="j_password" value="hqadmin" xmlns=""/>
+               </page>
+               <page disable-ssl-verification="true" host="${ipaddr}" http-version="1.1" method="GET" path="/Logout.do" port="7080" response-range="100-399" scheme="http" successMatch="HQ Login" xmlns=""/>
+            </page-sequence>
+         </parameter>
+      </service>
+      <service name="MySQL" interval="300000" user-defined="false" status="on">
+         <parameter key="retry" value="1"/>
+         <parameter key="timeout" value="3000"/>
+         <parameter key="port" value="3306"/>
+         <parameter key="banner" value="*"/>
+      </service>
+      <service name="SQLServer" interval="300000" user-defined="false" status="on">
+         <parameter key="retry" value="1"/>
+         <parameter key="timeout" value="3000"/>
+         <parameter key="port" value="1433"/>
+         <parameter key="banner" value="*"/>
+      </service>
+      <service name="Oracle" interval="300000" user-defined="false" status="on">
+         <parameter key="retry" value="1"/>
+         <parameter key="timeout" value="3000"/>
+         <parameter key="port" value="1521"/>
+         <parameter key="banner" value="*"/>
+      </service>
+      <service name="Postgres" interval="300000" user-defined="false" status="on">
+         <parameter key="retry" value="1"/>
+         <parameter key="banner" value="*"/>
+         <parameter key="port" value="5432"/>
+         <parameter key="timeout" value="3000"/>
+      </service>
+      <service name="SSH" interval="300000" user-defined="false" status="on">
+         <parameter key="retry" value="1"/>
+         <parameter key="banner" value="SSH"/>
+         <parameter key="port" value="22"/>
+         <parameter key="timeout" value="3000"/>
+         <parameter key="rrd-repository" value="/opt/opennms/share/rrd/response"/>
+         <parameter key="rrd-base-name" value="ssh"/>
+         <parameter key="ds-name" value="ssh"/>
+      </service>
+      <service name="IMAP" interval="300000" user-defined="false" status="on">
+         <parameter key="retry" value="1"/>
+         <parameter key="port" value="143"/>
+         <parameter key="timeout" value="3000"/>
+      </service>
+      <service name="POP3" interval="300000" user-defined="false" status="on">
+         <parameter key="retry" value="1"/>
+         <parameter key="port" value="110"/>
+         <parameter key="timeout" value="3000"/>
+         <parameter key="rrd-repository" value="/opt/opennms/share/rrd/response"/>
+         <parameter key="rrd-base-name" value="pop3"/>
+         <parameter key="ds-name" value="pop3"/>
+      </service>
+      <service name="NRPE" interval="300000" user-defined="false" status="on">
+         <parameter key="retry" value="3"/>
+         <parameter key="timeout" value="3000"/>
+         <parameter key="port" value="5666"/>
+         <parameter key="command" value="_NRPE_CHECK"/>
+         <parameter key="padding" value="2"/>
+         <parameter key="rrd-repository" value="/opt/opennms/share/rrd/response"/>
+         <parameter key="ds-name" value="nrpe"/>
+      </service>
+      <service name="NRPE-NoSSL" interval="300000" user-defined="false" status="on">
+         <parameter key="retry" value="3"/>
+         <parameter key="timeout" value="3000"/>
+         <parameter key="port" value="5666"/>
+         <parameter key="command" value="_NRPE_CHECK"/>
+         <parameter key="usessl" value="false"/>
+         <parameter key="padding" value="2"/>
+         <parameter key="rrd-repository" value="/opt/opennms/share/rrd/response"/>
+         <parameter key="ds-name" value="nrpe"/>
+      </service>
+      <service name="Windows-Task-Scheduler" interval="300000" user-defined="false" status="on">
+         <parameter key="service-name" value="Task Scheduler"/>
+      </service>
+      <service name="OpenNMS-JVM" interval="300000" user-defined="false" status="on">
+         <parameter key="port" value="18980"/>
+         <parameter key="retry" value="2"/>
+         <parameter key="timeout" value="3000"/>
+         <parameter key="rrd-repository" value="/opt/opennms/share/rrd/response"/>
+      </service>
+      <service name="VMwareCim-HostSystem" interval="300000" user-defined="false" status="on">
+         <parameter key="retry" value="2"/>
+         <parameter key="timeout" value="3000"/>
+         <parameter key="ignoreStandBy" value="false"/>
+      </service>
+      <service name="VMware-ManagedEntity" interval="300000" user-defined="false" status="on">
+         <parameter key="retry" value="2"/>
+         <parameter key="timeout" value="3000"/>
+         <parameter key="ignoreStandBy" value="false"/>
+      </service>
+      <service name="MS-RDP" interval="300000" user-defined="false" status="on">
+         <parameter key="retry" value="1"/>
+         <parameter key="banner" value="*"/>
+         <parameter key="port" value="3389"/>
+         <parameter key="timeout" value="3000"/>
+      </service>
+      <downtime begin="0" end="300000" interval="30000"/>
+      <downtime begin="300000" end="43200000" interval="300000"/>
+      <downtime begin="43200000" end="432000000" interval="600000"/>
+      <downtime begin="432000000" delete="true"/>
+   </package>
+   <package name="strafer">
+      <filter>IPADDR != '0.0.0.0'</filter>
+      <include-range begin="10.1.1.1" end="10.1.1.10"/>
+      <rrd step="300">
+         <rra>RRA:AVERAGE:0.5:1:2016</rra>
+         <rra>RRA:AVERAGE:0.5:12:1488</rra>
+         <rra>RRA:AVERAGE:0.5:288:366</rra>
+         <rra>RRA:MAX:0.5:288:366</rra>
+         <rra>RRA:MIN:0.5:288:366</rra>
+      </rrd>
+      <service name="StrafePing" interval="300000" user-defined="false" status="on">
+         <parameter key="retry" value="0"/>
+         <parameter key="timeout" value="3000"/>
+         <parameter key="ping-count" value="20"/>
+         <parameter key="failure-ping-count" value="20"/>
+         <parameter key="wait-interval" value="50"/>
+         <parameter key="rrd-repository" value="/opt/opennms/share/rrd/response"/>
+         <parameter key="rrd-base-name" value="strafeping"/>
+      </service>
+      <downtime begin="0" end="432000000" interval="300000"/>
+      <downtime begin="432000000" delete="true"/>
+   </package>
+   <monitor service="JMX-Cassandra" class-name="org.opennms.netmgt.poller.monitors.Jsr160Monitor"/>
+   <monitor service="JMX-Cassandra-Newts" class-name="org.opennms.netmgt.poller.monitors.Jsr160Monitor"/>
+   <monitor service="ICMP" class-name="org.opennms.netmgt.poller.monitors.IcmpMonitor"/>
+   <monitor service="StrafePing" class-name="org.opennms.netmgt.poller.monitors.StrafePingMonitor"/>
+   <monitor service="HTTP" class-name="org.opennms.netmgt.poller.monitors.HttpMonitor"/>
+   <monitor service="HTTP-8080" class-name="org.opennms.netmgt.poller.monitors.HttpMonitor"/>
+   <monitor service="HTTP-8000" class-name="org.opennms.netmgt.poller.monitors.HttpMonitor"/>
+   <monitor service="HTTPS" class-name="org.opennms.netmgt.poller.monitors.HttpsMonitor"/>
+   <monitor service="HypericAgent" class-name="org.opennms.netmgt.poller.monitors.TcpMonitor"/>
+   <monitor service="HypericHQ" class-name="org.opennms.netmgt.poller.monitors.PageSequenceMonitor"/>
+   <monitor service="SMTP" class-name="org.opennms.netmgt.poller.monitors.SmtpMonitor"/>
+   <monitor service="DNS" class-name="org.opennms.netmgt.poller.monitors.DnsMonitor"/>
+   <monitor service="FTP" class-name="org.opennms.netmgt.poller.monitors.FtpMonitor"/>
+   <monitor service="SNMP" class-name="org.opennms.netmgt.poller.monitors.SnmpMonitor"/>
+   <monitor service="Oracle" class-name="org.opennms.netmgt.poller.monitors.TcpMonitor"/>
+   <monitor service="Postgres" class-name="org.opennms.netmgt.poller.monitors.TcpMonitor"/>
+   <monitor service="MySQL" class-name="org.opennms.netmgt.poller.monitors.TcpMonitor"/>
+   <monitor service="SQLServer" class-name="org.opennms.netmgt.poller.monitors.TcpMonitor"/>
+   <monitor service="SSH" class-name="org.opennms.netmgt.poller.monitors.SshMonitor"/>
+   <monitor service="IMAP" class-name="org.opennms.netmgt.poller.monitors.ImapMonitor"/>
+   <monitor service="POP3" class-name="org.opennms.netmgt.poller.monitors.Pop3Monitor"/>
+   <monitor service="NRPE" class-name="org.opennms.netmgt.poller.monitors.NrpeMonitor"/>
+   <monitor service="NRPE-NoSSL" class-name="org.opennms.netmgt.poller.monitors.NrpeMonitor"/>
+   <monitor service="Windows-Task-Scheduler" class-name="org.opennms.netmgt.poller.monitors.Win32ServiceMonitor"/>
+   <monitor service="OpenNMS-JVM" class-name="org.opennms.netmgt.poller.monitors.Jsr160Monitor"/>
+   <monitor service="VMwareCim-HostSystem" class-name="org.opennms.netmgt.poller.monitors.VmwareCimMonitor"/>
+   <monitor service="VMware-ManagedEntity" class-name="org.opennms.netmgt.poller.monitors.VmwareMonitor"/>
+   <monitor service="MS-RDP" class-name="org.opennms.netmgt.poller.monitors.TcpMonitor"/>
 </poller-configuration>

--- a/opennms-base-assembly/src/main/filtered/etc/service-configuration.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/service-configuration.xml
@@ -7,287 +7,285 @@ When splitting services to run on mutiple VMs, the order of the services should 
 maintained
 -->
 <service-configuration xmlns="http://xmlns.opennms.org/xsd/config/vmmgr">
-  <service>
-    <name>OpenNMS:Name=Manager</name>
-    <class-name>org.opennms.netmgt.vmmgr.Manager</class-name>
-    <invoke at="stop" pass="1" method="doSystemExit"/>
-  </service>
-  <service>
-    <name>OpenNMS:Name=TestLoadLibraries</name>
-    <class-name>org.opennms.netmgt.vmmgr.Manager</class-name>
-    <invoke at="start" pass="0" method="doTestLoadLibraries"/>
-  </service>
-  <service>
-    <name>OpenNMS:Name=Eventd</name>
-    <class-name>org.opennms.netmgt.eventd.jmx.Eventd</class-name>
-    <invoke at="start" pass="0" method="init"/>
-    <invoke at="start" pass="1" method="start"/>
-    <invoke at="status" pass="0" method="status"/>
-    <invoke at="stop" pass="0" method="stop"/>
-  </service>
-  <service>
-    <name>OpenNMS:Name=Trapd</name>
-    <class-name>org.opennms.netmgt.trapd.jmx.Trapd</class-name>
-    <invoke at="start" pass="0" method="init"/>
-    <invoke at="start" pass="1" method="start"/>
-    <invoke at="status" pass="0" method="status"/>
-    <invoke at="stop" pass="0" method="stop"/>
-  </service>
-  <service>
-    <name>OpenNMS:Name=Queued</name>
-    <class-name>org.opennms.netmgt.queued.jmx.Queued</class-name>
-    <invoke at="start" pass="0" method="init"/>
-    <invoke at="start" pass="1" method="start"/>
-    <invoke at="status" pass="0" method="status"/>
-    <invoke at="stop" pass="0" method="stop"/>
-  </service>
-  <!--  Dhcpd is now distributed separately. You will need to ensure
-        it is installed before you enable it here. -->
-  <service enabled="false">
-    <name>OpenNMS:Name=Dhcpd</name>
-    <class-name>org.opennms.netmgt.dhcpd.jmx.Dhcpd</class-name>
-    <invoke at="start" pass="1" method="start"/>
-    <invoke at="status" pass="0" method="status"/>
-    <invoke at="stop" pass="0" method="stop"/>
-  </service>
-  <service>
-    <name>OpenNMS:Name=Actiond</name>
-    <class-name>org.opennms.netmgt.actiond.jmx.Actiond</class-name>
-    <invoke at="start" pass="0" method="init"/>
-    <invoke at="start" pass="1" method="start"/>
-    <invoke at="status" pass="0" method="status"/>
-    <invoke at="stop" pass="0" method="stop"/>
-  </service>
-  <service>
-    <name>OpenNMS:Name=Notifd</name>
-    <class-name>org.opennms.netmgt.notifd.jmx.Notifd</class-name>
-    <invoke at="start" pass="0" method="init"/>
-    <invoke at="start" pass="1" method="start"/>
-    <invoke at="status" pass="0" method="status"/>
-    <invoke at="stop" pass="0" method="stop"/>
-  </service>
-  <service>
-    <name>OpenNMS:Name=Scriptd</name>
-    <class-name>org.opennms.netmgt.scriptd.jmx.Scriptd</class-name>
-    <invoke at="start" pass="0" method="init"/>
-    <invoke at="start" pass="1" method="start"/>
-    <invoke at="status" pass="0" method="status"/>
-    <invoke at="stop" pass="0" method="stop"/>
-  </service>
-  <service>
-    <name>OpenNMS:Name=Rtcd</name>
-    <class-name>org.opennms.netmgt.rtc.jmx.Rtcd</class-name>
-    <invoke at="start" pass="0" method="init"/>
-    <invoke at="start" pass="1" method="start"/>
-    <invoke at="status" pass="0" method="status"/>
-    <invoke at="stop" pass="0" method="stop"/>
-  </service>
-  <service>
-    <name>OpenNMS:Name=Pollerd</name>
-    <class-name>org.opennms.netmgt.poller.jmx.Pollerd</class-name>
-    <invoke at="start" pass="0" method="init"/>
-    <invoke at="start" pass="1" method="start"/>
-    <invoke at="status" pass="0" method="status"/>
-    <invoke at="stop" pass="0" method="stop"/>
-  </service>
-  <service>
-    <name>OpenNMS:Name=PollerBackEnd</name>
-    <class-name>org.opennms.netmgt.poller.remote.jmx.RemotePollerBackEnd</class-name>
-    <invoke at="start" pass="0" method="init"/>
-    <invoke at="start" pass="1" method="start"/>
-    <invoke at="status" pass="0" method="status"/>
-    <invoke at="stop" pass="0" method="stop"/>
-  </service>
-  <service enabled="false">
-     <name>OpenNMS:Name=SnmpPoller</name>
-     <class-name>org.opennms.netmgt.snmpinterfacepoller.jmx.SnmpPollerd</class-name>
-     <invoke at="start" pass="0" method="init"/>
-     <invoke at="start" pass="1" method="start"/>
-     <invoke at="status" pass="0" method="status"/>
-     <invoke at="stop" pass="0" method="stop"/>
-  </service>
-  <service>
-    <name>OpenNMS:Name=EnhancedLinkd</name>
-    <class-name>org.opennms.netmgt.enlinkd.jmx.EnhancedLinkd</class-name>
-    <invoke at="start" pass="0" method="init"/>
-    <invoke at="start" pass="1" method="start"/>
-    <invoke at="status" pass="0" method="status"/>
-    <invoke at="stop" pass="0" method="stop"/>
-  </service>
-  <service>
-    <name>OpenNMS:Name=Ticketer</name>
-    <class-name>org.opennms.netmgt.ticketd.jmx.TroubleTicketer</class-name>
-    <invoke at="start" pass="0" method="init"/>
-    <invoke at="start" pass="1" method="start"/>
-    <invoke at="status" pass="0" method="status"/>
-    <invoke at="stop" pass="0" method="stop"/>
-  </service>
-  <service>
-    <name>OpenNMS:Name=Collectd</name>
-    <class-name>org.opennms.netmgt.collectd.jmx.Collectd</class-name>
-    <invoke at="start" pass="0" method="init"/>
-    <invoke at="start" pass="1" method="start"/>
-    <invoke at="status" pass="0" method="status"/>
-    <invoke at="stop" pass="0" method="stop"/>
-  </service>
-  <service>
-    <name>OpenNMS:Name=Discovery</name>
-    <class-name>org.opennms.netmgt.discovery.jmx.Discovery</class-name>
-    <invoke at="start" pass="0" method="init"/>
-    <invoke at="start" pass="1" method="start"/>
-    <invoke at="status" pass="0" method="status"/>
-    <invoke at="stop" pass="0" method="stop"/>
-  </service>
-  <service>
-    <name>OpenNMS:Name=Vacuumd</name>
-    <class-name>org.opennms.netmgt.vacuumd.jmx.Vacuumd</class-name>
-    <invoke at="start" pass="0" method="init"/>
-    <invoke at="start" pass="1" method="start"/>
-    <invoke at="status" pass="0" method="status"/>
-    <invoke at="stop" pass="0" method="stop"/>
-  </service>
-  <service>
-    <name>OpenNMS:Name=EventTranslator</name>
-    <class-name>org.opennms.netmgt.translator.jmx.EventTranslator</class-name>
-    <invoke at="start" pass="0" method="init"/>
-    <invoke at="start" pass="1" method="start"/>
-    <invoke at="status" pass="0" method="status"/>
-    <invoke at="stop" pass="0" method="stop"/>
-  </service>
-  <service>
-    <name>OpenNMS:Name=PassiveStatusd</name>
-    <class-name>org.opennms.netmgt.passive.jmx.PassiveStatusd</class-name>
-    <invoke at="start" pass="0" method="init"/>
-    <invoke at="start" pass="1" method="start"/>
-    <invoke at="status" pass="0" method="status"/>
-    <invoke at="stop" pass="0" method="stop"/>
-  </service>
-  <service>
-    <name>OpenNMS:Name=Statsd</name>
-    <class-name>org.opennms.netmgt.statsd.jmx.Statsd</class-name>
-    <invoke at="start" pass="0" method="init"/>
-    <invoke at="start" pass="1" method="start"/>
-    <invoke at="status" pass="0" method="status"/>
-    <invoke at="stop" pass="0" method="stop"/>
-  </service>
-  <service>
-    <name>OpenNMS:Name=Provisiond</name>
-    <class-name>org.opennms.netmgt.daemon.SimpleSpringContextJmxServiceDaemon</class-name>
-    <attribute>
-      <name>LoggingPrefix</name>
-      <value type="java.lang.String">provisiond</value>
-    </attribute>
-    <attribute>
-      <name>SpringContext</name>
-      <value type="java.lang.String">provisiondContext</value>
-    </attribute>
-    <invoke at="start" pass="0" method="init"/>
-    <invoke at="start" pass="1" method="start"/>
-    <invoke at="status" pass="0" method="status"/>
-    <invoke at="stop" pass="0" method="stop"/>
-  </service>
-  <service>
-    <name>OpenNMS:Name=Reportd</name>
-    <class-name>org.opennms.netmgt.daemon.SimpleSpringContextJmxServiceDaemon</class-name>
-    <attribute>
-      <name>LoggingPrefix</name>
-      <value type="java.lang.String">reportd</value>
-    </attribute>
-    <attribute>
-      <name>SpringContext</name>
-      <value type="java.lang.String">reportdContext</value>
-    </attribute>
-    <invoke at="start" pass="0" method="init"/>
-    <invoke at="start" pass="1" method="start"/>
-    <invoke at="status" pass="0" method="status"/>
-    <invoke at="stop" pass="0" method="stop"/>
-  </service>
-  <service>
-    <name>OpenNMS:Name=Bsmd</name>
-    <class-name>org.opennms.netmgt.daemon.SimpleSpringContextJmxServiceDaemon</class-name>
-    <attribute>
-      <name>LoggingPrefix</name>
-      <value type="java.lang.String">bsmd</value>
-    </attribute>
-    <attribute>
-      <name>SpringContext</name>
-      <value type="java.lang.String">bsmdContext</value>
-    </attribute>
-    <invoke at="start" pass="0" method="init"/>
-    <invoke at="start" pass="1" method="start"/>
-    <invoke at="status" pass="0" method="status"/>
-    <invoke at="stop" pass="0" method="stop"/>
-  </service>
-  <service>
-    <name>OpenNMS:Name=Alarmd</name>
-    <class-name>org.opennms.netmgt.daemon.SimpleSpringContextJmxServiceDaemon</class-name>
-    <attribute>
-      <name>LoggingPrefix</name>
-      <value type="java.lang.String">alarmd</value>
-    </attribute>
-    <attribute>
-      <name>SpringContext</name>
-      <value type="java.lang.String">alarmdContext</value>
-    </attribute>
-    <invoke at="start" pass="0" method="init"/>
-    <invoke at="start" pass="1" method="start"/>
-    <invoke at="status" pass="0" method="status"/>
-    <invoke at="stop" pass="0" method="stop"/>
-  </service>
-  <service>
-    <name>OpenNMS:Name=Ackd</name>
-    <class-name>org.opennms.netmgt.daemon.SimpleSpringContextJmxServiceDaemon</class-name>
-    <attribute>
-      <name>LoggingPrefix</name>
-      <value type="java.lang.String">ackd</value>
-    </attribute>
-    <attribute>
-      <name>SpringContext</name>
-      <value type="java.lang.String">ackdContext</value>
-    </attribute>
-    <invoke at="start" pass="0" method="init"/>
-    <invoke at="start" pass="1" method="start"/>
-    <invoke at="status" pass="0" method="status"/>
-    <invoke at="stop" pass="0" method="stop"/>
-  </service>
-  <service>
-    <name>OpenNMS:Name=JettyServer</name>
-    <class-name>org.opennms.netmgt.jetty.jmx.JettyServer</class-name>
-    <invoke at="start" pass="0" method="init"/>
-    <invoke at="start" pass="1" method="start"/>
-    <invoke at="status" pass="0" method="status"/>
-    <invoke at="stop" pass="0" method="stop"/>
-  </service>
-  <service enabled="false">
-    <name>OpenNMS:Name=Correlator</name>
-    <class-name>org.opennms.netmgt.correlation.jmx.Correlator</class-name>
-    <invoke at="start" pass="0" method="init"/>
-    <invoke at="start" pass="1" method="start"/>
-    <invoke at="status" pass="0" method="status"/>
-    <invoke at="stop" pass="0" method="stop"/>
-  </service>
-  <service enabled="false">
-    <name>OpenNMS:Name=Tl1d</name>
-    <class-name>org.opennms.netmgt.tl1d.jmx.Tl1d</class-name>
-    <invoke at="start" pass="0" method="init"/>
-    <invoke at="start" pass="1" method="start"/>
-    <invoke at="status" pass="0" method="status"/>
-    <invoke at="stop" pass="0" method="stop"/>
-  </service>
-  <service enabled="false">
-    <name>OpenNMS:Name=Syslogd</name>
-    <class-name>org.opennms.netmgt.syslogd.jmx.Syslogd</class-name>
-    <invoke at="start" pass="0" method="init"/>
-    <invoke at="start" pass="1" method="start"/>
-    <invoke at="status" pass="0" method="status"/>
-    <invoke at="stop" pass="0" method="stop"/>
-  </service>
-  <service enabled="false">
-    <name>OpenNMS:Name=AsteriskGateway</name>
-    <class-name>org.opennms.netmgt.asterisk.agi.jmx.AsteriskGateway</class-name>
-    <invoke at="start" pass="0" method="init"/>
-    <invoke at="start" pass="1" method="start"/>
-    <invoke at="status" pass="0" method="status"/>
-    <invoke at="stop" pass="0" method="stop"/>
-  </service>
+   <service>
+      <name>OpenNMS:Name=Manager</name>
+      <class-name>org.opennms.netmgt.vmmgr.Manager</class-name>
+      <invoke method="doSystemExit" pass="1" at="stop"/>
+   </service>
+   <service>
+      <name>OpenNMS:Name=TestLoadLibraries</name>
+      <class-name>org.opennms.netmgt.vmmgr.Manager</class-name>
+      <invoke method="doTestLoadLibraries" pass="0" at="start"/>
+   </service>
+   <service>
+      <name>OpenNMS:Name=Eventd</name>
+      <class-name>org.opennms.netmgt.eventd.jmx.Eventd</class-name>
+      <invoke method="init" pass="0" at="start"/>
+      <invoke method="start" pass="1" at="start"/>
+      <invoke method="status" pass="0" at="status"/>
+      <invoke method="stop" pass="0" at="stop"/>
+   </service>
+   <service>
+      <name>OpenNMS:Name=Trapd</name>
+      <class-name>org.opennms.netmgt.trapd.jmx.Trapd</class-name>
+      <invoke method="init" pass="0" at="start"/>
+      <invoke method="start" pass="1" at="start"/>
+      <invoke method="status" pass="0" at="status"/>
+      <invoke method="stop" pass="0" at="stop"/>
+   </service>
+   <service>
+      <name>OpenNMS:Name=Queued</name>
+      <class-name>org.opennms.netmgt.queued.jmx.Queued</class-name>
+      <invoke method="init" pass="0" at="start"/>
+      <invoke method="start" pass="1" at="start"/>
+      <invoke method="status" pass="0" at="status"/>
+      <invoke method="stop" pass="0" at="stop"/>
+   </service>
+   <service enabled="false">
+      <name>OpenNMS:Name=Dhcpd</name>
+      <class-name>org.opennms.netmgt.dhcpd.jmx.Dhcpd</class-name>
+      <invoke method="start" pass="1" at="start"/>
+      <invoke method="status" pass="0" at="status"/>
+      <invoke method="stop" pass="0" at="stop"/>
+   </service>
+   <service>
+      <name>OpenNMS:Name=Actiond</name>
+      <class-name>org.opennms.netmgt.actiond.jmx.Actiond</class-name>
+      <invoke method="init" pass="0" at="start"/>
+      <invoke method="start" pass="1" at="start"/>
+      <invoke method="status" pass="0" at="status"/>
+      <invoke method="stop" pass="0" at="stop"/>
+   </service>
+   <service>
+      <name>OpenNMS:Name=Notifd</name>
+      <class-name>org.opennms.netmgt.notifd.jmx.Notifd</class-name>
+      <invoke method="init" pass="0" at="start"/>
+      <invoke method="start" pass="1" at="start"/>
+      <invoke method="status" pass="0" at="status"/>
+      <invoke method="stop" pass="0" at="stop"/>
+   </service>
+   <service>
+      <name>OpenNMS:Name=Scriptd</name>
+      <class-name>org.opennms.netmgt.scriptd.jmx.Scriptd</class-name>
+      <invoke method="init" pass="0" at="start"/>
+      <invoke method="start" pass="1" at="start"/>
+      <invoke method="status" pass="0" at="status"/>
+      <invoke method="stop" pass="0" at="stop"/>
+   </service>
+   <service>
+      <name>OpenNMS:Name=Rtcd</name>
+      <class-name>org.opennms.netmgt.rtc.jmx.Rtcd</class-name>
+      <invoke method="init" pass="0" at="start"/>
+      <invoke method="start" pass="1" at="start"/>
+      <invoke method="status" pass="0" at="status"/>
+      <invoke method="stop" pass="0" at="stop"/>
+   </service>
+   <service>
+      <name>OpenNMS:Name=Pollerd</name>
+      <class-name>org.opennms.netmgt.poller.jmx.Pollerd</class-name>
+      <invoke method="init" pass="0" at="start"/>
+      <invoke method="start" pass="1" at="start"/>
+      <invoke method="status" pass="0" at="status"/>
+      <invoke method="stop" pass="0" at="stop"/>
+   </service>
+   <service>
+      <name>OpenNMS:Name=PollerBackEnd</name>
+      <class-name>org.opennms.netmgt.poller.remote.jmx.RemotePollerBackEnd</class-name>
+      <invoke method="init" pass="0" at="start"/>
+      <invoke method="start" pass="1" at="start"/>
+      <invoke method="status" pass="0" at="status"/>
+      <invoke method="stop" pass="0" at="stop"/>
+   </service>
+   <service enabled="false">
+      <name>OpenNMS:Name=SnmpPoller</name>
+      <class-name>org.opennms.netmgt.snmpinterfacepoller.jmx.SnmpPollerd</class-name>
+      <invoke method="init" pass="0" at="start"/>
+      <invoke method="start" pass="1" at="start"/>
+      <invoke method="status" pass="0" at="status"/>
+      <invoke method="stop" pass="0" at="stop"/>
+   </service>
+   <service>
+      <name>OpenNMS:Name=EnhancedLinkd</name>
+      <class-name>org.opennms.netmgt.enlinkd.jmx.EnhancedLinkd</class-name>
+      <invoke method="init" pass="0" at="start"/>
+      <invoke method="start" pass="1" at="start"/>
+      <invoke method="status" pass="0" at="status"/>
+      <invoke method="stop" pass="0" at="stop"/>
+   </service>
+   <service>
+      <name>OpenNMS:Name=Ticketer</name>
+      <class-name>org.opennms.netmgt.ticketd.jmx.TroubleTicketer</class-name>
+      <invoke method="init" pass="0" at="start"/>
+      <invoke method="start" pass="1" at="start"/>
+      <invoke method="status" pass="0" at="status"/>
+      <invoke method="stop" pass="0" at="stop"/>
+   </service>
+   <service>
+      <name>OpenNMS:Name=Collectd</name>
+      <class-name>org.opennms.netmgt.collectd.jmx.Collectd</class-name>
+      <invoke method="init" pass="0" at="start"/>
+      <invoke method="start" pass="1" at="start"/>
+      <invoke method="status" pass="0" at="status"/>
+      <invoke method="stop" pass="0" at="stop"/>
+   </service>
+   <service>
+      <name>OpenNMS:Name=Discovery</name>
+      <class-name>org.opennms.netmgt.discovery.jmx.Discovery</class-name>
+      <invoke method="init" pass="0" at="start"/>
+      <invoke method="start" pass="1" at="start"/>
+      <invoke method="status" pass="0" at="status"/>
+      <invoke method="stop" pass="0" at="stop"/>
+   </service>
+   <service>
+      <name>OpenNMS:Name=Vacuumd</name>
+      <class-name>org.opennms.netmgt.vacuumd.jmx.Vacuumd</class-name>
+      <invoke method="init" pass="0" at="start"/>
+      <invoke method="start" pass="1" at="start"/>
+      <invoke method="status" pass="0" at="status"/>
+      <invoke method="stop" pass="0" at="stop"/>
+   </service>
+   <service>
+      <name>OpenNMS:Name=EventTranslator</name>
+      <class-name>org.opennms.netmgt.translator.jmx.EventTranslator</class-name>
+      <invoke method="init" pass="0" at="start"/>
+      <invoke method="start" pass="1" at="start"/>
+      <invoke method="status" pass="0" at="status"/>
+      <invoke method="stop" pass="0" at="stop"/>
+   </service>
+   <service>
+      <name>OpenNMS:Name=PassiveStatusd</name>
+      <class-name>org.opennms.netmgt.passive.jmx.PassiveStatusd</class-name>
+      <invoke method="init" pass="0" at="start"/>
+      <invoke method="start" pass="1" at="start"/>
+      <invoke method="status" pass="0" at="status"/>
+      <invoke method="stop" pass="0" at="stop"/>
+   </service>
+   <service>
+      <name>OpenNMS:Name=Statsd</name>
+      <class-name>org.opennms.netmgt.statsd.jmx.Statsd</class-name>
+      <invoke method="init" pass="0" at="start"/>
+      <invoke method="start" pass="1" at="start"/>
+      <invoke method="status" pass="0" at="status"/>
+      <invoke method="stop" pass="0" at="stop"/>
+   </service>
+   <service>
+      <name>OpenNMS:Name=Provisiond</name>
+      <class-name>org.opennms.netmgt.daemon.SimpleSpringContextJmxServiceDaemon</class-name>
+      <attribute>
+         <name>LoggingPrefix</name>
+         <value type="java.lang.String">provisiond</value>
+      </attribute>
+      <attribute>
+         <name>SpringContext</name>
+         <value type="java.lang.String">provisiondContext</value>
+      </attribute>
+      <invoke method="init" pass="0" at="start"/>
+      <invoke method="start" pass="1" at="start"/>
+      <invoke method="status" pass="0" at="status"/>
+      <invoke method="stop" pass="0" at="stop"/>
+   </service>
+   <service>
+      <name>OpenNMS:Name=Reportd</name>
+      <class-name>org.opennms.netmgt.daemon.SimpleSpringContextJmxServiceDaemon</class-name>
+      <attribute>
+         <name>LoggingPrefix</name>
+         <value type="java.lang.String">reportd</value>
+      </attribute>
+      <attribute>
+         <name>SpringContext</name>
+         <value type="java.lang.String">reportdContext</value>
+      </attribute>
+      <invoke method="init" pass="0" at="start"/>
+      <invoke method="start" pass="1" at="start"/>
+      <invoke method="status" pass="0" at="status"/>
+      <invoke method="stop" pass="0" at="stop"/>
+   </service>
+   <service>
+      <name>OpenNMS:Name=Bsmd</name>
+      <class-name>org.opennms.netmgt.daemon.SimpleSpringContextJmxServiceDaemon</class-name>
+      <attribute>
+         <name>LoggingPrefix</name>
+         <value type="java.lang.String">bsmd</value>
+      </attribute>
+      <attribute>
+         <name>SpringContext</name>
+         <value type="java.lang.String">bsmdContext</value>
+      </attribute>
+      <invoke method="init" pass="0" at="start"/>
+      <invoke method="start" pass="1" at="start"/>
+      <invoke method="status" pass="0" at="status"/>
+      <invoke method="stop" pass="0" at="stop"/>
+   </service>
+   <service>
+      <name>OpenNMS:Name=Alarmd</name>
+      <class-name>org.opennms.netmgt.daemon.SimpleSpringContextJmxServiceDaemon</class-name>
+      <attribute>
+         <name>LoggingPrefix</name>
+         <value type="java.lang.String">alarmd</value>
+      </attribute>
+      <attribute>
+         <name>SpringContext</name>
+         <value type="java.lang.String">alarmdContext</value>
+      </attribute>
+      <invoke method="init" pass="0" at="start"/>
+      <invoke method="start" pass="1" at="start"/>
+      <invoke method="status" pass="0" at="status"/>
+      <invoke method="stop" pass="0" at="stop"/>
+   </service>
+   <service>
+      <name>OpenNMS:Name=Ackd</name>
+      <class-name>org.opennms.netmgt.daemon.SimpleSpringContextJmxServiceDaemon</class-name>
+      <attribute>
+         <name>LoggingPrefix</name>
+         <value type="java.lang.String">ackd</value>
+      </attribute>
+      <attribute>
+         <name>SpringContext</name>
+         <value type="java.lang.String">ackdContext</value>
+      </attribute>
+      <invoke method="init" pass="0" at="start"/>
+      <invoke method="start" pass="1" at="start"/>
+      <invoke method="status" pass="0" at="status"/>
+      <invoke method="stop" pass="0" at="stop"/>
+   </service>
+   <service>
+      <name>OpenNMS:Name=JettyServer</name>
+      <class-name>org.opennms.netmgt.jetty.jmx.JettyServer</class-name>
+      <invoke method="init" pass="0" at="start"/>
+      <invoke method="start" pass="1" at="start"/>
+      <invoke method="status" pass="0" at="status"/>
+      <invoke method="stop" pass="0" at="stop"/>
+   </service>
+   <service enabled="false">
+      <name>OpenNMS:Name=Correlator</name>
+      <class-name>org.opennms.netmgt.correlation.jmx.Correlator</class-name>
+      <invoke method="init" pass="0" at="start"/>
+      <invoke method="start" pass="1" at="start"/>
+      <invoke method="status" pass="0" at="status"/>
+      <invoke method="stop" pass="0" at="stop"/>
+   </service>
+   <service enabled="false">
+      <name>OpenNMS:Name=Tl1d</name>
+      <class-name>org.opennms.netmgt.tl1d.jmx.Tl1d</class-name>
+      <invoke method="init" pass="0" at="start"/>
+      <invoke method="start" pass="1" at="start"/>
+      <invoke method="status" pass="0" at="status"/>
+      <invoke method="stop" pass="0" at="stop"/>
+   </service>
+   <service enabled="false">
+      <name>OpenNMS:Name=Syslogd</name>
+      <class-name>org.opennms.netmgt.syslogd.jmx.Syslogd</class-name>
+      <invoke method="init" pass="0" at="start"/>
+      <invoke method="start" pass="1" at="start"/>
+      <invoke method="status" pass="0" at="status"/>
+      <invoke method="stop" pass="0" at="stop"/>
+   </service>
+   <service enabled="false">
+      <name>OpenNMS:Name=AsteriskGateway</name>
+      <class-name>org.opennms.netmgt.asterisk.agi.jmx.AsteriskGateway</class-name>
+      <invoke method="init" pass="0" at="start"/>
+      <invoke method="start" pass="1" at="start"/>
+      <invoke method="status" pass="0" at="status"/>
+      <invoke method="stop" pass="0" at="stop"/>
+   </service>
 </service-configuration>

--- a/opennms-base-assembly/src/main/filtered/etc/snmp-config.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/snmp-config.xml
@@ -1,2 +1,1 @@
-<?xml version="1.0"?>
-<snmp-config read-community="public" retry="1" timeout="1800" version="v2c" />
+<snmp-config xmlns="http://xmlns.opennms.org/xsd/config/snmp" version="v2c" read-community="public" timeout="1800" retry="1"/>

--- a/opennms-base-assembly/src/main/filtered/etc/threshd-configuration.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/threshd-configuration.xml
@@ -1,77 +1,60 @@
-<?xml version="1.0"?>
-<?castor class-name="org.opennms.netmgt.threshd.ThreshdConfiguration"?>
-<threshd-configuration 
-	threads="5">
-
-	<package name="mib2">
-		<filter>IPADDR != '0.0.0.0'</filter>	 
-		<include-range begin="1.1.1.1" end="254.254.254.254"/>
-		<include-range begin="::1" end="ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff" />
-		
-		<service name="SNMP" interval="300000" user-defined="false" status="on">
-			<parameter key="thresholding-group" value="mib2"/>
-		</service>
-	</package>
-	
-	<package name="hrstorage">
-		<filter>IPADDR != '0.0.0.0' &amp; (nodeSysOID LIKE '.1.3.6.1.4.1.311.%' | nodeSysOID LIKE '.1.3.6.1.4.1.2.3.1.2.1.1.3.%')</filter>	 
-		<include-range begin="1.1.1.1" end="254.254.254.254"/>
-		<include-range begin="::1" end="ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff" />
-		
-		<service name="SNMP" interval="300000" user-defined="false" status="on">
-			<parameter key="thresholding-group" value="hrstorage"/>
-		</service>
-	</package>
-
-	<package name="cisco">
-		<filter>IPADDR != '0.0.0.0' &amp; nodeSysOID LIKE '.1.3.6.1.4.1.9.%'</filter>	 
-		<include-range begin="1.1.1.1" end="254.254.254.254"/>
-		<include-range begin="::1" end="ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff" />
-		
-		<service name="SNMP" interval="300000" user-defined="false" status="on">
-			<parameter key="thresholding-group" value="cisco"/>
-		</service>
-	</package>
-
-	<package name="juniper-srx">
-		<filter>IPADDR != '0.0.0.0' &amp; nodeSysOID LIKE '.1.3.6.1.4.1.2636.1.1.1.2.39'</filter>
-		<include-range begin="1.1.1.1" end="254.254.254.254"/>
-		<include-range begin="::1" end="ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"/>
-
-		<service name="SNMP" interval="300000" user-defined="false" status="on">
-			<parameter key="thresholding-group" value="juniper-srx"/>
-		</service>
-	</package>
-
-	<package name="netsnmp">
-		<filter>IPADDR != '0.0.0.0' &amp; (nodeSysOID LIKE '.1.3.6.1.4.1.2021.%' | nodeSysOID LIKE '.1.3.6.1.4.1.8072.%')</filter>	 
-		<include-range begin="1.1.1.1" end="254.254.254.254"/>
-		<include-range begin="::1" end="ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff" />
-		
-		<service name="SNMP" interval="300000" user-defined="false" status="on">
-			<parameter key="thresholding-group" value="netsnmp"/>
-		</service>
-	</package>
-
-	<package name="netsnmp-memory-linux">
-		<filter>IPADDR != '0.0.0.0' &amp; nodeSysOID == '.1.3.6.1.4.1.8072.3.2.10'</filter> 
-		<include-range begin="1.1.1.1" end="254.254.254.254"/>
-		<include-range begin="::1" end="ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff" />
-		
-		<service name="SNMP" interval="300000" user-defined="false" status="on">
-			<parameter key="thresholding-group" value="netsnmp-memory-linux"/>
-		</service>
-	</package>
-
-	<package name="netsnmp-memory-nonlinux">
-		<filter>IPADDR != '0.0.0.0' &amp; (nodeSysOID LIKE '.1.3.6.1.4.1.2021.%' | nodeSysOID LIKE '.1.3.6.1.4.1.8072.%') &amp; nodeSysOID != '.1.3.6.1.4.1.8072.3.2.10'</filter> 
-		<include-range begin="1.1.1.1" end="254.254.254.254"/>
-		<include-range begin="::1" end="ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff" />
-		
-		<service name="SNMP" interval="300000" user-defined="false" status="on">
-			<parameter key="thresholding-group" value="netsnmp-memory-nonlinux"/>
-		</service>
-	</package>
-
+<?xml version="1.0" encoding="UTF-8"?>
+<threshd-configuration
+    xmlns="http://xmlns.opennms.org/xsd/config/threshd" threads="5">
+    <package name="mib2">
+        <filter>IPADDR != '0.0.0.0'</filter>
+        <include-range begin="1.1.1.1" end="254.254.254.254"/>
+        <include-range begin="::1" end="ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"/>
+        <service name="SNMP" interval="300000" user-defined="false" status="on">
+            <parameter key="thresholding-group" value="mib2"/>
+        </service>
+    </package>
+    <package name="hrstorage">
+        <filter>IPADDR != '0.0.0.0' &amp; (nodeSysOID LIKE '.1.3.6.1.4.1.311.%' | nodeSysOID LIKE '.1.3.6.1.4.1.2.3.1.2.1.1.3.%')</filter>
+        <include-range begin="1.1.1.1" end="254.254.254.254"/>
+        <include-range begin="::1" end="ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"/>
+        <service name="SNMP" interval="300000" user-defined="false" status="on">
+            <parameter key="thresholding-group" value="hrstorage"/>
+        </service>
+    </package>
+    <package name="cisco">
+        <filter>IPADDR != '0.0.0.0' &amp; nodeSysOID LIKE '.1.3.6.1.4.1.9.%'</filter>
+        <include-range begin="1.1.1.1" end="254.254.254.254"/>
+        <include-range begin="::1" end="ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"/>
+        <service name="SNMP" interval="300000" user-defined="false" status="on">
+            <parameter key="thresholding-group" value="cisco"/>
+        </service>
+    </package>
+    <package name="juniper-srx">
+        <filter>IPADDR != '0.0.0.0' &amp; nodeSysOID LIKE '.1.3.6.1.4.1.2636.1.1.1.2.39'</filter>
+        <include-range begin="1.1.1.1" end="254.254.254.254"/>
+        <include-range begin="::1" end="ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"/>
+        <service name="SNMP" interval="300000" user-defined="false" status="on">
+            <parameter key="thresholding-group" value="juniper-srx"/>
+        </service>
+    </package>
+    <package name="netsnmp">
+        <filter>IPADDR != '0.0.0.0' &amp; (nodeSysOID LIKE '.1.3.6.1.4.1.2021.%' | nodeSysOID LIKE '.1.3.6.1.4.1.8072.%')</filter>
+        <include-range begin="1.1.1.1" end="254.254.254.254"/>
+        <include-range begin="::1" end="ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"/>
+        <service name="SNMP" interval="300000" user-defined="false" status="on">
+            <parameter key="thresholding-group" value="netsnmp"/>
+        </service>
+    </package>
+    <package name="netsnmp-memory-linux">
+        <filter>IPADDR != '0.0.0.0' &amp; nodeSysOID == '.1.3.6.1.4.1.8072.3.2.10'</filter>
+        <include-range begin="1.1.1.1" end="254.254.254.254"/>
+        <include-range begin="::1" end="ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"/>
+        <service name="SNMP" interval="300000" user-defined="false" status="on">
+            <parameter key="thresholding-group" value="netsnmp-memory-linux"/>
+        </service>
+    </package>
+    <package name="netsnmp-memory-nonlinux">
+        <filter>IPADDR != '0.0.0.0' &amp; (nodeSysOID LIKE '.1.3.6.1.4.1.2021.%' | nodeSysOID LIKE '.1.3.6.1.4.1.8072.%') &amp; nodeSysOID != '.1.3.6.1.4.1.8072.3.2.10'</filter>
+        <include-range begin="1.1.1.1" end="254.254.254.254"/>
+        <include-range begin="::1" end="ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"/>
+        <service name="SNMP" interval="300000" user-defined="false" status="on">
+            <parameter key="thresholding-group" value="netsnmp-memory-nonlinux"/>
+        </service>
+    </package>
 </threshd-configuration>
-


### PR DESCRIPTION
Files written by opennms has a different format than
the format that comes from etc-pristine. This generates
unecessary configuration conflits on each upgrade.

This pull request simply let OpenNMS write a bunch of config files and use this result as pristine configuration.

BTW, what is the correct branch to use?

I guess some problems are not only on pristine files but also on opennms xml writer (like the cases where xml header got removed).

