### PR TITLE
HZN-1359: Fix the build of the jrb-to-rrd-converter

### DIFF
--- a/opennms-tools/jrb-to-rrd-converter/pom.xml
+++ b/opennms-tools/jrb-to-rrd-converter/pom.xml
@@ -49,7 +49,7 @@
           <execution>
             <phase>package</phase>
             <goals>
-              <goal>attached</goal>
+              <goal>single</goal>
             </goals>
           </execution>
         </executions>


### PR DESCRIPTION
This module's pom.xml uses the older "attached" goal, which was
deprecated in maven-assembly-plugin 2, and removed in 3, yielding this
error:

[ERROR] Could not find goal 'attached' in plugin
org.apache.maven.plugins:maven-assembly-plugin:3.0.0 among available
goals help, single -> [Help 1]

* JIRA: https://issues.opennms.org/browse/HZN-1359

Our [continuous integration system](http://bamboo.internal.opennms.com:8085) will test and verify your changes.