### PR TITLE
HZN-1383: Kafka Producer: Don't forward alarms for every reduce

### DIFF
--- a/features/kafka/producer/src/main/java/org/opennms/features/kafka/producer/AlarmEqualityChecker.java
+++ b/features/kafka/producer/src/main/java/org/opennms/features/kafka/producer/AlarmEqualityChecker.java
@@ -1,0 +1,108 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2018 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2018 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.features.kafka.producer;
+
+import java.util.Objects;
+import java.util.function.Function;
+
+import org.opennms.features.kafka.producer.model.OpennmsModelProtos;
+
+/**
+ * Checks equality between two alarms based on a defined set of excluded fields.
+ */
+public class AlarmEqualityChecker {
+    /**
+     * The function to use to apply exclusions.
+     */
+    private final Function<OpennmsModelProtos.Alarm.Builder, OpennmsModelProtos.Alarm.Builder> applyExclusions;
+
+    /**
+     * Private constructor.
+     *
+     * @param applyExclusions exclusion function
+     */
+    private AlarmEqualityChecker(Function<OpennmsModelProtos.Alarm.Builder,
+            OpennmsModelProtos.Alarm.Builder> applyExclusions) {
+        this.applyExclusions = Objects.requireNonNull(applyExclusions);
+    }
+
+    /**
+     * Static factory method.
+     *
+     * @param applyExclusions exclusion function
+     * @return the instance with the given exclusion function
+     */
+    public static AlarmEqualityChecker with(Function<OpennmsModelProtos.Alarm.Builder,
+            OpennmsModelProtos.Alarm.Builder> applyExclusions) {
+        return new AlarmEqualityChecker(applyExclusions);
+    }
+
+    /**
+     * Checks two given alarms for equality excluding a defined set of fields during the equality check.
+     *
+     * @param a alarm a
+     * @param b alarm b
+     * @return true if equal, false otherwise
+     */
+    public boolean equalsExcludingOnBoth(OpennmsModelProtos.Alarm a, OpennmsModelProtos.Alarm b) {
+        return applyExclusions.apply(Objects.requireNonNull(a).toBuilder()).build()
+                .equals(applyExclusions.apply(Objects.requireNonNull(b).toBuilder()).build());
+    }
+
+    /**
+     * Checks two given alarms for equality excluding a defined set of fields on alarm a during the equality check.
+     *
+     * @param a alarm a which will have exclusions applied
+     * @param b alarm b
+     * @return true if equal, false otherwise
+     */
+    public boolean equalsExcludingOnFirst(OpennmsModelProtos.Alarm a, OpennmsModelProtos.Alarm b) {
+        return applyExclusions.apply(Objects.requireNonNull(a).toBuilder()).build()
+                .equals(Objects.requireNonNull(b));
+    }
+
+    /**
+     * Static class to namespace a predefined set of exclusions.
+     */
+    public static class Exclusions {
+        /**
+         * The default exclusions.
+         *
+         * @param alarmBuilder the alarm builder to apply exclusions to
+         * @return the alarm builder with exclusions applied
+         */
+        public static OpennmsModelProtos.Alarm.Builder defaultExclusions(
+                OpennmsModelProtos.Alarm.Builder alarmBuilder) {
+            return alarmBuilder
+                    .clearCount()
+                    .clearLastEvent()
+                    .clearLastEventTime();
+        }
+    }
+}

--- a/features/kafka/producer/src/main/java/org/opennms/features/kafka/producer/AlarmEqualityChecker.java
+++ b/features/kafka/producer/src/main/java/org/opennms/features/kafka/producer/AlarmEqualityChecker.java
@@ -70,9 +70,9 @@ public class AlarmEqualityChecker {
      * @param b alarm b
      * @return true if equal, false otherwise
      */
-    public boolean equalsExcludingOnBoth(OpennmsModelProtos.Alarm a, OpennmsModelProtos.Alarm b) {
-        return applyExclusions.apply(Objects.requireNonNull(a).toBuilder()).build()
-                .equals(applyExclusions.apply(Objects.requireNonNull(b).toBuilder()).build());
+    public boolean equalsExcludingOnBoth(OpennmsModelProtos.Alarm.Builder a, OpennmsModelProtos.Alarm.Builder b) {
+        return applyExclusions.apply(Objects.requireNonNull(a)).build()
+                .equals(applyExclusions.apply(Objects.requireNonNull(b)).build());
     }
 
     /**
@@ -82,8 +82,8 @@ public class AlarmEqualityChecker {
      * @param b alarm b
      * @return true if equal, false otherwise
      */
-    public boolean equalsExcludingOnFirst(OpennmsModelProtos.Alarm a, OpennmsModelProtos.Alarm b) {
-        return applyExclusions.apply(Objects.requireNonNull(a).toBuilder()).build()
+    public boolean equalsExcludingOnFirst(OpennmsModelProtos.Alarm.Builder a, OpennmsModelProtos.Alarm b) {
+        return applyExclusions.apply(Objects.requireNonNull(a)).build()
                 .equals(Objects.requireNonNull(b));
     }
 

--- a/features/kafka/producer/src/main/java/org/opennms/features/kafka/producer/OpennmsKafkaProducer.java
+++ b/features/kafka/producer/src/main/java/org/opennms/features/kafka/producer/OpennmsKafkaProducer.java
@@ -199,9 +199,9 @@ public class OpennmsKafkaProducer implements AlarmLifecycleListener, EventListen
     }
 
     private boolean isIncrementalAlarm(String reductionKey, OnmsAlarm alarm) {
-        return outstandingAlarms.containsKey(reductionKey) &&
-                alarmEqualityChecker.equalsExcludingOnFirst(protobufMapper.toAlarm(alarm).build(),
-                        outstandingAlarms.get(reductionKey));
+        OpennmsModelProtos.Alarm existingAlarm = outstandingAlarms.get(reductionKey);
+        return existingAlarm != null && alarmEqualityChecker.equalsExcludingOnFirst(protobufMapper.toAlarm(alarm),
+                existingAlarm);
     }
 
     private void recordIncrementalAlarm(String reductionKey, OnmsAlarm alarm) {

--- a/features/kafka/producer/src/main/java/org/opennms/features/kafka/producer/datasync/KafkaAlarmDataSync.java
+++ b/features/kafka/producer/src/main/java/org/opennms/features/kafka/producer/datasync/KafkaAlarmDataSync.java
@@ -226,8 +226,9 @@ public class KafkaAlarmDataSync implements AlarmDataStore, Runnable {
             final Set<String> commonReductionKeys = Sets.intersection(reductionKeysInKtable, reductionKeysInDb);
             commonReductionKeys.forEach(rkey -> {
                 final OnmsAlarm dbAlarm = alarmsInDbByReductionKey.get(rkey);
-                final OpennmsModelProtos.Alarm mappedDbAlarm = protobufMapper.toAlarm(dbAlarm).build();
-                final OpennmsModelProtos.Alarm alarmFromKtable = alarmsInKtableByReductionKey.get(rkey);
+                final OpennmsModelProtos.Alarm.Builder mappedDbAlarm = protobufMapper.toAlarm(dbAlarm);
+                final OpennmsModelProtos.Alarm.Builder alarmFromKtable =
+                        alarmsInKtableByReductionKey.get(rkey).toBuilder();
 
                 if ((suppressIncrementalAlarms && !alarmEqualityChecker.equalsExcludingOnBoth(mappedDbAlarm,
                         alarmFromKtable)) || (!suppressIncrementalAlarms && !Objects.equals(mappedDbAlarm,

--- a/features/kafka/producer/src/main/resources/OSGI-INF/blueprint/blueprint-kafka-producer.xml
+++ b/features/kafka/producer/src/main/resources/OSGI-INF/blueprint/blueprint-kafka-producer.xml
@@ -23,6 +23,7 @@
       <cm:property name="eventFilter" value=""/>
       <cm:property name="alarmFilter" value=""/>
       <cm:property name="nodeIdToCriteriaMaxCacheSize" value="10000"/>
+      <cm:property name="suppressIncrementalAlarms" value="true"/>
     </cm:default-properties>
   </cm:property-placeholder>
 
@@ -60,6 +61,7 @@
     <property name="nodeTopic" value="${nodeTopic}"/>
     <property name="eventFilter" value="${eventFilter}"/>
     <property name="alarmFilter" value="${alarmFilter}"/>
+    <property name="suppressIncrementalAlarms" value="${suppressIncrementalAlarms}"/>
   </bean>
 
   <service ref="kafkaProducer" interface="org.opennms.netmgt.alarmd.api.AlarmLifecycleListener">
@@ -75,6 +77,7 @@
     <argument ref="protobufMapper" />
     <property name="alarmTopic" value="${alarmTopic}"/>
     <property name="alarmSync" value="${alarmSync}"/>
+    <property name="suppressIncrementalAlarms" value="${suppressIncrementalAlarms}"/>
   </bean>
 
   <bean factory-ref="kafkaProducer" factory-method="setDataSync">

--- a/features/kafka/producer/src/test/java/org/opennms/features/kafka/producer/KafkaForwarderIT.java
+++ b/features/kafka/producer/src/test/java/org/opennms/features/kafka/producer/KafkaForwarderIT.java
@@ -37,6 +37,8 @@ import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -243,18 +245,9 @@ public class KafkaForwarderIT implements TemporaryDatabaseAware<MockDatabase> {
         // Send a node down event (should be forwarded)
         eventdIpcMgr.sendNow(MockEventUtil.createNodeDownEventBuilder("test", databasePopulator.getNode1()).getEvent());
         // Create and trigger the associated alarm
-        final String alarmReductionKey = String.format("%s:%d", EventConstants.NODE_DOWN_EVENT_UEI, databasePopulator.getNode1().getId());
-        final OnmsAlarm alarm = new OnmsAlarm();
+        final OnmsAlarm alarm = nodeDownAlarm();
+        final String alarmReductionKey = alarm.getReductionKey();
         {
-            alarm.setId(1);
-            alarm.setUei(EventConstants.NODE_DOWN_EVENT_UEI);
-            alarm.setNode(databasePopulator.getNode1());
-            alarm.setCounter(1);
-            alarm.setDescription("node down");
-            alarm.setAlarmType(1);
-            alarm.setLogMsg("node down");
-            alarm.setSeverity(OnmsSeverity.NORMAL);
-            alarm.setReductionKey(alarmReductionKey);
             alarmDao.save(alarm);
             kafkaProducer.handleNewOrUpdatedAlarm(alarm);
         }
@@ -278,9 +271,7 @@ public class KafkaForwarderIT implements TemporaryDatabaseAware<MockDatabase> {
         }
 
         // Fire up the consumer
-        executor = Executors.newSingleThreadExecutor();
-        kafkaConsumer = new KafkaMessageConsumerRunner(kafkaServer.getKafkaConnectString());
-        executor.execute(kafkaConsumer);
+        kafkaConsumer = startConsumer();
 
         // Wait for the events to be consumed
         await().atMost(1, TimeUnit.MINUTES).until(this::getUeisForConsumedEvents, hasItems(
@@ -324,6 +315,82 @@ public class KafkaForwarderIT implements TemporaryDatabaseAware<MockDatabase> {
         await().atMost(2, TimeUnit.MINUTES).until(() ->
                 kafkaConsumer.getAlarmByReductionKey(alarmReductionKey), nullValue());
 
+    }
+
+    @Test
+    public void testProducerSuppression() throws Exception {
+        kafkaProducer.setSuppressIncrementalAlarms(true);
+
+        // Send an alarm
+        final OnmsAlarm alarm = nodeDownAlarm();
+        alarmDao.save(alarm);
+        kafkaProducer.handleNewOrUpdatedAlarm(alarm);
+
+        // Increment the alarm and re-send
+        alarm.setCounter(2);
+        alarmDao.save(alarm);
+        kafkaProducer.handleNewOrUpdatedAlarm(alarm);
+
+        // Fire up the consumer
+        kafkaConsumer = startConsumer();
+
+        // The second alarm should have been suppressed since the only field that changed was the count
+        if (!kafkaProducer.getAlarmSuppressedLatch().await(1, TimeUnit.MINUTES)) {
+            throw new Exception("No alarm was suppressed!");
+        }
+
+        // One alarm should have been consumed
+        await().atMost(1, TimeUnit.MINUTES).until(() -> !kafkaConsumer.getAlarms().isEmpty());
+        // Sleep an additional 10 seconds to verify a second alarm was not consumed
+        Thread.sleep(10000);
+        assertEquals(1, kafkaConsumer.getAlarms().size());
+    }
+
+    @Test
+    public void testSyncSuppression() {
+        kafkaProducer.setSuppressIncrementalAlarms(true);
+
+        // Send an alarm
+        final OnmsAlarm alarm = nodeDownAlarm();
+        alarmDao.save(alarm);
+        kafkaProducer.handleNewOrUpdatedAlarm(alarm);
+
+        // Increment the alarm and write directly to db
+        alarm.setCounter(2);
+        alarmDao.save(alarm);
+
+        // Fire up the consumer
+        kafkaConsumer = startConsumer();
+
+        // Only one alarm should have been consumed
+        try {
+            // This is a bit tricky since we need to wait fairly long to verify that the sync suppressed the alarm
+            await().atMost(2, TimeUnit.MINUTES).until(() -> kafkaConsumer.getAlarms().size() > 1);
+            fail("Alarm was not suppressed!");
+        } catch (Exception e) {
+        }
+    }
+
+    private KafkaMessageConsumerRunner startConsumer() {
+        executor = Executors.newSingleThreadExecutor();
+        kafkaConsumer = new KafkaMessageConsumerRunner(kafkaServer.getKafkaConnectString());
+        executor.execute(kafkaConsumer);
+        return kafkaConsumer;
+    }
+
+    private OnmsAlarm nodeDownAlarm() {
+        OnmsAlarm alarm = new OnmsAlarm();
+        alarm.setId(1);
+        alarm.setUei(EventConstants.NODE_DOWN_EVENT_UEI);
+        alarm.setNode(databasePopulator.getNode1());
+        alarm.setCounter(1);
+        alarm.setDescription("node down");
+        alarm.setAlarmType(1);
+        alarm.setLogMsg("node down");
+        alarm.setSeverity(OnmsSeverity.NORMAL);
+        alarm.setReductionKey(String.format("%s:%d", EventConstants.NODE_DOWN_EVENT_UEI,
+                databasePopulator.getNode1().getId()));
+        return alarm;
     }
 
     private Set<String> getUeisForConsumedEvents() {

--- a/features/kafka/producer/src/test/java/org/opennms/features/kafka/producer/KafkaForwarderIT.java
+++ b/features/kafka/producer/src/test/java/org/opennms/features/kafka/producer/KafkaForwarderIT.java
@@ -334,11 +334,6 @@ public class KafkaForwarderIT implements TemporaryDatabaseAware<MockDatabase> {
         // Fire up the consumer
         kafkaConsumer = startConsumer();
 
-        // The second alarm should have been suppressed since the only field that changed was the count
-        if (!kafkaProducer.getAlarmSuppressedLatch().await(1, TimeUnit.MINUTES)) {
-            throw new Exception("No alarm was suppressed!");
-        }
-
         // One alarm should have been consumed
         await().atMost(1, TimeUnit.MINUTES).until(() -> !kafkaConsumer.getAlarms().isEmpty());
         // Sleep an additional 10 seconds to verify a second alarm was not consumed

--- a/opennms-doc/guide-admin/src/asciidoc/text/kafka-producer/kafka-producer.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/kafka-producer/kafka-producer.adoc
@@ -105,6 +105,8 @@ The _Kafka Producer_ exposes the following options to help fine tune its behavio
 | `alarmSyncIntervalMs`   | `300000` (5 minutes) | Number of milliseconds at which the contents of the alarm topic will be synchronized with the local database.
                                                    Decrease this to improve accuracy at the cost of additional database look ups.
                                                    Set this value to 0 to disable alarm synchronization.
+| `suppressIncrementalAlarms` | `true`           | Suppresses forwarding alarms that differ only by count or last event time.
+                                                   Set this to `false` to prevent suppressing these alarms.                                                   
 |===
 
 ==== Configuring Filtering


### PR DESCRIPTION
HZN-1383: Added new configuration to the OpennmsKafkaProducer to suppress sending alarms that differ from an existing alarm only by the count or last event time. Also added equivalent functionality in the KafkaAlarmDataSync.

* JIRA: http://issues.opennms.org/browse/HZN-1383
Our [continuous integration system](http://bamboo.internal.opennms.com:8085) will test and verify your changes.
