### PR TITLE
HZN-1301: Improve service lookup reliability by adding a relative timeout

### DIFF
--- a/core/soa/src/main/java/org/opennms/core/soa/lookup/BlockingServiceLookup.java
+++ b/core/soa/src/main/java/org/opennms/core/soa/lookup/BlockingServiceLookup.java
@@ -70,8 +70,10 @@ public class BlockingServiceLookup implements ServiceLookup {
 
         // A service matching the filter is not currently available.
         // Wait until the system has finished starting up (uptime >= grace period)
-        // before aborting the search.
-        while (uptimeSupplier.get() < this.gracePeriodInMs) {
+        // while ensuring we've waited for at least WAIT_PERIOD_MS before aborting the search.
+        final long waitUntil = System.currentTimeMillis() + ServiceLookupBuilder.WAIT_PERIOD_MS;
+        while (uptimeSupplier.get() < this.gracePeriodInMs
+                && System.currentTimeMillis() < waitUntil) {
             try {
                 Thread.sleep(this.lookupDelayMs);
             } catch (InterruptedException e) {

--- a/core/soa/src/main/java/org/opennms/core/soa/lookup/ServiceLookupBuilder.java
+++ b/core/soa/src/main/java/org/opennms/core/soa/lookup/ServiceLookupBuilder.java
@@ -30,15 +30,18 @@ package org.opennms.core.soa.lookup;
 
 import java.lang.management.ManagementFactory;
 import java.util.Objects;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
 import org.opennms.core.soa.ServiceRegistry;
 
 public class ServiceLookupBuilder {
 
-    public static final long GRACE_PERIOD_MS = Long.getLong("org.opennms.core.soa.lookup.gracePeriodMs", 3 * 60 * 1000);
+    public static final long GRACE_PERIOD_MS = Long.getLong("org.opennms.core.soa.lookup.gracePeriodMs", TimeUnit.MINUTES.toMillis(5));
 
-    public static final long LOOKUP_DELAY_MS = Long.getLong("org.opennms.core.soa.lookup.lookupDelayMs", 5 * 1000);
+    public static final long WAIT_PERIOD_MS = Long.getLong("org.opennms.core.soa.lookup.gracePeriodMs", TimeUnit.MINUTES.toMillis(1));
+
+    public static final long LOOKUP_DELAY_MS = Long.getLong("org.opennms.core.soa.lookup.lookupDelayMs", TimeUnit.SECONDS.toMillis(5));
 
     private final ServiceRegistry registry;
     private long gracePeriodInMs;


### PR DESCRIPTION
JIRA: https://issues.opennms.org/browse/HZN-1301

Fix intermittent telemetryd adapter loading when the startup process takes a long time.
