### PR TITLE
NMS-9497: fix alarm-type on BSM events to be 3 rather than 1

### DIFF
--- a/core/schema/src/main/liquibase/changelog.xml
+++ b/core/schema/src/main/liquibase/changelog.xml
@@ -79,6 +79,7 @@
 	<include file="19.0.0/changelog.xml"/>
 	<include file="19.1.0/changelog.xml"/>
 	<include file="19.1.1/changelog.xml"/>
+	<include file="foundation-2017/changelog.xml"/>
 
 	<include file="stored-procedures/getManagePercentAvailIntfWindow.xml" />
 	<include file="stored-procedures/getManagePercentAvailNodeWindow.xml" />

--- a/core/schema/src/main/liquibase/foundation-2017/changelog.xml
+++ b/core/schema/src/main/liquibase/foundation-2017/changelog.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+
+  <!-- Fix for issue NMS-9497 -->
+  <changeSet author="ranger" id="foundation2017-fix-bsm-alarm-type">
+    <update tableName="alarms">
+      <column name="alarmtype" value="3" />
+      <where>eventuei='uei.opennms.org/bsm/serviceProblem' OR eventuei='uei.opennms.org/bsm/serviceProblemResolved'</where>
+    </update>
+
+    <rollback>
+      <update tableName="alarms">
+        <column name="alarmtype" value="1" />
+	<where>eventuei='uei.opennms.org/bsm/serviceProblem' OR eventuei='uei.opennms.org/bsm/serviceProblemResolved'</where>
+      </update>
+    </rollback>
+  </changeSet>
+
+</databaseChangeLog>

--- a/opennms-base-assembly/src/main/filtered/etc/events/opennms.events.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/events/opennms.events.xml
@@ -2052,7 +2052,7 @@
     </descr>
     <logmsg dest="logndisplay">One or more problems are affecting business service '%parm[businessServiceName]%'.</logmsg>
     <severity>Indeterminate</severity>
-    <alarm-data reduction-key="%uei%:%parm[businessServiceId]%" alarm-type="1" auto-clean="false">
+    <alarm-data reduction-key="%uei%:%parm[businessServiceId]%" alarm-type="3" auto-clean="false">
       <update-field field-name="severity" update-on-reduction="true"/>
     </alarm-data>
   </event>
@@ -2064,7 +2064,7 @@
     </descr>
     <logmsg dest="logndisplay">The problems affecting business service '%parm[businessServiceName]%' have been resolved.</logmsg>
     <severity>Indeterminate</severity>
-    <alarm-data reduction-key="uei.opennms.org/bsm/serviceProblem:%parm[businessServiceId]%" alarm-type="1" auto-clean="false">
+    <alarm-data reduction-key="uei.opennms.org/bsm/serviceProblem:%parm[businessServiceId]%" alarm-type="3" auto-clean="false">
       <update-field field-name="severity" update-on-reduction="true"/>
     </alarm-data>
   </event>


### PR DESCRIPTION
This PR sets the alarm-type on the BSM events to `3` (no possible resolution) rather than `1` (has a possible resolution) and introduces liquibase code to update existing BSM alarms to have the right type in the database.

* JIRA: http://issues.opennms.org/browse/NMS-9497
