### PR TITLE
NMS-8919: Add foreignSource and foreignId parameters when sending events as an alternative to nodeId

### DIFF
--- a/features/events/daemon/src/main/java/org/opennms/netmgt/eventd/DefaultEventHandlerImpl.java
+++ b/features/events/daemon/src/main/java/org/opennms/netmgt/eventd/DefaultEventHandlerImpl.java
@@ -35,6 +35,8 @@ import java.util.Objects;
 import org.opennms.netmgt.events.api.EventHandler;
 import org.opennms.netmgt.events.api.EventProcessor;
 import org.opennms.netmgt.events.api.EventProcessorException;
+import org.opennms.netmgt.dao.api.NodeDao;
+import org.opennms.netmgt.model.OnmsNode;
 import org.opennms.netmgt.xml.event.Event;
 import org.opennms.netmgt.xml.event.Events;
 import org.opennms.netmgt.xml.event.Log;
@@ -70,6 +72,8 @@ public final class DefaultEventHandlerImpl implements InitializingBean, EventHan
     private final Timer processTimer;
 
     private final Histogram logSizes;
+
+    private NodeDao m_nodeDao;
 
     /**
      * <p>Constructor for DefaultEventHandlerImpl.</p>
@@ -119,6 +123,17 @@ public final class DefaultEventHandlerImpl implements InitializingBean, EventHan
             }
 
             for (final Event event : events.getEventCollection()) {
+                if (event.getNodeid() == 0) {
+                    final Parm foreignSource = event.getParm("_foreignSource");
+                    final Parm foreignId = event.getParm("_foreignId");
+                    if (foreignSource != null && foreignSource.getValue() != null && foreignId != null && foreignId.getValue() != null) {
+                        final OnmsNode node = getNodeDao().findByForeignId(foreignSource.getValue().getContent(), foreignId.getValue().getContent());
+                        if (node != null) {
+                            event.setNodeid(Long.parseLong(node.getId().toString()));
+                        }
+                    }
+                }
+
                 if (LOG.isInfoEnabled() && getLogEventSummaries()) {
                     LOG.info("Received event: UEI={}, src={}, iface={}, svc={}, time={}, parms={}", event.getUei(), event.getSource(), event.getInterface(), event.getService(), event.getTime(), getPrettyParms(event));
                 }
@@ -209,5 +224,13 @@ public final class DefaultEventHandlerImpl implements InitializingBean, EventHan
     
     public void setLogEventSummaries(final boolean logEventSummaries) {
         m_logEventSummaries = logEventSummaries;
+    }
+
+    public void setNodeDao(NodeDao nodeDao) {
+        m_nodeDao = nodeDao;
+    }
+
+    public NodeDao getNodeDao() {
+        return m_nodeDao;
     }
 }

--- a/features/events/daemon/src/main/java/org/opennms/netmgt/eventd/DefaultEventHandlerImpl.java
+++ b/features/events/daemon/src/main/java/org/opennms/netmgt/eventd/DefaultEventHandlerImpl.java
@@ -125,11 +125,15 @@ public final class DefaultEventHandlerImpl implements InitializingBean, EventHan
             for (final Event event : events.getEventCollection()) {
                 if (event.getNodeid() == 0) {
                     final Parm foreignSource = event.getParm("_foreignSource");
-                    final Parm foreignId = event.getParm("_foreignId");
-                    if (foreignSource != null && foreignSource.getValue() != null && foreignId != null && foreignId.getValue() != null) {
-                        final OnmsNode node = getNodeDao().findByForeignId(foreignSource.getValue().getContent(), foreignId.getValue().getContent());
-                        if (node != null) {
-                            event.setNodeid(Long.parseLong(node.getId().toString()));
+                    if (foreignSource != null && foreignSource.getValue() != null) {
+                        final Parm foreignId = event.getParm("_foreignId");
+                        if (foreignId != null && foreignId.getValue() != null) {
+                            final OnmsNode node = getNodeDao().findByForeignId(foreignSource.getValue().getContent(), foreignId.getValue().getContent());
+                            if (node != null) {
+                                event.setNodeid(node.getId().longValue());
+                            } else {
+                                LOG.warn("Can't find node associated with foreignSource {} and foreignId {}", foreignSource, foreignId);
+                            }
                         }
                     }
                 }

--- a/features/events/daemon/src/main/resources/META-INF/opennms/applicationContext-eventDaemon.xml
+++ b/features/events/daemon/src/main/resources/META-INF/opennms/applicationContext-eventDaemon.xml
@@ -92,6 +92,7 @@
       </list>
     </property>
     <property name="logEventSummaries" ref="shouldLogEventSummaries" />
+    <property name="nodeDao" ref="nodeDao" />
   </bean>
 
   <bean id="eventWriter" class="org.opennms.netmgt.eventd.processor.HibernateEventWriter">

--- a/opennms-doc/guide-admin/src/asciidoc/text/events/events.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/events/events.adoc
@@ -64,7 +64,7 @@ Different parsers can be used to convert the syslog message fields into {opennms
 
 [options="header, autowidth"]
 |===
-| Parser  | Description 
+| Parser  | Description
 | `org.opennms.netmgt.syslogd.CustomSyslogParser`    | Default parser that uses a regex statement to parse the syslog header.
 | `org.opennms.netmgt.syslogd.RadixTreeSyslogParser` | Parser that uses an internal list of _grok_-style statements to parse the syslog header.
 | `org.opennms.netmgt.syslogd.SyslogNGParser`        | Parser that strictly parses messages in the default pattern of syslog-ng.
@@ -86,7 +86,7 @@ The patterns should be arranged in the file from most specific to least specific
 
 [options="header, autowidth"]
 |===
-| Pattern   | Description 
+| Pattern   | Description
 | `INT`     | Positive integer.
 | `MONTH`   | 3-character English month abbreviation.
 | `NOSPACE` | String that contains no whitespace.
@@ -95,7 +95,7 @@ The patterns should be arranged in the file from most specific to least specific
 
 [options="header, autowidth"]
 |===
-| Semantic Token | Description 
+| Semantic Token | Description
 | `day` | 2-digit day of month (1-31).
 | `facilityPriority` | Facility-priority integer.
 | `hostname` | String hostname (unqualified or FQDN), IPv4 address, or IPv6 address.
@@ -135,3 +135,10 @@ This publish-subscribe model enables components to use events as a mechanism to 
 For example, the provisioning subsystem of {opennms-product-name} publishes a _node-added_ event whenever a new node is added to the system.
 Other subsystems with an interest in new nodes subscribe to the _node-added_ event and automatically receive these events, so they know to start monitoring and managing the new node if their configuration dictates.
 The publisher and subscriber components do not need to have any knowledge of each other, allowing for a clean division of labor and lessening the programming burden to add entirely new {opennms-product-name} subsystems or modify the behavior of existing ones.
+
+==== Associate an Event to a given node
+
+There are 2 ways to associate an existing node to a given event prior sending it to the Event Bus:
+
+* Set the *nodeId* of the node in question to the event.
+* For requisitioned nodes, set the *_foreignSource* and *_foreignId* as parameters to the event. Then, any incoming event without a *nodeId* and these 2 parameters will trigger a lookup on the DB; if a node is found, the *nodeId* attribute will be dynamically set into the event, regardless which method has been used to send it to the *Event Bus*.


### PR DESCRIPTION
Add foreignSource and foreignId parameters when sending events as an alternative to nodeId

Please use the [JIRA](https://issues.opennms.org) issue number and create a link in the JIRA issue back to this pull request so we have a quick reference from the issue to the pull request.

* JIRA: http://issues.opennms.org/browse/NMS-8919

Our [continuous integration system](http://bamboo.internal.opennms.com:8085) will test and verify your changes.
