### PR TITLE
NMS-9545: bump mina version to 2.0.16

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1320,7 +1320,7 @@
     <lmaxDisruptorVersion>3.3.2</lmaxDisruptorVersion>
     <log4jVersion>99.99.99-use-log4j2</log4jVersion>
     <log4j2Version>2.5</log4j2Version>
-    <minaVersion>2.0.13</minaVersion>
+    <minaVersion>2.0.16</minaVersion>
     <minionKarafVersion>4.0.5</minionKarafVersion>
     <newtsVersion>1.4.3</newtsVersion>
     <paxExamVersion>4.8.0</paxExamVersion>


### PR DESCRIPTION
This PR bumps mina to 2.0.16 to (attempt to) resolve a resource leak reported in NMS-9545.  The user has reported upgrading mina to the latest version fixed their issue.

* JIRA: http://issues.opennms.org/browse/NMS-9545

Our [continuous integration system](http://bamboo.internal.opennms.com:8085) will test and verify your changes.
