### PR TITLE
NMS-9203: Fixed deadLetterStrategy config

### DIFF
--- a/opennms-base-assembly/src/main/filtered/etc/opennms-activemq.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/opennms-activemq.xml
@@ -96,15 +96,13 @@
                     <vmQueueCursor/>
                   </pendingQueuePolicy>
                   -->
-                </policyEntry>
-                <!--
-                  Change the dead-letter strategy to discard messages instead 
-                  of storing them in the DLQ. You can comment out this policyEntry
-                  to reenable the DLQ for troubleshooting.
-                -->
-                <policyEntry queue=">">
+                  <!--
+                    Change the dead-letter strategy to discard messages instead 
+                    of storing them in the DLQ. You can comment out this policyEntry
+                    to reenable the DLQ for troubleshooting.
+                  -->
                   <deadLetterStrategy>
-                    <sharedDeadLetterStrategy processExpired="false" />
+                    <discarding/>
                   </deadLetterStrategy>
                 </policyEntry>
               </policyEntries>

--- a/opennms-services/pom.xml
+++ b/opennms-services/pom.xml
@@ -357,6 +357,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.opennms</groupId>
+      <artifactId>org.opennms.icmp.proxy.rpc-impl</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.opennms.features.poller</groupId>
       <artifactId>org.opennms.features.poller.client-rpc</artifactId>
       <scope>test</scope>
@@ -364,6 +370,12 @@
     <dependency>
       <groupId>org.opennms.core.ipc.rpc</groupId>
       <artifactId>org.opennms.core.ipc.rpc.mock-impl</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.opennms.core.ipc.rpc</groupId>
+      <artifactId>org.opennms.core.ipc.rpc.camel-impl</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>

--- a/opennms-services/src/test/java/org/opennms/netmgt/collectd/HttpCollectorIT.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/collectd/HttpCollectorIT.java
@@ -83,6 +83,7 @@ import org.springframework.transaction.PlatformTransactionManager;
         "classpath:/META-INF/opennms/applicationContext-soa.xml",
         "classpath:/META-INF/opennms/applicationContext-dao.xml",
         "classpath*:/META-INF/opennms/component-dao.xml",
+        "classpath:/META-INF/opennms/applicationContext-pinger.xml",
         "classpath:/META-INF/opennms/applicationContext-daemon.xml",
         "classpath:/META-INF/opennms/applicationContext-collectdTest.xml",
         "classpath:/META-INF/opennms/mockEventIpcManager.xml"

--- a/opennms-services/src/test/java/org/opennms/netmgt/collectd/SnmpCollectorIT.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/collectd/SnmpCollectorIT.java
@@ -88,6 +88,7 @@ import org.springframework.transaction.annotation.Transactional;
         "classpath:/META-INF/opennms/applicationContext-soa.xml",
         "classpath:/META-INF/opennms/applicationContext-mockDao.xml",
         "classpath*:/META-INF/opennms/component-dao.xml",
+        "classpath:/META-INF/opennms/applicationContext-pinger.xml",
         "classpath:/META-INF/opennms/applicationContext-daemon.xml",
         "classpath:/META-INF/opennms/mockEventIpcManager.xml",
         "classpath:/META-INF/opennms/applicationContext-proxy-snmp.xml"

--- a/opennms-services/src/test/java/org/opennms/netmgt/collectd/SnmpCollectorMinMaxValIT.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/collectd/SnmpCollectorMinMaxValIT.java
@@ -87,6 +87,7 @@ import org.springframework.transaction.annotation.Transactional;
         "classpath:/META-INF/opennms/applicationContext-soa.xml",
         "classpath:/META-INF/opennms/applicationContext-mockDao.xml",
         "classpath*:/META-INF/opennms/component-dao.xml",
+        "classpath:/META-INF/opennms/applicationContext-pinger.xml",
         "classpath:/META-INF/opennms/applicationContext-daemon.xml",
         "classpath:/META-INF/opennms/mockEventIpcManager.xml",
         "classpath:/META-INF/opennms/applicationContext-proxy-snmp.xml"

--- a/opennms-services/src/test/java/org/opennms/netmgt/collectd/SnmpCollectorWithMibPropertiesIT.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/collectd/SnmpCollectorWithMibPropertiesIT.java
@@ -79,6 +79,7 @@ import org.springframework.transaction.PlatformTransactionManager;
         "classpath:/META-INF/opennms/applicationContext-soa.xml",
         "classpath:/META-INF/opennms/applicationContext-mockDao.xml",
         "classpath*:/META-INF/opennms/component-dao.xml",
+        "classpath:/META-INF/opennms/applicationContext-pinger.xml",
         "classpath:/META-INF/opennms/applicationContext-daemon.xml",
         "classpath:/META-INF/opennms/mockEventIpcManager.xml",
         "classpath:/META-INF/opennms/applicationContext-proxy-snmp.xml"

--- a/opennms-services/src/test/java/org/opennms/netmgt/mock/OpenNMSIntegrationTestCaseIT.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/mock/OpenNMSIntegrationTestCaseIT.java
@@ -50,6 +50,7 @@ import org.springframework.test.context.ContextConfiguration;
         "classpath:/META-INF/opennms/applicationContext-soa.xml",
         "classpath:/META-INF/opennms/applicationContext-mockDao.xml",
         "classpath*:/META-INF/opennms/component-dao.xml",
+        "classpath:/META-INF/opennms/applicationContext-pinger.xml",
         "classpath:/META-INF/opennms/applicationContext-daemon.xml",
         "classpath:/META-INF/opennms/applicationContext-commonConfigs.xml",
         "classpath:/META-INF/opennms/applicationContext-minimal-conf.xml"

--- a/opennms-services/src/test/java/org/opennms/netmgt/notifd/BSFNotificationStrategyIT.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/notifd/BSFNotificationStrategyIT.java
@@ -61,6 +61,7 @@ import org.springframework.test.context.ContextConfiguration;
         "classpath:/META-INF/opennms/applicationContext-minimal-conf.xml",
         "classpath*:/META-INF/opennms/component-dao.xml",
         "classpath*:/META-INF/opennms/component-service.xml",
+        "classpath:/META-INF/opennms/applicationContext-pinger.xml",
         "classpath:/META-INF/opennms/mockEventIpcManager.xml",
         // Notifd
         "classpath:/META-INF/opennms/applicationContext-notifdTest.xml"

--- a/opennms-services/src/test/java/org/opennms/netmgt/notifd/HttpNotificationStrategyIT.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/notifd/HttpNotificationStrategyIT.java
@@ -54,6 +54,7 @@ import org.springframework.test.context.ContextConfiguration;
         "classpath:/META-INF/opennms/applicationContext-soa.xml",
         "classpath:/META-INF/opennms/applicationContext-mockDao.xml",
         "classpath*:/META-INF/opennms/component-dao.xml",
+        "classpath:/META-INF/opennms/applicationContext-pinger.xml",
         "classpath:/META-INF/opennms/applicationContext-daemon.xml",
         "classpath:/META-INF/opennms/applicationContext-commonConfigs.xml",
         "classpath:/META-INF/opennms/applicationContext-minimal-conf.xml"

--- a/opennms-services/src/test/java/org/opennms/netmgt/notifd/MattermostNotificationStrategyIT.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/notifd/MattermostNotificationStrategyIT.java
@@ -55,6 +55,7 @@ import org.springframework.test.context.ContextConfiguration;
         "classpath:/META-INF/opennms/applicationContext-soa.xml",
         "classpath:/META-INF/opennms/applicationContext-mockDao.xml",
         "classpath*:/META-INF/opennms/component-dao.xml",
+        "classpath:/META-INF/opennms/applicationContext-pinger.xml",
         "classpath:/META-INF/opennms/applicationContext-daemon.xml",
         "classpath:/META-INF/opennms/applicationContext-commonConfigs.xml",
         "classpath:/META-INF/opennms/applicationContext-minimal-conf.xml"

--- a/opennms-services/src/test/java/org/opennms/netmgt/notifd/NotificationsITCase.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/notifd/NotificationsITCase.java
@@ -77,6 +77,7 @@ import org.springframework.test.context.ContextConfiguration;
         "classpath:/META-INF/opennms/applicationContext-minimal-conf.xml",
         "classpath*:/META-INF/opennms/component-dao.xml",
         "classpath*:/META-INF/opennms/component-service.xml",
+        "classpath:/META-INF/opennms/applicationContext-pinger.xml",
         "classpath:/META-INF/opennms/mockEventIpcManager.xml",
         // Notifd
         "classpath:/META-INF/opennms/applicationContext-notifdTest.xml"

--- a/opennms-services/src/test/java/org/opennms/netmgt/notifd/SlackNotificationStrategyIT.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/notifd/SlackNotificationStrategyIT.java
@@ -55,6 +55,7 @@ import org.springframework.test.context.ContextConfiguration;
         "classpath:/META-INF/opennms/applicationContext-soa.xml",
         "classpath:/META-INF/opennms/applicationContext-mockDao.xml",
         "classpath*:/META-INF/opennms/component-dao.xml",
+        "classpath:/META-INF/opennms/applicationContext-pinger.xml",
         "classpath:/META-INF/opennms/applicationContext-daemon.xml",
         "classpath:/META-INF/opennms/applicationContext-commonConfigs.xml",
         "classpath:/META-INF/opennms/applicationContext-minimal-conf.xml"

--- a/opennms-services/src/test/java/org/opennms/netmgt/poller/PathOutageManagerDaoIT.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/poller/PathOutageManagerDaoIT.java
@@ -65,6 +65,7 @@ import org.springframework.test.context.ContextConfiguration;
         "classpath:/META-INF/opennms/applicationContext-minimal-conf.xml",
         "classpath:/META-INF/opennms/applicationContext-dao.xml",
         "classpath*:/META-INF/opennms/component-dao.xml",
+        "classpath:/META-INF/opennms/applicationContext-pinger.xml",
         "classpath:/META-INF/opennms/applicationContext-daemon.xml",
         "classpath:/META-INF/opennms/mockEventIpcManager.xml",
         "classpath:/META-INF/opennms/applicationContext-pollerdTest.xml"

--- a/opennms-services/src/test/java/org/opennms/netmgt/poller/PollContextIT.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/poller/PollContextIT.java
@@ -85,6 +85,7 @@ import org.springframework.test.context.ContextConfiguration;
         "classpath:/META-INF/opennms/applicationContext-minimal-conf.xml",
         "classpath*:/META-INF/opennms/component-dao.xml",
         "classpath*:/META-INF/opennms/component-service.xml",
+        "classpath:/META-INF/opennms/applicationContext-pinger.xml",
         "classpath:/META-INF/opennms/applicationContext-daemon.xml",
         "classpath:/META-INF/opennms/mockEventIpcManager.xml",
 

--- a/opennms-services/src/test/java/org/opennms/netmgt/poller/PollerRpcTimeoutIT.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/poller/PollerRpcTimeoutIT.java
@@ -1,0 +1,302 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2004-2017 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.poller;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.opennms.core.utils.InetAddressUtils.str;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.lang.management.ManagementFactory;
+
+import javax.management.InstanceNotFoundException;
+import javax.management.ObjectName;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.opennms.core.camel.JmsQueueNameFactory;
+import org.opennms.core.db.DataSourceFactory;
+import org.opennms.core.test.MockLogAppender;
+import org.opennms.core.test.OpenNMSJUnit4ClassRunner;
+import org.opennms.core.test.db.MockDatabase;
+import org.opennms.core.test.db.TemporaryDatabaseAware;
+import org.opennms.core.test.db.annotations.JUnitTemporaryDatabase;
+import org.opennms.core.utils.InetAddressUtils;
+import org.opennms.netmgt.config.PollOutagesConfig;
+import org.opennms.netmgt.config.PollerConfigFactory;
+import org.opennms.netmgt.config.poller.Package;
+import org.opennms.netmgt.config.poller.Service;
+import org.opennms.netmgt.dao.api.MonitoredServiceDao;
+import org.opennms.netmgt.dao.api.MonitoringLocationDao;
+import org.opennms.netmgt.dao.api.NodeDao;
+import org.opennms.netmgt.dao.api.OutageDao;
+import org.opennms.netmgt.dao.mock.MockEventIpcManager;
+import org.opennms.netmgt.icmp.proxy.LocationAwarePingClient;
+import org.opennms.netmgt.mock.MockNetwork;
+import org.opennms.netmgt.model.OnmsNode;
+import org.opennms.netmgt.model.monitoringLocations.OnmsMonitoringLocation;
+import org.opennms.netmgt.poller.pollables.PollableNetwork;
+import org.opennms.test.JUnitConfigurationEnvironment;
+import org.opennms.test.mock.MockUtil;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
+
+@RunWith(OpenNMSJUnit4ClassRunner.class)
+@ContextConfiguration(locations={
+        "classpath:/META-INF/opennms/applicationContext-soa.xml",
+        "classpath:/META-INF/opennms/applicationContext-commonConfigs.xml",
+        "classpath:/META-INF/opennms/applicationContext-minimal-conf.xml",
+        "classpath:/META-INF/opennms/applicationContext-dao.xml",
+        "classpath*:/META-INF/opennms/component-dao.xml",
+        "classpath:/META-INF/opennms/applicationContext-daemon.xml",
+        "classpath:/META-INF/opennms/applicationContext-eventUtil.xml",
+        "classpath:/META-INF/opennms/mockEventIpcManager.xml",
+        "classpath:/META-INF/opennms/applicationContext-pinger.xml",
+        "classpath:/META-INF/opennms/applicationContext-rpc-client-camel.xml",
+        "classpath:/META-INF/opennms/applicationContext-rpc-icmp.xml",
+        "classpath:/META-INF/opennms/applicationContext-rpc-poller.xml",
+        "classpath:/META-INF/opennms/applicationContext-pollerd.xml"
+})
+@JUnitConfigurationEnvironment(systemProperties={
+        "org.opennms.netmgt.icmp.pingerClass=org.opennms.netmgt.icmp.jna.JnaPinger",
+        // Add immediate timeouts
+        "org.opennms.jms.timeout=1",
+        // Store the ActiveMQ kahadb in the target directory
+        // which we delete before the test executes
+        "activemq.data=" + PollerRpcTimeoutIT.ACTIVEMQ_STORAGE_DIRECTORY
+})
+@JUnitTemporaryDatabase(tempDbClass=MockDatabase.class,reuseDatabase=false)
+@Transactional
+public class PollerRpcTimeoutIT implements TemporaryDatabaseAware<MockDatabase> {
+
+    public static final String ACTIVEMQ_STORAGE_DIRECTORY = "target/activemq";
+    public static final String NONEXISTENT_LOCATION = "DOESNT_EXIST";
+
+    private Poller m_poller;
+
+    private MockNetwork m_network;
+
+    private MockDatabase m_db;
+
+    @Autowired
+    private PollOutagesConfig m_pollOutagesConfig;
+
+    @Autowired
+    private MockEventIpcManager m_eventMgr;
+
+    @Autowired
+    private QueryManager m_queryManager;
+
+    @Autowired
+    private OutageDao m_outageDao;
+
+    @Autowired
+    private NodeDao m_nodeDao;
+
+    @Autowired
+    private MonitoringLocationDao m_monitoringLocationDao;
+
+    @Autowired
+    private MonitoredServiceDao m_monitoredServiceDao;
+
+    @Autowired
+    private TransactionTemplate m_transactionTemplate;
+
+    @Autowired
+    private LocationAwarePollerClient m_locationAwarePollerClient;
+
+    @Autowired
+    private LocationAwarePingClient m_locationAwarePingClient;
+
+    @Override
+    public void setTemporaryDatabase(MockDatabase database) {
+        m_db = database;
+    }
+
+    private void startDaemons() {
+        m_poller.init();
+        m_poller.start();
+    }
+
+    private void stopDaemons() {
+        if (m_poller != null) {
+            m_poller.stop();
+        }
+    }
+
+    /**
+     * Clean up the activemq persistence directory before and after
+     * the test.
+     * 
+     * @throws Exception
+     */
+    @BeforeClass
+    @AfterClass
+    public static void deleteActiveMqStorage() throws Exception {
+        FileUtils.deleteDirectory(new File(ACTIVEMQ_STORAGE_DIRECTORY));
+    }
+
+    @Before
+    public void setUp() throws Exception {
+
+        MockUtil.println("------------ Begin Test  --------------------------");
+        MockLogAppender.setupLogging();
+
+        m_network = new MockNetwork();
+        m_network.setCriticalService("ICMP");
+        m_network.addNode(1, "Router");
+        m_network.addInterface(str(InetAddressUtils.UNPINGABLE_ADDRESS));
+        m_network.addService("ICMP");
+        m_network.addService("HTTP");
+
+        m_db.populate(m_network);
+        DataSourceFactory.setInstance(m_db);
+
+        // Add a location that no systems are monitoring
+        OnmsMonitoringLocation location = new OnmsMonitoringLocation(NONEXISTENT_LOCATION, "Nullsville");
+        m_monitoringLocationDao.save(location);
+
+        // Update all of the nodes to have the nonexistent location
+        for (OnmsNode node : m_nodeDao.findAll()) {
+            node.setLocation(location);
+            m_nodeDao.save(node);
+        }
+
+        InputStream is = new FileInputStream(new File("src/test/resources/etc/rpctimeout-poller-configuration.xml"));
+        PollerConfigFactory factory = new PollerConfigFactory(0, is, "localhost", false);
+        PollerConfigFactory.setInstance(factory);
+        IOUtils.closeQuietly(is);
+
+        // Sanity check the config
+        ServiceMonitor monitor = PollerConfigFactory.getInstance().getServiceMonitor("HTTP");
+        Assert.assertNotNull(monitor);
+        Package pkg = PollerConfigFactory.getInstance().getPackage("PollerRpcTimeoutIT");
+        Assert.assertNotNull(pkg);
+        Service svc = pkg.getServices().iterator().next();
+        Assert.assertEquals("HTTP", svc.getName());
+
+        DefaultPollContext pollContext = new DefaultPollContext();
+        pollContext.setEventManager(m_eventMgr);
+        pollContext.setLocalHostName("localhost");
+        pollContext.setName("Test.DefaultPollContext");
+        pollContext.setPollerConfig(factory);
+        pollContext.setQueryManager(m_queryManager);
+        pollContext.setLocationAwarePingClient(m_locationAwarePingClient);
+
+        PollableNetwork network = new PollableNetwork(pollContext);
+
+        m_poller = new Poller();
+        m_poller.setMonitoredServiceDao(m_monitoredServiceDao);
+        m_poller.setOutageDao(m_outageDao);
+        m_poller.setTransactionTemplate(m_transactionTemplate);
+        m_poller.setEventIpcManager(m_eventMgr);
+        m_poller.setNetwork(network);
+        m_poller.setQueryManager(m_queryManager);
+        m_poller.setPollerConfig(factory);
+        m_poller.setPollOutagesConfig(m_pollOutagesConfig);
+        m_poller.setLocationAwarePollerClient(m_locationAwarePollerClient);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        m_eventMgr.finishProcessingEvents();
+        MockUtil.println("------------ End Test  --------------------------");
+    }
+
+    @Test
+    public void testPolling() throws Exception {
+
+        String queueName = new JmsQueueNameFactory("RPC", "Poller", NONEXISTENT_LOCATION).getName();
+
+        try {
+            ManagementFactory.getPlatformMBeanServer().getObjectInstance(
+                ObjectName.getInstance("org.apache.activemq:type=Broker,brokerName=localhost,destinationType=Queue,destinationName=ActiveMQ.DLQ")
+            );
+            fail("DLQ was unexpected found in the PlatformMBeanServer");
+        } catch (InstanceNotFoundException e) {
+            // Expected: the queue hasn't been created yet
+        }
+
+        try {
+            ManagementFactory.getPlatformMBeanServer().getObjectInstance(
+                ObjectName.getInstance("org.apache.activemq:type=Broker,brokerName=localhost,destinationType=Queue,destinationName=" + queueName)
+            );
+            fail(queueName + " queue was unexpected found in the PlatformMBeanServer");
+        } catch (InstanceNotFoundException e) {
+            // Expected: the queue hasn't been created yet
+        }
+
+        // Start the poller: polls will timeout because there is no consumer for the location
+        startDaemons();
+
+        // Sleep long enough so that messages would be flushed to the DLQ
+        Thread.sleep(60000);
+
+        // Stop the poller daemon
+        stopDaemons();
+
+        try {
+            ManagementFactory.getPlatformMBeanServer().getObjectInstance(
+                ObjectName.getInstance("org.apache.activemq:type=Broker,brokerName=localhost,destinationType=Queue,destinationName=ActiveMQ.DLQ") 
+            );
+            fail("DLQ was unexpected found in the PlatformMBeanServer");
+        } catch (InstanceNotFoundException e) {
+            // Expected: the DLQ still should be absent
+        }
+
+        Long dequeueCount = (Long)ManagementFactory.getPlatformMBeanServer().getAttribute(
+            ObjectName.getInstance("org.apache.activemq:type=Broker,brokerName=localhost,destinationType=Queue,destinationName=" + queueName), 
+            "DequeueCount"
+        );
+        Long expiredCount = (Long)ManagementFactory.getPlatformMBeanServer().getAttribute(
+            ObjectName.getInstance("org.apache.activemq:type=Broker,brokerName=localhost,destinationType=Queue,destinationName=" + queueName), 
+            "ExpiredCount"
+        );
+        Long dispatchCount = (Long)ManagementFactory.getPlatformMBeanServer().getAttribute(
+            ObjectName.getInstance("org.apache.activemq:type=Broker,brokerName=localhost,destinationType=Queue,destinationName=" + queueName), 
+            "DispatchCount"
+        );
+
+        assertTrue("No expired messages were present", expiredCount > 0L);
+        assertEquals("Dequeued messages do not equal expired messages", expiredCount, dequeueCount);
+        assertEquals("Dispatched message count was not zero", 0, dispatchCount.intValue());
+    }
+}

--- a/opennms-services/src/test/java/org/opennms/netmgt/statsd/StatsdIT.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/statsd/StatsdIT.java
@@ -45,6 +45,7 @@ import org.springframework.test.context.ContextConfiguration;
         "classpath:/META-INF/opennms/applicationContext-mockDao.xml",
         "classpath:/META-INF/opennms/applicationContext-mockEventd.xml",
         "classpath*:/META-INF/opennms/component-dao.xml",
+        "classpath:/META-INF/opennms/applicationContext-pinger.xml",
         "classpath:/META-INF/opennms/applicationContext-statisticsDaemon.xml",
         "classpath:/META-INF/opennms/applicationContext-commonConfigs.xml",
         "classpath:/META-INF/opennms/applicationContext-minimal-conf.xml"

--- a/opennms-services/src/test/java/org/opennms/netmgt/statsd/StatsdValuesIT.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/statsd/StatsdValuesIT.java
@@ -61,6 +61,7 @@ import org.springframework.transaction.annotation.Transactional;
         "classpath:/META-INF/opennms/applicationContext-dao.xml",
         "classpath*:/META-INF/opennms/component-dao.xml",
         "classpath*:/META-INF/opennms/component-service.xml",
+        "classpath:/META-INF/opennms/applicationContext-pinger.xml",
         "classpath:/META-INF/opennms/applicationContext-commonConfigs.xml",
         "classpath:/META-INF/opennms/applicationContext-minimal-conf.xml"
 })

--- a/opennms-services/src/test/java/org/opennms/netmgt/utils/NodeLabelIT.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/utils/NodeLabelIT.java
@@ -54,6 +54,7 @@ import org.springframework.test.context.ContextConfiguration;
         "classpath:/META-INF/opennms/applicationContext-soa.xml",
         "classpath:/META-INF/opennms/applicationContext-dao.xml",
         "classpath*:/META-INF/opennms/component-dao.xml",
+        "classpath:/META-INF/opennms/applicationContext-pinger.xml",
         "classpath:/META-INF/opennms/applicationContext-daemon.xml",
         "classpath:/META-INF/opennms/applicationContext-commonConfigs.xml",
         "classpath:/META-INF/opennms/applicationContext-minimal-conf.xml",

--- a/opennms-services/src/test/java/org/opennms/netmgt/utils/TransactionAwareEventForwarderIT.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/utils/TransactionAwareEventForwarderIT.java
@@ -58,6 +58,7 @@ import org.springframework.transaction.support.TransactionTemplate;
         "classpath:/META-INF/opennms/applicationContext-soa.xml",
         "classpath:/META-INF/opennms/applicationContext-dao.xml",
         "classpath*:/META-INF/opennms/component-dao.xml",
+        "classpath:/META-INF/opennms/applicationContext-pinger.xml",
         "classpath:/META-INF/opennms/applicationContext-daemon.xml",
         "classpath:/org/opennms/netmgt/utils/applicationContext-testTAEventForwarderTest.xml",
         "classpath:/META-INF/opennms/mockEventIpcManager.xml",

--- a/opennms-services/src/test/resources/etc/rpctimeout-poller-configuration.xml
+++ b/opennms-services/src/test/resources/etc/rpctimeout-poller-configuration.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0"?>
+<poller-configuration
+  threads="30" 
+  serviceUnresponsiveEnabled="false"
+> 
+  <node-outage status="off"/>
+
+  <package name="PollerRpcTimeoutIT">
+    <filter>IPADDR != '0.0.0.0'</filter>
+    <include-range begin="1.1.1.1" end="254.254.254.254" />
+    <include-range begin="::1" end="ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff" />
+    <rrd step="300">
+      <rra>RRA:AVERAGE:0.5:1:2016</rra>
+      <rra>RRA:AVERAGE:0.5:12:1488</rra>
+      <rra>RRA:AVERAGE:0.5:288:366</rra>
+      <rra>RRA:MAX:0.5:288:366</rra>
+      <rra>RRA:MIN:0.5:288:366</rra>
+    </rrd>
+    <service name="HTTP" interval="500" user-defined="false" status="on">
+      <parameter key="retry" value="0" />
+      <parameter key="timeout" value="500" />
+      <parameter key="port" value="80" />
+      <parameter key="url" value="/" />
+      <parameter key="rrd-repository" value="${install.share.dir}/rrd/response" />
+      <parameter key="rrd-base-name" value="http" />
+      <parameter key="ds-name" value="http" />
+    </service>
+
+    <downtime interval="30000" begin="0" end="300000" /><!-- 30s, 0, 5m -->
+    <downtime interval="300000" begin="300000" end="43200000" /><!-- 5m, 5m, 12h -->
+    <downtime interval="600000" begin="43200000" end="432000000" /><!-- 10m, 12h, 5d -->
+    <downtime interval="3600000" begin="432000000" /><!-- 1h, 5d -->
+
+  </package>
+
+  <monitor service="HTTP" class-name="org.opennms.netmgt.poller.monitors.HttpMonitor" />
+</poller-configuration>


### PR DESCRIPTION
Moved the ```deadLetterStrategy``` tag inside the existing ```policyEntry``` tag so that it works properly. Added a test to make sure that the DLQ is not created when messages expire.

* JIRA: http://issues.opennms.org/browse/NMS-9203
