### PR TITLE
NMS-9472: Fix connection factory in AMQP features

### DIFF
--- a/container/features/pom.xml
+++ b/container/features/pom.xml
@@ -234,10 +234,11 @@
             <feature>opennms-syslogd-listener-javanet</feature>
             <feature>opennms-syslogd-listener-camel-netty</feature>
             <feature>opennms-trapd</feature>
-
             <!-- <feature>opennms-webapp</feature> -->
+
             <feature>org.json</feature>
             <feature>postgresql</feature>
+            <feature>qpid</feature>
             <feature>spring-security32</feature>
             <feature>spring-webflow</feature>
 

--- a/container/features/src/main/resources/features.xml
+++ b/container/features/src/main/resources/features.xml
@@ -51,6 +51,7 @@
       <feature>camel-http</feature>
       <feature>camel-amqp</feature>
       <feature version="${guavaVersion}">guava</feature>
+      <feature>qpid</feature>
 
       <feature>opennms-core-camel</feature>
       <feature>opennms-dao-api</feature>
@@ -65,6 +66,7 @@
       <feature>camel-http</feature>
       <feature>camel-amqp</feature>
       <feature version="${guavaVersion}">guava</feature>
+      <feature>qpid</feature>
 
       <feature>opennms-core-camel</feature>
       <feature>opennms-dao-api</feature>
@@ -78,6 +80,7 @@
       <feature>camel-blueprint</feature>
       <feature>camel-http</feature>
       <feature>camel-amqp</feature>
+      <feature>qpid</feature>
 
       <feature>opennms-core-camel</feature>
       <!-- TODO -->
@@ -328,6 +331,12 @@
     <feature name="postgresql" description="PostgreSQL :: JDBC Driver" version="${postgresqlVersion}">
       <bundle dependency="true">mvn:org.apache.geronimo.specs/geronimo-jta_1.1_spec/1.1.1</bundle>
       <bundle>wrap:mvn:org.postgresql/postgresql/${postgresqlVersion}</bundle>
+    </feature>
+
+    <feature name="qpid" description="Apache :: Qpid" version="0.32_3">
+      <bundle dependency="true">mvn:org.apache.geronimo.specs/geronimo-jms_1.1_spec/1.1.1</bundle>
+      <bundle dependency="true">mvn:org.apache.geronimo.specs/geronimo-jta_1.1_spec/1.1.1</bundle>
+      <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.qpid/0.32_3</bundle>
     </feature>
 
     <feature name="rate-limited-logger" description="Rate Limited Logger" version="${rateLimitedLoggerVersion}">

--- a/features/amqp/alarm-northbounder/src/main/resources/OSGI-INF/blueprint/blueprint-alarm-northbounder.xml
+++ b/features/amqp/alarm-northbounder/src/main/resources/OSGI-INF/blueprint/blueprint-alarm-northbounder.xml
@@ -21,7 +21,8 @@
   <!-- Configuration properties -->
   <cm:property-placeholder id="alarmNorthbounderProperties" persistent-id="org.opennms.features.amqp.alarmnorthbounder" update-strategy="reload">
     <cm:default-properties>
-        <!-- amqp://username:password@virtualhost?brokerlist='tcp://127.0.0.1:5672?options -->
+        <!-- amqp://[user:pass@][clientid]/virtualhost?brokerlist='tcp://host:port?option=\'value\',option=\'value\';tcp://host:port?option=\'value\'',failover='method?option=\'value\',option='value'' -->
+        <!-- The only required option is a single broker in the broker list -->
         <cm:property name="connectionUrl" value="amqp://guest:guest@onms/test?brokerlist='tcp://127.0.0.1:5672'"/>
         <!-- amqp:exchange/routingkey?options -->
         <cm:property name="destination" value="amqp:OpenNMS-Exchange/opennms-routing-key"/>

--- a/features/amqp/event-forwarder/src/main/resources/OSGI-INF/blueprint/blueprint-event-forwarder.xml
+++ b/features/amqp/event-forwarder/src/main/resources/OSGI-INF/blueprint/blueprint-event-forwarder.xml
@@ -21,7 +21,8 @@
   <!-- Configuration properties -->
   <cm:property-placeholder id="eventForwarderProperties" persistent-id="org.opennms.features.amqp.eventforwarder" update-strategy="reload">
     <cm:default-properties>
-      <!-- amqp://username:password@virtualhost?brokerlist='tcp://127.0.0.1:5672?options -->
+      <!-- amqp://[user:pass@][clientid]/virtualhost?brokerlist='tcp://host:port?option=\'value\',option=\'value\';tcp://host:port?option=\'value\'',failover='method?option=\'value\',option='value'' -->
+      <!-- The only required option is a single broker in the broker list -->
       <cm:property name="connectionUrl" value="amqp://guest:guest@onms/test?brokerlist='tcp://127.0.0.1:5672'"/>
       <!-- amqp:exchange/routingkey?options -->
       <cm:property name="destination" value="amqp:OpenNMS-Exchange/opennms-routing-key"/>

--- a/features/amqp/event-receiver/src/main/resources/OSGI-INF/blueprint/blueprint-event-receiver.xml
+++ b/features/amqp/event-receiver/src/main/resources/OSGI-INF/blueprint/blueprint-event-receiver.xml
@@ -21,7 +21,8 @@
   <!-- Configuration properties -->
   <cm:property-placeholder id="eventReceiverProperties" persistent-id="org.opennms.features.amqp.eventreceiver" update-strategy="reload">
     <cm:default-properties>
-      <!-- amqp://username:password@virtualhost?brokerlist='tcp://127.0.0.1:5672?options -->
+      <!-- amqp://[user:pass@][clientid]/virtualhost?brokerlist='tcp://host:port?option=\'value\',option=\'value\';tcp://host:port?option=\'value\'',failover='method?option=\'value\',option='value'' -->
+      <!-- The only required option is a single broker in the broker list -->
       <cm:property name="connectionUrl" value="amqp://guest:guest@onms/test?brokerlist='tcp://127.0.0.1:5672'"/>
       <!-- amqp:exchange/routingkey?options -->
       <cm:property name="source" value="amqp:OpenNMS-Queue"/>


### PR DESCRIPTION
Upgrading Camel to 2.16 broke the AMQP integration because the connection factory that we are using is no longer installed by the ```camel-amqp``` feature. This PR adds the Qpid bundle back to our features so that the connection factory is available for our blueprint to use.

I spot-checked this fix against RabbitMQ and it seems to be forwarding messages.

* JIRA: http://issues.opennms.org/browse/NMS-9472