### PR TITLE
NMS-8896: Address memory leak in Enhanced Linkd

### DIFF
--- a/opennms-config-model/src/main/castor/enlinkd-configuration.xsd
+++ b/opennms-config-model/src/main/castor/enlinkd-configuration.xsd
@@ -50,6 +50,15 @@
 				</annotation>
 			</attribute>
 
+			<attribute name="max_bft" type="int"
+				use="optional" default="1">
+				<annotation>
+					<documentation>
+						Max bridge forwarding table to hold in memory.
+					</documentation>
+				</annotation>
+			</attribute>
+
 			<attribute name="use-cdp-discovery" type="boolean"
 				use="optional" default="true">
 				<annotation>

--- a/opennms-config/src/main/java/org/opennms/netmgt/config/EnhancedLinkdConfig.java
+++ b/opennms-config/src/main/java/org/opennms/netmgt/config/EnhancedLinkdConfig.java
@@ -52,6 +52,12 @@ public interface EnhancedLinkdConfig {
      */
     int getThreads();
 
+    /**
+     * <p>getMaxBft</p>
+     *
+     * @return a int.
+     */
+    int getMaxBft();
 
     /**
      * <p>getInitialSleepTime</p>

--- a/opennms-config/src/main/java/org/opennms/netmgt/config/EnhancedLinkdConfigManager.java
+++ b/opennms-config/src/main/java/org/opennms/netmgt/config/EnhancedLinkdConfigManager.java
@@ -158,6 +158,11 @@ abstract public class EnhancedLinkdConfigManager implements EnhancedLinkdConfig 
         if (m_config.hasThreads()) return m_config.getThreads();
         return 5;
     }
+    
+    public int getMaxBft() {
+        if (m_config.hasMax_bft()) return m_config.getMax_bft();
+        return 1;
+    }
 
     /**
      * <p>saveXml</p>

--- a/opennms-services/src/main/java/org/opennms/netmgt/enlinkd/EnhancedLinkd.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/enlinkd/EnhancedLinkd.java
@@ -579,4 +579,7 @@ public class EnhancedLinkd extends AbstractServiceDaemon {
             return m_linkdConfig.getRescanInterval(); 
     }
 
+    public int getMaxbft() {
+        return m_linkdConfig.getMaxBft();
+    }
 }

--- a/opennms-services/src/main/java/org/opennms/netmgt/enlinkd/EnhancedLinkd.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/enlinkd/EnhancedLinkd.java
@@ -294,23 +294,28 @@ public class EnhancedLinkd extends AbstractServiceDaemon {
     }
 
     public boolean runSingleSnmpCollection(final int nodeId) {
+        boolean allready = true;
             final Node node = m_queryMgr.getSnmpNode(nodeId);
 
             for (final NodeDiscovery snmpColl : getSnmpCollections(node)) {
                 if (snmpColl instanceof NodeDiscoveryBridgeTopology)
                     continue;
+                if (!snmpColl.isReady()) {
+                    allready = false;
+                    continue;
+                }
                 snmpColl.setScheduler(m_scheduler);
                 snmpColl.run();
             }
 
-            return true;
+            return allready;
     }
 
     public boolean runTopologyDiscovery(final int nodeId) {
         final Node node = m_queryMgr.getSnmpNode(nodeId);
 
         for (final NodeDiscovery snmpColl : getSnmpCollections(node)) {
-            if (snmpColl instanceof NodeDiscoveryBridgeTopology) {
+            if (snmpColl instanceof NodeDiscoveryBridgeTopology && snmpColl.isReady()) {
                 snmpColl.setScheduler(m_scheduler);
                 snmpColl.run();
                 return true;

--- a/opennms-services/src/main/java/org/opennms/netmgt/enlinkd/NodeDiscoveryBridge.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/enlinkd/NodeDiscoveryBridge.java
@@ -488,4 +488,9 @@ public final class NodeDiscoveryBridge extends NodeDiscovery {
         return "BridgeLinkDiscovery";
     }
 
+    @Override
+    public boolean isReady() {
+        LOG.info("isReady: node: {}, maxBft {}, updateMapsixe {}.", getNodeId(),m_linkd.getMaxbft(),m_linkd.getQueryManager().getUpdateBftMap().size());
+        return m_linkd.getQueryManager().getUpdateBftMap().size() < m_linkd.getMaxbft();
+    }
 }

--- a/opennms-services/src/main/java/org/opennms/netmgt/enlinkd/NodeDiscoveryBridgeTopology.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/enlinkd/NodeDiscoveryBridgeTopology.java
@@ -488,17 +488,10 @@ public class NodeDiscoveryBridgeTopology extends NodeDiscovery {
 
     public NodeDiscoveryBridgeTopology(EnhancedLinkd linkd, Node node) {
         super(linkd, node);
-        setInitialSleepTime(linkd.getInitialSleepTime()+180000);
     }
 
     @Override
-    public void run() {
-        if (!m_linkd.getQueryManager().hasUpdatedBft(getNodeId())) {
-            LOG.info("run: node: {}, without updated bft. Rescheduling");
-            reschedule();
-            return;
-        }
-        
+    public void run() {        
         Date now = new Date();
                 
         Set<String> incomingSet = new HashSet<String>();
@@ -1079,6 +1072,16 @@ public class NodeDiscoveryBridgeTopology extends NodeDiscovery {
                 return null;
             }
         return goUp(up, bridge,++level);
+    }
+    
+    @Override
+    public boolean isReady() {
+        if (!m_linkd.getQueryManager().hasUpdatedBft(getNodeId())) {
+            LOG.info("isReady: node: {}, without updated bft. Topology Discovery Not Ready", getNodeId());
+            return false;
+        }
+        return true;
+
     }
 }
 

--- a/opennms-services/src/main/java/org/opennms/netmgt/enlinkd/scheduler/Scheduler.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/enlinkd/scheduler/Scheduler.java
@@ -529,117 +529,119 @@ public class Scheduler implements Runnable, PausableFiber, ScheduleTimer {
 	 * the runnable queues for ready objects and then enqueuing them into the
 	 * thread pool for execution.
 	 */
-        @Override
-	public void run() {
+    @Override
+    public void run() {
 
-		synchronized (this) {
-			m_status = RUNNING;
-		}
+        synchronized (this) {
+            m_status = RUNNING;
+        }
 
-		LOG.debug("run: scheduler running");
+        LOG.debug("run: scheduler running");
 
-		// Loop until a fatal exception occurs or until
-		// the thread is interrupted.
-		//
-		for (;;) {
-			// block if there is nothing in the queue(s)
-			// When something is added to the queue it
-			// signals us to wakeup
-			//
-			synchronized (this) {
-				if (m_status != RUNNING && m_status != PAUSED
-						&& m_status != PAUSE_PENDING
-						&& m_status != RESUME_PENDING) {
-				    LOG.debug("run: status = {}, time to exit", m_status);
-					break;
-				}
+        // Loop until a fatal exception occurs or until
+        // the thread is interrupted.
+        //
+        for (;;) {
+            // block if there is nothing in the queue(s)
+            // When something is added to the queue it
+            // signals us to wakeup
+            //
+            synchronized (this) {
+                if (m_status != RUNNING && m_status != PAUSED
+                        && m_status != PAUSE_PENDING
+                        && m_status != RESUME_PENDING) {
+                    LOG.debug("run: status = {}, time to exit", m_status);
+                    break;
+                }
 
-				if (m_scheduled == 0) {
-					try {
-					    LOG.debug("run: no interfaces scheduled, waiting...");
-						wait();
-					} catch (InterruptedException ex) {
-						break;
-					}
-				}
-			}
+                if (m_scheduled == 0) {
+                    try {
+                        LOG.debug("run: no interfaces scheduled, waiting...");
+                        wait();
+                    } catch (InterruptedException ex) {
+                        break;
+                    }
+                }
+            }
 
-			// cycle through the queues checking for
-			// what's ready to run. The queues are keyed
-			// by the interval, but the mapped elements
-			// are peekable fifo queues.
-			//
-			int runned = 0;
-			synchronized (m_queues) {
-				// get an iterator so that we can cycle
-				// through the queue elements.
-				//
-				Iterator<Long> iter = m_queues.keySet().iterator();
-				while (iter.hasNext()) {
-					// Peak for Runnable objects until
-					// there are no more ready runnables
-					//
-					// Also, only go through each queue once!
-					// if we didn't add a count then it would
-					// be possible to starve other queues.
-					//
-					Long key = iter.next();
-					PeekableFifoQueue<ReadyRunnable> in = m_queues.get(key);
-					if (in.isEmpty()) {
-						continue;
-					}
-					ReadyRunnable readyRun = null;
-					int maxLoops = in.size();
-					do {
-						try {
-							readyRun = in.peek();
-							if (readyRun != null)
-                                                            // Pop the interface/readyRunnable from the
-                                                            // queue for execution.
-                                                            //
-                                                            in.remove();
-							    
-							if (readyRun.isReady()) {
-							    LOG.debug("run: found ready runnable {}", readyRun.getInfo());
+            // cycle through the queues checking for
+            // what's ready to run. The queues are keyed
+            // by the interval, but the mapped elements
+            // are peekable fifo queues.
+            //
+            int runned = 0;
+            synchronized (m_queues) {
+                // get an iterator so that we can cycle
+                // through the queue elements.
+                //
+                Iterator<Long> iter = m_queues.keySet().iterator();
+                while (iter.hasNext()) {
+                    // Peak for Runnable objects until
+                    // there are no more ready runnables
+                    //
+                    // Also, only go through each queue once!
+                    // if we didn't add a count then it would
+                    // be possible to starve other queues.
+                    //
+                    Long key = iter.next();
+                    PeekableFifoQueue<ReadyRunnable> in = m_queues.get(key);
+                    if (in == null || in.isEmpty()) {
+                        continue;
+                    }
+                    ReadyRunnable readyRun = null;
+                    int maxLoops = in.size();
+                    do {
+                        try {
+                            readyRun = in.peek();
+                            if (readyRun != null) {
+                                // Pop the interface/readyRunnable from the
+                                // queue for execution.
+                                //
+                                in.remove();
 
+                                if (readyRun.isReady()) {
+                                    LOG.debug("run: found ready runnable {}",
+                                              readyRun.getInfo());
 
-								// Add runnable to the execution queue
-								m_runner.execute(readyRun);
-								++runned;
-							} else {
-                                                            LOG.debug("run: not ready ready runnable {}", readyRun.getInfo());
-							    in.add(readyRun);
-							}
-						} catch (InterruptedException ex) {
-							return; // jump all the way out
-						}
-					} while (readyRun != null && --maxLoops > 0);
-				}
-				
-			}
+                                    // Add runnable to the execution queue
+                                    m_runner.execute(readyRun);
+                                    ++runned;
+                                } else {
+                                    LOG.debug("run: not ready ready runnable {}",
+                                              readyRun.getInfo());
+                                    in.add(readyRun);
+                                }
+                            }
+                        } catch (InterruptedException ex) {
+                            return; // jump all the way out
+                        }
+                    } while (--maxLoops > 0);
+                }
 
-			// Wait for 1 second if there were no runnables
-			// executed during this loop, otherwise just
-			// start over.
-			//
-			synchronized (this) {
-				m_scheduled -= runned;
-				if (runned == 0) {
-					try {
-						wait(1000);
-					} catch (InterruptedException ex) {
-						break; // exit for loop
-					}
-				}
-			}
+            }
 
-		} // end for(;;)
+            // Wait for 1 second if there were no runnables
+            // executed during this loop, otherwise just
+            // start over.
+            //
+            synchronized (this) {
+                m_scheduled -= runned;
+                if (runned == 0) {
+                    try {
+                        wait(1000);
+                    } catch (InterruptedException ex) {
+                        break; // exit for loop
+                    }
+                }
+            }
 
-		LOG.debug("run: scheduler exiting, state = STOPPED");
-		synchronized (this) {
-			m_status = STOPPED;
-		}
+        } // end for(;;)
 
-	} // end run
-	
+        LOG.debug("run: scheduler exiting, state = STOPPED");
+        synchronized (this) {
+            m_status = STOPPED;
+        }
+
+    } // end run
+
 }

--- a/opennms-services/src/test/java/org/opennms/netmgt/enlinkd/Nms7918EnIT.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/enlinkd/Nms7918EnIT.java
@@ -158,7 +158,7 @@ public class Nms7918EnIT extends EnLinkdBuilderITCase {
             printBridgeMacLink(link);
         }
 
-        assertTrue(m_linkd.runTopologyDiscovery(stcasw01.getId()));
+        assertTrue(!m_linkd.runTopologyDiscovery(stcasw01.getId()));
 
         assertEquals(0,m_bridgeBridgeLinkDao.countAll());
         assertEquals(0,m_bridgeMacLinkDao.countAll());
@@ -264,7 +264,7 @@ public class Nms7918EnIT extends EnLinkdBuilderITCase {
             printBridgeMacLink(link);
         }
 
-        assertTrue(m_linkd.runTopologyDiscovery(samasw01.getId()));
+        assertTrue(!m_linkd.runTopologyDiscovery(samasw01.getId()));
 
         assertEquals(0,m_bridgeBridgeLinkDao.countAll());
         assertEquals(0,m_bridgeMacLinkDao.countAll());
@@ -370,7 +370,7 @@ public class Nms7918EnIT extends EnLinkdBuilderITCase {
             printBridgeMacLink(link);
         }
 
-        assertTrue(m_linkd.runTopologyDiscovery(asw01.getId()));
+        assertTrue(!m_linkd.runTopologyDiscovery(asw01.getId()));
 
         assertEquals(0,m_bridgeBridgeLinkDao.countAll());
         assertEquals(0,m_bridgeMacLinkDao.countAll());
@@ -458,6 +458,7 @@ public class Nms7918EnIT extends EnLinkdBuilderITCase {
         m_linkdConfig.getConfiguration().setUseOspfDiscovery(false);
         m_linkdConfig.getConfiguration().setUseLldpDiscovery(false);
         m_linkdConfig.getConfiguration().setUseIsisDiscovery(false);
+        m_linkdConfig.getConfiguration().setMax_bft(3);
         assertTrue(!m_linkdConfig.useLldpDiscovery());
         assertTrue(!m_linkdConfig.useCdpDiscovery());
         assertTrue(!m_linkdConfig.useOspfDiscovery());
@@ -482,17 +483,13 @@ public class Nms7918EnIT extends EnLinkdBuilderITCase {
         assertEquals(0,m_bridgeMacLinkDao.countAll());
         
         assertTrue(m_linkd.runTopologyDiscovery(asw01.getId()));
+        assertTrue(!m_linkd.runTopologyDiscovery(samasw01.getId()));
+        assertTrue(!m_linkd.runTopologyDiscovery(stcasw01.getId()));
         assertEquals(3,m_bridgeElementDao.countAll());
         assertEquals(0,m_bridgeStpLinkDao.countAll());
         assertEquals(2,m_bridgeBridgeLinkDao.countAll());
         assertEquals(91,m_bridgeMacLinkDao.countAll());
 
-        assertTrue(m_linkd.runTopologyDiscovery(samasw01.getId()));
-        assertTrue(m_linkd.runTopologyDiscovery(stcasw01.getId()));
-        assertEquals(3,m_bridgeElementDao.countAll());
-        assertEquals(0,m_bridgeStpLinkDao.countAll());
-        assertEquals(2,m_bridgeBridgeLinkDao.countAll());
-        assertEquals(91,m_bridgeMacLinkDao.countAll());
 
         for (BridgeBridgeLink bblink : m_bridgeBridgeLinkDao.findAll()) {
             printBridgeBridgeLink(bblink);
@@ -715,6 +712,8 @@ public class Nms7918EnIT extends EnLinkdBuilderITCase {
         m_linkdConfig.getConfiguration().setUseOspfDiscovery(false);
         m_linkdConfig.getConfiguration().setUseLldpDiscovery(false);
         m_linkdConfig.getConfiguration().setUseIsisDiscovery(false);
+        m_linkdConfig.getConfiguration().setMax_bft(2);
+
         assertTrue(!m_linkdConfig.useLldpDiscovery());
         assertTrue(!m_linkdConfig.useCdpDiscovery());
         assertTrue(!m_linkdConfig.useOspfDiscovery());
@@ -743,7 +742,7 @@ public class Nms7918EnIT extends EnLinkdBuilderITCase {
         assertEquals(1,m_bridgeBridgeLinkDao.countAll());
         assertEquals(67,m_bridgeMacLinkDao.countAll());
 
-        assertTrue(m_linkd.runTopologyDiscovery(samasw01.getId()));
+        assertTrue(!m_linkd.runTopologyDiscovery(samasw01.getId()));
         assertTrue(m_linkd.runSingleSnmpCollection(stcasw01.getId()));
         assertTrue(m_linkd.runTopologyDiscovery(stcasw01.getId()));
         assertEquals(3,m_bridgeElementDao.countAll());


### PR DESCRIPTION
This is a Fix for Issue NMS-8896
 
Memory Leak for enhancedLinkd

Check details on https://issues.opennms.org/browse/NMS-8896

Cretaed a new configuration attribute max_bft with default value 1.

The BridgeDiscovery is done if the number of bridge forwarding table saved into memory is less then max_bft. 

This is a simple mechanism to save memory to be exausted by the bridge forwarding table.