### PR TITLE
NMS-9816: Add Disk IO monitoring capabilities with Net-SNMP

### DIFF
--- a/opennms-base-assembly/src/main/filtered/etc/datacollection/netsnmp.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/datacollection/netsnmp.xml
@@ -1,219 +1,223 @@
 <datacollection-group xmlns="http://xmlns.opennms.org/xsd/config/datacollection" name="Net-SNMP">
-   <resourceType name="diskIOIndex" label="Disk IO (UCD-SNMP MIB)" resourceLabel="${diskIODevice} (index ${index})">
-      <persistenceSelectorStrategy class="org.opennms.netmgt.collectd.PersistRegexSelectorStrategy">
-         <parameter key="match-expression" value="not(#diskIODevice matches '^(loop|ram).*')"/>
-      </persistenceSelectorStrategy>
-      <storageStrategy class="org.opennms.netmgt.dao.support.SiblingColumnStorageStrategy">
-         <parameter key="sibling-column-name" value="diskIODevice"/>
-         <parameter key="replace-all" value="s/^-//"/>
-         <parameter key="replace-all" value="s/\s//"/>
-         <parameter key="replace-all" value="s/:\\.*//"/>
-      </storageStrategy>
-   </resourceType>
-   <resourceType name="dskIndex" label="Disk Table Index (UCD-SNMP MIB)" resourceLabel="${ns-dskPath} (index ${index})">
-      <persistenceSelectorStrategy class="org.opennms.netmgt.collection.support.PersistAllSelectorStrategy"/>
-      <storageStrategy class="org.opennms.netmgt.dao.support.SiblingColumnStorageStrategy">
-         <parameter key="sibling-column-name" value="ns-dskPath"/>
-         <parameter key="replace-first" value="s/^-$/_root_fs/"/>
-         <parameter key="replace-all" value="s/^-//"/>
-         <parameter key="replace-all" value="s/\s//"/>
-         <parameter key="replace-all" value="s/:\\.*//"/>
-      </storageStrategy>
-   </resourceType>
-   <resourceType name="lmTempIndex" label="Hardware Sensors: Temperature (lmSensors MIB)" resourceLabel="${lms-tempdevice} (index ${index})">
-      <persistenceSelectorStrategy class="org.opennms.netmgt.collection.support.PersistAllSelectorStrategy"/>
-      <storageStrategy class="org.opennms.netmgt.collection.support.IndexStorageStrategy"/>
-   </resourceType>
-   <resourceType name="lmFanIndex" label="Hardware Sensors: Fan (lmSensors MIB)" resourceLabel="${lms-fandevice} (index ${index})">
-      <persistenceSelectorStrategy class="org.opennms.netmgt.collection.support.PersistAllSelectorStrategy"/>
-      <storageStrategy class="org.opennms.netmgt.collection.support.IndexStorageStrategy"/>
-   </resourceType>
-   <resourceType name="lmVoltIndex" label="Hardware Sensors: Voltage (lmSensors MIB)" resourceLabel="${lms-voltdevice} (index ${index})">
-      <persistenceSelectorStrategy class="org.opennms.netmgt.collection.support.PersistAllSelectorStrategy"/>
-      <storageStrategy class="org.opennms.netmgt.collection.support.IndexStorageStrategy"/>
-   </resourceType>
-   <group name="net-snmp-disk" ifType="all">
-      <mibObj oid=".1.3.6.1.4.1.2021.9.1.2" instance="dskIndex" alias="ns-dskPath" type="string"/>
-      <mibObj oid=".1.3.6.1.4.1.2021.9.1.6" instance="dskIndex" alias="ns-dskTotal" type="gauge"/>
-      <mibObj oid=".1.3.6.1.4.1.2021.9.1.7" instance="dskIndex" alias="ns-dskAvail" type="gauge"/>
-      <mibObj oid=".1.3.6.1.4.1.2021.9.1.8" instance="dskIndex" alias="ns-dskUsed" type="gauge"/>
-      <mibObj oid=".1.3.6.1.4.1.2021.9.1.9" instance="dskIndex" alias="ns-dskPercent" type="gauge"/>
-   </group>
-   <group name="net-snmp-disk-more" ifType="all">
-      <mibObj oid=".1.3.6.1.4.1.2021.9.1.3" instance="dskIndex" alias="ns-dskDevice" type="string"/>
-      <mibObj oid=".1.3.6.1.4.1.2021.9.1.10" instance="dskIndex" alias="ns-dskPercentNode" type="gauge"/>
-   </group>
-   <group name="net-snmp-disk-highlow" ifType="all">
-      <mibObj oid=".1.3.6.1.4.1.2021.9.1.11" instance="dskIndex" alias="ns-dskTotalLow" type="gauge"/>
-      <mibObj oid=".1.3.6.1.4.1.2021.9.1.12" instance="dskIndex" alias="ns-dskTotalHigh" type="gauge"/>
-      <mibObj oid=".1.3.6.1.4.1.2021.9.1.13" instance="dskIndex" alias="ns-dskAvailLow" type="gauge"/>
-      <mibObj oid=".1.3.6.1.4.1.2021.9.1.14" instance="dskIndex" alias="ns-dskAvailHigh" type="gauge"/>
-      <mibObj oid=".1.3.6.1.4.1.2021.9.1.15" instance="dskIndex" alias="ns-dskUsedLow" type="gauge"/>
-      <mibObj oid=".1.3.6.1.4.1.2021.9.1.16" instance="dskIndex" alias="ns-dskUsedHigh" type="gauge"/>
-   </group>
-   <group name="ucd-loadavg" ifType="ignore">
-      <mibObj oid=".1.3.6.1.4.1.2021.10.1.5" instance="1" alias="loadavg1" type="integer"/>
-      <mibObj oid=".1.3.6.1.4.1.2021.10.1.5" instance="2" alias="loadavg5" type="integer"/>
-      <mibObj oid=".1.3.6.1.4.1.2021.10.1.5" instance="3" alias="loadavg15" type="integer"/>
-   </group>
-   <group name="ucd-memory" ifType="ignore">
-      <!-- Total Swap Size configured for the host -->
-      <mibObj oid=".1.3.6.1.4.1.2021.4.3" instance="0" alias="memTotalSwap" type="integer"/>
-      <mibObj oid=".1.3.6.1.4.1.2021.4.4" instance="0" alias="memAvailSwap" type="integer"/>
-      <mibObj oid=".1.3.6.1.4.1.2021.4.5" instance="0" alias="memTotalReal" type="integer"/>
-      <mibObj oid=".1.3.6.1.4.1.2021.4.6" instance="0" alias="memAvailReal" type="integer"/>
-      <mibObj oid=".1.3.6.1.4.1.2021.4.11" instance="0" alias="memTotalFree" type="integer"/>
-      <mibObj oid=".1.3.6.1.4.1.2021.4.13" instance="0" alias="memShared" type="integer"/>
-      <mibObj oid=".1.3.6.1.4.1.2021.4.14" instance="0" alias="memBuffer" type="integer"/>
-      <mibObj oid=".1.3.6.1.4.1.2021.4.15" instance="0" alias="memCached" type="integer"/>
-      <!-- Error flag.  1 indicates very little swap space left -->
-      <mibObj oid=".1.3.6.1.4.1.2021.4.100" instance="0" alias="memSwapError" type="integer"/>
-   </group>
-   <group name="ucd-sysstat" ifType="ignore">
-      <mibObj oid=".1.3.6.1.4.1.2021.11.3" instance="0" alias="SwapIn" type="integer"/>
-      <mibObj oid=".1.3.6.1.4.1.2021.11.4" instance="0" alias="SwapOut" type="integer"/>
-      <mibObj oid=".1.3.6.1.4.1.2021.11.7" instance="0" alias="SysInterrupts" type="integer"/>
-      <mibObj oid=".1.3.6.1.4.1.2021.11.8" instance="0" alias="SysContext" type="integer"/>
-      <mibObj oid=".1.3.6.1.4.1.2021.11.50" instance="0" alias="CpuRawUser" type="counter"/>
-      <mibObj oid=".1.3.6.1.4.1.2021.11.51" instance="0" alias="CpuRawNice" type="counter"/>
-      <mibObj oid=".1.3.6.1.4.1.2021.11.52" instance="0" alias="CpuRawSystem" type="counter"/>
-      <mibObj oid=".1.3.6.1.4.1.2021.11.53" instance="0" alias="CpuRawIdle" type="counter"/>
-      <mibObj oid=".1.3.6.1.4.1.2021.11.54" instance="0" alias="CpuRawWait" type="counter"/>
-      <mibObj oid=".1.3.6.1.4.1.2021.11.55" instance="0" alias="CpuRawKernel" type="counter"/>
-      <mibObj oid=".1.3.6.1.4.1.2021.11.56" instance="0" alias="CpuRawInterrupt" type="counter"/>
-      <mibObj oid=".1.3.6.1.4.1.2021.11.57" instance="0" alias="IORawSent" type="counter"/>
-      <mibObj oid=".1.3.6.1.4.1.2021.11.58" instance="0" alias="IORawReceived" type="counter"/>
-   </group>
-   <group name="ucd-sysstat-raw" ifType="ignore">
-      <mibObj oid=".1.3.6.1.4.1.2021.11.59" instance="0" alias="SysRawInterrupts" type="counter"/>
-      <mibObj oid=".1.3.6.1.4.1.2021.11.60" instance="0" alias="SysRawContext" type="counter"/>
-   </group>
-   <group name="ucd-sysstat-raw-more" ifType="ignore">
-      <mibObj oid=".1.3.6.1.4.1.2021.11.61" instance="0" alias="CpuRawSoftIRQ" type="counter"/>
-      <mibObj oid=".1.3.6.1.4.1.2021.11.62" instance="0" alias="RawBlksSwapIn" type="counter"/>
-      <mibObj oid=".1.3.6.1.4.1.2021.11.63" instance="0" alias="RawBlksSwapOut" type="counter"/>
-   </group>
-   <group name="ucd-diskio" ifType="all">
-      <mibObj oid=".1.3.6.1.4.1.2021.13.15.1.1.2" instance="diskIOIndex" alias="diskIODevice" type="string" />
-      <mibObj oid=".1.3.6.1.4.1.2021.13.15.1.1.3" instance="diskIOIndex" alias="diskIONRead" type="counter" />
-      <mibObj oid=".1.3.6.1.4.1.2021.13.15.1.1.4" instance="diskIOIndex" alias="diskIONWritten" type="counter" />
-      <mibObj oid=".1.3.6.1.4.1.2021.13.15.1.1.5" instance="diskIOIndex" alias="diskIOReads" type="counter" />
-      <mibObj oid=".1.3.6.1.4.1.2021.13.15.1.1.6" instance="diskIOIndex" alias="diskIOWrites" type="counter" />
-      <mibObj oid=".1.3.6.1.4.1.2021.13.15.1.1.9" instance="diskIOIndex" alias="diskIOLA1" type="integer" />
-      <mibObj oid=".1.3.6.1.4.1.2021.13.15.1.1.10" instance="diskIOIndex" alias="diskIOLA5" type="integer" />
-      <mibObj oid=".1.3.6.1.4.1.2021.13.15.1.1.11" instance="diskIOIndex" alias="diskIOLA15" type="integer" />
-      <mibObj oid=".1.3.6.1.4.1.2021.13.15.1.1.12" instance="diskIOIndex" alias="diskIONReadX" type="Counter64" />
-      <mibObj oid=".1.3.6.1.4.1.2021.13.15.1.1.13" instance="diskIOIndex" alias="diskIONWrittenX" type="Counter64" />
-   </group>
-   <group name="lmsensors-temp" ifType="all">
-      <mibObj oid=".1.3.6.1.4.1.2021.13.16.2.1.2" instance="lmTempIndex" alias="lms-tempdevice" type="string"/>
-      <mibObj oid=".1.3.6.1.4.1.2021.13.16.2.1.3" instance="lmTempIndex" alias="lms-temp" type="gauge32"/>
-   </group>
-   <group name="lmsensors-fan" ifType="all">
-      <mibObj oid=".1.3.6.1.4.1.2021.13.16.3.1.2" instance="lmFanIndex" alias="lms-fandevice" type="string"/>
-      <mibObj oid=".1.3.6.1.4.1.2021.13.16.3.1.3" instance="lmFanIndex" alias="lms-fan" type="gauge32"/>
-   </group>
-   <group name="lmsensors-volt" ifType="all">
-      <mibObj oid=".1.3.6.1.4.1.2021.13.16.4.1.2" instance="lmVoltIndex" alias="lms-voltdevice" type="string"/>
-      <mibObj oid=".1.3.6.1.4.1.2021.13.16.4.1.3" instance="lmVoltIndex" alias="lms-volt" type="gauge32"/>
-   </group>
-   <systemDef name="Net-SNMP (UCD)">
-      <sysoidMask>.1.3.6.1.4.1.2021.250.</sysoidMask>
-      <collect>
-         <includeGroup>mib2-host-resources-system</includeGroup>
-         <includeGroup>mib2-host-resources-memory</includeGroup>
-         <includeGroup>mib2-host-resources-storage</includeGroup>
-         <includeGroup>net-snmp-disk</includeGroup>
-         <includeGroup>net-snmp-disk-more</includeGroup>
-         <includeGroup>net-snmp-disk-highlow</includeGroup>
-         <includeGroup>ucd-loadavg</includeGroup>
-         <includeGroup>ucd-memory</includeGroup>
-         <includeGroup>ucd-sysstat</includeGroup>
-         <includeGroup>ucd-sysstat-raw</includeGroup>
-         <includeGroup>ucd-sysstat-raw-more</includeGroup>
-         <includeGroup>ucd-diskio</includeGroup>
-         <includeGroup>lmsensors-temp</includeGroup>
-         <includeGroup>lmsensors-fan</includeGroup>
-         <includeGroup>lmsensors-volt</includeGroup>
-      </collect>
-   </systemDef>
-   <systemDef name="Net-SNMP">
-      <sysoidMask>.1.3.6.1.4.1.8072.3.</sysoidMask>
-      <collect>
-         <includeGroup>mib2-host-resources-system</includeGroup>
-         <includeGroup>mib2-host-resources-memory</includeGroup>
-         <includeGroup>mib2-host-resources-storage</includeGroup>
-         <includeGroup>mib2-X-interfaces</includeGroup>
-         <includeGroup>mib2-X-interfaces-pkts</includeGroup>
-         <includeGroup>net-snmp-disk</includeGroup>
-         <includeGroup>net-snmp-disk-more</includeGroup>
-         <includeGroup>net-snmp-disk-highlow</includeGroup>
-         <includeGroup>openmanage-coolingdevices</includeGroup>
-         <includeGroup>openmanage-temperatureprobe</includeGroup>
-         <includeGroup>openmanage-powerusage</includeGroup>
-         <includeGroup>ucd-loadavg</includeGroup>
-         <includeGroup>ucd-memory</includeGroup>
-         <includeGroup>ucd-sysstat</includeGroup>
-         <includeGroup>ucd-sysstat-raw</includeGroup>
-         <includeGroup>ucd-sysstat-raw-more</includeGroup>
-         <includeGroup>ucd-diskio</includeGroup>
-         <includeGroup>lmsensors-temp</includeGroup>
-         <includeGroup>lmsensors-fan</includeGroup>
-         <includeGroup>lmsensors-volt</includeGroup>
-      </collect>
-   </systemDef>
-   <systemDef name="Net-SNMP 5.5 with sysObjectID bug on i386">
-      <sysoid>.1.3</sysoid>
-      <collect>
-         <includeGroup>mib2-interfaces</includeGroup>
-         <includeGroup>mib2-tcp</includeGroup>
-         <includeGroup>mib2-powerethernet</includeGroup>
-         <includeGroup>mib2-host-resources-system</includeGroup>
-         <includeGroup>mib2-host-resources-memory</includeGroup>
-         <includeGroup>mib2-X-interfaces</includeGroup>
-         <includeGroup>mib2-X-interfaces-pkts</includeGroup>
-         <includeGroup>net-snmp-disk</includeGroup>
-         <includeGroup>net-snmp-disk-more</includeGroup>
-         <includeGroup>net-snmp-disk-highlow</includeGroup>
-         <includeGroup>openmanage-coolingdevices</includeGroup>
-         <includeGroup>openmanage-temperatureprobe</includeGroup>
-         <includeGroup>openmanage-powerusage</includeGroup>
-         <includeGroup>ucd-loadavg</includeGroup>
-         <includeGroup>ucd-memory</includeGroup>
-         <includeGroup>ucd-sysstat</includeGroup>
-         <includeGroup>ucd-sysstat-raw</includeGroup>
-         <includeGroup>ucd-sysstat-raw-more</includeGroup>
-         <includeGroup>ucd-diskio</includeGroup>
-         <includeGroup>lmsensors-temp</includeGroup>
-         <includeGroup>lmsensors-fan</includeGroup>
-         <includeGroup>lmsensors-volt</includeGroup>
-      </collect>
-   </systemDef>
-   <systemDef name="Net-SNMP 5.5 with sysObjectID bug on x86_64">
-      <sysoid>.0.1</sysoid>
-      <collect>
-         <includeGroup>mib2-interfaces</includeGroup>
-         <includeGroup>mib2-tcp</includeGroup>
-         <includeGroup>mib2-powerethernet</includeGroup>
-         <includeGroup>mib2-host-resources-system</includeGroup>
-         <includeGroup>mib2-host-resources-memory</includeGroup>
-         <includeGroup>mib2-X-interfaces</includeGroup>
-         <includeGroup>mib2-X-interfaces-pkts</includeGroup>
-         <includeGroup>net-snmp-disk</includeGroup>
-         <includeGroup>net-snmp-disk-more</includeGroup>
-         <includeGroup>net-snmp-disk-highlow</includeGroup>
-         <includeGroup>openmanage-coolingdevices</includeGroup>
-         <includeGroup>openmanage-temperatureprobe</includeGroup>
-         <includeGroup>openmanage-powerusage</includeGroup>
-         <includeGroup>ucd-loadavg</includeGroup>
-         <includeGroup>ucd-memory</includeGroup>
-         <includeGroup>ucd-sysstat</includeGroup>
-         <includeGroup>ucd-sysstat-raw</includeGroup>
-         <includeGroup>ucd-sysstat-raw-more</includeGroup>
-         <includeGroup>ucd-diskio</includeGroup>
-         <includeGroup>lmsensors-temp</includeGroup>
-         <includeGroup>lmsensors-fan</includeGroup>
-         <includeGroup>lmsensors-volt</includeGroup>
-      </collect>
-   </systemDef>
+    <resourceType name="diskIOIndex" label="Disk IO (UCD-SNMP MIB)" resourceLabel="${diskIODevice} (index ${index})">
+        <persistenceSelectorStrategy class="org.opennms.netmgt.collectd.PersistRegexSelectorStrategy">
+            <parameter key="match-expression" value="not(#diskIODevice matches '^(loop|ram).*')"/>
+        </persistenceSelectorStrategy>
+        <storageStrategy class="org.opennms.netmgt.dao.support.SiblingColumnStorageStrategy">
+            <parameter key="sibling-column-name" value="diskIODevice"/>
+            <parameter key="replace-all" value="s/^-//"/>
+            <parameter key="replace-all" value="s/\s//"/>
+            <parameter key="replace-all" value="s/:\\.*//"/>
+        </storageStrategy>
+    </resourceType>
+    <resourceType name="dskIndex" label="Disk Table Index (UCD-SNMP MIB)"
+                  resourceLabel="${ns-dskPath} (index ${index})">
+        <persistenceSelectorStrategy class="org.opennms.netmgt.collection.support.PersistAllSelectorStrategy"/>
+        <storageStrategy class="org.opennms.netmgt.dao.support.SiblingColumnStorageStrategy">
+            <parameter key="sibling-column-name" value="ns-dskPath"/>
+            <parameter key="replace-first" value="s/^-$/_root_fs/"/>
+            <parameter key="replace-all" value="s/^-//"/>
+            <parameter key="replace-all" value="s/\s//"/>
+            <parameter key="replace-all" value="s/:\\.*//"/>
+        </storageStrategy>
+    </resourceType>
+    <resourceType name="lmTempIndex" label="Hardware Sensors: Temperature (lmSensors MIB)"
+                  resourceLabel="${lms-tempdevice} (index ${index})">
+        <persistenceSelectorStrategy class="org.opennms.netmgt.collection.support.PersistAllSelectorStrategy"/>
+        <storageStrategy class="org.opennms.netmgt.collection.support.IndexStorageStrategy"/>
+    </resourceType>
+    <resourceType name="lmFanIndex" label="Hardware Sensors: Fan (lmSensors MIB)"
+                  resourceLabel="${lms-fandevice} (index ${index})">
+        <persistenceSelectorStrategy class="org.opennms.netmgt.collection.support.PersistAllSelectorStrategy"/>
+        <storageStrategy class="org.opennms.netmgt.collection.support.IndexStorageStrategy"/>
+    </resourceType>
+    <resourceType name="lmVoltIndex" label="Hardware Sensors: Voltage (lmSensors MIB)"
+                  resourceLabel="${lms-voltdevice} (index ${index})">
+        <persistenceSelectorStrategy class="org.opennms.netmgt.collection.support.PersistAllSelectorStrategy"/>
+        <storageStrategy class="org.opennms.netmgt.collection.support.IndexStorageStrategy"/>
+    </resourceType>
+    <group name="net-snmp-disk" ifType="all">
+        <mibObj oid=".1.3.6.1.4.1.2021.9.1.2" instance="dskIndex" alias="ns-dskPath" type="string"/>
+        <mibObj oid=".1.3.6.1.4.1.2021.9.1.6" instance="dskIndex" alias="ns-dskTotal" type="gauge"/>
+        <mibObj oid=".1.3.6.1.4.1.2021.9.1.7" instance="dskIndex" alias="ns-dskAvail" type="gauge"/>
+        <mibObj oid=".1.3.6.1.4.1.2021.9.1.8" instance="dskIndex" alias="ns-dskUsed" type="gauge"/>
+        <mibObj oid=".1.3.6.1.4.1.2021.9.1.9" instance="dskIndex" alias="ns-dskPercent" type="gauge"/>
+    </group>
+    <group name="net-snmp-disk-more" ifType="all">
+        <mibObj oid=".1.3.6.1.4.1.2021.9.1.3" instance="dskIndex" alias="ns-dskDevice" type="string"/>
+        <mibObj oid=".1.3.6.1.4.1.2021.9.1.10" instance="dskIndex" alias="ns-dskPercentNode" type="gauge"/>
+    </group>
+    <group name="net-snmp-disk-highlow" ifType="all">
+        <mibObj oid=".1.3.6.1.4.1.2021.9.1.11" instance="dskIndex" alias="ns-dskTotalLow" type="gauge"/>
+        <mibObj oid=".1.3.6.1.4.1.2021.9.1.12" instance="dskIndex" alias="ns-dskTotalHigh" type="gauge"/>
+        <mibObj oid=".1.3.6.1.4.1.2021.9.1.13" instance="dskIndex" alias="ns-dskAvailLow" type="gauge"/>
+        <mibObj oid=".1.3.6.1.4.1.2021.9.1.14" instance="dskIndex" alias="ns-dskAvailHigh" type="gauge"/>
+        <mibObj oid=".1.3.6.1.4.1.2021.9.1.15" instance="dskIndex" alias="ns-dskUsedLow" type="gauge"/>
+        <mibObj oid=".1.3.6.1.4.1.2021.9.1.16" instance="dskIndex" alias="ns-dskUsedHigh" type="gauge"/>
+    </group>
+    <group name="ucd-loadavg" ifType="ignore">
+        <mibObj oid=".1.3.6.1.4.1.2021.10.1.5" instance="1" alias="loadavg1" type="integer"/>
+        <mibObj oid=".1.3.6.1.4.1.2021.10.1.5" instance="2" alias="loadavg5" type="integer"/>
+        <mibObj oid=".1.3.6.1.4.1.2021.10.1.5" instance="3" alias="loadavg15" type="integer"/>
+    </group>
+    <group name="ucd-memory" ifType="ignore">
+        <!-- Total Swap Size configured for the host -->
+        <mibObj oid=".1.3.6.1.4.1.2021.4.3" instance="0" alias="memTotalSwap" type="integer"/>
+        <mibObj oid=".1.3.6.1.4.1.2021.4.4" instance="0" alias="memAvailSwap" type="integer"/>
+        <mibObj oid=".1.3.6.1.4.1.2021.4.5" instance="0" alias="memTotalReal" type="integer"/>
+        <mibObj oid=".1.3.6.1.4.1.2021.4.6" instance="0" alias="memAvailReal" type="integer"/>
+        <mibObj oid=".1.3.6.1.4.1.2021.4.11" instance="0" alias="memTotalFree" type="integer"/>
+        <mibObj oid=".1.3.6.1.4.1.2021.4.13" instance="0" alias="memShared" type="integer"/>
+        <mibObj oid=".1.3.6.1.4.1.2021.4.14" instance="0" alias="memBuffer" type="integer"/>
+        <mibObj oid=".1.3.6.1.4.1.2021.4.15" instance="0" alias="memCached" type="integer"/>
+        <!-- Error flag.  1 indicates very little swap space left -->
+        <mibObj oid=".1.3.6.1.4.1.2021.4.100" instance="0" alias="memSwapError" type="integer"/>
+    </group>
+    <group name="ucd-sysstat" ifType="ignore">
+        <mibObj oid=".1.3.6.1.4.1.2021.11.3" instance="0" alias="SwapIn" type="integer"/>
+        <mibObj oid=".1.3.6.1.4.1.2021.11.4" instance="0" alias="SwapOut" type="integer"/>
+        <mibObj oid=".1.3.6.1.4.1.2021.11.7" instance="0" alias="SysInterrupts" type="integer"/>
+        <mibObj oid=".1.3.6.1.4.1.2021.11.8" instance="0" alias="SysContext" type="integer"/>
+        <mibObj oid=".1.3.6.1.4.1.2021.11.50" instance="0" alias="CpuRawUser" type="counter"/>
+        <mibObj oid=".1.3.6.1.4.1.2021.11.51" instance="0" alias="CpuRawNice" type="counter"/>
+        <mibObj oid=".1.3.6.1.4.1.2021.11.52" instance="0" alias="CpuRawSystem" type="counter"/>
+        <mibObj oid=".1.3.6.1.4.1.2021.11.53" instance="0" alias="CpuRawIdle" type="counter"/>
+        <mibObj oid=".1.3.6.1.4.1.2021.11.54" instance="0" alias="CpuRawWait" type="counter"/>
+        <mibObj oid=".1.3.6.1.4.1.2021.11.55" instance="0" alias="CpuRawKernel" type="counter"/>
+        <mibObj oid=".1.3.6.1.4.1.2021.11.56" instance="0" alias="CpuRawInterrupt" type="counter"/>
+        <mibObj oid=".1.3.6.1.4.1.2021.11.57" instance="0" alias="IORawSent" type="counter"/>
+        <mibObj oid=".1.3.6.1.4.1.2021.11.58" instance="0" alias="IORawReceived" type="counter"/>
+    </group>
+    <group name="ucd-sysstat-raw" ifType="ignore">
+        <mibObj oid=".1.3.6.1.4.1.2021.11.59" instance="0" alias="SysRawInterrupts" type="counter"/>
+        <mibObj oid=".1.3.6.1.4.1.2021.11.60" instance="0" alias="SysRawContext" type="counter"/>
+    </group>
+    <group name="ucd-sysstat-raw-more" ifType="ignore">
+        <mibObj oid=".1.3.6.1.4.1.2021.11.61" instance="0" alias="CpuRawSoftIRQ" type="counter"/>
+        <mibObj oid=".1.3.6.1.4.1.2021.11.62" instance="0" alias="RawBlksSwapIn" type="counter"/>
+        <mibObj oid=".1.3.6.1.4.1.2021.11.63" instance="0" alias="RawBlksSwapOut" type="counter"/>
+    </group>
+    <group name="ucd-diskio" ifType="all">
+        <mibObj oid=".1.3.6.1.4.1.2021.13.15.1.1.2" instance="diskIOIndex" alias="diskIODevice" type="string"/>
+        <mibObj oid=".1.3.6.1.4.1.2021.13.15.1.1.3" instance="diskIOIndex" alias="diskIONRead" type="counter"/>
+        <mibObj oid=".1.3.6.1.4.1.2021.13.15.1.1.4" instance="diskIOIndex" alias="diskIONWritten" type="counter"/>
+        <mibObj oid=".1.3.6.1.4.1.2021.13.15.1.1.5" instance="diskIOIndex" alias="diskIOReads" type="counter"/>
+        <mibObj oid=".1.3.6.1.4.1.2021.13.15.1.1.6" instance="diskIOIndex" alias="diskIOWrites" type="counter"/>
+        <mibObj oid=".1.3.6.1.4.1.2021.13.15.1.1.9" instance="diskIOIndex" alias="diskIOLA1" type="integer"/>
+        <mibObj oid=".1.3.6.1.4.1.2021.13.15.1.1.10" instance="diskIOIndex" alias="diskIOLA5" type="integer"/>
+        <mibObj oid=".1.3.6.1.4.1.2021.13.15.1.1.11" instance="diskIOIndex" alias="diskIOLA15" type="integer"/>
+        <mibObj oid=".1.3.6.1.4.1.2021.13.15.1.1.12" instance="diskIOIndex" alias="diskIONReadX" type="Counter64"/>
+        <mibObj oid=".1.3.6.1.4.1.2021.13.15.1.1.13" instance="diskIOIndex" alias="diskIONWrittenX" type="Counter64"/>
+    </group>
+    <group name="lmsensors-temp" ifType="all">
+        <mibObj oid=".1.3.6.1.4.1.2021.13.16.2.1.2" instance="lmTempIndex" alias="lms-tempdevice" type="string"/>
+        <mibObj oid=".1.3.6.1.4.1.2021.13.16.2.1.3" instance="lmTempIndex" alias="lms-temp" type="gauge32"/>
+    </group>
+    <group name="lmsensors-fan" ifType="all">
+        <mibObj oid=".1.3.6.1.4.1.2021.13.16.3.1.2" instance="lmFanIndex" alias="lms-fandevice" type="string"/>
+        <mibObj oid=".1.3.6.1.4.1.2021.13.16.3.1.3" instance="lmFanIndex" alias="lms-fan" type="gauge32"/>
+    </group>
+    <group name="lmsensors-volt" ifType="all">
+        <mibObj oid=".1.3.6.1.4.1.2021.13.16.4.1.2" instance="lmVoltIndex" alias="lms-voltdevice" type="string"/>
+        <mibObj oid=".1.3.6.1.4.1.2021.13.16.4.1.3" instance="lmVoltIndex" alias="lms-volt" type="gauge32"/>
+    </group>
+    <systemDef name="Net-SNMP (UCD)">
+        <sysoidMask>.1.3.6.1.4.1.2021.250.</sysoidMask>
+        <collect>
+            <includeGroup>mib2-host-resources-system</includeGroup>
+            <includeGroup>mib2-host-resources-memory</includeGroup>
+            <includeGroup>mib2-host-resources-storage</includeGroup>
+            <includeGroup>net-snmp-disk</includeGroup>
+            <includeGroup>net-snmp-disk-more</includeGroup>
+            <includeGroup>net-snmp-disk-highlow</includeGroup>
+            <includeGroup>ucd-loadavg</includeGroup>
+            <includeGroup>ucd-memory</includeGroup>
+            <includeGroup>ucd-sysstat</includeGroup>
+            <includeGroup>ucd-sysstat-raw</includeGroup>
+            <includeGroup>ucd-sysstat-raw-more</includeGroup>
+            <includeGroup>ucd-diskio</includeGroup>
+            <includeGroup>lmsensors-temp</includeGroup>
+            <includeGroup>lmsensors-fan</includeGroup>
+            <includeGroup>lmsensors-volt</includeGroup>
+        </collect>
+    </systemDef>
+    <systemDef name="Net-SNMP">
+        <sysoidMask>.1.3.6.1.4.1.8072.3.</sysoidMask>
+        <collect>
+            <includeGroup>mib2-host-resources-system</includeGroup>
+            <includeGroup>mib2-host-resources-memory</includeGroup>
+            <includeGroup>mib2-host-resources-storage</includeGroup>
+            <includeGroup>mib2-X-interfaces</includeGroup>
+            <includeGroup>mib2-X-interfaces-pkts</includeGroup>
+            <includeGroup>net-snmp-disk</includeGroup>
+            <includeGroup>net-snmp-disk-more</includeGroup>
+            <includeGroup>net-snmp-disk-highlow</includeGroup>
+            <includeGroup>openmanage-coolingdevices</includeGroup>
+            <includeGroup>openmanage-temperatureprobe</includeGroup>
+            <includeGroup>openmanage-powerusage</includeGroup>
+            <includeGroup>ucd-loadavg</includeGroup>
+            <includeGroup>ucd-memory</includeGroup>
+            <includeGroup>ucd-sysstat</includeGroup>
+            <includeGroup>ucd-sysstat-raw</includeGroup>
+            <includeGroup>ucd-sysstat-raw-more</includeGroup>
+            <includeGroup>ucd-diskio</includeGroup>
+            <includeGroup>lmsensors-temp</includeGroup>
+            <includeGroup>lmsensors-fan</includeGroup>
+            <includeGroup>lmsensors-volt</includeGroup>
+        </collect>
+    </systemDef>
+    <systemDef name="Net-SNMP 5.5 with sysObjectID bug on i386">
+        <sysoid>.1.3</sysoid>
+        <collect>
+            <includeGroup>mib2-interfaces</includeGroup>
+            <includeGroup>mib2-tcp</includeGroup>
+            <includeGroup>mib2-powerethernet</includeGroup>
+            <includeGroup>mib2-host-resources-system</includeGroup>
+            <includeGroup>mib2-host-resources-memory</includeGroup>
+            <includeGroup>mib2-X-interfaces</includeGroup>
+            <includeGroup>mib2-X-interfaces-pkts</includeGroup>
+            <includeGroup>net-snmp-disk</includeGroup>
+            <includeGroup>net-snmp-disk-more</includeGroup>
+            <includeGroup>net-snmp-disk-highlow</includeGroup>
+            <includeGroup>openmanage-coolingdevices</includeGroup>
+            <includeGroup>openmanage-temperatureprobe</includeGroup>
+            <includeGroup>openmanage-powerusage</includeGroup>
+            <includeGroup>ucd-loadavg</includeGroup>
+            <includeGroup>ucd-memory</includeGroup>
+            <includeGroup>ucd-sysstat</includeGroup>
+            <includeGroup>ucd-sysstat-raw</includeGroup>
+            <includeGroup>ucd-sysstat-raw-more</includeGroup>
+            <includeGroup>ucd-diskio</includeGroup>
+            <includeGroup>lmsensors-temp</includeGroup>
+            <includeGroup>lmsensors-fan</includeGroup>
+            <includeGroup>lmsensors-volt</includeGroup>
+        </collect>
+    </systemDef>
+    <systemDef name="Net-SNMP 5.5 with sysObjectID bug on x86_64">
+        <sysoid>.0.1</sysoid>
+        <collect>
+            <includeGroup>mib2-interfaces</includeGroup>
+            <includeGroup>mib2-tcp</includeGroup>
+            <includeGroup>mib2-powerethernet</includeGroup>
+            <includeGroup>mib2-host-resources-system</includeGroup>
+            <includeGroup>mib2-host-resources-memory</includeGroup>
+            <includeGroup>mib2-X-interfaces</includeGroup>
+            <includeGroup>mib2-X-interfaces-pkts</includeGroup>
+            <includeGroup>net-snmp-disk</includeGroup>
+            <includeGroup>net-snmp-disk-more</includeGroup>
+            <includeGroup>net-snmp-disk-highlow</includeGroup>
+            <includeGroup>openmanage-coolingdevices</includeGroup>
+            <includeGroup>openmanage-temperatureprobe</includeGroup>
+            <includeGroup>openmanage-powerusage</includeGroup>
+            <includeGroup>ucd-loadavg</includeGroup>
+            <includeGroup>ucd-memory</includeGroup>
+            <includeGroup>ucd-sysstat</includeGroup>
+            <includeGroup>ucd-sysstat-raw</includeGroup>
+            <includeGroup>ucd-sysstat-raw-more</includeGroup>
+            <includeGroup>ucd-diskio</includeGroup>
+            <includeGroup>lmsensors-temp</includeGroup>
+            <includeGroup>lmsensors-fan</includeGroup>
+            <includeGroup>lmsensors-volt</includeGroup>
+        </collect>
+    </systemDef>
 </datacollection-group>

--- a/opennms-base-assembly/src/main/filtered/etc/datacollection/netsnmp.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/datacollection/netsnmp.xml
@@ -1,236 +1,234 @@
 <datacollection-group xmlns="http://xmlns.opennms.org/xsd/config/datacollection" name="Net-SNMP">
-    <resourceType name="diskIOIndex" label="Disk IO (UCD-SNMP MIB)" resourceLabel="${diskIODevice} (index ${index})">
-        <persistenceSelectorStrategy class="org.opennms.netmgt.collectd.PersistRegexSelectorStrategy">
-            <parameter key="match-expression" value="not(#diskIODevice matches '^(loop|ram).*')"/>
-        </persistenceSelectorStrategy>
-        <storageStrategy class="org.opennms.netmgt.dao.support.SiblingColumnStorageStrategy">
-            <parameter key="sibling-column-name" value="diskIODevice"/>
-            <parameter key="replace-all" value="s/^-//"/>
-            <parameter key="replace-all" value="s/\s//"/>
-            <parameter key="replace-all" value="s/:\\.*//"/>
-        </storageStrategy>
-    </resourceType>
-    <resourceType name="dskIndex" label="Disk Table Index (UCD-SNMP MIB)"
-                  resourceLabel="${ns-dskPath} (index ${index})">
-        <persistenceSelectorStrategy class="org.opennms.netmgt.collection.support.PersistAllSelectorStrategy"/>
-        <storageStrategy class="org.opennms.netmgt.dao.support.SiblingColumnStorageStrategy">
-            <parameter key="sibling-column-name" value="ns-dskPath"/>
-            <parameter key="replace-first" value="s/^-$/_root_fs/"/>
-            <parameter key="replace-all" value="s/^-//"/>
-            <parameter key="replace-all" value="s/\s//"/>
-            <parameter key="replace-all" value="s/:\\.*//"/>
-        </storageStrategy>
-    </resourceType>
-    <resourceType name="lmTempIndex" label="Hardware Sensors: Temperature (lmSensors MIB)"
-                  resourceLabel="${lms-tempdevice} (index ${index})">
-        <persistenceSelectorStrategy class="org.opennms.netmgt.collection.support.PersistAllSelectorStrategy"/>
-        <storageStrategy class="org.opennms.netmgt.collection.support.IndexStorageStrategy"/>
-    </resourceType>
-    <resourceType name="lmFanIndex" label="Hardware Sensors: Fan (lmSensors MIB)"
-                  resourceLabel="${lms-fandevice} (index ${index})">
-        <persistenceSelectorStrategy class="org.opennms.netmgt.collection.support.PersistAllSelectorStrategy"/>
-        <storageStrategy class="org.opennms.netmgt.collection.support.IndexStorageStrategy"/>
-    </resourceType>
-    <resourceType name="lmVoltIndex" label="Hardware Sensors: Voltage (lmSensors MIB)"
-                  resourceLabel="${lms-voltdevice} (index ${index})">
-        <persistenceSelectorStrategy class="org.opennms.netmgt.collection.support.PersistAllSelectorStrategy"/>
-        <storageStrategy class="org.opennms.netmgt.collection.support.IndexStorageStrategy"/>
-    </resourceType>
-    <group name="net-snmp-disk" ifType="all">
-        <mibObj oid=".1.3.6.1.4.1.2021.9.1.2" instance="dskIndex" alias="ns-dskPath" type="string"/>
-        <mibObj oid=".1.3.6.1.4.1.2021.9.1.6" instance="dskIndex" alias="ns-dskTotal" type="gauge"/>
-        <mibObj oid=".1.3.6.1.4.1.2021.9.1.7" instance="dskIndex" alias="ns-dskAvail" type="gauge"/>
-        <mibObj oid=".1.3.6.1.4.1.2021.9.1.8" instance="dskIndex" alias="ns-dskUsed" type="gauge"/>
-        <mibObj oid=".1.3.6.1.4.1.2021.9.1.9" instance="dskIndex" alias="ns-dskPercent" type="gauge"/>
-    </group>
-    <group name="net-snmp-disk-more" ifType="all">
-        <mibObj oid=".1.3.6.1.4.1.2021.9.1.3" instance="dskIndex" alias="ns-dskDevice" type="string"/>
-        <mibObj oid=".1.3.6.1.4.1.2021.9.1.10" instance="dskIndex" alias="ns-dskPercentNode" type="gauge"/>
-    </group>
-    <group name="net-snmp-disk-highlow" ifType="all">
-        <mibObj oid=".1.3.6.1.4.1.2021.9.1.11" instance="dskIndex" alias="ns-dskTotalLow" type="gauge"/>
-        <mibObj oid=".1.3.6.1.4.1.2021.9.1.12" instance="dskIndex" alias="ns-dskTotalHigh" type="gauge"/>
-        <mibObj oid=".1.3.6.1.4.1.2021.9.1.13" instance="dskIndex" alias="ns-dskAvailLow" type="gauge"/>
-        <mibObj oid=".1.3.6.1.4.1.2021.9.1.14" instance="dskIndex" alias="ns-dskAvailHigh" type="gauge"/>
-        <mibObj oid=".1.3.6.1.4.1.2021.9.1.15" instance="dskIndex" alias="ns-dskUsedLow" type="gauge"/>
-        <mibObj oid=".1.3.6.1.4.1.2021.9.1.16" instance="dskIndex" alias="ns-dskUsedHigh" type="gauge"/>
-    </group>
-    <group name="ucd-loadavg" ifType="ignore">
-        <mibObj oid=".1.3.6.1.4.1.2021.10.1.5" instance="1" alias="loadavg1" type="integer"/>
-        <mibObj oid=".1.3.6.1.4.1.2021.10.1.5" instance="2" alias="loadavg5" type="integer"/>
-        <mibObj oid=".1.3.6.1.4.1.2021.10.1.5" instance="3" alias="loadavg15" type="integer"/>
-    </group>
-    <group name="ucd-memory" ifType="ignore">
-        <!-- Total Swap Size configured for the host -->
-        <mibObj oid=".1.3.6.1.4.1.2021.4.3" instance="0" alias="memTotalSwap" type="integer"/>
-        <mibObj oid=".1.3.6.1.4.1.2021.4.4" instance="0" alias="memAvailSwap" type="integer"/>
-        <mibObj oid=".1.3.6.1.4.1.2021.4.5" instance="0" alias="memTotalReal" type="integer"/>
-        <mibObj oid=".1.3.6.1.4.1.2021.4.6" instance="0" alias="memAvailReal" type="integer"/>
-        <mibObj oid=".1.3.6.1.4.1.2021.4.11" instance="0" alias="memTotalFree" type="integer"/>
-        <mibObj oid=".1.3.6.1.4.1.2021.4.13" instance="0" alias="memShared" type="integer"/>
-        <mibObj oid=".1.3.6.1.4.1.2021.4.14" instance="0" alias="memBuffer" type="integer"/>
-        <mibObj oid=".1.3.6.1.4.1.2021.4.15" instance="0" alias="memCached" type="integer"/>
-        <!-- Error flag.  1 indicates very little swap space left -->
-        <mibObj oid=".1.3.6.1.4.1.2021.4.100" instance="0" alias="memSwapError" type="integer"/>
-    </group>
-    <group name="ucd-sysstat" ifType="ignore">
-        <mibObj oid=".1.3.6.1.4.1.2021.11.3" instance="0" alias="SwapIn" type="integer"/>
-        <mibObj oid=".1.3.6.1.4.1.2021.11.4" instance="0" alias="SwapOut" type="integer"/>
-        <mibObj oid=".1.3.6.1.4.1.2021.11.7" instance="0" alias="SysInterrupts" type="integer"/>
-        <mibObj oid=".1.3.6.1.4.1.2021.11.8" instance="0" alias="SysContext" type="integer"/>
-        <mibObj oid=".1.3.6.1.4.1.2021.11.50" instance="0" alias="CpuRawUser" type="counter"/>
-        <mibObj oid=".1.3.6.1.4.1.2021.11.51" instance="0" alias="CpuRawNice" type="counter"/>
-        <mibObj oid=".1.3.6.1.4.1.2021.11.52" instance="0" alias="CpuRawSystem" type="counter"/>
-        <mibObj oid=".1.3.6.1.4.1.2021.11.53" instance="0" alias="CpuRawIdle" type="counter"/>
-        <mibObj oid=".1.3.6.1.4.1.2021.11.54" instance="0" alias="CpuRawWait" type="counter"/>
-        <mibObj oid=".1.3.6.1.4.1.2021.11.55" instance="0" alias="CpuRawKernel" type="counter"/>
-        <mibObj oid=".1.3.6.1.4.1.2021.11.56" instance="0" alias="CpuRawInterrupt" type="counter"/>
-        <mibObj oid=".1.3.6.1.4.1.2021.11.57" instance="0" alias="IORawSent" type="counter"/>
-        <mibObj oid=".1.3.6.1.4.1.2021.11.58" instance="0" alias="IORawReceived" type="counter"/>
-    </group>
-    <group name="ucd-sysstat-raw" ifType="ignore">
-        <mibObj oid=".1.3.6.1.4.1.2021.11.59" instance="0" alias="SysRawInterrupts" type="counter"/>
-        <mibObj oid=".1.3.6.1.4.1.2021.11.60" instance="0" alias="SysRawContext" type="counter"/>
-    </group>
-    <group name="ucd-sysstat-raw-more" ifType="ignore">
-        <mibObj oid=".1.3.6.1.4.1.2021.11.61" instance="0" alias="CpuRawSoftIRQ" type="counter"/>
-        <mibObj oid=".1.3.6.1.4.1.2021.11.62" instance="0" alias="RawBlksSwapIn" type="counter"/>
-        <mibObj oid=".1.3.6.1.4.1.2021.11.63" instance="0" alias="RawBlksSwapOut" type="counter"/>
-    </group>
-    <group name="ucd-diskio" ifType="all">
-        <mibObj oid=".1.3.6.1.4.1.2021.13.15.1.1.2" instance="diskIOIndex" alias="diskIODevice" type="string"/>
-        <mibObj oid=".1.3.6.1.4.1.2021.13.15.1.1.3" instance="diskIOIndex" alias="diskIONRead" type="counter"/>
-        <mibObj oid=".1.3.6.1.4.1.2021.13.15.1.1.4" instance="diskIOIndex" alias="diskIONWritten" type="counter"/>
-        <mibObj oid=".1.3.6.1.4.1.2021.13.15.1.1.5" instance="diskIOIndex" alias="diskIOReads" type="counter"/>
-        <mibObj oid=".1.3.6.1.4.1.2021.13.15.1.1.6" instance="diskIOIndex" alias="diskIOWrites" type="counter"/>
-    </group>
-    <group name="ucd-diskio-64bit" ifType="all">
-        <mibObj oid=".1.3.6.1.4.1.2021.13.15.1.1.12" instance="diskIOIndex" alias="diskIONReadX" type="Counter64"/>
-        <mibObj oid=".1.3.6.1.4.1.2021.13.15.1.1.13" instance="diskIOIndex" alias="diskIONWrittenX" type="Counter64"/>
-    </group>
-    <group name="ucd-diskio-load" ifType="all">
-        <mibObj oid=".1.3.6.1.4.1.2021.13.15.1.1.9" instance="diskIOIndex" alias="diskIOLA1" type="integer"/>
-        <mibObj oid=".1.3.6.1.4.1.2021.13.15.1.1.10" instance="diskIOIndex" alias="diskIOLA5" type="integer"/>
-        <mibObj oid=".1.3.6.1.4.1.2021.13.15.1.1.11" instance="diskIOIndex" alias="diskIOLA15" type="integer"/>
-    </group>
+   <resourceType name="diskIOIndex" label="Disk IO (UCD-SNMP MIB)" resourceLabel="${diskIODevice} (index ${index})">
+      <persistenceSelectorStrategy class="org.opennms.netmgt.collectd.PersistRegexSelectorStrategy">
+         <parameter key="match-expression" value="not(#diskIODevice matches '^(loop|ram).*')"/>
+      </persistenceSelectorStrategy>
+      <storageStrategy class="org.opennms.netmgt.dao.support.SiblingColumnStorageStrategy">
+         <parameter key="sibling-column-name" value="diskIODevice"/>
+         <parameter key="replace-all" value="s/^-//"/>
+         <parameter key="replace-all" value="s/\s//"/>
+         <parameter key="replace-all" value="s/:\\.*//"/>
+      </storageStrategy>
+   </resourceType>
+   <resourceType name="dskIndex" label="Disk Table Index (UCD-SNMP MIB)" resourceLabel="${ns-dskPath} (index ${index})">
+      <persistenceSelectorStrategy class="org.opennms.netmgt.collection.support.PersistAllSelectorStrategy"/>
+      <storageStrategy class="org.opennms.netmgt.dao.support.SiblingColumnStorageStrategy">
+         <parameter key="sibling-column-name" value="ns-dskPath"/>
+         <parameter key="replace-first" value="s/^-$/_root_fs/"/>
+         <parameter key="replace-all" value="s/^-//"/>
+         <parameter key="replace-all" value="s/\s//"/>
+         <parameter key="replace-all" value="s/:\\.*//"/>
+      </storageStrategy>
+   </resourceType>
+   <resourceType name="lmTempIndex" label="Hardware Sensors: Temperature (lmSensors MIB)" resourceLabel="${lms-tempdevice} (index ${index})">
+      <persistenceSelectorStrategy class="org.opennms.netmgt.collection.support.PersistAllSelectorStrategy"/>
+      <storageStrategy class="org.opennms.netmgt.collection.support.IndexStorageStrategy"/>
+   </resourceType>
+   <resourceType name="lmFanIndex" label="Hardware Sensors: Fan (lmSensors MIB)" resourceLabel="${lms-fandevice} (index ${index})">
+      <persistenceSelectorStrategy class="org.opennms.netmgt.collection.support.PersistAllSelectorStrategy"/>
+      <storageStrategy class="org.opennms.netmgt.collection.support.IndexStorageStrategy"/>
+   </resourceType>
+   <resourceType name="lmVoltIndex" label="Hardware Sensors: Voltage (lmSensors MIB)" resourceLabel="${lms-voltdevice} (index ${index})">
+      <persistenceSelectorStrategy class="org.opennms.netmgt.collection.support.PersistAllSelectorStrategy"/>
+      <storageStrategy class="org.opennms.netmgt.collection.support.IndexStorageStrategy"/>
+   </resourceType>
+   <group name="net-snmp-disk" ifType="all">
+      <mibObj oid=".1.3.6.1.4.1.2021.9.1.2" instance="dskIndex" alias="ns-dskPath" type="string"/>
+      <mibObj oid=".1.3.6.1.4.1.2021.9.1.6" instance="dskIndex" alias="ns-dskTotal" type="gauge"/>
+      <mibObj oid=".1.3.6.1.4.1.2021.9.1.7" instance="dskIndex" alias="ns-dskAvail" type="gauge"/>
+      <mibObj oid=".1.3.6.1.4.1.2021.9.1.8" instance="dskIndex" alias="ns-dskUsed" type="gauge"/>
+      <mibObj oid=".1.3.6.1.4.1.2021.9.1.9" instance="dskIndex" alias="ns-dskPercent" type="gauge"/>
+   </group>
+   <group name="net-snmp-disk-more" ifType="all">
+      <mibObj oid=".1.3.6.1.4.1.2021.9.1.3" instance="dskIndex" alias="ns-dskDevice" type="string"/>
+      <mibObj oid=".1.3.6.1.4.1.2021.9.1.10" instance="dskIndex" alias="ns-dskPercentNode" type="gauge"/>
+   </group>
+   <group name="net-snmp-disk-highlow" ifType="all">
+      <mibObj oid=".1.3.6.1.4.1.2021.9.1.11" instance="dskIndex" alias="ns-dskTotalLow" type="gauge"/>
+      <mibObj oid=".1.3.6.1.4.1.2021.9.1.12" instance="dskIndex" alias="ns-dskTotalHigh" type="gauge"/>
+      <mibObj oid=".1.3.6.1.4.1.2021.9.1.13" instance="dskIndex" alias="ns-dskAvailLow" type="gauge"/>
+      <mibObj oid=".1.3.6.1.4.1.2021.9.1.14" instance="dskIndex" alias="ns-dskAvailHigh" type="gauge"/>
+      <mibObj oid=".1.3.6.1.4.1.2021.9.1.15" instance="dskIndex" alias="ns-dskUsedLow" type="gauge"/>
+      <mibObj oid=".1.3.6.1.4.1.2021.9.1.16" instance="dskIndex" alias="ns-dskUsedHigh" type="gauge"/>
+   </group>
+   <group name="ucd-loadavg" ifType="ignore">
+      <mibObj oid=".1.3.6.1.4.1.2021.10.1.5" instance="1" alias="loadavg1" type="integer"/>
+      <mibObj oid=".1.3.6.1.4.1.2021.10.1.5" instance="2" alias="loadavg5" type="integer"/>
+      <mibObj oid=".1.3.6.1.4.1.2021.10.1.5" instance="3" alias="loadavg15" type="integer"/>
+   </group>
+   <group name="ucd-memory" ifType="ignore">
+      <!-- Total Swap Size configured for the host -->
+      <mibObj oid=".1.3.6.1.4.1.2021.4.3" instance="0" alias="memTotalSwap" type="integer"/>
+      <mibObj oid=".1.3.6.1.4.1.2021.4.4" instance="0" alias="memAvailSwap" type="integer"/>
+      <mibObj oid=".1.3.6.1.4.1.2021.4.5" instance="0" alias="memTotalReal" type="integer"/>
+      <mibObj oid=".1.3.6.1.4.1.2021.4.6" instance="0" alias="memAvailReal" type="integer"/>
+      <mibObj oid=".1.3.6.1.4.1.2021.4.11" instance="0" alias="memTotalFree" type="integer"/>
+      <mibObj oid=".1.3.6.1.4.1.2021.4.13" instance="0" alias="memShared" type="integer"/>
+      <mibObj oid=".1.3.6.1.4.1.2021.4.14" instance="0" alias="memBuffer" type="integer"/>
+      <mibObj oid=".1.3.6.1.4.1.2021.4.15" instance="0" alias="memCached" type="integer"/>
+      <!-- Error flag.  1 indicates very little swap space left -->
+      <mibObj oid=".1.3.6.1.4.1.2021.4.100" instance="0" alias="memSwapError" type="integer"/>
+   </group>
+   <group name="ucd-sysstat" ifType="ignore">
+      <mibObj oid=".1.3.6.1.4.1.2021.11.3" instance="0" alias="SwapIn" type="integer"/>
+      <mibObj oid=".1.3.6.1.4.1.2021.11.4" instance="0" alias="SwapOut" type="integer"/>
+      <mibObj oid=".1.3.6.1.4.1.2021.11.7" instance="0" alias="SysInterrupts" type="integer"/>
+      <mibObj oid=".1.3.6.1.4.1.2021.11.8" instance="0" alias="SysContext" type="integer"/>
+      <mibObj oid=".1.3.6.1.4.1.2021.11.50" instance="0" alias="CpuRawUser" type="counter"/>
+      <mibObj oid=".1.3.6.1.4.1.2021.11.51" instance="0" alias="CpuRawNice" type="counter"/>
+      <mibObj oid=".1.3.6.1.4.1.2021.11.52" instance="0" alias="CpuRawSystem" type="counter"/>
+      <mibObj oid=".1.3.6.1.4.1.2021.11.53" instance="0" alias="CpuRawIdle" type="counter"/>
+      <mibObj oid=".1.3.6.1.4.1.2021.11.54" instance="0" alias="CpuRawWait" type="counter"/>
+      <mibObj oid=".1.3.6.1.4.1.2021.11.55" instance="0" alias="CpuRawKernel" type="counter"/>
+      <mibObj oid=".1.3.6.1.4.1.2021.11.56" instance="0" alias="CpuRawInterrupt" type="counter"/>
+      <mibObj oid=".1.3.6.1.4.1.2021.11.57" instance="0" alias="IORawSent" type="counter"/>
+      <mibObj oid=".1.3.6.1.4.1.2021.11.58" instance="0" alias="IORawReceived" type="counter"/>
+   </group>
+   <group name="ucd-sysstat-raw" ifType="ignore">
+      <mibObj oid=".1.3.6.1.4.1.2021.11.59" instance="0" alias="SysRawInterrupts" type="counter"/>
+      <mibObj oid=".1.3.6.1.4.1.2021.11.60" instance="0" alias="SysRawContext" type="counter"/>
+   </group>
+   <group name="ucd-sysstat-raw-more" ifType="ignore">
+      <mibObj oid=".1.3.6.1.4.1.2021.11.61" instance="0" alias="CpuRawSoftIRQ" type="counter"/>
+      <mibObj oid=".1.3.6.1.4.1.2021.11.62" instance="0" alias="RawBlksSwapIn" type="counter"/>
+      <mibObj oid=".1.3.6.1.4.1.2021.11.63" instance="0" alias="RawBlksSwapOut" type="counter"/>
+   </group>
+   <group name="ucd-diskio" ifType="all">
+      <mibObj oid=".1.3.6.1.4.1.2021.13.15.1.1.2" instance="diskIOIndex" alias="diskIODevice" type="string"/>
+      <mibObj oid=".1.3.6.1.4.1.2021.13.15.1.1.3" instance="diskIOIndex" alias="diskIONRead" type="counter"/>
+      <mibObj oid=".1.3.6.1.4.1.2021.13.15.1.1.4" instance="diskIOIndex" alias="diskIONWritten" type="counter"/>
+      <mibObj oid=".1.3.6.1.4.1.2021.13.15.1.1.5" instance="diskIOIndex" alias="diskIOReads" type="counter"/>
+      <mibObj oid=".1.3.6.1.4.1.2021.13.15.1.1.6" instance="diskIOIndex" alias="diskIOWrites" type="counter"/>
+   </group>
 
-    <group name="lmsensors-temp" ifType="all">
-        <mibObj oid=".1.3.6.1.4.1.2021.13.16.2.1.2" instance="lmTempIndex" alias="lms-tempdevice" type="string"/>
-        <mibObj oid=".1.3.6.1.4.1.2021.13.16.2.1.3" instance="lmTempIndex" alias="lms-temp" type="gauge32"/>
-    </group>
-    <group name="lmsensors-fan" ifType="all">
-        <mibObj oid=".1.3.6.1.4.1.2021.13.16.3.1.2" instance="lmFanIndex" alias="lms-fandevice" type="string"/>
-        <mibObj oid=".1.3.6.1.4.1.2021.13.16.3.1.3" instance="lmFanIndex" alias="lms-fan" type="gauge32"/>
-    </group>
-    <group name="lmsensors-volt" ifType="all">
-        <mibObj oid=".1.3.6.1.4.1.2021.13.16.4.1.2" instance="lmVoltIndex" alias="lms-voltdevice" type="string"/>
-        <mibObj oid=".1.3.6.1.4.1.2021.13.16.4.1.3" instance="lmVoltIndex" alias="lms-volt" type="gauge32"/>
-    </group>
-    <systemDef name="Net-SNMP (UCD)">
-        <sysoidMask>.1.3.6.1.4.1.2021.250.</sysoidMask>
-        <collect>
-            <includeGroup>mib2-host-resources-system</includeGroup>
-            <includeGroup>mib2-host-resources-memory</includeGroup>
-            <includeGroup>mib2-host-resources-storage</includeGroup>
-            <includeGroup>net-snmp-disk</includeGroup>
-            <includeGroup>net-snmp-disk-more</includeGroup>
-            <includeGroup>net-snmp-disk-highlow</includeGroup>
-            <includeGroup>ucd-loadavg</includeGroup>
-            <includeGroup>ucd-memory</includeGroup>
-            <includeGroup>ucd-sysstat</includeGroup>
-            <includeGroup>ucd-sysstat-raw</includeGroup>
-            <includeGroup>ucd-sysstat-raw-more</includeGroup>
-            <includeGroup>ucd-diskio</includeGroup>
-            <includeGroup>ucd-diskio-64bit</includeGroup>
-            <includeGroup>ucd-diskio-load</includeGroup>
-            <includeGroup>lmsensors-temp</includeGroup>
-            <includeGroup>lmsensors-fan</includeGroup>
-            <includeGroup>lmsensors-volt</includeGroup>
-        </collect>
-    </systemDef>
-    <systemDef name="Net-SNMP">
-        <sysoidMask>.1.3.6.1.4.1.8072.3.</sysoidMask>
-        <collect>
-            <includeGroup>mib2-host-resources-system</includeGroup>
-            <includeGroup>mib2-host-resources-memory</includeGroup>
-            <includeGroup>mib2-host-resources-storage</includeGroup>
-            <includeGroup>mib2-X-interfaces</includeGroup>
-            <includeGroup>mib2-X-interfaces-pkts</includeGroup>
-            <includeGroup>net-snmp-disk</includeGroup>
-            <includeGroup>net-snmp-disk-more</includeGroup>
-            <includeGroup>net-snmp-disk-highlow</includeGroup>
-            <includeGroup>openmanage-coolingdevices</includeGroup>
-            <includeGroup>openmanage-temperatureprobe</includeGroup>
-            <includeGroup>openmanage-powerusage</includeGroup>
-            <includeGroup>ucd-loadavg</includeGroup>
-            <includeGroup>ucd-memory</includeGroup>
-            <includeGroup>ucd-sysstat</includeGroup>
-            <includeGroup>ucd-sysstat-raw</includeGroup>
-            <includeGroup>ucd-sysstat-raw-more</includeGroup>
-            <includeGroup>ucd-diskio</includeGroup>
-            <includeGroup>ucd-diskio-64bit</includeGroup>
-            <includeGroup>ucd-diskio-load</includeGroup>
-            <includeGroup>lmsensors-temp</includeGroup>
-            <includeGroup>lmsensors-fan</includeGroup>
-            <includeGroup>lmsensors-volt</includeGroup>
-        </collect>
-    </systemDef>
-    <systemDef name="Net-SNMP 5.5 with sysObjectID bug on i386">
-        <sysoid>.1.3</sysoid>
-        <collect>
-            <includeGroup>mib2-interfaces</includeGroup>
-            <includeGroup>mib2-tcp</includeGroup>
-            <includeGroup>mib2-powerethernet</includeGroup>
-            <includeGroup>mib2-host-resources-system</includeGroup>
-            <includeGroup>mib2-host-resources-memory</includeGroup>
-            <includeGroup>mib2-X-interfaces</includeGroup>
-            <includeGroup>mib2-X-interfaces-pkts</includeGroup>
-            <includeGroup>net-snmp-disk</includeGroup>
-            <includeGroup>net-snmp-disk-more</includeGroup>
-            <includeGroup>net-snmp-disk-highlow</includeGroup>
-            <includeGroup>openmanage-coolingdevices</includeGroup>
-            <includeGroup>openmanage-temperatureprobe</includeGroup>
-            <includeGroup>openmanage-powerusage</includeGroup>
-            <includeGroup>ucd-loadavg</includeGroup>
-            <includeGroup>ucd-memory</includeGroup>
-            <includeGroup>ucd-sysstat</includeGroup>
-            <includeGroup>ucd-sysstat-raw</includeGroup>
-            <includeGroup>ucd-sysstat-raw-more</includeGroup>
-            <includeGroup>ucd-diskio</includeGroup>
-            <includeGroup>ucd-diskio-64bit</includeGroup>
-            <includeGroup>ucd-diskio-load</includeGroup>
-            <includeGroup>lmsensors-temp</includeGroup>
-            <includeGroup>lmsensors-fan</includeGroup>
-            <includeGroup>lmsensors-volt</includeGroup>
-        </collect>
-    </systemDef>
-    <systemDef name="Net-SNMP 5.5 with sysObjectID bug on x86_64">
-        <sysoid>.0.1</sysoid>
-        <collect>
-            <includeGroup>mib2-interfaces</includeGroup>
-            <includeGroup>mib2-tcp</includeGroup>
-            <includeGroup>mib2-powerethernet</includeGroup>
-            <includeGroup>mib2-host-resources-system</includeGroup>
-            <includeGroup>mib2-host-resources-memory</includeGroup>
-            <includeGroup>mib2-X-interfaces</includeGroup>
-            <includeGroup>mib2-X-interfaces-pkts</includeGroup>
-            <includeGroup>net-snmp-disk</includeGroup>
-            <includeGroup>net-snmp-disk-more</includeGroup>
-            <includeGroup>net-snmp-disk-highlow</includeGroup>
-            <includeGroup>openmanage-coolingdevices</includeGroup>
-            <includeGroup>openmanage-temperatureprobe</includeGroup>
-            <includeGroup>openmanage-powerusage</includeGroup>
-            <includeGroup>ucd-loadavg</includeGroup>
-            <includeGroup>ucd-memory</includeGroup>
-            <includeGroup>ucd-sysstat</includeGroup>
-            <includeGroup>ucd-sysstat-raw</includeGroup>
-            <includeGroup>ucd-sysstat-raw-more</includeGroup>
-            <includeGroup>ucd-diskio</includeGroup>
-            <includeGroup>ucd-diskio-64bit</includeGroup>
-            <includeGroup>ucd-diskio-load</includeGroup>
-            <includeGroup>lmsensors-temp</includeGroup>
-            <includeGroup>lmsensors-fan</includeGroup>
-            <includeGroup>lmsensors-volt</includeGroup>
-        </collect>
-    </systemDef>
+   <group name="ucd-diskio-64bit" ifType="all">
+      <mibObj oid=".1.3.6.1.4.1.2021.13.15.1.1.12" instance="diskIOIndex" alias="diskIONReadX" type="Counter64"/>
+      <mibObj oid=".1.3.6.1.4.1.2021.13.15.1.1.13" instance="diskIOIndex" alias="diskIONWrittenX" type="Counter64"/>
+   </group>
+
+   <group name="ucd-diskio-load" ifType="all">
+      <mibObj oid=".1.3.6.1.4.1.2021.13.15.1.1.9" instance="diskIOIndex" alias="diskIOLA1" type="integer"/>
+      <mibObj oid=".1.3.6.1.4.1.2021.13.15.1.1.10" instance="diskIOIndex" alias="diskIOLA5" type="integer"/>
+      <mibObj oid=".1.3.6.1.4.1.2021.13.15.1.1.11" instance="diskIOIndex" alias="diskIOLA15" type="integer"/>
+   </group>
+
+   <group name="lmsensors-temp" ifType="all">
+      <mibObj oid=".1.3.6.1.4.1.2021.13.16.2.1.2" instance="lmTempIndex" alias="lms-tempdevice" type="string"/>
+      <mibObj oid=".1.3.6.1.4.1.2021.13.16.2.1.3" instance="lmTempIndex" alias="lms-temp" type="gauge32"/>
+   </group>
+   <group name="lmsensors-fan" ifType="all">
+      <mibObj oid=".1.3.6.1.4.1.2021.13.16.3.1.2" instance="lmFanIndex" alias="lms-fandevice" type="string"/>
+      <mibObj oid=".1.3.6.1.4.1.2021.13.16.3.1.3" instance="lmFanIndex" alias="lms-fan" type="gauge32"/>
+   </group>
+   <group name="lmsensors-volt" ifType="all">
+      <mibObj oid=".1.3.6.1.4.1.2021.13.16.4.1.2" instance="lmVoltIndex" alias="lms-voltdevice" type="string"/>
+      <mibObj oid=".1.3.6.1.4.1.2021.13.16.4.1.3" instance="lmVoltIndex" alias="lms-volt" type="gauge32"/>
+   </group>
+   <systemDef name="Net-SNMP (UCD)">
+      <sysoidMask>.1.3.6.1.4.1.2021.250.</sysoidMask>
+      <collect>
+         <includeGroup>mib2-host-resources-system</includeGroup>
+         <includeGroup>mib2-host-resources-memory</includeGroup>
+         <includeGroup>mib2-host-resources-storage</includeGroup>
+         <includeGroup>net-snmp-disk</includeGroup>
+         <includeGroup>net-snmp-disk-more</includeGroup>
+         <includeGroup>net-snmp-disk-highlow</includeGroup>
+         <includeGroup>ucd-loadavg</includeGroup>
+         <includeGroup>ucd-memory</includeGroup>
+         <includeGroup>ucd-sysstat</includeGroup>
+         <includeGroup>ucd-sysstat-raw</includeGroup>
+         <includeGroup>ucd-sysstat-raw-more</includeGroup>
+         <includeGroup>ucd-diskio</includeGroup>
+         <includeGroup>ucd-diskio-64bit</includeGroup>
+         <includeGroup>ucd-diskio-load</includeGroup>
+         <includeGroup>lmsensors-temp</includeGroup>
+         <includeGroup>lmsensors-fan</includeGroup>
+         <includeGroup>lmsensors-volt</includeGroup>
+      </collect>
+   </systemDef>
+   <systemDef name="Net-SNMP">
+      <sysoidMask>.1.3.6.1.4.1.8072.3.</sysoidMask>
+      <collect>
+         <includeGroup>mib2-host-resources-system</includeGroup>
+         <includeGroup>mib2-host-resources-memory</includeGroup>
+         <includeGroup>mib2-host-resources-storage</includeGroup>
+         <includeGroup>mib2-X-interfaces</includeGroup>
+         <includeGroup>mib2-X-interfaces-pkts</includeGroup>
+         <includeGroup>net-snmp-disk</includeGroup>
+         <includeGroup>net-snmp-disk-more</includeGroup>
+         <includeGroup>net-snmp-disk-highlow</includeGroup>
+         <includeGroup>openmanage-coolingdevices</includeGroup>
+         <includeGroup>openmanage-temperatureprobe</includeGroup>
+         <includeGroup>openmanage-powerusage</includeGroup>
+         <includeGroup>ucd-loadavg</includeGroup>
+         <includeGroup>ucd-memory</includeGroup>
+         <includeGroup>ucd-sysstat</includeGroup>
+         <includeGroup>ucd-sysstat-raw</includeGroup>
+         <includeGroup>ucd-sysstat-raw-more</includeGroup>
+         <includeGroup>ucd-diskio</includeGroup>
+         <includeGroup>ucd-diskio-64bit</includeGroup>
+         <includeGroup>ucd-diskio-load</includeGroup>
+         <includeGroup>lmsensors-temp</includeGroup>
+         <includeGroup>lmsensors-fan</includeGroup>
+         <includeGroup>lmsensors-volt</includeGroup>
+      </collect>
+   </systemDef>
+   <systemDef name="Net-SNMP 5.5 with sysObjectID bug on i386">
+      <sysoid>.1.3</sysoid>
+      <collect>
+         <includeGroup>mib2-interfaces</includeGroup>
+         <includeGroup>mib2-tcp</includeGroup>
+         <includeGroup>mib2-powerethernet</includeGroup>
+         <includeGroup>mib2-host-resources-system</includeGroup>
+         <includeGroup>mib2-host-resources-memory</includeGroup>
+         <includeGroup>mib2-X-interfaces</includeGroup>
+         <includeGroup>mib2-X-interfaces-pkts</includeGroup>
+         <includeGroup>net-snmp-disk</includeGroup>
+         <includeGroup>net-snmp-disk-more</includeGroup>
+         <includeGroup>net-snmp-disk-highlow</includeGroup>
+         <includeGroup>openmanage-coolingdevices</includeGroup>
+         <includeGroup>openmanage-temperatureprobe</includeGroup>
+         <includeGroup>openmanage-powerusage</includeGroup>
+         <includeGroup>ucd-loadavg</includeGroup>
+         <includeGroup>ucd-memory</includeGroup>
+         <includeGroup>ucd-sysstat</includeGroup>
+         <includeGroup>ucd-sysstat-raw</includeGroup>
+         <includeGroup>ucd-sysstat-raw-more</includeGroup>
+         <includeGroup>ucd-diskio</includeGroup>
+         <includeGroup>ucd-diskio-64bit</includeGroup>
+         <includeGroup>ucd-diskio-load</includeGroup>
+         <includeGroup>lmsensors-temp</includeGroup>
+         <includeGroup>lmsensors-fan</includeGroup>
+         <includeGroup>lmsensors-volt</includeGroup>
+      </collect>
+   </systemDef>
+   <systemDef name="Net-SNMP 5.5 with sysObjectID bug on x86_64">
+      <sysoid>.0.1</sysoid>
+      <collect>
+         <includeGroup>mib2-interfaces</includeGroup>
+         <includeGroup>mib2-tcp</includeGroup>
+         <includeGroup>mib2-powerethernet</includeGroup>
+         <includeGroup>mib2-host-resources-system</includeGroup>
+         <includeGroup>mib2-host-resources-memory</includeGroup>
+         <includeGroup>mib2-X-interfaces</includeGroup>
+         <includeGroup>mib2-X-interfaces-pkts</includeGroup>
+         <includeGroup>net-snmp-disk</includeGroup>
+         <includeGroup>net-snmp-disk-more</includeGroup>
+         <includeGroup>net-snmp-disk-highlow</includeGroup>
+         <includeGroup>openmanage-coolingdevices</includeGroup>
+         <includeGroup>openmanage-temperatureprobe</includeGroup>
+         <includeGroup>openmanage-powerusage</includeGroup>
+         <includeGroup>ucd-loadavg</includeGroup>
+         <includeGroup>ucd-memory</includeGroup>
+         <includeGroup>ucd-sysstat</includeGroup>
+         <includeGroup>ucd-sysstat-raw</includeGroup>
+         <includeGroup>ucd-sysstat-raw-more</includeGroup>
+         <includeGroup>ucd-diskio</includeGroup>
+         <includeGroup>ucd-diskio-64bit</includeGroup>
+         <includeGroup>ucd-diskio-load</includeGroup>
+         <includeGroup>lmsensors-temp</includeGroup>
+         <includeGroup>lmsensors-fan</includeGroup>
+         <includeGroup>lmsensors-volt</includeGroup>
+      </collect>
+   </systemDef>
 </datacollection-group>

--- a/opennms-base-assembly/src/main/filtered/etc/datacollection/netsnmp.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/datacollection/netsnmp.xml
@@ -94,11 +94,16 @@
       <mibObj oid=".1.3.6.1.4.1.2021.11.63" instance="0" alias="RawBlksSwapOut" type="counter"/>
    </group>
    <group name="ucd-diskio" ifType="all">
-      <mibObj oid=".1.3.6.1.4.1.2021.13.15.1.1.2" instance="diskIOIndex" alias="diskIODevice" type="string"/>
-      <mibObj oid=".1.3.6.1.4.1.2021.13.15.1.1.3" instance="diskIOIndex" alias="diskIONRead" type="counter"/>
-      <mibObj oid=".1.3.6.1.4.1.2021.13.15.1.1.4" instance="diskIOIndex" alias="diskIONWritten" type="counter"/>
-      <mibObj oid=".1.3.6.1.4.1.2021.13.15.1.1.5" instance="diskIOIndex" alias="diskIOReads" type="counter"/>
-      <mibObj oid=".1.3.6.1.4.1.2021.13.15.1.1.6" instance="diskIOIndex" alias="diskIOWrites" type="counter"/>
+      <mibObj oid=".1.3.6.1.4.1.2021.13.15.1.1.2" instance="diskIOIndex" alias="diskIODevice" type="string" />
+      <mibObj oid=".1.3.6.1.4.1.2021.13.15.1.1.3" instance="diskIOIndex" alias="diskIONRead" type="counter" />
+      <mibObj oid=".1.3.6.1.4.1.2021.13.15.1.1.4" instance="diskIOIndex" alias="diskIONWritten" type="counter" />
+      <mibObj oid=".1.3.6.1.4.1.2021.13.15.1.1.5" instance="diskIOIndex" alias="diskIOReads" type="counter" />
+      <mibObj oid=".1.3.6.1.4.1.2021.13.15.1.1.6" instance="diskIOIndex" alias="diskIOWrites" type="counter" />
+      <mibObj oid=".1.3.6.1.4.1.2021.13.15.1.1.9" instance="diskIOIndex" alias="diskIOLA1" type="integer" />
+      <mibObj oid=".1.3.6.1.4.1.2021.13.15.1.1.10" instance="diskIOIndex" alias="diskIOLA5" type="integer" />
+      <mibObj oid=".1.3.6.1.4.1.2021.13.15.1.1.11" instance="diskIOIndex" alias="diskIOLA15" type="integer" />
+      <mibObj oid=".1.3.6.1.4.1.2021.13.15.1.1.12" instance="diskIOIndex" alias="diskIONReadX" type="Counter64" />
+      <mibObj oid=".1.3.6.1.4.1.2021.13.15.1.1.13" instance="diskIOIndex" alias="diskIONWrittenX" type="Counter64" />
    </group>
    <group name="lmsensors-temp" ifType="all">
       <mibObj oid=".1.3.6.1.4.1.2021.13.16.2.1.2" instance="lmTempIndex" alias="lms-tempdevice" type="string"/>
@@ -126,6 +131,7 @@
          <includeGroup>ucd-sysstat</includeGroup>
          <includeGroup>ucd-sysstat-raw</includeGroup>
          <includeGroup>ucd-sysstat-raw-more</includeGroup>
+         <includeGroup>ucd-diskio</includeGroup>
          <includeGroup>lmsensors-temp</includeGroup>
          <includeGroup>lmsensors-fan</includeGroup>
          <includeGroup>lmsensors-volt</includeGroup>
@@ -150,6 +156,7 @@
          <includeGroup>ucd-sysstat</includeGroup>
          <includeGroup>ucd-sysstat-raw</includeGroup>
          <includeGroup>ucd-sysstat-raw-more</includeGroup>
+         <includeGroup>ucd-diskio</includeGroup>
          <includeGroup>lmsensors-temp</includeGroup>
          <includeGroup>lmsensors-fan</includeGroup>
          <includeGroup>lmsensors-volt</includeGroup>
@@ -176,6 +183,7 @@
          <includeGroup>ucd-sysstat</includeGroup>
          <includeGroup>ucd-sysstat-raw</includeGroup>
          <includeGroup>ucd-sysstat-raw-more</includeGroup>
+         <includeGroup>ucd-diskio</includeGroup>
          <includeGroup>lmsensors-temp</includeGroup>
          <includeGroup>lmsensors-fan</includeGroup>
          <includeGroup>lmsensors-volt</includeGroup>
@@ -202,6 +210,7 @@
          <includeGroup>ucd-sysstat</includeGroup>
          <includeGroup>ucd-sysstat-raw</includeGroup>
          <includeGroup>ucd-sysstat-raw-more</includeGroup>
+         <includeGroup>ucd-diskio</includeGroup>
          <includeGroup>lmsensors-temp</includeGroup>
          <includeGroup>lmsensors-fan</includeGroup>
          <includeGroup>lmsensors-volt</includeGroup>

--- a/opennms-base-assembly/src/main/filtered/etc/datacollection/netsnmp.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/datacollection/netsnmp.xml
@@ -103,12 +103,17 @@
         <mibObj oid=".1.3.6.1.4.1.2021.13.15.1.1.4" instance="diskIOIndex" alias="diskIONWritten" type="counter"/>
         <mibObj oid=".1.3.6.1.4.1.2021.13.15.1.1.5" instance="diskIOIndex" alias="diskIOReads" type="counter"/>
         <mibObj oid=".1.3.6.1.4.1.2021.13.15.1.1.6" instance="diskIOIndex" alias="diskIOWrites" type="counter"/>
-        <mibObj oid=".1.3.6.1.4.1.2021.13.15.1.1.9" instance="diskIOIndex" alias="diskIOLA1" type="integer"/>
-        <mibObj oid=".1.3.6.1.4.1.2021.13.15.1.1.10" instance="diskIOIndex" alias="diskIOLA5" type="integer"/>
-        <mibObj oid=".1.3.6.1.4.1.2021.13.15.1.1.11" instance="diskIOIndex" alias="diskIOLA15" type="integer"/>
+    </group>
+    <group name="ucd-diskio-64bit" ifType="all">
         <mibObj oid=".1.3.6.1.4.1.2021.13.15.1.1.12" instance="diskIOIndex" alias="diskIONReadX" type="Counter64"/>
         <mibObj oid=".1.3.6.1.4.1.2021.13.15.1.1.13" instance="diskIOIndex" alias="diskIONWrittenX" type="Counter64"/>
     </group>
+    <group name="ucd-diskio-load" ifType="all">
+        <mibObj oid=".1.3.6.1.4.1.2021.13.15.1.1.9" instance="diskIOIndex" alias="diskIOLA1" type="integer"/>
+        <mibObj oid=".1.3.6.1.4.1.2021.13.15.1.1.10" instance="diskIOIndex" alias="diskIOLA5" type="integer"/>
+        <mibObj oid=".1.3.6.1.4.1.2021.13.15.1.1.11" instance="diskIOIndex" alias="diskIOLA15" type="integer"/>
+    </group>
+
     <group name="lmsensors-temp" ifType="all">
         <mibObj oid=".1.3.6.1.4.1.2021.13.16.2.1.2" instance="lmTempIndex" alias="lms-tempdevice" type="string"/>
         <mibObj oid=".1.3.6.1.4.1.2021.13.16.2.1.3" instance="lmTempIndex" alias="lms-temp" type="gauge32"/>
@@ -136,6 +141,8 @@
             <includeGroup>ucd-sysstat-raw</includeGroup>
             <includeGroup>ucd-sysstat-raw-more</includeGroup>
             <includeGroup>ucd-diskio</includeGroup>
+            <includeGroup>ucd-diskio-64bit</includeGroup>
+            <includeGroup>ucd-diskio-load</includeGroup>
             <includeGroup>lmsensors-temp</includeGroup>
             <includeGroup>lmsensors-fan</includeGroup>
             <includeGroup>lmsensors-volt</includeGroup>
@@ -161,6 +168,8 @@
             <includeGroup>ucd-sysstat-raw</includeGroup>
             <includeGroup>ucd-sysstat-raw-more</includeGroup>
             <includeGroup>ucd-diskio</includeGroup>
+            <includeGroup>ucd-diskio-64bit</includeGroup>
+            <includeGroup>ucd-diskio-load</includeGroup>
             <includeGroup>lmsensors-temp</includeGroup>
             <includeGroup>lmsensors-fan</includeGroup>
             <includeGroup>lmsensors-volt</includeGroup>
@@ -188,6 +197,8 @@
             <includeGroup>ucd-sysstat-raw</includeGroup>
             <includeGroup>ucd-sysstat-raw-more</includeGroup>
             <includeGroup>ucd-diskio</includeGroup>
+            <includeGroup>ucd-diskio-64bit</includeGroup>
+            <includeGroup>ucd-diskio-load</includeGroup>
             <includeGroup>lmsensors-temp</includeGroup>
             <includeGroup>lmsensors-fan</includeGroup>
             <includeGroup>lmsensors-volt</includeGroup>
@@ -215,6 +226,8 @@
             <includeGroup>ucd-sysstat-raw</includeGroup>
             <includeGroup>ucd-sysstat-raw-more</includeGroup>
             <includeGroup>ucd-diskio</includeGroup>
+            <includeGroup>ucd-diskio-64bit</includeGroup>
+            <includeGroup>ucd-diskio-load</includeGroup>
             <includeGroup>lmsensors-temp</includeGroup>
             <includeGroup>lmsensors-fan</includeGroup>
             <includeGroup>lmsensors-volt</includeGroup>

--- a/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/netsnmp-graph.properties
+++ b/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/netsnmp-graph.properties
@@ -24,8 +24,13 @@ netsnmp.cpuUsageFull, \
 netsnmp.cpuStats, \
 netsnmp.cpuStatsFull, \
 netsnmp.diskio.bytes, \
+netsnmp.diskio.bytesx, \
 netsnmp.diskio.ops, \
-netsnmp.diskio.opsize
+netsnmp.diskio.opsize, \
+netsnmp.diskio.load1, \
+netsnmp.diskio.load5, \
+netsnmp.diskio.load15, \
+netsnmp.diskio.load.stats
 
 ######
 ###### Reports Generated from NET-SNMP agents
@@ -312,11 +317,32 @@ report.netsnmp.diskio.bytes.command=--title="Disk IO Bytes" \
  DEF:nread={rrd1}:diskIONRead:AVERAGE \
  DEF:nwritten={rrd2}:diskIONWritten:AVERAGE \
  CDEF:nwritteninv=nwritten,-1,* \
- AREA:nread#00ff00:"Read" \
+ AREA:nread#73d216: \
+ LINE1:nread#4e9a06:"Read   " \
  GPRINT:nread:AVERAGE:"Avg \\: %10.2lf %s" \
  GPRINT:nread:MIN:"Min \\: %10.2lf %s" \
  GPRINT:nread:MAX:"Max \\: %10.2lf %s\\n" \
- AREA:nwritteninv#0000ff:"Written" \
+ AREA:nwritteninv#3465a4: \
+ LINE1:nwritteninv#204a87:"Written" \
+ GPRINT:nwritten:AVERAGE:"Avg \\: %10.2lf %s" \
+ GPRINT:nwritten:MIN:"Min \\: %10.2lf %s" \
+ GPRINT:nwritten:MAX:"Max \\: %10.2lf %s\\n"
+
+report.netsnmp.diskio.bytesx.name=Disk IO Bytes (64bit)
+report.netsnmp.diskio.bytesx.columns=diskIONReadX,diskIONWrittenX
+report.netsnmp.diskio.bytesx.suppress=netsnmp.diskio.bytes
+report.netsnmp.diskio.bytesx.type=diskIOIndex
+report.netsnmp.diskio.bytesx.command=--title="Disk IO Bytes (64bit)" \
+ DEF:nread={rrd1}:diskIONReadX:AVERAGE \
+ DEF:nwritten={rrd2}:diskIONWrittenX:AVERAGE \
+ CDEF:nwritteninv=nwritten,-1,* \
+ AREA:nread#73d216: \
+ LINE1:nread#4e9a06:"Read   " \
+ GPRINT:nread:AVERAGE:"Avg \\: %10.2lf %s" \
+ GPRINT:nread:MIN:"Min \\: %10.2lf %s" \
+ GPRINT:nread:MAX:"Max \\: %10.2lf %s\\n" \
+ AREA:nwritteninv#3465a4: \
+ LINE1:nwritteninv#204a87:"Written" \
  GPRINT:nwritten:AVERAGE:"Avg \\: %10.2lf %s" \
  GPRINT:nwritten:MIN:"Min \\: %10.2lf %s" \
  GPRINT:nwritten:MAX:"Max \\: %10.2lf %s\\n"
@@ -328,11 +354,13 @@ report.netsnmp.diskio.ops.command=--title="Disk IO Operations" \
  DEF:reads={rrd1}:diskIOReads:AVERAGE \
  DEF:writes={rrd2}:diskIOWrites:AVERAGE \
  CDEF:writesinv=writes,-1,* \
- AREA:reads#00ff00:"Reads" \
+ AREA:reads#73d216: \
+ LINE1:reads#4e9a06:"Read  " \
  GPRINT:reads:AVERAGE:"Avg \\: %10.2lf %s" \
  GPRINT:reads:MIN:"Min \\: %10.2lf %s" \
  GPRINT:reads:MAX:"Max \\: %10.2lf %s\\n" \
- AREA:writesinv#0000ff:"Writes" \
+ AREA:writesinv#3465a4: \
+ LINE1:writesinv#204a87:"Writes" \
  GPRINT:writes:AVERAGE:"Avg \\: %10.2lf %s" \
  GPRINT:writes:MIN:"Min \\: %10.2lf %s" \
  GPRINT:writes:MAX:"Max \\: %10.2lf %s\\n"
@@ -348,11 +376,13 @@ report.netsnmp.diskio.opsize.command=--title="Disk IO Size" \
  CDEF:readsize=nread,reads,/ \
  CDEF:writesize=nwritten,writes,/ \
  CDEF:writesizeinv=nwritten,writes,/,-1,* \
- AREA:readsize#00ff00:"Read Size" \
+ AREA:readsize#73d216: \
+ LINE1:readsize#4e9a06:"Read Size " \
  GPRINT:readsize:AVERAGE:"Avg \\: %10.2lf %s" \
  GPRINT:readsize:MIN:"Min \\: %10.2lf %s" \
  GPRINT:readsize:MAX:"Max \\: %10.2lf %s\\n" \
- AREA:writesizeinv#0000ff:"Write Size" \
+ AREA:writesizeinv#3465a4: \
+ LINE1:writesizeinv#204a87:"Write Size" \
  GPRINT:writesize:AVERAGE:"Avg \\: %10.2lf %s" \
  GPRINT:writesize:MIN:"Min \\: %10.2lf %s" \
  GPRINT:writesize:MAX:"Max \\: %10.2lf %s\\n"
@@ -672,3 +702,139 @@ report.netsnmp.swapinout.command=--title="Swap" \
  GPRINT:floatout:AVERAGE:"Avg \\: %10.2lf %s" \
  GPRINT:floatout:MIN:"Min \\: %10.2lf %s" \
  GPRINT:floatout:MAX:"Max \\: %10.2lf %s\\n"
+
+report.netsnmp.diskio.load1.name="Disk IO Load Average 1 minute"
+report.netsnmp.diskio.load1.columns=diskIOLA1
+report.netsnmp.diskio.load1.type=diskIOIndex
+report.netsnmp.diskio.load1.command=--title="Disk IO Load Average 1 minute" \
+ --vertical-label="percent" \
+ --lower-limit 0 \
+ --upper-limit 105 \
+ DEF:usage={rrd1}:diskIOLA1:AVERAGE \
+ CDEF:usage10=0,usage,GE,0,usage,IF \
+ CDEF:usage20=10,usage,GT,0,usage,IF \
+ CDEF:usage30=20,usage,GT,0,usage,IF \
+ CDEF:usage40=30,usage,GT,0,usage,IF \
+ CDEF:usage50=40,usage,GT,0,usage,IF \
+ CDEF:usage60=50,usage,GT,0,usage,IF \
+ CDEF:usage70=60,usage,GT,0,usage,IF \
+ CDEF:usage80=70,usage,GT,0,usage,IF \
+ CDEF:usage90=80,usage,GT,0,usage,IF \
+ CDEF:usage100=90,usage,GT,0,usage,IF \
+ COMMENT:"\\n" \
+ AREA:usage10#5ca53f:" 0-10%" \
+ AREA:usage20#75b731:"11-20%" \
+ AREA:usage30#90c22f:"21-30%" \
+ AREA:usage40#b8d029:"31-40%" \
+ AREA:usage50#e4e11e:"41-50%" \
+ COMMENT:"\\n" \
+ AREA:usage60#fee610:"51-60%" \
+ AREA:usage70#f4bd1b:"61-70%" \
+ AREA:usage80#eaa322:"71-80%" \
+ AREA:usage90#de6822:"81-90%" \
+ AREA:usage100#d94c20:"91-100%" \
+ COMMENT:"\\n" \
+ COMMENT:" " \
+ COMMENT:"\\n" \
+ LINE1:usage#2e3436:"Disk IO Load in %\\:" \
+ GPRINT:usage:AVERAGE:"Avg\\: %6.2lf %s " \
+ GPRINT:usage:MIN:"Min\\: %6.2lf %s " \
+ GPRINT:usage:MAX:"Max\\: %6.2lf %s \\n"
+
+report.netsnmp.diskio.load5.name="Disk IO Load Average 5 minutes"
+report.netsnmp.diskio.load5.columns=diskIOLA5
+report.netsnmp.diskio.load5.type=diskIOIndex
+report.netsnmp.diskio.load5.command=--title="Disk IO Load Average 5 minutes" \
+ --vertical-label="percent" \
+ --lower-limit 0 \
+ --upper-limit 105 \
+ DEF:usage={rrd1}:diskIOLA5:AVERAGE \
+ CDEF:usage10=0,usage,GE,0,usage,IF \
+ CDEF:usage20=10,usage,GT,0,usage,IF \
+ CDEF:usage30=20,usage,GT,0,usage,IF \
+ CDEF:usage40=30,usage,GT,0,usage,IF \
+ CDEF:usage50=40,usage,GT,0,usage,IF \
+ CDEF:usage60=50,usage,GT,0,usage,IF \
+ CDEF:usage70=60,usage,GT,0,usage,IF \
+ CDEF:usage80=70,usage,GT,0,usage,IF \
+ CDEF:usage90=80,usage,GT,0,usage,IF \
+ CDEF:usage100=90,usage,GT,0,usage,IF \
+ COMMENT:"\\n" \
+ AREA:usage10#5ca53f:" 0-10%" \
+ AREA:usage20#75b731:"11-20%" \
+ AREA:usage30#90c22f:"21-30%" \
+ AREA:usage40#b8d029:"31-40%" \
+ AREA:usage50#e4e11e:"41-50%" \
+ COMMENT:"\\n" \
+ AREA:usage60#fee610:"51-60%" \
+ AREA:usage70#f4bd1b:"61-70%" \
+ AREA:usage80#eaa322:"71-80%" \
+ AREA:usage90#de6822:"81-90%" \
+ AREA:usage100#d94c20:"91-100%" \
+ COMMENT:"\\n" \
+ COMMENT:" " \
+ COMMENT:"\\n" \
+ LINE1:usage#2e3436:"Disk IO Load in %\\:" \
+ GPRINT:usage:AVERAGE:"Avg\\: %6.2lf %s " \
+ GPRINT:usage:MIN:"Min\\: %6.2lf %s " \
+ GPRINT:usage:MAX:"Max\\: %6.2lf %s \\n"
+
+report.netsnmp.diskio.load15.name="Disk IO Load Average 15 minutes"
+report.netsnmp.diskio.load15.columns=diskIOLA15
+report.netsnmp.diskio.load15.type=diskIOIndex
+report.netsnmp.diskio.load15.command=--title="Disk IO Load Average 15 minutes" \
+ --vertical-label="percent" \
+ --lower-limit 0 \
+ --upper-limit 105 \
+ DEF:usage={rrd1}:diskIOLA15:AVERAGE \
+ CDEF:usage10=0,usage,GE,0,usage,IF \
+ CDEF:usage20=10,usage,GT,0,usage,IF \
+ CDEF:usage30=20,usage,GT,0,usage,IF \
+ CDEF:usage40=30,usage,GT,0,usage,IF \
+ CDEF:usage50=40,usage,GT,0,usage,IF \
+ CDEF:usage60=50,usage,GT,0,usage,IF \
+ CDEF:usage70=60,usage,GT,0,usage,IF \
+ CDEF:usage80=70,usage,GT,0,usage,IF \
+ CDEF:usage90=80,usage,GT,0,usage,IF \
+ CDEF:usage100=90,usage,GT,0,usage,IF \
+ COMMENT:"\\n" \
+ AREA:usage10#5ca53f:" 0-10%" \
+ AREA:usage20#75b731:"11-20%" \
+ AREA:usage30#90c22f:"21-30%" \
+ AREA:usage40#b8d029:"31-40%" \
+ AREA:usage50#e4e11e:"41-50%" \
+ COMMENT:"\\n" \
+ AREA:usage60#fee610:"51-60%" \
+ AREA:usage70#f4bd1b:"61-70%" \
+ AREA:usage80#eaa322:"71-80%" \
+ AREA:usage90#de6822:"81-90%" \
+ AREA:usage100#d94c20:"91-100%" \
+ COMMENT:"\\n" \
+ COMMENT:" " \
+ COMMENT:"\\n" \
+ LINE1:usage#2e3436:"Disk IO Load in %\\:" \
+ GPRINT:usage:AVERAGE:"Avg\\: %6.2lf %s " \
+ GPRINT:usage:MIN:"Min\\: %6.2lf %s " \
+ GPRINT:usage:MAX:"Max\\: %6.2lf %s \\n"
+
+report.netsnmp.diskio.load.stats.name=Disk IO Load Average
+report.netsnmp.diskio.load.stats.columns=diskIOLA1, diskIOLA5, diskIOLA15
+report.netsnmp.diskio.load.stats.type=diskIOIndex
+report.netsnmp.diskio.load.stats.command=--title="Disk IO Load Average" \
+ --units-exponent=0 \
+ --vertical-label="percent" \
+ DEF:avg1={rrd1}:diskIOLA1:AVERAGE \
+ DEF:avg5={rrd2}:diskIOLA5:AVERAGE \
+ DEF:avg15={rrd3}:diskIOLA15:AVERAGE \
+ AREA:avg1#babdb6:"1  minute average in %" \
+ GPRINT:avg1:AVERAGE:"Avg \\: %10.2lf" \
+ GPRINT:avg1:MIN:"Min \\: %10.2lf" \
+ GPRINT:avg1:MAX:"Max \\: %10.2lf\\n" \
+ AREA:avg5#888a85:"5  minute average in %" \
+ GPRINT:avg5:AVERAGE:"Avg \\: %10.2lf" \
+ GPRINT:avg5:MIN:"Min \\: %10.2lf" \
+ GPRINT:avg5:MAX:"Max \\: %10.2lf\\n" \
+ LINE2:avg15#a40000:"15 minute average in %" \
+ GPRINT:avg15:AVERAGE:"Avg \\: %10.2lf" \
+ GPRINT:avg15:MIN:"Min \\: %10.2lf" \
+ GPRINT:avg15:MAX:"Max \\: %10.2lf\\n"


### PR DESCRIPTION
Enable disk IO metrics for read/writes in bytes and operations in default system definition to get collected by default. Added metrics for disk load in percent for 1, 5 and 15-minute averages and created RRD graph definitions for each value as percentage graph and an aggregated graph with all three values similar to a load average graph.

Added 64-bit counters for reading and write bytes and if they are supported, suppress the graph with the 32-bit counter.

* JIRA: http://issues.opennms.org/browse/NMS-9816
