### PR TITLE
NMS-8989: Make surveillance category box scrollable in node detail page

### DIFF
--- a/opennms-webapp/src/main/webapp/WEB-INF/jsp/includes/nodeCategory-box.jsp
+++ b/opennms-webapp/src/main/webapp/WEB-INF/jsp/includes/nodeCategory-box.jsp
@@ -30,34 +30,32 @@
 --%>
 
 <%@page language="java"
-	contentType="text/html"
-	session="true"
+        contentType="text/html"
+        session="true"
 %>
-<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
-
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 
 <div id="category-box" class="panel panel-default">
-  <div class="panel-heading">
-    <h3 class="panel-title">
-  	  Surveillance Category Memberships
-  	  <c:if test="${isAdmin == 'true'}">
-  	     (<a href="<c:url value="admin/categories.htm?edit&amp;node=${param.node}"/>">Edit</a>)
-      </c:if>
-    </h3>
-  </div>
-  <table class="table table-condensed">
-  <c:if test="${empty categories}">
-    <tr>
-      <td>This node is not a member of any categories.</td>
-    </tr>
-  </c:if>
-  
+    <div class="panel-heading">
+        <h3 class="panel-title">
+            Surveillance Category Memberships
+            <c:if test="${isAdmin == 'true'}">
+                (<a href="<c:url value="admin/categories.htm?edit&amp;node=${param.node}"/>">Edit</a>)
+            </c:if>
+        </h3>
+    </div>
+    <table class="table table-condensed">
+        <c:if test="${empty categories}">
+            <tr>
+                <td>This node is not a member of any categories.</td>
+            </tr>
+        </c:if>
 
-  <c:forEach items="${categories}" var="category">
-    <tr>
-      <td>${category.name}</td>
-    </tr>
-  </c:forEach>
-</table>   
 
+        <c:forEach items="${categories}" var="category">
+            <tr>
+                <td>${category.name}</td>
+            </tr>
+        </c:forEach>
+    </table>
 </div>

--- a/opennms-webapp/src/main/webapp/WEB-INF/jsp/includes/nodeCategory-box.jsp
+++ b/opennms-webapp/src/main/webapp/WEB-INF/jsp/includes/nodeCategory-box.jsp
@@ -44,18 +44,20 @@
             </c:if>
         </h3>
     </div>
-    <table class="table table-condensed">
-        <c:if test="${empty categories}">
-            <tr>
-                <td>This node is not a member of any categories.</td>
-            </tr>
-        </c:if>
+    <div style="max-height: 15em; overflow-x: auto">
+        <table class="table table-condensed" style="margin-bottom: 0px">
+            <c:if test="${empty categories}">
+                <tr>
+                    <td>This node is not a member of any categories.</td>
+                </tr>
+            </c:if>
 
 
-        <c:forEach items="${categories}" var="category">
-            <tr>
-                <td>${category.name}</td>
-            </tr>
-        </c:forEach>
-    </table>
+            <c:forEach items="${categories}" var="category">
+                <tr>
+                    <td>${category.name}</td>
+                </tr>
+            </c:forEach>
+        </table>
+    </div>
 </div>


### PR DESCRIPTION
When a node is assigned to a lot of surveillance categories, important information like recent events and outages get moved out of the view and requires scrolling through the whole node detail page. A max-height is set and a scroll bar just for the surveillance box is shown.

* JIRA: http://issues.opennms.org/browse/NMS-8989