### PR TITLE
HZN-1311: Enable InterfaceToNodeCache to refresh itself

### DIFF
--- a/opennms-base-assembly/src/main/filtered/etc/opennms.properties
+++ b/opennms-base-assembly/src/main/filtered/etc/opennms.properties
@@ -809,6 +809,10 @@ org.opennms.newts.nan_on_counter_wrap=true
 # minions locations.
 #opennms.minion.provisioning.foreignSourcePattern=Minions
 
+# ###### InterfaceToNodeCache ######
+# Defines the time in ms on which the InterfaceToNodeCache is automatically refreshed
+#org.opennms.interface-node-cache.refresh-timer=300000
+
 # ###### JMS Timeout ######
 # Various OpenNMS components communicate via a message queue. These messages require a request timeout value to
 # be set. In many cases OpenNMS computes a proper timeout value for its operations. However, if a value cannot be

--- a/opennms-dao/pom.xml
+++ b/opennms-dao/pom.xml
@@ -178,5 +178,10 @@
       <artifactId>hamcrest-library</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.jayway.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/opennms-dao/src/main/java/org/opennms/netmgt/dao/hibernate/InterfaceToNodeCacheDaoImpl.java
+++ b/opennms-dao/src/main/java/org/opennms/netmgt/dao/hibernate/InterfaceToNodeCacheDaoImpl.java
@@ -33,9 +33,13 @@ import static org.opennms.core.utils.InetAddressUtils.str;
 import java.net.InetAddress;
 import java.util.Collections;
 import java.util.Objects;
+import java.util.Timer;
+import java.util.TimerTask;
 import java.util.TreeSet;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import javax.annotation.PostConstruct;
 
 import org.opennms.core.criteria.CriteriaBuilder;
 import org.opennms.core.utils.LocationUtils;
@@ -51,6 +55,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionOperations;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import com.google.common.collect.ComparisonChain;
 import com.google.common.collect.Iterables;
@@ -176,8 +182,39 @@ public class InterfaceToNodeCacheDaoImpl extends AbstractInterfaceToNodeCache im
     @Autowired
     private IpInterfaceDao m_ipInterfaceDao;
 
+    @Autowired
+    private TransactionOperations transactionOperations;
+
     private final ReadWriteLock m_lock = new ReentrantReadWriteLock();
     private final SortedSetMultimap<Key, Value> m_managedAddresses = Multimaps.newSortedSetMultimap(Maps.newHashMap(), TreeSet::new);
+
+    private final Timer refreshTimer = new Timer(getClass().getSimpleName());
+
+    // in ms
+    private final long refreshRate;
+
+    public InterfaceToNodeCacheDaoImpl() {
+        this(-1); // By default refreshing the cache is disabled
+    }
+
+    public InterfaceToNodeCacheDaoImpl(long refreshRate) {
+        this.refreshRate = refreshRate;
+    }
+
+    @PostConstruct
+    public void init() {
+        // we call this, to ensure the bean-initialization is blocked, until it is initialized
+        dataSourceSync();
+
+        if (refreshRate > 0) {
+            refreshTimer.schedule(new TimerTask() {
+                @Override
+                public void run() {
+                    dataSourceSync();
+                }
+            }, refreshRate, refreshRate);
+        }
+    }
 
     public NodeDao getNodeDao() {
         return m_nodeDao;
@@ -207,31 +244,49 @@ public class InterfaceToNodeCacheDaoImpl extends AbstractInterfaceToNodeCache im
     @Override
     @Transactional
     public void dataSourceSync() {
-        /*
-         * Make a new list with which we'll replace the existing one, that way
-         * if something goes wrong with the DB we won't lose whatever was already
-         * in there
-         */
-        final SortedSetMultimap<Key, Value> newAlreadyDiscovered = Multimaps.newSortedSetMultimap(Maps.newHashMap(), TreeSet::new);
-
-        // Fetch all non-deleted nodes
-        final CriteriaBuilder builder = new CriteriaBuilder(OnmsNode.class);
-        builder.ne("type", String.valueOf(NodeType.DELETED.value()));
-
-        for (OnmsNode node : m_nodeDao.findMatching(builder.toCriteria())) {
-            for (final OnmsIpInterface iface : node.getIpInterfaces()) {
-                // Skip deleted interfaces
-                // TODO: Refactor the 'D' value with an enumeration
-                if ("D".equals(iface.getIsManaged())) {
-                    continue;
-                }
-                LOG.debug("Adding entry: {}:{} -> {}", node.getLocation().getLocationName(), iface.getIpAddress(), node.getId());
-                newAlreadyDiscovered.put(new Key(node.getLocation().getLocationName(), iface.getIpAddress()), new Value(node.getId(), iface.getIsSnmpPrimary()));
-            }
+        // Determine if spring already created a transaction or if we have to manually do it
+        // (depending on where the call to dataSourceSync comes from)
+        if (TransactionSynchronizationManager.isActualTransactionActive()) {
+            dataSourceSyncWithinTransaction();
+        } else {
+            transactionOperations.execute((status) -> {
+                dataSourceSyncWithinTransaction();
+                return null;
+            });
         }
-        m_managedAddresses.clear();
-        m_managedAddresses.putAll(newAlreadyDiscovered);
-        LOG.info("dataSourceSync: initialized list of managed IP addresses with {} members", m_managedAddresses.size());
+    }
+
+    private void dataSourceSyncWithinTransaction() {
+        m_lock.writeLock().lock();
+        try {
+            /*
+             * Make a new list with which we'll replace the existing one, that way
+             * if something goes wrong with the DB we won't lose whatever was already
+             * in there
+             */
+            final SortedSetMultimap<Key, Value> newAlreadyDiscovered = Multimaps.newSortedSetMultimap(Maps.newHashMap(), TreeSet::new);
+
+            // Fetch all non-deleted nodes
+            final CriteriaBuilder builder = new CriteriaBuilder(OnmsNode.class);
+            builder.ne("type", String.valueOf(NodeType.DELETED.value()));
+
+            for (OnmsNode node : m_nodeDao.findMatching(builder.toCriteria())) {
+                for (final OnmsIpInterface iface : node.getIpInterfaces()) {
+                    // Skip deleted interfaces
+                    // TODO: Refactor the 'D' value with an enumeration
+                    if ("D".equals(iface.getIsManaged())) {
+                        continue;
+                    }
+                    LOG.debug("Adding entry: {}:{} -> {}", node.getLocation().getLocationName(), iface.getIpAddress(), node.getId());
+                    newAlreadyDiscovered.put(new Key(node.getLocation().getLocationName(), iface.getIpAddress()), new Value(node.getId(), iface.getIsSnmpPrimary()));
+                }
+            }
+            m_managedAddresses.clear();
+            m_managedAddresses.putAll(newAlreadyDiscovered);
+            LOG.info("dataSourceSync: initialized list of managed IP addresses with {} members", m_managedAddresses.size());
+        } finally {
+            m_lock.writeLock().unlock();
+        }
     }
 
     /**

--- a/opennms-dao/src/main/java/org/opennms/netmgt/dao/hibernate/InterfaceToNodeCacheDaoImpl.java
+++ b/opennms-dao/src/main/java/org/opennms/netmgt/dao/hibernate/InterfaceToNodeCacheDaoImpl.java
@@ -210,7 +210,11 @@ public class InterfaceToNodeCacheDaoImpl extends AbstractInterfaceToNodeCache im
             refreshTimer.schedule(new TimerTask() {
                 @Override
                 public void run() {
-                    dataSourceSync();
+                    try {
+                        dataSourceSync();
+                    } catch (Exception ex) {
+                        LOG.error("An error occurred while synchronizing the datasource: {}", ex.getMessage(), ex);
+                    }
                 }
             }, refreshRate, refreshRate);
         }

--- a/opennms-dao/src/main/java/org/opennms/netmgt/dao/support/InterfaceToNodeCacheEventProcessor.java
+++ b/opennms-dao/src/main/java/org/opennms/netmgt/dao/support/InterfaceToNodeCacheEventProcessor.java
@@ -59,12 +59,8 @@ public class InterfaceToNodeCacheEventProcessor implements InitializingBean {
 
     @Override
     public void afterPropertiesSet() throws Exception {
-        // Initialize the cache when this listener is created
-        //
-        // TODO: Should we periodically rebuild the cache from
-        // scratch?
-        //
-        m_cache.dataSourceSync();
+        // Initialization of the cache has moved to the cache implementation itself.
+        // The same is true for refreshing the cache
     }
 
     @EventHandler(uei=EventConstants.NODE_GAINED_INTERFACE_EVENT_UEI)

--- a/opennms-dao/src/main/resources/META-INF/opennms/applicationContext-dao.xml
+++ b/opennms-dao/src/main/resources/META-INF/opennms/applicationContext-dao.xml
@@ -279,7 +279,9 @@
 
   <onmsgi:service interface="org.opennms.netmgt.dao.api.IfLabel" ref="ifLabel" />
 
-  <bean id="interfaceToNodeCache" class="org.opennms.netmgt.dao.hibernate.InterfaceToNodeCacheDaoImpl"/>
+  <bean id="interfaceToNodeCache" class="org.opennms.netmgt.dao.hibernate.InterfaceToNodeCacheDaoImpl">
+    <constructor-arg value="${org.opennms.interface-node-cache.refresh-timer:300000}"/>
+  </bean>
 
   <bean id="interfaceToNodeCache-init" class="org.springframework.beans.factory.config.MethodInvokingFactoryBean">
     <property name="staticMethod">

--- a/opennms-dao/src/test/java/org/opennms/netmgt/dao/hibernate/InterfaceToNodeCacheDaoImplIT.java
+++ b/opennms-dao/src/test/java/org/opennms/netmgt/dao/hibernate/InterfaceToNodeCacheDaoImplIT.java
@@ -28,9 +28,12 @@
 
 package org.opennms.netmgt.dao.hibernate;
 
+import static com.jayway.awaitility.Awaitility.await;
 import static org.opennms.core.utils.InetAddressUtils.addr;
 
 import java.net.InetAddress;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -39,6 +42,7 @@ import org.junit.runner.RunWith;
 import org.opennms.core.spring.BeanUtils;
 import org.opennms.core.test.OpenNMSJUnit4ClassRunner;
 import org.opennms.core.test.db.annotations.JUnitTemporaryDatabase;
+import org.opennms.core.utils.InetAddressUtils;
 import org.opennms.netmgt.dao.DatabasePopulator;
 import org.opennms.netmgt.dao.api.InterfaceToNodeCache;
 import org.opennms.netmgt.dao.api.MonitoringLocationDao;
@@ -49,8 +53,10 @@ import org.opennms.netmgt.model.PrimaryType;
 import org.opennms.test.JUnitConfigurationEnvironment;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionOperations;
 
 import com.google.common.collect.Iterables;
 
@@ -72,6 +78,12 @@ public class InterfaceToNodeCacheDaoImplIT implements InitializingBean {
     @Autowired
     DatabasePopulator m_databasePopulator;
 
+    @Autowired
+    ApplicationContext applicationContext;
+
+    @Autowired
+    TransactionOperations transactionOperations;
+
     @Override
     public void afterPropertiesSet() throws Exception {
         BeanUtils.assertAutowiring(this);
@@ -81,6 +93,44 @@ public class InterfaceToNodeCacheDaoImplIT implements InitializingBean {
     public void setUp() throws Exception {
         m_databasePopulator.populateDatabase();
         m_cache.clear();
+    }
+
+    // Verify reloading works. See HZN-1311
+    @Test
+    public void testReloading() {
+        // We manually have to create a reloading dao, as by default it does not
+        m_cache = new InterfaceToNodeCacheDaoImpl(1000L);
+        applicationContext.getAutowireCapableBeanFactory().autowireBean(m_cache);
+        applicationContext.getAutowireCapableBeanFactory().initializeBean(m_cache, "reloading-interface-to-node-cache");
+
+        // Verify it is initialized
+        Optional<Integer> nodeId = m_cache.getFirstNodeId(MonitoringLocationDao.DEFAULT_MONITORING_LOCATION_ID, m_databasePopulator.getNode1().getPrimaryInterface().getIpAddress());
+        Assert.assertEquals(true, nodeId.isPresent());
+        Assert.assertEquals(m_databasePopulator.getNode1().getId(), nodeId.get());
+
+        // Verify bean is not there yet
+        nodeId = m_cache.getFirstNodeId(MonitoringLocationDao.DEFAULT_MONITORING_LOCATION_ID, InetAddressUtils.addr("8.8.8.8"));
+        Assert.assertEquals(false, nodeId.isPresent());
+
+        // Execute adding of missing node in transaction scope
+        transactionOperations.execute((status) -> {
+            // Add missing node
+            final OnmsNode node = new OnmsNode();
+            node.setLocation(m_databasePopulator.getNode1().getLocation());
+            node.setLabel("Dummy-Node");
+            node.setType(OnmsNode.NodeType.ACTIVE);
+
+            // Add interface to node
+            new OnmsIpInterface(InetAddressUtils.addr("8.8.8.8"), node);
+            m_databasePopulator.getNodeDao().save(node);
+            m_databasePopulator.getNodeDao().flush();
+            return null;
+        });
+
+        // Try for number of seconds until it succeeds
+        await().atMost(10, TimeUnit.SECONDS)
+               .pollInterval(1000, TimeUnit.MILLISECONDS)
+               .until(() -> m_cache.getFirstNodeId(MonitoringLocationDao.DEFAULT_MONITORING_LOCATION_ID, InetAddressUtils.addr("8.8.8.8")).isPresent());
     }
 
     @Test


### PR DESCRIPTION
* JIRA: https://issues.opennms.org/browse/HZN-1311

At this point I keep the existing behaviour as is, but enable the cache to refresh itself if so desired.

Shall we make it automatically refresh by default?