### PR TITLE
NMS-9836: Use the AMQP connection factory bundled with Camel

### DIFF
--- a/container/features/pom.xml
+++ b/container/features/pom.xml
@@ -279,7 +279,6 @@
 
             <feature>org.json</feature>
             <feature>postgresql</feature>
-            <feature>qpid</feature>
             <feature>spring-security32</feature>
             <feature>spring-webflow</feature>
 

--- a/container/features/src/main/resources/features.xml
+++ b/container/features/src/main/resources/features.xml
@@ -54,7 +54,6 @@
       <feature>camel-http</feature>
       <feature>camel-amqp</feature>
       <feature version="${guavaVersion}">guava</feature>
-      <feature>qpid</feature>
 
       <feature>opennms-core-camel</feature>
       <feature>opennms-dao-api</feature>
@@ -69,7 +68,6 @@
       <feature>camel-http</feature>
       <feature>camel-amqp</feature>
       <feature version="${guavaVersion}">guava</feature>
-      <feature>qpid</feature>
 
       <feature>opennms-core-camel</feature>
       <feature>opennms-dao-api</feature>
@@ -83,7 +81,6 @@
       <feature>camel-blueprint</feature>
       <feature>camel-http</feature>
       <feature>camel-amqp</feature>
-      <feature>qpid</feature>
 
       <feature>opennms-core-camel</feature>
       <!-- TODO -->
@@ -330,12 +327,6 @@
       <feature>pax-jdbc-spec</feature>
       <bundle dependency="true">mvn:org.apache.geronimo.specs/geronimo-jta_1.1_spec/1.1.1</bundle>
       <bundle>wrap:mvn:org.postgresql/postgresql/${postgresqlVersion}</bundle>
-    </feature>
-
-    <feature name="qpid" description="Apache :: Qpid" version="0.32_3">
-      <bundle dependency="true">mvn:org.apache.geronimo.specs/geronimo-jms_1.1_spec/1.1.1</bundle>
-      <bundle dependency="true">mvn:org.apache.geronimo.specs/geronimo-jta_1.1_spec/1.1.1</bundle>
-      <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.qpid/0.32_3</bundle>
     </feature>
 
     <feature name="rate-limited-logger" description="Rate Limited Logger" version="${rateLimitedLoggerVersion}">

--- a/features/amqp/alarm-northbounder/pom.xml
+++ b/features/amqp/alarm-northbounder/pom.xml
@@ -159,11 +159,6 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.apache.qpid</groupId>
-      <artifactId>qpid-client</artifactId>
-      <version>${qpidVersion}</version>
-    </dependency>
-    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/features/amqp/alarm-northbounder/src/main/resources/OSGI-INF/blueprint/blueprint-alarm-northbounder.xml
+++ b/features/amqp/alarm-northbounder/src/main/resources/OSGI-INF/blueprint/blueprint-alarm-northbounder.xml
@@ -21,12 +21,12 @@
   <!-- Configuration properties -->
   <cm:property-placeholder id="alarmNorthbounderProperties" persistent-id="org.opennms.features.amqp.alarmnorthbounder" update-strategy="reload">
     <cm:default-properties>
-        <!-- amqp://[user:pass@][clientid]/virtualhost?brokerlist='tcp://host:port?option=\'value\',option=\'value\';tcp://host:port?option=\'value\'',failover='method?option=\'value\',option='value'' -->
-        <!-- The only required option is a single broker in the broker list -->
-        <cm:property name="connectionUrl" value="amqp://guest:guest@onms/test?brokerlist='tcp://127.0.0.1:5672'"/>
-        <!-- amqp:exchange/routingkey?options -->
-        <cm:property name="destination" value="amqp:OpenNMS-Exchange/opennms-routing-key"/>
-        <cm:property name="processorName" value="default-alarm-northbounder-processor"/>
+      <cm:property name="connectionUrl" value="amqp://localhost:5672"/>
+      <cm:property name="username" value="guest"/>
+      <cm:property name="password" value="guest"/>
+      <!-- amqp:[queue:|topic:]destinationName[?options] -->
+      <cm:property name="destination" value="amqp:topic:opennms-alarms"/>
+      <cm:property name="processorName" value="default-alarm-northbounder-processor"/>
     </cm:default-properties>
   </cm:property-placeholder>
 
@@ -79,11 +79,10 @@
     </route>
   </camelContext>
 
-  <bean id="amqp" class="org.apache.camel.component.amqp.AMQPComponent">
-    <property name="connectionFactory">
-      <bean class="org.apache.qpid.client.AMQConnectionFactory">
-        <property name="connectionURLString" value="${connectionUrl}" />
-      </bean>
-    </property>
+  <bean id="amqp" class="org.apache.camel.component.amqp.AMQPComponent" factory-method="amqpComponent">
+    <argument value="${connectionUrl}"/>
+    <argument value="${username}"/>
+    <argument value="${password}"/>
   </bean>
+
 </blueprint>

--- a/features/amqp/event-forwarder/pom.xml
+++ b/features/amqp/event-forwarder/pom.xml
@@ -167,11 +167,6 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.apache.qpid</groupId>
-      <artifactId>qpid-client</artifactId>
-      <version>${qpidVersion}</version>
-    </dependency>
-    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/features/amqp/event-forwarder/src/main/resources/OSGI-INF/blueprint/blueprint-event-forwarder.xml
+++ b/features/amqp/event-forwarder/src/main/resources/OSGI-INF/blueprint/blueprint-event-forwarder.xml
@@ -21,11 +21,11 @@
   <!-- Configuration properties -->
   <cm:property-placeholder id="eventForwarderProperties" persistent-id="org.opennms.features.amqp.eventforwarder" update-strategy="reload">
     <cm:default-properties>
-      <!-- amqp://[user:pass@][clientid]/virtualhost?brokerlist='tcp://host:port?option=\'value\',option=\'value\';tcp://host:port?option=\'value\'',failover='method?option=\'value\',option='value'' -->
-      <!-- The only required option is a single broker in the broker list -->
-      <cm:property name="connectionUrl" value="amqp://guest:guest@onms/test?brokerlist='tcp://127.0.0.1:5672'"/>
-      <!-- amqp:exchange/routingkey?options -->
-      <cm:property name="destination" value="amqp:OpenNMS-Exchange/opennms-routing-key"/>
+      <cm:property name="connectionUrl" value="amqp://localhost:5672"/>
+      <cm:property name="username" value="guest"/>
+      <cm:property name="password" value="guest"/>
+      <!-- amqp:[queue:|topic:]destinationName[?options] -->
+      <cm:property name="destination" value="amqp:topic:opennms-events"/>
       <cm:property name="processorName" value="default-event-forwarder-processor"/>
     </cm:default-properties>
   </cm:property-placeholder>
@@ -80,11 +80,10 @@
     </route>
   </camelContext>
 
-  <bean id="amqp" class="org.apache.camel.component.amqp.AMQPComponent">
-    <property name="connectionFactory">
-      <bean class="org.apache.qpid.client.AMQConnectionFactory">
-        <property name="connectionURLString" value="${connectionUrl}" />
-      </bean>
-    </property>
+  <bean id="amqp" class="org.apache.camel.component.amqp.AMQPComponent" factory-method="amqpComponent">
+    <argument value="${connectionUrl}"/>
+    <argument value="${username}"/>
+    <argument value="${password}"/>
   </bean>
+
 </blueprint>

--- a/features/amqp/event-receiver/pom.xml
+++ b/features/amqp/event-receiver/pom.xml
@@ -166,11 +166,6 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.apache.qpid</groupId>
-      <artifactId>qpid-client</artifactId>
-      <version>${qpidVersion}</version>
-    </dependency>
-    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/features/amqp/event-receiver/src/main/resources/OSGI-INF/blueprint/blueprint-event-receiver.xml
+++ b/features/amqp/event-receiver/src/main/resources/OSGI-INF/blueprint/blueprint-event-receiver.xml
@@ -21,11 +21,11 @@
   <!-- Configuration properties -->
   <cm:property-placeholder id="eventReceiverProperties" persistent-id="org.opennms.features.amqp.eventreceiver" update-strategy="reload">
     <cm:default-properties>
-      <!-- amqp://[user:pass@][clientid]/virtualhost?brokerlist='tcp://host:port?option=\'value\',option=\'value\';tcp://host:port?option=\'value\'',failover='method?option=\'value\',option='value'' -->
-      <!-- The only required option is a single broker in the broker list -->
-      <cm:property name="connectionUrl" value="amqp://guest:guest@onms/test?brokerlist='tcp://127.0.0.1:5672'"/>
-      <!-- amqp:exchange/routingkey?options -->
-      <cm:property name="source" value="amqp:OpenNMS-Queue"/>
+      <cm:property name="connectionUrl" value="amqp://localhost:5672"/>
+      <cm:property name="username" value="guest"/>
+      <cm:property name="password" value="guest"/>
+      <!-- amqp:[queue:|topic:]destinationName[?options] -->
+      <cm:property name="source" value="amqp:queue:opennms-events"/>
       <cm:property name="processorName" value="default-event-receiver-processor"/>
     </cm:default-properties>
   </cm:property-placeholder>
@@ -71,11 +71,10 @@
     </route>
   </camelContext>
 
-  <bean id="amqp" class="org.apache.camel.component.amqp.AMQPComponent">
-    <property name="connectionFactory">
-      <bean class="org.apache.qpid.client.AMQConnectionFactory">
-        <property name="connectionURLString" value="${connectionUrl}" />
-      </bean>
-    </property>
+  <bean id="amqp" class="org.apache.camel.component.amqp.AMQPComponent" factory-method="amqpComponent">
+    <argument value="${connectionUrl}"/>
+    <argument value="${username}"/>
+    <argument value="${password}"/>
   </bean>
+
 </blueprint>

--- a/features/amqp/pom.xml
+++ b/features/amqp/pom.xml
@@ -16,10 +16,6 @@
   <name>OpenNMS :: Features :: AMQP</name>
   <packaging>pom</packaging>
 
-  <properties>
-    <qpidVersion>0.32</qpidVersion>
-  </properties>
-
   <modules>
     <module>common</module>
     <module>event-forwarder</module>

--- a/opennms-doc/guide-development/src/asciidoc/text/amqp/alarm_northbounder.adoc
+++ b/opennms-doc/guide-development/src/asciidoc/text/amqp/alarm_northbounder.adoc
@@ -11,12 +11,12 @@ The alarm northbounder exposes the following properties via the `org.opennms.fea
 
 [options="header"]
 |===
-| Property        | Default                                                           | Description
-| _connectionUrl_ | `amqp://guest:guest@onms/test?brokerlist=\'tcp://127.0.0.1:5672'` | Used by the AMQPConnectionFactory.
-                                                                                        See http://people.apache.org/~grkvlt/qpid-site/qpid-java/qpid-client/apidocs/org/apache/qpid/jms/ConnectionURL.html[ConnectionURL] for a full list of options.
-| _destination_   | `amqp:OpenNMS-Exchange/opennms-routing-key`                       | Target queue or topic.
-                                                                                        See http://camel.apache.org/amqp.html[AMQP] for details.
-| _processorName_ | `default-alarm-northbounder-processor`                            | Name `org.apache.camel.Processor` used to filter and/or format the events.
+| Property        | Default                                  | Description
+| connectionUrl   | amqp://localhost:5672                    | Used by the JmsConnectionFactory. See http://camel.apache.org/amqp.html[AMQP] for details.
+| username        | guest                                    | Username
+| password        | guest                                    | Password
+| destination     | amqp:topic:opennms-alarms                | Target queue or topic. See http://camel.apache.org/amqp.html[AMQP] for details.
+| processorName   | default-alarm-northbounder-processor     | Named `org.apache.camel.Processor` implementation used to filter and/or format the alarms.
 |===
 
 The default processor, the `default-alarm-northbounder-processor`, converts the alarms to a string and does not perform any filtering.
@@ -31,8 +31,8 @@ Update the properties with your deployment specific values:
 [source]
 ----
 config:edit org.opennms.features.amqp.alarmnorthbounder
-config:property-set connectionUrl amqp://guest:guest@onms/test?brokerlist=\'tcp://127.0.0.1:5672\'
-config:property-set destination amqp:OpenNMS-Exchange/opennms-routing-key
+config:property-set connectionUrl amqp://localhost:5672
+config:property-set destination amqp:topic:opennms-alarms
 config:property-set processorName default-alarm-northbounder-processor
 config:update
 ----

--- a/opennms-doc/guide-development/src/asciidoc/text/amqp/custom_processors.adoc
+++ b/opennms-doc/guide-development/src/asciidoc/text/amqp/custom_processors.adoc
@@ -31,7 +31,7 @@ public class MyEventProcessor implements Processor {
 }
 ----
 
-In order to use the processor, package it as a bundle, and expose it to the OSGi service registiry using:
+In order to use the processor, package it as a bundle, and expose it to the OSGi service registry using:
 
 [source,xml]
 ----

--- a/opennms-doc/guide-development/src/asciidoc/text/amqp/event_forwarder.adoc
+++ b/opennms-doc/guide-development/src/asciidoc/text/amqp/event_forwarder.adoc
@@ -7,15 +7,16 @@
 The event forwarder listens for _all_ events on the internal event bus of {opennms-product-name}.
 Events from the bus are sent to a Camel processor, which can filter or transform these, before being sent to the AMQP endpoint.
 
-The event forwarer exposes the following properties via the `org.opennms.features.amqp.eventforwarder` pid:
+The event forwarder exposes the following properties via the `org.opennms.features.amqp.eventforwarder` pid:
 
 [options="header"]
 |===
-| Property      | Default                                                         | Description
-| connectionUrl | amqp://guest:guest@onms/test?brokerlist=\'tcp://127.0.0.1:5672' | Used by the AMQPConnectionFactory. See http://people.apache.org/~grkvlt/qpid-site/qpid-java/qpid-client/apidocs/org/apache/qpid/jms/ConnectionURL.html[ConnectionURL]
- for a full list of options.
-| destination   | amqp:OpenNMS-Exchange/opennms-routing-key  | Target queue or topic. See http://camel.apache.org/amqp.html[AMQP] for details.
-| processorName | default-event-forwarder-processor          | Name `org.apache.camel.Processor` used to filter and/or format the events.
+| Property      | Default                           | Description
+| connectionUrl | amqp://localhost:5672             | Used by the JmsConnectionFactory. See http://camel.apache.org/amqp.html[AMQP] for details.
+| username      | guest                             | Username
+| password      | guest                             | Password
+| destination   | amqp:topic:opennms-events         | Target queue or topic. See http://camel.apache.org/amqp.html[AMQP] for details.
+| processorName | default-event-forwarder-processor | Named `org.apache.camel.Processor` implementation used to filter and/or format the events.
 |===
 
 The default processor, the `default-event-forwarder-processor`, marshalls events to XML and does not perform any filtering.
@@ -30,8 +31,8 @@ Update the properties with your deployment specific values:
 [source]
 ----
 config:edit org.opennms.features.amqp.eventforwarder
-config:property-set connectionUrl amqp://guest:guest@onms/test?brokerlist=\'tcp://127.0.0.1:5672\'
-config:property-set destination amqp:OpenNMS-Exchange/opennms-routing-key
+config:property-set connectionUrl amqp://localhost:5672
+config:property-set destination amqp:topic:opennms-events
 config:property-set processorName default-event-forwarder-processor
 config:update
 ----

--- a/opennms-doc/guide-development/src/asciidoc/text/amqp/event_receiver.adoc
+++ b/opennms-doc/guide-development/src/asciidoc/text/amqp/event_receiver.adoc
@@ -7,15 +7,16 @@
 The event receiver listens for messages from an AMQP target and forwards them onto the internal event bus of {opennms-product-name}.
 Messages are sent to a Camel processor, which can filter or transform these, before being sent onto the event bus.
 
-The event forwarer exposes the following properties via the `org.opennms.features.amqp.eventreceiver` pid:
+The event receiver exposes the following properties via the `org.opennms.features.amqp.eventreceiver` pid:
 
 [options="header"]
 |===
-| Property      | Default                                                         | Description
-| connectionUrl | amqp://guest:guest@onms/test?brokerlist=\'tcp://127.0.0.1:5672' | Used by the AMQPConnectionFactory. See http://people.apache.org/~grkvlt/qpid-site/qpid-java/qpid-client/apidocs/org/apache/qpid/jms/ConnectionURL.html[ConnectionURL]
- for a full list of options.
-| source        | amqp:OpenNMS-Queue                | Source queue or topic. See http://camel.apache.org/amqp.html[AMQP] for details.
-| processorName | default-event-receiver-processor  | Name `org.apache.camel.Processor` used to filter and/or format the events.
+| Property      | Default                           | Description
+| connectionUrl | amqp://localhost:5672             | Used by the JmsConnectionFactory. See http://camel.apache.org/amqp.html[AMQP] for details.
+| username      | guest                             | Username
+| password      | guest                             | Password
+| source        | amqp:queue:opennms-events         | Source queue or topic. See http://camel.apache.org/amqp.html[AMQP] for details.
+| processorName | default-event-receiver-processor  | Named `org.apache.camel.Processor` implementation used to filter and/or format the events.
 |===
 
 The default processor, the `default-event-receiver-processor`, expects the message bodies to contain XML strings which are it unmarshalls to events.
@@ -29,8 +30,8 @@ Update the properties with your deployment specific values:
 [source]
 ----
 config:edit org.opennms.features.amqp.eventreceiver
-config:property-set connectionUrl amqp://guest:guest@onms/test?brokerlist=\'tcp://127.0.0.1:5672\'
-config:property-set source amqp:OpenNMS-Queue
+config:property-set connectionUrl amqp://localhost:5672
+config:property-set source amqp:queue:opennms-events
 config:property-set processorName default-event-receiver-processor
 config:update
 ----

--- a/opennms-doc/guide-development/src/asciidoc/text/amqp/introduction.adoc
+++ b/opennms-doc/guide-development/src/asciidoc/text/amqp/introduction.adoc
@@ -15,8 +15,4 @@ The integration is written using Camel + OSGi and has the following components:
 Custom filtering (i.e. which events to forward) and transformations (i.e. how the events are represented in the messages) can be used in each of the components.
 Generic implementations
 
-The integration is written using Camel + OSGi and exposes interfaces through which events and alarms can be filtered and/or transformed.
-The features are described in detail bellow.
-
-
 NOTE: Each componenent can be configured and setup independently, i.e. you can choose to only forward alarms.

--- a/opennms-full-assembly/src/test/java/org/opennms/assemblies/karaf/OnmsFeatureKarafIT.java
+++ b/opennms-full-assembly/src/test/java/org/opennms/assemblies/karaf/OnmsFeatureKarafIT.java
@@ -459,11 +459,6 @@ public class OnmsFeatureKarafIT extends KarafTestCase {
 		System.out.println(executeCommand("feature:list -i"));
 	}
 	@Test
-	public void testInstallFeatureQpid() {
-		installFeature("qpid");
-		System.out.println(executeCommand("feature:list -i"));
-	}
-	@Test
 	public void testInstallFeatureSpringSecurity32() {
 		installFeature("pax-http"); // Provides javax.servlet version 2.6
 		installFeature("spring-security32");


### PR DESCRIPTION
JIRA: https://issues.opennms.org/browse/NMS-9836

We were remove the calls to the legacy QPID client, and use the connection factory provided by Camel instead. This fixes compatibility with AMQP 1_0_0.

Also updated the documentation, and fixed a number of typos.

Tested against a standalone ActiveMQ 5.12.5 broker.
