### PR TITLE
HZN-1098: Add limit param to the search property value endpoint

### DIFF
--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/AbstractDaoRestServiceWithDTO.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/AbstractDaoRestServiceWithDTO.java
@@ -308,16 +308,18 @@ public abstract class AbstractDaoRestServiceWithDTO<T,D,Q,K extends Serializable
     private static class HibernateListCallback<T> implements HibernateCallback<List<T>> {
         private final SearchProperty property;
         private final String query;
+        private final Integer limit;
 
-        public HibernateListCallback(final SearchProperty property, final String query) {
+        public HibernateListCallback(final SearchProperty property, final String query, final Integer limit) {
             this.property = property;
             this.query = query;
+            this.limit = limit;
         }
 
         @Override
         public List<T> doInHibernate(Session session) throws HibernateException, SQLException {
             final Query hql;
-            // TODO: Add limit?
+
             // TODO: Sort by count?
 
             // If there is a query string...
@@ -343,6 +345,10 @@ public abstract class AbstractDaoRestServiceWithDTO<T,D,Q,K extends Serializable
                 );
             }
 
+            if (limit != null && limit > 0) {
+                hql.setMaxResults(limit);
+            }
+
             @SuppressWarnings("unchecked")
             List<T> list = (List<T>)hql.list();
             return list;
@@ -352,7 +358,7 @@ public abstract class AbstractDaoRestServiceWithDTO<T,D,Q,K extends Serializable
     @GET
     @Path("properties/{propertyId}")
     @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
-    public Response getPropertyValues(@PathParam("propertyId") final String propertyId, @QueryParam("q") final String query) {
+    public Response getPropertyValues(@PathParam("propertyId") final String propertyId, @QueryParam("q") final String query, @QueryParam("limit") final Integer limit) {
         Set<SearchProperty> props = getQueryProperties();
         // Find the property with the matching ID
         Optional<SearchProperty> prop = props.stream().filter(p -> p.getId().equals(propertyId)).findAny();
@@ -395,22 +401,22 @@ public abstract class AbstractDaoRestServiceWithDTO<T,D,Q,K extends Serializable
 
             switch(property.type) {
             case FLOAT:
-                List<Float> floats = new HibernateTemplate(m_sessionFactory).execute(new HibernateListCallback<Float>(property, query));
+                List<Float> floats = new HibernateTemplate(m_sessionFactory).execute(new HibernateListCallback<Float>(property, query, limit));
                 return Response.ok(new FloatCollection(floats)).build();
             case INTEGER:
-                List<Integer> ints = new HibernateTemplate(m_sessionFactory).execute(new HibernateListCallback<Integer>(property, query));
+                List<Integer> ints = new HibernateTemplate(m_sessionFactory).execute(new HibernateListCallback<Integer>(property, query, limit));
                 return Response.ok(new IntegerCollection(ints)).build();
             case LONG:
-                List<Long> longs = new HibernateTemplate(m_sessionFactory).execute(new HibernateListCallback<Long>(property, query));
+                List<Long> longs = new HibernateTemplate(m_sessionFactory).execute(new HibernateListCallback<Long>(property, query, limit));
                 return Response.ok(new LongCollection(longs)).build();
             case IP_ADDRESS:
-                List<InetAddress> addresses = new HibernateTemplate(m_sessionFactory).execute(new HibernateListCallback<InetAddress>(property, query));
+                List<InetAddress> addresses = new HibernateTemplate(m_sessionFactory).execute(new HibernateListCallback<InetAddress>(property, query, limit));
                 return Response.ok(new StringCollection(addresses.stream().map(InetAddressUtils::str).collect(Collectors.toList()))).build();
             case STRING:
-                List<String> strings = new HibernateTemplate(m_sessionFactory).execute(new HibernateListCallback<String>(property, query));
+                List<String> strings = new HibernateTemplate(m_sessionFactory).execute(new HibernateListCallback<String>(property, query, limit));
                 return Response.ok(new StringCollection(strings)).build();
             case TIMESTAMP:
-                List<Date> dates = new HibernateTemplate(m_sessionFactory).execute(new HibernateListCallback<Date>(property, query));
+                List<Date> dates = new HibernateTemplate(m_sessionFactory).execute(new HibernateListCallback<Date>(property, query, limit));
                 return Response.ok(new DateCollection(dates)).build();
             default:
                 return Response.noContent().build();

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v2/AlarmRestServiceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v2/AlarmRestServiceIT.java
@@ -33,6 +33,7 @@ import static org.junit.Assert.fail;
 import static org.opennms.web.svclayer.support.DefaultTroubleTicketProxy.createEventBuilder;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -40,6 +41,7 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.Assert;
 import org.junit.Test;
@@ -320,6 +322,59 @@ public class AlarmRestServiceIT extends AbstractSpringJerseyRestTestCase {
     public void testLocationFiltering() throws Exception {
         executeQueryAndVerify("_s=location.locationName==Default", 7);
         executeQueryAndVerify("_s=location.locationName!=Default", 0);
+    }
+
+    /**
+     * Test metadata autocompletion.
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testNodeLabelPropertyValues() throws Exception {
+        JSONObject object = new JSONObject(sendRequest(GET, "/alarms/properties/node.label", Collections.emptyMap(), 200));
+        Assert.assertEquals(2, object.getInt("totalCount"));
+        JSONArray values = object.getJSONArray("value");
+        // Values should be sorted alphabetically so this order is deterministic
+        assertEquals("server01", values.getString(0));
+        assertEquals("server02", values.getString(1));
+
+        object = new JSONObject(sendRequest(GET, "/alarms/properties/node.label", Collections.singletonMap("limit", "1"), 200));
+        Assert.assertEquals(1, object.getInt("totalCount"));
+        values = object.getJSONArray("value");
+        assertEquals("server01", values.getString(0));
+
+        // Using a limit less than 1 should result in an unlimited return value
+        object = new JSONObject(sendRequest(GET, "/alarms/properties/node.label", Collections.singletonMap("limit", "0"), 200));
+        Assert.assertEquals(2, object.getInt("totalCount"));
+        values = object.getJSONArray("value");
+        assertEquals("server01", values.getString(0));
+        assertEquals("server02", values.getString(1));
+        object = new JSONObject(sendRequest(GET, "/alarms/properties/node.label", Collections.singletonMap("limit", "-2"), 200));
+        Assert.assertEquals(2, object.getInt("totalCount"));
+        values = object.getJSONArray("value");
+        assertEquals("server01", values.getString(0));
+        assertEquals("server02", values.getString(1));
+
+        // Test a query
+        object = new JSONObject(sendRequest(GET, "/alarms/properties/node.label", Collections.singletonMap("q", "02"), 200));
+        Assert.assertEquals(1, object.getInt("totalCount"));
+        values = object.getJSONArray("value");
+        assertEquals("server02", values.getString(0));
+
+        object = new JSONObject(sendRequest(GET, "/alarms/properties/node.label", Collections.singletonMap("q", "server"), 200));
+        Assert.assertEquals(2, object.getInt("totalCount"));
+        values = object.getJSONArray("value");
+        assertEquals("server01", values.getString(0));
+        assertEquals("server02", values.getString(1));
+
+        // Test a query with a limit
+        object = new JSONObject(sendRequest(GET, "/alarms/properties/node.label", ImmutableMap.of(
+            "q", "server",
+            "limit", "1"
+        ), 200));
+        Assert.assertEquals(1, object.getInt("totalCount"));
+        values = object.getJSONArray("value");
+        assertEquals("server01", values.getString(0));
     }
 
     @Test


### PR DESCRIPTION
This is the last feature for the RESTv2 metadata: handling a `limit` parameter for the property value endpoints so that we can limit the results when performing autocomplete queries (since many values will have hundreds or thousands of results).

* JIRA: http://issues.opennms.org/browse/HZN-1098