### PR TITLE
NMS-5334, NMS-2207: Update editoutages.jsp to allow users options when picking nodes for an outage

### DIFF
--- a/opennms-webapp/src/main/webapp/admin/sched-outages/editoutage.jsp
+++ b/opennms-webapp/src/main/webapp/admin/sched-outages/editoutage.jsp
@@ -459,6 +459,18 @@ Could not find an outage to edit because no outage name parameter was specified 
 				String newNode = request.getParameter("newNode");
 				if (newNode == null || "".equals(newNode.trim())) {
 					// No node was specified
+				} else if (newNode.startsWith("@")) {
+					String category = newNode.substring(1);
+					for (OnmsNode node : NetworkElementFactory.getInstance(getServletContext()).getNodesWithCategories(new String[] { category }, false)) {
+						addNode(theOutage, node.getId());
+					}
+				} else if (newNode.startsWith("$")) {
+					String foreignSource = newNode.substring(1);
+					for (OnmsNode node : NetworkElementFactory.getInstance(getServletContext()).getAllNodes()) {
+						if (node.getForeignSource() != null && node.getForeignSource().equals(foreignSource)) {
+							addNode(theOutage, node.getId());
+						}
+					}
 				} else {
 					int newNodeId = WebSecurityUtils.safeParseInt(newNode);
 					addNode(theOutage, newNodeId);
@@ -760,7 +772,7 @@ function updateOutageTypeDisplay(selectElement) {
 					<td valign="top">
 						<form id="addNode" action="admin/sched-outages/editoutage.jsp" method="post">
 							<input type="hidden" name="formSubmission" value="true" />
-							<p style="font-weight: bold; margin-bottom: 2px;">Search (max 200 results):</p>
+							<p style="font-weight: bold; margin-bottom: 2px;">Search (max 200 results, Prefix search string with '@' to search for categories,<br /> '#' to search for nodes in a category, '$' for requisitions,<br />and '%' for nodes in a requisition):</p>
 							<div class="ui-widget">
 								<select id="newNodeSelect" name="newNodeSelect" style="display: none"></select>
 								<input type="radio"  value="addPathOutageDependency" name="addPathOutageNodeRadio"/> Add with path outage dependency

--- a/opennms-webapp/src/main/webapp/admin/sched-outages/jsonNodes.jsp
+++ b/opennms-webapp/src/main/webapp/admin/sched-outages/jsonNodes.jsp
@@ -2,8 +2,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2010-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2010-2017 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -99,7 +99,7 @@ if (autocomplete != null && autocomplete.matches("^[#@%\\$].*$")){
     }
 }
 if (listCategories) {
-    Set<OnmsCategory> set = new HashSet<OnmsCategory>();
+    Set<OnmsCategory> set = new TreeSet<>();
     for (OnmsNode item : items) {
         set.addAll(item.getCategories());
     }
@@ -114,7 +114,7 @@ if (listCategories) {
     }
 
 } else if (listForeignSources) {
-    Set<String> set = new HashSet<String>();
+    Set<String> set = new TreeSet<>();
     for (OnmsNode item : items) {
         if (item.getForeignSource() != null && !"".equals(item.getForeignSource())) {
             set.add(item.getForeignSource());
@@ -132,23 +132,39 @@ if (listCategories) {
 
 } else {
     for (OnmsNode item : items) {
-	// Check to see if the item matches the search term
+        // Check to see if the item matches the search term
+        if (category != null) {
+            boolean skipItem = true;
+            for (OnmsCategory cat : item.getCategories()) {
+                if (cat.getName().startsWith(category)) {
+                    skipItem = false;
+                    break;
+                }
+            }
+            if (skipItem) {
+                continue;
+            }
+        } else if (foreignSource != null) {
+            if (item.getForeignSource() != null && !item.getForeignSource().startsWith(foreignSource) && !item.getForeignSource().equals(foreignSource)) {
+                continue;
+            }
+        }
 
-		StringBuffer result = new StringBuffer();
+        StringBuffer result = new StringBuffer();
 
         result.append(item.getLabel());
-		result.append(" (Node ID ").append(item.getId()).append(")");
-		// If we've already printed the first item, separate the items with a comma
-		if (printedFirst) {
-			out.println(",");
-		}
-		out.println(JSONSerializer.toJSON(new AutocompleteRecord(result.toString(), item.getNodeId())));
-		printedFirst = true;
-		// Don't print more than a certain number of records to limit the
-		// performance impact in the web browser
-		if (recordCounter++ >= recordLimit) {
-			break;
-		}
+        result.append(" (Node ID ").append(item.getId()).append(")");
+        // If we've already printed the first item, separate the items with a comma
+        if (printedFirst) {
+            out.println(",");
+        }
+        out.println(JSONSerializer.toJSON(new AutocompleteRecord(result.toString(), item.getNodeId())));
+        printedFirst = true;
+        // Don't print more than a certain number of records to limit the
+        // performance impact in the web browser
+        if (recordCounter++ >= recordLimit) {
+            break;
+        }
     }
 }
 %>


### PR DESCRIPTION
NMS-5334: Category and Scheduled Outage GUI Enhancment Request
NMS-2207: allow categories when creating downtime schedules

    I added a couple of enhancements to the Scheduled Outages page that should make things a little bit easier when selecting nodes.

    In the nodelabel search box, you can now prefix the search string with a couple of special symbols to alter the search behavior:

    '@' will let you search for surveillance categories
    '#' Will search for nodes who are in the specified surveillance category
    '$' will let you search for requisition names
    '%' will search for nodes in a requisition that starts with the search string.

* JIRA: http://issues.opennms.org/browse/NMS-5334

Our [continuous integration system](http://bamboo.internal.opennms.com:8085) will test and verify your changes.
