### PR TITLE
NMS-9910: Update OffsetProvider to connect to alternate brokers

### DIFF
--- a/core/ipc/sink/kafka-impl/src/main/java/org/opennms/core/ipc/sink/kafka/offset/HostAndPort.java
+++ b/core/ipc/sink/kafka-impl/src/main/java/org/opennms/core/ipc/sink/kafka/offset/HostAndPort.java
@@ -32,20 +32,50 @@ public class HostAndPort {
 
     private String host;
     private int port;
+    private static String[] hostAndPortArray;
 
-    public final static HostAndPort fromString(final String hostWithPort) {
+    public final static HostAndPort fromString(String hostWithPort) {
+        hostWithPort = hostWithPort.replaceAll("\\s+", "");
+        hostAndPortArray = hostWithPort.split(",");
+        return getHostAndPort(hostAndPortArray[0]);
+    }
 
+    public static HostAndPort getNextHostAndPort(HostAndPort hostAndPort) {
+        String hostWithPort = hostAndPort.getHost() + ":" + hostAndPort.getPort();
+        if (hostAndPortArray.length == 0) {
+            return null;
+        } else {
+            hostWithPort = getNextHost(hostWithPort);
+        }
+        if (hostWithPort == null) {
+            return null;
+        }
+        return getHostAndPort(hostWithPort);
+    }
+
+    private static HostAndPort getHostAndPort(String hostWithPort) {
         int i = hostWithPort.lastIndexOf(":");
         if (i < 0 || (hostWithPort.length() == i)) {
             return null;
         }
         String[] hostWithPortArray = { hostWithPort.substring(0, i), hostWithPort.substring(i + 1) };
-
         HostAndPort hostAndPort = new HostAndPort();
         hostAndPort.setHost(hostWithPortArray[0]);
         hostAndPort.setPort(Integer.parseInt(hostWithPortArray[1]));
         return hostAndPort;
+    }
 
+    private static String getNextHost(String hostWithPort) {
+        int len = hostAndPortArray.length;
+        for (int i = 0; i < len; i++) {
+            if (hostWithPort.equals(hostAndPortArray[i]) && i != (len - 1)) {
+                return hostAndPortArray[i + 1];
+            }
+        }
+        if (hostWithPort.equals(hostAndPortArray[len - 1])) {
+            return hostAndPortArray[0];
+        }
+        return null;
     }
 
     public String getHost() {

--- a/core/ipc/sink/kafka-impl/src/test/java/org/opennms/core/ipc/sink/kafka/offset/HostAndPortTest.java
+++ b/core/ipc/sink/kafka-impl/src/test/java/org/opennms/core/ipc/sink/kafka/offset/HostAndPortTest.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2018 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2018 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.core.ipc.sink.kafka.offset;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class HostAndPortTest {
+
+    @Test
+    public void testHostAndPortWithMultipleBrokers() {
+        String kafkaHostString = "kafka:9092 , 127.0.0.1:9093 , 128.0.0.1:9094";
+        HostAndPort hostAndPort = HostAndPort.fromString(kafkaHostString);
+        assertEquals(9092, hostAndPort.getPort());
+        assertEquals("kafka", hostAndPort.getHost());
+        hostAndPort = HostAndPort.getNextHostAndPort(hostAndPort);
+        assertEquals(9093, hostAndPort.getPort());
+        assertEquals("127.0.0.1", hostAndPort.getHost());
+        hostAndPort = HostAndPort.getNextHostAndPort(hostAndPort);
+        assertEquals(9094, hostAndPort.getPort());
+        assertEquals("128.0.0.1", hostAndPort.getHost());
+        hostAndPort = HostAndPort.getNextHostAndPort(hostAndPort);
+        assertEquals(9092, hostAndPort.getPort());
+        assertEquals("kafka", hostAndPort.getHost());
+        kafkaHostString = "kafka:9092";
+        hostAndPort = HostAndPort.fromString(kafkaHostString);
+        assertEquals(9092, hostAndPort.getPort());
+        assertEquals("kafka", hostAndPort.getHost());
+        hostAndPort = HostAndPort.getNextHostAndPort(hostAndPort);
+        assertEquals(9092, hostAndPort.getPort());
+        assertEquals("kafka", hostAndPort.getHost());
+    }
+}


### PR DESCRIPTION
Support multiple brokers in kafka server configuration for offset calculation, Try other brokers in config.
If any of them doesn't connect in 1 minute, try another. Keep trying from the list

* JIRA: http://issues.opennms.org/browse/NMS-9910

Our [continuous integration system](http://bamboo.internal.opennms.com:8085) will test and verify your changes.
