### PR TITLE
HZN-1361: Do not use debugger in CamelBlueprintTests

### DIFF
--- a/core/test-api/camel/src/main/java/org/opennms/core/test/camel/CamelBlueprintTest.java
+++ b/core/test-api/camel/src/main/java/org/opennms/core/test/camel/CamelBlueprintTest.java
@@ -64,12 +64,6 @@ public class CamelBlueprintTest extends CamelBlueprintTestSupport {
     }
 
     @Override
-    public boolean isUseDebugger() {
-        // Must enable debugger
-        return true;
-    }
-
-    @Override
     public String isMockEndpoints() {
         return "*";
     }


### PR DESCRIPTION
* JIRA: https://issues.opennms.org/browse/HZN-1361

As mentioned yesterday, here we disable `isUseDebugger()` as it is causing weird issues and make some tests flap.