### PR TITLE
NMS-8962: Skip /var/lock/subsys actions when running as unprivileged user

### DIFF
--- a/opennms-base-assembly/src/main/filtered/bin/opennms
+++ b/opennms-base-assembly/src/main/filtered/bin/opennms
@@ -776,7 +776,9 @@ case "$COMMAND" in
 			ret=$?
 			if [ $ret -eq 0 ]; then
 				echo_success
-				touch /var/lock/subsys/${NAME}
+				if [ -w /var/lock/subsys ]; then
+					touch /var/lock/subsys/${NAME}
+				fi
 			else
 				echo_failure
 			fi
@@ -809,7 +811,9 @@ case "$COMMAND" in
 			else
 				echo_failure
 			fi
-			rm -f /var/lock/subsys/${NAME}
+			if [ -w /var/lock/subsys ]; then
+				rm -f /var/lock/subsys/${NAME}
+			fi
 			echo ""
 
 			doKill


### PR DESCRIPTION
* JIRA: http://issues.opennms.org/browse/NMS-8962

Should be zero-impact, but review requested since start/stop is pretty visible and a bit fragile. Bamboo pending.