### PR TITLE
HZN-1355: Use AlarmId to reference Situation

### DIFF
--- a/features/situation-feedback/rest/api/src/main/java/org/opennms/features/situationfeedback/rest/SituationFeedbackRestService.java
+++ b/features/situation-feedback/rest/api/src/main/java/org/opennms/features/situationfeedback/rest/SituationFeedbackRestService.java
@@ -44,13 +44,13 @@ import org.opennms.features.situationfeedback.api.AlarmFeedback;
 public interface SituationFeedbackRestService {
 
     @GET
-    @Path("/{situationKey}")
+    @Path("/{situationId}")
     @Produces(MediaType.APPLICATION_JSON)
-    public Collection<AlarmFeedback> getFeedback(@PathParam("situationKey") String situationKey);
+    public Collection<AlarmFeedback> getFeedback(@PathParam("situationId") int situationId);
 
     @POST
-    @Path("/{situationKey}")
+    @Path("/{situationId}")
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
-    public void setFeedback(List<AlarmFeedback> feedback);
+    public void setFeedback(@PathParam("situationId") int situationId, List<AlarmFeedback> feedback);
 }

--- a/features/situation-feedback/rest/impl/src/test/java/org/opennms/features/situationfeedback/rest/SituationFeedbackrestServiceIT.java
+++ b/features/situation-feedback/rest/impl/src/test/java/org/opennms/features/situationfeedback/rest/SituationFeedbackrestServiceIT.java
@@ -32,7 +32,6 @@ import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;

--- a/features/situation-feedback/rest/impl/src/test/java/org/opennms/features/situationfeedback/rest/SituationFeedbackrestServiceIT.java
+++ b/features/situation-feedback/rest/impl/src/test/java/org/opennms/features/situationfeedback/rest/SituationFeedbackrestServiceIT.java
@@ -32,6 +32,7 @@ import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -128,7 +129,9 @@ public class SituationFeedbackrestServiceIT {
         OnmsAlarm prior = alarmDao.findByReductionKey(situation.getReductionKey());
         assertThat(prior.getRelatedAlarms().size(), is(2));
 
-        sut.setFeedback(feedback);
+        int situationId = prior.getId();
+
+        sut.setFeedback(situationId, feedback);
 
         OnmsAlarm restrieved = alarmDao.findByReductionKey(situation.getReductionKey());
         assertThat(restrieved.getRelatedAlarms().size(), is(1));


### PR DESCRIPTION
JIRA: https://issues.opennms.org/browse/HZN-1355

This PR modifies the SituationFeedback REST API to use the AlarmId as the identifier of the Situations.