### PR TITLE
NMS-9319: Upgrade from camel-netty to camel-netty4

### DIFF
--- a/container/features/src/main/resources/features.xml
+++ b/container/features/src/main/resources/features.xml
@@ -824,7 +824,7 @@
       <feature>activemq-camel</feature>
       <feature>camel-core</feature>
       <feature>camel-http</feature>
-      <feature>camel-netty</feature>
+      <feature>camel-netty4</feature>
       <feature version="${guavaVersion}">guava</feature>
 
       <feature>dropwizard-metrics</feature>
@@ -859,7 +859,6 @@
       <feature version="[4.1,4.2)">spring</feature>
       <feature>camel-core</feature>
       <feature>camel-http</feature>
-      <feature>camel-netty</feature>
       <feature version="${guavaVersion}">guava</feature>
 
       <feature>opennms-core</feature>

--- a/dependencies/camel/pom.xml
+++ b/dependencies/camel/pom.xml
@@ -47,7 +47,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.camel</groupId>
-      <artifactId>camel-netty</artifactId>
+      <artifactId>camel-netty4</artifactId>
       <version>${camelVersion}</version>
       <exclusions>
         <exclusion>

--- a/features/alarm-change-notifier/feature/pom.xml
+++ b/features/alarm-change-notifier/feature/pom.xml
@@ -57,32 +57,32 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-common</artifactId>
-      <version>${nettyVersion}</version>
+      <version>${netty4Version}</version>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-transport</artifactId>
-      <version>${nettyVersion}</version>
+      <version>${netty4Version}</version>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-buffer</artifactId>
-      <version>${nettyVersion}</version>
+      <version>${netty4Version}</version>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-handler</artifactId>
-      <version>${nettyVersion}</version>
+      <version>${netty4Version}</version>
     </dependency>
     <!-- <dependency> -->
     <!-- <groupId>io.netty</groupId> -->
     <!-- <artifactId>netty-resolver</artifactId> -->
-    <!-- <version>${nettyVersion}</version> -->
+    <!-- <version>${netty4Version}</version> -->
     <!-- </dependency> -->
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-codec</artifactId>
-      <version>${nettyVersion}</version>
+      <version>${netty4Version}</version>
     </dependency>
 
     <dependency>

--- a/features/alarm-change-notifier/main-module/pom.xml
+++ b/features/alarm-change-notifier/main-module/pom.xml
@@ -93,37 +93,37 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-common</artifactId>
-      <version>${nettyVersion}</version>
+      <version>${netty4Version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-transport</artifactId>
-      <version>${nettyVersion}</version>
+      <version>${netty4Version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-buffer</artifactId>
-      <version>${nettyVersion}</version>
+      <version>${netty4Version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-handler</artifactId>
-      <version>${nettyVersion}</version>
+      <version>${netty4Version}</version>
       <scope>provided</scope>
     </dependency>
     <!-- <dependency> -->
     <!-- <groupId>io.netty</groupId> -->
     <!-- <artifactId>netty-resolver</artifactId> -->
-    <!-- <version>${nettyVersion}</version> -->
+    <!-- <version>${netty4Version}</version> -->
     <!-- <scope>provided</scope> -->
     <!-- </dependency> -->
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-codec</artifactId>
-      <version>${nettyVersion}</version>
+      <version>${netty4Version}</version>
       <scope>provided</scope>
     </dependency>
 

--- a/features/alarm-change-notifier/pg-jdbc-utils/pom.xml
+++ b/features/alarm-change-notifier/pg-jdbc-utils/pom.xml
@@ -118,37 +118,37 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-common</artifactId>
-      <version>${nettyVersion}</version>
+      <version>${netty4Version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-transport</artifactId>
-      <version>${nettyVersion}</version>
+      <version>${netty4Version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-buffer</artifactId>
-      <version>${nettyVersion}</version>
+      <version>${netty4Version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-handler</artifactId>
-      <version>${nettyVersion}</version>
+      <version>${netty4Version}</version>
       <scope>provided</scope>
     </dependency>
     <!-- <dependency> -->
     <!-- <groupId>io.netty</groupId> -->
     <!-- <artifactId>netty-resolver</artifactId> -->
-    <!-- <version>${nettyVersion}</version> -->
+    <!-- <version>${netty4Version}</version> -->
     <!-- <scope>provided</scope> -->
     <!-- </dependency> -->
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-codec</artifactId>
-      <version>${nettyVersion}</version>
+      <version>${netty4Version}</version>
       <scope>provided</scope>
     </dependency>
 

--- a/features/alarm-change-notifier/pom.xml
+++ b/features/alarm-change-notifier/pom.xml
@@ -35,9 +35,6 @@
     <!-- <pgjdbc-ng-version>0.6.osgi</pgjdbc-ng-version> -->
     <pgjdbc-ng-version>0.6.osgi-wrap</pgjdbc-ng-version>
 
-    <!-- <nettyVersion>4.1.1.Final</nettyVersion> -->
-    <nettyVersion>4.0.32.Final</nettyVersion>
-
     <json-simpleVersion>1.1.1</json-simpleVersion>
   </properties>
 

--- a/features/events/syslog/src/test/java/org/opennms/netmgt/syslogd/SyslogdEventdLoadIT.java
+++ b/features/events/syslog/src/test/java/org/opennms/netmgt/syslogd/SyslogdEventdLoadIT.java
@@ -90,7 +90,7 @@ import com.codahale.metrics.MetricRegistry;
         "classpath:/META-INF/opennms/applicationContext-eventUtil.xml",
         "classpath:/META-INF/opennms/mockMessageDispatcherFactory.xml"
 })
-@JUnitConfigurationEnvironment
+@JUnitConfigurationEnvironment(systemProperties = { "io.netty.leakDetectionLevel=PARANOID" })
 @JUnitTemporaryDatabase
 public class SyslogdEventdLoadIT implements InitializingBean {
     private static final Logger LOG = LoggerFactory.getLogger(SyslogdEventdLoadIT.class);

--- a/features/events/syslog/src/test/java/org/opennms/netmgt/syslogd/SyslogdLoadIT.java
+++ b/features/events/syslog/src/test/java/org/opennms/netmgt/syslogd/SyslogdLoadIT.java
@@ -93,7 +93,7 @@ import com.codahale.metrics.MetricRegistry;
         "classpath:/META-INF/opennms/mockMessageDispatcherFactory.xml",
         "classpath:/syslogdTest.xml"
 })
-@JUnitConfigurationEnvironment
+@JUnitConfigurationEnvironment(systemProperties = { "io.netty.leakDetectionLevel=PARANOID" })
 @JUnitTemporaryDatabase
 public class SyslogdLoadIT implements InitializingBean {
 
@@ -146,6 +146,7 @@ public class SyslogdLoadIT implements InitializingBean {
 
     @After
     public void tearDown() throws Exception {
+        MockLogAppender.assertNoErrorOrGreater();
         if (m_syslogd != null) {
             m_syslogd.stop();
         }

--- a/features/events/syslog/src/test/java/org/opennms/netmgt/syslogd/SyslogdLoadIT.java
+++ b/features/events/syslog/src/test/java/org/opennms/netmgt/syslogd/SyslogdLoadIT.java
@@ -28,6 +28,7 @@
 
 package org.opennms.netmgt.syslogd;
 
+import static com.jayway.awaitility.Awaitility.await;
 import static org.junit.Assert.assertEquals;
 import static org.opennms.core.utils.InetAddressUtils.addr;
 
@@ -40,6 +41,8 @@ import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.commons.io.IOUtils;
@@ -238,6 +241,13 @@ public class SyslogdLoadIT implements InitializingBean {
     @Transactional
     public void testSyslogReceiverCamelNetty() throws Exception {
         startSyslogdCamelNetty();
+        // Wait for the Camel context to start
+        await().atMost(10, TimeUnit.SECONDS).pollInterval(200, TimeUnit.MILLISECONDS).until(new Callable<Boolean>() {
+            @Override
+            public Boolean call() throws Exception {
+                return ((SyslogReceiverCamelNettyImpl)m_syslogd.getSyslogReceiver()).isStarted();
+            }
+        });
         doTestSyslogReceiver();
     }
 

--- a/features/events/traps/pom.xml
+++ b/features/events/traps/pom.xml
@@ -39,18 +39,6 @@
       <artifactId>camel-dependencies</artifactId>
       <type>pom</type>
     </dependency>
-    <!-- TODO: Is this necessary now that we're using RestClient? -->
-    <dependency>
-      <groupId>org.apache.camel</groupId>
-      <artifactId>camel-netty-http</artifactId>
-      <version>${camelVersion}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>com.sun.xml.bind</groupId>
-          <artifactId>jaxb-impl</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
     <dependency>
       <groupId>org.opennms.core</groupId>
       <artifactId>org.opennms.core.camel</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -1316,6 +1316,7 @@
     <log4j2Version>2.8.2</log4j2Version>
     <minaVersion>2.0.13</minaVersion>
     <minionKarafVersion>4.0.5</minionKarafVersion>
+    <netty4Version>4.0.34.Final</netty4Version>
     <newtsVersion>1.4.3</newtsVersion>
     <paxExamVersion>4.8.0</paxExamVersion>
     <paxSwissboxVersion>1.8.2</paxSwissboxVersion>
@@ -3718,6 +3719,36 @@
         <groupId>mx4j</groupId>
         <artifactId>mx4j-tools</artifactId>
         <version>3.0.1</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-all</artifactId>
+        <version>${netty4Version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-codec</artifactId>
+        <version>${netty4Version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-transport</artifactId>
+        <version>${netty4Version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-handler</artifactId>
+        <version>${netty4Version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-buffer</artifactId>
+        <version>${netty4Version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-common</artifactId>
+        <version>${netty4Version}</version>
       </dependency>
       <dependency>
         <groupId>com.novell.ldap</groupId>


### PR DESCRIPTION
This will upgrade us from the deprecated ```camel-netty``` component to the newer ```camel-netty4``` component. I also updated ```SyslogReceiverCamelNettyImpl``` to support the Camel async API.

* JIRA: http://issues.opennms.org/browse/NMS-9319