### PR TITLE
NMS-9201: Changed SyslogParser to use the local timezone

### DIFF
--- a/opennms-services/src/main/java/org/opennms/netmgt/syslogd/SyslogParser.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/syslogd/SyslogParser.java
@@ -111,12 +111,10 @@ public class SyslogParser {
         Date date;
         try {
             final DateFormat df = new SimpleDateFormat("yyyy-MM-dd", Locale.ROOT);
-            df.setTimeZone(TimeZone.getTimeZone("UTC"));
             date = df.parse(dateString);
         } catch (final Exception e) {
             try {
                 final DateFormat df = new SimpleDateFormat("MMM d HH:mm:ss", Locale.ROOT);
-                df.setTimeZone(TimeZone.getTimeZone("UTC"));
                 
                 // Ugh, what's a non-lame way of forcing it to parse to "this year"?
                 date = df.parse(dateString);

--- a/opennms-services/src/test/java/org/opennms/netmgt/syslogd/SyslogMessageTest.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/syslogd/SyslogMessageTest.java
@@ -104,7 +104,7 @@ public class SyslogMessageTest {
         final SyslogParser parser = CustomSyslogParser.getParser("<173>Dec  7 12:02:06 10.13.110.116 mgmtd[8326]: [mgmtd.NOTICE]: Configuration saved to database initial");
         assertTrue(parser.find());
         final SyslogMessage message = parser.parse();
-        final Calendar calendar = new GregorianCalendar(TimeZone.getTimeZone("UTC"));
+        final Calendar calendar = new GregorianCalendar();
         calendar.set(Calendar.MONTH, 11);
         calendar.set(Calendar.DATE, 7);
         calendar.set(Calendar.HOUR_OF_DAY, 12);
@@ -159,7 +159,6 @@ public class SyslogMessageTest {
             final SyslogMessage message = parser.parse();
             LOG.debug("message = {}", message);
             final Calendar cal = Calendar.getInstance();
-            cal.setTimeZone(TimeZone.getTimeZone("UTC"));
             cal.set(Calendar.MONTH, Calendar.MARCH);
             cal.set(Calendar.DAY_OF_MONTH, 14);
             cal.set(Calendar.HOUR_OF_DAY, 17);
@@ -184,7 +183,15 @@ public class SyslogMessageTest {
         final SyslogParser parser = SyslogNGParser.getParser("<6>test: 2007-01-01 127.0.0.1 OpenNMS[1234]: A SyslogNG style message");
         assertTrue(parser.find());
         final SyslogMessage message = parser.parse();
-        final Date date = new Date(1167609600000L);
+        final Calendar calendar = new GregorianCalendar();
+        calendar.set(Calendar.YEAR, 2007);
+        calendar.set(Calendar.MONTH, Calendar.JANUARY);
+        calendar.set(Calendar.DATE, 1);
+        calendar.set(Calendar.HOUR_OF_DAY, 0);
+        calendar.clear(Calendar.MINUTE);
+        calendar.clear(Calendar.SECOND);
+        calendar.clear(Calendar.MILLISECOND);
+        final Date date = calendar.getTime();
 
         assertEquals(SyslogFacility.KERNEL, message.getFacility());
         assertEquals(SyslogSeverity.INFO, message.getSeverity());
@@ -201,7 +208,15 @@ public class SyslogMessageTest {
         final SyslogParser parser = SyslogNGParser.getParser("<6>test: 2007-01-01 127.0.0.1 A SyslogNG style message");
         assertTrue(parser.find());
         final SyslogMessage message = parser.parse();
-        final Date date = new Date(1167609600000L);
+        final Calendar calendar = new GregorianCalendar();
+        calendar.set(Calendar.YEAR, 2007);
+        calendar.set(Calendar.MONTH, Calendar.JANUARY);
+        calendar.set(Calendar.DATE, 1);
+        calendar.set(Calendar.HOUR_OF_DAY, 0);
+        calendar.clear(Calendar.MINUTE);
+        calendar.clear(Calendar.SECOND);
+        calendar.clear(Calendar.MILLISECOND);
+        final Date date = calendar.getTime();
 
         assertEquals(SyslogFacility.KERNEL, message.getFacility());
         assertEquals(SyslogSeverity.INFO, message.getSeverity());
@@ -218,20 +233,19 @@ public class SyslogMessageTest {
         final SyslogParser parser = SyslogNGParser.getParser("<173>Dec  7 12:02:06 10.13.110.116 mgmtd[8326]: [mgmtd.NOTICE]: Configuration saved to database initial");
         assertTrue(parser.find());
         final SyslogMessage message = parser.parse();
-        final Date timestampIn2011 = new Date(1323259326000L);
-        
-        final Calendar cal = Calendar.getInstance();
-        final int currentYear = cal.get(Calendar.YEAR);
-        
-        cal.setTime(timestampIn2011);
-        cal.set(Calendar.YEAR, currentYear);
-        
-        final Date timestampThisYear = cal.getTime();
+        final Calendar calendar = new GregorianCalendar();
+        calendar.set(Calendar.MONTH, Calendar.DECEMBER);
+        calendar.set(Calendar.DATE, 7);
+        calendar.set(Calendar.HOUR_OF_DAY, 12);
+        calendar.set(Calendar.MINUTE, 2);
+        calendar.set(Calendar.SECOND, 6);
+        calendar.clear(Calendar.MILLISECOND);
+        final Date date = calendar.getTime();
 
         assertEquals(SyslogFacility.LOCAL5, message.getFacility());
         assertEquals(SyslogSeverity.NOTICE, message.getSeverity());
         assertEquals(null, message.getMessageID());
-        assertEquals(timestampThisYear, message.getDate());
+        assertEquals(date, message.getDate());
         assertEquals("10.13.110.116", message.getHostName());
         assertEquals("mgmtd", message.getProcessName());
         assertEquals(8326, message.getProcessId().intValue());


### PR DESCRIPTION
Assuming that syslog timestamps are in UTC is not correct: timestamps without a timezone should be assumed to be in the local timezone of the machine.

* JIRA: http://issues.opennms.org/browse/NMS-9201