### PR TITLE
NMS-9161: Collect and graph the size of the fixed thread pool task qu…

### DIFF
--- a/opennms-base-assembly/src/main/filtered/etc/jmx-datacollection-config.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/jmx-datacollection-config.xml
@@ -27,6 +27,8 @@
                 <attrib name="ActiveThreads" alias="ONMSPollerThreadAct" type="gauge"/>
                 <attrib name="TasksTotal" alias="ONMSPollerTasksTot" type="counter"/>
                 <attrib name="TasksCompleted" alias="ONMSPollerTasksCpt" type="counter"/>
+                <attrib name="TaskQueuePendingCount" alias="ONMSPollerTskQPCnt" type="gauge"/>
+                <attrib name="TaskQueueRemainingCapacity" alias="ONMSPollerTskQRCap" type="gauge"/>
             </mbean>
             <mbean name="OpenNMS Vacuumd" objectname="OpenNMS:Name=Vacuumd">
                 <attrib name="NumAutomations" alias="ONMSAutomCount" type="counter"/>
@@ -39,6 +41,8 @@
                 <attrib name="TasksTotal" alias="ONMSCollectTasksTot" type="counter"/>
                 <attrib name="TasksCompleted" alias="ONMSCollectTasksCpt" type="counter"/>
                 <attrib name="CollectableServiceCount" alias="ONMSCollectSvcCount" type="gauge"/>
+                <attrib name="TaskQueuePendingCount" alias="ONMSCollectTskQPCnt" type="gauge"/>
+                <attrib name="TaskQueueRemainingCapacity" alias="ONMSCollectTskQRCap" type="gauge"/>
             </mbean>
             <mbean name="OpenNMS.JettyServer" objectname="OpenNMS:Name=JettyServer">
                 <attrib name="HttpsConnectionsTotal" alias="HttpsConnTotal" type="counter"/>

--- a/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/opennms-graph.properties
+++ b/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/opennms-graph.properties
@@ -1,7 +1,9 @@
 reports=onms.manager.uptime, onms.queued.updates, onms.queued.pending, \
 onms.pollerd.activeThreads, onms.pollerd.completedRatio, onms.pollerd.polls, \
+onms.pollerd.taskqueue, \
 onms.collectd.activeThreads, onms.collectd.threadpool, \
 onms.collectd.completedRatio, onms.collectd.collectableServiceCount, \
+onms.collectd.taskqueue, \
 OpenNMS.JettyServer.HttpsConnTotal.AttributeReport, \
 OpenNMS.JettyServer.HttpsConnOpen.AttributeReport, \
 OpenNMS.JettyServer.HttpsConnOpenMax.AttributeReport, \
@@ -128,6 +130,17 @@ report.onms.pollerd.completedRatio.command=--title="OpenNMS Pollerd Task Complet
  GPRINT:percent:MIN:"Min  \\: %8.2lf %s" \
  GPRINT:percent:MAX:"Max  \\: %8.2lf %s\\n"
 
+report.onms.pollerd.taskqueue.name=OpenNMS Poller Task Queue
+report.onms.pollerd.taskqueue.columns=ONMSPollerTskQPCnt
+report.onms.pollerd.taskqueue.type=interfaceSnmp
+report.onms.pollerd.taskqueue.command=--title="OpenNMS Pollerd Task Queue" \
+ --vertical-label="Tasks" \
+ DEF:active={rrd1}:ONMSPollerTskQPCnt:AVERAGE \
+ LINE1:active#0000ff:"Pending Tasks" \
+ GPRINT:active:AVERAGE:" Avg  \\: %8.2lf %s" \
+ GPRINT:active:MIN:"Min  \\: %8.2lf %s" \
+ GPRINT:active:MAX:"Max  \\: %8.2lf %s\\n"
+
 ###
 ## OpenNMS Collectd
 ###
@@ -192,6 +205,17 @@ report.onms.collectd.collectableServiceCount.command=--title="OpenNMS Collectd C
  GPRINT:total:AVERAGE:" Avg  \\: %8.2lf %s" \
  GPRINT:total:MIN:"Min  \\: %8.2lf %s" \
  GPRINT:total:MAX:"Max  \\: %8.2lf %s\\n"
+
+report.onms.collectd.taskqueue.name=OpenNMS Collectd Task Queue
+report.onms.collectd.taskqueue.columns=ONMSCollectTskQPCnt
+report.onms.collectd.taskqueue.type=interfaceSnmp
+report.onms.collectd.taskqueue.command=--title="OpenNMS Collectd Task Queue" \
+ --vertical-label="Tasks" \
+ DEF:active={rrd1}:ONMSCollectTskQPCnt:AVERAGE \
+ LINE1:active#0000ff:"Pending Tasks" \
+ GPRINT:active:AVERAGE:" Avg  \\: %8.2lf %s" \
+ GPRINT:active:MIN:"Min  \\: %8.2lf %s" \
+ GPRINT:active:MAX:"Max  \\: %8.2lf %s\\n"
 
 ###
 ## OpenNMS Vacuumd

--- a/opennms-services/src/main/java/org/opennms/netmgt/collectd/jmx/Collectd.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/collectd/jmx/Collectd.java
@@ -122,6 +122,24 @@ public class Collectd extends AbstractSpringContextJmxServiceDaemon<org.opennms.
     }
     
     @Override
+    public long getTaskQueuePendingCount() {
+        if (getThreadPoolStatsStatus()) {
+            return getExecutor().getQueue().size();
+        } else {
+            return 0L;
+        }
+    }
+
+    @Override
+    public long getTaskQueueRemainingCapacity() {
+        if (getThreadPoolStatsStatus()) {
+            return getExecutor().getQueue().remainingCapacity();
+        } else {
+            return 0L;
+        }
+    }
+
+    @Override
     public long getCollectableServiceCount() {
         return getDaemon().getCollectableServiceCount();
     }

--- a/opennms-services/src/main/java/org/opennms/netmgt/collectd/jmx/CollectdMBean.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/collectd/jmx/CollectdMBean.java
@@ -76,4 +76,14 @@ public interface CollectdMBean extends BaseOnmsMBean {
      * @return The number of collectable services currently seen by Collectd
      */
     public long getCollectableServiceCount();
+
+    /**
+     * @return The number of pending tasks
+     */
+    public long getTaskQueuePendingCount();
+
+    /**
+     * @return The number of pending tasks
+     */
+    public long getTaskQueueRemainingCapacity();
 }

--- a/opennms-services/src/main/java/org/opennms/netmgt/poller/jmx/Pollerd.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/poller/jmx/Pollerd.java
@@ -121,6 +121,23 @@ public class Pollerd extends AbstractSpringContextJmxServiceDaemon<org.opennms.n
         }
     }
 
+    @Override
+    public long getTaskQueuePendingCount() {
+        if (getThreadPoolStatsStatus()) {
+            return getExecutor().getQueue().size();
+        } else {
+            return 0L;
+        }
+    }
+
+    @Override
+    public long getTaskQueueRemainingCapacity() {
+        if (getThreadPoolStatsStatus()) {
+            return getExecutor().getQueue().remainingCapacity();
+        } else {
+            return 0L;
+        }
+    }
     
     private ThreadPoolExecutor getExecutor() {
         return (ThreadPoolExecutor) ((LegacyScheduler) getDaemon().getScheduler()).getRunner();

--- a/opennms-services/src/main/java/org/opennms/netmgt/poller/jmx/PollerdMBean.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/poller/jmx/PollerdMBean.java
@@ -74,4 +74,14 @@ public interface PollerdMBean extends BaseOnmsMBean {
      * @return The maximum number of threads allowed in the poller's thread pool
      */
     public long getMaxPoolThreads();
+
+    /**
+     * @return The number of pending tasks on our ExecutorService
+     */
+    public long getTaskQueuePendingCount();
+
+    /**
+     * @return The number of open slots on our ExecutorService queue.
+     */
+    public long getTaskQueueRemainingCapacity();
 }


### PR DESCRIPTION
NMS-9161: Collect and graph the size of the fixed thread pool task queue used by collectd and pollerd.

* JIRA: http://issues.opennms.org/browse/NMS-9161