### PR TITLE
Removed a bunch of unnecessary Maven repositories from POMs

### DIFF
--- a/container/pom.xml
+++ b/container/pom.xml
@@ -18,15 +18,4 @@
     <module>bridge</module>
     <module>jaas-login-module</module>
   </modules>
-
-  <repositories>
-    <repository>
-      <id>servicemix</id>
-      <name>Apache ServiceMix Repository</name>
-      <url>http://maven.opennms.org/content/repositories/servicemix/</url>
-      <releases><enabled>true</enabled></releases>
-      <snapshots><enabled>false</enabled></snapshots>
-    </repository>
-  </repositories>
-
 </project>

--- a/core/test-api/karaf/pom.xml
+++ b/core/test-api/karaf/pom.xml
@@ -451,10 +451,5 @@
        <id>vaadin-addons</id>
        <url>http://maven.opennms.org/content/repositories/vaadin-addons/</url>
     </repository>
-    <repository>
-      <id>sonatype-public-repo</id>
-      <name>Sonatype Public Maven Repository</name>
-      <url>http://maven.opennms.org/content/repositories/sonatype-public-repo/</url>
-    </repository>
   </repositories>
 </project>

--- a/dependencies/newts/pom.xml
+++ b/dependencies/newts/pom.xml
@@ -38,20 +38,4 @@
       </exclusions>
     </dependency>
   </dependencies>
-  <repositories>
-    <repository>
-      <id>sonatype.org-snapshot-mirror</id>
-      <name>Sonatype OSS Snapshots Repository</name>
-      <url>http://maven.opennms.org/content/groups/sonatype.org-snapshot/</url>
-      <releases><enabled>false</enabled></releases>
-      <snapshots><enabled>true</enabled></snapshots>
-    </repository>
-    <repository>
-      <id>sonatype.org-snapshot</id>
-      <name>Sonatype OSS Snapshots Repository</name>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-      <releases><enabled>false</enabled></releases>
-      <snapshots><enabled>true</enabled></snapshots>
-    </repository>
-  </repositories>
 </project>

--- a/dependencies/owasp-encoder/pom.xml
+++ b/dependencies/owasp-encoder/pom.xml
@@ -27,13 +27,4 @@
       </exclusions>
     </dependency>
   </dependencies>
-  <repositories>
-    <repository>
-      <snapshots><enabled>false</enabled><updatePolicy>${updatePolicy}</updatePolicy></snapshots>
-      <releases><enabled>true</enabled><updatePolicy>${updatePolicy}</updatePolicy></releases>
-      <id>central</id>
-      <name>Maven Central</name>
-      <url>http://maven.opennms.org/content/repositories/central/</url>
-    </repository>
-  </repositories>
 </project>

--- a/dependencies/rancid/pom.xml
+++ b/dependencies/rancid/pom.xml
@@ -31,13 +31,6 @@
     <repository>
       <snapshots><enabled>false</enabled></snapshots>
       <releases><enabled>true</enabled></releases>
-      <id>sonatype-public-repo</id>
-      <name>Sonatype Public Maven Repository</name>
-      <url>http://maven.opennms.org/content/repositories/sonatype-public-repo/</url>
-    </repository>
-    <repository>
-      <snapshots><enabled>false</enabled></snapshots>
-      <releases><enabled>true</enabled></releases>
       <id>opennms-repo</id>
       <name>OpenNMS Maven Repository</name>
       <url>http://maven.opennms.org/content/groups/opennms.org-release</url>

--- a/dependencies/spring-security/pom.xml
+++ b/dependencies/spring-security/pom.xml
@@ -443,14 +443,4 @@
       <artifactId>commons-codec</artifactId>
     </dependency>
   </dependencies>
-  <repositories>
-    <repository>
-        <id>spring-releases</id>
-        <name>Spring Releases</name>
-        <url>http://repo.spring.io/release</url>
-        <snapshots>
-            <enabled>false</enabled>
-        </snapshots>
-    </repository>
-</repositories>
 </project>

--- a/features/alarm-change-notifier/pom.xml
+++ b/features/alarm-change-notifier/pom.xml
@@ -164,13 +164,6 @@
       </releases>
       <url>http://maven.opennms.org/content/groups/opennms.org-snapshot</url>
     </repository>
-    <repository>
-      <snapshots><enabled>false</enabled><updatePolicy>${updatePolicy}</updatePolicy></snapshots>
-      <releases><enabled>true</enabled><updatePolicy>${updatePolicy}</updatePolicy></releases>
-      <id>central</id>
-      <name>Maven Central</name>
-      <url>http://maven.opennms.org/content/repositories/central/</url>
-    </repository>
   </repositories>
 
 </project>

--- a/features/minion/core/repository/pom.xml
+++ b/features/minion/core/repository/pom.xml
@@ -135,16 +135,5 @@
             <name>OpenNMS Snapshot Maven Repository</name>
             <url>http://maven.opennms.org/content/groups/opennms.org-snapshot</url>
         </pluginRepository>
-        <pluginRepository>
-            <id>apache-snapshots</id>
-            <name>Apache Snapshots Repository</name>
-            <url>http://repository.apache.org/content/groups/snapshots-group</url>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </pluginRepository>
     </pluginRepositories>
 </project>

--- a/features/minion/repository/pom.xml
+++ b/features/minion/repository/pom.xml
@@ -281,17 +281,6 @@
             <name>OpenNMS Snapshot Maven Repository</name>
             <url>http://maven.opennms.org/content/groups/opennms.org-snapshot</url>
         </pluginRepository>
-        <pluginRepository>
-            <id>apache-snapshots</id>
-            <name>Apache Snapshots Repository</name>
-            <url>http://repository.apache.org/content/groups/snapshots-group</url>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </pluginRepository>
     </pluginRepositories>
 
     <repositories>
@@ -336,17 +325,6 @@
             <id>coova</id>
             <name>Coova Repository</name>
             <url>http://maven.opennms.org/content/repositories/coova/</url>
-        </repository>
-        <repository>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-            <releases>
-                <enabled>true</enabled>
-            </releases>
-            <id>jboss-repo</id>
-            <name>JBoss Repository</name>
-            <url>http://maven.opennms.org/content/repositories/jboss-repo/</url>
         </repository>
     </repositories>
 </project>

--- a/features/newts/pom.xml
+++ b/features/newts/pom.xml
@@ -129,21 +129,4 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-
-  <repositories>
-    <repository>
-      <id>sonatype.org-snapshot-mirror</id>
-      <name>Sonatype OSS Snapshots Repository</name>
-      <url>http://maven.opennms.org/content/groups/sonatype.org-snapshot/</url>
-      <releases><enabled>false</enabled></releases>
-      <snapshots><enabled>true</enabled></snapshots>
-    </repository>
-    <repository>
-      <id>sonatype.org-snapshot</id>
-      <name>Sonatype OSS Snapshots Repository</name>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-      <releases><enabled>false</enabled></releases>
-      <snapshots><enabled>true</enabled></snapshots>
-    </repository>
-  </repositories>
 </project>

--- a/features/opennms-es-rest/pom.xml
+++ b/features/opennms-es-rest/pom.xml
@@ -144,17 +144,6 @@
       <releases>
         <enabled>true</enabled>
       </releases>
-      <id>maven-repo</id>
-      <name>Maven Central</name>
-      <url>http://maven.opennms.org/content/repositories/central/</url>
-    </pluginRepository>
-    <pluginRepository>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
       <id>opennms-repo</id>
       <name>OpenNMS Repository</name>
       <url>http://maven.opennms.org/content/groups/opennms.org-release</url>

--- a/features/remote-poller/pom.xml
+++ b/features/remote-poller/pom.xml
@@ -325,12 +325,6 @@ groovy.compiler.output.path=target/classes
       <name>OpenNMS Maven Repository</name>
       <url>http://maven.opennms.org/content/groups/opennms.org-release</url>
     </repository>
-    <!--
-    <repository>
-        <id>maven-eclipse-repo</id>
-        <url>http://maven-eclipse.github.io/maven</url>
-    </repository>
-    -->
   </repositories>
 
 </project>

--- a/features/topology-map/poms/pom.xml
+++ b/features/topology-map/poms/pom.xml
@@ -43,33 +43,7 @@
     </dependencies>
   </dependencyManagement>
 
-<!--
-  <repositories>
-    <repository>
-      <id>servicemix</id>
-      <name>Apache ServiceMix Repository</name>
-      <url>http://maven.opennms.org/content/repositories/servicemix/</url>
-      <releases><enabled>true</enabled></releases>
-      <snapshots><enabled>false</enabled></snapshots>
-    </repository>
-    <repository>
-      <snapshots><enabled>false</enabled><updatePolicy>${updatePolicy}</updatePolicy></snapshots>
-      <releases><enabled>true</enabled><updatePolicy>${updatePolicy}</updatePolicy></releases>
-      <id>opennms-repo</id>
-      <name>OpenNMS Repository</name>
-      <url>http://maven.opennms.org/content/groups/opennms.org-release/</url>
-    </repository>
-  </repositories>
--->
-
   <pluginRepositories>
-    <pluginRepository>
-      <id>servicemix</id>
-      <name>Apache ServiceMix Repository</name>
-      <url>http://maven.opennms.org/content/repositories/servicemix/</url>
-      <releases><enabled>true</enabled></releases>
-      <snapshots><enabled>false</enabled></snapshots>
-    </pluginRepository>
     <pluginRepository>
       <snapshots><enabled>true</enabled></snapshots>
       <releases><enabled>false</enabled></releases>

--- a/features/vaadin-opennms-pluginmanager/pom.xml
+++ b/features/vaadin-opennms-pluginmanager/pom.xml
@@ -279,16 +279,6 @@
 
   <pluginRepositories>
     <pluginRepository>
-      <id>codehaus-snapshots</id>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-      <url>http://maven.opennms.org/content/groups/codehaus.org-snapshot/</url>
-    </pluginRepository>
-    <pluginRepository>
       <id>vaadin-snapshots</id>
       <snapshots>
         <enabled>true</enabled>

--- a/opennms-full-assembly/pom.xml
+++ b/opennms-full-assembly/pom.xml
@@ -773,12 +773,5 @@
       <name>Coova Repository</name>
       <url>http://maven.opennms.org/content/repositories/coova/</url>
     </repository>
-    <repository>
-      <snapshots><enabled>false</enabled></snapshots>
-      <releases><enabled>true</enabled></releases>
-      <id>jboss-repo</id>
-      <name>JBoss Repository</name>
-      <url>http://maven.opennms.org/content/repositories/jboss-repo/</url>
-    </repository>
   </repositories>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -4062,13 +4062,6 @@
       <url>http://maven.opennms.org/content/groups/opennms.org-snapshot/</url>
     </pluginRepository>
     <pluginRepository>
-      <snapshots><enabled>false</enabled></snapshots>
-      <releases><enabled>true</enabled></releases>
-      <id>java-net-repo</id>
-      <name>Java.net Repository</name>
-      <url>http://maven.opennms.org/content/repositories/maven2-repository.dev.java.net/</url>
-    </pluginRepository>
-    <pluginRepository>
       <id>onejar-maven-plugin.googlecode.com</id>
       <url>http://maven.opennms.org/content/repositories/onejar-maven-plugin.googlecode.com/</url>
     </pluginRepository>


### PR DESCRIPTION
This should speed up builds and make them more reliable since fewer repos will be hit when trying to look up Maven artifacts.

Most of these repos are completely unused (JBoss, Spring.io, Servicemix, Codehaus, Apache snapshots, Eclipse). We do use the Sonatype repo to fetch ```dnsjava``` but this PR removes extra references to that repo.