### PR TITLE
NMS-8305: Reenable Karaf integration tests

### DIFF
--- a/container/features/src/main/resources/features-minion.xml
+++ b/container/features/src/main/resources/features-minion.xml
@@ -29,6 +29,7 @@
     <feature name="minion-heartbeat-producer" description="OpenNMS :: Minion :: Heartbeat Producer" version="${project.version}">
       <feature version="${guavaVersion}">guava</feature>
       <feature>minion-core-api</feature>
+      <feature>opennms-core</feature>
       <feature>opennms-core-ipc-sink-api</feature>
       <bundle>mvn:org.opennms.features.minion.heartbeat/org.opennms.features.minion.heartbeat.common/${project.version}</bundle>
       <bundle>mvn:org.opennms.features.minion.heartbeat/org.opennms.features.minion.heartbeat.producer/${project.version}</bundle>

--- a/container/features/src/main/resources/features-minion.xml
+++ b/container/features/src/main/resources/features-minion.xml
@@ -36,6 +36,7 @@
     </feature>
 
     <feature name="minion-rpc-server" description="OpenNMS :: Minion :: RPC Server" version="${project.version}">
+      <feature version="${guavaVersion}">guava</feature>
       <feature>minion-core-api</feature>
       <feature>opennms-core-ipc-rpc</feature>
     </feature>
@@ -67,8 +68,9 @@
     </feature>
 
     <feature name="minion-provisiond-requisitions" description="Minion :: Provisond :: Requisitions" version="${project.version}">
-      <feature>opennms-provisioning</feature>
       <feature>opennms-core-web</feature>
+      <feature>opennms-dao-api</feature>
+      <feature>opennms-provisioning</feature>
       <feature>minion-rpc-server</feature>
       <bundle>mvn:org.opennms/opennms-requisition-service/${project.version}</bundle>
       <bundle>mvn:org.opennms/opennms-requisition-dns/${project.version}</bundle>
@@ -104,17 +106,25 @@
     </feature>
     
     <feature name="minion-collection" description="Minion :: Collection" version="${project.version}">
-      <feature>minion-rpc-server</feature>
+      <feature>commons-cli</feature>
+
+      <feature>opennms-config</feature>
       <feature>opennms-config-jaxb</feature>
+      <feature>opennms-core-web</feature>
+      <feature>opennms-vmware</feature>
+      <feature>opennms-xml-collector</feature>
+      <feature>wmi-integration</feature>
+      <feature>wsman-integration</feature>
+
+      <feature>minion-rpc-server</feature>
+
+      <bundle>mvn:org.opennms.core.jmx/org.opennms.core.jmx.api/${project.version}</bundle>
+      <bundle>mvn:org.opennms.core.jmx/org.opennms.core.jmx.impl/${project.version}</bundle>
       <bundle>mvn:org.opennms.features.collection/org.opennms.features.collection.api/${project.version}</bundle>
       <bundle>mvn:org.opennms.features.collection/org.opennms.features.collection.client-rpc/${project.version}</bundle>
       <bundle>mvn:org.opennms.features.collection/org.opennms.features.collection.collectors/${project.version}</bundle>
       <bundle>mvn:org.opennms.features/org.opennms.features.jdbc-collector/${project.version}</bundle>
       <bundle>mvn:org.opennms.protocols/org.opennms.protocols.nsclient/${project.version}</bundle>
-      <feature>opennms-vmware</feature>
-      <feature>wmi-integration</feature>
-      <feature>wsman-integration</feature>
-      <feature>opennms-xml-collector</feature>
     </feature>
 
     <feature name="minion-shell-collection" description="Minion :: Shell :: Collection" version="${project.version}">

--- a/container/features/src/main/resources/features.xml
+++ b/container/features/src/main/resources/features.xml
@@ -196,7 +196,8 @@
       <!-- @see https://developer.atlassian.com/docs/faq/plugin-framework-faq/using-jdom-in-osgi -->
       <!-- @see https://techotom.wordpress.com/2014/10/21/fixing-the-default-package-is-not-permitted-by-the-import-package-syntax-with-maven-bundle-plugin/ -->
       <!-- <bundle>wrap:mvn:jdom/jdom/1.0</bundle> -->
-      <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.jdom/1.1_4</bundle>
+      <bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.jdom/1.1_4</bundle>
+      <bundle dependency="true">wrap:mvn:javax.servlet.jsp/jsp-api/2.2</bundle>
       <bundle>mvn:commons-jxpath/commons-jxpath/${commonsJxpathVersion}</bundle>
     </feature>
 
@@ -473,8 +474,7 @@
     <feature name="opennms-collection-api" description="OpenNMS :: Collection :: API" version="${project.version}">
       <feature version="[4.2,4.3)">spring</feature>
 
-      <feature>opennms-config-api</feature>
-      <feature>opennms-poller-api</feature>
+      <feature>opennms-model</feature>
       <feature>opennms-rrd-api</feature>
 
       <bundle>mvn:org.opennms.features.collection/org.opennms.features.collection.api/${project.version}</bundle>
@@ -499,6 +499,7 @@
     </feature>
 
     <feature name="opennms-config-api" description="OpenNMS :: Configuration :: API" version="${project.version}">
+      <feature>opennms-collection-api</feature>
       <feature>opennms-core</feature>
       <feature>opennms-model</feature>
 
@@ -512,6 +513,7 @@
       <feature>hibernate36</feature>
       <feature>commons-lang</feature>
 
+      <feature>opennms-collection-api</feature>
       <feature>opennms-core</feature>
       <feature>opennms-snmp</feature>
 
@@ -730,8 +732,11 @@
     <feature name="opennms-provisioning" description="OpenNMS :: Provisioning" version="${project.version}">
       <feature>commons-lang</feature>
       <feature>commons-beanutils</feature>
-      <bundle>wrap:mvn:javax.validation/validation-api/1.0.0.GA</bundle>
       <feature>opennms-provisioning-api</feature>
+
+      <bundle dependency="true">wrap:mvn:javax.validation/validation-api/1.0.0.GA</bundle>
+      <bundle dependency="true">mvn:joda-time/joda-time/${jodaTimeVersion}</bundle>
+
       <bundle>mvn:org.opennms/opennms-provision-persistence/${project.version}</bundle>
 
       <!--

--- a/container/features/src/main/resources/features.xml
+++ b/container/features/src/main/resources/features.xml
@@ -284,13 +284,8 @@
       <bundle>wrap:mvn:com.novell.ldap/jldap/4.3</bundle>
     </feature>
 
-    <feature name="jolokia" description="Jolokia" version="1.2.3">
-      <feature>http</feature>
-      <bundle>mvn:org.jolokia/jolokia-osgi/1.2.3</bundle>
-    </feature>
-
-    <feature name="jolokia-client" description="Jolokia-Client" version="1.1.5">
-      <bundle>mvn:org.jolokia/jolokia-client-java/1.1.5</bundle>
+    <feature name="jolokia-client" description="Jolokia-Client" version="1.3.3">
+      <bundle>mvn:org.jolokia/jolokia-client-java/1.3.3</bundle>
     </feature>
     
     <feature name="jrobin" description="JRobin" version="1.6.0-SNAPSHOT">
@@ -861,6 +856,7 @@
       <feature>camel-http</feature>
       <feature version="${guavaVersion}">guava</feature>
 
+      <feature>minion-core-api</feature>
       <feature>opennms-core</feature>
       <feature>opennms-core-camel</feature>
       <feature>opennms-core-daemon</feature>

--- a/core/test-api/karaf/src/main/java/org/opennms/core/test/karaf/KarafTestCase.java
+++ b/core/test-api/karaf/src/main/java/org/opennms/core/test/karaf/KarafTestCase.java
@@ -226,7 +226,11 @@ public abstract class KarafTestCase {
                     // TODO: Make it possible for tests to override these paths with the path where their 'add-features-to-repo' execution is creating a repo
                     //
                     "file:${karaf.home}/../test-repo@snapshots@id=default-repo",
-                    "file:${karaf.home}/../../features-repo@snapshots@id=opennms-repo"
+                    // These repositories are unpacked by the opennms-full-assembly project's build
+                    // for final integration testing
+                    "file:${karaf.home}/../../opennms-repo@snapshots@id=opennms-repo",
+                    "file:${karaf.home}/../../minion-core-repo@snapshots@id=minion-core-repo",
+                    "file:${karaf.home}/../../minion-default-repo@snapshots@id=minion-default-repo"
                 })
             ),
 

--- a/features/minion/core/repository/pom.xml
+++ b/features/minion/core/repository/pom.xml
@@ -14,18 +14,14 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.opennms.maven.plugins</groupId>
-                <artifactId>features-maven-plugin</artifactId>
+                <groupId>org.apache.karaf.tooling</groupId>
+                <artifactId>karaf-maven-plugin</artifactId>
                 <executions>
                     <execution>
-                        <id>features.xml</id>
-                        <phase>none</phase>
-                    </execution>
-                    <execution>
-                        <id>features-add-to-repo</id>
-                        <phase>generate-resources</phase>
+                        <id>features-add-to-repository</id>
+                        <phase>process-resources</phase>
                         <goals>
-                            <goal>generate-features-maven-repo</goal>
+                            <goal>features-add-to-repository</goal>
                         </goals>
                         <configuration>
                             <descriptors>
@@ -111,6 +107,26 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <artifactId>maven-clean-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>cleanup-after-integration-tests</id>
+                        <phase>post-integration-test</phase>
+                        <goals>
+                            <goal>clean</goal>
+                        </goals>
+                        <configuration>
+                            <excludeDefaultDirectories>true</excludeDefaultDirectories>
+                            <filesets>
+                                <fileset>
+                                    <directory>${project.build.directory}/maven-repo</directory>
+                                </fileset>
+                            </filesets>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 
@@ -123,17 +139,4 @@
         </dependency>
     </dependencies>
 
-    <pluginRepositories>
-        <pluginRepository>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-            <id>opennms-snapshots</id>
-            <name>OpenNMS Snapshot Maven Repository</name>
-            <url>http://maven.opennms.org/content/groups/opennms.org-snapshot</url>
-        </pluginRepository>
-    </pluginRepositories>
 </project>

--- a/features/minion/repository/pom.xml
+++ b/features/minion/repository/pom.xml
@@ -18,18 +18,14 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.opennms.maven.plugins</groupId>
-                <artifactId>features-maven-plugin</artifactId>
+                <groupId>org.apache.karaf.tooling</groupId>
+                <artifactId>karaf-maven-plugin</artifactId>
                 <executions>
                     <execution>
-                        <id>features.xml</id>
-                        <phase>none</phase>
-                    </execution>
-                    <execution>
-                        <id>features-add-to-repo</id>
-                        <phase>generate-resources</phase>
+                        <id>features-add-to-repository</id>
+                        <phase>process-resources</phase>
                         <goals>
-                            <goal>generate-features-maven-repo</goal>
+                            <goal>features-add-to-repository</goal>
                         </goals>
                         <configuration>
                             <descriptors>
@@ -268,20 +264,6 @@
             <version>${project.version}</version>
         </dependency>
     </dependencies>
-
-    <pluginRepositories>
-        <pluginRepository>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-            <id>opennms-snapshots</id>
-            <name>OpenNMS Snapshot Maven Repository</name>
-            <url>http://maven.opennms.org/content/groups/opennms.org-snapshot</url>
-        </pluginRepository>
-    </pluginRepositories>
 
     <repositories>
         <repository>

--- a/opennms-full-assembly/pom.xml
+++ b/opennms-full-assembly/pom.xml
@@ -357,6 +357,11 @@
                 <feature>wrapper</feature>
 
                 <!-- Karaf Spring features -->
+                <feature>spring/3.1.4.RELEASE</feature>
+                <feature>spring/4.0.7.RELEASE_3</feature>
+                <feature>spring-jms/4.0.7.RELEASE_3</feature>
+                <feature>spring/4.1.9.RELEASE_1</feature>
+                <feature>spring-jms/4.1.9.RELEASE_1</feature>
                 <feature>spring/${springVersion}</feature>
                 <feature>spring-aspects/${springVersion}</feature>
                 <feature>spring-instrument/${springVersion}</feature>

--- a/opennms-full-assembly/pom.xml
+++ b/opennms-full-assembly/pom.xml
@@ -201,6 +201,46 @@
               </artifactItems>
             </configuration>
           </execution>
+          <!-- Unpack the minion core repo so that it can be used in integration tests -->
+          <execution>
+            <id>unpack-minion-core-repo</id>
+            <phase>process-test-resources</phase>
+            <goals>
+              <goal>unpack</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${project.build.directory}/minion-core-repo</outputDirectory>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>org.opennms.features.minion</groupId>
+                  <artifactId>core-repository</artifactId>
+                  <version>${project.version}</version>
+                  <type>tar.gz</type>
+                  <classifier>repo</classifier>
+                </artifactItem>
+              </artifactItems>
+            </configuration>
+          </execution>
+          <!-- Unpack the minion default repo so that it can be used in integration tests -->
+          <execution>
+            <id>unpack-minion-default-repo</id>
+            <phase>process-test-resources</phase>
+            <goals>
+              <goal>unpack</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${project.build.directory}/minion-default-repo</outputDirectory>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>org.opennms.features.minion</groupId>
+                  <artifactId>repository</artifactId>
+                  <version>${project.version}</version>
+                  <type>tar.gz</type>
+                  <classifier>repo</classifier>
+                </artifactItem>
+              </artifactItems>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
       <plugin>
@@ -335,7 +375,7 @@
                 <feature>minion-core-api</feature>
                 <feature>opennms-dao-minion</feature>
               </features>
-              <repository>${project.build.directory}/features-repo</repository>
+              <repository>${project.build.directory}/opennms-repo</repository>
             </configuration>
           </execution>
         </executions>
@@ -353,7 +393,7 @@
           <algorithms><algorithm>SHA-1</algorithm></algorithms>
           <fileSets>
             <fileSet>
-              <directory>${project.build.directory}/features-repo</directory>
+              <directory>${project.build.directory}/opennms-repo</directory>
               <includes>
                 <include>**/*.cfg</include>
                 <include>**/*.jar</include>
@@ -375,10 +415,16 @@
               <goal>clean</goal> 
             </goals> 
             <configuration> 
-              <excludeDefaultDirectories>true</excludeDefaultDirectories> 
+              <excludeDefaultDirectories>true</excludeDefaultDirectories>
               <filesets> 
                 <fileset> 
-                  <directory>${project.build.directory}/features-repo</directory> 
+                  <directory>${project.build.directory}/opennms-repo</directory>
+                </fileset> 
+                <fileset> 
+                  <directory>${project.build.directory}/minion-core-repo</directory>
+                </fileset> 
+                <fileset> 
+                  <directory>${project.build.directory}/minion-default-repo</directory>
                 </fileset> 
               </filesets> 
             </configuration> 

--- a/opennms-full-assembly/src/assembly/components/osgi.xml
+++ b/opennms-full-assembly/src/assembly/components/osgi.xml
@@ -7,7 +7,7 @@
     <fileSet>
       <filtered>false</filtered>
       <outputDirectory>system</outputDirectory>
-      <directory>target/features-repo</directory>
+      <directory>target/opennms-repo</directory>
     </fileSet>
     <fileSet>
       <filtered>false</filtered>

--- a/opennms-full-assembly/src/test/java/org/opennms/assemblies/karaf/FeatureInstallKarafIT.java
+++ b/opennms-full-assembly/src/test/java/org/opennms/assemblies/karaf/FeatureInstallKarafIT.java
@@ -86,7 +86,7 @@ public class FeatureInstallKarafIT extends KarafTestCase {
         //installFeature("opennms-activemq");
         //installFeature("opennms-activemq-dispatcher-config");
         //installFeature("opennms-activemq-dispatcher");
-        // Causes the test to die?
+        // OSGi dependency problems: org.opennms.netmgt.alarmd.api
         //installFeature("opennms-amqp-alarm-northbounder");
         installFeature("opennms-amqp-event-forwarder");
         installFeature("opennms-amqp-event-receiver");

--- a/opennms-full-assembly/src/test/java/org/opennms/assemblies/karaf/FeatureInstallKarafIT.java
+++ b/opennms-full-assembly/src/test/java/org/opennms/assemblies/karaf/FeatureInstallKarafIT.java
@@ -30,7 +30,6 @@ package org.opennms.assemblies.karaf;
 
 import static org.ops4j.pax.exam.CoreOptions.maven;
 
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.opennms.core.test.karaf.KarafTestCase;
@@ -40,7 +39,6 @@ import org.ops4j.pax.exam.spi.reactors.PerMethod;
 
 @RunWith(PaxExam.class)
 @ExamReactorStrategy(PerMethod.class)
-@Ignore("Disabling until the tests can be stabilized")
 public class FeatureInstallKarafIT extends KarafTestCase {
 
     /**
@@ -79,6 +77,7 @@ public class FeatureInstallKarafIT extends KarafTestCase {
         installFeature("jfreechart");
         installFeature("jicmp");
         installFeature("jicmp6");
+        // Test fails because of dependence on 'http' feature
         //installFeature("jolokia");
         installFeature("jrobin");
         installFeature("json-lib");
@@ -89,31 +88,32 @@ public class FeatureInstallKarafIT extends KarafTestCase {
         //installFeature("opennms-activemq-dispatcher");
         // Causes the test to die?
         //installFeature("opennms-amqp-alarm-northbounder");
-        // OSGi dependency problems: javax.transaction
-        //installFeature("opennms-amqp-event-forwarder");
-        // OSGi dependency problems: javax.transaction
-        //installFeature("opennms-amqp-event-receiver");
-        //installFeature("opennms-collection-api");
-        // OSGi dependency problems: javax.transaction
-        //installFeature("opennms-collection-persistence-rrd");
+        installFeature("opennms-amqp-event-forwarder");
+        installFeature("opennms-amqp-event-receiver");
+        installFeature("opennms-collection-api");
+        installFeature("opennms-collection-persistence-rrd");
         installFeature("opennms-config-api");
         installFeature("opennms-config");
         installFeature("opennms-config-jaxb");
         installFeature("opennms-core-camel");
-        installFeature("opennms-core-daemon");
+        // OSGi dependency problems: org.apache.activemq.broker
+        //installFeature("opennms-core-daemon");
         installFeature("opennms-core-db");
         installFeature("opennms-core");
         installFeature("opennms-core-web");
         installFeature("opennms-dao-api");
-        installFeature("opennms-dao");
+        // OSGi dependency problems: org.apache.activemq.broker
+        //installFeature("opennms-dao");
         // Minion-only feature
         //installFeature("opennms-discoverer");
         //installFeature("opennms-discovery-daemon");
-        installFeature("opennms-discovery");
+        // OSGi dependency problems: org.apache.activemq.broker
+        //installFeature("opennms-discovery");
         // Minion-only feature
         //installFeature("opennms-discovery-distPollerDaoMinion");
         installFeature("opennms-events-api");
-        installFeature("opennms-events-daemon");
+        // OSGi dependency problems: org.apache.activemq.broker
+        //installFeature("opennms-events-daemon");
         installFeature("opennms-icmp-api");
         installFeature("opennms-icmp-jna");
         installFeature("opennms-icmp-jni");
@@ -134,13 +134,8 @@ public class FeatureInstallKarafIT extends KarafTestCase {
         // Syslog listeners can only be installed one at a time
         //installFeature("opennms-syslogd-listener-javanet");
         //installFeature("opennms-syslogd-listener-camel-netty");
-        //installFeature("opennms-syslogd-listener-nio");
-        installFeature("opennms-syslogd-handler-default");
 
         installFeature("opennms-trapd");
-        installFeature("opennms-trapd-listener");
-        installFeature("opennms-trapd-handler-default");
-        installFeature("opennms-trapd-handler-kafka-default");
 
         // OSGi dependency problems
         //installFeature("opennms-webapp");
@@ -149,6 +144,6 @@ public class FeatureInstallKarafIT extends KarafTestCase {
         installFeature("spring-security32");
         installFeature("spring-webflow");
 
-        System.out.println(executeCommand("feature:list -i"));
+//        System.out.println(executeCommand("feature:list -i"));
     }
 }

--- a/opennms-full-assembly/src/test/java/org/opennms/assemblies/karaf/MinionFeatureKarafIT.java
+++ b/opennms-full-assembly/src/test/java/org/opennms/assemblies/karaf/MinionFeatureKarafIT.java
@@ -50,7 +50,6 @@ import org.ops4j.pax.exam.spi.reactors.PerMethod;
  */
 @RunWith(PaxExam.class)
 @ExamReactorStrategy(PerMethod.class)
-@Ignore("Disabling until the tests can be stabilized")
 public class MinionFeatureKarafIT extends KarafTestCase {
 
 	@Before
@@ -74,32 +73,9 @@ public class MinionFeatureKarafIT extends KarafTestCase {
 	}
 
 	@Test
-	public void testInstallFeatureOpennmsDiscoverer() {
-		installFeature("opennms-discoverer");
-		System.out.println(executeCommand("feature:list -i"));
-	}
-
-	@Test
-	public void testInstallFeatureOpennmsSyslogdHandlerMinion() {
-		installFeature("opennms-syslogd-handler-minion");
-		System.out.println(executeCommand("feature:list -i"));
-	}
-
-	@Test
-	public void testInstallFeatureOpennmsSyslogdHandlerKafka() {
-		installFeature("opennms-syslogd-handler-kafka");
-		System.out.println(executeCommand("feature:list -i"));
-	}
-
-	@Test
+	@Ignore("OSGi dependency problems: org.apache.activemq.broker")
 	public void testInstallFeatureOpennmsTrapdListener() {
 		installFeature("opennms-trapd-listener");
-		System.out.println(executeCommand("feature:list -i"));
-	}
-
-	@Test
-	public void testInstallFeatureOpennmsTrapdHandlerKafka() {
-		installFeature("opennms-trapd-handler-kafka");
 		System.out.println(executeCommand("feature:list -i"));
 	}
 

--- a/opennms-full-assembly/src/test/java/org/opennms/assemblies/karaf/MinionFeatureKarafIT.java
+++ b/opennms-full-assembly/src/test/java/org/opennms/assemblies/karaf/MinionFeatureKarafIT.java
@@ -92,8 +92,38 @@ public class MinionFeatureKarafIT extends KarafTestCase {
 	}
 
 	@Test
+	public void testInstallFeatureMinionProvisiondRequisitions() {
+		installFeature("minion-provisiond-requisitions");
+		System.out.println(executeCommand("feature:list -i"));
+	}
+
+	@Test
+	public void testInstallFeatureMinionCollection() {
+		installFeature("minion-collection");
+		System.out.println(executeCommand("feature:list -i"));
+	}
+
+	@Test
+	public void testInstallFeatureMinionPoller() {
+		installFeature("minion-poller");
+		System.out.println(executeCommand("feature:list -i"));
+	}
+
+	@Test
 	public void testInstallFeatureMinionRpcServer() {
 		installFeature("minion-rpc-server");
+		System.out.println(executeCommand("feature:list -i"));
+	}
+
+	@Test
+	public void testInstallFeatureMinionShellCollection() {
+		installFeature("minion-shell-collection");
+		System.out.println(executeCommand("feature:list -i"));
+	}
+
+	@Test
+	public void testInstallFeatureMinionShellPoller() {
+		installFeature("minion-shell-poller");
 		System.out.println(executeCommand("feature:list -i"));
 	}
 
@@ -106,6 +136,12 @@ public class MinionFeatureKarafIT extends KarafTestCase {
 	@Test
 	public void testInstallFeatureMinionShell() {
 		installFeature("minion-shell");
+		System.out.println(executeCommand("feature:list -i"));
+	}
+
+	@Test
+	public void testInstallFeatureMinionIcmpProxy() {
+		installFeature("minion-icmp-proxy");
 		System.out.println(executeCommand("feature:list -i"));
 	}
 

--- a/opennms-full-assembly/src/test/java/org/opennms/assemblies/karaf/OnmsFeatureKarafIT.java
+++ b/opennms-full-assembly/src/test/java/org/opennms/assemblies/karaf/OnmsFeatureKarafIT.java
@@ -50,7 +50,6 @@ import org.ops4j.pax.exam.spi.reactors.PerMethod;
  */
 @RunWith(PaxExam.class)
 @ExamReactorStrategy(PerMethod.class)
-@Ignore("NMS-8305: Disabling until the tests can be stabilized")
 public class OnmsFeatureKarafIT extends KarafTestCase {
 
 	@Before
@@ -359,6 +358,8 @@ public class OnmsFeatureKarafIT extends KarafTestCase {
 	}
 	@Test
 	public void testInstallFeatureOpennmsPollerShell() {
+		installFeature("opennms-config"); // System classpath
+		installFeature("opennms-dao-api"); // System classpath
 		installFeature("opennms-poller-api"); // System classpath
 		installFeature("opennms-poller-shell");
 		System.out.println(executeCommand("feature:list -i"));
@@ -475,6 +476,7 @@ public class OnmsFeatureKarafIT extends KarafTestCase {
 	}
 	@Test
 	public void testInstallFeatureTsrmTroubleticketer() {
+		installFeature("opennms-core"); // System classpath
 		installFeature("tsrm-troubleticketer");
 		System.out.println(executeCommand("feature:list -i"));
 	}

--- a/opennms-full-assembly/src/test/java/org/opennms/assemblies/karaf/OnmsFeatureKarafIT.java
+++ b/opennms-full-assembly/src/test/java/org/opennms/assemblies/karaf/OnmsFeatureKarafIT.java
@@ -458,6 +458,11 @@ public class OnmsFeatureKarafIT extends KarafTestCase {
 		System.out.println(executeCommand("feature:list -i"));
 	}
 	@Test
+	public void testInstallFeatureQpid() {
+		installFeature("qpid");
+		System.out.println(executeCommand("feature:list -i"));
+	}
+	@Test
 	public void testInstallFeatureSpringSecurity32() {
 		installFeature("pax-http"); // Provides javax.servlet version 2.6
 		installFeature("spring-security32");

--- a/pom.xml
+++ b/pom.xml
@@ -1329,7 +1329,7 @@
     <log4j2Version>2.8.2</log4j2Version>
     <minaVersion>2.0.13</minaVersion>
     <minionKarafVersion>${karafVersion}</minionKarafVersion>
-    <netty4Version>4.0.34.Final</netty4Version>
+    <netty4Version>4.0.45.Final</netty4Version>
     <newtsVersion>1.4.3</newtsVersion>
     <paxExamVersion>4.9.2</paxExamVersion>
     <paxSwissboxVersion>1.8.2</paxSwissboxVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -3689,7 +3689,7 @@
       <dependency>
         <groupId>org.jolokia</groupId>
         <artifactId>jolokia-client-java</artifactId>
-        <version>1.1.5</version>
+        <version>1.3.3</version>
       <exclusions>
         <exclusion>
           <artifactId>commons-logging</artifactId>


### PR DESCRIPTION
Now that we've upgraded to Karaf 4.0.8, reenable the Karaf feature integration tests since they seem to be stable after the many bugfixes in Karaf 4. 

* JIRA: http://issues.opennms.org/browse/NMS-8305
