### PR TITLE
NMS-9259: Upgrade to Spring 4.1.6

### DIFF
--- a/container/features/src/main/resources/features.xml
+++ b/container/features/src/main/resources/features.xml
@@ -363,7 +363,7 @@
 
     <feature name="spring-security32" description="Spring :: Security" version="${springSecurityVersion}">
       <!-- spring-web is necessary for HTTP remoting -->
-      <feature version="[4.0,4.1)">spring-web</feature>
+      <feature version="[4.1,4.2)">spring-web</feature>
       <feature>commons-codec</feature>
 
       <bundle>wrap:mvn:org.springframework.ldap/spring-ldap-core/1.3.2.RELEASE$Export-Package=org.springframework.ldap*;version="1.3.2"</bundle>
@@ -409,8 +409,8 @@
     
     
     <feature name="opennms-core" description="OpenNMS :: Core" version="${project.version}">
-      <feature version="[4.0,4.1)">spring</feature>
-      <feature version="[4.0,4.1)">spring-orm</feature>
+      <feature version="[4.1,4.2)">spring</feature>
+      <feature version="[4.1,4.2)">spring-orm</feature>
 
       <feature>commons-io</feature>
       <feature>dnsjava</feature>
@@ -478,10 +478,10 @@
     </feature>
 
     <feature name="opennms-model" description="OpenNMS :: Model" version="${project.version}">
-      <feature version="[4.0,4.1)">spring</feature>
-      <feature version="[4.0,4.1)">spring-jdbc</feature>
-      <feature version="[4.0,4.1)">spring-orm</feature>
-      <feature version="[4.0,4.1)">spring-tx</feature>
+      <feature version="[4.1,4.2)">spring</feature>
+      <feature version="[4.1,4.2)">spring-jdbc</feature>
+      <feature version="[4.1,4.2)">spring-orm</feature>
+      <feature version="[4.1,4.2)">spring-tx</feature>
 
       <feature>commons-io</feature>
       <feature>commons-lang</feature>
@@ -499,7 +499,7 @@
     </feature>
 
     <feature name="opennms-collection-api" description="OpenNMS :: Collection :: API" version="${project.version}">
-      <feature version="[4.0,4.1)">spring</feature>
+      <feature version="[4.1,4.2)">spring</feature>
 
       <feature>opennms-config-api</feature>
       <feature>opennms-poller-api</feature>
@@ -639,7 +639,7 @@
     </feature>
 
     <feature name="opennms-events-api" description="OpenNMS :: Events :: API" version="${project.version}">
-      <feature version="[4.0,4.1)">spring</feature>
+      <feature version="[4.1,4.2)">spring</feature>
 
       <feature>commons-lang</feature>
       <feature>jaxb</feature>
@@ -732,7 +732,7 @@
     </feature>
 
     <feature name="opennms-poller-api" description="OpenNMS :: Poller :: API" version="${project.version}">
-      <feature version="[4.0,4.1)">spring</feature>
+      <feature version="[4.1,4.2)">spring</feature>
 
       <feature>hibernate36</feature>
 
@@ -741,7 +741,7 @@
     </feature>
 
     <feature name="opennms-measurements-api" description="OpenNMS :: Measurements :: API" version="${project.version}">
-      <feature version="[4.0,4.1)">spring</feature>
+      <feature version="[4.1,4.2)">spring</feature>
 
       <feature>commons-lang</feature>
       <feature version="${guavaVersion}">guava</feature>
@@ -795,7 +795,7 @@
     </feature>
 
     <feature name="opennms-rrd-api" description="OpenNMS :: RRD :: API" version="${project.version}">
-      <feature version="[4.0,4.1)">spring</feature>
+      <feature version="[4.1,4.2)">spring</feature>
 
       <feature>opennms-core</feature>
 
@@ -803,7 +803,7 @@
     </feature>
 
     <feature name="opennms-rrd-jrobin" description="OpenNMS :: RRD :: JRobin" version="${project.version}">
-      <feature version="[4.0,4.1)">spring</feature>
+      <feature version="[4.1,4.2)">spring</feature>
 
       <feature>jrobin</feature>
       <feature>opennms-rrd-api</feature>
@@ -836,7 +836,7 @@
     </feature>
 
     <feature name="opennms-syslogd" description="OpenNMS :: Syslogd" version="${project.version}">
-      <feature version="[4.0,4.1)">spring</feature>
+      <feature version="[4.1,4.2)">spring</feature>
       <feature>activemq-camel</feature>
       <feature>camel-core</feature>
       <feature>camel-http</feature>
@@ -872,7 +872,7 @@
 
     <!-- TrapD feature -->
     <feature name="opennms-trapd" description="OpenNMS :: Trapd" version="${project.version}">
-      <feature version="[4.0,4.1)">spring</feature>
+      <feature version="[4.1,4.2)">spring</feature>
       <feature>camel-core</feature>
       <feature>camel-http</feature>
       <feature>camel-netty</feature>

--- a/core/daemon/src/main/resources/META-INF/opennms/applicationContext-activemq.xml
+++ b/core/daemon/src/main/resources/META-INF/opennms/applicationContext-activemq.xml
@@ -3,8 +3,8 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xmlns:context="http://www.springframework.org/schema/context"
   xsi:schemaLocation="
-  http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
-  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
+  http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
 ">
 
   <context:annotation-config />

--- a/core/daemon/src/main/resources/META-INF/opennms/applicationContext-daemon.xml
+++ b/core/daemon/src/main/resources/META-INF/opennms/applicationContext-daemon.xml
@@ -8,11 +8,11 @@
   xmlns:jdbc="http://www.springframework.org/schema/jdbc" 
   xmlns:onmsgi="http://xmlns.opennms.org/xsd/spring/onms-osgi"
   xsi:schemaLocation="
-  http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
-  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
-  http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
-  http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.0.xsd
-  http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-4.0.xsd
+  http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
+  http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+  http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.1.xsd
+  http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-4.1.xsd
   http://xmlns.opennms.org/xsd/spring/onms-osgi http://xmlns.opennms.org/xsd/spring/onms-osgi.xsd
 ">
 

--- a/core/daemon/src/main/resources/META-INF/opennms/applicationContext-pinger.xml
+++ b/core/daemon/src/main/resources/META-INF/opennms/applicationContext-pinger.xml
@@ -8,11 +8,11 @@
   xmlns:jdbc="http://www.springframework.org/schema/jdbc" 
   xmlns:onmsgi="http://xmlns.opennms.org/xsd/spring/onms-osgi"
   xsi:schemaLocation="
-  http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
-  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
-  http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
-  http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.0.xsd
-  http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-4.0.xsd
+  http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
+  http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+  http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.1.xsd
+  http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-4.1.xsd
   http://xmlns.opennms.org/xsd/spring/onms-osgi http://xmlns.opennms.org/xsd/spring/onms-osgi.xsd
 ">
 

--- a/core/daemon/src/main/resources/beanRefContext.xml
+++ b/core/daemon/src/main/resources/beanRefContext.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans-4.0.xsd" default-lazy-init="true">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd" default-lazy-init="true">
 
   <bean id="daemonContext" class="org.springframework.context.support.ClassPathXmlApplicationContext">
     <constructor-arg>

--- a/core/ipc/rpc/camel-impl/src/main/resources/META-INF/opennms/applicationContext-rpc-client-camel.xml
+++ b/core/ipc/rpc/camel-impl/src/main/resources/META-INF/opennms/applicationContext-rpc-client-camel.xml
@@ -6,10 +6,10 @@
   xmlns:util="http://www.springframework.org/schema/util"
   xmlns:onmsgi="http://xmlns.opennms.org/xsd/spring/onms-osgi"
   xsi:schemaLocation="
-  http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
-  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
-  http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
-  http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.0.xsd
+  http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
+  http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+  http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.1.xsd
   http://xmlns.opennms.org/xsd/spring/onms-osgi http://xmlns.opennms.org/xsd/spring/onms-osgi.xsd
   http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd
 ">

--- a/core/ipc/rpc/camel-impl/src/main/resources/META-INF/opennms/component-dao.xml
+++ b/core/ipc/rpc/camel-impl/src/main/resources/META-INF/opennms/component-dao.xml
@@ -4,7 +4,7 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="
        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
        ">
 
     <import resource="classpath:/META-INF/opennms/applicationContext-rpc-client-camel.xml" />

--- a/core/ipc/rpc/camel-impl/src/test/resources/META-INF/opennms/applicationContext-rpc-echo.xml
+++ b/core/ipc/rpc/camel-impl/src/test/resources/META-INF/opennms/applicationContext-rpc-echo.xml
@@ -4,8 +4,8 @@
        xmlns:tx="http://www.springframework.org/schema/tx" 
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
-       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd">
+       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
     <context:component-scan base-package="org.opennms.core.rpc.echo"/>
 </beans>

--- a/core/ipc/rpc/mock-impl/src/main/resources/META-INF/opennms/applicationContext-rpc-client-mock.xml
+++ b/core/ipc/rpc/mock-impl/src/main/resources/META-INF/opennms/applicationContext-rpc-client-mock.xml
@@ -4,7 +4,7 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="
        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
        ">
 
   <context:annotation-config />

--- a/core/ipc/rpc/mock-impl/src/main/resources/META-INF/opennms/component-dao.xml
+++ b/core/ipc/rpc/mock-impl/src/main/resources/META-INF/opennms/component-dao.xml
@@ -4,7 +4,7 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="
        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
        ">
 
     <import resource="classpath:/META-INF/opennms/applicationContext-rpc-client-mock.xml" />

--- a/core/ipc/sink/camel-impl/src/main/resources/META-INF/opennms/applicationContext-ipc-sink-server-camel.xml
+++ b/core/ipc/sink/camel-impl/src/main/resources/META-INF/opennms/applicationContext-ipc-sink-server-camel.xml
@@ -6,10 +6,10 @@
   xmlns:util="http://www.springframework.org/schema/util"
   xmlns:onmsgi="http://xmlns.opennms.org/xsd/spring/onms-osgi"
   xsi:schemaLocation="
-  http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
-  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
-  http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
-  http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.0.xsd
+  http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
+  http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+  http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.1.xsd
   http://xmlns.opennms.org/xsd/spring/onms-osgi http://xmlns.opennms.org/xsd/spring/onms-osgi.xsd
   http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd
 ">

--- a/core/ipc/sink/camel-impl/src/main/resources/META-INF/opennms/component-dao.xml
+++ b/core/ipc/sink/camel-impl/src/main/resources/META-INF/opennms/component-dao.xml
@@ -4,7 +4,7 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="
        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
        ">
 
     <!-- Conditionally load the Camel Sink -->

--- a/core/ipc/sink/camel-impl/src/test/resources/META-INF/opennms/applicationContext-rpc-echo.xml
+++ b/core/ipc/sink/camel-impl/src/test/resources/META-INF/opennms/applicationContext-rpc-echo.xml
@@ -4,8 +4,8 @@
        xmlns:tx="http://www.springframework.org/schema/tx" 
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
-       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd">
+       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
     <context:component-scan base-package="org.opennms.core.rpc.echo"/>
 </beans>

--- a/core/ipc/sink/kafka-impl/src/main/resources/META-INF/opennms/applicationContext-ipc-sink-server-kafka.xml
+++ b/core/ipc/sink/kafka-impl/src/main/resources/META-INF/opennms/applicationContext-ipc-sink-server-kafka.xml
@@ -5,9 +5,9 @@
   xmlns:util="http://www.springframework.org/schema/util"
   xmlns:onmsgi="http://xmlns.opennms.org/xsd/spring/onms-osgi"
   xsi:schemaLocation="
-  http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
-  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
-  http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.0.xsd
+  http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
+  http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.1.xsd
   http://xmlns.opennms.org/xsd/spring/onms-osgi http://xmlns.opennms.org/xsd/spring/onms-osgi.xsd
 ">
 

--- a/core/ipc/sink/kafka-impl/src/main/resources/META-INF/opennms/component-dao.xml
+++ b/core/ipc/sink/kafka-impl/src/main/resources/META-INF/opennms/component-dao.xml
@@ -4,7 +4,7 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="
        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
        ">
 
     <!-- Conditionally load the Kafka Sink -->

--- a/core/ipc/sink/kafka-impl/src/test/resources/META-INF/opennms/applicationContext-rpc-echo.xml
+++ b/core/ipc/sink/kafka-impl/src/test/resources/META-INF/opennms/applicationContext-rpc-echo.xml
@@ -4,8 +4,8 @@
        xmlns:tx="http://www.springframework.org/schema/tx" 
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
-       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd">
+       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
     <context:component-scan base-package="org.opennms.core.rpc.echo"/>
 </beans>

--- a/core/ipc/sink/mock-impl/src/main/resources/META-INF/opennms/mockMessageDispatcherFactory.xml
+++ b/core/ipc/sink/mock-impl/src/main/resources/META-INF/opennms/mockMessageDispatcherFactory.xml
@@ -4,7 +4,7 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="
        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
        ">
 
   <context:annotation-config />

--- a/core/ipc/sink/mock-impl/src/main/resources/META-INF/opennms/mockSinkConsumerManager.xml
+++ b/core/ipc/sink/mock-impl/src/main/resources/META-INF/opennms/mockSinkConsumerManager.xml
@@ -4,7 +4,7 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="
        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
        ">
 
   <context:annotation-config />

--- a/core/jmx/api/src/main/resources/META-INF/opennms/component-dao.xml
+++ b/core/jmx/api/src/main/resources/META-INF/opennms/component-dao.xml
@@ -4,8 +4,8 @@
        xmlns:tx="http://www.springframework.org/schema/tx"
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
-       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd"
+       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd"
         >
 
     <context:annotation-config />

--- a/core/snmp/api/src/main/resources/META-INF/opennms/component-dao.xml
+++ b/core/snmp/api/src/main/resources/META-INF/opennms/component-dao.xml
@@ -5,8 +5,8 @@
        xmlns:util="http://www.springframework.org/schema/util"
        xmlns:onmsgi="http://xmlns.opennms.org/xsd/spring/onms-osgi"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
-       http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.0.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
+       http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.1.xsd
        http://xmlns.opennms.org/xsd/spring/onms-osgi http://xmlns.opennms.org/xsd/spring/onms-osgi.xsd
        ">
        

--- a/core/snmp/integration-tests/src/test/resources/emptyContext.xml
+++ b/core/snmp/integration-tests/src/test/resources/emptyContext.xml
@@ -3,4 +3,4 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="
            http://www.springframework.org/schema/beans
-           http://www.springframework.org/schema/beans/spring-beans-4.0.xsd"/>
+           http://www.springframework.org/schema/beans/spring-beans-4.1.xsd"/>

--- a/core/snmp/proxy-rpc-impl/src/main/resources/META-INF/opennms/applicationContext-rpc-snmp.xml
+++ b/core/snmp/proxy-rpc-impl/src/main/resources/META-INF/opennms/applicationContext-rpc-snmp.xml
@@ -5,8 +5,8 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:onmsgi="http://xmlns.opennms.org/xsd/spring/onms-osgi"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
-       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
+       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
        http://xmlns.opennms.org/xsd/spring/onms-osgi http://xmlns.opennms.org/xsd/spring/onms-osgi.xsd">
 
 	<context:annotation-config />

--- a/core/snmp/proxy-rpc-impl/src/main/resources/META-INF/opennms/component-dao.xml
+++ b/core/snmp/proxy-rpc-impl/src/main/resources/META-INF/opennms/component-dao.xml
@@ -5,8 +5,8 @@
        xmlns:util="http://www.springframework.org/schema/util"
        xmlns:onmsgi="http://xmlns.opennms.org/xsd/spring/onms-osgi"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
-       http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.0.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
+       http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.1.xsd
        http://xmlns.opennms.org/xsd/spring/onms-osgi http://xmlns.opennms.org/xsd/spring/onms-osgi.xsd
        ">
 

--- a/core/soa/src/main/resources/META-INF/opennms/applicationContext-soa-osgi.xml
+++ b/core/soa/src/main/resources/META-INF/opennms/applicationContext-soa-osgi.xml
@@ -3,7 +3,7 @@
   xmlns:osgi="http://www.springframework.org/schema/osgi"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="
-  http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
+  http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
   http://www.springframework.org/schema/osgi http://www.springframework.org/schema/osgi/spring-osgi.xsd
 ">
 

--- a/core/soa/src/main/resources/META-INF/opennms/onms-osgi.xsd
+++ b/core/soa/src/main/resources/META-INF/opennms/onms-osgi.xsd
@@ -8,7 +8,7 @@
     attributeFormDefault="unqualified"
     
     xsi:schemaLocation="
-        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
+        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
     ">
 
    <xsd:import namespace="http://www.springframework.org/schema/beans"/>

--- a/core/soa/src/main/resources/beanRefContext.xml
+++ b/core/soa/src/main/resources/beanRefContext.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
    xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans-4.0.xsd">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
   <bean id="soaContext" class="org.springframework.context.support.ClassPathXmlApplicationContext" lazy-init="true">
      <constructor-arg>

--- a/core/soa/src/test/resources/org/opennms/core/soa/support/ReferenceFactoryBeanTest-context.xml
+++ b/core/soa/src/test/resources/org/opennms/core/soa/support/ReferenceFactoryBeanTest-context.xml
@@ -4,7 +4,7 @@
 	xmlns:util="http://www.springframework.org/schema/util"
 	xsi:schemaLocation="
 	   http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	   http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.0.xsd
+	   http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.1.xsd
 	">
     <!-- in order to make the tests independent I create a new registry for each test context
     <util:constant id="serviceRegistry" static-field="org.opennms.core.soa.support.DefaultServiceRegistry.INSTANCE" />

--- a/core/soa/src/test/resources/org/opennms/core/soa/support/ServiceFactoryBeanTest-context.xml
+++ b/core/soa/src/test/resources/org/opennms/core/soa/support/ServiceFactoryBeanTest-context.xml
@@ -4,7 +4,7 @@
     xmlns:util="http://www.springframework.org/schema/util"
 	xsi:schemaLocation="
 	http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-    http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.0.xsd
+    http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.1.xsd
 	">
 	
     <!-- in order to make the tests independent I create a new registry for each test context

--- a/core/soa/src/test/resources/org/opennms/core/soa/support/ServiceReferenceIntegrationTest-context.xml
+++ b/core/soa/src/test/resources/org/opennms/core/soa/support/ServiceReferenceIntegrationTest-context.xml
@@ -4,7 +4,7 @@
 	xmlns:util="http://www.springframework.org/schema/util"
 	xsi:schemaLocation=
 	"http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.0.xsd">
+	http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.1.xsd">
 	
     <!-- in order to make the tests independent I create a new registry for each test context
     <util:constant id="serviceRegistry" static-field="org.opennms.core.soa.support.DefaultServiceRegistry.INSTANCE" />

--- a/core/test-api/camel/src/main/resources/META-INF/opennms/applicationContext-queuingservice-mq-vm.xml
+++ b/core/test-api/camel/src/main/resources/META-INF/opennms/applicationContext-queuingservice-mq-vm.xml
@@ -6,10 +6,10 @@
   xmlns:util="http://www.springframework.org/schema/util"
   xmlns:onmsgi="http://xmlns.opennms.org/xsd/spring/onms-osgi"
   xsi:schemaLocation="
-  http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
-  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
-  http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
-  http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.0.xsd
+  http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
+  http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+  http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.1.xsd
   http://xmlns.opennms.org/xsd/spring/onms-osgi http://xmlns.opennms.org/xsd/spring/onms-osgi.xsd
   http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd
 ">

--- a/core/test-api/db/src/main/resources/META-INF/opennms/applicationContext-datasource.xml
+++ b/core/test-api/db/src/main/resources/META-INF/opennms/applicationContext-datasource.xml
@@ -8,11 +8,11 @@
   xmlns:jdbc="http://www.springframework.org/schema/jdbc" 
   xmlns:onmsgi="http://xmlns.opennms.org/xsd/spring/onms-osgi"
   xsi:schemaLocation="
-  http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
-  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
-  http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
-  http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.0.xsd
-  http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-4.0.xsd
+  http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
+  http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+  http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.1.xsd
+  http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-4.1.xsd
   http://xmlns.opennms.org/xsd/spring/onms-osgi http://xmlns.opennms.org/xsd/spring/onms-osgi.xsd
 ">
 

--- a/core/test-api/db/src/main/resources/META-INF/opennms/applicationContext-testDao.xml
+++ b/core/test-api/db/src/main/resources/META-INF/opennms/applicationContext-testDao.xml
@@ -5,8 +5,8 @@
        xmlns:util="http://www.springframework.org/schema/util"
        xmlns:onmsgi="http://xmlns.opennms.org/xsd/spring/onms-osgi"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
-       http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.0.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
+       http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.1.xsd
        http://xmlns.opennms.org/xsd/spring/onms-osgi http://xmlns.opennms.org/xsd/spring/onms-osgi.xsd
        ">
 

--- a/core/test-api/db/src/test/resources/migratorTest.xml
+++ b/core/test-api/db/src/test/resources/migratorTest.xml
@@ -3,9 +3,9 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:tx="http://www.springframework.org/schema/tx" 
        xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
-       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
-       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd"
        >
 
 	<bean id="dataSource" class="org.opennms.core.db.DataSourceFactoryBean" />

--- a/core/test-api/lib/src/main/resources/META-INF/opennms/emptyContext.xml
+++ b/core/test-api/lib/src/main/resources/META-INF/opennms/emptyContext.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans-4.0.xsd">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 </beans>

--- a/core/test-api/services/src/main/resources/META-INF/opennms/applicationContext-minimal-conf.xml
+++ b/core/test-api/services/src/main/resources/META-INF/opennms/applicationContext-minimal-conf.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
     <bean id="eventConfResourceLocation" class="java.lang.String">
       <constructor-arg value="classpath:/etc/eventconf.xml" />

--- a/core/test-api/services/src/main/resources/META-INF/opennms/applicationContext-mock-usergroup.xml
+++ b/core/test-api/services/src/main/resources/META-INF/opennms/applicationContext-mock-usergroup.xml
@@ -4,7 +4,7 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:context="http://www.springframework.org/schema/context"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
+		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
 	">
 
 	<context:annotation-config />

--- a/core/test-api/services/src/main/resources/META-INF/opennms/mockEventIpcManager.xml
+++ b/core/test-api/services/src/main/resources/META-INF/opennms/mockEventIpcManager.xml
@@ -8,11 +8,11 @@
   xmlns:jdbc="http://www.springframework.org/schema/jdbc" 
   xmlns:onmsgi="http://xmlns.opennms.org/xsd/spring/onms-osgi"
   xsi:schemaLocation="
-  http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
-  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
-  http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
-  http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.0.xsd
-  http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-4.0.xsd
+  http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
+  http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+  http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.1.xsd
+  http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-4.1.xsd
   http://xmlns.opennms.org/xsd/spring/onms-osgi http://xmlns.opennms.org/xsd/spring/onms-osgi.xsd
 ">
 

--- a/core/test-api/services/src/main/resources/META-INF/opennms/smallEventConfDao.xml
+++ b/core/test-api/services/src/main/resources/META-INF/opennms/smallEventConfDao.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans-4.0.xsd">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
         
         
   <bean id="eventConfResourceLocation" class="java.lang.String">

--- a/core/test-api/snmp/src/main/resources/META-INF/opennms/applicationContext-proxy-snmp.xml
+++ b/core/test-api/snmp/src/main/resources/META-INF/opennms/applicationContext-proxy-snmp.xml
@@ -3,9 +3,9 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans 
-           http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
+           http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
            http://www.springframework.org/schema/context
-           http://www.springframework.org/schema/context/spring-context-4.0.xsd">
+           http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
 	<context:annotation-config/>
 

--- a/features/bsm/daemon/src/main/resources/META-INF/opennms/applicationContext-bsmd.xml
+++ b/features/bsm/daemon/src/main/resources/META-INF/opennms/applicationContext-bsmd.xml
@@ -5,8 +5,8 @@
        xmlns:tx="http://www.springframework.org/schema/tx"
        xmlns:onmsgi="http://xmlns.opennms.org/xsd/spring/onms-osgi"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
-       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
+       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
        http://xmlns.opennms.org/xsd/spring/onms-osgi http://xmlns.opennms.org/xsd/spring/onms-osgi.xsd">
 
   <context:annotation-config />

--- a/features/bsm/daemon/src/main/resources/beanRefContext.xml
+++ b/features/bsm/daemon/src/main/resources/beanRefContext.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans-4.0.xsd" default-lazy-init="true">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd" default-lazy-init="true">
 
    <bean id="bsmdContext" class="org.springframework.context.support.ClassPathXmlApplicationContext">
      <constructor-arg>

--- a/features/bsm/persistence/impl/src/main/resources/META-INF/opennms/component-dao.xml
+++ b/features/bsm/persistence/impl/src/main/resources/META-INF/opennms/component-dao.xml
@@ -6,8 +6,8 @@
 	xmlns:onmsgi="http://xmlns.opennms.org/xsd/spring/onms-osgi"
 	xsi:schemaLocation="
 		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
-		http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
+		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
+		http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
 		http://xmlns.opennms.org/xsd/spring/onms-osgi http://xmlns.opennms.org/xsd/spring/onms-osgi.xsd
 	">
 

--- a/features/bsm/service/impl/src/main/resources/META-INF/opennms/component-dao.xml
+++ b/features/bsm/service/impl/src/main/resources/META-INF/opennms/component-dao.xml
@@ -5,9 +5,9 @@
        xmlns:onmsgi="http://xmlns.opennms.org/xsd/spring/onms-osgi"
        xsi:schemaLocation="
            http://www.springframework.org/schema/beans
-           http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
+           http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
            http://www.springframework.org/schema/context
-           http://www.springframework.org/schema/context/spring-context-4.0.xsd
+           http://www.springframework.org/schema/context/spring-context-4.1.xsd
            http://xmlns.opennms.org/xsd/spring/onms-osgi
            http://xmlns.opennms.org/xsd/spring/onms-osgi.xsd">
 

--- a/features/bsm/test-util/src/main/resources/META-INF/opennms/component-dao.xml
+++ b/features/bsm/test-util/src/main/resources/META-INF/opennms/component-dao.xml
@@ -5,10 +5,10 @@
        xmlns:util="http://www.springframework.org/schema/util"
        xmlns:cache="http://www.springframework.org/schema/cache"
        xmlns:onmsgi="http://xmlns.opennms.org/xsd/spring/onms-osgi"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
-       http://www.springframework.org/schema/cache http://www.springframework.org/schema/cache/spring-cache-4.0.xsd
-       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
-       http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.0.xsd
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+       http://www.springframework.org/schema/cache http://www.springframework.org/schema/cache/spring-cache-4.1.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
+       http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.1.xsd
        http://xmlns.opennms.org/xsd/spring/onms-osgi http://xmlns.opennms.org/xsd/spring/onms-osgi.xsd
        ">
 

--- a/features/discovery/src/main/resources/META-INF/opennms/applicationContext-discovery.xml
+++ b/features/discovery/src/main/resources/META-INF/opennms/applicationContext-discovery.xml
@@ -6,10 +6,10 @@
   xmlns:util="http://www.springframework.org/schema/util"
   xmlns:onmsgi="http://xmlns.opennms.org/xsd/spring/onms-osgi"
   xsi:schemaLocation="
-  http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
-  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
-  http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
-  http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.0.xsd
+  http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
+  http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+  http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.1.xsd
   http://xmlns.opennms.org/xsd/spring/onms-osgi http://xmlns.opennms.org/xsd/spring/onms-osgi.xsd
   http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd
 ">

--- a/features/discovery/src/main/resources/beanRefContext.xml
+++ b/features/discovery/src/main/resources/beanRefContext.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans-4.0.xsd" default-lazy-init="true">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd" default-lazy-init="true">
 
    <bean id="discoveryContext" class="org.springframework.context.support.ClassPathXmlApplicationContext">
      <constructor-arg>

--- a/features/discovery/src/test/resources/applicationContext-testPinger.xml
+++ b/features/discovery/src/test/resources/applicationContext-testPinger.xml
@@ -8,11 +8,11 @@
   xmlns:jdbc="http://www.springframework.org/schema/jdbc" 
   xmlns:onmsgi="http://xmlns.opennms.org/xsd/spring/onms-osgi"
   xsi:schemaLocation="
-  http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
-  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
-  http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
-  http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.0.xsd
-  http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-4.0.xsd
+  http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
+  http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+  http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.1.xsd
+  http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-4.1.xsd
   http://xmlns.opennms.org/xsd/spring/onms-osgi http://xmlns.opennms.org/xsd/spring/onms-osgi.xsd
 ">
 

--- a/features/events/daemon/src/main/resources/META-INF/opennms/applicationContext-daoEvents.xml
+++ b/features/events/daemon/src/main/resources/META-INF/opennms/applicationContext-daoEvents.xml
@@ -6,11 +6,11 @@
        xmlns:tx="http://www.springframework.org/schema/tx"
        xmlns:util="http://www.springframework.org/schema/util"
        xmlns:onmsgi="http://xmlns.opennms.org/xsd/spring/onms-osgi"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
-       http://www.springframework.org/schema/cache http://www.springframework.org/schema/cache/spring-cache-4.0.xsd
-       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
-       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
-       http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.0.xsd
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+       http://www.springframework.org/schema/cache http://www.springframework.org/schema/cache/spring-cache-4.1.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
+       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+       http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.1.xsd
        http://xmlns.opennms.org/xsd/spring/onms-osgi http://xmlns.opennms.org/xsd/spring/onms-osgi.xsd
        ">
 

--- a/features/events/daemon/src/main/resources/META-INF/opennms/applicationContext-eventDaemon-osgi.xml
+++ b/features/events/daemon/src/main/resources/META-INF/opennms/applicationContext-eventDaemon-osgi.xml
@@ -3,7 +3,7 @@
   xmlns:osgi="http://www.springframework.org/schema/osgi"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="
-  http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
+  http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
   http://www.springframework.org/schema/osgi http://www.springframework.org/schema/osgi/spring-osgi-1.2.xsd
 ">
 

--- a/features/events/daemon/src/main/resources/META-INF/opennms/applicationContext-eventDaemon-remote.xml
+++ b/features/events/daemon/src/main/resources/META-INF/opennms/applicationContext-eventDaemon-remote.xml
@@ -4,8 +4,8 @@
   xmlns:osgi="http://www.springframework.org/schema/osgi"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="
-  http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
-  http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.0.xsd
+  http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+  http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.1.xsd
   http://www.springframework.org/schema/osgi http://www.springframework.org/schema/osgi/spring-osgi.xsd
 ">
 

--- a/features/events/daemon/src/main/resources/META-INF/opennms/applicationContext-eventDaemon.xml
+++ b/features/events/daemon/src/main/resources/META-INF/opennms/applicationContext-eventDaemon.xml
@@ -8,11 +8,11 @@
   xmlns:jdbc="http://www.springframework.org/schema/jdbc" 
   xmlns:onmsgi="http://xmlns.opennms.org/xsd/spring/onms-osgi"
   xsi:schemaLocation="
-  http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
-  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
-  http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
-  http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.0.xsd
-  http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-4.0.xsd
+  http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
+  http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+  http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.1.xsd
+  http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-4.1.xsd
   http://xmlns.opennms.org/xsd/spring/onms-osgi http://xmlns.opennms.org/xsd/spring/onms-osgi.xsd
 ">
 

--- a/features/events/daemon/src/main/resources/META-INF/opennms/applicationContext-eventUtil.xml
+++ b/features/events/daemon/src/main/resources/META-INF/opennms/applicationContext-eventUtil.xml
@@ -3,9 +3,9 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:tx="http://www.springframework.org/schema/tx"
        xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
-  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
-  http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
+  http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd">
 
     <context:annotation-config />
     <tx:annotation-driven/>

--- a/features/events/daemon/src/main/resources/META-INF/opennms/component-dao.xml
+++ b/features/events/daemon/src/main/resources/META-INF/opennms/component-dao.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
   <import resource="classpath:/META-INF/opennms/applicationContext-eventUtil.xml" />
 

--- a/features/events/daemon/src/main/resources/beanRefContext.xml
+++ b/features/events/daemon/src/main/resources/beanRefContext.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans-4.0.xsd" default-lazy-init="true">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd" default-lazy-init="true">
 
     <bean id="eventDaemonContext" class="org.springframework.context.support.ClassPathXmlApplicationContext">
      <constructor-arg>

--- a/features/events/syslog/src/main/resources/META-INF/opennms/applicationContext-syslogDaemon.xml
+++ b/features/events/syslog/src/main/resources/META-INF/opennms/applicationContext-syslogDaemon.xml
@@ -6,10 +6,10 @@
   xmlns:util="http://www.springframework.org/schema/util"
   xmlns:onmsgi="http://xmlns.opennms.org/xsd/spring/onms-osgi"
   xsi:schemaLocation="
-  http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
-  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
-  http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
-  http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.0.xsd
+  http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
+  http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+  http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.1.xsd
   http://xmlns.opennms.org/xsd/spring/onms-osgi http://xmlns.opennms.org/xsd/spring/onms-osgi.xsd
 ">
 

--- a/features/events/syslog/src/main/resources/beanRefContext.xml
+++ b/features/events/syslog/src/main/resources/beanRefContext.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans-4.0.xsd" default-lazy-init="true">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd" default-lazy-init="true">
 
     <bean id="syslogDaemonContext" class="org.springframework.context.support.ClassPathXmlApplicationContext">
      <constructor-arg>

--- a/features/events/syslog/src/test/resources/applicationContext-syslogImplementations.xml
+++ b/features/events/syslog/src/test/resources/applicationContext-syslogImplementations.xml
@@ -6,10 +6,10 @@
   xmlns:util="http://www.springframework.org/schema/util"
   xmlns:onmsgi="http://xmlns.opennms.org/xsd/spring/onms-osgi"
   xsi:schemaLocation="
-  http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
-  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
-  http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
-  http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.0.xsd
+  http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
+  http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+  http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.1.xsd
   http://xmlns.opennms.org/xsd/spring/onms-osgi http://xmlns.opennms.org/xsd/spring/onms-osgi.xsd
 ">
 

--- a/features/events/syslog/src/test/resources/syslogdTest.xml
+++ b/features/events/syslog/src/test/resources/syslogdTest.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans" 
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:tx="http://www.springframework.org/schema/tx" 
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
-       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd">
 
   <bean id="eventConfResourceLocation" class="java.lang.String">
     <constructor-arg value="classpath:/etc/eventconf.xml" />

--- a/features/events/traps/src/main/resources/META-INF/opennms/applicationContext-trapDaemon.xml
+++ b/features/events/traps/src/main/resources/META-INF/opennms/applicationContext-trapDaemon.xml
@@ -8,11 +8,11 @@
   xmlns:jdbc="http://www.springframework.org/schema/jdbc" 
   xmlns:onmsgi="http://xmlns.opennms.org/xsd/spring/onms-osgi"
   xsi:schemaLocation="
-  http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
-  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
-  http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
-  http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.0.xsd
-  http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-4.0.xsd
+  http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
+  http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+  http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.1.xsd
+  http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-4.1.xsd
   http://xmlns.opennms.org/xsd/spring/onms-osgi http://xmlns.opennms.org/xsd/spring/onms-osgi.xsd
 ">
 

--- a/features/events/traps/src/main/resources/beanRefContext.xml
+++ b/features/events/traps/src/main/resources/beanRefContext.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans-4.0.xsd" default-lazy-init="true">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd" default-lazy-init="true">
 
     <bean id="trapDaemonContext" class="org.springframework.context.support.ClassPathXmlApplicationContext">
      <constructor-arg>

--- a/features/events/traps/src/test/resources/org/opennms/netmgt/trapd/applicationContext-trapDaemonTest.xml
+++ b/features/events/traps/src/test/resources/org/opennms/netmgt/trapd/applicationContext-trapDaemonTest.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans" 
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:tx="http://www.springframework.org/schema/tx" 
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
-       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd">
 
   <bean id="eventConfDao" class="org.opennms.netmgt.config.DefaultEventConfDao" init-method="reload">
     <property name="configResource"><value>classpath:/org/opennms/netmgt/trapd/eventconf.xml</value></property>

--- a/features/jdbc-collector/src/main/resources/META-INF/opennms/component-dao.xml
+++ b/features/jdbc-collector/src/main/resources/META-INF/opennms/component-dao.xml
@@ -4,8 +4,8 @@
        xmlns:tx="http://www.springframework.org/schema/tx" 
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
-       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd"
+       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd"
        >
 
   <context:annotation-config/>

--- a/features/juniper-tca-collector/src/test/resources/META-INF/opennms/junit-component-dao.xml
+++ b/features/juniper-tca-collector/src/test/resources/META-INF/opennms/junit-component-dao.xml
@@ -4,8 +4,8 @@
        xmlns:tx="http://www.springframework.org/schema/tx" 
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
-       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd"
+       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd"
        >
 
   <bean class="org.easymock.EasyMock" factory-method="createNiceMock" primary="true" id="tcaDataCollectionConfigDao">

--- a/features/measurements/api/src/main/resources/META-INF/opennms/component-measurement.xml
+++ b/features/measurements/api/src/main/resources/META-INF/opennms/component-measurement.xml
@@ -4,9 +4,9 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="
            http://www.springframework.org/schema/beans
-           http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
+           http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
            http://www.springframework.org/schema/context
-           http://www.springframework.org/schema/context/spring-context-4.0.xsd">
+           http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
   <context:annotation-config />
   <context:component-scan base-package="org.opennms.netmgt.measurements"/>

--- a/features/measurements/api/src/main/resources/META-INF/opennms/component-service.xml
+++ b/features/measurements/api/src/main/resources/META-INF/opennms/component-service.xml
@@ -5,9 +5,9 @@
        xmlns:onmsgi="http://xmlns.opennms.org/xsd/spring/onms-osgi"
        xsi:schemaLocation="
            http://www.springframework.org/schema/beans
-           http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
+           http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
            http://www.springframework.org/schema/context
-           http://www.springframework.org/schema/context/spring-context-4.0.xsd
+           http://www.springframework.org/schema/context/spring-context-4.1.xsd
            http://xmlns.opennms.org/xsd/spring/onms-osgi
            http://xmlns.opennms.org/xsd/spring/onms-osgi.xsd">
 

--- a/features/measurements/impl/src/main/resources/META-INF/opennms/component-measurement.xml
+++ b/features/measurements/impl/src/main/resources/META-INF/opennms/component-measurement.xml
@@ -5,9 +5,9 @@
        xmlns:onmsgi="http://xmlns.opennms.org/xsd/spring/onms-osgi"
        xsi:schemaLocation="
            http://www.springframework.org/schema/beans
-           http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
+           http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
            http://www.springframework.org/schema/context
-           http://www.springframework.org/schema/context/spring-context-4.0.xsd
+           http://www.springframework.org/schema/context/spring-context-4.1.xsd
            http://xmlns.opennms.org/xsd/spring/onms-osgi
            http://xmlns.opennms.org/xsd/spring/onms-osgi.xsd">
 

--- a/features/measurements/rest/src/test/resources/META-INF/opennms/applicationContext-jersey.xml
+++ b/features/measurements/rest/src/test/resources/META-INF/opennms/applicationContext-jersey.xml
@@ -3,9 +3,9 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:tx="http://www.springframework.org/schema/tx"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
-                http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
-                http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+                http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
+                http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd">
 
     <tx:annotation-driven />
 

--- a/features/measurements/rest/src/test/resources/META-INF/opennms/applicationContext-measurements-rest-test.xml
+++ b/features/measurements/rest/src/test/resources/META-INF/opennms/applicationContext-measurements-rest-test.xml
@@ -5,11 +5,11 @@
        xmlns:tx="http://www.springframework.org/schema/tx"
        xsi:schemaLocation="
            http://www.springframework.org/schema/beans
-           http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
+           http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
            http://www.springframework.org/schema/context
-           http://www.springframework.org/schema/context/spring-context-4.0.xsd
+           http://www.springframework.org/schema/context/spring-context-4.1.xsd
            http://www.springframework.org/schema/tx
-           http://www.springframework.org/schema/tx/spring-tx-4.0.xsd">
+           http://www.springframework.org/schema/tx/spring-tx-4.1.xsd">
 
   <context:annotation-config />
   <tx:annotation-driven />

--- a/features/minion/heartbeat/consumer/src/main/resources/META-INF/opennms/component-dao.xml
+++ b/features/minion/heartbeat/consumer/src/main/resources/META-INF/opennms/component-dao.xml
@@ -5,11 +5,11 @@
     xmlns:tx="http://www.springframework.org/schema/tx"
     xsi:schemaLocation="
            http://www.springframework.org/schema/beans
-           http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
+           http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
            http://www.springframework.org/schema/context
-           http://www.springframework.org/schema/context/spring-context-4.0.xsd
+           http://www.springframework.org/schema/context/spring-context-4.1.xsd
            http://www.springframework.org/schema/tx
-           http://www.springframework.org/schema/tx/spring-tx-4.0.xsd">
+           http://www.springframework.org/schema/tx/spring-tx-4.1.xsd">
 
     <tx:annotation-driven />
 

--- a/features/ncs/ncs-alarm-gui/src/main/webapp/WEB-INF/ncsDispatcher-servlet.xml
+++ b/features/ncs/ncs-alarm-gui/src/main/webapp/WEB-INF/ncsDispatcher-servlet.xml
@@ -4,8 +4,8 @@
        xmlns:tx="http://www.springframework.org/schema/tx" 
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
-       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd"
+       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd"
        >
 
 <!-- Scan the following packages for controllers that are annotated with the @Controller annotation -->

--- a/features/ncs/ncs-drools/src/test/resources/test-context.xml
+++ b/features/ncs/ncs-drools/src/test/resources/test-context.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans-4.0.xsd">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
     <bean id="droolsCorrelationEngineBuilderConfigurationResource" class="java.lang.String">
         <constructor-arg value="file:src/test/opennms-home/etc/drools-engine.xml" />

--- a/features/ncs/ncs-persistence/src/main/resources/META-INF/opennms/component-dao.xml
+++ b/features/ncs/ncs-persistence/src/main/resources/META-INF/opennms/component-dao.xml
@@ -6,8 +6,8 @@
 	xmlns:onmsgi="http://xmlns.opennms.org/xsd/spring/onms-osgi"
 	xsi:schemaLocation="
 		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
-		http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
+		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
+		http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
 		http://xmlns.opennms.org/xsd/spring/onms-osgi http://xmlns.opennms.org/xsd/spring/onms-osgi.xsd
 	">
 

--- a/features/ncs/ncs-persistence/src/main/resources/META-INF/opennms/component-service.xml
+++ b/features/ncs/ncs-persistence/src/main/resources/META-INF/opennms/component-service.xml
@@ -4,9 +4,9 @@
 	xmlns:context="http://www.springframework.org/schema/context"
 	xmlns:tx="http://www.springframework.org/schema/tx" 
 	xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
-        http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
+        http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
  	">
  	
   <tx:annotation-driven />

--- a/features/ncs/ncs-test/src/main/resources/META-INF/opennms/applicationContext-testDao.xml
+++ b/features/ncs/ncs-test/src/main/resources/META-INF/opennms/applicationContext-testDao.xml
@@ -5,8 +5,8 @@
        xmlns:util="http://www.springframework.org/schema/util"
        xmlns:onmsgi="http://xmlns.opennms.org/xsd/spring/onms-osgi"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
-       http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.0.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
+       http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.1.xsd
        http://xmlns.opennms.org/xsd/spring/onms-osgi http://xmlns.opennms.org/xsd/spring/onms-osgi.xsd
        ">
 

--- a/features/ncs/ncs-test/src/main/resources/beanRefContext.xml
+++ b/features/ncs/ncs-test/src/main/resources/beanRefContext.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans-4.0.xsd" default-lazy-init="true">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd" default-lazy-init="true">
         
    <bean id="testDaoContext" class="org.springframework.context.support.ClassPathXmlApplicationContext">
      <constructor-arg>

--- a/features/newts/src/main/resources/META-INF/opennms/applicationContext-newts.xml
+++ b/features/newts/src/main/resources/META-INF/opennms/applicationContext-newts.xml
@@ -4,9 +4,9 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:util="http://www.springframework.org/schema/util"
        xmlns:onmsgi="http://xmlns.opennms.org/xsd/spring/onms-osgi"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
-       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
-       http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.0.xsd
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
+       http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.1.xsd
        http://xmlns.opennms.org/xsd/spring/onms-osgi http://xmlns.opennms.org/xsd/spring/onms-osgi.xsd
        ">
 

--- a/features/newts/src/test/resources/META-INF/opennms/applicationContext-empty.xml
+++ b/features/newts/src/test/resources/META-INF/opennms/applicationContext-empty.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" 
 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
-xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
+xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
 ">
 </beans>

--- a/features/newts/src/test/resources/META-INF/opennms/component-rrd.xml
+++ b/features/newts/src/test/resources/META-INF/opennms/component-rrd.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans" 
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
-       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
        ">
 
   <context:annotation-config />

--- a/features/nrtg/protocolcollector/snmp/src/test/resources/SnmpProtocolCollectorTestContext.xml
+++ b/features/nrtg/protocolcollector/snmp/src/test/resources/SnmpProtocolCollectorTestContext.xml
@@ -4,8 +4,8 @@
        xmlns:tx="http://www.springframework.org/schema/tx" 
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
-       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd"
+       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd"
        >
 
   <bean class="org.opennms.nrtg.protocolcollector.snmp.internal.SnmpProtocolCollector" id="snmpProtocolCollector">

--- a/features/nrtg/protocolcollector/tca/src/test/resources/TcaProtocolCollectorTestContext.xml
+++ b/features/nrtg/protocolcollector/tca/src/test/resources/TcaProtocolCollectorTestContext.xml
@@ -4,8 +4,8 @@
        xmlns:tx="http://www.springframework.org/schema/tx" 
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
-       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd"
+       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd"
        >
 
   <bean class="org.opennms.nrtg.protocolcollector.tca.internal.TcaProtocolCollector" id="tcaProtocolCollector">

--- a/features/poller/client-rpc/src/main/resources/META-INF/opennms/applicationContext-rpc-poller.xml
+++ b/features/poller/client-rpc/src/main/resources/META-INF/opennms/applicationContext-rpc-poller.xml
@@ -5,8 +5,8 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:onmsgi="http://xmlns.opennms.org/xsd/spring/onms-osgi"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
-       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
+       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
        http://xmlns.opennms.org/xsd/spring/onms-osgi http://xmlns.opennms.org/xsd/spring/onms-osgi.xsd">
 
 	<context:annotation-config />

--- a/features/poller/monitors/core/src/test/resources/loginTestWar/WEB-INF/applicationContext-security.xml
+++ b/features/poller/monitors/core/src/test/resources/loginTestWar/WEB-INF/applicationContext-security.xml
@@ -2,7 +2,7 @@
 <beans:beans xmlns:beans="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns="http://www.springframework.org/schema/security"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
+	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
 		http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security-3.2.xsd">
 
   <http pattern="/**" auto-config='true'>

--- a/features/poller/remote/src/main/resources/META-INF/opennms/applicationContext-exportedPollerBackEnd-http.xml
+++ b/features/poller/remote/src/main/resources/META-INF/opennms/applicationContext-exportedPollerBackEnd-http.xml
@@ -8,11 +8,11 @@
   xmlns:jdbc="http://www.springframework.org/schema/jdbc" 
   xmlns:onmsgi="http://xmlns.opennms.org/xsd/spring/onms-osgi"
   xsi:schemaLocation="
-  http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
-  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
-  http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
-  http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.0.xsd
-  http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-4.0.xsd
+  http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
+  http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+  http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.1.xsd
+  http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-4.1.xsd
   http://xmlns.opennms.org/xsd/spring/onms-osgi http://xmlns.opennms.org/xsd/spring/onms-osgi.xsd
 ">
 

--- a/features/poller/remote/src/main/resources/META-INF/opennms/applicationContext-exportedPollerBackEnd-https.xml
+++ b/features/poller/remote/src/main/resources/META-INF/opennms/applicationContext-exportedPollerBackEnd-https.xml
@@ -8,11 +8,11 @@
   xmlns:jdbc="http://www.springframework.org/schema/jdbc" 
   xmlns:onmsgi="http://xmlns.opennms.org/xsd/spring/onms-osgi"
   xsi:schemaLocation="
-  http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
-  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
-  http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
-  http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.0.xsd
-  http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-4.0.xsd
+  http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
+  http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+  http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.1.xsd
+  http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-4.1.xsd
   http://xmlns.opennms.org/xsd/spring/onms-osgi http://xmlns.opennms.org/xsd/spring/onms-osgi.xsd
 ">
 

--- a/features/poller/remote/src/main/resources/META-INF/opennms/applicationContext-exportedPollerBackEnd-rmi.xml
+++ b/features/poller/remote/src/main/resources/META-INF/opennms/applicationContext-exportedPollerBackEnd-rmi.xml
@@ -8,11 +8,11 @@
   xmlns:jdbc="http://www.springframework.org/schema/jdbc" 
   xmlns:onmsgi="http://xmlns.opennms.org/xsd/spring/onms-osgi"
   xsi:schemaLocation="
-  http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
-  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
-  http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
-  http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.0.xsd
-  http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-4.0.xsd
+  http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
+  http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+  http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.1.xsd
+  http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-4.1.xsd
   http://xmlns.opennms.org/xsd/spring/onms-osgi http://xmlns.opennms.org/xsd/spring/onms-osgi.xsd
 ">
 

--- a/features/poller/remote/src/main/resources/META-INF/opennms/applicationContext-pollerBackEnd.xml
+++ b/features/poller/remote/src/main/resources/META-INF/opennms/applicationContext-pollerBackEnd.xml
@@ -8,11 +8,11 @@
   xmlns:jdbc="http://www.springframework.org/schema/jdbc" 
   xmlns:onmsgi="http://xmlns.opennms.org/xsd/spring/onms-osgi"
   xsi:schemaLocation="
-  http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
-  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
-  http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
-  http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.0.xsd
-  http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-4.0.xsd
+  http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
+  http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+  http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.1.xsd
+  http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-4.1.xsd
   http://xmlns.opennms.org/xsd/spring/onms-osgi http://xmlns.opennms.org/xsd/spring/onms-osgi.xsd
 ">
 

--- a/features/poller/remote/src/main/resources/META-INF/opennms/applicationContext-pollerFrontEnd-scanReport.xml
+++ b/features/poller/remote/src/main/resources/META-INF/opennms/applicationContext-pollerFrontEnd-scanReport.xml
@@ -6,11 +6,11 @@
 	xmlns:util="http://www.springframework.org/schema/util"
 	xmlns:onmsgi="http://xmlns.opennms.org/xsd/spring/onms-osgi"
 	xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
-		http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.0.xsd
-		http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-4.0.xsd
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
+		http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.1.xsd
+		http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-4.1.xsd
 		http://xmlns.opennms.org/xsd/spring/onms-osgi http://xmlns.opennms.org/xsd/spring/onms-osgi.xsd
 ">
 

--- a/features/poller/remote/src/main/resources/META-INF/opennms/applicationContext-pollerFrontEnd.xml
+++ b/features/poller/remote/src/main/resources/META-INF/opennms/applicationContext-pollerFrontEnd.xml
@@ -8,11 +8,11 @@
   xmlns:jdbc="http://www.springframework.org/schema/jdbc" 
   xmlns:onmsgi="http://xmlns.opennms.org/xsd/spring/onms-osgi"
   xsi:schemaLocation="
-  http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
-  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
-  http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
-  http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.0.xsd
-  http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-4.0.xsd
+  http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
+  http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+  http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.1.xsd
+  http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-4.1.xsd
   http://xmlns.opennms.org/xsd/spring/onms-osgi http://xmlns.opennms.org/xsd/spring/onms-osgi.xsd
 ">
 	   

--- a/features/poller/remote/src/main/resources/META-INF/opennms/applicationContext-remotePollerBackEnd-http.xml
+++ b/features/poller/remote/src/main/resources/META-INF/opennms/applicationContext-remotePollerBackEnd-http.xml
@@ -8,11 +8,11 @@
   xmlns:jdbc="http://www.springframework.org/schema/jdbc" 
   xmlns:onmsgi="http://xmlns.opennms.org/xsd/spring/onms-osgi"
   xsi:schemaLocation="
-  http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
-  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
-  http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
-  http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.0.xsd
-  http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-4.0.xsd
+  http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
+  http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+  http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.1.xsd
+  http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-4.1.xsd
   http://xmlns.opennms.org/xsd/spring/onms-osgi http://xmlns.opennms.org/xsd/spring/onms-osgi.xsd
 ">
 

--- a/features/poller/remote/src/main/resources/META-INF/opennms/applicationContext-remotePollerBackEnd-https.xml
+++ b/features/poller/remote/src/main/resources/META-INF/opennms/applicationContext-remotePollerBackEnd-https.xml
@@ -8,11 +8,11 @@
   xmlns:jdbc="http://www.springframework.org/schema/jdbc" 
   xmlns:onmsgi="http://xmlns.opennms.org/xsd/spring/onms-osgi"
   xsi:schemaLocation="
-  http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
-  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
-  http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
-  http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.0.xsd
-  http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-4.0.xsd
+  http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
+  http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+  http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.1.xsd
+  http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-4.1.xsd
   http://xmlns.opennms.org/xsd/spring/onms-osgi http://xmlns.opennms.org/xsd/spring/onms-osgi.xsd
 ">
 

--- a/features/poller/remote/src/main/resources/META-INF/opennms/applicationContext-remotePollerBackEnd-rmi.xml
+++ b/features/poller/remote/src/main/resources/META-INF/opennms/applicationContext-remotePollerBackEnd-rmi.xml
@@ -8,11 +8,11 @@
   xmlns:jdbc="http://www.springframework.org/schema/jdbc" 
   xmlns:onmsgi="http://xmlns.opennms.org/xsd/spring/onms-osgi"
   xsi:schemaLocation="
-  http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
-  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
-  http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
-  http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.0.xsd
-  http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-4.0.xsd
+  http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
+  http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+  http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.1.xsd
+  http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-4.1.xsd
   http://xmlns.opennms.org/xsd/spring/onms-osgi http://xmlns.opennms.org/xsd/spring/onms-osgi.xsd
 ">
 

--- a/features/poller/remote/src/main/resources/beanRefContext.xml
+++ b/features/poller/remote/src/main/resources/beanRefContext.xml
@@ -3,7 +3,7 @@
   default-lazy-init="true"
   xsi:schemaLocation="
     http://www.springframework.org/schema/beans
-    http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
+    http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
 ">
    
    <bean id="pollerBackEndContext" class="org.springframework.context.support.ClassPathXmlApplicationContext">

--- a/features/poller/remote/src/test/resources/org/opennms/netmgt/poller/remote/applicationContext-configOverride.xml
+++ b/features/poller/remote/src/test/resources/org/opennms/netmgt/poller/remote/applicationContext-configOverride.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans-4.0.xsd">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
     
   <bean id="pollerConfigDao" class="org.opennms.netmgt.config.DefaultPollerConfigDao">
     <property name="configResource" value="classpath:/org/opennms/netmgt/poller/remote/poller-configuration.xml"/>

--- a/features/remote-poller-gwt/src/main/webapp/WEB-INF/applicationContext-remote-poller.xml
+++ b/features/remote-poller-gwt/src/main/webapp/WEB-INF/applicationContext-remote-poller.xml
@@ -5,9 +5,9 @@
        xmlns:tx="http://www.springframework.org/schema/tx"
        xmlns:util="http://www.springframework.org/schema/util"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
-       http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.0.xsd
-       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
+       http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.1.xsd
+       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
 ">
 
   <tx:annotation-driven />

--- a/features/remote-poller-gwt/src/test/resources/locationDataManagerTest.xml
+++ b/features/remote-poller-gwt/src/test/resources/locationDataManagerTest.xml
@@ -4,8 +4,8 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:util="http://www.springframework.org/schema/util"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
-       http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.0.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
+       http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.1.xsd
        ">
 
   <context:annotation-config />

--- a/features/remote-poller-gwt/src/test/resources/locationDataServiceTest.xml
+++ b/features/remote-poller-gwt/src/test/resources/locationDataServiceTest.xml
@@ -4,8 +4,8 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:util="http://www.springframework.org/schema/util"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
-       http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.0.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
+       http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.1.xsd
        ">
 
   <context:annotation-config />

--- a/features/remote-poller/src/main/resources/META-INF/opennms/applicationContext-scan-gui.xml
+++ b/features/remote-poller/src/main/resources/META-INF/opennms/applicationContext-scan-gui.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:lang="http://www.springframework.org/schema/lang"
 	   xsi:schemaLocation=
-	   "http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
-	   http://www.springframework.org/schema/lang http://www.springframework.org/schema/lang/spring-lang-4.0.xsd">
+	   "http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+	   http://www.springframework.org/schema/lang http://www.springframework.org/schema/lang/spring-lang-4.1.xsd">
 
       <bean id="pollerView" class="org.opennms.groovy.poller.remote.ScanGui">
         <lookup-method name="createPollerFrontEnd" bean="pollerFrontEnd"/> 

--- a/features/remote-poller/src/main/resources/META-INF/opennms/applicationContext-ws-gui.xml
+++ b/features/remote-poller/src/main/resources/META-INF/opennms/applicationContext-ws-gui.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:lang="http://www.springframework.org/schema/lang"
 	   xsi:schemaLocation=
-	   "http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
-	   http://www.springframework.org/schema/lang http://www.springframework.org/schema/lang/spring-lang-4.0.xsd">
+	   "http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+	   http://www.springframework.org/schema/lang http://www.springframework.org/schema/lang/spring-lang-4.1.xsd">
 
 
       <bean id="pollerView" class="org.opennms.groovy.poller.remote.GroovyPollerView">

--- a/features/remote-poller/src/test/resources/applicationContext-client.xml
+++ b/features/remote-poller/src/test/resources/applicationContext-client.xml
@@ -3,9 +3,9 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:tx="http://www.springframework.org/schema/tx"
        xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
-       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
-       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
   <tx:annotation-driven />
 

--- a/features/remote-poller/src/test/resources/simple-test-webapp/WEB-INF/applicationContext-exportedSimpleBackEnd.xml
+++ b/features/remote-poller/src/test/resources/simple-test-webapp/WEB-INF/applicationContext-exportedSimpleBackEnd.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xmlns:tx="http://www.springframework.org/schema/tx"
-  xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
-       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd">
+  xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd">
 
   <bean id="defaultSimpleBackEnd" class="org.opennms.poller.remote.DefaultSimpleBackEnd">
   </bean>

--- a/features/remote-poller/src/test/resources/simple-test-webapp/WEB-INF/applicationContext-svclayer.xml
+++ b/features/remote-poller/src/test/resources/simple-test-webapp/WEB-INF/applicationContext-svclayer.xml
@@ -4,8 +4,8 @@
        xmlns:tx="http://www.springframework.org/schema/tx"
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
-       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd">
+       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
   <tx:annotation-driven />
 

--- a/features/reporting/availability/src/main/resources/META-INF/opennms/component-reporting.xml
+++ b/features/reporting/availability/src/main/resources/META-INF/opennms/component-reporting.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans
-	http://www.springframework.org/schema/beans/spring-beans-4.0.xsd">
+	http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
 	<bean id="calendarAvailabilityCalculator"
 		class="org.opennms.reporting.availability.AvailabilityCalculatorImpl"

--- a/features/reporting/availability/src/test/resources/META-INF/opennms/applicationContext-availabilityDatabasePopulator.xml
+++ b/features/reporting/availability/src/test/resources/META-INF/opennms/applicationContext-availabilityDatabasePopulator.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans-4.0.xsd">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
    <bean id="availabilityDatabasePopulator" class="org.opennms.reporting.availability.AvailabilityDatabasePopulator">
      <property name="distPollerDao" ref="distPollerDao" />

--- a/features/reporting/availability/src/test/resources/org/opennms/reporting/availability/svclayer/AvailabilityReportServiceTest.xml
+++ b/features/reporting/availability/src/test/resources/org/opennms/reporting/availability/svclayer/AvailabilityReportServiceTest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans-4.0.xsd">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
   	<bean id="availabilityReportService"
 		class="org.opennms.reporting.availability.svclayer.AvailabilityReportService"

--- a/features/reporting/core/src/main/resources/META-INF/opennms/applicationContext-reportingCore.xml
+++ b/features/reporting/core/src/main/resources/META-INF/opennms/applicationContext-reportingCore.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans
-	http://www.springframework.org/schema/beans/spring-beans-4.0.xsd">
+	http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
 	<bean id="reportServiceLocator" class="org.opennms.reporting.core.svclayer.support.DefaultReportServiceLocator">
         <property name="globalReportRepository" ref="defaultGlobalReportRepository" />

--- a/features/reporting/core/src/main/resources/beanRefContext.xml
+++ b/features/reporting/core/src/main/resources/beanRefContext.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans-4.0.xsd" default-lazy-init="true">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd" default-lazy-init="true">
 
     <bean id="reportingCoreContext" class="org.springframework.context.support.ClassPathXmlApplicationContext">
         <constructor-arg>

--- a/features/reporting/core/src/test/resources/org/opennms/reporting/core/svclayer/support/DefaultReportStoreServiceTest.xml
+++ b/features/reporting/core/src/test/resources/org/opennms/reporting/core/svclayer/support/DefaultReportStoreServiceTest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans-4.0.xsd">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
   	<bean id="reportStoreService"
 		class="org.opennms.reporting.core.svclayer.support.DefaultReportStoreService">

--- a/features/reporting/jasper-reports/src/test/resources/org/opennms/reporting/jasperreports/svclayer/JasperReportServiceTest.xml
+++ b/features/reporting/jasper-reports/src/test/resources/org/opennms/reporting/jasperreports/svclayer/JasperReportServiceTest.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans-4.0.xsd">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 	<bean id="jasperReportService" class="org.opennms.reporting.jasperreports.svclayer.JasperReportService">
 		<property name="globalReportRepository" ref="defaultGlobalReportRepository"/>
 	</bean>

--- a/features/system-report/src/main/resources/META-INF/opennms/applicationContext-systemReport.xml
+++ b/features/system-report/src/main/resources/META-INF/opennms/applicationContext-systemReport.xml
@@ -3,7 +3,7 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:onmsgi="http://xmlns.opennms.org/xsd/spring/onms-osgi"
 	xsi:schemaLocation="
-        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
+        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
 		http://xmlns.opennms.org/xsd/spring/onms-osgi http://xmlns.opennms.org/xsd/spring/onms-osgi.xsd
         ">
 

--- a/features/system-report/src/main/resources/beanRefContext.xml
+++ b/features/system-report/src/main/resources/beanRefContext.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans-4.0.xsd">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
         
   <bean id="systemReportContext" class="org.springframework.context.support.ClassPathXmlApplicationContext" lazy-init="true">
      <constructor-arg>

--- a/features/system-report/src/test/resources/applicationContext-test-systemReport.xml
+++ b/features/system-report/src/test/resources/applicationContext-test-systemReport.xml
@@ -3,7 +3,7 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:onmsgi="http://xmlns.opennms.org/xsd/spring/onms-osgi"
 	xsi:schemaLocation="
-        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
+        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
 		http://xmlns.opennms.org/xsd/spring/onms-osgi http://xmlns.opennms.org/xsd/spring/onms-osgi.xsd
         ">
 

--- a/features/ticketing/daemon/src/main/resources/META-INF/opennms/applicationContext-troubleTicketer.xml
+++ b/features/ticketing/daemon/src/main/resources/META-INF/opennms/applicationContext-troubleTicketer.xml
@@ -8,11 +8,11 @@
   xmlns:jdbc="http://www.springframework.org/schema/jdbc" 
   xmlns:onmsgi="http://xmlns.opennms.org/xsd/spring/onms-osgi"
   xsi:schemaLocation="
-  http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
-  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
-  http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
-  http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.0.xsd
-  http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-4.0.xsd
+  http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
+  http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+  http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.1.xsd
+  http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-4.1.xsd
   http://xmlns.opennms.org/xsd/spring/onms-osgi http://xmlns.opennms.org/xsd/spring/onms-osgi.xsd
 ">
 	<context:annotation-config />

--- a/features/ticketing/daemon/src/main/resources/META-INF/opennms/component-osgi-ticketer-plugin.xml
+++ b/features/ticketing/daemon/src/main/resources/META-INF/opennms/component-osgi-ticketer-plugin.xml
@@ -4,8 +4,8 @@
   xmlns:context="http://www.springframework.org/schema/context"
   xmlns:onmsgi="http://xmlns.opennms.org/xsd/spring/onms-osgi"
   xsi:schemaLocation="
-  http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
-  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
+  http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
   http://xmlns.opennms.org/xsd/spring/onms-osgi http://xmlns.opennms.org/xsd/spring/onms-osgi.xsd
 ">
 

--- a/features/ticketing/daemon/src/main/resources/beanRefContext.xml
+++ b/features/ticketing/daemon/src/main/resources/beanRefContext.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans-4.0.xsd" default-lazy-init="true">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd" default-lazy-init="true">
 
    <bean id="troubleTicketerContext" class="org.springframework.context.support.ClassPathXmlApplicationContext">
      <constructor-arg>

--- a/features/ticketing/daemon/src/test/resources/org/opennms/netmgt/ticketd/applicationContext-configOverride.xml
+++ b/features/ticketing/daemon/src/test/resources/org/opennms/netmgt/ticketd/applicationContext-configOverride.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:context="http://www.springframework.org/schema/context" xmlns:tx="http://www.springframework.org/schema/tx"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
        http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
        http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx.xsd">
 

--- a/features/timeseries-evaluate/src/main/resources/META-INF/opennms/applicationContext-evaluate.xml
+++ b/features/timeseries-evaluate/src/main/resources/META-INF/opennms/applicationContext-evaluate.xml
@@ -4,9 +4,9 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:util="http://www.springframework.org/schema/util"
        xmlns:onmsgi="http://xmlns.opennms.org/xsd/spring/onms-osgi"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
-       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
-       http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.0.xsd
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
+       http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.1.xsd
        http://xmlns.opennms.org/xsd/spring/onms-osgi http://xmlns.opennms.org/xsd/spring/onms-osgi.xsd
        ">
 

--- a/features/timeseries-evaluate/src/test/resources/applicationContext-evaluate-test.xml
+++ b/features/timeseries-evaluate/src/test/resources/applicationContext-evaluate-test.xml
@@ -3,9 +3,9 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:util="http://www.springframework.org/schema/util"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
-       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
-       http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.0.xsd
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
+       http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.1.xsd
        ">
 
   <bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer" />

--- a/features/topology-map/org.opennms.features.topology.persistence/org.opennms.features.topology.persistence.impl/src/main/resources/META-INF/opennms/component-dao.xml
+++ b/features/topology-map/org.opennms.features.topology.persistence/org.opennms.features.topology.persistence.impl/src/main/resources/META-INF/opennms/component-dao.xml
@@ -6,8 +6,8 @@
 	xmlns:onmsgi="http://xmlns.opennms.org/xsd/spring/onms-osgi"
 	xsi:schemaLocation="
 		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
-		http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
+		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
+		http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
 		http://xmlns.opennms.org/xsd/spring/onms-osgi http://xmlns.opennms.org/xsd/spring/onms-osgi.xsd
 	">
 

--- a/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.linkd/src/test/resources/META-INF/opennms/applicationContext-enhanced-mock.xml
+++ b/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.linkd/src/test/resources/META-INF/opennms/applicationContext-enhanced-mock.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans-4.0.xsd">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 <!--
     <bean class="org.easymock.EasyMock" factory-method="createNiceMock" primary="true" id="dataLinkInterfaceDao">
         <constructor-arg value="org.opennms.netmgt.dao.api.DataLinkInterfaceDao"/>

--- a/features/wsman/src/main/resources/META-INF/opennms/component-dao.xml
+++ b/features/wsman/src/main/resources/META-INF/opennms/component-dao.xml
@@ -4,8 +4,8 @@
        xmlns:tx="http://www.springframework.org/schema/tx" 
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
-       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd"
+       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd"
        >
 
   <context:annotation-config/>

--- a/features/wsman/src/main/resources/META-INF/opennms/detectors.xml
+++ b/features/wsman/src/main/resources/META-INF/opennms/detectors.xml
@@ -5,8 +5,8 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="
        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
-       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd">
+       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
     <context:component-scan base-package="org.opennms.netmgt.provision.detector.wsman" 
                            name-generator="org.opennms.netmgt.provision.support.DetectorBeanNameGenerator"/>

--- a/integrations/opennms-dns-provisioning-adapter/src/main/resources/META-INF/opennms/provisiond-extensions.xml
+++ b/integrations/opennms-dns-provisioning-adapter/src/main/resources/META-INF/opennms/provisiond-extensions.xml
@@ -4,8 +4,8 @@
        xmlns:tx="http://www.springframework.org/schema/tx" 
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
-       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd" >
+       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd" >
   
   <bean name="dpa" class="org.opennms.netmgt.provision.DnsProvisioningAdapter">
     <property name="eventForwarder" ref="eventForwarder" />

--- a/integrations/opennms-jasper-extensions/src/test/resources/META-INF/opennms/applicationContext-measurements-NMS-8337.xml
+++ b/integrations/opennms-jasper-extensions/src/test/resources/META-INF/opennms/applicationContext-measurements-NMS-8337.xml
@@ -4,9 +4,9 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="
            http://www.springframework.org/schema/beans
-           http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
+           http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
            http://www.springframework.org/schema/context
-           http://www.springframework.org/schema/context/spring-context-4.0.xsd">
+           http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
   <context:annotation-config />
   <bean id="springTestConfiguration" class="org.opennms.netmgt.jasper.measurement.CustomSpringConfiguration"/>

--- a/integrations/opennms-jasper-extensions/src/test/resources/META-INF/opennms/applicationContext-measurements-test.xml
+++ b/integrations/opennms-jasper-extensions/src/test/resources/META-INF/opennms/applicationContext-measurements-test.xml
@@ -4,9 +4,9 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="
            http://www.springframework.org/schema/beans
-           http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
+           http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
            http://www.springframework.org/schema/context
-           http://www.springframework.org/schema/context/spring-context-4.0.xsd">
+           http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
   <context:annotation-config />
   <bean id="springTestConfiguration" class="org.opennms.netmgt.jasper.measurement.DefaultSpringConfiguration"/>

--- a/integrations/opennms-puppet-provisioning-adapter/src/main/resources/META-INF/opennms/provisiond-extensions.xml
+++ b/integrations/opennms-puppet-provisioning-adapter/src/main/resources/META-INF/opennms/provisiond-extensions.xml
@@ -4,8 +4,8 @@
        xmlns:tx="http://www.springframework.org/schema/tx" 
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
-       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd" >
+       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd" >
   
   <bean name="ppa" class="org.opennms.netmgt.provision.PuppetProvisioningAdapter">
     <property name="eventForwarder" ref="eventForwarder" />

--- a/integrations/opennms-rancid-provisioning-adapter/src/main/resources/META-INF/opennms/provisiond-extensions.xml
+++ b/integrations/opennms-rancid-provisioning-adapter/src/main/resources/META-INF/opennms/provisiond-extensions.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans-4.0.xsd">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
   <bean name="rancidProvisioningAdapter" class="org.opennms.netmgt.provision.RancidProvisioningAdapter">
     <property name="eventForwarder" ref="eventForwarder" />

--- a/integrations/opennms-reverse-dns-provisioning-adapter/src/main/resources/META-INF/opennms/provisiond-extensions.xml
+++ b/integrations/opennms-reverse-dns-provisioning-adapter/src/main/resources/META-INF/opennms/provisiond-extensions.xml
@@ -4,8 +4,8 @@
        xmlns:tx="http://www.springframework.org/schema/tx" 
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
-       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd" >
+       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd" >
   
   <bean name="rdpa" class="org.opennms.netmgt.provision.ReverseDnsProvisioningAdapter">
     <property name="eventForwarder" ref="eventForwarder" />

--- a/integrations/opennms-rws/src/main/resources/META-INF/opennms/component-dao.xml
+++ b/integrations/opennms-rws/src/main/resources/META-INF/opennms/component-dao.xml
@@ -4,8 +4,8 @@
        xmlns:tx="http://www.springframework.org/schema/tx" 
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
-       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd"
+       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd"
        >
 
   <context:annotation-config/>

--- a/integrations/opennms-snmp-asset-provisioning-adapter/src/main/resources/META-INF/opennms/provisiond-extensions.xml
+++ b/integrations/opennms-snmp-asset-provisioning-adapter/src/main/resources/META-INF/opennms/provisiond-extensions.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans-4.0.xsd">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
 	<bean id="snmpAssetAdapterConfigFactory" class="org.opennms.netmgt.config.SnmpAssetAdapterConfigFactory">
 		<!-- <constructor-arg type="org.opennms.netmgt.config.OpennmsServerConfigFactory" ref="onmsServerConfig"/> -->

--- a/integrations/opennms-snmp-hardware-inventory-provisioning-adapter/src/main/resources/META-INF/opennms/provisiond-extensions.xml
+++ b/integrations/opennms-snmp-hardware-inventory-provisioning-adapter/src/main/resources/META-INF/opennms/provisiond-extensions.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans-4.0.xsd">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
 	<bean id="snmpHwInventoryAdapterConfigDao" class="org.opennms.netmgt.config.DefaultSnmpHwInventoryAdapterConfigDao">
 		<property name="configResource" value="file:${opennms.home}/etc/snmp-hardware-inventory-adapter-configuration.xml" />

--- a/integrations/opennms-vmware/src/main/resources/META-INF/opennms/component-dao.xml
+++ b/integrations/opennms-vmware/src/main/resources/META-INF/opennms/component-dao.xml
@@ -4,8 +4,8 @@
        xmlns:tx="http://www.springframework.org/schema/tx"
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
-       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd"
+       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd"
         >
 
     <context:annotation-config/>

--- a/integrations/opennms-vmware/src/test/resources/META-INF/opennms/component-dao.xml
+++ b/integrations/opennms-vmware/src/test/resources/META-INF/opennms/component-dao.xml
@@ -4,8 +4,8 @@
        xmlns:tx="http://www.springframework.org/schema/tx"
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
-       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd"
+       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd"
         >
 
     <context:annotation-config/>

--- a/opennms-ackd/src/main/resources/META-INF/opennms/applicationContext-ackd.xml
+++ b/opennms-ackd/src/main/resources/META-INF/opennms/applicationContext-ackd.xml
@@ -3,8 +3,8 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:tx="http://www.springframework.org/schema/tx" 
        xsi:schemaLocation="
-       http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
-       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd">
+       http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd">
 
   <bean id="ackdConfigurationDao" class="org.opennms.netmgt.dao.jaxb.DefaultAckdConfigurationDao">
     <property name="configResource" value="file:${opennms.home}/etc/ackd-configuration.xml" />

--- a/opennms-ackd/src/main/resources/beanRefContext.xml
+++ b/opennms-ackd/src/main/resources/beanRefContext.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans-4.0.xsd" default-lazy-init="true">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd" default-lazy-init="true">
         
    <bean id="ackdContext" class="org.springframework.context.support.ClassPathXmlApplicationContext">
      <constructor-arg>

--- a/opennms-alarms/daemon/src/main/resources/META-INF/opennms/applicationContext-alarmd.xml
+++ b/opennms-alarms/daemon/src/main/resources/META-INF/opennms/applicationContext-alarmd.xml
@@ -4,7 +4,7 @@
        xmlns:tx="http://www.springframework.org/schema/tx" 
        xmlns:onmsgi="http://xmlns.opennms.org/xsd/spring/onms-osgi"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
+       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
        http://xmlns.opennms.org/xsd/spring/onms-osgi http://xmlns.opennms.org/xsd/spring/onms-osgi.xsd">
 
   <tx:annotation-driven />

--- a/opennms-alarms/daemon/src/main/resources/beanRefContext.xml
+++ b/opennms-alarms/daemon/src/main/resources/beanRefContext.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans-4.0.xsd" default-lazy-init="true">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd" default-lazy-init="true">
         
    <bean id="alarmdContext" class="org.springframework.context.support.ClassPathXmlApplicationContext">
      <constructor-arg>

--- a/opennms-assemblies/http-remoting/src/main/webapp/WEB-INF/applicationContext-common.xml
+++ b/opennms-assemblies/http-remoting/src/main/webapp/WEB-INF/applicationContext-common.xml
@@ -4,9 +4,9 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="
            http://www.springframework.org/schema/beans
-           http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
+           http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
            http://www.springframework.org/schema/context
-           http://www.springframework.org/schema/context/spring-context-4.0.xsd">
+           http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
   <bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
       <property name="systemPropertiesModeName" value="SYSTEM_PROPERTIES_MODE_OVERRIDE" />

--- a/opennms-assemblies/http-remoting/src/main/webapp/WEB-INF/applicationContext-serviceRegistryRemoting.xml
+++ b/opennms-assemblies/http-remoting/src/main/webapp/WEB-INF/applicationContext-serviceRegistryRemoting.xml
@@ -3,9 +3,9 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:tx="http://www.springframework.org/schema/tx" 
        xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
-       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
-       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
   <!-- This bean exposes all interfaces registered in the OpenNMS SOA ServiceRegistry over Spring HTTP remoting -->
   <bean id="serviceRegistryExporter" class="org.opennms.core.spring.web.ServiceRegistryHttpInvokerServiceExporter">

--- a/opennms-assemblies/http-remoting/src/main/webapp/WEB-INF/applicationContext-spring-security.xml
+++ b/opennms-assemblies/http-remoting/src/main/webapp/WEB-INF/applicationContext-spring-security.xml
@@ -2,7 +2,7 @@
 <beans:beans xmlns="http://www.springframework.org/schema/security"
 	xmlns:beans="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
+	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
 		http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security-3.2.xsd"> 
 
 

--- a/opennms-assemblies/http-remoting/src/main/webapp/WEB-INF/applicationContext-svclayer.xml
+++ b/opennms-assemblies/http-remoting/src/main/webapp/WEB-INF/applicationContext-svclayer.xml
@@ -4,8 +4,8 @@
        xmlns:tx="http://www.springframework.org/schema/tx" 
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
-       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd">
+       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
   <tx:annotation-driven />
   

--- a/opennms-asterisk/src/main/resources/META-INF/opennms/applicationContext-asteriskGateway.xml
+++ b/opennms-asterisk/src/main/resources/META-INF/opennms/applicationContext-asteriskGateway.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans" 
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:tx="http://www.springframework.org/schema/tx" 
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
-       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd">
 
 	<bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer" />
         <bean name="daemon" class="org.opennms.netmgt.asterisk.agi.AsteriskGateway" />    

--- a/opennms-asterisk/src/main/resources/beanRefContext.xml
+++ b/opennms-asterisk/src/main/resources/beanRefContext.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans-4.0.xsd" default-lazy-init="true">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd" default-lazy-init="true">
         
    <bean id="asteriskGatewayContext" class="org.springframework.context.support.ClassPathXmlApplicationContext">
      <constructor-arg>

--- a/opennms-base-assembly/src/main/filtered/etc/examples/drools-engine.d/nodeParentRules/locationMonitorRules-context.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/examples/drools-engine.d/nodeParentRules/locationMonitorRules-context.xml
@@ -2,9 +2,9 @@
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
  		xmlns:tx="http://www.springframework.org/schema/tx"
 		xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
         http://www.springframework.org/schema/tx
-        http://www.springframework.org/schema/tx/spring-tx-4.0.xsd">
+        http://www.springframework.org/schema/tx/spring-tx-4.1.xsd">
         
     <!--  tx:annotation-driven / -->
     

--- a/opennms-base-assembly/src/main/filtered/etc/examples/drools-engine.d/nodeParentRules/nodeParentRules-context.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/examples/drools-engine.d/nodeParentRules/nodeParentRules-context.xml
@@ -2,9 +2,9 @@
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
  		xmlns:tx="http://www.springframework.org/schema/tx"
 		xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
         http://www.springframework.org/schema/tx
-        http://www.springframework.org/schema/tx/spring-tx-4.0.xsd">
+        http://www.springframework.org/schema/tx/spring-tx-4.1.xsd">
         
     <!--  tx:annotation-driven / -->
     

--- a/opennms-base-assembly/src/main/resources/contrib/qosdaemon/qos_example_configuration/opennms/QoSDrxOssBeanRunnerSpringContext.xml
+++ b/opennms-base-assembly/src/main/resources/contrib/qosdaemon/qos_example_configuration/opennms/QoSDrxOssBeanRunnerSpringContext.xml
@@ -3,7 +3,7 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="
            http://www.springframework.org/schema/beans
-           http://www.springframework.org/schema/beans/spring-beans-4.0.xsd">
+           http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 	 
 	<bean id="OssBeanRunnerList"	class="org.openoss.ossj.fm.monitor.spring.OssBeanRunnerList">
 		<property name="ossbeanrunnerlist">

--- a/opennms-config-tester/src/main/resources/META-INF/opennms/applicationContext-configTester.xml
+++ b/opennms-config-tester/src/main/resources/META-INF/opennms/applicationContext-configTester.xml
@@ -4,9 +4,9 @@
        xmlns:context="http://www.springframework.org/schema/context" 
        xmlns:tx="http://www.springframework.org/schema/tx" 
        xsi:schemaLocation="
-           http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
-           http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
-           http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd"
+           http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+           http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
+           http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd"
        default-lazy-init="true">
 
   <bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">

--- a/opennms-config-tester/src/main/resources/beanRefContext.xml
+++ b/opennms-config-tester/src/main/resources/beanRefContext.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
 
   <bean id="configTesterContext" class="org.springframework.context.support.ClassPathXmlApplicationContext">

--- a/opennms-config/src/main/resources/META-INF/opennms/applicationContext-commonConfigs-osgi.xml
+++ b/opennms-config/src/main/resources/META-INF/opennms/applicationContext-commonConfigs-osgi.xml
@@ -3,7 +3,7 @@
   xmlns:osgi="http://www.springframework.org/schema/osgi"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="
-  http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
+  http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
   http://www.springframework.org/schema/osgi http://www.springframework.org/schema/osgi/spring-osgi.xsd
 ">
 

--- a/opennms-config/src/main/resources/META-INF/opennms/applicationContext-commonConfigs.xml
+++ b/opennms-config/src/main/resources/META-INF/opennms/applicationContext-commonConfigs.xml
@@ -8,11 +8,11 @@
   xmlns:jdbc="http://www.springframework.org/schema/jdbc" 
   xmlns:onmsgi="http://xmlns.opennms.org/xsd/spring/onms-osgi"
   xsi:schemaLocation="
-  http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
-  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
-  http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
-  http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.0.xsd
-  http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-4.0.xsd
+  http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
+  http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+  http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.1.xsd
+  http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-4.1.xsd
   http://xmlns.opennms.org/xsd/spring/onms-osgi http://xmlns.opennms.org/xsd/spring/onms-osgi.xsd
 ">
 

--- a/opennms-config/src/main/resources/beanRefContext.xml
+++ b/opennms-config/src/main/resources/beanRefContext.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans-4.0.xsd" default-lazy-init="true">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd" default-lazy-init="true">
         
    <bean id="commonContext" class="org.springframework.context.support.ClassPathXmlApplicationContext">
      <constructor-arg>

--- a/opennms-correlation/drools-correlation-engine/src/main/resources/META-INF/opennms/correlation-engine.xml
+++ b/opennms-correlation/drools-correlation-engine/src/main/resources/META-INF/opennms/correlation-engine.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:context="http://www.springframework.org/schema/context"
 	xsi:schemaLocation="
-	    http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
-        http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
+	    http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+        http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
     ">
 
     <bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">

--- a/opennms-correlation/drools-correlation-engine/src/test/opennms-home/etc/dependencyRules-context.xml
+++ b/opennms-correlation/drools-correlation-engine/src/test/opennms-home/etc/dependencyRules-context.xml
@@ -2,9 +2,9 @@
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
  		xmlns:tx="http://www.springframework.org/schema/tx"
 		xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
         http://www.springframework.org/schema/tx
-        http://www.springframework.org/schema/tx/spring-tx-4.0.xsd">
+        http://www.springframework.org/schema/tx/spring-tx-4.1.xsd">
         
     <!--  tx:annotation-driven / -->
     

--- a/opennms-correlation/drools-correlation-engine/src/test/opennms-home/etc/drools-engine.d/dependencyRules/dependencyRules-context.xml
+++ b/opennms-correlation/drools-correlation-engine/src/test/opennms-home/etc/drools-engine.d/dependencyRules/dependencyRules-context.xml
@@ -2,9 +2,9 @@
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
  		xmlns:tx="http://www.springframework.org/schema/tx"
 		xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
         http://www.springframework.org/schema/tx
-        http://www.springframework.org/schema/tx/spring-tx-4.0.xsd">
+        http://www.springframework.org/schema/tx/spring-tx-4.1.xsd">
         
     <!--  tx:annotation-driven / -->
     

--- a/opennms-correlation/drools-correlation-engine/src/test/opennms-home/etc/drools-engine.d/nodeParentRules/nodeParentRules-context.xml
+++ b/opennms-correlation/drools-correlation-engine/src/test/opennms-home/etc/drools-engine.d/nodeParentRules/nodeParentRules-context.xml
@@ -2,9 +2,9 @@
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
  		xmlns:tx="http://www.springframework.org/schema/tx"
 		xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
         http://www.springframework.org/schema/tx
-        http://www.springframework.org/schema/tx/spring-tx-4.0.xsd">
+        http://www.springframework.org/schema/tx/spring-tx-4.1.xsd">
         
     <!--  tx:annotation-driven / -->
     

--- a/opennms-correlation/drools-correlation-engine/src/test/resources/test-context.xml
+++ b/opennms-correlation/drools-correlation-engine/src/test/resources/test-context.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans-4.0.xsd">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
     <bean id="droolsCorrelationEngineBuilderConfigurationResource" class="java.lang.String">
         <constructor-arg value="file:src/test/opennms-home/etc/drools-engine.xml" />

--- a/opennms-correlation/opennms-correlator/src/main/resources/META-INF/opennms/applicationContext-correlator.xml
+++ b/opennms-correlation/opennms-correlator/src/main/resources/META-INF/opennms/applicationContext-correlator.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans-4.0.xsd">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
         
   <bean id="correlationEngines" class="org.opennms.netmgt.correlation.CorrelationEngineFactoryBean">
   </bean>

--- a/opennms-correlation/opennms-correlator/src/main/resources/beanRefContext.xml
+++ b/opennms-correlation/opennms-correlator/src/main/resources/beanRefContext.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans-4.0.xsd" default-lazy-init="true">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd" default-lazy-init="true">
         
    <bean id="correlatorContext" class="org.springframework.context.support.ClassPathXmlApplicationContext">
      <constructor-arg>

--- a/opennms-correlation/opennms-correlator/src/test/resources/META-INF/opennms/correlation-engine.xml
+++ b/opennms-correlation/opennms-correlator/src/test/resources/META-INF/opennms/correlation-engine.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans-4.0.xsd">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
 	<bean name="testEngine" class="org.opennms.netmgt.correlation.TestEngine">
 		<property name="eventIpcManager" ref="eventIpcManager"/>

--- a/opennms-dao-mock/src/main/resources/META-INF/opennms/applicationContext-mockDao.xml
+++ b/opennms-dao-mock/src/main/resources/META-INF/opennms/applicationContext-mockDao.xml
@@ -6,8 +6,8 @@
     xmlns:onmsgi="http://xmlns.opennms.org/xsd/spring/onms-osgi"
     xsi:schemaLocation="
         http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
-        http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.0.xsd
+        http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
+        http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.1.xsd
         http://xmlns.opennms.org/xsd/spring/onms-osgi http://xmlns.opennms.org/xsd/spring/onms-osgi.xsd
     ">
 

--- a/opennms-dao-mock/src/main/resources/META-INF/opennms/applicationContext-mockEventd.xml
+++ b/opennms-dao-mock/src/main/resources/META-INF/opennms/applicationContext-mockEventd.xml
@@ -3,9 +3,9 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:context="http://www.springframework.org/schema/context"
 	xmlns:util="http://www.springframework.org/schema/util" xmlns:onmsgi="http://xmlns.opennms.org/xsd/spring/onms-osgi"
 	xsi:schemaLocation="
-        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
-        http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
-        http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.0.xsd
+        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+        http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
+        http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.1.xsd
         http://xmlns.opennms.org/xsd/spring/onms-osgi http://xmlns.opennms.org/xsd/spring/onms-osgi.xsd
     ">
 

--- a/opennms-dao/src/main/resources/META-INF/opennms/applicationContext-dao.xml
+++ b/opennms-dao/src/main/resources/META-INF/opennms/applicationContext-dao.xml
@@ -6,11 +6,11 @@
        xmlns:tx="http://www.springframework.org/schema/tx"
        xmlns:util="http://www.springframework.org/schema/util"
        xmlns:onmsgi="http://xmlns.opennms.org/xsd/spring/onms-osgi"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
-       http://www.springframework.org/schema/cache http://www.springframework.org/schema/cache/spring-cache-4.0.xsd
-       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
-       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
-       http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.0.xsd
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+       http://www.springframework.org/schema/cache http://www.springframework.org/schema/cache/spring-cache-4.1.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
+       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+       http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.1.xsd
        http://xmlns.opennms.org/xsd/spring/onms-osgi http://xmlns.opennms.org/xsd/spring/onms-osgi.xsd
        ">
 

--- a/opennms-dao/src/main/resources/META-INF/opennms/applicationContext-databasePopulator.xml
+++ b/opennms-dao/src/main/resources/META-INF/opennms/applicationContext-databasePopulator.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:onmsgi="http://xmlns.opennms.org/xsd/spring/onms-osgi"
 	xsi:schemaLocation="
-		http://www.springframework.org/schema/beans   http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
+		http://www.springframework.org/schema/beans   http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
 		http://xmlns.opennms.org/xsd/spring/onms-osgi http://xmlns.opennms.org/xsd/spring/onms-osgi.xsd
 	">
 

--- a/opennms-dao/src/main/resources/beanRefContext.xml
+++ b/opennms-dao/src/main/resources/beanRefContext.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans-4.0.xsd" default-lazy-init="true">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd" default-lazy-init="true">
         
    <bean id="daoContext" class="org.springframework.context.support.ClassPathXmlApplicationContext">
      <constructor-arg>

--- a/opennms-dao/src/test/resources/META-INF/opennms/applicationContext-AbstractTransactionalTemporaryDatabaseSpringContextTests-overridable.xml
+++ b/opennms-dao/src/test/resources/META-INF/opennms/applicationContext-AbstractTransactionalTemporaryDatabaseSpringContextTests-overridable.xml
@@ -3,7 +3,7 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="
            http://www.springframework.org/schema/beans
-           http://www.springframework.org/schema/beans/spring-beans-4.0.xsd">
+           http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
   
   <bean id="transactionManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager">
     <property name="dataSource" ref="dataSource"/>

--- a/opennms-dao/src/test/resources/META-INF/opennms/applicationContext-AbstractTransactionalTemporaryDatabaseSpringContextTests.xml
+++ b/opennms-dao/src/test/resources/META-INF/opennms/applicationContext-AbstractTransactionalTemporaryDatabaseSpringContextTests.xml
@@ -3,7 +3,7 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="
            http://www.springframework.org/schema/beans
-           http://www.springframework.org/schema/beans/spring-beans-4.0.xsd">
+           http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
   <bean id="populatedTemporaryDatabaseTestCase" class="org.opennms.netmgt.dao.db.PopulatedTemporaryDatabaseTestCase" init-method="setUp">
     <property name="setupIpLike" ref="setupIpLike"/>

--- a/opennms-dao/src/test/resources/META-INF/opennms/applicationContext-empty.xml
+++ b/opennms-dao/src/test/resources/META-INF/opennms/applicationContext-empty.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans-4.0.xsd">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
         
 </beans>

--- a/opennms-dao/src/test/resources/upsertTest-context.xml
+++ b/opennms-dao/src/test/resources/upsertTest-context.xml
@@ -5,9 +5,9 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:util="http://www.springframework.org/schema/util"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
-       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
-       http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.0.xsd
+       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
+       http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.1.xsd
        ">
 
   <tx:annotation-driven />

--- a/opennms-enterprise-reporting/opennms-reportd/src/main/resources/META-INF/opennms/applicationContext-reportd.xml
+++ b/opennms-enterprise-reporting/opennms-reportd/src/main/resources/META-INF/opennms/applicationContext-reportd.xml
@@ -4,8 +4,8 @@
        xmlns:tx="http://www.springframework.org/schema/tx" 
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
-       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd"
+       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd"
        >
 
   <tx:annotation-driven />

--- a/opennms-enterprise-reporting/opennms-reportd/src/main/resources/beanRefContext.xml
+++ b/opennms-enterprise-reporting/opennms-reportd/src/main/resources/beanRefContext.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans-4.0.xsd" default-lazy-init="true">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd" default-lazy-init="true">
         
    <bean id="reportdContext" class="org.springframework.context.support.ClassPathXmlApplicationContext">
      <constructor-arg>

--- a/opennms-icmp/opennms-icmp-proxy-rpc-impl/src/main/resources/META-INF/opennms/applicationContext-rpc-icmp.xml
+++ b/opennms-icmp/opennms-icmp-proxy-rpc-impl/src/main/resources/META-INF/opennms/applicationContext-rpc-icmp.xml
@@ -5,8 +5,8 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:onmsgi="http://xmlns.opennms.org/xsd/spring/onms-osgi"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
-       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
+       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
        http://xmlns.opennms.org/xsd/spring/onms-osgi http://xmlns.opennms.org/xsd/spring/onms-osgi.xsd">
 
 	<context:annotation-config />

--- a/opennms-icmp/opennms-icmp-proxy-rpc-impl/src/main/resources/META-INF/opennms/component-dao.xml
+++ b/opennms-icmp/opennms-icmp-proxy-rpc-impl/src/main/resources/META-INF/opennms/component-dao.xml
@@ -5,8 +5,8 @@
        xmlns:util="http://www.springframework.org/schema/util"
        xmlns:onmsgi="http://xmlns.opennms.org/xsd/spring/onms-osgi"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
-       http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.0.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
+       http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.1.xsd
        http://xmlns.opennms.org/xsd/spring/onms-osgi http://xmlns.opennms.org/xsd/spring/onms-osgi.xsd
        ">
 

--- a/opennms-icmp/opennms-icmp-proxy-rpc-impl/src/test/resources/pinger.xml
+++ b/opennms-icmp/opennms-icmp-proxy-rpc-impl/src/test/resources/pinger.xml
@@ -6,10 +6,10 @@
        xmlns:util="http://www.springframework.org/schema/util"
        xmlns:onmsgi="http://xmlns.opennms.org/xsd/spring/onms-osgi"
        xsi:schemaLocation="
-  http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
-  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
-  http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
-  http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.0.xsd
+  http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
+  http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+  http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.1.xsd
   http://xmlns.opennms.org/xsd/spring/onms-osgi http://xmlns.opennms.org/xsd/spring/onms-osgi.xsd
   http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd
 ">

--- a/opennms-jetty/src/main/resources/META-INF/opennms/applicationContext-jettyServer.xml
+++ b/opennms-jetty/src/main/resources/META-INF/opennms/applicationContext-jettyServer.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" 
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
     <bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer" />
 

--- a/opennms-jetty/src/main/resources/beanRefContext.xml
+++ b/opennms-jetty/src/main/resources/beanRefContext.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans-4.0.xsd" default-lazy-init="true">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd" default-lazy-init="true">
 
    <bean id="jettyServerContext" class="org.springframework.context.support.ClassPathXmlApplicationContext">
      <constructor-arg>

--- a/opennms-provision/opennms-detector-bsf/src/main/resources/META-INF/opennms/detectors.xml
+++ b/opennms-provision/opennms-detector-bsf/src/main/resources/META-INF/opennms/detectors.xml
@@ -5,8 +5,8 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="
        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
-       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd">
+       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
 	<context:component-scan base-package="org.opennms.netmgt.provision.detector.bsf"
 	       name-generator="org.opennms.netmgt.provision.support.DetectorBeanNameGenerator"/>

--- a/opennms-provision/opennms-detector-datagram/src/main/resources/META-INF/opennms/detectors.xml
+++ b/opennms-provision/opennms-detector-datagram/src/main/resources/META-INF/opennms/detectors.xml
@@ -5,8 +5,8 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="
        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
-       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd">
+       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
 	<context:component-scan base-package="org.opennms.netmgt.provision.detector.datagram"
 	       name-generator="org.opennms.netmgt.provision.support.DetectorBeanNameGenerator"/>

--- a/opennms-provision/opennms-detector-datagram/src/main/resources/META-INF/opennms/empty-context.xml
+++ b/opennms-provision/opennms-detector-datagram/src/main/resources/META-INF/opennms/empty-context.xml
@@ -5,8 +5,8 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="
        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
-       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd">
+       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
 	<context:component-scan base-package="org.opennms.netmgt.provision.detector.datagram"
 	       name-generator="org.opennms.netmgt.provision.support.DetectorBeanNameGenerator"/>

--- a/opennms-provision/opennms-detector-generic/src/main/resources/META-INF/opennms/detectors.xml
+++ b/opennms-provision/opennms-detector-generic/src/main/resources/META-INF/opennms/detectors.xml
@@ -5,8 +5,8 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="
        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
-       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd">
+       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
 	<context:component-scan base-package="org.opennms.netmgt.provision.detector.generic"
 	       name-generator="org.opennms.netmgt.provision.support.DetectorBeanNameGenerator"/>

--- a/opennms-provision/opennms-detector-jdbc/src/main/resources/META-INF/opennms/detectors.xml
+++ b/opennms-provision/opennms-detector-jdbc/src/main/resources/META-INF/opennms/detectors.xml
@@ -5,8 +5,8 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="
        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
-       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd">
+       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
 	<context:component-scan base-package="org.opennms.netmgt.provision.detector.jdbc" 
             name-generator="org.opennms.netmgt.provision.support.DetectorBeanNameGenerator"/>

--- a/opennms-provision/opennms-detector-jmx/src/main/resources/META-INF/opennms/detectors.xml
+++ b/opennms-provision/opennms-detector-jmx/src/main/resources/META-INF/opennms/detectors.xml
@@ -4,8 +4,8 @@
        xmlns:tx="http://www.springframework.org/schema/tx" 
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
-       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd">
+       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
 	<context:component-scan base-package="org.opennms.netmgt.provision.detector.jmx" 
             name-generator="org.opennms.netmgt.provision.support.DetectorBeanNameGenerator"/>

--- a/opennms-provision/opennms-detector-jmx/src/test/resources/test-spring-jmxconfig.xml
+++ b/opennms-provision/opennms-detector-jmx/src/test/resources/test-spring-jmxconfig.xml
@@ -4,8 +4,8 @@
        xmlns:tx="http://www.springframework.org/schema/tx"
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
-       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd"
+       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd"
         >
 
     <context:annotation-config />

--- a/opennms-provision/opennms-detector-lineoriented/src/main/resources/META-INF/opennms/detectors.xml
+++ b/opennms-provision/opennms-detector-lineoriented/src/main/resources/META-INF/opennms/detectors.xml
@@ -5,8 +5,8 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="
        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
-       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd">
+       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
 	<context:component-scan base-package="org.opennms.netmgt.provision.detector.simple" 
                            name-generator="org.opennms.netmgt.provision.support.DetectorBeanNameGenerator"/>

--- a/opennms-provision/opennms-detector-simple/src/main/resources/META-INF/opennms/detectors.xml
+++ b/opennms-provision/opennms-detector-simple/src/main/resources/META-INF/opennms/detectors.xml
@@ -4,8 +4,8 @@
        xmlns:tx="http://www.springframework.org/schema/tx" 
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
-       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd">
+       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
     <context:component-scan base-package="org.opennms.netmgt.provision.detector.icmp"
       name-generator="org.opennms.netmgt.provision.support.DetectorBeanNameGenerator"/>

--- a/opennms-provision/opennms-detector-simple/src/test/resources/META-INF/opennms/test/detectors.xml
+++ b/opennms-provision/opennms-detector-simple/src/test/resources/META-INF/opennms/test/detectors.xml
@@ -4,8 +4,8 @@
        xmlns:tx="http://www.springframework.org/schema/tx" 
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
-       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd">
+       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
   <context:annotation-config />
 

--- a/opennms-provision/opennms-detector-simple/src/test/resources/META-INF/opennms/test/snmpConfigFactoryContext.xml
+++ b/opennms-provision/opennms-detector-simple/src/test/resources/META-INF/opennms/test/snmpConfigFactoryContext.xml
@@ -4,8 +4,8 @@
        xmlns:tx="http://www.springframework.org/schema/tx" 
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
-       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd">
+       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
     <bean class="org.opennms.netmgt.provision.detector.AnAgentConfigFactory"/>
 	

--- a/opennms-provision/opennms-detector-ssh/src/main/resources/META-INF/opennms/detectors.xml
+++ b/opennms-provision/opennms-detector-ssh/src/main/resources/META-INF/opennms/detectors.xml
@@ -4,8 +4,8 @@
        xmlns:tx="http://www.springframework.org/schema/tx" 
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
-       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd">
+       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
 	<context:component-scan base-package="org.opennms.netmgt.provision.detector.ssh" 
           name-generator="org.opennms.netmgt.provision.support.DetectorBeanNameGenerator" />

--- a/opennms-provision/opennms-detector-web/src/main/resources/META-INF/opennms/detectors.xml
+++ b/opennms-provision/opennms-detector-web/src/main/resources/META-INF/opennms/detectors.xml
@@ -5,8 +5,8 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="
        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
-       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd">
+       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
 	<context:component-scan base-package="org.opennms.netmgt.provision.detector.web"
 	       name-generator="org.opennms.netmgt.provision.support.DetectorBeanNameGenerator"/>

--- a/opennms-provision/opennms-detectorclient-rpc/src/main/resources/META-INF/opennms/applicationContext-rpc-detect.xml
+++ b/opennms-provision/opennms-detectorclient-rpc/src/main/resources/META-INF/opennms/applicationContext-rpc-detect.xml
@@ -5,8 +5,8 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:onmsgi="http://xmlns.opennms.org/xsd/spring/onms-osgi"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
-       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
+       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
        http://xmlns.opennms.org/xsd/spring/onms-osgi http://xmlns.opennms.org/xsd/spring/onms-osgi.xsd">
 
 	<context:annotation-config />

--- a/opennms-provision/opennms-detectorclient-rpc/src/main/resources/META-INF/opennms/applicationContext-rpc-dns.xml
+++ b/opennms-provision/opennms-detectorclient-rpc/src/main/resources/META-INF/opennms/applicationContext-rpc-dns.xml
@@ -5,8 +5,8 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:onmsgi="http://xmlns.opennms.org/xsd/spring/onms-osgi"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
-       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
+       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
        http://xmlns.opennms.org/xsd/spring/onms-osgi http://xmlns.opennms.org/xsd/spring/onms-osgi.xsd">
 
 	<context:annotation-config />

--- a/opennms-provision/opennms-detectorclient-rpc/src/main/resources/META-INF/opennms/provisiond-extensions.xml
+++ b/opennms-provision/opennms-detectorclient-rpc/src/main/resources/META-INF/opennms/provisiond-extensions.xml
@@ -5,8 +5,8 @@
        xmlns:util="http://www.springframework.org/schema/util"
        xmlns:onmsgi="http://xmlns.opennms.org/xsd/spring/onms-osgi"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
-       http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.0.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
+       http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.1.xsd
        http://xmlns.opennms.org/xsd/spring/onms-osgi http://xmlns.opennms.org/xsd/spring/onms-osgi.xsd
        ">
 

--- a/opennms-provision/opennms-detectorclient-rpc/src/test/resources/META-INF/opennms/applicationContext-scan-executor.xml
+++ b/opennms-provision/opennms-detectorclient-rpc/src/test/resources/META-INF/opennms/applicationContext-scan-executor.xml
@@ -4,8 +4,8 @@
        xmlns:tx="http://www.springframework.org/schema/tx" 
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
-       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd">
+       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
     <bean id="scanExecutor" class="java.util.concurrent.Executors" factory-method="newCachedThreadPool"/>
 

--- a/opennms-provision/opennms-detectorclient-rpc/src/test/resources/META-INF/opennms/detectors.xml
+++ b/opennms-provision/opennms-detectorclient-rpc/src/test/resources/META-INF/opennms/detectors.xml
@@ -4,8 +4,8 @@
        xmlns:tx="http://www.springframework.org/schema/tx" 
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
-       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd">
+       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
     <context:component-scan base-package="org.opennms.netmgt.provision.detector.client.rpc"
       name-generator="org.opennms.netmgt.provision.support.DetectorBeanNameGenerator"/>

--- a/opennms-provision/opennms-provision-persistence/src/main/resources/META-INF/opennms/component-dao.xml
+++ b/opennms-provision/opennms-provision-persistence/src/main/resources/META-INF/opennms/component-dao.xml
@@ -3,9 +3,9 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:context="http://www.springframework.org/schema/context"
 	xmlns:tx="http://www.springframework.org/schema/tx"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
-       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
-       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
 	<context:annotation-config />
 

--- a/opennms-provision/opennms-provision-persistence/src/main/resources/META-INF/opennms/provisiond-extensions.xml
+++ b/opennms-provision/opennms-provision-persistence/src/main/resources/META-INF/opennms/provisiond-extensions.xml
@@ -5,8 +5,8 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="
        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
-       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd">
+       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
 	<context:component-scan base-package="org.opennms.netmgt.provision.persist.policies" 
                            name-generator="org.opennms.netmgt.provision.support.DetectorBeanNameGenerator"/>

--- a/opennms-provision/opennms-provision-persistence/src/test/resources/mockForeignSourceContext.xml
+++ b/opennms-provision/opennms-provision-persistence/src/test/resources/mockForeignSourceContext.xml
@@ -4,8 +4,8 @@
        xmlns:tx="http://www.springframework.org/schema/tx" 
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
-       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd"
+       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd"
        >
 
   <context:annotation-config/>

--- a/opennms-provision/opennms-provision-persistence/src/test/resources/org/opennms/netmgt/provision/persist/emptyContext.xml
+++ b/opennms-provision/opennms-provision-persistence/src/test/resources/org/opennms/netmgt/provision/persist/emptyContext.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans-4.0.xsd">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 </beans>

--- a/opennms-provision/opennms-provision-persistence/src/test/resources/testForeignSourceContext.xml
+++ b/opennms-provision/opennms-provision-persistence/src/test/resources/testForeignSourceContext.xml
@@ -3,8 +3,8 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tx="http://www.springframework.org/schema/tx"
 	xmlns:context="http://www.springframework.org/schema/context"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
-       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd">
+       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
 	<context:annotation-config />
 

--- a/opennms-provision/opennms-provisiond/src/main/resources/META-INF/opennms/applicationContext-provisiond.xml
+++ b/opennms-provision/opennms-provisiond/src/main/resources/META-INF/opennms/applicationContext-provisiond.xml
@@ -3,9 +3,9 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:tx="http://www.springframework.org/schema/tx" 
        xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
-       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
-       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd"
        >
 
   <tx:annotation-driven />

--- a/opennms-provision/opennms-provisiond/src/main/resources/META-INF/opennms/empty-context.xml
+++ b/opennms-provision/opennms-provisiond/src/main/resources/META-INF/opennms/empty-context.xml
@@ -5,8 +5,8 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="
        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
-       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd">
+       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
 	<context:component-scan base-package="org.opennms.netmgt.provision.detector.datagram"
 	       name-generator="org.opennms.netmgt.provision.support.DetectorBeanNameGenerator"/>

--- a/opennms-provision/opennms-provisiond/src/main/resources/beanRefContext.xml
+++ b/opennms-provision/opennms-provisiond/src/main/resources/beanRefContext.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans-4.0.xsd" default-lazy-init="true">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd" default-lazy-init="true">
         
    <bean id="provisiondContext" class="org.springframework.context.support.ClassPathXmlApplicationContext">
      <constructor-arg>

--- a/opennms-provision/opennms-provisiond/src/test/resources/importerServiceTest.xml
+++ b/opennms-provision/opennms-provisiond/src/test/resources/importerServiceTest.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans" 
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:tx="http://www.springframework.org/schema/tx" 
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
-       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd">
   
   <bean id="importResource" class="org.springframework.core.io.ClassPathResource">
     <constructor-arg><value>/tec_dump.xml.smalltest</value></constructor-arg>

--- a/opennms-provision/opennms-snmp-scanners/src/test/resources/emptyContext.xml
+++ b/opennms-provision/opennms-snmp-scanners/src/test/resources/emptyContext.xml
@@ -3,4 +3,4 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="
            http://www.springframework.org/schema/beans
-           http://www.springframework.org/schema/beans/spring-beans-4.0.xsd"/>
+           http://www.springframework.org/schema/beans/spring-beans-4.1.xsd"/>

--- a/opennms-reporting/src/main/resources/META-INF/opennms/standaloneApplicationContext-reporting.xml
+++ b/opennms-reporting/src/main/resources/META-INF/opennms/standaloneApplicationContext-reporting.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:context="http://www.springframework.org/schema/context"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
-	http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
+	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+	http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
 ">
 
     <bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">

--- a/opennms-rrd/opennms-rrd-api/pom.xml
+++ b/opennms-rrd/opennms-rrd-api/pom.xml
@@ -27,7 +27,7 @@
               Add all optional imports of RRD strategies to the import list as well.
             -->
             <Import-Package>
-              org.springframework.beans.factory.config;version="[4.0,4.1)",
+              org.springframework.beans.factory.config;version="[4.1,4.2)",
               org.opennms.netmgt.rrd.jrobin;resolution:=optional,
               org.opennms.netmgt.rrd.rrdtool;resolution:=optional,
               org.opennms.netmgt.rrd.tcp;resolution:=optional,

--- a/opennms-rrd/opennms-rrd-api/src/main/resources/META-INF/opennms/applicationContext-rrd.xml
+++ b/opennms-rrd/opennms-rrd-api/src/main/resources/META-INF/opennms/applicationContext-rrd.xml
@@ -3,8 +3,8 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:onmsgi="http://xmlns.opennms.org/xsd/spring/onms-osgi"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
-       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
        http://xmlns.opennms.org/xsd/spring/onms-osgi http://xmlns.opennms.org/xsd/spring/onms-osgi.xsd
        ">
 

--- a/opennms-rrd/opennms-rrd-api/src/main/resources/META-INF/opennms/component-rrd-tcp.xml
+++ b/opennms-rrd/opennms-rrd-api/src/main/resources/META-INF/opennms/component-rrd-tcp.xml
@@ -3,7 +3,7 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
        ">
 
     <context:annotation-config />

--- a/opennms-services/src/main/resources/META-INF/opennms/applicationContext-collectd.xml
+++ b/opennms-services/src/main/resources/META-INF/opennms/applicationContext-collectd.xml
@@ -8,11 +8,11 @@
   xmlns:jdbc="http://www.springframework.org/schema/jdbc" 
   xmlns:onmsgi="http://xmlns.opennms.org/xsd/spring/onms-osgi"
   xsi:schemaLocation="
-  http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
-  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
-  http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
-  http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.0.xsd
-  http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-4.0.xsd
+  http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
+  http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+  http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.1.xsd
+  http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-4.1.xsd
   http://xmlns.opennms.org/xsd/spring/onms-osgi http://xmlns.opennms.org/xsd/spring/onms-osgi.xsd
 ">
 

--- a/opennms-services/src/main/resources/META-INF/opennms/applicationContext-enhancedLinkd.xml
+++ b/opennms-services/src/main/resources/META-INF/opennms/applicationContext-enhancedLinkd.xml
@@ -7,11 +7,11 @@
   xmlns:aop="http://www.springframework.org/schema/aop"
   xmlns:onmsgi="http://xmlns.opennms.org/xsd/spring/onms-osgi"
   xsi:schemaLocation="
-  http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
-  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
-  http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
-  http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.0.xsd
-  http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-4.0.xsd
+  http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
+  http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+  http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.1.xsd
+  http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-4.1.xsd
   http://xmlns.opennms.org/xsd/spring/onms-osgi http://xmlns.opennms.org/xsd/spring/onms-osgi.xsd
   ">
 

--- a/opennms-services/src/main/resources/META-INF/opennms/applicationContext-notifd.xml
+++ b/opennms-services/src/main/resources/META-INF/opennms/applicationContext-notifd.xml
@@ -8,11 +8,11 @@
   xmlns:jdbc="http://www.springframework.org/schema/jdbc" 
   xmlns:onmsgi="http://xmlns.opennms.org/xsd/spring/onms-osgi"
   xsi:schemaLocation="
-  http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
-  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
-  http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
-  http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.0.xsd
-  http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-4.0.xsd
+  http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
+  http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+  http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.1.xsd
+  http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-4.1.xsd
   http://xmlns.opennms.org/xsd/spring/onms-osgi http://xmlns.opennms.org/xsd/spring/onms-osgi.xsd
 ">
 

--- a/opennms-services/src/main/resources/META-INF/opennms/applicationContext-pollerd.xml
+++ b/opennms-services/src/main/resources/META-INF/opennms/applicationContext-pollerd.xml
@@ -8,11 +8,11 @@
   xmlns:jdbc="http://www.springframework.org/schema/jdbc" 
   xmlns:onmsgi="http://xmlns.opennms.org/xsd/spring/onms-osgi"
   xsi:schemaLocation="
-  http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
-  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
-  http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
-  http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.0.xsd
-  http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-4.0.xsd
+  http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
+  http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+  http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.1.xsd
+  http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-4.1.xsd
   http://xmlns.opennms.org/xsd/spring/onms-osgi http://xmlns.opennms.org/xsd/spring/onms-osgi.xsd
 ">
 

--- a/opennms-services/src/main/resources/META-INF/opennms/applicationContext-queued.xml
+++ b/opennms-services/src/main/resources/META-INF/opennms/applicationContext-queued.xml
@@ -8,11 +8,11 @@
   xmlns:jdbc="http://www.springframework.org/schema/jdbc" 
   xmlns:onmsgi="http://xmlns.opennms.org/xsd/spring/onms-osgi"
   xsi:schemaLocation="
-  http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
-  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
-  http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
-  http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.0.xsd
-  http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-4.0.xsd
+  http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
+  http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+  http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.1.xsd
+  http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-4.1.xsd
   http://xmlns.opennms.org/xsd/spring/onms-osgi http://xmlns.opennms.org/xsd/spring/onms-osgi.xsd
 ">
 

--- a/opennms-services/src/main/resources/META-INF/opennms/applicationContext-snmpinterfacepollerd.xml
+++ b/opennms-services/src/main/resources/META-INF/opennms/applicationContext-snmpinterfacepollerd.xml
@@ -8,11 +8,11 @@
   xmlns:jdbc="http://www.springframework.org/schema/jdbc" 
   xmlns:onmsgi="http://xmlns.opennms.org/xsd/spring/onms-osgi"
   xsi:schemaLocation="
-  http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
-  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
-  http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
-  http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.0.xsd
-  http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-4.0.xsd
+  http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
+  http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+  http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.1.xsd
+  http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-4.1.xsd
   http://xmlns.opennms.org/xsd/spring/onms-osgi http://xmlns.opennms.org/xsd/spring/onms-osgi.xsd
 ">
 

--- a/opennms-services/src/main/resources/META-INF/opennms/applicationContext-statisticsDaemon.xml
+++ b/opennms-services/src/main/resources/META-INF/opennms/applicationContext-statisticsDaemon.xml
@@ -8,11 +8,11 @@
   xmlns:jdbc="http://www.springframework.org/schema/jdbc" 
   xmlns:onmsgi="http://xmlns.opennms.org/xsd/spring/onms-osgi"
   xsi:schemaLocation="
-  http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
-  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
-  http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
-  http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.0.xsd
-  http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-4.0.xsd
+  http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
+  http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+  http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.1.xsd
+  http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-4.1.xsd
   http://xmlns.opennms.org/xsd/spring/onms-osgi http://xmlns.opennms.org/xsd/spring/onms-osgi.xsd
 ">
 

--- a/opennms-services/src/main/resources/META-INF/opennms/applicationContext-tl1Daemon.xml
+++ b/opennms-services/src/main/resources/META-INF/opennms/applicationContext-tl1Daemon.xml
@@ -8,11 +8,11 @@
   xmlns:jdbc="http://www.springframework.org/schema/jdbc" 
   xmlns:onmsgi="http://xmlns.opennms.org/xsd/spring/onms-osgi"
   xsi:schemaLocation="
-  http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
-  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
-  http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
-  http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.0.xsd
-  http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-4.0.xsd
+  http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
+  http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+  http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.1.xsd
+  http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-4.1.xsd
   http://xmlns.opennms.org/xsd/spring/onms-osgi http://xmlns.opennms.org/xsd/spring/onms-osgi.xsd
 ">
   

--- a/opennms-services/src/main/resources/beanRefContext.xml
+++ b/opennms-services/src/main/resources/beanRefContext.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans-4.0.xsd" default-lazy-init="true">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd" default-lazy-init="true">
         
    <bean id="collectdContext" class="org.springframework.context.support.ClassPathXmlApplicationContext">
      <constructor-arg>

--- a/opennms-services/src/test/resources/META-INF/opennms/applicationContext-collectdTest.xml
+++ b/opennms-services/src/test/resources/META-INF/opennms/applicationContext-collectdTest.xml
@@ -8,11 +8,11 @@
   xmlns:jdbc="http://www.springframework.org/schema/jdbc" 
   xmlns:onmsgi="http://xmlns.opennms.org/xsd/spring/onms-osgi"
   xsi:schemaLocation="
-  http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
-  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
-  http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
-  http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.0.xsd
-  http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-4.0.xsd
+  http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
+  http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+  http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.1.xsd
+  http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-4.1.xsd
   http://xmlns.opennms.org/xsd/spring/onms-osgi http://xmlns.opennms.org/xsd/spring/onms-osgi.xsd
 ">
 

--- a/opennms-services/src/test/resources/META-INF/opennms/applicationContext-enhancedLinkdTest.xml
+++ b/opennms-services/src/test/resources/META-INF/opennms/applicationContext-enhancedLinkdTest.xml
@@ -6,11 +6,11 @@
 	xmlns:aop="http://www.springframework.org/schema/aop"
        xmlns:context="http://www.springframework.org/schema/context"
 	xsi:schemaLocation="
-	http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
-	http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
-	http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
-	http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.0.xsd
-	http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-4.0.xsd
+	http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+	http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+	http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
+	http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.1.xsd
+	http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-4.1.xsd
 	">
 
     <context:annotation-config />

--- a/opennms-services/src/test/resources/META-INF/opennms/applicationContext-notifdTest.xml
+++ b/opennms-services/src/test/resources/META-INF/opennms/applicationContext-notifdTest.xml
@@ -8,11 +8,11 @@
   xmlns:jdbc="http://www.springframework.org/schema/jdbc" 
   xmlns:onmsgi="http://xmlns.opennms.org/xsd/spring/onms-osgi"
   xsi:schemaLocation="
-  http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
-  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
-  http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
-  http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.0.xsd
-  http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-4.0.xsd
+  http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
+  http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+  http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.1.xsd
+  http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-4.1.xsd
   http://xmlns.opennms.org/xsd/spring/onms-osgi http://xmlns.opennms.org/xsd/spring/onms-osgi.xsd
 ">
 

--- a/opennms-services/src/test/resources/META-INF/opennms/applicationContext-pollerdTest.xml
+++ b/opennms-services/src/test/resources/META-INF/opennms/applicationContext-pollerdTest.xml
@@ -8,11 +8,11 @@
   xmlns:jdbc="http://www.springframework.org/schema/jdbc" 
   xmlns:onmsgi="http://xmlns.opennms.org/xsd/spring/onms-osgi"
   xsi:schemaLocation="
-  http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
-  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
-  http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
-  http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.0.xsd
-  http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-4.0.xsd
+  http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
+  http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+  http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.1.xsd
+  http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-4.1.xsd
   http://xmlns.opennms.org/xsd/spring/onms-osgi http://xmlns.opennms.org/xsd/spring/onms-osgi.xsd
 ">
 

--- a/opennms-services/src/test/resources/META-INF/opennms/applicationContext-serviceMonitorRegistry.xml
+++ b/opennms-services/src/test/resources/META-INF/opennms/applicationContext-serviceMonitorRegistry.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="
-  http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
+  http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
 ">
     
     <bean id="serviceMonitorRegistry" class="org.opennms.netmgt.poller.support.DefaultServiceMonitorRegistry" />

--- a/opennms-services/src/test/resources/META-INF/opennms/capsdTest.xml
+++ b/opennms-services/src/test/resources/META-INF/opennms/capsdTest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
 	<bean id="capsdConfigStream" class="org.opennms.core.test.ConfigurationTestUtils" factory-method="getInputStreamForResource">
 		<!-- Dummy string value that will fetch the current classloader -->

--- a/opennms-services/src/test/resources/loginTestWar/WEB-INF/applicationContext-security.xml
+++ b/opennms-services/src/test/resources/loginTestWar/WEB-INF/applicationContext-security.xml
@@ -2,7 +2,7 @@
 <beans:beans xmlns:beans="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns="http://www.springframework.org/schema/security"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
+	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
 		http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security-3.2.xsd">
 
   <http pattern="/**" auto-config='true'>

--- a/opennms-services/src/test/resources/org/opennms/netmgt/utils/applicationContext-testTAEventForwarderTest.xml
+++ b/opennms-services/src/test/resources/org/opennms/netmgt/utils/applicationContext-testTAEventForwarderTest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 	
     <bean name="transactionAwareForwarder" class="org.opennms.netmgt.dao.TransactionAwareEventForwarder">
         <property name="eventForwarder" ref="eventForwarder" />

--- a/opennms-services/src/test/resources/org/opennms/spring/xml/applicationContext-testAOP.xml
+++ b/opennms-services/src/test/resources/org/opennms/spring/xml/applicationContext-testAOP.xml
@@ -6,10 +6,10 @@
        xmlns:onmsgi="http://xmlns.opennms.org/xsd/spring/onms-osgi"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
-       http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.0.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
+       http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.1.xsd
        http://xmlns.opennms.org/xsd/spring/onms-osgi http://xmlns.opennms.org/xsd/spring/onms-osgi.xsd
-       http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-4.0.xsd
+       http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-4.1.xsd
        ">
 
     <context:annotation-config />

--- a/opennms-tools/access-point-monitor/src/main/resources/META-INF/opennms/applicationContext-accesspointmonitord.xml
+++ b/opennms-tools/access-point-monitor/src/main/resources/META-INF/opennms/applicationContext-accesspointmonitord.xml
@@ -6,11 +6,11 @@
 	xmlns:util="http://www.springframework.org/schema/util"
 	xmlns:aop="http://www.springframework.org/schema/aop"
 	xsi:schemaLocation="
-	http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
-	http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
-	http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
-	http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.0.xsd
-	http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-4.0.xsd
+	http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+	http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
+	http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+	http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.1.xsd
+	http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-4.1.xsd
 	">
 
     <aop:aspectj-autoproxy proxy-target-class="true"/>

--- a/opennms-tools/access-point-monitor/src/main/resources/META-INF/opennms/component-dao.xml
+++ b/opennms-tools/access-point-monitor/src/main/resources/META-INF/opennms/component-dao.xml
@@ -5,8 +5,8 @@
         xmlns:tx="http://www.springframework.org/schema/tx"
         xsi:schemaLocation="
             http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-                http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
-            http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
+                http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
+            http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
         ">
 
   <context:annotation-config />

--- a/opennms-tools/access-point-monitor/src/main/resources/META-INF/opennms/component-service.xml
+++ b/opennms-tools/access-point-monitor/src/main/resources/META-INF/opennms/component-service.xml
@@ -4,9 +4,9 @@
 	xmlns:context="http://www.springframework.org/schema/context"
 	xmlns:tx="http://www.springframework.org/schema/tx" 
 	xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
-        http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
+        http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
  	">
  	
   <tx:annotation-driven />

--- a/opennms-tools/access-point-monitor/src/main/resources/beanRefContext.xml
+++ b/opennms-tools/access-point-monitor/src/main/resources/beanRefContext.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans-4.0.xsd" default-lazy-init="true">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd" default-lazy-init="true">
         
    <bean id="accesspointmonitordContext" class="org.springframework.context.support.ClassPathXmlApplicationContext">
      <constructor-arg>

--- a/opennms-tools/access-point-monitor/src/test/resources/META-INF/opennms/applicationContext-accessPointDatabasePopulator.xml
+++ b/opennms-tools/access-point-monitor/src/test/resources/META-INF/opennms/applicationContext-accessPointDatabasePopulator.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans-4.0.xsd">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
    <bean id="accessPointDatabasePopulator" class="org.opennms.netmgt.accesspointmonitor.rest.AccessPointDatabasePopulator">
       <property name="accessPointDao" ref="accessPointDao" />

--- a/opennms-tools/access-point-monitor/src/test/resources/beanRefContext.xml
+++ b/opennms-tools/access-point-monitor/src/test/resources/beanRefContext.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans-4.0.xsd" default-lazy-init="true">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd" default-lazy-init="true">
         
    <bean id="testDaoContext" class="org.springframework.context.support.ClassPathXmlApplicationContext">
      <constructor-arg>

--- a/opennms-tools/access-point-monitor/src/test/resources/testContext.xml
+++ b/opennms-tools/access-point-monitor/src/test/resources/testContext.xml
@@ -5,10 +5,10 @@
 	xmlns:util="http://www.springframework.org/schema/util"
 	xmlns:aop="http://www.springframework.org/schema/aop"
 	xsi:schemaLocation="
-	http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
-	http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
-	http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.0.xsd
-	http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-4.0.xsd
+	http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+	http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+	http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.1.xsd
+	http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-4.1.xsd
 	">
 
     <bean id="accessPointDao" class="org.opennms.netmgt.dao.MockAccessPointDao" />

--- a/opennms-tools/opennms-qosdaemon/src/main/resources/org/openoss/opennms/spring/qosd/ossjTypeSpecificationApplicationContext.xml
+++ b/opennms-tools/opennms-qosdaemon/src/main/resources/org/openoss/opennms/spring/qosd/ossjTypeSpecificationApplicationContext.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans-4.0.xsd">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
 
 	<!-- *************************************** -->

--- a/opennms-tools/opennms-qosdaemon/src/main/resources/org/openoss/opennms/spring/qosd/qosd-j2ee-context.xml
+++ b/opennms-tools/opennms-qosdaemon/src/main/resources/org/openoss/opennms/spring/qosd/qosd-j2ee-context.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans-4.0.xsd">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
 <!--
 	<import resource="applicationContext-dao.xml" />

--- a/opennms-tools/opennms-qosdaemon/src/main/resources/org/openoss/opennms/spring/qosd/qosd-spring-context.xml
+++ b/opennms-tools/opennms-qosdaemon/src/main/resources/org/openoss/opennms/spring/qosd/qosd-spring-context.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans-4.0.xsd">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
 <!--
 	<import resource="applicationContext-dao.xml" />

--- a/opennms-tools/opennms-qosdaemon/src/main/resources/org/openoss/opennms/spring/qosdrx/qosdrx-spring-context.xml
+++ b/opennms-tools/opennms-qosdaemon/src/main/resources/org/openoss/opennms/spring/qosdrx/qosdrx-spring-context.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans-4.0.xsd">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
 <!-- 
 	<import resource="applicationContext-dao.xml" />

--- a/opennms-tools/opennms-qosdaemon/src/test/resources/org/openoss/opennms/spring/qosd/QoSDTest-context.xml
+++ b/opennms-tools/opennms-qosdaemon/src/test/resources/org/openoss/opennms/spring/qosd/QoSDTest-context.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd">
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 	<bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
 		<!-- Installed from src/test/resources -->
 		<property name="location" value="classpath:qosd.properties"/>

--- a/opennms-tools/opennms-tip/opennms-tip-ram/src/main/webapp/WEB-INF/app-context.xml
+++ b/opennms-tools/opennms-tip/opennms-tip-ram/src/main/webapp/WEB-INF/app-context.xml
@@ -3,9 +3,9 @@
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:context="http://www.springframework.org/schema/context"
   xmlns:jaxws="http://cxf.apache.org/jaxws"
   xsi:schemaLocation="http://www.springframework.org/schema/beans
-           http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
+           http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
            http://www.springframework.org/schema/context
-           http://www.springframework.org/schema/context/spring-context-4.0.xsd
+           http://www.springframework.org/schema/context/spring-context-4.1.xsd
            http://cxf.apache.org/jaxws
            http://cxf.apache.org/schemas/jaxws.xsd">
 

--- a/opennms-tools/opennms-tip/opennms-tip-ram/src/main/webapp/WEB-INF/applicationContext-tip-ram.xml
+++ b/opennms-tools/opennms-tip/opennms-tip-ram/src/main/webapp/WEB-INF/applicationContext-tip-ram.xml
@@ -5,9 +5,9 @@
        xmlns:tx="http://www.springframework.org/schema/tx"
        xmlns:util="http://www.springframework.org/schema/util"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
-       http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.0.xsd
-       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
+       http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.1.xsd
+       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
 ">
 
   <tx:annotation-driven />

--- a/opennms-tools/opennms-tip/opennms-tip-ram/src/test/resources/daoTestAppContext.xml
+++ b/opennms-tools/opennms-tip/opennms-tip-ram/src/test/resources/daoTestAppContext.xml
@@ -5,9 +5,9 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-           http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
+           http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
            http://www.springframework.org/schema/context
-           http://www.springframework.org/schema/context/spring-context-4.0.xsd">
+           http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
   <context:annotation-config/>
 

--- a/opennms-tools/opennms-tip/opennms-tip-ram/src/test/resources/soapImplAppContext.xml
+++ b/opennms-tools/opennms-tip/opennms-tip-ram/src/test/resources/soapImplAppContext.xml
@@ -3,9 +3,9 @@
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:context="http://www.springframework.org/schema/context"
   xmlns:jaxws="http://cxf.apache.org/jaxws"
   xsi:schemaLocation="http://www.springframework.org/schema/beans
-           http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
+           http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
            http://www.springframework.org/schema/context
-           http://www.springframework.org/schema/context/spring-context-4.0.xsd
+           http://www.springframework.org/schema/context/spring-context-4.1.xsd
            http://cxf.apache.org/jaxws
            http://cxf.apache.org/schemas/jaxws.xsd">
 

--- a/opennms-webapp-rest/src/main/webapp/WEB-INF/applicationContext-cxf-common.xml
+++ b/opennms-webapp-rest/src/main/webapp/WEB-INF/applicationContext-cxf-common.xml
@@ -6,10 +6,10 @@
         xmlns:util="http://www.springframework.org/schema/util"
         xmlns:cxf="http://cxf.apache.org/core"
         xmlns:jaxrs="http://cxf.apache.org/jaxrs"
-        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
-                http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
-                http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
-                http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.0.xsd
+        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+                http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
+                http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+                http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.1.xsd
                 http://cxf.apache.org/core http://cxf.apache.org/schemas/core.xsd
                 http://cxf.apache.org/jaxrs http://cxf.apache.org/schemas/jaxrs.xsd">
 

--- a/opennms-webapp-rest/src/main/webapp/WEB-INF/applicationContext-cxf-rest-v1.xml
+++ b/opennms-webapp-rest/src/main/webapp/WEB-INF/applicationContext-cxf-rest-v1.xml
@@ -6,10 +6,10 @@
         xmlns:util="http://www.springframework.org/schema/util"
         xmlns:cxf="http://cxf.apache.org/core"
         xmlns:jaxrs="http://cxf.apache.org/jaxrs"
-        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
-                http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
-                http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
-                http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.0.xsd
+        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+                http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
+                http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+                http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.1.xsd
                 http://cxf.apache.org/core http://cxf.apache.org/schemas/core.xsd
                 http://cxf.apache.org/jaxrs http://cxf.apache.org/schemas/jaxrs.xsd">
 

--- a/opennms-webapp-rest/src/main/webapp/WEB-INF/applicationContext-cxf-rest-v2.xml
+++ b/opennms-webapp-rest/src/main/webapp/WEB-INF/applicationContext-cxf-rest-v2.xml
@@ -6,10 +6,10 @@
         xmlns:util="http://www.springframework.org/schema/util"
         xmlns:cxf="http://cxf.apache.org/core"
         xmlns:jaxrs="http://cxf.apache.org/jaxrs"
-        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
-                http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
-                http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
-                http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.0.xsd
+        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+                http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
+                http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+                http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.1.xsd
                 http://cxf.apache.org/core http://cxf.apache.org/schemas/core.xsd
                 http://cxf.apache.org/jaxrs http://cxf.apache.org/schemas/jaxrs.xsd">
 

--- a/opennms-webapp-rest/src/main/webapp/WEB-INF/applicationContext-svclayer.xml
+++ b/opennms-webapp-rest/src/main/webapp/WEB-INF/applicationContext-svclayer.xml
@@ -5,9 +5,9 @@
   xmlns:tx="http://www.springframework.org/schema/tx" 
   xmlns:onmsgi="http://xmlns.opennms.org/xsd/spring/onms-osgi" 
   xsi:schemaLocation="
-    http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
-    http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
-    http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
+    http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+    http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
+    http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
     http://xmlns.opennms.org/xsd/spring/onms-osgi http://xmlns.opennms.org/xsd/spring/onms-osgi.xsd
 ">
 

--- a/opennms-webapp-rest/src/test/resources/applicationContext-rest-test.xml
+++ b/opennms-webapp-rest/src/test/resources/applicationContext-rest-test.xml
@@ -4,7 +4,7 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:context="http://www.springframework.org/schema/context"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
+		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
 	">
 
 	<context:annotation-config />

--- a/opennms-webapp/src/main/resources/org/opennms/web/svclayer/applicationContext-svclayer.xml
+++ b/opennms-webapp/src/main/resources/org/opennms/web/svclayer/applicationContext-svclayer.xml
@@ -4,9 +4,9 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 xmlns:tx="http://www.springframework.org/schema/tx" 
 xmlns:context="http://www.springframework.org/schema/context"
 xmlns:onmsgi="http://xmlns.opennms.org/xsd/spring/onms-osgi" 
-xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
-        http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
-        http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
+xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+        http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+        http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
         http://xmlns.opennms.org/xsd/spring/onms-osgi http://xmlns.opennms.org/xsd/spring/onms-osgi.xsd
 ">
   <tx:annotation-driven/>

--- a/opennms-webapp/src/main/webapp/WEB-INF/applicationContext-common.xml
+++ b/opennms-webapp/src/main/webapp/WEB-INF/applicationContext-common.xml
@@ -4,9 +4,9 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="
            http://www.springframework.org/schema/beans
-           http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
+           http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
            http://www.springframework.org/schema/context
-           http://www.springframework.org/schema/context/spring-context-4.0.xsd">
+           http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
   <bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
     <property name="systemPropertiesModeName" value="SYSTEM_PROPERTIES_MODE_OVERRIDE" />

--- a/opennms-webapp/src/main/webapp/WEB-INF/applicationContext-spring-security.xml
+++ b/opennms-webapp/src/main/webapp/WEB-INF/applicationContext-spring-security.xml
@@ -3,7 +3,7 @@
   xmlns:beans="http://www.springframework.org/schema/beans"
   xmlns:onmsgi="http://xmlns.opennms.org/xsd/spring/onms-osgi"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
+  xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
               http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security-3.2.xsd
               http://xmlns.opennms.org/xsd/spring/onms-osgi http://xmlns.opennms.org/xsd/spring/onms-osgi.xsd">
   

--- a/opennms-webapp/src/main/webapp/WEB-INF/applicationContext-spring-webflow.xml
+++ b/opennms-webapp/src/main/webapp/WEB-INF/applicationContext-spring-webflow.xml
@@ -4,7 +4,7 @@
        xmlns:webflow="http://www.springframework.org/schema/webflow-config"
        xsi:schemaLocation="
            http://www.springframework.org/schema/beans
-           http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
+           http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
            http://www.springframework.org/schema/webflow-config
            http://www.springframework.org/schema/webflow-config/spring-webflow-config-2.3.xsd">		
 

--- a/opennms-webapp/src/main/webapp/WEB-INF/dispatcher-servlet.xml
+++ b/opennms-webapp/src/main/webapp/WEB-INF/dispatcher-servlet.xml
@@ -4,9 +4,9 @@
        xmlns:tx="http://www.springframework.org/schema/tx"
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:onmsgi="http://xmlns.opennms.org/xsd/spring/onms-osgi" 
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
-       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
-       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd
        http://xmlns.opennms.org/xsd/spring/onms-osgi http://xmlns.opennms.org/xsd/spring/onms-osgi.xsd"
         >
 

--- a/opennms-webapp/src/main/webapp/WEB-INF/spring-security.d/sso_activeDirectory_kerb_ldap.xml.disabled
+++ b/opennms-webapp/src/main/webapp/WEB-INF/spring-security.d/sso_activeDirectory_kerb_ldap.xml.disabled
@@ -3,8 +3,8 @@
   xmlns:sec="http://www.springframework.org/schema/security"
   xmlns:context="http://www.springframework.org/schema/context"
   xsi:schemaLocation="http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd
-    http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
-    http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd">
+    http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+    http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
 <!--
      Example context for performing single sign-on (SSO) in an Active

--- a/opennms-webapp/src/main/webapp/WEB-INF/spring-security.d/sso_freeIPA_kerb_ldap.xml.disabled
+++ b/opennms-webapp/src/main/webapp/WEB-INF/spring-security.d/sso_freeIPA_kerb_ldap.xml.disabled
@@ -3,8 +3,8 @@
   xmlns:sec="http://www.springframework.org/schema/security"
   xmlns:context="http://www.springframework.org/schema/context"
   xsi:schemaLocation="http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd
-    http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
-    http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd">
+    http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+    http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
 <!--
      Example context for performing single sign-on (SSO) in a FreeIPA

--- a/opennms-webapp/src/test/resources/applicationContext-ldapTest.xml
+++ b/opennms-webapp/src/test/resources/applicationContext-ldapTest.xml
@@ -2,7 +2,7 @@
 <beans:beans xmlns="http://www.springframework.org/schema/security"
   xmlns:beans="http://www.springframework.org/schema/beans"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
+  xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
               http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security-3.2.xsd"> 
 
   <http pattern="/**" auto-config="true">

--- a/opennms-webapp/src/test/resources/org/opennms/dashboard/applicationContext-svclayer-dashboard-test.xml
+++ b/opennms-webapp/src/test/resources/org/opennms/dashboard/applicationContext-svclayer-dashboard-test.xml
@@ -3,7 +3,7 @@
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
      xmlns:tx="http://www.springframework.org/schema/tx" 
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd">
+       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd">
 
   <tx:annotation-driven />
   

--- a/opennms-webapp/src/test/resources/org/opennms/web/svclayer/schedulerServiceTest.xml
+++ b/opennms-webapp/src/test/resources/org/opennms/web/svclayer/schedulerServiceTest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans-4.0.xsd">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 
   <bean id="schedulerService" class="org.opennms.web.svclayer.support.DefaultSchedulerService">
 	<property name="scheduler" ref="schedulerFactory" />

--- a/opennms-webapp/src/test/resources/osgiTestWar/WEB-INF/applicationContext-security.xml
+++ b/opennms-webapp/src/test/resources/osgiTestWar/WEB-INF/applicationContext-security.xml
@@ -2,7 +2,7 @@
 <beans:beans xmlns:beans="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns="http://www.springframework.org/schema/security"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
+	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
 		http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security-3.2.xsd">
 
   <http pattern="/**" auto-config='true'>

--- a/opennms-webapp/src/test/resources/testSiteStatusServiceContext.xml
+++ b/opennms-webapp/src/test/resources/testSiteStatusServiceContext.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="
-      http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
+      http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
   "> 
 
   <bean id="siteStatusViewConfigDao" class="org.opennms.netmgt.dao.jaxb.DefaultSiteStatusViewConfigDao"/>

--- a/opennms-wmi/src/main/resources/META-INF/opennms/detectors.xml
+++ b/opennms-wmi/src/main/resources/META-INF/opennms/detectors.xml
@@ -5,8 +5,8 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="
        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
-       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd">
+       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
     <context:component-scan base-package="org.opennms.netmgt.provision.detector.wmi" 
                            name-generator="org.opennms.netmgt.provision.support.DetectorBeanNameGenerator"/>

--- a/pom.xml
+++ b/pom.xml
@@ -1340,9 +1340,9 @@
     <wsdl4jVersion>1.6.3</wsdl4jVersion>
     <wsmanVersion>1.2.2</wsmanVersion>
 
-    <springVersion>4.0.7.RELEASE_1</springVersion>
+    <springVersion>4.1.6.RELEASE_1</springVersion>
     <!-- ALWAYS change aspectj to match the version referenced in the spring poms -->
-    <aspectjVersion>1.7.4</aspectjVersion>
+    <aspectjVersion>1.8.5</aspectjVersion>
     <springWebFlowVersion>2.3.4.RELEASE</springWebFlowVersion>
     <springSecurityVersion>3.2.7.RELEASE</springSecurityVersion>
     <springLdapVersion>${springSecurityVersion}</springLdapVersion>

--- a/protocols/dhcp/src/main/resources/META-INF/opennms/detectors.xml
+++ b/protocols/dhcp/src/main/resources/META-INF/opennms/detectors.xml
@@ -5,8 +5,8 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="
        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
-       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd">
+       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
 	<context:component-scan base-package="org.opennms.protocols.dhcp.detector" 
       name-generator="org.opennms.netmgt.provision.support.DetectorBeanNameGenerator"/>

--- a/protocols/nsclient/src/main/resources/META-INF/opennms/detectors.xml
+++ b/protocols/nsclient/src/main/resources/META-INF/opennms/detectors.xml
@@ -5,8 +5,8 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="
        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
-       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd">
+       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
 	<context:component-scan base-package="org.opennms.protocols.nsclient.detector" 
                            name-generator="org.opennms.netmgt.provision.support.DetectorBeanNameGenerator"/>

--- a/protocols/radius/src/main/resources/META-INF/opennms/detectors.xml
+++ b/protocols/radius/src/main/resources/META-INF/opennms/detectors.xml
@@ -4,8 +4,8 @@
        xmlns:tx="http://www.springframework.org/schema/tx" 
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
-       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd">
+       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd">
 
 	<context:component-scan base-package="org.opennms.protocols.radius.detector" 
             name-generator="org.opennms.netmgt.provision.support.DetectorBeanNameGenerator"/>

--- a/protocols/selenium-monitor/src/test/resources/META-INF/opennms/emptyContext.xml
+++ b/protocols/selenium-monitor/src/test/resources/META-INF/opennms/emptyContext.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://www.springframework.org/schema/beans
-        http://www.springframework.org/schema/beans/spring-beans-4.0.xsd">
+        http://www.springframework.org/schema/beans/spring-beans-4.1.xsd">
 </beans>

--- a/protocols/xml/src/main/resources/META-INF/opennms/component-dao.xml
+++ b/protocols/xml/src/main/resources/META-INF/opennms/component-dao.xml
@@ -4,8 +4,8 @@
        xmlns:tx="http://www.springframework.org/schema/tx" 
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd
-       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd"
+       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
+       http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd"
        >
 
   <context:annotation-config/>

--- a/tests/dao/src/test/resources/applicationContext-alarmStatisticsServiceTest.xml
+++ b/tests/dao/src/test/resources/applicationContext-alarmStatisticsServiceTest.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="
-      http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
+      http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
   "> 
 
   <bean id="alarmStatisticsService" class="org.opennms.netmgt.dao.stats.DefaultAlarmStatisticsService" />


### PR DESCRIPTION
Bump Spring to version 4.1.6. There are no code changes required for this upgrade, only OSGi metadata bumps, Spring schema version bumps, and the version change in pom.xml.

JIRA: https://issues.opennms.org/browse/NMS-9259