### PR TITLE
NMS-9166: Fix permissions on opennms.service file for systemd

### DIFF
--- a/tools/packages/opennms/opennms.spec
+++ b/tools/packages/opennms/opennms.spec
@@ -912,7 +912,7 @@ for prefix in lib lib64; do
 		SYSTEMDDIR="/usr/$prefix/systemd/system"
 		printf -- "- installing service into $SYSTEMDDIR... "
 		install -d -m 755 "$SYSTEMDDIR"
-		install -m 655 "%{instprefix}/etc/opennms.service" "$SYSTEMDDIR"/
+		install -m 644 "%{instprefix}/etc/opennms.service" "$SYSTEMDDIR"/
 		echo "done"
 	fi
 done


### PR DESCRIPTION
NMS-9166: Fix permissions on opennms.service file for systemd

* JIRA: http://issues.opennms.org/browse/NMS-9166