### PR TITLE
HZN-985 / HZN-987: add node location to alarm/notification UI

### DIFF
--- a/opennms-webapp/src/main/java/org/opennms/web/alarm/AlarmUtil.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/alarm/AlarmUtil.java
@@ -54,17 +54,21 @@ import org.opennms.web.alarm.filter.EventParmLikeFilter;
 import org.opennms.web.alarm.filter.ExactUEIFilter;
 import org.opennms.web.alarm.filter.IPAddrLikeFilter;
 import org.opennms.web.alarm.filter.InterfaceFilter;
+import org.opennms.web.alarm.filter.LocationFilter;
 import org.opennms.web.alarm.filter.LogMessageMatchesAnyFilter;
 import org.opennms.web.alarm.filter.LogMessageSubstringFilter;
 import org.opennms.web.alarm.filter.NegativeAcknowledgedByFilter;
 import org.opennms.web.alarm.filter.NegativeEventParmLikeFilter;
 import org.opennms.web.alarm.filter.NegativeExactUEIFilter;
 import org.opennms.web.alarm.filter.NegativeInterfaceFilter;
+import org.opennms.web.alarm.filter.NegativeLocationFilter;
 import org.opennms.web.alarm.filter.NegativeNodeFilter;
+import org.opennms.web.alarm.filter.NegativeNodeLocationFilter;
 import org.opennms.web.alarm.filter.NegativePartialUEIFilter;
 import org.opennms.web.alarm.filter.NegativeServiceFilter;
 import org.opennms.web.alarm.filter.NegativeSeverityFilter;
 import org.opennms.web.alarm.filter.NodeFilter;
+import org.opennms.web.alarm.filter.NodeLocationFilter;
 import org.opennms.web.alarm.filter.NodeNameLikeFilter;
 import org.opennms.web.alarm.filter.PartialUEIFilter;
 import org.opennms.web.alarm.filter.ServiceFilter;
@@ -91,6 +95,8 @@ public abstract class AlarmUtil extends Object {
     public static OnmsCriteria getOnmsCriteria(final AlarmCriteria alarmCriteria) {
         final OnmsCriteria criteria = new OnmsCriteria(OnmsAlarm.class);
         criteria.createAlias("node", "node", OnmsCriteria.LEFT_JOIN);
+        criteria.createAlias("distPoller", "distPoller", OnmsCriteria.LEFT_JOIN);
+        criteria.createAlias("lastEvent", "lastEvent", OnmsCriteria.LEFT_JOIN);
         criteria.createAlias("serviceType", "serviceType", OnmsCriteria.LEFT_JOIN);
 
         alarmCriteria.visit(new AlarmCriteriaVisitor<RuntimeException>() {
@@ -259,6 +265,14 @@ public abstract class AlarmUtil extends Object {
             filter = new EventParmLikeFilter(value);
         } else if(type.equals(NegativeEventParmLikeFilter.TYPE)) {
             filter = new NegativeEventParmLikeFilter(value);
+        } else if (type.equals(LocationFilter.TYPE)) {
+            filter = new LocationFilter(value);
+        } else if (type.equals(NegativeLocationFilter.TYPE)) {
+            filter = new NegativeLocationFilter(value);
+        } else if (type.equals(NodeLocationFilter.TYPE)) {
+            filter = new NodeLocationFilter(value);
+        } else if (type.equals(NegativeNodeLocationFilter.TYPE)) {
+            filter = new NegativeNodeLocationFilter(value);
         }
 
         return filter;

--- a/opennms-webapp/src/main/java/org/opennms/web/alarm/SortStyle.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/alarm/SortStyle.java
@@ -51,6 +51,8 @@ public enum SortStyle {
     ID("id"),
     COUNT("count"),
     ACKUSER("ackuser"),
+    LOCATION("location"),
+    NODE_LOCATION("nodelocation"),
     REVERSE_SEVERITY("rev_severity"),
     REVERSE_LASTEVENTTIME("rev_lasteventtime"),
     REVERSE_FIRSTEVENTTIME("rev_firsteventtime"),
@@ -60,21 +62,23 @@ public enum SortStyle {
     REVERSE_POLLER("rev_poller"),
     REVERSE_ID("rev_id"),
     REVERSE_COUNT("rev_count"),
-    REVERSE_ACKUSER("rev_ackuser");
+    REVERSE_ACKUSER("rev_ackuser"),
+    REVERSE_LOCATION("rev_location"),
+    REVERSE_NODE_LOCATION("rev_nodelocation");
 
     /** Constant <code>m_sortStylesString</code> */
     private static final Map<String, SortStyle> m_sortStylesString;
-    
+
     private String m_shortName;
-    
+
     static {
         m_sortStylesString = new HashMap<String, SortStyle>();
         for (SortStyle sortStyle : SortStyle.values()) {
             m_sortStylesString.put(sortStyle.getShortName(), sortStyle);
-            
+
         }
     }
-    
+
     private SortStyle(String shortName) {
         m_shortName = shortName;
     }
@@ -127,92 +131,108 @@ public enum SortStyle {
      */
     protected String getOrderByClause() {
         String clause = null;
-    
+
         switch (this) {
         case SEVERITY:
             clause = " ORDER BY SEVERITY DESC";
             break;
-    
+
         case REVERSE_SEVERITY:
             clause = " ORDER BY SEVERITY ASC";
             break;
-    
+
         case LASTEVENTTIME:
             clause = " ORDER BY LASTEVENTTIME DESC";
             break;
-    
+
         case REVERSE_LASTEVENTTIME:
             clause = " ORDER BY LASTEVENTTIME ASC";
             break;
-    
+
         case FIRSTEVENTTIME:
             clause = " ORDER BY FIRSTEVENTTIME DESC";
             break;
-    
+
         case REVERSE_FIRSTEVENTTIME:
             clause = " ORDER BY FIRSTEVENTTIME ASC";
             break;
-    
+
         case NODE:
             clause = " ORDER BY NODELABEL ASC";
             break;
-    
+
         case REVERSE_NODE:
             clause = " ORDER BY NODELABEL DESC";
             break;
-    
+
         case INTERFACE:
             clause = " ORDER BY IPADDR ASC";
             break;
-    
+
         case REVERSE_INTERFACE:
             clause = " ORDER BY IPADDR DESC";
             break;
-    
+
         case SERVICE:
             clause = " ORDER BY SERVICENAME ASC";
             break;
-    
+
         case REVERSE_SERVICE:
             clause = " ORDER BY SERVICENAME DESC";
             break;
-    
+
         case POLLER:
             clause = " ORDER BY EVENTDPNAME ASC";
             break;
-    
+
         case REVERSE_POLLER:
             clause = " ORDER BY EVENTDPNAME DESC";
             break;
-    
+
         case ID:
             clause = " ORDER BY ALARMID DESC";
             break;
-    
+
         case REVERSE_ID:
             clause = " ORDER BY ALARMID ASC";
             break;
-    
+
         case COUNT:
             clause = " ORDER BY COUNTER DESC";
             break;
-    
+
         case REVERSE_COUNT:
             clause = " ORDER BY COUNTER ASC";
             break;
-    
+
         case ACKUSER:
             clause = " ORDER BY ALARMACKUSER ASC";
             break;
-    
+
         case REVERSE_ACKUSER:
             clause = " ORDER BY ALARMACKUSER DESC";
             break;
-        
+
+        case LOCATION:
+            clause = " ORDER BY LOCATION ASC";
+            break;
+
+        case REVERSE_LOCATION:
+            clause = " ORDER BY LOCATION DESC";
+            break;
+
+        case NODE_LOCATION:
+            clause = " ORDER BY NODE.LOCATION ASC, NODE.NODELABEL ASC";
+            break;
+
+        case REVERSE_NODE_LOCATION:
+            clause = " ORDER BY NODE.LOCATION DESC, NODE.NODELABEL ASC";
+            break;
+
         default:
             throw new IllegalArgumentException("Unknown SortStyle: " + this);
         }
-    
+
         return clause;
     }
 }

--- a/opennms-webapp/src/main/java/org/opennms/web/alarm/filter/LocationFilter.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/alarm/filter/LocationFilter.java
@@ -1,0 +1,67 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2002-2014 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.web.alarm.filter;
+
+import org.opennms.web.filter.EqualsFilter;
+import org.opennms.web.filter.SQLType;
+
+/**
+ * Encapsulates filtering on exact unique event identifiers.
+ *
+ * @author ranger
+ * @version $Id: $
+ * @since 1.8.1
+ */
+public class LocationFilter extends EqualsFilter<String> {
+    public static final String TYPE = "location";
+    private final String m_location;
+
+    public LocationFilter(final String location) {
+        super(TYPE, SQLType.STRING, "MONITORINGSYSTEMS.LOCATION", "distPoller.location", location);
+        m_location = location;
+    }
+
+    @Override
+    public String getTextDescription() {
+        return ("Location is " + m_location);
+    }
+
+    @Override
+    public String toString() {
+        return ("<AlarmFactory.LocationFilter: " + this.getDescription() + ">");
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) return false;
+        if (!(obj instanceof LocationFilter)) return false;
+        return (this.toString().equals(obj.toString()));
+    }
+}

--- a/opennms-webapp/src/main/java/org/opennms/web/alarm/filter/NegativeLocationFilter.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/alarm/filter/NegativeLocationFilter.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2002-2014 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.web.alarm.filter;
+
+import org.opennms.web.filter.NotEqualsFilter;
+import org.opennms.web.filter.SQLType;
+
+public class NegativeLocationFilter extends NotEqualsFilter<String> {
+    public static final String TYPE = "locationnot";
+
+    public NegativeLocationFilter(final String location) {
+        super(TYPE, SQLType.STRING, "MONITORINGSYSTEMS.LOCATION", "distPoller.location", location);
+    }
+
+    @Override
+    public String getTextDescription() {
+        return "Location is not " + getValue();
+    }
+
+    /**
+     * <p>toString</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
+    @Override
+    public String toString() {
+        return ("<AlarmFactory.NegativeLocationFilter: " + this.getDescription() + ">");
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) return false;
+        if (!(obj instanceof NegativeLocationFilter)) return false;
+        return (this.toString().equals(obj.toString()));
+    }
+}

--- a/opennms-webapp/src/main/java/org/opennms/web/alarm/filter/NegativeNodeLocationFilter.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/alarm/filter/NegativeNodeLocationFilter.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2002-2014 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.web.alarm.filter;
+
+import org.opennms.web.filter.NotEqualsFilter;
+import org.opennms.web.filter.SQLType;
+
+public class NegativeNodeLocationFilter extends NotEqualsFilter<String> {
+    public static final String TYPE = "nodelocationnot";
+
+    public NegativeNodeLocationFilter(final String location) {
+        super(TYPE, SQLType.STRING, "NODE.LOCATION", "node.location.locationName", location);
+    }
+
+    @Override
+    public String getTextDescription() {
+        return "Node location is not " + getValue();
+    }
+
+    @Override
+    public String toString() {
+        return ("<AlarmFactory.NegativeNodeLocationFilter: " + this.getDescription() + ">");
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) return false;
+        if (!(obj instanceof NegativeNodeLocationFilter)) return false;
+        return (this.toString().equals(obj.toString()));
+    }
+}

--- a/opennms-webapp/src/main/java/org/opennms/web/alarm/filter/NodeLocationFilter.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/alarm/filter/NodeLocationFilter.java
@@ -1,0 +1,67 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2002-2014 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.web.alarm.filter;
+
+import org.opennms.web.filter.EqualsFilter;
+import org.opennms.web.filter.SQLType;
+
+/**
+ * Encapsulates filtering on exact unique event identifiers.
+ *
+ * @author ranger
+ * @version $Id: $
+ * @since 1.8.1
+ */
+public class NodeLocationFilter extends EqualsFilter<String> {
+    public static final String TYPE = "nodelocation";
+    private final String m_location;
+
+    public NodeLocationFilter(final String location) {
+        super(TYPE, SQLType.STRING, "NODE.LOCATION", "node.location.locationName", location);
+        m_location = location;
+    }
+
+    @Override
+    public String getTextDescription() {
+        return ("Node location is " + m_location);
+    }
+
+    @Override
+    public String toString() {
+        return ("<AlarmFactory.NodeLocationFilter: " + this.getDescription() + ">");
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) return false;
+        if (!(obj instanceof NodeLocationFilter)) return false;
+        return (this.toString().equals(obj.toString()));
+    }
+}

--- a/opennms-webapp/src/main/java/org/opennms/web/element/NetworkElementFactory.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/element/NetworkElementFactory.java
@@ -1,7 +1,7 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2002-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2002-2016 The OpenNMS Group, Inc.
  * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
@@ -171,6 +171,22 @@ public class NetworkElementFactory implements InitializingBean, NetworkElementFa
         } else {
             return null;
         }
+    }
+
+    @Override
+    public String getNodeLocation(int nodeId) {
+        final CriteriaBuilder cb = new CriteriaBuilder(OnmsNode.class);
+        cb.eq("id", nodeId);
+        final List<OnmsNode> nodes = m_nodeDao.findMatching(cb.toCriteria());
+
+        if(nodes.size() > 0) {
+            final OnmsNode node = nodes.get(0);
+            if (node.getLocation() != null) {
+                return node.getLocation().getLocationName();
+            }
+        }
+
+        return null;
     }
 
     /* (non-Javadoc)

--- a/opennms-webapp/src/main/java/org/opennms/web/element/NetworkElementFactoryInterface.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/element/NetworkElementFactoryInterface.java
@@ -40,6 +40,14 @@ public interface NetworkElementFactoryInterface {
 	String getNodeLabel(int nodeId);
 
 	/**
+	 * Get the location name associated with the node.
+	 *
+	 * @param nodeId the node's ID
+	 * @return the location as a string, or null if the node does not have a location
+	 */
+	String getNodeLocation(int nodeId);
+
+	/**
 	 * Find the IP address of the primary SNMP interface.
 	 *
 	 * @return An IPv4 or IPv6 address in string format or null if the node has no primary

--- a/opennms-webapp/src/main/java/org/opennms/web/event/DaoWebEventRepository.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/event/DaoWebEventRepository.java
@@ -40,7 +40,9 @@ import org.opennms.core.utils.InetAddressUtils;
 import org.opennms.netmgt.dao.api.EventDao;
 import org.opennms.netmgt.model.OnmsCriteria;
 import org.opennms.netmgt.model.OnmsEvent;
+import org.opennms.netmgt.model.OnmsNode;
 import org.opennms.netmgt.model.OnmsSeverity;
+import org.opennms.netmgt.model.monitoringLocations.OnmsMonitoringLocation;
 import org.opennms.web.event.filter.EventCriteria;
 import org.opennms.web.event.filter.EventCriteria.EventCriteriaVisitor;
 import org.opennms.web.event.filter.EventDisplayFilter;
@@ -192,6 +194,7 @@ public class DaoWebEventRepository implements WebEventRepository, InitializingBe
         LOG.debug("Found NodeLabel for mapped event:{}", event.getNodeLabel());
         event.nodeID = getNodeIdFromNode(onmsEvent);
         LOG.debug("Found NodeId for mapped event:{}", event.getNodeId());
+        event.nodeLocation = getNodeLocationFromNode(onmsEvent);
         event.notification = onmsEvent.getEventNotification();
         event.operatorAction = onmsEvent.getEventOperAction();
         event.operatorActionMenuText = onmsEvent.getEventOperActionMenuText();
@@ -231,6 +234,22 @@ public class DaoWebEventRepository implements WebEventRepository, InitializingBe
         } 
     }
     
+    private String getNodeLocationFromNode(OnmsEvent onmsEvent) {
+        try {
+            final OnmsNode node = onmsEvent.getNode();
+            if (node != null) {
+                final OnmsMonitoringLocation location = node.getLocation();
+                if (location != null) {
+                    return location.getLocationName();
+                }
+            }
+            return "";
+        } catch (org.hibernate.ObjectNotFoundException e) {
+            LOG.debug("No node found in database for event with id: {}", onmsEvent.getId());
+            return "";
+        } 
+    }
+
     /**
      * <p>acknowledgeAll</p>
      *

--- a/opennms-webapp/src/main/java/org/opennms/web/event/Event.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/event/Event.java
@@ -38,10 +38,6 @@ import org.opennms.netmgt.model.OnmsSeverity;
  *
  * @author <A HREF="mailto:larry@opennms.org">Lawrence Karnowski </A>
  * @author <A HREF="http://www.opennms.org/">OpenNMS </A>
- * @author <A HREF="mailto:larry@opennms.org">Lawrence Karnowski </A>
- * @author <A HREF="http://www.opennms.org/">OpenNMS </A>
- * @version $Id: $
- * @since 1.8.1
  */
 public class Event {
     /** Unique identifier for the event, cannot be null */
@@ -209,6 +205,8 @@ public class Event {
 
     protected String location;
 
+    protected String nodeLocation;
+
     /**
      * Empty constructor to create an empty <code>Event</code> instance. All
      * fields will hold the default values.
@@ -313,41 +311,10 @@ public class Event {
     public Event(int id, String uei, Date time, String dpName, Date createTime, int severityId, String snmp, String host, String snmphost, String parms, Integer nodeID, Integer serviceID, String ipAddr, String description, String logMessage, String logGroup, String operatorInstruction, String autoAction, String operatorAction, String operatorActionMenuText, String notification, String troubleTicket, Integer troubleTicketState, String forward, String mouseOverText, String acknowledgeUser, Date acknowledgeTime, String nodeLabel, String serviceName, Integer alarmId) {
         this(id, uei, time, dpName, createTime, severityId, snmp, host, snmphost, parms, nodeID, serviceID, ipAddr, description, logMessage, logGroup, operatorInstruction, autoAction, operatorAction, operatorActionMenuText, notification, troubleTicket, troubleTicketState, forward, mouseOverText, acknowledgeUser, acknowledgeTime, nodeLabel, serviceName, alarmId, null);
     }
+
     /**
      * Create an event that represents a real network event with all the
      * parameters.
-     *
-     * @param id a int.
-     * @param uei a {@link java.lang.String} object.
-     * @param time a {@link java.util.Date} object.
-     * @param dpName a {@link java.lang.String} object.
-     * @param createTime a {@link java.util.Date} object.
-     * @param severityId a int.
-     * @param snmp a {@link java.lang.String} object.
-     * @param host a {@link java.lang.String} object.
-     * @param snmphost a {@link java.lang.String} object.
-     * @param parms a {@link java.lang.String} object.
-     * @param nodeID a {@link java.lang.Integer} object.
-     * @param serviceID a {@link java.lang.Integer} object.
-     * @param ipAddr a {@link java.lang.String} object.
-     * @param description a {@link java.lang.String} object.
-     * @param logMessage a {@link java.lang.String} object.
-     * @param logGroup a {@link java.lang.String} object.
-     * @param operatorInstruction a {@link java.lang.String} object.
-     * @param autoAction a {@link java.lang.String} object.
-     * @param operatorAction a {@link java.lang.String} object.
-     * @param operatorActionMenuText a {@link java.lang.String} object.
-     * @param notification a {@link java.lang.String} object.
-     * @param troubleTicket a {@link java.lang.String} object.
-     * @param troubleTicketState a {@link java.lang.Integer} object.
-     * @param forward a {@link java.lang.String} object.
-     * @param mouseOverText a {@link java.lang.String} object.
-     * @param acknowledgeUser a {@link java.lang.String} object.
-     * @param acknowledgeTime a {@link java.util.Date} object.
-     * @param nodeLabel a {@link java.lang.String} object.
-     * @param serviceName a {@link java.lang.String} object.
-     * @param alarmId a {@link java.lang.Integer} object.
-     * @param eventDisplay a {@link java.lang.Boolean} object.
      */
     public Event(int id, String uei, Date time, String dpName, Date createTime, int severityId, String snmp, String host, String snmphost, String parms, Integer nodeID, Integer serviceID, String ipAddr, String description, String logMessage, String logGroup, String operatorInstruction, String autoAction, String operatorAction, String operatorActionMenuText, String notification, String troubleTicket, Integer troubleTicketState, String forward, String mouseOverText, String acknowledgeUser, Date acknowledgeTime, String nodeLabel, String serviceName, Integer alarmId, Boolean eventDisplay) {
 
@@ -685,5 +652,9 @@ public class Event {
 
     public String getLocation() {
         return location;
+    }
+    
+    public String getNodeLocation() {
+        return nodeLocation;
     }
 }

--- a/opennms-webapp/src/main/java/org/opennms/web/event/EventQueryServlet.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/event/EventQueryServlet.java
@@ -52,6 +52,7 @@ import org.opennms.web.event.filter.IPAddrLikeFilter;
 import org.opennms.web.event.filter.LocationFilter;
 import org.opennms.web.event.filter.LogMessageMatchesAnyFilter;
 import org.opennms.web.event.filter.LogMessageSubstringFilter;
+import org.opennms.web.event.filter.NodeLocationFilter;
 import org.opennms.web.event.filter.NodeNameLikeFilter;
 import org.opennms.web.event.filter.ServiceFilter;
 import org.opennms.web.event.filter.SeverityFilter;
@@ -139,6 +140,12 @@ public class EventQueryServlet extends HttpServlet {
         String location = WebSecurityUtils.sanitizeString(request.getParameter("location"));
         if (location != null && !location.equalsIgnoreCase("any")) {
             filterArray.add(new LocationFilter(WebSecurityUtils.sanitizeString(location)));
+        }
+
+        // convenient syntax for NodeLocationFilter
+        String nodeLocation = WebSecurityUtils.sanitizeString(request.getParameter("nodelocation"));
+        if (nodeLocation != null && !nodeLocation.equalsIgnoreCase("any")) {
+            filterArray.add(new NodeLocationFilter(WebSecurityUtils.sanitizeString(nodeLocation)));
         }
 
         // convenient syntax for SystemIdFilter

--- a/opennms-webapp/src/main/java/org/opennms/web/event/EventUtil.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/event/EventUtil.java
@@ -54,11 +54,13 @@ import org.opennms.web.event.filter.NegativeExactUEIFilter;
 import org.opennms.web.event.filter.NegativeInterfaceFilter;
 import org.opennms.web.event.filter.NegativeLocationFilter;
 import org.opennms.web.event.filter.NegativeNodeFilter;
+import org.opennms.web.event.filter.NegativeNodeLocationFilter;
 import org.opennms.web.event.filter.NegativePartialUEIFilter;
 import org.opennms.web.event.filter.NegativeServiceFilter;
 import org.opennms.web.event.filter.NegativeSeverityFilter;
 import org.opennms.web.event.filter.NegativeSystemIdFilter;
 import org.opennms.web.event.filter.NodeFilter;
+import org.opennms.web.event.filter.NodeLocationFilter;
 import org.opennms.web.event.filter.NodeNameLikeFilter;
 import org.opennms.web.event.filter.PartialUEIFilter;
 import org.opennms.web.event.filter.ServiceFilter;
@@ -146,14 +148,18 @@ public abstract class EventUtil {
             filter = new AfterDateFilter(WebSecurityUtils.safeParseLong(value));
         } else if (type.equals(AlarmIDFilter.TYPE)) {
             filter = new AlarmIDFilter(WebSecurityUtils.safeParseInt(value));
-        }else if (type.equals(LocationFilter.TYPE)) {
+        } else if (type.equals(LocationFilter.TYPE)) {
             filter = new LocationFilter(WebSecurityUtils.sanitizeString(value));
-        }else if (type.equals(SystemIdFilter.TYPE)) {
+        } else if (type.equals(SystemIdFilter.TYPE)) {
             filter = new SystemIdFilter(WebSecurityUtils.sanitizeString(value));
-        }else if (type.equals(NegativeLocationFilter.TYPE)) {
+        } else if (type.equals(NegativeLocationFilter.TYPE)) {
             filter = new NegativeLocationFilter(WebSecurityUtils.sanitizeString(value));
-        }else if (type.equals(NegativeSystemIdFilter.TYPE)) {
+        } else if (type.equals(NegativeSystemIdFilter.TYPE)) {
             filter = new NegativeSystemIdFilter(WebSecurityUtils.sanitizeString(value));
+        } else if (type.equals(NodeLocationFilter.TYPE)) {
+            filter = new NodeLocationFilter(WebSecurityUtils.sanitizeString(value));
+        } else if (type.equals(NegativeNodeLocationFilter.TYPE)) {
+            filter = new NegativeNodeLocationFilter(WebSecurityUtils.sanitizeString(value));
         }
 
         return filter;

--- a/opennms-webapp/src/main/java/org/opennms/web/event/SortStyle.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/event/SortStyle.java
@@ -44,6 +44,7 @@ public enum SortStyle {
     SEVERITY("severity"),
     TIME("time"),
     NODE("node"),
+    NODE_LOCATION("nodelocation"),
     INTERFACE("interface"),
     SERVICE("service"),
     POLLER("poller"),
@@ -53,6 +54,7 @@ public enum SortStyle {
     REVERSE_SEVERITY("rev_severity"),
     REVERSE_TIME("rev_time"),
     REVERSE_NODE("rev_node"),
+    REVERSE_NODE_LOCATION("rev_nodelocation"),
     REVERSE_INTERFACE("rev_interface"),
     REVERSE_SERVICE("rev_service"),
     REVERSE_POLLER("rev_poller"),
@@ -151,6 +153,14 @@ public enum SortStyle {
             clause = " ORDER BY NODELABEL DESC";
             break;
     
+        case NODE_LOCATION:
+            clause = " ORDER BY NODE.LOCATION ASC, NODELABEL ASC";
+            break;
+            
+        case REVERSE_NODE_LOCATION:
+            clause = " ORDER BY NODE.LOCATION DESC, NODELABEL ASC";
+            break;
+
         case INTERFACE:
             clause = " ORDER BY IPADDR ASC";
             break;

--- a/opennms-webapp/src/main/java/org/opennms/web/event/filter/LocationFilter.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/event/filter/LocationFilter.java
@@ -42,7 +42,7 @@ public class LocationFilter extends EqualsFilter<String> {
 
     @Override
     public String getTextDescription() {
-        return (TYPE + "=" + m_location);
+        return ("Location is " + m_location);
     }
 
     @Override

--- a/opennms-webapp/src/main/java/org/opennms/web/event/filter/NegativeLocationFilter.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/event/filter/NegativeLocationFilter.java
@@ -53,7 +53,7 @@ public class NegativeLocationFilter extends NotEqualOrNullFilter<String> {
     @Override
     public boolean equals(Object obj) {
         if (obj == null) return false;
-        if (!(obj instanceof NegativeNodeLocationFilter)) return false;
+        if (!(obj instanceof NegativeLocationFilter)) return false;
         return (this.toString().equals(obj.toString()));
     }
 }

--- a/opennms-webapp/src/main/java/org/opennms/web/event/filter/NegativeLocationFilter.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/event/filter/NegativeLocationFilter.java
@@ -32,7 +32,7 @@ import org.opennms.web.filter.NotEqualOrNullFilter;
 import org.opennms.web.filter.SQLType;
 
 public class NegativeLocationFilter extends NotEqualOrNullFilter<String> {
-    public static final String TYPE = "locationNot";
+    public static final String TYPE = "locationnot";
     private String m_location;
 
     public NegativeLocationFilter(String location) {
@@ -42,7 +42,7 @@ public class NegativeLocationFilter extends NotEqualOrNullFilter<String> {
 
     @Override
     public String getTextDescription() {
-        return ("location is not " + m_location);
+        return ("Location is not " + m_location);
     }
 
     @Override
@@ -53,7 +53,7 @@ public class NegativeLocationFilter extends NotEqualOrNullFilter<String> {
     @Override
     public boolean equals(Object obj) {
         if (obj == null) return false;
-        if (!(obj instanceof NegativeLocationFilter)) return false;
+        if (!(obj instanceof NegativeNodeLocationFilter)) return false;
         return (this.toString().equals(obj.toString()));
     }
 }

--- a/opennms-webapp/src/main/java/org/opennms/web/event/filter/NegativeNodeLocationFilter.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/event/filter/NegativeNodeLocationFilter.java
@@ -1,0 +1,31 @@
+package org.opennms.web.event.filter;
+
+import org.opennms.web.filter.NotEqualOrNullFilter;
+import org.opennms.web.filter.SQLType;
+
+public class NegativeNodeLocationFilter extends NotEqualOrNullFilter<String> {
+    public static final String TYPE = "nodelocationnot";
+    private String m_location;
+
+    public NegativeNodeLocationFilter(final String location) {
+        super(TYPE, SQLType.STRING, "NODE.LOCATION", "node.location.locationName", location);
+        m_location = location;
+    }
+
+    @Override
+    public String getTextDescription() {
+        return ("Node location is not " + m_location);
+    }
+
+    @Override
+    public String toString() {
+        return ("<WebEventRepository.NegativeNodeLocationFilter: " + getDescription() + ">");
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if (obj == null) return false;
+        if (!(obj instanceof NegativeNodeLocationFilter)) return false;
+        return (this.toString().equals(obj.toString()));
+    }
+}

--- a/opennms-webapp/src/main/java/org/opennms/web/event/filter/NodeLocationFilter.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/event/filter/NodeLocationFilter.java
@@ -1,0 +1,31 @@
+package org.opennms.web.event.filter;
+
+import org.opennms.web.filter.EqualsFilter;
+import org.opennms.web.filter.SQLType;
+
+public class NodeLocationFilter extends EqualsFilter<String> {
+    public static final String TYPE = "nodelocation";
+    private String m_location;
+
+    public NodeLocationFilter(final String location) {
+        super(TYPE, SQLType.STRING, "NODE.LOCATION", "node.location.locationName", location);
+        m_location = location;
+    }
+
+    @Override
+    public String getTextDescription() {
+        return ("Node location is " + m_location);
+    }
+
+    @Override
+    public String toString() {
+        return ("<WebEventRepository.NodeLocationFilter: " + getDescription() + ">");
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if (obj == null) return false;
+        if (!(obj instanceof NodeLocationFilter)) return false;
+        return (this.toString().equals(obj.toString()));
+    }
+}

--- a/opennms-webapp/src/main/java/org/opennms/web/notification/DaoWebNotificationRepository.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/notification/DaoWebNotificationRepository.java
@@ -119,6 +119,9 @@ public class DaoWebNotificationRepository implements WebNotificationRepository, 
                     case NODE:
                         criteria.addOrder(Order.desc("node.label"));
                         break;
+                    case LOCATION:
+                        criteria.addOrder(Order.desc("node.location.locationName"));
+                        break;
                     case INTERFACE:
                         criteria.addOrder(Order.desc("ipAddress"));
                         break;
@@ -142,6 +145,9 @@ public class DaoWebNotificationRepository implements WebNotificationRepository, 
                         break;
                     case REVERSE_NODE:
                         criteria.addOrder(Order.asc("node.label"));
+                        break;
+                    case REVERSE_LOCATION:
+                        criteria.addOrder(Order.asc("node.location.locationName"));
                         break;
                     case REVERSE_INTERFACE:
                         criteria.addOrder(Order.asc("ipAddress"));

--- a/opennms-webapp/src/main/java/org/opennms/web/notification/DaoWebNotificationRepository.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/notification/DaoWebNotificationRepository.java
@@ -79,6 +79,7 @@ public class DaoWebNotificationRepository implements WebNotificationRepository, 
         criteria.createAlias("node", "node", OnmsCriteria.LEFT_JOIN);
         criteria.createAlias("serviceType", "serviceType", OnmsCriteria.LEFT_JOIN);
         criteria.createAlias("event", "event", OnmsCriteria.LEFT_JOIN);
+        criteria.createAlias("event.distPoller", "distPoller", OnmsCriteria.LEFT_JOIN);
         
         notificationCriteria.visit(new NotificationCriteriaVisitor<RuntimeException>(){
 
@@ -107,6 +108,9 @@ public class DaoWebNotificationRepository implements WebNotificationRepository, 
             @Override
             public void visitSortStyle(SortStyle sortStyle) throws RuntimeException {
                 switch(sortStyle){
+                    case LOCATION:
+                        criteria.addOrder(Order.desc("event.distPoller.location"));
+                        break;
                     case RESPONDER:
                         criteria.addOrder(Order.desc("answeredBy"));        
                         break;
@@ -119,7 +123,7 @@ public class DaoWebNotificationRepository implements WebNotificationRepository, 
                     case NODE:
                         criteria.addOrder(Order.desc("node.label"));
                         break;
-                    case LOCATION:
+                    case NODE_LOCATION:
                         criteria.addOrder(Order.desc("node.location.locationName"));
                         break;
                     case INTERFACE:
@@ -134,6 +138,9 @@ public class DaoWebNotificationRepository implements WebNotificationRepository, 
                     case SEVERITY:
                         criteria.addOrder(Order.desc("event.eventSeverity"));
                         break;
+                    case REVERSE_LOCATION:
+                        criteria.addOrder(Order.desc("event.distPoller.location"));
+                        break;
                     case REVERSE_RESPONDER:
                         criteria.addOrder(Order.asc("answeredBy"));            
                         break;
@@ -146,7 +153,7 @@ public class DaoWebNotificationRepository implements WebNotificationRepository, 
                     case REVERSE_NODE:
                         criteria.addOrder(Order.asc("node.label"));
                         break;
-                    case REVERSE_LOCATION:
+                    case REVERSE_NODE_LOCATION:
                         criteria.addOrder(Order.asc("node.location.locationName"));
                         break;
                     case REVERSE_INTERFACE:

--- a/opennms-webapp/src/main/java/org/opennms/web/notification/NoticeUtil.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/notification/NoticeUtil.java
@@ -38,6 +38,8 @@ import org.opennms.netmgt.model.OnmsSeverity;
 import org.opennms.web.filter.Filter;
 import org.opennms.web.notification.filter.AcknowledgedByFilter;
 import org.opennms.web.notification.filter.InterfaceFilter;
+import org.opennms.web.notification.filter.LocationFilter;
+import org.opennms.web.notification.filter.NegativeLocationFilter;
 import org.opennms.web.notification.filter.NegativeNodeFilter;
 import org.opennms.web.notification.filter.NodeFilter;
 import org.opennms.web.notification.filter.NotificationIdFilter;
@@ -92,6 +94,10 @@ public abstract class NoticeUtil extends Object {
             filter = new UserFilter(value);
         } else if (type.equals(SeverityFilter.TYPE)) {
             filter = new SeverityFilter(OnmsSeverity.get(value));
+        } else if (type.equals(LocationFilter.TYPE)) {
+            filter = new LocationFilter(WebSecurityUtils.sanitizeString(value));
+        } else if (type.equals(NegativeLocationFilter.TYPE)) {
+            filter = new NegativeLocationFilter(WebSecurityUtils.sanitizeString(value));
         }
 
         return filter;

--- a/opennms-webapp/src/main/java/org/opennms/web/notification/NoticeUtil.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/notification/NoticeUtil.java
@@ -41,7 +41,9 @@ import org.opennms.web.notification.filter.InterfaceFilter;
 import org.opennms.web.notification.filter.LocationFilter;
 import org.opennms.web.notification.filter.NegativeLocationFilter;
 import org.opennms.web.notification.filter.NegativeNodeFilter;
+import org.opennms.web.notification.filter.NegativeNodeLocationFilter;
 import org.opennms.web.notification.filter.NodeFilter;
+import org.opennms.web.notification.filter.NodeLocationFilter;
 import org.opennms.web.notification.filter.NotificationIdFilter;
 import org.opennms.web.notification.filter.ResponderFilter;
 import org.opennms.web.notification.filter.ServiceFilter;
@@ -98,6 +100,10 @@ public abstract class NoticeUtil extends Object {
             filter = new LocationFilter(WebSecurityUtils.sanitizeString(value));
         } else if (type.equals(NegativeLocationFilter.TYPE)) {
             filter = new NegativeLocationFilter(WebSecurityUtils.sanitizeString(value));
+        } else if (type.equals(NodeLocationFilter.TYPE)) {
+            filter = new NodeLocationFilter(WebSecurityUtils.sanitizeString(value));
+        } else if (type.equals(NegativeNodeLocationFilter.TYPE)) {
+            filter = new NegativeNodeLocationFilter(WebSecurityUtils.sanitizeString(value));
         }
 
         return filter;

--- a/opennms-webapp/src/main/java/org/opennms/web/notification/SortStyle.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/notification/SortStyle.java
@@ -41,20 +41,22 @@ import org.springframework.util.Assert;
  * @since 1.8.1
  */
 public enum SortStyle {
+    LOCATION("location"),
     RESPONDER("responder"),
     PAGETIME("pagetime"),
     RESPONDTIME("respondtime"),
     NODE("node"),
-    LOCATION("location"),
+    NODE_LOCATION("nodelocation"),
     INTERFACE("interface"),
     SERVICE("service"),
     ID("id"),
     SEVERITY("severity"),
+    REVERSE_LOCATION("rev_location"),
     REVERSE_RESPONDER("rev_responder"),
     REVERSE_PAGETIME("rev_pagetime"),
     REVERSE_RESPONDTIME("rev_respondtime"),
     REVERSE_NODE("rev_node"),
-    REVERSE_LOCATION("rev_location"),
+    REVERSE_NODE_LOCATION("rev_nodelocation"),
     REVERSE_INTERFACE("rev_interface"),
     REVERSE_SERVICE("rev_service"),
     REVERSE_ID("rev_id"),
@@ -194,11 +196,19 @@ public enum SortStyle {
             break;
 
         case LOCATION:
-            clause = " ORDER BY NODE.LOCATION DESC";
+            clause = " ORDER BY MONITORINGSYSTEMS.LOCATION ASC";
+            break;
+            
+        case REVERSE_LOCATION:
+            clause = " ORDER BY MONITORINGSYSTEMS.LOCATION DESC";
             break;
 
-        case REVERSE_LOCATION:
+        case NODE_LOCATION:
             clause = " ORDER BY NODE.LOCATION ASC";
+            break;
+
+        case REVERSE_NODE_LOCATION:
+            clause = " ORDER BY NODE.LOCATION DESC";
             break;
 
         default:

--- a/opennms-webapp/src/main/java/org/opennms/web/notification/SortStyle.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/notification/SortStyle.java
@@ -45,6 +45,7 @@ public enum SortStyle {
     PAGETIME("pagetime"),
     RESPONDTIME("respondtime"),
     NODE("node"),
+    LOCATION("location"),
     INTERFACE("interface"),
     SERVICE("service"),
     ID("id"),
@@ -53,6 +54,7 @@ public enum SortStyle {
     REVERSE_PAGETIME("rev_pagetime"),
     REVERSE_RESPONDTIME("rev_respondtime"),
     REVERSE_NODE("rev_node"),
+    REVERSE_LOCATION("rev_location"),
     REVERSE_INTERFACE("rev_interface"),
     REVERSE_SERVICE("rev_service"),
     REVERSE_ID("rev_id"),
@@ -191,10 +193,18 @@ public enum SortStyle {
             clause = " ORDER BY EVENT.EVENTSEVERITY ASC";
             break;
 
+        case LOCATION:
+            clause = " ORDER BY NODE.LOCATION DESC";
+            break;
+
+        case REVERSE_LOCATION:
+            clause = " ORDER BY NODE.LOCATION ASC";
+            break;
+
         default:
             throw new IllegalArgumentException("Unknown SortStyle: " + getName());
         }
-        
+
         return clause;
     }
 

--- a/opennms-webapp/src/main/java/org/opennms/web/notification/filter/LocationFilter.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/notification/filter/LocationFilter.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2009-2014 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.web.notification.filter;
+
+import org.opennms.web.filter.EqualsFilter;
+import org.opennms.web.filter.SQLType;
+
+/**
+ * Encapsulates all node location filtering functionality.
+ */
+public class LocationFilter extends EqualsFilter<String> {
+    public static final String TYPE = "location";
+    private String m_location;
+
+    public LocationFilter(final String location) {
+        super(TYPE, SQLType.STRING, "NODE.LOCATION", "node.location.locationName", location);
+        m_location = location;
+    }
+
+    @Override
+    public String getTextDescription() {
+        return ("location is " + m_location);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) return false;
+        if (!(obj instanceof LocationFilter)) return false;
+        return (this.toString().equals(obj.toString()));
+    }
+}

--- a/opennms-webapp/src/main/java/org/opennms/web/notification/filter/NegativeLocationFilter.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/notification/filter/NegativeLocationFilter.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2002-2014 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.web.notification.filter;
+
+import org.opennms.web.filter.NotEqualOrNullFilter;
+import org.opennms.web.filter.SQLType;
+
+/**
+ * Encapsulates all node location filtering functionality.
+ */
+public class NegativeLocationFilter extends NotEqualOrNullFilter<String> {
+    public static final String TYPE = "locationnot";
+    private String m_location;
+
+    public NegativeLocationFilter(final String location) {
+        super(TYPE, SQLType.STRING, "NODE.LOCATION", "node.location.locationName", location);
+        m_location = location;
+    }
+
+    @Override
+    public String getTextDescription() {
+        return ("location is not " + m_location);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) return false;
+        if (!(obj instanceof NegativeLocationFilter)) return false;
+        return (this.toString().equals(obj.toString()));
+    }
+}

--- a/opennms-webapp/src/main/java/org/opennms/web/notification/filter/NegativeLocationFilter.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/notification/filter/NegativeLocationFilter.java
@@ -39,7 +39,7 @@ public class NegativeLocationFilter extends NotEqualOrNullFilter<String> {
     private String m_location;
 
     public NegativeLocationFilter(final String location) {
-        super(TYPE, SQLType.STRING, "NODE.LOCATION", "node.location.locationName", location);
+        super(TYPE, SQLType.STRING, "MONITORINGSYSTEMS.LOCATION", "distPoller.location", location);
         m_location = location;
     }
 

--- a/opennms-webapp/src/main/java/org/opennms/web/notification/filter/NegativeNodeLocationFilter.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/notification/filter/NegativeNodeLocationFilter.java
@@ -1,7 +1,7 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2009-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2002-2014 The OpenNMS Group, Inc.
  * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
@@ -28,30 +28,30 @@
 
 package org.opennms.web.notification.filter;
 
-import org.opennms.web.filter.EqualsFilter;
+import org.opennms.web.filter.NotEqualOrNullFilter;
 import org.opennms.web.filter.SQLType;
 
 /**
  * Encapsulates all node location filtering functionality.
  */
-public class LocationFilter extends EqualsFilter<String> {
-    public static final String TYPE = "location";
+public class NegativeNodeLocationFilter extends NotEqualOrNullFilter<String> {
+    public static final String TYPE = "nodelocationnot";
     private String m_location;
 
-    public LocationFilter(final String location) {
-        super(TYPE, SQLType.STRING, "MONITORINGSYSTEMS.LOCATION", "distPoller.location", location);
+    public NegativeNodeLocationFilter(final String location) {
+        super(TYPE, SQLType.STRING, "NODE.LOCATION", "node.location.locationName", location);
         m_location = location;
     }
 
     @Override
     public String getTextDescription() {
-        return ("location is " + m_location);
+        return ("node location is not " + m_location);
     }
 
     @Override
     public boolean equals(Object obj) {
         if (obj == null) return false;
-        if (!(obj instanceof LocationFilter)) return false;
+        if (!(obj instanceof NegativeNodeLocationFilter)) return false;
         return (this.toString().equals(obj.toString()));
     }
 }

--- a/opennms-webapp/src/main/java/org/opennms/web/notification/filter/NodeLocationFilter.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/notification/filter/NodeLocationFilter.java
@@ -34,24 +34,24 @@ import org.opennms.web.filter.SQLType;
 /**
  * Encapsulates all node location filtering functionality.
  */
-public class LocationFilter extends EqualsFilter<String> {
-    public static final String TYPE = "location";
+public class NodeLocationFilter extends EqualsFilter<String> {
+    public static final String TYPE = "nodelocation";
     private String m_location;
 
-    public LocationFilter(final String location) {
-        super(TYPE, SQLType.STRING, "MONITORINGSYSTEMS.LOCATION", "distPoller.location", location);
+    public NodeLocationFilter(final String location) {
+        super(TYPE, SQLType.STRING, "NODE.LOCATION", "node.location.locationName", location);
         m_location = location;
     }
 
     @Override
     public String getTextDescription() {
-        return ("location is " + m_location);
+        return ("node location is " + m_location);
     }
 
     @Override
     public boolean equals(Object obj) {
         if (obj == null) return false;
-        if (!(obj instanceof LocationFilter)) return false;
+        if (!(obj instanceof NodeLocationFilter)) return false;
         return (this.toString().equals(obj.toString()));
     }
 }

--- a/opennms-webapp/src/main/java/org/opennms/web/outage/Outage.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/outage/Outage.java
@@ -74,6 +74,8 @@ public class Outage {
 
     protected String location;
 
+    protected String eventLocation;
+
     /**
      * <p>Constructor for Outage.</p>
      */
@@ -304,6 +306,14 @@ public class Outage {
         this.location = location;
     }
 
+    public String getEventLocation() {
+        return eventLocation;
+    }
+
+    public void setEventLocation(String eventLocation) {
+        this.eventLocation = eventLocation;
+    }
+
     /**
      * <p>toString</p>
      *
@@ -321,6 +331,7 @@ public class Outage {
             .append("Service Name", getServiceName())
             .append("Lost Service Time", getLostServiceTime())
             .append("Regained Service Time", getRegainedServiceTime())
+            .append("Event Location", getEventLocation())
             .append("Acknowledged By", getLostServiceNotificationAcknowledgedBy())
             .append("Suppress Time", getSuppressTime())
             .append("Suppressed By", getSuppressedBy())

--- a/opennms-webapp/src/main/webapp/WEB-INF/jsp/alarm/detail.jsp
+++ b/opennms-webapp/src/main/webapp/WEB-INF/jsp/alarm/detail.jsp
@@ -2,8 +2,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2012-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2012-2016 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2016 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -99,6 +99,16 @@
     }
     
     List<OnmsAcknowledgment> acks = (List<OnmsAcknowledgment>) request.getAttribute("acknowledgments");
+
+	String eventLocation = null;
+	String nodeLocation = null;
+
+	if (alarm.getLastEvent() != null && alarm.getLastEvent().getDistPoller() != null) {
+	    eventLocation = alarm.getLastEvent().getDistPoller().getLocation();
+	}
+	if (alarm.getNode() != null && alarm.getNode().getLocation() != null) {
+	    nodeLocation = alarm.getNode().getLocation().getLocationName();
+	}
 %>
 
 <jsp:include page="/includes/bootstrap.jsp" flush="false" >
@@ -171,6 +181,12 @@
             <% }%>
         </td>
     </tr> 
+    <tr class="severity-<%=alarm.getSeverity().getLabel().toLowerCase()%>">
+        <th class="col-md-1">Event Source Location</th>
+        <td class="col-md-3"><%= eventLocation == null? "&nbsp;" : eventLocation %>
+        <th class="col-md-1">Node Location</th>
+        <td class="col-md-3"><%= nodeLocation == null? "&nbsp;" : nodeLocation %>
+    </tr>
     <tr class="severity-<%=alarm.getSeverity().getLabel().toLowerCase()%>">
         <th class="col-md-1">Count</th>
         <td class="col-md-3"><%=alarm.getCounter()%></td>

--- a/opennms-webapp/src/main/webapp/WEB-INF/jsp/alarm/list.jsp
+++ b/opennms-webapp/src/main/webapp/WEB-INF/jsp/alarm/list.jsp
@@ -373,40 +373,46 @@
 
 
 
-			<th width="1%">
+			<th width="2%">
               <%=this.makeSortLink(callback, parms, SortStyle.ID,        SortStyle.REVERSE_ID,        "id",        "ID" ,       favorite )%>
             </th>
             <th width="6%">
               <%=this.makeSortLink(callback, parms, SortStyle.SEVERITY,  SortStyle.REVERSE_SEVERITY,  "severity",  "Severity",  favorite )%>
             </th>
-			<th width="19%">
+			<th>
               <%=this.makeSortLink(callback, parms, SortStyle.NODE,      SortStyle.REVERSE_NODE,      "node",      "Node",      favorite )%>
               <c:if test="${param.display == 'long'}">
-              <br />
-              <%=this.makeSortLink(callback, parms, SortStyle.NODE_LOCATION, SortStyle.REVERSE_NODE_LOCATION, "nodelocation", "Node Location", favorite )%>
-              <br />
+              /
               <%=this.makeSortLink(callback, parms, SortStyle.INTERFACE, SortStyle.REVERSE_INTERFACE, "interface", "Interface", favorite )%>
-              <br />
+              </th>
+              <th>
               <%=this.makeSortLink(callback, parms, SortStyle.SERVICE,   SortStyle.REVERSE_SERVICE,   "service",   "Service",   favorite )%>
+              </th>
+              <th>
+              <%=this.makeSortLink(callback, parms, SortStyle.NODE_LOCATION, SortStyle.REVERSE_NODE_LOCATION, "nodelocation", "Node Location", favorite )%>
               </c:if>
             </th>
 			<th width="3%">
               <%=this.makeSortLink(callback, parms, SortStyle.COUNT,  SortStyle.REVERSE_COUNT,  "count",  "Count", favorite  )%>
             </th>
-			<th width="13%">
-              <%=this.makeSortLink(callback, parms, SortStyle.LASTEVENTTIME,  SortStyle.REVERSE_LASTEVENTTIME,  "lasteventtime",  "Last Event Time", favorite  )%>
+			<th <% if ("long".equals(request.getParameter("display"))) { %>width="13%"<% } %>>
+              <%=this.makeSortLink(callback, parms, SortStyle.LASTEVENTTIME,  SortStyle.REVERSE_LASTEVENTTIME,  "lasteventtime",  "Last", favorite  )%>
               <c:if test="${param.display == 'long'}">
-              <br />
+              /
               <%=this.makeSortLink(callback, parms, SortStyle.FIRSTEVENTTIME,  SortStyle.REVERSE_FIRSTEVENTTIME,  "firsteventtime",  "First Event Time", favorite  )%>
-              <br />
+              </th>
+              <th>
               <%=this.makeSortLink(callback, parms, SortStyle.LOCATION,  SortStyle.REVERSE_LOCATION,  "location",  "Event Source Location", favorite  )%>
-              <br />
               <% if ( parms.getAckType().equals(AcknowledgeType.ACKNOWLEDGED.toNormalizedAcknowledgeType()) ) { %>
+              </th>
+              <th>
               <%=this.makeSortLink(callback, parms, SortStyle.ACKUSER,  SortStyle.REVERSE_ACKUSER,  "ackuser",  "Acknowledged By", favorite  )%>
               <% } %>
               </c:if>
             </th>
+            <c:if test="${param.display != 'long'}">
 			<th width="56%">Log Msg</th>
+			</c:if>
 		</tr>
 	</thead>
 
@@ -416,21 +422,21 @@
 
         <tr class="severity-<%=alarms[i].getSeverity().getLabel()%>">
           <% if( parms.getAckType().equals(AcknowledgeType.BOTH.toNormalizedAcknowledgeType()) ) { %>
-              <td class="divider" valign="middle" rowspan="1">
+              <td class="divider" valign="middle" rowspan="<%= ("long".equals(request.getParameter("display"))? 2:1) %>">
                 <nobr>
                   <input type="checkbox" name="alarm" disabled="disabled" <%=alarms[i].isAcknowledged() ? "checked='true'" : ""%> /> 
                 </nobr>
           <% } else if( req.isUserInRole( Authentication.ROLE_ADMIN ) || !req.isUserInRole( Authentication.ROLE_READONLY ) ) { %>
-              <td class="divider" valign="middle" rowspan="1">
+              <td class="divider" valign="middle" rowspan="<%= ("long".equals(request.getParameter("display"))? 2:1) %>">
                 <nobr>
                   <input type="checkbox" name="alarm" value="<%=alarms[i].getId()%>" /> 
                 </nobr>
           <% } else { %>
-            <td valign="middle" rowspan="1" class="divider">&nbsp;
+            <td valign="middle" rowspan="<%= ("long".equals(request.getParameter("display"))? 2:1) %>" class="divider">&nbsp;
           <% } %>
           </td>
 
-          <td class="divider" valign="middle" rowspan="1">
+          <td class="divider" valign="middle" rowspan="<%= ("long".equals(request.getParameter("display"))? 2:1) %>">
 
             <a style="vertical-align:middle" href="<%= Util.calculateUrlBase(request, "alarm/detail.htm?id=" + alarms[i].getId()) %>"><%=alarms[i].getId()%></a>
             <c:if test="<%= (alarms[i].getStickyMemo() != null && alarms[i].getStickyMemo().getId() != null) && (alarms[i].getReductionKeyMemo() != null && alarms[i].getReductionKeyMemo().getId() != null) %>">
@@ -446,16 +452,16 @@
           <c:if test="${param.display == 'long'}">
             <% if(alarms[i].getUei() != null) { %>
               <% Filter exactUEIFilter = new ExactUEIFilter(alarms[i].getUei()); %>
-                <br />UEI
-              <% if( !parms.getFilters().contains( exactUEIFilter )) { %>
+                <br />
                 <nobr>
+                UEI
+              <% if( !parms.getFilters().contains( exactUEIFilter )) { %>
                   <a href="<%=this.makeLink(callback, parms, exactUEIFilter, true, favorite)%>" class="filterLink" title="Show only events with this UEI">${addPositiveFilter}</a>
-                  <a href="<%=this.makeLink(callback, parms, new NegativeExactUEIFilter(alarms[i].getUei()), true, favorite)%>" class="filterLink" title="Do not show events for this UEI">${addNegativeFilter}</a>
-                </nobr>
-              <% } %>
+                  <a href="<%=this.makeLink(callback, parms, new NegativeExactUEIFilter(alarms[i].getUei()), true, favorite)%>" class="filterLink" title="Do not show events for this UEI">${addNegativeFilter}</a>              <% } %>
             <% } else { %>
               &nbsp;
             <% } %>
+            </nobr>
             <% Filter severityFilter = new SeverityFilter(alarms[i].getSeverity()); %>
             <% if( !parms.getFilters().contains( severityFilter )) { %>
 		<br />Sev.
@@ -467,17 +473,17 @@
             <% } %>
           </c:if>
           </td>
-          <td class="divider bright" valign="middle" rowspan="1">
+          <td class="divider bright" valign="middle" rowspan="<%= ("long".equals(request.getParameter("display"))? 2:1) %>">
+            <nobr>
             <strong><%= alarms[i].getSeverity().getLabel() %></strong>
             <% Filter severityFilter = new SeverityFilter(alarms[i].getSeverity()); %>
             <% if( !parms.getFilters().contains(severityFilter)) { %>
-            <nobr>
               <a href="<%=this.makeLink(callback, parms, severityFilter, true, favorite)%>" class="filterLink" title="Show only events with this severity">${addPositiveFilter}</a>
               <a href="<%=this.makeLink(callback, parms, new NegativeSeverityFilter(alarms[i].getSeverity()), true, favorite)%>" class="filterLink" title="Do not show events with this severity">${addNegativeFilter}</a>
-            </nobr>
             <% } %>
+            </nobr>
           </td>
-          <td class="divider">
+          <td>
 	    <% if(alarms[i].getNodeId() != null && alarms[i].getNodeLabel()!= null ) { %>
               <% Filter nodeFilter = new NodeFilter(alarms[i].getNodeId(), getServletContext()); %>             
               <% String[] labels = this.getNodeLabels( alarms[i].getNodeLabel() ); %>
@@ -493,18 +499,6 @@
               &nbsp;
             <% } %>
           <c:if test="${param.display == 'long'}">
-            <br />
-            <% if (alarms[i].getNodeId() != null && alarms[i].getNode() != null && alarms[i].getNode().getLocation() != null) { %>
-              <% String location = alarms[i].getNode().getLocation().getLocationName(); %>
-              <% Filter locationFilter = new NodeLocationFilter(location); %>
-              <a href="element/node.jsp?node=<%=alarms[i].getNodeId()%>"><%= location %></a>
-              <% if( !parms.getFilters().contains(locationFilter) ) { %>
-                <nobr>
-                  <a href="<%=this.makeLink(callback, parms, locationFilter, true, favorite)%>" class="filterLink" title="Show only alarms for this node location">${addPositiveFilter}</a>
-                  <a href="<%=this.makeLink(callback, parms, new NegativeNodeLocationFilter(location), true, favorite)%>" class="filterLink" title="Do not show alarms for this node location">${addNegativeFilter}</a>
-                </nobr>
-              <% } %>
-            <% } %>
 		    <br />
             <% if(alarms[i].getIpAddr() != null ) { %>
               <% Filter intfFilter = new InterfaceFilter(alarms[i].getIpAddr()); %>
@@ -526,7 +520,21 @@
             <% } else { %>
               &nbsp;
             <% } %>
-          <br />
+            </td>
+            <td>
+            <% if (alarms[i].getNodeId() != null && alarms[i].getNode() != null && alarms[i].getNode().getLocation() != null) { %>
+              <% String location = alarms[i].getNode().getLocation().getLocationName(); %>
+              <% Filter locationFilter = new NodeLocationFilter(location); %>
+              <a href="element/node.jsp?node=<%=alarms[i].getNodeId()%>"><%= location %></a>
+              <% if( !parms.getFilters().contains(locationFilter) ) { %>
+                <nobr>
+                  <a href="<%=this.makeLink(callback, parms, locationFilter, true, favorite)%>" class="filterLink" title="Show only alarms for this node location">${addPositiveFilter}</a>
+                  <a href="<%=this.makeLink(callback, parms, new NegativeNodeLocationFilter(location), true, favorite)%>" class="filterLink" title="Do not show alarms for this node location">${addNegativeFilter}</a>
+                </nobr>
+              <% } %>
+            <% } %>
+            </td>
+            <td>
             <% if(alarms[i].getServiceType() != null && !"".equals(alarms[i].getServiceType().getName())) { %>
               <% Filter serviceFilter = new ServiceFilter(alarms[i].getServiceType().getId(), getServletContext()); %>
               <% if( alarms[i].getNodeId() != null && alarms[i].getIpAddr() != null ) { %>
@@ -548,7 +556,7 @@
             <% } %>
             </c:if>
           </td>          
-          <td class="divider" valign="middle" rowspan="1" >
+          <td valign="middle">
 	    <% if(alarms[i].getId() > 0 ) { %>           
                 <nobr>
                   <a href="event/list.htm?sortby=id&amp;acktype=unack&amp;filter=alarm%3d<%=alarms[i].getId()%>"><%=alarms[i].getCounter()%></a>
@@ -557,7 +565,7 @@
             <%=alarms[i].getCounter()%>
             <% } %>
           </td>
-          <td class="divider">
+          <td>
             <nobr>
               <% if(alarms[i].getLastEvent() != null) { %><span title="Event <%= alarms[i].getLastEvent().getId()%>"><a href="event/detail.htm?id=<%= alarms[i].getLastEvent().getId()%>"><% } %>
                 <fmt:formatDate value="${alarm.lastEventTime}" type="BOTH" />
@@ -572,7 +580,8 @@
               <a href="<%=this.makeLink(callback, parms, new AfterFirstEventTimeFilter(alarms[i].getFirstEventTime()), true, favorite)%>"  class="filterLink" title="Only show alarms occurring after this one">${addAfterFilter}</a>
               <a href="<%=this.makeLink(callback, parms, new BeforeFirstEventTimeFilter(alarms[i].getFirstEventTime()), true, favorite)%>" class="filterLink" title="Only show alarms occurring before this one">${addBeforeFilter}</a>
             </nobr>
-          <br />
+          </td>
+          <td>
             <% if (alarms[i].getDistPoller() != null && alarms[i].getLastEvent() != null) { %>
               <% String location = alarms[i].getDistPoller().getLocation(); %>
               <% Filter locationFilter = new LocationFilter(location); %>
@@ -586,8 +595,9 @@
                 </nobr>
               <% } %>
             <% } %>
-          <br />
               <% if ( parms.getAckType().equals(AcknowledgeType.ACKNOWLEDGED.toNormalizedAcknowledgeType()) ) { %>
+          </td>
+          <td>
 			<nobr><%=alarms[i].getAckUser()%></nobr>          
             <nobr>
               <a href="<%=this.makeLink(callback, parms, new AcknowledgedByFilter(alarms[i].getAckUser()), true, favorite)%>"  class="filterLink" title="Only show alarms ack by this user">${addPositiveFilter}</a>
@@ -596,8 +606,15 @@
 			<% }%>
           </c:if>
           </td>
+          <c:if test="${param.display != 'long'}">
           <td class="divider"><%=WebSecurityUtils.sanitizeString(alarms[i].getLogMsg(), true)%></td>
+          </c:if>
+        </tr>
+        <c:if test="${param.display == 'long'}">
+        <tr class="severity-<%=alarms[i].getSeverity().getLabel()%>">
+          <td colspan="7" class="divider" style="border-top: none"><%=WebSecurityUtils.sanitizeString(alarms[i].getLogMsg(), true)%></td>
         </tr> 
+        </c:if>
       <% } /*end for*/%>
 
       </table>

--- a/opennms-webapp/src/main/webapp/WEB-INF/jsp/alarm/list.jsp
+++ b/opennms-webapp/src/main/webapp/WEB-INF/jsp/alarm/list.jsp
@@ -3,7 +3,7 @@
  * This file is part of OpenNMS(R).
  *
  * Copyright (C) 2002-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2016 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -383,6 +383,8 @@
               <%=this.makeSortLink(callback, parms, SortStyle.NODE,      SortStyle.REVERSE_NODE,      "node",      "Node",      favorite )%>
               <c:if test="${param.display == 'long'}">
               <br />
+              <%=this.makeSortLink(callback, parms, SortStyle.NODE_LOCATION, SortStyle.REVERSE_NODE_LOCATION, "nodelocation", "Node Location", favorite )%>
+              <br />
               <%=this.makeSortLink(callback, parms, SortStyle.INTERFACE, SortStyle.REVERSE_INTERFACE, "interface", "Interface", favorite )%>
               <br />
               <%=this.makeSortLink(callback, parms, SortStyle.SERVICE,   SortStyle.REVERSE_SERVICE,   "service",   "Service",   favorite )%>
@@ -396,6 +398,8 @@
               <c:if test="${param.display == 'long'}">
               <br />
               <%=this.makeSortLink(callback, parms, SortStyle.FIRSTEVENTTIME,  SortStyle.REVERSE_FIRSTEVENTTIME,  "firsteventtime",  "First Event Time", favorite  )%>
+              <br />
+              <%=this.makeSortLink(callback, parms, SortStyle.LOCATION,  SortStyle.REVERSE_LOCATION,  "location",  "Event Source Location", favorite  )%>
               <br />
               <% if ( parms.getAckType().equals(AcknowledgeType.ACKNOWLEDGED.toNormalizedAcknowledgeType()) ) { %>
               <%=this.makeSortLink(callback, parms, SortStyle.ACKUSER,  SortStyle.REVERSE_ACKUSER,  "ackuser",  "Acknowledged By", favorite  )%>
@@ -489,7 +493,19 @@
               &nbsp;
             <% } %>
           <c:if test="${param.display == 'long'}">
-		<br />
+            <br />
+            <% if (alarms[i].getNodeId() != null && alarms[i].getNode() != null && alarms[i].getNode().getLocation() != null) { %>
+              <% String location = alarms[i].getNode().getLocation().getLocationName(); %>
+              <% Filter locationFilter = new NodeLocationFilter(location); %>
+              <a href="element/node.jsp?node=<%=alarms[i].getNodeId()%>"><%= location %></a>
+              <% if( !parms.getFilters().contains(locationFilter) ) { %>
+                <nobr>
+                  <a href="<%=this.makeLink(callback, parms, locationFilter, true, favorite)%>" class="filterLink" title="Show only alarms for this node location">${addPositiveFilter}</a>
+                  <a href="<%=this.makeLink(callback, parms, new NegativeNodeLocationFilter(location), true, favorite)%>" class="filterLink" title="Do not show alarms for this node location">${addNegativeFilter}</a>
+                </nobr>
+              <% } %>
+            <% } %>
+		    <br />
             <% if(alarms[i].getIpAddr() != null ) { %>
               <% Filter intfFilter = new InterfaceFilter(alarms[i].getIpAddr()); %>
               <% if( alarms[i].getNodeId() != null ) { %>
@@ -556,6 +572,20 @@
               <a href="<%=this.makeLink(callback, parms, new AfterFirstEventTimeFilter(alarms[i].getFirstEventTime()), true, favorite)%>"  class="filterLink" title="Only show alarms occurring after this one">${addAfterFilter}</a>
               <a href="<%=this.makeLink(callback, parms, new BeforeFirstEventTimeFilter(alarms[i].getFirstEventTime()), true, favorite)%>" class="filterLink" title="Only show alarms occurring before this one">${addBeforeFilter}</a>
             </nobr>
+          <br />
+            <% if (alarms[i].getDistPoller() != null && alarms[i].getLastEvent() != null) { %>
+              <% String location = alarms[i].getDistPoller().getLocation(); %>
+              <% Filter locationFilter = new LocationFilter(location); %>
+              <span title="Event source location <%= location %>"><a href="event/detail.htm?id=<%= alarms[i].getLastEvent().getId()%>">
+                <%= location %>
+              </a></span>
+              <% if( !parms.getFilters().contains(locationFilter) ) { %>
+                <nobr>
+                  <a href="<%=this.makeLink(callback, parms, locationFilter, true, favorite)%>" class="filterLink" title="Show only alarms for this event source location">${addPositiveFilter}</a>
+                  <a href="<%=this.makeLink(callback, parms, new NegativeLocationFilter(location), true, favorite)%>" class="filterLink" title="Do not show alarms for this event source location">${addNegativeFilter}</a>
+                </nobr>
+              <% } %>
+            <% } %>
           <br />
               <% if ( parms.getAckType().equals(AcknowledgeType.ACKNOWLEDGED.toNormalizedAcknowledgeType()) ) { %>
 			<nobr><%=alarms[i].getAckUser()%></nobr>          

--- a/opennms-webapp/src/main/webapp/WEB-INF/jsp/event/detail.jsp
+++ b/opennms-webapp/src/main/webapp/WEB-INF/jsp/event/detail.jsp
@@ -2,7 +2,7 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2002-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2002-2016 The OpenNMS Group, Inc.
  * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
@@ -128,10 +128,10 @@
           </c:if>
         </tr>
           <tr class="severity-<%= event.getSeverity().getLabel().toLowerCase() %>">
-              <th class="col-md-1">Location</th>
-              <td class="col-md-3"><%=event.getLocation()%></td>
-              <th class="col-md-1">System-ID</th>
-              <td class="col-md-3"><%=event.getSystemId()%></td>
+              <th class="col-md-1">Event Source Location</th>
+              <td class="col-md-3"><%=event.getLocation()%> (<%= event.getSystemId() %>)</td>
+              <th class="col-md-1">Node Location</th>
+              <td class="col-md-3"><%= event.getNodeLocation() %></td>
           </tr>
           <tr class="severity-<%= event.getSeverity().getLabel().toLowerCase() %>">
           <th class="col-md-1">Time</th>

--- a/opennms-webapp/src/main/webapp/WEB-INF/jsp/event/list.jsp
+++ b/opennms-webapp/src/main/webapp/WEB-INF/jsp/event/list.jsp
@@ -366,14 +366,15 @@
 							<th width="1%">&nbsp;</th>
 						<% } %>
           <% } %>
-          <th width="01%"><%=this.makeSortLink(callback, parms, SortStyle.ID,        SortStyle.REVERSE_ID,        "id",        "ID"        , favorite)%></th>
-          <th width="06%"><%=this.makeSortLink(callback, parms, SortStyle.SEVERITY,  SortStyle.REVERSE_SEVERITY,  "severity",  "Severity"  , favorite)%></th>
-          <th width="10%"><%=this.makeSortLink(callback, parms, SortStyle.TIME,      SortStyle.REVERSE_TIME,      "time",      "Time"      , favorite)%></th>
-          <th width="05%"><%=this.makeSortLink(callback, parms, SortStyle.LOCATION,  SortStyle.REVERSE_LOCATION,  "location",  "Location"  , favorite)%></th>
-          <th width="19%"><%=this.makeSortLink(callback, parms, SortStyle.SYSTEMID,  SortStyle.REVERSE_SYSTEMID,  "systemid",  "System-ID" , favorite)%></th>
-          <th width="18%"><%=this.makeSortLink(callback, parms, SortStyle.NODE,      SortStyle.REVERSE_NODE,      "node",      "Node"      , favorite)%></th>
-          <th width="14%"><%=this.makeSortLink(callback, parms, SortStyle.INTERFACE, SortStyle.REVERSE_INTERFACE, "interface", "Interface" , favorite)%></th>
-          <th width="13%"><%=this.makeSortLink(callback, parms, SortStyle.SERVICE,   SortStyle.REVERSE_SERVICE,   "service",   "Service"   , favorite)%></th>
+          <th width="01%"><%=this.makeSortLink(callback, parms, SortStyle.ID,            SortStyle.REVERSE_ID,            "id",           "ID"            , favorite)%></th>
+          <th width="06%"><%=this.makeSortLink(callback, parms, SortStyle.SEVERITY,      SortStyle.REVERSE_SEVERITY,      "severity",     "Severity"      , favorite)%></th>
+          <th width="10%"><%=this.makeSortLink(callback, parms, SortStyle.TIME,          SortStyle.REVERSE_TIME,          "time",         "Time"          , favorite)%></th>
+          <th width="05%"><%=this.makeSortLink(callback, parms, SortStyle.LOCATION,      SortStyle.REVERSE_LOCATION,      "location",     "Location"      , favorite)%></th>
+          <th width="19%"><%=this.makeSortLink(callback, parms, SortStyle.SYSTEMID,      SortStyle.REVERSE_SYSTEMID,      "systemid",     "System-ID"     , favorite)%></th>
+          <th width="18%"><%=this.makeSortLink(callback, parms, SortStyle.NODE,          SortStyle.REVERSE_NODE,          "node",         "Node"          , favorite)%></th>
+          <th width="05%"><%=this.makeSortLink(callback, parms, SortStyle.NODE_LOCATION, SortStyle.REVERSE_NODE_LOCATION, "nodelocation", "Node-Location" , favorite)%></th>
+          <th width="14%"><%=this.makeSortLink(callback, parms, SortStyle.INTERFACE,     SortStyle.REVERSE_INTERFACE,     "interface",    "Interface"     , favorite)%></th>
+          <th width="13%"><%=this.makeSortLink(callback, parms, SortStyle.SERVICE,       SortStyle.REVERSE_SERVICE,       "service",      "Service"       , favorite)%></th>
         </tr>
         </thead>     
       <% for( int i=0; i < events.length; i++ ) {
@@ -458,6 +459,21 @@
             <% } %>
           </td>
           <td class="divider">
+              <% if(!Strings.isNullOrEmpty(events[i].getNodeLocation())) { %>
+              <% Filter nodeLocationFilter = new NodeLocationFilter(events[i].getNodeLocation()); %>
+              <%=events[i].getNodeLocation()%></a>
+
+              <% if( !parms.getFilters().contains(nodeLocationFilter) ) { %>
+              <nobr>
+                  <a href="<%=this.makeLink(callback, parms, nodeLocationFilter, true, favorite)%>" class="filterLink" title="Show only events for this node location">${addPositiveFilter}</a>
+                  <a href="<%=this.makeLink(callback, parms, new NegativeNodeLocationFilter(events[i].getNodeLocation()), true, favorite)%>" class="filterLink" title="Do not show events for this node location">${addNegativeFilter}</a>
+              </nobr>
+              <% } %>
+              <% } else { %>
+              &nbsp;
+              <% } %>
+          </td>
+          <td class="divider">
             <% if(events[i].getIpAddress() != null ) { %>
               <% Filter intfFilter = new InterfaceFilter(events[i].getIpAddress()); %>
               <% if( events[i].getNodeId() != 0 ) { %>
@@ -506,7 +522,7 @@
         </tr>
         
         <tr valign="top" class="severity-<%= events[i].getSeverity().getLabel() %>">
-          <td colspan="6">
+          <td colspan="7">
             <% if(events[i].getUei() != null) { %>
               <% Filter exactUEIFilter = new ExactUEIFilter(events[i].getUei()); %>
                 <%=events[i].getUei()%>

--- a/opennms-webapp/src/main/webapp/WEB-INF/jsp/event/list.jsp
+++ b/opennms-webapp/src/main/webapp/WEB-INF/jsp/event/list.jsp
@@ -3,7 +3,7 @@
  * This file is part of OpenNMS(R).
  *
  * Copyright (C) 2002-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2016 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -366,15 +366,15 @@
 							<th width="1%">&nbsp;</th>
 						<% } %>
           <% } %>
-          <th width="01%"><%=this.makeSortLink(callback, parms, SortStyle.ID,            SortStyle.REVERSE_ID,            "id",           "ID"            , favorite)%></th>
-          <th width="06%"><%=this.makeSortLink(callback, parms, SortStyle.SEVERITY,      SortStyle.REVERSE_SEVERITY,      "severity",     "Severity"      , favorite)%></th>
-          <th width="10%"><%=this.makeSortLink(callback, parms, SortStyle.TIME,          SortStyle.REVERSE_TIME,          "time",         "Time"          , favorite)%></th>
-          <th width="05%"><%=this.makeSortLink(callback, parms, SortStyle.LOCATION,      SortStyle.REVERSE_LOCATION,      "location",     "Location"      , favorite)%></th>
-          <th width="19%"><%=this.makeSortLink(callback, parms, SortStyle.SYSTEMID,      SortStyle.REVERSE_SYSTEMID,      "systemid",     "System-ID"     , favorite)%></th>
-          <th width="18%"><%=this.makeSortLink(callback, parms, SortStyle.NODE,          SortStyle.REVERSE_NODE,          "node",         "Node"          , favorite)%></th>
-          <th width="05%"><%=this.makeSortLink(callback, parms, SortStyle.NODE_LOCATION, SortStyle.REVERSE_NODE_LOCATION, "nodelocation", "Node-Location" , favorite)%></th>
-          <th width="14%"><%=this.makeSortLink(callback, parms, SortStyle.INTERFACE,     SortStyle.REVERSE_INTERFACE,     "interface",    "Interface"     , favorite)%></th>
-          <th width="13%"><%=this.makeSortLink(callback, parms, SortStyle.SERVICE,       SortStyle.REVERSE_SERVICE,       "service",      "Service"       , favorite)%></th>
+          <th width="01%"><%=this.makeSortLink(callback, parms, SortStyle.ID,            SortStyle.REVERSE_ID,            "id",           "ID"                  , favorite)%></th>
+          <th width="06%"><%=this.makeSortLink(callback, parms, SortStyle.SEVERITY,      SortStyle.REVERSE_SEVERITY,      "severity",     "Severity"            , favorite)%></th>
+          <th width="10%"><%=this.makeSortLink(callback, parms, SortStyle.TIME,          SortStyle.REVERSE_TIME,          "time",         "Time"                , favorite)%></th>
+          <th width="05%"><%=this.makeSortLink(callback, parms, SortStyle.LOCATION,      SortStyle.REVERSE_LOCATION,      "location",     "Source&nbsp;Location", favorite)%></th>
+          <th width="19%"><%=this.makeSortLink(callback, parms, SortStyle.SYSTEMID,      SortStyle.REVERSE_SYSTEMID,      "systemid",     "System-ID"           , favorite)%></th>
+          <th width="18%"><%=this.makeSortLink(callback, parms, SortStyle.NODE,          SortStyle.REVERSE_NODE,          "node",         "Node"                , favorite)%></th>
+          <th width="05%"><%=this.makeSortLink(callback, parms, SortStyle.NODE_LOCATION, SortStyle.REVERSE_NODE_LOCATION, "nodelocation", "Node&nbsp;Location"  , favorite)%></th>
+          <th width="14%"><%=this.makeSortLink(callback, parms, SortStyle.INTERFACE,     SortStyle.REVERSE_INTERFACE,     "interface",    "Interface"           , favorite)%></th>
+          <th width="13%"><%=this.makeSortLink(callback, parms, SortStyle.SERVICE,       SortStyle.REVERSE_SERVICE,       "service",      "Service"             , favorite)%></th>
         </tr>
         </thead>     
       <% for( int i=0; i < events.length; i++ ) {
@@ -396,18 +396,18 @@
           <td valign="top" rowspan="3" class="divider"><a href="event/detail.jsp?id=<%=events[i].getId()%>"><%=events[i].getId()%></a></td>
           
           <td valign="top" rowspan="3" class="divider bright"> 
+            <nobr>
             <strong><%= events[i].getSeverity().getLabel() %></strong>
             <% Filter severityFilter = new SeverityFilter(events[i].getSeverity()); %>      
             <% if( !parms.getFilters().contains(severityFilter)) { %>
-              <nobr>
                 <a href="<%=this.makeLink(callback, parms, severityFilter, true, favorite)%>" class="filterLink" title="Show only events with this severity">${addPositiveFilter}</a>
                 <a href="<%=this.makeLink(callback, parms, new NegativeSeverityFilter(events[i].getSeverity()), true, favorite)%>" class="filterLink" title="Do not show events with this severity">${addNegativeFilter}</a>
-              </nobr>
             <% } %>
+            </nobr>
           </td>
           <td class="divider">
-            <nobr><fmt:formatDate value="${event.time}" type="BOTH" /></nobr>
             <nobr>
+              <fmt:formatDate value="${event.time}" type="BOTH" />
               <a href="<%=this.makeLink(callback, parms, new AfterDateFilter(events[i].getTime()), true, favorite)%>"  class="filterLink" title="Only show events occurring after this one">${addAfterFilter}</a>
               <a href="<%=this.makeLink(callback, parms, new BeforeDateFilter(events[i].getTime()), true, favorite)%>" class="filterLink" title="Only show events occurring before this one">${addBeforeFilter}</a>
             </nobr>

--- a/opennms-webapp/src/main/webapp/WEB-INF/jsp/notification/list.jsp
+++ b/opennms-webapp/src/main/webapp/WEB-INF/jsp/notification/list.jsp
@@ -63,6 +63,8 @@
     @SuppressWarnings("unchecked")
     Map<Integer,String[]> nodeLabels = (Map<Integer,String[]>)request.getAttribute( "nodeLabels" );
     @SuppressWarnings("unchecked")
+    Map<Integer,String[]> nodeLocations = (Map<Integer,String[]>)request.getAttribute( "nodeLocations" );
+    @SuppressWarnings("unchecked")
     Map<Integer,Event> events = (Map<Integer,Event>)request.getAttribute( "events" );
 
     if( notices == null || parms == null || nodeLabels == null ) {
@@ -197,13 +199,14 @@
 			  <tr>
           <th nowrap><%=this.makeSortLink( parms, SortStyle.ID,SortStyle.REVERSE_ID,     "id",          "ID"           )%></th>
           <th nowrap>Event ID</th>
-          <th><%=this.makeSortLink( parms, SortStyle.SEVERITY,    SortStyle.REVERSE_SEVERITY,    "severity",    "Severity"     )%></th>
-          <th><%=this.makeSortLink( parms, SortStyle.PAGETIME,    SortStyle.REVERSE_PAGETIME,    "pagetime",    "Sent Time"    )%></th>
-          <th><%=this.makeSortLink( parms, SortStyle.RESPONDER,   SortStyle.REVERSE_RESPONDER,   "answeredby",  "Responder"    )%></th>
-          <th><%=this.makeSortLink( parms, SortStyle.RESPONDTIME, SortStyle.REVERSE_RESPONDTIME, "respondtime", "Respond Time" )%></th>  
-          <th><%=this.makeSortLink( parms, SortStyle.NODE,        SortStyle.REVERSE_NODE,        "node",        "Node"         )%></th>
-          <th><%=this.makeSortLink( parms, SortStyle.INTERFACE,   SortStyle.REVERSE_INTERFACE,   "interface",   "Interface"    )%></th>
-          <th><%=this.makeSortLink( parms, SortStyle.SERVICE,     SortStyle.REVERSE_SERVICE,     "service",     "Service"      )%></th>
+          <th><%=this.makeSortLink( parms, SortStyle.SEVERITY,    SortStyle.REVERSE_SEVERITY,    "severity",    "Severity"      )%></th>
+          <th><%=this.makeSortLink( parms, SortStyle.PAGETIME,    SortStyle.REVERSE_PAGETIME,    "pagetime",    "Sent Time"     )%></th>
+          <th><%=this.makeSortLink( parms, SortStyle.RESPONDER,   SortStyle.REVERSE_RESPONDER,   "answeredby",  "Responder"     )%></th>
+          <th><%=this.makeSortLink( parms, SortStyle.RESPONDTIME, SortStyle.REVERSE_RESPONDTIME, "respondtime", "Respond Time"  )%></th>  
+          <th><%=this.makeSortLink( parms, SortStyle.NODE,        SortStyle.REVERSE_NODE,        "node",        "Node"          )%></th>
+          <th><%=this.makeSortLink( parms, SortStyle.LOCATION,    SortStyle.REVERSE_LOCATION,    "location",    "Node Location" )%></th>
+          <th><%=this.makeSortLink( parms, SortStyle.INTERFACE,   SortStyle.REVERSE_INTERFACE,   "interface",   "Interface"     )%></th>
+          <th><%=this.makeSortLink( parms, SortStyle.SERVICE,     SortStyle.REVERSE_SERVICE,     "service",     "Service"       )%></th>
         </tr>
       </thead>
 
@@ -255,7 +258,18 @@
               <% if( parms.filters != null && !parms.filters.contains(nodeFilter) ) { %>
 
                 <a href="<%=this.makeLink( parms, nodeFilter, true)%>" class="filterLink" title="Show only notices on this node">${addPositiveFilter}</a>
-                <a href="<%=this.makeLink( parms, new NegativeNodeFilter(notification.getNodeId(), getServletContext()), true)%>" class="filterLink" title="Do not show events for this node">${addNegativeFilter}</a>
+                <a href="<%=this.makeLink( parms, new NegativeNodeFilter(notification.getNodeId(), getServletContext()), true)%>" class="filterLink" title="Do not show notices for this node">${addNegativeFilter}</a>
+              <% } %>
+            <% } %>
+          </td>
+          <td class="divider">
+            <% if(notification.getNodeId() > 0 ) { %>
+              <% String[] locations = nodeLocations.get(notification.getNodeId()); %>
+              <% Filter locationFilter = new LocationFilter(locations[1]); %>
+              <a href="element/node.jsp?node=<%=notification.getNodeId()%>" title="<%=locations[1]%>"><%=locations[0]%></a>
+              <% if( parms.filters != null && !parms.filters.contains(locationFilter) ) { %>
+                <a href="<%=this.makeLink( parms, locationFilter, true)%>" class="filterLink" title="Show only notices for this node location">${addPositiveFilter}</a>
+                <a href="<%=this.makeLink( parms, new NegativeLocationFilter(locations[1]), true)%>" class="filterLink" title="Do not show notices for this node location">${addNegativeFilter}</a>
               <% } %>
             <% } %>
           </td>
@@ -296,7 +310,7 @@
           </td>
         </tr>
         <tr class="severity-<%=eventSeverity%>">
-          <td colspan="6"><%=WebSecurityUtils.sanitizeString(notification.getTextMessage())%></td> 
+          <td colspan="7"><%=WebSecurityUtils.sanitizeString(notification.getTextMessage())%></td> 
         </tr>
       <% } /*end for*/%>
       </table>

--- a/opennms-webapp/src/main/webapp/WEB-INF/jsp/notification/list.jsp
+++ b/opennms-webapp/src/main/webapp/WEB-INF/jsp/notification/list.jsp
@@ -199,14 +199,15 @@
 			  <tr>
           <th nowrap><%=this.makeSortLink( parms, SortStyle.ID,SortStyle.REVERSE_ID,     "id",          "ID"           )%></th>
           <th nowrap>Event ID</th>
-          <th><%=this.makeSortLink( parms, SortStyle.SEVERITY,    SortStyle.REVERSE_SEVERITY,    "severity",    "Severity"      )%></th>
-          <th><%=this.makeSortLink( parms, SortStyle.PAGETIME,    SortStyle.REVERSE_PAGETIME,    "pagetime",    "Sent Time"     )%></th>
-          <th><%=this.makeSortLink( parms, SortStyle.RESPONDER,   SortStyle.REVERSE_RESPONDER,   "answeredby",  "Responder"     )%></th>
-          <th><%=this.makeSortLink( parms, SortStyle.RESPONDTIME, SortStyle.REVERSE_RESPONDTIME, "respondtime", "Respond Time"  )%></th>  
-          <th><%=this.makeSortLink( parms, SortStyle.NODE,        SortStyle.REVERSE_NODE,        "node",        "Node"          )%></th>
-          <th><%=this.makeSortLink( parms, SortStyle.LOCATION,    SortStyle.REVERSE_LOCATION,    "location",    "Node Location" )%></th>
-          <th><%=this.makeSortLink( parms, SortStyle.INTERFACE,   SortStyle.REVERSE_INTERFACE,   "interface",   "Interface"     )%></th>
-          <th><%=this.makeSortLink( parms, SortStyle.SERVICE,     SortStyle.REVERSE_SERVICE,     "service",     "Service"       )%></th>
+          <th><%=this.makeSortLink( parms, SortStyle.SEVERITY,      SortStyle.REVERSE_SEVERITY,      "severity",     "Severity"         )%></th>
+          <th><%=this.makeSortLink( parms, SortStyle.PAGETIME,      SortStyle.REVERSE_PAGETIME,      "pagetime",     "Sent&nbsp;Time"   )%></th>
+          <th><%=this.makeSortLink( parms, SortStyle.LOCATION,      SortStyle.REVERSE_LOCATION,      "location",     "Source&nbsp;Loc." )%></th>
+          <th><%=this.makeSortLink( parms, SortStyle.RESPONDER,     SortStyle.REVERSE_RESPONDER,     "answeredby",   "Responder"        )%></th>
+          <th><%=this.makeSortLink( parms, SortStyle.RESPONDTIME,   SortStyle.REVERSE_RESPONDTIME,   "respondtime",  "Respond&nbsp;Time")%></th>  
+          <th><%=this.makeSortLink( parms, SortStyle.NODE,          SortStyle.REVERSE_NODE,          "node",         "Node"             )%></th>
+          <th><%=this.makeSortLink( parms, SortStyle.NODE_LOCATION, SortStyle.REVERSE_NODE_LOCATION, "nodelocation", "Node&nbsp;Loc."   )%></th>
+          <th><%=this.makeSortLink( parms, SortStyle.INTERFACE,     SortStyle.REVERSE_INTERFACE,     "interface",    "Interface"        )%></th>
+          <th><%=this.makeSortLink( parms, SortStyle.SERVICE,       SortStyle.REVERSE_SERVICE,       "service",      "Service"          )%></th>
         </tr>
       </thead>
 
@@ -236,6 +237,18 @@
           <td class="bright divider" rowspan="2"><%=eventSeverity%></td>
           <td class="divider"><fmt:formatDate value="<%=notification.getTimeSent()%>" type="BOTH" /></td>
           <td class="divider">
+            <% if ( event != null ) { %>
+              <% Filter locationFilter = new LocationFilter(event.getLocation()); %>
+              <a href="event/detail.jsp?id=<%=notification.getEventId()%>"><%= event.getLocation() %></a>
+              <% if (parms.filters != null && !parms.filters.contains( locationFilter )) { %>
+                <nobr>
+                  <a href="<%=this.makeLink( parms, locationFilter, true)%>" class="filterLink" title="Show only notices from this event source location">${addPositiveFilter}</a>
+                  <a href="<%=this.makeLink( parms, new NegativeLocationFilter(event.getLocation()), true)%>" class="filterLink" title="Do not show notices from this event source location">${addNegativeFilter}</a>
+                </nobr>
+              <% } %>
+            <% } %>
+          </td>
+          <td class="divider">
           <% final String responder = notification.getResponder(); %>
           <% if (responder != null) { %>
             <% Filter responderFilter = new ResponderFilter(responder); %>      
@@ -256,20 +269,23 @@
               <% String[] labels = nodeLabels.get(notification.getNodeId()); %>
               <a href="element/node.jsp?node=<%=notification.getNodeId()%>" title="<%=labels[1]%>"><%=labels[0]%></a>
               <% if( parms.filters != null && !parms.filters.contains(nodeFilter) ) { %>
-
-                <a href="<%=this.makeLink( parms, nodeFilter, true)%>" class="filterLink" title="Show only notices on this node">${addPositiveFilter}</a>
-                <a href="<%=this.makeLink( parms, new NegativeNodeFilter(notification.getNodeId(), getServletContext()), true)%>" class="filterLink" title="Do not show notices for this node">${addNegativeFilter}</a>
+                <nobr>
+                  <a href="<%=this.makeLink( parms, nodeFilter, true)%>" class="filterLink" title="Show only notices on this node">${addPositiveFilter}</a>
+                  <a href="<%=this.makeLink( parms, new NegativeNodeFilter(notification.getNodeId(), getServletContext()), true)%>" class="filterLink" title="Do not show notices for this node">${addNegativeFilter}</a>
+                </nobr>
               <% } %>
             <% } %>
           </td>
           <td class="divider">
             <% if(notification.getNodeId() > 0 ) { %>
               <% String[] locations = nodeLocations.get(notification.getNodeId()); %>
-              <% Filter locationFilter = new LocationFilter(locations[1]); %>
+              <% Filter nodeLocationFilter = new NodeLocationFilter(locations[1]); %>
               <a href="element/node.jsp?node=<%=notification.getNodeId()%>" title="<%=locations[1]%>"><%=locations[0]%></a>
-              <% if( parms.filters != null && !parms.filters.contains(locationFilter) ) { %>
-                <a href="<%=this.makeLink( parms, locationFilter, true)%>" class="filterLink" title="Show only notices for this node location">${addPositiveFilter}</a>
-                <a href="<%=this.makeLink( parms, new NegativeLocationFilter(locations[1]), true)%>" class="filterLink" title="Do not show notices for this node location">${addNegativeFilter}</a>
+              <% if( parms.filters != null && !parms.filters.contains(nodeLocationFilter) ) { %>
+                <nobr>
+                  <a href="<%=this.makeLink( parms, nodeLocationFilter, true)%>" class="filterLink" title="Show only notices for this node location">${addPositiveFilter}</a>
+                  <a href="<%=this.makeLink( parms, new NegativeNodeLocationFilter(locations[1]), true)%>" class="filterLink" title="Do not show notices for this node location">${addNegativeFilter}</a>
+                </nobr>
               <% } %>
             <% } %>
           </td>
@@ -310,7 +326,7 @@
           </td>
         </tr>
         <tr class="severity-<%=eventSeverity%>">
-          <td colspan="7"><%=WebSecurityUtils.sanitizeString(notification.getTextMessage())%></td> 
+          <td colspan="8"><%=WebSecurityUtils.sanitizeString(notification.getTextMessage())%></td> 
         </tr>
       <% } /*end for*/%>
       </table>

--- a/opennms-webapp/src/main/webapp/WEB-INF/jsp/outage/detail.jsp
+++ b/opennms-webapp/src/main/webapp/WEB-INF/jsp/outage/detail.jsp
@@ -2,8 +2,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2002-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2002-2016 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2016 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -144,14 +144,22 @@
               &nbsp;
             <% } %>
           </td>
-          <th>Location</th>
-          <td colspan="3">
+          <th>Event Source Location</th>
+          <td>
+            <% if( outage.getEventLocation() != null ) { %>
+            <%=outage.getEventLocation()%>
+            <% } else { %>
+            &nbsp;
+            <% } %>
+          </td>
+          <th>Node Location</th>
+          <td>
             <% if( outage.getLocation() != null ) { %>
             <%=outage.getLocation()%>
             <% } else { %>
             &nbsp;
             <% } %>
-          </td>
+          <td>
         </tr>
       </table>
 </div>

--- a/opennms-webapp/src/main/webapp/WEB-INF/jsp/outage/list.jsp
+++ b/opennms-webapp/src/main/webapp/WEB-INF/jsp/outage/list.jsp
@@ -119,7 +119,7 @@
         <th><%=this.makeSortLink(request, parms, SortStyle.ID,                SortStyle.REVERSE_ID,                "id",                        "ID" )%></th>
         <th><%=this.makeSortLink(request, parms, SortStyle.FOREIGNSOURCE,     SortStyle.REVERSE_FOREIGNSOURCE,     "foreignsource",             "Foreign Source" )%></th>
         <th><%=this.makeSortLink(request, parms, SortStyle.NODE,              SortStyle.REVERSE_NODE,              "node",                      "Node")%></th>
-        <th><%=this.makeSortLink(request, parms, SortStyle.LOCATION,          SortStyle.REVERSE_LOCATION,          "location",                  "Location")%></th>
+        <th><%=this.makeSortLink(request, parms, SortStyle.LOCATION,          SortStyle.REVERSE_LOCATION,          "location",                  "Node Location")%></th>
         <th><%=this.makeSortLink(request, parms, SortStyle.INTERFACE,         SortStyle.REVERSE_INTERFACE,         "interface",                 "Interface")%></th>
         <th><%=this.makeSortLink(request, parms, SortStyle.SERVICE,           SortStyle.REVERSE_SERVICE,           "service",                   "Service")%></th>
         <th><%=this.makeSortLink(request, parms, SortStyle.IFLOSTSERVICE,     SortStyle.REVERSE_IFLOSTSERVICE,     "time service was lost",     "Down")%></th>
@@ -176,8 +176,8 @@
               <%=location%></a>
               <% Filter locationFilter = new LocationFilter(location); %>
               <% if( !parms.filters.contains(locationFilter) ) { %>
-                <a href="<%=OutageUtil.makeLink( request, parms, locationFilter, true)%>" title="Show only outages for this location"><%=ZOOM_IN_ICON%></a>
-                <a href="<%=OutageUtil.makeLink( request, parms, new NegativeLocationFilter(location), true)%>" title="Do not show outages for this location"><%=DISCARD_ICON%></a>
+                <a href="<%=OutageUtil.makeLink( request, parms, locationFilter, true)%>" title="Show only outages for this node location"><%=ZOOM_IN_ICON%></a>
+                <a href="<%=OutageUtil.makeLink( request, parms, new NegativeLocationFilter(location), true)%>" title="Do not show outages for this node location"><%=DISCARD_ICON%></a>
               <% } %>
             <% } %>
           </td>

--- a/opennms-webapp/src/main/webapp/WEB-INF/jsp/outage/list.jsp
+++ b/opennms-webapp/src/main/webapp/WEB-INF/jsp/outage/list.jsp
@@ -3,7 +3,7 @@
  * This file is part of OpenNMS(R).
  *
  * Copyright (C) 2006-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2016 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *

--- a/opennms-webapp/src/main/webapp/includes/event-advquerypanel.jsp
+++ b/opennms-webapp/src/main/webapp/includes/event-advquerypanel.jsp
@@ -94,8 +94,8 @@
 
 	<div class="row">
 		<div class="form-group col-sm-6">
-			<label for="location">Location:</label>
-			<select class="form-control" name="location">
+			<label for="nodelocation">Node Location:</label>
+			<select class="form-control" name="nodelocation">
 				<option selected="selected">Any</option>
 				<% for (OnmsMonitoringLocation onmsMonitoringLocation : monitoringLocations ) { %>
 				<option value="<%= onmsMonitoringLocation.getLocationName() %>">

--- a/opennms-webapp/src/main/webapp/notification/detail.jsp
+++ b/opennms-webapp/src/main/webapp/notification/detail.jsp
@@ -3,7 +3,7 @@
  * This file is part of OpenNMS(R).
  *
  * Copyright (C) 2002-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2016 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -50,7 +50,8 @@
 
     String noticeIdString = request.getParameter("notice");
 
-    String eventSeverity;
+    String eventSeverity = null;
+    String eventLocation = null;
     
     int noticeID = -1;
     
@@ -71,11 +72,13 @@
     if (NoticeFactory.canDisplayEvent(notice.getEventId())) {
 		Event event = EventFactory.getEvent(notice.getEventId());
 		eventSeverity = event.getSeverity().getLabel();
+		eventLocation = event.getLocation();
     } else {
 		eventSeverity = new String("Cleared");
     }
 
 	String nodeLabel = NetworkElementFactory.getInstance(getServletContext()).getNodeLabel(notice.getNodeId());
+	String nodeLocation = NetworkElementFactory.getInstance(getServletContext()).getNodeLocation(notice.getNodeId());
 %>
 
 <jsp:include page="/includes/bootstrap.jsp" flush="false" >
@@ -97,9 +100,9 @@
   <table class="table table-condensed severity">
   <tr class="severity-<%=eventSeverity.toLowerCase()%>">
     <th class="col-md-1">Notification&nbsp;Time</th>
-    <td class="col-md-3"><fmt:formatDate value="<%=notice.getTimeSent()%>" type="BOTH" /></td>
+    <td class="col-md-2"><fmt:formatDate value="<%=notice.getTimeSent()%>" type="BOTH" /></td>
     <th class="col-md-1">Time&nbsp;Replied</th>
-    <td class="col-md-3">
+    <td class="col-md-2">
       <c:choose>
         <c:when test="<%=notice.getTimeReplied() != null%>">
           <fmt:formatDate value="<%=notice.getTimeReplied()%>" type="BOTH" />
@@ -110,11 +113,22 @@
       </c:choose>
     </td>
     <th class="col-md-1">Responder</th>
-    <td class="col-md-3"><%=notice.getResponder()!=null ? notice.getResponder() : "&nbsp;"%></td>
+    <td class="col-md-2"><%=notice.getResponder()!=null ? notice.getResponder() : "&nbsp;"%></td>
+    <th class="col-md-1">Location</th>
+    <td class="col-md-2">
+      <c:choose>
+        <c:when test="<%= eventLocation != null %>">
+          <a href="event/detail.jsp?id=<%=notice.getEventId()%>"><%= eventLocation %></a>
+        </c:when>
+        <c:otherwise>
+          &nbsp;
+        </c:otherwise>
+      </c:choose>
+    </td>
   </tr>
   <tr class="severity-<%=eventSeverity.toLowerCase()%>">
-    <th>Node</th>
-    <td>
+    <th class="col-md-1">Node</th>
+    <td class="col-md-2">
       <%if (nodeLabel!=null) { %>
         <c:url var="nodeLink" value="element/node.jsp">
           <c:param name="node" value="<%=String.valueOf(notice.getNodeId())%>"/>
@@ -125,9 +139,8 @@
       <% } %>
     </td>
 
-    <th>Interface</th>
-
-    <td>
+    <th class="col-md-1">Interface</th>
+    <td class="col-md-2">
       <%if (nodeLabel!=null && notice.getIpAddress()!=null) { %>
         <c:url var="interfaceLink" value="element/interface.jsp">
           <c:param name="node" value="<%=String.valueOf(notice.getNodeId())%>"/>
@@ -141,9 +154,8 @@
       <% } %>
     </td>
           
-    <th>Service</th>
-
-    <td>
+    <th class="col-md-1">Service</th>
+    <td class="col-md-2">
       <%if (nodeLabel!=null && notice.getIpAddress()!=null && notice.getServiceName()!=null) { %>
         <c:url var="serviceLink" value="element/service.jsp">
           <c:param name="node" value="<%=String.valueOf(notice.getNodeId())%>"/>
@@ -157,11 +169,26 @@
         &nbsp;
       <% } %>
     </td>
+
+    <th class="col-md-1">Node&nbsp;Location</th>
+    <td class="col-md-2">
+      <c:choose>
+        <c:when test="<%= nodeLocation != null %>">
+          <c:url var="nodeLocationLink" value="element/node.jsp">
+            <c:param name="node" value="<%=String.valueOf(notice.getNodeId())%>"/>
+          </c:url>
+          <a href="${nodeLink}"><c:out value="<%=nodeLocation%>"/></a>
+        </c:when>
+        <c:otherwise>
+          &nbsp;
+        </c:otherwise>
+      </c:choose>
+    </td>
   </tr>
 
   <%if (nodeLabel!=null) { %>
     <tr class="severity-<%=eventSeverity.toLowerCase()%>">
-      <td colspan="6">
+      <td colspan="8">
         <c:url var="outageLink" value="outage/list.htm">
           <c:param name="filter" value='<%="node=" + notice.getNodeId()%>'/>
         </c:url>

--- a/opennms-webapp/src/test/java/org/opennms/web/event/filter/WebEventRepositoryFilterIT.java
+++ b/opennms-webapp/src/test/java/org/opennms/web/event/filter/WebEventRepositoryFilterIT.java
@@ -43,8 +43,12 @@ import org.opennms.core.test.OpenNMSJUnit4ClassRunner;
 import org.opennms.core.test.db.annotations.JUnitTemporaryDatabase;
 import org.opennms.core.utils.InetAddressUtils;
 import org.opennms.netmgt.dao.DatabasePopulator;
+import org.opennms.netmgt.dao.api.MonitoringLocationDao;
+import org.opennms.netmgt.dao.api.NodeDao;
 import org.opennms.netmgt.model.OnmsEvent;
+import org.opennms.netmgt.model.OnmsNode;
 import org.opennms.netmgt.model.OnmsSeverity;
+import org.opennms.netmgt.model.monitoringLocations.OnmsMonitoringLocation;
 import org.opennms.test.JUnitConfigurationEnvironment;
 import org.opennms.web.alarm.filter.AlarmIdFilter;
 import org.opennms.web.event.Event;
@@ -76,6 +80,12 @@ public class WebEventRepositoryFilterIT implements InitializingBean {
     DatabasePopulator m_dbPopulator;
     
     @Autowired
+    NodeDao m_nodeDao;
+
+    @Autowired
+    MonitoringLocationDao m_monitoringLocationDao;
+
+    @Autowired
     @Qualifier("dao")
     WebEventRepository m_daoEventRepo;
     
@@ -90,11 +100,17 @@ public class WebEventRepositoryFilterIT implements InitializingBean {
     @Before
     public void setUp(){
         m_dbPopulator.populateDatabase();
-        
-        OnmsEvent event = new OnmsEvent();
+
+        final OnmsNode node2 = m_dbPopulator.getNode2();
+        final OnmsMonitoringLocation location = m_monitoringLocationDao.get("RDU");
+        node2.setLocation(location);
+        m_nodeDao.saveOrUpdate(node2);
+        m_nodeDao.flush();
+
+        final OnmsEvent event = new OnmsEvent();
         event.setDistPoller(m_dbPopulator.getDistPollerDao().whoami());
         event.setAlarm(m_dbPopulator.getAlarmDao().get(1));
-        event.setNode(m_dbPopulator.getNode1());
+        event.setNode(node2);
         event.setEventUei("uei.opennms.org/test2");
         event.setEventTime(new Date());
         event.setEventSource("test");
@@ -300,16 +316,16 @@ public class WebEventRepositoryFilterIT implements InitializingBean {
     @Test
     @Transactional
     public void testNegativeNodeFilter(){
+        // should match the "RDU" event
         NegativeNodeFilter filter = new NegativeNodeFilter(m_dbPopulator.getNode2().getId(), m_appContext);
-        
         Event[] events = getMatchingDaoEvents(filter);
-        assertEquals(2, events.length);
-        
+        assertEquals(1, events.length);
+
+        // should match the "Default" event
         filter = new NegativeNodeFilter(m_dbPopulator.getNode1().getId(), m_appContext);
-        
         events = getMatchingDaoEvents(filter);
-        assertEquals(0, events.length);
-        
+        assertEquals(1, events.length);
+
         assertEquals("node is not node1", filter.getTextDescription());
     }
     
@@ -358,16 +374,16 @@ public class WebEventRepositoryFilterIT implements InitializingBean {
     
     @Test
     @JUnitTemporaryDatabase // Relies on specific IDs so we need a fresh database
-    public void testNodeFilter(){
+    public void testNodeFilter() {
+        // should match the "Default" event
         NodeFilter filter = new NodeFilter(1, m_appContext);
-        
         Event[] events = getMatchingDaoEvents(filter);
-        assertEquals(2, events.length);
-        
+        assertEquals(1, events.length);
+
+        // should match the "RDU event
         filter = new NodeFilter(2, m_appContext);
-        
         events = getMatchingDaoEvents(filter);
-        assertEquals(0, events.length);
+        assertEquals(1, events.length);
         
         assertEquals("node=node2", filter.getTextDescription());
     }
@@ -378,7 +394,7 @@ public class WebEventRepositoryFilterIT implements InitializingBean {
         NodeNameLikeFilter filter = new NodeNameLikeFilter("node1");
         
         Event[] events = getMatchingDaoEvents(filter);
-        assertEquals(2, events.length);
+        assertEquals(1, events.length);
         
         filter = new NodeNameLikeFilter("testNode");
         
@@ -450,21 +466,38 @@ public class WebEventRepositoryFilterIT implements InitializingBean {
     }
 
     @Test
-    @JUnitTemporaryDatabase // Relies on specific IDs so we need a fresh database
     public void testLocationFilter(){
-        LocationFilter filter1 = new LocationFilter("Default");
-
-        Event[] events1 = getMatchingDaoEvents(filter1);
+        final LocationFilter filter1 = new LocationFilter("Default");
+        final Event[] events1 = getMatchingDaoEvents(filter1);
         assertEquals(2, events1.length);
 
-        LocationFilter filter2 = new LocationFilter("Non-Default");
-
-        Event[] events2 = getMatchingDaoEvents(filter2);
+        final LocationFilter filter2 = new LocationFilter("Non-Default");
+        final Event[] events2 = getMatchingDaoEvents(filter2);
         assertEquals(0, events2.length);
+
+        final LocationFilter filter3 = new LocationFilter("RDU");
+        final Event[] events3 = getMatchingDaoEvents(filter3);
+        assertEquals(0, events3.length);
+
     }
 
     @Test
-    @JUnitTemporaryDatabase // Relies on specific IDs so we need a fresh database
+    public void testNodeLocationFilter(){
+        final NodeLocationFilter filter1 = new NodeLocationFilter("Default");
+        final Event[] events1 = getMatchingDaoEvents(filter1);
+        assertEquals(1, events1.length);
+
+        final NodeLocationFilter filter2 = new NodeLocationFilter("Non-Default");
+        final Event[] events2 = getMatchingDaoEvents(filter2);
+        assertEquals(0, events2.length);
+
+        final NodeLocationFilter filter3 = new NodeLocationFilter("RDU");
+        final Event[] events3 = getMatchingDaoEvents(filter3);
+        assertEquals(1, events3.length);
+
+    }
+
+    @Test
     public void testSystemIdFilter(){
         SystemIdFilter filter1 = new SystemIdFilter(m_dbPopulator.getDistPollerDao().whoami().getId());
 
@@ -478,7 +511,6 @@ public class WebEventRepositoryFilterIT implements InitializingBean {
     }
 
     @Test
-    @JUnitTemporaryDatabase // Relies on specific IDs so we need a fresh database
     public void testNegativeLocationFilter(){
         NegativeLocationFilter filter1 = new NegativeLocationFilter("Default");
 
@@ -492,7 +524,24 @@ public class WebEventRepositoryFilterIT implements InitializingBean {
     }
 
     @Test
-    @JUnitTemporaryDatabase // Relies on specific IDs so we need a fresh database
+    public void testNegativeNodeLocationFilter(){
+        // should match the "RDU" event
+        final NegativeNodeLocationFilter filter1 = new NegativeNodeLocationFilter("Default");
+        final Event[] events1 = getMatchingDaoEvents(filter1);
+        assertEquals(1, events1.length);
+
+        // should match all events
+        final NegativeNodeLocationFilter filter2 = new NegativeNodeLocationFilter("Non-Default");
+        final Event[] events2 = getMatchingDaoEvents(filter2);
+        assertEquals(2, events2.length);
+
+        // should match the "Default" event
+        final NegativeNodeLocationFilter filter3 = new NegativeNodeLocationFilter("RDU");
+        final Event[] events3 = getMatchingDaoEvents(filter3);
+        assertEquals(1, events3.length);
+    }
+
+    @Test
     public void testNegativeSystemIdFilter(){
         NegativeSystemIdFilter filter1 = new NegativeSystemIdFilter(m_dbPopulator.getDistPollerDao().whoami().getId());
 


### PR DESCRIPTION
This PR adds location to the alarm and notification UIs.  It also fixes up some issues with the event browser showing locations and adds support for showing both the node and event source locations, and contains a clarification in the outage UI.

Where appropriate, I always refer to a location associated with a node as a "Node Location".  Otherwise event locations are either just "Location" or "Event Source Location".

JIRA: 
* http://issues.opennms.org/browse/HZN-985
* http://issues.opennms.org/browse/HZN-987

Related JIRA issues:
* http://issues.opennms.org/browse/HZN-314
* http://issues.opennms.org/browse/HZN-315