### PR TITLE
NMS-9618: Fix the 'Quick Add Node' modal in the provisioning UI

### DIFF
--- a/opennms-webapp/src/main/webapp/admin/ng-requisitions/app/scripts/app.js
+++ b/opennms-webapp/src/main/webapp/admin/ng-requisitions/app/scripts/app.js
@@ -13,7 +13,8 @@
     'ngAnimate',
     'ui.bootstrap',
     'angular-growl',
-    'angular-loading-bar'
+    'angular-loading-bar',
+    'ngSanitize'
   ])
 
   .config(['$routeProvider', function ($routeProvider) {


### PR DESCRIPTION
JIRA: https://issues.opennms.org/browse/NMS-9618

Adds a missing dependency. Fixes a regression from NMS-9353.