### PR TITLE
NMS-9276: Elasticsearch integration avoid parm name conflicts for severity as integer

### DIFF
--- a/features/alarm-change-notifier/main-module/src/main/java/org/opennms/plugins/dbnotifier/alarmnotifier/AlarmChangeEventConstants.java
+++ b/features/alarm-change-notifier/main-module/src/main/java/org/opennms/plugins/dbnotifier/alarmnotifier/AlarmChangeEventConstants.java
@@ -1,3 +1,31 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2002-2014 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
 package org.opennms.plugins.dbnotifier.alarmnotifier;
 
 public interface AlarmChangeEventConstants {
@@ -42,8 +70,8 @@ public interface AlarmChangeEventConstants {
 	public static final String LOGMSG_PARAM="logmsg";
 	public static final String CLEARKEY_PARAM="clearkey";
 	public static final String ALARMTYPE_PARAM="alarmtype";
-	public static final String ALARMACKTIME_PARAM="alarmacktime";
-	public static final String ALARMACKUSER_PARAM="alarmackuser";
+	public static final String ALARM_ACK_TIME_PARAM="alarmacktime";
+	public static final String ALARM_ACK_USER_PARAM="alarmackuser";
 	public static final String SUPPRESSEDTIME_PARAM="suppressedtime";
 	public static final String SUPPRESSEDUNTIL_PARAM="suppresseduntil";
 	public static final String SUPPRESSEDUSER_PARAM="suppresseduser";

--- a/features/alarm-change-notifier/main-module/src/main/java/org/opennms/plugins/dbnotifier/alarmnotifier/AlarmChangeEventConstants.java
+++ b/features/alarm-change-notifier/main-module/src/main/java/org/opennms/plugins/dbnotifier/alarmnotifier/AlarmChangeEventConstants.java
@@ -1,0 +1,61 @@
+package org.opennms.plugins.dbnotifier.alarmnotifier;
+
+public interface AlarmChangeEventConstants {
+	
+	// note this should be aligned with definitions in AlarmChangeNotifierEvents.xml
+	
+	// stem of all alarm change notification uei's
+	public static final String ALARM_NOTIFICATION_UEI_STEM = "uei.opennms.org/plugin/AlarmChangeNotificationEvent";
+	
+	// uei definitions of alarm change events
+	public static final String ALARM_DELETED_EVENT = "uei.opennms.org/plugin/AlarmChangeNotificationEvent/AlarmDeleted";
+	public static final String ALARM_CREATED_EVENT = "uei.opennms.org/plugin/AlarmChangeNotificationEvent/NewAlarmCreated";
+	public static final String ALARM_SEVERITY_CHANGED_EVENT = "uei.opennms.org/plugin/AlarmChangeNotificationEvent/AlarmSeverityChanged";
+	public static final String ALARM_CLEARED_EVENT = "uei.opennms.org/plugin/AlarmChangeNotificationEvent/AlarmCleared";
+	public static final String ALARM_ACKNOWLEDGED_EVENT = "uei.opennms.org/plugin/AlarmChangeNotificationEvent/AlarmAcknowledged";
+	public static final String ALARM_UNACKNOWLEDGED_EVENT = "uei.opennms.org/plugin/AlarmChangeNotificationEvent/AlarmUnAcknowledged";
+	public static final String ALARM_SUPPRESSED_EVENT = "uei.opennms.org/plugin/AlarmChangeNotificationEvent/AlarmSuppressed";
+	public static final String ALARM_UNSUPPRESSED_EVENT = "uei.opennms.org/plugin/AlarmChangeNotificationEvent/AlarmUnSuppressed";
+	public static final String ALARM_TROUBLETICKET_STATE_CHANGE_EVENT = "uei.opennms.org/plugin/AlarmChangeNotificationEvent/TroubleTicketStateChange";
+	public static final String ALARM_CHANGED_EVENT = "uei.opennms.org/plugin/AlarmChangeNotificationEvent/AlarmChanged";
+	public static final String ALARM_STICKYMEMO_ADD_EVENT = "uei.opennms.org/plugin/AlarmChangeNotificationEvent/StickyMemoAdded";
+
+	// uei definitions of memo change events
+	public static final String STICKY_MEMO_EVENT = "uei.opennms.org/plugin/AlarmChangeNotificationEvent/StickyMemoUpdate";
+	public static final String JOURNAL_MEMO_EVENT = "uei.opennms.org/plugin/AlarmChangeNotificationEvent/JournalMemoUpdate";
+	
+	// param definitions for memo change events
+	public static final String MEMO_VALUES_PARAM="memovalues";
+	public static final String MEMO_ALARMID_PARAM="alarmid";
+	public static final String MEMO_BODY_PARAM="body";
+	public static final String MEMO_AUTHOR_PARAM="author";
+	public static final String MEMO_REDUCTIONKEY_PARAM="reductionkey";
+
+	// param definitions for alarm change events
+	public static final String OLD_ALARM_VALUES_PARAM="oldalarmvalues";
+	public static final String NEW_ALARM_VALUES_PARAM="newalarmvalues";
+	
+	public static final String INITIAL_SEVERITY_PARAM="initialseverity";
+	public static final String OLDSEVERITY_PARAM="oldseverity";
+	public static final String ALARM_SEVERITY_PARAM = "alarmseverity";
+	public static final String ALARMID_PARAM="alarmid";
+	public static final String LOGMSG_PARAM="logmsg";
+	public static final String CLEARKEY_PARAM="clearkey";
+	public static final String ALARMTYPE_PARAM="alarmtype";
+	public static final String ALARMACKTIME_PARAM="alarmacktime";
+	public static final String ALARMACKUSER_PARAM="alarmackuser";
+	public static final String SUPPRESSEDTIME_PARAM="suppressedtime";
+	public static final String SUPPRESSEDUNTIL_PARAM="suppresseduntil";
+	public static final String SUPPRESSEDUSER_PARAM="suppresseduser";
+	public static final String EVENTUEI_PARAM="eventuei";
+	public static final String REDUCTIONKEY_PARAM="reductionkey";
+	public static final String APPLICATIONDN_PARAM="applicationdn";
+	public static final String SERVICEID_PARAM="serviceid";
+	public static final String SYSTEMID_PARAM="systemid";
+	public static final String OLDTICKETID_PARAM="oldtticketid";
+	public static final String TTICKETID_PARAM="tticketid";
+	public static final String OLDTTICKETSTATE_PARAM="oldtticketstate";
+	public static final String TTICKETSTATE_PARAM="tticketstate";
+	public static final String STICKYMEMO_PARAM="stickymemo";
+
+}

--- a/features/alarm-change-notifier/main-module/src/main/java/org/opennms/plugins/dbnotifier/alarmnotifier/AlarmChangeNotificationClient.java
+++ b/features/alarm-change-notifier/main-module/src/main/java/org/opennms/plugins/dbnotifier/alarmnotifier/AlarmChangeNotificationClient.java
@@ -61,23 +61,6 @@ public class AlarmChangeNotificationClient implements NotificationClient {
 
 	public static final String EVENT_SOURCE_NAME = "AlarmChangeNotifier";
 
-	// uei definitions of alarm change events
-	public static final String ALARM_DELETED_EVENT = "uei.opennms.org/plugin/AlarmChangeNotificationEvent/AlarmDeleted";
-	public static final String ALARM_CREATED_EVENT = "uei.opennms.org/plugin/AlarmChangeNotificationEvent/NewAlarmCreated";
-	public static final String ALARM_SEVERITY_CHANGED_EVENT = "uei.opennms.org/plugin/AlarmChangeNotificationEvent/AlarmSeverityChanged";
-	public static final String ALARM_CLEARED_EVENT = "uei.opennms.org/plugin/AlarmChangeNotificationEvent/AlarmCleared";
-	public static final String ALARM_ACKNOWLEDGED_EVENT = "uei.opennms.org/plugin/AlarmChangeNotificationEvent/AlarmAcknowledged";
-	public static final String ALARM_UNACKNOWLEDGED_EVENT = "uei.opennms.org/plugin/AlarmChangeNotificationEvent/AlarmUnAcknowledged";
-	public static final String ALARM_SUPPRESSED_EVENT = "uei.opennms.org/plugin/AlarmChangeNotificationEvent/AlarmSuppressed";
-	public static final String ALARM_UNSUPPRESSED_EVENT = "uei.opennms.org/plugin/AlarmChangeNotificationEvent/AlarmUnSuppressed";
-	public static final String ALARM_TROUBLETICKET_STATE_CHANGE_EVENT = "uei.opennms.org/plugin/AlarmChangeNotificationEvent/TroubleTicketStateChange";
-	public static final String ALARM_CHANGED_EVENT = "uei.opennms.org/plugin/AlarmChangeNotificationEvent/AlarmChanged";
-	public static final String ALARM_STICKYMEMO_ADD_EVENT = "uei.opennms.org/plugin/AlarmChangeNotificationEvent/StickyMemoAdded";
-
-	public static final String OLD_ALARM_VALUES="oldalarmvalues";
-	public static final String NEW_ALARM_VALUES="newalarmvalues";
-	
-	public static final String INITIAL_SEVERITY="initialseverity";
 
 	EventProxy eventProxy = null;
 
@@ -119,11 +102,11 @@ public class AlarmChangeNotificationClient implements NotificationClient {
 				if(! "2".equals(oldJsonObject.get("alarmtype").toString())) {
 					if (LOG.isDebugEnabled()) LOG.debug("alarm deleted alarmid="+oldJsonObject.get("alarmid"));
 					EventBuilder eb= jsonAlarmToEventBuilder(oldJsonObject, 
-							new EventBuilder( ALARM_DELETED_EVENT, EVENT_SOURCE_NAME));
+							new EventBuilder( AlarmChangeEventConstants.ALARM_DELETED_EVENT, EVENT_SOURCE_NAME));
 
 					//copy in all values as json in params
-					eb.addParam(OLD_ALARM_VALUES,oldJsonObject.toString());
-					eb.addParam(NEW_ALARM_VALUES,newJsonObject.toString());
+					eb.addParam(AlarmChangeEventConstants.OLD_ALARM_VALUES_PARAM,oldJsonObject.toString());
+					eb.addParam(AlarmChangeEventConstants.NEW_ALARM_VALUES_PARAM,newJsonObject.toString());
 
 					sendEvent(eb.getEvent());
 				}
@@ -135,18 +118,18 @@ public class AlarmChangeNotificationClient implements NotificationClient {
 				if(! "2".equals(newJsonObject.get("alarmtype").toString())) {
 					if (LOG.isDebugEnabled()) LOG.debug("alarm created alarmid="+newJsonObject.get("alarmid"));
 					EventBuilder eb= jsonAlarmToEventBuilder(newJsonObject, 
-							new EventBuilder( ALARM_CREATED_EVENT, EVENT_SOURCE_NAME));
+							new EventBuilder( AlarmChangeEventConstants.ALARM_CREATED_EVENT, EVENT_SOURCE_NAME));
 
 					//copy in all values as json in params
-					eb.addParam(OLD_ALARM_VALUES,oldJsonObject.toString());
-					eb.addParam(NEW_ALARM_VALUES,newJsonObject.toString());
+					eb.addParam(AlarmChangeEventConstants.OLD_ALARM_VALUES_PARAM,oldJsonObject.toString());
+					eb.addParam(AlarmChangeEventConstants.NEW_ALARM_VALUES_PARAM,newJsonObject.toString());
 
 					// set initial severity to new alarm severity
 					if (newJsonObject.get("severity")!=null) {
 						try{
 							String newseverity= newJsonObject.get("severity").toString();
 							Integer newsvty= Integer.valueOf(newseverity);
-							eb.addParam(INITIAL_SEVERITY,newsvty.toString());
+							eb.addParam(AlarmChangeEventConstants.INITIAL_SEVERITY_PARAM,newsvty.toString());
 						} catch (Exception e){
 							LOG.error("problem parsing initial severity for new alarm event newJsonObject="+newJsonObject,e);
 						}
@@ -190,19 +173,20 @@ public class AlarmChangeNotificationClient implements NotificationClient {
 								if (LOG.isDebugEnabled()) LOG.debug("alarm cleared alarmid="+oldJsonObject.get("alarmid")
 										+" old severity="+oldseverity+" new severity="+newseverity);
 								eb= jsonAlarmToEventBuilder(newJsonObject, 
-										new EventBuilder( ALARM_CLEARED_EVENT, EVENT_SOURCE_NAME));
+										new EventBuilder( AlarmChangeEventConstants.ALARM_CLEARED_EVENT, EVENT_SOURCE_NAME));
 							} else {
 								// if just severity changed
 								if (LOG.isDebugEnabled()) LOG.debug("alarm severity changed alarmid="+oldJsonObject.get("alarmid")
 										+" old severity="+oldseverity+" new severity="+newseverity);
 								eb= jsonAlarmToEventBuilder(newJsonObject, 
-										new EventBuilder( ALARM_SEVERITY_CHANGED_EVENT, EVENT_SOURCE_NAME));
+										new EventBuilder( AlarmChangeEventConstants.ALARM_SEVERITY_CHANGED_EVENT, EVENT_SOURCE_NAME));
 							}
-							eb.addParam("oldseverity",oldseverity);
+							
+							eb.addParam(AlarmChangeEventConstants.OLDSEVERITY_PARAM,oldseverity);
 
 							//copy in all values as json in params
-							eb.addParam(OLD_ALARM_VALUES,oldJsonObject.toString());
-							eb.addParam(NEW_ALARM_VALUES,newJsonObject.toString());
+							eb.addParam(AlarmChangeEventConstants.OLD_ALARM_VALUES_PARAM,oldJsonObject.toString());
+							eb.addParam(AlarmChangeEventConstants.NEW_ALARM_VALUES_PARAM,newJsonObject.toString());
 
 							sendEvent(eb.getEvent());
 						}
@@ -215,11 +199,11 @@ public class AlarmChangeNotificationClient implements NotificationClient {
 							if (LOG.isDebugEnabled()) LOG.debug("alarm acknowleged alarmid="+newJsonObject.get("alarmid"));
 
 							EventBuilder eb= jsonAlarmToEventBuilder(newJsonObject, 
-									new EventBuilder( ALARM_ACKNOWLEDGED_EVENT, EVENT_SOURCE_NAME));
+									new EventBuilder(AlarmChangeEventConstants.ALARM_ACKNOWLEDGED_EVENT, EVENT_SOURCE_NAME));
 
 							//copy in all values as json in params
-							eb.addParam(OLD_ALARM_VALUES,oldJsonObject.toString());
-							eb.addParam(NEW_ALARM_VALUES,newJsonObject.toString());
+							eb.addParam(AlarmChangeEventConstants.OLD_ALARM_VALUES_PARAM,oldJsonObject.toString());
+							eb.addParam(AlarmChangeEventConstants.NEW_ALARM_VALUES_PARAM,newJsonObject.toString());
 
 							sendEvent(eb.getEvent());
 
@@ -230,11 +214,11 @@ public class AlarmChangeNotificationClient implements NotificationClient {
 								if (LOG.isDebugEnabled()) LOG.debug("alarm unacknowleged alarmid="+newJsonObject.get("alarmid"));
 								//TODO issue unacknowledged doesn't have a user because only user and time in alarm field
 								EventBuilder eb= jsonAlarmToEventBuilder(newJsonObject, 
-										new EventBuilder( ALARM_UNACKNOWLEDGED_EVENT, EVENT_SOURCE_NAME));
+										new EventBuilder(AlarmChangeEventConstants.ALARM_UNACKNOWLEDGED_EVENT, EVENT_SOURCE_NAME));
 
 								//copy in all values as json in params
-								eb.addParam(OLD_ALARM_VALUES,oldJsonObject.toString());
-								eb.addParam(NEW_ALARM_VALUES,newJsonObject.toString());
+								eb.addParam(AlarmChangeEventConstants.OLD_ALARM_VALUES_PARAM,oldJsonObject.toString());
+								eb.addParam(AlarmChangeEventConstants.NEW_ALARM_VALUES_PARAM,newJsonObject.toString());
 
 								sendEvent(eb.getEvent());
 							}
@@ -249,11 +233,11 @@ public class AlarmChangeNotificationClient implements NotificationClient {
 							if (LOG.isDebugEnabled()) LOG.debug("alarm suppressed alarmid="+newJsonObject.get("alarmid"));
 
 							EventBuilder eb= jsonAlarmToEventBuilder(newJsonObject, 
-									new EventBuilder( ALARM_SUPPRESSED_EVENT, EVENT_SOURCE_NAME));
+									new EventBuilder(AlarmChangeEventConstants.ALARM_SUPPRESSED_EVENT, EVENT_SOURCE_NAME));
 
 							//copy in all values as json in params
-							eb.addParam(OLD_ALARM_VALUES,oldJsonObject.toString());
-							eb.addParam(NEW_ALARM_VALUES,newJsonObject.toString());
+							eb.addParam(AlarmChangeEventConstants.OLD_ALARM_VALUES_PARAM,oldJsonObject.toString());
+							eb.addParam(AlarmChangeEventConstants.NEW_ALARM_VALUES_PARAM,newJsonObject.toString());
 
 							sendEvent(eb.getEvent());
 
@@ -265,12 +249,12 @@ public class AlarmChangeNotificationClient implements NotificationClient {
 								//TODO issue unsuppress doesn't have a user because only user and time in alarm field
 								EventBuilder eb= jsonAlarmToEventBuilder(newJsonObject, 
 										new EventBuilder(
-												ALARM_UNSUPPRESSED_EVENT,
+												AlarmChangeEventConstants.ALARM_UNSUPPRESSED_EVENT,
 												EVENT_SOURCE_NAME));
 
 								//copy in all values as json in params
-								eb.addParam(OLD_ALARM_VALUES,oldJsonObject.toString());
-								eb.addParam(NEW_ALARM_VALUES,newJsonObject.toString());
+								eb.addParam(AlarmChangeEventConstants.OLD_ALARM_VALUES_PARAM,oldJsonObject.toString());
+								eb.addParam(AlarmChangeEventConstants.NEW_ALARM_VALUES_PARAM,newJsonObject.toString());
 
 								sendEvent(eb.getEvent());
 							}
@@ -292,15 +276,16 @@ public class AlarmChangeNotificationClient implements NotificationClient {
 									+" oldtticketstate="+oldtticketstate
 									+" newtticketstate="+newtticketstate);
 							EventBuilder eb= jsonAlarmToEventBuilder(newJsonObject, 
-									new EventBuilder( ALARM_TROUBLETICKET_STATE_CHANGE_EVENT, EVENT_SOURCE_NAME));
-							eb.addParam("oldtticketid",oldtticketid);
-							eb.addParam("tticketid",newtticketid);
-							eb.addParam("oldtticketstate",oldtticketstate);
-							eb.addParam("tticketstate",newtticketstate);
+									new EventBuilder( AlarmChangeEventConstants.ALARM_TROUBLETICKET_STATE_CHANGE_EVENT, EVENT_SOURCE_NAME));
+							
+							eb.addParam(AlarmChangeEventConstants.OLDTICKETID_PARAM,oldtticketid);
+							eb.addParam(AlarmChangeEventConstants.TTICKETID_PARAM,newtticketid);
+							eb.addParam(AlarmChangeEventConstants.OLDTTICKETSTATE_PARAM,oldtticketstate);
+							eb.addParam(AlarmChangeEventConstants.TTICKETSTATE_PARAM,newtticketstate);
 
 							//copy in all values as json in params
-							eb.addParam(OLD_ALARM_VALUES,oldJsonObject.toString());
-							eb.addParam(NEW_ALARM_VALUES,newJsonObject.toString());
+							eb.addParam(AlarmChangeEventConstants.OLD_ALARM_VALUES_PARAM,oldJsonObject.toString());
+							eb.addParam(AlarmChangeEventConstants.NEW_ALARM_VALUES_PARAM,newJsonObject.toString());
 
 							sendEvent(eb.getEvent());
 						}
@@ -313,12 +298,12 @@ public class AlarmChangeNotificationClient implements NotificationClient {
 							if (LOG.isDebugEnabled()) LOG.debug("Sticky memo added for alarmid="+oldJsonObject.get("alarmid")
 									+" newstickymemo="+newstickymemo);
 							EventBuilder eb= jsonAlarmToEventBuilder(newJsonObject, 
-									new EventBuilder( ALARM_STICKYMEMO_ADD_EVENT, EVENT_SOURCE_NAME));
-							eb.addParam("stickymemo",newstickymemo);
+									new EventBuilder(AlarmChangeEventConstants.ALARM_STICKYMEMO_ADD_EVENT, EVENT_SOURCE_NAME));
+							eb.addParam(AlarmChangeEventConstants.STICKYMEMO_PARAM,newstickymemo);
 
 							//copy in all values as json in params
-							eb.addParam(OLD_ALARM_VALUES,oldJsonObject.toString());
-							eb.addParam(NEW_ALARM_VALUES,newJsonObject.toString());
+							eb.addParam(AlarmChangeEventConstants.OLD_ALARM_VALUES_PARAM,oldJsonObject.toString());
+							eb.addParam(AlarmChangeEventConstants.NEW_ALARM_VALUES_PARAM,newJsonObject.toString());
 
 							sendEvent(eb.getEvent());
 						}
@@ -344,11 +329,11 @@ public class AlarmChangeNotificationClient implements NotificationClient {
 						if (! newobj.toString().equals(oldobj.toString())) {
 
 							EventBuilder eb= jsonAlarmToEventBuilder(oldJsonObject, 
-									new EventBuilder( ALARM_CHANGED_EVENT, EVENT_SOURCE_NAME));
+									new EventBuilder(AlarmChangeEventConstants.ALARM_CHANGED_EVENT, EVENT_SOURCE_NAME));
 
 							//copy in all values as json in params
-							eb.addParam(OLD_ALARM_VALUES,oldJsonObject.toString());
-							eb.addParam(NEW_ALARM_VALUES,newJsonObject.toString());
+							eb.addParam(AlarmChangeEventConstants.OLD_ALARM_VALUES_PARAM,oldJsonObject.toString());
+							eb.addParam(AlarmChangeEventConstants.NEW_ALARM_VALUES_PARAM,newJsonObject.toString());
 
 							sendEvent(eb.getEvent());
 						}
@@ -387,19 +372,18 @@ public class AlarmChangeNotificationClient implements NotificationClient {
 		String serviceid= (jsonObject.get("serviceid")==null) ? null : jsonObject.get("serviceid").toString();
 		String systemid= (jsonObject.get("systemid")==null) ? null : jsonObject.get("systemid").toString();
 
-
-		eb.addParam("alarmid", alarmId );
-		eb.addParam("severity", severity );
-		eb.addParam("logmsg", logmsg );
-		eb.addParam("clearkey", clearkey );
-		eb.addParam("alarmtype", alarmtype );
-		eb.addParam("alarmacktime", alarmacktime );
-		eb.addParam("alarmackuser", alarmackuser );
-		eb.addParam("suppressedtime", suppressedtime );
-		eb.addParam("suppresseduntil", suppresseduntil );
-		eb.addParam("suppresseduser", suppresseduser );
-		eb.addParam("eventuei", eventuei );
-		eb.addParam("reductionkey", reductionkey );
+		eb.addParam(AlarmChangeEventConstants.ALARMID_PARAM, alarmId );
+		eb.addParam(AlarmChangeEventConstants.ALARM_SEVERITY_PARAM, severity );
+		eb.addParam(AlarmChangeEventConstants.LOGMSG_PARAM, logmsg );
+		eb.addParam(AlarmChangeEventConstants.CLEARKEY_PARAM, clearkey );
+		eb.addParam(AlarmChangeEventConstants.ALARMTYPE_PARAM, alarmtype );
+		eb.addParam(AlarmChangeEventConstants.ALARMACKTIME_PARAM, alarmacktime );
+		eb.addParam(AlarmChangeEventConstants.ALARMACKUSER_PARAM, alarmackuser );
+		eb.addParam(AlarmChangeEventConstants.SUPPRESSEDTIME_PARAM, suppressedtime );
+		eb.addParam(AlarmChangeEventConstants.SUPPRESSEDUNTIL_PARAM, suppresseduntil );
+		eb.addParam(AlarmChangeEventConstants.SUPPRESSEDUSER_PARAM, suppresseduser );
+		eb.addParam(AlarmChangeEventConstants.EVENTUEI_PARAM, eventuei );
+		eb.addParam(AlarmChangeEventConstants.REDUCTIONKEY_PARAM, reductionkey );
 
 		if(nodeid!=null) eb.setNodeid(Long.parseLong(nodeid));
 		if (ipaddr!= null) try {
@@ -409,9 +393,10 @@ public class AlarmChangeNotificationClient implements NotificationClient {
 			LOG.error("cannot parse json object ipaddr="+ipaddr,e);
 		}
 		if (ifindex!=null) eb.setIfIndex(Integer.parseInt(ifindex));
-		eb.addParam("applicationdn",applicationdn);
-		eb.addParam("serviceid",serviceid);
-		eb.addParam("systemid",systemid);
+
+		eb.addParam(AlarmChangeEventConstants.APPLICATIONDN_PARAM,applicationdn);
+		eb.addParam(AlarmChangeEventConstants.SERVICEID_PARAM,serviceid);
+		eb.addParam(AlarmChangeEventConstants.SYSTEMID_PARAM,systemid);
 
 		return eb;
 	}
@@ -519,8 +504,6 @@ public class AlarmChangeNotificationClient implements NotificationClient {
 
 	@Override
 	public void destroy() {
-		// TODO Auto-generated method stub
-
 	}
 
 }

--- a/features/alarm-change-notifier/main-module/src/main/java/org/opennms/plugins/dbnotifier/alarmnotifier/AlarmChangeNotificationClient.java
+++ b/features/alarm-change-notifier/main-module/src/main/java/org/opennms/plugins/dbnotifier/alarmnotifier/AlarmChangeNotificationClient.java
@@ -377,8 +377,8 @@ public class AlarmChangeNotificationClient implements NotificationClient {
 		eb.addParam(AlarmChangeEventConstants.LOGMSG_PARAM, logmsg );
 		eb.addParam(AlarmChangeEventConstants.CLEARKEY_PARAM, clearkey );
 		eb.addParam(AlarmChangeEventConstants.ALARMTYPE_PARAM, alarmtype );
-		eb.addParam(AlarmChangeEventConstants.ALARMACKTIME_PARAM, alarmacktime );
-		eb.addParam(AlarmChangeEventConstants.ALARMACKUSER_PARAM, alarmackuser );
+		eb.addParam(AlarmChangeEventConstants.ALARM_ACK_TIME_PARAM, alarmacktime );
+		eb.addParam(AlarmChangeEventConstants.ALARM_ACK_USER_PARAM, alarmackuser );
 		eb.addParam(AlarmChangeEventConstants.SUPPRESSEDTIME_PARAM, suppressedtime );
 		eb.addParam(AlarmChangeEventConstants.SUPPRESSEDUNTIL_PARAM, suppresseduntil );
 		eb.addParam(AlarmChangeEventConstants.SUPPRESSEDUSER_PARAM, suppresseduser );

--- a/features/alarm-change-notifier/main-module/src/main/java/org/opennms/plugins/dbnotifier/alarmnotifier/MemosChangeNotificationClient.java
+++ b/features/alarm-change-notifier/main-module/src/main/java/org/opennms/plugins/dbnotifier/alarmnotifier/MemosChangeNotificationClient.java
@@ -60,17 +60,6 @@ public class MemosChangeNotificationClient implements NotificationClient {
 
 	public static final String EVENT_SOURCE_NAME = "AlarmChangeNotifier";
 
-	// uei definitions of memo change events
-	public static final String STICKY_MEMO_EVENT = "uei.opennms.org/plugin/AlarmChangeNotificationEvent/StickyMemoUpdate";
-	public static final String JOURNAL_MEMO_EVENT = "uei.opennms.org/plugin/AlarmChangeNotificationEvent/JournalMemoUpdate";
-	
-	// param names in memo change events
-	public static final String MEMO_VALUES_PARAM="memovalues";
-	public static final String MEMO_ALARMID_PARAM="alarmid";
-	public static final String MEMO_BODY_PARAM="body";
-	public static final String MEMO_AUTHOR_PARAM="author";
-	public static final String MEMO_REDUCTIONKEY_PARAM="reductionkey";
-
 	EventProxy eventProxy = null;
 
 	public EventProxy getEventProxy() {
@@ -118,25 +107,25 @@ public class MemosChangeNotificationClient implements NotificationClient {
 				// sticky note event
 				if("Memo".equals(memoJsonObject.get("type").toString())) {
 					if (LOG.isDebugEnabled()) LOG.debug("sticky memo updated="+memoJsonObject.get("id"));
-					EventBuilder eb= new EventBuilder( STICKY_MEMO_EVENT, EVENT_SOURCE_NAME);
+					EventBuilder eb= new EventBuilder( AlarmChangeEventConstants.STICKY_MEMO_EVENT, EVENT_SOURCE_NAME);
 
 					//copy in all values as json in params
-					eb.addParam(MEMO_VALUES_PARAM,memoJsonObject.toString());
-					eb.addParam(MEMO_ALARMID_PARAM, alarmId );
-					eb.addParam(MEMO_BODY_PARAM, body );
-					eb.addParam(MEMO_AUTHOR_PARAM, author );
+					eb.addParam(AlarmChangeEventConstants.MEMO_VALUES_PARAM,memoJsonObject.toString());
+					eb.addParam(AlarmChangeEventConstants.MEMO_ALARMID_PARAM, alarmId );
+					eb.addParam(AlarmChangeEventConstants.MEMO_BODY_PARAM, body );
+					eb.addParam(AlarmChangeEventConstants.MEMO_AUTHOR_PARAM, author );
 
 					sendEvent(eb.getEvent());
 				} else if("ReductionKeyMemo".equals(memoJsonObject.get("type").toString())) {
 					if (LOG.isDebugEnabled()) LOG.debug("reduction key memo updated="+memoJsonObject.get("id"));
-					EventBuilder eb= new EventBuilder( JOURNAL_MEMO_EVENT, EVENT_SOURCE_NAME);
+					EventBuilder eb= new EventBuilder(AlarmChangeEventConstants.JOURNAL_MEMO_EVENT, EVENT_SOURCE_NAME);
 
 					//copy in all values as json in params
-					eb.addParam(MEMO_VALUES_PARAM,memoJsonObject.toString());
-					eb.addParam(MEMO_ALARMID_PARAM, alarmId );
-					eb.addParam(MEMO_BODY_PARAM, body );
-					eb.addParam(MEMO_AUTHOR_PARAM, author );
-					eb.addParam(MEMO_REDUCTIONKEY_PARAM, reductionkey );
+					eb.addParam(AlarmChangeEventConstants.MEMO_VALUES_PARAM,memoJsonObject.toString());
+					eb.addParam(AlarmChangeEventConstants.MEMO_ALARMID_PARAM, alarmId );
+					eb.addParam(AlarmChangeEventConstants.MEMO_BODY_PARAM, body );
+					eb.addParam(AlarmChangeEventConstants.MEMO_AUTHOR_PARAM, author );
+					eb.addParam(AlarmChangeEventConstants.MEMO_REDUCTIONKEY_PARAM, reductionkey );
 
 					sendEvent(eb.getEvent());
 				}
@@ -233,8 +222,6 @@ public class MemosChangeNotificationClient implements NotificationClient {
 
 	@Override
 	public void destroy() {
-		// TODO Auto-generated method stub
-
 	}
 
 }

--- a/features/internal-plugins-descriptor/pom.xml
+++ b/features/internal-plugins-descriptor/pom.xml
@@ -1,5 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="
+    http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd
+">
 
   <parent>
     <groupId>org.opennms</groupId>
@@ -85,6 +89,33 @@
               </features>
               <repository>${project.build.directory}/temp-features-repo</repository>
             </configuration>
+          </execution>
+        </executions>
+        <dependencies>
+          <dependency>
+            <groupId>org.apache.maven.wagon</groupId>
+            <artifactId>wagon-http</artifactId>
+            <version>2.8</version>
+          </dependency>
+        </dependencies>
+      </plugin>
+
+      <plugin>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>create-temp-features-repo</id>
+            <phase>initialize</phase>
+            <configuration>
+              <target>
+                <delete dir="${project.build.directory}/temp-features-repo" />
+                <mkdir dir="${project.build.directory}/temp-features-repo" />
+                <echo>PLEASE NOTE The exec-maven-plugin runs ProductSpecListGenerator twice. The second time generates useful output.</echo>
+              </target>
+            </configuration>
+            <goals>
+              <goal>run</goal>
+            </goals>
           </execution>
         </executions>
       </plugin>

--- a/features/opennms-es-rest/main-module/src/main/java/org/opennms/plugins/elasticsearch/rest/EventToIndex.java
+++ b/features/opennms-es-rest/main-module/src/main/java/org/opennms/plugins/elasticsearch/rest/EventToIndex.java
@@ -109,23 +109,6 @@ public class EventToIndex implements AutoCloseable {
 	public static final String ALARM_TROUBLETICKET_STATE_CHANGE_EVENT = "uei.opennms.org/plugin/AlarmChangeNotificationEvent/TroubleTicketStateChange";
 	public static final String ALARM_CHANGED_EVENT = "uei.opennms.org/plugin/AlarmChangeNotificationEvent/AlarmChanged";
 
-	public static final String OLD_ALARM_VALUES_PARAM="oldalarmvalues";
-	public static final String NEW_ALARM_VALUES_PARAM="newalarmvalues";
-
-	public static final String NODE_LABEL_PARAM="nodelabel";
-	public static final String INITIAL_SEVERITY_PARAM="initialseverity";
-	public static final String INITIAL_SEVERITY_PARAM_TEXT="initialseverity_text";
-	public static final String ALARM_SEVERITY_PARAM_TEXT="alarmseverity_text";
-	public static final String ALARM_SEVERITY_PARAM="alarmseverity";
-	public static final String FIRST_EVENT_TIME="firsteventtime";
-	public static final String EVENT_PARAMS="eventparms";
-	public static final String ALARM_ACK_TIME_PARAM="alarmacktime";
-	public static final String ALARM_ACK_USER_PARAM="alarmackuser";
-	public static final String ALARM_ACK_DURATION="alarmackduration"; // duration from alarm raise to acknowledge
-	public static final String ALARM_CLEAR_TIME="alarmcleartime";
-	public static final String ALARM_CLEAR_DURATION="alarmclearduration"; //duration from alarm raise to clear
-	public static final String ALARM_DELETED_TIME="alarmdeletedtime";
-
 	// uei definitions of memo change events
 	// TODO: Move these into EventConstants
 	public static final String STICKY_MEMO_EVENT = "uei.opennms.org/plugin/AlarmChangeNotificationEvent/StickyMemoUpdate";
@@ -138,6 +121,25 @@ public class EventToIndex implements AutoCloseable {
 	public static final String MEMO_BODY_PARAM="body";
 	public static final String MEMO_AUTHOR_PARAM="author";
 	public static final String MEMO_REDUCTIONKEY_PARAM="reductionkey";
+
+	public static final String OLD_ALARM_VALUES_PARAM="oldalarmvalues";
+	public static final String NEW_ALARM_VALUES_PARAM="newalarmvalues";
+
+	public static final String NODE_LABEL_PARAM="nodelabel";
+	public static final String INITIAL_SEVERITY_PARAM="initialseverity";
+	public static final String INITIAL_SEVERITY_PARAM_TEXT="initialseverity_text";
+	public static final String SEVERITY_TEXT="severity_text";
+	public static final String SEVERITY="severity";
+	public static final String ALARM_SEVERITY_PARAM="alarmseverity";
+	public static final String FIRST_EVENT_TIME="firsteventtime";
+	public static final String EVENT_PARAMS="eventparms";
+	public static final String ALARM_ACK_TIME_PARAM="alarmacktime";
+	public static final String ALARM_ACK_USER_PARAM="alarmackuser";
+	public static final String ALARM_ACK_DURATION="alarmackduration"; // duration from alarm raise to acknowledge
+	public static final String ALARM_CLEAR_TIME="alarmcleartime";
+	public static final String ALARM_CLEAR_DURATION="alarmclearduration"; //duration from alarm raise to clear
+	public static final String ALARM_DELETED_TIME="alarmdeletedtime";
+
 
 	public static final int DEFAULT_NUMBER_OF_THREADS = Runtime.getRuntime().availableProcessors() * 2;
 
@@ -773,8 +775,9 @@ public class EventToIndex implements AutoCloseable {
 				try{
 					int id= Integer.parseInt(value);
 					String label = OnmsSeverity.get(id).getLabel();
-					body.put(ALARM_SEVERITY_PARAM,value);
-					body.put(ALARM_SEVERITY_PARAM_TEXT,label);
+					// note alarm index uses severity even though alarm severity param is p_alarmseverity
+					body.put(SEVERITY,value);
+					body.put(SEVERITY_TEXT,label);
 				}
 				catch (Exception e){
 					LOG.error("cannot parse severity for alarm change event id"+event.getDbid());

--- a/features/opennms-es-rest/main-module/src/main/java/org/opennms/plugins/elasticsearch/rest/EventToIndex.java
+++ b/features/opennms-es-rest/main-module/src/main/java/org/opennms/plugins/elasticsearch/rest/EventToIndex.java
@@ -109,18 +109,18 @@ public class EventToIndex implements AutoCloseable {
 	public static final String ALARM_TROUBLETICKET_STATE_CHANGE_EVENT = "uei.opennms.org/plugin/AlarmChangeNotificationEvent/TroubleTicketStateChange";
 	public static final String ALARM_CHANGED_EVENT = "uei.opennms.org/plugin/AlarmChangeNotificationEvent/AlarmChanged";
 
-	public static final String OLD_ALARM_VALUES="oldalarmvalues";
-	public static final String NEW_ALARM_VALUES="newalarmvalues";
+	public static final String OLD_ALARM_VALUES_PARAM="oldalarmvalues";
+	public static final String NEW_ALARM_VALUES_PARAM="newalarmvalues";
 
-	public static final String NODE_LABEL="nodelabel";
-	public static final String INITIAL_SEVERITY="initialseverity";
-	public static final String INITIAL_SEVERITY_TEXT="initialseverity_text";
-	public static final String SEVERITY_TEXT="severity_text";
-	public static final String ALARM_SEVERITY="alarmseverity";
+	public static final String NODE_LABEL_PARAM="nodelabel";
+	public static final String INITIAL_SEVERITY_PARAM="initialseverity";
+	public static final String INITIAL_SEVERITY_PARAM_TEXT="initialseverity_text";
+	public static final String ALARM_SEVERITY_PARAM_TEXT="alarmseverity_text";
+	public static final String ALARM_SEVERITY_PARAM="alarmseverity";
 	public static final String FIRST_EVENT_TIME="firsteventtime";
 	public static final String EVENT_PARAMS="eventparms";
-	public static final String ALARM_ACK_TIME="alarmacktime";
-	public static final String ALARM_ACK_USER="alarmackuser";
+	public static final String ALARM_ACK_TIME_PARAM="alarmacktime";
+	public static final String ALARM_ACK_USER_PARAM="alarmackuser";
 	public static final String ALARM_ACK_DURATION="alarmackduration"; // duration from alarm raise to acknowledge
 	public static final String ALARM_CLEAR_TIME="alarmcleartime";
 	public static final String ALARM_CLEAR_DURATION="alarmclearduration"; //duration from alarm raise to clear
@@ -627,11 +627,11 @@ public class EventToIndex implements AutoCloseable {
 
 		// remove old and new alarm values parms if not needed
 		if(! archiveNewAlarmValues){
-			body.remove("p_"+OLD_ALARM_VALUES);
+			body.remove("p_"+OLD_ALARM_VALUES_PARAM);
 		}
 
 		if(! archiveOldAlarmValues){
-			body.remove("p_"+NEW_ALARM_VALUES);
+			body.remove("p_"+NEW_ALARM_VALUES_PARAM);
 		}
 
 		body.put("interface", event.getInterface());
@@ -642,8 +642,8 @@ public class EventToIndex implements AutoCloseable {
 			body.put("nodeid", Long.toString(event.getNodeid()));
 
 			// if the event contains nodelabel parameter then do not use node cache
-			if(body.containsKey("p_"+NODE_LABEL)){
-				body.put(NODE_LABEL,body.get("p_"+NODE_LABEL));
+			if(body.containsKey("p_"+NODE_LABEL_PARAM)){
+				body.put(NODE_LABEL_PARAM,body.get("p_"+NODE_LABEL_PARAM));
 			} else {
 				// add node details from cache
 				if (nodeCache!=null){
@@ -708,8 +708,8 @@ public class EventToIndex implements AutoCloseable {
 			parmsMap.put( parm.getParmName(), parm.getValue().getContent());
 		}
 
-		String oldValuesStr=parmsMap.get(OLD_ALARM_VALUES);
-		String newValuesStr=parmsMap.get(NEW_ALARM_VALUES);
+		String oldValuesStr=parmsMap.get(OLD_ALARM_VALUES_PARAM);
+		String newValuesStr=parmsMap.get(NEW_ALARM_VALUES_PARAM);
 
 		if (LOG.isDebugEnabled()) LOG.debug("AlarmChangeEvent from eventid "+event.getDbid()
 				+ "\n  newValuesStr="+newValuesStr
@@ -769,12 +769,12 @@ public class EventToIndex implements AutoCloseable {
 				for(Parm parm : params) {
 					body.put("p_" + parm.getParmName(), parm.getValue().getContent());
 				}
-			} else if((ALARM_SEVERITY.equals(key) && value!=null)){ 
+			} else if((ALARM_SEVERITY_PARAM.equals(key) && value!=null)){ 
 				try{
 					int id= Integer.parseInt(value);
 					String label = OnmsSeverity.get(id).getLabel();
-					body.put(ALARM_SEVERITY,value);
-					body.put(SEVERITY_TEXT,label);
+					body.put(ALARM_SEVERITY_PARAM,value);
+					body.put(ALARM_SEVERITY_PARAM_TEXT,label);
 				}
 				catch (Exception e){
 					LOG.error("cannot parse severity for alarm change event id"+event.getDbid());
@@ -833,19 +833,19 @@ public class EventToIndex implements AutoCloseable {
 		}
 
 		// remove ack if not in parameters i,e alarm not acknowleged
-		if(parmsMap.get(ALARM_ACK_TIME)==null || "".equals(parmsMap.get(ALARM_ACK_TIME)) ){
-			body.put(ALARM_ACK_TIME, null);
-			body.put(ALARM_ACK_USER, null);
+		if(parmsMap.get(ALARM_ACK_TIME_PARAM)==null || "".equals(parmsMap.get(ALARM_ACK_TIME_PARAM)) ){
+			body.put(ALARM_ACK_TIME_PARAM, null);
+			body.put(ALARM_ACK_USER_PARAM, null);
 		}
 
 		// add "initialseverity"
-		if(parmsMap.get(INITIAL_SEVERITY)!=null){
+		if(parmsMap.get(INITIAL_SEVERITY_PARAM)!=null){
 			try{
-				String severityId = parmsMap.get(INITIAL_SEVERITY);
+				String severityId = parmsMap.get(INITIAL_SEVERITY_PARAM);
 				int id= Integer.parseInt(severityId);
 				String label = OnmsSeverity.get(id).getLabel();
-				body.put(INITIAL_SEVERITY,severityId);
-				body.put(INITIAL_SEVERITY_TEXT,label);
+				body.put(INITIAL_SEVERITY_PARAM,severityId);
+				body.put(INITIAL_SEVERITY_PARAM_TEXT,label);
 			}
 			catch (Exception e){
 				LOG.error("cannot parse initial severity for alarm change event id"+event.getDbid());
@@ -853,8 +853,8 @@ public class EventToIndex implements AutoCloseable {
 		}
 
 		// if the event contains nodelabel parameter then do not use node cache
-		if (parmsMap.get(NODE_LABEL)!=null){
-			body.put(NODE_LABEL, parmsMap.get(NODE_LABEL));
+		if (parmsMap.get(NODE_LABEL_PARAM)!=null){
+			body.put(NODE_LABEL_PARAM, parmsMap.get(NODE_LABEL_PARAM));
 		} else {
 			// add node details from cache
 			if (nodeCache!=null && event.getNodeid()!=null){

--- a/features/opennms-es-rest/main-module/src/main/java/org/opennms/plugins/elasticsearch/rest/EventToIndex.java
+++ b/features/opennms-es-rest/main-module/src/main/java/org/opennms/plugins/elasticsearch/rest/EventToIndex.java
@@ -116,7 +116,7 @@ public class EventToIndex implements AutoCloseable {
 	public static final String INITIAL_SEVERITY="initialseverity";
 	public static final String INITIAL_SEVERITY_TEXT="initialseverity_text";
 	public static final String SEVERITY_TEXT="severity_text";
-	public static final String SEVERITY="severity";
+	public static final String ALARM_SEVERITY="alarmseverity";
 	public static final String FIRST_EVENT_TIME="firsteventtime";
 	public static final String EVENT_PARAMS="eventparms";
 	public static final String ALARM_ACK_TIME="alarmacktime";
@@ -769,11 +769,11 @@ public class EventToIndex implements AutoCloseable {
 				for(Parm parm : params) {
 					body.put("p_" + parm.getParmName(), parm.getValue().getContent());
 				}
-			} else if((SEVERITY.equals(key) && value!=null)){ 
+			} else if((ALARM_SEVERITY.equals(key) && value!=null)){ 
 				try{
 					int id= Integer.parseInt(value);
 					String label = OnmsSeverity.get(id).getLabel();
-					body.put(SEVERITY,value);
+					body.put(ALARM_SEVERITY,value);
 					body.put(SEVERITY_TEXT,label);
 				}
 				catch (Exception e){

--- a/features/opennms-es-rest/main-module/src/main/resources/eventsIndexTemplate.json
+++ b/features/opennms-es-rest/main-module/src/main/resources/eventsIndexTemplate.json
@@ -58,6 +58,15 @@
                "hour":{
                   "type":"long"
                },
+               "p_alarmseverity":{
+                  "type":"long"
+               },
+               "p_oldseverity":{
+                  "type":"long"
+               },              
+               "p_initialseverity":{
+                  "type":"long"
+               }, 
                "alarmackduration":{
                   "type":"long"
                },           

--- a/features/opennms-es-rest/main-module/src/test/java/org/opennms/plugins/elasticsearch/test/AlarmEventToIndexTest.java
+++ b/features/opennms-es-rest/main-module/src/test/java/org/opennms/plugins/elasticsearch/test/AlarmEventToIndexTest.java
@@ -53,6 +53,8 @@ import io.searchbox.core.SearchResult;
 
 public class AlarmEventToIndexTest {
 	private static final Logger LOG = LoggerFactory.getLogger(AlarmEventToIndexTest.class);
+	
+	public static final int INDEX_WAIT_SECONDS=10; // time to wait for index to catch up
 
 	public static final String ALARM_INDEX_NAME = "opennms-alarms";
 	public static final String ALARM_EVENT_INDEX_NAME = "opennms-events-alarmchange";
@@ -151,9 +153,9 @@ public class AlarmEventToIndexTest {
 			// forward event to Elasticsearch
 			eventToIndex.forwardEvents(Collections.singletonList(event));
 
-			// waiting 5 seconds for index 
+			// waiting INDEX_WAIT_SECONDS seconds for index 
 			try {
-				TimeUnit.SECONDS.sleep(5);
+				TimeUnit.SECONDS.sleep(INDEX_WAIT_SECONDS);
 			} catch (InterruptedException e) { }
 
 			// send query to check that alarm has been created
@@ -193,9 +195,9 @@ public class AlarmEventToIndexTest {
 			assertEquals(Long.valueOf(1), hits.get("total"));
 			
 			
-			// waiting 5 seconds for index 
+			// waiting INDEX_WAIT_SECONDS seconds for index 
             try {
-            	TimeUnit.SECONDS.sleep(5);
+            	TimeUnit.SECONDS.sleep(INDEX_WAIT_SECONDS);
             } catch (InterruptedException e) { }
 			
 			// search for resulting alarm change event

--- a/opennms-base-assembly/src/main/filtered/etc/events/AlarmChangeNotifierEvents.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/events/AlarmChangeNotifierEvents.xml
@@ -74,9 +74,9 @@
     <uei>uei.opennms.org/plugin/AlarmChangeNotificationEvent/AlarmSeverityChanged</uei>
     <event-label>Alarm Change Notification Event : Alarm Severity Changed</event-label>
     <descr>
-    &lt;p&gt;Alarm &lt;a href="/opennms/alarm/detail.htm?id=%parm[alarmid]%"&gt;%parm[alarmid]%&lt;/a&gt; Severity Changed to %parm[severity]%&lt;p&gt;
+    &lt;p&gt;Alarm &lt;a href="/opennms/alarm/detail.htm?id=%parm[alarmid]%"&gt;%parm[alarmid]%&lt;/a&gt; Severity Changed to %parm[alarmseverity]%&lt;p&gt;
     
-    &lt;p&gt;New Alarm Severity %parm[severity]%&lt;p&gt;
+    &lt;p&gt;New Alarm Severity %parm[alarmseverity]%&lt;p&gt;
     
     &lt;p&gt;Old Alarm Severity %parm[oldseverity]%&lt;p&gt;
     
@@ -85,7 +85,7 @@
     
     </descr>
     <logmsg dest="logndisplay">
-    &lt;p&gt;Alarm &lt;a href="/opennms/alarm/detail.htm?id=%parm[alarmid]%"&gt;%parm[alarmid]%&lt;/a&gt; Severity Changed to %parm[severity]%&lt;p&gt;
+    &lt;p&gt;Alarm &lt;a href="/opennms/alarm/detail.htm?id=%parm[alarmid]%"&gt;%parm[alarmid]%&lt;/a&gt; Severity Changed to %parm[alarmseverity]%&lt;p&gt;
     </logmsg>
     <severity>Normal</severity>
     <operinstruct></operinstruct>

--- a/opennms-doc/guide-admin/src/asciidoc/text/plugins/opennms-es-rest-mapping-table.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/plugins/opennms-es-rest-mapping-table.adoc
@@ -306,7 +306,7 @@ _Alarm Change Events:_
 
 Corresponds to the alarm's service ID.
 
-| "severity": "2", |"severity": |"p_severity": | "p_severity": "2",
+| "severity": "2", |"severity": |"p_alarmseverity": | "p_alarmseverity": "2",
 |string |
 _Alarm Change Events:_
 


### PR DESCRIPTION
* JIRA: https://issues.opennms.org/browse/NMS-9276
* bamboo http://bamboo.internal.opennms.com:8085/browse/OPENNMS-ONMS1478-COMPILE

Canged name of alarm change event parm from 'severity' (p_severity)  to 'alarmseverity' (p_alarmseverity). 
Changed Elastic search configuration in eventsIndexTemplate.json  to treat p_alarmseverity, p_initialseverity and p_oldseverity as integers instead of text so that they can be ranked in kibana

Also fixed build of internal-plugins-descriptor/pom.xml  to remove suspected compile errors. (Previously these errors were logged but in fact were not effecting build)