### PR TITLE
NMS-10286: Fix the JsonCollector on Minion

### DIFF
--- a/container/features/src/main/resources/features.xml
+++ b/container/features/src/main/resources/features.xml
@@ -1015,7 +1015,9 @@
 
     <feature name="opennms-xml-collector" version="${project.version}" description="OpenNMS :: Protocols :: XML Collector">
       <bundle>wrap:mvn:com.jcraft/jsch/0.1.51</bundle>
-      <!-- <bundle>wrap:mvn:net.sf.json-lib/json-lib/2.2.3//jdk15</bundle> -->
+      <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.oro/2.0.8_6</bundle>
+      <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.ezmorph/1.0.6_1</bundle>
+      <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.json-lib/${jsonlibBundleVersion}</bundle>
       <feature>commons-jxpath</feature>
       <bundle>wrap:mvn:org.jsoup/jsoup/${jsoupVersion}</bundle>
       <bundle>mvn:org.opennms.protocols/org.opennms.protocols.xml/${project.version}</bundle>

--- a/pom.xml
+++ b/pom.xml
@@ -1310,6 +1310,8 @@
     <jodaTimeVersion>2.1</jodaTimeVersion>
     <jrubyVersion>9.0.4.0</jrubyVersion>
     <jsoupVersion>1.7.2</jsoupVersion>
+    <jsonlibVersion>2.4</jsonlibVersion>
+    <jsonlibBundleVersion>2.4_1</jsonlibBundleVersion>
     <karafVersion>4.1.5</karafVersion>
     <kafkaStreamsVersion>1.0.1</kafkaStreamsVersion>
     <kafkaStreamsBundleVersion>1.0.1_1</kafkaStreamsBundleVersion>
@@ -3350,7 +3352,7 @@
       <dependency>
         <groupId>net.sf.json-lib</groupId>
         <artifactId>json-lib</artifactId>
-        <version>2.2.3</version>
+        <version>${jsonlibVersion}</version>
         <classifier>jdk15</classifier>
       </dependency>
       <dependency>

--- a/protocols/xml/pom.xml
+++ b/protocols/xml/pom.xml
@@ -24,7 +24,6 @@
             <!-- Don't export any packages, expose services only. -->
             <Export-Package></Export-Package>
             <Import-Package>
-              net.sf.json;resolution:=optional,
               org.eclipse.persistence.internal.jaxb;resolution:=optional,
               org.eclipse.persistence.internal.jaxb.many;resolution:=optional,
               org.opennms.core.network,


### PR DESCRIPTION
JIRA: https://issues.opennms.org/browse/NMS-10286

* Upgraded json-lib to v2.4 since ServiceMix provides
  bundles for that version
* Added related dependencies to the Karaf feature definition

There are no new tests for this, but the dependency is marked as mandatory, so existing tests will catch the failure if the json-lib dependency is not met.
