### PR TITLE
NMS-9604: Fix Scan Report log formatting

### DIFF
--- a/features/poller/remote/src/main/java/org/opennms/netmgt/poller/remote/support/Log4j2StringAppender.java
+++ b/features/poller/remote/src/main/java/org/opennms/netmgt/poller/remote/support/Log4j2StringAppender.java
@@ -56,7 +56,9 @@ public class Log4j2StringAppender extends AbstractOutputStreamAppender<Log4j2Str
 	private final static Configuration LOGGER_CONTEXT_CONFIGURATION = LOGGER_CONTEXT.getConfiguration();
 
 	/**
-	 * Create an appender with {@link PatternLayout#createDefaultLayout()} as the layout.
+	 * <p>Create an appender with the following pattern as the layout (to match our log file layout):</p>
+	 * 
+	 * {@code %d %-5p [%t] %c{1.}: %m%n}
 	 * 
 	 * @param name
 	 * @param filter
@@ -64,7 +66,7 @@ public class Log4j2StringAppender extends AbstractOutputStreamAppender<Log4j2Str
 	 * @param immediateFlush
 	 */
 	private Log4j2StringAppender(String name, Filter filter, boolean ignoreExceptions, boolean immediateFlush) {
-		this(name, PatternLayout.createDefaultLayout(), filter, ignoreExceptions, immediateFlush);
+		this(name, PatternLayout.newBuilder().withPattern("%d %-5p [%t] %c{1.}: %m%n").build(), filter, ignoreExceptions, immediateFlush);
 	}
 
 	/**

--- a/features/poller/remote/src/test/java/org/opennms/netmgt/poller/remote/support/Log4j2StringAppenderTest.java
+++ b/features/poller/remote/src/test/java/org/opennms/netmgt/poller/remote/support/Log4j2StringAppenderTest.java
@@ -28,7 +28,7 @@
 
 package org.opennms.netmgt.poller.remote.support;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
@@ -55,6 +55,6 @@ public class Log4j2StringAppenderTest {
         }
 
         // Verify that the log message was successfully captured
-        assertEquals("w00t\n", appender.getOutput());
+        assertTrue("Output did not contain test log message", appender.getOutput().contains("o.o.n.p.r.s.Log4j2StringAppenderTest: w00t"));
     }
 }


### PR DESCRIPTION
This PR makes the log format for Scan Reports the same as all of the normal logging so that timestamps and logger names are included.

* JIRA: http://issues.opennms.org/browse/NMS-9604