### PR TITLE
NMS-9789: add diskIO util metrics and graphs

### DIFF
--- a/opennms-base-assembly/src/main/filtered/etc/datacollection/netsnmp.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/datacollection/netsnmp.xml
@@ -121,6 +121,12 @@
         <mibObj oid=".1.3.6.1.4.1.2021.13.15.1.1.5" instance="diskIOIndex" alias="diskIOReads"    type="counter" />
         <mibObj oid=".1.3.6.1.4.1.2021.13.15.1.1.6" instance="diskIOIndex" alias="diskIOWrites"   type="counter" />
       </group>
+	
+      <group name="ucd-diskio-util" ifType="all">
+        <mibObj oid=".1.3.6.1.4.1.2021.13.15.1.1.9"  instance="diskIOIndex" alias="diskIOLA1"      type="integer" />
+        <mibObj oid=".1.3.6.1.4.1.2021.13.15.1.1.10" instance="diskIOIndex" alias="diskIOLA5"      type="integer" />
+        <mibObj oid=".1.3.6.1.4.1.2021.13.15.1.1.11" instance="diskIOIndex" alias="diskIOLA15"     type="integer" />
+      </group>
 
       <!-- lmsensors MIBs -->
       <group name="lmsensors-temp" ifType="all">

--- a/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/netsnmp-graph.properties
+++ b/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/netsnmp-graph.properties
@@ -24,6 +24,7 @@ netsnmp.cpuUsageFull, \
 netsnmp.cpuStats, \
 netsnmp.cpuStatsFull, \
 netsnmp.diskio.bytes, \
+netsnmp.diskio.la, \
 netsnmp.diskio.ops, \
 netsnmp.diskio.opsize
 
@@ -320,6 +321,26 @@ report.netsnmp.diskio.bytes.command=--title="Disk IO Bytes" \
  GPRINT:nwritten:AVERAGE:"Avg \\: %10.2lf %s" \
  GPRINT:nwritten:MIN:"Min \\: %10.2lf %s" \
  GPRINT:nwritten:MAX:"Max \\: %10.2lf %s\\n"
+ 
+report.netsnmp.diskio.la.name=Disk IO Load Avarage
+report.netsnmp.diskio.la.columns=diskIOLA1,diskIOLA5,diskIOLA15
+report.netsnmp.diskio.la.type=diskIOIndex
+report.netsnmp.diskio.la.command=--title="Disk IO Load Avarage" \
+ DEF:avg1={rrd1}:diskIOLA1:AVERAGE \
+ DEF:avg5={rrd2}:diskIOLA5:AVERAGE \
+ DEF:avg15={rrd3}:diskIOLA15:AVERAGE \
+ AREA:avg1#babdb6:"1  minute" \
+ GPRINT:avg1:AVERAGE:"Avg \\: %10.2lf" \
+ GPRINT:avg1:MIN:"Min \\: %10.2lf" \
+ GPRINT:avg1:MAX:"Max \\: %10.2lf\\n" \
+ AREA:avg5#888a85:"5  minute" \
+ GPRINT:avg5:AVERAGE:"Avg \\: %10.2lf" \
+ GPRINT:avg5:MIN:"Min \\: %10.2lf" \
+ GPRINT:avg5:MAX:"Max \\: %10.2lf\\n" \
+ LINE2:avg15#a40000:"15 minute" \
+ GPRINT:avg15:AVERAGE:"Avg \\: %10.2lf" \
+ GPRINT:avg15:MIN:"Min \\: %10.2lf" \
+ GPRINT:avg15:MAX:"Max \\: %10.2lf\\n" \
 
 report.netsnmp.diskio.ops.name=Disk IO Operations
 report.netsnmp.diskio.ops.columns=diskIOReads,diskIOWrites


### PR DESCRIPTION
* JIRA: https://issues.opennms.org/browse/NMS-9789

I added the disk IO utilization metrics and graphs because they were missing and really useful and netsnmp provides it per default.
Also I didn't include this definition because the existing disk IO stats are also inactive in default setting.
The graphs are copied from CPU LOAD so they have the same look. Is that ok?

Hopefully you can still merge it manually...