### PR TITLE
NMS-10146: Classify the Printer MIB as reference

### DIFF
--- a/opennms-base-assembly/src/main/filtered/etc/datacollection-config.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/datacollection-config.xml
@@ -65,6 +65,7 @@
       <include-collection dataCollectionGroup="Powerware"/>
       <include-collection dataCollectionGroup="Printers"/>
       <include-collection dataCollectionGroup="Riverbed"/>
+      <include-collection dataCollectionGroup="REF_Printers"/>
       <include-collection dataCollectionGroup="Routers"/>
       <include-collection dataCollectionGroup="Savin or Ricoh Printers"/>
       <include-collection dataCollectionGroup="ServerTech"/>

--- a/opennms-base-assembly/src/main/filtered/etc/datacollection/ref_printers.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/datacollection/ref_printers.xml
@@ -1,4 +1,4 @@
-<datacollection-group xmlns="http://xmlns.opennms.org/xsd/config/datacollection" name="Printers">
+<datacollection-group xmlns="http://xmlns.opennms.org/xsd/config/datacollection" name="REF_Printers">
    <resourceType name="prtMarkerSuppliesIndex" label="Printer Marker Supply" resourceLabel="${prtMarkerSuppliesDescription}">
       <persistenceSelectorStrategy class="org.opennms.netmgt.collection.support.PersistAllSelectorStrategy"/>
       <storageStrategy class="org.opennms.netmgt.collection.support.IndexStorageStrategy"/>


### PR DESCRIPTION
Classify the Printer MIB as reference cause it is not assigned by default.

* JIRA: http://issues.opennms.org/browse/NMS-10146
