### PR TITLE
NMS-10247: Re-add legacy 32-bit interface counter for Microsoft Windows

### DIFF
--- a/opennms-base-assembly/src/main/filtered/etc/datacollection/microsoft.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/datacollection/microsoft.xml
@@ -40,6 +40,7 @@
          <includeGroup>mib2-host-resources-storage</includeGroup>
          <includeGroup>mib2-host-resources-system</includeGroup>
          <includeGroup>windows-host</includeGroup>
+         <includeGroup>mib2-interfaces</includeGroup>
       </collect>
    </systemDef>
 </datacollection-group>


### PR DESCRIPTION
The SNMP agent on Microsoft is going to be deprecated and support for 64-bit counter will probably never happen. Re-add the 32-bit counter for Microsoft Windows systems.

* JIRA: http://issues.opennms.org/browse/NMS-10247

