### PR TITLE
NMS-4648: fix incorrect trouble ticket state in vacuumd

### DIFF
--- a/opennms-base-assembly/src/main/filtered/etc/vacuumd-configuration.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/vacuumd-configuration.xml
@@ -108,13 +108,13 @@
   </automations>
   
   <triggers>
-    <!-- Find Alarms that have a closed ticket state that haven't been cleared, yet -->
+    <!-- Find Alarms that have a closed ticket state that haven't been cleared, yet. State 5 is closed. -->
     <trigger name="selectClosedTicketStateForProblemAlarms" operator="&gt;=" row-count="1" >
       <statement>
           SELECT a.alarmid AS _alarmid, a.eventuei AS _eventUei, e.eventseverity AS _sev, now() AS _ts
                  now() AS _ts
             FROM alarms a
-           WHERE a.tticketstate = 3
+           WHERE a.tticketstate = 5
              AND a.severity &gt; 2
              AND ( a.alarmType = 1 OR a.alarmType = 3 )
       </statement>
@@ -350,13 +350,13 @@
     </action>
     -->
     
-    <!--  ticket state of 3 is closed -->
+    <!--  ticket state of 5 is closed, 11 is canceled -->
     <action name="deletePastClearedAlarms" >
       <statement>
         DELETE FROM alarms
          WHERE severity &lt;= 3
            AND COALESCE(lastautomationtime, lasteventtime) &lt; now() - interval '5 minutes'
-           AND (alarmacktime IS NULL AND (tticketState IS NULL OR tticketState = 3))
+           AND (alarmacktime IS NULL AND (tticketState IS NULL OR tticketState = 5  OR tticketState = 11))
       </statement>
     </action>
 
@@ -367,7 +367,7 @@
         DELETE from alarms
          WHERE severity &lt;= 3
            AND COALESCE(lastautomationtime, lasteventtime) &lt; now() - interval '24 hours'
-           AND (tticketState IS NULL OR tticketState = 3)
+           AND (tticketState IS NULL OR tticketState = 5 OR tticketState = 11)
       </statement>
     </action>
   

--- a/opennms-model/src/main/java/org/opennms/netmgt/model/TroubleTicketState.java
+++ b/opennms-model/src/main/java/org/opennms/netmgt/model/TroubleTicketState.java
@@ -33,11 +33,20 @@ package org.opennms.netmgt.model;
  *
  * @author <a href="mailto:brozow@opennms.org">Mathew Brozowski</a>
  * @author <a href="mailto:david@opennms.org">David Hustace</a>
- * @author <a href="mailto:brozow@opennms.org">Mathew Brozowski</a>
- * @author <a href="mailto:david@opennms.org">David Hustace</a>
+ * @author <a href="mailto:dschlenk@convergeone.com">David Schlenk</a>
  * @version $Id: $
  */
 public enum TroubleTicketState {
+    /* KEEP THESE IN ORDER or the DEFAULT ALARM VACUUM QUERIES will BREAK */
+    
+    /* TODO: once JPA 2.1+ in use, change things that use this to also use a
+     * javax.persistence.AttributeConverter<TroubleTicketState, Integer> that
+     * returns TroubleTicketState.getValue() in the converter. That should
+     * maintain backwords compatibility to the current default 
+     * Enum.toOrdinal() JPA behavior and prevent breaking when reordering items
+     * in the Enum. 
+     */
+    
     OPEN(0),
     CREATE_PENDING(1),
     CREATE_FAILED(2),
@@ -62,4 +71,6 @@ public enum TroubleTicketState {
     public int getValue() {
         return this.m_value;
     }
+    
+    
 }

--- a/opennms-model/src/main/java/org/opennms/netmgt/model/TroubleTicketState.java
+++ b/opennms-model/src/main/java/org/opennms/netmgt/model/TroubleTicketState.java
@@ -71,6 +71,5 @@ public enum TroubleTicketState {
     public int getValue() {
         return this.m_value;
     }
-    
-    
+
 }

--- a/opennms-model/src/main/java/org/opennms/netmgt/model/TroubleTicketState.java
+++ b/opennms-model/src/main/java/org/opennms/netmgt/model/TroubleTicketState.java
@@ -38,18 +38,28 @@ package org.opennms.netmgt.model;
  * @version $Id: $
  */
 public enum TroubleTicketState {
-    OPEN,
-    CREATE_PENDING,
-    CREATE_FAILED,
-    UPDATE_PENDING,
-    UPDATE_FAILED,
-    CLOSED,
-    CLOSE_PENDING,
-    CLOSE_FAILED,
-    RESOLVED,
-    RESOLVE_PENDING,
-    RESOLVE_FAILED,
-    CANCELLED,
-    CANCEL_PENDING,
-    CANCEL_FAILED
+    OPEN(0),
+    CREATE_PENDING(1),
+    CREATE_FAILED(2),
+    UPDATE_PENDING(3),
+    UPDATE_FAILED(4),
+    CLOSED(5),
+    CLOSE_PENDING(6),
+    CLOSE_FAILED(7),
+    RESOLVED(8),
+    RESOLVE_PENDING(9),
+    RESOLVE_FAILED(10),
+    CANCELLED(11),
+    CANCEL_PENDING(12),
+    CANCEL_FAILED(13);
+
+    private final int m_value;
+
+    TroubleTicketState(int value) {
+        m_value = value;
+    }
+    
+    public int getValue() {
+        return this.m_value;
+    }
 }


### PR DESCRIPTION
This PR fixes the incorrect tt state in vacuumd, and also changes the state object to have explicit numbers associated with them to be sure that they don't change.

* JIRA: http://issues.opennms.org/browse/NMS-4648

Our [continuous integration system](http://bamboo.internal.opennms.com:8085) will test and verify your changes.
