### PR TITLE
NMS-9116: Fix RPC integration tests

### DIFF
--- a/core/ipc/rpc/camel-impl/src/test/java/org/opennms/core/rpc/camel/EchoRpcBlueprintIT.java
+++ b/core/ipc/rpc/camel-impl/src/test/java/org/opennms/core/rpc/camel/EchoRpcBlueprintIT.java
@@ -35,7 +35,7 @@ import java.util.Properties;
 import org.apache.camel.Component;
 import org.apache.camel.util.KeyValueHolder;
 import org.junit.Ignore;
-import org.junit.Rule;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.opennms.core.rpc.api.RpcModule;
@@ -67,8 +67,8 @@ public class EchoRpcBlueprintIT extends CamelBlueprintTest {
 
     private static final String REMOTE_LOCATION_NAME = "remote";
 
-    @Rule
-    public ActiveMQBroker broker = new ActiveMQBroker();
+    @ClassRule
+    public static ActiveMQBroker broker = new ActiveMQBroker();
 
     @Autowired
     @Qualifier("queuingservice")

--- a/core/ipc/rpc/camel-impl/src/test/java/org/opennms/core/rpc/camel/EchoRpcBlueprintIT.java
+++ b/core/ipc/rpc/camel-impl/src/test/java/org/opennms/core/rpc/camel/EchoRpcBlueprintIT.java
@@ -34,7 +34,6 @@ import java.util.Properties;
 
 import org.apache.camel.Component;
 import org.apache.camel.util.KeyValueHolder;
-import org.junit.Ignore;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -95,7 +94,7 @@ public class EchoRpcBlueprintIT extends CamelBlueprintTest {
 
     @Override
     protected String getBlueprintDescriptor() {
-        return "classpath:/OSGI-INF/blueprint/blueprint-rpc-server.xml";
+        return "blueprint-empty-camel-context.xml";
     }
 
     @Test(timeout=60000)
@@ -108,7 +107,6 @@ public class EchoRpcBlueprintIT extends CamelBlueprintTest {
     }
 
     @Test(timeout=60000)
-    @Ignore("flapping with NPE at org.springframework.jms.support.JmsAccessor.createSession(JmsAccessor.java:197)")
     public void canExecuteRpcViaRemoteLocation() throws Exception {
         // Execute a request via a remote location
         assertNotEquals(REMOTE_LOCATION_NAME, identity.getLocation());

--- a/core/ipc/rpc/camel-impl/src/test/java/org/opennms/core/rpc/camel/EchoRpcBlueprintIT.java
+++ b/core/ipc/rpc/camel-impl/src/test/java/org/opennms/core/rpc/camel/EchoRpcBlueprintIT.java
@@ -98,11 +98,6 @@ public class EchoRpcBlueprintIT extends CamelBlueprintTest {
         return "classpath:/OSGI-INF/blueprint/blueprint-rpc-server.xml";
     }
 
-    @Override
-    public boolean isCreateCamelContextPerClass() {
-        return true;
-    }
-
     @Test(timeout=60000)
     public void canExecuteRpcViaCurrentLocation() throws Exception {
         // Execute a request via the current location

--- a/core/ipc/rpc/camel-impl/src/test/java/org/opennms/core/rpc/camel/EchoRpcThreadIT.java
+++ b/core/ipc/rpc/camel-impl/src/test/java/org/opennms/core/rpc/camel/EchoRpcThreadIT.java
@@ -37,7 +37,7 @@ import java.util.concurrent.CompletableFuture;
 
 import org.apache.camel.Component;
 import org.apache.camel.util.KeyValueHolder;
-import org.junit.Rule;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.opennms.core.rpc.api.RpcModule;
@@ -82,8 +82,8 @@ public class EchoRpcThreadIT extends CamelBlueprintTest {
 
     private static final String REMOTE_LOCATION_NAME = "remote";
 
-    @Rule
-    public ActiveMQBroker broker = new ActiveMQBroker();
+    @ClassRule
+    public static ActiveMQBroker broker = new ActiveMQBroker();
 
     @Autowired
     @Qualifier("queuingservice")

--- a/core/ipc/rpc/camel-impl/src/test/java/org/opennms/core/rpc/camel/EchoRpcThreadIT.java
+++ b/core/ipc/rpc/camel-impl/src/test/java/org/opennms/core/rpc/camel/EchoRpcThreadIT.java
@@ -115,11 +115,6 @@ public class EchoRpcThreadIT extends CamelBlueprintTest {
         return "classpath:/OSGI-INF/blueprint/blueprint-rpc-server.xml";
     }
 
-    @Override
-    public boolean isCreateCamelContextPerClass() {
-        return true;
-    }
-
     @Test(timeout=60000)
     public void canProcessManyRequestsAsynchronously() throws Exception {
         // Execute a request via a remote location

--- a/core/ipc/rpc/camel-impl/src/test/java/org/opennms/core/rpc/camel/EchoRpcThreadIT.java
+++ b/core/ipc/rpc/camel-impl/src/test/java/org/opennms/core/rpc/camel/EchoRpcThreadIT.java
@@ -112,7 +112,7 @@ public class EchoRpcThreadIT extends CamelBlueprintTest {
 
     @Override
     protected String getBlueprintDescriptor() {
-        return "classpath:/OSGI-INF/blueprint/blueprint-rpc-server.xml";
+        return "blueprint-empty-camel-context.xml";
     }
 
     @Test(timeout=60000)

--- a/core/ipc/sink/camel-impl/src/test/java/org/opennms/core/ipc/sink/camel/HeartbeatSinkBlueprintIT.java
+++ b/core/ipc/sink/camel-impl/src/test/java/org/opennms/core/ipc/sink/camel/HeartbeatSinkBlueprintIT.java
@@ -41,7 +41,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.camel.Component;
 import org.apache.camel.util.KeyValueHolder;
-import org.junit.Rule;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.opennms.core.ipc.sink.api.MessageConsumer;
@@ -75,8 +75,8 @@ public class HeartbeatSinkBlueprintIT extends CamelBlueprintTest {
 
     private static final String REMOTE_LOCATION_NAME = "remote";
 
-    @Rule
-    public ActiveMQBroker broker = new ActiveMQBroker();
+    @ClassRule
+    public static ActiveMQBroker broker = new ActiveMQBroker();
 
     @Autowired
     @Qualifier("queuingservice")

--- a/core/ipc/sink/camel-impl/src/test/java/org/opennms/core/ipc/sink/camel/HeartbeatSinkBlueprintIT.java
+++ b/core/ipc/sink/camel-impl/src/test/java/org/opennms/core/ipc/sink/camel/HeartbeatSinkBlueprintIT.java
@@ -113,11 +113,6 @@ public class HeartbeatSinkBlueprintIT extends CamelBlueprintTest {
         return "classpath:/OSGI-INF/blueprint/blueprint-ipc-client.xml";
     }
 
-    @Override
-    public boolean isCreateCamelContextPerClass() {
-        return true;
-    }
-
     @Test(timeout=60000)
     public void canProduceAndConsumerMessages() throws Exception {
         HeartbeatModule module = new HeartbeatModule();

--- a/core/ipc/sink/camel-impl/src/test/java/org/opennms/core/ipc/sink/camel/HeartbeatSinkPerfIT.java
+++ b/core/ipc/sink/camel-impl/src/test/java/org/opennms/core/ipc/sink/camel/HeartbeatSinkPerfIT.java
@@ -140,11 +140,6 @@ public class HeartbeatSinkPerfIT extends CamelBlueprintTest {
         return "classpath:/OSGI-INF/blueprint/blueprint-ipc-client.xml";
     }
 
-    @Override
-    public boolean isCreateCamelContextPerClass() {
-        return true;
-    }
-
     @Before
     public void setUp() throws Exception {
         super.setUp();

--- a/core/ipc/sink/camel-impl/src/test/java/org/opennms/core/ipc/sink/camel/HeartbeatSinkPerfIT.java
+++ b/core/ipc/sink/camel-impl/src/test/java/org/opennms/core/ipc/sink/camel/HeartbeatSinkPerfIT.java
@@ -44,7 +44,7 @@ import org.apache.camel.util.KeyValueHolder;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
-import org.junit.Rule;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.opennms.core.ipc.sink.api.MessageConsumer;
@@ -94,8 +94,8 @@ public class HeartbeatSinkPerfIT extends CamelBlueprintTest {
 
     private static final String REMOTE_LOCATION_NAME = "remote";
 
-    @Rule
-    public ActiveMQBroker broker = new ActiveMQBroker();
+    @ClassRule
+    public static ActiveMQBroker broker = new ActiveMQBroker();
 
     @Autowired
     @Qualifier("queuingservice")

--- a/core/snmp/proxy-rpc-tests/src/test/java/org/opennms/netmgt/snmp/proxy/common/LocationAwareSnmpClientIT.java
+++ b/core/snmp/proxy-rpc-tests/src/test/java/org/opennms/netmgt/snmp/proxy/common/LocationAwareSnmpClientIT.java
@@ -129,11 +129,6 @@ public class LocationAwareSnmpClientIT extends CamelBlueprintTest {
         return "classpath:/OSGI-INF/blueprint/blueprint-rpc-server.xml";
     }
 
-    @Override
-    public boolean isCreateCamelContextPerClass() {
-        return true;
-    }
-
     @Before
     public void setUp() throws Exception {
         super.setUp();

--- a/core/snmp/proxy-rpc-tests/src/test/java/org/opennms/netmgt/snmp/proxy/common/LocationAwareSnmpClientIT.java
+++ b/core/snmp/proxy-rpc-tests/src/test/java/org/opennms/netmgt/snmp/proxy/common/LocationAwareSnmpClientIT.java
@@ -40,7 +40,7 @@ import org.apache.camel.Component;
 import org.apache.camel.util.KeyValueHolder;
 import org.junit.Before;
 import org.junit.Ignore;
-import org.junit.Rule;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.opennms.core.rpc.api.RpcModule;
@@ -85,8 +85,8 @@ public class LocationAwareSnmpClientIT extends CamelBlueprintTest {
 
     private static final String REMOTE_LOCATION_NAME = "remote";
 
-    @Rule
-    public ActiveMQBroker broker = new ActiveMQBroker();
+    @ClassRule
+    public static ActiveMQBroker broker = new ActiveMQBroker();
 
     @Autowired
     private OnmsDistPoller identity;

--- a/core/snmp/proxy-rpc-tests/src/test/java/org/opennms/netmgt/snmp/proxy/common/LocationAwareSnmpClientIT.java
+++ b/core/snmp/proxy-rpc-tests/src/test/java/org/opennms/netmgt/snmp/proxy/common/LocationAwareSnmpClientIT.java
@@ -39,7 +39,6 @@ import java.util.concurrent.ExecutionException;
 import org.apache.camel.Component;
 import org.apache.camel.util.KeyValueHolder;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -126,7 +125,7 @@ public class LocationAwareSnmpClientIT extends CamelBlueprintTest {
 
     @Override
     protected String getBlueprintDescriptor() {
-        return "classpath:/OSGI-INF/blueprint/blueprint-rpc-server.xml";
+        return "blueprint-empty-camel-context.xml";
     }
 
     @Before
@@ -229,7 +228,6 @@ public class LocationAwareSnmpClientIT extends CamelBlueprintTest {
      * This should invoke the route in the Camel context initialize in this blueprint.
      */
     @Test(timeout=60000)
-    @Ignore("flapping with NPE at org.springframework.jms.support.JmsAccessor.createSession(JmsAccessor.java:197)")
     public void canWalkIpAddressTableViaAnotherLocation() throws Exception {
         assertNotEquals(REMOTE_LOCATION_NAME, identity.getLocation());
 

--- a/opennms-icmp/opennms-icmp-proxy-rpc-impl/src/test/java/org/opennms/netmgt/icmp/proxy/LocationAwarePingClientIT.java
+++ b/opennms-icmp/opennms-icmp-proxy-rpc-impl/src/test/java/org/opennms/netmgt/icmp/proxy/LocationAwarePingClientIT.java
@@ -111,11 +111,6 @@ public class LocationAwarePingClientIT extends CamelBlueprintTest {
         return "classpath:/OSGI-INF/blueprint/blueprint-rpc-server.xml";
     }
 
-    @Override
-    public boolean isCreateCamelContextPerClass() {
-        return true;
-    }
-
     @Before
     public void setUp() throws Exception {
         super.setUp();

--- a/opennms-icmp/opennms-icmp-proxy-rpc-impl/src/test/java/org/opennms/netmgt/icmp/proxy/LocationAwarePingClientIT.java
+++ b/opennms-icmp/opennms-icmp-proxy-rpc-impl/src/test/java/org/opennms/netmgt/icmp/proxy/LocationAwarePingClientIT.java
@@ -42,7 +42,6 @@ import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.opennms.core.rpc.api.RpcModule;
 import org.opennms.core.spring.BeanUtils;
 import org.opennms.core.test.OpenNMSJUnit4ClassRunner;
 import org.opennms.core.test.activemq.ActiveMQBroker;
@@ -75,9 +74,6 @@ public class LocationAwarePingClientIT extends CamelBlueprintTest {
     private OnmsDistPoller identity;
 
     @Autowired
-    private PingProxyRpcModule pingProxyRpcModule;
-
-    @Autowired
     @Qualifier("queuingservice")
     private Component queuingservice;
 
@@ -103,7 +99,6 @@ public class LocationAwarePingClientIT extends CamelBlueprintTest {
         Properties props = new Properties();
         props.setProperty("alias", "opennms.broker");
         services.put(Component.class.getName(), new KeyValueHolder<>(queuingservice, props));
-        services.put(RpcModule.class.getName(), new KeyValueHolder<>(pingProxyRpcModule, new Properties()));
     }
 
     @Override

--- a/opennms-icmp/opennms-icmp-proxy-rpc-impl/src/test/java/org/opennms/netmgt/icmp/proxy/LocationAwarePingSweepClientIT.java
+++ b/opennms-icmp/opennms-icmp-proxy-rpc-impl/src/test/java/org/opennms/netmgt/icmp/proxy/LocationAwarePingSweepClientIT.java
@@ -111,11 +111,6 @@ public class LocationAwarePingSweepClientIT extends CamelBlueprintTest {
         return "classpath:/OSGI-INF/blueprint/blueprint-rpc-server.xml";
     }
 
-    @Override
-    public boolean isCreateCamelContextPerClass() {
-        return true;
-    }
-
     @Before
     public void setUp() throws Exception {
         super.setUp();

--- a/opennms-icmp/opennms-icmp-proxy-rpc-impl/src/test/java/org/opennms/netmgt/icmp/proxy/LocationAwarePingSweepClientIT.java
+++ b/opennms-icmp/opennms-icmp-proxy-rpc-impl/src/test/java/org/opennms/netmgt/icmp/proxy/LocationAwarePingSweepClientIT.java
@@ -41,10 +41,8 @@ import org.apache.camel.util.KeyValueHolder;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.opennms.core.rpc.api.RpcModule;
 import org.opennms.core.spring.BeanUtils;
 import org.opennms.core.test.OpenNMSJUnit4ClassRunner;
 import org.opennms.core.test.activemq.ActiveMQBroker;
@@ -56,9 +54,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.test.context.ContextConfiguration;
 
-@Ignore("flapping")
 @RunWith(OpenNMSJUnit4ClassRunner.class)
-@ContextConfiguration(locations = { "classpath:/META-INF/opennms/applicationContext-soa.xml",
+@ContextConfiguration(locations = {
+        "classpath:/META-INF/opennms/applicationContext-soa.xml",
         "classpath:/META-INF/opennms/applicationContext-mockDao.xml",
         "classpath:/META-INF/opennms/applicationContext-queuingservice-mq-vm.xml",
         "classpath:/META-INF/opennms/applicationContext-rpc-client-camel.xml",
@@ -74,9 +72,6 @@ public class LocationAwarePingSweepClientIT extends CamelBlueprintTest {
 
     @Autowired
     private OnmsDistPoller identity;
-
-    @Autowired
-    private PingSweepRpcModule pingSweepRpcModule;
 
     @Autowired
     @Qualifier("queuingservice")
@@ -103,7 +98,6 @@ public class LocationAwarePingSweepClientIT extends CamelBlueprintTest {
         Properties props = new Properties();
         props.setProperty("alias", "opennms.broker");
         services.put(Component.class.getName(), new KeyValueHolder<>(queuingservice, props));
-        services.put(RpcModule.class.getName(), new KeyValueHolder<>(pingSweepRpcModule, new Properties()));
     }
 
     @Override

--- a/opennms-provision/opennms-detectorclient-rpc/src/test/java/org/opennms/netmgt/provision/detector/client/rpc/LocationAwareDetectorClientIT.java
+++ b/opennms-provision/opennms-detectorclient-rpc/src/test/java/org/opennms/netmgt/provision/detector/client/rpc/LocationAwareDetectorClientIT.java
@@ -39,7 +39,7 @@ import java.util.concurrent.Executors;
 import org.apache.camel.Component;
 import org.apache.camel.util.KeyValueHolder;
 import org.junit.Before;
-import org.junit.Rule;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.opennms.core.test.OpenNMSJUnit4ClassRunner;
@@ -70,8 +70,8 @@ public class LocationAwareDetectorClientIT extends CamelBlueprintTest {
 
     private static final String REMOTE_LOCATION_NAME = "remote";
 
-    @Rule
-    public ActiveMQBroker broker = new ActiveMQBroker();
+    @ClassRule
+    public static ActiveMQBroker broker = new ActiveMQBroker();
 
     @Autowired
     @Qualifier("queuingservice")


### PR DESCRIPTION
Made the RPC ITs consistent so that they can run without flapping. Please merge after this runs a couple more times in Bamboo. Not a blocker for 19.0.1.

* JIRA: http://issues.opennms.org/browse/NMS-9116