### PR TITLE
NMS-9660: trapd may silently discard invalid traps

### DIFF
--- a/features/events/traps/src/main/java/org/opennms/netmgt/trapd/TrapListener.java
+++ b/features/events/traps/src/main/java/org/opennms/netmgt/trapd/TrapListener.java
@@ -71,7 +71,12 @@ public class TrapListener implements TrapNotificationListener {
     @Override
     public void trapReceived(TrapInformation trapInformation) {
         try {
-            getMessageDispatcher().send(new TrapInformationWrapper(trapInformation));
+            getMessageDispatcher().send(new TrapInformationWrapper(trapInformation))
+                    .whenComplete((t,ex) -> {
+                        if (ex != null) {
+                            LOG.error("An error occured while forwarding trap {} for further processing. The trap will be dropped.", trapInformation, ex);
+                        }
+                    });
         } catch (IllegalArgumentException ex) {
             LOG.error("Received trap {} is not valid and cannot be processed.", trapInformation, ex);
         }

--- a/features/events/traps/src/main/java/org/opennms/netmgt/trapd/TrapListener.java
+++ b/features/events/traps/src/main/java/org/opennms/netmgt/trapd/TrapListener.java
@@ -75,10 +75,14 @@ public class TrapListener implements TrapNotificationListener {
                     .whenComplete((t,ex) -> {
                         if (ex != null) {
                             LOG.error("An error occured while forwarding trap {} for further processing. The trap will be dropped.", trapInformation, ex);
+                            // This trap will never reach the sink consumer
+                            TrapSinkConsumer.trapdInstrumentation.incErrorCount();
                         }
                     });
         } catch (IllegalArgumentException ex) {
-            LOG.error("Received trap {} is not valid and cannot be processed.", trapInformation, ex);
+            LOG.error("Received trap {} is not valid and cannot be processed. The trap will be dropped.", trapInformation, ex);
+            // This trap will never reach the sink consumer
+            TrapSinkConsumer.trapdInstrumentation.incErrorCount();
         }
     }
 

--- a/features/events/traps/src/main/java/org/opennms/netmgt/trapd/jmx/TrapdInstrumentation.java
+++ b/features/events/traps/src/main/java/org/opennms/netmgt/trapd/jmx/TrapdInstrumentation.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2016-2016 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2016 The OpenNMS Group, Inc.
+ * Copyright (C) 2016-2017 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -31,65 +31,67 @@ package org.opennms.netmgt.trapd.jmx;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.concurrent.atomic.AtomicLong;
+
 public class TrapdInstrumentation {
 
     private static final Logger LOG = LoggerFactory.getLogger(TrapdInstrumentation.class);
 
-    private long trapsReceived = 0;
-    private long v1TrapsReceived = 0;
-    private long v2cTrapsReceived = 0;
-    private long v3TrapsReceived = 0;
-    private long vUnknownTrapsReceived = 0;
-    private long trapsDiscarded = 0;
-    private long trapsErrored = 0;
+    private final AtomicLong trapsReceived = new AtomicLong();
+    private final AtomicLong v1TrapsReceived = new AtomicLong();
+    private final AtomicLong v2cTrapsReceived = new AtomicLong();
+    private final AtomicLong v3TrapsReceived = new AtomicLong();
+    private final AtomicLong vUnknownTrapsReceived = new AtomicLong();
+    private final AtomicLong trapsDiscarded = new AtomicLong();
+    private final AtomicLong trapsErrored = new AtomicLong();
 
-    synchronized public void incTrapsReceivedCount(String version) {
-        trapsReceived++;
+    public void incTrapsReceivedCount(String version) {
+        trapsReceived.incrementAndGet();
         if ("v1".equals(version)) {
-            v1TrapsReceived++;
+            v1TrapsReceived.incrementAndGet();
         } else if ("v2c".equals(version) || "v2".equals(version)) {
-            v2cTrapsReceived++;
+            v2cTrapsReceived.incrementAndGet();
         } else if ("v3".equals(version)) {
-            v3TrapsReceived++;
+            v3TrapsReceived.incrementAndGet();
         } else {
-            vUnknownTrapsReceived++;
-            LOG.warn("Received a trap with an unknown SNMP protocol version '{}'", version);
+            vUnknownTrapsReceived.incrementAndGet();
+            LOG.warn("Received a trap with an unknown SNMP protocol version '{}'.", version);
         }
     }
 
-    synchronized public void incDiscardCount() {
-        trapsDiscarded++;
+    public void incDiscardCount() {
+        trapsDiscarded.incrementAndGet();
     }
 
-    synchronized public void incErrorCount() {
-        trapsErrored++;
+    public void incErrorCount() {
+        trapsErrored.incrementAndGet();
     }
 
     public long getV1TrapsReceived() {
-        return v1TrapsReceived;
+        return v1TrapsReceived.get();
     }
 
     public long getV2cTrapsReceived() {
-        return v2cTrapsReceived;
+        return v2cTrapsReceived.get();
     }
 
     public long getV3TrapsReceived() {
-        return v3TrapsReceived;
+        return v3TrapsReceived.get();
     }
 
     public long getVUnknownTrapsReceived() {
-        return vUnknownTrapsReceived;
+        return vUnknownTrapsReceived.get();
     }
 
     public long getTrapsDiscarded() {
-        return trapsDiscarded;
+        return trapsDiscarded.get();
     }
 
     public long getTrapsErrored() {
-        return trapsErrored;
+        return trapsErrored.get();
     }
 
     public long getTrapsReceived() {
-        return trapsReceived;
+        return trapsReceived.get();
     }
 }


### PR DESCRIPTION
JIRA: https://issues.opennms.org/browse/NMS-9660

Log any errors that occur from asynchronously sending the traps via the Sink dispatcher and update the error counters accordingly.

Also, refactored the counters to use atomics to avoid unnecessary locks.

