### PR TITLE
NMS-9279: Upgrade Drools to 6.5.0

### DIFF
--- a/dependencies/drools/pom.xml
+++ b/dependencies/drools/pom.xml
@@ -15,7 +15,7 @@
     can depend on to use the drools library.
   </description>
   <properties>
-    <droolsVersion>6.4.0.Final</droolsVersion>
+    <droolsVersion>6.5.0.Final</droolsVersion>
   </properties>
   <dependencies>
     <dependency>


### PR DESCRIPTION
The correlator compiles, and all its tests are passing.

* JIRA: http://issues.opennms.org/browse/NMS-9279

Our [continuous integration system](http://bamboo.internal.opennms.com:8085) will test and verify your changes.
