### PR TITLE
NMS-9257: Poll every hour instead of deleting the service after being down for 5 days.

### DIFF
--- a/opennms-base-assembly/src/main/filtered/etc/poller-configuration.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/poller-configuration.xml
@@ -59,7 +59,7 @@
     <downtime interval="30000" begin="0" end="300000" /><!-- 30s, 0, 5m -->
     <downtime interval="300000" begin="300000" end="43200000" /><!-- 5m, 5m, 12h -->
     <downtime interval="600000" begin="43200000" end="432000000" /><!-- 10m, 12h, 5d -->
-    <downtime begin="432000000" delete="true" /><!-- anything after 5 days delete -->
+    <downtime interval="3600000" begin="432000000" /><!-- 1h, 5d -->
   </package>
 
   <package name="example1">
@@ -289,7 +289,7 @@
     <downtime interval="30000" begin="0" end="300000" /><!-- 30s, 0, 5m -->
     <downtime interval="300000" begin="300000" end="43200000" /><!-- 5m, 5m, 12h -->
     <downtime interval="600000" begin="43200000" end="432000000" /><!-- 10m, 12h, 5d -->
-    <downtime begin="432000000" delete="true" /><!-- anything after 5 days delete -->
+    <downtime interval="3600000" begin="432000000" /><!-- 1h, 5d -->
 
   </package>
 
@@ -319,7 +319,7 @@
       <parameter key="rrd-base-name" value="strafeping" />
     </service>
     <downtime interval="300000" begin="0" end="432000000"/><!-- 5m, 0, 5d -->
-    <downtime begin="432000000" delete="true" /><!-- anything after 5 days delete -->
+    <downtime interval="3600000" begin="432000000" /><!-- 1h, 5d -->
   </package>
 
 


### PR DESCRIPTION
JIRA: https://issues.opennms.org/browse/NMS-9257

Here we modify the default downtime model to continue polling the service once an hour after a service has been offline for >= 5 days.