### PR TITLE
NMS-9385: move netmask to the ipinterface table

### DIFF
--- a/core/schema/src/main/liquibase/21.0.0/changelog.xml
+++ b/core/schema/src/main/liquibase/21.0.0/changelog.xml
@@ -95,4 +95,21 @@
     </preConditions>
     <dropColumn tableName="events" columnName="eventparms"/>
   </changeSet>
+
+  <changeSet id="21.0.0-move-netmask-to-ipinterface" author="rangerrick">
+    <addColumn tableName="ipinterface">
+      <column name="netmask" type="character varying(45)" />
+    </addColumn>
+    <sql>
+      UPDATE ipinterface
+        SET netmask=snmpipadentnetmask
+      FROM ipinterface I
+      INNER JOIN snmpinterface S
+        ON I.nodeid=S.nodeid
+        AND I.snmpinterfaceid=S.id
+    </sql>
+    <dropColumn tableName="snmpinterface" columnName="snmpipadentnetmask" />
+  </changeSet>
+
+
 </databaseChangeLog>

--- a/core/test-api/rest/src/main/java/org/opennms/core/test/rest/AbstractSpringJerseyRestJsonTestCase.java
+++ b/core/test-api/rest/src/main/java/org/opennms/core/test/rest/AbstractSpringJerseyRestJsonTestCase.java
@@ -106,6 +106,7 @@ public abstract class AbstractSpringJerseyRestJsonTestCase extends AbstractSprin
         ipInterface.put("isManaged", "M");
         ipInterface.put("snmpPrimary", "P");
         ipInterface.put("ipAddress", "10.10.10.10");
+        ipInterface.put("netMask", "255.255.255.0");
         ipInterface.put("hostName", "TestMachine");
         ipInterface.put("ipStatus", "1");
         sendPost("/nodes/1/ipinterfaces", ipInterface.toString(), 303, "/nodes/1/ipinterfaces/10.10.10.10");
@@ -122,7 +123,6 @@ public abstract class AbstractSpringJerseyRestJsonTestCase extends AbstractSprin
         snmpInterface.put("ifOperStatus", "1");
         snmpInterface.put("ifSpeed", "10000000");
         snmpInterface.put("ifType", "6");
-        snmpInterface.put("netMask", "255.255.255.0");
         snmpInterface.put("physAddr", "001e5271136d");
         sendPost("/nodes/1/snmpinterfaces", snmpInterface.toString(), 303, "/nodes/1/snmpinterfaces/6");
     }

--- a/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.linkd/src/main/java/org/opennms/features/topology/plugins/topo/linkd/internal/EnhancedLinkdTopologyProvider.java
+++ b/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.linkd/src/main/java/org/opennms/features/topology/plugins/topo/linkd/internal/EnhancedLinkdTopologyProvider.java
@@ -38,6 +38,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.apache.commons.lang.StringUtils;
 import org.opennms.core.utils.InetAddressUtils;
@@ -1161,13 +1162,21 @@ public class EnhancedLinkdTopologyProvider extends AbstractLinkdTopologyProvider
 
         tooltipText.append(HTML_TOOLTIP_TAG_OPEN);
         tooltipText.append(linkDetail.getType());
-        if (sourceInterface != null && targetInterface != null
-                && sourceInterface.getNetMask() != null && !sourceInterface.getNetMask().isLoopbackAddress()
-                && targetInterface.getNetMask() != null && !targetInterface.getNetMask().isLoopbackAddress()) {
-            tooltipText.append(" Layer3/Layer2");
-        } else {
-            tooltipText.append(" Layer2");
+        String layerText = " Layer 2";
+        if (sourceInterface != null && targetInterface != null) {
+            final List<OnmsIpInterface> sourceNonLoopback = sourceInterface.getIpInterfaces().stream().filter(iface -> {
+                return !iface.getNetMask().isLoopbackAddress();
+            }).collect(Collectors.toList());
+            final List<OnmsIpInterface> targetNonLoopback = targetInterface.getIpInterfaces().stream().filter(iface -> {
+                return !iface.getNetMask().isLoopbackAddress();
+            }).collect(Collectors.toList());
+
+            if (!sourceNonLoopback.isEmpty() && !targetNonLoopback.isEmpty()) {
+                // if both the source and target have non-loopback IP interfaces, assume this is a layer3 edge
+                layerText = " Layer3/Layer2";
+            }
         }
+        tooltipText.append(layerText);
         tooltipText.append(HTML_TOOLTIP_TAG_END);
 
         tooltipText.append(HTML_TOOLTIP_TAG_OPEN);

--- a/opennms-base-assembly/src/main/filtered/etc/create.sql
+++ b/opennms-base-assembly/src/main/filtered/etc/create.sql
@@ -512,8 +512,6 @@ create unique index node_foreign_unique_idx on node(foreignSource, foreignId);
 --# This table provides the following information:
 --#
 --#  nodeID             : Unique identifier for node to which this if belongs
---#  snmpIpAdEntNetMask : SNMP MIB-2 ipAddrTable.ipAddrEntry.ipAdEntNetMask
---#                       Value is interface's subnet mask
 --#  snmpPhysAddr       : SNMP MIB-2 ifTable.ifEntry.ifPhysAddress
 --#                       Value is interface's MAC Address
 --#  snmpIfIndex        : SNMP MIB-2 ifTable.ifEntry.ifIndex
@@ -546,15 +544,12 @@ create unique index node_foreign_unique_idx on node(foreignSource, foreignId);
 --#
 --# NOTE:  Although not marked as "not null" the snmpIfIndex field
 --#        should never be null.  This table is considered to be uniquely
---#        keyed by nodeId and snmpIfIndex.  Eventually ipAddr and
---#        snmpIpAdEntNetMask will be removed and netmask added to
---#        the ipInterface table.
+--#        keyed by nodeId and snmpIfIndex.
 --########################################################################
 
 create table snmpInterface (
     id				INTEGER DEFAULT nextval('opennmsNxtId') NOT NULL,
 	nodeID			integer not null,
-	snmpIpAdEntNetMask	varchar(45),
 	snmpPhysAddr		varchar(32),
 	snmpIfIndex		integer not null,
 	snmpIfDescr		varchar(256),
@@ -585,6 +580,7 @@ create index snmpinterface_nodeid_idx on snmpinterface(nodeID);
 --#
 --#  nodeID          : Unique identifier of the node that "owns" this interface
 --#  ipAddr          : IP Address associated with this interface
+--#  netmask         : Netmask associated with this interface
 --#  ifIndex	     : SNMP index of interface, used to uniquely identify
 --# 		           unnumbered interfaces, or null if there is no mapping to
 --#                    snmpInterface table.  Can be -100 if old code added an
@@ -622,10 +618,11 @@ create table ipInterface (
     id              INTEGER DEFAULT nextval('opennmsNxtId') NOT NULL,
 	nodeID			integer not null,
 	ipAddr			text not null,
+	netmask			varchar(45),
 	ipHostname		varchar(256),
 	isManaged		char(1),
 	ipStatus		integer,
-    ipLastCapsdPoll timestamp with time zone,
+	ipLastCapsdPoll timestamp with time zone,
 	isSnmpPrimary   char(1),
 	snmpInterfaceId	integer,
 

--- a/opennms-base-assembly/src/main/filtered/etc/database-schema.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/database-schema.xml
@@ -40,6 +40,7 @@
 		<column name="id" visible="false"/>
 		<column name="nodeID" visible="false"/>
 		<column name="ipAddr"/>
+		<column name="netMask"/>
 		<column name="ipHostname"/>
 		<column name="IsManaged"/>
 		<column name="IsSnmpPrimary"/>
@@ -51,7 +52,6 @@
 		<join column="id" table="ipInterface" table-column="snmpinterfaceid"/>
 		<column name="id" visible="false"/>
 		<column name="nodeID" visible="false"/>
-		<column name="snmpIpAdEntNetMask"/>
 		<column name="snmpPhysAddr"/>
 		<column name="snmpIfIndex"/>
 		<column name="snmpIfDescr"/>

--- a/opennms-config/src/test/resources/etc/database-schema.xml
+++ b/opennms-config/src/test/resources/etc/database-schema.xml
@@ -46,6 +46,7 @@
 		<column name="id" visible="false"/>
 		<column name="nodeID" visible="false"/>
 		<column name="ipAddr"/>
+		<column name="netMask"/>
 		<column name="ipHostname"/>
 		<column name="IsManaged"/>
 		<column name="IsSnmpPrimary"/>
@@ -58,7 +59,6 @@
 		<column name="id" visible="false"/>
 		<column name="nodeID" visible="false"/>
 		<column name="ipAddr" visible="false"/>
-		<column name="snmpIpAdEntNetMask"/>
 		<column name="snmpPhysAddr"/>
 		<column name="snmpIfIndex"/>
 		<column name="snmpIfDescr"/>

--- a/opennms-correlation/drools-correlation-engine/src/test/opennms-home/etc/database-schema.xml
+++ b/opennms-correlation/drools-correlation-engine/src/test/opennms-home/etc/database-schema.xml
@@ -46,6 +46,7 @@
 		<column name="id" visible="false"/>
 		<column name="nodeID" visible="false"/>
 		<column name="ipAddr"/>
+		<column name="netMask"/>
 		<column name="ipHostname"/>
 		<column name="IsManaged"/>
 		<column name="IsSnmpPrimary"/>
@@ -58,7 +59,6 @@
 		<column name="id" visible="false"/>
 		<column name="nodeID" visible="false"/>
 		<column name="ipAddr" visible="false"/>
-		<column name="snmpIpAdEntNetMask"/>
 		<column name="snmpPhysAddr"/>
 		<column name="snmpIfIndex"/>
 		<column name="snmpIfDescr"/>

--- a/opennms-correlation/opennms-correlator/src/test/opennms-home/etc/database-schema.xml
+++ b/opennms-correlation/opennms-correlator/src/test/opennms-home/etc/database-schema.xml
@@ -46,6 +46,7 @@
 		<column name="id" visible="false"/>
 		<column name="nodeID" visible="false"/>
 		<column name="ipAddr"/>
+		<column name="netMask"/>
 		<column name="ipHostname"/>
 		<column name="IsManaged"/>
 		<column name="IsSnmpPrimary"/>
@@ -58,7 +59,6 @@
 		<column name="id" visible="false"/>
 		<column name="nodeID" visible="false"/>
 		<column name="ipAddr" visible="false"/>
-		<column name="snmpIpAdEntNetMask"/>
 		<column name="snmpPhysAddr"/>
 		<column name="snmpIfIndex"/>
 		<column name="snmpIfDescr"/>

--- a/opennms-dao/src/main/java/org/opennms/netmgt/dao/hibernate/IfLabelDaoImpl.java
+++ b/opennms-dao/src/main/java/org/opennms/netmgt/dao/hibernate/IfLabelDaoImpl.java
@@ -136,7 +136,6 @@ public class IfLabelDaoImpl extends AbstractIfLabel implements IfLabel {
                     // Get extra information about the interface
                     info.put("id", String.valueOf(iface.getId()));
                     info.put("nodeid", String.valueOf(iface.getNodeId()));
-                    info.put("snmpipadentnetmask", String.valueOf(iface.getNetMask()));
                     info.put("snmpphysaddr", String.valueOf(iface.getPhysAddr()));
                     info.put("snmpifindex", String.valueOf(iface.getIfIndex()));
                     info.put("snmpifdescr", String.valueOf(iface.getIfDescr()));

--- a/opennms-dao/src/test/opennms-home/etc/database-schema.xml
+++ b/opennms-dao/src/test/opennms-home/etc/database-schema.xml
@@ -46,6 +46,7 @@
 		<column name="id" visible="false"/>
 		<column name="nodeID" visible="false"/>
 		<column name="ipAddr"/>
+		<column name="netMask"/>
 		<column name="ipHostname"/>
 		<column name="IsManaged"/>
 		<column name="IsSnmpPrimary"/>
@@ -58,7 +59,6 @@
 		<column name="id" visible="false"/>
 		<column name="nodeID" visible="false"/>
 		<column name="ipAddr" visible="false"/>
-		<column name="snmpIpAdEntNetMask"/>
 		<column name="snmpPhysAddr"/>
 		<column name="snmpIfIndex"/>
 		<column name="snmpIfDescr"/>

--- a/opennms-model/src/main/java/org/opennms/netmgt/model/NetworkBuilder.java
+++ b/opennms-model/src/main/java/org/opennms/netmgt/model/NetworkBuilder.java
@@ -199,6 +199,15 @@ public class NetworkBuilder {
             m_iface = iface;
         }
 
+        public InterfaceBuilder setNetMask(final InetAddress mask) {
+            m_iface.setNetMask(mask);
+            return this;
+        }
+
+        public InterfaceBuilder setNetMask(final String mask) {
+            return this.setNetMask(addr(mask));
+        }
+
         public InterfaceBuilder setIsManaged(final String managed) {
             m_iface.setIsManaged(managed);
             return this;

--- a/opennms-model/src/main/java/org/opennms/netmgt/model/OnmsIpInterface.java
+++ b/opennms-model/src/main/java/org/opennms/netmgt/model/OnmsIpInterface.java
@@ -79,11 +79,13 @@ import org.springframework.core.style.ToStringCreator;
 @XmlAccessorType(XmlAccessType.NONE)
 @JsonIgnoreProperties({"hibernateLazyInitializer", "handler"})
 public class OnmsIpInterface extends OnmsEntity implements Serializable {
-    private static final long serialVersionUID = 5202941338689399917L;
+    private static final long serialVersionUID = 8463903013592837114L;
 
     private Integer m_id;
 
     private InetAddress m_ipAddress;
+
+    private InetAddress m_netMask;
 
     private String m_ipHostName;
 
@@ -427,6 +429,7 @@ public class OnmsIpInterface extends OnmsEntity implements Serializable {
         return new ToStringCreator(this)
         .append("id", m_id)
         .append("ipAddr", InetAddressUtils.str(m_ipAddress))
+        .append("netMask", InetAddressUtils.str(m_netMask))
         .append("ipHostName", m_ipHostName)
         .append("isManaged", m_isManaged)
         .append("isSnmpPrimary", m_isSnmpPrimary)
@@ -469,6 +472,17 @@ public class OnmsIpInterface extends OnmsEntity implements Serializable {
         m_ipAddress = ipaddr;
     }
 
+    @Column(name = "netmask")
+    @Type(type="org.opennms.netmgt.model.InetAddressUserType")
+    @XmlJavaTypeAdapter(InetAddressXmlAdapter.class)
+    public InetAddress getNetMask() {
+        return m_netMask;
+    }
+
+    public void setNetMask(final InetAddress netMask) {
+        m_netMask = netMask;
+    }
+    
     /**
      * <p>isDown</p>
      *
@@ -518,6 +532,10 @@ public class OnmsIpInterface extends OnmsEntity implements Serializable {
         
         if (hasNewValue(scannedIface.getIfIndex(), getIfIndex())) {
             setIfIndex(scannedIface.getIfIndex());
+        }
+    
+        if (hasNewValue(scannedIface.getNetMask(), getNetMask())) {
+            setNetMask(scannedIface.getNetMask());
         }
     
         if (hasNewValue(scannedIface.getIsManaged(), getIsManaged())) {

--- a/opennms-model/src/main/java/org/opennms/netmgt/model/OnmsSnmpInterface.java
+++ b/opennms-model/src/main/java/org/opennms/netmgt/model/OnmsSnmpInterface.java
@@ -29,7 +29,6 @@
 package org.opennms.netmgt.model;
 
 import java.io.Serializable;
-import java.net.InetAddress;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.Set;
@@ -55,8 +54,6 @@ import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
 import org.codehaus.jackson.annotate.JsonIgnore;
 import org.codehaus.jackson.annotate.JsonIgnoreProperties;
-import org.hibernate.annotations.Type;
-import org.opennms.core.network.InetAddressXmlAdapter;
 import org.opennms.core.utils.AlphaNumeric;
 import org.opennms.core.utils.RrdLabelUtils;
 import org.slf4j.Logger;
@@ -71,13 +68,10 @@ import org.springframework.core.style.ToStringCreator;
 @Table(name = "snmpInterface")
 @JsonIgnoreProperties({"hibernateLazyInitializer", "handler"})
 public class OnmsSnmpInterface extends OnmsEntity implements Serializable {
-    private static final long serialVersionUID = -963873273243372864L;
+    private static final long serialVersionUID = 4688655131862954563L;
     private static final Logger LOG = LoggerFactory.getLogger(OnmsSnmpInterface.class);
 
     private Integer m_id;
-
-    /** identifier field */
-    private InetAddress m_netMask;
 
     /** identifier field */
     private String m_physAddr;
@@ -169,27 +163,6 @@ public class OnmsSnmpInterface extends OnmsEntity implements Serializable {
         m_id = id;
     }
 
-    /**
-     * <p>getNetMask</p>
-     * 
-     * @return a {@link java.lang.String} object.
-     */
-    @Column(name = "snmpIpAdEntNetMask")
-    @Type(type="org.opennms.netmgt.model.InetAddressUserType")
-    @XmlJavaTypeAdapter(InetAddressXmlAdapter.class)
-    public InetAddress getNetMask() {
-        return m_netMask;
-    }
-
-    /**
-     * <p>setNetMask</p>
-     * 
-     * @param snmpipadentnetmask a {@link java.lang.String} object.
-     */
-    public void setNetMask(InetAddress snmpipadentnetmask) {
-        m_netMask = snmpipadentnetmask;
-    }
-    
     /**
      * <p>getPhysAddr</p>
      *
@@ -538,7 +511,6 @@ public class OnmsSnmpInterface extends OnmsEntity implements Serializable {
     @Override
     public String toString() {
         return new ToStringCreator(this)
-            .append("snmpipadentnetmask", getNetMask())
             .append("snmpphysaddr", getPhysAddr())
             .append("snmpifindex", getIfIndex())
             .append("snmpifdescr", getIfDescr())
@@ -719,10 +691,6 @@ public class OnmsSnmpInterface extends OnmsEntity implements Serializable {
         
         if (hasNewValue(scannedSnmpIface.getIfType(), getIfType())) {
             setIfType(scannedSnmpIface.getIfType());
-        }
-        
-        if (hasNewValue(scannedSnmpIface.getNetMask(), getNetMask())) {
-            setNetMask(scannedSnmpIface.getNetMask());
         }
         
         if (hasNewValue(scannedSnmpIface.getPhysAddr(), getPhysAddr())) {

--- a/opennms-model/src/main/java/org/opennms/netmgt/model/SnmpInterfaceBuilder.java
+++ b/opennms-model/src/main/java/org/opennms/netmgt/model/SnmpInterfaceBuilder.java
@@ -28,8 +28,6 @@
 
 package org.opennms.netmgt.model;
 
-import java.net.InetAddress;
-
 import org.opennms.core.utils.InetAddressUtils;
 import org.opennms.netmgt.model.NetworkBuilder.InterfaceBuilder;
 
@@ -143,18 +141,6 @@ public class SnmpInterfaceBuilder {
      */
     public SnmpInterfaceBuilder setPhysAddr(String physAddr) {
         m_snmpIf.setPhysAddr(physAddr);
-        return this;
-    }
-
-    /**
-     * <p>setPhysAddr</p>
-     *
-     * @param physAddr a {@link java.lang.String} object.
-     * @return a {@link org.opennms.netmgt.model.SnmpInterfaceBuilder} object.
-     */
-    public SnmpInterfaceBuilder setNetMask(InetAddress netmask) {
-        if (netmask != null )
-            m_snmpIf.setNetMask(netmask);
         return this;
     }
 

--- a/opennms-provision/opennms-provisiond/src/main/java/org/opennms/netmgt/provision/service/IPAddressTableTracker.java
+++ b/opennms-provision/opennms-provisiond/src/main/java/org/opennms/netmgt/provision/service/IPAddressTableTracker.java
@@ -36,8 +36,6 @@ import java.net.InetAddress;
 import java.util.Arrays;
 
 import org.opennms.core.utils.InetAddressUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.opennms.netmgt.model.OnmsIpInterface;
 import org.opennms.netmgt.model.OnmsSnmpInterface;
 import org.opennms.netmgt.snmp.RowCallback;
@@ -47,6 +45,8 @@ import org.opennms.netmgt.snmp.SnmpResult;
 import org.opennms.netmgt.snmp.SnmpRowResult;
 import org.opennms.netmgt.snmp.SnmpValue;
 import org.opennms.netmgt.snmp.TableTracker;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * PhysInterfaceTableTracker
@@ -215,10 +215,10 @@ public class IPAddressTableTracker extends TableTracker {
 
             final InetAddress inetAddress = InetAddressUtils.addr(ipAddr);
             final OnmsIpInterface iface = new OnmsIpInterface(inetAddress, null);
+            iface.setNetMask(netMask);
 
             if (ifIndex != null) {
                 final OnmsSnmpInterface snmpIface = new OnmsSnmpInterface(null, ifIndex);
-                snmpIface.setNetMask(netMask);
                 snmpIface.setCollectionEnabled(true);
                 iface.setSnmpInterface(snmpIface);
                 iface.setIfIndex(ifIndex);

--- a/opennms-provision/opennms-provisiond/src/main/java/org/opennms/netmgt/provision/service/IPInterfaceTableTracker.java
+++ b/opennms-provision/opennms-provisiond/src/main/java/org/opennms/netmgt/provision/service/IPInterfaceTableTracker.java
@@ -39,7 +39,6 @@ import org.opennms.netmgt.snmp.SnmpObjId;
 import org.opennms.netmgt.snmp.SnmpRowResult;
 import org.opennms.netmgt.snmp.SnmpValue;
 import org.opennms.netmgt.snmp.TableTracker;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -121,10 +120,10 @@ public class IPInterfaceTableTracker extends TableTracker {
 
             final InetAddress inetAddress = InetAddressUtils.addr(ipAddr);
             final OnmsIpInterface iface = new OnmsIpInterface(inetAddress, null);
+            iface.setNetMask(netMask);
 
             if (ifIndex != null) {
                 final OnmsSnmpInterface snmpIface = new OnmsSnmpInterface(null, ifIndex);
-                snmpIface.setNetMask(netMask);
                 snmpIface.setCollectionEnabled(true);
                 iface.setSnmpInterface(snmpIface);
                 iface.setIfIndex(ifIndex);

--- a/opennms-provision/opennms-provisiond/src/main/java/org/opennms/netmgt/provision/service/snmp/IpAddrTable.java
+++ b/opennms-provision/opennms-provisiond/src/main/java/org/opennms/netmgt/provision/service/snmp/IpAddrTable.java
@@ -34,13 +34,13 @@ import java.util.Set;
 import java.util.TreeSet;
 
 import org.opennms.core.utils.InetAddressUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.opennms.netmgt.model.OnmsIpInterface;
 import org.opennms.netmgt.model.OnmsNode;
 import org.opennms.netmgt.model.OnmsSnmpInterface;
 import org.opennms.netmgt.snmp.SnmpInstId;
 import org.opennms.netmgt.snmp.SnmpObjId;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * <P>
@@ -219,7 +219,7 @@ public class IpAddrTable extends SnmpTable<IpAddrTableEntry> {
 
             final InetAddress mask = getNetMask(inetAddr);
             if (mask != null) {
-                snmpIf.setNetMask(mask);
+                ipIf.setNetMask(mask);
             }
 
             snmpIf.setCollectionEnabled(true);

--- a/opennms-provision/opennms-provisiond/src/main/java/org/opennms/netmgt/provision/service/snmp/IpAddressTable.java
+++ b/opennms-provision/opennms-provisiond/src/main/java/org/opennms/netmgt/provision/service/snmp/IpAddressTable.java
@@ -227,7 +227,7 @@ public class IpAddressTable extends SnmpTable<IpAddressTableEntry> {
 
             final InetAddress mask = getNetMask(inetAddr);
             if (mask != null) {
-                snmpIf.setNetMask(mask);
+                ipIf.setNetMask(mask);
             }
 
             snmpIf.setCollectionEnabled(true);

--- a/opennms-reporting/src/test/opennms-home/etc/database-schema.xml
+++ b/opennms-reporting/src/test/opennms-home/etc/database-schema.xml
@@ -46,6 +46,7 @@
 		<column name="id" visible="false"/>
 		<column name="nodeID" visible="false"/>
 		<column name="ipAddr"/>
+		<column name="netMask"/>
 		<column name="ipHostname"/>
 		<column name="IsManaged"/>
 		<column name="IsSnmpPrimary"/>
@@ -58,7 +59,6 @@
 		<column name="id" visible="false"/>
 		<column name="nodeID" visible="false"/>
 		<column name="ipAddr" visible="false"/>
-		<column name="snmpIpAdEntNetMask"/>
 		<column name="snmpPhysAddr"/>
 		<column name="snmpIfIndex"/>
 		<column name="snmpIfDescr"/>

--- a/opennms-services/src/main/java/org/opennms/netmgt/snmpinterfacepoller/DefaultPollContext.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/snmpinterfacepoller/DefaultPollContext.java
@@ -28,9 +28,6 @@
 
 package org.opennms.netmgt.snmpinterfacepoller;
 
-import static org.opennms.core.utils.InetAddressUtils.addr;
-import static org.opennms.core.utils.InetAddressUtils.str;
-
 import java.util.Date;
 import java.util.List;
 
@@ -183,14 +180,17 @@ public class DefaultPollContext implements PollContext {
      */
     /** {@inheritDoc} */
     @Override
-    public Event createEvent(String uei, int nodeId, String address, Date date, OnmsSnmpInterface snmpinterface) {
+    public Event createEvent(final String uei, final int nodeId, final String addr, final String netMask, final Date date, final OnmsSnmpInterface snmpinterface) {
         
-            log().debug("createEvent: uei = " + uei + " nodeid = " + nodeId + " date = " + date);
+        log().debug("createEvent: uei = " + uei + " nodeid = " + nodeId + " date = " + date);
         
         EventBuilder bldr = new EventBuilder(uei, this.getName(), date);
         bldr.setNodeid(nodeId);
-        if (address != null) {
-            bldr.setInterface(addr(address));
+        if (addr != null) {
+            bldr.setInterface(InetAddressUtils.addr(addr));
+        }
+        if (netMask != null) {
+            bldr.addParam(EventConstants.PARM_SNMP_INTERFACE_MASK, InetAddressUtils.normalize(netMask));
         }
         bldr.setService(getServiceName());
 
@@ -202,7 +202,6 @@ public class DefaultPollContext implements PollContext {
         if (snmpinterface.getIfName() != null) bldr.addParam(EventConstants.PARM_SNMP_INTERFACE_NAME, snmpinterface.getIfName());
         if (snmpinterface.getIfDescr() != null) bldr.addParam(EventConstants.PARM_SNMP_INTERFACE_DESC, snmpinterface.getIfDescr());
         if (snmpinterface.getIfAlias() != null) bldr.addParam(EventConstants.PARM_SNMP_INTERFACE_ALIAS, snmpinterface.getIfAlias());
-        if (snmpinterface.getNetMask() != null) bldr.addParam(EventConstants.PARM_SNMP_INTERFACE_MASK, str(snmpinterface.getNetMask()));        
         
         return bldr.getEvent();
     }

--- a/opennms-services/src/main/java/org/opennms/netmgt/snmpinterfacepoller/SnmpPoller.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/snmpinterfacepoller/SnmpPoller.java
@@ -251,15 +251,16 @@ public class SnmpPoller extends AbstractServiceDaemon {
      */
     protected void schedulePollableInterface(OnmsIpInterface iface) {
         String ipaddress = iface.getIpAddress().getHostAddress();
+        String netmask = iface.getNetMask().getHostAddress();
         Integer nodeid = iface.getNode().getId();
         if (ipaddress != null && !ipaddress.equals("0.0.0.0")) {
             String pkgName = getPollerConfig().getPackageName(ipaddress);
             if (pkgName != null) {
                 LOG.debug("Scheduling snmppolling for node: {} ip address: {} - Found package interface with name: {}", nodeid, ipaddress, pkgName);
-                scheduleSnmpCollection(getNetwork().create(nodeid,ipaddress,pkgName), pkgName);
+                scheduleSnmpCollection(getNetwork().create(nodeid,ipaddress,netmask,pkgName), pkgName);
             } else if (!getPollerConfig().useCriteriaFilters()) {
                 LOG.debug("No SNMP Poll Package found for node: {} ip address: {}. - Scheduling according with default interval", nodeid, ipaddress);
-                scheduleSnmpCollection(getNetwork().create(nodeid, ipaddress, "null"), "null");
+                scheduleSnmpCollection(getNetwork().create(nodeid, ipaddress,netmask, "null"), "null");
             }
         }
     }

--- a/opennms-services/src/main/java/org/opennms/netmgt/snmpinterfacepoller/pollable/PollContext.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/snmpinterfacepoller/pollable/PollContext.java
@@ -71,11 +71,12 @@ public interface PollContext {
      * @param uei a {@link java.lang.String} object.
      * @param nodeId a int.
      * @param address a {@link java.lang.String} object.
+     * @param netMask a {@link java.lang.String} object.
      * @param date a {@link java.util.Date} object.
      * @return the event
      * @param snmpinterface a {@link org.opennms.netmgt.model.OnmsSnmpInterface} object.
      */
-    public Event createEvent(String uei, int nodeId, String address, Date date, OnmsSnmpInterface snmpinterface);
+    public Event createEvent(String uei, int nodeId, String address, String netMask, Date date, OnmsSnmpInterface snmpinterface);
     
     /**
      * <p>get</p>

--- a/opennms-services/src/main/java/org/opennms/netmgt/snmpinterfacepoller/pollable/PollableInterface.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/snmpinterfacepoller/pollable/PollableInterface.java
@@ -52,6 +52,8 @@ public class PollableInterface {
     
     private String m_ipaddress;
     
+    private String m_netMask;
+
     private PollableNetwork m_parent;
     
     private Map<String, PollableSnmpInterface> m_pollablesnmpinterface;
@@ -115,6 +117,14 @@ public class PollableInterface {
      */
     public void setIpaddress(String ipaddress) {
         m_ipaddress = ipaddress;
+    }
+
+    public String getNetMask() {
+        return m_netMask;
+    }
+
+    public void setNetMask(final String netMask) {
+        m_netMask = netMask;
     }
 
     /**

--- a/opennms-services/src/main/java/org/opennms/netmgt/snmpinterfacepoller/pollable/PollableNetwork.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/snmpinterfacepoller/pollable/PollableNetwork.java
@@ -63,10 +63,11 @@ public class PollableNetwork {
      * @param packageName a {@link java.lang.String} object.
      * @return a {@link org.opennms.netmgt.snmpinterfacepoller.pollable.PollableInterface} object.
      */
-    public PollableInterface create(int nodeid, String ipaddress, String packageName) {
+    public PollableInterface create(int nodeid, String ipaddress, String netMask, String packageName) {
         PollableInterface nodeGroup = new PollableInterface(this);
         nodeGroup.setNodeid(nodeid);
         nodeGroup.setIpaddress(ipaddress);
+        nodeGroup.setNetMask(netMask);
         nodeGroup.setPackageName(packageName);
         nodeGroup.initialize();
         m_members.put(nodeGroup.getIpaddress(), nodeGroup);

--- a/opennms-services/src/main/java/org/opennms/netmgt/snmpinterfacepoller/pollable/PollableSnmpInterface.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/snmpinterfacepoller/pollable/PollableSnmpInterface.java
@@ -189,8 +189,7 @@ public class PollableSnmpInterface implements ReadyRunnable {
      *
      * @param parent a {@link org.opennms.netmgt.snmpinterfacepoller.pollable.PollableInterface} object.
      */
-    public PollableSnmpInterface(
-            PollableInterface parent) {
+    public PollableSnmpInterface(PollableInterface parent) {
         m_parent = parent;
         m_snmpinterfaces = new HashMap<Integer,OnmsSnmpInterface>();
 
@@ -395,23 +394,23 @@ public class PollableSnmpInterface implements ReadyRunnable {
     
     private void sendAdminUpEvent(OnmsSnmpInterface iface) {
         getContext().sendEvent(getContext().createEvent(EventConstants.SNMP_INTERFACE_ADMIN_UP_EVENT_UEI, 
-                                                        getParent().getNodeid(), getParent().getIpaddress(), getDate(), iface));       
+                                                        getParent().getNodeid(), getParent().getIpaddress(), getParent().getNetMask(), getDate(), iface));
     }
     
     private void sendAdminDownEvent(OnmsSnmpInterface iface) {
         getContext().sendEvent(getContext().createEvent(EventConstants.SNMP_INTERFACE_ADMIN_DOWN_EVENT_UEI, 
-                                                        getParent().getNodeid(), getParent().getIpaddress(), getDate(), iface));
+                                                        getParent().getNodeid(), getParent().getIpaddress(), getParent().getNetMask(), getDate(), iface));
     }
     
     private void sendOperUpEvent(OnmsSnmpInterface iface) {
         getContext().sendEvent(getContext().createEvent(EventConstants.SNMP_INTERFACE_OPER_UP_EVENT_UEI, 
-                                                        getParent().getNodeid(), getParent().getIpaddress(), getDate(), iface));
+                                                        getParent().getNodeid(), getParent().getIpaddress(), getParent().getNetMask(), getDate(), iface));
         
     }
     
     private void sendOperDownEvent(OnmsSnmpInterface iface) {
         getContext().sendEvent(getContext().createEvent(EventConstants.SNMP_INTERFACE_OPER_DOWN_EVENT_UEI, 
-                                                        getParent().getNodeid(), getParent().getIpaddress(), getDate(), iface));
+                                                        getParent().getNodeid(), getParent().getIpaddress(), getParent().getNetMask(), getDate(), iface));
     }
     
     private Date getDate() {

--- a/opennms-services/src/test/java/org/opennms/netmgt/mock/DbSnmpInterfaceEntry.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/mock/DbSnmpInterfaceEntry.java
@@ -28,14 +28,12 @@
 
 package org.opennms.netmgt.mock;
 
-import java.net.InetAddress;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 
 import org.opennms.core.utils.DBUtils;
-import org.opennms.core.utils.InetAddressUtils;
 
 /**
  *
@@ -66,7 +64,7 @@ public final class DbSnmpInterfaceEntry {
      * keyed by the node identifier and the ifIndex.
      */
     private static final String SQL_LOAD_REC = "SELECT "
-        + "snmpIpAdEntNetMask, snmpPhysAddr, snmpIfDescr, snmpIfType, "
+        + "snmpPhysAddr, snmpIfDescr, snmpIfType, "
         + "snmpIfName, snmpIfSpeed, snmpIfAdminStatus, snmpIfOperStatus, "
         + "snmpIfAlias, snmpCollect FROM snmpInterface WHERE nodeID = ? AND snmpIfIndex = ?";
 
@@ -84,8 +82,6 @@ public final class DbSnmpInterfaceEntry {
      * The SNMP ifIndex
      */
     private int m_ifIndex;
-
-    private InetAddress m_netmask;
 
     private String m_physAddr;
 
@@ -141,12 +137,6 @@ public final class DbSnmpInterfaceEntry {
 
             // extract the values
             int ndx = 1;
-
-            // get the netmask
-            String str = rset.getString(ndx++);
-            if (str != null && !rset.wasNull()) {
-            	m_netmask = InetAddressUtils.addr(str);
-            }
 
             // get the physical address
             m_physAddr = rset.getString(ndx++);
@@ -237,7 +227,6 @@ public final class DbSnmpInterfaceEntry {
         m_fromDb = exists;
         m_nodeId = nodeId;
         m_ifIndex = ifIndex;
-        m_netmask = null;
         m_physAddr = null;
         m_ifDescription = null;
         m_ifType = -1;
@@ -290,7 +279,6 @@ public final class DbSnmpInterfaceEntry {
 
         buf.append("from database   = ").append(m_fromDb).append(sep);
         buf.append("node identifier = ").append(m_nodeId).append(sep);
-        buf.append("IP Netmask      = ").append(InetAddressUtils.str(m_netmask)).append(sep);
         buf.append("MAC             = ").append(m_physAddr).append(sep);
         buf.append("ifIndex         = ").append(m_ifIndex).append(sep);
         buf.append("ifDescr         = ").append(m_ifDescription).append(sep);

--- a/opennms-services/src/test/java/org/opennms/netmgt/nb/NmsNetworkBuilder.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/nb/NmsNetworkBuilder.java
@@ -35,8 +35,8 @@ import java.util.Map;
 import org.opennms.core.utils.InetAddressUtils;
 import org.opennms.netmgt.model.NetworkBuilder;
 import org.opennms.netmgt.model.OnmsNode;
-import org.opennms.netmgt.model.SnmpInterfaceBuilder;
 import org.opennms.netmgt.model.OnmsNode.NodeType;
+import org.opennms.netmgt.model.SnmpInterfaceBuilder;
 
 /**
  * 
@@ -1480,7 +1480,6 @@ public abstract class NmsNetworkBuilder {
                                       setIfName(ifindextoifnamemap.get(ifIndex)).
                                       setIfAlias(getSuitableString(ifindextoifalias, ifIndex)).
                                       setIfSpeed(100000000).
-                                      setNetMask(getMask(ifindextonetmaskmap,ifIndex)).
                                       setPhysAddr(getSuitableString(ifindextomacmap, ifIndex)).setIfDescr(getSuitableString(ifindextoifdescrmap,ifIndex)));
         }
         
@@ -1492,24 +1491,28 @@ public abstract class NmsNetworkBuilder {
             if (ifIndex == null)
                 nb.addInterface(ipaddr.getHostAddress()).setIsSnmpPrimary(isSnmpPrimary).setIsManaged("M");
             else {
-                nb.addInterface(ipaddr.getHostAddress(), ifindexsnmpbuildermap.get(ifIndex).getSnmpInterface()).
-                setIsSnmpPrimary(isSnmpPrimary).setIsManaged("M");            }
+                final InetAddress mask = getMask(ifindextonetmaskmap, ifIndex);
+                nb.addInterface(ipaddr.getHostAddress(), ifindexsnmpbuildermap.get(ifIndex).getSnmpInterface())
+                    .setNetMask(mask)
+                    .setIsSnmpPrimary(isSnmpPrimary)
+                    .setIsManaged("M");            }
         }
             
         return nb.getCurrentNode();
     }
     
-    private InetAddress getMask(
-            Map<Integer, InetAddress> ifindextonetmaskmap, Integer ifIndex) {
-        if (ifindextonetmaskmap.containsKey(ifIndex))
+    private InetAddress getMask(Map<Integer, InetAddress> ifindextonetmaskmap, Integer ifIndex) {
+        if (ifindextonetmaskmap.containsKey(ifIndex)) {
             return ifindextonetmaskmap.get(ifIndex);
+        }
         return null;
     }
 
     private String getSuitableString(Map<Integer,String> ifindextomacmap, Integer ifIndex) {
         String value = "";
-        if (ifindextomacmap.containsKey(ifIndex))
+        if (ifindextomacmap.containsKey(ifIndex)) {
             value = ifindextomacmap.get(ifIndex);
+        }
         return value;
     }
     

--- a/opennms-services/src/test/resources/etc/database-schema.xml
+++ b/opennms-services/src/test/resources/etc/database-schema.xml
@@ -46,6 +46,7 @@
 		<column name="id" visible="false"/>
 		<column name="nodeID" visible="false"/>
 		<column name="ipAddr"/>
+		<column name="netMask"/>
 		<column name="ipHostname"/>
 		<column name="IsManaged"/>
 		<column name="IsSnmpPrimary"/>
@@ -58,7 +59,6 @@
 		<column name="id" visible="false"/>
 		<column name="nodeID" visible="false"/>
 		<column name="ipAddr" visible="false"/>
-		<column name="snmpIpAdEntNetMask"/>
 		<column name="snmpPhysAddr"/>
 		<column name="snmpIfIndex"/>
 		<column name="snmpIfDescr"/>

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/CriteriaBehaviors.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/CriteriaBehaviors.java
@@ -226,6 +226,7 @@ public abstract class CriteriaBehaviors {
         IP_INTERFACE_BEHAVIORS.put("id", new CriteriaBehavior<Integer>(INT_CONVERTER));
         IP_INTERFACE_BEHAVIORS.put("ipLastCapsdPoll", new CriteriaBehavior<Date>(DATE_CONVERTER));
         IP_INTERFACE_BEHAVIORS.put("ipAddress", new CriteriaBehavior<InetAddress>(INET_ADDRESS_CONVERTER));
+        IP_INTERFACE_BEHAVIORS.put("netMask", new CriteriaBehavior<InetAddress>(INET_ADDRESS_CONVERTER));
 
         MONITORED_SERVICE_BEHAVIORS.put("id", new CriteriaBehavior<Integer>(INT_CONVERTER));
         MONITORED_SERVICE_BEHAVIORS.put("lastFail", new CriteriaBehavior<Date>(DATE_CONVERTER));
@@ -322,6 +323,5 @@ public abstract class CriteriaBehaviors {
         SNMP_INTERFACE_BEHAVIORS.put("ifSpeed", new CriteriaBehavior<Long>(LONG_CONVERTER));
         SNMP_INTERFACE_BEHAVIORS.put("lastCapsdPoll", new CriteriaBehavior<Date>(DATE_CONVERTER));
         SNMP_INTERFACE_BEHAVIORS.put("lastSnmpPoll", new CriteriaBehavior<Date>(DATE_CONVERTER));
-        SNMP_INTERFACE_BEHAVIORS.put("netMask", new CriteriaBehavior<InetAddress>(INET_ADDRESS_CONVERTER));
     }
 }

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/SearchProperties.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/SearchProperties.java
@@ -281,6 +281,7 @@ public abstract class SearchProperties {
 	static final SortedSet<SearchProperty> IP_INTERFACE_PROPERTIES = new TreeSet<>(Arrays.asList(new SearchProperty[] {
 		new SearchProperty(OnmsIpInterface.class, "id", "ID", INTEGER),
 		new SearchProperty(OnmsIpInterface.class, "ipAddress", "IP Address", IP_ADDRESS),
+                new SearchProperty(OnmsIpInterface.class, "netMask", "Network Mask", IP_ADDRESS),
 		new SearchProperty(OnmsIpInterface.class, "ipHostName", "Hostname", STRING),
 		new SearchProperty(OnmsIpInterface.class, "ipLastCapsdPoll", "Last Provisioning Scan", TIMESTAMP),
 		new SearchProperty(OnmsIpInterface.class, "isManaged", "Management Status", STRING)
@@ -377,7 +378,6 @@ public abstract class SearchProperties {
 		new SearchProperty(OnmsSnmpInterface.class, "ifSpeed", "Interface Speed (Bits per second)", LONG),
 		new SearchProperty(OnmsSnmpInterface.class, "lastCapsdPoll", "Last Provisioning Scan", TIMESTAMP),
 		new SearchProperty(OnmsSnmpInterface.class, "lastSnmpPoll", "Last SNMP Interface Poll", TIMESTAMP),
-		new SearchProperty(OnmsSnmpInterface.class, "netMask", "Network Mask", IP_ADDRESS)
 	}));
 
 	public static final Set<SearchProperty> ALARM_SERVICE_PROPERTIES = new LinkedHashSet<>();

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/README.adoc
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/README.adoc
@@ -259,6 +259,7 @@ org.opennms.web.rest.support.SearchPropertiesToAsciidocTest
 | Name | Type | Description
 | ipInterface.id | Integer | ID
 | ipInterface.ipAddress | IP Address | IP Address
+| ipInterface.netMask | IP Address | Network Mask
 | ipInterface.ipHostName | String | Hostname
 | ipInterface.ipLastCapsdPoll | Timestamp | Last Provisioning Scan
 | ipInterface.isManaged | String | Management Status
@@ -428,7 +429,6 @@ org.opennms.web.rest.support.SearchPropertiesToAsciidocTest
 | snmpInterface.ifSpeed | Long | Interface Speed (Bits per second)
 | snmpInterface.lastCapsdPoll | Timestamp | Last Provisioning Scan
 | snmpInterface.lastSnmpPoll | Timestamp | Last SNMP Interface Poll
-| snmpInterface.netMask | IP Address | Network Mask
 |===
 
 ////

--- a/opennms-webapp/src/main/java/org/opennms/web/element/Interface.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/element/Interface.java
@@ -28,8 +28,6 @@
 
 package org.opennms.web.element;
 
-import static org.opennms.core.utils.InetAddressUtils.str;
-
 import java.util.List;
 
 import org.opennms.core.utils.InetAddressUtils;
@@ -60,8 +58,6 @@ public class Interface {
     char m_isManaged;
 
     String m_ipLastCapsdPoll;
-
-    String m_snmpIpAdEntNetMask;
 
     String m_snmpPhysAddr;
 
@@ -106,7 +102,6 @@ public class Interface {
         }
         
         m_snmpIfIndex = snmpIface.getIfIndex();
-        m_snmpIpAdEntNetMask = str(snmpIface.getNetMask());
         m_snmpPhysAddr = snmpIface.getPhysAddr();
         m_snmpIfDescr = snmpIface.getIfDescr();
         m_snmpIfName = snmpIface.getIfName();
@@ -252,15 +247,6 @@ public class Interface {
      */
     public int getSnmpIfIndex() {
         return m_snmpIfIndex;
-    }
-
-    /**
-     * <p>getSnmpIpAdEntNetMask</p>
-     *
-     * @return a {@link java.lang.String} object.
-     */
-    public String getSnmpIpAdEntNetMask() {
-        return m_snmpIpAdEntNetMask;
     }
 
     /**

--- a/opennms-webapp/src/test/opennms-home/etc/database-schema.xml
+++ b/opennms-webapp/src/test/opennms-home/etc/database-schema.xml
@@ -46,6 +46,7 @@
 		<column name="id" visible="false"/>
 		<column name="nodeID" visible="false"/>
 		<column name="ipAddr"/>
+		<column name="netMask"/>
 		<column name="ipHostname"/>
 		<column name="IsManaged"/>
 		<column name="IsSnmpPrimary"/>
@@ -58,7 +59,6 @@
 		<column name="id" visible="false"/>
 		<column name="nodeID" visible="false"/>
 		<column name="ipAddr" visible="false"/>
-		<column name="snmpIpAdEntNetMask"/>
 		<column name="snmpPhysAddr"/>
 		<column name="snmpIfIndex"/>
 		<column name="snmpIfDescr"/>

--- a/src/test/resources/test-data.sql
+++ b/src/test/resources/test-data.sql
@@ -282,9 +282,9 @@ INSERT INTO service (serviceid, servicename) VALUES (3, 'HTTP');
 -- Data for Name: snmpinterface; Type: TABLE DATA; Schema: public; Owner: opennms
 --
 
-INSERT INTO snmpinterface (nodeid, ipaddr, snmpipadentnetmask, snmpphysaddr, snmpifindex, snmpifdescr, snmpiftype, snmpifname, snmpifspeed, snmpifadminstatus, snmpifoperstatus, snmpifalias) VALUES (1, '192.168.1.1', NULL, NULL, 1, NULL, NULL, NULL, 10000000, NULL, NULL, NULL);
-INSERT INTO snmpinterface (nodeid, ipaddr, snmpipadentnetmask, snmpphysaddr, snmpifindex, snmpifdescr, snmpiftype, snmpifname, snmpifspeed, snmpifadminstatus, snmpifoperstatus, snmpifalias) VALUES (1, '192.168.1.2', NULL, NULL, 2, NULL, NULL, NULL, 10000000, NULL, NULL, NULL);
-INSERT INTO snmpinterface (nodeid, ipaddr, snmpipadentnetmask, snmpphysaddr, snmpifindex, snmpifdescr, snmpiftype, snmpifname, snmpifspeed, snmpifadminstatus, snmpifoperstatus, snmpifalias) VALUES (1, '192.168.1.3', NULL, NULL, 3, NULL, NULL, NULL, 10000000, NULL, NULL, NULL);
+INSERT INTO snmpinterface (nodeid, ipaddr, snmpphysaddr, snmpifindex, snmpifdescr, snmpiftype, snmpifname, snmpifspeed, snmpifadminstatus, snmpifoperstatus, snmpifalias) VALUES (1, '192.168.1.1', NULL, 1, NULL, NULL, NULL, 10000000, NULL, NULL, NULL);
+INSERT INTO snmpinterface (nodeid, ipaddr, snmpphysaddr, snmpifindex, snmpifdescr, snmpiftype, snmpifname, snmpifspeed, snmpifadminstatus, snmpifoperstatus, snmpifalias) VALUES (1, '192.168.1.2', NULL, 2, NULL, NULL, NULL, 10000000, NULL, NULL, NULL);
+INSERT INTO snmpinterface (nodeid, ipaddr, snmpphysaddr, snmpifindex, snmpifdescr, snmpiftype, snmpifname, snmpifspeed, snmpifadminstatus, snmpifoperstatus, snmpifalias) VALUES (1, '192.168.1.3', NULL, 3, NULL, NULL, NULL, 10000000, NULL, NULL, NULL);
 
 
 --


### PR DESCRIPTION
This PR moves the `snmpinterface.snmpipadentnetmask` column to `ipinterface.netmask` and changes all of the places that we reference netmask from the `OnmsSnmpInterface` object to its equivalent in `OnmsIpInterface`.

* JIRA: http://issues.opennms.org/browse/NMS-9385

Our [continuous integration system](http://bamboo.internal.opennms.com:8085) will test and verify your changes.
