### PR TITLE
NMS-9885: collection:collect command fails with ClassCastException

### DIFF
--- a/features/collection/api/src/main/java/org/opennms/netmgt/collection/api/InvalidCollectionAgentException.java
+++ b/features/collection/api/src/main/java/org/opennms/netmgt/collection/api/InvalidCollectionAgentException.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2018 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2018 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.collection.api;
+
+public class InvalidCollectionAgentException extends CollectionException {
+    public InvalidCollectionAgentException(String message) {
+        super(message);
+    }
+}

--- a/features/collection/shell-commands/src/main/java/org/opennms/netmgt/collection/commands/CollectCommand.java
+++ b/features/collection/shell-commands/src/main/java/org/opennms/netmgt/collection/commands/CollectCommand.java
@@ -53,6 +53,7 @@ import org.opennms.netmgt.collection.api.CollectionInitializationException;
 import org.opennms.netmgt.collection.api.CollectionResource;
 import org.opennms.netmgt.collection.api.CollectionSet;
 import org.opennms.netmgt.collection.api.CollectionStatus;
+import org.opennms.netmgt.collection.api.InvalidCollectionAgentException;
 import org.opennms.netmgt.collection.api.LocationAwareCollectorClient;
 import org.opennms.netmgt.collection.api.ServiceCollector;
 import org.opennms.netmgt.collection.api.ServiceCollectorRegistry;
@@ -134,6 +135,11 @@ public class CollectCommand implements Action {
                 } catch (InterruptedException e) {
                     System.out.println("\nInterrupted.");
                 } catch (ExecutionException e) {
+                    final Throwable cause = e.getCause();
+                    if (cause != null && cause instanceof InvalidCollectionAgentException) {
+                        System.out.printf("The collector requires a valid node and interface. Try specifying a valid node using the --node option.\n", e);
+                        break;
+                    }
                     System.out.printf("\nCollect failed with:", e);
                     e.printStackTrace();
                     System.out.println();

--- a/features/telemetry/itests/src/test/resources/META-INF/opennms/applicationContext-collectionAgentFactory.xml
+++ b/features/telemetry/itests/src/test/resources/META-INF/opennms/applicationContext-collectionAgentFactory.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:tx="http://www.springframework.org/schema/tx"
+  xmlns:context="http://www.springframework.org/schema/context"
+  xmlns:onmsgi="http://xmlns.opennms.org/xsd/spring/onms-osgi"
+  xsi:schemaLocation="
+  http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.2.xsd
+  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.2.xsd
+  http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.2.xsd
+  http://xmlns.opennms.org/xsd/spring/onms-osgi http://xmlns.opennms.org/xsd/spring/onms-osgi.xsd
+">
+
+    <context:annotation-config />
+    <tx:annotation-driven/>
+
+    <bean id="collectionAgentFactory" class="org.opennms.netmgt.collectd.DefaultSnmpCollectionAgentFactory" />
+    <onmsgi:service interface="org.opennms.netmgt.collection.api.CollectionAgentFactory" ref="collectionAgentFactory" />
+
+</beans>

--- a/opennms-dao/src/main/resources/META-INF/opennms/applicationContext-dao.xml
+++ b/opennms-dao/src/main/resources/META-INF/opennms/applicationContext-dao.xml
@@ -493,10 +493,6 @@
 
   <onmsgi:service interface="org.opennms.netmgt.dao.api.TopologyDao" ref="topologyDao" />
 
-  <bean id="collectionAgentFactory" class="org.opennms.netmgt.collection.core.DefaultCollectionAgentFactory" />
-
-  <onmsgi:service interface="org.opennms.netmgt.collection.api.CollectionAgentFactory" ref="collectionAgentFactory" />
-
   <!-- The time-series strategy specific context should provide beans that implement:
             org.opennms.netmgt.collection.api.PersisterFactory
             org.opennms.netmgt.dao.api.ResourceStorageDao

--- a/opennms-services/src/main/java/org/opennms/netmgt/collectd/DefaultSnmpCollectionAgentFactory.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/collectd/DefaultSnmpCollectionAgentFactory.java
@@ -26,21 +26,22 @@
  *     http://www.opennms.com/
  *******************************************************************************/
 
-package org.opennms.netmgt.collection.core;
+package org.opennms.netmgt.collectd;
 
 import java.net.InetAddress;
 
+import org.opennms.core.utils.InetAddressUtils;
 import org.opennms.netmgt.collection.api.CollectionAgent;
 import org.opennms.netmgt.collection.api.CollectionAgentFactory;
+import org.opennms.netmgt.collection.core.DefaultCollectionAgent;
 import org.opennms.netmgt.dao.api.IpInterfaceDao;
 import org.opennms.netmgt.dao.api.NodeDao;
 import org.opennms.netmgt.model.OnmsIpInterface;
 import org.opennms.netmgt.model.OnmsNode;
-import org.opennms.netmgt.snmp.InetAddrUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.PlatformTransactionManager;
 
-public class DefaultCollectionAgentFactory implements CollectionAgentFactory {
+public class DefaultSnmpCollectionAgentFactory implements CollectionAgentFactory {
 
     @Autowired
     private NodeDao nodeDao;
@@ -60,12 +61,12 @@ public class DefaultCollectionAgentFactory implements CollectionAgentFactory {
                     nodeCriteria));
         }
         final OnmsIpInterface ipInterface = ipInterfaceDao.findByNodeIdAndIpAddress(
-                node.getId(), InetAddrUtils.str(ipAddr));
+                node.getId(), InetAddressUtils.str(ipAddr));
         if (ipInterface == null) {
             throw new IllegalArgumentException(String.format("No interface found with IP %s on node %s",
-                    InetAddrUtils.str(ipAddr), nodeCriteria));
+                    InetAddressUtils.str(ipAddr), nodeCriteria));
         }
-        return DefaultCollectionAgent.create(ipInterface.getId(), ipInterfaceDao, transMgr, location);
+        return DefaultSnmpCollectionAgent.create(ipInterface.getId(), ipInterfaceDao, transMgr, location);
     }
 
     @Override
@@ -75,7 +76,7 @@ public class DefaultCollectionAgentFactory implements CollectionAgentFactory {
 
     @Override
     public CollectionAgent createCollectionAgent(OnmsIpInterface ipIf) {
-        return DefaultCollectionAgent.create(ipIf.getId(), ipInterfaceDao, transMgr);
+        return DefaultSnmpCollectionAgent.create(ipIf.getId(), ipInterfaceDao, transMgr);
     }
 
 }

--- a/opennms-services/src/main/java/org/opennms/netmgt/collectd/SnmpCollector.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/collectd/SnmpCollector.java
@@ -39,6 +39,7 @@ import org.opennms.netmgt.collection.api.CollectionAgent;
 import org.opennms.netmgt.collection.api.CollectionException;
 import org.opennms.netmgt.collection.api.CollectionInitializationException;
 import org.opennms.netmgt.collection.api.CollectionSet;
+import org.opennms.netmgt.collection.api.InvalidCollectionAgentException;
 import org.opennms.netmgt.collection.api.ServiceParameters;
 import org.opennms.netmgt.config.DataCollectionConfigFactory;
 import org.opennms.netmgt.config.SnmpPeerFactory;
@@ -228,6 +229,11 @@ public class SnmpCollector extends AbstractServiceCollector {
 
             if (m_client == null) {
                 m_client = BeanUtils.getBean("daoContext", "locationAwareSnmpClient", LocationAwareSnmpClient.class);
+            }
+
+            if (!(agent instanceof SnmpCollectionAgent)) {
+                throw new InvalidCollectionAgentException(String.format("Expected agent of type: %s, but got: %s",
+                        SnmpCollectionAgent.class.getCanonicalName(), agent.getClass().getCanonicalName()));
             }
             OnmsSnmpCollection snmpCollection = new OnmsSnmpCollection((SnmpCollectionAgent)agent, params, m_client);
 

--- a/opennms-services/src/main/resources/META-INF/opennms/applicationContext-collectd.xml
+++ b/opennms-services/src/main/resources/META-INF/opennms/applicationContext-collectd.xml
@@ -23,6 +23,9 @@
       <property name="eventIpcManager" ref="eventIpcManager"/>
     </bean>
 
+    <bean id="collectionAgentFactory" class="org.opennms.netmgt.collectd.DefaultSnmpCollectionAgentFactory" />
+    <onmsgi:service interface="org.opennms.netmgt.collection.api.CollectionAgentFactory" ref="collectionAgentFactory" />
+
     <bean id="defaultResourceTypeMapper" class="org.opennms.netmgt.collectd.DefaultResourceTypeMapper" />
 
 </beans>


### PR DESCRIPTION
JIRA: https://issues.opennms.org/browse/NMS-9885

Update the default CollectionAgentFactory implementation to create instances of the SnmpCollectionAgent as opposed to the DefaultCollectionAgent so that these work with all of the collectors.

Also improve the error message when the SnmpCollector is invoked via the collection:collection command without specifying a valid node/interface pair.
