### PR TITLE
Changed all blueprint CM properties to reload

### DIFF
--- a/core/ipc/rpc/camel-impl/src/main/resources/OSGI-INF/blueprint/blueprint-rpc-server.xml
+++ b/core/ipc/rpc/camel-impl/src/main/resources/OSGI-INF/blueprint/blueprint-rpc-server.xml
@@ -12,7 +12,7 @@
 ">
 
     <cm:property-placeholder id="ipcProperties"
-        persistent-id="org.opennms.core.ipc" update-strategy="none">
+        persistent-id="org.opennms.core.ipc" update-strategy="reload">
         <cm:default-properties>
             <cm:property name="body.debug" value="-1" />
         </cm:default-properties>

--- a/core/ipc/sink/camel-impl/src/main/resources/OSGI-INF/blueprint/blueprint-ipc-client.xml
+++ b/core/ipc/sink/camel-impl/src/main/resources/OSGI-INF/blueprint/blueprint-ipc-client.xml
@@ -12,7 +12,7 @@
 ">
 
     <cm:property-placeholder id="ipcProperties"
-      persistent-id="org.opennms.core.ipc" update-strategy="none">
+      persistent-id="org.opennms.core.ipc" update-strategy="reload">
       <cm:default-properties>
         <cm:property name="body.debug" value="-1" />
       </cm:default-properties>

--- a/features/events/syslog/blueprint-syslog-listener-camel-netty.xml
+++ b/features/events/syslog/blueprint-syslog-listener-camel-netty.xml
@@ -13,7 +13,7 @@
 ">
 
 	<cm:property-placeholder id="syslogProperties"
-		persistent-id="org.opennms.netmgt.syslog" update-strategy="none">
+		persistent-id="org.opennms.netmgt.syslog" update-strategy="reload">
 		<cm:default-properties>
 			<cm:property name="syslog.listen.interface" value="0.0.0.0" />
 			<cm:property name="syslog.listen.port" value="1514" />

--- a/features/events/syslog/blueprint-syslog-listener-javanet.xml
+++ b/features/events/syslog/blueprint-syslog-listener-javanet.xml
@@ -13,7 +13,7 @@
 		http://aries.apache.org/schemas/blueprint-ext/blueprint-ext-1.1.xsd
 ">
 
-	<cm:property-placeholder id="syslogProperties" persistent-id="org.opennms.netmgt.syslog" update-strategy="none">
+	<cm:property-placeholder id="syslogProperties" persistent-id="org.opennms.netmgt.syslog" update-strategy="reload">
 		<cm:default-properties>
 			<cm:property name="syslog.listen.interface" value="0.0.0.0" />
 			<cm:property name="syslog.listen.port" value="1514" />

--- a/features/events/traps/src/main/resources/OSGI-INF/blueprint/blueprint-trapd-listener.xml
+++ b/features/events/traps/src/main/resources/OSGI-INF/blueprint/blueprint-trapd-listener.xml
@@ -11,7 +11,7 @@
         http://aries.apache.org/schemas/blueprint-ext/blueprint-ext-1.1.xsd
 ">
 
-	<cm:property-placeholder id="trapHandlerDefaultProperties" persistent-id="org.opennms.netmgt.trapd" update-strategy="none">
+	<cm:property-placeholder id="trapHandlerDefaultProperties" persistent-id="org.opennms.netmgt.trapd" update-strategy="reload">
 		<cm:default-properties>
 			<cm:property name="trapd.listen.interface" value="127.0.0.1" /> <!-- the interface the TrapListener listens for traps -->
 			<cm:property name="trapd.listen.port" value="1162" /> <!-- the port the TrapListener listens for traps -->

--- a/features/minion/container/scv/blueprint-scv.xml
+++ b/features/minion/container/scv/blueprint-scv.xml
@@ -17,7 +17,7 @@
 
     <!-- Used for sytem properties -->
     <ext:property-placeholder placeholder-prefix="$[" placeholder-suffix="]" />
-    <cm:property-placeholder id="scvProperties" persistent-id="org.opennms.features.scv" placeholder-prefix="[[" placeholder-suffix="]]" update-strategy="none">
+    <cm:property-placeholder id="scvProperties" persistent-id="org.opennms.features.scv" placeholder-prefix="[[" placeholder-suffix="]]" update-strategy="reload">
         <cm:default-properties>
             <cm:property name="key" value="QqSezYvBtk2gzrdpggMHvt5fJGWCdkRw"/>
         </cm:default-properties>

--- a/features/minion/core/impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/features/minion/core/impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -15,7 +15,7 @@
         http://aries.apache.org/schemas/blueprint-ext/blueprint-ext-1.1.xsd
 ">
 
-    <cm:property-placeholder id="minionProperties" persistent-id="org.opennms.minion.controller" placeholder-prefix="[[" placeholder-suffix="]]" update-strategy="none">
+    <cm:property-placeholder id="minionProperties" persistent-id="org.opennms.minion.controller" placeholder-prefix="[[" placeholder-suffix="]]" update-strategy="reload">
         <cm:default-properties>
             <cm:property name="location" value="MINION"/>
             <cm:property name="id" value="00000000-0000-0000-0000-000000ddba11"/>

--- a/features/scv/jceks-impl/src/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/features/scv/jceks-impl/src/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -15,7 +15,7 @@
         http://aries.apache.org/schemas/blueprint-ext/blueprint-ext-1.1.xsd
 ">
 
-    <cm:property-placeholder id="scvProperties" persistent-id="org.opennms.features.scv" placeholder-prefix="[[" placeholder-suffix="]]" update-strategy="none">
+    <cm:property-placeholder id="scvProperties" persistent-id="org.opennms.features.scv" placeholder-prefix="[[" placeholder-suffix="]]" update-strategy="reload">
         <cm:default-properties>
             <cm:property name="key" value="QqSezYvBtk2gzrdpggMHvt5fJGWCdkRw"/>
         </cm:default-properties>


### PR DESCRIPTION
Some of the blueprint CM properties were still set to ```update-strategy="none"``` to work around issues with Karaf integration tests. These test issues have been resolved so all properties should be set to ```update-strategy="reload"``` so that properties can be dynamically reloaded.