### PR TITLE
NMS-11794: Allow partially completed provisioning scans

### DIFF
--- a/features/events/api/src/main/java/org/opennms/netmgt/events/api/EventConstants.java
+++ b/features/events/api/src/main/java/org/opennms/netmgt/events/api/EventConstants.java
@@ -437,8 +437,12 @@ public abstract class EventConstants {
 
     /** Constant <code>PROVISION_SCAN_COMPLETE_UEI="uei.opennms.org/internal/provisiond/nod"{trunked}</code> */
     public static final String PROVISION_SCAN_COMPLETE_UEI="uei.opennms.org/internal/provisiond/nodeScanCompleted";
+    /** Constant <code>PROVISION_SCAN_PARTIALLY_COMPLETED_UEI="uei.opennms.org/internal/provisiond/nod"{trunked}</code> */
+    public static final String PROVISION_SCAN_PARTIALLY_COMPLETED_UEI="uei.opennms.org/internal/provisiond/nodeScanPartiallyCompleted";
     /** Constant <code>PROVISION_SCAN_ABORTED_UEI="uei.opennms.org/internal/provisiond/nod"{trunked}</code> */
     public static final String PROVISION_SCAN_ABORTED_UEI="uei.opennms.org/internal/provisiond/nodeScanAborted";
+    /** Constant <code>PROVISION_TASK_FAILED_UEI="uei.opennms.org/internal/provisiond/pro"{trunked}</code> */
+    public static final String PROVISION_TASK_FAILED_UEI="uei.opennms.org/internal/provisiond/provisionTaskFailed";
     
     /** Constant <code>PARM_FAILURE_MESSAGE="failureMessage"</code> */
     public static final String PARM_FAILURE_MESSAGE = "failureMessage";
@@ -451,6 +455,11 @@ public abstract class EventConstants {
 
     public static final String PARM_IMPORT_RESCAN_EXISTING = "importRescanExisting";
     
+    /** Constant <code>PARM_PROVISION_TASK="provisionTask"</code> */
+    public static final String PARM_PROVISION_TASK = "provisionTask";
+    /** Constant <code>PARM_PROVISION_FAILED_TASK_COUNT="provisionFailedTaskCount"</code> */
+    public static final String PARM_PROVISION_FAILED_TASK_COUNT = "provisionFailedTaskCount";
+
     /** Constant <code>PARM_ALARM_ID="alarmId"</code> */
     public static final String PARM_ALARM_ID = "alarmId";
     /** Constant <code>PARM_ALARM_UEI="alarmUei"</code> */

--- a/opennms-base-assembly/src/main/filtered/etc/events/opennms.provisioning.events.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/events/opennms.provisioning.events.xml
@@ -21,6 +21,21 @@
             completed.&lt;/p>
         </logmsg>
       <severity>Normal</severity>
+      <alarm-data reduction-key="%uei%:%nodeid%" alarm-type="2" clear-key="uei.opennms.org/internal/provisiond/nodeScanPartiallyCompleted:%nodeid%" auto-clean="false"/>
+   </event>
+   <event>
+      <uei>uei.opennms.org/internal/provisiond/nodeScanPartiallyCompleted</uei>
+      <event-label>OpenNMS-defined Provisiond Event: nodeScanPartiallyCompleted</event-label>
+      <descr>A message from the Provisiond NodeScan lifecycle that a NodeScan has completed with failed tasks:
+            &lt;p>The Node with Id: %nodeid%; ForeignSource: %parm[foreignSource]%; ForeignId:%parm[foreignId]% has
+            completed with %parm[provisionFailedTaskCount]% failed task(s).&lt;/p>
+            Typically the result of a request of an import request or a scheduled/user forced rescan.</descr>
+      <logmsg dest="logndisplay">
+            &lt;p>The Node with Id: %nodeid%; ForeignSource: %parm[foreignSource]%; ForeignId:%parm[foreignId]% has
+            completed with %parm[provisionFailedTaskCount]% failed task(s).&lt;/p>
+        </logmsg>
+      <severity>Warning</severity>
+      <alarm-data reduction-key="%uei%:%nodeid%" alarm-type="1" auto-clean="false"/>
    </event>
    <event>
       <uei>uei.opennms.org/internal/provisiond/nodeScanAborted</uei>
@@ -31,6 +46,15 @@
       <logmsg dest="logndisplay">
             &lt;p>The Node with Id: %nodeid%; ForeignSource: %parm[foreignSource]%; ForeignId:%parm[foreignId]% has
             aborted.&lt;/p>
+        </logmsg>
+      <severity>Warning</severity>
+   </event>
+   <event>
+      <uei>uei.opennms.org/internal/provisiond/provisionTaskFailed</uei>
+      <event-label>OpenNMS-defined Provisiond Event: provisionTaskFailed</event-label>
+      <descr>Provisioning task %parm[provisionTask]% failed for host %host% with the following condition: %parm[reason]%.&lt;p></descr>
+      <logmsg dest="logndisplay">
+            &lt;p>Provisioning task %parm[provisionTask]% failed.&lt;/p>
         </logmsg>
       <severity>Warning</severity>
    </event>

--- a/opennms-provision/opennms-provisiond/src/main/java/org/opennms/netmgt/provision/service/ForceRescanScan.java
+++ b/opennms-provision/opennms-provisiond/src/main/java/org/opennms/netmgt/provision/service/ForceRescanScan.java
@@ -112,6 +112,8 @@ public class ForceRescanScan implements Scan {
     private ScanProgress createScanProgress() {
         return new ScanProgress() {
             private boolean m_aborted = false;
+            private int m_failedTasks = 0;
+
             @Override
             public void abort(final String message) {
                 m_aborted = true;
@@ -119,9 +121,26 @@ public class ForceRescanScan implements Scan {
             }
 
             @Override
+            public void failTask(final String provisionTask, final String message) {
+                m_failedTasks++;
+                LOG.info("Provisioning task {} failed: {}", provisionTask, message);
+            }
+
+            @Override
             public boolean isAborted() {
                 return m_aborted;
-            }};
+            }
+
+            @Override
+            public int getFailedTasksCount() {
+                return m_failedTasks;
+            }
+
+            @Override
+            public boolean hasFailedTasks() {
+                return (m_failedTasks > 0);
+            }
+        };
     }
 
     /**

--- a/opennms-provision/opennms-provisiond/src/main/java/org/opennms/netmgt/provision/service/NewSuspectScan.java
+++ b/opennms-provision/opennms-provisiond/src/main/java/org/opennms/netmgt/provision/service/NewSuspectScan.java
@@ -118,16 +118,34 @@ public class NewSuspectScan implements Scan {
     private ScanProgress createScanProgress() {
         return new ScanProgress() {
             private boolean m_aborted = false;
+            private int m_failedTasks = 0;
+
             @Override
             public void abort(final String message) {
                 m_aborted = true;
                 LOG.info(message);
             }
 
+            public void failTask(final String provisionTask, final String message) {
+                m_failedTasks += 1;
+                LOG.info("Provisioning task {} failed: {}", provisionTask, message);
+            }
+
             @Override
             public boolean isAborted() {
                 return m_aborted;
-            }};
+            }
+
+            @Override
+            public int getFailedTasksCount() {
+                return m_failedTasks;
+            }
+
+            @Override
+            public boolean hasFailedTasks() {
+                return (m_failedTasks > 0);
+            }
+        };
     }
 
     /**

--- a/opennms-provision/opennms-provisiond/src/main/java/org/opennms/netmgt/provision/service/NodeInfoScan.java
+++ b/opennms-provision/opennms-provisiond/src/main/java/org/opennms/netmgt/provision/service/NodeInfoScan.java
@@ -123,6 +123,10 @@ final class NodeInfoScan implements RunInBatch {
         m_scanProgress.abort(reason);
     }
 
+    private void failTask(String provisionTask, String reason) {
+        m_scanProgress.failTask(provisionTask, reason);
+    }
+
     private OnmsNode getNode() {
         return m_node;
     }
@@ -151,7 +155,7 @@ final class NodeInfoScan implements RunInBatch {
                     .get();
                 systemGroup.updateSnmpDataForNode(getNode());
             } catch (ExecutionException e) {
-                abort("Aborting node scan : Agent failed while scanning the system table: " + e.getMessage());
+                failTask("collectNodeInfo", "Agent failed while scanning the system table: " + e.getMessage());
             }
 
             List<NodePolicy> nodePolicies = getProvisionService().getNodePoliciesForForeignSource(getEffectiveForeignSource());
@@ -204,5 +208,13 @@ final class NodeInfoScan implements RunInBatch {
 
     private boolean isAborted() {
         return m_scanProgress.isAborted();
+    }
+
+    private int getFailedTasksCount() {
+        return m_scanProgress.getFailedTasksCount();
+    }
+
+    private boolean hasFailedTasks() {
+        return m_scanProgress.hasFailedTasks();
     }
 }

--- a/opennms-provision/opennms-provisiond/src/main/java/org/opennms/netmgt/provision/service/ScanProgress.java
+++ b/opennms-provision/opennms-provisiond/src/main/java/org/opennms/netmgt/provision/service/ScanProgress.java
@@ -42,10 +42,33 @@ public interface ScanProgress {
      * @param message a {@link java.lang.String} object.
      */
     public void abort(String message);
+
     /**
      * <p>isAborted</p>
      *
      * @return a boolean.
      */
     public boolean isAborted();
+
+    /**
+     * <p>failTask</p>
+     *
+     * @param provisionTask a {@link java.lang.String} object.
+     * @param message a {@link java.lang.String} object.
+     */
+    public void failTask(String provisionTask, String message);
+
+    /**
+     * <p>getFailedTasksCount</p>
+     *
+     * @return an int.
+     */
+    public int getFailedTasksCount();
+
+    /**
+     * <p>hasFailedTasks</p>
+     *
+     * @return a boolean.
+     */
+    public boolean hasFailedTasks();
 }


### PR DESCRIPTION
* JIRA: https://issues.opennms.org/browse/NMS-11794

Basing this on the 'develop' branch, since the commit affects a critical part of OpenNMS, changing the current behaviour.

This commit adds two new events: 
1. uei.opennms.org/internal/provisiond/provisionTaskFailed
2. uei.opennms.org/internal/provisiond/nodeScanPartiallyCompleted

Whenever NodeScan encounters a non-critical problem during the scan, a Warning event (including information about which step failed) will be created, but the scan will continue.

If one or more of these failures were encountered, a nodeScanPartiallyCompleted Warning event will be created, triggering an alarm. This alarm will be auto-cleared by the next nodeScanCompleted event, triggered by a successful scan.