### PR TITLE
NMS-9413: Validate the agent prior to scheduling the interfaces

### DIFF
--- a/features/collection/api/src/main/java/org/opennms/netmgt/collection/api/AbstractServiceCollector.java
+++ b/features/collection/api/src/main/java/org/opennms/netmgt/collection/api/AbstractServiceCollector.java
@@ -47,6 +47,11 @@ public abstract class AbstractServiceCollector implements ServiceCollector {
     }
 
     @Override
+    public void validateAgent(CollectionAgent agent, Map<String, Object> parameters) throws CollectionInitializationException {
+        // pass
+    }
+
+    @Override
     public Map<String, Object> getRuntimeAttributes(CollectionAgent agent, Map<String, Object> parameters) {
         return Collections.emptyMap();
     }

--- a/features/collection/api/src/main/java/org/opennms/netmgt/collection/api/ServiceCollector.java
+++ b/features/collection/api/src/main/java/org/opennms/netmgt/collection/api/ServiceCollector.java
@@ -78,6 +78,25 @@ public interface ServiceCollector {
    void initialize() throws CollectionInitializationException;
 
     /**
+     * Validate whether or not this collector should be scheduled
+     * to run against the given agent.
+     *
+     * If the collector cannot, or should not be a run against
+     * a given agent, a {@link CollectionInitializationException}
+     * must be thrown.
+     *
+     * In the case of the SNMP collector, this is used to prevent
+     * collect from scheduling interfaces other than the those
+     * marked as primary on a given node.
+     *
+     * @param agent
+     * @param parameters
+     * @throws CollectionInitializationException
+     */
+    void validateAgent(CollectionAgent agent, Map<String, Object> parameters) throws CollectionInitializationException;
+
+
+    /**
      * Invokes a collection on the object.
      *
      * This call will be performed in both OpenNMS and Minion.

--- a/opennms-services/src/main/java/org/opennms/netmgt/collectd/CollectableService.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/collectd/CollectableService.java
@@ -169,6 +169,8 @@ final class CollectableService implements ReadyRunnable {
 
         m_lastScheduledCollectionTime = 0L;
 
+        m_spec.initialize(m_agent);
+
         m_params = m_spec.getServiceParameters();
         m_repository=m_spec.getRrdRepository(m_params.getCollectionName());
 
@@ -618,10 +620,12 @@ final class CollectableService implements ReadyRunnable {
 
         return !ABORT_COLLECTION;
     }
-    
+
     private void reinitialize(OnmsIpInterface newIface) throws CollectionInitializationException {
+        m_spec.release(m_agent);
         m_agent = DefaultCollectionAgent.create(newIface.getId(), m_ifaceDao,
                                                 m_transMgr);
+        m_spec.initialize(m_agent);
     }
 
     /**

--- a/opennms-services/src/main/java/org/opennms/netmgt/collectd/CollectionSpecification.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/collectd/CollectionSpecification.java
@@ -39,6 +39,7 @@ import org.opennms.core.rpc.api.RpcExceptionHandler;
 import org.opennms.core.rpc.api.RpcExceptionUtils;
 import org.opennms.netmgt.collection.api.CollectionAgent;
 import org.opennms.netmgt.collection.api.CollectionException;
+import org.opennms.netmgt.collection.api.CollectionInitializationException;
 import org.opennms.netmgt.collection.api.CollectionInstrumentation;
 import org.opennms.netmgt.collection.api.CollectionSet;
 import org.opennms.netmgt.collection.api.CollectionStatus;
@@ -232,6 +233,30 @@ public class CollectionSpecification {
         }
         m.put("packageName", m_package.getName());
         m_parameters = m;
+    }
+
+    /**
+     * <p>initialize</p>
+     *
+     * @param agent a {@link org.opennms.netmgt.collection.api.CollectionAgent} object.
+     */
+    public void initialize(CollectionAgent agent) throws CollectionInitializationException {
+        m_instrumentation.beginCollectorInitialize(m_package.getName(), agent.getNodeId(), agent.getHostAddress(), m_svcName);
+        try {
+            m_collector.validateAgent(agent, getPropertyMap());
+        } finally {
+            m_instrumentation.endCollectorInitialize(m_package.getName(), agent.getNodeId(), agent.getHostAddress(), m_svcName);
+        }
+    }
+
+    /**
+     * <p>release</p>
+     *
+     * @param agent a {@link org.opennms.netmgt.collection.api.CollectionAgent} object.
+     */
+    public void release(CollectionAgent agent) {
+        m_instrumentation.beginCollectorRelease(m_package.getName(), agent.getNodeId(), agent.getHostAddress(), m_svcName);
+        m_instrumentation.endCollectorRelease(m_package.getName(), agent.getNodeId(), agent.getHostAddress(), m_svcName);
     }
 
     /**

--- a/opennms-services/src/main/java/org/opennms/netmgt/collectd/SnmpCollector.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/collectd/SnmpCollector.java
@@ -37,6 +37,7 @@ import org.opennms.core.spring.BeanUtils;
 import org.opennms.netmgt.collection.api.AbstractServiceCollector;
 import org.opennms.netmgt.collection.api.CollectionAgent;
 import org.opennms.netmgt.collection.api.CollectionException;
+import org.opennms.netmgt.collection.api.CollectionInitializationException;
 import org.opennms.netmgt.collection.api.CollectionSet;
 import org.opennms.netmgt.collection.api.ServiceParameters;
 import org.opennms.netmgt.config.DataCollectionConfigFactory;
@@ -209,6 +210,11 @@ public class SnmpCollector extends AbstractServiceCollector {
         }
     }
 
+    @Override
+    public void validateAgent(CollectionAgent agent, Map<String, Object> parameters) throws CollectionInitializationException {
+        ((SnmpCollectionAgent)agent).validateAgent();
+    }
+
     /**
      * {@inheritDoc}
      *
@@ -217,8 +223,6 @@ public class SnmpCollector extends AbstractServiceCollector {
     @Override
     public CollectionSet collect(CollectionAgent agent, Map<String, Object> parameters) throws CollectionException {
         try {
-            ((SnmpCollectionAgent)agent).validateAgent();
-
             final ServiceParameters params = new ServiceParameters(parameters);
             params.logIfAliasConfig();
 

--- a/opennms-services/src/test/java/org/opennms/netmgt/collectd/MockServiceCollector.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/collectd/MockServiceCollector.java
@@ -83,6 +83,12 @@ public class MockServiceCollector implements ServiceCollector {
     }
 
     @Override
+    public void validateAgent(CollectionAgent agent, Map<String, Object> parameters)
+            throws CollectionInitializationException {
+        if (s_delegate != null) s_delegate.validateAgent(agent, parameters);
+    }
+
+    @Override
     public Map<String, Object> getRuntimeAttributes(CollectionAgent agent, Map<String, Object> parameters) {
         if (s_delegate != null) return s_delegate.getRuntimeAttributes(agent, parameters);
         return Collections.emptyMap();


### PR DESCRIPTION
JIRA: https://issues.opennms.org/browse/NMS-9413

Validate the agent prior to scheduling the interface in order to ensure that the SNMP collector only gets scheduled to run against the primary interfaces.