### PR TITLE
NMS-9327: Added warning to ensure the OpenJDK development kit is installed

### DIFF
--- a/opennms-doc/guide-install/src/asciidoc/text/java/introduction.adoc
+++ b/opennms-doc/guide-install/src/asciidoc/text/java/introduction.adoc
@@ -17,3 +17,8 @@ The following tools should be installed to follow this installation manual:
 
 WARNING: By downloading the _Oracle Java SE Development Kit 8_ RPM installer, you will accept the license agreement 
 from _Oracle_ which can be found on the link:https://www.java.com/en/download/faq/distribution.xml[Java distribution] web site.
+
+WARNING: Installing the _Java Runtime Environment (JRE)_ is not sufficient.
+         The development kit is often named _openjdk-devel_ or _openjdk-jdk_.
+         With a _JRE_ installed, _{opennms-product-name}_ will not start and throws a `java.lang.ClassNotFoundException: com.sun.tools.attach.AttachNotSupportedException`.
+         For more details see link:https://issues.opennms.org/browse/NMS-9327[NMS-9327].


### PR DESCRIPTION
Add a hint to ensure users install the development kit.

* JIRA: http://issues.opennms.org/browse/NMS-9327
