### PR TITLE
HZN-1276: Fix the event and alarm templates for Elasticsearch 6.x

### DIFF
--- a/features/flows/elastic/src/main/java/org/opennms/netmgt/flows/elastic/ElasticFlowRepositoryInitializer.java
+++ b/features/flows/elastic/src/main/java/org/opennms/netmgt/flows/elastic/ElasticFlowRepositoryInitializer.java
@@ -38,7 +38,7 @@ import io.searchbox.client.JestClient;
 
 public class ElasticFlowRepositoryInitializer extends DefaultTemplateInitializer {
 
-    public static final String TEMPLATE_RESOURCE = "/netflow-template.json";
+    public static final String TEMPLATE_RESOURCE = "/netflow-template";
 
     private static final String FLOW_TEMPLATE_NAME = "netflow";
 

--- a/features/flows/elastic/src/test/java/org/opennms/netmgt/flows/elastic/template/CachingTemplateLoaderTest.java
+++ b/features/flows/elastic/src/test/java/org/opennms/netmgt/flows/elastic/template/CachingTemplateLoaderTest.java
@@ -29,6 +29,7 @@
 package org.opennms.netmgt.flows.elastic.template;
 
 import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -40,8 +41,11 @@ import org.opennms.netmgt.flows.elastic.ElasticFlowRepositoryInitializer;
 import org.opennms.plugins.elasticsearch.rest.template.CachingTemplateLoader;
 import org.opennms.plugins.elasticsearch.rest.template.DefaultTemplateLoader;
 import org.opennms.plugins.elasticsearch.rest.template.TemplateLoader;
+import org.opennms.plugins.elasticsearch.rest.template.Version;
 
 public class CachingTemplateLoaderTest {
+
+    private static final Version version = new Version(6,2,3);
 
     @Test
     public void verifyCaching() throws IOException {
@@ -53,12 +57,12 @@ public class CachingTemplateLoaderTest {
         final TemplateLoader cachingTemplateLoader = new CachingTemplateLoader(actualTemplateLoader);
 
         // Ask the caching loader
-        cachingTemplateLoader.load(ElasticFlowRepositoryInitializer.TEMPLATE_RESOURCE);
-        cachingTemplateLoader.load(ElasticFlowRepositoryInitializer.TEMPLATE_RESOURCE);
-        cachingTemplateLoader.load("/netflow-template-merged.json");
-        cachingTemplateLoader.load("/netflow-template-merged.json");
+        cachingTemplateLoader.load(version, ElasticFlowRepositoryInitializer.TEMPLATE_RESOURCE);
+        cachingTemplateLoader.load(version, ElasticFlowRepositoryInitializer.TEMPLATE_RESOURCE);
+        cachingTemplateLoader.load(version, "/netflow-template-merged");
+        cachingTemplateLoader.load(version, "/netflow-template-merged");
 
         // Verify that, actual loader was only be invoked twice
-        verify(actualTemplateLoader, times(2)).load(anyString());
+        verify(actualTemplateLoader, times(2)).load(any(), anyString());
     }
 }

--- a/features/flows/elastic/src/test/java/org/opennms/netmgt/flows/elastic/template/DefaultTemplateLoaderTest.java
+++ b/features/flows/elastic/src/test/java/org/opennms/netmgt/flows/elastic/template/DefaultTemplateLoaderTest.java
@@ -37,12 +37,13 @@ import org.hamcrest.Matchers;
 import org.junit.Test;
 import org.opennms.netmgt.flows.elastic.ElasticFlowRepositoryInitializer;
 import org.opennms.plugins.elasticsearch.rest.template.DefaultTemplateLoader;
+import org.opennms.plugins.elasticsearch.rest.template.Version;
 
 public class DefaultTemplateLoaderTest {
 
     @Test
     public void verifyTemplateLoading() throws IOException {
-        final String template = new DefaultTemplateLoader().load(ElasticFlowRepositoryInitializer.TEMPLATE_RESOURCE);
+        final String template = new DefaultTemplateLoader().load(new Version(6,2,3), ElasticFlowRepositoryInitializer.TEMPLATE_RESOURCE);
         assertNotNull(template);
         assertThat(template.length(), Matchers.greaterThan(0));
     }

--- a/features/flows/elastic/src/test/java/org/opennms/netmgt/flows/elastic/template/MergingTemplateLoaderTest.java
+++ b/features/flows/elastic/src/test/java/org/opennms/netmgt/flows/elastic/template/MergingTemplateLoaderTest.java
@@ -37,13 +37,16 @@ import org.opennms.core.test.xml.JsonTest;
 import org.opennms.plugins.elasticsearch.rest.template.DefaultTemplateLoader;
 import org.opennms.plugins.elasticsearch.rest.template.IndexSettings;
 import org.opennms.plugins.elasticsearch.rest.template.MergingTemplateLoader;
+import org.opennms.plugins.elasticsearch.rest.template.Version;
 
 public class MergingTemplateLoaderTest {
 
+    private static final Version version = new Version(6,2,3);
+
     @Test
     public void verifyMergingEmpty() throws IOException {
-        final String merged = new MergingTemplateLoader(new DefaultTemplateLoader(), new IndexSettings()).load(TEMPLATE_RESOURCE);
-        final String expected = new DefaultTemplateLoader().load(TEMPLATE_RESOURCE);
+        final String merged = new MergingTemplateLoader(new DefaultTemplateLoader(), new IndexSettings()).load(version, TEMPLATE_RESOURCE);
+        final String expected = new DefaultTemplateLoader().load(version, TEMPLATE_RESOURCE);
         JsonTest.assertJsonEquals(expected, merged);
     }
 
@@ -55,8 +58,8 @@ public class MergingTemplateLoaderTest {
         IndexSettings.setRefreshInterval("60s");
         IndexSettings.setRoutingPartitionSize(100);
 
-        final String merged = new MergingTemplateLoader(new DefaultTemplateLoader(), IndexSettings).load(TEMPLATE_RESOURCE);
-        final String expected = new DefaultTemplateLoader().load("/netflow-template-merged.json");
+        final String merged = new MergingTemplateLoader(new DefaultTemplateLoader(), IndexSettings).load(version, TEMPLATE_RESOURCE);
+        final String expected = new DefaultTemplateLoader().load(version,"/netflow-template-merged");
         JsonTest.assertJsonEquals(expected, merged);
     }
 

--- a/features/jest/client/src/main/java/org/opennms/plugins/elasticsearch/rest/template/DefaultTemplateLoader.java
+++ b/features/jest/client/src/main/java/org/opennms/plugins/elasticsearch/rest/template/DefaultTemplateLoader.java
@@ -42,9 +42,9 @@ public class DefaultTemplateLoader implements TemplateLoader {
 
     @Override
     public String load(Version serverVersion, String resource) throws IOException {
-        // Attempt to find a template that is prefixed using the ES# where # is the major version
-        // of the ES server. If no template is found for the current major version, try the previous.
-        // If no template is found then attempt to look it up without the version suffix.
+        // Attempt to find a template that ends in .es#.json where # is the major version
+        // of the ES server. If no template is found for the current major version, try the previous,
+	// and so on. If no template is found then attempt to look it up without the version in the suffix.
         for (int i = serverVersion.getMajor(); i >= 0; i--) {
             final String versionSuffix = i == 0 ? "" : String.format(".es%d", i);
             final String resourceWithSuffix = String.format("%s%s.json", resource, versionSuffix);

--- a/features/jest/client/src/main/java/org/opennms/plugins/elasticsearch/rest/template/DefaultTemplateLoader.java
+++ b/features/jest/client/src/main/java/org/opennms/plugins/elasticsearch/rest/template/DefaultTemplateLoader.java
@@ -31,22 +31,43 @@ package org.opennms.plugins.elasticsearch.rest.template;
 import java.io.IOException;
 import java.io.InputStream;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.google.common.io.ByteStreams;
 
 public class DefaultTemplateLoader implements TemplateLoader {
 
+    private static final Logger LOG = LoggerFactory.getLogger(DefaultTemplateLoader.class);
+
     @Override
     public String load(Version serverVersion, String resource) throws IOException {
+        // Attempt to find a template that is prefixed using the ES# where # is the major version
+        // of the ES server. If no template is found for the current major version, try the previous.
+        // If no template is found then attempt to look it up without the version suffix.
+        for (int i = serverVersion.getMajor(); i >= 0; i--) {
+            final String versionSuffix = i == 0 ? "" : String.format(".es%d", i);
+            final String resourceWithSuffix = String.format("%s%s.json", resource, versionSuffix);
+            final String template = getResource(resourceWithSuffix);
+            if (template != null) {
+                LOG.info("Using template with resource name: {}", resource);
+                return template;
+            }
+             LOG.debug("No template found with resource name: {}", resource);
+        }
+        throw new NullPointerException(String.format("No template found for server version %s and resource %s.",
+                serverVersion, resource));
+    }
+
+    protected String getResource(String resource) throws IOException {
         try (InputStream inputStream = getResourceAsStream(resource)) {
-            // Ensure resource actually exists
             if (inputStream == null) {
-                throw new NullPointerException("Provided inputStream to read template from is null");
+                return null;
             }
             // Read template
             final byte[] bytes = new byte[inputStream.available()];
             ByteStreams.readFully(inputStream, bytes);
-            final String template = new String(bytes);
-            return template;
+            return new String(bytes);
         }
     }
 

--- a/features/jest/client/src/main/java/org/opennms/plugins/elasticsearch/rest/template/DefaultTemplateLoader.java
+++ b/features/jest/client/src/main/java/org/opennms/plugins/elasticsearch/rest/template/DefaultTemplateLoader.java
@@ -44,7 +44,7 @@ public class DefaultTemplateLoader implements TemplateLoader {
     public String load(Version serverVersion, String resource) throws IOException {
         // Attempt to find a template that ends in .es#.json where # is the major version
         // of the ES server. If no template is found for the current major version, try the previous,
-	// and so on. If no template is found then attempt to look it up without the version in the suffix.
+        // and so on. If no template is found then attempt to look it up without the version in the suffix.
         for (int i = serverVersion.getMajor(); i >= 0; i--) {
             final String versionSuffix = i == 0 ? "" : String.format(".es%d", i);
             final String resourceWithSuffix = String.format("%s%s.json", resource, versionSuffix);

--- a/features/jest/client/src/main/java/org/opennms/plugins/elasticsearch/rest/template/DefaultTemplateLoader.java
+++ b/features/jest/client/src/main/java/org/opennms/plugins/elasticsearch/rest/template/DefaultTemplateLoader.java
@@ -36,7 +36,7 @@ import com.google.common.io.ByteStreams;
 public class DefaultTemplateLoader implements TemplateLoader {
 
     @Override
-    public String load(String resource) throws IOException {
+    public String load(Version serverVersion, String resource) throws IOException {
         try (InputStream inputStream = getResourceAsStream(resource)) {
             // Ensure resource actually exists
             if (inputStream == null) {

--- a/features/jest/client/src/main/java/org/opennms/plugins/elasticsearch/rest/template/MergingTemplateLoader.java
+++ b/features/jest/client/src/main/java/org/opennms/plugins/elasticsearch/rest/template/MergingTemplateLoader.java
@@ -45,8 +45,8 @@ public class MergingTemplateLoader implements TemplateLoader {
     }
 
     @Override
-    public String load(String resource) throws IOException {
-        final String template = delegate.load(resource);
+    public String load(Version serverVersion, String resource) throws IOException {
+        final String template = delegate.load(serverVersion, resource);
         return merge(template);
     }
 

--- a/features/jest/client/src/main/java/org/opennms/plugins/elasticsearch/rest/template/TemplateLoader.java
+++ b/features/jest/client/src/main/java/org/opennms/plugins/elasticsearch/rest/template/TemplateLoader.java
@@ -31,5 +31,5 @@ package org.opennms.plugins.elasticsearch.rest.template;
 import java.io.IOException;
 
 public interface TemplateLoader {
-    String load(String resource) throws IOException;
+    String load(Version serverVersion, String resource) throws IOException;
 }

--- a/features/jest/client/src/main/java/org/opennms/plugins/elasticsearch/rest/template/Version.java
+++ b/features/jest/client/src/main/java/org/opennms/plugins/elasticsearch/rest/template/Version.java
@@ -1,0 +1,82 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2018 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2018 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.plugins.elasticsearch.rest.template;
+
+import java.util.Objects;
+
+public class Version {
+    private int major;
+    private int minor;
+    private int patch;
+
+    public Version(int major, int minor, int patch) {
+        if (major < 0 || minor < 0 || patch < 0) {
+            throw new IllegalArgumentException("Versions must be non-negative.");
+        }
+        this.major = major;
+        this.minor = minor;
+        this.patch = patch;
+    }
+
+    public static Version fromVersionString(String versionString) {
+        String[] tokens = versionString.split("\\.");
+        if (tokens.length != 3) {
+            throw new IllegalArgumentException("Invalid version string: " + versionString);
+        }
+        return new Version(Integer.parseInt(tokens[0]), Integer.parseInt(tokens[1]), Integer.parseInt(tokens[2]));
+    }
+
+    public int getMajor() {
+        return major;
+    }
+
+    public void setMajor(int major) {
+        this.major = major;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Version version = (Version) o;
+        return major == version.major &&
+                minor == version.minor &&
+                patch == version.patch;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(major, minor, patch);
+    }
+
+    @Override
+    public String toString() {
+        return String.format("%d.%d.%d", major, minor, patch);
+    }
+}

--- a/features/jest/client/src/main/java/org/opennms/plugins/elasticsearch/rest/template/Version.java
+++ b/features/jest/client/src/main/java/org/opennms/plugins/elasticsearch/rest/template/Version.java
@@ -65,9 +65,9 @@ public class Version {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         Version version = (Version) o;
-        return major == version.major &&
-                minor == version.minor &&
-                patch == version.patch;
+        return Objects.equals(major, version.major) &&
+                Objects.equals(minor, version.minor) &&
+                Objects.equals(patch, version.patch);
     }
 
     @Override

--- a/features/jest/client/src/test/java/org/opennms/plugins/elasticsearch/rest/template/DefaultTemplateLoaderTest.java
+++ b/features/jest/client/src/test/java/org/opennms/plugins/elasticsearch/rest/template/DefaultTemplateLoaderTest.java
@@ -1,0 +1,68 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2018 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2018 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.plugins.elasticsearch.rest.template;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+
+import org.junit.Test;
+
+public class DefaultTemplateLoaderTest {
+
+    @Test
+    public void canLoadTemplateForVersion() throws IOException {
+        DefaultTemplateLoader loader = mock(DefaultTemplateLoader.class);
+        when(loader.load(any(), any())).thenCallRealMethod();
+        when(loader.getResource("/template.es6.json")).thenReturn("ES6!");
+        when(loader.getResource("/template.json")).thenReturn("ES!");
+
+        // ES 6 template
+        String template = loader.load(new Version(6,2,3), "/template");
+        assertThat(template, equalTo("ES6!"));
+
+        // Fallback to next major when no specific match is made
+        template = loader.load(new Version(7,1,0), "/template");
+        assertThat(template, equalTo("ES6!"));
+
+        // Use the default otherwise
+        template = loader.load(new Version(2,1,1), "/template");
+        assertThat(template, equalTo("ES!"));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void failsWithNPEIfNoMatchIsMade() throws IOException {
+        DefaultTemplateLoader loader = new DefaultTemplateLoader();
+        loader.load(new Version(6,2,3), "/non-existent-template");
+    }
+}

--- a/features/opennms-es-rest/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/features/opennms-es-rest/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -141,8 +141,8 @@
   <bean id="elasticSearchInitializer" class="org.opennms.plugins.elasticsearch.rest.template.DefaultTemplateInitializer">
     <argument ref="blueprintBundleContext" />
     <argument ref="restClient" />
-    <argument value="/eventsIndexTemplate.json" />
-    <argument value="eventsindextemplate"/>
+    <argument value="/eventsIndexTemplate" />
+    <argument value="eventsindextemplate" />
     <argument ref="indexSettings" />
   </bean>
 

--- a/features/opennms-es-rest/src/main/resources/eventsIndexTemplate.es6.json
+++ b/features/opennms-es-rest/src/main/resources/eventsIndexTemplate.es6.json
@@ -1,0 +1,782 @@
+{
+   "template":"opennms-*",
+   "settings":{
+      "index.refresh_interval":"5s"
+   },
+   "mappings": {
+      "_default_": {
+         "dynamic_templates": [
+            {
+               "parameter_fields": {
+                  "match_mapping_type": "string",
+                  "match": "p_*",
+                  "unmatch": "p_stickymemo",
+                  "mapping": {
+                     "index": true,
+                     "type": "keyword",
+                     "fields": {
+                        "raw": {
+                           "index": true,
+                           "type": "text"
+                        }
+                     }
+                  }
+               }
+            },
+            {
+               "asset_fields": {
+                  "match_mapping_type": "string",
+                  "match": "asset-*",
+                  "mapping": {
+                     "index": true,
+                     "type": "keyword",
+                     "fields": {
+                        "raw": {
+                           "index": true,
+                           "type": "text"
+                        }
+                     }
+                  }
+               }
+            },
+            {
+               "base_fields": {
+                  "match_mapping_type": "string",
+                  "match": "*",
+                  "unmatch": [
+                     "asset-*",
+                     "p_*"
+                  ],
+                  "mapping": {
+                     "index": true,
+                     "type": "keyword",
+                     "fields": {
+                        "raw": {
+                           "index": true,
+                           "type": "text"
+                        }
+                     }
+                  }
+               }
+            }
+         ],
+         "properties": {
+            "dow": {
+               "index": true,
+               "type": "long"
+            },
+            "dom": {
+               "index": true,
+               "type": "long"
+            },
+            "hour": {
+               "index": true,
+               "type": "long"
+            },
+            "eventdescr": {
+               "index": true,
+               "type": "text"
+            },
+            "eventseverity": {
+               "index": true,
+               "type": "byte"
+            },
+            "eventseverity_text": {
+               "index": true,
+               "type": "keyword"
+            },
+            "eventsource": {
+               "index": true,
+               "type": "keyword"
+            },
+            "eventuei": {
+               "index": true,
+               "type": "keyword"
+            },
+            "id": {
+               "index": true,
+               "type": "text"
+            },
+            "interface": {
+               "index": true,
+               "type": "ip"
+            },
+            "ipaddr": {
+               "index": true,
+               "type": "keyword"
+            },
+            "logmsg": {
+               "index": true,
+               "type": "text"
+            },
+            "logmsgdest": {
+               "index": true,
+               "type": "keyword"
+            },
+            "p_newalarmvalues": {
+               "properties": {
+                  "alarmacktime": {
+                     "index": true,
+                     "type": "date"
+                  },
+                  "alarmackuser": {
+                     "index": true,
+                     "type": "keyword"
+                  },
+                  "alarmid": {
+                     "index": true,
+                     "type": "long"
+                  },
+                  "alarmtype": {
+                     "index": true,
+                     "type": "short"
+                  },
+                  "applicationdn": {
+                     "index": true,
+                     "type": "keyword"
+                  },
+                  "clearkey": {
+                     "index": true,
+                     "type": "text"
+                  },
+                  "counter": {
+                     "index": true,
+                     "type": "long"
+                  },
+                  "description": {
+                     "index": true,
+                     "type": "text"
+                  },
+                  "eventparms": {
+                     "index": true,
+                     "type": "text"
+                  },
+                  "eventuei": {
+                     "index": true,
+                     "type": "keyword"
+                  },
+                  "firstautomationtime": {
+                     "index": true,
+                     "type": "date"
+                  },
+                  "firsteventtime": {
+                     "index": true,
+                     "type": "date"
+                  },
+                  "ifindex": {
+                     "index": true,
+                     "type": "keyword"
+                  },
+                  "ipaddr": {
+                     "index": true,
+                     "type": "ip"
+                  },
+                  "lastautomationtime": {
+                     "index": true,
+                     "type": "date"
+                  },
+                  "lasteventid": {
+                     "index": true,
+                     "type": "long"
+                  },
+                  "lasteventtime": {
+                     "index": true,
+                     "type": "date"
+                  },
+                  "logmsg": {
+                     "index": true,
+                     "type": "text"
+                  },
+                  "managedobjectinstance": {
+                     "index": true,
+                     "type": "text"
+                  },
+                  "managedobjecttype": {
+                     "index": true,
+                     "type": "text"
+                  },
+                  "mouseovertext": {
+                     "index": false,
+                     "type": "text"
+                  },
+                  "nodeid": {
+                     "index": true,
+                     "type": "long"
+                  },
+                  "operinstruct": {
+                     "index": false,
+                     "type": "text"
+                  },
+                  "ossprimarykey": {
+                     "index": true,
+                     "type": "keyword"
+                  },
+                  "qosalarmstate": {
+                     "index": true,
+                     "type": "text"
+                  },
+                  "reductionkey": {
+                     "index": false,
+                     "type": "text"
+                  },
+                  "serviceid": {
+                     "index": true,
+                     "type": "long"
+                  },
+                  "severity": {
+                     "index": true,
+                     "type": "byte"
+                  },
+                  "stickymemo": {
+                     "properties": {
+                        "p_author": {
+                           "index": true,
+                           "type": "keyword",
+                           "fields": {
+                              "raw": {
+                                 "index": true,
+                                 "type": "text"
+                              }
+                           }
+                        },
+                        "p_body": {
+                           "index": true,
+                           "type": "text"
+                        },
+                        "p_reductionkey": {
+                           "index": false,
+                           "type": "text"
+                        }
+                     }
+                  },
+                  "suppressedtime": {
+                     "index": true,
+                     "type": "date"
+                  },
+                  "suppresseduntil": {
+                     "index": true,
+                     "type": "date"
+                  },
+                  "suppresseduser": {
+                     "index": true,
+                     "type": "keyword"
+                  },
+                  "systemid": {
+                     "index": true,
+                     "type": "keyword"
+                  },
+                  "tticketid": {
+                     "index": true,
+                     "type": "keyword"
+                  },
+                  "tticketstate": {
+                     "index": true,
+                     "type": "byte"
+                  },
+                  "x733alarmtype": {
+                     "index": true,
+                     "type": "keyword"
+                  },
+                  "x733probablecause": {
+                     "index": true,
+                     "type": "short"
+                  }
+               }
+            },
+            "p_oldalarmvalues": {
+               "properties": {
+                  "alarmacktime": {
+                     "index": true,
+                     "type": "date"
+                  },
+                  "alarmackuser": {
+                     "index": true,
+                     "type": "keyword"
+                  },
+                  "alarmid": {
+                     "index": true,
+                     "type": "long"
+                  },
+                  "alarmtype": {
+                     "index": true,
+                     "type": "short"
+                  },
+                  "applicationdn": {
+                     "index": true,
+                     "type": "keyword"
+                  },
+                  "clearkey": {
+                     "index": true,
+                     "type": "text"
+                  },
+                  "counter": {
+                     "index": true,
+                     "type": "long"
+                  },
+                  "description": {
+                     "index": true,
+                     "type": "text"
+                  },
+                  "eventparms": {
+                     "index": true,
+                     "type": "text"
+                  },
+                  "eventuei": {
+                     "index": true,
+                     "type": "keyword"
+                  },
+                  "firstautomationtime": {
+                     "index": true,
+                     "type": "date"
+                  },
+                  "firsteventtime": {
+                     "index": true,
+                     "type": "date"
+                  },
+                  "ifindex": {
+                     "index": true,
+                     "type": "keyword"
+                  },
+                  "ipaddr": {
+                     "index": true,
+                     "type": "ip"
+                  },
+                  "lastautomationtime": {
+                     "index": true,
+                     "type": "date"
+                  },
+                  "lasteventid": {
+                     "index": true,
+                     "type": "long"
+                  },
+                  "lasteventtime": {
+                     "index": true,
+                     "type": "date"
+                  },
+                  "logmsg": {
+                     "index": true,
+                     "type": "text"
+                  },
+                  "managedobjectinstance": {
+                     "index": true,
+                     "type": "text"
+                  },
+                  "managedobjecttype": {
+                     "index": true,
+                     "type": "text"
+                  },
+                  "mouseovertext": {
+                     "index": false,
+                     "type": "text"
+                  },
+                  "nodeid": {
+                     "index": true,
+                     "type": "long"
+                  },
+                  "operinstruct": {
+                     "index": false,
+                     "type": "text"
+                  },
+                  "ossprimarykey": {
+                     "index": true,
+                     "type": "keyword"
+                  },
+                  "qosalarmstate": {
+                     "index": true,
+                     "type": "text"
+                  },
+                  "reductionkey": {
+                     "index": false,
+                     "type": "text"
+                  },
+                  "serviceid": {
+                     "index": true,
+                     "type": "long"
+                  },
+                  "severity": {
+                     "index": true,
+                     "type": "byte"
+                  },
+                  "stickymemo": {
+                     "properties": {
+                        "p_author": {
+                           "index": true,
+                           "type": "keyword",
+                           "fields": {
+                              "raw": {
+                                 "index": true,
+                                 "type": "text"
+                              }
+                           }
+                        },
+                        "p_body": {
+                           "index": true,
+                           "type": "text"
+                        },
+                        "p_reductionkey": {
+                           "index": false,
+                           "type": "text"
+                        }
+                     }
+                  },
+                  "suppressedtime": {
+                     "index": true,
+                     "type": "date"
+                  },
+                  "suppresseduntil": {
+                     "index": true,
+                     "type": "date"
+                  },
+                  "suppresseduser": {
+                     "index": true,
+                     "type": "keyword"
+                  },
+                  "systemid": {
+                     "index": true,
+                     "type": "keyword"
+                  },
+                  "tticketid": {
+                     "index": true,
+                     "type": "keyword"
+                  },
+                  "tticketstate": {
+                     "index": true,
+                     "type": "byte"
+                  },
+                  "x733alarmtype": {
+                     "index": true,
+                     "type": "keyword"
+                  },
+                  "x733probablecause": {
+                     "index": true,
+                     "type": "short"
+                  }
+               }
+            },
+            "p_oldseverity": {
+               "index": true,
+               "type": "byte"
+            },
+            "alarmackduration": {
+               "index": true,
+               "type": "long"
+            },
+            "alarmacktime": {
+               "index": true,
+               "type": "date"
+            },
+            "p_alarmacktime": {
+               "index": true,
+               "type": "date"
+            },
+            "alarmackuser": {
+               "index": true,
+               "type": "keyword"
+            },
+            "p_alarmackuser": {
+               "index": true,
+               "type": "keyword"
+            },
+            "alarmclearduration": {
+               "index": true,
+               "type": "long"
+            },
+            "alarmcleartime": {
+               "index": true,
+               "type": "date"
+            },
+            "p_alarmcleartime": {
+               "index": true,
+               "type": "date"
+            },
+            "alarmid": {
+               "index": true,
+               "type": "long"
+            },
+            "p_alarmid": {
+               "index": true,
+               "type": "long"
+            },
+            "alarmtype": {
+               "index": true,
+               "type": "short"
+            },
+            "p_alarmtype": {
+               "index": true,
+               "type": "short"
+            },
+            "applicationdn": {
+               "index": true,
+               "type": "keyword"
+            },
+            "categories": {
+               "index": true,
+               "type": "text"
+            },
+            "clearkey": {
+               "index": true,
+               "type": "text"
+            },
+            "counter": {
+               "index": true,
+               "type": "long"
+            },
+            "description": {
+               "index": true,
+               "type": "text"
+            },
+            "eventparms": {
+               "index": true,
+               "type": "text"
+            },
+            "p_eventuei": {
+               "index": true,
+               "type": "keyword"
+            },
+            "firstautomationtime": {
+               "index": true,
+               "type": "date"
+            },
+            "firsteventtime": {
+               "index": true,
+               "type": "date"
+            },
+            "foreignid": {
+               "index": true,
+               "type": "keyword"
+            },
+            "foreignsource": {
+               "index": true,
+               "type": "keyword"
+            },
+            "ifindex": {
+               "index": true,
+               "type": "keyword"
+            },
+            "lastautomationtime": {
+               "index": true,
+               "type": "date"
+            },
+            "lasteventid": {
+               "index": true,
+               "type": "long"
+            },
+            "lasteventtime": {
+               "index": true,
+               "type": "date"
+            },
+            "p_logmsg": {
+               "index": true,
+               "type": "text"
+            },
+            "managedobjectinstance": {
+               "index": true,
+               "type": "text"
+            },
+            "managedobjecttype": {
+               "index": true,
+               "type": "text"
+            },
+            "mouseovertext": {
+               "index": false,
+               "type": "text"
+            },
+            "nodeid": {
+               "index": true,
+               "type": "long"
+            },
+            "nodelabel": {
+               "index": true,
+               "type": "keyword",
+               "fields": {
+                  "raw": {
+                     "index": true,
+                     "type": "text"
+                  }
+               }
+            },
+            "nodesyslocation": {
+               "index": true,
+               "type": "keyword",
+               "fields": {
+                  "raw": {
+                     "index": true,
+                     "type": "text"
+                  }
+               }
+            },
+            "nodesysname": {
+               "index": true,
+               "type": "keyword",
+               "fields": {
+                  "raw": {
+                     "index": true,
+                     "type": "text"
+                  }
+               }
+            },
+            "p_oids": {
+               "type": "nested"
+            },
+            "operatingsystem": {
+               "index": true,
+               "type": "keyword",
+               "fields": {
+                  "raw": {
+                     "index": true,
+                     "type": "text"
+                  }
+               }
+            },
+            "operinstruct": {
+               "index": false,
+               "type": "text"
+            },
+            "ossprimarykey": {
+               "index": true,
+               "type": "keyword"
+            },
+            "p_reason": {
+               "index": true,
+               "type": "text"
+            },
+            "qosalarmstate": {
+               "index": true,
+               "type": "text"
+            },
+            "reductionkey": {
+               "index": false,
+               "type": "text"
+            },
+            "p_reductionkey": {
+               "index": false,
+               "type": "text"
+            },
+            "serviceid": {
+               "index": true,
+               "type": "long"
+            },
+            "p_serviceid": {
+               "index": false,
+               "type": "text"
+            },
+            "severity": {
+               "index": true,
+               "type": "byte"
+            },
+            "p_alarmseverity": {
+               "index": false,
+               "type": "byte"
+            },
+            "severity_text": {
+               "index": true,
+               "type": "keyword"
+            },
+            "stickymemo": {
+               "properties": {
+                  "p_author": {
+                     "index": true,
+                     "type": "keyword",
+                     "fields": {
+                        "raw": {
+                           "index": true,
+                           "type": "text"
+                        }
+                     }
+                  },
+                  "p_body": {
+                     "index": true,
+                     "type": "text"
+                  },
+                  "p_reductionkey": {
+                     "index": false,
+                     "type": "text"
+                  }
+               }
+            },
+            "p_stickymemo": {
+               "properties": {
+                  "p_author": {
+                     "index": true,
+                     "type": "keyword",
+                     "fields": {
+                        "raw": {
+                           "index": true,
+                           "type": "text"
+                        }
+                     }
+                  },
+                  "p_body": {
+                     "index": true,
+                     "type": "text"
+                  },
+                  "p_reductionkey": {
+                     "index": false,
+                     "type": "text"
+                  }
+               }
+            },
+            "suppressedtime": {
+               "index": true,
+               "type": "date"
+            },
+            "p_suppressedtime": {
+               "index": true,
+               "type": "date"
+            },
+            "suppresseduntil": {
+               "index": true,
+               "type": "date"
+            },
+            "p_suppresseduntil": {
+               "index": true,
+               "type": "date"
+            },
+            "suppresseduser": {
+               "index": true,
+               "type": "keyword"
+            },
+            "p_suppresseduser": {
+               "index": true,
+               "type": "keyword"
+            },
+            "systemid": {
+               "index": true,
+               "type": "keyword"
+            },
+            "p_systemid": {
+               "index": true,
+               "type": "keyword"
+            },
+            "tticketid": {
+               "index": true,
+               "type": "keyword"
+            },
+            "p_tticketid": {
+               "index": true,
+               "type": "keyword"
+            },
+            "tticketstate": {
+               "index": true,
+               "type": "byte"
+            },
+            "p_tticketstate": {
+               "index": true,
+               "type": "byte"
+            },
+            "x733alarmtype": {
+               "index": true,
+               "type": "keyword"
+            },
+            "x733probablecause": {
+               "index": true,
+               "type": "short"
+            }
+         },
+         "_all": {
+            "enabled": false
+         }
+      }
+   },
+   "aliases": {}
+}

--- a/smoke-test/src/test/java/org/opennms/smoketest/minion/AbstractSyslogTestCase.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/minion/AbstractSyslogTestCase.java
@@ -44,6 +44,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
@@ -80,6 +81,8 @@ import io.searchbox.core.SearchResult;
 public abstract class AbstractSyslogTestCase {
 
     private static final Logger LOG = LoggerFactory.getLogger(AbstractSyslogTestCase.class);
+
+    protected static final String SYSLOG_MESSAGE_UEI = "uei.opennms.org/vendor/cisco/syslog/SEC-6-IPACCESSLOGP/aclDeniedIPTraffic";
 
     @Rule
     public TestEnvironment testEnvironment = getTestEnvironment();
@@ -227,11 +230,25 @@ public abstract class AbstractSyslogTestCase {
         }
     }
 
+    protected static String doQuery() {
+        return new SearchSourceBuilder()
+                .query(QueryBuilders.matchQuery("eventuei", SYSLOG_MESSAGE_UEI))
+                .toString();
+    }
+
     protected static void pollForElasticsearchEventsUsingJest(InetSocketAddress esTransportAddr, int numMessages) {
-        pollForElasticsearchEventsUsingJest(() -> esTransportAddr, numMessages);
+        pollForElasticsearchEventsUsingJest(() -> esTransportAddr, numMessages, AbstractSyslogTestCase::doQuery);
+    }
+
+    protected static void pollForElasticsearchEventsUsingJest(InetSocketAddress esTransportAddr, int numMessages, Supplier<String> query) {
+        pollForElasticsearchEventsUsingJest(() -> esTransportAddr, numMessages, query);
     }
 
     protected static void pollForElasticsearchEventsUsingJest(Supplier<InetSocketAddress> esTransportAddr, int numMessages) {
+        pollForElasticsearchEventsUsingJest(esTransportAddr, numMessages, AbstractSyslogTestCase::doQuery);
+    }
+
+    protected static void pollForElasticsearchEventsUsingJest(Supplier<InetSocketAddress> esTransportAddr, int numMessages, Supplier<String> query) {
         with().pollInterval(15, SECONDS).await().atMost(5, MINUTES).until(() -> {
             JestClient client = null;
             try {
@@ -241,15 +258,13 @@ public abstract class AbstractSyslogTestCase {
                     .build());
                 client = factory.getObject();
 
+                final String queryString = query.get();
+                LOG.debug("SEARCH QUERY: {}", queryString);
                 SearchResult response = client.execute(
-                    new Search.Builder(new SearchSourceBuilder()
-                        .query(QueryBuilders.matchQuery("eventuei", "uei.opennms.org/vendor/cisco/syslog/SEC-6-IPACCESSLOGP/aclDeniedIPTraffic"))
-                        .toString()
-                    )
+                    new Search.Builder(queryString)
                         .addIndex("opennms*")
                         .build()
                 );
-
                 LOG.debug("SEARCH RESPONSE: {}", response.toString());
 
                 // Sometimes, the first warm-up message is successful so treat both message counts as valid

--- a/smoke-test/src/test/java/org/opennms/smoketest/minion/SyslogKafkaElasticsearch6IT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/minion/SyslogKafkaElasticsearch6IT.java
@@ -136,6 +136,14 @@ public class SyslogKafkaElasticsearch6IT extends AbstractSyslogTestCase {
         }
 
         // 100 warm-up messages plus ${numMessages} messages
-        pollForElasticsearchEventsUsingJest(esRestAddr, 100 + numMessages);
+        pollForElasticsearchEventsUsingJest(esRestAddr, 100 + numMessages, () -> "{\n" +
+                "    \"query\": {\n" +
+                "        \"bool\" : {\n" +
+                "            \"filter\" : {\n" +
+                "                \"term\" : { \"eventuei\" : \"" + AbstractSyslogTestCase.SYSLOG_MESSAGE_UEI + "\" }\n" +
+                "            }\n" +
+                "        }\n" +
+                "    }\n" +
+                "}");
     }
 }

--- a/smoke-test/src/test/java/org/opennms/smoketest/minion/SyslogKafkaElasticsearch6IT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/minion/SyslogKafkaElasticsearch6IT.java
@@ -1,0 +1,141 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2018 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2018 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+package org.opennms.smoketest.minion;
+
+import static com.jayway.awaitility.Awaitility.await;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.hamcrest.Matchers.is;
+
+import java.net.InetSocketAddress;
+import java.util.Date;
+
+import org.junit.Test;
+import org.opennms.core.criteria.CriteriaBuilder;
+import org.opennms.netmgt.dao.hibernate.MinionDaoHibernate;
+import org.opennms.netmgt.model.minion.OnmsMinion;
+import org.opennms.smoketest.utils.DaoUtils;
+import org.opennms.test.system.api.NewTestEnvironment.ContainerAlias;
+import org.opennms.test.system.api.TestEnvironmentBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.util.concurrent.RateLimiter;
+
+/**
+ * This test will send syslog messages over the following message bus:
+ * 
+ * Minion -> Kafka -> OpenNMS Eventd -> Elasticsearch REST -> Elasticsearch 6
+ * 
+ * @author Seth
+ */
+public class SyslogKafkaElasticsearch6IT extends AbstractSyslogTestCase {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SyslogKafkaElasticsearch6IT.class);
+
+    @Override
+    protected TestEnvironmentBuilder getEnvironmentBuilder() {
+        TestEnvironmentBuilder builder = super.getEnvironmentBuilder();
+        // Enable Elasticsearch 6
+        return builder.es6();
+    }
+
+    @Test
+    public void testMinionSyslogsOverKafkaToEsRest() throws Exception {
+        Date startOfTest = new Date();
+        int numMessages = 10000;
+        int packetsPerSecond = 500;
+
+        InetSocketAddress minionSshAddr = testEnvironment.getServiceAddress(ContainerAlias.MINION, 8201);
+        InetSocketAddress esRestAddr = testEnvironment.getServiceAddress(ContainerAlias.ELASTICSEARCH_6, 9200);
+        InetSocketAddress opennmsSshAddr = testEnvironment.getServiceAddress(ContainerAlias.OPENNMS, 8101);
+        InetSocketAddress kafkaAddress = testEnvironment.getServiceAddress(ContainerAlias.KAFKA, 9092);
+        InetSocketAddress zookeeperAddress = testEnvironment.getServiceAddress(ContainerAlias.KAFKA, 2181);
+
+        // Install the Kafka syslog and trap handlers on the Minion system
+        installFeaturesOnMinion(minionSshAddr, kafkaAddress);
+
+        // Install the Kafka and Elasticsearch features on the OpenNMS system
+        installFeaturesOnOpenNMS(opennmsSshAddr, kafkaAddress, zookeeperAddress);
+
+        final String sender = testEnvironment.getContainerInfo(ContainerAlias.SNMPD).networkSettings().ipAddress();
+
+        // Wait for the minion to show up
+        await().atMost(90, SECONDS).pollInterval(5, SECONDS)
+            .until(DaoUtils.countMatchingCallable(
+                 getDaoFactory().getDao(MinionDaoHibernate.class),
+                 new CriteriaBuilder(OnmsMinion.class)
+                     .gt("lastUpdated", startOfTest)
+                     .eq("location", "MINION")
+                     .toCriteria()
+                 ),
+                 is(1)
+             );
+
+        LOG.info("Warming up syslog routes by sending 100 packets");
+
+        // Warm up the routes
+        sendMessage(ContainerAlias.MINION, sender, 100);
+
+        for (int i = 0; i < 10; i++) {
+            LOG.info("Slept for " + i + " seconds");
+            Thread.sleep(1000);
+        }
+
+        LOG.info("Resetting statistics");
+        resetRouteStatistics(opennmsSshAddr, minionSshAddr);
+
+        for (int i = 0; i < 20; i++) {
+            LOG.info("Slept for " + i + " seconds");
+            Thread.sleep(1000);
+        }
+
+        // Make sure that this evenly divides into the numMessages
+        final int chunk = 500;
+        // Make sure that this is an even multiple of chunk
+        final int logEvery = 1000;
+
+        int count = 0;
+        long start = System.currentTimeMillis();
+
+        // Send ${numMessages} syslog messages
+        RateLimiter limiter = RateLimiter.create(packetsPerSecond);
+        for (int i = 0; i < (numMessages / chunk); i++) {
+            limiter.acquire(chunk);
+            sendMessage(ContainerAlias.MINION, sender, chunk);
+            count += chunk;
+            if (count % logEvery == 0) {
+                long mid = System.currentTimeMillis();
+                LOG.info(String.format("Sent %d packets in %d milliseconds", logEvery, mid - start));
+                start = System.currentTimeMillis();
+            }
+        }
+
+        // 100 warm-up messages plus ${numMessages} messages
+        pollForElasticsearchEventsUsingJest(esRestAddr, 100 + numMessages);
+    }
+}


### PR DESCRIPTION
JIRA: https://issues.opennms.org/browse/HZN-1276

Here we fix the event and alarm templates for ES 6.x by adding support for version aware templates.

We also include system tests for indexing in ES 6.x similar to those that were already present for ES 5.x.
