### PR TITLE
NMS-8925: Delegate JAAS requests to both the system and the Karaf implementations.

### DIFF
--- a/features/springframework-security/src/main/java/org/opennms/web/springframework/security/OpenNMSConfiguration.java
+++ b/features/springframework-security/src/main/java/org/opennms/web/springframework/security/OpenNMSConfiguration.java
@@ -1,6 +1,37 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2016-2017 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
 package org.opennms.web.springframework.security;
 
 import java.util.Collections;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.Set;
 
 import javax.security.auth.login.AppConfigurationEntry;
 import javax.security.auth.login.AppConfigurationEntry.LoginModuleControlFlag;
@@ -14,43 +45,57 @@ import org.slf4j.LoggerFactory;
  * Outside of Karaf (ie, in the "system" bundle) we need to use the springframework-security version of
  * the OpenNMSLoginModule run.  We can't share login modules because of classloading boundaries, and
  * the peculiar way that Karaf wraps login modules in a proxy class.
+ *
+ * Additionally, there are some cases where we wish to use the system's JAAS configuration.
+ *
+ * To achieve this, we gather all of the configuration implementations until the
+ * Karaf implementation is loaded (this implementation is currently loaded last in the startup
+ * process). When a request is made, we then delegate to all of the known implementations.
+ *
  */
 public class OpenNMSConfiguration extends Configuration {
     private static volatile Logger LOG = LoggerFactory.getLogger(OpenNMSConfiguration.class);
-    Configuration m_parentConfiguration;
+
+    private static final String JAAS_TIMEOUT_SYS_PROP = "org.opennms.web.springframework.security.jaas-timeout";
+    private static final long DEFAULT_JAAS_TIMEOUT_MS = 120000;
+
+    private final Set<Configuration> m_delegates = new LinkedHashSet<>();
 
     public void init() throws InterruptedException {
         LOG.debug("OpenNMSConfiguration initializing.");
         new Thread(new Runnable() {
             @Override public void run() {
                 // wait up to 2 minutes for Karaf's JAAS Configuration to become active so we can put a facade on top of it.
-                final long giveUp = System.currentTimeMillis() + Long.getLong("org.opennms.web.springframework.security.jaas-timeout", 120000);
+                final long giveUp = System.currentTimeMillis() + Long.getLong(JAAS_TIMEOUT_SYS_PROP, DEFAULT_JAAS_TIMEOUT_MS);
                 do {
                     final Configuration c = Configuration.getConfiguration();
                     if (c != null) {
-                        LOG.trace("OpenNMSConfiguration found existing configuration: " + c.getClass().getName());
-                        if (c.getClass().getName().contains("OsgiConfiguration")) {
-                            LOG.debug("Found Karaf OSGi JAAS configuration.  Inserting OpenNMS redirector.");
-                            break;
+                        // gather all configurations that are found, until the Karaf implementation is loaded
+                        if (m_delegates.add(c)) {
+                            LOG.trace("OpenNMSConfiguration found existing configuration: " + c.getClass().getName());
+                            if (c.getClass().getName().contains("OsgiConfiguration")) {
+                                LOG.debug("Found Karaf OSGi JAAS configuration.  Inserting OpenNMS redirector.");
+                                break;
+                            }
                         }
                     }
                     LOG.trace("OpenNMSConfiguration still waiting for Karaf OsgiConfiguration to activate...");
                     try {
-                        Thread.sleep(1000);
+                        Thread.sleep(200);
                     } catch (final InterruptedException e) {
                         LOG.warn("Interrupted while waiting for Karaf's OSGi Configuration to initialize.", e);
+                        break;
                     }
                 } while (System.currentTimeMillis() < giveUp);
-
-                m_parentConfiguration = Configuration.getConfiguration();
                 Configuration.setConfiguration(OpenNMSConfiguration.this);
             }
         }).start();
     }
 
     public void close() {
-        Configuration.setConfiguration(m_parentConfiguration);
-        m_parentConfiguration = null;
+        final Iterator<Configuration> it = m_delegates.iterator();
+        Configuration.setConfiguration(it.hasNext() ? it.next() : null);
+        m_delegates.clear();
     }
 
     @Override
@@ -60,18 +105,26 @@ public class OpenNMSConfiguration extends Configuration {
             LOG.debug("getAppConfigurationEntry: Overriding.");
             return new AppConfigurationEntry[] { new AppConfigurationEntry(OpenNMSProxyLoginModule.class.getName(), LoginModuleControlFlag.REQUIRED, Collections.emptyMap()) };
         } else {
-            LOG.debug("getAppConfigurationEntry: Passing through to Karaf.");
-            if (m_parentConfiguration != null) {
-                return m_parentConfiguration.getAppConfigurationEntry(name);
-            } else {
-                return null;
-            }
+            LOG.debug("getAppConfigurationEntry: Passing through.");
+            return m_delegates.stream()
+                .map(c -> c.getAppConfigurationEntry(name))
+                .reduce(null, (a,b) -> {
+                    if (a == null) {
+                        return b;
+                    } else if (b == null) {
+                        return a;
+                    } else {
+                        // Concatenate the arrays
+                        final AppConfigurationEntry[] c = new AppConfigurationEntry[a.length + b.length];
+                        System.arraycopy(a, 0, c, 0, a.length);
+                        System.arraycopy(b, 0, c, a.length, b.length);
+                        return c;
+                    }
+                });
         }
     }
 
     public void refresh() {
-        if (m_parentConfiguration != null) {
-            m_parentConfiguration.refresh();
-        }
+        m_delegates.stream().forEach(c -> c.refresh());
     }
 }

--- a/features/springframework-security/src/test/java/org/opennms/web/springframework/security/OpenNMSConfigurationTest.java
+++ b/features/springframework-security/src/test/java/org/opennms/web/springframework/security/OpenNMSConfigurationTest.java
@@ -1,0 +1,113 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2017-2017 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.web.springframework.security;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.util.Collections;
+
+import javax.security.auth.login.AppConfigurationEntry;
+import javax.security.auth.login.Configuration;
+import javax.security.auth.login.AppConfigurationEntry.LoginModuleControlFlag;
+
+import org.junit.Test;
+import org.opennms.bootstrap.OpenNMSProxyLoginModule;
+
+public class OpenNMSConfigurationTest {
+
+    private static AppConfigurationEntry newEntry(String name) {
+        return new AppConfigurationEntry(name, LoginModuleControlFlag.OPTIONAL, Collections.emptyMap());
+    }
+
+    private static final class MockConfiguration extends Configuration {
+        @Override
+        public AppConfigurationEntry[] getAppConfigurationEntry(String name) {
+            if ("realm1".equals(name)) {
+                return new AppConfigurationEntry[] {newEntry("realm1")};
+            } else if ("realm2".equals(name)) {
+                return new AppConfigurationEntry[] {newEntry("realm2a")};
+            }
+            return null;
+        }
+    }
+
+    private static final class KarafOsgiConfiguration extends Configuration {
+        @Override
+        public AppConfigurationEntry[] getAppConfigurationEntry(String name) {
+            if ("karaf".equals(name)) {
+                return new AppConfigurationEntry[] {newEntry("karaf")};
+            } else if ("realm2".equals(name)) {
+                return new AppConfigurationEntry[] {newEntry("realm2b")};
+            }
+            return null;
+        }
+    }
+
+    @Test
+    public void canRetrieveAppConfigurationsFromMultipleConfigs() throws InterruptedException {
+        // Set a mock config.
+        MockConfiguration mockConfig = new MockConfiguration();
+        Configuration.setConfiguration(mockConfig);
+
+        // Now instantiate the OpenNMS configuration
+        OpenNMSConfiguration onmsConfig = new OpenNMSConfiguration();
+        onmsConfig.init();
+
+        Thread.sleep(500);
+
+        // Now set another config. that will be detected as the Karaf config.
+        KarafOsgiConfiguration karafConfig = new KarafOsgiConfiguration();
+        Configuration.setConfiguration(karafConfig);
+
+        Thread.sleep(500);
+
+        // Requests for "opennms" should be handled by the OpenNMSConfiguration
+        AppConfigurationEntry[] entries = Configuration.getConfiguration().getAppConfigurationEntry("opennms");
+        assertEquals(1, entries.length);
+        assertEquals(OpenNMSProxyLoginModule.class.getName(), entries[0].getLoginModuleName());
+
+        // Other requests should be passed to both the original and the Karaf configs.
+        entries = Configuration.getConfiguration().getAppConfigurationEntry("realm1");
+        assertEquals(1, entries.length);
+        assertEquals("realm1", entries[0].getLoginModuleName());
+
+        entries = Configuration.getConfiguration().getAppConfigurationEntry("realm2");
+        assertEquals(2, entries.length);
+        assertEquals("realm2a", entries[0].getLoginModuleName());
+        assertEquals("realm2b", entries[1].getLoginModuleName());
+
+        entries = Configuration.getConfiguration().getAppConfigurationEntry("karaf");
+        assertEquals(1, entries.length);
+        assertEquals("karaf", entries[0].getLoginModuleName());
+
+        entries = Configuration.getConfiguration().getAppConfigurationEntry("!");
+        assertNull(entries);
+    }
+}


### PR DESCRIPTION
JIRA: https://issues.opennms.org/browse/NMS-8925

Here we update the OpenNMSConfiguration to support delegating to both the system and Karaf implementations, as opposed to only delegating to the Karaf implementation.
