### PR TITLE
Get rid of separate minionKarafVersion in favor of karafVersion

### DIFF
--- a/features/minion/container/extender/pom.xml
+++ b/features/minion/container/extender/pom.xml
@@ -39,12 +39,12 @@
         <dependency>
             <groupId>org.apache.karaf.features</groupId>
             <artifactId>org.apache.karaf.features.core</artifactId>
-            <version>${minionKarafVersion}</version>
+            <version>${karafVersion}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.karaf.config</groupId>
             <artifactId>org.apache.karaf.config.core</artifactId>
-            <version>${minionKarafVersion}</version>
+            <version>${karafVersion}</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/features/minion/container/karaf/pom.xml
+++ b/features/minion/container/karaf/pom.xml
@@ -150,7 +150,7 @@
                 in etc/org.apache.karaf.features.cfg file -->
             <groupId>org.apache.karaf.features</groupId>
             <artifactId>framework</artifactId>
-            <version>${minionKarafVersion}</version>
+            <version>${karafVersion}</version>
             <type>kar</type>
         </dependency>
         <dependency>
@@ -159,7 +159,7 @@
                 the plugin configuration -->
             <groupId>org.apache.karaf.features</groupId>
             <artifactId>standard</artifactId>
-            <version>${minionKarafVersion}</version>
+            <version>${karafVersion}</version>
             <classifier>features</classifier>
             <type>xml</type>
             <scope>runtime</scope>
@@ -170,7 +170,7 @@
                 the plugin configuration -->
             <groupId>org.apache.karaf.features</groupId>
             <artifactId>spring</artifactId>
-            <version>${minionKarafVersion}</version>
+            <version>${karafVersion}</version>
             <classifier>features</classifier>
             <type>xml</type>
             <scope>runtime</scope>

--- a/features/minion/container/karaf/src/main/filtered-resources/etc/branding-ssh.properties
+++ b/features/minion/container/karaf/src/main/filtered-resources/etc/branding-ssh.properties
@@ -36,7 +36,7 @@
   \u001B[36m    | | |||   |||   ||   |      \u001B[0m\r\n\
   \u001B[36m    ` ' '``   '``---'`   '      \u001B[0m\r\n\
   \r\n\
-  \u001B[1m  OpenNMS Minion \u001B[0m(${project.version}) on Apache Karaf (${minionKarafVersion})\r\n\
+  \u001B[1m  OpenNMS Minion \u001B[0m(${project.version}) on Apache Karaf (${karafVersion})\r\n\
   \r\n\
   Hit '\u001B[1m<tab>\u001B[0m' for a list of available commands\r\n\
      and '\u001B[1m[cmd] --help\u001B[0m' for help on a specific command.\r\n\

--- a/features/minion/container/karaf/src/main/filtered-resources/etc/branding.properties
+++ b/features/minion/container/karaf/src/main/filtered-resources/etc/branding.properties
@@ -36,7 +36,7 @@
   \u001B[36m    | | |||   |||   ||   |      \u001B[0m\r\n\
   \u001B[36m    ` ' '``   '``---'`   '      \u001B[0m\r\n\
   \r\n\
-  \u001B[1m  OpenNMS Minion \u001B[0m(${project.version}) on Apache Karaf (${minionKarafVersion})\r\n\
+  \u001B[1m  OpenNMS Minion \u001B[0m(${project.version}) on Apache Karaf (${karafVersion})\r\n\
   \r\n\
   Hit '\u001B[1m<tab>\u001B[0m' for a list of available commands\r\n\
      and '\u001B[1m[cmd] --help\u001B[0m' for help on a specific command.\r\n\

--- a/features/minion/core/repository/pom.xml
+++ b/features/minion/core/repository/pom.xml
@@ -26,8 +26,8 @@
                         <configuration>
                             <descriptors>
                                 <!-- Default repositories -->
-                                <descriptor>mvn:org.apache.karaf.features/standard/${minionKarafVersion}/xml/features</descriptor>
-                                <descriptor>mvn:org.apache.karaf.features/spring/${minionKarafVersion}/xml/features</descriptor>
+                                <descriptor>mvn:org.apache.karaf.features/standard/${karafVersion}/xml/features</descriptor>
+                                <descriptor>mvn:org.apache.karaf.features/spring/${karafVersion}/xml/features</descriptor>
                                 <!-- Add Minion features -->
                                 <descriptor>mvn:org.opennms.features.minion/core-features/${project.version}/xml</descriptor>
                             </descriptors>

--- a/features/minion/core/shell/pom.xml
+++ b/features/minion/core/shell/pom.xml
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>org.apache.karaf.shell</groupId>
             <artifactId>org.apache.karaf.shell.console</artifactId>
-            <version>${minionKarafVersion}</version>
+            <version>${karafVersion}</version>
         </dependency>
     </dependencies>
 </project>

--- a/features/minion/pom.xml
+++ b/features/minion/pom.xml
@@ -25,7 +25,7 @@
                 <plugin>
                     <groupId>org.apache.karaf.tooling</groupId>
                     <artifactId>karaf-maven-plugin</artifactId>
-                    <version>${minionKarafVersion}</version>
+                    <version>${karafVersion}</version>
                     <extensions>true</extensions>
                 </plugin>
             </plugins>

--- a/features/minion/repository/pom.xml
+++ b/features/minion/repository/pom.xml
@@ -29,8 +29,8 @@
                         </goals>
                         <configuration>
                             <descriptors>
-                                <descriptor>mvn:org.apache.karaf.features/standard/${minionKarafVersion}/xml/features</descriptor>
-                                <descriptor>mvn:org.apache.karaf.features/spring/${minionKarafVersion}/xml/features</descriptor>
+                                <descriptor>mvn:org.apache.karaf.features/standard/${karafVersion}/xml/features</descriptor>
+                                <descriptor>mvn:org.apache.karaf.features/spring/${karafVersion}/xml/features</descriptor>
                                 <!-- Add OpenNMS features -->
                                 <descriptor>mvn:org.opennms.karaf/opennms/${project.version}/xml/features</descriptor>
                                 <!-- Add Minion features -->

--- a/features/minion/shell/collection/pom.xml
+++ b/features/minion/shell/collection/pom.xml
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>org.apache.karaf.shell</groupId>
             <artifactId>org.apache.karaf.shell.console</artifactId>
-            <version>${minionKarafVersion}</version>
+            <version>${karafVersion}</version>
         </dependency>
         <dependency>
             <groupId>org.opennms.features.collection</groupId>

--- a/features/minion/shell/poller/pom.xml
+++ b/features/minion/shell/poller/pom.xml
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>org.apache.karaf.shell</groupId>
             <artifactId>org.apache.karaf.shell.console</artifactId>
-            <version>${minionKarafVersion}</version>
+            <version>${karafVersion}</version>
         </dependency>
         <dependency>
             <groupId>org.opennms.features.poller</groupId>

--- a/features/minion/shell/provision/pom.xml
+++ b/features/minion/shell/provision/pom.xml
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>org.apache.karaf.shell</groupId>
             <artifactId>org.apache.karaf.shell.console</artifactId>
-            <version>${minionKarafVersion}</version>
+            <version>${karafVersion}</version>
         </dependency>
     </dependencies>
 </project>

--- a/features/scv/shell/pom.xml
+++ b/features/scv/shell/pom.xml
@@ -39,7 +39,7 @@
         <dependency>
             <groupId>org.apache.karaf.shell</groupId>
             <artifactId>org.apache.karaf.shell.console</artifactId>
-            <version>${minionKarafVersion}</version>
+            <version>${karafVersion}</version>
         </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1332,7 +1332,6 @@
     <log4j2Version>2.8.2</log4j2Version>
     <mapstructVersion>1.2.0.CR1</mapstructVersion>
     <minaVersion>2.0.16</minaVersion>
-    <minionKarafVersion>${karafVersion}</minionKarafVersion>
     <netty4Version>4.1.9.Final</netty4Version>
     <newtsVersion>1.4.3</newtsVersion>
     <paxExamVersion>4.9.2</paxExamVersion>


### PR DESCRIPTION
This was a minor commit as part of my Karaf 4.1 upgrade branch but I think it should be merged separately since it reduces the number of files touched in the Karaf 4.1 upgrade branch.

* JIRA: http://issues.opennms.org/browse/HZN-1092