### PR TITLE
NMS-9802: There is no section which explain the Alarm life cycle

### DIFF
--- a/opennms-doc/guide-admin/src/asciidoc/text/events/events.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/events/events.adoc
@@ -33,7 +33,6 @@ Operator Instruction::
     A set of instructions for an operator to respond appropriately to an event of this type.
 Alarm Data::
     If this field is provided for an event, {opennms-product-name} will create, update, or clear *alarms* for events of that type according to the alarm-data specifics.
-    For more about alarms and how they relate to events, see <<alarms-introduction>>.
 
 [[ga-events-sources-of-events]]
 === Sources of Events


### PR DESCRIPTION
The Alarm workflow was started to be documented in [NMS-8032](https://github.com/OpenNMS/opennms/blob/NMS-8032/opennms-doc/guide-user/src/asciidoc/text/alarms/introduction.adoc) but was never merged and is unfinished. Removed dead link.

* JIRA: http://issues.opennms.org/browse/NMS-9802