### PR TITLE
NMS-9164: handle retries inside trackers

### DIFF
--- a/core/snmp/api/src/main/java/org/opennms/netmgt/snmp/AggregateTracker.java
+++ b/core/snmp/api/src/main/java/org/opennms/netmgt/snmp/AggregateTracker.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2011-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2011-2017 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -70,8 +70,6 @@ public class AggregateTracker extends CollectionTracker {
         public int getMaxRepititions() {
             return hasRepeaters() ? m_maxRepititions : Integer.MAX_VALUE;
         }
-        
-        
         
         public int size() {
             return m_oids.size();
@@ -262,6 +260,13 @@ public class AggregateTracker extends CollectionTracker {
     public void setMaxRepetitions(int maxRepititions) {
         for (CollectionTracker child : m_children) {
             child.setMaxRepetitions(maxRepititions);
+        }
+    }
+
+    @Override
+    public void setMaxRetries(final int maxRetries) {
+        for (final CollectionTracker child : m_children) {
+            child.setMaxRetries(maxRetries);
         }
     }
 

--- a/core/snmp/api/src/main/java/org/opennms/netmgt/snmp/CollectionTracker.java
+++ b/core/snmp/api/src/main/java/org/opennms/netmgt/snmp/CollectionTracker.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2011-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2011-2017 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -58,6 +58,8 @@ public abstract class CollectionTracker implements Collectable {
     
     public abstract void setMaxRepetitions(int maxRepetitions);
     
+    public abstract void setMaxRetries(int maxRetries);
+
     public void setFailed(boolean failed) {
         m_failed = failed;
     }

--- a/core/snmp/api/src/main/java/org/opennms/netmgt/snmp/SingleInstanceTracker.java
+++ b/core/snmp/api/src/main/java/org/opennms/netmgt/snmp/SingleInstanceTracker.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2011-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2011-2017 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -37,6 +37,8 @@ public class SingleInstanceTracker extends CollectionTracker {
     private SnmpObjId m_base;
     private SnmpInstId m_inst;
     private SnmpObjId m_oid;
+    private int m_maxRetries;
+    private Integer m_retries;
     
     public SingleInstanceTracker(SnmpObjId base, SnmpInstId inst) {
         this(base, inst, null);
@@ -58,7 +60,16 @@ public class SingleInstanceTracker extends CollectionTracker {
         // do nothing since we are not a repeater
     }
 
-        @Override
+    public int getMaxRetries() {
+        return m_maxRetries;
+    }
+
+    @Override
+    public void setMaxRetries(final int maxRetries) {
+        m_maxRetries = maxRetries;
+    }
+
+    @Override
     public ResponseProcessor buildNextPdu(PduBuilder pduBuilder) {
         if (pduBuilder.getMaxVarsPerPdu() < 1) {
             throw new IllegalArgumentException("maxVarsPerPdu < 1");
@@ -89,7 +100,8 @@ public class SingleInstanceTracker extends CollectionTracker {
 
             @Override
             public boolean processErrors(int errorStatus, int errorIndex) {
-                //LOG.trace("processErrors: errorStatus={}, errorIndex={}", errorStatus, errorIndex);
+                if (m_retries == null) m_retries = getMaxRetries();
+                //LOG.trace("processErrors: errorStatus={}, errorIndex={}, retries={}", errorStatus, errorIndex, m_retries);
 
                 final ErrorStatus status = ErrorStatus.fromStatus(errorStatus);
                 if (status == ErrorStatus.TOO_BIG) {
@@ -108,9 +120,20 @@ public class SingleInstanceTracker extends CollectionTracker {
                     throw ex;
                 } else if (status != ErrorStatus.NO_ERROR) {
                     LOG.warn("Non-fatal error encountered: {}. {}", status, status.retry()? "Retrying." : "Giving up.");
-                    return status.retry();
                 }
-                return false;
+
+                if (status.retry()) {
+                    if (m_retries-- <= 0) {
+                        final ErrorStatusException ex = new ErrorStatusException(status, "Non-fatal error met maximum number of retries. Aborting!");
+                        reportFatalErr(ex);
+                        throw ex;
+                    }
+                } else {
+                    // On success, reset the retries
+                    m_retries = getMaxRetries();
+                }
+
+                return status.retry();
             }
         };
         

--- a/core/snmp/api/src/main/java/org/opennms/netmgt/snmp/SnmpWalker.java
+++ b/core/snmp/api/src/main/java/org/opennms/netmgt/snmp/SnmpWalker.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2011-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2011-2017 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -62,7 +62,7 @@ public abstract class SnmpWalker implements Closeable {
     private String m_errorMessage = "";
     private Throwable m_errorThrowable = null;
     
-    protected SnmpWalker(InetAddress address, String name, int maxVarsPerPdu, int maxRepetitions, CollectionTracker tracker) {
+    protected SnmpWalker(InetAddress address, String name, int maxVarsPerPdu, int maxRepetitions, int maxRetries, CollectionTracker tracker) {
         m_address = address;
         m_signal = new CountDownLatch(1);
         
@@ -70,6 +70,7 @@ public abstract class SnmpWalker implements Closeable {
 
         m_tracker = tracker;
         m_tracker.setMaxRepetitions(maxRepetitions);
+        m_tracker.setMaxRetries(maxRetries);
         
         m_maxVarsPerPdu = maxVarsPerPdu;
     }

--- a/core/snmp/api/src/main/java/org/opennms/netmgt/snmp/TableTracker.java
+++ b/core/snmp/api/src/main/java/org/opennms/netmgt/snmp/TableTracker.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2011-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2011-2017 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -50,15 +50,15 @@ public class TableTracker extends CollectionTracker implements RowCallback, RowR
     }
     
     public TableTracker(RowCallback rc, SnmpObjId... ids) {
-        this(rc, 2, ids);
+        this(rc, 2, 0, ids);
     }
 
-    public TableTracker(RowCallback rc, int maxRepetitions, SnmpObjId... columns) {
+    public TableTracker(RowCallback rc, int maxRepetitions, int maxRetries, SnmpObjId... columns) {
         m_tableResult = new SnmpTableResult(rc == null ? this : rc, this, columns);
 
         m_columnTrackers = new ArrayList<ColumnTracker>(columns.length);
         for (SnmpObjId id : columns) {
-            m_columnTrackers.add(new ColumnTracker(this, id, maxRepetitions));
+            m_columnTrackers.add(new ColumnTracker(this, id, maxRepetitions, maxRetries));
         }
     }
 
@@ -66,6 +66,13 @@ public class TableTracker extends CollectionTracker implements RowCallback, RowR
     public void setMaxRepetitions(int maxRepetitions) {
         for(ColumnTracker child : m_columnTrackers) {
             child.setMaxRepetitions(maxRepetitions);
+        }
+    }
+
+    @Override
+    public void setMaxRetries(final int maxRetries) {
+        for(final ColumnTracker child : m_columnTrackers) {
+            child.setMaxRetries(maxRetries);
         }
     }
 

--- a/core/snmp/impl-joesnmp/src/main/java/org/opennms/netmgt/snmp/joesnmp/JoeSnmpWalker.java
+++ b/core/snmp/impl-joesnmp/src/main/java/org/opennms/netmgt/snmp/joesnmp/JoeSnmpWalker.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2011-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2011-2017 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -175,7 +175,7 @@ public class JoeSnmpWalker extends SnmpWalker {
     private JoeSnmpAgentConfig m_agentConfig;
 
     public JoeSnmpWalker(JoeSnmpAgentConfig agentConfig, String name, CollectionTracker tracker) {
-        super(agentConfig.getAddress(), name, agentConfig.getMaxVarsPerPdu(), agentConfig.getMaxRepetitions(), tracker);
+        super(agentConfig.getAddress(), name, agentConfig.getMaxVarsPerPdu(), agentConfig.getMaxRepetitions(), agentConfig.getRetries(), tracker);
         m_agentConfig = agentConfig;
         m_peer = getPeer(agentConfig);
         m_handler = new JoeSnmpResponseHandler();

--- a/core/snmp/impl-mock/src/main/java/org/opennms/netmgt/snmp/mock/MockSnmpStrategy.java
+++ b/core/snmp/impl-mock/src/main/java/org/opennms/netmgt/snmp/mock/MockSnmpStrategy.java
@@ -87,7 +87,7 @@ public class MockSnmpStrategy implements SnmpStrategy {
         LOG.debug("createWalker({}/{}, {}, {})", InetAddrUtils.str(agentConfig.getAddress()), agentConfig.getPort(), name, tracker.getClass().getName());
         final SnmpAgentAddress aa = new SnmpAgentAddress(agentConfig.getAddress(), agentConfig.getPort());
         final PropertyOidContainer oidContainer = getOidContainer(aa);
-        return new MockSnmpWalker(aa, agentConfig.getVersion(), oidContainer, name, tracker, agentConfig.getMaxVarsPerPdu());
+        return new MockSnmpWalker(aa, agentConfig.getVersion(), oidContainer, name, tracker, agentConfig.getMaxVarsPerPdu(), agentConfig.getRetries());
     }
 
     @Override

--- a/core/snmp/impl-mock/src/main/java/org/opennms/netmgt/snmp/mock/MockSnmpWalker.java
+++ b/core/snmp/impl-mock/src/main/java/org/opennms/netmgt/snmp/mock/MockSnmpWalker.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2011-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2011-2017 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -105,8 +105,8 @@ public class MockSnmpWalker extends SnmpWalker {
     private final PropertyOidContainer m_container;
     private final ExecutorService m_executor;
 
-    public MockSnmpWalker(final SnmpAgentAddress agentAddress, int snmpVersion, final PropertyOidContainer container, final String name, final CollectionTracker tracker, int maxVarsPerPdu) {
-        super(agentAddress.getAddress(), name, maxVarsPerPdu, 1, tracker);
+    public MockSnmpWalker(final SnmpAgentAddress agentAddress, final int snmpVersion, final PropertyOidContainer container, final String name, final CollectionTracker tracker, final int maxVarsPerPdu, final int maxRetries) {
+        super(agentAddress.getAddress(), name, maxVarsPerPdu, 1, maxRetries, tracker);
         m_agentAddress = agentAddress;
         m_snmpVersion = snmpVersion;
         m_container = container;

--- a/core/snmp/impl-snmp4j/src/main/java/org/opennms/netmgt/snmp/snmp4j/Snmp4JWalker.java
+++ b/core/snmp/impl-snmp4j/src/main/java/org/opennms/netmgt/snmp/snmp4j/Snmp4JWalker.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2011-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2011-2017 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -191,7 +191,7 @@ public class Snmp4JWalker extends SnmpWalker {
     private final Snmp4JAgentConfig m_agentConfig;
 
     public Snmp4JWalker(Snmp4JAgentConfig agentConfig, String name, CollectionTracker tracker) {
-        super(agentConfig.getInetAddress(), name, agentConfig.getMaxVarsPerPdu(), agentConfig.getMaxRepetitions(), tracker);
+        super(agentConfig.getInetAddress(), name, agentConfig.getMaxVarsPerPdu(), agentConfig.getMaxRepetitions(), agentConfig.getRetries(), tracker);
         
         m_agentConfig = agentConfig;
         

--- a/core/snmp/integration-tests/src/test/java/org/opennms/netmgt/snmp/SnmpTrackerTest.java
+++ b/core/snmp/integration-tests/src/test/java/org/opennms/netmgt/snmp/SnmpTrackerTest.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2011-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2011-2017 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -93,26 +93,68 @@ public class SnmpTrackerTest implements InitializingBean {
     }
 
     static private class CountingColumnTracker extends ColumnTracker {
-        private long m_count = 0;
+        private long m_columnCount = 0;
+        private final List<ResponseError> m_errors = new ArrayList<>();
 
         public CountingColumnTracker(final SnmpObjId base) {
             super(base);
         }
         
-        public CountingColumnTracker(final SnmpObjId base, final int maxRepetitions) {
-            super(base, maxRepetitions);
+        public CountingColumnTracker(final SnmpObjId base, final int maxRepetitions, final int maxRetries) {
+            super(base, maxRepetitions, maxRetries);
         }
         
-        public long getCount() {
-            return m_count;
+        public long getColumnCount() {
+            return m_columnCount;
         }
         
+        public List<ResponseError> getResponseErrors() {
+            return m_errors;
+        }
+
         @Override
         protected void storeResult(final SnmpResult res) {
         	LOG.debug("storing result: {}", res);
-            m_count++;
+            m_columnCount++;
         }
 
+        @Override
+        public ResponseProcessor buildNextPdu(PduBuilder pduBuilder) {
+            final ResponseProcessor rp = super.buildNextPdu(pduBuilder);
+            final ResponseProcessor errorRp = new ResponseProcessor() {
+
+                @Override
+                public void processResponse(final SnmpObjId snmpObjId, SnmpValue val) {
+                    rp.processResponse(snmpObjId, val);
+                }
+
+                @Override
+                public boolean processErrors(final int errorStatus, final int errorIndex) {
+                    final boolean retry = rp.processErrors(errorStatus, errorIndex);
+                    m_errors.add(new ResponseError(ErrorStatus.fromStatus(errorStatus), retry));
+                    return retry;
+                }
+            };
+            return errorRp;
+        }
+    }
+
+    static private class ResponseError {
+        private ErrorStatus m_status;
+        private boolean m_retry;
+
+        public ResponseError(final ErrorStatus status, final boolean retry) {
+            m_status = status;
+            m_retry = retry;
+        }
+
+        public ErrorStatus getStatus() {
+            return m_status;
+        }
+
+        public boolean getRetry() {
+            return m_retry;
+        }
     }
 
     static private final class ResultTable {
@@ -172,11 +214,12 @@ public class SnmpTrackerTest implements InitializingBean {
         }
     }
 
-    private void walk(final CollectionTracker c, final int maxVarsPerPdu, final int maxRepetitions) throws Exception {
+    private void walk(final CollectionTracker c, final int maxVarsPerPdu, final int maxRepetitions, final int maxRetries) throws Exception {
     	final SnmpAgentConfig config = m_snmpPeerFactory.getAgentConfig(InetAddressUtils.addr("192.0.2.205"));
         config.setVersion(SnmpAgentConfig.VERSION2C);
         config.setMaxVarsPerPdu(maxVarsPerPdu);
         config.setMaxRepetitions(maxRepetitions);
+        config.setRetries(maxRetries);
         final SnmpWalker walker = SnmpUtils.createWalker(config, "test", c);
         assertNotNull(walker);
         walker.start();
@@ -197,16 +240,29 @@ public class SnmpTrackerTest implements InitializingBean {
     @Test
     public void testColumnTracker() throws Exception {
     	final CountingColumnTracker ct = new CountingColumnTracker(SnmpObjId.get(".1.3.6.1.2.1.2.2.1.1"));
-        walk(ct, 10, 3);
-        assertEquals("number of columns returned must match test data", Long.valueOf(6).longValue(), ct.getCount());
+        walk(ct, 10, 3, 0);
+        assertEquals("number of columns returned must match test data", 6l, ct.getColumnCount());
     }
  
+    @Test
+    @JUnitSnmpAgent(host="192.0.2.205", resource="classpath:snmpTestDataError.properties")
+    public void testColumnTrackerWithError() throws Exception {
+        final CountingColumnTracker ct = new CountingColumnTracker(SnmpObjId.get(".1.3.6.1.3.17"));
+        walk(ct, 10, 3, 3);
+        final List<ResponseError> errors = ct.getResponseErrors();
+        assertEquals("Number of errors before giving up should be 3", 3, errors.size());
+        for (final ResponseError error : errors) {
+            assertEquals("buildNextPdu should indicate a retry should be attempted", true, error.getRetry());
+            assertEquals(".1.3.6.1.3.17 should return an AUTHORIZATION_ERROR(16)", ErrorStatus.AUTHORIZATION_ERROR, error.getStatus());
+        }
+    }
+
     @Test
     public void testTableTrackerWithFullTable() throws Exception {
     	final TestRowCallback rc = new TestRowCallback();
     	final TableTracker tt = new TableTracker(rc, SnmpTableConstants.ifIndex, SnmpTableConstants.ifDescr, SnmpTableConstants.ifSpeed);
 
-        walk(tt, 3, 10);
+        walk(tt, 3, 10, 0);
 
         final ResultTable results = rc.getResults();
         assertTrue("tracker must be finished", tt.isFinished());
@@ -230,7 +286,7 @@ public class SnmpTrackerTest implements InitializingBean {
             SnmpTableConstants.ifOutUcastPkts, SnmpTableConstants.ifOutNUcastPkts, SnmpTableConstants.ifOutErrors
         );
 
-        walk(tt, 4, 3);
+        walk(tt, 4, 3, 0);
 
         printResponses(rc);
         final ResultTable results = rc.getResults();
@@ -252,7 +308,7 @@ public class SnmpTrackerTest implements InitializingBean {
         tt[1] = new TableTracker(rc, SnmpTableConstants.ifMtu, SnmpTableConstants.ifLastChange);
         final AggregateTracker at = new AggregateTracker(tt);
 
-        walk(at, 4, 10);
+        walk(at, 4, 10, 0);
 
         printResponses(rc);
     }

--- a/core/snmp/integration-tests/src/test/java/org/opennms/netmgt/snmp/mock/MockSnmpStrategyTest.java
+++ b/core/snmp/integration-tests/src/test/java/org/opennms/netmgt/snmp/mock/MockSnmpStrategyTest.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2011-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2011-2017 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -244,6 +244,7 @@ public class MockSnmpStrategyTest {
         config.setVersion(SnmpAgentConfig.VERSION1);
         config.setMaxVarsPerPdu(20);
         config.setMaxRepetitions(20);
+        config.setRetries(3);
         return config;
     }
 
@@ -260,8 +261,8 @@ public class MockSnmpStrategyTest {
         public CountingColumnTracker(final SnmpObjId base) {
             super(base);
         }
-        public CountingColumnTracker(final SnmpObjId base, final int maxRepetitions) {
-            super(base, maxRepetitions);
+        public CountingColumnTracker(final SnmpObjId base, final int maxRepetitions, final int maxRetries) {
+            super(base, maxRepetitions, maxRetries);
         }
         public long getCount() {
             return m_count;

--- a/core/snmp/integration-tests/src/test/resources/snmpTestDataError.properties
+++ b/core/snmp/integration-tests/src/test/resources/snmpTestDataError.properties
@@ -1,0 +1,3 @@
+.1.3.6.1.2.1.25.5.1.1.2.717 = INTEGER: 0
+# Fails with SNMP_ERROR_AUTHORIZATION_ERROR
+.1.3.6.1.3.17.16 = Responder: org.opennms.mock.snmp.responder.Error


### PR DESCRIPTION
This PR fixes an issue with the new SNMP error-handling code that could cause loops.  It adds support for passing retries down into the tracker(s) and they, in turn, track retries and treat non-fatal errors as fatal if they have run out of retries.

* JIRA: http://issues.opennms.org/browse/NMS-9164