### PR TITLE
NMS-9724: add validation of the event before attempting to send it

### DIFF
--- a/core/xml/src/main/java/org/opennms/core/xml/JaxbUtils.java
+++ b/core/xml/src/main/java/org/opennms/core/xml/JaxbUtils.java
@@ -432,7 +432,10 @@ public abstract class JaxbUtils {
                     };
                 }
                 if (schemaInputStream == null) {
-                    final URL schemaResource = Thread.currentThread().getContextClassLoader().getResource("xsds/" + schemaFileName);
+                    URL schemaResource = Thread.currentThread().getContextClassLoader().getResource("xsds/" + schemaFileName);
+                    if (schemaResource == null) {
+                        schemaResource = clazz.getClassLoader().getResource("xsds/" + schemaFileName);
+                    }
                     if (schemaResource == null) {
                         LOG.debug("Unable to load resource xsds/{} from the classpath.", schemaFileName);
                     } else {

--- a/features/events/api/pom.xml
+++ b/features/events/api/pom.xml
@@ -37,6 +37,11 @@
       <artifactId>commons-lang</artifactId>
     </dependency>
     <dependency>
+      <groupId>javax.validation</groupId>
+      <artifactId>validation-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.opennms.dependencies</groupId>
       <artifactId>castor-dependencies</artifactId>
       <type>pom</type>
@@ -67,6 +72,21 @@
       <groupId>org.hibernate.javax.persistence</groupId>
       <artifactId>hibernate-jpa-2.0-api</artifactId>
       <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.opennms.core.test-api</groupId>
+      <artifactId>org.opennms.core.test-api.lib</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hibernate</groupId>
+      <artifactId>hibernate-validator-annotation-processor</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 </project>

--- a/features/events/api/src/main/java/org/opennms/netmgt/xml/event/AlarmData.java
+++ b/features/events/api/src/main/java/org/opennms/netmgt/xml/event/AlarmData.java
@@ -37,6 +37,9 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
+import javax.validation.Valid;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
@@ -61,12 +64,15 @@ public class AlarmData implements Serializable {
      * Field _reductionKey.
      */
 	@XmlAttribute(name="reduction-key", required=true)
+	@NotNull
     private java.lang.String _reductionKey;
 
     /**
      * Field _alarmType.
      */
 	@XmlAttribute(name="alarm-type", required=true)
+	@NotNull
+	@Min(1)
     private Integer _alarmType;
 
     /**
@@ -97,6 +103,7 @@ public class AlarmData implements Serializable {
 	 * Field m_updateField
 	 */
     @XmlElement(name="update-field", required=false)
+    @Valid
     private List<UpdateField> m_updateFieldList = new ArrayList<UpdateField>();
     
 

--- a/features/events/api/src/main/java/org/opennms/netmgt/xml/event/Autoacknowledge.java
+++ b/features/events/api/src/main/java/org/opennms/netmgt/xml/event/Autoacknowledge.java
@@ -41,6 +41,8 @@ package org.opennms.netmgt.xml.event;
 
 import java.io.Serializable;
 
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
@@ -72,12 +74,14 @@ public class Autoacknowledge implements Serializable {
      * internal content storage
      */
 	@XmlValue
+	@NotNull
     private java.lang.String _content = "";
 
     /**
      * Field _state.
      */
 	@XmlAttribute(name="state")
+	@Pattern(regexp="(on|off)")
     private java.lang.String _state = "on";
 
 

--- a/features/events/api/src/main/java/org/opennms/netmgt/xml/event/Autoaction.java
+++ b/features/events/api/src/main/java/org/opennms/netmgt/xml/event/Autoaction.java
@@ -41,6 +41,8 @@ package org.opennms.netmgt.xml.event;
 
 import java.io.Serializable;
 
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
@@ -70,12 +72,14 @@ public class Autoaction implements Serializable {
      * internal content storage
      */
 	@XmlValue
+	@NotNull
     private java.lang.String _content = "";
 
     /**
      * Field _state.
      */
 	@XmlAttribute(name="state")
+	@Pattern(regexp="(on|off)")
     private java.lang.String _state = "on";
 
 

--- a/features/events/api/src/main/java/org/opennms/netmgt/xml/event/Correlation.java
+++ b/features/events/api/src/main/java/org/opennms/netmgt/xml/event/Correlation.java
@@ -41,6 +41,7 @@ package org.opennms.netmgt.xml.event;
 
 import java.io.Serializable;
 
+import javax.validation.constraints.Pattern;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
@@ -70,12 +71,14 @@ public class Correlation implements Serializable {
      *  correlated
      */
 	@XmlAttribute(name="state")
+	@Pattern(regexp="(on|off)")
     private java.lang.String _state = "off";
 
     /**
      * Field _path.
      */
 	@XmlAttribute(name="path")
+	@Pattern(regexp="(suppressDuplicates|cancellingEvent|suppressAndCancel|pathOutage)")
     private java.lang.String _path = "suppressDuplicates".intern();
 
     /**

--- a/features/events/api/src/main/java/org/opennms/netmgt/xml/event/Event.java
+++ b/features/events/api/src/main/java/org/opennms/netmgt/xml/event/Event.java
@@ -45,6 +45,9 @@ import java.util.Enumeration;
 import java.util.Iterator;
 import java.util.List;
 
+import javax.validation.Valid;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
@@ -70,6 +73,7 @@ public class Event implements Serializable {
 	/**
 	 * The event database id
 	 */
+	@Min(1)
 	@XmlElement(name = "dbid")
 	private Integer _dbid;
 
@@ -96,6 +100,7 @@ public class Event implements Serializable {
 	 * The event mask which helps to uniquely identify an event
 	 */
 	@XmlElement(name = "mask")
+	@Valid
 	private Mask _mask;
 
 	/**
@@ -107,6 +112,7 @@ public class Event implements Serializable {
 	/**
 	 * Field _source.
 	 */
+	@NotNull
 	@XmlElement(name = "source")
 	private String _source;
 
@@ -124,6 +130,7 @@ public class Event implements Serializable {
 	 */
 	@XmlElement(name = "time")
 	@XmlJavaTypeAdapter(DateTimeAdapter.class)
+	@NotNull
 	private Date _time;
 
 	/**
@@ -157,6 +164,7 @@ public class Event implements Serializable {
 	 * The snmp information from the trap
 	 */
 	@XmlElement(name = "snmp")
+	@Valid
 	private Snmp _snmp;
 
 	/**
@@ -164,6 +172,7 @@ public class Event implements Serializable {
 	 */
 	@XmlElementWrapper(name="parms")
 	@XmlElement(name="parm")
+	@Valid
 	private List<Parm> _parms;
 
 	/**
@@ -176,6 +185,7 @@ public class Event implements Serializable {
 	 * The event logmsg
 	 */
 	@XmlElement(name = "logmsg")
+	@Valid
 	private Logmsg _logmsg;
 
 	/**
@@ -194,6 +204,7 @@ public class Event implements Serializable {
 	 * The event correlation information
 	 */
 	@XmlElement(name = "correlation")
+	@Valid
 	private Correlation _correlation;
 
 	/**
@@ -206,18 +217,21 @@ public class Event implements Serializable {
 	 * The automatic action to occur when this event occurs
 	 */
 	@XmlElement(name = "autoaction")
+	@Valid
 	private List<Autoaction> _autoactionList;
 
 	/**
 	 * The operator action to be taken when this event occurs
 	 */
 	@XmlElement(name = "operaction")
+	@Valid
 	private List<Operaction> _operactionList;
 
 	/**
 	 * The autoacknowledge information for the user
 	 */
 	@XmlElement(name = "autoacknowledge")
+	@Valid
 	private Autoacknowledge _autoacknowledge;
 
 	/**
@@ -230,18 +244,21 @@ public class Event implements Serializable {
 	 * The trouble ticket info
 	 */
 	@XmlElement(name = "tticket")
+	@Valid
 	private Tticket _tticket;
 
 	/**
 	 * The forwarding information for this event
 	 */
 	@XmlElement(name = "forward")
+	@Valid
 	private List<Forward> _forwardList;
 
 	/**
 	 * The script information for this event
 	 */
 	@XmlElement(name = "script")
+	@Valid
 	private List<Script> _scriptList;
 
 	/**
@@ -267,6 +284,7 @@ public class Event implements Serializable {
 	 * Data used to create an event.
 	 */
 	@XmlElement(name = "alarm-data")
+	@Valid
 	private AlarmData _alarmData;
 
 	// ----------------/

--- a/features/events/api/src/main/java/org/opennms/netmgt/xml/event/EventReceipt.java
+++ b/features/events/api/src/main/java/org/opennms/netmgt/xml/event/EventReceipt.java
@@ -41,6 +41,7 @@ package org.opennms.netmgt.xml.event;
 
 import java.io.Serializable;
 
+import javax.validation.constraints.Size;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
@@ -68,6 +69,7 @@ public class EventReceipt implements Serializable {
      * Field _uuidList.
      */
 	@XmlElement(name="uuid")
+	@Size(min=1)
     private java.util.List<java.lang.String> _uuidList;
 
 

--- a/features/events/api/src/main/java/org/opennms/netmgt/xml/event/Events.java
+++ b/features/events/api/src/main/java/org/opennms/netmgt/xml/event/Events.java
@@ -43,6 +43,8 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.validation.Valid;
+import javax.validation.constraints.Size;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
@@ -70,6 +72,8 @@ public class Events implements Serializable {
      * Field _eventList.
      */
 	@XmlElement(name="event")
+	@Size(min=1)
+	@Valid
     private java.util.List<org.opennms.netmgt.xml.event.Event> _eventList;
 
 

--- a/features/events/api/src/main/java/org/opennms/netmgt/xml/event/Forward.java
+++ b/features/events/api/src/main/java/org/opennms/netmgt/xml/event/Forward.java
@@ -41,6 +41,8 @@ package org.opennms.netmgt.xml.event;
 
 import java.io.Serializable;
 
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
@@ -72,18 +74,21 @@ public class Forward implements Serializable {
      * internal content storage
      */
 	@XmlValue
+	@NotNull
     private java.lang.String _content = "";
 
     /**
      * Field _state.
      */
 	@XmlAttribute(name="state")
+	@Pattern(regexp="(on|off)")
     private java.lang.String _state = "off";
 
     /**
      * Field _mechanism.
      */
 	@XmlAttribute(name="mechanism")
+	@Pattern(regexp="(snmpudp|snmptcp|xmltcp|xmludp)")
     private java.lang.String _mechanism = "snmpudp";
 
 

--- a/features/events/api/src/main/java/org/opennms/netmgt/xml/event/Log.java
+++ b/features/events/api/src/main/java/org/opennms/netmgt/xml/event/Log.java
@@ -41,6 +41,8 @@ package org.opennms.netmgt.xml.event;
 
 import java.io.Serializable;
 
+import javax.validation.Valid;
+import javax.validation.constraints.Size;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
@@ -68,12 +70,15 @@ public class Log implements Serializable {
      * Field _header.
      */
     @XmlElement(name="header", required=false)
+    @Valid
     private org.opennms.netmgt.xml.event.Header _header;
 
     /**
      * Field _events.
      */
     @XmlElement(name="events", required=true)
+    @Size(min=1)
+    @Valid
     private org.opennms.netmgt.xml.event.Events _events;
 
 

--- a/features/events/api/src/main/java/org/opennms/netmgt/xml/event/Logmsg.java
+++ b/features/events/api/src/main/java/org/opennms/netmgt/xml/event/Logmsg.java
@@ -41,6 +41,8 @@ package org.opennms.netmgt.xml.event;
 
 import java.io.Serializable;
 
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
@@ -79,6 +81,7 @@ public class Logmsg implements Serializable {
      * internal content storage
      */
 	@XmlValue
+	@NotNull
     private java.lang.String _content = "";
 
     /**
@@ -91,6 +94,7 @@ public class Logmsg implements Serializable {
      * Field _dest.
      */
     @XmlAttribute(name="dest")
+    @Pattern(regexp="(logndisplay|displayonly|logonly|suppress|donotpersist)")
     private java.lang.String _dest = "logndisplay".intern();
 
 

--- a/features/events/api/src/main/java/org/opennms/netmgt/xml/event/Mask.java
+++ b/features/events/api/src/main/java/org/opennms/netmgt/xml/event/Mask.java
@@ -41,6 +41,8 @@ package org.opennms.netmgt.xml.event;
 
 import java.io.Serializable;
 
+import javax.validation.Valid;
+import javax.validation.constraints.Size;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
@@ -74,6 +76,8 @@ public class Mask implements Serializable {
      * The mask element
      */
 	@XmlElement(name="maskelement", required=true, nillable = false)
+	@Size(min=1)
+	@Valid
     private java.util.List<org.opennms.netmgt.xml.event.Maskelement> _maskelementList;
 
 

--- a/features/events/api/src/main/java/org/opennms/netmgt/xml/event/Maskelement.java
+++ b/features/events/api/src/main/java/org/opennms/netmgt/xml/event/Maskelement.java
@@ -41,6 +41,8 @@ package org.opennms.netmgt.xml.event;
 
 import java.io.Serializable;
 
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
@@ -70,12 +72,14 @@ public class Maskelement implements Serializable {
      */
 
 	@XmlElement(name="mename", required=true)
+	@NotNull
     private java.lang.String _mename;
 
     /**
      * The mask element value
      */
 	@XmlElement(name="mevalue", required=true)
+	@Size(min=1)
     private java.util.List<java.lang.String> _mevalueList;
 
 

--- a/features/events/api/src/main/java/org/opennms/netmgt/xml/event/Operaction.java
+++ b/features/events/api/src/main/java/org/opennms/netmgt/xml/event/Operaction.java
@@ -41,6 +41,8 @@ package org.opennms.netmgt.xml.event;
 
 import java.io.Serializable;
 
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
@@ -71,18 +73,21 @@ public class Operaction implements Serializable {
      * internal content storage
      */
 	@XmlValue
+	@NotNull
     private java.lang.String _content = "";
 
     /**
      * Field _state.
      */
 	@XmlAttribute(name="state")
+	@Pattern(regexp="(on|off)")
     private java.lang.String _state = "on";
 
     /**
      * Field _menutext.
      */
 	@XmlAttribute(name="menutext", required=true)
+	@NotNull
     private java.lang.String _menutext;
 
 

--- a/features/events/api/src/main/java/org/opennms/netmgt/xml/event/Parm.java
+++ b/features/events/api/src/main/java/org/opennms/netmgt/xml/event/Parm.java
@@ -41,6 +41,8 @@ package org.opennms.netmgt.xml.event;
 
 import java.io.Serializable;
 
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
@@ -68,12 +70,15 @@ public class Parm implements Serializable {
      * parm name
      */
 	@XmlElement(name="parmName", required=true)
+	@NotNull
     private java.lang.String _parmName;
 
     /**
      * parm value
      */
 	@XmlElement(name="value", required=true)
+	@NotNull
+	@Valid
 	private org.opennms.netmgt.xml.event.Value _value;
 
 

--- a/features/events/api/src/main/java/org/opennms/netmgt/xml/event/Parms.java
+++ b/features/events/api/src/main/java/org/opennms/netmgt/xml/event/Parms.java
@@ -41,6 +41,8 @@ package org.opennms.netmgt.xml.event;
 
 import java.io.Serializable;
 
+import javax.validation.Valid;
+import javax.validation.constraints.Size;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
@@ -69,6 +71,8 @@ public class Parms implements Serializable {
      * A varbind from the trap
      */
 	@XmlElement(name="parm", required=true)
+	@Size(min=1)
+	@Valid
     private java.util.List<org.opennms.netmgt.xml.event.Parm> _parmList;
 
 

--- a/features/events/api/src/main/java/org/opennms/netmgt/xml/event/Script.java
+++ b/features/events/api/src/main/java/org/opennms/netmgt/xml/event/Script.java
@@ -41,6 +41,7 @@ package org.opennms.netmgt.xml.event;
 
 import java.io.Serializable;
 
+import javax.validation.constraints.NotNull;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
@@ -70,12 +71,14 @@ public class Script implements Serializable {
      * internal content storage
      */
 	@XmlValue
+	@NotNull
     private java.lang.String _content = "";
 
     /**
      * Field _language.
      */
 	@XmlAttribute(name="language", required=true)
+	@NotNull
     private java.lang.String _language;
 
 

--- a/features/events/api/src/main/java/org/opennms/netmgt/xml/event/Snmp.java
+++ b/features/events/api/src/main/java/org/opennms/netmgt/xml/event/Snmp.java
@@ -41,6 +41,7 @@ package org.opennms.netmgt.xml.event;
 
 import java.io.Serializable;
 
+import javax.validation.constraints.NotNull;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
@@ -68,6 +69,7 @@ public class Snmp implements Serializable {
      * The snmp enterprise id
      */
 	@XmlElement(name="id", required=true)
+	@NotNull
     private java.lang.String _id;
 
     /**
@@ -80,6 +82,7 @@ public class Snmp implements Serializable {
      * The snmp version
      */
 	@XmlElement(name="version", required=true)
+	@NotNull
     private java.lang.String _version;
 
     /**

--- a/features/events/api/src/main/java/org/opennms/netmgt/xml/event/Tticket.java
+++ b/features/events/api/src/main/java/org/opennms/netmgt/xml/event/Tticket.java
@@ -41,6 +41,8 @@ package org.opennms.netmgt.xml.event;
 
 import java.io.Serializable;
 
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
@@ -70,12 +72,14 @@ public class Tticket implements Serializable {
      * internal content storage
      */
 	@XmlValue
+	@NotNull
     private java.lang.String _content = "";
 
     /**
      * Field _state.
      */
 	@XmlAttribute(name="state")
+	@Pattern(regexp="(on|off)")
     private java.lang.String _state = "on";
 
 

--- a/features/events/api/src/main/java/org/opennms/netmgt/xml/event/Value.java
+++ b/features/events/api/src/main/java/org/opennms/netmgt/xml/event/Value.java
@@ -41,6 +41,8 @@ package org.opennms.netmgt.xml.event;
 
 import java.io.Serializable;
 
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
@@ -70,18 +72,21 @@ public class Value implements Serializable {
      * internal content storage
      */
 	@XmlValue
+	@NotNull
     private java.lang.String _content = "";
 
     /**
      * Field _type.
      */
 	@XmlAttribute(name="type")
+	@Pattern(regexp="(int|string|Int32|OctetString|Null|ObjectIdentifier|Sequence|IpAddress|Counter32|Gauge32|TimeTicks|Opaque|Counter64)")
     private java.lang.String _type = "string";
 
     /**
      * Field _encoding.
      */
 	@XmlAttribute(name="encoding")
+	@Pattern(regexp="(text|base64)")
     private java.lang.String _encoding = "text";
 
 	@XmlTransient

--- a/features/events/api/src/test/java/org/opennms/netmgt/xml/event/EventValidationTest.java
+++ b/features/events/api/src/test/java/org/opennms/netmgt/xml/event/EventValidationTest.java
@@ -1,0 +1,73 @@
+package org.opennms.netmgt.xml.event;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.util.Date;
+import java.util.Set;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.ValidatorFactory;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.opennms.core.test.MockLogAppender;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class EventValidationTest {
+    private static final Logger LOG = LoggerFactory.getLogger(EventValidationTest.class);
+    private static final ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+
+    @Before
+    public void setUp() {
+        MockLogAppender.setupLogging();
+    }
+
+    @Test
+    public void testEmptyEvent() throws Exception {
+        final Validator validator = factory.getValidator();
+        final Event event = new Event();
+        final Set<ConstraintViolation<Event>> errors = validator.validate(event);
+        assertNull(event.getSource());
+        assertEquals(2, errors.size());
+    }
+
+    @Test
+    public void testEmptySource() throws Exception {
+        final Validator validator = factory.getValidator();
+        final Event event = new Event();
+        event.setTime(new Date());
+        final Set<ConstraintViolation<Event>> errors = validator.validate(event);
+        assertNull(event.getSource());
+        assertEquals(1, errors.size());
+    }
+
+    @Test
+    public void testBadDbid() throws Exception {
+        final Validator validator = factory.getValidator();
+        final Event event = new Event();
+        event.setSource("tests");
+        event.setTime(new Date());
+        event.setDbid(-1);
+        final Set<ConstraintViolation<Event>> errors = validator.validate(event);
+        assertEquals(1, errors.size());
+    }
+
+    @Test
+    public void testBadState() throws Exception {
+        final Validator validator = factory.getValidator();
+        final Event event = new Event();
+        event.setSource("tests");
+        event.setTime(new Date());
+        final Operaction action = new Operaction();
+        action.setState("monkey");
+        event.addOperaction(action);
+        final Set<ConstraintViolation<Event>> errors = validator.validate(event);
+        LOG.debug("errors: {}", errors);
+        assertEquals(2, errors.size());
+    }
+
+}

--- a/opennms-model/pom.xml
+++ b/opennms-model/pom.xml
@@ -92,6 +92,11 @@
       <artifactId>commons-lang</artifactId>
     </dependency>
     <dependency>
+      <groupId>javax.validation</groupId>
+      <artifactId>validation-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.opennms.core</groupId>
       <artifactId>org.opennms.core.api</artifactId>
     </dependency>

--- a/opennms-model/src/test/java/org/opennms/xmlns/xsd/event/AlarmData.java
+++ b/opennms-model/src/test/java/org/opennms/xmlns/xsd/event/AlarmData.java
@@ -36,6 +36,8 @@
 
 package org.opennms.xmlns.xsd.event;
 
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
@@ -77,8 +79,11 @@ import javax.xml.bind.annotation.XmlType;
 public class AlarmData {
 
     @XmlAttribute(name = "reduction-key", required = true)
+    @NotNull
     protected String reductionKey;
     @XmlAttribute(name = "alarm-type", required = true)
+    @NotNull
+    @Min(1)
     protected int alarmType;
     @XmlAttribute(name = "clear-key")
     protected String clearKey;

--- a/opennms-model/src/test/java/org/opennms/xmlns/xsd/event/Autoacknowledge.java
+++ b/opennms-model/src/test/java/org/opennms/xmlns/xsd/event/Autoacknowledge.java
@@ -36,6 +36,8 @@
 
 package org.opennms.xmlns.xsd.event;
 
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
@@ -75,8 +77,10 @@ import javax.xml.bind.annotation.XmlValue;
 public class Autoacknowledge {
 
     @XmlValue
+    @NotNull
     protected String value;
     @XmlAttribute(name = "state")
+    @Pattern(regexp="(on|off)")
     protected String state;
 
     /**

--- a/opennms-model/src/test/java/org/opennms/xmlns/xsd/event/Autoaction.java
+++ b/opennms-model/src/test/java/org/opennms/xmlns/xsd/event/Autoaction.java
@@ -36,6 +36,8 @@
 
 package org.opennms.xmlns.xsd.event;
 
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
@@ -75,8 +77,10 @@ import javax.xml.bind.annotation.XmlValue;
 public class Autoaction {
 
     @XmlValue
+    @NotNull
     protected String value;
     @XmlAttribute(name = "state")
+    @Pattern(regexp="(on|off)")
     protected String state;
 
     /**

--- a/opennms-model/src/test/java/org/opennms/xmlns/xsd/event/Correlation.java
+++ b/opennms-model/src/test/java/org/opennms/xmlns/xsd/event/Correlation.java
@@ -39,6 +39,7 @@ package org.opennms.xmlns.xsd.event;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.validation.constraints.Pattern;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
@@ -97,8 +98,10 @@ public class Correlation {
     protected String cmax;
     protected String ctime;
     @XmlAttribute(name = "state")
+    @Pattern(regexp="(on|off)")
     protected String state;
     @XmlAttribute(name = "path")
+    @Pattern(regexp="(suppressDuplicates|cancellingEvent|suppressAndCancel|pathOutage)")
     protected String path;
 
     /**

--- a/opennms-model/src/test/java/org/opennms/xmlns/xsd/event/Event.java
+++ b/opennms-model/src/test/java/org/opennms/xmlns/xsd/event/Event.java
@@ -39,6 +39,9 @@ package org.opennms.xmlns.xsd.event;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.validation.Valid;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
@@ -142,6 +145,7 @@ import javax.xml.bind.annotation.XmlType;
 @XmlRootElement(name = "event")
 public class Event {
 
+    @Min(1)
     protected Integer dbid;
     @XmlElement(name = "dist-poller")
     protected String distPoller;
@@ -150,12 +154,15 @@ public class Event {
     @XmlElement(name = "master-station")
     protected String masterStation;
     @XmlElement(namespace = "http://xmlns.opennms.org/xsd/event")
+    @Valid
     protected Mask mask;
     protected String uei;
     @XmlElement(required = true)
+    @NotNull
     protected String source;
     protected Long nodeid;
     @XmlElement(required = true)
+    @NotNull
     protected String time;
     protected String host;
     @XmlElement(name = "interface")
@@ -163,34 +170,45 @@ public class Event {
     protected String snmphost;
     protected String service;
     @XmlElement(namespace = "http://xmlns.opennms.org/xsd/event")
+    @Valid
     protected Snmp snmp;
     @XmlElement(namespace = "http://xmlns.opennms.org/xsd/event")
+    @Valid
     protected Parms parms;
     protected String descr;
     @XmlElement(namespace = "http://xmlns.opennms.org/xsd/event")
+    @Valid
     protected Logmsg logmsg;
     protected String severity;
     protected String pathoutage;
     @XmlElement(namespace = "http://xmlns.opennms.org/xsd/event")
+    @Valid
     protected Correlation correlation;
     protected String operinstruct;
     @XmlElement(namespace = "http://xmlns.opennms.org/xsd/event")
+    @Valid
     protected List<Autoaction> autoaction;
     @XmlElement(namespace = "http://xmlns.opennms.org/xsd/event")
+    @Valid
     protected List<Operaction> operaction;
     @XmlElement(namespace = "http://xmlns.opennms.org/xsd/event")
+    @Valid
     protected Autoacknowledge autoacknowledge;
     protected List<String> loggroup;
     @XmlElement(namespace = "http://xmlns.opennms.org/xsd/event")
+    @Valid
     protected Tticket tticket;
     @XmlElement(namespace = "http://xmlns.opennms.org/xsd/event")
+    @Valid
     protected List<Forward> forward;
     @XmlElement(namespace = "http://xmlns.opennms.org/xsd/event")
+    @Valid
     protected List<Script> script;
     protected Integer ifIndex;
     protected String ifAlias;
     protected String mouseovertext;
     @XmlElement(name = "alarm-data", namespace = "http://xmlns.opennms.org/xsd/event")
+    @Valid
     protected AlarmData alarmData;
     @XmlAttribute(name = "uuid")
     protected String uuid;

--- a/opennms-model/src/test/java/org/opennms/xmlns/xsd/event/EventReceipt.java
+++ b/opennms-model/src/test/java/org/opennms/xmlns/xsd/event/EventReceipt.java
@@ -39,6 +39,7 @@ package org.opennms.xmlns.xsd.event;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.validation.constraints.Size;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
@@ -73,6 +74,7 @@ import javax.xml.bind.annotation.XmlType;
 public class EventReceipt {
 
     @XmlElement(required = true)
+    @Size(min=1)
     protected List<String> uuid;
 
     /**

--- a/opennms-model/src/test/java/org/opennms/xmlns/xsd/event/Events.java
+++ b/opennms-model/src/test/java/org/opennms/xmlns/xsd/event/Events.java
@@ -39,6 +39,8 @@ package org.opennms.xmlns.xsd.event;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.validation.Valid;
+import javax.validation.constraints.Size;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
@@ -73,6 +75,8 @@ import javax.xml.bind.annotation.XmlType;
 public class Events {
 
     @XmlElement(namespace = "http://xmlns.opennms.org/xsd/event", required = true)
+    @Size(min=1)
+    @Valid
     protected List<Event> event;
 
     /**

--- a/opennms-model/src/test/java/org/opennms/xmlns/xsd/event/Forward.java
+++ b/opennms-model/src/test/java/org/opennms/xmlns/xsd/event/Forward.java
@@ -36,6 +36,8 @@
 
 package org.opennms.xmlns.xsd.event;
 
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
@@ -82,10 +84,13 @@ import javax.xml.bind.annotation.XmlValue;
 public class Forward {
 
     @XmlValue
+    @NotNull
     protected String value;
     @XmlAttribute(name = "state")
+    @Pattern(regexp="(on|off)")
     protected String state;
     @XmlAttribute(name = "mechanism")
+    @Pattern(regexp="(snmpudp|snmptcp|xmltcp|xmludp)")
     protected String mechanism;
 
     /**

--- a/opennms-model/src/test/java/org/opennms/xmlns/xsd/event/Log.java
+++ b/opennms-model/src/test/java/org/opennms/xmlns/xsd/event/Log.java
@@ -36,6 +36,8 @@
 
 package org.opennms.xmlns.xsd.event;
 
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
@@ -72,8 +74,11 @@ import javax.xml.bind.annotation.XmlType;
 public class Log {
 
     @XmlElement(namespace = "http://xmlns.opennms.org/xsd/event")
+    @Valid
     protected Header header;
     @XmlElement(namespace = "http://xmlns.opennms.org/xsd/event", required = true)
+    @NotNull
+    @Valid
     protected Events events;
 
     /**

--- a/opennms-model/src/test/java/org/opennms/xmlns/xsd/event/Logmsg.java
+++ b/opennms-model/src/test/java/org/opennms/xmlns/xsd/event/Logmsg.java
@@ -36,6 +36,8 @@
 
 package org.opennms.xmlns.xsd.event;
 
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
@@ -76,10 +78,12 @@ import javax.xml.bind.annotation.XmlValue;
 public class Logmsg {
 
     @XmlValue
+    @NotNull
     protected String value;
     @XmlAttribute(name = "notify")
     protected Boolean notify;
     @XmlAttribute(name = "dest")
+    @Pattern(regexp="(logndisplay|displayonly|logonly|suppress|donotpersist)")
     protected String dest;
 
     /**

--- a/opennms-model/src/test/java/org/opennms/xmlns/xsd/event/Mask.java
+++ b/opennms-model/src/test/java/org/opennms/xmlns/xsd/event/Mask.java
@@ -39,6 +39,8 @@ package org.opennms.xmlns.xsd.event;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.validation.Valid;
+import javax.validation.constraints.Size;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
@@ -73,6 +75,8 @@ import javax.xml.bind.annotation.XmlType;
 public class Mask {
 
     @XmlElement(namespace = "http://xmlns.opennms.org/xsd/event", required = true)
+    @Size(min=1)
+    @Valid
     protected List<Maskelement> maskelement;
 
     /**

--- a/opennms-model/src/test/java/org/opennms/xmlns/xsd/event/Maskelement.java
+++ b/opennms-model/src/test/java/org/opennms/xmlns/xsd/event/Maskelement.java
@@ -39,6 +39,8 @@ package org.opennms.xmlns.xsd.event;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
@@ -75,8 +77,10 @@ import javax.xml.bind.annotation.XmlType;
 public class Maskelement {
 
     @XmlElement(required = true)
+    @NotNull
     protected String mename;
     @XmlElement(required = true)
+    @Size(min=1)
     protected List<String> mevalue;
 
     /**

--- a/opennms-model/src/test/java/org/opennms/xmlns/xsd/event/Operaction.java
+++ b/opennms-model/src/test/java/org/opennms/xmlns/xsd/event/Operaction.java
@@ -36,6 +36,8 @@
 
 package org.opennms.xmlns.xsd.event;
 
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
@@ -76,10 +78,13 @@ import javax.xml.bind.annotation.XmlValue;
 public class Operaction {
 
     @XmlValue
+    @NotNull
     protected String value;
     @XmlAttribute(name = "state")
+    @Pattern(regexp="(on|off)")
     protected String state;
     @XmlAttribute(name = "menutext", required = true)
+    @NotNull
     protected String menutext;
 
     /**

--- a/opennms-model/src/test/java/org/opennms/xmlns/xsd/event/Parm.java
+++ b/opennms-model/src/test/java/org/opennms/xmlns/xsd/event/Parm.java
@@ -36,6 +36,8 @@
 
 package org.opennms.xmlns.xsd.event;
 
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
@@ -72,8 +74,11 @@ import javax.xml.bind.annotation.XmlType;
 public class Parm {
 
     @XmlElement(required = true)
+    @NotNull
     protected String parmName;
     @XmlElement(namespace = "http://xmlns.opennms.org/xsd/event", required = true)
+    @NotNull
+    @Valid
     protected Value value;
 
     /**

--- a/opennms-model/src/test/java/org/opennms/xmlns/xsd/event/Parms.java
+++ b/opennms-model/src/test/java/org/opennms/xmlns/xsd/event/Parms.java
@@ -39,6 +39,8 @@ package org.opennms.xmlns.xsd.event;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.validation.Valid;
+import javax.validation.constraints.Size;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
@@ -73,6 +75,8 @@ import javax.xml.bind.annotation.XmlType;
 public class Parms {
 
     @XmlElement(namespace = "http://xmlns.opennms.org/xsd/event", required = true)
+    @Size(min=1)
+    @Valid
     protected List<Parm> parm;
 
     /**

--- a/opennms-model/src/test/java/org/opennms/xmlns/xsd/event/Script.java
+++ b/opennms-model/src/test/java/org/opennms/xmlns/xsd/event/Script.java
@@ -36,6 +36,7 @@
 
 package org.opennms.xmlns.xsd.event;
 
+import javax.validation.constraints.NotNull;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
@@ -69,8 +70,10 @@ import javax.xml.bind.annotation.XmlValue;
 public class Script {
 
     @XmlValue
+    @NotNull
     protected String value;
     @XmlAttribute(name = "language", required = true)
+    @NotNull
     protected String language;
 
     /**

--- a/opennms-model/src/test/java/org/opennms/xmlns/xsd/event/Snmp.java
+++ b/opennms-model/src/test/java/org/opennms/xmlns/xsd/event/Snmp.java
@@ -36,6 +36,7 @@
 
 package org.opennms.xmlns.xsd.event;
 
+import javax.validation.constraints.NotNull;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
@@ -82,9 +83,11 @@ import javax.xml.bind.annotation.XmlType;
 public class Snmp {
 
     @XmlElement(required = true)
+    @NotNull
     protected String id;
     protected String idtext;
     @XmlElement(required = true)
+    @NotNull
     protected String version;
     protected Integer specific;
     protected Integer generic;

--- a/opennms-model/src/test/java/org/opennms/xmlns/xsd/event/Tticket.java
+++ b/opennms-model/src/test/java/org/opennms/xmlns/xsd/event/Tticket.java
@@ -36,6 +36,8 @@
 
 package org.opennms.xmlns.xsd.event;
 
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
@@ -75,8 +77,10 @@ import javax.xml.bind.annotation.XmlValue;
 public class Tticket {
 
     @XmlValue
+    @NotNull
     protected String value;
     @XmlAttribute(name = "state")
+    @Pattern(regexp="(on|off)")
     protected String state;
 
     /**

--- a/opennms-model/src/test/java/org/opennms/xmlns/xsd/event/Value.java
+++ b/opennms-model/src/test/java/org/opennms/xmlns/xsd/event/Value.java
@@ -36,6 +36,8 @@
 
 package org.opennms.xmlns.xsd.event;
 
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
@@ -82,10 +84,13 @@ import javax.xml.bind.annotation.XmlValue;
 public class Value {
 
     @XmlValue
+    @NotNull
     protected String value;
     @XmlAttribute(name = "type")
+    @Pattern(regexp="(int|string|Int32|OctetString|Null|ObjectIdentifier|Sequence|IpAddress|Counter32|Gauge32|TimeTicks|Opaque|Counter64)")
     protected String type;
     @XmlAttribute(name = "encoding")
+    @Pattern(regexp="(text|base64)")
     protected String encoding;
 
     /**

--- a/opennms-webapp-rest/pom.xml
+++ b/opennms-webapp-rest/pom.xml
@@ -231,6 +231,14 @@
       <artifactId>slf4j-api</artifactId>
       <scope>${onmsLibScope}</scope>
     </dependency>
+    <dependency>
+      <groupId>javax.validation</groupId>
+      <artifactId>validation-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.hibernate</groupId>
+      <artifactId>hibernate-validator-annotation-processor</artifactId>
+    </dependency>
 
     <!-- CORS support -->
     <dependency>

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/EventRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/EventRestService.java
@@ -30,7 +30,12 @@ package org.opennms.web.rest.v1;
 
 import java.text.ParseException;
 import java.util.Date;
+import java.util.Set;
 
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.ValidatorFactory;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.FormParam;
 import javax.ws.rs.GET;
@@ -56,6 +61,8 @@ import org.opennms.netmgt.events.api.EventIpcManager;
 import org.opennms.netmgt.model.OnmsEvent;
 import org.opennms.netmgt.model.OnmsEventCollection;
 import org.opennms.web.rest.support.MultivaluedMapImpl;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -63,8 +70,10 @@ import org.springframework.transaction.annotation.Transactional;
 @Component("eventRestService")
 @Path("events")
 public class EventRestService extends OnmsRestService {
+    private static final Logger LOG = LoggerFactory.getLogger(EventRestService.class);
     private static final DateTimeFormatter ISO8601_FORMATTER_MILLIS = ISODateTimeFormat.dateTime();
     private static final DateTimeFormatter ISO8601_FORMATTER = ISODateTimeFormat.dateTimeNoMillis();
+    private static final ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
 
     @Autowired
     private EventDao m_eventDao;
@@ -277,8 +286,23 @@ public class EventRestService extends OnmsRestService {
         if (event.getTime() == null) {
             event.setTime(new Date());
         }
-        m_eventForwarder.sendNow(event);
-        return Response.noContent().build();
+        try {
+            final Validator validator = factory.getValidator();
+            final Set<ConstraintViolation<org.opennms.netmgt.xml.event.Event>> errors = validator.validate(event);
+            LOG.debug("got errors: {}", errors);
+            if (errors.size() > 0) {
+                final StringBuilder sb = new StringBuilder("Error validating event:\n");
+                for (final ConstraintViolation<?> error : errors) {
+                    sb.append(error.toString()).append("\n");
+                }
+                LOG.debug(sb.toString());
+                throw getException(Status.BAD_REQUEST, errors.size() + " errors found while validating event.");
+            }
+            m_eventForwarder.sendNow(event);
+            return Response.accepted().build();
+        } catch (final Exception e) {
+            throw getException(Status.BAD_REQUEST, e.getMessage());
+        }
     }
 
     private static CriteriaBuilder getCriteriaBuilder(final MultivaluedMap<String, String> params) {
@@ -293,3 +317,4 @@ public class EventRestService extends OnmsRestService {
     }
 
 }
+

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/EventRestServiceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/EventRestServiceIT.java
@@ -31,6 +31,7 @@ package org.opennms.web.rest.v1;
 import static org.junit.Assert.assertTrue;
 
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response.Status;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -39,10 +40,12 @@ import org.opennms.core.test.OpenNMSJUnit4ClassRunner;
 import org.opennms.core.test.db.annotations.JUnitTemporaryDatabase;
 import org.opennms.core.test.rest.AbstractSpringJerseyRestTestCase;
 import org.opennms.core.xml.JaxbUtils;
+import org.opennms.core.xml.MarshallingResourceFailureException;
 import org.opennms.netmgt.dao.DatabasePopulator;
 import org.opennms.netmgt.dao.mock.EventAnticipator;
 import org.opennms.netmgt.dao.mock.MockEventIpcManager;
 import org.opennms.netmgt.xml.event.Event;
+import org.opennms.netmgt.xml.event.Operaction;
 import org.opennms.test.JUnitConfigurationEnvironment;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
@@ -103,10 +106,37 @@ public class EventRestServiceIT extends AbstractSpringJerseyRestTestCase {
         anticipator.anticipateEvent(e);
 
         // POST the event to the REST API
-        sendData(POST, MediaType.APPLICATION_XML, "/events", JaxbUtils.marshal(e), 204);
+        sendData(POST, MediaType.APPLICATION_XML, "/events", JaxbUtils.marshal(e), Status.ACCEPTED.getStatusCode());
 
         // Verify
         m_eventMgr.finishProcessingEvents();
         anticipator.verifyAnticipated(1000, 0, 0, 0, 0);
+    }
+
+    @Test
+    public void testBadDbidEvent() throws Exception {
+        final Event e = new Event();
+        e.setDbid(-1);
+        sendData(POST, MediaType.APPLICATION_XML, "/events", JaxbUtils.marshal(e), Status.BAD_REQUEST.getStatusCode());
+    }
+
+    @Test
+    public void testPostBadStateEvent() throws Exception {
+        final Event e = new Event();
+        final Operaction action = new Operaction();
+        action.setState("monkey");
+        e.addOperaction(action);
+        sendData(POST, MediaType.APPLICATION_XML, "/events", JaxbUtils.marshal(e), Status.BAD_REQUEST.getStatusCode());
+    }
+
+    @Test(expected=MarshallingResourceFailureException.class)
+    public void testStrangeDate() throws Exception {
+        final String xml = "<event xmlns=\"http://xmlns.opennms.org/xsd/event\">\n" +
+                "   <uei>some.uei</uei>\n" +
+                // /* works */ "   <time>Thursday, January 1, 1970 12:00:00 AM GMT</time>\n" +
+                /* fails */ "   <time>Wednesday, November 08, 2017  3:07 PM EST</time>\n" +
+                "   <host>from-some-host</host>\n" +
+                "</event>";
+        sendData(POST, MediaType.APPLICATION_XML, "/events", xml, Status.BAD_REQUEST.getStatusCode());
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -3209,6 +3209,11 @@
         <version>1.0.1.Final</version>
       </dependency>
       <dependency>
+	      <groupId>org.hibernate</groupId>
+        <artifactId>hibernate-validator-annotation-processor</artifactId>
+        <version>4.1.0.Final</version>
+      </dependency>
+      <dependency>
         <groupId>javax.samples.jnlp</groupId>
         <artifactId>jnlp-servlet</artifactId>
         <version>1.6.0</version>

--- a/smoke-test/src/test/java/org/opennms/smoketest/AlarmsPageIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/AlarmsPageIT.java
@@ -62,7 +62,7 @@ public class AlarmsPageIT extends OpenNMSSeleniumTestCase {
         request.setEntity(new ByteArrayEntity(xml.getBytes("UTF-8")));
         final HttpResponse response = client.execute(request);
         final int statusCode = response.getStatusLine().getStatusCode();
-        if (statusCode != 200 && statusCode != 204) {
+        if (statusCode != 200 && statusCode != 202 && statusCode != 204) {
             throw new RuntimeException("bad response! " + response.getStatusLine().toString());
         }
     }


### PR DESCRIPTION
This PR adds some basic validation of the event object(s) when `POST`ed to the event rest service.

* JIRA: http://issues.opennms.org/browse/NMS-9724

Our [continuous integration system](http://bamboo.internal.opennms.com:8085) will test and verify your changes.
