### PR TITLE
NMS-10144: Remove Cisco Call Manager stats from all Windows Server

### DIFF
--- a/opennms-base-assembly/src/main/filtered/etc/datacollection/microsoft.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/datacollection/microsoft.xml
@@ -24,7 +24,6 @@
       <sysoidMask>.1.3.6.1.4.1.311.1.1.3.1.</sysoidMask>
       <collect>
          <includeGroup>checkpoint</includeGroup>
-         <includeGroup>cisco-ccm</includeGroup>
          <includeGroup>compaq-insight-manager-stats</includeGroup>
          <includeGroup>domino-stats</includeGroup>
          <includeGroup>microsoft-http</includeGroup>


### PR DESCRIPTION
Remove Cisco Call Manager stats from all Windows Server

* JIRA: http://issues.opennms.org/browse/NMS-10144
