### PR TITLE
HZN-1220: add mbeans/graphs for kafka topics ingestion rate

### DIFF
--- a/opennms-base-assembly/src/main/filtered/etc/jmx-datacollection-config.d/minion.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/jmx-datacollection-config.d/minion.xml
@@ -31,6 +31,9 @@
                 </comp-attrib>
             </mbean>
 
+            <mbean name="kafka ingestion rate" resource-type="kafkaIngestionRate" objectname="kafka.producer:type=producer-topic-metrics,*">
+                <attrib name="record-send-rate" alias="recordSendRate" type="gauge"/>
+            </mbean>
 
             <!-- Route stats for syslogListen -->
             <mbean name="Syslog Listener" objectname="org.apache.camel:context=syslogdListenerCamelNettyContext,type=routes,name=&quot;syslogListen&quot;">

--- a/opennms-base-assembly/src/main/filtered/etc/resource-types.d/jmx-resource.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/resource-types.d/jmx-resource.xml
@@ -7,4 +7,13 @@
 		   <parameter key="sibling-column-name" value="name" />
       </storageStrategy>
     </resourceType>
+
+    <resourceType name="kafkaIngestionRate" label="Kafka Ingestion Rate"
+                  resourceLabel="${index}">
+      <persistenceSelectorStrategy class="org.opennms.netmgt.collection.support.PersistAllSelectorStrategy"/>
+      <storageStrategy class="org.opennms.netmgt.dao.support.SiblingColumnStorageStrategy">
+		   <parameter key="sibling-column-name" value="topic" />
+      </storageStrategy>
+    </resourceType>
+
 </resource-types>

--- a/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/opennms-minion-graph.properties
+++ b/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/opennms-minion-graph.properties
@@ -11,7 +11,8 @@ OpenNMS.Minion.RPC.Server.Poller.Exchanges, \
 OpenNMS.Minion.RPC.Server.Poller.ProcessingTime, \
 OpenNMS.Minion.RPC.Server.SNMP.Exchanges, \
 OpenNMS.Minion.RPC.Server.SNMP.ProcessingTime, \
-OpenNMS.Minion.Syslogd.Listener.Exchanges
+OpenNMS.Minion.Syslogd.Listener.Exchanges, \
+Kafka.Producer.Topic.Metrics
 
 
 ###########################################
@@ -269,3 +270,17 @@ report.OpenNMS.Minion.Syslogd.Listener.Exchanges.command=--title="Syslog Message
  GPRINT:complete:MIN:" Min \\: %8.2lf %s" \
  GPRINT:complete:MAX:" Max \\: %8.2lf %s\\n"
 
+###########################################
+## OpenNMS Kafka  Ingestion Rate
+###########################################
+report.Kafka.Producer.Topic.Metrics.name=Kafka Ingestion rate
+report.Kafka.Producer.Topic.Metrics.columns=recordSendRate
+report.Kafka.Producer.Topic.Metrics.type=kafkaIngestionRate
+report.Kafka.Producer.Topic.Metrics.command=--title="Kafka recordSendRate" \
+ --vertical-label="Kafka IngestionRate" \
+ DEF:recordSendRate={rrd1}:recordSendRate:AVERAGE \
+ AREA:recordSendRate#edd400 \
+ LINE2:recordSendRate#c4a000:"Value" \
+ GPRINT:recordSendRate:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:recordSendRate:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:recordSendRate:MAX:" Max \\: %8.2lf %s\\n"


### PR DESCRIPTION
Add mbeans/graphs for kafka topics ingestion rate ( rate at which records are being sent).  records/sec  where 1 record is 1 offset in topic.

* JIRA: http://issues.opennms.org/browse/hzn-1220

Our [continuous integration system](http://bamboo.internal.opennms.com:8085) will test and verify your changes.
