### PR TITLE
NMS-9225: Prevent Kafka Heartbeat consumer from failing on startup

### DIFF
--- a/core/ipc/sink/kafka-impl/src/main/java/org/opennms/core/ipc/sink/kafka/KafkaMessageConsumerManager.java
+++ b/core/ipc/sink/kafka-impl/src/main/java/org/opennms/core/ipc/sink/kafka/KafkaMessageConsumerManager.java
@@ -95,7 +95,11 @@ public class KafkaMessageConsumerManager extends AbstractMessageConsumerManager 
                 while (!closed.get()) {
                     ConsumerRecords<String, String> records = consumer.poll(100);
                     for (ConsumerRecord<String, String> record : records) {
-                        dispatch(module, module.unmarshal(record.value()));
+                        try {
+                            dispatch(module, module.unmarshal(record.value()));
+                        } catch (RuntimeException e) {
+                            LOG.warn("Unexpected exception while dispatching message", e);
+                        }
                     }
                 }
             } catch (WakeupException e) {

--- a/features/minion/heartbeat/consumer/src/main/java/org/opennms/minion/heartbeat/consumer/HeartbeatConsumer.java
+++ b/features/minion/heartbeat/consumer/src/main/java/org/opennms/minion/heartbeat/consumer/HeartbeatConsumer.java
@@ -28,7 +28,10 @@
 
 package org.opennms.minion.heartbeat.consumer;
 
-import com.google.common.collect.Sets;
+import java.util.Collections;
+import java.util.Date;
+import java.util.Objects;
+import java.util.Set;
 
 import org.opennms.core.ipc.sink.api.MessageConsumer;
 import org.opennms.core.ipc.sink.api.MessageConsumerManager;
@@ -57,10 +60,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.dao.DataAccessResourceFailureException;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Collections;
-import java.util.Date;
-import java.util.Objects;
-import java.util.Set;
+import com.google.common.collect.Sets;
 
 public class HeartbeatConsumer implements MessageConsumer<MinionIdentityDTO, MinionIdentityDTO>, InitializingBean {
 
@@ -154,7 +154,7 @@ public class HeartbeatConsumer implements MessageConsumer<MinionIdentityDTO, Min
             return;
         }
 
-        // Return fast until the provisioner is running to pick up the events send below
+        // Return fast until the provisioner is running to pick up the events sent below
         if (!this.eventSubscriptionService.hasEventListener(EventConstants.RELOAD_IMPORT_UEI)) {
             return;
         }

--- a/smoke-test/src/test/java/org/opennms/smoketest/minion/MinionHeartbeatOutageKafkaTest.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/minion/MinionHeartbeatOutageKafkaTest.java
@@ -1,0 +1,293 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2016 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2016 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+package org.opennms.smoketest.minion;
+
+import static com.jayway.awaitility.Awaitility.await;
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
+
+import java.io.PrintStream;
+import java.net.InetSocketAddress;
+import java.util.Date;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+import org.opennms.core.criteria.CriteriaBuilder;
+import org.opennms.netmgt.dao.hibernate.EventDaoHibernate;
+import org.opennms.netmgt.dao.hibernate.MinionDaoHibernate;
+import org.opennms.netmgt.dao.hibernate.NodeDaoHibernate;
+import org.opennms.netmgt.events.api.EventConstants;
+import org.opennms.netmgt.model.OnmsEvent;
+import org.opennms.netmgt.model.OnmsMonitoringSystem;
+import org.opennms.netmgt.model.OnmsNode;
+import org.opennms.netmgt.model.minion.OnmsMinion;
+import org.opennms.smoketest.NullTestEnvironment;
+import org.opennms.smoketest.OpenNMSSeleniumTestCase;
+import org.opennms.smoketest.utils.DaoUtils;
+import org.opennms.smoketest.utils.HibernateDaoFactory;
+import org.opennms.test.system.api.AbstractTestEnvironment;
+import org.opennms.test.system.api.NewTestEnvironment.ContainerAlias;
+import org.opennms.test.system.api.TestEnvironment;
+import org.opennms.test.system.api.TestEnvironmentBuilder;
+import org.opennms.test.system.api.utils.SshClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.spotify.docker.client.DockerClient;
+import com.spotify.docker.client.exceptions.DockerException;
+import com.spotify.docker.client.messages.ContainerInfo;
+
+/**
+ * This test starts up Minion with the Apache Kafka sink and makes sure
+ * that heartbeat messages continue to be processed even if the Minion
+ * and OpenNMS instances are restarted.
+ * 
+ * @author Seth
+ */
+public class MinionHeartbeatOutageKafkaTest {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MinionHeartbeatOutageKafkaTest.class);
+
+    @Rule
+    public TestEnvironment testEnvironment = getTestEnvironment();
+
+    @Rule
+    public Timeout timeout = new Timeout(20, TimeUnit.MINUTES);
+
+    protected HibernateDaoFactory daoFactory;
+
+    public final TestEnvironment getTestEnvironment() {
+        if (!OpenNMSSeleniumTestCase.isDockerEnabled()) {
+            return new NullTestEnvironment();
+        }
+        try {
+            return getEnvironmentBuilder().build();
+        } catch (final Throwable t) {
+            throw new RuntimeException(t);
+        }
+    }
+
+    /**
+     * Override this method to customize the test environment.
+     */
+    protected TestEnvironmentBuilder getEnvironmentBuilder() {
+        final TestEnvironmentBuilder builder = TestEnvironment.builder().all()
+                // Enable Kafka
+                .kafka();
+        builder.withOpenNMSEnvironment()
+                // Switch sink impl to Kafka using opennms-properties.d file
+                .addFile(MinionHeartbeatOutageKafkaTest.class.getResource("/opennms.properties.d/kafka-sink.properties"), "etc/opennms.properties.d/kafka-sink.properties");
+        builder.withMinionEnvironment()
+                // Switch sink impl to Kafka using features.boot file
+                .addFile(MinionHeartbeatOutageKafkaTest.class.getResource("/featuresBoot.d/kafka.boot"), "etc/featuresBoot.d/kafka.boot");
+        OpenNMSSeleniumTestCase.configureTestEnvironment(builder);
+        return builder;
+    }
+
+    @Before
+    public void checkForDocker() {
+        Assume.assumeTrue(OpenNMSSeleniumTestCase.isDockerEnabled());
+    }
+
+    @Before
+    public void setup() {
+        // Connect to the postgresql container
+        final InetSocketAddress pgsql = testEnvironment.getServiceAddress(ContainerAlias.POSTGRES, 5432);
+        this.daoFactory = new HibernateDaoFactory(pgsql);
+    }
+
+    /**
+     * Install the Kafka features on Minion.
+     * 
+     * @param minionSshAddr
+     * @param kafkaAddress
+     * @throws Exception
+     */
+    protected static void installFeaturesOnMinion(InetSocketAddress minionSshAddr, InetSocketAddress kafkaAddress) throws Exception {
+        try (final SshClient sshClient = new SshClient(minionSshAddr, "admin", "admin")) {
+            PrintStream pipe = sshClient.openShell();
+            pipe.println("feature:list -i");
+            pipe.println("list");
+            // Set the log level to INFO
+            pipe.println("log:set INFO");
+            pipe.println("logout");
+            try {
+                await().atMost(2, MINUTES).until(sshClient.isShellClosedCallable());
+            } finally {
+                LOG.info("Karaf output:\n{}", sshClient.getStdout());
+            }
+        }
+    }
+
+    protected static void installFeaturesOnOpenNMS(InetSocketAddress opennmsSshAddr, InetSocketAddress kafkaAddress, InetSocketAddress zookeeperAddress, boolean useEsRest) throws Exception {
+        try (final SshClient sshClient = new SshClient(opennmsSshAddr, "admin", "admin")) {
+            PrintStream pipe = sshClient.openShell();
+
+            pipe.println("features:list -i");
+            // Set the log level to INFO
+            pipe.println("log:set INFO");//
+            pipe.println("logout");
+            try {
+                await().atMost(2, MINUTES).until(sshClient.isShellClosedCallable());
+            } finally {
+                LOG.info("Karaf output:\n{}", sshClient.getStdout());
+            }
+        }
+    }
+
+    @Test
+    public void testHeartbeatOutages() throws Exception {
+        Date startOfTest = new Date();
+
+        InetSocketAddress minionSshAddr = testEnvironment.getServiceAddress(ContainerAlias.MINION, 8201);
+        InetSocketAddress opennmsSshAddr = testEnvironment.getServiceAddress(ContainerAlias.OPENNMS, 8101);
+        InetSocketAddress kafkaAddress = testEnvironment.getServiceAddress(ContainerAlias.KAFKA, 9092);
+        InetSocketAddress zookeeperAddress = testEnvironment.getServiceAddress(ContainerAlias.KAFKA, 2181);
+
+        installFeaturesOnMinion(minionSshAddr, kafkaAddress);
+
+        installFeaturesOnOpenNMS(opennmsSshAddr, kafkaAddress, zookeeperAddress, true);
+
+        // Wait for the Minion to show up
+        await().atMost(90, SECONDS).pollInterval(5, SECONDS)
+            .until(DaoUtils.countMatchingCallable(
+                 this.daoFactory.getDao(MinionDaoHibernate.class),
+                 new CriteriaBuilder(OnmsMinion.class)
+                     .gt("lastUpdated", startOfTest)
+                     .eq("location", "MINION")
+                     .toCriteria()
+                 ),
+                 is(1)
+             );
+
+        // Make sure that the node is available
+        await().atMost(180, SECONDS).pollInterval(5, SECONDS)
+            .until(DaoUtils.countMatchingCallable(
+                this.daoFactory.getDao(NodeDaoHibernate.class),
+                new CriteriaBuilder(OnmsNode.class)
+                .eq("foreignSource", "Minions")
+                .eq("foreignId", "00000000-0000-0000-0000-000000ddba11")
+                .toCriteria()
+                ),
+            equalTo(1)
+        );
+
+        // Make sure that the expected events are present
+        assertEquals(1, DaoUtils.countMatchingCallable(
+            this.daoFactory.getDao(EventDaoHibernate.class),
+            new CriteriaBuilder(OnmsEvent.class)
+            .eq("eventUei", EventConstants.MONITORING_SYSTEM_ADDED_UEI)
+            .like("eventParms", String.format("%%%s=%s%%", EventConstants.PARAM_MONITORING_SYSTEM_TYPE, OnmsMonitoringSystem.TYPE_MINION))
+            .like("eventParms", String.format("%%%s=%s%%", EventConstants.PARAM_MONITORING_SYSTEM_ID, "00000000-0000-0000-0000-000000ddba11"))
+            .like("eventParms", String.format("%%%s=%s%%", EventConstants.PARAM_MONITORING_SYSTEM_LOCATION, "MINION"))
+            .toCriteria()
+            ).call().intValue()
+        );
+
+        assertEquals(0, DaoUtils.countMatchingCallable(
+            this.daoFactory.getDao(EventDaoHibernate.class),
+            new CriteriaBuilder(OnmsEvent.class)
+            .eq("eventUei", EventConstants.MONITORING_SYSTEM_LOCATION_CHANGED_UEI)
+            .toCriteria()
+            ).call().intValue()
+        );
+
+        for (int i = 0; i < 3; i++) {
+            restartContainer(ContainerAlias.MINION);
+
+            // Reset the startOfTest timestamp
+            startOfTest = new Date();
+
+            await().atMost(90, SECONDS).pollInterval(5, SECONDS)
+                .until(DaoUtils.countMatchingCallable(
+                     this.daoFactory.getDao(MinionDaoHibernate.class),
+                     new CriteriaBuilder(OnmsMinion.class)
+                         .gt("lastUpdated", startOfTest)
+                         .eq("location", "MINION")
+                         .toCriteria()
+                     ),
+                     is(1)
+                 );
+        }
+
+        for (int i = 0; i < 3; i++) {
+            restartContainer(ContainerAlias.OPENNMS);
+
+            // Reset the startOfTest timestamp
+            startOfTest = new Date();
+
+            await().atMost(90, SECONDS).pollInterval(5, SECONDS)
+                .until(DaoUtils.countMatchingCallable(
+                     this.daoFactory.getDao(MinionDaoHibernate.class),
+                     new CriteriaBuilder(OnmsMinion.class)
+                         .gt("lastUpdated", startOfTest)
+                         .eq("location", "MINION")
+                         .toCriteria()
+                     ),
+                     is(1)
+                 );
+        }
+
+        for (int i = 0; i < 1; i++) {
+            restartContainer(ContainerAlias.MINION);
+
+            // Reset the startOfTest timestamp
+            startOfTest = new Date();
+
+            await().atMost(90, SECONDS).pollInterval(5, SECONDS)
+                .until(DaoUtils.countMatchingCallable(
+                     this.daoFactory.getDao(MinionDaoHibernate.class),
+                     new CriteriaBuilder(OnmsMinion.class)
+                         .gt("lastUpdated", startOfTest)
+                         .eq("location", "MINION")
+                         .toCriteria()
+                     ),
+                     is(1)
+                 );
+        }
+    }
+
+    private void restartContainer(ContainerAlias alias) {
+        final DockerClient docker = ((AbstractTestEnvironment)testEnvironment).getDockerClient();
+        final String id = testEnvironment.getContainerInfo(alias).id();
+        try {
+            LOG.info("Restarting container: {} -> {}", alias, id);
+            docker.restartContainer(id);
+            LOG.info("Container restarted: {} -> {}", alias, id);
+        } catch (DockerException | InterruptedException e) {
+            LOG.warn("Unexpected exception while restarting container {}", id, e);
+        }
+    }
+}

--- a/smoke-test/src/test/java/org/opennms/smoketest/minion/MinionHeartbeatOutageTest.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/minion/MinionHeartbeatOutageTest.java
@@ -1,0 +1,282 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2016 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2016 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+package org.opennms.smoketest.minion;
+
+import static com.jayway.awaitility.Awaitility.await;
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
+
+import java.io.PrintStream;
+import java.net.InetSocketAddress;
+import java.util.Date;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+import org.opennms.core.criteria.CriteriaBuilder;
+import org.opennms.netmgt.dao.hibernate.EventDaoHibernate;
+import org.opennms.netmgt.dao.hibernate.MinionDaoHibernate;
+import org.opennms.netmgt.dao.hibernate.NodeDaoHibernate;
+import org.opennms.netmgt.events.api.EventConstants;
+import org.opennms.netmgt.model.OnmsEvent;
+import org.opennms.netmgt.model.OnmsMonitoringSystem;
+import org.opennms.netmgt.model.OnmsNode;
+import org.opennms.netmgt.model.minion.OnmsMinion;
+import org.opennms.smoketest.NullTestEnvironment;
+import org.opennms.smoketest.OpenNMSSeleniumTestCase;
+import org.opennms.smoketest.utils.DaoUtils;
+import org.opennms.smoketest.utils.HibernateDaoFactory;
+import org.opennms.test.system.api.AbstractTestEnvironment;
+import org.opennms.test.system.api.NewTestEnvironment.ContainerAlias;
+import org.opennms.test.system.api.TestEnvironment;
+import org.opennms.test.system.api.TestEnvironmentBuilder;
+import org.opennms.test.system.api.utils.SshClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.spotify.docker.client.DockerClient;
+import com.spotify.docker.client.exceptions.DockerException;
+
+/**
+ * This test starts up Minion with the default JMS sink and makes sure
+ * that heartbeat messages continue to be processed even if the Minion
+ * and OpenNMS instances are restarted.
+ * 
+ * @author Seth
+ */
+public class MinionHeartbeatOutageTest {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MinionHeartbeatOutageKafkaTest.class);
+
+    @Rule
+    public TestEnvironment testEnvironment = getTestEnvironment();
+
+    @Rule
+    public Timeout timeout = new Timeout(20, TimeUnit.MINUTES);
+
+    protected HibernateDaoFactory daoFactory;
+
+    public final TestEnvironment getTestEnvironment() {
+        if (!OpenNMSSeleniumTestCase.isDockerEnabled()) {
+            return new NullTestEnvironment();
+        }
+        try {
+            return getEnvironmentBuilder().build();
+        } catch (final Throwable t) {
+            throw new RuntimeException(t);
+        }
+    }
+
+    /**
+     * Override this method to customize the test environment.
+     */
+    protected TestEnvironmentBuilder getEnvironmentBuilder() {
+        final TestEnvironmentBuilder builder = TestEnvironment.builder().all();
+        OpenNMSSeleniumTestCase.configureTestEnvironment(builder);
+        return builder;
+    }
+
+    @Before
+    public void checkForDocker() {
+        Assume.assumeTrue(OpenNMSSeleniumTestCase.isDockerEnabled());
+    }
+
+    @Before
+    public void setup() {
+        // Connect to the postgresql container
+        final InetSocketAddress pgsql = testEnvironment.getServiceAddress(ContainerAlias.POSTGRES, 5432);
+        this.daoFactory = new HibernateDaoFactory(pgsql);
+    }
+
+    /**
+     * Install the Kafka features on Minion.
+     * 
+     * @param minionSshAddr
+     * @param kafkaAddress
+     * @throws Exception
+     */
+    protected static void installFeaturesOnMinion(InetSocketAddress minionSshAddr) throws Exception {
+        try (final SshClient sshClient = new SshClient(minionSshAddr, "admin", "admin")) {
+            PrintStream pipe = sshClient.openShell();
+            pipe.println("feature:list -i");
+            pipe.println("list");
+            // Set the log level to INFO
+            pipe.println("log:set INFO");
+            pipe.println("logout");
+            try {
+                await().atMost(2, MINUTES).until(sshClient.isShellClosedCallable());
+            } finally {
+                LOG.info("Karaf output:\n{}", sshClient.getStdout());
+            }
+        }
+    }
+
+    protected static void installFeaturesOnOpenNMS(InetSocketAddress opennmsSshAddr) throws Exception {
+        try (final SshClient sshClient = new SshClient(opennmsSshAddr, "admin", "admin")) {
+            PrintStream pipe = sshClient.openShell();
+
+            pipe.println("features:list -i");
+            // Set the log level to INFO
+            pipe.println("log:set INFO");//
+            pipe.println("logout");
+            try {
+                await().atMost(2, MINUTES).until(sshClient.isShellClosedCallable());
+            } finally {
+                LOG.info("Karaf output:\n{}", sshClient.getStdout());
+            }
+        }
+    }
+
+    @Test
+    public void testHeartbeatOutages() throws Exception {
+        Date startOfTest = new Date();
+
+        InetSocketAddress minionSshAddr = testEnvironment.getServiceAddress(ContainerAlias.MINION, 8201);
+        InetSocketAddress opennmsSshAddr = testEnvironment.getServiceAddress(ContainerAlias.OPENNMS, 8101);
+
+        installFeaturesOnMinion(minionSshAddr);
+
+        installFeaturesOnOpenNMS(opennmsSshAddr);
+
+        // Wait for the Minion to show up
+        await().atMost(90, SECONDS).pollInterval(5, SECONDS)
+            .until(DaoUtils.countMatchingCallable(
+                 this.daoFactory.getDao(MinionDaoHibernate.class),
+                 new CriteriaBuilder(OnmsMinion.class)
+                     .gt("lastUpdated", startOfTest)
+                     .eq("location", "MINION")
+                     .toCriteria()
+                 ),
+                 is(1)
+             );
+
+        // Make sure that the node is available
+        await().atMost(180, SECONDS).pollInterval(5, SECONDS)
+            .until(DaoUtils.countMatchingCallable(
+                this.daoFactory.getDao(NodeDaoHibernate.class),
+                new CriteriaBuilder(OnmsNode.class)
+                .eq("foreignSource", "Minions")
+                .eq("foreignId", "00000000-0000-0000-0000-000000ddba11")
+                .toCriteria()
+                ),
+            equalTo(1)
+        );
+
+        // Make sure that the expected events are present
+        assertEquals(1, DaoUtils.countMatchingCallable(
+            this.daoFactory.getDao(EventDaoHibernate.class),
+            new CriteriaBuilder(OnmsEvent.class)
+            .eq("eventUei", EventConstants.MONITORING_SYSTEM_ADDED_UEI)
+            .like("eventParms", String.format("%%%s=%s%%", EventConstants.PARAM_MONITORING_SYSTEM_TYPE, OnmsMonitoringSystem.TYPE_MINION))
+            .like("eventParms", String.format("%%%s=%s%%", EventConstants.PARAM_MONITORING_SYSTEM_ID, "00000000-0000-0000-0000-000000ddba11"))
+            .like("eventParms", String.format("%%%s=%s%%", EventConstants.PARAM_MONITORING_SYSTEM_LOCATION, "MINION"))
+            .toCriteria()
+            ).call().intValue()
+        );
+
+        assertEquals(0, DaoUtils.countMatchingCallable(
+            this.daoFactory.getDao(EventDaoHibernate.class),
+            new CriteriaBuilder(OnmsEvent.class)
+            .eq("eventUei", EventConstants.MONITORING_SYSTEM_LOCATION_CHANGED_UEI)
+            .toCriteria()
+            ).call().intValue()
+        );
+
+        for (int i = 0; i < 3; i++) {
+            restartContainer(ContainerAlias.MINION);
+
+            // Reset the startOfTest timestamp
+            startOfTest = new Date();
+
+            await().atMost(90, SECONDS).pollInterval(5, SECONDS)
+                .until(DaoUtils.countMatchingCallable(
+                     this.daoFactory.getDao(MinionDaoHibernate.class),
+                     new CriteriaBuilder(OnmsMinion.class)
+                         .gt("lastUpdated", startOfTest)
+                         .eq("location", "MINION")
+                         .toCriteria()
+                     ),
+                     is(1)
+                 );
+        }
+
+        for (int i = 0; i < 2; i++) {
+            restartContainer(ContainerAlias.OPENNMS);
+
+            // Reset the startOfTest timestamp
+            startOfTest = new Date();
+
+            await().atMost(240, SECONDS).pollInterval(5, SECONDS)
+                .until(DaoUtils.countMatchingCallable(
+                     this.daoFactory.getDao(MinionDaoHibernate.class),
+                     new CriteriaBuilder(OnmsMinion.class)
+                         .gt("lastUpdated", startOfTest)
+                         .eq("location", "MINION")
+                         .toCriteria()
+                     ),
+                     is(1)
+                 );
+        }
+
+        for (int i = 0; i < 1; i++) {
+            restartContainer(ContainerAlias.MINION);
+
+            // Reset the startOfTest timestamp
+            startOfTest = new Date();
+
+            await().atMost(90, SECONDS).pollInterval(5, SECONDS)
+                .until(DaoUtils.countMatchingCallable(
+                     this.daoFactory.getDao(MinionDaoHibernate.class),
+                     new CriteriaBuilder(OnmsMinion.class)
+                         .gt("lastUpdated", startOfTest)
+                         .eq("location", "MINION")
+                         .toCriteria()
+                     ),
+                     is(1)
+                 );
+        }
+    }
+
+    private void restartContainer(ContainerAlias alias) {
+        final DockerClient docker = ((AbstractTestEnvironment)testEnvironment).getDockerClient();
+        final String id = testEnvironment.getContainerInfo(alias).id();
+        try {
+            LOG.info("Restarting container: {} -> {}", alias, id);
+            docker.restartContainer(id);
+            LOG.info("Container restarted: {} -> {}", alias, id);
+        } catch (DockerException | InterruptedException e) {
+            LOG.warn("Unexpected exception while restarting container {}", id, e);
+        }
+    }
+}


### PR DESCRIPTION
Catch exceptions when receiving messages from Kafka so that the consumer thread isn't stopped. Added system tests that restart Minion and OpenNMS and verify that heartbeats resume.

* JIRA: http://issues.opennms.org/browse/NMS-9225