### PR TITLE
HZN-1150: Allow users with ROLE_DELEGATE to acknowledge alarms on behalf of other users

### DIFF
--- a/opennms-doc/guide-admin/src/asciidoc/text/user-management/security-roles.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/user-management/security-roles.adoc
@@ -24,6 +24,7 @@ The following _Security Roles_ are available:
 | _ROLE_ADMIN_        | Permissions to create, read, update and delete in the Web User Interface and the _ReST API_.
 | _ROLE_ASSET_EDITOR_ | Permissions to just update the asset records from nodes.
 | _ROLE_DASHBOARD_    | Allow users to just have access to the _Dashboard_.
+| _ROLE_DELEGATE_     | Allows actions (such as acknowledging an alarm) to be performed on behalf of another user.
 | _ROLE_JMX_          | Allows retrieving JMX metrics but does not allow executing MBeans of the _{opennms-product-name}_ JVM, even if they just return simple values.
 ifndef::opennms-prime[]
 | _ROLE_MINION_       | Minimal amount of permissions required for a _Minion_ to operate.

--- a/opennms-web-api/src/main/java/org/opennms/web/api/Authentication.java
+++ b/opennms-web-api/src/main/java/org/opennms/web/api/Authentication.java
@@ -72,6 +72,7 @@ public final class Authentication extends Object {
     public static final String ROLE_ADMIN = "ROLE_ADMIN";
     public static final String ROLE_READONLY = "ROLE_READONLY";
     public static final String ROLE_DASHBOARD = "ROLE_DASHBOARD";
+    public static final String ROLE_DELEGATE = "ROLE_DELEGATE";
     public static final String ROLE_RTC = "ROLE_RTC";
     public static final String ROLE_PROVISION = "ROLE_PROVISION";
     public static final String ROLE_REMOTING = "ROLE_REMOTING";
@@ -89,6 +90,7 @@ public final class Authentication extends Object {
         s_availableRoles.add(ROLE_ADMIN);
         s_availableRoles.add(ROLE_READONLY);
         s_availableRoles.add(ROLE_DASHBOARD);
+        s_availableRoles.add(ROLE_DELEGATE);
         s_availableRoles.add(ROLE_RTC);
         s_availableRoles.add(ROLE_PROVISION);
         s_availableRoles.add(ROLE_REMOTING);

--- a/opennms-webapp-rest/pom.xml
+++ b/opennms-webapp-rest/pom.xml
@@ -304,6 +304,11 @@
       <version>1.2.3</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-all</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <pluginRepositories>

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/SecurityHelper.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/SecurityHelper.java
@@ -67,9 +67,9 @@ public class SecurityHelper {
         if (securityContext.isUserInRole(Authentication.ROLE_REST) ||
                 securityContext.isUserInRole(Authentication.ROLE_USER) ||
                 securityContext.isUserInRole(Authentication.ROLE_MOBILE)) {
-            if (ackUser.equals(currentUser)) {
+            if (ackUser.equals(currentUser) || (!ackUser.equals(currentUser) && securityContext.isUserInRole(Authentication.ROLE_DELEGATE))) {
                 // ROLE_REST and ROLE_MOBILE are allowed to modify things as long as it's as the
-                // same user as they're logging in with.
+                // same user as they're logging in with, or if they also have ROLE_DELEGATE.
                 return;
             }
         }

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/support/SecurityHelperTest.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/support/SecurityHelperTest.java
@@ -1,0 +1,117 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2017-2017 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.web.rest.support;
+
+import org.junit.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.SecurityContext;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.opennms.web.api.Authentication.ROLE_ADMIN;
+import static org.opennms.web.api.Authentication.ROLE_DELEGATE;
+import static org.opennms.web.api.Authentication.ROLE_MOBILE;
+import static org.opennms.web.api.Authentication.ROLE_READONLY;
+import static org.opennms.web.api.Authentication.ROLE_REST;
+import static org.opennms.web.api.Authentication.ROLE_USER;
+
+public class SecurityHelperTest {
+    private static final String USER = "joe";
+    private static final String OTHER_USER = "bob";
+
+    @Test
+    public void assertUserEditPrivilegesWithSameAckUser() {
+        // Admin always allowed
+        assertUserEditPrivileges(true, USER, ROLE_ADMIN);
+
+        // REST, USER and MOBILE roles allowed
+        assertUserEditPrivileges(true, USER, ROLE_USER);
+        assertUserEditPrivileges(true, USER, ROLE_REST);
+        assertUserEditPrivileges(true, USER, ROLE_MOBILE);
+
+        // No role rejected
+        assertUserEditPrivileges(false, USER);
+
+        // Read-only users rejected
+        assertUserEditPrivileges(false, USER, ROLE_USER, ROLE_READONLY);
+    }
+
+    @Test
+    public void assertUserEditPrivilegesWithDifferentAckUser() {
+        // Admin always allowed
+        assertUserEditPrivileges(true, OTHER_USER, ROLE_ADMIN);
+
+        // REST, USER and MOBILE roles not allowed
+        assertUserEditPrivileges(false, OTHER_USER, ROLE_USER);
+        assertUserEditPrivileges(false, OTHER_USER, ROLE_REST);
+        assertUserEditPrivileges(false, OTHER_USER, ROLE_MOBILE);
+
+        // REST, USER and MOBILE roles allowed when they have the delegate role too
+        assertUserEditPrivileges(true, OTHER_USER, ROLE_USER, ROLE_DELEGATE);
+        assertUserEditPrivileges(true, OTHER_USER, ROLE_REST, ROLE_DELEGATE);
+        assertUserEditPrivileges(true, OTHER_USER, ROLE_MOBILE, ROLE_DELEGATE);
+    }
+
+    private void assertUserEditPrivileges(boolean isAllowed, String ackUser, String... roles) {
+        final Set<String> userRoles = new HashSet<>(Arrays.asList(roles));
+        SecurityContext securityContext = mock(SecurityContext.class, RETURNS_DEEP_STUBS);
+        when(securityContext.getUserPrincipal().getName()).thenReturn(USER);
+        when(securityContext.isUserInRole(anyString())).thenAnswer((Answer) invocation -> {
+            final String role = invocation.getArgumentAt(0, String.class);
+            return userRoles.contains(role);
+        });
+
+        WebApplicationException ex = null;
+        try {
+            SecurityHelper.assertUserEditCredentials(securityContext, ackUser);
+        } catch (WebApplicationException e) {
+            ex = e;
+        }
+
+        if (isAllowed) {
+            assertNull("Should be allowed, but got: " + ex, ex);
+        } else {
+            assertNotNull("Should not be allowed, but passed.", ex);
+        }
+    }
+}


### PR DESCRIPTION
JIRA: https://issues.opennms.org/browse/HZN-1150

Here we add a new role, ROLE_DELEGATE, that allows alarms to be acknowledged on behalf of other users, without required ROLE_ADMIN.
