### PR TITLE
NMS-9132: Upgrade log4j2 to latest release 2.8.2

### DIFF
--- a/features/poller/remote/src/main/java/org/opennms/netmgt/poller/remote/support/Log4j2StringAppender.java
+++ b/features/poller/remote/src/main/java/org/opennms/netmgt/poller/remote/support/Log4j2StringAppender.java
@@ -31,6 +31,7 @@ package org.opennms.netmgt.poller.remote.support;
 import java.io.ByteArrayOutputStream;
 import java.io.Serializable;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.io.IOException;
 
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
@@ -104,8 +105,12 @@ public class Log4j2StringAppender extends AbstractOutputStreamAppender<Log4j2Str
 	}
 
 	public String getOutput() {
-		getManager().flush();
-		return new String(getManager().getByteArrayOutputStream().toByteArray());
+		try {
+			getManager().flush();
+			return new String(getManager().getByteArrayOutputStream().toByteArray());
+		} catch (IOException e) {
+			return new String();
+		}
 	}
 
 	public static class ByteArrayOutputStreamManager extends OutputStreamManager {
@@ -113,7 +118,7 @@ public class Log4j2StringAppender extends AbstractOutputStreamAppender<Log4j2Str
 			super(new ByteArrayOutputStream(), ByteArrayOutputStreamManager.class.getName(), layout, true);
 		}
 
-		public ByteArrayOutputStream getByteArrayOutputStream() {
+		public ByteArrayOutputStream getByteArrayOutputStream() throws IOException {
 			return (ByteArrayOutputStream)getOutputStream();
 		}
 	}

--- a/pom.xml
+++ b/pom.xml
@@ -1313,7 +1313,7 @@
     <liquibaseVersion>2.0.5-ONMS20160524b</liquibaseVersion>
     <lmaxDisruptorVersion>3.3.2</lmaxDisruptorVersion>
     <log4jVersion>99.99.99-use-log4j2</log4jVersion>
-    <log4j2Version>2.8.1</log4j2Version>
+    <log4j2Version>2.8.2</log4j2Version>
     <minaVersion>2.0.13</minaVersion>
     <minionKarafVersion>4.0.5</minionKarafVersion>
     <newtsVersion>1.4.3</newtsVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -1313,7 +1313,7 @@
     <liquibaseVersion>2.0.5-ONMS20160524b</liquibaseVersion>
     <lmaxDisruptorVersion>3.3.2</lmaxDisruptorVersion>
     <log4jVersion>99.99.99-use-log4j2</log4jVersion>
-    <log4j2Version>2.5</log4j2Version>
+    <log4j2Version>2.8.1</log4j2Version>
     <minaVersion>2.0.13</minaVersion>
     <minionKarafVersion>4.0.5</minionKarafVersion>
     <newtsVersion>1.4.3</newtsVersion>
@@ -3655,27 +3655,10 @@
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
-        <artifactId>log4j-api</artifactId>
+        <artifactId>log4j-bom</artifactId>
         <version>${log4j2Version}</version>
-        <scope>runtime</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.logging.log4j</groupId>
-        <artifactId>log4j-core</artifactId>
-        <version>${log4j2Version}</version>
-        <scope>runtime</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.logging.log4j</groupId>
-        <artifactId>log4j-1.2-api</artifactId>
-        <version>${log4j2Version}</version>
-        <scope>runtime</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.logging.log4j</groupId>
-        <artifactId>log4j-slf4j-impl</artifactId>
-        <version>${log4j2Version}</version>
-        <scope>runtime</scope>
+        <scope>import</scope>
+        <type>pom</type>
       </dependency>
       <dependency>
         <groupId>log4j</groupId>


### PR DESCRIPTION
This PR updates log4j2 to 2.8.1. Also, change the dependency management to use the log4j-bom which pins all log4j2 dependencies to the same version. (From https://logging.apache.org/log4j/2.x/maven-artifacts.html)

The big list of changes since 2.5 can be seen here: https://logging.apache.org/log4j/2.x/changes-report.html

* JIRA: http://issues.opennms.org/browse/NMS-9132

