### PR TITLE
NMS-9846: Improve event processing rate in alarmd

### DIFF
--- a/features/amqp/alarm-northbounder/src/main/java/org/opennms/features/amqp/alarmnorthbounder/AlarmNorthbounder.java
+++ b/features/amqp/alarm-northbounder/src/main/java/org/opennms/features/amqp/alarmnorthbounder/AlarmNorthbounder.java
@@ -68,4 +68,9 @@ public class AlarmNorthbounder extends AbstractNorthbounder {
     public void setAlarmForwarder(DefaultAlarmForwarder alarmForwarder) {
         this.alarmForwarder = alarmForwarder;
     }
+
+    @Override
+    public boolean isReady() {
+        return true;
+    }
 }

--- a/features/events/api/src/main/java/org/opennms/netmgt/events/api/ThreadAwareEventListener.java
+++ b/features/events/api/src/main/java/org/opennms/netmgt/events/api/ThreadAwareEventListener.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2007-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2018 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2018 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -26,34 +26,21 @@
  *     http://www.opennms.com/
  *******************************************************************************/
 
-package org.opennms.netmgt.events.api.annotations;
-
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Inherited;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
-
-import org.opennms.netmgt.events.api.AnnotationBasedEventListenerAdapter;
+package org.opennms.netmgt.events.api;
 
 /**
- * Annotation that is used to denote methods on a class that act as event listener callbacks.
- * The {@link AnnotationBasedEventListenerAdapter} is used inside a Spring context to activate
- * classes that are {@link EventListener}-annotated by using its 
- * {@link AnnotationBasedEventListenerAdapter#setAnnotatedListener(Object)} method.
+ * Optional interface which can be implemented by event listeners (and
+ * annotated event listeners) in order to request the event callbacks
+ * to be invoked using multiple threads.
  *
- * @author <a href="mailto:brozow@opennms.org">Mathew Brozowski</a>
- * @version $Id: $
+ * If this interface is not present (and not threads are set in the case
+ * of an annotated listener), then the callbacks will be performed using
+ * a single thread.
+ *
+ * @author jwhite
  */
-@Inherited
-@Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.TYPE)
-public @interface EventListener {
+public interface ThreadAwareEventListener {
 
-    String name();
-
-    String logPrefix() default "";
-
-    int threads() default 1;
+    int getNumThreads();
 
 }

--- a/features/events/daemon/src/test/java/org/opennms/netmgt/eventd/EventIpcManagerDefaultImplTest.java
+++ b/features/events/daemon/src/test/java/org/opennms/netmgt/eventd/EventIpcManagerDefaultImplTest.java
@@ -29,6 +29,7 @@
 package org.opennms.netmgt.eventd;
 
 import static com.jayway.awaitility.Awaitility.await;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertNotEquals;
@@ -37,18 +38,24 @@ import static org.opennms.core.utils.InetAddressUtils.addr;
 import java.lang.Thread.UncaughtExceptionHandler;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.junit.Test;
 import org.opennms.netmgt.events.api.EventConstants;
 import org.opennms.netmgt.events.api.EventHandler;
 import org.opennms.netmgt.events.api.EventListener;
+import org.opennms.netmgt.events.api.ThreadAwareEventListener;
 import org.opennms.netmgt.model.events.EventBuilder;
 import org.opennms.netmgt.xml.event.Event;
 import org.opennms.netmgt.xml.event.Log;
+import org.opennms.test.ThreadLocker;
 import org.opennms.test.ThrowableAnticipator;
 import org.opennms.test.mock.EasyMockUtils;
 import org.slf4j.Logger;
@@ -756,5 +763,66 @@ public class EventIpcManagerDefaultImplTest extends TestCase {
         manager.broadcastNow(e, true);
         // broadcastNow() returned, so the counter should have been increased
         assertEquals(1, counter.get());
+    }
+
+    private static class MultiThreadedEventListener implements ThreadAwareEventListener, EventListener {
+        private final ThreadLocker locker;
+        private final int numThreads;
+
+        public MultiThreadedEventListener(int numThreads, ThreadLocker locker) {
+            this.numThreads = numThreads;
+            this.locker = Objects.requireNonNull(locker);
+        }
+
+        @Override
+        public String getName() {
+            return getClass().getCanonicalName();
+        }
+
+        @Override
+        public void onEvent(Event e) {
+            locker.park();
+        }
+
+        @Override
+        public int getNumThreads() {
+            return numThreads;
+        }
+    }
+
+    /**
+     * Verify that an event listener that implements the {@link ThreadAwareEventListener} interface
+     * receives event callbacks over mulitple threads.
+     *
+     * @throws ExecutionException
+     * @throws InterruptedException
+     */
+    @Test
+    public void testMultiThreadedEventListener() throws ExecutionException, InterruptedException {
+        int N = 10;
+        ThreadLocker locker = new ThreadLocker();
+        MultiThreadedEventListener mtListener = new MultiThreadedEventListener(N, locker);
+        m_manager.addEventListener(mtListener);
+
+        // No threads waiting
+        CompletableFuture<Integer> lockedFuture = locker.waitForThreads(N);
+
+        // Send 2*N events
+        for (int k = 0; k < 2*N; k++) {
+            EventBuilder bldr = new EventBuilder("uei.opennms.org/foo", "testMultiThreadedEventListener");
+            m_manager.broadcastNow(bldr.getEvent(), false);
+        }
+
+        // Wait for N threads to be locked
+        lockedFuture.get();
+
+        // Sleep a little longer
+        Thread.sleep(500);
+
+        // No extra threads should be waiting
+        assertThat(locker.getNumExtraThreadsWaiting(), equalTo(0));
+
+        // Release
+        locker.release();
     }
 }

--- a/features/events/shell-commands/src/main/java/org/opennms/netmgt/events/commands/StressCommand.java
+++ b/features/events/shell-commands/src/main/java/org/opennms/netmgt/events/commands/StressCommand.java
@@ -71,7 +71,9 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder;
  */
 @Command(scope = "events", name = "stress", description="Stress the event bus with generated events.",detailedDescription=
         "Generate newSuspect events with increasing IP addresses:\n"
-        + "\tevents:stress -u uei.opennms.org/internal/discovery/newSuspect -e 10 -s 1 -j \"i=i+1\" -j \"eb.setInterface(iputils:int2ip(167837696 + i))\"")
+        + "\tevents:stress -u uei.opennms.org/internal/discovery/newSuspect -e 10 -s 1 -j \"i=i+1\" -j \"eb.setInterface(iputils:int2ip(167837696 + i))\"\n"
+	+ "Trigger 100 alarms and reduce additional events against these:\n"
+	+ "\tevents:stress -x -t 10 -e 100 -u uei.opennms.org/alarms/trigger -j \"eb.addParam('node', math:floor(math:random() * 100))\"")
 @Service
 public class StressCommand implements Action {
 
@@ -123,6 +125,7 @@ public class StressCommand implements Action {
 
             Map<String, Object> functions = Maps.newHashMap();
             functions.put("iputils", IpUtils.class);
+            functions.put("math", Math.class);
             engine.setFunctions(functions);
 
             for (String jexlExpression : jexlExpressions) {

--- a/features/ncs/ncs-northbounder/src/main/etc/ncs-northbounder-configuration.xml
+++ b/features/ncs/ncs-northbounder/src/main/etc/ncs-northbounder-configuration.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<ncs-northbounder-config enabled="true" nagles-delay="1000" 
+<ncs-northbounder-config enabled="false" nagles-delay="1000"
 	scheme="https" host="localhost" path="/fmpm/restful/NotificationMessageRelay">
 	<uei>uei.opennms.org/internal/ncs/componentImpacted</uei>
 	<uei>uei.opennms.org/internal/ncs/componentResolved</uei>

--- a/features/ncs/ncs-northbounder/src/main/java/org/opennms/netmgt/ncs/northbounder/NCSNorthbounder.java
+++ b/features/ncs/ncs-northbounder/src/main/java/org/opennms/netmgt/ncs/northbounder/NCSNorthbounder.java
@@ -117,6 +117,11 @@ public class NCSNorthbounder extends AbstractNorthbounder {
 
     }
 
+    @Override
+    public boolean isReady() {
+        return getConfig().isEnabled();
+    }
+
     private ServiceAlarmNotification toServiceAlarms(List<NorthboundAlarm> alarms) {
 
         List<ServiceAlarm> serviceAlarms = new ArrayList<ServiceAlarm>(alarms.size());

--- a/opennms-alarms/api/src/main/java/org/opennms/netmgt/alarmd/api/Northbounder.java
+++ b/opennms-alarms/api/src/main/java/org/opennms/netmgt/alarmd/api/Northbounder.java
@@ -43,6 +43,19 @@ public interface Northbounder {
     public void start() throws NorthbounderException;
 
     /**
+     * Used to determine if the northbounder is ready to accept alarms.
+     *
+     * If no northbounders are ready, the caller can save resources by not creating and
+     * initializing the {@link NorthboundAlarm}s.
+     *
+     * This method is called once after northbounder is registered and started.
+     * If the status were to change sometime after, the northbounder must re-register itself.
+     *
+     * @return <code>true</code> if the northbounder is ready to accept alarms, <code>false</code> otherwise.
+     */
+    boolean isReady();
+
+    /**
      * On alarm.
      *
      * @param alarm the alarm

--- a/opennms-alarms/api/src/test/java/org/opennms/netmgt/alarmd/api/support/AbstractNorthbounderTest.java
+++ b/opennms-alarms/api/src/test/java/org/opennms/netmgt/alarmd/api/support/AbstractNorthbounderTest.java
@@ -81,6 +81,11 @@ public class AbstractNorthbounderTest {
             return m_accepting;
         }
 
+        @Override
+        public boolean isReady() {
+            return true;
+        }
+
         /* (non-Javadoc)
          * @see org.opennms.netmgt.alarmd.api.support.AbstractNorthbounder#forwardAlarms(java.util.List)
          */

--- a/opennms-alarms/bsf-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/bsf/BSFNorthbounder.java
+++ b/opennms-alarms/bsf-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/bsf/BSFNorthbounder.java
@@ -158,6 +158,11 @@ public class BSFNorthbounder extends AbstractNorthbounder implements Initializin
         return false;
     }
 
+    @Override
+    public boolean isReady() {
+        return initialized && getConfig().isEnabled();
+    }
+
     /**
      * Each implementation of the AbstractNorthbounder has a nice queue (Nagle's algorithmic) and the worker thread that processes the queue
      * calls this method to send alarms to the northern NMS.

--- a/opennms-alarms/bsf-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/bsf/BSFNorthbounderManager.java
+++ b/opennms-alarms/bsf-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/bsf/BSFNorthbounderManager.java
@@ -126,6 +126,11 @@ public class BSFNorthbounderManager implements InitializingBean, Northbounder, D
         // There is no need to do something here. Only the reload method will be implemented
     }
 
+    @Override
+    public boolean isReady() {
+        return false;
+    }
+
     /**
      * On alarm.
      *

--- a/opennms-alarms/daemon/src/main/java/org/opennms/netmgt/alarmd/AlarmPersister.java
+++ b/opennms-alarms/daemon/src/main/java/org/opennms/netmgt/alarmd/AlarmPersister.java
@@ -43,8 +43,9 @@ public interface AlarmPersister {
      * <p>persist</p>
      *
      * @param event a {@link org.opennms.netmgt.xml.event.Event} object.
+     * @param eagerlyLoadAlarm <code>true</code> if all fields on the returned alarlm should be early loaded, <code>false</code> otherwise
      * @return 
      */
-    OnmsAlarm persist(Event event);
+    OnmsAlarm persist(Event event, boolean eagerlyLoadAlarm);
 
 }

--- a/opennms-alarms/daemon/src/main/java/org/opennms/netmgt/alarmd/AlarmPersisterImpl.java
+++ b/opennms-alarms/daemon/src/main/java/org/opennms/netmgt/alarmd/AlarmPersisterImpl.java
@@ -28,6 +28,12 @@
 
 package org.opennms.netmgt.alarmd;
 
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReadWriteLock;
+
 import org.hibernate.Hibernate;
 import org.opennms.netmgt.dao.api.AlarmDao;
 import org.opennms.netmgt.dao.api.EventDao;
@@ -46,6 +52,9 @@ import org.springframework.transaction.support.TransactionCallback;
 import org.springframework.transaction.support.TransactionOperations;
 import org.springframework.util.Assert;
 
+import com.google.common.base.Supplier;
+import com.google.common.util.concurrent.Striped;
+
 /**
  * Singleton to persist OnmsAlarms.
  *
@@ -55,10 +64,13 @@ import org.springframework.util.Assert;
 public class AlarmPersisterImpl implements AlarmPersister {
     private static final Logger LOG = LoggerFactory.getLogger(AlarmPersisterImpl.class);
 
+    protected static final Integer NUM_STRIPE_LOCKS = Integer.getInteger("org.opennms.alarmd.stripe.locks", Alarmd.THREADS * 4);
+
     private AlarmDao m_alarmDao;
     private EventDao m_eventDao;
     private EventForwarder m_eventForwarder;
     private TransactionOperations m_transactionOperations;
+    private Striped<Lock> lockStripes = StripedExt.fairLock(NUM_STRIPE_LOCKS);
 
     private static class OnmsAlarmAndLifecycleEvent {
         private final OnmsAlarm m_alarm;
@@ -90,13 +102,18 @@ public class AlarmPersisterImpl implements AlarmPersister {
             LOG.debug("process: {}; nodeid: {}; ipaddr: {}; serviceid: {}", event.getUei(), event.getNodeid(), event.getInterface(), event.getService());
         }
 
-        // Process the alarm inside a transaction
-        OnmsAlarmAndLifecycleEvent alarmAndEvent = m_transactionOperations.execute(new TransactionCallback<OnmsAlarmAndLifecycleEvent>() {
-            @Override
-            public OnmsAlarmAndLifecycleEvent doInTransaction(TransactionStatus arg0) {
-                return addOrReduceEventAsAlarm(event);
-            }
-        });
+        // Lock both the reduction and clear keys (if set) using a fair striped lock
+        // We do this to ensure that clears and triggers are processed in the same order
+        // as the calls are made
+        final Iterable<Lock> locks = lockStripes.bulkGet(getLockKeys(event));
+        final OnmsAlarmAndLifecycleEvent alarmAndEvent;
+        try {
+            locks.forEach(Lock::lock);
+            // Process the alarm inside a transaction
+            alarmAndEvent = m_transactionOperations.execute((action) -> addOrReduceEventAsAlarm(event));
+        } finally {
+            locks.forEach(Lock::unlock);
+        }
 
         // Send the event outside of the database transaction
         m_eventForwarder.sendNow(alarmAndEvent.getEvent());
@@ -109,17 +126,17 @@ public class AlarmPersisterImpl implements AlarmPersister {
         OnmsEvent e = m_eventDao.get(event.getDbid());
         Assert.notNull(e, "Event was deleted before we could retrieve it and create an alarm.");
 
-        String reductionKey = event.getAlarmData().getReductionKey();
+        final String reductionKey = event.getAlarmData().getReductionKey();
         LOG.debug("addOrReduceEventAsAlarm: looking for existing reduction key: {}", reductionKey);
         OnmsAlarm alarm = m_alarmDao.findByReductionKey(reductionKey);
 
-        EventBuilder ebldr = null;
+        final EventBuilder ebldr;
         if (alarm == null) {
             if (LOG.isDebugEnabled()) {
                 LOG.debug("addOrReduceEventAsAlarm: reductionKey:{} not found, instantiating new alarm", reductionKey);
             }
             alarm = createNewAlarm(e, event);
-            
+
             //FIXME: this should be a cascaded save
             m_alarmDao.save(alarm);
             m_eventDao.saveOrUpdate(e);
@@ -140,14 +157,17 @@ public class AlarmPersisterImpl implements AlarmPersister {
             ebldr = new EventBuilder(EventConstants.ALARM_UPDATED_WITH_REDUCED_EVENT_UEI, Alarmd.NAME);
         }
 
+        // Load fields which are known to be used by the NBIs
+        if (alarm.getServiceType() != null) {
+            alarm.getServiceType().getName(); // To avoid potential LazyInitializationException when dealing with NorthboundAlarm
+        }
         if (alarm.getNodeId() != null) {
             alarm.getNode().getForeignSource(); // This should trigger the lazy loading of the node object, to properly populate the NorthboundAlarm class.
         }
+        Hibernate.initialize(alarm.getEventParameters());
 
         ebldr.addParam(EventConstants.PARM_ALARM_UEI, alarm.getUei());
         ebldr.addParam(EventConstants.PARM_ALARM_ID, alarm.getId());
-
-        Hibernate.initialize(alarm.getEventParameters());
 
         return new OnmsAlarmAndLifecycleEvent(alarm, ebldr.getEvent());
     }
@@ -214,9 +234,6 @@ public class AlarmPersisterImpl implements AlarmPersister {
     }
 
     private static OnmsAlarm createNewAlarm(OnmsEvent e, Event event) {
-        if (e.getServiceType() != null) {
-            e.getServiceType().getName(); // To avoid potential LazyInitializationException when dealing with NorthboundAlarm
-        }
         OnmsAlarm alarm = new OnmsAlarm();
         alarm.setAlarmType(event.getAlarmData().getAlarmType());
         alarm.setClearKey(event.getAlarmData().getClearKey());
@@ -266,6 +283,14 @@ public class AlarmPersisterImpl implements AlarmPersister {
         Assert.isTrue(event.getDbid() > 0, "Incoming event has an illegal dbid (" + event.getDbid() + "), aborting");
 
         return true;
+    }
+
+    private static Collection<String> getLockKeys(Event event) {
+        if (event.getAlarmData().getClearKey() == null) {
+            return Collections.singletonList(event.getAlarmData().getReductionKey());
+        } else {
+            return Arrays.asList(event.getAlarmData().getReductionKey(), event.getAlarmData().getClearKey());
+        }
     }
 
     public TransactionOperations getTransactionOperations() {

--- a/opennms-alarms/daemon/src/main/java/org/opennms/netmgt/alarmd/StripedExt.java
+++ b/opennms-alarms/daemon/src/main/java/org/opennms/netmgt/alarmd/StripedExt.java
@@ -1,0 +1,96 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2018 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2018 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.alarmd;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+import com.google.common.base.Supplier;
+import com.google.common.util.concurrent.Striped;
+
+/**
+ * Here we extend {@link com.google.common.util.concurrent.Striped}
+ * to support creating fair reentrant locks.
+ *
+ * We use reflection to invoke {@link com.google.common.util.concurrent.Striped.CompactStriped#CompactStriped(int, Supplier)}
+ * and provide a supplier that creates a fair lock.
+ *
+ * This is clearly a hack, but seems better than the alternative of A) trying to find another library that supports this
+ * or B) re-implementing striped locking ourselves.
+ *
+ * Guava Feature Request:
+ *   https://github.com/google/guava/issues/2514
+ *
+ * @author jwhite
+ */
+public class StripedExt {
+
+    /**
+     * Creates a {@code Striped<Lock>} with eagerly initialized, strongly referenced locks.
+     * Every lock is fair and reentrant.
+     *
+     * @param stripes the minimum number of stripes (locks) required
+     * @return a new {@code Striped<Lock>}
+     */
+    public static Striped<Lock> fairLock(int stripes) {
+        final Striped<Lock> lockStripes = Striped.lock(1);
+        try {
+            final Constructor<?> ctor = lockStripes.getClass().getDeclaredConstructor(int.class, Supplier.class);
+            ctor.setAccessible(true);
+            try {
+                return (Striped<Lock>)ctor.newInstance(stripes, (Supplier<Lock>) () -> new FairPaddedLock());
+            } catch (InstantiationException|IllegalAccessException|InvocationTargetException ex) {
+                throw new RuntimeException(ex);
+            }
+        } catch (NoSuchMethodException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Modified version com.google.common.util.concurrent.Striped.PaddedLock that
+     * creates a fair ReentrantLock
+     */
+    private static class FairPaddedLock extends ReentrantLock {
+        /*
+         * Padding from 40 into 64 bytes, same size as cache line. Might be beneficial to add
+         * a fourth long here, to minimize chance of interference between consecutive locks,
+         * but I couldn't observe any benefit from that.
+         */
+        @SuppressWarnings("unused")
+        long q1, q2, q3;
+
+        FairPaddedLock() {
+            super(true);
+        }
+    }
+
+}

--- a/opennms-alarms/daemon/src/main/resources/META-INF/opennms/applicationContext-alarmd.xml
+++ b/opennms-alarms/daemon/src/main/resources/META-INF/opennms/applicationContext-alarmd.xml
@@ -18,7 +18,6 @@
 
   <bean id="daemon" class="org.opennms.netmgt.alarmd.Alarmd" >
     <property name="persister" ref="alarmPersister" />
-    <property name="northboundInterfaces" ref="northbounderList" />
   </bean>
 
   <bean id="daemonListener" class="org.opennms.netmgt.events.api.AnnotationBasedEventListenerAdapter">

--- a/opennms-alarms/daemon/src/test/java/org/opennms/netmgt/alarmd/AlarmdIT.java
+++ b/opennms-alarms/daemon/src/test/java/org/opennms/netmgt/alarmd/AlarmdIT.java
@@ -28,6 +28,9 @@
 
 package org.opennms.netmgt.alarmd;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -101,6 +104,11 @@ public class AlarmdIT implements TemporaryDatabaseAware<MockDatabase>, Initializ
         @Override
         public void start() throws NorthbounderException {
             m_startCalled = true;
+        }
+
+        @Override
+        public boolean isReady() {
+            return true;
         }
 
         @Override
@@ -313,7 +321,7 @@ public class AlarmdIT implements TemporaryDatabaseAware<MockDatabase>, Initializ
         ThrowableAnticipator ta = new ThrowableAnticipator();
         ta.anticipate(new IllegalArgumentException("Incoming event was null, aborting"));
         try {
-            m_alarmd.getPersister().persist(null);
+            m_alarmd.getPersister().persist(null, true);
         } catch (Throwable t) {
             ta.throwableReceived(t);
         }
@@ -323,7 +331,7 @@ public class AlarmdIT implements TemporaryDatabaseAware<MockDatabase>, Initializ
     @Test
     public void testNorthbounder() throws Exception {
         assertTrue(m_northbounder.isInitialized());
-        assertTrue(m_northbounder.getAlarms().isEmpty());
+        assertThat(m_northbounder.getAlarms(), hasSize(0));
 
         final EventBuilder bldr = new EventBuilder("testNoLogmsg", "AlarmdTest");
         bldr.setAlarmData(new AlarmData());
@@ -336,7 +344,7 @@ public class AlarmdIT implements TemporaryDatabaseAware<MockDatabase>, Initializ
         sendNodeDownEvent("%nodeid%", node);
 
         final List<NorthboundAlarm> alarms = m_northbounder.getAlarms();
-        assertTrue(alarms.size() > 0);
+        assertThat(alarms, hasSize(greaterThan(0)));
     }
     
 
@@ -348,7 +356,7 @@ public class AlarmdIT implements TemporaryDatabaseAware<MockDatabase>, Initializ
         ThrowableAnticipator ta = new ThrowableAnticipator();
         ta.anticipate(new IllegalArgumentException("Incoming event has an illegal dbid (0), aborting"));
         try {
-            m_alarmd.getPersister().persist(bldr.getEvent());
+            m_alarmd.getPersister().persist(bldr.getEvent(), false);
         } catch (Throwable t) {
             ta.throwableReceived(t);
         }
@@ -360,7 +368,7 @@ public class AlarmdIT implements TemporaryDatabaseAware<MockDatabase>, Initializ
         EventBuilder bldr = new EventBuilder("testNoAlarmData", "AlarmdTest");
         bldr.setLogMessage(null);
 
-        m_alarmd.getPersister().persist(bldr.getEvent());
+        m_alarmd.getPersister().persist(bldr.getEvent(), false);
     }
 
     @Test
@@ -372,7 +380,7 @@ public class AlarmdIT implements TemporaryDatabaseAware<MockDatabase>, Initializ
         ThrowableAnticipator ta = new ThrowableAnticipator();
         ta.anticipate(new IllegalArgumentException("Incoming event has an illegal dbid (0), aborting"));
         try {
-            m_alarmd.getPersister().persist(bldr.getEvent());
+            m_alarmd.getPersister().persist(bldr.getEvent(), false);
         } catch (Throwable t) {
             ta.throwableReceived(t);
         }

--- a/opennms-alarms/drools-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/drools/DroolsNorthbounder.java
+++ b/opennms-alarms/drools-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/drools/DroolsNorthbounder.java
@@ -329,4 +329,8 @@ public class DroolsNorthbounder extends AbstractNorthbounder implements Initiali
         }
     }
 
+    @Override
+    public boolean isReady() {
+        return initialized && getConfig().isEnabled();
+    }
 }

--- a/opennms-alarms/drools-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/drools/DroolsNorthbounderManager.java
+++ b/opennms-alarms/drools-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/drools/DroolsNorthbounderManager.java
@@ -128,6 +128,11 @@ public class DroolsNorthbounderManager implements Northbounder, InitializingBean
         // There is no need to do something here. Only the reload method will be implemented
     }
 
+    @Override
+    public boolean isReady() {
+        return false;
+    }
+
     /**
      * On alarm.
      *

--- a/opennms-alarms/email-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/email/EmailNorthbounder.java
+++ b/opennms-alarms/email-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/email/EmailNorthbounder.java
@@ -160,6 +160,11 @@ public class EmailNorthbounder extends AbstractNorthbounder implements Initializ
         return false;
     }
 
+    @Override
+    public boolean isReady() {
+        return initialized && getConfig().isEnabled();
+    }
+
     /**
      * Each implementation of the AbstractNorthbounder has a nice queue (Nagle's algorithmic) and the worker thread that processes the queue
      * calls this method to send alarms to the northern NMS.

--- a/opennms-alarms/email-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/email/EmailNorthbounderManager.java
+++ b/opennms-alarms/email-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/email/EmailNorthbounderManager.java
@@ -124,6 +124,11 @@ public class EmailNorthbounderManager implements InitializingBean, Northbounder,
         // There is no need to do something here. Only the reload method will be implemented
     }
 
+    @Override
+    public boolean isReady() {
+        return false;
+    }
+
     /**
      * On alarm.
      *

--- a/opennms-alarms/http-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/http/HttpNorthbounder.java
+++ b/opennms-alarms/http-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/http/HttpNorthbounder.java
@@ -99,6 +99,10 @@ public class HttpNorthbounder extends AbstractNorthbounder {
         return false;
     }
 
+    @Override
+    public boolean isReady() {
+        return true;
+    }
 
     /* (non-Javadoc)
      * @see org.opennms.netmgt.alarmd.api.support.AbstractNorthbounder#forwardAlarms(java.util.List)

--- a/opennms-alarms/jms-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/jms/JmsNorthbounder.java
+++ b/opennms-alarms/jms-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/jms/JmsNorthbounder.java
@@ -127,6 +127,11 @@ public class JmsNorthbounder extends AbstractNorthbounder implements Initializin
         return false;
     }
 
+    @Override
+    public boolean isReady() {
+        return getConfig().isEnabled();
+    }
+
     /* (non-Javadoc)
      * @see org.springframework.beans.factory.InitializingBean#afterPropertiesSet()
      */

--- a/opennms-alarms/jms-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/jms/JmsNorthbounderManager.java
+++ b/opennms-alarms/jms-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/jms/JmsNorthbounderManager.java
@@ -120,6 +120,11 @@ public class JmsNorthbounderManager implements InitializingBean, Northbounder, D
         // There is no need to do something here. Only the reload method will be implemented
     }
 
+    @Override
+    public boolean isReady() {
+        return false;
+    }
+
     /* (non-Javadoc)
      * @see org.opennms.netmgt.alarmd.api.Northbounder#onAlarm(org.opennms.netmgt.alarmd.api.NorthboundAlarm)
      */

--- a/opennms-alarms/snmptrap-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/snmptrap/SnmpTrapNorthbounder.java
+++ b/opennms-alarms/snmptrap-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/snmptrap/SnmpTrapNorthbounder.java
@@ -120,6 +120,11 @@ public class SnmpTrapNorthbounder extends AbstractNorthbounder implements Initia
         return false;
     }
 
+    @Override
+    public boolean isReady() {
+        return initialized && getConfig().isEnabled();
+    }
+
     /**
      * Each implementation of the AbstractNorthbounder has a nice queue (Nagle's algorithmic) and the worker thread that processes the queue
      * calls this method to send alarms to the northern NMS.

--- a/opennms-alarms/snmptrap-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/snmptrap/SnmpTrapNorthbounderManager.java
+++ b/opennms-alarms/snmptrap-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/snmptrap/SnmpTrapNorthbounderManager.java
@@ -123,6 +123,11 @@ public class SnmpTrapNorthbounderManager implements InitializingBean, Northbound
         // There is no need to do something here. Only the reload method will be implemented
     }
 
+    @Override
+    public boolean isReady() {
+        return false;
+    }
+
     /**
      * On alarm.
      *

--- a/opennms-alarms/syslog-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/syslog/SyslogNorthbounder.java
+++ b/opennms-alarms/syslog-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/syslog/SyslogNorthbounder.java
@@ -128,6 +128,11 @@ public class SyslogNorthbounder extends AbstractNorthbounder implements Initiali
         return false;
     }
 
+    @Override
+    public boolean isReady() {
+        return initialized && getConfig().isEnabled();
+    }
+
     /**
      * Each implementation of the AbstractNorthbounder has a nice queue
      * (Nagle's algorithmic) and the worker thread that processes the queue

--- a/opennms-alarms/syslog-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/syslog/SyslogNorthbounderManager.java
+++ b/opennms-alarms/syslog-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/syslog/SyslogNorthbounderManager.java
@@ -126,6 +126,11 @@ public class SyslogNorthbounderManager implements InitializingBean, Northbounder
         // There is no need to do something here. Only the reload method will be implemented
     }
 
+    @Override
+    public boolean isReady() {
+        return false;
+    }
+
     /**
      * On alarm.
      *


### PR DESCRIPTION
JIRA: https://issues.opennms.org/browse/NMS-9846

This PR contains a number of fixes aimed at improving the processing speed of alarmd:
 * Process events in parallel while use a fair striped lock on both the reduction and clear keys to continue processing events in order.
 * Avoid further processing required by northbounder (NBIs) if none are enabled.

On my system, I was able to double the rate at which events were processed with these changes. The `events:stress` command has been update with an example showing how `alarmd` can be benchmarked.
