### PR TITLE
NMS-9829: Allow any external jdbc drivers to load in jdbc detector/poller/collector

### DIFF
--- a/core/lib/src/main/java/org/opennms/core/utils/DBTools.java
+++ b/core/lib/src/main/java/org/opennms/core/utils/DBTools.java
@@ -46,7 +46,7 @@ public abstract class DBTools {
      * 
      * @see #constructUrl
      */
-    private static final String JDBC_HOST = "OPENNMS_JDBC_HOSTNAME";
+    private static final String JDBC_HOST = "localhost:5432";
 
     /**
      * Minimal port range
@@ -62,7 +62,7 @@ public abstract class DBTools {
      * Default Sybase JDBC driver to use. Defaults to
      * 'com.sybase.jdbc2.jdbc.SybDriver'
      */
-    public static final String DEFAULT_JDBC_DRIVER = "com.sybase.jdbc2.jdbc.SybDriver";
+    public static final String DEFAULT_JDBC_DRIVER = "org.postgresql.Driver";
 
     /**
      * PostgreSQL JDBC driver
@@ -72,7 +72,7 @@ public abstract class DBTools {
     /**
      * Default user to use when connecting to the database. Defaults to 'sa'
      */
-    public static final String DEFAULT_DATABASE_USER = "sa";
+    public static final String DEFAULT_DATABASE_USER = "postgres";
 
     /**
      * Default database password. Should be empty. You should not put a database
@@ -84,7 +84,7 @@ public abstract class DBTools {
     /**
      * Default vendor protocol, like jdbc:sybase:Tds:
      */
-    public static final String DEFAULT_URL = "jdbc:sybase:Tds:" + JDBC_HOST + "/tempdb";
+    public static final String DEFAULT_URL = "jdbc:postgresql://" + JDBC_HOST + "/opennms";
 
     // Pattern for the JDBC_HOST
     private static final Pattern _pattern = Pattern.compile(JDBC_HOST);

--- a/features/jdbc-collector/pom.xml
+++ b/features/jdbc-collector/pom.xml
@@ -28,6 +28,7 @@
               org.opennms.netmgt.collection.adapters,
               *
             </Import-Package>
+            <DynamicImport-Package>*</DynamicImport-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/features/poller/monitors/core/pom.xml
+++ b/features/poller/monitors/core/pom.xml
@@ -22,6 +22,7 @@
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
+            <DynamicImport-Package>*</DynamicImport-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/opennms-provision/opennms-detector-jdbc/pom.xml
+++ b/opennms-provision/opennms-detector-jdbc/pom.xml
@@ -21,6 +21,7 @@
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <Bundle-SymbolicName>${project.groupId}.${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
+            <DynamicImport-Package>*</DynamicImport-Package>
             <Export-Package>org.opennms.netmgt.provision.detector.jdbc.*;version="${project.version}"</Export-Package>
           </instructions>
         </configuration>


### PR DESCRIPTION
Adding dynamic import for the bundles allow any other drivers to load for that bundle. 
Also make postgres as default in DBTools.

* JIRA: http://issues.opennms.org/browse/NMS-9829

Our [continuous integration system](http://bamboo.internal.opennms.com:8085) will test and verify your changes.
