### PR TITLE
NMS-9608: Restored update() function in AbstractDaoRestServiceWithDTO

### DIFF
--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/AlarmRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/AlarmRestService.java
@@ -191,7 +191,7 @@ public class AlarmRestService extends AbstractDaoRestServiceWithDTO<OnmsAlarm,Al
     }
 
     @Override
-    protected Response doUpdate(SecurityContext securityContext, UriInfo uriInfo, OnmsAlarm alarm, MultivaluedMapImpl params) {
+    protected Response doUpdateProperties(SecurityContext securityContext, UriInfo uriInfo, OnmsAlarm alarm, MultivaluedMapImpl params) {
         boolean isProcessAck = true;
 
         final String ackValue = params.getFirst("ack");

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/IfServiceRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/IfServiceRestService.java
@@ -151,7 +151,7 @@ public class IfServiceRestService extends AbstractDaoRestService<OnmsMonitoredSe
     }
 
     @Override
-    protected Response doUpdate(SecurityContext securityContext, UriInfo uriInfo, OnmsMonitoredService targetObject, MultivaluedMapImpl params) {
+    protected Response doUpdateProperties(SecurityContext securityContext, UriInfo uriInfo, OnmsMonitoredService targetObject, MultivaluedMapImpl params) {
         final String previousStatus = targetObject.getStatus();
         RestUtils.setBeanProperties(targetObject, params);
         getDao().update(targetObject);

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/MinionRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/MinionRestService.java
@@ -32,8 +32,10 @@ import java.util.Collection;
 import java.util.Set;
 
 import javax.ws.rs.Path;
+import javax.ws.rs.core.Response;
 import javax.ws.rs.core.SecurityContext;
 import javax.ws.rs.core.UriInfo;
+import javax.ws.rs.core.Response.Status;
 
 import org.opennms.core.config.api.JaxbListWrapper;
 import org.opennms.core.criteria.CriteriaBuilder;
@@ -107,6 +109,15 @@ public class MinionRestService extends AbstractDaoRestService<OnmsMinion,OnmsMin
     @Override
     protected Set<SearchProperty> getQueryProperties() {
         return SearchProperties.MINION_SERVICE_PROPERTIES;
+    }
+
+    @Override
+    protected Response doUpdate(SecurityContext securityContext, UriInfo uriInfo, String key, OnmsMinion targetObject) {
+        if (!key.equals(targetObject.getId())) {
+            throw getException(Status.BAD_REQUEST, "The ID of the object doesn't match the ID of the path: {} != {}", targetObject.getId(), key);
+        }
+        getDao().saveOrUpdate(targetObject);
+        return Response.noContent().build();
     }
 
     @Override

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/MonitoringLocationRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/MonitoringLocationRestService.java
@@ -33,6 +33,7 @@ import java.util.Set;
 
 import javax.ws.rs.Path;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.SecurityContext;
 import javax.ws.rs.core.UriInfo;
 
@@ -44,7 +45,6 @@ import org.opennms.web.rest.support.RedirectHelper;
 import org.opennms.web.rest.support.SearchProperties;
 import org.opennms.web.rest.support.SearchProperty;
 import org.opennms.web.rest.v1.support.OnmsMonitoringLocationDefinitionList;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -106,6 +106,15 @@ public class MonitoringLocationRestService extends AbstractDaoRestService<OnmsMo
     public Response doCreate(final SecurityContext securityContext, final UriInfo uriInfo, final OnmsMonitoringLocation object) {
         final String id = getDao().save(object);
         return Response.created(RedirectHelper.getRedirectUri(uriInfo, id)).build();
+    }
+
+    @Override
+    protected Response doUpdate(final SecurityContext securityContext, final UriInfo uriInfo, final String key, final OnmsMonitoringLocation targetObject) {
+        if (!key.equals(targetObject.getLocationName())) {
+            throw getException(Status.BAD_REQUEST, "The ID of the object doesn't match the ID of the path: {} != {}", targetObject.getLocationName(), key);
+        }
+        getDao().saveOrUpdate(targetObject);
+        return Response.noContent().build();
     }
 
     @Override

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NodeCategoriesRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NodeCategoriesRestService.java
@@ -122,14 +122,6 @@ public class NodeCategoriesRestService extends AbstractNodeDependentRestService<
         return Response.ok(node.getCategories().size()).build();
     }
 
-    public Response updateMany(@Context final UriInfo uriInfo, @Context final SearchContext searchContext, final MultivaluedMapImpl params) {
-        return Response.status(Status.NOT_IMPLEMENTED).build();
-    }
-
-    public Response deleteMany(@Context final UriInfo uriInfo, @Context final SearchContext searchContext) {
-        return Response.status(Status.NOT_IMPLEMENTED).build();
-    }
-
     @Override
     protected Response doCreate(SecurityContext securityContext, UriInfo uriInfo, OnmsCategory source) {
         OnmsNode node = getNode(uriInfo);
@@ -151,7 +143,7 @@ public class NodeCategoriesRestService extends AbstractNodeDependentRestService<
     }
 
     @Override
-    protected Response doUpdate(SecurityContext securityContext, UriInfo uriInfo, OnmsCategory targetObject, MultivaluedMapImpl params) {
+    protected Response doUpdateProperties(SecurityContext securityContext, UriInfo uriInfo, OnmsCategory targetObject, MultivaluedMapImpl params) {
         if (params.getFirst("name") != null) {
             throw getException(Status.BAD_REQUEST, "Cannot rename category.");
         }

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NodeIpInterfacesRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NodeIpInterfacesRestService.java
@@ -130,7 +130,7 @@ public class NodeIpInterfacesRestService extends AbstractNodeDependentRestServic
     }
 
     @Override
-    protected Response doUpdate(SecurityContext securityContext, UriInfo uriInfo, OnmsIpInterface targetObject, MultivaluedMapImpl params) {
+    protected Response doUpdateProperties(SecurityContext securityContext, UriInfo uriInfo, OnmsIpInterface targetObject, MultivaluedMapImpl params) {
         if (params.getFirst("ipAddress") != null) {
             throw getException(Status.BAD_REQUEST, "Cannot change the IP address.");
         }

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NodeMonitoredServiceRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NodeMonitoredServiceRestService.java
@@ -161,7 +161,7 @@ public class NodeMonitoredServiceRestService extends AbstractNodeDependentRestSe
     }
 
     @Override
-    protected Response doUpdate(SecurityContext securityContext, UriInfo uriInfo, OnmsMonitoredService targetObject, MultivaluedMapImpl params) {
+    protected Response doUpdateProperties(SecurityContext securityContext, UriInfo uriInfo, OnmsMonitoredService targetObject, MultivaluedMapImpl params) {
         final String previousStatus = targetObject.getStatus();
         RestUtils.setBeanProperties(targetObject, params);
         getDao().update(targetObject);

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NodeRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NodeRestService.java
@@ -218,7 +218,7 @@ public class NodeRestService extends AbstractDaoRestService<OnmsNode,SearchBean,
     }
 
     @Override
-    protected Response doUpdate(SecurityContext securityContext, UriInfo uriInfo, OnmsNode targetObject, MultivaluedMapImpl params) {
+    protected Response doUpdateProperties(SecurityContext securityContext, UriInfo uriInfo, OnmsNode targetObject, MultivaluedMapImpl params) {
         RestUtils.setBeanProperties(targetObject, params);
         getDao().update(targetObject);
         return Response.noContent().build();

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NodeSnmpInterfacesRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NodeSnmpInterfacesRestService.java
@@ -109,7 +109,7 @@ public class NodeSnmpInterfacesRestService extends AbstractNodeDependentRestServ
     }
 
     @Override
-    protected Response doUpdate(SecurityContext securityContext, UriInfo uriInfo, OnmsSnmpInterface targetObject, MultivaluedMapImpl params) {
+    protected Response doUpdateProperties(SecurityContext securityContext, UriInfo uriInfo, OnmsSnmpInterface targetObject, MultivaluedMapImpl params) {
         if (params.getFirst("ifIndex") != null) {
             throw getException(Status.BAD_REQUEST, "Cannot change ifIndex.");
         }

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/ScanReportRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/ScanReportRestService.java
@@ -38,6 +38,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
+import javax.ws.rs.core.SecurityContext;
 import javax.ws.rs.core.UriInfo;
 
 import org.opennms.core.config.api.JaxbListWrapper;
@@ -119,4 +120,14 @@ public class ScanReportRestService extends AbstractDaoRestService<ScanReport,Sca
     protected ScanReport doGet(UriInfo uriInfo, String id) {
         return getDao().get(id);
     }
+
+    @Override
+    protected Response doUpdate(final SecurityContext securityContext, final UriInfo uriInfo, final String key, ScanReport targetObject) {
+        if (!key.equals(targetObject.getId())) {
+            throw getException(Status.BAD_REQUEST, "The ID of the object doesn't match the ID of the path: {} != {}", targetObject.getId(), key);
+        }
+        getDao().saveOrUpdate(targetObject);
+        return Response.noContent().build();
+    }
+
 }


### PR DESCRIPTION
The `update()` function was mistakenly erased from `AbstractDaoRestServiceWithDTO` (previously known as `AbstractDaoRestService`) during the refactoring of the RESTv2 code that took place in preparation for the Helm enhancements. This was causing edits to the Minions, monitoring locations, and scan reports to fail via REST.

* JIRA: http://issues.opennms.org/browse/NMS-9608