### PR TITLE
NMS-9835: Avoid unecessary AlarmDao calls when no business rules are defined.

### DIFF
--- a/features/bsm/daemon/pom.xml
+++ b/features/bsm/daemon/pom.xml
@@ -122,5 +122,16 @@
       <artifactId>hamcrest-library</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.hamcrest</groupId>
+          <artifactId>hamcrest-core</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
   </dependencies>
 </project>

--- a/features/bsm/daemon/src/main/java/org/opennms/netmgt/bsm/daemon/Bsmd.java
+++ b/features/bsm/daemon/src/main/java/org/opennms/netmgt/bsm/daemon/Bsmd.java
@@ -157,7 +157,17 @@ public class Bsmd implements SpringServiceDaemon, BusinessServiceStateChangeHand
                 }
             }
         }, pollInterval, pollInterval, TimeUnit.SECONDS);
+    }
 
+    private void stopAlarmPolling() {
+        if (m_alarmPoller != null) {
+            m_alarmPoller.shutdown();
+            m_alarmPoller = null;
+        }
+    }
+
+    protected boolean isAlarmPolling() {
+        return m_alarmPoller != null;
     }
 
     protected long getPollInterval() {
@@ -200,8 +210,12 @@ public class Bsmd implements SpringServiceDaemon, BusinessServiceStateChangeHand
             }
         });
 
-        if (m_hasBusinessServicesDefined && m_alarmPoller == null) {
+        // Enable/disable polling for alarms based on whether or not
+        // we have any business services
+        if (m_hasBusinessServicesDefined && !isAlarmPolling()) {
             startAlarmPolling();
+        } else if (!m_hasBusinessServicesDefined && isAlarmPolling()) {
+            stopAlarmPolling();
         }
     }
 
@@ -378,9 +392,7 @@ public class Bsmd implements SpringServiceDaemon, BusinessServiceStateChangeHand
     @Override
     public void destroy() throws Exception {
         LOG.info("Stopping bsmd...");
-        if (m_alarmPoller != null) {
-            m_alarmPoller.shutdown();
-        }
+        stopAlarmPolling();
     }
 
     public void setAlarmDao(AlarmDao alarmDao) {


### PR DESCRIPTION
JIRA: https://issues.opennms.org/browse/NMS-9835

This will reduce overhead on systems that have bsmd enabled (by default) but do not have any business rules defined.
