### PR TITLE
Fix NMS-9218: OsPfRouterId not properly updated

### DIFF
--- a/opennms-model/src/main/java/org/opennms/netmgt/model/OspfElement.java
+++ b/opennms-model/src/main/java/org/opennms/netmgt/model/OspfElement.java
@@ -311,7 +311,7 @@ public final class OspfElement implements Serializable {
 			return;
 		setOspfRouterId(element.getOspfRouterId());
 		setOspfRouterIdIfindex(element.getOspfRouterIdIfindex());
-		setOspfRouterId(element.getOspfRouterIdNetmask());
+		setOspfRouterIdNetmask(element.getOspfRouterIdNetmask());
 		
 		setOspfNodeLastPollTime(element.getOspfNodeCreateTime());
 	}


### PR DESCRIPTION
Fixed merge method in OspfElement


NMS-9218: OsPfRouterId not properly updated

Please use the [JIRA](https://issues.opennms.org) issue number and create a link in the JIRA issue back to this pull request so we have a quick reference from the issue to the pull request.

* JIRA: http://issues.opennms.org/browse/NMS-9218
