### PR TITLE
HZN-1021: Update the Vmware requisition handler to implement the RequisitionHandler interface

### DIFF
--- a/integrations/opennms-vmware/pom.xml
+++ b/integrations/opennms-vmware/pom.xml
@@ -94,16 +94,6 @@
             </exclusions>
         </dependency>
 
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-core</artifactId>
-            <scope>runtime</scope>
-        </dependency>
         <!-- Attention this is EPL license -->
         <dependency>
             <groupId>org.sblim.slp</groupId>
@@ -156,6 +146,16 @@
         <dependency>
             <groupId>org.opennms.features.collection</groupId>
             <artifactId>org.opennms.features.collection.test-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.opennms</groupId>
+            <artifactId>opennms-requisition-service</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.opennms.core.test-api</groupId>
+            <artifactId>org.opennms.core.test-api.xml</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/integrations/opennms-vmware/src/main/java/org/opennms/netmgt/poller/monitors/AbstractVmwareMonitor.java
+++ b/integrations/opennms-vmware/src/main/java/org/opennms/netmgt/poller/monitors/AbstractVmwareMonitor.java
@@ -1,0 +1,108 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2017-2017 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.poller.monitors;
+
+import java.util.Map;
+
+import org.opennms.core.spring.BeanUtils;
+import org.opennms.netmgt.config.vmware.VmwareServer;
+import org.opennms.netmgt.dao.VmwareConfigDao;
+import org.opennms.netmgt.dao.api.NodeDao;
+import org.opennms.netmgt.model.OnmsNode;
+import org.opennms.netmgt.poller.MonitoredService;
+import org.opennms.netmgt.poller.support.AbstractServiceMonitor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.ImmutableMap;
+
+public abstract class AbstractVmwareMonitor extends AbstractServiceMonitor {
+    private final Logger logger = LoggerFactory.getLogger(AbstractVmwareMonitor.class);
+
+    protected static final String VMWARE_MANAGEMENT_SERVER_KEY = "vmwareManagementServer";
+    protected static final String VMWARE_MANAGED_ENTITY_TYPE_KEY = "vmwareManagedEntityType";
+    protected static final String VMWARE_MANAGED_OBJECT_ID_KEY = "vmwareManagedObjectId";
+    protected static final String VMWARE_MANAGEMENT_SERVER_USERNAME_KEY = "vmwareMangementServerUsername";
+    protected static final String VMWARE_MANAGEMENT_SERVER_PASSWORD_KEY = "vmwareMangementServerPassword";
+
+    /**
+     * the node dao object for retrieving assets
+     */
+    private NodeDao m_nodeDao = null;
+
+    /**
+     * the config dao
+     */
+    private VmwareConfigDao m_vmwareConfigDao = null;
+
+    @Override
+    public Map<String, Object> getRuntimeAttributes(MonitoredService svc, Map<String, Object> parameters) {
+        if (m_nodeDao == null) {
+            m_nodeDao = BeanUtils.getBean("daoContext", "nodeDao", NodeDao.class);
+        }
+
+        if (m_vmwareConfigDao == null) {
+            m_vmwareConfigDao = BeanUtils.getBean("daoContext", "vmwareConfigDao", VmwareConfigDao.class);
+        }
+
+        final OnmsNode onmsNode = m_nodeDao.get(svc.getNodeId());
+        if (onmsNode == null) {
+            throw new IllegalArgumentException("No node found with ID: " + svc.getNodeId());
+        }
+
+        // retrieve the assets
+        final String vmwareManagementServer = onmsNode.getAssetRecord().getVmwareManagementServer();
+        final String vmwareManagedEntityType = onmsNode.getAssetRecord().getVmwareManagedEntityType();
+        final String vmwareManagedObjectId = onmsNode.getForeignId();
+
+        String vmwareMangementServerUsername = null;
+        String vmwareMangementServerPassword = null;
+        final Map<String, VmwareServer> serverMap = m_vmwareConfigDao.getServerMap();
+        if (serverMap == null) {
+            logger.error("Error getting vmware-config.xml's server map.");
+        } else {
+            final VmwareServer vmwareServer = serverMap.get(vmwareManagementServer);
+            if (vmwareServer == null) {
+                logger.error("Error getting credentials for VMware management server '{}'.", vmwareManagementServer);
+            } else {
+                vmwareMangementServerUsername = vmwareServer.getUsername();
+                vmwareMangementServerPassword = vmwareServer.getPassword();
+            }
+        }
+
+        return new ImmutableMap.Builder<String, Object>()
+                .put(VMWARE_MANAGEMENT_SERVER_KEY, vmwareManagementServer)
+                .put(VMWARE_MANAGED_ENTITY_TYPE_KEY, vmwareManagedEntityType)
+                .put(VMWARE_MANAGED_OBJECT_ID_KEY, vmwareManagedObjectId)
+                .put(VMWARE_MANAGEMENT_SERVER_USERNAME_KEY, vmwareMangementServerUsername)
+                .put(VMWARE_MANAGEMENT_SERVER_PASSWORD_KEY, vmwareMangementServerPassword)
+                .build();
+    }
+
+}

--- a/integrations/opennms-vmware/src/main/java/org/opennms/netmgt/provision/service/vmware/RequisitionXmlAdapter.java
+++ b/integrations/opennms-vmware/src/main/java/org/opennms/netmgt/provision/service/vmware/RequisitionXmlAdapter.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2017-2017 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.provision.service.vmware;
+
+import javax.xml.bind.annotation.adapters.XmlAdapter;
+
+import org.opennms.core.xml.JaxbUtils;
+import org.opennms.netmgt.provision.persist.requisition.Requisition;
+
+public class RequisitionXmlAdapter extends XmlAdapter<String, Requisition> {
+
+    @Override
+    public Requisition unmarshal(String v) throws Exception {
+        return JaxbUtils.unmarshal(Requisition.class, v);
+    }
+
+    @Override
+    public String marshal(Requisition v) throws Exception {
+        return JaxbUtils.marshal(v);
+    }
+
+}

--- a/integrations/opennms-vmware/src/main/java/org/opennms/netmgt/provision/service/vmware/VmwareImportRequest.java
+++ b/integrations/opennms-vmware/src/main/java/org/opennms/netmgt/provision/service/vmware/VmwareImportRequest.java
@@ -1,0 +1,454 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2017-2017 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.provision.service.vmware;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+
+import org.opennms.netmgt.provision.persist.RequisitionRequest;
+import org.opennms.netmgt.provision.persist.requisition.Requisition;
+
+/**
+ * Options that control how the requisition is generated.
+ *
+ * @author Christian Pape <Christian.Pape@informatik.hs-fulda.de>
+ * @author Alejandro Galue <agalue@opennms.org>
+ */
+@XmlRootElement(name = "vmware-requisition-request")
+@XmlAccessorType(XmlAccessType.NONE)
+public class VmwareImportRequest implements RequisitionRequest {
+
+    private static final String VMWARE_HOSTSYSTEM_SERVICES = "hostSystemServices";
+    private static final String VMWARE_VIRTUALMACHINE_SERVICES = "virtualMachineServices";
+
+    private static final List<String> DEFAULT_HOST_SYSTEM_SERVICES = Arrays.asList("VMware-ManagedEntity", "VMware-HostSystem", "VMwareCim-HostSystem");
+
+    private static final List<String> DEFAULT_VIRTUAL_MACHINE_SERVICES = Arrays.asList("VMware-ManagedEntity", "VMware-VirtualMachine");
+
+    @XmlAttribute(name="hostname")
+    private String hostname = null;
+
+    @XmlAttribute(name="username")
+    private String username = null;
+
+    @XmlAttribute(name="password")
+    private String password = null;
+
+    @XmlAttribute(name="location")
+    private String location = null;
+
+    @XmlAttribute(name="foreign-source")
+    private String foreignSource = null;
+
+    @XmlAttribute(name="import-vm-powered-on")
+    private boolean importVMPoweredOn = true;
+
+    @XmlAttribute(name="import-vm-powered-off")
+    private boolean importVMPoweredOff = false;
+
+    @XmlAttribute(name="import-vm-suspended")
+    private boolean importVMSuspended = false;
+
+    @XmlAttribute(name="import-host-powered-on")
+    private boolean importHostPoweredOn = true;
+
+    @XmlAttribute(name="import-host-powered-off")
+    private boolean importHostPoweredOff = false;
+
+    @XmlAttribute(name="import-host-standby")
+    private boolean importHostStandBy = false;
+
+    @XmlAttribute(name="import-host-unknown")
+    private boolean importHostUnknown = false;
+
+    @XmlAttribute(name="persist-ipv4")
+    private boolean persistIPv4 = true;
+
+    @XmlAttribute(name="persist-ipv6")
+    private boolean persistIPv6 = true;
+
+    @XmlAttribute(name="persist-vms")
+    private boolean persistVMs = true;
+
+    @XmlAttribute(name="persist-hosts")
+    private boolean persistHosts = true;
+
+    @XmlAttribute(name="topology-port-groups")
+    private boolean topologyPortGroups = false;
+
+    @XmlAttribute(name="topology-networks")
+    private boolean topologyNetworks = true;
+
+    @XmlAttribute(name="topology-datastores")
+    private boolean topologyDatastores = true;
+
+    @XmlElement(name="host-system-service")
+    private List<String> hostSystemServices = null;
+
+    @XmlElement(name="virtual-machine-service")
+    private List<String> virtualMachineServices = null;
+
+    @XmlElement(name="custom-attribute")
+    private List<VmwareImportRequestAttribute> customAttributes = new ArrayList<>();
+
+    @XmlAttribute(name="old-key")
+    private String oldKey;
+
+    @XmlAttribute(name="old-key")
+    private String oldValue;
+
+    @XmlElement(name="existing-requisition")
+    @XmlJavaTypeAdapter(RequisitionXmlAdapter.class)
+    private Requisition existingRequisition;
+
+    public VmwareImportRequest() { }
+
+    public VmwareImportRequest(Map<String, String> params) {
+        setHostname(params.get("host"));
+        setUsername(params.get("username"));
+        setPassword(params.get("password"));
+        setLocation(params.get("location"));
+
+        boolean importVMOnly = queryParameter(params, "importVMOnly", false);
+        boolean importHostOnly = queryParameter(params, "importHostOnly", false);
+
+        if (importHostOnly && importVMOnly) {
+            throw new IllegalArgumentException("importHostOnly and importVMOnly can't be true simultaneously");
+        }
+        if (importHostOnly) {
+            setPersistVMs(false);
+        }
+        if (importVMOnly) {
+            setPersistHosts(false);
+        }
+
+        boolean importIPv4Only = queryParameter(params, "importIPv4Only", false);
+        boolean importIPv6Only = queryParameter(params, "importIPv6Only", false);
+
+        if (importIPv4Only && importIPv6Only) {
+            throw new IllegalArgumentException("importIPv4Only and importIPv6Only can't be true simultaneously");
+        }
+        if (importIPv4Only) {
+            setPersistIPv6(false);
+        }
+        if (importIPv6Only) {
+            setPersistIPv4(false);
+        }
+
+        setTopologyPortGroups(queryParameter(params, "topologyPortGroups", false));
+        setTopologyNetworks(queryParameter(params, "topologyNetworks", true));
+        setTopologyDatastores(queryParameter(params, "topologyDatastores", true));
+
+        setImportVMPoweredOn(queryParameter(params, "importVMPoweredOn", true));
+        setImportVMPoweredOff(queryParameter(params, "importVMPoweredOff", false));
+        setImportVMSuspended(queryParameter(params, "importVMSuspended", false));
+
+        setImportHostPoweredOn(queryParameter(params, "importHostPoweredOn", true));
+        setImportHostPoweredOff(queryParameter(params, "importHostPoweredOff", false));
+        setImportHostStandBy(queryParameter(params, "importHostStandBy", false));
+        setImportHostUnknown(queryParameter(params, "importHostUnknown", false));
+
+        if (queryParameter(params, "importHostAll", false)) {
+            setImportHostPoweredOn(true);
+            setImportHostPoweredOff(true);
+            setImportHostStandBy(true);
+            setImportHostUnknown(true);
+        }
+
+        if (queryParameter(params, "importVMAll", false)) {
+            setImportHostPoweredOff(true);
+            setImportHostPoweredOn(true);
+            setImportVMSuspended(true);
+        }
+
+        String path = params.get("path");
+        if (path == null) {
+            throw new IllegalArgumentException("path is required");
+        }
+
+        path = path.replaceAll("^/", "");
+        path = path.replaceAll("/$", "");
+
+        String[] pathElements = path.split("/");
+
+        if (pathElements.length == 1) {
+            if ("".equals(pathElements[0])) {
+                setForeignSource("vmware-" + getHostname());
+            } else {
+                setForeignSource(pathElements[0]);
+            }
+        } else {
+            throw new IllegalArgumentException("Error processing path element of URL (vmware://host[/foreign-source]?keyA=valueA;keyB=valueB;...)");
+        }
+
+        // get services to be added to host systems
+        if (params.get(VMWARE_HOSTSYSTEM_SERVICES) != null) {
+            setHostSystemServices(Arrays.asList(params.get(VMWARE_HOSTSYSTEM_SERVICES).split(",")));
+        }
+
+        // get services to be added to virtual machines
+        if (params.get(VMWARE_VIRTUALMACHINE_SERVICES) != null) {
+            setVirtualMachineServices(Arrays.asList(params.get(VMWARE_VIRTUALMACHINE_SERVICES).split(",")));
+        }
+
+        Map<String, String> customAttributes = new HashMap<>();
+        for (String k : params.keySet()) {
+            if (k.startsWith("_")) {
+                customAttributes.put(k, params.get(k));
+            }
+        }
+        setCustomAttributes(customAttributes);
+    }
+
+    public void setOldValue(String oldValue) {
+        this.oldValue = oldValue;
+    }
+    public String getHostname() {
+        return hostname;
+    }
+    public void setHostname(String hostname) {
+        this.hostname = hostname;
+    }
+    public String getUsername() {
+        return username;
+    }
+    public void setUsername(String username) {
+        this.username = username;
+    }
+    public String getPassword() {
+        return password;
+    }
+    public void setPassword(String password) {
+        this.password = password;
+    }
+    public String getLocation() {
+        return location;
+    }
+    public void setLocation(String location) {
+        this.location = location;
+    }
+    public String getForeignSource() {
+        return foreignSource;
+    }
+    public void setForeignSource(String foreignSource) {
+        this.foreignSource = foreignSource;
+    }
+    public boolean isImportVMPoweredOn() {
+        return importVMPoweredOn;
+    }
+    public void setImportVMPoweredOn(boolean importVMPoweredOn) {
+        this.importVMPoweredOn = importVMPoweredOn;
+    }
+    public boolean isImportVMPoweredOff() {
+        return importVMPoweredOff;
+    }
+    public void setImportVMPoweredOff(boolean importVMPoweredOff) {
+        this.importVMPoweredOff = importVMPoweredOff;
+    }
+    public boolean isImportVMSuspended() {
+        return importVMSuspended;
+    }
+    public void setImportVMSuspended(boolean importVMSuspended) {
+        this.importVMSuspended = importVMSuspended;
+    }
+    public boolean isImportHostPoweredOn() {
+        return importHostPoweredOn;
+    }
+    public void setImportHostPoweredOn(boolean importHostPoweredOn) {
+        this.importHostPoweredOn = importHostPoweredOn;
+    }
+    public boolean isImportHostPoweredOff() {
+        return importHostPoweredOff;
+    }
+    public void setImportHostPoweredOff(boolean importHostPoweredOff) {
+        this.importHostPoweredOff = importHostPoweredOff;
+    }
+    public boolean isImportHostStandBy() {
+        return importHostStandBy;
+    }
+    public void setImportHostStandBy(boolean importHostStandBy) {
+        this.importHostStandBy = importHostStandBy;
+    }
+    public boolean isImportHostUnknown() {
+        return importHostUnknown;
+    }
+    public void setImportHostUnknown(boolean importHostUnknown) {
+        this.importHostUnknown = importHostUnknown;
+    }
+    public boolean isPersistIPv4() {
+        return persistIPv4;
+    }
+    public void setPersistIPv4(boolean persistIPv4) {
+        this.persistIPv4 = persistIPv4;
+    }
+    public boolean isPersistIPv6() {
+        return persistIPv6;
+    }
+    public void setPersistIPv6(boolean persistIPv6) {
+        this.persistIPv6 = persistIPv6;
+    }
+    public boolean isPersistVMs() {
+        return persistVMs;
+    }
+    public void setPersistVMs(boolean persistVMs) {
+        this.persistVMs = persistVMs;
+    }
+    public boolean isPersistHosts() {
+        return persistHosts;
+    }
+    public void setPersistHosts(boolean persistHosts) {
+        this.persistHosts = persistHosts;
+    }
+    public boolean isTopologyPortGroups() {
+        return topologyPortGroups;
+    }
+    public void setTopologyPortGroups(boolean topologyPortGroups) {
+        this.topologyPortGroups = topologyPortGroups;
+    }
+    public boolean isTopologyNetworks() {
+        return topologyNetworks;
+    }
+    public void setTopologyNetworks(boolean topologyNetworks) {
+        this.topologyNetworks = topologyNetworks;
+    }
+    public boolean isTopologyDatastores() {
+        return topologyDatastores;
+    }
+    public void setTopologyDatastores(boolean topologyDatastores) {
+        this.topologyDatastores = topologyDatastores;
+    }
+    public List<String> getHostSystemServices() {
+        return hostSystemServices != null ? hostSystemServices : DEFAULT_HOST_SYSTEM_SERVICES;
+    }
+    public void setHostSystemServices(List<String> hostSystemServices) {
+        this.hostSystemServices = hostSystemServices;
+    }
+    public List<String> getVirtualMachineServices() {
+        return virtualMachineServices != null ? virtualMachineServices : DEFAULT_VIRTUAL_MACHINE_SERVICES;
+    }
+    public void setVirtualMachineServices(List<String> virtualMachineServices) {
+        this.virtualMachineServices = virtualMachineServices;
+    }
+    public List<VmwareImportRequestAttribute> getCustomAttributes() {
+        return customAttributes;
+    }
+    public Map<String, String> getCustomAttributesMap() {
+        final Map<String, String> attributesMap = new HashMap<>();
+        for (VmwareImportRequestAttribute attr : customAttributes) {
+            attributesMap.put(attr.getKey(), attr.getValue());
+        }
+        return attributesMap;
+    }
+    public void setCustomAttributes(List<VmwareImportRequestAttribute> customAttributes) {
+        this.customAttributes = customAttributes;
+    }
+    public void setCustomAttributes(Map<String, String> customAttributes) {
+        this.customAttributes = customAttributes.entrySet().stream()
+                .map(e -> new VmwareImportRequestAttribute(e.getKey(), e.getValue()))
+                .collect(Collectors.toList());
+    }
+    public String getOldKey() {
+        return oldKey;
+    }
+    public void setOldKey(String oldKey) {
+        this.oldKey = oldKey;
+    }
+    public String getOldValue() {
+        return oldValue;
+    }
+    public Requisition getExistingRequisition() {
+        return existingRequisition;
+    }
+    public void setExistingRequisition(Requisition existingRequisition) {
+        this.existingRequisition = existingRequisition;
+    }
+    
+    @Override
+    public int hashCode() {
+        return Objects.hash(hostname, username, password, location, foreignSource, importVMPoweredOn, importVMPoweredOff,
+                importVMSuspended, importHostPoweredOn, importHostPoweredOff, importHostStandBy, importHostUnknown,
+                persistIPv4, persistIPv6, persistVMs, persistHosts, topologyPortGroups, topologyNetworks,
+                topologyDatastores, hostSystemServices, virtualMachineServices, customAttributes, oldKey, oldValue,
+                existingRequisition);
+    }
+
+    @Override
+    public boolean equals(final Object other) {
+        if (!(other instanceof VmwareImportRequest)) {
+            return false;
+        }
+        VmwareImportRequest castOther = (VmwareImportRequest) other;
+        return Objects.equals(hostname, castOther.hostname)
+                && Objects.equals(username, castOther.username)
+                && Objects.equals(password, castOther.password)
+                && Objects.equals(location, castOther.location)
+                && Objects.equals(foreignSource, castOther.foreignSource)
+                && Objects.equals(importVMPoweredOn, castOther.importVMPoweredOn)
+                && Objects.equals(importVMPoweredOff, castOther.importVMPoweredOff)
+                && Objects.equals(importVMSuspended, castOther.importVMSuspended)
+                && Objects.equals(importHostPoweredOn, castOther.importHostPoweredOn)
+                && Objects.equals(importHostPoweredOff, castOther.importHostPoweredOff)
+                && Objects.equals(importHostStandBy, castOther.importHostStandBy)
+                && Objects.equals(importHostUnknown, castOther.importHostUnknown)
+                && Objects.equals(persistIPv4, castOther.persistIPv4)
+                && Objects.equals(persistIPv6, castOther.persistIPv6)
+                && Objects.equals(persistVMs, castOther.persistVMs)
+                && Objects.equals(persistHosts, castOther.persistHosts)
+                && Objects.equals(topologyPortGroups, castOther.topologyPortGroups)
+                && Objects.equals(topologyNetworks, castOther.topologyNetworks)
+                && Objects.equals(topologyDatastores, castOther.topologyDatastores)
+                && Objects.equals(hostSystemServices, castOther.hostSystemServices)
+                && Objects.equals(virtualMachineServices, castOther.virtualMachineServices)
+                && Objects.equals(customAttributes, castOther.customAttributes)
+                && Objects.equals(oldKey, castOther.oldKey) && Objects.equals(oldValue, castOther.oldValue)
+                && Objects.equals(existingRequisition, castOther.existingRequisition);
+    }
+
+    private static boolean queryParameter(Map<String, String> parms, String key, boolean defaultValue) {
+        if (parms.get(key) == null) {
+            return defaultValue;
+        } else {
+            String value = parms.get(key).toLowerCase();
+
+            return ("yes".equals(value) || "true".equals(value) || "on".equals(value) || "1".equals(value));
+        }
+    }
+}

--- a/integrations/opennms-vmware/src/main/java/org/opennms/netmgt/provision/service/vmware/VmwareImportRequestAttribute.java
+++ b/integrations/opennms-vmware/src/main/java/org/opennms/netmgt/provision/service/vmware/VmwareImportRequestAttribute.java
@@ -1,0 +1,85 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2017-2017 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.provision.service.vmware;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlValue;
+import java.util.Objects;
+
+@XmlRootElement(name = "custom-attribute")
+@XmlAccessorType(XmlAccessType.NONE)
+public class VmwareImportRequestAttribute {
+
+    @XmlAttribute(name="key")
+    private String key;
+
+    @XmlValue
+    private String value;
+
+    public VmwareImportRequestAttribute() { }
+
+    public VmwareImportRequestAttribute(String key, String value) {
+        this.key = key;
+        this.value = value;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    @Override
+    public boolean equals(final Object other) {
+        if (!(other instanceof VmwareImportRequestAttribute)) {
+            return false;
+        }
+        VmwareImportRequestAttribute castOther = (VmwareImportRequestAttribute) other;
+        return Objects.equals(key, castOther.key) && Objects.equals(value, castOther.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(key, value);
+    }
+
+}

--- a/integrations/opennms-vmware/src/main/java/org/opennms/netmgt/provision/service/vmware/VmwareImporter.java
+++ b/integrations/opennms-vmware/src/main/java/org/opennms/netmgt/provision/service/vmware/VmwareImporter.java
@@ -1,0 +1,831 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2017-2017 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.provision.service.vmware;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.ConnectException;
+import java.net.InetAddress;
+import java.net.MalformedURLException;
+import java.net.URLEncoder;
+import java.net.UnknownHostException;
+import java.nio.charset.StandardCharsets;
+import java.rmi.RemoteException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.http.conn.util.InetAddressUtils;
+import org.opennms.netmgt.model.PrimaryType;
+import org.opennms.netmgt.provision.persist.requisition.Requisition;
+import org.opennms.netmgt.provision.persist.requisition.RequisitionAsset;
+import org.opennms.netmgt.provision.persist.requisition.RequisitionCategory;
+import org.opennms.netmgt.provision.persist.requisition.RequisitionInterface;
+import org.opennms.netmgt.provision.persist.requisition.RequisitionMonitoredService;
+import org.opennms.netmgt.provision.persist.requisition.RequisitionNode;
+import org.opennms.protocols.vmware.VmwareViJavaAccess;
+import org.sblim.wbem.cim.CIMException;
+import org.sblim.wbem.cim.CIMObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.vmware.vim25.CustomFieldDef;
+import com.vmware.vim25.CustomFieldStringValue;
+import com.vmware.vim25.CustomFieldValue;
+import com.vmware.vim25.HostRuntimeInfo;
+import com.vmware.vim25.HostSystemPowerState;
+import com.vmware.vim25.VirtualMachinePowerState;
+import com.vmware.vim25.VirtualMachineRuntimeInfo;
+import com.vmware.vim25.mo.Datastore;
+import com.vmware.vim25.mo.DistributedVirtualPortgroup;
+import com.vmware.vim25.mo.HostSystem;
+import com.vmware.vim25.mo.ManagedEntity;
+import com.vmware.vim25.mo.Network;
+import com.vmware.vim25.mo.VirtualMachine;
+
+/**
+ * <p>Generates a requisition of Vmware related entities using
+ * the configuration details given in the {@link VmwareImportRequest}.</p>
+ *
+ * @author Christian Pape <Christian.Pape@informatik.hs-fulda.de>
+ * @author Alejandro Galue <agalue@opennms.org>
+ */
+public class VmwareImporter {
+
+    private static final Logger logger = LoggerFactory.getLogger(VmwareImporter.class);
+
+    private final VmwareImportRequest request;
+
+    /**
+     * Host system managedObjectId to name mapping
+     */
+    private Map<String, String> m_hostSystemMap = new HashMap<String, String>();
+
+    /**
+     * requisition object
+     */
+    private Requisition m_requisition = null;
+
+    public VmwareImporter(VmwareImportRequest request) {
+        this.request = Objects.requireNonNull(request);
+    }
+
+    public Requisition getRequisition() {
+        logger.debug("Getting existing requisition (if any) for VMware management server {}", request.getHostname());
+        Requisition curReq = request.getExistingRequisition();
+        logger.debug("Building new requisition for VMware management server {}", request.getHostname());
+        Requisition newReq = buildVMwareRequisition();
+        logger.debug("Finished building new requisition for VMware management server {}", request.getHostname());
+        if (curReq == null) {
+            if (newReq == null) {
+                // FIXME Is this correct ? This is the old behavior
+                newReq = new Requisition(request.getForeignSource());
+            }
+        } else {
+            if (newReq == null) {
+                // If there is a requisition and the vCenter is not responding for some reason, it is better to use the old requisition,
+                // instead of returning an empty one, which can cause the lost of all the nodes from the DB.
+                newReq = curReq;
+            } else {
+                // If there is already a requisition, retrieve the custom assets and categories from the old one, and put them on the new one.
+                // The VMWare related assets and categories will be preserved.
+                for (RequisitionNode newNode : newReq.getNodes()) {
+                    for (RequisitionNode curNode : curReq.getNodes()) {
+                        if (newNode.getForeignId().equals(curNode.getForeignId())) {
+                            // Add existing custom assets
+                            for (RequisitionAsset asset : curNode.getAssets()) {
+                                if (!asset.getName().startsWith("vmware")) {
+                                    newNode.putAsset(asset);
+                                }
+                            }
+                            // Add existing custom categories
+                            for (RequisitionCategory cat : curNode.getCategories()) {
+                                if (!cat.getName().startsWith("VMWare")) {
+                                    newNode.putCategory(cat);
+                                }
+                            }
+                            // Add existing custom services
+                            /*
+                             * For each interface on the new requisition,
+                             * - Retrieve the list of custom services from the corresponding interface on the existing requisition,
+                             *   matching the interface by the IP address
+                             * - If the list of services is not empty, add them to the new interface
+                             */
+                            for (RequisitionInterface intf : curNode.getInterfaces()) {
+                                List<RequisitionMonitoredService> services = getManualyConfiguredServices(intf);
+                                if (!services.isEmpty()) {
+                                    RequisitionInterface newIntf = getRequisitionInterface(newNode, intf.getIpAddr());
+                                    if (newIntf != null) {
+                                        newIntf.getMonitoredServices().addAll(services);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        return newReq;
+    }
+
+    /**
+     * Builds the complete requisition object.
+     *
+     * @return the requisition object
+     */
+    private Requisition buildVMwareRequisition() {
+        VmwareViJavaAccess vmwareViJavaAccess = null;
+
+        // for now, set the foreign source to the specified vcenter host
+        m_requisition = new Requisition(request.getForeignSource());
+
+        logger.debug("Creating new VIJava access object for host {} ...", request.getHostname());
+        if ((request.getHostname() == null || "".equals(request.getHostname())) || (request.getPassword() == null || "".equals(request.getPassword()))) {
+            logger.info("No credentials found for connecting to host {}, trying anonymously...", request.getHostname());
+            try {
+                vmwareViJavaAccess = new VmwareViJavaAccess(request.getHostname());
+            } catch (IOException e) {
+                logger.warn("Error initialising VMware connection to '{}': '{}'", request.getHostname(), e.getMessage());
+                return null;
+            }
+        } else {
+            vmwareViJavaAccess = new VmwareViJavaAccess(request.getHostname(), request.getUsername(), request.getPassword());
+        }
+        logger.debug("Successfully created new VIJava access object for host {}", request.getHostname());
+
+        logger.debug("Connecting VIJava access for host {} ...", request.getHostname());
+        try {
+            vmwareViJavaAccess.connect();
+        } catch (MalformedURLException e) {
+            logger.warn("Error connecting VMware management server '{}': '{}'", request.getHostname(), e.getMessage());
+            return null;
+        } catch (RemoteException e) {
+            logger.warn("Error connecting VMware management server '{}': '{}'", request.getHostname(), e.getMessage());
+            return null;
+        }
+        logger.debug("Successfully connected VIJava access for host {}", request.getHostname());
+
+        logger.debug("Starting to enumerate VMware managed objects from host {} ...", request.getHostname());
+        try {
+            int apiVersion = vmwareViJavaAccess.getMajorApiVersion();
+            logger.debug("Starting to iterate host system managed objects from host {} ...", request.getHostname());
+            iterateHostSystems(vmwareViJavaAccess, apiVersion);
+            logger.debug("Done iterating host system managed objects from host {}", request.getHostname());
+            logger.debug("Starting to iterate VM managed objects from host {} ...", request.getHostname());
+            iterateVirtualMachines(vmwareViJavaAccess, apiVersion);
+            logger.debug("Done iterating VM managed objects from host {}", request.getHostname());
+        } catch (RemoteException e) {
+            logger.warn("Error retrieving managed objects from VMware management server '{}': '{}'", request.getHostname(), e.getMessage());
+            return null;
+        } finally {
+            vmwareViJavaAccess.disconnect();
+        }
+
+        return m_requisition;
+    }
+
+    /**
+     * Creates a requisition node for the given managed entity and type.
+     *
+     * @param ipAddresses   the set of Ip addresses
+     * @param managedEntity the managed entity
+     * @return the generated requisition node
+     */
+    private RequisitionNode createRequisitionNode(Set<String> ipAddresses, ManagedEntity managedEntity, int apiVersion, VmwareViJavaAccess vmwareViJavaAccess) {
+        RequisitionNode requisitionNode = new RequisitionNode();
+
+        // Setting the node label
+        requisitionNode.setNodeLabel(managedEntity.getName());
+
+        // Foreign Id consisting of managed entity Id
+        requisitionNode.setForeignId(managedEntity.getMOR().getVal());
+
+        /*
+         * Original version:
+         *
+         * Foreign Id consisting of VMware management server's hostname and managed entity id
+         *
+         * requisitionNode.setForeignId(m_hostname + "/" + managedEntity.getMOR().getVal());
+         */
+
+        if (managedEntity instanceof VirtualMachine) {
+            boolean firstInterface = true;
+
+            // add all given interfaces
+            for (String ipAddress : ipAddresses) {
+
+                try {
+                    if ((request.isPersistIPv4() && InetAddressUtils.isIPv4Address(ipAddress)) || (request.isPersistIPv6() && InetAddressUtils.isIPv6Address(ipAddress))) {
+                        InetAddress inetAddress = InetAddress.getByName(ipAddress);
+
+                        if (!inetAddress.isLoopbackAddress()) {
+                            RequisitionInterface requisitionInterface = new RequisitionInterface();
+                            requisitionInterface.setIpAddr(ipAddress);
+
+                            //  the first one will be primary
+                            if (firstInterface) {
+                                requisitionInterface.setSnmpPrimary(PrimaryType.PRIMARY);
+                                for (String service : request.getVirtualMachineServices()) {
+                                    requisitionInterface.insertMonitoredService(new RequisitionMonitoredService(service.trim()));
+                                }
+                                firstInterface = false;
+                            } else {
+                                requisitionInterface.setSnmpPrimary(PrimaryType.SECONDARY);
+                            }
+
+                            requisitionInterface.setManaged(Boolean.TRUE);
+                            requisitionInterface.setStatus(Integer.valueOf(1));
+                            requisitionNode.putInterface(requisitionInterface);
+                        }
+                    }
+                } catch (UnknownHostException unknownHostException) {
+                    logger.warn("Invalid IP address '{}'", unknownHostException.getMessage());
+                }
+            }
+        } else {
+            if (managedEntity instanceof HostSystem) {
+                boolean reachableInterfaceFound = false, firstInterface = true;
+                List<RequisitionInterface> requisitionInterfaceList = new ArrayList<RequisitionInterface>();
+                RequisitionInterface primaryInterfaceCandidate = null;
+
+                // add all given interfaces
+                for (String ipAddress : ipAddresses) {
+
+                    try {
+                        if ((request.isPersistIPv4() && InetAddressUtils.isIPv4Address(ipAddress)) || (request.isPersistIPv6() && InetAddressUtils.isIPv6Address(ipAddress))) {
+                            InetAddress inetAddress = InetAddress.getByName(ipAddress);
+
+                            if (!inetAddress.isLoopbackAddress()) {
+                                RequisitionInterface requisitionInterface = new RequisitionInterface();
+                                requisitionInterface.setIpAddr(ipAddress);
+
+                                if (firstInterface) {
+                                    primaryInterfaceCandidate = requisitionInterface;
+                                    firstInterface = false;
+                                }
+
+                                if (!reachableInterfaceFound && reachableCimService(vmwareViJavaAccess, (HostSystem) managedEntity, ipAddress)) {
+                                    primaryInterfaceCandidate = requisitionInterface;
+                                    reachableInterfaceFound = true;
+                                }
+
+                                requisitionInterface.setManaged(Boolean.TRUE);
+                                requisitionInterface.setStatus(Integer.valueOf(1));
+                                requisitionInterface.setSnmpPrimary(PrimaryType.SECONDARY);
+                                requisitionInterfaceList.add(requisitionInterface);
+                            }
+                        }
+
+                    } catch (UnknownHostException unknownHostException) {
+                        logger.warn("Invalid IP address '{}'", unknownHostException.getMessage());
+                    }
+                }
+
+                if (primaryInterfaceCandidate != null) {
+                    if (reachableInterfaceFound) {
+                        logger.warn("Found reachable primary interface '{}'", primaryInterfaceCandidate.getIpAddr());
+                    } else {
+                        logger.warn("Only non-reachable interfaces found, using first one for primary interface '{}'", primaryInterfaceCandidate.getIpAddr());
+                    }
+                    primaryInterfaceCandidate.setSnmpPrimary(PrimaryType.PRIMARY);
+
+                    for (String service : request.getHostSystemServices()) {
+                        if (reachableInterfaceFound || !"VMwareCim-HostSystem".equals(service)) {
+                            primaryInterfaceCandidate.insertMonitoredService(new RequisitionMonitoredService(service.trim()));
+                        }
+                    }
+                } else {
+                    logger.warn("No primary interface found");
+                }
+
+                for (RequisitionInterface requisitionInterface : requisitionInterfaceList) {
+                    requisitionNode.putInterface(requisitionInterface);
+                }
+
+            } else {
+                logger.error("Undefined type of managedEntity '{}'", managedEntity.getMOR().getType());
+                return null;
+            }
+        }
+
+        /*
+         * For now we use displaycategory, notifycategory and pollercategory for storing
+         * the vcenter Ip address, the username and the password
+         */
+
+        String powerState = "unknown";
+        StringBuffer vmwareTopologyInfo = new StringBuffer();
+
+        // putting parents to topology information
+        ManagedEntity parentEntity = managedEntity.getParent();
+
+        do {
+            if (vmwareTopologyInfo.length() > 0) {
+                vmwareTopologyInfo.append(", ");
+            }
+            try {
+                if (parentEntity != null && parentEntity.getMOR() != null) {
+                    vmwareTopologyInfo.append(parentEntity.getMOR().getVal() + "/" + URLEncoder.encode(parentEntity.getName(), StandardCharsets.UTF_8.name()));
+                } else {
+                    logger.warn("Can't add topologyInformation because either the parentEntity or the MOR is null for " + managedEntity.getName());
+                }
+            } catch (UnsupportedEncodingException e) {
+                logger.warn("Unsupported encoding '{}'", e.getMessage());
+            }
+            parentEntity = parentEntity == null ? null : parentEntity.getParent();
+        } while (parentEntity != null);
+
+        if (managedEntity instanceof HostSystem) {
+
+            HostSystem hostSystem = (HostSystem) managedEntity;
+
+            HostRuntimeInfo hostRuntimeInfo = hostSystem.getRuntime();
+
+            if (hostRuntimeInfo == null) {
+                logger.debug("hostRuntimeInfo=null");
+            } else {
+                HostSystemPowerState hostSystemPowerState = hostRuntimeInfo.getPowerState();
+                if (hostSystemPowerState == null) {
+                    logger.debug("hostSystemPowerState=null");
+                } else {
+                    powerState = hostSystemPowerState.toString();
+                }
+            }
+
+            try {
+                if (request.isTopologyDatastores()) {
+                    for (Datastore datastore : hostSystem.getDatastores()) {
+                        if (vmwareTopologyInfo.length() > 0) {
+                            vmwareTopologyInfo.append(", ");
+                        }
+                        try {
+                            vmwareTopologyInfo.append(datastore.getMOR().getVal() + "/" + URLEncoder.encode(datastore.getSummary().getName(), StandardCharsets.UTF_8.name()));
+                        } catch (UnsupportedEncodingException e) {
+                            logger.warn("Unsupported encoding '{}'", e.getMessage());
+                        }
+                    }
+                }
+            } catch (RemoteException e) {
+                logger.warn("Cannot retrieve datastores for managedEntity '{}': '{}'", managedEntity.getMOR().getVal(), e.getMessage());
+            }
+
+            try {
+                if (request.isTopologyNetworks()) {
+                    for (Network network : hostSystem.getNetworks()) {
+                        if (vmwareTopologyInfo.length() > 0) {
+                            vmwareTopologyInfo.append(", ");
+                        }
+                        try {
+                            if (network instanceof DistributedVirtualPortgroup ? request.isTopologyPortGroups() : true) {
+                                vmwareTopologyInfo.append(network.getMOR().getVal() + "/" + URLEncoder.encode(network.getSummary().getName(), StandardCharsets.UTF_8.name()));
+                            }
+                        } catch (UnsupportedEncodingException e) {
+                            logger.warn("Unsupported encoding '{}'", e.getMessage());
+                        }
+                    }
+                }
+            } catch (RemoteException e) {
+                logger.warn("Cannot retrieve networks for managedEntity '{}': '{}'", managedEntity.getMOR().getVal(), e.getMessage());
+            }
+        } else {
+
+            if (managedEntity instanceof VirtualMachine) {
+                VirtualMachine virtualMachine = (VirtualMachine) managedEntity;
+
+                VirtualMachineRuntimeInfo virtualMachineRuntimeInfo = virtualMachine.getRuntime();
+
+                if (virtualMachineRuntimeInfo == null) {
+                    logger.debug("virtualMachineRuntimeInfo=null");
+                } else {
+                    VirtualMachinePowerState virtualMachinePowerState = virtualMachineRuntimeInfo.getPowerState();
+                    if (virtualMachinePowerState == null) {
+                        logger.debug("virtualMachinePowerState=null");
+                    } else {
+                        powerState = virtualMachinePowerState.toString();
+                    }
+                }
+
+                try {
+                    if (request.isTopologyDatastores()) {
+                        for (Datastore datastore : virtualMachine.getDatastores()) {
+                            if (vmwareTopologyInfo.length() > 0) {
+                                vmwareTopologyInfo.append(", ");
+                            }
+                            try {
+                                vmwareTopologyInfo.append(datastore.getMOR().getVal() + "/" + URLEncoder.encode(datastore.getSummary().getName(), StandardCharsets.UTF_8.name()));
+                            } catch (UnsupportedEncodingException e) {
+                                logger.warn("Unsupported encoding '{}'", e.getMessage());
+                            }
+                        }
+                    }
+                } catch (RemoteException e) {
+                    logger.warn("Cannot retrieve datastores for managedEntity '{}': '{}'", managedEntity.getMOR().getVal(), e.getMessage());
+                }
+                try {
+                    if (request.isTopologyNetworks()) {
+                        for (Network network : virtualMachine.getNetworks()) {
+                            if (vmwareTopologyInfo.length() > 0) {
+                                vmwareTopologyInfo.append(", ");
+                            }
+                            try {
+                                if (network instanceof DistributedVirtualPortgroup ? request.isTopologyPortGroups() : true) {
+                                    vmwareTopologyInfo.append(network.getMOR().getVal() + "/" + URLEncoder.encode(network.getSummary().getName(), StandardCharsets.UTF_8.name()));
+                                }
+                            } catch (UnsupportedEncodingException e) {
+                                logger.warn("Unsupported encoding '{}'", e.getMessage());
+                            }
+                        }
+                    }
+                } catch (RemoteException e) {
+                    logger.warn("Cannot retrieve networks for managedEntity '{}': '{}'", managedEntity.getMOR().getVal(), e.getMessage());
+                }
+
+                if (vmwareTopologyInfo.length() > 0) {
+                    vmwareTopologyInfo.append(", ");
+                }
+
+                try {
+                    vmwareTopologyInfo.append(virtualMachine.getRuntime().getHost().getVal() + "/" + URLEncoder.encode(m_hostSystemMap.get(virtualMachine.getRuntime().getHost().getVal()), StandardCharsets.UTF_8.name()));
+                } catch (UnsupportedEncodingException e) {
+                    logger.warn("Unsupported encoding '{}'", e.getMessage());
+                }
+            } else {
+                logger.error("Undefined type of managedEntity '{}'", managedEntity.getMOR().getType());
+
+                return null;
+            }
+        }
+
+        RequisitionAsset requisitionAssetHostname = new RequisitionAsset("vmwareManagementServer", request.getHostname());
+        requisitionNode.putAsset(requisitionAssetHostname);
+
+        RequisitionAsset requisitionAssetType = new RequisitionAsset("vmwareManagedEntityType", (managedEntity instanceof HostSystem ? "HostSystem" : "VirtualMachine"));
+        requisitionNode.putAsset(requisitionAssetType);
+
+        RequisitionAsset requisitionAssetId = new RequisitionAsset("vmwareManagedObjectId", managedEntity.getMOR().getVal());
+        requisitionNode.putAsset(requisitionAssetId);
+
+        RequisitionAsset requisitionAssetTopologyInfo = new RequisitionAsset("vmwareTopologyInfo", vmwareTopologyInfo.toString());
+        requisitionNode.putAsset(requisitionAssetTopologyInfo);
+
+        RequisitionAsset requisitionAssetState = new RequisitionAsset("vmwareState", powerState);
+        requisitionNode.putAsset(requisitionAssetState);
+
+        requisitionNode.putCategory(new RequisitionCategory("VMware" + apiVersion));
+
+        return requisitionNode;
+    }
+
+    private boolean reachableCimService(VmwareViJavaAccess vmwareViJavaAccess, HostSystem hostSystem, String ipAddress) {
+        if (!vmwareViJavaAccess.setTimeout(3000)) {
+            logger.warn("Error setting connection timeout");
+        }
+
+        List<CIMObject> cimObjects = null;
+        try {
+            cimObjects = vmwareViJavaAccess.queryCimObjects(hostSystem, "CIM_NumericSensor", ipAddress);
+        } catch (ConnectException e) {
+            return false;
+        } catch (RemoteException e) {
+            return false;
+        } catch (CIMException e) {
+            return false;
+        }
+
+        return cimObjects != null;
+    }
+
+    /**
+     * Checks whether the host system should be imported into the requisition.
+     *
+     * @param hostSystem the system to check
+     * @return true for import, false otherwise
+     */
+    private boolean checkHostPowerState(HostSystem hostSystem) {
+        logger.debug("Checking power state for host system {} (ID {})", hostSystem.getName(), hostSystem.getMOR().getVal());
+        String powerState = hostSystem.getRuntime().getPowerState().toString();
+
+        if ("poweredOn".equals(powerState) && request.isImportHostPoweredOn()) {
+            return true;
+        }
+        if ("poweredOff".equals(powerState) && request.isImportHostPoweredOff()) {
+            return true;
+        }
+        if ("standBy".equals(powerState) && request.isImportHostStandBy()) {
+            return true;
+        }
+        if ("unknown".equals(powerState) && request.isImportHostUnknown()) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Checks whether the virtual machine should be imported into the requisition.
+     *
+     * @param virtualMachine the system to check
+     * @return true for import, false otherwise
+     */
+    private boolean checkVMPowerState(VirtualMachine virtualMachine) {
+        logger.debug("Checking power state for VM {} (ID: {})", virtualMachine.getName(), virtualMachine.getMOR().getVal());
+        String powerState = virtualMachine.getRuntime().getPowerState().toString();
+
+        if ("poweredOn".equals(powerState) && request.isImportVMPoweredOn()) {
+            return true;
+        }
+        if ("poweredOff".equals(powerState) && request.isImportVMPoweredOff()) {
+            return true;
+        }
+        if ("suspended".equals(powerState) && request.isImportVMSuspended()) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Iterates through the host systems and adds them to the requisition object.
+     *
+     * @param vmwareViJavaAccess the access/connection to use
+     * @throws RemoteException
+     */
+    private void iterateHostSystems(VmwareViJavaAccess vmwareViJavaAccess, int apiVersion) throws RemoteException {
+        ManagedEntity[] hostSystems;
+
+        // search for host systems (esx hosts)
+        logger.debug("Starting to iterate host systems on VMware host {} ...", request.getHostname());
+        hostSystems = vmwareViJavaAccess.searchManagedEntities("HostSystem");
+
+        if (hostSystems != null) {
+
+            for (ManagedEntity managedEntity : hostSystems) {
+                HostSystem hostSystem = (HostSystem) managedEntity;
+                logger.debug("Iterating host systems on VMware management server {} : {} (ID: {})", request.getHostname(), hostSystem.getName(), hostSystem.getMOR().getVal());
+
+                m_hostSystemMap.put(hostSystem.getMOR().getVal(), hostSystem.getName());
+
+                // check for correct key/value-pair
+                if (checkHostPowerState(hostSystem) && checkForAttribute(hostSystem)) {
+                    logger.debug("Adding Host System '{}' (ID: {})", hostSystem.getName(), hostSystem.getMOR().getVal());
+
+                    // iterate over all service console networks and add interface Ip addresses
+                    TreeSet<String> ipAddresses = vmwareViJavaAccess.getHostSystemIpAddresses(hostSystem);
+
+                    // create the new node...
+                    RequisitionNode node = createRequisitionNode(ipAddresses, hostSystem, apiVersion, vmwareViJavaAccess);
+
+                    // add cpu
+                    try {
+                        node.putAsset(new RequisitionAsset("cpu", hostSystem.getHardware().getCpuInfo().getNumCpuCores() + " cores"));
+                    } catch (Exception e) {
+                        logger.debug("Can't find CPU information for {} (ID: {})", hostSystem.getName(), hostSystem.getMOR().getVal());
+                    }
+
+                    // add memory
+                    try {
+                        node.putAsset(new RequisitionAsset("ram", Math.round(hostSystem.getHardware().getMemorySize()/1000000f) + " MB"));
+                    } catch (Exception e) {
+                        logger.debug("Can't find Memory information for {} (ID: {})", hostSystem.getName(), hostSystem.getMOR().getVal());
+                    }
+
+                    // add vendor
+                    /*
+                    try {
+                        node.putAsset(new RequisitionAsset("vendor", hostSystem.getHardware().getSystemInfo().getVendor()));
+                    } catch (Exception e) {
+                        logger.debug("Can't find vendor information for {}", hostSystem.getName());
+                    }
+                    */
+
+                    // set the location
+                    node.setLocation(request.getLocation());
+
+                    // ...and add it to the requisition
+                    if (node != null && request.isPersistHosts()) {
+                        m_requisition.insertNode(node);
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Iterates through the virtual machines and adds them to the requisition object.
+     *
+     * @param vmwareViJavaAccess the access/connection to use
+     * @throws RemoteException
+     */
+    private void iterateVirtualMachines(VmwareViJavaAccess vmwareViJavaAccess, int apiVersion) throws RemoteException {
+        ManagedEntity[] virtualMachines;
+
+        // search for all virtual machines
+        virtualMachines = vmwareViJavaAccess.searchManagedEntities("VirtualMachine");
+
+        if (virtualMachines != null) {
+
+            // check for correct key/value-pair
+            for (ManagedEntity managedEntity : virtualMachines) {
+                VirtualMachine virtualMachine = (VirtualMachine) managedEntity;
+                logger.debug("Iterating host systems on VMware management server {} : {} (ID: {})", request.getHostname(), virtualMachine.getName(), virtualMachine.getMOR().getVal());
+
+                // import only when the specified attributes is set
+                if (checkVMPowerState(virtualMachine) && checkForAttribute(virtualMachine)) {
+                    logger.debug("Adding Virtual Machine '{}' (ID: {})", virtualMachine.getName(), virtualMachine.getMOR().getVal());
+
+                    // iterate over all interfaces
+                    TreeSet<String> ipAddresses = vmwareViJavaAccess.getVirtualMachineIpAddresses(virtualMachine);
+
+                    // create the new node...
+                    RequisitionNode node = createRequisitionNode(ipAddresses, virtualMachine, apiVersion, vmwareViJavaAccess);
+
+                    // add the operating system
+                    if (virtualMachine.getGuest().getGuestFullName() != null) {
+                        node.putAsset(new RequisitionAsset("operatingSystem", virtualMachine.getGuest().getGuestFullName()));
+                    }
+
+                    // add cpu
+                    try {
+                        node.putAsset(new RequisitionAsset("cpu", virtualMachine.getConfig().getHardware().getNumCPU() + " vCPU"));
+                    } catch (Exception e) {
+                        logger.debug("Can't find CPU information for {} (ID: {})", virtualMachine.getName(), virtualMachine.getMOR().getVal());
+                    }
+
+                    // add memory
+                    try {
+                        node.putAsset(new RequisitionAsset("ram", virtualMachine.getConfig().getHardware().getMemoryMB() + " MB"));
+                    } catch (Exception e) {
+                        logger.debug("Can't find Memory information for {} (ID: {})", virtualMachine.getName(), virtualMachine.getMOR().getVal());
+                    }
+
+                    // set the location
+                    node.setLocation(request.getLocation());
+
+                    // ...and add it to the requisition
+                    if (node != null && request.isPersistVMs()) {
+                        m_requisition.insertNode(node);
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Checks whether an attribute/value is defined by a managed entity.
+     * 
+     * <p>The old implementation allows the user to specify only one parameter.</p>
+     * <p>The new implementation allows the user to use a regular expression for the value:</p>
+     * <ul><li>key=location&value=~North.*</li></ul>
+     * <p>As an alternative, now it is possible to specify several parameters on the query.
+     * The rule is to add an underscore character ('_') before the parameter's name and use similar rules for the value:</p>
+     * <ul><li>_location=~North.*</li></ul>
+     * <p>With the new parameter specification, it is possible to pass several attributes. The managed entity must match
+     * all of them to be accepted.</p>
+     * <p>The new specification will take precedence over the old specification. If the new specification is not being used,
+     * the old one will be processed. Otherwise, the new one will be processed, and the old one will be ignored. There is no
+     * way to use both at the same time.</p>
+     *
+     * @param managedEntity the managed entity to check
+     * @return true if present and value is equal, false otherwise
+     * @throws RemoteException
+     */
+    private boolean checkForAttribute(ManagedEntity managedEntity) throws RemoteException {
+        logger.debug("Getting Managed entity custom attributes from VMware management server {} : ManagedEntity {} (ID: {})", request.getHostname(), managedEntity.getName(), managedEntity.getMOR().getVal());
+        Map<String,String> attribMap = getCustomAttributes(managedEntity);
+
+        // Using new parameter specification
+        if (!request.getCustomAttributes().isEmpty()) {
+            logger.debug("_[customAttributeName] provisioning attributes specified. Making sure Managed Entity {} has the requested custom attributes", managedEntity.getName());
+            boolean ok = true;
+            final Map<String, String> customAttributes = request.getCustomAttributesMap();
+            for (String keyName : customAttributes.keySet()) {
+                logger.debug("Looking up for custom attribute {} with value {}", keyName, customAttributes.get(keyName));
+                String attribValue = attribMap.get(StringUtils.removeStart(keyName, "_"));
+                if (attribValue == null) {
+                    logger.debug("No custom attribute named {} found for Managed Entity {}", keyName, managedEntity.getName());
+                    ok = false;
+                } else {
+                    String keyValue = customAttributes.get(keyName);
+                    if (keyValue.startsWith("~")) {
+                        ok = ok && attribValue.matches(StringUtils.removeStart(keyValue, "~"));
+                    } else {
+                        ok = ok && attribValue.equals(keyValue);
+                    }
+                }
+            }
+            return ok;
+        }
+
+        // Using old parameter specification
+        String key = request.getOldKey();
+        String value = request.getOldValue();
+        if (key == null && value == null) {
+            logger.debug("No custom attributes required for provisioning Managed Entity {}.", managedEntity.getName());
+            return true;
+        }
+        if (key == null || value == null) {
+            logger.error("Not provisioning Manged Entiry {}: Using old key/value parameters, but either 'key' or 'value' parameter isn't set.", managedEntity.getName());
+            return false;
+        }
+        String attribValue = attribMap.get(key);
+        if (attribValue != null) {
+            if (value.startsWith("~")) {
+                return attribValue.matches(StringUtils.removeStart(value, "~"));
+            } else {
+                return attribValue.equals(value);
+            }
+        }
+
+        logger.debug("No custom attributes named {} found for Managed Entity {}", key, managedEntity.getName());
+        return false;
+    }
+
+    /**
+     * Gets the custom attributes.
+     *
+     * @param entity the entity
+     * @return the custom attributes
+     * @throws RemoteException the remote exception
+     */
+    private Map<String,String> getCustomAttributes(ManagedEntity entity) throws RemoteException {
+        final Map<String,String> attributes = new TreeMap<String,String>();
+        logger.debug("Getting custom attributes from VMware management server {} : ManagedEntity {} (ID: {})", request.getHostname(), entity.getName(), entity.getMOR().getVal());
+        CustomFieldDef[] defs = entity.getAvailableField();
+        CustomFieldValue[] values = entity.getCustomValue();
+        for (int i = 0; defs != null && i < defs.length; i++) {
+            String key = defs[i].getName();
+            int targetIndex = defs[i].getKey();
+            for (int j = 0; values != null && j < values.length; j++) {
+                if (targetIndex == values[j].getKey()) {
+                    attributes.put(key, ((CustomFieldStringValue) values[j]).getValue());
+                }
+            }
+        }
+        return attributes;
+    }
+
+    private RequisitionInterface getRequisitionInterface(RequisitionNode node, String ipAddr) {
+        for (RequisitionInterface intf : node.getInterfaces()) {
+            if (ipAddr.equals(intf.getIpAddr())) {
+                return intf;
+            }
+        }
+        return null;
+    }
+
+    private List<RequisitionMonitoredService> getManualyConfiguredServices(RequisitionInterface intf) {
+        List<RequisitionMonitoredService> services = new ArrayList<RequisitionMonitoredService>();
+        for (RequisitionMonitoredService svc : intf.getMonitoredServices()) {
+            boolean found = false;
+            for (String svcName : request.getHostSystemServices()) {
+                if (svcName.trim().equals(svc.getServiceName())) {
+                    found = true;
+                    continue;
+                }
+            }
+            for (String svcName : request.getVirtualMachineServices()) {
+                if (svcName.trim().equals(svc.getServiceName())) {
+                    found = true;
+                    continue;
+                }
+            }
+            if (!found) {
+                services.add(svc);
+            }
+        }
+        return services;
+    }
+
+}

--- a/integrations/opennms-vmware/src/main/java/org/opennms/netmgt/provision/service/vmware/VmwareRequisitionProvider.java
+++ b/integrations/opennms-vmware/src/main/java/org/opennms/netmgt/provision/service/vmware/VmwareRequisitionProvider.java
@@ -1,0 +1,109 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2017-2017 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.provision.service.vmware;
+
+import java.util.Map;
+
+import org.apache.commons.lang.StringUtils;
+import org.opennms.netmgt.config.vmware.VmwareServer;
+import org.opennms.netmgt.dao.VmwareConfigDao;
+import org.opennms.netmgt.provision.persist.AbstractRequisitionProvider;
+import org.opennms.netmgt.provision.persist.ForeignSourceRepository;
+import org.opennms.netmgt.provision.persist.requisition.Requisition;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+
+/**
+ * Generates requisition for Vmware entities.
+ *
+ * See {@link VmwareImportRequest} for all supported options.
+ *
+ * @author jwhite
+ */
+public class VmwareRequisitionProvider extends AbstractRequisitionProvider<VmwareImportRequest> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(VmwareRequisitionProvider.class);
+
+    public static final String TYPE_NAME = "vmware";
+
+    @Autowired
+    @Qualifier("fileDeployed")
+    private ForeignSourceRepository foreignSourceRepository;
+
+    @Autowired
+    private VmwareConfigDao vmwareConfigDao;
+
+    public VmwareRequisitionProvider() {
+        super(VmwareImportRequest.class);
+    }
+
+    @Override
+    public String getType() {
+        return TYPE_NAME;
+    }
+
+    @Override
+    public VmwareImportRequest getRequest(Map<String, String> parameters) {
+        // Generate a request using the parameter map
+        final VmwareImportRequest request = new VmwareImportRequest(parameters);
+        if (StringUtils.isBlank(request.getUsername()) ||
+                StringUtils.isBlank(request.getPassword())) {
+            // No credentials were specified in the parameter map, attempt to look these up
+            final Map<String, VmwareServer> serverMap = vmwareConfigDao.getServerMap();
+            final VmwareServer vmwareServer = serverMap.get(request.getHostname());
+            if (vmwareServer != null) {
+                // We found a corresponding entry - copy the credentials to the request
+                request.setUsername(vmwareServer.getUsername());
+                request.setPassword(vmwareServer.getPassword());
+            }
+        }
+        // Lookup the existing requisition, and store it in the request
+        final Requisition existingRequisition = getExistingRequisition(request.getForeignSource());
+        request.setExistingRequisition(existingRequisition);
+        return request;
+    }
+
+    @Override
+    public Requisition getRequisitionFor(VmwareImportRequest request) {
+        final VmwareImporter importer = new VmwareImporter(request);
+        return importer.getRequisition();
+    }
+
+    protected Requisition getExistingRequisition(String foreignSource) {
+        try {
+            return foreignSourceRepository.getRequisition(foreignSource);
+        } catch (Exception e) {
+            LOG.warn("Can't retrieve requisition {}", foreignSource, e);
+            return null;
+        }
+    }
+
+}

--- a/integrations/opennms-vmware/src/main/java/org/opennms/netmgt/provision/service/vmware/VmwareRequisitionTool.java
+++ b/integrations/opennms-vmware/src/main/java/org/opennms/netmgt/provision/service/vmware/VmwareRequisitionTool.java
@@ -95,9 +95,9 @@ public abstract class VmwareRequisitionTool {
 
         VmwareRequisitionUrlConnection c = new VmwareRequisitionUrlConnection(url) {
             @Override
-            protected Requisition getExistingRequisition() {
+            protected Requisition getExistingRequisition(String foreignSource) {
                 // This is not elegant but it is necessary to avoid booting Spring
-                File req = new File(ConfigFileConstants.getFilePathString(), "imports" + File.separator + m_foreignSource + ".xml");
+                File req = new File(ConfigFileConstants.getFilePathString(), "imports" + File.separator + foreignSource + ".xml");
                 if (req.exists()) {
                     return JaxbUtils.unmarshal(Requisition.class, req);
                 }

--- a/integrations/opennms-vmware/src/main/java/org/opennms/netmgt/provision/service/vmware/VmwareRequisitionUrlConnection.java
+++ b/integrations/opennms-vmware/src/main/java/org/opennms/netmgt/provision/service/vmware/VmwareRequisitionUrlConnection.java
@@ -28,40 +28,32 @@
 
 package org.opennms.netmgt.provision.service.vmware;
 
-import com.vmware.vim25.*;
-import com.vmware.vim25.mo.*;
-
-import org.apache.commons.io.IOExceptionWithCause;
-import org.apache.commons.lang.StringUtils;
-import org.apache.http.conn.util.InetAddressUtils;
-import org.opennms.core.spring.BeanUtils;
-import org.opennms.core.utils.url.GenericURLConnection;
-import org.opennms.core.xml.JaxbUtils;
-import org.opennms.netmgt.model.PrimaryType;
-import org.opennms.netmgt.provision.persist.ForeignSourceRepository;
-import org.opennms.netmgt.provision.persist.requisition.*;
-import org.opennms.protocols.vmware.VmwareViJavaAccess;
-import org.sblim.wbem.cim.CIMException;
-import org.sblim.wbem.cim.CIMObject;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import javax.xml.bind.JAXBException;
-
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.UnsupportedEncodingException;
-import java.net.*;
-import java.nio.charset.StandardCharsets;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.rmi.RemoteException;
-import java.util.*;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.xml.bind.JAXBException;
+
+import org.apache.commons.io.IOExceptionWithCause;
+import org.opennms.core.spring.BeanUtils;
+import org.opennms.core.utils.url.GenericURLConnection;
+import org.opennms.core.xml.JaxbUtils;
+import org.opennms.netmgt.provision.persist.ForeignSourceRepository;
+import org.opennms.netmgt.provision.persist.requisition.Requisition;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The Class VmwareRequisitionUrlConnection
  * 
- * <p>This class is used for the automtic requisition of Vmware related entities.</p>
+ * <p>This class is used for the automatic requisition of Vmware related entities.</p>
  *
+ * @deprecated Use the {@link VmwareRequisitionProvider} instead.
  * @author Christian Pape <Christian.Pape@informatik.hs-fulda.de>
  * @author Alejandro Galue <agalue@opennms.org>
  */
@@ -69,53 +61,9 @@ public class VmwareRequisitionUrlConnection extends GenericURLConnection {
     /**
      * the logger
      */
-    private Logger logger = LoggerFactory.getLogger(VmwareRequisitionUrlConnection.class);
+    private static final Logger logger = LoggerFactory.getLogger(VmwareRequisitionUrlConnection.class);
 
-    private static final String VMWARE_HOSTSYSTEM_SERVICES = "hostSystemServices";
-    private static final String VMWARE_VIRTUALMACHINE_SERVICES = "virtualMachineServices";
-
-    private String[] m_hostSystemServices;
-    private String[] m_virtualMachineServices;
-
-    private String m_hostname = null;
-    private String m_username = null;
-    private String m_password = null;
-    protected String m_foreignSource = null;
-
-    private boolean m_importVMPoweredOn = true;
-    private boolean m_importVMPoweredOff = false;
-    private boolean m_importVMSuspended = false;
-
-    private boolean m_importHostPoweredOn = true;
-    private boolean m_importHostPoweredOff = false;
-    private boolean m_importHostStandBy = false;
-    private boolean m_importHostUnknown = false;
-
-    private boolean m_persistIPv4 = true;
-    private boolean m_persistIPv6 = true;
-
-    private boolean m_persistVMs = true;
-    private boolean m_persistHosts = true;
-
-    private boolean m_topologyPortGroups = false;
-    private boolean m_topologyNetworks = true;
-    private boolean m_topologyDatastores = true;
-
-    /*
-     * Host system managedObjectId to name mapping
-     */
-
-    private Map<String, String> m_hostSystemMap = new HashMap<String, String>();
-
-    /**
-     * the query arguments
-     */
-    private Map<String, String> m_args = null;
-
-    /**
-     * requisition object
-     */
-    private Requisition m_requisition = null;
+    private final VmwareImportRequest importRequest;
 
     /**
      * Constructor for creating an instance of this class.
@@ -127,770 +75,39 @@ public class VmwareRequisitionUrlConnection extends GenericURLConnection {
     public VmwareRequisitionUrlConnection(URL url) throws MalformedURLException, RemoteException {
         super(url);
 
-        m_hostname = url.getHost();
+        logger.debug("Initializing URL Connection for host {}", url.getHost());
 
-        logger.debug("Initializing URL Connection for host {}", m_hostname);
-
-        m_args = getQueryArgs();
+        Map<String, String> requestParameters = new HashMap<>();
+        requestParameters.put("host", url.getHost());
+        requestParameters.put("path", url.getPath());
 
         // Old or new user credentials handling scheme
-	if (url.getUserInfo() != null && !url.getUserInfo().isEmpty()) {
+        if (url.getUserInfo() != null && !url.getUserInfo().isEmpty()) {
             logger.warn("Old user credentials handling scheme detected. I'm gonna use it but you'd better adapt your URL to the new query parameter scheme 'vmware://<vcenter_server_fqdn>?username=<username>;password=<password>;....'");
-            m_username = getUsername();
-            m_password = getPassword();
-        } else {
-            m_username = m_args.get("username");
-            m_password = m_args.get("password");
+            requestParameters.put("username", getUsername());
+            requestParameters.put("password", getPassword());
         }
+        requestParameters.putAll(getQueryArgs());
 
-        logger.debug("Found username parameter {}", (m_username == null) ? "NULL" : m_username );
-
-        boolean importVMOnly = queryParameter("importVMOnly", false);
-        boolean importHostOnly = queryParameter("importHostOnly", false);
-
-        if (importHostOnly && importVMOnly) {
-            throw new MalformedURLException("importHostOnly and importVMOnly can't be true simultaneously");
-        }
-        if (importHostOnly) {
-            m_persistVMs = false;
-        }
-        if (importVMOnly) {
-            m_persistHosts = false;
-        }
-
-        boolean importIPv4Only = queryParameter("importIPv4Only", false);
-        boolean importIPv6Only = queryParameter("importIPv6Only", false);
-
-        if (importIPv4Only && importIPv6Only) {
-            throw new MalformedURLException("importIPv4Only and importIPv6Only can't be true simultaneously");
-        }
-        if (importIPv4Only) {
-            m_persistIPv6 = false;
-        }
-        if (importIPv6Only) {
-            m_persistIPv4 = false;
-        }
-
-        m_topologyPortGroups = queryParameter("topologyPortGroups", false);
-        m_topologyNetworks = queryParameter("topologyNetworks", true);
-        m_topologyDatastores = queryParameter("topologyDatastores", true);
-
-        m_importVMPoweredOn = queryParameter("importVMPoweredOn", true);
-        m_importVMPoweredOff = queryParameter("importVMPoweredOff", false);
-        m_importVMSuspended = queryParameter("importVMSuspended", false);
-
-        m_importHostPoweredOn = queryParameter("importHostPoweredOn", true);
-        m_importHostPoweredOff = queryParameter("importHostPoweredOff", false);
-        m_importHostStandBy = queryParameter("importHostStandBy", false);
-        m_importHostUnknown = queryParameter("importHostUnknown", false);
-
-        if (queryParameter("importHostAll", false)) {
-            m_importHostPoweredOn = true;
-            m_importHostPoweredOff = true;
-            m_importHostStandBy = true;
-            m_importHostUnknown = true;
-        }
-
-        if (queryParameter("importVMAll", false)) {
-            m_importVMPoweredOff = true;
-            m_importVMPoweredOn = true;
-            m_importVMSuspended = true;
-        }
-
-        String path = url.getPath();
-
-        path = path.replaceAll("^/", "");
-        path = path.replaceAll("/$", "");
-
-        String[] pathElements = path.split("/");
-
-        if (pathElements.length == 1) {
-            if ("".equals(pathElements[0])) {
-                m_foreignSource = "vmware-" + m_hostname;
-            } else {
-                m_foreignSource = pathElements[0];
-            }
-        } else {
-            throw new MalformedURLException("Error processing path element of URL (vmware://host[/foreign-source]?keyA=valueA;keyB=valueB;...)");
-        }
+        importRequest = new VmwareImportRequest(requestParameters);
     }
 
-    /**
-     * Returns a boolean representation for a given on/off parameter.
-     *
-     * @param key          the parameter's name
-     * @param defaultValue the default value to use
-     * @return the boolean value
-     */
-    private boolean queryParameter(String key, boolean defaultValue) {
-        if (m_args.get(key) == null) {
-            return defaultValue;
-        } else {
-            String value = m_args.get(key).toLowerCase();
-
-            return ("yes".equals(value) || "true".equals(value) || "on".equals(value) || "1".equals(value));
+    protected Requisition getExistingRequisition(String foreignSource) {
+        Requisition curReq = null;
+        try {
+            ForeignSourceRepository repository = BeanUtils.getBean("daoContext", "deployedForeignSourceRepository", ForeignSourceRepository.class);
+            if (repository != null) {
+                curReq = repository.getRequisition(foreignSource);
+            }
+        } catch (Exception e) {
+            logger.warn("Can't retrieve requisition {}", foreignSource, e);
         }
+        return curReq;
     }
 
     @Override
-    public void connect() throws IOException {
-        // To change body of implemented methods use File | Settings | File
-        // Templates.
-    }
-
-    private boolean reachableCimService(VmwareViJavaAccess vmwareViJavaAccess, HostSystem hostSystem, String ipAddress) {
-        if (!vmwareViJavaAccess.setTimeout(3000)) {
-            logger.warn("Error setting connection timeout");
-        }
-
-        List<CIMObject> cimObjects = null;
-        try {
-            cimObjects = vmwareViJavaAccess.queryCimObjects(hostSystem, "CIM_NumericSensor", ipAddress);
-        } catch (ConnectException e) {
-            return false;
-        } catch (RemoteException e) {
-            return false;
-        } catch (CIMException e) {
-            return false;
-        }
-
-        return cimObjects != null;
-    }
-
-    /**
-     * Creates a requisition node for the given managed entity and type.
-     *
-     * @param ipAddresses   the set of Ip addresses
-     * @param managedEntity the managed entity
-     * @return the generated requisition node
-     */
-    private RequisitionNode createRequisitionNode(Set<String> ipAddresses, ManagedEntity managedEntity, int apiVersion, VmwareViJavaAccess vmwareViJavaAccess) {
-        RequisitionNode requisitionNode = new RequisitionNode();
-
-        // Setting the node label
-        requisitionNode.setNodeLabel(managedEntity.getName());
-
-        // Foreign Id consisting of managed entity Id
-        requisitionNode.setForeignId(managedEntity.getMOR().getVal());
-
-        /*
-         * Original version:
-         *
-         * Foreign Id consisting of VMware management server's hostname and managed entity id
-         *
-         * requisitionNode.setForeignId(m_hostname + "/" + managedEntity.getMOR().getVal());
-         */
-
-        if (managedEntity instanceof VirtualMachine) {
-            boolean firstInterface = true;
-
-            // add all given interfaces
-            for (String ipAddress : ipAddresses) {
-
-                try {
-                    if ((m_persistIPv4 && InetAddressUtils.isIPv4Address(ipAddress)) || (m_persistIPv6 && InetAddressUtils.isIPv6Address(ipAddress))) {
-                        InetAddress inetAddress = InetAddress.getByName(ipAddress);
-
-                        if (!inetAddress.isLoopbackAddress()) {
-                            RequisitionInterface requisitionInterface = new RequisitionInterface();
-                            requisitionInterface.setIpAddr(ipAddress);
-
-                            //  the first one will be primary
-                            if (firstInterface) {
-                                requisitionInterface.setSnmpPrimary(PrimaryType.PRIMARY);
-                                for (String service : m_virtualMachineServices) {
-                                    requisitionInterface.insertMonitoredService(new RequisitionMonitoredService(service.trim()));
-                                }
-                                firstInterface = false;
-                            } else {
-                                requisitionInterface.setSnmpPrimary(PrimaryType.SECONDARY);
-                            }
-
-                            requisitionInterface.setManaged(Boolean.TRUE);
-                            requisitionInterface.setStatus(Integer.valueOf(1));
-                            requisitionNode.putInterface(requisitionInterface);
-                        }
-                    }
-                } catch (UnknownHostException unknownHostException) {
-                    logger.warn("Invalid IP address '{}'", unknownHostException.getMessage());
-                }
-            }
-        } else {
-            if (managedEntity instanceof HostSystem) {
-                boolean reachableInterfaceFound = false, firstInterface = true;
-                List<RequisitionInterface> requisitionInterfaceList = new ArrayList<RequisitionInterface>();
-                RequisitionInterface primaryInterfaceCandidate = null;
-
-                // add all given interfaces
-                for (String ipAddress : ipAddresses) {
-
-                    try {
-                        if ((m_persistIPv4 && InetAddressUtils.isIPv4Address(ipAddress)) || (m_persistIPv6 && InetAddressUtils.isIPv6Address(ipAddress))) {
-                            InetAddress inetAddress = InetAddress.getByName(ipAddress);
-
-                            if (!inetAddress.isLoopbackAddress()) {
-                                RequisitionInterface requisitionInterface = new RequisitionInterface();
-                                requisitionInterface.setIpAddr(ipAddress);
-
-                                if (firstInterface) {
-                                    primaryInterfaceCandidate = requisitionInterface;
-                                    firstInterface = false;
-                                }
-
-                                if (!reachableInterfaceFound && reachableCimService(vmwareViJavaAccess, (HostSystem) managedEntity, ipAddress)) {
-                                    primaryInterfaceCandidate = requisitionInterface;
-                                    reachableInterfaceFound = true;
-                                }
-
-                                requisitionInterface.setManaged(Boolean.TRUE);
-                                requisitionInterface.setStatus(Integer.valueOf(1));
-                                requisitionInterface.setSnmpPrimary(PrimaryType.SECONDARY);
-                                requisitionInterfaceList.add(requisitionInterface);
-                            }
-                        }
-
-                    } catch (UnknownHostException unknownHostException) {
-                        logger.warn("Invalid IP address '{}'", unknownHostException.getMessage());
-                    }
-                }
-
-                if (primaryInterfaceCandidate != null) {
-                    if (reachableInterfaceFound) {
-                        logger.warn("Found reachable primary interface '{}'", primaryInterfaceCandidate.getIpAddr());
-                    } else {
-                        logger.warn("Only non-reachable interfaces found, using first one for primary interface '{}'", primaryInterfaceCandidate.getIpAddr());
-                    }
-                    primaryInterfaceCandidate.setSnmpPrimary(PrimaryType.PRIMARY);
-
-                    for (String service : m_hostSystemServices) {
-                        if (reachableInterfaceFound || !"VMwareCim-HostSystem".equals(service)) {
-                            primaryInterfaceCandidate.insertMonitoredService(new RequisitionMonitoredService(service.trim()));
-                        }
-                    }
-                } else {
-                    logger.warn("No primary interface found");
-                }
-
-                for (RequisitionInterface requisitionInterface : requisitionInterfaceList) {
-                    requisitionNode.putInterface(requisitionInterface);
-                }
-
-            } else {
-                logger.error("Undefined type of managedEntity '{}'", managedEntity.getMOR().getType());
-                return null;
-            }
-        }
-
-        /*
-         * For now we use displaycategory, notifycategory and pollercategory for storing
-         * the vcenter Ip address, the username and the password
-         */
-
-        String powerState = "unknown";
-        StringBuffer vmwareTopologyInfo = new StringBuffer();
-
-        // putting parents to topology information
-        ManagedEntity parentEntity = managedEntity.getParent();
-
-        do {
-            if (vmwareTopologyInfo.length() > 0) {
-                vmwareTopologyInfo.append(", ");
-            }
-            try {
-                if (parentEntity != null && parentEntity.getMOR() != null) {
-                    vmwareTopologyInfo.append(parentEntity.getMOR().getVal() + "/" + URLEncoder.encode(parentEntity.getName(), StandardCharsets.UTF_8.name()));
-                } else {
-                    logger.warn("Can't add topologyInformation because either the parentEntity or the MOR is null for " + managedEntity.getName());
-                }
-            } catch (UnsupportedEncodingException e) {
-                logger.warn("Unsupported encoding '{}'", e.getMessage());
-            }
-            parentEntity = parentEntity == null ? null : parentEntity.getParent();
-        } while (parentEntity != null);
-
-        if (managedEntity instanceof HostSystem) {
-
-            HostSystem hostSystem = (HostSystem) managedEntity;
-
-            HostRuntimeInfo hostRuntimeInfo = hostSystem.getRuntime();
-
-            if (hostRuntimeInfo == null) {
-                logger.debug("hostRuntimeInfo=null");
-            } else {
-                HostSystemPowerState hostSystemPowerState = hostRuntimeInfo.getPowerState();
-                if (hostSystemPowerState == null) {
-                    logger.debug("hostSystemPowerState=null");
-                } else {
-                    powerState = hostSystemPowerState.toString();
-                }
-            }
-
-            try {
-                if (m_topologyDatastores) {
-                    for (Datastore datastore : hostSystem.getDatastores()) {
-                        if (vmwareTopologyInfo.length() > 0) {
-                            vmwareTopologyInfo.append(", ");
-                        }
-                        try {
-                            vmwareTopologyInfo.append(datastore.getMOR().getVal() + "/" + URLEncoder.encode(datastore.getSummary().getName(), StandardCharsets.UTF_8.name()));
-                        } catch (UnsupportedEncodingException e) {
-                            logger.warn("Unsupported encoding '{}'", e.getMessage());
-                        }
-                    }
-                }
-            } catch (RemoteException e) {
-                logger.warn("Cannot retrieve datastores for managedEntity '{}': '{}'", managedEntity.getMOR().getVal(), e.getMessage());
-            }
-
-            try {
-                if (m_topologyNetworks) {
-                    for (Network network : hostSystem.getNetworks()) {
-                        if (vmwareTopologyInfo.length() > 0) {
-                            vmwareTopologyInfo.append(", ");
-                        }
-                        try {
-                            if (network instanceof DistributedVirtualPortgroup ? m_topologyPortGroups : true) {
-                                vmwareTopologyInfo.append(network.getMOR().getVal() + "/" + URLEncoder.encode(network.getSummary().getName(), StandardCharsets.UTF_8.name()));
-                            }
-                        } catch (UnsupportedEncodingException e) {
-                            logger.warn("Unsupported encoding '{}'", e.getMessage());
-                        }
-                    }
-                }
-            } catch (RemoteException e) {
-                logger.warn("Cannot retrieve networks for managedEntity '{}': '{}'", managedEntity.getMOR().getVal(), e.getMessage());
-            }
-        } else {
-
-            if (managedEntity instanceof VirtualMachine) {
-                VirtualMachine virtualMachine = (VirtualMachine) managedEntity;
-
-                VirtualMachineRuntimeInfo virtualMachineRuntimeInfo = virtualMachine.getRuntime();
-
-                if (virtualMachineRuntimeInfo == null) {
-                    logger.debug("virtualMachineRuntimeInfo=null");
-                } else {
-                    VirtualMachinePowerState virtualMachinePowerState = virtualMachineRuntimeInfo.getPowerState();
-                    if (virtualMachinePowerState == null) {
-                        logger.debug("virtualMachinePowerState=null");
-                    } else {
-                        powerState = virtualMachinePowerState.toString();
-                    }
-                }
-
-                try {
-                    if (m_topologyDatastores) {
-                        for (Datastore datastore : virtualMachine.getDatastores()) {
-                            if (vmwareTopologyInfo.length() > 0) {
-                                vmwareTopologyInfo.append(", ");
-                            }
-                            try {
-                                vmwareTopologyInfo.append(datastore.getMOR().getVal() + "/" + URLEncoder.encode(datastore.getSummary().getName(), StandardCharsets.UTF_8.name()));
-                            } catch (UnsupportedEncodingException e) {
-                                logger.warn("Unsupported encoding '{}'", e.getMessage());
-                            }
-                        }
-                    }
-                } catch (RemoteException e) {
-                    logger.warn("Cannot retrieve datastores for managedEntity '{}': '{}'", managedEntity.getMOR().getVal(), e.getMessage());
-                }
-                try {
-                    if (m_topologyNetworks) {
-                        for (Network network : virtualMachine.getNetworks()) {
-                            if (vmwareTopologyInfo.length() > 0) {
-                                vmwareTopologyInfo.append(", ");
-                            }
-                            try {
-                                if (network instanceof DistributedVirtualPortgroup ? m_topologyPortGroups : true) {
-                                    vmwareTopologyInfo.append(network.getMOR().getVal() + "/" + URLEncoder.encode(network.getSummary().getName(), StandardCharsets.UTF_8.name()));
-                                }
-                            } catch (UnsupportedEncodingException e) {
-                                logger.warn("Unsupported encoding '{}'", e.getMessage());
-                            }
-                        }
-                    }
-                } catch (RemoteException e) {
-                    logger.warn("Cannot retrieve networks for managedEntity '{}': '{}'", managedEntity.getMOR().getVal(), e.getMessage());
-                }
-
-                if (vmwareTopologyInfo.length() > 0) {
-                    vmwareTopologyInfo.append(", ");
-                }
-
-                try {
-                    vmwareTopologyInfo.append(virtualMachine.getRuntime().getHost().getVal() + "/" + URLEncoder.encode(m_hostSystemMap.get(virtualMachine.getRuntime().getHost().getVal()), StandardCharsets.UTF_8.name()));
-                } catch (UnsupportedEncodingException e) {
-                    logger.warn("Unsupported encoding '{}'", e.getMessage());
-                }
-            } else {
-                logger.error("Undefined type of managedEntity '{}'", managedEntity.getMOR().getType());
-
-                return null;
-            }
-        }
-
-        RequisitionAsset requisitionAssetHostname = new RequisitionAsset("vmwareManagementServer", m_hostname);
-        requisitionNode.putAsset(requisitionAssetHostname);
-
-        RequisitionAsset requisitionAssetType = new RequisitionAsset("vmwareManagedEntityType", (managedEntity instanceof HostSystem ? "HostSystem" : "VirtualMachine"));
-        requisitionNode.putAsset(requisitionAssetType);
-
-        RequisitionAsset requisitionAssetId = new RequisitionAsset("vmwareManagedObjectId", managedEntity.getMOR().getVal());
-        requisitionNode.putAsset(requisitionAssetId);
-
-        RequisitionAsset requisitionAssetTopologyInfo = new RequisitionAsset("vmwareTopologyInfo", vmwareTopologyInfo.toString());
-        requisitionNode.putAsset(requisitionAssetTopologyInfo);
-
-        RequisitionAsset requisitionAssetState = new RequisitionAsset("vmwareState", powerState);
-        requisitionNode.putAsset(requisitionAssetState);
-
-        requisitionNode.putCategory(new RequisitionCategory("VMware" + apiVersion));
-
-        return requisitionNode;
-    }
-
-    /**
-     * Builds the complete requisition object.
-     *
-     * @return the requisition object
-     */
-    private Requisition buildVMwareRequisition() {
-        VmwareViJavaAccess vmwareViJavaAccess = null;
-
-        // for now, set the foreign source to the specified vcenter host
-        m_requisition = new Requisition(m_foreignSource);
-
-        logger.debug("Creating new VIJava access object for host {} ...", m_hostname);
-        if ((m_username == null || "".equals(m_username)) || (m_password == null || "".equals(m_password))) {
-            logger.info("No credentials found for connecting to host {}, trying anonymously...", m_hostname);
-            try {
-                vmwareViJavaAccess = new VmwareViJavaAccess(m_hostname);
-            } catch (IOException e) {
-                logger.warn("Error initialising VMware connection to '{}': '{}'", m_hostname, e.getMessage());
-                return null;
-            }
-        } else {
-            vmwareViJavaAccess = new VmwareViJavaAccess(m_hostname, m_username, m_password);
-        }
-        logger.debug("Successfully created new VIJava access object for host {}", m_hostname);
-
-        logger.debug("Connecting VIJava access for host {} ...", m_hostname);
-        try {
-            vmwareViJavaAccess.connect();
-        } catch (MalformedURLException e) {
-            logger.warn("Error connecting VMware management server '{}': '{}'", m_hostname, e.getMessage());
-            return null;
-        } catch (RemoteException e) {
-            logger.warn("Error connecting VMware management server '{}': '{}'", m_hostname, e.getMessage());
-            return null;
-        }
-        logger.debug("Successfully connected VIJava access for host {}", m_hostname);
-
-        logger.debug("Starting to enumerate VMware managed objects from host {} ...", m_hostname);
-        try {
-            int apiVersion = vmwareViJavaAccess.getMajorApiVersion();
-
-            // get services to be added to host systems
-            // m_hostSystemServices = getHostSystemServices(apiVersion);
-
-            if (m_args != null && m_args.get(VMWARE_HOSTSYSTEM_SERVICES) != null) {
-                m_hostSystemServices = m_args.get(VMWARE_HOSTSYSTEM_SERVICES).split(",");
-            } else {
-                m_hostSystemServices = new String[]{"VMware-ManagedEntity", "VMware-HostSystem", "VMwareCim-HostSystem"};
-            }
-
-            // get services to be added to virtual machines
-            // m_virtualMachineServices = getVirtualMachineServices(apiVersion);
-
-            if (m_args != null && m_args.get(VMWARE_VIRTUALMACHINE_SERVICES) != null) {
-                m_virtualMachineServices = m_args.get(VMWARE_VIRTUALMACHINE_SERVICES).split(",");
-            } else {
-                m_virtualMachineServices = new String[]{"VMware-ManagedEntity", "VMware-VirtualMachine"};
-            }
-
-            logger.debug("Starting to iterate host system managed objects from host {} ...", m_hostname);
-            iterateHostSystems(vmwareViJavaAccess, apiVersion);
-            logger.debug("Done iterating host system managed objects from host {}", m_hostname);
-            logger.debug("Starting to iterate VM managed objects from host {} ...", m_hostname);
-            iterateVirtualMachines(vmwareViJavaAccess, apiVersion);
-            logger.debug("Done iterating VM managed objects from host {}", m_hostname);
-        } catch (RemoteException e) {
-            logger.warn("Error retrieving managed objects from VMware management server '{}': '{}'", m_hostname, e.getMessage());
-            return null;
-        } finally {
-            vmwareViJavaAccess.disconnect();
-        }
-
-        return m_requisition;
-    }
-
-    /**
-     * Checks whether the host system should be imported into the requisition.
-     *
-     * @param hostSystem the system to check
-     * @return true for import, false otherwise
-     */
-    private boolean checkHostPowerState(HostSystem hostSystem) {
-        logger.debug("Checking power state for host system {} (ID {})", hostSystem.getName(), hostSystem.getMOR().getVal());
-        String powerState = hostSystem.getRuntime().getPowerState().toString();
-
-        if ("poweredOn".equals(powerState) && m_importHostPoweredOn) {
-            return true;
-        }
-        if ("poweredOff".equals(powerState) && m_importHostPoweredOff) {
-            return true;
-        }
-        if ("standBy".equals(powerState) && m_importHostStandBy) {
-            return true;
-        }
-        if ("unknown".equals(powerState) && m_importHostUnknown) {
-            return true;
-        }
-
-        return false;
-    }
-
-    /**
-     * Checks whether the virtual machine should be imported into the requisition.
-     *
-     * @param virtualMachine the system to check
-     * @return true for import, false otherwise
-     */
-    private boolean checkVMPowerState(VirtualMachine virtualMachine) {
-        logger.debug("Checking power state for VM {} (ID: {})", virtualMachine.getName(), virtualMachine.getMOR().getVal());
-        String powerState = virtualMachine.getRuntime().getPowerState().toString();
-
-        if ("poweredOn".equals(powerState) && m_importVMPoweredOn) {
-            return true;
-        }
-        if ("poweredOff".equals(powerState) && m_importVMPoweredOff) {
-            return true;
-        }
-        if ("suspended".equals(powerState) && m_importVMSuspended) {
-            return true;
-        }
-
-        return false;
-    }
-
-    /**
-     * Iterates through the host systems and adds them to the requisition object.
-     *
-     * @param vmwareViJavaAccess the access/connection to use
-     * @throws RemoteException
-     */
-    private void iterateHostSystems(VmwareViJavaAccess vmwareViJavaAccess, int apiVersion) throws RemoteException {
-        ManagedEntity[] hostSystems;
-
-        // search for host systems (esx hosts)
-        logger.debug("Starting to iterate host systems on VMware host {} ...", m_hostname);
-        hostSystems = vmwareViJavaAccess.searchManagedEntities("HostSystem");
-
-        if (hostSystems != null) {
-
-            for (ManagedEntity managedEntity : hostSystems) {
-                HostSystem hostSystem = (HostSystem) managedEntity;
-                logger.debug("Iterating host systems on VMware management server {} : {} (ID: {})", m_hostname, hostSystem.getName(), hostSystem.getMOR().getVal());
-
-                m_hostSystemMap.put(hostSystem.getMOR().getVal(), hostSystem.getName());
-
-                // check for correct key/value-pair
-                if (checkHostPowerState(hostSystem) && checkForAttribute(hostSystem)) {
-                    logger.debug("Adding Host System '{}' (ID: {})", hostSystem.getName(), hostSystem.getMOR().getVal());
-
-                    // iterate over all service console networks and add interface Ip addresses
-                    TreeSet<String> ipAddresses = vmwareViJavaAccess.getHostSystemIpAddresses(hostSystem);
-
-                    // create the new node...
-                    RequisitionNode node = createRequisitionNode(ipAddresses, hostSystem, apiVersion, vmwareViJavaAccess);
-
-                    // add cpu
-                    try {
-                        node.putAsset(new RequisitionAsset("cpu", hostSystem.getHardware().getCpuInfo().getNumCpuCores() + " cores"));
-                    } catch (Exception e) {
-                        logger.debug("Can't find CPU information for {} (ID: {})", hostSystem.getName(), hostSystem.getMOR().getVal());
-                    }
-
-                    // add memory
-                    try {
-                        node.putAsset(new RequisitionAsset("ram", Math.round(hostSystem.getHardware().getMemorySize()/1000000f) + " MB"));
-                    } catch (Exception e) {
-                        logger.debug("Can't find Memory information for {} (ID: {})", hostSystem.getName(), hostSystem.getMOR().getVal());
-                    }
-
-                    // add vendor
-                    /*
-                    try {
-                        node.putAsset(new RequisitionAsset("vendor", hostSystem.getHardware().getSystemInfo().getVendor()));
-                    } catch (Exception e) {
-                        logger.debug("Can't find vendor information for {}", hostSystem.getName());
-                    }
-                    */
-
-                    // ...and add it to the requisition
-                    if (node != null && m_persistHosts) {
-                        m_requisition.insertNode(node);
-                    }
-                }
-            }
-        }
-    }
-
-    /**
-     * Iterates through the virtual machines and adds them to the requisition object.
-     *
-     * @param vmwareViJavaAccess the access/connection to use
-     * @throws RemoteException
-     */
-    private void iterateVirtualMachines(VmwareViJavaAccess vmwareViJavaAccess, int apiVersion) throws RemoteException {
-        ManagedEntity[] virtualMachines;
-
-        // search for all virtual machines
-        virtualMachines = vmwareViJavaAccess.searchManagedEntities("VirtualMachine");
-
-        if (virtualMachines != null) {
-
-            // check for correct key/value-pair
-            for (ManagedEntity managedEntity : virtualMachines) {
-                VirtualMachine virtualMachine = (VirtualMachine) managedEntity;
-                logger.debug("Iterating host systems on VMware management server {} : {} (ID: {})", m_hostname, virtualMachine.getName(), virtualMachine.getMOR().getVal());
-
-                // import only when the specified attributes is set
-                if (checkVMPowerState(virtualMachine) && checkForAttribute(virtualMachine)) {
-                    logger.debug("Adding Virtual Machine '{}' (ID: {})", virtualMachine.getName(), virtualMachine.getMOR().getVal());
-
-                    // iterate over all interfaces
-                    TreeSet<String> ipAddresses = vmwareViJavaAccess.getVirtualMachineIpAddresses(virtualMachine);
-
-                    // create the new node...
-                    RequisitionNode node = createRequisitionNode(ipAddresses, virtualMachine, apiVersion, vmwareViJavaAccess);
-
-                    // add the operating system
-                    if (virtualMachine.getGuest().getGuestFullName() != null) {
-                        node.putAsset(new RequisitionAsset("operatingSystem", virtualMachine.getGuest().getGuestFullName()));
-                    }
-
-                    // add cpu
-                    try {
-                        node.putAsset(new RequisitionAsset("cpu", virtualMachine.getConfig().getHardware().getNumCPU() + " vCPU"));
-                    } catch (Exception e) {
-                        logger.debug("Can't find CPU information for {} (ID: {})", virtualMachine.getName(), virtualMachine.getMOR().getVal());
-                    }
-
-                    // add memory
-                    try {
-                        node.putAsset(new RequisitionAsset("ram", virtualMachine.getConfig().getHardware().getMemoryMB() + " MB"));
-                    } catch (Exception e) {
-                        logger.debug("Can't find Memory information for {} (ID: {})", virtualMachine.getName(), virtualMachine.getMOR().getVal());
-                    }
-
-                    // ...and add it to the requisition
-                    if (node != null && m_persistVMs) {
-                        m_requisition.insertNode(node);
-                    }
-                }
-            }
-        }
-    }
-
-    /**
-     * Checks whether an attribute/value is defined by a managed entity.
-     * 
-     * <p>The old implementation allows the user to specify only one parameter.</p>
-     * <p>The new implementation allows the user to use a regular expression for the value:</p>
-     * <ul><li>key=location&value=~North.*</li></ul>
-     * <p>As an alternative, now it is possible to specify several parameters on the query.
-     * The rule is to add an underscore character ('_') before the parameter's name and use similar rules for the value:</p>
-     * <ul><li>_location=~North.*</li></ul>
-     * <p>With the new parameter specification, it is possible to pass several attributes. The managed entity must match
-     * all of them to be accepted.</p>
-     * <p>The new specification will take precedence over the old specification. If the new specification is not being used,
-     * the old one will be processed. Otherwise, the new one will be processed, and the old one will be ignored. There is no
-     * way to use both at the same time.</p>
-     *
-     * @param managedEntity the managed entity to check
-     * @return true if present and value is equal, false otherwise
-     * @throws RemoteException
-     */
-    private boolean checkForAttribute(ManagedEntity managedEntity) throws RemoteException {
-        logger.debug("Getting Managed entity custom attributes from VMware management server {} : ManagedEntity {} (ID: {})", m_hostname, managedEntity.getName(), managedEntity.getMOR().getVal());
-        Map<String,String> attribMap = getCustomAttributes(managedEntity);
-
-        Set<String> keySet = new TreeSet<String>();
-        for (String k : m_args.keySet()) {
-            if (k.startsWith("_")) {
-                keySet.add(k);
-            }
-        }
-
-	// Using new parameter specification
-        if (!keySet.isEmpty()) {
-       	    logger.debug("_[customAttributeName] provisioning attributes specified. Making sure Managed Entity {} has the requested custom attributes", managedEntity.getName());
-            boolean ok = true;
-            for (String keyName : keySet) {
-       	        logger.debug("Looking up for custom attribute {} with value {}", keyName, m_args.get(keyName));
-                String attribValue = attribMap.get(StringUtils.removeStart(keyName, "_"));
-                if (attribValue == null) {
-       	            logger.debug("No custom attribute named {} found for Managed Entity {}", keyName, managedEntity.getName());
-                    ok = false;
-                } else {
-                    String keyValue = m_args.get(keyName);
-                    if (keyValue.startsWith("~")) {
-                        ok = ok && attribValue.matches(StringUtils.removeStart(keyValue, "~"));
-                    } else {
-                        ok = ok && attribValue.equals(keyValue);
-                    }
-                }
-            }
-            return ok;
-        }
-
-        // Using old parameter specification
-        String key = m_args.get("key");
-        String value = m_args.get("value");
-        if (key == null && value == null) {
-      	    logger.debug("No custom attributes required for provisioning Managed Entity {}.", managedEntity.getName());
-            return true;
-        }
-        if (key == null || value == null) {
-      	    logger.error("Not provisioning Manged Entiry {}: Using old key/value parameters, but either 'key' or 'value' parameter isn't set.", managedEntity.getName());
-            return false;
-        }
-        String attribValue = attribMap.get(key);
-        if (attribValue != null) {
-            if (value.startsWith("~")) {
-                return attribValue.matches(StringUtils.removeStart(value, "~"));
-            } else {
-                return attribValue.equals(value);
-            }
-        }
-
-    	logger.debug("No custom attributes named {} found for Managed Entity {}", key, managedEntity.getName());
-        return false;
-    }
-
-    /**
-     * Gets the custom attributes.
-     *
-     * @param entity the entity
-     * @return the custom attributes
-     * @throws RemoteException the remote exception
-     */
-    private Map<String,String> getCustomAttributes(ManagedEntity entity) throws RemoteException {
-        final Map<String,String> attributes = new TreeMap<String,String>();
-        logger.debug("Getting custom attributes from VMware management server {} : ManagedEntity {} (ID: {})", m_hostname, entity.getName(), entity.getMOR().getVal());
-        CustomFieldDef[] defs = entity.getAvailableField();
-        CustomFieldValue[] values = entity.getCustomValue();
-        for (int i = 0; defs != null && i < defs.length; i++) {
-            String key = defs[i].getName();
-            int targetIndex = defs[i].getKey();
-            for (int j = 0; values != null && j < values.length; j++) {
-                if (targetIndex == values[j].getKey()) {
-                    attributes.put(key, ((CustomFieldStringValue) values[j]).getValue());
-                }
-            }
-        }
-        return attributes;
+    public void connect() {
+        // pass
     }
 
     /**
@@ -904,114 +121,17 @@ public class VmwareRequisitionUrlConnection extends GenericURLConnection {
     public InputStream getInputStream() throws IOException {
 
         InputStream stream = null;
-
         try {
-            logger.debug("Getting existing requisition (if any) for VMware management server {}", m_hostname);
-            Requisition curReq = getExistingRequisition();
-            logger.debug("Building new requisition for VMware management server {}", m_hostname);
-            Requisition newReq = buildVMwareRequisition();
-            logger.debug("Finished building new requisition for VMware management server {}", m_hostname);
-            if (curReq == null) {
-                if (newReq == null) {
-                    // FIXME Is this correct ? This is the old behavior
-                    newReq = new Requisition(m_foreignSource);
-                }
-            } else {
-                if (newReq == null) {
-                    // If there is a requisition and the vCenter is not responding for some reason, it is better to use the old requisition,
-                    // instead of returning an empty one, which can cause the lost of all the nodes from the DB.
-                    newReq = curReq;
-                } else {
-                    // If there is already a requisition, retrieve the custom assets and categories from the old one, and put them on the new one.
-                    // The VMWare related assets and categories will be preserved.
-                    for (RequisitionNode newNode : newReq.getNodes()) {
-                        for (RequisitionNode curNode : curReq.getNodes()) {
-                            if (newNode.getForeignId().equals(curNode.getForeignId())) {
-                                // Add existing custom assets
-                                for (RequisitionAsset asset : curNode.getAssets()) {
-                                    if (!asset.getName().startsWith("vmware")) {
-                                        newNode.putAsset(asset);
-                                    }
-                                }
-                                // Add existing custom categories
-                                for (RequisitionCategory cat : curNode.getCategories()) {
-                                    if (!cat.getName().startsWith("VMWare")) {
-                                        newNode.putCategory(cat);
-                                    }
-                                }
-                                // Add existing custom services
-                                /*
-                                 * For each interface on the new requisition,
-                                 * - Retrieve the list of custom services from the corresponding interface on the existing requisition,
-                                 *   matching the interface by the IP address
-                                 * - If the list of services is not empty, add them to the new interface
-                                 */
-                                for (RequisitionInterface intf : curNode.getInterfaces()) {
-                                    List<RequisitionMonitoredService> services = getManualyConfiguredServices(intf);
-                                    if (!services.isEmpty()) {
-                                        RequisitionInterface newIntf = getRequisitionInterface(newNode, intf.getIpAddr());
-                                        if (newIntf != null) {
-                                            newIntf.getMonitoredServices().addAll(services);
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-            stream = new ByteArrayInputStream(jaxBMarshal(newReq).getBytes());
+            final Requisition existingRequisition = getExistingRequisition(importRequest.getForeignSource());
+            importRequest.setExistingRequisition(existingRequisition);
+            final VmwareImporter importer = new VmwareImporter(importRequest);
+            stream = new ByteArrayInputStream(jaxBMarshal(importer.getRequisition()).getBytes());
         } catch (Throwable e) {
             logger.warn("Problem getting input stream: '{}'", e);
             throw new IOExceptionWithCause("Problem getting input stream: " + e, e);
         }
 
         return stream;
-    }
-
-    protected Requisition getExistingRequisition() {
-        Requisition curReq = null;
-        try {
-            ForeignSourceRepository repository = BeanUtils.getBean("daoContext", "deployedForeignSourceRepository", ForeignSourceRepository.class);
-            if (repository != null) {
-                curReq = repository.getRequisition(m_foreignSource);
-            }
-        } catch (Exception e) {
-            logger.warn("Can't retrieve requisition {}", m_foreignSource);
-        }
-        return curReq;
-    }
-
-    private RequisitionInterface getRequisitionInterface(RequisitionNode node, String ipAddr) {
-        for (RequisitionInterface intf : node.getInterfaces()) {
-            if (ipAddr.equals(intf.getIpAddr())) {
-                return intf;
-            }
-        }
-        return null;
-    }
-
-    private List<RequisitionMonitoredService> getManualyConfiguredServices(RequisitionInterface intf) {
-        List<RequisitionMonitoredService> services = new ArrayList<RequisitionMonitoredService>();
-        for (RequisitionMonitoredService svc : intf.getMonitoredServices()) {
-            boolean found = false;
-            for (String svcName : m_hostSystemServices) {
-                if (svcName.trim().equals(svc.getServiceName())) {
-                    found = true;
-                    continue;
-                }
-            }
-            for (String svcName : m_virtualMachineServices) {
-                if (svcName.trim().equals(svc.getServiceName())) {
-                    found = true;
-                    continue;
-                }
-            }
-            if (!found) {
-                services.add(svc);
-            }
-        }
-        return services;
     }
 
     /**
@@ -1023,5 +143,9 @@ public class VmwareRequisitionUrlConnection extends GenericURLConnection {
      */
     private String jaxBMarshal(Requisition r) throws JAXBException {
         return JaxbUtils.marshal(r);
+    }
+
+    public VmwareImportRequest getImportRequest() {
+        return importRequest;
     }
 }

--- a/integrations/opennms-vmware/src/main/resources/META-INF/opennms/component-dao.xml
+++ b/integrations/opennms-vmware/src/main/resources/META-INF/opennms/component-dao.xml
@@ -3,9 +3,11 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:tx="http://www.springframework.org/schema/tx"
        xmlns:context="http://www.springframework.org/schema/context"
+       xmlns:onmsgi="http://xmlns.opennms.org/xsd/spring/onms-osgi"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
        http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
-       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd"
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
+       http://xmlns.opennms.org/xsd/spring/onms-osgi http://xmlns.opennms.org/xsd/spring/onms-osgi.xsd"
         >
 
     <context:annotation-config/>
@@ -34,5 +36,13 @@
         <property name="configResource" ref="vmwareConfigResourceLocation"/>
     </bean>
 
+    <!-- The 'vmware' provider -->
+    <bean id="vmwareRequisitionProvider" class="org.opennms.netmgt.provision.service.vmware.VmwareRequisitionProvider" />
+    <onmsgi:service interface="org.opennms.netmgt.provision.persist.RequisitionProvider" ref="vmwareRequisitionProvider">
+      <onmsgi:service-properties>
+        <entry key="type" value="vmware" />
+        <entry key="registration.export" value="true" />
+      </onmsgi:service-properties>
+    </onmsgi:service>
 
 </beans>

--- a/integrations/opennms-vmware/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/integrations/opennms-vmware/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -23,4 +23,12 @@
         </service-properties>
     </service>
 
+    <!-- The 'vmware' provider -->
+    <bean id="vmwareRequisitionProvider" class="org.opennms.netmgt.provision.service.vmware.VmwareRequisitionProvider" />
+    <service ref="vmwareRequisitionProvider" interface="org.opennms.netmgt.provision.persist.RequisitionProvider">
+      <service-properties>
+        <entry key="type" value="vmware" />
+      </service-properties>
+    </service>
+
 </blueprint>

--- a/integrations/opennms-vmware/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/integrations/opennms-vmware/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -9,6 +9,20 @@
         http://aries.apache.org/schemas/blueprint-ext/blueprint-ext-1.1.xsd
 ">
 
+    <bean id="vmwareMonitor" class="org.opennms.netmgt.poller.monitors.VmwareMonitor" />
+    <service ref="vmwareMonitor" interface="org.opennms.netmgt.poller.ServiceMonitor">
+        <service-properties>
+            <entry key="type" value="org.opennms.netmgt.poller.monitors.VmwareMonitor" />
+        </service-properties>
+    </service>
+
+    <bean id="vmwareCimMonitor" class="org.opennms.netmgt.poller.monitors.VmwareCimMonitor" />
+    <service ref="vmwareCimMonitor" interface="org.opennms.netmgt.poller.ServiceMonitor">
+        <service-properties>
+            <entry key="type" value="org.opennms.netmgt.poller.monitors.VmwareCimMonitor" />
+        </service-properties>
+    </service>
+
     <bean id="vmwareCollector" class="org.opennms.netmgt.collectd.VmwareCollector" />
     <service ref="vmwareCollector" interface="org.opennms.netmgt.collection.api.ServiceCollector">
         <service-properties>

--- a/integrations/opennms-vmware/src/test/java/org/opennms/netmgt/provision/service/vmware/VmwareImportRequestTest.java
+++ b/integrations/opennms-vmware/src/test/java/org/opennms/netmgt/provision/service/vmware/VmwareImportRequestTest.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2017-2017 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.provision.service.vmware;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.runners.Parameterized.Parameters;
+import org.opennms.core.test.xml.XmlTestNoCastor;
+
+public class VmwareImportRequestTest extends XmlTestNoCastor<VmwareImportRequest> {
+
+    public VmwareImportRequestTest(VmwareImportRequest sampleObject, String sampleXml) {
+        super(sampleObject, sampleXml, null);
+    }
+
+    @Parameters
+    public static Collection<Object[]> data() throws Exception {
+        VmwareImportRequest request = new VmwareImportRequest();
+        request.getCustomAttributes().add(new VmwareImportRequestAttribute("k", "v"));
+
+        // This causes problems due to the date formatting
+        //Requisition existingRequisition = new Requisition();
+        //existingRequisition.setDate(new Date(0));
+        //request.setExistingRequisition(existingRequisition);
+
+        return Arrays.asList(new Object[][] {
+            {
+                request,
+                "<vmware-requisition-request import-vm-powered-on=\"true\" import-vm-powered-off=\"false\" import-vm-suspended=\"false\" import-host-powered-on=\"true\" import-host-powered-off=\"false\" import-host-standby=\"false\" import-host-unknown=\"false\" persist-ipv4=\"true\" persist-ipv6=\"true\" persist-vms=\"true\" persist-hosts=\"true\" topology-port-groups=\"false\" topology-networks=\"true\" topology-datastores=\"true\">\n" +
+                "   <custom-attribute key=\"k\">v</custom-attribute>\n" +
+                "</vmware-requisition-request>"
+            }
+        });
+    }
+
+}

--- a/integrations/opennms-vmware/src/test/java/org/opennms/netmgt/provision/service/vmware/VmwareRequisitionUrlTest.java
+++ b/integrations/opennms-vmware/src/test/java/org/opennms/netmgt/provision/service/vmware/VmwareRequisitionUrlTest.java
@@ -1,0 +1,99 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2017-2017 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.provision.service.vmware;
+
+import static org.junit.Assert.assertEquals;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.rmi.RemoteException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Map;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+import org.opennms.core.utils.url.GenericURLFactory;
+import org.opennms.netmgt.provision.service.requisition.RequisitionUrlConnection;
+
+@RunWith(Parameterized.class)
+public class VmwareRequisitionUrlTest {
+    private final String vmwareUrl;
+    private final String requisitionUrl;
+
+    @Parameters
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][] {     
+             {
+               "vmware://vcenter.mydomain.org?importHostPoweredOff=true",
+               "requisition://vmware?host=vcenter.mydomain.org&importHostPoweredOff=true"
+             },
+             {
+               "vmware://172.16.123.100/vCenterImport?key=shouldImport;value=1",
+               "requisition://vmware/vCenterImport?host=172.16.123.100&key=shouldImport;value=1"
+             },
+             {
+               "vmware://172.16.123.100/vCenterImport?_shouldImport=1",
+               "requisition://vmware/vCenterImport?host=172.16.123.100&_shouldImport=1"
+             },
+             {
+               "vmware://172.16.123.100/vCenterImport?_shouldImport=1;username=opennms;password=secret",
+               "requisition://vmware/vCenterImport?host=172.16.123.100&_shouldImport=1&username=opennms&password=secret"
+             },
+             {
+               "vmware://[2001:db8:0:8d3:0:8a2e:70:7344]?virtualMachineServices=VM-SERVICE1,VM-SERVICE2",
+               "requisition://vmware?host=[2001:db8:0:8d3:0:8a2e:70:7344]&virtualMachineServices=VM-SERVICE1,VM-SERVICE2"
+             }
+       });
+    }
+
+    @BeforeClass
+    public static void setUpClass() {
+        GenericURLFactory.initialize();
+    }
+
+    public VmwareRequisitionUrlTest(String vmwareUrl, String requisitionUrl) {
+        this.vmwareUrl = vmwareUrl;
+        this.requisitionUrl = requisitionUrl;
+    }
+
+    @Test
+    public void compareGeneratedRequests() throws MalformedURLException, RemoteException {
+        VmwareRequisitionUrlConnection vmwareUrlConnection = new VmwareRequisitionUrlConnection(new URL(vmwareUrl));
+        VmwareImportRequest vmwareUrlImportRequest = vmwareUrlConnection.getImportRequest();
+
+        Map<String, String> requisitionUrlParms = RequisitionUrlConnection.getParameters(new URL(requisitionUrl));
+        VmwareImportRequest requisitionUrlImportRequest = new VmwareImportRequest(requisitionUrlParms);
+
+        assertEquals(vmwareUrlImportRequest, requisitionUrlImportRequest);
+    }
+}

--- a/smoke-test/src/test/java/org/opennms/smoketest/minion/MonitorListTest.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/minion/MonitorListTest.java
@@ -118,7 +118,9 @@ public class MonitorListTest {
             "org.opennms.netmgt.poller.monitors.HostResourceSwRunMonitor",
             "org.opennms.netmgt.poller.monitors.NetScalerGroupHealthMonitor",
             "org.opennms.netmgt.poller.monitors.WebMonitor", 
-            "org.opennms.netmgt.poller.monitors.CiscoIpSlaMonitor")
+            "org.opennms.netmgt.poller.monitors.CiscoIpSlaMonitor",
+            "org.opennms.netmgt.poller.monitors.VmwareMonitor",
+            "org.opennms.netmgt.poller.monitors.VmwareCimMonitor")
             .build();
 
     @ClassRule


### PR DESCRIPTION
JIRA: https://issues.opennms.org/browse/HZN-1021

Here we update the Vmware requisition handler to support the new `requisition://` protocol, while maintaining backward compatibility with the existing `vmware://` protocol style URLs.

With this in place, it should now be possible to provision and monitor Vmware servers using Minion.