### PR TITLE
NMS-9417 : use an internal radius server for radius tests

### DIFF
--- a/protocols/radius/pom.xml
+++ b/protocols/radius/pom.xml
@@ -53,5 +53,18 @@
       <artifactId>org.opennms.core.test-api.services</artifactId>
       <scope>test</scope>
     </dependency>
+    <!-- https://mvnrepository.com/artifact/com.hynnet/tinyradius -->
+	<dependency>
+    <groupId>com.hynnet</groupId>
+    <artifactId>tinyradius</artifactId>
+    <version>1.0.1</version>
+     <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging</artifactId>
+        </exclusion>
+      </exclusions>
+	</dependency>
   </dependencies>
 </project>

--- a/protocols/radius/pom.xml
+++ b/protocols/radius/pom.xml
@@ -53,18 +53,17 @@
       <artifactId>org.opennms.core.test-api.services</artifactId>
       <scope>test</scope>
     </dependency>
-    <!-- https://mvnrepository.com/artifact/com.hynnet/tinyradius -->
-	<dependency>
-    <groupId>com.hynnet</groupId>
-    <artifactId>tinyradius</artifactId>
-    <version>1.0.1</version>
-     <scope>test</scope>
+    <dependency>
+      <groupId>com.hynnet</groupId>
+      <artifactId>tinyradius</artifactId>
+      <version>1.0.1</version>
+      <scope>test</scope>
       <exclusions>
         <exclusion>
           <groupId>commons-logging</groupId>
           <artifactId>commons-logging</artifactId>
         </exclusion>
       </exclusions>
-	</dependency>
+    </dependency>
   </dependencies>
 </project>

--- a/protocols/radius/src/test/java/org/opennms/protocols/radius/detector/RadiusAuthDetectorTest.java
+++ b/protocols/radius/src/test/java/org/opennms/protocols/radius/detector/RadiusAuthDetectorTest.java
@@ -65,9 +65,9 @@ public class RadiusAuthDetectorTest implements ApplicationContextAware, Initiali
 
     @Before
     public void setUp(){
-        MockLogAppender.setupLogging();
         mockSrv = new MockRadiusServer();
         mockSrv.start(true,false);
+        MockLogAppender.setupLogging();
     }
     @After
     public void tearDown(){

--- a/protocols/radius/src/test/java/org/opennms/protocols/radius/detector/RadiusAuthDetectorTest.java
+++ b/protocols/radius/src/test/java/org/opennms/protocols/radius/detector/RadiusAuthDetectorTest.java
@@ -56,7 +56,7 @@ public class RadiusAuthDetectorTest implements ApplicationContextAware, Initiali
 
     @Autowired
     public RadiusAuthDetector m_detector;
-	private MockRadiusServer mockSrv = null;
+    	private MockRadiusServer mockSrv = null;
 
     @Override
     public void afterPropertiesSet() throws Exception {
@@ -66,8 +66,8 @@ public class RadiusAuthDetectorTest implements ApplicationContextAware, Initiali
     @Before
     public void setUp(){
         MockLogAppender.setupLogging();
-         mockSrv = new MockRadiusServer();
-         mockSrv.start(true,false);
+        mockSrv = new MockRadiusServer();
+        mockSrv.start(true,false);
     }
     @After
     public void tearDown(){

--- a/protocols/radius/src/test/java/org/opennms/protocols/radius/monitor/MockRadiusServer.java
+++ b/protocols/radius/src/test/java/org/opennms/protocols/radius/monitor/MockRadiusServer.java
@@ -1,3 +1,31 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2008-2015 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2015 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
 package org.opennms.protocols.radius.monitor;
 
 import java.net.InetSocketAddress;
@@ -9,31 +37,33 @@ import org.tinyradius.util.RadiusException;
 import org.tinyradius.util.RadiusServer;
 
 public class MockRadiusServer extends RadiusServer {
-		@Override
-		public String getSharedSecret(InetSocketAddress arg0) {
-			return "testing123";
-		}
+    @Override
+    public String getSharedSecret(InetSocketAddress arg0) {
+        return "testing123";
+    }
 
-		@Override
-		public String getUserPassword(String usename) {
-			return "password";
-		}
-		@Override
-		public RadiusPacket accessRequestReceived(AccessRequest ar, InetSocketAddress client)
-				throws RadiusException{
-			MockUtil.println(ar.getAuthProtocol());
-			return super.accessRequestReceived(ar, client);
-		}
-		@Override
-		public void start(boolean hasAuth,boolean hasAcct){
-			MockUtil.println("Mock radius server starting");
-			super.start(hasAuth, hasAcct);
-		}
-		@Override
-		public void stop(){
-			MockUtil.println("Stopping Radius server");
-			super.stop();
-			
-		}
-		
+    @Override
+    public String getUserPassword(String usename) {
+        return "password";
+    }
+
+    @Override
+    public RadiusPacket accessRequestReceived(AccessRequest ar,
+            InetSocketAddress client) throws RadiusException {
+        MockUtil.println(ar.getAuthProtocol());
+        return super.accessRequestReceived(ar, client);
+    }
+
+    @Override
+    public void start(boolean hasAuth, boolean hasAcct) {
+        MockUtil.println("Mock radius server starting");
+        super.start(hasAuth, hasAcct);
+    }
+
+    @Override
+    public void stop() {
+        MockUtil.println("Stopping Radius server");
+        super.stop();
+    }
+
 }

--- a/protocols/radius/src/test/java/org/opennms/protocols/radius/monitor/MockRadiusServer.java
+++ b/protocols/radius/src/test/java/org/opennms/protocols/radius/monitor/MockRadiusServer.java
@@ -1,0 +1,32 @@
+package org.opennms.protocols.radius.monitor;
+
+import java.net.InetSocketAddress;
+
+import org.opennms.test.mock.MockUtil;
+import org.tinyradius.packet.AccessRequest;
+import org.tinyradius.packet.RadiusPacket;
+import org.tinyradius.util.RadiusException;
+import org.tinyradius.util.RadiusServer;
+
+public class MockRadiusServer extends RadiusServer {
+		@Override
+		public String getSharedSecret(InetSocketAddress arg0) {
+			return "testing123";
+		}
+
+		@Override
+		public String getUserPassword(String usename) {
+			return "password";
+		}
+		@Override
+		public RadiusPacket accessRequestReceived(AccessRequest ar, InetSocketAddress client)
+				throws RadiusException{
+			MockUtil.println(ar.getAuthProtocol());
+			return super.accessRequestReceived(ar, client);
+		}
+		@Override
+		public void start(boolean hasAuth,boolean hasAcct){
+			MockUtil.println("Mock radius server starting");
+			super.start(hasAuth, hasAcct);
+		}
+}

--- a/protocols/radius/src/test/java/org/opennms/protocols/radius/monitor/MockRadiusServer.java
+++ b/protocols/radius/src/test/java/org/opennms/protocols/radius/monitor/MockRadiusServer.java
@@ -29,4 +29,11 @@ public class MockRadiusServer extends RadiusServer {
 			MockUtil.println("Mock radius server starting");
 			super.start(hasAuth, hasAcct);
 		}
+		@Override
+		public void stop(){
+			MockUtil.println("Stopping Radius server");
+			super.stop();
+			
+		}
+		
 }

--- a/protocols/radius/src/test/java/org/opennms/protocols/radius/springsecurity/RadiusAuthenticationProviderTest.java
+++ b/protocols/radius/src/test/java/org/opennms/protocols/radius/springsecurity/RadiusAuthenticationProviderTest.java
@@ -28,6 +28,8 @@
 
 package org.opennms.protocols.radius.springsecurity;
 
+import static org.junit.Assert.*;
+
 import java.io.IOException;
 
 import net.jradius.client.auth.CHAPAuthenticator;
@@ -38,9 +40,13 @@ import net.jradius.client.auth.MSCHAPv2Authenticator;
 import net.jradius.client.auth.PAPAuthenticator;
 import net.jradius.client.auth.RadiusAuthenticator;
 
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.opennms.protocols.radius.monitor.MockRadiusServer;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.userdetails.UserDetails;
 
 /**
  */
@@ -50,10 +56,18 @@ public class RadiusAuthenticationProviderTest {
 	private String m_sharedSecret = "testing123";
 	private Object m_principal = "test";
 	private final String m_username = "test";
-	private Object m_credentials = "opennms";
-
+	private Object m_credentials = "password";
+	private MockRadiusServer mockSrv = null;
+	@Before
+    public void setUp(){
+         mockSrv = new MockRadiusServer();
+         mockSrv.start(true,false);
+    }
+    @After
+    public void tearDown(){
+        mockSrv.stop();
+    }
 	@Test
-	@Ignore("Need to have a RADIUS server running on localhost")
 	public void testRetrieveUserDefault() throws IOException {
 		RadiusAuthenticationProvider provider = new RadiusAuthenticationProvider(m_radiusServer, m_sharedSecret);
 		RadiusAuthenticator authTypeClass = null;
@@ -66,7 +80,7 @@ public class RadiusAuthenticationProviderTest {
 	}
 
 	@Test
-	@Ignore("Need to have a RADIUS server running on localhost")
+	
 	public void testRetrieveUserPap() throws IOException {
 		RadiusAuthenticationProvider provider = new RadiusAuthenticationProvider(m_radiusServer, m_sharedSecret);
 		RadiusAuthenticator authTypeClass = new PAPAuthenticator();
@@ -75,11 +89,10 @@ public class RadiusAuthenticationProviderTest {
 		provider.setRolesAttribute("Unknown-VSAttribute(5813:1)");
 
 		UsernamePasswordAuthenticationToken token = new UsernamePasswordAuthenticationToken(m_principal, m_credentials);
-		provider.retrieveUser(m_username, token);
+		UserDetails ud = provider.retrieveUser(m_username, token);
 	}
 
 	@Test
-	@Ignore("Need to have a RADIUS server running on localhost")
 	public void testRetrieveUserChap() throws IOException {
 		RadiusAuthenticationProvider provider = new RadiusAuthenticationProvider(m_radiusServer, m_sharedSecret);
 		RadiusAuthenticator authTypeClass = new CHAPAuthenticator();
@@ -96,47 +109,46 @@ public class RadiusAuthenticationProviderTest {
 	 * PAP authentication.
 	 */
 	@Test
-	@Ignore("Need to have a RADIUS server running on localhost")
+	
 	public void testRetrieveUserMultipleTimesDefault() throws IOException {
 		doTestRetrieveUserMultipleTimes(null);
 	}
 
 	@Test
-	@Ignore("Need to have a RADIUS server running on localhost")
+	
 	public void testRetrieveUserMultipleTimesPAP() throws IOException {
 		doTestRetrieveUserMultipleTimes(new PAPAuthenticator());
 	}
 
 	@Test
-	@Ignore("Need to have a RADIUS server running on localhost")
 	public void testRetrieveUserMultipleTimesCHAP() throws IOException {
 		doTestRetrieveUserMultipleTimes(new CHAPAuthenticator());
 	}
 
 	@Test
-	@Ignore("Need to have a RADIUS server running on localhost")
+	@Ignore("Need to have a RADIUS server running on localhost, tinyradius does not know eap families")
 	public void testRetrieveUserMultipleTimesEAPMD5() throws IOException {
 		doTestRetrieveUserMultipleTimes(new EAPMD5Authenticator());
 	}
 
 	@Test
-	@Ignore("Need to have a RADIUS server running on localhost")
+	@Ignore("Need to have a RADIUS server running on localhost, tinyradius does not know eap families")
 	public void testRetrieveUserMultipleTimesEAPMSCHAPv2() throws IOException {
 		doTestRetrieveUserMultipleTimes(new EAPMSCHAPv2Authenticator());
 	}
 
 	@Test
-	@Ignore("Need to have a RADIUS server running on localhost")
+	@Ignore("Need to have a RADIUS server running on localhost, tinyradius does not know MSCHAPv1")
 	public void testRetrieveUserMultipleTimesMSCHAPv1() throws IOException {
 		doTestRetrieveUserMultipleTimes(new MSCHAPv1Authenticator());
 	}
 
 	@Test
-	@Ignore("Need to have a RADIUS server running on localhost")
+	@Ignore("Need to have a RADIUS server running on localhost, tinyradius does not know MSCHAPv2")
 	public void testRetrieveUserMultipleTimesMSCHAPv2() throws IOException {
 		doTestRetrieveUserMultipleTimes(new MSCHAPv2Authenticator());
 	}
-
+	
 	public void doTestRetrieveUserMultipleTimes(RadiusAuthenticator authenticator) {
 		RadiusAuthenticationProvider provider = new RadiusAuthenticationProvider(m_radiusServer, m_sharedSecret);
 		RadiusAuthenticator authTypeClass = authenticator;

--- a/protocols/radius/src/test/java/org/opennms/protocols/radius/springsecurity/RadiusAuthenticationProviderTest.java
+++ b/protocols/radius/src/test/java/org/opennms/protocols/radius/springsecurity/RadiusAuthenticationProviderTest.java
@@ -28,8 +28,6 @@
 
 package org.opennms.protocols.radius.springsecurity;
 
-import static org.junit.Assert.*;
-
 import java.io.IOException;
 
 import net.jradius.client.auth.CHAPAuthenticator;
@@ -40,13 +38,9 @@ import net.jradius.client.auth.MSCHAPv2Authenticator;
 import net.jradius.client.auth.PAPAuthenticator;
 import net.jradius.client.auth.RadiusAuthenticator;
 
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
-import org.opennms.protocols.radius.monitor.MockRadiusServer;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.userdetails.UserDetails;
 
 /**
  */
@@ -56,18 +50,10 @@ public class RadiusAuthenticationProviderTest {
 	private String m_sharedSecret = "testing123";
 	private Object m_principal = "test";
 	private final String m_username = "test";
-	private Object m_credentials = "password";
-	private MockRadiusServer mockSrv = null;
-	@Before
-    public void setUp(){
-         mockSrv = new MockRadiusServer();
-         mockSrv.start(true,false);
-    }
-    @After
-    public void tearDown(){
-        mockSrv.stop();
-    }
+	private Object m_credentials = "opennms";
+
 	@Test
+	@Ignore("Need to have a RADIUS server running on localhost")
 	public void testRetrieveUserDefault() throws IOException {
 		RadiusAuthenticationProvider provider = new RadiusAuthenticationProvider(m_radiusServer, m_sharedSecret);
 		RadiusAuthenticator authTypeClass = null;
@@ -80,7 +66,7 @@ public class RadiusAuthenticationProviderTest {
 	}
 
 	@Test
-	
+	@Ignore("Need to have a RADIUS server running on localhost")
 	public void testRetrieveUserPap() throws IOException {
 		RadiusAuthenticationProvider provider = new RadiusAuthenticationProvider(m_radiusServer, m_sharedSecret);
 		RadiusAuthenticator authTypeClass = new PAPAuthenticator();
@@ -89,10 +75,11 @@ public class RadiusAuthenticationProviderTest {
 		provider.setRolesAttribute("Unknown-VSAttribute(5813:1)");
 
 		UsernamePasswordAuthenticationToken token = new UsernamePasswordAuthenticationToken(m_principal, m_credentials);
-		UserDetails ud = provider.retrieveUser(m_username, token);
+		provider.retrieveUser(m_username, token);
 	}
 
 	@Test
+	@Ignore("Need to have a RADIUS server running on localhost")
 	public void testRetrieveUserChap() throws IOException {
 		RadiusAuthenticationProvider provider = new RadiusAuthenticationProvider(m_radiusServer, m_sharedSecret);
 		RadiusAuthenticator authTypeClass = new CHAPAuthenticator();
@@ -109,46 +96,47 @@ public class RadiusAuthenticationProviderTest {
 	 * PAP authentication.
 	 */
 	@Test
-	
+	@Ignore("Need to have a RADIUS server running on localhost")
 	public void testRetrieveUserMultipleTimesDefault() throws IOException {
 		doTestRetrieveUserMultipleTimes(null);
 	}
 
 	@Test
-	
+	@Ignore("Need to have a RADIUS server running on localhost")
 	public void testRetrieveUserMultipleTimesPAP() throws IOException {
 		doTestRetrieveUserMultipleTimes(new PAPAuthenticator());
 	}
 
 	@Test
+	@Ignore("Need to have a RADIUS server running on localhost")
 	public void testRetrieveUserMultipleTimesCHAP() throws IOException {
 		doTestRetrieveUserMultipleTimes(new CHAPAuthenticator());
 	}
 
 	@Test
-	@Ignore("Need to have a RADIUS server running on localhost, tinyradius does not know eap families")
+	@Ignore("Need to have a RADIUS server running on localhost")
 	public void testRetrieveUserMultipleTimesEAPMD5() throws IOException {
 		doTestRetrieveUserMultipleTimes(new EAPMD5Authenticator());
 	}
 
 	@Test
-	@Ignore("Need to have a RADIUS server running on localhost, tinyradius does not know eap families")
+	@Ignore("Need to have a RADIUS server running on localhost")
 	public void testRetrieveUserMultipleTimesEAPMSCHAPv2() throws IOException {
 		doTestRetrieveUserMultipleTimes(new EAPMSCHAPv2Authenticator());
 	}
 
 	@Test
-	@Ignore("Need to have a RADIUS server running on localhost, tinyradius does not know MSCHAPv1")
+	@Ignore("Need to have a RADIUS server running on localhost")
 	public void testRetrieveUserMultipleTimesMSCHAPv1() throws IOException {
 		doTestRetrieveUserMultipleTimes(new MSCHAPv1Authenticator());
 	}
 
 	@Test
-	@Ignore("Need to have a RADIUS server running on localhost, tinyradius does not know MSCHAPv2")
+	@Ignore("Need to have a RADIUS server running on localhost")
 	public void testRetrieveUserMultipleTimesMSCHAPv2() throws IOException {
 		doTestRetrieveUserMultipleTimes(new MSCHAPv2Authenticator());
 	}
-	
+
 	public void doTestRetrieveUserMultipleTimes(RadiusAuthenticator authenticator) {
 		RadiusAuthenticationProvider provider = new RadiusAuthenticationProvider(m_radiusServer, m_sharedSecret);
 		RadiusAuthenticator authTypeClass = authenticator;


### PR DESCRIPTION
See https://issues.opennms.org/browse/NMS-9417
Added a maven dependency on tinyradius 1.0.1 (scope test)
Defined a mock radius server as Subclass of TinyRadiusServer
Used this internal radius server in tests (did not touch springsecurity however)
