### PR TITLE
NMS-9422: Event Configuration Screen Requires Alarm Type

### DIFF
--- a/features/vaadin-snmp-events-and-metrics/src/main/java/org/opennms/features/vaadin/events/EventForm.java
+++ b/features/vaadin-snmp-events-and-metrics/src/main/java/org/opennms/features/vaadin/events/EventForm.java
@@ -29,6 +29,7 @@
 package org.opennms.features.vaadin.events;
 
 import org.opennms.netmgt.model.OnmsSeverity;
+import org.opennms.netmgt.xml.eventconf.AlarmData;
 import org.opennms.netmgt.xml.eventconf.Logmsg;
 import org.opennms.netmgt.xml.eventconf.Mask;
 
@@ -153,6 +154,7 @@ public class EventForm extends CustomComponent {
         alarmDataAlarmType.setDescription("<b>1</b> to be a problem that has a possible resolution, alarm-type set to <b>2</b> to be a resolution event, and alarm-type set to <b>3</b> for events that have no possible resolution");
         alarmDataAlarmType.setNullSelectionAllowed(false);
         alarmDataAlarmType.setVisible(false);
+        alarmDataAlarmType.setRequired(true);
         eventLayout.addComponent(alarmDataAlarmType);
 
         alarmDataAutoClean.setWidth("100%");
@@ -162,8 +164,10 @@ public class EventForm extends CustomComponent {
         alarmDataReductionKey.setWidth("100%");
         alarmDataReductionKey.setNullRepresentation("");
         alarmDataReductionKey.setVisible(false);
+        alarmDataReductionKey.setRequired(true);
         eventLayout.addComponent(alarmDataReductionKey);
 
+        // TODO the clear-key is required only when the alarm-type is 2
         alarmDataClearKey.setWidth("100%");
         alarmDataClearKey.setNullRepresentation("");
         alarmDataClearKey.setVisible(false);
@@ -221,6 +225,9 @@ public class EventForm extends CustomComponent {
         alarmDataReductionKey.setVisible(enable);
         alarmDataClearKey.setVisible(enable);
         if (enable) {
+            if (getEvent().getAlarmData() == null) {
+                getEvent().setAlarmData(new AlarmData());
+            }
             eventEditor.bind(alarmDataAlarmType, "alarmData.alarmType");
             eventEditor.bind(alarmDataAutoClean, "alarmData.autoClean");
             eventEditor.bind(alarmDataReductionKey, "alarmData.reductionKey");

--- a/features/vaadin-snmp-events-and-metrics/src/main/java/org/opennms/features/vaadin/events/EventPanel.java
+++ b/features/vaadin-snmp-events-and-metrics/src/main/java/org/opennms/features/vaadin/events/EventPanel.java
@@ -318,7 +318,7 @@ public abstract class EventPanel extends Panel {
             for (org.opennms.netmgt.xml.eventconf.Event event : baseEventsObject.getEventCollection()) {
                 logger.debug("Normalizing event " + event.getUei());
                 AlarmData ad = event.getAlarmData();
-                if (ad != null && (ad.getReductionKey() == null || ad.getReductionKey().trim().isEmpty())) {
+                if (ad != null && (ad.getReductionKey() == null || ad.getReductionKey().trim().isEmpty() || ad.getAlarmType() == null || ad.getAlarmType() == 0)) {
                     event.setAlarmData(null);
                 }
                 Mask m = event.getMask();

--- a/features/vaadin-snmp-events-and-metrics/src/test/java/org/opennms/features/vaadin/events/EventFormTest.java
+++ b/features/vaadin-snmp-events-and-metrics/src/test/java/org/opennms/features/vaadin/events/EventFormTest.java
@@ -50,8 +50,14 @@ import com.vaadin.data.fieldgroup.FieldGroup;
  */
 public class EventFormTest {
 
+    /** The Event Configuration DAO. */
     private DefaultEventConfDao dao;
 
+    /**
+     * Sets the up.
+     *
+     * @throws Exception the exception
+     */
     @Before
     public void setUp() throws Exception {
         File config = new File(ConfigurationTestUtils.getDaemonEtcDirectory(), "events/MPLS.events.xml");
@@ -89,6 +95,58 @@ public class EventFormTest {
         Assert.assertNotNull(logMsgDest);
         Assert.assertTrue(logMsgDest instanceof ComboBox);
         Assert.assertEquals(event.getLogmsg().getDest(), logMsgDest.getValue());
+    }
+
+
+    /**
+     * Test event without alarm data.
+     * <p>See NMS-9422 for more details</p>
+     *
+     * @throws Exception the exception
+     */
+    @Test
+    public void testEventWithoutAlarmData() throws Exception {
+        EventForm form = new EventForm();
+        Event event = dao.findByUei("uei.opennms.org/ietf/mplsTeStdMib/traps/mplsTunnelReoptimized");
+        Assert.assertNotNull(event);
+        Assert.assertNull(event.getAlarmData());
+        form.setEvent(event);
+
+        form.setEnabled(true);
+        form.hasAlarmData.setValue(true);
+        form.alarmDataAlarmType.setValue(1);
+        form.alarmDataAutoClean.setValue(true);
+        form.alarmDataReductionKey.setValue("%uei%::%nodeid%");
+        form.commit();
+
+        Event updatedEvent = form.getEvent();
+        Assert.assertNotNull(updatedEvent.getAlarmData());
+        Assert.assertEquals(new Integer(1), updatedEvent.getAlarmData().getAlarmType());
+    }
+
+    /**
+     * Test event with alarm data.
+     * <p>See NMS-9422 for more details</p>
+     *
+     * @throws Exception the exception
+     */
+    @Test
+    public void testEventWithAlarmData() throws Exception {
+        EventForm form = new EventForm();
+        Event event = dao.findByUei("uei.opennms.org/mpls/traps/mplsVrfIfDown");
+        Assert.assertNotNull(event);
+        Assert.assertNotNull(event.getAlarmData());
+        form.setEvent(event);
+
+        form.setEnabled(true);
+        Assert.assertTrue(form.hasAlarmData.getValue());
+        Assert.assertEquals(new Integer(1), form.alarmDataAlarmType.getValue());
+        form.alarmDataReductionKey.setValue("this-is-a-new-reduction-key");
+        form.commit();
+
+        Event updatedEvent = form.getEvent();
+        Assert.assertNotNull(updatedEvent.getAlarmData());
+        Assert.assertEquals("this-is-a-new-reduction-key", updatedEvent.getAlarmData().getReductionKey());
     }
 
 }


### PR DESCRIPTION
* JIRA: http://issues.opennms.org/browse/NMS-9422

Our [continuous integration system](http://bamboo.internal.opennms.com:8085) will test and verify your changes.

The solution has been manually verified on my test environment.

The solution will require manual merge to foundation-2017, as the Vaadin API is slightly different.

In case this is needed in foundation for Meridian 2015, the solution has to be reworked as well (same thing, because of the Vaadin API).