### PR TITLE
NMS-9620: Ensure that the snmp4j session is closed

### DIFF
--- a/core/snmp/impl-snmp4j/src/main/java/org/opennms/netmgt/snmp/snmp4j/Snmp4JStrategy.java
+++ b/core/snmp/impl-snmp4j/src/main/java/org/opennms/netmgt/snmp/snmp4j/Snmp4JStrategy.java
@@ -316,7 +316,7 @@ public class Snmp4JStrategy implements SnmpStrategy {
                     public void onResponse(ResponseEvent responseEvent) {
                         try {
                             future.complete(processResponse(agentConfig, responseEvent));
-                        } catch (IOException e) {
+                        } catch (Exception e) {
                             future.completeExceptionally(e);
                         } finally {
                             // Close the tracker using a separate thread


### PR DESCRIPTION
JIRA: https://issues.opennms.org/browse/NMS-9620

This fixes a snmp4j session leak caused by an exception thrown during the call to send().
