### PR TITLE
NMS-8046: handle NoSuchInstance properly

### DIFF
--- a/core/snmp/api/src/main/java/org/opennms/netmgt/snmp/SnmpTableResult.java
+++ b/core/snmp/api/src/main/java/org/opennms/netmgt/snmp/SnmpTableResult.java
@@ -34,10 +34,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * @author brozow
  */
 public class SnmpTableResult implements RowResultFactory {
+    private static final Logger LOG = LoggerFactory.getLogger(SnmpTableResult.class);
 
     private final RowCallback m_callback;
     private final SnmpObjId[] m_columns;
@@ -95,8 +99,13 @@ public class SnmpTableResult implements RowResultFactory {
         if (lastInstance != null || isFinished()) {
             Iterator<SnmpInstId> i = m_pendingData.keySet().iterator();
             while (i.hasNext()) {
-                SnmpInstId key = i.next();
-                m_callback.rowCompleted(m_pendingData.get(key));
+                final SnmpInstId key = i.next();
+                final SnmpRowResult pendingData = m_pendingData.get(key);
+                try {
+                    m_callback.rowCompleted(pendingData);
+                } catch (final Exception e) {
+                    LOG.warn("Failed to handle completed SNMP table row {}: {}", key, pendingData, e);
+                }
                 i.remove();
                 if (key.equals(lastInstance)) {
                     break;

--- a/opennms-provision/opennms-provisiond/src/main/java/org/opennms/netmgt/provision/service/PhysInterfaceTableTracker.java
+++ b/opennms-provision/opennms-provisiond/src/main/java/org/opennms/netmgt/provision/service/PhysInterfaceTableTracker.java
@@ -191,6 +191,9 @@ public class PhysInterfaceTableTracker extends TableTracker {
         
         private String getPhysAddr() {
             final SnmpValue value = getValue(IF_PHYS_ADDR);
+            if (value == null || value.isError()) {
+                return null;
+            }
             String hexString = value == null ? null : value.toHexString();
             String displayString = value == null ? null : value.toDisplayString();
             // See ifTableEntry: NMS-4902 (revision cee964fe979e6465aeb4e2efd4772e50ebc54831)


### PR DESCRIPTION
This PR does 2 things:

1. make sure the physical interface tracker continues even if it encounters an error, rather than stopping scanning the table
2. traps errors in marking a row completed in `SnmpTableResult` so that it will continue rather than failing if an unexpected value is encountered

* JIRA: http://issues.opennms.org/browse/NMS-8046

Our [continuous integration system](http://bamboo.internal.opennms.com:8085) will test and verify your changes.
