### PR TITLE
Updated JVM debug flags to use agentlib:jdwp

### DIFF
--- a/opennms-assemblies/remote-poller-windows/src/main/filtered/install.bat
+++ b/opennms-assemblies/remote-poller-windows/src/main/filtered/install.bat
@@ -15,11 +15,7 @@ OpenNMSRemotePoller install ^
   --JvmOptions="-Dopennms.home=%OPENNMS_HOME%" ^
   ++JvmOptions="-Djava.rmi.activation.port=1099" ^
   ++JvmOptions=-Xmx384m ^
-  ++JvmOptions=-XX:MaxMetaspaceSize=256M ^
-  ++JvmOptions="-Xdebug" ^
-  ++JvmOptions="-Xnoagent" ^
-  ++JvmOptions="-Djava.compiler=none" ^
-  ++JvmOptions="-Xrunjdwp:transport=dt_socket,server=y,address=8001,suspend=n" ^
+  ++JvmOptions="-agentlib:jdwp=transport=dt_socket,server=y,address=8001,suspend=n" ^
   --Classpath="%OPENNMS_HOME%\remote-poller-${project.version}.jar" ^
   --StartMode=jvm ^
   --StartClass=com.simontuffs.onejar.Boot ^
@@ -36,8 +32,5 @@ OpenNMSRemotePoller install ^
   --StopMethod stop
 
 :: Add these options to enable remote debugging
-::  ++JvmOptions="-Xdebug" ^
-::  ++JvmOptions="-Xnoagent" ^
-::  ++JvmOptions="-Djava.compiler=none" ^
-::  ++JvmOptions="-Xrunjdwp:transport=dt_socket,server=y,address=8001,suspend=n" ^
+::  ++JvmOptions="-agentlib:jdwp=transport=dt_socket,server=y,address=8001,suspend=n" ^
 

--- a/opennms-base-assembly/src/main/filtered/bin/opennms
+++ b/opennms-base-assembly/src/main/filtered/bin/opennms
@@ -319,7 +319,7 @@ doStart(){
 	###########################################################################
 	if [ $TEST -gt 0 ]; then
 		echo "- enabling JPDA debugging on port 8001" >&2
-		JPDA="-Xdebug -Xnoagent -Djava.compiler=none -Xrunjdwp:transport=dt_socket,server=y,address=8001,suspend=n"
+		JPDA="-agentlib:jdwp=transport=dt_socket,server=y,address=8001,suspend=n"
 	fi
 
 	# See: http://www.khelekore.org/jmp/tijmp/

--- a/opennms-webapp/runInPlace.sh
+++ b/opennms-webapp/runInPlace.sh
@@ -29,8 +29,8 @@ function runInPlace() {
         OFFLINE_ARGS="-o"
     fi
 	if $DEBUG; then
-			MAVEN_OPTS="${MAVEN_OPTS} -XX:PermSize=512m -XX:MaxMetaspaceSize=1g -Xmx1g -XX:ReservedCodeCacheSize=512m"
-			MAVEN_OPTS="${MAVEN_OPTS} -Xdebug -Xnoagent -Djava.compiler=NONE -Xrunjdwp:transport=dt_socket,address=8002,server=y,suspend=n"
+			MAVEN_OPTS="${MAVEN_OPTS} -Xmx1g -XX:ReservedCodeCacheSize=512m"
+			MAVEN_OPTS="${MAVEN_OPTS} -agentlib:jdwp=transport=dt_socket,address=8002,server=y,suspend=n"
 			export MAVEN_OPTS;
 	fi
 	echo $MAVEN_OPTS;


### PR DESCRIPTION
This PR gets rid of deprecated pre-Java5 debug flags and uses `agentlib:jdwp` instead.