### PR TITLE
Use java.nio.charset.StandardCharsets

### DIFF
--- a/checkstyle/src/main/resources/nms_checks.xml
+++ b/checkstyle/src/main/resources/nms_checks.xml
@@ -14,5 +14,10 @@
             <property name="forbiddenImportsExcludesRegexp" value="" />
             <message key="forbid.certain.imports" value="Use ''java.nio.charset.StandardCharsets'' instead of ''{0}''" />
         </module>
+        <module name="IllegalTokenText">
+            <property name="tokens" value="STRING_LITERAL"/>
+            <property name="format" value="^UTF-8$"/>
+            <message key="forbid.UTF8.string.literal" value="Use ''java.nio.charset.StandardCharsets.UTF_8.name()'' instead of ''{0}''" />
+        </module>
     </module>
 </module>

--- a/core/api/src/main/java/org/opennms/core/network/IpListFromUrl.java
+++ b/core/api/src/main/java/org/opennms/core/network/IpListFromUrl.java
@@ -34,6 +34,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -93,7 +94,7 @@ public abstract class IpListFromUrl {
 
             // check to see if the file exists
             if (stream != null) {
-                isr = new InputStreamReader(stream, "UTF-8");
+                isr = new InputStreamReader(stream, StandardCharsets.UTF_8);
                 br = new BufferedReader(isr);
 
                 String ipLine = null;

--- a/core/db-install/src/main/java/org/opennms/core/db/install/InstallerDb.java
+++ b/core/db-install/src/main/java/org/opennms/core/db/install/InstallerDb.java
@@ -37,6 +37,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.PrintStream;
 import java.io.Reader;
+import java.nio.charset.StandardCharsets;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -51,7 +52,6 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.regex.Matcher;
@@ -180,7 +180,7 @@ public class InstallerDb {
      * @throws java.lang.Exception if any.
      */
     public void readTables() throws Exception {
-        readTables(new InputStreamReader(new FileInputStream(m_createSqlLocation), "UTF-8"));
+        readTables(new InputStreamReader(new FileInputStream(m_createSqlLocation), StandardCharsets.UTF_8));
     }
 
     /**
@@ -547,7 +547,7 @@ public class InstallerDb {
         		throw new Exception(message);
         	}
         	
-        	final BufferedReader in = new BufferedReader(new InputStreamReader(sqlfile, "UTF-8"));
+        	final BufferedReader in = new BufferedReader(new InputStreamReader(sqlfile, StandardCharsets.UTF_8));
         	final StringBuffer createFunction = new StringBuffer();
         	String line;
         	while ((line = in.readLine()) != null) {
@@ -612,7 +612,7 @@ public class InstallerDb {
 
             m_out.print("\n  - " + element.getName() + "... ");
 
-            final BufferedReader r = new BufferedReader(new InputStreamReader(new FileInputStream(element), "UTF-8"));
+            final BufferedReader r = new BufferedReader(new InputStreamReader(new FileInputStream(element), StandardCharsets.UTF_8));
             while ((line = r.readLine()) != null) {
                 line = line.trim();
 

--- a/core/icmp-jna/src/main/java/org/opennms/jicmp/standalone/V4PingReply.java
+++ b/core/icmp-jna/src/main/java/org/opennms/jicmp/standalone/V4PingReply.java
@@ -38,7 +38,7 @@ class V4PingReply extends ICMPEchoPacket implements PingReply {
     
     // The below long is equivalent to the next line and is more efficient than
     // manipulation as a string
-    // Charset.forName("US-ASCII").encode("OpenNMS!").getLong(0);
+    // StandardCharsets.US_ASCII.encode("OpenNMS!").getLong(0);
     public static final long COOKIE = 0x4F70656E4E4D5321L; 
     
     private long m_receivedTimeNanos;

--- a/core/icmp-jna/src/main/java/org/opennms/jicmp/standalone/V6PingReply.java
+++ b/core/icmp-jna/src/main/java/org/opennms/jicmp/standalone/V6PingReply.java
@@ -38,7 +38,7 @@ class V6PingReply extends ICMPv6EchoPacket implements PingReply {
     
     // The below long is equivalent to the next line and is more efficient than
     // manipulation as a string
-    // Charset.forName("US-ASCII").encode("OpenNMS!").getLong(0);
+    // StandardCharsets.US_ASCII.encode("OpenNMS!").getLong(0);
     public static final long COOKIE = 0x4F70656E4E4D5321L;
     
     private long m_receivedTimeNanos;

--- a/core/icmp-jna/src/test/java/org/opennms/jicmp/jna/BSDByteBufferTest.java
+++ b/core/icmp-jna/src/test/java/org/opennms/jicmp/jna/BSDByteBufferTest.java
@@ -28,24 +28,26 @@
 
 package org.opennms.jicmp.jna;
 
-import static org.junit.Assert.*;
-import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 
 import java.net.InetAddress;
 import java.nio.Buffer;
 import java.nio.ByteBuffer;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestName;
 
 import com.sun.jna.LastErrorException;
 import com.sun.jna.Native;
 import com.sun.jna.Platform;
 import com.sun.jna.ptr.IntByReference;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.rules.TestName;
 
 
 /**
@@ -101,7 +103,7 @@ public class BSDByteBufferTest {
         int socket = -1;
         try {
             InetAddress svrAddr = server.getInetAddress();
-            byte[] data = msg.getBytes("US-ASCII");
+            byte[] data = msg.getBytes(StandardCharsets.US_ASCII);
             String sent = msg.substring(4,7);
             ByteBuffer buf = ByteBuffer.wrap(data, 4, 3).slice();
 
@@ -133,7 +135,7 @@ public class BSDByteBufferTest {
             byte[] b = new byte[rBuf.remaining()];
             rBuf.get(b);
 
-            String results = new String(b, "US-ASCII");
+            String results = new String(b, StandardCharsets.US_ASCII);
 
             printf("Received: %s\n", results);
 

--- a/core/icmp-jna/src/test/java/org/opennms/jicmp/jna/ByteBufferTest.java
+++ b/core/icmp-jna/src/test/java/org/opennms/jicmp/jna/ByteBufferTest.java
@@ -28,24 +28,26 @@
 
 package org.opennms.jicmp.jna;
 
-import static org.junit.Assert.*;
-import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 
 import java.net.InetAddress;
 import java.nio.Buffer;
 import java.nio.ByteBuffer;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestName;
 
 import com.sun.jna.LastErrorException;
 import com.sun.jna.Native;
 import com.sun.jna.Platform;
 import com.sun.jna.ptr.IntByReference;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.rules.TestName;
 
 
 /**
@@ -83,11 +85,11 @@ public class ByteBufferTest {
     }
 
     @Test
-    public void testWrap() throws Exception {
+    public void testWrap() {
         
         String msg = "OpenNMS!";
         
-        byte[] data = msg.getBytes("US-ASCII");
+        byte[] data = msg.getBytes(StandardCharsets.US_ASCII);
 
         ByteBuffer buf = ByteBuffer.wrap(data, 2, 4);
         
@@ -108,16 +110,11 @@ public class ByteBufferTest {
          *  accessing the byte array that may or may NOT be behind it
          */
         
-        Charset ascii = Charset.forName("US-ASCII");
-
-        ByteBuffer buf = ascii.encode("OpenNMS!");
+        ByteBuffer buf = StandardCharsets.US_ASCII.encode("OpenNMS!");
         
-        String decoded = ascii.decode(buf).toString();
+        String decoded = StandardCharsets.US_ASCII.decode(buf).toString();
         
         assertThat(decoded, is(equalTo("OpenNMS!")));
-        
-        
-        
     }
     
     @Test(timeout=30000)
@@ -137,7 +134,7 @@ public class ByteBufferTest {
         int socket = -1;
         try {
             
-            byte[] data = msg.getBytes("US-ASCII");
+            byte[] data = msg.getBytes(StandardCharsets.US_ASCII);
             String sent = msg.substring(4,7);
             ByteBuffer buf = ByteBuffer.wrap(data, 4, 3).slice();
 
@@ -163,7 +160,7 @@ public class ByteBufferTest {
             byte[] b = new byte[rBuf.remaining()];
             rBuf.get(b);
             
-            String results = new String(b, "US-ASCII");
+            String results = new String(b, StandardCharsets.US_ASCII);
             
             printf("Received: %s\n", results);
             

--- a/core/icmp-jna/src/test/java/org/opennms/jicmp/jna/NativeSocketTest.java
+++ b/core/icmp-jna/src/test/java/org/opennms/jicmp/jna/NativeSocketTest.java
@@ -35,7 +35,7 @@ import java.net.DatagramPacket;
 import java.net.DatagramSocket;
 import java.net.InetAddress;
 import java.nio.ByteBuffer;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -57,7 +57,6 @@ import org.junit.rules.TestName;
 @Ignore
 public class NativeSocketTest {
 
-    private static final Charset UTF_8 = Charset.forName("UTF-8");
     private static final ExecutorService m_executor = Executors.newCachedThreadPool();
 
     Server m_server;
@@ -99,7 +98,7 @@ public class NativeSocketTest {
                     @Override public DatagramPacket call() throws Exception {
                         printf("Sending cmd: %s\n", cmd);
 
-                        final byte[] data = cmd.getBytes("UTF-8");
+                        final byte[] data = cmd.getBytes(StandardCharsets.UTF_8);
                         final DatagramPacket p = new DatagramPacket(data, data.length, InetAddress.getLocalHost(), sock.getLocalPort());
                         sock.send(p);
 
@@ -116,7 +115,7 @@ public class NativeSocketTest {
                 final DatagramPacket r = task.get(10, TimeUnit.SECONDS);
                 assertNotNull(r);
 
-                final String response = new String(r.getData(), r.getOffset(), r.getLength(), "UTF-8");
+                final String response = new String(r.getData(), r.getOffset(), r.getLength(), StandardCharsets.UTF_8);
                 printf("Received Response: %s from %s:%d\n", response, r.getAddress().getHostAddress(), r.getPort());
                 assertEquals(cmd, response);
             }
@@ -148,7 +147,7 @@ public class NativeSocketTest {
                 final FutureTask<NativeDatagramPacket> task = new FutureTask<NativeDatagramPacket>(new Callable<NativeDatagramPacket>() {
                     @Override public NativeDatagramPacket call() throws Exception {
                         printf("Sending cmd: %s\n", cmd);
-                        final ByteBuffer buf = UTF_8.encode(cmd);
+                        final ByteBuffer buf = StandardCharsets.UTF_8.encode(cmd);
                         final NativeDatagramPacket p = new NativeDatagramPacket(buf, address, m_port);
                         sock.send(p);
 
@@ -166,7 +165,7 @@ public class NativeSocketTest {
                 final NativeDatagramPacket r = task.get(10, TimeUnit.SECONDS);
                 assertNotNull(r);
 
-                final String response = UTF_8.decode(r.getContent()).toString();
+                final String response = StandardCharsets.UTF_8.decode(r.getContent()).toString();
                 printf("Received Response: %s from %s:%d\n", response, r.getAddress().getHostAddress(), r.getPort());
 
                 assertEquals(cmd, response);
@@ -183,7 +182,7 @@ public class NativeSocketTest {
         try(final NativeDatagramSocket socket = NativeDatagramSocket.create(NativeDatagramSocket.PF_INET, NativeDatagramSocket.IPPROTO_UDP, 1234)) {
             final FutureTask<NativeDatagramPacket> task = new FutureTask<NativeDatagramPacket>(new Callable<NativeDatagramPacket>() {
                 @Override public NativeDatagramPacket call() throws Exception {
-                    final ByteBuffer buf = UTF_8.encode("msg1");
+                    final ByteBuffer buf = StandardCharsets.UTF_8.encode("msg1");
                     final NativeDatagramPacket p = new NativeDatagramPacket(buf, InetAddress.getLocalHost(), m_port);
                     socket.send(p);
 
@@ -199,7 +198,7 @@ public class NativeSocketTest {
             final NativeDatagramPacket r = task.get(10, TimeUnit.SECONDS);
             assertNotNull(r);
 
-            final String response = UTF_8.decode(r.getContent()).toString();
+            final String response = StandardCharsets.UTF_8.decode(r.getContent()).toString();
             printf("Received Response: %s from %s:%d\n", response, r.getAddress().getHostAddress(), r.getPort());
         }
     }

--- a/core/icmp-jna/src/test/java/org/opennms/jicmp/jna/Server.java
+++ b/core/icmp-jna/src/test/java/org/opennms/jicmp/jna/Server.java
@@ -31,6 +31,7 @@ package org.opennms.jicmp.jna;
 import java.net.DatagramPacket;
 import java.net.DatagramSocket;
 import java.net.InetAddress;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
@@ -87,7 +88,7 @@ class Server implements Runnable {
             while (!m_stopped.get()) {
                 DatagramPacket p = new DatagramPacket(new byte[128], 128);
                 m_socket.receive(p);
-                String cmd = new String(p.getData(), p.getOffset(), p.getLength(), "UTF-8");
+                String cmd = new String(p.getData(), p.getOffset(), p.getLength(), StandardCharsets.UTF_8);
                 System.err.print(String.format("SERVER: %s\n", cmd));
                 m_socket.send(p);
                 if (cmd.startsWith("quit")) {

--- a/core/lib/src/main/java/org/opennms/core/utils/StringUtils.java
+++ b/core/lib/src/main/java/org/opennms/core/utils/StringUtils.java
@@ -36,6 +36,7 @@ import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.StringWriter;
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
@@ -217,13 +218,13 @@ public abstract class StringUtils {
         Transformer transformer  = transFactory.newTransformer();
 
         // Set options on the transformer so that it will indent the XML properly
-        transformer.setOutputProperty(OutputKeys.ENCODING, "UTF-8");
+        transformer.setOutputProperty(OutputKeys.ENCODING, StandardCharsets.UTF_8.name());
         transformer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "no");
         transformer.setOutputProperty(OutputKeys.INDENT, "yes");
         transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "2");
 
         StreamResult result = new StreamResult(out);
-        Source source = new StreamSource(new ByteArrayInputStream(xml.getBytes("UTF-8")));
+        Source source = new StreamSource(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
 
         // Run the transformer to put the XML into the StringWriter
         transformer.transform(source, result);

--- a/core/snmp/api/src/test/java/org/opennms/netmgt/snmp/AbstractSnmpValueTest.java
+++ b/core/snmp/api/src/test/java/org/opennms/netmgt/snmp/AbstractSnmpValueTest.java
@@ -32,6 +32,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 
 import org.junit.Test;
 
@@ -59,13 +60,13 @@ public class AbstractSnmpValueTest {
 		strings[3] = "56697275732f4d616c776172653a2045696361725f746573745f66696c6520436f6d70757465723a2049542d30303220446f6de46e653a2050632d6974206f686e65206669726577616c6c5c2044617465693a20473a5c6569636172202d204b6f7069655c6569636172202d204b6f7069652e746172202865696361722e636f6d2920446174756d2f5568727a6569743a2030312e31312e323031332031313a34383a34382045726765626e69733a2045732077757264652065696e20566972757320656e746465636b742e2053e4756265726e206e69636874206df6676c6963682e202851756172616e74e46e652920";
 
 		for (String string : strings) {
-			System.out.println(new String(hexStringToBytes(string), "UTF-8"));
-			System.out.println(new String(hexStringToBytes(string), "ISO-8859-1"));
+			System.out.println(new String(hexStringToBytes(string), StandardCharsets.UTF_8));
+			System.out.println(new String(hexStringToBytes(string), StandardCharsets.ISO_8859_1));
 		}
 
 		for (String string : strings) {
 			System.out.println(new String(hexStringToBytes(string)));
-			assertTrue(new String(hexStringToBytes(string), "ISO-8859-1"), AbstractSnmpValue.allBytesDisplayable(hexStringToBytes(string)));
+			assertTrue(new String(hexStringToBytes(string), StandardCharsets.ISO_8859_1), AbstractSnmpValue.allBytesDisplayable(hexStringToBytes(string)));
 		}
 	}
 

--- a/core/snmp/api/src/test/java/org/opennms/netmgt/snmp/SnmpUtilsTest.java
+++ b/core/snmp/api/src/test/java/org/opennms/netmgt/snmp/SnmpUtilsTest.java
@@ -32,6 +32,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
 import org.junit.Test;
@@ -46,10 +47,10 @@ public class SnmpUtilsTest {
 	 * @throws UnsupportedEncodingException
 	 */
 	@Test
-	public void testGetProtoCounter63Value() throws UnsupportedEncodingException {
+	public void testGetProtoCounter63Value() {
 		for (byte[] bytes : new byte[][] {
 			// Not all decimal digits
-			"abcdef01".getBytes("UTF-8"),
+			"abcdef01".getBytes(StandardCharsets.UTF_8),
 			// Highest 63-bit value
 			{ (byte)0x79, (byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff },
 			// Zero
@@ -62,15 +63,15 @@ public class SnmpUtilsTest {
 
 		for (byte[] bytes : new byte[][] {
 			// Not 8 bytes
-			"abcdef".getBytes("UTF-8"),
+			"abcdef".getBytes(StandardCharsets.UTF_8),
 			// All decimal digits
-			"01234567".getBytes("UTF-8"),
+			"01234567".getBytes(StandardCharsets.UTF_8),
 			// All decimal digits
-			"00000000".getBytes("UTF-8"),
+			"00000000".getBytes(StandardCharsets.UTF_8),
 			// All decimal digits
-			"11111111".getBytes("UTF-8"),
+			"11111111".getBytes(StandardCharsets.UTF_8),
 			// All decimal digits
-			"99999999".getBytes("UTF-8"),
+			"99999999".getBytes(StandardCharsets.UTF_8),
 			// Special case for "not supported"
 			{ (byte)0x80, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0 },
 			// 64-bit value

--- a/core/snmp/impl-mock/src/main/java/org/opennms/netmgt/snmp/mock/MockSnmpStrategy.java
+++ b/core/snmp/impl-mock/src/main/java/org/opennms/netmgt/snmp/mock/MockSnmpStrategy.java
@@ -32,6 +32,7 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.math.BigInteger;
 import java.net.InetAddress;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -247,11 +248,7 @@ public class MockSnmpStrategy implements SnmpStrategy {
     }
 
     public static void updateStringValue(final SnmpAgentAddress agentAddress, String oid, String value) {
-        try {
-            m_loaders.get(agentAddress).set(SnmpObjId.get(oid), new MockSnmpValueFactory().getOctetString(value.getBytes("UTF-8")));
-        } catch (UnsupportedEncodingException e) {
-            // Should be impossible
-        }
+        m_loaders.get(agentAddress).set(SnmpObjId.get(oid), new MockSnmpValueFactory().getOctetString(value.getBytes(StandardCharsets.UTF_8)));
     }
 
     public static void updateCounter32Value(final SnmpAgentAddress agentAddress, String oid, long value) {

--- a/core/test-api/db/src/test/java/org/opennms/core/test/db/InstallerDbIT.java
+++ b/core/test-api/db/src/test/java/org/opennms/core/test/db/InstallerDbIT.java
@@ -41,6 +41,7 @@ import java.io.InputStreamReader;
 import java.io.PrintStream;
 import java.io.StringReader;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -1800,7 +1801,7 @@ public class InstallerDbIT extends TemporaryDatabaseITCase {
 
     private void assertNoTablesHaveChanged() throws IOException {
         ByteArrayInputStream in = new ByteArrayInputStream(m_outputStream.toByteArray());
-        BufferedReader reader = new BufferedReader(new InputStreamReader(in, "UTF-8"));
+        BufferedReader reader = new BufferedReader(new InputStreamReader(in, StandardCharsets.UTF_8));
 
         String line;
         List<String> unanticipatedOutput = new ArrayList<String>();

--- a/core/test-api/lib/src/main/java/org/opennms/core/test/ConfigurationTestUtils.java
+++ b/core/test-api/lib/src/main/java/org/opennms/core/test/ConfigurationTestUtils.java
@@ -39,8 +39,8 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.io.StringReader;
-import java.io.UnsupportedEncodingException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.regex.Matcher;
 
 import org.junit.Assert;
@@ -138,13 +138,7 @@ public abstract class ConfigurationTestUtils extends Assert {
      * @return a {@link java.io.Reader} object.
      */
     public static Reader getReaderForResource(Object obj, String resource) {
-        Reader retval = null;
-        try {
-            retval = new InputStreamReader(getInputStreamForResource(obj, resource), "UTF-8");
-        } catch (UnsupportedEncodingException e) {
-            fail("Your JVM doesn't support UTF-8 encoding, which is pretty much impossible.");
-        }
-        return retval;
+        return new InputStreamReader(getInputStreamForResource(obj, resource), StandardCharsets.UTF_8);
     }
 
     /**
@@ -255,13 +249,7 @@ public abstract class ConfigurationTestUtils extends Assert {
      * @throws java.io.FileNotFoundException if any.
      */
     public static Reader getReaderForConfigFile(String configFile) throws FileNotFoundException {
-        Reader retval = null;
-        try {
-            retval = new InputStreamReader(getInputStreamForConfigFile(configFile), "UTF-8");
-        } catch (UnsupportedEncodingException e) {
-            fail("Your JVM doesn't support UTF-8 encoding, which is pretty much impossible.");
-        }
-        return retval;
+        return new InputStreamReader(getInputStreamForConfigFile(configFile), StandardCharsets.UTF_8);
     }
 
     /**

--- a/core/test-api/lib/src/main/java/org/opennms/test/FileAnticipator.java
+++ b/core/test-api/lib/src/main/java/org/opennms/test/FileAnticipator.java
@@ -34,6 +34,7 @@ import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -346,7 +347,7 @@ public class FileAnticipator extends Assert {
         PrintWriter printWriter = null;
         try {
         	out = new FileOutputStream(f);
-        	writer = new OutputStreamWriter(out, "UTF-8");
+        	writer = new OutputStreamWriter(out, StandardCharsets.UTF_8);
         	printWriter = new PrintWriter(writer);
         	printWriter.print(contents);
         } finally {

--- a/core/test-api/rest/src/main/java/org/opennms/core/test/rest/AbstractSpringJerseyRestJsonTestCase.java
+++ b/core/test-api/rest/src/main/java/org/opennms/core/test/rest/AbstractSpringJerseyRestJsonTestCase.java
@@ -34,6 +34,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 
 import javax.ws.rs.core.MediaType;
 
@@ -62,8 +63,8 @@ public abstract class AbstractSpringJerseyRestJsonTestCase extends AbstractSprin
         if (expectedUrlSuffix != null) {
             final Object header = response.getHeader("Location");
             assertNotNull("Location header is null", header);
-            final String location = URLDecoder.decode(header.toString(), "UTF-8");
-            final String decodedExpectedUrlSuffix = URLDecoder.decode(expectedUrlSuffix, "UTF-8");
+            final String location = URLDecoder.decode(header.toString(), StandardCharsets.UTF_8.name());
+            final String decodedExpectedUrlSuffix = URLDecoder.decode(expectedUrlSuffix, StandardCharsets.UTF_8.name());
             assertTrue("location '" + location + "' should end with '" + decodedExpectedUrlSuffix + "'", location.endsWith(decodedExpectedUrlSuffix));
         }
         return response;

--- a/core/test-api/rest/src/main/java/org/opennms/core/test/rest/AbstractSpringJerseyRestTestCase.java
+++ b/core/test-api/rest/src/main/java/org/opennms/core/test/rest/AbstractSpringJerseyRestTestCase.java
@@ -40,6 +40,7 @@ import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -340,8 +341,8 @@ public abstract class AbstractSpringJerseyRestTestCase {
         if (expectedUrlSuffix != null) {
             final Object header = response.getHeader("Location");
             assertNotNull("Location header is null", header);
-            final String location = URLDecoder.decode(header.toString(), "UTF-8");
-            final String decodedExpectedUrlSuffix = URLDecoder.decode(expectedUrlSuffix, "UTF-8");
+            final String location = URLDecoder.decode(header.toString(), StandardCharsets.UTF_8.name());
+            final String decodedExpectedUrlSuffix = URLDecoder.decode(expectedUrlSuffix, StandardCharsets.UTF_8.name());
             assertTrue("location '" + location + "' should end with '" + decodedExpectedUrlSuffix + "'", location.endsWith(decodedExpectedUrlSuffix));
         }
         return response;
@@ -427,7 +428,7 @@ public abstract class AbstractSpringJerseyRestTestCase {
         for (String item : data.split("&")) {
             int idx = item.indexOf("=");
             if (idx > 0) {
-                retVal.put(URLDecoder.decode(item.substring(0, idx), "UTF-8"), URLDecoder.decode(item.substring(idx + 1), "UTF-8"));
+                retVal.put(URLDecoder.decode(item.substring(0, idx), StandardCharsets.UTF_8.name()), URLDecoder.decode(item.substring(idx + 1), StandardCharsets.UTF_8.name()));
             }
         }
         return retVal;
@@ -464,7 +465,7 @@ public abstract class AbstractSpringJerseyRestTestCase {
                     }
 
                     for (final String valueEntry : valueEntries) {
-                        sb.append(URLEncoder.encode((String)key, "UTF-8")).append("=").append(URLEncoder.encode((String)valueEntry, "UTF-8")).append("&");
+                        sb.append(URLEncoder.encode((String)key, StandardCharsets.UTF_8.name())).append("=").append(URLEncoder.encode((String)valueEntry, StandardCharsets.UTF_8.name())).append("&");
                     }
                 } else {
                     LOG.warn("key was not a string! ({})", key);

--- a/core/test-api/services/src/main/java/org/opennms/netmgt/config/mock/MockDestinationPathManager.java
+++ b/core/test-api/services/src/main/java/org/opennms/netmgt/config/mock/MockDestinationPathManager.java
@@ -32,7 +32,7 @@ import java.io.ByteArrayInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 
 import org.opennms.netmgt.config.DestinationPathManager;
 /**
@@ -41,8 +41,8 @@ import org.opennms.netmgt.config.DestinationPathManager;
 
 public class MockDestinationPathManager extends DestinationPathManager {
     
-    public MockDestinationPathManager(String xmlString) throws IOException, UnsupportedEncodingException {
-        InputStream reader = new ByteArrayInputStream(xmlString.getBytes("UTF-8"));
+    public MockDestinationPathManager(String xmlString) throws IOException {
+        InputStream reader = new ByteArrayInputStream(xmlString.getBytes(StandardCharsets.UTF_8));
         parseXML(reader);
     }
 

--- a/core/test-api/services/src/main/java/org/opennms/netmgt/config/mock/MockGroupManager.java
+++ b/core/test-api/services/src/main/java/org/opennms/netmgt/config/mock/MockGroupManager.java
@@ -31,7 +31,7 @@ package org.opennms.netmgt.config.mock;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 
 import org.opennms.netmgt.config.GroupManager;
 
@@ -46,13 +46,9 @@ public class MockGroupManager extends GroupManager {
     }
 
     private void parseXML() throws IOException {
-        try {
-            InputStream reader = new ByteArrayInputStream(m_xmlString.getBytes("UTF-8"));
-            parseXml(reader);
-            updateNeeded = false;
-        } catch (UnsupportedEncodingException e) {
-            // Can't happen with UTF-8
-        }
+        InputStream reader = new ByteArrayInputStream(m_xmlString.getBytes(StandardCharsets.UTF_8));
+        parseXml(reader);
+        updateNeeded = false;
     }
 
     @Override

--- a/core/test-api/services/src/main/java/org/opennms/netmgt/config/mock/MockNotifdConfigManager.java
+++ b/core/test-api/services/src/main/java/org/opennms/netmgt/config/mock/MockNotifdConfigManager.java
@@ -31,6 +31,7 @@ package org.opennms.netmgt.config.mock;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 
 import org.opennms.netmgt.config.NotifdConfigManager;
 
@@ -52,7 +53,7 @@ public class MockNotifdConfigManager extends NotifdConfigManager {
      * @throws IOException
      */
     public MockNotifdConfigManager(String configString) throws IOException {
-        InputStream reader = new ByteArrayInputStream(configString.getBytes("UTF-8"));
+        InputStream reader = new ByteArrayInputStream(configString.getBytes(StandardCharsets.UTF_8));
         parseXml(reader);
         reader.close();
     }

--- a/core/test-api/services/src/main/java/org/opennms/netmgt/config/mock/MockNotificationCommandManager.java
+++ b/core/test-api/services/src/main/java/org/opennms/netmgt/config/mock/MockNotificationCommandManager.java
@@ -30,7 +30,7 @@ package org.opennms.netmgt.config.mock;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 
 import org.opennms.netmgt.config.NotificationCommandManager;
 
@@ -41,11 +41,7 @@ import org.opennms.netmgt.config.NotificationCommandManager;
 public class MockNotificationCommandManager extends NotificationCommandManager {
 
     public MockNotificationCommandManager(String xmlString) throws IOException {
-        try {
-            parseXML(new ByteArrayInputStream(xmlString.getBytes("UTF-8")));
-        } catch (UnsupportedEncodingException e) {
-            // This will never happen; all JVMs support UTF-8
-        }
+        parseXML(new ByteArrayInputStream(xmlString.getBytes(StandardCharsets.UTF_8)));
     }
 
     @Override

--- a/core/upgrade/src/main/java/org/opennms/upgrade/implementations/DiscoveryConfigurationLocationMigratorOffline.java
+++ b/core/upgrade/src/main/java/org/opennms/upgrade/implementations/DiscoveryConfigurationLocationMigratorOffline.java
@@ -32,6 +32,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
 
 import javax.xml.parsers.DocumentBuilder;
@@ -129,7 +130,7 @@ public class DiscoveryConfigurationLocationMigratorOffline extends AbstractOnmsU
             updateLocations(doc, "specific");
 
             final Transformer tf = TransformerFactory.newInstance().newTransformer();
-            tf.setOutputProperty(OutputKeys.ENCODING, "UTF-8");
+            tf.setOutputProperty(OutputKeys.ENCODING, StandardCharsets.UTF_8.name());
             tf.setOutputProperty(OutputKeys.INDENT, "yes");
             out = new StringWriter();
             tf.transform(new DOMSource(doc), new StreamResult(out));

--- a/core/upgrade/src/main/java/org/opennms/upgrade/implementations/DiscoveryConfigurationMigratorOffline.java
+++ b/core/upgrade/src/main/java/org/opennms/upgrade/implementations/DiscoveryConfigurationMigratorOffline.java
@@ -32,6 +32,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
 
 import javax.xml.parsers.DocumentBuilder;
@@ -91,7 +92,7 @@ public class DiscoveryConfigurationMigratorOffline extends AbstractOnmsUpgrade {
                 final Element el = (Element)found.item(0);
                 el.removeAttribute("threads");
                 final Transformer tf = TransformerFactory.newInstance().newTransformer();
-                tf.setOutputProperty(OutputKeys.ENCODING, "UTF-8");
+                tf.setOutputProperty(OutputKeys.ENCODING, StandardCharsets.UTF_8.name());
                 tf.setOutputProperty(OutputKeys.INDENT, "yes");
                 out = new StringWriter();
                 tf.transform(new DOMSource(doc), new StreamResult(out));

--- a/core/upgrade/src/main/java/org/opennms/upgrade/implementations/RequisitionsMigratorOffline.java
+++ b/core/upgrade/src/main/java/org/opennms/upgrade/implementations/RequisitionsMigratorOffline.java
@@ -31,6 +31,8 @@ package org.opennms.upgrade.implementations;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
+import java.nio.charset.StandardCharsets;
+
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.opennms.core.utils.ConfigFileConstants;
@@ -138,11 +140,11 @@ public class RequisitionsMigratorOffline extends AbstractOnmsUpgrade {
         try {
             for (File req : FileUtils.listFiles(getRequisitionDir(), new String[]{"xml"}, true)) {
                 log("Processing %s\n", req);
-                String content = IOUtils.toString(new FileInputStream(req), "UTF-8");
+                String content = IOUtils.toString(new FileInputStream(req), StandardCharsets.UTF_8);
                 String output = content.replaceAll(" non-ip-(snmp-primary|interfaces)=\"[^\"]+\"", "");
                 if (content.length() != output.length()) {
                     log("  Updating and parsing the requisition\n", req);
-                    IOUtils.write(output, new FileOutputStream(req), "UTF-8");
+                    IOUtils.write(output, new FileOutputStream(req), StandardCharsets.UTF_8);
                     Requisition requisition = JaxbUtils.unmarshal(Requisition.class, req, true);
                     if (requisition == null) {
                         throw new OnmsUpgradeException("Can't parse requisition " + req);

--- a/core/xml/src/main/java/org/opennms/core/xml/JaxbUtils.java
+++ b/core/xml/src/main/java/org/opennms/core/xml/JaxbUtils.java
@@ -41,6 +41,7 @@ import java.io.StringReader;
 import java.io.StringWriter;
 import java.io.Writer;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -125,7 +126,7 @@ public abstract class JaxbUtils {
         String xmlString = marshal(obj);
 
         if (xmlString != null) {
-            Writer fileWriter = new OutputStreamWriter(new FileOutputStream(file), "UTF-8");
+            Writer fileWriter = new OutputStreamWriter(new FileOutputStream(file), StandardCharsets.UTF_8);
             fileWriter.write(xmlString);
             fileWriter.flush();
             fileWriter.close();
@@ -311,7 +312,7 @@ public abstract class JaxbUtils {
                 context = jaxbContext;
             }
             final Marshaller marshaller = context.createMarshaller();
-            marshaller.setProperty(Marshaller.JAXB_ENCODING, "UTF-8");
+            marshaller.setProperty(Marshaller.JAXB_ENCODING, StandardCharsets.UTF_8.name());
             marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
             marshaller.setProperty(Marshaller.JAXB_FRAGMENT, true);
             if (context.getClass().getName().startsWith("org.eclipse.persistence.jaxb")) {

--- a/features/datachoices/src/main/java/org/opennms/features/datachoices/internal/UsageStatisticsReporter.java
+++ b/features/datachoices/src/main/java/org/opennms/features/datachoices/internal/UsageStatisticsReporter.java
@@ -29,6 +29,7 @@
 package org.opennms.features.datachoices.internal;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Timer;
 import java.util.TimerTask;
 
@@ -130,7 +131,7 @@ public class UsageStatisticsReporter implements StateChangeHandler {
                     .useSystemProxySettings();
             try (CloseableHttpClient client = clientWrapper.getClient()) {
                 HttpPost httpRequest = new HttpPost(m_url + USAGE_REPORT);
-                httpRequest.setEntity(new StringEntity(usageStatsReportJson, ContentType.create("application/json", "UTF-8")));
+                httpRequest.setEntity(new StringEntity(usageStatsReportJson, ContentType.create("application/json", StandardCharsets.UTF_8)));
                 LOG.info("Sending usage statistics report to {}: {}", httpRequest.getURI(), usageStatsReportJson);
                 client.execute(httpRequest);
                 LOG.info("Succesfully sent usage statistics report.");

--- a/features/events/api/src/main/java/org/opennms/netmgt/events/api/support/TcpEventProxy.java
+++ b/features/events/api/src/main/java/org/opennms/netmgt/events/api/support/TcpEventProxy.java
@@ -39,6 +39,7 @@ import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.net.UnknownHostException;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import org.opennms.core.utils.InetAddressUtils;
 import org.opennms.core.xml.JaxbUtils;
@@ -165,7 +166,7 @@ public final class TcpEventProxy implements EventProxy {
             m_sock.setSoTimeout(500);
             LOG.debug("Default Charset: {}", Charset.defaultCharset().displayName());
             LOG.debug("Setting Charset: UTF-8");
-            m_writer = new OutputStreamWriter(new BufferedOutputStream(m_sock.getOutputStream()), Charset.forName("UTF-8"));
+            m_writer = new OutputStreamWriter(new BufferedOutputStream(m_sock.getOutputStream()), StandardCharsets.UTF_8);
             m_input = m_sock.getInputStream();
             m_rdrThread = new Thread("TcpEventProxy Input Discarder") {
                 @Override

--- a/features/events/daemon/src/main/java/org/opennms/netmgt/eventd/adaptors/tcp/TcpStreamHandler.java
+++ b/features/events/daemon/src/main/java/org/opennms/netmgt/eventd/adaptors/tcp/TcpStreamHandler.java
@@ -39,6 +39,7 @@ import java.io.StringWriter;
 import java.io.Writer;
 import java.net.InetAddress;
 import java.net.Socket;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
@@ -375,7 +376,7 @@ final class TcpStreamHandler implements Runnable {
                 if (hasReceipt) {
                     // Transform it to XML and send it to the socket in one call
                     try {
-                    	final Writer writer = new BufferedWriter(new OutputStreamWriter(m_connection.getOutputStream(), "UTF-8"));
+                    	final Writer writer = new BufferedWriter(new OutputStreamWriter(m_connection.getOutputStream(), StandardCharsets.UTF_8));
                     	JaxbUtils.marshal(receipt, writer);
                         writer.flush();
 

--- a/features/events/daemon/src/main/java/org/opennms/netmgt/eventd/adaptors/udp/UdpReceivedEvent.java
+++ b/features/events/daemon/src/main/java/org/opennms/netmgt/eventd/adaptors/udp/UdpReceivedEvent.java
@@ -30,9 +30,9 @@ package org.opennms.netmgt.eventd.adaptors.udp;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
-import java.io.UnsupportedEncodingException;
 import java.net.DatagramPacket;
 import java.net.InetAddress;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -89,12 +89,8 @@ final class UdpReceivedEvent {
      * 
      * @param packet
      *            The datagram received from the remote agent.
-     * 
-     * @throws java.io.UnsupportedEncodingException
-     *             Thrown if the data buffer cannot be decoded using the
-     *             US-ASCII encoding.
      */
-    static UdpReceivedEvent make(DatagramPacket packet) throws UnsupportedEncodingException {
+    static UdpReceivedEvent make(DatagramPacket packet) {
         return make(packet.getAddress(), packet.getPort(), packet.getData(), packet.getLength());
     }
 
@@ -111,16 +107,12 @@ final class UdpReceivedEvent {
      *            The XML data in US-ASCII encoding.
      * @param len
      *            The length of the XML data in the buffer.
-     * 
-     * @throws java.io.UnsupportedEncodingException
-     *             Thrown if the data buffer cannot be decoded using the
-     *             US-ASCII encoding.
      */
-    static UdpReceivedEvent make(InetAddress addr, int port, byte[] data, int len) throws UnsupportedEncodingException {
+    static UdpReceivedEvent make(InetAddress addr, int port, byte[] data, int len) {
         UdpReceivedEvent e = new UdpReceivedEvent();
         e.m_sender = addr;
         e.m_port = port;
-        e.m_eventXML = new String(Arrays.copyOf(data, data.length), 0, len, "US-ASCII");
+        e.m_eventXML = new String(Arrays.copyOf(data, data.length), 0, len, StandardCharsets.US_ASCII);
         e.m_ackEvents = new ArrayList<Event>(16);
         e.m_log = null;
         return e;

--- a/features/events/daemon/src/main/java/org/opennms/netmgt/eventd/adaptors/udp/UdpReceiver.java
+++ b/features/events/daemon/src/main/java/org/opennms/netmgt/eventd/adaptors/udp/UdpReceiver.java
@@ -30,7 +30,6 @@ package org.opennms.netmgt.eventd.adaptors.udp;
 
 import java.io.IOException;
 import java.io.InterruptedIOException;
-import java.io.UnsupportedEncodingException;
 import java.net.DatagramPacket;
 import java.net.DatagramSocket;
 import java.net.SocketException;
@@ -174,16 +173,12 @@ class UdpReceiver implements Runnable {
                 break;
             }
 
-            try {
-                LOG.debug("Sending received packet to processor");
+            LOG.debug("Sending received packet to processor");
 
-                UdpReceivedEvent re = UdpReceivedEvent.make(pkt);
-                synchronized (m_eventsIn) {
-                    m_eventsIn.add(re);
-                    m_eventsIn.notify();
-                }
-            } catch (UnsupportedEncodingException e) {
-                LOG.warn("Failed to convert received XML event, discarding", e);
+            UdpReceivedEvent re = UdpReceivedEvent.make(pkt);
+            synchronized (m_eventsIn) {
+                m_eventsIn.add(re);
+                m_eventsIn.notify();
             }
 
             pkt = new DatagramPacket(buffer, length);

--- a/features/events/daemon/src/main/java/org/opennms/netmgt/eventd/adaptors/udp/UdpUuidSender.java
+++ b/features/events/daemon/src/main/java/org/opennms/netmgt/eventd/adaptors/udp/UdpUuidSender.java
@@ -33,6 +33,7 @@ import java.io.StringWriter;
 import java.io.UnsupportedEncodingException;
 import java.net.DatagramPacket;
 import java.net.DatagramSocket;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -203,7 +204,7 @@ final class UdpUuidSender implements Runnable {
 
                 String xml = writer.getBuffer().toString();
                 try {
-                    byte[] xml_bytes = xml.getBytes("US-ASCII");
+                    byte[] xml_bytes = xml.getBytes(StandardCharsets.US_ASCII);
                     DatagramPacket pkt = new DatagramPacket(xml_bytes, xml_bytes.length, re.getSender(), re.getPort());
 
                     LOG.debug("Transmitting receipt to destination {}:{}", InetAddressUtils.str(re.getSender()), re.getPort());
@@ -225,8 +226,6 @@ final class UdpUuidSender implements Runnable {
                         LOG.debug(xml);
                         LOG.debug("}");
                     }
-                } catch (UnsupportedEncodingException e) {
-                    LOG.warn("Failed to convert XML to byte array", e);
                 } catch (IOException e) {
                     LOG.warn("Failed to send packet to host {}:{}", InetAddressUtils.str(re.getSender()), re.getPort(), e);
                 }

--- a/features/events/syslog/src/main/java/org/opennms/netmgt/syslogd/ConvertToEvent.java
+++ b/features/events/syslog/src/main/java/org/opennms/netmgt/syslogd/ConvertToEvent.java
@@ -30,9 +30,9 @@ package org.opennms.netmgt.syslogd;
 
 import static org.opennms.core.utils.InetAddressUtils.str;
 
-import java.io.UnsupportedEncodingException;
 import java.net.DatagramPacket;
 import java.net.InetAddress;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
 import java.util.regex.Matcher;
@@ -101,9 +101,6 @@ public class ConvertToEvent {
      * into a string using the <tt>US-ASCII</tt> character encoding.
      *
      * @param packet The datagram received from the remote agent.
-     * @throws java.io.UnsupportedEncodingException
-     *          Thrown if the data buffer cannot be decoded using the
-     *          US-ASCII encoding.
      * @throws MessageDiscardedException 
      */
     public ConvertToEvent(
@@ -111,8 +108,8 @@ public class ConvertToEvent {
         final String location,
         final DatagramPacket packet,
         final SyslogdConfig config
-    ) throws UnsupportedEncodingException, MessageDiscardedException {
-        this(systemId, location, packet.getAddress(), packet.getPort(), new String(packet.getData(), 0, packet.getLength(), "US-ASCII"), config);
+    ) throws MessageDiscardedException {
+        this(systemId, location, packet.getAddress(), packet.getPort(), new String(packet.getData(), 0, packet.getLength(), StandardCharsets.US_ASCII), config);
     }
 
     /**
@@ -124,9 +121,6 @@ public class ConvertToEvent {
      * @param port The remote agent's port
      * @param data The XML data in US-ASCII encoding.
      * @param len  The length of the XML data in the buffer.
-     * @throws java.io.UnsupportedEncodingException
-     *          Thrown if the data buffer cannot be decoded using the
-     *          US-ASCII encoding.
      * @throws MessageDiscardedException 
      */
     public ConvertToEvent(
@@ -136,7 +130,7 @@ public class ConvertToEvent {
         final int port,
         final String data,
         final SyslogdConfig config
-    ) throws UnsupportedEncodingException, MessageDiscardedException {
+    ) throws MessageDiscardedException {
 
         if (config == null) {
             throw new IllegalArgumentException("Config cannot be null");

--- a/features/events/syslog/src/main/java/org/opennms/netmgt/syslogd/SyslogSinkConsumer.java
+++ b/features/events/syslog/src/main/java/org/opennms/netmgt/syslogd/SyslogSinkConsumer.java
@@ -128,8 +128,6 @@ public class SyslogSinkConsumer implements MessageConsumer<SyslogConnection, Sys
                         syslogdConfig
                     );
                 events.addEvent(re.getEvent());
-            } catch (final UnsupportedEncodingException e) {
-                LOG.info("Failure to convert package", e);
             } catch (final MessageDiscardedException e) {
                 LOG.info("Message discarded, returning without enqueueing event.", e);
             } catch (final Throwable e) {

--- a/features/events/syslog/src/test/java/org/opennms/netmgt/syslogd/ConvertToEventTest.java
+++ b/features/events/syslog/src/test/java/org/opennms/netmgt/syslogd/ConvertToEventTest.java
@@ -33,7 +33,6 @@ import static org.junit.Assert.fail;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.UnsupportedEncodingException;
 import java.net.DatagramPacket;
 import java.net.InetAddress;
 import java.nio.ByteBuffer;
@@ -261,7 +260,7 @@ public class ConvertToEventTest {
                 assertTrue("service parms do not match", compare("service", services.toArray(new String[0])));
                 assertTrue("processid parms do not match", compare("processid", processids.toArray(new String[0])));
                 assertTrue("parm counts do not match", compare("parm count", parmcounts.toArray(new Long[0])));
-            } catch (UnsupportedEncodingException e) {
+            } catch (Throwable e) {
                 e.printStackTrace();
                 fail("Unexpected exception: " + e.getMessage());
             }
@@ -271,7 +270,7 @@ public class ConvertToEventTest {
         results.stream().forEach(System.out::println);
     }
 
-    private static Event parseSyslog(final String name, final SyslogdConfig config, final String syslog) throws UnsupportedEncodingException {
+    private static Event parseSyslog(final String name, final SyslogdConfig config, final String syslog) {
         try {
             ConvertToEvent convert = new ConvertToEvent(
                 DistPollerDao.DEFAULT_DIST_POLLER_ID,

--- a/features/geocoder/nominatim/src/main/java/org/opennms/features/geocoder/nominatim/NominatimGeocoderService.java
+++ b/features/geocoder/nominatim/src/main/java/org/opennms/features/geocoder/nominatim/NominatimGeocoderService.java
@@ -31,6 +31,7 @@ package org.opennms.features.geocoder.nominatim;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import net.simon04.jelementtree.ElementTree;
@@ -113,7 +114,7 @@ public class NominatimGeocoderService implements GeocoderService {
 
     private String getUrl(final String geolocation) throws GeocoderException {
         try {
-            return GEOCODE_URL + "&email=" + URLEncoder.encode(geolocation, "UTF-8") + "&q=" + URLEncoder.encode(geolocation, "UTF-8");
+            return GEOCODE_URL + "&email=" + URLEncoder.encode(geolocation, StandardCharsets.UTF_8.name()) + "&q=" + URLEncoder.encode(geolocation, StandardCharsets.UTF_8.name());
         } catch (final UnsupportedEncodingException e) {
             throw new GeocoderException("unable to URL-encode query string", e);
         }

--- a/features/jdbc-collector/src/test/java/org/opennms/netmgt/config/jdbc/JdbcDataCollectionConfigTest.java
+++ b/features/jdbc-collector/src/test/java/org/opennms/netmgt/config/jdbc/JdbcDataCollectionConfigTest.java
@@ -37,6 +37,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import javax.xml.bind.JAXBContext;
@@ -146,7 +147,7 @@ public class JdbcDataCollectionConfigTest {
         StringBuffer exampleXML = new StringBuffer();
         File jdbcCollectionConfig = new File(ClassLoader.getSystemResource("jdbc-datacollection-config.xml").getFile());
         assertTrue("jdbc-datacollection-config.xml is readable", jdbcCollectionConfig.canRead());
-        BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream(jdbcCollectionConfig), "UTF-8"));
+        BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream(jdbcCollectionConfig), StandardCharsets.UTF_8));
         String line;
         while (true) {
             line = reader.readLine();

--- a/features/juniper-tca-collector/src/test/java/org/opennms/netmgt/collectd/tca/config/TcaDataCollectionConfigTest.java
+++ b/features/juniper-tca-collector/src/test/java/org/opennms/netmgt/collectd/tca/config/TcaDataCollectionConfigTest.java
@@ -38,6 +38,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import javax.xml.bind.JAXBContext;
@@ -179,7 +180,7 @@ public class TcaDataCollectionConfigTest {
 		StringBuffer exampleXML = new StringBuffer();
 		File tcaCollectionConfig = getSourceFile();
 		assertTrue(TcaDataCollectionConfig.TCA_DATACOLLECTION_CONFIG_FILE + " is readable", tcaCollectionConfig.canRead());
-		BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream(tcaCollectionConfig), "UTF-8"));
+		BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream(tcaCollectionConfig), StandardCharsets.UTF_8));
 		String line;
 		while (true) {
 			line = reader.readLine();

--- a/features/ncs/ncs-alarm-gui/src/test/java/org/opennms/web/controller/ncs/NCSListFormattingTest.java
+++ b/features/ncs/ncs-alarm-gui/src/test/java/org/opennms/web/controller/ncs/NCSListFormattingTest.java
@@ -32,6 +32,7 @@ import static org.junit.Assert.assertEquals;
 
 import java.io.ByteArrayOutputStream;
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.Set;
 
 import javax.xml.bind.JAXBContext;
@@ -203,7 +204,7 @@ public class NCSListFormattingTest {
         
     }
     
-    private void printJaxbXML(NCSComponent svc) throws JAXBException, UnsupportedEncodingException {
+    private void printJaxbXML(NCSComponent svc) throws JAXBException {
         JAXBContext context = JAXBContext.newInstance(NCSComponent.class);
         Marshaller marshaller = context.createMarshaller();
         marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
@@ -217,7 +218,7 @@ public class NCSListFormattingTest {
         // verify its matches the expected results
         byte[] utf8 = out.toByteArray();
 
-        String result = new String(utf8, "UTF-8");
+        String result = new String(utf8, StandardCharsets.UTF_8);
         
         System.err.println(result);
     }

--- a/features/ncs/ncs-drools/src/test/java/org/opennms/netmgt/correlation/ncs/ImpactProgagationRulesIT.java
+++ b/features/ncs/ncs-drools/src/test/java/org/opennms/netmgt/correlation/ncs/ImpactProgagationRulesIT.java
@@ -33,6 +33,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.opennms.core.utils.InetAddressUtils.addr;
 
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -199,7 +200,7 @@ public class ImpactProgagationRulesIT extends CorrelationRulesITCase {
 //        // verify its matches the expected results
 //        byte[] utf8 = out.toByteArray();
 //
-//        String result = new String(utf8, "UTF-8");
+//        String result = new String(utf8, StandardCharsets.UTF_8);
 //        
 //        System.err.println(result);
 

--- a/features/ncs/ncs-model/src/test/java/org/opennms/netmgt/model/ncs/JAXBTest.java
+++ b/features/ncs/ncs-model/src/test/java/org/opennms/netmgt/model/ncs/JAXBTest.java
@@ -34,6 +34,7 @@ import static org.opennms.core.test.xml.XmlTest.assertXmlEquals;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.Marshaller;
@@ -289,7 +290,7 @@ public class JAXBTest {
 		// verify its matches the expected results
 		byte[] utf8 = out.toByteArray();
 
-		String result = new String(utf8, "UTF-8");
+		String result = new String(utf8, StandardCharsets.UTF_8);
 		assertXmlEquals(expectedXML, result);
 		
 		System.err.println(result);
@@ -314,7 +315,7 @@ public class JAXBTest {
 		ByteArrayOutputStream reout = new ByteArrayOutputStream();
 		marshaller.marshal(read, reout);
 		
-		String roundTrip = new String(reout.toByteArray(), "UTF-8");
+		String roundTrip = new String(reout.toByteArray(), StandardCharsets.UTF_8);
 		
 		assertXmlEquals(expectedXML, roundTrip);
 	}

--- a/features/ncs/ncs-northbounder/src/test/java/org/opennms/netmgt/ncs/northbounder/transfer/MarshallTest.java
+++ b/features/ncs/ncs-northbounder/src/test/java/org/opennms/netmgt/ncs/northbounder/transfer/MarshallTest.java
@@ -34,6 +34,7 @@ import static org.junit.Assert.assertNotNull;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -134,7 +135,7 @@ public class MarshallTest {
 		byte[] utf8 = marshallToUTF8(notification);
 		
 		
-		String result = new String(utf8, "UTF-8");
+		String result = new String(utf8, StandardCharsets.UTF_8);
 		assertEquals(expectedXML, result);
 		
 		System.err.println(result);

--- a/features/poller/monitors/core/src/main/java/org/opennms/netmgt/poller/monitors/BSFMonitor.java
+++ b/features/poller/monitors/core/src/main/java/org/opennms/netmgt/poller/monitors/BSFMonitor.java
@@ -33,6 +33,7 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -184,7 +185,7 @@ public class BSFMonitor extends AbstractServiceMonitor {
             }
             
             if(file.exists() && file.canRead()){   
-                    String code = IOUtils.getStringFromReader(new InputStreamReader(new FileInputStream(file), "UTF-8"));
+                    String code = IOUtils.getStringFromReader(new InputStreamReader(new FileInputStream(file), StandardCharsets.UTF_8));
                     HashMap<String,String> results = new HashMap<String,String>();
                     LinkedHashMap<String,Number> times = new LinkedHashMap<String,Number>();
                     

--- a/features/poller/monitors/core/src/main/java/org/opennms/netmgt/poller/monitors/HttpPostMonitor.java
+++ b/features/poller/monitors/core/src/main/java/org/opennms/netmgt/poller/monitors/HttpPostMonitor.java
@@ -31,6 +31,7 @@ package org.opennms.netmgt.poller.monitors;
 import java.io.InputStream;
 import java.net.InetAddress;
 import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
 import java.nio.charset.UnsupportedCharsetException;
 import java.util.Map;
 
@@ -86,7 +87,7 @@ final public class HttpPostMonitor extends AbstractServiceMonitor {
     private static final int DEFAULT_TIMEOUT = 3000;
 
     public static final String DEFAULT_MIMETYPE = "text/xml";
-    public static final String DEFAULT_CHARSET = "utf-8";
+    public static final String DEFAULT_CHARSET = StandardCharsets.UTF_8.name();
     public static final String DEFAULT_URI = "/";
     public static final String DEFAULT_SCHEME = "http";
     public static final boolean DEFAULT_SSLFILTER = false;

--- a/features/poller/monitors/core/src/main/java/org/opennms/netmgt/poller/monitors/MemcachedMonitor.java
+++ b/features/poller/monitors/core/src/main/java/org/opennms/netmgt/poller/monitors/MemcachedMonitor.java
@@ -38,6 +38,7 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.NoRouteToHostException;
 import java.net.Socket;
+import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -122,7 +123,7 @@ final public class MemcachedMonitor extends AbstractServiceMonitor {
                 // We're connected, so upgrade status to unresponsive
                 serviceStatus = PollStatus.unresponsive();
 
-                OutputStreamWriter osw = new OutputStreamWriter(socket.getOutputStream(), "UTF-8");
+                OutputStreamWriter osw = new OutputStreamWriter(socket.getOutputStream(), StandardCharsets.UTF_8);
                 osw.write("stats\n");
                 osw.flush();
 

--- a/features/poller/monitors/core/src/main/java/org/opennms/netmgt/poller/monitors/PageSequenceMonitor.java
+++ b/features/poller/monitors/core/src/main/java/org/opennms/netmgt/poller/monitors/PageSequenceMonitor.java
@@ -29,13 +29,12 @@
 package org.opennms.netmgt.poller.monitors;
 
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.net.Inet4Address;
 import java.net.InetAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.UnknownHostException;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -230,13 +229,8 @@ public class PageSequenceMonitor extends AbstractServiceMonitor {
 
         @Override
         public void setQueryParameters(final List<NameValuePair> parms) {
-            try {
-                final UrlEncodedFormEntity entity = new UrlEncodedFormEntity(parms, "UTF-8");
-                this.setEntity(entity);
-            } catch (final UnsupportedEncodingException e) {
-                // Should never happen
-                LOG.debug("Unsupported encoding", e);
-            }
+            final UrlEncodedFormEntity entity = new UrlEncodedFormEntity(parms, StandardCharsets.UTF_8);
+            this.setEntity(entity);
         }
     }
 
@@ -251,9 +245,9 @@ public class PageSequenceMonitor extends AbstractServiceMonitor {
             URI uri = this.getURI();
             URI uriWithQueryString = null;
             try {
-                String query = URLEncodedUtils.format(parms, "UTF-8");
+                String query = URLEncodedUtils.format(parms, StandardCharsets.UTF_8);
                 URIBuilder ub = new URIBuilder(uri);
-                final List<NameValuePair> params = URLEncodedUtils.parse(query, Charset.forName("UTF-8"));
+                final List<NameValuePair> params = URLEncodedUtils.parse(query, StandardCharsets.UTF_8);
                 if (!params.isEmpty()) {
                     ub.setParameters(params);
                 }
@@ -498,7 +492,7 @@ public class PageSequenceMonitor extends AbstractServiceMonitor {
             ub.setHost(host);
             ub.setPort(getPort());
             ub.setPath(getPath(seqProps, svcProps));
-            final List<NameValuePair> params = URLEncodedUtils.parse(getQuery(seqProps, svcProps), Charset.forName("UTF-8"));
+            final List<NameValuePair> params = URLEncodedUtils.parse(getQuery(seqProps, svcProps), StandardCharsets.UTF_8);
             if (!params.isEmpty()) {
                 ub.setParameters(params);
             }

--- a/features/poller/monitors/core/src/main/java/org/opennms/netmgt/poller/monitors/WebMonitor.java
+++ b/features/poller/monitors/core/src/main/java/org/opennms/netmgt/poller/monitors/WebMonitor.java
@@ -30,7 +30,7 @@ package org.opennms.netmgt.poller.monitors;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
 import java.util.List;
 import java.util.Map;
@@ -89,7 +89,7 @@ public class WebMonitor extends AbstractServiceMonitor {
 
             String queryString = ParameterMap.getKeyedString(map,"queryString",null);
             if (queryString != null && !queryString.trim().isEmpty()) {
-                final List<NameValuePair> params = URLEncodedUtils.parse(queryString, Charset.forName("UTF-8"));
+                final List<NameValuePair> params = URLEncodedUtils.parse(queryString, StandardCharsets.UTF_8);
                 if (!params.isEmpty()) {
                     ub.setParameters(params);
                 }

--- a/features/poller/monitors/core/src/test/java/org/opennms/netmgt/poller/monitors/MailTransportMonitorTest.java
+++ b/features/poller/monitors/core/src/test/java/org/opennms/netmgt/poller/monitors/MailTransportMonitorTest.java
@@ -35,6 +35,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.InetAddress;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.InvalidPropertiesFormatException;
 import java.util.Map;
@@ -130,7 +131,7 @@ public class MailTransportMonitorTest {
                 .append("<entry key=\"foo\">1</entry>\n") 
                 .append("<entry key=\"fu\">baz</entry>\n") 
                 .append("</properties>");
-        InputStream stream = new ByteArrayInputStream(reader.toString().getBytes("UTF-8"));
+        InputStream stream = new ByteArrayInputStream(reader.toString().getBytes(StandardCharsets.UTF_8));
         props.loadFromXML(stream);
         assertEquals("1", props.get("foo"));
     }

--- a/features/poller/monitors/core/src/test/java/org/opennms/netmgt/poller/monitors/PageSequenceMonitorOpenNMSTest.java
+++ b/features/poller/monitors/core/src/test/java/org/opennms/netmgt/poller/monitors/PageSequenceMonitorOpenNMSTest.java
@@ -33,6 +33,7 @@ import static org.junit.Assert.assertTrue;
 import java.io.InputStreamReader;
 import java.io.LineNumberReader;
 import java.net.InetAddress;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -97,7 +98,7 @@ public class PageSequenceMonitorOpenNMSTest {
         LineNumberReader in = new LineNumberReader(
             new InputStreamReader(
                 Thread.currentThread().getContextClassLoader().getResourceAsStream("opennmsPageSequence.xml"),
-                "UTF-8"
+                StandardCharsets.UTF_8
             )
         );
         String line;

--- a/features/remote-poller-gwt/src/main/java/org/opennms/features/poller/remote/gwt/server/geocoding/MapquestGeocoder.java
+++ b/features/remote-poller-gwt/src/main/java/org/opennms/features/poller/remote/gwt/server/geocoding/MapquestGeocoder.java
@@ -31,6 +31,7 @@ package org.opennms.features.poller.remote.gwt.server.geocoding;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import net.simon04.jelementtree.ElementTree;
@@ -149,7 +150,7 @@ public class MapquestGeocoder implements Geocoder {
 
 	private String getUrl(String geolocation) throws GeocoderException {
 		try {
-			return GEOCODE_URL + "&key=" + m_apiKey + "&location=" + URLEncoder.encode(geolocation, "UTF-8");
+			return GEOCODE_URL + "&key=" + m_apiKey + "&location=" + URLEncoder.encode(geolocation, StandardCharsets.UTF_8.name());
 		} catch (UnsupportedEncodingException e) {
 			throw new GeocoderException("unable to URL-encode query string", e);
 		}

--- a/features/remote-poller-gwt/src/main/java/org/opennms/features/poller/remote/gwt/server/geocoding/NominatimGeocoder.java
+++ b/features/remote-poller-gwt/src/main/java/org/opennms/features/poller/remote/gwt/server/geocoding/NominatimGeocoder.java
@@ -31,6 +31,7 @@ package org.opennms.features.poller.remote.gwt.server.geocoding;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import net.simon04.jelementtree.ElementTree;
@@ -119,7 +120,7 @@ public class NominatimGeocoder implements Geocoder {
 
 	private String getUrl(String geolocation) throws GeocoderException {
 		try {
-			return GEOCODE_URL + "&q=" + URLEncoder.encode(geolocation, "UTF-8");
+			return GEOCODE_URL + "&q=" + URLEncoder.encode(geolocation, StandardCharsets.UTF_8.name());
 		} catch (UnsupportedEncodingException e) {
 			throw new GeocoderException("unable to URL-encode query string", e);
 		}

--- a/features/reporting/availability/src/main/java/org/opennms/reporting/availability/AvailabilityCalculatorImpl.java
+++ b/features/reporting/availability/src/main/java/org/opennms/reporting/availability/AvailabilityCalculatorImpl.java
@@ -34,6 +34,7 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Date;
@@ -316,7 +317,7 @@ public class AvailabilityCalculatorImpl implements AvailabilityCalculator {
                 @Override
                 public Void call() throws Exception {
                     try {
-                        Writer fileWriter = new OutputStreamWriter(new FileOutputStream(outputFile), "UTF-8");
+                        Writer fileWriter = new OutputStreamWriter(new FileOutputStream(outputFile), StandardCharsets.UTF_8);
                         JaxbUtils.marshal(m_report, fileWriter);
                         LOG.debug("The xml marshalled from the JAXB classes is saved in {}", outputFile.getAbsoluteFile());
                         fileWriter.close();
@@ -339,7 +340,7 @@ public class AvailabilityCalculatorImpl implements AvailabilityCalculator {
                 @Override
                 public Void call() throws Exception {
                     try {
-                        OutputStreamWriter writer = new OutputStreamWriter(outputStream, "UTF-8");
+                        OutputStreamWriter writer = new OutputStreamWriter(outputStream, StandardCharsets.UTF_8);
                         JaxbUtils.marshal(m_report, writer);
                         LOG.debug("The xml marshalled from the JAXB classes has been written to the output stream");
                         writer.flush();

--- a/features/reporting/availability/src/main/java/org/opennms/reporting/availability/AvailabilityReport.java
+++ b/features/reporting/availability/src/main/java/org/opennms/reporting/availability/AvailabilityReport.java
@@ -38,6 +38,7 @@ import java.io.OutputStreamWriter;
 import java.io.Reader;
 import java.io.Writer;
 import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.GregorianCalendar;
@@ -212,7 +213,7 @@ public class AvailabilityReport extends Object {
         File file = new File(ConfigFileConstants.getHome()
                              + "/share/reports/AvailReport.xml");
         try {
-            Writer fileWriter = new OutputStreamWriter(new FileOutputStream(file), "UTF-8");
+            Writer fileWriter = new OutputStreamWriter(new FileOutputStream(file), StandardCharsets.UTF_8);
             JaxbUtils.marshal(m_report, fileWriter);
             LOG.debug("The xml marshalled from the JAXB classes is saved in {}/share/reports/AvailReport.xml", ConfigFileConstants.getHome());
             fileWriter.close();
@@ -240,11 +241,11 @@ public class AvailabilityReport extends Object {
                                      + "/share/reports/AvailReport.xml");
                 try {
                     LOG.debug("The xml marshalled from the JAXB classes is saved in {}/share/reports/AvailReport.xml", ConfigFileConstants.getHome());
-                    Reader fileReader = new InputStreamReader(new FileInputStream(file), "UTF-8");
+                    Reader fileReader = new InputStreamReader(new FileInputStream(file), StandardCharsets.UTF_8);
                     if (!format.equals("HTML")) {
-                        new PDFReportRenderer().render(fileReader, out, new InputStreamReader(new FileInputStream(xsltFileName), "UTF-8"));
+                        new PDFReportRenderer().render(fileReader, out, new InputStreamReader(new FileInputStream(xsltFileName), StandardCharsets.UTF_8));
                     } else {
-                        new HTMLReportRenderer().render(fileReader, out, new InputStreamReader(new FileInputStream(xsltFileName), "UTF-8"));
+                        new HTMLReportRenderer().render(fileReader, out, new InputStreamReader(new FileInputStream(xsltFileName), StandardCharsets.UTF_8));
                     }
                 } catch (Throwable e) {
                     LOG.error("Exception", e);

--- a/features/reporting/availability/src/main/java/org/opennms/reporting/availability/render/HTMLReportRenderer.java
+++ b/features/reporting/availability/src/main/java/org/opennms/reporting/availability/render/HTMLReportRenderer.java
@@ -36,6 +36,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.Reader;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.Callable;
 
 import javax.xml.transform.OutputKeys;
@@ -120,9 +121,9 @@ public class HTMLReportRenderer implements ReportRenderer {
                     FileInputStream in = null, xslt = null;
                     try {
                         in = new FileInputStream(xsltResource.getFile());
-                        Reader xsl = new InputStreamReader(in, "UTF-8");
+                        Reader xsl = new InputStreamReader(in, StandardCharsets.UTF_8);
                         xslt = new FileInputStream(inputFileName);
-                        Reader xml = new InputStreamReader(xslt, "UTF-8");
+                        Reader xml = new InputStreamReader(xslt, StandardCharsets.UTF_8);
 
                         render(xml, outputStream, xsl);
                     } finally {
@@ -152,8 +153,8 @@ public class HTMLReportRenderer implements ReportRenderer {
                     Reader xml = null;
                     try {
                         xslt = new FileInputStream(xsltResource.getFile());
-                        xsl = new InputStreamReader(xslt, "UTF-8");
-                        xml = new InputStreamReader(inputStream, "UTF-8");
+                        xsl = new InputStreamReader(xslt, StandardCharsets.UTF_8);
+                        xml = new InputStreamReader(inputStream, StandardCharsets.UTF_8);
                         render(xml, outputStream, xsl);
                         return null;
                     } finally {
@@ -184,9 +185,9 @@ public class HTMLReportRenderer implements ReportRenderer {
                     try {
 
                         xslt = new FileInputStream(xsltResource.getFile());
-                        xsl = new InputStreamReader(xslt, "UTF-8");
+                        xsl = new InputStreamReader(xslt, StandardCharsets.UTF_8);
                         in = new FileInputStream(m_baseDir + "/" + inputFileName);
-                        xml = new InputStreamReader(in, "UTF-8");
+                        xml = new InputStreamReader(in, StandardCharsets.UTF_8);
 
                         out = new FileOutputStream(new File(m_baseDir + "/" + outputFileName));
 
@@ -219,7 +220,7 @@ public class HTMLReportRenderer implements ReportRenderer {
         try {
             TransformerFactory tfact = TransformerFactory.newInstance();
             Transformer transformer = tfact.newTransformer(new StreamSource(xslt));
-            transformer.setOutputProperty(OutputKeys.ENCODING, "UTF-8");
+            transformer.setOutputProperty(OutputKeys.ENCODING, StandardCharsets.UTF_8.name());
             transformer.transform(new StreamSource(in), new StreamResult(out));
         } catch (final Exception e) {
             if (e instanceof ReportRenderException) throw (ReportRenderException)e;

--- a/features/reporting/availability/src/main/java/org/opennms/reporting/availability/render/PDFReportRenderer.java
+++ b/features/reporting/availability/src/main/java/org/opennms/reporting/availability/render/PDFReportRenderer.java
@@ -36,6 +36,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.Reader;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.Callable;
 
 import javax.xml.transform.OutputKeys;
@@ -121,9 +122,9 @@ public class PDFReportRenderer implements ReportRenderer {
                         LOG.debug("Rendering {} with XSL File {} to OutputStream", inputFileName, xsltResource.getDescription());
     
                         in = new FileInputStream(xsltResource.getFile());
-                        xsl = new InputStreamReader(in, "UTF-8");
+                        xsl = new InputStreamReader(in, StandardCharsets.UTF_8);
                         xslt = new FileInputStream(inputFileName);
-                        xml = new InputStreamReader(xslt, "UTF-8");
+                        xml = new InputStreamReader(xslt, StandardCharsets.UTF_8);
             
                         render(xml, outputStream, xsl);
                         return null;
@@ -153,8 +154,8 @@ public class PDFReportRenderer implements ReportRenderer {
                     Reader xsl = null, xml = null;
                     try {
                         xslt = new FileInputStream(xsltResource.getFile());
-                        xsl = new InputStreamReader(xslt, "UTF-8");
-                        xml = new InputStreamReader(inputStream, "UTF-8");
+                        xsl = new InputStreamReader(xslt, StandardCharsets.UTF_8);
+                        xml = new InputStreamReader(inputStream, StandardCharsets.UTF_8);
             
                         render(xml, outputStream, xsl);
                         return null;
@@ -184,9 +185,9 @@ public class PDFReportRenderer implements ReportRenderer {
                     try {
             
                         xslt = new FileInputStream(xsltResource.getFile());
-                        xsl = new InputStreamReader(xslt, "UTF-8");
+                        xsl = new InputStreamReader(xslt, StandardCharsets.UTF_8);
                         in = new FileInputStream(m_baseDir + "/" + inputFileName);
-                        xml = new InputStreamReader(in, "UTF-8");
+                        xml = new InputStreamReader(in, StandardCharsets.UTF_8);
             
                         out = new FileOutputStream(new File(m_baseDir + "/" + outputFileName));
                         
@@ -223,7 +224,7 @@ public class PDFReportRenderer implements ReportRenderer {
 
             final TransformerFactory tfact = TransformerFactory.newInstance();
             final Transformer transformer = tfact.newTransformer(new StreamSource(xslt));
-            transformer.setOutputProperty(OutputKeys.ENCODING, "UTF-8");
+            transformer.setOutputProperty(OutputKeys.ENCODING, StandardCharsets.UTF_8.name());
             final StreamSource streamSource = new StreamSource(in);
             transformer.transform(streamSource, new SAXResult(fop.getDefaultHandler()));
         } catch (final Exception e) {

--- a/features/reporting/availability/src/test/java/org/opennms/reporting/availability/AvailabilityReportIT.java
+++ b/features/reporting/availability/src/test/java/org/opennms/reporting/availability/AvailabilityReportIT.java
@@ -33,6 +33,7 @@ import java.io.InputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.lang.reflect.UndeclaredThrowableException;
+import java.nio.charset.StandardCharsets;
 import java.util.Calendar;
 import java.util.GregorianCalendar;
 import java.util.Locale;
@@ -234,7 +235,7 @@ public class AvailabilityReportIT extends TestCase {
         
         assertNotNull("report", report);
 
-        Writer fileWriter = new OutputStreamWriter(System.out, "UTF-8");
+        Writer fileWriter = new OutputStreamWriter(System.out, StandardCharsets.UTF_8);
         JaxbUtils.marshal(report, fileWriter);
 
         Categories categories = report.getCategories();

--- a/features/reporting/availability/src/test/java/org/opennms/reporting/availability/render/PDFReportRendererTest.java
+++ b/features/reporting/availability/src/test/java/org/opennms/reporting/availability/render/PDFReportRendererTest.java
@@ -30,6 +30,7 @@ package org.opennms.reporting.availability.render;
 
 import java.io.FileOutputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 
 import junit.framework.TestCase;
 
@@ -39,12 +40,12 @@ public class PDFReportRendererTest extends TestCase {
                 new InputStreamReader(
                         // This is a freely-licensed sample XSL-FO document from IBM developerWorks
                         Thread.currentThread().getContextClassLoader().getResourceAsStream("org/opennms/reporting/availability/render/currency.fo"), 
-                        "UTF-8"
+                        StandardCharsets.UTF_8
                 ),
                 new FileOutputStream("target/sampleDocument.pdf"),
                 new InputStreamReader(
                         Thread.currentThread().getContextClassLoader().getResourceAsStream("org/opennms/reporting/availability/render/identity.xsl"), 
-                        "UTF-8"
+                        StandardCharsets.UTF_8
                 )
         );
     }

--- a/features/request-tracker/src/main/java/org/opennms/netmgt/rt/RequestTracker.java
+++ b/features/request-tracker/src/main/java/org/opennms/netmgt/rt/RequestTracker.java
@@ -32,7 +32,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -100,13 +100,8 @@ public class RequestTracker {
         params.add(new BasicNameValuePair("pass", m_password));
         params.add(new BasicNameValuePair("content", content));
 
-        try {
-            UrlEncodedFormEntity entity = new UrlEncodedFormEntity(params, "UTF-8");
-            post.setEntity(entity);
-        } catch (final UnsupportedEncodingException e) {
-            // Should never happen
-            LOG.warn("unsupported encoding exception for UTF-8 -- WTF?!", e);
-        }
+        UrlEncodedFormEntity entity = new UrlEncodedFormEntity(params, StandardCharsets.UTF_8);
+        post.setEntity(entity);
 
         CloseableHttpResponse response = null;
         try {
@@ -240,7 +235,7 @@ public class RequestTracker {
         params.add(new BasicNameValuePair("query", "Queue='" + queueName + "' AND Status='open'"));
         params.add(new BasicNameValuePair("format", "i"));
         params.add(new BasicNameValuePair("orderby", "-id"));
-        final HttpGet get = new HttpGet(m_baseURL + "/REST/1.0/search/ticket?" + URLEncodedUtils.format(params, "UTF-8"));
+        final HttpGet get = new HttpGet(m_baseURL + "/REST/1.0/search/ticket?" + URLEncodedUtils.format(params, StandardCharsets.UTF_8));
 
         final List<RTTicket> tickets = new ArrayList<RTTicket>();
         final List<Long> ticketIds = new ArrayList<Long>();
@@ -477,7 +472,7 @@ public class RequestTracker {
             CloseableHttpResponse response = null;
 
             try {
-                UrlEncodedFormEntity entity = new UrlEncodedFormEntity(params, "UTF-8");
+                UrlEncodedFormEntity entity = new UrlEncodedFormEntity(params, StandardCharsets.UTF_8);
                 post.setEntity(entity);
 
                 response = m_clientWrapper.execute(post);
@@ -490,8 +485,6 @@ public class RequestTracker {
                     }
                     LOG.warn("got user session for username: {}", m_user);
                 }
-            } catch (final UnsupportedEncodingException e) {
-                LOG.warn("unsupported encoding exception for UTF-8 -- WTF?!", e);
             } catch (final Exception e) {
                 LOG.warn("Unable to get session (by requesting user details)", e);
             } finally {

--- a/features/springframework-security/src/test/java/org/opennms/web/springframework/security/LdapAuthTest.java
+++ b/features/springframework-security/src/test/java/org/opennms/web/springframework/security/LdapAuthTest.java
@@ -34,6 +34,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
@@ -171,12 +172,12 @@ public class LdapAuthTest implements InitializingBean {
         return request;
     }
     
-    private MockHttpServletRequest createRequest(String requestType, String urlPath, String user, String passwd) throws UnsupportedEncodingException {
+    private MockHttpServletRequest createRequest(String requestType, String urlPath, String user, String passwd) {
         MockHttpServletRequest request = createRequest(requestType, urlPath);
         
         String token = user + ":"  + passwd;
-        byte[] encodedToken = Base64.encodeBase64(token.getBytes("UTF-8"));
-        request.addHeader("Authorization", "Basic " + new String(encodedToken, "UTF-8"));
+        byte[] encodedToken = Base64.encodeBase64(token.getBytes(StandardCharsets.UTF_8));
+        request.addHeader("Authorization", "Basic " + new String(encodedToken, StandardCharsets.UTF_8));
 
         return request;
     }

--- a/features/topology-map/org.opennms.features.topology.api/src/main/java/org/opennms/features/topology/api/support/SavedHistory.java
+++ b/features/topology-map/org.opennms.features.topology.api/src/main/java/org/opennms/features/topology/api/support/SavedHistory.java
@@ -29,6 +29,7 @@
 package org.opennms.features.topology.api.support;
 
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -140,51 +141,31 @@ public class SavedHistory {
         // Add a CRC of all of the key-value pairs in m_settings to make the fragment unique
         CRC32 settingsCrc = new CRC32();
         for (Map.Entry<String,String> entry : m_settings.entrySet()) {
-            try {
-                settingsCrc.update(entry.getKey().getBytes("UTF-8"));
-                settingsCrc.update(entry.getValue().getBytes("UTF-8"));
-            } catch (UnsupportedEncodingException e) {
-                // Impossible on modern JVMs
-                LOG.error(e.getMessage(), e);
-            }
+            settingsCrc.update(entry.getKey().getBytes(StandardCharsets.UTF_8));
+            settingsCrc.update(entry.getValue().getBytes(StandardCharsets.UTF_8));
         }
         retval.append(String.format(",(%X)", settingsCrc.getValue()));
 
         CRC32 locationsCrc = new CRC32();
         for(Map.Entry<VertexRef, Point> entry : m_locations.entrySet()) {
-            try {
-                locationsCrc.update(entry.getKey().getId().getBytes("UTF-8"));
-                //TODO cast to int for now
-                locationsCrc.update((int)entry.getValue().getX());
-                locationsCrc.update((int)entry.getValue().getY());
-            } catch(UnsupportedEncodingException e) {
-                // Impossible on modern JVMs
-                LOG.error(e.getMessage(), e);
-            }
+            locationsCrc.update(entry.getKey().getId().getBytes(StandardCharsets.UTF_8));
+            //TODO cast to int for now
+            locationsCrc.update((int)entry.getValue().getX());
+            locationsCrc.update((int)entry.getValue().getY());
         }
         retval.append(String.format(",(%X)", locationsCrc.getValue()));
 
         CRC32 selectionsCrc = new CRC32();
         for(VertexRef entry : m_selectedVertices) {
-            try {
-                selectionsCrc.update(entry.getNamespace().getBytes("UTF-8"));
-                selectionsCrc.update(entry.getId().getBytes("UTF-8"));
-            } catch(UnsupportedEncodingException e) {
-                // Impossible on modern JVMs
-                LOG.error(e.getMessage(), e);
-            }
+            selectionsCrc.update(entry.getNamespace().getBytes(StandardCharsets.UTF_8));
+            selectionsCrc.update(entry.getId().getBytes(StandardCharsets.UTF_8));
         }
         retval.append(String.format(",(%X)", selectionsCrc.getValue()));
 
         CRC32 focusCrc = new CRC32();
         for(VertexRef entry : m_focusVertices) {
-            try {
-                focusCrc.update(entry.getNamespace().getBytes("UTF-8"));
-                focusCrc.update(entry.getId().getBytes("UTF-8"));
-            } catch(UnsupportedEncodingException e) {
-                // Impossible on modern JVMs
-                LOG.error(e.getMessage(), e);
-            }
+            focusCrc.update(entry.getNamespace().getBytes(StandardCharsets.UTF_8));
+            focusCrc.update(entry.getId().getBytes(StandardCharsets.UTF_8));
         }
         retval.append(String.format(",(%X)", focusCrc.getValue()));
         return retval.toString();

--- a/features/topology-map/org.opennms.features.topology.link/src/main/java/org/opennms/features/topology/link/TopologyLinkBuilder.java
+++ b/features/topology-map/org.opennms.features.topology.link/src/main/java/org/opennms/features/topology/link/TopologyLinkBuilder.java
@@ -30,6 +30,7 @@ package org.opennms.features.topology.link;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -130,6 +131,6 @@ public class TopologyLinkBuilder {
     }
 
     private static String parameter(String parameterName, String value) throws UnsupportedEncodingException {
-        return URLEncoder.encode(parameterName, "UTF-8") + "=" + URLEncoder.encode(value, "UTF-8");
+        return URLEncoder.encode(parameterName, StandardCharsets.UTF_8.name()) + "=" + URLEncoder.encode(value, StandardCharsets.UTF_8.name());
     }
 }

--- a/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.vmware/src/main/java/org/opennms/features/topology/plugins/topo/vmware/internal/VmwareTopologyProvider.java
+++ b/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.vmware/src/main/java/org/opennms/features/topology/plugins/topo/vmware/internal/VmwareTopologyProvider.java
@@ -30,6 +30,7 @@ package org.opennms.features.topology.plugins.topo.vmware.internal;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -87,7 +88,7 @@ public class VmwareTopologyProvider extends SimpleGraphProvider {
 
             if (splitBySlash.length > 1) {
                 try {
-                    entityName = new String(URLDecoder.decode(splitBySlash[1], "UTF-8"));
+                    entityName = new String(URLDecoder.decode(splitBySlash[1], StandardCharsets.UTF_8.name()));
                 } catch (UnsupportedEncodingException e) {
                     LOG.error(e.getMessage(), e);
                 }

--- a/features/vaadin-dashlets/dashlet-rrd/src/main/java/org/opennms/features/vaadin/dashboard/dashlets/GraphSelectionWindow.java
+++ b/features/vaadin-dashlets/dashlet-rrd/src/main/java/org/opennms/features/vaadin/dashboard/dashlets/GraphSelectionWindow.java
@@ -40,6 +40,7 @@ import org.opennms.netmgt.model.OnmsResourceType;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 
@@ -164,12 +165,14 @@ public class GraphSelectionWindow extends Window {
 
                         for (OnmsResource onmsResource : resourceTypeMapEntry.getValue()) {
 
-                            String newResourceItemId = null;
+                            String newResourceItemId;
 
                             try {
-                                newResourceItemId = URLDecoder.decode(onmsResource.getId(), "UTF-8");
+                                newResourceItemId = URLDecoder.decode(onmsResource.getId(), StandardCharsets.UTF_8.name());
                             } catch (UnsupportedEncodingException e) {
+                                // Should not happen
                                 e.printStackTrace();
+                                continue;
                             }
 
                             Item newResourceItem = hierarchicalContainer.addItem(newResourceItemId);

--- a/features/vaadin-dashlets/dashlet-rrd/src/main/java/org/opennms/features/vaadin/dashboard/dashlets/RrdDashletConfigurationWindow.java
+++ b/features/vaadin-dashlets/dashlet-rrd/src/main/java/org/opennms/features/vaadin/dashboard/dashlets/RrdDashletConfigurationWindow.java
@@ -45,6 +45,7 @@ import org.opennms.netmgt.model.OnmsResourceType;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Calendar;
 import java.util.List;
 import java.util.Map;
@@ -446,7 +447,7 @@ public class RrdDashletConfigurationWindow extends DashletConfigurationWindow {
                     String onmsResourceId = null;
 
                     try {
-                        onmsResourceId = URLDecoder.decode(onmsResource.getId(), "UTF-8");
+                        onmsResourceId = URLDecoder.decode(onmsResource.getId(), StandardCharsets.UTF_8.name());
                     } catch (UnsupportedEncodingException e) {
                         e.printStackTrace();
                     }

--- a/features/vaadin-dashlets/dashlet-rrd/src/main/java/org/opennms/features/vaadin/dashboard/dashlets/RrdGraphHelper.java
+++ b/features/vaadin-dashlets/dashlet-rrd/src/main/java/org/opennms/features/vaadin/dashboard/dashlets/RrdGraphHelper.java
@@ -42,6 +42,7 @@ import org.springframework.transaction.support.TransactionOperations;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 
 /**
@@ -222,8 +223,8 @@ public class RrdGraphHelper {
             String key;
             String value;
             try {
-                key = URLDecoder.decode(pair.substring(0, idx), "UTF-8");
-                value = URLDecoder.decode(pair.substring(idx + 1), "UTF-8");
+                key = URLDecoder.decode(pair.substring(0, idx), StandardCharsets.UTF_8.name());
+                value = URLDecoder.decode(pair.substring(idx + 1), StandardCharsets.UTF_8.name());
             } catch (UnsupportedEncodingException e) {
                 continue;
             }

--- a/features/vaadin-node-maps/src/main/java/org/opennms/features/vaadin/nodemaps/internal/InvalidConfigurationWindow.java
+++ b/features/vaadin-node-maps/src/main/java/org/opennms/features/vaadin/nodemaps/internal/InvalidConfigurationWindow.java
@@ -29,6 +29,7 @@
 package org.opennms.features.vaadin.nodemaps.internal;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.commons.io.IOUtils;
 
@@ -77,7 +78,7 @@ public class InvalidConfigurationWindow extends Window {
 
     private String getErrorLabel(NodeMapConfiguration nodeMapConfiguration) {
         try {
-            String errorTemplate = IOUtils.toString(getClass().getResourceAsStream("/error-configuration.txt"), "UTF-8");
+            String errorTemplate = IOUtils.toString(getClass().getResourceAsStream("/error-configuration.txt"), StandardCharsets.UTF_8);
             String problems = "";
             if (Strings.isNullOrEmpty(nodeMapConfiguration.getTileServerUrl())) {
                 problems = "<li>No <i>gwt.openlayers.url</i> property defined</li>";

--- a/integrations/opennms-R/src/main/java/org/opennms/netmgt/integrations/R/RScriptExecutor.java
+++ b/integrations/opennms-R/src/main/java/org/opennms/netmgt/integrations/R/RScriptExecutor.java
@@ -36,7 +36,7 @@ import java.io.InputStream;
 import java.io.OutputStreamWriter;
 import java.io.StringReader;
 import java.io.Writer;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
 import org.apache.commons.csv.CSVFormat;
@@ -93,7 +93,7 @@ public class RScriptExecutor {
     private void setupFreemarker() {
         m_freemarkerConfiguration = new Configuration(Configuration.VERSION_2_3_21);
         m_freemarkerConfiguration.setTemplateLoader(new HybridTemplateLoader());
-        m_freemarkerConfiguration.setDefaultEncoding("UTF-8");
+        m_freemarkerConfiguration.setDefaultEncoding(StandardCharsets.UTF_8.name());
         m_freemarkerConfiguration.setTemplateExceptionHandler(TemplateExceptionHandler.RETHROW_HANDLER);
     }
 
@@ -155,7 +155,7 @@ public class RScriptExecutor {
 
         // Use the CharSequenceInputStream in order to avoid explicitly converting
         // the StringBuilder a string and then an array of bytes.
-        InputStream stdin = new CharSequenceInputStream(inputTableAsCsv, Charset.forName("UTF-8"));
+        InputStream stdin = new CharSequenceInputStream(inputTableAsCsv, StandardCharsets.UTF_8);
         ByteArrayOutputStream stderr = new ByteArrayOutputStream();
         ByteArrayOutputStream stdout = new ByteArrayOutputStream();
         executor.setStreamHandler(new PumpStreamHandler(stdout, stderr, stdin));

--- a/integrations/opennms-jasper-extensions/src/main/java/org/opennms/netmgt/jasper/measurement/remote/MeasurementApiClient.java
+++ b/integrations/opennms-jasper-extensions/src/main/java/org/opennms/netmgt/jasper/measurement/remote/MeasurementApiClient.java
@@ -33,6 +33,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLException;
@@ -118,7 +119,7 @@ class MeasurementApiClient {
         connection.setDoOutput(true);
         connection.setRequestMethod("POST");
         connection.setRequestProperty("Accept", "application/xml");
-        connection.setRequestProperty("Accept-Charset", "UTF-8");
+        connection.setRequestProperty("Accept-Charset", StandardCharsets.UTF_8.name());
         connection.setRequestProperty("Content-Type", "application/xml");
         connection.setInstanceFollowRedirects(false); // we do not want to follow redirects, otherwise 200 OK might be returned
         connection.connect();

--- a/integrations/opennms-jasper-extensions/src/test/java/org/opennms/netmgt/jasper/measurement/remote/MeasurementApiConnectorIT.java
+++ b/integrations/opennms-jasper-extensions/src/test/java/org/opennms/netmgt/jasper/measurement/remote/MeasurementApiConnectorIT.java
@@ -32,6 +32,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.net.ConnectException;
 import java.net.SocketTimeoutException;
+import java.nio.charset.StandardCharsets;
 
 import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLHandshakeException;
@@ -300,6 +301,6 @@ public class MeasurementApiConnectorIT {
         return WireMock.postRequestedFor(WireMock.urlMatching(url))
                 .withRequestBody(WireMock.matching("<dummy request>"))
                 .withHeader("Content-Type", WireMock.equalTo("application/xml"))
-                .withHeader("Accept-Charset", WireMock.equalTo("UTF-8"));
+                .withHeader("Accept-Charset", WireMock.equalTo(StandardCharsets.UTF_8.name()));
     }
 }

--- a/integrations/opennms-rancid-provisioning-adapter/src/main/java/org/opennms/netmgt/config/RancidAdapterConfigFactory.java
+++ b/integrations/opennms-rancid-provisioning-adapter/src/main/java/org/opennms/netmgt/config/RancidAdapterConfigFactory.java
@@ -35,6 +35,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 
 import org.opennms.core.utils.ConfigFileConstants;
 import org.slf4j.Logger;
@@ -155,7 +156,7 @@ public class RancidAdapterConfigFactory extends RancidAdapterConfigManager {
                 long timestamp = System.currentTimeMillis();
                 File cfgFile = ConfigFileConstants.getFile(ConfigFileConstants.RANCID_CONFIG_FILE_NAME);
                 LOG.debug("saveXml: saving config file at {}: {}", timestamp, cfgFile.getPath());
-                Writer fileWriter = new OutputStreamWriter(new FileOutputStream(cfgFile), "UTF-8");
+                Writer fileWriter = new OutputStreamWriter(new FileOutputStream(cfgFile), StandardCharsets.UTF_8);
                 fileWriter.write(xml);
                 fileWriter.flush();
                 fileWriter.close();

--- a/integrations/opennms-rws/src/main/java/org/opennms/netmgt/config/RWSConfigFactory.java
+++ b/integrations/opennms-rws/src/main/java/org/opennms/netmgt/config/RWSConfigFactory.java
@@ -35,6 +35,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.commons.io.IOUtils;
 import org.opennms.core.utils.ConfigFileConstants;
@@ -155,7 +156,7 @@ public final class RWSConfigFactory extends RWSConfigManager {
                 final long timestamp = System.currentTimeMillis();
                 final File cfgFile = ConfigFileConstants.getFile(ConfigFileConstants.RWS_CONFIG_FILE_NAME);
                 LOG.debug("saveXml: saving config file at {}: {}", timestamp, cfgFile.getPath());
-                final Writer fileWriter = new OutputStreamWriter(new FileOutputStream(cfgFile), "UTF-8");
+                final Writer fileWriter = new OutputStreamWriter(new FileOutputStream(cfgFile), StandardCharsets.UTF_8);
                 fileWriter.write(xml);
                 fileWriter.flush();
                 fileWriter.close();

--- a/integrations/opennms-snmp-asset-provisioning-adapter/src/main/java/org/opennms/netmgt/config/SnmpAssetAdapterConfigFactory.java
+++ b/integrations/opennms-snmp-asset-provisioning-adapter/src/main/java/org/opennms/netmgt/config/SnmpAssetAdapterConfigFactory.java
@@ -35,6 +35,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.commons.io.IOUtils;
 import org.opennms.core.utils.ConfigFileConstants;
@@ -84,7 +85,7 @@ public class SnmpAssetAdapterConfigFactory {
     		    final long timestamp = System.currentTimeMillis();
     			final File cfgFile = ConfigFileConstants.getFile(ConfigFileConstants.SNMP_ASSET_ADAPTER_CONFIG_FILE_NAME);
     			LOG.debug("saveXml: saving config file at {}: {}", timestamp, cfgFile.getPath());
-    			final Writer fileWriter = new OutputStreamWriter(new FileOutputStream(cfgFile), "UTF-8");
+    			final Writer fileWriter = new OutputStreamWriter(new FileOutputStream(cfgFile), StandardCharsets.UTF_8);
     			fileWriter.write(xml);
     			fileWriter.flush();
     			fileWriter.close();

--- a/integrations/opennms-vmware/src/main/java/org/opennms/netmgt/provision/service/vmware/VmwareRequisitionTool.java
+++ b/integrations/opennms-vmware/src/main/java/org/opennms/netmgt/provision/service/vmware/VmwareRequisitionTool.java
@@ -32,6 +32,7 @@ import java.io.File;
 import java.io.InputStream;
 import java.io.PrintWriter;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.net.MalformedURLException;
 import java.util.List;
 
@@ -110,7 +111,7 @@ public abstract class VmwareRequisitionTool {
             System.err.println("Couldn't generate requisition from " +  urlString);
             System.exit(1);
         } else {
-            System.out.println(IOUtils.toString(is, "UTF-8"));
+            System.out.println(IOUtils.toString(is, StandardCharsets.UTF_8));
         }
     }
 

--- a/integrations/opennms-vmware/src/main/java/org/opennms/netmgt/provision/service/vmware/VmwareRequisitionUrlConnection.java
+++ b/integrations/opennms-vmware/src/main/java/org/opennms/netmgt/provision/service/vmware/VmwareRequisitionUrlConnection.java
@@ -53,6 +53,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 import java.net.*;
+import java.nio.charset.StandardCharsets;
 import java.rmi.RemoteException;
 import java.util.*;
 
@@ -397,7 +398,7 @@ public class VmwareRequisitionUrlConnection extends GenericURLConnection {
             }
             try {
                 if (parentEntity != null && parentEntity.getMOR() != null) {
-                    vmwareTopologyInfo.append(parentEntity.getMOR().getVal() + "/" + URLEncoder.encode(parentEntity.getName(), "UTF-8"));
+                    vmwareTopologyInfo.append(parentEntity.getMOR().getVal() + "/" + URLEncoder.encode(parentEntity.getName(), StandardCharsets.UTF_8.name()));
                 } else {
                     logger.warn("Can't add topologyInformation because either the parentEntity or the MOR is null for " + managedEntity.getName());
                 }
@@ -431,7 +432,7 @@ public class VmwareRequisitionUrlConnection extends GenericURLConnection {
                             vmwareTopologyInfo.append(", ");
                         }
                         try {
-                            vmwareTopologyInfo.append(datastore.getMOR().getVal() + "/" + URLEncoder.encode(datastore.getSummary().getName(), "UTF-8"));
+                            vmwareTopologyInfo.append(datastore.getMOR().getVal() + "/" + URLEncoder.encode(datastore.getSummary().getName(), StandardCharsets.UTF_8.name()));
                         } catch (UnsupportedEncodingException e) {
                             logger.warn("Unsupported encoding '{}'", e.getMessage());
                         }
@@ -449,7 +450,7 @@ public class VmwareRequisitionUrlConnection extends GenericURLConnection {
                         }
                         try {
                             if (network instanceof DistributedVirtualPortgroup ? m_topologyPortGroups : true) {
-                                vmwareTopologyInfo.append(network.getMOR().getVal() + "/" + URLEncoder.encode(network.getSummary().getName(), "UTF-8"));
+                                vmwareTopologyInfo.append(network.getMOR().getVal() + "/" + URLEncoder.encode(network.getSummary().getName(), StandardCharsets.UTF_8.name()));
                             }
                         } catch (UnsupportedEncodingException e) {
                             logger.warn("Unsupported encoding '{}'", e.getMessage());
@@ -484,7 +485,7 @@ public class VmwareRequisitionUrlConnection extends GenericURLConnection {
                                 vmwareTopologyInfo.append(", ");
                             }
                             try {
-                                vmwareTopologyInfo.append(datastore.getMOR().getVal() + "/" + URLEncoder.encode(datastore.getSummary().getName(), "UTF-8"));
+                                vmwareTopologyInfo.append(datastore.getMOR().getVal() + "/" + URLEncoder.encode(datastore.getSummary().getName(), StandardCharsets.UTF_8.name()));
                             } catch (UnsupportedEncodingException e) {
                                 logger.warn("Unsupported encoding '{}'", e.getMessage());
                             }
@@ -501,7 +502,7 @@ public class VmwareRequisitionUrlConnection extends GenericURLConnection {
                             }
                             try {
                                 if (network instanceof DistributedVirtualPortgroup ? m_topologyPortGroups : true) {
-                                    vmwareTopologyInfo.append(network.getMOR().getVal() + "/" + URLEncoder.encode(network.getSummary().getName(), "UTF-8"));
+                                    vmwareTopologyInfo.append(network.getMOR().getVal() + "/" + URLEncoder.encode(network.getSummary().getName(), StandardCharsets.UTF_8.name()));
                                 }
                             } catch (UnsupportedEncodingException e) {
                                 logger.warn("Unsupported encoding '{}'", e.getMessage());
@@ -517,7 +518,7 @@ public class VmwareRequisitionUrlConnection extends GenericURLConnection {
                 }
 
                 try {
-                    vmwareTopologyInfo.append(virtualMachine.getRuntime().getHost().getVal() + "/" + URLEncoder.encode(m_hostSystemMap.get(virtualMachine.getRuntime().getHost().getVal()), "UTF-8"));
+                    vmwareTopologyInfo.append(virtualMachine.getRuntime().getHost().getVal() + "/" + URLEncoder.encode(m_hostSystemMap.get(virtualMachine.getRuntime().getHost().getVal()), StandardCharsets.UTF_8.name()));
                 } catch (UnsupportedEncodingException e) {
                     logger.warn("Unsupported encoding '{}'", e.getMessage());
                 }

--- a/opennms-ackd/src/test/java/org/opennms/netmgt/ackd/readers/HypericAckProcessorIT.java
+++ b/opennms-ackd/src/test/java/org/opennms/netmgt/ackd/readers/HypericAckProcessorIT.java
@@ -38,6 +38,7 @@ import static org.junit.Assert.assertTrue;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.LineNumberReader;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 
@@ -240,7 +241,7 @@ public class HypericAckProcessorIT implements InitializingBean {
 
     @Test
     public void testParseHypericAlerts() throws Exception {
-        LineNumberReader reader = new LineNumberReader(new InputStreamReader(Thread.currentThread().getContextClassLoader().getResourceAsStream("hqu/opennms/alertStatus/list.hqu"), "UTF-8"));
+        LineNumberReader reader = new LineNumberReader(new InputStreamReader(Thread.currentThread().getContextClassLoader().getResourceAsStream("hqu/opennms/alertStatus/list.hqu"), StandardCharsets.UTF_8));
         reader.mark(4000);
         try {
             while(true) {

--- a/opennms-alarms/http-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/http/HttpNorthbounder.java
+++ b/opennms-alarms/http-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/http/HttpNorthbounder.java
@@ -31,6 +31,7 @@ package org.opennms.netmgt.alarmd.northbounder.http;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
 import java.util.ArrayList;
 import java.util.List;
@@ -147,12 +148,8 @@ public class HttpNorthbounder extends AbstractNorthbounder {
             NameValuePair p = new BasicNameValuePair("foo", "bar");
             postParms.add(p);
 
-            try {
-                UrlEncodedFormEntity entity = new UrlEncodedFormEntity(postParms, "UTF-8");
-                postMethod.setEntity(entity);
-            } catch (UnsupportedEncodingException e) {
-                throw new NorthbounderException(e);
-            }
+            UrlEncodedFormEntity formEntity = new UrlEncodedFormEntity(postParms, StandardCharsets.UTF_8);
+            postMethod.setEntity(formEntity);
 
             HttpEntity entity = null;
             try {

--- a/opennms-alarms/http-northbounder/src/test/java/org/opennms/netmgt/alarmd/northbounder/http/JAXBTest.java
+++ b/opennms-alarms/http-northbounder/src/test/java/org/opennms/netmgt/alarmd/northbounder/http/JAXBTest.java
@@ -33,6 +33,7 @@ import static org.opennms.core.test.xml.XmlTest.assertXmlEquals;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
 
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.Marshaller;
@@ -159,7 +160,7 @@ public class JAXBTest {
         // verify its matches the expected results
         byte[] utf8 = out.toByteArray();
 
-        String result = new String(utf8, "UTF-8");
+        String result = new String(utf8, StandardCharsets.UTF_8);
         assertXmlEquals(expectedXML, result);
 
         System.err.println(result);
@@ -184,7 +185,7 @@ public class JAXBTest {
         ByteArrayOutputStream reout = new ByteArrayOutputStream();
         marshaller.marshal(read, reout);
 
-        String roundTrip = new String(reout.toByteArray(), "UTF-8");
+        String roundTrip = new String(reout.toByteArray(), StandardCharsets.UTF_8);
 
         assertXmlEquals(expectedXML, roundTrip);
     }

--- a/opennms-alarms/syslog-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/syslog/SyslogDestination.java
+++ b/opennms-alarms/syslog-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/syslog/SyslogDestination.java
@@ -28,6 +28,7 @@
 
 package org.opennms.netmgt.alarmd.northbounder.syslog;
 
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -309,7 +310,7 @@ public class SyslogDestination implements Destination {
      * @return the char set
      */
     public String getCharSet() {
-        return m_charSet == null ? "UTF-8" : m_charSet;
+        return m_charSet == null ? StandardCharsets.UTF_8.name() : m_charSet;
     }
 
     /**

--- a/opennms-config-model/src/main/java/org/opennms/netmgt/xml/eventconf/Events.java
+++ b/opennms-config-model/src/main/java/org/opennms/netmgt/xml/eventconf/Events.java
@@ -36,6 +36,7 @@ import java.io.Reader;
 import java.io.Serializable;
 import java.io.StringWriter;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -572,7 +573,7 @@ public class Events implements Serializable {
 			Writer fileWriter = null;
 			try {
 				try {
-					fileWriter = new OutputStreamWriter(new FileOutputStream(file), "UTF-8");
+					fileWriter = new OutputStreamWriter(new FileOutputStream(file), StandardCharsets.UTF_8);
 				} catch (final IOException e) {
 					throw new DataAccessResourceFailureException("Event file '" + file + "' could not be opened.  Nested exception: " + e, e);
 				}

--- a/opennms-config/src/main/java/org/opennms/netmgt/config/AmiPeerFactory.java
+++ b/opennms-config/src/main/java/org/opennms/netmgt/config/AmiPeerFactory.java
@@ -37,6 +37,7 @@ import java.io.Writer;
 import java.math.BigInteger;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.TreeMap;
@@ -198,7 +199,7 @@ public class AmiPeerFactory {
             final StringWriter stringWriter = new StringWriter();
             JaxbUtils.marshal(m_config, stringWriter);
             if (stringWriter.toString() != null) {
-                final Writer fileWriter = new OutputStreamWriter(new FileOutputStream(ConfigFileConstants.getFile(ConfigFileConstants.AMI_CONFIG_FILE_NAME)), "UTF-8");
+                final Writer fileWriter = new OutputStreamWriter(new FileOutputStream(ConfigFileConstants.getFile(ConfigFileConstants.AMI_CONFIG_FILE_NAME)), StandardCharsets.UTF_8);
                 fileWriter.write(stringWriter.toString());
                 fileWriter.flush();
                 fileWriter.close();

--- a/opennms-config/src/main/java/org/opennms/netmgt/config/ChartConfigFactory.java
+++ b/opennms-config/src/main/java/org/opennms/netmgt/config/ChartConfigFactory.java
@@ -36,6 +36,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.commons.io.IOUtils;
 import org.opennms.core.utils.ConfigFileConstants;
@@ -92,7 +93,7 @@ public class ChartConfigFactory extends ChartConfigManager {
     @Override
     protected void saveXml(String xml) throws IOException {
         if (xml != null) {
-            Writer fileWriter = new OutputStreamWriter(new FileOutputStream(m_chartConfigFile), "UTF-8");
+            Writer fileWriter = new OutputStreamWriter(new FileOutputStream(m_chartConfigFile), StandardCharsets.UTF_8);
             fileWriter.write(xml);
             fileWriter.flush();
             fileWriter.close();

--- a/opennms-config/src/main/java/org/opennms/netmgt/config/DestinationPathFactory.java
+++ b/opennms-config/src/main/java/org/opennms/netmgt/config/DestinationPathFactory.java
@@ -36,6 +36,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 
 import org.opennms.core.utils.ConfigFileConstants;
 
@@ -119,7 +120,7 @@ public class DestinationPathFactory extends DestinationPathManager {
     @Override
     protected void saveXML(String writerString) throws IOException {
         if (writerString != null) {
-            Writer fileWriter = new OutputStreamWriter(new FileOutputStream(m_pathsConfFile), "UTF-8");
+            Writer fileWriter = new OutputStreamWriter(new FileOutputStream(m_pathsConfFile), StandardCharsets.UTF_8);
             fileWriter.write(writerString);
             fileWriter.flush();
             fileWriter.close();

--- a/opennms-config/src/main/java/org/opennms/netmgt/config/DiscoveryConfigFactory.java
+++ b/opennms-config/src/main/java/org/opennms/netmgt/config/DiscoveryConfigFactory.java
@@ -44,6 +44,7 @@ import java.io.Writer;
 import java.net.InetAddress;
 import java.net.URL;
 import java.net.UnknownHostException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.LinkedList;
@@ -175,7 +176,7 @@ public class DiscoveryConfigFactory implements DiscoveryConfigurationFactory {
             Writer fileWriter = null;
             getWriteLock().lock();
             try {
-                fileWriter = new OutputStreamWriter(new FileOutputStream(ConfigFileConstants.getFile(ConfigFileConstants.DISCOVERY_CONFIG_FILE_NAME)), "UTF-8");
+                fileWriter = new OutputStreamWriter(new FileOutputStream(ConfigFileConstants.getFile(ConfigFileConstants.DISCOVERY_CONFIG_FILE_NAME)), StandardCharsets.UTF_8);
                 fileWriter.write(xml);
                 fileWriter.flush();
             } finally {
@@ -266,7 +267,7 @@ public class DiscoveryConfigFactory implements DiscoveryConfigurationFactory {
         boolean bRet = true;
 
         try {
-            final BufferedReader buffer = new BufferedReader(new InputStreamReader(is, "UTF-8"));
+            final BufferedReader buffer = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8));
 
             String ipLine = null;
             String specIP = null;

--- a/opennms-config/src/main/java/org/opennms/netmgt/config/EnhancedLinkdConfigFactory.java
+++ b/opennms-config/src/main/java/org/opennms/netmgt/config/EnhancedLinkdConfigFactory.java
@@ -38,6 +38,7 @@ import java.io.OutputStreamWriter;
 import java.io.Reader;
 import java.io.StringWriter;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.commons.io.IOUtils;
 import org.opennms.core.utils.ConfigFileConstants;
@@ -82,7 +83,7 @@ public final class EnhancedLinkdConfigFactory extends EnhancedLinkdConfigManager
             long timestamp = System.currentTimeMillis();
             final File cfgFile = ConfigFileConstants.getFile(ConfigFileConstants.ENLINKD_CONFIG_FILE_NAME);
             LOG.debug("saveXml: saving config file at {}: {}", timestamp, cfgFile.getPath());
-            final Writer fileWriter = new OutputStreamWriter(new FileOutputStream(cfgFile), "UTF-8");
+            final Writer fileWriter = new OutputStreamWriter(new FileOutputStream(cfgFile), StandardCharsets.UTF_8);
             fileWriter.write(xml);
             fileWriter.flush();
             fileWriter.close();

--- a/opennms-config/src/main/java/org/opennms/netmgt/config/GroupFactory.java
+++ b/opennms-config/src/main/java/org/opennms/netmgt/config/GroupFactory.java
@@ -36,6 +36,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.commons.io.IOUtils;
 import org.opennms.core.utils.ConfigFileConstants;
@@ -147,7 +148,7 @@ public class GroupFactory extends GroupManager {
     @Override
     protected void saveXml(String data) throws IOException {
         if (data != null) {
-            Writer fileWriter = new OutputStreamWriter(new FileOutputStream(m_groupsConfFile), "UTF-8");
+            Writer fileWriter = new OutputStreamWriter(new FileOutputStream(m_groupsConfFile), StandardCharsets.UTF_8);
             fileWriter.write(data);
             fileWriter.flush();
             fileWriter.close();

--- a/opennms-config/src/main/java/org/opennms/netmgt/config/NotifdConfigFactory.java
+++ b/opennms-config/src/main/java/org/opennms/netmgt/config/NotifdConfigFactory.java
@@ -36,6 +36,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.commons.io.IOUtils;
 import org.opennms.core.utils.ConfigFileConstants;
@@ -149,7 +150,7 @@ public class NotifdConfigFactory extends NotifdConfigManager {
     @Override
     protected void saveXml(String xml) throws IOException {
         if (xml != null) {
-            Writer fileWriter = new OutputStreamWriter(new FileOutputStream(m_notifdConfFile), "UTF-8");
+            Writer fileWriter = new OutputStreamWriter(new FileOutputStream(m_notifdConfFile), StandardCharsets.UTF_8);
             fileWriter.write(xml);
             fileWriter.flush();
             fileWriter.close();

--- a/opennms-config/src/main/java/org/opennms/netmgt/config/NotificationFactory.java
+++ b/opennms-config/src/main/java/org/opennms/netmgt/config/NotificationFactory.java
@@ -37,6 +37,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
 
 import org.apache.commons.io.IOUtils;
@@ -130,7 +131,7 @@ public class NotificationFactory extends NotificationManager {
     @Override
     protected void saveXML(String xmlString) throws IOException {
         if (xmlString != null) {
-            Writer fileWriter = new OutputStreamWriter(new FileOutputStream(m_noticeConfFile), "UTF-8");
+            Writer fileWriter = new OutputStreamWriter(new FileOutputStream(m_noticeConfFile), StandardCharsets.UTF_8);
             fileWriter.write(xmlString);
             fileWriter.flush();
             fileWriter.close();

--- a/opennms-config/src/main/java/org/opennms/netmgt/config/PollerConfigFactory.java
+++ b/opennms-config/src/main/java/org/opennms/netmgt/config/PollerConfigFactory.java
@@ -36,6 +36,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.commons.io.IOUtils;
 import org.opennms.core.utils.ConfigFileConstants;
@@ -188,7 +189,7 @@ public final class PollerConfigFactory extends PollerConfigManager {
                 final long timestamp = System.currentTimeMillis();
                 final File cfgFile = ConfigFileConstants.getFile(ConfigFileConstants.POLLER_CONFIG_FILE_NAME);
                 LOG.debug("saveXml: saving config file at {}: {}", timestamp, cfgFile.getPath());
-                final Writer fileWriter = new OutputStreamWriter(new FileOutputStream(cfgFile), "UTF-8");
+                final Writer fileWriter = new OutputStreamWriter(new FileOutputStream(cfgFile), StandardCharsets.UTF_8);
                 fileWriter.write(xml);
                 fileWriter.flush();
                 fileWriter.close();

--- a/opennms-config/src/main/java/org/opennms/netmgt/config/SnmpInterfacePollerConfigFactory.java
+++ b/opennms-config/src/main/java/org/opennms/netmgt/config/SnmpInterfacePollerConfigFactory.java
@@ -35,6 +35,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.commons.io.IOUtils;
 import org.opennms.core.utils.ConfigFileConstants;
@@ -154,7 +155,7 @@ public final class SnmpInterfacePollerConfigFactory extends SnmpInterfacePollerC
             long timestamp = System.currentTimeMillis();
             File cfgFile = ConfigFileConstants.getFile(ConfigFileConstants.SNMP_INTERFACE_POLLER_CONFIG_FILE_NAME);
             LOG.debug("saveXml: saving config file at {}: {}",timestamp, cfgFile.getPath());
-            Writer fileWriter = new OutputStreamWriter(new FileOutputStream(cfgFile), "UTF-8");
+            Writer fileWriter = new OutputStreamWriter(new FileOutputStream(cfgFile), StandardCharsets.UTF_8);
             fileWriter.write(xml);
             fileWriter.flush();
             fileWriter.close();

--- a/opennms-config/src/main/java/org/opennms/netmgt/config/SnmpPeerFactory.java
+++ b/opennms-config/src/main/java/org/opennms/netmgt/config/SnmpPeerFactory.java
@@ -37,6 +37,7 @@ import java.io.StringWriter;
 import java.io.UnsupportedEncodingException;
 import java.io.Writer;
 import java.net.InetAddress;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.locks.Lock;
 
 import org.apache.commons.io.IOUtils;
@@ -225,7 +226,7 @@ public class SnmpPeerFactory implements SnmpAgentConfigFactory {
         try {
             if (marshalledConfig != null) {
                 out = new FileOutputStream(file);
-                fileWriter = new OutputStreamWriter(out, "UTF-8");
+                fileWriter = new OutputStreamWriter(out, StandardCharsets.UTF_8);
                 fileWriter.write(marshalledConfig);
                 fileWriter.flush();
                 fileWriter.close();

--- a/opennms-config/src/main/java/org/opennms/netmgt/config/ThreshdConfigFactory.java
+++ b/opennms-config/src/main/java/org/opennms/netmgt/config/ThreshdConfigFactory.java
@@ -35,6 +35,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.commons.io.IOUtils;
 import org.opennms.core.utils.ConfigFileConstants;
@@ -147,7 +148,7 @@ public final class ThreshdConfigFactory extends ThreshdConfigManager {
     @Override
         protected void saveXML(String xmlString) throws IOException {
             File cfgFile = ConfigFileConstants.getFile(ConfigFileConstants.THRESHD_CONFIG_FILE_NAME);
-            Writer fileWriter = new OutputStreamWriter(new FileOutputStream(cfgFile), "UTF-8");
+            Writer fileWriter = new OutputStreamWriter(new FileOutputStream(cfgFile), StandardCharsets.UTF_8);
             fileWriter.write(xmlString);
             fileWriter.flush();
             fileWriter.close();

--- a/opennms-config/src/main/java/org/opennms/netmgt/config/ThresholdingConfigFactory.java
+++ b/opennms-config/src/main/java/org/opennms/netmgt/config/ThresholdingConfigFactory.java
@@ -37,6 +37,7 @@ import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.io.Reader;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -288,7 +289,7 @@ public final class ThresholdingConfigFactory {
         if (xmlString != null) {
             File cfgFile = ConfigFileConstants.getFile(ConfigFileConstants.THRESHOLDING_CONF_FILE_NAME);
 
-            Writer fileWriter = new OutputStreamWriter(new FileOutputStream(cfgFile), "UTF-8");
+            Writer fileWriter = new OutputStreamWriter(new FileOutputStream(cfgFile), StandardCharsets.UTF_8);
             fileWriter.write(xmlString);
             fileWriter.flush();
             fileWriter.close();

--- a/opennms-config/src/main/java/org/opennms/netmgt/config/UserFactory.java
+++ b/opennms-config/src/main/java/org/opennms/netmgt/config/UserFactory.java
@@ -36,6 +36,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.commons.io.IOUtils;
 import org.opennms.core.utils.ConfigFileConstants;
@@ -146,7 +147,7 @@ public class UserFactory extends UserManager {
         if (writerString != null) {
             Writer fileWriter = null;
             try {
-                fileWriter = new OutputStreamWriter(new FileOutputStream(m_usersConfFile), "UTF-8");
+                fileWriter = new OutputStreamWriter(new FileOutputStream(m_usersConfFile), StandardCharsets.UTF_8);
                 fileWriter.write(writerString);
                 fileWriter.flush();
             } finally {

--- a/opennms-config/src/test/java/org/opennms/netmgt/config/HttpCollectionConfigFactoryTest.java
+++ b/opennms-config/src/test/java/org/opennms/netmgt/config/HttpCollectionConfigFactoryTest.java
@@ -33,6 +33,7 @@ import static org.junit.Assert.assertNotNull;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 
 import org.junit.Test;
 
@@ -70,7 +71,7 @@ public class HttpCollectionConfigFactoryTest {
                 "      </uri>\n" + 
                 "    </uris>\n" + 
                 "  </http-collection>\n" + 
-                "</http-datacollection-config>").getBytes("UTF-8"));
+                "</http-datacollection-config>").getBytes(StandardCharsets.UTF_8));
         new HttpCollectionConfigFactory(rdr);
         assertNotNull(HttpCollectionConfigFactory.getConfig());
     }

--- a/opennms-config/src/test/java/org/opennms/netmgt/config/PollerConfigFactoryIT.java
+++ b/opennms-config/src/test/java/org/opennms/netmgt/config/PollerConfigFactoryIT.java
@@ -32,6 +32,7 @@ import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 import junit.framework.TestCase;
 
@@ -135,7 +136,7 @@ public class PollerConfigFactoryIT extends TestCase {
         private String m_xml;
 
         public TestPollerConfigManager(String xml, String localServer, boolean verifyServer) throws IOException {
-            super(new ByteArrayInputStream(xml.getBytes("UTF-8")), localServer, verifyServer);
+            super(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)), localServer, verifyServer);
             save();
         }
 

--- a/opennms-dao/src/main/java/org/opennms/netmgt/dao/support/InterfaceSnmpResourceType.java
+++ b/opennms-dao/src/main/java/org/opennms/netmgt/dao/support/InterfaceSnmpResourceType.java
@@ -30,6 +30,7 @@ package org.opennms.netmgt.dao.support;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -296,7 +297,7 @@ public class InterfaceSnmpResourceType implements OnmsResourceType {
         for (String intfName : intfNames) {
             OnmsResource resource = getResourceByParentPathAndInterface(parent, intfName); 
             try {
-                resource.setLink("element/nodeList.htm?listInterfaces=true&snmpParm=ifAlias&snmpParmMatchType=contains&snmpParmValue=" + URLEncoder.encode(intfName, "UTF-8"));
+                resource.setLink("element/nodeList.htm?listInterfaces=true&snmpParm=ifAlias&snmpParmMatchType=contains&snmpParmValue=" + URLEncoder.encode(intfName, StandardCharsets.UTF_8.name()));
             } catch (UnsupportedEncodingException e) {
                 throw new IllegalStateException("URLEncoder.encode complained about UTF-8. " + e, e);
             }

--- a/opennms-dao/src/test/java/org/opennms/netmgt/dao/support/PropertiesGraphDaoIT.java
+++ b/opennms-dao/src/test/java/org/opennms/netmgt/dao/support/PropertiesGraphDaoIT.java
@@ -35,6 +35,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.HashSet;
 
@@ -319,20 +320,20 @@ public class PropertiesGraphDaoIT extends PropertiesGraphDaoITCase {
         File graphHCbits = m_fileAnticipator.tempFile(graphDirectory, "mib2.HCbits.properties");
                     
         m_outputStream = new FileOutputStream(rootFile);
-		m_writer = new OutputStreamWriter(m_outputStream, "UTF-8");
+		m_writer = new OutputStreamWriter(m_outputStream, StandardCharsets.UTF_8);
         m_writer.write(s_baseIncludePrefab);
         m_writer.close();
         m_outputStream.close();
                     
         graphDirectory.mkdir();
         m_outputStream = new FileOutputStream(graphBits);
-        m_writer = new OutputStreamWriter(m_outputStream, "UTF-8");
+        m_writer = new OutputStreamWriter(m_outputStream, StandardCharsets.UTF_8);
         m_writer.write(s_separateBitsGraph);
         m_writer.close();
         m_outputStream.close();
         
         m_outputStream = new FileOutputStream(graphHCbits);
-        m_writer = new OutputStreamWriter(m_outputStream, "UTF-8");
+        m_writer = new OutputStreamWriter(m_outputStream, StandardCharsets.UTF_8);
         m_writer.write(s_separateHCBitsGraph);
         m_writer.close();
         m_outputStream.close();
@@ -370,20 +371,20 @@ public class PropertiesGraphDaoIT extends PropertiesGraphDaoITCase {
         File multiFile2 = m_fileAnticipator.tempFile(graphDirectory, "mib2.bits2.properties");
                     
         m_outputStream = new FileOutputStream(rootFile);
-        m_writer = new OutputStreamWriter(m_outputStream, "UTF-8");
+        m_writer = new OutputStreamWriter(m_outputStream, StandardCharsets.UTF_8);
         m_writer.write(s_baseIncludePrefab);
         m_writer.close();
         m_outputStream.close();
                     
         graphDirectory.mkdir();
         m_outputStream = new FileOutputStream(multiFile1);
-        m_writer = new OutputStreamWriter(m_outputStream, "UTF-8");
+        m_writer = new OutputStreamWriter(m_outputStream, StandardCharsets.UTF_8);
         m_writer.write(s_includedMultiGraph1);
         m_writer.close();
         m_outputStream.close();
         
         m_outputStream = new FileOutputStream(multiFile2);
-        m_writer = new OutputStreamWriter(m_outputStream, "UTF-8");
+        m_writer = new OutputStreamWriter(m_outputStream, StandardCharsets.UTF_8);
         m_writer.write(s_includedMultiGraph2);
         m_writer.close();
         m_outputStream.close();
@@ -440,27 +441,27 @@ public class PropertiesGraphDaoIT extends PropertiesGraphDaoITCase {
         File graphHCbits = m_fileAnticipator.tempFile(graphDirectory, "mib2.HCbits.properties");
 
         m_outputStream = new FileOutputStream(rootFile);
-        m_writer = new OutputStreamWriter(m_outputStream, "UTF-8");
+        m_writer = new OutputStreamWriter(m_outputStream, StandardCharsets.UTF_8);
         m_writer.write(s_baseIncludePrefab);
         m_writer.close();
         m_outputStream.close();
                     
         graphDirectory.mkdir();
         m_outputStream = new FileOutputStream(graphBits);
-        m_writer = new OutputStreamWriter(m_outputStream, "UTF-8");
+        m_writer = new OutputStreamWriter(m_outputStream, StandardCharsets.UTF_8);
         m_writer.write(s_separateBitsGraph);
         m_writer.close();
         m_outputStream.close();
         
         m_outputStream = new FileOutputStream(graphHCbits);
-        m_writer = new OutputStreamWriter(m_outputStream, "UTF-8");
+        m_writer = new OutputStreamWriter(m_outputStream, StandardCharsets.UTF_8);
         m_writer.write(s_separateHCBitsGraph);
         m_writer.close();
         m_outputStream.close();
                     
         graphDirectory.mkdir();
         m_outputStream = new FileOutputStream(multiFile);
-        m_writer = new OutputStreamWriter(m_outputStream, "UTF-8");
+        m_writer = new OutputStreamWriter(m_outputStream, StandardCharsets.UTF_8);
         m_writer.write(s_includedMultiGraph1);
         m_writer.close();
         m_outputStream.close();
@@ -519,7 +520,7 @@ public class PropertiesGraphDaoIT extends PropertiesGraphDaoITCase {
         m_testSpecificLoggingTest = true;
         
         PropertiesGraphDao dao = createPropertiesGraphDao(s_emptyMap, s_emptyMap);
-        dao.loadProperties("foo", new ByteArrayInputStream(s_partlyBorkedPrefab.getBytes("UTF-8")));
+        dao.loadProperties("foo", new ByteArrayInputStream(s_partlyBorkedPrefab.getBytes(StandardCharsets.UTF_8)));
         
         //We expect to be able to get a mib2.HCbits, and a mib2.discards, but no mib2.bits 
         try {
@@ -547,14 +548,14 @@ public class PropertiesGraphDaoIT extends PropertiesGraphDaoITCase {
         File graphBits = m_fileAnticipator.tempFile(graphDirectory, "mib2.bits.properties");
 
         m_outputStream = new FileOutputStream(rootFile);
-        m_writer = new OutputStreamWriter(m_outputStream, "UTF-8");
+        m_writer = new OutputStreamWriter(m_outputStream, StandardCharsets.UTF_8);
         m_writer.write(s_baseIncludePrefab);
         m_writer.close();
         m_outputStream.close();
 
         graphDirectory.mkdir();
         m_outputStream = new FileOutputStream(graphBits);
-        m_writer = new OutputStreamWriter(m_outputStream, "UTF-8");
+        m_writer = new OutputStreamWriter(m_outputStream, StandardCharsets.UTF_8);
         m_writer.write(s_separateBitsGraph.replace("report.id", "report.noid"));
         m_writer.close();
         m_outputStream.close();

--- a/opennms-icmp/opennms-icmp-jna/src/main/java/org/opennms/netmgt/icmp/jna/AbstractPinger.java
+++ b/opennms-icmp/opennms-icmp-jna/src/main/java/org/opennms/netmgt/icmp/jna/AbstractPinger.java
@@ -52,7 +52,6 @@ public abstract class AbstractPinger<T extends InetAddress> implements Runnable 
     private volatile boolean m_stopped = false;
     private final List<PingReplyListener> m_listeners = new ArrayList<PingReplyListener>();
 
-    @SuppressWarnings("unused")
     protected AbstractPinger(int pingerId, NativeDatagramSocket pingSocket) {
         m_pingerId = pingerId;
         m_pingSocket = pingSocket;

--- a/opennms-icmp/opennms-icmp-jna/src/main/java/org/opennms/netmgt/icmp/jna/V4PingRequest.java
+++ b/opennms-icmp/opennms-icmp-jna/src/main/java/org/opennms/netmgt/icmp/jna/V4PingRequest.java
@@ -39,7 +39,7 @@ class V4PingRequest extends ICMPEchoPacket {
     
     // The below long is equivalent to the next line and is more efficient than
     // manipulation as a string
-    // Charset.forName("US-ASCII").encode("OpenNMS!").getLong(0);
+    // StandardCharsets.US_ASCII.encode("OpenNMS!").getLong(0);
     public static final int PACKET_LENGTH = 64;
     public static final long COOKIE = 0x4F70656E4E4D5321L;
     public static final int OFFSET_COOKIE = 0;

--- a/opennms-install/src/main/java/org/opennms/install/Installer.java
+++ b/opennms-install/src/main/java/org/opennms/install/Installer.java
@@ -41,6 +41,7 @@ import java.io.PrintWriter;
 import java.io.Reader;
 import java.net.InetAddress;
 import java.nio.channels.FileChannel;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Map;
@@ -728,7 +729,7 @@ public class Installer {
             return;
         }
 
-        Reader fr = new InputStreamReader(new FileInputStream(f), "UTF-8");
+        Reader fr = new InputStreamReader(new FileInputStream(f), StandardCharsets.UTF_8);
         BufferedReader r = new BufferedReader(fr);
         String line;
 
@@ -886,7 +887,7 @@ public class Installer {
 
         System.out.print("- setting tomcat4 user to 'root'... ");
 
-        BufferedReader r = new BufferedReader(new InputStreamReader(new FileInputStream(f), "UTF-8"));
+        BufferedReader r = new BufferedReader(new InputStreamReader(new FileInputStream(f), StandardCharsets.UTF_8));
         StringBuffer b = new StringBuffer();
         String line;
 
@@ -1024,7 +1025,7 @@ public class Installer {
             return null;
         }
         Pattern p = Pattern.compile("The Tomcat (\\S+) Servlet/JSP Container");
-        BufferedReader in = new BufferedReader(new InputStreamReader(new FileInputStream(file), "UTF-8"));
+        BufferedReader in = new BufferedReader(new InputStreamReader(new FileInputStream(file), StandardCharsets.UTF_8));
         for (int i = 0; i < 5; i++) {
             String line = in.readLine();
             if (line == null) { // EOF

--- a/opennms-model/src/main/java/org/opennms/netmgt/model/OnmsResource.java
+++ b/opennms-model/src/main/java/org/opennms/netmgt/model/OnmsResource.java
@@ -31,6 +31,7 @@ package org.opennms.netmgt.model;
 import java.io.UnsupportedEncodingException;
 import java.lang.reflect.UndeclaredThrowableException;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -327,7 +328,7 @@ public class OnmsResource implements Comparable<OnmsResource> {
     private static String encode(String string) {
         if (string == null) return null;
         try {
-            return URLEncoder.encode(string, "UTF-8");
+            return URLEncoder.encode(string, StandardCharsets.UTF_8.name());
         } catch (UnsupportedEncodingException e) {
             // UTF-8 should *never* throw this
             throw new UndeclaredThrowableException(e);

--- a/opennms-provision/opennms-detector-bsf/src/main/java/org/opennms/netmgt/provision/detector/bsf/client/BSFClient.java
+++ b/opennms-provision/opennms-detector-bsf/src/main/java/org/opennms/netmgt/provision/detector/bsf/client/BSFClient.java
@@ -34,6 +34,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.InetAddress;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -93,7 +94,7 @@ public class BSFClient implements Client<BSFRequest, BSFResponse> {
             }
 
             if (file.exists() && file.canRead()) {
-                String code = IOUtils.getStringFromReader(new InputStreamReader(new FileInputStream(file), "UTF-8"));
+                String code = IOUtils.getStringFromReader(new InputStreamReader(new FileInputStream(file), StandardCharsets.UTF_8));
 
                 // Declare some beans that can be used inside the script
                 bsfManager.declareBean("map", map, Map.class);

--- a/opennms-provision/opennms-detector-lineoriented/src/main/java/org/opennms/netmgt/provision/detector/simple/AsyncLineOrientedDetectorMinaImpl.java
+++ b/opennms-provision/opennms-detector-lineoriented/src/main/java/org/opennms/netmgt/provision/detector/simple/AsyncLineOrientedDetectorMinaImpl.java
@@ -28,7 +28,7 @@
 
 package org.opennms.netmgt.provision.detector.simple;
 
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.mina.filter.codec.ProtocolCodecFilter;
 import org.opennms.netmgt.provision.detector.simple.request.LineOrientedRequest;
@@ -45,8 +45,6 @@ import org.opennms.netmgt.provision.support.codec.LineOrientedCodecFactory;
  */
 public abstract class AsyncLineOrientedDetectorMinaImpl extends AsyncBasicDetectorMinaImpl<LineOrientedRequest, LineOrientedResponse> {
 
-    protected static final Charset CHARSET_UTF8 = Charset.forName("UTF-8");
-
     /**
      * <p>Constructor for AsyncLineOrientedDetector.</p>
      *
@@ -55,7 +53,7 @@ public abstract class AsyncLineOrientedDetectorMinaImpl extends AsyncBasicDetect
      */
     public AsyncLineOrientedDetectorMinaImpl(final String serviceName, final int port) {
         super(serviceName, port);
-        setProtocolCodecFilter(new ProtocolCodecFilter(new LineOrientedCodecFactory(CHARSET_UTF8)));
+        setProtocolCodecFilter(new ProtocolCodecFilter(new LineOrientedCodecFactory(StandardCharsets.UTF_8)));
     }
 
     /**
@@ -68,7 +66,7 @@ public abstract class AsyncLineOrientedDetectorMinaImpl extends AsyncBasicDetect
      */
     public AsyncLineOrientedDetectorMinaImpl(final String serviceName, final int port, final int timeout, final int retries) {
         super(serviceName, port, timeout, retries);
-        setProtocolCodecFilter(new ProtocolCodecFilter(new LineOrientedCodecFactory(CHARSET_UTF8)));
+        setProtocolCodecFilter(new ProtocolCodecFilter(new LineOrientedCodecFactory(StandardCharsets.UTF_8)));
     }
 
     /** {@inheritDoc} */

--- a/opennms-provision/opennms-detector-lineoriented/src/main/java/org/opennms/netmgt/provision/detector/simple/AsyncLineOrientedDetectorNettyImpl.java
+++ b/opennms-provision/opennms-detector-lineoriented/src/main/java/org/opennms/netmgt/provision/detector/simple/AsyncLineOrientedDetectorNettyImpl.java
@@ -28,8 +28,6 @@
 
 package org.opennms.netmgt.provision.detector.simple;
 
-import java.nio.charset.Charset;
-
 import org.jboss.netty.channel.ChannelPipeline;
 import org.jboss.netty.handler.codec.frame.DelimiterBasedFrameDecoder;
 import org.jboss.netty.handler.codec.frame.Delimiters;
@@ -52,8 +50,6 @@ import org.opennms.netmgt.provision.support.ResponseValidator;
  * @version $Id: $
  */
 public abstract class AsyncLineOrientedDetectorNettyImpl extends AsyncBasicDetectorNettyImpl<LineOrientedRequest, LineOrientedResponse> {
-
-    protected static final Charset CHARSET_UTF8 = Charset.forName("UTF-8");
 
     /**
      * <p>Constructor for AsyncLineOrientedDetectorNettyImpl.</p>

--- a/opennms-provision/opennms-detector-lineoriented/src/main/java/org/opennms/netmgt/provision/detector/simple/FtpDetector.java
+++ b/opennms-provision/opennms-detector-lineoriented/src/main/java/org/opennms/netmgt/provision/detector/simple/FtpDetector.java
@@ -28,6 +28,8 @@
 
 package org.opennms.netmgt.provision.detector.simple;
 
+import java.nio.charset.StandardCharsets;
+
 import org.apache.mina.filter.codec.ProtocolCodecFilter;
 import org.opennms.netmgt.provision.support.codec.MultilineOrientedCodecFactory;
 
@@ -67,7 +69,7 @@ public class FtpDetector extends AsyncMultilineDetectorMinaImpl {
     @Override
     protected void onInit() {
         //setup the correct codec for this Detector
-        setProtocolCodecFilter(new ProtocolCodecFilter(new MultilineOrientedCodecFactory(CHARSET_UTF8, getMultilineIndicator())));
+        setProtocolCodecFilter(new ProtocolCodecFilter(new MultilineOrientedCodecFactory(StandardCharsets.UTF_8, getMultilineIndicator())));
         
         expectBanner(expectCodeRange(100, 600));
         send(request("quit"), expectCodeRange(100,600));

--- a/opennms-provision/opennms-detector-lineoriented/src/main/java/org/opennms/netmgt/provision/detector/simple/SmtpDetector.java
+++ b/opennms-provision/opennms-detector-lineoriented/src/main/java/org/opennms/netmgt/provision/detector/simple/SmtpDetector.java
@@ -28,6 +28,8 @@
 
 package org.opennms.netmgt.provision.detector.simple;
 
+import java.nio.charset.StandardCharsets;
+
 import org.apache.mina.filter.codec.ProtocolCodecFilter;
 import org.opennms.netmgt.provision.support.codec.MultilineOrientedCodecFactory;
 
@@ -65,7 +67,7 @@ public class SmtpDetector extends AsyncMultilineDetectorMinaImpl {
      */
     @Override
     protected void onInit() {
-        setProtocolCodecFilter(new ProtocolCodecFilter(new MultilineOrientedCodecFactory(CHARSET_UTF8, "-")));
+        setProtocolCodecFilter(new ProtocolCodecFilter(new MultilineOrientedCodecFactory(StandardCharsets.UTF_8, "-")));
         
         expectBanner(startsWith("220"));
         send(request("HELO LOCALHOST"), startsWith("250"));

--- a/opennms-provision/opennms-detector-lineoriented/src/main/java/org/opennms/netmgt/provision/detector/simple/TcpDetector.java
+++ b/opennms-provision/opennms-detector-lineoriented/src/main/java/org/opennms/netmgt/provision/detector/simple/TcpDetector.java
@@ -28,6 +28,8 @@
 
 package org.opennms.netmgt.provision.detector.simple;
 
+import java.nio.charset.StandardCharsets;
+
 import org.apache.mina.filter.codec.ProtocolCodecFilter;
 import org.opennms.netmgt.provision.detector.simple.request.LineOrientedRequest;
 import org.opennms.netmgt.provision.detector.simple.response.LineOrientedResponse;
@@ -67,7 +69,7 @@ public class TcpDetector extends AsyncLineOrientedDetectorMinaImpl {
     public TcpDetector(final String serviceName, final int port) {
         super(serviceName, port);
         setDetectorHandler(new TcpDetectorHandler());
-        setProtocolCodecFilter(new ProtocolCodecFilter(new TcpCodecFactory(CHARSET_UTF8)));
+        setProtocolCodecFilter(new ProtocolCodecFilter(new TcpCodecFactory(StandardCharsets.UTF_8)));
     }
 
     /**

--- a/opennms-provision/opennms-detector-lineoriented/src/main/java/org/opennms/netmgt/provision/detector/simple/request/LineOrientedRequest.java
+++ b/opennms-provision/opennms-detector-lineoriented/src/main/java/org/opennms/netmgt/provision/detector/simple/request/LineOrientedRequest.java
@@ -30,6 +30,7 @@ package org.opennms.netmgt.provision.detector.simple.request;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 
 /**
  * <p>LineOrientedRequest class.</p>
@@ -62,7 +63,7 @@ public class LineOrientedRequest {
      * @param out a {@link java.io.OutputStream} object.
      */
     public void send(final OutputStream out) throws IOException {
-        out.write(String.format("%s\r\n", m_command).getBytes("UTF-8"));
+        out.write(String.format("%s\r\n", m_command).getBytes(StandardCharsets.UTF_8));
     }
     
     /**

--- a/opennms-provision/opennms-detector-web/src/main/java/org/opennms/netmgt/provision/detector/web/client/WebClient.java
+++ b/opennms-provision/opennms-detector-web/src/main/java/org/opennms/netmgt/provision/detector/web/client/WebClient.java
@@ -30,7 +30,7 @@ package org.opennms.netmgt.provision.detector.web.client;
 
 import java.io.IOException;
 import java.net.InetAddress;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map.Entry;
 
@@ -85,7 +85,7 @@ public class WebClient implements Client<WebRequest, WebResponse> {
         ub.setPort(port);
         ub.setPath(m_path);
         if (m_queryString != null && m_queryString.trim().length() > 0) {
-            final List<NameValuePair> params = URLEncodedUtils.parse(m_queryString, Charset.forName("UTF-8"));
+            final List<NameValuePair> params = URLEncodedUtils.parse(m_queryString, StandardCharsets.UTF_8);
             if (!params.isEmpty()) {
                 ub.setParameters(params);
             }

--- a/opennms-provision/opennms-mock-simpleserver/src/main/java/org/opennms/netmgt/provision/server/AsyncSimpleServer.java
+++ b/opennms-provision/opennms-mock-simpleserver/src/main/java/org/opennms/netmgt/provision/server/AsyncSimpleServer.java
@@ -29,7 +29,7 @@
 package org.opennms.netmgt.provision.server;
 
 import java.net.InetSocketAddress;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.mina.core.service.IoAcceptor;
 import org.apache.mina.core.service.IoHandler;
@@ -47,8 +47,7 @@ import org.opennms.netmgt.provision.server.exchange.LineConversation;
  * @version $Id: $
  */
 public class AsyncSimpleServer {
-    
-    protected static final Charset CHARSET_UTF8 = Charset.forName("UTF-8");
+
     private LineConversation m_lineConversation;
     private IoAcceptor m_acceptor;
     private IoHandler m_ioHandler;
@@ -82,7 +81,7 @@ public class AsyncSimpleServer {
         
         m_acceptor = new NioSocketAcceptor();
         m_acceptor.getFilterChain().addLast("logger", new LoggingFilter());
-        m_acceptor.getFilterChain().addLast("codec", new ProtocolCodecFilter(new TextLineCodecFactory(CHARSET_UTF8)));
+        m_acceptor.getFilterChain().addLast("codec", new ProtocolCodecFilter(new TextLineCodecFactory(StandardCharsets.UTF_8)));
         
         m_acceptor.setHandler(getServerHandler());
         m_acceptor.getSessionConfig().setReadBufferSize(getBufferSize());

--- a/opennms-provision/opennms-provision-api/src/main/java/org/opennms/netmgt/provision/support/AsyncBasicDetector.java
+++ b/opennms-provision/opennms-provision-api/src/main/java/org/opennms/netmgt/provision/support/AsyncBasicDetector.java
@@ -28,7 +28,6 @@
 
 package org.opennms.netmgt.provision.support;
 
-import java.nio.charset.Charset;
 import java.util.regex.Pattern;
 
 import org.apache.mina.core.session.IdleStatus;
@@ -40,8 +39,6 @@ import org.apache.mina.core.session.IdleStatus;
  * @version $Id: $
  */
 public abstract class AsyncBasicDetector<Request, Response> extends AsyncAbstractDetector {
-    
-    protected static final Charset CHARSET_UTF8 = Charset.forName("UTF-8");
 
     /**
      * Default value of 3000ms = 3s

--- a/opennms-provision/opennms-provision-api/src/main/java/org/opennms/netmgt/provision/support/AsyncBasicDetectorMinaImpl.java
+++ b/opennms-provision/opennms-provision-api/src/main/java/org/opennms/netmgt/provision/support/AsyncBasicDetectorMinaImpl.java
@@ -31,6 +31,7 @@ package org.opennms.netmgt.provision.support;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 
@@ -65,7 +66,7 @@ public abstract class AsyncBasicDetectorMinaImpl<Request, Response> extends Asyn
     
     private BaseDetectorHandler<Request, Response> m_detectorHandler = new BaseDetectorHandler<Request, Response>();
     private IoFilterAdapter m_filterLogging = null;
-    private ProtocolCodecFilter m_protocolCodecFilter = new ProtocolCodecFilter(new TextLineCodecFactory(CHARSET_UTF8));
+    private ProtocolCodecFilter m_protocolCodecFilter = new ProtocolCodecFilter(new TextLineCodecFactory(StandardCharsets.UTF_8));
     
     private final ConnectionFactory m_connectionFactory;
 

--- a/opennms-provision/opennms-provision-persistence/src/main/java/org/opennms/netmgt/provision/persist/AbstractForeignSourceRepository.java
+++ b/opennms-provision/opennms-provision-persistence/src/main/java/org/opennms/netmgt/provision/persist/AbstractForeignSourceRepository.java
@@ -33,6 +33,7 @@ import java.io.FileOutputStream;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.commons.io.IOUtils;
 import org.opennms.core.utils.ConfigFileConstants;
@@ -98,7 +99,7 @@ public abstract class AbstractForeignSourceRepository implements ForeignSourceRe
         OutputStream outputStream = null;
         try {
             outputStream = new FileOutputStream(outputFile);
-            writer = new OutputStreamWriter(outputStream, "UTF-8");
+            writer = new OutputStreamWriter(outputStream, StandardCharsets.UTF_8);
             JaxbUtils.marshal(foreignSource, writer);
         } catch (final Throwable e) {
             throw new ForeignSourceRepositoryException("unable to write requisition to " + outputFile.getPath(), e);

--- a/opennms-provision/opennms-provision-persistence/src/main/java/org/opennms/netmgt/provision/persist/FilesystemForeignSourceRepository.java
+++ b/opennms-provision/opennms-provision-persistence/src/main/java/org/opennms/netmgt/provision/persist/FilesystemForeignSourceRepository.java
@@ -35,6 +35,7 @@ import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.Date;
 import java.util.Set;
 import java.util.TreeSet;
@@ -194,7 +195,7 @@ public class FilesystemForeignSourceRepository extends AbstractForeignSourceRepo
             Writer writer = null;
             try {
                 outputStream = new FileOutputStream(outputFile);
-                writer = new OutputStreamWriter(outputStream, "UTF-8");
+                writer = new OutputStreamWriter(outputStream, StandardCharsets.UTF_8);
                 JaxbUtils.marshal(foreignSource, writer);
             } catch (final Throwable e) {
                 throw new ForeignSourceRepositoryException("unable to write requisition to " + outputFile.getPath(), e);
@@ -314,7 +315,7 @@ public class FilesystemForeignSourceRepository extends AbstractForeignSourceRepo
             OutputStream outputStream = null;
             try {
                 outputStream = new FileOutputStream(outputFile);
-                writer = new OutputStreamWriter(outputStream, "UTF-8");
+                writer = new OutputStreamWriter(outputStream, StandardCharsets.UTF_8);
                 JaxbUtils.marshal(requisition, writer);
             } catch (final Throwable e) {
                 throw new ForeignSourceRepositoryException("unable to write requisition to " + outputFile.getPath(), e);

--- a/opennms-provision/opennms-provision-persistence/src/main/java/org/opennms/netmgt/provision/persist/RequisitionFileUtils.java
+++ b/opennms-provision/opennms-provision-persistence/src/main/java/org/opennms/netmgt/provision/persist/RequisitionFileUtils.java
@@ -33,6 +33,7 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URL;
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -216,7 +217,7 @@ public abstract class RequisitionFileUtils {
 
     private static String getFilename(final URL url) {
         try {
-            return URLDecoder.decode(url.getFile(), "UTF-8");
+            return URLDecoder.decode(url.getFile(), StandardCharsets.UTF_8.name());
         } catch (UnsupportedEncodingException e) {
             LOG.warn("Failed to decode URL {} as a file.", url.getFile(), e);
             return null;

--- a/opennms-provision/opennms-provision-persistence/src/test/java/org/opennms/netmgt/provision/persist/PersistenceSerializationTest.java
+++ b/opennms-provision/opennms-provision-persistence/src/test/java/org/opennms/netmgt/provision/persist/PersistenceSerializationTest.java
@@ -37,6 +37,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -154,7 +155,7 @@ public class PersistenceSerializationTest {
         StringBuffer exampleXML = new StringBuffer();
         File foreignSources = new File(ClassLoader.getSystemResource("foreign-sources.xml").getFile());
         assertTrue("foreign-sources.xml is readable", foreignSources.canRead());
-        BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream(foreignSources), "UTF-8"));
+        BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream(foreignSources), StandardCharsets.UTF_8));
         String line;
         while (true) {
             line = reader.readLine();

--- a/opennms-provision/opennms-provisiond/src/main/java/org/opennms/netmgt/provision/service/dns/DnsRequisitionUrlConnection.java
+++ b/opennms-provision/opennms-provisiond/src/main/java/org/opennms/netmgt/provision/service/dns/DnsRequisitionUrlConnection.java
@@ -36,6 +36,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLConnection;
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -552,7 +553,7 @@ public class DnsRequisitionUrlConnection extends URLConnection {
         
         String query = null;
         try {
-            query = URLDecoder.decode(url.getQuery(), "UTF-8");
+            query = URLDecoder.decode(url.getQuery(), StandardCharsets.UTF_8.name());
         } catch (UnsupportedEncodingException e) {
             LOG.error("decodeQueryString", e);
         }

--- a/opennms-reporting/src/main/java/org/opennms/report/inventory/InventoryReportRunner.java
+++ b/opennms-reporting/src/main/java/org/opennms/report/inventory/InventoryReportRunner.java
@@ -301,7 +301,7 @@ public class InventoryReportRunner implements Runnable {
                 FileOutputStream hmtlFileWriter = new FileOutputStream(file);
                 PDFWriter htmlWriter = new PDFWriter(ConfigFileConstants.getFilePathString() + "/rws-nbinventoryreport.xsl");
                 File fileR = new File(xmlFileName);
-                Reader fileReader = new InputStreamReader(new FileInputStream(fileR), "UTF-8");
+                Reader fileReader = new InputStreamReader(new FileInputStream(fileR), StandardCharsets.UTF_8);
                 htmlWriter.generateHTML(fileReader, hmtlFileWriter);
                 log().debug("runNodeBaseInventoryReport html sending email");
                 ReportMailer mailer = new ReportMailer(reportEmail,htmlFileName,"OpenNMS Inventory Report");

--- a/opennms-services/src/main/java/org/opennms/netmgt/collectd/HttpCollector.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/collectd/HttpCollector.java
@@ -36,6 +36,7 @@ import java.lang.reflect.UndeclaredThrowableException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
@@ -573,12 +574,8 @@ public class HttpCollector implements ServiceCollector {
     private static HttpPost buildPostMethod(final URI uri, final HttpCollectionSet collectionSet) {
         HttpPost method = new HttpPost(uri);
         List<NameValuePair> postParams = buildRequestParameters(collectionSet);
-        try {
-            UrlEncodedFormEntity entity = new UrlEncodedFormEntity(postParams, "UTF-8");
-            method.setEntity(entity);
-        } catch (UnsupportedEncodingException e) {
-            // Should never happen
-        }
+        UrlEncodedFormEntity entity = new UrlEncodedFormEntity(postParams, StandardCharsets.UTF_8);
+        method.setEntity(entity);
         return method;
     }
 
@@ -587,7 +584,7 @@ public class HttpCollector implements ServiceCollector {
         List<NameValuePair> queryParams = buildRequestParameters(collectionSet);
         try {
             StringBuffer query = new StringBuffer();
-            query.append(URLEncodedUtils.format(queryParams, "UTF-8"));
+            query.append(URLEncodedUtils.format(queryParams, StandardCharsets.UTF_8));
             if (uri.getQuery() != null && !uri.getQuery().trim().isEmpty()) {
                 if (query.length() > 0) {
                     query.append("&");
@@ -596,7 +593,7 @@ public class HttpCollector implements ServiceCollector {
             }
             final URIBuilder ub = new URIBuilder(uri);
             if (query.length() > 0) {
-                final List<NameValuePair> params = URLEncodedUtils.parse(query.toString(), Charset.forName("UTF-8"));
+                final List<NameValuePair> params = URLEncodedUtils.parse(query.toString(), StandardCharsets.UTF_8);
                 if (!params.isEmpty()) {
                     ub.setParameters(params);
                 }
@@ -633,7 +630,7 @@ public class HttpCollector implements ServiceCollector {
         ub.setPath(substituteKeywords(substitutions, collectionSet.getUriDef().getUrl().getPath(), "getURL"));
 
         final String query = substituteKeywords(substitutions, collectionSet.getUriDef().getUrl().getQuery(), "getQuery");
-        final List<NameValuePair> params = URLEncodedUtils.parse(query, Charset.forName("UTF-8"));
+        final List<NameValuePair> params = URLEncodedUtils.parse(query, StandardCharsets.UTF_8);
         ub.setParameters(params);
 
         ub.setFragment(substituteKeywords(substitutions, collectionSet.getUriDef().getUrl().getFragment(), "getFragment"));

--- a/opennms-services/src/main/java/org/opennms/netmgt/notifd/BSFNotificationStrategy.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/notifd/BSFNotificationStrategy.java
@@ -33,6 +33,7 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -108,7 +109,7 @@ public class BSFNotificationStrategy implements NotificationStrategy {
             }
 
             if(scriptFile.exists() && scriptFile.canRead()){   
-                String code = IOUtils.getStringFromReader(new InputStreamReader(new FileInputStream(scriptFile), "UTF-8"));
+                String code = IOUtils.getStringFromReader(new InputStreamReader(new FileInputStream(scriptFile), StandardCharsets.UTF_8));
 
                 // Check foot before firing
                 obj.checkAberrantScriptBehaviors(code);

--- a/opennms-services/src/main/java/org/opennms/netmgt/notifd/CommandExecutor.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/notifd/CommandExecutor.java
@@ -31,6 +31,7 @@ package org.opennms.netmgt.notifd;
 import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -116,7 +117,7 @@ public class CommandExecutor implements ExecutorStrategy {
             // see if we have streamed arguments
             if (streamed) {
                 // make sure the output we are writing is buffered
-                BufferedWriter processInput = new BufferedWriter(new OutputStreamWriter(command.getOutputStream(), "UTF-8"));
+                BufferedWriter processInput = new BufferedWriter(new OutputStreamWriter(command.getOutputStream(), StandardCharsets.UTF_8));
 
                 // put the streamed arguments into the stream
                 LOG.debug("Streamed arguments: {}", streamBuffer);

--- a/opennms-services/src/main/java/org/opennms/netmgt/notifd/HttpNotificationStrategy.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/notifd/HttpNotificationStrategy.java
@@ -30,6 +30,7 @@ package org.opennms.netmgt.notifd;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -99,12 +100,8 @@ public class HttpNotificationStrategy implements NotificationStrategy {
                 LOG.debug("send: post argument: {} = {}", post.getName(), post.getValue());
             }
             method = new HttpPost(url);
-            try {
-                final UrlEncodedFormEntity entity = new UrlEncodedFormEntity(posts, "UTF-8");
-                ((HttpPost)method).setEntity(entity);
-            } catch (UnsupportedEncodingException e) {
-                // Should never happen
-            }
+            final UrlEncodedFormEntity entity = new UrlEncodedFormEntity(posts, StandardCharsets.UTF_8);
+            ((HttpPost)method).setEntity(entity);
         }
 
         String contents = null;

--- a/opennms-services/src/main/java/org/opennms/netmgt/rtc/HttpUtils.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/rtc/HttpUtils.java
@@ -39,6 +39,7 @@ import java.io.OutputStreamWriter;
 import java.io.Reader;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 
 /**
  * Provides convenience methods for use the HTTP POST method.
@@ -227,7 +228,7 @@ public abstract class HttpUtils {
         conn.setRequestProperty("Content-type", "text/xml; charset=\"utf-8\"");
 
         // get the out-going HTTP connection
-        OutputStreamWriter ostream = new OutputStreamWriter(conn.getOutputStream(), "US-ASCII");
+        OutputStreamWriter ostream = new OutputStreamWriter(conn.getOutputStream(), StandardCharsets.US_ASCII);
 
         // log data
         LOG.debug("HTTP Post: Current time: {}", new java.text.SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(new java.util.GregorianCalendar().getTime()));

--- a/opennms-services/src/test/java/org/opennms/netmgt/collectd/SnmpAttributeTest.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/collectd/SnmpAttributeTest.java
@@ -35,6 +35,7 @@ import static org.easymock.EasyMock.matches;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -209,7 +210,7 @@ public class SnmpAttributeTest {
         String longValue = "49197860";
         testPersisting(
             new Double(longValue).toString(),
-            new Snmp4JValueFactory().getOctetString(longValue.getBytes("UTF-8"))
+            new Snmp4JValueFactory().getOctetString(longValue.getBytes(StandardCharsets.UTF_8))
         );
     }
 

--- a/opennms-services/src/test/java/org/opennms/netmgt/config/EventTranslatorConfigFactoryIT.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/config/EventTranslatorConfigFactoryIT.java
@@ -30,6 +30,7 @@ package org.opennms.netmgt.config;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 
 import org.junit.After;
 import org.junit.Before;
@@ -65,7 +66,7 @@ public class EventTranslatorConfigFactoryIT extends OpenNMSITCase {
         m_eventMgr.addEventListener(m_outageAnticipator);
         m_eventMgr.setSynchronous(true);
 
-        InputStream rdr = new ByteArrayInputStream(m_passiveStatusConfiguration.getBytes("UTF-8"));
+        InputStream rdr = new ByteArrayInputStream(m_passiveStatusConfiguration.getBytes(StandardCharsets.UTF_8));
         m_config = new EventTranslatorConfigFactory(rdr, m_db);
         EventTranslatorConfigFactory.setInstance(m_config);
 

--- a/opennms-services/src/test/java/org/opennms/netmgt/translator/EventTranslatorIT.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/translator/EventTranslatorIT.java
@@ -36,6 +36,7 @@ import static org.junit.Assert.assertTrue;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Statement;
@@ -100,7 +101,7 @@ public class EventTranslatorIT {
         m_eventMgr.addEventListener(m_outageAnticipator);
         m_eventMgr.setSynchronous(true);
 
-        InputStream rdr = new ByteArrayInputStream(m_passiveStatusConfiguration.getBytes("UTF-8"));
+        InputStream rdr = new ByteArrayInputStream(m_passiveStatusConfiguration.getBytes(StandardCharsets.UTF_8));
         m_config = new EventTranslatorConfigFactory(rdr, m_db);
         EventTranslatorConfigFactory.setInstance(m_config);
         
@@ -265,7 +266,7 @@ public class EventTranslatorIT {
     
     @Test
     public void testTranslateLinkDown() throws SQLException, IOException {
-        InputStream rdr = new ByteArrayInputStream(getLinkDownTranslation().getBytes("UTF-8"));
+        InputStream rdr = new ByteArrayInputStream(getLinkDownTranslation().getBytes(StandardCharsets.UTF_8));
         m_config = new EventTranslatorConfigFactory(rdr, m_db);
         EventTranslatorConfigFactory.setInstance(m_config);
         

--- a/opennms-util/src/main/java/org/opennms/core/utils/url/GenericURLConnection.java
+++ b/opennms-util/src/main/java/org/opennms/core/utils/url/GenericURLConnection.java
@@ -35,6 +35,7 @@ import java.io.UnsupportedEncodingException;
 import java.net.URL;
 import java.net.URLConnection;
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -60,11 +61,6 @@ public abstract class GenericURLConnection extends URLConnection {
      * User and password delimiter for URL user:pass@host
      */
     private static final String USERINFO_DELIMITER = ":";
-
-    /**
-     * Default encoding for URL
-     */
-    private static final String UTF8_ENCODING = "UTF-8";
 
     /**
      * Delimiter for URL arguments
@@ -146,10 +142,10 @@ public abstract class GenericURLConnection extends URLConnection {
         if (queryString != null) {
 
             try {
-                queryString = URLDecoder.decode(queryString, UTF8_ENCODING);
+                queryString = URLDecoder.decode(queryString, StandardCharsets.UTF_8.name());
             } catch (UnsupportedEncodingException e) {
                 // Your system does not support UTF-8 encoding
-                logger.error("Unsupported " + UTF8_ENCODING + " encoding for URL query string: '{}'. Error message: '{}'", queryString, e.getMessage());
+                logger.error("Unsupported {} encoding for URL query string: '{}'. Error message: '{}'", StandardCharsets.UTF_8.name(), queryString, e.getMessage());
             }
 
             // queryString is everthing behind "?"

--- a/opennms-web-api/src/main/java/org/opennms/web/api/Util.java
+++ b/opennms-web-api/src/main/java/org/opennms/web/api/Util.java
@@ -35,6 +35,7 @@ import java.net.InetSocketAddress;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.net.UnknownHostException;
+import java.nio.charset.StandardCharsets;
 import java.text.DateFormat;
 import java.util.Arrays;
 import java.util.Collections;
@@ -185,7 +186,7 @@ public abstract class Util extends Object {
      */
     public static String encode(final String string) {
         try {
-            return URLEncoder.encode(string, "UTF-8");
+            return URLEncoder.encode(string, StandardCharsets.UTF_8.name());
         } catch (final UnsupportedEncodingException e) {
             // UTF-8 should *never* throw this
             throw new UndeclaredThrowableException(e);
@@ -201,7 +202,7 @@ public abstract class Util extends Object {
      */
     public static String decode(final String string) {
         try {
-            return URLDecoder.decode(string, "UTF-8");
+            return URLDecoder.decode(string, StandardCharsets.UTF_8.name());
         } catch (UnsupportedEncodingException e) {
             // UTF-8 should *never* throw this
             throw new UndeclaredThrowableException(e);

--- a/opennms-web-api/src/test/java/org/opennms/web/charts/ChartUtilsIT.java
+++ b/opennms-web-api/src/test/java/org/opennms/web/charts/ChartUtilsIT.java
@@ -40,6 +40,7 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
 
 import org.jfree.chart.JFreeChart;
@@ -195,7 +196,7 @@ public class ChartUtilsIT {
 
     private static void initalizeChartFactory() throws IOException {
         ChartConfigFactory.setInstance(new ChartConfigFactory());
-        ByteArrayInputStream rdr = new ByteArrayInputStream(CHART_CONFIG.getBytes("UTF-8"));
+        ByteArrayInputStream rdr = new ByteArrayInputStream(CHART_CONFIG.getBytes(StandardCharsets.UTF_8));
         ChartConfigFactory.parseXml(rdr);
         rdr.close();        
         //        m_config = ChartConfigFactory.getInstance().getConfiguration();

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/AvailabilityRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/AvailabilityRestService.java
@@ -32,6 +32,7 @@ import static org.opennms.core.utils.InetAddressUtils.str;
 
 import java.io.IOException;
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -115,7 +116,7 @@ public class AvailabilityRestService extends OnmsRestService {
     @Path("/categories/{category}")
     public Category getCategory(@PathParam("category") final String categoryName) {
         try {
-            final String category = URLDecoder.decode(categoryName, "UTF-8");
+            final String category = URLDecoder.decode(categoryName, StandardCharsets.UTF_8.name());
             final Category cat = CategoryModel.getInstance().getCategory(category);
             if (cat == null) {
                 throw getException(Status.NOT_FOUND, "Category {} was not found.", categoryName);
@@ -131,7 +132,7 @@ public class AvailabilityRestService extends OnmsRestService {
     @Path("/categories/{category}/nodes")
     public NodeList getCategoryNodes(@PathParam("category") final String categoryName) {
         try {
-            final String category = URLDecoder.decode(categoryName, "UTF-8");
+            final String category = URLDecoder.decode(categoryName, StandardCharsets.UTF_8.name());
             final Category cat = CategoryModel.getInstance().getCategory(category);
             if (cat == null) {
                 throw getException(Status.NOT_FOUND, "Category {} was not found.", categoryName);
@@ -147,7 +148,7 @@ public class AvailabilityRestService extends OnmsRestService {
     @Path("/categories/{category}/nodes/{nodeId}")
     public AvailabilityNode getCategoryNode(@PathParam("category") final String categoryName, @PathParam("nodeId") final Long nodeId) {
         try {
-            final String category = URLDecoder.decode(categoryName, "UTF-8");
+            final String category = URLDecoder.decode(categoryName, StandardCharsets.UTF_8.name());
             final Category cat = CategoryModel.getInstance().getCategory(category);
             if (cat == null) {
                 throw getException(Status.NOT_FOUND, "Category {} was not found.", categoryName);

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/GraphMLRestServiceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/GraphMLRestServiceIT.java
@@ -28,6 +28,8 @@
 
 package org.opennms.web.rest.v1;
 
+import java.nio.charset.StandardCharsets;
+
 import org.apache.commons.io.IOUtils;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -66,7 +68,7 @@ public class GraphMLRestServiceIT extends AbstractSpringJerseyRestTestCase {
 
     @Test
     public void verifyCanCreateAndDelete() throws Exception {
-        final String inputGraph = IOUtils.toString(getClass().getResourceAsStream("/v1/test-graph.xml"), "UTF-8");
+        final String inputGraph = IOUtils.toString(getClass().getResourceAsStream("/v1/test-graph.xml"), StandardCharsets.UTF_8);
 
         // Create
         sendPost("/graphml/new-graph", inputGraph, 201);

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/GraphRestServiceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/GraphRestServiceIT.java
@@ -32,6 +32,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.commons.io.FileUtils;
 import org.junit.Before;
@@ -115,12 +116,12 @@ public class GraphRestServiceIT extends AbstractSpringJerseyRestTestCase {
         sendRequest(GET, url, 404);
 
         // By resource
-        url = "/graphs/for/" + URLEncoder.encode("node[1].nodeSnmp[]", "UTF-8");
+        url = "/graphs/for/" + URLEncoder.encode("node[1].nodeSnmp[]", StandardCharsets.UTF_8.name());
         xml = sendRequest(GET, url, 200);
         assertTrue(xml.contains("netsnmp.swapinout"));
 
         // 404 on invalid resource
-        url = "/graphs/for/" + URLEncoder.encode("node[99].nodeSnmp[]", "UTF-8");
+        url = "/graphs/for/" + URLEncoder.encode("node[99].nodeSnmp[]", StandardCharsets.UTF_8.name());
         sendRequest(GET, url, 404);
 
         url = "/graphs/fornode/1";

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/NodeRestServiceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/NodeRestServiceIT.java
@@ -36,6 +36,7 @@ import static org.opennms.core.test.xml.XmlTest.assertXpathMatches;
 
 import java.io.FileInputStream;
 import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Comparator;
@@ -543,7 +544,7 @@ public class NodeRestServiceIT extends AbstractSpringJerseyRestTestCase {
 
         createIpInterface();
         byte[] encoded = Files.readAllBytes(Paths.get("src/test/resources/hardware-inventory.xml"));
-        String entity = new String(encoded, "UTF-8");
+        String entity = new String(encoded, StandardCharsets.UTF_8);
         sendPost("/nodes/1/hardwareInventory", entity, 204, null);
         String xml = sendRequest(GET, "/nodes/1/hardwareInventory", 200);
         assertTrue(xml, xml.contains("Cisco 7206VXR, 6-slot chassis"));

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/ResourceRestServiceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/ResourceRestServiceIT.java
@@ -33,6 +33,7 @@ import static org.junit.Assert.assertTrue;
 import java.io.File;
 import java.io.FileInputStream;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 
 import javax.servlet.ServletContext;
 import javax.ws.rs.core.MediaType;
@@ -122,12 +123,12 @@ public class ResourceRestServiceIT extends AbstractSpringJerseyRestTestCase {
         System.err.println(xml);
 
         // By ID
-        url = "/resources/" + URLEncoder.encode("node[1].nodeSnmp[]", "UTF-8");
+        url = "/resources/" + URLEncoder.encode("node[1].nodeSnmp[]", StandardCharsets.UTF_8.name());
         xml = sendRequest(GET, url, 200);
         assertTrue(xml.contains("Node-level Performance Data"));
 
         // 404 on invalid resource
-        url = "/resources/" + URLEncoder.encode("node[99].nodeSnmp[]", "UTF-8");
+        url = "/resources/" + URLEncoder.encode("node[99].nodeSnmp[]", StandardCharsets.UTF_8.name());
         sendRequest(GET, url, 404);
 
         // By Node ID

--- a/opennms-webapp/src/main/java/org/opennms/web/admin/config/PollerConfigServlet.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/admin/config/PollerConfigServlet.java
@@ -28,17 +28,16 @@
 
 package org.opennms.web.admin.config;
 
-import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
-import java.util.Properties;
 import java.util.StringTokenizer;
 
 import javax.servlet.ServletConfig;
@@ -187,7 +186,7 @@ public class PollerConfigServlet extends HttpServlet {
             adjustNonChecked(checkedList);
             deleteThese(deleteList);
 
-            try(Writer poller_fileWriter = new OutputStreamWriter(new FileOutputStream(ConfigFileConstants.getFile(ConfigFileConstants.POLLER_CONFIG_FILE_NAME)), "UTF-8")) {
+            try(Writer poller_fileWriter = new OutputStreamWriter(new FileOutputStream(ConfigFileConstants.getFile(ConfigFileConstants.POLLER_CONFIG_FILE_NAME)), StandardCharsets.UTF_8)) {
                 JaxbUtils.marshal(pollerConfig, poller_fileWriter);
             }
         }

--- a/opennms-webapp/src/main/java/org/opennms/web/admin/nodeManagement/ManageNodeServlet.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/admin/nodeManagement/ManageNodeServlet.java
@@ -35,6 +35,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
@@ -314,7 +315,7 @@ public class ManageNodeServlet extends HttpServlet {
         Writer fileWriter = null;
         try {
         	fos = new FileOutputStream(fileName);
-            fileWriter = new OutputStreamWriter(fos, "UTF-8");
+            fileWriter = new OutputStreamWriter(fos, StandardCharsets.UTF_8);
 
             for (int i = 0; i < interfaceList.size(); i++) {
                 fileWriter.write(interfaceList.get(i) + System.getProperty("line.separator"));

--- a/opennms-webapp/src/main/java/org/opennms/web/admin/nodeManagement/ManageNodesServlet.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/admin/nodeManagement/ManageNodesServlet.java
@@ -35,6 +35,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
@@ -306,7 +307,7 @@ public class ManageNodesServlet extends HttpServlet {
         FileOutputStream fos = null;
         try {
         	fos = new FileOutputStream(fileName);
-        	fileWriter = new OutputStreamWriter(fos, "UTF-8");
+        	fileWriter = new OutputStreamWriter(fos, StandardCharsets.UTF_8);
 
             for (int i = 0; i < interfaceList.size(); i++) {
                 fileWriter.write((String) interfaceList.get(i) + System.getProperty("line.separator"));

--- a/opennms-webapp/src/main/java/org/opennms/web/controller/NavBarController.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/controller/NavBarController.java
@@ -31,6 +31,7 @@ package org.opennms.web.controller;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -78,7 +79,7 @@ public class NavBarController extends AbstractController implements Initializing
 
         // Initialize the Freemarker engine and fetch our template
         Configuration cfg = new Configuration(Configuration.VERSION_2_3_21);
-        cfg.setDefaultEncoding("UTF-8");
+        cfg.setDefaultEncoding(StandardCharsets.UTF_8.name());
         cfg.setClassForTemplateLoading(NavBarController.class, "");
         cfg.setTemplateExceptionHandler(TemplateExceptionHandler.HTML_DEBUG_HANDLER);
         Template template = cfg.getTemplate("navbar.ftl");

--- a/opennms-webapp/src/main/java/org/opennms/web/element/ElementIdNotFoundException.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/element/ElementIdNotFoundException.java
@@ -30,6 +30,7 @@ package org.opennms.web.element;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 
 /**
  * <p>ElementIdNotFoundException class.</p>
@@ -109,7 +110,7 @@ public class ElementIdNotFoundException extends RuntimeException {
     
     private void setBadId(String idIn) {
     	try {
-			this.badId = URLEncoder.encode(idIn, "UTF-8");
+			this.badId = URLEncoder.encode(idIn, StandardCharsets.UTF_8.name());
 		} catch (UnsupportedEncodingException e) {
 			this.badId = "";
 		}

--- a/opennms-webapp/src/main/java/org/opennms/web/extremecomponent/view/resolver/OnmsPdfViewResolver.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/extremecomponent/view/resolver/OnmsPdfViewResolver.java
@@ -31,6 +31,7 @@ package org.opennms.web.extremecomponent.view.resolver;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
@@ -52,7 +53,7 @@ public class OnmsPdfViewResolver implements ViewResolver {
 
     @Override
     public void resolveView(ServletRequest request, ServletResponse response, Preferences preferences, Object viewData) throws Exception {
-        InputStream is = new ByteArrayInputStream(((String) viewData).getBytes("UTF-8"));
+        InputStream is = new ByteArrayInputStream(((String) viewData).getBytes(StandardCharsets.UTF_8));
         
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         

--- a/protocols/nsclient/src/main/java/org/opennms/protocols/nsclient/config/NSClientPeerFactory.java
+++ b/protocols/nsclient/src/main/java/org/opennms/protocols/nsclient/config/NSClientPeerFactory.java
@@ -29,6 +29,7 @@
 package org.opennms.protocols.nsclient.config;
 
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -39,6 +40,7 @@ import java.io.Writer;
 import java.math.BigInteger;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.TreeMap;
@@ -173,10 +175,11 @@ public final class NSClientPeerFactory {
 
     /**
      * Saves the current settings to disk
-     *
+     * @throws IOException 
+     * @throws FileNotFoundException 
      * @throws java.lang.Exception if any.
      */
-    public void saveCurrent() throws Exception {
+    public void saveCurrent() throws FileNotFoundException, IOException {
         getWriteLock().lock();
 
         try {
@@ -188,7 +191,7 @@ public final class NSClientPeerFactory {
             final StringWriter stringWriter = new StringWriter();
             JaxbUtils.marshal(m_config, stringWriter);
             if (stringWriter.toString() != null) {
-                final Writer fileWriter = new OutputStreamWriter(new FileOutputStream(ConfigFileConstants.getFile(ConfigFileConstants.NSCLIENT_CONFIG_FILE_NAME)), "UTF-8");
+                final Writer fileWriter = new OutputStreamWriter(new FileOutputStream(ConfigFileConstants.getFile(ConfigFileConstants.NSCLIENT_CONFIG_FILE_NAME)), StandardCharsets.UTF_8);
                 fileWriter.write(stringWriter.toString());
                 fileWriter.flush();
                 fileWriter.close();

--- a/protocols/nsclient/src/test/java/org/opennms/protocols/nsclient/config/NSClientPeerFactoryTest.java
+++ b/protocols/nsclient/src/test/java/org/opennms/protocols/nsclient/config/NSClientPeerFactoryTest.java
@@ -32,9 +32,9 @@ import static org.junit.Assert.assertEquals;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 import org.junit.Test;
-import org.opennms.protocols.nsclient.config.NSClientPeerFactory;
 
 /**
  * JUnit tests for the configureSNMP event handling and optimization of
@@ -61,7 +61,7 @@ public class NSClientPeerFactoryTest {
         "</nsclient-config>\n" + 
         "";
 
-        NSClientPeerFactory factory = new NSClientPeerFactory(new ByteArrayInputStream(amiConfigXml.getBytes("UTF-8")));
+        NSClientPeerFactory factory = new NSClientPeerFactory(new ByteArrayInputStream(amiConfigXml.getBytes(StandardCharsets.UTF_8)));
 
         assertEquals(1, factory.getConfig().getDefinition().size());
 
@@ -90,7 +90,7 @@ public class NSClientPeerFactoryTest {
         "</nsclient-config>\n" + 
         "";
 
-        NSClientPeerFactory factory = new NSClientPeerFactory(new ByteArrayInputStream(amiConfigXml.getBytes("UTF-8")));
+        NSClientPeerFactory factory = new NSClientPeerFactory(new ByteArrayInputStream(amiConfigXml.getBytes(StandardCharsets.UTF_8)));
 
         assertEquals(1, factory.getConfig().getDefinition().size());
         assertEquals(2, factory.getConfig().getDefinition().get(0).getSpecific().size());
@@ -119,7 +119,7 @@ public class NSClientPeerFactoryTest {
         "</nsclient-config>\n" + 
         "";
 
-        NSClientPeerFactory factory = new NSClientPeerFactory(new ByteArrayInputStream(amiConfigXml.getBytes("UTF-8")));
+        NSClientPeerFactory factory = new NSClientPeerFactory(new ByteArrayInputStream(amiConfigXml.getBytes(StandardCharsets.UTF_8)));
 
         assertEquals(1, factory.getConfig().getDefinition().size());
         assertEquals(2, factory.getConfig().getDefinition().get(0).getSpecific().size());
@@ -148,7 +148,7 @@ public class NSClientPeerFactoryTest {
         "</nsclient-config>\n" + 
         "";
 
-        NSClientPeerFactory factory = new NSClientPeerFactory(new ByteArrayInputStream(amiConfigXml.getBytes("UTF-8")));
+        NSClientPeerFactory factory = new NSClientPeerFactory(new ByteArrayInputStream(amiConfigXml.getBytes(StandardCharsets.UTF_8)));
 
         assertEquals(1, factory.getConfig().getDefinition().size());
         assertEquals(2, factory.getConfig().getDefinition().get(0).getSpecific().size());
@@ -177,7 +177,7 @@ public class NSClientPeerFactoryTest {
         "</nsclient-config>\n" + 
         "";
 
-        NSClientPeerFactory factory = new NSClientPeerFactory(new ByteArrayInputStream(amiConfigXml.getBytes("UTF-8")));
+        NSClientPeerFactory factory = new NSClientPeerFactory(new ByteArrayInputStream(amiConfigXml.getBytes(StandardCharsets.UTF_8)));
 
         assertEquals(1, factory.getConfig().getDefinition().size());
         assertEquals(2, factory.getConfig().getDefinition().get(0).getSpecific().size());
@@ -214,7 +214,7 @@ public class NSClientPeerFactoryTest {
         "</nsclient-config>\n" + 
         "";
 
-        NSClientPeerFactory factory = new NSClientPeerFactory(new ByteArrayInputStream(amiConfigXml.getBytes("UTF-8")));
+        NSClientPeerFactory factory = new NSClientPeerFactory(new ByteArrayInputStream(amiConfigXml.getBytes(StandardCharsets.UTF_8)));
 
         assertEquals(1, factory.getConfig().getDefinition().size());
         assertEquals(1, factory.getConfig().getDefinition().get(0).getSpecific().size());
@@ -252,7 +252,7 @@ public class NSClientPeerFactoryTest {
         "</nsclient-config>\n" + 
         "";
 
-        NSClientPeerFactory factory = new NSClientPeerFactory(new ByteArrayInputStream(amiConfigXml.getBytes("UTF-8")));
+        NSClientPeerFactory factory = new NSClientPeerFactory(new ByteArrayInputStream(amiConfigXml.getBytes(StandardCharsets.UTF_8)));
 
         assertEquals(1, factory.getConfig().getDefinition().size());
         assertEquals(1, factory.getConfig().getDefinition().get(0).getSpecific().size());
@@ -289,7 +289,7 @@ public class NSClientPeerFactoryTest {
         "</nsclient-config>\n" + 
         "";
 
-        NSClientPeerFactory factory = new NSClientPeerFactory(new ByteArrayInputStream(amiConfigXml.getBytes("UTF-8")));
+        NSClientPeerFactory factory = new NSClientPeerFactory(new ByteArrayInputStream(amiConfigXml.getBytes(StandardCharsets.UTF_8)));
 
         assertEquals(1, factory.getConfig().getDefinition().size());
         assertEquals(1, factory.getConfig().getDefinition().get(0).getSpecific().size());
@@ -324,7 +324,7 @@ public class NSClientPeerFactoryTest {
         "</nsclient-config>\n" + 
         "";
 
-        NSClientPeerFactory factory = new NSClientPeerFactory(new ByteArrayInputStream(amiConfigXml.getBytes("UTF-8")));
+        NSClientPeerFactory factory = new NSClientPeerFactory(new ByteArrayInputStream(amiConfigXml.getBytes(StandardCharsets.UTF_8)));
 
         assertEquals(1, factory.getConfig().getDefinition().size());
         assertEquals(1, factory.getConfig().getDefinition().get(0).getSpecific().size());
@@ -360,7 +360,7 @@ public class NSClientPeerFactoryTest {
         "</nsclient-config>\n" + 
         "";
 
-        NSClientPeerFactory factory = new NSClientPeerFactory(new ByteArrayInputStream(amiConfigXml.getBytes("UTF-8")));
+        NSClientPeerFactory factory = new NSClientPeerFactory(new ByteArrayInputStream(amiConfigXml.getBytes(StandardCharsets.UTF_8)));
 
         assertEquals(1, factory.getConfig().getDefinition().size());
         assertEquals(0, factory.getConfig().getDefinition().get(0).getSpecific().size());

--- a/protocols/xml/src/main/java/org/opennms/protocols/http/FormFields.java
+++ b/protocols/xml/src/main/java/org/opennms/protocols/http/FormFields.java
@@ -29,6 +29,7 @@
 package org.opennms.protocols.http;
 
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -91,7 +92,7 @@ public class FormFields extends JaxbListWrapper<FormField> {
         for (FormField field : this) {
             nvps.add(new BasicNameValuePair(field.getName(), field.getValue()));
         }
-        return new UrlEncodedFormEntity(nvps, "UTF-8");
+        return new UrlEncodedFormEntity(nvps, StandardCharsets.UTF_8);
     }
 
 }

--- a/protocols/xml/src/main/java/org/opennms/protocols/http/HttpUrlConnection.java
+++ b/protocols/xml/src/main/java/org/opennms/protocols/http/HttpUrlConnection.java
@@ -33,7 +33,7 @@ import java.io.InputStream;
 import java.net.URL;
 import java.net.URLConnection;
 import java.net.URLDecoder;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
 import java.util.List;
 
@@ -129,8 +129,8 @@ public class HttpUrlConnection extends URLConnection {
         String[] userInfo = m_url.getUserInfo() == null ? null :  m_url.getUserInfo().split(":");
         if (userInfo != null && userInfo.length == 2) {
             // If the URL contains a username/password, it might need to be decoded
-            String uname = URLDecoder.decode(userInfo[0], "UTF-8");
-            String pwd = URLDecoder.decode(userInfo[1], "UTF-8");
+            String uname = URLDecoder.decode(userInfo[0], StandardCharsets.UTF_8.name());
+            String pwd = URLDecoder.decode(userInfo[1], StandardCharsets.UTF_8.name());
             m_clientWrapper.addBasicCredentials(uname, pwd);
         }
 
@@ -154,7 +154,7 @@ public class HttpUrlConnection extends URLConnection {
             ub.setHost(m_url.getHost());
             ub.setPath(m_url.getPath());
             if (m_url.getQuery() != null && !m_url.getQuery().trim().isEmpty()) {
-                final List<NameValuePair> params = URLEncodedUtils.parse(m_url.getQuery(), Charset.forName("UTF-8"));
+                final List<NameValuePair> params = URLEncodedUtils.parse(m_url.getQuery(), StandardCharsets.UTF_8);
                 if (!params.isEmpty()) {
                     ub.addParameters(params);
                 }

--- a/protocols/xml/src/main/java/org/opennms/protocols/xml/collector/AbstractXmlCollectionHandler.java
+++ b/protocols/xml/src/main/java/org/opennms/protocols/xml/collector/AbstractXmlCollectionHandler.java
@@ -39,6 +39,7 @@ import java.io.UnsupportedEncodingException;
 import java.net.URL;
 import java.net.URLConnection;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Date;
@@ -451,7 +452,7 @@ public abstract class AbstractXmlCollectionHandler implements XmlCollectionHandl
                     String objStr = obj.toString();
                     try {
                         //NMS-7381 - if pulling from asset info you'd expect to not have to encode reserved words yourself.  
-                        objStr = URLEncoder.encode(obj.toString(), "UTF-8");
+                        objStr = URLEncoder.encode(obj.toString(), StandardCharsets.UTF_8.name());
                     } catch (UnsupportedEncodingException e) {
                         e.printStackTrace();
                     }
@@ -503,15 +504,15 @@ public abstract class AbstractXmlCollectionHandler implements XmlCollectionHandl
         factory.setNamespaceAware(true);
         DocumentBuilder builder = factory.newDocumentBuilder();
         StringWriter writer = new StringWriter();
-        IOUtils.copy(is, writer, "UTF-8");
+        IOUtils.copy(is, writer, StandardCharsets.UTF_8);
         String contents = writer.toString();
-        Document doc = builder.parse(IOUtils.toInputStream(contents, "UTF-8"));
+        Document doc = builder.parse(IOUtils.toInputStream(contents, StandardCharsets.UTF_8));
         // Ugly hack to deal with DOM & XPath 1.0's battle royale 
         // over handling namespaces without a prefix. 
         if(doc.getNamespaceURI() != null && doc.getPrefix() == null){
             factory.setNamespaceAware(false);
             builder = factory.newDocumentBuilder();
-            doc = builder.parse(IOUtils.toInputStream(contents, "UTF-8"));
+            doc = builder.parse(IOUtils.toInputStream(contents, StandardCharsets.UTF_8));
         }
         return doc;
     }

--- a/protocols/xml/src/main/java/org/opennms/protocols/xml/collector/XmlCollector.java
+++ b/protocols/xml/src/main/java/org/opennms/protocols/xml/collector/XmlCollector.java
@@ -29,8 +29,6 @@
 package org.opennms.protocols.xml.collector;
 
 import java.io.File;
-import java.nio.charset.Charset;
-import java.nio.charset.UnsupportedCharsetException;
 import java.util.Map;
 
 import org.opennms.core.spring.BeanUtils;
@@ -93,13 +91,6 @@ public class XmlCollector implements ServiceCollector {
     @Override
     public void initialize(Map<String, String> parameters) throws CollectionInitializationException {
         LOG.debug("initialize: initializing XML collector");
-
-        try {
-            // This is not strictly required but added just in case (see NMS-7963)
-            Charset.forName("UTF-8");
-        } catch (UnsupportedCharsetException e) {
-            throw new CollectionInitializationException("Can't initialize charset UTF-8: " + e.getMessage());
-        }
 
         // Retrieve the DAO for our configuration file.
         if (m_xmlCollectionDao == null)

--- a/protocols/xml/src/test/java/org/opennms/protocols/xml/config/XmlDataCollectionConfigTest.java
+++ b/protocols/xml/src/test/java/org/opennms/protocols/xml/config/XmlDataCollectionConfigTest.java
@@ -37,6 +37,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import javax.xml.bind.JAXBContext;
@@ -193,7 +194,7 @@ public class XmlDataCollectionConfigTest {
         StringBuffer exampleXML = new StringBuffer();
         File xmlCollectionConfig = getSourceFile();
         assertTrue(XmlDataCollectionConfig.XML_DATACOLLECTION_CONFIG_FILE + " is readable", xmlCollectionConfig.canRead());
-        BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream(xmlCollectionConfig), "UTF-8"));
+        BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream(xmlCollectionConfig), StandardCharsets.UTF_8));
         String line;
         while (true) {
             line = reader.readLine();

--- a/smoke-test/src/test/java/org/opennms/smoketest/AlarmsPageIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/AlarmsPageIT.java
@@ -30,6 +30,8 @@ package org.opennms.smoketest;
 
 import static org.junit.Assert.assertEquals;
 
+import java.nio.charset.StandardCharsets;
+
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.ByteArrayEntity;
@@ -59,7 +61,7 @@ public class AlarmsPageIT extends OpenNMSSeleniumTestCase {
         request.setHeader("Authorization", createBasicAuthHeader());
         request.setHeader("Content-Type", "application/xml");
         request.setHeader("Accept", "*/*");
-        request.setEntity(new ByteArrayEntity(xml.getBytes("UTF-8")));
+        request.setEntity(new ByteArrayEntity(xml.getBytes(StandardCharsets.UTF_8)));
         final HttpResponse response = client.execute(request);
         final int statusCode = response.getStatusLine().getStatusCode();
         if (statusCode != 200 && statusCode != 204) {


### PR DESCRIPTION
Instead of using names for character encodings, switch over to use StandardCharsets. This means that we need fewer try/catch blocks for UnsupportedEncodingException.