### PR TITLE
NMS-9468: vacuumd config for service cleanup

### DIFF
--- a/opennms-base-assembly/src/main/filtered/etc/vacuumd-configuration.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/vacuumd-configuration.xml
@@ -74,6 +74,9 @@
                 trigger-name="selectPathOutagesNodes"
                 action-name="clearPathOutages" />
 
+    <automation name="deleteUnassignedServices" interval="3600000" active="true"
+                action-name="deleteUnassignedServices" />
+
     <!-- Enable these automation for automatic Trouble Ticketing -->
     <automation name="createTickets" interval="30000" active="false" 
                 trigger-name="selectNullTicketStateAlarms" 
@@ -438,6 +441,17 @@
          WHERE eventuei = 'uei.opennms.org/nodes/pathOutage'
            AND nodeid = ${_nodeid}
            AND lasteventtime &lt;= ${_eventtime_from_node_up}
+      </statement>
+    </action>
+
+    <action name="deleteUnassignedServices" >
+      <statement>
+        DELETE from service a
+         WHERE a.serviceid in (
+        SELECT a.serviceid from service a
+     LEFT JOIN ifservices b
+            ON a.serviceid = b.serviceid
+         WHERE b.serviceid is null)
       </statement>
     </action>
 


### PR DESCRIPTION
A cleanup job to remove unassigned services. See https://issues.opennms.org/browse/NMS-9468

In my system it works fine and I don't get any issues because of this config. But please make sure, that the entries the automation deletes, aren't required for anything else.