### PR TITLE
NMS-9112: Avoid scheduling services multiple times when handling node change events.

### DIFF
--- a/opennms-services/src/main/java/org/opennms/netmgt/poller/PollerEventProcessor.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/poller/PollerEventProcessor.java
@@ -756,6 +756,7 @@ final class PollerEventProcessor implements EventListener {
         for (final Service databaseService : databaseServices) {
             if (polledServices.contains(databaseService)) {
                 LOG.debug("{} is being skipped. Already scheduled.", databaseService);
+                continue;
             }
 
             LOG.debug("{} is being scheduled (or rescheduled) for polling.", databaseService);

--- a/opennms-services/src/test/java/org/opennms/netmgt/poller/PollerTest.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/poller/PollerTest.java
@@ -1219,6 +1219,39 @@ public class PollerTest implements TemporaryDatabaseAware<MockDatabase> {
         verifyAnticipated(2000, true);
     }
 
+    /**
+     * Test for NMS-9112
+     */
+    @Test
+    public void testNoInvalidPollsAfterNodeCategoryMembershipChanged() throws InterruptedException {
+        m_pollerConfig.setNodeOutageProcessingEnabled(true);
+
+        MockNode node = m_network.getNode(1);
+
+        // Start the poller
+        startDaemons();
+
+        // Send a uei.opennms.org/nodes/nodeCategoryMembershipChanged
+        // This will remove, add or reschedule services for the node as necessary
+        EventBuilder eventBuilder = MockEventUtil.createEventBuilder("Test", EventConstants.NODE_CATEGORY_MEMBERSHIP_CHANGED_EVENT_UEI);
+        eventBuilder.setNodeid(node.getNodeId());
+        Event nodeCatMemChangedEvent = eventBuilder.getEvent();
+        m_eventMgr.sendEventToListeners(nodeCatMemChangedEvent);
+
+        // Delete the node and send a nodeDeleted event
+        m_network.removeElement(node);
+        Event deleteEvent = node.createDeleteEvent();
+        m_eventMgr.sendEventToListeners(deleteEvent);
+
+        // Wait a little long than a polling cycle
+        sleep(3000);
+        m_network.resetInvalidPollCount();
+
+        // Sleep some more and verify that no invalid polls have occurred
+        sleep(3000);
+        assertEquals("Received a poll for an element that doesn't exist", 0, m_network.getInvalidPollCount());
+    }
+
     //
     // Utility methods
     //


### PR DESCRIPTION
JIRA: https://issues.opennms.org/browse/NMS-9112

This fixes a regression introduced in NMS-7761.

When receiving events that cause pollerd to recompute it's schedule, it can end up re-scheduling services that we already scheduled. If the node or interface is subsequently delete, the duplicate services remain scheduled.
