### PR TITLE
NMS-10139: Make 64bit interface counter default

### DIFF
--- a/opennms-base-assembly/src/main/filtered/etc/datacollection-config.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/datacollection-config.xml
@@ -65,6 +65,7 @@
       <include-collection dataCollectionGroup="Powerware"/>
       <include-collection dataCollectionGroup="Printers"/>
       <include-collection dataCollectionGroup="REF_Compaq-Insight-Manager"/>
+      <include-collection dataCollectionGroup="REF_MIB2-Interfaces"/>
       <include-collection dataCollectionGroup="REF_MIB2-Powerethernet"/>
       <include-collection dataCollectionGroup="Riverbed"/>
       <include-collection dataCollectionGroup="Routers"/>

--- a/opennms-base-assembly/src/main/filtered/etc/datacollection/legacy_mib2-interfaces.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/datacollection/legacy_mib2-interfaces.xml
@@ -1,0 +1,8 @@
+<datacollection-group xmlns="http://xmlns.opennms.org/xsd/config/datacollection" name="Legacy_MIB2-Interfaces">
+   <systemDef name="Legacy MIB-2 Interfaces">
+      <sysoidMask>.1.3.6.1.4.1.</sysoidMask>
+      <collect>
+         <includeGroup>mib2-interfaces</includeGroup>
+      </collect>
+   </systemDef>
+</datacollection-group>

--- a/opennms-base-assembly/src/main/filtered/etc/datacollection/mib2.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/datacollection/mib2.xml
@@ -23,20 +23,6 @@
       <persistenceSelectorStrategy class="org.opennms.netmgt.collection.support.PersistAllSelectorStrategy"/>
       <storageStrategy class="org.opennms.netmgt.collection.support.IndexStorageStrategy"/>
    </resourceType>
-   <group name="mib2-interfaces" ifType="all">
-      <mibObj oid=".1.3.6.1.2.1.2.2.1.2" instance="ifIndex" alias="ifDescr" type="string"/>
-      <mibObj oid=".1.3.6.1.2.1.2.2.1.5" instance="ifIndex" alias="ifSpeed" type="string"/>
-      <mibObj oid=".1.3.6.1.2.1.2.2.1.10" instance="ifIndex" alias="ifInOctets" type="counter"/>
-      <mibObj oid=".1.3.6.1.2.1.2.2.1.11" instance="ifIndex" alias="ifInUcastpkts" type="counter"/>
-      <mibObj oid=".1.3.6.1.2.1.2.2.1.12" instance="ifIndex" alias="ifInNUcastpkts" type="counter"/>
-      <mibObj oid=".1.3.6.1.2.1.2.2.1.13" instance="ifIndex" alias="ifInDiscards" type="counter"/>
-      <mibObj oid=".1.3.6.1.2.1.2.2.1.14" instance="ifIndex" alias="ifInErrors" type="counter"/>
-      <mibObj oid=".1.3.6.1.2.1.2.2.1.16" instance="ifIndex" alias="ifOutOctets" type="counter"/>
-      <mibObj oid=".1.3.6.1.2.1.2.2.1.17" instance="ifIndex" alias="ifOutUcastPkts" type="counter"/>
-      <mibObj oid=".1.3.6.1.2.1.2.2.1.18" instance="ifIndex" alias="ifOutNUcastPkts" type="counter"/>
-      <mibObj oid=".1.3.6.1.2.1.2.2.1.19" instance="ifIndex" alias="ifOutDiscards" type="counter"/>
-      <mibObj oid=".1.3.6.1.2.1.2.2.1.20" instance="ifIndex" alias="ifOutErrors" type="counter"/>
-   </group>
    <group name="mib2-X-interfaces" ifType="all">
       <mibObj oid=".1.3.6.1.2.1.31.1.1.1.1" instance="ifIndex" alias="ifName" type="string"/>
       <mibObj oid=".1.3.6.1.2.1.31.1.1.1.15" instance="ifIndex" alias="ifHighSpeed" type="string"/>
@@ -154,7 +140,7 @@
    <systemDef name="Enterprise">
       <sysoidMask>.1.3.6.1.4.1.</sysoidMask>
       <collect>
-         <includeGroup>mib2-interfaces</includeGroup>
+         <includeGroup>mib2-X-interfaces</includeGroup>
          <includeGroup>mib2-tcp</includeGroup>
       </collect>
    </systemDef>

--- a/opennms-base-assembly/src/main/filtered/etc/datacollection/ref_mib2-interfaces.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/datacollection/ref_mib2-interfaces.xml
@@ -1,0 +1,16 @@
+<datacollection-group xmlns="http://xmlns.opennms.org/xsd/config/datacollection" name="REF_MIB2-Interfaces">
+   <group name="mib2-interfaces" ifType="all">
+      <mibObj oid=".1.3.6.1.2.1.2.2.1.2" instance="ifIndex" alias="ifDescr" type="string"/>
+      <mibObj oid=".1.3.6.1.2.1.2.2.1.5" instance="ifIndex" alias="ifSpeed" type="string"/>
+      <mibObj oid=".1.3.6.1.2.1.2.2.1.10" instance="ifIndex" alias="ifInOctets" type="counter"/>
+      <mibObj oid=".1.3.6.1.2.1.2.2.1.11" instance="ifIndex" alias="ifInUcastpkts" type="counter"/>
+      <mibObj oid=".1.3.6.1.2.1.2.2.1.12" instance="ifIndex" alias="ifInNUcastpkts" type="counter"/>
+      <mibObj oid=".1.3.6.1.2.1.2.2.1.13" instance="ifIndex" alias="ifInDiscards" type="counter"/>
+      <mibObj oid=".1.3.6.1.2.1.2.2.1.14" instance="ifIndex" alias="ifInErrors" type="counter"/>
+      <mibObj oid=".1.3.6.1.2.1.2.2.1.16" instance="ifIndex" alias="ifOutOctets" type="counter"/>
+      <mibObj oid=".1.3.6.1.2.1.2.2.1.17" instance="ifIndex" alias="ifOutUcastPkts" type="counter"/>
+      <mibObj oid=".1.3.6.1.2.1.2.2.1.18" instance="ifIndex" alias="ifOutNUcastPkts" type="counter"/>
+      <mibObj oid=".1.3.6.1.2.1.2.2.1.19" instance="ifIndex" alias="ifOutDiscards" type="counter"/>
+      <mibObj oid=".1.3.6.1.2.1.2.2.1.20" instance="ifIndex" alias="ifOutErrors" type="counter"/>
+   </group>
+</datacollection-group>

--- a/opennms-doc/releasenotes/src/asciidoc/releasenotes/whatsnew.adoc
+++ b/opennms-doc/releasenotes/src/asciidoc/releasenotes/whatsnew.adoc
@@ -96,6 +96,42 @@ For more details please refer to link:../guide-admin/index.html#configure-elasti
 * The configuration of the _Elasticsearch ReST plugin_ has changed. Please refer to <<releasenotes-22-opennms-es-rest-properties>>.
 * The index creation of the _Elasticsearch ReST plugin_ has changed and is now configurable. Please refer to <<releasenotes-22-opennms-es-rest-index-properties>>.
 * The _Elasticsearch ReST plugin_ no longer supports ElasticSearch version 2.4. A version >= 5.x must be used.
+* By default the data collection gathered data twice from SNMP agents supporting the MIB-II with 32bit and 64bit counter on network interfaces.
+  The default 32bit interface counters are no disabled by default and only 64bit counters are collected.
+
+IMPORTANT: If you have legacy SNMP agents which only support 32bit interface counters, the data collection for this interfaces will stop after you upgraded to 22.0.0.
+           To get them enabled, you have to create a data collection package and add the `mib2-interfaces` data collection group manually for this devices with the example below.
+
+.Example to collect 32bit MIB-2 Interface counter from nodes in a category configured in collectd-configuration.xml
+[source, xml]
+----
+<package name="Legacy-MIB2-Interfaces" remote="false">
+    <filter>categoryName == 'Legacy-MIB2-Interfaces'</filter>
+    <include-range begin="1.1.1.1" end="254.254.254.254"/>
+    <include-range begin="::1" end="ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"/>
+
+    <service name="SNMP" interval="300000" user-defined="false" status="on">
+        <parameter key="collection" value="legacy-32bit-mib2"/>
+        <parameter key="thresholding-enabled" value="true"/>
+    </service>
+</package>
+----
+
+.Load the Legacy MIB-2 Interfaces metrics configured in the datacollection-config.xml
+[source, xml]
+----
+<snmp-collection name="legacy-32bit-mib2" snmpStorageFlag="select">
+    <rrd step="300">
+        <rra>RRA:AVERAGE:0.5:1:2016</rra>
+        <rra>RRA:AVERAGE:0.5:12:1488</rra>
+        <rra>RRA:AVERAGE:0.5:288:366</rra>
+        <rra>RRA:MAX:0.5:288:366</rra>
+        <rra>RRA:MIN:0.5:288:366</rra>
+    </rrd>
+    <include-collection dataCollectionGroup="Legacy_MIB2-Interfaces"/>
+    <include-collection dataCollectionGroup="REF_MIB2-Interfaces"/>
+</snmp-collection>
+----
 
 === New Features
 


### PR DESCRIPTION
A lot of devices add 64bit counter additional to the 32bit counter. This means the interface metrics are collected twice. Make the 64bit counter default and just allow the user to add 32bit counter on legacy devices and reduce the data collection by default.

The old 32bit MIB-II interface counter is added as a reference file which is not assigned by default to any system definition. They need to be added to legacy devices which support only 32bit counter and not 64bit counter by default.

* JIRA: http://issues.opennms.org/browse/NMS-10139
