### PR TITLE
NMS-9261: Make org.opennms.newts.nan_on_counter_wrap=true by default.

### DIFF
--- a/core/daemon/src/main/java/org/opennms/netmgt/vmmgr/Starter.java
+++ b/core/daemon/src/main/java/org/opennms/netmgt/vmmgr/Starter.java
@@ -173,6 +173,16 @@ public class Starter {
         } else {
             java.security.Security.setProperty("networkaddress.cache.ttl", "120");
         }
+
+        // NMS-9261: Make org.opennms.newts.nan_on_counter_wrap=true by default
+        // without requiring any changes to opennms.properties
+        // This will code block will be reverted in foundation-2017, and
+        // the relevant entry will be placed in opennms.properties instead
+        final String newtsNaNOnCounterWrapSysProp = "org.opennms.newts.nan_on_counter_wrap";
+        if (System.getProperty(newtsNaNOnCounterWrapSysProp) == null) {
+            // The property was not set by the user
+            System.setProperty(newtsNaNOnCounterWrapSysProp, Boolean.TRUE.toString());
+        }
     }
 
     /**


### PR DESCRIPTION
JIRA: https://issues.opennms.org/browse/NMS-9261

Set `org.opennms.newts.nan_on_counter_wrap=true` on startup without changing the configuration files, and creating a .rpmnew file.
