### PR TITLE
NMS-9383: DNS test-api should support more than just A or AAAA records

### DIFF
--- a/core/test-api/dns/src/main/java/org/opennms/core/test/dns/JUnitDNSServerExecutionListener.java
+++ b/core/test-api/dns/src/main/java/org/opennms/core/test/dns/JUnitDNSServerExecutionListener.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2011-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2011-2017 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -28,6 +28,8 @@
 
 package org.opennms.core.test.dns;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.opennms.core.test.OpenNMSAbstractTestExecutionListener;
 import org.opennms.core.test.dns.annotations.DNSEntry;
 import org.opennms.core.test.dns.annotations.DNSZone;
@@ -39,11 +41,16 @@ import org.springframework.test.context.TestContext;
 import org.springframework.test.context.TestExecutionListener;
 import org.xbill.DNS.AAAARecord;
 import org.xbill.DNS.ARecord;
+import org.xbill.DNS.CNAMERecord;
 import org.xbill.DNS.DClass;
+import org.xbill.DNS.MXRecord;
 import org.xbill.DNS.NSRecord;
 import org.xbill.DNS.Name;
+import org.xbill.DNS.PTRRecord;
 import org.xbill.DNS.Record;
 import org.xbill.DNS.SOARecord;
+import org.xbill.DNS.SRVRecord;
+import org.xbill.DNS.TXTRecord;
 import org.xbill.DNS.Zone;
 
 /**
@@ -51,11 +58,15 @@ import org.xbill.DNS.Zone;
  * and uses attributes on it to launch a temporary HTTP server for use during unit tests.
  */
 public class JUnitDNSServerExecutionListener extends OpenNMSAbstractTestExecutionListener {
-	
+
 	private static final Logger LOG = LoggerFactory.getLogger(JUnitDNSServerExecutionListener.class);
-	
+
     private static final int DEFAULT_TTL = 3600;
     private DNSServer m_server;
+
+    private static final Pattern s_mxPattern = Pattern.compile("^(\\d+)\\s+(.*)$");
+    private static final Pattern s_soaPattern = Pattern.compile("^(\\S+) (\\S+) (\\d+) (\\d+) (\\d+) (\\d+) (\\d+)$");
+    private static final Pattern s_srvPattern = Pattern.compile("^(\\d+) (\\d+) (\\d+) (\\S+)$");
 
     /** {@inheritDoc} */
     @Override
@@ -89,15 +100,60 @@ public class JUnitDNSServerExecutionListener extends OpenNMSAbstractTestExecutio
             });
             LOG.debug("zone = {}", zone);
 
+            Matcher m;
             for (final DNSEntry entry : dnsZone.entries()) {
                 LOG.debug("adding entry: {}", entry);
                 String hostname = entry.hostname();
                 final Name recordName = Name.fromString(hostname, zoneName);
                 LOG.debug("name = {}", recordName);
-                if (entry.ipv6()) {
-                    zone.addRecord(new AAAARecord(recordName, DClass.IN, DEFAULT_TTL, InetAddressUtils.addr(entry.address())));
-                } else {
-                    zone.addRecord(new ARecord(recordName, DClass.IN, DEFAULT_TTL, InetAddressUtils.addr(entry.address())));
+                switch (entry.type()) {
+                    case "A":
+                        zone.addRecord(new ARecord(recordName, DClass.value(entry.dclass()), DEFAULT_TTL, InetAddressUtils.addr(entry.data())));
+                        break;
+                    case "AAAA":
+                        zone.addRecord(new AAAARecord(recordName, DClass.value(entry.dclass()), DEFAULT_TTL, InetAddressUtils.addr(entry.data())));
+                        break;
+                    case "CNAME":
+                        zone.addRecord(new CNAMERecord(recordName, DClass.value(entry.dclass()), DEFAULT_TTL, Name.fromString(entry.data())));
+                        break;
+                    case "NS":
+                        zone.addRecord(new NSRecord(recordName, DClass.value(entry.dclass()), DEFAULT_TTL, Name.fromString(entry.data())));
+                        break;
+                    case "MX":
+                        m = s_mxPattern.matcher(entry.data());
+                        if (m.matches()) {
+                            zone.addRecord(new MXRecord(recordName, DClass.value(entry.dclass()), DEFAULT_TTL, Integer.valueOf(m.group(1)), Name.fromString(m.group(2))));
+                        } else {
+                            LOG.error("Entry data '{}' does not match MX pattern", entry.data());
+                        }
+                        break;
+                    case "PTR":
+                        zone.addRecord(new PTRRecord(recordName, DClass.value(entry.dclass()), DEFAULT_TTL, Name.fromString(entry.data())));
+                        break;
+                    case "SOA":
+                        m = s_soaPattern.matcher(entry.data());
+                        if (m.matches()) {
+                            zone.addRecord(new SOARecord(recordName, DClass.value(entry.dclass()), DEFAULT_TTL, Name.fromString(m.group(1)), Name.fromString(m.group(2)),
+                              Long.valueOf(m.group(3)), Long.valueOf(m.group(4)), Long.valueOf(m.group(5)), Long.valueOf(m.group(6)), Long.valueOf(m.group(7))));
+                        } else {
+                            LOG.error("Entry data '{}' does not match SOA pattern", entry.data());
+                        }
+                        break;
+                    case "SRV":
+                        m = s_srvPattern.matcher(entry.data());
+                        if (m.matches()) {
+                            zone.addRecord(new SRVRecord(recordName, DClass.value(entry.dclass()), DEFAULT_TTL, Integer.valueOf(m.group(1)), Integer.valueOf(m.group(2)),
+                              Integer.valueOf(m.group(3)), Name.fromString(m.group(4))));
+                        } else {
+                            LOG.error("Entry data '{}' does not match MX pattern", entry.data());
+                        }
+                        break;
+                    case "TXT":
+                        zone.addRecord(new TXTRecord(recordName, DClass.value(entry.dclass()), DEFAULT_TTL, entry.data()));
+                        break;
+                    default:
+                        LOG.error("DNS entry type {} not supported.", entry.type());
+                        break;
                 }
             }
 

--- a/core/test-api/dns/src/main/java/org/opennms/core/test/dns/annotations/DNSEntry.java
+++ b/core/test-api/dns/src/main/java/org/opennms/core/test/dns/annotations/DNSEntry.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2010-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2010-2017 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -36,7 +36,8 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.ANNOTATION_TYPE})
 public @interface DNSEntry {
+    String dclass() default "IN";
+    String type() default "A";
     String hostname();
-    String address();
-    boolean ipv6() default false;
+    String data();
 }

--- a/features/poller/monitors/core/src/test/java/org/opennms/netmgt/poller/monitors/DNSResolutionMonitorTest.java
+++ b/features/poller/monitors/core/src/test/java/org/opennms/netmgt/poller/monitors/DNSResolutionMonitorTest.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2011-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2011-2017 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -29,6 +29,7 @@
 package org.opennms.netmgt.poller.monitors;
 
 import static org.junit.Assert.assertEquals;
+import static org.opennms.netmgt.poller.monitors.DNSResolutionMonitor.PARM_NAMESERVER;
 import static org.opennms.netmgt.poller.monitors.DNSResolutionMonitor.PARM_RESOLUTION_TYPE;
 import static org.opennms.netmgt.poller.monitors.DNSResolutionMonitor.PARM_RESOLUTION_TYPE_BOTH;
 import static org.opennms.netmgt.poller.monitors.DNSResolutionMonitor.PARM_RESOLUTION_TYPE_EITHER;
@@ -36,46 +37,80 @@ import static org.opennms.netmgt.poller.monitors.DNSResolutionMonitor.PARM_RESOL
 import static org.opennms.netmgt.poller.monitors.DNSResolutionMonitor.PARM_RESOLUTION_TYPE_V6;
 
 import java.net.InetAddress;
-import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.opennms.core.test.MockLogAppender;
+import org.opennms.core.test.OpenNMSJUnit4ClassRunner;
+import org.opennms.core.test.dns.annotations.DNSEntry;
+import org.opennms.core.test.dns.annotations.DNSZone;
+import org.opennms.core.test.dns.annotations.JUnitDNSServer;
 import org.opennms.netmgt.poller.PollStatus;
 import org.opennms.netmgt.poller.mock.MockMonitoredService;
+import org.opennms.test.JUnitConfigurationEnvironment;
+import org.springframework.test.context.ContextConfiguration;
 
 /**
  * DNSResolutionMonitorTest
  *
  * @author brozow
  */
+@RunWith(OpenNMSJUnit4ClassRunner.class)
+@ContextConfiguration(locations = {"classpath:/META-INF/opennms/emptyContext.xml"})
+@JUnitDNSServer(port = 9153, zones = {
+    @DNSZone(name = "example.com", entries = {
+        @DNSEntry(hostname = "test", data = "192.168.0.1")
+    })
+    ,
+
+    @DNSZone(name = "opennms.org", entries = {
+        @DNSEntry(hostname = "wipv6day", data = "192.168.0.2")
+        ,
+        @DNSEntry(hostname = "wipv6day", data = "fded:beef:cafe:1::63", type = "AAAA")
+        ,
+        @DNSEntry(hostname = "choopa-ipv4", data = "192.168.0.3")
+        ,
+        @DNSEntry(hostname = "choopa-ipv6", data = "fded:beef:cafe:1::64", type = "AAAA")
+        ,
+        @DNSEntry(hostname = "www", data = "web02.opennms.org.", type = "CNAME")
+        ,
+        @DNSEntry(hostname = "web02", data = "192.168.0.4", type = "A")
+        ,
+        @DNSEntry(hostname = "web02", data = "fded:beef:cafe:1::65", type = "AAAA"),})
+})
+@JUnitConfigurationEnvironment
 public class DNSResolutionMonitorTest {
-    
+
     @Before
     public void setUp() {
         MockLogAppender.setupLogging(true);
     }
-    
+
     @Test
     public void testPoll() throws Exception {
         MockMonitoredService dual = new MockMonitoredService(1, "wipv6day.opennms.org", InetAddress.getLocalHost(), "RESOLVE");
         MockMonitoredService v4only = new MockMonitoredService(1, "choopa-ipv4.opennms.org", InetAddress.getLocalHost(), "RESOLVE");
         MockMonitoredService v6only = new MockMonitoredService(1, "choopa-ipv6.opennms.org", InetAddress.getLocalHost(), "RESOLVE");
         MockMonitoredService neither = new MockMonitoredService(1, "no-such-name.example.com", InetAddress.getLocalHost(), "RESOLVE");
-        
+
         DNSResolutionMonitor monitor = new DNSResolutionMonitor();
 
-        Map<String, Object> v4Parms = Collections.<String, Object>singletonMap(PARM_RESOLUTION_TYPE,
-                                                                               PARM_RESOLUTION_TYPE_V4);
-        Map<String, Object> v6Parms = Collections.<String, Object>singletonMap(PARM_RESOLUTION_TYPE,
-                                                                               PARM_RESOLUTION_TYPE_V6);
-        Map<String, Object> bothParms = Collections.<String, Object>singletonMap(PARM_RESOLUTION_TYPE,
-                                                                                 PARM_RESOLUTION_TYPE_BOTH);
-        Map<String, Object> eitherParms = Collections.<String, Object>singletonMap(PARM_RESOLUTION_TYPE,
-                                                                                   PARM_RESOLUTION_TYPE_EITHER);
-        
-        
+        Map<String, Object> v4Parms = new HashMap<>();
+        v4Parms.put(PARM_RESOLUTION_TYPE, PARM_RESOLUTION_TYPE_V4);
+        v4Parms.put(PARM_NAMESERVER, "[::1]:9153");
+        Map<String, Object> v6Parms = new HashMap<>();
+        v6Parms.put(PARM_RESOLUTION_TYPE, PARM_RESOLUTION_TYPE_V6);
+        v6Parms.put(PARM_NAMESERVER, "[::1]:9153");
+        Map<String, Object> bothParms = new HashMap<>();
+        bothParms.put(PARM_RESOLUTION_TYPE, PARM_RESOLUTION_TYPE_BOTH);
+        bothParms.put(PARM_NAMESERVER, "[::1]:9153");
+        Map<String, Object> eitherParms = new HashMap<>();
+        eitherParms.put(PARM_RESOLUTION_TYPE, PARM_RESOLUTION_TYPE_EITHER);
+        eitherParms.put(PARM_NAMESERVER, "[::1]:9153");
+
         assertEquals(PollStatus.available(), monitor.poll(dual, v4Parms));
         assertEquals(PollStatus.available(), monitor.poll(dual, v6Parms));
         assertEquals(PollStatus.available(), monitor.poll(dual, bothParms));

--- a/features/poller/monitors/core/src/test/java/org/opennms/netmgt/poller/monitors/DnsMonitorIT.java
+++ b/features/poller/monitors/core/src/test/java/org/opennms/netmgt/poller/monitors/DnsMonitorIT.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2011-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2011-2017 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -64,16 +64,17 @@ import org.xbill.DNS.Type;
 @RunWith(OpenNMSJUnit4ClassRunner.class)
 @ContextConfiguration(locations={"classpath:/META-INF/opennms/emptyContext.xml"})
 @JUnitDNSServer(port=9153, zones={
-            @DNSZone(name="example.com", entries={
-                    @DNSEntry(hostname="test", address="192.168.0.1")
-            }),
-            @DNSZone(name="ipv6.example.com", entries= {
-                    @DNSEntry(hostname="ipv6test", address="2001:4860:8007::63", ipv6=true)
-            })
+    @DNSZone(name = "example.com", entries = {
+        @DNSEntry(hostname = "test", data = "192.168.0.1")
     })
+    ,
+    @DNSZone(name = "ipv6.example.com", entries = {
+        @DNSEntry(hostname = "ipv6test", data = "2001:4860:8007::63", type = "AAAA")
+    })
+})
 @JUnitConfigurationEnvironment
 public class DnsMonitorIT {
-    
+
     @Before
     public void setup() throws Exception {
         MockLogAppender.setupLogging(true);
@@ -86,7 +87,7 @@ public class DnsMonitorIT {
         // so it doesn't interact with the cache
         Options.set("verbose", "true");
     }
-    
+
     @Test
     public void testIPV6Response() throws UnknownHostException {
         final Map<String, Object> m = new ConcurrentSkipListMap<String, Object>();
@@ -98,12 +99,12 @@ public class DnsMonitorIT {
         m.put("retry", "1");
         m.put("timeout", "1000");
         m.put("lookup", "ipv6.example.com");
-        
+
         final PollStatus status = monitor.poll(svc, m);
         MockUtil.println("Reason: "+status.getReason());
         assertEquals(PollStatus.SERVICE_AVAILABLE, status.getStatusCode());
     }
-    
+
     @Test
     // type not found is still considered a valid response with the default response codes
     public void testNotFound() throws UnknownHostException {
@@ -116,12 +117,12 @@ public class DnsMonitorIT {
         m.put("retry", "2");
         m.put("timeout", "5000");
         m.put("lookup", "bogus.example.com");
-        
+
         final PollStatus status = monitor.poll(svc, m);
         MockUtil.println("Reason: "+status.getReason());
         assertEquals("Expected service to be available", PollStatus.SERVICE_AVAILABLE, status.getStatusCode());
     }
-    
+
     @Test
     // type not found is still considered a valid response with the default response codes
     public void testNotFoundWithCustomRcode() throws UnknownHostException {
@@ -135,12 +136,12 @@ public class DnsMonitorIT {
         m.put("timeout", "5000");
         m.put("lookup", "bogus.example.com");
         m.put("fatal-response-codes", "3");
-        
+
         final PollStatus status = monitor.poll(svc, m);
         MockUtil.println("Reason: "+status.getReason());
         assertEquals(PollStatus.SERVICE_UNAVAILABLE, status.getStatusCode());
     }
-    
+
     @Test
     public void testUnrecoverable() throws UnknownHostException {
         final Map<String, Object> m = new ConcurrentSkipListMap<String, Object>();
@@ -151,12 +152,12 @@ public class DnsMonitorIT {
         m.put("port", "9000");
         m.put("retry", "2");
         m.put("timeout", "500");
-        
+
         final PollStatus status = monitor.poll(svc, m);
         MockUtil.println("Reason: "+status.getReason());
         assertEquals(PollStatus.SERVICE_UNAVAILABLE, status.getStatusCode());
     }
-    
+
     @Test
     public void testDNSIPV4Response() throws UnknownHostException {
         final Map<String, Object> m = new ConcurrentSkipListMap<String, Object>();
@@ -168,12 +169,12 @@ public class DnsMonitorIT {
         m.put("retry", "1");
         m.put("timeout", "3000");
         m.put("lookup", "example.com");
-        
+
         final PollStatus status = monitor.poll(svc, m);
         MockUtil.println("Reason: "+status.getReason());
         assertEquals(PollStatus.SERVICE_AVAILABLE, status.getStatusCode());
     }
-    
+
     @Test
     public void testTooFewAnswers() throws UnknownHostException {
         final Map<String, Object> m = new ConcurrentSkipListMap<String, Object>();
@@ -186,12 +187,12 @@ public class DnsMonitorIT {
         m.put("timeout", "3000");
         m.put("lookup", "example.empty");
         m.put("min-answers", "1");
-        
+
         final PollStatus status = monitor.poll(svc, m);
         MockUtil.println("Reason: "+status.getReason());
         assertEquals(PollStatus.SERVICE_UNAVAILABLE, status.getStatusCode());
     }
-    
+
     @Test
     public void testTooManyAnswers() throws UnknownHostException {
         final Map<String, Object> m = new ConcurrentSkipListMap<String, Object>();
@@ -204,12 +205,12 @@ public class DnsMonitorIT {
         m.put("timeout", "3000");
         m.put("lookup", "example.com");
         m.put("max-answers", "0");
-        
+
         final PollStatus status = monitor.poll(svc, m);
         MockUtil.println("Reason: "+status.getReason());
         assertEquals(PollStatus.SERVICE_UNAVAILABLE, status.getStatusCode());
     }
-    
+
     @Test
     public void testDnsJavaResponse() throws IOException {
         final Lookup l = new Lookup("example.com");
@@ -220,14 +221,14 @@ public class DnsMonitorIT {
         resolver.setPort(9153);
         l.setResolver(resolver);
         l.run();
-        
+
         System.out.println("result: " + l.getResult());
         if(l.getResult() == Lookup.SUCCESSFUL) {
             System.out.println(l.getAnswers()[0].rdataToString());
         }
         assertTrue(l.getResult() == Lookup.SUCCESSFUL);
     }
-    
+
     @Test
     public void testDnsJavaQuadARecord() throws IOException {
         final Lookup l = new Lookup("ipv6.example.com", Type.AAAA);
@@ -238,14 +239,14 @@ public class DnsMonitorIT {
         resolver.setPort(9153);
         l.setResolver(resolver);
         l.run();
-        
+
         System.out.println("result: " + l.getResult());
         if(l.getResult() == Lookup.SUCCESSFUL) {
             System.out.println(l.getAnswers()[0].rdataToString());
         }
         assertTrue(l.getResult() == Lookup.SUCCESSFUL);
     }
-    
+
     @Test
     public void testDnsJavaWithDnsServer() throws TextParseException, UnknownHostException {
         final Lookup l = new Lookup("example.com", Type.AAAA);
@@ -256,14 +257,14 @@ public class DnsMonitorIT {
         resolver.setPort(9153);
         l.setResolver(resolver);
         l.run();
-        
+
         System.out.println("result: " + l.getResult());
         final Record[] answers = l.getAnswers();
         assertEquals(answers.length, 1);
-        
+
         final Record record = answers[0];
         System.err.println(record.getTTL());
-        
+
         if(l.getResult() == Lookup.SUCCESSFUL) {
             System.out.println(l.getAnswers()[0].rdataToString());
         }
@@ -277,13 +278,13 @@ public class DnsMonitorIT {
         // make sure we use a temporary cache so don't get results from a previously cached query
         // from another test
         l.setCache(null);
-        
+
         final SimpleResolver resolver = new SimpleResolver("::1");
         resolver.setPort(9153);
         l.setResolver(resolver);
         l.run();
-        
-        // and NXRRSET record should be sent meaning that the server has no records for 
+
+        // and NXRRSET record should be sent meaning that the server has no records for
         // example.com at all.  This results in a null answers.  This is result 4 I think
         System.out.println("result: " + l.getResult());
         final Record[] answers = l.getAnswers();

--- a/integrations/opennms-dns-provisioning-adapter/src/test/java/org/opennms/netmgt/provision/DnsProvisioningAdapterTest.java
+++ b/integrations/opennms-dns-provisioning-adapter/src/test/java/org/opennms/netmgt/provision/DnsProvisioningAdapterTest.java
@@ -68,13 +68,13 @@ import org.springframework.test.context.TestExecutionListeners;
 public class DnsProvisioningAdapterTest implements InitializingBean {
     @Autowired
     private DnsProvisioningAdapter m_adapter;
-    
+
     @Autowired
     private NodeDao m_nodeDao;
 
     private AdapterOperation m_addOperation;
     private AdapterOperation m_deleteOperation;
-    
+
     @Override
     public void afterPropertiesSet() throws Exception {
         BeanUtils.assertAutowiring(this);
@@ -88,7 +88,7 @@ public class DnsProvisioningAdapterTest implements InitializingBean {
         m_nodeDao.save(nb.getCurrentNode());
         m_nodeDao.flush();
 
-        // Call afterPropertiesSet() again so that the adapter is 
+        // Call afterPropertiesSet() again so that the adapter is
         // aware of the node that we just added.
         m_adapter.afterPropertiesSet();
 
@@ -97,7 +97,7 @@ public class DnsProvisioningAdapterTest implements InitializingBean {
             AdapterOperationType.ADD,
             new SimpleQueuedProvisioningAdapter.AdapterOperationSchedule(0, 1, 1, TimeUnit.SECONDS)
         );
-        
+
         m_deleteOperation = m_adapter.new AdapterOperation(
             m_nodeDao.findByForeignId("dns", "1").getId(),
             AdapterOperationType.DELETE,
@@ -107,21 +107,21 @@ public class DnsProvisioningAdapterTest implements InitializingBean {
 
     @Test
     @JUnitDNSServer(port=9153, zones={
-            @DNSZone(name="example.com", entries={
-                    @DNSEntry(hostname="test", address="192.168.0.1")
-            })
+        @DNSZone(name = "example.com", entries = {
+            @DNSEntry(hostname = "test", data = "192.168.0.1")
+        })
     })
     public void testAdd() throws Exception {
         OnmsNode n = m_nodeDao.findByForeignId("dns", "1");
         m_adapter.addNode(n.getId());
         m_adapter.processPendingOperationForNode(m_addOperation);
     }
-    
+
     @Test
     @JUnitDNSServer(port=9153, zones={
-            @DNSZone(name="example.com", entries={
-                    @DNSEntry(hostname="test", address="192.168.0.1")
-            })
+        @DNSZone(name = "example.com", entries = {
+            @DNSEntry(hostname = "test", data = "192.168.0.1")
+        })
     })
     public void testDelete() throws Exception {
         OnmsNode n = m_nodeDao.findByForeignId("dns", "1");

--- a/opennms-provision/opennms-detector-datagram/src/test/java/org/opennms/netmgt/provision/detector/DnsDetectorTest.java
+++ b/opennms-provision/opennms-detector-datagram/src/test/java/org/opennms/netmgt/provision/detector/DnsDetectorTest.java
@@ -57,9 +57,9 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 @ContextConfiguration(locations={"classpath:/META-INF/opennms/empty-context.xml"})
 @TestExecutionListeners(JUnitDNSServerExecutionListener.class)
 @JUnitDNSServer(port=9153, zones={
-        @DNSZone(name="google.com.", entries={
-                @DNSEntry(hostname="www", address="72.14.204.99")
-        })
+    @DNSZone(name = "google.com.", entries = {
+        @DNSEntry(hostname = "www", data = "72.14.204.99")
+    })
 })
 public class DnsDetectorTest {
 
@@ -75,7 +75,7 @@ public class DnsDetectorTest {
         //m_socket = new DatagramSocket(4445);
         //m_serverThread = createThread();
         //m_serverThread.start();
-    } 
+    }
 
     @After
     public void tearDown() {

--- a/opennms-provision/opennms-provisiond/src/test/java/org/opennms/netmgt/provision/service/ProvisionerIT.java
+++ b/opennms-provision/opennms-provisiond/src/test/java/org/opennms/netmgt/provision/service/ProvisionerIT.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2006-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2006-2017 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -364,17 +364,17 @@ public class ProvisionerIT extends ProvisioningITCase implements InitializingBea
     }
     /**
      * We have to ignore this test until there is a DNS service available in the test harness
-     * 
+     *
      * @throws ForeignSourceRepositoryException
      * @throws MalformedURLException
      */
     @Test(timeout=300000)
     @JUnitDNSServer(port=9153, zones={
-            @DNSZone(name="opennms.com.", v4address="1.2.3.4", entries={
-                    @DNSEntry(hostname="www", address="1.2.3.4")
-                    // V6 support is only in master right now
-                    // @DNSEntry(hostname="www", address="::1:2:3:4", ipv6=true)
-            })
+        @DNSZone(name = "opennms.com.", v4address = "1.2.3.4", entries = {
+            @DNSEntry(hostname = "www", data = "1.2.3.4")
+            ,
+            @DNSEntry(hostname = "www", data = "::1:2:3:4", type = "AAAA")
+        })
     })
     public void testDnsVisit() throws ForeignSourceRepositoryException, MalformedURLException {
         final Requisition requisition = m_foreignSourceRepository.importResourceRequisition(new UrlResource("dns://localhost:9153/opennms.com"));
@@ -1163,7 +1163,7 @@ public class ProvisionerIT extends ProvisioningITCase implements InitializingBea
     /**
      * This test first bulk imports 10 nodes then runs update with 1 node missing
      * from the import file.
-     * 
+     *
      * @throws ModelImportException
      */
     @Test(timeout=300000)
@@ -1173,7 +1173,7 @@ public class ProvisionerIT extends ProvisioningITCase implements InitializingBea
         m_provisioner.importModelFromResource(new ClassPathResource("/utf-8.xml"), Boolean.TRUE.toString());
 
         assertEquals(1, getNodeDao().countAll());
-        // \u00f1 is unicode for n~ 
+        // \u00f1 is unicode for n~
         final OnmsNode onmsNode = getNodeDao().get(nextNodeId);
         LOG.debug("node = {}", onmsNode);
         assertEquals("\u00f1ode2", onmsNode.getLabel());
@@ -1183,7 +1183,7 @@ public class ProvisionerIT extends ProvisioningITCase implements InitializingBea
     /**
      * This test first bulk imports 10 nodes then runs update with 1 node missing
      * from the import file.
-     * 
+     *
      * @throws ModelImportException
      */
     @Test(timeout=300000)
@@ -1447,7 +1447,7 @@ public class ProvisionerIT extends ProvisioningITCase implements InitializingBea
     /**
      * Test that the parent-foreign-source attribute in a requisition can add a parent to a
      * node that resides in a different provisioning group.
-     * 
+     *
      * @see http://issues.opennms.org/browse/NMS-4109
      */
     @Test(timeout=300000)
@@ -1780,13 +1780,13 @@ public class ProvisionerIT extends ProvisioningITCase implements InitializingBea
     private static Event nodeDeleted(int nodeid) {
         EventBuilder bldr = new EventBuilder(EventConstants.NODE_DELETED_EVENT_UEI, "Test");
         bldr.setNodeid(nodeid);
-        return bldr.getEvent();        
+        return bldr.getEvent();
     }
 
     private static Event deleteNode(int nodeid) {
         EventBuilder bldr = new EventBuilder(EventConstants.DELETE_NODE_EVENT_UEI, "Test");
         bldr.setNodeid(nodeid);
-        return bldr.getEvent();        
+        return bldr.getEvent();
     }
 
     private static Event interfaceDeleted(int nodeid, String ipaddr) {

--- a/opennms-provision/opennms-requisition-dns/src/test/java/org/opennms/netmgt/provision/service/dns/DnsRequisitionUrlConnectionIT.java
+++ b/opennms-provision/opennms-requisition-dns/src/test/java/org/opennms/netmgt/provision/service/dns/DnsRequisitionUrlConnectionIT.java
@@ -57,7 +57,7 @@ import java.net.URLConnection;
 
 /**
  * This class tests the new "dns" protocol handling created for the Provisioner.
- * 
+ *
  * @author <a href="mailto:david@opennms.org">David Hustace</a>
  *
  */
@@ -79,7 +79,7 @@ public class DnsRequisitionUrlConnectionIT {
     public void registerFactory() {
         GenericURLFactory.initialize();
     }
-    
+
     @Test
     public void dwoValidateMultipathUrl() throws MalformedURLException {
         DnsRequisitionUrlConnection c = new DnsRequisitionUrlConnection(new URL("dns://localhost/opennms"));
@@ -131,7 +131,7 @@ public class DnsRequisitionUrlConnectionIT {
         }
         Assert.assertNotNull(e);
         Assert.assertEquals("The specified DNS URL contains an invalid query string: dns://localhost/opennms/?string=abc[123]", e.getLocalizedMessage());
-        
+
     }
 
     @Test
@@ -149,9 +149,9 @@ public class DnsRequisitionUrlConnectionIT {
 
     @Test
     @JUnitDNSServer(port=9153, zones={
-            @DNSZone(name="example.com", entries={
-                    @DNSEntry(hostname="www", address="72.14.204.99")
-            })
+        @DNSZone(name = "example.com", entries = {
+            @DNSEntry(hostname = "www", data = "72.14.204.99")
+        })
     })
     public void dwoUrlAsResource() throws IOException, JAXBException {
         Resource resource = new UrlResource(TEST_URL);
@@ -172,10 +172,11 @@ public class DnsRequisitionUrlConnectionIT {
 
     @Test
     @JUnitDNSServer(port=9153, zones={
-            @DNSZone(name="example.com", entries={
-                    @DNSEntry(hostname="www", address="72.14.204.99"),
-                    @DNSEntry(hostname="monkey", address="72.14.204.99")
-            })
+        @DNSZone(name = "example.com", entries = {
+            @DNSEntry(hostname = "www", data = "72.14.204.99")
+            ,
+            @DNSEntry(hostname = "monkey", data = "72.14.204.99")
+        })
     })
     public void dwoUrlAsResourceUsingMatchingExpression() throws IOException, JAXBException {
         String urlString = "dns://localhost:9153/example.com/?expression=[Ww]ww.*";
@@ -197,10 +198,11 @@ public class DnsRequisitionUrlConnectionIT {
 
     @Test
     @JUnitDNSServer(port=9153, zones={
-            @DNSZone(name="example.com", entries={
-                    @DNSEntry(hostname="www", address="72.14.204.99"),
-                    @DNSEntry(hostname="monkey", address="72.14.204.99")
-            })
+        @DNSZone(name = "example.com", entries = {
+            @DNSEntry(hostname = "www", data = "72.14.204.99")
+            ,
+            @DNSEntry(hostname = "monkey", data = "72.14.204.99")
+        })
     })
     public void dwoUrlAsResourceUsingNonMatchingExpression() throws IOException, JAXBException {
         String urlString = "dns://localhost:9153/example.com/?expression=Local.*";
@@ -219,12 +221,12 @@ public class DnsRequisitionUrlConnectionIT {
         Assert.assertEquals(0, req.getNodeCount());
         resourceStream.close();
     }
-    
+
     @Test
     @JUnitDNSServer(port=9153, zones={
-            @DNSZone(name="example.com", entries={
-                    @DNSEntry(hostname="www", address="72.14.204.99")
-            })
+        @DNSZone(name = "example.com", entries = {
+            @DNSEntry(hostname = "www", data = "72.14.204.99")
+        })
     })
     public void dwoUrlAsResourceUsingComplexMatchingExpression() throws IOException, JAXBException {
         String urlString = "dns://localhost:9153/example.com/?expression=(%3Fi)^WWW.EXAM.*";
@@ -243,7 +245,7 @@ public class DnsRequisitionUrlConnectionIT {
         Assert.assertEquals(1, req.getNodeCount());
         resourceStream.close();
     }
-    
+
     @Test
     public void dwoDnsRequisitionUrlConnection() throws MalformedURLException {
         URLConnection c = new DnsRequisitionUrlConnection(new URL(TEST_URL));
@@ -256,9 +258,9 @@ public class DnsRequisitionUrlConnectionIT {
      */
     @Test
     @JUnitDNSServer(port=9153, zones={
-            @DNSZone(name="example.com", entries={
-                    @DNSEntry(hostname="www", address="72.14.204.99")
-            })
+        @DNSZone(name = "example.com", entries = {
+            @DNSEntry(hostname = "www", data = "72.14.204.99")
+        })
     })
     public void dwoConnect() throws IOException {
         URLConnection c = new DnsRequisitionUrlConnection(new URL(TEST_URL));
@@ -267,9 +269,9 @@ public class DnsRequisitionUrlConnectionIT {
 
     @Test
     @JUnitDNSServer(port=9153, zones={
-            @DNSZone(name="example.com", entries={
-                    @DNSEntry(hostname="www", address="72.14.204.99")
-            })
+        @DNSZone(name = "example.com", entries = {
+            @DNSEntry(hostname = "www", data = "72.14.204.99")
+        })
     })
     public void dwoGetInputStream() throws IOException {
         URLConnection c = new DnsRequisitionUrlConnection(new URL(TEST_URL));


### PR DESCRIPTION
This pull request is a combination pull request for two separate issues.

NMS-9383: DNS test-api should support more than just A or AAAA records
NMS-9378: The neither test in DNSResolutionMonitorTest fails (when DNS hijacking occurs by your ISP.)

* JIRA: http://issues.opennms.org/browse/NMS-9383