### PR TITLE
NMS-10138: Remove Power over Ethernet MIB data collection by default

### DIFF
--- a/opennms-base-assembly/src/main/filtered/etc/datacollection-config.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/datacollection-config.xml
@@ -65,6 +65,7 @@
       <include-collection dataCollectionGroup="Powerware"/>
       <include-collection dataCollectionGroup="Printers"/>
       <include-collection dataCollectionGroup="REF_Compaq-Insight-Manager"/>
+      <include-collection dataCollectionGroup="REF_MIB2-Powerethernet"/>
       <include-collection dataCollectionGroup="Riverbed"/>
       <include-collection dataCollectionGroup="Routers"/>
       <include-collection dataCollectionGroup="Savin or Ricoh Printers"/>

--- a/opennms-base-assembly/src/main/filtered/etc/datacollection/mib2.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/datacollection/mib2.xml
@@ -84,10 +84,6 @@
       <mibObj oid=".1.3.6.1.2.1.10.132.4.1.2" instance="0" alias="coffeePotLevel" type="integer"/>
       <mibObj oid=".1.3.6.1.2.1.10.132.4.1.6" instance="0" alias="coffeePotTemp" type="integer"/>
    </group>
-   <group name="mib2-powerethernet" ifType="all">
-      <mibObj oid="1.3.6.1.2.1.105.1.3.1.1.2" instance="pethMainPseGroupIndex" alias="pethMainPsePower" type="gauge"/>
-      <mibObj oid="1.3.6.1.2.1.105.1.3.1.1.4" instance="pethMainPseGroupIndex" alias="pethMainPseConPower" type="gauge"/>
-   </group>
    <group name="mib2-tcp" ifType="ignore">
       <mibObj oid=".1.3.6.1.2.1.6.5" instance="0" alias="tcpActiveOpens" type="Counter32"/>
       <mibObj oid=".1.3.6.1.2.1.6.6" instance="0" alias="tcpPassiveOpens" type="Counter32"/>
@@ -160,7 +156,6 @@
       <collect>
          <includeGroup>mib2-interfaces</includeGroup>
          <includeGroup>mib2-tcp</includeGroup>
-         <includeGroup>mib2-powerethernet</includeGroup>
       </collect>
    </systemDef>
 </datacollection-group>

--- a/opennms-base-assembly/src/main/filtered/etc/datacollection/netsnmp.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/datacollection/netsnmp.xml
@@ -175,7 +175,6 @@
       <collect>
          <includeGroup>mib2-interfaces</includeGroup>
          <includeGroup>mib2-tcp</includeGroup>
-         <includeGroup>mib2-powerethernet</includeGroup>
          <includeGroup>mib2-host-resources-system</includeGroup>
          <includeGroup>mib2-host-resources-memory</includeGroup>
          <includeGroup>mib2-X-interfaces</includeGroup>

--- a/opennms-base-assembly/src/main/filtered/etc/datacollection/ref_mib2-powerethernet.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/datacollection/ref_mib2-powerethernet.xml
@@ -1,0 +1,10 @@
+<datacollection-group xmlns="http://xmlns.opennms.org/xsd/config/datacollection" name="REF_MIB2-Powerethernet">
+    <resourceType name="pethMainPseGroupIndex" label="Power Ethernet (MIB-2 powerEthernet)">
+        <persistenceSelectorStrategy class="org.opennms.netmgt.collection.support.PersistAllSelectorStrategy"/>
+        <storageStrategy class="org.opennms.netmgt.collection.support.IndexStorageStrategy"/>
+    </resourceType>
+    <group name="mib2-powerethernet" ifType="all">
+        <mibObj oid=".1.3.6.1.2.1.105.1.3.1.1.2" instance="pethMainPseGroupIndex" alias="pethMainPsePower" type="gauge"/>
+        <mibObj oid=".1.3.6.1.2.1.105.1.3.1.1.4" instance="pethMainPseGroupIndex" alias="pethMainPseConPower" type="gauge"/>
+    </group>
+</datacollection-group>


### PR DESCRIPTION
Remove Power over Ethernet MIB data collection from all SNMP agents supporting Standard MIB-II and from Net-SNMP agents by default. For the reason they can be added to any Vendor who supports the standard PoE MIB it is added and included as a Reference file (REF_...) and can included to any vendor who supports it.

* JIRA: http://issues.opennms.org/browse/NMS-10138
