### PR TITLE
NMS-9763: Added MD4 provider for Radius

### DIFF
--- a/protocols/radius/pom.xml
+++ b/protocols/radius/pom.xml
@@ -44,6 +44,12 @@
       <type>pom</type>
     </dependency>
     <dependency>
+      <!-- This adds support for MD4 digest used by mschapv2 - NMS-9763 -->
+      <groupId>org.opennms.dependencies</groupId>
+      <artifactId>jcifs-dependencies</artifactId>
+      <type>pom</type>
+    </dependency>
+    <dependency>
       <groupId>org.opennms.core.test-api</groupId>
       <artifactId>org.opennms.core.test-api.services</artifactId>
       <scope>test</scope>

--- a/protocols/radius/src/main/java/org/opennms/protocols/radius/detector/RadiusAuthDetector.java
+++ b/protocols/radius/src/main/java/org/opennms/protocols/radius/detector/RadiusAuthDetector.java
@@ -128,7 +128,11 @@ public class RadiusAuthDetector extends BasicDetector<CompositeAttributeLists, R
     private String m_password = DEFAULT_PASSWORD;
     private String m_ttlsInnerAuthType = DEFAULT_TTLS_INNER_AUTH_TYPE;
 	private String m_InnerIdentity = DEFAULT_INNER_IDENTITY;
-    
+
+    static {
+        RadiusUtils.loadSecurityProvider();
+    }
+
     /**
      * Default constructor
      */

--- a/protocols/radius/src/main/java/org/opennms/protocols/radius/monitor/RadiusAuthMonitor.java
+++ b/protocols/radius/src/main/java/org/opennms/protocols/radius/monitor/RadiusAuthMonitor.java
@@ -133,6 +133,10 @@ public final class RadiusAuthMonitor extends AbstractServiceMonitor {
      */
     public static final String DEFAULT_TTLS_INNER_AUTH_TYPE= "pap";
 
+    static {
+        RadiusUtils.loadSecurityProvider();
+    }
+
     /**
      * Class constructor.
      *

--- a/protocols/radius/src/main/java/org/opennms/protocols/radius/springsecurity/RadiusAuthenticationProvider.java
+++ b/protocols/radius/src/main/java/org/opennms/protocols/radius/springsecurity/RadiusAuthenticationProvider.java
@@ -35,21 +35,8 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 
-import net.jradius.client.RadiusClient;
-import net.jradius.client.auth.PAPAuthenticator;
-import net.jradius.client.auth.RadiusAuthenticator;
-import net.jradius.dictionary.Attr_UserName;
-import net.jradius.dictionary.Attr_UserPassword;
-import net.jradius.exception.RadiusException;
-import net.jradius.packet.AccessAccept;
-import net.jradius.packet.AccessRequest;
-import net.jradius.packet.RadiusPacket;
-import net.jradius.packet.attribute.AttributeFactory;
-import net.jradius.packet.attribute.AttributeList;
-import net.jradius.packet.attribute.RadiusAttribute;
-
-
 import org.opennms.core.utils.InetAddressUtils;
+import org.opennms.protocols.radius.utils.RadiusUtils;
 import org.opennms.web.api.Authentication;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -65,6 +52,19 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
+import net.jradius.client.RadiusClient;
+import net.jradius.client.auth.PAPAuthenticator;
+import net.jradius.client.auth.RadiusAuthenticator;
+import net.jradius.dictionary.Attr_UserName;
+import net.jradius.dictionary.Attr_UserPassword;
+import net.jradius.exception.RadiusException;
+import net.jradius.packet.AccessAccept;
+import net.jradius.packet.AccessRequest;
+import net.jradius.packet.RadiusPacket;
+import net.jradius.packet.attribute.AttributeFactory;
+import net.jradius.packet.attribute.AttributeList;
+import net.jradius.packet.attribute.RadiusAttribute;
+
 /**
  * An org.springframework.security.providers.AuthenticationProvider implementation that provides integration with a Radius server.
  *
@@ -74,6 +74,9 @@ public class RadiusAuthenticationProvider extends AbstractUserDetailsAuthenticat
 	
 	private static final Logger LOG = LoggerFactory.getLogger(RadiusAuthenticationProvider.class);
 
+    static {
+        RadiusUtils.loadSecurityProvider();
+    }
 
     private String server, secret;
     private int port = 1812, timeout = 5, retries = 3;

--- a/protocols/radius/src/main/java/org/opennms/protocols/radius/utils/RadiusUtils.java
+++ b/protocols/radius/src/main/java/org/opennms/protocols/radius/utils/RadiusUtils.java
@@ -28,6 +28,9 @@
 
 package org.opennms.protocols.radius.utils;
 
+import java.security.Provider;
+import java.security.Security;
+
 /**
  * @author jmk <jm+opennms@kubek.fr>
  *
@@ -39,5 +42,14 @@ public class RadiusUtils {
     }
     public final static boolean isTunneling(final String authType) {
         return isEAPTTLS(authType) || authType.equalsIgnoreCase("peap");
+    }
+
+    public final static void loadSecurityProvider() {
+        // This adds support for MD4 digest used by mschapv2 - NMS-9763
+        Security.addProvider(new Provider("MD4", 0.0D, "MD4 for Radius") {
+            {
+                this.put("MessageDigest.MD4", jcifs.util.MD4.class.getName());
+            }
+        });
     }
 }


### PR DESCRIPTION
* JIRA: http://issues.opennms.org/browse/NMS-9763

This is an ugly hack to get the radius stuff working again: It uses the MD4 implementation from jcifs and provides is to the security service interface, so jradius can pick it up.

The _clean_ solution would be to use BouncyCastle, but it breaks the karaf SSH shell.

Note: Having a OSGI bundle for each monitor implementation would be neat.