### PR TITLE
NMS-10352: Fix type for some Cassandra JMX values

### DIFF
--- a/opennms-base-assembly/src/main/filtered/etc/jmx-datacollection-config.d/cassandra30x-newts.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/jmx-datacollection-config.d/cassandra30x-newts.xml
@@ -26,7 +26,7 @@
             <!-- Memtable :: Count -->
             <mbean name="org.apache.cassandra.metrics.Keyspace"
                    objectname="org.apache.cassandra.metrics:type=Keyspace,keyspace=newts,name=MemtableSwitchCount">
-                <attrib name="Value" alias="memTblSwitchCount" type="gauge"/>
+                <attrib name="Value" alias="memTblSwitchCount" type="counter"/>
             </mbean>
 
             <mbean name="org.apache.cassandra.metrics.Keyspace"

--- a/opennms-base-assembly/src/main/filtered/etc/jmx-datacollection-config.d/cassandra30x.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/jmx-datacollection-config.d/cassandra30x.xml
@@ -47,27 +47,27 @@
             <!-- Dropped Messages -->
             <mbean name="org.apache.cassandra.metrics.DroppedMessage"
                    objectname="org.apache.cassandra.metrics:type=DroppedMessage,scope=READ,name=Dropped">
-                <attrib name="Count" alias="drpdMsgRead" type="gauge"/>
+                <attrib name="Count" alias="drpdMsgRead" type="counter"/>
             </mbean>
             <mbean name="org.apache.cassandra.metrics.DroppedMessage"
                    objectname="org.apache.cassandra.metrics:type=DroppedMessage,scope=READ_REPAIR,name=Dropped">
-                <attrib name="Count" alias="drpdMsgReadRepair" type="gauge"/>
+                <attrib name="Count" alias="drpdMsgReadRepair" type="counter"/>
             </mbean>
             <mbean name="org.apache.cassandra.metrics.DroppedMessage"
                    objectname="org.apache.cassandra.metrics:type=DroppedMessage,scope=REQUEST_RESPONSE,name=Dropped">
-                <attrib name="Count" alias="drpdMsgReqResp" type="gauge"/>
+                <attrib name="Count" alias="drpdMsgReqResp" type="counter"/>
             </mbean>
             <mbean name="org.apache.cassandra.metrics.DroppedMessage"
                    objectname="org.apache.cassandra.metrics:type=DroppedMessage,scope=RANGE_SLICE,name=Dropped">
-                <attrib name="Count" alias="drpdMsgRangeSlice" type="gauge"/>
+                <attrib name="Count" alias="drpdMsgRangeSlice" type="counter"/>
             </mbean>
             <mbean name="org.apache.cassandra.metrics.DroppedMessage"
                    objectname="org.apache.cassandra.metrics:type=DroppedMessage,scope=MUTATION,name=Dropped">
-                <attrib name="Count" alias="drpdMsgMutation" type="gauge"/>
+                <attrib name="Count" alias="drpdMsgMutation" type="counter"/>
             </mbean>
             <mbean name="org.apache.cassandra.metrics.DroppedMessage"
                    objectname="org.apache.cassandra.metrics:type=DroppedMessage,scope=PAGED_RANGE,name=Dropped">
-                <attrib name="Count" alias="drpdMsgPagedRange" type="gauge"/>
+                <attrib name="Count" alias="drpdMsgPagedRange" type="counter"/>
             </mbean>
 
             <!-- ThreadPools :: MemtableFlushWriter -->


### PR DESCRIPTION
* JIRA: https://issues.opennms.org/browse/NMS-10352

Changes type from 'gauge' to 'counter' for MemtableSwitchCount and
the DroppedMessage attributes, to match the JMX types.