### PR TITLE
NMS-9771: Restructure and improve Help/Support pages

### DIFF
--- a/opennms-base-assembly/src/main/filtered/etc/rws-nbinventoryreport.xsl
+++ b/opennms-base-assembly/src/main/filtered/etc/rws-nbinventoryreport.xsl
@@ -985,7 +985,7 @@ li.pagination {
 					</xsl:for-each>
 				</xsl:for-each>
 				        <p><center>
-        OpenNMS <a href="help/about.jsp">Copyright</a> 2002-2009
+        OpenNMS <a href="about/index.jsp">Copyright</a> 2002-2018
             <a href="http://www.opennms.com/">The OpenNMS Group, Inc.</a>
             OpenNMS is a registered trademark of
         <a href="http://www.opennms.com">The OpenNMS Group, Inc.</a>

--- a/opennms-base-assembly/src/main/filtered/etc/rws-rancidlistreport.xsl
+++ b/opennms-base-assembly/src/main/filtered/etc/rws-rancidlistreport.xsl
@@ -927,7 +927,7 @@ li.pagination {
     </xsl:for-each>
     
         <p><center>
-        OpenNMS <a href="help/about.jsp">Copyright</a> 2002-2009
+        OpenNMS <a href="about/index.jsp">Copyright</a> 2002-2018
             <a href="http://www.opennms.com/">The OpenNMS Group, Inc.</a>
             OpenNMS is a registered trademark of
         <a href="http://www.opennms.com">The OpenNMS Group, Inc.</a>

--- a/opennms-webapp/src/main/resources/org/opennms/web/controller/navbar.ftl
+++ b/opennms-webapp/src/main/resources/org/opennms/web/controller/navbar.ftl
@@ -95,11 +95,15 @@
               <#if isAdmin || isProvision >
                 <li><a name="nav-admin-quick-add" href="${baseHref}admin/ng-requisitions/quick-add-node.jsp#/" style="white-space: nowrap">Quick-Add Node</a></li>
               </#if>
-              <li><a name="nav-admin-support" href="${baseHref}support/index.htm">Help/Support</a></li>
+              <#if isAdmin >
+                <li><a name="nav-admin-support" href="${baseHref}support/index.htm">Support</a></li>
+              </#if>
               <#if request.remoteUser?has_content >
                 <li><a name="nav-admin-self-service" href="${baseHref}account/selfService/index.jsp">Change Password</a>
                 <li><a name="nav-admin-logout" href="${baseHref}j_spring_security_logout" style="white-space: nowrap">Log Out</a></li>
               </#if>
+              <li><a name="nav-admin-help" href="${baseHref}help/index.jsp" style="white-space: nowrap">Help</a></li>
+              <li><a name="nav-admin-about" href="${baseHref}about/index.jsp" style="white-space: nowrap">About</a></li>
             </ul>
           </li>
 		</#if>

--- a/opennms-webapp/src/main/webapp/WEB-INF/jsp/support/index.jsp
+++ b/opennms-webapp/src/main/webapp/WEB-INF/jsp/support/index.jsp
@@ -2,8 +2,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2010-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2010-2018 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2018 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -32,222 +32,163 @@
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 
 <%@page language="java"
-	contentType="text/html"
-session="true"
+        contentType="text/html"
+        session="true"
 %>
 
-<jsp:include page="/includes/bootstrap.jsp" flush="false" >
-  <jsp:param name="title" value="Support" />
-  <jsp:param name="headTitle" value="Get Support" />
-  <jsp:param name="location" value="help" />
-  <jsp:param name="breadcrumb" value="Support" />
+<jsp:include page="/includes/bootstrap.jsp" flush="false">
+    <jsp:param name="title" value="Support"/>
+    <jsp:param name="headTitle" value="Get Support"/>
+    <jsp:param name="location" value="help"/>
+    <jsp:param name="breadcrumb" value="Support"/>
 </jsp:include>
 
-<script type="text/javascript">
-  // Shorthand for 'onload'
-  $(function() {
-    // Check to see if the URL provided by the opennms-docs package is present on the system.
-    // If so, display the links to the offline docs symlinked from /usr/share/doc/opennms-${version}.
-    $.ajax({
-      url: 'docs/guide-install/index.html',
-      method: 'HEAD',
-      error: function()
-      {
-        $('#online-documentation').css("display", "inline-block");
-      },
-      success: function()
-      {
-        $('#offline-documentation').css("display", "inline-block");
-      }
-    });
-  });
-</script>
-
 <div class="row">
-<div class="col-md-6">
-    <c:choose>
+    <div class="col-md-4">
+        <c:choose>
+            <c:when test="${!results.needsLogin}">
+                <!-- we have a login session, show support details -->
 
-      <c:when test="${!results.needsLogin}">
-        <!-- we have a login session, show support details -->
+                <div class="panel panel-default">
+                    <div class="panel-heading">
+                        <h3 class="panel-title">Commercial Support</h3>
+                    </div>
+                    <div class="panel-body">
 
-		<div class="panel panel-default">
-		  <div class="panel-heading">
-        	<h3 class="panel-title">Commercial Support</h3>
-        </div>
-        <div class="panel-body">
+                        <c:if test="${not empty results.message}">
+                            <div class="something">
+                                <c:out value="${results.message}" escapeXml="false"/>
+                            </div>
+                        </c:if>
 
-        <c:if test="${not empty results.message}">
-          <div class="something">
-            <c:out value="${results.message}" escapeXml="false" />
-          </div>
-        </c:if>
+                        <p>To create a support ticket, enter a subject and a description of the
+                            problem below. Please choose a descriptive subject and indicate whether
+                            this is a new problem (something that worked before but doesn't now) or
+                            a &quot;day one&quot; problem.</p>
 
-        <p>To create a support ticket, enter a subject and a description of the
-           problem below. Please choose a descriptive subject and indicate whether
-           this is a new problem (something that worked before but doesn't now) or
-           a &quot;day one&quot; problem.</p>
+                        <p>You may elect to include a basic system report to help the support engineer who works your
+                            ticket diagnose the problem more quickly.</p>
 
-        <p>You may elect to include a basic system report to help
-           the support engineer who works your ticket diagnose the problem more
-           quickly.</p>
+                        <form method="post" action="support/index.htm" id="signout">
+                            <input type="hidden" name="operation" value="logout"/>
+                        </form>
+                        <form role="form" class="form-horizontal" method="post" action="support/index.htm">
+                            <div class="form-group">
+                                <div class="col-md-2">
+                                    <label for="sign-out" class="control-label">Username:</label>
+                                </div>
+                                <div class="col-md-2">
+                                    <p class="form-control-static"><c:out value="${results.username}"/></p>
+                                </div>
+                                <div class="col-md-8">
+                                    <input id="sign-out" class="btn btn-default pull-right" value="Sign Out"
+                                           onClick="document.forms['signout'].submit();"/>
+                                </div>
+                            </div>
+                            <div class="form-group">
+                                <div class="col-md-2">
+                                    <label class="control-label">Queue:</label>
+                                </div>
+                                <div class="col-md-2">
+                                    <p class="form-control-static"><c:out value="${results.queue}"/></p>
+                                </div>
+                            </div>
+                            <div class="form-group">
+                                <div class="col-md-12">
+                                    <label for="subject" class="control-label">Subject:</label>
+                                    <input id="subject" class="form-control" type="text" name="subject"
+                                           value="${sessionScope.errorReportSubject}"/>
+                                </div>
+                            </div>
+                            <div class="form-group">
+                                <div class="col-md-12">
+                                    <label for="details" class="control-label">Details:</label>
+                                    <textarea id="details" class="form-control" name="text"
+                                              rows="15">${sessionScope.errorReportDetails}</textarea>
+                                </div>
+                            </div>
+                            <div class="form-group">
+                                <div class="col-md-12">
+                                    <div class="checkbox pull-left">
+                                        <label>
+                                            <input type="checkbox" name="include-report" id="include-report"
+                                                   checked="checked" value="true">Include Basic System Report
+                                        </label>
+                                    </div>
+                                    <div class="pull-right">
+                                        <input class="btn btn-default" type="reset" value="Clear"/>
+                                        <input class="btn btn-default" type="submit" value="Create Ticket"/>
+                                    </div>
+                                </div>
+                            </div>
+                            <input type="hidden" name="operation" value="createTicket"/>
+                        </form>
 
-        <form method="post" action="support/index.htm" id="signout">
-	      <input type="hidden" name="operation" value="logout" />
-        </form>
-        <form role="form" class="form-horizontal" method="post" action="support/index.htm">
-          <div class="form-group">
-            <div class="col-md-2">
-              <label for="sign-out" class="control-label">Username:</label>
-	        </div>
-            <div class="col-md-2">
-              <p class="form-control-static"><c:out value="${results.username}" /></p>
-	        </div>
-            <div class="col-md-8">
-	          <input id="sign-out" class="btn btn-default pull-right" value="Sign Out" onClick="document.forms['signout'].submit();"/>
-	        </div>
-          </div>
-          <div class="form-group">
-          	<div class="col-md-2">
-              <label class="control-label">Queue:</label>
-	        </div>
-	        <div class="col-md-2">
-              <p class="form-control-static"><c:out value="${results.queue}" /></p>
-	        </div>
-          </div>
-          <div class="form-group">
-          	<div class="col-md-12">
-              <label for="subject" class="control-label">Subject:</label>
-			  <input id="subject" class="form-control" type="text" name="subject" value="${sessionScope.errorReportSubject}" />
-			</div>
-          </div>
-          <div class="form-group">
-            <div class="col-md-12">
-              <label for="details" class="control-label">Details:</label>
-              <textarea id="details" class="form-control" name="text" rows="15" >${sessionScope.errorReportDetails}</textarea>
-            </div>
-          </div>
-          <div class="form-group">
-            <div class="col-md-12">
-              <div class="checkbox pull-left">
-          	    <label>
-                  <input type="checkbox" name="include-report" id="include-report" checked="checked" value="true">Include Basic System Report
-                </label>
-              </div>
-          	  <div class="pull-right">
-                <input class="btn btn-default" type="reset" value="Clear" />
-                <input class="btn btn-default" type="submit" value="Create Ticket" />
-              </div>
-            </div>
-          </div>
-          <input type="hidden" name="operation" value="createTicket" />
-        </form>
+                        <p>
+                            Your newest tickets are listed below. For a complete list, log in to the
+                            <a href="<c:out value="${results.RTUrl}" />">OpenNMS support portal</a>.
+                        </p>
 
-        <p>
-        	Your newest tickets are listed below.  For a complete list, log in to the
-        	<a href="<c:out value="${results.RTUrl}" />">OpenNMS support portal</a>.
-        </p>
-        
-        <table>
-        <c:forEach var="ticket" items="${results.latestTickets}">
-          <tr>
-            <td><c:out value="${ticket.created}" /></td>
-            <td><a href="<c:out value="${results.RTUrl}/Ticket/Display.html?id=${ticket.id}" />" target="_blank"><c:out value="${ticket.subject}" /></a></td>
-          </tr>
-        </c:forEach>
-        </table>
-        </div>
-        </div>
-      </c:when>
+                        <table>
+                            <c:forEach var="ticket" items="${results.latestTickets}">
+                                <tr>
+                                    <td><c:out value="${ticket.created}"/></td>
+                                    <td><a href="<c:out value="${results.RTUrl}/Ticket/Display.html?id=${ticket.id}" />"
+                                           target="_blank"><c:out value="${ticket.subject}"/></a></td>
+                                </tr>
+                            </c:forEach>
+                        </table>
+                    </div>
+                </div>
+            </c:when>
 
-      <c:otherwise>
-        <!-- no account session found, ask for login -->
-        <div class="panel panel-default">
-        <div class="panel-heading">
-        	<h3 class="panel-title">Commercial Support</h3>
-        </div>
-        <div class="panel-body">
+            <c:otherwise>
+                <!-- no account session found, ask for login -->
+                <div class="panel panel-default">
+                    <div class="panel-heading">
+                        <h3 class="panel-title">Commercial Support</h3>
+                    </div>
+                    <div class="panel-body">
 
-        <p>
-          Enter your OpenNMS Group commercial support login to open a support ticket or view your open
-          issues.
-        </p>
-        <p>
-          If you do not have a commercial support agreement, see
-          <a href="http://www.opennms.com/support/">the OpenNMS.com support page</a> for more details.
-        </p>
-        <form role="form" method="post" action="support/index.htm">
-			<div class="form-group">
-    					<label for="username" class="control-label">Username:</label>
-      					<input type="text" name="username" class="form-control" id="username" placeholder="Username">
-  			</div>
-  			<div class="form-group">
-    			<label for="password" class="control-label">Password:</label>
-      			<input type="password" name="password" class="form-control" id="password" placeholder="Password">
-  			</div>
-  			<div class="form-group">
-  				<button type="reset" class="btn btn-default">Clear</button>
-  				<button type="submit" class="btn btn-default">Log in</button>
-  				<input type="hidden" name="operation" value="login" />
-  			</div>
-        </form>
-        </div>
-        </div>
-      </c:otherwise>
+                        <p>
+                            Enter your OpenNMS Group commercial support login to open a support ticket or view your open
+                            issues.
+                        </p>
+                        <p>
+                            If you do not have a commercial support agreement, see
+                            <a href="http://www.opennms.com/support/">the OpenNMS.com support page</a> for more details.
+                        </p>
+                        <form role="form" method="post" action="support/index.htm">
+                            <div class="form-group">
+                                <label for="username" class="control-label">Username:</label>
+                                <input type="text" name="username" class="form-control" id="username"
+                                       placeholder="Username">
+                            </div>
+                            <div class="form-group">
+                                <label for="password" class="control-label">Password:</label>
+                                <input type="password" name="password" class="form-control" id="password"
+                                       placeholder="Password">
+                            </div>
+                            <div class="form-group">
+                                <button type="reset" class="btn btn-default">Clear</button>
+                                <button type="submit" class="btn btn-default">Log in</button>
+                                <input type="hidden" name="operation" value="login"/>
+                            </div>
+                        </form>
+                    </div>
+                </div>
+            </c:otherwise>
 
-    </c:choose>
+        </c:choose>
+    </div>
+
+    <div class="col-md-4">
+        <jsp:include page="/includes/support-system-diagnostics.jsp" flush="false"/>
+    </div>
+
+    <div class="col-md-4">
+        <jsp:include page="/includes/help-contact.jsp" flush="false"/>
+    </div>
 </div>
 
-<div class="col-md-6">
-  <div class="panel panel-default">
-  <div class="panel-heading">
-  	<h3 class="panel-title">About</h3>
-  </div>
-  <div class="panel-body">
-    <ul class="list-unstyled">
-      <li><a href="support/about.jsp">About the OpenNMS Web Console</a></li>
-      <li><a href="http://docs.opennms.org/opennms/releases/latest/releasenotes/releasenotes.html">Release Notes</a></li>
-    </ul>
-  </div>
-  </div>
-
-  <div class="panel panel-default">
-  <div class="panel-heading">
-    <h3 class="panel-title">Documentation</h3>
-  </div>
-  <div class="panel-body">
-    <span id="online-documentation" style="display:none;">
-    <ul class="list-unstyled">
-      <li><a href="http://docs.opennms.org/opennms/releases/latest/guide-install/guide-install.html">Installation Guide</a></li>
-      <li><a href="http://docs.opennms.org/opennms/releases/latest/guide-user/guide-user.html">Users Guide</a></li>
-      <li><a href="http://docs.opennms.org/opennms/releases/latest/guide-admin/guide-admin.html">Administrators Guide</a></li>
-      <li><a href="http://docs.opennms.org/opennms/releases/latest/guide-development/guide-development.html">Developers Guide</a></li>
-      <li><a href="http://www.opennms.org/wiki/">Online Wiki Documentation</a></li>
-    </ul>
-    </span>
-    <span id="offline-documentation" style="display:none;">
-    <ul class="list-unstyled">
-      <li><a href="docs/guide-install/index.html">Installation Guide</a></li>
-      <li><a href="docs/guide-user/index.html">Users Guide</a></li>
-      <li><a href="docs/guide-admin/index.html">Administrators Guide</a></li>
-      <li><a href="docs/guide-development/index.html">Developers Guide</a></li>
-      <li><a href="http://www.opennms.org/wiki/">Online Wiki Documentation</a></li>
-    </ul>
-    </span>
-  </div>
-  </div>
-
-  <div class="panel panel-default">
-  <div class="panel-heading">
-  	<h3 class="panel-title">Other Support Options</h3>
-  </div>
-  <div class="panel-body">
-    <ul class="list-unstyled">
-      <li><a href="admin/support/systemReport.htm">Generate a System Report</a></li>
-      <li><a href="http://issues.opennms.org/">Open a Bug or Enhancement Request</a></li>
-      <li><a href="irc://irc.freenode.net/%23opennms">Chat with Developers on IRC</a></li>
-    </ul>
-  </div>
-</div>
-</div><!-- col -->
-</div><!-- row -->
 <jsp:include page="/includes/bootstrap-footer.jsp" flush="false"/>

--- a/opennms-webapp/src/main/webapp/about/index.jsp
+++ b/opennms-webapp/src/main/webapp/about/index.jsp
@@ -44,7 +44,7 @@
 
 <%
     boolean role = request.isUserInRole(Authentication.ROLE_ADMIN);
-    
+
     final DBUtils d = new DBUtils();
     String dbName;
     String dbVersion;
@@ -59,23 +59,22 @@
    	} finally {
    	  d.cleanUp();
    	}
-%> 
+%>
 
 <jsp:include page="/includes/bootstrap.jsp" flush="false" >
   <jsp:param name="title" value="About" />
   <jsp:param name="headTitle" value="About" />
-  <jsp:param name="breadcrumb" value="<a href='support/index.htm'>Support</a>" />
   <jsp:param name="breadcrumb" value="About" />
 </jsp:include>
 
   <div class="panel panel-default">
     <div class="panel-heading">
-      <h3 class="panel-title">OpenNMS Web Console</h3>
+      <h3 class="panel-title">Version Details</h3>
     </div>
 <table class="table table-condensed">
   <tr>
     <th>Version:</th>
-    <td><%=Vault.getProperty("version.display")%></td>
+    <td><a href="http://docs.opennms.org/opennms/releases/latest/releasenotes/releasenotes.html" target="_blank" title="Release Notes"><%=Vault.getProperty("version.display")%></a></td>
   </tr>
 
   <tr>

--- a/opennms-webapp/src/main/webapp/about/index.jsp
+++ b/opennms-webapp/src/main/webapp/about/index.jsp
@@ -74,7 +74,7 @@
 <table class="table table-condensed">
   <tr>
     <th>Version:</th>
-    <td><a href="http://docs.opennms.org/opennms/releases/latest/releasenotes/releasenotes.html" target="_blank" title="Release Notes"><%=Vault.getProperty("version.display")%></a></td>
+    <td><a href="http://docs.opennms.org/opennms/releases/<%=Vault.getProperty("version.display")%> /releasenotes/releasenotes.html" target="_blank" title="Release Notes"><%=Vault.getProperty("version.display")%></a></td>
   </tr>
 
   <tr>

--- a/opennms-webapp/src/main/webapp/includes/bootstrap-footer.jsp
+++ b/opennms-webapp/src/main/webapp/includes/bootstrap-footer.jsp
@@ -2,8 +2,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2002-2017 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
+ * Copyright (C) 2002-2018 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2018 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -29,11 +29,11 @@
 
 --%>
 
-<%-- 
-  This page is included by other JSPs to create a uniform footer. 
+<%--
+  This page is included by other JSPs to create a uniform footer.
   It expects that a <base> tag has been set in the including page
   that directs all URLs to be relative to the servlet context.
-  
+
   This include JSP takes one parameter:
     location (optional): used to "dull out" the item in the menu bar
       that has a link to the location given  (for example, on the
@@ -41,48 +41,60 @@
 --%>
 
 <%@page language="java"
-	contentType="text/html"
-	session="true"
-	import="java.io.File,org.opennms.web.api.HtmlInjectHandler"
+        contentType="text/html"
+        session="true"
+        import="java.io.File,
+                org.opennms.core.resource.Vault,
+                org.opennms.web.api.HtmlInjectHandler,
+                org.opennms.web.servlet.XssRequestWrapper"
 %>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 
-  <!-- End of Content -->
-  <div class="spacer"><!-- --></div>
+<%
+    XssRequestWrapper req = new XssRequestWrapper(request);
+%>
+
+<!-- End of Content -->
+<div class="spacer"><!-- --></div>
 
 
 <c:choose>
-  <c:when test="${param.quiet == 'true'}">
-    <!-- Not displaying footer -->
-  </c:when>
+    <c:when test="${param.quiet == 'true'}">
+        <!-- Not displaying footer -->
+    </c:when>
 
-  <c:otherwise>
-    <!-- Footer -->
+    <c:otherwise>
+        <!-- Footer -->
 
-    <footer id="footer">
-      <p>
-        OpenNMS <a href="support/about.jsp">Copyright</a> &copy; 2002-2017
-        <a href="http://www.opennms.com/">The OpenNMS Group, Inc.</a>
-        OpenNMS&reg; is a registered trademark of
-        <a href="http://www.opennms.com">The OpenNMS Group, Inc.</a>
-      </p>
-    </footer>
-  </c:otherwise>
+        <footer id="footer">
+            <p>
+                OpenNMS <a href="about/index.jsp">Copyright</a> &copy; 2002-2018
+                <a href="http://www.opennms.com/">The OpenNMS Group, Inc.</a>
+                OpenNMS&reg; is a registered trademark of
+                <a href="http://www.opennms.com">The OpenNMS Group, Inc.</a>
+                <%
+                    if (req.getUserPrincipal() != null) {
+                        out.print(" - Version: " + Vault.getProperty("version.display"));
+                    }
+                %>
+            </p>
+        </footer>
+    </c:otherwise>
 </c:choose>
 
 <%
-  File extraIncludes = new File(request.getSession().getServletContext().getRealPath("includes") + File.separator + "custom-footer");
-  if (extraIncludes.exists()) {
-	  for (File file : extraIncludes.listFiles()) {
-		  if (file.isFile()) {
-			  pageContext.setAttribute("file", "custom-footer/" + file.getName());
+    File extraIncludes = new File(request.getSession().getServletContext().getRealPath("includes") + File.separator + "custom-footer");
+    if (extraIncludes.exists()) {
+        for (File file : extraIncludes.listFiles()) {
+            if (file.isFile()) {
+                pageContext.setAttribute("file", "custom-footer/" + file.getName());
 %>
-<jsp:include page="${file}" />
+<jsp:include page="${file}"/>
 <%
-		  }
-	  }
-  }
+            }
+        }
+    }
 %>
 
 <%-- This </div> tag is unmatched in this file (its matching tag is in the
@@ -91,7 +103,7 @@
 <%= "</div>" %><!-- id="content" class="container-fluid" -->
 
 <%-- Allows services exposed via the OSGi registry to inject HTML content --%>
-<%= HtmlInjectHandler.inject( request ) %>
+<%= HtmlInjectHandler.inject(request) %>
 
 <%-- The </body> and </html> tags are unmatched in this file (the matching
      tags are in the header), so we hide them in JSP code fragments so the

--- a/opennms-webapp/src/main/webapp/includes/footer.jsp
+++ b/opennms-webapp/src/main/webapp/includes/footer.jsp
@@ -2,8 +2,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2002-2017 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
+ * Copyright (C) 2002-2018 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2018 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -54,53 +54,65 @@
 --%>
 
 <%@page language="java"
-	contentType="text/html"
-	session="true"
-	import="java.io.File"
+        contentType="text/html"
+        session="true"
+        import="java.io.File,
+                org.opennms.core.resource.Vault,
+                org.opennms.web.servlet.XssRequestWrapper"
 %>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 
-  <!-- End of Content -->
-  <div class="spacer"><!-- --></div>
+<%
+    XssRequestWrapper req = new XssRequestWrapper(request);
+%>
+
+<!-- End of Content -->
+<div class="spacer"><!-- --></div>
 <%-- This </div> tag is unmatched in this file (its matching tag is in the
      header), so we hide it in a JSP code fragment so the Eclipse HTML
      validator doesn't complain.  See bug #1728. --%>
 <%= "</div>" %><!-- id="content" -->
 
 <c:choose>
-  <c:when test="${param.quiet == 'true'}">
-    <!-- Not displaying footer -->
-  </c:when>
+    <c:when test="${param.quiet == 'true'}">
+        <!-- Not displaying footer -->
+    </c:when>
 
-  <c:otherwise>
-    <!-- Footer -->
+    <c:otherwise>
+        <!-- Footer -->
 
-    <div id="prefooter"></div>
+        <div id="prefooter"></div>
 
-    <div id="footer">
-      <p>
-        OpenNMS <a href="support/about.jsp">Copyright</a> &copy; 2002-2017
-	    <a href="http://www.opennms.com/">The OpenNMS Group, Inc.</a>
-	    OpenNMS&reg; is a registered trademark of
-        <a href="http://www.opennms.com">The OpenNMS Group, Inc.</a>
-	  </p>
-    </div>
-  </c:otherwise>
+        <div id="footer">
+            <p>
+                OpenNMS <a href="about/index.jsp">Copyright</a> &copy; 2002-2018
+                <a href="http://www.opennms.com/">The OpenNMS Group, Inc.</a>
+                OpenNMS&reg; is a registered trademark of
+                <a href="http://www.opennms.com">The OpenNMS Group, Inc.</a>
+                <%
+                    if (req.getUserPrincipal() != null) {
+                        out.print(" - Version: " + Vault.getProperty("version.display"));
+                    }
+                %>
+
+            </p>
+        </div>
+    </c:otherwise>
 </c:choose>
 
 <%
-  File extraIncludes = new File(request.getSession().getServletContext().getRealPath("includes") + File.separator + "custom-footer");
-  if (extraIncludes.exists()) {
-	  for (File file : extraIncludes.listFiles()) {
-		  if (file.isFile()) {
-			  pageContext.setAttribute("file", "custom-footer/" + file.getName());
+    File extraIncludes = new File(request.getSession().getServletContext().getRealPath("includes") + File.separator + "custom-footer");
+    if (extraIncludes.exists()) {
+        for (File file : extraIncludes.listFiles()) {
+            if (file.isFile()) {
+                pageContext.setAttribute("file", "custom-footer/" + file.getName());
 %>
-<jsp:include page="${file}" />
+<jsp:include page="${file}"/>
 <%
-		  }
-	  }
-  }
+            }
+        }
+    }
 %>
 <%-- The </body> and </html> tags are unmatched in this file (the matching
      tags are in the header), so we hide them in JSP code fragments so the

--- a/opennms-webapp/src/main/webapp/includes/help-contact.jsp
+++ b/opennms-webapp/src/main/webapp/includes/help-contact.jsp
@@ -1,0 +1,55 @@
+<%--
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2002-2018 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2018 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+--%>
+
+<div class="panel panel-default">
+    <div class="panel-heading">
+        <h3 class="panel-title">Get in Contact</h3>
+    </div>
+    <div class="panel-body">
+        <table class="table">
+            <tr>
+                <td style="border-top: none;"><a href="https://www.opennms.com/support/" target="_blank" class="btn btn-default" role="button" style="width: 100%">Commercial Support</a></td>
+                <td style="border-top: none;">Get commercial support for OpenNMS software provided by The OpenNMS Group, Inc.</td>
+            </tr>
+            <tr>
+                <td style="border-top: none;"><a href="https://chat.opennms.org/opennms" target="_blank" class="btn btn-default" role="button" style="width: 100%">Web Chat</a></td>
+                <td style="border-top: none;">Use the &quot;web-based&quot; chat platform powered by Mattermost. The Discussion channel is a good starting point to reach users and developers. If you prefer IRC, you can join the "#opennms" channel on irc.freenode.net which is bridged to our Web Chat.</td>
+            </tr>
+            <tr>
+                <td style="border-top: none;"><a href="https://wiki.opennms.org/wiki/Mailing_lists" target="_blank" class="btn btn-default" role="button" style="width: 100%">Mailing Lists</a></td>
+                <td style="border-top: none;">Get into contact with OpenNMS users in our community through our topic-driven mailing lists. The opennms-discuss mailing list is a good way to ask questions about getting started with OpenNMS.</td>
+            </tr>
+            <tr>
+                <td style="border-top: none;"><a href="https://stackoverflow.com/search?q=opennms" target="_blank" class="btn btn-default" role="button" style="width: 100%">Questions &amp; Answers</a></td>
+                <td style="border-top: none;">Questions and Answers around using and developing OpenNMS can also be found on StackOverflow.</td>
+            </tr>
+        </table>
+    </div>
+</div>

--- a/opennms-webapp/src/main/webapp/includes/help-documentation.jsp
+++ b/opennms-webapp/src/main/webapp/includes/help-documentation.jsp
@@ -1,0 +1,121 @@
+<%--
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2002-2018 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2018 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+--%>
+
+<script type="text/javascript">
+    // Shorthand for 'onload'
+    $(function () {
+        // Check to see if the URL provided by the opennms-docs package is present on the system.
+        // If so, display the links to the offline docs symlinked from /usr/share/doc/opennms-${version}.
+        $.ajax({
+            url: 'docs/guide-install/index.html',
+            method: 'HEAD',
+            error: function () {
+                $('#online-documentation').css("display", "inline-block");
+            },
+            success: function () {
+                $('#offline-documentation').css("display", "inline-block");
+            }
+        });
+    });
+</script>
+
+<div class="panel panel-default">
+    <div class="panel-heading">
+        <h3 class="panel-title">Documentation</h3>
+    </div>
+    <div class="panel-body">
+        <span id="online-documentation" style="display:none;">
+            <table class="table">
+                <tr>
+                    <td style="border-top: none;"><a
+                            href="https://docs.opennms.org/opennms/releases/latest/guide-install/guide-install.html"
+                            target="_blank" class="btn btn-default" role="button"
+                            style="width: 100%">Installation Guide</a></td>
+                    <td style="border-top: none;">OpenNMS can be installed several operating systems and can be deployed for several scenarios with different technologies. Have a look in the Installation Guide to find instructions to deploy and maintain your OpenNMS instance.</td>
+                </tr>
+                <tr>
+                    <td style="border-top: none;"><a
+                            href="https://docs.opennms.org/opennms/releases/latest/guide-user/guide-user.html"
+                            target="_blank" class="btn btn-default" role="button"
+                            style="width: 100%">Users Guide</a></td>
+                    <td style="border-top: none;">OpenNMS users tend to have a broad network monitoring skill set. This User Guide contains an overview of concepts and explains how to use OpenNMS for day-to-day monitoring.</td>
+                </tr>
+                <tr>
+                    <td style="border-top: none;"><a
+                            href="https://docs.opennms.org/opennms/releases/latest/guide-development/guide-development.html"
+                            target="_blank" class="btn btn-default" role="button"
+                            style="width: 100%">Developers Guide</a></td>
+                    <td style="border-top: none;">Developers can extend and improve the OpenNMS platform. The Developers Guide is a good starting point for extending OpenNMS and using the ReST APIs for integration.</td>
+                </tr>
+                <tr>
+                    <td style="border-top: none;"><a href="https://wiki.opennms.org" target="_blank"
+                                                     class="btn btn-default" role="button" style="width: 100%">OpenNMS Wiki</a></td>
+                    <td style="border-top: none;">With the large variety of devices and applications you can monitor with OpenNMS, the Wiki provides space to share experience with How Tos and Tutorials to address specific use cases.</td>
+                </tr>
+                <tr>
+                    <td style="border-top: none;"><a
+                            href="https://wiki.opennms.org/wiki/Community/Welcome_Guide" target="_blank"
+                            class="btn btn-default" role="button" style="width: 100%">Welcome Guide</a></td>
+                    <td style="border-top: none;">If you are new in the project, you can find useful information in your Welcome Guide to get anything you need to get started.</td>
+                </tr>
+            </table>
+        </span>
+        <span id="offline-documentation" style="display:none;">
+            <table class="table">
+                <tr>
+                    <td style="border-top: none;"><a href="docs/guide-install/index.html" target="_blank"
+                                                     class="btn btn-default" role="button" style="width: 100%">Installation Guide</a></td>
+                    <td style="border-top: none;">OpenNMS can be installed several operating systems and can be deployed for several scenarios with different technologies. Have a look in the Installation Guide to find instructions to deploy and maintain your OpenNMS instance.</td>
+                </tr>
+                <tr>
+                    <td style="border-top: none;"><a href="docs/guide-user/index.html" target="_blank"
+                                                     class="btn btn-default" role="button" style="width: 100%">Users Guide</a></td>
+                    <td style="border-top: none;">OpenNMS users tend to have a broad network monitoring skill set. This User Guide contains an overview of concepts and explains how to use OpenNMS for day-to-day monitoring.</td>
+                </tr>
+                <tr>
+                    <td style="border-top: none;"><a href="docs/guide-development/index.html" target="_blank"
+                                                     class="btn btn-default" role="button" style="width: 100%">Developers Guide</a></td>
+                    <td style="border-top: none;">Developers can extend and improve the OpenNMS platform. The Developers Guide is a good starting point for extending OpenNMS and using the ReST APIs for integration.</td>
+                </tr>
+                <tr>
+                    <td style="border-top: none;"><a href="https://wiki.opennms.org" target="_blank"
+                                                     class="btn btn-default" role="button" style="width: 100%">OpenNMS Wiki</a></td>
+                    <td style="border-top: none;">With the large variety of devices and applications you can monitor with OpenNMS, the Wiki provides space to share experience with How Tos and Tutorials to address specific use cases.</td>
+                </tr>
+                <tr>
+                    <td style="border-top: none;"><a
+                            href="https://wiki.opennms.org/wiki/Community/Welcome_Guide" target="_blank"
+                            class="btn btn-default" role="button" style="width: 100%">Welcome Guide</a></td>
+                    <td style="border-top: none;">If you are new in the project, you can find useful information in your Welcome Guide to get anything you need to get started.</td>
+                </tr>
+            </table>
+        </span>
+    </div>
+</div>

--- a/opennms-webapp/src/main/webapp/includes/help-documentation.jsp
+++ b/opennms-webapp/src/main/webapp/includes/help-documentation.jsp
@@ -1,4 +1,4 @@
-<%--
+<%@ page import="org.opennms.core.resource.Vault" %><%--
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
@@ -55,21 +55,21 @@
             <table class="table">
                 <tr>
                     <td style="border-top: none;"><a
-                            href="https://docs.opennms.org/opennms/releases/latest/guide-install/guide-install.html"
+                            href="https://docs.opennms.org/opennms/releases/<%=Vault.getProperty("version.display")%>/guide-install/guide-install.html"
                             target="_blank" class="btn btn-default" role="button"
                             style="width: 100%">Installation Guide</a></td>
                     <td style="border-top: none;">OpenNMS can be installed several operating systems and can be deployed for several scenarios with different technologies. Have a look in the Installation Guide to find instructions to deploy and maintain your OpenNMS instance.</td>
                 </tr>
                 <tr>
                     <td style="border-top: none;"><a
-                            href="https://docs.opennms.org/opennms/releases/latest/guide-user/guide-user.html"
+                            href="https://docs.opennms.org/opennms/releases/<%=Vault.getProperty("version.display")%>/guide-user/guide-user.html"
                             target="_blank" class="btn btn-default" role="button"
                             style="width: 100%">Users Guide</a></td>
                     <td style="border-top: none;">OpenNMS users tend to have a broad network monitoring skill set. This User Guide contains an overview of concepts and explains how to use OpenNMS for day-to-day monitoring.</td>
                 </tr>
                 <tr>
                     <td style="border-top: none;"><a
-                            href="https://docs.opennms.org/opennms/releases/latest/guide-development/guide-development.html"
+                            href="https://docs.opennms.org/opennms/releases/<%=Vault.getProperty("version.display")%>/guide-development/guide-development.html"
                             target="_blank" class="btn btn-default" role="button"
                             style="width: 100%">Developers Guide</a></td>
                     <td style="border-top: none;">Developers can extend and improve the OpenNMS platform. The Developers Guide is a good starting point for extending OpenNMS and using the ReST APIs for integration.</td>

--- a/opennms-webapp/src/main/webapp/includes/help-software-management.jsp
+++ b/opennms-webapp/src/main/webapp/includes/help-software-management.jsp
@@ -1,0 +1,52 @@
+<%--
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2002-2018 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2018 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+--%>
+
+<div class="panel panel-default">
+    <div class="panel-heading">
+        <h3 class="panel-title">Software Management</h3>
+    </div>
+    <div class="panel-body">
+        <table class="table">
+            <tr>
+                <td style="border-top: none;"><a href="https://github.com/OpenNMS/opennms" target="_blank" class="btn btn-default" role="button" style="width: 100%">OpenNMS on GitHub</a></td>
+                <td style="border-top: none;">Our source code is version controlled with git and hosted on GitHub. Download the source code for released versions of OpenNMS or the latest development code.</td>
+            </tr>
+            <tr>
+                <td style="border-top: none;"><a href="https://issues.opennms.org" target="_blank" class="btn btn-default" role="button" style="width: 100%">Issue Tracker</a></td>
+                <td style="border-top: none;">The software project is managed with JIRA. We use it to manage bugs, enhancements, feature and release management. Create your free account and you are welcome to participate.</td>
+            </tr>
+            <tr>
+                <td style="border-top: none;"><a href="https://bamboo.opennms.org/browse/OPENNMS-ONMS" target="_blank" class="btn btn-default" role="button" style="width: 100%">Continuous Integration</a></td>
+                <td style="border-top: none;">Running OpenNMS in production requires software quality gates which are provided by bamboo our public CI/CD system.</td>
+            </tr>
+
+        </table>
+    </div>
+</div>

--- a/opennms-webapp/src/main/webapp/includes/support-system-diagnostics.jsp
+++ b/opennms-webapp/src/main/webapp/includes/support-system-diagnostics.jsp
@@ -1,0 +1,51 @@
+<%--
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2002-2018 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2018 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+--%>
+
+<div class="panel panel-default">
+    <div class="panel-heading">
+        <h3 class="panel-title">System Diagnostics</h3>
+    </div>
+    <div class="panel-body">
+        <table class="table">
+            <tr>
+                <td style="border-top: none;"><a href="admin/support/systemReport.htm" class="btn btn-default" role="button" style="width: 100%">Generate System Report</a></td>
+                <td style="border-top: none;">Generate &quot;support-friendly&quot; information about your OpenNMS instance and system environment.</td>
+            </tr>
+            <tr>
+                <td style="border-top: none;"><a href="admin/nodemanagement/instrumentationLogReader.jsp" class="btn btn-default" role="button" style="width: 100%">Collectd Statistics</a></td>
+                <td style="border-top: none;">Get detailed statistics about your configured performance data collection.</td>
+            </tr>
+            <tr>
+                <td style="border-top: none;"><a href="about/index.jsp" class="btn btn-default" role="button" style="width: 100%">About OpenNMS</a></td>
+                <td style="border-top: none;">Get an overview about your running OpenNMS instance such as Java Version, Operating System, PostgreSQL version and Time Series Strategy.</td>
+            </tr>
+        </table>
+    </div>
+</div>

--- a/smoke-test/src/test/java/org/opennms/smoketest/AboutPageIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/AboutPageIT.java
@@ -1,8 +1,7 @@
-<%--
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2010-2018 The OpenNMS Group, Inc.
+ * Copyright (C) 2011-2018 The OpenNMS Group, Inc.
  * OpenNMS(R) is Copyright (C) 1999-2018 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
@@ -27,29 +26,31 @@
  *     http://www.opennms.com/
  *******************************************************************************/
 
---%>
+package org.opennms.smoketest;
 
-<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
 
-<%@page language="java"
-        contentType="text/html"
-        session="true"
-%>
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
-<jsp:include page="/includes/bootstrap.jsp" flush="false">
-    <jsp:param name="title" value="Help"/>
-    <jsp:param name="headTitle" value="Help"/>
-    <jsp:param name="breadcrumb" value="Help"/>
-</jsp:include>
+public class AboutPageIT extends OpenNMSSeleniumTestCase {
 
-<div class="col-md-4">
-    <jsp:include page="/includes/help-documentation.jsp" flush="false" />
-</div>
-<div class="col-md-4">
-    <jsp:include page="/includes/help-contact.jsp" flush="false" />
-</div>
-<div class="col-md-4">
-    <jsp:include page="/includes/help-software-management.jsp" flush="false" />
-</div>
+    @Before
+    public void setUp() throws Exception {
+        m_driver.get(getBaseUrl() + "opennms/about/index.jsp");
+    }
 
-<jsp:include page="/includes/bootstrap-footer.jsp" flush="false"/>
+    @Test
+    public void hasAllPanels() throws Exception {
+        assertEquals(4, countElementsMatchingCss("h3.panel-title"));
+    }
+
+    @Test
+    public void hasContent() throws Exception {
+        assertNotNull(m_driver.findElement(By.xpath("//h3[text()='License and Copyright']")));
+        assertNotNull(m_driver.findElement(By.xpath("//th[text()='Version:']")));
+    }
+}

--- a/smoke-test/src/test/java/org/opennms/smoketest/FooterIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/FooterIT.java
@@ -1,9 +1,8 @@
-<%--
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2002-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2011-2018 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2018 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -27,10 +26,31 @@
  *     http://www.opennms.com/
  *******************************************************************************/
 
---%>
+package org.opennms.smoketest;
 
-<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
-<%@page language="java" contentType="text/html" session="true"  %>
+import org.junit.Before;
+import org.junit.Test;
 
-<c:redirect url="/support/about.jsp" />
+public class FooterIT extends OpenNMSSeleniumTestCase {
+
+    @Before
+    public void setUp() throws Exception {
+        m_driver.get(getBaseUrl() + "opennms/login.jsp");
+    }
+
+    @Test
+    public void verifyDisplayVersionForLoggedInUser() throws Exception {
+        assertNotNull(findElementByXpath("//*[@id=\"footer\"]/p"));
+        assertNotNull(findElementByXpath("//*[@id=\"footer\"]/p[contains(.,'Version')]"));
+    }
+
+    @Test
+    public void verifyDoNotDisplayVersionForAnonymous() throws Exception {
+        final String adminMenuName = "name=nav-admin-top";
+        clickMenuItem(adminMenuName, "Log Out", "j_spring_security_logout");
+        assertNotNull(findElementByXpath("//*[@id=\"footer\"]/p[not(contains(.,'Version'))]"));
+    }
+}

--- a/smoke-test/src/test/java/org/opennms/smoketest/HelpPageIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/HelpPageIT.java
@@ -1,0 +1,73 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2011-2018 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2018 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.smoketest;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.By;
+
+public class HelpPageIT extends OpenNMSSeleniumTestCase {
+
+    @Before
+    public void setUp() throws Exception {
+        m_driver.get(getBaseUrl() + "opennms/help/index.jsp");
+    }
+
+    @Test
+    public void verifyAllButtonsPresent() throws Exception {
+        final String[] links = new String[] {
+                // Online Links
+                "Installation Guide",
+                "Users Guide",
+                "Developers Guide",
+                "OpenNMS Wiki",
+                "Welcome Guide",
+                // Offline Links
+                "Installation Guide",
+                "Users Guide",
+                "Developers Guide",
+                "OpenNMS Wiki",
+                "Welcome Guide",
+                "Commercial Support",
+                "Web Chat",
+                "Mailing Lists",
+                "Questions & Answers",
+                "OpenNMS on GitHub",
+                "Issue Tracker",
+                "Continuous Integration"
+        };
+        assertEquals(links.length, countElementsMatchingCss("a.btn"));
+        for (final String text : links) {
+            assertNotNull("Link with text '" + text + "' must exist.", m_driver.findElement(By.linkText(text)));
+        }
+    }
+}

--- a/smoke-test/src/test/java/org/opennms/smoketest/MenuHeaderIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/MenuHeaderIT.java
@@ -1,8 +1,8 @@
-/*******************************************************************************
+ /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2013-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2013-2018 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2018 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -126,8 +126,12 @@ public class MenuHeaderIT extends OpenNMSSeleniumTestCase {
         findElementByXpath("//h3[text()='Distributed Monitoring']");
 
         frontPage();
-        clickMenuItem(adminMenuName, "Help/Support", "opennms/support/index.htm");
+        clickMenuItem(adminMenuName, "Help", "opennms/help/index.jsp");
+        findElementByXpath("//h3[text()='Documentation']");
+        clickMenuItem(adminMenuName, "Support", "opennms/support/index.htm");
         findElementByXpath("//h3[text()='Commercial Support']");
+        clickMenuItem(adminMenuName, "About", "opennms/about/index.jsp");
+        findElementByXpath("//h3[text()='Version Details']");
 
         frontPage();
         clickMenuItem(adminMenuName, "Log Out", "opennms/j_spring_security_logout");

--- a/smoke-test/src/test/java/org/opennms/smoketest/SupportPageIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/SupportPageIT.java
@@ -28,10 +28,10 @@
 
 package org.opennms.smoketest;
 
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertThat;
 
 import org.junit.Before;
 import org.junit.FixMethodOrder;
@@ -48,28 +48,16 @@ public class SupportPageIT extends OpenNMSSeleniumTestCase {
     }
 
     @Test
-    public void testAllLinksArePresent() throws Exception {
-        Thread.sleep(4000);
-        assertEquals(4, countElementsMatchingCss("h3.panel-title"));
+    public void testAllButtonsArePresent() throws Exception {
         final String[] links = new String[] {
                 "the OpenNMS.com support page",
-                "About the OpenNMS Web Console",
-                "Release Notes",
-                // Online docs links
-                "Installation Guide",
-                "Users Guide",
-                "Administrators Guide",
-                "Developers Guide",
-                "Online Wiki Documentation",
-                // Offline docs links
-                "Installation Guide",
-                "Users Guide",
-                "Administrators Guide",
-                "Developers Guide",
-                "Online Wiki Documentation",
-                "Generate a System Report",
-                "Open a Bug or Enhancement Request",
-                "Chat with Developers on IRC"
+                "Generate System Report",
+                "Collectd Statistics",
+                "About OpenNMS",
+                "Commercial Support",
+                "Web Chat",
+                "Mailing Lists",
+                "Questions & Answers"
         };
         assertEquals(links.length, countElementsMatchingCss("div.panel-body a"));
         for (final String text : links) {
@@ -78,34 +66,22 @@ public class SupportPageIT extends OpenNMSSeleniumTestCase {
     }
 
     @Test
-    public void testAllFormsArePresent() throws InterruptedException {
+    public void testAllFormsArePresent() {
         final WebElement form = m_driver.findElement(By.cssSelector("form[action='support/index.htm']"));
-        assertNotNull(form);
         assertNotNull(form.findElement(By.cssSelector("input[type=text][name=username]")));
         assertNotNull(form.findElement(By.cssSelector("input[type=password][name=password]")));
     }
 
     @Test
-    public void testAboutPage() throws Exception {
-        final WebElement about = m_driver.findElement(By.linkText("About the OpenNMS Web Console"));
-        assertNotNull(about);
-        about.click();
-        assertNotNull(m_driver.findElement(By.xpath("//h3[text()='License and Copyright']")));
-        assertNotNull(m_driver.findElement(By.xpath("//th[text()='Version:']")));
-    }
-    
-    @Test
-    public void testSystemReport() throws Exception {
-        final WebElement generate = m_driver.findElement(By.linkText("Generate a System Report"));
-        assertNotNull(generate);
-        generate.click();
+    public void testSystemReport() {
+        m_driver.findElement(By.linkText("Generate System Report")).click();
+
         // checkboxes are selected by default
         final WebElement allCheckbox = m_driver.findElement(By.cssSelector("input[type=checkbox][name=all]"));
-        assertNotNull(allCheckbox);
-        assertTrue(m_driver.findElement(By.cssSelector("input[type=checkbox][name=plugins][value=Java]")).isSelected());
+        assertThat(m_driver.findElement(By.cssSelector("input[type=checkbox][name=plugins][value=Java]")).isSelected(), is(true));
+
         // deselect the "all" checkbox
         allCheckbox.click();
-        assertFalse(m_driver.findElement(By.cssSelector("input[type=checkbox][name=plugins][value=Java]")).isSelected());
+        assertThat(m_driver.findElement(By.cssSelector("input[type=checkbox][name=plugins][value=Java]")).isSelected(), is(false));
     }
-
 }


### PR DESCRIPTION
The support page contains the web form which is used by OpenNMS administrators to open commercial support tickets. The account. This page is now restricted to Admin users. Introduced a Help page which gives information where to find documentation and to get in contact with people. To give users a better visibility what version of OpenNMS is running, the version number is added to the footer page. To make it easier getting version information about the running Open "About" page in the user's menu is added. The web site components are refactored to be reusable as JSP includes.

JIRA: https://issues.opennms.org/browse/NMS-9771