### PR TITLE
HZN-1203: Split experimental features out into separate repo

### DIFF
--- a/container/features/pom.xml
+++ b/container/features/pom.xml
@@ -233,14 +233,6 @@
             <feature>jrobin</feature>
             <feature>json-lib</feature>
             <feature>lmax-disruptor</feature>
-            <!--
-            <feature>opennms-activemq-config</feature>
-            <feature>opennms-activemq</feature>
-            <feature>opennms-activemq-dispatcher-config</feature>
-            <feature>opennms-activemq-dispatcher</feature>
-            <feature>opennms-activemq-event-forwarder</feature>
-            <feature>opennms-activemq-event-receiver</feature>
-            -->
             <feature>opennms-bootstrap</feature>
             <feature>opennms-bundle-refresher</feature>
             <feature>opennms-collection-api</feature>
@@ -256,9 +248,7 @@
             <feature>opennms-core-web</feature>
             <feature>opennms-dao-api</feature>
             <feature>opennms-dao</feature>
-            <feature>opennms-discovery</feature>
             <feature>opennms-events-api</feature>
-            <feature>opennms-events-daemon</feature>
             <feature>opennms-events-commands</feature>
             <feature>opennms-icmp-api</feature>
             <feature>opennms-icmp-jna</feature>
@@ -273,7 +263,6 @@
             <feature>opennms-provisioning</feature>
             <feature>opennms-provisioning-detectors</feature>
             <feature>opennms-provisioning-shell</feature>
-            <feature>opennms-reporting</feature>
             <feature>opennms-rrd-api</feature>
             <feature>opennms-rrd-jrobin</feature>
             <feature>opennms-snmp</feature>
@@ -282,7 +271,6 @@
             <feature>opennms-syslogd-listener-javanet</feature>
             <feature>opennms-syslogd-listener-camel-netty</feature>
             <feature>opennms-trapd</feature>
-            <!-- <feature>opennms-webapp</feature> -->
 
             <!-- OSGI Rest -->
             <feature>jax-rs-connector</feature>
@@ -397,6 +385,11 @@
             </goals>
             <configuration>
               <artifacts>
+                <artifact>
+                  <file>${project.build.outputDirectory}/features-experimental.xml</file>
+                  <type>xml</type>
+                  <classifier>experimental</classifier>
+                </artifact>
                 <artifact>
                   <file>${project.build.outputDirectory}/features-minion.xml</file>
                   <type>xml</type>

--- a/container/features/src/main/resources/features-experimental.xml
+++ b/container/features/src/main/resources/features-experimental.xml
@@ -1,0 +1,149 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<features
+  name="opennms-experimental-${project.version}"
+  xmlns="http://karaf.apache.org/xmlns/features/v1.4.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://karaf.apache.org/xmlns/features/v1.4.0 http://karaf.apache.org/xmlns/features/v1.4.0"
+>
+
+    <!--
+      These features are not installed as part of OpenNMS. They represent experimental work to:
+
+      - Add new components to OpenNMS
+      - Get existing OpenNMS components to run in OSGi (especially the service daemons and web UI)
+    -->
+
+    <!-- OpenNMS Features -->
+    <repository>mvn:${project.groupId}/${project.artifactId}/${project.version}/xml/features</repository>
+
+    <!-- ActiveMQ service features -->
+
+    <feature name="opennms-activemq-dispatcher-config" description="OpenNMS :: Features :: ActiveMQ :: Dispatcher Broker Config" version="${project.version}">
+      <!-- This broker configuration will configure a broker to talk to a remote OpenNMS machine -->
+      <configfile override="true" finalname="/etc/activemq-dispatcher.xml">mvn:org.opennms.features.activemq/org.opennms.features.activemq.broker/${project.version}/xml/activemq-dispatcher</configfile>
+      <!-- Don't overwrite any existing properties file -->
+      <configfile finalname="/etc/org.apache.activemq.server-dispatcher.cfg">mvn:org.opennms.features.activemq/org.opennms.features.activemq.broker/${project.version}/cfg/activemq-dispatcher</configfile>
+    </feature>
+
+    <feature name="opennms-activemq-dispatcher" description="OpenNMS :: Features :: ActiveMQ :: Dispatcher Broker" version="${project.version}">
+      <feature>opennms-activemq-dispatcher-config</feature>
+      <feature>activemq</feature>
+    </feature>
+
+    <feature name="opennms-activemq-config" description="OpenNMS :: Features :: ActiveMQ :: Broker Config" version="${project.version}">
+      <!-- This broker configuration will configure a local ActiveMQ broker to process messages on the OpenNMS machine -->
+      <configfile override="true" finalname="/etc/activemq-receiver.xml">mvn:org.opennms.features.activemq/org.opennms.features.activemq.broker/${project.version}/xml/activemq-receiver</configfile>
+      <!-- Don't overwrite any existing properties file -->
+      <configfile finalname="/etc/org.apache.activemq.server-broker.cfg">mvn:org.opennms.features.activemq/org.opennms.features.activemq.broker/${project.version}/cfg/activemq-receiver</configfile>
+    </feature>
+
+    <feature name="opennms-activemq" description="OpenNMS :: Features :: ActiveMQ :: Broker" version="${project.version}">
+      <feature>opennms-activemq-config</feature>
+      <feature>activemq</feature>
+    </feature>
+
+    <feature name="opennms-activemq-component" description="OpenNMS :: Features :: ActiveMQ :: Component" version="${project.version}">
+      <bundle>mvn:org.opennms.features.activemq/org.opennms.features.activemq.pool/${project.version}</bundle>
+      <bundle>mvn:org.opennms.features.activemq/org.opennms.features.activemq.component/${project.version}</bundle>
+    </feature>
+
+    <!-- OpenNMS features -->
+
+    <feature name="opennms-discovery" description="OpenNMS :: Discovery" version="${project.version}">
+      <feature>guava</feature>
+      <feature>opennms-core-ipc-rpc-api</feature>
+
+      <feature>opennms-core-daemon</feature>
+      <feature>opennms-core-db</feature>
+      <feature>opennms-config</feature>
+      <feature>opennms-dao-api</feature>
+
+      <bundle>mvn:org.opennms.features/org.opennms.features.discovery/${project.version}</bundle>
+    </feature>
+
+    <feature name="opennms-events-daemon" description="OpenNMS :: Events :: Daemon" version="${project.version}">
+      <feature>camel-netty4</feature>
+      <feature>commons-beanutils</feature>
+      <feature>guava</feature>
+      <feature>gemini-blueprint</feature>
+
+      <feature>opennms-core-daemon</feature>
+      <feature>opennms-dao-api</feature>
+      <feature>opennms-events-api</feature>
+
+      <bundle>mvn:org.opennms.features.events/org.opennms.features.events.daemon/${project.version}</bundle>
+    </feature>
+
+    <feature name="opennms-reporting" description="OpenNMS :: Reporting" version="${project.version}">
+      <feature>commons-beanutils</feature>
+      <feature>commons-io</feature>
+      <feature>fop</feature>
+      <feature>quartz</feature>
+
+      <feature>opennms-config</feature>
+      <feature>opennms-core</feature>
+      <feature>opennms-core-db</feature>
+      <feature>opennms-dao-api</feature>
+      <feature>opennms-javamail</feature>
+
+      <bundle>mvn:org.opennms/opennms-reporting/${project.version}</bundle>
+      <bundle>mvn:org.opennms.features.reporting/org.opennms.features.reporting.api/${project.version}</bundle>
+      <bundle>mvn:org.opennms.features.reporting/org.opennms.features.reporting.availability/${project.version}</bundle>
+      <bundle>mvn:org.opennms.features.reporting/org.opennms.features.reporting.core/${project.version}</bundle>
+      <bundle>mvn:org.opennms.features.reporting/org.opennms.features.reporting.dao/${project.version}</bundle>
+      <!--
+      <bundle>mvn:org.opennms.features.reporting/org.opennms.features.reporting.jasper-reports/${project.version}</bundle>
+      -->
+      <bundle>mvn:org.opennms.features.reporting/org.opennms.features.reporting.model/${project.version}</bundle>
+      <bundle>mvn:org.opennms.features.reporting/org.opennms.features.reporting.repository/${project.version}</bundle>
+      <bundle>mvn:org.opennms.features.reporting/org.opennms.features.reporting.sdo/${project.version}</bundle>
+    </feature>
+
+    <feature name="opennms-webapp" description="OpenNMS :: Webapp" version="${project.version}">
+      <feature>war</feature>
+
+      <feature>commons-beanutils</feature>
+      <feature>commons-configuration</feature>
+      <feature>commons-jexl</feature>
+      <feature>fop</feature>
+      <feature>hibernate-validator41</feature>
+      <feature>jfreechart</feature>
+      <feature>joda-time</feature>
+      <feature>jrobin</feature>
+      <feature>json-lib</feature>
+      <feature>quartz</feature>
+      <feature>spring-webflow</feature>
+
+      <feature>opennms-config</feature>
+      <feature>opennms-dao</feature>
+      <feature>opennms-provisioning</feature>
+      <feature>opennms-reporting</feature>
+
+      <bundle>wrap:mvn:xalan/xalan/2.7.2</bundle>
+      <bundle>wrap:mvn:xalan/serializer/2.7.2</bundle>
+      <bundle>wrap:mvn:org.w3c.css/sac/1.3</bundle>
+      <bundle>mvn:com.vaadin.external.flute/flute/1.3.0.gg2</bundle>
+      <bundle>wrap:mvn:net.sourceforge.cssparser/cssparser/0.9.11</bundle>
+      <!-- <bundle>wrap:mvn:com.google.gwt/gwt-servlet/${gwtVersion}</bundle> -->
+
+      <feature>commons-cli</feature>
+      <feature>commons-exec</feature>
+      <feature>commons-net</feature>
+      <bundle>mvn:org.opennms.features/org.opennms.features.system-report/${project.version}</bundle>
+
+      <feature>opennms-core-web</feature>
+      <bundle>mvn:org.opennms.features/org.opennms.features.request-tracker/${project.version}</bundle>
+
+      <!-- TODO: Make this JAR into a bundle -->
+      <bundle>wrap:mvn:org.opennms/rancid-api/1.0.3</bundle>
+
+      <bundle>mvn:org.opennms/opennms-web-api/${project.version}</bundle>
+
+      <feature>spring-security32</feature>
+      <bundle>mvn:org.opennms.features/org.opennms.features.springframework-security/${project.version}</bundle>
+
+      <!-- The main webapp WAR file -->
+      <bundle>mvn:org.opennms/opennms-webapp/${project.version}/war</bundle>
+    </feature>
+
+</features>

--- a/container/features/src/main/resources/features-minion.xml
+++ b/container/features/src/main/resources/features-minion.xml
@@ -6,7 +6,7 @@
   xsi:schemaLocation="http://karaf.apache.org/xmlns/features/v1.4.0 http://karaf.apache.org/xmlns/features/v1.4.0"
 >
     <!-- OpenNMS Features -->
-    <repository>mvn:org.opennms.karaf/opennms/${project.version}/xml/features</repository>
+    <repository>mvn:${project.groupId}/${project.artifactId}/${project.version}/xml/features</repository>
 
     <!-- TODO: Maybe this is already defined somewhere else -->
     <feature name="minion-core-api" description="OpenNMS :: Minion :: Core :: API" version="${project.version}">

--- a/container/features/src/main/resources/features.xml
+++ b/container/features/src/main/resources/features.xml
@@ -17,37 +17,6 @@
     <!-- Pax JDBC features -->
     <repository>mvn:org.ops4j.pax.jdbc/pax-jdbc-features/1.0.1/xml/features</repository>
 
-    <!-- ActiveMQ service features -->
-
-    <!-- This broker configuration will configure a broker to talk to a remote OpenNMS machine -->
-    <feature name="opennms-activemq-dispatcher-config" description="OpenNMS :: Features :: ActiveMQ :: Dispatcher Broker Config" version="${project.version}">
-      <configfile override="true" finalname="/etc/activemq-dispatcher.xml">mvn:org.opennms.features.activemq/org.opennms.features.activemq.broker/${project.version}/xml/activemq-dispatcher</configfile>
-      <!-- Don't overwrite any existing properties file -->
-      <configfile finalname="/etc/org.apache.activemq.server-dispatcher.cfg">mvn:org.opennms.features.activemq/org.opennms.features.activemq.broker/${project.version}/cfg/activemq-dispatcher</configfile>
-    </feature>
-
-    <feature name="opennms-activemq-dispatcher" description="OpenNMS :: Features :: ActiveMQ :: Dispatcher Broker" version="${project.version}">
-      <feature>opennms-activemq-dispatcher-config</feature>
-      <feature>activemq</feature>
-    </feature>
-
-    <!-- This broker configuration will configure a local ActiveMQ broker to process messages on the OpenNMS machine -->
-    <feature name="opennms-activemq-config" description="OpenNMS :: Features :: ActiveMQ :: Broker Config" version="${project.version}">
-      <configfile override="true" finalname="/etc/activemq-receiver.xml">mvn:org.opennms.features.activemq/org.opennms.features.activemq.broker/${project.version}/xml/activemq-receiver</configfile>
-      <!-- Don't overwrite any existing properties file -->
-      <configfile finalname="/etc/org.apache.activemq.server-broker.cfg">mvn:org.opennms.features.activemq/org.opennms.features.activemq.broker/${project.version}/cfg/activemq-receiver</configfile>
-    </feature>
-
-    <feature name="opennms-activemq" description="OpenNMS :: Features :: ActiveMQ :: Broker" version="${project.version}">
-      <feature>opennms-activemq-config</feature>
-      <feature>activemq</feature>
-    </feature>
-
-    <feature name="opennms-activemq-component" description="OpenNMS :: Features :: ActiveMQ :: Component" version="${project.version}">
-      <bundle>mvn:org.opennms.features.activemq/org.opennms.features.activemq.pool/${project.version}</bundle>
-      <bundle>mvn:org.opennms.features.activemq/org.opennms.features.activemq.component/${project.version}</bundle>
-    </feature>
-
     <feature name="opennms-amqp-event-forwarder" description="OpenNMS :: Features :: AMQP :: Event Forwarder" version="${project.version}">
       <feature>camel-core</feature>
       <feature>camel-blueprint</feature>
@@ -692,18 +661,6 @@
       <bundle>mvn:org.opennms/opennms-dao/${project.version}</bundle>
     </feature>
 
-    <feature name="opennms-discovery" description="OpenNMS :: Discovery" version="${project.version}">
-      <feature>guava</feature>
-      <feature>opennms-core-ipc-rpc-api</feature>
-
-      <feature>opennms-core-daemon</feature>
-      <feature>opennms-core-db</feature>
-      <feature>opennms-config</feature>
-      <feature>opennms-dao-api</feature>
-
-      <bundle>mvn:org.opennms.features/org.opennms.features.discovery/${project.version}</bundle>
-    </feature>
-
     <feature name="opennms-events-api" description="OpenNMS :: Events :: API" version="${project.version}">
       <feature version="[4.2,4.3)">spring</feature>
 
@@ -733,19 +690,6 @@
       -->
 
       <bundle>mvn:org.opennms.features.events/org.opennms.features.events.commands/${project.version}</bundle>
-    </feature>
-
-    <feature name="opennms-events-daemon" description="OpenNMS :: Events :: Daemon" version="${project.version}">
-      <feature>camel-netty4</feature>
-      <feature>commons-beanutils</feature>
-      <feature>guava</feature>
-      <feature>gemini-blueprint</feature>
-
-      <feature>opennms-core-daemon</feature>
-      <feature>opennms-dao-api</feature>
-      <feature>opennms-events-api</feature>
-
-      <bundle>mvn:org.opennms.features.events/org.opennms.features.events.daemon/${project.version}</bundle>
     </feature>
 
     <feature name="opennms-icmp-api" description="OpenNMS :: ICMP :: API" version="${project.version}">
@@ -845,31 +789,6 @@
       <bundle>mvn:org.opennms/opennms-provision-api/${project.version}</bundle>
     </feature>
 
-    <feature name="opennms-reporting" description="OpenNMS :: Reporting" version="${project.version}">
-      <feature>commons-beanutils</feature>
-      <feature>commons-io</feature>
-      <feature>fop</feature>
-      <feature>quartz</feature>
-
-      <feature>opennms-config</feature>
-      <feature>opennms-core</feature>
-      <feature>opennms-core-db</feature>
-      <feature>opennms-dao-api</feature>
-      <feature>opennms-javamail</feature>
-
-      <bundle>mvn:org.opennms/opennms-reporting/${project.version}</bundle>
-      <bundle>mvn:org.opennms.features.reporting/org.opennms.features.reporting.api/${project.version}</bundle>
-      <bundle>mvn:org.opennms.features.reporting/org.opennms.features.reporting.availability/${project.version}</bundle>
-      <bundle>mvn:org.opennms.features.reporting/org.opennms.features.reporting.core/${project.version}</bundle>
-      <bundle>mvn:org.opennms.features.reporting/org.opennms.features.reporting.dao/${project.version}</bundle>
-      <!--
-      <bundle>mvn:org.opennms.features.reporting/org.opennms.features.reporting.jasper-reports/${project.version}</bundle>
-      -->
-      <bundle>mvn:org.opennms.features.reporting/org.opennms.features.reporting.model/${project.version}</bundle>
-      <bundle>mvn:org.opennms.features.reporting/org.opennms.features.reporting.repository/${project.version}</bundle>
-      <bundle>mvn:org.opennms.features.reporting/org.opennms.features.reporting.sdo/${project.version}</bundle>
-    </feature>
-
     <feature name="opennms-rrd-api" description="OpenNMS :: RRD :: API" version="${project.version}">
       <feature version="[4.2,4.3)">spring</feature>
 
@@ -946,7 +865,6 @@
       <bundle>blueprint:mvn:org.opennms.features.events/org.opennms.features.events.syslog/${project.version}/xml/blueprint-syslog-listener-camel-netty</bundle>
     </feature>
 
-    <!-- TrapD feature -->
     <feature name="opennms-trapd" description="OpenNMS :: Trapd" version="${project.version}">
       <feature version="[4.2,4.3)">spring</feature>
       <feature>camel-core</feature>
@@ -982,53 +900,6 @@
         <feature>opennms-dao-api</feature>
 
         <bundle>mvn:org.opennms.features/org.opennms.features.eif-adapter/${project.version}</bundle>
-    </feature>
-
-    <feature name="opennms-webapp" description="OpenNMS :: Webapp" version="${project.version}">
-      <feature>war</feature>
-
-      <feature>commons-beanutils</feature>
-      <feature>commons-configuration</feature>
-      <feature>commons-jexl</feature>
-      <feature>fop</feature>
-      <feature>hibernate-validator41</feature>
-      <feature>jfreechart</feature>
-      <feature>joda-time</feature>
-      <feature>jrobin</feature>
-      <feature>json-lib</feature>
-      <feature>quartz</feature>
-      <feature>spring-webflow</feature>
-
-      <feature>opennms-config</feature>
-      <feature>opennms-dao</feature>
-      <feature>opennms-provisioning</feature>
-      <feature>opennms-reporting</feature>
-
-      <bundle>wrap:mvn:xalan/xalan/2.7.2</bundle>
-      <bundle>wrap:mvn:xalan/serializer/2.7.2</bundle>
-      <bundle>wrap:mvn:org.w3c.css/sac/1.3</bundle>
-      <bundle>mvn:com.vaadin.external.flute/flute/1.3.0.gg2</bundle>
-      <bundle>wrap:mvn:net.sourceforge.cssparser/cssparser/0.9.11</bundle>
-      <!-- <bundle>wrap:mvn:com.google.gwt/gwt-servlet/${gwtVersion}</bundle> -->
-
-      <feature>commons-cli</feature>
-      <feature>commons-exec</feature>
-      <feature>commons-net</feature>
-      <bundle>mvn:org.opennms.features/org.opennms.features.system-report/${project.version}</bundle>
-
-      <feature>opennms-core-web</feature>
-      <bundle>mvn:org.opennms.features/org.opennms.features.request-tracker/${project.version}</bundle>
-
-      <!-- TODO: Make this JAR into a bundle -->
-      <bundle>wrap:mvn:org.opennms/rancid-api/1.0.3</bundle>
-
-      <bundle>mvn:org.opennms/opennms-web-api/${project.version}</bundle>
-
-      <feature>spring-security32</feature>
-      <bundle>mvn:org.opennms.features/org.opennms.features.springframework-security/${project.version}</bundle>
-
-      <!-- The main webapp WAR file -->
-      <bundle>mvn:org.opennms/opennms-webapp/${project.version}/war</bundle>
     </feature>
 
     <feature name="smack" description="Ignite Realtime :: Smack" version="4.0.6">

--- a/core/ipc/common/aws-sqs/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/core/ipc/common/aws-sqs/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -1,14 +1,14 @@
 <blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0"
-    xmlns:ext="http://aries.apache.org/blueprint/xmlns/blueprint-ext/v1.1.0"
+    xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.3.0"
+    xmlns:ext="http://aries.apache.org/blueprint/xmlns/blueprint-ext/v1.5.0"
     xsi:schemaLocation="
 		http://www.osgi.org/xmlns/blueprint/v1.0.0 
 		http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd
-		http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0
-		http://aries.apache.org/schemas/blueprint-cm/blueprint-cm-1.1.0.xsd
-		http://aries.apache.org/blueprint/xmlns/blueprint-ext/v1.1.0
-		http://aries.apache.org/schemas/blueprint-ext/blueprint-ext-1.1.xsd
+		http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.3.0
+		http://aries.apache.org/schemas/blueprint-cm/blueprint-cm-1.3.0.xsd
+		http://aries.apache.org/blueprint/xmlns/blueprint-ext/v1.5.0
+		http://aries.apache.org/schemas/blueprint-ext/blueprint-ext-1.5.xsd
 		http://camel.apache.org/schema/blueprint
 		http://camel.apache.org/schema/blueprint/camel-blueprint-2.19.1.xsd
 ">

--- a/core/ipc/rpc/aws-sqs-impl/src/main/resources/META-INF/opennms/applicationContext-rpc-client-sqs.xml
+++ b/core/ipc/rpc/aws-sqs-impl/src/main/resources/META-INF/opennms/applicationContext-rpc-client-sqs.xml
@@ -11,7 +11,7 @@
   http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.2.xsd
   http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.2.xsd
   http://xmlns.opennms.org/xsd/spring/onms-osgi http://xmlns.opennms.org/xsd/spring/onms-osgi.xsd
-  http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring-2.14.4.xsd
+  http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring-2.19.1.xsd
 ">
 
   <context:annotation-config />

--- a/core/ipc/rpc/aws-sqs-impl/src/main/resources/OSGI-INF/blueprint/blueprint-rpc-server.xml
+++ b/core/ipc/rpc/aws-sqs-impl/src/main/resources/OSGI-INF/blueprint/blueprint-rpc-server.xml
@@ -1,14 +1,14 @@
 <blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0"
-    xmlns:ext="http://aries.apache.org/blueprint/xmlns/blueprint-ext/v1.1.0"
+    xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.3.0"
+    xmlns:ext="http://aries.apache.org/blueprint/xmlns/blueprint-ext/v1.5.0"
     xsi:schemaLocation="
 		http://www.osgi.org/xmlns/blueprint/v1.0.0 
 		http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd
-		http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0
-		http://aries.apache.org/schemas/blueprint-cm/blueprint-cm-1.1.0.xsd
-		http://aries.apache.org/blueprint/xmlns/blueprint-ext/v1.1.0
-		http://aries.apache.org/schemas/blueprint-ext/blueprint-ext-1.1.xsd
+		http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.3.0
+		http://aries.apache.org/schemas/blueprint-cm/blueprint-cm-1.3.0.xsd
+		http://aries.apache.org/blueprint/xmlns/blueprint-ext/v1.5.0
+		http://aries.apache.org/schemas/blueprint-ext/blueprint-ext-1.5.xsd
 		http://camel.apache.org/schema/blueprint
 		http://camel.apache.org/schema/blueprint/camel-blueprint-2.19.1.xsd
 ">

--- a/core/ipc/rpc/jms-impl/src/main/resources/META-INF/opennms/applicationContext-rpc-client-jms.xml
+++ b/core/ipc/rpc/jms-impl/src/main/resources/META-INF/opennms/applicationContext-rpc-client-jms.xml
@@ -11,7 +11,7 @@
   http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.2.xsd
   http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.2.xsd
   http://xmlns.opennms.org/xsd/spring/onms-osgi http://xmlns.opennms.org/xsd/spring/onms-osgi.xsd
-  http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring-2.14.4.xsd
+  http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring-2.19.1.xsd
 ">
 
   <context:annotation-config />

--- a/core/ipc/sink/aws-sqs-impl/src/main/resources/OSGI-INF/blueprint/blueprint-ipc-client.xml
+++ b/core/ipc/sink/aws-sqs-impl/src/main/resources/OSGI-INF/blueprint/blueprint-ipc-client.xml
@@ -1,14 +1,14 @@
 <blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0"
-    xmlns:ext="http://aries.apache.org/blueprint/xmlns/blueprint-ext/v1.1.0"
+    xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.3.0"
+    xmlns:ext="http://aries.apache.org/blueprint/xmlns/blueprint-ext/v1.5.0"
     xsi:schemaLocation="
 		http://www.osgi.org/xmlns/blueprint/v1.0.0 
 		http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd
-		http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0
-		http://aries.apache.org/schemas/blueprint-cm/blueprint-cm-1.1.0.xsd
-		http://aries.apache.org/blueprint/xmlns/blueprint-ext/v1.1.0
-		http://aries.apache.org/schemas/blueprint-ext/blueprint-ext-1.1.xsd
+		http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.3.0
+		http://aries.apache.org/schemas/blueprint-cm/blueprint-cm-1.3.0.xsd
+		http://aries.apache.org/blueprint/xmlns/blueprint-ext/v1.5.0
+		http://aries.apache.org/schemas/blueprint-ext/blueprint-ext-1.5.xsd
 ">
 
 	<reference id="awsSqsConfig" interface="org.opennms.core.ipc.common.aws.sqs.AmazonSQSConfig" />

--- a/core/ipc/sink/camel-impl/src/main/resources/META-INF/opennms/applicationContext-ipc-sink-server-camel.xml
+++ b/core/ipc/sink/camel-impl/src/main/resources/META-INF/opennms/applicationContext-ipc-sink-server-camel.xml
@@ -11,7 +11,7 @@
   http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.2.xsd
   http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.2.xsd
   http://xmlns.opennms.org/xsd/spring/onms-osgi http://xmlns.opennms.org/xsd/spring/onms-osgi.xsd
-  http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring-2.14.4.xsd
+  http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring-2.19.1.xsd
 ">
 
   <context:annotation-config />

--- a/core/test-api/karaf/src/main/java/org/opennms/core/test/karaf/KarafTestCase.java
+++ b/core/test-api/karaf/src/main/java/org/opennms/core/test/karaf/KarafTestCase.java
@@ -239,6 +239,7 @@ public abstract class KarafTestCase {
                     // These repositories are unpacked by the opennms-full-assembly project's build
                     // for final integration testing
                     "file:${karaf.home}/../../opennms-repo@snapshots@id=opennms-repo",
+                    "file:${karaf.home}/../../experimental-repo@snapshots@id=experimental-repo",
                     "file:${karaf.home}/../../minion-core-repo@snapshots@id=minion-core-repo",
                     "file:${karaf.home}/../../minion-default-repo@snapshots@id=minion-default-repo"
                 })

--- a/features/opennms-osgi-core-rest/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/features/opennms-osgi-core-rest/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -1,9 +1,9 @@
 <blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
-           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.3.0"
            xsi:schemaLocation="
 http://www.osgi.org/xmlns/blueprint/v1.0.0 http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd
-http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0 http://aries.apache.org/schemas/blueprint-cm/blueprint-cm-1.1.0.xsd
-http://www.osgi.org/xmlns/blueprint-ext/v1.1.0 http://aries.apache.org/schemas/blueprint-ext/blueprint-ext-1.1.xsd">
+http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.3.0 http://aries.apache.org/schemas/blueprint-cm/blueprint-cm-1.3.0.xsd
+http://aries.apache.org/blueprint/xmlns/blueprint-ext/v1.5.0 http://aries.apache.org/schemas/blueprint-ext/blueprint-ext-1.5.xsd">
 
     <service interface="javax.ws.rs.ext.ExceptionMapper">
         <bean class="org.opennms.web.rest.support.NotFoundProvider"/>

--- a/features/rest-provider/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/features/rest-provider/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -1,9 +1,9 @@
 <blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
-           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.3.0"
            xsi:schemaLocation="
 http://www.osgi.org/xmlns/blueprint/v1.0.0 http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd
-http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0 http://aries.apache.org/schemas/blueprint-cm/blueprint-cm-1.1.0.xsd
-http://www.osgi.org/xmlns/blueprint-ext/v1.1.0 http://aries.apache.org/schemas/blueprint-ext/blueprint-ext-1.1.xsd">
+http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.3.0 http://aries.apache.org/schemas/blueprint-cm/blueprint-cm-1.3.0.xsd
+http://aries.apache.org/blueprint/xmlns/blueprint-ext/v1.5.0 http://aries.apache.org/schemas/blueprint-ext/blueprint-ext-1.5.xsd">
 
     <service interface="javax.ws.rs.ext.ExceptionMapper">
         <bean class="org.opennms.web.rest.support.NotFoundProvider"/>

--- a/features/telemetry/adapters/jti/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/features/telemetry/adapters/jti/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -1,12 +1,12 @@
 <blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0" xmlns:ext="http://aries.apache.org/blueprint/xmlns/blueprint-ext/v1.1.0"
+	xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.3.0" xmlns:ext="http://aries.apache.org/blueprint/xmlns/blueprint-ext/v1.5.0"
 	xsi:schemaLocation="
 		http://www.osgi.org/xmlns/blueprint/v1.0.0 
 		http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd
-		http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0
-		http://aries.apache.org/schemas/blueprint-cm/blueprint-cm-1.1.0.xsd
-		http://aries.apache.org/blueprint/xmlns/blueprint-ext/v1.1.0
-		http://aries.apache.org/schemas/blueprint-ext/blueprint-ext-1.1.xsd
+		http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.3.0
+		http://aries.apache.org/schemas/blueprint-cm/blueprint-cm-1.3.0.xsd
+		http://aries.apache.org/blueprint/xmlns/blueprint-ext/v1.5.0
+		http://aries.apache.org/schemas/blueprint-ext/blueprint-ext-1.5.xsd
 ">
 
 	<bean id="jtiFactory" class="org.opennms.netmgt.telemetry.adapters.jti.JtiAdapterFactory">

--- a/features/telemetry/adapters/nxos/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/features/telemetry/adapters/nxos/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -1,12 +1,12 @@
 <blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0" xmlns:ext="http://aries.apache.org/blueprint/xmlns/blueprint-ext/v1.1.0"
+	xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.3.0" xmlns:ext="http://aries.apache.org/blueprint/xmlns/blueprint-ext/v1.5.0"
 	xsi:schemaLocation="
 		http://www.osgi.org/xmlns/blueprint/v1.0.0 
 		http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd
-		http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0
-		http://aries.apache.org/schemas/blueprint-cm/blueprint-cm-1.1.0.xsd
-		http://aries.apache.org/blueprint/xmlns/blueprint-ext/v1.1.0
-		http://aries.apache.org/schemas/blueprint-ext/blueprint-ext-1.1.xsd
+		http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.3.0
+		http://aries.apache.org/schemas/blueprint-cm/blueprint-cm-1.3.0.xsd
+		http://aries.apache.org/blueprint/xmlns/blueprint-ext/v1.5.0
+		http://aries.apache.org/schemas/blueprint-ext/blueprint-ext-1.5.xsd
 ">
 
 	<bean id="nxosAdapterFactory" class="org.opennms.netmgt.telemetry.adapters.nxos.NxosAdapterFactory">

--- a/features/telemetry/minion/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/features/telemetry/minion/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -1,14 +1,14 @@
 <blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-           xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0"
-           xmlns:ext="http://aries.apache.org/blueprint/xmlns/blueprint-ext/v1.1.0"
+           xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.3.0"
+           xmlns:ext="http://aries.apache.org/blueprint/xmlns/blueprint-ext/v1.5.0"
            xsi:schemaLocation="
 		http://www.osgi.org/xmlns/blueprint/v1.0.0
 		http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd
-		http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0
-		http://aries.apache.org/schemas/blueprint-cm/blueprint-cm-1.1.0.xsd
-		http://aries.apache.org/blueprint/xmlns/blueprint-ext/v1.1.0
-		http://aries.apache.org/schemas/blueprint-ext/blueprint-ext-1.1.xsd
+		http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.3.0
+		http://aries.apache.org/schemas/blueprint-cm/blueprint-cm-1.3.0.xsd
+		http://aries.apache.org/blueprint/xmlns/blueprint-ext/v1.5.0
+		http://aries.apache.org/schemas/blueprint-ext/blueprint-ext-1.5.xsd
 ">
 
     <reference id="distPollerDao" interface="org.opennms.netmgt.dao.api.DistPollerDao"/>

--- a/opennms-full-assembly/pom.xml
+++ b/opennms-full-assembly/pom.xml
@@ -273,7 +273,7 @@
               <goal>features-add-to-repository</goal>
             </goals>
             <configuration>
-              <karafVersion>DONT_USE_STANDARD_FEATURES</karafVersion>
+              <karafVersion>${karafVersion}</karafVersion>
               <descriptors>
                 <!-- 
                   All of these feature files need to be added to the featuresRepositories parameter in the
@@ -384,6 +384,30 @@
               <repository>${project.build.directory}/opennms-repo</repository>
             </configuration>
           </execution>
+          <!-- Create an experimental repo so that it can be used in integration tests -->
+          <execution>
+            <id>features-add-to-repository-experimental</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>features-add-to-repository</goal>
+            </goals>
+            <configuration>
+              <karafVersion>${karafVersion}</karafVersion>
+              <descriptors>
+                <descriptor>mvn:org.opennms.karaf/opennms/${project.version}/xml/spring</descriptor>
+                <descriptor>mvn:org.opennms.karaf/opennms/${project.version}/xml/spring-legacy</descriptor>
+                <descriptor>mvn:org.opennms.karaf/opennms/${project.version}/xml/experimental</descriptor>
+              </descriptors>
+              <features>
+                <!-- Experimental features that are not included in OpenNMS -->
+                <feature>opennms-discovery</feature>
+                <feature>opennms-events-daemon</feature>
+                <feature>opennms-reporting</feature>
+                <feature>opennms-webapp</feature>
+              </features>
+              <repository>${project.build.directory}/experimental-repo</repository>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
       <plugin>
@@ -425,6 +449,9 @@
               <filesets> 
                 <fileset> 
                   <directory>${project.build.directory}/opennms-repo</directory>
+                </fileset> 
+                <fileset> 
+                  <directory>${project.build.directory}/experimental-repo</directory>
                 </fileset> 
                 <fileset> 
                   <directory>${project.build.directory}/minion-core-repo</directory>

--- a/opennms-full-assembly/src/test/java/org/opennms/assemblies/karaf/FeatureInstallKarafIT.java
+++ b/opennms-full-assembly/src/test/java/org/opennms/assemblies/karaf/FeatureInstallKarafIT.java
@@ -83,10 +83,6 @@ public class FeatureInstallKarafIT extends KarafTestCase {
         installFeature("jrobin");
         installFeature("json-lib");
         installFeature("lmax-disruptor");
-        //installFeature("opennms-activemq-config");
-        //installFeature("opennms-activemq");
-        //installFeature("opennms-activemq-dispatcher-config");
-        //installFeature("opennms-activemq-dispatcher");
         // OSGi dependency problems: org.opennms.netmgt.alarmd.api
         //installFeature("opennms-amqp-alarm-northbounder");
         installFeature("opennms-amqp-event-forwarder");
@@ -105,16 +101,7 @@ public class FeatureInstallKarafIT extends KarafTestCase {
         installFeature("opennms-dao-api");
         // OSGi dependency problems: org.apache.activemq.broker
         //installFeature("opennms-dao");
-        // Minion-only feature
-        //installFeature("opennms-discoverer");
-        //installFeature("opennms-discovery-daemon");
-        // OSGi dependency problems: org.apache.activemq.broker
-        //installFeature("opennms-discovery");
-        // Minion-only feature
-        //installFeature("opennms-discovery-distPollerDaoMinion");
         installFeature("opennms-events-api");
-        // OSGi dependency problems: org.apache.activemq.broker
-        //installFeature("opennms-events-daemon");
         installFeature("opennms-icmp-api");
         installFeature("opennms-icmp-jna");
         installFeature("opennms-icmp-jni");
@@ -125,8 +112,6 @@ public class FeatureInstallKarafIT extends KarafTestCase {
         installFeature("opennms-poller-api");
         // OSGi dependency problems
         //installFeature("opennms-provisioning");
-        // OSGi dependency problems
-        //installFeature("opennms-reporting");
         installFeature("opennms-rrd-api");
         installFeature("opennms-rrd-jrobin");
         installFeature("opennms-snmp");
@@ -138,8 +123,6 @@ public class FeatureInstallKarafIT extends KarafTestCase {
 
         installFeature("opennms-trapd");
 
-        // OSGi dependency problems
-        //installFeature("opennms-webapp");
         installFeature("org.json");
         installFeature("postgresql");
         installFeature("spring-security32");

--- a/opennms-full-assembly/src/test/java/org/opennms/assemblies/karaf/OnmsExperimentalFeaturesKarafIT.java
+++ b/opennms-full-assembly/src/test/java/org/opennms/assemblies/karaf/OnmsExperimentalFeaturesKarafIT.java
@@ -1,0 +1,86 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2014-2015 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2015 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.assemblies.karaf;
+
+import static org.ops4j.pax.exam.CoreOptions.maven;
+
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.opennms.core.test.karaf.KarafTestCase;
+import org.ops4j.pax.exam.junit.PaxExam;
+import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
+import org.ops4j.pax.exam.spi.reactors.PerMethod;
+
+/**
+ * <p>This test checks that the features from:</p>
+ * <code>
+ * mvn:org.opennms.karaf/opennms/${currentVersion}/xml/experimental
+ * <code>
+ * <p>load correctly in Karaf.</p>
+ * 
+ * @author Seth
+ */
+@RunWith(PaxExam.class)
+@ExamReactorStrategy(PerMethod.class)
+public class OnmsExperimentalFeaturesKarafIT extends KarafTestCase {
+
+	@Before
+	public void setUp() {
+		final String version = getOpenNMSVersion();
+		addFeaturesUrl(maven().groupId("org.opennms.karaf").artifactId("opennms").version(version).type("xml").classifier("standard").getURL());
+		addFeaturesUrl(maven().groupId("org.opennms.karaf").artifactId("opennms").version(version).type("xml").classifier("spring-legacy").getURL());
+		addFeaturesUrl(maven().groupId("org.opennms.karaf").artifactId("opennms").version(version).type("xml").classifier("experimental").getURL());
+	}
+
+	@Test
+	public void testInstallFeatureOpennmsDiscovery() {
+		installFeature("opennms-discovery");
+		System.out.println(executeCommand("feature:list -i"));
+	}
+	@Test
+	@Ignore("OSGi dependency problems: org.apache.activemq.broker")
+	public void testInstallFeatureOpennmsEventsDaemon() {
+		installFeature("opennms-events-daemon");
+		System.out.println(executeCommand("feature:list -i"));
+	}
+	@Test
+	@Ignore("OSGi dependency problems: org.opennms.rancid")
+	public void testInstallFeatureOpennmsReporting() {
+		installFeature("opennms-reporting");
+		System.out.println(executeCommand("feature:list -i"));
+	}
+	@Test
+	@Ignore("Experimental feature")
+	public void testInstallFeatureOpennmsWebapp() {
+		installFeature("opennms-webapp");
+		System.out.println(executeCommand("feature:list -i"));
+	}
+}

--- a/opennms-full-assembly/src/test/java/org/opennms/assemblies/karaf/OnmsFeatureKarafIT.java
+++ b/opennms-full-assembly/src/test/java/org/opennms/assemblies/karaf/OnmsFeatureKarafIT.java
@@ -416,19 +416,8 @@ public class OnmsFeatureKarafIT extends KarafTestCase {
 		System.out.println(executeCommand("feature:list -i"));
 	}
 	@Test
-	public void testInstallFeatureOpennmsDiscovery() {
-		installFeature("opennms-discovery");
-		System.out.println(executeCommand("feature:list -i"));
-	}
-	@Test
 	public void testInstallFeatureOpennmsEventsApi() {
 		installFeature("opennms-events-api");
-		System.out.println(executeCommand("feature:list -i"));
-	}
-	@Test
-	@Ignore("OSGi dependency problems: org.apache.activemq.broker")
-	public void testInstallFeatureOpennmsEventsDaemon() {
-		installFeature("opennms-events-daemon");
 		System.out.println(executeCommand("feature:list -i"));
 	}
 	@Test
@@ -532,12 +521,6 @@ public class OnmsFeatureKarafIT extends KarafTestCase {
 		System.out.println(executeCommand("feature:list -i"));
 	}
 	@Test
-	@Ignore("OSGi dependency problems: org.opennms.rancid")
-	public void testInstallFeatureOpennmsReporting() {
-		installFeature("opennms-reporting");
-		System.out.println(executeCommand("feature:list -i"));
-	}
-	@Test
 	public void testInstallFeatureOpennmsRrdApi() {
 		installFeature("opennms-rrd-api");
 		System.out.println(executeCommand("feature:list -i"));
@@ -606,12 +589,6 @@ public class OnmsFeatureKarafIT extends KarafTestCase {
 	@Ignore("OSGi dependency problems: javax.persistence")
 	public void testInstallFeatureOpennmsVmware() {
 		installFeature("opennms-vmware");
-		System.out.println(executeCommand("feature:list -i"));
-	}
-	@Test
-	@Ignore("Experimental feature")
-	public void testInstallFeatureOpennmsWebapp() {
-		installFeature("opennms-webapp");
 		System.out.println(executeCommand("feature:list -i"));
 	}
 	@Test


### PR DESCRIPTION
The PR creates a `features-experimental.xml` file for Karaf features that are not used in the product because they are not yet needed or do not load correctly due to OSGi dependency issues. These features may be useful at some point, for instance for running daemon processes or the webapp inside Karaf. I'm splitting them out so that people won't be confused by unsupported features inside the main `features.xml` file.

Please do not delete the branch, I'm using it for other work that's in progress.

* JIRA: http://issues.opennms.org/browse/HZN-1203