### PR TITLE
NMS-10069: replaced default downtime model config in the doc

### DIFF
--- a/opennms-doc/guide-admin/src/asciidoc/text/service-assurance/downtime-model.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/service-assurance/downtime-model.adoc
@@ -23,12 +23,12 @@ The scheduler changed the polling interval back to 5 minutes.
 .Example default configuration of the Downtime Model
 [source, xml]
 ----
-<downtime interval="30000" begin="0" end="300000" /><1>
-<downtime interval="300000" begin="300000" end="43200000" /><2>
-<downtime interval="600000" begin="43200000" end="432000000" /><3>
-<downtime begin="432000000" delete="true" /><4>
+<downtime interval="30000" begin="0" end="300000" /><!-- 30s, 0, 5m --><1>
+<downtime interval="300000" begin="300000" end="43200000" /><!-- 5m, 5m, 12h --><2>
+<downtime interval="600000" begin="43200000" end="432000000" /><!-- 10m, 12h, 5d --><3>
+<downtime interval="3600000" begin="432000000" /><!-- 1h, 5d --><4>
 ----
 <1> from 0 seconds after an outage is detected until 5 minutes the polling interval will be set to 30 seconds
 <2> after 5 minutes of an ongoing outage until 12 hours the polling interval will be set to 5 minutes
 <3> after 12 hours of an ongoing outage until 5 days the polling interval will be set to 10 minutes
-<4> after 5 days of an ongoing outage the service will be deleted from the monitoring system
+<4> after 5 days of an ongoing outage the service will polled only once a hour


### PR DESCRIPTION

* Documentation needed an update because of the changes in: https://issues.opennms.org/browse/NMS-9257
* Jira: https://issues.opennms.org/browse/NMS-10069

