### PR TITLE
HZN-705, HZN-1058: Upgrade to Camel 2.16, ActiveMQ 5.13

### DIFF
--- a/core/daemon/pom.xml
+++ b/core/daemon/pom.xml
@@ -136,6 +136,14 @@
           </exclusion>
           <exclusion>
             <groupId>org.springframework</groupId>
+            <artifactId>spring-core</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-expression</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.springframework</groupId>
             <artifactId>spring-jms</artifactId>
           </exclusion>
           <exclusion>

--- a/core/daemon/src/main/resources/META-INF/opennms/applicationContext-daemon.xml
+++ b/core/daemon/src/main/resources/META-INF/opennms/applicationContext-daemon.xml
@@ -29,6 +29,17 @@
   <onmsgi:reference id="eventProxy" interface="org.opennms.netmgt.events.api.EventProxy"/>
   <onmsgi:reference id="eventSubscriptionService" interface="org.opennms.netmgt.events.api.EventSubscriptionService"/>
 
+  <!-- TODO: Remove this bean after we stop using serialized object messages -->
+  <bean id="enableActiveMqObjectMessages" class="org.springframework.beans.factory.config.MethodInvokingFactoryBean">
+     <property name="staticMethod" value="java.lang.System.setProperty"/>
+     <property name="arguments">
+       <list>
+         <value>org.apache.activemq.SERIALIZABLE_PACKAGES</value>
+         <value>*</value>
+       </list>
+     </property>
+  </bean>
+
   <!-- Conditionally start a local ActiveMQ broker. -->
   <bean class="org.opennms.netmgt.daemon.ConditionalActiveMQContext"/>
 
@@ -36,6 +47,8 @@
     <property name="brokerURL" value="#{T(java.lang.System).getProperty('org.opennms.activemq.broker.url', 'vm://localhost?create=false')}" />
     <property name="userName" value="#{T(java.lang.System).getProperty('org.opennms.activemq.broker.username', '')}" />
     <property name="password" value="#{T(java.lang.System).getProperty('org.opennms.activemq.broker.password', '')}" />
+    <!-- TODO: Remove this parameter after we stop using serialized object messages -->
+    <property name="trustAllPackages" value="true"/>
   </bean>
 
   <bean id="pooledConnectionFactory" class="org.opennms.features.activemq.PooledConnectionFactory"

--- a/core/ipc/rpc/camel-impl/pom.xml
+++ b/core/ipc/rpc/camel-impl/pom.xml
@@ -65,6 +65,14 @@
         </exclusion>
         <exclusion>
           <groupId>org.springframework</groupId>
+          <artifactId>spring-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.springframework</groupId>
+          <artifactId>spring-expression</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.springframework</groupId>
           <artifactId>spring-jms</artifactId>
         </exclusion>
         <exclusion>

--- a/core/ipc/rpc/camel-impl/src/main/resources/OSGI-INF/blueprint/blueprint-rpc-server.xml
+++ b/core/ipc/rpc/camel-impl/src/main/resources/OSGI-INF/blueprint/blueprint-rpc-server.xml
@@ -10,7 +10,7 @@
 		http://aries.apache.org/blueprint/xmlns/blueprint-ext/v1.1.0
 		http://aries.apache.org/schemas/blueprint-ext/blueprint-ext-1.1.xsd
 		http://camel.apache.org/schema/blueprint
-		https://camel.apache.org/schema/blueprint/camel-blueprint-2.14.4.xsd
+		http://camel.apache.org/schema/blueprint/camel-blueprint-2.16.5.xsd
 ">
 
     <cm:property-placeholder id="ipcProperties"

--- a/core/ipc/sink/camel-impl/pom.xml
+++ b/core/ipc/sink/camel-impl/pom.xml
@@ -77,6 +77,14 @@
         </exclusion>
         <exclusion>
           <groupId>org.springframework</groupId>
+          <artifactId>spring-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.springframework</groupId>
+          <artifactId>spring-expression</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.springframework</groupId>
           <artifactId>spring-jms</artifactId>
         </exclusion>
         <exclusion>

--- a/core/ipc/sink/camel-impl/src/main/resources/OSGI-INF/blueprint/blueprint-ipc-client.xml
+++ b/core/ipc/sink/camel-impl/src/main/resources/OSGI-INF/blueprint/blueprint-ipc-client.xml
@@ -9,6 +9,8 @@
 		http://aries.apache.org/schemas/blueprint-cm/blueprint-cm-1.1.0.xsd
 		http://aries.apache.org/blueprint/xmlns/blueprint-ext/v1.1.0
 		http://aries.apache.org/schemas/blueprint-ext/blueprint-ext-1.1.xsd
+		http://camel.apache.org/schema/blueprint
+		http://camel.apache.org/schema/blueprint/camel-blueprint-2.16.5.xsd
 ">
 
     <cm:property-placeholder id="ipcProperties"

--- a/core/ipc/sink/kafka-impl/pom.xml
+++ b/core/ipc/sink/kafka-impl/pom.xml
@@ -113,6 +113,14 @@
         </exclusion>
         <exclusion>
           <groupId>org.springframework</groupId>
+          <artifactId>spring-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.springframework</groupId>
+          <artifactId>spring-expression</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.springframework</groupId>
           <artifactId>spring-jms</artifactId>
         </exclusion>
         <exclusion>

--- a/core/test-api/activemq/pom.xml
+++ b/core/test-api/activemq/pom.xml
@@ -60,6 +60,14 @@
         </exclusion>
         <exclusion>
           <groupId>org.springframework</groupId>
+          <artifactId>spring-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.springframework</groupId>
+          <artifactId>spring-expression</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.springframework</groupId>
           <artifactId>spring-jms</artifactId>
         </exclusion>
         <exclusion>

--- a/core/test-api/camel/src/main/resources/blueprint-empty-camel-context.xml
+++ b/core/test-api/camel/src/main/resources/blueprint-empty-camel-context.xml
@@ -11,6 +11,9 @@
 
 		http://aries.apache.org/blueprint/xmlns/blueprint-ext/v1.1.0
 		http://aries.apache.org/schemas/blueprint-ext/blueprint-ext-1.1.xsd
+
+		http://camel.apache.org/schema/blueprint
+		http://camel.apache.org/schema/blueprint/camel-blueprint-2.16.5.xsd
 ">
 
 	<camelContext id="emptyCamelContext" xmlns="http://camel.apache.org/schema/blueprint"/>

--- a/dependencies/activemq/pom.xml
+++ b/dependencies/activemq/pom.xml
@@ -36,6 +36,10 @@
         </exclusion>
         <exclusion>
           <groupId>org.eclipse.jetty.aggregate</groupId>
+          <artifactId>jetty-all</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.eclipse.jetty.aggregate</groupId>
           <artifactId>jetty-all-server</artifactId>
         </exclusion>
         <exclusion>
@@ -74,6 +78,10 @@
         </exclusion>
         <exclusion>
           <groupId>org.springframework</groupId>
+          <artifactId>spring-jms</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.springframework</groupId>
           <artifactId>org.springframework.asm</artifactId>
         </exclusion>
         <exclusion>
@@ -83,6 +91,10 @@
         <exclusion>
           <groupId>org.springframework</groupId>
           <artifactId>org.springframework.expression</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.springframework</groupId>
+          <artifactId>org.springframework.jms</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -151,6 +163,10 @@
         <exclusion>
           <groupId>org.eclipse.jetty</groupId>
           <artifactId>jetty-websocket</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.eclipse.jetty.aggregate</groupId>
+          <artifactId>jetty-all</artifactId>
         </exclusion>
         <exclusion>
           <groupId>org.eclipse.jetty.aggregate</groupId>

--- a/dependencies/camel-test/pom.xml
+++ b/dependencies/camel-test/pom.xml
@@ -13,44 +13,6 @@
   <dependencies>
     <dependency>
       <groupId>org.apache.camel</groupId>
-      <artifactId>camel-blueprint</artifactId>
-      <version>${camelVersion}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>javax.xml.bind</groupId>
-          <artifactId>jaxb-api</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.sun.xml.bind</groupId>
-          <artifactId>jaxb-impl</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>commons-logging</groupId>
-          <artifactId>commons-logging</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.camel</groupId>
-      <artifactId>camel-core-osgi</artifactId>
-      <version>${camelVersion}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>javax.xml.bind</groupId>
-          <artifactId>jaxb-api</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.sun.xml.bind</groupId>
-          <artifactId>jaxb-impl</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>commons-logging</groupId>
-          <artifactId>commons-logging</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.camel</groupId>
       <artifactId>camel-test</artifactId>
       <version>${camelVersion}</version>
       <exclusions>
@@ -71,17 +33,7 @@
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-test-blueprint</artifactId>
-      <!--
-        We're overriding the version here so that the
-        Camel blueprint tests are more reliable.
-
-        https://issues.apache.org/jira/browse/CAMEL-8948
-
-        We also have to add all of the transitive deps
-        of camel-test-blueprint so that ${camelVersion}
-        of those deps is used instead of the 2.15.6 version.
-      -->
-      <version>2.15.6</version>
+      <version>${camelVersion}</version>
       <exclusions>
         <exclusion>
           <groupId>javax.xml.bind</groupId>

--- a/features/activemq/broker/pom.xml
+++ b/features/activemq/broker/pom.xml
@@ -152,6 +152,14 @@
         </exclusion>
         <exclusion>
           <groupId>org.springframework</groupId>
+          <artifactId>spring-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.springframework</groupId>
+          <artifactId>spring-expression</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.springframework</groupId>
           <artifactId>spring-jms</artifactId>
         </exclusion>
         <exclusion>
@@ -185,6 +193,14 @@
         <exclusion>
           <groupId>org.springframework</groupId>
           <artifactId>spring-context</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.springframework</groupId>
+          <artifactId>spring-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.springframework</groupId>
+          <artifactId>spring-expression</artifactId>
         </exclusion>
         <exclusion>
           <groupId>org.springframework</groupId>
@@ -225,6 +241,14 @@
         <exclusion>
           <groupId>org.springframework</groupId>
           <artifactId>spring-context</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.springframework</groupId>
+          <artifactId>spring-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.springframework</groupId>
+          <artifactId>spring-expression</artifactId>
         </exclusion>
         <exclusion>
           <groupId>org.springframework</groupId>

--- a/features/activemq/component/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/features/activemq/component/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -11,6 +11,9 @@
 
         http://aries.apache.org/blueprint/xmlns/blueprint-ext/v1.1.0
         http://aries.apache.org/schemas/blueprint-ext/blueprint-ext-1.1.xsd
+
+        http://camel.apache.org/schema/blueprint
+        http://camel.apache.org/schema/blueprint/camel-blueprint-2.16.5.xsd
 ">
 
 	<ext:property-placeholder placeholder-prefix="$[" placeholder-suffix="]" >

--- a/features/amqp/alarm-northbounder/pom.xml
+++ b/features/amqp/alarm-northbounder/pom.xml
@@ -114,6 +114,10 @@
       <version>${camelVersion}</version>
       <exclusions>
         <exclusion>
+          <groupId>com.sun.xml.bind</groupId>
+          <artifactId>jaxb-impl</artifactId>
+        </exclusion>
+        <exclusion>
           <groupId>org.springframework</groupId>
           <artifactId>spring-aop</artifactId>
         </exclusion>
@@ -124,6 +128,14 @@
         <exclusion>
           <groupId>org.springframework</groupId>
           <artifactId>spring-context</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.springframework</groupId>
+          <artifactId>spring-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.springframework</groupId>
+          <artifactId>spring-expression</artifactId>
         </exclusion>
         <exclusion>
           <groupId>org.springframework</groupId>
@@ -139,6 +151,12 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-amqp</artifactId>
       <version>${camelVersion}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.sun.xml.bind</groupId>
+          <artifactId>jaxb-impl</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.qpid</groupId>

--- a/features/amqp/alarm-northbounder/src/main/resources/OSGI-INF/blueprint/blueprint-alarm-northbounder.xml
+++ b/features/amqp/alarm-northbounder/src/main/resources/OSGI-INF/blueprint/blueprint-alarm-northbounder.xml
@@ -15,7 +15,7 @@
 		http://aries.apache.org/schemas/blueprint-ext/blueprint-ext-1.1.xsd
 
 		http://camel.apache.org/schema/blueprint
-		http://camel.apache.org/schema/blueprint/camel-blueprint-2.12.2.xsd
+		http://camel.apache.org/schema/blueprint/camel-blueprint-2.16.5.xsd
 ">
 
   <!-- Configuration properties -->

--- a/features/amqp/event-forwarder/pom.xml
+++ b/features/amqp/event-forwarder/pom.xml
@@ -122,6 +122,10 @@
       <version>${camelVersion}</version>
       <exclusions>
         <exclusion>
+          <groupId>com.sun.xml.bind</groupId>
+          <artifactId>jaxb-impl</artifactId>
+        </exclusion>
+        <exclusion>
           <groupId>org.springframework</groupId>
           <artifactId>spring-aop</artifactId>
         </exclusion>
@@ -132,6 +136,14 @@
         <exclusion>
           <groupId>org.springframework</groupId>
           <artifactId>spring-context</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.springframework</groupId>
+          <artifactId>spring-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.springframework</groupId>
+          <artifactId>spring-expression</artifactId>
         </exclusion>
         <exclusion>
           <groupId>org.springframework</groupId>
@@ -147,6 +159,12 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-amqp</artifactId>
       <version>${camelVersion}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.sun.xml.bind</groupId>
+          <artifactId>jaxb-impl</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.qpid</groupId>

--- a/features/amqp/event-forwarder/src/main/resources/OSGI-INF/blueprint/blueprint-event-forwarder.xml
+++ b/features/amqp/event-forwarder/src/main/resources/OSGI-INF/blueprint/blueprint-event-forwarder.xml
@@ -15,7 +15,7 @@
 		http://aries.apache.org/schemas/blueprint-ext/blueprint-ext-1.1.xsd
 
 		http://camel.apache.org/schema/blueprint
-		http://camel.apache.org/schema/blueprint/camel-blueprint-2.12.2.xsd
+		http://camel.apache.org/schema/blueprint/camel-blueprint-2.16.5.xsd
 ">
 
   <!-- Configuration properties -->

--- a/features/amqp/event-receiver/pom.xml
+++ b/features/amqp/event-receiver/pom.xml
@@ -121,6 +121,10 @@
       <version>${camelVersion}</version>
       <exclusions>
         <exclusion>
+          <groupId>com.sun.xml.bind</groupId>
+          <artifactId>jaxb-impl</artifactId>
+        </exclusion>
+        <exclusion>
           <groupId>org.springframework</groupId>
           <artifactId>spring-aop</artifactId>
         </exclusion>
@@ -131,6 +135,14 @@
         <exclusion>
           <groupId>org.springframework</groupId>
           <artifactId>spring-context</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.springframework</groupId>
+          <artifactId>spring-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.springframework</groupId>
+          <artifactId>spring-expression</artifactId>
         </exclusion>
         <exclusion>
           <groupId>org.springframework</groupId>
@@ -146,6 +158,12 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-amqp</artifactId>
       <version>${camelVersion}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.sun.xml.bind</groupId>
+          <artifactId>jaxb-impl</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.qpid</groupId>

--- a/features/amqp/event-receiver/src/main/resources/OSGI-INF/blueprint/blueprint-event-receiver.xml
+++ b/features/amqp/event-receiver/src/main/resources/OSGI-INF/blueprint/blueprint-event-receiver.xml
@@ -15,7 +15,7 @@
 		http://aries.apache.org/schemas/blueprint-ext/blueprint-ext-1.1.xsd
 
 		http://camel.apache.org/schema/blueprint
-		http://camel.apache.org/schema/blueprint/camel-blueprint-2.12.2.xsd
+		http://camel.apache.org/schema/blueprint/camel-blueprint-2.16.5.xsd
 ">
 
   <!-- Configuration properties -->

--- a/features/events/traps/pom.xml
+++ b/features/events/traps/pom.xml
@@ -44,6 +44,12 @@
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-netty-http</artifactId>
       <version>${camelVersion}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.sun.xml.bind</groupId>
+          <artifactId>jaxb-impl</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.opennms.core</groupId>
@@ -187,6 +193,14 @@
         <exclusion>
           <groupId>org.springframework</groupId>
           <artifactId>spring-context</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.springframework</groupId>
+          <artifactId>spring-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.springframework</groupId>
+          <artifactId>spring-expression</artifactId>
         </exclusion>
         <exclusion>
           <groupId>org.springframework</groupId>

--- a/features/events/traps/src/main/resources/OSGI-INF/blueprint/blueprint-trapd-listener.xml
+++ b/features/events/traps/src/main/resources/OSGI-INF/blueprint/blueprint-trapd-listener.xml
@@ -9,6 +9,8 @@
         http://aries.apache.org/schemas/blueprint-cm/blueprint-cm-1.1.0.xsd
         http://aries.apache.org/blueprint/xmlns/blueprint-ext/v1.1.0
         http://aries.apache.org/schemas/blueprint-ext/blueprint-ext-1.1.xsd
+        http://camel.apache.org/schema/blueprint
+        http://camel.apache.org/schema/blueprint/camel-blueprint-2.16.5.xsd
 ">
 
 	<cm:property-placeholder id="trapHandlerDefaultProperties" persistent-id="org.opennms.netmgt.trapd" update-strategy="reload">

--- a/features/minion/container/scv/blueprint-scv.xml
+++ b/features/minion/container/scv/blueprint-scv.xml
@@ -3,7 +3,6 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0"
     xmlns:ext="http://aries.apache.org/blueprint/xmlns/blueprint-ext/v1.1.0"
-    xmlns:cb="http://camel.apache.org/schema/blueprint"
     xsi:schemaLocation="
         http://www.osgi.org/xmlns/blueprint/v1.0.0 
         http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd

--- a/features/minion/core/api/pom.xml
+++ b/features/minion/core/api/pom.xml
@@ -29,7 +29,7 @@
     </build>
 
     <dependencies>
-        <!-- This is the version used by activemq-client:jar:5.10.0 -->
+        <!-- This is the version used by activemq-client:jar:5.13.3 -->
         <dependency>
             <groupId>org.apache.geronimo.specs</groupId>
             <artifactId>geronimo-jms_1.1_spec</artifactId>

--- a/features/minion/core/impl/pom.xml
+++ b/features/minion/core/impl/pom.xml
@@ -67,31 +67,27 @@
                 </exclusion>
                 <exclusion>
                     <groupId>org.springframework</groupId>
-                    <artifactId>spring-beans</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.springframework</groupId>
-                    <artifactId>spring-context</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.springframework</groupId>
-                    <artifactId>spring-jms</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.springframework</groupId>
-                    <artifactId>spring-beans</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.springframework</groupId>
-                    <artifactId>spring-context</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.springframework</groupId>
-                    <artifactId>spring-jms</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.springframework</groupId>
                     <artifactId>spring-aop</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.springframework</groupId>
+                    <artifactId>spring-beans</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.springframework</groupId>
+                    <artifactId>spring-context</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.springframework</groupId>
+                    <artifactId>spring-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.springframework</groupId>
+                    <artifactId>spring-expression</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.springframework</groupId>
+                    <artifactId>spring-jms</artifactId>
                 </exclusion>
                 <exclusion>
                     <groupId>org.springframework</groupId>

--- a/features/minion/core/impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/features/minion/core/impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -3,7 +3,6 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0"
     xmlns:ext="http://aries.apache.org/blueprint/xmlns/blueprint-ext/v1.1.0"
-    xmlns:cb="http://camel.apache.org/schema/blueprint"
     xsi:schemaLocation="
         http://www.osgi.org/xmlns/blueprint/v1.0.0 
         http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd

--- a/features/minion/heartbeat/producer/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/features/minion/heartbeat/producer/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -1,7 +1,6 @@
 <blueprint
     xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xmlns:cb="http://camel.apache.org/schema/blueprint"
     xsi:schemaLocation="
         http://www.osgi.org/xmlns/blueprint/v1.0.0 
         http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd

--- a/features/scv/jceks-impl/src/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/features/scv/jceks-impl/src/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -3,7 +3,6 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0"
     xmlns:ext="http://aries.apache.org/blueprint/xmlns/blueprint-ext/v1.1.0"
-    xmlns:cb="http://camel.apache.org/schema/blueprint"
     xsi:schemaLocation="
         http://www.osgi.org/xmlns/blueprint/v1.0.0 
         http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd

--- a/features/topology-map/plugins/org.opennms.features.topology.plugins.ncs/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/features/topology-map/plugins/org.opennms.features.topology.plugins.ncs/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -3,6 +3,7 @@ xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0"
     xsi:schemaLocation="
     http://www.osgi.org/xmlns/blueprint/v1.0.0 http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd
     http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0 http://aries.apache.org/schemas/blueprint-cm/blueprint-cm-1.1.0.xsd
+    http://camel.apache.org/schema/blueprint http://camel.apache.org/schema/blueprint/camel-blueprint-2.16.5.xsd
 ">
     
    <cm:property-placeholder id="ncsPlugin" persistent-id="org.opennms.features.topology.plugin.ncs" update-strategy="reload">

--- a/features/topology-map/plugins/org.opennms.features.topology.plugins.ncs/src/test/resources/blueprint/camelContext.xml
+++ b/features/topology-map/plugins/org.opennms.features.topology.plugins.ncs/src/test/resources/blueprint/camelContext.xml
@@ -1,7 +1,9 @@
 <blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="
-             http://www.osgi.org/xmlns/blueprint/v1.0.0 http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd">
+             http://www.osgi.org/xmlns/blueprint/v1.0.0 http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd
+             http://camel.apache.org/schema/blueprint http://camel.apache.org/schema/blueprint/camel-blueprint-2.16.5.xsd
+">
 
     <bean id="nodeDao" class="org.opennms.features.topology.plugins.ncs.MockNodeDao"/>
     <bean id="ncsRepository" class="org.opennms.features.topology.plugins.ncs.MockNCSComponentRepository"/>

--- a/opennms-alarms/jms-northbounder/src/test/java/org/opennms/netmgmt/alarmd/northbounder/jms/JmsNorthBounderTest.java
+++ b/opennms-alarms/jms-northbounder/src/test/java/org/opennms/netmgmt/alarmd/northbounder/jms/JmsNorthBounderTest.java
@@ -38,12 +38,14 @@ import java.util.Set;
 
 import javax.jms.ConnectionFactory;
 import javax.jms.Message;
-import javax.jms.TextMessage;
 import javax.jms.ObjectMessage;
+import javax.jms.TextMessage;
 
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.opennms.core.test.MockLogAppender;
@@ -86,6 +88,8 @@ public class JmsNorthBounderTest {
     /** The Constant NODE_LABEL. */
     private static final String NODE_LABEL = "schlazor";
     
+    private static final String AMQ_SERIALIZABLE_PACKAGES_PROPERTY = "org.apache.activemq.SERIALIZABLE_PACKAGES";
+    
     /** The JMS template. */
     private JmsTemplate m_template;
     
@@ -100,6 +104,23 @@ public class JmsNorthBounderTest {
     /** The Node DAO. */
     @Autowired
     private MockNodeDao m_nodeDao;
+    
+    private static String s_oldSerializablePackages;
+    
+    @BeforeClass
+    public static void setSerializablePackages() {
+        s_oldSerializablePackages = System.getProperty(AMQ_SERIALIZABLE_PACKAGES_PROPERTY);
+        System.setProperty(AMQ_SERIALIZABLE_PACKAGES_PROPERTY, "*");
+    }
+    
+    @AfterClass
+    public static void resetSerializablePackages() {
+        if (s_oldSerializablePackages == null) {
+            System.clearProperty(AMQ_SERIALIZABLE_PACKAGES_PROPERTY);
+        } else {
+            System.setProperty(AMQ_SERIALIZABLE_PACKAGES_PROPERTY, s_oldSerializablePackages);
+        }
+    }
     
     /**
      * Start broker.

--- a/pom.xml
+++ b/pom.xml
@@ -1259,7 +1259,7 @@
     <asciidoctorVersion>1.5.3</asciidoctorVersion>
     <asciidoctorjVersion>1.5.4</asciidoctorjVersion>
     <asciidoctorjPdfVersion>1.5.0-alpha.11</asciidoctorjPdfVersion>
-    <activemqVersion>5.10.0</activemqVersion>
+    <activemqVersion>5.13.3</activemqVersion>
     <atomikosVersion>3.9.2</atomikosVersion>
     <batikVersion>1.7</batikVersion>
     <bsfVersion>2.4.0</bsfVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -1263,7 +1263,7 @@
     <atomikosVersion>3.9.2</atomikosVersion>
     <batikVersion>1.7</batikVersion>
     <bsfVersion>2.4.0</bsfVersion>
-    <camelVersion>2.14.4</camelVersion>
+    <camelVersion>2.16.5</camelVersion>
     <cloverVersion>3.2.0</cloverVersion>
     <commonsBeanutilsVersion>1.8.3</commonsBeanutilsVersion>
     <commonsCodecVersion>1.10</commonsCodecVersion>

--- a/smoke-test/pom.xml
+++ b/smoke-test/pom.xml
@@ -9,7 +9,7 @@
     <skipITs>true</skipITs>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <updatePolicy>interval:60</updatePolicy>
-    <camelVersion>2.14.4</camelVersion>
+    <camelVersion>2.16.5</camelVersion>
     <frontendPluginVersion>0.0.29</frontendPluginVersion>
     <nodeVersion>v6.10.2</nodeVersion>
     <npmVersion>3.10.10</npmVersion>


### PR DESCRIPTION
Now that we're using Spring 4.1, this PR upgrades Camel and ActiveMQ to versions that roughly align with each other.

* JIRA: http://issues.opennms.org/browse/HZN-705
* JIRA: http://issues.opennms.org/browse/HZN-1058