### PR TITLE
HZN-980: Add 'blockWhenFull' configuration property to Eventd

### DIFF
--- a/features/events/daemon/pom.xml
+++ b/features/events/daemon/pom.xml
@@ -97,5 +97,10 @@
       <artifactId>mockito-all</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.jayway.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/features/events/daemon/src/main/java/org/opennms/netmgt/eventd/DefaultEventHandlerImpl.java
+++ b/features/events/daemon/src/main/java/org/opennms/netmgt/eventd/DefaultEventHandlerImpl.java
@@ -178,7 +178,7 @@ public final class DefaultEventHandlerImpl implements InitializingBean, EventHan
      */
     @Override
     public void afterPropertiesSet() throws IllegalStateException {
-        Assert.state(m_eventProcessors != null, "property eventPersisters must be set");
+        Assert.state(m_eventProcessors != null, "property eventProcessors must be set");
     }
 
     /**

--- a/features/events/daemon/src/main/java/org/opennms/netmgt/eventd/EventIpcManagerDefaultImpl.java
+++ b/features/events/daemon/src/main/java/org/opennms/netmgt/eventd/EventIpcManagerDefaultImpl.java
@@ -103,7 +103,7 @@ public class EventIpcManagerDefaultImpl implements EventIpcManager, EventIpcBroa
                 if (!super.offer(event)) {
                     // If the queue is full, run on current thread
                     LOG.warn("Execution queue is full, executing Runnable on current thread");
-                    event.run();
+                    Logging.withPrefix(Eventd.LOG4J_CATEGORY, event);
                 }
                 return true;
             } else {
@@ -255,7 +255,11 @@ public class EventIpcManagerDefaultImpl implements EventIpcManager, EventIpcBroa
                         // Make sure we restore our log4j logging prefix after onEvent is called
                         Map<String,String> mdc = Logging.getCopyOfContextMap();
                         try {
-                            m_listener.onEvent(event);
+                            // Synchronize on the listener because the onEvent() methods are not
+                            // always threadsafe
+                            synchronized(m_listener) {
+                                m_listener.onEvent(event);
+                            }
                         } finally {
                             Logging.setContextMap(mdc);
                         }

--- a/features/events/daemon/src/main/resources/META-INF/opennms/applicationContext-eventDaemon.xml
+++ b/features/events/daemon/src/main/resources/META-INF/opennms/applicationContext-eventDaemon.xml
@@ -51,6 +51,7 @@
     <constructor-arg ref="eventdMetricRegistry"/>
     <property name="handlerPoolSize" ref="eventIpcManagerHandlerPoolSize"/>
     <property name="handlerQueueLength" ref="eventIpcManagerHandlerQueueLength"/>
+    <property name="handlerBlockWhenFull" ref="eventIpcManagerHandlerBlockWhenFull"/>
     <property name="eventHandler" ref="eventdEventHandler"/>
   </bean>
 
@@ -75,8 +76,9 @@
 
   <bean id="eventIpcManagerHandlerPoolSize" factory-bean="eventdConfigManager" factory-method="getReceivers"/>
   <bean id="eventIpcManagerHandlerQueueLength" factory-bean="eventdConfigManager" factory-method="getQueueLength"/>
+  <bean id="eventIpcManagerHandlerBlockWhenFull" factory-bean="eventdConfigManager" factory-method="getBlockWhenFull"/>
   <bean id="shouldLogEventSummaries" factory-bean="eventdConfigManager" factory-method="shouldLogEventSummaries"/>
-  
+
   <bean id="eventdEventHandler" class="org.opennms.netmgt.eventd.DefaultEventHandlerImpl">
     <constructor-arg ref="eventdMetricRegistry"/>
     <property name="eventProcessors">

--- a/features/executor-factory/cassandra/src/main/java/org/opennms/core/concurrent/cassandra/ExecutorFactoryCassandraSEPImpl.java
+++ b/features/executor-factory/cassandra/src/main/java/org/opennms/core/concurrent/cassandra/ExecutorFactoryCassandraSEPImpl.java
@@ -29,6 +29,7 @@
 package org.opennms.core.concurrent.cassandra;
 
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.RejectedExecutionHandler;
 
 import org.apache.cassandra.concurrent.JMXEnabledSharedExecutorPool;
 import org.apache.cassandra.concurrent.SharedExecutorPool;
@@ -67,5 +68,14 @@ public class ExecutorFactoryCassandraSEPImpl implements ExecutorFactory {
 	public ExecutorService newExecutor(int threads, int queueSize, String daemonName, String executorName) {
 		// Yes, the last two arguments are supposed to be reversed
 		return SHARED.newExecutor(threads, queueSize, executorName, daemonName);
+	}
+
+	/**
+	 * @deprecated Using a {@link RejectedExecutionHandler} with this executor is unsupported.
+	 */
+	@Deprecated
+	@Override
+	public ExecutorService newExecutor(int threads, int queueSize, String daemonName, String executorName, RejectedExecutionHandler handler) {
+		return newExecutor(threads, queueSize, executorName, daemonName);
 	}
 }

--- a/opennms-config-model/src/main/castor/eventd-configuration.xsd
+++ b/opennms-config-model/src/main/castor/eventd-configuration.xsd
@@ -88,6 +88,14 @@
         </simpleType>
       </attribute>
 
+      <attribute name="blockWhenFull" type="boolean" use="optional" default="false">
+        <annotation>
+          <documentation>Whether to block when the incoming event
+          queue (if a maximum size is specified with queueLength) is full.
+          The default value is false.</documentation>
+        </annotation>
+      </attribute>
+
       <attribute name="getNextEventID" type="string" use="optional">
         <annotation>
           <documentation>SQL query to get next value of the 'nodeNxtId'

--- a/opennms-config/src/main/java/org/opennms/netmgt/config/EventdConfigManager.java
+++ b/opennms-config/src/main/java/org/opennms/netmgt/config/EventdConfigManager.java
@@ -171,6 +171,24 @@ public class EventdConfigManager implements EventdConfig {
     }
 
     /**
+     * Return whether we should block when the handler or
+     * listener queues are full (defaults to false). If false,
+     * events are discarded if the queue fills up. If true, enqueuing
+     * new events will block to throttle incoming event processing.
+     *
+     * @return Whether we should block when the Eventd
+     *         queues are full
+     */
+    public boolean getBlockWhenFull() {
+        getReadLock().lock();
+        try {
+            return m_config.hasBlockWhenFull() ? m_config.getBlockWhenFull() : Boolean.FALSE;
+        } finally {
+            getReadLock().unlock();
+        }
+    }
+
+    /**
      * Return string indicating if timeout is to be set on the socket.
      *
      * @return string indicating if timeout is to be set on the socket

--- a/opennms-util/src/main/java/org/opennms/core/concurrent/ExecutorFactory.java
+++ b/opennms-util/src/main/java/org/opennms/core/concurrent/ExecutorFactory.java
@@ -29,6 +29,7 @@
 package org.opennms.core.concurrent;
 
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.RejectedExecutionHandler;
 
 /**
  * This factory is used to create {@link ExecutorService} thread pools for use by
@@ -84,4 +85,21 @@ public interface ExecutorFactory {
 	 * @return An ExecutorService pool
 	 */
 	ExecutorService newExecutor(int threads, int queueSize, String daemonName, String executorName);
+
+	/**
+	 * Construct a new {@link ExecutorService} with a specified queue size for 
+	 * the backlog of tasks. When the queue is full, the specified 
+	 * {@link RejectedExecutionHandler} will be used.
+	 * 
+	 * For CPU-intensive tasks, it is a good idea to use the value of
+	 * {@link Runtime#availableProcessors()} (or a reasonable multiple of it
+	 * based on the tasks) for the <code>threads</code> parameter to ensure 
+	 * that the CPU is fully utilized.
+	 * 
+	 * @param threads
+	 * @param daemonName
+	 * @param executorName
+	 * @return An ExecutorService pool
+	 */
+	ExecutorService newExecutor(int threads, int queueSize, String daemonName, String executorName, RejectedExecutionHandler handler);
 }

--- a/opennms-util/src/main/java/org/opennms/core/concurrent/ExecutorFactoryJavaImpl.java
+++ b/opennms-util/src/main/java/org/opennms/core/concurrent/ExecutorFactoryJavaImpl.java
@@ -30,6 +30,7 @@ package org.opennms.core.concurrent;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.RejectedExecutionHandler;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
@@ -56,6 +57,19 @@ public class ExecutorFactoryJavaImpl implements ExecutorFactory {
 			TimeUnit.MILLISECONDS,
 			new LinkedBlockingQueue<Runnable>(queueSize),
 			new LogPreservingThreadFactory(daemonName + "-" + executorName, Integer.MAX_VALUE)
+		);
+	}
+
+	@Override
+	public ExecutorService newExecutor(int threads, int queueSize, String daemonName, String executorName, RejectedExecutionHandler handler) {
+		return new ThreadPoolExecutor(
+			threads,
+			threads,
+			1000L,
+			TimeUnit.MILLISECONDS,
+			new LinkedBlockingQueue<Runnable>(queueSize),
+			new LogPreservingThreadFactory(daemonName + "-" + executorName, Integer.MAX_VALUE),
+			handler
 		);
 	}
 }

--- a/opennms-util/src/main/java/org/opennms/core/concurrent/OfferBlockingQueue.java
+++ b/opennms-util/src/main/java/org/opennms/core/concurrent/OfferBlockingQueue.java
@@ -1,0 +1,72 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2016-2016 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2016 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.core.concurrent;
+
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.RejectedExecutionHandler;
+import java.util.concurrent.ThreadPoolExecutor;
+
+/**
+ * When used in a ThreadPoolExecutor, this queue will block calls to
+ * {@link ThreadPoolExecutor#execute(Runnable)} when the queue is full.
+ * This is done by overriding calls to {@link LinkedBlockingQueue#offer(Object)}
+ * with calls to {@link LinkedBlockingQueue#put(Object)}, but comes with the caveat
+ * that executor must be built with <code>corePoolSize == maxPoolSize</code>.
+ * In the context of the {@link AsyncDispatcherImpl}, this is an acceptable caveat,
+ * since we enforce the matching pool sizes.
+ *
+ * There are alternative ways of solving this problem, for example we could use a
+ * {@link RejectedExecutionHandler} to achieve similar behavior, and allow
+ * for <code>corePoolSize < maxPoolSize</code>, but not for <code>corePoolSize==0</code>.
+ *
+ * For further discussions on this topic see:
+ *   http://stackoverflow.com/a/3518588
+ *   http://stackoverflow.com/a/32123535
+ *
+ * If the implementation is changed, make sure that that executor is built accordingly.
+ */
+public class OfferBlockingQueue<E> extends LinkedBlockingQueue<E> {
+
+    private static final long serialVersionUID = 3311058329865555257L;
+
+    public OfferBlockingQueue(int capacity) {
+        super(capacity);
+    }
+
+    @Override
+    public boolean offer(E e) {
+        try {
+            put(e);
+            return true;
+        } catch(InterruptedException ie) {
+            Thread.currentThread().interrupt();
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
When a queueSize is specified in Eventd and this blockWhenFull property is set to 'true', Eventd will throttle incoming events by blocking to avoid discarding events or exhausting memory.

* JIRA: http://issues.opennms.org/browse/HZN-980
