### PR TITLE
NMS-10164 Support customizing the default time zone when parsing dates in syslog messages

### DIFF
--- a/features/events/syslog/src/main/java/org/opennms/netmgt/syslogd/Rfc5424SyslogParser.java
+++ b/features/events/syslog/src/main/java/org/opennms/netmgt/syslogd/Rfc5424SyslogParser.java
@@ -114,11 +114,12 @@ public class Rfc5424SyslogParser extends SyslogParser {
         return message;
     }
 
-    protected static Date parseDate(final String dateString) {
+    protected Date parseDate(final String dateString) {
         if (dateString.endsWith("Z")) {
             try {
                 final DateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.ROOT);
                 df.setTimeZone(TimeZone.getTimeZone("GMT"));
+                adjustTimeZone(df);
                 return df.parse(dateString);
             } catch (final Exception e) {
                 // try again with optional decimals
@@ -126,6 +127,7 @@ public class Rfc5424SyslogParser extends SyslogParser {
                     final DateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSSSS'Z'", Locale.ROOT);
                     df.setLenient(true);
                     df.setTimeZone(TimeZone.getTimeZone("GMT"));
+                    adjustTimeZone(df);
                     return df.parse(dateString);
                 } catch (final Exception pe) {
                     LOG.debug("Unable to parse date string '{}'.", dateString, pe);

--- a/features/events/syslog/src/main/java/org/opennms/netmgt/syslogd/SyslogConfigBean.java
+++ b/features/events/syslog/src/main/java/org/opennms/netmgt/syslogd/SyslogConfigBean.java
@@ -30,13 +30,14 @@ package org.opennms.netmgt.syslogd;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.TimeZone;
 
 import org.opennms.netmgt.config.SyslogdConfig;
 import org.opennms.netmgt.config.syslogd.HideMatch;
 import org.opennms.netmgt.config.syslogd.UeiMatch;
 
 /**
- * This is a bean container that can be used as a {@link SyslogConfig}
+ * This is a bean container that can be used as a {@link SyslogdConfig}
  * service.
  */
 public final class SyslogConfigBean implements SyslogdConfig {
@@ -53,6 +54,7 @@ public final class SyslogConfigBean implements SyslogdConfig {
 	private int m_queueSize;
 	private int m_batchSize;
 	private int m_batchIntervalMs;
+	private TimeZone timeZone;
 
 	@Override
 	public int getSyslogPort() {
@@ -171,7 +173,16 @@ public final class SyslogConfigBean implements SyslogdConfig {
         return m_batchIntervalMs;
     }
 
-    public void setBatchIntervalMs(int batchIntervalMs) {
+	@Override
+	public TimeZone getTimeZone() {
+		return this.timeZone;
+	}
+
+	public void setTimeZone(TimeZone timeZone){
+		this.timeZone = timeZone;
+	}
+
+	public void setBatchIntervalMs(int batchIntervalMs) {
         m_batchIntervalMs = batchIntervalMs;
     }
 }

--- a/features/events/syslog/src/main/java/org/opennms/netmgt/syslogd/SyslogParser.java
+++ b/features/events/syslog/src/main/java/org/opennms/netmgt/syslogd/SyslogParser.java
@@ -29,7 +29,6 @@
 package org.opennms.netmgt.syslogd;
 
 import java.lang.reflect.Constructor;
-import java.net.InetAddress;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.text.DateFormat;
@@ -41,11 +40,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.opennms.core.time.ZonedDateTimeBuilder;
-import org.opennms.core.utils.InetAddressUtils;
 import org.opennms.netmgt.config.SyslogdConfig;
-import org.opennms.netmgt.dao.api.AbstractInterfaceToNodeCache;
-import org.opennms.netmgt.dao.api.InterfaceToNodeCache;
-import org.opennms.netmgt.model.events.EventBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -158,16 +153,17 @@ public class SyslogParser {
         return m_matcher;
     }
 
-    protected static Date parseDate(final String dateString) {
+    protected Date parseDate(final String dateString) {
         try {
             // Date pattern has been created and checked inside if loop instead of 
             // parsing date inside the exception class.
             if (dateString.matches(datePattern)) {
                 final DateFormat df = new SimpleDateFormat("yyyy-MM-dd", Locale.ROOT);
+                adjustTimeZone(df);
                 return df.parse(dateString);
             } else {
                 final DateFormat df = new SimpleDateFormat("MMM dd HH:mm:ss", Locale.ROOT);
-                
+                adjustTimeZone(df);
                 // 2012-03-14 Ben: Ugh, what's a non-lame way of forcing it to parse to "this year"?
                 Date date = df.parse(dateString);
                 final Calendar c = df.getCalendar();
@@ -180,6 +176,12 @@ public class SyslogParser {
         } catch (final Exception e) {
             LOG.debug("Unable to parse date '{}'", dateString, e);
             return null;
+        }
+    }
+
+    void adjustTimeZone(DateFormat df) {
+        if(m_config.getTimeZone() !=null) {
+            df.setTimeZone(m_config.getTimeZone());
         }
     }
 }

--- a/features/events/syslog/src/test/java/org/opennms/netmgt/syslogd/Rfc5424SyslogParserTest.java
+++ b/features/events/syslog/src/test/java/org/opennms/netmgt/syslogd/Rfc5424SyslogParserTest.java
@@ -1,0 +1,77 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2017 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *     http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.syslogd;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Date;
+import java.util.TimeZone;
+
+import org.junit.Test;
+import org.opennms.netmgt.config.SyslogdConfigFactory;
+
+public class Rfc5424SyslogParserTest {
+    @Test
+    public void shouldHonorTimezoneWithConfiguredDefault() throws IOException {
+        checkDateParserWith(TimeZone.getTimeZone("CET"), "timezone=\"CET\" ");
+    }
+
+    @Test
+    public void shouldHonorTimezoneWithoutConfiguredDefault() throws IOException {
+        checkDateParserWith(TimeZone.getTimeZone("GMT"), "");
+    }
+
+    private void checkDateParserWith(TimeZone expectedTimeZone, String timezoneProperty) throws IOException {
+        String configuration = "<syslogd-configuration>" +
+                "<configuration " +
+                "syslog-port=\"10514\" " +
+                timezoneProperty+
+                "/></syslogd-configuration>";
+
+        final InputStream stream = new ByteArrayInputStream((configuration).getBytes());
+        final SyslogdConfigFactory config = new SyslogdConfigFactory(stream);
+        final SyslogParser parser = new Rfc5424SyslogParser(config, SyslogdTestUtils.toByteBuffer("something"));
+        checkDateParserWith(expectedTimeZone, "yyyy-MM-dd'T'HH:mm:ss'Z'", parser);
+        checkDateParserWith(expectedTimeZone, "yyyy-MM-dd'T'HH:mm:ss.SSSSSS'Z'", parser);
+    }
+
+    private void checkDateParserWith(TimeZone expectedTimeZone, String pattern, SyslogParser parser) throws IOException {
+        LocalDateTime expectedLocalDateTime = LocalDateTime.of(2017, 2, 3, 12, 21, 20);
+        ZonedDateTime expectedDateTime = ZonedDateTime.of(expectedLocalDateTime, expectedTimeZone.toZoneId());
+        Date parsedDate = parser.parseDate(DateTimeFormatter.ofPattern(pattern).format(expectedDateTime));
+        assertEquals(expectedDateTime.toInstant(), parsedDate.toInstant());
+    }
+
+}

--- a/opennms-base-assembly/src/main/filtered/etc/syslogd-configuration.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/syslogd-configuration.xml
@@ -1,5 +1,10 @@
 <?xml version="1.0"?>
 <syslogd-configuration>
+    <!--
+      optional attribute "timezone":
+          - if set it will be used as default timezone if no timezone is given
+          - if not set the system time zone will be used
+    -->
     <configuration
             syslog-port="10514"
             new-suspect-on-message="false"
@@ -8,6 +13,7 @@
             matching-group-host="6"
             matching-group-message="8"
             discard-uei="DISCARD-MATCHING-MESSAGES"
+            timezone=""
             />
 
     <!--

--- a/opennms-config-model/src/main/java/org/opennms/netmgt/config/syslogd/Configuration.java
+++ b/opennms-config-model/src/main/java/org/opennms/netmgt/config/syslogd/Configuration.java
@@ -30,8 +30,10 @@ package org.opennms.netmgt.config.syslogd;
 
 
 import java.io.Serializable;
+import java.time.ZoneId;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.TimeZone;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
@@ -40,6 +42,8 @@ import javax.xml.bind.annotation.XmlRootElement;
 
 import org.opennms.core.xml.ValidateUsing;
 import org.opennms.netmgt.config.utils.ConfigUtils;
+
+import com.google.common.base.Strings;
 
 /**
  * Top-level element for the syslogd-configuration.xml configuration file.
@@ -145,6 +149,9 @@ public class Configuration implements Serializable {
     @XmlAttribute(name = "batch-interval")
     private Integer m_batchInterval;
 
+    @XmlAttribute(name = "timezone")
+    private String timeZone;
+
     public Optional<String> getListenAddress() {
         return Optional.ofNullable(m_listenAddress);
     }
@@ -241,6 +248,22 @@ public class Configuration implements Serializable {
         m_batchInterval = ConfigUtils.assertMinimumInclusive(batchInterval, 1, "batch-interval");
     }
 
+    public Optional<TimeZone> getTimeZone(){
+        if(Strings.emptyToNull(this.timeZone) ==null){
+            return Optional.empty();
+        }
+        return Optional.of(TimeZone.getTimeZone(ZoneId.of(timeZone)));
+    }
+
+    public void setTimeZone(String timeZone){
+        if(Strings.emptyToNull(timeZone) == null ){
+            this.timeZone = null;
+        }
+        // test if zone is valid:
+        ZoneId.of(timeZone);
+        this.timeZone = timeZone;
+    }
+
     @Override
     public int hashCode() {
         return Objects.hash(m_listenAddress, 
@@ -254,7 +277,8 @@ public class Configuration implements Serializable {
                             m_threads, 
                             m_queueSize, 
                             m_batchSize, 
-                            m_batchInterval);
+                            m_batchInterval,
+                            timeZone);
     }
 
     /**
@@ -282,7 +306,8 @@ public class Configuration implements Serializable {
                     && Objects.equals(this.m_threads, that.m_threads)
                     && Objects.equals(this.m_queueSize, that.m_queueSize)
                     && Objects.equals(this.m_batchSize, that.m_batchSize)
-                    && Objects.equals(this.m_batchInterval, that.m_batchInterval);
+                    && Objects.equals(this.m_batchInterval, that.m_batchInterval)
+                    && Objects.equals(this.timeZone, that.timeZone);
         }
         return false;
     }

--- a/opennms-config-model/src/main/resources/xsds/syslog.xsd
+++ b/opennms-config-model/src/main/resources/xsds/syslog.xsd
@@ -151,6 +151,13 @@
                   </restriction>
                 </simpleType>
             </attribute>
+            <attribute name="timezone" type="string" use="optional">
+                <annotation>
+                    <documentation>time zone to use for log messages that doen't express a time zone. If none is given the
+                        system's default time zone will be taken. See java.util.TimeZone.
+                    </documentation>
+                </annotation>
+            </attribute>
         </complexType>
 
     </element>

--- a/opennms-config-model/src/test/java/org/opennms/netmgt/config/syslogd/ConfigurationTest.java
+++ b/opennms-config-model/src/test/java/org/opennms/netmgt/config/syslogd/ConfigurationTest.java
@@ -1,0 +1,75 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2017 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *     http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.config.syslogd;
+
+import static junit.framework.TestCase.assertNull;
+import static org.junit.Assert.assertEquals;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.time.zone.ZoneRulesException;
+import java.util.TimeZone;
+
+import org.junit.Test;
+import org.opennms.core.xml.JaxbUtils;
+
+public class ConfigurationTest {
+
+    @Test
+    public void validTimeZoneShouldReturned() throws IOException {
+        assertEquals("GMT", readTimeZone("timezone=\"GMT\" ").getID());
+    }
+
+    @Test
+    public void emptyTimeZoneAttributeShouldReturnNull() throws IOException {
+        assertNull(readTimeZone("timezone=\"\""));
+    }
+
+    @Test(expected = ZoneRulesException.class)
+    public void invalidTimeZoneShouldBeReported() throws IOException {
+        readTimeZone("timezone=\"NotATimeZone\" ");
+    }
+
+    private TimeZone readTimeZone(String timezoneProperty) throws IOException {
+        String configuration = "<syslogd-configuration>" +
+                "<configuration " +
+                "syslog-port=\"10514\" " +
+                timezoneProperty +
+                "/></syslogd-configuration>";
+        final InputStream stream = new ByteArrayInputStream((configuration).getBytes());
+        SyslogdConfiguration config;
+        try (final Reader reader = new InputStreamReader(stream)) {
+            config = JaxbUtils.unmarshal(SyslogdConfiguration.class, reader);
+        }
+        return config.getConfiguration().getTimeZone().orElse(null);
+    }
+}

--- a/opennms-config/src/main/java/org/opennms/netmgt/config/SyslogdConfig.java
+++ b/opennms-config/src/main/java/org/opennms/netmgt/config/SyslogdConfig.java
@@ -29,6 +29,7 @@
 package org.opennms.netmgt.config;
 
 import java.util.List;
+import java.util.TimeZone;
 
 import org.opennms.netmgt.config.syslogd.HideMatch;
 import org.opennms.netmgt.config.syslogd.UeiMatch;
@@ -140,4 +141,11 @@ public interface SyslogdConfig {
      * @return interval in ms
      */
     int getBatchIntervalMs();
+
+    /**
+     * Optional:
+     * - if not null it will be used as default time zone if no time zone is given
+     * - if not set the system time zone will be used
+     */
+    TimeZone getTimeZone();
 }

--- a/opennms-config/src/main/java/org/opennms/netmgt/config/SyslogdConfigFactory.java
+++ b/opennms-config/src/main/java/org/opennms/netmgt/config/SyslogdConfigFactory.java
@@ -35,6 +35,7 @@ import java.io.InputStreamReader;
 import java.io.Reader;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.TimeZone;
 
 import org.opennms.core.utils.ConfigFileConstants;
 import org.opennms.core.xml.JaxbUtils;
@@ -214,6 +215,11 @@ public final class SyslogdConfigFactory implements SyslogdConfig {
     @Override
     public int getBatchIntervalMs() {
         return m_config.getConfiguration().getBatchInterval();
+    }
+
+    @Override
+    public TimeZone getTimeZone() {
+        return m_config.getConfiguration().getTimeZone().orElse(null);
     }
 
     /**


### PR DESCRIPTION
* JIRA: https://issues.opennms.org/browse/NMS-10164

Our [continuous integration system](http://bamboo.internal.opennms.com:8085) will test and verify your changes.
