### PR TITLE
NMS-9607: Allow use of %% as an escaped percent sign in eventconf

### DIFF
--- a/features/events/daemon/src/main/java/org/opennms/netmgt/eventd/processor/expandable/EventTemplate.java
+++ b/features/events/daemon/src/main/java/org/opennms/netmgt/eventd/processor/expandable/EventTemplate.java
@@ -91,7 +91,13 @@ public class EventTemplate implements ExpandableToken {
             tempInp = tempInp.substring(index1);
 
             index2 = tempInp.indexOf(PERCENT, 1);
-            if (index2 != -1) {
+            // If another % character is the next value
+            if (index2 == 1) {
+                tokens.add(new ExpandableConstant(PERCENT));
+                tempInp = tempInp.substring(index2 + 1);
+                LOG.debug("Escaped percent %% found in value");
+                continue;
+            } else if (index2 != -1) {
                 // Get the value between the %s
                 String parm = tempInp.substring(1, index2);
                 LOG.debug("parm: {} found in value", parm);

--- a/features/events/daemon/src/test/java/org/opennms/netmgt/eventd/EventUtilHibernateIT.java
+++ b/features/events/daemon/src/test/java/org/opennms/netmgt/eventd/EventUtilHibernateIT.java
@@ -105,6 +105,81 @@ public class EventUtilHibernateIT {
         assertEquals("testUei:2:node2:RDU", string2);
     }
 
+    /**
+     * <p>Requirements:</p>
+     * <ul>
+     * <li>'%%' will expand to a single percent sign in output.</li>
+     * <li>If whitespace is found before the expansion parameter is closed
+     *   (ie. %event uei%) then it is an invalid expansion parameter. The
+     *   leading percent sign is reproduced in the output and parsing
+     *   continues after its position.</li>
+     * <li>Percent signs that are unpaired by the time the end of input
+     *   is reached will be reproduced in the output.</li>
+     * </ul>
+     */
+    @Test
+    public void testExpansionStringWithPercentSign() {
+        // Escaped percent sign '%%'
+        String testString = "This string for %uei% has a %% sign in it.";
+        Event event1 = new EventBuilder("testUei", "testSource").getEvent();
+        String string1 = eventUtilDaoImpl.expandParms(testString, event1);
+        assertEquals("This string for testUei has a % sign in it.", string1);
+
+        // Escaped percent sign '%%' with trailing percent sign
+        testString = "This string for %uei% has a %%uei% sign in it.";
+        event1 = new EventBuilder("testUei", "testSource").getEvent();
+        string1 = eventUtilDaoImpl.expandParms(testString, event1);
+        assertEquals("This string for testUei has a %uei% sign in it.", string1);
+
+        // No whitespace with several escaped percent signs and trailing percent
+        testString = "%%uei%%%uei%%%%%uei%%%";
+        event1 = new EventBuilder("testUei", "testSource").getEvent();
+        string1 = eventUtilDaoImpl.expandParms(testString, event1);
+        assertEquals("%uei%testUei%%uei%%", string1);
+
+        // Single percent
+        testString = "%";
+        event1 = new EventBuilder("testUei", "testSource").getEvent();
+        string1 = eventUtilDaoImpl.expandParms(testString, event1);
+        assertEquals("%", string1);
+
+        // Parameter expansion with leading and trailing single percents
+        testString = "%This string for %uei% is 100% awesome.";
+        event1 = new EventBuilder("testUei", "testSource").getEvent();
+        string1 = eventUtilDaoImpl.expandParms(testString, event1);
+        assertEquals("%This string for testUei is 100% awesome.", string1);
+
+        // Parameter expansion with trailing single percent
+        testString = "This string for %uei% is 100% awesome.";
+        event1 = new EventBuilder("testUei", "testSource").getEvent();
+        string1 = eventUtilDaoImpl.expandParms(testString, event1);
+        assertEquals("This string for testUei is 100% awesome.", string1);
+
+        // No parameter expansion, 1 percent
+        testString = "This string is 100% awesome.";
+        event1 = new EventBuilder("testUei", "testSource").getEvent();
+        string1 = eventUtilDaoImpl.expandParms(testString, event1);
+        assertEquals("This string is 100% awesome.", string1);
+
+        // No parameter expansion, 2 percents with whitespace in between
+        testString = "This string is 100% awesome and 100% lame.";
+        event1 = new EventBuilder("testUei", "testSource").getEvent();
+        string1 = eventUtilDaoImpl.expandParms(testString, event1);
+        assertEquals("This string is 100% awesome and 100% lame.", string1);
+
+        // Parameter expansion with interstitial percent
+        testString = "This string for %uei% is 100% awesome even though it is %uei%.";
+        event1 = new EventBuilder("testUei", "testSource").getEvent();
+        string1 = eventUtilDaoImpl.expandParms(testString, event1);
+        assertEquals("This string for testUei is 100% awesome even though it is testUei.", string1);
+
+        // Percent sign at end of string without trailing whitespace
+        testString = "This string for %uei% is 100%awesomeAndCool";
+        event1 = new EventBuilder("testUei", "testSource").getEvent();
+        string1 = eventUtilDaoImpl.expandParms(testString, event1);
+        assertEquals("This string for testUei is 100%awesomeAndCool", string1);
+    }
+
     @Test
     public void testGetNodeLabel() {
     	String label = eventUtilDaoImpl.getNodeLabel(m_populator.getNode3().getId());

--- a/opennms-services/src/test/java/org/opennms/netmgt/notifd/BroadcastEventProcessorIT.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/notifd/BroadcastEventProcessorIT.java
@@ -109,7 +109,7 @@ public class BroadcastEventProcessorIT extends NotificationsITCase {
         bldr.setInterface(addr("0.0.0.0"));
         
         bldr.addParam("ds", "dsk-usr-pcent");
-        bldr.addParam("value", "Crap! There's only 15% free on the SAN and we need 20%! RUN AWAY!");
+        bldr.addParam("value", "Crap! RUN AWAY! We need 20% on the SAN and there's only 15");
         bldr.addParam("threshold", "");
         bldr.addParam("trigger", "");
         bldr.addParam("rearm", "");
@@ -135,7 +135,7 @@ public class BroadcastEventProcessorIT extends NotificationsITCase {
             System.out.println(entry.getKey() + " => " + entry.getValue());
         }
          */
-        assertEquals("High disk Threshold exceeded on 0.0.0.0, dsk-usr-pcent with Crap! There's only 15% free on the SAN and we need 20%! RUN AWAY!", paramMap.get("-tm"));
+        assertEquals("High disk Threshold exceeded on 0.0.0.0, dsk-usr-pcent with Crap! RUN AWAY! We need 20% on the SAN and there's only 15%", paramMap.get("-tm"));
         expandResult = NotificationManager.expandNotifParms("Notice #%noticeid%: Disk threshold exceeded on %nodelabel%: %parm[all]%.", paramMap);
         assertEquals("Notice #9999: Disk threshold exceeded on %nodelabel%: %parm[all]%.", expandResult);
     }

--- a/opennms-services/src/test/java/org/opennms/netmgt/notifd/NotifdIT.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/notifd/NotifdIT.java
@@ -88,12 +88,13 @@ public class NotifdIT extends NotificationsITCase {
         
         Date date = new Date();
         
-        long finished = anticipateNotificationsForGroup("High loadavg5 Threshold exceeded", "High loadavg5 Threshold exceeded on 192.168.1.1, loadavg5 with ", "InitialGroup", date, 0);
+        long finished = anticipateNotificationsForGroup("High loadavg5 Threshold exceeded", "High loadavg5 Threshold exceeded on 192.168.1.1, loadavg5 with 90%", "InitialGroup", date, 0);
 
         MockInterface iface = m_network.getInterface(1, "192.168.1.1");
         EventBuilder e = MockEventUtil.createInterfaceEventBuilder("test", EventConstants.HIGH_THRESHOLD_EVENT_UEI, iface);
         e.setTime(date);
         e.addParam("ds", "loadavg5");
+        e.addParam("value", "90");
         m_eventMgr.sendEventToListeners(e.getEvent());
         
         /*


### PR DESCRIPTION
Our eventconf files (and other files that use parm expansion, like the notification messages) assume that you can use '%%' as an escaped percent sign. However, this isn't supported but it was easy to add support for this that doesn't break any other parm expansion.

This probably wasn't noticed before because '%%' was evaluated as an invalid parm expansion and was simply erased in the output.

* JIRA: http://issues.opennms.org/browse/NMS-9607