### PR TITLE
NMS-9108: Fix effective location when handling newSuspect events

### DIFF
--- a/opennms-provision/opennms-provisiond/src/main/java/org/opennms/netmgt/provision/service/Provisioner.java
+++ b/opennms-provision/opennms-provisiond/src/main/java/org/opennms/netmgt/provision/service/Provisioner.java
@@ -50,6 +50,7 @@ import org.opennms.core.tasks.TaskCoordinator;
 import org.opennms.core.utils.url.GenericURLFactory;
 import org.opennms.netmgt.config.api.SnmpAgentConfigFactory;
 import org.opennms.netmgt.daemon.SpringServiceDaemon;
+import org.opennms.netmgt.dao.api.MonitoringLocationDao;
 import org.opennms.netmgt.dao.api.MonitoringSystemDao;
 import org.opennms.netmgt.events.api.EventConstants;
 import org.opennms.netmgt.events.api.EventForwarder;
@@ -614,7 +615,7 @@ public class Provisioner implements SpringServiceDaemon {
             @Override
             public void run() {
                 try {
-                    InetAddress addr = addr(ip);
+                    final InetAddress addr = addr(ip);
                     if (addr == null) {
                     	LOG.error("Unable to convert {} to an InetAddress.", ip);
                     	return;
@@ -623,11 +624,16 @@ public class Provisioner implements SpringServiceDaemon {
                     final String location;
                     if (paramMap.containsKey("location")) {
                         location = paramMap.get("location");
-                    } else {
+                    } else if (event.getDistPoller() != null) {
                         location = monitoringSystemDao.get(event.getDistPoller()).getLocation();
+                    } else {
+                        location = MonitoringLocationDao.DEFAULT_MONITORING_LOCATION_ID;
                     }
 
-                    NewSuspectScan scan = createNewSuspectScan(addr, paramMap.get("foreignSource"), location);
+                    final String foreignSource = paramMap.get("foreignSource");
+                    LOG.debug("Triggering new suspect scan for: {} at location: {} with foreign source: {}.",
+                            addr, location, foreignSource);
+                    final NewSuspectScan scan = createNewSuspectScan(addr, foreignSource, location);
                     Task t = scan.createTask();
                     t.schedule();
                     t.waitFor();


### PR DESCRIPTION
JIRA: https://issues.opennms.org/browse/NMS-9108

The logic for determining the effective location when handling `newSuspect` events is now:
* Use the value of the location parameter if set
* Otherwise, use the source location of the event, if it is associated
  with a particular system
* Fallback to the using the default location
