### PR TITLE
NMS-9861: Add jstl library 

### DIFF
--- a/dependencies/servlet/pom.xml
+++ b/dependencies/servlet/pom.xml
@@ -19,5 +19,10 @@
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>apache-jsp</artifactId>
     </dependency>
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>jstl</artifactId>
+      <version>1.2</version>
+    </dependency>
   </dependencies>
 </project>

--- a/opennms-webapp/pom.xml
+++ b/opennms-webapp/pom.xml
@@ -770,11 +770,6 @@
       <scope>${onmsLibScope}</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.taglibs</groupId>
-      <artifactId>taglibs-standard-impl</artifactId>
-      <scope>${onmsLibScope}</scope>
-    </dependency>
-    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <scope>${onmsLibScope}</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -3430,7 +3430,7 @@
       <dependency>
         <groupId>javax.servlet</groupId>
         <artifactId>jstl</artifactId>
-        <version>99.99.99-exclude-and-use-opennms-servlet-instead</version>
+        <version>1.2</version>
       </dependency>
       <dependency>
         <groupId>javax.servlet.jsp</groupId>
@@ -3559,11 +3559,6 @@
         <version>${jettyVersion}</version>
       </dependency>
       <!-- Make sure that this version matches the version from Jetty -->
-      <dependency>
-        <groupId>org.apache.taglibs</groupId>
-        <artifactId>taglibs-standard-impl</artifactId>
-        <version>1.2.5</version>
-      </dependency>
       <dependency>
         <groupId>javax.servlet</groupId>
         <artifactId>javax.servlet-api</artifactId>

--- a/smoke-test/src/test/java/org/opennms/smoketest/StatisticsReportsIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/StatisticsReportsIT.java
@@ -1,3 +1,31 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2018 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2018 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
 package org.opennms.smoketest;
 
 import static com.jayway.awaitility.Awaitility.await;
@@ -6,7 +34,6 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertNotNull;
 
-import java.net.InetSocketAddress;
 import java.util.Date;
 
 import org.junit.Before;
@@ -21,21 +48,20 @@ import org.opennms.netmgt.model.StatisticsReport;
 import org.opennms.netmgt.model.StatisticsReportData;
 import org.opennms.smoketest.utils.DaoUtils;
 import org.opennms.smoketest.utils.HibernateDaoFactory;
-import org.opennms.test.system.api.NewTestEnvironment.ContainerAlias;
 
-public class StatsIT extends OpenNMSSeleniumTestCase {
-    
+public class StatisticsReportsIT extends OpenNMSSeleniumTestCase {
+
     @Before
     public void setUp() throws Exception {
         m_driver.get(getBaseUrl() + "opennms/statisticsReports/index.htm");
+
     }
 
     @Test
     public void hasReportLinkThatMatchDescription() throws Exception {
-        
         Date startOfTest = new Date();
-        InetSocketAddress pgsql = getTestEnvironment().getServiceAddress(ContainerAlias.POSTGRES, 5432);
-        HibernateDaoFactory daoFactory = new HibernateDaoFactory(pgsql);
+
+        HibernateDaoFactory daoFactory = new HibernateDaoFactory(getPostgresService());
         ResourceReferenceDao resourceReferenceDao = daoFactory.getDao(ResourceReferenceDaoHibernate.class);
         StatisticsReportDao statisticsReportDao = daoFactory.getDao(StatisticsReportDaoHibernate.class);
 
@@ -60,8 +86,10 @@ public class StatsIT extends OpenNMSSeleniumTestCase {
 
         statisticsReportDao.save(report);
         await().atMost(1, MINUTES).pollInterval(5, SECONDS)
-        .until(DaoUtils.findMatchingCallable(statisticsReportDao, new CriteriaBuilder(StatisticsReport.class)
-                .ge("createTime", startOfTest).toCriteria()), notNullValue());
+                .until(DaoUtils.findMatchingCallable(statisticsReportDao,
+                        new CriteriaBuilder(StatisticsReport.class).ge("startDate", startOfTest).toCriteria()),
+                        notNullValue());
+        m_driver.navigate().refresh();
 
         assertNotNull(findElementByLink("Hourly Top 10 responses across all nodes"));
     }

--- a/smoke-test/src/test/java/org/opennms/smoketest/StatsIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/StatsIT.java
@@ -1,0 +1,69 @@
+package org.opennms.smoketest;
+
+import static com.jayway.awaitility.Awaitility.await;
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertNotNull;
+
+import java.net.InetSocketAddress;
+import java.util.Date;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.opennms.core.criteria.CriteriaBuilder;
+import org.opennms.netmgt.dao.api.ResourceReferenceDao;
+import org.opennms.netmgt.dao.api.StatisticsReportDao;
+import org.opennms.netmgt.dao.hibernate.ResourceReferenceDaoHibernate;
+import org.opennms.netmgt.dao.hibernate.StatisticsReportDaoHibernate;
+import org.opennms.netmgt.model.ResourceReference;
+import org.opennms.netmgt.model.StatisticsReport;
+import org.opennms.netmgt.model.StatisticsReportData;
+import org.opennms.smoketest.utils.DaoUtils;
+import org.opennms.smoketest.utils.HibernateDaoFactory;
+import org.opennms.test.system.api.NewTestEnvironment.ContainerAlias;
+
+public class StatsIT extends OpenNMSSeleniumTestCase {
+    
+    @Before
+    public void setUp() throws Exception {
+        m_driver.get(getBaseUrl() + "opennms/statisticsReports/index.htm");
+    }
+
+    @Test
+    public void hasReportLinkThatMatchDescription() throws Exception {
+        
+        Date startOfTest = new Date();
+        InetSocketAddress pgsql = getTestEnvironment().getServiceAddress(ContainerAlias.POSTGRES, 5432);
+        HibernateDaoFactory daoFactory = new HibernateDaoFactory(pgsql);
+        ResourceReferenceDao resourceReferenceDao = daoFactory.getDao(ResourceReferenceDaoHibernate.class);
+        StatisticsReportDao statisticsReportDao = daoFactory.getDao(StatisticsReportDaoHibernate.class);
+
+        StatisticsReport report = new StatisticsReport();
+        report.setName("Top10_Response_Hourly");
+        report.setDescription("Hourly Top 10 responses across all nodes");
+        report.setStartDate(new Date());
+        report.setEndDate(new Date());
+        report.setJobStartedDate(new Date());
+        report.setJobCompletedDate(new Date());
+        report.setPurgeDate(new Date());
+
+        ResourceReference resource = new ResourceReference();
+        resource.setResourceId("node1");
+        resourceReferenceDao.save(resource);
+
+        StatisticsReportData data = new StatisticsReportData();
+        data.setReport(report);
+        data.setResource(resource);
+        data.setValue(4.0);
+        report.addData(data);
+
+        statisticsReportDao.save(report);
+        await().atMost(1, MINUTES).pollInterval(5, SECONDS)
+        .until(DaoUtils.findMatchingCallable(statisticsReportDao, new CriteriaBuilder(StatisticsReport.class)
+                .ge("createTime", startOfTest).toCriteria()), notNullValue());
+
+        assertNotNull(findElementByLink("Hourly Top 10 responses across all nodes"));
+    }
+
+}


### PR DESCRIPTION
Statsd requires  ExtremeComponents jar which in turn depend on ExpressionEvaluatorManager class for some of the tags.
This class is not available in jstl library that jetty provides by default. So we need to have jstl  1.2 

* JIRA: http://issues.opennms.org/browse/NMS-9861

Our [continuous integration system](http://bamboo.internal.opennms.com:8085) will test and verify your changes.
