### PR TITLE
NMS-10331: Optionally create new alarms when a problem reoccurs

### DIFF
--- a/opennms-base-assembly/src/main/filtered/etc/opennms.properties
+++ b/opennms-base-assembly/src/main/filtered/etc/opennms.properties
@@ -178,6 +178,14 @@ rrd.binary=${install.rrdtool.bin}
 # Default: 3600 seconds
 #org.opennms.utils.propertiesCache.cacheTimeout=3600
 
+###### Alarmd Properties ######
+#
+# Disable this property to force Alarmd to create new alarms when an problem re-occurs and the
+# existing Alarm is in a "Cleared" state.
+#
+# Default: false
+#org.opennms.alarmd.newIfClearedAlarmExists = false
+
 ###### TROUBLE TICKETING ######
 # The ticketer responsible for creating tickets from the Alarm details and passing these
 # to the ticket plugin.

--- a/opennms-base-assembly/src/main/filtered/etc/opennms.properties
+++ b/opennms-base-assembly/src/main/filtered/etc/opennms.properties
@@ -180,7 +180,7 @@ rrd.binary=${install.rrdtool.bin}
 
 ###### Alarmd Properties ######
 #
-# Disable this property to force Alarmd to create new alarms when an problem re-occurs and the
+# Enable this property to force Alarmd to create new alarms when an problem re-occurs and the
 # existing Alarm is in a "Cleared" state.
 #
 # Default: false

--- a/opennms-model/src/main/java/org/opennms/netmgt/model/OnmsAlarm.java
+++ b/opennms-model/src/main/java/org/opennms/netmgt/model/OnmsAlarm.java
@@ -88,6 +88,8 @@ public class OnmsAlarm implements Acknowledgeable, Serializable {
     /** Constant <code>PROBLEM_WITHOUT_RESOLUTION_TYPE=3</code> */
     public static final int PROBLEM_WITHOUT_RESOLUTION_TYPE = 3;
 
+    public static final String ARCHIVED = "Archived";
+
     /** identifier field */
     private Integer m_id;
 
@@ -1101,6 +1103,22 @@ public class OnmsAlarm implements Acknowledgeable, Serializable {
         m_severity = OnmsSeverity.escalate(m_severity);
 //        m_alarmAckUser = ackUser;
 //        m_alarmAckTime = Calendar.getInstance().getTime();
+    }
+
+    /**
+     * This marks an alarm as archived and prevents it from being used again in during reduction.
+     */
+    public void archive() {
+        m_qosAlarmState = ARCHIVED;
+        m_severity = OnmsSeverity.CLEARED;
+        m_reductionKey = getReductionKey() + ":ID:"+ getId();
+    }
+
+    // Alarms that are archived
+    @Transient
+    @XmlTransient
+    public boolean isArchived() {
+        return ARCHIVED.equals(m_qosAlarmState);
     }
 
     /**

--- a/opennms-model/src/main/java/org/opennms/netmgt/model/OnmsAlarm.java
+++ b/opennms-model/src/main/java/org/opennms/netmgt/model/OnmsAlarm.java
@@ -1018,7 +1018,7 @@ public class OnmsAlarm implements Acknowledgeable, Serializable {
     @XmlTransient
     @ElementCollection
     @JoinTable(name="alarm_attributes", joinColumns = @JoinColumn(name="alarmId"))
-    @MapKeyColumn(name="attribute")
+    @MapKeyColumn(name="attributename")
     @Column(name="attributeValue", nullable=false)
     public Map<String, String> getDetails() {
         return m_details;


### PR DESCRIPTION
JIRA: https://issues.opennms.org/browse/NMS-10331

Here we add a new flag that allows us to force alarmd to create a new alarm instead of reducing onto the existing alarm when it is already cleared.

This can be used to make sure there is a single `OnmsAlarm` entity per problem.

