### PR TITLE
Fix SyslogMessageTest after February wrap

### DIFF
--- a/features/events/syslog/src/test/java/org/opennms/netmgt/syslogd/SyslogMessageTest.java
+++ b/features/events/syslog/src/test/java/org/opennms/netmgt/syslogd/SyslogMessageTest.java
@@ -164,7 +164,7 @@ public class SyslogMessageTest {
             final SyslogMessage message = parser.parse();
             LOG.debug("message = {}", message);
             final Calendar cal = Calendar.getInstance();
-            cal.set(Calendar.YEAR, ZonedDateTimeBuilder.getBestYearForMonth(Calendar.MARCH));
+            cal.set(Calendar.YEAR, ZonedDateTimeBuilder.getBestYearForMonth(Month.MARCH.getValue()));
             cal.set(Calendar.MONTH, Calendar.MARCH);
             cal.set(Calendar.DAY_OF_MONTH, 14);
             cal.set(Calendar.HOUR_OF_DAY, 17);


### PR DESCRIPTION
Oops, I used a Calendar value instead of a java.time value. :P This will need to be merged into all branches from `foundation-2017` and higher to fix the test.