### PR TITLE
NMS-10272: Syslog messages should default to being associated with the hosts from which they were received

### DIFF
--- a/features/events/syslog/src/main/java/org/opennms/netmgt/syslogd/ConvertToEvent.java
+++ b/features/events/syslog/src/main/java/org/opennms/netmgt/syslogd/ConvertToEvent.java
@@ -241,6 +241,12 @@ public class ConvertToEvent {
             LOG.trace("got syslog message {}", SyslogParser.fromByteBuffer(buffer));
         }
 
+        // If no host name was provided we will use the source IP address
+        if(message.getHostName() == null)
+        {
+            message.setHostName(addr.getHostAddress());
+        }
+
         final String priorityTxt = message.getSeverity().toString();
         final String facilityTxt = message.getFacility().toString();
 

--- a/features/events/syslog/src/test/java/org/opennms/netmgt/syslogd/ConvertToEventTest.java
+++ b/features/events/syslog/src/test/java/org/opennms/netmgt/syslogd/ConvertToEventTest.java
@@ -42,7 +42,11 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.junit.BeforeClass;
@@ -396,6 +400,7 @@ public class ConvertToEventTest {
         Integer nodeId = 1;
 
         // Mock the cache hit for the IP Address to Node ID lookup
+        InterfaceToNodeCache originalCache = AbstractInterfaceToNodeCache.getInstance();
         InterfaceToNodeCache mockCache = Mockito.mock(InterfaceToNodeCache.class);
         AbstractInterfaceToNodeCache.setInstance(mockCache);
         when(mockCache.getFirstNodeId(MonitoringLocationDao.DEFAULT_MONITORING_LOCATION_ID,
@@ -403,9 +408,12 @@ public class ConvertToEventTest {
 
         Event event = parseSyslog("testNoHostNameProvided", radixConfig, syslogMessage);
         String eventHostname = event.getParm("hostname").getValue().getContent();
+
+        // Stop using the mock cache so we don't interfere with other tests
+        AbstractInterfaceToNodeCache.setInstance(originalCache);
+
         assertNotNull(eventHostname);
-        assertEquals(localHostIP,
-                InetAddressUtils.addr(eventHostname));
+        assertEquals(localHostIP, InetAddressUtils.addr(eventHostname));
         assertEquals(nodeId.intValue(), event.getNodeid().intValue());
     }
 

--- a/features/events/syslog/src/test/java/org/opennms/netmgt/syslogd/ConvertToEventTest.java
+++ b/features/events/syslog/src/test/java/org/opennms/netmgt/syslogd/ConvertToEventTest.java
@@ -36,15 +36,14 @@ import static org.junit.Assert.fail;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.DatagramPacket;
+import java.net.Inet4Address;
 import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.List;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import org.junit.Test;
@@ -56,9 +55,12 @@ import org.opennms.netmgt.dao.api.DistPollerDao;
 import org.opennms.netmgt.dao.api.MonitoringLocationDao;
 import org.opennms.netmgt.dao.hibernate.InterfaceToNodeCacheDaoImpl;
 import org.opennms.netmgt.dao.mock.MockInterfaceToNodeCache;
+import org.opennms.netmgt.syslogd.api.SyslogMessageDTO;
+import org.opennms.netmgt.syslogd.api.SyslogMessageLogDTO;
 import org.opennms.netmgt.xml.event.Event;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  * Test the performance of Syslogd's {@link ConvertToEvent} processor.
@@ -68,6 +70,9 @@ import org.slf4j.LoggerFactory;
 public class ConvertToEventTest {
 
     private static final Logger LOG = LoggerFactory.getLogger(ConvertToEventTest.class);
+
+    @Autowired
+    private SyslogdConfig syslogdConfig;
 
     /**
      * Test method which calls the ConvertToEvent constructor.
@@ -372,5 +377,30 @@ public class ConvertToEventTest {
         assertEquals(0, middleByteTrimmed.position());
         assertEquals(3, middleByteTrimmed.limit());
         assertEquals(3, middleByteTrimmed.remaining());
+    }
+
+    /**
+     * Test to make sure that a syslog message with no host provided uses the source
+     * address of the message log and that the node is is correctly populated.
+     */
+    @Test
+    public void testNoHostNameProvided()
+    {
+        // TODO: Copied from above
+        final String syslogMessage = "<14> Mar 29 2004 09:57:04: %PIX-5-304001: 192.168.0.2 Accessed URL 212.227.109.224:/scriptlib/ClientStdScripts.js";
+
+        // TODO: Mock the cache that will respond with a cache hit
+        // for the node ID corresponding to the host name that
+        // should be populated
+
+        // TODO: This is duplicated from above...
+        SyslogConfigBean radixConfig = new SyslogConfigBean();
+        radixConfig.setParser("org.opennms.netmgt.syslogd.RadixTreeSyslogParser");
+        radixConfig.setDiscardUei("DISCARD-MATCHING-MESSAGES");
+        Event event = parseSyslog("test", radixConfig, syslogMessage);
+
+        // TODO: Assert the node id was populated
+        // TODO: Fix this so it doesn't resolve to the hostname string
+        //assertEquals(InetAddressUtils.ONE_TWENTY_SEVEN.toString(),event.getHost());
     }
 }


### PR DESCRIPTION
* JIRA: http://issues.opennms.org/browse/NMS-10272

Our [continuous integration system](http://bamboo.internal.opennms.com:8085) will test and verify your changes.
