### PR TITLE
NMS-9496: Don't index events if the UEI is matched by a mask element.

### DIFF
--- a/opennms-config/src/test/java/org/opennms/netmgt/config/EventConfMatcherTest.java
+++ b/opennms-config/src/test/java/org/opennms/netmgt/config/EventConfMatcherTest.java
@@ -1,0 +1,86 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2017-2017 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.config;
+
+import java.io.File;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.opennms.core.test.MockLogAppender;
+import org.opennms.netmgt.model.events.EventBuilder;
+import org.opennms.netmgt.xml.eventconf.Event;
+import org.springframework.core.io.FileSystemResource;
+
+public class EventConfMatcherTest {
+
+    DefaultEventConfDao eventConfDao;
+
+    @Before
+    public void setUp() throws Exception {
+        MockLogAppender.setupLogging();
+        eventConfDao = new DefaultEventConfDao();
+        eventConfDao.setConfigResource(new FileSystemResource(new File("src/test/resources/NMS-9496.events.xml")));
+        eventConfDao.afterPropertiesSet();
+        Assert.assertEquals(3, eventConfDao.getAllEvents().size()); 
+    }
+
+    @After
+    public void tearDown() {
+        MockLogAppender.assertNoWarningsOrGreater();
+    }
+
+    /**
+     * NMS-9496: Verify that mask elements can be used to match
+     * event definitions, even when an existing UEI is set in the event.
+     */
+    @Test
+    public void canUseMaskElementsOnEventWithUei() throws Exception {
+        EventBuilder eb = new EventBuilder("uei.opennms.org/threshold/highThresholdExceeded", "JUnit");
+        Event event = eventConfDao.findByEvent(eb.getEvent());
+        Assert.assertNull(event.getOperinstruct());
+
+        eb.setNodeid(101); // Match first definition
+        event = eventConfDao.findByEvent(eb.getEvent());
+        Assert.assertEquals("Call Linux People", event.getOperinstruct());
+        Assert.assertEquals("Critical", event.getSeverity());
+
+        eb.setNodeid(201); // Match second definition
+        event = eventConfDao.findByEvent(eb.getEvent());
+        Assert.assertEquals("Call Windows People", event.getOperinstruct());
+        Assert.assertEquals("Major", event.getSeverity());
+
+        eb.setNodeid(121); // Match default
+        event = eventConfDao.findByEvent(eb.getEvent());
+        Assert.assertNull(event.getOperinstruct());
+        Assert.assertEquals("Minor", event.getSeverity());
+    }
+
+}

--- a/opennms-config/src/test/resources/NMS-9496.events.xml
+++ b/opennms-config/src/test/resources/NMS-9496.events.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0"?>
+<events>
+
+   <global>
+      <security>
+         <doNotOverride>logmsg</doNotOverride>
+         <doNotOverride>operaction</doNotOverride>
+         <doNotOverride>autoaction</doNotOverride>
+         <doNotOverride>tticket</doNotOverride>
+         <doNotOverride>script</doNotOverride>
+      </security>
+   </global>
+
+   <event>
+      <mask>
+         <maskelement>
+            <mename>uei</mename>
+            <mevalue>uei.opennms.org/threshold/highThresholdExceeded</mevalue>
+         </maskelement>
+         <maskelement>
+            <mename>nodeid</mename>
+            <mevalue>~10[123]</mevalue>
+            <mevalue>110</mevalue>			
+         </maskelement>
+      </mask>
+    <uei>uei.opennms.org/threshold/highThresholdExceeded</uei>
+    <event-label>OpenNMS-defined threshold event: highThresholdExceeded</event-label>
+    <descr>
+      &lt;p&gt;High threshold exceeded for %service% datasource
+                        %parm[ds]% on interface %interface%, parms: %parm[all]%&lt;/p&gt;
+                        &lt;p&gt;By default, OpenNMS watches some key parameters
+                        on devices in your network and will alert you with
+                        an event if certain conditions arise. For example, if
+                        the CPU utilization on your Cisco router maintains an
+                        inordinately high percentage of utilization for an extended
+                        period, an event will be generated. These thresholds are
+                        determined and configured based on vendor recommendations,
+                        tempered with real-world experience in working
+                        deployments.&lt;/p&gt; &lt;p&gt;This specific event
+                        indicates that a high threshold was exceeded.&lt;/p&gt;
+    </descr>
+    <logmsg dest="logndisplay">
+      High threshold exceeded for IronPort (%interface%) - CPU %parm[value]%, Threshold %parm[threshold]%
+	</logmsg>
+    <severity>Critical</severity>
+    <operinstruct>Call Linux People</operinstruct>
+    <alarm-data reduction-key="%uei%:%dpname%:%nodeid%:%interface%:%parm[ds]%:%parm[threshold]%:%parm[trigger]%:%parm[rearm]%:%parm[label]%" alarm-type="1" auto-clean="false"/>
+  </event>
+
+   <event>
+      <mask>
+         <maskelement>
+            <mename>uei</mename>
+            <mevalue>uei.opennms.org/threshold/highThresholdExceeded</mevalue>
+         </maskelement>
+         <maskelement>
+            <mename>nodeid</mename>
+            <mevalue>~20[123]</mevalue>
+            <mevalue>210</mevalue>			
+         </maskelement>
+      </mask>
+    <uei>uei.opennms.org/threshold/highThresholdExceeded</uei>
+    <event-label>OpenNMS-defined threshold event: highThresholdExceeded</event-label>
+    <descr>
+      &lt;p&gt;High threshold exceeded for %service% datasource
+                        %parm[ds]% on interface %interface%, parms: %parm[all]%&lt;/p&gt;
+                        &lt;p&gt;By default, OpenNMS watches some key parameters
+                        on devices in your network and will alert you with
+                        an event if certain conditions arise. For example, if
+                        the CPU utilization on your Cisco router maintains an
+                        inordinately high percentage of utilization for an extended
+                        period, an event will be generated. These thresholds are
+                        determined and configured based on vendor recommendations,
+                        tempered with real-world experience in working
+                        deployments.&lt;/p&gt; &lt;p&gt;This specific event
+                        indicates that a high threshold was exceeded.&lt;/p&gt;
+    </descr>
+    <logmsg dest="logndisplay">
+      High threshold exceeded for IronPort (%interface%) - CPU %parm[value]%, Threshold %parm[threshold]%
+	</logmsg>
+    <severity>Major</severity>
+    <operinstruct>Call Windows People</operinstruct>
+    <alarm-data reduction-key="%uei%:%dpname%:%nodeid%:%interface%:%parm[ds]%:%parm[threshold]%:%parm[trigger]%:%parm[rearm]%:%parm[label]%" alarm-type="1" auto-clean="false"/>
+  </event>
+
+   <event>
+    <uei>uei.opennms.org/threshold/highThresholdExceeded</uei>
+    <event-label>OpenNMS-defined threshold event: highThresholdExceeded</event-label>
+    <descr>
+      &lt;p&gt;High threshold exceeded for %service% datasource
+                        %parm[ds]% on interface %interface%, parms: %parm[all]%&lt;/p&gt;
+                        &lt;p&gt;By default, OpenNMS watches some key parameters
+                        on devices in your network and will alert you with
+                        an event if certain conditions arise. For example, if
+                        the CPU utilization on your Cisco router maintains an
+                        inordinately high percentage of utilization for an extended
+                        period, an event will be generated. These thresholds are
+                        determined and configured based on vendor recommendations,
+                        tempered with real-world experience in working
+                        deployments.&lt;/p&gt; &lt;p&gt;This specific event
+                        indicates that a high threshold was exceeded.&lt;/p&gt;
+    </descr>
+    <logmsg dest="logndisplay">
+      High threshold exceeded for IronPort (%interface%) - CPU %parm[value]%, Threshold %parm[threshold]%
+	</logmsg>
+    <severity>Minor</severity>
+    <alarm-data reduction-key="%uei%:%dpname%:%nodeid%:%interface%:%parm[ds]%:%parm[threshold]%:%parm[trigger]%:%parm[rearm]%:%parm[label]%" alarm-type="1" auto-clean="false"/>
+  </event>
+
+</events>


### PR DESCRIPTION
JIRA: https://issues.opennms.org/browse/NMS-9496

Remove event definitions from the index if any mask elements from any other event definitions match the UEI.

 This allows mask elements to be used against incoming event instances that already have a UEI set, provided that they include a UEI match. In this case the associated event definition will no longer be found in the UEI to Event definition index.
