### PR TITLE
NMS-9550: The reason parameter for a nodeLostService event is limited to 255 characters

### DIFF
--- a/core/schema/src/main/liquibase/20.0.2/changelog.xml
+++ b/core/schema/src/main/liquibase/20.0.2/changelog.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+
+  <!-- Fix for issue NMS-9550 -->
+  <changeSet author="agalue" id="20.0.2-changeDataTypeOfReasonToText">
+    <modifyDataType tableName="location_specific_status_changes" columnName="reason" newDataType="text"/>
+
+    <rollback>
+      <modifyDataType tableName="location_specific_status_changes" columnName="reason" newDataType="varchar(255)"/>
+    </rollback>
+  </changeSet>
+
+</databaseChangeLog>

--- a/core/schema/src/main/liquibase/changelog.xml
+++ b/core/schema/src/main/liquibase/changelog.xml
@@ -70,6 +70,8 @@
 	<include file="14.0.3/changelog.xml"/>
 	<include file="14.0.4/changelog.xml"/>
 
+	<include file="foundation-2015/changelog.xml"/>
+
 	<include file="stored-procedures/getManagePercentAvailIntfWindow.xml" />
 	<include file="stored-procedures/getManagePercentAvailNodeWindow.xml" />
 	<include file="stored-procedures/getManagedOutageForIntfInWindow.xml" />

--- a/core/schema/src/main/liquibase/foundation-2015/changelog.xml
+++ b/core/schema/src/main/liquibase/foundation-2015/changelog.xml
@@ -6,7 +6,7 @@
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
 
   <!-- Fix for issue NMS-9550 -->
-  <changeSet author="agalue" id="20.0.2-changeDataTypeOfReasonToText">
+  <changeSet author="agalue" id="foundation2015-changeDataTypeOfReasonToText">
     <modifyDataType tableName="location_specific_status_changes" columnName="reason" newDataType="text"/>
 
     <rollback>

--- a/core/schema/src/main/liquibase/foundation-2015/changelog.xml
+++ b/core/schema/src/main/liquibase/foundation-2015/changelog.xml
@@ -7,10 +7,10 @@
 
   <!-- Fix for issue NMS-9550 -->
   <changeSet author="agalue" id="foundation2015-changeDataTypeOfReasonToText">
-    <modifyDataType tableName="location_specific_status_changes" columnName="statusReason" newDataType="text"/>
+    <modifyDataType tableName="location_specific_status_changes" columnName="statusreason" newDataType="text"/>
 
     <rollback>
-      <modifyDataType tableName="location_specific_status_changes" columnName="statusReason" newDataType="varchar(255)"/>
+      <modifyDataType tableName="location_specific_status_changes" columnName="statusreason" newDataType="varchar(255)"/>
     </rollback>
   </changeSet>
 

--- a/core/schema/src/main/liquibase/foundation-2015/changelog.xml
+++ b/core/schema/src/main/liquibase/foundation-2015/changelog.xml
@@ -7,10 +7,10 @@
 
   <!-- Fix for issue NMS-9550 -->
   <changeSet author="agalue" id="foundation2015-changeDataTypeOfReasonToText">
-    <modifyDataType tableName="location_specific_status_changes" columnName="reason" newDataType="text"/>
+    <modifyDataType tableName="location_specific_status_changes" columnName="statusReason" newDataType="text"/>
 
     <rollback>
-      <modifyDataType tableName="location_specific_status_changes" columnName="reason" newDataType="varchar(255)"/>
+      <modifyDataType tableName="location_specific_status_changes" columnName="statusReason" newDataType="varchar(255)"/>
     </rollback>
   </changeSet>
 

--- a/features/poller/api/src/main/java/org/opennms/netmgt/poller/PollStatus.java
+++ b/features/poller/api/src/main/java/org/opennms/netmgt/poller/PollStatus.java
@@ -418,7 +418,7 @@ public class PollStatus implements Serializable {
      *
      * @return a {@link java.lang.String} object.
      */
-    @Column(name="statusReason", length=255, nullable=true)
+    @Column(name="statusReason", nullable=true)
     public String getReason() {
         return m_reason;
     }
@@ -429,13 +429,7 @@ public class PollStatus implements Serializable {
      * @param reason a {@link java.lang.String} object.
      */
     public void setReason(final String reason) {
-        if (reason == null) {
-            m_reason = null;
-        } else if (reason.length() <= 255) {
-            m_reason = reason;
-        } else {
-            m_reason = reason.substring(0, 255);
-        }
+        m_reason = reason;
     }
 
     /**

--- a/opennms-base-assembly/src/main/filtered/etc/create.sql
+++ b/opennms-base-assembly/src/main/filtered/etc/create.sql
@@ -1455,7 +1455,7 @@ CREATE TABLE location_specific_status_changes (
     ifServiceId INTEGER NOT NULL,
     statusCode INTEGER NOT NULL,
     statusTime timestamp with time zone NOT NULL,
-    statusReason VARCHAR(255),
+    statusReason TEXT,
     responseTime DOUBLE PRECISION,
 
     CONSTRAINT location_specific_status_changes_pkey PRIMARY KEY (id),


### PR DESCRIPTION
The reason parameter for a nodeLostService event is limited to 255 characters.

* JIRA: http://issues.opennms.org/browse/NMS-9550

Our [continuous integration system](http://bamboo.internal.opennms.com:8085) will test and verify your changes.
