### PR TITLE
LTS-215: make sure an empty ncs directory is not created in core

### DIFF
--- a/tools/packages/opennms/opennms.spec
+++ b/tools/packages/opennms/opennms.spec
@@ -726,6 +726,7 @@ rm -rf $RPM_BUILD_ROOT
 
 %files core -f %{_tmppath}/files.main
 %defattr(664 root root 775)
+%exclude %dir %{instprefix}/etc/drools-engine.d/ncs
 %attr(755,root,root)	%{profiledir}/%{name}.sh
 %attr(755,root,root)	%{logdir}
 %attr(640,root,root)	%config(noreplace) %{instprefix}/etc/users.xml
@@ -750,6 +751,7 @@ rm -rf $RPM_BUILD_ROOT
 %defattr(644 root root 755)
 %{instprefix}/lib/ncs-*.jar
 %{jettydir}/%{servletdir}/WEB-INF/lib/ncs-*
+%dir %{instprefix}/etc/drools-engine.d/ncs
 %config(noreplace) %{instprefix}/etc/drools-engine.d/ncs/*
 %config(noreplace) %{instprefix}/etc/ncs-northbounder-configuration.xml
 %{sharedir}/xsds/ncs-*.xsd


### PR DESCRIPTION
This PR fixes the RPMs to not create the drools ncs directory in the main (core) RPM, but to leave it to the NCS package.

* JIRA: http://issues.opennms.org/browse/LTS-215

Our [continuous integration system](http://bamboo.internal.opennms.com:8085) will test and verify your changes.
