### PR TITLE
NMS-9068: remove opennms.conf include from secondary scripts

### DIFF
--- a/opennms-base-assembly/src/main/filtered/bin/liquibase
+++ b/opennms-base-assembly/src/main/filtered/bin/liquibase
@@ -3,10 +3,6 @@
 OPENNMS_HOME="${install.dir}"
 OPENNMS_BINDIR="${install.bin.dir}"
 
-if [ -f "$OPENNMS_HOME/etc/opennms.conf" ]; then
-	. "$OPENNMS_HOME/etc/opennms.conf"
-fi
-
 for file in $OPENNMS_HOME/lib/*.jar; do
 	export CLASSPATH="$file:$CLASSPATH"
 done

--- a/opennms-base-assembly/src/main/filtered/bin/microblog-auth
+++ b/opennms-base-assembly/src/main/filtered/bin/microblog-auth
@@ -3,10 +3,6 @@
 OPENNMS_HOME="${install.dir}"
 OPENNMS_BINDIR="${install.bin.dir}"
 
-if [ -f "$OPENNMS_HOME/etc/opennms.conf" ]; then
-	. "$OPENNMS_HOME/etc/opennms.conf"
-fi
-
 exec "$OPENNMS_BINDIR"/runjava -r -- \
 	$ADDITIONAL_MANAGER_OPTIONS \
 	-Dopennms.home="$OPENNMS_HOME" \

--- a/opennms-base-assembly/src/main/filtered/bin/snmp-request
+++ b/opennms-base-assembly/src/main/filtered/bin/snmp-request
@@ -3,10 +3,6 @@
 OPENNMS_HOME="${install.dir}"
 OPENNMS_BINDIR="${install.bin.dir}"
 
-if [ -f "$OPENNMS_HOME/etc/opennms.conf" ]; then
-	. "$OPENNMS_HOME/etc/opennms.conf"
-fi
-
 SNMP4J_JAR=`ls -1 $OPENNMS_HOME/lib/snmp4j-*.jar | grep -v snmp4j-agent | tail -n 1`
 if [ -f $SNMP4J_JAR ]; then
 	echo "Using SNMP4J from: $SNMP4J_JAR"

--- a/opennms-base-assembly/src/main/filtered/bin/system-report
+++ b/opennms-base-assembly/src/main/filtered/bin/system-report
@@ -4,10 +4,6 @@ OPENNMS_HOME="${install.dir}"
 OPENNMS_BINDIR="${install.bin.dir}"
 APP_CLASS="org.opennms.systemreport.SystemReport"
 
-if [ -f "$OPENNMS_HOME/etc/opennms.conf" ]; then
-	. "$OPENNMS_HOME/etc/opennms.conf"
-fi
-
 exec "$OPENNMS_BINDIR"/runjava -r -- \
 	$ADDITIONAL_MANAGER_OPTIONS \
 	-Dopennms.home="$OPENNMS_HOME" \


### PR DESCRIPTION
This PR removes the inclusion of `opennms.conf` from a number of scripts where it doesn't make sense.

Support folks, since you're most likely to run into them, mind looking it over and let me know if there's any reason any of these still need to include it.

* JIRA: http://issues.opennms.org/browse/NMS-9068
