### PR TITLE
NMS-9621: fix logging in the remote poller

### DIFF
--- a/features/remote-poller/src/main/resources/log4j2.xml
+++ b/features/remote-poller/src/main/resources/log4j2.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- WARN here is just for internal log4j messages and does not effect logging in general -->
 <configuration status="WARN" monitorInterval="60">
+  <Properties>
+    <Property name="poller.logfile">/var/log/opennms-remote-poller.log</Property>
+  </Properties>
+
   <appenders>
     <!--
      When running in headless mode, output the logs to both the console and the log file specified by the

--- a/opennms-assemblies/remote-poller-standalone/src/main/filtered/remote-poller.init
+++ b/opennms-assemblies/remote-poller-standalone/src/main/filtered/remote-poller.init
@@ -27,7 +27,7 @@ DESC="${install.package.description} Remote Poller"
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 PIDFILE="/var/run/$NAME.pid"
 OPENNMS_HOME="${install.dir}"
-JVM_ARGS="-Dpoller.logfile=/var/log/opennms-remote-poller.log"
+JVM_ARGS=""
 EXTRA_ARGS=""
 URI="http://localhost:8980/opennms-remoting"
 LOCATION="Default"

--- a/opennms-assemblies/remote-poller-standalone/src/main/filtered/remote-poller.init
+++ b/opennms-assemblies/remote-poller-standalone/src/main/filtered/remote-poller.init
@@ -53,7 +53,7 @@ fi
 if [ x$JAVA_EXE = x ]; then
 	if [ x$JAVA_HOME = x ] || [ ! -x "$JAVA_HOME/bin/java" ]; then
 		echo "ERROR: $JAVA_CONF file not found, and \$JAVA_HOME is not set to a valid JDK."
-		echo "Try running $OPENNMS_HOME/bin/runjava if ${opennms.package.description} is installed, or set JAVA_HOME in $CONFFILE."
+		echo "Try running $OPENNMS_HOME/bin/runjava if ${install.package.description} is installed, or set JAVA_HOME in $CONFFILE."
 		exit 1
 	else
 		JAVA_EXE="$JAVA_HOME/bin/java"


### PR DESCRIPTION
This PR fixes the logging in the remote poller package to work no matter how it is started (it relies on a system property that wasn't set in all code paths).

Also while testing this, I found a property-replacement bug in the init script that is fixed as well.

* JIRA: http://issues.opennms.org/browse/NMS-9621
