### PR TITLE
NMS-9473: Fixed colors in default trend chart config

### DIFF
--- a/opennms-base-assembly/src/main/filtered/etc/trend-configuration.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/trend-configuration.xml
@@ -12,7 +12,7 @@
             <trend-attribute key="sparkChartRangeMin" value="0"/>
             <trend-attribute key="sparkLineColor" value="#4c9d29"/>
             <trend-attribute key="sparkLineWidth" value="1.5"/>
-            <trend-attribute key="sparkFillColor" value="#4c9d2977"/>
+            <trend-attribute key="sparkFillColor" value="rgba(76, 157, 41, 0.4)"/>
             <trend-attribute key="sparkSpotColor" value="#4c9d29"/>
             <trend-attribute key="sparkMinSpotColor" value="#4c9d29"/>
             <trend-attribute key="sparkMaxSpotColor" value="#4c9d29"/>
@@ -93,7 +93,7 @@
             <trend-attribute key="sparkChartRangeMin" value="0"/>
             <trend-attribute key="sparkLineColor" value="#4c9d29"/>
             <trend-attribute key="sparkLineWidth" value="1.5"/>
-            <trend-attribute key="sparkFillColor" value="#4c9d2977"/>
+            <trend-attribute key="sparkFillColor" value="rgba(76, 157, 41, 0.4)"/>
             <trend-attribute key="sparkSpotColor" value="#4c9d29"/>
             <trend-attribute key="sparkMinSpotColor" value="#4c9d29"/>
             <trend-attribute key="sparkMaxSpotColor" value="#4c9d29"/>
@@ -151,7 +151,7 @@
             <trend-attribute key="sparkChartRangeMin" value="0"/>
             <trend-attribute key="sparkLineColor" value="#4c9d29"/>
             <trend-attribute key="sparkLineWidth" value="1.5"/>
-            <trend-attribute key="sparkFillColor" value="#4c9d2977"/>
+            <trend-attribute key="sparkFillColor" value="rgba(76, 157, 41, 0.4)"/>
             <trend-attribute key="sparkSpotColor" value="#4c9d29"/>
             <trend-attribute key="sparkMinSpotColor" value="#4c9d29"/>
             <trend-attribute key="sparkMaxSpotColor" value="#4c9d29"/>
@@ -209,7 +209,7 @@
             <trend-attribute key="sparkChartRangeMin" value="0"/>
             <trend-attribute key="sparkLineColor" value="#4c9d29"/>
             <trend-attribute key="sparkLineWidth" value="1.5"/>
-            <trend-attribute key="sparkFillColor" value="#4c9d2977"/>
+            <trend-attribute key="sparkFillColor" value="rgba(76, 157, 41, 0.4)"/>
             <trend-attribute key="sparkSpotColor" value="#4c9d29"/>
             <trend-attribute key="sparkMinSpotColor" value="#4c9d29"/>
             <trend-attribute key="sparkMaxSpotColor" value="#4c9d29"/>


### PR DESCRIPTION
* JIRA: https://issues.opennms.org/browse/NMS-9473

Please note that this applies only to 20.0.1 since these color changes do not exist in foundation-2017 yet.