### PR TITLE
NMS-9739: allow pre-authentication through HTTP headers

### DIFF
--- a/opennms-doc/guide-admin/src/asciidoc/index.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/index.adoc
@@ -23,6 +23,7 @@ include::text/datachoices.adoc[]
 == User Management
 include::text/user-management/users.adoc[]
 include::text/user-management/security-roles.adoc[]
+include::text/user-management/pre-authentication.adoc[]
 
 [[ga-admin-ui]]
 == Administrative Webinterface

--- a/opennms-doc/guide-admin/src/asciidoc/text/user-management/pre-authentication.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/user-management/pre-authentication.adoc
@@ -1,0 +1,34 @@
+// Allow GitHub image rendering
+:imagesdir: ../../images
+
+[[ga-role-user-management-pre-authentication]]
+=== Web UI Pre-Authentication
+
+It is possible to configure _{opennms-product-name}_ to run behind a proxy that provides authentication, and then pass the pre-authenticated user to the _{opennms-product-name}_ webapp using a header.
+
+The pre-authentication configuration is defined in `$OPENNMS_HOME/jetty-webapps/opennms/WEB-INF/spring-security.d/header-preauth.xml`. This file is automatically included in the Spring Security context, but is not enabled by default.
+
+WARNING: *DO NOT* configure _{opennms-product-name}_ in this manner unless you are certain the web UI is only accessible to the proxy and not to end-users.
+	Otherwise, malicious attackers can craft queries that include the pre-authentication header and get full control of the web UI and ReST APIs.
+
+==== Enabling Pre-Authentication
+
+Edit the `header-preauth.xml` file, and set the `enabled` property:
+
+[source,xml]
+----
+<beans:property name="enabled" value="true" />
+----
+
+==== Configuring Pre-Authentication
+
+There are a number of other properties that can be set to change the behavior of the pre-authentication plugin.
+
+[options="header",frame="topbot",grid="none"]
+|====
+|Property|Description|Default
+|`enabled`|Whether the pre-authentication plugin is active.|`false`
+|`failOnError`|If true, disallow login if the header is not set or the user does not exist. If false, fall through to other mechanisms (basic auth, form login, etc.)|`false`
+|`userHeader`|The HTTP header that will specify the user to authenticate as.|`X-Remote-User`
+|`credentialsHeader`|A comma-separated list of additional credentials (roles) the user should have.|
+|====

--- a/opennms-doc/guide-admin/src/asciidoc/text/user-management/security-roles.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/user-management/security-roles.adoc
@@ -49,7 +49,7 @@ endif::opennms-prime[]
 . Click *Finish* to persist and apply the Changes
 . *Logout* and *Login* to apply the new _Security Role_ settings
 
-.How to add custom rules
+.How to add custom roles
 
 * Create a file called `$OPENNMS_HOME/etc/security-roles.properties`.
 * Add a property called `roles`, and for its value, a comma separated list of the custom roles, for example:

--- a/opennms-webapp/src/main/webapp/WEB-INF/applicationContext-spring-security.xml
+++ b/opennms-webapp/src/main/webapp/WEB-INF/applicationContext-spring-security.xml
@@ -46,6 +46,8 @@
 
     <http-basic />
 
+    <custom-filter position="PRE_AUTH_FILTER" ref="attributePreAuthFilter"/>
+    <custom-filter after="PRE_AUTH_FILTER" ref="headerPreAuthFilter"/>
     <custom-filter position="LAST" ref="authFilterEnabler"/>
   </http>
 
@@ -59,6 +61,8 @@
 
     <http-basic />
 
+    <custom-filter position="PRE_AUTH_FILTER" ref="attributePreAuthFilter"/>
+    <custom-filter after="PRE_AUTH_FILTER" ref="headerPreAuthFilter"/>
     <custom-filter position="LAST" ref="authFilterEnabler"/>
   </http>
 
@@ -82,6 +86,8 @@
 
     <http-basic />
 
+    <custom-filter position="PRE_AUTH_FILTER" ref="attributePreAuthFilter"/>
+    <custom-filter after="PRE_AUTH_FILTER" ref="headerPreAuthFilter"/>
     <custom-filter position="LAST" ref="authFilterEnabler"/>
   </http>
 
@@ -91,6 +97,8 @@
 
     <http-basic />
 
+    <custom-filter position="PRE_AUTH_FILTER" ref="attributePreAuthFilter"/>
+    <custom-filter after="PRE_AUTH_FILTER" ref="headerPreAuthFilter"/>
     <custom-filter position="LAST" ref="authFilterEnabler"/>
   </http>
   
@@ -147,6 +155,8 @@
       <!-- added for custom authentication filter -->
     <custom-filter position="FORM_LOGIN_FILTER" ref="onmsUsernamePasswordAuthenticationFilter" />
 
+    <custom-filter position="PRE_AUTH_FILTER" ref="attributePreAuthFilter"/>
+    <custom-filter after="PRE_AUTH_FILTER" ref="headerPreAuthFilter"/>
     <custom-filter position="LAST" ref="authFilterEnabler"/>
   </http>
   
@@ -177,8 +187,19 @@
     </beans:bean>
     <!-- END CUSTOM AUthentication Filter -->
 
+  <!-- If a user is pre-authenticated, this will provide user details for the pre-authenticated user -->
+  <beans:bean id="preauthAuthProvider" class="org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationProvider">
+    <beans:property name="preAuthenticatedUserDetailsService">
+      <beans:bean id="userDetailsServiceWrapper" class="org.springframework.security.core.userdetails.UserDetailsByNameServiceWrapper">
+        <beans:property name="userDetailsService" ref="openNMSUserDetailsService"/>
+      </beans:bean>
+    </beans:property>
+  </beans:bean>
+
   <!-- use our custom authentication provider; to use RADIUS instead, change this to "radiusAuthenticationProvider" and uncomment below -->
   <authentication-manager alias="authenticationManager">
+    <!-- If a user is pre-authenticated, make sure their user details are populated correctly. -->
+    <authentication-provider ref="preauthAuthProvider" />
     <!-- Use our custom authentication provider -->
     <authentication-provider ref="hybridAuthenticationProvider" />
     <!-- To enable external (e.g. LDAP, RADIUS) authentication, uncomment the following.

--- a/opennms-webapp/src/main/webapp/WEB-INF/spring-security.d/attribute-preauth.xml
+++ b/opennms-webapp/src/main/webapp/WEB-INF/spring-security.d/attribute-preauth.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans:beans xmlns="http://www.springframework.org/schema/security"
+  xmlns:beans="http://www.springframework.org/schema/beans"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+              http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security-3.1.xsd">
+
+  <!-- This filter will pre-authenticate the user if the servlet request has the specified attribute set. -->
+  <beans:bean id="attributePreAuthFilter" class="org.opennms.web.springframework.security.RequestAttributePreAuthenticationProcessingFilter">
+    <beans:property name="enabled" value="false" />
+    <beans:property name="failOnError" value="false" />
+    <beans:property name="principalRequestHeader" value="REMOTE_USER" />
+    <beans:property name="credentialsRequestHeader" value="" />
+    <beans:property name="authenticationManager" ref="authenticationManager" />
+  </beans:bean>
+
+</beans:beans>

--- a/opennms-webapp/src/main/webapp/WEB-INF/spring-security.d/header-preauth.xml
+++ b/opennms-webapp/src/main/webapp/WEB-INF/spring-security.d/header-preauth.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans:beans xmlns="http://www.springframework.org/schema/security"
+  xmlns:beans="http://www.springframework.org/schema/beans"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+              http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security-3.1.xsd">
+
+  <!-- This filter will pre-authenticate the user if the servlet request has the specified HTTP header set.
+       NOTE: THIS IS A HUGE SECURITY RISK IF NOT CONFIGURED CORRECTLY!  ONLY ENABLE THIS WITH A PROXY THAT SETS THE HEADERS UNCONDITIONALLY!
+       Make sure your OpenNMS instance is:
+         a) not reachable from the outside except through the proxy
+         b) not able to receive the header if a malicious user passes it on their request
+  -->
+  <beans:bean id="headerPreAuthFilter" class="org.opennms.web.springframework.security.RequestHeaderPreAuthenticationProcessingFilter">
+    <beans:property name="enabled" value="false" />
+    <beans:property name="failOnError" value="false" />
+    <beans:property name="userHeader" value="X-Remote-User" />
+    <beans:property name="credentialsHeader" value="" />
+    <beans:property name="authenticationManager" ref="authenticationManager" />
+  </beans:bean>
+
+</beans:beans>

--- a/opennms-webapp/src/test/java/org/opennms/web/report/database/SpringWebflowContextIT.java
+++ b/opennms-webapp/src/test/java/org/opennms/web/report/database/SpringWebflowContextIT.java
@@ -58,6 +58,8 @@ import org.springframework.web.context.WebApplicationContext;
         "classpath:/org/opennms/web/svclayer/applicationContext-svclayer.xml",
         "classpath:/META-INF/opennms/applicationContext-reporting.xml",
         "file:src/main/webapp/WEB-INF/applicationContext-spring-security.xml",
+        "file:src/main/webapp/WEB-INF/spring-security.d/header-preauth.xml",
+        "file:src/main/webapp/WEB-INF/spring-security.d/attribute-preauth.xml",
         "file:src/main/webapp/WEB-INF/applicationContext-spring-webflow.xml"
 })
 @JUnitConfigurationEnvironment


### PR DESCRIPTION
This commit creates a new pre-authentication filter for servlets
(RequestHeaderPreAuthenticationProcessingFilter) and configures it
in applicationContext-spring-security.xml.

It also refactors the existing servlet attribute filter
(RequestAttributePreAuthenticationProcessingFilter) to look more
like the new header-based filter.

Both now require a property "enabled" to be set to "true" or else
they will silently pass control to the next filter in the chain
without authenticating.  This allows us to leave them always
configured in the spring security .xml without having to make
large/unusual config changes besides enabling the filter.

* JIRA: http://issues.opennms.org/browse/NMS-9739

Our [continuous integration system](http://bamboo.internal.opennms.com:8085) will test and verify your changes.
