### PR TITLE
NMS-9445: minion:ping does not properly validate JMS broker connectivity

### DIFF
--- a/features/minion/core/shell/src/main/java/org/opennms/minion/core/shell/MinionPingCommand.java
+++ b/features/minion/core/shell/src/main/java/org/opennms/minion/core/shell/MinionPingCommand.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2016 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2016 The OpenNMS Group, Inc.
+ * Copyright (C) 2016-2017 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -27,6 +27,10 @@
  *******************************************************************************/
 package org.opennms.minion.core.shell;
 
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
+
 import javax.jms.Connection;
 import javax.jms.ConnectionFactory;
 import javax.jms.JMSException;
@@ -34,6 +38,7 @@ import javax.jms.Session;
 
 import org.apache.karaf.shell.api.action.Action;
 import org.apache.karaf.shell.api.action.Command;
+import org.apache.karaf.shell.api.action.Option;
 import org.apache.karaf.shell.api.action.lifecycle.Reference;
 import org.apache.karaf.shell.api.action.lifecycle.Service;
 import org.opennms.minion.core.api.RestClient;
@@ -48,6 +53,9 @@ public class MinionPingCommand implements Action {
     @Reference
     public RestClient restClient;
 
+    @Option(name = "-j", description = "Maximum number of milliseconds to wait before failing when attempting to establish a JMS session.")
+    public long jmsTimeoutMillis = 20*1000;
+
     @Override
     public Object execute() throws Exception {
         System.out.println("Connecting to ReST...");
@@ -55,23 +63,48 @@ public class MinionPingCommand implements Action {
         System.out.println("OK");
 
         System.out.println("Connecting to Broker...");
-        Connection jmsConnection = null;
-        try {
-            jmsConnection = brokerConnectionFactory.createConnection();
-            // NMS-9445: Attempt to use the connection by creating a session
-            // and immediately closing it.
-            jmsConnection.createSession(false, Session.AUTO_ACKNOWLEDGE).close();
-        } finally{
-            if (jmsConnection != null) {
-                try {
-                    jmsConnection.close();
-                } catch(JMSException ex) {
-                    System.out.println("Failed to close JMSConnection: " + ex.getMessage());
-                }
-            }
-        }
-
+        testJmsConnectivity(jmsTimeoutMillis);
         System.out.println("OK");
         return null;
+    }
+
+    private void testJmsConnectivity(long maxDurationMillis) throws InterruptedException, ExecutionException, TimeoutException {
+        final AtomicReference<Throwable> throwableRef = new AtomicReference<>();
+        // Establishing the session in separate thread, allowing
+        // us to control how long we wait for.
+        final Thread t = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    Connection jmsConnection = null;
+                    try {
+                        jmsConnection = brokerConnectionFactory.createConnection();
+                        // NMS-9445: Attempt to use the connection by creating a session
+                        // and immediately closing it.
+                        jmsConnection.createSession(false, Session.AUTO_ACKNOWLEDGE).close();
+                    } finally{
+                        if (jmsConnection != null) {
+                            try {
+                                jmsConnection.close();
+                            } catch(JMSException ex) {
+                                System.out.println("Failed to close the JMS connection: " + ex.getMessage());
+                            }
+                        }
+                    }
+                } catch (Throwable t) {
+                    throwableRef.set(t);
+                }
+            }
+        });
+        t.setName("minion:ping");
+        t.start();
+        t.join(maxDurationMillis);
+        if (t.isAlive()) {
+            t.interrupt();
+            throw new TimeoutException(String.format("Failed to create a JMS session within %d milliseconds.", maxDurationMillis));
+        }
+        if (throwableRef.get() != null) {
+            throw new ExecutionException("Failed to create a JMS session.", throwableRef.get());
+        }
     }
 }


### PR DESCRIPTION
JIRA: https://issues.opennms.org/browse/NMS-9445

Here we improve the JMS broker test by trying to create a session over the connection we've acquired.

We also add a time limit, since certain connection pools may block forever until a session is actually acquired.
