### PR TITLE
NMS-9333: Fix 'mvn install clean' builds

### DIFF
--- a/features/remote-poller/pom.xml
+++ b/features/remote-poller/pom.xml
@@ -124,6 +124,16 @@ groovy.compiler.output.path=target/classes
           </execution>
         </executions>
       </plugin>
+      <!--
+        NMS-9333: Skip the clean phase so that the artifact can be resolved by the 
+        plugins in the remote-poller-jnlp project
+      -->
+      <plugin> 
+        <artifactId>maven-clean-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration> 
+      </plugin>
     </plugins>
   </build>
   <dependencies>


### PR DESCRIPTION
This avoids cleaning the ```remote-poller``` project to avoid problems in the ```remote-poller-jnlp``` build when using ```mvn install clean```.

* JIRA: http://issues.opennms.org/browse/NMS-9333