### PR TITLE
HZN-1326: Alarmd support for Situations

### DIFF
--- a/opennms-alarms/daemon/src/main/java/org/opennms/netmgt/alarmd/AlarmPersisterImpl.java
+++ b/opennms-alarms/daemon/src/main/java/org/opennms/netmgt/alarmd/AlarmPersisterImpl.java
@@ -141,7 +141,7 @@ public class AlarmPersisterImpl implements AlarmPersister {
             if (LOG.isDebugEnabled()) {
                 LOG.debug("addOrReduceEventAsAlarm: reductionKey:{} not found, instantiating new alarm", reductionKey);
             }
-            alarm = createNewAlarm(e, event, m_alarmDao);
+            alarm = createNewAlarm(e, event);
 
             //FIXME: this should be a cascaded save
             m_alarmDao.save(alarm);
@@ -269,7 +269,7 @@ public class AlarmPersisterImpl implements AlarmPersister {
             }
         }
 
-        Set<OnmsAlarm> containedAlarms = getAlarms(event.getParmCollection(), m_alarmDao);
+        Set<OnmsAlarm> containedAlarms = getAlarms(event.getParmCollection());
         if (containedAlarms != null && !containedAlarms.isEmpty()) {
             if (alarm instanceof Situation) {
                 for(OnmsAlarm related : containedAlarms) {
@@ -284,9 +284,9 @@ public class AlarmPersisterImpl implements AlarmPersister {
         e.setAlarm(alarm);
     }
 
-    private static OnmsAlarm createNewAlarm(OnmsEvent e, Event event, AlarmDao alarmDao) {
+    private OnmsAlarm createNewAlarm(OnmsEvent e, Event event) {
         OnmsAlarm alarm;
-        Set<OnmsAlarm> containedAlarms = getAlarms(event.getParmCollection(), alarmDao);
+        Set<OnmsAlarm> containedAlarms = getAlarms(event.getParmCollection());
         // Situations are denoted by the existance of related-reductionKeys
         if (containedAlarms == null || containedAlarms.isEmpty()) {
             alarm = new OnmsAlarm();
@@ -320,13 +320,13 @@ public class AlarmPersisterImpl implements AlarmPersister {
         return alarm;
     }
     
-    private static Set<OnmsAlarm> getAlarms(List<Parm> list, AlarmDao alarmDao) {
+    private Set<OnmsAlarm> getAlarms(List<Parm> list) {
         if (list == null || list.isEmpty()) {
             return Collections.emptySet();
         }
         Set<String> reductionKeys = list.stream().filter(AlarmPersisterImpl::isRelatedReductionKeyWithContent).map(p -> p.getValue().getContent()).collect(Collectors.toSet());
         // Only existing alarms are returned. Reduction Keys for non-existing alarms are dropped.
-        return reductionKeys.stream().map(reductionKey -> alarmDao.findByReductionKey(reductionKey)).filter(Objects::nonNull).collect(Collectors.toSet());
+        return reductionKeys.stream().map(reductionKey -> m_alarmDao.findByReductionKey(reductionKey)).filter(Objects::nonNull).collect(Collectors.toSet());
     }
 
     private static boolean isRelatedReductionKeyWithContent(Parm param) {

--- a/opennms-alarms/daemon/src/main/java/org/opennms/netmgt/alarmd/AlarmPersisterImpl.java
+++ b/opennms-alarms/daemon/src/main/java/org/opennms/netmgt/alarmd/AlarmPersisterImpl.java
@@ -269,6 +269,17 @@ public class AlarmPersisterImpl implements AlarmPersister {
             }
         }
 
+        Set<OnmsAlarm> containedAlarms = getAlarms(event.getParmCollection(), m_alarmDao);
+        if (containedAlarms != null && !containedAlarms.isEmpty()) {
+            if (alarm instanceof Situation) {
+                for(OnmsAlarm related : containedAlarms) {
+                    ((Situation)alarm).addAlarm(related);
+                }
+            } else {
+                LOG.warn("reduceEvent: Event {} attempts to add alarms to alarm that is not a Situation: {}.", event.getUei(), alarm);
+            }
+        }
+
         e.setAlarm(alarm);
     }
 
@@ -317,7 +328,7 @@ public class AlarmPersisterImpl implements AlarmPersister {
 
     private static boolean isRelatedReductionKeyWithContent(Parm param) {
         return param.getParmName() != null
-                && param.getParmName().equals("related-reductionKey")
+                && param.getParmName().startsWith("related-reductionKey")
                 && param.getValue() != null
                 && param.getValue().getContent() != null;
     }

--- a/opennms-alarms/daemon/src/test/java/org/opennms/netmgt/alarmd/SituationIT.java
+++ b/opennms-alarms/daemon/src/test/java/org/opennms/netmgt/alarmd/SituationIT.java
@@ -130,9 +130,9 @@ public class SituationIT {
 
         // update the situation by adding an alarm
         OnmsAlarm alarm3 = new OnmsAlarm();
-        linkDownAlarmOnR2.setDistPoller(m_distPollerDao.whoami());
-        linkDownAlarmOnR2.setCounter(1);
-        linkDownAlarmOnR2.setUei("linkDown");
+        alarm3.setDistPoller(m_distPollerDao.whoami());
+        alarm3.setCounter(1);
+        alarm3.setUei("linkDown");
         retrieved.addAlarm(alarm3);
         assertThat(retrieved.getAlarms().size(), is(3));
 

--- a/opennms-base-assembly/pom.xml
+++ b/opennms-base-assembly/pom.xml
@@ -1,4 +1,3 @@
-
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <parent>


### PR DESCRIPTION
This PR provides support for Alarmd to create and update Situations from events received with the one or more parameters with name 'related-reductionKey'. e.g.: 
     -p 'related-reductionKey uei.value1' 

Each 'related-reductionKey' that resolves to an existing Alarm will be grouped under the Situation.

* JIRA: https://issues.opennms.org/browse/HZN-1326
