### PR TITLE
NMS-9234: Show a better error message when the SNMP agents time out.

### DIFF
--- a/core/snmp/api/src/main/java/org/opennms/netmgt/snmp/SnmpAgentTimeoutException.java
+++ b/core/snmp/api/src/main/java/org/opennms/netmgt/snmp/SnmpAgentTimeoutException.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2017 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.snmp;
+
+import java.net.InetAddress;
+
+public class SnmpAgentTimeoutException extends Exception {
+    private static final long serialVersionUID = 1L;
+
+    public SnmpAgentTimeoutException(String name, InetAddress agentAddress) {
+        super(String.format("Timeout retrieving '%s' for %s.", name, InetAddrUtils.str(agentAddress)));
+    }
+}

--- a/core/snmp/api/src/main/java/org/opennms/netmgt/snmp/SnmpWalker.java
+++ b/core/snmp/api/src/main/java/org/opennms/netmgt/snmp/SnmpWalker.java
@@ -149,7 +149,7 @@ public abstract class SnmpWalker implements AutoCloseable {
     
     protected void handleTimeout(String msg) {
         m_tracker.setTimedOut(true);
-        processError("Timeout retrieving", msg, null);
+        processError("Timeout retrieving", msg, new SnmpAgentTimeoutException(getName(), m_address));
     }
 
     private void processError(String reason, String cause, Throwable t) {

--- a/core/snmp/integration-tests/src/test/java/org/opennms/netmgt/snmp/mock/MockSnmpStrategyTest.java
+++ b/core/snmp/integration-tests/src/test/java/org/opennms/netmgt/snmp/mock/MockSnmpStrategyTest.java
@@ -257,7 +257,7 @@ public class MockSnmpStrategyTest {
     public void testCallbackOnTrackerTimeout() throws Exception {
         // Expect an exception on get
         expectedEx.expect(Exception.class);
-        expectedEx.expectMessage("Timeout retrieving test for /127.0.0.1");
+        expectedEx.expectMessage("Timeout retrieving 'test' for 127.0.0.1");
         final CountingColumnTracker ct = new CountingColumnTracker(SnmpObjId.get(".1.3.5.1.1"));
         final SnmpAgentConfig sac = getAgentConfig();
         sac.setPort(12345);

--- a/opennms-services/src/main/java/org/opennms/netmgt/collectd/SnmpCollectionSet.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/collectd/SnmpCollectionSet.java
@@ -52,6 +52,7 @@ import org.opennms.netmgt.snmp.AggregateTracker;
 import org.opennms.netmgt.snmp.Collectable;
 import org.opennms.netmgt.snmp.CollectionTracker;
 import org.opennms.netmgt.snmp.SnmpAgentConfig;
+import org.opennms.netmgt.snmp.SnmpAgentTimeoutException;
 import org.opennms.netmgt.snmp.SnmpResult;
 import org.opennms.netmgt.snmp.SnmpUtils;
 import org.opennms.netmgt.snmp.SnmpWalker;
@@ -397,6 +398,8 @@ public class SnmpCollectionSet implements Collectable, CollectionSet {
                 throw new CollectionUnknown(String.format("The request to remotely collect SNMP data"
                         + " for interface %s at location %s was rejected.",
                         getCollectionAgent().getHostAddress(), getCollectionAgent().getLocationName()), e);
+            } else if (cause != null && cause instanceof SnmpAgentTimeoutException) {
+                throw new CollectionTimedOut(cause.getMessage());
             }
             throw new CollectionWarning(String.format("Unexpected exception when collecting SNMP data for interface %s at location %s.",
                     getCollectionAgent().getHostAddress(), getCollectionAgent().getLocationName()), e);

--- a/opennms-services/src/test/java/org/opennms/netmgt/collectd/SnmpCollectorIT.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/collectd/SnmpCollectorIT.java
@@ -54,6 +54,8 @@ import org.opennms.core.test.db.annotations.JUnitTemporaryDatabase;
 import org.opennms.core.test.snmp.annotations.JUnitSnmpAgent;
 import org.opennms.core.utils.InetAddressUtils;
 import org.opennms.netmgt.collection.api.CollectionAgent;
+import org.opennms.netmgt.collection.api.CollectionException;
+import org.opennms.netmgt.collection.api.CollectionInitializationException;
 import org.opennms.netmgt.collection.api.CollectionSet;
 import org.opennms.netmgt.collection.api.ServiceCollector;
 import org.opennms.netmgt.config.SnmpPeerFactory;
@@ -552,6 +554,22 @@ public class SnmpCollectorIT implements InitializingBean, TestContextAware {
         // see http://issues.opennms.org/browse/NMS-7367
         value = properties.get("swFCPortWwn");
         assertEquals("1100334455667788", value);
+    }
+
+    @Test(expected=CollectionTimedOut.class)
+    @Transactional
+    @JUnitCollector(
+                    datacollectionConfig = "/org/opennms/netmgt/config/datacollection-persistTest-config.xml",
+                    datacollectionType = "snmp"
+            )
+    public void collectionTimedOutExceptionOnAgentTimeout() throws CollectionInitializationException, CollectionException {
+        // Initialize the agent and perform the collection
+        m_collectionSpecification.initialize(m_collectionAgent);
+        m_collectionSpecification.collect(m_collectionAgent);
+
+        // There is no @JUnitSnmpAgent annotation on this method, so
+        // we don't actually start the SNMP agent, which should
+        // generate a CollectionTimedOut exception
     }
 
     private String rrd(String file) {


### PR DESCRIPTION
JIRA: https://issues.opennms.org/browse/NMS-9234

This restores the behavior before 19.0.0 where the dataCollectionFailed alarms include a message of the form:
  "SNMP data collection on interface 172.23.1.1 failed with 'Timeout retrieving..."

instead of the current:
  "SNMP data collection on interface 172.23.1.1 failed with 'Unexpected exception..."
