### PR TITLE
HZN-983: Make the 'hawtio-offline' feature available on the default repository for Minion

### DIFF
--- a/features/minion/repository/pom.xml
+++ b/features/minion/repository/pom.xml
@@ -11,6 +11,10 @@
     <packaging>pom</packaging>
     <name>OpenNMS :: Features :: Minion :: Default Repository</name>
 
+    <properties>
+        <minionHawtioVersion>2.0.0</minionHawtioVersion>
+    </properties>
+
     <build>
         <plugins>
             <plugin>
@@ -35,6 +39,8 @@
                                 <descriptor>mvn:org.opennms.karaf/opennms/${project.version}/xml/features</descriptor>
                                 <!-- Add Minion features -->
                                 <descriptor>mvn:org.opennms.karaf/opennms/${project.version}/xml/minion</descriptor>
+                                <!-- Additional tools -->
+                                <descriptor>mvn:io.hawt/hawtio-karaf/${minionHawtioVersion}/xml/features</descriptor>
                             </descriptors>
                             <!-- To ensure that all JAR files for a feature 
                                 are included in the repository tar.gz file, add the feature to this list. -->
@@ -53,6 +59,7 @@
                                 <feature>minion-provisiond-detectors</feature>
                                 <feature>minion-poller</feature>
                                 <feature>minion-icmp-proxy</feature>
+                                <feature>hawtio-offline</feature>
                             </features>
                             <repository>target/maven-repo</repository>
                         </configuration>

--- a/features/minion/repository/src/main/resources/features.uri
+++ b/features/minion/repository/src/main/resources/features.uri
@@ -1,1 +1,2 @@
 mvn:org.opennms.karaf/opennms/${project.version}/xml/minion
+mvn:io.hawt/hawtio-karaf/${minionHawtioVersion}/xml/features

--- a/features/minion/runInPlace.sh
+++ b/features/minion/runInPlace.sh
@@ -26,6 +26,9 @@ mkdir -p "$MINION_HOME/repositories/default"
 tar zxvf repository-*-repo.tar.gz -C "$MINION_HOME/repositories/default"
 popd
 
+# Enable Hawtio
+echo 'hawtio-offline' > "$MINION_HOME/etc/featuresBoot.d/hawtio.boot"
+
 # Start the container as root (currently required for ICMP)
 pushd "$MINION_HOME"
 sudo ./bin/karaf debug


### PR DESCRIPTION
JIRA: https://issues.opennms.org/browse/HZN-983

This patch allows includes Hawtio in the default repository, which some in handy for debugging.

We do not enable it by default in the RPMs.

It can be installed by running `feature:install hawtio-offline` in the Karaf shell (or adding it to featuresBoot.d).


