### PR TITLE
NMS-9858: embed Hawtio in jetty-webapps & create packages

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -133,6 +133,20 @@ Description: Enterprise-grade Open-source Network Management Platform (Remote Po
  .
  This webapp contains the JNLP application that provides the Remote Poller.
 
+Package: opennms-webapp-hawtio
+Architecture: all
+Depends: opennms-server (=${binary:Version})
+Description: Enterprise-grade Open-source Network Management Platform (Hawtio Console)
+ OpenNMS is an enterprise-grade network management system written in Java.
+ .
+ OpenNMS can monitor various network services to determine status and service
+ level availability.  Data collection is performed using protocols such as SNMP
+ to generate reports and alert on thresholds.  An extensible event management
+ and notification system handles both internally and externally generated
+ events (such as SNMP traps), and generates notices via email, pager, SMS, etc.
+ .
+ This webapp contains the Hawtio console.
+
 Package: opennms-ncs
 Architecture: all
 Depends: opennms-webapp-jetty (=${binary:Version})

--- a/debian/opennms-webapp-hawtio.conffiles
+++ b/debian/opennms-webapp-hawtio.conffiles
@@ -1,0 +1,1 @@
+/usr/share/opennms/jetty-webapps/hawtio/WEB-INF/web.xml

--- a/debian/opennms-webapp-hawtio.overrides
+++ b/debian/opennms-webapp-hawtio.overrides
@@ -1,0 +1,1 @@
+opennms-webapp-hawtio: file-in-usr-marked-as-conffile

--- a/debian/rules
+++ b/debian/rules
@@ -327,6 +327,14 @@ install: build
 	find debian/opennms-webapp-remoting/usr/share/opennms/jetty-webapps/opennms* -type f -execdir chmod 644 {} \;
 
 	##
+	## Setup the opennms-webapp-hawtio package
+	##
+	install -d -m 755 debian/opennms-webapp-hawtio/usr/share/opennms/jetty-webapps/hawtio debian/opennms-webapp-hawtio/usr/share/lintian/overrides
+	install -m 644 debian/opennms-webapp-hawtio.overrides debian/opennms-webapp-hawtio/usr/share/lintian/overrides/opennms-webapp-hawtio
+	mv debian/temp/jetty-webapps/hawtio/* debian/opennms-webapp-hawtio/usr/share/opennms/jetty-webapps/hawtio/
+	find debian/opennms-webapp-hawtio/usr/share/opennms/jetty-webapps/hawtio* -type f -execdir chmod 644 {} \;
+
+	##
 	## Setup the opennms-doc package
 	##
 	mv debian/temp/docs/* debian/opennms-doc/usr/share/doc/opennms/

--- a/opennms-full-assembly/pom.xml
+++ b/opennms-full-assembly/pom.xml
@@ -260,6 +260,25 @@
               </artifactItems>
             </configuration>
           </execution>
+          <!-- Unpack hawtio -->
+          <execution>
+            <id>unpack-hawtio</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>unpack</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${project.build.directory}/hawtio-webapp/</outputDirectory>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>io.hawt</groupId>
+                  <artifactId>hawtio-default</artifactId>
+                  <version>${hawtioVersion}</version>
+                  <type>war</type>
+                </artifactItem>
+              </artifactItems>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
       <plugin>
@@ -744,6 +763,12 @@
       <version>${project.version}</version>
       <type>tar.gz</type>
       <classifier>etc</classifier>
+    </dependency>
+    <dependency>
+      <groupId>io.hawt</groupId>
+      <artifactId>hawtio-default</artifactId>
+      <version>${hawtioVersion}</version>
+      <type>war</type>
     </dependency>
 
     <!-- Apache Karaf features.xml artifacts -->

--- a/opennms-full-assembly/src/assembly/components/webapps.xml
+++ b/opennms-full-assembly/src/assembly/components/webapps.xml
@@ -64,4 +64,16 @@
       <includes><include>org.opennms.assemblies:org.opennms.assemblies.http-remoting:war:${project.version}</include></includes>
     </dependencySet>
   </dependencySets>
+  <fileSets>
+    <!-- Copy Hawtio to jetty-webapps -->
+    <fileSet>
+      <directory>${project.build.directory}/hawtio-webapp/</directory>
+      <filtered>false</filtered>
+      <outputDirectory>jetty-webapps/hawtio/</outputDirectory>
+      <excludes>
+        <exclude>**/*log4j*.jar</exclude>
+        <exclude>**/*slf4j*.jar</exclude>
+      </excludes>
+    </fileSet>
+  </fileSets>
 </component>

--- a/pom.xml
+++ b/pom.xml
@@ -1289,6 +1289,7 @@
     <guavaOldVersion>17.0</guavaOldVersion>
     <gwtVersion>2.6.1</gwtVersion>
     <gwtPluginVersion>2.6.1</gwtPluginVersion>
+    <hawtioVersion>1.4.68</hawtioVersion>
     <hibernateValidatorVersion>4.3.2.Final</hibernateValidatorVersion>
     <hikaricpVersion>2.5.1</hikaricpVersion>
     <httpcoreVersion>4.4.4</httpcoreVersion>

--- a/tools/packages/opennms/opennms.spec
+++ b/tools/packages/opennms/opennms.spec
@@ -200,6 +200,18 @@ The JNLP application that provides the Remote Poller.
 %{extrainfo2}
 
 
+%package webapp-hawtio
+Summary:	Hawtio webapp
+Group:		Applications/System
+Requires:	%{name}-core = %{version}-%{release}
+
+%description webapp-hawtio
+The Hawtio web console.
+
+%{extrainfo}
+%{extrainfo2}
+
+
 %package ncs
 Summary:	Network Component Services
 Group:		Applications/System
@@ -719,6 +731,7 @@ find %{buildroot}%{instprefix}/etc %{buildroot}%{instprefix}/lib %{buildroot}%{i
 find %{buildroot}%{jettydir} ! -type d | \
 	sed -e "s,^%{buildroot},," | \
 	grep -v '/opennms-remoting' | \
+	grep -v '/hawtio' | \
 	grep -v '/opennms/source/' | \
 	grep -v '/WEB-INF/[^/]*\.xml$' | \
 	grep -v '/WEB-INF/[^/]*\.properties$' | \
@@ -729,11 +742,13 @@ find %{buildroot}%{jettydir} ! -type d | \
 find %{buildroot}%{jettydir}/*/WEB-INF/*.xml | \
 	sed -e "s,^%{buildroot},%config ," | \
 	grep -v '/opennms-remoting' | \
+	grep -v '/hawtio' | \
 	grep -v '/WEB-INF/ncs' | \
 	sort >> %{_tmppath}/files.jetty
 find %{buildroot}%{jettydir} -type d | \
 	sed -e "s,^%{buildroot},%dir ," | \
 	grep -v '/opennms-remoting' | \
+	grep -v '/hawtio' | \
 	sort >> %{_tmppath}/files.jetty
 
 cd -
@@ -798,6 +813,11 @@ rm -rf %{buildroot}
 %defattr(644 root root 755)
 %config %{jettydir}/opennms-remoting/WEB-INF/*.xml
 %{jettydir}/opennms-remoting
+
+%files webapp-hawtio
+%defattr(644 root root 755)
+%config %{jettydir}/hawtio/WEB-INF/*.xml
+%{jettydir}/hawtio
 
 %files plugins
 


### PR DESCRIPTION
This PR embeds Hawtio in the webapp by unpacking it into `$OPENNMS_HOME/jetty-webapps/hawtio/` (and removing slf4j and log4j from `WEB-INF/lib/` to avoid conflicts).

* JIRA: http://issues.opennms.org/browse/NMS-9858

Our [continuous integration system](http://bamboo.internal.opennms.com:8085) will test and verify your changes.
