### PR TITLE
NMS-9110: Improve REST API support for node locations

### DIFF
--- a/opennms-doc/guide-development/src/asciidoc/text/rest/rest-api.adoc
+++ b/opennms-doc/guide-development/src/asciidoc/text/rest/rest-api.adoc
@@ -62,6 +62,7 @@ Take `/events` as an example.
 | `/events?eventAckTime=notnull&id=100&comparator=gt&limit=20`                       | would return the first 20 events that have a non-null Ack time and an id greater than 100.  Note that the notnull value causes the comparator to be ignored for eventAckTime
 | `/events?eventAckTime=2008-07-28T04:41:30.530%2B12:00&id=100&comparator=gt&limit=20` | would return the first 20 events that have were acknowledged after 28th July 2008 at 4:41am (+12:00), and an id greater than 100.  Note that the same comparator applies to both property comparisons. Also note that you must URL encode the plus sign when using GET.
 | `/events?orderBy=id&order=desc`                                                    | would return the 10 latest events inserted (probably, unless you've been messing with the id's)
+| `/events?location.id=MINION`                                                       | would return the first 10 events associated with some node in location 'MINION'
 |===
 
 === HTTP Return Codes

--- a/opennms-model/src/main/java/org/opennms/netmgt/model/MonitoringLocationJsonDeserializer.java
+++ b/opennms-model/src/main/java/org/opennms/netmgt/model/MonitoringLocationJsonDeserializer.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2017 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.model;
+
+import java.io.IOException;
+
+import org.codehaus.jackson.JsonParser;
+import org.codehaus.jackson.JsonProcessingException;
+import org.codehaus.jackson.JsonToken;
+import org.codehaus.jackson.map.DeserializationContext;
+import org.codehaus.jackson.map.deser.std.StdScalarDeserializer;
+import org.opennms.netmgt.model.monitoringLocations.OnmsMonitoringLocation;
+
+public class MonitoringLocationJsonDeserializer extends StdScalarDeserializer<OnmsMonitoringLocation> {
+
+    protected MonitoringLocationJsonDeserializer() {
+        super(OnmsMonitoringLocation.class);
+    }
+
+    @Override
+    public OnmsMonitoringLocation deserialize(JsonParser jp, DeserializationContext ctxt)
+            throws IOException, JsonProcessingException {
+        JsonToken t = jp.getCurrentToken();
+        if (t == JsonToken.VALUE_STRING) {
+            final String locationName = jp.getText().trim();
+            return new OnmsMonitoringLocation(locationName, locationName);
+        }
+        throw ctxt.mappingException(_valueClass, t);
+    }
+
+}

--- a/opennms-model/src/main/java/org/opennms/netmgt/model/MonitoringLocationJsonSerializer.java
+++ b/opennms-model/src/main/java/org/opennms/netmgt/model/MonitoringLocationJsonSerializer.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2017 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.model;
+
+import java.io.IOException;
+
+import org.codehaus.jackson.JsonGenerationException;
+import org.codehaus.jackson.JsonGenerator;
+import org.codehaus.jackson.map.SerializerProvider;
+import org.codehaus.jackson.map.ser.std.SerializerBase;
+import org.opennms.netmgt.model.monitoringLocations.OnmsMonitoringLocation;
+
+public class MonitoringLocationJsonSerializer extends SerializerBase<OnmsMonitoringLocation> {
+
+    protected MonitoringLocationJsonSerializer() {
+        super(OnmsMonitoringLocation.class);
+    }
+
+    @Override
+    public void serialize(OnmsMonitoringLocation value, JsonGenerator jgen, SerializerProvider provider)
+            throws IOException, JsonGenerationException {
+        jgen.writeString(value.getLocationName());
+    }
+
+}

--- a/opennms-model/src/main/java/org/opennms/netmgt/model/OnmsNode.java
+++ b/opennms-model/src/main/java/org/opennms/netmgt/model/OnmsNode.java
@@ -73,10 +73,11 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlTransient;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
-import org.codehaus.jackson.annotate.JsonBackReference;
 import org.codehaus.jackson.annotate.JsonIgnore;
 import org.codehaus.jackson.annotate.JsonIgnoreProperties;
 import org.codehaus.jackson.annotate.JsonValue;
+import org.codehaus.jackson.map.annotate.JsonDeserialize;
+import org.codehaus.jackson.map.annotate.JsonSerialize;
 import org.hibernate.annotations.Filter;
 import org.hibernate.annotations.Type;
 import org.opennms.core.utils.InetAddressUtils;
@@ -734,11 +735,11 @@ public class OnmsNode extends OnmsEntity implements Serializable, Comparable<Onm
     /**
      * Monitoring location that this node is located in.
      */
-    @JsonBackReference
+    @JsonSerialize(using=MonitoringLocationJsonSerializer.class)
+    @JsonDeserialize(using=MonitoringLocationJsonDeserializer.class)
     @XmlElement(name="location")
     @ManyToOne(optional=false, fetch=FetchType.LAZY)
     @JoinColumn(name="location")
-    //@XmlIDREF
     @XmlJavaTypeAdapter(MonitoringLocationIdAdapter.class)
     public OnmsMonitoringLocation getLocation() {
         return m_location;

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/AlarmRestServiceBase.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/AlarmRestServiceBase.java
@@ -75,6 +75,7 @@ public class AlarmRestServiceBase extends OnmsRestService {
         cb.alias("node", "node", JoinType.LEFT_JOIN);
         cb.alias("node.snmpInterfaces", "snmpInterface", JoinType.LEFT_JOIN);
         cb.alias("node.ipInterfaces", "ipInterface", JoinType.LEFT_JOIN);
+        cb.alias("node.location", "location", JoinType.LEFT_JOIN);
 
         if (params.containsKey("alarmId")) {
         	if (params.containsKey("id")) {

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/EventRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/EventRestService.java
@@ -286,6 +286,7 @@ public class EventRestService extends OnmsRestService {
         builder.alias("node", "node", JoinType.LEFT_JOIN);
         builder.alias("node.snmpInterfaces", "snmpInterface", JoinType.LEFT_JOIN);
         builder.alias("node.ipInterfaces", "ipInterface", JoinType.LEFT_JOIN);
+        builder.alias("node.location", "location", JoinType.LEFT_JOIN);
         builder.alias("serviceType", "serviceType", JoinType.LEFT_JOIN);
 
         applyQueryFilters(params, builder);

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/NodeRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/NodeRestService.java
@@ -476,6 +476,7 @@ public class NodeRestService extends OnmsRestService {
         builder.alias("ipInterfaces", "ipInterface", JoinType.LEFT_JOIN);
         builder.alias("categories", "category", JoinType.LEFT_JOIN);
         builder.alias("assetRecord", "assetRecord", JoinType.LEFT_JOIN);
+        builder.alias("location", "location", JoinType.LEFT_JOIN);
         builder.alias("ipInterfaces.monitoredServices.serviceType", "serviceType", JoinType.LEFT_JOIN);
 
         applyQueryFilters(params, builder);

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/OutageRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/OutageRestService.java
@@ -134,6 +134,7 @@ public class OutageRestService extends OnmsRestService {
         builder.alias("monitoredService", "monitoredService", JoinType.LEFT_JOIN);
         builder.alias("monitoredService.ipInterface", "ipInterface", JoinType.LEFT_JOIN);
         builder.alias("ipInterface.node", "node", JoinType.LEFT_JOIN);
+        builder.alias("ipInterface.node.location", "location", JoinType.LEFT_JOIN);
         builder.alias("ipInterface.snmpInterface", "snmpInterface", JoinType.LEFT_JOIN);
         builder.alias("monitoredService.serviceType", "serviceType", JoinType.LEFT_JOIN);
         builder.alias("serviceLostEvent", "serviceLostEvent", JoinType.LEFT_JOIN);

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NodeRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NodeRestService.java
@@ -85,6 +85,7 @@ public class NodeRestService extends AbstractDaoRestService<OnmsNode,Integer> {
 		builder.alias("ipInterfaces", "ipInterface", JoinType.LEFT_JOIN);
 		builder.alias("categories", "category", JoinType.LEFT_JOIN);
 		builder.alias("assetRecord", "assetRecord", JoinType.LEFT_JOIN);
+		builder.alias("location", "location", JoinType.LEFT_JOIN);
 		builder.alias("ipInterfaces.monitoredServices.serviceType", "serviceType", JoinType.LEFT_JOIN);
 
 		// Order by label by default

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/OutageRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/OutageRestService.java
@@ -72,6 +72,7 @@ public class OutageRestService extends AbstractDaoRestService<OnmsOutage,Integer
 		builder.alias("monitoredService.ipInterface", "ipInterface", JoinType.LEFT_JOIN);
 		builder.alias("monitoredService.serviceType", "serviceType", JoinType.LEFT_JOIN);
 		builder.alias("ipInterface.node", "node", JoinType.LEFT_JOIN);
+		builder.alias("ipInterface.node.location", "location", JoinType.LEFT_JOIN);
 		builder.alias("serviceLostEvent", "serviceLostEvent", JoinType.LEFT_JOIN);
 		builder.alias("serviceRegainedEvent", "serviceRegainedEvent", JoinType.LEFT_JOIN); 
 

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/NodeRestServiceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/NodeRestServiceIT.java
@@ -229,6 +229,7 @@ public class NodeRestServiceIT extends AbstractSpringJerseyRestTestCase {
         jo = ja.getJSONObject(0);
         assertEquals("A", jo.getString("type"));
         assertEquals("TestMachine0", jo.getString("label"));
+        assertEquals("Default", jo.getString("location"));
     }
 
     @Test

--- a/opennms-webapp-rest/src/test/resources/v1/nodes.json
+++ b/opennms-webapp-rest/src/test/resources/v1/nodes.json
@@ -76,6 +76,7 @@
             "label": "TestMachine0", 
             "labelSource": "H", 
             "lastCapsdPoll": 1316862766421, 
+            "location": "Default",
             "sysContact": "The Owner", 
             "sysDescription": "Darwin TestMachine 9.4.0 Darwin Kernel Version 9.4.0: Mon Jun  9 19:30:53 PDT 2008; root:xnu-1228.5.20~1/RELEASE_I386 i386", 
             "sysLocation": "DevJam", 


### PR DESCRIPTION
JIRA: https://issues.opennms.org/browse/NMS-9110

* Include the location name when rendering a OnmsNode object in JSON (already there in XML).
 * Add joins on the alarms, events, nodes and outages endpoints, allowing these to be filtered by location.
 * Add a simple example on how to filter by location
