### PR TITLE
NMS-10324: make the default relative time period 1 day again

### DIFF
--- a/opennms-base-assembly/src/main/filtered/etc/opennms.properties
+++ b/opennms-base-assembly/src/main/filtered/etc/opennms.properties
@@ -666,6 +666,19 @@ excludeServiceMonitorsFromRemotePoller=DHCP,NSClient,RadiusAuth,XMP
 #   backshift
 #org.opennms.web.graphs.engine=backshift
 
+# Use this property to set the default time period when rendering graphs.
+# Supported values are:
+#    last_1_hour
+#    last_2_hour
+#    last_4_hour
+#    last_8_hour
+#    last_12_hour
+#    lastday
+#    lastweek
+#    lastmonth
+#    lastyear
+#org.opennms.web.defaultGraphPeriod=lastday
+
 ###### Newts #####
 # Use these properties to configure persistence using Newts
 # Note that Newts must be enabled using the 'org.opennms.timeseries.strategy' property

--- a/opennms-web-api/src/main/java/org/opennms/web/svclayer/model/RelativeTimePeriod.java
+++ b/opennms-web-api/src/main/java/org/opennms/web/svclayer/model/RelativeTimePeriod.java
@@ -63,6 +63,8 @@ public class RelativeTimePeriod {
                                        Calendar.DATE, -366) };
     }
 
+    public static final RelativeTimePeriod DEFAULT_RELATIVE_TIME_PERIOD = RelativeTimePeriod.getPeriodByIdOrDefault(System.getProperty("org.opennms.web.defaultGraphPeriod", "lastday"));
+
     /**
      * <p>Constructor for RelativeTimePeriod.</p>
      */
@@ -173,8 +175,7 @@ public class RelativeTimePeriod {
      * @return a {@link org.opennms.web.svclayer.model.RelativeTimePeriod} object.
      */
     public static RelativeTimePeriod getPeriodByIdOrDefault(String id) {
-        return getPeriodByIdOrDefault(s_defaultPeriods, id,
-                                      s_defaultPeriods[0]);
+        return getPeriodByIdOrDefault(s_defaultPeriods, id, s_defaultPeriods[5]);
     }
     /**
      * <p>getPeriodByIdOrDefault</p>

--- a/opennms-webapp/src/main/java/org/opennms/web/controller/GraphResultsController.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/controller/GraphResultsController.java
@@ -213,10 +213,10 @@ public class GraphResultsController extends AbstractController implements Initia
             endLong = endCal.getTime().getTime();
         } else {
             if (relativeTime == null) {
-                relativeTime = s_periods[0].getId();
+                relativeTime = RelativeTimePeriod.DEFAULT_RELATIVE_TIME_PERIOD.getId();
             }
 
-            RelativeTimePeriod period = RelativeTimePeriod.getPeriodByIdOrDefault(s_periods, relativeTime, s_periods[0]);
+            RelativeTimePeriod period = RelativeTimePeriod.getPeriodByIdOrDefault(s_periods, relativeTime, RelativeTimePeriod.DEFAULT_RELATIVE_TIME_PERIOD);
 
             long[] times = period.getStartAndEndTimes();
             startLong = times[0];


### PR DESCRIPTION
This PR fixes a long-standing regression and make the default relative time period 1 day again, rather than 1 hour.

I also add a property (`org.opennms.web.defaultGraphPeriod`) for setting the default, if you prefer the old behavior of 1 hour.

* JIRA: http://issues.opennms.org/browse/NMS-10324

Our [continuous integration system](http://bamboo.internal.opennms.com:8085) will test and verify your changes.
