### PR TITLE
NMS-8976: Prevent dataCollectionFailed alarms on OpenNMS restart with Minion

### DIFF
--- a/opennms-services/src/main/java/org/opennms/netmgt/collectd/CollectableService.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/collectd/CollectableService.java
@@ -342,6 +342,9 @@ final class CollectableService implements ReadyRunnable {
             } catch (CollectionWarning e) {
                 LOG.warn(e.getMessage(), e);
                 updateStatus(ServiceCollector.COLLECTION_FAILED, e);
+            } catch (CollectionUnknown e) {
+                LOG.warn(e.getMessage(), e);
+                // Omit any status updates
             } catch (CollectionException e) {
                 LOG.error(e.getMessage(), e);
                 updateStatus(ServiceCollector.COLLECTION_FAILED, e);

--- a/opennms-services/src/main/java/org/opennms/netmgt/collectd/CollectionUnknown.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/collectd/CollectionUnknown.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2017-2017 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.collectd;
+
+import org.opennms.netmgt.collection.api.CollectionException;
+
+/**
+ * This exception should be thrown by a {@link ServiceCollector} when
+ * collection fails, but should not trigger a status change (resulting
+ * in an alarm) for target service.
+ *
+ * For example, collection may fail if the OpenNMS system is in the process
+ * of shutting down, and required components are not available.
+ *
+ * @author jesse
+ */
+public class CollectionUnknown extends CollectionException {
+
+    private static final long serialVersionUID = 5630156328994222706L;
+
+    public CollectionUnknown(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+}


### PR DESCRIPTION
JIRA: https://issues.opennms.org/browse/NMS-8976

Omit changing collectd's service status and generating events if the RPC is not executed.