### PR TITLE
NMS-9278: Fix RESTv2 node service

### DIFF
--- a/core/criteria/src/main/java/org/opennms/core/criteria/AliasBuilder.java
+++ b/core/criteria/src/main/java/org/opennms/core/criteria/AliasBuilder.java
@@ -57,6 +57,15 @@ public class AliasBuilder {
         return this;
     }
 
+    public final AliasBuilder alias(final Alias alias) {
+        if (m_aliases.containsKey(alias.getAlias())) {
+            LOG.debug("alias '{}' already associated with associationPath '{}', skipping.", alias.getAlias(), alias.getAssociationPath());
+        } else {
+            m_aliases.put(alias.getAlias(), alias);
+        }
+        return this;
+    }
+
     public final Collection<Alias> getAliasCollection() {
         // make a copy so the internal one can't be modified outside of the builder
         return new ArrayList<Alias>(m_aliases.values());

--- a/core/criteria/src/main/java/org/opennms/core/criteria/CriteriaBuilder.java
+++ b/core/criteria/src/main/java/org/opennms/core/criteria/CriteriaBuilder.java
@@ -119,10 +119,14 @@ public class CriteriaBuilder {
         return alias(associationPath, alias, JoinType.LEFT_JOIN);
     }
 
+    public CriteriaBuilder alias(final Alias alias) {
+        m_aliasBuilder.alias(alias);
+        return this;
+    }
+
     public CriteriaBuilder alias(final String associationPath, final String alias) {
         return alias(associationPath, alias, JoinType.LEFT_JOIN);
     }
-
 
     public CriteriaBuilder createAlias(final String associationPath, final String alias) {
         return alias(associationPath, alias);

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/CriteriaBehavior.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/CriteriaBehavior.java
@@ -30,6 +30,7 @@ package org.opennms.web.rest.support;
 
 import java.util.function.Function;
 
+import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.cxf.jaxrs.ext.search.ConditionType;
 import org.opennms.core.criteria.CriteriaBuilder;
 
@@ -64,16 +65,8 @@ public class CriteriaBehavior<T> {
     private final Function<String,T> m_converter;
     private boolean m_skipProperty = false;
 
-    public CriteriaBehavior(String name) {
-        this(name, null, (b,v,c,w)-> {});
-    }
-
     public CriteriaBehavior(Function<String,T> converter) {
         this(null, converter, (b,v,c,w) -> {});
-    }
-
-    public CriteriaBehavior(String name, BeforeVisit beforeVisit) {
-        this(name, null, beforeVisit);
     }
 
     public CriteriaBehavior(String name, Function<String,T> converter) {
@@ -90,6 +83,10 @@ public class CriteriaBehavior<T> {
         return m_criteriaPropertyName;
     }
 
+    public Function<String,T> getConverter() {
+        return m_converter;
+    }
+
     public void beforeVisit(CriteriaBuilder builder, Object value, ConditionType c, boolean isWildcard) {
         m_beforeVisit.accept(builder, value, c, isWildcard);
     }
@@ -104,5 +101,15 @@ public class CriteriaBehavior<T> {
 
     public boolean shouldSkipProperty() {
         return m_skipProperty;
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+            .append("criteriaPropertyName", m_criteriaPropertyName)
+            .append("converter", m_converter)
+            .append("beforeVisit", m_beforeVisit)
+            .append("skipProperty", m_skipProperty)
+            .build();
     }
 }

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/CriteriaBehaviors.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/CriteriaBehaviors.java
@@ -28,6 +28,12 @@
 
 package org.opennms.web.rest.support;
 
+import static org.opennms.web.rest.support.CriteriaValueConverters.DATE_CONVERTER;
+import static org.opennms.web.rest.support.CriteriaValueConverters.FLOAT_CONVERTER;
+import static org.opennms.web.rest.support.CriteriaValueConverters.INET_ADDRESS_CONVERTER;
+import static org.opennms.web.rest.support.CriteriaValueConverters.INT_CONVERTER;
+import static org.opennms.web.rest.support.CriteriaValueConverters.LONG_CONVERTER;
+
 import java.net.InetAddress;
 import java.text.DateFormat;
 import java.text.ParseException;
@@ -37,7 +43,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.opennms.core.criteria.restrictions.SqlRestriction.Type;
-import org.opennms.core.utils.InetAddressUtils;
 import org.opennms.netmgt.model.OnmsSeverity;
 import org.opennms.netmgt.model.TroubleTicketState;
 
@@ -114,58 +119,57 @@ public abstract class CriteriaBehaviors {
     public static final Map<String,CriteriaBehavior<?>> SNMP_INTERFACE_BEHAVIORS = new HashMap<>();
 
     static {
-        ALARM_BEHAVIORS.put("id", new CriteriaBehavior<Integer>(Integer::parseInt));
-        ALARM_BEHAVIORS.put("alarmAckTime", new CriteriaBehavior<Date>(CriteriaBehaviors::parseDate));
-        ALARM_BEHAVIORS.put("alarmType", new CriteriaBehavior<Integer>(Integer::parseInt));
-        ALARM_BEHAVIORS.put("counter", new CriteriaBehavior<Integer>(Integer::parseInt));
-        ALARM_BEHAVIORS.put("firstAutomationTime", new CriteriaBehavior<Date>(CriteriaBehaviors::parseDate));
-        ALARM_BEHAVIORS.put("firstEventTime", new CriteriaBehavior<Date>(CriteriaBehaviors::parseDate));
-        ALARM_BEHAVIORS.put("ifIndex", new CriteriaBehavior<Integer>(Integer::parseInt));
-        ALARM_BEHAVIORS.put("ipAddr", new CriteriaBehavior<InetAddress>(InetAddressUtils::addr));
-        ALARM_BEHAVIORS.put("lastAutomationTime", new CriteriaBehavior<Date>(CriteriaBehaviors::parseDate));
-        ALARM_BEHAVIORS.put("lastEventTime", new CriteriaBehavior<Date>(CriteriaBehaviors::parseDate));
+        ALARM_BEHAVIORS.put("id", new CriteriaBehavior<Integer>(INT_CONVERTER));
+        ALARM_BEHAVIORS.put("alarmAckTime", new CriteriaBehavior<Date>(DATE_CONVERTER));
+        ALARM_BEHAVIORS.put("alarmType", new CriteriaBehavior<Integer>(INT_CONVERTER));
+        ALARM_BEHAVIORS.put("counter", new CriteriaBehavior<Integer>(INT_CONVERTER));
+        ALARM_BEHAVIORS.put("firstAutomationTime", new CriteriaBehavior<Date>(DATE_CONVERTER));
+        ALARM_BEHAVIORS.put("firstEventTime", new CriteriaBehavior<Date>(DATE_CONVERTER));
+        ALARM_BEHAVIORS.put("ifIndex", new CriteriaBehavior<Integer>(INT_CONVERTER));
+        ALARM_BEHAVIORS.put("ipAddr", new CriteriaBehavior<InetAddress>(INET_ADDRESS_CONVERTER));
+        ALARM_BEHAVIORS.put("lastAutomationTime", new CriteriaBehavior<Date>(DATE_CONVERTER));
+        ALARM_BEHAVIORS.put("lastEventTime", new CriteriaBehavior<Date>(DATE_CONVERTER));
         ALARM_BEHAVIORS.put("severity", new CriteriaBehavior<OnmsSeverity>(OnmsSeverity::get));
-        ALARM_BEHAVIORS.put("suppressedTime", new CriteriaBehavior<Date>(CriteriaBehaviors::parseDate));
-        ALARM_BEHAVIORS.put("suppressedUntil", new CriteriaBehavior<Date>(CriteriaBehaviors::parseDate));
+        ALARM_BEHAVIORS.put("suppressedTime", new CriteriaBehavior<Date>(DATE_CONVERTER));
+        ALARM_BEHAVIORS.put("suppressedUntil", new CriteriaBehavior<Date>(DATE_CONVERTER));
         ALARM_BEHAVIORS.put("troubleTicketState", new CriteriaBehavior<TroubleTicketState>(TroubleTicketState::valueOf));
-        ALARM_BEHAVIORS.put("x733ProbableCause", new CriteriaBehavior<Integer>(Integer::parseInt));
+        ALARM_BEHAVIORS.put("x733ProbableCause", new CriteriaBehavior<Integer>(INT_CONVERTER));
 
-        ASSET_RECORD_BEHAVIORS.put("id", new CriteriaBehavior<Integer>(Integer::parseInt));
-        ASSET_RECORD_BEHAVIORS.put("lastModifiedDate", new CriteriaBehavior<Date>(CriteriaBehaviors::parseDate));
+        ASSET_RECORD_BEHAVIORS.put("id", new CriteriaBehavior<Integer>(INT_CONVERTER));
+        ASSET_RECORD_BEHAVIORS.put("lastModifiedDate", new CriteriaBehavior<Date>(DATE_CONVERTER));
         //ASSET_RECORD_BEHAVIORS.put("geolocation", ???);
 
-        DIST_POLLER_BEHAVIORS.put("lastUpdated", new CriteriaBehavior<Date>(CriteriaBehaviors::parseDate));
+        DIST_POLLER_BEHAVIORS.put("lastUpdated", new CriteriaBehavior<Date>(DATE_CONVERTER));
 
-        EVENT_BEHAVIORS.put("eventAckTime", new CriteriaBehavior<Date>(CriteriaBehaviors::parseDate));
-        EVENT_BEHAVIORS.put("eventCreateTime", new CriteriaBehavior<Date>(CriteriaBehaviors::parseDate));
-        EVENT_BEHAVIORS.put("eventSeverity", new CriteriaBehavior<Integer>(Integer::parseInt));
-        EVENT_BEHAVIORS.put("eventSuppressedCount", new CriteriaBehavior<Integer>(Integer::parseInt));
-        EVENT_BEHAVIORS.put("eventTime", new CriteriaBehavior<Date>(CriteriaBehaviors::parseDate));
-        EVENT_BEHAVIORS.put("eventTTicketState", new CriteriaBehavior<Integer>(Integer::parseInt));
-        EVENT_BEHAVIORS.put("id", new CriteriaBehavior<Integer>(Integer::parseInt));
-        EVENT_BEHAVIORS.put("ifIndex", new CriteriaBehavior<Integer>(Integer::parseInt));
-        EVENT_BEHAVIORS.put("ipAddr", new CriteriaBehavior<InetAddress>(InetAddressUtils::addr));
+        EVENT_BEHAVIORS.put("eventAckTime", new CriteriaBehavior<Date>(DATE_CONVERTER));
+        EVENT_BEHAVIORS.put("eventCreateTime", new CriteriaBehavior<Date>(DATE_CONVERTER));
+        EVENT_BEHAVIORS.put("eventSeverity", new CriteriaBehavior<Integer>(INT_CONVERTER));
+        EVENT_BEHAVIORS.put("eventSuppressedCount", new CriteriaBehavior<Integer>(INT_CONVERTER));
+        EVENT_BEHAVIORS.put("eventTime", new CriteriaBehavior<Date>(DATE_CONVERTER));
+        EVENT_BEHAVIORS.put("eventTTicketState", new CriteriaBehavior<Integer>(INT_CONVERTER));
+        EVENT_BEHAVIORS.put("id", new CriteriaBehavior<Integer>(INT_CONVERTER));
+        EVENT_BEHAVIORS.put("ifIndex", new CriteriaBehavior<Integer>(INT_CONVERTER));
+        EVENT_BEHAVIORS.put("ipAddr", new CriteriaBehavior<InetAddress>(INET_ADDRESS_CONVERTER));
 
-        IP_INTERFACE_BEHAVIORS.put("id", new CriteriaBehavior<Integer>(Integer::parseInt));
-        IP_INTERFACE_BEHAVIORS.put("ipLastCapsdPoll", new CriteriaBehavior<Date>(CriteriaBehaviors::parseDate));
-        IP_INTERFACE_BEHAVIORS.put("ipAddress", new CriteriaBehavior<InetAddress>(InetAddressUtils::addr));
+        IP_INTERFACE_BEHAVIORS.put("id", new CriteriaBehavior<Integer>(INT_CONVERTER));
+        IP_INTERFACE_BEHAVIORS.put("ipLastCapsdPoll", new CriteriaBehavior<Date>(DATE_CONVERTER));
+        IP_INTERFACE_BEHAVIORS.put("ipAddress", new CriteriaBehavior<InetAddress>(INET_ADDRESS_CONVERTER));
 
-        MONITORED_SERVICE_BEHAVIORS.put("id", new CriteriaBehavior<Integer>(Integer::parseInt));
-        MONITORED_SERVICE_BEHAVIORS.put("ifindex", new CriteriaBehavior<Integer>(Integer::parseInt));
-        MONITORED_SERVICE_BEHAVIORS.put("lastFail", new CriteriaBehavior<Date>(CriteriaBehaviors::parseDate));
-        MONITORED_SERVICE_BEHAVIORS.put("lastGood", new CriteriaBehavior<Date>(CriteriaBehaviors::parseDate));
+        MONITORED_SERVICE_BEHAVIORS.put("id", new CriteriaBehavior<Integer>(INT_CONVERTER));
+        MONITORED_SERVICE_BEHAVIORS.put("lastFail", new CriteriaBehavior<Date>(DATE_CONVERTER));
+        MONITORED_SERVICE_BEHAVIORS.put("lastGood", new CriteriaBehavior<Date>(DATE_CONVERTER));
 
-        MONITORING_LOCATION_BEHAVIORS.put("latitude", new CriteriaBehavior<Float>(Float::parseFloat));
-        MONITORING_LOCATION_BEHAVIORS.put("longitude", new CriteriaBehavior<Float>(Float::parseFloat));
-        MONITORING_LOCATION_BEHAVIORS.put("priority", new CriteriaBehavior<Long>(Long::parseLong));
+        MONITORING_LOCATION_BEHAVIORS.put("latitude", new CriteriaBehavior<Float>(FLOAT_CONVERTER));
+        MONITORING_LOCATION_BEHAVIORS.put("longitude", new CriteriaBehavior<Float>(FLOAT_CONVERTER));
+        MONITORING_LOCATION_BEHAVIORS.put("priority", new CriteriaBehavior<Long>(LONG_CONVERTER));
         //MONITORING_LOCATION_BEHAVIORS.put("tags", ???);
 
-        NODE_BEHAVIORS.put("id", new CriteriaBehavior<Integer>(Integer::parseInt));
-        NODE_BEHAVIORS.put("createTime", new CriteriaBehavior<Date>(CriteriaBehaviors::parseDate));
-        NODE_BEHAVIORS.put("lastCapsdPoll", new CriteriaBehavior<Date>(CriteriaBehaviors::parseDate));
+        NODE_BEHAVIORS.put("id", new CriteriaBehavior<Integer>(INT_CONVERTER));
+        NODE_BEHAVIORS.put("createTime", new CriteriaBehavior<Date>(DATE_CONVERTER));
+        NODE_BEHAVIORS.put("lastCapsdPoll", new CriteriaBehavior<Date>(DATE_CONVERTER));
 
         // Add aliases with join conditions when joining in the many-to-many node-to-category relationship
-        CriteriaBehavior<Integer> categoryId = new CriteriaBehavior<Integer>(Aliases.category.prop("id"), Integer::parseInt, (b,v,c,w) -> {
+        CriteriaBehavior<Integer> categoryId = new CriteriaBehavior<Integer>(Aliases.category.prop("id"), INT_CONVERTER, (b,v,c,w) -> {
             // Add a categories alias that only matches the specified value
             // TODO: This should work but Hibernate is generating invalid SQL for this criteria
             //b.alias(Aliases.node.prop("categories"), Aliases.category.toString(), JoinType.LEFT_JOIN, Restrictions.or(Restrictions.eq(Aliases.category.prop("id"), v), Restrictions.isNull(Aliases.category.prop("id"))));
@@ -228,24 +232,24 @@ public abstract class CriteriaBehaviors {
         categoryDescription.setSkipProperty(true);
         NODE_CATEGORY_BEHAVIORS.put("description", categoryDescription);
 
-        NOTIFICATION_BEHAVIORS.put("notifyId", new CriteriaBehavior<Integer>(Integer::parseInt));
-        NOTIFICATION_BEHAVIORS.put("pageTime", new CriteriaBehavior<Date>(CriteriaBehaviors::parseDate));
-        NOTIFICATION_BEHAVIORS.put("respondTime", new CriteriaBehavior<Date>(CriteriaBehaviors::parseDate));
+        NOTIFICATION_BEHAVIORS.put("notifyId", new CriteriaBehavior<Integer>(INT_CONVERTER));
+        NOTIFICATION_BEHAVIORS.put("pageTime", new CriteriaBehavior<Date>(DATE_CONVERTER));
+        NOTIFICATION_BEHAVIORS.put("respondTime", new CriteriaBehavior<Date>(DATE_CONVERTER));
 
-        OUTAGE_BEHAVIORS.put("id", new CriteriaBehavior<Integer>(Integer::parseInt));
-        OUTAGE_BEHAVIORS.put("ifLostService", new CriteriaBehavior<Date>(CriteriaBehaviors::parseDate));
-        OUTAGE_BEHAVIORS.put("ifRegainedService", new CriteriaBehavior<Date>(CriteriaBehaviors::parseDate));
-        OUTAGE_BEHAVIORS.put("suppressTime", new CriteriaBehavior<Date>(CriteriaBehaviors::parseDate));
+        OUTAGE_BEHAVIORS.put("id", new CriteriaBehavior<Integer>(INT_CONVERTER));
+        OUTAGE_BEHAVIORS.put("ifLostService", new CriteriaBehavior<Date>(DATE_CONVERTER));
+        OUTAGE_BEHAVIORS.put("ifRegainedService", new CriteriaBehavior<Date>(DATE_CONVERTER));
+        OUTAGE_BEHAVIORS.put("suppressTime", new CriteriaBehavior<Date>(DATE_CONVERTER));
 
-        SERVICE_TYPE_BEHAVIORS.put("id", new CriteriaBehavior<Integer>(Integer::parseInt));
+        SERVICE_TYPE_BEHAVIORS.put("id", new CriteriaBehavior<Integer>(INT_CONVERTER));
 
-        SNMP_INTERFACE_BEHAVIORS.put("id", new CriteriaBehavior<Integer>(Integer::parseInt));
-        SNMP_INTERFACE_BEHAVIORS.put("ifAdminStatus", new CriteriaBehavior<Integer>(Integer::parseInt));
-        SNMP_INTERFACE_BEHAVIORS.put("ifIndex", new CriteriaBehavior<Integer>(Integer::parseInt));
-        SNMP_INTERFACE_BEHAVIORS.put("ifOperStatus", new CriteriaBehavior<Integer>(Integer::parseInt));
-        SNMP_INTERFACE_BEHAVIORS.put("ifSpeed", new CriteriaBehavior<Long>(Long::parseLong));
-        SNMP_INTERFACE_BEHAVIORS.put("lastCapsdPoll", new CriteriaBehavior<Date>(CriteriaBehaviors::parseDate));
-        SNMP_INTERFACE_BEHAVIORS.put("lastSnmpPoll", new CriteriaBehavior<Date>(CriteriaBehaviors::parseDate));
-        SNMP_INTERFACE_BEHAVIORS.put("netMask", new CriteriaBehavior<InetAddress>(InetAddressUtils::addr));
+        SNMP_INTERFACE_BEHAVIORS.put("id", new CriteriaBehavior<Integer>(INT_CONVERTER));
+        SNMP_INTERFACE_BEHAVIORS.put("ifAdminStatus", new CriteriaBehavior<Integer>(INT_CONVERTER));
+        SNMP_INTERFACE_BEHAVIORS.put("ifIndex", new CriteriaBehavior<Integer>(INT_CONVERTER));
+        SNMP_INTERFACE_BEHAVIORS.put("ifOperStatus", new CriteriaBehavior<Integer>(INT_CONVERTER));
+        SNMP_INTERFACE_BEHAVIORS.put("ifSpeed", new CriteriaBehavior<Long>(LONG_CONVERTER));
+        SNMP_INTERFACE_BEHAVIORS.put("lastCapsdPoll", new CriteriaBehavior<Date>(DATE_CONVERTER));
+        SNMP_INTERFACE_BEHAVIORS.put("lastSnmpPoll", new CriteriaBehavior<Date>(DATE_CONVERTER));
+        SNMP_INTERFACE_BEHAVIORS.put("netMask", new CriteriaBehavior<InetAddress>(INET_ADDRESS_CONVERTER));
     }
 }

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/CriteriaBuilderSearchVisitor.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/CriteriaBuilderSearchVisitor.java
@@ -41,6 +41,7 @@ import org.apache.cxf.jaxrs.ext.search.SearchCondition;
 import org.apache.cxf.jaxrs.ext.search.SearchConditionVisitor;
 import org.apache.cxf.jaxrs.ext.search.SearchUtils;
 import org.apache.cxf.jaxrs.ext.search.visitor.AbstractSearchConditionVisitor;
+import org.opennms.core.criteria.Alias;
 import org.opennms.core.criteria.Criteria;
 import org.opennms.core.criteria.CriteriaBuilder;
 import org.opennms.core.criteria.restrictions.Restriction;
@@ -239,8 +240,18 @@ public class CriteriaBuilderSearchVisitor<T,Q> extends AbstractSearchConditionVi
 				// Visit the children
 				condition.accept(newVisitor);
 
+				Criteria newCriteria = newVisitor.getQuery().toCriteria();
+
+				// Add any aliases from the subcriteria
+				Collection<Alias> aliases = newCriteria.getAliases();
+				if (aliases != null) {
+					for (Alias alias : aliases) {
+						m_criteriaBuilder.alias(alias);
+					}
+				}
+
 				// Fetch the rendered restrictions
-				Collection<Restriction> restrictions = newVisitor.getQuery().toCriteria().getRestrictions();
+				Collection<Restriction> restrictions = newCriteria.getRestrictions();
 				// If there are restrictions...
 				if (restrictions != null && restrictions.size() > 0) {
 					final Restriction subRestriction;

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/CriteriaValueConverters.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/CriteriaValueConverters.java
@@ -1,0 +1,125 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2017-2017 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.web.rest.support;
+
+import java.net.InetAddress;
+import java.util.Date;
+import java.util.function.Function;
+
+import org.opennms.core.utils.InetAddressUtils;
+
+/**
+ * This class is used to override {@link #toString()} on several
+ * string conversion functions so that they are identifiable inside
+ * a debugger. Otherwise, you will just see the object hash identifier
+ * for the {@link Function}.
+ */
+public abstract class CriteriaValueConverters {
+
+    public static final Function<String,Date> DATE_CONVERTER = new Function<String,Date>() {
+        @Override
+        public Date apply(String t) {
+            return CriteriaBehaviors.parseDate(t);
+        }
+
+        /**
+         * Override {@link #toString()} on this functional interface
+         * to make it identifiable inside a debugger.
+         */
+        @Override
+        public String toString() {
+            return "DATE_CONVERTER";
+        }
+    };
+
+    public static final Function<String,Float> FLOAT_CONVERTER = new Function<String,Float>() {
+        @Override
+        public Float apply(String t) {
+            return Float.parseFloat(t);
+        }
+
+        /**
+         * Override {@link #toString()} on this functional interface
+         * to make it identifiable inside a debugger.
+         */
+        @Override
+        public String toString() {
+            return "FLOAT_CONVERTER";
+        }
+    };
+
+    public static final Function<String,InetAddress> INET_ADDRESS_CONVERTER = new Function<String,InetAddress>() {
+        @Override
+        public InetAddress apply(String t) {
+            return InetAddressUtils.addr(t);
+        }
+
+        /**
+         * Override {@link #toString()} on this functional interface
+         * to make it identifiable inside a debugger.
+         */
+        @Override
+        public String toString() {
+            return "INET_ADDRESS_CONVERTER";
+        }
+    };
+
+    public static final Function<String,Integer> INT_CONVERTER = new Function<String,Integer>() {
+        @Override
+        public Integer apply(String t) {
+            return Integer.parseInt(t);
+        }
+
+        /**
+         * Override {@link #toString()} on this functional interface
+         * to make it identifiable inside a debugger.
+         */
+        @Override
+        public String toString() {
+            return "INT_CONVERTER";
+        }
+    };
+
+    public static final Function<String,Long> LONG_CONVERTER = new Function<String,Long>() {
+        @Override
+        public Long apply(String t) {
+            return Long.parseLong(t);
+        }
+
+        /**
+         * Override {@link #toString()} on this functional interface
+         * to make it identifiable inside a debugger.
+         */
+        @Override
+        public String toString() {
+            return "LONG_CONVERTER";
+        }
+    };
+
+}

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/SearchProperties.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/SearchProperties.java
@@ -378,7 +378,7 @@ public abstract class SearchProperties {
 	public static final Set<SearchProperty> IF_SERVICE_SERVICE_PROPERTIES = new LinkedHashSet<>();
 	public static final Set<SearchProperty> MINION_SERVICE_PROPERTIES = new LinkedHashSet<>();
 	public static final Set<SearchProperty> LOCATION_SERVICE_PROPERTIES = new LinkedHashSet<>();
-	//public static final Set<SearchProperty> NODE_SERVICE_PROPERTIES = new LinkedHashSet<>();
+	public static final Set<SearchProperty> NODE_SERVICE_PROPERTIES = new LinkedHashSet<>();
 	public static final Set<SearchProperty> NOTIFICATION_SERVICE_PROPERTIES = new LinkedHashSet<>();
 	public static final Set<SearchProperty> OUTAGE_SERVICE_PROPERTIES = new LinkedHashSet<>();
 	public static final Set<SearchProperty> SCAN_REPORT_SERVICE_PROPERTIES = new LinkedHashSet<>();
@@ -488,6 +488,18 @@ public abstract class SearchProperties {
 
 		// Root prefix
 		LOCATION_SERVICE_PROPERTIES.addAll(LOCATION_PROPERTIES);
+
+		// Root prefix
+		NODE_SERVICE_PROPERTIES.addAll(NODE_PROPERTIES);
+		//NODE_SERVICE_PROPERTIES.addAll(withAliasPrefix(Aliases.node, NODE_PROPERTIES));
+		NODE_SERVICE_PROPERTIES.addAll(withAliasPrefix(Aliases.assetRecord, "Asset", ASSET_RECORD_PROPERTIES));
+		NODE_SERVICE_PROPERTIES.addAll(withAliasPrefix(Aliases.category, "Category", CATEGORY_PROPERTIES, false));
+		NODE_SERVICE_PROPERTIES.addAll(withAliasPrefix(Aliases.ipInterface, "IP Interface", IP_INTERFACE_PROPERTIES, false));
+		NODE_SERVICE_PROPERTIES.addAll(withAliasPrefix(Aliases.location, "Location", LOCATION_PROPERTIES));
+		// TODO: Figure out if it makes sense to search/orderBy on 2nd-level and greater JOINed properties
+		//NODE_SERVICE_PROPERTIES.addAll(withAliasPrefix(Aliases.monitoredService, "Monitored Service", IF_SERVICE_PROPERTIES, false));
+		//NODE_SERVICE_PROPERTIES.addAll(withAliasPrefix(Aliases.serviceType, "Service", SERVICE_TYPE_PROPERTIES, false));
+		NODE_SERVICE_PROPERTIES.addAll(withAliasPrefix(Aliases.snmpInterface, "SNMP Interface", SNMP_INTERFACE_PROPERTIES, false));
 
 		// Root prefix
 		NOTIFICATION_SERVICE_PROPERTIES.addAll(NOTIFICATION_PROPERTIES);

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/SearchProperty.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/SearchProperty.java
@@ -36,6 +36,8 @@ import javax.xml.bind.annotation.XmlElementWrapper;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlTransient;
 
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
 /**
  * @author Seth
  */
@@ -133,5 +135,18 @@ public class SearchProperty implements Comparable<SearchProperty> {
 	@Override
 	public int compareTo(SearchProperty o) {
 		return COMPARATOR.compare(this, o);
+	}
+
+	@Override
+	public String toString() {
+		return new ToStringBuilder(this)
+			.append("idPrefix", idPrefix)
+			.append("id", id)
+			.append("namePrefix", namePrefix)
+			.append("name", name)
+			.append("type", type.toString())
+			.append("iplike", iplike)
+			.append("orderBy", orderBy)
+			.build();
 	}
 }

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/README.adoc
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/README.adoc
@@ -513,7 +513,14 @@ Supported search/order properties:
 
 Interface: `/api/v2/nodes`
 
-WARNING: This interface is not complete.
+Supported search/order properties:
+
+* <<assetProperties,`assetRecord.*`>>
+* <<categoryProperties,`category.*`>> (Only valid for search)
+* <<ipInterfaceProperties,`ipInterface.*`>> (Only valid for search)
+* <<locationProperties,`location.*`>>
+* <<nodeProperties,`node.*`>>
+* <<snmpInterfaceProperties,`snmpInterface.*`>> (Only valid for search)
 
 === Notifications Interface
 

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v2/SearchPropertiesIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v2/SearchPropertiesIT.java
@@ -116,6 +116,11 @@ public class SearchPropertiesIT extends AbstractSpringJerseyRestTestCase {
     }
 
     @Test
+    public void testNodesSearchProperties() throws Exception {
+        testAllSearchParameters("/nodes", SearchProperties.NODE_SERVICE_PROPERTIES);
+    }
+
+    @Test
     public void testNotificationSearchProperties() throws Exception {
         testAllSearchParameters("/notifications", SearchProperties.NOTIFICATION_SERVICE_PROPERTIES);
     }


### PR DESCRIPTION
This PR fixes the aliases on the `/api/v2/nodes` endpoint and adds metadata support to it so that it has basically the same level of function that the other RESTv2 endpoints do.

* JIRA: http://issues.opennms.org/browse/NMS-9278
