### PR TITLE
NMS-10282: Fix the default Alarm Northbounder date format to be valid ISO 8601

### DIFF
--- a/opennms-alarms/api/src/main/java/org/opennms/netmgt/alarmd/api/support/AbstractNorthbounder.java
+++ b/opennms-alarms/api/src/main/java/org/opennms/netmgt/alarmd/api/support/AbstractNorthbounder.java
@@ -302,7 +302,7 @@ public abstract class AbstractNorthbounder implements Northbounder, Runnable, St
         String count = alarm.getCount() == null ? "1" : alarm.getCount().toString();
         mapping.put("count", count);
         if (dateFormat == null) {
-            dateFormat = "yyyy-MM-dd'T'HH:mm:ss:SSSXXX";
+            dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX";
         }
         SimpleDateFormat simpleDateFormat = new SimpleDateFormat(dateFormat);
         String firstOccurence = "";

--- a/opennms-alarms/jms-northbounder/src/test/java/org/opennms/netmgmt/alarmd/northbounder/jms/JmsNorthBounderTest.java
+++ b/opennms-alarms/jms-northbounder/src/test/java/org/opennms/netmgmt/alarmd/northbounder/jms/JmsNorthBounderTest.java
@@ -638,7 +638,7 @@ public class JmsNorthBounderTest {
     }
 
     private String convertDateToDefaultFormat(Date date) {
-        SimpleDateFormat simpleDateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss:SSSXXX");
+        SimpleDateFormat simpleDateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
         return simpleDateFormat.format(date);
 
     }

--- a/opennms-alarms/syslog-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/syslog/SyslogNorthbounderConfig.java
+++ b/opennms-alarms/syslog-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/syslog/SyslogNorthbounderConfig.java
@@ -70,7 +70,7 @@ public class SyslogNorthbounderConfig implements Serializable {
     private String m_messageFormat;
     
     /** The date format. */
-    @XmlElement(name = "date-format", required = false, defaultValue = "yyyy-MM-dd'T'HH:mm:ss:SSSXXX")
+    @XmlElement(name = "date-format", required = false, defaultValue = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX")
     private String m_dateFormat;
 
     /** The destinations. */

--- a/opennms-alarms/syslog-northbounder/src/main/resources/xsds/syslog-northbounder-configuration.xsd
+++ b/opennms-alarms/syslog-northbounder/src/main/resources/xsds/syslog-northbounder-configuration.xsd
@@ -14,7 +14,7 @@
       <xs:element name="batch-size" type="xs:int" default="100" minOccurs="0"/>
       <xs:element name="queue-size" type="xs:int" default="300000" minOccurs="0"/>
       <xs:element name="message-format" type="xs:string" default="ALARM ID:${alarmId} NODE:${nodeLabel} ${logMsg}" minOccurs="0"/>
-      <xs:element name="date-format" type="xs:string" default="yyyy-MM-dd'T'HH:mm:ss:SSSXXX" minOccurs="0"/>
+      <xs:element name="date-format" type="xs:string" default="yyyy-MM-dd'T'HH:mm:ss.SSSXXX" minOccurs="0"/>
       <xs:element name="destination" type="syslogDestination" minOccurs="0" maxOccurs="unbounded"/>
       <xs:element name="uei" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
     </xs:sequence>

--- a/opennms-base-assembly/src/main/filtered/etc/syslog-northbounder-configuration.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/syslog-northbounder-configuration.xml
@@ -6,7 +6,7 @@
    <batch-size>100</batch-size>
    <queue-size>300000</queue-size>
    <message-format>ALARM ID:${alarmId} NODE:${nodeLabel}; ${logMsg}</message-format>
-    <!-- You can specify date format, default is ISO 8601  <date-format>yyyy-MM-dd'T'HH:mm:ss:SSSXXX</date-format> -->
+    <!-- You can specify date format, default is ISO 8601  <date-format>yyyy-MM-dd'T'HH:mm:ss.SSSXXX</date-format> -->
 <!-- You could do something like the following
    <message-format>ALARM ID:${alarmId} NODE:${nodeLabel} IP:${ipAddr} 
       FIRST:${firstOccurrence} LAST:${lastOccurrence} 


### PR DESCRIPTION
The syntax is supposed to use a '.' to separate seconds and fractional
seconds, not a ':'.

* JIRA: http://issues.opennms.org/browse/NMS-10282