### PR TITLE
HZN-1366: Enable all adapters and verify them

### DIFF
--- a/smoke-test/src/test/java/org/opennms/smoketest/flow/FlowStackIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/flow/FlowStackIT.java
@@ -71,9 +71,9 @@ public class FlowStackIT {
     private static Logger LOG = LoggerFactory.getLogger(FlowStackIT.class);
 
     public static int NETFLOW5_LISTENER_UDP_PORT = 50000;
-    private static int NETFLOW9_LISTENER_UDP_PORT = 50001;
-    private static int IPFIX_LISTENER_UDP_PORT = 50002;
-    private static int SFLOW_LISTENER_UDP_PORT = 50003;
+    public static int NETFLOW9_LISTENER_UDP_PORT = 50001;
+    public static int IPFIX_LISTENER_UDP_PORT = 50002;
+    public static int SFLOW_LISTENER_UDP_PORT = 50003;
 
     public static final String TEMPLATE_NAME = "netflow";
 

--- a/smoke-test/src/test/java/org/opennms/smoketest/sentinel/FlowStackJmsIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/sentinel/FlowStackJmsIT.java
@@ -44,10 +44,6 @@ public class FlowStackJmsIT extends AbstractFlowIT {
             // Enable Netflow 5 Adapter
             builder.withSentinelEnvironment()
                     .addFile(getClass().getResource("/sentinel/features-jms.xml"), "deploy/features.xml");
-
-            // Enable Netflow 5 Listener
-            builder.withMinionEnvironment()
-                    .addFile(getClass().getResource("/sentinel/org.opennms.features.telemetry.listeners-udp-50000.cfg"), "etc/org.opennms.features.telemetry.listeners-udp-50000.cfg");
     }
 
     @Override

--- a/smoke-test/src/test/java/org/opennms/smoketest/sentinel/FlowStackKafkaIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/sentinel/FlowStackKafkaIT.java
@@ -48,8 +48,7 @@ public class FlowStackKafkaIT extends AbstractFlowIT {
 
             // Enable Netflow 5 Listener
             builder.withMinionEnvironment()
-                    .addFile(getClass().getResource("/featuresBoot.d/kafka.boot"), "etc/featuresBoot.d/kafka.boot")
-                    .addFile(getClass().getResource("/sentinel/org.opennms.features.telemetry.listeners-udp-50000.cfg"), "etc/org.opennms.features.telemetry.listeners-udp-50000.cfg");
+                    .addFile(getClass().getResource("/featuresBoot.d/kafka.boot"), "etc/featuresBoot.d/kafka.boot");
     }
 
     @Override

--- a/smoke-test/src/test/resources/sentinel/features-jms.xml
+++ b/smoke-test/src/test/resources/sentinel/features-jms.xml
@@ -17,6 +17,18 @@
             name = Netflow-5
             class-name = org.opennms.netmgt.telemetry.adapters.netflow.v5.Netflow5Adapter
         </config>
+        <config name="org.opennms.features.telemetry.adapters-netflow9">
+            name = Netflow-9
+            class-name = org.opennms.netmgt.telemetry.adapters.netflow.v9.Netflow9Adapter
+        </config>
+        <config name="org.opennms.features.telemetry.adapters-ipfix">
+            name = IPFIX
+            class-name = org.opennms.netmgt.telemetry.adapters.netflow.ipfix.IpfixAdapter
+        </config>
+        <config name="org.opennms.features.telemetry.adapters-sflow">
+            name = SFlow
+            class-name = org.opennms.netmgt.telemetry.adapters.netflow.sflow.SFlowAdapter
+        </config>
         <!-- Point sentinel to the correct elastic endpoint -->
         <config name="org.opennms.features.flows.persistence.elastic">
             elasticUrl = http://elasticsearch:9200

--- a/smoke-test/src/test/resources/sentinel/features-kafka.xml
+++ b/smoke-test/src/test/resources/sentinel/features-kafka.xml
@@ -17,6 +17,18 @@
             name = Netflow-5
             class-name = org.opennms.netmgt.telemetry.adapters.netflow.v5.Netflow5Adapter
         </config>
+        <config name="org.opennms.features.telemetry.adapters-netflow9">
+            name = Netflow-9
+            class-name = org.opennms.netmgt.telemetry.adapters.netflow.v9.Netflow9Adapter
+        </config>
+        <config name="org.opennms.features.telemetry.adapters-ipfix">
+            name = IPFIX
+            class-name = org.opennms.netmgt.telemetry.adapters.netflow.ipfix.IpfixAdapter
+        </config>
+        <config name="org.opennms.features.telemetry.adapters-sflow">
+            name = SFlow
+            class-name = org.opennms.netmgt.telemetry.adapters.netflow.sflow.SFlowAdapter
+        </config>
         <!-- Point sentinel to the correct elastic endpoint -->
         <config name="org.opennms.features.flows.persistence.elastic">
             elasticUrl = http://elasticsearch:9200

--- a/smoke-test/src/test/resources/sentinel/org.opennms.features.telemetry.listeners-udp-50001.cfg
+++ b/smoke-test/src/test/resources/sentinel/org.opennms.features.telemetry.listeners-udp-50001.cfg
@@ -1,0 +1,3 @@
+name=Netflow-9
+class-name=org.opennms.netmgt.telemetry.listeners.flow.netflow9.UdpListener
+listener.port=50001

--- a/smoke-test/src/test/resources/sentinel/org.opennms.features.telemetry.listeners-udp-50002.cfg
+++ b/smoke-test/src/test/resources/sentinel/org.opennms.features.telemetry.listeners-udp-50002.cfg
@@ -1,0 +1,3 @@
+name=IPFIX
+class-name=org.opennms.netmgt.telemetry.listeners.flow.ipfix.UdpListener
+listener.port=50002

--- a/smoke-test/src/test/resources/sentinel/org.opennms.features.telemetry.listeners-udp-50003.cfg
+++ b/smoke-test/src/test/resources/sentinel/org.opennms.features.telemetry.listeners-udp-50003.cfg
@@ -1,0 +1,3 @@
+name=SFlow
+class-name=org.opennms.netmgt.telemetry.listeners.sflow.Listener
+listener.port=50003


### PR DESCRIPTION
* JIRA: https://issues.opennms.org/browse/HZN-1366

Here we verify that all flow adapters run on sentinel, not just the `Netflow5Adapter`.