### PR TITLE
NMS-9089: grafanaBox needs a count limiter/pager

### DIFF
--- a/opennms-base-assembly/src/main/filtered/etc/opennms.properties
+++ b/opennms-base-assembly/src/main/filtered/etc/opennms.properties
@@ -761,6 +761,9 @@ excludeServiceMonitorsFromRemotePoller=DHCP,NSClient,RadiusAuth,XMP
 # Timeouts for contacting the grafana server
 #org.opennms.grafanaBox.connectionTimeout=500
 #org.opennms.grafanaBox.soTimeout=500
+#
+# Limit the number of grafana dashboards to list.
+#org.opennms.grafanaBox.dashboardLimit=0
 
 # ###### ActiveMQ Settings ######
 # These settings are used to control which ActiveMQ broker will be used.

--- a/opennms-webapp/src/main/webapp/graph/grafana.jsp
+++ b/opennms-webapp/src/main/webapp/graph/grafana.jsp
@@ -1,0 +1,48 @@
+<%--
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2017 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+--%>
+
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+
+<jsp:include page="/includes/bootstrap.jsp" flush="false" >
+  <jsp:param name="title" value="Grafana Dashboard List" />
+  <jsp:param name="headTitle" value="Grafana Dashboard List" />
+</jsp:include>
+
+<div class="row">
+
+    <% String showGrafanaBox = System.getProperty("org.opennms.grafanaBox.show", "false");
+       if (Boolean.parseBoolean(showGrafanaBox)) { %>
+           <jsp:include page="/includes/grafana-box.jsp" flush="false">
+               <jsp:param name="useLimit" value="false" />
+           </jsp:include>
+    <% } %>
+</div>
+
+<jsp:include page="/includes/bootstrap-footer.jsp" flush="false"/>

--- a/opennms-webapp/src/main/webapp/includes/grafana-box.jsp
+++ b/opennms-webapp/src/main/webapp/includes/grafana-box.jsp
@@ -52,7 +52,13 @@
 
 <%@taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
+<%
+    int grafanaDashboadLimit = Integer.parseInt(System.getProperty("org.opennms.grafanaBox.dashboardLimit", "0"));
+%>
 
+<c:if test="${param.useLimit != 'true'}">
+<% grafanaDashboadLimit = 0; %>
+</c:if>
 <%
     String grafanaApiKey = System.getProperty("org.opennms.grafanaBox.apiKey", "");
     String grafanaProtocol = System.getProperty("org.opennms.grafanaBox.protocol", "http");
@@ -102,6 +108,8 @@
         <script type="text/javascript">
             var grafanaTag = '<%=grafanaTag%>';
             var obj = <%=responseString%>;
+            var limit = <%=grafanaDashboadLimit%>;
+            var count = 0;
 
             for (var val of obj) {
                 var showDashboard = true;
@@ -117,9 +125,14 @@
                     }
                 }
                 if (showDashboard) {
-                    $('#dashboardlist').append('<a href="<%=grafanaProtocol%>://<%=grafanaHostname%>:<%=grafanaPort%>/dashboard/' + val['uri'] + '"><span class="glyphicon glyphicon-signal" aria-hidden="true"></span>&nbsp;' + val['title'] + "</a><br/>");
+                    if (limit < 1 || count++ < limit) {
+                        $('#dashboardlist').append('<a href="<%=grafanaProtocol%>://<%=grafanaHostname%>:<%=grafanaPort%>/dashboard/' + val['uri'] + '"><span class="glyphicon glyphicon-signal" aria-hidden="true"></span>&nbsp;' + val['title'] + "</a><br/>");
+                    }
                 }
             };
+            if (limit > 0 && count > limit) {
+                $('#dashboardlist').append('<a href="graph/grafana.jsp">&nbsp;&nbsp;View List of All Dashboards</a><br/>');
+            }
         </script>
         <%
             } else {

--- a/opennms-webapp/src/main/webapp/index.jsp
+++ b/opennms-webapp/src/main/webapp/index.jsp
@@ -2,8 +2,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2002-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2002-2017 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -84,7 +84,9 @@
 
 		<% String showGrafanaBox = System.getProperty("org.opennms.grafanaBox.show", "false");
 			if (Boolean.parseBoolean(showGrafanaBox)) { %>
-		<jsp:include page="/includes/grafana-box.jsp" flush="false" />
+		<jsp:include page="/includes/grafana-box.jsp" flush="false">
+                    <jsp:param name="useLimit" value="true" />
+                </jsp:include>
 		<% } %>
 
 		<!-- Quick Search box -->


### PR DESCRIPTION
Add support for limiting the number of grafana dashboards to display in the grafana-box. If the limit is hit, display a link to a new page ( graph/grafana.jsp ) that will display all available dashboards.

* JIRA: http://issues.opennms.org/browse/NMS-9089
