### PR TITLE
NMS-7904: Allow root arrays in json datacollection

### DIFF
--- a/protocols/xml/src/main/java/org/opennms/protocols/json/collector/AbstractJsonCollectionHandler.java
+++ b/protocols/xml/src/main/java/org/opennms/protocols/json/collector/AbstractJsonCollectionHandler.java
@@ -38,8 +38,12 @@ import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
 
+import net.sf.json.JSON;
+import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
 
+import net.sf.json.JSONSerializer;
+import net.sf.json.util.JSONUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.jxpath.JXPathContext;
 import org.apache.commons.jxpath.Pointer;
@@ -190,12 +194,23 @@ public abstract class AbstractJsonCollectionHandler extends AbstractXmlCollectio
             is = c.getInputStream();
             StringWriter writer = new StringWriter();
             IOUtils.copy(is, writer);
-            final JSONObject jsonObject = JSONObject.fromObject(writer.toString());
-            return jsonObject;
+
+            return wrapArray(JSONSerializer.toJSON(writer.toString()));
+
         } finally {
             IOUtils.closeQuietly(is);
             UrlFactory.disconnect(c);
         }
     }
 
+    protected static JSONObject wrapArray(final JSON json) {
+        if (json.isArray()) {
+            final JSONObject wrapper = new JSONObject();
+            wrapper.put("elements", json);
+            return wrapper;
+
+        } else {
+            return (JSONObject) json;
+        }
+    }
 }

--- a/protocols/xml/src/main/java/org/opennms/protocols/json/collector/DefaultJsonCollectionHandler.java
+++ b/protocols/xml/src/main/java/org/opennms/protocols/json/collector/DefaultJsonCollectionHandler.java
@@ -28,6 +28,7 @@
 
 package org.opennms.protocols.json.collector;
 
+import net.sf.json.JSON;
 import net.sf.json.JSONObject;
 
 import org.opennms.netmgt.collection.api.AttributeGroupType;

--- a/protocols/xml/src/test/java/org/opennms/protocols/json/collector/JsonCollectorArrayIT.java
+++ b/protocols/xml/src/test/java/org/opennms/protocols/json/collector/JsonCollectorArrayIT.java
@@ -1,0 +1,86 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2011-2017 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.protocols.json.collector;
+
+import net.sf.json.JSON;
+import net.sf.json.JSONObject;
+import org.apache.commons.jxpath.JXPathContext;
+import org.apache.commons.jxpath.Pointer;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+public class JsonCollectorArrayIT extends JsonCollectorITCase {
+
+    @Override
+    public String getConfigFileName() {
+        return "src/test/resources/json-array-datacollection-config.xml";
+    }
+
+    @Override
+    public String getSampleFileName() {
+        return "src/test/resources/array.json";
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testXpath() throws Exception {
+        JSONObject json = MockDocumentBuilder.getJSONDocument();
+        JXPathContext context = JXPathContext.newContext(json);
+
+        Iterator<Pointer> itr = context.iteratePointers("/elements[4]/it");
+
+        Assert.assertTrue(itr.hasNext());
+        Assert.assertEquals(itr.next().getValue(), "works");
+
+        Assert.assertFalse(itr.hasNext());
+    }
+
+    @Test
+    public void testJsonCollector() throws Exception {
+        Map<String, Object> parameters = new HashMap();
+        parameters.put("collection", "json-array");
+        parameters.put("handler-class", "org.opennms.protocols.json.collector.MockDefaultJsonCollectionHandler");
+
+        executeCollectorTest(parameters, 4);
+        Assert.assertTrue(new File(getSnmpRootDirectory(), "1/jsonArrayStats/foo/json-array-stats.jrb").exists());
+        Assert.assertTrue(new File(getSnmpRootDirectory(), "1/jsonArrayStats/bar/json-array-stats.jrb").exists());
+        Assert.assertTrue(new File(getSnmpRootDirectory(), "1/jsonArrayStats/baz/json-array-stats.jrb").exists());
+        Assert.assertTrue(new File(getSnmpRootDirectory(), "1/jsonArrayStats/works/json-array-stats.jrb").exists());
+
+        validateJrb(new File(getSnmpRootDirectory(), "1/jsonArrayStats/foo/json-array-stats.jrb"), new String[] {"val"}, new Double[] {0.0});
+        validateJrb(new File(getSnmpRootDirectory(), "1/jsonArrayStats/bar/json-array-stats.jrb"), new String[] {"val"}, new Double[] {1.0});
+        validateJrb(new File(getSnmpRootDirectory(), "1/jsonArrayStats/baz/json-array-stats.jrb"), new String[] {"val"}, new Double[] {2.0});
+        validateJrb(new File(getSnmpRootDirectory(), "1/jsonArrayStats/works/json-array-stats.jrb"), new String[] {"val"}, new Double[] {1337.0});
+    }
+}

--- a/protocols/xml/src/test/java/org/opennms/protocols/json/collector/MockDocumentBuilder.java
+++ b/protocols/xml/src/test/java/org/opennms/protocols/json/collector/MockDocumentBuilder.java
@@ -32,6 +32,7 @@ import java.io.FileInputStream;
 
 import net.sf.json.JSONObject;
 
+import net.sf.json.JSONSerializer;
 import org.apache.commons.io.IOUtils;
 
 /**
@@ -64,7 +65,7 @@ public class MockDocumentBuilder {
         try {
             inputStream = new FileInputStream(m_jsonFileName);
             String everything = IOUtils.toString(inputStream);
-            json = JSONObject.fromObject(everything);
+            json = AbstractJsonCollectionHandler.wrapArray(JSONSerializer.toJSON(everything));
         } catch (Exception e) {
         } finally {
             if (inputStream != null)
@@ -74,11 +75,6 @@ public class MockDocumentBuilder {
         return json;
     }
 
-    /**
-     * Sets the XML file name.
-     *
-     * @param xmlFileName the new XML file name
-     */
     public static void setJSONFileName(String jsonFileName) {
         m_jsonFileName = jsonFileName;
     }

--- a/protocols/xml/src/test/resources/array.json
+++ b/protocols/xml/src/test/resources/array.json
@@ -1,0 +1,6 @@
+[
+  {"it": "foo", "val": 0},
+  {"it": "bar", "val": 1},
+  {"it": "baz", "val": 2},
+  {"it": "works", "val": 1337}
+]

--- a/protocols/xml/src/test/resources/json-array-datacollection-config.xml
+++ b/protocols/xml/src/test/resources/json-array-datacollection-config.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<xml-datacollection-config rrdRepository="target/snmp/" xmlns="http://xmlns.opennms.org/xsd/config/xml-datacollection">
+    <xml-collection name="json-array">
+        <rrd step="900">
+            <rra>RRA:AVERAGE:0.5:1:8928</rra>
+            <rra>RRA:AVERAGE:0.5:12:8784</rra>
+            <rra>RRA:MIN:0.5:12:8784</rra>
+            <rra>RRA:MAX:0.5:12:8784</rra>
+        </rrd>
+        <xml-source url="http://{ipaddr}:10342/junit/array.json">
+            <xml-group name="json-array-stats" resource-type="jsonArrayStats"
+                resource-xpath="/elements"
+                key-xpath="@it">
+                <xml-object name="val" type="COUNTER" xpath="val" />
+            </xml-group>
+        </xml-source>
+    </xml-collection>
+ </xml-datacollection-config>


### PR DESCRIPTION
If a json datacollection returns an arrays as to level element, it is
warpped in an object exposing the array using an 'elements' property.
This allows to query such data using the existing xpath queries.

* JIRA: http://issues.opennms.org/browse/NMS-7904
