### PR TITLE
NMS-8963: Add logAllEvents config parameter to Elasticsearch forwarder

### DIFF
--- a/features/elasticsearch/event-forwarder/src/main/java/org/opennms/features/elasticsearch/eventforwarder/ElasticsearchNorthbounder.java
+++ b/features/elasticsearch/event-forwarder/src/main/java/org/opennms/features/elasticsearch/eventforwarder/ElasticsearchNorthbounder.java
@@ -35,7 +35,9 @@ public class ElasticsearchNorthbounder extends AbstractNorthbounder {
     @Override
     public void forwardAlarms(List<NorthboundAlarm> alarms) throws NorthbounderException {
         for(NorthboundAlarm alarm: alarms) {
-            LOG.trace("ElasticsearchNorthbounder Forwarding alarm: "+alarm);
+            if (LOG.isTraceEnabled()) {
+                LOG.trace("ElasticsearchNorthbounder Forwarding alarm: "+alarm);
+            }
             alarmForwarder.sendNow(alarm);
         }
     }

--- a/features/elasticsearch/event-forwarder/src/main/java/org/opennms/features/elasticsearch/eventforwarder/ForwardingEventListener.java
+++ b/features/elasticsearch/event-forwarder/src/main/java/org/opennms/features/elasticsearch/eventforwarder/ForwardingEventListener.java
@@ -51,6 +51,7 @@ public class ForwardingEventListener implements EventListener {
 	private volatile EventIpcManager eventIpcManager;
 	private volatile NodeDao nodeDao;
 	private volatile TransactionTemplate transactionTemplate;
+	private volatile boolean logAllEvents = false;
 
 	public CamelEventForwarder getEventForwarder() {
 		return eventForwarder;
@@ -82,6 +83,14 @@ public class ForwardingEventListener implements EventListener {
 
 	public void setTransactionTemplate(TransactionTemplate transactionTemplate) {
 		this.transactionTemplate = transactionTemplate;
+	}
+
+	public boolean isLogAllEvents() {
+		return logAllEvents;
+	}
+
+	public void setLogAllEvents(boolean logAllEvents) {
+		this.logAllEvents = logAllEvents;
 	}
 
 	/**
@@ -121,7 +130,7 @@ public class ForwardingEventListener implements EventListener {
 	@Override
 	public void onEvent(final Event event) {
 		// only process events persisted to database
-		if(event.getDbid()!=null && event.getDbid()!=0) {
+		if(logAllEvents || (event.getDbid() != null && event.getDbid() > 0)) {
 			// Send the event to the event forwarder
 			eventForwarder.sendNow(event);
 		}

--- a/features/elasticsearch/event-forwarder/src/main/java/org/opennms/features/elasticsearch/eventforwarder/internal/DefaultAlarmForwarder.java
+++ b/features/elasticsearch/event-forwarder/src/main/java/org/opennms/features/elasticsearch/eventforwarder/internal/DefaultAlarmForwarder.java
@@ -6,7 +6,7 @@ import org.opennms.netmgt.alarmd.api.NorthboundAlarm;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class DefaultAlarmForwarder extends DefaultDispatcher {
+public class DefaultAlarmForwarder extends DefaultDispatcher implements CamelAlarmForwarder {
 
 	private static final Logger LOG = LoggerFactory.getLogger(DefaultAlarmForwarder.class);
 
@@ -17,6 +17,7 @@ public class DefaultAlarmForwarder extends DefaultDispatcher {
 		super(endpointUri);
 	}
 
+	@Override
 	public void sendNow(NorthboundAlarm alarm) {
 		if(LOG.isTraceEnabled()) {
 			LOG.trace("forwarding alarm " + alarm);

--- a/features/elasticsearch/event-forwarder/src/main/java/org/opennms/features/elasticsearch/eventforwarder/internal/ElMappingLoader.java
+++ b/features/elasticsearch/event-forwarder/src/main/java/org/opennms/features/elasticsearch/eventforwarder/internal/ElMappingLoader.java
@@ -1,13 +1,12 @@
 package org.opennms.features.elasticsearch.eventforwarder.internal;
 
-import org.apache.camel.Exchange;
-import org.apache.camel.Message;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+
+import org.apache.camel.Exchange;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This processor bean replaces the message body with the content of the elmapping.json file
@@ -22,7 +21,7 @@ import java.io.InputStreamReader;
  * Date: 7:03 PM 6/25/15
  */
 public class ElMappingLoader {
-    Logger logger = LoggerFactory.getLogger(ElMappingLoader.class);
+    private static final Logger LOG = LoggerFactory.getLogger(ElMappingLoader.class);
 
     public void process(Exchange exchange) {
         StringBuffer body=new StringBuffer();
@@ -34,7 +33,7 @@ public class ElMappingLoader {
                 body.append(l);
             }
         } catch (IOException e) {
-            logger.error("Cannot read elasticsearch mapping file", e);
+            LOG.error("Cannot read elasticsearch mapping file", e);
         }
 
         exchange.getOut().setBody(body.toString());

--- a/features/elasticsearch/event-forwarder/src/main/resources/OSGI-INF/blueprint/blueprint-event-forwarder.xml
+++ b/features/elasticsearch/event-forwarder/src/main/resources/OSGI-INF/blueprint/blueprint-event-forwarder.xml
@@ -23,6 +23,7 @@
     <cm:default-properties>
         <cm:property name="elasticsearchCluster" value="opennms"/>
         <cm:property name="elasticsearchIp" value="127.0.0.1"/>
+        <cm:property name="logAllEvents" value="false"/>
         <cm:property name="logEventDescription" value="false"/>
         <cm:property name="cache_max_ttl" value="0"/> <!-- set to zero to disable TTL -->
         <cm:property name="cache_max_size" value="10000"/> <!-- set to zero to disable max size -->
@@ -46,6 +47,7 @@
   <bean id="eventListener" class="org.opennms.features.elasticsearch.eventforwarder.ForwardingEventListener" init-method="init" destroy-method="destroy">
     <property name="eventIpcManager" ref="eventIpcManager" />
     <property name="eventForwarder" ref="eventForwarder" />
+    <property name="logAllEvents" value="${logAllEvents}"/>
   </bean>
 
   <reference id="eventIpcManager" interface="org.opennms.netmgt.events.api.EventIpcManager" availability="mandatory"/>


### PR DESCRIPTION
This allows you to forward events to Elasticsearch even if they aren't stored in the OpenNMS database. There are also some logging speed improvements in this commit.

* JIRA: http://issues.opennms.org/browse/NMS-8963
