### PR TITLE
HZN-950: create sha1 files for Karaf repositories

### DIFF
--- a/container/karaf/pom.xml
+++ b/container/karaf/pom.xml
@@ -90,7 +90,7 @@
                             <goal>copy-resources</goal>
                         </goals>
                         <configuration>
-                            <outputDirectory>target/filtered-resources</outputDirectory>
+                            <outputDirectory>${project.build.directory}/filtered-resources</outputDirectory>
                             <resources>
                                 <resource>
                                     <directory>src/main/filtered-resources</directory>
@@ -100,6 +100,30 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>net.nicoulaj.maven.plugins</groupId>
+                <artifactId>checksum-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>prepare-package</phase>
+                        <goals><goal>files</goal></goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <algorithms><algorithm>SHA-1</algorithm></algorithms>
+                    <fileSets>
+                        <fileSet>
+                            <directory>${project.build.directory}/filtered-resources</directory>
+                            <includes>
+                                <include>**/*.jar</include>
+                                <include>**/*.pom</include>
+                                <include>**/*.war</include>
+                                <include>**/*.xml</include>
+                            </includes>
+                        </fileSet>
+                    </fileSets>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -134,7 +158,7 @@
                 <configuration>
                   <artifacts>
                     <artifact>
-                      <file>target/filtered-resources/features/features.xml</file>
+                      <file>${project.build.directory}/filtered-resources/features/features.xml</file>
                       <type>xml</type>
                       <classifier>features</classifier>
                     </artifact>

--- a/container/karaf/src/assembly/karaf.xml
+++ b/container/karaf/src/assembly/karaf.xml
@@ -34,7 +34,7 @@
                     <exclude>demos/*</exclude>
 
                     <!-- Get rid of the old Karaf features XML -->
-                    <exclude>**/org.opennms.container.standalone*-features.xml</exclude>
+                    <exclude>**/org.opennms.container.standalone*-features.xml*</exclude>
 
                     <!-- Get rid of any files that we replace with files from this project -->
                     <exclude>**/custom.properties</exclude>
@@ -48,7 +48,7 @@
 
     <fileSets>
         <fileSet>
-            <directory>target/filtered-resources/etc</directory>
+            <directory>${project.build.directory}/filtered-resources/etc</directory>
             <outputDirectory>etc</outputDirectory>
             <lineEnding>unix</lineEnding>
             <filtered>false</filtered>
@@ -57,9 +57,15 @@
 
     <files>
         <file>
-            <source>target/filtered-resources/features/features.xml</source>
+            <source>${project.build.directory}/filtered-resources/features/features.xml</source>
             <outputDirectory>system/org/opennms/container/${project.artifactId}/${project.version}</outputDirectory>
             <destName>${project.groupId}.${project.artifactId}-${project.version}-features.xml</destName>
+            <lineEnding>unix</lineEnding>
+        </file>
+        <file>
+            <source>${project.build.directory}/filtered-resources/features/features.xml.sha1</source>
+            <outputDirectory>system/org/opennms/container/${project.artifactId}/${project.version}</outputDirectory>
+            <destName>${project.groupId}.${project.artifactId}-${project.version}-features.xml.sha1</destName>
             <lineEnding>unix</lineEnding>
         </file>
     </files>

--- a/container/standalone/pom.xml
+++ b/container/standalone/pom.xml
@@ -177,6 +177,49 @@
         </executions>
       </plugin>
       <plugin>
+        <groupId>net.nicoulaj.maven.plugins</groupId>
+        <artifactId>checksum-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>prepare-package</phase>
+            <goals><goal>files</goal></goals>
+          </execution>
+        </executions>
+        <configuration>
+          <algorithms><algorithm>SHA-1</algorithm></algorithms>
+          <fileSets>
+            <fileSet>
+              <directory>${project.build.directory}/classes</directory>
+              <includes>
+                <include>**/*.jar</include>
+                <include>**/*.pom</include>
+                <include>**/*.war</include>
+                <include>**/*.xml</include>
+              </includes>
+            </fileSet>
+            <fileSet>
+              <directory>${project.build.directory}/dependencies/apache-karaf-${karafVersion}/system</directory>
+              <includes>
+                <include>**/*.jar</include>
+                <include>**/*.pom</include>
+                <include>**/*.war</include>
+                <include>**/*.xml</include>
+              </includes>
+            </fileSet>
+            <fileSet>
+              <directory>${project.build.directory}/features-repo</directory>
+              <includes>
+                <include>**/*.cfg</include>
+                <include>**/*.jar</include>
+                <include>**/*.pom</include>
+                <include>**/*.war</include>
+                <include>**/*.xml</include>
+              </includes>
+            </fileSet>
+          </fileSets>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
         <executions>

--- a/container/standalone/src/assembly/bin.xml
+++ b/container/standalone/src/assembly/bin.xml
@@ -16,7 +16,7 @@
 
         <!-- Expanded Karaf Standard Distribution -->
         <fileSet>
-            <directory>target/dependencies/apache-karaf-${karafVersion}</directory>
+            <directory>${project.build.directory}/dependencies/apache-karaf-${karafVersion}</directory>
             <!-- Output to the root directory -->
             <outputDirectory></outputDirectory>
             <excludes>
@@ -46,7 +46,7 @@
 
         <!-- Copy over bin/* separately to get the correct file mode -->
         <fileSet>
-            <directory>target/dependencies/apache-karaf-${karafVersion}</directory>
+            <directory>${project.build.directory}/dependencies/apache-karaf-${karafVersion}</directory>
             <!-- Output to the root directory -->
             <outputDirectory></outputDirectory>
             <includes>
@@ -66,13 +66,13 @@
         </fileSet>
 
         <fileSet>
-            <directory>target/classes/etc</directory>
+            <directory>${project.build.directory}/classes/etc</directory>
             <outputDirectory>etc</outputDirectory>
             <lineEnding>unix</lineEnding>
         </fileSet>
 
         <fileSet>
-            <directory>target/features-repo</directory>
+            <directory>${project.build.directory}/features-repo</directory>
             <outputDirectory>system</outputDirectory>
         </fileSet>
 
@@ -80,20 +80,26 @@
 
     <files>
         <file>
-            <source>${basedir}/target/dependencies/apache-karaf-${karafVersion}/bin/karaf</source>
+            <source>${project.build.directory}/dependencies/apache-karaf-${karafVersion}/bin/karaf</source>
             <outputDirectory>bin</outputDirectory>
             <destName>karaf</destName>
             <fileMode>0755</fileMode>
             <lineEnding>unix</lineEnding>
         </file>
         <file>
-            <source>${basedir}/target/classes/features.xml</source>
+            <source>${project.build.directory}/classes/features.xml</source>
             <outputDirectory>system/org/opennms/container/${project.artifactId}/${project.version}</outputDirectory>
             <destName>${project.artifactId}-${project.version}-features.xml</destName>
             <lineEnding>unix</lineEnding>
         </file>
         <file>
-            <source>${basedir}/target/dependencies/opennms-branding.jar</source>
+            <source>${project.build.directory}/classes/features.xml.sha1</source>
+            <outputDirectory>system/org/opennms/container/${project.artifactId}/${project.version}</outputDirectory>
+            <destName>${project.artifactId}-${project.version}-features.xml.sha1</destName>
+            <lineEnding>unix</lineEnding>
+        </file>
+        <file>
+            <source>${project.build.directory}/dependencies/opennms-branding.jar</source>
             <outputDirectory>lib</outputDirectory>
             <destName>opennms-branding.jar</destName>
         </file>

--- a/features/minion/core/repository/pom.xml
+++ b/features/minion/core/repository/pom.xml
@@ -42,7 +42,7 @@
                                 <feature>minion-core</feature>
                                 <feature>minion-core-shell</feature>
                             </features>
-                            <repository>target/maven-repo</repository>
+                            <repository>${project.build.directory}/maven-repo</repository>
                         </configuration>
                     </execution>
                 </executions>
@@ -58,7 +58,7 @@
                             <goal>copy-resources</goal>
                         </goals>
                         <configuration>
-                            <outputDirectory>target/maven-repo</outputDirectory>
+                            <outputDirectory>${project.build.directory}/maven-repo</outputDirectory>
                             <resources>
                                 <resource>
                                     <directory>src/main/resources</directory>
@@ -68,6 +68,31 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>net.nicoulaj.maven.plugins</groupId>
+                <artifactId>checksum-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>prepare-package</phase>
+                        <goals><goal>files</goal></goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <algorithms><algorithm>SHA-1</algorithm></algorithms>
+                    <fileSets>
+                        <fileSet>
+                            <directory>${project.build.directory}/maven-repo</directory>
+                            <includes>
+                                <include>**/*.cfg</include>
+                                <include>**/*.jar</include>
+                                <include>**/*.pom</include>
+                                <include>**/*.war</include>
+                                <include>**/*.xml</include>
+                            </includes>
+                        </fileSet>
+                    </fileSets>
+                </configuration>
             </plugin>
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>

--- a/opennms-assemblies/minion/pom.xml
+++ b/opennms-assemblies/minion/pom.xml
@@ -52,7 +52,7 @@
               <goal>unpack</goal>
             </goals>
             <configuration>
-              <outputDirectory>${project.build.directory}</outputDirectory>
+              <outputDirectory>${project.build.directory}/unpacked</outputDirectory>
               <artifactItems>
                 <artifactItem>
                   <groupId>org.opennms.features.minion.container</groupId>
@@ -66,7 +66,7 @@
                   <version>${project.version}</version>
                   <classifier>repo</classifier>
                   <type>tar.gz</type>
-                  <outputDirectory>${project.build.directory}/default</outputDirectory>
+                  <outputDirectory>${project.build.directory}/unpacked/repositories/default</outputDirectory>
                 </artifactItem>
                 <artifactItem>
                   <groupId>org.opennms.features.minion</groupId>
@@ -74,7 +74,7 @@
                   <version>${project.version}</version>
                   <classifier>repo</classifier>
                   <type>tar.gz</type>
-                  <outputDirectory>${project.build.directory}/core</outputDirectory>
+                  <outputDirectory>${project.build.directory}/unpacked/repositories/core</outputDirectory>
                 </artifactItem>
                 <artifactItem>
                   <groupId>org.opennms</groupId>
@@ -82,13 +82,46 @@
                   <version>${project.version}</version>
                   <classifier>daemon</classifier>
                   <type>tar.gz</type>
-                  <outputDirectory>${project.build.directory}/base-assembly</outputDirectory>
+                  <outputDirectory>${project.build.directory}/unpacked/base-assembly</outputDirectory>
                   <includes>bin/find-java.sh</includes>
                 </artifactItem>
               </artifactItems>
             </configuration>
           </execution>
         </executions>
+      </plugin>
+      <plugin>
+        <groupId>net.nicoulaj.maven.plugins</groupId>
+        <artifactId>checksum-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>prepare-package</phase>
+            <goals><goal>files</goal></goals>
+          </execution>
+        </executions>
+        <configuration>
+          <algorithms><algorithm>SHA-1</algorithm></algorithms>
+          <fileSets>
+            <fileSet>
+              <directory>${project.build.directory}/unpacked/repositories</directory>
+              <includes>
+                <include>**/*.jar</include>
+                <include>**/*.pom</include>
+                <include>**/*.war</include>
+                <include>**/*.xml</include>
+              </includes>
+            </fileSet>
+            <fileSet>
+              <directory>${project.build.directory}/unpacked/karaf-${project.version}</directory>
+              <includes>
+                <include>**/*.jar</include>
+                <include>**/*.pom</include>
+                <include>**/*.war</include>
+                <include>**/*.xml</include>
+              </includes>
+            </fileSet>
+          </fileSets>
+        </configuration>
       </plugin>
       <plugin>
         <artifactId>maven-assembly-plugin</artifactId>

--- a/opennms-assemblies/minion/src/assembly/minion.xml
+++ b/opennms-assemblies/minion/src/assembly/minion.xml
@@ -10,7 +10,7 @@
   <includeBaseDirectory>false</includeBaseDirectory>
   <fileSets>
     <fileSet>
-      <directory>target/classes</directory>
+      <directory>${project.build.directory}/classes</directory>
       <outputDirectory>minion-${project.version}</outputDirectory>
       <includes>
         <include>debian/rules</include>
@@ -19,7 +19,7 @@
       <fileMode>0755</fileMode>
     </fileSet>
     <fileSet>
-      <directory>target/classes</directory>
+      <directory>${project.build.directory}/classes</directory>
       <outputDirectory>minion-${project.version}</outputDirectory>
       <excludes>
         <exclude>debian/rules</exclude>
@@ -27,19 +27,15 @@
       </excludes>
     </fileSet>
     <fileSet>
-      <directory>target/karaf-${project.version}</directory>
+      <directory>${project.build.directory}/unpacked/karaf-${project.version}</directory>
       <outputDirectory>minion-${project.version}</outputDirectory>
     </fileSet>
     <fileSet>
-      <directory>target/core</directory>
-      <outputDirectory>minion-${project.version}/repositories/core</outputDirectory>
+      <directory>${project.build.directory}/unpacked/repositories</directory>
+      <outputDirectory>minion-${project.version}/repositories</outputDirectory>
     </fileSet>
     <fileSet>
-      <directory>target/default</directory>
-      <outputDirectory>minion-${project.version}/repositories/default</outputDirectory>
-    </fileSet>
-    <fileSet>
-      <directory>target/base-assembly/bin</directory>
+      <directory>${project.build.directory}/unpacked/base-assembly/bin</directory>
       <outputDirectory>minion-${project.version}/bin</outputDirectory>
     </fileSet>
   </fileSets>

--- a/opennms-full-assembly/pom.xml
+++ b/opennms-full-assembly/pom.xml
@@ -301,6 +301,31 @@
           </dependency>
         </dependencies>
       </plugin>
+      <plugin>
+        <groupId>net.nicoulaj.maven.plugins</groupId>
+        <artifactId>checksum-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>prepare-package</phase>
+            <goals><goal>files</goal></goals>
+          </execution>
+        </executions>
+        <configuration>
+          <algorithms><algorithm>SHA-1</algorithm></algorithms>
+          <fileSets>
+            <fileSet>
+              <directory>${project.build.directory}/features-repo</directory>
+              <includes>
+                <include>**/*.cfg</include>
+                <include>**/*.jar</include>
+                <include>**/*.pom</include>
+                <include>**/*.war</include>
+                <include>**/*.xml</include>
+              </includes>
+            </fileSet>
+          </fileSets>
+        </configuration>
+      </plugin>
       <plugin> 
         <artifactId>maven-clean-plugin</artifactId> 
         <executions> 

--- a/pom.xml
+++ b/pom.xml
@@ -178,6 +178,11 @@
         <version>${asciidoctorVersion}</version>
       </plugin>
       <plugin>
+        <groupId>net.nicoulaj.maven.plugins</groupId>
+        <artifactId>checksum-maven-plugin</artifactId>
+        <version>1.5</version>
+      </plugin>
+      <plugin>
         <groupId>org.apache.servicemix.tooling</groupId>
         <artifactId>depends-maven-plugin</artifactId>
         <version>1.2</version>

--- a/tools/packages/opennms/opennms.spec
+++ b/tools/packages/opennms/opennms.spec
@@ -833,7 +833,9 @@ rm -rf %{buildroot}
 %files plugin-ticketer-jira
 %defattr(664 root root 775)
 %{instprefix}/system/org/opennms/features/jira-troubleticketer/*/jira-*.jar
+%{instprefix}/system/org/opennms/features/jira-troubleticketer/*/jira-*.jar.sha1
 %{instprefix}/system/org/opennms/features/jira-client/*/jira-*.jar
+%{instprefix}/system/org/opennms/features/jira-client/*/jira-*.jar.sha1
 %config(noreplace) %{instprefix}/etc/jira.properties
 %{sharedir}/etc-pristine/jira.properties
 


### PR DESCRIPTION
This is an alternate PR to https://github.com/OpenNMS/opennms/pull/1497 which does the sha1 generation in maven rather than generating after the fact in the debian/rpm packages.

* JIRA: http://issues.opennms.org/browse/HZN-950

Our [continuous integration system](http://bamboo.internal.opennms.com:8085) will test and verify your changes.
