### PR TITLE
HZN-1344: Add all default sentinel feature repositories to cfg

### DIFF
--- a/container/shared/pom.xml
+++ b/container/shared/pom.xml
@@ -36,12 +36,12 @@
                         <!-\- OPENNMS: Add the OpenNMS Karaf extensions feature repository -\->
                         <repository>mvn:org.opennms.karaf/opennms/${project.version}/xml/karaf-extensions</repository>
                     </bootRepositories> -->
-		    <descriptors>
+		            <descriptors>
                         <!-- OPENNMS: Add the OpenNMS Karaf extensions feature repository -->
                         <descriptor>mvn:org.opennms.karaf/opennms/${project.version}/xml/karaf-extensions</descriptor>
                         <!-- OPENNMS: Additional tools -->
                         <descriptor>mvn:io.hawt/hawtio-karaf/${hawtio.version}/xml/features</descriptor>
-		    </descriptors>
+		            </descriptors>
                     <installedFeatures>
                         <feature>wrapper</feature>
 

--- a/features/container/sentinel/src/main/filtered-resources/etc/org.apache.karaf.features.cfg
+++ b/features/container/sentinel/src/main/filtered-resources/etc/org.apache.karaf.features.cfg
@@ -1,0 +1,93 @@
+################################################################################
+#
+#    Licensed to the Apache Software Foundation (ASF) under one or more
+#    contributor license agreements.  See the NOTICE file distributed with
+#    this work for additional information regarding copyright ownership.
+#    The ASF licenses this file to You under the Apache License, Version 2.0
+#    (the "License"); you may not use this file except in compliance with
+#    the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+################################################################################
+
+#
+# Comma separated list of features repositories to register by default
+#
+featuresRepositories = \
+    mvn:org.apache.karaf.features/framework/${karafVersion}/xml/features, \
+    mvn:org.apache.karaf.features/spring/${karafVersion}/xml/features, \
+    mvn:org.opennms.karaf/opennms/${project.version}/xml/karaf-extensions, \
+    mvn:org.opennms.karaf/opennms/${project.version}/xml/opennms, \
+    mvn:org.opennms.karaf/opennms/${project.version}/xml/sentinel, \
+    mvn:org.apache.karaf.features/standard/${karafVersion}/xml/features, \
+    mvn:org.apache.karaf.features/spring-legacy/${karafVersion}/xml/features
+
+#
+# Comma separated list of features to install at startup
+#
+featuresBoot = \
+    (aries-blueprint, \
+    deployer), \
+    instance/${karafVersion}, \
+    package/${karafVersion}, \
+    log/${karafVersion}, \
+    scv/${project.version}, \
+    ssh/${karafVersion}, \
+    karaf-extender/${project.version}, \
+    framework/${karafVersion}, \
+    system/${karafVersion}, \
+    eventadmin/${karafVersion}, \
+    feature/${karafVersion}, \
+    shell/${karafVersion}, \
+    management/${karafVersion}, \
+    service/${karafVersion}, \
+    jaas/${karafVersion}, \
+    shell-compat/${karafVersion}, \
+    diagnostic/${karafVersion}, \
+    wrap, \
+    bundle/${karafVersion}, \
+    config/${karafVersion}, \
+    kar/${karafVersion}
+
+#
+# Resource repositories (OBR) that the features resolver can use
+# to resolve requirements/capabilities
+#
+# The format of the resourceRepositories is 
+# resourceRepositories=[xml:url|json:url],...
+# for Instance:
+#
+#resourceRepositories=xml:http://host/path/to/index.xml
+# or
+#resourceRepositories=json:http://host/path/to/index.json
+#
+
+#
+# Defines if the boot features are started in asynchronous mode (in a dedicated thread)
+#
+featuresBootAsynchronous=false
+
+#
+# Service requirements enforcement
+#
+# By default, the feature resolver checks the service requirements/capabilities of
+# bundles for new features (xml schema >= 1.3.0) in order to automatically installs
+# the required bundles.
+# The following flag can have those values:
+#   - disable: service requirements are completely ignored
+#   - default: service requirements are ignored for old features
+#   - enforce: service requirements are always verified
+#
+#serviceRequirements=default
+
+#
+# Store cfg file for config element in feature
+#
+#configCfgStore=true

--- a/opennms-doc/guide-admin/src/asciidoc/text/sentinel/sentinel.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/sentinel/sentinel.adoc
@@ -89,16 +89,7 @@ NOTE:   Basically the same properties as for the _Minion Controller_ are support
 
 ===== Install features
 
-The first step is to make the features known to the container:
-
-```
-repo-add mvn:org.apache.karaf.features/spring/4.1.5/xml/features
-repo-add mvn:org.opennms.karaf/opennms/23.0.0-SNAPSHOT/xml/karaf-extensions
-repo-add mvn:org.opennms.karaf/opennms/23.0.0-SNAPSHOT/xml/features
-repo-add mvn:org.opennms.karaf/opennms/23.0.0-SNAPSHOT/xml/sentinel
-```
-
-Afterwards the following features may be installed manually:
+The following features may be installed manually:
 
 [options="header"]
 |====
@@ -165,12 +156,6 @@ This will install all features with `install=auto` automatically.
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://karaf.apache.org/xmlns/features/v1.4.0 http://karaf.apache.org/xmlns/features/v1.4.0"
 >
-    <!-- Make all features available in sentinel known to the system -->
-    <repository>mvn:org.apache.karaf.features/spring/4.1.5/xml/features</repository>
-    <repository>mvn:org.opennms.karaf/opennms/${project.version}/xml/karaf-extensions</repository>
-    <repository>mvn:org.opennms.karaf/opennms/${project.version}/xml/features</repository>
-    <repository>mvn:org.opennms.karaf/opennms/${project.version}/xml/sentinel</repository>
-
     <!-- Install bootstrap feature to start all required features automatically -->
     <feature name="autostart-sentinel-bootstrap-modules" version="${project.version}" start-level="100" install="auto">
         <config name="org.opennms.sentinel.controller">
@@ -225,11 +210,6 @@ This will install all features with `install=auto` automatically.
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://karaf.apache.org/xmlns/features/v1.4.0 http://karaf.apache.org/xmlns/features/v1.4.0"
 >
-    <!-- Make all features available in sentinel known to the system -->
-    <repository>mvn:org.apache.karaf.features/spring/4.1.5/xml/features</repository>
-    <repository>mvn:org.opennms.karaf/opennms/${project.version}/xml/karaf-extensions</repository>
-    <repository>mvn:org.opennms.karaf/opennms/${project.version}/xml/features</repository>
-    <repository>mvn:org.opennms.karaf/opennms/${project.version}/xml/sentinel</repository>
 
     <!-- Install bootstrap feature to start all required features automatically -->
     <feature name="autostart-sentinel-bootstrap-modules" version="${project.version}" start-level="100" install="auto">

--- a/smoke-test/src/test/resources/sentinel/features-jms.xml
+++ b/smoke-test/src/test/resources/sentinel/features-jms.xml
@@ -5,12 +5,6 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://karaf.apache.org/xmlns/features/v1.4.0 http://karaf.apache.org/xmlns/features/v1.4.0"
 >
-    <!-- Make all features available in sentinel known to the system -->
-    <repository>mvn:org.apache.karaf.features/spring/4.1.5/xml/features</repository>
-    <repository>mvn:org.opennms.karaf/opennms/${project.version}/xml/karaf-extensions</repository>
-    <repository>mvn:org.opennms.karaf/opennms/${project.version}/xml/features</repository>
-    <repository>mvn:org.opennms.karaf/opennms/${project.version}/xml/sentinel</repository>
-
     <!-- Install bootstrap feature to start all required features automatically -->
     <feature name="autostart-bootstrap-modules" version="${project.version}" start-level="100" install="auto">
         <feature>scv</feature>

--- a/smoke-test/src/test/resources/sentinel/features-kafka.xml
+++ b/smoke-test/src/test/resources/sentinel/features-kafka.xml
@@ -5,12 +5,6 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://karaf.apache.org/xmlns/features/v1.4.0 http://karaf.apache.org/xmlns/features/v1.4.0"
 >
-    <!-- Make all features available in sentinel known to the system -->
-    <repository>mvn:org.apache.karaf.features/spring/4.1.5/xml/features</repository>
-    <repository>mvn:org.opennms.karaf/opennms/${project.version}/xml/karaf-extensions</repository>
-    <repository>mvn:org.opennms.karaf/opennms/${project.version}/xml/features</repository>
-    <repository>mvn:org.opennms.karaf/opennms/${project.version}/xml/sentinel</repository>
-
     <!-- Install bootstrap feature to start all required features automatically -->
     <feature name="autostart-bootstrap-modules" version="${project.version}" start-level="100" install="auto">
         <feature>scv</feature>


### PR DESCRIPTION
Here we make all relevant features known to the sentinel container, to not use the `karaf-extender`, as in case of minion.

* JIRA: https://issues.opennms.org/browse/HZN-1344