### PR TITLE
HZN-1146: Added eventparm search to RESTv2 endpoints

### DIFF
--- a/core/criteria/src/main/java/org/opennms/core/criteria/Alias.java
+++ b/core/criteria/src/main/java/org/opennms/core/criteria/Alias.java
@@ -51,7 +51,7 @@ public class Alias {
 
     private final JoinType m_type;
 
-    private final Restriction m_joinCondition;
+    private Restriction m_joinCondition;
 
     public Alias(final String associationPath, final String alias, final JoinType type, final Restriction joinCondition) {
         m_alias = alias.intern();
@@ -82,6 +82,10 @@ public class Alias {
 
     public Restriction getJoinCondition() {
         return m_joinCondition;
+    }
+
+    public void setJoinCondition(Restriction joinCondition) {
+        m_joinCondition = joinCondition;
     }
 
     @Override

--- a/core/criteria/src/main/java/org/opennms/core/criteria/AliasBuilder.java
+++ b/core/criteria/src/main/java/org/opennms/core/criteria/AliasBuilder.java
@@ -35,6 +35,7 @@ import java.util.Map;
 
 import org.opennms.core.criteria.Alias.JoinType;
 import org.opennms.core.criteria.restrictions.Restriction;
+import org.opennms.core.criteria.restrictions.Restrictions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -45,23 +46,47 @@ public class AliasBuilder {
     final Map<String, Alias> m_aliases = new HashMap<String, Alias>();
 
     public final AliasBuilder alias(final String associationPath, final String alias, final JoinType type, final Restriction joinCondition) {
-        if (m_aliases.containsKey(alias)) {
-            LOG.debug("alias '{}' already associated with associationPath '{}', skipping.", alias, associationPath);
-        } else {
+        Alias existing = m_aliases.get(alias);
+        if (existing == null) {
             if (joinCondition == null) {
                 m_aliases.put(alias, new Alias(associationPath, alias, type));
             } else {
                 m_aliases.put(alias, new Alias(associationPath, alias, type, joinCondition));
+            }
+        } else {
+            if (joinCondition == null) {
+                LOG.debug("alias '{}' already associated with associationPath '{}', skipping.", alias, associationPath);
+            } else {
+                if (existing.hasJoinCondition()) {
+                    // Combine the JOIN conditions
+                    LOG.debug("alias '{}' already associated with associationPath '{}', appending join condition.", alias, associationPath);
+                    existing.setJoinCondition(Restrictions.and(existing.getJoinCondition(), joinCondition));
+                } else {
+                    LOG.debug("alias '{}' already associated with associationPath '{}', adding join condition.", alias, associationPath);
+                    existing.setJoinCondition(joinCondition);
+                }
             }
         }
         return this;
     }
 
     public final AliasBuilder alias(final Alias alias) {
-        if (m_aliases.containsKey(alias.getAlias())) {
-            LOG.debug("alias '{}' already associated with associationPath '{}', skipping.", alias.getAlias(), alias.getAssociationPath());
-        } else {
+        Alias existing = m_aliases.get(alias.getAlias());
+        if (existing == null) {
             m_aliases.put(alias.getAlias(), alias);
+        } else {
+            if (alias.hasJoinCondition()) {
+                if (existing.hasJoinCondition()) {
+                    // Combine the JOIN conditions
+                    LOG.debug("alias '{}' already associated with associationPath '{}', appending join condition.", alias.getAlias(), alias.getAssociationPath());
+                    existing.setJoinCondition(Restrictions.and(existing.getJoinCondition(), alias.getJoinCondition()));
+                } else {
+                    LOG.debug("alias '{}' already associated with associationPath '{}', adding join condition.", alias.getAlias(), alias.getAssociationPath());
+                    existing.setJoinCondition(alias.getJoinCondition());
+                }
+            } else {
+                LOG.debug("alias '{}' already associated with associationPath '{}', skipping.", alias.getAlias(), alias.getAssociationPath());
+            }
         }
         return this;
     }

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/Aliases.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/Aliases.java
@@ -40,6 +40,7 @@ public enum Aliases {
     category,
     distPoller,
     event,
+    eventParameter,
     ipInterface,
     location,
     memo,

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/CriteriaBehavior.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/CriteriaBehavior.java
@@ -95,11 +95,11 @@ public class CriteriaBehavior<T> {
         return m_converter.apply(value);
     }
 
-    public void setSkipProperty(boolean skip) {
+    public void setSkipPropertyByDefault(boolean skip) {
         m_skipProperty = skip;
     }
 
-    public boolean shouldSkipProperty() {
+    public boolean shouldSkipProperty(ConditionType condition, boolean wildcard) {
         return m_skipProperty;
     }
 

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/CriteriaBehaviors.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/CriteriaBehaviors.java
@@ -39,7 +39,11 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.cxf.jaxrs.ext.search.ConditionType;
+import org.opennms.core.criteria.Alias.JoinType;
+import org.opennms.core.criteria.restrictions.Restrictions;
 import org.opennms.core.criteria.restrictions.SqlRestriction.Type;
+import org.opennms.netmgt.model.OnmsEventParameter;
 import org.opennms.netmgt.model.OnmsSeverity;
 import org.opennms.netmgt.model.TroubleTicketState;
 import org.opennms.web.api.ISO8601DateEditor;
@@ -83,16 +87,45 @@ public abstract class CriteriaBehaviors {
         return retval;
     }
 
+    /**
+     * <p>This criteria behavior uses SQL subselect restrictions when doing wildcard filtering or 
+     * negative filtering (since these queries will most likely return multiple rows that match
+     * the criteria) but it uses an alias with a join condition for specific filters. The join
+     * conditions will stack so that multiple specific filters will narrow the results, allowing
+     * you to query for specific combinations of:</p>
+     * <ul>
+     * <li>eventParameter.name</li>
+     * <li>eventParameter.value</li>
+     * <li>eventParameter.type</li>
+     * </ul>
+     * <p>Querying for a specific name-value pair is the primary use case for event parameter filtering.</p>
+     */
     private static final class EventParameterBehavior extends StringCriteriaBehavior {
-        public EventParameterBehavior(String eventIdColumn, String eventParameterProperty) {
-            super(Aliases.eventParameter.prop(eventParameterProperty), (b,v,c,w) -> {
-                // Add a categories alias that only matches the specified value
-                // TODO: This should work but Hibernate is generating invalid SQL for this criteria
-                //b.alias(Aliases.event.prop("eventParameters"), Aliases.eventParameter.toString(), JoinType.LEFT_JOIN, Restrictions.or(Restrictions.eq(Aliases.eventParameter.prop("value"), v), Restrictions.isNull(Aliases.eventParameter.prop("value")))); 
 
+        /**
+         * @param eventParameterPath The Hibernate property path for the eventParameter relationship
+         * @param eventIdColumn The column name in the database for the event ID column in the root entity table
+         * @param eventParameterProperty The name of the property in the {@link OnmsEventParameter} object that
+         *        this behavior is being applied to
+         */
+        public EventParameterBehavior(String eventParameterPath, String eventIdColumn, String eventParameterProperty) {
+            super(Aliases.eventParameter.prop(eventParameterProperty), (b,v,c,w) -> {
                 switch (c) {
                 case EQUALS:
-                    b.sql(String.format("{alias}.%s in (select event_parameters.eventid from event_parameters where event_parameters.%s %s ?)", eventIdColumn, eventParameterProperty, w ? "like" : "="), v, Type.STRING);
+                    if (w) {
+                        b.sql(String.format("{alias}.%s in (select event_parameters.eventid from event_parameters where event_parameters.%s %s ?)", eventIdColumn, eventParameterProperty, w ? "like" : "="), v, Type.STRING);
+                    } else {
+                        // Add an eventParameter alias that only matches the specified value
+                        b.alias(
+                            eventParameterPath,
+                            Aliases.eventParameter.toString(),
+                            JoinType.LEFT_JOIN,
+                            Restrictions.or(
+                                Restrictions.eq(Aliases.eventParameter.prop(eventParameterProperty), v),
+                                Restrictions.isNull(Aliases.eventParameter.prop(eventParameterProperty))
+                            )
+                        );
+                    }
                     break;
                 case NOT_EQUALS:
                     b.sql(String.format("{alias}.%s not in (select event_parameters.eventid from event_parameters where event_parameters.%s %s ?)", eventIdColumn, eventParameterProperty, w ? "like" : "="), v, Type.STRING);
@@ -101,7 +134,28 @@ public abstract class CriteriaBehaviors {
                     throw new IllegalArgumentException("Illegal condition type when filtering event_parameters." + eventParameterProperty + ": " + c.toString());
                 }
             });
-            super.setSkipProperty(true);
+        }
+
+        @Override
+        public boolean shouldSkipProperty(ConditionType condition, boolean wildcard) {
+            switch(condition) {
+            case EQUALS:
+                if (wildcard) {
+                    // If we're using a SQL subselect restriction, then skip the normal
+                    // property filtering
+                    return true;
+                } else {
+                    // If we're using an alias with join condition, then process the
+                    // property filtering as usual
+                    return false;
+                }
+            case NOT_EQUALS:
+                // All negative filters use SQL subselect restrictions so skip the normal
+                // property filtering
+                return true;
+            default:
+                return super.shouldSkipProperty(condition, wildcard);
+            }
         }
     }
 
@@ -145,9 +199,9 @@ public abstract class CriteriaBehaviors {
         ALARM_BEHAVIORS.put("troubleTicketState", new CriteriaBehavior<TroubleTicketState>(TroubleTicketState::valueOf));
         ALARM_BEHAVIORS.put("x733ProbableCause", new CriteriaBehavior<Integer>(INT_CONVERTER));
 
-        ALARM_LASTEVENT_PARAMETER_BEHAVIORS.put("name", new EventParameterBehavior("lasteventid", "name"));
-        ALARM_LASTEVENT_PARAMETER_BEHAVIORS.put("value", new EventParameterBehavior("lasteventid", "value"));
-        ALARM_LASTEVENT_PARAMETER_BEHAVIORS.put("type", new EventParameterBehavior("lasteventid", "type"));
+        ALARM_LASTEVENT_PARAMETER_BEHAVIORS.put("name", new EventParameterBehavior("lastEvent.eventParameters", "lasteventid", "name"));
+        ALARM_LASTEVENT_PARAMETER_BEHAVIORS.put("value", new EventParameterBehavior("lastEvent.eventParameters", "lasteventid", "value"));
+        ALARM_LASTEVENT_PARAMETER_BEHAVIORS.put("type", new EventParameterBehavior("lastEvent.eventParameters", "lasteventid", "type"));
 
         ASSET_RECORD_BEHAVIORS.put("id", new CriteriaBehavior<Integer>(INT_CONVERTER));
         ASSET_RECORD_BEHAVIORS.put("lastModifiedDate", new CriteriaBehavior<Date>(DATE_CONVERTER));
@@ -165,9 +219,9 @@ public abstract class CriteriaBehaviors {
         EVENT_BEHAVIORS.put("ifIndex", new CriteriaBehavior<Integer>(INT_CONVERTER));
         EVENT_BEHAVIORS.put("ipAddr", new CriteriaBehavior<InetAddress>(INET_ADDRESS_CONVERTER));
 
-        EVENT_PARAMETER_BEHAVIORS.put("name", new EventParameterBehavior("eventid", "name"));
-        EVENT_PARAMETER_BEHAVIORS.put("value", new EventParameterBehavior("eventid", "value"));
-        EVENT_PARAMETER_BEHAVIORS.put("type", new EventParameterBehavior("eventid", "type"));
+        EVENT_PARAMETER_BEHAVIORS.put("name", new EventParameterBehavior(Aliases.event.prop("eventParameters"), "eventid", "name"));
+        EVENT_PARAMETER_BEHAVIORS.put("value", new EventParameterBehavior(Aliases.event.prop("eventParameters"), "eventid", "value"));
+        EVENT_PARAMETER_BEHAVIORS.put("type", new EventParameterBehavior(Aliases.event.prop("eventParameters"), "eventid", "type"));
 
         IP_INTERFACE_BEHAVIORS.put("id", new CriteriaBehavior<Integer>(INT_CONVERTER));
         IP_INTERFACE_BEHAVIORS.put("ipLastCapsdPoll", new CriteriaBehavior<Date>(DATE_CONVERTER));
@@ -205,7 +259,7 @@ public abstract class CriteriaBehaviors {
         });
         // Skip normal processing of the property since we're doing all of the filtering 
         // in the beforeVisit() method
-        categoryId.setSkipProperty(true);
+        categoryId.setSkipPropertyByDefault(true);
         NODE_CATEGORY_BEHAVIORS.put("id", categoryId);
 
         CriteriaBehavior<String> categoryName = new StringCriteriaBehavior(Aliases.category.prop("name"), (b,v,c,w) -> {
@@ -226,7 +280,7 @@ public abstract class CriteriaBehaviors {
         });
         // Skip normal processing of the property since we're doing all of the filtering 
         // in the beforeVisit() method
-        categoryName.setSkipProperty(true);
+        categoryName.setSkipPropertyByDefault(true);
         NODE_CATEGORY_BEHAVIORS.put("name", categoryName);
 
         CriteriaBehavior<String> categoryDescription = new StringCriteriaBehavior(Aliases.category.prop("description"), (b,v,c,w) -> {
@@ -247,7 +301,7 @@ public abstract class CriteriaBehaviors {
         });
         // Skip normal processing of the property since we're doing all of the filtering 
         // in the beforeVisit() method
-        categoryDescription.setSkipProperty(true);
+        categoryDescription.setSkipPropertyByDefault(true);
         NODE_CATEGORY_BEHAVIORS.put("description", categoryDescription);
 
         NOTIFICATION_BEHAVIORS.put("notifyId", new CriteriaBehavior<Integer>(INT_CONVERTER));

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/CriteriaBuilderSearchVisitor.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/CriteriaBuilderSearchVisitor.java
@@ -152,7 +152,7 @@ public class CriteriaBuilderSearchVisitor<T,Q> extends AbstractSearchConditionVi
 					behavior.beforeVisit(m_criteriaBuilder, value, sc.getConditionType(), isWildcard);
 
 					// If the behavior indicates that we should skip this search term, then return
-					if (behavior.shouldSkipProperty()) {
+					if (behavior.shouldSkipProperty(sc.getConditionType(), isWildcard)) {
 						return;
 					}
 				} else {

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/IpLikeCriteriaBehavior.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/IpLikeCriteriaBehavior.java
@@ -67,6 +67,6 @@ public class IpLikeCriteriaBehavior extends CriteriaBehavior<String> {
         super(name, Function.identity(), beforeVisit);
         // Skip normal processing for this property since we're applying
         // the filter in the BeforeVisit operation.
-        super.setSkipProperty(true);
+        super.setSkipPropertyByDefault(true);
     }
 }

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/SearchProperties.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/SearchProperties.java
@@ -49,6 +49,7 @@ import org.opennms.netmgt.model.OnmsAssetRecord;
 import org.opennms.netmgt.model.OnmsCategory;
 import org.opennms.netmgt.model.OnmsDistPoller;
 import org.opennms.netmgt.model.OnmsEvent;
+import org.opennms.netmgt.model.OnmsEventParameter;
 import org.opennms.netmgt.model.OnmsIpInterface;
 import org.opennms.netmgt.model.OnmsMonitoredService;
 import org.opennms.netmgt.model.OnmsNode;
@@ -251,6 +252,13 @@ public abstract class SearchProperties {
 		new SearchPropertyBuilder().entityClass(OnmsEvent.class).id("ipAddr").name("IP Address").type(IP_ADDRESS).iplike(true).build(),
 	}));
 
+	static final SortedSet<SearchProperty> EVENT_PARAMETER_PROPERTIES = new TreeSet<>(Arrays.asList(new SearchProperty[] {
+		//new SearchProperty(OnmsEventParameter.class, "id", "ID", INTEGER),
+		new SearchProperty(OnmsEventParameter.class, "name", "Name", STRING),
+		new SearchProperty(OnmsEventParameter.class, "type", "Type", STRING),
+		new SearchProperty(OnmsEventParameter.class, "value", "Value", STRING)
+	}));
+
 	static final SortedSet<SearchProperty> IF_SERVICE_PROPERTIES = new TreeSet<>(Arrays.asList(new SearchProperty[] {
 		new SearchProperty(OnmsMonitoredService.class, "id", "ID", INTEGER),
 		new SearchProperty(OnmsMonitoredService.class, "lastFail", "Last Failure Time", TIMESTAMP),
@@ -450,6 +458,7 @@ public abstract class SearchProperties {
 		ALARM_SERVICE_PROPERTIES.addAll(withAliasPrefix(Aliases.assetRecord, "Asset", ASSET_RECORD_PROPERTIES));
 		ALARM_SERVICE_PROPERTIES.addAll(withAliasPrefix(Aliases.category, "Category", CATEGORY_PROPERTIES, false));
 		ALARM_SERVICE_PROPERTIES.addAll(withAliasPrefix(Aliases.distPoller, "Monitoring System", DIST_POLLER_PROPERTIES));
+		ALARM_SERVICE_PROPERTIES.addAll(withAliasPrefix(Aliases.eventParameter, "Event Parameter", EVENT_PARAMETER_PROPERTIES, false));
 		ALARM_SERVICE_PROPERTIES.addAll(withAliasPrefix(Aliases.ipInterface, "IP Interface", IP_INTERFACE_PROPERTIES));
 		ALARM_SERVICE_PROPERTIES.addAll(withAliasPrefix("lastEvent", "Last Event", EVENT_PROPERTIES));
 		ALARM_SERVICE_PROPERTIES.addAll(withAliasPrefix(Aliases.location, "Location", LOCATION_PROPERTIES));
@@ -467,6 +476,7 @@ public abstract class SearchProperties {
 		EVENT_SERVICE_PROPERTIES.addAll(withAliasPrefix(Aliases.assetRecord, "Asset", ASSET_RECORD_PROPERTIES));
 		EVENT_SERVICE_PROPERTIES.addAll(withAliasPrefix(Aliases.category, "Category", CATEGORY_PROPERTIES, false));
 		EVENT_SERVICE_PROPERTIES.addAll(withAliasPrefix(Aliases.distPoller, "Monitoring System", DIST_POLLER_PROPERTIES));
+		EVENT_SERVICE_PROPERTIES.addAll(withAliasPrefix(Aliases.eventParameter, "Event Parameter", EVENT_PARAMETER_PROPERTIES, false));
 		EVENT_SERVICE_PROPERTIES.addAll(withAliasPrefix(Aliases.ipInterface, "IP Interface", IP_INTERFACE_PROPERTIES));
 		EVENT_SERVICE_PROPERTIES.addAll(withAliasPrefix(Aliases.location, "Location", LOCATION_PROPERTIES));
 		EVENT_SERVICE_PROPERTIES.addAll(withAliasPrefix(Aliases.node, "Node", NODE_PROPERTIES));
@@ -508,6 +518,7 @@ public abstract class SearchProperties {
 		NOTIFICATION_SERVICE_PROPERTIES.addAll(withAliasPrefix(Aliases.category, "Category", CATEGORY_PROPERTIES, false));
 		NOTIFICATION_SERVICE_PROPERTIES.addAll(withAliasPrefix(Aliases.distPoller, "Monitoring System", DIST_POLLER_PROPERTIES));
 		NOTIFICATION_SERVICE_PROPERTIES.addAll(withAliasPrefix(Aliases.event, "Event", EVENT_PROPERTIES));
+		NOTIFICATION_SERVICE_PROPERTIES.addAll(withAliasPrefix(Aliases.eventParameter, "Event Parameter", EVENT_PARAMETER_PROPERTIES, false));
 		NOTIFICATION_SERVICE_PROPERTIES.addAll(withAliasPrefix(Aliases.ipInterface, "IP Interface", IP_INTERFACE_PROPERTIES));
 		NOTIFICATION_SERVICE_PROPERTIES.addAll(withAliasPrefix(Aliases.location, "Location", LOCATION_PROPERTIES));
 		NOTIFICATION_SERVICE_PROPERTIES.addAll(withAliasPrefix(Aliases.node, "Node", NODE_PROPERTIES));

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/AlarmRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/AlarmRestService.java
@@ -177,6 +177,7 @@ public class AlarmRestService extends AbstractDaoRestServiceWithDTO<OnmsAlarm,Al
 
         // 2nd level JOINs
         map.putAll(CriteriaBehaviors.withAliasPrefix(Aliases.assetRecord, CriteriaBehaviors.ASSET_RECORD_BEHAVIORS));
+        map.putAll(CriteriaBehaviors.withAliasPrefix(Aliases.eventParameter, CriteriaBehaviors.ALARM_LASTEVENT_PARAMETER_BEHAVIORS));
         map.putAll(CriteriaBehaviors.withAliasPrefix(Aliases.ipInterface, CriteriaBehaviors.IP_INTERFACE_BEHAVIORS));
         map.putAll(CriteriaBehaviors.withAliasPrefix(Aliases.location, CriteriaBehaviors.MONITORING_LOCATION_BEHAVIORS));
         map.putAll(CriteriaBehaviors.withAliasPrefix(Aliases.category, CriteriaBehaviors.NODE_CATEGORY_BEHAVIORS));

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/EventRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/EventRestService.java
@@ -152,6 +152,7 @@ public class EventRestService extends AbstractDaoRestServiceWithDTO<OnmsEvent,Ev
         // 1st level JOINs
         map.putAll(CriteriaBehaviors.withAliasPrefix(Aliases.alarm, CriteriaBehaviors.ALARM_BEHAVIORS));
         map.putAll(CriteriaBehaviors.withAliasPrefix(Aliases.distPoller, CriteriaBehaviors.DIST_POLLER_BEHAVIORS));
+        map.putAll(CriteriaBehaviors.withAliasPrefix(Aliases.eventParameter, CriteriaBehaviors.EVENT_PARAMETER_BEHAVIORS));
         map.putAll(CriteriaBehaviors.withAliasPrefix(Aliases.node, CriteriaBehaviors.NODE_BEHAVIORS));
         map.putAll(CriteriaBehaviors.withAliasPrefix(Aliases.serviceType, CriteriaBehaviors.SERVICE_TYPE_BEHAVIORS));
 

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NotificationRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NotificationRestService.java
@@ -132,6 +132,7 @@ public class NotificationRestService extends AbstractDaoRestService<OnmsNotifica
         // 2nd level JOINs
         map.putAll(CriteriaBehaviors.withAliasPrefix(Aliases.assetRecord, CriteriaBehaviors.ASSET_RECORD_BEHAVIORS));
         map.putAll(CriteriaBehaviors.withAliasPrefix(Aliases.distPoller, CriteriaBehaviors.DIST_POLLER_BEHAVIORS));
+        map.putAll(CriteriaBehaviors.withAliasPrefix(Aliases.eventParameter, CriteriaBehaviors.EVENT_PARAMETER_BEHAVIORS));
         map.putAll(CriteriaBehaviors.withAliasPrefix(Aliases.ipInterface, CriteriaBehaviors.IP_INTERFACE_BEHAVIORS));
         map.putAll(CriteriaBehaviors.withAliasPrefix(Aliases.location, CriteriaBehaviors.MONITORING_LOCATION_BEHAVIORS));
         map.putAll(CriteriaBehaviors.withAliasPrefix(Aliases.category, CriteriaBehaviors.NODE_CATEGORY_BEHAVIORS));

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/README.adoc
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/README.adoc
@@ -242,6 +242,16 @@ org.opennms.web.rest.support.SearchPropertiesToAsciidocTest
 | event.ipAddr | IP Address | IP Address
 |===
 
+[[eventParameterProperties]]
+.Event Parameter Properties
+[options="header",width="99%",cols="2m,1,3"]
+|===
+| Name | Type | Description
+| eventParameter.name | String | Name
+| eventParameter.type | String | Type
+| eventParameter.value | String | Value
+|===
+
 [[ipInterfaceProperties]]
 .IP Interface Properties
 [options="header",width="99%",cols="2m,1,3"]
@@ -436,6 +446,7 @@ Supported search/order properties:
 * <<assetProperties,`assetRecord.*`>>
 * <<categoryProperties,`category.*`>> (Only valid for search)
 * <<distPollerProperties,`distPoller.*`>>
+* <<eventParameterProperties,`eventParameter.*`>> (for parameters of `lastEvent`)
 * <<ipInterfaceProperties,`ipInterface.*`>>
 * `lastEvent.\*` (with the same properties as <<eventProperties,`event.*`>>)
 * <<locationProperties,`location.*`>>
@@ -464,6 +475,7 @@ Supported search/order properties:
 * <<distPollerProperties,`distPoller.*`>>
 * <<eventProperties,`event.*`>>
 ** `event.ipAddr` can be an iplike expression
+* <<eventParameterProperties,`eventParameter.*`>>
 * <<ipInterfaceProperties,`ipInterface.*`>>
 * <<locationProperties,`location.*`>>
 * <<nodeProperties,`node.*`>>
@@ -532,6 +544,7 @@ Supported search/order properties:
 * <<categoryProperties,`category.*`>> (Only valid for search)
 * <<distPollerProperties,`distPoller.*`>>
 * <<eventProperties,`event.*`>>
+* <<eventParameterProperties,`eventParameter.*`>>
 * <<ipInterfaceProperties,`ipInterface.*`>>
 * <<locationProperties,`location.*`>>
 * <<nodeProperties,`node.*`>>

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/README.adoc
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/README.adoc
@@ -446,7 +446,7 @@ Supported search/order properties:
 * <<assetProperties,`assetRecord.*`>>
 * <<categoryProperties,`category.*`>> (Only valid for search)
 * <<distPollerProperties,`distPoller.*`>>
-* <<eventParameterProperties,`eventParameter.*`>> (for parameters of `lastEvent`)
+* <<eventParameterProperties,`eventParameter.*`>> (for parameters of `lastEvent`, only valid for search)
 * <<ipInterfaceProperties,`ipInterface.*`>>
 * `lastEvent.\*` (with the same properties as <<eventProperties,`event.*`>>)
 * <<locationProperties,`location.*`>>
@@ -475,7 +475,7 @@ Supported search/order properties:
 * <<distPollerProperties,`distPoller.*`>>
 * <<eventProperties,`event.*`>>
 ** `event.ipAddr` can be an iplike expression
-* <<eventParameterProperties,`eventParameter.*`>>
+* <<eventParameterProperties,`eventParameter.*`>> (Only valid for search)
 * <<ipInterfaceProperties,`ipInterface.*`>>
 * <<locationProperties,`location.*`>>
 * <<nodeProperties,`node.*`>>
@@ -544,7 +544,7 @@ Supported search/order properties:
 * <<categoryProperties,`category.*`>> (Only valid for search)
 * <<distPollerProperties,`distPoller.*`>>
 * <<eventProperties,`event.*`>>
-* <<eventParameterProperties,`eventParameter.*`>>
+* <<eventParameterProperties,`eventParameter.*`>> (Only valid for search)
 * <<ipInterfaceProperties,`ipInterface.*`>>
 * <<locationProperties,`location.*`>>
 * <<nodeProperties,`node.*`>>

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/support/SearchPropertiesToAsciidocTest.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/support/SearchPropertiesToAsciidocTest.java
@@ -33,6 +33,7 @@ import static org.opennms.web.rest.support.SearchProperties.APPLICATION_PROPERTI
 import static org.opennms.web.rest.support.SearchProperties.ASSET_RECORD_PROPERTIES;
 import static org.opennms.web.rest.support.SearchProperties.CATEGORY_PROPERTIES;
 import static org.opennms.web.rest.support.SearchProperties.DIST_POLLER_PROPERTIES;
+import static org.opennms.web.rest.support.SearchProperties.EVENT_PARAMETER_PROPERTIES;
 import static org.opennms.web.rest.support.SearchProperties.EVENT_PROPERTIES;
 import static org.opennms.web.rest.support.SearchProperties.IF_SERVICE_PROPERTIES;
 import static org.opennms.web.rest.support.SearchProperties.IP_INTERFACE_PROPERTIES;
@@ -105,6 +106,12 @@ public class SearchPropertiesToAsciidocTest {
 
 		System.out.println(String.format(HEADER_FORMAT, "event", "Event"));
 		for (SearchProperty prop : SearchProperties.withAliasPrefix(Aliases.event, null, EVENT_PROPERTIES)) {
+			System.out.println(String.format(ROW_FORMAT, prop.getId(), toPrettyType(prop.type), nameAndValues(prop)));
+		}
+		System.out.println(FOOTER_FORMAT);
+
+		System.out.println(String.format(HEADER_FORMAT, "eventParameter", "Event Parameter"));
+		for (SearchProperty prop : SearchProperties.withAliasPrefix(Aliases.eventParameter, null, EVENT_PARAMETER_PROPERTIES)) {
 			System.out.println(String.format(ROW_FORMAT, prop.getId(), toPrettyType(prop.type), nameAndValues(prop)));
 		}
 		System.out.println(FOOTER_FORMAT);

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v2/AlarmRestServiceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v2/AlarmRestServiceIT.java
@@ -59,6 +59,7 @@ import org.opennms.netmgt.model.OnmsAlarm;
 import org.opennms.netmgt.model.OnmsAssetRecord;
 import org.opennms.netmgt.model.OnmsCategory;
 import org.opennms.netmgt.model.OnmsEvent;
+import org.opennms.netmgt.model.OnmsEventParameter;
 import org.opennms.netmgt.model.OnmsIpInterface;
 import org.opennms.netmgt.model.OnmsNode;
 import org.opennms.netmgt.model.OnmsNode.NodeType;
@@ -95,9 +96,10 @@ import com.google.common.collect.ImmutableMap;
 @JUnitTemporaryDatabase
 @Transactional
 public class AlarmRestServiceIT extends AbstractSpringJerseyRestTestCase {
+
     private static final Logger LOG = LoggerFactory.getLogger(AlarmRestServiceIT.class);
     private static final String SERVER3_NAME = "w\u00EAird%20server+name";
-
+    private static final AtomicInteger ALARM_COUNTER = new AtomicInteger();
 
     public AlarmRestServiceIT() {
         super(CXF_REST_V2_CONTEXT_PATH);
@@ -115,6 +117,8 @@ public class AlarmRestServiceIT extends AbstractSpringJerseyRestTestCase {
 
     @Override
     protected void afterServletStart() throws Exception {
+        ALARM_COUNTER.set(0);
+
         MockLogAppender.setupLogging(true, "DEBUG");
 
         final OnmsCategory linux = createCategory("Linux");
@@ -212,6 +216,58 @@ public class AlarmRestServiceIT extends AbstractSpringJerseyRestTestCase {
         executeQueryAndVerify("_s=category.name!=ma*S", 4);
         executeQueryAndVerify("_s=category.name==DoesntExist", 0);
         executeQueryAndVerify("_s=category.name!=DoesntExist", 8);
+    }
+
+    /**
+     * Test filtering for properties of {@link OnmsEventParameter}. The implementation
+     * for this filtering is different because the event-to-parameter relationship
+     * is a one-to-many relationship.
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testEventParameterFiltering() throws Exception {
+        executeQueryAndVerify("_s=eventParameter.name==testParm1", 4);
+        executeQueryAndVerify("_s=eventParameter.name!=testParm1", 4);
+
+        executeQueryAndVerify("_s=eventParameter.name==testParm2", 4);
+        executeQueryAndVerify("_s=eventParameter.name!=testParm2", 4);
+
+        executeQueryAndVerify("_s=eventParameter.name==doesntExist", 0);
+        executeQueryAndVerify("_s=eventParameter.name!=doesntExist", 8);
+
+        executeQueryAndVerify("_s=eventParameter.value==This is an awesome parm%21", 4);
+        executeQueryAndVerify("_s=eventParameter.value!=This is an awesome parm%21", 4);
+        executeQueryAndVerify("_s=eventParameter.value!=This is an awesome parm%21;eventParameter.value==This is a weird parm", 4);
+
+        executeQueryAndVerify("_s=eventParameter.value==This is a weird parm", 4);
+        executeQueryAndVerify("_s=eventParameter.value!=This is a weird parm", 4);
+        executeQueryAndVerify("_s=eventParameter.value!=This is a weird parm;eventParameter.value==This is an awesome parm%21", 4);
+
+        executeQueryAndVerify("_s=eventParameter.value!=This is an awesome parm%21;eventParameter.value!=This is a weird parm", 0);
+
+        executeQueryAndVerify("_s=eventParameter.value==doesntExist", 0);
+        executeQueryAndVerify("_s=eventParameter.value!=doesntExist", 8);
+
+        executeQueryAndVerify("_s=eventParameter.type==string", 8);
+        executeQueryAndVerify("_s=eventParameter.type!=string", 0);
+
+        executeQueryAndVerify("_s=eventParameter.type==doesntExist", 0);
+        executeQueryAndVerify("_s=eventParameter.type!=doesntExist", 8);
+
+        executeQueryAndVerify("_s=eventParameter.name==testParm1;eventParameter.value==This is an awesome parm%21", 4);
+        executeQueryAndVerify("_s=eventParameter.name==testParm1;eventParameter.value==This is a weird parm", 0);
+
+        executeQueryAndVerify("_s=eventParameter.name==testParm2;eventParameter.value==This is a weird parm", 4);
+        executeQueryAndVerify("_s=eventParameter.name==testParm2;eventParameter.value==This is an awesome parm%21", 0);
+
+        executeQueryAndVerify("_s=eventParameter.name==testParm*", 8);
+        executeQueryAndVerify("_s=eventParameter.name==testParm*;eventParameter.value==*awesome*", 4);
+        executeQueryAndVerify("_s=eventParameter.name==testParm*;eventParameter.value!=*awesome*", 4);
+        executeQueryAndVerify("_s=eventParameter.name==testParm*;eventParameter.value==*weird*", 4);
+        executeQueryAndVerify("_s=eventParameter.name==testParm*;eventParameter.value!=*weird*", 4);
+        executeQueryAndVerify("_s=eventParameter.type==*ring*;eventParameter.value==*awesome*", 4);
+        executeQueryAndVerify("_s=eventParameter.type==*ring*;eventParameter.value!=*weird*", 4);
     }
 
     @Test
@@ -527,6 +583,11 @@ public class AlarmRestServiceIT extends AbstractSpringJerseyRestTestCase {
         event.setEventSource("JUnit");
         event.setEventTime(new Date(epoch));
         event.setEventUei(eventUei);
+        if (ALARM_COUNTER.getAndIncrement() % 2 == 0) {
+            event.addEventParameter(new OnmsEventParameter(event, "testParm1", "This is an awesome parm!", "string"));
+        } else {
+            event.addEventParameter(new OnmsEventParameter(event, "testParm2", "This is a weird parm", "string"));
+        }
         event.setIpAddr(node.getIpInterfaces().iterator().next().getIpAddress());
         event.setNode(node);
         event.setServiceType(m_databasePopulator.getServiceTypeDao().findByName("ICMP"));


### PR DESCRIPTION
Now that the event parameters are in a separate database table, we can filter based on parameters in our Criteria API and, subsequently, in the RESTv2 services.

This PR adds eventparm filtering support to the alarm, event, and notification endpoints.

* JIRA: http://issues.opennms.org/browse/HZN-1146