### PR TITLE
HZN-1275: Use the direction instead of the initiator field to establish conversation directionality

### DIFF
--- a/features/flows/api/src/main/java/org/opennms/netmgt/flows/api/ConversationKey.java
+++ b/features/flows/api/src/main/java/org/opennms/netmgt/flows/api/ConversationKey.java
@@ -45,9 +45,9 @@ public class ConversationKey {
     public ConversationKey(String location, Integer protocol, String srcIp, Integer srcPort, String dstIp, Integer dstPort) {
         this.location = location;
         this.protocol = protocol;
-        this.srcIp = Objects.requireNonNull(srcIp);
+        this.srcIp = srcIp;
         this.srcPort = srcPort;
-        this.dstIp = Objects.requireNonNull(dstIp);
+        this.dstIp = dstIp;
         this.dstPort = dstPort;
     }
 
@@ -55,7 +55,7 @@ public class ConversationKey {
         return location;
     }
 
-    public int getProtocol() {
+    public Integer getProtocol() {
         return protocol;
     }
 
@@ -91,5 +91,17 @@ public class ConversationKey {
     @Override
     public int hashCode() {
         return Objects.hash(location, protocol, srcIp, dstIp, srcPort, dstPort);
+    }
+
+    @Override
+    public String toString() {
+        return "ConversationKey{" +
+                "location='" + location + '\'' +
+                ", protocol=" + protocol +
+                ", srcIp='" + srcIp + '\'' +
+                ", dstIp='" + dstIp + '\'' +
+                ", srcPort=" + srcPort +
+                ", dstPort=" + dstPort +
+                '}';
     }
 }

--- a/features/flows/elastic/src/main/java/org/opennms/netmgt/flows/elastic/DocumentEnricher.java
+++ b/features/flows/elastic/src/main/java/org/opennms/netmgt/flows/elastic/DocumentEnricher.java
@@ -136,9 +136,7 @@ public class DocumentEnricher {
                 }
 
                 // Conversation tagging
-                if (document.isInitiator() != null) {
-                    document.setConvoKey(ConversationKeyUtils.getConvoKeyAsJsonString(document));
-                }
+                document.setConvoKey(ConversationKeyUtils.getConvoKeyAsJsonString(document));
 
                 // Apply Application mapping
                 if (document.isInitiator() != null) {

--- a/features/flows/elastic/src/main/java/org/opennms/netmgt/flows/elastic/SearchQueryProvider.java
+++ b/features/flows/elastic/src/main/java/org/opennms/netmgt/flows/elastic/SearchQueryProvider.java
@@ -100,13 +100,11 @@ public class SearchQueryProvider implements FilterVisitor<String> {
     }
 
     public String getSeriesFromTopNQuery(List<String> topN, long step, long start, long end,
-                                         String groupByTerm, String directionTerm,
-                                         List<Filter> filters) {
+                                         String groupByTerm, List<Filter> filters) {
         return render("series_for_terms.ftl", ImmutableMap.builder()
                 .put("filters", getFilterQueries(filters))
                 .put("topN", topN)
                 .put("groupByTerm", groupByTerm)
-                .put("directionTerm", directionTerm)
                 .put("step", step)
                 .put("start", start)
                 .put("end", end)
@@ -114,12 +112,10 @@ public class SearchQueryProvider implements FilterVisitor<String> {
     }
 
     public String getSeriesFromMissingQuery(long step, long start, long end, String groupByTerm,
-                                            String directionTerm, String keyForMissingTerm,
-                                            List<Filter> filters) {
+                                            String keyForMissingTerm, List<Filter> filters) {
         return render("series_for_missing.ftl", ImmutableMap.builder()
                 .put("filters", getFilterQueries(filters))
                 .put("groupByTerm", groupByTerm)
-                .put("directionTerm", directionTerm)
                 .put("keyForMissingTerm", keyForMissingTerm)
                 .put("step", step)
                 .put("start", start)
@@ -128,13 +124,12 @@ public class SearchQueryProvider implements FilterVisitor<String> {
     }
 
     public String getSeriesFromOthersQuery(List<String> topN, long step, long start, long end,
-                                           String groupByTerm, String directionTerm,
-                                           boolean excludeMissing, List<Filter> filters) {
+                                           String groupByTerm, boolean excludeMissing,
+                                           List<Filter> filters) {
         return render("series_for_others.ftl", ImmutableMap.builder()
                 .put("filters", getFilterQueries(filters))
                 .put("topN", topN)
                 .put("groupByTerm", groupByTerm)
-                .put("directionTerm", directionTerm)
                 .put("excludeMissing", excludeMissing)
                 .put("step", step)
                 .put("start", start)

--- a/features/flows/elastic/src/main/resources/org/opennms/netmgt/flows/elastic/series_for_missing.ftl
+++ b/features/flows/elastic/src/main/resources/org/opennms/netmgt/flows/elastic/series_for_missing.ftl
@@ -21,7 +21,7 @@
       "aggs": {
         "direction": {
           "terms": {
-            "field": "${directionTerm?json_string}",
+            "field": "netflow.direction",
             "size": 2
           },
           "aggs": {

--- a/features/flows/elastic/src/main/resources/org/opennms/netmgt/flows/elastic/series_for_others.ftl
+++ b/features/flows/elastic/src/main/resources/org/opennms/netmgt/flows/elastic/series_for_others.ftl
@@ -22,7 +22,7 @@
   "aggs": {
     "direction": {
       "terms": {
-        "field": "${directionTerm?json_string}",
+        "field": "netflow.direction",
         "size": 2
       },
       "aggs": {

--- a/features/flows/elastic/src/main/resources/org/opennms/netmgt/flows/elastic/series_for_terms.ftl
+++ b/features/flows/elastic/src/main/resources/org/opennms/netmgt/flows/elastic/series_for_terms.ftl
@@ -21,7 +21,7 @@
       "aggs": {
         "direction": {
           "terms": {
-            "field": "${directionTerm?json_string}",
+            "field": "netflow.direction",
             "size": 2
           },
           "aggs": {

--- a/features/flows/elastic/src/test/java/org/opennms/netmgt/flows/elastic/ConversationKeyUtilsTest.java
+++ b/features/flows/elastic/src/test/java/org/opennms/netmgt/flows/elastic/ConversationKeyUtilsTest.java
@@ -1,0 +1,78 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2018 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2018 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.flows.elastic;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+
+import org.junit.Test;
+import org.opennms.netmgt.flows.api.ConversationKey;
+
+public class ConversationKeyUtilsTest {
+
+    @Test
+    public void canCreateAndParseConversationKey() {
+        FlowDocument flowIn = new FlowDocument();
+        flowIn.setDirection(Direction.INGRESS);
+        flowIn.setLocation("SomeLoc");
+        flowIn.setProtocol(1);
+        flowIn.setSrcAddr("1.1.1.1");
+        flowIn.setSrcPort(9999);
+        flowIn.setDstAddr("2.2.2.2");
+        flowIn.setDstPort(10000);
+
+        FlowDocument flowOut = new FlowDocument();
+        flowOut.setDirection(Direction.EGRESS);
+        flowOut.setLocation(flowIn.getLocation());
+        flowOut.setProtocol(flowIn.getProtocol());
+        flowOut.setSrcAddr(flowIn.getDstAddr());
+        flowOut.setSrcPort(flowIn.getDstPort());
+        flowOut.setDstAddr(flowIn.getSrcAddr());
+        flowOut.setDstPort(flowIn.getSrcPort());
+
+        String inKey = ConversationKeyUtils.getConvoKeyAsJsonString(flowIn);
+        String outKey = ConversationKeyUtils.getConvoKeyAsJsonString(flowOut);
+
+        // We should have generated some key, and both should match
+        assertThat(inKey, notNullValue());
+        assertThat(inKey, equalTo(outKey));
+
+        ConversationKey expectedKey = new ConversationKey(
+                flowIn.getLocation(),
+                flowIn.getProtocol(),
+                flowIn.getSrcAddr(),
+                flowIn.getSrcPort(),
+                flowIn.getDstAddr(),
+                flowIn.getDstPort());
+        ConversationKey actualKey = ConversationKeyUtils.fromJsonString(inKey);
+        assertThat(actualKey, equalTo(expectedKey));
+    }
+
+}

--- a/features/flows/elastic/src/test/resources/flow-document-netflow5.json
+++ b/features/flows/elastic/src/test/resources/flow-document-netflow5.json
@@ -4,7 +4,7 @@
   "host": "192.168.1.1",
   "location": "SomeLocation",
   "netflow.bytes": 0,
-  "netflow.convo_key": "[\"SomeLocation\",0,\"192.168.2.2\",0,\"192.168.1.2\",0]",
+  "netflow.convo_key": "[\"SomeLocation\",0,\"192.168.1.2\",0,\"192.168.2.2\",0]",
   "netflow.direction": "ingress",
   "netflow.dst_addr": "192.168.2.2",
   "netflow.dst_as": 0,


### PR DESCRIPTION
JIRA: https://issues.opennms.org/browse/HZN-1275

Here we rework some of the logic related to conversation tagging for flows and update it to use the actual direction (ingress vs egress) instead of the "initiator" field.
