### PR TITLE
HZN-1279: Make the telemetry groovy scripts reloadable

### DIFF
--- a/container/features/src/main/resources/features.xml
+++ b/container/features/src/main/resources/features.xml
@@ -1124,7 +1124,7 @@
 
       <feature>opennms-collection-api</feature>
       <feature>opennms-osgi-jsr223</feature>
-
+      <bundle>mvn:org.opennms.core/org.opennms.core.lib/${project.version}</bundle>
       <bundle>mvn:org.opennms.features.telemetry.config/org.opennms.features.telemetry.config.api/${project.version}</bundle>
       <bundle>mvn:org.opennms.features.telemetry.adapters/org.opennms.features.telemetry.adapters.api/${project.version}</bundle>
       <bundle>mvn:org.opennms.features.telemetry.adapters/org.opennms.features.telemetry.adapters.collection/${project.version}</bundle>

--- a/core/lib/pom.xml
+++ b/core/lib/pom.xml
@@ -21,11 +21,6 @@
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
-            <Export-Package>
-              org.opennms.core.collections;version="${project.version}",
-              org.opennms.core.time;version="${project.version}",
-              org.opennms.core.utils;version="${project.version}"
-            </Export-Package>
           </instructions>
         </configuration>
       </plugin>
@@ -49,6 +44,11 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.jayway.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/core/lib/src/main/java/org/opennms/core/fileutils/FileUpdateCallback.java
+++ b/core/lib/src/main/java/org/opennms/core/fileutils/FileUpdateCallback.java
@@ -26,38 +26,15 @@
  *     http://www.opennms.com/
  *******************************************************************************/
 
-package org.opennms.netmgt.telemetry.adapters.api;
-
-import org.opennms.netmgt.telemetry.config.api.Protocol;
-
 /**
- * Responsible for handling telemetry messages received by the listeners
- * within a protocol definition.
- *
- * The adapter should decode the message and handle the contents appropriately.
- *
- * @author jwhite
+ * Callback interface. Classes implementing this interface can be passed as param 
+ * in FileUpdateWatcher to get callback whenever file updates.
+ * 
  */
-public interface Adapter {
 
-    /**
-     * A single instance of an adapter will only be responsible
-     * for one protocol. The protocol will be set using this method before
-     * any calls to {@link #handleMessageLog} are made.
-     *
-     * @param protocol the protocol in which the adapter is defined
-     */
-    void setProtocol(Protocol protocol);
+package org.opennms.core.fileutils;
 
-    /**
-     * Handle the messages.
-     *
-     * IMPORTANT: Implementations of this method MUST be thread-safe.
-     *
-     * @param messageLog group of messages to be handled
-     */
-    void handleMessageLog(TelemetryMessageLog messageLog);
+public interface FileUpdateCallback {
 
-    void destroy();
-
+    void reload();
 }

--- a/core/lib/src/main/java/org/opennms/core/fileutils/FileUpdateWatcher.java
+++ b/core/lib/src/main/java/org/opennms/core/fileutils/FileUpdateWatcher.java
@@ -1,0 +1,137 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2018-2018 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+/**
+ * Instantiate this class with fileName and callback implementing FileUpdateCallback
+ * Whenever file updates, callback  reload() will be invoked.
+ */
+
+package org.opennms.core.fileutils;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardWatchEventKinds;
+import java.nio.file.WatchEvent;
+import java.nio.file.WatchKey;
+import java.nio.file.WatchService;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class FileUpdateWatcher {
+
+    private static final Logger LOG = LoggerFactory.getLogger(FileUpdateWatcher.class);
+
+    private final FileUpdateCallback callback;
+
+    private final WatchService watcher;
+
+    private final String fileName;
+
+    private final AtomicBoolean closed = new AtomicBoolean(false);
+
+    public FileUpdateWatcher(String fileName, FileUpdateCallback fileUpdateCb) throws IOException {
+        File file = new File(fileName);
+        if (!file.exists() || file.isDirectory()) {
+            throw new IllegalArgumentException("script file doesn't exist");
+        }
+        this.fileName = fileName;
+        Path path = Paths.get(file.getParent());
+        this.callback = fileUpdateCb;
+        watcher = path.getFileSystem().newWatchService();
+        path.register(watcher, StandardWatchEventKinds.ENTRY_CREATE, StandardWatchEventKinds.ENTRY_MODIFY);
+        final Executor executor = Executors.newSingleThreadExecutor();
+        executor.execute(new FileWatcherThread());
+        LOG.info(" started watcher thread");
+    }
+
+    private class FileWatcherThread implements Runnable {
+
+        @Override
+        public void run() {
+            long lastTimeStamp = 0;
+            while (!closed.get()) {
+                WatchKey key = null;
+                try {
+                    key = watcher.take();
+                } catch (Exception e) {
+                    LOG.info("Watcher is either interruped or closed", e);
+                    break;
+                }
+
+                for (WatchEvent<?> event : key.pollEvents()) {
+                    WatchEvent.Kind<?> kind = event.kind();
+                    WatchEvent<Path> ev = cast(event);
+                    Path dir = (Path) key.watchable();
+                    Path updatedFile = dir.resolve(ev.context());
+                    // Some editors create temporary buffers, watch for both create/modify
+                    if (kind == StandardWatchEventKinds.ENTRY_MODIFY || kind == StandardWatchEventKinds.ENTRY_CREATE) {
+                        if (updatedFile.toString().equals(fileName)) {
+                            final long now = System.currentTimeMillis();
+                            final long interval = Long.getLong("org.opennms.core.fileutils.watcher.interval.seconds", 1);
+                            if (now - lastTimeStamp > TimeUnit.SECONDS.toMillis(interval)) {
+                                LOG.info(" file got updated, send callback");
+                                callback.reload();
+                            } else {
+                                LOG.debug(" callback was not sent as the changes are in within {} secs interval ", interval);
+                            }
+                            lastTimeStamp = now;
+                        }
+                    }
+                    if (!key.reset()) {
+                        break;
+                    }
+                }
+            }
+        }
+
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T> WatchEvent<T> cast(WatchEvent<?> event) {
+        return (WatchEvent<T>) event;
+    }
+
+    public void destroy() {
+        try {
+            if (watcher != null) {
+                watcher.close();
+            }
+        } catch (Exception e) {
+            LOG.info("Exception while closing watcher", e);
+        }
+        closed.set(true);
+    }
+
+}

--- a/core/lib/src/test/java/org/opennms/core/fileutils/FileUpdateWatcherTest.java
+++ b/core/lib/src/test/java/org/opennms/core/fileutils/FileUpdateWatcherTest.java
@@ -1,0 +1,86 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2007-2014 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.core.fileutils;
+
+import static com.jayway.awaitility.Awaitility.await;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class FileUpdateWatcherTest {
+    
+    @Rule
+    public TemporaryFolder tempFolder = new TemporaryFolder();
+    
+    private AtomicBoolean reloadCalled = new AtomicBoolean(false);
+    
+    private File testFile;
+    
+    private FileUpdateWatcher fileWatcher;
+    
+    @Before
+    public void before() throws IOException {
+        testFile = tempFolder.newFile("testWatcher.log");
+        fileWatcher = new FileUpdateWatcher(testFile.getAbsolutePath(), fileReload());
+
+    }
+
+    private FileUpdateCallback fileReload() {
+        return new FileUpdateCallback() {
+
+            @Override
+            public void reload() {
+                reloadCalled.set(true);     
+            }
+            
+        };
+    }
+
+    @Test
+    public void testFileUpdateWatcher() throws IOException {
+        
+        String str = "Hello";
+        BufferedWriter writer = new BufferedWriter(new FileWriter(testFile));
+        writer.write(str);
+        writer.close();
+        await().atMost(5, SECONDS).pollDelay(0, SECONDS).pollInterval(2, SECONDS)
+        .untilTrue(reloadCalled);
+        fileWatcher.destroy();
+    }
+
+}

--- a/core/lib/src/test/java/org/opennms/core/fileutils/FileUpdateWatcherTest.java
+++ b/core/lib/src/test/java/org/opennms/core/fileutils/FileUpdateWatcherTest.java
@@ -74,9 +74,9 @@ public class FileUpdateWatcherTest {
     @Test
     public void testFileUpdateWatcher() throws IOException {
         
-        String str = "Hello";
+        String hello = "Hello";
         BufferedWriter writer = new BufferedWriter(new FileWriter(testFile));
-        writer.write(str);
+        writer.write(hello);
         writer.close();
         await().atMost(5, SECONDS).pollDelay(0, SECONDS).pollInterval(2, SECONDS)
         .untilTrue(reloadCalled);

--- a/features/telemetry/adapters/jti/src/main/java/org/opennms/netmgt/telemetry/adapters/jti/JtiGpbAdapter.java
+++ b/features/telemetry/adapters/jti/src/main/java/org/opennms/netmgt/telemetry/adapters/jti/JtiGpbAdapter.java
@@ -91,25 +91,6 @@ public class JtiGpbAdapter extends AbstractPersistingAdapter {
 
     private TransactionOperations transactionTemplate;
 
-    private String script;
-
-    private BundleContext bundleContext;
-
-    private final ThreadLocal<ScriptedCollectionSetBuilder> scriptedCollectionSetBuilders = new ThreadLocal<ScriptedCollectionSetBuilder>() {
-        @Override
-        protected ScriptedCollectionSetBuilder initialValue() {
-            try {
-                if (bundleContext != null) {
-                    return new ScriptedCollectionSetBuilder(new File(script), bundleContext);
-                } else {
-                    return new ScriptedCollectionSetBuilder(new File(script));
-                }
-            } catch (Exception e) {
-                LOG.error("Failed to create builder for script '{}'.", script, e);
-                return null;
-            }
-        }
-    };
 
     @Override
     public Optional<CollectionSetWithAgent> handleMessage(TelemetryMessage message, TelemetryMessageLog messageLog)
@@ -153,21 +134,10 @@ public class JtiGpbAdapter extends AbstractPersistingAdapter {
             return Optional.empty();
         }
 
-        final ScriptedCollectionSetBuilder builder = scriptedCollectionSetBuilders.get();
-        if (builder == null) {
-            throw new Exception(String.format("Error compiling script '%s'. See logs for details.", script));
-        }
+        ScriptedCollectionSetBuilder builder = getCollectionBuilder();
 
         final CollectionSet collectionSet = builder.build(agent, jtiMsg);
         return Optional.of(new CollectionSetWithAgent(agent, collectionSet));
-    }
-
-    public String getScript() {
-        return script;
-    }
-
-    public void setScript(String script) {
-        this.script = script;
     }
 
     public void setCollectionAgentFactory(CollectionAgentFactory collectionAgentFactory) {
@@ -184,10 +154,6 @@ public class JtiGpbAdapter extends AbstractPersistingAdapter {
 
     public void setTransactionTemplate(TransactionOperations transactionTemplate) {
         this.transactionTemplate = transactionTemplate;
-    }
-
-    public void setBundleContext(BundleContext bundleContext) {
-        this.bundleContext = bundleContext;
     }
 
 }

--- a/features/telemetry/adapters/netflow/src/main/java/org/opennms/netmgt/telemetry/adapters/netflow/AbstractAdapter.java
+++ b/features/telemetry/adapters/netflow/src/main/java/org/opennms/netmgt/telemetry/adapters/netflow/AbstractAdapter.java
@@ -111,4 +111,8 @@ public abstract class AbstractAdapter<P> implements Adapter {
     }
 
     protected abstract P parse(TelemetryMessage message);
+
+    public void destroy() {
+        // not needed
+    }
 }

--- a/features/telemetry/adapters/nxos/src/main/java/org/opennms/netmgt/telemetry/adapters/nxos/NxosTelemetryClient.java
+++ b/features/telemetry/adapters/nxos/src/main/java/org/opennms/netmgt/telemetry/adapters/nxos/NxosTelemetryClient.java
@@ -39,7 +39,9 @@ import java.util.List;
 import org.opennms.core.utils.InetAddressUtils;
 import org.opennms.netmgt.telemetry.adapters.nxos.proto.TelemetryBis;
 
-
+/**
+ * Utility to send Nxos messages to Telemetry stack
+ **/
 public class NxosTelemetryClient {
 
     private static TelemetryBis.Telemetry buildMessage(String ipAddress , int i) throws IOException {
@@ -74,7 +76,6 @@ public class NxosTelemetryClient {
             try {
                 sendNxosPacket(i);
             } catch (IOException e) {
-                // TODO Auto-generated catch block
                 e.printStackTrace();
             }
         });

--- a/features/telemetry/adapters/nxos/src/main/java/org/opennms/netmgt/telemetry/adapters/nxos/NxosTelemetryClient.java
+++ b/features/telemetry/adapters/nxos/src/main/java/org/opennms/netmgt/telemetry/adapters/nxos/NxosTelemetryClient.java
@@ -32,7 +32,9 @@ import java.io.IOException;
 import java.net.DatagramPacket;
 import java.net.DatagramSocket;
 import java.net.InetAddress;
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
 
 import org.opennms.core.utils.InetAddressUtils;
 import org.opennms.netmgt.telemetry.adapters.nxos.proto.TelemetryBis;
@@ -40,12 +42,12 @@ import org.opennms.netmgt.telemetry.adapters.nxos.proto.TelemetryBis;
 
 public class NxosTelemetryClient {
 
-    private static TelemetryBis.Telemetry buildMessage(String ipAddress) throws IOException {
+    private static TelemetryBis.Telemetry buildMessage(String ipAddress , int i) throws IOException {
 
         // Set Telemetry fields
         TelemetryBis.TelemetryField field1 = TelemetryBis.TelemetryField.newBuilder()
                                                 .setName("loadavg")
-                                                .setUint32Value(23)
+                                                .setUint32Value(i+32)
                                                 .setTimestamp(1510584351).build();
         
 
@@ -53,7 +55,7 @@ public class NxosTelemetryClient {
                                                         .setNodeIdStr(ipAddress)
                                                         .addDataGpbkv(field1)
                                                         .setSubscriptionIdStr("18374686715878047745")
-                                                        .setCollectionId(4)
+                                                        .setCollectionId(10456)
                                                         .setCollectionStartTime(1510584351)
                                                         .setCollectionEndTime(1510584402)
                                                         .setMsgTimestamp(new Date().getTime())
@@ -63,8 +65,24 @@ public class NxosTelemetryClient {
     }
     
     public static void main(String... args) throws IOException {
-        // Making assumption that NodeId is IpAddress
-        TelemetryBis.Telemetry nxosMsg = buildMessage("192.168.2.1");
+        
+        List<Integer> numbers = new ArrayList<>();
+        for ( int i=0; i < 1000; i++) {
+            numbers.add(i);
+        }
+        numbers.parallelStream().forEach( i -> {
+            try {
+                sendNxosPacket(i);
+            } catch (IOException e) {
+                // TODO Auto-generated catch block
+                e.printStackTrace();
+            }
+        });
+    }
+    
+    public static void sendNxosPacket(int i) throws IOException {
+        
+        TelemetryBis.Telemetry nxosMsg = buildMessage("192.168.0.106", i);
         byte[] nxosMsgBytes = nxosMsg.toByteArray();
 
         InetAddress address = InetAddressUtils.getLocalHostAddress();

--- a/features/telemetry/daemon/src/main/java/org/opennms/netmgt/telemetry/daemon/TelemetryMessageConsumer.java
+++ b/features/telemetry/daemon/src/main/java/org/opennms/netmgt/telemetry/daemon/TelemetryMessageConsumer.java
@@ -33,6 +33,7 @@ import java.util.List;
 import java.util.Objects;
 
 import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
 
 import org.opennms.core.ipc.sink.api.MessageConsumer;
 import org.opennms.core.ipc.sink.api.SinkModule;
@@ -46,6 +47,7 @@ import org.opennms.netmgt.telemetry.listeners.api.TelemetryMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+
 
 public class TelemetryMessageConsumer implements MessageConsumer<TelemetryMessage, TelemetryProtos.TelemetryMessageLog> {
     private final Logger LOG = LoggerFactory.getLogger(TelemetryMessageConsumer.class);
@@ -95,6 +97,11 @@ public class TelemetryMessageConsumer implements MessageConsumer<TelemetryMessag
                 }
             }
         }
+    }
+
+    @PreDestroy
+    public void destroy() {
+        adapters.forEach((adapter) -> adapter.destroy());
     }
 
     @Override

--- a/features/telemetry/daemon/src/main/java/org/opennms/netmgt/telemetry/daemon/Telemetryd.java
+++ b/features/telemetry/daemon/src/main/java/org/opennms/netmgt/telemetry/daemon/Telemetryd.java
@@ -162,6 +162,7 @@ public class Telemetryd implements SpringServiceDaemon {
         }
         dispatchers.clear();
 
+        final AutowireCapableBeanFactory beanFactory = applicationContext.getAutowireCapableBeanFactory();
         // Stop the consumers
         for (TelemetryMessageConsumer consumer : consumers) {
             try {
@@ -170,6 +171,7 @@ public class Telemetryd implements SpringServiceDaemon {
             } catch (Exception e) {
                 LOG.error("Error while stopping consumer.", e);
             }
+            beanFactory.destroyBean(consumer);
         }
         consumers.clear();
 


### PR DESCRIPTION
Add generic fileUpdateWatcher,   use this watcher for groovy scripts.
When groovy script file updates, check and load updated script if it builds else use existing script.

* JIRA: http://issues.opennms.org/browse/HZN-1279

Our [continuous integration system](http://bamboo.internal.opennms.com:8085) will test and verify your changes.
