### PR TITLE
NMS-9464: enlinkd thread throws StackOverflowError

### DIFF
--- a/opennms-model/src/main/java/org/opennms/netmgt/model/topology/BroadcastDomain.java
+++ b/opennms-model/src/main/java/org/opennms/netmgt/model/topology/BroadcastDomain.java
@@ -342,11 +342,14 @@ E:    	for (BridgeElement element: bridgeelements) {
             return;
         for (SharedSegment segment : getSharedSegmentOnTopologyForBridge(root.getId())) {
             segment.setDesignatedBridge(root.getId());
-            tier(segment, root.getId());
+            tier(segment, root.getId(), 0);
         }
     }
     
-    private void tier(SharedSegment segment, Integer rootid) {
+    private void tier(SharedSegment segment, Integer rootid, int level) {
+        level++;
+        if (level == 30)
+            return;
         for (Integer bridgeid: segment.getBridgeIdsOnSegment()) {
             if (bridgeid.intValue() == rootid.intValue())
                 continue;
@@ -357,7 +360,7 @@ E:    	for (BridgeElement element: bridgeelements) {
                 if (s2.getDesignatedBridge() != null && s2.getDesignatedBridge().intValue() == rootid.intValue())
                     continue;
                 s2.setDesignatedBridge(bridgeid);
-                tier(s2,bridgeid);
+                tier(s2,bridgeid,level);
             }
         }
     }


### PR DESCRIPTION


Thanks for taking time to contribute!

Please read our [Contribution Guidelines](https://github.com/OpenNMS/opennms/blob/develop/CONTRIBUTING.md) and format the title of the pull request in the format of:

NMS-9464: enlinkd thread throws StackOverflowError


* JIRA: http://issues.opennms.org/browse/NMS-9464

Fixed to go down for 30 level
then return

Need to add more test and check for loops in topology to avoid this
