### PR TITLE
NMS-10269: Set kafka logging to INFO by default

### DIFF
--- a/opennms-base-assembly/src/main/filtered/etc/log4j2.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/log4j2.xml
@@ -147,6 +147,9 @@
     <logger name="org.snmp4j.transport" additivity="false" level="ERROR">
       <appender-ref ref="RoutingAppender"/>
     </logger>
+    <logger name="org.apache.kafka" additivity="false" level="INFO">
+      <appender-ref ref="RoutingAppender" />
+    </logger>
 
     <!-- Allow any message to pass through the root logger -->
     <root level="DEBUG">


### PR DESCRIPTION
back porting kafka logging to foundation-2018.

* JIRA: http://issues.opennms.org/browse/NMS-10269

Our [continuous integration system](http://bamboo.internal.opennms.com:8085) will test and verify your changes.
