### PR TITLE
NMS-9958: Set correct sysoid definitions in datacollection

### DIFF
--- a/opennms-base-assembly/src/main/filtered/etc/datacollection/ceragon-FA1500.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/datacollection/ceragon-FA1500.xml
@@ -85,7 +85,7 @@
       <mibObj oid=".1.3.6.1.4.1.2281.4.5.1.1.5" instance="faAccessStatTableIndex" alias="accStatCV" type="gauge"/>
    </group>
    <systemDef name="Ceragon Fibreair 1500P">
-      <sysoidMask>.1.3.6.1.4.1.2281.1.4</sysoidMask>
+      <sysoid>.1.3.6.1.4.1.2281.1.4</sysoid>
       <collect>
          <includeGroup>ceragonfa1500-eth-stats</includeGroup>
          <includeGroup>ceragonfa1500-drawer-stats</includeGroup>
@@ -95,7 +95,7 @@
       </collect>
    </systemDef>
    <systemDef name="Ceragon Fibreair 1500R">
-      <sysoidMask>.1.3.6.1.4.1.2281.1.4.4</sysoidMask>
+      <sysoid>.1.3.6.1.4.1.2281.1.4.4</sysoid>
       <collect>
          <includeGroup>ceragonfa1500-drawer-stats</includeGroup>
          <includeGroup>ceragonfa1500-mux-stats</includeGroup>

--- a/opennms-base-assembly/src/main/filtered/etc/datacollection/juniper.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/datacollection/juniper.xml
@@ -146,76 +146,76 @@
       </collect>
    </systemDef>
    <systemDef name="Juniper SRX210he2 Routers">
-      <sysoidMask>.1.3.6.1.4.1.2636.1.1.1.2.36</sysoidMask>
+      <sysoid>.1.3.6.1.4.1.2636.1.1.1.2.36</sysoid>
       <collect>
          <includeGroup>juniper-spu-monitor</includeGroup>
          <includeGroup>juniper-fwdd-process</includeGroup>
       </collect>
    </systemDef>
    <systemDef name="Juniper SRX240 Routers">
-      <sysoidMask>.1.3.6.1.4.1.2636.1.1.1.2.39</sysoidMask>
+      <sysoid>.1.3.6.1.4.1.2636.1.1.1.2.39</sysoid>
       <collect>
          <includeGroup>juniper-spu-monitor</includeGroup>
          <includeGroup>juniper-fwdd-process</includeGroup>
       </collect>
    </systemDef>
    <systemDef name="Juniper SRX100h Routers">
-      <sysoidMask>.1.3.6.1.4.1.2636.1.1.1.2.41</sysoidMask>
+      <sysoid>.1.3.6.1.4.1.2636.1.1.1.2.41</sysoid>
       <collect>
          <includeGroup>juniper-spu-monitor</includeGroup>
          <includeGroup>juniper-fwdd-process</includeGroup>
       </collect>
    </systemDef>
    <systemDef name="Juniper SRX220 Routers">
-      <sysoidMask>.1.3.6.1.4.1.2636.1.1.1.2.58</sysoidMask>
+      <sysoid>.1.3.6.1.4.1.2636.1.1.1.2.58</sysoid>
       <collect>
          <includeGroup>juniper-spu-monitor</includeGroup>
       </collect>
    </systemDef>
    <systemDef name="Juniper J-Routers (J2300)">
-      <sysoidMask>.1.3.6.1.4.1.2636.1.1.1.2.13</sysoidMask>
+      <sysoid>.1.3.6.1.4.1.2636.1.1.1.2.13</sysoid>
       <collect>
          <includeGroup>juniper-fwdd-process</includeGroup>
       </collect>
    </systemDef>
    <systemDef name="Juniper J-Routers (J4300)">
-      <sysoidMask>.1.3.6.1.4.1.2636.1.1.1.2.14</sysoidMask>
+      <sysoid>.1.3.6.1.4.1.2636.1.1.1.2.14</sysoid>
       <collect>
          <includeGroup>juniper-fwdd-process</includeGroup>
       </collect>
    </systemDef>
    <systemDef name="Juniper J-Routers (J6300)">
-      <sysoidMask>.1.3.6.1.4.1.2636.1.1.1.2.15</sysoidMask>
+      <sysoid>.1.3.6.1.4.1.2636.1.1.1.2.15</sysoid>
       <collect>
          <includeGroup>juniper-fwdd-process</includeGroup>
       </collect>
    </systemDef>
    <systemDef name="Juniper J-Routers (J4350)">
-      <sysoidMask>.1.3.6.1.4.1.2636.1.1.1.2.19</sysoidMask>
+      <sysoid>.1.3.6.1.4.1.2636.1.1.1.2.19</sysoid>
       <collect>
          <includeGroup>juniper-fwdd-process</includeGroup>
       </collect>
    </systemDef>
    <systemDef name="Juniper J-Routers (J6350)">
-      <sysoidMask>.1.3.6.1.4.1.2636.1.1.1.2.20</sysoidMask>
+      <sysoid>.1.3.6.1.4.1.2636.1.1.1.2.20</sysoid>
       <collect>
          <includeGroup>juniper-fwdd-process</includeGroup>
       </collect>
    </systemDef>
    <systemDef name="Juniper J-Routers (J4320)">
-      <sysoidMask>.1.3.6.1.4.1.2636.1.1.1.2.22</sysoidMask>
+      <sysoid>.1.3.6.1.4.1.2636.1.1.1.2.22</sysoid>
       <collect>
          <includeGroup>juniper-fwdd-process</includeGroup>
       </collect>
    </systemDef>
    <systemDef name="Juniper J-Routers (J2320)">
-      <sysoidMask>.1.3.6.1.4.1.2636.1.1.1.2.23</sysoidMask>
+      <sysoid>.1.3.6.1.4.1.2636.1.1.1.2.23</sysoid>
       <collect>
          <includeGroup>juniper-fwdd-process</includeGroup>
       </collect>
    </systemDef>
    <systemDef name="Juniper J-Routers (J2350)">
-      <sysoidMask>.1.3.6.1.4.1.2636.1.1.1.2.24</sysoidMask>
+      <sysoid>.1.3.6.1.4.1.2636.1.1.1.2.24</sysoid>
       <collect>
          <includeGroup>juniper-fwdd-process</includeGroup>
       </collect>

--- a/opennms-base-assembly/src/main/filtered/etc/datacollection/konica.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/datacollection/konica.xml
@@ -1,6 +1,6 @@
 <datacollection-group xmlns="http://xmlns.opennms.org/xsd/config/datacollection" name="Konica">
    <systemDef name="Konica Minolta Network Printer">
-      <sysoidMask>.1.3.6.1.4.1.18334.1.1.1.2.1</sysoidMask>
+      <sysoid>.1.3.6.1.4.1.18334.1.1.1.2.1</sysoid>
       <collect>
          <includeGroup>printer-usage</includeGroup>
          <includeGroup>printer-mib-supplies</includeGroup>

--- a/opennms-base-assembly/src/main/filtered/etc/datacollection/paloalto.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/datacollection/paloalto.xml
@@ -58,7 +58,7 @@
       <mibObj oid=".1.3.6.1.4.1.25461.2.1.2.3.8" instance="0" alias="panSessionSslProxy" type="Integer32"/>
    </group>
    <systemDef name="Palo Alto PA-4050">
-      <sysoidMask>.1.3.6.1.4.1.25461.2.3.1</sysoidMask>
+      <sysoid>.1.3.6.1.4.1.25461.2.3.1</sysoid>
       <collect>
          <includeGroup>pan-global-protect</includeGroup>
          <includeGroup>pan-vsys-sessions</includeGroup>
@@ -73,7 +73,7 @@
       </collect>
    </systemDef>
    <systemDef name="Palo Alto PA-4020">
-      <sysoidMask>.1.3.6.1.4.1.25461.2.3.2</sysoidMask>
+      <sysoid>.1.3.6.1.4.1.25461.2.3.2</sysoid>
       <collect>
          <includeGroup>pan-global-protect</includeGroup>
          <includeGroup>pan-vsys-sessions</includeGroup>
@@ -88,7 +88,7 @@
       </collect>
    </systemDef>
    <systemDef name="Palo Alto PA-2050">
-      <sysoidMask>.1.3.6.1.4.1.25461.2.3.3</sysoidMask>
+      <sysoid>.1.3.6.1.4.1.25461.2.3.3</sysoid>
       <collect>
          <includeGroup>pan-global-protect</includeGroup>
          <includeGroup>pan-vsys-sessions</includeGroup>
@@ -103,7 +103,7 @@
       </collect>
    </systemDef>
    <systemDef name="Palo Alto PA-2020">
-      <sysoidMask>.1.3.6.1.4.1.25461.2.3.4</sysoidMask>
+      <sysoid>.1.3.6.1.4.1.25461.2.3.4</sysoid>
       <collect>
          <includeGroup>pan-global-protect</includeGroup>
          <includeGroup>pan-vsys-sessions</includeGroup>
@@ -118,7 +118,7 @@
       </collect>
    </systemDef>
    <systemDef name="Palo Alto PA-4060">
-      <sysoidMask>.1.3.6.1.4.1.25461.2.3.5</sysoidMask>
+      <sysoid>.1.3.6.1.4.1.25461.2.3.5</sysoid>
       <collect>
          <includeGroup>pan-global-protect</includeGroup>
          <includeGroup>pan-vsys-sessions</includeGroup>
@@ -133,7 +133,7 @@
       </collect>
    </systemDef>
    <systemDef name="Palo Alto PA-500">
-      <sysoidMask>.1.3.6.1.4.1.25461.2.3.6</sysoidMask>
+      <sysoid>.1.3.6.1.4.1.25461.2.3.6</sysoid>
       <collect>
          <includeGroup>pan-global-protect</includeGroup>
          <includeGroup>pan-vsys-sessions</includeGroup>
@@ -148,7 +148,7 @@
       </collect>
    </systemDef>
    <systemDef name="Palo Alto Panorama">
-      <sysoidMask>.1.3.6.1.4.1.25461.2.3.7</sysoidMask>
+      <sysoid>.1.3.6.1.4.1.25461.2.3.7</sysoid>
       <collect>
          <includeGroup>mib2-host-resources-storage</includeGroup>
          <includeGroup>mib2-host-resources-system</includeGroup>
@@ -157,7 +157,7 @@
       </collect>
    </systemDef>
    <systemDef name="Palo Alto PA-5060">
-      <sysoidMask>.1.3.6.1.4.1.25461.2.3.8</sysoidMask>
+      <sysoid>.1.3.6.1.4.1.25461.2.3.8</sysoid>
       <collect>
          <includeGroup>pan-global-protect</includeGroup>
          <includeGroup>pan-vsys-sessions</includeGroup>
@@ -172,7 +172,7 @@
       </collect>
    </systemDef>
    <systemDef name="Palo Alto PA-5050">
-      <sysoidMask>.1.3.6.1.4.1.25461.2.3.9</sysoidMask>
+      <sysoid>.1.3.6.1.4.1.25461.2.3.9</sysoid>
       <collect>
          <includeGroup>pan-global-protect</includeGroup>
          <includeGroup>pan-vsys-sessions</includeGroup>
@@ -187,7 +187,7 @@
       </collect>
    </systemDef>
    <systemDef name="Palo Alto PA-5020">
-      <sysoidMask>.1.3.6.1.4.1.25461.2.3.11</sysoidMask>
+      <sysoid>.1.3.6.1.4.1.25461.2.3.11</sysoid>
       <collect>
          <includeGroup>pan-global-protect</includeGroup>
          <includeGroup>pan-vsys-sessions</includeGroup>
@@ -202,7 +202,7 @@
       </collect>
    </systemDef>
    <systemDef name="Palo Alto PA-200">
-      <sysoidMask>.1.3.6.1.4.1.25461.2.3.12</sysoidMask>
+      <sysoid>.1.3.6.1.4.1.25461.2.3.12</sysoid>
       <collect>
          <includeGroup>pan-global-protect</includeGroup>
          <includeGroup>mib2-X-interfaces</includeGroup>
@@ -216,7 +216,7 @@
       </collect>
    </systemDef>
    <systemDef name="Palo Alto PA-3050">
-      <sysoidMask>.1.3.6.1.4.1.25461.2.3.17</sysoidMask>
+      <sysoid>.1.3.6.1.4.1.25461.2.3.17</sysoid>
       <collect>
          <includeGroup>pan-global-protect</includeGroup>
          <includeGroup>pan-vsys-sessions</includeGroup>
@@ -231,7 +231,7 @@
       </collect>
    </systemDef>
    <systemDef name="Palo Alto PA-3020">
-      <sysoidMask>.1.3.6.1.4.1.25461.2.3.18</sysoidMask>
+      <sysoid>.1.3.6.1.4.1.25461.2.3.18</sysoid>
       <collect>
          <includeGroup>pan-global-protect</includeGroup>
          <includeGroup>pan-vsys-sessions</includeGroup>
@@ -246,7 +246,7 @@
       </collect>
    </systemDef>
    <systemDef name="Palo Alto PA-3060">
-      <sysoidMask>.1.3.6.1.4.1.25461.2.3.19</sysoidMask>
+      <sysoid>.1.3.6.1.4.1.25461.2.3.19</sysoid>
       <collect>
          <includeGroup>pan-global-protect</includeGroup>
          <includeGroup>pan-vsys-sessions</includeGroup>
@@ -261,11 +261,11 @@
       </collect>
    </systemDef>
    <systemDef name="Palo Alto PA-VM">
-      <sysoidMask>.1.3.6.1.4.1.25461.2.3.29</sysoidMask>
+      <sysoid>.1.3.6.1.4.1.25461.2.3.29</sysoid>
       <collect/>
    </systemDef>
    <systemDef name="Palo Alto M-100">
-      <sysoidMask>.1.3.6.1.4.1.25461.2.3.30</sysoidMask>
+      <sysoid>.1.3.6.1.4.1.25461.2.3.30</sysoid>
       <collect>
          <includeGroup>pan-log-collector-disk</includeGroup>
          <includeGroup>pan-log-collector-rate</includeGroup>
@@ -278,7 +278,7 @@
       </collect>
    </systemDef>
    <systemDef name="Palo Alto M-500">
-      <sysoidMask>.1.3.6.1.4.1.25461.2.3.35</sysoidMask>
+      <sysoid>.1.3.6.1.4.1.25461.2.3.35</sysoid>
       <collect>
          <includeGroup>pan-log-collector-disk</includeGroup>
          <includeGroup>pan-log-collector-rate</includeGroup>


### PR DESCRIPTION
The sysoidMask value can cause unwanted sideffects when the sysoidMask does not end with a "." character. All sysoid defintions which match a full described sysoid are set to sysoid instead of sysoidMask.

* JIRA: http://issues.opennms.org/browse/NMS-9958