### PR TITLE
HZN-1155: Add support for invoking notification strategies exposed via the service registry.

### DIFF
--- a/core/test-api/services/pom.xml
+++ b/core/test-api/services/pom.xml
@@ -46,5 +46,10 @@
       <artifactId>junit</artifactId>
       <scope>compile</scope>
     </dependency>
+    <dependency>
+      <groupId>org.opennms.features.notifications</groupId>
+      <artifactId>org.opennms.features.notifications.api</artifactId>
+      <scope>compile</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/features/notifications/api/pom.xml
+++ b/features/notifications/api/pom.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <parent>
+    <groupId>org.opennms.features</groupId>
+    <artifactId>org.opennms.features.notifications</artifactId>
+    <version>21.0.0-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.opennms.features.notifications</groupId>
+  <artifactId>org.opennms.features.notifications.api</artifactId>
+  <name>OpenNMS :: Features :: Notifications :: API</name>
+  <packaging>bundle</packaging>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
+            <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+            <Bundle-Version>${project.version}</Bundle-Version>
+          </instructions>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/features/notifications/api/src/main/java/org/opennms/netmgt/model/notifd/Argument.java
+++ b/features/notifications/api/src/main/java/org/opennms/netmgt/model/notifd/Argument.java
@@ -60,9 +60,9 @@ public class Argument {
     /**
      * Default constructor, initializes the members
      *
-     * @param aSwitch a {@link java.lang.String} object.
-     * @param sub a {@link java.lang.String} object.
-     * @param value a {@link java.lang.String} object.
+     * @param aSwitch a {@link String} object.
+     * @param sub a {@link String} object.
+     * @param value a {@link String} object.
      * @param streamed a boolean.
      */
     public Argument(String aSwitch, String sub, String value, boolean streamed) {

--- a/features/notifications/api/src/main/java/org/opennms/netmgt/model/notifd/NotificationStrategy.java
+++ b/features/notifications/api/src/main/java/org/opennms/netmgt/model/notifd/NotificationStrategy.java
@@ -30,26 +30,21 @@ package org.opennms.netmgt.model.notifd;
 
 import java.util.List;
 
-
 /**
  * Implement this interface as a Java notification "plug-in" for use with the
  * notficationCommands.xml file. Build a class using this interface, and in the
  * xml file set binary=false, and specify the class in the execute tag.
  *
  * @author <A HREF="mailto:david@opennms.org">David Hustace </A>
- *
- * TODO To change the template for this generated type comment go to Window -
- * Preferences - Java - Code Style - Code Templates
- * @version $Id: $
  */
 public interface NotificationStrategy {
 
     /**
      * <p>send</p>
      *
-     * @param arguments a {@link java.util.List} object.
+     * @param arguments a {@link List} object.
      * @return a int.
      */
-    public int send(List<Argument> arguments);
+    int send(List<Argument> arguments);
 
 }

--- a/features/notifications/pom.xml
+++ b/features/notifications/pom.xml
@@ -11,6 +11,7 @@
   <packaging>pom</packaging>
   <name>OpenNMS :: Features :: Notification</name>
   <modules>
+    <module>api</module>
     <module>ticket-strategy</module>
   </modules>
 </project>

--- a/opennms-config-model/src/main/java/org/opennms/netmgt/config/notificationCommands/Command.java
+++ b/opennms-config-model/src/main/java/org/opennms/netmgt/config/notificationCommands/Command.java
@@ -47,10 +47,13 @@ import org.opennms.netmgt.config.utils.ConfigUtils;
 @XmlAccessorType(XmlAccessType.FIELD)
 @ValidateUsing("notificationCommands.xsd")
 public class Command implements Serializable {
-    private static final long serialVersionUID = 2L;
+    private static final long serialVersionUID = 3L;
 
     @XmlAttribute(name = "binary")
     private Boolean m_binary;
+
+    @XmlAttribute(name = "service-registry")
+    private Boolean m_serviceRegistry;
 
     @XmlElement(name = "name", required = true)
     private String m_name;
@@ -75,6 +78,14 @@ public class Command implements Serializable {
 
     public void setBinary(final Boolean binary) {
         m_binary = binary;
+    }
+
+    public Boolean getServiceRegistry() {
+        return m_serviceRegistry != null ? m_serviceRegistry : Boolean.FALSE;
+    }
+
+    public void setServiceRegistry(final Boolean serviceRegistry) {
+        m_serviceRegistry = serviceRegistry;
     }
 
     public String getName() {
@@ -129,7 +140,8 @@ public class Command implements Serializable {
 
     @Override
     public int hashCode() {
-        return Objects.hash(m_binary, 
+        return Objects.hash(m_binary,
+                            m_serviceRegistry,
                             m_name, 
                             m_execute, 
                             m_comment, 
@@ -146,6 +158,7 @@ public class Command implements Serializable {
         if (obj instanceof Command) {
             final Command that = (Command)obj;
             return Objects.equals(this.m_binary, that.m_binary)
+                    && Objects.equals(this.m_serviceRegistry, that.m_serviceRegistry)
                     && Objects.equals(this.m_name, that.m_name)
                     && Objects.equals(this.m_execute, that.m_execute)
                     && Objects.equals(this.m_comment, that.m_comment)

--- a/opennms-config-model/src/main/resources/xsds/notificationCommands.xsd
+++ b/opennms-config-model/src/main/resources/xsds/notificationCommands.xsd
@@ -59,6 +59,7 @@
       </sequence>
 
       <attribute default="true" name="binary" type="boolean"/>
+      <attribute default="false" name="service-registry" type="boolean"/>
     </complexType>
   </element>
 

--- a/opennms-services/pom.xml
+++ b/opennms-services/pom.xml
@@ -214,6 +214,10 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
+      <groupId>org.opennms.features.notifications</groupId>
+      <artifactId>org.opennms.features.notifications.api</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.opennms.features.collection</groupId>
       <artifactId>org.opennms.features.collection.api</artifactId>
     </dependency>

--- a/opennms-services/src/main/java/org/opennms/netmgt/notifd/ServiceRegistryExecutor.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/notifd/ServiceRegistryExecutor.java
@@ -1,0 +1,87 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2017-2017 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.notifd;
+
+import org.opennms.core.soa.support.DefaultServiceRegistry;
+import org.opennms.netmgt.model.notifd.Argument;
+import org.opennms.netmgt.model.notifd.NotificationStrategy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.management.ManagementFactory;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+public class ServiceRegistryExecutor implements ExecutorStrategy {
+    private static final Logger LOG = LoggerFactory.getLogger(ServiceRegistryExecutor.class);
+
+    private static final DefaultServiceRegistry s_registry = DefaultServiceRegistry.INSTANCE;
+
+    private static final String GRACE_PERIOD_MS_SYS_PROP = "org.opennms.netmgt.notifd.notificationStrategyGracePeriodMs";
+    private static final int GRACE_PERIOD_MS = Integer.getInteger(GRACE_PERIOD_MS_SYS_PROP, 3*60*1000);
+    private static final int LOOKUP_DELAY_MS = 5*1000;
+
+    @Override
+    public int execute(String filter, List<Argument> arguments) {
+        LOG.debug("Searching for notification strategy matching filter: {}", filter);
+        final NotificationStrategy ns = getNotificationStrategy(filter);
+        if (ns == null) {
+            LOG.error("No notification strategy found matching filter: {}", filter);
+            return 1;
+        }
+        LOG.debug("Found notification strategy: {}", ns);
+        return ns.send(arguments);
+    }
+
+    private NotificationStrategy getNotificationStrategy(String filter) {
+        // Lookup
+        NotificationStrategy ns = s_registry.findProvider(NotificationStrategy.class, filter);
+        if (ns != null) {
+            return ns;
+        }
+
+        // A strategy matching the filter is not currently available.
+        // Wait until the system has finished starting up (uptime >= grace period)
+        // before aborting the search.
+        while (ManagementFactory.getRuntimeMXBean().getUptime() < GRACE_PERIOD_MS) {
+            try {
+                Thread.sleep(LOOKUP_DELAY_MS);
+            } catch (InterruptedException e) {
+                LOG.error("Interrupted while waiting for notification strategy to become available in the service registry. Aborting.");
+                return null;
+            }
+            ns = s_registry.findProvider(NotificationStrategy.class, filter);
+            if (ns != null) {
+                return ns;
+            }
+        }
+
+        return null;
+    }
+}

--- a/opennms-services/src/test/java/org/opennms/netmgt/notifd/ServiceRegistryExecutorTest.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/notifd/ServiceRegistryExecutorTest.java
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2017-2017 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.notifd;
+
+import org.junit.Test;
+import org.opennms.core.soa.support.DefaultServiceRegistry;
+import org.opennms.netmgt.model.notifd.NotificationStrategy;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+public class ServiceRegistryExecutorTest {
+
+    @Test
+    public void canFindServiceUsingFilter() {
+        NullNotificationStrategy strategy = new NullNotificationStrategy();
+        Map<String, String> props = new HashMap<>();
+        props.put("type", NullNotificationStrategy.class.getCanonicalName());
+        DefaultServiceRegistry.INSTANCE.register(strategy, props, NotificationStrategy.class);
+
+        ServiceRegistryExecutor executor = new ServiceRegistryExecutor();
+        int ret = executor.execute("(type=" + NullNotificationStrategy.class.getCanonicalName() + ")", Collections.emptyList());
+        assertEquals(0, ret);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -1886,6 +1886,11 @@
         <version>${project.version}</version>
       </dependency>
       <dependency>
+        <groupId>org.opennms.features.notifications</groupId>
+        <artifactId>org.opennms.features.notifications.api</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
         <groupId>org.opennms.features</groupId>
         <artifactId>org.opennms.features.mib-compiler</artifactId>
         <version>${project.version}</version>


### PR DESCRIPTION
JIRA: https://issues.opennms.org/browse/HZN-1155

Here create the `org.opennms.features.notifications/org.opennms.features.notifications.api` bundle with the minimal dependencies required for the `NotificationStrategy` interface and extend Notifd to support invoking implements via the service registry using commands of this form:
```
  <command service-registry="true">
     <execute>(type=org.opennms.netmgt.notifd.me.MyNotificationStrategy)</execute>
     ...
  </command>
```
