### PR TITLE
NMS-8610: Stop Ackd from loading component-service.xml contexts

### DIFF
--- a/container/features/src/main/resources/features.xml
+++ b/container/features/src/main/resources/features.xml
@@ -418,6 +418,8 @@
       <feature>jaxb</feature>
       <feature>owasp-encoder</feature>
 
+      <!-- Used by org.opennms.core.spring -->
+      <bundle dependency="true">wrap:mvn:javax.inject/javax.inject/1</bundle>
       <!-- Used by org.opennms.core.xml -->
       <bundle dependency="true">mvn:org.codehaus.jackson/jackson-core-asl/${jacksonVersion}</bundle>
       <bundle dependency="true">mvn:org.codehaus.jackson/jackson-mapper-asl/${jacksonVersion}</bundle>

--- a/core/spring/pom.xml
+++ b/core/spring/pom.xml
@@ -45,5 +45,10 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
+    <dependency>
+      <groupId>javax.inject</groupId>
+      <artifactId>javax.inject</artifactId>
+      <version>1</version>
+    </dependency>
   </dependencies>
 </project>

--- a/opennms-ackd/src/main/resources/META-INF/opennms/applicationContext-ackd.xml
+++ b/opennms-ackd/src/main/resources/META-INF/opennms/applicationContext-ackd.xml
@@ -1,10 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="http://www.springframework.org/schema/beans" 
+<beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
        xmlns:tx="http://www.springframework.org/schema/tx" 
        xsi:schemaLocation="
-       http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
-       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.1.xsd">
+           http://www.springframework.org/schema/beans
+           http://www.springframework.org/schema/beans/spring-beans-4.1.xsd
+           http://www.springframework.org/schema/context
+           http://www.springframework.org/schema/context/spring-context-4.1.xsd
+           http://www.springframework.org/schema/tx
+           http://www.springframework.org/schema/tx/spring-tx-4.1.xsd">
+
+  <context:annotation-config />
 
   <bean id="ackdConfigurationDao" class="org.opennms.netmgt.dao.jaxb.DefaultAckdConfigurationDao">
     <property name="configResource" value="file:${opennms.home}/etc/ackd-configuration.xml" />

--- a/opennms-ackd/src/main/resources/beanRefContext.xml
+++ b/opennms-ackd/src/main/resources/beanRefContext.xml
@@ -7,7 +7,6 @@
      <constructor-arg>
        <list>
          <value>META-INF/opennms/applicationContext-ackd.xml</value>
-         <value>classpath*:/META-INF/opennms/component-service.xml</value>
        </list>
      </constructor-arg>
      <constructor-arg ref="daoContext" />


### PR DESCRIPTION
The beanRefContext.xml for Ackd contained an old stanza for loading component-service.xml contexts. This should be removed to prevent these contexts from being loaded twice: once by the webapp (the correct place) and again by Ackd.

* JIRA: http://issues.opennms.org/browse/NMS-8610