### PR TITLE
NMS-9475: Document the logic behind the response time value reported by the SnmpMonitor

### DIFF
--- a/opennms-doc/guide-admin/src/asciidoc/text/poller/monitors/SnmpMonitor.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/poller/monitors/SnmpMonitor.adoc
@@ -35,7 +35,8 @@ It is currently not possible for the Remote Poller to have access to the SNMP co
 | Remote Enabled | false
 |===
 
-When the monitor is configured to persist the response time, it will count the total amount of time spent until a successful response is obtained, including the retries. it won't store the time spent during the last successful attempt.
+When the monitor is configured to persist the response time, it will count the total amount of time spent until a successful response is obtained, including the retries.
+It won't store the time spent during the last successful attempt.
 
 ===== Configuration and Usage
 

--- a/opennms-doc/guide-admin/src/asciidoc/text/poller/monitors/SnmpMonitor.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/poller/monitors/SnmpMonitor.adoc
@@ -35,6 +35,8 @@ It is currently not possible for the Remote Poller to have access to the SNMP co
 | Remote Enabled | false
 |===
 
+When the monitor is configured to persist the response time, it will count the total amount of time spent until a successful response is obtained, including the retries. it won't store the time spent during the last successful attempt.
+
 ===== Configuration and Usage
 
 .Monitor specific parameters for the SnmpMonitor


### PR DESCRIPTION
Document the logic behind the response time value reported by the SnmpMonitor.

* JIRA: http://issues.opennms.org/browse/NMS-9475

There are several ways to improve the implementation of the `SnmpMonitor` as mentioned on Jira, but the customer who is responsible for requesting this change agreed to just include a note on the documentation about how the response time is calculated.

As a side note, this should be audited across all the monitors, as this behavior might be the case of others.

Our [continuous integration system](http://bamboo.internal.opennms.com:8085) will test and verify your changes.
