### PR TITLE
NMS-9653: undo NMS-9497 and set to 1+2 respectively

### DIFF
--- a/core/schema/src/main/liquibase/foundation-2017/changelog.xml
+++ b/core/schema/src/main/liquibase/foundation-2017/changelog.xml
@@ -20,4 +20,23 @@
     </rollback>
   </changeSet>
 
+  <!-- NMS-9653: undo NMS-9497 and set to 1+2 respectively -->
+  <changeSet author="ranger" id="foundation2017-bsm-service-problem-type">
+    <update tableName="alarms">
+      <column name="alarmtype" value="1" />
+      <where>eventuei='uei.opennms.org/bsm/serviceProblem'</where>
+    </update>
+    <update tableName="alarms">
+      <column name="alarmtype" value="2" />
+      <where>eventuei='uei.opennms.org/bsm/serviceProblemResolved'</where>
+    </update>
+
+    <rollback>
+      <update tableName="alarms">
+        <column name="alarmtype" value="3" />
+	<where>eventuei='uei.opennms.org/bsm/serviceProblem' OR eventuei='uei.opennms.org/bsm/serviceProblemResolved'</where>
+      </update>
+    </rollback>
+  </changeSet>
+
 </databaseChangeLog>

--- a/opennms-base-assembly/src/main/filtered/etc/events/opennms.events.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/events/opennms.events.xml
@@ -2052,7 +2052,7 @@
     </descr>
     <logmsg dest="logndisplay">One or more problems are affecting business service '%parm[businessServiceName]%'.</logmsg>
     <severity>Indeterminate</severity>
-    <alarm-data reduction-key="%uei%:%parm[businessServiceId]%" alarm-type="3" auto-clean="false">
+    <alarm-data reduction-key="%uei%:%parm[businessServiceId]%" alarm-type="1" auto-clean="false">
       <update-field field-name="severity" update-on-reduction="true"/>
     </alarm-data>
   </event>
@@ -2064,7 +2064,7 @@
     </descr>
     <logmsg dest="logndisplay">The problems affecting business service '%parm[businessServiceName]%' have been resolved.</logmsg>
     <severity>Indeterminate</severity>
-    <alarm-data reduction-key="uei.opennms.org/bsm/serviceProblem:%parm[businessServiceId]%" alarm-type="3" auto-clean="false">
+    <alarm-data reduction-key="uei.opennms.org/bsm/serviceProblem:%parm[businessServiceId]%" alarm-type="2" auto-clean="false">
       <update-field field-name="severity" update-on-reduction="true"/>
     </alarm-data>
   </event>


### PR DESCRIPTION
After further discussion, it was decided to set alarm-type on `uei.opennms.org/bsm/serviceProblem` and `uei.opennms.org/bsm/serviceProblemResolved` to 1 and 2, respectively.

* JIRA: http://issues.opennms.org/browse/NMS-9653

Our [continuous integration system](http://bamboo.internal.opennms.com:8085) will test and verify your changes.
