### PR TITLE
NMS-9294: Add initialSleepTime to IPC sink code

### DIFF
--- a/core/ipc/sink/camel-impl/src/main/java/org/opennms/core/ipc/sink/camel/CamelMessageConsumerManager.java
+++ b/core/ipc/sink/camel-impl/src/main/java/org/opennms/core/ipc/sink/camel/CamelMessageConsumerManager.java
@@ -61,7 +61,7 @@ public class CamelMessageConsumerManager extends AbstractMessageConsumerManager 
     }
 
     @Override
-    public void startConsumingForModule(SinkModule<?, Message> module) throws Exception {
+    protected synchronized void startConsumingForModule(SinkModule<?, Message> module) throws Exception {
         if (!routeIdsByModule.containsKey(module)) {
             LOG.info("Creating route for module: {}", module);
             final DynamicIpcRouteBuilder routeBuilder = new DynamicIpcRouteBuilder(context, this, module);
@@ -71,10 +71,10 @@ public class CamelMessageConsumerManager extends AbstractMessageConsumerManager 
     }
 
     @Override
-    public void stopConsumingForModule(SinkModule<?, Message> module) throws Exception {
+    protected synchronized void stopConsumingForModule(SinkModule<?, Message> module) throws Exception {
         if (routeIdsByModule.containsKey(module)) {
             LOG.info("Destroying route for module: {}", module);
-            final String routeId = routeIdsByModule.get(module);
+            final String routeId = routeIdsByModule.remove(module);
             context.stopRoute(routeId);
             context.removeRoute(routeId);
         }

--- a/core/ipc/sink/common/src/main/java/org/opennms/core/ipc/sink/common/AbstractMessageConsumerManager.java
+++ b/core/ipc/sink/common/src/main/java/org/opennms/core/ipc/sink/common/AbstractMessageConsumerManager.java
@@ -30,6 +30,7 @@ package org.opennms.core.ipc.sink.common;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
 
 import org.opennms.core.ipc.sink.api.Message;
 import org.opennms.core.ipc.sink.api.MessageConsumer;
@@ -48,11 +49,39 @@ public abstract class AbstractMessageConsumerManager implements MessageConsumerM
 
     private static final Logger LOG = LoggerFactory.getLogger(AbstractMessageConsumerManager.class);
 
+    public static final String SINK_INITIAL_SLEEP_TIME = "org.opennms.core.ipc.sink.initialSleepTime";
+
     private final Multimap<SinkModule<?, Message>, MessageConsumer<?, Message>> consumersByModule = LinkedListMultimap.create();
 
-    public abstract void startConsumingForModule(SinkModule<?, Message> module) throws Exception;
+    protected abstract void startConsumingForModule(SinkModule<?, Message> module) throws Exception;
 
-    public abstract void stopConsumingForModule(SinkModule<?, Message> module) throws Exception;
+    protected abstract void stopConsumingForModule(SinkModule<?, Message> module) throws Exception;
+
+    public final CompletableFuture<Void> waitForStartup;
+
+    protected AbstractMessageConsumerManager() {
+        // By default, do not introduce any delay on startup
+        CompletableFuture<Void> startupFuture = CompletableFuture.completedFuture(null);
+        String initialSleepString = System.getProperty(SINK_INITIAL_SLEEP_TIME, "0");
+        try {
+            int initialSleep = Integer.parseInt(initialSleepString);
+            if (initialSleep > 0) {
+                startupFuture = CompletableFuture.runAsync(new Runnable() {
+                    @Override
+                    public void run() {
+                        try {
+                            Thread.sleep(initialSleep);
+                        } catch (InterruptedException e) {
+                            LOG.warn(e.getMessage(), e);
+                        }
+                    }
+                });
+            }
+        } catch (NumberFormatException e) {
+            LOG.warn("Invalid value for system property {}: {}", SINK_INITIAL_SLEEP_TIME, initialSleepString);
+        }
+        waitForStartup = startupFuture;
+    }
 
     @SuppressWarnings("unchecked")
     @Override
@@ -75,8 +104,17 @@ public abstract class AbstractMessageConsumerManager implements MessageConsumerM
             final int numConsumersBefore = consumersByModule.get(module).size();
             consumersByModule.put(module, (MessageConsumer<?, Message>)consumer);
             if (numConsumersBefore < 1) {
-                LOG.info("Starting consuming messages for module: {}", module);
-                startConsumingForModule(module);
+                waitForStartup.thenRunAsync(new Runnable() {
+                    @Override
+                    public void run() {
+                        try {
+                            LOG.info("Starting to consume messages for module: {}", module);
+                            startConsumingForModule(module);
+                        } catch (Exception e) {
+                            LOG.error("Unexpected exception while trying to start consumer for module: {}", module, e);
+                        }
+                    }
+                });
             }
         }
     }
@@ -94,8 +132,17 @@ public abstract class AbstractMessageConsumerManager implements MessageConsumerM
             final SinkModule<?, Message> module = (SinkModule<?, Message>)consumer.getModule();
             consumersByModule.remove(module, (MessageConsumer<?, Message>)consumer);
             if (consumersByModule.get(module).size() < 1) {
-                LOG.info("Stopping consuming messages for module: {}", module);
-                stopConsumingForModule(module);
+                waitForStartup.thenRunAsync(new Runnable() {
+                    @Override
+                    public void run() {
+                        try {
+                            LOG.info("Stopping consumption of messages for module: {}", module);
+                            stopConsumingForModule(module);
+                        } catch (Exception e) {
+                            LOG.error("Unexpected exception while trying to stop consumer for module: {}", module, e);
+                        }
+                    }
+                });
             }
         }
     }

--- a/core/ipc/sink/kafka-impl/src/main/java/org/opennms/core/ipc/sink/kafka/KafkaMessageConsumerManager.java
+++ b/core/ipc/sink/kafka-impl/src/main/java/org/opennms/core/ipc/sink/kafka/KafkaMessageConsumerManager.java
@@ -120,7 +120,7 @@ public class KafkaMessageConsumerManager extends AbstractMessageConsumerManager 
     }
 
     @Override
-    public void startConsumingForModule(SinkModule<?, Message> module) throws Exception {
+    protected void startConsumingForModule(SinkModule<?, Message> module) throws Exception {
         if (!consumerRunnersByModule.containsKey(module)) {
             LOG.info("Starting consumers for module: {}", module);
 
@@ -137,7 +137,7 @@ public class KafkaMessageConsumerManager extends AbstractMessageConsumerManager 
     }
 
     @Override
-    public void stopConsumingForModule(SinkModule<?, Message> module) throws Exception {
+    protected void stopConsumingForModule(SinkModule<?, Message> module) throws Exception {
         if (consumerRunnersByModule.containsKey(module)) {
             LOG.info("Stopping consumers for module: {}", module);
             final List<KafkaConsumerRunner> consumerRunners = consumerRunnersByModule.get(module);

--- a/opennms-doc/guide-admin/src/asciidoc/text/minion/kafka.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/minion/kafka.adoc
@@ -4,13 +4,13 @@
 
 === Using Kafka
 
-By default, we use the embedded _ActiveMQ_ broker to communicate with the _Minions_.
-This broker is used for both issuing remote procedure calls (RPCs) i.e. ping this host, and for transporting unsolicited messages such as SNMP traps and Syslogs.
+By default, _{opennms-product-name}_ uses the embedded _ActiveMQ_ broker to communicate with _Minions_.
+This broker is used for both issuing remote procedure calls (RPCs, ie. ping this host) and for transporting unsolicited messages such as SNMP traps and syslog messages.
 
-_Apache Kafka_ can be used as an alternative to  _ActiveMQ_ for transporting the unsolicited messages.
+_Apache Kafka_ can be used as an alternative to _ActiveMQ_ for transporting the unsolicited messages.
 
-WARNING: _Kafka_ cannot currently be used for handling the RPCs.
-This means that _ActiveMQ_ is still required when the _Kafka_ support is enabled.
+WARNING: _Kafka_ cannot currently be used for handling RPC messages.
+This means that _ActiveMQ_ is still required even when _Kafka_ support is enabled.
 
 _Kafka_ must be enabled on both _{opennms-product-name}_ and _Minion_ to function.
 
@@ -18,10 +18,11 @@ The _Kafka_ server must be compatible with _Kafka_ client version `0.10.1.1_1`.
 
 ==== Consumer Configuration
 
-Enable and configure the _Kafka_ consumer on _{opennms-product-name}_ using:
+Enable and configure the _Kafka_ consumer on _{opennms-product-name}_ by using the following commands. The `initialSleepTime` property will ensure that messages are not consumed from _Kafka_ until the _{opennms-product-name}_ system has fully initialized.
 
 [source, sh]
 ----
+echo 'org.opennms.core.ipc.sink.initialSleepTime=60000' > "$OPENNMS_HOME/etc/opennms.properties.d/sink-initial-sleep-time.properties"
 echo 'org.opennms.core.ipc.sink.strategy=kafka
 org.opennms.core.ipc.sink.kafka.bootstrap.servers=127.0.0.1:9092' > "$OPENNMS_HOME/etc/opennms.properties.d/kafka.properties"
 ----

--- a/smoke-test/pom.xml
+++ b/smoke-test/pom.xml
@@ -15,6 +15,12 @@
     <test.fork.count>1</test.fork.count>
   </properties>
   <build>
+    <testResources>
+      <testResource>
+        <directory>src/test/resources</directory>
+        <filtering>true</filtering>
+      </testResource>
+    </testResources>
     <pluginManagement>
       <plugins>
         <plugin>

--- a/smoke-test/src/test/java/org/opennms/smoketest/minion/SyslogKafkaElasticsearchBufferingTest.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/minion/SyslogKafkaElasticsearchBufferingTest.java
@@ -1,0 +1,223 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2017 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+package org.opennms.smoketest.minion;
+
+import static com.jayway.awaitility.Awaitility.await;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.hamcrest.Matchers.is;
+
+import java.net.InetSocketAddress;
+import java.util.Date;
+
+import org.junit.Test;
+import org.opennms.core.criteria.CriteriaBuilder;
+import org.opennms.netmgt.dao.hibernate.MinionDaoHibernate;
+import org.opennms.netmgt.model.minion.OnmsMinion;
+import org.opennms.smoketest.OpenNMSSeleniumTestCase;
+import org.opennms.smoketest.utils.DaoUtils;
+import org.opennms.test.system.api.AbstractTestEnvironment;
+import org.opennms.test.system.api.NewTestEnvironment.ContainerAlias;
+import org.opennms.test.system.api.TestEnvironment;
+import org.opennms.test.system.api.TestEnvironmentBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.util.concurrent.RateLimiter;
+import com.spotify.docker.client.DockerClient;
+import com.spotify.docker.client.exceptions.DockerException;
+import com.spotify.docker.client.messages.ContainerInfo;
+
+/**
+ * This test will send syslog messages over the following message bus:
+ * 
+ * Minion -> Kafka -> OpenNMS Eventd -> Elasticsearch REST -> Elasticsearch 5
+ * 
+ * It stops OpenNMS, sends 1000 messages (that will be buffered inside Kafka)
+ * and then starts OpenNMS to make sure that all of the buffered messages get
+ * converted into events and are forwarded to Elasticsearch.
+ * 
+ * @author Seth
+ */
+public class SyslogKafkaElasticsearchBufferingTest extends AbstractSyslogTest {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SyslogKafkaElasticsearchBufferingTest.class);
+
+    /**
+     * Override this method to customize the test environment.
+     */
+    @Override
+    protected TestEnvironmentBuilder getEnvironmentBuilder() {
+        final TestEnvironmentBuilder builder = TestEnvironment.builder().all()
+
+            // Enable Elasticsearch 5
+            .es5()
+
+            // Enable Kafka
+            .kafka();
+        builder.withOpenNMSEnvironment()
+
+            // Add opennms-es-rest to the featuresBoot list
+            .addFile(AbstractSyslogTest.class.getResource("/org.apache.karaf.features.cfg"), "etc/org.apache.karaf.features.cfg")
+
+            // Set logging to INFO level
+            .addFile(AbstractSyslogTest.class.getResource("/log4j2-info.xml"), "etc/log4j2.xml")
+            .addFile(AbstractSyslogTest.class.getResource("/eventconf.xml"), "etc/eventconf.xml")
+            .addFile(AbstractSyslogTest.class.getResource("/events/Cisco.syslog.events.xml"), "etc/events/Cisco.syslog.events.xml")
+            // Disable Alarmd, enable Syslogd
+            .addFile(AbstractSyslogTest.class.getResource("/service-configuration-disable-alarmd.xml"), "etc/service-configuration.xml")
+            .addFile(AbstractSyslogTest.class.getResource("/syslogd-configuration.xml"), "etc/syslogd-configuration.xml")
+            .addFile(AbstractSyslogTest.class.getResource("/syslog/Cisco.syslog.xml"), "etc/syslog/Cisco.syslog.xml")
+
+            // Add a 60-second delay to the sink consumer startup to give 
+            // opennms-es-rest time to start up before consuming from Kafka
+            .addFile(AbstractSyslogTest.class.getResource("/opennms.properties.d/sink-initial-sleep-time.properties"), "etc/opennms.properties.d/sink-initial-sleep-time.properties")
+
+            // Switch sink impl to Kafka using opennms-properties.d file
+            .addFile(AbstractSyslogTest.class.getResource("/opennms.properties.d/kafka-sink.properties"), "etc/opennms.properties.d/kafka-sink.properties");
+        builder.withMinionEnvironment()
+            // Switch sink impl to Kafka using features.boot file
+            .addFile(AbstractSyslogTest.class.getResource("/featuresBoot.d/kafka.boot"), "etc/featuresBoot.d/kafka.boot");
+        OpenNMSSeleniumTestCase.configureTestEnvironment(builder);
+        return builder;
+    }
+
+    @Test
+    public void testMinionSyslogsOverKafkaToEsRest() throws Exception {
+        Date startOfTest = new Date();
+        int numMessages = 1000;
+        int packetsPerSecond = 50;
+
+        InetSocketAddress minionSshAddr = testEnvironment.getServiceAddress(ContainerAlias.MINION, 8201);
+        InetSocketAddress opennmsSshAddr = testEnvironment.getServiceAddress(ContainerAlias.OPENNMS, 8101);
+        InetSocketAddress kafkaAddress = testEnvironment.getServiceAddress(ContainerAlias.KAFKA, 9092);
+        InetSocketAddress zookeeperAddress = testEnvironment.getServiceAddress(ContainerAlias.KAFKA, 2181);
+
+        // Install the Kafka syslog and trap handlers on the Minion system
+        installFeaturesOnMinion(minionSshAddr, kafkaAddress);
+
+        // Install the Kafka and Elasticsearch features on the OpenNMS system
+        installFeaturesOnOpenNMS(opennmsSshAddr, kafkaAddress, zookeeperAddress, true);
+
+        final String sender = testEnvironment.getContainerInfo(ContainerAlias.SNMPD).networkSettings().ipAddress();
+
+        // Wait for the minion to show up
+        await().atMost(90, SECONDS).pollInterval(5, SECONDS)
+            .until(DaoUtils.countMatchingCallable(
+                 this.daoFactory.getDao(MinionDaoHibernate.class),
+                 new CriteriaBuilder(OnmsMinion.class)
+                     .gt("lastUpdated", startOfTest)
+                     .eq("location", "MINION")
+                     .toCriteria()
+                 ),
+                 is(1)
+             );
+
+        // Shut down OpenNMS. Syslog messages will accumulate in the Kafka
+        // message queue while it is down.
+        stopContainer(ContainerAlias.OPENNMS);
+
+        LOG.info("Warming up syslog routes by sending 100 packets");
+
+        // Warm up the routes
+        sendMessage(ContainerAlias.MINION, sender, 100);
+
+        for (int i = 0; i < 20; i++) {
+            LOG.info("Slept for " + i + " seconds");
+            Thread.sleep(1000);
+        }
+
+        // Make sure that this evenly divides into the numMessages
+        final int chunk = 50;
+        // Make sure that this is an even multiple of chunk
+        final int logEvery = 100;
+
+        int count = 0;
+        long start = System.currentTimeMillis();
+
+        // Send ${numMessages} syslog messages
+        RateLimiter limiter = RateLimiter.create(packetsPerSecond);
+        for (int i = 0; i < (numMessages / chunk); i++) {
+            limiter.acquire(chunk);
+            sendMessage(ContainerAlias.MINION, sender, chunk);
+            count += chunk;
+            if (count % logEvery == 0) {
+                long mid = System.currentTimeMillis();
+                LOG.info(String.format("Sent %d packets in %d milliseconds", logEvery, mid - start));
+                start = System.currentTimeMillis();
+            }
+        }
+
+        // Start OpenNMS. It should begin to consume syslog messages and forward
+        // them to Elasticsearch without dropping messages.
+        startContainer(ContainerAlias.OPENNMS);
+
+        // 100 warm-up messages plus ${numMessages} messages
+        pollForElasticsearchEventsUsingJest(this::getEs5Address, 100 + numMessages);
+    }
+
+    protected InetSocketAddress getEs5Address() {
+        return getServiceAddress((AbstractTestEnvironment)testEnvironment, ContainerAlias.ELASTICSEARCH_5, 9200, "tcp");
+    }
+
+    protected static InetSocketAddress getServiceAddress(AbstractTestEnvironment env, ContainerAlias alias, int port, String protocol) {
+        try {
+            // Fetch an up-to-date ContainerInfo for the ELASTICSEARCH_5 container
+            final DockerClient docker = env.getDockerClient();
+            final String id = env.getContainerInfo(alias).id();
+            ContainerInfo info = docker.inspectContainer(id);
+            return env.getServiceAddress(info, port, protocol); 
+        } catch (DockerException | InterruptedException e) {
+            LOG.error("Unexpected exception trying to fetch Elassticsearch port", e);
+            return null;
+        }
+    }
+
+    private void stopContainer(ContainerAlias alias) {
+        final DockerClient docker = ((AbstractTestEnvironment)testEnvironment).getDockerClient();
+        final String id = testEnvironment.getContainerInfo(alias).id();
+        try {
+            LOG.info("Stopping container: {} -> {}", alias, id);
+            docker.stopContainer(id, 60);
+            LOG.info("Container stopped: {} -> {}", alias, id);
+        } catch (DockerException | InterruptedException e) {
+            LOG.warn("Unexpected exception while stopping container {}", id, e);
+        }
+    }
+
+    private void startContainer(ContainerAlias alias) {
+        final DockerClient docker = ((AbstractTestEnvironment)testEnvironment).getDockerClient();
+        final String id = testEnvironment.getContainerInfo(alias).id();
+        try {
+            LOG.info("Starting container: {} -> {}", alias, id);
+            docker.startContainer(id);
+            LOG.info("Container started: {} -> {}", alias, id);
+        } catch (DockerException | InterruptedException e) {
+            LOG.warn("Unexpected exception while starting container {}", id, e);
+        }
+    }
+}

--- a/smoke-test/src/test/resources/opennms.properties.d/sink-initial-sleep-time.properties
+++ b/smoke-test/src/test/resources/opennms.properties.d/sink-initial-sleep-time.properties
@@ -1,0 +1,2 @@
+# Add a startup delay to the sink IPC modules
+org.opennms.core.ipc.sink.initialSleepTime=60000

--- a/smoke-test/src/test/resources/org.apache.karaf.features.cfg
+++ b/smoke-test/src/test/resources/org.apache.karaf.features.cfg
@@ -1,7 +1,7 @@
 #
 # Comma separated list of features repositories to register by default
 #
-featuresRepositories=mvn:org.opennms.container/org.opennms.container.karaf/19.0.0-SNAPSHOT/xml/features,mvn:org.opennms.karaf/opennms/19.0.0-SNAPSHOT/xml/features
+featuresRepositories=mvn:org.opennms.container/org.opennms.container.karaf/${project.version}/xml/features,mvn:org.opennms.karaf/opennms/${project.version}/xml/features
 
 #
 # Comma separated list of features to install at startup

--- a/smoke-test/src/test/resources/org.apache.karaf.features.cfg
+++ b/smoke-test/src/test/resources/org.apache.karaf.features.cfg
@@ -1,0 +1,52 @@
+#
+# Comma separated list of features repositories to register by default
+#
+featuresRepositories=mvn:org.opennms.container/org.opennms.container.karaf/19.0.0-SNAPSHOT/xml/features,mvn:org.opennms.karaf/opennms/19.0.0-SNAPSHOT/xml/features
+
+#
+# Comma separated list of features to install at startup
+#
+#karaf-framework,shell,features,service-security,admin,config,ssh,management,kar,deployer,diagnostic,\
+featuresBoot=karaf-framework,ssh,config,features,management,\
+  http,\
+  http-whiteboard,\
+  kar,\
+  deployer,\
+  opennms-es-rest,\
+  opennms-jaas-login-module,\
+  datachoices, \
+  opennms-collection-commands, \
+  opennms-events-commands, \
+  opennms-icmp-commands, \
+  opennms-snmp-commands, \
+  opennms-topology-runtime-browsers,\
+  opennms-topology-runtime-linkd,\
+  opennms-topology-runtime-vmware,\
+  opennms-topology-runtime-application,\
+  opennms-topology-runtime-bsm,\
+  opennms-provisioning-shell,\
+  opennms-poller-shell,\
+  opennms-topology-runtime-graphml,\
+  osgi-nrtg-local,\
+  vaadin-node-maps,\
+  vaadin-snmp-events-and-metrics, \
+  vaadin-dashboard, \
+  dashlet-summary, \
+  dashlet-alarms, \
+  dashlet-bsm, \
+  dashlet-map, \
+  dashlet-image, \
+  dashlet-charts, \
+  dashlet-rtc, \
+  dashlet-rrd, \
+  dashlet-ksc, \
+  dashlet-topology, \
+  dashlet-url, \
+  dashlet-surveillance, \
+  vaadin-surveillance-views, \
+  vaadin-jmxconfiggenerator, \
+  vaadin-opennms-pluginmanager, \
+  vaadin-adminpage, \
+  org.opennms.features.bsm.shell-commands, \
+  internal-plugins-descriptor, \
+  geolocation

--- a/smoke-test/src/test/resources/service-configuration-disable-alarmd.xml
+++ b/smoke-test/src/test/resources/service-configuration-disable-alarmd.xml
@@ -25,6 +25,54 @@ maintained
     <invoke at="status" pass="0" method="status"/>
     <invoke at="stop" pass="0" method="stop"/>
   </service>
+  <service enabled="false">
+    <name>OpenNMS:Name=Alarmd</name>
+    <class-name>org.opennms.netmgt.daemon.SimpleSpringContextJmxServiceDaemon</class-name>
+    <attribute>
+      <name>LoggingPrefix</name>
+      <value type="java.lang.String">alarmd</value>
+    </attribute>
+    <attribute>
+      <name>SpringContext</name>
+      <value type="java.lang.String">alarmdContext</value>
+    </attribute>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Bsmd</name>
+    <class-name>org.opennms.netmgt.daemon.SimpleSpringContextJmxServiceDaemon</class-name>
+    <attribute>
+      <name>LoggingPrefix</name>
+      <value type="java.lang.String">bsmd</value>
+    </attribute>
+    <attribute>
+      <name>SpringContext</name>
+      <value type="java.lang.String">bsmdContext</value>
+    </attribute>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Ticketer</name>
+    <class-name>org.opennms.netmgt.ticketd.jmx.TroubleTicketer</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service enabled="false">
+    <name>OpenNMS:Name=Correlator</name>
+    <class-name>org.opennms.netmgt.correlation.jmx.Correlator</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
   <service>
     <name>OpenNMS:Name=Trapd</name>
     <class-name>org.opennms.netmgt.trapd.jmx.Trapd</class-name>
@@ -115,14 +163,6 @@ maintained
     <invoke at="stop" pass="0" method="stop"/>
   </service>
   <service>
-    <name>OpenNMS:Name=Ticketer</name>
-    <class-name>org.opennms.netmgt.ticketd.jmx.TroubleTicketer</class-name>
-    <invoke at="start" pass="0" method="init"/>
-    <invoke at="start" pass="1" method="start"/>
-    <invoke at="status" pass="0" method="status"/>
-    <invoke at="stop" pass="0" method="stop"/>
-  </service>
-  <service>
     <name>OpenNMS:Name=Collectd</name>
     <class-name>org.opennms.netmgt.collectd.jmx.Collectd</class-name>
     <invoke at="start" pass="0" method="init"/>
@@ -203,38 +243,6 @@ maintained
     <invoke at="stop" pass="0" method="stop"/>
   </service>
   <service>
-    <name>OpenNMS:Name=Bsmd</name>
-    <class-name>org.opennms.netmgt.daemon.SimpleSpringContextJmxServiceDaemon</class-name>
-    <attribute>
-      <name>LoggingPrefix</name>
-      <value type="java.lang.String">bsmd</value>
-    </attribute>
-    <attribute>
-      <name>SpringContext</name>
-      <value type="java.lang.String">bsmdContext</value>
-    </attribute>
-    <invoke at="start" pass="0" method="init"/>
-    <invoke at="start" pass="1" method="start"/>
-    <invoke at="status" pass="0" method="status"/>
-    <invoke at="stop" pass="0" method="stop"/>
-  </service>
-  <service enabled="false">
-    <name>OpenNMS:Name=Alarmd</name>
-    <class-name>org.opennms.netmgt.daemon.SimpleSpringContextJmxServiceDaemon</class-name>
-    <attribute>
-      <name>LoggingPrefix</name>
-      <value type="java.lang.String">alarmd</value>
-    </attribute>
-    <attribute>
-      <name>SpringContext</name>
-      <value type="java.lang.String">alarmdContext</value>
-    </attribute>
-    <invoke at="start" pass="0" method="init"/>
-    <invoke at="start" pass="1" method="start"/>
-    <invoke at="status" pass="0" method="status"/>
-    <invoke at="stop" pass="0" method="stop"/>
-  </service>
-  <service>
     <name>OpenNMS:Name=Ackd</name>
     <class-name>org.opennms.netmgt.daemon.SimpleSpringContextJmxServiceDaemon</class-name>
     <attribute>
@@ -259,14 +267,6 @@ maintained
     <invoke at="stop" pass="0" method="stop"/>
   </service>
   <service enabled="false">
-    <name>OpenNMS:Name=Correlator</name>
-    <class-name>org.opennms.netmgt.correlation.jmx.Correlator</class-name>
-    <invoke at="start" pass="0" method="init"/>
-    <invoke at="start" pass="1" method="start"/>
-    <invoke at="status" pass="0" method="status"/>
-    <invoke at="stop" pass="0" method="stop"/>
-  </service>
-  <service enabled="false">
     <name>OpenNMS:Name=Tl1d</name>
     <class-name>org.opennms.netmgt.tl1d.jmx.Tl1d</class-name>
     <invoke at="start" pass="0" method="init"/>
@@ -274,7 +274,7 @@ maintained
     <invoke at="status" pass="0" method="status"/>
     <invoke at="stop" pass="0" method="stop"/>
   </service>
-  <service enabled="true">
+  <service>
     <name>OpenNMS:Name=Syslogd</name>
     <class-name>org.opennms.netmgt.syslogd.jmx.Syslogd</class-name>
     <invoke at="start" pass="0" method="init"/>

--- a/smoke-test/src/test/resources/service-configuration.xml
+++ b/smoke-test/src/test/resources/service-configuration.xml
@@ -7,285 +7,287 @@ When splitting services to run on mutiple VMs, the order of the services should 
 maintained
 -->
 <service-configuration xmlns="http://xmlns.opennms.org/xsd/config/vmmgr">
-   <service>
-      <name>OpenNMS:Name=Manager</name>
-      <class-name>org.opennms.netmgt.vmmgr.Manager</class-name>
-      <invoke method="doSystemExit" pass="1" at="stop"/>
-   </service>
-   <service>
-      <name>OpenNMS:Name=TestLoadLibraries</name>
-      <class-name>org.opennms.netmgt.vmmgr.Manager</class-name>
-      <invoke method="doTestLoadLibraries" pass="0" at="start"/>
-   </service>
-   <service>
-      <name>OpenNMS:Name=Eventd</name>
-      <class-name>org.opennms.netmgt.eventd.jmx.Eventd</class-name>
-      <invoke method="init" pass="0" at="start"/>
-      <invoke method="start" pass="1" at="start"/>
-      <invoke method="status" pass="0" at="status"/>
-      <invoke method="stop" pass="0" at="stop"/>
-   </service>
-   <service>
-      <name>OpenNMS:Name=Trapd</name>
-      <class-name>org.opennms.netmgt.trapd.jmx.Trapd</class-name>
-      <invoke method="init" pass="0" at="start"/>
-      <invoke method="start" pass="1" at="start"/>
-      <invoke method="status" pass="0" at="status"/>
-      <invoke method="stop" pass="0" at="stop"/>
-   </service>
-   <service>
-      <name>OpenNMS:Name=Queued</name>
-      <class-name>org.opennms.netmgt.queued.jmx.Queued</class-name>
-      <invoke method="init" pass="0" at="start"/>
-      <invoke method="start" pass="1" at="start"/>
-      <invoke method="status" pass="0" at="status"/>
-      <invoke method="stop" pass="0" at="stop"/>
-   </service>
-   <service enabled="false">
-      <name>OpenNMS:Name=Dhcpd</name>
-      <class-name>org.opennms.netmgt.dhcpd.jmx.Dhcpd</class-name>
-      <invoke method="start" pass="1" at="start"/>
-      <invoke method="status" pass="0" at="status"/>
-      <invoke method="stop" pass="0" at="stop"/>
-   </service>
-   <service>
-      <name>OpenNMS:Name=Actiond</name>
-      <class-name>org.opennms.netmgt.actiond.jmx.Actiond</class-name>
-      <invoke method="init" pass="0" at="start"/>
-      <invoke method="start" pass="1" at="start"/>
-      <invoke method="status" pass="0" at="status"/>
-      <invoke method="stop" pass="0" at="stop"/>
-   </service>
-   <service>
-      <name>OpenNMS:Name=Notifd</name>
-      <class-name>org.opennms.netmgt.notifd.jmx.Notifd</class-name>
-      <invoke method="init" pass="0" at="start"/>
-      <invoke method="start" pass="1" at="start"/>
-      <invoke method="status" pass="0" at="status"/>
-      <invoke method="stop" pass="0" at="stop"/>
-   </service>
-   <service>
-      <name>OpenNMS:Name=Scriptd</name>
-      <class-name>org.opennms.netmgt.scriptd.jmx.Scriptd</class-name>
-      <invoke method="init" pass="0" at="start"/>
-      <invoke method="start" pass="1" at="start"/>
-      <invoke method="status" pass="0" at="status"/>
-      <invoke method="stop" pass="0" at="stop"/>
-   </service>
-   <service>
-      <name>OpenNMS:Name=Rtcd</name>
-      <class-name>org.opennms.netmgt.rtc.jmx.Rtcd</class-name>
-      <invoke method="init" pass="0" at="start"/>
-      <invoke method="start" pass="1" at="start"/>
-      <invoke method="status" pass="0" at="status"/>
-      <invoke method="stop" pass="0" at="stop"/>
-   </service>
-   <service>
-      <name>OpenNMS:Name=Pollerd</name>
-      <class-name>org.opennms.netmgt.poller.jmx.Pollerd</class-name>
-      <invoke method="init" pass="0" at="start"/>
-      <invoke method="start" pass="1" at="start"/>
-      <invoke method="status" pass="0" at="status"/>
-      <invoke method="stop" pass="0" at="stop"/>
-   </service>
-   <service>
-      <name>OpenNMS:Name=PollerBackEnd</name>
-      <class-name>org.opennms.netmgt.poller.remote.jmx.RemotePollerBackEnd</class-name>
-      <invoke method="init" pass="0" at="start"/>
-      <invoke method="start" pass="1" at="start"/>
-      <invoke method="status" pass="0" at="status"/>
-      <invoke method="stop" pass="0" at="stop"/>
-   </service>
-   <service enabled="false">
-      <name>OpenNMS:Name=SnmpPoller</name>
-      <class-name>org.opennms.netmgt.snmpinterfacepoller.jmx.SnmpPollerd</class-name>
-      <invoke method="init" pass="0" at="start"/>
-      <invoke method="start" pass="1" at="start"/>
-      <invoke method="status" pass="0" at="status"/>
-      <invoke method="stop" pass="0" at="stop"/>
-   </service>
-   <service>
-      <name>OpenNMS:Name=EnhancedLinkd</name>
-      <class-name>org.opennms.netmgt.enlinkd.jmx.EnhancedLinkd</class-name>
-      <invoke method="init" pass="0" at="start"/>
-      <invoke method="start" pass="1" at="start"/>
-      <invoke method="status" pass="0" at="status"/>
-      <invoke method="stop" pass="0" at="stop"/>
-   </service>
-   <service>
-      <name>OpenNMS:Name=Ticketer</name>
-      <class-name>org.opennms.netmgt.ticketd.jmx.TroubleTicketer</class-name>
-      <invoke method="init" pass="0" at="start"/>
-      <invoke method="start" pass="1" at="start"/>
-      <invoke method="status" pass="0" at="status"/>
-      <invoke method="stop" pass="0" at="stop"/>
-   </service>
-   <service>
-      <name>OpenNMS:Name=Collectd</name>
-      <class-name>org.opennms.netmgt.collectd.jmx.Collectd</class-name>
-      <invoke method="init" pass="0" at="start"/>
-      <invoke method="start" pass="1" at="start"/>
-      <invoke method="status" pass="0" at="status"/>
-      <invoke method="stop" pass="0" at="stop"/>
-   </service>
-   <service>
-      <name>OpenNMS:Name=Discovery</name>
-      <class-name>org.opennms.netmgt.discovery.jmx.Discovery</class-name>
-      <invoke method="init" pass="0" at="start"/>
-      <invoke method="start" pass="1" at="start"/>
-      <invoke method="status" pass="0" at="status"/>
-      <invoke method="stop" pass="0" at="stop"/>
-   </service>
-   <service>
-      <name>OpenNMS:Name=Vacuumd</name>
-      <class-name>org.opennms.netmgt.vacuumd.jmx.Vacuumd</class-name>
-      <invoke method="init" pass="0" at="start"/>
-      <invoke method="start" pass="1" at="start"/>
-      <invoke method="status" pass="0" at="status"/>
-      <invoke method="stop" pass="0" at="stop"/>
-   </service>
-   <service>
-      <name>OpenNMS:Name=EventTranslator</name>
-      <class-name>org.opennms.netmgt.translator.jmx.EventTranslator</class-name>
-      <invoke method="init" pass="0" at="start"/>
-      <invoke method="start" pass="1" at="start"/>
-      <invoke method="status" pass="0" at="status"/>
-      <invoke method="stop" pass="0" at="stop"/>
-   </service>
-   <service>
-      <name>OpenNMS:Name=PassiveStatusd</name>
-      <class-name>org.opennms.netmgt.passive.jmx.PassiveStatusd</class-name>
-      <invoke method="init" pass="0" at="start"/>
-      <invoke method="start" pass="1" at="start"/>
-      <invoke method="status" pass="0" at="status"/>
-      <invoke method="stop" pass="0" at="stop"/>
-   </service>
-   <service>
-      <name>OpenNMS:Name=Statsd</name>
-      <class-name>org.opennms.netmgt.statsd.jmx.Statsd</class-name>
-      <invoke method="init" pass="0" at="start"/>
-      <invoke method="start" pass="1" at="start"/>
-      <invoke method="status" pass="0" at="status"/>
-      <invoke method="stop" pass="0" at="stop"/>
-   </service>
-   <service>
-      <name>OpenNMS:Name=Provisiond</name>
-      <class-name>org.opennms.netmgt.daemon.SimpleSpringContextJmxServiceDaemon</class-name>
-      <attribute>
-         <name>LoggingPrefix</name>
-         <value type="java.lang.String">provisiond</value>
-      </attribute>
-      <attribute>
-         <name>SpringContext</name>
-         <value type="java.lang.String">provisiondContext</value>
-      </attribute>
-      <invoke method="init" pass="0" at="start"/>
-      <invoke method="start" pass="1" at="start"/>
-      <invoke method="status" pass="0" at="status"/>
-      <invoke method="stop" pass="0" at="stop"/>
-   </service>
-   <service>
-      <name>OpenNMS:Name=Reportd</name>
-      <class-name>org.opennms.netmgt.daemon.SimpleSpringContextJmxServiceDaemon</class-name>
-      <attribute>
-         <name>LoggingPrefix</name>
-         <value type="java.lang.String">reportd</value>
-      </attribute>
-      <attribute>
-         <name>SpringContext</name>
-         <value type="java.lang.String">reportdContext</value>
-      </attribute>
-      <invoke method="init" pass="0" at="start"/>
-      <invoke method="start" pass="1" at="start"/>
-      <invoke method="status" pass="0" at="status"/>
-      <invoke method="stop" pass="0" at="stop"/>
-   </service>
-   <service>
-      <name>OpenNMS:Name=Bsmd</name>
-      <class-name>org.opennms.netmgt.daemon.SimpleSpringContextJmxServiceDaemon</class-name>
-      <attribute>
-         <name>LoggingPrefix</name>
-         <value type="java.lang.String">bsmd</value>
-      </attribute>
-      <attribute>
-         <name>SpringContext</name>
-         <value type="java.lang.String">bsmdContext</value>
-      </attribute>
-      <invoke method="init" pass="0" at="start"/>
-      <invoke method="start" pass="1" at="start"/>
-      <invoke method="status" pass="0" at="status"/>
-      <invoke method="stop" pass="0" at="stop"/>
-   </service>
-   <service>
-      <name>OpenNMS:Name=Alarmd</name>
-      <class-name>org.opennms.netmgt.daemon.SimpleSpringContextJmxServiceDaemon</class-name>
-      <attribute>
-         <name>LoggingPrefix</name>
-         <value type="java.lang.String">alarmd</value>
-      </attribute>
-      <attribute>
-         <name>SpringContext</name>
-         <value type="java.lang.String">alarmdContext</value>
-      </attribute>
-      <invoke method="init" pass="0" at="start"/>
-      <invoke method="start" pass="1" at="start"/>
-      <invoke method="status" pass="0" at="status"/>
-      <invoke method="stop" pass="0" at="stop"/>
-   </service>
-   <service>
-      <name>OpenNMS:Name=Ackd</name>
-      <class-name>org.opennms.netmgt.daemon.SimpleSpringContextJmxServiceDaemon</class-name>
-      <attribute>
-         <name>LoggingPrefix</name>
-         <value type="java.lang.String">ackd</value>
-      </attribute>
-      <attribute>
-         <name>SpringContext</name>
-         <value type="java.lang.String">ackdContext</value>
-      </attribute>
-      <invoke method="init" pass="0" at="start"/>
-      <invoke method="start" pass="1" at="start"/>
-      <invoke method="status" pass="0" at="status"/>
-      <invoke method="stop" pass="0" at="stop"/>
-   </service>
-   <service>
-      <name>OpenNMS:Name=JettyServer</name>
-      <class-name>org.opennms.netmgt.jetty.jmx.JettyServer</class-name>
-      <invoke method="init" pass="0" at="start"/>
-      <invoke method="start" pass="1" at="start"/>
-      <invoke method="status" pass="0" at="status"/>
-      <invoke method="stop" pass="0" at="stop"/>
-   </service>
-   <service enabled="false">
-      <name>OpenNMS:Name=Correlator</name>
-      <class-name>org.opennms.netmgt.correlation.jmx.Correlator</class-name>
-      <invoke method="init" pass="0" at="start"/>
-      <invoke method="start" pass="1" at="start"/>
-      <invoke method="status" pass="0" at="status"/>
-      <invoke method="stop" pass="0" at="stop"/>
-   </service>
-   <service enabled="false">
-      <name>OpenNMS:Name=Tl1d</name>
-      <class-name>org.opennms.netmgt.tl1d.jmx.Tl1d</class-name>
-      <invoke method="init" pass="0" at="start"/>
-      <invoke method="start" pass="1" at="start"/>
-      <invoke method="status" pass="0" at="status"/>
-      <invoke method="stop" pass="0" at="stop"/>
-   </service>
-   <service enabled="true">
-      <name>OpenNMS:Name=Syslogd</name>
-      <class-name>org.opennms.netmgt.syslogd.jmx.Syslogd</class-name>
-      <invoke method="init" pass="0" at="start"/>
-      <invoke method="start" pass="1" at="start"/>
-      <invoke method="status" pass="0" at="status"/>
-      <invoke method="stop" pass="0" at="stop"/>
-   </service>
-   <service enabled="false">
-      <name>OpenNMS:Name=AsteriskGateway</name>
-      <class-name>org.opennms.netmgt.asterisk.agi.jmx.AsteriskGateway</class-name>
-      <invoke method="init" pass="0" at="start"/>
-      <invoke method="start" pass="1" at="start"/>
-      <invoke method="status" pass="0" at="status"/>
-      <invoke method="stop" pass="0" at="stop"/>
-   </service>
+  <service>
+    <name>OpenNMS:Name=Manager</name>
+    <class-name>org.opennms.netmgt.vmmgr.Manager</class-name>
+    <invoke at="stop" pass="1" method="doSystemExit"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=TestLoadLibraries</name>
+    <class-name>org.opennms.netmgt.vmmgr.Manager</class-name>
+    <invoke at="start" pass="0" method="doTestLoadLibraries"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Eventd</name>
+    <class-name>org.opennms.netmgt.eventd.jmx.Eventd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Alarmd</name>
+    <class-name>org.opennms.netmgt.daemon.SimpleSpringContextJmxServiceDaemon</class-name>
+    <attribute>
+      <name>LoggingPrefix</name>
+      <value type="java.lang.String">alarmd</value>
+    </attribute>
+    <attribute>
+      <name>SpringContext</name>
+      <value type="java.lang.String">alarmdContext</value>
+    </attribute>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Bsmd</name>
+    <class-name>org.opennms.netmgt.daemon.SimpleSpringContextJmxServiceDaemon</class-name>
+    <attribute>
+      <name>LoggingPrefix</name>
+      <value type="java.lang.String">bsmd</value>
+    </attribute>
+    <attribute>
+      <name>SpringContext</name>
+      <value type="java.lang.String">bsmdContext</value>
+    </attribute>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Ticketer</name>
+    <class-name>org.opennms.netmgt.ticketd.jmx.TroubleTicketer</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service enabled="false">
+    <name>OpenNMS:Name=Correlator</name>
+    <class-name>org.opennms.netmgt.correlation.jmx.Correlator</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Trapd</name>
+    <class-name>org.opennms.netmgt.trapd.jmx.Trapd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Queued</name>
+    <class-name>org.opennms.netmgt.queued.jmx.Queued</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <!--  Dhcpd is now distributed separately. You will need to ensure
+        it is installed before you enable it here. -->
+  <service enabled="false">
+    <name>OpenNMS:Name=Dhcpd</name>
+    <class-name>org.opennms.netmgt.dhcpd.jmx.Dhcpd</class-name>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Actiond</name>
+    <class-name>org.opennms.netmgt.actiond.jmx.Actiond</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Notifd</name>
+    <class-name>org.opennms.netmgt.notifd.jmx.Notifd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Scriptd</name>
+    <class-name>org.opennms.netmgt.scriptd.jmx.Scriptd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Rtcd</name>
+    <class-name>org.opennms.netmgt.rtc.jmx.Rtcd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Pollerd</name>
+    <class-name>org.opennms.netmgt.poller.jmx.Pollerd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=PollerBackEnd</name>
+    <class-name>org.opennms.netmgt.poller.remote.jmx.RemotePollerBackEnd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service enabled="false">
+     <name>OpenNMS:Name=SnmpPoller</name>
+     <class-name>org.opennms.netmgt.snmpinterfacepoller.jmx.SnmpPollerd</class-name>
+     <invoke at="start" pass="0" method="init"/>
+     <invoke at="start" pass="1" method="start"/>
+     <invoke at="status" pass="0" method="status"/>
+     <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=EnhancedLinkd</name>
+    <class-name>org.opennms.netmgt.enlinkd.jmx.EnhancedLinkd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Collectd</name>
+    <class-name>org.opennms.netmgt.collectd.jmx.Collectd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Discovery</name>
+    <class-name>org.opennms.netmgt.discovery.jmx.Discovery</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Vacuumd</name>
+    <class-name>org.opennms.netmgt.vacuumd.jmx.Vacuumd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=EventTranslator</name>
+    <class-name>org.opennms.netmgt.translator.jmx.EventTranslator</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=PassiveStatusd</name>
+    <class-name>org.opennms.netmgt.passive.jmx.PassiveStatusd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Statsd</name>
+    <class-name>org.opennms.netmgt.statsd.jmx.Statsd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Provisiond</name>
+    <class-name>org.opennms.netmgt.daemon.SimpleSpringContextJmxServiceDaemon</class-name>
+    <attribute>
+      <name>LoggingPrefix</name>
+      <value type="java.lang.String">provisiond</value>
+    </attribute>
+    <attribute>
+      <name>SpringContext</name>
+      <value type="java.lang.String">provisiondContext</value>
+    </attribute>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Reportd</name>
+    <class-name>org.opennms.netmgt.daemon.SimpleSpringContextJmxServiceDaemon</class-name>
+    <attribute>
+      <name>LoggingPrefix</name>
+      <value type="java.lang.String">reportd</value>
+    </attribute>
+    <attribute>
+      <name>SpringContext</name>
+      <value type="java.lang.String">reportdContext</value>
+    </attribute>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Ackd</name>
+    <class-name>org.opennms.netmgt.daemon.SimpleSpringContextJmxServiceDaemon</class-name>
+    <attribute>
+      <name>LoggingPrefix</name>
+      <value type="java.lang.String">ackd</value>
+    </attribute>
+    <attribute>
+      <name>SpringContext</name>
+      <value type="java.lang.String">ackdContext</value>
+    </attribute>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=JettyServer</name>
+    <class-name>org.opennms.netmgt.jetty.jmx.JettyServer</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service enabled="false">
+    <name>OpenNMS:Name=Tl1d</name>
+    <class-name>org.opennms.netmgt.tl1d.jmx.Tl1d</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service>
+    <name>OpenNMS:Name=Syslogd</name>
+    <class-name>org.opennms.netmgt.syslogd.jmx.Syslogd</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
+  <service enabled="false">
+    <name>OpenNMS:Name=AsteriskGateway</name>
+    <class-name>org.opennms.netmgt.asterisk.agi.jmx.AsteriskGateway</class-name>
+    <invoke at="start" pass="0" method="init"/>
+    <invoke at="start" pass="1" method="start"/>
+    <invoke at="status" pass="0" method="status"/>
+    <invoke at="stop" pass="0" method="stop"/>
+  </service>
 </service-configuration>


### PR DESCRIPTION
This PR adds a ```org.opennms.core.ipc.sink.initialSleepTime``` system property that can be used to delay sink consumers from registering for messages to give the rest of the event system (ie. Elasticsearch forwarding) time to start up.

* JIRA: http://issues.opennms.org/browse/NMS-9294