### PR TITLE
HZN-950: Add SHA1 checksums to the Karaf repositories

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -263,6 +263,10 @@ install: build
 	mv debian/temp/{data,deploy,system} debian/opennms-common/usr/share/opennms/
 	find debian/opennms-common/usr/share/opennms/{data,deploy,system} ! -type d -execdir chmod 644 {} \;
 	find debian/opennms-common/usr/share/opennms/{data,deploy,system}   -type d -execdir chmod 755 {} \;
+	# Generate SHA-1 checksums for the JAR and XML artifacts in the feature repositories
+	for FILE in `find debian/opennms-common/usr/share/opennms/system ! -type d -name "*.xml" -or -name "*.jar"`; do \
+		sha1sum $$FILE | cut -d ' ' -f 1 > $$FILE.sha1; \
+	done
 	
 	# move SNMP MIB files
 	install -d -m 755 debian/opennms-common/var/lib/opennms/mibs/compiled

--- a/tools/packages/minion/minion.spec
+++ b/tools/packages/minion/minion.spec
@@ -162,6 +162,11 @@ rm -rf %{buildroot}%{minioninstprefix}/data
 # Remove the demos directory
 rm -rf %{buildroot}%{minioninstprefix}/demos
 
+# Generate SHA-1 checksums for the JAR and XML artifacts in the feature repositories
+for FILE in `find %{buildroot}%{minioninstprefix}/{repositories,system} ! -type d -name "*.xml" -or -name "*.jar"`; do
+  sha1sum $FILE | cut -d ' ' -f 1 > $FILE.sha1
+done
+
 # Create a default org.opennms.minion.controller.cfg file
 echo "location = MINION" > %{buildroot}%{minioninstprefix}/etc/org.opennms.minion.controller.cfg
 echo "id = 00000000-0000-0000-0000-000000ddba11" >> %{buildroot}%{minioninstprefix}/etc/org.opennms.minion.controller.cfg

--- a/tools/packages/opennms/opennms.spec
+++ b/tools/packages/opennms/opennms.spec
@@ -617,6 +617,11 @@ for FILE in %{buildroot}%{instprefix}/lib/*.jar; do BASENAME=`basename $FILE`; f
 # NOTE: We can't do this because the JARs in webstart are signed
 #for FILE in %{buildroot}%{instprefix}/lib/*.jar; do BASENAME=`basename $FILE`; for SYSFILE in `find %{buildroot}%{instprefix}/jetty-webapps/opennms-remoting/webstart -name $BASENAME`; do rm -f $SYSFILE; ln -s %{instprefix}/lib/$BASENAME $SYSFILE; done; done
 
+# Generate SHA-1 checksums for the JAR and XML artifacts in the feature repositories
+for FILE in `find %{buildroot}%{instprefix}/system ! -type d -name "*.xml" -or -name "*.jar"`; do
+  sha1sum $FILE | cut -d ' ' -f 1 > $FILE.sha1
+done
+
 cd %{buildroot}
 
 # core package files
@@ -833,7 +838,9 @@ rm -rf %{buildroot}
 %files plugin-ticketer-jira
 %defattr(664 root root 775)
 %{instprefix}/system/org/opennms/features/jira-troubleticketer/*/jira-*.jar
+%{instprefix}/system/org/opennms/features/jira-troubleticketer/*/jira-*.jar.sha1
 %{instprefix}/system/org/opennms/features/jira-client/*/jira-*.jar
+%{instprefix}/system/org/opennms/features/jira-client/*/jira-*.jar.sha1
 %config(noreplace) %{instprefix}/etc/jira.properties
 %{sharedir}/etc-pristine/jira.properties
 


### PR DESCRIPTION
To prevent a bunch of warning messages during Karaf startup.

* JIRA: http://issues.opennms.org/browse/HZN-950
