### PR TITLE
NMS-10158: Allow configuring date format in syslog north bounder 

### DIFF
--- a/opennms-alarms/api/src/main/java/org/opennms/netmgt/alarmd/api/support/AbstractNorthbounder.java
+++ b/opennms-alarms/api/src/main/java/org/opennms/netmgt/alarmd/api/support/AbstractNorthbounder.java
@@ -30,10 +30,8 @@ package org.opennms.netmgt.alarmd.api.support;
 
 import java.io.Serializable;
 import java.io.StringWriter;
-import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -45,7 +43,6 @@ import javax.xml.bind.Marshaller;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.namespace.QName;
 
-import org.opennms.core.utils.StringUtils;
 import org.opennms.netmgt.alarmd.api.NorthboundAlarm;
 import org.opennms.netmgt.alarmd.api.NorthboundAlarm.AlarmType;
 import org.opennms.netmgt.alarmd.api.NorthboundAlarm.x733ProbableCause;
@@ -279,7 +276,7 @@ public abstract class AbstractNorthbounder implements Northbounder, Runnable, St
      * @param alarm the northbound alarm
      * @return the mapping object
      */
-    protected Map<String, Object> createMapping(NorthboundAlarm alarm) {
+    protected Map<String, Object> createMapping(NorthboundAlarm alarm, String dateFormat) {
         Map<String, Object> mapping;
         mapping = new HashMap<String, Object>();
         String defaultMapping = "";
@@ -304,11 +301,22 @@ public abstract class AbstractNorthbounder implements Northbounder, Runnable, St
 
         String count = alarm.getCount() == null ? "1" : alarm.getCount().toString();
         mapping.put("count", count);
-
-        mapping.put("firstOccurrence", nullSafeIso8601String(alarm.getFirstOccurrence(), defaultMapping));
+        if (dateFormat == null) {
+            dateFormat = "yyyy-MM-dd'T'HH:mm:ss:SSSXXX";
+        }
+        SimpleDateFormat simpleDateFormat = new SimpleDateFormat(dateFormat);
+        String firstOccurence = "";
+        if (alarm.getFirstOccurrence() != null) {
+            firstOccurence = simpleDateFormat.format(alarm.getFirstOccurrence());
+        }
+        String lastOccurence = "";
+        if (alarm.getLastOccurrence() != null) {
+            lastOccurence = simpleDateFormat.format(alarm.getLastOccurrence());
+        }
+        mapping.put("firstOccurrence", firstOccurence);
         mapping.put("alarmId", alarm.getId().toString());
         mapping.put("ipAddr", nullSafeToString(alarm.getIpAddr(), defaultMapping));
-        mapping.put("lastOccurrence", nullSafeIso8601String(alarm.getLastOccurrence(), defaultMapping));
+        mapping.put("lastOccurrence", lastOccurence);
 
         if (alarm.getNodeId() != null) {
             LOG.debug("Adding nodeId: " + alarm.getNodeId().toString());
@@ -361,14 +369,7 @@ public abstract class AbstractNorthbounder implements Northbounder, Runnable, St
         }
         return defaultString;
     }
-    
-    private String nullSafeIso8601String(Date d, String defaultString) {
-        if(d != null) {
-            defaultString = StringUtils.iso8601LocalOffsetString(d);
-        }
-        return defaultString;
-    }
-    
+
     /**
      * Builds the parameters mappings.
      *

--- a/opennms-alarms/email-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/email/EmailNorthbounder.java
+++ b/opennms-alarms/email-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/email/EmailNorthbounder.java
@@ -211,7 +211,7 @@ public class EmailNorthbounder extends AbstractNorthbounder implements Initializ
         }
         LOG.debug("getSendmailConfig: from = {}", message.getFrom());
         LOG.debug("getSendmailConfig: to = {}", message.getTo());
-        Map<String, Object> mapping = createMapping(alarm);
+        Map<String, Object> mapping = createMapping(alarm, null);
         final String subject = PropertiesUtils.substitute(message.getSubject(), mapping);
         LOG.debug("getSendmailConfig: subject = {}", subject);
         message.setSubject(subject);

--- a/opennms-alarms/jms-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/jms/JmsNorthbounder.java
+++ b/opennms-alarms/jms-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/jms/JmsNorthbounder.java
@@ -187,7 +187,7 @@ public class JmsNorthbounder extends AbstractNorthbounder implements Initializin
      */
     private String convertAlarmToText(NorthboundAlarm alarm) {
         String alarmXml = null;
-        Map<String, Object> mapping = createMapping(alarm);
+        Map<String, Object> mapping = createMapping(alarm, null);
         LOG.debug("Making substitutions for tokens in message format for alarm: {}.", alarm.getId());
         if (m_jmsDestination.getMessageFormat() != null) {
             alarmXml = PropertiesUtils.substitute(m_jmsDestination.getMessageFormat(), mapping);

--- a/opennms-alarms/jms-northbounder/src/test/java/org/opennms/netmgmt/alarmd/northbounder/jms/JmsNorthBounderTest.java
+++ b/opennms-alarms/jms-northbounder/src/test/java/org/opennms/netmgmt/alarmd/northbounder/jms/JmsNorthBounderTest.java
@@ -30,6 +30,7 @@ package org.opennms.netmgmt.alarmd.northbounder.jms;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
@@ -373,7 +374,7 @@ public class JmsNorthBounderTest {
                 " ossState: qosAlarmState ticketId: tticketId alarmUei: uei.uei.org/uei alarmKey: reductionKey clearKey: clearKey description: eventdescr operInstruct: operInstruct ackTime: \n" +
                 " alarmType: PROBLEM count: 1 alarmId: 9 ipAddr: 127.0.0.1 lastOccurrence:  nodeId: 1\n" +
                 " nodeLabel: schlazor distPoller: 00000000-0000-0000-0000-000000000000 ifService:  severity: WARNING ticketState:  x733AlarmType: other\n"+
-                " x733ProbableCause: other firstOccurrence: " + StringUtils.iso8601LocalOffsetString(new Date(0)) + " lastOccurrence  eventParmsXml: <eventParms/>";
+                " x733ProbableCause: other firstOccurrence: " + convertDateToDefaultFormat(new Date(0)) + " lastOccurrence  eventParmsXml: <eventParms/>";
         String response = ((TextMessage)m).getText();
         Assert.assertEquals("Contents of message\n'" + response + "'\n not equals\n'" + escapedResponse+"'.", response, escapedResponse);
     }
@@ -618,9 +619,9 @@ public class JmsNorthBounderTest {
         Message m = m_template.receive("MappingTestQueue");
         String escapedResponse = "ackUser:  appDn: applicationDN logMsg: eventlogmsg objectInstance: managedObjectInstance objectType: managedObjectType ossKey: ossPrimaryKey\n" +
                 " ossState: qosAlarmState ticketId: tticketId alarmUei: uei.uei.org/uei alarmKey: reductionKey clearKey: clearKey description: eventdescr operInstruct: operInstruct ackTime: \n" +
-                " alarmType: PROBLEM count: 1 alarmId: 9 ipAddr: 127.0.0.1 lastOccurrence: " + StringUtils.iso8601LocalOffsetString(date2) + " nodeId: 1\n" +
+                " alarmType: PROBLEM count: 1 alarmId: 9 ipAddr: 127.0.0.1 lastOccurrence: " + convertDateToDefaultFormat(date2) + " nodeId: 1\n" +
                 " nodeLabel: schlazor distPoller: 00000000-0000-0000-0000-000000000000 ifService:  severity: WARNING ticketState:  x733AlarmType: other\n"+
-                " x733ProbableCause: other firstOccurrence: " + StringUtils.iso8601LocalOffsetString(date1) + " lastOccurrence " + StringUtils.iso8601LocalOffsetString(date2) + " eventParmsXml: <eventParms>\n" +
+                " x733ProbableCause: other firstOccurrence: " + convertDateToDefaultFormat(date1) + " lastOccurrence " + convertDateToDefaultFormat(date2) + " eventParmsXml: <eventParms>\n" +
                 "    <parm name=\"syslogmessage\" value=\"Dec 22 2015 20:12:57.1 UTC :  %UC_CTI-3-CtiProviderOpenFailure: %[CTIconnectionId%61232238][ Login User Id%61pguser][Reason code.%61-1932787616][UNKNOWN_PARAMNAME:IPAddress%61172.17.12.73][UNKNOWN_PARAMNAME:IPv6Address%61][App ID%61Cisco CTIManager][Cluster ID%61SplkCluster][Node ID%61splkcucm6p]: CTI application failed to open provider%59 application startup failed\" type=\"string\"/>\n" +
                 "    <parm name=\"severity\" value=\"Error\" type=\"string\"/>\n" +
                 "    <parm name=\"timestamp\" value=\"Dec 22 14:13:21\" type=\"string\"/>\n" +
@@ -635,6 +636,13 @@ public class JmsNorthBounderTest {
         m = m_template.receive("MappingTestQueue");
         Assert.assertNull(m);
     }
+
+    private String convertDateToDefaultFormat(Date date) {
+        SimpleDateFormat simpleDateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss:SSSXXX");
+        return simpleDateFormat.format(date);
+
+    }
+
     /**
      * Generate configuration XML.
      *

--- a/opennms-alarms/syslog-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/syslog/SyslogNorthbounder.java
+++ b/opennms-alarms/syslog-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/syslog/SyslogNorthbounder.java
@@ -177,7 +177,8 @@ public class SyslogNorthbounder extends AbstractNorthbounder implements Initiali
                 if (msgFormat == null) {
                     msgFormat = getConfig().getMessageFormat();
                 }
-                syslogMessage = PropertiesUtils.substitute(msgFormat, createMapping(alarm));
+                String dateFormat = getConfig().getDateFormat();
+                syslogMessage = PropertiesUtils.substitute(msgFormat, createMapping(alarm, dateFormat));
 
                 LOG.debug("Determining LOG_LEVEL for alarm: {}", alarm.getId());
                 level = SyslogUtils.determineLogLevel(alarm.getSeverity());

--- a/opennms-alarms/syslog-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/syslog/SyslogNorthbounderConfig.java
+++ b/opennms-alarms/syslog-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/syslog/SyslogNorthbounderConfig.java
@@ -68,6 +68,10 @@ public class SyslogNorthbounderConfig implements Serializable {
     /** The message format. */
     @XmlElement(name = "message-format", required = false, defaultValue = "ALARM ID:${alarmId} NODE:${nodeLabel} ${logMsg}")
     private String m_messageFormat;
+    
+    /** The date format. */
+    @XmlElement(name = "date-format", required = false, defaultValue = "yyyy-MM-dd'T'HH:mm:ss:SSSXXX")
+    private String m_dateFormat;
 
     /** The destinations. */
     @XmlElement(name = "destination")
@@ -129,6 +133,24 @@ public class SyslogNorthbounderConfig implements Serializable {
      */
     public void setMessageFormat(String messageFormat) {
         m_messageFormat = messageFormat;
+    }
+
+    /**
+     * Gets the date format.
+     *
+     * @return the date format
+     */
+    public String getDateFormat() {
+        return m_dateFormat;
+    }
+
+    /**
+     * Sets the date format.
+     *
+     * @param dateFormat sets the date format
+     */
+    public void setDateFormat(String dateFormat) {
+        this.m_dateFormat = dateFormat;
     }
 
     /**

--- a/opennms-alarms/syslog-northbounder/src/main/resources/xsds/syslog-northbounder-configuration.xsd
+++ b/opennms-alarms/syslog-northbounder/src/main/resources/xsds/syslog-northbounder-configuration.xsd
@@ -14,6 +14,7 @@
       <xs:element name="batch-size" type="xs:int" default="100" minOccurs="0"/>
       <xs:element name="queue-size" type="xs:int" default="300000" minOccurs="0"/>
       <xs:element name="message-format" type="xs:string" default="ALARM ID:${alarmId} NODE:${nodeLabel} ${logMsg}" minOccurs="0"/>
+      <xs:element name="date-format" type="xs:string" default="yyyy-MM-dd'T'HH:mm:ss:SSSXXX" minOccurs="0"/>
       <xs:element name="destination" type="syslogDestination" minOccurs="0" maxOccurs="unbounded"/>
       <xs:element name="uei" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
     </xs:sequence>

--- a/opennms-alarms/syslog-northbounder/src/test/java/org/opennms/netmgt/alarmd/northbounder/syslog/SyslogConfigDaoTest.java
+++ b/opennms-alarms/syslog-northbounder/src/test/java/org/opennms/netmgt/alarmd/northbounder/syslog/SyslogConfigDaoTest.java
@@ -54,6 +54,7 @@ public class SyslogConfigDaoTest {
             "  <batch-size>10</batch-size>" +
             "  <queue-size>100</queue-size>" +
             "  <message-format>ALARM ID:${alarmId} NODE:${nodeLabel}</message-format>" +
+            "  <date-format>yyyy-MM-dd HH:mm:ss</date-format>" +
             ">\n" +
             "  <destination>" +
             "    <destination-name>test-host</destination-name>" +
@@ -81,6 +82,7 @@ public class SyslogConfigDaoTest {
             "  <batch-size>10</batch-size>" +
             "  <queue-size>100</queue-size>" +
             "  <message-format>ALARM ID:${alarmId} NODE:${nodeLabel}</message-format>" +
+            "  <date-format>yyyy-MM-dd HH:mm:ss.SSS</date-format>" +
             ">\n" +
             "  <destination>" +
             "    <destination-name>test-host</destination-name>" +
@@ -107,6 +109,7 @@ public class SyslogConfigDaoTest {
             "  <batch-size>10</batch-size>" +
             "  <queue-size>100</queue-size>" +
             "  <message-format>ALARM ID:${alarmId} NODE:${nodeLabel}</message-format>" +
+            "  <date-format>yyyy-MM-dd HH:mm:ss.SSSZ</date-format>" +
             ">\n" +
             "  <destination>" +
             "    <destination-name>test-host</destination-name>" +
@@ -152,6 +155,7 @@ public class SyslogConfigDaoTest {
         assertEquals(new Integer(10), config.getBatchSize());
         assertEquals(new Integer(100), config.getQueueSize());
         assertEquals("ALARM ID:${alarmId} NODE:${nodeLabel}", config.getMessageFormat());
+        assertEquals("yyyy-MM-dd HH:mm:ss", config.getDateFormat());
 
         SyslogDestination syslogDestination = config.getDestinations().get(0);
         assertNotNull(syslogDestination);
@@ -186,6 +190,7 @@ public class SyslogConfigDaoTest {
         assertNotNull(config);
         assertEquals(null, config.getUeis());
         assertTrue(config.getDestinations().get(0).isFirstOccurrenceOnly());
+        assertEquals("yyyy-MM-dd HH:mm:ss.SSS", config.getDateFormat());
     }
 
     /**
@@ -211,7 +216,8 @@ public class SyslogConfigDaoTest {
         assertEquals(2, dst.getFilters().size());
         assertEquals(true, dst.getFilters().get(0).isEnabled());
         assertEquals(false,dst.getFilters().get(1).isEnabled());
-
+        assertEquals("yyyy-MM-dd HH:mm:ss.SSSZ", dao.getConfig().getDateFormat());
+        
         writer = new FileWriter(configFile);
         writer.write(xmlNoUeis);
         writer.close();

--- a/opennms-alarms/syslog-northbounder/src/test/java/org/opennms/netmgt/alarmd/northbounder/syslog/SyslogNorthBounderWithFiltersTest.java
+++ b/opennms-alarms/syslog-northbounder/src/test/java/org/opennms/netmgt/alarmd/northbounder/syslog/SyslogNorthBounderWithFiltersTest.java
@@ -32,6 +32,8 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.StringReader;
 import java.net.InetAddress;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
@@ -120,6 +122,12 @@ public class SyslogNorthBounderWithFiltersTest extends SyslogNorthBounderTest {
             this.setEventParameters(Lists.newArrayList(
                     new OnmsEventParameter(this, "owner", "agalue", "String")));
         }});
+        String pattern = "yyyy-MM-dd HH:mm:ss";
+        SimpleDateFormat simpleDateFormat = new SimpleDateFormat(pattern);
+        Date firstOccurence = simpleDateFormat.parse("2017-3-1 11:59:59");
+        Date lastOccurence = simpleDateFormat.parse("2018-3-1 11:59:59");
+        onmsAlarm.setFirstEventTime(firstOccurence);
+        onmsAlarm.setLastEventTime(lastOccurence);
         NorthboundAlarm nbAlarm = new NorthboundAlarm(onmsAlarm);
         List<NorthboundAlarm> alarms = new LinkedList<>();
         alarms.add(nbAlarm);
@@ -138,8 +146,9 @@ public class SyslogNorthBounderWithFiltersTest extends SyslogNorthBounderTest {
         Assert.assertTrue("Log messages sent: 2, Log messages received: " + messages.size(), 2 == messages.size());
         Assert.assertTrue(messages.get(0).contains("ALARM 10 FROM NODE agalue@TestGroup"));
         Assert.assertTrue(messages.get(1).contains("ALARM 10 FROM INTERFACE 10.0.1.1"));
+        Assert.assertTrue(messages.get(0).contains("FIRST:2017-03-01 11:59:59"));
+        Assert.assertTrue(messages.get(0).contains("LAST:2018-03-01 11:59:59"));
         reader.close();
-
         // Remove the temporary configuration file
         configFile.delete();
     }

--- a/opennms-alarms/syslog-northbounder/src/test/resources/syslog-northbounder-config1.xml
+++ b/opennms-alarms/syslog-northbounder/src/test/resources/syslog-northbounder-config1.xml
@@ -4,9 +4,8 @@
   <nagles-delay>1000</nagles-delay>
   <batch-size>100</batch-size>
   <queue-size>300000</queue-size>
-
-  <message-format>ALARM ID:${alarmId} NODE:${nodeLabel}; ${logMsg}</message-format>
-
+  <date-format>yyyy-MM-dd HH:mm:ss</date-format>
+  <message-format>ALARM ID:${alarmId} NODE:${nodeLabel} FIRST:${firstOccurrence} LAST:${lastOccurrence} ; ${logMsg}</message-format>
   <destination>
     <destination-name>localTest1</destination-name>
     <host>127.0.0.1</host>
@@ -19,7 +18,7 @@
     <truncate-message>false</truncate-message>
     <filter name="Filter 1 : Match Node">
       <rule>parameters['owner'] == 'agalue' and uei matches '^.*interfaceDown$'</rule>
-      <message-format>ALARM ${alarmId} FROM NODE ${nodeLabel}@${foreignSource}: ${logMsg}</message-format>
+      <message-format>ALARM ${alarmId} FROM NODE ${nodeLabel}@${foreignSource} FIRST:${firstOccurrence} LAST:${lastOccurrence} : ${logMsg}</message-format>
     </filter>
   </destination>
 

--- a/opennms-base-assembly/src/main/filtered/etc/syslog-northbounder-configuration.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/syslog-northbounder-configuration.xml
@@ -6,6 +6,7 @@
    <batch-size>100</batch-size>
    <queue-size>300000</queue-size>
    <message-format>ALARM ID:${alarmId} NODE:${nodeLabel}; ${logMsg}</message-format>
+    <!-- You can specify date format, default is ISO 8601  <date-format>yyyy-MM-dd'T'HH:mm:ss:SSSXXX</date-format> -->
 <!-- You could do something like the following
    <message-format>ALARM ID:${alarmId} NODE:${nodeLabel} IP:${ipAddr} 
       FIRST:${firstOccurrence} LAST:${lastOccurrence} 


### PR DESCRIPTION
Add  `<date-format>`  tag in  `syslog-northbounder-configuration.xml`.
It allows  date format in  FIRST and LAST occurence to be specified by users. Default formatting would be  `yyyy-MM-dd HH:mm:ss`

* JIRA: http://issues.opennms.org/browse/NMS-10158

Our [continuous integration system](http://bamboo.internal.opennms.com:8085) will test and verify your changes.
