### PR TITLE
HZN-1095: Switch from using the maven-jaxb2-plugin to the cxf-xjc-plugin

### DIFF
--- a/features/jmx-config-generator/pom.xml
+++ b/features/jmx-config-generator/pom.xml
@@ -62,23 +62,31 @@
             However the subset defined in "jmx-datacollection.config.xsd" must be compatible with the one
             defined in opennms-config. -->
             <plugin>
-                <groupId>org.jvnet.jaxb2.maven2</groupId>
-                <artifactId>maven-jaxb2-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>generate</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.opennms.dependencies</groupId>
-                        <artifactId>jaxb-dependencies</artifactId>
-                        <type>pom</type>
-                        <version>${project.version}</version>
-                    </dependency>
-                </dependencies>
+              <groupId>org.apache.cxf</groupId>
+              <artifactId>cxf-xjc-plugin</artifactId>
+              <configuration>
+                <extensions>
+                  <extension>org.apache.cxf.xjcplugins:cxf-xjc-dv:${cxfXjcVersion}</extension>
+                </extensions>
+              </configuration>
+              <executions>
+                <execution>
+                  <id>generate-sources-trans</id>
+                  <phase>generate-sources</phase>
+                  <goals>
+                    <goal>xsdtojava</goal>
+                  </goals>
+                  <configuration>
+                    <sourceRoot>${project.build.directory}/generated-sources/jaxb</sourceRoot>
+                    <xsdOptions>
+                      <xsdOption>
+                        <xsd>src/main/resources/jmx-datacollection-config.xsd</xsd>
+                        <packagename>org.opennms.xmlns.xsd.config.jmx_datacollection</packagename>
+                      </xsdOption>
+                    </xsdOptions>
+                  </configuration>
+                </execution>
+              </executions>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
@@ -96,6 +104,17 @@
                                     <classifier>features</classifier>
                                 </artifact>
                             </artifacts>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>${project.build.directory}/generated-sources/jaxb</source>
+                            </sources>
                         </configuration>
                     </execution>
                 </executions>

--- a/features/ticketing/otrs-integration-31/pom.xml
+++ b/features/ticketing/otrs-integration-31/pom.xml
@@ -111,7 +111,7 @@
 		<dependency>
 			<groupId>org.apache.cxf.xjc-utils</groupId>
 			<artifactId>cxf-xjc-runtime</artifactId>
-			<version>3.0.4</version>
+			<version>${cxfXjcVersion}</version>
 			<exclusions>
 				<exclusion>
 					<groupId>javax.xml.bind</groupId>

--- a/features/ticketing/tsrm-integration/pom.xml
+++ b/features/ticketing/tsrm-integration/pom.xml
@@ -107,7 +107,7 @@
 		<dependency>
 			<groupId>org.apache.cxf.xjc-utils</groupId>
 			<artifactId>cxf-xjc-runtime</artifactId>
-			<version>3.0.5</version>
+			<version>${cxfXjcVersion}</version>
 			<exclusions>
 				<exclusion>
 					<groupId>javax.xml.bind</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1051,9 +1051,9 @@
       </plugin>
       -->
       <plugin>
-        <groupId>org.jvnet.jaxb2.maven2</groupId>
-        <artifactId>maven-jaxb2-plugin</artifactId>
-        <version>0.12.3</version>
+        <groupId>org.apache.cxf</groupId>
+        <artifactId>cxf-xjc-plugin</artifactId>
+        <version>${cxfXjcVersion}</version>
       </plugin>
     </plugins>
  </build>
@@ -1291,6 +1291,7 @@
     <c3p0Version>0.9.5.2</c3p0Version>
     <curatorVersion>3.2.1</curatorVersion>
     <cxfVersion>3.1.11</cxfVersion>
+    <cxfXjcVersion>3.1.0</cxfXjcVersion>
     <dnsjavaVersion>2.1.3</dnsjavaVersion>
     <dropwizardMetricsVersion>3.1.2</dropwizardMetricsVersion>
     <ecjVersion>4.4.2</ecjVersion>


### PR DESCRIPTION
JIRA: https://issues.opennms.org/browse/HZN-1095

Switching to cxf-xjc-plugin allows us to compile these modules under Java 9.