### PR TITLE
NMS-10145: Classify IETF MIB as reference

### DIFF
--- a/opennms-base-assembly/src/main/filtered/etc/datacollection-config.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/datacollection-config.xml
@@ -64,6 +64,7 @@
       <include-collection dataCollectionGroup="PostgreSQL-JDBC"/>
       <include-collection dataCollectionGroup="Powerware"/>
       <include-collection dataCollectionGroup="Printers"/>
+      <include-collection dataCollectionGroup="REF_IETF"/>
       <include-collection dataCollectionGroup="Riverbed"/>
       <include-collection dataCollectionGroup="Routers"/>
       <include-collection dataCollectionGroup="Savin or Ricoh Printers"/>

--- a/opennms-base-assembly/src/main/filtered/etc/datacollection/ref_ietf.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/datacollection/ref_ietf.xml
@@ -1,4 +1,4 @@
-<datacollection-group xmlns="http://xmlns.opennms.org/xsd/config/datacollection" name="IETF">
+<datacollection-group xmlns="http://xmlns.opennms.org/xsd/config/datacollection" name="REF_IETF">
    <resourceType name="msdpPeerEntry" label="MSDP Peer" resourceLabel="Remote ${msdpPeerRemoteAddr}:${msdpPeerRemotePort} (Local ${msdpPeerLocalAddr}:${msdpPeerLocalPort})">
       <persistenceSelectorStrategy class="org.opennms.netmgt.collection.support.PersistAllSelectorStrategy"/>
       <storageStrategy class="org.opennms.netmgt.collection.support.IndexStorageStrategy"/>


### PR DESCRIPTION
Classify IETF MIB as reference, cause nothing is assigned to any device and needs to be added manually to vendors who supports it.

* JIRA: http://issues.opennms.org/browse/NMS-10145
