### PR TITLE
NMS-10141: Remove overlapping MIB-2 64bit counter configs

### DIFF
--- a/opennms-base-assembly/src/main/filtered/etc/datacollection/cisco.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/datacollection/cisco.xml
@@ -970,7 +970,6 @@
          <includeGroup>cisco-rttmon-latest-rtp-stats</includeGroup>
          <includeGroup>rfc1315-frame-relay</includeGroup>
          <includeGroup>cisco-frame-relay</includeGroup>
-         <includeGroup>mib2-X-interfaces</includeGroup>
          <includeGroup>mib2-X-interfaces-pkts</includeGroup>
          <includeGroup>ietf-bgp4-peer-stats</includeGroup>
          <includeGroup>cisco-bgp-peer-addr-family-prefix-stats</includeGroup>

--- a/opennms-base-assembly/src/main/filtered/etc/datacollection/ciscoNexus.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/datacollection/ciscoNexus.xml
@@ -32,7 +32,6 @@
       <sysoid>.1.3.6.1.4.1.9.12.3.1.3.840</sysoid>
       <collect>
          <includeGroup>cisco-process</includeGroup>
-         <includeGroup>mib2-X-interfaces</includeGroup>
          <includeGroup>cisco-nx-environmental</includeGroup>
       </collect>
    </systemDef>
@@ -40,7 +39,6 @@
       <sysoid>.1.3.6.1.4.1.9.12.3.1.3.907</sysoid>
       <collect>
          <includeGroup>cisco-process</includeGroup>
-         <includeGroup>mib2-X-interfaces</includeGroup>
          <includeGroup>cisco-nx-environmental</includeGroup>
       </collect>
    </systemDef>
@@ -49,7 +47,6 @@
       <sysoid>.1.3.6.1.4.1.9.12.3.1.3.1239</sysoid>
       <collect>
          <includeGroup>cisco-process</includeGroup>
-         <includeGroup>mib2-X-interfaces</includeGroup>
          <includeGroup>cisco-nx-environmental</includeGroup>
       </collect>
    </systemDef>
@@ -58,7 +55,6 @@
       <sysoid>.1.3.6.1.4.1.9.12.3.1.3.719</sysoid>
       <collect>
          <includeGroup>cisco-process</includeGroup>
-         <includeGroup>mib2-X-interfaces</includeGroup>
          <includeGroup>cisco-nx-environmental</includeGroup>
       </collect>
    </systemDef>
@@ -67,7 +63,6 @@
       <sysoid>.1.3.6.1.4.1.9.12.3.1.3.1008</sysoid>
       <collect>
          <includeGroup>cisco-process</includeGroup>
-         <includeGroup>mib2-X-interfaces</includeGroup>
          <includeGroup>cisco-nx-environmental</includeGroup>
       </collect>
    </systemDef>
@@ -76,7 +71,6 @@
       <sysoid>.1.3.6.1.4.1.9.12.3.1.3.1038</sysoid>
       <collect>
          <includeGroup>cisco-process</includeGroup>
-         <includeGroup>mib2-X-interfaces</includeGroup>
          <includeGroup>cisco-nx-environmental</includeGroup>
       </collect>
    </systemDef>
@@ -85,7 +79,6 @@
       <sysoid>.1.3.6.1.4.1.9.12.3.1.3.1147</sysoid>
       <collect>
          <includeGroup>cisco-nx-process-index</includeGroup>
-         <includeGroup>mib2-X-interfaces</includeGroup>
          <includeGroup>cisco-nx-environmental</includeGroup>
       </collect>
    </systemDef>
@@ -94,7 +87,6 @@
       <sysoid>.1.3.6.1.4.1.9.12.3.1.3.932</sysoid>
       <collect>
          <includeGroup>cisco-nx-process-index</includeGroup>
-         <includeGroup>mib2-X-interfaces</includeGroup>
          <includeGroup>cisco-nx-environmental</includeGroup>
       </collect>
    </systemDef>
@@ -103,7 +95,6 @@
       <sysoid>.1.3.6.1.4.1.9.12.3.1.3.612</sysoid>
       <collect>
          <includeGroup>cisco-nx-process-index</includeGroup>
-         <includeGroup>mib2-X-interfaces</includeGroup>
          <includeGroup>cisco-nx-environmental</includeGroup>
       </collect>
    </systemDef>
@@ -112,7 +103,6 @@
       <sysoid>.1.3.6.1.4.1.9.12.3.1.3.777</sysoid>
       <collect>
          <includeGroup>cisco-nx-process-index</includeGroup>
-         <includeGroup>mib2-X-interfaces</includeGroup>
          <includeGroup>cisco-nx-environmental</includeGroup>
       </collect>
    </systemDef>

--- a/opennms-base-assembly/src/main/filtered/etc/datacollection/extreme.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/datacollection/extreme.xml
@@ -6,7 +6,6 @@
       <sysoidMask>.1.3.6.1.4.1.1916.2.</sysoidMask>
       <collect>
          <includeGroup>extreme-sys</includeGroup>
-         <includeGroup>mib2-X-interfaces</includeGroup>
          <includeGroup>mib2-X-interfaces-pkts</includeGroup>
       </collect>
    </systemDef>

--- a/opennms-base-assembly/src/main/filtered/etc/datacollection/f5.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/datacollection/f5.xml
@@ -110,7 +110,6 @@
          <includeGroup>bigip-sys-global-cpu</includeGroup>
          <includeGroup>bigip-gtm-wideip-stats</includeGroup>
          <includeGroup>bigip-gtm-wideip-global-stats</includeGroup>
-         <includeGroup>mib2-X-interfaces</includeGroup>
       </collect>
    </systemDef>
 </datacollection-group>

--- a/opennms-base-assembly/src/main/filtered/etc/datacollection/force10.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/datacollection/force10.xml
@@ -12,7 +12,6 @@
    <systemDef name="Force10 10Gbe switches">
       <sysoidMask>.1.3.6.1.4.1.6027.</sysoidMask>
       <collect>
-         <includeGroup>mib2-X-interfaces</includeGroup>
          <includeGroup>mib2-X-interfaces-pkts</includeGroup>
          <includeGroup>force10-stack-unit-stats</includeGroup>
       </collect>

--- a/opennms-base-assembly/src/main/filtered/etc/datacollection/foundry.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/datacollection/foundry.xml
@@ -10,7 +10,6 @@
       <sysoidMask>.1.3.6.1.4.1.1991.1.</sysoidMask>
       <collect>
          <includeGroup>foundry-sys</includeGroup>
-         <includeGroup>mib2-X-interfaces</includeGroup>
          <includeGroup>mib2-X-interfaces-pkts</includeGroup>
       </collect>
    </systemDef>
@@ -18,7 +17,6 @@
       <sysoid>.1.3.6.1.4.1.1991.1.3.6.2</sysoid>
       <collect>
          <includeGroup>foundry-sys</includeGroup>
-         <includeGroup>mib2-X-interfaces</includeGroup>
          <includeGroup>mib2-X-interfaces-pkts</includeGroup>
          <includeGroup>ietf-bgp4-peer-stats</includeGroup>
       </collect>
@@ -27,7 +25,6 @@
       <sysoid>.1.3.6.1.4.1.1991.1.3.7.2</sysoid>
       <collect>
          <includeGroup>foundry-sys</includeGroup>
-         <includeGroup>mib2-X-interfaces</includeGroup>
          <includeGroup>mib2-X-interfaces-pkts</includeGroup>
          <includeGroup>ietf-bgp4-peer-stats</includeGroup>
       </collect>
@@ -36,7 +33,6 @@
       <sysoid>.1.3.6.1.4.1.1991.1.3.40.2.2</sysoid>
       <collect>
          <includeGroup>foundry-sys</includeGroup>
-         <includeGroup>mib2-X-interfaces</includeGroup>
          <includeGroup>mib2-X-interfaces-pkts</includeGroup>
          <includeGroup>ietf-bgp4-peer-stats</includeGroup>
       </collect>

--- a/opennms-base-assembly/src/main/filtered/etc/datacollection/juniper.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/datacollection/juniper.xml
@@ -130,7 +130,6 @@
       <sysoidMask>.1.3.6.1.4.1.2636.1.</sysoidMask>
       <collect>
          <includeGroup>juniper-router</includeGroup>
-         <includeGroup>mib2-X-interfaces</includeGroup>
          <includeGroup>mib2-X-interfaces-pkts</includeGroup>
          <includeGroup>ietf-bgp4-peer-stats</includeGroup>
       </collect>
@@ -141,7 +140,6 @@
          <includeGroup>juniper-erx-router</includeGroup>
          <includeGroup>juniper-erx-systemslot</includeGroup>
          <includeGroup>juniper-erx-temperature</includeGroup>
-         <includeGroup>mib2-X-interfaces</includeGroup>
          <includeGroup>mib2-X-interfaces-pkts</includeGroup>
       </collect>
    </systemDef>

--- a/opennms-base-assembly/src/main/filtered/etc/datacollection/netsnmp.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/datacollection/netsnmp.xml
@@ -152,7 +152,6 @@
          <includeGroup>mib2-host-resources-system</includeGroup>
          <includeGroup>mib2-host-resources-memory</includeGroup>
          <includeGroup>mib2-host-resources-storage</includeGroup>
-         <includeGroup>mib2-X-interfaces</includeGroup>
          <includeGroup>mib2-X-interfaces-pkts</includeGroup>
          <includeGroup>net-snmp-disk</includeGroup>
          <includeGroup>net-snmp-disk-more</includeGroup>

--- a/opennms-base-assembly/src/main/filtered/etc/datacollection/paloalto.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/datacollection/paloalto.xml
@@ -62,7 +62,6 @@
       <collect>
          <includeGroup>pan-global-protect</includeGroup>
          <includeGroup>pan-vsys-sessions</includeGroup>
-         <includeGroup>mib2-X-interfaces</includeGroup>
          <includeGroup>mib2-X-interfaces-pkts</includeGroup>
          <includeGroup>mib2-host-resources-storage</includeGroup>
          <includeGroup>mib2-host-resources-system</includeGroup>
@@ -77,7 +76,6 @@
       <collect>
          <includeGroup>pan-global-protect</includeGroup>
          <includeGroup>pan-vsys-sessions</includeGroup>
-         <includeGroup>mib2-X-interfaces</includeGroup>
          <includeGroup>mib2-X-interfaces-pkts</includeGroup>
          <includeGroup>mib2-host-resources-storage</includeGroup>
          <includeGroup>mib2-host-resources-system</includeGroup>
@@ -92,7 +90,6 @@
       <collect>
          <includeGroup>pan-global-protect</includeGroup>
          <includeGroup>pan-vsys-sessions</includeGroup>
-         <includeGroup>mib2-X-interfaces</includeGroup>
          <includeGroup>mib2-X-interfaces-pkts</includeGroup>
          <includeGroup>mib2-host-resources-storage</includeGroup>
          <includeGroup>mib2-host-resources-system</includeGroup>
@@ -107,7 +104,6 @@
       <collect>
          <includeGroup>pan-global-protect</includeGroup>
          <includeGroup>pan-vsys-sessions</includeGroup>
-         <includeGroup>mib2-X-interfaces</includeGroup>
          <includeGroup>mib2-X-interfaces-pkts</includeGroup>
          <includeGroup>mib2-host-resources-storage</includeGroup>
          <includeGroup>mib2-host-resources-system</includeGroup>
@@ -122,7 +118,6 @@
       <collect>
          <includeGroup>pan-global-protect</includeGroup>
          <includeGroup>pan-vsys-sessions</includeGroup>
-         <includeGroup>mib2-X-interfaces</includeGroup>
          <includeGroup>mib2-X-interfaces-pkts</includeGroup>
          <includeGroup>mib2-host-resources-storage</includeGroup>
          <includeGroup>mib2-host-resources-system</includeGroup>
@@ -137,7 +132,6 @@
       <collect>
          <includeGroup>pan-global-protect</includeGroup>
          <includeGroup>pan-vsys-sessions</includeGroup>
-         <includeGroup>mib2-X-interfaces</includeGroup>
          <includeGroup>mib2-X-interfaces-pkts</includeGroup>
          <includeGroup>mib2-host-resources-storage</includeGroup>
          <includeGroup>mib2-host-resources-system</includeGroup>
@@ -161,7 +155,6 @@
       <collect>
          <includeGroup>pan-global-protect</includeGroup>
          <includeGroup>pan-vsys-sessions</includeGroup>
-         <includeGroup>mib2-X-interfaces</includeGroup>
          <includeGroup>mib2-X-interfaces-pkts</includeGroup>
          <includeGroup>mib2-host-resources-storage</includeGroup>
          <includeGroup>mib2-host-resources-system</includeGroup>
@@ -176,7 +169,6 @@
       <collect>
          <includeGroup>pan-global-protect</includeGroup>
          <includeGroup>pan-vsys-sessions</includeGroup>
-         <includeGroup>mib2-X-interfaces</includeGroup>
          <includeGroup>mib2-X-interfaces-pkts</includeGroup>
          <includeGroup>mib2-host-resources-storage</includeGroup>
          <includeGroup>mib2-host-resources-system</includeGroup>
@@ -191,7 +183,6 @@
       <collect>
          <includeGroup>pan-global-protect</includeGroup>
          <includeGroup>pan-vsys-sessions</includeGroup>
-         <includeGroup>mib2-X-interfaces</includeGroup>
          <includeGroup>mib2-X-interfaces-pkts</includeGroup>
          <includeGroup>mib2-host-resources-storage</includeGroup>
          <includeGroup>mib2-host-resources-system</includeGroup>
@@ -205,7 +196,6 @@
       <sysoid>.1.3.6.1.4.1.25461.2.3.12</sysoid>
       <collect>
          <includeGroup>pan-global-protect</includeGroup>
-         <includeGroup>mib2-X-interfaces</includeGroup>
          <includeGroup>mib2-X-interfaces-pkts</includeGroup>
          <includeGroup>mib2-host-resources-storage</includeGroup>
          <includeGroup>mib2-host-resources-system</includeGroup>
@@ -220,7 +210,6 @@
       <collect>
          <includeGroup>pan-global-protect</includeGroup>
          <includeGroup>pan-vsys-sessions</includeGroup>
-         <includeGroup>mib2-X-interfaces</includeGroup>
          <includeGroup>mib2-X-interfaces-pkts</includeGroup>
          <includeGroup>mib2-host-resources-storage</includeGroup>
          <includeGroup>mib2-host-resources-system</includeGroup>
@@ -235,7 +224,6 @@
       <collect>
          <includeGroup>pan-global-protect</includeGroup>
          <includeGroup>pan-vsys-sessions</includeGroup>
-         <includeGroup>mib2-X-interfaces</includeGroup>
          <includeGroup>mib2-X-interfaces-pkts</includeGroup>
          <includeGroup>mib2-host-resources-storage</includeGroup>
          <includeGroup>mib2-host-resources-system</includeGroup>
@@ -250,7 +238,6 @@
       <collect>
          <includeGroup>pan-global-protect</includeGroup>
          <includeGroup>pan-vsys-sessions</includeGroup>
-         <includeGroup>mib2-X-interfaces</includeGroup>
          <includeGroup>mib2-X-interfaces-pkts</includeGroup>
          <includeGroup>mib2-host-resources-storage</includeGroup>
          <includeGroup>mib2-host-resources-system</includeGroup>

--- a/opennms-base-assembly/src/main/filtered/etc/datacollection/pfsense.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/datacollection/pfsense.xml
@@ -105,7 +105,6 @@
          <includeGroup>mib2-host-resources-memory</includeGroup>
          <!-- hrStorage is problematic on pfSense, over 200 instances on 2.0.1 -->
          <!-- <includeGroup>mib2-host-resources-storage</includeGroup> -->
-         <includeGroup>mib2-X-interfaces</includeGroup>
          <includeGroup>mib2-X-interfaces-pkts</includeGroup>
          <includeGroup>pfsense-system-scalars</includeGroup>
          <includeGroup>pfsense-statetable-scalars</includeGroup>

--- a/opennms-base-assembly/src/main/filtered/etc/datacollection/riverbed.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/datacollection/riverbed.xml
@@ -51,7 +51,6 @@
    <systemDef name="Riverbed Steelhead WAN Accelerators">
       <sysoid>.1.3.6.1.4.1.17163.1.1</sysoid>
       <collect>
-         <includeGroup>mib2-X-interfaces</includeGroup>
          <includeGroup>mib2-X-interfaces-pkts</includeGroup>
          <includeGroup>riverbed-steelhead-scalars</includeGroup>
          <includeGroup>riverbed-steelhead-cpu-stats</includeGroup>


### PR DESCRIPTION
Remove overlapping MIB-II overlapping 64bit interface counter from default, cause they are already collected by default from MIB-2 Interface configuration. More details are described in JIRA.

This PR depends on PR #1964 

* JIRA: http://issues.opennms.org/browse/NMS-10141

