### PR TITLE
NMS-9409: TCP persistence strategy should output time in milliseconds…

### DIFF
--- a/opennms-rrd/opennms-rrd-tcp/src/main/java/org/opennms/netmgt/rrd/tcp/RrdOutputSocket.java
+++ b/opennms-rrd/opennms-rrd-tcp/src/main/java/org/opennms/netmgt/rrd/tcp/RrdOutputSocket.java
@@ -99,7 +99,7 @@ public class RrdOutputSocket {
         m_messages.addMessage(PerformanceDataReading.newBuilder()
                 .setPath(filename)
                 .setOwner(owner)
-                .setTimestamp(timestamp)
+                .setTimestamp(timestamp * 1000)
                 .addAllDblValue(dblValues)
                 .addAllStrValue(strValues)
         );


### PR DESCRIPTION
…, not seconds

- Timestamp needs to be converted from seconds to milliseconds.

JIRA: http://issues.opennms.org/browse/NMS-9409

Todo Review:
- [ ] Typo and grammar
- [ ] Formatting and conventions
- [ ] Content