### PR TITLE
NMS-8875: Make timeout of Google Map API http client configurable i

### DIFF
--- a/container/karaf/src/main/filtered-resources/etc/org.opennms.features.geocoder.google.cfg
+++ b/container/karaf/src/main/filtered-resources/etc/org.opennms.features.geocoder.google.cfg
@@ -1,2 +1,3 @@
 clientId=
 clientKey=
+timeout=500

--- a/features/geocoder/google/src/main/java/org/opennms/features/geocoder/google/GoogleGeocoderService.java
+++ b/features/geocoder/google/src/main/java/org/opennms/features/geocoder/google/GoogleGeocoderService.java
@@ -50,11 +50,13 @@ import com.google.code.geocoder.model.GeocoderRequest;
 public class GoogleGeocoderService implements GeocoderService {
     private static final Logger LOG = LoggerFactory.getLogger(GoogleGeocoderService.class);
 
+    private final int timeout; // in ms
     private AdvancedGeoCoder m_geocoder = null;
     private String m_clientId = null;
     private String m_clientKey = null;
 
-    public GoogleGeocoderService() {
+    public GoogleGeocoderService(int timeout) {
+        this.timeout = Math.max(0, timeout);
     }
 
     public void setClientId(final String clientId) {
@@ -95,6 +97,7 @@ public class GoogleGeocoderService implements GeocoderService {
 
             /* Limit retries... */
             httpClient.getParams().setParameter(HttpMethodParams.RETRY_HANDLER, new DefaultHttpMethodRetryHandler(1, true));
+            httpClient.getParams().setParameter(HttpMethodParams.SO_TIMEOUT, timeout);
 
             LOG.info("Google Geocoder initialized.");
         }

--- a/features/geocoder/google/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/features/geocoder/google/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -11,10 +11,12 @@
         <cm:default-properties>
             <cm:property name="clientId" value="" />
             <cm:property name="clientKey" value="" />
+			<cm:property name="timeout" value="500"/>
         </cm:default-properties>
     </cm:property-placeholder>
 
 	<bean id="googleGeocoderService" class="org.opennms.features.geocoder.google.GoogleGeocoderService">
+		<argument value="${timeout}" />
 		<property name="clientId" value="${clientId}" />
 		<property name="clientKey" value="${clientKey}" />
 	</bean>

--- a/opennms-doc/guide-admin/src/asciidoc/index.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/index.adoc
@@ -171,6 +171,7 @@ include::text/enlinkd/layer-3/is-is-discovery.adoc[]
 [[ga-opennms-operation]]
 == Operation
 include::text/operation/ssl/ssl.adoc[]
+include::text/operation/geocoder.adoc[]
 include::text/operation/resourcecli.adoc[]
 include::text/operation/newts-repository-converter.adoc[]
 

--- a/opennms-doc/guide-admin/src/asciidoc/text/operation/geocoder.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/operation/geocoder.adoc
@@ -1,0 +1,22 @@
+
+// Allow GitHub image rendering
+:imagesdir: ../../images
+
+=== Geocoder Service
+
+The _Geocoder Service_ is used to resolve geolocation information within _{opennms-product-name}_.
+By default The Google Map API is used to resolve the geolocation information, if available.
+In order to configure the Google Map API the following properties in `etc/org.opennms.features.geocoder.google.cfg` are supported:
+
+[options="header, autowidth"]
+|===
+| Property       | Type         | Default             | Description
+| `clientId`     | `String`     | _empty string_      | The Google Map API `Client ID`.
+                                                        This is required if you exceed the free Google Map API usage.
+                                                        Please refer to the link:https://developers.google.com/maps/documentation/javascript/get-api-key[official documentation] for more information.
+| `clientKey`    | `String`     | _empty string_      | The Google Map API `API Key`.
+                                                        This is required if you exceed the free Google Map API usage.
+                                                        Please refer to the link:https://developers.google.com/maps/documentation/javascript/get-api-key[official documentation] for more information.
+| `timeout`      | `Integer`    | `500`               | The connection timeout in milliseconds the Geocoder tries to resolve a single geolocation.
+|===
+


### PR DESCRIPTION
* JIRA: https://issues.opennms.org/browse/NMS-7148

Backports default socket timeout setting for the google geocoder service from `foundation-2017` to `foundation-2016`. The original issue was NMS-8875: https://issues.opennms.org/browse/NMS-8875