### PR TITLE
NMS-9702: Sanitize resource name inside storage strategy, rather than…

### DIFF
--- a/features/collection/api/src/main/java/org/opennms/netmgt/collection/dto/InterfaceLevelResourceDTO.java
+++ b/features/collection/api/src/main/java/org/opennms/netmgt/collection/dto/InterfaceLevelResourceDTO.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2017-2017 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
+ * Copyright (C) 2017-2018 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2018 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -62,7 +62,7 @@ public class InterfaceLevelResourceDTO {
 
     @Override
     public String toString() {
-        return String.format("InterfaceLevelResourceDTO[parent=%s, ifName=%s]", ifName);
+        return String.format("InterfaceLevelResourceDTO[parent=%s, ifName=%s]", parent, ifName);
     }
 
     @Override

--- a/features/collection/api/src/main/java/org/opennms/netmgt/collection/support/IndexStorageStrategy.java
+++ b/features/collection/api/src/main/java/org/opennms/netmgt/collection/support/IndexStorageStrategy.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2006-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2006-2018 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2018 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -33,6 +33,7 @@ import org.opennms.netmgt.collection.api.CollectionResource;
 import org.opennms.netmgt.collection.api.Parameter;
 import org.opennms.netmgt.collection.api.StorageStrategy;
 import org.opennms.netmgt.collection.api.StorageStrategyService;
+import org.opennms.netmgt.collection.support.builder.GenericTypeResource;
 import org.opennms.netmgt.model.ResourcePath;
 
 public class IndexStorageStrategy implements StorageStrategy {
@@ -65,7 +66,7 @@ public class IndexStorageStrategy implements StorageStrategy {
     @Override
     public String getResourceNameFromIndex(CollectionResource resource) {
         // Use the instance value as the name of the resource
-        return resource.getInstance();
+        return GenericTypeResource.sanitizeInstance(resource.getInstance());
     }
 
     /** {@inheritDoc} */

--- a/features/collection/api/src/main/java/org/opennms/netmgt/collection/support/builder/DeferredGenericTypeResource.java
+++ b/features/collection/api/src/main/java/org/opennms/netmgt/collection/support/builder/DeferredGenericTypeResource.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2017-2017 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
+ * Copyright (C) 2017-2018 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2018 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -64,7 +64,7 @@ public class DeferredGenericTypeResource extends AbstractResource {
         m_node = Objects.requireNonNull(node, "node argument");
         m_resourceTypeName = Objects.requireNonNull(resourceTypeName, "resourceTypeName argument");
         m_fallbackResourceTypeName = fallbackResourceTypeName;
-        m_instance = GenericTypeResource.sanitizeInstance(Objects.requireNonNull(instance, "instance argument"));
+        m_instance = Objects.requireNonNull(instance, "instance argument");
     }
 
     @Override

--- a/features/collection/api/src/main/java/org/opennms/netmgt/collection/support/builder/GenericTypeResource.java
+++ b/features/collection/api/src/main/java/org/opennms/netmgt/collection/support/builder/GenericTypeResource.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2010-2016 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2016 The OpenNMS Group, Inc.
+ * Copyright (C) 2010-2018 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2018 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -56,7 +56,7 @@ public class GenericTypeResource extends DeferredGenericTypeResource {
         m_persistenceSelectorStrategy.setParameters(resourceType.getPersistenceSelectorStrategy().getParameters());
     }
 
-    protected static String sanitizeInstance(String instance) {
+    public static String sanitizeInstance(String instance) {
         return instance.replaceAll("\\s+", "_").replaceAll(":", "_").replaceAll("\\\\", "_").replaceAll("[\\[\\]]", "_");
     }
 


### PR DESCRIPTION
… on resource.


NMS-9702: GenericResourceType is altering index names on class object initialization

* JIRA: http://issues.opennms.org/browse/NMS-9702
