### PR TITLE
NMS-9078: autodetect best ICMP strategy

### DIFF
--- a/container/features/pom.xml
+++ b/container/features/pom.xml
@@ -215,6 +215,7 @@
             <feature>opennms-icmp-jna</feature>
             <feature>opennms-icmp-jni</feature>
             <feature>opennms-icmp-jni6</feature>
+            <feature>opennms-icmp-best</feature>
             <feature>opennms-icmp-commands</feature>
             <feature>opennms-javamail</feature>
             <feature>opennms-model</feature>

--- a/container/features/src/main/resources/features-minion.xml
+++ b/container/features/src/main/resources/features-minion.xml
@@ -47,7 +47,7 @@
       <bundle>mvn:org.opennms.core.snmp/org.opennms.core.snmp.proxy.rpc-impl/${project.version}</bundle>
     </feature>
 
-    <feature name="minion-icmp-proxy" description="OpenNMS :: Minion :: Icmp Proxy" version="${project.version}">
+    <feature name="minion-icmp-proxy" description="OpenNMS :: Minion :: ICMP Proxy" version="${project.version}">
         <feature>minion-rpc-server</feature>
         <feature>opennms-model</feature>
 

--- a/container/features/src/main/resources/features-minion.xml
+++ b/container/features/src/main/resources/features-minion.xml
@@ -58,7 +58,7 @@
     <feature name="minion-provisiond-detectors" description="Minion :: Provisond :: Detectors" version="${project.version}">
       <feature>opennms-config</feature>
       <feature>opennms-dao-api</feature>
-      <feature>opennms-icmp-jna</feature>
+      <feature>opennms-icmp-best</feature>
       <feature>opennms-provisioning-detectors</feature>
       <feature>minion-rpc-server</feature>
       <bundle>mvn:org.opennms/opennms-detector-registry/${project.version}</bundle>

--- a/container/features/src/main/resources/features.xml
+++ b/container/features/src/main/resources/features.xml
@@ -690,6 +690,15 @@
       <bundle>mvn:org.opennms/opennms-icmp-api/${project.version}</bundle>
     </feature>
 
+    <feature name="opennms-icmp-best" description="OpenNMS :: ICMP :: Best Match" version="${project.version}">
+      <feature>opennms-icmp-api</feature>
+      <feature>opennms-icmp-jna</feature>
+      <feature>opennms-icmp-jni</feature>
+      <feature>opennms-icmp-jni6</feature>
+
+      <bundle>mvn:org.opennms/opennms-icmp-best/${project.version}</bundle>
+    </feature>
+
     <feature name="opennms-icmp-jna" description="OpenNMS :: ICMP :: JNA" version="${project.version}">
       <feature version="${guavaVersion}">guava</feature>
 

--- a/core/daemon/src/main/java/org/opennms/netmgt/vmmgr/Manager.java
+++ b/core/daemon/src/main/java/org/opennms/netmgt/vmmgr/Manager.java
@@ -239,7 +239,8 @@ public class Manager implements ManagerMBean {
     }
 
     private void testPinger() {
-        final Pinger pinger = new PingerFactoryImpl().getInstance();
+        final PingerFactoryImpl pingerFactory = new PingerFactoryImpl();
+        final Pinger pinger = pingerFactory.getInstance();
 
         boolean hasV4 = pinger.isV4Available();
         boolean hasV6 = pinger.isV6Available();
@@ -282,6 +283,8 @@ public class Manager implements ManagerMBean {
         }
         
         // at least one is initialized, and we haven't said otherwise, so barrel ahead
+        // but first, reset the pinger factory so we can let auto-detection happen
+        pingerFactory.reset();
     }
 
     private void throwPingError(final String message) throws IllegalStateException {

--- a/core/daemon/src/main/resources/META-INF/opennms/applicationContext-pinger.xml
+++ b/core/daemon/src/main/resources/META-INF/opennms/applicationContext-pinger.xml
@@ -18,7 +18,7 @@
 
   <context:annotation-config />
 
-  <bean id="pingerFactory" class="org.opennms.netmgt.icmp.PingerFactoryImpl" />
+  <bean id="pingerFactory" class="org.opennms.netmgt.icmp.best.BestMatchPingerFactory" />
   <onmsgi:service interface="org.opennms.netmgt.icmp.PingerFactory" ref="pingerFactory" />
 
   <bean id="pinger" factory-bean="pingerFactory" factory-method="getInstance">

--- a/core/test-api/camel/src/main/java/org/opennms/core/test/camel/CamelBlueprintTest.java
+++ b/core/test-api/camel/src/main/java/org/opennms/core/test/camel/CamelBlueprintTest.java
@@ -29,8 +29,8 @@
 package org.opennms.core.test.camel;
 
 import org.apache.camel.test.blueprint.CamelBlueprintTestSupport;
+import org.opennms.netmgt.icmp.AbstractPingerFactory;
 import org.opennms.netmgt.icmp.PingerFactory;
-import org.opennms.netmgt.icmp.PingerFactoryImpl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -50,8 +50,8 @@ public class CamelBlueprintTest extends CamelBlueprintTestSupport {
         System.setProperty( "de.kalpatec.pojosr.framework.events.sync", Boolean.TRUE.toString() );
         try {
             final PingerFactory pingerFactory = getOsgiService(PingerFactory.class, 2000);
-            if (pingerFactory instanceof PingerFactoryImpl) {
-                ((PingerFactoryImpl) pingerFactory).reset();
+            if (pingerFactory instanceof AbstractPingerFactory) {
+                ((AbstractPingerFactory) pingerFactory).reset();
             }
         } catch (final Exception e) {
             LOG.warn("Failed to get PingerFactory. This may be intentional.");

--- a/core/test-api/lib/src/main/java/org/opennms/test/DaoTestConfigBean.java
+++ b/core/test-api/lib/src/main/java/org/opennms/test/DaoTestConfigBean.java
@@ -66,7 +66,7 @@ public class DaoTestConfigBean implements InitializingBean {
     @Override
     public void afterPropertiesSet() {
         if (System.getProperty("org.opennms.netmgt.icmp.pingerClass") == null) {
-            System.setProperty("org.opennms.netmgt.icmp.pingerClass", "org.opennms.netmgt.icmp.jna.JnaPinger");
+            System.setProperty("org.opennms.netmgt.icmp.pingerClass", "org.opennms.netmgt.icmp.best.JnaPinger");
         }
         if (System.getProperty("activemq.data") == null) {
             System.setProperty("activemq.data", "target/test/activemq");

--- a/features/discovery/pom.xml
+++ b/features/discovery/pom.xml
@@ -98,5 +98,10 @@
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.opennms</groupId>
+      <artifactId>opennms-icmp-best</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/features/events/daemon/pom.xml
+++ b/features/events/daemon/pom.xml
@@ -78,6 +78,11 @@
     </dependency>
     <dependency>
       <groupId>org.opennms</groupId>
+      <artifactId>opennms-icmp-best</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.opennms</groupId>
       <artifactId>opennms-rrd-jrobin</artifactId>
       <scope>test</scope>
     </dependency>

--- a/features/events/syslog/pom.xml
+++ b/features/events/syslog/pom.xml
@@ -134,6 +134,11 @@
     </dependency>
     <dependency>
       <groupId>org.opennms</groupId>
+      <artifactId>opennms-icmp-best</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.opennms</groupId>
       <artifactId>opennms-rrd-jrobin</artifactId>
       <scope>test</scope>
     </dependency>

--- a/features/remote-poller/pom.xml
+++ b/features/remote-poller/pom.xml
@@ -252,6 +252,10 @@ groovy.compiler.output.path=target/classes
       <groupId>org.opennms</groupId>
       <artifactId>opennms-icmp-jni6</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.opennms</groupId>
+      <artifactId>opennms-icmp-best</artifactId>
+    </dependency>
     <!-- Logging implementation dependencies -->
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>

--- a/features/topology-map/plugins/org.opennms.features.topology.plugins.netutils/pom.xml
+++ b/features/topology-map/plugins/org.opennms.features.topology.plugins.netutils/pom.xml
@@ -81,5 +81,11 @@
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.opennms</groupId>
+			<artifactId>opennms-icmp-best</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 </project>

--- a/integration-tests/remote-poller-18/pom.xml
+++ b/integration-tests/remote-poller-18/pom.xml
@@ -97,6 +97,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.opennms</groupId>
+      <artifactId>opennms-icmp-best</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.opennms.core.test-api</groupId>
       <artifactId>org.opennms.core.test-api.db</artifactId>
     </dependency>

--- a/opennms-assemblies/http-remoting/pom.xml
+++ b/opennms-assemblies/http-remoting/pom.xml
@@ -274,6 +274,11 @@
     </dependency>
     <dependency>
       <groupId>org.opennms</groupId>
+      <artifactId>opennms-icmp-best</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.opennms</groupId>
       <artifactId>opennms-rrdtool-api</artifactId>
       <scope>test</scope>
     </dependency>

--- a/opennms-base-assembly/pom.xml
+++ b/opennms-base-assembly/pom.xml
@@ -245,6 +245,10 @@
     </dependency>
     <dependency>
       <groupId>org.opennms</groupId>
+      <artifactId>opennms-icmp-best</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.opennms</groupId>
       <artifactId>opennms-icmp-jna</artifactId>
     </dependency>
     <dependency>

--- a/opennms-base-assembly/src/main/filtered/etc/opennms.properties
+++ b/opennms-base-assembly/src/main/filtered/etc/opennms.properties
@@ -28,15 +28,18 @@
 # the default ICMP implementation used in the remote poller, since it does
 # not rely on any external native code to be installed outside of the JVM.
 #
-# To use the JNI ICMPv4 interface only, use the following property setting:
+# To use the JNI ICMPv4/ICMPv6 implementation, use the following property:
+#org.opennms.netmgt.icmp.pingerClass=org.opennms.netmgt.icmp.jni6.Jni6Pinger
+#
+# To use the JNI ICMPv4 interface only, use the following property:
 #org.opennms.netmgt.icmp.pingerClass=org.opennms.netmgt.icmp.jni.JniPinger
 #
 # To use the JNA ICMPv4/ICMPv6 implementation, use the following property:
 #org.opennms.netmgt.icmp.pingerClass=org.opennms.netmgt.icmp.jna.JnaPinger
 #
-# The default is set to use the JNI ICMPv4/ICMPv6 interface like so:
-#org.opennms.netmgt.icmp.pingerClass=org.opennms.netmgt.icmp.jni6.Jni6Pinger
-
+# If no pingerClass is set, OpenNMS will attempt to choose the best
+# available pinger automatically.
+#
 # By default, OpenNMS will start up if either ICMPv4 *or* ICMPv6 are
 # available and initialize properly.  If you wish to force IPv4 or IPv6
 # explicitly, set one or both of these properties to true.

--- a/opennms-config/src/main/java/org/opennms/netmgt/config/DiscoveryConfigFactory.java
+++ b/opennms-config/src/main/java/org/opennms/netmgt/config/DiscoveryConfigFactory.java
@@ -622,6 +622,8 @@ public class DiscoveryConfigFactory implements DiscoveryConfigurationFactory {
         getReadLock().lock();
         try {
             return getConfiguration().getRestartSleepTime();
+        } catch (final NullPointerException e) {
+            return 86400000L;
         } finally {
             getReadLock().unlock();
         }
@@ -637,6 +639,8 @@ public class DiscoveryConfigFactory implements DiscoveryConfigurationFactory {
         getReadLock().lock();
         try {
             return getConfiguration().getInitialSleepTime();
+        } catch (final NullPointerException e) {
+            return 30000L;
         } finally {
             getReadLock().unlock();
         }

--- a/opennms-full-assembly/src/test/java/org/opennms/assemblies/karaf/FeatureInstallKarafIT.java
+++ b/opennms-full-assembly/src/test/java/org/opennms/assemblies/karaf/FeatureInstallKarafIT.java
@@ -122,6 +122,7 @@ public class FeatureInstallKarafIT extends KarafTestCase {
         installFeature("opennms-icmp-jna");
         installFeature("opennms-icmp-jni");
         installFeature("opennms-icmp-jni6");
+        installFeature("opennms-icmp-best");
         installFeature("opennms-javamail");
         installFeature("opennms-model");
         installFeature("opennms-poller-api");

--- a/opennms-full-assembly/src/test/java/org/opennms/assemblies/karaf/OnmsFeatureKarafIT.java
+++ b/opennms-full-assembly/src/test/java/org/opennms/assemblies/karaf/OnmsFeatureKarafIT.java
@@ -413,6 +413,11 @@ public class OnmsFeatureKarafIT extends KarafTestCase {
 		System.out.println(executeCommand("features:list -i"));
 	}
 	@Test
+	public void testInstallFeatureOpennmsIcmpBest() {
+		installFeature("opennms-icmp-best");
+		System.out.println(executeCommand("features:list -i"));
+	}
+	@Test
 	public void testInstallFeatureOpennmsIcmpJna() {
 		installFeature("opennms-icmp-jna");
 		System.out.println(executeCommand("features:list -i"));

--- a/opennms-icmp/opennms-icmp-best/pom.xml
+++ b/opennms-icmp/opennms-icmp-best/pom.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <parent>
+    <artifactId>opennms-icmp</artifactId>
+    <groupId>org.opennms</groupId>
+    <version>19.0.0-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>opennms-icmp-best</artifactId>
+  <name>OpenNMS ICMP Pinger - dynamic implementation</name>
+  <packaging>bundle</packaging>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
+            <Bundle-SymbolicName>${project.groupId}.${project.artifactId}</Bundle-SymbolicName>
+            <Bundle-Version>${project.version}</Bundle-Version>
+            <Export-Package>org.opennms.netmgt.icmp.best.*;version="${project.version}"</Export-Package>
+          </instructions>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+  <dependencies>
+    <dependency>
+      <groupId>org.opennms</groupId>
+      <artifactId>opennms-icmp-jna</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.opennms</groupId>
+      <artifactId>opennms-icmp-jni</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.opennms</groupId>
+      <artifactId>opennms-icmp-jni6</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/opennms-icmp/opennms-icmp-best/src/main/java/org/opennms/netmgt/icmp/best/BestMatchPinger.java
+++ b/opennms-icmp/opennms-icmp-best/src/main/java/org/opennms/netmgt/icmp/best/BestMatchPinger.java
@@ -1,0 +1,154 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2017 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.icmp.best;
+
+import java.net.InetAddress;
+import java.util.List;
+
+import org.opennms.netmgt.icmp.NullPinger;
+import org.opennms.netmgt.icmp.PingResponseCallback;
+import org.opennms.netmgt.icmp.Pinger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class BestMatchPinger implements Pinger {
+    private static final Logger LOG = LoggerFactory.getLogger(BestMatchPinger.class);
+    private Pinger m_pinger = null;
+    private Boolean m_allowFragmentation;
+    private Integer m_trafficClass;
+
+    @Override
+    public void ping(final InetAddress host, final long timeout, final int retries, final int packetsize, final int sequenceId, final PingResponseCallback cb) throws Exception {
+        initialize();
+        m_pinger.ping(host, timeout, retries, packetsize, sequenceId, cb);
+    }
+
+    @Override
+    public void ping(final InetAddress host, final long timeout, final int retries, final int sequenceId, final PingResponseCallback cb) throws Exception {
+        initialize();
+        m_pinger.ping(host, timeout, retries, sequenceId, cb);
+    }
+
+    @Override
+    public Number ping(final InetAddress host, final long timeout, final int retries, final int packetsize) throws Exception {
+        initialize();
+        return m_pinger.ping(host, timeout, retries, packetsize);
+    }
+
+    @Override
+    public Number ping(final InetAddress host, final long timeout, final int retries) throws Exception {
+        initialize();
+        return m_pinger.ping(host, timeout, retries);
+    }
+
+    @Override
+    public Number ping(final InetAddress host) throws Exception {
+        initialize();
+        return m_pinger.ping(host);
+    }
+
+    @Override
+    public List<Number> parallelPing(final InetAddress host, final int count, final long timeout, final long pingInterval) throws Exception {
+        initialize();
+        return m_pinger.parallelPing(host, count, timeout, pingInterval);
+    }
+
+    @Override
+    public List<Number> parallelPing(final InetAddress host, final int count, final long timeout, final long pingInterval, final int size) throws Exception {
+        initialize();
+        return m_pinger.parallelPing(host, count, timeout, pingInterval, size);
+    }
+
+    @Override
+    public void initialize4() throws Exception {
+        initialize();
+
+    }
+
+    @Override
+    public void initialize6() throws Exception {
+        initialize();
+    }
+
+    @Override
+    public boolean isV4Available() {
+        initialize();
+        return m_pinger.isV4Available();
+    }
+
+    @Override
+    public boolean isV6Available() {
+        initialize();
+        return m_pinger.isV6Available();
+    }
+
+    @Override
+    public void setAllowFragmentation(final boolean allow) throws Exception {
+        if (m_pinger != null) {
+            m_pinger.setAllowFragmentation(allow);        
+        }
+        m_allowFragmentation = allow;
+    }
+
+    @Override
+    public void setTrafficClass(final int tc) throws Exception {
+        if (m_pinger != null) {
+            m_pinger.setTrafficClass(tc);
+        }
+        m_trafficClass = tc;
+    }
+
+    private void initialize() {
+        if (m_pinger == null) {
+            final Class<? extends Pinger> pinger = BestMatchPingerFactory.findPinger();
+            try {
+                m_pinger = pinger.newInstance();
+            } catch (final Throwable t) {
+                LOG.error("Failed to initialize best match pinger ({}).  Falling back to the null pinger.", pinger, t);
+                m_pinger = new NullPinger();
+            }
+
+            try {
+                if (m_allowFragmentation != null) {
+                    m_pinger.setAllowFragmentation(m_allowFragmentation);
+                }
+            } catch (final Throwable t) {
+                LOG.debug("Failed to set 'allow fragmentation' flag on pinger {}", pinger, t);
+            }
+
+            try {
+                if (m_trafficClass != null) {
+                    m_pinger.setTrafficClass(m_trafficClass);
+                }
+            } catch (final Throwable t) {
+                LOG.debug("Failed to set traffic class on pinger {}", pinger, t);
+            }
+        }
+    }
+}

--- a/opennms-icmp/opennms-icmp-best/src/main/java/org/opennms/netmgt/icmp/best/BestMatchPingerFactory.java
+++ b/opennms-icmp/opennms-icmp-best/src/main/java/org/opennms/netmgt/icmp/best/BestMatchPingerFactory.java
@@ -1,0 +1,133 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2017 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.icmp.best;
+
+import java.util.Arrays;
+
+import org.opennms.core.utils.InetAddressUtils;
+import org.opennms.netmgt.icmp.AbstractPingerFactory;
+import org.opennms.netmgt.icmp.NullPinger;
+import org.opennms.netmgt.icmp.Pinger;
+import org.opennms.netmgt.icmp.jna.JnaPinger;
+import org.opennms.netmgt.icmp.jni.JniPinger;
+import org.opennms.netmgt.icmp.jni6.Jni6Pinger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class BestMatchPingerFactory extends AbstractPingerFactory {
+    private static Logger LOG = LoggerFactory.getLogger(BestMatchPingerFactory.class);
+    Class<? extends Pinger> m_pingerClass = null;
+
+    @Override
+    public Class<? extends Pinger> getPingerClass() {
+        initialize();
+        return m_pingerClass;
+    }
+
+    private static PingerMatch tryPinger(final Class<? extends Pinger> pingerClass) {
+        boolean v4 = false;
+        boolean v6 = false;
+
+        final Pinger pinger;
+        try {
+            pinger = pingerClass.newInstance();
+        } catch (final Throwable t) {
+            LOG.info("Failed to get instance of {}.", pingerClass, t);
+            return PingerMatch.NONE;
+        }
+
+        try {
+            if (pinger.isV4Available()) {
+                v4 = true;
+            }
+        } catch (final Throwable t) {
+            LOG.info("Failed to initialize {} for IPv4.", pingerClass, t);
+        }
+
+        try {
+            if (pinger.isV6Available()) {
+                v6 = true;
+            }
+        } catch (final Throwable t) {
+            LOG.info("Failed to initialize {} for IPv4.", pingerClass, t);
+        }
+
+        try {
+            final long timeout = Long.valueOf(System.getProperty("org.opennms.netmgt.icmp.best.timeout", "500"), 10);
+            final Number result = pinger.ping(InetAddressUtils.getLocalHostAddress(), timeout, 0);
+            if (result == null) {
+                throw new IllegalStateException("No result pinging localhost.");
+            }
+        } catch (final Throwable t) {
+            LOG.info("Found pinger {}, but it was unable to ping localhost.", pingerClass, t);
+            return PingerMatch.NONE;
+        }
+
+        if (v4 && v6) {
+            return PingerMatch.IPv46;
+        } else if (v6) {
+            return PingerMatch.IPv6;
+        } else if (v4) {
+            return PingerMatch.IPv4;
+        } else {
+            return PingerMatch.NONE;
+        }
+    }
+
+    static Class<? extends Pinger> findPinger() {
+        PingerMatch match = PingerMatch.NONE;
+        Class<? extends Pinger> pinger = NullPinger.class;
+
+        LOG.info("Searching for best available pinger...");
+        for (final Class<? extends Pinger> pingerClass : Arrays.asList(Jni6Pinger.class, JniPinger.class, JnaPinger.class)) {
+            final PingerMatch tried = tryPinger(pingerClass);
+            if (tried.compareTo(match) > 0) {
+                match = tried;
+                pinger = pingerClass;
+            }
+        }
+
+        LOG.info("Best available pinger is: {}", pinger);
+        return pinger;
+    }
+
+    private void initialize() {
+        if (m_pingerClass == null) {
+            // If the default (0) DSCP pinger has already been initialized, use the
+            // same class in case it's been manually overridden with a setInstance()
+            // call (ie, in the Remote Poller)
+            final Pinger defaultPinger = m_pingers.getIfPresent(1);
+            if (defaultPinger != null) {
+                m_pingerClass = defaultPinger.getClass();
+            } else {
+                m_pingerClass = findPinger();
+            }
+        }
+    }
+}

--- a/opennms-icmp/opennms-icmp-best/src/main/java/org/opennms/netmgt/icmp/best/PingerMatch.java
+++ b/opennms-icmp/opennms-icmp-best/src/main/java/org/opennms/netmgt/icmp/best/PingerMatch.java
@@ -1,7 +1,7 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2016-2017 The OpenNMS Group, Inc.
+ * Copyright (C) 2017 The OpenNMS Group, Inc.
  * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
@@ -26,26 +26,11 @@
  *     http://www.opennms.com/
  *******************************************************************************/
 
-package org.opennms.netmgt.icmp;
+package org.opennms.netmgt.icmp.best;
 
-public class PingerFactoryImpl extends AbstractPingerFactory {
-    @Override
-    public Class<? extends Pinger> getPingerClass() {
-        final String pingerClassName = System.getProperty("org.opennms.netmgt.icmp.pingerClass", "org.opennms.netmgt.icmp.jni6.Jni6Pinger");
-
-        // If the default (0) DSCP pinger has already been initialized, use the
-        // same class in case it's been manually overridden with a setInstance()
-        // call (ie, in the Remote Poller)
-        final Pinger defaultPinger = m_pingers.getIfPresent(1);
-        if (defaultPinger != null) {
-            return defaultPinger.getClass();
-        }
-
-        try {
-            return Class.forName(pingerClassName).asSubclass(Pinger.class);
-        } catch (final ClassNotFoundException e) {
-            throw new IllegalStateException("Unable to locate pinger class " + pingerClassName);
-        }
-    }
-
+enum PingerMatch {
+    NONE,
+    IPv4,
+    IPv6,
+    IPv46
 }

--- a/opennms-icmp/opennms-icmp-best/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/opennms-icmp/opennms-icmp-best/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -1,0 +1,24 @@
+ <blueprint
+        xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0"
+        xsi:schemaLocation="
+                http://www.osgi.org/xmlns/blueprint/v1.0.0 http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd
+                http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0 https://svn.apache.org/repos/asf/aries/tags/blueprint-0.3.1/blueprint-cm/src/main/resources/org/apache/aries/blueprint/compendium/cm/blueprint-cm-1.1.0.xsd
+                http://www.osgi.org/xmlns/blueprint-ext/v1.1.0 https://svn.apache.org/repos/asf/aries/tags/blueprint-0.3.1/blueprint-core/src/main/resources/org/apache/aries/blueprint/ext/blueprint-ext.xsd
+        ">
+
+        <bean id="pingerFactory" class="org.opennms.netmgt.icmp.best.BestMatchPingerFactory" />
+        <service interface="org.opennms.netmgt.icmp.PingerFactory" ref="pingerFactory" ranking="1000"/>
+
+        <bean id="bestMatchPinger" factory-ref="pingerFactory" factory-method="getInstance" />
+
+    	<service interface="org.opennms.netmgt.icmp.Pinger" ref="bestMatchPinger" ranking="1000" >
+			<service-properties>
+				<entry key="type">
+					<value type="java.lang.String">best</value>
+				</entry>
+			</service-properties>
+        </service>
+
+</blueprint>

--- a/opennms-icmp/opennms-icmp-proxy-rpc-impl/pom.xml
+++ b/opennms-icmp/opennms-icmp-proxy-rpc-impl/pom.xml
@@ -98,6 +98,11 @@
     </dependency>
     <dependency>
       <groupId>org.opennms</groupId>
+      <artifactId>opennms-icmp-best</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.opennms</groupId>
       <artifactId>opennms-dao</artifactId>
       <scope>test</scope>
     </dependency>

--- a/opennms-icmp/pom.xml
+++ b/opennms-icmp/pom.xml
@@ -14,6 +14,7 @@
     <module>opennms-icmp-jni</module>
     <module>opennms-icmp-jni6</module>
     <module>opennms-icmp-jna</module>
+    <module>opennms-icmp-best</module>
     <module>commands</module>
     <module>opennms-icmp-proxy-rpc-impl</module>
   </modules>

--- a/opennms-install/pom.xml
+++ b/opennms-install/pom.xml
@@ -72,7 +72,7 @@
     <!-- OpenNMS dependencies -->
     <dependency>
       <groupId>org.opennms</groupId>
-      <artifactId>opennms-icmp-jni</artifactId>
+      <artifactId>opennms-icmp-best</artifactId>
     </dependency>
     <dependency>
       <groupId>org.opennms.dependencies</groupId>

--- a/opennms-install/src/main/java/org/opennms/install/Installer.java
+++ b/opennms-install/src/main/java/org/opennms/install/Installer.java
@@ -69,7 +69,7 @@ import org.opennms.core.utils.ConfigFileConstants;
 import org.opennms.core.utils.ProcessExec;
 import org.opennms.netmgt.config.opennmsDataSources.JdbcDataSource;
 import org.opennms.netmgt.icmp.Pinger;
-import org.opennms.netmgt.icmp.PingerFactoryImpl;
+import org.opennms.netmgt.icmp.best.BestMatchPingerFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.support.GenericApplicationContext;
@@ -1223,7 +1223,7 @@ public class Installer {
         Pinger pinger;
         try {
        
-            pinger = new PingerFactoryImpl().getInstance();
+            pinger = new BestMatchPingerFactory().getInstance();
         
         } catch (UnsatisfiedLinkError e) {
             System.out.println("UnsatisfiedLinkError while creating an ICMP Pinger.  Most likely failed to load "

--- a/opennms-provision/opennms-detector-simple/pom.xml
+++ b/opennms-provision/opennms-detector-simple/pom.xml
@@ -60,6 +60,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.opennms</groupId>
+      <artifactId>opennms-icmp-best</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.opennms.dependencies</groupId>
       <artifactId>jcifs-dependencies</artifactId>
       <type>pom</type>

--- a/opennms-provision/opennms-detector-simple/src/test/java/org/opennms/netmgt/provision/detector/IcmpDetectorTest.java
+++ b/opennms-provision/opennms-detector-simple/src/test/java/org/opennms/netmgt/provision/detector/IcmpDetectorTest.java
@@ -38,8 +38,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.opennms.core.test.MockLogAppender;
 import org.opennms.core.utils.InetAddressUtils;
+import org.opennms.netmgt.icmp.AbstractPingerFactory;
 import org.opennms.netmgt.icmp.PingerFactory;
-import org.opennms.netmgt.icmp.PingerFactoryImpl;
 import org.opennms.netmgt.icmp.jna.JnaPinger;
 import org.opennms.netmgt.icmp.jni.JniPinger;
 import org.opennms.netmgt.provision.detector.icmp.IcmpDetector;
@@ -118,10 +118,10 @@ public class IcmpDetectorTest {
         assertFalse("ICMP was incorrectly identified on " + InetAddressUtils.UNPINGABLE_ADDRESS.getHostAddress(), m_icmpDetector.isServiceDetected(InetAddressUtils.UNPINGABLE_ADDRESS));
     }
 
-    private PingerFactoryImpl getPingerFactory() {
-        if (m_pingerFactory instanceof PingerFactoryImpl) {
-            return (PingerFactoryImpl) m_pingerFactory;
+    private AbstractPingerFactory getPingerFactory() {
+        if (m_pingerFactory instanceof AbstractPingerFactory) {
+            return (AbstractPingerFactory) m_pingerFactory;
         }
-        throw new IllegalStateException("Pinger factory for testing is not a normal PingerFactoryImpl!");
+        throw new IllegalStateException("Pinger factory for testing is not a normal AbstractPingerFactory!");
     }
 }

--- a/opennms-provision/opennms-detector-simple/src/test/resources/META-INF/opennms/test/detectors.xml
+++ b/opennms-provision/opennms-detector-simple/src/test/resources/META-INF/opennms/test/detectors.xml
@@ -9,6 +9,6 @@
 
   <context:annotation-config />
 
-  <bean id="pingerFactory" class="org.opennms.netmgt.icmp.PingerFactoryImpl" />
+  <bean id="pingerFactory" class="org.opennms.netmgt.icmp.best.BestMatchPingerFactory" />
 
 </beans>

--- a/opennms-provision/opennms-detectorclient-rpc/pom.xml
+++ b/opennms-provision/opennms-detectorclient-rpc/pom.xml
@@ -129,5 +129,10 @@
       <artifactId>opennms-icmp-jna</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.opennms</groupId>
+      <artifactId>opennms-icmp-best</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/opennms-provision/opennms-provisiond/pom.xml
+++ b/opennms-provision/opennms-provisiond/pom.xml
@@ -131,5 +131,10 @@
       <artifactId>opennms-icmp-jna</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.opennms</groupId>
+      <artifactId>opennms-icmp-best</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/opennms-services/pom.xml
+++ b/opennms-services/pom.xml
@@ -378,6 +378,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.opennms</groupId>
+      <artifactId>opennms-icmp-best</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.opennms.features.poller</groupId>
       <artifactId>org.opennms.features.poller.client-rpc</artifactId>
       <scope>test</scope>

--- a/opennms-tools/cli-pinger/pom.xml
+++ b/opennms-tools/cli-pinger/pom.xml
@@ -54,6 +54,11 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.opennms</groupId>
+      <artifactId>opennms-icmp-best</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
         <groupId>args4j</groupId>
         <artifactId>args4j</artifactId>
         <version>2.33</version>

--- a/opennms-tools/cli-pinger/src/main/java/org/opennms/netmgt/clipinger/CLIPinger.java
+++ b/opennms-tools/cli-pinger/src/main/java/org/opennms/netmgt/clipinger/CLIPinger.java
@@ -44,7 +44,7 @@ import org.kohsuke.args4j.CmdLineParser;
 import org.kohsuke.args4j.Option;
 import org.opennms.netmgt.icmp.Pinger;
 import org.opennms.netmgt.icmp.PingerFactory;
-import org.opennms.netmgt.icmp.PingerFactoryImpl;
+import org.opennms.netmgt.icmp.best.BestMatchPingerFactory;
 
 /**
  * <P>
@@ -106,7 +106,7 @@ final public class CLIPinger {
         
         try {
             host = InetAddress.getByName(s_arguments.get(0));
-            final PingerFactory pf = new PingerFactoryImpl();
+            final PingerFactory pf = new BestMatchPingerFactory();
             final Pinger p = pf.getInstance(Integer.decode(s_dscp), s_allowFragmentation);
             for (int i = 0; i < s_count; i++) {
                 Number rtt = p.ping(host, s_timeout, s_retries);

--- a/opennms-webapp-rest/pom.xml
+++ b/opennms-webapp-rest/pom.xml
@@ -107,6 +107,10 @@
           <groupId>org.opennms</groupId>
           <artifactId>opennms-icmp-jna</artifactId>
         </dependency>
+        <dependency>
+          <groupId>org.opennms</groupId>
+          <artifactId>opennms-icmp-best</artifactId>
+        </dependency>
       </dependencies>
     </profile>
   </profiles>
@@ -238,6 +242,11 @@
     <dependency>
       <groupId>org.opennms</groupId>
       <artifactId>opennms-icmp-jna</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.opennms</groupId>
+      <artifactId>opennms-icmp-best</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/opennms-webapp/pom.xml
+++ b/opennms-webapp/pom.xml
@@ -881,6 +881,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.opennms</groupId>
+      <artifactId>opennms-icmp-best</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.opennms.core.test-api</groupId>
       <artifactId>org.opennms.core.test-api.db</artifactId>
       <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -2445,6 +2445,11 @@
         <version>${project.version}</version>
       </dependency>
       <dependency>
+        <groupId>org.opennms</groupId>
+        <artifactId>opennms-icmp-best</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
         <groupId>org.opennms.core</groupId>
         <artifactId>org.opennms.core.icmp-jna</artifactId>
         <version>${project.version}</version>


### PR DESCRIPTION
This PR adds a new PingerFactory implementation called the `BestMatchPingerFactory`, which will attempt all strategies until one is matched, or give up and choose the `NullPinger` otherwise.  This means that on systems where JICMP is not available, JNA will be used automatically.

* JIRA: http://issues.opennms.org/browse/NMS-9078