### PR TITLE
Move cleanup to after writing new dump, and exit if dump fails, so we…

### DIFF
--- a/opennms-base-assembly/src/main/filtered/bin/opennms-thread-dump
+++ b/opennms-base-assembly/src/main/filtered/bin/opennms-thread-dump
@@ -143,7 +143,7 @@ deleteOldThreadDumps() {
 
 writeThreadDump() {
     dump_file="${output_dir}/${base_filename}.`date +${date_pattern}`"
-    "${java_home_actual}/bin/jstack" -l ${opennms_pid} > "${dump_file}"
+    "${java_home_actual}/bin/jstack" -l ${opennms_pid} > "${dump_file}" || die "FATAL: Failed to write thread dump. Exiting with no cleanup."
     chmod 0666 ${dump_file}
 }
 
@@ -170,5 +170,5 @@ fi
 
 find_jstack_bin
 find_opennms_pid
-deleteOldThreadDumps
 writeThreadDump
+deleteOldThreadDumps


### PR DESCRIPTION
don't clean up old thread dumps on a system where OpenNMS is not running

* JIRA: http://issues.opennms.org/browse/NMS-9872