### PR TITLE
NMS-10301: expose datetimeformat in InfoService REST Endpoint

### DIFF
--- a/core/lib/src/main/java/org/opennms/core/time/CentralizedDateTimeFormat.java
+++ b/core/lib/src/main/java/org/opennms/core/time/CentralizedDateTimeFormat.java
@@ -50,6 +50,7 @@ public class CentralizedDateTimeFormat {
 
     public final static String SYSTEM_PROPERTY_DATE_FORMAT = "org.opennms.ui.datettimeformat";
     public final static String SESSION_PROPERTY_TIMEZONE_ID = "org.opennms.ui.timezoneid";
+    public final static String DEFAULT_FORMAT_PATTERN = "yyyy-MM-dd'T'HH:mm:ssxxx";
 
     public static final Logger LOG = LoggerFactory.getLogger(CentralizedDateTimeFormat.class);
 
@@ -60,23 +61,27 @@ public class CentralizedDateTimeFormat {
     }
 
     private DateTimeFormatter createFormatter() {
-        String format = System.getProperty(SYSTEM_PROPERTY_DATE_FORMAT);
+        String format = getFormatPattern();
         DateTimeFormatter formatter;
-        if (format == null) {
-            formatter = getDefaultFormatter();
-        } else {
-            try {
-                formatter = DateTimeFormatter.ofPattern(format);
-            } catch (IllegalArgumentException e) {
-                LOG.warn(String.format("Can not use System Property %s=%s as dateformat, will fall back to default." +
+        try {
+            formatter = DateTimeFormatter.ofPattern(format);
+        } catch (IllegalArgumentException e) {
+            LOG.warn(String.format("Can not use System Property %s=%s as dateformat, will fall back to default." +
                                 " Please see also java.time.format.DateTimeFormatter for the correct syntax",
-                        SYSTEM_PROPERTY_DATE_FORMAT,
-                        format)
-                        , e);
-                formatter = getDefaultFormatter();
+                SYSTEM_PROPERTY_DATE_FORMAT,
+                format)
+                    , e);
+            formatter = getDefaultFormatter();
             }
-        }
         return formatter;
+    }
+
+    public String getFormatPattern(){
+        String format = System.getProperty(SYSTEM_PROPERTY_DATE_FORMAT);
+        if(format == null) {
+            format = DEFAULT_FORMAT_PATTERN;
+        }
+        return format;
     }
 
     private DateTimeFormatter getDefaultFormatter() {

--- a/features/measurements/rest/pom.xml
+++ b/features/measurements/rest/pom.xml
@@ -108,5 +108,11 @@
       <artifactId>opennms-alarm-northbounder-snmptrap</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.opennms.features.timeformat</groupId>
+      <artifactId>org.opennms.features.timeformat.impl</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/features/measurements/rest/src/test/resources/META-INF/opennms/applicationContext-measurements-rest-test.xml
+++ b/features/measurements/rest/src/test/resources/META-INF/opennms/applicationContext-measurements-rest-test.xml
@@ -15,5 +15,6 @@
   <tx:annotation-driven />
 
   <bean id="measurementsRestService" class="org.opennms.web.rest.v1.MeasurementsRestService"/>
+  <bean name="timeformatService" class="org.opennms.features.timeformat.impl.DefaultTimeformatService" />
 
 </beans>

--- a/features/ncs/ncs-persistence/pom.xml
+++ b/features/ncs/ncs-persistence/pom.xml
@@ -167,6 +167,12 @@
       <artifactId>opennms-dao-mock</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.opennms.features.timeformat</groupId>
+      <artifactId>org.opennms.features.timeformat.impl</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
     </dependencies>
   
   <repositories>

--- a/features/ncs/ncs-persistence/src/test/java/org/opennms/netmgt/ncs/rest/NCSRestServiceIT.java
+++ b/features/ncs/ncs-persistence/src/test/java/org/opennms/netmgt/ncs/rest/NCSRestServiceIT.java
@@ -79,7 +79,7 @@ import org.springframework.web.context.WebApplicationContext;
         "classpath:/META-INF/opennms/mockEventIpcManager.xml",
         "file:../../../opennms-webapp-rest/src/main/webapp/WEB-INF/applicationContext-svclayer.xml",
         "file:../../../opennms-webapp-rest/src/main/webapp/WEB-INF/applicationContext-cxf-common.xml",
-		"classpath:/applicationContext-rest-test.xml"
+		"classpath:/application-context-timeformat.xml"
 })
 @JUnitConfigurationEnvironment
 @JUnitTemporaryDatabase(reuseDatabase=false)

--- a/features/ncs/ncs-persistence/src/test/java/org/opennms/netmgt/ncs/rest/NCSRestServiceIT.java
+++ b/features/ncs/ncs-persistence/src/test/java/org/opennms/netmgt/ncs/rest/NCSRestServiceIT.java
@@ -78,7 +78,8 @@ import org.springframework.web.context.WebApplicationContext;
         "classpath*:/META-INF/opennms/component-dao.xml",
         "classpath:/META-INF/opennms/mockEventIpcManager.xml",
         "file:../../../opennms-webapp-rest/src/main/webapp/WEB-INF/applicationContext-svclayer.xml",
-        "file:../../../opennms-webapp-rest/src/main/webapp/WEB-INF/applicationContext-cxf-common.xml"
+        "file:../../../opennms-webapp-rest/src/main/webapp/WEB-INF/applicationContext-cxf-common.xml",
+		"classpath:/applicationContext-rest-test.xml"
 })
 @JUnitConfigurationEnvironment
 @JUnitTemporaryDatabase(reuseDatabase=false)

--- a/features/ncs/ncs-persistence/src/test/resources/application-context-timeformat.xml
+++ b/features/ncs/ncs-persistence/src/test/resources/application-context-timeformat.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans
+        xmlns="http://www.springframework.org/schema/beans"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns:context="http://www.springframework.org/schema/context"
+        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.2.xsd">
+
+    <context:annotation-config />
+
+    <bean name="timeformatService" class="org.opennms.features.timeformat.impl.DefaultTimeformatService">
+    </bean>
+
+</beans>

--- a/features/timeformat/api/src/main/java/org/opennms/features/timeformat/api/TimeformatService.java
+++ b/features/timeformat/api/src/main/java/org/opennms/features/timeformat/api/TimeformatService.java
@@ -38,4 +38,5 @@ public interface TimeformatService {
 
     String format(Date date, ZoneId zoneId);
 
+    String getFormatPattern();
 }

--- a/features/timeformat/impl/src/main/java/org/opennms/features/timeformat/impl/DefaultTimeformatService.java
+++ b/features/timeformat/impl/src/main/java/org/opennms/features/timeformat/impl/DefaultTimeformatService.java
@@ -48,4 +48,9 @@ public class DefaultTimeformatService implements TimeformatService {
     public String format(Date date, ZoneId zoneId) {
         return format.format(date, zoneId);
     }
+
+    @Override
+    public String getFormatPattern() {
+        return format.getFormatPattern();
+    }
 }

--- a/opennms-webapp-rest/pom.xml
+++ b/opennms-webapp-rest/pom.xml
@@ -242,6 +242,13 @@
       <scope>${onmsLibScope}</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.opennms.features.timeformat</groupId>
+      <artifactId>org.opennms.features.timeformat.impl</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+
     <!-- CORS support -->
     <dependency>
       <groupId>org.ebaysf.web</groupId>

--- a/opennms-webapp-rest/pom.xml
+++ b/opennms-webapp-rest/pom.xml
@@ -235,6 +235,13 @@
       <scope>${onmsLibScope}</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.opennms.features.timeformat</groupId>
+      <artifactId>org.opennms.features.timeformat.api</artifactId>
+      <version>${project.version}</version>
+      <scope>${onmsLibScope}</scope>
+    </dependency>
+
     <!-- CORS support -->
     <dependency>
       <groupId>org.ebaysf.web</groupId>

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/InfoDTO.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/InfoDTO.java
@@ -31,6 +31,7 @@ package org.opennms.web.rest.v1;
 import javax.xml.bind.annotation.XmlRootElement;
 
 import org.opennms.web.rest.v1.config.TicketerConfig;
+import org.opennms.web.rest.v1.config.DatetimeformatConfig;
 
 
 @XmlRootElement(name="info")
@@ -40,6 +41,15 @@ public class InfoDTO {
     private String packageName;
     private String packageDescription;
     private TicketerConfig ticketerConfig;
+    private DatetimeformatConfig datetimeformatConfig;
+
+    public DatetimeformatConfig getDatetimeformatConfig() {
+        return datetimeformatConfig;
+    }
+
+    public void setDatetimeformatConfig(DatetimeformatConfig datetimeformatConfig) {
+        this.datetimeformatConfig = datetimeformatConfig;
+    }
 
     public void setDisplayVersion(String displayVersion) {
         this.displayVersion = displayVersion;

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/InfoRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/InfoRestService.java
@@ -40,10 +40,11 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import org.opennms.core.resource.Vault;
-import org.opennms.core.time.CentralizedDateTimeFormat;
 import org.opennms.core.utils.SystemInfoUtils;
+import org.opennms.features.timeformat.api.TimeformatService;
 import org.opennms.web.rest.v1.config.DatetimeformatConfig;
 import org.opennms.web.rest.v1.config.TicketerConfig;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -51,6 +52,9 @@ import org.springframework.transaction.annotation.Transactional;
 @Path("info")
 @Transactional
 public class InfoRestService extends OnmsRestService {
+
+    @Autowired
+    TimeformatService timeformatService;
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
@@ -70,9 +74,8 @@ public class InfoRestService extends OnmsRestService {
     private DatetimeformatConfig getDateformatConfig(HttpServletRequest request) {
         DatetimeformatConfig config = new DatetimeformatConfig();
         String userId = request.getRemoteUser();
-        CentralizedDateTimeFormat format = new CentralizedDateTimeFormat();
         config.setZoneId(ZoneId.systemDefault()); // TODO
-       //  config.setDatetimeformat(format.Pattern); // TODO
+        config.setDatetimeformat("yyyy-MM-dd'T'HH:mm:ssxxx"); // TODO
         return config;
     }
 

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/InfoRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/InfoRestService.java
@@ -29,15 +29,20 @@
 package org.opennms.web.rest.v1;
 
 import java.text.ParseException;
+import java.time.ZoneId;
 
+import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import org.opennms.core.resource.Vault;
+import org.opennms.core.time.CentralizedDateTimeFormat;
 import org.opennms.core.utils.SystemInfoUtils;
+import org.opennms.web.rest.v1.config.DatetimeformatConfig;
 import org.opennms.web.rest.v1.config.TicketerConfig;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -49,7 +54,7 @@ public class InfoRestService extends OnmsRestService {
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    public Response getInfo() throws ParseException {
+    public Response getInfo(@Context HttpServletRequest request) throws ParseException {
         final SystemInfoUtils sysInfoUtils = new SystemInfoUtils();
 
         final InfoDTO info = new InfoDTO();
@@ -58,8 +63,17 @@ public class InfoRestService extends OnmsRestService {
         info.setPackageName(sysInfoUtils.getPackageName());
         info.setPackageDescription(sysInfoUtils.getPackageDescription());
         info.setTicketerConfig(getTicketerConfig());
-
+        info.setDatetimeformatConfig(getDateformatConfig(request));
         return Response.ok().entity(info).build();
+    }
+
+    private DatetimeformatConfig getDateformatConfig(HttpServletRequest request) {
+        DatetimeformatConfig config = new DatetimeformatConfig();
+        String userId = request.getRemoteUser();
+        CentralizedDateTimeFormat format = new CentralizedDateTimeFormat();
+        config.setZoneId(ZoneId.systemDefault()); // TODO
+       //  config.setDatetimeformat(format.Pattern); // TODO
+        return config;
     }
 
     private TicketerConfig getTicketerConfig() {

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/InfoRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/InfoRestService.java
@@ -60,7 +60,7 @@ public class InfoRestService extends OnmsRestService {
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    public Response getInfo(@Context HttpSession session) throws ParseException {
+    public Response getInfo(@Context HttpServletRequest httpServletRequest) throws ParseException {
         final SystemInfoUtils sysInfoUtils = new SystemInfoUtils();
 
         final InfoDTO info = new InfoDTO();
@@ -69,7 +69,7 @@ public class InfoRestService extends OnmsRestService {
         info.setPackageName(sysInfoUtils.getPackageName());
         info.setPackageDescription(sysInfoUtils.getPackageDescription());
         info.setTicketerConfig(getTicketerConfig());
-        info.setDatetimeformatConfig(getDateformatConfig(session));
+        info.setDatetimeformatConfig(getDateformatConfig(httpServletRequest.getSession(false)));
         return Response.ok().entity(info).build();
     }
 
@@ -81,7 +81,10 @@ public class InfoRestService extends OnmsRestService {
     }
 
     private ZoneId extractUserTimeZoneId(HttpSession session){
-        ZoneId zoneId = (ZoneId) session.getAttribute(CentralizedDateTimeFormat.SESSION_PROPERTY_TIMEZONE_ID);
+        ZoneId zoneId = null;
+        if(session != null){
+            zoneId = (ZoneId) session.getAttribute(CentralizedDateTimeFormat.SESSION_PROPERTY_TIMEZONE_ID);
+        }
         if(zoneId == null){
             zoneId = ZoneId.systemDefault();
         }

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/config/DatetimeformatConfig.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/config/DatetimeformatConfig.java
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2018 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2018 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.web.rest.v1.config;
+
+import java.time.ZoneId;
+
+public class DatetimeformatConfig {
+    private ZoneId zoneId;
+    private String datetimeformat;
+
+    public ZoneId getZoneId() {
+        return zoneId;
+    }
+
+    public void setZoneId(ZoneId zoneId) {
+        this.zoneId = zoneId;
+    }
+
+    public String getDatetimeformat() {
+        return datetimeformat;
+    }
+
+    public void setDatetimeformat(String datetimeformat) {
+        this.datetimeformat = datetimeformat;
+    }
+}

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/config/DatetimeformatConfig.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/config/DatetimeformatConfig.java
@@ -31,15 +31,15 @@ package org.opennms.web.rest.v1.config;
 import java.time.ZoneId;
 
 public class DatetimeformatConfig {
-    private ZoneId zoneId;
+    private String zoneId;
     private String datetimeformat;
 
-    public ZoneId getZoneId() {
+    public String getZoneId() {
         return zoneId;
     }
 
     public void setZoneId(ZoneId zoneId) {
-        this.zoneId = zoneId;
+        this.zoneId = zoneId.getId();
     }
 
     public String getDatetimeformat() {

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/AcknowledgmentRestServiceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/AcknowledgmentRestServiceIT.java
@@ -76,7 +76,8 @@ import org.springframework.transaction.support.TransactionTemplate;
         "classpath:/META-INF/opennms/applicationContext-databasePopulator.xml",
         "classpath:/META-INF/opennms/mockEventIpcManager.xml",
         "file:src/main/webapp/WEB-INF/applicationContext-svclayer.xml",
-        "file:src/main/webapp/WEB-INF/applicationContext-cxf-common.xml"
+        "file:src/main/webapp/WEB-INF/applicationContext-cxf-common.xml",
+        "classpath:/applicationContext-rest-test.xml"
 })
 @JUnitConfigurationEnvironment
 @JUnitTemporaryDatabase

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/AlarmRestServiceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/AlarmRestServiceIT.java
@@ -83,7 +83,8 @@ import org.springframework.transaction.support.TransactionTemplate;
         "classpath:/META-INF/opennms/applicationContext-databasePopulator.xml",
         "classpath:/META-INF/opennms/mockEventIpcManager.xml",
         "file:src/main/webapp/WEB-INF/applicationContext-svclayer.xml",
-        "file:src/main/webapp/WEB-INF/applicationContext-cxf-common.xml"
+        "file:src/main/webapp/WEB-INF/applicationContext-cxf-common.xml",
+        "classpath:/applicationContext-rest-test.xml"
 })
 @JUnitConfigurationEnvironment
 @JUnitTemporaryDatabase

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/AlarmStatsRestServiceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/AlarmStatsRestServiceIT.java
@@ -86,7 +86,8 @@ import com.google.common.collect.Lists;
         "classpath:/META-INF/opennms/applicationContext-databasePopulator.xml",
         "classpath:/META-INF/opennms/mockEventIpcManager.xml",
         "file:src/main/webapp/WEB-INF/applicationContext-svclayer.xml",
-        "file:src/main/webapp/WEB-INF/applicationContext-cxf-common.xml"
+        "file:src/main/webapp/WEB-INF/applicationContext-cxf-common.xml",
+        "classpath:/applicationContext-rest-test.xml"
 })
 @JUnitConfigurationEnvironment
 @JUnitTemporaryDatabase

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/AssetRecordResourceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/AssetRecordResourceIT.java
@@ -67,7 +67,8 @@ import org.springframework.transaction.support.TransactionTemplate;
         "classpath:/META-INF/opennms/applicationContext-databasePopulator.xml",
         "classpath:/META-INF/opennms/mockEventIpcManager.xml",
         "file:src/main/webapp/WEB-INF/applicationContext-svclayer.xml",
-        "file:src/main/webapp/WEB-INF/applicationContext-cxf-common.xml"
+        "file:src/main/webapp/WEB-INF/applicationContext-cxf-common.xml",
+        "classpath:/applicationContext-rest-test.xml"
 })
 @JUnitConfigurationEnvironment
 @JUnitTemporaryDatabase

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/AssetSuggestionsRestServiceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/AssetSuggestionsRestServiceIT.java
@@ -71,7 +71,8 @@ import org.springframework.transaction.support.TransactionTemplate;
         "classpath:/META-INF/opennms/applicationContext-databasePopulator.xml",
         "classpath:/META-INF/opennms/mockEventIpcManager.xml",
         "file:src/main/webapp/WEB-INF/applicationContext-svclayer.xml",
-        "file:src/main/webapp/WEB-INF/applicationContext-cxf-common.xml"
+        "file:src/main/webapp/WEB-INF/applicationContext-cxf-common.xml",
+        "classpath:/applicationContext-rest-test.xml"
 })
 @JUnitConfigurationEnvironment
 @JUnitTemporaryDatabase

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/AvailabilityRestServiceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/AvailabilityRestServiceIT.java
@@ -71,7 +71,8 @@ import org.springframework.transaction.support.TransactionTemplate;
         "classpath:/META-INF/opennms/applicationContext-databasePopulator.xml",
         "classpath:/META-INF/opennms/mockEventIpcManager.xml",
         "file:src/main/webapp/WEB-INF/applicationContext-svclayer.xml",
-        "file:src/main/webapp/WEB-INF/applicationContext-cxf-common.xml"
+        "file:src/main/webapp/WEB-INF/applicationContext-cxf-common.xml",
+        "classpath:/applicationContext-rest-test.xml"
 })
 @JUnitConfigurationEnvironment
 @JUnitTemporaryDatabase

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/CategoryRestServiceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/CategoryRestServiceIT.java
@@ -71,7 +71,8 @@ import org.springframework.test.context.web.WebAppConfiguration;
         "file:src/main/webapp/WEB-INF/applicationContext-cxf-common.xml",
 
         // Use this to prevent us from overwriting users.xml and groups.xml
-        "classpath:/META-INF/opennms/applicationContext-mock-usergroup.xml"
+        "classpath:/META-INF/opennms/applicationContext-mock-usergroup.xml",
+        "classpath:/applicationContext-rest-test.xml"
 })
 @JUnitConfigurationEnvironment
 @JUnitTemporaryDatabase

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/EventRestServiceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/EventRestServiceIT.java
@@ -63,7 +63,8 @@ import org.springframework.transaction.annotation.Transactional;
         "classpath:/META-INF/opennms/applicationContext-databasePopulator.xml",
         "classpath:/META-INF/opennms/mockEventIpcManager.xml",
         "file:src/main/webapp/WEB-INF/applicationContext-svclayer.xml",
-        "file:src/main/webapp/WEB-INF/applicationContext-cxf-common.xml"
+        "file:src/main/webapp/WEB-INF/applicationContext-cxf-common.xml",
+        "classpath:/applicationContext-rest-test.xml"
 })
 @JUnitConfigurationEnvironment
 @JUnitTemporaryDatabase

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/ForeignSourceConfigRestServiceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/ForeignSourceConfigRestServiceIT.java
@@ -61,7 +61,8 @@ import org.springframework.test.context.web.WebAppConfiguration;
         "classpath:/META-INF/opennms/applicationContext-databasePopulator.xml",
         "classpath:/META-INF/opennms/mockEventIpcManager.xml",
         "file:src/main/webapp/WEB-INF/applicationContext-svclayer.xml",
-        "file:src/main/webapp/WEB-INF/applicationContext-cxf-common.xml"
+        "file:src/main/webapp/WEB-INF/applicationContext-cxf-common.xml",
+        "classpath:/applicationContext-rest-test.xml"
 })
 @JUnitConfigurationEnvironment
 @JUnitTemporaryDatabase

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/ForeignSourceRestServiceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/ForeignSourceRestServiceIT.java
@@ -57,7 +57,8 @@ import org.springframework.test.context.web.WebAppConfiguration;
         "classpath:/META-INF/opennms/applicationContext-databasePopulator.xml",
         "classpath:/META-INF/opennms/mockEventIpcManager.xml",
         "file:src/main/webapp/WEB-INF/applicationContext-svclayer.xml",
-        "file:src/main/webapp/WEB-INF/applicationContext-cxf-common.xml"
+        "file:src/main/webapp/WEB-INF/applicationContext-cxf-common.xml",
+        "classpath:/applicationContext-rest-test.xml"
 })
 @JUnitConfigurationEnvironment
 @JUnitTemporaryDatabase

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/GraphMLRestServiceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/GraphMLRestServiceIT.java
@@ -58,7 +58,8 @@ import org.springframework.test.context.web.WebAppConfiguration;
         "classpath:/META-INF/opennms/applicationContext-databasePopulator.xml",
         "classpath:/META-INF/opennms/mockEventIpcManager.xml",
         "file:src/main/webapp/WEB-INF/applicationContext-svclayer.xml",
-        "file:src/main/webapp/WEB-INF/applicationContext-cxf-common.xml"
+        "file:src/main/webapp/WEB-INF/applicationContext-cxf-common.xml",
+        "classpath:/applicationContext-rest-test.xml"
 })
 @JUnitConfigurationEnvironment
 @JUnitTemporaryDatabase

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/GraphRestServiceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/GraphRestServiceIT.java
@@ -64,7 +64,8 @@ import org.springframework.transaction.annotation.Transactional;
         "classpath:/META-INF/opennms/applicationContext-databasePopulator.xml",
         "classpath:/META-INF/opennms/mockEventIpcManager.xml",
         "file:src/main/webapp/WEB-INF/applicationContext-svclayer.xml",
-        "file:src/main/webapp/WEB-INF/applicationContext-cxf-common.xml"
+        "file:src/main/webapp/WEB-INF/applicationContext-cxf-common.xml",
+        "classpath:/applicationContext-rest-test.xml"
 })
 @JUnitConfigurationEnvironment
 @JUnitTemporaryDatabase

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/GroupRestServiceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/GroupRestServiceIT.java
@@ -77,7 +77,8 @@ import org.springframework.test.context.web.WebAppConfiguration;
         "file:src/main/webapp/WEB-INF/applicationContext-cxf-common.xml",
 
         // Use this to prevent us from overwriting users.xml and groups.xml
-        "classpath:/META-INF/opennms/applicationContext-mock-usergroup.xml"
+        "classpath:/META-INF/opennms/applicationContext-mock-usergroup.xml",
+        "classpath:/applicationContext-rest-test.xml"
 })
 @JUnitConfigurationEnvironment
 @JUnitTemporaryDatabase

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/GzipEncodingRestIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/GzipEncodingRestIT.java
@@ -75,7 +75,8 @@ import com.google.common.io.CharStreams;
         "classpath:/META-INF/opennms/applicationContext-databasePopulator.xml",
         "classpath:/META-INF/opennms/mockEventIpcManager.xml",
         "file:src/main/webapp/WEB-INF/applicationContext-svclayer.xml",
-        "file:src/main/webapp/WEB-INF/applicationContext-cxf-common.xml"
+        "file:src/main/webapp/WEB-INF/applicationContext-cxf-common.xml",
+        "classpath:/applicationContext-rest-test.xml"
 })
 @JUnitConfigurationEnvironment
 @JUnitTemporaryDatabase

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/IPhoneRestServiceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/IPhoneRestServiceIT.java
@@ -69,7 +69,8 @@ import org.springframework.transaction.annotation.Transactional;
         "classpath:/META-INF/opennms/applicationContext-databasePopulator.xml",
         "classpath:/META-INF/opennms/mockEventIpcManager.xml",
         "file:src/main/webapp/WEB-INF/applicationContext-svclayer.xml",
-        "file:src/main/webapp/WEB-INF/applicationContext-cxf-common.xml"
+        "file:src/main/webapp/WEB-INF/applicationContext-cxf-common.xml",
+        "classpath:/applicationContext-rest-test.xml"
 })
 @JUnitConfigurationEnvironment
 @JUnitTemporaryDatabase

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/IfServicesRestServiceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/IfServicesRestServiceIT.java
@@ -69,7 +69,8 @@ import org.springframework.transaction.annotation.Transactional;
         "classpath:/META-INF/opennms/applicationContext-databasePopulator.xml",
         "classpath:/META-INF/opennms/mockEventIpcManager.xml",
         "file:src/main/webapp/WEB-INF/applicationContext-svclayer.xml",
-        "file:src/main/webapp/WEB-INF/applicationContext-cxf-common.xml"
+        "file:src/main/webapp/WEB-INF/applicationContext-cxf-common.xml",
+        "classpath:/applicationContext-rest-test.xml"
 })
 @JUnitConfigurationEnvironment
 @JUnitTemporaryDatabase

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/KscRestServiceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/KscRestServiceIT.java
@@ -71,7 +71,8 @@ import com.google.common.io.Files;
         "classpath:/META-INF/opennms/applicationContext-databasePopulator.xml",
         "classpath:/META-INF/opennms/mockEventIpcManager.xml",
         "file:src/main/webapp/WEB-INF/applicationContext-svclayer.xml",
-        "file:src/main/webapp/WEB-INF/applicationContext-cxf-common.xml"
+        "file:src/main/webapp/WEB-INF/applicationContext-cxf-common.xml",
+        "classpath:/applicationContext-rest-test.xml"
 })
 @JUnitConfigurationEnvironment
 @JUnitTemporaryDatabase

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/MinionRestServiceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/MinionRestServiceIT.java
@@ -59,7 +59,8 @@ import org.springframework.test.context.web.WebAppConfiguration;
         "classpath:/META-INF/opennms/applicationContext-databasePopulator.xml",
         "classpath:/META-INF/opennms/mockEventIpcManager.xml",
         "file:src/main/webapp/WEB-INF/applicationContext-svclayer.xml",
-        "file:src/main/webapp/WEB-INF/applicationContext-cxf-common.xml"
+        "file:src/main/webapp/WEB-INF/applicationContext-cxf-common.xml",
+        "classpath:/applicationContext-rest-test.xml"
 })
 @JUnitConfigurationEnvironment
 @JUnitTemporaryDatabase

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/NodeRestServiceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/NodeRestServiceIT.java
@@ -99,7 +99,8 @@ import org.springframework.test.context.web.WebAppConfiguration;
         "classpath:/META-INF/opennms/applicationContext-databasePopulator.xml",
         "classpath:/META-INF/opennms/mockEventIpcManager.xml",
         "file:src/main/webapp/WEB-INF/applicationContext-svclayer.xml",
-        "file:src/main/webapp/WEB-INF/applicationContext-cxf-common.xml"
+        "file:src/main/webapp/WEB-INF/applicationContext-cxf-common.xml",
+        "classpath:/applicationContext-rest-test.xml"
 })
 @JUnitConfigurationEnvironment
 @JUnitTemporaryDatabase

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/NotificationRestServiceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/NotificationRestServiceIT.java
@@ -65,7 +65,8 @@ import org.springframework.transaction.annotation.Transactional;
         "classpath:/META-INF/opennms/applicationContext-databasePopulator.xml",
         "classpath:/META-INF/opennms/mockEventIpcManager.xml",
         "file:src/main/webapp/WEB-INF/applicationContext-svclayer.xml",
-        "file:src/main/webapp/WEB-INF/applicationContext-cxf-common.xml"
+        "file:src/main/webapp/WEB-INF/applicationContext-cxf-common.xml",
+        "classpath:/applicationContext-rest-test.xml"
 })
 @JUnitConfigurationEnvironment
 @JUnitTemporaryDatabase

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/OutageRestServiceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/OutageRestServiceIT.java
@@ -79,7 +79,8 @@ import org.springframework.test.context.web.WebAppConfiguration;
         "classpath:/META-INF/opennms/applicationContext-databasePopulator.xml",
         "classpath:/META-INF/opennms/mockEventIpcManager.xml",
         "file:src/main/webapp/WEB-INF/applicationContext-svclayer.xml",
-        "file:src/main/webapp/WEB-INF/applicationContext-cxf-common.xml"
+        "file:src/main/webapp/WEB-INF/applicationContext-cxf-common.xml",
+        "classpath:/applicationContext-rest-test.xml"
 })
 @JUnitConfigurationEnvironment
 @JUnitTemporaryDatabase

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/RemotePollerAvailabilityRestServiceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/RemotePollerAvailabilityRestServiceIT.java
@@ -85,7 +85,8 @@ import org.springframework.transaction.support.TransactionTemplate;
         "classpath:/META-INF/opennms/applicationContext-databasePopulator.xml",
         "classpath:/META-INF/opennms/mockEventIpcManager.xml",
         "file:src/main/webapp/WEB-INF/applicationContext-svclayer.xml",
-        "file:src/main/webapp/WEB-INF/applicationContext-cxf-common.xml"
+        "file:src/main/webapp/WEB-INF/applicationContext-cxf-common.xml",
+        "classpath:/applicationContext-rest-test.xml"
 })
 @JUnitConfigurationEnvironment
 @JUnitTemporaryDatabase

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/RequisitionRestServiceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/RequisitionRestServiceIT.java
@@ -65,7 +65,8 @@ import org.springframework.test.context.web.WebAppConfiguration;
         "classpath:/META-INF/opennms/applicationContext-databasePopulator.xml",
         "classpath:/META-INF/opennms/mockEventIpcManager.xml",
         "file:src/main/webapp/WEB-INF/applicationContext-svclayer.xml",
-        "file:src/main/webapp/WEB-INF/applicationContext-cxf-common.xml"
+        "file:src/main/webapp/WEB-INF/applicationContext-cxf-common.xml",
+        "classpath:/applicationContext-rest-test.xml"
 })
 @JUnitConfigurationEnvironment
 @JUnitTemporaryDatabase

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/ResourceRestServiceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/ResourceRestServiceIT.java
@@ -72,7 +72,8 @@ import org.springframework.transaction.annotation.Transactional;
         "classpath:/META-INF/opennms/applicationContext-databasePopulator.xml",
         "classpath:/META-INF/opennms/mockEventIpcManager.xml",
         "file:src/main/webapp/WEB-INF/applicationContext-svclayer.xml",
-        "file:src/main/webapp/WEB-INF/applicationContext-cxf-common.xml"
+        "file:src/main/webapp/WEB-INF/applicationContext-cxf-common.xml",
+        "classpath:/applicationContext-rest-test.xml"
 })
 @JUnitConfigurationEnvironment
 @JUnitTemporaryDatabase

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/ScheduledOutagesRestServiceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/ScheduledOutagesRestServiceIT.java
@@ -79,7 +79,8 @@ import org.springframework.test.context.web.WebAppConfiguration;
         "classpath:/META-INF/opennms/applicationContext-databasePopulator.xml",
         "classpath:/META-INF/opennms/mockEventIpcManager.xml",
         "file:src/main/webapp/WEB-INF/applicationContext-svclayer.xml",
-        "file:src/main/webapp/WEB-INF/applicationContext-cxf-common.xml"
+        "file:src/main/webapp/WEB-INF/applicationContext-cxf-common.xml",
+        "classpath:/applicationContext-rest-test.xml"
 })
 @JUnitConfigurationEnvironment
 @JUnitTemporaryDatabase

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/SnmpConfigRestServiceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/SnmpConfigRestServiceIT.java
@@ -70,7 +70,8 @@ import org.springframework.test.context.web.WebAppConfiguration;
         "classpath:/META-INF/opennms/applicationContext-databasePopulator.xml",
         "classpath:/META-INF/opennms/mockEventIpcManager.xml",
         "file:src/main/webapp/WEB-INF/applicationContext-svclayer.xml",
-        "file:src/main/webapp/WEB-INF/applicationContext-cxf-common.xml"
+        "file:src/main/webapp/WEB-INF/applicationContext-cxf-common.xml",
+		"classpath:/applicationContext-rest-test.xml"
 })
 @JUnitConfigurationEnvironment
 @JUnitTemporaryDatabase

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/UserRestServiceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/UserRestServiceIT.java
@@ -78,7 +78,8 @@ import org.springframework.test.context.web.WebAppConfiguration;
         "file:src/main/webapp/WEB-INF/applicationContext-cxf-common.xml",
 
         // Use this to prevent us from overwriting users.xml and groups.xml
-        "classpath:/META-INF/opennms/applicationContext-mock-usergroup.xml"
+        "classpath:/META-INF/opennms/applicationContext-mock-usergroup.xml",
+        "classpath:/applicationContext-rest-test.xml"
 })
 @JUnitConfigurationEnvironment
 @JUnitTemporaryDatabase

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/config/AgentConfigurationResourceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/config/AgentConfigurationResourceIT.java
@@ -60,7 +60,8 @@ import org.springframework.test.context.web.WebAppConfiguration;
         "classpath:/META-INF/opennms/applicationContext-databasePopulator.xml",
         "classpath:/META-INF/opennms/mockEventIpcManager.xml",
         "file:src/main/webapp/WEB-INF/applicationContext-svclayer.xml",
-        "file:src/main/webapp/WEB-INF/applicationContext-cxf-common.xml"
+        "file:src/main/webapp/WEB-INF/applicationContext-cxf-common.xml",
+        "classpath:/applicationContext-rest-test.xml"
 })
 @JUnitConfigurationEnvironment
 @JUnitTemporaryDatabase

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/config/DataCollectionConfigResourceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/config/DataCollectionConfigResourceIT.java
@@ -60,7 +60,8 @@ import org.springframework.test.context.web.WebAppConfiguration;
         "classpath:/META-INF/opennms/applicationContext-databasePopulator.xml",
         "classpath:/META-INF/opennms/mockEventIpcManager.xml",
         "file:src/main/webapp/WEB-INF/applicationContext-svclayer.xml",
-        "file:src/main/webapp/WEB-INF/applicationContext-cxf-common.xml"
+        "file:src/main/webapp/WEB-INF/applicationContext-cxf-common.xml",
+        "classpath:/applicationContext-rest-test.xml"
 })
 @JUnitConfigurationEnvironment
 @JUnitTemporaryDatabase

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/config/JmxDataCollectionConfigResourceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/config/JmxDataCollectionConfigResourceIT.java
@@ -57,7 +57,8 @@ import static org.junit.Assert.assertNotNull;
         "classpath:/META-INF/opennms/applicationContext-databasePopulator.xml",
         "classpath:/META-INF/opennms/mockEventIpcManager.xml",
         "file:src/main/webapp/WEB-INF/applicationContext-svclayer.xml",
-        "file:src/main/webapp/WEB-INF/applicationContext-cxf-common.xml"
+        "file:src/main/webapp/WEB-INF/applicationContext-cxf-common.xml",
+        "classpath:/applicationContext-rest-test.xml"
 })
 @JUnitConfigurationEnvironment
 @JUnitTemporaryDatabase

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/config/SnmpConfigurationResourceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/config/SnmpConfigurationResourceIT.java
@@ -54,7 +54,8 @@ import org.springframework.test.context.web.WebAppConfiguration;
         "classpath:/META-INF/opennms/applicationContext-databasePopulator.xml",
         "classpath:/META-INF/opennms/mockEventIpcManager.xml",
         "file:src/main/webapp/WEB-INF/applicationContext-svclayer.xml",
-        "file:src/main/webapp/WEB-INF/applicationContext-cxf-common.xml"
+        "file:src/main/webapp/WEB-INF/applicationContext-cxf-common.xml",
+        "classpath:/applicationContext-rest-test.xml"
 })
 @JUnitConfigurationEnvironment
 @JUnitTemporaryDatabase

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/config/TrapdConfigurationResourceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/config/TrapdConfigurationResourceIT.java
@@ -54,7 +54,8 @@ import org.springframework.test.context.web.WebAppConfiguration;
         "classpath:/META-INF/opennms/applicationContext-databasePopulator.xml",
         "classpath:/META-INF/opennms/mockEventIpcManager.xml",
         "file:src/main/webapp/WEB-INF/applicationContext-svclayer.xml",
-        "file:src/main/webapp/WEB-INF/applicationContext-cxf-common.xml"
+        "file:src/main/webapp/WEB-INF/applicationContext-cxf-common.xml",
+        "classpath:/applicationContext-rest-test.xml"
 })
 @JUnitConfigurationEnvironment
 @JUnitTemporaryDatabase

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/json/RequisitionRestServiceJsonIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/json/RequisitionRestServiceJsonIT.java
@@ -66,7 +66,8 @@ import org.springframework.test.context.web.WebAppConfiguration;
         "classpath:/META-INF/opennms/applicationContext-databasePopulator.xml",
         "classpath:/META-INF/opennms/mockEventIpcManager.xml",
         "file:src/main/webapp/WEB-INF/applicationContext-svclayer.xml",
-        "file:src/main/webapp/WEB-INF/applicationContext-cxf-common.xml"
+        "file:src/main/webapp/WEB-INF/applicationContext-cxf-common.xml",
+        "classpath:/applicationContext-rest-test.xml"
 })
 @JUnitConfigurationEnvironment
 @JUnitTemporaryDatabase

--- a/opennms-webapp-rest/src/test/resources/applicationContext-rest-test.xml
+++ b/opennms-webapp-rest/src/test/resources/applicationContext-rest-test.xml
@@ -28,5 +28,8 @@
 		<constructor-arg value="org.opennms.netmgt.config.poller.PollerConfiguration" />
 		<constructor-arg value="file:target/test-classes/poller-configuration.xml" />
 	</bean>
-	
+
+	<bean name="timeformatService" class="org.opennms.features.timeformat.impl.DefaultTimeformatService">
+	</bean>
+
 </beans>


### PR DESCRIPTION
* JIRA: https://issues.opennms.org/browse/NMS-10301

Please do not merge yet: This branch contains as well the changes from https://github.com/OpenNMS/opennms/pull/2080 (NMS-10268 render dateformat for Vaadin). I will rebase to foundation-2018 once NMS 10268 is merged.

@RangerRick you will need this endpoint to get the zoneId and format information to the client, for:
* https://issues.opennms.org/browse/NMS-10232 and
* https://issues.opennms.org/browse/NMS-10233
Could you check if the endpoint gives you the necessary information?

Example output:

```
{

    "displayVersion": "21.1.0-SNAPSHOT",
    "version": "21.1.0",
    "packageName": "opennms",
    "packageDescription": "OpenNMS",
    "ticketerConfig": {
        "plugin": null,
        "enabled": false
    },
    "datetimeformatConfig": {
        "zoneId": "America/St_Lucia",
        "datetimeformat": "yyyy-MM-dd'T'HH:mm:ssxxx"
    }

} 
```
Thanks!

Our [continuous integration system](http://bamboo.internal.opennms.com:8085) will test and verify your changes.
