### PR TITLE
NMS-10143: Remove by default to collect Compaq Insight Manager stats

### DIFF
--- a/opennms-base-assembly/src/main/filtered/etc/datacollection-config.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/datacollection-config.xml
@@ -64,6 +64,7 @@
       <include-collection dataCollectionGroup="PostgreSQL-JDBC"/>
       <include-collection dataCollectionGroup="Powerware"/>
       <include-collection dataCollectionGroup="Printers"/>
+      <include-collection dataCollectionGroup="REF_Compaq-Insight-Manager"/>
       <include-collection dataCollectionGroup="Riverbed"/>
       <include-collection dataCollectionGroup="Routers"/>
       <include-collection dataCollectionGroup="Savin or Ricoh Printers"/>

--- a/opennms-base-assembly/src/main/filtered/etc/datacollection/hp.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/datacollection/hp.xml
@@ -8,11 +8,6 @@
          <parameter key="replace-all" value="s/\s//"/>
       </storageStrategy>
    </resourceType>
-   <group name="compaq-insight-manager-stats" ifType="ignore">
-      <mibObj oid=".1.3.6.1.4.1.232.11.2.4.1.1.5" instance="0" alias="cimPctHddUsed1" type="integer"/>
-      <mibObj oid=".1.3.6.1.4.1.232.11.2.4.1.1.5" instance="1" alias="cimPctHddUsed2" type="integer"/>
-      <mibObj oid=".1.3.6.1.4.1.232.11.2.3.1.1.3" instance="0" alias="cim5MinCpuUtilPct" type="integer"/>
-   </group>
    <group name="hp-procurve" ifType="ignore">
       <mibObj oid=".1.3.6.1.4.1.11.2.14.11.5.1.9.6.1" instance="0" alias="hpSwitchCpuStat" type="gauge"/>
       <mibObj oid=".1.3.6.1.4.1.11.2.14.11.5.1.1.1.1.1.1.2" instance="1" alias="hpMsgBufCorrupt" type="gauge"/>

--- a/opennms-base-assembly/src/main/filtered/etc/datacollection/microsoft.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/datacollection/microsoft.xml
@@ -24,7 +24,6 @@
       <sysoidMask>.1.3.6.1.4.1.311.1.1.3.1.</sysoidMask>
       <collect>
          <includeGroup>checkpoint</includeGroup>
-         <includeGroup>compaq-insight-manager-stats</includeGroup>
          <includeGroup>domino-stats</includeGroup>
          <includeGroup>microsoft-http</includeGroup>
          <includeGroup>snmpinformant-cpu</includeGroup>

--- a/opennms-base-assembly/src/main/filtered/etc/datacollection/ref_compaq-insight-manager.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/datacollection/ref_compaq-insight-manager.xml
@@ -1,0 +1,7 @@
+<datacollection-group xmlns="http://xmlns.opennms.org/xsd/config/datacollection" name="REF_Compaq-Insight-Manager">
+   <group name="compaq-insight-manager-stats" ifType="ignore">
+      <mibObj oid=".1.3.6.1.4.1.232.11.2.4.1.1.5" instance="0" alias="cimPctHddUsed1" type="integer"/>
+      <mibObj oid=".1.3.6.1.4.1.232.11.2.4.1.1.5" instance="1" alias="cimPctHddUsed2" type="integer"/>
+      <mibObj oid=".1.3.6.1.4.1.232.11.2.3.1.1.3" instance="0" alias="cim5MinCpuUtilPct" type="integer"/>
+   </group>
+</datacollection-group>


### PR DESCRIPTION
Remove Compaq Insight Manager statistics data collection from all Windows servers.

* JIRA: http://issues.opennms.org/browse/NMS-10143