### PR TITLE
HZN-1193: Improve Netflow performance and metrics

### DIFF
--- a/opennms-base-assembly/src/main/filtered/etc/jmx-datacollection-config.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/jmx-datacollection-config.xml
@@ -313,6 +313,59 @@
             <attrib name="TempLimit" alias="TempLimit" type="gauge"/>
             <attrib name="TempPercentUsage" alias="TempPctUsage" type="gauge"/>
          </mbean>
+         <mbean name="org.opennms.netmgt.telemetry.adapters.netflow.flowsPersisted" objectname="org.opennms.netmgt.telemetry.adapters.netflow:name=flowsPersisted">
+            <attrib name="Count" alias="NF5FlowsPerst" type="counter"/>
+            <attrib name="OneMinuteRate" alias="NF5FlowsPerst1m" type="gauge"/>
+            <attrib name="FiveMinuteRate" alias="NF5FlowsPerst5m" type="gauge"/>
+         </mbean>
+         <mbean name="org.opennms.netmgt.telemetry.adapters.netflow.flowsPerPacket" objectname="org.opennms.netmgt.telemetry.adapters.netflow:name=flowsPerPacket">
+            <attrib name="50thPercentile" alias="NF5FlowsPerPkt50" type="gauge"/>
+            <attrib name="75thPercentile" alias="NF5FlowsPerPkt75" type="gauge"/>
+            <attrib name="95thPercentile" alias="NF5FlowsPerPkt95" type="gauge"/>
+            <attrib name="98thPercentile" alias="NF5FlowsPerPkt98" type="gauge"/>
+            <attrib name="99thPercentile" alias="NF5FlowsPerPkt99" type="gauge"/>
+            <attrib name="999thPercentile" alias="NF5FlowsPerPkt999" type="gauge"/>
+            <attrib name="Count" alias="NF5FlowsPerPktCnt" type="counter"/>
+         </mbean>
+         <mbean name="org.opennms.netmgt.telemetry.adapters.netflow.packetsPerLog" objectname="org.opennms.netmgt.telemetry.adapters.netflow:name=packetsPerLog">
+            <attrib name="50thPercentile" alias="NF5PktsPerLog50" type="gauge"/>
+            <attrib name="75thPercentile" alias="NF5PktsPerLog75" type="gauge"/>
+            <attrib name="95thPercentile" alias="NF5PktsPerLog95" type="gauge"/>
+            <attrib name="98thPercentile" alias="NF5PktsPerLog98" type="gauge"/>
+            <attrib name="99thPercentile" alias="NF5PktsPerLog99" type="gauge"/>
+            <attrib name="999thPercentile" alias="NF5PktsPerLog999" type="gauge"/>
+            <attrib name="Count" alias="NF5PktsPerLogCnt" type="counter"/>
+         </mbean>
+         <mbean name="org.opennms.netmgt.telemetry.adapters.netflow.logParsing" objectname="org.opennms.netmgt.telemetry.adapters.netflow:name=logParsing">
+            <attrib name="50thPercentile" alias="NF5LogParse50" type="gauge"/>
+            <attrib name="75thPercentile" alias="NF5LogParse75" type="gauge"/>
+            <attrib name="95thPercentile" alias="NF5LogParse95" type="gauge"/>
+            <attrib name="98thPercentile" alias="NF5LogParse98" type="gauge"/>
+            <attrib name="99thPercentile" alias="NF5LogParse99" type="gauge"/>
+            <attrib name="999thPercentile" alias="NF5LogParse999" type="gauge"/>
+            <attrib name="OneMinuteRate" alias="NF5LogParse1m" type="gauge"/>
+            <attrib name="FiveMinuteRate" alias="NF5LogParse5m" type="gauge"/>
+         </mbean>
+         <mbean name="org.opennms.netmgt.telemetry.adapters.netflow.logEnrichment" objectname="org.opennms.netmgt.telemetry.adapters.netflow:name=logEnrichment">
+            <attrib name="50thPercentile" alias="NF5LogEnrich50" type="gauge"/>
+            <attrib name="75thPercentile" alias="NF5LogEnrich75" type="gauge"/>
+            <attrib name="95thPercentile" alias="NF5LogEnrich95" type="gauge"/>
+            <attrib name="98thPercentile" alias="NF5LogEnrich98" type="gauge"/>
+            <attrib name="99thPercentile" alias="NF5LogEnrich99" type="gauge"/>
+            <attrib name="999thPercentile" alias="NF5LogEnrich999" type="gauge"/>
+            <attrib name="OneMinuteRate" alias="NF5LogEnrich1m" type="gauge"/>
+            <attrib name="FiveMinuteRate" alias="NF5LogEnrich5m" type="gauge"/>
+         </mbean>
+         <mbean name="org.opennms.netmgt.telemetry.adapters.netflow.logPersisting" objectname="org.opennms.netmgt.telemetry.adapters.netflow:name=logPersisting">
+            <attrib name="50thPercentile" alias="NF5LogPerst50" type="gauge"/>
+            <attrib name="75thPercentile" alias="NF5LogPerst75" type="gauge"/>
+            <attrib name="95thPercentile" alias="NF5LogPerst95" type="gauge"/>
+            <attrib name="98thPercentile" alias="NF5LogPerst98" type="gauge"/>
+            <attrib name="99thPercentile" alias="NF5LogPerst99" type="gauge"/>
+            <attrib name="999thPercentile" alias="NF5LogPerst999" type="gauge"/>
+            <attrib name="OneMinuteRate" alias="NF5LogPerst1m" type="gauge"/>
+            <attrib name="FiveMinuteRate" alias="NF5LogPerst5m" type="gauge"/>
+         </mbean>
       </mbeans>
    </jmx-collection>
 </jmx-datacollection-config>

--- a/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/opennms-netflow-graph.properties
+++ b/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/opennms-netflow-graph.properties
@@ -1,0 +1,206 @@
+##############################################################################
+##
+##  Please add report definition in a new line to make it easier
+##  for script based sanity checks
+##
+##################################################
+
+reports=OpenNMS.Flows.Netflow5.FlowsPersisted, \
+OpenNMS.Flows.Netflow5.Persisting.Latency, \
+OpenNMS.Flows.Netflow5.Enrichment.Latency, \
+OpenNMS.Flows.Netflow5.Parsing.Latency, \
+OpenNMS.Flows.Netflow5.PacketsPerLog, \
+OpenNMS.Flows.Netflow5.FlowsPerPacket
+
+report.OpenNMS.Flows.Netflow5.FlowsPersisted.name=Netflow5 Flows Persisted
+report.OpenNMS.Flows.Netflow5.FlowsPersisted.columns=NF5FlowsPerst5m
+report.OpenNMS.Flows.Netflow5.FlowsPersisted.type=interfaceSnmp
+report.OpenNMS.Flows.Netflow5.FlowsPersisted.command=--title="Netflow5: Flows Persisted" \
+ --vertical-label="Flows per second" \
+ DEF:rate={rrd1}:NF5FlowsPerst5m:AVERAGE \
+ AREA:rate#C7F464:"Flows per second" \
+ GPRINT:rate:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:rate:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:rate:MAX:" Max \\: %8.2lf %s"
+
+report.OpenNMS.Flows.Netflow5.Parsing.Latency.name=Netflow5 Log Parsing Latency
+report.OpenNMS.Flows.Netflow5.Parsing.Latency.columns=NF5LogParse999,NF5LogParse99,NF5LogParse98,NF5LogParse95,NF5LogParse75,NF5LogParse50
+report.OpenNMS.Flows.Netflow5.Parsing.Latency.type=interfaceSnmp
+report.OpenNMS.Flows.Netflow5.Parsing.Latency.command=--title="Netflow5: Log Parsing Latency" \
+ --color GRID#f2f2f288  --color MGRID#c2c2d688  --vertical-label="Milliseconds" \
+ DEF:999th={rrd1}:NF5LogParse999:AVERAGE \
+ DEF:99th={rrd2}:NF5LogParse99:AVERAGE \
+ DEF:98th={rrd3}:NF5LogParse98:AVERAGE \
+ DEF:95th={rrd4}:NF5LogParse95:AVERAGE \
+ DEF:75th={rrd5}:NF5LogParse75:AVERAGE \
+ DEF:50th={rrd6}:NF5LogParse50:AVERAGE \
+ AREA:999th#542437:"999th percentile" \
+ GPRINT:999th:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:999th:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:999th:MAX:" Max \\: %8.2lf %s\\n" \
+ AREA:99th#C44D58:"99th percentile" \
+ GPRINT:99th:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:99th:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:99th:MAX:" Max \\: %8.2lf %s\\n" \
+ AREA:98th#FF6B6B:"98th percentile" \
+ GPRINT:98th:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:98th:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:98th:MAX:" Max \\: %8.2lf %s\\n" \
+ AREA:95th#556270:"95th percentile" \
+ GPRINT:95th:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:95th:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:95th:MAX:" Max \\: %8.2lf %s\\n" \
+ AREA:75th#4ECDC4:"75th percentile" \
+ GPRINT:75th:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:75th:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:75th:MAX:" Max \\: %8.2lf %s\\n" \
+ AREA:50th#C7F464:"50th percentile" \
+ GPRINT:50th:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:50th:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:50th:MAX:" Max \\: %8.2lf %s\\n"
+
+report.OpenNMS.Flows.Netflow5.Enrichment.Latency.name=Netflow5 Log Enrichment Latency
+report.OpenNMS.Flows.Netflow5.Enrichment.Latency.columns=NF5LogEnrich999,NF5LogEnrich99,NF5LogEnrich98,NF5LogEnrich95,NF5LogEnrich75,NF5LogEnrich50
+report.OpenNMS.Flows.Netflow5.Enrichment.Latency.type=interfaceSnmp
+report.OpenNMS.Flows.Netflow5.Enrichment.Latency.command=--title="Netflow5: Log Enrichment Latency" \
+ --color GRID#f2f2f288  --color MGRID#c2c2d688  --vertical-label="Milliseconds" \
+ DEF:999th={rrd1}:NF5LogEnrich999:AVERAGE \
+ DEF:99th={rrd2}:NF5LogEnrich99:AVERAGE \
+ DEF:98th={rrd3}:NF5LogEnrich98:AVERAGE \
+ DEF:95th={rrd4}:NF5LogEnrich95:AVERAGE \
+ DEF:75th={rrd5}:NF5LogEnrich75:AVERAGE \
+ DEF:50th={rrd6}:NF5LogEnrich50:AVERAGE \
+ AREA:999th#542437:"999th percentile" \
+ GPRINT:999th:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:999th:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:999th:MAX:" Max \\: %8.2lf %s\\n" \
+ AREA:99th#C44D58:"99th percentile" \
+ GPRINT:99th:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:99th:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:99th:MAX:" Max \\: %8.2lf %s\\n" \
+ AREA:98th#FF6B6B:"98th percentile" \
+ GPRINT:98th:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:98th:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:98th:MAX:" Max \\: %8.2lf %s\\n" \
+ AREA:95th#556270:"95th percentile" \
+ GPRINT:95th:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:95th:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:95th:MAX:" Max \\: %8.2lf %s\\n" \
+ AREA:75th#4ECDC4:"75th percentile" \
+ GPRINT:75th:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:75th:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:75th:MAX:" Max \\: %8.2lf %s\\n" \
+ AREA:50th#C7F464:"50th percentile" \
+ GPRINT:50th:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:50th:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:50th:MAX:" Max \\: %8.2lf %s\\n"
+
+report.OpenNMS.Flows.Netflow5.Persisting.Latency.name=Netflow5 Log Persisting Latency
+report.OpenNMS.Flows.Netflow5.Persisting.Latency.columns=NF5LogPerst999,NF5LogPerst99,NF5LogPerst98,NF5LogPerst95,NF5LogPerst75,NF5LogPerst50
+report.OpenNMS.Flows.Netflow5.Persisting.Latency.type=interfaceSnmp
+report.OpenNMS.Flows.Netflow5.Persisting.Latency.command=--title="Netflow5: Log Persisting Latency" \
+ --color GRID#f2f2f288  --color MGRID#c2c2d688  --vertical-label="Milliseconds" \
+ DEF:999th={rrd1}:NF5LogPerst999:AVERAGE \
+ DEF:99th={rrd2}:NF5LogPerst99:AVERAGE \
+ DEF:98th={rrd3}:NF5LogPerst98:AVERAGE \
+ DEF:95th={rrd4}:NF5LogPerst95:AVERAGE \
+ DEF:75th={rrd5}:NF5LogPerst75:AVERAGE \
+ DEF:50th={rrd6}:NF5LogPerst50:AVERAGE \
+ AREA:999th#542437:"999th percentile" \
+ GPRINT:999th:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:999th:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:999th:MAX:" Max \\: %8.2lf %s\\n" \
+ AREA:99th#C44D58:"99th percentile" \
+ GPRINT:99th:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:99th:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:99th:MAX:" Max \\: %8.2lf %s\\n" \
+ AREA:98th#FF6B6B:"98th percentile" \
+ GPRINT:98th:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:98th:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:98th:MAX:" Max \\: %8.2lf %s\\n" \
+ AREA:95th#556270:"95th percentile" \
+ GPRINT:95th:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:95th:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:95th:MAX:" Max \\: %8.2lf %s\\n" \
+ AREA:75th#4ECDC4:"75th percentile" \
+ GPRINT:75th:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:75th:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:75th:MAX:" Max \\: %8.2lf %s\\n" \
+ AREA:50th#C7F464:"50th percentile" \
+ GPRINT:50th:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:50th:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:50th:MAX:" Max \\: %8.2lf %s\\n"
+
+report.OpenNMS.Flows.Netflow5.FlowsPerPacket.name=Netflow5 Flows Per Packet
+report.OpenNMS.Flows.Netflow5.FlowsPerPacket.columns=NF5FlowsPerPkt999,NF5FlowsPerPkt99,NF5FlowsPerPkt98,NF5FlowsPerPkt95,NF5FlowsPerPkt75,NF5FlowsPerPkt50
+report.OpenNMS.Flows.Netflow5.FlowsPerPacket.type=interfaceSnmp
+report.OpenNMS.Flows.Netflow5.FlowsPerPacket.command=--title="Netflow5: Flows Per Packet" \
+ --color GRID#f2f2f288  --color MGRID#c2c2d688  --vertical-label="Flows" \
+ DEF:999th={rrd1}:NF5FlowsPerPkt999:AVERAGE \
+ DEF:99th={rrd2}:NF5FlowsPerPkt99:AVERAGE \
+ DEF:98th={rrd3}:NF5FlowsPerPkt98:AVERAGE \
+ DEF:95th={rrd4}:NF5FlowsPerPkt95:AVERAGE \
+ DEF:75th={rrd5}:NF5FlowsPerPkt75:AVERAGE \
+ DEF:50th={rrd6}:NF5FlowsPerPkt50:AVERAGE \
+ AREA:999th#542437:"999th percentile" \
+ GPRINT:999th:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:999th:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:999th:MAX:" Max \\: %8.2lf %s\\n" \
+ AREA:99th#C44D58:"99th percentile" \
+ GPRINT:99th:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:99th:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:99th:MAX:" Max \\: %8.2lf %s\\n" \
+ AREA:98th#FF6B6B:"98th percentile" \
+ GPRINT:98th:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:98th:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:98th:MAX:" Max \\: %8.2lf %s\\n" \
+ AREA:95th#556270:"95th percentile" \
+ GPRINT:95th:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:95th:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:95th:MAX:" Max \\: %8.2lf %s\\n" \
+ AREA:75th#4ECDC4:"75th percentile" \
+ GPRINT:75th:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:75th:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:75th:MAX:" Max \\: %8.2lf %s\\n" \
+ AREA:50th#C7F464:"50th percentile" \
+ GPRINT:50th:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:50th:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:50th:MAX:" Max \\: %8.2lf %s\\n"
+
+report.OpenNMS.Flows.Netflow5.PacketsPerLog.name=Netflow5 Packets Per Log
+report.OpenNMS.Flows.Netflow5.PacketsPerLog.columns=NF5PktsPerLog999,NF5PktsPerLog99,NF5PktsPerLog98,NF5PktsPerLog95,NF5PktsPerLog75,NF5PktsPerLog50
+report.OpenNMS.Flows.Netflow5.PacketsPerLog.type=interfaceSnmp
+report.OpenNMS.Flows.Netflow5.PacketsPerLog.command=--title="Netflow5: Packets Per Log" \
+ --color GRID#f2f2f288  --color MGRID#c2c2d688  --vertical-label="Packets" \
+ DEF:999th={rrd1}:NF5PktsPerLog999:AVERAGE \
+ DEF:99th={rrd2}:NF5PktsPerLog99:AVERAGE \
+ DEF:98th={rrd3}:NF5PktsPerLog98:AVERAGE \
+ DEF:95th={rrd4}:NF5PktsPerLog95:AVERAGE \
+ DEF:75th={rrd5}:NF5PktsPerLog75:AVERAGE \
+ DEF:50th={rrd6}:NF5PktsPerLog50:AVERAGE \
+ AREA:999th#542437:"999th percentile" \
+ GPRINT:999th:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:999th:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:999th:MAX:" Max \\: %8.2lf %s\\n" \
+ AREA:99th#C44D58:"99th percentile" \
+ GPRINT:99th:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:99th:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:99th:MAX:" Max \\: %8.2lf %s\\n" \
+ AREA:98th#FF6B6B:"98th percentile" \
+ GPRINT:98th:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:98th:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:98th:MAX:" Max \\: %8.2lf %s\\n" \
+ AREA:95th#556270:"95th percentile" \
+ GPRINT:95th:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:95th:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:95th:MAX:" Max \\: %8.2lf %s\\n" \
+ AREA:75th#4ECDC4:"75th percentile" \
+ GPRINT:75th:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:75th:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:75th:MAX:" Max \\: %8.2lf %s\\n" \
+ AREA:50th#C7F464:"50th percentile" \
+ GPRINT:50th:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:50th:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:50th:MAX:" Max \\: %8.2lf %s\\n"
+
+# EOF

--- a/opennms-webapp-rest/pom.xml
+++ b/opennms-webapp-rest/pom.xml
@@ -315,6 +315,11 @@
       <artifactId>mockito-all</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-library</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <pluginRepositories>

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/RequisitionRestServiceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/RequisitionRestServiceIT.java
@@ -28,6 +28,7 @@
 
 package org.opennms.web.rest.v1;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
@@ -35,7 +36,6 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.List;
 
-import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -336,7 +336,7 @@ public class RequisitionRestServiceIT extends AbstractSpringJerseyRestTestCase {
 
         final MockHttpServletResponse response = sendPost("/requisitions", req, 500, null);
         final String responseText = response.getContentAsString();
-        assertThat(responseText, CoreMatchers.containsString("Failed to marshal/unmarshal XML file while unmarshalling an object (Requisition)"));
+        assertThat(responseText, containsString("Failed to marshal/unmarshal XML file while unmarshalling an object (Requisition)"));
     }
 
     @Test

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/config/JmxDataCollectionConfigResourceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/config/JmxDataCollectionConfigResourceIT.java
@@ -42,6 +42,8 @@ import org.slf4j.LoggerFactory;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.web.WebAppConfiguration;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
@@ -79,27 +81,27 @@ public class JmxDataCollectionConfigResourceIT extends AbstractSpringJerseyRestT
 
         assertNotNull(config);
 
-        assertEquals(6, config.getJmxCollectionCount());
+        assertThat(config.getJmxCollectionCount(), greaterThanOrEqualTo(6));
 
         assertEquals("jmx-jboss", config.getJmxCollection("jmx-jboss").getName());
         assertEquals(300, config.getJmxCollection("jmx-jboss").getRrd().getStep());
-        assertEquals(4, config.getJmxCollection("jmx-jboss").getMbeanCount());
+        assertThat(config.getJmxCollection("jmx-jboss").getMbeanCount(), greaterThanOrEqualTo(4));
 
         assertEquals("jsr160", config.getJmxCollection("jsr160").getName());
         assertEquals(300, config.getJmxCollection("jsr160").getRrd().getStep());
-        assertEquals(38, config.getJmxCollection("jsr160").getMbeanCount());
+        assertThat(config.getJmxCollection("jsr160").getMbeanCount(), greaterThanOrEqualTo(38));
 
         assertEquals("jmx-minion", config.getJmxCollection("jmx-minion").getName());
         assertEquals(300, config.getJmxCollection("jmx-minion").getRrd().getStep());
-        assertEquals(10, config.getJmxCollection("jmx-minion").getMbeanCount());
+        assertThat(config.getJmxCollection("jmx-minion").getMbeanCount(), greaterThanOrEqualTo(10));
 
         assertEquals("jmx-cassandra30x", config.getJmxCollection("jmx-cassandra30x").getName());
         assertEquals(300, config.getJmxCollection("jmx-cassandra30x").getRrd().getStep());
-        assertEquals(53, config.getJmxCollection("jmx-cassandra30x").getMbeanCount());
+        assertThat(config.getJmxCollection("jmx-cassandra30x").getMbeanCount(), greaterThanOrEqualTo(53));
 
         assertEquals("jmx-cassandra30x-newts", config.getJmxCollection("jmx-cassandra30x-newts").getName());
         assertEquals(300, config.getJmxCollection("jmx-cassandra30x-newts").getRrd().getStep());
-        assertEquals(22, config.getJmxCollection("jmx-cassandra30x-newts").getMbeanCount());
+        assertThat(config.getJmxCollection("jmx-cassandra30x-newts").getMbeanCount(), greaterThanOrEqualTo(22));
     }
 
 }


### PR DESCRIPTION
JIRA: https://issues.opennms.org/browse/HZN-1193

Here we improve the performance of the Netflow adapter by working on logs instead of individual packets and expose additional metrics via JMX.

The JMX metrics are collected via the opennms-jvm collection and include associated graphs.
