### PR TITLE
NMS-9113: Upgrade to Camel 2.14.4

### DIFF
--- a/features/elasticsearch/event-forwarder/src/main/resources/OSGI-INF/blueprint/blueprint-event-forwarder.xml
+++ b/features/elasticsearch/event-forwarder/src/main/resources/OSGI-INF/blueprint/blueprint-event-forwarder.xml
@@ -15,7 +15,7 @@
 		http://aries.apache.org/schemas/blueprint-ext/blueprint-ext-1.1.xsd
 
 		http://camel.apache.org/schema/blueprint
-		http://camel.apache.org/schema/blueprint/camel-blueprint-2.14.1.xsd
+		http://camel.apache.org/schema/blueprint/camel-blueprint-2.14.4.xsd
 ">
 
   <!-- Configuration properties -->

--- a/pom.xml
+++ b/pom.xml
@@ -2874,6 +2874,16 @@
         <version>1.4</version>
       </dependency>
       <dependency>
+        <groupId>org.apache.camel</groupId>
+        <artifactId>camel-jms</artifactId>
+        <version>${camelVersion}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.camel</groupId>
+        <artifactId>camel-spring</artifactId>
+        <version>${camelVersion}</version>
+      </dependency>
+      <dependency>
         <groupId>org.apache.xmlgraphics</groupId>
         <artifactId>batik-dom</artifactId>
         <version>${batikVersion}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -1317,7 +1317,7 @@
     <atomikosVersion>3.9.2</atomikosVersion>
     <batikVersion>1.7</batikVersion>
     <bsfVersion>2.4.0</bsfVersion>
-    <camelVersion>2.14.1</camelVersion>
+    <camelVersion>2.14.4</camelVersion>
     <elasticsearchVersion>1.0.0_4</elasticsearchVersion>
     <cloverVersion>3.2.0</cloverVersion>
     <commonsBeanutilsVersion>1.8.3</commonsBeanutilsVersion>


### PR DESCRIPTION
Camel 2.14.1 has a bug that prevents us from using Netty4 in our syslog receiver code. It is resolved by upgrading to Camel 2.14.3 or higher so we might as well upgrade to the latest 2.14 version (2.14.4).

https://issues.apache.org/jira/browse/CAMEL-8674