### PR TITLE
NMS-9597 - Making the Mattermost plugin display the same format as slack

### DIFF
--- a/opennms-services/src/main/java/org/opennms/netmgt/notifd/MattermostNotificationStrategy.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/notifd/MattermostNotificationStrategy.java
@@ -80,8 +80,11 @@ public class MattermostNotificationStrategy extends AbstractSlackCompatibleNotif
 
     @Override
 	protected String decorateMessageSubject(String subject) {
-    	StringBuilder bldr = new StringBuilder("#### ");
-    	bldr.append(subject).append("\n");
+    	if ("".equals(subject)) {
+    		return "";
+    	}
+    	StringBuilder bldr = new StringBuilder("*");
+    	bldr.append(subject).append("*").append("\n");
     	return bldr.toString();
     }
     

--- a/opennms-services/src/main/java/org/opennms/netmgt/notifd/MattermostNotificationStrategy.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/notifd/MattermostNotificationStrategy.java
@@ -83,8 +83,8 @@ public class MattermostNotificationStrategy extends AbstractSlackCompatibleNotif
     	if ("".equals(subject)) {
     		return "";
     	}
-    	StringBuilder bldr = new StringBuilder("*");
-    	bldr.append(subject).append("*").append("\n");
+    	StringBuilder bldr = new StringBuilder("**");
+    	bldr.append(subject).append("**").append("\n");
     	return bldr.toString();
     }
     

--- a/opennms-services/src/test/java/org/opennms/netmgt/notifd/MattermostNotificationStrategyIT.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/notifd/MattermostNotificationStrategyIT.java
@@ -99,7 +99,7 @@ public class MattermostNotificationStrategyIT {
             JSONObject inputJson = MattermostNotificationStrategyTestServlet.getInputJson();
             assertNotNull(inputJson);
             assertEquals("opennms", inputJson.get("username"));
-            assertEquals("*Test*\nThis is only a test", inputJson.get("text"));
+            assertEquals("**Test**\nThis is only a test", inputJson.get("text"));
             assertEquals("integrationtests", inputJson.get("channel"));
             assertEquals("http://opennms.org/logo.png", inputJson.get("icon_url"));
             assertEquals(":shipit:", inputJson.get("icon_emoji"));
@@ -116,7 +116,7 @@ public class MattermostNotificationStrategyIT {
             inputJson = MattermostNotificationStrategyTestServlet.getInputJson();
             assertNotNull(inputJson);
             assertEquals("opennmsXX", inputJson.get("username"));
-            assertEquals("*Test again*\nThis is only a second test", inputJson.get("text"));
+            assertEquals("**Test again**\nThis is only a second test", inputJson.get("text"));
             assertEquals("integrationtestsXX", inputJson.get("channel"));
             assertEquals("http://opennms.org/logo.pngXX", inputJson.get("icon_url"));
             assertEquals(":shipitXX:", inputJson.get("icon_emoji"));

--- a/opennms-services/src/test/java/org/opennms/netmgt/notifd/MattermostNotificationStrategyIT.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/notifd/MattermostNotificationStrategyIT.java
@@ -99,7 +99,7 @@ public class MattermostNotificationStrategyIT {
             JSONObject inputJson = MattermostNotificationStrategyTestServlet.getInputJson();
             assertNotNull(inputJson);
             assertEquals("opennms", inputJson.get("username"));
-            assertEquals("#### Test\nThis is only a test", inputJson.get("text"));
+            assertEquals("*Test*\nThis is only a test", inputJson.get("text"));
             assertEquals("integrationtests", inputJson.get("channel"));
             assertEquals("http://opennms.org/logo.png", inputJson.get("icon_url"));
             assertEquals(":shipit:", inputJson.get("icon_emoji"));
@@ -116,7 +116,7 @@ public class MattermostNotificationStrategyIT {
             inputJson = MattermostNotificationStrategyTestServlet.getInputJson();
             assertNotNull(inputJson);
             assertEquals("opennmsXX", inputJson.get("username"));
-            assertEquals("#### Test again\nThis is only a second test", inputJson.get("text"));
+            assertEquals("*Test again*\nThis is only a second test", inputJson.get("text"));
             assertEquals("integrationtestsXX", inputJson.get("channel"));
             assertEquals("http://opennms.org/logo.pngXX", inputJson.get("icon_url"));
             assertEquals(":shipitXX:", inputJson.get("icon_emoji"));


### PR DESCRIPTION
Fix the subject formatting from `#### my-subject` to `** my subject **`

* JIRA: https://issues.opennms.org/browse/NMS-9597