### PR TITLE
NMS-10238: match behavior of all test data from C IPLIKE

### DIFF
--- a/core/test-api/db/src/test/java/org/opennms/core/test/db/IPLikeCoverageIT.java
+++ b/core/test-api/db/src/test/java/org/opennms/core/test/db/IPLikeCoverageIT.java
@@ -1,0 +1,133 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2018 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2018 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.core.test.db;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class IPLikeCoverageIT extends InstallerDbITCase {
+
+    /*
+     * This set of coverage data matches that in https://github.com/OpenNMS/iplike/blob/master/tests.dat
+     */
+    @Test
+    public void testIplikeCoverage() throws Exception {
+        getInstallerDb().updatePlPgsql();
+        getInstallerDb().setPostgresIpLikeLocation(null); // Ensure that we don't try to load the C version
+        getInstallerDb().updateIplike();
+
+        // IPv4 basic matches
+        checkIplikeRule("1.2.3.4","1.2.3.4",true);
+        checkIplikeRule("1.2.3.4","1.2.3.5",false);
+        checkIplikeRule("1.2.3.4","1.2.3.*",true);
+        checkIplikeRule("1.2.3.4","1.*.3.4",true);
+        checkIplikeRule("1.2.3.4","1.*.3.5",false);
+
+        // IPv4 range matches
+        checkIplikeRule("192.168.10.11","192.168.10.10-11",true);
+        checkIplikeRule("192.168.10.12","192.168.10.10-11",false);
+        checkIplikeRule("192.168.223.9","192.168.216-223.*",true);
+        checkIplikeRule("192.168.224.9","192.168.216-223.*",false);
+
+        // IPv4 list matches
+        checkIplikeRule("192.168.1.9","192.168.0,1,2.*",true);
+        checkIplikeRule("192.168.1.9","192.168.1,2,0.*",true);
+        checkIplikeRule("192.168.1.9","192.168.2,0,1.*",true);
+        checkIplikeRule("192.168.3.9","192.168.0,1,2.*",false);
+        checkIplikeRule("192.168.3.9","192.168.1,2,0.*",false);
+        checkIplikeRule("192.168.3.9","192.168.2,0,1.*",false);
+        checkIplikeRule("192.168.3.9","192.168.*,1,2.*",true);
+        checkIplikeRule("192.168.3.9","192.168.0,*,2.*",true);
+        checkIplikeRule("192.168.3.9","192.168.0,1,*.*",true);
+
+        // IPv4 list and range in separate octet
+        checkIplikeRule("192.168.1.9","192.168.0,1,2.0-20",true);
+        checkIplikeRule("192.168.1.21","192.168.0,1,2.0-20",false);
+
+        // IPv4 list and range in same octet
+        checkIplikeRule("192.168.1.9","192.168.0,1,2-4.0-20",true);
+        checkIplikeRule("192.168.3.9","192.168.0,1,2-4.0-20",true);
+        checkIplikeRule("192.168.5.9","192.168.0,1,2-4.0-20",false);
+        checkIplikeRule("192.168.1.21","192.168.0,1,2,3-4.0-20",false);
+        checkIplikeRule("192.168.0.1","192.168.1-2,5.*",false);
+
+        // IPv6 tests
+        checkIplikeRule("fe80:0000:0000:0000:aaaa:bbbb:cccc:dddd","*:*:*:*:*:*:*:*",true);
+        checkIplikeRule("fe80:0000:0000:0000:aaaa:bbbb:cccc:dddd%4","*:*:*:*:*:*:*:*",true);
+        checkIplikeRule("fe80:0000:0000:0000:aaaa:bbbb:cccc:dddd%4","*:*:*:*:*:*:*:*%4",true);
+        checkIplikeRule("fe80:0000:0000:0000:aaaa:bbbb:cccc:dddd","*:*:*:*:*:*:*:*%4",false);
+
+        checkIplikeRule("fe80:0000:0000:0000:aaaa:bbbb:cccc:dddd","fe80:*:*:*:*:*:*:*",true);
+        checkIplikeRule("fe80:0000:0000:0000:aaaa:bbbb:cccc:dddd%45","fe80:*:*:*:*:*:*:*",true);
+        checkIplikeRule("fe80:0000:0000:0000:aaaa:bbbb:cccc:dddd%45","fe80:*:*:*:*:*:*:*%45",true);
+        checkIplikeRule("fe80:0000:0000:0000:aaaa:bbbb:cccc:dddd","fe80:*:*:*:*:*:*:*%45",false);
+
+        checkIplikeRule("fe80:0000:0000:0000:aaaa:bbbb:cccc:dddd","*:*:*:0:*:*:*:*",true);
+        checkIplikeRule("fe80:0000:0000:0000:aaaa:bbbb:cccc:dddd%4","*:*:*:0:*:*:*:*",true);
+        checkIplikeRule("fe80:0000:0000:0000:aaaa:bbbb:cccc:dddd%4","*:*:*:0:*:*:*:*%4",true);
+        checkIplikeRule("fe80:0000:0000:0000:aaaa:bbbb:cccc:dddd","*:*:*:0:*:*:*:*%4",false);
+
+        checkIplikeRule("fe80:0000:0000:0000:aaaa:bbbb:cccc:dddd","*:*:*:*:*:bbbb:*:*",true);
+        checkIplikeRule("fe80:0000:0000:0000:aaaa:bbbb:cccc:dddd%4","*:*:*:*:*:bbbb:*:*",true);
+        checkIplikeRule("fe80:0000:0000:0000:aaaa:bbbb:cccc:dddd%4","*:*:*:*:*:bbbb:*:*%4",true);
+        checkIplikeRule("fe80:0000:0000:0000:aaaa:bbbb:cccc:dddd%4","*:*:*:*:*:bbbb:*:*%5",false);
+        checkIplikeRule("fe80:0000:0000:0000:aaaa:bbbb:cccc:dddd","*:*:*:*:*:bbbb:*:*%4",false);
+
+        checkIplikeRule("fe80:0000:0000:0000:aaaa:bbbb:cccc:dddd","*:*:*:*:*:bbb0-bbbf:*:*",true);
+        checkIplikeRule("fe80:0000:0000:0000:aaaa:bbbb:cccc:dddd%4","*:*:*:*:*:bbb0-bbbf:*:*",true);
+        checkIplikeRule("fe80:0000:0000:0000:aaaa:bbbb:cccc:dddd%4","*:*:*:*:*:bbb0-bbbf:*:*%4",true);
+        checkIplikeRule("fe80:0000:0000:0000:aaaa:bbbb:cccc:dddd","*:*:*:*:*:bbb0-bbbf:*:*%4",false);
+
+        checkIplikeRule("fe80:0000:0000:0000:aaaa:bbbb:cccc:dddd","fe80:0000:0000:0000:aaaa:bbb0-bbbf:cccc:dddd",true);
+        checkIplikeRule("fe80:0000:0000:0000:aaaa:bbbb:cccc:dddd%4","fe80:0000:0000:0000:aaaa:bbb0-bbbf:cccc:dddd",true);
+        checkIplikeRule("fe80:0000:0000:0000:aaaa:bbbb:cccc:dddd%4","fe80:0000:0000:0000:aaaa:bbb0-bbbf:cccc:dddd%4",true);
+        checkIplikeRule("fe80:0000:0000:0000:aaaa:bbbb:cccc:dddd","fe80:0000:0000:0000:aaaa:bbb0-bbbf:cccc:dddd%4",false);
+
+        checkIplikeRule("fe80:0000:0000:0000:aaaa:bbbb:cccc:dddd","fe20,fe70-fe90:0000:0000:0000:*:bbb0,bbb1,bbb2,bbb3,bbb4,bbbb,bbbc:cccc:dddd",true);
+        checkIplikeRule("fe80:0000:0000:0000:aaaa:bbbb:cccc:dddd%4","fe20,fe70-fe90:0000:0000:0000:*:bbb0,bbb1,bbb2,bbb3,bbb4,bbbb,bbbc:cccc:dddd",true);
+        checkIplikeRule("fe80:0000:0000:0000:aaaa:bbbb:cccc:dddd%4","fe20,fe70-fe90:0000:0000:0000:*:bbb0,bbb1,bbb2,bbb3,bbb4,bbbb,bbbc:cccc:dddd%4",true);
+        checkIplikeRule("fe80:0000:0000:0000:aaaa:bbbb:cccc:dddd","fe20,fe70-fe90:0000:0000:0000:*:bbb0,bbb1,bbb2,bbb3,bbb4,bbbb,bbbc:cccc:dddd%4",false);
+
+        checkIplikeRule("fe80:0000:0000:0000:aaaa:bbbb:cccc:dddd","fe80:0000:0000:0000:aaaa:bbbb:cccc:dddd",true);
+        checkIplikeRule("fe80:0000:0000:0000:aaaa:bbbb:cccc:dddd%4","fe80:0000:0000:0000:aaaa:bbbb:cccc:dddd",true);
+        checkIplikeRule("fe80:0000:0000:0000:aaaa:bbbb:cccc:dddd%4","fe80:0000:0000:0000:aaaa:bbbb:cccc:dddd%4",true);
+        checkIplikeRule("fe80:0000:0000:0000:aaaa:bbbb:cccc:dddd","fe80:0000:0000:0000:aaaa:bbbb:cccc:dddd%4",false);
+
+        getInstallerDb().closeConnection();
+    }
+
+    private void checkIplikeRule(final String value, final String rule, final boolean expected) throws Exception {
+        final Boolean result = getJdbcTemplate().queryForObject("SELECT iplike(CAST(? AS TEXT),CAST(? AS TEXT))", new String[] { value, rule }, Boolean.class);
+        if (expected) {
+            assertTrue("SELECT iplike(" + value + "," + rule + ") === " + expected, result);
+        }
+    }
+
+}

--- a/core/test-api/db/src/test/java/org/opennms/core/test/db/InstallerDbIT.java
+++ b/core/test-api/db/src/test/java/org/opennms/core/test/db/InstallerDbIT.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2005-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2005-2018 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2018 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -35,14 +35,11 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.io.PrintStream;
 import java.io.StringReader;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
-import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
@@ -53,63 +50,21 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.opennms.core.db.install.Column;
 import org.opennms.core.db.install.Constraint;
-import org.opennms.core.db.install.InstallerDb;
 import org.opennms.core.db.install.Table;
 import org.opennms.core.db.install.Trigger;
-import org.opennms.core.test.db.TemporaryDatabaseITCase;
 import org.opennms.test.ThrowableAnticipator;
 import org.springframework.util.StringUtils;
 
-public class InstallerDbIT extends TemporaryDatabaseITCase {
-    private InstallerDb m_installerDb;
-    private Connection m_connection;
-
-    private ByteArrayOutputStream m_outputStream;
-
-    @Before
-    public void setUp() throws Exception {
-        super.setUp();
-
-        m_installerDb = new InstallerDb();
-
-        resetOutputStream();
-        getInstallerDb().setDatabaseName(getTestDatabase());
-        m_installerDb.setPostgresOpennmsUser("opennms");
-
-        getInstallerDb().setCreateSqlLocation("../../../opennms-base-assembly/src/main/filtered/etc/create.sql");
-
-        getInstallerDb().setStoredProcedureDirectory("../../../opennms-base-assembly/src/main/filtered/etc");
-
-        getInstallerDb().setDebug(true);
-
-        getInstallerDb().readTables();
-
-        getInstallerDb().setDataSource(getDataSource());
-
-        m_connection = getDataSource().getConnection();
-    }
-
-    @After
-    public void tearDown() throws Exception {
-        m_connection.close();
-        getInstallerDb().closeConnection();
-
-        super.tearDown();
-    }
-
-    // XXX this should be an integration test
+public class InstallerDbIT extends InstallerDbITCase {
     @Test
     public void testCreateSequences() throws Exception {
         getInstallerDb().createSequences();
     }
 
-    // XXX this should be an integration test
     @Test
     public void testCreateTables() throws Exception {
         getInstallerDb().createSequences();
@@ -119,7 +74,6 @@ public class InstallerDbIT extends TemporaryDatabaseITCase {
         getInstallerDb().createTables();
     }
 
-    // XXX this should be an integration test
     @Test
     public void testCreateTablesTwice() throws Exception {
         // First pass.
@@ -812,7 +766,7 @@ public class InstallerDbIT extends TemporaryDatabaseITCase {
 
         getInstallerDb().createTables();
 
-        Statement st = m_connection.createStatement();
+        Statement st = getConnection().createStatement();
         ResultSet rs = st.executeQuery("SELECT eventsource from events");
         int count = 0;
         while (rs.next()) {
@@ -856,7 +810,7 @@ public class InstallerDbIT extends TemporaryDatabaseITCase {
 
         getInstallerDb().createTables();
 
-        Statement st = m_connection.createStatement();
+        Statement st = getConnection().createStatement();
         ResultSet rs = st.executeQuery("SELECT outageid from outages");
         int count = 0;
         for (int expected = 1; rs.next(); expected++) {
@@ -893,7 +847,7 @@ public class InstallerDbIT extends TemporaryDatabaseITCase {
 
         getInstallerDb().createTables();
 
-        Statement st = m_connection.createStatement();
+        Statement st = getConnection().createStatement();
         ResultSet rs = st.executeQuery("SELECT svcregainedeventid from outages");
         int count = 0;
         while (rs.next()) {
@@ -934,7 +888,7 @@ public class InstallerDbIT extends TemporaryDatabaseITCase {
 
         getInstallerDb().createTables();
 
-        Statement st = m_connection.createStatement();
+        Statement st = getConnection().createStatement();
         ResultSet rs = st.executeQuery("SELECT id from usersnotified");
         int count = 0;
         for (int expected = 1; rs.next(); expected++) {
@@ -969,7 +923,7 @@ public class InstallerDbIT extends TemporaryDatabaseITCase {
 
         getInstallerDb().createTables();
 
-        Statement st = m_connection.createStatement();
+        Statement st = getConnection().createStatement();
         ResultSet rs = st.executeQuery("SELECT id from snmpInterface");
         int count = 0;
         for (int expected = 1; rs.next(); expected++) {
@@ -1001,7 +955,7 @@ public class InstallerDbIT extends TemporaryDatabaseITCase {
 
         getInstallerDb().createTables();
 
-        Statement st = m_connection.createStatement();
+        Statement st = getConnection().createStatement();
         ResultSet rs = st.executeQuery("SELECT id from snmpInterface");
 
         assertTrue("Could not ResultSet.next() to first result entry",
@@ -1125,7 +1079,7 @@ public class InstallerDbIT extends TemporaryDatabaseITCase {
 
         getInstallerDb().createTables();
 
-        Statement st = m_connection.createStatement();
+        Statement st = getConnection().createStatement();
         ResultSet rs = st.executeQuery("SELECT id from assets");
 
         assertTrue("Could not ResultSet.next() to first result entry",
@@ -1190,7 +1144,7 @@ public class InstallerDbIT extends TemporaryDatabaseITCase {
         Statement st;
         ResultSet rs;
 
-        st = m_connection.createStatement();
+        st = getConnection().createStatement();
         rs = st.executeQuery("SELECT id from snmpInterface ORDER BY nodeId");
 
         assertTrue("Could not ResultSet.next() to first result entry",
@@ -1203,7 +1157,7 @@ public class InstallerDbIT extends TemporaryDatabaseITCase {
 
         assertFalse("Too many entries", rs.next());
 
-        st = m_connection.createStatement();
+        st = getConnection().createStatement();
         rs = st.executeQuery("SELECT id, snmpInterfaceID from ipInterface ORDER BY nodeId");
 
         assertTrue("Could not ResultSet.next() to first result entry",
@@ -1280,7 +1234,7 @@ public class InstallerDbIT extends TemporaryDatabaseITCase {
 
         getInstallerDb().createTables();
 
-        Statement st = m_connection.createStatement();
+        Statement st = getConnection().createStatement();
         ResultSet rs = st.executeQuery("SELECT id from ipInterface");
 
         assertTrue("could not advance results to first row", rs.next());
@@ -1362,7 +1316,7 @@ public class InstallerDbIT extends TemporaryDatabaseITCase {
 
         getInstallerDb().createTables();
 
-        Statement st = m_connection.createStatement();
+        Statement st = getConnection().createStatement();
         ResultSet rs = st.executeQuery("SELECT id from ifServices");
         int count = 0;
         for (int expected = 1; rs.next(); expected++) {
@@ -1787,20 +1741,11 @@ public class InstallerDbIT extends TemporaryDatabaseITCase {
                    + "' does not exist on table '"
                    + trigger.getTable() + "' to execute '"
                    + trigger.getStoredProcedure() + "' function",
-                   trigger.isOnDatabase(m_connection));
-    }
-
-    public InstallerDb getInstallerDb() {
-        return m_installerDb;
-    }
-    
-    public void resetOutputStream() {
-        m_outputStream = new ByteArrayOutputStream();
-        getInstallerDb().setOutputStream(new PrintStream(m_outputStream));
+                   trigger.isOnDatabase(getConnection()));
     }
 
     private void assertNoTablesHaveChanged() throws IOException {
-        ByteArrayInputStream in = new ByteArrayInputStream(m_outputStream.toByteArray());
+        ByteArrayInputStream in = new ByteArrayInputStream(getOutputStream().toByteArray());
         BufferedReader reader = new BufferedReader(new InputStreamReader(in, StandardCharsets.UTF_8));
 
         String line;
@@ -1832,7 +1777,7 @@ public class InstallerDbIT extends TemporaryDatabaseITCase {
         }
         
         if (unanticipatedOutput.size() > 0) {
-            org.junit.Assert.fail(unanticipatedOutput.size() + "unexpected line(s) output by createTables(): \n\t" + StringUtils.collectionToDelimitedString(unanticipatedOutput, "\n\t") + "\nAll output:\n" + m_outputStream);
+            org.junit.Assert.fail(unanticipatedOutput.size() + "unexpected line(s) output by createTables(): \n\t" + StringUtils.collectionToDelimitedString(unanticipatedOutput, "\n\t") + "\nAll output:\n" + getOutputStream());
         }
     }
 

--- a/core/test-api/db/src/test/java/org/opennms/core/test/db/InstallerDbITCase.java
+++ b/core/test-api/db/src/test/java/org/opennms/core/test/db/InstallerDbITCase.java
@@ -1,0 +1,83 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2018 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2018 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.core.test.db;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+
+import org.junit.After;
+import org.junit.Before;
+import org.opennms.core.db.install.InstallerDb;
+
+public class InstallerDbITCase extends TemporaryDatabaseITCase {
+    private InstallerDb m_installerDb;
+    private ByteArrayOutputStream m_outputStream;
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+
+        m_installerDb = new InstallerDb();
+
+        resetOutputStream();
+        getInstallerDb().setDatabaseName(getTestDatabase());
+        m_installerDb.setPostgresOpennmsUser("opennms");
+
+        getInstallerDb().setCreateSqlLocation("../../../opennms-base-assembly/src/main/filtered/etc/create.sql");
+
+        getInstallerDb().setStoredProcedureDirectory("../../../opennms-base-assembly/src/main/filtered/etc");
+
+        getInstallerDb().setDebug(true);
+
+        getInstallerDb().readTables();
+
+        getInstallerDb().setDataSource(getDataSource());
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        getConnection().close();
+        getInstallerDb().closeConnection();
+
+        super.tearDown();
+    }
+
+    public InstallerDb getInstallerDb() {
+        return m_installerDb;
+    }
+
+    public ByteArrayOutputStream getOutputStream() {
+        return m_outputStream;
+    }
+
+    public void resetOutputStream() {
+        m_outputStream = new ByteArrayOutputStream();
+        getInstallerDb().setOutputStream(new PrintStream(m_outputStream));
+    }
+}


### PR DESCRIPTION
These changes do a number of things to fix the behavior of matching
to more closely follow the C version of IPLIKE.  It also includes
a few "best practices" fixes.

* do simple matching of scope identifiers
* use 'if X is not true' rather than 'if not X' to avoid incorrect matches when NULL is returned
* handle wildcards in hex rule checks properly

* JIRA: http://issues.opennms.org/browse/NMS-10238

Our [continuous integration system](http://bamboo.internal.opennms.com:8085) will test and verify your changes.
