### PR TITLE
NMS-9591: Rename tests that require JNI/JNA to integration tests

### DIFF
--- a/opennms-provision/opennms-detector-simple/src/test/java/org/opennms/netmgt/provision/detector/IcmpDetectorIT.java
+++ b/opennms-provision/opennms-detector-simple/src/test/java/org/opennms/netmgt/provision/detector/IcmpDetectorIT.java
@@ -54,7 +54,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
         "classpath:/META-INF/opennms/test/detectors.xml",
         "classpath:/META-INF/opennms/detectors.xml"
 })
-public class IcmpDetectorTest {
+public class IcmpDetectorIT {
 
     @Autowired
     private IcmpDetectorFactory m_detectorFactory;

--- a/opennms-services/src/test/java/org/opennms/netmgt/poller/pollables/PollableServiceConfigIT.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/poller/pollables/PollableServiceConfigIT.java
@@ -80,7 +80,7 @@ import com.google.common.collect.Lists;
 @JUnitConfigurationEnvironment(systemProperties={
         "org.opennms.netmgt.icmp.pingerClass=org.opennms.netmgt.icmp.jna.JnaPinger"
 })
-public class PollableServiceConfigTest {
+public class PollableServiceConfigIT {
 
     @Autowired
     private LocationAwarePollerClient m_locationAwarePollerClient;


### PR DESCRIPTION
Address some build errors with unit tests enabled where JNI/JNA (particularly with root access) was needed for some unit tests. Renamed these to be integration tests.

* JIRA: http://issues.opennms.org/browse/NMS-9591