### PR TITLE
NMS-9481: Clone foreign source requisition overwrites config of other requisition without any hint or warning

### DIFF
--- a/opennms-webapp/src/main/webapp/admin/ng-requisitions/app/scripts/controllers/Requisitions.js
+++ b/opennms-webapp/src/main/webapp/admin/ng-requisitions/app/scripts/controllers/Requisitions.js
@@ -164,13 +164,16 @@
         }
       });
       modalInstance.result.then(function(targetForeignSource) {
-        RequisitionsService.startTiming();
-        RequisitionsService.cloneForeignSourceDefinition(foreignSource, targetForeignSource).then(
-          function() { // success
-            growl.success('The foreign source definition for ' + foreignSource + ' has been cloned to ' + targetForeignSource);
-          },
-          $scope.errorHandler
-        );
+        bootbox.confirm('This action will override the existing foreign source definition for the target requisition. Are you sure you want to continue ?', function(ok) {
+          if (!ok) return;
+          RequisitionsService.startTiming();
+          RequisitionsService.cloneForeignSourceDefinition(foreignSource, targetForeignSource).then(
+            function() { // success
+              growl.success('The foreign source definition for ' + foreignSource + ' has been cloned to ' + targetForeignSource);
+            },
+            $scope.errorHandler
+          );
+        });
       });
     };
 


### PR DESCRIPTION
Clone foreign source requisition overwrites config of other requisition without any hint or warning.

* JIRA: http://issues.opennms.org/browse/NMS-9481

Because a customer opened a support ticket about this for Meridian, I'm applying the solution for `foundation-2016`.

The JavaScript files have been moved as part of the WebUI rework for H19, the solution has to be manually ported to `foundation-2017`. I can do that without issues as soon as this PR is merged.

Our [continuous integration system](http://bamboo.internal.opennms.com:8085) will test and verify your changes.
