### PR TITLE
NMS-9725: improve validation of requisitions

### DIFF
--- a/opennms-provision/opennms-provision-persistence/src/main/java/org/opennms/netmgt/provision/persist/AbstractForeignSourceRepository.java
+++ b/opennms-provision/opennms-provision-persistence/src/main/java/org/opennms/netmgt/provision/persist/AbstractForeignSourceRepository.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2009-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2009-2017 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -34,12 +34,13 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
 
+import javax.xml.bind.ValidationException;
+
 import org.apache.commons.io.IOUtils;
 import org.opennms.core.utils.ConfigFileConstants;
 import org.opennms.core.xml.JaxbUtils;
 import org.opennms.netmgt.provision.persist.foreignsource.ForeignSource;
 import org.opennms.netmgt.provision.persist.requisition.Requisition;
-import org.opennms.netmgt.provision.persist.requisition.RequisitionNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.io.ClassPathResource;
@@ -141,15 +142,10 @@ public abstract class AbstractForeignSourceRepository implements ForeignSourceRe
 
     @Override
     public void validate(final Requisition requisition) throws ForeignSourceRepositoryException {
-        final String foreignSource = requisition.getForeignSource();
-        if (foreignSource.contains("/")) {
-            throw new ForeignSourceRepositoryException("Foreign Source (" + foreignSource + ") contains invalid characters. ('/' is forbidden.)");
-        }
-        for (final RequisitionNode node : requisition.getNodes()) {
-            final String foreignId = node.getForeignId();
-            if (foreignId.contains("/")) {
-                throw new ForeignSourceRepositoryException("Foreign ID (" + foreignId + ") for node " + node.getNodeLabel() + " in Foreign Source " + foreignSource + " contains invalid characters. '/' is forbidden.)");
-            }
+        try {
+            requisition.validate();
+        } catch (final ValidationException e) {
+            throw new ForeignSourceRepositoryException(e.getMessage(), e);
         }
     }
 

--- a/opennms-provision/opennms-provision-persistence/src/main/java/org/opennms/netmgt/provision/persist/requisition/Requisition.java
+++ b/opennms-provision/opennms-provision-persistence/src/main/java/org/opennms/netmgt/provision/persist/requisition/Requisition.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2009-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2009-2017 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -468,8 +468,16 @@ public class Requisition implements Serializable, Comparable<Requisition> {
     	final Map<String,Integer> foreignSourceCounts = new HashMap<String,Integer>();
     	final Set<String> errors = new HashSet<String>();
 
+    	if (m_foreignSource == null) {
+    	    throw new ValidationException("Requisition 'foreign-source' must be set!");
+    	}
+    	if (m_foreignSource.contains("/")) {
+            throw new ValidationException("Foreign Source (" + m_foreignSource + ") contains invalid characters. ('/' is forbidden.)");
+    	}
+
     	for (final RequisitionNode node : m_nodes) {
     		final String foreignId = node.getForeignId();
+    		node.validate();
 			Integer count = foreignSourceCounts.get(foreignId);
 			foreignSourceCounts.put(foreignId, count == null? 1 : ++count);
     	}

--- a/opennms-provision/opennms-provision-persistence/src/main/java/org/opennms/netmgt/provision/persist/requisition/RequisitionAsset.java
+++ b/opennms-provision/opennms-provision-persistence/src/main/java/org/opennms/netmgt/provision/persist/requisition/RequisitionAsset.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2009-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2009-2017 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -36,6 +36,7 @@
 
 package org.opennms.netmgt.provision.persist.requisition;
 
+import javax.xml.bind.ValidationException;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
@@ -112,6 +113,15 @@ public class RequisitionAsset implements Comparable<RequisitionAsset> {
      */
     public void setValue(String value) {
         m_value = value;
+    }
+
+    public void validate() throws ValidationException {
+        if (m_name == null) {
+            throw new ValidationException("Requisition asset 'name' is a required attribute!");
+        }
+        if (m_value == null) {
+            throw new ValidationException("Requisition asset 'value' is a required attribute!");
+        }
     }
 
     @Override

--- a/opennms-provision/opennms-provision-persistence/src/main/java/org/opennms/netmgt/provision/persist/requisition/RequisitionCategory.java
+++ b/opennms-provision/opennms-provision-persistence/src/main/java/org/opennms/netmgt/provision/persist/requisition/RequisitionCategory.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2009-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2009-2017 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -36,6 +36,7 @@
 
 package org.opennms.netmgt.provision.persist.requisition;
 
+import javax.xml.bind.ValidationException;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
@@ -89,6 +90,12 @@ public class RequisitionCategory implements Comparable<RequisitionCategory> {
      */
     public void setName(String value) {
         m_name = value;
+    }
+
+    public void validate() throws ValidationException {
+        if (m_name == null || m_name.trim().isEmpty()) {
+            throw new ValidationException("Requisition category 'name' is a required attribute!");
+        }
     }
 
     @Override

--- a/opennms-provision/opennms-provision-persistence/src/main/java/org/opennms/netmgt/provision/persist/requisition/RequisitionInterface.java
+++ b/opennms-provision/opennms-provision-persistence/src/main/java/org/opennms/netmgt/provision/persist/requisition/RequisitionInterface.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2009-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2009-2017 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -40,6 +40,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
+import javax.xml.bind.ValidationException;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
@@ -379,6 +380,17 @@ public class RequisitionInterface implements Comparable<RequisitionInterface> {
      */
     public void setStatus(Integer value) {
         m_status = value;
+    }
+
+    public void validate() throws ValidationException {
+        if (m_ipAddress == null) {
+            throw new ValidationException("Requisition interface 'ip-addr' is a required attribute!");
+        }
+        if (m_monitoredServices != null) {
+            for (final RequisitionMonitoredService svc : m_monitoredServices) {
+                svc.validate();
+            }
+        }
     }
 
     @Override

--- a/opennms-provision/opennms-provision-persistence/src/main/java/org/opennms/netmgt/provision/persist/requisition/RequisitionMonitoredService.java
+++ b/opennms-provision/opennms-provision-persistence/src/main/java/org/opennms/netmgt/provision/persist/requisition/RequisitionMonitoredService.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2009-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2009-2017 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -40,6 +40,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
+import javax.xml.bind.ValidationException;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
@@ -193,6 +194,17 @@ public class RequisitionMonitoredService implements Comparable<RequisitionMonito
      */
     public void setServiceName(String value) {
         m_serviceName = value;
+    }
+
+    public void validate() throws ValidationException {
+        if (m_serviceName == null) {
+            throw new ValidationException("Requisition monitored-service 'service-name' is a required attribute!");
+        }
+        if (m_categories != null) {
+            for (final RequisitionCategory cat : m_categories) {
+                cat.validate();
+            }
+        }
     }
 
     @Override

--- a/opennms-provision/opennms-provision-persistence/src/main/java/org/opennms/netmgt/provision/persist/requisition/RequisitionNode.java
+++ b/opennms-provision/opennms-provision-persistence/src/main/java/org/opennms/netmgt/provision/persist/requisition/RequisitionNode.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2009-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2009-2017 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -34,6 +34,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.TreeSet;
 
+import javax.xml.bind.ValidationException;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
@@ -493,6 +494,33 @@ public class RequisitionNode {
      */
     public void setParentNodeLabel(String value) {
         m_parentNodeLabel = value != null && "".equals(value.trim()) ? null : value;
+    }
+
+    public void validate() throws ValidationException {
+        if (m_nodeLabel == null) {
+            throw new ValidationException("Requisition node 'node-label' is a required attribute!");
+        }
+        if (m_foreignId == null) {
+            throw new ValidationException("Requisition node 'foreign-id' is a required attribute!");
+        }
+        if (m_foreignId.contains("/")) {
+            throw new ValidationException("Node foreign ID (" + m_foreignId + ") contains invalid characters. ('/' is forbidden.)");
+        }
+        if (m_interfaces != null) {
+            for (final RequisitionInterface iface : m_interfaces) {
+                iface.validate();
+            }
+        }
+        if (m_categories != null) {
+            for (final RequisitionCategory cat : m_categories) {
+                cat.validate();
+            }
+        }
+        if (m_assets != null) {
+            for (final RequisitionAsset asset : m_assets) {
+                asset.validate();
+            }
+        }
     }
 
     @Override

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/RequisitionRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/RequisitionRestService.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2009-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2009-2017 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -468,6 +468,12 @@ public class RequisitionRestService extends OnmsRestService {
     @Consumes({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
     @Transactional
     public Response addOrReplaceNode(@Context final UriInfo uriInfo, @PathParam("foreignSource") String foreignSource, RequisitionNode node) {
+        try {
+            node.validate();
+        } catch (final ValidationException e) {
+            LOG.debug("error validating incoming node '{}'", node, e);
+            throw getException(Status.BAD_REQUEST, e.getMessage());
+        }
         debug("addOrReplaceNode: Adding node %s to requisition %s", node.getForeignId(), foreignSource);
         m_accessService.addOrReplaceNode(foreignSource, node);
         return Response.accepted().header("Location", getRedirectUri(uriInfo, node.getForeignId())).build();
@@ -486,6 +492,12 @@ public class RequisitionRestService extends OnmsRestService {
     @Consumes({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
     @Transactional
     public Response addOrReplaceInterface(@Context final UriInfo uriInfo, @PathParam("foreignSource") String foreignSource, @PathParam("foreignId") String foreignId, RequisitionInterface iface) {
+        try {
+            iface.validate();
+        } catch (final ValidationException e) {
+            LOG.debug("error validating incoming interface '{}'", iface, e);
+            throw getException(Status.BAD_REQUEST, e.getMessage());
+        }
         debug("addOrReplaceInterface: Adding interface %s to node %s/%s", iface, foreignSource, foreignId);
         m_accessService.addOrReplaceInterface(foreignSource, foreignId, iface);
         return Response.accepted().header("Location", getRedirectUri(uriInfo, iface.getIpAddr())).build();
@@ -505,6 +517,12 @@ public class RequisitionRestService extends OnmsRestService {
     @Consumes({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
     @Transactional
     public Response addOrReplaceService(@Context final UriInfo uriInfo, @PathParam("foreignSource") String foreignSource, @PathParam("foreignId") String foreignId, @PathParam("ipAddress") String ipAddress, RequisitionMonitoredService service) {
+        try {
+            service.validate();
+        } catch (final ValidationException e) {
+            LOG.debug("error validating incoming service '{}'", service, e);
+            throw getException(Status.BAD_REQUEST, e.getMessage());
+        }
         debug("addOrReplaceService: Adding service %s to node %s/%s, interface %s", service.getServiceName(), foreignSource, foreignId, ipAddress);
         m_accessService.addOrReplaceService(foreignSource, foreignId, ipAddress, service);
         return Response.accepted().header("Location", getRedirectUri(uriInfo, service.getServiceName())).build();
@@ -523,6 +541,12 @@ public class RequisitionRestService extends OnmsRestService {
     @Consumes({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
     @Transactional
     public Response addOrReplaceNodeCategory(@Context final UriInfo uriInfo, @PathParam("foreignSource") String foreignSource, @PathParam("foreignId") String foreignId, RequisitionCategory category) {
+        try {
+            category.validate();
+        } catch (final ValidationException e) {
+            LOG.debug("error validating incoming category '{}'", category, e);
+            throw getException(Status.BAD_REQUEST, e.getMessage());
+        }
         debug("addOrReplaceNodeCategory: Adding category %s to node %s/%s", category.getName(), foreignSource, foreignId);
         m_accessService.addOrReplaceNodeCategory(foreignSource, foreignId, category);
         return Response.accepted().header("Location", getRedirectUri(uriInfo, category.getName())).build();
@@ -541,6 +565,12 @@ public class RequisitionRestService extends OnmsRestService {
     @Consumes({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
     @Transactional
     public Response addOrReplaceNodeAssetParameter(@Context final UriInfo uriInfo, @PathParam("foreignSource") String foreignSource, @PathParam("foreignId") String foreignId, RequisitionAsset asset) {
+        try {
+            asset.validate();
+        } catch (final ValidationException e) {
+            LOG.debug("error validating incoming asset '{}'", asset, e);
+            throw getException(Status.BAD_REQUEST, e.getMessage());
+        }
         debug("addOrReplaceNodeCategory: Adding asset %s to node %s/%s", asset.getName(), foreignSource, foreignId);
         m_accessService.addOrReplaceNodeAssetParameter(foreignSource, foreignId, asset);
         return Response.accepted().header("Location", getRedirectUri(uriInfo, asset.getName())).build();

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/RequisitionRestServiceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/RequisitionRestServiceIT.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2009-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2009-2017 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -340,6 +340,14 @@ public class RequisitionRestServiceIT extends AbstractSpringJerseyRestTestCase {
         }
         assertNotNull("we should have an exception", ex);
         assertTrue("validator should expect only elements", ex.getMessage().contains("content type is element-only"));
+    }
+
+    @Test
+    public void testBadNodeRequest() throws Exception {
+        createRequisition();
+
+        final String req = "<node label=\"bad-node\" foreignSource=\"test\" building=\"Office\" type=\"A\" foreignId=\"bad-node\" />\n";
+        sendPost("/requisitions/test/nodes", req, 400, null);
     }
 
     @Test

--- a/opennms-webapp/src/test/resources/tec_dump.xml
+++ b/opennms-webapp/src/test/resources/tec_dump.xml
@@ -19,7 +19,7 @@
         <category name="UK"/>
         <category name="low"/>
 	</node>
-	<node node-label="djgregor" parent-node-label="apknd" foreign-id="4243">
+	<node node-label="djgregor" parent-node-label="apknd" foreign-id="4244">
 		<interface ip-addr="192.0.2.207" status="1" snmp-primary="S" descr="VPN interface">
 			<monitored-service service-name="ICMP"/>
 			<monitored-service service-name="HTTP"/>


### PR DESCRIPTION
This PR adds validation for sub-objects of the requisition, and normalizes the way validation is performed in the ReST interface.

* JIRA: http://issues.opennms.org/browse/NMS-9725

Our [continuous integration system](http://bamboo.internal.opennms.com:8085) will test and verify your changes.
