### PR TITLE
NMS-9449: Add support for retrieving the SNMPv2 agent address from a specific varbind.

### DIFF
--- a/features/events/traps/src/main/java/org/opennms/netmgt/trapd/TrapSinkModule.java
+++ b/features/events/traps/src/main/java/org/opennms/netmgt/trapd/TrapSinkModule.java
@@ -89,7 +89,7 @@ public class TrapSinkModule extends AbstractXmlSinkModule<TrapInformationWrapper
             public TrapLogDTO aggregate(TrapLogDTO oldBucket, TrapInformationWrapper newMessage) {
                 final TrapInformation trapInfo = newMessage.getTrapInformation();
                 if (oldBucket == null) { // no log created yet
-                    oldBucket = new TrapLogDTO(distPoller.getId(), distPoller.getLocation(), trapInfo.getTrapAddress());
+                    oldBucket = new TrapLogDTO(distPoller.getId(), distPoller.getLocation(), TrapUtils.getEffectiveTrapAddress(trapInfo, config.shouldUseAddressFromVarbind()));
                 }
                 final TrapDTO trapDTO = new TrapDTO(trapInfo);
 

--- a/features/events/traps/src/main/java/org/opennms/netmgt/trapd/TrapUtils.java
+++ b/features/events/traps/src/main/java/org/opennms/netmgt/trapd/TrapUtils.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2017 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.trapd;
+
+import java.net.InetAddress;
+import java.util.Objects;
+
+import org.opennms.netmgt.snmp.SnmpObjId;
+import org.opennms.netmgt.snmp.SnmpVarBindDTO;
+import org.opennms.netmgt.snmp.TrapInformation;
+
+public class TrapUtils {
+
+    /**
+     * SNMP-COMMUNITY-MIB: snmpTrapAddress (1.3.6.1.6.3.18.1.3.0) of type IpAddress 
+     */
+    protected static final SnmpObjId SNMP_TRAP_ADDRESS_OID = SnmpObjId.get(".1.3.6.1.6.3.18.1.3.0");
+
+    public static final String GET_TRAP_ADDRESS_FROM_VARBIND_SYS_PROP = "org.opennms.trapd";
+
+    public static InetAddress getEffectiveTrapAddress(TrapInformation trapInfo, boolean useAddressFromVarbind) {
+        if (useAddressFromVarbind) {
+            final SnmpVarBindDTO varBindDTO = getFirstVarBindWithOid(trapInfo, SNMP_TRAP_ADDRESS_OID);
+            if (varBindDTO != null) {
+                return varBindDTO.getSnmpValue().toInetAddress();
+            }
+        }
+        return trapInfo.getTrapAddress();
+    }
+
+    public static SnmpVarBindDTO getFirstVarBindWithOid(TrapInformation trapInfo, SnmpObjId oid) {
+        for (int i = 0; i < trapInfo.getPduLength(); i++) {
+            final SnmpVarBindDTO varBindDTO = trapInfo.getSnmpVarBindDTO(i);
+            if (varBindDTO != null && Objects.equals(oid, varBindDTO.getSnmpObjectId())) {
+                return varBindDTO;
+            }
+        }
+        return null;
+    }
+}

--- a/features/events/traps/src/main/java/org/opennms/netmgt/trapd/TrapdConfigBean.java
+++ b/features/events/traps/src/main/java/org/opennms/netmgt/trapd/TrapdConfigBean.java
@@ -51,7 +51,7 @@ import org.slf4j.LoggerFactory;
  */
 public class TrapdConfigBean implements TrapdConfig, Serializable {
 
-	private static final long serialVersionUID = -4406324301602556539L;
+	private static final long serialVersionUID = 2L;
 
 	private String snmpTrapAddress;
 	private int snmpTrapPort;
@@ -62,6 +62,7 @@ public class TrapdConfigBean implements TrapdConfig, Serializable {
 	private int batchSize;
 	private int queueSize;
 	private int numThreads;
+	private boolean useAddressFromVarbind;
 
 	public TrapdConfigBean() {
 
@@ -198,5 +199,14 @@ public class TrapdConfigBean implements TrapdConfig, Serializable {
 		snmpV3User.setPrivProtocol(snmpv3User.getPrivacyProtocol());
 		snmpV3User.setSecurityName(snmpv3User.getSecurityName());
 		return snmpV3User;
+	}
+
+	@Override
+	public boolean shouldUseAddressFromVarbind() {
+		return this.useAddressFromVarbind;
+	}
+
+	public void setUseAddressFromVarbind(boolean useAddressFromVarbind) {
+		this.useAddressFromVarbind = useAddressFromVarbind;
 	}
 }

--- a/opennms-config-jaxb/src/main/java/org/opennms/netmgt/config/trapd/TrapdConfiguration.java
+++ b/opennms-config-jaxb/src/main/java/org/opennms/netmgt/config/trapd/TrapdConfiguration.java
@@ -50,7 +50,9 @@ import javax.xml.bind.annotation.XmlTransient;
 @XmlAccessorType(XmlAccessType.NONE)
 @SuppressWarnings("all") 
 public class TrapdConfiguration implements  Serializable {
-	private static final long serialVersionUID = -3548367130814097723L;
+	private static final long serialVersionUID = 2;
+
+	public static final boolean DEFAULT_USE_ADDESS_FROM_VARBIND = false;
 
 	/**
      * The IP address on which trapd listens for connections.
@@ -124,6 +126,14 @@ public class TrapdConfiguration implements  Serializable {
 	@XmlElement(name="snmpv3-user")
     private java.util.List<Snmpv3User> _snmpv3UserList;
 
+	/**
+	 * When enabled, the source address of the trap will be pulled
+     * from the snmpTrapAddress (1.3.6.1.6.3.18.1.3.0) varbind when available.
+     * This varbind is appended by certain trap forwarders when forwarding
+     * SNMPv2 traps.
+	 */
+	@XmlAttribute(name="use-address-from-varbind", required=false)
+    private Boolean _useAddessFromVarbind;
 
     public TrapdConfiguration() {
         super();
@@ -196,7 +206,7 @@ public class TrapdConfiguration implements  Serializable {
 
     public int hashCode() {
         return Objects.hash(_snmpTrapAddress, _snmpTrapPort, _has_snmpTrapPort, _newSuspectOnTrap, _snmpv3UserList,
-                _includeRawMessage, _threads, _queueSize, _batchSize, _batchInterval);
+                _includeRawMessage, _threads, _queueSize, _batchSize, _batchInterval, _useAddessFromVarbind);
     }
 
     @Override()
@@ -215,7 +225,8 @@ public class TrapdConfiguration implements  Serializable {
                     && Objects.equals(_threads, other._threads)
                     && Objects.equals(_queueSize, other._queueSize)
                     && Objects.equals(_batchSize, other._batchSize)
-                    && Objects.equals(_batchInterval, other._batchInterval);
+                    && Objects.equals(_batchInterval, other._batchInterval)
+                    && Objects.equals(_useAddessFromVarbind, other._useAddessFromVarbind);
             return equals;
         }
         return false;
@@ -351,6 +362,13 @@ public class TrapdConfiguration implements  Serializable {
         return this._newSuspectOnTrap;
     }
 
+    public boolean shouldUseAddressFromVarbind() {
+        return _useAddessFromVarbind != null ? _useAddessFromVarbind : DEFAULT_USE_ADDESS_FROM_VARBIND;
+    }
+
+    public void setUseAddressFromVarbind(Boolean useAddessFromVarbind) {
+        _useAddessFromVarbind = useAddessFromVarbind;
+    }
 
     /**
      * Method iterateSnmpv3User.

--- a/opennms-config-jaxb/src/main/resources/xsds/trapd-configuration.xsd
+++ b/opennms-config-jaxb/src/main/resources/xsds/trapd-configuration.xsd
@@ -60,6 +60,15 @@
         </annotation>
       </attribute>
 
+      <attribute name="use-address-from-varbind" type="boolean" use="optional">
+        <annotation>
+            <documentation>When enabled, the source address of the trap will be pulled
+            from the snmpTrapAddress (1.3.6.1.6.3.18.1.3.0) varbind when available.
+            This varbind is appended by certain trap forwarders when forwarding
+            SNMPv2 traps.</documentation>
+        </annotation>
+      </attribute>
+
       <attribute name="threads" use="optional">
         <annotation>
           <documentation>Number of threads used for consuming/dispatching messages.

--- a/opennms-config/src/main/java/org/opennms/netmgt/config/TrapdConfig.java
+++ b/opennms-config/src/main/java/org/opennms/netmgt/config/TrapdConfig.java
@@ -82,4 +82,6 @@ public interface TrapdConfig {
     int getBatchIntervalMs();
 
     void update(TrapdConfig config);
+
+    boolean shouldUseAddressFromVarbind();
 }

--- a/opennms-config/src/main/java/org/opennms/netmgt/config/TrapdConfigFactory.java
+++ b/opennms-config/src/main/java/org/opennms/netmgt/config/TrapdConfigFactory.java
@@ -223,6 +223,11 @@ public final class TrapdConfigFactory implements TrapdConfig {
     }
 
     @Override
+    public boolean shouldUseAddressFromVarbind() {
+        return m_config.shouldUseAddressFromVarbind();
+    }
+
+    @Override
     public void update(TrapdConfig config) {
         m_config.setSnmpTrapAddress(config.getSnmpTrapAddress());
         m_config.setSnmpTrapPort(config.getSnmpTrapPort());
@@ -244,5 +249,9 @@ public final class TrapdConfigFactory implements TrapdConfig {
             return newUser;
         }).collect(Collectors.toList());
         m_config.setSnmpv3User(snmpv3Users);
+    }
+
+    public TrapdConfiguration getConfig() {
+        return m_config;
     }
 }


### PR DESCRIPTION
JIRA: https://issues.opennms.org/browse/NMS-9449

* Pull the agent address from the snmpTrapAddress (1.3.6.1.6.3.18.1.3.0) varbind when available.
* Add a flag to trapd-configuration.xml that can be used to enable the feature.
