### PR TITLE
NMS-9466: Added tests for ReentrantLock timeouts, fixed issues

### DIFF
--- a/opennms-services/src/main/java/org/opennms/netmgt/poller/pollables/LockUnavailable.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/poller/pollables/LockUnavailable.java
@@ -34,7 +34,7 @@ package org.opennms.netmgt.poller.pollables;
  * @author <a href="mailto:brozow@opennms.org">Mathew Brozowski</a>
  * @version $Id: $
  */
-public class LockUnavailable extends RuntimeException {
+public class LockUnavailable extends Exception {
 
     private static final long serialVersionUID = 6054183865580259303L;
 
@@ -43,7 +43,6 @@ public class LockUnavailable extends RuntimeException {
      */
     public LockUnavailable() {
         super();
-        // TODO Auto-generated constructor stub
     }
 
     /**
@@ -53,7 +52,6 @@ public class LockUnavailable extends RuntimeException {
      */
     public LockUnavailable(String message) {
         super(message);
-        // TODO Auto-generated constructor stub
     }
 
     /**

--- a/opennms-services/src/main/java/org/opennms/netmgt/poller/pollables/PollableElement.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/poller/pollables/PollableElement.java
@@ -189,24 +189,32 @@ public abstract class PollableElement {
      *
      * @return a {@link org.opennms.netmgt.poller.pollables.PollableElement} object.
      */
-    public PollableElement getLockRoot() {
+    protected PollableElement getLockRoot() {
         PollableContainer parent = getParent();
         return (parent == null ? this : parent.getLockRoot());
     }
 
     /**
      * <p>obtainTreeLock</p>
-     *
-     * @param timeout a long.
      */
-    public void obtainTreeLock(long timeout) {
+    protected void obtainTreeLock() {
+        getLockRoot().obtainTreeLock();
+    }
+    
+    /**
+     * <p>obtainTreeLock</p>
+     *
+     * @param timeout Lock timeout in milliseconds
+     * @throws LockUnavailable 
+     */
+    protected void obtainTreeLock(long timeout) throws LockUnavailable {
         getLockRoot().obtainTreeLock(timeout);
     }
     
     /**
      * <p>releaseTreeLock</p>
      */
-    public void releaseTreeLock() {
+    protected void releaseTreeLock() {
         getLockRoot().releaseTreeLock();
     }
 
@@ -215,8 +223,8 @@ public abstract class PollableElement {
      *
      * @param r a {@link java.lang.Runnable} object.
      */
-    public void withTreeLock(Runnable r) {
-        withTreeLock(r, 0);
+    public final void withTreeLock(Runnable r) {
+        withTreeLock(Executors.callable(r));
     }
     
     /**
@@ -226,32 +234,9 @@ public abstract class PollableElement {
      * @param <T> a T object.
      * @return a T object.
      */
-    public <T> T withTreeLock(Callable<T> c) {
-        return withTreeLock(c, 0);
-    }
-    
-    
-    /**
-     * <p>withTreeLock</p>
-     *
-     * @param r a {@link java.lang.Runnable} object.
-     * @param timeout a long.
-     */
-    public void withTreeLock(Runnable r, long timeout) {
-        withTreeLock(Executors.callable(r), timeout);
-    }
-
-    /**
-     * <p>withTreeLock</p>
-     *
-     * @param c a {@link java.util.concurrent.Callable} object.
-     * @param timeout a long.
-     * @param <T> a T object.
-     * @return a T object.
-     */
-    public <T> T withTreeLock(Callable<T> c, long timeout) {
+    protected final <T> T withTreeLock(Callable<T> c) {
         try {
-            obtainTreeLock(timeout);
+            obtainTreeLock();
             return c.call();
         } catch (RuntimeException e) {
             throw e;
@@ -259,6 +244,46 @@ public abstract class PollableElement {
             throw new RuntimeException(e);
         } finally {
             releaseTreeLock();
+        }
+    }
+    
+    
+    /**
+     * <p>withTreeLock</p>
+     *
+     * @param r a {@link java.lang.Runnable} object.
+     * @param timeout Lock timeout in milliseconds
+     * @throws LockUnavailable 
+     */
+    protected final void withTreeLock(Runnable r, long timeout) throws LockUnavailable {
+        withTreeLock(Executors.callable(r), timeout);
+    }
+
+    /**
+     * <p>withTreeLock</p>
+     *
+     * @param c a {@link java.util.concurrent.Callable} object.
+     * @param timeout Lock timeout in milliseconds
+     * @param <T> a T object.
+     * @return a T object.
+     * @throws LockUnavailable 
+     */
+    protected final <T> T withTreeLock(Callable<T> c, long timeout) throws LockUnavailable {
+        boolean locked = false;
+        try {
+            obtainTreeLock(timeout);
+            locked = true;
+            return c.call();
+        } catch (LockUnavailable e) {
+            throw e;
+        } catch (RuntimeException e) {
+            throw e;
+        } catch (Throwable e) {
+            throw new RuntimeException(e);
+        } finally {
+            if (locked) {
+                releaseTreeLock();
+            }
         }
     }
 

--- a/opennms-services/src/main/java/org/opennms/netmgt/poller/pollables/PollableNetwork.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/poller/pollables/PollableNetwork.java
@@ -306,19 +306,25 @@ public class PollableNetwork extends PollableContainer {
      * @return a {@link org.opennms.netmgt.poller.pollables.PollableElement} object.
      */
     @Override
-    public PollableElement getLockRoot() {
+    protected PollableElement getLockRoot() {
         return this;
     }
     
     /** {@inheritDoc} */
     @Override
-    public void obtainTreeLock(long timeout) {
+    protected void obtainTreeLock() {
     }
+
+    /** {@inheritDoc} */
+    @Override
+    protected void obtainTreeLock(long timeout) {
+    }
+
     /**
      * <p>releaseTreeLock</p>
      */
     @Override
-    public void releaseTreeLock() {
+    protected void releaseTreeLock() {
     }
 
     /** {@inheritDoc} */

--- a/opennms-services/src/main/java/org/opennms/netmgt/poller/pollables/PollableNode.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/poller/pollables/PollableNode.java
@@ -230,16 +230,30 @@ public class PollableNode extends PollableContainer {
      * @return a {@link org.opennms.netmgt.poller.pollables.PollableElement} object.
      */
     @Override
-    public PollableElement getLockRoot() {
+    protected PollableElement getLockRoot() {
         return this;
     }
     
-    /** {@inheritDoc} */
+    /**
+     * This method does not have a timeout, it blocks indefinitely
+     * until the lock is obtained. 
+     */
     @Override
-    public void obtainTreeLock(long timeout) {
+    protected void obtainTreeLock() {
+        m_lock.lock();
+    }
+
+    /** 
+     * This method tries to obtain the lock within the given timeout.
+     * @param Timeout in milliseconds
+     * @throws LockUnavailable If the lock cannot be acquired before
+     * the timeout or the thread is interrupted while trying to acquire the 
+     * lock.
+     */
+    @Override
+    protected void obtainTreeLock(long timeout) throws LockUnavailable {
         if (timeout < 1) {
-            // Block until the lock is obtained
-            m_lock.lock();
+            obtainTreeLock();
         } else {
             try {
                 if (m_lock.tryLock(timeout, TimeUnit.MILLISECONDS)) {
@@ -259,7 +273,7 @@ public class PollableNode extends PollableContainer {
      * <p>releaseTreeLock</p>
      */
     @Override
-    public void releaseTreeLock() {
+    protected void releaseTreeLock() {
         m_lock.unlock();
     }
     


### PR DESCRIPTION
Changed ```LockUnavailable``` to a checked exception and fixed methods that were trying to unlock a lock that they do not hold (which caused uncaught RuntimeExceptions).

* JIRA: http://issues.opennms.org/browse/NMS-9466