### PR TITLE
NMS-9269: escape foreignSource/foreignId in ReST calls

### DIFF
--- a/opennms-base-assembly/src/main/filtered/bin/provision.pl
+++ b/opennms-base-assembly/src/main/filtered/bin/provision.pl
@@ -256,8 +256,8 @@ sub cmd_requisition {
 		if ($key eq 'rescanExisting' and $value !~ /^(true|false|dbonly)$/i) {
 			pod2usage(-exitval => 1, -message => "Error: You must specify a valid value for rescanExisting (true, false, dbonly)!", -verbose => 0);
 		}
-		my $query = "$key=$value" if $key eq 'rescanExisting';
-		put_simple($foreign_source . '/import', $query);
+		my $query = URI::Escape::uri_escape_utf8($key) . "=" . URI::Escape::uri_escape_utf8($value) if $key eq 'rescanExisting';
+		put_simple(URI::Escape::uri_escape_utf8($foreign_source) . '/import', $query);
 	} else {
 		pod2usage(-exitval => 1, -message => "Unknown command: requisition $command", -verbose => 0);
 	}
@@ -325,7 +325,7 @@ sub cmd_node {
 		my $root = $xml->root;
 		$root->{'att'}->{'foreign-id'} = $foreign_id;
 		$root->{'att'}->{'node-label'} = $node_label;
-		post("$foreign_source/nodes", $root);
+		post(URI::Escape::uri_escape_utf8($foreign_source) . "/nodes", $root);
 	} elsif (is_remove($command)) {
 		remove($foreign_source . '/nodes/' . $foreign_id);
 	} elsif (is_set($command)) {
@@ -338,7 +338,7 @@ sub cmd_node {
 
 		$key   = URI::Escape::uri_escape_utf8($key);
 		$value = URI::Escape::uri_escape_utf8($value);
-		put($foreign_source . '/nodes/' . $foreign_id, "$key=$value");
+		put(URI::Escape::uri_escape_utf8($foreign_source) . '/nodes/' . URI::Escape::uri_escape_utf8($foreign_id), URI::Escape::uri_escape_utf8($key) . "=" . URI::Escape::uri_escape_utf8($value));
 	} else {
 		pod2usage(-exitval => 1, -message => "Unknown command: node $command", -verbose => 0);
 	}
@@ -396,7 +396,7 @@ sub cmd_interface {
 		my $xml = get_element('interface');
 		my $root = $xml->root;
 		$root->{'att'}->{'ip-addr'} = $ip;
-		post("$foreign_source/nodes/$foreign_id/interfaces", $root);
+		post(URI::Escape::uri_escape_utf8($foreign_source) . "/nodes/ " . URI::Escape::uri_escape_utf8($foreign_id) . "/interfaces", $root);
 	} elsif (is_remove($command)) {
 		remove($foreign_source . '/nodes/' . $foreign_id . '/interfaces/' . $ip);
 	} elsif (is_set($command)) {
@@ -411,7 +411,7 @@ sub cmd_interface {
 		$key   = URI::Escape::uri_escape_utf8($key);
 		$value = URI::Escape::uri_escape_utf8($value);
 
-		put($foreign_source . '/nodes/' . $foreign_id . '/interfaces/' . $ip, "$key=$value");
+		put(URI::Escape::uri_escape_utf8($foreign_source) . '/nodes/' . URI::Escape::uri_escape_utf8($foreign_id) . '/interfaces/' . URI::Escape::uri_escape_utf8($ip), URI::Escape::uri_escape_utf8($key) . "=" . URI::Escape::uri_escape_utf8($value));
 	} else {
 		pod2usage(-exitval => 1, -message => "Unknown command: interface $command", -verbose => 0);
 	}
@@ -459,7 +459,7 @@ sub cmd_service {
 		my $xml = get_element('monitored-service');
 		my $root = $xml->root;
 		$root->{'att'}->{'service-name'} = $service;
-		post("$foreign_source/nodes/$foreign_id/interfaces/$ip/services", $root);
+		post(URI::Escape::uri_escape_utf8($foreign_source) . "/nodes/" . URI::Escape::uri_escape_utf8($foreign_id) . "/interfaces/" . URI::Escape::uri_escape_utf8($ip) . "/services", $root);
 	} elsif (is_remove($command)) {
 		remove($foreign_source . '/nodes/' . $foreign_id . '/interfaces/' . $ip . '/services/' . $service);
 	} else {
@@ -505,7 +505,7 @@ sub cmd_category {
 		my $xml = get_element('category');
 		my $root = $xml->root;
 		$root->{'att'}->{'name'} = $category;
-		post("$foreign_source/nodes/$foreign_id/categories", $root);
+		post(URI::Escape::uri_escape_utf8($foreign_source) . "/nodes/" . URI::Escape::uri_escape_utf8($foreign_id) . "/categories", $root);
 	} elsif (is_remove($command)) {
 		remove("$foreign_source/nodes/$foreign_id/categories/$category");
 	} else {
@@ -558,7 +558,7 @@ sub cmd_asset {
 		my $root = $xml->root;
 		$root->{'att'}->{'name'}  = $key;
 		$root->{'att'}->{'value'} = $value;
-		post("$foreign_source/nodes/$foreign_id/assets", $root);
+		post(URI::Escape::uri_escape_utf8($foreign_source) . "/nodes/" . URI::Escape::uri_escape_utf8($foreign_id) . "/assets", $root);
 	} elsif (is_remove($command)) {
 		remove("$foreign_source/nodes/$foreign_id/assets/$key");
 	} else {
@@ -656,7 +656,7 @@ sub cmd_snmp {
 	}
 
 	if ($command eq 'get' or $command eq 'list') {
-		my $response = get($ip, '/snmpConfig');
+		my $response = get(URI::Escape::uri_escape_utf8($ip), '/snmpConfig');
 		$XML->parse($response->content);
 		my $root = $XML->root;
 		print "SNMP Configuration for $ip:\n";
@@ -664,7 +664,7 @@ sub cmd_snmp {
 			print "* ", $child->tag, ": ", $child->text, "\n";
 		}
 	} elsif ($command eq 'netsnmp') {
-		my $response = get($ip, '/snmpConfig');
+		my $response = get(URI::Escape::uri_escape_utf8($ip), '/snmpConfig');
 		$XML->parse($response->content);
 		my $root = $XML->root;
 		my $versionSwitch = "-" . $root->first_child('version')->text;
@@ -683,7 +683,7 @@ sub cmd_snmp {
 			my ($key, $value) = split(/=/, $arg);
 			$arguments .= "&" . URI::Escape::uri_escape_utf8($key) . "=" . URI::Escape::uri_escape_utf8($value);
 		}
-		put($ip, $arguments, '/snmpConfig');
+		put(URI::Escape::uri_escape_utf8($ip), $arguments, '/snmpConfig');
 	} else {
 		pod2usage(-exitval => 1, -message => "Unknown command: snmp $command", -verbose => 0);
 	}

--- a/opennms-webapp/src/main/webapp/admin/ng-requisitions/app/scripts/controllers/ForeignSource.js
+++ b/opennms-webapp/src/main/webapp/admin/ng-requisitions/app/scripts/controllers/ForeignSource.js
@@ -205,7 +205,7 @@
         if ($scope.foreignSource == 'default') {
           $window.location.href = '#/requisitions';
         } else {
-          $window.location.href = '#/requisitions/' + $scope.foreignSource;
+          $window.location.href = '#/requisitions/' + encodeURIComponent($scope.foreignSource);
         }
       };
       $scope.goTo(doGoBack);

--- a/opennms-webapp/src/main/webapp/admin/ng-requisitions/app/scripts/controllers/Node.js
+++ b/opennms-webapp/src/main/webapp/admin/ng-requisitions/app/scripts/controllers/Node.js
@@ -156,7 +156,7 @@
     * @methodOf NodeController
     */
     $scope.goBack = function() {
-      $scope.goTo('#/requisitions/' + $scope.foreignSource);
+      $scope.goTo('#/requisitions/' + encodeURIComponent($scope.foreignSource));
     };
 
     /**
@@ -168,7 +168,7 @@
     */
     $scope.goVerticalLayout = function() {
       $cookies.put('use_requisitions_node_vertical_layout', 'true');
-      $scope.goTo('#/requisitions/' + $scope.foreignSource + '/nodes/' + $scope.foreignId + '/vertical');
+      $scope.goTo('#/requisitions/' + encodeURIComponent($scope.foreignSource) + '/nodes/' + encodeURIComponent($scope.foreignId) + '/vertical');
     };
 
     /**
@@ -180,7 +180,7 @@
     */
     $scope.goHorizontalLayout = function() {
       $cookies.put('use_requisitions_node_vertical_layout', 'false');
-      $scope.goTo('#/requisitions/' + $scope.foreignSource + '/nodes/' + $scope.foreignId);
+      $scope.goTo('#/requisitions/' + encodeURIComponent($scope.foreignSource) + '/nodes/' + $encodeURIComponent(scope.foreignId));
     };
 
     /**

--- a/opennms-webapp/src/main/webapp/admin/ng-requisitions/app/scripts/controllers/Requisition.js
+++ b/opennms-webapp/src/main/webapp/admin/ng-requisitions/app/scripts/controllers/Requisition.js
@@ -120,7 +120,7 @@
     * @methodOf RequisitionController
     */
     $scope.editForeignSource = function() {
-      $window.location.href = '#/requisitions/' + $scope.foreignSource + '/foreignSource';
+      $window.location.href = '#/requisitions/' + encodeURIComponent($scope.foreignSource) + '/foreignSource';
     };
 
     /**
@@ -169,7 +169,7 @@
     * @methodOf RequisitionController
     */
     $scope.addNode = function() {
-      $window.location.href = '#/requisitions/' + $scope.foreignSource + '/nodes/__new__' + $scope.getVerticalLayout();
+      $window.location.href = '#/requisitions/' + encodeURIComponent($scope.foreignSource) + '/nodes/__new__' + $scope.getVerticalLayout();
     };
 
     /**
@@ -182,7 +182,7 @@
     * @param {object} The node's object to edit
     */
     $scope.editNode = function(node) {
-      $window.location.href = '#/requisitions/' + $scope.foreignSource + '/nodes/' + node.foreignId + $scope.getVerticalLayout();
+      $window.location.href = '#/requisitions/' + encodeURIComponent($scope.foreignSource) + '/nodes/' + encodeURIComponent(node.foreignId) + $scope.getVerticalLayout();
     };
 
     /**

--- a/opennms-webapp/src/main/webapp/admin/ng-requisitions/app/scripts/controllers/Requisitions.js
+++ b/opennms-webapp/src/main/webapp/admin/ng-requisitions/app/scripts/controllers/Requisitions.js
@@ -216,7 +216,7 @@
     * @param {string} foreignSource The name of the requisition
     */
     $scope.editForeignSource = function(foreignSource) {
-      $window.location.href = '#/requisitions/' + foreignSource + '/foreignSource';
+      $window.location.href = '#/requisitions/' + encodeURIComponent(foreignSource) + '/foreignSource';
     };
 
     /**
@@ -228,7 +228,7 @@
     * @param {string} foreignSource The name of the requisition
     */
     $scope.edit = function(foreignSource) {
-      $window.location.href = '#/requisitions/' + foreignSource;
+      $window.location.href = '#/requisitions/' + encodeURIComponent(foreignSource);
     };
 
     /**

--- a/opennms-webapp/src/main/webapp/admin/ng-requisitions/app/scripts/services/Requisitions.js
+++ b/opennms-webapp/src/main/webapp/admin/ng-requisitions/app/scripts/services/Requisitions.js
@@ -428,7 +428,7 @@
     */
     requisitionsService.updateDeployedStatsForRequisition = function(existingReq) {
       var deferred = $q.defer();
-      var url = requisitionsService.internal.requisitionsUrl + '/deployed/stats/' + existingReq.foreignSource;
+      var url = requisitionsService.internal.requisitionsUrl + '/deployed/stats/' + encodeURIComponent(existingReq.foreignSource);
       $log.debug('updateDeployedStatsForRequisition: retrieving deployed statistics for requisition ' + existingReq.foreignSource);
       $http.get(url)
       .success(function(deployedReq) {
@@ -466,7 +466,7 @@
         return deferred.promise;
       }
 
-      var url = requisitionsService.internal.requisitionsUrl + '/' + foreignSource;
+      var url = requisitionsService.internal.requisitionsUrl + '/' + encodeURIComponent(foreignSource);
       $log.debug('getRequisition: getting requisition ' + foreignSource);
       $http.get(url)
       .success(function(data) {
@@ -513,7 +513,7 @@
         }
       }
 
-      var url = requisitionsService.internal.requisitionsUrl + '/' + foreignSource + '/import';
+      var url = requisitionsService.internal.requisitionsUrl + '/' + encodeURIComponent(foreignSource) + '/import';
       $log.debug('synchronizeRequisition: synchronizing requisition ' + foreignSource + ' with rescanExisting=' + rescanExisting);
       $http({ method: 'PUT', url: url, params: { rescanExisting: rescanExisting }})
       .success(function(data) {
@@ -608,10 +608,10 @@
       }
 
       $log.debug('deleteRequisition: deleting requisition ' + foreignSource);
-      var deferredReqPending  = $http.delete(requisitionsService.internal.requisitionsUrl + '/' + foreignSource);
-      var deferredReqDeployed = $http.delete(requisitionsService.internal.requisitionsUrl + '/deployed/' + foreignSource);
-      var deferredFSPending  = $http.delete(requisitionsService.internal.foreignSourcesUrl + '/' + foreignSource);
-      var deferredFSDeployed = $http.delete(requisitionsService.internal.foreignSourcesUrl + '/deployed/' + foreignSource);
+      var deferredReqPending  = $http.delete(requisitionsService.internal.requisitionsUrl + '/' + encodeURIComponent(foreignSource));
+      var deferredReqDeployed = $http.delete(requisitionsService.internal.requisitionsUrl + '/deployed/' + encodeURIComponent(foreignSource));
+      var deferredFSPending  = $http.delete(requisitionsService.internal.foreignSourcesUrl + '/' + encodeURIComponent(foreignSource));
+      var deferredFSDeployed = $http.delete(requisitionsService.internal.foreignSourcesUrl + '/deployed/' + encodeURIComponent(foreignSource));
 
       $q.all([ deferredReqPending, deferredReqDeployed, deferredFSPending, deferredFSDeployed ])
       .then(function(results) {
@@ -705,7 +705,7 @@
         return deferred.promise;
       }
 
-      var url  = requisitionsService.internal.requisitionsUrl + '/' + foreignSource + '/nodes/' + foreignId;
+      var url  = requisitionsService.internal.requisitionsUrl + '/' + encodeURIComponent(foreignSource) + '/nodes/' + encodeURIComponent(foreignId);
       $log.debug('getNode: getting node ' + foreignId + '@' + foreignSource);
       $http.get(url)
       .success(function(data) {
@@ -744,7 +744,7 @@
       var deferred = $q.defer();
       var requisitionNode = node.getOnmsRequisitionNode();
 
-      var url = requisitionsService.internal.requisitionsUrl + '/' + node.foreignSource + '/nodes';
+      var url = requisitionsService.internal.requisitionsUrl + '/' + encodeURIComponent(node.foreignSource) + '/nodes';
       $log.debug('saveNode: saving node ' + node.nodeLabel + ' on requisition ' + node.foreignSource);
       $http.post(url, requisitionNode)
       .success(function(data) {
@@ -777,7 +777,7 @@
     requisitionsService.deleteNode = function(node) {
       var deferred = $q.defer();
 
-      var url = requisitionsService.internal.requisitionsUrl + '/' + node.foreignSource + '/nodes/' + node.foreignId;
+      var url = requisitionsService.internal.requisitionsUrl + '/' + encodeURIComponent(node.foreignSource) + '/nodes/' + encodeURIComponent(node.foreignId);
       $log.debug('deleteNode: deleting node ' + node.nodeLabel + ' from requisition ' + node.foreignSource);
       $http.delete(url)
       .success(function(data) {
@@ -817,7 +817,7 @@
     requisitionsService.getForeignSourceDefinition = function(foreignSource) {
       var deferred = $q.defer();
 
-      var url = requisitionsService.internal.foreignSourcesUrl + '/' + foreignSource;
+      var url = requisitionsService.internal.foreignSourcesUrl + '/' + encodeURIComponent(foreignSource);
       $log.debug('getForeignSourceDefinition: getting definition for requisition ' + foreignSource);
       $http.get(url)
       .success(function(data) {
@@ -926,8 +926,8 @@
       var deferred = $q.defer();
 
       $log.debug('deleteForeignSourceDefinition: deleting foreign source definition ' + foreignSource);
-      var deferredFSPending  = $http.delete(requisitionsService.internal.foreignSourcesUrl + '/' + foreignSource);
-      var deferredFSDeployed = $http.delete(requisitionsService.internal.foreignSourcesUrl + '/deployed/' + foreignSource);
+      var deferredFSPending  = $http.delete(requisitionsService.internal.foreignSourcesUrl + '/' + encodeURIComponent(foreignSource));
+      var deferredFSDeployed = $http.delete(requisitionsService.internal.foreignSourcesUrl + '/deployed/' + encodeURIComponent(foreignSource));
 
       $q.all([ deferredFSPending, deferredFSDeployed ])
       .then(function(results) {
@@ -1055,7 +1055,7 @@
         return deferred.promise;
       }
 
-      var url = requisitionsService.internal.foreignSourcesConfigUrl + '/services/' + foreignSource;
+      var url = requisitionsService.internal.foreignSourcesConfigUrl + '/services/' + encodeURIComponent(foreignSource);
       $log.debug('getAvailableServices: getting available services');
       $http.get(url)
       .success(function(data) {


### PR DESCRIPTION
This PR escapes foreign sources and foreign IDs in ReST calls from `provision.pl` and the Angular requisitions editor UI.

* JIRA: http://issues.opennms.org/browse/NMS-9269
