### PR TITLE
NMS-9668: Use OWASP HTML sanitizer

### DIFF
--- a/container/features/src/main/resources/features.xml
+++ b/container/features/src/main/resources/features.xml
@@ -257,8 +257,13 @@
       <bundle>wrap:mvn:org.json/json/20140107$Export-Package=org.json</bundle>
     </feature>
 
-    <feature name="owasp-encoder" description="owasp-encoder" version="${owaspEncoderVersion}">
+    <feature name="owasp-encoder" description="OWASP :: Encoder" version="${owaspEncoderVersion}">
       <bundle>wrap:mvn:org.owasp.encoder/encoder/${owaspEncoderVersion}$Export-Package=org.owasp.encoder</bundle>
+    </feature>
+
+    <feature name="owasp-html-sanitizer" description="OWASP :: HTML Sanitizer" version="${waspHtmlSanitizerVersion}">
+      <feature>guava</feature>
+      <bundle>wrap:mvn:com.googlecode.owasp-java-html-sanitizer/owasp-java-html-sanitizer/${owaspHtmlSanitizerVersion}$Export-Package=org.owasp.html</bundle>
     </feature>
 
     <feature name="postgresql" description="PostgreSQL :: JDBC Driver" version="${postgresqlVersion}">
@@ -298,6 +303,7 @@
       <feature>dnsjava</feature>
       <feature>jaxb</feature>
       <feature>owasp-encoder</feature>
+      <feature>owasp-html-sanitizer</feature>
 
       <bundle>mvn:org.opennms.core/org.opennms.core.api/${project.version}</bundle>
       <bundle>mvn:org.opennms.core/org.opennms.core.criteria/${project.version}</bundle>

--- a/container/features/src/main/resources/features.xml
+++ b/container/features/src/main/resources/features.xml
@@ -261,7 +261,7 @@
       <bundle>wrap:mvn:org.owasp.encoder/encoder/${owaspEncoderVersion}$Export-Package=org.owasp.encoder</bundle>
     </feature>
 
-    <feature name="owasp-html-sanitizer" description="OWASP :: HTML Sanitizer" version="${waspHtmlSanitizerVersion}">
+    <feature name="owasp-html-sanitizer" description="OWASP :: HTML Sanitizer" version="${owaspHtmlSanitizerVersion}">
       <feature>guava</feature>
       <bundle>wrap:mvn:com.googlecode.owasp-java-html-sanitizer/owasp-java-html-sanitizer/${owaspHtmlSanitizerVersion}$Export-Package=org.owasp.html</bundle>
     </feature>

--- a/core/lib/pom.xml
+++ b/core/lib/pom.xml
@@ -34,7 +34,7 @@
     </dependency>
     <dependency>
       <groupId>org.opennms.dependencies</groupId>
-      <artifactId>owasp-encoder-dependencies</artifactId>
+      <artifactId>owasp-dependencies</artifactId>
       <scope>compile</scope>
       <type>pom</type>
     </dependency>

--- a/core/lib/src/main/java/org/opennms/core/utils/WebSecurityUtils.java
+++ b/core/lib/src/main/java/org/opennms/core/utils/WebSecurityUtils.java
@@ -59,7 +59,9 @@ public abstract class WebSecurityUtils {
 			// Allows HTTP, HTTPS, MAILTO, and relative links.
 			.and(Sanitizers.LINKS)
 			// Allows certain safe CSS properties in style="..." attributes.
-			.and(Sanitizers.STYLES);
+			.and(Sanitizers.STYLES)
+			// Allows common table elements.
+			.and(Sanitizers.TABLES);
 
     /**
      * <p>sanitizeString</p>

--- a/core/lib/src/main/java/org/opennms/core/utils/WebSecurityUtils.java
+++ b/core/lib/src/main/java/org/opennms/core/utils/WebSecurityUtils.java
@@ -32,6 +32,8 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.owasp.encoder.Encode;
+import org.owasp.html.PolicyFactory;
+import org.owasp.html.Sanitizers;
 
 /**
  * <p>WebSecurityUtils class.</p>
@@ -46,10 +48,18 @@ public abstract class WebSecurityUtils {
 	private static final Pattern ILLEGAL_IN_FLOAT = Pattern.compile("[^0-9.Ee+-]");
 	
 	private static final Pattern ILLEGAL_IN_COLUMN_NAME_PATTERN = Pattern.compile("[^A-Za-z0-9_]");
-	
-    private static final Pattern scriptPattern = Pattern.compile("script", Pattern.CASE_INSENSITIVE);
 
-    private static final Pattern imgOnErrorPattern = Pattern.compile("(img[^>]+)o(nerror=[^>]+>)", Pattern.CASE_INSENSITIVE);
+	private static final PolicyFactory s_sanitizer = Sanitizers
+			// Allows common formatting elements including <b>, <i>, etc.
+			.FORMATTING
+			// Allows common block elements including <p>, <h1>, etc.
+			.and(Sanitizers.BLOCKS)
+			// Allows <img> elements from HTTP, HTTPS, and relative sources.
+			.and(Sanitizers.IMAGES)
+			// Allows HTTP, HTTPS, MAILTO, and relative links.
+			.and(Sanitizers.LINKS)
+			// Allows certain safe CSS properties in style="..." attributes.
+			.and(Sanitizers.STYLES);
 
     /**
      * <p>sanitizeString</p>
@@ -89,11 +99,7 @@ public abstract class WebSecurityUtils {
         String next;
 
         if (allowHTML) {
-            Matcher scriptMatcher = scriptPattern.matcher(raw);
-            next = scriptMatcher.replaceAll("&#x73;cript");
-
-            Matcher imgOnErrorMatcher = imgOnErrorPattern.matcher(next);
-            next = imgOnErrorMatcher.replaceAll("$1&#x6f;$2");
+			next = s_sanitizer.sanitize(raw);
         } else {
             next = Encode.forHtmlContent(raw);
         }

--- a/core/lib/src/test/java/org/opennms/core/utils/WebSecurityUtilsTest.java
+++ b/core/lib/src/test/java/org/opennms/core/utils/WebSecurityUtilsTest.java
@@ -59,15 +59,18 @@ public class WebSecurityUtilsTest {
 
 	@Test
 	public void testHTMLallowedSanitizeString() {
-		String script = "<script>foo</script>";
+		String script = "<script>foo</script><p>valid</p>";
 		String imgXss = "<img src=/ onerror=\"alert('XSS');\"></img>";
-		String html = "<table>";
+		String inputXss = "tst<input type=image src=123 onerror=alert(1)> ";
+		String html = "<table></table>";
 		script = WebSecurityUtils.sanitizeString(script, true);
 		imgXss = WebSecurityUtils.sanitizeString(imgXss, true);
+		inputXss = WebSecurityUtils.sanitizeString(inputXss, true);
 		html = WebSecurityUtils.sanitizeString(html, true);
-		assertEquals("Script is sanitized with HTML allowed", "<&#x73;cript>foo</&#x73;cript>", script);
-                assertEquals("IMG XSS is sanitized with HTML allowed", "<img src=/ &#x6f;nerror=\"alert('XSS');\"></img>", imgXss);
-		assertEquals("HtmlTable is sanitized with HTML allowed, so unchanged", "<table>", html);
+		assertEquals("Script is sanitized with HTML allowed", "<p>valid</p>", script);
+		assertEquals("IMG XSS is sanitized with HTML allowed", "<img src=\"/\" />", imgXss);
+		assertEquals("INPUT XSS is sanitized with HTML allowed", "tst ", inputXss);
+		assertEquals("HtmlTable is sanitized with HTML allowed, so unchanged", "<table></table>", html);
 	}
 
 }

--- a/dependencies/owasp/pom.xml
+++ b/dependencies/owasp/pom.xml
@@ -7,12 +7,12 @@
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.dependencies</groupId>
-  <artifactId>owasp-encoder-dependencies</artifactId>
+  <artifactId>owasp-dependencies</artifactId>
   <packaging>pom</packaging>
-  <name>OpenNMS Dependencies OWASP Java Encoder</name>
+  <name>OpenNMS Dependencies OWASP</name>
   <description>
     This module is used to provide a single artifact that the opennms project
-    can depend on to use the OWASP Java Encoder
+    can depend on to use the OWASP Java Encoder and the OWASP HTML Sanitizer
   </description>
   <dependencies>
     <dependency>
@@ -25,6 +25,11 @@
           <artifactId>junit</artifactId>
         </exclusion>
       </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>com.googlecode.owasp-java-html-sanitizer</groupId>
+      <artifactId>owasp-java-html-sanitizer</artifactId>
+      <version>${owaspHtmlSanitizerVersion}</version>
     </dependency>
   </dependencies>
   <repositories>

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -42,7 +42,7 @@
     <module>mina</module>
     <module>netty</module>
     <module>newts</module>
-    <module>owasp-encoder</module>
+    <module>owasp</module>
     <module>pax-exam</module>
     <module>quartz</module>
     <module>rancid</module>

--- a/opennms-base-assembly/pom.xml
+++ b/opennms-base-assembly/pom.xml
@@ -340,11 +340,6 @@
     </dependency>
     <dependency>
       <groupId>org.opennms.dependencies</groupId>
-      <artifactId>owasp-encoder-dependencies</artifactId>
-      <type>pom</type>
-    </dependency>
-    <dependency>
-      <groupId>org.opennms.dependencies</groupId>
       <artifactId>snmp-dependencies</artifactId>
       <type>pom</type>
     </dependency>

--- a/opennms-full-assembly/pom.xml
+++ b/opennms-full-assembly/pom.xml
@@ -271,11 +271,6 @@
       <type>pom</type>
     </dependency>
     <dependency>
-      <groupId>org.opennms.dependencies</groupId>
-      <artifactId>owasp-encoder-dependencies</artifactId>
-      <type>pom</type>
-    </dependency>
-    <dependency>
       <groupId>org.opennms.features</groupId>
       <artifactId>root-webapp</artifactId>
       <type>war</type>

--- a/pom.xml
+++ b/pom.xml
@@ -1315,7 +1315,7 @@
     <oroVersion>2.0.8</oroVersion>
     <osgiVersion>5.0.0</osgiVersion>
     <osgiEnterpriseVersion>5.0.0</osgiEnterpriseVersion>
-    <owaspEncoderVersion>1.2</owaspEncoderVersion>
+    <owaspEncoderVersion>1.2.1</owaspEncoderVersion>
     <quartzVersion>1.6.5</quartzVersion>
     <slf4jVersion>1.7.21</slf4jVersion>
     <snmp4jVersion>2.5.5</snmp4jVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -1316,6 +1316,7 @@
     <osgiVersion>5.0.0</osgiVersion>
     <osgiEnterpriseVersion>5.0.0</osgiEnterpriseVersion>
     <owaspEncoderVersion>1.2.1</owaspEncoderVersion>
+    <owaspHtmlSanitizerVersion>20170515.1</owaspHtmlSanitizerVersion>
     <quartzVersion>1.6.5</quartzVersion>
     <slf4jVersion>1.7.21</slf4jVersion>
     <snmp4jVersion>2.5.5</snmp4jVersion>
@@ -2671,7 +2672,7 @@
       </dependency>
       <dependency>
         <groupId>org.opennms.dependencies</groupId>
-        <artifactId>owasp-encoder-dependencies</artifactId>
+        <artifactId>owasp-dependencies</artifactId>
         <version>${project.version}</version>
         <type>pom</type>
       </dependency>


### PR DESCRIPTION
JIRA: https://issues.opennms.org/browse/NMS-9668
JIRA: https://issues.opennms.org/browse/NMS-9669

Here we update WebSecurityUtils to use the OWASP HTML Sanitizer for safely rendering strings that we allow to contain HTML.

Our current protection is quite limited since we only filter out a few known patterns.
