### PR TITLE
NMS-9947: Test for Java properly on Windows and Mingwin.

### DIFF
--- a/bin/functions.pl
+++ b/bin/functions.pl
@@ -325,8 +325,24 @@ sub get_minimum_java {
 sub get_version_from_java {
 	my $javacmd = shift;
 
-	if (not defined $javacmd or not -x $javacmd) {
+	if (not defined $javacmd) {
+		warning("\$javacmd is not defined.\n");
 		return ();
+	}
+
+	# Check Windows and Windows GitBash (mingW64)
+	if ($^O =~ /(mswin|msys)/i) {
+		$javacmd .= '.exe';
+		if (not -e $javacmd) {
+			warning("$javacmd does not exist.\n");
+			return ();
+		}
+	} else {
+		# Check Linux
+		if (not -x $javacmd) {
+			warning("$javacmd is not Executable.\n");
+			return ();
+		}
 	}
 
 	my ($output, $bindir, $shortversion, $version, $build, $java_home);
@@ -348,10 +364,6 @@ sub find_java_home {
 
 	my $versions = {};
 	my $javacmd = 'java';
-
-	if ($^O =~ /(mswin|msys)/i) {
-		$javacmd .= '.exe';
-	}
 
 	for my $searchdir (@JAVA_SEARCH_DIRS) {
 		my @javas = (


### PR DESCRIPTION
JIRA: https://issues.opennms.org/browse/NMS-9947

When compiling on Windows the bin/functions.pl script assumed that it could test the Java binary for executability. There were also conditions where it assumed the Linux format (i.e. w/o trailing '.exe').
