### PR TITLE
NMS-9120: Selection of non-disk RRD strategies

### DIFF
--- a/opennms-base-assembly/src/main/filtered/etc/rrd-configuration.properties
+++ b/opennms-base-assembly/src/main/filtered/etc/rrd-configuration.properties
@@ -196,3 +196,9 @@
 #
 # The queue size for outgoing TCP metrics
 #org.opennms.rrd.queuing.queueSize=50000
+
+#
+# If you would like to avoid writing to disk, set org.opennms.rrd.userrd to
+# 'false'.  By default it is set to true (write to disk).
+#
+#org.opennms.rrd.userrd=true

--- a/opennms-rrd/opennms-rrd-api/src/main/java/org/opennms/netmgt/rrd/RrdStrategyFactory.java
+++ b/opennms-rrd/opennms-rrd-api/src/main/java/org/opennms/netmgt/rrd/RrdStrategyFactory.java
@@ -44,6 +44,8 @@ public class RrdStrategyFactory implements ApplicationContextAware {
     private ApplicationContext m_context;
 
     private static enum StrategyName {
+        tcpRrdStrategy,
+        queuingTcpRrdStrategy,
         basicRrdStrategy,
         queuingRrdStrategy,
         tcpAndBasicRrdStrategy,
@@ -63,25 +65,36 @@ public class RrdStrategyFactory implements ApplicationContextAware {
     @SuppressWarnings("unchecked")
     public <D, F> RrdStrategy<D, F> getStrategy() {
         RrdStrategy<D, F> rrdStrategy = null;
+        Boolean useRrd = (Boolean) m_context.getBean("useRrd");
         Boolean useQueue = (Boolean) m_context.getBean("useQueue");
         Boolean useTcp = (Boolean) m_context.getBean("useTcp");
 
-        if (useQueue) {
-            if (useTcp) {
-                rrdStrategy = (RrdStrategy<D, F>) m_context.getBean(StrategyName.tcpAndQueuingRrdStrategy.toString());
+        if (useRrd) {
+            if (useQueue) {
+                if (useTcp) {
+                    rrdStrategy = (RrdStrategy<D, F>) m_context.getBean(StrategyName.tcpAndQueuingRrdStrategy.toString());
+                } else {
+                    rrdStrategy = (RrdStrategy<D, F>) m_context.getBean(StrategyName.queuingRrdStrategy.toString());
+                }
             } else {
-                rrdStrategy = (RrdStrategy<D, F>) m_context.getBean(StrategyName.queuingRrdStrategy.toString());
+                if (useTcp) {
+                    rrdStrategy = (RrdStrategy<D, F>) m_context.getBean(StrategyName.tcpAndBasicRrdStrategy.toString());
+                } else {
+                    rrdStrategy = (RrdStrategy<D, F>) m_context.getBean(StrategyName.basicRrdStrategy.toString());
+                }
             }
         } else {
             if (useTcp) {
-                rrdStrategy = (RrdStrategy<D, F>) m_context.getBean(StrategyName.tcpAndBasicRrdStrategy.toString());
-            } else {
-                rrdStrategy = (RrdStrategy<D, F>) m_context.getBean(StrategyName.basicRrdStrategy.toString());
+                if (useQueue) {
+                    rrdStrategy = (RrdStrategy<D, F>) m_context.getBean(StrategyName.queuingTcpRrdStrategy.toString());
+                } else {
+                    rrdStrategy = (RrdStrategy<D, F>) m_context.getBean(StrategyName.tcpRrdStrategy.toString());
+                }
             }
         }
 
         if (rrdStrategy == null) {
-            throw new IllegalStateException(String.format("Invalid RRD configuration useQueue: %s, useTcp: %s", useQueue, useTcp));
+            throw new IllegalStateException(String.format("Invalid RRD configuration useRrd %s, useQueue: %s, useTcp: %s", useRrd, useQueue, useTcp));
         }
 
         return rrdStrategy;

--- a/opennms-rrd/opennms-rrd-api/src/main/resources/META-INF/opennms/applicationContext-rrd.xml
+++ b/opennms-rrd/opennms-rrd-api/src/main/resources/META-INF/opennms/applicationContext-rrd.xml
@@ -18,6 +18,7 @@
             <props>
                 <!-- General configuration -->
                 <prop key="org.opennms.rrd.strategyClass">#{ T(org.opennms.core.utils.TimeSeries).DEFAULT_RRD_STRATEGY_CLASS }</prop>
+                <prop key="org.opennms.rrd.userrd">true</prop>
                 <prop key="org.opennms.rrd.usequeue">true</prop>
                 <prop key="org.opennms.rrd.usetcp">false</prop>
                 <prop key="org.opennms.rrd.fileExtension" />
@@ -64,6 +65,10 @@
 
     <bean id="rrdFileExtension" class="java.lang.String">
         <constructor-arg type="java.lang.String" value="${org.opennms.rrd.fileExtension}" />
+    </bean>
+
+    <bean id="useRrd" class="java.lang.Boolean">
+        <constructor-arg type="java.lang.String" value="${org.opennms.rrd.userrd}" />
     </bean>
 
     <bean id="useQueue" class="java.lang.Boolean">

--- a/opennms-rrd/opennms-rrd-api/src/main/resources/META-INF/opennms/component-rrd-tcp.xml
+++ b/opennms-rrd/opennms-rrd-api/src/main/resources/META-INF/opennms/component-rrd-tcp.xml
@@ -13,6 +13,7 @@
             <props>
                 <!-- General configuration -->
                 <prop key="org.opennms.rrd.strategyClass">org.opennms.netmgt.rrd.jrobin.JRobinRrdStrategy</prop>
+                <prop key="org.opennms.rrd.userrd">true</prop>
                 <prop key="org.opennms.rrd.usequeue">true</prop>
                 <prop key="org.opennms.rrd.usetcp">false</prop>
                 <prop key="org.opennms.rrd.fileExtension" />
@@ -56,14 +57,16 @@
         <property name="port" value="${org.opennms.rrd.tcp.port}" />
     </bean>
 
+    <bean id="queuingTcpRrdStrategy" class="org.opennms.netmgt.rrd.tcp.QueuingTcpRrdStrategy" lazy-init="true">
+        <constructor-arg ref="tcpRrdStrategy" />
+        <constructor-arg value="${org.opennms.rrd.queuing.queueSize}" />
+    </bean>
+
     <bean id="tcpAndBasicRrdStrategy" class="org.opennms.netmgt.rrd.MultiOutputRrdStrategy" lazy-init="true">
         <property name="delegates">
             <list>
                 <ref bean="basicRrdStrategy" />
-                <bean class="org.opennms.netmgt.rrd.tcp.QueuingTcpRrdStrategy" lazy-init="true">
-                    <constructor-arg ref="tcpRrdStrategy" />
-                    <constructor-arg value="${org.opennms.rrd.queuing.queueSize}" />
-                </bean>
+                <ref bean="queuingTcpRrdStrategy" />
             </list>
         </property>
         <!-- Use JRobinRrdStrategy for all graphing calls -->
@@ -76,10 +79,7 @@
         <property name="delegates">
             <list>
                 <ref bean="queuingRrdStrategy" />
-                <bean class="org.opennms.netmgt.rrd.tcp.QueuingTcpRrdStrategy" lazy-init="true">
-                    <constructor-arg ref="tcpRrdStrategy" />
-                    <constructor-arg value="${org.opennms.rrd.queuing.queueSize}" />
-                </bean>
+                <ref bean="queuingTcpRrdStrategy" />
             </list>
         </property>
         <!-- Use JRobinRrdStrategy for all graphing calls -->


### PR DESCRIPTION
- Add a "userrd" properties which controls whether the RRD strategy writes to the DB.  If false, only the TCP strtagy is used if usetcp is true.  If usetcp is false, the strategy is null.

JIRA: http://issues.opennms.org/browse/NMS-9120
