### PR TITLE
NMS-10161: Typos in Horizon 22.0.0 release notes (part 2)

### DIFF
--- a/opennms-doc/releasenotes/src/asciidoc/releasenotes/whatsnew.adoc
+++ b/opennms-doc/releasenotes/src/asciidoc/releasenotes/whatsnew.adoc
@@ -16,7 +16,7 @@
 * The index creation of the _Elasticsearch ReST plugin_ has changed and is now configurable. Please refer to <<releasenotes-22-opennms-es-rest-index-properties>>.
 * The _Elasticsearch ReST plugin_ no longer supports ElasticSearch version 2.4. A version >= 5.x must be used.
 * All JavaScript code in OpenNMS has been unified under a single build system. While we did quite a bit of testing of the resulting changes, it's possible something was missed. If you run into any JS-related issues in the UI please link:https://issues.opennms.org/[create an issue].
-* The default database access implementation is now using _HikariCP_, rather than _C3P0_. This will probably not affect you (other than give better peformance) but could affect unusual workloads.
+* The default database access implementation is now using _HikariCP_, rather than _C3P0_. This will probably not affect you (other than give better performance) but could affect unusual workloads.
 * Backshift is now the default rendering engine for graphs.
 
 [[releasenotes-22-opennms-es-rest]]


### PR DESCRIPTION
Line 19: misspelling of "performance"

NMS-10161: Typos in Horizon 22.0.0 release notes

* JIRA: https://issues.opennms.org/browse/NMS-10161