### PR TITLE
NMS-9551: Respect the order of the event file definitions when reloading

### DIFF
--- a/opennms-config-model/src/main/java/org/opennms/netmgt/xml/eventconf/Events.java
+++ b/opennms-config-model/src/main/java/org/opennms/netmgt/xml/eventconf/Events.java
@@ -386,7 +386,17 @@ public class Events implements Serializable {
 
             m_loadedEventFiles.put(eventFile, events);
         }
-    }
+
+		// Re-order the loaded event files to match the order specified in the root configuration
+		final Map<String, Events> orderedAndLoadedEventFiles = new LinkedHashMap<>();
+		for (String eventFile : m_eventFiles) {
+			final Events loadedEvents = m_loadedEventFiles.get(eventFile);
+			if (loadedEvents != null) {
+				orderedAndLoadedEventFiles.put(eventFile, loadedEvents);
+			}
+		}
+		m_loadedEventFiles = orderedAndLoadedEventFiles;
+	}
 
 	public boolean isSecureTag(String tag) {
 		return m_global == null ? false : m_global.isSecureTag(tag);

--- a/opennms-config/src/test/java/org/opennms/netmgt/config/EventConfDaoReloadTest.java
+++ b/opennms-config/src/test/java/org/opennms/netmgt/config/EventConfDaoReloadTest.java
@@ -1,6 +1,7 @@
 package org.opennms.netmgt.config;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 import java.io.File;
 import java.io.IOException;
@@ -12,6 +13,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.opennms.core.test.MockLogAppender;
+import org.opennms.netmgt.model.events.EventBuilder;
+import org.opennms.netmgt.xml.eventconf.Event;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.io.Resource;
@@ -124,6 +127,56 @@ public class EventConfDaoReloadTest {
         // Reload
         eventConfDao.reload();
         assertEquals(5, eventConfDao.getAllEvents().size());
+    }
+
+    /**
+     * Verify that the order of the includes is maintained
+     * when new event configuration files are added, and reloaded.
+     */
+    @Test
+    public void canMaintainOrderOnReload() throws Exception {
+        // Copy the resources to the file system
+        File eventconfXml = copyEventConfig("order/eventconf.empty.xml", "eventconf.xml");
+
+        // Load
+        DefaultEventConfDao eventConfDao = new DefaultEventConfDao();
+        eventConfDao.setConfigResource(new FileSystemResource(eventconfXml));
+        eventConfDao.afterPropertiesSet();
+        assertEquals(0, eventConfDao.getAllEvents().size());
+
+        EventBuilder eb = new EventBuilder("uei.opennms.org/test/order", "JUnit");
+        Event event = eventConfDao.findByEvent(eb.getEvent());
+        assertNull("no event should match", event);
+
+        // Replace the eventconf.xml with one that references 1
+        Thread.sleep(1000);
+        copyEventConfig("order/eventconf.1.xml", "eventconf.xml");
+        copyEventConfig("order/1.events.xml", "1.events.xml");
+
+        // Reload
+        eventConfDao.reload();
+        assertEquals(1, eventConfDao.getAllEvents().size());
+
+        event = eventConfDao.findByEvent(eb.getEvent());
+        assertEquals("Critical", event.getSeverity());
+
+        // Replace the eventconf.xml with one that references 2 and then 1
+        Thread.sleep(1000);
+        copyEventConfig("order/eventconf.21.xml", "eventconf.xml");
+        copyEventConfig("order/2.events.xml", "2.events.xml");
+
+        // Reload
+        eventConfDao.reload();
+        assertEquals(2, eventConfDao.getAllEvents().size());
+
+        event = eventConfDao.findByEvent(eb.getEvent());
+        assertEquals("Major", event.getSeverity());
+    }
+
+    private File copyEventConfig(String from, String to) throws IOException {
+        final File dest = new File(tempFolder.getRoot(), to);
+        FileUtils.copyInputStreamToFile(getResourceForRelativePath(from).getInputStream(), dest);
+        return dest;
     }
 
     private Resource getResourceForRelativePath(String resourceSuffix) {

--- a/opennms-config/src/test/resources/org/opennms/netmgt/config/eventd/order/1.events.xml
+++ b/opennms-config/src/test/resources/org/opennms/netmgt/config/eventd/order/1.events.xml
@@ -1,0 +1,9 @@
+<events xmlns="http://xmlns.opennms.org/xsd/eventconf">
+    <event>
+        <uei>uei.opennms.org/test/order</uei>
+        <event-label>order</event-label>
+        <descr>order</descr>
+        <logmsg dest="logndisplay">order</logmsg>
+        <severity>Critical</severity>
+    </event>
+</events>

--- a/opennms-config/src/test/resources/org/opennms/netmgt/config/eventd/order/2.events.xml
+++ b/opennms-config/src/test/resources/org/opennms/netmgt/config/eventd/order/2.events.xml
@@ -1,0 +1,9 @@
+<events xmlns="http://xmlns.opennms.org/xsd/eventconf">
+    <event>
+        <uei>uei.opennms.org/test/order</uei>
+        <event-label>order</event-label>
+        <descr>order</descr>
+        <logmsg dest="logndisplay">order</logmsg>
+        <severity>Major</severity>
+    </event>
+</events>

--- a/opennms-config/src/test/resources/org/opennms/netmgt/config/eventd/order/eventconf.1.xml
+++ b/opennms-config/src/test/resources/org/opennms/netmgt/config/eventd/order/eventconf.1.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<events xmlns="http://xmlns.opennms.org/xsd/eventconf">
+    <global>
+        <security>
+            <doNotOverride>logmsg</doNotOverride>
+            <doNotOverride>operaction</doNotOverride>
+            <doNotOverride>autoaction</doNotOverride>
+            <doNotOverride>tticket</doNotOverride>
+            <doNotOverride>script</doNotOverride>
+        </security>
+    </global>
+
+    <event-file>1.events.xml</event-file>
+</events>

--- a/opennms-config/src/test/resources/org/opennms/netmgt/config/eventd/order/eventconf.21.xml
+++ b/opennms-config/src/test/resources/org/opennms/netmgt/config/eventd/order/eventconf.21.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<events xmlns="http://xmlns.opennms.org/xsd/eventconf">
+    <global>
+        <security>
+            <doNotOverride>logmsg</doNotOverride>
+            <doNotOverride>operaction</doNotOverride>
+            <doNotOverride>autoaction</doNotOverride>
+            <doNotOverride>tticket</doNotOverride>
+            <doNotOverride>script</doNotOverride>
+        </security>
+    </global>
+
+    <event-file>2.events.xml</event-file>
+    <event-file>1.events.xml</event-file>
+</events>

--- a/opennms-config/src/test/resources/org/opennms/netmgt/config/eventd/order/eventconf.empty.xml
+++ b/opennms-config/src/test/resources/org/opennms/netmgt/config/eventd/order/eventconf.empty.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<events xmlns="http://xmlns.opennms.org/xsd/eventconf">
+    <global>
+        <security>
+            <doNotOverride>logmsg</doNotOverride>
+            <doNotOverride>operaction</doNotOverride>
+            <doNotOverride>autoaction</doNotOverride>
+            <doNotOverride>tticket</doNotOverride>
+            <doNotOverride>script</doNotOverride>
+        </security>
+    </global>
+</events>


### PR DESCRIPTION
JIRA: https://issues.opennms.org/browse/NMS-9551

This fixes a bug where the order of event definitions is not respected after reloading the event configuration without restarting.