### PR TITLE
NMS-9252: Upgrade Newts to 1.4.3

### DIFF
--- a/opennms-doc/guide-admin/src/asciidoc/text/operation/newts/configuration.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/operation/newts/configuration.adoc
@@ -54,6 +54,7 @@ The following properties, found in `${OPENNMS_HOME}/etc/opennms.properties`, can
 | `org.opennms.newts.query.parallelism`           | Number of cores      | Maximum number of threads that can be used to compute aggregates. Defaults to the number of available cores.
 | `org.opennms.newts.config.cache.strategy`       | See bellow           | Canonical name of the class used for resource level caching. See the table bellow for all of the available options.
 | `org.opennms.newts.config.cache.max_entries`    | `8192`               | Maximum number of records to keep in the cache when using an in-memory caching strategy.
+| `org.opennms.newts.nan_on_counter_wrap`         | `false`              | Disables the processing of counter wraps, replacing these with NaNs instead.
 |===
 
 Available caching strategies include:

--- a/pom.xml
+++ b/pom.xml
@@ -1305,7 +1305,7 @@
     <log4jVersion>99.99.99-use-log4j2</log4jVersion>
     <log4j2Version>2.5</log4j2Version>
     <minaVersion>2.0.7</minaVersion>
-    <newtsVersion>1.4.2</newtsVersion>
+    <newtsVersion>1.4.3</newtsVersion>
     <paxExamVersion>4.6.0</paxExamVersion>
     <paxSwissboxVersion>1.8.1</paxSwissboxVersion>
     <postgresqlVersion>9.4.1211</postgresqlVersion>


### PR DESCRIPTION
JIRA: https://issues.opennms.org/browse/NMS-9252

This adds support for globally changing the behavior of counter wraps using a system property. By default, we maintain the existing behavior, but we now have the option to ignore counter wraps and replace these with NaNs, by setting a system property.

Example screenshots are available in the JIRA issue.