### PR TITLE
NMS-9457: Escape some HTTP params

### DIFF
--- a/opennms-webapp/src/main/java/org/opennms/web/controller/alarm/AlarmFilterController.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/controller/alarm/AlarmFilterController.java
@@ -158,7 +158,16 @@ public class AlarmFilterController extends MultiActionController implements Init
     }
 
     private String getDisplay(HttpServletRequest request) {
-        return request.getParameter("display");
+        // handle the display parameter
+        String displayString = request.getParameter("display");
+        String display = null;
+        if (displayString != null) {
+            String temp = WebSecurityUtils.sanitizeString(displayString);
+            if (temp != null) {
+                display = temp;
+            }
+        }
+        return display;
     }
 
     private int getLimit(HttpServletRequest request) {

--- a/opennms-webapp/src/main/java/org/opennms/web/controller/statisticsReports/ReportController.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/controller/statisticsReports/ReportController.java
@@ -57,10 +57,14 @@ public class ReportController extends AbstractCommandController implements Initi
         StatisticsReportCommand command = (StatisticsReportCommand) cmd;
 
         try {
-        	StatisticsReportModel report = m_statisticsReportService.getReport(command, errors);
-            return new ModelAndView(getSuccessView(), "model", report);
+            StatisticsReportModel report = m_statisticsReportService.getReport(command, errors);
+            if (report == null) {
+                throw new StatisticsReportIdNotFoundException("No such report ID", command.getId().toString());
+            } else {
+                return new ModelAndView(getSuccessView(), "model", report);
+            }
         } catch (org.springframework.orm.hibernate3.HibernateObjectRetrievalFailureException horfe) {
-        	throw new StatisticsReportIdNotFoundException("No such report ID", command.getId().toString());
+            throw new StatisticsReportIdNotFoundException("No such report ID", command.getId().toString());
         }
     }
 

--- a/opennms-webapp/src/main/java/org/opennms/web/tags/filters/AbstractFilterCallback.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/tags/filters/AbstractFilterCallback.java
@@ -103,9 +103,12 @@ public abstract class AbstractFilterCallback implements FilterCallback {
         if (parameters.getDisplay() != null) {
             buffer.append("&amp;display=").append(parameters.getDisplay());
         }
-        buffer.append("&amp;").append(toFilterString(parameters.getFilters()));
+        String filters = toFilterString(parameters.getFilters());
+        if (filters != null && filters.length() > 0) {
+            buffer.append("&amp;").append(filters);
+        }
         if (favorite != null) {
-            buffer.append("&favoriteId=" + favorite.getId());
+            buffer.append("&amp;favoriteId=" + favorite.getId());
         }
         return (buffer.toString());
     }

--- a/opennms-webapp/src/main/webapp/WEB-INF/jsp/alarm/list.jsp
+++ b/opennms-webapp/src/main/webapp/WEB-INF/jsp/alarm/list.jsp
@@ -105,6 +105,10 @@
   <jsp:param name="breadcrumb" value="List" />
 </jsp:include>
 
+<c:url var="alarmListLink" value="alarm/list">
+  <c:param name="display" value="<%=parms.getDisplay()%>"/>
+</c:url>
+
   <script type="text/javascript">
     function checkAllCheckboxes() {
        if( document.alarm_action_form.alarm.length ) {  
@@ -199,7 +203,7 @@
     }
 
     function changeFavorite(favoriteId, filter) {
-        window.location.href = "<%=req.getContextPath()%>/alarm/list?display=<%=parms.getDisplay()%>&favoriteId=" + favoriteId + '&' + filter;
+        window.location.href = "<%=req.getContextPath()%>/${alarmListLink}&favoriteId=" + favoriteId + '&' + filter;
     }
 
   </script>

--- a/opennms-webapp/src/main/webapp/errors/statisticsreportidnotfound.jsp
+++ b/opennms-webapp/src/main/webapp/errors/statisticsreportidnotfound.jsp
@@ -60,7 +60,7 @@
 <h1>Statistics Report ID Not Found</h1>
     
 <p>
-  A statistics report could not be found for the identifier <%=e.getBadID()%>.
+  A statistics report could not be found for the identifier <c:out value="<%=e.getBadID()%>"/>.
 </p>
 
 <p>


### PR DESCRIPTION
This fixes some parameter escaping on the alarm list and the statistics report list.

* JIRA: http://issues.opennms.org/browse/NMS-9457