### PR TITLE
NMS-9278: RESTv2 metadata tweaks

### DIFF
--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/SearchProperties.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/SearchProperties.java
@@ -521,6 +521,7 @@ public abstract class SearchProperties {
 		OUTAGE_SERVICE_PROPERTIES.addAll(withAliasPrefix(Aliases.distPoller, "Monitoring System", DIST_POLLER_PROPERTIES));
 		OUTAGE_SERVICE_PROPERTIES.addAll(withAliasPrefix(Aliases.ipInterface, "IP Interface", IP_INTERFACE_PROPERTIES));
 		OUTAGE_SERVICE_PROPERTIES.addAll(withAliasPrefix(Aliases.location, "Location", LOCATION_PROPERTIES));
+		OUTAGE_SERVICE_PROPERTIES.addAll(withAliasPrefix(Aliases.monitoredService, "Monitored Service", IF_SERVICE_PROPERTIES));
 		OUTAGE_SERVICE_PROPERTIES.addAll(withAliasPrefix(Aliases.node, "Node", NODE_PROPERTIES));
 		OUTAGE_SERVICE_PROPERTIES.addAll(withAliasPrefix("serviceLostEvent", "Service Lost Event", EVENT_PROPERTIES));
 		OUTAGE_SERVICE_PROPERTIES.addAll(withAliasPrefix("serviceRegainedEvent", "Service Regained Event", EVENT_PROPERTIES));

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NodeRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NodeRestService.java
@@ -31,6 +31,7 @@ package org.opennms.web.rest.v2;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 import javax.ws.rs.Path;
 import javax.ws.rs.container.ResourceContext;
@@ -59,6 +60,8 @@ import org.opennms.web.rest.support.CriteriaBehavior;
 import org.opennms.web.rest.support.CriteriaBehaviors;
 import org.opennms.web.rest.support.MultivaluedMapImpl;
 import org.opennms.web.rest.support.RedirectHelper;
+import org.opennms.web.rest.support.SearchProperties;
+import org.opennms.web.rest.support.SearchProperty;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -130,6 +133,11 @@ public class NodeRestService extends AbstractDaoRestService<OnmsNode,SearchBean,
         builder.orderBy("label").desc();
 
         return builder;
+    }
+
+    @Override
+    protected Set<SearchProperty> getQueryProperties() {
+        return SearchProperties.NODE_SERVICE_PROPERTIES;
     }
 
     @Override

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/README.adoc
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/README.adoc
@@ -242,8 +242,20 @@ org.opennms.web.rest.support.SearchPropertiesToAsciidocTest
 | event.ipAddr | IP Address | IP Address
 |===
 
-[[ifServiceProperties]]
-.Interface Service Properties
+[[ipInterfaceProperties]]
+.IP Interface Properties
+[options="header",width="99%",cols="2m,1,3"]
+|===
+| Name | Type | Description
+| ipInterface.id | Integer | ID
+| ipInterface.ipAddress | IP Address | IP Address
+| ipInterface.ipHostName | String | Hostname
+| ipInterface.ipLastCapsdPoll | Timestamp | Last Provisioning Scan
+| ipInterface.isManaged | String | Management Status
+|===
+
+[[monitoredServiceProperties]]
+.Monitored Service Properties
 [options="header",width="99%",cols="2m,1,3"]
 |===
 | Name | Type | Description
@@ -278,18 +290,6 @@ org.opennms.web.rest.support.SearchPropertiesToAsciidocTest
 `X`: Remotely Monitored
 
 `N`: Not Monitored
-|===
-
-[[ipInterfaceProperties]]
-.IP Interface Properties
-[options="header",width="99%",cols="2m,1,3"]
-|===
-| Name | Type | Description
-| ipInterface.id | Integer | ID
-| ipInterface.ipAddress | IP Address | IP Address
-| ipInterface.ipHostName | String | Hostname
-| ipInterface.ipLastCapsdPoll | Timestamp | Last Provisioning Scan
-| ipInterface.isManaged | String | Management Status
 |===
 
 [[locationProperties]]
@@ -477,9 +477,9 @@ Interface: `/api/v2/ifservices`
 Supported search/order properties:
 
 * <<assetProperties,`assetRecord.*`>>
-* <<ifServiceProperties,`ifService.*`>>
 * <<ipInterfaceProperties,`ipInterface.*`>>
 * <<locationProperties,`location.*`>>
+* <<monitoredServiceProperties,`monitoredService.*`>>
 * <<nodeProperties,`node.*`>>
 * <<serviceTypeProperties,`serviceType.*`>>
 * <<snmpInterfaceProperties,`snmpInterface.*`>>
@@ -551,6 +551,7 @@ Supported search/order properties:
 * <<distPollerProperties,`distPoller.*`>>
 * <<ipInterfaceProperties,`ipInterface.*`>>
 * <<locationProperties,`location.*`>>
+* <<monitoredServiceProperties,`monitoredService.*`>>
 * <<nodeProperties,`node.*`>>
 * <<outageProperties,`outage.*`>>
 * `serviceLostEvent.\*` (with the same properties as <<eventProperties,`event.*`>>)

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/support/SearchPropertiesToAsciidocTest.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/support/SearchPropertiesToAsciidocTest.java
@@ -109,14 +109,14 @@ public class SearchPropertiesToAsciidocTest {
 		}
 		System.out.println(FOOTER_FORMAT);
 
-		System.out.println(String.format(HEADER_FORMAT, "ifService", "Interface Service"));
-		for (SearchProperty prop : SearchProperties.withAliasPrefix(Aliases.monitoredService, null, IF_SERVICE_PROPERTIES)) {
+		System.out.println(String.format(HEADER_FORMAT, "ipInterface", "IP Interface"));
+		for (SearchProperty prop : SearchProperties.withAliasPrefix(Aliases.ipInterface, null, IP_INTERFACE_PROPERTIES)) {
 			System.out.println(String.format(ROW_FORMAT, prop.getId(), toPrettyType(prop.type), nameAndValues(prop)));
 		}
 		System.out.println(FOOTER_FORMAT);
 
-		System.out.println(String.format(HEADER_FORMAT, "ipInterface", "IP Interface"));
-		for (SearchProperty prop : SearchProperties.withAliasPrefix(Aliases.ipInterface, null, IP_INTERFACE_PROPERTIES)) {
+		System.out.println(String.format(HEADER_FORMAT, "monitoredService", "Monitored Service"));
+		for (SearchProperty prop : SearchProperties.withAliasPrefix(Aliases.monitoredService, null, IF_SERVICE_PROPERTIES)) {
 			System.out.println(String.format(ROW_FORMAT, prop.getId(), toPrettyType(prop.type), nameAndValues(prop)));
 		}
 		System.out.println(FOOTER_FORMAT);


### PR DESCRIPTION
Added a method override that I missed in NodeRestService. This will actually expose the metadata for the node endpoint.

* JIRA: http://issues.opennms.org/browse/NMS-9278