### PR TITLE
NMS-9766: Limit the number of threads that can be used to send notifications

### DIFF
--- a/opennms-config-model/src/main/java/org/opennms/netmgt/config/notifd/NotifdConfiguration.java
+++ b/opennms-config-model/src/main/java/org/opennms/netmgt/config/notifd/NotifdConfiguration.java
@@ -51,7 +51,7 @@ import org.opennms.netmgt.config.utils.ConfigUtils;
 @XmlAccessorType(XmlAccessType.FIELD)
 @ValidateUsing("notifd-configuration.xsd")
 public class NotifdConfiguration implements Serializable {
-    private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 2L;
 
     private static final String DEFAULT_PAGES_SENT = "SELECT * FROM notifications";
     private static final String DEFAULT_NEXT_NOTIFID = "SELECT nextval('notifynxtid')";
@@ -62,6 +62,7 @@ public class NotifdConfiguration implements Serializable {
     private static final String DEFAULT_ACKNOWLEDGEID_SQL = "SELECT notifyid FROM notifications WHERE eventuei=? AND nodeid=? AND interfaceid=? AND serviceid=?";
     private static final String DEFAULT_ACKNOWLEDGE_UPDATE_SQL = "UPDATE notifications SET answeredby=?, respondtime=? WHERE notifyId=?";
     private static final String DEFAULT_EMAIL_ADDRESS_COMMAND = "javaEmail";
+    private static final Integer DEFAULT_MAX_THREADS = 100;
 
     @XmlAttribute(name = "status", required = true)
     private String m_status;
@@ -98,6 +99,9 @@ public class NotifdConfiguration implements Serializable {
 
     @XmlAttribute(name = "numeric-skip-resolution-prefix")
     private Boolean m_numericSkipResolutionPrefix;
+
+    @XmlAttribute(name = "max-threads")
+    private Integer m_maxThreads;
 
     @XmlElement(name = "auto-acknowledge-alarm")
     private AutoAcknowledgeAlarm m_autoAcknowledgeAlarm;
@@ -209,6 +213,14 @@ public class NotifdConfiguration implements Serializable {
         m_numericSkipResolutionPrefix = prefix;
     }
 
+    public Integer getMaxThreads() {
+        return m_maxThreads != null ? m_maxThreads : DEFAULT_MAX_THREADS;
+    }
+
+    public void setMaxThreads(Integer maxThreads) {
+        m_maxThreads = maxThreads;
+    }
+
     public Optional<AutoAcknowledgeAlarm> getAutoAcknowledgeAlarm() {
         return Optional.ofNullable(m_autoAcknowledgeAlarm);
     }
@@ -275,7 +287,8 @@ public class NotifdConfiguration implements Serializable {
                             m_acknowledgeUpdateSql, 
                             m_matchAll, 
                             m_emailAddressCommand, 
-                            m_numericSkipResolutionPrefix, 
+                            m_numericSkipResolutionPrefix,
+                            m_maxThreads,
                             m_autoAcknowledgeAlarm, 
                             m_autoAcknowledges, 
                             m_queues, 
@@ -302,6 +315,7 @@ public class NotifdConfiguration implements Serializable {
                     && Objects.equals(this.m_matchAll, that.m_matchAll)
                     && Objects.equals(this.m_emailAddressCommand, that.m_emailAddressCommand)
                     && Objects.equals(this.m_numericSkipResolutionPrefix, that.m_numericSkipResolutionPrefix)
+                    && Objects.equals(this.m_maxThreads, that.m_maxThreads)
                     && Objects.equals(this.m_autoAcknowledgeAlarm, that.m_autoAcknowledgeAlarm)
                     && Objects.equals(this.m_autoAcknowledges, that.m_autoAcknowledges)
                     && Objects.equals(this.m_queues, that.m_queues)

--- a/opennms-config-model/src/main/resources/xsds/notifd-configuration.xsd
+++ b/opennms-config-model/src/main/resources/xsds/notifd-configuration.xsd
@@ -54,7 +54,9 @@
       
       <attribute name="email-address-command" type="string" use="optional" default="javaEmail"/>
 
-		<attribute name="numeric-skip-resolution-prefix" type="boolean" use="optional" default="false"/>
+      <attribute name="numeric-skip-resolution-prefix" type="boolean" use="optional" default="false"/>
+
+      <attribute name="max-threads" type="nonNegativeInteger" use="optional" default="100"/>
     </complexType>
   </element>
 

--- a/opennms-services/pom.xml
+++ b/opennms-services/pom.xml
@@ -338,8 +338,14 @@
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
+      <artifactId>mockito-core</artifactId>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.hamcrest</groupId>
+          <artifactId>hamcrest-core</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.opennms.features.measurements</groupId>
@@ -377,6 +383,16 @@
       <groupId>org.opennms.core.ipc.rpc</groupId>
       <artifactId>org.opennms.core.ipc.rpc.camel-impl</artifactId>
       <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.jayway.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-library</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/opennms-services/src/test/java/org/opennms/netmgt/notifd/NotificationThreadsIT.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/notifd/NotificationThreadsIT.java
@@ -1,0 +1,104 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2017 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.notifd;
+
+import static com.jayway.awaitility.Awaitility.await;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.opennms.netmgt.mock.MockNode;
+import org.opennms.netmgt.model.events.EventBuilder;
+import org.opennms.test.ThreadLocker;
+
+public class NotificationThreadsIT extends NotificationsITCase  {
+
+    @Before
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+    }
+
+    @After
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+    }
+
+    /**
+     * NMS-9766: Verifies that the number of threads used to concurrently execute
+     * the notification strategies does not exceed the "max-threads" configuration.
+     */
+    @Test
+    public void canLimitThreads() throws Exception {
+        // Verify the thread limit N
+        final int N = m_notifdConfig.getConfiguration().getMaxThreads();
+        assertTrue( N + " should be some positive value < max int.",
+                0 < N && N < Integer.MAX_VALUE);
+
+        // Setup the locker
+        final ThreadLocker threadLocker = ThreadLockingNotificationStrategy.getThreadLocker();
+        final CompletableFuture<Integer> future = ThreadLockingNotificationStrategy.getThreadLocker().waitForThreads(N);
+
+        // Trigger M notifications where M = 2 * N
+        final int M = 2 * N;
+        for (int i = 0; i < M; i++) {
+            MockNode node = m_network.getNode(1);
+            EventBuilder eb = new EventBuilder("uei.opennms.org/test/notificationConcurrencyTest", "test");
+            eb.setNodeid(node.getNodeId());
+            m_eventMgr.sendEventToListeners(eb.getEvent());
+        }
+
+        // Wait until N threads a locked
+        future.get(1, TimeUnit.MINUTES);
+
+        // Wait a little longer and verify that no extra threads are waiting
+        // This validates that no more than N threads are currently invoking
+        // the notification strategy
+        Thread.sleep(TimeUnit.SECONDS.toMillis(1));
+        assertEquals(0, threadLocker.getNumExtraThreadsWaiting());
+
+        // Release the gate
+        threadLocker.release();
+
+        // Wait until all M notifications have been executed
+        // This validates that all of the M notifications end up
+        // being invoked
+        Thread.sleep(TimeUnit.SECONDS.toMillis(5));
+        await().atMost(5, TimeUnit.SECONDS)
+                .until(ThreadLockingNotificationStrategy::getNotificationsSent, equalTo((long)M));
+    }
+
+}

--- a/opennms-services/src/test/java/org/opennms/netmgt/notifd/ThreadLockingNotificationStrategy.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/notifd/ThreadLockingNotificationStrategy.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2017 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.notifd;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.opennms.netmgt.model.notifd.Argument;
+import org.opennms.netmgt.model.notifd.NotificationStrategy;
+import org.opennms.test.ThreadLocker;
+
+public class ThreadLockingNotificationStrategy implements NotificationStrategy {
+
+    private static final ThreadLocker threadLocker = new ThreadLocker();
+    private static final AtomicLong notificationsSent = new AtomicLong();
+
+    @Override
+    public int send(List<Argument> arguments) {
+        threadLocker.park();
+        notificationsSent.incrementAndGet();
+        return 0;
+    }
+
+    public static ThreadLocker getThreadLocker() {
+        return threadLocker;
+    }
+
+    public static long getNotificationsSent() {
+        return notificationsSent.get();
+    }
+}

--- a/opennms-services/src/test/java/org/opennms/netmgt/poller/pollables/PollableServiceConfigTest.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/poller/pollables/PollableServiceConfigTest.java
@@ -28,10 +28,10 @@
 
 package org.opennms.netmgt.poller.pollables;
 
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;

--- a/opennms-services/src/test/resources/org/opennms/netmgt/notifd/destination-paths.xml
+++ b/opennms-services/src/test/resources/org/opennms/netmgt/notifd/destination-paths.xml
@@ -47,4 +47,10 @@
             <command>mockNotifier</command>
         </target>
     </path>
+    <path name="LockThread" initial-delay="0s">
+        <target>
+            <name>SingleUserGroup</name>
+            <command>threadLockingNotifier</command>
+        </target>
+    </path>
 </destinationPaths>

--- a/opennms-services/src/test/resources/org/opennms/netmgt/notifd/groups.xml
+++ b/opennms-services/src/test/resources/org/opennms/netmgt/notifd/groups.xml
@@ -27,6 +27,11 @@
             <comments>The group things escalate to</comments>
             <user>brozow</user>           <duty-schedule>MoTuWeThFrSaSu800-2300</duty-schedule>
         </group>
+        <group>
+            <name>SingleUserGroup</name>
+            <comments>A group with a single user</comments>
+            <user>brozow</user>
+        </group>
     </groups>
     <roles>
       <role name="oncall" supervisor="admin" description="oncall role" membership-group="All">           <schedule name="brozow" type="weekly">               <time day="sunday" begins="09:00:00" ends="17:00:00"/>

--- a/opennms-services/src/test/resources/org/opennms/netmgt/notifd/notification-commands.xml
+++ b/opennms-services/src/test/resources/org/opennms/netmgt/notifd/notification-commands.xml
@@ -51,4 +51,20 @@
             <switch>-tm</switch>
         </argument>
     </command>
+    <command binary="false">
+        <name>threadLockingNotifier</name>
+        <execute>org.opennms.netmgt.notifd.ThreadLockingNotificationStrategy</execute>
+        <comment>Mock class for testing notification concurrency</comment>
+        <argument streamed="false">
+            <switch>-subject</switch>
+        </argument>
+        <argument streamed="false">
+            <switch>-email</switch>
+        </argument>
+        <argument streamed="false">
+            <switch>-tm</switch>
+        </argument>
+    </command>
+
+
 </notification-commands>

--- a/opennms-services/src/test/resources/org/opennms/netmgt/notifd/notifications.xml
+++ b/opennms-services/src/test/resources/org/opennms/netmgt/notifd/notifications.xml
@@ -124,4 +124,12 @@
         <text-message>Notification '%noticeid%'</text-message>
         <subject>notification '%noticeid%'</subject>
     </notification>
+    <notification name="notification concurrency test" status="on">
+        <uei>uei.opennms.org/test/notificationConcurrencyTest</uei>
+        <description>Test for notification concurrency</description>
+        <rule>IPADDR IPLIKE *.*.*.*</rule>
+        <destinationPath>LockThread</destinationPath>
+        <text-message>Notification '%noticeid%'</text-message>
+        <subject>notification '%noticeid%'</subject>
+    </notification>
 </notifications>

--- a/pom.xml
+++ b/pom.xml
@@ -1303,6 +1303,7 @@
     <minaVersion>2.0.16</minaVersion>
     <mapstructVersion>1.2.0.CR1</mapstructVersion>
     <minionKarafVersion>4.0.5</minionKarafVersion>
+    <mockitoVersion>1.10.19</mockitoVersion>
     <newtsVersion>1.4.3</newtsVersion>
     <paxExamVersion>4.8.0</paxExamVersion>
     <paxSwissboxVersion>1.8.2</paxSwissboxVersion>
@@ -3576,7 +3577,13 @@
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-all</artifactId>
-        <version>1.10.19</version>
+	<version>${mockitoVersion}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-core</artifactId>
+	<version>${mockitoVersion}</version>
         <scope>test</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
JIRA: https://issues.opennms.org/browse/NMS-9766

Here we introduce a thread pool in notifd that is used to invoke the notification tasks, and use this pool to limit the number of threads that are active at any given time. Additional notifications tasks that a waiting for threads will be kept in an unbounded queue.

By default we limit the number of threads to 100, and allow it to be configured via the notifid-configuration.xml.
