### PR TITLE
NMS-9695: Fix ClassNotFoundException by removing log4j.ignoreTCL=true

### DIFF
--- a/container/servlet/src/main/java/org/opennms/container/web/WebAppListener.java
+++ b/container/servlet/src/main/java/org/opennms/container/web/WebAppListener.java
@@ -56,15 +56,6 @@ public class WebAppListener implements ServletContextListener {
 
             m_servletContext.log("contextInitialized");
 
-            // log4j class instances will leak into the OSGi classloader so we
-            // need to tell log4j to ignore the thread context loader and to use
-            // the same classloader for all classloading.
-            //
-            // @see https://issues.apache.org/jira/browse/FELIX-2108
-            // @see http://www.mail-archive.com/announcements@jakarta.apache.org/msg00110.html
-            //
-            System.setProperty("log4j.ignoreTCL", "true");
-
             final String root = karafRoot.getAbsolutePath();
             m_servletContext.log("Root: " + root);
             System.setProperty("karaf.home", root);


### PR DESCRIPTION
Removing this old workaround fixes the `ClassNotFoundException` inside `output.log`. I don't think there was any real effect on the logging: it seems to work identically regardless of the `log4j.ignoreTCL` setting (except for the `ClassNotFoundException` stack trace).

Right now, we have identical versions of log4j2 inside Karaf and in the OpenNMS system classpath (2.8.2). We'll have to keep an eye on this in case we ever have mismatched versions and then run into problems.

* JIRA: http://issues.opennms.org/browse/NMS-9695