### PR TITLE
NMS-8957: Alarmd: Only start transactions for events with alarm data

### DIFF
--- a/opennms-alarms/daemon/src/main/java/org/opennms/netmgt/alarmd/AlarmPersister.java
+++ b/opennms-alarms/daemon/src/main/java/org/opennms/netmgt/alarmd/AlarmPersister.java
@@ -30,10 +30,9 @@ package org.opennms.netmgt.alarmd;
 
 import org.opennms.netmgt.model.OnmsAlarm;
 import org.opennms.netmgt.xml.event.Event;
-import org.springframework.transaction.annotation.Transactional;
 
 /**
- * AlarmPersting Interface
+ * Alarm persisting interface.
  *
  * @author <a href="mailto:david@opennms.org">David Hustace</a>
  * @version $Id: $
@@ -46,7 +45,6 @@ public interface AlarmPersister {
      * @param event a {@link org.opennms.netmgt.xml.event.Event} object.
      * @return 
      */
-    @Transactional
-    public abstract OnmsAlarm persist(Event event);
+    OnmsAlarm persist(Event event);
 
 }

--- a/opennms-alarms/daemon/src/main/resources/META-INF/opennms/applicationContext-alarmd.xml
+++ b/opennms-alarms/daemon/src/main/resources/META-INF/opennms/applicationContext-alarmd.xml
@@ -10,6 +10,7 @@
   <tx:annotation-driven />
 
   <bean id="alarmPersister" class="org.opennms.netmgt.alarmd.AlarmPersisterImpl" >
+    <property name="transactionOperations" ref="transactionTemplate" />
     <property name="alarmDao" ref="alarmDao" />
     <property name="eventDao" ref="eventDao" />
     <property name="eventForwarder" ref="eventForwarder"/>

--- a/opennms-alarms/daemon/src/test/java/org/opennms/netmgt/alarmd/AlarmdIT.java
+++ b/opennms-alarms/daemon/src/test/java/org/opennms/netmgt/alarmd/AlarmdIT.java
@@ -311,7 +311,7 @@ public class AlarmdIT implements TemporaryDatabaseAware<MockDatabase>, Initializ
     @Test
     public void testNullEvent() throws Exception {
         ThrowableAnticipator ta = new ThrowableAnticipator();
-        ta.anticipate(new IllegalArgumentException("event argument must not be null"));
+        ta.anticipate(new IllegalArgumentException("Incoming event was null, aborting"));
         try {
             m_alarmd.getPersister().persist(null);
         } catch (Throwable t) {


### PR DESCRIPTION
This should make Alarmd's event listener more efficient.

* JIRA: http://issues.opennms.org/browse/NMS-8957
