### PR TITLE
HZN-1291: Enhancements to Plugin Manager

### DIFF
--- a/opennms-doc/guide-admin/src/asciidoc/index.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/index.adoc
@@ -292,8 +292,9 @@ endif::opennms-prime[]
 include::text/plugin-manager/introduction.adoc[]
 include::text/plugin-manager/setting-karaf-instance-data.adoc[]
 include::text/plugin-manager/installing-available-plugins.adoc[]
-include::text/plugin-manager/installing-licences.adoc[]
 include::text/plugin-manager/internal-plugins-repository.adoc[]
+include::text/plugin-manager/installing-licences.adoc[]
+include::text/plugin-manager/licence-structure.adoc[]
 
 == Internal Plugins
 include::text/plugins/introduction.adoc[]

--- a/opennms-doc/guide-admin/src/asciidoc/text/plugin-manager/installing-available-plugins.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/plugin-manager/installing-available-plugins.adoc
@@ -24,7 +24,7 @@ Each plugin has metadata associated with it which is used to identify and descri
 | Feature Repository URL | The URL identifying the feature repository (Same as _Karaf_ Feature Repository URL)
 | Product Description    | A textual description of the functionality provided by the plugin.
 | Product URL            | A URL to point to the plugin's documentation / web site
-| Licence Type           | A description of the licence applied to the plugin (May be GPL if the plugin is not subject to an ELUA)
+| Licence Type           | A description of the licence applied to the plugin (May be GPL if the plugin is not subject to an EULA)
 | Organisation           | The organisation issuing the plugin and/or licence.
 |===
 

--- a/opennms-doc/guide-admin/src/asciidoc/text/plugin-manager/installing-available-plugins.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/plugin-manager/installing-available-plugins.adoc
@@ -5,9 +5,10 @@
 === Installed Plugins
 
 Under plugin settings, the Installed Plugins tab lists which plugins are currently installed in the _Karaf_ instance selected in the _Karaf_ instance data panel.
-System Plugins cannot be uninstalled through the UI.
+Installed plugins can be uninstalled by selecting the plugin on the list and selecting 'uninstall' or reinstalled by selecting the reinstall button.
+However Plugins designated as System Plugins (i.e. the System Plugin checkbox is ticked and grayed out) cannot be uninstalled through the UI.
 (The _Plugin Manager_ is itself a system plugin).
-Non-system plugins can be reinstalled or removed from the system.
+
 Each plugin has metadata associated with it which is used to identify and describe the plugin.
 
 .Plugin Metadata Fields
@@ -23,16 +24,24 @@ Each plugin has metadata associated with it which is used to identify and descri
 | Feature Repository URL | The URL identifying the feature repository (Same as _Karaf_ Feature Repository URL)
 | Product Description    | A textual description of the functionality provided by the plugin.
 | Product URL            | A URL to point to the plugin's documentation / web site
-| licence Type           | A description of the licence applied to the plugin (May be GPL if the plugin is not subject to an ELUA)
+| Licence Type           | A description of the licence applied to the plugin (May be GPL if the plugin is not subject to an ELUA)
 | Organisation           | The organisation issuing the plugin and/or licence.
 |===
 
 image::plugin-manager/05_installedPlugins.png[]
 
-NOTE: The installed plugins tab shows the data retrieved the last time the `Reload Karaf Instance` data button was pressed. (This allow us to maintain a record of offline 
-_Karaf_ instances). However it also means that the localhost data may not be up to date with the local _Karaf_ instance. You should always reload to get the accurate picture of what is currently installed.
+NOTE: The installed plugins tab shows the data retrieved the last time the `Reload Karaf Instance` data button was pressed. 
+(This allow us to maintain a record of offline _Karaf_ instances). 
+However it also means that the localhost data may not be up to date with the local _Karaf_ instance. 
+You should always reload to get the accurate picture of what is currently installed.
+
 
 === Available Plugins Server
+
+Plugins which are available to be installed in _{opennms-product-name}_ are either listed in the Local Available Plugins tab or the Remote Available Plugins tab.
+Local Available Plugins are plugins which are available as standard packaged with the _{opennms-product-name}_ build.
+
+The Plugin Manager gets this list from the local system using the rest interface with the admin user and password.
 
 The _Plugin Manager_ obtains a list of available plugins from the _Available Plugin's server_.
 
@@ -40,8 +49,9 @@ _Available Plugin's server_ can be part of an externally hosted plugin shopping 
 internal list of available plugins as described in the section on Internal Plugins.
  
 In order for externally downloaded plugins to be installed, the _Available Plugin's server_ must have a related maven repository from which
-_Karaf_ can download the feature. By default feature download is not enabled in _{opennms-product-name}_. To enable _Karaf_ external
-feature download, the address of the maven repository should be entered in the org.ops4j.pax.url.mvn.cfg file in the 
+_Karaf_ can download the feature. 
+By default feature download is not enabled in _{opennms-product-name}_. 
+To enable _Karaf_ external feature download, the address of the maven repository should be entered in the org.ops4j.pax.url.mvn.cfg file in the 
 _{opennms-product-name}_ /etc directory.
 
 Alternatively the _Plugin Manager_ can list the available plugins which have been installed on the local machine as bundled Plugin Kar's 
@@ -66,7 +76,7 @@ image::plugin-manager/07_availablePlugins.png[]
 === Plugins Manifest
 
 The Plugins Manifest for a given _Karaf_ instance lists the target plugins which the _Karaf_ instance should install when it next contacts the licence manager.
-If the _Plugin Manager_ can communicate with the remote server, then a manifest can be selected for installation.
+If the _Plugin Manager_ can communicate with the remote server, then a manifest can be selected for immediate installation.
 A manual manifest entry can also be created for a feature.
 This can be used to install features which are not listed in the Available Features list.
 

--- a/opennms-doc/guide-admin/src/asciidoc/text/plugin-manager/installing-available-plugins.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/plugin-manager/installing-available-plugins.adoc
@@ -3,7 +3,7 @@
 :imagesdir: ../../images
 
 === Installed Plugins
-
+ 
 Under plugin settings, the Installed Plugins tab lists which plugins are currently installed in the _Karaf_ instance selected in the _Karaf_ instance data panel.
 Installed plugins can be uninstalled by selecting the plugin on the list and selecting 'uninstall' or reinstalled by selecting the reinstall button.
 However Plugins designated as System Plugins (i.e. the System Plugin checkbox is ticked and grayed out) cannot be uninstalled through the UI.

--- a/opennms-doc/guide-admin/src/asciidoc/text/plugin-manager/internal-plugins-repository.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/plugin-manager/internal-plugins-repository.adoc
@@ -8,12 +8,13 @@ _{opennms-product-name}_ is packaged with an internal repository of plugins whic
 These plugins can be installed in the local _{opennms-product-name}_  _Karaf_ instance and activated by a user using the _Plugin Manager_ 
 in the same way it could be used to download and install external plugins.
 
-The _internal-plugin-descriptor_ feature maintains a list of internal plugins which are packaged with _{opennms-product-name}_. This list of internal
- plugins can be accessed by the _Plugin Manager_ by setting the `Available Plugins Server` to point to the local _{opennms-product-name}_ instance. To do this set
- `Plugin Server URL` to the address of the local _{opennms-product-name}_ (i.e. http:\\localhost:8980\opennms) and set the `Plugin Server Username` and `Plugin Server Password` to match the
-_{opennms-product-name}_ ReST or admin username and password. 
+The _internal-plugin-descriptor_ feature maintains a list of internal plugins which are packaged with _{opennms-product-name}_. 
+This list of internal plugins can be accessed by the _Plugin Manager_ through the Local Available Plugins Panel. 
+ 
+ The same list can also be accessed through the remote plugins panel if the Available Plugins Server entry is set to point to the local _{opennms-product-name}_ instance. 
+ To do this set Plugin Server URL to the address of the local _{opennms-product-name}_ (i.e. http:\\localhost:8980\opennms) and set the Plugin Server Username and Plugin Server Password to match the _{opennms-product-name}_ ReST or admin username and password. 
   
-Clicking `Reload available plugins` will then add the list of available internal plugins to the Available Plugins Tab where they
+Clicking Reload available plugins will then add the list of available internal plugins to the Available Plugins Tab where they
 can be installed and started by the user as described previously. 
 
-The internal plugins included with this _{opennms-product-name}_ release are documented in the next section.
+The internal plugins included with this _{opennms-product-name}_ release are documented in a later section.

--- a/opennms-doc/guide-admin/src/asciidoc/text/plugin-manager/introduction.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/plugin-manager/introduction.adoc
@@ -12,15 +12,39 @@ In addition to managing the installation of _OSGi_ features, the _Plugin Manager
 Although the _{opennms-product-name}_ platform remains open source, this provides a mechanism for third parties developing features on top of the _{opennms-product-name}_ platform to manage access to their software.
 
 The _Plugin Manager_ also provides a mechanism for a separate 'app-store' or Available Plugins Server to be used to deliver these new features and / or licences into a particular _{opennms-product-name}_ instance.
-It is also possible to deliver software without access to the internet using the traditional _Karaf_ Kar/RPM deployment model. (Kar files are a
-form of zip file containing bundles and features definitions which can be deployed in the _Karaf_ /deploy directory). These can be placed in the /deploy directory directly or installed there using an RPM). In this case a number of features can be delivered together in a single software package but each only enabled at run time using the Plugin Manager.
+It is also possible to deliver software without access to the internet using the traditional _Karaf_ Kar/RPM deployment model. 
+(Kar files are a form of zip file containing bundles and features definitions which can be deployed in the _Karaf_ /deploy directory). 
+These can be placed in the /deploy directory directly or installed there using an RPM). 
+In this case a number of features can be delivered together in a single software package but each only enabled at run time using the Plugin Manager.
 
 _{opennms-product-name}_ plugins are standard _Karaf_ features with additional metadata which describes the feature and the licence (if any) required.
 A plugin requiring a licence will not start if a valid licence string is not also installed.
 
+In addition to options described in the licence metadata which is publicly accessible, licences can also contain encrypted secret properties which can only be decrypted when the licence in authenticated. 
+After licence authentication, these properties are then available to a plugin as properties of it's licenceAuthenticator object. 
+
 Note that _Karaf_'s features mechanism has not been modified in any way.
 The Plugin Manager simply provides a user front end and additional metadata for features.
-Plugin features can be installed from the internal features repository, remote maven repositories or _Kar_ files placed in the deploy directory depending on how the _Karaf_ configuration is set up. The standard _{opennms-product-name}_ configuration has no remote maven access enabled for _Karaf_ and external features must be locally provisioned as a _Kar_ or an _RPM_ before being enabled with the _Plugin Manager_.
+Plugin features can be installed from the internal features repository, remote maven repositories or from _Kar_ files placed in the deploy directory depending on how the _Karaf_ configuration is set up. 
+The standard _{opennms-product-name}_ configuration has no remote maven access enabled for _Karaf_ and external features must be locally provisioned as a _Kar_ or an _RPM_ before being enabled with the _Plugin Manager_.
 
 This guide describes how to deploy and manage plugins using the _Plugin Manager_.
-A separate plugin developer's guide is provided for those wishing to write their own plugins.
+A separate plugin developer's guide is provided for those wishing to write their own plugins or generate licences.
+
+=== Plugin Manager UI
+The Plugin Manager page is split into four quadrants. 
+
+The top left quadrant is a panel for setting access properties for each of the managed karaf instances including the local _{opennms-product-name}_ instance.
+In order to access any information through the Plugin Manager, users must enter the url, admin or ReST username and password of the remote karaf being managed by editing its entry in the karaf instance list. 
+This is done by selecting the required karaf entry and selecting edit karaf instance button.
+The local  _{opennms-product-name}_ system is designated by the localhost entry which cannot be removed.
+_NOTE_ that the localhost entry in the karaf instance list also needs to have an entry matching the admin or ReST users of the localhost system for anything to work.
+
+The top right quadrant is a panel for displaying response messages to any action performed. 
+When any operation is performed in the plugin manager, the result is displayed. 
+The full error message associated with any failures can also be viewed.
+
+The bottom right quadrant allows a remote plugin repository and shopping cart to be set up.
+
+The bottom left quadrant contains panels for showing the installed plugins, for setting up a plugin manifest, selecting locally or remotely hosted plugins to be installed and for controlling the installed licences.
+

--- a/opennms-doc/guide-admin/src/asciidoc/text/plugin-manager/licence-structure.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/plugin-manager/licence-structure.adoc
@@ -1,0 +1,47 @@
+
+// Allow GitHub image rendering
+:imagesdir: ../../images
+
+The system provides a robust licencing mechanism which would be difficult to spoof and is considered sufficient for most applications.
+However it should not be considered cryptographic secure to the extent that a determined hacker could not break the system.
+
+=== Licence Structure
+
+The following note describes how licence keys are structured.
+
+Licence keys contain machine readable metadata which can be accessed without decryption.
+The metadata is digitally signed with an encrypted hash which must be decrypted in order to verify the licence data.
+
+Licence keys may also contain additional encrypted secret properties. 
+The secret properties are intended to securely convey application specific secrets such as passwords or keys needed to access remote services.
+
+The entire licence has a Crc32 Checksum appended to ensure it is conveyed intact when it is installed.
+
+The licence keys consist of Hexadecimal strings as ascii printable characters in three (or four) sections separated by the ':' character as follows;
+
+```
+With secret properties:
+<licenceMetadataHexStr>:<encryptedHashStr>":"<aesSecretKeyStr>:<encryptedSecretPropertiesStr>-<Crc32Checksum>
+
+Without secret properties:
+<licenceMetadataHexStr>:<encryptedHashStr>":"<aesSecretKeyStr>-<Crc32Checksum>
+
+```
+The licenceMetadataHexStr is a Hexadecimal encoded version of the XML licence metadata. 
+This section is not encrypted and may be read without decoding so that the key features of the licence may be displayed without access to the licence keys.
+
+The encryptedHashStr is a Hexadecimal version of the encrypted hash of the licenceMetadataHexStr.
+If the hash can be decrypted and the resulting hash matches a hash of the licenceMetadataHexStr, then the licence is deemed to be validated.
+Note that the start time and duration of the licence and the unique system id in the licence must match the local context for the licence to be fully activated.
+
+If the encryptedSecretPropertiesStr is present it contains an encrypted version of the secret properties (as name value pairs) supplied with the licence. (Note that the size of the original properties are limited to 245 bytes by the encrypting algorithm).
+
+Private key encryption is used to encrypt the metadata hash and the secret properties. 
+The AesSymetricKeyCipher has a length of 124 bits which is the longest length key allowed without Government Export authorised without cryptographic extensions
+
+The encryption key is held in the licence creation server as part of the licence specification. 
+The decryption key is held in the remote licence authenticator where the licence is verified. 
+
+However the key held in the licence authenticator is itself encrypted and must first also be decrypted using the aesSecretKeyStr supplied with the licence.
+This means that a licence can only be validated and the secret properties decrypted if the remote licence authenticator is itself unlocked by the licence.
+

--- a/pom.xml
+++ b/pom.xml
@@ -1387,9 +1387,9 @@
     <skipSignJar>true</skipSignJar>
 
     <!-- change to match which version of opennms-pluginmanger you want to run -->
-    <pluginmanagerVersion>1.1.0</pluginmanagerVersion>
-    <licencemanagerVersion>1.1.0</licencemanagerVersion>
-    <featuremanagerVersion>1.1.0</featuremanagerVersion>
+    <pluginmanagerVersion>1.1.0-SNAPSHOT</pluginmanagerVersion>
+    <licencemanagerVersion>1.1.0-SNAPSHOT</licencemanagerVersion>
+    <featuremanagerVersion>1.1.0-SNAPSHOT</featuremanagerVersion>
 
     <!-- nodejs development -->
     <frontendPluginVersion>1.6</frontendPluginVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -1387,9 +1387,9 @@
     <skipSignJar>true</skipSignJar>
 
     <!-- change to match which version of opennms-pluginmanger you want to run -->
-    <pluginmanagerVersion>1.0.7</pluginmanagerVersion>
-    <licencemanagerVersion>1.0.7</licencemanagerVersion>
-    <featuremanagerVersion>1.0.7</featuremanagerVersion>
+    <pluginmanagerVersion>1.1.0-SNAPSHOT</pluginmanagerVersion>
+    <licencemanagerVersion>1.1.0-SNAPSHOT</licencemanagerVersion>
+    <featuremanagerVersion>1.1.0-SNAPSHOT</featuremanagerVersion>
 
     <!-- nodejs development -->
     <frontendPluginVersion>1.6</frontendPluginVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -1387,9 +1387,9 @@
     <skipSignJar>true</skipSignJar>
 
     <!-- change to match which version of opennms-pluginmanger you want to run -->
-    <pluginmanagerVersion>1.1.0-SNAPSHOT</pluginmanagerVersion>
-    <licencemanagerVersion>1.1.0-SNAPSHOT</licencemanagerVersion>
-    <featuremanagerVersion>1.1.0-SNAPSHOT</featuremanagerVersion>
+    <pluginmanagerVersion>1.1.0</pluginmanagerVersion>
+    <licencemanagerVersion>1.1.0</licencemanagerVersion>
+    <featuremanagerVersion>1.1.0</featuremanagerVersion>
 
     <!-- nodejs development -->
     <frontendPluginVersion>1.6</frontendPluginVersion>


### PR DESCRIPTION
This pull request adds enhancements to the OpenNMS Plugin Manager
Jira : https://issues.opennms.org/browse/HZN-1291 Enhancements to Plugin Manager
Enhancements include
* Improved  UI
* More functions available through ReST
* Ability for a 'manifest' of plug-in features to be downloaded by remote at start-up to control which features to install when a remote Karaf is started
* Licence can contain 'secret properties' which can only be read when the licence is decoded
*  Rolling backup licence file to prevent corruption of licences on power fail

The enhancements have actually been made in the Plugin Manager 1.1.0 project
https://github.com/OpenNMS/osgi-plugin-manager/tree/v1.1.0/
This pull request simply ups the version of the plugin manager called into OpenNMS and adds some additional documentation.

Bamboo build succeeds
https://bamboo.opennms.org/browse/OPENNMS-ONMS2272-1 