### PR TITLE
NMS-9330: Update a lot of minor dependencies

### DIFF
--- a/container/features/src/main/resources/features.xml
+++ b/container/features/src/main/resources/features.xml
@@ -96,26 +96,26 @@
       <bundle>wrap:mvn:com.atomikos/transactions-jdbc/${atomikosVersion}</bundle>
     </feature>
 
-    <feature name="batik" description="Apache :: XML Graphics :: Batik" version="1.7">
+    <feature name="batik" description="Apache :: XML Graphics :: Batik" version="${batikVersion}">
       <bundle>wrap:mvn:xalan/xalan/2.7.2</bundle>
       <bundle>wrap:mvn:xalan/serializer/2.7.2</bundle>
       <bundle>wrap:mvn:xml-apis/xml-apis/1.4.01</bundle>
       <bundle>wrap:mvn:xml-apis/xml-apis-ext/1.3.04</bundle>
 
-      <bundle>wrap:mvn:org.apache.xmlgraphics/batik-anim/1.7</bundle>
-      <bundle>wrap:mvn:org.apache.xmlgraphics/batik-awt-util/1.7</bundle>
-      <bundle>wrap:mvn:org.apache.xmlgraphics/batik-bridge/1.7</bundle>
-      <bundle>wrap:mvn:org.apache.xmlgraphics/batik-css/1.7</bundle>
-      <bundle>wrap:mvn:org.apache.xmlgraphics/batik-dom/1.7</bundle>
-      <bundle>wrap:mvn:org.apache.xmlgraphics/batik-ext/1.7</bundle>
-      <bundle>wrap:mvn:org.apache.xmlgraphics/batik-gvt/1.7</bundle>
-      <bundle>wrap:mvn:org.apache.xmlgraphics/batik-parser/1.7</bundle>
-      <bundle>wrap:mvn:org.apache.xmlgraphics/batik-script/1.7</bundle>
-      <bundle>wrap:mvn:org.apache.xmlgraphics/batik-svggen/1.7</bundle>
-      <bundle>wrap:mvn:org.apache.xmlgraphics/batik-svg-dom/1.7</bundle>
-      <bundle>wrap:mvn:org.apache.xmlgraphics/batik-transcoder/1.7</bundle>
-      <bundle>wrap:mvn:org.apache.xmlgraphics/batik-util/1.7</bundle>
-      <bundle>wrap:mvn:org.apache.xmlgraphics/batik-xml/1.7</bundle>
+      <bundle>wrap:mvn:org.apache.xmlgraphics/batik-anim/${batikVersion}</bundle>
+      <bundle>wrap:mvn:org.apache.xmlgraphics/batik-awt-util/${batikVersion}</bundle>
+      <bundle>wrap:mvn:org.apache.xmlgraphics/batik-bridge/${batikVersion}</bundle>
+      <bundle>wrap:mvn:org.apache.xmlgraphics/batik-css/${batikVersion}</bundle>
+      <bundle>wrap:mvn:org.apache.xmlgraphics/batik-dom/${batikVersion}</bundle>
+      <bundle>wrap:mvn:org.apache.xmlgraphics/batik-ext/${batikVersion}</bundle>
+      <bundle>wrap:mvn:org.apache.xmlgraphics/batik-gvt/${batikVersion}</bundle>
+      <bundle>wrap:mvn:org.apache.xmlgraphics/batik-parser/${batikVersion}</bundle>
+      <bundle>wrap:mvn:org.apache.xmlgraphics/batik-script/${batikVersion}</bundle>
+      <bundle>wrap:mvn:org.apache.xmlgraphics/batik-svggen/${batikVersion}</bundle>
+      <bundle>wrap:mvn:org.apache.xmlgraphics/batik-svg-dom/${batikVersion}</bundle>
+      <bundle>wrap:mvn:org.apache.xmlgraphics/batik-transcoder/${batikVersion}</bundle>
+      <bundle>wrap:mvn:org.apache.xmlgraphics/batik-util/${batikVersion}</bundle>
+      <bundle>wrap:mvn:org.apache.xmlgraphics/batik-xml/${batikVersion}</bundle>
     </feature>
 
     <feature name="bsf" description="Apache :: Bean Scripting Framework" version="${bsfVersion}">
@@ -201,8 +201,8 @@
       <bundle>mvn:commons-lang/commons-lang/${commonsLangVersion}</bundle>
     </feature>
 
-    <feature name="commons-net" description="Apache :: commons-net" version="3.3">
-      <bundle>mvn:commons-net/commons-net/3.3</bundle>
+    <feature name="commons-net" description="Apache :: commons-net" version="3.6">
+      <bundle>mvn:commons-net/commons-net/3.6</bundle>
     </feature>
 
     <feature name="dnsjava" description="dnsjava" version="${dnsjavaVersion}">
@@ -213,8 +213,8 @@
       <bundle>mvn:io.dropwizard.metrics/metrics-core/3.1.2</bundle>
     </feature>
 
-    <feature name="fop" description="Apache :: XML Graphics :: FOP" version="1.0">
-      <bundle>wrap:mvn:org.apache.xmlgraphics/fop/1.0</bundle>
+    <feature name="fop" description="Apache :: XML Graphics :: FOP" version="${fopVersion}">
+      <bundle>wrap:mvn:org.apache.xmlgraphics/fop/${fopVersion}</bundle>
     </feature>
 
     <feature name="guava" description="Google :: Guava" version="${guavaVersion}">

--- a/features/reporting/availability/pom.xml
+++ b/features/reporting/availability/pom.xml
@@ -156,7 +156,7 @@
     <dependency>
       <groupId>org.apache.xmlgraphics</groupId>
       <artifactId>fop</artifactId>
-      <version>1.0</version>
+      <version>${fopVersion}</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>

--- a/opennms-base-assembly/pom.xml
+++ b/opennms-base-assembly/pom.xml
@@ -570,7 +570,7 @@
       <version>20100506</version>
     </dependency>
     <dependency>
-      <groupId>ognl</groupId>
+      <groupId>opensymphony</groupId>
       <artifactId>ognl</artifactId>
     </dependency>
     <dependency>

--- a/opennms-config-model/pom.xml
+++ b/opennms-config-model/pom.xml
@@ -92,7 +92,6 @@
               org.opennms.netmgt.config.viewsdisplay.*;version="${project.version}",
               org.opennms.netmgt.config.webuiColors.*;version="${project.version}",
               org.opennms.netmgt.config.wmi.*;version="${project.version}",
-              org.opennms.netmgt.config.xmlrpcd.*;version="${project.version}",
               org.opennms.netmgt.eventd.datablock.*;version="${project.version}",
               org.opennms.netmgt.xml.eventconf.*;version="${project.version}",
               org.opennms.netmgt.xml.rtc.*;version="${project.version}"

--- a/opennms-tools/csv-address/pom.xml
+++ b/opennms-tools/csv-address/pom.xml
@@ -59,7 +59,7 @@
       <artifactId>junit</artifactId>
     </dependency>
     <dependency>
-    	<groupId>net.sf.opencsv</groupId>
+    	<groupId>com.opencsv</groupId>
     	<artifactId>opencsv</artifactId>
     </dependency>
   </dependencies>

--- a/opennms-tools/csv-address/src/main/java/org/opennms/model/utils/AssetsUpdater.java
+++ b/opennms-tools/csv-address/src/main/java/org/opennms/model/utils/AssetsUpdater.java
@@ -49,7 +49,7 @@ import java.util.regex.Pattern;
 
 import org.apache.commons.lang.StringUtils;
 
-import au.com.bytecode.opencsv.CSVReader;
+import com.opencsv.CSVReader;
 
 /**
  * @deprecated Replace this class with a Hibernate implementation instead of using JDBC.

--- a/opennms-webapp/pom.xml
+++ b/opennms-webapp/pom.xml
@@ -725,11 +725,11 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>net.sf.opencsv</groupId>
+      <groupId>com.opencsv</groupId>
       <artifactId>opencsv</artifactId>
     </dependency>
     <dependency>
-      <groupId>ognl</groupId>
+      <groupId>opensymphony</groupId>
       <artifactId>ognl</artifactId>
       <scope>${onmsLibScope}</scope>
     </dependency>
@@ -793,11 +793,21 @@
     <!-- these should all be <scope>compile</scope> -->
 
     <dependency>
-      <groupId>poi</groupId>
+      <groupId>org.apache.poi</groupId>
       <artifactId>poi</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
-      <groupId>rome</groupId>
+      <groupId>com.rometools</groupId>
       <artifactId>rome</artifactId>
       <exclusions>
         <exclusion>

--- a/opennms-webapp/src/main/java/org/opennms/web/asset/ExportAssetsServlet.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/asset/ExportAssetsServlet.java
@@ -39,7 +39,7 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.opennms.web.element.NetworkElementFactory;
 
-import au.com.bytecode.opencsv.CSVWriter;
+import com.opencsv.CSVWriter;
 
 /**
  *

--- a/opennms-webapp/src/main/java/org/opennms/web/asset/ImportAssetsServlet.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/asset/ImportAssetsServlet.java
@@ -56,7 +56,7 @@ import org.opennms.web.servlet.MissingParameterException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import au.com.bytecode.opencsv.CSVReader;
+import com.opencsv.CSVReader;
 
 /**
  * <p>ImportAssetsServlet class.</p>

--- a/opennms-webapp/src/main/java/org/opennms/web/rss/AbstractFeed.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/rss/AbstractFeed.java
@@ -36,8 +36,8 @@ import javax.servlet.ServletRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.sun.syndication.feed.synd.SyndFeed;
-import com.sun.syndication.io.SyndFeedOutput;
+import com.rometools.rome.feed.synd.SyndFeed;
+import com.rometools.rome.io.SyndFeedOutput;
 
 /**
  * <p>AbstractFeed class.</p>
@@ -151,7 +151,7 @@ public abstract class AbstractFeed implements Feed {
     /**
      * <p>getFeed</p>
      *
-     * @return a {@link com.sun.syndication.feed.synd.SyndFeed} object.
+     * @return a {@link com.rometools.rome.feed.synd.SyndFeed} object.
      */
     public abstract SyndFeed getFeed();
 

--- a/opennms-webapp/src/main/java/org/opennms/web/rss/AlarmFeed.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/rss/AlarmFeed.java
@@ -45,12 +45,12 @@ import org.opennms.web.alarm.filter.NodeFilter;
 import org.opennms.web.alarm.filter.SeverityFilter;
 import org.opennms.web.filter.Filter;
 
-import com.sun.syndication.feed.synd.SyndContent;
-import com.sun.syndication.feed.synd.SyndContentImpl;
-import com.sun.syndication.feed.synd.SyndEntry;
-import com.sun.syndication.feed.synd.SyndEntryImpl;
-import com.sun.syndication.feed.synd.SyndFeed;
-import com.sun.syndication.feed.synd.SyndFeedImpl;
+import com.rometools.rome.feed.synd.SyndContent;
+import com.rometools.rome.feed.synd.SyndContentImpl;
+import com.rometools.rome.feed.synd.SyndEntry;
+import com.rometools.rome.feed.synd.SyndEntryImpl;
+import com.rometools.rome.feed.synd.SyndFeed;
+import com.rometools.rome.feed.synd.SyndFeedImpl;
 
 /**
  * <p>AlarmFeed class.</p>
@@ -79,7 +79,7 @@ public class AlarmFeed extends AbstractFeed {
     /**
      * <p>getFeed</p>
      *
-     * @return a {@link com.sun.syndication.feed.synd.SyndFeed} object.
+     * @return a {@link com.rometools.rome.feed.synd.SyndFeed} object.
      */
     @Override
     public SyndFeed getFeed() {

--- a/opennms-webapp/src/main/java/org/opennms/web/rss/EventFeed.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/rss/EventFeed.java
@@ -44,12 +44,12 @@ import org.opennms.web.filter.Filter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.sun.syndication.feed.synd.SyndContent;
-import com.sun.syndication.feed.synd.SyndContentImpl;
-import com.sun.syndication.feed.synd.SyndEntry;
-import com.sun.syndication.feed.synd.SyndEntryImpl;
-import com.sun.syndication.feed.synd.SyndFeed;
-import com.sun.syndication.feed.synd.SyndFeedImpl;
+import com.rometools.rome.feed.synd.SyndContent;
+import com.rometools.rome.feed.synd.SyndContentImpl;
+import com.rometools.rome.feed.synd.SyndEntry;
+import com.rometools.rome.feed.synd.SyndEntryImpl;
+import com.rometools.rome.feed.synd.SyndFeed;
+import com.rometools.rome.feed.synd.SyndFeedImpl;
 
 
 /**
@@ -67,7 +67,7 @@ public class EventFeed extends AbstractFeed {
     /**
      * <p>getFeed</p>
      *
-     * @return a {@link com.sun.syndication.feed.synd.SyndFeed} object.
+     * @return a {@link com.rometools.rome.feed.synd.SyndFeed} object.
      */
     @Override
     public SyndFeed getFeed() {

--- a/opennms-webapp/src/main/java/org/opennms/web/rss/NotificationFeed.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/rss/NotificationFeed.java
@@ -37,10 +37,10 @@ import org.opennms.web.notification.NotificationModel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.sun.syndication.feed.synd.SyndEntry;
-import com.sun.syndication.feed.synd.SyndEntryImpl;
-import com.sun.syndication.feed.synd.SyndFeed;
-import com.sun.syndication.feed.synd.SyndFeedImpl;
+import com.rometools.rome.feed.synd.SyndEntry;
+import com.rometools.rome.feed.synd.SyndEntryImpl;
+import com.rometools.rome.feed.synd.SyndFeed;
+import com.rometools.rome.feed.synd.SyndFeedImpl;
 
 /**
  * <p>NotificationFeed class.</p>
@@ -57,7 +57,7 @@ public class NotificationFeed extends AbstractFeed {
     /**
      * <p>getFeed</p>
      *
-     * @return a {@link com.sun.syndication.feed.synd.SyndFeed} object.
+     * @return a {@link com.rometools.rome.feed.synd.SyndFeed} object.
      */
     @Override
     public SyndFeed getFeed() {

--- a/opennms-webapp/src/main/java/org/opennms/web/rss/OutageFeed.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/rss/OutageFeed.java
@@ -38,10 +38,10 @@ import org.opennms.web.outage.OutageModel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.sun.syndication.feed.synd.SyndEntry;
-import com.sun.syndication.feed.synd.SyndEntryImpl;
-import com.sun.syndication.feed.synd.SyndFeed;
-import com.sun.syndication.feed.synd.SyndFeedImpl;
+import com.rometools.rome.feed.synd.SyndEntry;
+import com.rometools.rome.feed.synd.SyndEntryImpl;
+import com.rometools.rome.feed.synd.SyndFeed;
+import com.rometools.rome.feed.synd.SyndFeedImpl;
 
 /**
  * <p>OutageFeed class.</p>
@@ -78,7 +78,7 @@ public class OutageFeed extends AbstractFeed {
     /**
      * <p>getFeed</p>
      *
-     * @return a {@link com.sun.syndication.feed.synd.SyndFeed} object.
+     * @return a {@link com.rometools.rome.feed.synd.SyndFeed} object.
      */
     @Override
     public SyndFeed getFeed() {

--- a/pom.xml
+++ b/pom.xml
@@ -1283,11 +1283,11 @@
     <commonsCsvVersion>1.1</commonsCsvVersion>
     <commonsDigesterVersion>2.1</commonsDigesterVersion>
     <commonsJxpathVersion>1.3</commonsJxpathVersion>
-    <commonsIoVersion>2.4</commonsIoVersion>
+    <commonsIoVersion>2.5</commonsIoVersion>
     <commonsLangVersion>2.6</commonsLangVersion>
     <commonsLoggingVersion>99.99.99-use-jcl-over-slf4j</commonsLoggingVersion>
     <commonsMath3Version>3.5</commonsMath3Version>
-    <commonsValidatorVersion>1.3.1</commonsValidatorVersion>
+    <commonsValidatorVersion>1.6</commonsValidatorVersion>
     <c3p0Version>0.9.5.2</c3p0Version>
     <curatorVersion>3.2.1</curatorVersion>
     <cxfVersion>3.1.11</cxfVersion>
@@ -1295,17 +1295,18 @@
     <dropwizardMetricsVersion>3.1.2</dropwizardMetricsVersion>
     <ecjVersion>4.4.2</ecjVersion>
     <eclipselinkVersion>2.5.1</eclipselinkVersion>
+    <fopVersion>1.0</fopVersion>
     <freemarkerVersion>2.3.21</freemarkerVersion>
-    <groovyVersion>2.4.5</groovyVersion>
+    <groovyVersion>2.4.11</groovyVersion>
     <guavaVersion>18.0</guavaVersion>
     <guavaOldVersion>17.0</guavaOldVersion>
     <gwtVersion>2.6.1</gwtVersion>
     <gwtPluginVersion>2.6.1</gwtPluginVersion>
     <hibernateValidatorVersion>4.3.2.Final</hibernateValidatorVersion>
     <hikaricpVersion>2.5.1</hikaricpVersion>
-    <httpcoreVersion>4.3.3</httpcoreVersion>
-    <httpclientVersion>4.3.6</httpclientVersion>
-    <httpasyncclientVersion>4.0.2</httpasyncclientVersion>
+    <httpcoreVersion>4.4.6</httpcoreVersion>
+    <httpclientVersion>4.5.3</httpclientVersion>
+    <httpasyncclientVersion>4.1.3</httpasyncclientVersion>
     <jacksonVersion>1.9.13</jacksonVersion>
     <jackson2Version>2.6.6</jackson2Version>
     <jasperreportsVersion>6.3.0</jasperreportsVersion>
@@ -1316,16 +1317,16 @@
     <jfreechartVersion>1.0.19</jfreechartVersion>
     <jinteropVersion>2.0.8</jinteropVersion>
     <jldapVersion>4.3</jldapVersion>
-    <jodaTimeVersion>2.1</jodaTimeVersion>
+    <jodaTimeVersion>2.3</jodaTimeVersion>
     <jrubyVersion>9.0.4.0</jrubyVersion>
-    <jsoupVersion>1.7.2</jsoupVersion>
+    <jsoupVersion>1.10.2</jsoupVersion>
     <karafVersion>4.0.8</karafVersion>
     <felixVersion>3.0.0</felixVersion>
     <liquibaseVersion>2.0.5-ONMS20160524b</liquibaseVersion>
     <lmaxDisruptorVersion>3.3.2</lmaxDisruptorVersion>
     <log4jVersion>99.99.99-use-log4j2</log4jVersion>
     <log4j2Version>2.8.2</log4j2Version>
-    <minaVersion>2.0.13</minaVersion>
+    <minaVersion>2.0.16</minaVersion>
     <minionKarafVersion>${karafVersion}</minionKarafVersion>
     <netty4Version>4.0.34.Final</netty4Version>
     <newtsVersion>1.4.3</newtsVersion>
@@ -2905,7 +2906,7 @@
       <dependency>
         <groupId>org.apache.ant</groupId>
         <artifactId>ant</artifactId>
-        <version>1.8.2</version>
+        <version>1.10.1</version>
       </dependency>
       <dependency>
         <groupId>antlr</groupId>
@@ -2992,7 +2993,7 @@
       <dependency>
         <groupId>cglib</groupId>
         <artifactId>cglib-nodep</artifactId>
-        <version>2.2.2</version>
+        <version>3.1</version>
       </dependency>
       <dependency>
         <groupId>com.mchange</groupId>
@@ -3071,7 +3072,7 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-exec</artifactId>
-        <version>1.2</version>
+        <version>1.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.httpcomponents</groupId>
@@ -3139,7 +3140,7 @@
       <dependency>
         <groupId>commons-net</groupId>
         <artifactId>commons-net</artifactId>
-        <version>3.3</version>
+        <version>3.6</version>
       </dependency>
       <dependency>
         <groupId>commons-pool</groupId>
@@ -3171,7 +3172,7 @@
       <dependency>
         <groupId>org.dbunit</groupId>
         <artifactId>dbunit</artifactId>
-        <version>2.4.8</version>
+        <version>2.5.3</version>
         <scope>test</scope>
       </dependency>
       <dependency>
@@ -3212,7 +3213,7 @@
       <dependency>
         <groupId>org.reflections</groupId>
         <artifactId>reflections</artifactId>
-        <version>0.9.10</version>
+        <version>0.9.11</version>
       </dependency>
       <dependency>
         <groupId>com.googlecode.concurrent-locks</groupId>
@@ -3293,14 +3294,14 @@
         <version>${project.version}</version>
       </dependency>
       <dependency>
-        <groupId>ognl</groupId>
+        <groupId>opensymphony</groupId>
         <artifactId>ognl</artifactId>
-        <version>2.6.9</version>
+        <version>2.6.11</version>
       </dependency>
       <dependency>
-        <groupId>net.sf.opencsv</groupId>
+        <groupId>com.opencsv</groupId>
         <artifactId>opencsv</artifactId>
-        <version>2.3</version>
+        <version>3.9</version>
       </dependency>
       <dependency>
         <groupId>net.sf.json-lib</groupId>
@@ -3337,7 +3338,7 @@
       <dependency>
         <groupId>net.sf.ehcache</groupId>
         <artifactId>ehcache</artifactId>
-        <version>1.8.0</version>
+        <version>2.2.0</version>
         <type>pom</type>
       </dependency>
       <dependency>
@@ -3656,7 +3657,7 @@
       <dependency>
         <groupId>com.jcraft</groupId>
         <artifactId>jsch</artifactId>
-        <version>0.1.51</version>
+        <version>0.1.54</version>
       </dependency>
       <dependency>
         <groupId>org.mockito</groupId>
@@ -3722,7 +3723,7 @@
       <dependency>
         <groupId>net.sourceforge.jwebunit</groupId>
         <artifactId>jwebunit-htmlunit-plugin</artifactId>
-        <version>2.5</version>
+        <version>3.3</version>
         <scope>test</scope>
       </dependency>
       <dependency>
@@ -3917,12 +3918,12 @@
       <dependency>
         <groupId>org.tuckey</groupId>
         <artifactId>urlrewritefilter</artifactId>
-        <version>4.0.3</version>
+        <version>4.0.4</version>
       </dependency>
       <dependency>
-        <groupId>poi</groupId>
+        <groupId>org.apache.poi</groupId>
         <artifactId>poi</artifactId>
-        <version>2.5.1-final-20040804</version>
+        <version>3.16</version>
       </dependency>
       <dependency>
         <groupId>org.postgresql</groupId>
@@ -3935,14 +3936,14 @@
         <version>${protobufVersion}</version>
       </dependency>
       <dependency>
-        <groupId>rome</groupId>
+        <groupId>com.rometools</groupId>
         <artifactId>rome</artifactId>
-        <version>1.0</version>
+        <version>1.7.2</version>
       </dependency>
       <dependency>
         <groupId>com.ximpleware</groupId>
         <artifactId>vtd-xml</artifactId>
-        <version>2.11</version>
+        <version>2.13</version>
       </dependency>
       <dependency>
         <groupId>wsdl4j</groupId>
@@ -3971,11 +3972,6 @@
         <version>${xmlApisVersion}</version>
       </dependency>
       <dependency>
-        <groupId>xmlrpc</groupId>
-        <artifactId>xmlrpc</artifactId>
-        <version>2.0.1</version>
-      </dependency>
-      <dependency>
         <groupId>org.krupczak</groupId>
         <artifactId>xmp</artifactId>
         <version>1.40</version>
@@ -3983,7 +3979,7 @@
       <dependency>
         <groupId>xmlunit</groupId>
         <artifactId>xmlunit</artifactId>
-        <version>1.5</version>
+        <version>1.6</version>
         <scope>test</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
There's nothing really risky here except maybe upgrading ecj since it's used by Drools. This fixes two deps that were dep-managed downward (ehcache and cglib-nodep).

* JIRA: http://issues.opennms.org/browse/NMS-9330