### PR TITLE
HZN-492: add jicmp* dependencies to Minion

### DIFF
--- a/opennms-assemblies/minion/src/main/filtered/debian/control
+++ b/opennms-assemblies/minion/src/main/filtered/debian/control
@@ -16,7 +16,7 @@ Description: distributed OpenNMS monitoring client
 
 Package: opennms-minion-container
 Architecture: all
-Depends: oracle-java8-installer | openjdk-8-jre | java8-runtime | java8-runtime-headless, adduser, openssh-client, uuid-runtime, sudo
+Depends: oracle-java8-installer | openjdk-8-jre | java8-runtime | java8-runtime-headless, adduser, openssh-client, uuid-runtime, sudo, jicmp (>= 2.0.0), jicmp6 (>= 2.0.0)
 Description: distributed OpenNMS monitoring client (main container)
  OpenNMS Minion is a container infrastructure for distributed, scalable network
  management and monitoring.

--- a/tools/packages/minion/minion.spec
+++ b/tools/packages/minion/minion.spec
@@ -89,6 +89,10 @@ Requires(pre):  %{name}-container = %{version}-%{release}
 Requires:       %{name}-container = %{version}-%{release}
 Requires(post): util-linux
 Requires:       util-linux
+Requires:       jicmp >= 2.0.0
+Requires(pre):  jicmp >= 2.0.0
+Requires:       jicmp6 >= 2.0.0
+Requires(pre):  jicmp6 >= 2.0.0
 
 %description features-core
 Minion Core Features


### PR DESCRIPTION
This PR adds JICMP and JICMP6 as dependencies to the RPM and Debian Minion packages.  I have confirmed on both platforms that the Minion uses the BestMatchPinger properly, and ends up with the JNI version(s) of the plugins.

* JIRA: http://issues.opennms.org/browse/HZN-492

Our [continuous integration system](http://bamboo.internal.opennms.com:8085) will test and verify your changes.
