### PR TITLE
NMS-8907: Invalid graph templates (fixing large/invalid DS)

### DIFF
--- a/opennms-base-assembly/src/main/filtered/etc/datacollection/fortinet-fortigate-application-v5.2.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/datacollection/fortinet-fortigate-application-v5.2.xml
@@ -160,15 +160,15 @@
     <mibObj oid=".1.3.6.1.4.1.12356.101.10.111.3.1.1" instance="fgApFTPStatsEntry" alias="fgApFTPReqProcessed" type="Counter32" />
   </group>
   <group name="fgApFTPConnections" ifType="ignore">
-    <mibObj oid=".1.3.6.1.4.1.12356.101.10.111.4" instance="0" alias="fgApFTPConnections" type="Integer32" />
-    <mibObj oid=".1.3.6.1.4.1.12356.101.10.111.5" instance="0" alias="fgApFTPMaxConnections" type="Integer32" />
+    <mibObj oid=".1.3.6.1.4.1.12356.101.10.111.4" instance="0" alias="fgApFTPConns" type="Integer32" />
+    <mibObj oid=".1.3.6.1.4.1.12356.101.10.111.5" instance="0" alias="fgApFTPMaxConns" type="Integer32" />
   </group>
   <group name="fgWebCacheDiskStatsTable" ifType="all">
     <mibObj oid=".1.3.6.1.4.1.12356.101.10.113.2.1.1" instance="fgWebChDskStsEntry" alias="fgWebCacheDisk" type="String" />
     <mibObj oid=".1.3.6.1.4.1.12356.101.10.113.2.1.2" instance="fgWebChDskStsEntry" alias="fgWebCacheDiskLimit" type="Gauge64" />
     <mibObj oid=".1.3.6.1.4.1.12356.101.10.113.2.1.3" instance="fgWebChDskStsEntry" alias="fgWebCacheDiskUsage" type="Gauge64" />
     <mibObj oid=".1.3.6.1.4.1.12356.101.10.113.2.1.4" instance="fgWebChDskStsEntry" alias="fgWebCacheDiskHits" type="Counter32" />
-    <mibObj oid=".1.3.6.1.4.1.12356.101.10.113.2.1.5" instance="fgWebChDskStsEntry" alias="fgWebCacheDiskMisses" type="Counter32" />
+    <mibObj oid=".1.3.6.1.4.1.12356.101.10.113.2.1.5" instance="fgWebChDskStsEntry" alias="fgWebCacheDiskMiss" type="Counter32" />
   </group>
   <systemDef name="Fortinet-Fortigate-Application-v5.2">
     <sysoidMask>.1.3.6.1.4.1.12356.</sysoidMask>

--- a/opennms-base-assembly/src/main/filtered/etc/datacollection/netapp.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/datacollection/netapp.xml
@@ -46,8 +46,8 @@
       </group>
 
       <group name="netapp-misc" ifType="ignore">
-        <mibObj oid=".1.3.6.1.4.1.789.1.2.2.16"      instance="0" alias="naMiscLowDiskReadBytes"  type="Counter" />
-        <mibObj oid=".1.3.6.1.4.1.789.1.2.2.18"      instance="0" alias="naMiscLowDiskWriteBytes"  type="Counter" />
+        <mibObj oid=".1.3.6.1.4.1.789.1.2.2.16"      instance="0" alias="naMscLowDiskRdBytes"  type="Counter" />
+        <mibObj oid=".1.3.6.1.4.1.789.1.2.2.18"      instance="0" alias="naMscLowDiskWrBytes"  type="Counter" />
       </group>
 
       <group name="netapp-sis" ifType="all">

--- a/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/fortinet-fortigate-application-v5.2-graph.properties
+++ b/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/fortinet-fortigate-application-v5.2-graph.properties
@@ -377,12 +377,12 @@ report.fortinet.fgApFTPStatsEntry.stats.command=--title="Fortigate FTP Proxy Sta
  GPRINT:val1:MAX:"Max \\: %10.2lf\\n"
 
 report.fortinet.fgApFTPStatsEntry.connection.name=Fortigate FTP Proxy Connections Statistics
-report.fortinet.fgApFTPStatsEntry.connection.columns=fgApFTPMaxConnections, fgApFTPConnections
+report.fortinet.fgApFTPStatsEntry.connection.columns=fgApFTPMaxConns, fgApFTPConns
 report.fortinet.fgApFTPStatsEntry.connection.type=nodeSnmp
 report.fortinet.fgApFTPStatsEntry.connection.command=--title="Fortigate FTP Proxy Connections Statistics" \
  --vertical-label="number" \
- DEF:val1={rrd1}:fgApFTPMaxConnections:AVERAGE \
- DEF:val2={rrd2}:fgApFTPConnections:AVERAGE \
+ DEF:val1={rrd1}:fgApFTPMaxConns:AVERAGE \
+ DEF:val2={rrd2}:fgApFTPConns:AVERAGE \
  LINE1:val1#cc0000:"max Connections" \
  GPRINT:val1:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:val1:MIN:"Min \\: %8.2lf %s" \
@@ -410,13 +410,13 @@ report.fortinet.fgWebCacheDiskUsage.command=--title="Fortigate Web Cache Usage f
  GPRINT:val2:MAX:"Max \\: %8.2lf %s\\n"
 
 report.fortinet.fgWebChDskStsEntry.name=Fortigate Web Cache Disk Statistics
-report.fortinet.fgWebChDskStsEntry.columns=fgWebCacheDiskHits, fgWebCacheDiskMisses
+report.fortinet.fgWebChDskStsEntry.columns=fgWebCacheDiskHits, fgWebCacheDiskMiss
 report.fortinet.fgWebChDskStsEntry.type=fgWebChDskStsEntry
 report.fortinet.fgWebChDskStsEntry.propertiesValues=fgWebCacheDisk
 report.fortinet.fgWebChDskStsEntry.command=--title="Fortigate Web Cache Disk Statistics for Disk: {fgWebCacheDisk}" \
  --vertical-label="number" \
  DEF:val1={rrd1}:fgWebCacheDiskHits:AVERAGE \
- DEF:val2={rrd2}:fgWebCacheDiskMisses:AVERAGE \
+ DEF:val2={rrd2}:fgWebCacheDiskMiss:AVERAGE \
  AREA:val1#cc0000:"Hits   " \
  GPRINT:val1:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:val1:MIN:"Min \\: %8.2lf %s" \

--- a/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/netapp-graph.properties
+++ b/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/netapp-graph.properties
@@ -232,12 +232,12 @@ report.netapp.sis.command=--title="NetApp {naDfFileSys} SIS percent savings" \
  GPRINT:naSisPercent:MAX:"Max \\: %8.2lf %s\\n"
 
 report.netapp.diskio.name=NetApp Disk IO
-report.netapp.diskio.columns=naMiscLowDiskReadBytes, naMiscLowDiskWriteBytes
+report.netapp.diskio.columns=naMscLowDiskRdBytes,naMscLowDiskWrBytes
 report.netapp.diskio.type=nodeSnmp
 report.netapp.diskio.command=--title="NetApp Disk IO Bytes" \
  --vertical-label operations \
- DEF:naMiscLowDiskReadBytes={rrd1}:naMiscLowDiskReadBy:AVERAGE \
- DEF:naMiscLowDiskWriteBytes={rrd2}:naMiscLowDiskWriteB:AVERAGE \
+ DEF:naMiscLowDiskReadBytes={rrd1}:naMscLowDiskRdBytes:AVERAGE \
+ DEF:naMiscLowDiskWriteBytes={rrd2}:naMscLowDiskWrBytes:AVERAGE \
  CDEF:naMiscLowDiskWriteBytesNeg=0,naMiscLowDiskWriteBytes,- \
  LINE1:naMiscLowDiskReadBytes#0000ff:"IO reads Bytes" \
  GPRINT:naMiscLowDiskReadBytes:AVERAGE:" Avg \\: %8.2lf %s" \

--- a/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/vmware6-graph-simple.properties
+++ b/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/vmware6-graph-simple.properties
@@ -1885,11 +1885,11 @@ GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
 GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware6.MemVmfs.pbc.OdLat.name=vmware6.mem.vmfs.pbc.overhead.latest
-report.vmware6.MemVmfs.pbc.OdLat.columns=MemVmfs.pbc.OdLat
+report.vmware6.MemVmfs.pbc.OdLat.columns=MemVmfsPbcOdLat
 report.vmware6.MemVmfs.pbc.OdLat.type=nodeSnmp
 report.vmware6.MemVmfs.pbc.OdLat.command=--title="VMware6 mem.vmfs.pbc.overhead.latest" \
 --vertical-label="MemVmfs.pbc.OdLat" \
-DEF:xxx={rrd1}:MemVmfs.pbc.OdLat:AVERAGE \
+DEF:xxx={rrd1}:MemVmfsPbcOdLat:AVERAGE \
 LINE2:xxx#0000ff:"MemVmfs.pbc.OdLat" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
@@ -1907,11 +1907,11 @@ GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \
 GPRINT:xxx:MAX:"Max  \\: %8.2lf %s\\n"
 
 report.vmware6.MemVmfs.pbc.sizeLat.name=vmware6.mem.vmfs.pbc.size.latest
-report.vmware6.MemVmfs.pbc.sizeLat.columns=MemVmfs.pbc.sizeLat
+report.vmware6.MemVmfs.pbc.sizeLat.columns=MemVmfsPbcSizeLat
 report.vmware6.MemVmfs.pbc.sizeLat.type=nodeSnmp
 report.vmware6.MemVmfs.pbc.sizeLat.command=--title="VMware6 mem.vmfs.pbc.size.latest" \
 --vertical-label="MemVmfs.pbc.sizeLat" \
-DEF:xxx={rrd1}:MemVmfs.pbc.sizeLat:AVERAGE \
+DEF:xxx={rrd1}:MemVmfsPbcSizeLat:AVERAGE \
 LINE2:xxx#0000ff:"MemVmfs.pbc.sizeLat" \
 GPRINT:xxx:AVERAGE:"Avg  \\: %8.2lf %s" \
 GPRINT:xxx:MIN:"Min  \\: %8.2lf %s" \

--- a/opennms-base-assembly/src/main/filtered/etc/vmware-datacollection-config.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/vmware-datacollection-config.xml
@@ -986,9 +986,9 @@
         <attrib name="mem.totalCapacity.average" alias="MemTlCyAvg" type="Gauge"/>
         <attrib name="mem.unreserved.average" alias="MemUdAvg" type="Gauge"/>
         <attrib name="mem.usage.average" alias="MemUsageAvg" type="Gauge"/>
-        <attrib name="mem.vmfs.pbc.overhead.latest" alias="MemVmfs.pbc.OdLat" type="Gauge"/>
+        <attrib name="mem.vmfs.pbc.overhead.latest" alias="MemVmfsPbcOdLat" type="Gauge"/>
         <attrib name="mem.vmfs.pbc.capMissRatio.latest" alias="MemVmfsPbcCpMsRtiLt" type="Gauge"/>
-        <attrib name="mem.vmfs.pbc.size.latest" alias="MemVmfs.pbc.sizeLat" type="Gauge"/>
+        <attrib name="mem.vmfs.pbc.size.latest" alias="MemVmfsPbcSizeLat" type="Gauge"/>
         <attrib name="mem.vmfs.pbc.sizeMax.latest" alias="MemVmfsPbcSizMaxLat" type="Gauge"/>
         <attrib name="mem.vmfs.pbc.workingSet.latest" alias="MemVmfsPbcWrkSetLat" type="Gauge"/>
         <attrib name="mem.vmfs.pbc.workingSetMax.latest" alias="MemVmfsPbcWrkStMxLt" type="Gauge"/>


### PR DESCRIPTION
Fixing invalid data sources (with more than 19 characters), to make them compatible with RRDtool.

The VMWare DS were also using invalid characters. It is recommended to use only alphanumeric characters for DS names.

* JIRA: http://issues.opennms.org/browse/NMS-8907

Our [continuous integration system](http://bamboo.internal.opennms.com:8085) will test and verify your changes.

After these changes, the Perl script I made to validate the graph templates shows no errors.