### PR TITLE
NMS-10282: Use ISO8601 date format conversion from StringUtils

### DIFF
--- a/opennms-alarms/jms-northbounder/src/test/java/org/opennms/netmgmt/alarmd/northbounder/jms/JmsNorthBounderTest.java
+++ b/opennms-alarms/jms-northbounder/src/test/java/org/opennms/netmgmt/alarmd/northbounder/jms/JmsNorthBounderTest.java
@@ -30,7 +30,6 @@ package org.opennms.netmgmt.alarmd.northbounder.jms;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
-import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
@@ -374,7 +373,7 @@ public class JmsNorthBounderTest {
                 " ossState: qosAlarmState ticketId: tticketId alarmUei: uei.uei.org/uei alarmKey: reductionKey clearKey: clearKey description: eventdescr operInstruct: operInstruct ackTime: \n" +
                 " alarmType: PROBLEM count: 1 alarmId: 9 ipAddr: 127.0.0.1 lastOccurrence:  nodeId: 1\n" +
                 " nodeLabel: schlazor distPoller: 00000000-0000-0000-0000-000000000000 ifService:  severity: WARNING ticketState:  x733AlarmType: other\n"+
-                " x733ProbableCause: other firstOccurrence: " + convertDateToDefaultFormat(new Date(0)) + " lastOccurrence  eventParmsXml: <eventParms/>";
+                " x733ProbableCause: other firstOccurrence: " + StringUtils.iso8601LocalOffsetString(new Date(0)) + " lastOccurrence  eventParmsXml: <eventParms/>";
         String response = ((TextMessage)m).getText();
         Assert.assertEquals("Contents of message\n'" + response + "'\n not equals\n'" + escapedResponse+"'.", response, escapedResponse);
     }
@@ -619,9 +618,9 @@ public class JmsNorthBounderTest {
         Message m = m_template.receive("MappingTestQueue");
         String escapedResponse = "ackUser:  appDn: applicationDN logMsg: eventlogmsg objectInstance: managedObjectInstance objectType: managedObjectType ossKey: ossPrimaryKey\n" +
                 " ossState: qosAlarmState ticketId: tticketId alarmUei: uei.uei.org/uei alarmKey: reductionKey clearKey: clearKey description: eventdescr operInstruct: operInstruct ackTime: \n" +
-                " alarmType: PROBLEM count: 1 alarmId: 9 ipAddr: 127.0.0.1 lastOccurrence: " + convertDateToDefaultFormat(date2) + " nodeId: 1\n" +
+                " alarmType: PROBLEM count: 1 alarmId: 9 ipAddr: 127.0.0.1 lastOccurrence: " + StringUtils.iso8601LocalOffsetString(date2) + " nodeId: 1\n" +
                 " nodeLabel: schlazor distPoller: 00000000-0000-0000-0000-000000000000 ifService:  severity: WARNING ticketState:  x733AlarmType: other\n"+
-                " x733ProbableCause: other firstOccurrence: " + convertDateToDefaultFormat(date1) + " lastOccurrence " + convertDateToDefaultFormat(date2) + " eventParmsXml: <eventParms>\n" +
+                " x733ProbableCause: other firstOccurrence: " + StringUtils.iso8601LocalOffsetString(date1) + " lastOccurrence " + StringUtils.iso8601LocalOffsetString(date2) + " eventParmsXml: <eventParms>\n" +
                 "    <parm name=\"syslogmessage\" value=\"Dec 22 2015 20:12:57.1 UTC :  %UC_CTI-3-CtiProviderOpenFailure: %[CTIconnectionId%61232238][ Login User Id%61pguser][Reason code.%61-1932787616][UNKNOWN_PARAMNAME:IPAddress%61172.17.12.73][UNKNOWN_PARAMNAME:IPv6Address%61][App ID%61Cisco CTIManager][Cluster ID%61SplkCluster][Node ID%61splkcucm6p]: CTI application failed to open provider%59 application startup failed\" type=\"string\"/>\n" +
                 "    <parm name=\"severity\" value=\"Error\" type=\"string\"/>\n" +
                 "    <parm name=\"timestamp\" value=\"Dec 22 14:13:21\" type=\"string\"/>\n" +
@@ -636,13 +635,6 @@ public class JmsNorthBounderTest {
         m = m_template.receive("MappingTestQueue");
         Assert.assertNull(m);
     }
-
-    private String convertDateToDefaultFormat(Date date) {
-        SimpleDateFormat simpleDateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss:SSSXXX");
-        return simpleDateFormat.format(date);
-
-    }
-
     /**
      * Generate configuration XML.
      *

--- a/opennms-alarms/syslog-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/syslog/SyslogNorthbounderConfig.java
+++ b/opennms-alarms/syslog-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/syslog/SyslogNorthbounderConfig.java
@@ -70,7 +70,7 @@ public class SyslogNorthbounderConfig implements Serializable {
     private String m_messageFormat;
     
     /** The date format. */
-    @XmlElement(name = "date-format", required = false, defaultValue = "yyyy-MM-dd'T'HH:mm:ss:SSSXXX")
+    @XmlElement(name = "date-format", required = false)
     private String m_dateFormat;
 
     /** The destinations. */

--- a/opennms-alarms/syslog-northbounder/src/main/resources/xsds/syslog-northbounder-configuration.xsd
+++ b/opennms-alarms/syslog-northbounder/src/main/resources/xsds/syslog-northbounder-configuration.xsd
@@ -14,7 +14,7 @@
       <xs:element name="batch-size" type="xs:int" default="100" minOccurs="0"/>
       <xs:element name="queue-size" type="xs:int" default="300000" minOccurs="0"/>
       <xs:element name="message-format" type="xs:string" default="ALARM ID:${alarmId} NODE:${nodeLabel} ${logMsg}" minOccurs="0"/>
-      <xs:element name="date-format" type="xs:string" default="yyyy-MM-dd'T'HH:mm:ss:SSSXXX" minOccurs="0"/>
+      <xs:element name="date-format" type="xs:string" minOccurs="0"/>
       <xs:element name="destination" type="syslogDestination" minOccurs="0" maxOccurs="unbounded"/>
       <xs:element name="uei" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
     </xs:sequence>

--- a/opennms-base-assembly/src/main/filtered/etc/syslog-northbounder-configuration.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/syslog-northbounder-configuration.xml
@@ -6,7 +6,7 @@
    <batch-size>100</batch-size>
    <queue-size>300000</queue-size>
    <message-format>ALARM ID:${alarmId} NODE:${nodeLabel}; ${logMsg}</message-format>
-    <!-- You can specify date format, default is ISO 8601  <date-format>yyyy-MM-dd'T'HH:mm:ss:SSSXXX</date-format> -->
+    <!-- You can specify date format within <date-format>, default is ISO 8601 -->
 <!-- You could do something like the following
    <message-format>ALARM ID:${alarmId} NODE:${nodeLabel} IP:${ipAddr} 
       FIRST:${firstOccurrence} LAST:${lastOccurrence} 


### PR DESCRIPTION
Use ISO8601 date format conversion like [here](https://github.com/OpenNMS/opennms/blob/c1cb2d3777059be9672218491b6374ee4140ded9/core/lib/src/main/java/org/opennms/core/utils/StringUtils.java#L249) instead of specifying it in `yyyy-MM-dd'T'HH:mm:ss.SSS` format.
Remove default date format in xml, it will still default to ISO8601 format.

* JIRA: http://issues.opennms.org/browse/NMS-10282

Our [continuous integration system](http://bamboo.internal.opennms.com:8085) will test and verify your changes.
