### PR TITLE
NMS-9799: Update notifd to reference new event_parameters table

### DIFF
--- a/opennms-config/src/main/java/org/opennms/netmgt/config/NotificationManager.java
+++ b/opennms-config/src/main/java/org/opennms/netmgt/config/NotificationManager.java
@@ -943,7 +943,9 @@ public abstract class NotificationManager {
 
             final ResultSet results = statement.executeQuery();
             d.watch(results);
-            results.next();
+            if (!results.next()) {
+                throw new SQLException("No serviceID found for service with serviceName: " + service);
+            }
 
             serviceID = results.getInt(1);
 

--- a/opennms-config/src/main/java/org/opennms/netmgt/config/NotificationManager.java
+++ b/opennms-config/src/main/java/org/opennms/netmgt/config/NotificationManager.java
@@ -44,6 +44,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -521,8 +522,6 @@ public abstract class NotificationManager {
             // First get most recent event ID from notifications 
             // that match the matchList, then get all notifications
             // with this event ID
-            Connection connection = getConnection();
-            dbUtils.watch(connection);
 
             // Verify if parameter matching is required
             boolean matchParameters = false;
@@ -533,64 +532,58 @@ public abstract class NotificationManager {
                 }
             }
 
-            final StringBuilder sql = new StringBuilder(matchParameters ? "SELECT n.eventid FROM notifications n, events e WHERE n.eventid = e.eventid AND n.eventuei=? " : "SELECT n.eventid FROM notifications n WHERE n.eventuei=? ");
+            final Map<String, String> eventParametersToMatch = new LinkedHashMap<>();
+            final StringBuilder sql = new StringBuilder("SELECT n.eventid FROM notifications n ");
+            if (matchParameters) {
+                sql.append("INNER JOIN events as e on e.eventid = n.eventid ");
+                for (int i = 0; i < matchList.length; i++) {
+                    if (matchList[i].startsWith("parm[")) {
+                        if (appendParameterNameAndValue(matchList[i], event, eventParametersToMatch)) {
+                            sql.append(String.format("INNER JOIN event_parameters as ep%d on ep%d.eventid = n.eventid and ep%d.name=? and ep%d.value=? ",
+                                    i, i, i, i));
+                        } else {
+                            // The given event does contain the specified parameter, so no match can be made
+                            LOG.warn("No parameter matching {} was found on {}. No notices with UEI {} will be acknowledged.",
+                                    matchList[i], event, uei);
+                            // No DB connections have been acquired yet, so we can return immediately
+                            return Collections.emptyList();
+                        }
+                    }
+                }
+                LOG.debug("Matching notices with UEI {} against event parameters: {}", uei, eventParametersToMatch);
+            }
+            sql.append("WHERE n.eventuei=? ");
             for (int i = 0; i < matchList.length; i++) {
-                if (matchList[i].startsWith("parm[")) {
-                    sql.append("AND e.eventparms LIKE ? ");
-                } else {
+                if (!matchList[i].startsWith("parm[")) {
                     sql.append("AND n.").append(matchList[i]).append("=? ");
                 }
             }
             sql.append("ORDER BY eventid desc limit 1");
+
+            Connection connection = getConnection();
+            dbUtils.watch(connection);
             PreparedStatement statement = connection.prepareStatement(sql.toString());
             dbUtils.watch(statement);
-            statement.setString(1, uei);
+
+            int offset = 1;
+            for (Map.Entry<String, String> eventParameterToMatch : eventParametersToMatch.entrySet()) {
+                statement.setString(offset++, eventParameterToMatch.getKey());
+                statement.setString(offset++, eventParameterToMatch.getValue());
+            }
+
+            statement.setString(offset++, uei);
 
             for (int i = 0; i < matchList.length; i++) {
                 if (matchList[i].equals("nodeid")) {
-                    statement.setLong(i + 2, event.getNodeid());
-                }
-
-                if (matchList[i].equals("interfaceid")) {
-                    statement.setString(i + 2, event.getInterface());
-                }
-
-                if (matchList[i].equals("serviceid")) {
-                    statement.setInt(i + 2, getServiceId(event.getService()));
-                }
-
-                if (matchList[i].startsWith("parm[")) {
-                    String match = matchList[i];
-                    String key = null;
-                    String param = null;
-                    String value = null;
-                    try {
-                        key = match.substring(match.indexOf('[') + 1, match.indexOf(']'));
-                    } catch (Exception e) {}
-                    if (key != null) {
-                        int numkey = 0;
-                        if (key.startsWith("#")) {
-                            try {
-                                numkey = Integer.parseInt(key.substring(1));
-                            } catch (Exception e) {}
-                        }
-                        int idx = 1;
-                        for (Parm p : event.getParmCollection()) {
-                            if (numkey > 0) {
-                                if (numkey == idx) {
-                                    param = p.getParmName();
-                                    value = p.getValue().getContent();
-                                }
-                            } else {
-                                if (p.getParmName().equalsIgnoreCase(key)) {
-                                    param = p.getParmName();
-                                    value = p.getValue().getContent();
-                                }
-                            }
-                            idx++;
-                        }
-                    }
-                    statement.setString(i + 2, '%' + param + '=' + value + '%');
+                    statement.setLong(offset++, event.getNodeid());
+                } else if (matchList[i].equals("interfaceid")) {
+                    statement.setString(offset++, event.getInterface());
+                } else if (matchList[i].equals("serviceid")) {
+                    statement.setInt(offset++, getServiceId(event.getService()));
+                } else if (matchList[i].startsWith("parm[")) {
+                    // Ignore
+                } else {
+                    LOG.warn("Unknown match statement {} for UEI {}.", matchList[i], uei);
                 }
             }
 
@@ -606,6 +599,55 @@ public abstract class NotificationManager {
             dbUtils.cleanUp();
         }
         return notifIDs;
+    }
+
+    /**
+     * Parses the given match statement i.e. param[key] or parm[#99] and retrieves the corresponding
+     * parameter from the given event.
+     *
+     * If the parameter is found, it is added to the map and <code>true</code> is returned, otherwise <code>false</code>
+     * is returned.
+     *
+     * @param match notification match statement
+     * @param event event to match
+     * @param eventParametersToMatch ordered map of event parameters we need to match
+     * @return <code>true</code> if the map was modified, <code>false</code> otherwise
+     */
+    private static boolean appendParameterNameAndValue(String match, Event event, Map<String, String> eventParametersToMatch) {
+        String key = null;
+        String param = null;
+        String value = null;
+        try {
+            key = match.substring(match.indexOf('[') + 1, match.indexOf(']'));
+        } catch (Exception e) {}
+        if (key != null) {
+            int numkey = 0;
+            if (key.startsWith("#")) {
+                try {
+                    numkey = Integer.parseInt(key.substring(1));
+                } catch (Exception e) {}
+            }
+            int idx = 1;
+            for (Parm p : event.getParmCollection()) {
+                if (numkey > 0) {
+                    if (numkey == idx) {
+                        param = p.getParmName();
+                        value = p.getValue().getContent();
+                    }
+                } else {
+                    if (p.getParmName().equalsIgnoreCase(key)) {
+                        param = p.getParmName();
+                        value = p.getValue().getContent();
+                    }
+                }
+                idx++;
+            }
+        }
+        if (param == null || value == null) {
+            return false;
+        }
+        eventParametersToMatch.put(param, value);
+        return true;
     }
 
     /**

--- a/opennms-dao/src/test/java/org/opennms/netmgt/config/NotificationManagerIT.java
+++ b/opennms-dao/src/test/java/org/opennms/netmgt/config/NotificationManagerIT.java
@@ -32,6 +32,8 @@ import static org.junit.Assert.assertEquals;
 import static org.opennms.core.utils.InetAddressUtils.addr;
 
 import java.io.IOException;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.Collection;
@@ -48,6 +50,8 @@ import org.opennms.core.spring.BeanUtils;
 import org.opennms.core.test.ConfigurationTestUtils;
 import org.opennms.core.test.OpenNMSJUnit4ClassRunner;
 import org.opennms.core.test.db.annotations.JUnitTemporaryDatabase;
+import org.opennms.core.utils.DBUtils;
+import org.opennms.core.utils.InetAddressUtils;
 import org.opennms.netmgt.config.mock.MockNotifdConfigManager;
 import org.opennms.netmgt.config.notifications.Notification;
 import org.opennms.netmgt.dao.api.CategoryDao;
@@ -120,6 +124,9 @@ public class NotificationManagerIT implements InitializingBean {
     private NotificationManagerImpl m_notificationManager;
     private NotifdConfigManager m_configManager;
 
+    private OnmsNode node1;
+    private OnmsIpInterface ipInterfaceOnNode1;
+
     @Override
     public void afterPropertiesSet() throws Exception {
         BeanUtils.assertAutowiring(this);
@@ -136,7 +143,7 @@ public class NotificationManagerIT implements InitializingBean {
         FilterDaoFactory.setInstance(jdbcFilterDao);
 
         m_configManager = new MockNotifdConfigManager(ConfigurationTestUtils.getConfigForResourceWithReplacements(this, "notifd-configuration.xml"));
-        m_notificationManager = new NotificationManagerImpl(m_configManager, m_dataSource);
+        m_notificationManager = new NotificationManagerIT.NotificationManagerImpl(m_configManager, m_dataSource);
 
         OnmsNode node;
         OnmsIpInterface ipInterface;
@@ -153,50 +160,55 @@ public class NotificationManagerIT implements InitializingBean {
         m_categoryDao.save(category4);
         m_categoryDao.flush();
 
-        // node 1
+        serviceType = new OnmsServiceType("ICMP");
+        m_serviceTypeDao.save(serviceType);
+
         serviceType = new OnmsServiceType("HTTP");
         m_serviceTypeDao.save(serviceType);
 
-		node = new OnmsNode(m_locationDao.getDefaultLocation(), "node 1");
-		node.addCategory(category1);
-		node.addCategory(category2);
-		node.addCategory(category3);
-		
-		ipInterface = new OnmsIpInterface(addr("192.168.1.1"), node);
+        // node 1
+        node = new OnmsNode(m_locationDao.getDefaultLocation(), "node 1");
+        node.addCategory(category1);
+        node.addCategory(category2);
+        node.addCategory(category3);
+        node1 = node;
+
+        ipInterface = new OnmsIpInterface(addr("192.168.1.1"), node);
+        ipInterfaceOnNode1 = ipInterface;
         service = new OnmsMonitoredService(ipInterface, serviceType);
-		m_nodeDao.save(node);
+        m_nodeDao.save(node);
 
         // node 2
         node = new OnmsNode(m_locationDao.getDefaultLocation(), "node 2");
-		node.addCategory(category1);
-		node.addCategory(category2);
-		node.addCategory(category4);
-		m_nodeDao.save(node);
-        
+        node.addCategory(category1);
+        node.addCategory(category2);
+        node.addCategory(category4);
+        m_nodeDao.save(node);
+
         ipInterface = new OnmsIpInterface(addr("192.168.1.1"), node);
         m_ipInterfaceDao.save(ipInterface);
         service = new OnmsMonitoredService(ipInterface, serviceType);
         m_serviceDao.save(service);
-        
+
         ipInterface = new OnmsIpInterface(addr("0.0.0.0"), node);
         m_ipInterfaceDao.save(ipInterface);
-        
+
         // node 3
         node = new OnmsNode(m_locationDao.getDefaultLocation(), "node 3");
         m_nodeDao.save(node);
-        
+
         ipInterface = new OnmsIpInterface(addr("192.168.1.2"), node);
         m_ipInterfaceDao.save(ipInterface);
         service = new OnmsMonitoredService(ipInterface, serviceType);
         m_serviceDao.save(service);
-        
+
         // node 4 has an interface, but no services
         node = new OnmsNode(m_locationDao.getDefaultLocation(), "node 4");
         m_nodeDao.save(node);
 
         ipInterface = new OnmsIpInterface(addr("192.168.1.3"), node);
         m_ipInterfaceDao.save(ipInterface);
-        
+
         // node 5 has no interfaces
         node = new OnmsNode(m_locationDao.getDefaultLocation(), "node 5");
         m_nodeDao.save(node);
@@ -433,6 +445,7 @@ public class NotificationManagerIT implements InitializingBean {
                 false);
     }
 
+
     @Test
     @JUnitTemporaryDatabase
     public void canMatchEventParametersWhenAcknowledgingNotices() throws IOException, SQLException {
@@ -446,6 +459,7 @@ public class NotificationManagerIT implements InitializingBean {
         dbEvent.setEventSeverity(OnmsSeverity.CRITICAL.getId());
         dbEvent.setEventSource("test");
         dbEvent.setEventTime(new Date());
+        dbEvent.setNode(node1);
         dbEvent.setEventParameters(Arrays.asList(
                 new OnmsEventParameter(dbEvent, "some-parameter", "some-specific-value", "string"),
                 new OnmsEventParameter(dbEvent, "some-other-parameter", "some-other-specific-value", "string")
@@ -457,49 +471,87 @@ public class NotificationManagerIT implements InitializingBean {
         Notification notification = new Notification();
         Map<String, String> params = new ImmutableMap.Builder<String, String>()
                 .put(NotificationManager.PARAM_TEXT_MSG, "some text message")
+                .put(NotificationManager.PARAM_NODE, node1.getNodeId())
+                .put(NotificationManager.PARAM_INTERFACE, InetAddressUtils.toIpAddrString(ipInterfaceOnNode1.getIpAddress()))
+                .put(NotificationManager.PARAM_SERVICE, "ICMP")
                 .put("eventUEI", dbEvent.getEventUei())
                 .put("eventID", Integer.toString(dbEvent.getId()))
                 .build();
         m_notificationManager.insertNotice(1, params, "q1", notification);
 
-        final String[] matchList = new String[] {"parm[some-parameter]", "parm[#2]"};
+        final String[] parmMatchList = new String[] {"parm[some-parameter]", "parm[#2]"};
 
         // Verify that we're able to match the the notice when we have the same parameters set
         Event e = new EventBuilder(EventConstants.SERVICE_RESPONSIVE_EVENT_UEI, "test")
                 .addParam("some-parameter", "some-specific-value")
                 .addParam("some-other-parameter", "some-other-specific-value")
                 .getEvent();
-        Collection<Integer> eventIds = m_notificationManager.acknowledgeNotice(e, EventConstants.SERVICE_UNRESPONSIVE_EVENT_UEI, matchList);
+        Collection<Integer> eventIds = m_notificationManager.acknowledgeNotice(e, EventConstants.SERVICE_UNRESPONSIVE_EVENT_UEI, parmMatchList);
         assertEquals(1, eventIds.size());
         assertEquals(dbEvent.getId(), eventIds.iterator().next());
+        unacknowledgeAllNotices();
 
         // It should not match when either of the event parameters are different
         e = new EventBuilder(EventConstants.SERVICE_RESPONSIVE_EVENT_UEI, "test")
                 .addParam("some-parameter", "!some-specific-value")
                 .addParam("some-other-parameter", "some-other-specific-value")
                 .getEvent();
-        eventIds = m_notificationManager.acknowledgeNotice(e, EventConstants.SERVICE_UNRESPONSIVE_EVENT_UEI, matchList);
+        eventIds = m_notificationManager.acknowledgeNotice(e, EventConstants.SERVICE_UNRESPONSIVE_EVENT_UEI, parmMatchList);
         assertEquals(0, eventIds.size());
+        unacknowledgeAllNotices();
 
         e = new EventBuilder(EventConstants.SERVICE_RESPONSIVE_EVENT_UEI, "test")
                 .addParam("some-parameter", "some-specific-value")
                 .addParam("some-other-parameter", "!some-other-specific-value")
                 .getEvent();
-        eventIds = m_notificationManager.acknowledgeNotice(e, EventConstants.SERVICE_UNRESPONSIVE_EVENT_UEI, matchList);
+        eventIds = m_notificationManager.acknowledgeNotice(e, EventConstants.SERVICE_UNRESPONSIVE_EVENT_UEI, parmMatchList);
         assertEquals(0, eventIds.size());
+        unacknowledgeAllNotices();
 
         // It should not match when either of the event parameters are missing
         e = new EventBuilder(EventConstants.SERVICE_RESPONSIVE_EVENT_UEI, "test")
                 .addParam("some-other-parameter", "some-other-specific-value")
                 .getEvent();
-        eventIds = m_notificationManager.acknowledgeNotice(e, EventConstants.SERVICE_UNRESPONSIVE_EVENT_UEI, matchList);
+        eventIds = m_notificationManager.acknowledgeNotice(e, EventConstants.SERVICE_UNRESPONSIVE_EVENT_UEI, parmMatchList);
         assertEquals(0, eventIds.size());
+        unacknowledgeAllNotices();
 
         e = new EventBuilder(EventConstants.SERVICE_RESPONSIVE_EVENT_UEI, "test")
                 .addParam("some-parameter", "some-specific-value")
                 .getEvent();
-        eventIds = m_notificationManager.acknowledgeNotice(e, EventConstants.SERVICE_UNRESPONSIVE_EVENT_UEI, matchList);
+        eventIds = m_notificationManager.acknowledgeNotice(e, EventConstants.SERVICE_UNRESPONSIVE_EVENT_UEI, parmMatchList);
         assertEquals(0, eventIds.size());
+        unacknowledgeAllNotices();
+
+        // Now try matching on other fields without any event parameters
+        final String[] fieldMatchList = new String[] {"nodeid", "interfaceid", "serviceid"};
+        e = new EventBuilder(EventConstants.SERVICE_RESPONSIVE_EVENT_UEI, "test")
+                .setNodeid(node1.getId())
+                .setInterface(ipInterfaceOnNode1.getIpAddress())
+                .setService("ICMP")
+                .getEvent();
+        eventIds = m_notificationManager.acknowledgeNotice(e, EventConstants.SERVICE_UNRESPONSIVE_EVENT_UEI, fieldMatchList);
+        assertEquals(1, eventIds.size());
+        unacknowledgeAllNotices();
+
+        // Expect no match if we set different values responsive event
+        e = new EventBuilder(EventConstants.SERVICE_RESPONSIVE_EVENT_UEI, "test")
+                .setNodeid(node1.getId() + 1)
+                .setInterface(InetAddressUtils.UNPINGABLE_ADDRESS)
+                .setService("HTTP")
+                .getEvent();
+        eventIds = m_notificationManager.acknowledgeNotice(e, EventConstants.SERVICE_UNRESPONSIVE_EVENT_UEI, fieldMatchList);
+        assertEquals(0, eventIds.size());
+        unacknowledgeAllNotices();
+    }
+
+    private void unacknowledgeAllNotices() throws SQLException {
+        final DBUtils dbUtils = new DBUtils(getClass());
+        Connection connection = m_dataSource.getConnection();
+        dbUtils.watch(connection);
+        PreparedStatement statement = connection.prepareStatement("update notifications set answeredby = null, respondtime = null");
+        dbUtils.watch(statement);
+        statement.execute();
     }
 
     private void doTestNodeInterfaceServiceWithRule(String description, int nodeId, String intf, String svc, String rule, boolean matches) {


### PR DESCRIPTION
JIRA: https://issues.opennms.org/browse/NMS-9799

Here we update notifd to reference the new event_parameters table instead of the eventparms column when performing acknowledgments.

