### PR TITLE
NMS-9689: Upgrade Jetty to version 9.4.2.v20170220

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1285,7 +1285,7 @@
     <jasperreportsMavenPluginVersion>1.0-beta-4-OPENNMS-20160912-1</jasperreportsMavenPluginVersion>
     <jcifsVersion>1.3.14</jcifsVersion>
     <jcommonVersion>1.0.23</jcommonVersion>
-    <jettyVersion>9.4.0.v20161208</jettyVersion>
+    <jettyVersion>9.4.2.v20170220</jettyVersion>
     <jfreechartVersion>1.0.19</jfreechartVersion>
     <jinteropVersion>2.0.8</jinteropVersion>
     <jldapVersion>4.3</jldapVersion>


### PR DESCRIPTION
HEAD requests to our UI are failing for static resources (preventing the Remote Poller EXE installer link and offline docs links from appearing). This Jetty micro upgrade fixes the problem.

* JIRA: http://issues.opennms.org/browse/NMS-9689