### PR TITLE
NMS-9091: Added StringUtils.toStringEfficiently(Date)

### DIFF
--- a/core/lib/src/main/java/org/opennms/core/utils/StringUtils.java
+++ b/core/lib/src/main/java/org/opennms/core/utils/StringUtils.java
@@ -317,6 +317,27 @@ public abstract class StringUtils {
         return false;
     }
 
+    /**
+     * <p>NMS-9091: This method calls {@link Date#toString()} but then calls
+     * {@link Date#setTime(long)} so that internally, the {@link Date#cdate}
+     * field is deallocated. This saves significant heap space for {@link Date} 
+     * instances that are stored in long-lived collections.</p>
+     * 
+     * <ul>
+     * <li>java.util.Date with only fastTime: 24 bytes</li>
+     * <li>java.util.Date with fastTime and cdate: 120 bytes</li>
+     * </ul>
+     * 
+     * @param date
+     * @return Value of date.toString()
+     */
+    public static String toStringEfficiently(final Date date) {
+        final long time = date.getTime();
+        final String retval = date.toString();
+        date.setTime(time);
+        return retval;
+    }
+
     public static Integer parseDecimalInt(String value) {
         return parseDecimalInt(value, true);
     }

--- a/features/vaadin-dashlets/dashlet-alarms/src/main/java/org/opennms/features/vaadin/dashboard/dashlets/AlarmDetailsDashlet.java
+++ b/features/vaadin-dashlets/dashlet-alarms/src/main/java/org/opennms/features/vaadin/dashboard/dashlets/AlarmDetailsDashlet.java
@@ -42,6 +42,7 @@ import org.opennms.core.criteria.CriteriaBuilder;
 import org.opennms.core.criteria.Fetch;
 import org.opennms.core.criteria.restrictions.InRestriction;
 import org.opennms.core.criteria.restrictions.Restriction;
+import org.opennms.core.utils.StringUtils;
 import org.opennms.features.topology.plugins.browsers.AlarmDaoContainer;
 import org.opennms.features.topology.plugins.browsers.AlarmIdColumnLinkGenerator;
 import org.opennms.features.topology.plugins.browsers.AlarmTable;
@@ -63,7 +64,6 @@ import org.opennms.netmgt.model.OnmsNode;
 import org.opennms.netmgt.model.OnmsSeverity;
 import org.opennms.osgi.EventProxy;
 import org.opennms.osgi.VaadinApplicationContextImpl;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.support.TransactionOperations;
 
 import java.util.LinkedHashMap;
@@ -354,7 +354,7 @@ public class AlarmDetailsDashlet extends AbstractDashlet {
                 sb.append("<td class='alert-details-dashlet onms-cell divider onms' valign='middle' rowspan='1'><nobr>" + onmsAlarm.getSeverity().getLabel() + "</nobr></td>");
                 sb.append("<td class='alert-details-dashlet onms-cell divider onms' valign='middle' rowspan='1'><nobr>" + (onmsNode != null ? onmsNode.getLabel() : "-") + "</nobr></td>");
                 sb.append("<td class='alert-details-dashlet onms-cell divider onms' valign='middle' rowspan='1'><nobr>" + onmsAlarm.getCounter() + "</nobr></td>");
-                sb.append("<td class='alert-details-dashlet onms-cell divider onms' valign='middle' rowspan='1'><nobr>" + onmsAlarm.getLastEventTime().toString() + "</nobr></td>");
+                sb.append("<td class='alert-details-dashlet onms-cell divider onms' valign='middle' rowspan='1'><nobr>" + StringUtils.toStringEfficiently(onmsAlarm.getLastEventTime()) + "</nobr></td>");
                 sb.append("<td class='alert-details-dashlet onms-cell divider onms' valign='middle' rowspan='1'>" + onmsAlarm.getLogMsg().replaceAll("\\<.*?>", "") + "</td>");
                 sb.append("</td></tr>");
             }
@@ -391,13 +391,13 @@ public class AlarmDetailsDashlet extends AbstractDashlet {
         lastEvent.setSizeUndefined();
         lastEvent.addStyleName("alert-details-font");
         lastEvent.setCaption("Last event");
-        lastEvent.setValue(onmsAlarm.getLastEventTime().toString());
+        lastEvent.setValue(StringUtils.toStringEfficiently(onmsAlarm.getLastEventTime()));
 
         Label firstEvent = new Label();
         firstEvent.setSizeUndefined();
         firstEvent.addStyleName("alert-details-font");
         firstEvent.setCaption("First event");
-        firstEvent.setValue(onmsAlarm.getFirstEventTime().toString());
+        firstEvent.setValue(StringUtils.toStringEfficiently(onmsAlarm.getFirstEventTime()));
 
         verticalLayout1.addComponent(firstEvent);
         verticalLayout1.addComponent(lastEvent);

--- a/features/vaadin-dashlets/dashlet-ksc/src/main/java/org/opennms/features/vaadin/dashboard/dashlets/KscDashlet.java
+++ b/features/vaadin-dashlets/dashlet-ksc/src/main/java/org/opennms/features/vaadin/dashboard/dashlets/KscDashlet.java
@@ -33,6 +33,7 @@ import com.vaadin.server.Sizeable.Unit;
 import com.vaadin.shared.ui.label.ContentMode;
 import com.vaadin.ui.*;
 
+import org.opennms.core.utils.StringUtils;
 import org.opennms.features.vaadin.components.graph.GraphContainer;
 import org.opennms.features.vaadin.dashboard.model.AbstractDashlet;
 import org.opennms.features.vaadin.dashboard.model.AbstractDashletComponent;
@@ -201,10 +202,10 @@ public class KscDashlet extends AbstractDashlet {
 
                                 labelTitle.addStyleName("text");
 
-                                Label labelFrom = new Label("From: " + beginTime.getTime().toString());
+                                Label labelFrom = new Label("From: " + StringUtils.toStringEfficiently(beginTime.getTime()));
                                 labelFrom.addStyleName("text");
 
-                                Label labelTo = new Label("To: " + endTime.getTime().toString());
+                                Label labelTo = new Label("To: " + StringUtils.toStringEfficiently(endTime.getTime()));
                                 labelTo.addStyleName("text");
 
                                 Label labelNodeLabel = new Label(data.get("nodeLabel"));
@@ -336,10 +337,10 @@ public class KscDashlet extends AbstractDashlet {
 
                         labelTitle.addStyleName("text");
 
-                        Label labelFrom = new Label("From: " + beginTime.getTime().toString());
+                        Label labelFrom = new Label("From: " + StringUtils.toStringEfficiently(beginTime.getTime()));
                         labelFrom.addStyleName("text");
 
-                        Label labelTo = new Label("To: " + endTime.getTime().toString());
+                        Label labelTo = new Label("To: " + StringUtils.toStringEfficiently(endTime.getTime()));
                         labelTo.addStyleName("text");
 
                         Label labelNodeLabel = new Label(data.get("nodeLabel"));

--- a/opennms-model/src/main/java/org/opennms/netmgt/model/events/EventBuilder.java
+++ b/opennms-model/src/main/java/org/opennms/netmgt/model/events/EventBuilder.java
@@ -36,6 +36,7 @@ import java.util.Date;
 import java.util.List;
 
 import org.opennms.core.time.ZonedDateTimeBuilder;
+import org.opennms.core.utils.StringUtils;
 import org.opennms.netmgt.model.OnmsIpInterface;
 import org.opennms.netmgt.model.OnmsMonitoredService;
 import org.opennms.netmgt.model.OnmsNode;
@@ -54,7 +55,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.BeanWrapper;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.PropertyAccessorFactory;
-import org.springframework.util.StringUtils;
 
 /**
  * <p>EventBuilder class.</p>
@@ -148,7 +148,7 @@ public class EventBuilder {
         events.setEvent(new Event[]{event});
 
         Header header = new Header();
-        header.setCreated(event.getCreationTime().toString());
+        header.setCreated(StringUtils.toStringEfficiently(event.getCreationTime()));
 
         Log log = new Log();
         log.setHeader(header);
@@ -450,7 +450,7 @@ public class EventBuilder {
      * @return a {@link org.opennms.netmgt.model.events.EventBuilder} object.
      */
     public EventBuilder addParam(final String parmName, final Collection<String> vals) {
-    	final String val = StringUtils.collectionToCommaDelimitedString(vals);
+        final String val = org.springframework.util.StringUtils.collectionToCommaDelimitedString(vals);
         return addParam(parmName, val);
         
     }

--- a/opennms-reporting/src/main/java/org/opennms/report/configuration/ConfigurationReportCalculator.java
+++ b/opennms-reporting/src/main/java/org/opennms/report/configuration/ConfigurationReportCalculator.java
@@ -37,6 +37,7 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
 
+import org.opennms.core.utils.StringUtils;
 import org.opennms.core.xml.JaxbUtils;
 import org.opennms.netmgt.config.RWSConfig;
 import org.opennms.rancid.ConnectionProperties;
@@ -238,7 +239,7 @@ public class ConfigurationReportCalculator implements InitializingBean {
 
         rlist = new RwsRancidlistreport();
         rlist.setUser(user);
-        rlist.setReportRequestDate(reportRequestDate.toString());
+        rlist.setReportRequestDate(StringUtils.toStringEfficiently(reportRequestDate));
 
         //parse date
         SimpleDateFormat format = new SimpleDateFormat("yyyy/M/d");

--- a/opennms-reporting/src/main/java/org/opennms/report/configuration/ConfigurationReportRunner.java
+++ b/opennms-reporting/src/main/java/org/opennms/report/configuration/ConfigurationReportRunner.java
@@ -31,8 +31,7 @@ package org.opennms.report.configuration;
 import java.io.IOException;
 import java.util.Date;
 
-
-
+import org.opennms.core.utils.StringUtils;
 import org.opennms.report.ReportMailer;
 import org.opennms.reporting.availability.render.ReportRenderException;
 import org.opennms.reporting.availability.render.ReportRenderer;
@@ -212,7 +211,7 @@ public class ConfigurationReportRunner implements Runnable {
     @Override
     public void run() {
 
-        LOG.debug("run: getting configuration report on Date [{}]. Requested by User: {}on Date {}", theDate, user,  reportRequestDate.toString());
+        LOG.debug("run: getting configuration report on Date [{}]. Requested by User: {}on Date {}", theDate, user, StringUtils.toStringEfficiently(reportRequestDate));
 
         ReportRenderer renderer;
         calculator.setReportRequestDate(reportRequestDate);

--- a/opennms-reporting/src/main/java/org/opennms/report/inventory/InventoryReportCalculator.java
+++ b/opennms-reporting/src/main/java/org/opennms/report/inventory/InventoryReportCalculator.java
@@ -38,6 +38,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.regex.Pattern;
 
+import org.opennms.core.utils.StringUtils;
 import org.opennms.core.xml.JaxbUtils;
 import org.opennms.netmgt.config.RWSConfig;
 import org.opennms.rancid.ConnectionProperties;
@@ -263,7 +264,7 @@ public class InventoryReportCalculator implements InitializingBean {
         
         rnbi = new RwsNbinventoryreport();
         rnbi.setUser(user);
-        rnbi.setReportRequestDate(reportRequestDate.toString());
+        rnbi.setReportRequestDate(StringUtils.toStringEfficiently(reportRequestDate));
 
         boolean withKey = false;
         if (theField.compareTo("")!=0){

--- a/opennms-reporting/src/main/java/org/opennms/report/inventory/InventoryReportRunner.java
+++ b/opennms-reporting/src/main/java/org/opennms/report/inventory/InventoryReportRunner.java
@@ -31,6 +31,7 @@ package org.opennms.report.inventory;
 import java.io.IOException;
 import java.util.Date;
 
+import org.opennms.core.utils.StringUtils;
 import org.opennms.report.ReportMailer;
 import org.opennms.reporting.availability.render.ReportRenderException;
 import org.opennms.reporting.availability.render.ReportRenderer;
@@ -230,7 +231,7 @@ public class InventoryReportRunner implements Runnable {
     @Override
     public void run() {
 
-        LOG.debug("run: getting inventory report on Date [{}] for key [{}]. Requested by User: {}on Date {}", theDate, theField, user, reportRequestDate.toString());
+        LOG.debug("run: getting inventory report on Date [{}] for key [{}]. Requested by User: {}on Date {}", theDate, theField, user, StringUtils.toStringEfficiently(reportRequestDate));
         ReportRenderer renderer;
         calculator.setReportRequestDate(reportRequestDate);
         calculator.setTheDate(theDate);

--- a/opennms-webapp/src/main/java/org/opennms/web/element/Service.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/element/Service.java
@@ -29,6 +29,7 @@
 package org.opennms.web.element;
 
 import org.opennms.core.utils.InetAddressUtils;
+import org.opennms.core.utils.StringUtils;
 import org.opennms.netmgt.model.OnmsMonitoredService;
 
 public class Service {
@@ -58,10 +59,10 @@ public class Service {
         setServiceId(monSvc.getServiceId());
         setServiceName(monSvc.getServiceName());
         if(monSvc.getLastGood() != null) {
-           setLastGood(monSvc.getLastGood().toString());
+           setLastGood(StringUtils.toStringEfficiently(monSvc.getLastGood()));
         }
         if(monSvc.getLastFail() != null) {
-            setLastFail(monSvc.getLastFail().toString());
+            setLastFail(StringUtils.toStringEfficiently(monSvc.getLastFail()));
         }
         setNotify(monSvc.getNotify());
         if(monSvc.getStatus() != null) {

--- a/opennms-webapp/src/main/java/org/opennms/web/filter/DateSqlType.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/filter/DateSqlType.java
@@ -32,6 +32,7 @@ import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.Date;
 
+import org.opennms.core.utils.StringUtils;
 import org.opennms.netmgt.events.api.EventConstants;
 
 /**
@@ -75,7 +76,7 @@ public class DateSqlType implements SQLType<Date> {
      */
     @Override
     public String formatValue(Date value) {
-        return "to_timestamp(\'" + value.toString() + "\', " + EventConstants.POSTGRES_DATE_FORMAT +")";
+        return "to_timestamp(\'" + StringUtils.toStringEfficiently(value) + "\', " + EventConstants.POSTGRES_DATE_FORMAT +")";
     }
 
     /**


### PR DESCRIPTION
To avoid memory bloat of Events in the Eventd backlog, I've added a method that will call java.util.Date.toString() and then call java.util.Date.setTime() to clear internal fields in the Date object to reduce heap space.

The inspiration for this change was a heap dump analysis where ~ 40% of the heap was being consumed by java.util.Date instances inside the Eventd backlog.

* JIRA: http://issues.opennms.org/browse/NMS-9091