### PR TITLE
NMS-9426: Fix thresholding editor

### DIFF
--- a/opennms-webapp/src/main/webapp/WEB-INF/jsp/admin/thresholds/editExpression.jsp
+++ b/opennms-webapp/src/main/webapp/WEB-INF/jsp/admin/thresholds/editExpression.jsp
@@ -2,8 +2,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2007-2016 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2016 The OpenNMS Group, Inc.
+ * Copyright (C) 2007-2017 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -70,7 +70,7 @@
         			<select name="type" class="form-control">
         				<c:forEach items="${thresholdTypes}" var="thisType">
        						<c:choose>
-      							<c:when test="${expression.type==thisType}">
+      							<c:when test="${expression.type.enumName==thisType}">
         							<c:set var="selected">selected="selected"</c:set>
       							</c:when>
     	 						<c:otherwise>
@@ -96,7 +96,7 @@
     						<option ${selected} value='${thisDsType.key}'>${thisDsType.value}</option>
         				</c:forEach>
         			</select></td>
-     			<td><input type="text" name="dsLabel" class="form-control" size="30" value="${expression.dsLabel}"/></td>
+     			<td><input type="text" name="dsLabel" class="form-control" size="30" value="${expression.dsLabel.orElse(null)}"/></td>
         		<td><input type="text" name="value" class="form-control" size="10" value="${expression.value}"/></td>
         		<td><input type="text" name="rearm" class="form-control" size="10" value="${expression.rearm}"/></td>
         		<td><input type="text" name="trigger" class="form-control" size="10" value="${expression.trigger}"/></td>
@@ -109,9 +109,9 @@
                     <th>Re-armed UEI</th>
             </tr>
         	<tr>
-    			<td><input type="text" name="description" class="form-control" size="60" value="${expression.description}"/></td>
-    			<td><input type="text" name="triggeredUEI" class="form-control" size="60" value="${expression.triggeredUEI}"/></td>
-    		    <td><input type="text" name="rearmedUEI" class="form-control" size="60" value="${expression.rearmedUEI}"/></td>
+    			<td><input type="text" name="description" class="form-control" size="60" value="${expression.description.orElse(null)}"/></td>
+    			<td><input type="text" name="triggeredUEI" class="form-control" size="60" value="${expression.triggeredUEI.orElse(null)}"/></td>
+    		    <td><input type="text" name="rearmedUEI" class="form-control" size="60" value="${expression.rearmedUEI.orElse(null)}"/></td>
         	</tr>
       </table>
       <div class="panel-footer">
@@ -140,7 +140,7 @@
                   <select name="filterOperator" class="form-control">
                       <c:forEach items="${filterOperators}" var="thisOperator">
                           <c:choose>
-                              <c:when test="${expression.filterOperator==thisOperator}">
+                              <c:when test="${expression.filterOperator.enumName==thisOperator}">
                                   <c:set var="selected">selected="selected"</c:set>
                               </c:when>
                               <c:otherwise>
@@ -159,7 +159,7 @@
           <div class="col-md-12">
             <table class="table table-condensed">
             <tr><th>Field Name</th><th>Regular Expression</th><th>Actions</th></tr>
-              <c:forEach items="${expression.resourceFilter}" var="filter" varStatus="i">
+              <c:forEach items="${expression.resourceFilters}" var="filter" varStatus="i">
                 <tr>
                     <c:choose>
                       <c:when test="${i.count==filterSelected}">

--- a/opennms-webapp/src/main/webapp/WEB-INF/jsp/admin/thresholds/editGroup.jsp
+++ b/opennms-webapp/src/main/webapp/WEB-INF/jsp/admin/thresholds/editGroup.jsp
@@ -2,8 +2,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2007-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2007-2017 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -87,18 +87,18 @@
             <th>&nbsp;</th>
             <th>&nbsp;</th>
         </tr>
-        <c:forEach items="${group.threshold}" varStatus="thresholdIndex" var="threshold">
+        <c:forEach items="${group.thresholds}" varStatus="thresholdIndex" var="threshold">
             <tr>
-              <td>${threshold.type}</td>
-              <td>${threshold.description}</td>
+              <td>${threshold.type.enumName}</td>
+              <td>${threshold.description.orElse(null)}</td>
               <td>${threshold.dsName}</td>
               <td>${threshold.dsType}</td>
-              <td>${threshold.dsLabel}</td>
+              <td>${threshold.dsLabel.orElse(null)}</td>
               <td>${threshold.value}</td>
               <td>${threshold.rearm}</td>
               <td>${threshold.trigger}</td>
-              <td><a href="javascript: void submitNewNotificationForm('${threshold.triggeredUEI}');" title="Edit notifications for this uei">${threshold.triggeredUEI}</a></td>
-              <td><a href="javascript: void submitNewNotificationForm('${threshold.rearmedUEI}');" title="Edit notifications for this uei">${threshold.rearmedUEI}</a></td>
+              <td><a href="javascript: void submitNewNotificationForm('${threshold.triggeredUEI.orElse(null)}');" title="Edit notifications for this uei">${threshold.triggeredUEI.orElse(null)}</a></td>
+              <td><a href="javascript: void submitNewNotificationForm('${threshold.rearmedUEI.orElse(null)}');" title="Edit notifications for this uei">${threshold.rearmedUEI.orElse(null)}</a></td>
               <td><a href="admin/thresholds/index.htm?groupName=${group.name}&thresholdIndex=${thresholdIndex.index}&editThreshold">Edit</a></td>
               <td><a href="admin/thresholds/index.htm?groupName=${group.name}&thresholdIndex=${thresholdIndex.index}&deleteThreshold">Delete</a></td>
             </tr>
@@ -132,18 +132,18 @@
             <th>&nbsp;</th>
             <th>&nbsp;</th>
         </tr>
-          <c:forEach items="${group.expression}" varStatus="expressionIndex" var="expression">
+          <c:forEach items="${group.expressions}" varStatus="expressionIndex" var="expression">
             <tr>
-              <td>${expression.type}</td>
-              <td>${expression.description}</td>
+              <td>${expression.type.enumName}</td>
+              <td>${expression.description.orElse(null)}</td>
               <td>${expression.expression}</td>
               <td>${expression.dsType}</td>
-              <td>${expression.dsLabel}</td>
+              <td>${expression.dsLabel.orElse(null)}</td>
               <td>${expression.value}</td>
               <td>${expression.rearm}</td>
               <td>${expression.trigger}</td>
-              <td><a href="javascript: void submitNewNotificationForm('${expression.triggeredUEI}');" title="Edit notifications for this uei">${expression.triggeredUEI}</a></td>
-              <td><a href="javascript: void submitNewNotificationForm('${expression.rearmedUEI}');" title="Edit notifications for this uei">${expression.rearmedUEI}</a></td>
+              <td><a href="javascript: void submitNewNotificationForm('${expression.triggeredUEI.orElse(null)}');" title="Edit notifications for this uei">${expression.triggeredUEI.orElse(null)}</a></td>
+              <td><a href="javascript: void submitNewNotificationForm('${expression.rearmedUEI.orElse(null)}');" title="Edit notifications for this uei">${expression.rearmedUEI.orElse(null)}</a></td>
               <td><a href="admin/thresholds/index.htm?groupName=${group.name}&expressionIndex=${expressionIndex.index}&editExpression">Edit</a></td>
               <td><a href="admin/thresholds/index.htm?groupName=${group.name}&expressionIndex=${expressionIndex.index}&deleteExpression">Delete</a></td>
             </tr>

--- a/opennms-webapp/src/main/webapp/WEB-INF/jsp/admin/thresholds/editThreshold.jsp
+++ b/opennms-webapp/src/main/webapp/WEB-INF/jsp/admin/thresholds/editThreshold.jsp
@@ -2,8 +2,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2007-2016 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2016 The OpenNMS Group, Inc.
+ * Copyright (C) 2007-2017 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -70,7 +70,7 @@
         			<select name="type" class="form-control">
         				<c:forEach items="${thresholdTypes}" var="thisType">
        						<c:choose>
-      							<c:when test="${threshold.type==thisType}">
+      							<c:when test="${threshold.type.enumName==thisType}">
         							<c:set var="selected">selected="selected"</c:set>
       							</c:when>
     	 						<c:otherwise>
@@ -96,7 +96,7 @@
     						<option ${selected} value='${thisDsType.key}'>${thisDsType.value}</option>
         				</c:forEach>
         			</select></td>
-     			<td><input type="text" class="form-control" name="dsLabel" size="30" value="${threshold.dsLabel}"/></td>
+     			<td><input type="text" class="form-control" name="dsLabel" size="30" value="${threshold.dsLabel.orElse(null)}"/></td>
         		<td><input type="text" class="form-control" name="value" size="10" value="${threshold.value}"/></td>
         		<td><input type="text" class="form-control" name="rearm" size="10" value="${threshold.rearm}"/></td>
         		<td><input type="text" class="form-control" name="trigger" size="10" value="${threshold.trigger}"/></td>
@@ -109,9 +109,9 @@
                     <th>Re-armed UEI</th>
             </tr>
         	<tr>
-    			<td><input type="text" name="description" class="form-control" size="60" value="${threshold.description}"/></td>
-    			<td><input type="text" name="triggeredUEI" class="form-control" size="60" value="${threshold.triggeredUEI}"/></td>
-    		    <td><input type="text" name="rearmedUEI" class="form-control" size="60" value="${threshold.rearmedUEI}"/></td>
+    			<td><input type="text" name="description" class="form-control" size="60" value="${threshold.description.orElse(null)}"/></td>
+    			<td><input type="text" name="triggeredUEI" class="form-control" size="60" value="${threshold.triggeredUEI.orElse(null)}"/></td>
+    		    <td><input type="text" name="rearmedUEI" class="form-control" size="60" value="${threshold.rearmedUEI.orElse(null)}"/></td>
         	</tr>
       </table>
       <div class="panel-footer">
@@ -140,7 +140,7 @@
                   <select name="filterOperator" class="form-control">
                       <c:forEach items="${filterOperators}" var="thisOperator">
                           <c:choose>
-                              <c:when test="${threshold.filterOperator==thisOperator}">
+                              <c:when test="${threshold.filterOperator.enumName==thisOperator}">
                                   <c:set var="selected">selected="selected"</c:set>
                               </c:when>
                               <c:otherwise>
@@ -159,17 +159,17 @@
           <div class="col-md-12">
             <table class="table table-condensed">
             <tr><th>Field Name</th><th>Regular Expression</th><th>Actions</th></tr>
-              <c:forEach items="${threshold.resourceFilter}" var="filter" varStatus="i">
+              <c:forEach items="${threshold.resourceFilters}" var="filter" varStatus="i">
                 <tr>
                     <c:choose>
                       <c:when test="${i.count==filterSelected}">
                         <td><input type="text" name="updateFilterField" class="form-control" size="60" value="${filter.field}"/></td>
-                        <td><input type="text" name="updateFilterRegexp" class="form-control" size="60" value="${filter.content}"/></td>
+                        <td><input type="text" name="updateFilterRegexp" class="form-control" size="60" value="${filter.content.orElse(null)}"/></td>
                         <td><input type="submit" name="submitAction" class="btn btn-default" value="${updateButtonTitle}" onClick="document.frm.filterSelected.value='${i.count}'"/></td>          
                       </c:when>
                       <c:otherwise>
                         <td><input type="text" disabled="disabled" class="form-control" size="60" value="${filter.field}"/></td>
-                        <td><input type="text" disabled="disabled" class="form-control" size="60" value="${filter.content}"/></td>
+                        <td><input type="text" disabled="disabled" class="form-control" size="60" value="${filter.content.orElse(null)}"/></td>
                         <td><input type="submit" name="submitAction" class="btn btn-default" value="${editButtonTitle}" onClick="document.frm.filterSelected.value='${i.count}'"/>
                             <input type="submit" name="submitAction" class="btn btn-default" value="${deleteButtonTitle}" onClick="document.frm.filterSelected.value='${i.count}'"/>
                             <input type="submit" name="submitAction" class="btn btn-default" value="${moveUpButtonTitle}" onClick="document.frm.filterSelected.value='${i.count}'"/>


### PR DESCRIPTION
The thresholding editor was broken by the refactor of JAXB code, and because it uses the old servlet-with-model-objects style, it wasn't caught at compile time.

This fixes all the issues I could find in both rendering and editing of thresholds and expressions.

* JIRA: http://issues.opennms.org/browse/NMS-9426

Our [continuous integration system](http://bamboo.internal.opennms.com:8085) will test and verify your changes.
