### PR TITLE
NMS-9542: Microsoft IE and Edge doesn't like relative path on Angular apps

### DIFF
--- a/opennms-webapp/karma.conf.js
+++ b/opennms-webapp/karma.conf.js
@@ -29,6 +29,8 @@ module.exports = function(config) {
       'src/main/webapp/lib/angular-bootstrap/ui-bootstrap-tpls.js',
       'src/main/webapp/lib/angular-loading-bar/build/loading-bar.js',
       'src/main/webapp/lib/angular-growl-v2/build/angular-growl.js',
+      // Global Variables/Methods
+      'src/test/javascript/global.js',
       // OpenNMS applications (expected to be subdirectories inside 'js')
       'src/main/webapp/js/**/*.js',
       // OpenNMS tests (expected to be subdirectories)

--- a/opennms-webapp/src/main/webapp/js/onms-interfaces/app.js
+++ b/opennms-webapp/src/main/webapp/js/onms-interfaces/app.js
@@ -113,7 +113,7 @@ angular.module('onms-interfaces', [
   };
 
   $scope.openIpPage = function(intf) {
-    $window.location.href = "element/interface.jsp?ipinterfaceid=" + intf.id;
+    $window.location.href = getBaseHref() + "element/interface.jsp?ipinterfaceid=" + intf.id;
   };
 
   $scope.$watch('filters.ipInterface', function() {
@@ -159,7 +159,7 @@ angular.module('onms-interfaces', [
   };
 
   $scope.openSnmpPage = function(intf) {
-    $window.location.href = "element/snmpinterface.jsp?node=" + $scope.nodeId + "&ifindex=" + intf.ifIndex;
+    $window.location.href = getBaseHref() + "element/snmpinterface.jsp?node=" + $scope.nodeId + "&ifindex=" + intf.ifIndex;
   };
 
   $scope.$watch('filters.snmpInterface', function() {

--- a/opennms-webapp/src/main/webapp/js/onms-ksc/wizard.js
+++ b/opennms-webapp/src/main/webapp/js/onms-ksc/wizard.js
@@ -126,7 +126,7 @@ angular.module('onms-ksc-wizard', [
   $scope.kscMaxSize = 5;
   $scope.kscTotalItems = 0;
 
-  $scope.actionUrl = 'KSC/formProcMain.htm';
+  $scope.actionUrl = getBaseHref() + 'KSC/formProcMain.htm';
 
   $scope.reloadConfig = function() {
     bootbox.dialog({
@@ -195,10 +195,11 @@ angular.module('onms-ksc-wizard', [
   };
 
   $scope.selectResource = function(resource) {
+    var baseUrl = getBaseHref() + 'KSC/customView.htm';
     if (resource.name.indexOf(':') > 0) {
-      $window.location.href = "KSC/customView.htm?type=nodeSource&report=" + resource.name;
+      $window.location.href = baseUrl + '?type=nodeSource&report=' + resource.name;
     } else {
-      $window.location.href = "KSC/customView.htm?type=node&report=" + resource.name;
+      $window.location.href = baseUrl + '?type=node&report=' + resource.name;
     }
   };
 

--- a/opennms-webapp/src/main/webapp/js/onms-requisitions/app-requisitions.js
+++ b/opennms-webapp/src/main/webapp/js/onms-requisitions/app-requisitions.js
@@ -17,7 +17,7 @@
   ])
 
   .constant("Configuration", {
-    'baseHref': 'admin/ng-requisitions/index.jsp'
+    'baseHref': getBaseHref() + 'admin/ng-requisitions/index.jsp'
   })
 
   .config(['$routeProvider', function ($routeProvider) {

--- a/opennms-webapp/src/main/webapp/js/onms-requisitions/scripts/controllers/QuickAddNode.js
+++ b/opennms-webapp/src/main/webapp/js/onms-requisitions/scripts/controllers/QuickAddNode.js
@@ -234,7 +234,7 @@
             $scope.errorHandler
           );
         } else {
-          window.location.href = 'admin/opennms/index.jsp'; // TODO Is this the best way ?
+          window.location.href = getBaseHref() + 'admin/opennms/index.jsp'; // TODO Is this the best way ?
         }
       });
     };

--- a/opennms-webapp/src/main/webapp/js/onms-resources/app.js
+++ b/opennms-webapp/src/main/webapp/js/onms-resources/app.js
@@ -36,7 +36,7 @@ angular.module('onms-resources', [
   $scope.hasResources = false;
 
   $scope.goTo = function(id) {
-    $window.location.href = 'graph/chooseresource.jsp?reports=all&parentResourceId=' + id + '&endUrl=' + $scope.endUrl;
+    $window.location.href = getBaseHref() + 'graph/chooseresource.jsp?reports=all&parentResourceId=' + id + '&endUrl=' + $scope.endUrl;
   };
 
   $scope.update = function() {
@@ -128,7 +128,7 @@ angular.module('onms-resources', [
 
   $scope.doGraph = function(selected) {
     if (selected.length > 0) {
-      $window.location.href = $scope.url + '?' + selected.join('&') + ($scope.reports ? '&reports=' + $scope.reports : '');
+      $window.location.href = getBaseHref() + $scope.url + '?' + selected.join('&') + ($scope.reports ? '&reports=' + $scope.reports : '');
     } else {
       growl.error('Please select at least one resource.');
     }

--- a/opennms-webapp/src/main/webapp/js/onms-search/app.js
+++ b/opennms-webapp/src/main/webapp/js/onms-search/app.js
@@ -40,7 +40,7 @@ angular.module('onms-search', [
   };
 
   $scope.goToChooseResources = function(node) {
-    $window.location.href = 'graph/chooseresource.jsp?node=' + node.id;
+    $window.location.href = getBaseHref() + 'graph/chooseresource.jsp?node=' + node.id;
   }
 
 }])
@@ -58,7 +58,7 @@ angular.module('onms-search', [
   };
 
   $scope.goToKscReport = function(ksc) {
-    $window.location.href = 'KSC/customView.htm?type=custom&report=' + ksc.id;
+    $window.location.href = getBaseHref() + 'KSC/customView.htm?type=custom&report=' + ksc.id;
   }
 
 }]);

--- a/opennms-webapp/src/test/javascript/global.js
+++ b/opennms-webapp/src/test/javascript/global.js
@@ -1,0 +1,3 @@
+function getBaseHref() {
+    return 'http://localhost:8980/opennms/';
+}


### PR DESCRIPTION
Microsoft IE and Edge doesn't like relative path on Angular apps.

The solution is always use full URLs, which works on any browser (including IE and Edge). Tested against H20.

* JIRA: http://issues.opennms.org/browse/NMS-9542

Our [continuous integration system](http://bamboo.internal.opennms.com:8085) will test and verify your changes.
