### PR TITLE
NMS-10239: apply centralized datetime rendering to freemarker template(s)

### DIFF
--- a/core/lib/src/main/java/org/opennms/core/time/CentralizedDateTimeFormat.java
+++ b/core/lib/src/main/java/org/opennms/core/time/CentralizedDateTimeFormat.java
@@ -1,0 +1,112 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2018 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2018 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.core.time;
+
+import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE;
+import static java.time.temporal.ChronoField.HOUR_OF_DAY;
+import static java.time.temporal.ChronoField.MINUTE_OF_HOUR;
+import static java.time.temporal.ChronoField.SECOND_OF_MINUTE;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.util.Date;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * This class provides a centralized point to format date times consistently across OpenNMS.
+ * Class is thread safe
+ */
+public class CentralizedDateTimeFormat {
+
+    public final static String SYSTEM_PROPERTY_DATE_FORMAT = "org.opennms.ui.datettimeformat";
+
+    private final static Logger log = Logger.getLogger(CentralizedDateTimeFormat.class.getName());
+
+    private final DateTimeFormatter formatter;
+
+    public CentralizedDateTimeFormat(){
+        this.formatter = createFormatter();
+    }
+
+    public String format(Instant instant) {
+        if(instant == null){
+            return null;
+        }
+        return formatter.format(instant);
+    }
+
+    @Deprecated // please use format(Instant) instead
+    public String format(Date date) {
+        if (date == null) {
+            return null;
+        }
+        return format(date.toInstant());
+    }
+
+
+    private static DateTimeFormatter createFormatter() {
+        String format = System.getProperty(SYSTEM_PROPERTY_DATE_FORMAT);
+        DateTimeFormatter formatter;
+        if (format == null) {
+            formatter = getDefaultFormatter();
+        } else {
+            try {
+                formatter = DateTimeFormatter.ofPattern(format).withZone(ZoneId.systemDefault());
+            } catch (IllegalArgumentException e) {
+                log.log(Level.WARNING,
+                        String.format("Can not use System Property %s=%s as dateformat, will fall back to default." +
+                                        " Please see also java.time.format.DateTimeFormatter for the correct syntax",
+                                SYSTEM_PROPERTY_DATE_FORMAT,
+                                format)
+                        , e);
+                formatter = getDefaultFormatter();
+            }
+        }
+        return formatter;
+    }
+
+    private static DateTimeFormatter getDefaultFormatter() {
+
+        return new DateTimeFormatterBuilder()
+                .parseCaseInsensitive()
+                .append(ISO_LOCAL_DATE)
+                .appendLiteral('T')
+                .appendValue(HOUR_OF_DAY, 2)
+                .appendLiteral(':')
+                .appendValue(MINUTE_OF_HOUR, 2)
+                .optionalStart()
+                .appendLiteral(':')
+                .appendValue(SECOND_OF_MINUTE, 2)
+                .appendOffsetId().toFormatter()
+                .withZone(ZoneId.systemDefault());
+    }
+}

--- a/opennms-webapp/src/main/java/org/opennms/web/controller/NavBarController.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/controller/NavBarController.java
@@ -32,6 +32,7 @@ import java.io.IOException;
 import java.io.StringWriter;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
+import java.time.Instant;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -40,6 +41,7 @@ import java.util.HashMap;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.opennms.core.time.CentralizedDateTimeFormat;
 import org.opennms.netmgt.config.NotifdConfigFactory;
 import org.opennms.web.api.Authentication;
 import org.opennms.web.api.OnmsHeaderProvider;
@@ -68,6 +70,7 @@ import freemarker.template.TemplateModelException;
 public class NavBarController extends AbstractController implements InitializingBean, OnmsHeaderProvider {
     private List<NavBarEntry> m_navBarItems;
     private FreemarkerView m_view;
+    private CentralizedDateTimeFormat dateTimeFormat;
 
     /**
      * <p>afterPropertiesSet</p>
@@ -85,6 +88,7 @@ public class NavBarController extends AbstractController implements Initializing
         Template template = cfg.getTemplate("navbar.ftl");
 
         m_view = new FreemarkerView(template);
+        dateTimeFormat = new CentralizedDateTimeFormat();
     }
 
     /** {@inheritDoc} */
@@ -109,6 +113,7 @@ public class NavBarController extends AbstractController implements Initializing
                 org.opennms.web.api.Util.calculateUrlBase(request));
         model.put("isProvision", request.isUserInRole(Authentication.ROLE_PROVISION));
         model.put("isAdmin", request.isUserInRole(Authentication.ROLE_ADMIN));
+        model.put("formattedTime", this.dateTimeFormat.format(Instant.now()));
 
         String noticeStatus = "Unknown";
         try {

--- a/opennms-webapp/src/main/java/org/opennms/web/tags/DateTimeTag.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/tags/DateTimeTag.java
@@ -28,21 +28,13 @@
 
 package org.opennms.web.tags;
 
-import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE;
-import static java.time.temporal.ChronoField.HOUR_OF_DAY;
-import static java.time.temporal.ChronoField.MINUTE_OF_HOUR;
-import static java.time.temporal.ChronoField.SECOND_OF_MINUTE;
-
 import java.io.IOException;
 import java.time.Instant;
-import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeFormatterBuilder;
 import java.util.Date;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 import javax.servlet.jsp.tagext.SimpleTagSupport;
+
+import org.opennms.core.time.CentralizedDateTimeFormat;
 
 /**
  * This class replaces the &lt;fmt:formatDate /&gt; tag.
@@ -57,49 +49,11 @@ import javax.servlet.jsp.tagext.SimpleTagSupport;
  */
 public class DateTimeTag extends SimpleTagSupport {
 
-    final static String SYSTEM_PROPERTY_DATE_FORMAT = "org.opennms.ui.datettimeformat";
-
-    private final static Logger LOG = Logger.getLogger(DateTimeTag.class.getName());
-
-    private final static DateTimeFormatter DEFAULT_FORMATTER = new DateTimeFormatterBuilder()
-            .parseCaseInsensitive()
-            .append(ISO_LOCAL_DATE)
-            .appendLiteral('T')
-            .appendValue(HOUR_OF_DAY, 2)
-            .appendLiteral(':')
-            .appendValue(MINUTE_OF_HOUR, 2)
-            .optionalStart()
-            .appendLiteral(':')
-            .appendValue(SECOND_OF_MINUTE, 2)
-            .appendOffsetId().toFormatter()
-            .withZone(ZoneId.systemDefault());
-
     private Instant instant;
-    private DateTimeFormatter formatter;
-
-
-    public DateTimeTag(){
-        String format = System.getProperty(SYSTEM_PROPERTY_DATE_FORMAT);
-        if(format == null) {
-            this.formatter = DEFAULT_FORMATTER;
-        } else {
-            try {
-                this.formatter = DateTimeFormatter.ofPattern(format).withZone(ZoneId.systemDefault());
-            } catch (IllegalArgumentException e) {
-                LOG.log(Level.WARNING,
-                        String.format("Can not use System Property %s=%s as dateformat, will fall back to default." +
-                                " Please see also java.time.format.DateTimeFormatter for the correct syntax",
-                                SYSTEM_PROPERTY_DATE_FORMAT,
-                                format)
-                        , e);
-                this.formatter = DEFAULT_FORMATTER;
-            }
-        }
-    }
 
     @Override
     public void doTag() throws IOException {
-        String output = this.formatter.format(instant);
+        String output = new CentralizedDateTimeFormat().format(instant);
         getJspContext().getOut().write(output);
     }
 

--- a/opennms-webapp/src/main/java/org/opennms/web/tags/DateTimeTag.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/tags/DateTimeTag.java
@@ -31,6 +31,7 @@ package org.opennms.web.tags;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.Date;
+import java.util.Optional;
 
 import javax.servlet.jsp.tagext.SimpleTagSupport;
 
@@ -53,7 +54,8 @@ public class DateTimeTag extends SimpleTagSupport {
 
     @Override
     public void doTag() throws IOException {
-        String output = new CentralizedDateTimeFormat().format(instant);
+        // Output an empty string for null values. I believe fmt:formatDate does the same
+        String output = Optional.ofNullable(new CentralizedDateTimeFormat().format(instant)).orElse("");
         getJspContext().getOut().write(output);
     }
 

--- a/opennms-webapp/src/main/resources/org/opennms/web/controller/navbar.ftl
+++ b/opennms-webapp/src/main/resources/org/opennms/web/controller/navbar.ftl
@@ -15,7 +15,7 @@
 
     <#if request.remoteUser?has_content >
       <div id="headerinfo" style="display: none" class="nav navbar-nav navbar-right navbar-info">
-        ${currentDate?string["MMM d, y HH:mm z"]}
+        ${formattedTime}
         <span class="fa-stack" style="text-shadow:none">
         <#if noticeStatus = 'Unknown'>
             <!-- Gray circle with bell inside -->

--- a/opennms-webapp/src/test/java/org/opennms/web/tags/DateTimeTagTest.java
+++ b/opennms-webapp/src/test/java/org/opennms/web/tags/DateTimeTagTest.java
@@ -55,14 +55,15 @@ public class DateTimeTagTest {
 
     @Test
     public void shouldBeResilientAgainstNull() throws IOException {
-        test("yyyy-MM-dd'T'HH:mm:ssxxx", Instant.now());
+        // we expect an empty String, same as fmt:formatDate outputs
+        assertEquals("", DateTimeTagInvoker.create().setInstant(null).invokeAndGet());
     }
 
     @Test
     public void shouldHonorSystemSettings() throws IOException {
         String format = "yyy-MM-dd";
         System.setProperty(CentralizedDateTimeFormat.SYSTEM_PROPERTY_DATE_FORMAT, format);
-        test(format, null);
+        test(format, Instant.now());
         System.clearProperty(CentralizedDateTimeFormat.SYSTEM_PROPERTY_DATE_FORMAT);
     }
 
@@ -109,7 +110,7 @@ public class DateTimeTagTest {
         public String invokeAndGet() throws IOException {
             this.tag.doTag();
             this.writer.close();
-            return this.writer.getBuffer().toString();
+            return this.writer.getBuffer() == null ? null : this.writer.getBuffer().toString();
         }
     }
 }


### PR DESCRIPTION
* JIRA: https://issues.opennms.org/browse/NMS-10239

Part of NMS-10072: Normalize date formats across the WebUI
Should be merged after: https://github.com/OpenNMS/opennms/pull/2033 (was branched off of that branch)

Our [continuous integration system](http://bamboo.internal.opennms.com:8085) will test and verify your changes.
