### PR TITLE
NMS-8524: The ReST API used to return XMLs with namespace, and now it doesn't

### DIFF
--- a/opennms-doc/guide-development/src/asciidoc/text/rest/rest-api.adoc
+++ b/opennms-doc/guide-development/src/asciidoc/text/rest/rest-api.adoc
@@ -16,7 +16,7 @@ By default you will not receive a challenge, so you must configure your ReST cli
 === Data format
 
 Jersey allows ReST calls to be made using either XML or JSON.
-By default a request to the API is returned in XML. XML is delivered without namespaces.
+By default a request to the API is returned in XML. XML is delivered without namespaces. Please note: If a namespace is added manually in order to use a XML tool to validate against the XSD (like xmllint) it won't be preserved when OpenNMS updates that file. The same applies to comments.
 To get JSON encoded responses one has to send the following header with the request: `Accept: application/json`.
 
 === Standard Parameters

--- a/opennms-doc/guide-development/src/asciidoc/text/rest/rest-api.adoc
+++ b/opennms-doc/guide-development/src/asciidoc/text/rest/rest-api.adoc
@@ -16,7 +16,7 @@ By default you will not receive a challenge, so you must configure your ReST cli
 === Data format
 
 Jersey allows ReST calls to be made using either XML or JSON.
-By default a request to the API is returned in XML.
+By default a request to the API is returned in XML. XML is delivered without namespaces.
 To get JSON encoded responses one has to send the following header with the request: `Accept: application/json`.
 
 === Standard Parameters


### PR DESCRIPTION
* JIRA: https://issues.opennms.org/browse/NMS-8524

Our [continuous integration system](http://bamboo.internal.opennms.com:8085) will test and verify your changes.
