### PR TITLE
NMS-9941: Use the .equals() method when comparing nodeId in EventUtil…

### DIFF
--- a/opennms-model/src/main/java/org/opennms/netmgt/model/events/EventUtils.java
+++ b/opennms-model/src/main/java/org/opennms/netmgt/model/events/EventUtils.java
@@ -572,7 +572,7 @@ public abstract class EventUtils {
         		return false;
         }
     
-        if (e1.getNodeid() != e2.getNodeid()) {
+        if (!e1.getNodeid().equals(e2.getNodeid())) {
             return false;
         }
         if (e1.getInterface() != e2.getInterface() && (e1.getInterface() == null || e2.getInterface() == null || !e1.getInterface().equals(e2.getInterface()))) {

--- a/opennms-model/src/main/java/org/opennms/netmgt/model/events/EventUtils.java
+++ b/opennms-model/src/main/java/org/opennms/netmgt/model/events/EventUtils.java
@@ -572,7 +572,7 @@ public abstract class EventUtils {
         		return false;
         }
     
-        if (!e1.getNodeid().equals(e2.getNodeid())) {
+        if ((long)e1.getNodeid() != (long)e2.getNodeid()) {
             return false;
         }
         if (e1.getInterface() != e2.getInterface() && (e1.getInterface() == null || e2.getInterface() == null || !e1.getInterface().equals(e2.getInterface()))) {


### PR DESCRIPTION
…s.eventsMatch.

JIRA: https://issues.opennms.org/browse/NMS-9941