### PR TITLE
NMS-9102: fix pre-existing 'localhost' monitoring location

### DIFF
--- a/core/schema/src/main/liquibase/19.0.0/changelog.xml
+++ b/core/schema/src/main/liquibase/19.0.0/changelog.xml
@@ -5,6 +5,11 @@
   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd" >
 
   <changeSet author="seth" id="19.0.0-insert-default-monitoringlocation">
+    <preConditions onFail="MARK_RAN">
+      <sqlCheck expectedResult="0">
+        SELECT COUNT(id) FROM monitoringlocations WHERE id='localhost';
+      </sqlCheck>
+    </preConditions>
     <insert tableName="monitoringlocations">
       <column name="id" value="localhost"/>
       <column name="monitoringarea" value="localhost"/>


### PR DESCRIPTION
This PR fixes an issue with upgrades to 19 when the user has defined a `localhost` location in `monitoring-locations.xml` or equivalent.

* JIRA: http://issues.opennms.org/browse/NMS-9102
