### PR TITLE
NMS-9937: Always add group with empty name

### DIFF
--- a/features/springframework-security/src/main/java/org/opennms/web/springframework/security/UserGroupLdapAuthoritiesPopulator.java
+++ b/features/springframework-security/src/main/java/org/opennms/web/springframework/security/UserGroupLdapAuthoritiesPopulator.java
@@ -104,6 +104,9 @@ public class UserGroupLdapAuthoritiesPopulator extends DefaultLdapAuthoritiesPop
 				this.groupRoleAttribute
 		);
 
+		// A Role mapping with an empty name is always applied to all users
+		userRoles.add("");
+
 		for(String group : userRoles) {
 			final List<String> rolesForGroup = this.groupToRoleMap.get(group);
 			LOG.debug("Checking {} for an associated role", group);

--- a/opennms-webapp/src/main/webapp/WEB-INF/spring-security.d/activeDirectory.xml.disabled
+++ b/opennms-webapp/src/main/webapp/WEB-INF/spring-security.d/activeDirectory.xml.disabled
@@ -67,6 +67,15 @@
     <!-- <beans:property name="groupSearchFilter" value="member:1.2.840.113556.1.4.1941:={0}" /> -->
     <beans:property name="groupToRoleMap">
       <beans:map>
+        <!-- If the is an empty string, the roles are applied to all users -->
+        <!--
+        <beans:entry>
+          <beans:key><beans:value></beans:value></beans:key>
+          <beans:list>
+            <beans:value>ROLE_USER</beans:value>
+          </beans:list>
+        </beans:entry>
+        -->
         <beans:entry>
           <!-- Name of the AD group for normal (non-admin) OpenNMS users -->
           <beans:key><beans:value>OpenNMS-Users</beans:value></beans:key>

--- a/opennms-webapp/src/main/webapp/WEB-INF/spring-security.d/ldap.xml.disabled
+++ b/opennms-webapp/src/main/webapp/WEB-INF/spring-security.d/ldap.xml.disabled
@@ -62,6 +62,15 @@
     <beans:property name="groupSearchFilter" value="member={0}" />
     <beans:property name="groupToRoleMap">
       <beans:map>
+        <!-- If the is an empty string, the roles are applied to all users -->
+        <!--
+        <beans:entry>
+          <beans:key><beans:value></beans:value></beans:key>
+          <beans:list>
+            <beans:value>ROLE_USER</beans:value>
+          </beans:list>
+        </beans:entry>
+        -->
         <beans:entry>
           <!-- Name of the LDAP group for normal (non-admin) OpenNMS users -->
           <beans:key><beans:value>opennms-users</beans:value></beans:key>


### PR DESCRIPTION
By adding the empty named group, one can leverage the existing group
maping by adding something like
```
"" => [ROLE_USER, ROLE_DASHBOARD]
```
which will be applied to all users.


* JIRA: http://issues.opennms.org/browse/NMS-9937
