### PR TITLE
NMS-8908: Added null check when NRTG metrics cannot be found

### DIFF
--- a/features/nrtg/api/src/main/java/org/opennms/nrtg/api/model/DefaultCollectionJob.java
+++ b/features/nrtg/api/src/main/java/org/opennms/nrtg/api/model/DefaultCollectionJob.java
@@ -274,7 +274,7 @@ public class DefaultCollectionJob implements CollectionJob {
             }
         }
 
-        return m_allMetrics.get(metricId).get(1);
+        return m_allMetrics.get(metricId) == null ? null : m_allMetrics.get(metricId).get(1);
     }
 
     @Override
@@ -291,7 +291,7 @@ public class DefaultCollectionJob implements CollectionJob {
             }
         }
 
-        return m_allMetrics.get(metricId).get(0);
+        return m_allMetrics.get(metricId) == null ? null : m_allMetrics.get(metricId).get(0);
     }
 
     private String getDestinationString(Set<String> destinationSet) {


### PR DESCRIPTION
This will avoid crashing the NRTG graphs when we cannot find metrics that we expect inside the DefaultCollectionJob.

* JIRA: http://issues.opennms.org/browse/NMS-8908