### PR TITLE
NMS-9777: Geographical maps refresh tweaks

### DIFF
--- a/features/vaadin-node-maps/src/main/java/org/opennms/features/vaadin/nodemaps/internal/NodeMapComponent.java
+++ b/features/vaadin-node-maps/src/main/java/org/opennms/features/vaadin/nodemaps/internal/NodeMapComponent.java
@@ -148,6 +148,14 @@ public class NodeMapComponent extends AbstractComponent implements GeoAssetProvi
 
     public void showNodes(final Map<Integer, MapNode> nodeEntries) {
         LOG.info("Updating map node list: {} entries.", nodeEntries.size());
+        final List<MapNode> nodeEntryList = new ArrayList<>(nodeEntries.values());
+        if (getState().nodes != null &&
+                nodeEntryList.containsAll(getState().nodes) &&
+                getState().nodes.containsAll(nodeEntryList)) {
+            LOG.info("Skipping update. Map node list is unchanged.");
+            return;
+        }
+
         getState().nodes = new ArrayList<>(nodeEntries.values());
         LOG.info("Finished updating map node list.");
     }

--- a/features/vaadin-node-maps/src/main/java/org/opennms/features/vaadin/nodemaps/internal/NodeMapsApplication.java
+++ b/features/vaadin-node-maps/src/main/java/org/opennms/features/vaadin/nodemaps/internal/NodeMapsApplication.java
@@ -121,7 +121,7 @@ import com.vaadin.ui.VerticalSplitPanel;
 })
 public class NodeMapsApplication extends UI {
     private static final Logger LOG = LoggerFactory.getLogger(NodeMapsApplication.class);
-    private static final int REFRESH_INTERVAL = 5 * 1000;
+    private static final int REFRESH_INTERVAL = Integer.getInteger("org.opennms.features.nodemaps.refresh", 30*1000);
     private VerticalLayout m_rootLayout;
     private VerticalLayout m_layout;
 

--- a/features/vaadin-node-maps/src/main/java/org/opennms/features/vaadin/nodemaps/internal/gwt/client/MapNode.java
+++ b/features/vaadin-node-maps/src/main/java/org/opennms/features/vaadin/nodemaps/internal/gwt/client/MapNode.java
@@ -30,6 +30,7 @@ package org.opennms.features.vaadin.nodemaps.internal.gwt.client;
 
 import java.io.Serializable;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * @author Marcus Hellberg (marcus@vaadin.com)
@@ -153,5 +154,31 @@ public class MapNode implements Serializable {
 
     public void setCategories(List<String> categories) {
         this.categories = categories;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        final MapNode mapNode = (MapNode) o;
+        return Double.compare(mapNode.latitude, latitude) == 0 &&
+                Double.compare(mapNode.longitude, longitude) == 0 &&
+                unackedCount == mapNode.unackedCount &&
+                Objects.equals(nodeId, mapNode.nodeId) &&
+                Objects.equals(nodeLabel, mapNode.nodeLabel) &&
+                Objects.equals(foreignSource, mapNode.foreignSource) &&
+                Objects.equals(foreignId, mapNode.foreignId) &&
+                Objects.equals(description, mapNode.description) &&
+                Objects.equals(maintcontract, mapNode.maintcontract) &&
+                Objects.equals(ipAddress, mapNode.ipAddress) &&
+                Objects.equals(severity, mapNode.severity) &&
+                Objects.equals(severityLabel, mapNode.severityLabel) &&
+                Objects.equals(categories, mapNode.categories);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(latitude, longitude, nodeId, nodeLabel, foreignSource, foreignId, description,
+                maintcontract, ipAddress, severity, severityLabel, unackedCount, categories);
     }
 }

--- a/features/vaadin-node-maps/src/test/java/org/opennms/features/vaadin/nodemaps/internal/NodeMapComponentTest.java
+++ b/features/vaadin-node-maps/src/test/java/org/opennms/features/vaadin/nodemaps/internal/NodeMapComponentTest.java
@@ -29,8 +29,10 @@
 package org.opennms.features.vaadin.nodemaps.internal;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -78,6 +80,31 @@ public class NodeMapComponentTest {
         entries.remove(1);
         component.showNodes(entries);
         assertEquals(0, state.nodes.size());
+    }
+
+    @Test
+    public void testStateNotUpdatedWhenNodesAreUnchanged() {
+        final NodeMapState state = new NodeMapState();
+        final NodeMapComponent component = new NodeMapComponent() {
+            private static final long serialVersionUID = 1L;
+            public NodeMapState getState() {
+                return state;
+            }
+        };
+
+        Map<Integer,MapNode> entries = new HashMap<>();
+        entries.put(1, createMapNode(1, "Foo", 3f, 4f));
+        entries.put(2, createMapNode(2, "Bar", 6f, 7f));
+        component.showNodes(entries);
+        List<MapNode> stateNodes = state.nodes;
+        assertEquals(2, state.nodes.size());
+
+        // Now recreate the entries using new objects and update the component
+        entries = new HashMap<>();
+        entries.put(1, createMapNode(1, "Foo", 3f, 4f));
+        entries.put(2, createMapNode(2, "Bar", 6f, 7f));
+        component.showNodes(entries);
+        assertSame("An update with the same entries should not update the underlying array.", stateNodes, state.nodes);
     }
 
     private MapNode createMapNode(int nodeId, String nodeLabel, float longitude, float latitude) {


### PR DESCRIPTION
JIRA: https://issues.opennms.org/browse/NMS-9777

Here we:
1) Update the default refresh rate for the geo maps from 5s to 30s and allow it to be configured via the `org.opennms.features.nodemaps.refresh` system property.
2) Avoid updating the client state after a refresh triggered if the list of nodes was not changed, avoiding unnecessary re-rendering on the client side.