### PR TITLE
NMS-9382: Recommend using the failover: protocol when configuring Minion.

### DIFF
--- a/opennms-doc/guide-install/src/asciidoc/text/minion/configure-minion.adoc
+++ b/opennms-doc/guide-install/src/asciidoc/text/minion/configure-minion.adoc
@@ -18,10 +18,13 @@ NOTE: By default the _Minion_ is configured to communicate with _{opennms-produc
 ...
 admin@minion()> config:edit org.opennms.minion.controller
 admin@minion()> config:property-set http-url http://opennms-fqdn:8980/opennms
-admin@minion()> config:property-set broker-url tcp://opennms-fqdn:61616
+admin@minion()> config:property-set broker-url failover:tcp://opennms-fqdn:61616
 admin@minion()> config:property-set location Office-Pittsboro
 admin@minion()> config:update
 ----
+
+TIP: Include the `failover:` portion of the broker URL to allow the _Minion_ to re-establish connectivity on failure.
+     For a reference on the different URL formats, see http://activemq.apache.org/uri-protocols.html[ActiveMQ URI Protocols].
 
 .Configure the credentials to use when communicating with _OpenNMS_
 [source]


### PR DESCRIPTION
JIRA: https://issues.opennms.org/browse/NMS-9382