### PR TITLE
NMS-9722: fix NPE in string handling

### DIFF
--- a/features/vaadin-surveillance-views/src/main/java/org/opennms/features/vaadin/surveillanceviews/ui/SurveillanceViewConfigurationCategoryWindow.java
+++ b/features/vaadin-surveillance-views/src/main/java/org/opennms/features/vaadin/surveillanceviews/ui/SurveillanceViewConfigurationCategoryWindow.java
@@ -113,7 +113,7 @@ public class SurveillanceViewConfigurationCategoryWindow extends Window {
         labelField.addValidator(new AbstractStringValidator("Please use an unique name for this column/row definition") {
             @Override
             protected boolean isValidValue(String s) {
-                if ("".equals(s.trim())) {
+                if (s == null || s.trim().isEmpty()) {
                     return false;
                 }
 

--- a/features/vaadin-surveillance-views/src/main/java/org/opennms/features/vaadin/surveillanceviews/ui/SurveillanceViewConfigurationWindow.java
+++ b/features/vaadin-surveillance-views/src/main/java/org/opennms/features/vaadin/surveillanceviews/ui/SurveillanceViewConfigurationWindow.java
@@ -105,7 +105,7 @@ public class SurveillanceViewConfigurationWindow extends Window {
         titleField.addValidator(new AbstractStringValidator("Please use an unique name for the surveillance view") {
             @Override
             protected boolean isValidValue(String string) {
-                if ("".equals(string.trim())) {
+                if (string == null || string.trim().isEmpty()) {
                     return false;
                 }
                 if (SurveillanceViewProvider.getInstance().containsView(string) && !view.getName().equals(string)) {
@@ -127,6 +127,7 @@ public class SurveillanceViewConfigurationWindow extends Window {
         refreshSecondsField.addValidator(new AbstractStringValidator("Only numbers allowed here") {
             @Override
             protected boolean isValidValue(String s) {
+                if (s == null || s.trim().isEmpty()) return false;
                 int number;
                 try {
                     number = Integer.parseInt(s);


### PR DESCRIPTION
Since the newer JAXB code cleans out empty strings properly, the editor was NPE'ing trying to call `.trim()` on it.  This PR fixes it.

* JIRA: http://issues.opennms.org/browse/NMS-9722

Our [continuous integration system](http://bamboo.internal.opennms.com:8085) will test and verify your changes.
