### PR TITLE
NMS-9203: Discard expired messages instead of using the DLQ

### DIFF
--- a/opennms-base-assembly/src/main/filtered/etc/opennms-activemq.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/opennms-activemq.xml
@@ -97,6 +97,16 @@
                   </pendingQueuePolicy>
                   -->
                 </policyEntry>
+                <!--
+                  Change the dead-letter strategy to discard messages instead 
+                  of storing them in the DLQ. You can comment out this policyEntry
+                  to reenable the DLQ for troubleshooting.
+                -->
+                <policyEntry queue=">">
+                  <deadLetterStrategy>
+                    <sharedDeadLetterStrategy processExpired="false" />
+                  </deadLetterStrategy>
+                </policyEntry>
               </policyEntries>
             </policyMap>
         </destinationPolicy>


### PR DESCRIPTION
To avoid filling up the kahadb storage limit with expired messages, we should just discard them. Users can reenable the DLQ easily by commenting out the section of ```opennms-activemq.xml```.

* JIRA: http://issues.opennms.org/browse/NMS-9203
