### PR TITLE
NMS-9507: Using varbind to match event definition doesn't work

### DIFF
--- a/features/events/traps/src/main/java/org/opennms/netmgt/trapd/EventCreator.java
+++ b/features/events/traps/src/main/java/org/opennms/netmgt/trapd/EventCreator.java
@@ -110,8 +110,6 @@ class EventCreator {
         final org.opennms.netmgt.xml.eventconf.Event econf = eventConfDao.findByEvent(event);
         if (econf == null || econf.getUei() == null) {
             event.setUei("uei.opennms.org/default/trap");
-        } else {
-            event.setUei(econf.getUei());
         }
         return event;
     }


### PR DESCRIPTION
Using varbind to match event definition doesn't work

* JIRA: http://issues.opennms.org/browse/NMS-9507

Our [continuous integration system](http://bamboo.internal.opennms.com:8085) will test and verify your changes.

A customer is expecting a patched JAR for this based on 19.1.0, so I've created the PR to see if there are repercussions about the fix.

In terms of the fix itself, it works on my test environment.

I don't know how to make a JUnit test for this, so someone wants to have one, someone else should do it.