### PR TITLE
NMS-9831,HZN-1272: Handle OID event parameter keys and JSON event parameter values correctly

### DIFF
--- a/features/alarm-change-notifier/main-module/src/main/java/org/opennms/plugins/dbnotifier/alarmnotifier/AlarmChangeNotificationClient.java
+++ b/features/alarm-change-notifier/main-module/src/main/java/org/opennms/plugins/dbnotifier/alarmnotifier/AlarmChangeNotificationClient.java
@@ -61,6 +61,8 @@ public class AlarmChangeNotificationClient implements NotificationClient {
 
 	public static final String EVENT_SOURCE_NAME = "AlarmChangeNotifier";
 
+	protected static final String TYPE_JSON = "json";
+	protected static final String ENCODING_TEXT = "text";
 
 	EventProxy eventProxy = null;
 
@@ -105,8 +107,8 @@ public class AlarmChangeNotificationClient implements NotificationClient {
 							new EventBuilder( AlarmChangeEventConstants.ALARM_DELETED_EVENT, EVENT_SOURCE_NAME));
 
 					//copy in all values as json in params
-					eb.addParam(AlarmChangeEventConstants.OLD_ALARM_VALUES_PARAM,oldJsonObject.toString());
-					eb.addParam(AlarmChangeEventConstants.NEW_ALARM_VALUES_PARAM,newJsonObject.toString());
+					eb.addParam(AlarmChangeEventConstants.OLD_ALARM_VALUES_PARAM,oldJsonObject.toString(), TYPE_JSON, ENCODING_TEXT);
+					eb.addParam(AlarmChangeEventConstants.NEW_ALARM_VALUES_PARAM,newJsonObject.toString(), TYPE_JSON, ENCODING_TEXT);
 
 					sendEvent(eb.getEvent());
 				}
@@ -121,8 +123,8 @@ public class AlarmChangeNotificationClient implements NotificationClient {
 							new EventBuilder( AlarmChangeEventConstants.ALARM_CREATED_EVENT, EVENT_SOURCE_NAME));
 
 					//copy in all values as json in params
-					eb.addParam(AlarmChangeEventConstants.OLD_ALARM_VALUES_PARAM,oldJsonObject.toString());
-					eb.addParam(AlarmChangeEventConstants.NEW_ALARM_VALUES_PARAM,newJsonObject.toString());
+					eb.addParam(AlarmChangeEventConstants.OLD_ALARM_VALUES_PARAM,oldJsonObject.toString(), TYPE_JSON, ENCODING_TEXT);
+					eb.addParam(AlarmChangeEventConstants.NEW_ALARM_VALUES_PARAM,newJsonObject.toString(), TYPE_JSON, ENCODING_TEXT);
 
 					// set initial severity to new alarm severity
 					if (newJsonObject.get("severity")!=null) {
@@ -185,8 +187,8 @@ public class AlarmChangeNotificationClient implements NotificationClient {
 							eb.addParam(AlarmChangeEventConstants.OLDSEVERITY_PARAM,oldseverity);
 
 							//copy in all values as json in params
-							eb.addParam(AlarmChangeEventConstants.OLD_ALARM_VALUES_PARAM,oldJsonObject.toString());
-							eb.addParam(AlarmChangeEventConstants.NEW_ALARM_VALUES_PARAM,newJsonObject.toString());
+							eb.addParam(AlarmChangeEventConstants.OLD_ALARM_VALUES_PARAM,oldJsonObject.toString(), TYPE_JSON, ENCODING_TEXT);
+							eb.addParam(AlarmChangeEventConstants.NEW_ALARM_VALUES_PARAM,newJsonObject.toString(), TYPE_JSON, ENCODING_TEXT);
 
 							sendEvent(eb.getEvent());
 						}
@@ -202,8 +204,8 @@ public class AlarmChangeNotificationClient implements NotificationClient {
 									new EventBuilder(AlarmChangeEventConstants.ALARM_ACKNOWLEDGED_EVENT, EVENT_SOURCE_NAME));
 
 							//copy in all values as json in params
-							eb.addParam(AlarmChangeEventConstants.OLD_ALARM_VALUES_PARAM,oldJsonObject.toString());
-							eb.addParam(AlarmChangeEventConstants.NEW_ALARM_VALUES_PARAM,newJsonObject.toString());
+							eb.addParam(AlarmChangeEventConstants.OLD_ALARM_VALUES_PARAM,oldJsonObject.toString(), TYPE_JSON, ENCODING_TEXT);
+							eb.addParam(AlarmChangeEventConstants.NEW_ALARM_VALUES_PARAM,newJsonObject.toString(), TYPE_JSON, ENCODING_TEXT);
 
 							sendEvent(eb.getEvent());
 
@@ -217,8 +219,8 @@ public class AlarmChangeNotificationClient implements NotificationClient {
 										new EventBuilder(AlarmChangeEventConstants.ALARM_UNACKNOWLEDGED_EVENT, EVENT_SOURCE_NAME));
 
 								//copy in all values as json in params
-								eb.addParam(AlarmChangeEventConstants.OLD_ALARM_VALUES_PARAM,oldJsonObject.toString());
-								eb.addParam(AlarmChangeEventConstants.NEW_ALARM_VALUES_PARAM,newJsonObject.toString());
+								eb.addParam(AlarmChangeEventConstants.OLD_ALARM_VALUES_PARAM,oldJsonObject.toString(), TYPE_JSON, ENCODING_TEXT);
+								eb.addParam(AlarmChangeEventConstants.NEW_ALARM_VALUES_PARAM,newJsonObject.toString(), TYPE_JSON, ENCODING_TEXT);
 
 								sendEvent(eb.getEvent());
 							}
@@ -236,8 +238,8 @@ public class AlarmChangeNotificationClient implements NotificationClient {
 									new EventBuilder(AlarmChangeEventConstants.ALARM_SUPPRESSED_EVENT, EVENT_SOURCE_NAME));
 
 							//copy in all values as json in params
-							eb.addParam(AlarmChangeEventConstants.OLD_ALARM_VALUES_PARAM,oldJsonObject.toString());
-							eb.addParam(AlarmChangeEventConstants.NEW_ALARM_VALUES_PARAM,newJsonObject.toString());
+							eb.addParam(AlarmChangeEventConstants.OLD_ALARM_VALUES_PARAM,oldJsonObject.toString(), TYPE_JSON, ENCODING_TEXT);
+							eb.addParam(AlarmChangeEventConstants.NEW_ALARM_VALUES_PARAM,newJsonObject.toString(), TYPE_JSON, ENCODING_TEXT);
 
 							sendEvent(eb.getEvent());
 
@@ -253,8 +255,8 @@ public class AlarmChangeNotificationClient implements NotificationClient {
 												EVENT_SOURCE_NAME));
 
 								//copy in all values as json in params
-								eb.addParam(AlarmChangeEventConstants.OLD_ALARM_VALUES_PARAM,oldJsonObject.toString());
-								eb.addParam(AlarmChangeEventConstants.NEW_ALARM_VALUES_PARAM,newJsonObject.toString());
+								eb.addParam(AlarmChangeEventConstants.OLD_ALARM_VALUES_PARAM,oldJsonObject.toString(), TYPE_JSON, ENCODING_TEXT);
+								eb.addParam(AlarmChangeEventConstants.NEW_ALARM_VALUES_PARAM,newJsonObject.toString(), TYPE_JSON, ENCODING_TEXT);
 
 								sendEvent(eb.getEvent());
 							}
@@ -284,8 +286,8 @@ public class AlarmChangeNotificationClient implements NotificationClient {
 							eb.addParam(AlarmChangeEventConstants.TTICKETSTATE_PARAM,newtticketstate);
 
 							//copy in all values as json in params
-							eb.addParam(AlarmChangeEventConstants.OLD_ALARM_VALUES_PARAM,oldJsonObject.toString());
-							eb.addParam(AlarmChangeEventConstants.NEW_ALARM_VALUES_PARAM,newJsonObject.toString());
+							eb.addParam(AlarmChangeEventConstants.OLD_ALARM_VALUES_PARAM,oldJsonObject.toString(), TYPE_JSON, ENCODING_TEXT);
+							eb.addParam(AlarmChangeEventConstants.NEW_ALARM_VALUES_PARAM,newJsonObject.toString(), TYPE_JSON, ENCODING_TEXT);
 
 							sendEvent(eb.getEvent());
 						}
@@ -302,8 +304,8 @@ public class AlarmChangeNotificationClient implements NotificationClient {
 							eb.addParam(AlarmChangeEventConstants.STICKYMEMO_PARAM,newstickymemo);
 
 							//copy in all values as json in params
-							eb.addParam(AlarmChangeEventConstants.OLD_ALARM_VALUES_PARAM,oldJsonObject.toString());
-							eb.addParam(AlarmChangeEventConstants.NEW_ALARM_VALUES_PARAM,newJsonObject.toString());
+							eb.addParam(AlarmChangeEventConstants.OLD_ALARM_VALUES_PARAM,oldJsonObject.toString(), TYPE_JSON, ENCODING_TEXT);
+							eb.addParam(AlarmChangeEventConstants.NEW_ALARM_VALUES_PARAM,newJsonObject.toString(), TYPE_JSON, ENCODING_TEXT);
 
 							sendEvent(eb.getEvent());
 						}
@@ -332,8 +334,8 @@ public class AlarmChangeNotificationClient implements NotificationClient {
 									new EventBuilder(AlarmChangeEventConstants.ALARM_CHANGED_EVENT, EVENT_SOURCE_NAME));
 
 							//copy in all values as json in params
-							eb.addParam(AlarmChangeEventConstants.OLD_ALARM_VALUES_PARAM,oldJsonObject.toString());
-							eb.addParam(AlarmChangeEventConstants.NEW_ALARM_VALUES_PARAM,newJsonObject.toString());
+							eb.addParam(AlarmChangeEventConstants.OLD_ALARM_VALUES_PARAM,oldJsonObject.toString(), TYPE_JSON, ENCODING_TEXT);
+							eb.addParam(AlarmChangeEventConstants.NEW_ALARM_VALUES_PARAM,newJsonObject.toString(), TYPE_JSON, ENCODING_TEXT);
 
 							sendEvent(eb.getEvent());
 						}

--- a/features/alarm-change-notifier/main-module/src/main/java/org/opennms/plugins/dbnotifier/alarmnotifier/MemosChangeNotificationClient.java
+++ b/features/alarm-change-notifier/main-module/src/main/java/org/opennms/plugins/dbnotifier/alarmnotifier/MemosChangeNotificationClient.java
@@ -29,6 +29,9 @@
 package org.opennms.plugins.dbnotifier.alarmnotifier;
 
 
+import static org.opennms.plugins.dbnotifier.alarmnotifier.AlarmChangeNotificationClient.ENCODING_TEXT;
+import static org.opennms.plugins.dbnotifier.alarmnotifier.AlarmChangeNotificationClient.TYPE_JSON;
+
 import java.sql.Timestamp;
 import java.util.Calendar;
 
@@ -110,7 +113,7 @@ public class MemosChangeNotificationClient implements NotificationClient {
 					EventBuilder eb= new EventBuilder( AlarmChangeEventConstants.STICKY_MEMO_EVENT, EVENT_SOURCE_NAME);
 
 					//copy in all values as json in params
-					eb.addParam(AlarmChangeEventConstants.MEMO_VALUES_PARAM,memoJsonObject.toString());
+					eb.addParam(AlarmChangeEventConstants.MEMO_VALUES_PARAM,memoJsonObject.toString(), TYPE_JSON, ENCODING_TEXT);
 					eb.addParam(AlarmChangeEventConstants.MEMO_ALARMID_PARAM, alarmId );
 					eb.addParam(AlarmChangeEventConstants.MEMO_BODY_PARAM, body );
 					eb.addParam(AlarmChangeEventConstants.MEMO_AUTHOR_PARAM, author );
@@ -121,7 +124,7 @@ public class MemosChangeNotificationClient implements NotificationClient {
 					EventBuilder eb= new EventBuilder(AlarmChangeEventConstants.JOURNAL_MEMO_EVENT, EVENT_SOURCE_NAME);
 
 					//copy in all values as json in params
-					eb.addParam(AlarmChangeEventConstants.MEMO_VALUES_PARAM,memoJsonObject.toString());
+					eb.addParam(AlarmChangeEventConstants.MEMO_VALUES_PARAM,memoJsonObject.toString(), TYPE_JSON, ENCODING_TEXT);
 					eb.addParam(AlarmChangeEventConstants.MEMO_ALARMID_PARAM, alarmId );
 					eb.addParam(AlarmChangeEventConstants.MEMO_BODY_PARAM, body );
 					eb.addParam(AlarmChangeEventConstants.MEMO_AUTHOR_PARAM, author );

--- a/features/events/api/src/main/java/org/opennms/netmgt/xml/event/Value.java
+++ b/features/events/api/src/main/java/org/opennms/netmgt/xml/event/Value.java
@@ -70,7 +70,7 @@ public class Value implements Serializable {
      * Field _type.
      */
 	@XmlAttribute(name="type")
-	@Pattern(regexp="(int|string|Int32|OctetString|Null|ObjectIdentifier|Sequence|IpAddress|Counter32|Gauge32|TimeTicks|Opaque|Counter64)")
+	@Pattern(regexp="(int|string|Int32|OctetString|Null|ObjectIdentifier|Sequence|IpAddress|Counter32|Gauge32|TimeTicks|Opaque|Counter64|json)")
     private java.lang.String _type = "string";
 
     /**

--- a/features/opennms-es-rest/src/main/java/org/opennms/plugins/elasticsearch/rest/EventToIndex.java
+++ b/features/opennms-es-rest/src/main/java/org/opennms/plugins/elasticsearch/rest/EventToIndex.java
@@ -382,9 +382,14 @@ public class EventToIndex implements AutoCloseable {
 
 		body.put("host",event.getHost());
 
-		//get params from event
 		for(Parm parm : event.getParmCollection()) {
-			body.put("p_" + parm.getParmName(), parm.getValue().getContent());
+			// We have to handle oid parameters differently, as elastic would consider a containing "." as a sub
+			// field, e.g. ".1.2" results in a mapping of { 1: properties: { 2 } } which may exceed the maximum allowed
+			// fields for a mapping, see NMS-9831. Initially an array was used, to store the oids in the fashion:
+			// { "oid": "1.1.1", "value": "dummy value" } but elastic has some limitations on accessing objects in an
+			// array. Therefore we replace all existing . with an _
+			final String parmName = parm.getParmName().replaceAll("\\.", "_");
+			body.put("p_" + parmName, parm.getValue().getContent());
 		}
 
 		// remove old and new alarm values parms if not needed

--- a/features/opennms-es-rest/src/main/java/org/opennms/plugins/elasticsearch/rest/EventToIndex.java
+++ b/features/opennms-es-rest/src/main/java/org/opennms/plugins/elasticsearch/rest/EventToIndex.java
@@ -352,7 +352,7 @@ public class EventToIndex implements AutoCloseable {
 	 * Utility method to populate a Map with the most import event attributes
 	 */
 	private Index createEventIndexFromEvent(final Event event, final IndexAndType indexAndType) {
-		final Map<String,String> body = new HashMap<String,String>();
+		final JSONObject body = new JSONObject();
 
 		final Integer id = event.getDbid();
 		body.put("id", Integer.toString(id));
@@ -382,14 +382,31 @@ public class EventToIndex implements AutoCloseable {
 
 		body.put("host",event.getHost());
 
+		// Parse event parameters
+		final JSONParser jsonParser = new JSONParser();
 		for(Parm parm : event.getParmCollection()) {
 			// We have to handle oid parameters differently, as elastic would consider a containing "." as a sub
 			// field, e.g. ".1.2" results in a mapping of { 1: properties: { 2 } } which may exceed the maximum allowed
 			// fields for a mapping, see NMS-9831. Initially an array was used, to store the oids in the fashion:
 			// { "oid": "1.1.1", "value": "dummy value" } but elastic has some limitations on accessing objects in an
 			// array. Therefore we replace all existing . with an _
-			final String parmName = parm.getParmName().replaceAll("\\.", "_");
-			body.put("p_" + parmName, parm.getValue().getContent());
+			final String parmName = "p_" + parm.getParmName().replaceAll("\\.", "_");
+
+			// Some parameter values are of type json and should be decoded properly.
+			// See HZN-1272
+			if ("json".equalsIgnoreCase(parm.getValue().getType())) {
+				try {
+					JSONObject tmpJson = (JSONObject) jsonParser.parse(parm.getValue().getContent());
+					body.put(parmName, tmpJson);
+				} catch (ParseException ex) {
+					LOG.error("Cannot parse parameter content '{}' of parameter '{}' from eventid {} to json: {}",
+							parm.getValue().getContent(), parm.getParmName(), event.getDbid(), ex.getMessage(), ex);
+					// To not lose the data, just use as is
+					body.put(parmName, parm.getValue().getContent());
+				}
+			} else {
+				body.put(parmName, parm.getValue().getContent());
+			}
 		}
 
 		// remove old and new alarm values parms if not needed
@@ -431,10 +448,7 @@ public class EventToIndex implements AutoCloseable {
 					+ "/"+completeIndexName
 					+ "/"+indexAndType.getType()
 					+ "/"+id
-					+ "\n   body: ";
-			for (String key:body.keySet()){
-				str=str+"["+ key+" : "+body.get(key)+"]";
-			}
+					+ "\n   body: \n" + body.toJSONString();
 			LOG.debug(str);
 		}
 

--- a/features/opennms-es-rest/src/main/java/org/opennms/plugins/elasticsearch/rest/EventToIndex.java
+++ b/features/opennms-es-rest/src/main/java/org/opennms/plugins/elasticsearch/rest/EventToIndex.java
@@ -46,7 +46,7 @@ import java.util.stream.Collectors;
 
 import javax.xml.bind.DatatypeConverter;
 
-import org.json.JSONArray;
+import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
@@ -436,7 +436,7 @@ public class EventToIndex implements AutoCloseable {
 			LOG.debug(str);
 		}
 
-		Index.Builder builder = new Index.Builder(body.toJSONString())
+		Index.Builder builder = new Index.Builder(body)
 				.index(completeIndexName)
 				.type(indexAndType.getType());
 
@@ -469,7 +469,7 @@ public class EventToIndex implements AutoCloseable {
 					final JSONObject eachOidObject = new JSONObject();
 					eachOidObject.put("oid", eachOid.getParmName());
 					eachOidObject.put("value", eachOid.getValue().getContent());
-					jsonArray.put(eachOidObject);
+					jsonArray.add(eachOidObject);
 				}
 				body.put("p_oids", jsonArray);
 			}

--- a/features/opennms-es-rest/src/main/java/org/opennms/plugins/elasticsearch/rest/EventToIndex.java
+++ b/features/opennms-es-rest/src/main/java/org/opennms/plugins/elasticsearch/rest/EventToIndex.java
@@ -42,9 +42,11 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 
 import javax.xml.bind.DatatypeConverter;
 
+import org.json.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
@@ -162,6 +164,8 @@ public class EventToIndex implements AutoCloseable {
 
 	private boolean archiveNewAlarmValues = true;
 
+	private boolean groupOidParameters = false;
+
 	private NodeCache nodeCache = null;
 
 	private final JestClient jestClient;
@@ -242,6 +246,10 @@ public class EventToIndex implements AutoCloseable {
 
 	public void setArchiveNewAlarmValues(boolean archiveNewAlarmValues) {
 		this.archiveNewAlarmValues = archiveNewAlarmValues;
+	}
+
+	public void setGroupOidParameters(boolean groupOidParameters) {
+		this.groupOidParameters = groupOidParameters;
 	}
 
 	@Override
@@ -383,31 +391,7 @@ public class EventToIndex implements AutoCloseable {
 		body.put("host",event.getHost());
 
 		// Parse event parameters
-		final JSONParser jsonParser = new JSONParser();
-		for(Parm parm : event.getParmCollection()) {
-			// We have to handle oid parameters differently, as elastic would consider a containing "." as a sub
-			// field, e.g. ".1.2" results in a mapping of { 1: properties: { 2 } } which may exceed the maximum allowed
-			// fields for a mapping, see NMS-9831. Initially an array was used, to store the oids in the fashion:
-			// { "oid": "1.1.1", "value": "dummy value" } but elastic has some limitations on accessing objects in an
-			// array. Therefore we replace all existing . with an _
-			final String parmName = "p_" + parm.getParmName().replaceAll("\\.", "_");
-
-			// Some parameter values are of type json and should be decoded properly.
-			// See HZN-1272
-			if ("json".equalsIgnoreCase(parm.getValue().getType())) {
-				try {
-					JSONObject tmpJson = (JSONObject) jsonParser.parse(parm.getValue().getContent());
-					body.put(parmName, tmpJson);
-				} catch (ParseException ex) {
-					LOG.error("Cannot parse parameter content '{}' of parameter '{}' from eventid {} to json: {}",
-							parm.getValue().getContent(), parm.getParmName(), event.getDbid(), ex.getMessage(), ex);
-					// To not lose the data, just use as is
-					body.put(parmName, parm.getValue().getContent());
-				}
-			} else {
-				body.put(parmName, parm.getValue().getContent());
-			}
-		}
+		handleParameters(event, body);
 
 		// remove old and new alarm values parms if not needed
 		if(! archiveNewAlarmValues){
@@ -452,7 +436,7 @@ public class EventToIndex implements AutoCloseable {
 			LOG.debug(str);
 		}
 
-		Index.Builder builder = new Index.Builder(body)
+		Index.Builder builder = new Index.Builder(body.toJSONString())
 				.index(completeIndexName)
 				.type(indexAndType.getType());
 
@@ -466,6 +450,56 @@ public class EventToIndex implements AutoCloseable {
 		Index index = builder.build();
 
 		return index;
+	}
+
+	private void handleParameters(Event event, JSONObject body) {
+		// Decide if oids should be grouped in a single JsonArray or flattened
+		if (groupOidParameters) {
+			final List<Parm> oidParameters = event.getParmCollection().stream().filter(p -> isOID(p.getParmName())).collect(Collectors.toList());
+			final List<Parm> normalParameters = event.getParmCollection();
+			normalParameters.removeAll(oidParameters);
+
+			// Handle non oid paramaters as always
+			handleParameters(event, normalParameters, body);
+
+			// Special treatment for oid parameters
+			if (!oidParameters.isEmpty()) {
+				final JSONArray jsonArray = new JSONArray();
+				for (Parm eachOid : oidParameters) {
+					final JSONObject eachOidObject = new JSONObject();
+					eachOidObject.put("oid", eachOid.getParmName());
+					eachOidObject.put("value", eachOid.getValue().getContent());
+					jsonArray.put(eachOidObject);
+				}
+				body.put("p_oids", jsonArray);
+			}
+
+		} else { // flattened
+			handleParameters(event, event.getParmCollection(), body);
+		}
+	}
+
+	private void handleParameters(Event event, List<Parm> parameters, JSONObject body) {
+		final JSONParser jsonParser = new JSONParser();
+		for(Parm parm : parameters) {
+			final String parmName = "p_" + parm.getParmName().replaceAll("\\.", "_");
+
+			// Some parameter values are of type json and should be decoded properly.
+			// See HZN-1272
+			if ("json".equalsIgnoreCase(parm.getValue().getType())) {
+				try {
+					JSONObject tmpJson = (JSONObject) jsonParser.parse(parm.getValue().getContent());
+					body.put(parmName, tmpJson);
+				} catch (ParseException ex) {
+					LOG.error("Cannot parse parameter content '{}' of parameter '{}' from eventid {} to json: {}",
+							parm.getValue().getContent(), parm.getParmName(), event.getDbid(), ex.getMessage(), ex);
+					// To not lose the data, just use as is
+					body.put(parmName, parm.getValue().getContent());
+				}
+			} else {
+				body.put(parmName, parm.getValue().getContent());
+			}
+		}
 	}
 
 	/**
@@ -740,5 +774,9 @@ public class EventToIndex implements AutoCloseable {
 						"   error message: {}",
 				operation, index, type, result, responseCode, errorMessage
 		);
+	}
+
+	protected static boolean isOID(String input) {
+		return input.matches("^(\\.[0-9]+)+$");
 	}
 }

--- a/features/opennms-es-rest/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/features/opennms-es-rest/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -43,6 +43,7 @@
       <cm:property name="archiveOldAlarmValues" value="true" />
       <cm:property name="archiveNewAlarmValues" value="true" />
       <cm:property name="archiveAssetData" value="true" />
+      <cm:property name="groupOidParameters" value="false" />
 
       <!-- Bulk Action Retry settings -->
       <cm:property name="bulkRetryCount" value="5" /> <!-- Number of retries until a bulk operation is considered failed -->
@@ -134,6 +135,7 @@
     <property name="archiveAlarmChangeEvents" value="${archiveAlarmChangeEvents}" />
     <property name="archiveOldAlarmValues" value="${archiveOldAlarmValues}" />
     <property name="archiveNewAlarmValues" value="${archiveNewAlarmValues}" />
+    <property name="groupOidParameters" value="${groupOidParameters}" />
   </bean>
 
   <bean id="elasticSearchInitializer" class="org.opennms.plugins.elasticsearch.rest.template.DefaultTemplateInitializer">

--- a/features/opennms-es-rest/src/test/java/org/opennms/plugins/elasticsearch/rest/AbstractEventToIndexTest.java
+++ b/features/opennms-es-rest/src/test/java/org/opennms/plugins/elasticsearch/rest/AbstractEventToIndexTest.java
@@ -53,4 +53,8 @@ public abstract class AbstractEventToIndexTest {
             eventToIndex.close();
         }
     }
+
+    protected EventToIndex getEventToIndex() {
+        return eventToIndex;
+    }
 }

--- a/features/opennms-es-rest/src/test/java/org/opennms/plugins/elasticsearch/rest/EventToIndexTest.java
+++ b/features/opennms-es-rest/src/test/java/org/opennms/plugins/elasticsearch/rest/EventToIndexTest.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2018-2018 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2018 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+package org.opennms.plugins.elasticsearch.rest;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.opennms.plugins.elasticsearch.rest.EventToIndex.*;
+
+import org.junit.Test;
+
+public class EventToIndexTest {
+
+    @Test
+    public void verifyIsOID() {
+        assertThat(isOID(".3"), is(true));
+        assertThat(isOID(".3.1.2"), is(true));
+        assertThat(isOID("..3.."), is(false));
+        assertThat(isOID("192.168.0.1"), is(false));
+        assertThat(isOID("nodeLabel"), is(false));
+    }
+}

--- a/opennms-doc/guide-admin/src/asciidoc/text/plugins/opennms-es-rest.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/plugins/opennms-es-rest.adoc
@@ -68,6 +68,11 @@ The following options are available to configure the forwarding of events from O
 
 (asset-latitude,asset-longitude,asset-region,asset-building,asset-floor,asset-room,asset-rack,asset-slot,asset-port,asset-category,asset-displaycategory,asset-notifycategory,asset-pollercategory,asset-thresholdcategory,asset-managedobjecttype,asset-managedobjectinstance,asset-manufacturer,asset-vendor,asset-modelnumber,parent-nodelabel,parent-nodeid,parent-foreignsource,parent-foreignid)
 
+|`groupOidParameters`
+| false
+| optional
+| If `true` all oid from the event parameters are stored in a single array `p_oids` instead of a flattened structue.
+
 |`logAllEvents`
 | false
 | optional


### PR DESCRIPTION
Here we address some issues with the opennms-es-rest and opennms-alarm-change-notifier modules. It was easier to address it in one branch, than have the branches separated:
* JIRA: https://issues.opennms.org/browse/NMS-9831
* JIRA: https://issues.opennms.org/browse/HZN-1272

Please also note, that this change should also be merged to `release-21.x`.
As we changed the underlying structure for drift and `22.0.0` I will manually backport these changes to `21.x` as soon as this is considered okay.
