### PR TITLE
NMS-9573: fix RPM replacement of users.xml

### DIFF
--- a/tools/packages/opennms/opennms.spec
+++ b/tools/packages/opennms/opennms.spec
@@ -714,7 +714,7 @@ rm -rf $RPM_BUILD_ROOT
 %defattr(664 root root 775)
 %attr(755,root,root)	%{profiledir}/%{name}.sh
 %attr(755,root,root)	%{logdir}
-%attr(640,root,root)	%{instprefix}/etc/users.xml
+%attr(640,root,root)	%config(noreplace) %{instprefix}/etc/users.xml
 			%{instprefix}/data
 			%{instprefix}/deploy
 
@@ -895,6 +895,13 @@ if [ "$1" = 0 ]; then
 	if [ -L "$ROOT_INST/docs" ]; then
 		rm -f "$ROOT_INST/docs"
 	fi
+fi
+
+%pre -p /bin/bash core
+ROOT_INST="$RPM_INSTALL_PREFIX0"
+[ -z "$ROOT_INST"  ] && ROOT_INST="%{instprefix}"
+if [ -e "${ROOT_INST}/etc/users.xml" ]; then
+	chmod 640 "${ROOT_INST}/etc/users.xml"
 fi
 
 %post -p /bin/bash core

--- a/tools/packages/opennms/opennms.spec
+++ b/tools/packages/opennms/opennms.spec
@@ -921,7 +921,7 @@ for prefix in lib lib64; do
 		SYSTEMDDIR="/usr/$prefix/systemd/system"
 		printf -- "- installing service into $SYSTEMDDIR... "
 		install -d -m 755 "$SYSTEMDDIR"
-		install -m 644 "%{instprefix}/etc/opennms.service" "$SYSTEMDDIR"/
+		install -m 644 "${ROOT_INST}/etc/opennms.service" "${SYSTEMDDIR}"/
 		echo "done"
 	fi
 done


### PR DESCRIPTION
In the process of fixing NMS-9493, I accidentally made it so `users.xml` is not marked as a `%config` file.  This patch fixes that, and also makes sure permissions match during `%pre` install so that an upgrade won't cause .rpmnew or .rpmsave files to be created in most cases.

* JIRA: http://issues.opennms.org/browse/NMS-9573
