### PR TITLE
NMS-9420: update JDHCP to give a better error from malformed packets

### DIFF
--- a/protocols/dhcp/pom.xml
+++ b/protocols/dhcp/pom.xml
@@ -51,9 +51,9 @@
   <dependencies>
     <!-- NOTE: JDHCP is licensed as GPL and should be kept separate from other libraries -->
     <dependency>
-      <groupId>org.dhcp.jdhcp</groupId>
+      <groupId>org.opennms</groupId>
       <artifactId>jdhcp</artifactId>
-      <version>1.1.1</version>
+      <version>1.2.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.opennms</groupId>
@@ -98,6 +98,13 @@
   </dependencies>
 
   <repositories>
+    <repository>
+      <snapshots><enabled>true</enabled></snapshots>
+      <releases><enabled>false</enabled></releases>
+      <id>opennms-snapshots</id>
+      <name>OpenNMS Snapshot Repository</name>
+      <url>http://maven.opennms.org/content/groups/opennms.org-snapshot</url>
+    </repository>
     <repository>
       <snapshots><enabled>false</enabled></snapshots>
       <releases><enabled>true</enabled></releases>

--- a/protocols/dhcp/pom.xml
+++ b/protocols/dhcp/pom.xml
@@ -53,7 +53,7 @@
     <dependency>
       <groupId>org.opennms</groupId>
       <artifactId>jdhcp</artifactId>
-      <version>1.2.0-SNAPSHOT</version>
+      <version>1.2.0</version>
     </dependency>
     <dependency>
       <groupId>org.opennms</groupId>
@@ -98,13 +98,6 @@
   </dependencies>
 
   <repositories>
-    <repository>
-      <snapshots><enabled>true</enabled></snapshots>
-      <releases><enabled>false</enabled></releases>
-      <id>opennms-snapshots</id>
-      <name>OpenNMS Snapshot Repository</name>
-      <url>http://maven.opennms.org/content/groups/opennms.org-snapshot</url>
-    </repository>
     <repository>
       <snapshots><enabled>false</enabled></snapshots>
       <releases><enabled>true</enabled></releases>

--- a/protocols/dhcp/src/assembly/lib.xml
+++ b/protocols/dhcp/src/assembly/lib.xml
@@ -13,7 +13,7 @@
       <useProjectArtifact>false</useProjectArtifact>
       <outputDirectory>lib</outputDirectory>
       <includes>
-        <include>org.dhcp.jdhcp:jdhcp</include>
+        <include>org.opennms:jdhcp</include>
       </includes>
     </dependencySet>
   </dependencySets>

--- a/protocols/dhcp/src/main/java/org/opennms/netmgt/dhcpd/Client.java
+++ b/protocols/dhcp/src/main/java/org/opennms/netmgt/dhcpd/Client.java
@@ -40,10 +40,9 @@ import java.util.Observable;
 
 import org.opennms.core.fiber.Fiber;
 import org.opennms.core.utils.InetAddressUtils;
+import org.opennms.jdhcp.DHCPMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import edu.bucknell.net.JDHCP.DHCPMessage;
 
 final class Client extends Observable implements Runnable, Fiber {
 	
@@ -154,8 +153,8 @@ final class Client extends Observable implements Runnable, Fiber {
                     continue;
                 } catch (ArrayIndexOutOfBoundsException oobE) {
                     // Packet was too large for buffer...log and discard
-                    LOG.debug("UnicastListener.run: array out of bounds exception.", oobE);
-                    LOG.warn("UnicastListener.run: malformed DHCP packet, packet too large for buffer (buffer sz={}), discarding packet.", dgbuf.length);
+                    LOG.debug("UnicastListener.run: malformed DHCP packet", oobE);
+                    LOG.warn("UnicastListener.run: malformed DHCP packet or packet too large for buffer (buffer sz={}), discarding packet.", dgbuf.length);
                 } catch (IOException ioE) {
                     LOG.error("UnicastListener.run: io exception receiving response", ioE);
                     m_keepListening = false;
@@ -282,7 +281,7 @@ final class Client extends Observable implements Runnable, Fiber {
                         LOG.debug("Got disconnect request from Poller corresponding to sending port {}", m_sender.getLocalPort());
                     isOk = false;
                 } else {
-                        LOG.debug("Got request... adress = {}", msg.getAddress());
+                        LOG.debug("Got request... address = {}", msg.getAddress());
                     byte[] dhcp = msg.getMessage().externalize();
 
                     DatagramPacket pkt = new DatagramPacket(dhcp, dhcp.length, msg.getAddress(), DHCP_TARGET_PORT);

--- a/protocols/dhcp/src/main/java/org/opennms/netmgt/dhcpd/Message.java
+++ b/protocols/dhcp/src/main/java/org/opennms/netmgt/dhcpd/Message.java
@@ -34,7 +34,8 @@ import java.io.ObjectOutputStream;
 import java.io.Serializable;
 import java.net.InetAddress;
 
-import edu.bucknell.net.JDHCP.DHCPMessage;
+import org.opennms.jdhcp.DHCPMessage;
+import org.opennms.jdhcp.MalformedPacketException;
 
 /**
  * <p>Message class.</p>
@@ -93,7 +94,7 @@ public final class Message implements Serializable {
         out.write(buf);
     }
 
-    private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+    private void readObject(ObjectInputStream in) throws MalformedPacketException, ClassNotFoundException, IOException {
         m_target = (InetAddress) in.readObject();
 
         byte[] buf = new byte[in.readInt()];

--- a/protocols/dhcp/src/main/java/org/opennms/netmgt/dhcpd/Poller.java
+++ b/protocols/dhcp/src/main/java/org/opennms/netmgt/dhcpd/Poller.java
@@ -39,11 +39,10 @@ import java.net.UnknownHostException;
 import java.util.StringTokenizer;
 
 import org.opennms.core.utils.InetAddressUtils;
+import org.opennms.jdhcp.DHCPMessage;
 import org.opennms.netmgt.config.dhcpd.DhcpdConfigFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import edu.bucknell.net.JDHCP.DHCPMessage;
 
 /**
  * <P>

--- a/protocols/dhcp/src/main/java/org/opennms/netmgt/dhcpd/Receiver.java
+++ b/protocols/dhcp/src/main/java/org/opennms/netmgt/dhcpd/Receiver.java
@@ -36,10 +36,9 @@ import java.util.Iterator;
 import java.util.List;
 
 import org.opennms.core.fiber.Fiber;
+import org.opennms.jdhcp.DHCPMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import edu.bucknell.net.JDHCP.DHCPMessage;
 
 final class Receiver implements Runnable, Fiber {
 	

--- a/protocols/dhcp/src/main/java/org/opennms/netmgt/dhcpd/Receiver2.java
+++ b/protocols/dhcp/src/main/java/org/opennms/netmgt/dhcpd/Receiver2.java
@@ -37,10 +37,9 @@ import java.util.Iterator;
 import java.util.List;
 
 import org.opennms.core.fiber.Fiber;
+import org.opennms.jdhcp.DHCPMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import edu.bucknell.net.JDHCP.DHCPMessage;
 
 final class Receiver2 implements Runnable, Fiber {
 	

--- a/protocols/dhcp/src/test/java/org/opennms/netmgt/config/dhcpd/DhcpdConfigFactoryTest.java
+++ b/protocols/dhcp/src/test/java/org/opennms/netmgt/config/dhcpd/DhcpdConfigFactoryTest.java
@@ -36,25 +36,25 @@ import org.junit.Test;
 
 public class DhcpdConfigFactoryTest {
 
-	@Test
-	public void testRead() throws Exception {
-		/*
-		 * <DhcpdConfiguration
-		 *    port="5818"
-	     *    macAddress="00:06:0D:BE:9C:B2"
+    @Test
+    public void testRead() throws Exception {
+        /*
+         * <DhcpdConfiguration
+         *    port="5818"
+         *    macAddress="00:06:0D:BE:9C:B2"
          *    myIpAddress="127.0.0.1"
          *    extendedMode="false"
          *    requestIpAddress="127.0.0.1"> 
          * </DhcpdConfiguration>
          *
-		 */
-		DhcpdConfigFactory factory = new DhcpdConfigFactory(new File("src/main/etc/dhcpd-configuration.xml"));
-		
-		assertEquals(5818, factory.getPort());
-		assertEquals("00:06:0D:BE:9C:B2", factory.getMacAddress());
-		assertEquals("127.0.0.1", factory.getMyIpAddress());
-		assertEquals("false", factory.getExtendedMode());
-		assertEquals("127.0.0.1", factory.getRequestIpAddress());
-	}
+         */
+        DhcpdConfigFactory factory = new DhcpdConfigFactory(new File("src/main/etc/dhcpd-configuration.xml"));
+
+        assertEquals(5818, factory.getPort());
+        assertEquals("00:06:0D:BE:9C:B2", factory.getMacAddress());
+        assertEquals("127.0.0.1", factory.getMyIpAddress());
+        assertEquals("false", factory.getExtendedMode());
+        assertEquals("127.0.0.1", factory.getRequestIpAddress());
+    }
 
 }


### PR DESCRIPTION
This PR updates the `protocols/dhcp/` DHCP implementation to use [JDHCP 1.2.0](https://github.com/OpenNMS/jdhcp), a fork of the original dhcp.org java DHCP implementation which has been updated to throw more meaningful errors when malformed packets are encountered.

* JIRA: http://issues.opennms.org/browse/NMS-9420

Our [continuous integration system](http://bamboo.internal.opennms.com:8085) will test and verify your changes.