### PR TITLE
NMS-9548: initial-delay="null" when adding a new destination path.

### DIFF
--- a/opennms-webapp/src/main/webapp/admin/notification/pathOutline.jsp
+++ b/opennms-webapp/src/main/webapp/admin/notification/pathOutline.jsp
@@ -179,7 +179,7 @@
         <div class="form-group">
           <label for="input_initialDelay" class="control-label col-sm-2">Initial Delay:</label>
           <div class="col-sm-10">
-            <%=buildDelaySelect(intervals, "initialDelay", newPath.getInitialDelay().orElse(null))%>
+            <%=buildDelaySelect(intervals, "initialDelay", newPath.getInitialDelay().orElse("0s"))%>
           </div>
         </div>
         <div class="form-group">


### PR DESCRIPTION
initial-delay="null" when adding a new destination path.

The default should be "0s" like in older versions of OpenNMS (including Meridian 2016).

* JIRA: http://issues.opennms.org/browse/NMS-9548

Our [continuous integration system](http://bamboo.internal.opennms.com:8085) will test and verify your changes.
