### PR TITLE
HZN-1381: Situation severity should be set to max related alarm severity

### DIFF
--- a/core/schema/src/main/liquibase/23.0.0/changelog.xml
+++ b/core/schema/src/main/liquibase/23.0.0/changelog.xml
@@ -99,4 +99,17 @@
             tableName="alarm_situations"/>
  </changeSet>
  
+  <changeSet author="jwhite" id="23.0.0-alarm-situations-cascades">
+    <dropForeignKeyConstraint baseTableName="alarm_situations" constraintName="fk_alarm_situations_alarm_id" />
+    <dropForeignKeyConstraint baseTableName="alarm_situations" constraintName="fk_alarm_situations_situation_id" />
+
+    <addForeignKeyConstraint constraintName="fk_alarm_situations_situation_id" onDelete="CASCADE"
+          baseTableName="alarm_situations" baseColumnNames="situation_id"
+          referencedTableName="alarms" referencedColumnNames="alarmid"/>
+    <addForeignKeyConstraint constraintName="fk_alarm_situations_alarm_id" onDelete="CASCADE"
+	    baseTableName="alarm_situations" baseColumnNames="related_alarm_id"
+          referencedTableName="alarms" referencedColumnNames="alarmid"/>
+  </changeSet>
+
 </databaseChangeLog>
+

--- a/features/events/api/src/main/java/org/opennms/netmgt/events/api/EventConstants.java
+++ b/features/events/api/src/main/java/org/opennms/netmgt/events/api/EventConstants.java
@@ -57,6 +57,11 @@ public abstract class EventConstants {
     //
 
     /**
+     * The situation event UEI.
+     */
+    public static final String SITUATION_EVENT_UEI = "uei.opennms.org/alarms/situation";
+
+    /**
      * The new suspect event UEI.
      */
     public static final String NEW_SUSPECT_INTERFACE_EVENT_UEI = "uei.opennms.org/internal/discovery/newSuspect";

--- a/opennms-alarms/daemon/src/main/java/org/opennms/netmgt/alarmd/AlarmPersisterImpl.java
+++ b/opennms-alarms/daemon/src/main/java/org/opennms/netmgt/alarmd/AlarmPersisterImpl.java
@@ -69,6 +69,8 @@ import com.google.common.util.concurrent.Striped;
 public class AlarmPersisterImpl implements AlarmPersister {
     private static final Logger LOG = LoggerFactory.getLogger(AlarmPersisterImpl.class);
 
+    public static final String RELATED_REDUCTION_KEY_PREFIX = "related-reductionKey";
+
     protected static final Integer NUM_STRIPE_LOCKS = Integer.getInteger("org.opennms.alarmd.stripe.locks", Alarmd.THREADS * 4);
 
     @Autowired
@@ -298,7 +300,7 @@ public class AlarmPersisterImpl implements AlarmPersister {
     private static boolean isRelatedReductionKeyWithContent(Parm param) {
         return param.getParmName() != null
                 // TOOD revisit using equals() when event_parameters table supports multiple params with the same name (see NMS-10214)
-                && param.getParmName().startsWith("related-reductionKey")
+                && param.getParmName().startsWith(RELATED_REDUCTION_KEY_PREFIX)
                 && param.getValue() != null
                 && param.getValue().getContent() != null;
     }

--- a/opennms-alarms/daemon/src/main/java/org/opennms/netmgt/alarmd/drools/AlarmService.java
+++ b/opennms-alarms/daemon/src/main/java/org/opennms/netmgt/alarmd/drools/AlarmService.java
@@ -39,7 +39,7 @@ public interface AlarmService {
 
     void deleteAlarm(OnmsAlarm alarm);
 
-    void unclearAlarm(OnmsAlarm alarm);
+    void unclearAlarm(OnmsAlarm alarm, Date now);
 
     void escalateAlarm(OnmsAlarm alarm, Date now);
 

--- a/opennms-alarms/daemon/src/main/java/org/opennms/netmgt/alarmd/drools/DefaultAlarmService.java
+++ b/opennms-alarms/daemon/src/main/java/org/opennms/netmgt/alarmd/drools/DefaultAlarmService.java
@@ -73,6 +73,7 @@ public class DefaultAlarmService implements AlarmService {
         final OnmsAlarm alarmInTrans = alarmDao.get(alarm.getId());
         if (alarmInTrans == null) {
             LOG.warn("Alarm disappeared: {}. Skipping delete.", alarm);
+            return;
         }
         alarmDao.delete(alarmInTrans);
         alarmEntityNotifier.didDeleteAlarm(alarmInTrans);
@@ -124,6 +125,21 @@ public class DefaultAlarmService implements AlarmService {
         alarmInTrans.setAlarmAckTime(now);
         alarmDao.update(alarmInTrans);
         alarmEntityNotifier.didAcknowledgeAlarm(alarmInTrans, previousAckUser, previousAckTime);
+    }
+
+    @Override
+    @Transactional
+    public void setSeverity(OnmsAlarm alarm, OnmsSeverity severity, Date now) {
+        LOG.info("Updating severity on alarm with id: {}", alarm.getId());
+        final OnmsAlarm alarmInTrans = alarmDao.get(alarm.getId());
+        if (alarmInTrans == null) {
+            LOG.warn("Alarm disappeared: {}. Skipping severity update.", alarm);
+            return;
+        }
+        final OnmsSeverity previousSeverity = alarmInTrans.getSeverity();
+        alarmInTrans.setSeverity(severity);
+        alarmDao.update(alarmInTrans);
+        alarmEntityNotifier.didUpdateAlarmSeverity(alarmInTrans, previousSeverity);
     }
 
     private static void updateAutomationTime(OnmsAlarm alarm, Date now) {

--- a/opennms-alarms/daemon/src/main/java/org/opennms/netmgt/alarmd/drools/DefaultAlarmService.java
+++ b/opennms-alarms/daemon/src/main/java/org/opennms/netmgt/alarmd/drools/DefaultAlarmService.java
@@ -81,7 +81,7 @@ public class DefaultAlarmService implements AlarmService {
 
     @Override
     @Transactional
-    public void unclearAlarm(OnmsAlarm alarm) {
+    public void unclearAlarm(OnmsAlarm alarm, Date now) {
         LOG.info("Un-clearing alarm with id: {} at: {}", alarm.getId(), alarm.getLastEventTime());
         final OnmsAlarm alarmInTrans = alarmDao.get(alarm.getId());
         if (alarmInTrans == null) {
@@ -90,6 +90,7 @@ public class DefaultAlarmService implements AlarmService {
         }
         final OnmsSeverity previousSeverity = alarmInTrans.getSeverity();
         alarmInTrans.setSeverity(OnmsSeverity.get(alarmInTrans.getLastEvent().getEventSeverity()));
+        updateAutomationTime(alarmInTrans, now);
         alarmDao.update(alarmInTrans);
         alarmEntityNotifier.didUpdateAlarmSeverity(alarmInTrans, previousSeverity);
     }
@@ -138,6 +139,7 @@ public class DefaultAlarmService implements AlarmService {
         }
         final OnmsSeverity previousSeverity = alarmInTrans.getSeverity();
         alarmInTrans.setSeverity(severity);
+        updateAutomationTime(alarm, now);
         alarmDao.update(alarmInTrans);
         alarmEntityNotifier.didUpdateAlarmSeverity(alarmInTrans, previousSeverity);
     }

--- a/opennms-alarms/daemon/src/main/java/org/opennms/netmgt/alarmd/drools/DroolsAlarmContext.java
+++ b/opennms-alarms/daemon/src/main/java/org/opennms/netmgt/alarmd/drools/DroolsAlarmContext.java
@@ -35,6 +35,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.hibernate.Hibernate;
 import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.rule.FactHandle;
 import org.opennms.core.utils.ConfigFileConstants;
@@ -136,6 +137,8 @@ public class DroolsAlarmContext extends ManagedDroolsContext implements AlarmLif
 
     private void handleNewOrUpdatedAlarmNoLock(OnmsAlarm alarm) {
         final KieSession kieSession = getKieSession();
+        // Initialize any related objects that are needed for rule execution
+        Hibernate.initialize(alarm.getRelatedAlarms());
         final AlarmAndFact alarmAndFact = alarmsById.get(alarm.getId());
         if (alarmAndFact == null) {
             LOG.debug("Inserting alarm into session: {}", alarm);

--- a/opennms-alarms/daemon/src/main/java/org/opennms/netmgt/alarmd/drools/MaxSeverityAccumulateFunction.java
+++ b/opennms-alarms/daemon/src/main/java/org/opennms/netmgt/alarmd/drools/MaxSeverityAccumulateFunction.java
@@ -1,0 +1,110 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2018 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2018 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.alarmd.drools;
+
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+
+import org.drools.core.base.accumulators.AbstractAccumulateFunction;
+import org.opennms.netmgt.model.OnmsSeverity;
+
+public class MaxSeverityAccumulateFunction extends AbstractAccumulateFunction<MaxSeverityAccumulateFunction.MaxSeverity> {
+
+    protected static class MaxSeverity implements Externalizable {
+        public OnmsSeverity max = null;
+
+        public MaxSeverity() {}
+
+        public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
+            max = (OnmsSeverity) in.readObject();
+        }
+
+        public void writeExternal(ObjectOutput out) throws IOException {
+            out.writeObject(max);
+        }
+
+        @Override
+        public String toString() {
+            return "max";
+        }
+    }
+
+    @Override
+    public MaxSeverity createContext() {
+        return new MaxSeverity();
+    }
+
+    @Override
+    public void init(MaxSeverity context) {
+        context.max = null;
+    }
+
+    @Override
+    public void accumulate(MaxSeverity context, Object value) {
+        if (value instanceof OnmsSeverity) {
+            final OnmsSeverity severity = (OnmsSeverity)value;
+            context.max = context.max == null || context.max.compareTo( severity ) < 0 ?
+                    severity:
+                    context.max;
+        }
+    }
+
+    @Override
+    public Object getResult(MaxSeverity context) {
+        return context.max;
+    }
+
+    @Override
+    public boolean supportsReverse() {
+        return false;
+    }
+
+    @Override
+    public void reverse(MaxSeverity context, Object value) {
+        // pass
+    }
+
+    @Override
+    public Class<?> getResultType() {
+        return OnmsSeverity.class;
+    }
+
+    @Override
+    public void writeExternal(ObjectOutput out) {
+        // pass
+    }
+
+    @Override
+    public void readExternal(ObjectInput in) {
+        // pass
+    }
+
+}

--- a/opennms-alarms/daemon/src/main/resources/META-INF/kie.properties.conf
+++ b/opennms-alarms/daemon/src/main/resources/META-INF/kie.properties.conf
@@ -1,0 +1,1 @@
+drools.accumulate.function.maxSeverity = org.opennms.netmgt.alarmd.drools.MaxSeverityAccumulateFunction

--- a/opennms-alarms/daemon/src/test/java/org/opennms/netmgt/alarmd/AlarmdBlackboxIT.java
+++ b/opennms-alarms/daemon/src/test/java/org/opennms/netmgt/alarmd/AlarmdBlackboxIT.java
@@ -271,6 +271,44 @@ public class AlarmdBlackboxIT {
         assertThat(problemStates.get(2).getAlarm(), nullValue()); // DELETED
     }
 
+
+    /**
+     * Verifies the basic lifecycle of a situation.
+     */
+    @Test
+    public void canCreateSituation() {
+        Scenario scenario = Scenario.builder()
+                // Create some node down alarms
+                .withNodeDownEvent(1, 1)
+                .withNodeDownEvent(2, 2)
+                // Create a situation that contains the node down alarms
+                .withSituationForNodeDownAlarms(3, "situation#1", 1, 2)
+                // Now clear the node down alarms
+                .withNodeUpEvent(4, 1)
+                .withNodeUpEvent(4, 2)
+                .build();
+        ScenarioResults results = play(scenario);
+
+        // Verify the set of alarms at various points in time
+
+        // t=0, no alarms
+        assertThat(results.getAlarms(0), hasSize(0));
+        // t=1, a single problem alarm
+        assertThat(results.getAlarms(1), hasSize(1));
+        assertThat(results.getProblemAlarm(1), hasSeverity(OnmsSeverity.MAJOR));
+        // t=2, two problem alarms
+        assertThat(results.getAlarms(2), hasSize(2));
+        // t=3, two problem alarms + 1 situation
+        assertThat(results.getAlarms(3), hasSize(3)); // the situation is also an alarm, so it is counted here
+        assertThat(results.getSituations(3), hasSize(1));
+        assertThat(results.getSituation(3), hasSeverity(OnmsSeverity.MAJOR));
+        // t=4, everything should be cleared
+        assertThat(results.getProblemAlarm(4), hasSeverity(OnmsSeverity.CLEARED));
+        assertThat(results.getSituation(4), hasSeverity(OnmsSeverity.CLEARED));
+        // t=∞
+        assertThat(results.getAlarmsAtLastKnownTime(), hasSize(0));
+    }
+
     private ScenarioResults play(Scenario scenario) {
         JUnitScenarioDriver driver = new JUnitScenarioDriver();
         return driver.run(scenario);

--- a/opennms-alarms/daemon/src/test/java/org/opennms/netmgt/alarmd/driver/ScenarioResults.java
+++ b/opennms-alarms/daemon/src/test/java/org/opennms/netmgt/alarmd/driver/ScenarioResults.java
@@ -57,6 +57,18 @@ public class ScenarioResults {
         return alarmsByTime.get(lastTime);
     }
 
+    public List<OnmsAlarm> getSituations(long time) {
+        return getAlarms(time).stream()
+                .filter(OnmsAlarm::isSituation)
+                .collect(Collectors.toList());
+    }
+
+    public OnmsAlarm getSituation(long time) {
+        return getSituations(time).stream()
+                .findFirst()
+                .orElse(null);
+    }
+
     public OnmsAlarm getProblemAlarm(long time) {
         return getFirstAlarmWithType(time, OnmsAlarm.PROBLEM_TYPE, "problem");
     }

--- a/opennms-base-assembly/src/main/filtered/etc/alarmd/drools-rules.d/alarmd.drl
+++ b/opennms-base-assembly/src/main/filtered/etc/alarmd/drools-rules.d/alarmd.drl
@@ -109,7 +109,8 @@ rule "unclear"
                          OnmsSeverity.get(lastEvent.getEventSeverity()).isGreaterThan(OnmsSeverity.CLEARED),
                          lastEventTime > lastAutomationTime)
   then
-    alarmService.unclearAlarm($trigger);
+    Date now = new Date(drools.getWorkingMemory().getSessionClock().getCurrentTime());
+    alarmService.unclearAlarm($trigger, now);
 end
 
 /*

--- a/opennms-base-assembly/src/main/filtered/etc/alarmd/drools-rules.d/situations.drl
+++ b/opennms-base-assembly/src/main/filtered/etc/alarmd/drools-rules.d/situations.drl
@@ -29,22 +29,26 @@
 package org.opennms.netmgt.alarmd.drools;
 
 import java.util.Date;
-
+import org.kie.api.time.SessionClock;
 import org.opennms.netmgt.model.OnmsAlarm;
 import org.opennms.netmgt.model.OnmsSeverity;
+import org.opennms.netmgt.model.TroubleTicketState;
+import java.util.LinkedList;
 
-public interface AlarmService {
+global org.opennms.netmgt.alarmd.drools.AlarmService alarmService;
 
-    void clearAlarm(OnmsAlarm alarm, Date clearTime);
+declare org.opennms.netmgt.model.OnmsAlarm
+    @role(event)
+    @timestamp(lastUpdateTime)
+end
 
-    void deleteAlarm(OnmsAlarm alarm);
-
-    void unclearAlarm(OnmsAlarm alarm);
-
-    void escalateAlarm(OnmsAlarm alarm, Date now);
-
-    void acknowledgeAlarm(OnmsAlarm alarm, Date now);
-
-    void setSeverity(OnmsAlarm alarm, OnmsSeverity severity, Date now);
-
-}
+rule "setSituationSeverityToMaxAlarmSeverity"
+  when
+    $situation : OnmsAlarm( isSituation() == true, $relatedAlarmIds : relatedAlarmIds )
+    $relatedAlarms : LinkedList() from collect( OnmsAlarm($relatedAlarmIds contains id) )
+    $maxSeverity : OnmsSeverity() from accumulate( OnmsAlarm( $severity : severity ) from $relatedAlarms, maxSeverity( $severity ) )
+    OnmsAlarm( this == $situation, severity != $maxSeverity )
+  then
+    Date now = new Date(drools.getWorkingMemory().getSessionClock().getCurrentTime());
+    alarmService.setSeverity($situation, $maxSeverity, now);
+end

--- a/opennms-base-assembly/src/main/filtered/etc/create.sql
+++ b/opennms-base-assembly/src/main/filtered/etc/create.sql
@@ -1114,8 +1114,8 @@ CREATE TABLE alarm_situations (
     situation_id    INTEGER NOT NULL,
     related_alarm_id  INTEGER NOT NULL,
     
-    CONSTRAINT fk_alarm_situations_alarm_id FOREIGN KEY (related_alarm_id) REFERENCES alarms (alarmid),
-    CONSTRAINT fk_alarm_situations_situation_id FOREIGN KEY (situation_id) REFERENCES alarms (alarmid)
+    CONSTRAINT fk_alarm_situations_alarm_id FOREIGN KEY (related_alarm_id) REFERENCES alarms (alarmid) ON DELETE CASCADE,
+    CONSTRAINT fk_alarm_situations_situation_id FOREIGN KEY (situation_id) REFERENCES alarms (alarmid) ON DELETE CASCADE
 );
 
 CREATE UNIQUE INDEX alarm_situations_situation_id_alarms_alarmid_key ON alarm_situations(situation_id, related_alarm_id);

--- a/opennms-base-assembly/src/main/filtered/etc/events/opennms.alarm.events.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/events/opennms.alarm.events.xml
@@ -19,4 +19,12 @@
          <update-field field-name="severity" update-on-reduction="true"/>
       </alarm-data>
    </event>
+   <event>
+      <uei>uei.opennms.org/alarms/situation</uei>
+      <event-label>Alarm: Situation</event-label>
+      <descr>%parm[situationDescr]%</descr>
+      <logmsg dest="logndisplay">%parm[situationLogMsg]%</logmsg>
+      <severity>Normal</severity>
+      <alarm-data reduction-key="%uei%:%parm[situationId]%" alarm-type="3" auto-clean="true" />
+   </event>
 </events>

--- a/opennms-model/src/main/java/org/opennms/netmgt/model/OnmsAlarm.java
+++ b/opennms-model/src/main/java/org/opennms/netmgt/model/OnmsAlarm.java
@@ -38,6 +38,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
@@ -1156,7 +1157,7 @@ public class OnmsAlarm implements Acknowledgeable, Serializable {
     }
 
     /**
-     * <p>getAlarms</p>
+     * <p>getRelatedAlarms</p>
      *
      * @return a {@link java.util.Set} object.
      */
@@ -1166,6 +1167,14 @@ public class OnmsAlarm implements Acknowledgeable, Serializable {
     @Column(name="alarm_id", nullable=false)
     public Set<OnmsAlarm> getRelatedAlarms() {
         return m_relatedAlarms;
+    }
+
+    @Transient
+    @XmlTransient
+    public Set<Integer> getRelatedAlarmIds() {
+        return getRelatedAlarms().stream()
+                .map(OnmsAlarm::getId)
+                .collect(Collectors.toSet());
     }
 
     /**


### PR DESCRIPTION
JIRA: https://issues.opennms.org/browse/HZN-1381

With this update, the Drools rules now automatically set the severity of the situations to be the maximum severity of the related child alarms. This improves the life-cycle of situations by ensuring that they get cleared and delete similar to alarms.

