### PR TITLE
Fix NMS-9222: set the domain level in dns adapter

### DIFF
--- a/integrations/opennms-dns-provisioning-adapter/src/main/java/org/opennms/netmgt/provision/DnsProvisioningAdapter.java
+++ b/integrations/opennms-dns-provisioning-adapter/src/main/java/org/opennms/netmgt/provision/DnsProvisioningAdapter.java
@@ -76,6 +76,7 @@ public class DnsProvisioningAdapter extends SimpleQueuedProvisioningAdapter impl
     
     private static final String MESSAGE_PREFIX = "Dynamic DNS provisioning failed: ";
     private static final String ADAPTER_NAME="DNS Provisioning Adapter";
+    private Integer m_level = 3;
     
     private static volatile ConcurrentMap<Integer, DnsRecord> m_nodeDnsRecordMap;
 
@@ -96,6 +97,12 @@ public class DnsProvisioningAdapter extends SimpleQueuedProvisioningAdapter impl
             }
         });
 
+        String levelString = System.getProperty("importer.adapter.dns.level");
+        if (levelString != null) {
+        	Integer level = Integer.getInteger(levelString);
+        	if (level != null)
+        		m_level = level;
+        }
         String dnsServer = System.getProperty("importer.adapter.dns.server");
         if (!StringUtils.isBlank(dnsServer)) {
             LOG.info("DNS property found: {}", dnsServer);
@@ -124,7 +131,7 @@ public class DnsProvisioningAdapter extends SimpleQueuedProvisioningAdapter impl
         m_nodeDnsRecordMap = new ConcurrentHashMap<Integer, DnsRecord>(nodes.size());
         
         for (OnmsNode onmsNode : nodes) {
-            m_nodeDnsRecordMap.putIfAbsent(onmsNode.getId(), new DnsRecord(onmsNode));
+            m_nodeDnsRecordMap.putIfAbsent(onmsNode.getId(), new DnsRecord(onmsNode,m_level));
         }
         
     }
@@ -213,7 +220,11 @@ public class DnsProvisioningAdapter extends SimpleQueuedProvisioningAdapter impl
         LOG.debug("doUpdate: operation: {}", op.getType().name());
         try {
             node = m_nodeDao.get(op.getNodeId());
-            DnsRecord record = new DnsRecord(node);
+            if (node == null) {
+            	doDelete(op);
+            	return;
+            }
+            DnsRecord record = new DnsRecord(node,m_level);
             LOG.debug("doUpdate: DnsRecord: hostname: {} zone: {} ip address {}", record.getIp().getHostAddress(), record.getHostname(), record.getZone());
             DnsRecord oldRecord = m_nodeDnsRecordMap.get(Integer.valueOf(node.getId()));
 

--- a/integrations/opennms-dns-provisioning-adapter/src/main/java/org/opennms/netmgt/provision/DnsProvisioningAdapter.java
+++ b/integrations/opennms-dns-provisioning-adapter/src/main/java/org/opennms/netmgt/provision/DnsProvisioningAdapter.java
@@ -100,7 +100,7 @@ public class DnsProvisioningAdapter extends SimpleQueuedProvisioningAdapter impl
         String levelString = System.getProperty("importer.adapter.dns.level");
         if (levelString != null) {
         	Integer level = Integer.getInteger(levelString);
-        	if (level != null)
+        	if (level != null && level.intValue() > 0)
         		m_level = level;
         }
         String dnsServer = System.getProperty("importer.adapter.dns.server");

--- a/integrations/opennms-dns-provisioning-adapter/src/main/java/org/opennms/netmgt/provision/DnsProvisioningAdapter.java
+++ b/integrations/opennms-dns-provisioning-adapter/src/main/java/org/opennms/netmgt/provision/DnsProvisioningAdapter.java
@@ -76,7 +76,7 @@ public class DnsProvisioningAdapter extends SimpleQueuedProvisioningAdapter impl
     
     private static final String MESSAGE_PREFIX = "Dynamic DNS provisioning failed: ";
     private static final String ADAPTER_NAME="DNS Provisioning Adapter";
-    private Integer m_level = 3;
+    private Integer m_level = 0;
     
     private static volatile ConcurrentMap<Integer, DnsRecord> m_nodeDnsRecordMap;
 

--- a/integrations/opennms-dns-provisioning-adapter/src/main/java/org/opennms/netmgt/provision/DnsRecord.java
+++ b/integrations/opennms-dns-provisioning-adapter/src/main/java/org/opennms/netmgt/provision/DnsRecord.java
@@ -65,7 +65,7 @@ class DnsRecord {
         LOG.debug("Constructor: set hostname: {}", m_hostname);
 
         String[] singlestat = m_hostname.split("\\.");
-        if ( level > singlestat.length){
+        if ( level == 0 || level >= singlestat.length){
             m_zone = m_hostname.substring(m_hostname.indexOf('.') + 1);
         } else {
         	String domain="";
@@ -105,5 +105,5 @@ class DnsRecord {
     public String getHostname() {
         return m_hostname;
     }
-    
+        
 }

--- a/integrations/opennms-dns-provisioning-adapter/src/main/java/org/opennms/netmgt/provision/DnsRecord.java
+++ b/integrations/opennms-dns-provisioning-adapter/src/main/java/org/opennms/netmgt/provision/DnsRecord.java
@@ -42,8 +42,10 @@ class DnsRecord {
     private String m_hostname;
     private String m_zone;
     
-    DnsRecord(OnmsNode node) {
-        
+    DnsRecord(OnmsNode node, int level) {
+
+        LOG.debug("Constructor: set level: {}", level);
+
         OnmsIpInterface primaryInterface = node.getPrimaryInterface();
         
         
@@ -61,7 +63,18 @@ class DnsRecord {
         LOG.debug("Constructor: set ip address: {}", m_ip);
         m_hostname = node.getLabel() + ".";
         LOG.debug("Constructor: set hostname: {}", m_hostname);
-        m_zone = m_hostname.substring(m_hostname.indexOf('.') + 1);
+
+        String[] singlestat = m_hostname.split("\\.");
+        if ( level > singlestat.length){
+            m_zone = m_hostname.substring(m_hostname.indexOf('.') + 1);
+        } else {
+        	String domain="";
+        	for (int i=singlestat.length-level;i < singlestat.length;i++ ) {
+        		domain+=singlestat[i];
+        		domain+=".";
+        	}
+        	m_zone=domain;
+        }
         LOG.debug("Constructor: set zone: {}", m_zone);
 
     }
@@ -92,4 +105,5 @@ class DnsRecord {
     public String getHostname() {
         return m_hostname;
     }
+    
 }

--- a/integrations/opennms-dns-provisioning-adapter/src/test/java/org/opennms/netmgt/provision/DnsRecordTest.java
+++ b/integrations/opennms-dns-provisioning-adapter/src/test/java/org/opennms/netmgt/provision/DnsRecordTest.java
@@ -1,0 +1,110 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2009-2014 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.provision;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.opennms.netmgt.model.NetworkBuilder;
+
+import static org.junit.Assert.assertEquals;
+public class DnsRecordTest {
+
+	private NetworkBuilder nb;
+    private String hostname = "www.test.opennms.org";
+    private String ip = "192.168.1.10";
+
+    @Before
+    public void setUp() throws Exception {
+        nb = new NetworkBuilder();
+        nb.addNode(hostname).setForeignSource("dns").setForeignId("1");
+        nb.addInterface(ip);
+    }
+
+    
+    @Test
+    public void testDnsRecondDefaultLevel() throws Exception {
+    	DnsRecord dnsRecord = new DnsRecord(nb.getCurrentNode(), 0);
+    	assertEquals(hostname+".", dnsRecord.getHostname());
+    	assertEquals(ip, dnsRecord.getIp().getHostAddress());
+    	assertEquals("test.opennms.org.", dnsRecord.getZone());
+    	
+    }
+    
+    @Test
+    public void testDnsRecondFirstLevel() throws Exception {
+    	DnsRecord dnsRecord = new DnsRecord(nb.getCurrentNode(), 1);
+    	assertEquals(hostname+".", dnsRecord.getHostname());
+    	assertEquals(ip, dnsRecord.getIp().getHostAddress());
+    	assertEquals("org.", dnsRecord.getZone());
+    	
+    }
+
+    @Test
+    public void testDnsRecondSecondLevel() throws Exception {
+    	DnsRecord dnsRecord = new DnsRecord(nb.getCurrentNode(), 2);
+    	assertEquals(hostname+".", dnsRecord.getHostname());
+    	assertEquals(ip, dnsRecord.getIp().getHostAddress());
+    	assertEquals("opennms.org.", dnsRecord.getZone());
+    	
+    }
+    
+    @Test
+    public void testDnsRecondThirdLevel() throws Exception {
+    	DnsRecord dnsRecord = new DnsRecord(nb.getCurrentNode(), 3);
+    	assertEquals(hostname+".", dnsRecord.getHostname());
+    	assertEquals(ip, dnsRecord.getIp().getHostAddress());
+    	assertEquals("test.opennms.org.", dnsRecord.getZone());    	
+    }
+
+    @Test
+    public void testDnsRecondFourthLevel() throws Exception {
+    	DnsRecord dnsRecord = new DnsRecord(nb.getCurrentNode(), 4);
+    	assertEquals(hostname+".", dnsRecord.getHostname());
+    	assertEquals(ip, dnsRecord.getIp().getHostAddress());
+    	assertEquals("test.opennms.org.", dnsRecord.getZone());    	
+    }
+
+    @Test
+    public void testDnsRecondFifthLevel() throws Exception {
+    	DnsRecord dnsRecord = new DnsRecord(nb.getCurrentNode(), 5);
+    	assertEquals(hostname+".", dnsRecord.getHostname());
+    	assertEquals(ip, dnsRecord.getIp().getHostAddress());
+    	assertEquals("test.opennms.org.", dnsRecord.getZone());    	
+    }
+
+    @Test
+    public void testDnsRecondUpperLevel() throws Exception {
+    	DnsRecord dnsRecord = new DnsRecord(nb.getCurrentNode(), 90);
+    	assertEquals(hostname+".", dnsRecord.getHostname());
+    	assertEquals(ip, dnsRecord.getIp().getHostAddress());
+    	assertEquals("test.opennms.org.", dnsRecord.getZone());    	
+    }
+
+    
+}

--- a/integrations/opennms-reverse-dns-provisioning-adapter/src/main/java/org/opennms/netmgt/provision/DefaultReverseDnsProvisioningAdapterService.java
+++ b/integrations/opennms-reverse-dns-provisioning-adapter/src/main/java/org/opennms/netmgt/provision/DefaultReverseDnsProvisioningAdapterService.java
@@ -45,6 +45,8 @@ public class DefaultReverseDnsProvisioningAdapterService implements
     private NodeDao m_nodeDao;
     private IpInterfaceDao m_ipInterfaceDao;
     private TransactionTemplate m_template;
+    private Integer m_level = 3;
+
     
     /**
      * <p>setTemplate</p>
@@ -81,6 +83,12 @@ public class DefaultReverseDnsProvisioningAdapterService implements
     public void afterPropertiesSet() throws Exception {
         Assert.notNull(m_nodeDao, "ReverseDnsProvisioner requires a NodeDao which is not null.");
         Assert.notNull(m_ipInterfaceDao, "ReverseDnsProvisioner requires an IpInterfaceDao which is not null.");
+        String levelString = System.getProperty("importer.adapter.dns.reverse.level");
+        if (levelString != null) {
+        	Integer level = Integer.getInteger(levelString);
+        	if (level != null && level.intValue() > 0)
+        		m_level=level;
+        }
     }
     
     @Override
@@ -90,7 +98,7 @@ public class DefaultReverseDnsProvisioningAdapterService implements
             @Override
             public void doInTransactionWithoutResult(TransactionStatus arg0) {
                 for (OnmsIpInterface ipInterface : m_nodeDao.get(nodeid).getIpInterfaces()) {
-                    records.add(new ReverseDnsRecord(ipInterface));
+                    records.add(new ReverseDnsRecord(ipInterface,m_level));
                 }
             }
         });
@@ -105,5 +113,13 @@ public class DefaultReverseDnsProvisioningAdapterService implements
             m_ipInterfaceDao.update(ipInterface);
         }
     }
+
+	public Integer getLevel() {
+		return m_level;
+	}
+
+	public void setLevel(Integer level) {
+		m_level = level;
+	}
 
 }

--- a/integrations/opennms-reverse-dns-provisioning-adapter/src/main/java/org/opennms/netmgt/provision/ReverseDnsProvisioningAdapter.java
+++ b/integrations/opennms-reverse-dns-provisioning-adapter/src/main/java/org/opennms/netmgt/provision/ReverseDnsProvisioningAdapter.java
@@ -31,16 +31,13 @@ package org.opennms.netmgt.provision;
 import java.util.Date;
 
 import org.apache.commons.lang.StringUtils;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.opennms.netmgt.events.api.EventConstants;
 import org.opennms.netmgt.events.api.EventForwarder;
 import org.opennms.netmgt.model.events.EventBuilder;
 import org.opennms.netmgt.xml.event.Event;
-
 import org.springframework.beans.factory.InitializingBean;
-
 import org.xbill.DNS.Name;
 import org.xbill.DNS.Resolver;
 import org.xbill.DNS.ReverseMap;
@@ -69,7 +66,6 @@ public class ReverseDnsProvisioningAdapter extends SimpleQueuedProvisioningAdapt
     
     private static final String MESSAGE_PREFIX = "Dynamic Reverse DNS provisioning failed: ";
     private static final String ADAPTER_NAME="Reverse DNS Provisioning Adapter";
-    
     
     /**
      * <p>afterPropertiesSet</p>

--- a/integrations/opennms-reverse-dns-provisioning-adapter/src/main/java/org/opennms/netmgt/provision/ReverseDnsProvisioningAdapterService.java
+++ b/integrations/opennms-reverse-dns-provisioning-adapter/src/main/java/org/opennms/netmgt/provision/ReverseDnsProvisioningAdapterService.java
@@ -35,5 +35,5 @@ public interface ReverseDnsProvisioningAdapterService {
     List<ReverseDnsRecord> get(Integer nodeid);
     
     void update(Integer nodeid, ReverseDnsRecord rdr);
-
+    
 }

--- a/integrations/opennms-reverse-dns-provisioning-adapter/src/main/java/org/opennms/netmgt/provision/ReverseDnsRecord.java
+++ b/integrations/opennms-reverse-dns-provisioning-adapter/src/main/java/org/opennms/netmgt/provision/ReverseDnsRecord.java
@@ -43,7 +43,7 @@ public class ReverseDnsRecord {
     String m_zone;
     InetAddress m_ip;
     
-    public ReverseDnsRecord(OnmsIpInterface ipInterface) {
+    public ReverseDnsRecord(OnmsIpInterface ipInterface, int level) {
 
         OnmsSnmpInterface snmpInterface = ipInterface.getSnmpInterface();
 
@@ -65,7 +65,12 @@ public class ReverseDnsRecord {
         m_ip = ipInterface.getIpAddress();
         LOG.debug("Constructor: set ip address: {}", m_ip);
 
-        m_zone=ReverseDnsRecord.thirdLevelZonefromInet4Address(m_ip.getAddress());
+        if (level == 1)
+        	m_zone = ReverseDnsRecord.firstLevelZonefromInet4Address(m_ip.getAddress());
+        else if (level == 2)
+        	m_zone = ReverseDnsRecord.secondLevelZonefromInet4Address(m_ip.getAddress());
+    	else
+    		m_zone=ReverseDnsRecord.thirdLevelZonefromInet4Address(m_ip.getAddress());
         LOG.debug("Constructor: set zone: {}", m_zone);
     }
 
@@ -97,4 +102,40 @@ public class ReverseDnsRecord {
       sb.append(".in-addr.arpa.");
       return sb.toString();
     }
+    
+    public static String secondLevelZonefromInet4Address(byte[] addr ) {
+        if (addr.length != 4 && addr.length != 16)
+            throw new IllegalArgumentException("array must contain " +
+                                         "4 or 16 elements");
+              
+      StringBuffer sb = new StringBuffer();
+      if (addr.length == 4) {
+          for (int i = addr.length - 3; i >= 0; i--) {
+              sb.append(addr[i] & 0xFF);
+              if (i > 0)
+                  sb.append(".");
+              }
+          }
+      sb.append(".in-addr.arpa.");
+      return sb.toString();
+    }
+    
+    public static String firstLevelZonefromInet4Address(byte[] addr ) {
+        if (addr.length != 4 && addr.length != 16)
+            throw new IllegalArgumentException("array must contain " +
+                                         "4 or 16 elements");
+              
+      StringBuffer sb = new StringBuffer();
+      if (addr.length == 4) {
+          for (int i = addr.length - 4; i >= 0; i--) {
+              sb.append(addr[i] & 0xFF);
+              if (i > 0)
+                  sb.append(".");
+              }
+          }
+      sb.append(".in-addr.arpa.");
+      return sb.toString();
+    }
+
+
 }

--- a/integrations/opennms-reverse-dns-provisioning-adapter/src/test/java/org/opennms/netmgt/provision/ReverseDnsRecordTest.java
+++ b/integrations/opennms-reverse-dns-provisioning-adapter/src/test/java/org/opennms/netmgt/provision/ReverseDnsRecordTest.java
@@ -1,0 +1,116 @@
+package org.opennms.netmgt.provision;
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2009-2014 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+
+import org.junit.Before;
+import org.junit.Test;
+import org.opennms.netmgt.model.NetworkBuilder;
+
+import static org.junit.Assert.assertEquals;
+public class ReverseDnsRecordTest {
+
+	private NetworkBuilder nb;
+    private String hostname = "test.opennms.org";
+    private String ifname = "onms001";
+    private String ip = "192.168.1.10";
+
+    @Before
+    public void setUp() throws Exception {
+        nb = new NetworkBuilder();
+        nb.addNode(hostname).setForeignSource("dns").setForeignId("1");
+        nb.addSnmpInterface(100).setIfName(ifname).addIpInterface(ip);
+    }
+
+    
+    @Test
+    public void testDnsRecondDefaultLevel() throws Exception {
+    	ReverseDnsRecord dnsRecord = new ReverseDnsRecord(nb.getCurrentNode().getIpInterfaceByIpAddress(ip), -10);
+    	assertEquals(ifname+"-"+hostname+".", dnsRecord.getHostname());
+    	assertEquals(ip, dnsRecord.getIp().getHostAddress());
+    	assertEquals("1.168.192.in-addr.arpa.", dnsRecord.getZone());
+    }
+
+    @Test
+    public void testDnsRecondZeroLevel() throws Exception {
+    	ReverseDnsRecord dnsRecord = new ReverseDnsRecord(nb.getCurrentNode().getIpInterfaceByIpAddress(ip), 0);
+    	assertEquals(ifname+"-"+hostname+".", dnsRecord.getHostname());
+    	assertEquals(ip, dnsRecord.getIp().getHostAddress());
+    	assertEquals("1.168.192.in-addr.arpa.", dnsRecord.getZone());
+    }
+    
+
+    @Test
+    public void testDnsRecondFirstLevel() throws Exception {
+    	ReverseDnsRecord dnsRecord = new ReverseDnsRecord(nb.getCurrentNode().getIpInterfaceByIpAddress(ip), 1);
+    	assertEquals(ifname+"-"+hostname+".", dnsRecord.getHostname());
+    	assertEquals(ip, dnsRecord.getIp().getHostAddress());
+    	assertEquals("192.in-addr.arpa.", dnsRecord.getZone());    	
+    }
+
+    @Test
+    public void testDnsRecondSecondLevel() throws Exception {
+    	ReverseDnsRecord dnsRecord = new ReverseDnsRecord(nb.getCurrentNode().getIpInterfaceByIpAddress(ip), 2);
+    	assertEquals(ifname+"-"+hostname+".", dnsRecord.getHostname());
+    	assertEquals(ip, dnsRecord.getIp().getHostAddress());
+    	assertEquals("168.192.in-addr.arpa.", dnsRecord.getZone());    	
+    }
+    
+    @Test
+    public void testDnsRecondThirdLevel() throws Exception {
+    	ReverseDnsRecord dnsRecord = new ReverseDnsRecord(nb.getCurrentNode().getIpInterfaceByIpAddress(ip), 3);
+    	assertEquals(ifname+"-"+hostname+".", dnsRecord.getHostname());
+    	assertEquals(ip, dnsRecord.getIp().getHostAddress());
+    	assertEquals("1.168.192.in-addr.arpa.", dnsRecord.getZone());
+    }
+
+    @Test
+    public void testDnsRecondFourthLevel() throws Exception {
+    	ReverseDnsRecord dnsRecord = new ReverseDnsRecord(nb.getCurrentNode().getIpInterfaceByIpAddress(ip), 4);
+    	assertEquals(ifname+"-"+hostname+".", dnsRecord.getHostname());
+    	assertEquals(ip, dnsRecord.getIp().getHostAddress());
+    	assertEquals("1.168.192.in-addr.arpa.", dnsRecord.getZone());
+    }
+
+    @Test
+    public void testDnsRecondFifthLevel() throws Exception {
+    	ReverseDnsRecord dnsRecord = new ReverseDnsRecord(nb.getCurrentNode().getIpInterfaceByIpAddress(ip), 5);
+    	assertEquals(ifname+"-"+hostname+".", dnsRecord.getHostname());
+    	assertEquals(ip, dnsRecord.getIp().getHostAddress());
+    	assertEquals("1.168.192.in-addr.arpa.", dnsRecord.getZone());
+    }
+
+    @Test
+    public void testDnsRecondUpperLevel() throws Exception {
+    	ReverseDnsRecord dnsRecord = new ReverseDnsRecord(nb.getCurrentNode().getIpInterfaceByIpAddress(ip), 90);
+    	assertEquals(ifname+"-"+hostname+".", dnsRecord.getHostname());
+    	assertEquals(ip, dnsRecord.getIp().getHostAddress());
+    	assertEquals("1.168.192.in-addr.arpa.", dnsRecord.getZone());
+    }
+    
+}


### PR DESCRIPTION
Created a POC for setting a property
import.dns.level for setting the
domain suitable level for nsupdates


The DNS update needs that the zone exists on dns server.

We should be able to check against possible zone.

for example the label 

www.ess01.arsinfo.it 

can be stored as an A record either in zone 
NSUPDATE
zone arsinfo.it
www.ess01 1.2.1.1 A

otrherwise you can say

NSUPDATE
zone ess01.arsinfo.it
www 1.2.1.1 A


The actual implementation uses the last. I'd like to set up a level to try if level=2 then you try zone arsinfo.it.f:

NMS-9222: set the domain level in dns adapter

* JIRA: http://issues.opennms.org/browse/NMS-9222

Set up property with domain level....in opennms.properties:

importer.adapter.dns.level=3 (means use level 3 domain!)

Also added a property for dns reverse adapter to use reverse zone level

importer.adapter.dns.reverse.level=2 (means use level 2 reverse lookup zone!)
