### PR TITLE
NMS-9821: Config-tester not validating varbind matching in event files

### DIFF
--- a/opennms-config-model/src/main/resources/xsds/eventconf.xsd
+++ b/opennms-config-model/src/main/resources/xsds/eventconf.xsd
@@ -637,19 +637,19 @@
     </annotation>
 
     <complexType mixed="true">
-      <choice minOccurs="0" maxOccurs="unbounded">
-        <element maxOccurs="1" minOccurs="1" name="vbnumber" type="int">
+      <sequence minOccurs="0" maxOccurs="1">
+        <element minOccurs="1" maxOccurs="1" name="vbnumber" type="int">
           <annotation>
             <documentation>The varbind element number</documentation>
           </annotation>
         </element>
 
-        <element maxOccurs="unbounded" minOccurs="1" name="vbvalue" type="string">
+        <element minOccurs="1" maxOccurs="unbounded" name="vbvalue" type="string">
           <annotation>
             <documentation>The varbind element value</documentation>
           </annotation>
         </element>
-      </choice>
+      </sequence>
       <attribute name="textual-convention" type="this:rfc1903-snmp-tc" use="optional" />
     </complexType>
   </element>

--- a/opennms-config-tester/src/test/java/org/opennms/netmgt/config/tester/ConfigTesterTest.java
+++ b/opennms-config-tester/src/test/java/org/opennms/netmgt/config/tester/ConfigTesterTest.java
@@ -34,9 +34,9 @@ import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.io.FileOutputStream;
-import java.io.FileWriter;
 import java.io.FilenameFilter;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -670,7 +670,7 @@ public class ConfigTesterTest {
         setUpOpennmsHomeInTmpDir();
 
         // create broken properties file in opennms.properties.d:
-        File file = createPropertiesFileInPropertiesD("properties");
+        File file = createFileInPropertiesD("properties");
         String invalidCharacter="'\\u0zb9";
         Files.write(invalidCharacter, file, StandardCharsets.UTF_8);
 
@@ -691,16 +691,18 @@ public class ConfigTesterTest {
     }
 
     private void saveXmlToPropertiesD(String xml) throws IOException{
-        File file = createPropertiesFileInPropertiesD("xml");
+        File file = createFileInPropertiesD("xml");
         Files.write(xml, file, StandardCharsets.UTF_8);
     }
 
     private void savePropertiesToPropertiesD(Properties properties) throws IOException{
-        File file = createPropertiesFileInPropertiesD("properties");
-        properties.store(new FileOutputStream(file), "");
+        File file = createFileInPropertiesD("properties");
+        try(OutputStream out = new FileOutputStream(file)){
+            properties.store(out, "");
+        }
     }
 
-    private File createPropertiesFileInPropertiesD(String sufffix) throws IOException{
+    private File createFileInPropertiesD(String sufffix) throws IOException{
         Path etcDir = java.nio.file.Files.createDirectories(Paths.get(this.opennmsHomeDir.getPath(), "etc/opennms.properties.d"));
         File file = new File(etcDir.toFile(), this.getClass().getSimpleName() + "." + sufffix);
         file.createNewFile();

--- a/opennms-config-tester/src/test/java/org/opennms/netmgt/config/tester/ConfigTesterTest_testEventConf.java
+++ b/opennms-config-tester/src/test/java/org/opennms/netmgt/config/tester/ConfigTesterTest_testEventConf.java
@@ -42,19 +42,21 @@ public class ConfigTesterTest_testEventConf {
 
     @Test
     public void testEventConfWithValidVbNumber() throws IOException {
-        assertNotNull(testEventConf("<vbnumber>1</vbnumber>"));
+        assertNotNull(testEventConf("<vbnumber>1</vbnumber><vbvalue>0</vbvalue>"));
     }
 
     @Test(expected = MarshallingResourceFailureException.class)
-    public void testEventConfWithMissingVbNumber() throws IOException {
-        // Tests NMS-9821
-        // create xml file with missing vbnumber element:
-        testEventConf("<!-- vbnumber missing -->");
+    public void testEventConfWithMissingVbNumberButExistingVbValue() throws IOException {
+        testEventConf("<!-- vbnumber missing --><vbvalue>0</vbvalue>");
     }
 
-    private Events testEventConf(String vbNumber) throws IOException {
+    @Test
+    public void testEventConfWithMissingVbNumberAndExistingVbValue() throws IOException {
+        testEventConf("<!-- vbnumber and vbvalue missing -->");
+    }
+
+    private Events testEventConf(String varbindContent) throws IOException {
         // Tests NMS-9821
-        // create xml file with missing vbnumber element:
         String xml = String.format("<events xmlns=\"http://xmlns.opennms.org/xsd/eventconf\">%n" +
                 "   <event>%n" +
                 "      <mask>%n" +
@@ -64,7 +66,6 @@ public class ConfigTesterTest_testEventConf {
                 "         </maskelement>%n" +
                 "         <varbind>%n" +
                 "            %s%n" +
-                "            <vbvalue>0</vbvalue>%n" +
                 "         </varbind>%n" +
                 "      </mask>%n" +
                 "      <uei>uei.opennms.org/vendor/juniper/traps/juniCliSecurityAlertPriority0</uei>%n" +
@@ -73,7 +74,7 @@ public class ConfigTesterTest_testEventConf {
                 "      <logmsg dest=\"logndisplay\">Juniper CLI Security Alert.</logmsg>%n" +
                 "      <severity>Major</severity>%n" +
                 "   </event>%n" +
-                "</events>", vbNumber);
+                "</events>", varbindContent);
         return JaxbUtils.unmarshal(Events.class, new StringReader(xml));
     }
 }

--- a/opennms-config-tester/src/test/java/org/opennms/netmgt/config/tester/ConfigTesterTest_testEventConf.java
+++ b/opennms-config-tester/src/test/java/org/opennms/netmgt/config/tester/ConfigTesterTest_testEventConf.java
@@ -1,0 +1,79 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2011-2014 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.config.tester;
+
+import static org.junit.Assert.assertNotNull;
+
+import java.io.IOException;
+import java.io.StringReader;
+
+import org.junit.Test;
+import org.opennms.core.xml.JaxbUtils;
+import org.opennms.core.xml.MarshallingResourceFailureException;
+import org.opennms.netmgt.xml.eventconf.Events;
+
+public class ConfigTesterTest_testEventConf {
+
+    @Test
+    public void testEventConfWithValidVbNumber() throws IOException {
+        assertNotNull(testEventConf("<vbnumber>1</vbnumber>"));
+    }
+
+    @Test(expected = MarshallingResourceFailureException.class)
+    public void testEventConfWithMissingVbNumber() throws IOException {
+        // Tests NMS-9821
+        // create xml file with missing vbnumber element:
+        testEventConf("<!-- vbnumber missing -->");
+    }
+
+    private Events testEventConf(String vbNumber) throws IOException {
+        // Tests NMS-9821
+        // create xml file with missing vbnumber element:
+        String xml = String.format("<events xmlns=\"http://xmlns.opennms.org/xsd/eventconf\">%n" +
+                "   <event>%n" +
+                "      <mask>%n" +
+                "         <maskelement>%n" +
+                "            <mename>id</mename>%n" +
+                "            <mevalue>.1.3.6.1.4.1.4874.2.2.30</mevalue>%n" +
+                "         </maskelement>%n" +
+                "         <varbind>%n" +
+                "            %s%n" +
+                "            <vbvalue>0</vbvalue>%n" +
+                "         </varbind>%n" +
+                "      </mask>%n" +
+                "      <uei>uei.opennms.org/vendor/juniper/traps/juniCliSecurityAlertPriority0</uei>%n" +
+                "      <event-label>Juniper-CLI-MIB defined trap event: juniCliSecurityAlert</event-label>%n" +
+                "      <descr>blah</descr>%n" +
+                "      <logmsg dest=\"logndisplay\">Juniper CLI Security Alert.</logmsg>%n" +
+                "      <severity>Major</severity>%n" +
+                "   </event>%n" +
+                "</events>", vbNumber);
+        return JaxbUtils.unmarshal(Events.class, new StringReader(xml));
+    }
+}


### PR DESCRIPTION
* JIRA: https://issues.opennms.org/browse/NMS-9821

This PR is to demonstrate a possible solution to https://issues.opennms.org/browse/NMS-9821 but should no be merged yet since it is not clear why the current code behaves like it is.

Our [continuous integration system](http://bamboo.internal.opennms.com:8085) will test and verify your changes.
