### PR TITLE
NMS-9371: Improve heartbeat generation and handling

### DIFF
--- a/features/minion/heartbeat/common/src/main/java/org/opennms/minion/heartbeat/common/MinionIdentityDTO.java
+++ b/features/minion/heartbeat/common/src/main/java/org/opennms/minion/heartbeat/common/MinionIdentityDTO.java
@@ -28,6 +28,7 @@
 
 package org.opennms.minion.heartbeat.common;
 
+import java.util.Date;
 import java.util.Objects;
 
 import javax.xml.bind.annotation.XmlAccessType;
@@ -46,6 +47,8 @@ public class MinionIdentityDTO implements Message {
     private String id;
     @XmlElement(name = "location")
     private String location;
+    @XmlElement(name = "timestamp")
+    private Date timestamp;
 
     public MinionIdentityDTO() {
 
@@ -54,6 +57,7 @@ public class MinionIdentityDTO implements Message {
     public MinionIdentityDTO(MinionIdentity minion) {
         id = minion.getId();
         location = minion.getLocation();
+        timestamp = new Date();
     }
 
     public String getId() {
@@ -72,9 +76,17 @@ public class MinionIdentityDTO implements Message {
         this.location = location;
     }
 
+    public Date getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(Date timestamp) {
+        this.timestamp = timestamp;
+    }
+
     @Override
     public int hashCode() {
-        return Objects.hash(id, location);
+        return Objects.hash(id, location, timestamp);
     }
 
     @Override
@@ -87,11 +99,12 @@ public class MinionIdentityDTO implements Message {
             return false;
         MinionIdentityDTO other = (MinionIdentityDTO) obj;
         return Objects.equals(this.id, other.id)
-                && Objects.equals(this.location, other.location);
+                && Objects.equals(this.location, other.location)
+                && Objects.equals(this.timestamp, other.timestamp);
     }
 
     @Override
     public String toString() {
-        return String.format("MinionIdentityDTO[id=%s, location=%s]", id, location);
+        return String.format("MinionIdentityDTO[id=%s, location=%s, timestamp=%s]", id, location, timestamp);
     }
 }

--- a/features/minion/heartbeat/common/src/test/java/org/opennms/minion/heartbeat/common/MinionIdentityDTOTest.java
+++ b/features/minion/heartbeat/common/src/test/java/org/opennms/minion/heartbeat/common/MinionIdentityDTOTest.java
@@ -31,9 +31,11 @@ package org.opennms.minion.heartbeat.common;
 import java.text.ParseException;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Date;
 
 import org.junit.runners.Parameterized.Parameters;
 import org.opennms.core.test.xml.XmlTestNoCastor;
+import org.opennms.core.utils.StringUtils;
 
 public class MinionIdentityDTOTest extends XmlTestNoCastor<MinionIdentityDTO> {
 
@@ -43,15 +45,18 @@ public class MinionIdentityDTOTest extends XmlTestNoCastor<MinionIdentityDTO> {
 
     @Parameters
     public static Collection<Object[]> data() throws ParseException {
+        Date timestamp = new Date(0);
         MinionIdentityDTO identity = new MinionIdentityDTO();
         identity.setId("idx");
         identity.setLocation("locationx");
+        identity.setTimestamp(timestamp);
         return Arrays.asList(new Object[][] {
             {
                 identity,
                 "<minion>\n" +
                    "<id>idx</id>\n" +
                    "<location>locationx</location>\n" +
+                   "<timestamp>" + StringUtils.iso8601LocalOffsetString(timestamp) + "</timestamp>\n" +
                 "</minion>",
                 null, }
         });

--- a/features/minion/heartbeat/producer/src/main/java/org/opennms/minion/heartbeat/producer/HeartbeatProducer.java
+++ b/features/minion/heartbeat/producer/src/main/java/org/opennms/minion/heartbeat/producer/HeartbeatProducer.java
@@ -28,6 +28,7 @@
 
 package org.opennms.minion.heartbeat.producer;
 
+import java.util.Date;
 import java.util.Timer;
 import java.util.TimerTask;
 
@@ -57,6 +58,9 @@ public class HeartbeatProducer {
                 try {
                     LOG.info("Sending heartbeat to Minion with id: {} at location: {}",
                             identity.getId(), identity.getLocation());
+                    // We reuse the same DTO instead of creating a new object
+                    // on every trigger, so we need to update the timestamp each time
+                    identityDTO.setTimestamp(new Date());
                     dispatcher.send(identityDTO);
                 } catch (Throwable t) {
                     LOG.error("An error occured while sending the heartbeat. Will try again in {} ms", PERIOD_MS, t);

--- a/features/minion/heartbeat/producer/src/main/java/org/opennms/minion/heartbeat/producer/HeartbeatProducer.java
+++ b/features/minion/heartbeat/producer/src/main/java/org/opennms/minion/heartbeat/producer/HeartbeatProducer.java
@@ -51,7 +51,7 @@ public class HeartbeatProducer {
         final MinionIdentityDTO identityDTO = new MinionIdentityDTO(identity);
         final SyncDispatcher<MinionIdentityDTO> dispatcher = messageDispatcherFactory.createSyncDispatcher(new HeartbeatModule());
         timer = new Timer();
-        timer.scheduleAtFixedRate(new TimerTask() {
+        timer.schedule(new TimerTask() {
             @Override
             public void run() {
                 try {


### PR DESCRIPTION
JIRA: https://issues.opennms.org/browse/NMS-9371

Improve the heartbeat generation to avoid generating floods of messages after being disconnected for a long period, and include timestamps o avoid processing stale messages.
