### PR TITLE
NMS-9936 - OID for new Cisco CallManager

### DIFF
--- a/opennms-base-assembly/src/main/filtered/etc/datacollection/cisco.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/datacollection/cisco.xml
@@ -984,6 +984,12 @@
          <includeGroup>cisco-ccm</includeGroup>
       </collect>
    </systemDef>
+   <systemDef name="Cisco Virtual CallManager">
+      <sysoid>.1.3.6.1.4.1.9.1.1348</sysoid>
+      <collect>
+         <includeGroup>cisco-ccm</includeGroup>
+      </collect>
+   </systemDef>
    <systemDef name="Cisco ACE Load Balancer 10K9">
       <sysoid>.1.3.6.1.4.1.9.1.730</sysoid>
       <collect>


### PR DESCRIPTION
The sysoid for current Cisco CallManager releases has change since they moved from a hardware appliance to a virtual appliance.  This change adds a second systemDef block to catch the virtual appliance.

NMS-9936 - Datacollection for Cisco Call Manager as old OID

* JIRA: https://issues.opennms.org/browse/NMS-9936
