### PR TITLE
NMS-9233: Fix thread leak in SnmpUtils

### DIFF
--- a/core/snmp/impl-snmp4j/src/main/java/org/opennms/netmgt/snmp/snmp4j/Snmp4JStrategy.java
+++ b/core/snmp/impl-snmp4j/src/main/java/org/opennms/netmgt/snmp/snmp4j/Snmp4JStrategy.java
@@ -88,7 +88,7 @@ public class Snmp4JStrategy implements SnmpStrategy {
 
     private static final transient Logger LOG = LoggerFactory.getLogger(Snmp4JStrategy.class);
 
-    private static final ExecutorService REAPER_EXECUTOR = Executors.newSingleThreadExecutor(new ThreadFactory() {
+    private static final ExecutorService REAPER_EXECUTOR = Executors.newCachedThreadPool(new ThreadFactory() {
         @Override
         public Thread newThread(Runnable r) {
             return new Thread(r, "SNMP4J-Session-Reaper");

--- a/core/snmp/proxy-rpc-impl/src/main/java/org/opennms/netmgt/snmp/proxy/common/SnmpProxyRpcModule.java
+++ b/core/snmp/proxy-rpc-impl/src/main/java/org/opennms/netmgt/snmp/proxy/common/SnmpProxyRpcModule.java
@@ -64,7 +64,7 @@ public class SnmpProxyRpcModule extends AbstractXmlRpcModule<SnmpRequestDTO, Snm
 
     public static final String RPC_MODULE_ID = "SNMP";
 
-    private static final ExecutorService REAPER_EXECUTOR = Executors.newSingleThreadExecutor(new ThreadFactory() {
+    private static final ExecutorService REAPER_EXECUTOR = Executors.newCachedThreadPool(new ThreadFactory() {
         @Override
         public Thread newThread(Runnable r) {
             return new Thread(r, "SNMP-Proxy-RPC-Session-Reaper");


### PR DESCRIPTION
JIRA: https://issues.opennms.org/browse/NMS-9233

Use a cached thread pool, instead of a single thread, to close sessions since the call to
close can take up to 60 seconds by default (see org.snmp4j.SNMP4JSettings#threadJoinTimeout).