### PR TITLE
NMS-9331: fix BestMatchPinger to work with IPv4-only systems

### DIFF
--- a/core/icmp-jna/src/main/java/org/opennms/jicmp/jna/NativeDatagramSocket.java
+++ b/core/icmp-jna/src/main/java/org/opennms/jicmp/jna/NativeDatagramSocket.java
@@ -89,7 +89,8 @@ public abstract class NativeDatagramSocket implements AutoCloseable {
         try {
             return constructor.newInstance(family, SOCK_DGRAM, protocol, listenPort);
         } catch (final Exception e) {
-            LOG.warn("Failed to create {} SOCK_DGRAM socket.  Trying with SOCK_RAW.", implementationClass, e);
+            LOG.debug("Failed to create {} SOCK_DGRAM socket ({}).  Trying with SOCK_RAW.", implementationClass, e.getMessage());
+            LOG.trace("Failed to create {} SOCK_DGRAM socket.  Trying with SOCK_RAW.", implementationClass, e);
             return constructor.newInstance(family, SOCK_RAW, protocol, listenPort);
         }
     }

--- a/opennms-icmp/opennms-icmp-api/src/main/java/org/opennms/netmgt/icmp/PingerFactoryImpl.java
+++ b/opennms-icmp/opennms-icmp-api/src/main/java/org/opennms/netmgt/icmp/PingerFactoryImpl.java
@@ -31,7 +31,7 @@ package org.opennms.netmgt.icmp;
 public class PingerFactoryImpl extends AbstractPingerFactory {
     @Override
     public Class<? extends Pinger> getPingerClass() {
-        final String pingerClassName = System.getProperty("org.opennms.netmgt.icmp.pingerClass", "org.opennms.netmgt.icmp.jni6.Jni6Pinger");
+        final String pingerClassName = System.getProperty("org.opennms.netmgt.icmp.pingerClass", "org.opennms.netmgt.icmp.best.BestMatchPinger");
 
         // If the default (0) DSCP pinger has already been initialized, use the
         // same class in case it's been manually overridden with a setInstance()

--- a/opennms-icmp/opennms-icmp-best/src/main/java/org/opennms/netmgt/icmp/best/BestMatchPinger.java
+++ b/opennms-icmp/opennms-icmp-best/src/main/java/org/opennms/netmgt/icmp/best/BestMatchPinger.java
@@ -130,7 +130,8 @@ public class BestMatchPinger implements Pinger {
             try {
                 m_pinger = pinger.newInstance();
             } catch (final Throwable t) {
-                LOG.error("Failed to initialize best match pinger ({}).  Falling back to the null pinger.", pinger, t);
+                LOG.error("Failed to initialize best match pinger ({}): {}  Falling back to the null pinger.", pinger, t.getMessage());
+                LOG.trace("Failed to initialize best match pinger ({}).  Falling back to the null pinger.", pinger, t);
                 m_pinger = new NullPinger();
             }
 
@@ -139,7 +140,8 @@ public class BestMatchPinger implements Pinger {
                     m_pinger.setAllowFragmentation(m_allowFragmentation);
                 }
             } catch (final Throwable t) {
-                LOG.debug("Failed to set 'allow fragmentation' flag on pinger {}", pinger, t);
+                LOG.debug("Failed to set 'allow fragmentation' flag on pinger {}: {}", pinger, t.getMessage());
+                LOG.trace("Failed to set 'allow fragmentation' flag on pinger {}.", pinger, t);
             }
 
             try {

--- a/opennms-icmp/opennms-icmp-best/src/main/java/org/opennms/netmgt/icmp/best/BestMatchPingerFactory.java
+++ b/opennms-icmp/opennms-icmp-best/src/main/java/org/opennms/netmgt/icmp/best/BestMatchPingerFactory.java
@@ -64,6 +64,7 @@ public class BestMatchPingerFactory extends AbstractPingerFactory {
 
         try {
             if (pinger.isV4Available()) {
+                pinger.initialize4();
                 v4 = true;
             }
         } catch (final Throwable t) {
@@ -72,6 +73,7 @@ public class BestMatchPingerFactory extends AbstractPingerFactory {
 
         try {
             if (pinger.isV6Available()) {
+                pinger.initialize6();
                 v6 = true;
             }
         } catch (final Throwable t) {
@@ -117,7 +119,7 @@ public class BestMatchPingerFactory extends AbstractPingerFactory {
         Class<? extends Pinger> pinger = NullPinger.class;
 
         LOG.info("Searching for best available pinger...");
-        for (final Class<? extends Pinger> pingerClass : Arrays.asList(Jni6Pinger.class, JniPinger.class, JnaPinger.class)) {
+        for (final Class<? extends Pinger> pingerClass : Arrays.asList(JniPinger.class, Jni6Pinger.class, JnaPinger.class)) {
             final PingerMatch tried = tryPinger(pingerClass);
             if (tried.compareTo(match) > 0) {
                 match = tried;

--- a/opennms-icmp/opennms-icmp-best/src/main/java/org/opennms/netmgt/icmp/best/BestMatchPingerFactory.java
+++ b/opennms-icmp/opennms-icmp-best/src/main/java/org/opennms/netmgt/icmp/best/BestMatchPingerFactory.java
@@ -58,7 +58,8 @@ public class BestMatchPingerFactory extends AbstractPingerFactory {
         try {
             pinger = pingerClass.newInstance();
         } catch (final Throwable t) {
-            LOG.info("Failed to get instance of {}.", pingerClass, t);
+            LOG.info("Failed to get instance of {}: {}", pingerClass, t.getMessage());
+            LOG.trace("Failed to get instance of {}.", pingerClass, t);
             return PingerMatch.NONE;
         }
 
@@ -68,7 +69,8 @@ public class BestMatchPingerFactory extends AbstractPingerFactory {
                 v4 = true;
             }
         } catch (final Throwable t) {
-            LOG.info("Failed to initialize {} for IPv4.", pingerClass, t);
+            LOG.info("Failed to initialize {} for IPv4: ", pingerClass, t.getMessage());
+            LOG.trace("Failed to initialize {} for IPv4.", pingerClass, t);
         }
 
         try {
@@ -77,7 +79,8 @@ public class BestMatchPingerFactory extends AbstractPingerFactory {
                 v6 = true;
             }
         } catch (final Throwable t) {
-            LOG.info("Failed to initialize {} for IPv4.", pingerClass, t);
+            LOG.info("Failed to initialize {} for IPv4: {}", pingerClass, t.getMessage());
+            LOG.trace("Failed to initialize {} for IPv4.", pingerClass, t);
         }
 
         try {
@@ -87,7 +90,8 @@ public class BestMatchPingerFactory extends AbstractPingerFactory {
                 throw new IllegalStateException("No result pinging localhost.");
             }
         } catch (final Throwable t) {
-            LOG.info("Found pinger {}, but it was unable to ping localhost.", pingerClass, t);
+            LOG.info("Found pinger {}, but it was unable to ping localhost: {}", pingerClass, t.getMessage());
+            LOG.trace("Found pinger {}, but it was unable to ping localhost.", pingerClass, t);
             return PingerMatch.NONE;
         }
 


### PR DESCRIPTION
This PR fixes the `BestMatchPinger` to handle IPv4-only systems better.  It changes the default pinger factory to the `BestMatchPingerFactory` and makes sure that when trying pingers, IPv4 and IPv6 initialization happens at the time of testing, rather than at the time of first use.

The reason for this is that on IPv4-only systems, it would try pinging the local host address using the `Jni6Pinger`, which would *only* call `initializev4()` and it would pass and accept the `Jni6Pinger` as "best", but then at runtime when full v4/v6 initialization happens, it would die.

Finally, the PR changes some of the logging to not show full stack traces without enabling TRACE debugging, as the output was kind of scary and not terribly useful for regular every day use.

* JIRA: http://issues.opennms.org/browse/NMS-9331

Our [continuous integration system](http://bamboo.internal.opennms.com:8085) will test and verify your changes.
