### PR TITLE
NMS-9745: Karaf snmp:show-config command lists value of timeout for retries

### DIFF
--- a/core/snmp/commands/src/main/java/org/opennms/netmgt/snmp/commands/ShowConfigCommand.java
+++ b/core/snmp/commands/src/main/java/org/opennms/netmgt/snmp/commands/ShowConfigCommand.java
@@ -58,7 +58,7 @@ public class ShowConfigCommand extends OsgiCommandSupport {
         System.out.println("ProxyForAddress: " + InetAddrUtils.str(agent.getProxyFor()));
         System.out.println("Port: " + agent.getPort());
         System.out.println("Timeout: " + agent.getTimeout());
-        System.out.println("Retries: " + agent.getTimeout());
+        System.out.println("Retries: " + agent.getRetries());
         System.out.println("MaxVarsPerPdu: " + agent.getMaxVarsPerPdu());
         System.out.println("MaxRepetitions: " + agent.getMaxRepetitions());
         System.out.println("MaxRequestSize: " + agent.getMaxRequestSize());


### PR DESCRIPTION
* JIRA: http://issues.opennms.org/browse/NMS-9745