### PR TITLE
NMS-10161 - Typos in Horizon 22.0.0 release notes

### DIFF
--- a/opennms-doc/releasenotes/src/asciidoc/releasenotes/whatsnew.adoc
+++ b/opennms-doc/releasenotes/src/asciidoc/releasenotes/whatsnew.adoc
@@ -67,7 +67,7 @@ Besides that the following default values have been changed:
 | Parameter | Old default | New default
 
 | `batchSize`
-| `1
+| `1`
 | `200`
 
 | `batchInterval`
@@ -102,7 +102,7 @@ For more details please refer to link:../guide-admin/index.html#ga-elasticsearch
 * The index creation of the _Elasticsearch ReST plugin_ has changed and is now configurable. Please refer to <<releasenotes-22-opennms-es-rest-index-properties>>.
 * The _Elasticsearch ReST plugin_ no longer supports ElasticSearch version 2.4. A version >= 5.x must be used.
 * By default the data collection gathered data twice from SNMP agents supporting the MIB-II with 32bit and 64bit counter on network interfaces.
-  The default 32bit interface counters are no disabled by default and only 64bit counters are collected.
+  The default 32bit interface counters are now disabled by default and only 64bit counters are collected.
 
 IMPORTANT: If you have legacy SNMP agents which only support 32bit interface counters, the data collection for this interfaces will stop after you upgraded to 22.0.0.
   To get them enabled, you have to create a data collection package and add the `mib2-interfaces` data collection group manually for this devices with the example below.


### PR DESCRIPTION
Line 70: missing closing format ` tag
Line 105: missing W at "counters are no disabled by default"

NMS-10161 - Typos in Horizon 22.0.0 release notes
* JIRA: https://issues.opennms.org/browse/NMS-10161