### PR TITLE
NMS-9773: Restore root logger additivity to org.opennms logger

### DIFF
--- a/container/karaf/src/main/filtered-resources/etc/org.ops4j.pax.logging.cfg
+++ b/container/karaf/src/main/filtered-resources/etc/org.ops4j.pax.logging.cfg
@@ -52,7 +52,6 @@ log4j2.logger.opennmsTopology.level = WARN
 # OPENNMS: Display all DEBUG logs for our code
 log4j2.logger.opennms.name = org.opennms
 log4j2.logger.opennms.level = DEBUG
-log4j2.logger.opennms.additivity = false
 
 # Appenders configuration
 


### PR DESCRIPTION
After upgrading Karaf, I left additivity set to `false` on the `org.opennms` logger without setting an appender for it. This meant that the log messages were dropped instead of being forwarded to the root appender. This fix should restore logging for our components inside `karaf.log`.

* JIRA: http://issues.opennms.org/browse/NMS-9773