### PR TITLE
NMS-9498: The button to add a graph to a KSC report doesn't work

### DIFF
--- a/opennms-webapp/src/main/webapp/WEB-INF/jsp/graph/results.jsp
+++ b/opennms-webapp/src/main/webapp/WEB-INF/jsp/graph/results.jsp
@@ -161,7 +161,7 @@
 
 <c:set var="showFootnote1" value="false"/>
 
-<div class="row">
+<div class="row" ng-app="onms-ksc" ng-controller="AddToKscCtrl">
 
 	<div class="col-md-10">
 	<c:forEach var="resultSet" items="${results.graphResultSets}">
@@ -200,7 +200,7 @@
             </c:if>
         </h3>
      </div> <!-- panel-heading -->
-     <div class="panel-body" ng-app="onms-ksc" ng-controller="AddToKscCtrl">
+     <div class="panel-body">
         <div growl></div>
         <!-- NRTG Starter script 'window'+resourceId+report -->
         <script type="text/javascript">


### PR DESCRIPTION
The button to add a graph to a KSC report doesn't work.

* JIRA: http://issues.opennms.org/browse/NMS-9498

Our [continuous integration system](http://bamboo.internal.opennms.com:8085) will test and verify your changes.

Fortunately, an easy fix. I tested the solution on my lab.