### PR TITLE
NMS-10291: DefaultProvisionService logs noisily for monitored service having state "N"

### DIFF
--- a/opennms-provision/opennms-provisiond/src/main/java/org/opennms/netmgt/provision/service/DefaultProvisionService.java
+++ b/opennms-provision/opennms-provisiond/src/main/java/org/opennms/netmgt/provision/service/DefaultProvisionService.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2008-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2008-2018 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2018 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -689,6 +689,9 @@ public class DefaultProvisionService implements ProvisionService, InitializingBe
                     break;
                 case "A":
                     // we can ignore active statuses
+                    break;
+                case "N":
+                    // we can ignore not-polled statuses
                     break;
                 default:
                     LOG.warn("Unhandled state: {}", dbObj.getStatus());


### PR DESCRIPTION
* JIRA: http://issues.opennms.org/browse/NMS-10291