### PR TITLE
HZN-998, NMS-8963, NMS-9015: Add batching support to es-rest forwarder

### DIFF
--- a/core/ipc/sink/api/src/main/java/org/opennms/core/ipc/sink/api/AggregationPolicy.java
+++ b/core/ipc/sink/api/src/main/java/org/opennms/core/ipc/sink/api/AggregationPolicy.java
@@ -46,7 +46,7 @@ package org.opennms.core.ipc.sink.api;
  * @param <S> type of message that will be sent by the producers
  * @param <T> type of message (bucket) that will be received by the consumers
  */
-public interface AggregationPolicy<S, T extends Message> {
+public interface AggregationPolicy<S, T> {
 
     /**
      * Maximum number of messages to be added to a bucket before dispatching.

--- a/core/ipc/sink/api/src/main/java/org/opennms/core/ipc/sink/api/MessageDispatcher.java
+++ b/core/ipc/sink/api/src/main/java/org/opennms/core/ipc/sink/api/MessageDispatcher.java
@@ -26,39 +26,17 @@
  *     http://www.opennms.com/
  *******************************************************************************/
 
-package org.opennms.core.ipc.sink.aggregation;
-
-import org.opennms.core.ipc.sink.api.AggregationPolicy;
-import org.opennms.core.ipc.sink.api.MessageDispatcher;
-import org.opennms.core.ipc.sink.api.SinkModule;
+package org.opennms.core.ipc.sink.api;
 
 /**
- * A {@link MessageDispatcher} that applies the {@link SinkModule}'s {@link AggregationPolicy}
- * using the {@link Aggregator}.
+ * Used to synchronously dispatch messages.
+ *
+ * Instances of these should be created by the {@link MessageDispatcherFactory}.
  *
  * @author jwhite
  */
-public abstract class AggregatingMessageProducer<S, T> implements MessageDispatcher<S> {
+public interface MessageDispatcher<S> extends AutoCloseable {
 
-    private final Aggregator<S,T> aggregator;
+    void send(S message);
 
-    public AggregatingMessageProducer(String id, AggregationPolicy<S,T> policy) {
-        aggregator = new Aggregator<S,T>(id, policy, this);
-    }
-
-    @Override
-    public void send(S message) {
-        final T bucket = aggregator.aggregate(message);
-        if (bucket != null) {
-            // This bucket is ready to be dispatched
-            dispatch(bucket);
-        }
-    }
-
-    public abstract void dispatch(T message);
-
-    @Override
-    public void close() throws Exception {
-        aggregator.close();
-    }
 }

--- a/core/ipc/sink/api/src/main/java/org/opennms/core/ipc/sink/api/SyncDispatcher.java
+++ b/core/ipc/sink/api/src/main/java/org/opennms/core/ipc/sink/api/SyncDispatcher.java
@@ -35,8 +35,5 @@ package org.opennms.core.ipc.sink.api;
  *
  * @author jwhite
  */
-public interface SyncDispatcher<S extends Message> extends AutoCloseable {
-
-    void send(S message);
-
+public interface SyncDispatcher<S extends Message> extends MessageDispatcher<S> {
 }

--- a/core/ipc/sink/common/src/main/java/org/opennms/core/ipc/sink/aggregation/AggregatingSinkMessageProducer.java
+++ b/core/ipc/sink/common/src/main/java/org/opennms/core/ipc/sink/aggregation/AggregatingSinkMessageProducer.java
@@ -30,7 +30,9 @@ package org.opennms.core.ipc.sink.aggregation;
 
 import org.opennms.core.ipc.sink.api.AggregationPolicy;
 import org.opennms.core.ipc.sink.api.MessageDispatcher;
+import org.opennms.core.ipc.sink.api.Message;
 import org.opennms.core.ipc.sink.api.SinkModule;
+import org.opennms.core.ipc.sink.api.SyncDispatcher;
 
 /**
  * A {@link MessageDispatcher} that applies the {@link SinkModule}'s {@link AggregationPolicy}
@@ -38,27 +40,9 @@ import org.opennms.core.ipc.sink.api.SinkModule;
  *
  * @author jwhite
  */
-public abstract class AggregatingMessageProducer<S, T> implements MessageDispatcher<S> {
+public abstract class AggregatingSinkMessageProducer<S extends Message, T extends Message> extends AggregatingMessageProducer<S,T> implements SyncDispatcher<S> {
 
-    private final Aggregator<S,T> aggregator;
-
-    public AggregatingMessageProducer(String id, AggregationPolicy<S,T> policy) {
-        aggregator = new Aggregator<S,T>(id, policy, this);
-    }
-
-    @Override
-    public void send(S message) {
-        final T bucket = aggregator.aggregate(message);
-        if (bucket != null) {
-            // This bucket is ready to be dispatched
-            dispatch(bucket);
-        }
-    }
-
-    public abstract void dispatch(T message);
-
-    @Override
-    public void close() throws Exception {
-        aggregator.close();
+    public AggregatingSinkMessageProducer(SinkModule<S, T> module) {
+        super(module.getId(), module.getAggregationPolicy());
     }
 }

--- a/core/ipc/sink/common/src/main/java/org/opennms/core/ipc/sink/aggregation/Aggregator.java
+++ b/core/ipc/sink/common/src/main/java/org/opennms/core/ipc/sink/aggregation/Aggregator.java
@@ -39,8 +39,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.Lock;
 
 import org.opennms.core.ipc.sink.api.AggregationPolicy;
-import org.opennms.core.ipc.sink.api.Message;
-import org.opennms.core.ipc.sink.api.SinkModule;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -57,7 +55,7 @@ import com.google.common.util.concurrent.Striped;
  * @param <S> individual message
  * @param <T> aggregated message (i.e. bucket)
  */
-public class Aggregator<S extends Message, T extends Message> implements AutoCloseable, Runnable {
+public class Aggregator<S, T> implements AutoCloseable, Runnable {
 
     private static final Logger LOG = LoggerFactory.getLogger(Aggregator.class);
 
@@ -90,16 +88,15 @@ public class Aggregator<S extends Message, T extends Message> implements AutoClo
 
     private final Striped<Lock> lockStripes = Striped.lock(NUM_STRIPE_LOCKS);
 
-    public Aggregator(SinkModule<S, T> module, AggregatingMessageProducer<S,T> messageProducer) {
-        Objects.requireNonNull(module);
+    public Aggregator(String id, AggregationPolicy<S,T> policy, AggregatingMessageProducer<S,T> messageProducer) {
+        aggregationPolicy = Objects.requireNonNull(policy);
         this.messageProducer = Objects.requireNonNull(messageProducer);
-        aggregationPolicy = Objects.requireNonNull(module.getAggregationPolicy());
         completionSize = aggregationPolicy.getCompletionSize();
         completionIntervalMs = aggregationPolicy.getCompletionIntervalMs();
 
         if (completionIntervalMs > 0) {
             // Periodically verify the buckets, and flush those that are older than completionIntervalMs
-            flushTimer = new Timer(String.format("SinkAggregatorFlush-%s", module.getId()));
+            flushTimer = new Timer(String.format("AggregatorFlush-%s", id));
             flushTimer.scheduleAtFixedRate(new TimerTask() {
                 @Override
                 public void run() {
@@ -108,7 +105,7 @@ public class Aggregator<S extends Message, T extends Message> implements AutoClo
                     } catch (Throwable t) {
                         // The timer may abort if we throw, so we catch here to make
                         // sure that the timer keeps running
-                        LOG.error("An error occurred while flushing one or more aggregates in module '{}'.", module, t);
+                        LOG.error("An error occurred while flushing one or more aggregates in module '{}'.", id, t);
                     }
                 }
             }, completionIntervalMs, completionIntervalMs);

--- a/core/ipc/sink/common/src/main/java/org/opennms/core/ipc/sink/aggregation/SinkAggregator.java
+++ b/core/ipc/sink/common/src/main/java/org/opennms/core/ipc/sink/aggregation/SinkAggregator.java
@@ -28,37 +28,23 @@
 
 package org.opennms.core.ipc.sink.aggregation;
 
-import org.opennms.core.ipc.sink.api.AggregationPolicy;
-import org.opennms.core.ipc.sink.api.MessageDispatcher;
+import java.util.Objects;
+
+import org.opennms.core.ipc.sink.api.Message;
 import org.opennms.core.ipc.sink.api.SinkModule;
 
 /**
- * A {@link MessageDispatcher} that applies the {@link SinkModule}'s {@link AggregationPolicy}
- * using the {@link Aggregator}.
+ * This is a specific aggregator where the messsages implement
+ * the {@link Message} marker interface.
  *
  * @author jwhite
+ *
+ * @param <S> individual message
+ * @param <T> aggregated message (i.e. bucket)
  */
-public abstract class AggregatingMessageProducer<S, T> implements MessageDispatcher<S> {
+public class SinkAggregator<S extends Message, T extends Message> extends Aggregator<S,T> {
 
-    private final Aggregator<S,T> aggregator;
-
-    public AggregatingMessageProducer(String id, AggregationPolicy<S,T> policy) {
-        aggregator = new Aggregator<S,T>(id, policy, this);
-    }
-
-    @Override
-    public void send(S message) {
-        final T bucket = aggregator.aggregate(message);
-        if (bucket != null) {
-            // This bucket is ready to be dispatched
-            dispatch(bucket);
-        }
-    }
-
-    public abstract void dispatch(T message);
-
-    @Override
-    public void close() throws Exception {
-        aggregator.close();
+    public SinkAggregator(SinkModule<S, T> module, AggregatingSinkMessageProducer<S,T> messageProducer) {
+        super(Objects.requireNonNull(module).getId(), module.getAggregationPolicy(), messageProducer);
     }
 }

--- a/core/ipc/sink/common/src/main/java/org/opennms/core/ipc/sink/common/AbstractMessageDispatcherFactory.java
+++ b/core/ipc/sink/common/src/main/java/org/opennms/core/ipc/sink/common/AbstractMessageDispatcherFactory.java
@@ -30,7 +30,7 @@ package org.opennms.core.ipc.sink.common;
 
 import java.util.Objects;
 
-import org.opennms.core.ipc.sink.aggregation.AggregatingMessageProducer;
+import org.opennms.core.ipc.sink.aggregation.AggregatingSinkMessageProducer;
 import org.opennms.core.ipc.sink.api.AsyncDispatcher;
 import org.opennms.core.ipc.sink.api.Message;
 import org.opennms.core.ipc.sink.api.MessageDispatcherFactory;
@@ -101,7 +101,7 @@ public abstract class AbstractMessageDispatcherFactory<W> implements MessageDisp
         final SinkModule<S,T> module = state.getModule();
         if (module.getAggregationPolicy() != null) {
             // Aggregate the message before dispatching them
-            return new AggregatingMessageProducer<S,T>(module) {
+            return new AggregatingSinkMessageProducer<S,T>(module) {
                 @Override
                 public void dispatch(T message) {
                     AbstractMessageDispatcherFactory.this.timedDispatch(state, message);

--- a/features/bsm/service/api/pom.xml
+++ b/features/bsm/service/api/pom.xml
@@ -27,10 +27,12 @@
         <groupId>org.opennms.maven.plugins</groupId>
         <artifactId>features-maven-plugin</artifactId>
         <configuration>
+          <features>
+            <feature>guava</feature>
+          </features>
           <bundles>
             <bundle>mvn:org.opennms.features.bsm/org.opennms.features.bsm.persistence.api/${project.version}</bundle>
             <bundle>mvn:org.opennms.features.bsm/org.opennms.features.bsm.service.api/${project.version}</bundle>
-            <bundle>wrap:mvn:com.google.guava/guava/${guavaVersion}</bundle>
             <bundle>wrap:mvn:net.sf.jung/jung-api/${jungVersion}</bundle>
           </bundles>
         </configuration>

--- a/features/datachoices/pom.xml
+++ b/features/datachoices/pom.xml
@@ -34,11 +34,11 @@
                 <artifactId>features-maven-plugin</artifactId>
                 <configuration>
                     <features>
+                        <feature>guava</feature>
                         <feature>hibernate36</feature> <!-- Required by opennms-web-api -->
                     </features>
                     <bundles>
                         <bundle>mvn:org.opennms.features/datachoices/${project.version}</bundle>
-                        <bundle>wrap:mvn:com.google.guava/guava/${guavaVersion}</bundle>
                         <bundle>wrap:mvn:org.freemarker/freemarker/${freemarkerVersion}</bundle>
                     </bundles>
                 </configuration>

--- a/features/opennms-es-rest/feature/pom.xml
+++ b/features/opennms-es-rest/feature/pom.xml
@@ -19,27 +19,29 @@
       <plugin>
         <groupId>org.opennms.maven.plugins</groupId>
         <artifactId>features-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>features.xml</id>
-            <phase>process-resources</phase>
-            <goals>
-              <goal>generate-features-xml</goal>
-            </goals>
-            <configuration>
-              <bundles>
-                <!-- <bundle>wrap:mvn:io.searchbox/jest-common/${jestVersion}</bundle> -->
-                <!-- <bundle>wrap:mvn:io.searchbox/jest/${jestVersion}</bundle> -->
-                <!-- <bundle>wrap:mvn:io.searchbox/jest-complete-osgi/${jestVersion}</bundle> -->
+        <configuration>
+          <bundles>
+            <!-- <bundle>wrap:mvn:io.searchbox/jest-common/${jestVersion}</bundle> -->
+            <!-- <bundle>wrap:mvn:io.searchbox/jest/${jestVersion}</bundle> -->
+            <!-- <bundle>wrap:mvn:io.searchbox/jest-complete-osgi/${jestVersion}</bundle> -->
 
-<!--                 <bundle>wrap:mvn:org.apache.httpcomponents/httpcore-nio/${httpcoreVersion}</bundle> -->
-                <!-- <bundle>wrap:mvn:org.apache.httpcomponents/httpasyncclient/4.1.1</bundle> -->
-                <!-- <bundle>wrap:mvn:org.apache.httpcomponents/httpasyncclient/${httpclientVersion}</bundle> -->
+            <!-- <bundle>wrap:mvn:org.apache.httpcomponents/httpcore-nio/${httpcoreVersion}</bundle> -->
+            <!-- <bundle>wrap:mvn:org.apache.httpcomponents/httpasyncclient/4.1.1</bundle> -->
+            <!-- <bundle>wrap:mvn:org.apache.httpcomponents/httpasyncclient/${httpclientVersion}</bundle> -->
 
-              </bundles>
-            </configuration>
-          </execution>
-        </executions>
+            <!-- dropwizard-metrics feature -->
+            <bundle>mvn:io.dropwizard.metrics/metrics-core/3.1.2</bundle>
+
+            <!-- rate-limited-logger feature -->
+            <bundle>mvn:joda-time/joda-time/${jodaTimeVersion}</bundle>
+            <bundle>wrap:mvn:com.swrve/rate-limited-logger/${rateLimitedLoggerVersion}</bundle>
+
+            <!-- opennms-core-ipc-sink-api feature -->
+            <bundle>mvn:org.opennms.core.ipc.sink/org.opennms.core.ipc.sink.api/${project.version}</bundle>
+            <bundle>mvn:org.opennms.core.ipc.sink/org.opennms.core.ipc.sink.common/${project.version}</bundle>
+            <bundle>mvn:org.opennms.core.ipc.sink/org.opennms.core.ipc.sink.xml/${project.version}</bundle>
+          </bundles>
+        </configuration>
       </plugin>
     </plugins>
 
@@ -86,6 +88,11 @@
     </dependency>
 
     <dependency>
+      <groupId>commons-lang</groupId>
+      <artifactId>commons-lang</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
       <version>3.4</version> <!-- opennms 3.3.2 -->
@@ -100,13 +107,11 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpcore-osgi</artifactId>
-      <scope>provided</scope>
     </dependency>
 
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient-osgi</artifactId>
-      <scope>provided</scope>
     </dependency>
 
     <!-- <dependency> -->
@@ -120,7 +125,6 @@
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpasyncclient-osgi</artifactId>
       <!-- <version>4.1.1</version> -->
-       <scope>provided</scope>
     </dependency>
 
     <!-- <dependency> -->
@@ -156,18 +160,5 @@
     <!-- [INFO] \- org.apache.httpcomponents:httpasyncclient:jar:4.1.1:provided -->
 
   </dependencies>
-  <pluginRepositories>
-    <pluginRepository>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-      <id>opennms-repo</id>
-      <name>OpenNMS Repository</name>
-      <url>http://maven.opennms.org/content/groups/opennms.org-release</url>
-    </pluginRepository>
-  </pluginRepositories>
 
 </project>

--- a/features/opennms-es-rest/feature/pom.xml
+++ b/features/opennms-es-rest/feature/pom.xml
@@ -100,15 +100,12 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpcore-osgi</artifactId>
-      <!-- <version>4.4.4</version> --><!-- jest version -->
-      <version>${httpcoreVersion}</version>
       <scope>provided</scope>
     </dependency>
 
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient-osgi</artifactId>
-      <!-- <version>4.5.2</version> --><!-- jest version -->
       <scope>provided</scope>
     </dependency>
 

--- a/features/opennms-es-rest/main-module/pom.xml
+++ b/features/opennms-es-rest/main-module/pom.xml
@@ -221,6 +221,13 @@
     </dependency>
 
     <dependency>
+      <groupId>org.opennms.core.ipc.sink</groupId>
+      <artifactId>org.opennms.core.ipc.sink.common</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.opennms</groupId>
       <artifactId>opennms-model</artifactId>
       <scope>provided</scope>

--- a/features/opennms-es-rest/main-module/src/main/java/org/opennms/plugins/elasticsearch/rest/EventForwarderImpl.java
+++ b/features/opennms-es-rest/main-module/src/main/java/org/opennms/plugins/elasticsearch/rest/EventForwarderImpl.java
@@ -36,7 +36,6 @@ import org.slf4j.LoggerFactory;
 
 public class EventForwarderImpl implements EventForwarder {
 
-
 	private static final Logger LOG = LoggerFactory.getLogger(EventForwarderImpl.class);
 
 	private EventToIndex eventToIndex=null;
@@ -50,25 +49,28 @@ public class EventForwarderImpl implements EventForwarder {
 	}
 	
 	@Override
-	public void sendNow(Event event) {		
+	public void sendNow(Event event) {
 		LOG.debug("Event to send received: " + event.toString());
 		if (eventToIndex!=null) eventToIndex.forwardEvent(event);
 	}
 
 	@Override
-	public void sendNow(Log arg0) {
-		// TODO Auto-generated method stub
-
+	public void sendNow(Log eventLog) {
+		if (eventLog != null && eventLog.getEvents() != null) {
+			for (Event event : eventLog.getEvents().getEvent()) {
+				sendNow(event);
+			}
+		}
 	}
 
-    @Override
-    public void sendNowSync(Event event) {
-        throw new UnsupportedOperationException();
-    }
+	@Override
+	public void sendNowSync(Event event) {
+		sendNow(event);
+	}
 
-    @Override
-    public void sendNowSync(Log eventLog) {
-        throw new UnsupportedOperationException();
-    }
+	@Override
+	public void sendNowSync(Log eventLog) {
+		sendNow(eventLog);
+	}
 
 }

--- a/features/opennms-es-rest/main-module/src/main/java/org/opennms/plugins/elasticsearch/rest/EventForwarderImpl.java
+++ b/features/opennms-es-rest/main-module/src/main/java/org/opennms/plugins/elasticsearch/rest/EventForwarderImpl.java
@@ -28,6 +28,8 @@
 
 package org.opennms.plugins.elasticsearch.rest;
 
+import java.util.Collections;
+
 import org.opennms.netmgt.events.api.EventForwarder;
 import org.opennms.netmgt.xml.event.Event;
 import org.opennms.netmgt.xml.event.Log;
@@ -51,7 +53,7 @@ public class EventForwarderImpl implements EventForwarder {
 	@Override
 	public void sendNow(Event event) {
 		LOG.debug("Event to send received: " + event.toString());
-		if (eventToIndex!=null) eventToIndex.forwardEvent(event);
+		if (eventToIndex!=null) eventToIndex.forwardEvents(Collections.singletonList(event));
 	}
 
 	@Override

--- a/features/opennms-es-rest/main-module/src/main/java/org/opennms/plugins/elasticsearch/rest/EventForwarderQueueImpl.java
+++ b/features/opennms-es-rest/main-module/src/main/java/org/opennms/plugins/elasticsearch/rest/EventForwarderQueueImpl.java
@@ -171,20 +171,15 @@ public class EventForwarderQueueImpl implements EventForwarder, AutoCloseable {
 			);
 		}
 
+		/**
+		 * Send events to the index processor.
+		 */
 		@Override
 		public void dispatch(List<Event> events) {
-			// TODO: HZN-998: Use batch index command to insert all events at once
-			for (Event event : events) {
-				if (LOG.isDebugEnabled()) {
-					LOG.debug("Event dispatched to producer:\n event: {}", event.toString());
-				}
-
-				// send event to index processor
-				if (eventToIndex != null) {
-					eventToIndex.forwardEvent(event);
-				} else {
-					LOG.error("cannot send event, eventToIndex is null");
-				}
+			if (eventToIndex != null) {
+				eventToIndex.forwardEvents(events);
+			} else {
+				LOG.error("cannot send event, eventToIndex is null");
 			}
 		}
 	}

--- a/features/opennms-es-rest/main-module/src/main/java/org/opennms/plugins/elasticsearch/rest/EventToIndex.java
+++ b/features/opennms-es-rest/main-module/src/main/java/org/opennms/plugins/elasticsearch/rest/EventToIndex.java
@@ -107,6 +107,8 @@ public class EventToIndex {
 
 	private boolean logEventDescription=false;
 
+	private boolean logAllEvents=false;
+
 	private boolean archiveRawEvents=true;
 
 	private boolean archiveAlarms=true;
@@ -139,6 +141,14 @@ public class EventToIndex {
 
 	public void setLogEventDescription(boolean logEventDescription) {
 		this.logEventDescription = logEventDescription;
+	}
+
+	public boolean isLogAllEvents() {
+		return logAllEvents;
+	}
+
+	public void setLogAllEvents(boolean logAllEvents) {
+		this.logAllEvents = logAllEvents;
 	}
 
 	public NodeCache getNodeCache() {
@@ -379,7 +389,7 @@ public class EventToIndex {
 
 				if(archiveRawEvents){
 					// only send events to ES which are persisted to database
-					if(event.getDbid()!=null && event.getDbid()!=0) {
+					if(logAllEvents || (event.getDbid()!=null && event.getDbid()!=0)) {
 						if (LOG.isDebugEnabled()) LOG.debug("Sending Event to ES:"+event.toString());
 						// Send the event to the event forwarder
 						eventIndex = populateEventIndexBodyFromEvent(event, EVENT_INDEX_NAME, EVENT_INDEX_TYPE);

--- a/features/opennms-es-rest/main-module/src/main/java/org/opennms/plugins/elasticsearch/rest/NodeCacheImpl.java
+++ b/features/opennms-es-rest/main-module/src/main/java/org/opennms/plugins/elasticsearch/rest/NodeCacheImpl.java
@@ -28,10 +28,11 @@
 
 package org.opennms.plugins.elasticsearch.rest;
 
-import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.CacheLoader;
-import com.google.common.cache.LoadingCache;
-import org.opennms.netmgt.config.categories.Category;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
 import org.opennms.netmgt.dao.api.NodeDao;
 import org.opennms.netmgt.model.OnmsCategory;
 import org.opennms.netmgt.model.OnmsNode;
@@ -41,10 +42,9 @@ import org.springframework.transaction.TransactionStatus;
 import org.springframework.transaction.support.TransactionCallbackWithoutResult;
 import org.springframework.transaction.support.TransactionOperations;
 
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Map;
-import java.util.concurrent.TimeUnit;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
 
 /**
  * Created:

--- a/features/opennms-es-rest/main-module/src/main/java/org/opennms/plugins/elasticsearch/rest/SayHello.java
+++ b/features/opennms-es-rest/main-module/src/main/java/org/opennms/plugins/elasticsearch/rest/SayHello.java
@@ -36,10 +36,10 @@ package org.opennms.plugins.elasticsearch.rest;
 public class SayHello {
 	public SayHello(){
 		super();
-		System.out.println("Hello - Elastic Search ReST Event Forwarder started");
+		System.out.println("Hello - Elasticsearch ReST Event Forwarder started");
 	}
 	
 	public void destroyMethod(){
-		System.out.println("Goodbye - Elastic Search ReST Event Forwarder stopped");
+		System.out.println("Goodbye - Elasticsearch ReST Event Forwarder stopped");
 	}
 }

--- a/features/opennms-es-rest/main-module/src/main/java/org/opennms/plugins/elasticsearch/rest/archive/OnmsRestEventsClient.java
+++ b/features/opennms-es-rest/main-module/src/main/java/org/opennms/plugins/elasticsearch/rest/archive/OnmsRestEventsClient.java
@@ -33,12 +33,8 @@ import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.Unmarshaller;
-
 import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.UsernamePasswordCredentials;
-import org.apache.http.client.ClientProtocolException;
 import org.apache.http.client.CredentialsProvider;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;

--- a/features/opennms-es-rest/main-module/src/main/java/org/opennms/plugins/elasticsearch/rest/archive/OpenNMSHistoricEventsToEs.java
+++ b/features/opennms-es-rest/main-module/src/main/java/org/opennms/plugins/elasticsearch/rest/archive/OpenNMSHistoricEventsToEs.java
@@ -28,12 +28,10 @@
 
 package org.opennms.plugins.elasticsearch.rest.archive;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.ListIterator;
 
 import org.opennms.netmgt.events.api.EventForwarder;
-import org.opennms.plugins.elasticsearch.rest.archive.OnmsRestEventsClient;
 import org.opennms.netmgt.xml.event.Event;
 import org.opennms.netmgt.xml.event.Parm;
 import org.slf4j.Logger;

--- a/features/opennms-es-rest/main-module/src/main/resources/OSGI-INF/blueprint/mainModuleBlueprint.xml
+++ b/features/opennms-es-rest/main-module/src/main/resources/OSGI-INF/blueprint/mainModuleBlueprint.xml
@@ -23,6 +23,7 @@
       <cm:property name="esusername" value="" />
       <cm:property name="espassword" value="" />
       <cm:property name="logEventDescription" value="true" />
+      <cm:property name="logAllEvents" value="false" />
       <cm:property name="archiveRawEvents" value="true" />
       <cm:property name="archiveAlarms" value="true" />
       <cm:property name="archiveAlarmChangeEvents" value="true" />
@@ -78,6 +79,7 @@
     <property name="nodeCache" ref="nodeDataCache" />
     <property name="indexNameFunction" ref="indexNameFunction" />
     <property name="logEventDescription" value="${logEventDescription}" />
+    <property name="logAllEvents" value="${logAllEvents}" />
     <property name="archiveRawEvents" value="${archiveRawEvents}" />
     <property name="archiveAlarms" value="${archiveAlarms}" />
     <property name="archiveAlarmChangeEvents" value="${archiveAlarmChangeEvents}" />

--- a/features/opennms-es-rest/main-module/src/main/resources/OSGI-INF/blueprint/mainModuleBlueprint.xml
+++ b/features/opennms-es-rest/main-module/src/main/resources/OSGI-INF/blueprint/mainModuleBlueprint.xml
@@ -11,7 +11,7 @@
 		http://aries.apache.org/schemas/blueprint-ext/blueprint-ext-1.1.xsd
 ">
 
-  <!-- print startup message to karaf consol -->
+  <!-- print startup message to karaf console -->
   <bean id="sayHello" class="org.opennms.plugins.elasticsearch.rest.SayHello" destroy-method="destroyMethod">
   </bean>
 
@@ -29,8 +29,8 @@
       <cm:property name="archiveAlarmChangeEvents" value="true" />
       <cm:property name="archiveOldAlarmValues" value="true" />
       <cm:property name="archiveNewAlarmValues" value="true" />
-      <cm:property name="maxQueueLength" value="1000" />
-      <cm:property name="blockWhenFull" value="true" />
+      <cm:property name="batchSize" value="1" /> <!-- disable batching by default -->
+      <cm:property name="batchInterval" value="0" /> <!-- disable batching by default -->
       <cm:property name="cache_max_ttl" value="0" /> <!-- set to zero to disable TTL -->
       <cm:property name="cache_max_size" value="10000" /> <!-- set to zero to disable max size -->
     </cm:default-properties>
@@ -50,12 +50,10 @@
   <!-- <property name="eventToIndex" ref="eventToIndex" /> -->
   <!-- </bean> -->
 
-  <bean id="eventForwarder" class=" org.opennms.plugins.elasticsearch.rest.EventForwarderQueueImpl" init-method="init" destroy-method="destroy">
+  <bean id="eventForwarder" class=" org.opennms.plugins.elasticsearch.rest.EventForwarderQueueImpl" init-method="init" destroy-method="close">
+    <property name="batchSize" value="${batchSize}" />
+    <property name="batchInterval" value="${batchInterval}" />
     <property name="eventToIndex" ref="eventToIndex" />
-    <!-- sets length of event queue for forwarding to ES -->
-    <property name="maxQueueLength" value="${maxQueueLength}" />
-    <!-- specify whether the queue blocks or discards events when the queue is full -->
-    <property name="blockWhenFull" value="${blockWhenFull}" />
     <property name="elasticSearchInitialiser" ref="elasticSearchInitialiser" />
   </bean>
 
@@ -74,7 +72,7 @@
   </bean>
 
 
-  <bean id="eventToIndex" class="org.opennms.plugins.elasticsearch.rest.EventToIndex" destroy-method="destroy">
+  <bean id="eventToIndex" class="org.opennms.plugins.elasticsearch.rest.EventToIndex" destroy-method="close">
     <property name="restClientFactory" ref="restClientFactory" />
     <property name="nodeCache" ref="nodeDataCache" />
     <property name="indexNameFunction" ref="indexNameFunction" />

--- a/features/opennms-es-rest/main-module/src/test/java/org/opennms/plugins/elasticsearch/rest/archive/manual/OpenNMSHistoricEventsToEsTest.java
+++ b/features/opennms-es-rest/main-module/src/test/java/org/opennms/plugins/elasticsearch/rest/archive/manual/OpenNMSHistoricEventsToEsTest.java
@@ -28,8 +28,6 @@
 
 package org.opennms.plugins.elasticsearch.rest.archive.manual;
 
-import static org.junit.Assert.*;
-
 import org.junit.Test;
 import org.opennms.plugins.elasticsearch.rest.EventForwarderImpl;
 import org.opennms.plugins.elasticsearch.rest.archive.OpenNMSHistoricEventsToEs;

--- a/features/opennms-es-rest/main-module/src/test/java/org/opennms/plugins/elasticsearch/rest/archive/manual/OpenNMSRestEventsClientTest.java
+++ b/features/opennms-es-rest/main-module/src/test/java/org/opennms/plugins/elasticsearch/rest/archive/manual/OpenNMSRestEventsClientTest.java
@@ -28,8 +28,6 @@
 
 package org.opennms.plugins.elasticsearch.rest.archive.manual;
 
-import static org.junit.Assert.*;
-
 import java.util.List;
 
 import org.junit.Test;

--- a/features/opennms-es-rest/main-module/src/test/java/org/opennms/plugins/elasticsearch/test/AlarmEventToIndexTest.java
+++ b/features/opennms-es-rest/main-module/src/test/java/org/opennms/plugins/elasticsearch/test/AlarmEventToIndexTest.java
@@ -28,35 +28,26 @@
 
 package org.opennms.plugins.elasticsearch.test;
 
-import java.net.InetAddress;
-import java.util.Date;
+import static org.junit.Assert.assertEquals;
+
 import java.util.concurrent.TimeUnit;
-
-import org.opennms.plugins.elasticsearch.rest.EventToIndex;
-import org.opennms.plugins.elasticsearch.rest.IndexNameFunction;
-import org.opennms.plugins.elasticsearch.rest.NodeCache;
-import org.opennms.plugins.elasticsearch.rest.RestClientFactory;
-import org.opennms.core.utils.InetAddressUtils;
-import org.opennms.netmgt.model.events.EventBuilder;
-import org.opennms.netmgt.xml.event.Event;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import io.searchbox.client.JestClient;
-import io.searchbox.client.JestClientFactory;
-import io.searchbox.client.config.HttpClientConfig;
-import io.searchbox.core.DocumentResult;
-import io.searchbox.core.Index;
-import io.searchbox.core.Search;
-import io.searchbox.core.SearchResult;
-import io.searchbox.core.Update;
-import static org.junit.Assert.*;
 
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
-import org.json.simple.parser.ParseException;
 import org.junit.Test;
+import org.opennms.netmgt.model.events.EventBuilder;
+import org.opennms.netmgt.xml.event.Event;
+import org.opennms.plugins.elasticsearch.rest.EventToIndex;
+import org.opennms.plugins.elasticsearch.rest.IndexNameFunction;
+import org.opennms.plugins.elasticsearch.rest.NodeCache;
+import org.opennms.plugins.elasticsearch.rest.RestClientFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.searchbox.client.JestClient;
+import io.searchbox.core.Search;
+import io.searchbox.core.SearchResult;
 
 
 public class AlarmEventToIndexTest {
@@ -262,7 +253,7 @@ public class AlarmEventToIndexTest {
 		} finally {
 			// shutdown client
 			if (jestClient !=null )   jestClient.shutdownClient();
-			if (eventToIndex !=null ) eventToIndex.destroy();
+			if (eventToIndex !=null ) eventToIndex.close();
 		}
 		LOG.debug("***************** end of test jestClientAlarmToESTest");
 	}

--- a/features/opennms-es-rest/main-module/src/test/java/org/opennms/plugins/elasticsearch/test/AlarmEventToIndexTest.java
+++ b/features/opennms-es-rest/main-module/src/test/java/org/opennms/plugins/elasticsearch/test/AlarmEventToIndexTest.java
@@ -30,6 +30,7 @@ package org.opennms.plugins.elasticsearch.test;
 
 import static org.junit.Assert.assertEquals;
 
+import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 
 import org.json.simple.JSONArray;
@@ -148,12 +149,12 @@ public class AlarmEventToIndexTest {
 			event.setNodeid((long) 34);
 
 			// forward event to elastic search
-			eventToIndex.forwardEvent(event);
-			
+			eventToIndex.forwardEvents(Collections.singletonList(event));
+
 			// waiting 5 seconds for index 
-            try {
-            	TimeUnit.SECONDS.sleep(5);
-            } catch (InterruptedException e) { }
+			try {
+				TimeUnit.SECONDS.sleep(5);
+			} catch (InterruptedException e) { }
 
 			// send query to check that alarm has been created
 			jestClient = restClientFactory.getJestClient();

--- a/features/opennms-es-rest/main-module/src/test/java/org/opennms/plugins/elasticsearch/test/RawEventToIndexTest.java
+++ b/features/opennms-es-rest/main-module/src/test/java/org/opennms/plugins/elasticsearch/test/RawEventToIndexTest.java
@@ -31,6 +31,7 @@ package org.opennms.plugins.elasticsearch.test;
 import static org.junit.Assert.assertEquals;
 
 import java.net.InetAddress;
+import java.util.Collections;
 import java.util.Date;
 import java.util.concurrent.TimeUnit;
 
@@ -161,12 +162,12 @@ public class RawEventToIndexTest {
 			LOG.debug("ecreated node lost service event:"+event.toString());
 
 			// forward event to elastic search
-			eventToIndex.forwardEvent(event);
-			
+			eventToIndex.forwardEvents(Collections.singletonList(event));
+
 			// waiting 5 seconds for index 
-            try {
-            	TimeUnit.SECONDS.sleep(5);
-            } catch (InterruptedException e) { }
+			try {
+				TimeUnit.SECONDS.sleep(5);
+			} catch (InterruptedException e) { }
 
 			// send query to check that event has been created
 			jestClient = restClientFactory.getJestClient();

--- a/features/opennms-es-rest/main-module/src/test/java/org/opennms/plugins/elasticsearch/test/RawEventToIndexTest.java
+++ b/features/opennms-es-rest/main-module/src/test/java/org/opennms/plugins/elasticsearch/test/RawEventToIndexTest.java
@@ -28,35 +28,29 @@
 
 package org.opennms.plugins.elasticsearch.test;
 
+import static org.junit.Assert.assertEquals;
+
 import java.net.InetAddress;
 import java.util.Date;
 import java.util.concurrent.TimeUnit;
 
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.junit.Test;
+import org.opennms.core.utils.InetAddressUtils;
+import org.opennms.netmgt.model.events.EventBuilder;
+import org.opennms.netmgt.xml.event.Event;
 import org.opennms.plugins.elasticsearch.rest.EventToIndex;
 import org.opennms.plugins.elasticsearch.rest.IndexNameFunction;
 import org.opennms.plugins.elasticsearch.rest.NodeCache;
 import org.opennms.plugins.elasticsearch.rest.RestClientFactory;
-import org.opennms.core.utils.InetAddressUtils;
-import org.opennms.netmgt.model.events.EventBuilder;
-import org.opennms.netmgt.xml.event.Event;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.searchbox.client.JestClient;
-import io.searchbox.client.JestClientFactory;
-import io.searchbox.client.config.HttpClientConfig;
-import io.searchbox.core.DocumentResult;
-import io.searchbox.core.Index;
 import io.searchbox.core.Search;
 import io.searchbox.core.SearchResult;
-import io.searchbox.core.Update;
-import static org.junit.Assert.*;
-
-import org.json.simple.JSONArray;
-import org.json.simple.JSONObject;
-import org.json.simple.parser.JSONParser;
-import org.json.simple.parser.ParseException;
-import org.junit.Test;
 
 
 public class RawEventToIndexTest {
@@ -234,7 +228,7 @@ public class RawEventToIndexTest {
 		} finally {
 			// shutdown client
 			if (jestClient !=null )   jestClient.shutdownClient();
-			if (eventToIndex !=null ) eventToIndex.destroy();
+			if (eventToIndex !=null ) eventToIndex.close();
 		}
 		LOG.debug("***************** end of test jestClientRawEventToESTest");
 	}

--- a/features/opennms-es-rest/main-module/src/test/java/org/opennms/plugins/elasticsearch/test/manual/ClientRecoveryTest.java
+++ b/features/opennms-es-rest/main-module/src/test/java/org/opennms/plugins/elasticsearch/test/manual/ClientRecoveryTest.java
@@ -28,26 +28,19 @@
 
 package org.opennms.plugins.elasticsearch.test.manual;
 
-import static org.junit.Assert.*;
-import io.searchbox.client.JestClient;
-import io.searchbox.client.JestClientFactory;
-import io.searchbox.client.config.HttpClientConfig;
-import io.searchbox.core.DocumentResult;
-import io.searchbox.core.Index;
-import io.searchbox.core.Search;
-import io.searchbox.core.SearchResult;
-
-import java.net.InetAddress;
 import java.util.Date;
 
 import org.junit.Test;
-import org.opennms.core.utils.InetAddressUtils;
-import org.opennms.netmgt.model.events.EventBuilder;
-import org.opennms.netmgt.xml.event.Event;
 import org.opennms.plugins.elasticsearch.rest.EventToIndex;
 import org.opennms.plugins.elasticsearch.rest.IndexNameFunction;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import io.searchbox.client.JestClient;
+import io.searchbox.client.JestClientFactory;
+import io.searchbox.client.config.HttpClientConfig;
+import io.searchbox.core.Search;
+import io.searchbox.core.SearchResult;
 
 public class ClientRecoveryTest {
 	private static final Logger LOG = LoggerFactory.getLogger(ClientRecoveryTest .class);
@@ -59,7 +52,7 @@ public class ClientRecoveryTest {
 		try {
 
 			IndexNameFunction indexNameFunction = new IndexNameFunction();
-			String rootIndexName = EventToIndex.ALARM_INDEX_NAME;
+			String rootIndexName = EventToIndex.INDEX_NAMES.get(EventToIndex.Indices.ALARMS);
 			String indexName = indexNameFunction.apply(rootIndexName , new Date());
 			
 			// Get Jest client


### PR DESCRIPTION
This PR adds config options so that you can forward all events (including 'donotpersist' events) to Elasticsearch and also adds support for batched 'index' operations so that multiple records can be sent to Elasticsearch in one Bulk API operation.

* JIRA: http://issues.opennms.org/browse/HZN-998
* JIRA: http://issues.opennms.org/browse/NMS-8963
* JIRA: http://issues.opennms.org/browse/NMS-9015
