### PR TITLE
NMS-9072: XmlCollector use parameters defined in the service definition in xml-source url

### DIFF
--- a/integrations/opennms-vtdxml-collector-handler/src/main/java/org/opennms/protocols/xml/vtdxml/Sftp3gppVTDXmlCollectionHandler.java
+++ b/integrations/opennms-vtdxml-collector-handler/src/main/java/org/opennms/protocols/xml/vtdxml/Sftp3gppVTDXmlCollectionHandler.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2011-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2011-2017 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -33,10 +33,12 @@ import java.io.InputStream;
 import java.net.URL;
 import java.util.Date;
 import java.util.List;
+import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.commons.io.IOUtils;
 import org.joda.time.DateTime;
+import org.opennms.core.utils.ParameterMap;
 import org.opennms.netmgt.collection.api.AttributeGroupType;
 import org.opennms.netmgt.collection.api.CollectionAgent;
 import org.opennms.netmgt.collection.api.CollectionException;
@@ -83,6 +85,9 @@ public class Sftp3gppVTDXmlCollectionHandler extends AbstractVTDXmlCollectionHan
         collectionSet.setCollectionTimestamp(new Date());
         collectionSet.setStatus(CollectionStatus.UNKNOWN);
 
+        // Create a map of parameters from the service to use in URLs, etc.
+        Map<String, String> params = filterParameters(parameters);
+
         // TODO We could be careful when handling exceptions because parsing exceptions will be treated different from connection or retrieval exceptions
         DateTime startTime = new DateTime();
         Sftp3gppUrlConnection connection = null;
@@ -93,8 +98,8 @@ public class Sftp3gppVTDXmlCollectionHandler extends AbstractVTDXmlCollectionHan
                 if (!source.getUrl().startsWith(Sftp3gppUrlHandler.PROTOCOL)) {
                     throw new CollectionException("The 3GPP SFTP Collection Handler can only use the protocol " + Sftp3gppUrlHandler.PROTOCOL);
                 }
-                String urlStr = parseUrl(source.getUrl(), agent, collection.getXmlRrd().getStep());
-                Request request = parseRequest(source.getRequest(), agent, collection.getXmlRrd().getStep());
+                String urlStr = parseUrl(source.getUrl(), agent, collection.getXmlRrd().getStep(), params);
+                Request request = parseRequest(source.getRequest(), agent, collection.getXmlRrd().getStep(), params);
                 URL url = UrlFactory.getUrl(urlStr, request);
                 String lastFile = Sftp3gppUtils.getLastFilename(getResourceStorageDao(), getServiceName(), resourcePath, url.getPath());
                 connection = (Sftp3gppUrlConnection) url.openConnection();

--- a/integrations/opennms-vtdxml-collector-handler/src/test/java/org/opennms/protocols/xml/vtdxml/MockDefaultVTDXmlCollectionHandler.java
+++ b/integrations/opennms-vtdxml-collector-handler/src/test/java/org/opennms/protocols/xml/vtdxml/MockDefaultVTDXmlCollectionHandler.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2011-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2011-2017 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -27,6 +27,8 @@
  *******************************************************************************/
 
 package org.opennms.protocols.xml.vtdxml;
+
+import java.util.Map;
 
 import org.opennms.netmgt.collection.api.CollectionAgent;
 import org.opennms.protocols.xml.collector.XmlResourceType;
@@ -55,7 +57,7 @@ public class MockDefaultVTDXmlCollectionHandler extends DefaultVTDXmlCollectionH
      * @see org.opennms.protocols.xml.collector.AbstractXmlCollectionHandler#parseUrl(java.lang.String, org.opennms.netmgt.collectd.CollectionAgent, java.lang.Integer)
      */
     @Override
-    protected String parseUrl(String unformattedUrl, CollectionAgent agent, Integer collectionStep) {
+    protected String parseUrl(String unformattedUrl, CollectionAgent agent, Integer collectionStep, final Map<String,String> parameters) {
         return unformattedUrl.replace("{ipaddr}", "127.0.0.1");
     }
 

--- a/protocols/xml/src/main/java/org/opennms/protocols/xml/collector/AbstractXmlCollectionHandler.java
+++ b/protocols/xml/src/main/java/org/opennms/protocols/xml/collector/AbstractXmlCollectionHandler.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2011-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2011-2017 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -28,6 +28,7 @@
 
 package org.opennms.protocols.xml.collector;
 
+import com.google.common.collect.Sets;
 import java.beans.PropertyDescriptor;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -42,8 +43,11 @@ import java.net.URLEncoder;
 import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import javax.xml.namespace.NamespaceContext;
 import javax.xml.parsers.DocumentBuilder;
@@ -66,6 +70,7 @@ import org.joda.time.format.DateTimeFormatter;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Entities.EscapeMode;
 import org.opennms.core.spring.BeanUtils;
+import org.opennms.core.utils.ParameterMap;
 import org.opennms.netmgt.collection.api.AttributeGroupType;
 import org.opennms.netmgt.collection.api.CollectionAgent;
 import org.opennms.netmgt.collection.api.CollectionException;
@@ -106,6 +111,8 @@ public abstract class AbstractXmlCollectionHandler implements XmlCollectionHandl
 
     /** The Constant LOG. */
     private static final Logger LOG = LoggerFactory.getLogger(AbstractXmlCollectionHandler.class);
+
+    private static final Set<String> PROPERTY_BLACKLIST = Sets.newHashSet("SERVICE", "collection", "xml-collection", "handler-class");
 
     /** The Service Name associated with this Collection Handler. */
     private String m_serviceName;
@@ -189,14 +196,18 @@ public abstract class AbstractXmlCollectionHandler implements XmlCollectionHandl
         XmlCollectionSet collectionSet = new XmlCollectionSet();
         collectionSet.setCollectionTimestamp(new Date());
         collectionSet.setStatus(CollectionStatus.UNKNOWN);
+
+        // Create a map of parameters from the service to use in URLs, etc.
+        Map<String, String> params = filterParameters(parameters);
+
         DateTime startTime = new DateTime();
         try {
             LOG.debug("collect: looping sources for collection {}", collection.getName());
             for (XmlSource source : collection.getXmlSources()) {
                 LOG.debug("collect: starting source url '{}' collection", source.getUrl());
-                String urlStr = parseUrl(source.getUrl(), agent, collection.getXmlRrd().getStep());
+                String urlStr = parseUrl(source.getUrl(), agent, collection.getXmlRrd().getStep(), params);
                 LOG.debug("collect: parsed url for source url '{}'", urlStr);
-                Request request = parseRequest(source.getRequest(), agent, collection.getXmlRrd().getStep());
+                Request request = parseRequest(source.getRequest(), agent, collection.getXmlRrd().getStep(), params);
                 LOG.debug("collect: parsed request for source url '{}' : {}", urlStr, request);
                 fillCollectionSet(urlStr, request, agent, collectionSet, source);
                 LOG.debug("collect: finished source url '{}' collection with {} resources", urlStr, collectionSet.getCollectionResources().size());
@@ -372,13 +383,14 @@ public abstract class AbstractXmlCollectionHandler implements XmlCollectionHandl
      * @param unformattedUrl the unformatted URL
      * @param agent the collection agent
      * @param collectionStep the collection step (in seconds)
+     * @param parameters the service parameters
      * @return the string
      * 
      * @throws IllegalArgumentException the illegal argument exception
      */
-    protected String parseUrl(final String unformattedUrl, final CollectionAgent agent, final Integer collectionStep) throws IllegalArgumentException {
+    protected String parseUrl(final String unformattedUrl, final CollectionAgent agent, final Integer collectionStep, final Map<String, String> parameters) throws IllegalArgumentException {
         final OnmsNode node = getNodeDao().get(agent.getNodeId());
-        return parseString("URL", unformattedUrl, node, agent.getHostAddress(), collectionStep);
+        return parseString("URL", unformattedUrl, node, agent.getHostAddress(), collectionStep, parameters);
     }
 
     /**
@@ -387,24 +399,25 @@ public abstract class AbstractXmlCollectionHandler implements XmlCollectionHandl
      * @param unformattedRequest the unformatted request
      * @param agent the agent
      * @param collectionStep the collection step
+     * @param parameters the service parameters
      * @return the request
      * @throws IllegalArgumentException the illegal argument exception
      */
-    protected Request parseRequest(final Request unformattedRequest, final CollectionAgent agent, final Integer collectionStep) throws IllegalArgumentException {
+    protected Request parseRequest(final Request unformattedRequest, final CollectionAgent agent, final Integer collectionStep, final Map<String, String> parameters) throws IllegalArgumentException {
         if (unformattedRequest == null)
             return null;
         final OnmsNode node = getNodeDao().get(agent.getNodeId());
         final Request request = new Request();
         request.setMethod(unformattedRequest.getMethod());
         for (Header header : unformattedRequest.getHeaders()) {
-            request.addHeader(header.getName(), parseString(header.getName(), header.getValue(), node, agent.getHostAddress(), collectionStep));
+            request.addHeader(header.getName(), parseString(header.getName(), header.getValue(), node, agent.getHostAddress(), collectionStep, parameters));
         }
         for (Parameter param : unformattedRequest.getParameters()) {
-            request.addParameter(param.getName(), parseString(param.getName(), param.getValue(), node, agent.getHostAddress(), collectionStep));
+            request.addParameter(param.getName(), parseString(param.getName(), param.getValue(), node, agent.getHostAddress(), collectionStep, parameters));
         }
         final Content cnt = unformattedRequest.getContent();
         if (cnt != null)
-            request.setContent(new Content(cnt.getType(), parseString("Content", cnt.getData(), node, agent.getHostAddress(), collectionStep)));
+            request.setContent(new Content(cnt.getType(), parseString("Content", cnt.getData(), node, agent.getHostAddress(), collectionStep, parameters)));
         return request;
     }
 
@@ -427,10 +440,11 @@ public abstract class AbstractXmlCollectionHandler implements XmlCollectionHandl
      * @param node the node
      * @param ipAddress the IP address
      * @param collectionStep the collection step
+     * @param parameters the service parameters
      * @return the string
      * @throws IllegalArgumentException the illegal argument exception
      */
-    protected String parseString(final String reference, final String unformattedString, final OnmsNode node, final String ipAddress, final Integer collectionStep) throws IllegalArgumentException {
+    protected String parseString(final String reference, final String unformattedString, final OnmsNode node, final String ipAddress, final Integer collectionStep, final Map<String, String> parameters) throws IllegalArgumentException {
         if (unformattedString == null || node == null)
             return null;
         String formattedString = unformattedString.replaceAll("[{](?i)(ipAddr|ipAddress)[}]", ipAddress);
@@ -442,6 +456,9 @@ public abstract class AbstractXmlCollectionHandler implements XmlCollectionHandl
             formattedString = formattedString.replaceAll("[{](?i)foreignId[}]", node.getForeignId());
         if (node.getForeignSource() != null)
             formattedString = formattedString.replaceAll("[{](?i)foreignSource[}]", node.getForeignSource());
+        for(Map.Entry<String, String> entry : parameters.entrySet()) {
+            formattedString = formattedString.replaceAll("[{]parameter:"+entry.getKey()+"[}]", entry.getValue());
+        }
         if (node.getAssetRecord() != null) {
             BeanWrapper wrapper = new BeanWrapperImpl(node.getAssetRecord());
             for (PropertyDescriptor p : wrapper.getPropertyDescriptors()) {
@@ -586,4 +603,14 @@ public abstract class AbstractXmlCollectionHandler implements XmlCollectionHandl
         return new XmlResourceType(agent, rt);
     }
 
+    /**
+     * Filter out blacklisted key/values out from an input Map.
+     * @param input the original parameters
+     * @return a new map containing the filtered parameters
+     */
+    protected Map<String, String> filterParameters(Map<String, Object> input) {
+        return input.entrySet().stream()
+            .filter(e -> !PROPERTY_BLACKLIST.contains(e.getKey()))
+            .collect(Collectors.toMap(e -> e.getKey(), e -> ParameterMap.getKeyedString(input, e.getKey(), "")));
+    }
 }

--- a/protocols/xml/src/main/java/org/opennms/protocols/xml/collector/Sftp3gppXmlCollectionHandler.java
+++ b/protocols/xml/src/main/java/org/opennms/protocols/xml/collector/Sftp3gppXmlCollectionHandler.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2011-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2011-2017 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -32,11 +32,13 @@ import java.io.File;
 import java.io.InputStream;
 import java.net.URL;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.io.IOUtils;
 import org.joda.time.DateTime;
+import org.opennms.core.utils.ParameterMap;
 import org.opennms.netmgt.collection.api.AttributeGroupType;
 import org.opennms.netmgt.collection.api.CollectionAgent;
 import org.opennms.netmgt.collection.api.CollectionException;
@@ -76,6 +78,9 @@ public class Sftp3gppXmlCollectionHandler extends AbstractXmlCollectionHandler {
         collectionSet.setCollectionTimestamp(new Date());
         collectionSet.setStatus(CollectionStatus.UNKNOWN);
 
+        // Create a map of parameters from the service to use in URLs, etc.
+        Map<String, String> params = filterParameters(parameters);
+
         // TODO We could be careful when handling exceptions because parsing exceptions will be treated different from connection or retrieval exceptions
         DateTime startTime = new DateTime();
         Sftp3gppUrlConnection connection = null;
@@ -85,8 +90,8 @@ public class Sftp3gppXmlCollectionHandler extends AbstractXmlCollectionHandler {
                 if (!source.getUrl().startsWith(Sftp3gppUrlHandler.PROTOCOL)) {
                     throw new CollectionException("The 3GPP SFTP Collection Handler can only use the protocol " + Sftp3gppUrlHandler.PROTOCOL);
                 }
-                String urlStr = parseUrl(source.getUrl(), agent, collection.getXmlRrd().getStep());
-                Request request = parseRequest(source.getRequest(), agent, collection.getXmlRrd().getStep());
+                String urlStr = parseUrl(source.getUrl(), agent, collection.getXmlRrd().getStep(), params);
+                Request request = parseRequest(source.getRequest(), agent, collection.getXmlRrd().getStep(), params);
                 URL url = UrlFactory.getUrl(urlStr, request);
                 String lastFile = Sftp3gppUtils.getLastFilename(getResourceStorageDao(), getServiceName(), resourcePath, url.getPath());
                 connection = (Sftp3gppUrlConnection) url.openConnection();

--- a/protocols/xml/src/main/java/org/opennms/protocols/xml/collector/XmlCollector.java
+++ b/protocols/xml/src/main/java/org/opennms/protocols/xml/collector/XmlCollector.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2011-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2011-2017 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -155,7 +155,7 @@ public class XmlCollector extends AbstractLegacyServiceCollector {
     @Override
     public CollectionSet collect(CollectionAgent agent, EventProxy eproxy, Map<String, Object> parameters) throws CollectionException {
         if (parameters == null) {
-            throw new CollectionException("Null parameters is now allowed in XML Collector!");
+            throw new CollectionException("Null parameters is not allowed in XML Collector!");
         }
         try {
             // Getting XML Collection

--- a/protocols/xml/src/test/java/org/opennms/protocols/json/collector/MockDefaultJsonCollectionHandler.java
+++ b/protocols/xml/src/test/java/org/opennms/protocols/json/collector/MockDefaultJsonCollectionHandler.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2011-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2011-2017 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -28,6 +28,7 @@
 
 package org.opennms.protocols.json.collector;
 
+import java.util.Map;
 import net.sf.json.JSONObject;
 
 import org.opennms.netmgt.collection.api.CollectionAgent;
@@ -56,7 +57,7 @@ public class MockDefaultJsonCollectionHandler extends DefaultJsonCollectionHandl
      * @see org.opennms.protocols.xml.collector.AbstractXmlCollectionHandler#parseUrl(java.lang.String, org.opennms.netmgt.collectd.CollectionAgent, java.lang.Integer)
      */
     @Override
-    protected String parseUrl(String unformattedUrl, CollectionAgent agent, Integer collectionStep) {
+    protected String parseUrl(String unformattedUrl, CollectionAgent agent, Integer collectionStep, final Map<String, String> parameters) {
         return unformattedUrl.replace("{ipaddr}", "127.0.0.1");
     }
 

--- a/protocols/xml/src/test/java/org/opennms/protocols/xml/collector/AbstractXmlCollectionHandlerTest.java
+++ b/protocols/xml/src/test/java/org/opennms/protocols/xml/collector/AbstractXmlCollectionHandlerTest.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2013-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2013-2017 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -28,6 +28,7 @@
 
 package org.opennms.protocols.xml.collector;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import org.junit.Assert;
@@ -83,10 +84,12 @@ public class AbstractXmlCollectionHandlerTest {
         OnmsAssetRecord asset = new OnmsAssetRecord();
         asset.setSerialNumber("1001");
         node.setAssetRecord(asset);
-        String url = handler.parseString("URL", "http://{nodeLabel}/{ipAddress}/serial/{serialNumber}/{step}", node, "127.0.0.1", 300);
-        Assert.assertEquals("http://mynode.local/127.0.0.1/serial/1001/300", url);
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put("port", "80");
+        String url = handler.parseString("URL", "http://{nodeLabel}:{parameter:port}/{ipAddress}/serial/{serialNumber}/{step}", node, "127.0.0.1", 300, parameters);
+        Assert.assertEquals("http://mynode.local:80/127.0.0.1/serial/1001/300", url);
         String multiline = "<data>\n   <source label='{nodeLabel}'/>\n</data>";
-        String xml = handler.parseString("Content", multiline, node, "127.0.0.1", 300);
+        String xml = handler.parseString("Content", multiline, node, "127.0.0.1", 300, parameters);
         Assert.assertEquals("<data>\n   <source label='mynode.local'/>\n</data>", xml);
     }
 

--- a/protocols/xml/src/test/java/org/opennms/protocols/xml/collector/MockDefaultXmlCollectionHandler.java
+++ b/protocols/xml/src/test/java/org/opennms/protocols/xml/collector/MockDefaultXmlCollectionHandler.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2011-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2011-2017 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -28,6 +28,7 @@
 
 package org.opennms.protocols.xml.collector;
 
+import java.util.Map;
 import org.opennms.netmgt.collection.api.CollectionAgent;
 import org.opennms.protocols.xml.config.Request;
 import org.opennms.protocols.xml.config.XmlResourceUtils;
@@ -53,7 +54,7 @@ public class MockDefaultXmlCollectionHandler extends DefaultXmlCollectionHandler
      * @see org.opennms.protocols.xml.collector.AbstractXmlCollectionHandler#parseUrl(java.lang.String, org.opennms.netmgt.collectd.CollectionAgent, java.lang.Integer)
      */
     @Override
-    protected String parseUrl(String unformattedUrl, CollectionAgent agent, Integer collectionStep) {
+    protected String parseUrl(String unformattedUrl, CollectionAgent agent, Integer collectionStep, final Map<String, String> parameters) {
         return unformattedUrl.replace("{ipaddr}", "127.0.0.1");
     }
 


### PR DESCRIPTION
NMS-9072: Pass the service parameters through and allow them to be used in the URLs and Request headers/data.

* JIRA: http://issues.opennms.org/browse/NMS-9072
