### PR TITLE
NMS-9470: Added tests for Hibernate join condition bug

### DIFF
--- a/opennms-dao/src/test/java/org/opennms/netmgt/dao/MonitoredServiceDaoIT.java
+++ b/opennms-dao/src/test/java/org/opennms/netmgt/dao/MonitoredServiceDaoIT.java
@@ -36,13 +36,18 @@ import static org.opennms.core.utils.InetAddressUtils.addr;
 import java.util.List;
 
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.opennms.core.criteria.CriteriaBuilder;
+import org.opennms.core.criteria.Alias.JoinType;
+import org.opennms.core.criteria.restrictions.Restrictions;
 import org.opennms.core.spring.BeanUtils;
 import org.opennms.core.test.OpenNMSJUnit4ClassRunner;
 import org.opennms.core.test.db.annotations.JUnitTemporaryDatabase;
 import org.opennms.netmgt.dao.api.MonitoredServiceDao;
 import org.opennms.netmgt.model.OnmsMonitoredService;
+import org.opennms.netmgt.model.OnmsNode;
 import org.opennms.test.JUnitConfigurationEnvironment;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -115,6 +120,24 @@ public class MonitoredServiceDaoIT implements InitializingBean {
         final OnmsMonitoredService monSvc2 = m_monitoredServiceDao.get(m_databasePopulator.getNode1().getId(), addr("192.168.1.1"), monSvc.getIfIndex(), monSvc.getServiceId());
         assertNotNull(monSvc2);
 
+    }
+
+    /**
+     * This test exposes a bug in Hibernate: it is not applying join conditions
+     * correctly to the many-to-many service-to-application relationship.
+     * 
+     * This issue is documented in NMS-9470. If we upgrade Hibernate, we should
+     * recheck this issue to see if it is fixed.
+     * 
+     * @see https://issues.opennms.org/browse/NMS-9470
+     */
+    @Test
+    @Transactional
+    @Ignore("Ignore until Hibernate can be upgraded and this can be rechecked")
+    public void testCriteriaBuilderWithApplicationAlias() {
+        CriteriaBuilder cb = new CriteriaBuilder(OnmsMonitoredService.class);
+        cb.alias("applications", "application", JoinType.LEFT_JOIN, Restrictions.eq("application.name", "HelloWorld"));
+        m_monitoredServiceDao.findMatching(cb.toCriteria());
     }
 
 }

--- a/opennms-dao/src/test/java/org/opennms/netmgt/dao/UpsertIT.java
+++ b/opennms-dao/src/test/java/org/opennms/netmgt/dao/UpsertIT.java
@@ -114,8 +114,7 @@ public class UpsertIT implements InitializingBean {
         assertEquals(1, countIfs(m_populator.getNode1().getId(), 1001, newIfName));
     }
     
-    @SuppressWarnings("deprecation")
-	private int countIfs(int nodeId, int ifIndex, String ifName) {
+    private int countIfs(int nodeId, int ifIndex, String ifName) {
         return m_jdbcTemplate.queryForObject("select count(*) from snmpInterface where nodeid=? and snmpifindex=? and snmpifname=?", new Object[] { nodeId, ifIndex, ifName }, Integer.class);
     }
     


### PR DESCRIPTION
This adds a couple of tests that fail with our current version of Hibernate. We should reenable them after we upgrade Hibernate to see if the behavior has been fixed.

* JIRA: http://issues.opennms.org/browse/NMS-9470