### PR TITLE
NMS-9111: Increase the socket buffer size for the SNMP4J trap listener

### DIFF
--- a/core/snmp/impl-snmp4j/src/main/java/org/opennms/netmgt/snmp/snmp4j/Snmp4JStrategy.java
+++ b/core/snmp/impl-snmp4j/src/main/java/org/opennms/netmgt/snmp/snmp4j/Snmp4JStrategy.java
@@ -505,7 +505,12 @@ public class Snmp4JStrategy implements SnmpStrategy {
 
         // Set socket option SO_REUSEADDR so that we can bind to the port even if it
         // has recently been closed by passing 'true' as the second argument here.
-        final TransportMapping<UdpAddress> transport = new DefaultUdpTransportMapping(udpAddress, true);
+        final DefaultUdpTransportMapping transport = new DefaultUdpTransportMapping(udpAddress, true);
+        // Increase the receive buffer for the socket
+        LOG.debug("Attempting to set receive buffer size to {}", Integer.MAX_VALUE);
+        transport.setReceiveBufferSize(Integer.MAX_VALUE);
+        LOG.debug("Actual receive buffer size is {}", transport.getReceiveBufferSize());
+
         info.setTransportMapping(transport);
         Snmp snmp = new Snmp(transport);
         snmp.addCommandResponder(trapNotifier);


### PR DESCRIPTION
This might reduce/eliminate packet drops under heavy trap load.

* JIRA: http://issues.opennms.org/browse/NMS-9111