### PR TITLE
Fix Eclipse compiler version errors

### DIFF
--- a/checkstyle/pom.xml
+++ b/checkstyle/pom.xml
@@ -5,4 +5,15 @@
   <artifactId>org.opennms.checkstyle</artifactId>
   <version>22.0.0-SNAPSHOT</version>
   <name>OpenNMS :: Checkstyle</name>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>1.8</source>
+          <target>1.8</target>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/features/measurements/api/pom.xml
+++ b/features/measurements/api/pom.xml
@@ -11,15 +11,23 @@
   <packaging>bundle</packaging>
   <name>OpenNMS :: Features :: Measurements :: API</name>
   <build>
-    <!-- We need to be JDK 6 compliant, because we rely on an old jasper-reports version -->
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <!-- To load the jar file into jaspersoft studio it is required to be Java 6 compatible -->
-          <source>1.7</source>
-          <target>1.7</target>
-        </configuration>
+        <executions>
+          <execution>
+            <id>default-compile</id>
+            <phase>compile</phase>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+            <configuration>
+              <!-- To load the jar file into jaspersoft studio it is required to be Java 1.7 compatible -->
+              <source>1.7</source>
+              <target>1.7</target>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.felix</groupId>


### PR DESCRIPTION
I've been getting annoying Eclipse errors wrt source levels; this PR fixes the problems and continues to ensure that our Jasper plugin is JDK7 compatible.