### PR TITLE
NMS-4552: Auto-compile of jasper subreports

### DIFF
--- a/features/reporting/jasper-reports/src/main/java/org/opennms/reporting/jasperreports/svclayer/JasperReportService.java
+++ b/features/reporting/jasper-reports/src/main/java/org/opennms/reporting/jasperreports/svclayer/JasperReportService.java
@@ -408,6 +408,7 @@ public class JasperReportService implements ReportService {
 
         // Filter parameter for sub reports
         for (JRParameter parameter : mainReport.getParameters()) {
+            LOG.debug("buildSubreport: found main report parameter {} whose class is {}", parameter.getName(), parameter.getValueClassName());
             // We need only parameter for Sub reports and we *DON'T* need the default parameter JASPER_REPORT
             if ("net.sf.jasperreports.engine.JasperReport".equals(parameter.getValueClassName()) && !"JASPER_REPORT".equals(parameter.getName())) {
                 subreportMap.put(parameter.getName(), parameter.getValueClassName());
@@ -420,7 +421,7 @@ public class JasperReportService implements ReportService {
         }
 
         for (final Map.Entry<String,Object> entry : subreportMap.entrySet()) {
-            LOG.debug("Key: {} - Value: {}", entry.getKey(), entry.getValue());
+            LOG.debug("Main jasper report {}: Found subreport parameter Key: {} - Value: {}", mainReportId, entry.getKey(), entry.getValue());
         }
         return subreportMap;
     }
@@ -433,6 +434,7 @@ public class JasperReportService implements ReportService {
         try {
             Logging.withPrefix(LOG4J_CATEGORY, new Callable<Void>() {
                 @Override public Void call() throws Exception {
+                    LOG.debug("Rendering jasper report {}", reportId);
                     final JasperReport jasperReport = getJasperReport(reportId);
                     final Map<String, Object> jrReportParms = buildJRparameters(reportParms, jasperReport.getParameters());
                     jrReportParms.putAll(buildSubreport(reportId, jasperReport));
@@ -564,9 +566,11 @@ public class JasperReportService implements ReportService {
     private JasperReport getJasperReport(String reportId) throws ReportException {
         try {
             JasperReport report = JasperCompileManager.compileReport(m_globalReportRepository.getTemplateStream(reportId));
+            LOG.debug("Compiling jasper report {}, reportId);
             for (Object eachKey : System.getProperties().keySet()) {
                 String eachStringKey = (String) eachKey;
                 if (eachStringKey.startsWith("net.sf.jasperreports")) {
+                    LOG.debug("Adding property {} with value {}", eachStringKey, System.getProperty(eachStringKey));
                     report.setProperty(eachStringKey, System.getProperty(eachStringKey));
                 }
             }


### PR DESCRIPTION
This PR is a work-in progress to make OpenNMS be able to also automaticaly compile Jasper subreports at run-time (rather than only the main Jasper reports).

It is intended for ONMS v18 and would probably work for <subreportExpression> specified as plain text. 

<subreportExpression> containing references to report parameters, fields, or variables is an issue, and might require quite a lot of work.

I've also issues a PR against ONMS v19 at https://github.com/OpenNMS/opennms/pull/1181 but it should be in a worse state.

Here's an excerpt of reports.log when running this code:

> 2016-12-14 14:25:19,306 DEBUG [qtp2014033596-3421 - /opennms/report/database/onlineReport.htm?reportId=local_Belnet-Assets-Report] o.o.r.j.s.JasperReportService: jasper report local_Belnet-Assets-Report has been compiled
> 2016-12-14 14:25:19,307 DEBUG [qtp2014033596-3421 - /opennms/report/database/onlineReport.htm?reportId=local_Belnet-Assets-Report] o.o.r.j.s.JasperReportService: Visiting subreport P{SUBREPORT_DIR} + "BelnetAssetReport_NodesOSList.jrxml
> 2016-12-14 14:25:19,307 INFO  [qtp2014033596-3421 - /opennms/report/database/onlineReport.htm?reportId=local_Belnet-Assets-Report] o.o.r.j.s.JasperReportService: P{SUBREPORT_DIR} + "BelnetAssetReport_NodesOSList.jrxml needs to be compiled.
> 2016-12-14 14:25:19,308 ERROR [qtp2014033596-3421 - /opennms/report/database/onlineReport.htm?reportId=local_Belnet-Assets-Report] o.o.r.j.s.JasperReportService: unable to compile jasper subreport
> net.sf.jasperreports.engine.JRException: java.io.FileNotFoundException: P{SUBREPORT_DIR} + "BelnetAssetReport_NodesOSList.jrxml (No such file or directory)

* JIRA: https://issues.opennms.org/browse/NMS-4552

Our [continuous integration system](http://bamboo.internal.opennms.com:8085) will test and verify your changes.
