### PR TITLE
Jira/nms 4648

### DIFF
--- a/opennms-model/src/main/java/org/opennms/netmgt/model/TroubleTicketState.java
+++ b/opennms-model/src/main/java/org/opennms/netmgt/model/TroubleTicketState.java
@@ -33,11 +33,20 @@ package org.opennms.netmgt.model;
  *
  * @author <a href="mailto:brozow@opennms.org">Mathew Brozowski</a>
  * @author <a href="mailto:david@opennms.org">David Hustace</a>
- * @author <a href="mailto:brozow@opennms.org">Mathew Brozowski</a>
- * @author <a href="mailto:david@opennms.org">David Hustace</a>
+ * @author <a href="mailto:dschlenk@convergeone.com">David Schlenk</a>
  * @version $Id: $
  */
 public enum TroubleTicketState {
+    /* KEEP THESE IN ORDER or the DEFAULT ALARM VACUUM QUERIES will BREAK */
+    
+    /* TODO: once JPA 2.1+ in use, change things that use this to also use a
+     * javax.persistence.AttributeConverter<TroubleTicketState, Integer> that
+     * returns TroubleTicketState.getValue() in the converter. That should
+     * maintain backwords compatibility to the current default 
+     * Enum.toOrdinal() JPA behavior and prevent breaking when reordering items
+     * in the Enum. 
+     */
+    
     OPEN(0),
     CREATE_PENDING(1),
     CREATE_FAILED(2),
@@ -62,4 +71,6 @@ public enum TroubleTicketState {
     public int getValue() {
         return this.m_value;
     }
+    
+    
 }

--- a/opennms-model/src/main/java/org/opennms/netmgt/model/TroubleTicketState.java
+++ b/opennms-model/src/main/java/org/opennms/netmgt/model/TroubleTicketState.java
@@ -71,6 +71,5 @@ public enum TroubleTicketState {
     public int getValue() {
         return this.m_value;
     }
-    
-    
+
 }

--- a/opennms-model/src/main/java/org/opennms/netmgt/model/TroubleTicketState.java
+++ b/opennms-model/src/main/java/org/opennms/netmgt/model/TroubleTicketState.java
@@ -38,18 +38,28 @@ package org.opennms.netmgt.model;
  * @version $Id: $
  */
 public enum TroubleTicketState {
-    OPEN,
-    CREATE_PENDING,
-    CREATE_FAILED,
-    UPDATE_PENDING,
-    UPDATE_FAILED,
-    CLOSED,
-    CLOSE_PENDING,
-    CLOSE_FAILED,
-    RESOLVED,
-    RESOLVE_PENDING,
-    RESOLVE_FAILED,
-    CANCELLED,
-    CANCEL_PENDING,
-    CANCEL_FAILED
+    OPEN(0),
+    CREATE_PENDING(1),
+    CREATE_FAILED(2),
+    UPDATE_PENDING(3),
+    UPDATE_FAILED(4),
+    CLOSED(5),
+    CLOSE_PENDING(6),
+    CLOSE_FAILED(7),
+    RESOLVED(8),
+    RESOLVE_PENDING(9),
+    RESOLVE_FAILED(10),
+    CANCELLED(11),
+    CANCEL_PENDING(12),
+    CANCEL_FAILED(13);
+
+    private final int m_value;
+
+    TroubleTicketState(int value) {
+        m_value = value;
+    }
+    
+    public int getValue() {
+        return this.m_value;
+    }
 }


### PR DESCRIPTION
NMS-4648:Fix default alarm vacuum queries

Some background: OnmsAlarm uses the TroubleTicketState enum as a data type. JPA by default uses Enum.toOrdinal() to store enums, which makes values dependent on order in the enum. At some point circa 2011 there was a change made to this and the default alarm vacuum queries have been broken for sixish years (whoops). Anyway, there are alternative to hava JPA store things: you can use strings for instance, but that would break existing installs. If JPA >= 2.1 were used we could write an javax.persistence.AttributeConverter<TroubleTicketState, Integer> that would return the integer value I added to the enum in this PR. Left a note in some comments about order being important and the future TODO. 

Certainly could also just change the return of getTroubleTicketState in OnmsAlarm to Integer and return m_troubleTicketState().getValue(), but not sure if there's value in a change that large as it smells like something that would impact things that might not have adequate test coverage. 

* JIRA: http://issues.opennms.org/browse/NMS-4648

