### PR TITLE
NMS-8905: Create fresh MockLogger instances in MockLoggerFactory

### DIFF
--- a/core/snmp/integration-tests/src/test/java/org/opennms/netmgt/snmp/snmp4j/Snmp4JStrategyIT.java
+++ b/core/snmp/integration-tests/src/test/java/org/opennms/netmgt/snmp/snmp4j/Snmp4JStrategyIT.java
@@ -36,7 +36,6 @@ import java.util.concurrent.CompletableFuture;
 
 import org.junit.Ignore;
 import org.junit.Test;
-import org.opennms.core.test.MockLogAppender;
 import org.opennms.netmgt.snmp.SnmpObjId;
 import org.opennms.netmgt.snmp.SnmpValue;
 import org.snmp4j.PDU;
@@ -308,9 +307,6 @@ public class Snmp4JStrategyIT extends MockSnmpAgentITCase {
         
         PDU pdu = m_strategy.buildPdu(new Snmp4JAgentConfig(getAgentConfig()), PDU.SET, oids, values);
         assertNull("PDU should be null", pdu);
-        
-        MockLogAppender.resetEvents();
-        MockLogAppender.resetLogLevel();
     }
     
     @Test
@@ -328,9 +324,6 @@ public class Snmp4JStrategyIT extends MockSnmpAgentITCase {
         
         PDU pdu = m_strategy.buildPdu(new Snmp4JAgentConfig(getAgentConfig()), PDU.SET, oids, values);
         assertNull("PDU should be null", pdu);
-        
-        MockLogAppender.resetEvents();
-        MockLogAppender.resetLogLevel();
     }
     
     private void assertSnmpValueEquals(String message, int expectedType, int expectedValue, SnmpValue value) {

--- a/core/test-api/lib/src/main/java/org/opennms/core/test/LoggingEvent.java
+++ b/core/test-api/lib/src/main/java/org/opennms/core/test/LoggingEvent.java
@@ -29,9 +29,9 @@
 package org.opennms.core.test;
 
 public class LoggingEvent {
-    private String m_name;
-    private Level m_level;
-    private String m_message;
+    private final String m_name;
+    private final Level m_level;
+    private final String m_message;
 
     public LoggingEvent(final String name, final Level level, final String message) {
         m_name = name;

--- a/core/test-api/lib/src/main/java/org/opennms/core/test/MockLogger.java
+++ b/core/test-api/lib/src/main/java/org/opennms/core/test/MockLogger.java
@@ -129,8 +129,10 @@ public class MockLogger extends MarkerIgnoringBase {
         loadProperties();
 
         String defaultLogLevelString = getStringProperty(DEFAULT_LOG_LEVEL_KEY, null);
-        if (defaultLogLevelString != null)
+        if (defaultLogLevelString != null) {
+            //System.err.println("Changing default log level to: " + defaultLogLevelString);
             DEFAULT_LOG_LEVEL = stringToLevel(defaultLogLevelString);
+        }
 
         SHOW_LOG_NAME = getBooleanProperty(SHOW_LOG_NAME_KEY, SHOW_LOG_NAME);
         SHOW_SHORT_LOG_NAME = getBooleanProperty(SHOW_SHORT_LOG_NAME_KEY, SHOW_SHORT_LOG_NAME);

--- a/core/test-api/lib/src/main/java/org/opennms/core/test/MockLoggerFactory.java
+++ b/core/test-api/lib/src/main/java/org/opennms/core/test/MockLoggerFactory.java
@@ -28,42 +28,15 @@
 
 package org.opennms.core.test;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import org.slf4j.ILoggerFactory;
 import org.slf4j.Logger;
 
 public class MockLoggerFactory implements ILoggerFactory {
-    final static MockLoggerFactory INSTANCE = new MockLoggerFactory();
-    static MockLogAppender s_appender = MockLogAppender.getInstance();
-
-    final Map<String,Logger> m_loggerMap;
-
-    public MockLoggerFactory() {
-        m_loggerMap = new HashMap<String,Logger>();
-    }
-
-    public static void setAppender(final MockLogAppender appender) {
-        s_appender = appender;
-    }
 
     /**
      * Return an appropriate {@link MockLogger} instance by name.
      */
     public Logger getLogger(final String name) {
-        if (s_appender == null) {
-            System.err.println("WARNING: getLogger(" + name + ") called, but MockLogAppender hasn't been set up yet!");
-        }
-        Logger slogger = null;
-        // protect against concurrent access of the loggerMap
-        synchronized (this) {
-            slogger = (Logger) m_loggerMap.get(name);
-            if (slogger == null) {
-                slogger = new MockLogger(name);
-                m_loggerMap.put(name, slogger);
-            }
-        }
-        return slogger;
+        return new MockLogger(name);
     }
 }

--- a/core/test-api/lib/src/test/java/org/opennms/core/test/MockLogAppenderTest.java
+++ b/core/test-api/lib/src/test/java/org/opennms/core/test/MockLogAppenderTest.java
@@ -32,7 +32,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-
 import junit.framework.AssertionFailedError;
 
 import org.junit.Before;
@@ -48,8 +47,24 @@ public class MockLogAppenderTest {
 
     @Before
     public void setUp() throws Exception {
-        MockLogAppender.resetLogLevel();
-        MockLogAppender.resetEvents();
+        MockLogAppender.setupLogging(true, MockLogAppender.DEFAULT_LOG_LEVEL);
+        MockLogAppender.resetState();
+    }
+
+    @Test
+    public void testDefaultLevelInfo() {
+        MockLogAppender.setupLogging(true, "INFO");
+        LoggerFactory.getLogger(getClass()).debug("A debug message");
+        MockLogAppender.assertNoLogging();
+    }
+
+    @Test
+    public void testDefaultLevelDebug() {
+        MockLogAppender.setupLogging(true, "DEBUG");
+        LoggerFactory.getLogger(getClass()).trace("A trace message");
+        MockLogAppender.assertNoLogging();
+        LoggerFactory.getLogger(getClass()).debug("A debug message");
+        MockLogAppender.assertLogAtLevel(Level.DEBUG);
     }
 
     @Test

--- a/features/events/syslog/src/test/java/org/opennms/netmgt/syslogd/SyslogdIT.java
+++ b/features/events/syslog/src/test/java/org/opennms/netmgt/syslogd/SyslogdIT.java
@@ -118,7 +118,7 @@ public class SyslogdIT implements InitializingBean {
     @Before
     public void setUp() throws Exception {
         MockLogAppender.setupLogging();
-        MockLogAppender.resetEvents();
+        MockLogAppender.resetState();
 
         InputStream stream = null;
         try {

--- a/integrations/opennms-jasper-extensions/src/test/java/org/opennms/netmgt/jasper/measurement/AbstractMeasurementQueryExecutorTest.java
+++ b/integrations/opennms-jasper-extensions/src/test/java/org/opennms/netmgt/jasper/measurement/AbstractMeasurementQueryExecutorTest.java
@@ -101,7 +101,7 @@ public class AbstractMeasurementQueryExecutorTest {
                 }
             }
         } finally {
-            MockLogAppender.resetEvents();
+            MockLogAppender.resetState();
         }
     }
 

--- a/integrations/opennms-snmp-asset-provisioning-adapter/src/test/java/org/opennms/netmgt/provision/SnmpAssetProvisioningAdapterFullIT.java
+++ b/integrations/opennms-snmp-asset-provisioning-adapter/src/test/java/org/opennms/netmgt/provision/SnmpAssetProvisioningAdapterFullIT.java
@@ -106,7 +106,6 @@ public class SnmpAssetProvisioningAdapterFullIT implements InitializingBean {
 
 	@Before
 	public void setUp() throws Exception {
-		// Use the mock.logLevel system property to control the log level
 		MockLogAppender.setupLogging(true);
 
 		// Set the operation delay to 1 second so that queued operations execute immediately

--- a/integrations/opennms-snmp-asset-provisioning-adapter/src/test/java/org/opennms/netmgt/provision/SnmpAssetProvisioningAdapterIT.java
+++ b/integrations/opennms-snmp-asset-provisioning-adapter/src/test/java/org/opennms/netmgt/provision/SnmpAssetProvisioningAdapterIT.java
@@ -81,7 +81,6 @@ public class SnmpAssetProvisioningAdapterIT implements InitializingBean {
 
 	@Before
 	public void setUp() throws Exception {
-		// Use the mock.logLevel system property to control the log level
 		MockLogAppender.setupLogging(true);
 
 		// Set the operation delay to 1 second so that queued operations execute immediately

--- a/opennms-dao/src/test/java/org/opennms/netmgt/dao/support/PropertiesGraphDaoITCase.java
+++ b/opennms-dao/src/test/java/org/opennms/netmgt/dao/support/PropertiesGraphDaoITCase.java
@@ -263,7 +263,7 @@ public class PropertiesGraphDaoITCase {
 	
 		m_fileAnticipator.deleteExpected();
 		m_fileAnticipator.tearDown();
-	    MockLogAppender.resetEvents();
+	    MockLogAppender.resetState();
 	}
 
 	public PropertiesGraphDao createPropertiesGraphDao(Map<String, Resource> prefabConfigs, Map<String, Resource> adhocConfigs)

--- a/opennms-services/src/test/java/org/opennms/netmgt/poller/PathOutageManagerDaoIT.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/poller/PathOutageManagerDaoIT.java
@@ -102,8 +102,6 @@ public class PathOutageManagerDaoIT implements TemporaryDatabaseAware<MockDataba
 	@Before
 	public void setUp() throws Exception {
 
-		// System.setProperty("mock.logLevel", "DEBUG");
-		// System.setProperty("mock.debug", "true");
 		MockUtil.println("------------ Begin Test  --------------------------");
 		MockLogAppender.setupLogging();
 

--- a/opennms-services/src/test/java/org/opennms/netmgt/poller/PollerIT.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/poller/PollerIT.java
@@ -158,8 +158,6 @@ public class PollerIT implements TemporaryDatabaseAware<MockDatabase> {
     @Before
     public void setUp() throws Exception {
 
-        // System.setProperty("mock.logLevel", "DEBUG");
-        // System.setProperty("mock.debug", "true");
         MockUtil.println("------------ Begin Test  --------------------------");
         MockLogAppender.setupLogging();
 

--- a/opennms-services/src/test/java/org/opennms/netmgt/poller/PollerQueryManagerDaoIT.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/poller/PollerQueryManagerDaoIT.java
@@ -148,8 +148,6 @@ public class PollerQueryManagerDaoIT implements TemporaryDatabaseAware<MockDatab
 	@Before
 	public void setUp() throws Exception {
 
-		// System.setProperty("mock.logLevel", "DEBUG");
-		// System.setProperty("mock.debug", "true");
 		MockUtil.println("------------ Begin Test  --------------------------");
 		MockLogAppender.setupLogging();
 

--- a/opennms-services/src/test/java/org/opennms/netmgt/threshd/ThresholdingVisitorIT.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/threshd/ThresholdingVisitorIT.java
@@ -1140,7 +1140,7 @@ public class ThresholdingVisitorIT {
     }
 
     private void runTestForBug3554() throws Exception {
-        MockLogAppender.resetEvents();
+        MockLogAppender.resetState();
         System.err.println("----------------------------------------------------------------------------------- begin test");
 
         String baseIpAddress = "10.0.0.";

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/NodeRestServiceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/NodeRestServiceIT.java
@@ -79,6 +79,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * TODO
@@ -506,6 +507,7 @@ public class NodeRestServiceIT extends AbstractSpringJerseyRestTestCase {
     }
 
     @Test
+    @Transactional
     @JUnitTemporaryDatabase
     public void testCategory() throws Exception {
         createNode();

--- a/pom.xml
+++ b/pom.xml
@@ -924,7 +924,6 @@
             <!-- Turn off queuing in the RRD output -->
             <org.opennms.rrd.usequeue>false</org.opennms.rrd.usequeue>
             <java.awt.headless>true</java.awt.headless>
-            <mock.logLevel>${mock.logLevel}</mock.logLevel>
             <mock.debug>${mock.debug}</mock.debug>
             <mock.rundbtests>${mock.rundbtests}</mock.rundbtests>
             <mock.leaveDatabase>${mock.leaveDatabase}</mock.leaveDatabase>
@@ -1187,8 +1186,6 @@
     <antlr.version>2.7.7</antlr.version>
     <sass.maven.plugin.version>1.1.2-ONMS-20131018-1</sass.maven.plugin.version>
 
-    <!-- turn down the default DEBUG logLevel. Override on the command line if you want -->
-    <mock.logLevel>WARN</mock.logLevel>
     <mock.debug>false</mock.debug>
     <mock.rundbtests>true</mock.rundbtests>
     <mock.leaveDatabase>false</mock.leaveDatabase>


### PR DESCRIPTION
This PR changes MockLoggerFactory so that it doesn't cache MockLogger instances. This means that MockLoggers will use the log level that is specified by calling static methods on MockLogAppender (as it was intended to work).

This reduces the log output of the build on Bamboo from about 3.2 million log messages down to about 1.8 million since DEBUG messages are no longer leaking into the output (from tests where DEBUG logging is not enabled).

There's also thread safety/API cleanup here for MockLogAppender. 

* JIRA: http://issues.opennms.org/browse/NMS-8905