### PR TITLE
NMS-9833: fix startup to make sure $MINION_HOME/data exists

### DIFF
--- a/opennms-assemblies/minion/src/main/filtered/etc/minion.init
+++ b/opennms-assemblies/minion/src/main/filtered/etc/minion.init
@@ -136,6 +136,9 @@ case "$COMMAND" in
 		fi
 
 		validate_icmp
+		if [ ! -d "${MINION_HOME}/data/tmp" ]; then
+			mkdir -p "${MINION_HOME}/data/tmp"
+		fi
 		"$MINION_HOME"/bin/start
 		exit $?
 		;;

--- a/tools/packages/minion/minion.spec
+++ b/tools/packages/minion/minion.spec
@@ -218,7 +218,11 @@ ROOT_INST="${RPM_INSTALL_PREFIX0}"
 [ -z "${ROOT_INST}" ] && ROOT_INST="%{minioninstprefix}"
 
 # Clean out the data directory
-rm -rf "${ROOT_INST}/data"
+if [ -d "${ROOT_INST}/data" ]; then
+    find "$ROOT_INST/data/"* -maxdepth 0 -name tmp -prune -o -print0 | xargs -0 rm -rf
+    find "$ROOT_INST/data/tmp/"* -maxdepth 0 -name README -prune -o -print0 | xargs -0 rm -rf
+fi
+
 # Generate an SSH key if necessary
 if [ ! -f "${ROOT_INST}/etc/host.key" ]; then
     /usr/bin/ssh-keygen -t rsa -N "" -b 4096 -f "${ROOT_INST}/etc/host.key"

--- a/tools/packages/opennms/opennms.spec
+++ b/tools/packages/opennms/opennms.spec
@@ -1043,8 +1043,8 @@ done
 
 printf -- "- cleaning up \$OPENNMS_HOME/data... "
 if [ -d "$ROOT_INST/data" ]; then
-	find "$ROOT_INST/data/"* -maxdepth 0 -name tmp -prune -o -print | xargs rm -rf
-	find "$ROOT_INST/data/tmp/"* -maxdepth 0 -name README -prune -o -print | xargs rm -rf
+	find "$ROOT_INST/data/"* -maxdepth 0 -name tmp -prune -o -print0 | xargs -0 rm -rf
+	find "$ROOT_INST/data/tmp/"* -maxdepth 0 -name README -prune -o -print0 | xargs -0 rm -rf
 fi
 echo "done"
 


### PR DESCRIPTION
This PR fixes the Minion init to make sure `$MINION_HOME/data` exists.

It also changes `find -print` calls to use `-print0` to make sure there aren't issues with spaces in filenames.  Shouldn't affect anything, but it's best practice when shell scripting.  :)

* JIRA: http://issues.opennms.org/browse/NMS-9833