### PR TITLE
NMS-9127: document disabling package upgrade while running

### DIFF
--- a/opennms-doc/guide-install/src/asciidoc/text/opennms/debian.adoc
+++ b/opennms-doc/guide-install/src/asciidoc/text/opennms/debian.adoc
@@ -55,6 +55,38 @@ With the successful installed packages the _OpenNMS_ platform is installed in th
    └── system
 ----
 
+[[gi-install-opennms-deb-disable-update]]
+==== Disable Automatic Updates (Optional)
+
+We recommend you disable automatic updating of the {opennms-product-name} packages to avoid upgrades while it is running.
+
+{opennms-product-name} requires some manual steps upon upgrade to make sure the database and configuration are consistent in the new version, and on systems with many nodes or lots of events, this can take hours.
+For this reason, it is recommended to exclude the {opennms-product-name} packages from update except when you are planning on performing an upgrade.
+
+To do so, run:
+
+[source, shell]
+----
+sudo apt-mark hold libopennms-java \
+     libopennmsdeps-java \
+     opennms-common opennms-db
+----
+
+When you are ready to upgrade {opennms-product-name}, unhold them and upgrade, then hold them again:
+
+[source, shell]
+----
+sudo apt-mark unhold libopennms-java \
+     libopennmsdeps-java \
+     opennms-common opennms-db
+
+sudo apt-get upgrade opennms
+
+sudo apt-mark hold libopennms-java \
+     libopennmsdeps-java \
+     opennms-common opennms-db
+----
+
 [[gi-install-opennms-deb-prepare-pg]]
 ==== Prepare PostgreSQL
 

--- a/opennms-doc/guide-install/src/asciidoc/text/opennms/rhel.adoc
+++ b/opennms-doc/guide-install/src/asciidoc/text/opennms/rhel.adoc
@@ -57,6 +57,26 @@ With the successful installed packages the _OpenNMS_ platform is installed in th
    └── system
 ----
 
+[[gi-install-opennms-rhel-disable-yum-repo]]
+==== Disable Automatic Updates (Optional)
+
+We recommend you disable the {opennms-product-name} Yum repository to avoid upgrades while it is running.
+
+{opennms-product-name} requires some manual steps upon upgrade to make sure the database and configuration are consistent in the new version, and on systems with many nodes or lots of events, this can take hours.
+For this reason, it is recommended to exclude the {opennms-product-name} packages from yum except when you are planning on performing an upgrade.
+
+To do so, edit the `/etc/yum.repos.d/opennms-*.repo` file and change `enabled=1` to `enabled=0` in each section.
+
+When you are ready to upgrade {opennms-product-name}, call yum with the `--enablerepo` option to turn the 2 repositories defined in this file back on.
+For example, if you installed the stable repository _RPM_ on a _CentOS_ or _RHEL 7_ system, you would run:
+
+[source, shell]
+----
+yum -y --enablerepo=opennms-repo-stable-common \
+  --enablerepo=opennms-repo-stable-rhel7 \
+  upgrade opennms
+----
+
 [[gi-install-opennms-rhel-prepare-pg]]
 ==== Prepare PostgreSQL
 


### PR DESCRIPTION
This PR adds documentation on disabling automatic upgrade of OpenNMS for yum and apt users.

* JIRA: http://issues.opennms.org/browse/NMS-9127

Our [continuous integration system](http://bamboo.internal.opennms.com:8085) will test and verify your changes.
