### PR TITLE
NMS-10140: Make Standard UPS MIB a reference

### DIFF
--- a/opennms-base-assembly/src/main/filtered/etc/datacollection-config.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/datacollection-config.xml
@@ -64,6 +64,7 @@
       <include-collection dataCollectionGroup="PostgreSQL-JDBC"/>
       <include-collection dataCollectionGroup="Powerware"/>
       <include-collection dataCollectionGroup="Printers"/>
+      <include-collection dataCollectionGroup="REF_MIB2-UPS"/>
       <include-collection dataCollectionGroup="Riverbed"/>
       <include-collection dataCollectionGroup="Routers"/>
       <include-collection dataCollectionGroup="Savin or Ricoh Printers"/>

--- a/opennms-base-assembly/src/main/filtered/etc/datacollection/mib2.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/datacollection/mib2.xml
@@ -100,22 +100,6 @@
       <mibObj oid=".1.3.6.1.2.1.6.14" instance="0" alias="tcpInErrors" type="Counter32"/>
       <mibObj oid=".1.3.6.1.2.1.6.15" instance="0" alias="tcpOutRsts" type="Counter32"/>
    </group>
-   <group name="mib2-ups-rfc1628" ifType="ignore">
-      <mibObj oid=".1.3.6.1.2.1.33.1.2.2" instance="0" alias="upsSecondsOnBattery" type="Integer32"/>
-      <mibObj oid=".1.3.6.1.2.1.33.1.2.3" instance="0" alias="upsEstMinsRemain" type="Integer32"/>
-      <mibObj oid=".1.3.6.1.2.1.33.1.2.4" instance="0" alias="upsEstChargeRemain" type="Integer32"/>
-      <mibObj oid=".1.3.6.1.2.1.33.1.2.5" instance="0" alias="upsBatteryVoltage" type="Integer32"/>
-      <mibObj oid=".1.3.6.1.2.1.33.1.2.6" instance="0" alias="upsBatteryCurrent" type="Integer32"/>
-      <mibObj oid=".1.3.6.1.2.1.33.1.2.7" instance="0" alias="upsBatteryTemp" type="Integer32"/>
-      <mibObj oid=".1.3.6.1.2.1.33.1.3.3.1.2" instance="1" alias="upsInputFrequency1" type="Integer32"/>
-      <mibObj oid=".1.3.6.1.2.1.33.1.3.3.1.3" instance="1" alias="upsInputVoltage1" type="Integer32"/>
-      <mibObj oid=".1.3.6.1.2.1.33.1.4.1" instance="0" alias="upsOutputSource" type="Integer32"/>
-      <mibObj oid=".1.3.6.1.2.1.33.1.4.2" instance="0" alias="upsOutputFrequency" type="Integer32"/>
-      <mibObj oid=".1.3.6.1.2.1.33.1.4.4.1.2" instance="1" alias="upsOutputVoltage1" type="Integer32"/>
-      <mibObj oid=".1.3.6.1.2.1.33.1.4.4.1.3" instance="1" alias="upsOutputCurrent1" type="Integer32"/>
-      <mibObj oid=".1.3.6.1.2.1.33.1.4.4.1.4" instance="1" alias="upsOutputPower1" type="Integer32"/>
-      <mibObj oid=".1.3.6.1.2.1.33.1.4.4.1.5" instance="1" alias="upsOutputLoad1" type="Integer32"/>
-   </group>
    <group name="mib2-host-resources-storage" ifType="all">
       <mibObj oid=".1.3.6.1.2.1.25.2.3.1.2" instance="hrStorageIndex" alias="hrStorageType" type="string"/>
       <mibObj oid=".1.3.6.1.2.1.25.2.3.1.3" instance="hrStorageIndex" alias="hrStorageDescr" type="string"/>

--- a/opennms-base-assembly/src/main/filtered/etc/datacollection/ref_mib2-ups.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/datacollection/ref_mib2-ups.xml
@@ -1,0 +1,18 @@
+<datacollection-group xmlns="http://xmlns.opennms.org/xsd/config/datacollection" name="REF_MIB2-UPS">
+   <group name="mib2-ups-rfc1628" ifType="ignore">
+      <mibObj oid=".1.3.6.1.2.1.33.1.2.2" instance="0" alias="upsSecondsOnBattery" type="Integer32"/>
+      <mibObj oid=".1.3.6.1.2.1.33.1.2.3" instance="0" alias="upsEstMinsRemain" type="Integer32"/>
+      <mibObj oid=".1.3.6.1.2.1.33.1.2.4" instance="0" alias="upsEstChargeRemain" type="Integer32"/>
+      <mibObj oid=".1.3.6.1.2.1.33.1.2.5" instance="0" alias="upsBatteryVoltage" type="Integer32"/>
+      <mibObj oid=".1.3.6.1.2.1.33.1.2.6" instance="0" alias="upsBatteryCurrent" type="Integer32"/>
+      <mibObj oid=".1.3.6.1.2.1.33.1.2.7" instance="0" alias="upsBatteryTemp" type="Integer32"/>
+      <mibObj oid=".1.3.6.1.2.1.33.1.3.3.1.2" instance="1" alias="upsInputFrequency1" type="Integer32"/>
+      <mibObj oid=".1.3.6.1.2.1.33.1.3.3.1.3" instance="1" alias="upsInputVoltage1" type="Integer32"/>
+      <mibObj oid=".1.3.6.1.2.1.33.1.4.1" instance="0" alias="upsOutputSource" type="Integer32"/>
+      <mibObj oid=".1.3.6.1.2.1.33.1.4.2" instance="0" alias="upsOutputFrequency" type="Integer32"/>
+      <mibObj oid=".1.3.6.1.2.1.33.1.4.4.1.2" instance="1" alias="upsOutputVoltage1" type="Integer32"/>
+      <mibObj oid=".1.3.6.1.2.1.33.1.4.4.1.3" instance="1" alias="upsOutputCurrent1" type="Integer32"/>
+      <mibObj oid=".1.3.6.1.2.1.33.1.4.4.1.4" instance="1" alias="upsOutputPower1" type="Integer32"/>
+      <mibObj oid=".1.3.6.1.2.1.33.1.4.4.1.5" instance="1" alias="upsOutputLoad1" type="Integer32"/>
+   </group>
+</datacollection-group>


### PR DESCRIPTION
Set the Standard UPS MIB as a reference, cause it is required to add it manually to the vendors who support it.

* JIRA: http://issues.opennms.org/browse/NMS-10140

