### PR TITLE
NMS-9415: Check if ipAddressIfIndex contains any data before attempting to parse it

### DIFF
--- a/opennms-provision/opennms-provisiond/src/main/java/org/opennms/netmgt/provision/service/IPAddressTableTracker.java
+++ b/opennms-provision/opennms-provisiond/src/main/java/org/opennms/netmgt/provision/service/IPAddressTableTracker.java
@@ -100,6 +100,11 @@ public class IPAddressTableTracker extends TableTracker {
         
         public String getIpAddress() {
             final SnmpResult result = getResult(IP_ADDRESS_IF_INDEX);
+            if (result == null) {
+                LOG.warn("BAD AGENT: Device is missing IP-MIB::ipAddressIfIndex. Skipping.");
+                return null;
+            }
+
             SnmpInstId instance = result.getInstance();
             final int[] instanceIds = instance.getIds();
 


### PR DESCRIPTION
OpenNMS throws a NullPointerException during the node scan of devices with non-existent IP-MIB::ipAddressIfIndex entries.

This is a quick bugfix / workaround, which simply checks if anything was returned in the SNMP reply. If the reply was empty, a warning will be printed before returning null.

* JIRA: https://issues.opennms.org/browse/NMS-9415
