### PR TITLE
NMS-10142: Remove checkpoint data collection from all Windows servers

### DIFF
--- a/opennms-base-assembly/src/main/filtered/etc/datacollection/microsoft.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/datacollection/microsoft.xml
@@ -23,7 +23,6 @@
    <systemDef name="Microsoft Windows NT/2000">
       <sysoidMask>.1.3.6.1.4.1.311.1.1.3.1.</sysoidMask>
       <collect>
-         <includeGroup>checkpoint</includeGroup>
          <includeGroup>domino-stats</includeGroup>
          <includeGroup>microsoft-http</includeGroup>
          <includeGroup>snmpinformant-cpu</includeGroup>


### PR DESCRIPTION
Remove by default Checkpoint firewall SNMP metrics from every Windows server

* JIRA: http://issues.opennms.org/browse/NMS-10142
