### PR TITLE
NMS-9524: Northbounders implementation are not sending feedback events for reloadDaemonConfig.

### DIFF
--- a/opennms-alarms/api/src/main/java/org/opennms/netmgt/alarmd/api/Northbounder.java
+++ b/opennms-alarms/api/src/main/java/org/opennms/netmgt/alarmd/api/Northbounder.java
@@ -67,6 +67,6 @@ public interface Northbounder {
     /**
      * Reloads configuration.
      */
-    public void reloadConfig();
+    public void reloadConfig() throws NorthbounderException;
 
 }

--- a/opennms-alarms/drools-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/drools/DroolsNorthbounderManager.java
+++ b/opennms-alarms/drools-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/drools/DroolsNorthbounderManager.java
@@ -36,10 +36,7 @@ import org.opennms.core.soa.ServiceRegistry;
 import org.opennms.netmgt.alarmd.api.NorthboundAlarm;
 import org.opennms.netmgt.alarmd.api.Northbounder;
 import org.opennms.netmgt.alarmd.api.NorthbounderException;
-import org.opennms.netmgt.events.api.EventConstants;
 import org.opennms.netmgt.events.api.EventProxy;
-import org.opennms.netmgt.events.api.EventProxyException;
-import org.opennms.netmgt.model.events.EventBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.DisposableBean;
@@ -166,28 +163,15 @@ public class DroolsNorthbounderManager implements Northbounder, InitializingBean
      * Reloads the configuration.
      */
     @Override
-    public void reloadConfig() {
+    public void reloadConfig() throws NorthbounderException {
         // FIXME As this can be expensive, I would say do it on a per-engine basis
-        EventBuilder ebldr = null;
         LOG.info("Reloading Drools northbound configuration.");
         try {
             m_configDao.reload();
             m_registrations.forEach((k,v) -> { if (k != getName()) v.unregister();});
             registerNorthnounders();
-            ebldr = new EventBuilder(EventConstants.RELOAD_DAEMON_CONFIG_SUCCESSFUL_UEI, getName());
-            ebldr.addParam(EventConstants.PARM_DAEMON_NAME, getName());
         } catch (Exception e) {
-            LOG.error("Can't reload the Drools northbound configuration", e);
-            ebldr = new EventBuilder(EventConstants.RELOAD_DAEMON_CONFIG_FAILED_UEI, getName());
-            ebldr.addParam(EventConstants.PARM_DAEMON_NAME, getName());
-            ebldr.addParam(EventConstants.PARM_REASON, e.getMessage());
-        } finally {
-            if (ebldr != null)
-                try {
-                    m_eventProxy.send(ebldr.getEvent());
-                } catch (EventProxyException e) {
-                    LOG.error("Can't send reload status event", e);
-                }
+            throw new NorthbounderException("Can't reload the Drools northbound configuration", e);
         }
     }
 

--- a/opennms-alarms/email-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/email/EmailNorthbounderManager.java
+++ b/opennms-alarms/email-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/email/EmailNorthbounderManager.java
@@ -167,7 +167,7 @@ public class EmailNorthbounderManager implements InitializingBean, Northbounder,
             m_registrations.forEach((k,v) -> { if (k != getName()) v.unregister();});
             registerNorthnounders();
         } catch (Exception e) {
-            LOG.error("Can't reload the SNMP trap northbound configuration", e);
+            throw new NorthbounderException("Can't reload the SNMP trap northbound configuration", e);
         }
     }
 

--- a/opennms-alarms/jms-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/jms/JmsNorthbounderManager.java
+++ b/opennms-alarms/jms-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/jms/JmsNorthbounderManager.java
@@ -148,14 +148,14 @@ public class JmsNorthbounderManager implements InitializingBean, Northbounder, D
      * @see org.opennms.netmgt.alarmd.api.Northbounder#reloadConfig()
      */
     @Override
-    public void reloadConfig() {
+    public void reloadConfig() throws NorthbounderException {
         LOG.info("Reloading JMS northbound configuration.");
         try {
             m_configDao.reload();
             m_registrations.forEach((k,v) -> { if (k != getName()) v.unregister();});
             registerNorthnounders();
         } catch (Exception e) {
-            LOG.error("Can't reload the JMS northbound configuration", e);
+            throw new NorthbounderException("Can't reload the JMS northbound configuration", e);
         }
     }
 

--- a/opennms-alarms/snmptrap-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/snmptrap/SnmpTrapNorthbounderManager.java
+++ b/opennms-alarms/snmptrap-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/snmptrap/SnmpTrapNorthbounderManager.java
@@ -158,14 +158,14 @@ public class SnmpTrapNorthbounderManager implements InitializingBean, Northbound
      * Reloads the configuration.
      */
     @Override
-    public void reloadConfig() {
+    public void reloadConfig() throws NorthbounderException {
         LOG.info("Reloading SNMP Traps northbound configuration.");
         try {
             m_configDao.reload();
             m_registrations.forEach((k,v) -> { if (k != getName()) v.unregister();});
             registerNorthnounders();
         } catch (Exception e) {
-            LOG.error("Can't reload the SNMP trap northbound configuration", e);
+            throw new NorthbounderException("Can't reload the SNMP trap northbound configuration", e);
         }
     }
 

--- a/opennms-alarms/syslog-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/syslog/SyslogNorthbounderManager.java
+++ b/opennms-alarms/syslog-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/syslog/SyslogNorthbounderManager.java
@@ -161,7 +161,7 @@ public class SyslogNorthbounderManager implements InitializingBean, Northbounder
      * Reloads the configuration.
      */
     @Override
-    public void reloadConfig() {
+    public void reloadConfig() throws NorthbounderException {
         LOG.info("Reloading Syslog northbound configuration.");
         try {
             m_configDao.reload();
@@ -169,7 +169,7 @@ public class SyslogNorthbounderManager implements InitializingBean, Northbounder
             Syslog.shutdown(); // Shutdown all Syslog instances.
             registerNorthnounders(); // Re-registering all Syslog destinations.
         } catch (Exception e) {
-            LOG.error("Can't reload the syslog northbound configuration", e);
+            throw new NorthbounderException("Can't reload the Syslog northbound configuration", e);
         }
     }
 }


### PR DESCRIPTION
Northbounders implementation are not sending feedback events for reloadDaemonConfig.

* JIRA: http://issues.opennms.org/browse/NMS-9524

Our [continuous integration system](http://bamboo.internal.opennms.com:8085) will test and verify your changes.

I've created the PR against `foundation-2017` due to the Drools NBI and BSF NBI. For `foundation-2016` I can cherry-pick the solution and manually remove the changes on the NBIs that don't exist there, which is easier than creating 2 separate PRs, one for each foundation branch.