### PR TITLE
Create 19.1.0 changelog

### DIFF
--- a/core/schema/src/main/liquibase/19.1.0/changelog.xml
+++ b/core/schema/src/main/liquibase/19.1.0/changelog.xml
@@ -5,7 +5,7 @@
   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd" >
 
   <!-- NMS-9146: Assure that the Default location exists in the database -->
-  <changeSet author="cpape" id="19.0.2-assure-default-location-exists">
+  <changeSet author="cpape" id="19.1.0-assure-default-location-exists">
     <preConditions onFail="MARK_RAN">
       <sqlCheck expectedResult="0">
         SELECT COUNT(id) FROM monitoringlocations WHERE id='Default';
@@ -18,7 +18,7 @@
   </changeSet>
 
   <!-- NMS-9146: Check for references to blank locations and associate them to the Default location -->
-  <changeSet author="cpape" id="19.0.2-fix-empty-locations-in-node-table">
+  <changeSet author="cpape" id="19.1.0-fix-empty-locations-in-node-table">
     <preConditions onFail="MARK_RAN">
       <sqlCheck expectedResult="1">
         select
@@ -36,7 +36,7 @@
   </changeSet>
 
   <!-- NMS-9146: Check for references to blank locations and associate them to the Default location -->
-  <changeSet author="cpape" id="19.0.2-fix-empty-locations-in-collectionpackages-table">
+  <changeSet author="cpape" id="19.1.0-fix-empty-locations-in-collectionpackages-table">
     <preConditions onFail="MARK_RAN">
       <sqlCheck expectedResult="1">
         select
@@ -54,7 +54,7 @@
   </changeSet>
 
   <!-- NMS-9146: Check for references to blank locations and associate them to the Default location -->
-  <changeSet author="cpape" id="19.0.2-fix-empty-locations-in-pollingpackages-table">
+  <changeSet author="cpape" id="19.1.0-fix-empty-locations-in-pollingpackages-table">
     <preConditions onFail="MARK_RAN">
       <sqlCheck expectedResult="1">
         select
@@ -72,7 +72,7 @@
   </changeSet>
 
   <!-- NMS-9146: Check for references to blank locations and associate them to the Default location -->
-  <changeSet author="cpape" id="19.0.2-fix-empty-locations-in-tags-table">
+  <changeSet author="cpape" id="19.1.0-fix-empty-locations-in-tags-table">
     <preConditions onFail="MARK_RAN">
       <sqlCheck expectedResult="1">
         select
@@ -90,7 +90,7 @@
   </changeSet>
 
   <!-- NMS-9146: Check for references to blank locations and associate them to the Default location -->
-  <changeSet author="cpape" id="19.0.2-fix-empty-locations-in-scanreports-table">
+  <changeSet author="cpape" id="19.1.0-fix-empty-locations-in-scanreports-table">
     <preConditions onFail="MARK_RAN">
       <sqlCheck expectedResult="1">
         select
@@ -108,7 +108,7 @@
   </changeSet>
 
   <!-- NMS-9146: Remove ON DELETE CASCADE for the location foreign key constraint in the node table -->
-  <changeSet author="cpape" id="19.0.2-remove-on-delete-cascade">
+  <changeSet author="cpape" id="19.1.0-remove-on-delete-cascade">
     <!-- Drop existing foreign key constraints -->
     <dropForeignKeyConstraint baseTableName="node" constraintName="fk_node_location"/>
     <!-- Recreate the foreign key constraint without using onDelete="CASCADE" -->
@@ -116,7 +116,7 @@
   </changeSet>
 
   <!-- NMS-9146: Double check that nothing is associated with the blank location before deleting it -->
-  <changeSet author="cpape" id="19.0.2-delete-blank-location">
+  <changeSet author="cpape" id="19.1.0-delete-blank-location">
     <preConditions onFail="MARK_RAN">
       <sqlCheck expectedResult="0">
         select

--- a/core/schema/src/main/liquibase/changelog.xml
+++ b/core/schema/src/main/liquibase/changelog.xml
@@ -76,7 +76,7 @@
 	<include file="17.0.0/changelog.xml"/>
 	<include file="18.0.0/changelog.xml"/>
 	<include file="19.0.0/changelog.xml"/>
-	<include file="19.0.2/changelog.xml"/>
+	<include file="19.1.0/changelog.xml"/>
 
 	<include file="stored-procedures/getManagePercentAvailIntfWindow.xml" />
 	<include file="stored-procedures/getManagePercentAvailNodeWindow.xml" />


### PR DESCRIPTION
Since we're bumping the version to 19.1.0, this PR changes the name of the liquibase changelog accordingly.