### PR TITLE
NMS-9283: Fixed missing quartz dependency in datachoices feature

### DIFF
--- a/container/features/src/main/resources/features.xml
+++ b/container/features/src/main/resources/features.xml
@@ -393,6 +393,7 @@
     </feature>
     
     <feature name="quartz" description="quartz" version="${quartzVersion}">
+      <feature>c3p0</feature>
       <bundle>wrap:mvn:org.quartz-scheduler/quartz/${quartzVersion}</bundle>
     </feature>
     
@@ -772,14 +773,13 @@
       <feature>commons-beanutils</feature>
       <feature>commons-io</feature>
       <feature>fop</feature>
+      <feature>quartz</feature>
 
       <feature>opennms-config</feature>
       <feature>opennms-core</feature>
       <feature>opennms-core-db</feature>
       <feature>opennms-dao-api</feature>
       <feature>opennms-javamail</feature>
-
-      <bundle>wrap:mvn:org.quartz-scheduler/quartz/2.1.5</bundle>
 
       <bundle>mvn:org.opennms/opennms-reporting/${project.version}</bundle>
       <bundle>mvn:org.opennms.features.reporting/org.opennms.features.reporting.api/${project.version}</bundle>
@@ -908,6 +908,7 @@
       <feature>jfreechart</feature>
       <feature>jrobin</feature>
       <feature>json-lib</feature>
+      <feature>quartz</feature>
       <feature>spring-webflow</feature>
 
       <feature>opennms-config</feature>
@@ -918,7 +919,6 @@
       <bundle>wrap:mvn:xalan/xalan/2.7.2</bundle>
       <bundle>wrap:mvn:xalan/serializer/2.7.2</bundle>
       <bundle>mvn:joda-time/joda-time/${jodaTimeVersion}</bundle>
-      <bundle>wrap:mvn:org.quartz-scheduler/quartz/2.1.5</bundle>
       <bundle>wrap:mvn:org.w3c.css/sac/1.3</bundle>
       <bundle>mvn:com.vaadin.external.flute/flute/1.3.0.gg2</bundle>
       <bundle>wrap:mvn:net.sourceforge.cssparser/cssparser/0.9.11</bundle>

--- a/features/datachoices/pom.xml
+++ b/features/datachoices/pom.xml
@@ -36,6 +36,7 @@
                     <features>
                         <feature>guava</feature>
                         <feature>hibernate36</feature> <!-- Required by opennms-web-api -->
+                        <feature>quartz</feature> <!-- Required by opennms-web-api -->
                     </features>
                     <bundles>
                         <bundle>mvn:org.opennms.features/datachoices/${project.version}</bundle>


### PR DESCRIPTION
This was causing a bundle failure in the latest OpenNMS builds.

* JIRA: http://issues.opennms.org/browse/NMS-9283