### PR TITLE
NMS-9265: Don't include iplike query when it is an actual result

### DIFF
--- a/features/topology-map/org.opennms.features.topology.api/src/main/java/org/opennms/features/topology/api/topo/SearchProvider.java
+++ b/features/topology-map/org.opennms.features.topology.api/src/main/java/org/opennms/features/topology/api/topo/SearchProvider.java
@@ -28,7 +28,6 @@
 
 package org.opennms.features.topology.api.topo;
 
-import java.util.List;
 import java.util.Set;
 
 import org.opennms.features.topology.api.GraphContainer;
@@ -73,7 +72,7 @@ public interface SearchProvider {
      * @param graphContainer
      * @return A list of SearchResults
      */
-    List<SearchResult> query(SearchQuery searchQuery, GraphContainer graphContainer);
+    Set<SearchResult> query(SearchQuery searchQuery, GraphContainer graphContainer);
     
     
     

--- a/features/topology-map/org.opennms.features.topology.api/src/main/java/org/opennms/features/topology/api/topo/SimpleSearchProvider.java
+++ b/features/topology-map/org.opennms.features.topology.api/src/main/java/org/opennms/features/topology/api/topo/SimpleSearchProvider.java
@@ -59,16 +59,16 @@ public abstract class SimpleSearchProvider extends AbstractSearchProvider {
     public abstract List<? extends VertexRef> queryVertices(SearchQuery searchQuery, GraphContainer container);
     
     @Override
-    public List<SearchResult> query(SearchQuery searchQuery, GraphContainer container) {
+    public Set<SearchResult> query(SearchQuery searchQuery, GraphContainer container) {
         LOG.info("SimpleSearchProvider->query: called with search query: '{}'", searchQuery);
 
         // Build search results from the matching vertices
-        final List<SearchResult> results = queryVertices(searchQuery, container).stream().map(v -> {
+        final Set<SearchResult> results = queryVertices(searchQuery, container).stream().map(v -> {
             SearchResult searchResult = new SearchResult(v);
             searchResult.setCollapsed(false);
             searchResult.setCollapsible(true);
             return searchResult;
-        }).collect(Collectors.toList());
+        }).collect(Collectors.toSet());
 
         LOG.info("SimpleSearchProvider->query: found {} results: {}", results.size(), results);
         return results;

--- a/features/topology-map/org.opennms.features.topology.api/src/test/java/org/opennms/features/topology/api/topo/AbstractSearchProviderTest.java
+++ b/features/topology-map/org.opennms.features.topology.api/src/test/java/org/opennms/features/topology/api/topo/AbstractSearchProviderTest.java
@@ -34,6 +34,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -124,8 +125,8 @@ public class AbstractSearchProviderTest {
             }
 
             @Override
-            public List<SearchResult> query(SearchQuery searchQuery, GraphContainer graphContainer) {
-                List<SearchResult> verts = new ArrayList<SearchResult>();
+            public Set<SearchResult> query(SearchQuery searchQuery, GraphContainer graphContainer) {
+                Set<SearchResult> verts = new HashSet<SearchResult>();
                 for (VertexRef vertexRef : m_vertexRefs) {
                     if (searchQuery.matches(vertexRef.getLabel())) {
                         verts.add(new SearchResult(vertexRef.getNamespace(), vertexRef.getId(), vertexRef.getLabel(), searchQuery.getQueryString()));

--- a/features/topology-map/org.opennms.features.topology.app/src/main/java/org/opennms/features/topology/app/internal/AlarmSearchProvider.java
+++ b/features/topology-map/org.opennms.features.topology.app/src/main/java/org/opennms/features/topology/app/internal/AlarmSearchProvider.java
@@ -29,7 +29,6 @@
 package org.opennms.features.topology.app.internal;
 
 
-import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -154,16 +153,16 @@ public class AlarmSearchProvider extends AbstractSearchProvider implements Searc
     }
 
     /**
-     * This method processes the <SearchQuery> that the user has typed and returns a <SearchResult> list
+     * This method processes the <SearchQuery> that the user has typed and returns a <SearchResult> set
      * of matching IP addresses as well as the query string itself, which is collapsible, to act
      * as a subnet container.
      * 
      */
     @Override
-    public List<SearchResult> query(SearchQuery searchQuery, GraphContainer graphContainer) {
+    public Set<SearchResult> query(SearchQuery searchQuery, GraphContainer graphContainer) {
     	LOG.info("SearchProvider.query: called with search query: '{}'", searchQuery);
 
-        final List<SearchResult> results = new ArrayList<>();
+        final Set<SearchResult> results = new HashSet<SearchResult>();
 		final String queryString = searchQuery.getQueryString();
 		if (!isAlarmQuery(queryString)) {
 			LOG.debug("SearchProvider.query: query not Alarm compatible.");
@@ -207,7 +206,7 @@ public class AlarmSearchProvider extends AbstractSearchProvider implements Searc
         return queryResults;
     }
 
-    private List<OnmsAlarm> findAlarms(final List<SearchResult> results, final String queryString) {
+    private List<OnmsAlarm> findAlarms(final Set<SearchResult> results, final String queryString) {
         CriteriaBuilder bldr = new CriteriaBuilder(OnmsAlarm.class);
         
         OnmsSeverity severity = OnmsSeverity.get(queryString);

--- a/features/topology-map/org.opennms.features.topology.app/src/main/java/org/opennms/features/topology/app/internal/CategorySearchProvider.java
+++ b/features/topology-map/org.opennms.features.topology.app/src/main/java/org/opennms/features/topology/app/internal/CategorySearchProvider.java
@@ -29,10 +29,9 @@
 package org.opennms.features.topology.app.internal;
 
 
-import java.util.*;
-
-import java.util.ArrayList;
-import java.util.List;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Set;
 
 import org.opennms.features.topology.api.GraphContainer;
@@ -73,11 +72,11 @@ public class CategorySearchProvider extends AbstractSearchProvider implements Se
     }
 
     @Override
-    public List<SearchResult> query(SearchQuery searchQuery, GraphContainer graphContainer) {
+    public Set<SearchResult> query(SearchQuery searchQuery, GraphContainer graphContainer) {
 
         Collection<OnmsCategory> categories = m_categoryDao.findAll();
 
-        List<SearchResult> results = new ArrayList<SearchResult>();
+        Set<SearchResult> results = new HashSet<SearchResult>();
         for (OnmsCategory category : categories) {
             if (!checkHiddenPrefix(category.getName()) && searchQuery.matches(category.getName())) {
                 SearchResult result = new SearchResult("category", category.getId().toString(), category.getName(), searchQuery.getQueryString());

--- a/features/topology-map/org.opennms.features.topology.app/src/main/java/org/opennms/features/topology/app/internal/IpLikeSearchProvider.java
+++ b/features/topology-map/org.opennms.features.topology.app/src/main/java/org/opennms/features/topology/app/internal/IpLikeSearchProvider.java
@@ -98,10 +98,10 @@ public class IpLikeSearchProvider extends AbstractSearchProvider implements Sear
      * 
      */
     @Override
-    public List<SearchResult> query(SearchQuery searchQuery, GraphContainer graphContainer) {
+    public Set<SearchResult> query(SearchQuery searchQuery, GraphContainer graphContainer) {
     	LOG.info("SearchProvider->query: called with search query: '{}'", searchQuery);
 
-        List<SearchResult> results = new ArrayList<SearchResult>();
+        Set<SearchResult> results = new HashSet<SearchResult>();
         
 		String queryString = searchQuery.getQueryString();
 		

--- a/features/topology-map/org.opennms.features.topology.app/src/main/java/org/opennms/features/topology/app/internal/ui/SearchBox.java
+++ b/features/topology-map/org.opennms.features.topology.app/src/main/java/org/opennms/features/topology/app/internal/ui/SearchBox.java
@@ -308,7 +308,7 @@ public class SearchBox extends AbstractComponent implements SelectionListener, G
                 if (provider.supportsPrefix(query)) {
                     // If there is an '=' divider, strip it off. Otherwise, use an empty query string
                     String queryOnly = query.indexOf('=') > 0 ? query.substring(query.indexOf('=') + 1) : "";
-                    List<SearchResult> q = provider.query(getSearchQuery(queryOnly), m_operationContext.getGraphContainer());
+                    Set<SearchResult> q = provider.query(getSearchQuery(queryOnly), m_operationContext.getGraphContainer());
                     results.addAll(q);
 
                     if (m_suggestionMap.containsKey(provider)) {
@@ -319,7 +319,7 @@ public class SearchBox extends AbstractComponent implements SelectionListener, G
                     }
 
                 } else {
-                    List<SearchResult> q = provider.query(getSearchQuery(query), m_operationContext.getGraphContainer());
+                    Set<SearchResult> q = provider.query(getSearchQuery(query), m_operationContext.getGraphContainer());
                     results.addAll(q);
                     if (m_suggestionMap.containsKey(provider)) {
                         m_suggestionMap.get(provider).addAll(q);

--- a/features/topology-map/plugins/org.opennms.features.topology.plugins.ncs/src/main/java/org/opennms/features/topology/plugins/ncs/NCSSearchProvider.java
+++ b/features/topology-map/plugins/org.opennms.features.topology.plugins.ncs/src/main/java/org/opennms/features/topology/plugins/ncs/NCSSearchProvider.java
@@ -28,7 +28,6 @@
 
 package org.opennms.features.topology.plugins.ncs;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -137,8 +136,8 @@ public class NCSSearchProvider extends AbstractSearchProvider implements SearchP
     }
 
     @Override
-    public List<SearchResult> query(SearchQuery searchQuery, GraphContainer graphContainer) {
-        List<SearchResult> searchResults = new ArrayList<SearchResult>();
+    public Set<SearchResult> query(SearchQuery searchQuery, GraphContainer graphContainer) {
+        Set<SearchResult> searchResults = new HashSet<SearchResult>();
 
         List<NCSComponent> components = m_ncsComponentRepository.findByType("Service");
         for (NCSComponent component : components) {

--- a/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.application/src/main/java/org/opennms/features/topology/plugins/topo/application/ApplicationSearchProvider.java
+++ b/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.application/src/main/java/org/opennms/features/topology/plugins/topo/application/ApplicationSearchProvider.java
@@ -29,7 +29,7 @@
 package org.opennms.features.topology.plugins.topo.application;
 
 import java.util.Arrays;
-import java.util.List;
+import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
 
@@ -49,7 +49,6 @@ import org.opennms.netmgt.vaadin.core.TransactionAwareBeanProxyFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 
 public class ApplicationSearchProvider extends AbstractSearchProvider implements SearchProvider {
@@ -79,9 +78,9 @@ public class ApplicationSearchProvider extends AbstractSearchProvider implements
     }
 
     @Override
-    public List<SearchResult> query(SearchQuery searchQuery, GraphContainer container) {
+    public Set<SearchResult> query(SearchQuery searchQuery, GraphContainer container) {
         LOG.info("ApplicationServiceSearchProvider->query: called with search query: '{}'", searchQuery);
-        List<SearchResult> results = Lists.newArrayList();
+        Set<SearchResult> results = new HashSet<>();
 
         String queryString = searchQuery.getQueryString();
         CriteriaBuilder bldr = new CriteriaBuilder(OnmsApplication.class);

--- a/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.bsm/src/test/java/org/opennms/features/topology/plugins/topo/bsm/BusinessServiceSearchProviderIT.java
+++ b/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.bsm/src/test/java/org/opennms/features/topology/plugins/topo/bsm/BusinessServiceSearchProviderIT.java
@@ -28,7 +28,7 @@
 
 package org.opennms.features.topology.plugins.topo.bsm;
 
-import java.util.List;
+import java.util.Set;
 
 import org.easymock.EasyMock;
 import org.junit.Assert;
@@ -117,7 +117,7 @@ public class BusinessServiceSearchProviderIT {
                 return true; // always match, it does not matter
             }
         };
-        final List<SearchResult> result = provider.query(query, graphContainerMock);
+        final Set<SearchResult> result = provider.query(query, graphContainerMock);
         Assert.assertEquals(1, result.size());
         EasyMock.verify(graphContainerMock, graphProviderMock);
     }

--- a/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.linkd/src/main/java/org/opennms/features/topology/plugins/topo/linkd/internal/EnhancedLinkdTopologyProvider.java
+++ b/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.linkd/src/main/java/org/opennms/features/topology/plugins/topo/linkd/internal/EnhancedLinkdTopologyProvider.java
@@ -37,9 +37,9 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Set;
-import java.util.Map.Entry;
 
 import javax.xml.bind.JAXBException;
 
@@ -96,7 +96,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
-import com.google.common.collect.Lists;
 
 public class EnhancedLinkdTopologyProvider extends AbstractLinkdTopologyProvider {
 
@@ -1380,11 +1379,11 @@ public class EnhancedLinkdTopologyProvider extends AbstractLinkdTopologyProvider
     }
 
     @Override
-    public List<SearchResult> query(SearchQuery searchQuery, GraphContainer graphContainer) {
+    public Set<SearchResult> query(SearchQuery searchQuery, GraphContainer graphContainer) {
         //LOG.debug("SearchProvider->query: called with search query: '{}'", searchQuery);
 
         List<Vertex> vertices = getFilteredVertices();
-        List<SearchResult> searchResults = Lists.newArrayList();
+        Set<SearchResult> searchResults = new HashSet<>();
 
         for(Vertex vertex : vertices){
             if(searchQuery.matches(vertex.getLabel())) {


### PR DESCRIPTION
When forming iplike queries in Topology, duplicate entries occur when typing an actual result - fixed