### PR TITLE
HZN-1196: Enable Karaf IT that bootstraps our modified container

### DIFF
--- a/opennms-full-assembly/src/test/java/org/opennms/assemblies/karaf/FeaturesBootKarafIT.java
+++ b/opennms-full-assembly/src/test/java/org/opennms/assemblies/karaf/FeaturesBootKarafIT.java
@@ -28,79 +28,40 @@
 
 package org.opennms.assemblies.karaf;
 
-import static org.ops4j.pax.exam.CoreOptions.maven;
-
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
 import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
 import org.ops4j.pax.exam.spi.reactors.PerMethod;
 
+/**
+ * <p>This test bootstraps the OpenNMS-modified Karaf container
+ * ensuring that:</p>
+ * 
+ * <ul>
+ * <li>The system classpath is sufficient to satisfy the OSGi classpath</li>
+ * <li>There are no missing dependencies for the default featuresBoot features</li>
+ * </ul>
+ * 
+ * <p>Even though the system bootstraps, many bundles end up in {@code Failed}
+ * or {@code GracePeriod} status because the services that are normally started
+ * as part of OpenNMS have not been started.</p>
+ * 
+ * <p>TODO: Diagnose bundle failures and enhance test to prevent them</p>
+ * <p>TODO: Assert that no bundles end up in failure state</p>
+ * <p>TODO: Add mock services if necessary to prevent {@code GracePeriod} statuses</p>
+ * <p>TODO: Verify availability of services provided by OSGi bundles</p>
+ * 
+ * <p>Until these TODOs are implemented, we must rely on full-system smoke tests
+ * to diagnose failures related to the OSGi wiring inside Karaf.</p>
+ */
 @RunWith(PaxExam.class)
 @ExamReactorStrategy(PerMethod.class)
-@Ignore("This doesn't work because of problems with the system classpath")
 public class FeaturesBootKarafIT extends OnmsKarafTestCase {
 
-	/**
-	 * This test attempts to install all features from the OpenNMS
-	 * featuresBoot list in:
-	 * 
-	 * src/main/filtered-resources/etc/org.apache.karaf.features.cfg
-	 */
 	@Test
 	public void testInstallAllOpenNMSFeatures() {
-		final String version = getOpenNMSVersion();
-		addFeaturesUrl(maven().groupId("org.opennms.karaf").artifactId("opennms").version(version).type("xml").classifier("standard").getURL());
-		addFeaturesUrl(maven().groupId("org.opennms.karaf").artifactId("opennms").version(version).type("xml").classifier("spring-legacy").getURL());
-		addFeaturesUrl(maven().groupId("org.opennms.karaf").artifactId("opennms").version(version).type("xml").classifier("features").getURL());
-
-		for (String feature : new String[] {
-			"karaf-framework",
-			"ssh",
-			"config",
-			"features",
-			"management",
-			"http",
-			"http-whiteboard",
-			"kar",
-			"deployer",
-			"opennms-jaas-login-module",
-			"datachoices",
-			"opennms-topology-runtime-browsers",
-			"opennms-topology-runtime-linkd",
-			"opennms-topology-runtime-simple",
-			"opennms-topology-runtime-vmware",
-			"opennms-topology-runtime-application",
-			"opennms-topology-runtime-bsm",
-			"osgi-nrtg-local",
-			"vaadin-node-maps",
-			"vaadin-snmp-events-and-metrics",
-			"vaadin-dashboard",
-			"dashlet-summary",
-			"dashlet-alarms",
-			"dashlet-bsm",
-			"dashlet-map",
-			"dashlet-image",
-			"dashlet-charts",
-			"dashlet-grafana",
-			"dashlet-rtc",
-			"dashlet-rrd",
-			"dashlet-ksc",
-			"dashlet-topology",
-			"dashlet-url",
-			"dashlet-surveillance",
-			"vaadin-surveillance-views",
-			"vaadin-jmxconfiggenerator",
-			"vaadin-opennms-pluginmanager",
-			"vaadin-adminpage",
-			"org.opennms.features.bsm.shell-commands"
-		}) {
-			System.out.println("Installing feature: " + feature);
-			installFeature(feature);
-			System.out.println("Installed feature: " + feature);
-		}
-
 		System.out.println(executeCommand("feature:list -i"));
+		System.out.println(executeCommand("list"));
 	}
 }

--- a/opennms-full-assembly/src/test/java/org/opennms/assemblies/karaf/OnmsKarafTestCase.java
+++ b/opennms-full-assembly/src/test/java/org/opennms/assemblies/karaf/OnmsKarafTestCase.java
@@ -30,23 +30,12 @@ package org.opennms.assemblies.karaf;
 
 import static org.ops4j.pax.exam.CoreOptions.maven;
 
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.Properties;
-import java.util.stream.Collectors;
-
 import org.opennms.core.test.karaf.KarafTestCase;
 import org.ops4j.pax.exam.options.MavenUrlReference;
 
 /**
- * @deprecated This test base class doesn't work because our Karaf 
- * container artifact:
- * 
- * mvn:org.opennms.container/org.opennms.container.karaf/${version}/tar.gz
- * 
- * isn't packaged with a top-level product directory like the Apache Karaf
- * tar.gz artifacts are.
+ * This base class uses the OpenNMS-modified Karaf container
+ * from container/karaf instead of a vanilla Karaf container.
  */
 public class OnmsKarafTestCase extends KarafTestCase {
 
@@ -60,29 +49,5 @@ public class OnmsKarafTestCase extends KarafTestCase {
 				.artifactId("org.opennms.container.karaf")
 				.type("tar.gz")
 				.version("22.0.0-SNAPSHOT");
-	}
-
-	/**
-	 * Fetch the OpenNMS system classpath from our modified custom.properties file.
-	 */
-	@Override
-	protected String[] getSystemPackages() {
-		Properties customProperties = new Properties();
-		try {
-			customProperties.load(new FileInputStream("../container/karaf/src/main/filtered-resources/etc/custom.properties"));
-		} catch (IOException e) {
-			System.err.println("Unexpected error while trying to load system properties");
-			e.printStackTrace();
-			return new String[0];
-		}
-
-		String classpath =  customProperties.getProperty("org.osgi.framework.system.packages.extra");
-		System.out.println("System classpath: " + classpath);
-		return Arrays.stream(classpath.split(","))
-			// Remove all of the version constraints
-			.map(s -> {
-				return s.replaceAll(";.*$", "");
-			})
-			.collect(Collectors.toList()).toArray(new String[0]);
 	}
 }


### PR DESCRIPTION
This enables a Karaf IT that bootstraps the `container/karaf` container with our modifications instead of a vanilla Karaf container. A lot of the bundles end up in `Failed` or `GracePeriod` blueprint state because the underlaying OpenNMS services are not started but this simple test will still verify that the system classpath and OSGi classpath dependencies are correct in our modified container.

* JIRA: http://issues.opennms.org/browse/HZN-1196