### PR TITLE
HZN-1022: Added multithreading to ES REST processing

### DIFF
--- a/features/opennms-es-rest/main-module/src/main/java/org/opennms/plugins/elasticsearch/rest/EventToIndex.java
+++ b/features/opennms-es-rest/main-module/src/main/java/org/opennms/plugins/elasticsearch/rest/EventToIndex.java
@@ -36,6 +36,12 @@ import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 import javax.xml.bind.DatatypeConverter;
@@ -130,6 +136,8 @@ public class EventToIndex implements AutoCloseable {
 	public static final String MEMO_AUTHOR_PARAM="author";
 	public static final String MEMO_REDUCTIONKEY_PARAM="reductionkey";
 
+	public static final int DEFAULT_NUMBER_OF_THREADS = Runtime.getRuntime().availableProcessors() * 2;
+
 	private boolean logEventDescription=false;
 
 	private boolean logAllEvents=false;
@@ -150,7 +158,25 @@ public class EventToIndex implements AutoCloseable {
 
 	private RestClientFactory restClientFactory = null;
 
-	IndexNameFunction indexNameFunction = new IndexNameFunction();
+	private int threads = DEFAULT_NUMBER_OF_THREADS;
+
+	private final ThreadPoolExecutor executor = new ThreadPoolExecutor(
+		threads,
+		threads,
+		0L, TimeUnit.MILLISECONDS,
+		new SynchronousQueue<>(true),
+		new ThreadFactory() {
+			final AtomicInteger index = new AtomicInteger();
+			@Override
+			public Thread newThread(Runnable r) {
+				return new Thread(r, EventToIndex.class.getSimpleName() + "-Thread-" + String.valueOf(index.incrementAndGet()));
+			}
+		},
+		// Throttle incoming tasks by running them on the caller thread
+		new ThreadPoolExecutor.CallerRunsPolicy()
+	);
+
+	private IndexNameFunction indexNameFunction = new IndexNameFunction();
 
 	public IndexNameFunction getIndexNameFunction() {
 		return indexNameFunction;
@@ -174,6 +200,21 @@ public class EventToIndex implements AutoCloseable {
 
 	public void setLogAllEvents(boolean logAllEvents) {
 		this.logAllEvents = logAllEvents;
+	}
+
+	public int getThreads() {
+		return threads;
+	}
+
+	public void setThreads(int threads) {
+		if (threads > 0) {
+			this.threads = threads;
+			// Resize the executor pool
+			executor.setCorePoolSize(threads);
+			executor.setMaximumPoolSize(threads);
+		} else {
+			setThreads(DEFAULT_NUMBER_OF_THREADS);
+		}
 	}
 
 	public NodeCache getNodeCache() {
@@ -261,15 +302,33 @@ public class EventToIndex implements AutoCloseable {
 				jestClient = null;
 			}
 		}
+
+		// Shutdown the thread pool
+		executor.shutdown();
 	}
 
 	/**
 	 * @param events
 	 */
 	public void forwardEvents(final List<Event> events) {
+		CompletableFuture.completedFuture(events)
+			// Convert the events to ES actions
+			.thenApplyAsync(this::convertEventsToEsActions, executor)
+			// Log any uncaught exceptions
+			.exceptionally(e -> {
+				LOG.error("Unexpected exception during task execution: " + e.getMessage(), e);
+				return null;
+			})
+			// Send the events to Elasticsearch
+			.thenAcceptAsync(this::sendEvents, executor)
+			// Log any uncaught exceptions
+			.exceptionally(e -> {
+				LOG.error("Unexpected exception during task completion: " + e.getMessage(), e);
+				return null;
+			});
+	}
 
-		final List<BulkableAction<DocumentResult>> actions = convertEventsToEsActions(events);
-
+	private void sendEvents(final List<BulkableAction<DocumentResult>> actions) {
 		if (actions != null && actions.size() > 0) {
 			// Split the actions up by index
 			for (Map.Entry<String,List<BulkableAction<DocumentResult>>> entry : actions.stream().collect(Collectors.groupingBy(BulkableAction::getIndex)).entrySet()) {

--- a/features/opennms-es-rest/main-module/src/main/java/org/opennms/plugins/elasticsearch/rest/NodeCache.java
+++ b/features/opennms-es-rest/main-module/src/main/java/org/opennms/plugins/elasticsearch/rest/NodeCache.java
@@ -32,8 +32,8 @@ import java.util.Map;
 
 public interface NodeCache {
 
-	public Map getEntry(Long key);
+	Map<String,String> getEntry(Long key);
 
-	public void refreshEntry(Long key);
+	void refreshEntry(Long key);
 
 }

--- a/features/opennms-es-rest/main-module/src/main/java/org/opennms/plugins/elasticsearch/rest/NodeCacheImpl.java
+++ b/features/opennms-es-rest/main-module/src/main/java/org/opennms/plugins/elasticsearch/rest/NodeCacheImpl.java
@@ -60,7 +60,7 @@ public class NodeCacheImpl implements NodeCache {
     private volatile NodeDao nodeDao;
     private volatile TransactionOperations transactionOperations;
 
-    private LoadingCache<Long, Map> cache=null;
+    private LoadingCache<Long, Map<String,String>> cache = null;
 
     public NodeCacheImpl() {}
 
@@ -75,9 +75,9 @@ public class NodeCacheImpl implements NodeCache {
                 cacheBuilder.maximumSize(MAX_SIZE);
             }
 
-            cache=cacheBuilder.build(new CacheLoader<Long, Map>() {
+            cache=cacheBuilder.build(new CacheLoader<Long, Map<String,String>>() {
                                              @Override
-                                             public Map load(Long key) throws Exception {
+                                             public Map<String,String> load(Long key) throws Exception {
                                                  return getNodeAndCategoryInfo(key);
                                              }
                                          }
@@ -85,7 +85,7 @@ public class NodeCacheImpl implements NodeCache {
         }
     }
 
-    public Map getEntry(Long key) {
+    public Map<String,String> getEntry(Long key) {
         return cache.getUnchecked(key);
     }
 
@@ -94,8 +94,8 @@ public class NodeCacheImpl implements NodeCache {
         cache.refresh(key);
     }
 
-    private Map getNodeAndCategoryInfo(Long nodeId) {
-        final Map result=new HashMap();
+    private Map<String,String> getNodeAndCategoryInfo(Long nodeId) {
+        final Map<String,String> result=new HashMap<>();
 
         // safety check
         if(nodeId!=null) {
@@ -122,7 +122,7 @@ public class NodeCacheImpl implements NodeCache {
      * @param body the map
      * @param node the node object
      */
-    private void populateBodyWithNodeInfo(Map body, OnmsNode node) {
+    private static void populateBodyWithNodeInfo(Map<String,String> body, OnmsNode node) {
         body.put("nodelabel", node.getLabel());
         body.put("nodesysname", node.getSysName());
         body.put("nodesyslocation", node.getSysLocation());
@@ -130,7 +130,7 @@ public class NodeCacheImpl implements NodeCache {
         body.put("foreignid", node.getForeignId());
         body.put("operatingsystem", node.getOperatingSystem());
         StringBuilder categories=new StringBuilder();
-        for (Iterator i=node.getCategories().iterator();i.hasNext();) {
+        for (Iterator<OnmsCategory> i=node.getCategories().iterator();i.hasNext();) {
             categories.append(((OnmsCategory)i.next()).getName());
             if(i.hasNext()) {
                 categories.append(",");

--- a/features/opennms-es-rest/main-module/src/main/resources/OSGI-INF/blueprint/mainModuleBlueprint.xml
+++ b/features/opennms-es-rest/main-module/src/main/resources/OSGI-INF/blueprint/mainModuleBlueprint.xml
@@ -29,10 +29,11 @@
       <cm:property name="archiveAlarmChangeEvents" value="true" />
       <cm:property name="archiveOldAlarmValues" value="true" />
       <cm:property name="archiveNewAlarmValues" value="true" />
-      <cm:property name="batchSize" value="1" /> <!-- disable batching by default -->
-      <cm:property name="batchInterval" value="0" /> <!-- disable batching by default -->
-      <cm:property name="cache_max_ttl" value="0" /> <!-- set to zero to disable TTL -->
-      <cm:property name="cache_max_size" value="10000" /> <!-- set to zero to disable max size -->
+      <cm:property name="batchSize" value="1" /> <!-- Disable batching by default -->
+      <cm:property name="batchInterval" value="0" /> <!-- Disable batching by default -->
+      <cm:property name="threads" value="0" /> <!-- Use the default number of threads -->
+      <cm:property name="cache_max_ttl" value="0" /> <!-- Set to zero to disable TTL -->
+      <cm:property name="cache_max_size" value="10000" /> <!-- Set to zero to disable max size -->
     </cm:default-properties>
   </cm:property-placeholder>
 
@@ -78,6 +79,7 @@
     <property name="indexNameFunction" ref="indexNameFunction" />
     <property name="logEventDescription" value="${logEventDescription}" />
     <property name="logAllEvents" value="${logAllEvents}" />
+    <property name="threads" value="${threads}" />
     <property name="archiveRawEvents" value="${archiveRawEvents}" />
     <property name="archiveAlarms" value="${archiveAlarms}" />
     <property name="archiveAlarmChangeEvents" value="${archiveAlarmChangeEvents}" />


### PR DESCRIPTION
Use a SynchronousQueue ThreadPoolExecutor to parallelize the Elasticsearch operations inside EventToIndex.

* JIRA: http://issues.opennms.org/browse/HZN-1022
