### PR TITLE
HZN-1268: Use timestamp of flow instead of current date for index creation

### DIFF
--- a/features/flows/elastic/src/main/java/org/opennms/netmgt/flows/elastic/ElasticFlowRepository.java
+++ b/features/flows/elastic/src/main/java/org/opennms/netmgt/flows/elastic/ElasticFlowRepository.java
@@ -161,10 +161,9 @@ public class ElasticFlowRepository implements FlowRepository {
 
         LOG.debug("Persisting {} flow documents.", flowDocuments.size());
         try (final Timer.Context ctx = logPersistingTimer.time()) {
-            final String index = indexStrategy.getIndex(new Date());
-
             final Bulk.Builder bulkBuilder = new Bulk.Builder();
             for (FlowDocument flowDocument : flowDocuments) {
+                final String index = indexStrategy.getIndex(new Date(flowDocument.getTimestamp()));
                 final Index.Builder indexBuilder = new Index.Builder(flowDocument)
                         .index(index)
                         .type(TYPE);


### PR DESCRIPTION
* JIRA: https://issues.opennms.org/browse/HZN-1268