### PR TITLE
NMS-9062: use a facade to JestResult to do proper success-checking

### DIFF
--- a/features/opennms-es-rest/main-module/src/main/java/org/opennms/plugins/elasticsearch/rest/ElasticSearchInitialiser.java
+++ b/features/opennms-es-rest/main-module/src/main/java/org/opennms/plugins/elasticsearch/rest/ElasticSearchInitialiser.java
@@ -218,7 +218,7 @@ public class ElasticSearchInitialiser {
 
 						PutTemplate putTemplate = new PutTemplate.Builder(templateName, body).build();
 
-						JestResult jestResult = getJestClient().execute(putTemplate);
+						JestResult jestResult = new OnmsJestResult(getJestClient().execute(putTemplate));
 
 						if (! jestResult.isSucceeded()){
 							LOG.error("Error sending template '"+templateName+"' to Elasticsearch"

--- a/features/opennms-es-rest/main-module/src/main/java/org/opennms/plugins/elasticsearch/rest/EventToIndex.java
+++ b/features/opennms-es-rest/main-module/src/main/java/org/opennms/plugins/elasticsearch/rest/EventToIndex.java
@@ -297,7 +297,7 @@ public class EventToIndex implements AutoCloseable {
 						BulkResult result = getJestClient().execute(bulk);
 
 						// If the bulk command fails completely...
-						if (result.getResponseCode() != 200) {
+						if (!result.isSucceeded()) {
 							logEsError("Bulk API action", entry.getKey(), type, result.getJsonString(), result.getResponseCode(), result.getErrorMessage());
 
 							// Try and issue the bulk actions individually as a fallback
@@ -331,7 +331,7 @@ public class EventToIndex implements AutoCloseable {
 						}
 
 						// If the bulk command fails completely...
-						if (result.getResponseCode() != 200) {
+						if (!result.isSucceeded()) {
 							logEsError("Bulk API action", entry.getKey(), type, result.getJsonString(), result.getResponseCode(), result.getErrorMessage());
 
 							// Try and issue the bulk actions individually as a fallback
@@ -403,7 +403,7 @@ public class EventToIndex implements AutoCloseable {
 			result = client.execute(action);
 		}
 
-		if(result.getResponseCode() != 200){
+		if(!result.isSucceeded()){
 			logEsError(action.getRestMethodName(), action.getIndex(), action.getType(), result.getJsonString(), result.getResponseCode(), result.getErrorMessage());
 		} else if(LOG.isDebugEnabled()) {
 			logEsDebug(action.getRestMethodName(), action.getIndex(), action.getType(), result.getJsonString(), result.getResponseCode(), result.getErrorMessage());
@@ -843,7 +843,7 @@ public class EventToIndex implements AutoCloseable {
 	private static void createIndex(JestClient client, String name, String type) throws IOException {
 		// create new index
 		CreateIndex createIndex = new CreateIndex.Builder(name).build();
-		JestResult result = client.execute(createIndex);
+		JestResult result = new OnmsJestResult(client.execute(createIndex));
 		if(LOG.isDebugEnabled()) {
 			LOG.debug("created new alarm index: {} type: {}" +
 					"\n   received search result: {}" +

--- a/features/opennms-es-rest/main-module/src/main/java/org/opennms/plugins/elasticsearch/rest/OnmsJestResult.java
+++ b/features/opennms-es-rest/main-module/src/main/java/org/opennms/plugins/elasticsearch/rest/OnmsJestResult.java
@@ -1,0 +1,22 @@
+package org.opennms.plugins.elasticsearch.rest;
+
+import com.google.gson.Gson;
+
+import io.searchbox.client.JestResult;
+
+public class OnmsJestResult extends JestResult {
+
+    public OnmsJestResult(final Gson gson) {
+        super(gson);
+    }
+
+    public OnmsJestResult(final JestResult result) {
+        super(result);
+    }
+
+    @Override
+    public boolean isSucceeded() {
+        final int response = this.getResponseCode();
+        return (response >= 200 && response < 300);
+    }
+}


### PR DESCRIPTION
This PR puts a simple facade on top of the `JestResult` object to handle non-200 success (like `201 CREATED`).  It also changes a few other places we were checking specifically for 200 results to use the `isSuccess()` method.

* JIRA: http://issues.opennms.org/browse/NMS-9062
