### PR TITLE
NMS-9197, NMS-9210: Add retries, timeouts, and exception handling for Elasticsearch forwarding

### DIFF
--- a/core/lib/src/main/java/org/opennms/core/utils/TimeoutTracker.java
+++ b/core/lib/src/main/java/org/opennms/core/utils/TimeoutTracker.java
@@ -37,9 +37,6 @@ import java.util.concurrent.TimeUnit;
  *
  * @author <a href="mailto:ranger@opennms.org">Ben Reed</a>
  * @author <a href="mailto:brozow@opennms.org">Mathew Brozowski</a>
- * @author <a href="mailto:ranger@opennms.org">Ben Reed</a>
- * @author <a href="mailto:brozow@opennms.org">Mathew Brozowski</a>
- * @version $Id: $
  */
 public class TimeoutTracker {
 
@@ -47,8 +44,13 @@ public class TimeoutTracker {
     private final long m_timeoutInNanos;
     private final long m_timeoutInMillis;
     private final long m_timeoutInSeconds;
+
+    /**
+     * Strict timeouts will enforce that the timeout time elapses between subsequent
+     * attempts even if the operation returns more quickly than the timeout.
+     */
     private final boolean m_strictTimeouts;
-    
+
     private int m_attempt = 0;
     private long m_nextRetryTimeNanos = -1L;
     private long m_attemptStartTimeNanos = -1L;

--- a/features/opennms-es-rest/main-module/src/main/java/org/opennms/plugins/elasticsearch/rest/EventToIndex.java
+++ b/features/opennms-es-rest/main-module/src/main/java/org/opennms/plugins/elasticsearch/rest/EventToIndex.java
@@ -360,8 +360,12 @@ public class EventToIndex implements AutoCloseable {
 						BulkResult result = getJestClient().execute(bulk);
 
 						// If the bulk command fails completely...
-						if (!result.isSucceeded()) {
-							logEsError("Bulk API action", entry.getKey(), type, result.getJsonString(), result.getResponseCode(), result.getErrorMessage());
+						if (result == null || !result.isSucceeded()) {
+							if (result == null) {
+								logEsError("Bulk API action", entry.getKey(), type, null, -1, null);
+							} else {
+								logEsError("Bulk API action", entry.getKey(), type, result.getJsonString(), result.getResponseCode(), result.getErrorMessage());
+							}
 
 							// Try and issue the bulk actions individually as a fallback
 							for (BulkableAction<DocumentResult> action : entry.getValue()) {
@@ -394,8 +398,12 @@ public class EventToIndex implements AutoCloseable {
 						}
 
 						// If the bulk command fails completely...
-						if (!result.isSucceeded()) {
-							logEsError("Bulk API action", entry.getKey(), type, result.getJsonString(), result.getResponseCode(), result.getErrorMessage());
+						if (result == null || !result.isSucceeded()) {
+							if (result == null) {
+								logEsError("Bulk API action", entry.getKey(), type, null, -1, null);
+							} else {
+								logEsError("Bulk API action", entry.getKey(), type, result.getJsonString(), result.getResponseCode(), result.getErrorMessage());
+							}
 
 							// Try and issue the bulk actions individually as a fallback
 							for (BulkableAction<DocumentResult> action : entry.getValue()) {
@@ -455,11 +463,15 @@ public class EventToIndex implements AutoCloseable {
 
 		DocumentResult result = client.execute(action);
 
-		if(result.getResponseCode() == 404){
+		if(result == null || result.getResponseCode() == 404){
 			// index doesn't exist for upsert command so create new index and try again
 
 			if(LOG.isDebugEnabled()) {
-				logEsDebug(action.getRestMethodName(), action.getIndex(), action.getType(), result.getJsonString(), result.getResponseCode(), result.getErrorMessage());
+				if (result == null) {
+					logEsDebug(action.getRestMethodName(), action.getIndex(), action.getType(), null, -1, null);
+				} else {
+					logEsDebug(action.getRestMethodName(), action.getIndex(), action.getType(), result.getJsonString(), result.getResponseCode(), result.getErrorMessage());
+				}
 				LOG.debug("index name "+action.getIndex() + " doesn't exist, creating new index");
 			}
 
@@ -468,7 +480,9 @@ public class EventToIndex implements AutoCloseable {
 			result = client.execute(action);
 		}
 
-		if(!result.isSucceeded()){
+		if (result == null) {
+			logEsError(action.getRestMethodName(), action.getIndex(), action.getType(), null, -1, null);
+		} else if (!result.isSucceeded()){
 			logEsError(action.getRestMethodName(), action.getIndex(), action.getType(), result.getJsonString(), result.getResponseCode(), result.getErrorMessage());
 		} else if(LOG.isDebugEnabled()) {
 			logEsDebug(action.getRestMethodName(), action.getIndex(), action.getType(), result.getJsonString(), result.getResponseCode(), result.getErrorMessage());

--- a/features/opennms-es-rest/main-module/src/main/java/org/opennms/plugins/elasticsearch/rest/EventToIndex.java
+++ b/features/opennms-es-rest/main-module/src/main/java/org/opennms/plugins/elasticsearch/rest/EventToIndex.java
@@ -290,8 +290,7 @@ public class EventToIndex implements AutoCloseable {
 		return jestClient;
 	}
 
-	@Override
-	public void close(){
+	private void closeJestClient() {
 		if (jestClient != null) {
 			synchronized(this){
 				try{
@@ -302,6 +301,11 @@ public class EventToIndex implements AutoCloseable {
 				jestClient = null;
 			}
 		}
+	}
+
+	@Override
+	public void close(){
+		closeJestClient();
 
 		// Shutdown the thread pool
 		executor.shutdown();
@@ -416,7 +420,7 @@ public class EventToIndex implements AutoCloseable {
 				} catch (Throwable ex){
 					LOG.error("Unexpected problem sending event to Elasticsearch", ex);
 					// Shutdown the ES client, it will be recreated as needed
-					close();
+					closeJestClient();
 				}
 			}
 		}

--- a/features/opennms-es-rest/main-module/src/main/java/org/opennms/plugins/elasticsearch/rest/RestClientFactory.java
+++ b/features/opennms-es-rest/main-module/src/main/java/org/opennms/plugins/elasticsearch/rest/RestClientFactory.java
@@ -91,8 +91,8 @@ public class RestClientFactory {
 				timeoutTracker.startAttempt();
 				try {
 					return m_delegate.execute(clientRequest);
-				} catch (Throwable e) {
-					LOG.warn("Exception while trying to execute REST operation", e);
+				} catch (Exception e) {
+					LOG.warn("Exception while trying to execute REST operation (attempt {})", timeoutTracker.getAttempt() + 1, e);
 				}
 			}
 			return null;

--- a/features/opennms-es-rest/main-module/src/main/resources/OSGI-INF/blueprint/mainModuleBlueprint.xml
+++ b/features/opennms-es-rest/main-module/src/main/resources/OSGI-INF/blueprint/mainModuleBlueprint.xml
@@ -29,8 +29,9 @@
       <cm:property name="archiveAlarmChangeEvents" value="true" />
       <cm:property name="archiveOldAlarmValues" value="true" />
       <cm:property name="archiveNewAlarmValues" value="true" />
-      <cm:property name="timeout" value="5000" /> <!-- 5 second timeout for Elasticsearch operations -->
+      <cm:property name="timeout" value="3000" /> <!-- 3 second timeout for Elasticsearch operations -->
       <cm:property name="retries" value="0" /> <!-- Disable retries by default -->
+      <cm:property name="socketTimeout" value="3000" /> <!-- 3 second timeout for Elasticsearch socket reads -->
       <cm:property name="batchSize" value="1" /> <!-- Disable batching by default -->
       <cm:property name="batchInterval" value="0" /> <!-- Disable batching by default -->
       <cm:property name="threads" value="0" /> <!-- Use the default number of threads -->
@@ -74,6 +75,7 @@
     <argument value="${espassword}" />
     <property name="timeout" value="${timeout}" />
     <property name="retries" value="${retries}" />
+    <property name="socketTimeout" value="${socketTimeout}" />
   </bean>
 
 

--- a/features/opennms-es-rest/main-module/src/main/resources/OSGI-INF/blueprint/mainModuleBlueprint.xml
+++ b/features/opennms-es-rest/main-module/src/main/resources/OSGI-INF/blueprint/mainModuleBlueprint.xml
@@ -29,6 +29,8 @@
       <cm:property name="archiveAlarmChangeEvents" value="true" />
       <cm:property name="archiveOldAlarmValues" value="true" />
       <cm:property name="archiveNewAlarmValues" value="true" />
+      <cm:property name="timeout" value="5000" /> <!-- 5 second timeout for Elasticsearch operations -->
+      <cm:property name="retries" value="0" /> <!-- Disable retries by default -->
       <cm:property name="batchSize" value="1" /> <!-- Disable batching by default -->
       <cm:property name="batchInterval" value="0" /> <!-- Disable batching by default -->
       <cm:property name="threads" value="0" /> <!-- Use the default number of threads -->
@@ -70,6 +72,8 @@
     <argument value="${elasticsearchUrl}" />
     <argument value="${esusername}" />
     <argument value="${espassword}" />
+    <property name="timeout" value="${timeout}" />
+    <property name="retries" value="${retries}" />
   </bean>
 
 

--- a/opennms-doc/guide-admin/src/asciidoc/text/plugins/opennms-es-rest.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/plugins/opennms-es-rest.adoc
@@ -25,19 +25,21 @@ With the following properties (defaults shown will be used if file is not presen
 
 [options="header, autowidth"]
 |===
-| Parameter                 | Default               | Description
-|`elasticsearchUrl`         | http://localhost:9200 | URL of _Elasticsearch_ ReST interface
-|`esusername`               |                       | Username to access _Elasticsearch_
-|`espassword`               |                       | Username to access _Elasticsearch_
-|`logEventDescription`      | true                  | Whether to forward the event description field to _Elasticsearch_. It can be disabled because it contains a long text field that can be redundant with the rest of the metadata included in the event.
-|`archiveRawEvents`         | true                  | Archive events.
-|`archiveAlarms`            | true                  | Archive alarms.
-|`archiveAlarmChangeEvents` | true                  | Archive alarm change events.
-|`archiveOldAlarmValues`    | true                  | For alarm change events, we can choose to archive the detailed alarm values but this is expensive. Set false in production.
-|`archiveNewAlarmValues`    | true                  | 
-|`logAllEvents`             | false                 | If changed to true, then archive all events even if they have not been persisted in the OpenNMS database.
-|`batchSize`                | 1                     | Increase this value to enable batch inserts into Elasticsearch. This is the maximum size of a batch of events that is sent to Elasticsearch in a single connection.
-|`batchInterval`            | 0                     | This value specifies the maximum time interval between batch events (recommended: 500ms).
+| Parameter                 | Default Value         | Required | Description
+|`elasticsearchUrl`         | http://localhost:9200 | optional | URL of _Elasticsearch_ ReST interface. This value can also contain a comma-separated list of URLs that will be used in round-robin fashion for increased scalability.
+|`esusername`               |                       | optional | Username to access _Elasticsearch_.
+|`espassword`               |                       | optional | Password to access _Elasticsearch_.
+|`logEventDescription`      | true                  | optional | Whether to forward the event description field to _Elasticsearch_. It can be disabled because it contains a long text field that can be redundant with the rest of the metadata included in the event.
+|`archiveRawEvents`         | true                  | optional | Archive events.
+|`archiveAlarms`            | true                  | optional | Archive alarms.
+|`archiveAlarmChangeEvents` | true                  | optional | Archive alarm change events.
+|`archiveOldAlarmValues`    | true                  | optional | For alarm change events, we can choose to archive the detailed alarm values but this is expensive. Set false in production.
+|`archiveNewAlarmValues`    | true                  | optional | 
+|`logAllEvents`             | false                 | optional | If changed to true, then archive all events even if they have not been persisted in the OpenNMS database.
+|`retries`                  | 0                     | optional | The number of times to retry an _Elasticsearch_ operation that fails completely. You can increase `retries` to avoid losing forwarded events and alarms when _Elasticsearch_ is down or unreachable.
+|`timeout`                  | 5000                  | optional | The interval between subsequent retries when a `retries` value greater than 1 is being used.
+|`batchSize`                | 1                     | optional | Increase this value to enable batch inserts into _Elasticsearch_. This is the maximum size of a batch of events that is sent to _Elasticsearch_ in a single connection.
+|`batchInterval`            | 0                     | optional | The maximum time interval in milliseconds between batch events (recommended: 500ms) when a `batchSize` value greater than 1 is being used.
 |===
 
 Once you are sure everything is correctly configured, you can activate the _Elasticsearch_ forwarder by logging into the _OSGi_ console and installing the feature.

--- a/smoke-test/src/test/java/org/opennms/smoketest/minion/SyslogKafkaElasticsearch5OutageTest.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/minion/SyslogKafkaElasticsearch5OutageTest.java
@@ -1,0 +1,190 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2016 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2016 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+package org.opennms.smoketest.minion;
+
+import static com.jayway.awaitility.Awaitility.await;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertTrue;
+
+import java.net.InetSocketAddress;
+import java.util.Date;
+import java.util.Timer;
+import java.util.TimerTask;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.Test;
+import org.opennms.core.criteria.CriteriaBuilder;
+import org.opennms.netmgt.dao.hibernate.MinionDaoHibernate;
+import org.opennms.netmgt.model.minion.OnmsMinion;
+import org.opennms.smoketest.utils.DaoUtils;
+import org.opennms.test.system.api.AbstractTestEnvironment;
+import org.opennms.test.system.api.NewTestEnvironment.ContainerAlias;
+import org.opennms.test.system.api.TestEnvironmentBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.util.concurrent.RateLimiter;
+import com.spotify.docker.client.DockerClient;
+import com.spotify.docker.client.exceptions.DockerException;
+import com.spotify.docker.client.messages.ContainerInfo;
+
+/**
+ * This test will send syslog messages over the following message bus:
+ * 
+ * Minion -> Kafka -> OpenNMS Eventd -> Elasticsearch REST -> Elasticsearch 5
+ * 
+ * and will restart the Elasticsearch system several times to ensure that
+ * no messages are lost.
+ * 
+ * @author Seth
+ */
+public class SyslogKafkaElasticsearch5OutageTest extends AbstractSyslogTest {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SyslogKafkaElasticsearch5OutageTest.class);
+
+    @Override
+    protected TestEnvironmentBuilder getEnvironmentBuilder() {
+        TestEnvironmentBuilder builder = super.getEnvironmentBuilder();
+        // Enable Elasticsearch 5
+        return builder.es5();
+    }
+
+    @Test
+    public void testMinionSyslogsOverKafkaToEsRest() throws Exception {
+        Date startOfTest = new Date();
+        int numMessages = 10000;
+        int packetsPerSecond = 250;
+
+        InetSocketAddress minionSshAddr = testEnvironment.getServiceAddress(ContainerAlias.MINION, 8201);
+        InetSocketAddress opennmsSshAddr = testEnvironment.getServiceAddress(ContainerAlias.OPENNMS, 8101);
+        InetSocketAddress kafkaAddress = testEnvironment.getServiceAddress(ContainerAlias.KAFKA, 9092);
+        InetSocketAddress zookeeperAddress = testEnvironment.getServiceAddress(ContainerAlias.KAFKA, 2181);
+
+        // Install the Kafka syslog and trap handlers on the Minion system
+        installFeaturesOnMinion(minionSshAddr, kafkaAddress);
+
+        // Install the Kafka and Elasticsearch features on the OpenNMS system
+        installFeaturesOnOpenNMS(opennmsSshAddr, kafkaAddress, zookeeperAddress, true);
+
+        final String sender = testEnvironment.getContainerInfo(ContainerAlias.SNMPD).networkSettings().ipAddress();
+
+        // Wait for the minion to show up
+        await().atMost(90, SECONDS).pollInterval(5, SECONDS)
+            .until(DaoUtils.countMatchingCallable(
+                 this.daoFactory.getDao(MinionDaoHibernate.class),
+                 new CriteriaBuilder(OnmsMinion.class)
+                     .gt("lastUpdated", startOfTest)
+                     .eq("location", "MINION")
+                     .toCriteria()
+                 ),
+                 is(1)
+             );
+
+        LOG.info("Warming up syslog routes by sending 100 packets");
+
+        // Warm up the routes
+        sendMessage(ContainerAlias.MINION, sender, 100);
+
+        for (int i = 0; i < 10; i++) {
+            LOG.info("Slept for " + i + " seconds");
+            Thread.sleep(1000);
+        }
+
+        LOG.info("Resetting statistics");
+        resetRouteStatistics(opennmsSshAddr, minionSshAddr);
+
+        for (int i = 0; i < 20; i++) {
+            LOG.info("Slept for " + i + " seconds");
+            Thread.sleep(1000);
+        }
+
+        // Make sure that this evenly divides into the numMessages
+        final int chunk = 250;
+        // Make sure that this is an even multiple of chunk
+        final int logEvery = 1000;
+
+        int count = 0;
+        long start = System.currentTimeMillis();
+
+        AtomicInteger restartCounter = new AtomicInteger();
+
+        // Start a timer that occasionally restarts Elasticsearch
+        Timer restarter = new Timer("Elasticsearch-Restarter", true);
+        restarter.scheduleAtFixedRate(new TimerTask() {
+            @Override
+            public void run() {
+                final DockerClient docker = ((AbstractTestEnvironment)testEnvironment).getDockerClient();
+                final String id = testEnvironment.getContainerInfo(ContainerAlias.ELASTICSEARCH_5).id();
+                try {
+                    LOG.info("Restarting container: {}", id);
+                    docker.restartContainer(id);
+                    restartCounter.incrementAndGet();
+                    LOG.info("Container restarted: {}", id);
+                } catch (DockerException | InterruptedException e) {
+                    LOG.warn("Unexpected exception while restarting container {}", id, e);
+                }
+            }
+        }, 0L, TimeUnit.SECONDS.toMillis(29));
+
+        // Send ${numMessages} syslog messages
+        RateLimiter limiter = RateLimiter.create(packetsPerSecond);
+        for (int i = 0; i < (numMessages / chunk); i++) {
+            limiter.acquire(chunk);
+            sendMessage(ContainerAlias.MINION, sender, chunk);
+            count += chunk;
+            if (count % logEvery == 0) {
+                long mid = System.currentTimeMillis();
+                LOG.info(String.format("Sent %d packets in %d milliseconds", logEvery, mid - start));
+                start = System.currentTimeMillis();
+            }
+        }
+
+        // Stop restarting Elasticsearch
+        restarter.cancel();
+
+        // 100 warm-up messages plus ${numMessages} messages
+        pollForElasticsearchEventsUsingJest(this::getEs5Address, 100 + numMessages);
+
+        assertTrue("Elasticsearch was never restarted", restartCounter.get() > 0);
+    }
+
+    protected InetSocketAddress getEs5Address() {
+        try {
+            // Fetch an up-to-date ContainerInfo for the ELASTICSEARCH_5 container
+            final DockerClient docker = ((AbstractTestEnvironment)testEnvironment).getDockerClient();
+            final String id = testEnvironment.getContainerInfo(ContainerAlias.ELASTICSEARCH_5).id();
+            ContainerInfo info = docker.inspectContainer(id);
+            return testEnvironment.getServiceAddress(info, 9200, "tcp"); 
+        } catch (DockerException | InterruptedException e) {
+            LOG.error("Unexpected exception trying to fetch Elassticsearch port", e);
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
These changes fix exception handling in the ```opennms-es-rest``` feature and add ```timeout``` and ```retries``` configuration params so that ES operations can be retried if the connection to the ES cluster fails.

The commits also include an enhancement to handle multiple ES URLs by providing a comma-separated list of URLs.

* JIRA: http://issues.opennms.org/browse/NMS-9197
* JIRA: http://issues.opennms.org/browse/NMS-9210