### PR TITLE
NMS-9113, NMS-9116: Upgrade to Camel 2.14.4 to fix Netty4 support, RPC fixes

### DIFF
--- a/core/ipc/rpc/camel-impl/src/main/java/org/opennms/core/rpc/camel/CamelRpcServerProcessor.java
+++ b/core/ipc/rpc/camel-impl/src/main/java/org/opennms/core/rpc/camel/CamelRpcServerProcessor.java
@@ -90,4 +90,9 @@ public class CamelRpcServerProcessor implements AsyncProcessor {
         });
         return false;
     }
+
+    @Override
+    public String toString() {
+        return String.format("%s[module=%s]", super.toString(), module.toString());
+    }
 }

--- a/core/ipc/rpc/camel-impl/src/main/java/org/opennms/core/rpc/camel/CamelRpcServerRouteManager.java
+++ b/core/ipc/rpc/camel-impl/src/main/java/org/opennms/core/rpc/camel/CamelRpcServerRouteManager.java
@@ -97,14 +97,14 @@ public class CamelRpcServerRouteManager {
         if (module != null) {
             final RpcModule<RpcRequest,RpcResponse> rpcModule = (RpcModule<RpcRequest,RpcResponse>)module;
             if (routeIdsByModule.containsKey(rpcModule)) {
-                LOG.warn("RpcModule {} was already registered.", rpcModule.getId());
-                return;
-            }
-            final DynamicRpcRouteBuilder routeBuilder = new DynamicRpcRouteBuilder(context, identity, rpcModule);
-            context.addRoutes(routeBuilder);
-            routeIdsByModule.put(rpcModule, routeBuilder.getRouteId());
+                LOG.warn("RpcModule {} ({}) was already registered", rpcModule.getId(), rpcModule.hashCode());
+            } else {
+                final DynamicRpcRouteBuilder routeBuilder = new DynamicRpcRouteBuilder(context, identity, rpcModule);
+                context.addRoutes(routeBuilder);
+                routeIdsByModule.put(rpcModule, routeBuilder.getRouteId());
 
-            LOG.info("Registered RpcModule {} on queue {}", rpcModule.getId(), routeBuilder.getQueueName());
+                LOG.info("Registered RpcModule {} ({}) on queue {}", rpcModule.getId(), rpcModule.hashCode(), routeBuilder.getQueueName());
+            }
         }
     }
 
@@ -116,8 +116,10 @@ public class CamelRpcServerRouteManager {
             if (routeId != null) {
                 context.stopRoute(routeId);
                 context.removeRoute(routeId);
+                LOG.info("Deregistered RpcModule {} ({})", rpcModule.getId(), rpcModule.hashCode());
+            } else {
+                LOG.warn("Could not determine route ID for RpcModule {} ({})", rpcModule.getId(), rpcModule.hashCode());
             }
-            LOG.info("Deregistered RpcModule {}", rpcModule.getId());
         }
     }
 }

--- a/core/ipc/rpc/camel-impl/src/main/java/org/opennms/core/rpc/camel/CamelRpcServerRouteManager.java
+++ b/core/ipc/rpc/camel-impl/src/main/java/org/opennms/core/rpc/camel/CamelRpcServerRouteManager.java
@@ -34,6 +34,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.camel.CamelContext;
 import org.apache.camel.ExchangePattern;
+import org.apache.camel.Route;
 import org.apache.camel.builder.RouteBuilder;
 import org.opennms.core.camel.JmsQueueNameFactory;
 import org.opennms.core.rpc.api.RpcModule;
@@ -75,10 +76,6 @@ public class CamelRpcServerRouteManager {
                     module.getId(), identity.getLocation());
         }
 
-        public String getRouteId() {
-            return "RPC.Server." + module.getId();
-        }
-
         public String getQueueName() {
             return queueNameFactory.getName();
         }
@@ -88,22 +85,54 @@ public class CamelRpcServerRouteManager {
             from(String.format("queuingservice:%s?asyncConsumer=true", queueNameFactory.getName()))
                 .setExchangePattern(ExchangePattern.InOut)
                 .process(new CamelRpcServerProcessor(module))
-                .routeId(getRouteId());
+                .routeId(getRouteId(module));
         }
+    }
+
+    public static String getRouteId(RpcModule<?,?> module) {
+        return "RPC.Server." + module.getId();
     }
 
     @SuppressWarnings({ "rawtypes", "unchecked" })
     public void bind(RpcModule module) throws Exception {
         if (module != null) {
             final RpcModule<RpcRequest,RpcResponse> rpcModule = (RpcModule<RpcRequest,RpcResponse>)module;
+            final String routeId = getRouteId(rpcModule);
+            final Route existingRoute = context.getRoute(routeId);
             if (routeIdsByModule.containsKey(rpcModule)) {
-                LOG.warn("RpcModule {} ({}) was already registered", rpcModule.getId(), rpcModule.hashCode());
+                if (existingRoute == null) {
+                    LOG.error("RpcModule {} ({}) was marked as registered but its route {} cannot be found in the Camel context", 
+                        rpcModule.getId(),
+                        Integer.toHexString(rpcModule.hashCode()),
+                        routeId
+                    );
+                } else {
+                    LOG.warn("RpcModule {} ({}) was already registered on route {}: {}",
+                        rpcModule.getId(),
+                        Integer.toHexString(rpcModule.hashCode()),
+                        routeId,
+                        existingRoute
+                    );
+                }
             } else {
-                final DynamicRpcRouteBuilder routeBuilder = new DynamicRpcRouteBuilder(context, identity, rpcModule);
-                context.addRoutes(routeBuilder);
-                routeIdsByModule.put(rpcModule, routeBuilder.getRouteId());
-
-                LOG.info("Registered RpcModule {} ({}) on queue {}", rpcModule.getId(), rpcModule.hashCode(), routeBuilder.getQueueName());
+                if (existingRoute == null) {
+                    final DynamicRpcRouteBuilder routeBuilder = new DynamicRpcRouteBuilder(context, identity, rpcModule);
+                    context.addRoutes(routeBuilder);
+                    routeIdsByModule.put(rpcModule, routeId);
+                    LOG.info("Registered RpcModule {} ({}) on route {} with queue {}",
+                        rpcModule.getId(),
+                        Integer.toHexString(rpcModule.hashCode()),
+                        routeId,
+                        routeBuilder.getQueueName()
+                    );
+                } else {
+                    LOG.warn("RpcModule {} ({}) cannot be registered, route {} is already present: {}",
+                        rpcModule.getId(),
+                        Integer.toHexString(rpcModule.hashCode()),
+                        routeId,
+                        existingRoute
+                    );
+                }
             }
         }
     }
@@ -116,9 +145,9 @@ public class CamelRpcServerRouteManager {
             if (routeId != null) {
                 context.stopRoute(routeId);
                 context.removeRoute(routeId);
-                LOG.info("Deregistered RpcModule {} ({})", rpcModule.getId(), rpcModule.hashCode());
+                LOG.info("Deregistered RpcModule {} ({})", rpcModule.getId(), Integer.toHexString(rpcModule.hashCode()));
             } else {
-                LOG.warn("Could not determine route ID for RpcModule {} ({})", rpcModule.getId(), rpcModule.hashCode());
+                LOG.warn("Could not determine route ID for RpcModule {} ({})", rpcModule.getId(), Integer.toHexString(rpcModule.hashCode()));
             }
         }
     }

--- a/core/ipc/rpc/camel-impl/src/main/resources/META-INF/opennms/applicationContext-rpc-client-camel.xml
+++ b/core/ipc/rpc/camel-impl/src/main/resources/META-INF/opennms/applicationContext-rpc-client-camel.xml
@@ -11,7 +11,7 @@
   http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
   http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.1.xsd
   http://xmlns.opennms.org/xsd/spring/onms-osgi http://xmlns.opennms.org/xsd/spring/onms-osgi.xsd
-  http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd
+  http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring-2.14.4.xsd
 ">
 
   <context:annotation-config />
@@ -36,8 +36,6 @@
   <bean id="shutdownStrategy" class="org.apache.camel.impl.DefaultShutdownStrategy">
       <property name="timeout" value="15"/>
   </bean>
-
-  <bean id="properties" class="org.apache.camel.component.properties.PropertiesComponent" />
 
   <camelContext id="rpcClient" xmlns="http://camel.apache.org/schema/spring">
     <!-- Exchanges contain credentials i.e. SNMP community details, so avoid logging them -->

--- a/core/ipc/rpc/camel-impl/src/main/resources/OSGI-INF/blueprint/blueprint-rpc-server.xml
+++ b/core/ipc/rpc/camel-impl/src/main/resources/OSGI-INF/blueprint/blueprint-rpc-server.xml
@@ -9,6 +9,8 @@
 		http://aries.apache.org/schemas/blueprint-cm/blueprint-cm-1.1.0.xsd
 		http://aries.apache.org/blueprint/xmlns/blueprint-ext/v1.1.0
 		http://aries.apache.org/schemas/blueprint-ext/blueprint-ext-1.1.xsd
+		http://camel.apache.org/schema/blueprint
+		https://camel.apache.org/schema/blueprint/camel-blueprint-2.14.4.xsd
 ">
 
     <cm:property-placeholder id="ipcProperties"

--- a/core/ipc/rpc/camel-impl/src/test/java/org/opennms/core/rpc/camel/EchoRpcBlueprintIT.java
+++ b/core/ipc/rpc/camel-impl/src/test/java/org/opennms/core/rpc/camel/EchoRpcBlueprintIT.java
@@ -94,7 +94,7 @@ public class EchoRpcBlueprintIT extends CamelBlueprintTest {
 
     @Override
     protected String getBlueprintDescriptor() {
-        return "blueprint-empty-camel-context.xml";
+        return "classpath:OSGI-INF/blueprint/blueprint-rpc-server.xml";
     }
 
     @Test(timeout=60000)

--- a/core/ipc/rpc/camel-impl/src/test/java/org/opennms/core/rpc/camel/EchoRpcIT.java
+++ b/core/ipc/rpc/camel-impl/src/test/java/org/opennms/core/rpc/camel/EchoRpcIT.java
@@ -53,6 +53,8 @@ import org.opennms.core.rpc.echo.EchoRequest;
 import org.opennms.core.rpc.echo.EchoResponse;
 import org.opennms.core.rpc.echo.EchoRpcModule;
 import org.opennms.core.rpc.echo.MyEchoException;
+import org.opennms.core.test.Level;
+import org.opennms.core.test.MockLogAppender;
 import org.opennms.core.test.OpenNMSJUnit4ClassRunner;
 import org.opennms.core.test.activemq.ActiveMQBroker;
 import org.opennms.netmgt.model.OnmsDistPoller;
@@ -114,6 +116,7 @@ public class EchoRpcIT {
         SimpleRegistry registry = new SimpleRegistry();
         CamelContext context = new DefaultCamelContext(registry);
         context.addComponent("queuingservice", queuingservice);
+        context.start();
 
         CamelRpcServerRouteManager routeManager = new CamelRpcServerRouteManager(context,
                 new MockMinionIdentity(REMOTE_LOCATION_NAME));
@@ -158,6 +161,7 @@ public class EchoRpcIT {
         SimpleRegistry registry = new SimpleRegistry();
         CamelContext context = new DefaultCamelContext(registry);
         context.addComponent("queuingservice", queuingservice);
+        context.start();
 
         CamelRpcServerRouteManager routeManager = new CamelRpcServerRouteManager(context,
                 new MockMinionIdentity(REMOTE_LOCATION_NAME));
@@ -283,6 +287,8 @@ public class EchoRpcIT {
             fail("Did not get ExecutionException");
         } catch (ExecutionException e) {
             assertTrue("Cause is not of type RequestTimedOutException: " + ExceptionUtils.getStackTrace(e), e.getCause() instanceof RequestTimedOutException);
+            // Verify that the message body was suppressed
+            MockLogAppender.assertLogMatched(Level.DEBUG, "[Body is not logged]");
         }
 
         routeManager.unbind(echoRpcModule);

--- a/core/ipc/sink/camel-impl/src/main/resources/META-INF/opennms/applicationContext-ipc-sink-server-camel.xml
+++ b/core/ipc/sink/camel-impl/src/main/resources/META-INF/opennms/applicationContext-ipc-sink-server-camel.xml
@@ -11,7 +11,7 @@
   http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd
   http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.1.xsd
   http://xmlns.opennms.org/xsd/spring/onms-osgi http://xmlns.opennms.org/xsd/spring/onms-osgi.xsd
-  http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd
+  http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring-2.14.4.xsd
 ">
 
   <context:annotation-config />
@@ -36,8 +36,6 @@
   <bean id="shutdownStrategy" class="org.apache.camel.impl.DefaultShutdownStrategy">
     <property name="timeout" value="15"/>
   </bean>
-
-  <bean id="properties" class="org.apache.camel.component.properties.PropertiesComponent" />
 
   <camelContext id="sinkServer" xmlns="http://camel.apache.org/schema/spring">
     <!-- Exchanges contain credentials i.e. SNMP community details, so avoid logging them -->

--- a/core/snmp/proxy-rpc-tests/src/test/java/org/opennms/netmgt/snmp/proxy/common/LocationAwareSnmpClientIT.java
+++ b/core/snmp/proxy-rpc-tests/src/test/java/org/opennms/netmgt/snmp/proxy/common/LocationAwareSnmpClientIT.java
@@ -42,7 +42,6 @@ import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.opennms.core.rpc.api.RpcModule;
 import org.opennms.core.test.OpenNMSJUnit4ClassRunner;
 import org.opennms.core.test.activemq.ActiveMQBroker;
 import org.opennms.core.test.camel.CamelBlueprintTest;
@@ -120,12 +119,11 @@ public class LocationAwareSnmpClientIT extends CamelBlueprintTest {
         Properties props = new Properties();
         props.setProperty("alias", "opennms.broker");
         services.put(Component.class.getName(), new KeyValueHolder<Object, Dictionary>(queuingservice, props));
-        services.put(RpcModule.class.getName(), new KeyValueHolder<Object, Dictionary>(SnmpProxyRpcModule.INSTANCE, new Properties()));
     }
 
     @Override
     protected String getBlueprintDescriptor() {
-        return "blueprint-empty-camel-context.xml";
+        return "classpath:OSGI-INF/blueprint/blueprint-rpc-server.xml";
     }
 
     @Before

--- a/core/test-api/lib/src/main/java/org/opennms/core/test/MockLogAppender.java
+++ b/core/test-api/lib/src/main/java/org/opennms/core/test/MockLogAppender.java
@@ -28,14 +28,12 @@
 
 package org.opennms.core.test;
 
-import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Properties;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import junit.framework.AssertionFailedError;
-
-import org.slf4j.LoggerFactory;
 
 /**
  * <p>MockLogAppender class. If you do not specify the log level specifically, the level
@@ -76,7 +74,7 @@ public class MockLogAppender {
      * <p>resetEvents</p>
      */
     public static void resetEvents() {
-        s_events = Collections.synchronizedList(new LinkedList<LoggingEvent>());
+        s_events = new CopyOnWriteArrayList<>();
     }
 
     /**

--- a/features/elasticsearch/event-forwarder/src/main/resources/OSGI-INF/blueprint/blueprint-event-forwarder.xml
+++ b/features/elasticsearch/event-forwarder/src/main/resources/OSGI-INF/blueprint/blueprint-event-forwarder.xml
@@ -15,7 +15,7 @@
 		http://aries.apache.org/schemas/blueprint-ext/blueprint-ext-1.1.xsd
 
 		http://camel.apache.org/schema/blueprint
-		http://camel.apache.org/schema/blueprint/camel-blueprint-2.14.1.xsd
+		http://camel.apache.org/schema/blueprint/camel-blueprint-2.14.4.xsd
 ">
 
   <!-- Configuration properties -->

--- a/opennms-provision/opennms-detectorclient-rpc/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/opennms-provision/opennms-detectorclient-rpc/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -14,12 +14,13 @@
     <reference id="serviceDetectorRegistry" interface="org.opennms.netmgt.provision.detector.registry.api.ServiceDetectorRegistry" availability="mandatory"/>
     <bean id="detectorExecutor" class="java.util.concurrent.Executors" factory-method="newCachedThreadPool"/>
     <bean id="detectorRpcModule" class="org.opennms.netmgt.provision.detector.client.rpc.DetectorClientRpcModule" >
-       <property name="serviceDetectorRegistry" ref="serviceDetectorRegistry"/>
-       <property name="executor" ref="detectorExecutor"/>
+        <property name="serviceDetectorRegistry" ref="serviceDetectorRegistry"/>
+        <property name="executor" ref="detectorExecutor"/>
     </bean>
     <service ref="detectorRpcModule" interface="org.opennms.core.rpc.api.RpcModule" />
 
-    <bean id="dnsLookupRpcModule" class="org.opennms.netmgt.provision.dns.client.rpc.DnsLookupClientRpcModule" />
-    <service ref="dnsLookupRpcModule" interface="org.opennms.core.rpc.api.RpcModule" />
+    <service interface="org.opennms.core.rpc.api.RpcModule">
+        <bean class="org.opennms.netmgt.provision.dns.client.rpc.DnsLookupClientRpcModule" />
+    </service>
 
 </blueprint>

--- a/opennms-provision/opennms-detectorclient-rpc/src/test/java/org/opennms/netmgt/provision/detector/client/rpc/LocationAwareDetectorClientIT.java
+++ b/opennms-provision/opennms-detectorclient-rpc/src/test/java/org/opennms/netmgt/provision/detector/client/rpc/LocationAwareDetectorClientIT.java
@@ -96,6 +96,12 @@ public class LocationAwareDetectorClientIT extends CamelBlueprintTest {
         detectorClientRpcModule.setExecutor(Executors.newSingleThreadExecutor());
     }
 
+    @Override
+    protected String setConfigAdminInitialConfiguration(Properties props) {
+        props.put("body.debug", "-5");
+        return "org.opennms.core.ipc";
+    }
+
     @SuppressWarnings( "rawtypes" )
     @Override
     protected void addServicesOnStartup(Map<String, KeyValueHolder<Object, Dictionary>> services) {
@@ -119,7 +125,7 @@ public class LocationAwareDetectorClientIT extends CamelBlueprintTest {
 
     @Override
     protected String getBlueprintDescriptor() {
-        return "classpath:/OSGI-INF/blueprint/blueprint-rpc-server.xml,classpath:/OSGI-INF/blueprint/blueprint.xml";
+        return "classpath:/OSGI-INF/blueprint/blueprint.xml";
     }
 
     /**
@@ -186,5 +192,10 @@ public class LocationAwareDetectorClientIT extends CamelBlueprintTest {
             final String message = e.getCause().getMessage();
             assertTrue(message, message.contains("Failure on async detection."));
         }
+    }
+
+    @Test
+    public void didOverrideBodyDebug() throws Exception {
+        assertEquals("-5", context.getProperty("CamelLogDebugBodyMaxChars"));
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -2891,6 +2891,16 @@
         <version>1.4</version>
       </dependency>
       <dependency>
+        <groupId>org.apache.camel</groupId>
+        <artifactId>camel-jms</artifactId>
+        <version>${camelVersion}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.camel</groupId>
+        <artifactId>camel-spring</artifactId>
+        <version>${camelVersion}</version>
+      </dependency>
+      <dependency>
         <groupId>org.apache.xmlgraphics</groupId>
         <artifactId>batik-dom</artifactId>
         <version>${batikVersion}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -1263,7 +1263,7 @@
     <atomikosVersion>3.9.2</atomikosVersion>
     <batikVersion>1.7</batikVersion>
     <bsfVersion>2.4.0</bsfVersion>
-    <camelVersion>2.14.1</camelVersion>
+    <camelVersion>2.14.4</camelVersion>
     <elasticsearchVersion>1.0.0_4</elasticsearchVersion>
     <cloverVersion>3.2.0</cloverVersion>
     <commonsBeanutilsVersion>1.8.3</commonsBeanutilsVersion>


### PR DESCRIPTION
The syslog receiver code still uses Netty 3 and cannot switch to Netty 4 without this minor Camel upgrade from 2.14.1 to 2.14.4.

This branch also contains additional fixes for the RPC code:
- Avoid starting the context manually CamelRpcServerRouteManager.
- Added tests to make sure that overriding ```CamelLogDebugBodyMaxChars``` is working.
- Fixed ConcurrentModificationException in MockLogAppender.

This code has been running in Bamboo continuously without failure.

* JIRA: http://issues.opennms.org/browse/NMS-9113
* JIRA: http://issues.opennms.org/browse/NMS-9116