### PR TITLE
NMS-9330 (Part 1): Minor dependency upgrades

### DIFF
--- a/container/features/src/main/resources/features.xml
+++ b/container/features/src/main/resources/features.xml
@@ -212,8 +212,8 @@
       <bundle>mvn:org.apache.commons/commons-lang3/${commonsLang3Version}</bundle>
     </feature>
 
-    <feature name="commons-net" description="Apache :: commons-net" version="3.3">
-      <bundle>mvn:commons-net/commons-net/3.3</bundle>
+    <feature name="commons-net" description="Apache :: commons-net" version="3.6">
+      <bundle>mvn:commons-net/commons-net/3.6</bundle>
     </feature>
 
     <feature name="dnsjava" description="dnsjava" version="${dnsjavaVersion}">

--- a/container/features/src/main/resources/features.xml
+++ b/container/features/src/main/resources/features.xml
@@ -102,26 +102,26 @@
       <bundle>wrap:mvn:com.atomikos/transactions-jdbc/${atomikosVersion}</bundle>
     </feature>
 
-    <feature name="batik" description="Apache :: XML Graphics :: Batik" version="1.7">
+    <feature name="batik" description="Apache :: XML Graphics :: Batik" version="${batikVersion}">
       <bundle>wrap:mvn:xalan/xalan/2.7.2</bundle>
       <bundle>wrap:mvn:xalan/serializer/2.7.2</bundle>
       <bundle>wrap:mvn:xml-apis/xml-apis/1.4.01</bundle>
       <bundle>wrap:mvn:xml-apis/xml-apis-ext/1.3.04</bundle>
 
-      <bundle>wrap:mvn:org.apache.xmlgraphics/batik-anim/1.7</bundle>
-      <bundle>wrap:mvn:org.apache.xmlgraphics/batik-awt-util/1.7</bundle>
-      <bundle>wrap:mvn:org.apache.xmlgraphics/batik-bridge/1.7</bundle>
-      <bundle>wrap:mvn:org.apache.xmlgraphics/batik-css/1.7</bundle>
-      <bundle>wrap:mvn:org.apache.xmlgraphics/batik-dom/1.7</bundle>
-      <bundle>wrap:mvn:org.apache.xmlgraphics/batik-ext/1.7</bundle>
-      <bundle>wrap:mvn:org.apache.xmlgraphics/batik-gvt/1.7</bundle>
-      <bundle>wrap:mvn:org.apache.xmlgraphics/batik-parser/1.7</bundle>
-      <bundle>wrap:mvn:org.apache.xmlgraphics/batik-script/1.7</bundle>
-      <bundle>wrap:mvn:org.apache.xmlgraphics/batik-svggen/1.7</bundle>
-      <bundle>wrap:mvn:org.apache.xmlgraphics/batik-svg-dom/1.7</bundle>
-      <bundle>wrap:mvn:org.apache.xmlgraphics/batik-transcoder/1.7</bundle>
-      <bundle>wrap:mvn:org.apache.xmlgraphics/batik-util/1.7</bundle>
-      <bundle>wrap:mvn:org.apache.xmlgraphics/batik-xml/1.7</bundle>
+      <bundle>wrap:mvn:org.apache.xmlgraphics/batik-anim/${batikVersion}</bundle>
+      <bundle>wrap:mvn:org.apache.xmlgraphics/batik-awt-util/${batikVersion}</bundle>
+      <bundle>wrap:mvn:org.apache.xmlgraphics/batik-bridge/${batikVersion}</bundle>
+      <bundle>wrap:mvn:org.apache.xmlgraphics/batik-css/${batikVersion}</bundle>
+      <bundle>wrap:mvn:org.apache.xmlgraphics/batik-dom/${batikVersion}</bundle>
+      <bundle>wrap:mvn:org.apache.xmlgraphics/batik-ext/${batikVersion}</bundle>
+      <bundle>wrap:mvn:org.apache.xmlgraphics/batik-gvt/${batikVersion}</bundle>
+      <bundle>wrap:mvn:org.apache.xmlgraphics/batik-parser/${batikVersion}</bundle>
+      <bundle>wrap:mvn:org.apache.xmlgraphics/batik-script/${batikVersion}</bundle>
+      <bundle>wrap:mvn:org.apache.xmlgraphics/batik-svggen/${batikVersion}</bundle>
+      <bundle>wrap:mvn:org.apache.xmlgraphics/batik-svg-dom/${batikVersion}</bundle>
+      <bundle>wrap:mvn:org.apache.xmlgraphics/batik-transcoder/${batikVersion}</bundle>
+      <bundle>wrap:mvn:org.apache.xmlgraphics/batik-util/${batikVersion}</bundle>
+      <bundle>wrap:mvn:org.apache.xmlgraphics/batik-xml/${batikVersion}</bundle>
     </feature>
 
     <feature name="bsf" description="Apache :: Bean Scripting Framework" version="${bsfVersion}">
@@ -224,8 +224,8 @@
       <bundle>mvn:io.dropwizard.metrics/metrics-core/3.1.2</bundle>
     </feature>
 
-    <feature name="fop" description="Apache :: XML Graphics :: FOP" version="1.0">
-      <bundle>wrap:mvn:org.apache.xmlgraphics/fop/1.0</bundle>
+    <feature name="fop" description="Apache :: XML Graphics :: FOP" version="${fopVersion}">
+      <bundle>wrap:mvn:org.apache.xmlgraphics/fop/${fopVersion}</bundle>
     </feature>
 
     <feature name="guava" description="Google :: Guava" version="${guavaVersion}">

--- a/features/reporting/availability/pom.xml
+++ b/features/reporting/availability/pom.xml
@@ -156,7 +156,7 @@
     <dependency>
       <groupId>org.apache.xmlgraphics</groupId>
       <artifactId>fop</artifactId>
-      <version>1.0</version>
+      <version>${fopVersion}</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>

--- a/opennms-base-assembly/pom.xml
+++ b/opennms-base-assembly/pom.xml
@@ -578,7 +578,7 @@
       <version>20100506</version>
     </dependency>
     <dependency>
-      <groupId>ognl</groupId>
+      <groupId>opensymphony</groupId>
       <artifactId>ognl</artifactId>
     </dependency>
     <dependency>

--- a/opennms-config-model/pom.xml
+++ b/opennms-config-model/pom.xml
@@ -92,7 +92,6 @@
               org.opennms.netmgt.config.viewsdisplay.*;version="${project.version}",
               org.opennms.netmgt.config.webuiColors.*;version="${project.version}",
               org.opennms.netmgt.config.wmi.*;version="${project.version}",
-              org.opennms.netmgt.config.xmlrpcd.*;version="${project.version}",
               org.opennms.netmgt.eventd.datablock.*;version="${project.version}",
               org.opennms.netmgt.xml.eventconf.*;version="${project.version}",
               org.opennms.netmgt.xml.rtc.*;version="${project.version}"

--- a/opennms-tools/csv-address/pom.xml
+++ b/opennms-tools/csv-address/pom.xml
@@ -59,7 +59,7 @@
       <artifactId>junit</artifactId>
     </dependency>
     <dependency>
-    	<groupId>net.sf.opencsv</groupId>
+    	<groupId>com.opencsv</groupId>
     	<artifactId>opencsv</artifactId>
     </dependency>
   </dependencies>

--- a/opennms-tools/csv-address/src/main/java/org/opennms/model/utils/AssetsUpdater.java
+++ b/opennms-tools/csv-address/src/main/java/org/opennms/model/utils/AssetsUpdater.java
@@ -49,7 +49,7 @@ import java.util.regex.Pattern;
 
 import org.apache.commons.lang.StringUtils;
 
-import au.com.bytecode.opencsv.CSVReader;
+import com.opencsv.CSVReader;
 
 /**
  * @deprecated Replace this class with a Hibernate implementation instead of using JDBC.

--- a/opennms-webapp/pom.xml
+++ b/opennms-webapp/pom.xml
@@ -725,7 +725,7 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>net.sf.opencsv</groupId>
+      <groupId>com.opencsv</groupId>
       <artifactId>opencsv</artifactId>
     </dependency>
     <dependency>

--- a/opennms-webapp/pom.xml
+++ b/opennms-webapp/pom.xml
@@ -729,7 +729,7 @@
       <artifactId>opencsv</artifactId>
     </dependency>
     <dependency>
-      <groupId>ognl</groupId>
+      <groupId>opensymphony</groupId>
       <artifactId>ognl</artifactId>
       <scope>${onmsLibScope}</scope>
     </dependency>

--- a/opennms-webapp/pom.xml
+++ b/opennms-webapp/pom.xml
@@ -793,8 +793,18 @@
     <!-- these should all be <scope>compile</scope> -->
 
     <dependency>
-      <groupId>poi</groupId>
+      <groupId>org.apache.poi</groupId>
       <artifactId>poi</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.rometools</groupId>

--- a/opennms-webapp/pom.xml
+++ b/opennms-webapp/pom.xml
@@ -797,7 +797,7 @@
       <artifactId>poi</artifactId>
     </dependency>
     <dependency>
-      <groupId>rome</groupId>
+      <groupId>com.rometools</groupId>
       <artifactId>rome</artifactId>
       <exclusions>
         <exclusion>

--- a/opennms-webapp/src/main/java/org/opennms/web/asset/ExportAssetsServlet.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/asset/ExportAssetsServlet.java
@@ -39,7 +39,7 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.opennms.web.element.NetworkElementFactory;
 
-import au.com.bytecode.opencsv.CSVWriter;
+import com.opencsv.CSVWriter;
 
 /**
  *

--- a/opennms-webapp/src/main/java/org/opennms/web/asset/ImportAssetsServlet.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/asset/ImportAssetsServlet.java
@@ -56,7 +56,7 @@ import org.opennms.web.servlet.MissingParameterException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import au.com.bytecode.opencsv.CSVReader;
+import com.opencsv.CSVReader;
 
 /**
  * <p>ImportAssetsServlet class.</p>

--- a/opennms-webapp/src/main/java/org/opennms/web/rss/AbstractFeed.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/rss/AbstractFeed.java
@@ -36,8 +36,8 @@ import javax.servlet.ServletRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.sun.syndication.feed.synd.SyndFeed;
-import com.sun.syndication.io.SyndFeedOutput;
+import com.rometools.rome.feed.synd.SyndFeed;
+import com.rometools.rome.io.SyndFeedOutput;
 
 /**
  * <p>AbstractFeed class.</p>
@@ -151,7 +151,7 @@ public abstract class AbstractFeed implements Feed {
     /**
      * <p>getFeed</p>
      *
-     * @return a {@link com.sun.syndication.feed.synd.SyndFeed} object.
+     * @return a {@link com.rometools.rome.feed.synd.SyndFeed} object.
      */
     public abstract SyndFeed getFeed();
 

--- a/opennms-webapp/src/main/java/org/opennms/web/rss/AlarmFeed.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/rss/AlarmFeed.java
@@ -45,12 +45,12 @@ import org.opennms.web.alarm.filter.NodeFilter;
 import org.opennms.web.alarm.filter.SeverityFilter;
 import org.opennms.web.filter.Filter;
 
-import com.sun.syndication.feed.synd.SyndContent;
-import com.sun.syndication.feed.synd.SyndContentImpl;
-import com.sun.syndication.feed.synd.SyndEntry;
-import com.sun.syndication.feed.synd.SyndEntryImpl;
-import com.sun.syndication.feed.synd.SyndFeed;
-import com.sun.syndication.feed.synd.SyndFeedImpl;
+import com.rometools.rome.feed.synd.SyndContent;
+import com.rometools.rome.feed.synd.SyndContentImpl;
+import com.rometools.rome.feed.synd.SyndEntry;
+import com.rometools.rome.feed.synd.SyndEntryImpl;
+import com.rometools.rome.feed.synd.SyndFeed;
+import com.rometools.rome.feed.synd.SyndFeedImpl;
 
 /**
  * <p>AlarmFeed class.</p>
@@ -79,7 +79,7 @@ public class AlarmFeed extends AbstractFeed {
     /**
      * <p>getFeed</p>
      *
-     * @return a {@link com.sun.syndication.feed.synd.SyndFeed} object.
+     * @return a {@link com.rometools.rome.feed.synd.SyndFeed} object.
      */
     @Override
     public SyndFeed getFeed() {

--- a/opennms-webapp/src/main/java/org/opennms/web/rss/EventFeed.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/rss/EventFeed.java
@@ -44,12 +44,12 @@ import org.opennms.web.filter.Filter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.sun.syndication.feed.synd.SyndContent;
-import com.sun.syndication.feed.synd.SyndContentImpl;
-import com.sun.syndication.feed.synd.SyndEntry;
-import com.sun.syndication.feed.synd.SyndEntryImpl;
-import com.sun.syndication.feed.synd.SyndFeed;
-import com.sun.syndication.feed.synd.SyndFeedImpl;
+import com.rometools.rome.feed.synd.SyndContent;
+import com.rometools.rome.feed.synd.SyndContentImpl;
+import com.rometools.rome.feed.synd.SyndEntry;
+import com.rometools.rome.feed.synd.SyndEntryImpl;
+import com.rometools.rome.feed.synd.SyndFeed;
+import com.rometools.rome.feed.synd.SyndFeedImpl;
 
 
 /**
@@ -67,7 +67,7 @@ public class EventFeed extends AbstractFeed {
     /**
      * <p>getFeed</p>
      *
-     * @return a {@link com.sun.syndication.feed.synd.SyndFeed} object.
+     * @return a {@link com.rometools.rome.feed.synd.SyndFeed} object.
      */
     @Override
     public SyndFeed getFeed() {

--- a/opennms-webapp/src/main/java/org/opennms/web/rss/NotificationFeed.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/rss/NotificationFeed.java
@@ -37,10 +37,10 @@ import org.opennms.web.notification.NotificationModel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.sun.syndication.feed.synd.SyndEntry;
-import com.sun.syndication.feed.synd.SyndEntryImpl;
-import com.sun.syndication.feed.synd.SyndFeed;
-import com.sun.syndication.feed.synd.SyndFeedImpl;
+import com.rometools.rome.feed.synd.SyndEntry;
+import com.rometools.rome.feed.synd.SyndEntryImpl;
+import com.rometools.rome.feed.synd.SyndFeed;
+import com.rometools.rome.feed.synd.SyndFeedImpl;
 
 /**
  * <p>NotificationFeed class.</p>
@@ -57,7 +57,7 @@ public class NotificationFeed extends AbstractFeed {
     /**
      * <p>getFeed</p>
      *
-     * @return a {@link com.sun.syndication.feed.synd.SyndFeed} object.
+     * @return a {@link com.rometools.rome.feed.synd.SyndFeed} object.
      */
     @Override
     public SyndFeed getFeed() {

--- a/opennms-webapp/src/main/java/org/opennms/web/rss/OutageFeed.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/rss/OutageFeed.java
@@ -38,10 +38,10 @@ import org.opennms.web.outage.OutageModel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.sun.syndication.feed.synd.SyndEntry;
-import com.sun.syndication.feed.synd.SyndEntryImpl;
-import com.sun.syndication.feed.synd.SyndFeed;
-import com.sun.syndication.feed.synd.SyndFeedImpl;
+import com.rometools.rome.feed.synd.SyndEntry;
+import com.rometools.rome.feed.synd.SyndEntryImpl;
+import com.rometools.rome.feed.synd.SyndFeed;
+import com.rometools.rome.feed.synd.SyndFeedImpl;
 
 /**
  * <p>OutageFeed class.</p>
@@ -78,7 +78,7 @@ public class OutageFeed extends AbstractFeed {
     /**
      * <p>getFeed</p>
      *
-     * @return a {@link com.sun.syndication.feed.synd.SyndFeed} object.
+     * @return a {@link com.rometools.rome.feed.synd.SyndFeed} object.
      */
     @Override
     public SyndFeed getFeed() {

--- a/pom.xml
+++ b/pom.xml
@@ -1285,12 +1285,12 @@
     <commonsCsvVersion>1.1</commonsCsvVersion>
     <commonsDigesterVersion>2.1</commonsDigesterVersion>
     <commonsJxpathVersion>1.3</commonsJxpathVersion>
-    <commonsIoVersion>2.4</commonsIoVersion>
+    <commonsIoVersion>2.5</commonsIoVersion>
     <commonsLangVersion>2.6</commonsLangVersion>
     <commonsLang3Version>3.4</commonsLang3Version>
     <commonsLoggingVersion>99.99.99-use-jcl-over-slf4j</commonsLoggingVersion>
     <commonsMath3Version>3.5</commonsMath3Version>
-    <commonsValidatorVersion>1.3.1</commonsValidatorVersion>
+    <commonsValidatorVersion>1.6</commonsValidatorVersion>
     <c3p0Version>0.9.5.2</c3p0Version>
     <curatorVersion>3.2.1</curatorVersion>
     <cxfVersion>3.1.11</cxfVersion>
@@ -3097,7 +3097,7 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-exec</artifactId>
-        <version>1.2</version>
+        <version>1.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.httpcomponents</groupId>
@@ -3170,7 +3170,7 @@
       <dependency>
         <groupId>commons-net</groupId>
         <artifactId>commons-net</artifactId>
-        <version>3.3</version>
+        <version>3.6</version>
       </dependency>
       <dependency>
         <groupId>commons-pool</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -3966,9 +3966,9 @@
         <version>${protobufVersion}</version>
       </dependency>
       <dependency>
-        <groupId>rome</groupId>
+        <groupId>com.rometools</groupId>
         <artifactId>rome</artifactId>
-        <version>1.0</version>
+        <version>1.7.2</version>
       </dependency>
       <dependency>
         <groupId>com.ximpleware</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1299,6 +1299,7 @@
     <dropwizardMetricsVersion>3.1.2</dropwizardMetricsVersion>
     <ecjVersion>4.4.2</ecjVersion>
     <eclipselinkVersion>2.5.1</eclipselinkVersion>
+    <fopVersion>1.0</fopVersion>
     <freemarkerVersion>2.3.21</freemarkerVersion>
     <groovyVersion>2.4.5</groovyVersion>
     <guavaVersion>18.0</guavaVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -3329,9 +3329,9 @@
         <version>2.6.11</version>
       </dependency>
       <dependency>
-        <groupId>net.sf.opencsv</groupId>
+        <groupId>com.opencsv</groupId>
         <artifactId>opencsv</artifactId>
-        <version>2.3</version>
+        <version>3.9</version>
       </dependency>
       <dependency>
         <groupId>net.sf.json-lib</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -3324,9 +3324,9 @@
         <version>${project.version}</version>
       </dependency>
       <dependency>
-        <groupId>ognl</groupId>
+        <groupId>opensymphony</groupId>
         <artifactId>ognl</artifactId>
-        <version>2.6.9</version>
+        <version>2.6.11</version>
       </dependency>
       <dependency>
         <groupId>net.sf.opencsv</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4001,11 +4001,6 @@
         <version>${xmlApisVersion}</version>
       </dependency>
       <dependency>
-        <groupId>xmlrpc</groupId>
-        <artifactId>xmlrpc</artifactId>
-        <version>2.0.1</version>
-      </dependency>
-      <dependency>
         <groupId>org.krupczak</groupId>
         <artifactId>xmp</artifactId>
         <version>1.40</version>

--- a/pom.xml
+++ b/pom.xml
@@ -3951,9 +3951,9 @@
         <version>4.0.3</version>
       </dependency>
       <dependency>
-        <groupId>poi</groupId>
+        <groupId>org.apache.poi</groupId>
         <artifactId>poi</artifactId>
-        <version>2.5.1-final-20040804</version>
+        <version>3.16</version>
       </dependency>
       <dependency>
         <groupId>org.postgresql</groupId>


### PR DESCRIPTION
This PR has some version cleanup and upgrades the version and artifactId of the following dependencies (since these deps have changed artifactId since we started using them):

- OGNL: 2.6.9 → 2.6.11
- opencsv: 2.3 → 3.9
- Rome: 1.0 → 1.7.2

Please don't mark NMS-9330 fixed after this is merged, I have more changes to commit.

* JIRA: http://issues.opennms.org/browse/NMS-9330