### PR TITLE
OCE-REST: fix broken negative feedback submission

### DIFF
--- a/features/situation-feedback/api/src/main/java/org/opennms/features/situationfeedback/api/AlarmFeedback.java
+++ b/features/situation-feedback/api/src/main/java/org/opennms/features/situationfeedback/api/AlarmFeedback.java
@@ -34,7 +34,7 @@ package org.opennms.features.situationfeedback.api;
 public class AlarmFeedback {
 
     public enum FeedbackType {
-        FALSE_POSITVE, // Alarm does not belong in this Situation
+        FALSE_POSITIVE, // Alarm does not belong in this Situation
         FALSE_NEGATIVE, // Alarm was missing from this Situation
         CORRECT, // Alarm is correctly correlated
         UNKNOWN;
@@ -42,7 +42,7 @@ public class AlarmFeedback {
         public static FeedbackType getType(String type) {
             switch(type) {
             case "FALSE_POSITVE": 
-                return FALSE_POSITVE;
+                return FALSE_POSITIVE;
             case "FALSE_NEGATIVE":
                 return FALSE_NEGATIVE;
             case "CORRECT":

--- a/features/situation-feedback/elastic/src/test/java/org/opennms/features/situationfeedback/elastic/ElasticFeedbackRepositoryIT.java
+++ b/features/situation-feedback/elastic/src/test/java/org/opennms/features/situationfeedback/elastic/ElasticFeedbackRepositoryIT.java
@@ -87,11 +87,11 @@ public class ElasticFeedbackRepositoryIT {
 
     @Test
     public void canPersistFeedback() throws FeedbackException {
-        AlarmFeedback feedback1 = new AlarmFeedback("situationKey1", "fingerprint1", "alarmKey1", FeedbackType.FALSE_POSITVE, "reason", "user",
+        AlarmFeedback feedback1 = new AlarmFeedback("situationKey1", "fingerprint1", "alarmKey1", FeedbackType.FALSE_POSITIVE, "reason", "user",
                                                     System.currentTimeMillis());
-        AlarmFeedback feedback2 = new AlarmFeedback("situationKey2", "fingerprint2", "alarmKey2", FeedbackType.FALSE_POSITVE, "reason", "user",
+        AlarmFeedback feedback2 = new AlarmFeedback("situationKey2", "fingerprint2", "alarmKey2", FeedbackType.FALSE_POSITIVE, "reason", "user",
                                                     System.currentTimeMillis());
-        AlarmFeedback feedback3 = new AlarmFeedback("situationKey3", "fingerprint3", "alarmKey3", FeedbackType.FALSE_POSITVE, "reason", "user",
+        AlarmFeedback feedback3 = new AlarmFeedback("situationKey3", "fingerprint3", "alarmKey3", FeedbackType.FALSE_POSITIVE, "reason", "user",
                                                     System.currentTimeMillis());
         final Collection<AlarmFeedback> feedback = Arrays.asList(feedback1, feedback2, feedback3);
         feedbackRepository.persist(feedback);

--- a/features/situation-feedback/rest/impl/src/main/java/org/opennms/features/situationfeedback/rest/SituationFeedbackRestServiceImpl.java
+++ b/features/situation-feedback/rest/impl/src/main/java/org/opennms/features/situationfeedback/rest/SituationFeedbackRestServiceImpl.java
@@ -89,7 +89,7 @@ public class SituationFeedbackRestServiceImpl implements SituationFeedbackRestSe
         runInTransaction(status -> {
             // Update Situation in case of false_neg and false_pos
             feedback.stream().filter(f -> (f.getFeedbackType() == FeedbackType.FALSE_NEGATIVE)).forEach(c -> addCorrelation(c, alarmDao, alarmEntityNotifier));
-            feedback.stream().filter(f -> (f.getFeedbackType() == FeedbackType.FALSE_POSITVE)).forEach(c -> removeCorrelation(c, alarmDao, alarmEntityNotifier));
+            feedback.stream().filter(f -> (f.getFeedbackType() == FeedbackType.FALSE_POSITIVE)).forEach(c -> removeCorrelation(c, alarmDao, alarmEntityNotifier));
             try {
                 repository.persist(feedback);
             } catch (Exception e) {

--- a/features/situation-feedback/rest/impl/src/test/java/org/opennms/features/situationfeedback/rest/SituationFeedbackrestServiceIT.java
+++ b/features/situation-feedback/rest/impl/src/test/java/org/opennms/features/situationfeedback/rest/SituationFeedbackrestServiceIT.java
@@ -122,7 +122,7 @@ public class SituationFeedbackrestServiceIT {
     public void testRemoveAlarmWithFeedback() {
         SituationFeedbackRestServiceImpl sut = new SituationFeedbackRestServiceImpl(alarmDao, alarmEntityNotifier, mockFeebackRepository, transactionTemplate);
         AlarmFeedback falsePositive = new AlarmFeedback(situation.getReductionKey(), "fingerprint", linkDownAlarmOnR1.getReductionKey(),
-                                                        FeedbackType.FALSE_POSITVE, "not related", "user", System.currentTimeMillis());
+                                                        FeedbackType.FALSE_POSITIVE, "not related", "user", System.currentTimeMillis());
         List<AlarmFeedback> feedback = Collections.singletonList(falsePositive);
 
         OnmsAlarm prior = alarmDao.findByReductionKey(situation.getReductionKey());


### PR DESCRIPTION
This PR corrects a bug where a typo in the enum prevented negative feedback from being submitted.