### PR TITLE
NMS-5450: Escape colons in IPv6 directory paths in Jasper reports

### DIFF
--- a/integrations/opennms-jasper-extensions/src/main/java/org/opennms/netmgt/jasper/helper/JRobinDirectoryUtil.java
+++ b/integrations/opennms-jasper-extensions/src/main/java/org/opennms/netmgt/jasper/helper/JRobinDirectoryUtil.java
@@ -209,6 +209,13 @@ public class JRobinDirectoryUtil {
         }
     }
 
+    /**
+     * Escape colons with backslashes so that they can be used in RRD commands.
+     */
+    public static String escapeColons(final String input) {
+        return input.replace(":", "\\:");
+    }
+
     public String getInterfaceDirectory(String snmpifname, String snmpifdescr, String snmpphysaddr) {
         return RrdLabelUtils.computeLabelForRRD(snmpifname, snmpifdescr, snmpphysaddr);
     }

--- a/integrations/opennms-jasper-extensions/src/test/java/org/opennms/netmgt/jasper/jrobin/RrdXportCmdTest.java
+++ b/integrations/opennms-jasper-extensions/src/test/java/org/opennms/netmgt/jasper/jrobin/RrdXportCmdTest.java
@@ -31,13 +31,15 @@ package org.opennms.netmgt.jasper.jrobin;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import java.io.File;
 import java.io.IOException;
 
 import net.sf.jasperreports.engine.JRException;
 
+import org.apache.commons.io.FileUtils;
 import org.jrobin.core.RrdException;
 import org.junit.Test;
-
+import org.opennms.netmgt.jasper.helper.JRobinDirectoryUtil;
 
 public class RrdXportCmdTest {
     
@@ -46,8 +48,40 @@ public class RrdXportCmdTest {
          JRobinDataSource dataSource = (JRobinDataSource) new RrdXportCmd().executeCommand(getQueryString());
          assertTrue(dataSource.next());
     }
-    
 
+    /**
+     * This test attempts to create a JRobinDataSource from JRB files
+     * in a directory that has colons in the path, like the latency
+     * metrics for an IPv6 interface would.
+     * 
+     * @throws RrdException
+     * @throws IOException
+     * @throws JRException
+     */
+    @Test
+    public void testExecuteInIPv6Directory() throws RrdException, IOException, JRException {
+        File tempDir = null;
+        try {
+            tempDir = new File(FileUtils.getTempDirectory(), getClass().getSimpleName());
+            File tempSubDir = new File(tempDir, "0000:0000:0000:0000:0000:0000:0000:0001");
+            if (tempSubDir.mkdirs()) {
+                FileUtils.copyFileToDirectory(new File("src/test/resources/http-8980.jrb"), tempSubDir);
+                FileUtils.copyFileToDirectory(new File("src/test/resources/ssh.jrb"), tempSubDir);
+                String queryString = getIPv6QueryString(new File(tempSubDir, "http-8980.jrb").toString(), new File(tempSubDir, "ssh.jrb").toString());
+
+                JRobinDataSource dataSource = (JRobinDataSource) new RrdXportCmd().executeCommand(queryString);
+                assertTrue(dataSource.next());
+            } else {
+                System.out.println("Test directory could not be created on this filesystem.");
+            }
+        } finally {
+            FileUtils.deleteDirectory(tempDir);
+        }
+   }
+
+    private String getIPv6QueryString(String httpPath, String sshPath) {
+        return "--start 1287005100 --end 1287018990 DEF:xx=" + JRobinDirectoryUtil.escapeColons(httpPath) + ":http-8980:AVERAGE DEF:zz=" + JRobinDirectoryUtil.escapeColons(sshPath) + ":ssh:AVERAGE XPORT:xx:HttpLatency XPORT:zz:SshLatency";
+    }
 
     private String getQueryString() {
         return "--start 1287005100 --end 1287018990 DEF:xx=src/test/resources/http-8980.jrb:http-8980:AVERAGE DEF:zz=src/test/resources/ssh.jrb:ssh:AVERAGE XPORT:xx:HttpLatency XPORT:zz:SshLatency";

--- a/opennms-base-assembly/src/main/filtered/etc/report-templates/ResponseTimeCharts.jrxml
+++ b/opennms-base-assembly/src/main/filtered/etc/report-templates/ResponseTimeCharts.jrxml
@@ -57,6 +57,9 @@
 		<parameter name="ds_IPv4_interface" class="java.lang.String">
 			<defaultValueExpression><![CDATA["127.0.0.1"]]></defaultValueExpression>
 		</parameter>
+		<parameter name="escapedInterface" class="java.lang.String">
+			<defaultValueExpression><![CDATA[org.opennms.netmgt.jasper.helper.JRobinDirectoryUtil.escapeColons($P{ds_IPv4_interface})]]></defaultValueExpression>
+		</parameter>
 		<parameter name="ds_startDate" class="java.util.Date" isForPrompting="false"/>
 		<parameter name="ds_endDate" class="java.util.Date" isForPrompting="false"/>
 		<parameter name="ds_rrdDir" class="java.lang.String">
@@ -70,7 +73,7 @@
 		</parameter>
 		<queryString language="jrobin">
 			<![CDATA[--start $P{ds_startDate} --end $P{ds_endDate}
-		DEF:xx=$P{ds_rrdDir}/response/$P{ds_IPv4_interface}/icmp.jrb:icmp:AVERAGE
+		DEF:xx=$P{ds_rrdDir}/response/$P{escapedInterface}/icmp.jrb:icmp:AVERAGE
 		XPORT:xx:IcmpLatency]]>
 		</queryString>
 		<field name="Timestamp" class="java.util.Date">

--- a/opennms-base-assembly/src/main/filtered/etc/report-templates/subreports/ResponseTimeAvg_subreport.jrxml
+++ b/opennms-base-assembly/src/main/filtered/etc/report-templates/subreports/ResponseTimeAvg_subreport.jrxml
@@ -19,9 +19,12 @@
 	</parameter>
 	<parameter name="rrdDir" class="java.lang.String"/>
 	<parameter name="ipv4_interface" class="java.lang.String"/>
+	<parameter name="escapedInterface" class="java.lang.String">
+		<defaultValueExpression><![CDATA[org.opennms.netmgt.jasper.helper.JRobinDirectoryUtil.escapeColons($P{ipv4_interface})]]></defaultValueExpression>
+	</parameter>
 	<queryString language="jrobin">
 		<![CDATA[--start $P{startDate} --end $P{endDate}
-		DEF:xx=$P{rrdDir}/response/$P{ipv4_interface}/icmp.jrb:icmp:AVERAGE
+		DEF:xx=$P{rrdDir}/response/$P{escapedInterface}/icmp.jrb:icmp:AVERAGE
 		XPORT:xx:IcmpLatency]]>
 	</queryString>
 	<field name="Timestamp" class="java.util.Date">

--- a/opennms-base-assembly/src/main/filtered/etc/report-templates/subreports/ResponseTimeSummary_subreport.jrxml
+++ b/opennms-base-assembly/src/main/filtered/etc/report-templates/subreports/ResponseTimeSummary_subreport.jrxml
@@ -19,9 +19,12 @@
 	</parameter>
 	<parameter name="rrdDir" class="java.lang.String"/>
 	<parameter name="ipv4_interface" class="java.lang.String"/>
+	<parameter name="escapedInterface" class="java.lang.String">
+		<defaultValueExpression><![CDATA[org.opennms.netmgt.jasper.helper.JRobinDirectoryUtil.escapeColons($P{ipv4_interface})]]></defaultValueExpression>
+	</parameter>
 	<queryString language="jrobin">
 		<![CDATA[--start $P{startDate} --end $P{endDate}
-		DEF:xx=$P{rrdDir}/response/$P{ipv4_interface}/icmp.jrb:icmp:AVERAGE
+		DEF:xx=$P{rrdDir}/response/$P{escapedInterface}/icmp.jrb:icmp:AVERAGE
 		XPORT:xx:IcmpLatency]]>
 	</queryString>
 	<field name="Timestamp" class="java.util.Date">

--- a/opennms-base-assembly/src/main/filtered/etc/report-templates/subreports/ResponseTime_subreport1.jrxml
+++ b/opennms-base-assembly/src/main/filtered/etc/report-templates/subreports/ResponseTime_subreport1.jrxml
@@ -15,9 +15,12 @@
 	<parameter name="endDate" class="java.util.Date" isForPrompting="false"/>
 	<parameter name="rrdDir" class="java.lang.String"/>
 	<parameter name="ipv4_interface" class="java.lang.String"/>
+	<parameter name="escapedInterface" class="java.lang.String">
+		<defaultValueExpression><![CDATA[org.opennms.netmgt.jasper.helper.JRobinDirectoryUtil.escapeColons($P{ipv4_interface})]]></defaultValueExpression>
+	</parameter>
 	<queryString language="jrobin">
 		<![CDATA[--start $P{startDate} --end $P{endDate}
-		DEF:xx=$P{rrdDir}/response/$P{ipv4_interface}/icmp.jrb:icmp:AVERAGE
+		DEF:xx=$P{rrdDir}/response/$P{escapedInterface}/icmp.jrb:icmp:AVERAGE
 		XPORT:xx:IcmpLatency]]>
 	</queryString>
 	<field name="Timestamp" class="java.util.Date">


### PR DESCRIPTION
Added util method to escape colons in IP addresses so that reports can access RRD files in directories with IPv6 addresses in the path.

* JIRA: http://issues.opennms.org/browse/NMS-5450