### PR TITLE
NMS-9455: BridgeTopology Discovery Mismatch after opennms restart

### DIFF
--- a/opennms-dao/src/main/java/org/opennms/netmgt/dao/BridgeTopologyDaoInMemory.java
+++ b/opennms-dao/src/main/java/org/opennms/netmgt/dao/BridgeTopologyDaoInMemory.java
@@ -47,6 +47,7 @@ import org.opennms.netmgt.model.topology.BroadcastDomain;
 import org.opennms.netmgt.model.topology.SharedSegment;
 
 public class BridgeTopologyDaoInMemory implements BridgeTopologyDao {
+    
     volatile Set<BroadcastDomain> m_domains = new HashSet<BroadcastDomain>();
 
     @Override
@@ -62,24 +63,6 @@ public class BridgeTopologyDaoInMemory implements BridgeTopologyDao {
     @Override
     public List<SharedSegment> getBridgeNodeSharedSegments(BridgeBridgeLinkDao bridgeBridgeLinkDao,BridgeMacLinkDao bridgeMacLinkDao, int nodeid) {
         List<SharedSegment> segments = new ArrayList<SharedSegment>();
-        /*
-        for (BroadcastDomain domain: getAllPersisted(bridgeBridgeLinkDao, bridgeMacLinkDao)) {
-            System.out.println("parsing domain:" + domain);
-            System.out.println("parsing domain with nodes:" + domain.getBridgeNodesOnDomain());
-            System.out.println("parsing domain with macs:" + domain.getMacsOnDomain());
-            if (domain.getBridgeNodesOnDomain().contains(nodeid)) {
-                System.out.println("got domain with nodeid:" + nodeid);
-                for (SharedSegment segment: domain.getTopology()) {
-                    System.out.println("parsing segment:" + segment);
-                    System.out.println("parsing segment with nodes:" + segment.getBridgeIdsOnSegment());
-                    System.out.println("parsing segment with macs:" + segment.getMacsOnSegment());
-                    if (segment.getBridgeIdsOnSegment().contains(nodeid)) {
-                        segments.add(segment);
-                        System.out.println("added segment:" + segment);
-                    }
-                }
-            }
-        }*/
         Set<Integer> designated = new HashSet<Integer>();
 BRIDGELINK:        for (BridgeBridgeLink link : bridgeBridgeLinkDao.findByNodeId(nodeid)) {
             for (SharedSegment segment : segments) {
@@ -181,7 +164,6 @@ BRIDGELINK:        for (BridgeBridgeLink link : bridgeBridgeLinkDao.findAll()) {
 
         List<BridgeMacLink> forwarders = new ArrayList<BridgeMacLink>();
 MAC:        for (String macaddress: mactobridgeportlist.keySet()) {
-            System.err.println("parsing mac:" + macaddress);
             List<BridgeMacLink> maclinks = mactobridgeportlist.get(macaddress); 
             SharedSegment segmentfound = null;
 MACLINK:    for (BridgeMacLink link : maclinks) {
@@ -190,7 +172,6 @@ MACLINK:    for (BridgeMacLink link : maclinks) {
                     if (segment.containsPort(link.getNode().getId(),
                                                     link.getBridgePort())) {
                         segmentfound = segment;
-                        System.err.println("found segment:" + segmentfound.printTopology());
                         break MACLINK;
                     }
                 }
@@ -211,7 +192,6 @@ MACLINK:    for (BridgeMacLink link : maclinks) {
                         break;
                     }
                 }
-                System.err.println("forwarder:" + forwardermac);
                              if (forwardermac) {
                     forwarders.addAll(maclinks);
                     continue MAC;

--- a/opennms-model/src/main/java/org/opennms/netmgt/model/topology/BridgePort.java
+++ b/opennms-model/src/main/java/org/opennms/netmgt/model/topology/BridgePort.java
@@ -31,7 +31,9 @@ package org.opennms.netmgt.model.topology;
 import java.util.Date;
 
 import org.opennms.netmgt.model.BridgeBridgeLink;
+import org.opennms.netmgt.model.BridgeMacLink;
 import org.opennms.netmgt.model.OnmsNode;
+import org.opennms.netmgt.model.BridgeMacLink.BridgeDot1qTpFdbStatus;
 
 public class BridgePort {
 
@@ -42,6 +44,32 @@ public class BridgePort {
     private Integer m_vlan;
     private Date m_createTime;
     private Date m_pollTime;
+
+    public static BridgeMacLink getBridgeMacLink(BridgePort bp, String mac) {
+        BridgeMacLink maclink = new BridgeMacLink();
+        maclink.setNode(bp.getNode());
+        maclink.setBridgePort(bp.getBridgePort());
+        maclink.setBridgePortIfIndex(bp.getBridgePortIfIndex());
+        maclink.setBridgePortIfName(bp.getBridgePortIfName());
+        maclink.setMacAddress(mac);
+        maclink.setBridgeDot1qTpFdbStatus(BridgeDot1qTpFdbStatus.DOT1D_TP_FDB_STATUS_LEARNED);
+        maclink.setVlan(bp.getVlan());
+        maclink.setBridgeMacLinkCreateTime(bp.getCreateTime());
+        maclink.setBridgeMacLinkLastPollTime(bp.getPollTime());
+        return maclink;
+    }
+
+    public static BridgePort getBridgeFromBridgeMacLink(BridgeMacLink link) {
+        BridgePort bp = new BridgePort();
+        bp.setNode(link.getNode());
+        bp.setBridgePort(link.getBridgePort());
+        bp.setBridgePortIfIndex(link.getBridgePortIfIndex());
+        bp.setBridgePortIfName(link.getBridgePortIfName());
+        bp.setVlan(link.getVlan());
+        bp.setCreateTime(link.getBridgeMacLinkCreateTime());
+        bp.setPollTime(link.getBridgeMacLinkLastPollTime());
+        return bp;
+    }
 
     public static BridgePort getFromBridgeBridgeLink(BridgeBridgeLink link) {
         BridgePort bp = new BridgePort();

--- a/opennms-model/src/main/java/org/opennms/netmgt/model/topology/SharedSegment.java
+++ b/opennms-model/src/main/java/org/opennms/netmgt/model/topology/SharedSegment.java
@@ -35,7 +35,6 @@ import java.util.Set;
 
 import org.opennms.netmgt.model.BridgeBridgeLink;
 import org.opennms.netmgt.model.BridgeMacLink;
-import org.opennms.netmgt.model.BridgeMacLink.BridgeDot1qTpFdbStatus;
 
 public class SharedSegment {
     
@@ -43,32 +42,6 @@ public class SharedSegment {
     Set<String> m_macsOnSegment = new HashSet<String>();
     Set<BridgePort> m_portsOnSegment = new HashSet<BridgePort>();
     BroadcastDomain m_domain;
-
-    private BridgePort getBridgeFromBridgeMacLink(BridgeMacLink link) {
-        BridgePort bp = new BridgePort();
-        bp.setNode(link.getNode());
-        bp.setBridgePort(link.getBridgePort());
-        bp.setBridgePortIfIndex(link.getBridgePortIfIndex());
-        bp.setBridgePortIfName(link.getBridgePortIfName());
-        bp.setVlan(link.getVlan());
-        bp.setCreateTime(link.getBridgeMacLinkCreateTime());
-        bp.setPollTime(link.getBridgeMacLinkLastPollTime());
-        return bp;
-    }
-
-    private BridgeMacLink getBridgeMacLink(BridgePort bp, String mac) {
-    	BridgeMacLink maclink = new BridgeMacLink();
-        maclink.setNode(bp.getNode());
-        maclink.setBridgePort(bp.getBridgePort());
-        maclink.setBridgePortIfIndex(bp.getBridgePortIfIndex());
-        maclink.setBridgePortIfName(bp.getBridgePortIfName());
-        maclink.setMacAddress(mac);
-        maclink.setBridgeDot1qTpFdbStatus(BridgeDot1qTpFdbStatus.DOT1D_TP_FDB_STATUS_LEARNED);
-        maclink.setVlan(bp.getVlan());
-        maclink.setBridgeMacLinkCreateTime(bp.getCreateTime());
-        maclink.setBridgeMacLinkLastPollTime(bp.getPollTime());
-        return maclink;
-    }
     
     private BridgeBridgeLink getBridgeBridgeLink(BridgePort bp) {
         BridgeBridgeLink link = new BridgeBridgeLink();
@@ -88,6 +61,9 @@ public class SharedSegment {
     }
 
     public SharedSegment(){};
+    public boolean hasDesignatedBridgeport() {
+        return (m_designatedBridge != null);
+    }
     
     public SharedSegment(BroadcastDomain domain) {
         m_domain =domain;
@@ -103,7 +79,7 @@ public class SharedSegment {
 
     public SharedSegment(BroadcastDomain domain, BridgeMacLink link) {
         m_domain =domain;
-        m_designatedBridge = getBridgeFromBridgeMacLink(link);
+        m_designatedBridge = BridgePort.getBridgeFromBridgeMacLink(link);
         m_macsOnSegment.add(link.getMacAddress());
         m_portsOnSegment.add(m_designatedBridge);
 
@@ -112,7 +88,7 @@ public class SharedSegment {
     public SharedSegment(BroadcastDomain domain, List<BridgeMacLink> links) {
         m_domain =domain;
         for (BridgeMacLink link: links) {
-        	m_portsOnSegment.add(getBridgeFromBridgeMacLink(link));
+            m_portsOnSegment.add(BridgePort.getBridgeFromBridgeMacLink(link));
             m_macsOnSegment.add(link.getMacAddress());
         }
 
@@ -170,7 +146,7 @@ public class SharedSegment {
     	List<BridgeMacLink> maclinks = new ArrayList<BridgeMacLink>();
     	for (String mac: m_macsOnSegment) {
     		for (BridgePort bp: m_portsOnSegment) {
-    			maclinks.add(getBridgeMacLink(bp, mac));
+    			maclinks.add(BridgePort.getBridgeMacLink(bp, mac));
     		}
     	}
         return maclinks;
@@ -182,7 +158,7 @@ public class SharedSegment {
 
     public void add(BridgeMacLink link) {
         m_macsOnSegment.add(link.getMacAddress());
-        m_portsOnSegment.add(getBridgeFromBridgeMacLink(link));
+        m_portsOnSegment.add(BridgePort.getBridgeFromBridgeMacLink(link));
     }
 
     public void add(BridgeBridgeLink link) {

--- a/opennms-services/src/main/java/org/opennms/netmgt/enlinkd/EnhancedLinkd.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/enlinkd/EnhancedLinkd.java
@@ -233,7 +233,10 @@ public class EnhancedLinkd extends AbstractServiceDaemon {
      */
     protected synchronized void onStop() {
 
-        // Stop the scheduler
+        LOG.info("stop: persisting forwarders");
+        m_queryMgr.persistForwarders();
+        LOG.info("stop: persisted forwarders");
+              // Stop the scheduler
         LOG.info("stop: Stopping enhanced linkd scheduler");
         m_scheduler.stop();
         m_scheduler = null;

--- a/opennms-services/src/main/java/org/opennms/netmgt/enlinkd/EnhancedLinkdService.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/enlinkd/EnhancedLinkdService.java
@@ -147,5 +147,7 @@ public interface EnhancedLinkdService {
     boolean hasUpdatedBft(int nodeid);
         
     List<BridgeElement> getBridgeElements(Set<Integer> nodeids);
+    
+    void persistForwarders();
 
 }

--- a/opennms-services/src/main/java/org/opennms/netmgt/enlinkd/EnhancedLinkdServiceImpl.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/enlinkd/EnhancedLinkdServiceImpl.java
@@ -940,4 +940,19 @@ public class EnhancedLinkdServiceImpl implements EnhancedLinkdService {
             elems.addAll(m_bridgeElementDao.findByNodeId(nodeid));
         return elems;
     }
+    
+    @Override
+    public void persistForwarders() {
+        for (BroadcastDomain domain: m_bridgeTopologyDao.getAll()) {
+            for (Integer nodeId: domain.getBridgeNodesOnDomain()) {
+                List<BridgeMacLink> forwarders = domain.getForwarders(nodeId);
+                if (forwarders == null || forwarders.size() == 0)
+                    continue;
+                for (BridgeMacLink forward: forwarders) {
+                    forward.setBridgeMacLinkLastPollTime(new Date());
+                    saveBridgeMacLink(forward);
+                }
+            }
+        }
+    }
 }

--- a/opennms-services/src/test/java/org/opennms/netmgt/enlinkd/BroadcastDomainTest.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/enlinkd/BroadcastDomainTest.java
@@ -1213,5 +1213,69 @@ public class BroadcastDomainTest extends EnLinkdTestHelper {
         topology.check(domain);
         
     }
+    
+    
+    @Test
+    public void testFiveSwitchTopologyBEDCABEDAC() {
+
+        FiveSwitchTopology topology = new FiveSwitchTopology();
+
+        BroadcastDomain domain = new BroadcastDomain();
+        domain.addBridge(new Bridge(topology.nodeAId));
+        domain.addBridge(new Bridge(topology.nodeBId));
+        domain.addBridge(new Bridge(topology.nodeCId));
+        domain.addBridge(new Bridge(topology.nodeDId));
+        domain.addBridge(new Bridge(topology.nodeEId));
+        domain.setBridgeElements(topology.elemlist);
+        
+        NodeDiscoveryBridgeTopology ndbtB= new NodeDiscoveryBridgeTopology(linkd, new Node(topology.nodeBId, null, null, null,location));
+        ndbtB.setDomain(domain);
+        ndbtB.addUpdatedBFT(domain.getBridge(topology.nodeBId),topology.bftB);
+        ndbtB.calculate();
+
+        NodeDiscoveryBridgeTopology ndbtE= new NodeDiscoveryBridgeTopology(linkd, new Node(topology.nodeEId, null, null, null,location));
+        ndbtE.setDomain(domain);
+        ndbtE.addUpdatedBFT(domain.getBridge(topology.nodeEId),topology.bftE);
+        ndbtE.calculate();
+
+        NodeDiscoveryBridgeTopology ndbtD= new NodeDiscoveryBridgeTopology(linkd, new Node(topology.nodeDId, null, null, null,location));
+        ndbtD.setDomain(domain);
+        ndbtD.addUpdatedBFT(domain.getBridge(topology.nodeDId),topology.bftD);
+        ndbtD.calculate();
+
+        NodeDiscoveryBridgeTopology ndbtC= new NodeDiscoveryBridgeTopology(linkd, new Node(topology.nodeCId, null, null, null,location));
+        ndbtC.setDomain(domain);
+        ndbtC.addUpdatedBFT(domain.getBridge(topology.nodeCId),topology.bftC);
+        ndbtC.calculate();
+
+        NodeDiscoveryBridgeTopology ndbtA= new NodeDiscoveryBridgeTopology(linkd, new Node(topology.nodeAId, null, null, null,location));
+        ndbtA.setDomain(domain);
+        ndbtA.addUpdatedBFT(domain.getBridge(topology.nodeAId),topology.bftA);
+        ndbtA.calculate();
+
+        topology.check(domain);
+
+        ndbtB.addUpdatedBFT(domain.getBridge(topology.nodeBId),topology.bftB);
+        ndbtB.calculate();
+        topology.check(domain);
+
+        ndbtE.addUpdatedBFT(domain.getBridge(topology.nodeEId),topology.bftE);
+        ndbtE.calculate();
+        topology.check(domain);
+
+        ndbtD.addUpdatedBFT(domain.getBridge(topology.nodeDId),topology.bftD);
+        ndbtD.calculate();
+        topology.check(domain);
+
+        ndbtA.addUpdatedBFT(domain.getBridge(topology.nodeAId),topology.bftA);
+        ndbtA.calculate();
+        topology.check(domain);
+
+        ndbtC.addUpdatedBFT(domain.getBridge(topology.nodeCId),topology.bftC);
+        ndbtC.calculate();
+        topology.check(domain);
+        
+    }
+
 
 }

--- a/opennms-services/src/test/java/org/opennms/netmgt/enlinkd/EnLinkdIT.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/enlinkd/EnLinkdIT.java
@@ -171,6 +171,13 @@ public class EnLinkdIT extends EnLinkdBuilderITCase {
         bclink.setDesignatedPort(topology.portBC);
         bclink.setBridgeBridgeLinkLastPollTime(ablink.getBridgeBridgeLinkCreateTime());
         m_bridgeBridgeLinkDao.save(bclink);
+        
+        BridgeMacLink forward = new BridgeMacLink();
+        forward.setNode(nodeB);
+        forward.setBridgePort(topology.portBA);
+        forward.setMacAddress(topology.macA);
+        forward.setBridgeMacLinkLastPollTime(forward.getBridgeMacLinkCreateTime());
+        m_bridgeMacLinkDao.save(forward);
 
         BridgeMacLink mac1 = new BridgeMacLink();
         mac1.setNode(nodeA);
@@ -195,7 +202,7 @@ public class EnLinkdIT extends EnLinkdBuilderITCase {
 
         m_bridgeMacLinkDao.flush();
         m_bridgeBridgeLinkDao.flush();
-        assertEquals(3, m_bridgeMacLinkDao.countAll());
+        assertEquals(4, m_bridgeMacLinkDao.countAll());
         assertEquals(2, m_bridgeBridgeLinkDao.countAll());
         
         assertNotNull(m_bridgeTopologyDao);
@@ -209,13 +216,16 @@ public class EnLinkdIT extends EnLinkdBuilderITCase {
         assertEquals(nodeAbd, nodeBbd);
         assertEquals(nodeAbd, nodeCbd);
         nodeAbd.hierarchySetUp(nodeAbd.getBridge(nodeA.getId()));
+
         topology.check(nodeAbd);
+        assertEquals(0, nodeAbd.getForwarders(topology.nodeAId).size());
+        assertEquals(1, nodeAbd.getForwarders(topology.nodeBId).size());
+        assertEquals(0, nodeAbd.getForwarders(topology.nodeCId).size());
         
         List<SharedSegment> nodeASegments = m_bridgeTopologyDao.getBridgeNodeSharedSegments(m_bridgeBridgeLinkDao, m_bridgeMacLinkDao, nodeA.getId());
         assertEquals(2, nodeASegments.size());
-        for (SharedSegment segment: nodeASegments) {
-        	System.err.println(segment.printTopology());
-        }
+        
+        System.err.println(nodeAbd.printTopology());
     }    
     
     @Test

--- a/opennms-services/src/test/java/org/opennms/netmgt/enlinkd/EnLinkdTestHelper.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/enlinkd/EnLinkdTestHelper.java
@@ -763,7 +763,9 @@ public abstract class EnLinkdTestHelper {
         String mac2 = "000daaaa0202"; // port AB ---port B  ---port CB
         String mac3 = "000daaaa0303"; // port AB ---port BC ---port C
 
-
+        String macA = "aaaaaaaaaaaa";
+        String macB = "bbbbbbbbbbbb";
+        String macC = "cccccccccccc";
         /*
          *              -----------------
          *     mac1 --  ||portA|        |
@@ -791,17 +793,17 @@ public abstract class EnLinkdTestHelper {
         public ABCTopology() {
             nodeA.setId(nodeAId);
             elementA.setNode(nodeA);
-            elementA.setBaseBridgeAddress("aaaaaaaaaaaa");
+            elementA.setBaseBridgeAddress(macA);
             elemlist.add(elementA);
     
             nodeB.setId(nodeBId);
             elementB.setNode(nodeB);
-            elementB.setBaseBridgeAddress("bbbbbbbbbbbb");
+            elementB.setBaseBridgeAddress(macB);
             elemlist.add(elementB);
     
             nodeC.setId(nodeCId);
             elementC.setNode(nodeC);
-            elementC.setBaseBridgeAddress("cccccccccccc");
+            elementC.setBaseBridgeAddress(macC);
             elemlist.add(elementC);
 
             bftA.add(addBridgeForwardingTableEntry(nodeA,portA, mac1));


### PR DESCRIPTION
NMS-9455: BridgeTopology Discovery Mismatch after opennms restart

JIRA: http://issues.opennms.org/browse/NMS-9455

After a restart opennms is not able to properly discovery the bridge topology

This is related to the so called forwarders. 
There are bridge forwarding table entry that cannot be assigned to a shared segment.
A bft entry is assigned to a shered segment if and only if it is on the forwarding table of every BridgePort belongng to segment.
So if I have a shared segment with Bridge(A,a) Bridge(B,b) and Bridge(C,c) the macs assigned on segment are only the macs belonging to the intersection of the forwarding tables for port a,b and c.
Nevertheless there can be interesting forwarding entry that do not belong to the intersection as for example the entries for the mac bridge mac addresses.
These entries are very important for the topology discovery and must be saved. 
This entries are so called forwarders and are assigned properly to braodcast domains.
The problem is that forwarders are not persisted. So a restart of opennms can have as side effect a topology mismatch proper to the loss of forwarders table entry.
This will led to persist the forwarders so that they are available for topology calculation at opennms startup.
