### PR TITLE
NMS-9927: fix Backshift (and maybe others) jQuery import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ nb-configuration.xml
 .idea
 dependency-reduced-pom.xml
 npm-debug.log
+yarn-error.log
 /core/web-assets/node_modules
 /features/discovery/activemq-data
 /features/topology-map/org.opennms.features.topology.app/www-test/

--- a/core/web-assets/src/main/assets/js/apps/onms-graph/index.js
+++ b/core/web-assets/src/main/assets/js/apps/onms-graph/index.js
@@ -7,8 +7,8 @@
  * @author jwhite
  */
 
-const $j = require('vendor/jquery-ui-js');
-require('vendor/flot-js');
+require('vendor/jquery-ui-js');
+const $j = require('vendor/flot-js');
 
 const Backshift = require('vendor/backshift-js');
 const holder = require('vendor/holder-js');

--- a/core/web-assets/src/main/assets/js/vendor/bootstrap-js.js
+++ b/core/web-assets/src/main/assets/js/vendor/bootstrap-js.js
@@ -3,4 +3,4 @@ require('bootstrap/dist/js/bootstrap');
 
 console.log('init: bootstrap-js'); // eslint-disable-line no-console
 
-module.exports = window.jQuery = jQuery;
+module.exports = jQuery;

--- a/core/web-assets/src/main/assets/js/vendor/flot-js.js
+++ b/core/web-assets/src/main/assets/js/vendor/flot-js.js
@@ -14,4 +14,4 @@ require('flot-datatable/jquery.flot.datatable.js');
 
 console.log('init: flot-js'); // eslint-disable-line no-console
 
-module.exports = jQuery.plot;
+module.exports = jQuery;

--- a/core/web-assets/src/main/assets/js/vendor/jquery-js.js
+++ b/core/web-assets/src/main/assets/js/vendor/jquery-js.js
@@ -2,4 +2,4 @@ const jQuery = require('jquery');
 
 console.log('init: jquery-js'); // eslint-disable-line no-console
 
-module.exports = window['$'] = window['jQuery'] = jQuery;
+module.exports = jQuery;

--- a/core/web-assets/webpack.config.js
+++ b/core/web-assets/webpack.config.js
@@ -389,8 +389,10 @@ var config = {
     extensions: ['.tsx', '.ts', '.jsx', '.js']
   },
   plugins: [
-  /*
     new webpack.ProvidePlugin({
+      jQuery: 'vendor/jquery-js',
+      $: 'vendor/jquery-js'
+      /*,
       angular: 'angular',
       Backshift: 'backshift/dist/backshift.onms',
       bootbox: 'bootbox',
@@ -398,12 +400,10 @@ var config = {
       d3: 'd3',
       Holder: 'holderjs',
       holder: 'holderjs',
-      jQuery: 'jquery',
-      $: 'jquery',
       L: 'leaflet',
       _: 'underscore'
+      */
     }),
-    */
     new WebpackMd5Hash(),
     new StringReplacePlugin()
   ]


### PR DESCRIPTION
This fixes how a number of scripts in `core/web-assets` reference jQuery, using the webpack `ProvidePlugin` rather than attempting to manipulate window.jQuery directly.

* JIRA: http://issues.opennms.org/browse/NMS-9927

Our [continuous integration system](http://bamboo.internal.opennms.com:8085) will test and verify your changes.
