### PR TITLE
NMS-9356: Allow provisiond to perform reverse lookups without requiring an A record

### DIFF
--- a/opennms-provision/opennms-detectorclient-rpc/pom.xml
+++ b/opennms-provision/opennms-detectorclient-rpc/pom.xml
@@ -63,6 +63,11 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.opennms.dependencies</groupId>
+      <artifactId>dnsjava-dependencies</artifactId>
+      <type>pom</type>
+    </dependency>
+    <dependency>
       <groupId>org.opennms.core.ipc.rpc</groupId>
       <artifactId>org.opennms.core.ipc.rpc.camel-impl</artifactId>
       <version>${project.version}</version>

--- a/opennms-provision/opennms-detectorclient-rpc/src/main/java/org/opennms/netmgt/provision/dns/client/rpc/DnsLookupClientRpcModule.java
+++ b/opennms-provision/opennms-detectorclient-rpc/src/main/java/org/opennms/netmgt/provision/dns/client/rpc/DnsLookupClientRpcModule.java
@@ -33,6 +33,7 @@ import java.util.concurrent.CompletableFuture;
 
 import org.opennms.core.rpc.xml.AbstractXmlRpcModule;
 import org.opennms.core.utils.InetAddressUtils;
+import org.xbill.DNS.Address;
 
 public class DnsLookupClientRpcModule extends AbstractXmlRpcModule<DnsLookupRequestDTO, DnsLookupResponseDTO> {
 
@@ -62,7 +63,9 @@ public class DnsLookupClientRpcModule extends AbstractXmlRpcModule<DnsLookupRequ
             if (queryType.equals(QueryType.LOOKUP)) {
                 dto.setHostResponse(addr.getHostAddress());
             } else if (queryType.equals(QueryType.REVERSE_LOOKUP)) {
-                dto.setHostResponse(addr.getCanonicalHostName());
+                // NMS-9356: Use dnsjava instead of InetAddress#getCanonicalHostName
+                // in order to support reverse lookups without requiring an A record
+                dto.setHostResponse(Address.getHostName(addr));
             }
             future.complete(dto);
         } catch (Exception e) {

--- a/opennms-provision/opennms-provision-shell/src/main/java/org/opennms/netmgt/provision/dns/command/DnsLookup.java
+++ b/opennms-provision/opennms-provision-shell/src/main/java/org/opennms/netmgt/provision/dns/command/DnsLookup.java
@@ -58,11 +58,11 @@ public class DnsLookup extends OsgiCommandSupport {
             try {
                 try {
                     String ipAddress = future.get(1, TimeUnit.SECONDS);
-                    System.out.printf("IpAddress returned for the %s  is  %s \n", m_host, ipAddress);
+                    System.out.printf("\n%s resolves to: %s\n", m_host, ipAddress);
                 } catch (InterruptedException e) {
                     System.out.println("\nInterrupted.");
                 } catch (ExecutionException e) {
-                    System.out.printf("\n DNS lookup failed with: %s\n", e);
+                    System.out.printf("\nDNS lookup failed with: %s\n", e);
                 }
                 break;
             } catch (TimeoutException e) {

--- a/opennms-provision/opennms-provision-shell/src/main/java/org/opennms/netmgt/provision/dns/command/DnsReverseLookup.java
+++ b/opennms-provision/opennms-provision-shell/src/main/java/org/opennms/netmgt/provision/dns/command/DnsReverseLookup.java
@@ -37,8 +37,8 @@ import org.apache.felix.gogo.commands.Argument;
 import org.apache.felix.gogo.commands.Command;
 import org.apache.felix.gogo.commands.Option;
 import org.apache.karaf.shell.console.OsgiCommandSupport;
+import org.opennms.core.utils.InetAddressUtils;
 import org.opennms.netmgt.provision.LocationAwareDnsLookupClient;
-import org.opennms.netmgt.snmp.InetAddrUtils;
 
 @Command(scope = "dns", name = "reverse-lookup", description = "DNS reverse lookup for the specified ipaddress")
 public class DnsReverseLookup extends OsgiCommandSupport {
@@ -53,12 +53,12 @@ public class DnsReverseLookup extends OsgiCommandSupport {
 
     @Override
     protected Object doExecute() throws Exception {
-        final CompletableFuture<String> future = client.reverseLookup(InetAddrUtils.addr(ipAddress), m_location);
+        final CompletableFuture<String> future = client.reverseLookup(InetAddressUtils.addr(ipAddress), m_location);
         while (true) {
             try {
                 try {
                     String hostName = future.get(1, TimeUnit.SECONDS);
-                    System.out.printf("Hostname returned for the ipAddress = %s  is  %s \n", ipAddress, hostName);
+                    System.out.printf("\n%s resolves to: %s\n", ipAddress, hostName);
                 } catch (InterruptedException e) {
                     System.out.println("\nInterrupted.");
                 } catch (ExecutionException e) {

--- a/opennms-provision/opennms-provisiond/src/main/java/org/opennms/netmgt/provision/service/DefaultHostnameResolver.java
+++ b/opennms-provision/opennms-provisiond/src/main/java/org/opennms/netmgt/provision/service/DefaultHostnameResolver.java
@@ -33,8 +33,8 @@ import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
+import org.opennms.core.utils.InetAddressUtils;
 import org.opennms.netmgt.provision.LocationAwareDnsLookupClient;
-import org.opennms.netmgt.snmp.InetAddrUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -58,7 +58,7 @@ public final class DefaultHostnameResolver implements HostnameResolver {
             return result;
         } catch (InterruptedException | ExecutionException e) {
             LOG.warn("Reverse lookup failed for {} at location {}. Using IP address as hostname.", addr, location);
-            return InetAddrUtils.str(addr);
+            return InetAddressUtils.str(addr);
         }
     }
 }


### PR DESCRIPTION
JIRA: https://issues.opennms.org/browse/NMS-9356

Support reverse lookups without requiring an A record in provisiond. See JIRA for details.