### PR TITLE
NMS-9415: NullPointerException during nodeScan

### DIFF
--- a/opennms-provision/opennms-provisiond/src/main/java/org/opennms/netmgt/provision/service/IPAddressTableTracker.java
+++ b/opennms-provision/opennms-provisiond/src/main/java/org/opennms/netmgt/provision/service/IPAddressTableTracker.java
@@ -100,6 +100,11 @@ public class IPAddressTableTracker extends TableTracker {
         
         public String getIpAddress() {
             final SnmpResult result = getResult(IP_ADDRESS_IF_INDEX);
+            if (result == null) {
+                LOG.warn("BAD AGENT: Device is missing IP-MIB::ipAddressIfIndex. Skipping.");
+                return null;
+            }
+
             SnmpInstId instance = result.getInstance();
             final int[] instanceIds = instance.getIds();
 


### PR DESCRIPTION
Fix NullPointerException during nodeScan on devices with broken IP-MIB::ipAddressIfIndex

* JIRA: http://issues.opennms.org/browse/NMS-9415
