### PR TITLE
NMS-10195: Re-add MIB2 interface errors to default data collection

### DIFF
--- a/opennms-base-assembly/src/main/filtered/etc/datacollection/mib2.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/datacollection/mib2.xml
@@ -37,6 +37,12 @@
       <mibObj oid=".1.3.6.1.2.1.31.1.1.1.12" instance="ifIndex" alias="ifHCOutMulticastPkt" type="Counter64"/>
       <mibObj oid=".1.3.6.1.2.1.31.1.1.1.13" instance="ifIndex" alias="ifHCOutBroadcastPkt" type="Counter64"/>
    </group>
+   <group name="mib2-interface-errors" ifType="all">
+      <mibObj oid=".1.3.6.1.2.1.2.2.1.13" instance="ifIndex" alias="ifInDiscards" type="counter"/>
+      <mibObj oid=".1.3.6.1.2.1.2.2.1.14" instance="ifIndex" alias="ifInErrors" type="counter"/>
+      <mibObj oid=".1.3.6.1.2.1.2.2.1.19" instance="ifIndex" alias="ifOutDiscards" type="counter"/>
+      <mibObj oid=".1.3.6.1.2.1.2.2.1.20" instance="ifIndex" alias="ifOutErrors" type="counter"/>
+   </group>
    <group name="mib2-icmp" ifType="ignore">
       <mibObj oid=".1.3.6.1.2.1.5.2" instance="0" alias="icmpInErrors" type="counter"/>
       <mibObj oid=".1.3.6.1.2.1.5.3" instance="0" alias="icmpInDestUnreachs" type="counter"/>
@@ -141,6 +147,7 @@
       <sysoidMask>.1.3.6.1.4.1.</sysoidMask>
       <collect>
          <includeGroup>mib2-X-interfaces</includeGroup>
+         <includeGroup>mib2-interface-errors</includeGroup>
          <includeGroup>mib2-tcp</includeGroup>
       </collect>
    </systemDef>


### PR DESCRIPTION
This issue re-adds the MIB2 32-bit counters for interface errors. The counters were removed by NMS-10139 which removed the duplicated data collection for 32-bit and 64-bit interface counters.

* JIRA: http://issues.opennms.org/browse/NMS-10195

