### PR TITLE
NMS-10212: Do not reuse RadiusAuthenticator in RadiousAuthenticationProvider

### DIFF
--- a/opennms-webapp/src/main/webapp/WEB-INF/spring-security.d/radius.xml.disabled
+++ b/opennms-webapp/src/main/webapp/WEB-INF/spring-security.d/radius.xml.disabled
@@ -47,7 +47,7 @@
     <!--<beans:property name="port" value="1812"/>-->
     <!--<beans:property name="timeout" value="5"/>-->
     <!--<beans:property name="retries" value="3"/>-->
-    <!--<beans:property name="authTypeClass"><beans:bean class="net.jradius.client.auth.PAPAuthenticator"/></beans:property>-->
+    <!--<beans:property name="authTypeClass" value="net.jradius.client.auth.PAPAuthenticator"/>
     <!--<beans:property name="defaultRoles" value="ROLE_USER"/>-->
     <!--<beans:property name="rolesAttribute" value="Unknown-VSAttribute(%%% Vendor ID %%%:%%% Attribute Number %%%)"/>-->
   </beans:bean>

--- a/protocols/radius/src/main/java/org/opennms/protocols/radius/springsecurity/RadiusAuthenticationProvider.java
+++ b/protocols/radius/src/main/java/org/opennms/protocols/radius/springsecurity/RadiusAuthenticationProvider.java
@@ -82,14 +82,15 @@ public class RadiusAuthenticationProvider extends AbstractUserDetailsAuthenticat
     private int port = 1812, timeout = 5, retries = 3;
 
     /**
-     * There is a bug in {@link net.jradius.client.auth.PAPAuthenticator#processRequest(RadiusPacket)} that prevents 
-     * instances of the class from being reused. Set the authenticator class to null to work 
-     * around this problem (while still using the {@link net.jradius.client.auth.PAPAuthenticator}
-     * class).
-     * 
+     * The type of the {@link RadiusAuthenticator} to use for authentication.
+     * A class/type is used instead of an instance (as it was the case in earlier versions) as
+     * a {@link RadiusAuthenticator} cannot be re-used in another request, as username and password
+     * values are not reset. See {@link RadiusAuthenticator#setupRequest(RadiusClient, RadiusPacket)} for
+     * more details.
+     *
      * @see net.jradius.client.RadiusClient#authenticate(AccessRequest, RadiusAuthenticator, int)
      */
-    private RadiusAuthenticator authTypeClass = null;
+    private Class<? extends RadiusAuthenticator> authTypeClass = null;
 
     private String defaultRoles = Authentication.ROLE_USER, rolesAttribute;
 
@@ -116,8 +117,11 @@ public class RadiusAuthenticationProvider extends AbstractUserDetailsAuthenticat
         Assert.notNull(this.port, "A port number must be specified");
         Assert.notNull(this.timeout, "A timeout must be specified");
         Assert.notNull(this.retries, "A retry count must be specified");
-        //Assert.notNull(this.authTypeClass, "A RadiusAuthenticator object must be supplied in authTypeClass");
         Assert.notNull(this.defaultRoles, "Default Roles must be supplied in defaultRoles");
+
+        if (this.authTypeClass == null) {
+            LOG.warn("No RadiusAuthenticator provided. Falling back to {}", PAPAuthenticator.class);
+        }
     }
 
     /**
@@ -152,15 +156,8 @@ public class RadiusAuthenticationProvider extends AbstractUserDetailsAuthenticat
      *
      * @param authTypeClass An instance of net.jradius.client.auth.RadiusAuthenticator (defaults to PAPAuthenticator)
      */
-    public void setAuthTypeClass(RadiusAuthenticator authTypeClass) {
-        if (authTypeClass instanceof PAPAuthenticator) {
-            // There is a bug in PAPAuthenticator() that prevents instances of the class
-            // from being reused. Set the authenticator class to null to work around this
-            // problem.
-            this.authTypeClass = null;
-        } else {
-            this.authTypeClass = authTypeClass;
-        }
+    public void setAuthTypeClass(Class<? extends RadiusAuthenticator> authTypeClass) {
+        this.authTypeClass = authTypeClass;
     }
 
     /**
@@ -236,11 +233,12 @@ public class RadiusAuthenticationProvider extends AbstractUserDetailsAuthenticat
         attributeList.add(new Attr_UserPassword(password));
         RadiusPacket reply;
         try {
-            RadiusClient radiusClient = new RadiusClient(serverIP, secret, port, port+1, timeout);
-            AccessRequest request = new AccessRequest(radiusClient, attributeList);
+            final RadiusAuthenticator authenticator = createAuthenticator(this.authTypeClass);
+            final RadiusClient radiusClient = new RadiusClient(serverIP, secret, port, port+1, timeout);
+            final AccessRequest request = new AccessRequest(radiusClient, attributeList);
 
-            LOG.debug("Sending AccessRequest message to {}:{} using {} protocol with timeout = {}, retries = {}, attributes:\n{}", InetAddressUtils.str(serverIP), port, (authTypeClass == null ? "PAP" : authTypeClass.getAuthName()), timeout, retries, attributeList.toString());
-            reply = radiusClient.authenticate(request, authTypeClass, retries);
+            LOG.debug("Sending AccessRequest message to {}:{} using {} protocol with timeout = {}, retries = {}, attributes:\n{}", InetAddressUtils.str(serverIP), port, authenticator.getAuthName(), timeout, retries, attributeList.toString());
+            reply = radiusClient.authenticate(request, authenticator, retries);
         } catch (RadiusException e) {
             LOG.error("Error connecting to radius server {} : {}", server, e);
             throw new AuthenticationServiceException(messages.getMessage("RadiusAuthenticationProvider.radiusError",
@@ -252,11 +250,16 @@ public class RadiusAuthenticationProvider extends AbstractUserDetailsAuthenticat
                 new Object[] {e},
                 "Error connecting to radius server: "+e));
         } catch (NoSuchAlgorithmException e) {
-        	LOG.error("Error no such algorithm {} : {}",this.authTypeClass.getClass().getName(), e);
+        	LOG.error("Error no such algorithm {} : {}",this.authTypeClass.getName(), e);
         	throw new AuthenticationServiceException(messages.getMessage("RadiusAuthenticationProvider.radiusError",
                     new Object[] {e},
                     "Error connecting to radius server: "+e));
-		}
+		} catch (IllegalAccessException | InstantiationException e) {
+            LOG.error("Error instantiating configured RadiusAuthenticator {}", this.authTypeClass, e);
+            throw new AuthenticationServiceException(messages.getMessage("RadiusAuthenticationProvider.radiusError",
+                    new Object[] {e},
+                    "Error connecting to radius server: "+e));
+        }
         if (reply == null) {
             LOG.error("Timed out connecting to radius server {}", server);
             throw new AuthenticationServiceException(messages.getMessage("RadiusAuthenticationProvider.radiusTimeout",
@@ -303,6 +306,13 @@ public class RadiusAuthenticationProvider extends AbstractUserDetailsAuthenticat
             LOG.debug("Parsed roles {} for user {}", readRoles, username);
 
         return new User(username, password, true, true, true, true, authorities);
+    }
+
+    private RadiusAuthenticator createAuthenticator(Class<? extends RadiusAuthenticator> authTypeClass) throws IllegalAccessException, InstantiationException {
+        if (authTypeClass == null) {
+            return new PAPAuthenticator();
+        }
+        return authTypeClass.newInstance();
     }
 
 }

--- a/protocols/radius/src/test/java/org/opennms/protocols/radius/springsecurity/RadiusAuthenticationProviderIT.java
+++ b/protocols/radius/src/test/java/org/opennms/protocols/radius/springsecurity/RadiusAuthenticationProviderIT.java
@@ -80,7 +80,8 @@ public class RadiusAuthenticationProviderIT {
     @Test
     public void verifyAuthenticatorIsNotReused() {
         final RadiusAuthenticationProvider provider = new RadiusAuthenticationProvider("localhost", SHARED_SECRET);
-        provider.setAuthTypeClass(new MSCHAPv2Authenticator());
+        provider.setAuthTypeClass(MSCHAPv2Authenticator.class); // The authenticator does not matter,
+                                                                // the problem should occurs with all, except null
 
         // Verify that authenticating with an existing user works
         final UsernamePasswordAuthenticationToken token = new UsernamePasswordAuthenticationToken(USER, PASSWORD);

--- a/protocols/radius/src/test/java/org/opennms/protocols/radius/springsecurity/RadiusAuthenticationProviderIT.java
+++ b/protocols/radius/src/test/java/org/opennms/protocols/radius/springsecurity/RadiusAuthenticationProviderIT.java
@@ -1,0 +1,98 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2018-2018 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2018 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.protocols.radius.springsecurity;
+
+import java.net.InetSocketAddress;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.AuthenticationException;
+import org.tinyradius.util.RadiusServer;
+
+import net.jradius.client.auth.MSCHAPv2Authenticator;
+
+public class RadiusAuthenticationProviderIT {
+
+    private static final String SHARED_SECRET = "SECRET";
+    private static final String USER = "user1";
+    private static final String PASSWORD = "u5er1p455";
+    private static final String PASSWORD_WRONG = "xxxx";
+
+    private RadiusServer radiusServer = new RadiusServer() {
+        @Override
+        public String getSharedSecret(InetSocketAddress client) {
+            return SHARED_SECRET;
+        }
+
+        @Override
+        public String getUserPassword(String userName) {
+            if (USER.equals(userName)) {
+                return PASSWORD;
+            }
+            throw new IllegalArgumentException("No password for user " + userName + " defined");
+        }
+    };
+
+    @Before
+    public void setUp() {
+        radiusServer.start(true, false);
+        if (PASSWORD.equals(PASSWORD_WRONG)) {
+            throw new IllegalStateException("PASSWORD and PASSWORD_WRONG cannot match");
+        }
+    }
+
+    @After
+    public void tearDown() {
+        radiusServer.stop();
+    }
+
+    // Ensure that whatever the first response was, it is not re-used for another user
+    // See NMS-10212
+    @Test
+    public void verifyAuthenticatorIsNotReused() {
+        final RadiusAuthenticationProvider provider = new RadiusAuthenticationProvider("localhost", SHARED_SECRET);
+        provider.setAuthTypeClass(new MSCHAPv2Authenticator());
+
+        // Verify that authenticating with an existing user works
+        final UsernamePasswordAuthenticationToken token = new UsernamePasswordAuthenticationToken(USER, PASSWORD);
+        provider.retrieveUser(USER, token);
+
+        // Verify that authenticating without an existing user also works
+        // This means, that the access should be denied. See NMS-10212
+        try {
+            provider.retrieveUser(USER, new UsernamePasswordAuthenticationToken(USER, PASSWORD_WRONG));
+            Assert.fail("Expected an AuthenticationException but did not receive one. Failing..");
+        } catch (AuthenticationException ex) {
+            // expected Exception
+        }
+    }
+}

--- a/protocols/radius/src/test/java/org/opennms/protocols/radius/springsecurity/RadiusAuthenticationProviderTest.java
+++ b/protocols/radius/src/test/java/org/opennms/protocols/radius/springsecurity/RadiusAuthenticationProviderTest.java
@@ -56,9 +56,7 @@ public class RadiusAuthenticationProviderTest {
 	@Ignore("Need to have a RADIUS server running on localhost")
 	public void testRetrieveUserDefault() throws IOException {
 		RadiusAuthenticationProvider provider = new RadiusAuthenticationProvider(m_radiusServer, m_sharedSecret);
-		RadiusAuthenticator authTypeClass = null;
-
-		provider.setAuthTypeClass(authTypeClass);
+		provider.setAuthTypeClass(null);
 		provider.setRolesAttribute("Unknown-VSAttribute(5813:1)");
 
 		UsernamePasswordAuthenticationToken token = new UsernamePasswordAuthenticationToken(m_principal, m_credentials);
@@ -69,9 +67,7 @@ public class RadiusAuthenticationProviderTest {
 	@Ignore("Need to have a RADIUS server running on localhost")
 	public void testRetrieveUserPap() throws IOException {
 		RadiusAuthenticationProvider provider = new RadiusAuthenticationProvider(m_radiusServer, m_sharedSecret);
-		RadiusAuthenticator authTypeClass = new PAPAuthenticator();
-
-		provider.setAuthTypeClass(authTypeClass);
+		provider.setAuthTypeClass(PAPAuthenticator.class);
 		provider.setRolesAttribute("Unknown-VSAttribute(5813:1)");
 
 		UsernamePasswordAuthenticationToken token = new UsernamePasswordAuthenticationToken(m_principal, m_credentials);
@@ -82,9 +78,7 @@ public class RadiusAuthenticationProviderTest {
 	@Ignore("Need to have a RADIUS server running on localhost")
 	public void testRetrieveUserChap() throws IOException {
 		RadiusAuthenticationProvider provider = new RadiusAuthenticationProvider(m_radiusServer, m_sharedSecret);
-		RadiusAuthenticator authTypeClass = new CHAPAuthenticator();
-
-		provider.setAuthTypeClass(authTypeClass);
+		provider.setAuthTypeClass(CHAPAuthenticator.class);
 		provider.setRolesAttribute("Unknown-VSAttribute(5813:1)");
 
 		UsernamePasswordAuthenticationToken token = new UsernamePasswordAuthenticationToken(m_principal, m_credentials);
@@ -139,9 +133,7 @@ public class RadiusAuthenticationProviderTest {
 
 	public void doTestRetrieveUserMultipleTimes(RadiusAuthenticator authenticator) {
 		RadiusAuthenticationProvider provider = new RadiusAuthenticationProvider(m_radiusServer, m_sharedSecret);
-		RadiusAuthenticator authTypeClass = authenticator;
-
-		provider.setAuthTypeClass(authTypeClass);
+		provider.setAuthTypeClass(authenticator.getClass());
 		provider.setRolesAttribute("Unknown-VSAttribute(5813:1)");
 
 		UsernamePasswordAuthenticationToken token = new UsernamePasswordAuthenticationToken(m_principal, m_credentials);


### PR DESCRIPTION
* JIRA: https://issues.opennms.org/browse/NMS-10212

This is first targeted for foundation-2018. 
We need to decide where to backport this fix as well.