### PR TITLE
Fix SyslogMessageTest after year wrap

### DIFF
--- a/features/events/syslog/src/test/java/org/opennms/netmgt/syslogd/SyslogMessageTest.java
+++ b/features/events/syslog/src/test/java/org/opennms/netmgt/syslogd/SyslogMessageTest.java
@@ -164,6 +164,7 @@ public class SyslogMessageTest {
             final SyslogMessage message = parser.parse();
             LOG.debug("message = {}", message);
             final Calendar cal = Calendar.getInstance();
+            cal.set(Calendar.YEAR, ZonedDateTimeBuilder.getBestYearForMonth(Calendar.MARCH));
             cal.set(Calendar.MONTH, Calendar.MARCH);
             cal.set(Calendar.DAY_OF_MONTH, 14);
             cal.set(Calendar.HOUR_OF_DAY, 17);


### PR DESCRIPTION
Oops, my smart year parsing inside Syslogd was too smart for one of the unit tests which still assumed that a `March` timestamp must be `March, ${currentYear}`.