### PR TITLE
jira/HZN-1260 Missing Plug-in Manager in Windows installation

### DIFF
--- a/features/vaadin-opennms-pluginmanager/src/main/filtered-resources/productSpec.xml
+++ b/features/vaadin-opennms-pluginmanager/src/main/filtered-resources/productSpec.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <product>
-  <!-- productId is expected to contain the name of the product in the form <name>/<version> -->
+  <!-- productId is expected to contain the name of the product in the form <name>/<version>  -->
   <!-- The productId is used as the feature name for installing into Karaf the top level feature -->
   <!-- definition of the licensed product such that the feature can be installed using -->
   <!-- features:install name/version (version is optional) (Karaf 2.4.3) -->
   <!-- Karaf features can reference dependent features with a range of versions -->
-  <!-- e.g. feature version="[2.5.6,4)" -->
+  <!-- e.g. feature version="[2.5.6,4)"  -->
   <!-- so this allows us to have a single licence which can cover a range of releases of the -->
   <!-- feature which implements the product. -->
   <productId>${project.artifactId}/${project.version}</productId>

--- a/features/vaadin-opennms-pluginmanager/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/features/vaadin-opennms-pluginmanager/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -1,10 +1,19 @@
-<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0"
-  xsi:schemaLocation="http://www.osgi.org/xmlns/blueprint/v1.0.0 
-					http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd
-					http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0 
-					https://svn.apache.org/repos/asf/aries/tags/blueprint-0.3.1/blueprint-cm/src/main/resources/org/apache/aries/blueprint/compendium/cm/blueprint-cm-1.1.0.xsd
-					http://www.osgi.org/xmlns/blueprint-ext/v1.1.0 
-					https://svn.apache.org/repos/asf/aries/tags/blueprint-0.3.1/blueprint-core/src/main/resources/org/apache/aries/blueprint/ext/blueprint-ext.xsd">
+<blueprint
+    xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0"
+    xmlns:ext="http://aries.apache.org/blueprint/xmlns/blueprint-ext/v1.1.0"
+    xsi:schemaLocation="
+        http://www.osgi.org/xmlns/blueprint/v1.0.0 
+        http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd
+        http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0
+        http://aries.apache.org/schemas/blueprint-cm/blueprint-cm-1.1.0.xsd
+        http://aries.apache.org/blueprint/xmlns/blueprint-ext/v1.1.0
+        http://aries.apache.org/schemas/blueprint-ext/blueprint-ext-1.1.xsd
+">
+
+  <!-- Used for system properties -->
+  <ext:property-placeholder placeholder-prefix="$[" placeholder-suffix="]" />
 
   <!-- register product information with product registry in licence manager-->
   <reference id="productRegister" interface="org.opennms.karaf.productpub.ProductRegister" timeout="10000" />
@@ -162,7 +171,7 @@
   <!-- load default properties from  org.opennms.features.pluginmgr.config.cfg if exists -->
   <cm:property-placeholder persistent-id="org.opennms.features.pluginmgr.config" update-strategy="reload">
     <cm:default-properties>
-      <cm:property name="pluginModelfileUri" value="./etc/pluginManifestData.xml" />
+      <cm:property name="pluginModelfileUri" value="$[karaf.etc]$[file.separator]pluginManifestData.xml" />
       <cm:property name="pluginServerUsername" value="admin" />
       <cm:property name="pluginServerPassword" value="admin" />
       <cm:property name="pluginServerUrl" value="http://localhost:8980/opennms" />

--- a/pom.xml
+++ b/pom.xml
@@ -1366,9 +1366,9 @@
     <skipSignJar>true</skipSignJar>
 
     <!-- change to match which version of opennms-pluginmanger you want to run -->
-    <pluginmanagerVersion>1.0.6</pluginmanagerVersion>
-    <licencemanagerVersion>1.0.6</licencemanagerVersion>
-    <featuremanagerVersion>1.0.6</featuremanagerVersion>
+    <pluginmanagerVersion>1.0.7</pluginmanagerVersion>
+    <licencemanagerVersion>1.0.7</licencemanagerVersion>
+    <featuremanagerVersion>1.0.7</featuremanagerVersion>
   </properties>
 
   <profiles>


### PR DESCRIPTION
* JIRA: https://issues.opennms.org/browse/HZN-1260 Missing Plug-in Manager in Windows installation

This patch changes the path settings in Plugin Manager blueprint.xml files from referencing the OpenNMS etc directory using ./etc which does not appear to work in windows. As a result of these changes the Plugin Manager should now start up correctly in windows environments.

We are now referencing using
<ext:property-placeholder placeholder-prefix="$[" placeholder-suffix="]" />
and
 $[karaf.etc]$[file.separator].

Similar changes have been made in the OSGI Plugin Manager which has now been updated to Version 1.0.7

Bamboo passes https://bamboo.opennms.org/browse/OPENNMS-ONMS2074-3
