### PR TITLE
HZN-1223: Include the Drift plugin when running Elasticsearch in our integration tests.

### DIFF
--- a/core/test-api/elasticsearch/pom.xml
+++ b/core/test-api/elasticsearch/pom.xml
@@ -10,6 +10,11 @@
   <artifactId>org.opennms.core.test-api.elasticsearch</artifactId>
   <name>OpenNMS :: Core :: Test API :: Elasticsearch</name>
   <packaging>jar</packaging>
+
+  <properties>
+    <elasticsearchVersion>6.1.1</elasticsearchVersion>
+  </properties>
+
    <dependencies>
      <dependency>
        <groupId>org.slf4j</groupId>
@@ -18,12 +23,12 @@
      <dependency>
        <groupId>org.elasticsearch</groupId>
        <artifactId>elasticsearch</artifactId>
-       <version>5.6.2</version>
+       <version>${elasticsearchVersion}</version>
      </dependency>
      <dependency>
        <groupId>org.elasticsearch.client</groupId>
        <artifactId>transport</artifactId>
-       <version>5.6.2</version>
+       <version>${elasticsearchVersion}</version>
        <exclusions>
          <exclusion>
            <groupId>commons-logging</groupId>
@@ -34,7 +39,12 @@
      <dependency>
        <groupId>org.elasticsearch.plugin</groupId>
        <artifactId>transport-netty4-client</artifactId>
-       <version>5.6.2</version>
+       <version>${elasticsearchVersion}</version>
+     </dependency>
+     <dependency>
+       <groupId>org.elasticsearch.plugin</groupId>
+       <artifactId>aggs-matrix-stats-client</artifactId>
+       <version>${elasticsearchVersion}</version>
      </dependency>
      <dependency>
        <groupId>io.netty</groupId>

--- a/core/test-api/elasticsearch/src/main/java/org/opennms/core/test/elastic/ElasticSearchServerConfig.java
+++ b/core/test-api/elasticsearch/src/main/java/org/opennms/core/test/elastic/ElasticSearchServerConfig.java
@@ -28,6 +28,9 @@
 
 package org.opennms.core.test.elastic;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Objects;
 
 import org.elasticsearch.cluster.ClusterName;
@@ -35,6 +38,7 @@ import org.elasticsearch.common.network.NetworkModule;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.node.Node;
+import org.elasticsearch.plugins.Plugin;
 
 public class ElasticSearchServerConfig {
 
@@ -44,6 +48,7 @@ public class ElasticSearchServerConfig {
     private long startDelay; // in ms
     private boolean manualStartup;
     private boolean keepElasticHomeAfterShutdown;
+    private List<Class<? extends Plugin>> plugins = new ArrayList<>();
 
     public ElasticSearchServerConfig withDefaults() {
         withNodeName("testNode");
@@ -86,9 +91,26 @@ public class ElasticSearchServerConfig {
         return this;
     }
 
-    public ElasticSearchServerConfig withSetting(String key, Object value) {
+    public ElasticSearchServerConfig withSetting(String key, String value) {
         Objects.requireNonNull(key);
         builder.put(key, value);
+        return this;
+    }
+
+    public ElasticSearchServerConfig withSetting(String key, boolean value) {
+        Objects.requireNonNull(key);
+        builder.put(key, value);
+        return this;
+    }
+
+    public ElasticSearchServerConfig withSetting(String key, int value) {
+        Objects.requireNonNull(key);
+        builder.put(key, value);
+        return this;
+    }
+
+    public ElasticSearchServerConfig withPlugins(Class<? extends Plugin>... plugins) {
+        this.plugins.addAll(Arrays.asList(plugins));
         return this;
     }
 
@@ -129,6 +151,10 @@ public class ElasticSearchServerConfig {
 
     public String getHomeDirectory() {
         return builder.get(Environment.PATH_HOME_SETTING.getKey());
+    }
+
+    public List<Class<? extends Plugin>> getPlugins() {
+        return plugins;
     }
 
     public Settings build() {

--- a/features/flows/elastic/pom.xml
+++ b/features/flows/elastic/pom.xml
@@ -145,6 +145,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.opennms.elasticsearch</groupId>
+      <artifactId>elasticsearch-drift-plugin</artifactId>
+      <version>1.0.0-SNAPSHOT</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.opennms</groupId>
       <artifactId>opennms-dao-mock</artifactId>
       <scope>test</scope>
@@ -155,4 +161,13 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <repositories>
+    <repository>
+      <id>snapshots-repo</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+      <releases><enabled>false</enabled></releases>
+      <snapshots><enabled>true</enabled></snapshots>
+    </repository>
+  </repositories>
 </project>

--- a/features/flows/elastic/src/main/resources/org/opennms/netmgt/flows/elastic/top_n_series.ftl
+++ b/features/flows/elastic/src/main/resources/org/opennms/netmgt/flows/elastic/top_n_series.ftl
@@ -27,9 +27,15 @@
       },
       "aggs": {
         "bytes_over_time": {
-          "date_histogram": {
-            "field": "@timestamp",
-            "interval": "${step?long?c}ms"
+          "proportional_sum": {
+            "fields": [
+              "netflow.first_switched",
+              "netflow.last_switched",
+              "netflow.bytes"
+            ],
+            "interval": "${step?long?c}ms",
+            "start": ${start?long?c},
+            "end": ${end?long?c}
           },
           "aggs": {
             "direction": {

--- a/features/flows/elastic/src/test/java/org/opennms/netmgt/flows/elastic/FlowBuilder.java
+++ b/features/flows/elastic/src/test/java/org/opennms/netmgt/flows/elastic/FlowBuilder.java
@@ -36,15 +36,55 @@ public class FlowBuilder {
 
     private final List<FlowDocument> flows = new ArrayList<>();
 
+    private NodeDocument exporterNode;
+    private Integer snmpInterfaceId;
+    private boolean initiator = false;
+    private String application = null;
+
+    public FlowBuilder withExporter(String fs, String fid) {
+        exporterNode = new NodeDocument();
+        exporterNode.setForeignSource(fs);
+        exporterNode.setForeignId(fid);
+        return this;
+    }
+
+    public FlowBuilder withSnmpInterfaceId(Integer snmpInterfaceId) {
+        this.snmpInterfaceId = snmpInterfaceId;
+        return this;
+    }
+
+    public FlowBuilder withInitiator(boolean initiator) {
+        this.initiator = initiator;
+        return this;
+    }
+
+    public FlowBuilder withApplication(String application) {
+        this.application = application;
+        return this;
+    }
+
     public FlowBuilder withFlow(Date date, String sourceIp, int sourcePort, String destIp, int destPort, long numBytes) {
+        return withFlow(date, date, sourceIp, sourcePort, destIp, destPort, numBytes);
+    }
+
+    public FlowBuilder withFlow(Date firstSwitched, Date lastSwitched, String sourceIp, int sourcePort, String destIp, int destPort, long numBytes) {
         final FlowDocument flow = new FlowDocument();
-        flow.setTimestamp(date.getTime());
+        flow.setTimestamp(lastSwitched.getTime());
+        flow.setFirstSwitched(firstSwitched.getTime());
+        flow.setLastSwitched(lastSwitched.getTime());
         flow.setSrcAddr(sourceIp);
         flow.setSrcPort(sourcePort);
         flow.setDstAddr(destIp);
         flow.setDstPort(destPort);
         flow.setBytes(numBytes);
         flow.setProtocol(6); // TCP
+        if (exporterNode !=  null) {
+            flow.setNodeExporter(exporterNode);
+        }
+        flow.setInputSnmp(snmpInterfaceId);
+        flow.setOutputSnmp(snmpInterfaceId);
+        flow.setInitiator(initiator);
+        flow.setApplication(application);
         flows.add(flow);
         return this;
     }

--- a/features/flows/elastic/src/test/java/org/opennms/netmgt/flows/elastic/FlowQueryIT.java
+++ b/features/flows/elastic/src/test/java/org/opennms/netmgt/flows/elastic/FlowQueryIT.java
@@ -46,6 +46,7 @@ import org.junit.Test;
 import org.opennms.core.test.MockLogAppender;
 import org.opennms.core.test.elastic.ElasticSearchRule;
 import org.opennms.core.test.elastic.ElasticSearchServerConfig;
+import org.opennms.elasticsearch.plugin.DriftPlugin;
 import org.opennms.netmgt.flows.api.ConversationKey;
 import org.opennms.netmgt.flows.api.Directional;
 import org.opennms.netmgt.flows.api.FlowException;
@@ -73,6 +74,7 @@ public class FlowQueryIT {
                     .withSetting("http.type", "netty4")
                     .withSetting("transport.type", "netty4")
                     .withSetting("transport.tcp.port", HTTP_TRANSPORT_PORT)
+                    .withPlugins(DriftPlugin.class)
     );
 
     private ElasticFlowRepository flowRepository;


### PR DESCRIPTION
JIRA: https://issues.opennms.org/browse/HZN-1223

Here we enhance the Elasticsearch server used in our integration tests to support loading plugins specified by the test, and update the flow module to use the Drift plugin.

We currently use snapshot artifacts for the plugin, but we'll need to issue a tagged release before merging this to develop.
