### PR TITLE
NMS-10332: fix minion init to honor sysconfig

### DIFF
--- a/opennms-assemblies/minion/src/main/filtered/etc/minion.init
+++ b/opennms-assemblies/minion/src/main/filtered/etc/minion.init
@@ -58,6 +58,21 @@ if [ -r "${MINION_HOME}/etc/minion.conf" ]; then
 	. "${MINION_HOME}/etc/minion.conf"
 fi
 
+# The user config can set JAVA_OPTS, but Karaf will not
+# do ANY of its own JAVA_OPTS processing if it is already
+# set, so work around this by grabbing DEFAULT_JAVA_OPTS
+# now, rather than letting Karaf init do it.
+
+# shellcheck disable=SC1090,SC1091
+. "${MINION_HOME}/bin/inc"
+setupDefaults
+
+# always dump heap if we OOM
+DEFAULT_JAVA_OPTS="${DEFAULT_JAVA_OPTS} -XX:+HeapDumpOnOutOfMemoryError"
+
+# combine user JAVA_OPTS with the defaults from Karaf
+JAVA_OPTS="${DEFAULT_JAVA_OPTS} ${JAVA_OPTS}"
+
 validate_icmp() {
 	if [ "$RUNAS" != "root" ]; then
 		if [ "$(uname -s)" = "Linux" ]; then
@@ -85,9 +100,6 @@ validate_icmp() {
 		fi
 	fi
 }
-
-# always dump heap if we OOM
-JAVA_OPTS="$JAVA_OPTS -XX:+HeapDumpOnOutOfMemoryError"
 
 # export any default configurable variables from sysconf
 export JAVA_HOME JAVA_MIN_MEM JAVA_MAX_MEM MAX_FD JAVA JAVA_DEBUG_OPTS JAVA_DEBUG_PORT JAVA_OPTS CLASSPATH KARAF_DEBUG LD_LIBRARY_PATH

--- a/tools/packages/minion/minion.spec
+++ b/tools/packages/minion/minion.spec
@@ -199,7 +199,9 @@ ROOT_INST="${RPM_INSTALL_PREFIX0}"
 # Clean out the data directory
 if [ -d "${ROOT_INST}/data" ]; then
     find "$ROOT_INST/data/"* -maxdepth 0 -name tmp -prune -o -print0 | xargs -0 rm -rf
-    find "$ROOT_INST/data/tmp/"* -maxdepth 0 -name README -prune -o -print0 | xargs -0 rm -rf
+    if [ -d "${ROOT_INST}/data/tmp"  ]; then
+        find "$ROOT_INST/data/tmp/"* -maxdepth 0 -name README -prune -o -print0 | xargs -0 rm -rf
+    fi
 fi
 
 # Generate an SSH key if necessary

--- a/tools/packages/opennms/opennms.spec
+++ b/tools/packages/opennms/opennms.spec
@@ -1063,7 +1063,9 @@ done
 printf -- "- cleaning up \$OPENNMS_HOME/data... "
 if [ -d "$ROOT_INST/data" ]; then
 	find "$ROOT_INST/data/"* -maxdepth 0 -name tmp -prune -o -print0 | xargs -0 rm -rf
-	find "$ROOT_INST/data/tmp/"* -maxdepth 0 -name README -prune -o -print0 | xargs -0 rm -rf
+	if [ -d "$ROOT_INST/data/tmp" ]; then
+		find "$ROOT_INST/data/tmp/"* -maxdepth 0 -name README -prune -o -print0 | xargs -0 rm -rf
+	fi
 fi
 echo "done"
 


### PR DESCRIPTION
Karaf's `bin/inc` only initializes `JAVA_OPTS` if it isn't already set, so in most cases our default init scripts were ignoring most of the values set in `/etc/sysconfig/minion`.

This PR fixes that.

* JIRA: http://issues.opennms.org/browse/NMS-10332

Our [continuous integration system](http://bamboo.internal.opennms.com:8085) will test and verify your changes.
