### PR TITLE
NMS-9406: Allow provisiond to perform reverse lookups without requiring an A record

### DIFF
--- a/opennms-provision/opennms-provisiond/src/main/java/org/opennms/netmgt/provision/service/DefaultHostnameResolver.java
+++ b/opennms-provision/opennms-provisiond/src/main/java/org/opennms/netmgt/provision/service/DefaultHostnameResolver.java
@@ -28,10 +28,33 @@
 
 package org.opennms.netmgt.provision.service;
 
+import org.opennms.core.utils.InetAddressUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.xbill.DNS.Address;
+
 import java.net.InetAddress;
+import java.net.UnknownHostException;
 
 public final class DefaultHostnameResolver implements HostnameResolver {
+    private static final Logger LOG = LoggerFactory.getLogger(DefaultHostnameResolver.class);
+
     @Override public String getHostname(final InetAddress addr) {
-        return addr.getCanonicalHostName();
+        // Attempt to retrieve the fully qualified domain name for this IP address
+        String hostName = addr.getCanonicalHostName();
+        if (InetAddressUtils.str(addr).equals(hostName)) {
+            // The given host name matches the textual representation of
+            // the IP address, which means that the reverse lookup failed
+            // NMS-9356: InetAddress#getCanonicalHostName requires PTR records
+            // to have a corresponding A record in order to succeed, so we
+            // try using dnsjava's implementation to work around this
+            try {
+                hostName = Address.getHostName(addr);
+            } catch (UnknownHostException e) {
+                LOG.warn("Failed to retrieve the fully qualified domain name for {}. "
+                        + "Using the textual representation of the IP address.", addr);
+            }
+        }
+        return hostName;
     }
 }

--- a/opennms-provision/opennms-provisiond/src/main/java/org/opennms/netmgt/provision/service/operations/SaveOrUpdateOperation.java
+++ b/opennms-provision/opennms-provisiond/src/main/java/org/opennms/netmgt/provision/service/operations/SaveOrUpdateOperation.java
@@ -29,6 +29,7 @@
 package org.opennms.netmgt.provision.service.operations;
 
 import java.net.InetAddress;
+import java.net.UnknownHostException;
 
 import org.opennms.core.utils.InetAddressUtils;
 import org.opennms.netmgt.model.OnmsCategory;
@@ -45,6 +46,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.BeanWrapper;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.PropertyAccessorFactory;
+import org.xbill.DNS.Address;
 
 public abstract class SaveOrUpdateOperation extends ImportOperation {
     private static final Logger LOG = LoggerFactory.getLogger(SaveOrUpdateOperation.class);
@@ -214,9 +216,25 @@ public abstract class SaveOrUpdateOperation extends ImportOperation {
         }
     }
 
-	private String reverseResolveHostname(String ipAddr) {
-		InetAddress addr = InetAddressUtils.addr(ipAddr);
-		return addr.getCanonicalHostName();
-	}
-    
+    private String reverseResolveHostname(final String ipAddr) {
+        final InetAddress addr = InetAddressUtils.addr(ipAddr);
+
+        // Attempt to retrieve the fully qualified domain name for this IP address
+        String hostName = addr.getCanonicalHostName();
+        if (InetAddressUtils.str(addr).equals(hostName)) {
+            // The given host name matches the textual representation of
+            // the IP address, which means that the reverse lookup failed
+            // NMS-9356: InetAddress#getCanonicalHostName requires PTR records
+            // to have a corresponding A record in order to succeed, so we
+            // try using dnsjava's implementation to work around this
+            try {
+                hostName = Address.getHostName(addr);
+            } catch (UnknownHostException e) {
+                LOG.warn("Failed to retrieve the fully qualified domain name for {}. "
+                        + "Using the textual representation of the IP address.", addr);
+            }
+        }
+        return hostName;
+    }
+
 }


### PR DESCRIPTION
JIRA: https://issues.opennms.org/browse/NMS-9406

This is a backport of [NMS-9356](https://issues.opennms.org/browse/NMS-9356) to foundation-2016.