### PR TITLE
NMS-8948, NMS-8777: Minion performance fixes for Kafka

### DIFF
--- a/features/events/syslog/blueprint-syslog-handler-default.xml
+++ b/features/events/syslog/blueprint-syslog-handler-default.xml
@@ -61,21 +61,21 @@
 			<from uri="queuingservice:{{queueName}}?concurrentConsumers=8"/>
 			<!-- No performance improvement with asyncConsumer -->
 			<!-- <from uri="activemq:{{queueName}}?asyncConsumer=true&amp;concurrentConsumers=8"/> -->
-			<to uri="seda:unmarshalMessage"/>
+			<to uri="seda:unmarshalMessage?size=25000"/>
 		</route>
 
 		<route id="unmarshalSyslogConnection">
-			<from uri="seda:unmarshalMessage?concurrentConsumers=8"/>
+			<from uri="seda:unmarshalMessage?concurrentConsumers=8&amp;size=25000&amp;blockWhenFull=true"/>
 			<!-- TODO: Change these to <process> tags once Syslogd is loaded from inside Karaf -->
 			<bean ref="unmarshaller"/>
 			<bean ref="mapper"/>
 			<!-- Update the SyslogdConfig on the message to the local config value -->
 			<bean ref="syslogdConfigProcessor"/>
-			<to uri="seda:syslogHandler"/>
+			<to uri="seda:syslogHandler?size=25000"/>
 		</route>
 
 		<route id="handleSyslogConnection">
-			<from uri="seda:syslogHandler?concurrentConsumers=8"/>
+			<from uri="seda:syslogHandler?concurrentConsumers=8&amp;size=25000&amp;blockWhenFull=true"/>
 			<!-- 
 				Pass the message to the default handler which will convert it into
 				an event and broadcast the event.

--- a/features/events/syslog/blueprint-syslog-handler-kafka-default.xml
+++ b/features/events/syslog/blueprint-syslog-handler-kafka-default.xml
@@ -54,11 +54,11 @@
 			<bean ref="mapper"/>
 			<!-- Update the SyslogdConfig on the message to the local config value -->
 			<bean ref="syslogdConfigProcessor"/>
-			<to uri="seda:syslogkafkaHandler"/>
+			<to uri="seda:syslogkafkaHandler?size=25000"/>
 		</route>
 
 		<route id="syslogHandler">
-			<from uri="seda:syslogkafkaHandler"/>
+			<from uri="seda:syslogkafkaHandler?concurrentConsumers=8&amp;size=25000&amp;blockWhenFull=true"/>
 			<!-- 
 				Pass the message to the default handler which will convert it into
 				an event and broadcast the event.

--- a/features/events/syslog/blueprint-syslog-handler-kafka.xml
+++ b/features/events/syslog/blueprint-syslog-handler-kafka.xml
@@ -24,7 +24,7 @@
 	<bean id="partitionKeyGenerator" class="org.opennms.core.camel.RandomPartitionKeyGenerator"/>
 
 	<bean id="syslogConnectionHandlerCamel" class="org.opennms.netmgt.syslogd.SyslogConnectionHandlerCamelImpl">
-		<argument value="seda:handleMessage"/>
+		<argument value="seda:handleMessage?size=25000"/>
 	</bean>
 
 	<service interface="org.opennms.netmgt.syslogd.SyslogConnectionHandler" ref="syslogConnectionHandlerCamel"/>
@@ -41,7 +41,7 @@
 		<propertyPlaceholder id="properties" location="blueprint:syslogHandlerKafkaProperties" />
 
 		<route id="syslogMarshal">
-			<from uri="seda:handleMessage?concurrentConsumers=4" />
+			<from uri="seda:handleMessage?concurrentConsumers=8&amp;size=25000&amp;blockWhenFull=true" />
 
 			<setHeader headerName="includeRawMessage">
 				<simple resultType="java.lang.Boolean">properties:includeRawMessage</simple>
@@ -51,11 +51,11 @@
 			<process ref="mapper"/>
 			<process ref="marshaller"/>
 
-			<to uri="seda:sendMessage"/>
+			<to uri="seda:sendMessage?size=25000"/>
 		</route>
 
 		<route id="syslogSendKafka">
-			<from uri="seda:sendMessage?concurrentConsumers=4" />
+			<from uri="seda:sendMessage?concurrentConsumers=8&amp;size=25000&amp;blockWhenFull=true" />
 
 			<!-- HZN-862: Use ByteArrayPartitioner instead of this key generator -->
 			<setHeader headerName="kafka.PARTITION_KEY">

--- a/features/events/syslog/blueprint-syslog-handler-kafka.xml
+++ b/features/events/syslog/blueprint-syslog-handler-kafka.xml
@@ -63,7 +63,7 @@
 			</setHeader>
 
 			<!-- Have to use StringEncoder because of camel bug CAMEL-8790 -->
-			<to uri="kafka:{{kafkaAddress}}?topic={{kafkatopic}}&amp;serializerClass=kafka.serializer.StringEncoder"/>
+			<to uri="kafka:{{kafkaAddress}}?topic={{kafkatopic}}&amp;serializerClass=kafka.serializer.StringEncoder&amp;producerType=async"/>
 		</route>
 	</camelContext>
 

--- a/features/events/syslog/blueprint-syslog-handler-minion.xml
+++ b/features/events/syslog/blueprint-syslog-handler-minion.xml
@@ -28,7 +28,7 @@
 	</cm:property-placeholder>
 
 	<bean id="syslogConnectionHandlerCamel" class="org.opennms.netmgt.syslogd.SyslogConnectionHandlerCamelImpl">
-		<argument value="seda:handleMessage"/>
+		<argument value="seda:handleMessage?size=25000"/>
 	</bean>
 
 	<service interface="org.opennms.netmgt.syslogd.SyslogConnectionHandler" ref="syslogConnectionHandlerCamel"/>
@@ -48,7 +48,7 @@
 		<propertyPlaceholder id="properties" location="blueprint:syslogHandlerMinionProperties" />
 
 		<route id="syslogMarshal">
-			<from uri="seda:handleMessage?concurrentConsumers=4" />
+			<from uri="seda:handleMessage?concurrentConsumers=8&amp;size=25000&amp;blockWhenFull=true" />
 
 			<setHeader headerName="includeRawMessage">
 				<simple resultType="java.lang.Boolean">properties:includeRawMessage</simple>
@@ -58,12 +58,12 @@
 			<process ref="mapper"/>
 			<process ref="marshaller"/>
 
-			<to uri="seda:sendMessage"/>
+			<to uri="seda:sendMessage?size=25000"/>
 		</route>
 
 		<route id="syslogSendJms">
 			<!-- Concurrent consumers gives a performance boost here because we have pooled connections to the JMS broker -->
-			<from uri="seda:sendMessage?concurrentConsumers=4"/>
+			<from uri="seda:sendMessage?concurrentConsumers=8&amp;size=25000&amp;blockWhenFull=true"/>
 			<!-- Broadcast the message over ActiveMQ -->
 			<!--
 				Turn off persistent messages to avoid the latency penalty: 

--- a/features/events/syslog/src/main/java/org/opennms/netmgt/syslogd/SyslogConnectionHandlerDefaultImpl.java
+++ b/features/events/syslog/src/main/java/org/opennms/netmgt/syslogd/SyslogConnectionHandlerDefaultImpl.java
@@ -45,18 +45,32 @@ public class SyslogConnectionHandlerDefaultImpl implements SyslogConnectionHandl
 	 * 
 	 * TODO: Make this configurable
 	 */
-	public static final int EVENT_PARSER_THREADS = Runtime.getRuntime().availableProcessors();
+	public static final int PARSER_THREADS = Runtime.getRuntime().availableProcessors();
 
 	/**
 	 * This is the number of threads that are used to broadcast the OpenNMS events.
 	 * 
 	 * TODO: Make this configurable
 	 */
-	public static final int EVENT_SENDER_THREADS = Runtime.getRuntime().availableProcessors();
+	public static final int SENDER_THREADS = Runtime.getRuntime().availableProcessors();
+
+	/**
+	 * Maximum size of the backlog queue for event processing.
+	 * 
+	 * TODO: Make this configurable
+	 */
+	public static final int PARSER_QUEUE_SIZE = 25000;
+
+	/**
+	 * Maximum size of the backlog queue for event sending.
+	 * 
+	 * TODO: Make this configurable
+	 */
+	public static final int SENDER_QUEUE_SIZE = 25000;
 
 	private final ExecutorFactory m_executorFactory = new ExecutorFactoryJavaImpl();
-	private final ExecutorService m_syslogConnectionExecutor = m_executorFactory.newExecutor(EVENT_PARSER_THREADS, Integer.MAX_VALUE, "OpenNMS.Syslogd", "syslogConnections");
-	private final ExecutorService m_syslogProcessorExecutor = m_executorFactory.newExecutor(EVENT_SENDER_THREADS, Integer.MAX_VALUE, "OpenNMS.Syslogd", "syslogProcessors");
+	private final ExecutorService m_syslogConnectionExecutor = m_executorFactory.newExecutor(PARSER_THREADS, PARSER_QUEUE_SIZE, "OpenNMS.Syslogd", "syslogConnections");
+	private final ExecutorService m_syslogProcessorExecutor = m_executorFactory.newExecutor(SENDER_THREADS, SENDER_QUEUE_SIZE, "OpenNMS.Syslogd", "syslogProcessors");
 
 	@Override
 	public void handleSyslogConnection(final SyslogConnection message) {

--- a/features/events/traps/blueprint-trapd-handler-default.xml
+++ b/features/events/traps/blueprint-trapd-handler-default.xml
@@ -72,11 +72,11 @@
 			<!-- TODO: Change these to <process> tags once Trapd is loaded from inside Karaf -->
 			<bean ref="unmarshaller"/>
 			<bean ref="mapper"/>
-			<to uri="seda:trapHandler"/>
+			<to uri="seda:trapHandler?size=25000"/>
 		</route>
 
 		<route id="trapHandler">
-			<from uri="seda:trapHandler?concurrentConsumers=4" />
+			<from uri="seda:trapHandler?concurrentConsumers=8&amp;size=25000&amp;blockWhenFull=true" />
 			<convertBodyTo type="org.opennms.netmgt.snmp.TrapNotification" />
 			<!--
 				Pass the message to the default handler which will convert it into 

--- a/features/events/traps/blueprint-trapd-handler-kafka-default.xml
+++ b/features/events/traps/blueprint-trapd-handler-kafka-default.xml
@@ -68,11 +68,11 @@
 			<!-- TODO: Change these to <process> tags once Trapd is loaded from inside Karaf -->
 			<bean ref="unmarshaller"/>
 			<bean ref="mapper"/>
-			<to uri="seda:trapHandler"/>
+			<to uri="seda:trapHandler?size=25000"/>
 		</route>
 
 		<route id="trapHandler">
-			<from uri="seda:trapHandler" />
+			<from uri="seda:trapHandler?concurrentConsumers=8&amp;size=25000&amp;blockWhenFull=true" />
 			<!--
 				Pass the message to the default handler which will convert it into 
 				an event and broadcast the event.

--- a/features/events/traps/blueprint-trapd-handler-kafka.xml
+++ b/features/events/traps/blueprint-trapd-handler-kafka.xml
@@ -66,7 +66,7 @@
 			</setHeader>
 
 			<!-- Have to use StringEncoder because of camel bug CAMEL-8790 -->
-			<to uri="kafka:{{kafkaAddress}}?topic={{kafkatopic}}&amp;serializerClass=kafka.serializer.StringEncoder"/>
+			<to uri="kafka:{{kafkaAddress}}?topic={{kafkatopic}}&amp;serializerClass=kafka.serializer.StringEncoder&amp;producerType=async"/>
 		</route>
 	</camelContext>
 </blueprint>

--- a/features/events/traps/blueprint-trapd-handler-minion.xml
+++ b/features/events/traps/blueprint-trapd-handler-minion.xml
@@ -28,7 +28,7 @@
 	</cm:property-placeholder>
 
 	<bean id="trapdNotificationHandlerCamel" class="org.opennms.netmgt.trapd.TrapNotificationHandlerCamelImpl">
-		<argument value="seda:handleMessage"/>
+		<argument value="seda:handleMessage?size=25000"/>
 	</bean>
 
 	<service interface="org.opennms.netmgt.trapd.TrapNotificationHandler" ref="trapdNotificationHandlerCamel"/>
@@ -52,7 +52,7 @@
 		<propertyPlaceholder id="properties" location="blueprint:trapHandlerMinionProperties" />
 
 		<route id="trapMarshal">
-			<from uri="seda:handleMessage?concurrentConsumers=4"/>
+			<from uri="seda:handleMessage?concurrentConsumers=8&amp;size=25000&amp;blockWhenFull=true"/>
 
 			<setHeader headerName="includeRawMessage">
 				<simple resultType="java.lang.Boolean">properties:includeRawMessage</simple>
@@ -62,11 +62,11 @@
 			<process ref="mapper"/>
 			<process ref="marshaller"/>
 
-			<to uri="seda:sendMessage"/>
+			<to uri="seda:sendMessage?size=25000"/>
 		</route>
 
 		<route id="trapSendJms">
-			<from uri="seda:sendMessage?concurrentConsumers=4"/>
+			<from uri="seda:sendMessage?concurrentConsumers=8&amp;size=25000&amp;blockWhenFull=true"/>
 
 			<!-- Broadcast the message over ActiveMQ -->
 			<!--

--- a/features/events/traps/src/main/java/org/opennms/netmgt/trapd/TrapNotificationHandlerDefaultImpl.java
+++ b/features/events/traps/src/main/java/org/opennms/netmgt/trapd/TrapNotificationHandlerDefaultImpl.java
@@ -48,8 +48,15 @@ public class TrapNotificationHandlerDefaultImpl implements TrapNotificationHandl
 	 */
 	public static final int TRAP_PROCESSOR_THREADS = Runtime.getRuntime().availableProcessors();
 
+	/**
+	 * Maximum size of the backlog queue for event processing.
+	 * 
+	 * TODO: Make this configurable
+	 */
+	public static final int QUEUE_SIZE = 25000;
+
 	private final ExecutorFactory m_executorFactory = new ExecutorFactoryJavaImpl();
-	private final ExecutorService m_processorExecutor = m_executorFactory.newExecutor(TRAP_PROCESSOR_THREADS, Integer.MAX_VALUE, "OpenNMS.Trapd", "trapProcessors");
+	private final ExecutorService m_processorExecutor = m_executorFactory.newExecutor(TRAP_PROCESSOR_THREADS, QUEUE_SIZE, "OpenNMS.Trapd", "trapProcessors");
 
 	private TrapQueueProcessorFactory m_processorFactory;
 


### PR DESCRIPTION
This PR limits the size of all of the SEDA queues and Executor queues to prevent OOMs under high load and it switches the Kafka producers on Minion to "async" mode to increase throughput.

Some of these changes will conflict with the sink work (since the SEDA queues have been removed) but the Kafka endpoint tweak needs to be merged over into the sink branch.

* JIRA: http://issues.opennms.org/browse/NMS-8948
* JIRA: http://issues.opennms.org/browse/NMS-8777
