### PR TITLE
NMS-9369: Update business service states properly when alarms are deleted

### DIFF
--- a/features/bsm/daemon/pom.xml
+++ b/features/bsm/daemon/pom.xml
@@ -112,5 +112,15 @@
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.jayway.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-library</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/features/bsm/service/api/src/main/java/org/opennms/netmgt/bsm/service/BusinessServiceStateMachine.java
+++ b/features/bsm/service/api/src/main/java/org/opennms/netmgt/bsm/service/BusinessServiceStateMachine.java
@@ -96,6 +96,15 @@ public interface BusinessServiceStateMachine {
     void handleNewOrUpdatedAlarm(AlarmWrapper alarm);
 
     /**
+     * Updates the states of the Business Services using the given list of alarms.
+     *
+     * The given list of alarms is expected to be the complete set of current alarms,
+     * and any alarms missing from this list will be treated as not being present.
+     *
+     */
+    void handleAllAlarms(List<AlarmWrapper> alarms);
+
+    /**
      * Registers a state change handler.
      *
      * @param handler handler to register

--- a/features/bsm/service/api/src/main/java/org/opennms/netmgt/bsm/service/model/AlarmWrapper.java
+++ b/features/bsm/service/api/src/main/java/org/opennms/netmgt/bsm/service/model/AlarmWrapper.java
@@ -34,6 +34,4 @@ public interface AlarmWrapper {
 
     Status getStatus();
 
-    Integer getId();
-
 }

--- a/features/bsm/service/impl/src/main/java/org/opennms/netmgt/bsm/service/internal/AlarmWrapperImpl.java
+++ b/features/bsm/service/impl/src/main/java/org/opennms/netmgt/bsm/service/internal/AlarmWrapperImpl.java
@@ -38,13 +38,11 @@ public class AlarmWrapperImpl implements AlarmWrapper {
 
     private final String m_reductionKey;
     private final Status m_status;
-    private final Integer m_id;
 
     public AlarmWrapperImpl(OnmsAlarm alarm) {
         Objects.requireNonNull(alarm);
         m_reductionKey = alarm.getReductionKey();
         m_status = SeverityMapper.toStatus(alarm.getSeverity());
-        m_id = alarm.getId();
     }
 
     @Override
@@ -58,7 +56,22 @@ public class AlarmWrapperImpl implements AlarmWrapper {
     }
 
     @Override
-    public Integer getId() {
-        return m_id;
+    public boolean equals(final Object other) {
+        if (!(other instanceof AlarmWrapperImpl)) {
+            return false;
+        }
+        AlarmWrapperImpl castOther = (AlarmWrapperImpl) other;
+        return Objects.equals(m_reductionKey, castOther.m_reductionKey) && Objects.equals(m_status, castOther.m_status);
     }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(m_reductionKey, m_status);
+    }
+
+    @Override
+    public String toString() {
+        return String.format("AlarmWrapperImpl[reductionKey=%s, status=%s]", m_reductionKey, m_status);
+    }
+
 }

--- a/features/bsm/test-util/src/main/java/org/opennms/netmgt/bsm/mock/MockAlarmWrapper.java
+++ b/features/bsm/test-util/src/main/java/org/opennms/netmgt/bsm/mock/MockAlarmWrapper.java
@@ -50,9 +50,4 @@ public class MockAlarmWrapper implements AlarmWrapper {
         return m_status;
     }
 
-    @Override
-    public Integer getId() {
-        return Integer.valueOf(0);
-    }
-
 }

--- a/features/bsm/test-util/src/main/java/org/opennms/netmgt/bsm/test/BsmTestUtils.java
+++ b/features/bsm/test-util/src/main/java/org/opennms/netmgt/bsm/test/BsmTestUtils.java
@@ -249,11 +249,6 @@ public class BsmTestUtils {
             public Status getStatus() {
                 return SeverityMapper.toStatus(alarm.getSeverity());
             }
-
-            @Override
-            public Integer getId() {
-                return alarm.getId();
-            }
         };
     }
 

--- a/features/events/api/src/main/java/org/opennms/netmgt/events/api/EventConstants.java
+++ b/features/events/api/src/main/java/org/opennms/netmgt/events/api/EventConstants.java
@@ -612,6 +612,8 @@ public abstract class EventConstants {
     public static final String PARM_ALARM_ID = "alarmId";
     /** Constant <code>PARM_ALARM_UEI="alarmUei"</code> */
     public static final String PARM_ALARM_UEI = "alarmUei";
+    /** Constant <code>PARM_ALARM_REDUCTION_KEY="alarmReductionKey"</code> */
+    public static final String PARM_ALARM_REDUCTION_KEY = "alarmReductionKey";
     /** Constant <code>PARM_TROUBLE_TICKET="troubleTicket"</code> */
     public static final String PARM_TROUBLE_TICKET = "troubleTicket";
 

--- a/features/events/api/src/main/java/org/opennms/netmgt/events/api/EventConstants.java
+++ b/features/events/api/src/main/java/org/opennms/netmgt/events/api/EventConstants.java
@@ -1109,6 +1109,8 @@ public abstract class EventConstants {
     public static final String ALARM_UNCLEARED_UEI = "uei.opennms.org/alarms/alarmUncleared";
     // Sent when an alarm is updated with a reduce event
     public static final String ALARM_UPDATED_WITH_REDUCED_EVENT_UEI = "uei.opennms.org/alarms/alarmUpdatedWithReducedEvent";
+    // Sent when an alarm is deleted
+    public static final String ALARM_DELETED_EVENT_UEI = "uei.opennms.org/alarms/alarmDeleted";
 
     //
     // for Bsmd

--- a/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.bsm/src/main/java/org/opennms/features/topology/plugins/topo/bsm/simulate/SimulationAwareStateMachineFactory.java
+++ b/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.bsm/src/main/java/org/opennms/features/topology/plugins/topo/bsm/simulate/SimulationAwareStateMachineFactory.java
@@ -81,11 +81,6 @@ public class SimulationAwareStateMachineFactory {
                 public Status getStatus() {
                     return entry.getValue();
                 }
-
-                @Override
-                public Integer getId() {
-                    return 0;
-                }
             });
         }
 

--- a/opennms-alarms/daemon/src/test/java/org/opennms/netmgt/alarmd/AlarmLifecycleEventsIT.java
+++ b/opennms-alarms/daemon/src/test/java/org/opennms/netmgt/alarmd/AlarmLifecycleEventsIT.java
@@ -31,6 +31,8 @@ package org.opennms.netmgt.alarmd;
 import static com.jayway.awaitility.Awaitility.await;
 import static java.util.concurrent.TimeUnit.MINUTES;
 
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.Date;
 import java.util.concurrent.Callable;
 
@@ -38,14 +40,18 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.opennms.core.criteria.Criteria;
+import org.opennms.core.criteria.restrictions.EqRestriction;
 import org.opennms.core.test.OpenNMSJUnit4ClassRunner;
 import org.opennms.core.test.db.MockDatabase;
 import org.opennms.core.test.db.TemporaryDatabaseAware;
 import org.opennms.core.test.db.annotations.JUnitTemporaryDatabase;
+import org.opennms.netmgt.dao.api.AlarmDao;
 import org.opennms.netmgt.dao.api.MonitoringLocationDao;
 import org.opennms.netmgt.dao.api.NodeDao;
 import org.opennms.netmgt.dao.mock.MockEventIpcManager;
 import org.opennms.netmgt.events.api.EventConstants;
+import org.opennms.netmgt.model.OnmsAlarm;
 import org.opennms.netmgt.model.OnmsNode;
 import org.opennms.netmgt.model.events.EventBuilder;
 import org.opennms.netmgt.vacuumd.Vacuumd;
@@ -53,6 +59,9 @@ import org.opennms.netmgt.xml.event.AlarmData;
 import org.opennms.test.JUnitConfigurationEnvironment;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.support.TransactionCallbackWithoutResult;
+import org.springframework.transaction.support.TransactionTemplate;
 
 /**
  * Used to verify that alarmd and vacuumd generate alarm
@@ -85,7 +94,13 @@ public class AlarmLifecycleEventsIT implements TemporaryDatabaseAware<MockDataba
     private NodeDao m_nodeDao;
 
     @Autowired
+    private AlarmDao m_alarmDao;
+
+    @Autowired
     private MockEventIpcManager m_eventMgr;
+
+    @Autowired
+    private TransactionTemplate transactionTemplate;
 
     private MockDatabase m_database;
 
@@ -165,6 +180,60 @@ public class AlarmLifecycleEventsIT implements TemporaryDatabaseAware<MockDataba
         // Wait until we've received the alarmUncleared event
         // We need to wait for the unclear automation, which currently runs every 30 seconds
         await().atMost(1, MINUTES).until(allAnticipatedEventsWereReceived());
+    }
+
+    @Test
+    public void canGenerateAlarmDeletedLifecycleEvents() {
+        // Expect an alarmCreated event
+        m_eventMgr.getEventAnticipator().resetAnticipated();
+        m_eventMgr.getEventAnticipator().anticipateEvent(new EventBuilder(EventConstants.ALARM_CREATED_UEI, "alarmd").getEvent());
+        m_eventMgr.getEventAnticipator().setDiscardUnanticipated(true);
+
+        // Send a nodeDown
+        sendNodeDownEvent(1);
+
+        // Wait until we've received the alarmCreated event
+        await().until(allAnticipatedEventsWereReceived());
+
+        // Expect an alarmCreated and a alarmCleared event
+        m_eventMgr.getEventAnticipator().resetAnticipated();
+        m_eventMgr.getEventAnticipator().anticipateEvent(new EventBuilder(EventConstants.ALARM_CREATED_UEI, "alarmd").getEvent());
+        m_eventMgr.getEventAnticipator().anticipateEvent(new EventBuilder(EventConstants.ALARM_CLEARED_UEI, "alarmd").getEvent());
+        m_eventMgr.getEventAnticipator().setDiscardUnanticipated(true);
+
+        // Send a nodeUp
+        sendNodeUpEvent(1);
+
+        // Wait until we've received the alarmCreated and alarmCleared events
+        // We need to wait for the cosmicClear automation, which currently runs every 30 seconds
+        await().atMost(1, MINUTES).until(allAnticipatedEventsWereReceived());
+
+        // Expect an alarmDeleted event
+        m_eventMgr.getEventAnticipator().anticipateEvent(new EventBuilder(EventConstants.ALARM_DELETED_EVENT_UEI, "alarmd").getEvent());
+        m_eventMgr.getEventAnticipator().setDiscardUnanticipated(true);
+
+        // We need to wait for the cleanUp automation, which currently runs every 60 seconds
+        // but it will only trigger then 'lastautomationtime' and 'lasteventtime' < "5 minutes ago"
+        // so we cheat a little and update the timestamps ourselves instead of waiting
+        transactionTemplate.execute(new TransactionCallbackWithoutResult() {
+            @Override
+            protected void doInTransactionWithoutResult(TransactionStatus status) {
+                Criteria criteria = new Criteria(OnmsAlarm.class);
+                criteria.addRestriction(new EqRestriction("node.id", 1));
+                criteria.addRestriction(new EqRestriction("uei", EventConstants.NODE_DOWN_EVENT_UEI));
+                for (OnmsAlarm alarm : m_alarmDao.findMatching(criteria)) {
+                    LocalDateTime tenMinutesAgo = LocalDateTime.now().minusMinutes(10);
+                    Date then = Date.from(tenMinutesAgo.toInstant(ZoneOffset.UTC));
+                    alarm.setLastAutomationTime(then);
+                    alarm.setLastEventTime(then);
+                    m_alarmDao.save(alarm);
+                }
+                m_alarmDao.flush();
+            }
+        });
+
+        // Wait until we've received the alarmDeleted event
+        await().atMost(2, MINUTES).until(allAnticipatedEventsWereReceived());
     }
 
     public Callable<Boolean> allAnticipatedEventsWereReceived() {

--- a/opennms-base-assembly/src/main/filtered/etc/events/opennms.events.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/events/opennms.events.xml
@@ -2025,6 +2025,15 @@
     <logmsg dest="donotpersist">Alarm with id %parm[alarmId]% was updated by a reduced event.</logmsg>
     <severity>Normal</severity>
   </event>
+  <event>
+    <uei>uei.opennms.org/alarms/alarmDeleted</uei>
+    <event-label>OpenNMS-defined internal event: alarmDeleted</event-label>
+    <descr>
+        &lt;p&gt;Alarm with reduction key %param[reductionkey] and id: %parm[alarmId]% was deleted.
+    </descr>
+    <logmsg dest="donotpersist">Alarm with id %parm[alarmId]% was deleted.</logmsg>
+    <severity>Normal</severity>
+  </event>
 
   <event>
     <uei>uei.opennms.org/bsm/serviceOperationalStatusChanged</uei>

--- a/opennms-base-assembly/src/main/filtered/etc/events/opennms.events.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/events/opennms.events.xml
@@ -2029,7 +2029,7 @@
     <uei>uei.opennms.org/alarms/alarmDeleted</uei>
     <event-label>OpenNMS-defined internal event: alarmDeleted</event-label>
     <descr>
-        &lt;p&gt;Alarm with reduction key %param[reductionkey] and id: %parm[alarmId]% was deleted.
+        &lt;p&gt;Alarm with reduction key %param[reductionkey] and id: %parm[alarmId]% was deleted.&lt;/p&gt;
     </descr>
     <logmsg dest="donotpersist">Alarm with id %parm[alarmId]% was deleted.</logmsg>
     <severity>Normal</severity>

--- a/opennms-base-assembly/src/main/filtered/etc/vacuumd-configuration.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/vacuumd-configuration.xml
@@ -37,17 +37,25 @@
                 action-event="sendAlarmClearedEvent" />
 
     <automation name="cleanUp" interval="60000" active="true"
-                action-name="deletePastClearedAlarms" />
+                trigger-name="selectPastClearedAlarmsToDelete"
+                action-name="deleteAlarms"
+                action-event="sendAlarmDeletedEvent" />
                 
     <automation name="fullCleanUp" interval="300000" active="true" 
-                action-name="deleteAllPastClearedAlarms" />
-                
+                trigger-name="selectAllPastClearedAlarmsToDelete"
+                action-name="deleteAlarms"
+                action-event="sendAlarmDeletedEvent" />
+
     <automation name="GC" interval="300000" active="true" 
-                action-name="garbageCollect" />
-                
+                trigger-name="selectAlarmsToGarbageCollect"
+                action-name="deleteAlarms"
+                action-event="sendAlarmDeletedEvent" />
+
     <automation name="fullGC" interval="300000" active="true" 
-                action-name="fullGarbageCollect" />
-                
+                trigger-name="selectAlarmsToFullGarbageCollect"
+                action-name="deleteAlarms"
+                action-event="sendAlarmDeletedEvent" />
+
     <automation name="unclear" interval="30000"  active="true" 
                 trigger-name="selectClearedAlarms" 
                 action-name="resetSeverity"
@@ -231,6 +239,48 @@
       </statement>
     </trigger>
 
+    <!-- Find cleared alarms that can be deleted -->
+    <!--  ticket state of 5 is closed, 11 is canceled -->
+    <trigger name="selectPastClearedAlarmsToDelete" operator="&gt;=" row-count="1" >
+      <statement>
+        SELECT alarmid, eventuei, reductionkey, now() AS _ts
+          FROM alarms
+         WHERE severity &lt;= 3
+           AND COALESCE(lastautomationtime, lasteventtime) &lt; now() - interval '5 minutes'
+           AND (alarmacktime IS NULL AND (tticketState IS NULL OR tticketState = 5  OR tticketState = 11))
+      </statement>
+    </trigger>
+
+    <!-- Find cleared alarms that can be deleted -->
+    <!-- May need to add a check for Open ticket state and wait for the state to be closed based on
+         update ticket action-event -->
+    <trigger name="selectAllPastClearedAlarmsToDelete" operator="&gt;=" row-count="1" >
+      <statement>
+        SELECT alarmid, eventuei, reductionkey, now() AS _ts
+          FROM alarms
+         WHERE severity &lt;= 3
+           AND COALESCE(lastautomationtime, lasteventtime) &lt; now() - interval '24 hours'
+           AND (tticketState IS NULL OR tticketState = 5 OR tticketState = 11)
+      </statement>
+    </trigger>
+
+    <trigger name="selectAlarmsToGarbageCollect" operator="&gt;=" row-count="1" >
+      <statement>
+        SELECT alarmid, eventuei, reductionkey, now() AS _ts
+          FROM alarms
+         WHERE COALESCE(lastautomationtime, lasteventtime) &lt; now() - interval '3 days'
+           AND alarmacktime IS NULL
+      </statement>
+    </trigger>
+
+    <trigger name="selectAlarmsToFullGarbageCollect" operator="&gt;=" row-count="1" >
+      <statement>
+        SELECT alarmid, eventuei, reductionkey, now() AS _ts
+          FROM alarms
+         WHERE COALESCE(lastautomationtime, lasteventtime) &lt; now() - interval '8 days'
+      </statement>
+    </trigger>
+
     <!-- Find assets that have maintenance-contract that will expire in less then 30 days -->
     <!-- 
     <trigger name="selectExpirationMaintenance" operator="&gt;=" row-count="1" >
@@ -314,63 +364,13 @@
       </statement>
     </action>
 
-    <!-- action used for postgres 7.4 compatibility -->
-    <action name="garbageCollect" >
+    <action name="deleteAlarms" >
       <statement>
         DELETE FROM alarms
-         WHERE COALESCE(lastautomationtime, lasteventtime) &lt; now() - interval '3 days'
-           AND alarmacktime IS NULL
-      </statement>
-    </action>
-  
-    <!-- a better action when using postgres 8.1 
-    <action name="garbageCollect" >
-      <statement>
-        DELETE FROM alarms
-         WHERE GREATEST(lastautomationtime, lasteventtime) &lt; now() - interval '3 days'
-           AND alarmacktime IS NULL
-      </statement>
-    </action>
-    -->
-  
-    <!-- action used for postgres 7.4 compatibility -->
-    <action name="fullGarbageCollect" >
-      <statement>
-        DELETE FROM alarms
-         WHERE COALESCE(lastautomationtime, lasteventtime) &lt; now() - interval '8 days'
-      </statement>
-    </action>
-  
-    <!-- a better action when using postgres 8.1 
-    <action name="fullGarbageCollect" >
-      <statement>
-        DELETE FROM alarms
-         WHERE GREATEST(lastautomationtime, lasteventtime) &lt; now() - interval '8 days'
-      </statement>
-    </action>
-    -->
-    
-    <!--  ticket state of 5 is closed, 11 is canceled -->
-    <action name="deletePastClearedAlarms" >
-      <statement>
-        DELETE FROM alarms
-         WHERE severity &lt;= 3
-           AND COALESCE(lastautomationtime, lasteventtime) &lt; now() - interval '5 minutes'
-           AND (alarmacktime IS NULL AND (tticketState IS NULL OR tticketState = 5  OR tticketState = 11))
+         WHERE alarmid = ${alarmid}
       </statement>
     </action>
 
-    <!-- May need to add a check for Open ticket state and wait for the state to be closed based on
-         update ticket action-event -->
-    <action name="deleteAllPastClearedAlarms" >
-      <statement>
-        DELETE from alarms
-         WHERE severity &lt;= 3
-           AND COALESCE(lastautomationtime, lasteventtime) &lt; now() - interval '24 hours'
-           AND (tticketState IS NULL OR tticketState = 5 OR tticketState = 11)
-      </statement>
-    </action>
-  
     <action name="clearAlarms" >
       <statement>
         UPDATE alarms
@@ -503,7 +503,14 @@
       <assignment type="parameter" name="alarmEventUei" value="${_eventUei}" />
     </action-event>
 
-    <!-- Monitoring maintenance conracts -->
+    <action-event name="sendAlarmDeletedEvent" for-each-result="true" >
+      <assignment type="field" name="uei" value="uei.opennms.org/alarms/alarmDeleted" />
+      <assignment type="parameter" name="alarmId" value="${alarmid}" />
+      <assignment type="parameter" name="alarmEventUei" value="${eventUei}" />
+      <assignment type="parameter" name="alarmReductionKey" value="${reductionkey}" />
+    </action-event>
+
+    <!-- Monitoring maintenance contracts -->
     <!--
     <action-event name="maintenanceExpirationWarning" for-each-result="true" >
       <assignment type="field" name="uei" value="uei.opennms.org/asset/maintenance/expirationWarning" />


### PR DESCRIPTION
JIRA: https://issues.opennms.org/browse/NMS-9369

Here we introduce a new 'alarmDelete' lifecycle event and update the default automations responsible for deleting alarms to generate these. We also add support to bsmd for handling these, and making sure that deleted alarms are properly accounted for when performing the scheduled poll of the alarm table.

With these changes, if a business service references an alarm that is deleted by a vacuumd automation, it's state will be immediately updated. Similarly, if a business service references an alarm, and that alarm is deleted by some other means, the business service will be updated on the next poll.
