### PR TITLE
HZN-1202, HZN-1203: Karaf feature cleanup, OSGi service tweaks

### DIFF
--- a/container/features/pom.xml
+++ b/container/features/pom.xml
@@ -233,6 +233,7 @@
             <feature>jrobin</feature>
             <feature>json-lib</feature>
             <feature>lmax-disruptor</feature>
+            <feature>opennms-activemq-pool</feature>
             <feature>opennms-bootstrap</feature>
             <feature>opennms-bundle-refresher</feature>
             <feature>opennms-collection-api</feature>
@@ -286,8 +287,6 @@
             <feature>twitter4j</feature>
 
             <!-- Features from other OpenNMS repositories -->
-            <feature>opennms-core</feature>
-            <feature>opennms-core-web</feature>
             <feature>opennms-jaas-login-module</feature>
             <feature>dashlet-alarms</feature>
             <feature>dashlet-bsm</feature>
@@ -329,6 +328,7 @@
             <feature>datachoices</feature>
             <feature>eif-adapter</feature>
             <feature>opennms-telemetry-collection</feature>
+            <feature>opennms-telemetry-daemon</feature>
             <feature>opennms-telemetry-jti</feature>
             <feature>opennms-telemetry-nxos</feature>
 

--- a/container/features/src/main/resources/features-experimental.xml
+++ b/container/features/src/main/resources/features-experimental.xml
@@ -43,7 +43,7 @@
     </feature>
 
     <feature name="opennms-activemq-component" description="OpenNMS :: Features :: ActiveMQ :: Component" version="${project.version}">
-      <bundle>mvn:org.opennms.features.activemq/org.opennms.features.activemq.pool/${project.version}</bundle>
+      <feature>opennms-activemq-pool</feature>
       <bundle>mvn:org.opennms.features.activemq/org.opennms.features.activemq.component/${project.version}</bundle>
     </feature>
 

--- a/container/features/src/main/resources/features-minion.xml
+++ b/container/features/src/main/resources/features-minion.xml
@@ -106,6 +106,8 @@
       <feature>opennms-config</feature>
       <feature>opennms-config-jaxb</feature>
       <feature>opennms-core-web</feature>
+      <!-- System classpath dependency of opennms-vmware -->
+      <feature>opennms-provisioning</feature>
       <feature>opennms-vmware</feature>
       <feature>opennms-xml-collector</feature>
       <feature>wmi-integration</feature>

--- a/container/features/src/main/resources/features.xml
+++ b/container/features/src/main/resources/features.xml
@@ -134,6 +134,9 @@
       <feature>commons-codec</feature>
       <feature>commons-digester</feature>
       <feature>commons-jxpath</feature>
+      <feature>commons-lang</feature>
+      <feature>javax.mail</feature>
+      <feature>javax.servlet</feature>
 
       <bundle>wrap:mvn:org.apache.ant/ant/1.8.2</bundle>
       <bundle>mvn:commons-configuration/commons-configuration/${commonsConfigurationVersion}</bundle>
@@ -163,8 +166,9 @@
       <bundle>mvn:org.apache.commons/commons-jexl/${commonsJexlVersion}</bundle>
     </feature>
 
-    <feature name="commons-jxpath" description="Apache :: commons-jxpath" version="1.3">
+    <feature name="commons-jxpath" description="Apache :: commons-jxpath" version="${commonsJxpathVersion}">
       <feature>commons-beanutils</feature>
+      <feature>javax.servlet</feature>
 
       <!-- jdom has OSGi issues... use the ServiceMix bundle for it -->
       <!-- @see https://developer.atlassian.com/docs/faq/plugin-framework-faq/using-jdom-in-osgi -->
@@ -245,6 +249,11 @@
       <bundle>mvn:javax.mail/mail/1.4.5</bundle>
     </feature>
 
+    <feature name="javax.servlet" description="javax.servlet" version="3.1.0">
+      <!-- Make sure that this matches the version from pax-jetty -->
+      <bundle start-level="30">mvn:javax.servlet/javax.servlet-api/3.1.0</bundle>
+    </feature>
+
     <feature name="javax.validation" description="javax.validation" version="1.0.0.GA">
       <!-- Declare versions for all exported packages -->
       <bundle dependency="true">wrap:mvn:javax.validation/validation-api/1.0.0.GA$Bundle-SymbolicName=javax.validation:validation-api&amp;Bundle-Version=1.0.0&amp;Export-Package=javax.validation;version="1.0.0",javax.validation.bootstrap;version="1.0.0",javax.validation.constraints;version="1.0.0",javax.validation.groups;version="1.0.0",javax.validation.metadata;version="1.0.0",javax.validation.spi;version="1.0.0"</bundle>
@@ -277,6 +286,7 @@
     </feature>
 
     <feature name="jolokia-client" description="Jolokia-Client" version="1.3.3">
+      <feature>javax.servlet</feature>
       <feature>json-simple</feature>
 
       <bundle dependency="true">mvn:org.apache.httpcomponents/httpcore-osgi/${httpcoreVersion}</bundle>
@@ -337,6 +347,7 @@
       <!-- spring-web is necessary for HTTP remoting -->
       <feature version="[4.2,4.3)">spring-web</feature>
       <feature>commons-codec</feature>
+      <feature>javax.servlet</feature>
 
       <bundle>wrap:mvn:org.springframework.ldap/spring-ldap-core/1.3.2.RELEASE$Export-Package=org.springframework.ldap*;version="1.3.2"</bundle>
       <bundle>mvn:org.springframework.security/spring-security-aspects/${springSecurityVersion}</bundle>
@@ -376,6 +387,18 @@
     <!-- OpenNMS features -->
     
     
+    <feature name="opennms-activemq-pool" description="OpenNMS :: Features :: ActiveMQ :: Pool" version="${project.version}">
+      <feature>activemq-client</feature>
+      <feature>camel-core</feature>
+      <feature>camel-jms</feature>
+      <feature>opennms-core</feature>
+
+      <!-- Missing dependency of activemq-client -->
+      <bundle dependency="true">mvn:org.ow2.asm/asm-all/5.2</bundle>
+
+      <bundle>mvn:org.opennms.features.activemq/org.opennms.features.activemq.pool/${project.version}</bundle>
+    </feature>
+
     <feature name="opennms-bootstrap" description="opennms-bootstrap" version="${project.version}">
       <bundle>wrap:mvn:org.opennms/opennms-bootstrap/${project.version}</bundle>
     </feature>
@@ -419,12 +442,18 @@
     </feature>
 
     <feature name="opennms-core-daemon" description="OpenNMS :: Core :: Daemon" version="${project.version}">
+      <feature>activemq-client</feature>
+      <feature>camel-jms</feature>
       <feature>guava</feature>
 
+      <feature>opennms-activemq-pool</feature>
       <feature>opennms-core</feature>
       <feature>opennms-config</feature>
       <feature>opennms-icmp-api</feature>
       <feature>opennms-model</feature>
+
+      <!-- Missing dependency of activemq-client -->
+      <bundle dependency="true">mvn:org.ow2.asm/asm-all/5.2</bundle>
 
       <bundle>mvn:org.opennms.core/org.opennms.core.daemon/${project.version}</bundle>
     </feature>
@@ -492,6 +521,15 @@
       <feature>opennms-collection-api</feature>
       -->
       <bundle>mvn:org.opennms.features.collection/org.opennms.features.collection.commands/${project.version}</bundle>
+    </feature>
+
+    <feature name="opennms-collection-core" description="OpenNMS :: Collection :: Core" version="${project.version}">
+      <feature>opennms-collection-api</feature>
+      <feature>opennms-config</feature>
+      <feature>opennms-core-ipc-rpc-api</feature>
+      <feature>opennms-dao-api</feature>
+
+      <bundle>mvn:org.opennms.features.collection/org.opennms.features.collection.core/${project.version}</bundle>
     </feature>
 
     <feature name="opennms-collection-persistence-rrd" description="OpenNMS :: Collection :: Persistence :: RRD" version="${project.version}">
@@ -577,6 +615,7 @@
     <feature name="opennms-core-ipc-sink-camel" description="OpenNMS :: Core :: IPC :: Sink :: Camel Impl." version="${project.version}">
       <feature>opennms-core-ipc-sink-api</feature>
       <feature>opennms-core-camel</feature>
+      <feature>opennms-dao-api</feature>
       <feature>minion-core-api</feature>
       <feature>camel-blueprint</feature>
       <feature>camel-jms</feature>
@@ -615,6 +654,7 @@
 
     <feature name="opennms-core-ipc-rpc-jms" description="OpenNMS :: Core :: IPC :: RPC :: JMS Impl." version="${project.version}">
       <feature>opennms-core-ipc-rpc-api</feature>
+      <feature>opennms-dao-api</feature>
       <bundle>mvn:org.opennms.core.ipc.rpc/org.opennms.core.ipc.rpc.jms-impl/${project.version}</bundle>
     </feature>
 
@@ -648,6 +688,7 @@
       <feature>hibernate-validator41</feature>
 
       <feature>opennms-collection-api</feature>
+      <feature>opennms-collection-core</feature>
       <feature>opennms-collection-persistence-rrd</feature>
       <feature>opennms-dao-api</feature>
       <!-- Parent Spring context -->
@@ -887,6 +928,8 @@
 
     <feature name="tsrm-troubleticketer" version="${project.version}" description="OpenNMS :: Features :: Ticketing :: Tivoli Service Request Manager (TSRM)">
         <feature version="${cxfVersion}">cxf-jaxws</feature>
+        <feature>javax.servlet</feature>
+
         <bundle>mvn:org.opennms.features.ticketing/org.opennms.features.ticketing.api/${project.version}</bundle>
         <bundle>mvn:org.opennms.features/opennms-integration-tsrm/${project.version}</bundle>
     </feature>
@@ -912,6 +955,7 @@
     
     <feature name="wsman-integration" version="${project.version}" description="OpenNMS :: Features :: WS-Man Integration">
       <feature>guava17</feature>
+      <feature>javax.servlet</feature>
 
       <!-- The version of Xerces, Xalan and BCEL declared here should match the
            versions declared in the parent pom of the corresponding CXF version -->
@@ -964,6 +1008,7 @@
     <feature name="opennms-provisioning-detectors" description="OpenNMS :: Provisioning :: Detectors" version="${project.version}">
       <feature>bsf</feature>
       <feature>commons-cli</feature>
+      <feature>javax.servlet</feature>
       <feature>jcifs</feature>
       <feature>jldap</feature>
       <feature>spring-security32</feature>
@@ -999,15 +1044,25 @@
       <!--
       These classes are in the system classpath inside OpenNMS
       <feature>opennms-provisioning</feature>
+      <feature>opennms-provisioning-detectors</feature>
       -->
       <bundle>mvn:org.opennms/opennms-provision-shell/${project.version}</bundle>
     </feature>
     
     <feature name="opennms-vmware" description="OpenNMS :: Integrations :: VMware Integration" version="${project.version}">
       <feature>commons-cli</feature>
+      <feature>commons-io</feature>
+      <feature>commons-lang</feature>
       <feature>guava</feature>
 
+      <!--
+      These classes are in the system classpath inside OpenNMS
+      <feature>opennms-core</feature>
       <feature>opennms-provisioning</feature>
+      -->
+
+      <bundle dependency="true">mvn:org.apache.httpcomponents/httpcore-osgi/${httpcoreVersion}</bundle>
+      <bundle dependency="true">mvn:org.apache.httpcomponents/httpclient-osgi/${httpclientVersion}</bundle>
 
       <bundle>wrap:mvn:com.toastcoders/yavijava/6.0.03</bundle>
       <bundle>wrap:mvn:org.sblim.slp/sblimSLPClient/1.17</bundle>
@@ -1062,6 +1117,27 @@
       <bundle>mvn:org.opennms.features.telemetry.adapters/org.opennms.features.telemetry.adapters.api/${project.version}</bundle>
       <bundle>mvn:org.opennms.features.telemetry.adapters/org.opennms.features.telemetry.adapters.collection/${project.version}</bundle>
       <bundle>mvn:org.opennms.features.telemetry.adapters/org.opennms.features.telemetry.adapters.factory/${project.version}</bundle>
+    </feature>
+
+    <feature name="opennms-telemetry-daemon" description="OpenNMS :: Telemetry :: Daemon" version="${project.version}">
+      <feature>camel-netty4</feature>
+      <!-- Needed to bootstrap opennms-core-ipc-sink-api Spring context -->
+      <feature>camel-spring</feature>
+
+      <feature>opennms-core-daemon</feature>
+      <feature>opennms-core-ipc-sink-api</feature>
+      <feature>opennms-dao-api</feature>
+      <feature>opennms-dao</feature>
+      <feature>opennms-telemetry-collection</feature>
+
+      <bundle dependency="true">mvn:com.google.protobuf/protobuf-java/${protobufVersion}</bundle>
+
+      <bundle>mvn:org.opennms.features.telemetry/org.opennms.features.telemetry.common/${project.version}</bundle>
+      <bundle>mvn:org.opennms.features.telemetry/org.opennms.features.telemetry.daemon/${project.version}</bundle>
+      <bundle>mvn:org.opennms.features.telemetry.adapters/org.opennms.features.telemetry.adapters.registry/${project.version}</bundle>
+      <bundle>mvn:org.opennms.features.telemetry.config/org.opennms.features.telemetry.config.jaxb/${project.version}</bundle>
+      <bundle>mvn:org.opennms.features.telemetry.listeners/org.opennms.features.telemetry.listeners.api/${project.version}</bundle>
+      <bundle>mvn:org.opennms.features.telemetry.listeners/org.opennms.features.telemetry.listeners.udp/${project.version}</bundle>
     </feature>
 
     <feature name="opennms-telemetry-jti" description="OpenNMS :: Telemetry :: JTI" version="${project.version}">

--- a/core/ipc/sink/aws-sqs-impl/src/main/resources/META-INF/opennms/applicationContext-ipc-sink-server-aws.xml
+++ b/core/ipc/sink/aws-sqs-impl/src/main/resources/META-INF/opennms/applicationContext-ipc-sink-server-aws.xml
@@ -20,9 +20,13 @@
   </bean>
 
   <bean id="awsMessageConsumerManager" class="org.opennms.core.ipc.sink.aws.sqs.AmazonSQSMessageConsumerManager">
-  	<property name="awsSqsManager" ref="awsSqsManager"/>
+    <property name="awsSqsManager" ref="awsSqsManager"/>
   </bean>
 
+  <onmsgi:service ref="awsMessageConsumerManager" interface="org.opennms.core.ipc.sink.api.MessageConsumerManager" />
+
   <bean id="awsLocalMessageDispatcherFactory" class="org.opennms.core.ipc.sink.aws.sqs.AmazonSQSLocalMessageDispatcherFactory" />
+
+  <onmsgi:service ref="awsLocalMessageDispatcherFactory" interface="org.opennms.core.ipc.sink.api.MessageDispatcherFactory" />
 
 </beans>

--- a/core/ipc/sink/camel-impl/src/main/resources/META-INF/opennms/applicationContext-ipc-sink-server-camel.xml
+++ b/core/ipc/sink/camel-impl/src/main/resources/META-INF/opennms/applicationContext-ipc-sink-server-camel.xml
@@ -30,7 +30,11 @@
     <constructor-arg ref="sinkServer"/>
   </bean>
 
+  <onmsgi:service ref="camelMessageConsumerManager" interface="org.opennms.core.ipc.sink.api.MessageConsumerManager" />
+
   <bean id="camelLocalMessageDispatcherFactory" class="org.opennms.core.ipc.sink.camel.CamelLocalMessageDispatcherFactory" />
+
+  <onmsgi:service ref="camelLocalMessageDispatcherFactory" interface="org.opennms.core.ipc.sink.api.MessageDispatcherFactory" />
 
   <!-- Reduces the graceful shutdown time from 300 to 15 seconds. -->
   <bean id="shutdownStrategy" class="org.apache.camel.impl.DefaultShutdownStrategy">

--- a/core/ipc/sink/kafka-impl/src/main/resources/META-INF/opennms/applicationContext-ipc-sink-server-kafka.xml
+++ b/core/ipc/sink/kafka-impl/src/main/resources/META-INF/opennms/applicationContext-ipc-sink-server-kafka.xml
@@ -15,8 +15,12 @@
 
   <bean id="kafkaMessageConsumerManager" class="org.opennms.core.ipc.sink.kafka.KafkaMessageConsumerManager" />
 
+  <onmsgi:service ref="kafkaMessageConsumerManager" interface="org.opennms.core.ipc.sink.api.MessageConsumerManager" />
+
   <bean id="kafkaLocalMessageDispatcherFactory" class="org.opennms.core.ipc.sink.kafka.KafkaLocalMessageDispatcherFactory" />
-  
+
+  <onmsgi:service ref="kafkaLocalMessageDispatcherFactory" interface="org.opennms.core.ipc.sink.api.MessageDispatcherFactory" />
+
   <bean id="kafkaOffsetProvider" class="org.opennms.core.ipc.sink.kafka.offset.KafkaOffsetProvider"
 		init-method="start" destroy-method="stop" />
 

--- a/core/test-api/karaf/src/main/java/org/opennms/core/test/karaf/KarafTestCase.java
+++ b/core/test-api/karaf/src/main/java/org/opennms/core/test/karaf/KarafTestCase.java
@@ -47,6 +47,7 @@ import java.net.URI;
 import java.security.PrivilegedExceptionAction;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.Callable;
@@ -326,6 +327,15 @@ public abstract class KarafTestCase {
         try {
             LOG.info("Installing feature {}", featureName);
             featuresService.installFeature(featureName);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    protected void installFeature(String featureName, EnumSet<FeaturesService.Option> options) {
+        try {
+            LOG.info("Installing feature {}", featureName);
+            featuresService.installFeature(featureName, options);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/features/datachoices/pom.xml
+++ b/features/datachoices/pom.xml
@@ -36,6 +36,7 @@
                     <features>
                         <feature>guava</feature>
                         <feature>hibernate36</feature> <!-- Required by opennms-web-api -->
+                        <feature>javax.servlet</feature>
                         <feature>quartz</feature> <!-- Required by opennms-web-api -->
                     </features>
                     <bundles>

--- a/features/telemetry/daemon/src/main/resources/META-INF/opennms/applicationContext-telemetryDaemon.xml
+++ b/features/telemetry/daemon/src/main/resources/META-INF/opennms/applicationContext-telemetryDaemon.xml
@@ -20,9 +20,6 @@
     <property name="configResource" value="file:${opennms.home}/etc/telemetryd-configuration.xml" />
   </bean>
 
-  <!-- Duplicated from the collectd context -->
-  <bean id="collectionAgentFactory" class="org.opennms.netmgt.collection.core.DefaultCollectionAgentFactory" />
-
   <bean id="daemon" class="org.opennms.netmgt.telemetry.daemon.Telemetryd" />
 
   <bean id="daemonListener" class="org.opennms.netmgt.events.api.AnnotationBasedEventListenerAdapter">

--- a/opennms-dao/pom.xml
+++ b/opennms-dao/pom.xml
@@ -96,6 +96,11 @@
       <artifactId>org.opennms.features.collection.api</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.opennms.features.collection</groupId>
+      <artifactId>org.opennms.features.collection.core</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
       <groupId>org.opennms</groupId>
       <artifactId>opennms-rrd-jrobin</artifactId>
       <scope>test</scope>

--- a/opennms-dao/src/main/resources/META-INF/opennms/applicationContext-dao.xml
+++ b/opennms-dao/src/main/resources/META-INF/opennms/applicationContext-dao.xml
@@ -493,6 +493,10 @@
 
   <onmsgi:service interface="org.opennms.netmgt.dao.api.TopologyDao" ref="topologyDao" />
 
+  <bean id="collectionAgentFactory" class="org.opennms.netmgt.collection.core.DefaultCollectionAgentFactory" />
+
+  <onmsgi:service interface="org.opennms.netmgt.collection.api.CollectionAgentFactory" ref="collectionAgentFactory" />
+
   <!-- The time-series strategy specific context should provide beans that implement:
             org.opennms.netmgt.collection.api.PersisterFactory
             org.opennms.netmgt.dao.api.ResourceStorageDao

--- a/opennms-full-assembly/pom.xml
+++ b/opennms-full-assembly/pom.xml
@@ -357,6 +357,7 @@
 
                 <!-- Karaf Spring features -->
                 <feature>spring/3.1.4.RELEASE</feature>
+                <feature>spring/3.2.18.RELEASE_1</feature>
                 <feature>spring/4.0.7.RELEASE_3</feature>
                 <feature>spring-jms/4.0.7.RELEASE_3</feature>
                 <feature>spring/4.1.9.RELEASE_1</feature>
@@ -400,6 +401,7 @@
               </descriptors>
               <features>
                 <!-- Experimental features that are not included in OpenNMS -->
+                <feature>opennms-activemq-component</feature>
                 <feature>opennms-discovery</feature>
                 <feature>opennms-events-daemon</feature>
                 <feature>opennms-reporting</feature>

--- a/opennms-full-assembly/src/test/java/org/opennms/assemblies/karaf/MinionFeatureKarafIT.java
+++ b/opennms-full-assembly/src/test/java/org/opennms/assemblies/karaf/MinionFeatureKarafIT.java
@@ -30,8 +30,10 @@ package org.opennms.assemblies.karaf;
 
 import static org.ops4j.pax.exam.CoreOptions.maven;
 
+import java.util.EnumSet;
+
+import org.apache.karaf.features.FeaturesService;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.opennms.core.test.karaf.KarafTestCase;
@@ -75,7 +77,6 @@ public class MinionFeatureKarafIT extends KarafTestCase {
 	}
 
 	@Test
-	@Ignore("OSGi dependency problems: org.apache.activemq.broker")
 	public void testInstallFeatureOpennmsTrapdListener() {
 		installFeature("opennms-trapd-listener");
 		System.out.println(executeCommand("feature:list -i"));
@@ -89,19 +90,19 @@ public class MinionFeatureKarafIT extends KarafTestCase {
 
 	@Test
 	public void testInstallFeatureMinionProvisiondDetectors() {
-		installFeature("minion-provisiond-detectors");
+		installFeature("minion-provisiond-detectors", EnumSet.of(FeaturesService.Option.NoAutoRefreshBundles));
 		System.out.println(executeCommand("feature:list -i"));
 	}
 
 	@Test
 	public void testInstallFeatureMinionProvisiondRequisitions() {
-		installFeature("minion-provisiond-requisitions");
+		installFeature("minion-provisiond-requisitions", EnumSet.of(FeaturesService.Option.NoAutoRefreshBundles));
 		System.out.println(executeCommand("feature:list -i"));
 	}
 
 	@Test
 	public void testInstallFeatureMinionCollection() {
-		installFeature("minion-collection");
+		installFeature("minion-collection", EnumSet.of(FeaturesService.Option.NoAutoRefreshBundles));
 		System.out.println(executeCommand("feature:list -i"));
 	}
 
@@ -113,7 +114,7 @@ public class MinionFeatureKarafIT extends KarafTestCase {
 
 	@Test
 	public void testInstallFeatureMinionShellCollection() {
-		installFeature("minion-shell-collection");
+		installFeature("minion-shell-collection", EnumSet.of(FeaturesService.Option.NoAutoRefreshBundles));
 		System.out.println(executeCommand("feature:list -i"));
 	}
 
@@ -125,13 +126,13 @@ public class MinionFeatureKarafIT extends KarafTestCase {
 
 	@Test
 	public void testInstallFeatureMinionShellProvision() {
-		installFeature("minion-shell-provision");
+		installFeature("minion-shell-provision", EnumSet.of(FeaturesService.Option.NoAutoRefreshBundles));
 		System.out.println(executeCommand("feature:list -i"));
 	}
 
 	@Test
 	public void testInstallFeatureMinionShell() {
-		installFeature("minion-shell");
+		installFeature("minion-shell", EnumSet.of(FeaturesService.Option.NoAutoRefreshBundles));
 		System.out.println(executeCommand("feature:list -i"));
 	}
 

--- a/opennms-full-assembly/src/test/java/org/opennms/assemblies/karaf/OnmsExperimentalFeaturesKarafIT.java
+++ b/opennms-full-assembly/src/test/java/org/opennms/assemblies/karaf/OnmsExperimentalFeaturesKarafIT.java
@@ -61,6 +61,11 @@ public class OnmsExperimentalFeaturesKarafIT extends KarafTestCase {
 	}
 
 	@Test
+	public void testInstallFeatureOpennmsActivemqComponent() {
+		installFeature("opennms-activemq-component");
+		System.out.println(executeCommand("feature:list -i"));
+	}
+	@Test
 	public void testInstallFeatureOpennmsDiscovery() {
 		installFeature("opennms-discovery");
 		System.out.println(executeCommand("feature:list -i"));

--- a/opennms-full-assembly/src/test/java/org/opennms/assemblies/karaf/OnmsFeatureKarafIT.java
+++ b/opennms-full-assembly/src/test/java/org/opennms/assemblies/karaf/OnmsFeatureKarafIT.java
@@ -30,6 +30,9 @@ package org.opennms.assemblies.karaf;
 
 import static org.ops4j.pax.exam.CoreOptions.maven;
 
+import java.util.EnumSet;
+
+import org.apache.karaf.features.FeaturesService;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -101,9 +104,7 @@ public class OnmsFeatureKarafIT extends KarafTestCase {
 		System.out.println(executeCommand("feature:list -i"));
 	}
 	@Test
-	@Ignore("OSGi dependency problems: javax.servlet.jsp")
 	public void testInstallFeatureCommonsConfiguration() {
-		installFeature("pax-http"); // Provides javax.servlet version 3.1
 		installFeature("commons-configuration");
 		System.out.println(executeCommand("feature:list -i"));
 	}
@@ -129,7 +130,6 @@ public class OnmsFeatureKarafIT extends KarafTestCase {
 	}
 	@Test
 	public void testInstallFeatureCommonsJxpath() {
-		installFeature("pax-http"); // Provides javax.servlet version 3.1
 		installFeature("commons-jxpath");
 		System.out.println(executeCommand("feature:list -i"));
 	}
@@ -169,9 +169,8 @@ public class OnmsFeatureKarafIT extends KarafTestCase {
 		System.out.println(executeCommand("feature:list -i"));
 	}
 	@Test
-	@Ignore("This refreshes the Karaf framework bundles and breaks Pax Exam")
 	public void testInstallFeatureGeminiBlueprint() {
-		installFeature("gemini-blueprint");
+		installFeature("gemini-blueprint", EnumSet.of(FeaturesService.Option.NoAutoRefreshBundles));
 		System.out.println(executeCommand("feature:list -i"));
 	}
 	@Test
@@ -207,6 +206,11 @@ public class OnmsFeatureKarafIT extends KarafTestCase {
 	@Test
 	public void testInstallFeatureJavaxMail() {
 		installFeature("javax.mail");
+		System.out.println(executeCommand("feature:list -i"));
+	}
+	@Test
+	public void testInstallFeatureJavaxServlet() {
+		installFeature("javax.servlet");
 		System.out.println(executeCommand("feature:list -i"));
 	}
 	@Test
@@ -251,7 +255,6 @@ public class OnmsFeatureKarafIT extends KarafTestCase {
 	}
 	@Test
 	public void testInstallFeatureJolokiaClient() {
-		installFeature("pax-http"); // Provides javax.servlet version 3.1
 		installFeature("jolokia-client");
 		System.out.println(executeCommand("feature:list -i"));
 	}
@@ -290,6 +293,11 @@ public class OnmsFeatureKarafIT extends KarafTestCase {
 	@Test
 	public void testInstallFeatureAmqpEventReceiver() {
 		installFeature("opennms-amqp-event-receiver");
+		System.out.println(executeCommand("feature:list -i"));
+	}
+	@Test
+	public void testInstallFeatureOpennmsActivemqPool() {
+		installFeature("opennms-activemq-pool");
 		System.out.println(executeCommand("feature:list -i"));
 	}
 	@Test
@@ -344,7 +352,6 @@ public class OnmsFeatureKarafIT extends KarafTestCase {
 		System.out.println(executeCommand("feature:list -i"));
 	}
 	@Test
-	@Ignore("OSGi dependency problems: org.apache.activemq.broker")
 	public void testInstallFeatureOpennmsCoreDaemon() {
 		installFeature("opennms-core-daemon");
 		System.out.println(executeCommand("feature:list -i"));
@@ -410,7 +417,6 @@ public class OnmsFeatureKarafIT extends KarafTestCase {
 		System.out.println(executeCommand("feature:list -i"));
 	}
 	@Test
-	@Ignore("OSGi dependency problems: org.apache.activemq.broker")
 	public void testInstallFeatureOpennmsDao() {
 		installFeature("opennms-dao");
 		System.out.println(executeCommand("feature:list -i"));
@@ -498,26 +504,27 @@ public class OnmsFeatureKarafIT extends KarafTestCase {
 		System.out.println(executeCommand("feature:list -i"));
 	}
 	@Test
-	@Ignore("OSGi dependency problems: javax.validation.constraints")
 	public void testInstallFeatureOpennmsProvisioning() {
 		installFeature("opennms-core"); // System classpath
 		installFeature("opennms-model"); // System classpath
-		installFeature("opennms-provisioning-api"); // System classpath
-		installFeature("opennms-provisioning");
+		installFeature("opennms-provisioning-api", EnumSet.of(FeaturesService.Option.NoAutoRefreshBundles)); // System classpath
+		installFeature("opennms-provisioning", EnumSet.of(FeaturesService.Option.NoAutoRefreshBundles));
 		System.out.println(executeCommand("feature:list -i"));
 	}
 	@Test
 	public void testInstallFeatureOpennmsProvisioningDetectors() {
-		installFeature("pax-http"); // Provides javax.servlet version 3.1
 		installFeature("opennms-config"); // System classpath
-		installFeature("opennms-provisioning-detectors");
+		installFeature("opennms-provisioning-detectors", EnumSet.of(FeaturesService.Option.NoAutoRefreshBundles));
 		System.out.println(executeCommand("feature:list -i"));
 	}
 	@Test
-	@Ignore("OSGi dependency problems: javax.persistence")
 	public void testInstallFeatureOpennmsProvisioningShell() {
-		installFeature("opennms-provisioning"); // System classpath
-		installFeature("opennms-provisioning-shell");
+		installFeature("opennms-core"); // System classpath
+		installFeature("opennms-model"); // System classpath
+		installFeature("opennms-config"); // System classpath
+		installFeature("opennms-provisioning", EnumSet.of(FeaturesService.Option.NoAutoRefreshBundles)); // System classpath
+		installFeature("opennms-provisioning-detectors", EnumSet.of(FeaturesService.Option.NoAutoRefreshBundles)); // System classpath
+		installFeature("opennms-provisioning-shell", EnumSet.of(FeaturesService.Option.NoAutoRefreshBundles));
 		System.out.println(executeCommand("feature:list -i"));
 	}
 	@Test
@@ -542,21 +549,18 @@ public class OnmsFeatureKarafIT extends KarafTestCase {
 		System.out.println(executeCommand("feature:list -i"));
 	}
 	@Test
-	@Ignore("ActiveMQ/Spring OSGi dependency problems")
 	public void testInstallFeatureOpennmsSyslogd() {
 		installFeature("opennms-syslogd");
 		System.out.println(executeCommand("feature:list -i"));
 	}
 	
 	@Test
-	@Ignore("ActiveMQ/Spring OSGi dependency problems")
 	public void testInstallFeatureOpennmsSyslogdListenerJavanet() {
 		installFeature("opennms-syslogd-listener-javanet");
 		System.out.println(executeCommand("feature:list -i"));
 	}
 	
 	@Test
-	@Ignore("ActiveMQ/Spring OSGi dependency problems")
 	public void testInstallFeatureOpennmsSyslogdListenerCamelNetty() {
 		installFeature("opennms-syslogd-listener-camel-netty");
 		System.out.println(executeCommand("feature:list -i"));
@@ -566,6 +570,13 @@ public class OnmsFeatureKarafIT extends KarafTestCase {
 		installFeature("opennms-dao-api"); // System classpath
 		installFeature("opennms-telemetry-collection");
 		System.out.println(executeCommand("feature:list -i"));
+	}
+	@Test
+	public void testInstallFeatureOpennmsTelemetryDaemon() {
+		//installFeature("gemini-blueprint", EnumSet.of(FeaturesService.Option.NoAutoRefreshBundles));
+		installFeature("opennms-telemetry-daemon", EnumSet.of(FeaturesService.Option.NoAutoRefreshBundles));
+		System.out.println(executeCommand("feature:list -i"));
+		System.out.println(executeCommand("bundle:services"));
 	}
 	@Test
 	public void testInstallFeatureOpennmsTelemetryJti() {
@@ -580,20 +591,19 @@ public class OnmsFeatureKarafIT extends KarafTestCase {
 		System.out.println(executeCommand("feature:list -i"));
 	}
 	@Test
-	@Ignore("OSGi dependency problems: org.apache.activemq.broker")
 	public void testInstallFeatureOpennmsTrapd() {
 		installFeature("opennms-trapd");
 		System.out.println(executeCommand("feature:list -i"));
 	}
 	@Test
-	@Ignore("OSGi dependency problems: javax.persistence")
+	@Ignore("OSGi dependency problems: org.opennms.features.reporting.model")
 	public void testInstallFeatureOpennmsVmware() {
+		installFeature("opennms-core"); // System classpath
 		installFeature("opennms-vmware");
 		System.out.println(executeCommand("feature:list -i"));
 	}
 	@Test
 	public void testInstallFeatureOpennmsXmlCollector() {
-		installFeature("pax-http"); // Provides javax.servlet version 3.1
 		installFeature("opennms-config-api"); // System classpath
 		installFeature("opennms-dao-api"); // System classpath
 		installFeature("opennms-xml-collector");
@@ -641,7 +651,6 @@ public class OnmsFeatureKarafIT extends KarafTestCase {
 	}
 	@Test
 	public void testInstallFeatureSpringSecurity32() {
-		installFeature("pax-http"); // Provides javax.servlet version 3.1
 		installFeature("spring-security32");
 		System.out.println(executeCommand("feature:list -i"));
 	}
@@ -651,14 +660,14 @@ public class OnmsFeatureKarafIT extends KarafTestCase {
 		System.out.println(executeCommand("feature:list -i"));
 	}
 	@Test
-	@Ignore("OSGi dependency problems: com.atlassian.jira.rest.client.api")
+	@Ignore("OSGi dependency problems: javax.ws.rs")
 	public void testInstallFeatureJiraTroubleticketer() {
+		installFeature("opennms-core"); // System classpath
 		installFeature("jira-troubleticketer");
 		System.out.println(executeCommand("feature:list -i"));
 	}
 	@Test
 	public void testInstallFeatureTsrmTroubleticketer() {
-		installFeature("pax-http"); // Provides javax.servlet version 3.1
 		installFeature("opennms-core"); // System classpath
 		installFeature("tsrm-troubleticketer");
 		System.out.println(executeCommand("feature:list -i"));
@@ -671,19 +680,18 @@ public class OnmsFeatureKarafIT extends KarafTestCase {
 	@Test
 	public void testInstallFeatureWmiIntegration() {
 		installFeature("opennms-config"); // System classpath
-		installFeature("wmi-integration");
+		installFeature("wmi-integration", EnumSet.of(FeaturesService.Option.NoAutoRefreshBundles));
 		System.out.println(executeCommand("feature:list -i"));
 	}
 	@Test
 	public void testInstallFeatureWsmanIntegration() {
-		installFeature("pax-http"); // Provides javax.servlet version 3.1
-		installFeature("wsman-integration");
+		installFeature("wsman-integration", EnumSet.of(FeaturesService.Option.NoAutoRefreshBundles));
 		System.out.println(executeCommand("feature:list -i"));
 	}
+
 	@Test
-	@Ignore("OSGi dependency problems: org.apache.http")
+	@Ignore("OSGi dependency problems: javax.ws.rs.core")
 	public void testInstallFeatureDatachoices() {
-		installFeature("pax-http"); // Provides javax.servlet version 3.1
 		installFeature("datachoices");
 		System.out.println(executeCommand("feature:list -i"));
 	}
@@ -701,8 +709,15 @@ public class OnmsFeatureKarafIT extends KarafTestCase {
 		System.out.println(executeCommand("feature:list -i"));
 	}
 	@Test
-	@Ignore("OSGi dependency problems: javax.transaction.xa")
 	public void testInstallFeatureAlarmChangeNotifier() {
+		installFeature("pax-http", "4.3.0");
+		installFeature("opennms-http-whiteboard");
+		installFeature("org.opennms.plugin.licencemanager"); // Plugin manager
+		installFeature("org.opennms.plugin.featuremanager"); // Plugin manager
+		installFeature("opennms-core"); // System classpath
+		installFeature("opennms-core-db"); // System classpath
+		installFeature("opennms-events-api"); // System classpath
+		installFeature("opennms-model"); // System classpath
 		installFeature("alarm-change-notifier");
 		System.out.println(executeCommand("feature:list -i"));
 	}
@@ -719,7 +734,8 @@ public class OnmsFeatureKarafIT extends KarafTestCase {
 	}
 	@Test
 	public void testInstallFeatureInternalPluginsDescriptor() {
-		installFeature("pax-http"); // Provides javax.servlet version 3.1
+		installFeature("pax-http", "4.3.0");
+		installFeature("opennms-http-whiteboard");
 		installFeature("internal-plugins-descriptor");
 		System.out.println(executeCommand("feature:list -i"));
 	}

--- a/opennms-services/src/main/resources/META-INF/opennms/applicationContext-collectd.xml
+++ b/opennms-services/src/main/resources/META-INF/opennms/applicationContext-collectd.xml
@@ -23,9 +23,6 @@
       <property name="eventIpcManager" ref="eventIpcManager"/>
     </bean>
 
-    <bean id="collectionAgentFactory" class="org.opennms.netmgt.collection.core.DefaultCollectionAgentFactory" />
-    <onmsgi:service interface="org.opennms.netmgt.collection.api.CollectionAgentFactory" ref="collectionAgentFactory" />
-
     <bean id="defaultResourceTypeMapper" class="org.opennms.netmgt.collectd.DefaultResourceTypeMapper" />
 
 </beans>


### PR DESCRIPTION
This PR:
* Cleans up and reenables a bunch of Karaf integration tests
* Creates Karaf features for `opennms-collection-core` and `opennms-telemetry-daemon`
* Exposes the sink API and `CollectionAgentFactory` services in the `onmsgi` registry (which will be used by Telemetryd)

Please do not delete the branch after merging.

JIRA:
* http://issues.opennms.org/browse/HZN-1202
* http://issues.opennms.org/browse/HZN-1203