### PR TITLE
NMS-9952: Fix jdbc-collector default host name.

### DIFF
--- a/core/lib/src/main/java/org/opennms/core/utils/DBTools.java
+++ b/core/lib/src/main/java/org/opennms/core/utils/DBTools.java
@@ -46,7 +46,7 @@ public abstract class DBTools {
      * 
      * @see #constructUrl
      */
-    private static final String JDBC_HOST = "localhost:5432";
+    private static final String OPENNMS_JDBC_HOSTNAME = "OPENNMS_JDBC_HOSTNAME";
 
     /**
      * Minimal port range
@@ -82,12 +82,12 @@ public abstract class DBTools {
     public static final String DEFAULT_DATABASE_PASSWORD = "";
 
     /**
-     * Default vendor protocol, like jdbc:sybase:Tds:
+     * Default vendor protocol, like jdbc:postgresql
      */
-    public static final String DEFAULT_URL = "jdbc:postgresql://" + JDBC_HOST + "/opennms";
+    public static final String DEFAULT_URL = "jdbc:postgresql://" + OPENNMS_JDBC_HOSTNAME + "/opennms";
 
     // Pattern for the JDBC_HOST
-    private static final Pattern _pattern = Pattern.compile(JDBC_HOST);
+    private static final Pattern _pattern = Pattern.compile(OPENNMS_JDBC_HOSTNAME);
 
     /**
      * Constructs a JDBC url given a set of fragments. The resulting Url will
@@ -97,13 +97,13 @@ public abstract class DBTools {
      * @param hostname_
      *            The hostname where the database server is
      * @param url_
-     *            (for example jdbc:sybase:Tds:@{link #JDBC_HOST
-     *            JDBC_HOST}:4100/tempdb). The JDBC_HOST is replaced by the real
+     *            (for example jdbc:sybase:Tds:@{link #OPENNMS_JDBC_HOSTNAME
+     *            OPENNMS_JDBC_HOSTNAME}:4100/tempdb). The OPENNMS_JDBC_HOSTNAME is replaced by the real
      *            hostname
      * @throws java.lang.NullPointerException
      *             If one of the arguments is null
      * @throws java.lang.IllegalArgumentException
-     *             If the JDBC_HOST is not part of the JDBC url
+     *             If the OPENNMS_JDBC_HOSTNAME is not part of the JDBC url
      * @return a {@link java.lang.String} object.
      */
     public static String constructUrl(String url_, String hostname_) throws IllegalArgumentException, NullPointerException {

--- a/core/lib/src/test/java/org/opennms/core/utils/DBToolsTest.java
+++ b/core/lib/src/test/java/org/opennms/core/utils/DBToolsTest.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2007-2018 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2018 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.core.utils;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class DBToolsTest {
+
+    @Test
+    public void verifyHostNameMatching() {
+        // configs use this pattern for JDBC URL
+        final String URL = "jdbc:postgresql://OPENNMS_JDBC_HOSTNAME:5432/opennms";
+        String resultingUrl = DBTools.constructUrl(URL, "localhost");
+        assertEquals("jdbc:postgresql://localhost:5432/opennms", resultingUrl);
+
+    }
+
+}


### PR DESCRIPTION
Fix bug caused due to replacing OPENNMS_JDBC_HOSTNAME
* JIRA: http://issues.opennms.org/browse/NMS-9952

Our [continuous integration system](http://bamboo.internal.opennms.com:8085) will test and verify your changes.
