### PR TITLE
HZN-1190: Allow the Jest connection pool size to be configured

### DIFF
--- a/features/flows/elastic/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/features/flows/elastic/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -18,6 +18,8 @@
             <cm:property name="elasticUser" value="" />
             <cm:property name="elasticPassword" value="" />
             <cm:property name="elasticIndexStrategy" value="monthly" />
+            <cm:property name="defaultMaxTotalConnectionPerRoute" value="-1" />
+            <cm:property name="maxTotalConnection" value="-1" />
             <!-- TODO MVR add more -->
         </cm:default-properties>
     </cm:property-placeholder>
@@ -27,6 +29,8 @@
         <argument value="${elasticUrl}"/>
         <argument value="${elasticUser}"/>
         <argument value="${elasticPassword}"/>
+        <property name="defaultMaxTotalConnectionPerRoute" value="${defaultMaxTotalConnectionPerRoute}"/>
+        <property name="maxTotalConnection" value="${maxTotalConnection}"/>
     </bean>
 
     <!-- Actually creates the client, but only once -->

--- a/features/jest/client/src/main/java/org/opennms/plugins/elasticsearch/rest/RestClientFactory.java
+++ b/features/jest/client/src/main/java/org/opennms/plugins/elasticsearch/rest/RestClientFactory.java
@@ -51,6 +51,16 @@ import io.searchbox.client.config.HttpClientConfig;
  */
 public class RestClientFactory {
 
+	/**
+	 * Use the same formula used to compute the number of threads used in the Sink API.
+	 */
+	private static final int DEFAULT_MAX_TOTAL_CONNECTION_PER_ROUTE = Runtime.getRuntime().availableProcessors() * 2;
+
+	/**
+	 * Scale according to the number of connections per route.
+	 */
+	private static final int DEFAULT_MAX_TOTAL_CONNECTION = DEFAULT_MAX_TOTAL_CONNECTION_PER_ROUTE * 3;
+
 	private HttpClientConfig.Builder clientConfigBuilder;
 	private int m_timeout = 0;
 	private int m_retries = 0;
@@ -58,7 +68,7 @@ public class RestClientFactory {
 
 	/**
 	 * Create a RestClientFactory.
-	 * 
+	 *
 	 * @param elasticSearchURL Elasticsearch URL, either a single URL or
 	 *   multiple URLs that are comma-separated without spaces
 	 * @param elasticUser Optional HTTP username
@@ -87,8 +97,8 @@ public class RestClientFactory {
 		// If multiple URLs are specified in a comma-separated string, split them up
 		clientConfigBuilder = new HttpClientConfig.Builder(urls)
 					.multiThreaded(true)
-					.defaultMaxTotalConnectionPerRoute(2)
-					.maxTotalConnection(20)
+					.defaultMaxTotalConnectionPerRoute(DEFAULT_MAX_TOTAL_CONNECTION_PER_ROUTE)
+					.maxTotalConnection(DEFAULT_MAX_TOTAL_CONNECTION)
 					.gson(gson);
 
 		// Apply optional credentials
@@ -145,12 +155,40 @@ public class RestClientFactory {
 		clientConfigBuilder.multiThreaded(multiThreaded);
 	}
 
-	public void setDefaultMaxTotalConnectionPerRoute(int count) {
-		clientConfigBuilder.defaultMaxTotalConnectionPerRoute(count);
+	/**
+	 * Set the default max connections per route.
+	 * By default, we use the number of available processors * 2.
+	 *
+	 * If a negative value is given, the set is ignored.
+	 * This allows us to use -1 as the default in the Blueprint in order
+	 * to avoid having to caculate the default again there.
+	 *
+	 * @param connections default max connections per route
+	 */
+	public void setDefaultMaxTotalConnectionPerRoute(int connections) {
+		if (connections < 0) {
+			// Ignore
+			return;
+		}
+		clientConfigBuilder.defaultMaxTotalConnectionPerRoute(connections);
 	}
 
-	public void setMaxTotalConnection(int count) {
-		clientConfigBuilder.maxTotalConnection(count);
+	/**
+	 * Set the default max total connections.
+	 * By default, we use the default max connections per route * 3.
+	 *
+	 * If a negative value is given, the set is ignored.
+	 * This allows us to use -1 as the default in the Blueprint in order
+	 * to avoid having to caculate the default again there.
+	 *
+	 * @param connections default max connections per route
+	 */
+	public void setMaxTotalConnection(int connections) {
+		if (connections < 0) {
+			// Ignore
+			return;
+		}
+		clientConfigBuilder.maxTotalConnection(connections);
 	}
 
 	public void setMaxConnectionIdleTime(int timeout, TimeUnit unit) {


### PR DESCRIPTION
JIRA: https://issues.opennms.org/browse/HZN-1190

Update the default connection limits and allow them to be configured.