### PR TITLE
NMS-9080: Add an ObjectNameStorageStrategy with JEXL for formatting the resources index

### DIFF
--- a/features/collection/api/pom.xml
+++ b/features/collection/api/pom.xml
@@ -54,5 +54,14 @@
       <artifactId>mockito-all</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-jexl</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/features/collection/api/src/main/java/org/opennms/netmgt/collection/support/JexlIndexStorageStrategy.java
+++ b/features/collection/api/src/main/java/org/opennms/netmgt/collection/support/JexlIndexStorageStrategy.java
@@ -1,0 +1,128 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2017-2017 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.collection.support;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.jexl2.JexlContext;
+import org.apache.commons.jexl2.JexlEngine;
+import org.apache.commons.jexl2.JexlException;
+import org.apache.commons.jexl2.MapContext;
+import org.apache.commons.jexl2.ReadonlyContext;
+import org.apache.commons.jexl2.UnifiedJEXL;
+import org.opennms.netmgt.collection.api.CollectionResource;
+import org.opennms.netmgt.collection.api.Parameter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ *
+ * @author roskens
+ */
+public class JexlIndexStorageStrategy extends IndexStorageStrategy {
+
+    private static final Logger LOG = LoggerFactory.getLogger(JexlIndexStorageStrategy.class);
+    private static final int DEFAULT_JEXLENGINE_CACHESIZE = 512;
+    private static final String QUOTE = "\"";
+
+    private static final String PARAM_INDEX_FORMAT = "index-format";
+    private static final String PARAM_CLEAN_OUTPUT = "clean-output";
+
+    private static final JexlEngine JEXL_ENGINE;
+    private static final UnifiedJEXL EL;
+
+    private final Map<String, String> m_parameters;
+
+    static {
+        final int cacheSize = Integer.getInteger("org.opennms.netmgt.dao.support.JEXLIndexStorageStrategy.cacheSize", DEFAULT_JEXLENGINE_CACHESIZE);
+        JEXL_ENGINE = new JexlEngine();
+        JEXL_ENGINE.setCache(cacheSize);
+        JEXL_ENGINE.setLenient(false);
+        JEXL_ENGINE.setStrict(true);
+
+        EL = new UnifiedJEXL(JEXL_ENGINE);
+    }
+
+    public JexlIndexStorageStrategy() {
+        super();
+        m_parameters = new HashMap<>();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String getResourceNameFromIndex(CollectionResource resource) {
+        String resourceName = null;
+        try {
+            UnifiedJEXL.Expression expr = EL.parse( m_parameters.get(PARAM_INDEX_FORMAT) );
+            JexlContext context = new MapContext();
+            m_parameters.entrySet().forEach((entry) -> {
+                context.set(entry.getKey(), entry.getValue());
+            });
+            updateContext(context, resource);
+            resourceName = (String) expr.evaluate(new ReadonlyContext(context));
+        } catch (JexlException e) {
+            LOG.error("getResourceNameFromIndex(): error evaluating index-format [{}] as a Jexl Expression", m_parameters.get(PARAM_INDEX_FORMAT), e);
+        } finally {
+            if (resourceName == null) {
+                resourceName = resource.getInstance();
+            }
+        }
+        if ("true".equals(m_parameters.get(PARAM_CLEAN_OUTPUT)) && resourceName != null) {
+            resourceName = resourceName.replaceAll("\\s+", "_").replaceAll(":", "_").replaceAll("\\\\", "_").replaceAll("[\\[\\]]", "_").replaceAll("[|/]", "_").replaceAll("=", "").replaceAll("[_]+$", "").replaceAll("___", "_");
+        }
+
+        LOG.debug("getResourceNameFromIndex(): {}", resourceName);
+        return resourceName;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void setParameters(List<Parameter> parameterCollection) throws IllegalArgumentException {
+        if (parameterCollection == null) {
+            final String msg ="Got a null parameter list, but need one containing a '" + PARAM_INDEX_FORMAT + "' parameter.";
+            LOG.error(msg);
+            throw new IllegalArgumentException(msg);
+        }
+        parameterCollection.forEach((param) -> {
+            if (null == param.getKey()) {
+                LOG.warn("Encountered unsupported parameter key=\"{}\". Can accept: {}, {}", param.getKey(), PARAM_INDEX_FORMAT, PARAM_CLEAN_OUTPUT);
+            } else {
+                m_parameters.put(param.getKey(), param.getValue());
+            }
+        });
+        if (!m_parameters.containsKey(PARAM_INDEX_FORMAT)) {
+            throw new IllegalArgumentException("Missing index-format expression");
+        }
+    }
+
+    public void updateContext(JexlContext context, CollectionResource resource) {
+    }
+}

--- a/features/collection/api/src/main/java/org/opennms/netmgt/collection/support/ObjectNameStorageStrategy.java
+++ b/features/collection/api/src/main/java/org/opennms/netmgt/collection/support/ObjectNameStorageStrategy.java
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2017-2017 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.collection.support;
+
+import javax.management.ObjectName;
+
+import org.apache.commons.jexl2.JexlContext;
+import org.opennms.netmgt.collection.api.CollectionResource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ObjectNameStorageStrategy extends JexlIndexStorageStrategy {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ObjectNameStorageStrategy.class);
+    private static final String QUOTE = "\"";
+
+    public ObjectNameStorageStrategy() {
+        super();
+    }
+
+    @Override
+    public void updateContext(JexlContext context, CollectionResource resource) {
+        try {
+            ObjectName oname = new ObjectName(resource.getInstance());
+            context.set("ObjectName", oname);
+            context.set("domain", oname.getDomain() == null ? "" : oname.getDomain());
+            oname.getKeyPropertyList().entrySet().forEach((entry) -> {
+                final String value = entry.getValue();
+                if (value.startsWith(QUOTE) && value.endsWith(QUOTE)) {
+                    context.set(entry.getKey(), ObjectName.unquote(entry.getValue()));
+                } else {
+                    context.set(entry.getKey(), entry.getValue());
+                }
+            });
+        } catch (javax.management.MalformedObjectNameException e) {
+            LOG.debug("getResourceNameFromIndex(): malformed object name: {}", resource.getInstance(), e);
+        }
+    }
+}

--- a/opennms-dao/src/test/java/org/opennms/netmgt/dao/support/ObjectNameStorageStrategyTest.java
+++ b/opennms-dao/src/test/java/org/opennms/netmgt/dao/support/ObjectNameStorageStrategyTest.java
@@ -1,0 +1,157 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2017-2017 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.dao.support;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Test;
+import static org.junit.Assert.*;
+import org.opennms.netmgt.collection.api.CollectionResource;
+import org.opennms.netmgt.collection.support.ObjectNameStorageStrategy;
+import org.opennms.netmgt.config.datacollection.Parameter;
+import org.opennms.netmgt.model.ResourcePath;
+
+/**
+ */
+public class ObjectNameStorageStrategyTest {
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testSetNullParameters() {
+        List<org.opennms.netmgt.collection.api.Parameter> params = null;
+        ObjectNameStorageStrategy instance = new ObjectNameStorageStrategy();
+        instance.setParameters(params);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testSetEmptyParameters() {
+        List<org.opennms.netmgt.collection.api.Parameter> params = new ArrayList<>();
+        ObjectNameStorageStrategy instance = new ObjectNameStorageStrategy();
+        instance.setParameters(params);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testSetInvalidParameters() {
+        List<org.opennms.netmgt.collection.api.Parameter> params = new ArrayList<>();
+        params.add(new Parameter("SERVICE", "svc"));
+        ObjectNameStorageStrategy instance = new ObjectNameStorageStrategy();
+        instance.setParameters(params);
+    }
+
+    @Test()
+    public void testSetValidParameters() {
+        List<org.opennms.netmgt.collection.api.Parameter> params = new ArrayList<>();
+        params.add(new Parameter("index-format", "${ObjectName.toString()}"));
+        ObjectNameStorageStrategy instance = new ObjectNameStorageStrategy();
+        instance.setParameters(params);
+    }
+
+    @Test
+    public void testGetResourceNameFromIndex() {
+        ResourcePath parentResource = ResourcePath.get("1");
+        CollectionResource resource = new MockCollectionResource(parentResource, "java.lang:type=MemoryPool,name=Survivor Space", "");
+        List<org.opennms.netmgt.collection.api.Parameter> params = new ArrayList<>();
+        params.add(new Parameter("index-format", "${ObjectName.toString()}"));
+        ObjectNameStorageStrategy instance = new ObjectNameStorageStrategy();
+        instance.setParameters(params);
+
+        String expResult = "java.lang:type=MemoryPool,name=Survivor Space";
+        String result = instance.getResourceNameFromIndex(resource);
+        assertEquals(expResult, result);
+    }
+
+    @Test
+    public void testGetResourceNameFromIndexCleanOutput() {
+        ResourcePath parentResource = ResourcePath.get("1");
+        CollectionResource resource = new MockCollectionResource(parentResource, "java.lang:type=MemoryPool,name=Survivor Space", "");
+        List<org.opennms.netmgt.collection.api.Parameter> params = new ArrayList<>();
+        params.add(new Parameter("index-format", "${ObjectName.toString()}"));
+        params.add(new Parameter("clean-output", "true"));
+        ObjectNameStorageStrategy instance = new ObjectNameStorageStrategy();
+        instance.setParameters(params);
+
+        String expResult = "java.lang_typeMemoryPool,nameSurvivor_Space";
+        String result = instance.getResourceNameFromIndex(resource);
+        assertEquals(expResult, result);
+    }
+
+    @Test
+    public void testGetResourceNameFromIndex2() {
+        ResourcePath parentResource = ResourcePath.get("1");
+        CollectionResource resource = new MockCollectionResource(parentResource, "java.lang:type=MemoryPool,name=Survivor Space", "");
+        List<org.opennms.netmgt.collection.api.Parameter> params = new ArrayList<>();
+        Parameter p = new Parameter("index-format", "${domain}");
+        params.add(p);
+        ObjectNameStorageStrategy instance = new ObjectNameStorageStrategy();
+        instance.setParameters(params);
+
+        String expResult = "java.lang";
+        String result = instance.getResourceNameFromIndex(resource);
+        assertEquals(expResult, result);
+
+        params.clear();
+        p.setValue("${type}");
+        params.add(p);
+        instance.setParameters(params);
+        expResult = "MemoryPool";
+        result = instance.getResourceNameFromIndex(resource);
+        assertEquals(expResult, result);
+
+        params.clear();
+        p.setValue("${name}");
+        params.add(p);
+        instance.setParameters(params);
+        expResult = "Survivor Space";
+        result = instance.getResourceNameFromIndex(resource);
+        assertEquals(expResult, result);
+
+        params.clear();
+        p.setValue("${domain}:type=${type},name=${name}");
+        params.add(p);
+        instance.setParameters(params);
+        expResult = "java.lang:type=MemoryPool,name=Survivor Space";
+        result = instance.getResourceNameFromIndex(resource);
+        assertEquals(expResult, result);
+    }
+
+    @Test
+    public void testQuotedKeyValues() {
+        ResourcePath parentResource = ResourcePath.get("1");
+        CollectionResource resource = new MockCollectionResource(parentResource, "d:k1=\"ab\",k2=\"cd\",k3=\"v3\"", "");
+        List<org.opennms.netmgt.collection.api.Parameter> params = new ArrayList<>();
+        Parameter p = new Parameter("index-format", "${domain}-${k1}-${k2}-${k3}");
+        params.add(p);
+        ObjectNameStorageStrategy instance = new ObjectNameStorageStrategy();
+        instance.setParameters(params);
+
+        String expResult = "d-ab-cd-v3";
+        String result = instance.getResourceNameFromIndex(resource);
+        assertEquals(expResult, result);
+    }
+
+}

--- a/opennms-doc/guide-admin/src/asciidoc/text/performance-data-collection/configuration.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/performance-data-collection/configuration.adoc
@@ -95,17 +95,68 @@ On evaulation, this expression should return either true, persist index to stora
 .Storage Strategies
 [options="header, autowidth"]
 |===
-| Class                                                        | Storage Path Value
-| org.opennms.netmgt.collection.support.IndexStorageStrategy   | Index
-| org.opennms.netmgt.dao.support.FrameRelayStorageStrategy     | interface label + '.' + dlci
-| org.opennms.netmgt.dao.support.HostFileSystemStorageStrategy | Uses the value from the hrStorageDescr column in the hrStorageTable, cleaned up for unix filesystems.
-| org.opennms.netmgt.dao.support.SiblingColumnStorageStrategy  | Uses the value from an SNMP lookup of OID in sibling-column-name parameter, cleaned up for unix filesystems.
-| org.opennms.protocols.xml.collector.XmlStorageStrategy       | Index, but cleaned up for unix filesystems.
+| Class                                                           | Storage Path Value
+| org.opennms.netmgt.collection.support.IndexStorageStrategy      | Index
+| org.opennms.netmgt.collection.support.JexlIndexStorageStrategy  | Value after JexlExpression evaluation
+| org.opennms.netmgt.collection.support.ObjectNameStorageStrategy | Value after JexlExpression evaluation
+| org.opennms.netmgt.dao.support.FrameRelayStorageStrategy        | interface label + '.' + dlci
+| org.opennms.netmgt.dao.support.HostFileSystemStorageStrategy    | Uses the value from the hrStorageDescr column in the hrStorageTable, cleaned up for unix filesystems.
+| org.opennms.netmgt.dao.support.SiblingColumnStorageStrategy     | Uses the value from an SNMP lookup of OID in sibling-column-name parameter, cleaned up for unix filesystems.
+| org.opennms.protocols.xml.collector.XmlStorageStrategy          | Index, but cleaned up for unix filesystems.
+| org.opennms.netmgt.dao.support.
 |===
 
 ====== IndexStorageStrategy
 
 The IndexStorageStrategy takes no parameters.
+
+====== JexlIndexStorageStrategy
+
+The JexlIndexStorageStrategy takes two parameters, `index-format` which is required, and `clean-output` which is optional.
+
+[options="header, autowidth"]
+|===
+| Parameter    | Description
+| index-format | The JexlExpression to evaluate
+| clean-output | Boolean to indicate whether the index value is cleaned up.
+|===
+
+If the index value will be cleaned up, then it will have all whitespace, colons, forward and back slashes, and vertical bars replaced with underscores. All equal signs are removed.
+
+This class can be extended to create custom storage strategies by overriding the `updateContext` method to set additional key/value pairs to use in your `index-format` template.
+[source, java]
+----
+public class ExampleStorageStrategy extends JexlIndexStorageStrategy {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ExampleStorageStrategy.class);
+    public ExampleStorageStrategy() {
+        super();
+    }
+
+    @Override
+    public void updateContext(JexlContext context, CollectionResource resource) {
+        context.set("Example", resource.getInstance());
+    }
+}
+----
+
+====== ObjectNameStorageStrategy
+
+The ObjectNameStorageStrategy extends the JexlIndexStorageStrategy, so its requirements are the same. Extra key/values pairs are added to the JexlContext which can then be used in the `index-format` template.
+The original index string is converted to an ObjectName and can be referenced as `${ObjectName}`. The _domain_ from the ObjectName can be referenced as `${domain}`. All _key properties_
+from the ObjectName can also be referenced by `${key}`.
+
+This storage strategy is meant to be used with JMX MBean datacollections where multiple MBeans can return the same set of attributes. As of OpenNMS Horizon 20, this is only supported using a HTTP to JMX proxy and using the XmlCollector as the JmxCollector does not yet support indexed groups.
+
+Given an MBean like `java.lang:type=MemoryPool,name=Survivor Space`, and a storage strategy like this:
+[source, xml]
+----
+<storageStrategy class="org.opennms.netmgt.collection.support.ObjectNameStorageStragegy">
+  <parameter key="index-format" value="${domain}_${type}_${name}" />
+  <parameter key="clean-output" value="true" />
+</storageStrategy>
+----
+Then the index value would be `java_lang_MemoryPool_Survivor_Space`.
 
 ====== FrameRelayStorageStrategy
 


### PR DESCRIPTION
NMS-9080: Add a ObjectNameStorageStrategy that uses a JEXL template to format the resource's index.

* JIRA: http://issues.opennms.org/browse/NMS-9080

Our [continuous integration system](http://bamboo.internal.opennms.com:8085) will test and verify your changes.
