### PR TITLE
NMS-5105: Fix handling of delete related events in collectd

### DIFF
--- a/opennms-services/src/main/java/org/opennms/netmgt/collectd/CollectableService.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/collectd/CollectableService.java
@@ -29,6 +29,7 @@
 package org.opennms.netmgt.collectd;
 
 import java.io.File;
+import java.net.InetAddress;
 
 import org.opennms.core.logging.Logging;
 import org.opennms.core.utils.InetAddressUtils;
@@ -67,8 +68,8 @@ import org.springframework.transaction.PlatformTransactionManager;
  * @author <A HREF="http://www.opennms.org/">OpenNMS </A>
  * 
  */
-final class CollectableService implements ReadyRunnable {
-    
+class CollectableService implements ReadyRunnable {
+
     private static final Logger LOG = LoggerFactory.getLogger(CollectableService.class);
     
     /**
@@ -156,9 +157,9 @@ final class CollectableService implements ReadyRunnable {
     /**
      * <p>getAddress</p>
      *
-     * @return a {@link java.lang.Object} object.
+     * @return a {@link java.net.InetAddress} object.
      */
-    public Object getAddress() {
+    public InetAddress getAddress() {
     	return m_agent.getAddress();
     }
     

--- a/opennms-services/src/main/java/org/opennms/netmgt/collectd/Collectd.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/collectd/Collectd.java
@@ -76,6 +76,7 @@ import org.opennms.netmgt.model.events.EventListener;
 import org.opennms.netmgt.scheduler.LegacyScheduler;
 import org.opennms.netmgt.scheduler.ReadyRunnable;
 import org.opennms.netmgt.scheduler.Scheduler;
+import org.opennms.netmgt.snmp.InetAddrUtils;
 import org.opennms.netmgt.xml.event.Event;
 import org.opennms.netmgt.xml.event.Parm;
 import org.opennms.netmgt.xml.event.Value;
@@ -657,7 +658,7 @@ public class Collectd extends AbstractServiceDaemon implements
         }
     }
 
-    private List<CollectableService> getCollectableServices() {
+    protected List<CollectableService> getCollectableServices() {
         return m_collectableServices;
     }
 
@@ -820,7 +821,7 @@ public class Collectd extends AbstractServiceDaemon implements
                 // Only interested in entries with matching nodeId and IP
                 // address
                 InetAddress addr = (InetAddress) cSvc.getAddress();
-                if (!(cSvc.getNodeId() == nodeId && addr.getHostName().equals(ipAddr)))
+                if (!(cSvc.getNodeId() == nodeId && InetAddrUtils.str(addr).equals(ipAddr)))
                     continue;
 
                 synchronized (cSvc) {
@@ -832,7 +833,7 @@ public class Collectd extends AbstractServiceDaemon implements
                     // time it is selected for execution by the scheduler
                     // the collection will be skipped and the service will not
                     // be rescheduled.
-                    LOG.debug("Marking CollectableService for deletion because an interface was deleted:  Service nodeid={}, deleted node:{}service address:{}deleted interface:{}", cSvc.getNodeId(), nodeId, addr.getHostName(), ipAddr);
+                    LOG.debug("Marking CollectableService for deletion because an interface was deleted:  Service nodeid={}, deleted node:{}service address:{}deleted interface:{}", cSvc.getNodeId(), nodeId, InetAddrUtils.str(addr), ipAddr);
 
                     updates.markForDeletion();
                 }
@@ -958,7 +959,6 @@ public class Collectd extends AbstractServiceDaemon implements
     private void handleNodeDeleted(Event event)
             throws InsufficientInformationException {
         EventUtils.checkNodeId(event);
-        EventUtils.checkInterface(event);
 
         Long nodeId = event.getNodeid();
 
@@ -1408,7 +1408,7 @@ public class Collectd extends AbstractServiceDaemon implements
                 
                 //WATCH the brackets; there used to be an extra close bracket after the ipAddr comparison which borked this whole expression
                 if (!(cSvc.getNodeId() == nodeId && 
-                        addr.getHostName().equals(ipAddr) && 
+                        InetAddrUtils.str(addr).equals(ipAddr) &&
                         cSvc.getServiceName().equals(svcName))) 
                     continue;
 
@@ -1421,7 +1421,7 @@ public class Collectd extends AbstractServiceDaemon implements
                     // time it is selected for execution by the scheduler
                     // the collection will be skipped and the service will not
                     // be rescheduled.
-                    LOG.debug("Marking CollectableService for deletion because a service was deleted:  Service nodeid={}, deleted node:{}, service address:{}, deleted interface:{}, service servicename:{}, deleted service name:{}, event source {}", cSvc.getNodeId(), nodeId, addr.getHostName(), ipAddr, cSvc.getServiceName(), svcName, event.getSource());
+                    LOG.debug("Marking CollectableService for deletion because a service was deleted:  Service nodeid={}, deleted node:{}, service address:{}, deleted interface:{}, service servicename:{}, deleted service name:{}, event source {}", cSvc.getNodeId(), nodeId, InetAddrUtils.str(addr), ipAddr, cSvc.getServiceName(), svcName, event.getSource());
                     updates.markForDeletion();
                 }
 

--- a/opennms-services/src/main/java/org/opennms/netmgt/collectd/DefaultCollectionAgent.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/collectd/DefaultCollectionAgent.java
@@ -76,9 +76,11 @@ public class DefaultCollectionAgent extends InetNetworkInterface implements Snmp
     private int m_ifCount = -1;
     private long m_sysUpTime = -1;
 
-        // cached attributes
-    private int m_nodeId = -1;
-    private InetAddress m_inetAddress = null;
+    // fixed attributes
+    private final int m_nodeId;
+    private final InetAddress m_inetAddress;
+
+    // cached attributes
     private int m_ifIndex = -1;
     private PrimaryType m_isSnmpPrimary = null;
     private String m_sysObjId = null;
@@ -97,14 +99,14 @@ public class DefaultCollectionAgent extends InetNetworkInterface implements Snmp
         if (Boolean.getBoolean("org.opennms.netmgt.collectd.DefaultCollectionAgent.loadSnmpDataOnInit")) {
             getSnmpInterfaceData();
         }
+
+        m_inetAddress = m_agentService.getInetAddress();
+        m_nodeId = m_agentService.getNodeId();
     }
 
     /** {@inheritDoc} */
     @Override
     public InetAddress getAddress() {
-        if (m_inetAddress == null) {
-            m_inetAddress = m_agentService.getInetAddress();
-        }
         return m_inetAddress;
     }
 
@@ -166,9 +168,6 @@ public class DefaultCollectionAgent extends InetNetworkInterface implements Snmp
      */
     @Override
     public int getNodeId() {
-        if (m_nodeId == -1) {
-            m_nodeId = m_agentService.getNodeId();
-        }
         return m_nodeId; 
     }
 

--- a/opennms-services/src/main/java/org/opennms/netmgt/collectd/DefaultCollectionAgentService.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/collectd/DefaultCollectionAgentService.java
@@ -146,7 +146,8 @@ public class DefaultCollectionAgentService implements CollectionAgentService {
      */
     @Override
     public int getNodeId() {
-        return getIpInterface().getNode().getId() == null ? -1 : getIpInterface().getNode().getId().intValue();
+        final OnmsNode node = getIpInterface().getNode();
+        return node.getId() == null ? -1 : node.getId().intValue();
     }
 
     /* (non-Javadoc)

--- a/opennms-services/src/test/java/org/opennms/netmgt/collectd/CollectdEventHandlingTest.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/collectd/CollectdEventHandlingTest.java
@@ -1,0 +1,134 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2017-2017 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.collectd;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.easymock.EasyMock;
+import org.junit.Before;
+import org.junit.Test;
+import org.opennms.core.utils.InetAddressUtils;
+import org.opennms.netmgt.EventConstants;
+import org.opennms.netmgt.dao.mock.MockTransactionTemplate;
+import org.opennms.netmgt.model.OnmsIpInterface;
+import org.opennms.netmgt.model.OnmsNode;
+import org.opennms.netmgt.model.events.EventBuilder;
+import org.opennms.netmgt.xml.event.Event;
+
+public class CollectdEventHandlingTest {
+
+    private Collectd collectd = new Collectd();
+
+    private CollectableService svc1;
+    private CollectableService svc2;
+
+    @Before
+    public void setUp() {
+        // Setup the transaction template
+        MockTransactionTemplate transactionTemplate = new MockTransactionTemplate();
+        transactionTemplate.afterPropertiesSet();
+        collectd.setTransactionTemplate(transactionTemplate);
+
+        // Create two collectable services
+        CollectorUpdates svc1_udpates = new CollectorUpdates();
+        svc1 = EasyMock.createMock(CollectableService.class);
+        EasyMock.expect(svc1.getNodeId()).andReturn(42).anyTimes();
+        EasyMock.expect(svc1.getAddress()).andReturn(InetAddressUtils.ONE_TWENTY_SEVEN).anyTimes();
+        EasyMock.expect(svc1.getServiceName()).andReturn("JMX").anyTimes();
+        EasyMock.expect(svc1.getCollectorUpdates()).andReturn(svc1_udpates).anyTimes();
+        EasyMock.replay(svc1);
+        collectd.getCollectableServices().add(svc1);
+
+        CollectorUpdates svc2_udpates = new CollectorUpdates();
+        svc2 = EasyMock.createMock(CollectableService.class);
+        EasyMock.expect(svc2.getNodeId()).andReturn(43).anyTimes();
+        EasyMock.expect(svc2.getAddress()).andReturn(InetAddressUtils.UNPINGABLE_ADDRESS).anyTimes();
+        EasyMock.expect(svc2.getServiceName()).andReturn("WS-Man").anyTimes();
+        EasyMock.expect(svc2.getCollectorUpdates()).andReturn(svc2_udpates).anyTimes();
+        EasyMock.replay(svc2);
+        collectd.getCollectableServices().add(svc2);
+    }
+
+    @Test
+    public void canHandleNodeDeletedEvents() {
+        // Handle a interfaceDeleted event targeting svc1
+        Event e = new EventBuilder(EventConstants.NODE_DELETED_EVENT_UEI, "test")
+                .setNodeid(svc1.getNodeId())
+                .getEvent();
+        collectd.onEvent(e);
+
+        // The delete flag should be set (and only set) on svc1
+        assertTrue("deletion flag was not set on svc1!", svc1.getCollectorUpdates().isDeletionFlagSet());
+        assertFalse("deletion flag was set on svc2!", svc2.getCollectorUpdates().isDeletionFlagSet());
+    }
+
+    @Test
+    public void canHandleInterfaceDeletedEvents() {
+        // Handle a interfaceDeleted event targeting svc1
+        OnmsNode node = new OnmsNode();
+        node.setId(svc1.getNodeId());
+
+        OnmsIpInterface iface = new OnmsIpInterface();
+        iface.setId(99);
+        iface.setNode(node);
+        iface.setIpAddress(svc1.getAddress());
+
+        Event e = new EventBuilder(EventConstants.INTERFACE_DELETED_EVENT_UEI, "test")
+                .setIpInterface(iface)
+                .getEvent();
+        collectd.onEvent(e);
+
+        // The delete flag should be set (and only set) on svc1
+        assertTrue("deletion flag was not set on svc1!", svc1.getCollectorUpdates().isDeletionFlagSet());
+        assertFalse("deletion flag was set on svc2!", svc2.getCollectorUpdates().isDeletionFlagSet());
+    }
+
+    @Test
+    public void canHandleServiceDeletedEvents() {
+        // Handle a serviceDeleted event targeting svc2
+        OnmsNode node = new OnmsNode();
+        node.setId(svc2.getNodeId());
+
+        OnmsIpInterface iface = new OnmsIpInterface();
+        iface.setId(101);
+        iface.setNode(node);
+        iface.setIpAddress(svc2.getAddress());
+
+        Event e = new EventBuilder(EventConstants.SERVICE_DELETED_EVENT_UEI, "test")
+                .setIpInterface(iface)
+                .setService(svc2.getServiceName())
+                .getEvent();
+        collectd.onEvent(e);
+
+        // The delete flag should be set (and only set) on svc2
+        assertFalse("deletion flag was set on svc1!", svc1.getCollectorUpdates().isDeletionFlagSet());
+        assertTrue("deletion flag was not set on svc2!", svc2.getCollectorUpdates().isDeletionFlagSet());
+    }
+}

--- a/opennms-services/src/test/java/org/opennms/netmgt/collectd/DefaultCollectionAgentTest.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/collectd/DefaultCollectionAgentTest.java
@@ -1,0 +1,77 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2017-2017 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.collectd;
+
+import static org.junit.Assert.assertEquals;
+
+import org.easymock.EasyMock;
+import org.junit.Test;
+import org.opennms.core.test.MockPlatformTransactionManager;
+import org.opennms.core.utils.InetAddressUtils;
+import org.opennms.netmgt.dao.api.IpInterfaceDao;
+import org.opennms.netmgt.model.OnmsIpInterface;
+import org.opennms.netmgt.model.OnmsNode;
+import org.springframework.transaction.PlatformTransactionManager;
+
+public class DefaultCollectionAgentTest {
+
+    /**
+     * NMS-5105: When processing serviceDeleted and interfaceDeleted events
+     * in Collectd we need to match both the Node ID and IP Address of
+     * the service that is being collected with the information from the event.
+     *
+     * Since the entities have been deleted, we not longer be able to reach
+     * in the database to fetch the required details. Instead, they
+     * should be loaded when the agent is created, and cached for the lifetime
+     * of the object.
+     */
+    @Test
+    public void verifyThatTheIpAndNodeIdAreCached() {
+        OnmsNode node = new OnmsNode();
+        node.setId(11);
+
+        OnmsIpInterface iface = new OnmsIpInterface();
+        iface.setId(42);
+        iface.setNode(node);
+        iface.setIpAddress(InetAddressUtils.ONE_TWENTY_SEVEN);
+
+        IpInterfaceDao ifaceDao = EasyMock.createMock(IpInterfaceDao.class);
+        EasyMock.expect(ifaceDao.load(iface.getId())).andReturn(iface).times(2);
+        EasyMock.replay(ifaceDao);
+
+        PlatformTransactionManager transMgr = new MockPlatformTransactionManager();
+
+        SnmpCollectionAgent agent = DefaultCollectionAgent.create(iface.getId(), ifaceDao, transMgr);
+
+        EasyMock.verify(ifaceDao);
+
+        assertEquals(iface.getIpAddress(), agent.getAddress());
+        assertEquals(node.getId().intValue(), agent.getNodeId());
+    }
+}

--- a/opennms-services/src/test/java/org/opennms/netmgt/collectd/SnmpAttributeTest.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/collectd/SnmpAttributeTest.java
@@ -129,7 +129,7 @@ public class SnmpAttributeTest extends TestCase {
         ipInterface.setNode(node);
         ipInterface.setIpAddress(InetAddressUtils.addr("192.168.1.1"));
 
-        expect(m_ipInterfaceDao.load(1)).andReturn(ipInterface).times(7); // It used to be 3, but I think it is more correct to use getStoreDir from DefaultCollectionAgentService on DefaultCollectionAgent (NMS-7516)
+        expect(m_ipInterfaceDao.load(1)).andReturn(ipInterface).times(5); // It used to be 3, but I think it is more correct to use getStoreDir from DefaultCollectionAgentService on DefaultCollectionAgent (NMS-7516)
 
         expect(m_rrdStrategy.getDefaultFileExtension()).andReturn(".myLittleEasyMockedStrategyAndMe").anyTimes();
         expect(m_rrdStrategy.createDefinition(isA(String.class), isA(String.class), isA(String.class), anyInt(), isAList(RrdDataSource.class), isAList(String.class))).andReturn(new Object());


### PR DESCRIPTION
JIRA: https://issues.opennms.org/browse/NMS-5105

This fixes a long standing bug where node, interface and service deleted events weren't being handled properly by collectd, leaving the services scheduled after deletion.
