### PR TITLE
NMS-9783: Add missing header to onms-classifications angular app

### DIFF
--- a/core/web-assets/src/main/assets/js/apps/onms-classifications/index.js
+++ b/core/web-assets/src/main/assets/js/apps/onms-classifications/index.js
@@ -1,6 +1,7 @@
 const angular = require('vendor/angular-js');
 const elementList = require('../onms-elementList/lib/elementList');
 require('../../lib/onms-pagination');
+require('../../lib/onms-http');
 require('angular-bootstrap-confirm');
 require('angular-bootstrap-toggle/dist/angular-bootstrap-toggle');
 require('angular-bootstrap-toggle/dist/angular-bootstrap-toggle.css');
@@ -20,7 +21,19 @@ const exportModalTemplate  = require('./views/modals/export-modal.html');
     var MODULE_NAME = 'onms.classifications';
 
 
-    angular.module(MODULE_NAME, [ 'angular-loading-bar', 'ngResource', 'ui.router', 'ui.bootstrap', 'ui.checkbox', 'ui.toggle', 'onms.elementList', 'mwl.confirm', 'onms.pagination'])
+    angular.module(MODULE_NAME, [
+            'angular-loading-bar',
+            'ngResource',
+            'ui.router',
+            'ui.bootstrap',
+            'ui.checkbox',
+            'ui.toggle',
+            'onms.http',
+            'onms.elementList',
+            'mwl.confirm',
+            'onms.pagination'
+        ])
+
         .config( ['$locationProvider', function ($locationProvider) {
             $locationProvider.hashPrefix('!');
             $locationProvider.html5Mode(false);


### PR DESCRIPTION
The original PR https://github.com/OpenNMS/opennms/pull/1893 was created against `develop` and we forgot to adapt `features/drift` as well. 
Here we apply the changes from `NMS-9783` to `features/drift`.

* JIRA: https://issues.opennms.org/browse/NMS-9783