### PR TITLE
HZN-1175: Disable bundle ACLs in Karaf

### DIFF
--- a/opennms-full-assembly/src/main/filtered-resources/etc/org.apache.karaf.command.acl.bundle.cfg
+++ b/opennms-full-assembly/src/main/filtered-resources/etc/org.apache.karaf.command.acl.bundle.cfg
@@ -1,0 +1,29 @@
+
+                #
+                # This configuration file defines the ACLs for commands in the bundle subshell
+                #
+                # For an explanation of the syntax of this file, see the file:
+                #   org.apache.karaf.command.acl.system.cfg
+                #
+                # This configuration relies on the fact that 'system' bundles need to be managed
+                # with the
+                #   -f (--force)
+                # flag. Operations with -f need admin permission. Most of these operations without
+                # the 'force' option can be done by a manager.
+
+                # OPENNMS: Disable bundle ACLs
+                #install = admin
+                #refresh[/.*[-][f].*/] = admin
+                #refresh = manager
+                #restart[/.*[-][f].*/] = admin
+                #restart = manager
+                #start[/.*[-][f].*/] = admin
+                #start = manager
+                #stop[/.*[-][f].*/] = admin
+                #stop = manager
+                #uninstall[/.*[-][f].*/] = admin
+                #uninstall = manager
+                #update[/.*[-][f].*/] = admin
+                #update = manager
+                #watch = admin
+            


### PR DESCRIPTION
This disables the bundle ACLs in OpenNMS's Karaf container.

* JIRA: http://issues.opennms.org/browse/HZN-1175