### PR TITLE
NMS-9374 Fixed Insert/Update OspfElement

### DIFF
--- a/opennms-model/src/main/java/org/opennms/netmgt/model/OspfElement.java
+++ b/opennms-model/src/main/java/org/opennms/netmgt/model/OspfElement.java
@@ -312,7 +312,9 @@ public final class OspfElement implements Serializable {
 		setOspfRouterId(element.getOspfRouterId());
 		setOspfRouterIdIfindex(element.getOspfRouterIdIfindex());
 		setOspfRouterIdNetmask(element.getOspfRouterIdNetmask());
-		
+		setOspfAdminStat(element.getOspfAdminStat());
+		setOspfASBdrRtrStatus(element.getOspfASBdrRtrStatus());
+		setOspfBdrRtrStatus(element.getOspfASBdrRtrStatus());
 		setOspfNodeLastPollTime(element.getOspfNodeCreateTime());
 	}
 

--- a/opennms-services/src/main/java/org/opennms/netmgt/enlinkd/snmp/OspfIpAddrTableGetter.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/enlinkd/snmp/OspfIpAddrTableGetter.java
@@ -52,6 +52,8 @@ public class OspfIpAddrTableGetter extends SnmpGetter {
     public OspfElement get(OspfElement element) {
         //loopback mask by default
         element.setOspfRouterIdNetmask(InetAddressUtils.addr("255.255.255.255"));
+        //-1 ifindex by default
+        element.setOspfRouterIdIfindex(-1);
         List<SnmpValue> val = get(element.getOspfRouterId());
         if (val != null && val.size() == 2) {
             if (!val.get(0).isNull() && val.get(0).isNumeric())


### PR DESCRIPTION

NMS-9374: Insert/Update OspfElement: null value in column "ospfrouteridifindex" violates not-null constrain

* JIRA: http://issues.opennms.org/browse/NMS-9374

Our [continuous integration system](http://bamboo.internal.opennms.com:8085) will test and verify your changes.
