### PR TITLE
NMS-9620 update SNMP exception handling + track sessions

### DIFF
--- a/container/features/src/main/resources/features.xml
+++ b/container/features/src/main/resources/features.xml
@@ -829,6 +829,7 @@
     <feature name="opennms-snmp" description="OpenNMS :: Core :: SNMP" version="${project.version}">
       <feature>org.json</feature>
 
+      <bundle>mvn:org.opennms.core/org.opennms.core.logging/${project.version}</bundle>
       <bundle>mvn:org.opennms.core.snmp/org.opennms.core.snmp.api/${project.version}</bundle>
       <bundle>mvn:org.opennms.core.snmp/org.opennms.core.snmp.implementations.snmp4j/${project.version}</bundle>
       <bundle>mvn:org.opennms.core.snmp/org.opennms.core.snmp.joesnmp/${project.version}</bundle>

--- a/core/snmp/api/src/main/java/org/opennms/netmgt/snmp/AggregateTracker.java
+++ b/core/snmp/api/src/main/java/org/opennms/netmgt/snmp/AggregateTracker.java
@@ -135,7 +135,7 @@ public class AggregateTracker extends CollectionTracker {
             return getRepeaterStartIndex() <= canonicalIndex && canonicalIndex < getRepeaterStartIndex()+getRepeaters();
         }
         
-        public int getChildIndex(int canonicalIndex) {
+        public int getChildIndex(int canonicalIndex) throws SnmpException {
             if (isNonRepeater(canonicalIndex)) {
                 return canonicalIndex - getNonRepeaterStartIndex();
             }
@@ -144,7 +144,7 @@ public class AggregateTracker extends CollectionTracker {
                 return canonicalIndex - getRepeaterStartIndex() + getNonRepeaters();
             }
             
-            throw new IllegalArgumentException("index out of range for tracker "+this);
+            throw new SnmpException("index out of range for tracker "+this);
         }
     }
 
@@ -166,19 +166,19 @@ public class AggregateTracker extends CollectionTracker {
         }
     
         @Override
-        public void processResponse(SnmpObjId snmpObjId, SnmpValue val) {
+        public void processResponse(SnmpObjId snmpObjId, SnmpValue val) throws SnmpException {
             ChildTrackerPduBuilder childBuilder = getChildBuilder(m_currResponseIndex++);
             childBuilder.getResponseProcessor().processResponse(snmpObjId, val);
         }
     
-        public boolean processChildError(int errorStatus, int errorIndex) {
+        public boolean processChildError(int errorStatus, int errorIndex) throws SnmpException {
             int canonicalIndex = getCanonicalIndex(errorIndex-1);
             ChildTrackerPduBuilder childBuilder = getChildBuilder(canonicalIndex);
             int childIndex = childBuilder.getChildIndex(canonicalIndex);
             return childBuilder.getResponseProcessor().processErrors(errorStatus, childIndex+1);
         }
     
-        private ChildTrackerPduBuilder getChildBuilder(int zeroBasedIndex) {
+        private ChildTrackerPduBuilder getChildBuilder(int zeroBasedIndex) throws SnmpException {
             int canonicalIndex = getCanonicalIndex(zeroBasedIndex);
             for (ChildTrackerPduBuilder childBuilder : m_childPduBuilders) {
                 if (childBuilder.isNonRepeater(canonicalIndex) || childBuilder.isRepeater(canonicalIndex)) {
@@ -186,7 +186,7 @@ public class AggregateTracker extends CollectionTracker {
                 }
             }
     
-            throw new IllegalStateException("Unable to find childBuilder for index "+zeroBasedIndex);
+            throw new SnmpException("Unable to find childBuilder for index "+zeroBasedIndex);
         }
     
         private int getCanonicalIndex(int zeroBasedIndex) {
@@ -202,8 +202,8 @@ public class AggregateTracker extends CollectionTracker {
         }
     
         @Override
-        public boolean processErrors(int errorStatus, int errorIndex) {
-            //LOG.trace("processErrors: errorStatus={}, errorIndex={}", errorStatus, errorIndex);;
+        public boolean processErrors(int errorStatus, int errorIndex) throws SnmpException {
+            //LOG.trace("processErrors: errorStatus={}, errorIndex={}", errorStatus, errorIndex);
 
             final ErrorStatus status = ErrorStatus.fromStatus(errorStatus);
 
@@ -211,7 +211,7 @@ public class AggregateTracker extends CollectionTracker {
             if (status == ErrorStatus.TOO_BIG) {
                 int maxVarsPerPdu = m_pduBuilder.getMaxVarsPerPdu();
                 if (maxVarsPerPdu <= 1) {
-                    throw new IllegalArgumentException("Unable to handle tooBigError when maxVarsPerPdu = "+maxVarsPerPdu);
+                    throw new SnmpException("Unable to handle tooBigError when maxVarsPerPdu = "+maxVarsPerPdu);
                 }
                 m_pduBuilder.setMaxVarsPerPdu(maxVarsPerPdu/2);
                 m_tracker.reportTooBigErr("Reducing maxVarsPerPDU for this request.");
@@ -291,7 +291,7 @@ public class AggregateTracker extends CollectionTracker {
     }
     
     @Override
-    public ResponseProcessor buildNextPdu(final PduBuilder parentBuilder) {
+    public ResponseProcessor buildNextPdu(final PduBuilder parentBuilder) throws SnmpException {
         
         // first process the child trackers that aren't finished up to maxVars 
         int count = 0;

--- a/core/snmp/api/src/main/java/org/opennms/netmgt/snmp/CollectionTracker.java
+++ b/core/snmp/api/src/main/java/org/opennms/netmgt/snmp/CollectionTracker.java
@@ -84,7 +84,7 @@ public abstract class CollectionTracker implements Collectable, ProxiableTracker
         m_finished = finished;
     }
 
-    public abstract ResponseProcessor buildNextPdu(PduBuilder pduBuilder);
+    public abstract ResponseProcessor buildNextPdu(PduBuilder pduBuilder) throws SnmpException;
 
     protected void reportTooBigErr(String msg) {
         if (m_parent != null) {

--- a/core/snmp/api/src/main/java/org/opennms/netmgt/snmp/ColumnTracker.java
+++ b/core/snmp/api/src/main/java/org/opennms/netmgt/snmp/ColumnTracker.java
@@ -79,9 +79,9 @@ public class ColumnTracker extends CollectionTracker {
             .toString();
     }
         @Override
-    public ResponseProcessor buildNextPdu(PduBuilder pduBuilder) {
+    public ResponseProcessor buildNextPdu(PduBuilder pduBuilder) throws SnmpException {
         if (pduBuilder.getMaxVarsPerPdu() < 1) {
-            throw new IllegalArgumentException("maxVarsPerPdu < 1");
+            throw new SnmpException("maxVarsPerPdu < 1");
         }
 
         LOG.debug("Requesting oid following: {}", m_last);
@@ -114,13 +114,13 @@ public class ColumnTracker extends CollectionTracker {
             }
 
             @Override
-            public boolean processErrors(int errorStatus, int errorIndex) {
+            public boolean processErrors(int errorStatus, int errorIndex) throws SnmpException {
                 if (m_retries == null) m_retries = getMaxRetries();
                 //LOG.trace("processErrors: errorStatus={}, errorIndex={}, retries={}", errorStatus, errorIndex, m_retries);
 
                 final ErrorStatus status = ErrorStatus.fromStatus(errorStatus);
                 if (status == ErrorStatus.TOO_BIG) {
-                    throw new IllegalArgumentException("Unable to handle tooBigError for next oid request after "+m_last);
+                    throw new SnmpException("Unable to handle tooBigError for next oid request after "+m_last);
                 } else if (status == ErrorStatus.GEN_ERR) {
                     reportGenErr("Received genErr requesting next oid after "+m_last+". Marking column is finished.");
                     errorOccurred();

--- a/core/snmp/api/src/main/java/org/opennms/netmgt/snmp/ResponseProcessor.java
+++ b/core/snmp/api/src/main/java/org/opennms/netmgt/snmp/ResponseProcessor.java
@@ -30,8 +30,8 @@ package org.opennms.netmgt.snmp;
 
 public interface ResponseProcessor {
 
-    void processResponse(SnmpObjId snmpObjId, SnmpValue val);
+    void processResponse(SnmpObjId snmpObjId, SnmpValue val) throws SnmpException;
 
-    boolean processErrors(int errorStatus, int errorIndex);
+    boolean processErrors(int errorStatus, int errorIndex) throws SnmpException;
 
 }

--- a/core/snmp/api/src/main/java/org/opennms/netmgt/snmp/SingleInstanceTracker.java
+++ b/core/snmp/api/src/main/java/org/opennms/netmgt/snmp/SingleInstanceTracker.java
@@ -75,9 +75,9 @@ public class SingleInstanceTracker extends CollectionTracker {
     }
 
     @Override
-    public ResponseProcessor buildNextPdu(PduBuilder pduBuilder) {
+    public ResponseProcessor buildNextPdu(PduBuilder pduBuilder) throws SnmpException {
         if (pduBuilder.getMaxVarsPerPdu() < 1) {
-            throw new IllegalArgumentException("maxVarsPerPdu < 1");
+            throw new SnmpException("maxVarsPerPdu < 1");
         }
         
         SnmpObjId requestOid = m_oid.decrement();
@@ -104,13 +104,13 @@ public class SingleInstanceTracker extends CollectionTracker {
             }
 
             @Override
-            public boolean processErrors(int errorStatus, int errorIndex) {
+            public boolean processErrors(int errorStatus, int errorIndex) throws SnmpException {
                 if (m_retries == null) m_retries = getMaxRetries();
                 //LOG.trace("processErrors: errorStatus={}, errorIndex={}, retries={}", errorStatus, errorIndex, m_retries);
 
                 final ErrorStatus status = ErrorStatus.fromStatus(errorStatus);
                 if (status == ErrorStatus.TOO_BIG) {
-                    throw new IllegalArgumentException("Unable to handle tooBigError for oid request "+m_oid.decrement());
+                    throw new SnmpException("Unable to handle tooBigError for oid request "+m_oid.decrement());
                 } else if (status == ErrorStatus.GEN_ERR) {
                     reportGenErr("Received genErr requesting oid "+m_oid.decrement()+". Marking column as finished.");
                     errorOccurred();

--- a/core/snmp/api/src/main/java/org/opennms/netmgt/snmp/SnmpAgentConfig.java
+++ b/core/snmp/api/src/main/java/org/opennms/netmgt/snmp/SnmpAgentConfig.java
@@ -76,7 +76,7 @@ public class SnmpAgentConfig extends SnmpConfiguration implements Serializable {
 
         final JSONObject protocolConfig = new JSONObject(new JSONTokener(protocolConfigString)).optJSONObject("snmp");
         if (protocolConfig == null) {
-            throw new IllegalArgumentException("Invalid protocol configuration string for SnmpAgentConfig: Expected it to start with snmp object" + protocolConfigString);
+            throw new IllegalStateException("Invalid protocol configuration string for SnmpAgentConfig: Expected it to start with snmp object" + protocolConfigString);
         }
 
         Map<String, String> attributes = new HashMap<>();

--- a/core/snmp/api/src/main/java/org/opennms/netmgt/snmp/SnmpException.java
+++ b/core/snmp/api/src/main/java/org/opennms/netmgt/snmp/SnmpException.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2016 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2017 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -24,23 +24,26 @@
  *     OpenNMS(R) Licensing <license@opennms.org>
  *     http://www.opennms.org/
  *     http://www.opennms.com/
- *******************************************************************************/
+ ******************************************************************************/
 
 package org.opennms.netmgt.snmp;
 
-public class ErrorStatusException extends SnmpException {
+public class SnmpException extends Exception {
     private static final long serialVersionUID = 1L;
 
-    public ErrorStatusException(final ErrorStatus status) {
-        super("SNMP error-status: " + status.toString() + "(" + status.ordinal() + ")");
+    public SnmpException() {
+        super();
     }
 
-    public ErrorStatusException(final ErrorStatus status, final Throwable t) {
-        super("SNMP error-status: " + status.toString() + "(" + status.ordinal() + ")", t);
+    public SnmpException(final String message) {
+        super(message);
     }
 
-    public ErrorStatusException(final ErrorStatus status, final String message) {
-        super("SNMP error-status: " + status.toString() + "(" + status.ordinal() + "): " + message);
+    public SnmpException(final Throwable cause) {
+        super(cause);
     }
 
+    public SnmpException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
 }

--- a/core/snmp/api/src/main/java/org/opennms/netmgt/snmp/SnmpInstId.java
+++ b/core/snmp/api/src/main/java/org/opennms/netmgt/snmp/SnmpInstId.java
@@ -70,7 +70,7 @@ public class SnmpInstId extends SnmpObjId {
 
     public int toInt() {
         if (this.length() != 1)
-            throw new IllegalArgumentException("Cannot convert "+this+" to an int");
+            throw new IllegalStateException("Cannot convert "+this+" to an int");
         
         return getLastSubId();
     }

--- a/core/snmp/api/src/main/java/org/opennms/netmgt/snmp/SnmpWalker.java
+++ b/core/snmp/api/src/main/java/org/opennms/netmgt/snmp/SnmpWalker.java
@@ -28,7 +28,6 @@
 
 package org.opennms.netmgt.snmp;
 
-import java.io.IOException;
 import java.net.InetAddress;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -96,7 +95,7 @@ public abstract class SnmpWalker implements AutoCloseable {
         return (m_pduBuilder == null ? m_maxVarsPerPdu : m_pduBuilder.getMaxVarsPerPdu());
     }
 
-    protected void buildAndSendNextPdu() throws IOException {
+    protected void buildAndSendNextPdu() throws SnmpException {
         if (m_tracker.isFinished()) {
             handleDone();
         } else {
@@ -106,7 +105,7 @@ public abstract class SnmpWalker implements AutoCloseable {
         }
     }
 
-    protected abstract void sendNextPdu(WalkerPduBuilder pduBuilder) throws IOException;
+    protected abstract void sendNextPdu(WalkerPduBuilder pduBuilder) throws SnmpException;
 
     protected void handleDone() {
         finish();
@@ -208,11 +207,11 @@ public abstract class SnmpWalker implements AutoCloseable {
     }
     
     // processErrors returns true if we need to retry the request and false otherwise
-    protected boolean processErrors(int errorStatus, int errorIndex) {
+    protected boolean processErrors(int errorStatus, int errorIndex) throws SnmpException {
         return m_responseProcessor.processErrors(errorStatus, errorIndex);
     }
     
-    protected void processResponse(SnmpObjId receivedOid, SnmpValue val) {
+    protected void processResponse(SnmpObjId receivedOid, SnmpValue val) throws SnmpException {
         m_responseProcessor.processResponse(receivedOid, val);
     }
 

--- a/core/snmp/api/src/main/java/org/opennms/netmgt/snmp/TableTracker.java
+++ b/core/snmp/api/src/main/java/org/opennms/netmgt/snmp/TableTracker.java
@@ -95,7 +95,7 @@ public class TableTracker extends CollectionTracker implements RowCallback, RowR
     }
 
     @Override
-    public ResponseProcessor buildNextPdu(PduBuilder pduBuilder) {
+    public ResponseProcessor buildNextPdu(PduBuilder pduBuilder) throws SnmpException {
         if (pduBuilder.getMaxVarsPerPdu() < 1) {
             throw new IllegalArgumentException("maxVarsPerPdu < 1");
         }
@@ -185,7 +185,7 @@ public class TableTracker extends CollectionTracker implements RowCallback, RowR
         }
 
         @Override
-        public boolean processErrors(int errorStatus, int errorIndex) {
+        public boolean processErrors(int errorStatus, int errorIndex) throws SnmpException {
             
             /*
              * errorIndex is varBind index (1 based array of vars)

--- a/core/snmp/api/src/main/java/org/opennms/netmgt/snmp/TrapInformation.java
+++ b/core/snmp/api/src/main/java/org/opennms/netmgt/snmp/TrapInformation.java
@@ -99,9 +99,9 @@ public abstract class TrapInformation {
     /**
      * Validate the trap.
      *
-     * @throws IllegalArgumentException on validation error.
+     * @throws SnmpException on validation error.
      */
-    public void validate() throws IllegalArgumentException {
+    public void validate() throws SnmpException {
         // by default we do nothing
     }
 

--- a/core/snmp/api/src/test/java/org/opennms/netmgt/snmp/SnmpAgentConfigTest.java
+++ b/core/snmp/api/src/test/java/org/opennms/netmgt/snmp/SnmpAgentConfigTest.java
@@ -29,7 +29,6 @@
 package org.opennms.netmgt.snmp;
 
 import java.net.InetAddress;
-import java.net.UnknownHostException;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -63,7 +62,7 @@ public class SnmpAgentConfigTest {
      * are at least equal.
      */
     @Test
-    public void testProtocolConfiguration() throws UnknownHostException {
+    public void testProtocolConfiguration() throws Exception {
         SnmpAgentConfig config = new SnmpAgentConfig();
         config.setAddress(InetAddress.getByName("127.0.0.1"));
         config.setProxyFor(InetAddress.getByName("127.0.0.1"));
@@ -124,7 +123,7 @@ public class SnmpAgentConfigTest {
     }
 
     @Test
-    public void canConvertToAndFromProtocolConfigString() {
+    public void canConvertToAndFromProtocolConfigString() throws Exception {
         SnmpAgentConfig config = new SnmpAgentConfig();
         String protocolConfigString = "{\"snmp\":{\"address\":null,\"proxyFor\":null,\"port\":\"161\",\"timeout\":\"3000\",\"retries\":\"0\",\"max-vars-per-pdu\":\"10\",\"max-repetitions\":\"2\",\"max-request-size\":\"65535\",\"version\":\"1\",\"security-level\":\"1\",\"security-name\":\"opennmsUser\",\"auth-passphrase\":\"0p3nNMSv3\",\"auth-protocol\":\"MD5\",\"priv-passphrase\":\"0p3nNMSv3\",\"priv-protocol\":\"DES\",\"context-name\":null,\"engine-id\":null,\"context-engine-id\":null,\"enterprise-id\":null,\"read-community\":\"public\",\"write-community\":\"private\"}}";
         Assert.assertEquals(protocolConfigString, config.toProtocolConfigString());

--- a/core/snmp/impl-joesnmp/src/main/java/org/opennms/netmgt/snmp/joesnmp/JoeSnmpWalker.java
+++ b/core/snmp/impl-joesnmp/src/main/java/org/opennms/netmgt/snmp/joesnmp/JoeSnmpWalker.java
@@ -31,6 +31,7 @@ package org.opennms.netmgt.snmp.joesnmp;
 import java.net.SocketException;
 
 import org.opennms.netmgt.snmp.CollectionTracker;
+import org.opennms.netmgt.snmp.SnmpException;
 import org.opennms.netmgt.snmp.SnmpObjId;
 import org.opennms.netmgt.snmp.SnmpValue;
 import org.opennms.netmgt.snmp.SnmpWalker;
@@ -206,9 +207,14 @@ public class JoeSnmpWalker extends SnmpWalker {
     }
 
         @Override
-    protected void sendNextPdu(WalkerPduBuilder pduBuilder) throws SocketException {
+    protected void sendNextPdu(WalkerPduBuilder pduBuilder) throws SnmpException {
         JoeSnmpPduBuilder joePduBuilder = (JoeSnmpPduBuilder)pduBuilder;
-        if (m_session == null) m_session = new SnmpSession(m_peer);
+        if (m_session == null)
+            try {
+                m_session = new SnmpSession(m_peer);
+            } catch (final SocketException e) {
+                throw new SnmpException("Failed to create session to peer " + m_peer.toString(), e);
+            }
         LOG.debug("Sending tracker pdu of size {}", joePduBuilder.getPdu().getLength());
         m_session.send(joePduBuilder.getPdu(), m_handler);
     }

--- a/core/snmp/impl-joesnmp/src/main/java/org/opennms/netmgt/snmp/joesnmp/V2TrapInformation.java
+++ b/core/snmp/impl-joesnmp/src/main/java/org/opennms/netmgt/snmp/joesnmp/V2TrapInformation.java
@@ -30,6 +30,7 @@ package org.opennms.netmgt.snmp.joesnmp;
 
 import java.net.InetAddress;
 
+import org.opennms.netmgt.snmp.SnmpException;
 import org.opennms.netmgt.snmp.SnmpObjId;
 import org.opennms.netmgt.snmp.SnmpValue;
 import org.opennms.netmgt.snmp.SnmpVarBindDTO;
@@ -140,18 +141,18 @@ public class V2TrapInformation extends TrapInformation {
     }
 
     @Override
-    public void validate() {
+    public void validate() throws SnmpException {
         //
         // verify the type
         //
         if (m_pdu.typeId() != (byte) (SnmpPduPacket.V2TRAP)) {
             // if not V2 trap, do nothing
-            throw new IllegalArgumentException("Received not SNMPv2 Trap from host " + getTrapAddress() + "PDU Type = " + m_pdu.getCommand());
+            throw new SnmpException("Received not SNMPv2 Trap from host " + getTrapAddress() + "PDU Type = " + m_pdu.getCommand());
         }
         LOG.debug("V2 trap numVars or pdu length: {}", getPduLength());
         if (getPduLength() < 2) // check number of varbinds
         {
-            throw new IllegalArgumentException("V2 trap from " + getTrapAddress() + " IGNORED due to not having the required varbinds.  Have " + getPduLength() + ", needed 2");
+            throw new SnmpException("V2 trap from " + getTrapAddress() + " IGNORED due to not having the required varbinds.  Have " + getPduLength() + ", needed 2");
         }
         // The first varbind has the sysUpTime
         // Modify the sysUpTime varbind to add the trailing 0 if it is
@@ -166,7 +167,7 @@ public class V2TrapInformation extends TrapInformation {
             varBindName0 = V2TrapInformation.SNMP_SYSUPTIME_OID;
         }
         if ((!(varBindName0.equals(V2TrapInformation.SNMP_SYSUPTIME_OID))) || (!(varBindName1.equals(V2TrapInformation.SNMP_TRAP_OID)))) {
-            throw new IllegalArgumentException("V2 trap from " + getTrapAddress() + " IGNORED due to not having the required varbinds.\n\tThe first varbind must be sysUpTime.0 and the second snmpTrapOID.0\n\tVarbinds received are : " + varBindName0 + " and " + varBindName1);
+            throw new SnmpException("V2 trap from " + getTrapAddress() + " IGNORED due to not having the required varbinds.\n\tThe first varbind must be sysUpTime.0 and the second snmpTrapOID.0\n\tVarbinds received are : " + varBindName0 + " and " + varBindName1);
         }
     }
 

--- a/core/snmp/impl-mock/src/main/java/org/opennms/netmgt/snmp/mock/MockSnmpStrategy.java
+++ b/core/snmp/impl-mock/src/main/java/org/opennms/netmgt/snmp/mock/MockSnmpStrategy.java
@@ -29,7 +29,6 @@
 package org.opennms.netmgt.snmp.mock;
 
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.math.BigInteger;
 import java.net.InetAddress;
 import java.nio.charset.StandardCharsets;

--- a/core/snmp/impl-mock/src/main/java/org/opennms/netmgt/snmp/mock/MockSnmpWalker.java
+++ b/core/snmp/impl-mock/src/main/java/org/opennms/netmgt/snmp/mock/MockSnmpWalker.java
@@ -28,7 +28,6 @@
 
 package org.opennms.netmgt.snmp.mock;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
@@ -39,6 +38,7 @@ import org.opennms.netmgt.snmp.CollectionTracker;
 import org.opennms.netmgt.snmp.ErrorStatus;
 import org.opennms.netmgt.snmp.SnmpAgentAddress;
 import org.opennms.netmgt.snmp.SnmpAgentConfig;
+import org.opennms.netmgt.snmp.SnmpException;
 import org.opennms.netmgt.snmp.SnmpObjId;
 import org.opennms.netmgt.snmp.SnmpValue;
 import org.opennms.netmgt.snmp.SnmpWalker;
@@ -121,7 +121,7 @@ public class MockSnmpWalker extends SnmpWalker {
     }
 
     @Override
-    protected void sendNextPdu(final WalkerPduBuilder pduBuilder) throws IOException {
+    protected void sendNextPdu(final WalkerPduBuilder pduBuilder) throws SnmpException {
         final MockPduBuilder builder = (MockPduBuilder)pduBuilder;
         final List<SnmpObjId> oids = builder.getOids();
         LOG.debug("'Sending' tracker PDU of size {}", oids.size());
@@ -171,7 +171,7 @@ public class MockSnmpWalker extends SnmpWalker {
     }
 
     @Override
-    protected void buildAndSendNextPdu() throws IOException {
+    protected void buildAndSendNextPdu() throws SnmpException {
     	LOG.debug("buildAndSendNextPdu()");
     	super.buildAndSendNextPdu();
     }

--- a/core/snmp/impl-snmp4j/pom.xml
+++ b/core/snmp/impl-snmp4j/pom.xml
@@ -44,6 +44,10 @@
       <artifactId>org.opennms.core.snmp.api</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.opennms.core</groupId>
+      <artifactId>org.opennms.core.logging</artifactId>
+    </dependency>
+    <dependency>
       <groupId>commons-lang</groupId>
       <artifactId>commons-lang</artifactId>
     </dependency>

--- a/core/snmp/impl-snmp4j/src/main/java/org/opennms/netmgt/snmp/snmp4j/Snmp4JStrategy.java
+++ b/core/snmp/impl-snmp4j/src/main/java/org/opennms/netmgt/snmp/snmp4j/Snmp4JStrategy.java
@@ -32,16 +32,23 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.net.SocketException;
 import java.net.UnknownHostException;
+import java.time.Duration;
+import java.time.LocalDateTime;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
 
+import org.opennms.core.logging.Logging;
 import org.opennms.netmgt.snmp.CollectionTracker;
 import org.opennms.netmgt.snmp.SnmpAgentConfig;
 import org.opennms.netmgt.snmp.SnmpConfiguration;
@@ -86,7 +93,6 @@ import org.snmp4j.smi.VariableBinding;
 import org.snmp4j.transport.DefaultUdpTransportMapping;
 
 public class Snmp4JStrategy implements SnmpStrategy {
-
     private static final transient Logger LOG = LoggerFactory.getLogger(Snmp4JStrategy.class);
 
     private static final ExecutorService REAPER_EXECUTOR = Executors.newCachedThreadPool(new ThreadFactory() {
@@ -103,6 +109,12 @@ public class Snmp4JStrategy implements SnmpStrategy {
     private static USM m_usm;
 
     private Snmp4JValueFactory m_valueFactory;
+
+    private static ScheduledExecutorService s_sessionStatsExecutor;
+    private static ConcurrentHashMap<Snmp, SessionInfo> s_sessions;
+    private static boolean s_trackSessions = Boolean.getBoolean("org.opennms.core.snmp.trackSessions");
+    private static long s_trackSummaryDelay = Long.getLong("org.opennms.core.snmp.trackSummaryDelay", 60);
+    private static long s_trackSummaryLimit = Long.getLong("org.opennms.core.snmp.trackSummaryLimit", 10);
 
     /**
      * Initialize for v3 communications
@@ -295,6 +307,7 @@ public class Snmp4JStrategy implements SnmpStrategy {
 
         try {
             session = agentConfig.createSnmpSession();
+            Snmp4JStrategy.trackSession(session);
         } catch (final Exception e) {
             LOG.error("send: Could not create SNMP session for agent {}", agentConfig, e);
             future.completeExceptionally(new SnmpException("Could not create SNMP session for agent", e));
@@ -312,7 +325,8 @@ public class Snmp4JStrategy implements SnmpStrategy {
             }
 
             try {
-                session.send(pdu, agentConfig.getTarget(), null, new ResponseListener() {
+                final Snmp mySession = session;
+                mySession.send(pdu, agentConfig.getTarget(), null, new ResponseListener() {
                     @Override
                     public void onResponse(final ResponseEvent responseEvent) {
                         try {
@@ -326,7 +340,7 @@ public class Snmp4JStrategy implements SnmpStrategy {
                             REAPER_EXECUTOR.submit(new Runnable() {
                                 @Override
                                 public void run() {
-                                    closeQuietly(session);
+                                    closeQuietly(mySession);
                                 }
                             });
                         }
@@ -348,6 +362,7 @@ public class Snmp4JStrategy implements SnmpStrategy {
                 future.completeExceptionally(new SnmpException(e));
             } finally {
                 closeQuietly(session);
+                Snmp4JStrategy.reapSession(session);
             }
         }
     }
@@ -451,6 +466,9 @@ public class Snmp4JStrategy implements SnmpStrategy {
 		}
 
         public void setSession(final Snmp trapSession) {
+            if (m_trapSession != null && m_trapSession != trapSession) {
+                LOG.warn("replacing existing session {} with {}", m_trapSession, trapSession);
+            }
             m_trapSession = trapSession;
         }
         
@@ -522,6 +540,7 @@ public class Snmp4JStrategy implements SnmpStrategy {
 
         info.setTransportMapping(transport);
         Snmp snmp = new Snmp(transport);
+        Snmp4JStrategy.trackSession(snmp);
         snmp.addCommandResponder(trapNotifier);
 
         if (snmpUsers != null) {
@@ -571,23 +590,29 @@ public class Snmp4JStrategy implements SnmpStrategy {
 
     @Override
     public void unregisterForTraps(final TrapNotificationListener listener, InetAddress address, int snmpTrapPort) throws IOException {
+        final RegistrationInfo info = s_registrations.remove(listener);
+        final Snmp session = info.getSession();
         try {
-            final RegistrationInfo info = s_registrations.remove(listener);
-            info.getSession().close();
+            session.close();
         } catch (final IOException e) {
             LOG.error("session error unregistering for traps", e);
             throw e;
+        } finally {
+            Snmp4JStrategy.reapSession(session);
         }
     }
 
     @Override
     public void unregisterForTraps(final TrapNotificationListener listener, final int snmpTrapPort) throws IOException {
+        final RegistrationInfo info = s_registrations.remove(listener);
+        final Snmp session = info.getSession();
         try {
-            final RegistrationInfo info = s_registrations.remove(listener);
-            info.getSession().close();
+            session.close();
         } catch (final IOException e) {
             LOG.error("session error unregistering for traps", e);
             throw e;
+        } finally {
+            Snmp4JStrategy.reapSession(session);
         }
     }
 
@@ -668,7 +693,8 @@ public class Snmp4JStrategy implements SnmpStrategy {
     public void sendTest(String agentAddress, int port, String community, PDU pdu) {
         for (RegistrationInfo info : s_registrations.values()) {
             if (port == info.getPort()) {
-                Snmp snmp = info.getSession();
+                final Snmp snmp = info.getSession();
+                Snmp4JStrategy.trackSession(snmp);
                 MessageDispatcher dispatcher = snmp.getMessageDispatcher();
                 TransportMapping<UdpAddress> transport = info.getTransportMapping();
                 
@@ -693,6 +719,8 @@ public class Snmp4JStrategy implements SnmpStrategy {
             session.close();
         } catch (IOException e) {
             LOG.error("error closing SNMP connection", e);
+        } finally {
+            Snmp4JStrategy.reapSession(session);
         }
     }
 
@@ -700,4 +728,135 @@ public class Snmp4JStrategy implements SnmpStrategy {
 	public byte[] getLocalEngineID() {
 		return MPv3.createLocalEngineID();
 	}
+
+        private static void assertTrackingInitialized() {
+            if (s_sessions == null) {
+                s_sessions = new ConcurrentHashMap<>();
+                s_sessionStatsExecutor = Executors.newSingleThreadScheduledExecutor();
+                s_sessionStatsExecutor.scheduleAtFixedRate(new Runnable() {
+                    @Override public void run() {
+                        logSessionStats();
+                    }
+                }, s_trackSummaryDelay, s_trackSummaryDelay, TimeUnit.SECONDS);
+            }
+        }
+
+        public static void trackSession(final Snmp session) {
+            if (!s_trackSessions || session == null) return;
+            Logging.withPrefix("snmp", () -> {
+                assertTrackingInitialized();
+                if (s_sessions.containsKey(session)) {
+                    LOG.warn("track: session {} is already tracked -- overwriting", s_sessions.get(session));
+                }
+                final SessionInfo ts = new SessionInfo(session);
+                LOG.debug("track: tracking session {}", ts);
+                s_sessions.put(session, ts);
+            });
+        }
+
+        public static void reapSession(final Snmp session) {
+            if (!s_trackSessions || session == null) return;
+            Logging.withPrefix("snmp", () -> {
+                assertTrackingInitialized();
+                if (!s_sessions.containsKey(session)) {
+                    LOG.warn("reap: session {} is not being tracked", session, new Exception());
+                } else {
+                    LOG.debug("reap: reaping session {}", s_sessions.get(session));
+                }
+                s_sessions.remove(session);
+            });
+        }
+
+        private static void logSessionStats() {
+            LOG.debug("SNMP session tracker: {} sessions being tracked on {} unique threads", s_sessions.size(), s_sessions.values().stream().map(si -> {
+                return si.getThread();
+            }).distinct().count());
+            s_sessions.values().stream().sorted(new Comparator<SessionInfo>() {
+                @Override
+                public int compare(final SessionInfo o1, final SessionInfo o2) {
+                    return o1.getStart().compareTo(o2.getStart());
+                }
+            }).limit(s_trackSummaryLimit).forEach((si) -> {
+                LOG.debug("SNMP session tracker: active session: {}", si);
+            });
+        }
+
+        private static class SessionInfo implements Comparable<SessionInfo> {
+            private final Snmp m_session;
+            private final StackTraceElement[] m_stackTrace;
+            private final Thread m_thread;
+            private final LocalDateTime m_start;
+
+            public SessionInfo(final Snmp session) {
+                m_session = session;
+                m_stackTrace = new Exception().getStackTrace();
+                m_thread = Thread.currentThread();
+                m_start = LocalDateTime.now();
+            }
+
+            public Thread getThread() {
+                return m_thread;
+            }
+
+            public LocalDateTime getStart() {
+                return m_start;
+            }
+
+            public String getOutsideCaller() {
+                for (final StackTraceElement ste : m_stackTrace) {
+                    final String name = ste.getClassName();
+                    if (!name.startsWith("org.opennms.netmgt.snmp.snmp4j") && !name.startsWith("org.opennms.core.logging") && !name.startsWith("org.opennms.netmgt.snmp.SnmpUtils")) {
+                        return ste.toString();
+                    }
+                }
+                LOG.warn("unable to determine non-snmp4j caller from stack trace: {}", Arrays.asList(m_stackTrace));
+                return m_stackTrace[0].toString();
+            }
+            @Override
+            public int hashCode() {
+                return Objects.hash(m_session, m_thread);
+            }
+
+            @Override
+            public boolean equals(Object obj) {
+                if (this == obj) {
+                    return true;
+                }
+                if (obj == null) {
+                    return false;
+                }
+                if (getClass() != obj.getClass()) {
+                    return false;
+                }
+                final SessionInfo that = (SessionInfo) obj;
+                return Objects.equals(this.m_session, that.m_session) &&
+                        Objects.equals(this.m_stackTrace, that.m_stackTrace) &&
+                        Objects.equals(this.m_thread, that.m_thread);
+            }
+
+            @Override
+            public int compareTo(final SessionInfo that) {
+                if (this.m_session.hashCode() < that.m_session.hashCode()) {
+                    return -1;
+                } else if (this.m_session.hashCode() > that.m_session.hashCode()) {
+                    return 1;
+                }
+                if (this.m_stackTrace.hashCode() < that.m_stackTrace.hashCode()) {
+                    return -1;
+                } else if (this.m_stackTrace.hashCode() > that.m_stackTrace.hashCode()) {
+                    return 1;
+                }
+                if (this.m_thread.hashCode() < that.m_thread.hashCode()) {
+                    return -1;
+                } else if (this.m_thread.hashCode() > that.m_thread.hashCode()) {
+                    return 1;
+                }
+                return 0;
+            }
+
+            @Override
+            public String toString() {
+                return "SessionInfo[session=" + m_session + ", caller=" + getOutsideCaller() + ", thread=" + m_thread.getName() + ", age=" + Duration.between(m_start, LocalDateTime.now()).getSeconds() + "s]";
+            }
+        }
 }

--- a/core/snmp/impl-snmp4j/src/main/java/org/opennms/netmgt/snmp/snmp4j/Snmp4JTrapNotifier.java
+++ b/core/snmp/impl-snmp4j/src/main/java/org/opennms/netmgt/snmp/snmp4j/Snmp4JTrapNotifier.java
@@ -30,6 +30,7 @@ package org.opennms.netmgt.snmp.snmp4j;
 
 import java.net.InetAddress;
 
+import org.opennms.netmgt.snmp.SnmpException;
 import org.opennms.netmgt.snmp.SnmpObjId;
 import org.opennms.netmgt.snmp.SnmpValue;
 import org.opennms.netmgt.snmp.SnmpVarBindDTO;
@@ -250,16 +251,16 @@ public class Snmp4JTrapNotifier implements CommandResponder {
         }
 
         @Override
-        public void validate() {
+        public void validate() throws SnmpException {
         	int pduType = getPdu().getType();
             if (pduType != PDU.TRAP && pduType != PDU.INFORM) {
-                throw new IllegalArgumentException("Received not SNMPv2 Trap|Inform from host " + getTrapAddress() + " PDU Type = " + PDU.getTypeString(getPdu().getType()));
+                throw new SnmpException("Received not SNMPv2 Trap|Inform from host " + getTrapAddress() + " PDU Type = " + PDU.getTypeString(getPdu().getType()));
             }
             
             LOG.debug("V2 {} numVars or pdu length: {}", m_pduTypeString, getPduLength());
             
             if (getPduLength() < 2) {
-                throw new IllegalArgumentException("V2 "+m_pduTypeString+" from " + getTrapAddress() + " IGNORED due to not having the required varbinds.  Have " + getPduLength() + ", needed at least 2");
+                throw new SnmpException("V2 "+m_pduTypeString+" from " + getTrapAddress() + " IGNORED due to not having the required varbinds.  Have " + getPduLength() + ", needed at least 2");
             }
             
             OID varBindName0 = getVarBindAt(0).getOid();
@@ -284,7 +285,7 @@ public class Snmp4JTrapNotifier implements CommandResponder {
              * snmpTrapOID) are present and in that order.
              */
             if ((!(varBindName0.equals(SNMP_SYSUPTIME_OID))) || (!(varBindName1.equals(SNMP_TRAP_OID)))) {
-                throw new IllegalArgumentException("V2 "+m_pduTypeString+" from " + getTrapAddress() + " IGNORED due to not having the required varbinds.\n\tThe first varbind must be sysUpTime.0 and the second snmpTrapOID.0\n\tVarbinds received are : " + varBindName0 + " and " + varBindName1);
+                throw new SnmpException("V2 "+m_pduTypeString+" from " + getTrapAddress() + " IGNORED due to not having the required varbinds.\n\tThe first varbind must be sysUpTime.0 and the second snmpTrapOID.0\n\tVarbinds received are : " + varBindName0 + " and " + varBindName1);
             }
         }
 

--- a/core/snmp/impl-snmp4j/src/main/java/org/opennms/netmgt/snmp/snmp4j/Snmp4JUtils.java
+++ b/core/snmp/impl-snmp4j/src/main/java/org/opennms/netmgt/snmp/snmp4j/Snmp4JUtils.java
@@ -28,6 +28,7 @@
 
 package org.opennms.netmgt.snmp.snmp4j;
 
+import java.io.IOException;
 import java.net.InetAddress;
 import java.nio.ByteBuffer;
 import java.util.concurrent.CountDownLatch;
@@ -98,6 +99,7 @@ public class Snmp4JUtils {
 		dispatcher.addMessageProcessingModel(new MPv2c());
 
 		final Snmp snmp = new Snmp(dispatcher, responder);
+		Snmp4JStrategy.trackSession(snmp);
 		try {
 			snmp.listen();
 
@@ -116,7 +118,13 @@ public class Snmp4JUtils {
 
 			return bytes.get();
 		} finally {
+		    try {
 			snmp.close();
+		    } catch (final IOException e) {
+		        LOG.error("failed to close SNMP session", e);
+		    } finally {
+		        Snmp4JStrategy.reapSession(snmp);
+		    }
 		}
 	}
 

--- a/core/snmp/impl-snmp4j/src/main/java/org/opennms/netmgt/snmp/snmp4j/Snmp4JWalker.java
+++ b/core/snmp/impl-snmp4j/src/main/java/org/opennms/netmgt/snmp/snmp4j/Snmp4JWalker.java
@@ -223,9 +223,11 @@ public class Snmp4JWalker extends SnmpWalker {
         try {
             if (m_session == null) {
                 m_session = m_agentConfig.createSnmpSession();
+                Snmp4JStrategy.trackSession(m_session);
                 m_session.listen();
             }
         } catch (final IOException e) {
+            close();
             throw new SnmpException(e);
         }
 
@@ -250,6 +252,8 @@ public class Snmp4JWalker extends SnmpWalker {
                 m_session.close();
             } catch (IOException e) {
                 LOG.error("{}: Unexpected Error occured closing SNMP session for: {}", getName(), m_agentConfig, e);
+            } finally {
+                Snmp4JStrategy.reapSession(m_session);
             }
             m_session = null;
         }

--- a/core/snmp/impl-snmp4j/src/main/java/org/opennms/netmgt/snmp/snmp4j/Snmp4JWalker.java
+++ b/core/snmp/impl-snmp4j/src/main/java/org/opennms/netmgt/snmp/snmp4j/Snmp4JWalker.java
@@ -31,6 +31,7 @@ package org.opennms.netmgt.snmp.snmp4j;
 import java.io.IOException;
 
 import org.opennms.netmgt.snmp.CollectionTracker;
+import org.opennms.netmgt.snmp.SnmpException;
 import org.opennms.netmgt.snmp.SnmpObjId;
 import org.opennms.netmgt.snmp.SnmpValue;
 import org.opennms.netmgt.snmp.SnmpWalker;
@@ -134,7 +135,7 @@ public class Snmp4JWalker extends SnmpWalker {
      */
     public class Snmp4JResponseListener implements ResponseListener {
 
-        private void processResponse(final PDU response) {
+        private void processResponse(final PDU response) throws SnmpException {
             try {
                 LOG.debug("Received a tracker PDU of type {} from {} of size {}, errorStatus = {}, errorStatusText = {}, errorIndex = {}", PDU.getTypeString(response.getType()), getAddress(), response.size(), response.getErrorStatus(), response.getErrorStatusText(), response.getErrorIndex());
                 if (response.getType() == PDU.REPORT) {
@@ -154,9 +155,7 @@ public class Snmp4JWalker extends SnmpWalker {
                     }
                     buildAndSendNextPdu();
                 }
-            } catch (final IOException e) {
-                handleFatalError(e);
-            } catch (final RuntimeException e) {
+            } catch (final RuntimeException|SnmpException e) {
                 handleFatalError(e);
             }
         }
@@ -177,7 +176,11 @@ public class Snmp4JWalker extends SnmpWalker {
                 handleError(getName()+": snmpInternalError: " + responseEvent.getError() + " for: " + getAddress(), responseEvent.getError());
             // If we have a PDU in the response, process it
             } else {
-                processResponse(responseEvent.getResponse());
+                try {
+                    processResponse(responseEvent.getResponse());
+                } catch (final SnmpException e) {
+                    handleFatalError(e);
+                }
             }
             
         }
@@ -215,15 +218,25 @@ public class Snmp4JWalker extends SnmpWalker {
     }
 
         @Override
-    protected void sendNextPdu(WalkerPduBuilder pduBuilder) throws IOException {
+    protected void sendNextPdu(WalkerPduBuilder pduBuilder) throws SnmpException {
         Snmp4JPduBuilder snmp4JPduBuilder = (Snmp4JPduBuilder)pduBuilder;
-        if (m_session == null) {
-            m_session = m_agentConfig.createSnmpSession();
-            m_session.listen();
+        try {
+            if (m_session == null) {
+                m_session = m_agentConfig.createSnmpSession();
+                m_session.listen();
+            }
+        } catch (final IOException e) {
+            throw new SnmpException(e);
         }
-        
+
         LOG.debug("Sending tracker pdu of size {}", snmp4JPduBuilder.getPdu().size());
-        m_session.send(snmp4JPduBuilder.getPdu(), m_tgt, null, m_listener);
+        try {
+            m_session.send(snmp4JPduBuilder.getPdu(), m_tgt, null, m_listener);
+        } catch (final IOException e) {
+            LOG.debug("Failed to send pdu of size {}", snmp4JPduBuilder.getPdu().size(), e);
+            close();
+            throw new SnmpException(e);
+        }
     }
     
     protected int getVersion() {

--- a/core/snmp/integration-tests/src/test/java/org/opennms/netmgt/snmp/InstanceTrackerTest.java
+++ b/core/snmp/integration-tests/src/test/java/org/opennms/netmgt/snmp/InstanceTrackerTest.java
@@ -62,15 +62,15 @@ public class InstanceTrackerTest extends TestCase {
 
     }
 
-    public void testSingleInstanceTrackerZeroInstance() {
+    public void testSingleInstanceTrackerZeroInstance() throws Exception {
         testSingleInstanceTracker("0", SnmpObjId.get(m_sysNameOid, "0"));
     }
     
-    public void testSingleInstanceTrackerMultiIdInstance() {
+    public void testSingleInstanceTrackerMultiIdInstance() throws Exception {
         testSingleInstanceTracker("1.2.3", SnmpObjId.get(m_sysNameOid, "1.2.3"));
     }
     
-    public void testSingleInstanceTracker(String instance, SnmpObjId receivedOid) {
+    public void testSingleInstanceTracker(String instance, SnmpObjId receivedOid) throws Exception {
         SnmpInstId inst = new SnmpInstId(instance);
         CollectionTracker it = new SingleInstanceTracker(m_sysNameOid, inst);
         
@@ -80,11 +80,11 @@ public class InstanceTrackerTest extends TestCase {
         assertTrue(it.isFinished());
     }
     
-    private void testCollectionTrackerInnerLoop(CollectionTracker tracker, final SnmpObjId expectedOid, SnmpObjId receivedOid, final int nonRepeaters) {
+    private void testCollectionTrackerInnerLoop(CollectionTracker tracker, final SnmpObjId expectedOid, SnmpObjId receivedOid, final int nonRepeaters) throws Exception {
         testCollectionTrackerInnerLoop(tracker, new SnmpObjId[] { expectedOid }, new SnmpObjId[] { receivedOid }, nonRepeaters);
     }
     
-    private void testCollectionTrackerInnerLoop(CollectionTracker tracker, final SnmpObjId[] expectedOids, SnmpObjId[] receivedOids, final int nonRepeaters) {
+    private void testCollectionTrackerInnerLoop(CollectionTracker tracker, final SnmpObjId[] expectedOids, SnmpObjId[] receivedOids, final int nonRepeaters) throws Exception {
         class OidCheckedPduBuilder extends PduBuilder {
             int count = 0;
 
@@ -117,7 +117,11 @@ public class InstanceTrackerTest extends TestCase {
         ResponseProcessor rp = tracker.buildNextPdu(builder);
         assertNotNull(rp);
         assertEquals(expectedOids.length, builder.getCount());
-        rp.processErrors(0, 0);
+        try {
+            rp.processErrors(0, 0);
+        } catch (SnmpException e) {
+            throw new RuntimeException(e);
+        }
         for (SnmpObjId receivedOid : receivedOids) {
             rp.processResponse(receivedOid, SnmpUtils.getValueFactory().getOctetString("Value".getBytes()));
         }
@@ -125,16 +129,16 @@ public class InstanceTrackerTest extends TestCase {
         
     }
     
-    public void testSingleInstanceTrackerNonZeroInstance() {
+    public void testSingleInstanceTrackerNonZeroInstance() throws Exception {
         testSingleInstanceTracker("1", SnmpObjId.get(m_sysNameOid, "1"));
 
     }
     
-    public void testSingleInstanceTrackerNoMatch() {
+    public void testSingleInstanceTrackerNoMatch() throws Exception {
         testSingleInstanceTracker("0", SnmpObjId.get(m_sysNameOid, "1"));
     }
     
-    public void testInstanceListTrackerWithAllResults() {
+    public void testInstanceListTrackerWithAllResults() throws Exception {
         String[] instances = { "1", "3", "5" };
         CollectionTracker it = new InstanceListTracker(m_sysNameOid, toCommaSeparated(instances));
         
@@ -147,7 +151,7 @@ public class InstanceTrackerTest extends TestCase {
         assertTrue(it.isFinished());
     }
     
-    public void testInstanceListTrackerWithNoResults() {
+    public void testInstanceListTrackerWithNoResults() throws Exception {
         String[] instances = { "1", "3", "5" };
         CollectionTracker it = new InstanceListTracker(m_sysNameOid, toCommaSeparated(instances));
         
@@ -163,7 +167,7 @@ public class InstanceTrackerTest extends TestCase {
     }
 
     
-    public void testColumnTracker() {
+    public void testColumnTracker() throws Exception {
         SnmpObjId colOid = SnmpObjId.get(".1.3.6.1.2.1.1.5");
         SnmpObjId nextColOid = SnmpObjId.get(".1.3.6.1.2.1.1.6.2");
         MyColumnTracker tracker = new MyColumnTracker(colOid);

--- a/core/snmp/integration-tests/src/test/java/org/opennms/netmgt/snmp/SnmpTrackerIT.java
+++ b/core/snmp/integration-tests/src/test/java/org/opennms/netmgt/snmp/SnmpTrackerIT.java
@@ -120,17 +120,17 @@ public class SnmpTrackerIT implements InitializingBean {
         }
 
         @Override
-        public ResponseProcessor buildNextPdu(PduBuilder pduBuilder) {
+        public ResponseProcessor buildNextPdu(PduBuilder pduBuilder) throws SnmpException {
             final ResponseProcessor rp = super.buildNextPdu(pduBuilder);
             final ResponseProcessor errorRp = new ResponseProcessor() {
 
                 @Override
-                public void processResponse(final SnmpObjId snmpObjId, SnmpValue val) {
+                public void processResponse(final SnmpObjId snmpObjId, SnmpValue val) throws SnmpException {
                     rp.processResponse(snmpObjId, val);
                 }
 
                 @Override
-                public boolean processErrors(final int errorStatus, final int errorIndex) {
+                public boolean processErrors(final int errorStatus, final int errorIndex) throws SnmpException {
                     final boolean retry = rp.processErrors(errorStatus, errorIndex);
                     m_errors.add(new ResponseError(ErrorStatus.fromStatus(errorStatus), retry));
                     return retry;

--- a/features/events/traps/src/main/java/org/opennms/netmgt/trapd/TrapInformationWrapper.java
+++ b/features/events/traps/src/main/java/org/opennms/netmgt/trapd/TrapInformationWrapper.java
@@ -31,6 +31,7 @@ package org.opennms.netmgt.trapd;
 import java.util.Objects;
 
 import org.opennms.core.ipc.sink.api.Message;
+import org.opennms.netmgt.snmp.SnmpException;
 import org.opennms.netmgt.snmp.TrapInformation;
 
 /**
@@ -42,7 +43,7 @@ public class TrapInformationWrapper implements Message {
 
     private final TrapInformation trapInformation;
 
-    public TrapInformationWrapper(TrapInformation trapInformation) throws IllegalArgumentException {
+    public TrapInformationWrapper(TrapInformation trapInformation) throws SnmpException {
         this.trapInformation = Objects.requireNonNull(trapInformation);
         trapInformation.validate(); // Before this was at ProcessQueueProcessor which does not exist anymore
     }

--- a/features/events/traps/src/main/java/org/opennms/netmgt/trapd/TrapListener.java
+++ b/features/events/traps/src/main/java/org/opennms/netmgt/trapd/TrapListener.java
@@ -41,6 +41,7 @@ import org.opennms.core.utils.InetAddressUtils;
 import org.opennms.netmgt.config.TrapdConfig;
 import org.opennms.netmgt.config.trapd.TrapdConfiguration;
 import org.opennms.netmgt.dao.api.DistPollerDao;
+import org.opennms.netmgt.snmp.SnmpException;
 import org.opennms.netmgt.snmp.SnmpUtils;
 import org.opennms.netmgt.snmp.TrapInformation;
 import org.opennms.netmgt.snmp.TrapNotificationListener;
@@ -79,7 +80,7 @@ public class TrapListener implements TrapNotificationListener {
                             TrapSinkConsumer.trapdInstrumentation.incErrorCount();
                         }
                     });
-        } catch (IllegalArgumentException ex) {
+        } catch (final SnmpException | IllegalArgumentException ex) {
             LOG.error("Received trap {} is not valid and cannot be processed. The trap will be dropped.", trapInformation, ex);
             // This trap will never reach the sink consumer
             TrapSinkConsumer.trapdInstrumentation.incErrorCount();

--- a/features/poller/monitors/core/src/main/java/org/opennms/netmgt/poller/monitors/SnmpMonitorStrategy.java
+++ b/features/poller/monitors/core/src/main/java/org/opennms/netmgt/poller/monitors/SnmpMonitorStrategy.java
@@ -30,7 +30,6 @@ package org.opennms.netmgt.poller.monitors;
 
 import java.io.IOException;
 import java.math.BigInteger;
-import java.net.InetAddress;
 import java.util.Map;
 import java.util.regex.Pattern;
 

--- a/opennms-base-assembly/src/main/filtered/etc/log4j2.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/log4j2.xml
@@ -197,6 +197,7 @@
         <KeyValuePair key="rtc"                  value="DEBUG" />
         <KeyValuePair key="statsd"               value="DEBUG" />
         <KeyValuePair key="scriptd"              value="DEBUG" />
+        <KeyValuePair key="snmp"                 value="DEBUG" />
         <KeyValuePair key="snmp-poller"          value="DEBUG" />
         <KeyValuePair key="syslogd"              value="DEBUG" />
         <KeyValuePair key="telemetryd"           value="DEBUG" />


### PR DESCRIPTION
As part of the work done on diagnosing NMS-9620, I changed a number of places where a`RuntimeException` (usually `IOException`) was implicitly passed up the call chain and changed them to a new encapsulating exception `SnmpException`.

This PR also adds a session tracker that keeps track of open SNMP sessions and posts a report to an SNMP debug log with statistics on long-running threads.

The session tracker can be enabled by setting `-Dorg.opennms.core.snmp.trackSessions=true`. By default it will print a summary of the top 10 oldest threads every 60 seconds to the SNMP debug log.

The number of threads and the amount of time between summaries (in seconds) can be changed by setting `-Dorg.opennms.core.snmp.trackSummaryLimit=n` and `-Dorg.opennms.core.snmp.trackSummaryDelay=n` respectively.

* JIRA: http://issues.opennms.org/browse/NMS-9620

Our [continuous integration system](http://bamboo.internal.opennms.com:8085) will test and verify your changes.
