### PR TITLE
NMS-9624: BSM daemon reload indicator

### DIFF
--- a/features/bsm/vaadin-adminpage/src/main/java/org/opennms/netmgt/bsm/vaadin/adminpage/BusinessServiceMainLayout.java
+++ b/features/bsm/vaadin-adminpage/src/main/java/org/opennms/netmgt/bsm/vaadin/adminpage/BusinessServiceMainLayout.java
@@ -40,6 +40,8 @@ import com.vaadin.ui.Alignment;
 import com.vaadin.ui.Button;
 import com.vaadin.ui.HorizontalLayout;
 import com.vaadin.ui.Label;
+import com.vaadin.ui.Notification;
+import com.vaadin.ui.Notification.Type;
 import com.vaadin.ui.TextField;
 import com.vaadin.ui.VerticalLayout;
 
@@ -117,6 +119,7 @@ public class BusinessServiceMainLayout extends VerticalLayout {
         // Reload daemon
         final Button reloadButton = UIHelper.createButton("Reload Daemon", "Reloads the Business Service State Machine", FontAwesome.RETWEET, (Button.ClickListener) event -> {
             m_businessServiceManager.triggerDaemonReload();
+            Notification.show("Reloading", "Business Service daemon is being reloaded.", Type.TRAY_NOTIFICATION);
         });
         reloadButton.setId("reloadButton");
 


### PR DESCRIPTION
This PR adds a visual indication (notification popup) when the reload daemon has been sent in the BSM admin UI.

* JIRA: http://issues.opennms.org/browse/NMS-9624

Our [continuous integration system](http://bamboo.internal.opennms.com:8085) will test and verify your changes.
