### PR TITLE
NMS-9145: Add JMX instrumentation for the Drools Correlator to understand the the working memory of each rule-set (a.k.a. engine)

### DIFF
--- a/features/ncs/ncs-drools/src/test/resources/test-context.xml
+++ b/features/ncs/ncs-drools/src/test/resources/test-context.xml
@@ -13,11 +13,14 @@
 
     <bean id="droolsCorrelationEngineBuilder" class="org.opennms.netmgt.correlation.drools.DroolsCorrelationEngineBuilder">
     	<property name="eventIpcManager" ref="eventProxy" />
+    	<property name="metricRegistry" ref="metricRegistry" />
     	<property name="correlationEngineRegistrar" ref="correlator" />
     	<property name="configurationResource" ref="droolsCorrelationEngineBuilderConfigurationResource"/>
     	<property name="configurationDirectory" ref="droolsCorrelationEngineBuilderConfigurationDirectory"/>
     </bean>
 
     <bean name="correlator" class="org.opennms.netmgt.correlation.ncs.MockCorrelator" />
+
+	<bean id="metricRegistry" class="com.codahale.metrics.MetricRegistry" />
 
 </beans>

--- a/opennms-correlation/drools-correlation-engine/pom.xml
+++ b/opennms-correlation/drools-correlation-engine/pom.xml
@@ -141,6 +141,11 @@
       <artifactId>bsh</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.dropwizard.metrics</groupId>
+      <artifactId>metrics-core</artifactId>
+      <version>${dropwizardMetricsVersion}</version>
+    </dependency>
+    <dependency>
       <groupId>org.opennms.core.test-api</groupId>
       <artifactId>org.opennms.core.test-api.db</artifactId>
       <scope>test</scope>

--- a/opennms-correlation/drools-correlation-engine/src/main/java/org/opennms/netmgt/correlation/drools/DroolsCorrelationEngine.java
+++ b/opennms-correlation/drools-correlation-engine/src/main/java/org/opennms/netmgt/correlation/drools/DroolsCorrelationEngine.java
@@ -48,7 +48,6 @@ import org.drools.core.RuleBaseConfiguration.AssertBehaviour;
 import org.drools.core.RuleBaseFactory;
 import org.drools.core.WorkingMemory;
 import org.kie.api.conf.EventProcessingOption;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.opennms.netmgt.correlation.AbstractCorrelationEngine;
@@ -80,8 +79,8 @@ public class DroolsCorrelationEngine extends AbstractCorrelationEngine {
     
     public DroolsCorrelationEngine(final String name, final MetricRegistry metricRegistry) {
         this.m_name = name;
-        final Gauge<Long> memorySize = () -> { return getWorkingMemory().getFactCount(); };
-        metricRegistry.register(MetricRegistry.name(name, "working-memory-size"), memorySize);
+        final Gauge<Long> factCount = () -> { return getWorkingMemory().getFactCount(); };
+        metricRegistry.register(MetricRegistry.name(name, "fact-count"), factCount);
         final Gauge<Integer> pendingTasksCount = () -> { return getPendingTasksCount(); };
         metricRegistry.register(MetricRegistry.name(name, "pending-tasks-count"), pendingTasksCount);
         m_eventsMeter = metricRegistry.meter(MetricRegistry.name(name, "events"));

--- a/opennms-correlation/drools-correlation-engine/src/main/java/org/opennms/netmgt/correlation/drools/DroolsCorrelationEngine.java
+++ b/opennms-correlation/drools-correlation-engine/src/main/java/org/opennms/netmgt/correlation/drools/DroolsCorrelationEngine.java
@@ -79,10 +79,11 @@ public class DroolsCorrelationEngine extends AbstractCorrelationEngine {
     private final Meter m_eventsMeter;
     
     public DroolsCorrelationEngine(final String name, final MetricRegistry metricRegistry) {
-        super();
         this.m_name = name;
-        final Gauge<Integer> size = () -> { return getMemorySize(); };
-        metricRegistry.register(MetricRegistry.name(name, "working-memory-size"), size);
+        final Gauge<Long> memorySize = () -> { return getWorkingMemory().getFactCount(); };
+        metricRegistry.register(MetricRegistry.name(name, "working-memory-size"), memorySize);
+        final Gauge<Integer> pendingTasksCount = () -> { return getPendingTasksCount(); };
+        metricRegistry.register(MetricRegistry.name(name, "pending-tasks-count"), pendingTasksCount);
         m_eventsMeter = metricRegistry.meter(MetricRegistry.name(name, "events"));
     }
 

--- a/opennms-correlation/drools-correlation-engine/src/main/java/org/opennms/netmgt/correlation/drools/DroolsCorrelationEngineBuilder.java
+++ b/opennms-correlation/drools-correlation-engine/src/main/java/org/opennms/netmgt/correlation/drools/DroolsCorrelationEngineBuilder.java
@@ -50,6 +50,8 @@ import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.io.Resource;
 import org.springframework.util.Assert;
 
+import com.codahale.metrics.MetricRegistry;
+
 /**
  * <p>DroolsCorrelationEngineBuilder class.</p>
  *
@@ -74,10 +76,10 @@ public class DroolsCorrelationEngineBuilder extends PropertyEditorRegistrySuppor
 			m_configuration = JaxbUtils.unmarshal(EngineConfiguration.class, m_configResource);
 		}
 
-		public CorrelationEngine[] constructEngines(ApplicationContext appContext, EventIpcManager eventIpcManager) {
+		public CorrelationEngine[] constructEngines(ApplicationContext appContext, EventIpcManager eventIpcManager, MetricRegistry metricRegistry) {
 			LOG.info("Creating drools engins for configuration {}.", m_configResource);
 
-			return m_configuration.constructEngines(m_configResource, appContext, eventIpcManager);
+			return m_configuration.constructEngines(m_configResource, appContext, eventIpcManager, metricRegistry);
 		}
 
 	}
@@ -87,6 +89,7 @@ public class DroolsCorrelationEngineBuilder extends PropertyEditorRegistrySuppor
     private Resource m_configResource;
     private EventIpcManager m_eventIpcManager;
     private CorrelationEngineRegistrar m_correlator;
+    private MetricRegistry m_metricRegistry;
 
     // built
     private PluginConfiguration[] m_pluginConfigurations;
@@ -119,6 +122,7 @@ public class DroolsCorrelationEngineBuilder extends PropertyEditorRegistrySuppor
         assertSet(m_configDirectory, "configurationDirectory");
         assertSet(m_eventIpcManager, "eventIpcManager");
         assertSet(m_correlator, "correlator");
+        assertSet(m_metricRegistry, "metricRegistry");
         
         Assert.state(!m_configDirectory.exists() || m_configDirectory.isDirectory(), m_configDirectory+" must be a directory!");
         
@@ -127,18 +131,27 @@ public class DroolsCorrelationEngineBuilder extends PropertyEditorRegistrySuppor
 
     private void registerEngines(final ApplicationContext appContext) {
     	for(PluginConfiguration pluginConfig : m_pluginConfigurations) {
-    		m_correlator.addCorrelationEngines(pluginConfig.constructEngines(appContext, m_eventIpcManager));
+    		m_correlator.addCorrelationEngines(pluginConfig.constructEngines(appContext, m_eventIpcManager, m_metricRegistry));
     	}
 
     }
 
-	/**
+    /**
      * <p>setEventIpcManager</p>
      *
      * @param eventIpcManager a {@link org.opennms.netmgt.events.api.EventIpcManager} object.
      */
     public void setEventIpcManager(final EventIpcManager eventIpcManager) {
         m_eventIpcManager = eventIpcManager;
+    }
+
+    /**
+     * <p>setMetricRegistry</p>
+     *
+     * @param metricRegistry a {@link com.codahale.metrics.MetricRegistry} object.
+     */
+    public void setMetricRegistry(final MetricRegistry metricRegistry) {
+        m_metricRegistry = metricRegistry;
     }
 
     /**

--- a/opennms-correlation/drools-correlation-engine/src/main/java/org/opennms/netmgt/correlation/drools/config/EngineConfiguration.java
+++ b/opennms-correlation/drools-correlation-engine/src/main/java/org/opennms/netmgt/correlation/drools/config/EngineConfiguration.java
@@ -68,6 +68,8 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.core.io.Resource;
 import org.xml.sax.ContentHandler;
 
+import com.codahale.metrics.MetricRegistry;
+
 
 /**
  * The top-level element of the drools-engine.xml configuration
@@ -375,14 +377,14 @@ public class EngineConfiguration implements Serializable {
 	}
 
 
-	public CorrelationEngine[] constructEngines(Resource basePath, ApplicationContext appContext, EventIpcManager eventIpcManager) {
+	public CorrelationEngine[] constructEngines(Resource basePath, ApplicationContext appContext, EventIpcManager eventIpcManager, MetricRegistry metricRegistry) {
 		
 		LOG.info("Creating drools engins for configuration {}.", basePath);
 
 		List<CorrelationEngine> engineList = new ArrayList<CorrelationEngine>();
 		for (final RuleSet ruleSet : getRuleSet()) {
 			LOG.debug("Constucting engind for ruleset {} in configuration {}.", ruleSet.getName(), basePath);
-			engineList.add(ruleSet.constructEngine(basePath, appContext, eventIpcManager));
+			engineList.add(ruleSet.constructEngine(basePath, appContext, eventIpcManager, metricRegistry));
 	    }
 	    
 	    return engineList.toArray(new CorrelationEngine[0]);

--- a/opennms-correlation/drools-correlation-engine/src/main/java/org/opennms/netmgt/correlation/drools/config/RuleSet.java
+++ b/opennms-correlation/drools-correlation-engine/src/main/java/org/opennms/netmgt/correlation/drools/config/RuleSet.java
@@ -62,6 +62,8 @@ import org.springframework.core.io.Resource;
 import org.springframework.core.io.ResourceLoader;
 import org.xml.sax.ContentHandler;
 
+import com.codahale.metrics.MetricRegistry;
+
 /**
  * Class RuleSet.
  *
@@ -831,11 +833,10 @@ public class RuleSet implements Serializable {
         return true;
     }
 
-    public CorrelationEngine constructEngine(Resource basePath, ApplicationContext appContext, EventIpcManager eventIpcManager) {
+    public CorrelationEngine constructEngine(Resource basePath, ApplicationContext appContext, EventIpcManager eventIpcManager, MetricRegistry metricRegistry) {
         final ApplicationContext configContext = new ConfigFileApplicationContext(basePath, getConfigLocation(), appContext);
 
-        final DroolsCorrelationEngine engine = new DroolsCorrelationEngine();
-        engine.setName(getName());
+        final DroolsCorrelationEngine engine = new DroolsCorrelationEngine(getName(), metricRegistry);
         engine.setAssertBehaviour(getAssertBehaviour());
         engine.setEventProcessingMode(getEventProcessingMode());
         engine.setEventIpcManager(eventIpcManager);

--- a/opennms-correlation/drools-correlation-engine/src/main/resources/META-INF/opennms/correlation-engine.xml
+++ b/opennms-correlation/drools-correlation-engine/src/main/resources/META-INF/opennms/correlation-engine.xml
@@ -18,9 +18,26 @@
     
     <bean id="droolsCorrelationEngineBuilder" class="org.opennms.netmgt.correlation.drools.DroolsCorrelationEngineBuilder">
     	<property name="eventIpcManager" ref="eventIpcManager" />
+    	<property name="metricRegistry" ref="metricRegistry" />
     	<property name="correlationEngineRegistrar" ref="correlator" />
     	<property name="configurationResource" ref="droolsCorrelationEngineBuilderConfigurationResource"/>
     	<property name="configurationDirectory" ref="droolsCorrelationEngineBuilderConfigurationDirectory"/>
     </bean>
-        
+
+	<bean id="metricRegistry" class="com.codahale.metrics.MetricRegistry" />
+
+	<bean id="metricRegistryJmxReporterBuilder" class="com.codahale.metrics.JmxReporter" factory-method="forRegistry">
+		<constructor-arg ref="metricRegistry"/>
+	</bean>
+
+	<bean id="metricRegistryDomainedJmxReporterBuilder" factory-bean="metricRegistryJmxReporterBuilder" factory-method="inDomain">
+		<constructor-arg value="org.opennms.drools"/>
+	</bean>
+
+	<bean id="metricRegistryJmxReporter"
+        factory-bean="metricRegistryDomainedJmxReporterBuilder"
+        factory-method="build"
+        init-method="start"
+        destroy-method="stop" />
+
 </beans>

--- a/opennms-correlation/drools-correlation-engine/src/test/resources/test-context.xml
+++ b/opennms-correlation/drools-correlation-engine/src/test/resources/test-context.xml
@@ -13,11 +13,14 @@
 
     <bean id="droolsCorrelationEngineBuilder" class="org.opennms.netmgt.correlation.drools.DroolsCorrelationEngineBuilder">
     	<property name="eventIpcManager" ref="eventIpcManager" />
+    	<property name="metricRegistry" ref="metricRegistry" />
     	<property name="correlationEngineRegistrar" ref="correlator" />
     	<property name="configurationResource" ref="droolsCorrelationEngineBuilderConfigurationResource"/>
     	<property name="configurationDirectory" ref="droolsCorrelationEngineBuilderConfigurationDirectory"/>
     </bean>
 
     <bean name="correlator" class="org.opennms.netmgt.correlation.drools.MockCorrelator" />
+
+	<bean id="metricRegistry" class="com.codahale.metrics.MetricRegistry" />
 
 </beans>

--- a/opennms-correlation/opennms-correlator/src/main/java/org/opennms/netmgt/correlation/AbstractCorrelationEngine.java
+++ b/opennms-correlation/opennms-correlator/src/main/java/org/opennms/netmgt/correlation/AbstractCorrelationEngine.java
@@ -108,6 +108,10 @@ public abstract class AbstractCorrelationEngine implements CorrelationEngine {
         }
     }
     
+    public int getPendingTasksCount() {
+        return m_pendingTasks.size();
+    }
+
     /**
      * <p>timerExpired</p>
      *


### PR DESCRIPTION
Add JMX instrumentation for the Drools Correlator to understand the the
working memory of each rule-set (a.k.a. engine)

* JIRA: http://issues.opennms.org/browse/NMS-9145

Our [continuous integration system](http://bamboo.internal.opennms.com:8085) will test and verify your changes.
