### PR TITLE
HZN-1047: Added ability to override patterns for RadixTreeSyslogParser

### DIFF
--- a/core/lib/src/main/java/org/opennms/core/collections/RadixTreeNodeImpl.java
+++ b/core/lib/src/main/java/org/opennms/core/collections/RadixTreeNodeImpl.java
@@ -112,8 +112,8 @@ public class RadixTreeNodeImpl<T> implements RadixTreeNode<T> {
 	public int size() {
 		// Sum up the size of the children
 		int retval = getChildren().stream().collect(Collectors.summingInt(RadixTreeNode::size));
-		// And add 1
-		return ++retval;
+		// And add 1 if our node has content
+		return content == null ? retval : ++retval;
 	}
 
 	@Override

--- a/core/lib/src/main/java/org/opennms/core/utils/ConfigFileConstants.java
+++ b/core/lib/src/main/java/org/opennms/core/utils/ConfigFileConstants.java
@@ -196,6 +196,11 @@ public abstract class ConfigFileConstants {
      */
     public static final int SYSLOGD_CONFIG_FILE_NAME;
 
+    /**
+     * The grok pattern file for Syslogd's {@link RadixTreeSyslogParser}
+     */
+    public static final int SYSLOGD_GROK_PATTERNS_FILE_NAME;
+
     //
     // End services config files
     //
@@ -530,7 +535,9 @@ public abstract class ConfigFileConstants {
         TRANSLATOR_CONFIG_FILE_NAME = 57;
 
         SYSLOGD_CONFIG_FILE_NAME = 58;
-        
+
+        SYSLOGD_GROK_PATTERNS_FILE_NAME = 59;
+
         SURVEILLANCE_VIEWS_FILE_NAME = 61;
         
         SITE_STATUS_VIEWS_FILE_NAME = 62;
@@ -643,6 +650,7 @@ public abstract class ConfigFileConstants {
         FILE_ID_TO_NAME[JMX_DATA_COLLECTION_CONF_FILE_NAME] = "jmx-datacollection-config.xml";
         FILE_ID_TO_NAME[TRANSLATOR_CONFIG_FILE_NAME] = "translator-configuration.xml";
         FILE_ID_TO_NAME[SYSLOGD_CONFIG_FILE_NAME] = "syslogd-configuration.xml";
+        FILE_ID_TO_NAME[SYSLOGD_GROK_PATTERNS_FILE_NAME] = "syslogd-grok-patterns.txt";
         FILE_ID_TO_NAME[ENLINKD_CONFIG_FILE_NAME] = "enlinkd-configuration.xml";
         FILE_ID_TO_NAME[SURVEILLANCE_VIEWS_FILE_NAME] = "surveillance-views.xml";
         FILE_ID_TO_NAME[SITE_STATUS_VIEWS_FILE_NAME] = "site-status-views.xml";

--- a/features/events/syslog/src/main/java/org/opennms/netmgt/syslogd/RadixTreeParser.java
+++ b/features/events/syslog/src/main/java/org/opennms/netmgt/syslogd/RadixTreeParser.java
@@ -97,6 +97,13 @@ public class RadixTreeParser implements ByteBufferParser<SyslogMessage> {
 //	private final ExecutorService m_executor = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors() * 2);
 
 	/**
+	 * @return The number of nodes in the underlying radix tree.
+	 */
+	public int size() {
+		return tree.size();
+	}
+
+	/**
 	 * Teach a new {@link ParserStage} sequence to this parser.
 	 * 
 	 * @param stages

--- a/features/events/syslog/src/test/java/org/opennms/netmgt/syslogd/BufferParserTest.java
+++ b/features/events/syslog/src/test/java/org/opennms/netmgt/syslogd/BufferParserTest.java
@@ -58,6 +58,11 @@ public class BufferParserTest {
 	final static Logger LOG = LoggerFactory.getLogger(BufferParserTest.class);
 
 	@Test
+	public void testSizeOfEmptyParser() {
+		assertEquals(0, new RadixTreeParser().size());
+	}
+
+	@Test
 	public void testDifferentImplementations() throws Exception {
 
 		MockLogAppender.setupLogging(true, "INFO");

--- a/opennms-doc/guide-admin/src/asciidoc/text/events/events.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/events/events.adoc
@@ -57,7 +57,62 @@ Event definitions are included with {opennms-product-name} for traps from many v
 Syslog messages sent over the network to {opennms-product-name} can be transformed into events according to pre-configured rules.
 
 IMPORTANT: The `Syslogd` service daemon, which enables {opennms-product-name} to receive syslog messages over the network, must be enabled for this functionality to work. This service daemon is *disabled* by default.
-    
+
+===== Parsers
+
+Different parsers can be used to convert the syslog message fields into {opennms-product-name} event fields.
+
+[options="header, autowidth"]
+|===
+| Parser  | Description 
+| `org.opennms.netmgt.syslogd.CustomSyslogParser`    | Default parser that uses a regex statement to parse the syslog header.
+| `org.opennms.netmgt.syslogd.RadixTreeSyslogParser` | Parser that uses an internal list of _grok_-style statements to parse the syslog header.
+| `org.opennms.netmgt.syslogd.SyslogNGParser`        | Parser that strictly parses messages in the default pattern of syslog-ng.
+| `org.opennms.netmgt.syslogd.Rfc5424SyslogParser`   | Parser that strictly parses the RFC 5424 format for syslog messages.
+|===
+
+====== RadixTreeSyslogParser
+
+The `RadixTreeSyslogParser` normally uses a set of internally-defined patterns to parse multiple syslog message formats.
+If you wish to customize the set of patterns, you can put a new set of patterns into a `syslog-grok-patterns.txt` in the `etc` directory for {opennms-product-name}.
+
+The patterns are defined in _grok_-style statements where each token is defined by a `%{PATTERN:semantic}` clause.
+Whitespace in the pattern will match 0...n whitespace characters and character literals in the pattern will match the corresponding characters.
+The '%' character literal must be escaped by using a backslash, ie. '\%'.
+
+NOTE: The RadixTreeSyslogParser's _grok_ implementation only supports a limited number of pattern types. However, these patterns should be sufficient to parse any syslog message format.
+
+The patterns should be arranged in the file from most specific to least specific since the first pattern to successfully match the syslog message will be used to construct the {opennms-product-name} event.
+
+[options="header, autowidth"]
+|===
+| Pattern   | Description 
+| `INT`     | Positive integer.
+| `MONTH`   | 3-character English month abbreviation.
+| `NOSPACE` | String that contains no whitespace.
+| `STRING`  | String. Because this matches any character, it must be followed by a delimiter in the pattern string.
+|===
+
+[options="header, autowidth"]
+|===
+| Semantic Token | Description 
+| `day` | 2-digit day of month (1-31).
+| `facilityPriority` | Facility-priority integer.
+| `hostname` | String hostname (unqualified or FQDN), IPv4 address, or IPv6 address.
+| `hour` | 2-digit hour of day (0-23).
+| `message` | Remaining string message.
+| `messageId` | String message ID.
+| `minute` | 2-digit minute (0-59).
+| `month` | 2-digit month (1-12).
+| `processId` | String process ID.
+| `processName` | String process name.
+| `second` | 2-digit second (0-59).
+| `secondFraction` | 1- to 6-digit fractional second value as a string.
+| `timezone` | String timezone value.
+| `version` | Version.
+| `year` | 4-digit year.
+|===
+
 ==== TL1 Autonomous Messages
 
 Autonomous messages can be retrieved from certain TL1-enabled equipment and transformed into events.


### PR DESCRIPTION
A customized set of patterns can be put into ```$OPENNMS_HOME/etc/syslogd-grok-patterns.txt```.

* JIRA: http://issues.opennms.org/browse/HZN-1047