### PR TITLE
NMS-10353: Add support for suppressAdminDownEvent

### DIFF
--- a/opennms-base-assembly/src/main/filtered/etc/snmp-interface-poller-configuration.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/snmp-interface-poller-configuration.xml
@@ -1,4 +1,4 @@
-<snmp-interface-poller-configuration xmlns="http://xmlns.opennms.org/xsd/config/snmpinterfacepoller" threads="30" service="SNMP" suppressAdminDownEvent="true">
+<snmp-interface-poller-configuration xmlns="http://xmlns.opennms.org/xsd/config/snmpinterfacepoller" threads="30" service="SNMP" suppressAdminDownEvent="false">
    <node-outage>
       <critical-service name="ICMP"/>
       <critical-service name="SNMP"/>

--- a/opennms-base-assembly/src/main/filtered/etc/snmp-interface-poller-configuration.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/snmp-interface-poller-configuration.xml
@@ -1,4 +1,4 @@
-<snmp-interface-poller-configuration xmlns="http://xmlns.opennms.org/xsd/config/snmpinterfacepoller" threads="30" service="SNMP">
+<snmp-interface-poller-configuration xmlns="http://xmlns.opennms.org/xsd/config/snmpinterfacepoller" threads="30" service="SNMP" suppressAdminDownEvent="true">
    <node-outage>
       <critical-service name="ICMP"/>
       <critical-service name="SNMP"/>

--- a/opennms-config-model/src/main/java/org/opennms/netmgt/config/snmpinterfacepoller/SnmpInterfacePollerConfiguration.java
+++ b/opennms-config-model/src/main/java/org/opennms/netmgt/config/snmpinterfacepoller/SnmpInterfacePollerConfiguration.java
@@ -74,9 +74,7 @@ public class SnmpInterfacePollerConfiguration implements Serializable {
     private String m_service;
 
     /**
-     * Flag which indicates to suppress Admin Status events at all.
-     *  This is deprecated and will be ignored in the code!
-     *  
+     * Flag which toggles suppression of all Admin Status events
      */
     @XmlAttribute(name = "suppressAdminDownEvent")
     private Boolean m_suppressAdminDownEvent;

--- a/opennms-config-model/src/main/java/org/opennms/netmgt/config/snmpinterfacepoller/SnmpInterfacePollerConfiguration.java
+++ b/opennms-config-model/src/main/java/org/opennms/netmgt/config/snmpinterfacepoller/SnmpInterfacePollerConfiguration.java
@@ -127,7 +127,7 @@ public class SnmpInterfacePollerConfiguration implements Serializable {
     }
 
     public Boolean getSuppressAdminDownEvent() {
-        return m_suppressAdminDownEvent != null ? m_suppressAdminDownEvent : Boolean.TRUE;
+        return m_suppressAdminDownEvent != null ? m_suppressAdminDownEvent : Boolean.FALSE;
     }
 
     public void setSuppressAdminDownEvent(final Boolean suppressAdminDownEvent) {

--- a/opennms-config-model/src/main/resources/xsds/snmp-interface-poller-configuration.xsd
+++ b/opennms-config-model/src/main/resources/xsds/snmp-interface-poller-configuration.xsd
@@ -55,7 +55,7 @@
         </annotation>
       </attribute>
 
-      <attribute type="boolean" default="true" name="suppressAdminDownEvent" use="optional">
+      <attribute type="boolean" default="false" name="suppressAdminDownEvent" use="optional">
         <annotation>
           <documentation>Flag which toggles suppression of all Admin Status events.
           When this is enabled, Oper Status changes that occur because of an Admin Status change

--- a/opennms-config-model/src/main/resources/xsds/snmp-interface-poller-configuration.xsd
+++ b/opennms-config-model/src/main/resources/xsds/snmp-interface-poller-configuration.xsd
@@ -57,8 +57,10 @@
 
       <attribute type="boolean" default="true" name="suppressAdminDownEvent" use="optional">
         <annotation>
-          <documentation>Flag which indicates to suppress Admin Status events at all.
-          This is deprecated and will be ignored in the code!
+          <documentation>Flag which toggles suppression of all Admin Status events.
+          When this is enabled, Oper Status changes that occur because of an Admin Status change
+          will also be suppressed. The only exception is if Oper Status remains Down after
+          Admin Status changes from Down to Up. In this case, an Oper Status Down event is triggered.
           </documentation>
         </annotation>
       </attribute>    

--- a/opennms-config/src/main/java/org/opennms/netmgt/config/SnmpInterfacePollerConfig.java
+++ b/opennms-config/src/main/java/org/opennms/netmgt/config/SnmpInterfacePollerConfig.java
@@ -59,6 +59,12 @@ public interface SnmpInterfacePollerConfig {
      */
     boolean useCriteriaFilters();
     /**
+     * <p>getSuppressAdminDownEvent</p>
+     *
+     * @return a boolean.
+     */
+    boolean getSuppressAdminDownEvent();
+    /**
      * <p>getService</p>
      *
      * @return a {@link java.lang.String} object.

--- a/opennms-config/src/main/java/org/opennms/netmgt/config/SnmpInterfacePollerConfigManager.java
+++ b/opennms-config/src/main/java/org/opennms/netmgt/config/SnmpInterfacePollerConfigManager.java
@@ -589,4 +589,14 @@ abstract public class SnmpInterfacePollerConfigManager implements SnmpInterfaceP
         return getConfiguration().getUseCriteriaFilters();
     }
 
+    /**
+     * <p>getSuppressAdminDownEvent</p>
+     *
+     * @return a boolean.
+     */
+    @Override
+    public boolean getSuppressAdminDownEvent() {
+        return getConfiguration().getSuppressAdminDownEvent();
+    }
+
 }

--- a/opennms-services/src/main/java/org/opennms/netmgt/snmpinterfacepoller/SnmpPoller.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/snmpinterfacepoller/SnmpPoller.java
@@ -272,6 +272,7 @@ public class SnmpPoller extends AbstractServiceDaemon {
     private void scheduleSnmpCollection(PollableInterface nodeGroup,String pkgName) {
     	
     	String excludingCriteria = new String(" snmpifindex > 0 ");
+        boolean suppressAdminDownEvent = getPollerConfig().getSuppressAdminDownEvent();
         for (String pkgInterfaceName: getPollerConfig().getInterfaceOnPackage(pkgName)) {
             LOG.debug("found package interface with name: {}", pkgInterfaceName);
             if (getPollerConfig().getStatus(pkgName, pkgInterfaceName)){
@@ -294,7 +295,7 @@ public class SnmpPoller extends AbstractServiceDaemon {
                 if (hasMaxVarsPerPdu) maxVarsPerPdu = getPollerConfig().getMaxVarsPerPdu(pkgName, pkgInterfaceName);
 
                 PollableSnmpInterface node = nodeGroup.createPollableSnmpInterface(pkgInterfaceName, criteria, 
-                   port != -1, port, timeout != -1, timeout, retries != -1, retries, hasMaxVarsPerPdu, maxVarsPerPdu);
+                   port != -1, port, timeout != -1, timeout, retries != -1, retries, hasMaxVarsPerPdu, maxVarsPerPdu, suppressAdminDownEvent);
 
                 node.setSnmpinterfaces(getNetwork().getContext().get(node.getParent().getNodeid(), criteria));
 
@@ -306,7 +307,7 @@ public class SnmpPoller extends AbstractServiceDaemon {
         if (!getPollerConfig().useCriteriaFilters()) {
             LOG.debug("excluding criteria used for default polling: {}", excludingCriteria);
             PollableSnmpInterface node = nodeGroup.createPollableSnmpInterface("null", excludingCriteria, 
-                false, -1, false, -1, false, -1, false, -1);
+                false, -1, false, -1, false, -1, false, -1, suppressAdminDownEvent);
 
             node.setSnmpinterfaces(getNetwork().getContext().get(node.getParent().getNodeid(), excludingCriteria));
 

--- a/opennms-services/src/main/java/org/opennms/netmgt/snmpinterfacepoller/pollable/PollableInterface.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/snmpinterfacepoller/pollable/PollableInterface.java
@@ -150,11 +150,12 @@ public class PollableInterface {
    * @param retries a int.
    * @param hasMaxVarsPerPdu a boolean.
    * @param maxVarsPerPdu a int.
+   * @param suppressAdminDownEvent a boolean.
    * @return a {@link org.opennms.netmgt.snmpinterfacepoller.pollable.PollableSnmpInterface} object.
    */
   public PollableSnmpInterface createPollableSnmpInterface(String name, String criteria, boolean hasPort, 
           int port, boolean hasTimeout, int timeout, boolean hasRetries, int retries, 
-          boolean hasMaxVarsPerPdu,int maxVarsPerPdu) {
+          boolean hasMaxVarsPerPdu, int maxVarsPerPdu, boolean suppressAdminDownEvent) {
 
         PollableSnmpInterface iface = new PollableSnmpInterface(this);
         iface.setName(name);
@@ -168,6 +169,7 @@ public class PollableInterface {
         if (hasMaxVarsPerPdu) agentConfig.setMaxVarsPerPdu(maxVarsPerPdu);
 
         iface.setAgentConfig(agentConfig);
+        iface.setSuppressAdminDownEvent(suppressAdminDownEvent);
                
         m_pollablesnmpinterface.put(name,iface);
         return iface;

--- a/opennms-services/src/main/java/org/opennms/netmgt/snmpinterfacepoller/pollable/PollableSnmpInterface.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/snmpinterfacepoller/pollable/PollableSnmpInterface.java
@@ -381,8 +381,8 @@ public class PollableSnmpInterface implements ReadyRunnable {
                     }
                     // Next, deal with all ifOperStatus changes that are *not* related to any changes in ifAdminStatus
                     else if (miface.getOperstatus() != iface.getIfOperStatus()) {
-                        LOG.info("ifOperStatus for interface {} ({}) has changed from {} to {}.",
-                                iface.getIfIndex(), iface.getIfName(), iface.getIfOperStatus(), miface.getOperstatus()
+                        LOG.info("ifOperStatus for interface {} ({}) on nodeId {} has changed from {} to {}.",
+                                iface.getIfIndex(), iface.getIfName(), iface.getNodeId(), iface.getIfOperStatus(), miface.getOperstatus()
                         );
                         if (miface.getOperstatus() == SnmpMinimalPollInterface.IF_DOWN) {
                             sendOperDownEvent(iface);

--- a/opennms-services/src/main/java/org/opennms/netmgt/snmpinterfacepoller/pollable/PollableSnmpInterface.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/snmpinterfacepoller/pollable/PollableSnmpInterface.java
@@ -367,17 +367,15 @@ public class PollableSnmpInterface implements ReadyRunnable {
                                 sendAdminUpEvent(iface);
                             }
                         }
-                        // There's no guarantee ifOperStatus was UP *before* the admin interface went down.
-                        // Because of this, it's probably safest to send an UP event, in case there are old alarms present.
-                        if (miface.getAdminstatus() == SnmpMinimalPollInterface.IF_UP && miface.getOperstatus() == SnmpMinimalPollInterface.IF_UP) {
-                            sendOperUpEvent(iface);
-                        }
                     }
-                    // Handle ifOperStatus changes, with the assumption that ifOperStatus will never change as long as ifAdminStatus remains DOWN
-                    else if (miface.getOperstatus() != iface.getIfOperStatus()) {
-                        LOG.info("ifOperStatus for interface {} ({}) has changed from {} to {}.",
-                                iface.getIfIndex(), iface.getIfName(), iface.getIfOperStatus(), miface.getOperstatus()
-                        );
+                    // Always generate events for ifOperStatus changes, even if the ifOperStatus changes because of ifAdminStatus going DOWN
+                    if (miface.getOperstatus() != iface.getIfOperStatus()) {
+                        // Don't bother logging if the ifAdminStatus changed, since we include ifOperStatus info there
+                        if (miface.getAdminstatus() == iface.getIfAdminStatus()) {
+                            LOG.info("ifOperStatus for interface {} ({}) has changed from {} to {}.",
+                                    iface.getIfIndex(), iface.getIfName(), iface.getIfOperStatus(), miface.getOperstatus()
+                            );
+                        }
                         // ifOperStatus has changed from Up to Down
                         if (miface.getOperstatus() == SnmpMinimalPollInterface.IF_DOWN) {
                             sendOperDownEvent(iface);

--- a/opennms-services/src/main/java/org/opennms/netmgt/snmpinterfacepoller/pollable/PollableSnmpInterface.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/snmpinterfacepoller/pollable/PollableSnmpInterface.java
@@ -368,7 +368,10 @@ public class PollableSnmpInterface implements ReadyRunnable {
                             if (!getSuppressAdminDownEvent()) {
                                 sendAdminUpEvent(iface);
                             }
-                            // Should ifOperStatus continue to stay down after ifAdminStatus comes up, trigger an ifOperDownEvent
+                            // Should ifOperStatus continue to stay down after ifAdminStatus comes up, trigger an OperDownEvent.
+                            // This *will* trigger duplicate OperDownEvents for interfaces where ifOperStatus was already down when ifAdminStatus went down,
+                            // but the alternative carries a risk of suppressing OperDownEvents for interfaces where ifOperStatus was originally up.
+                            // Without saving the original ifOperStatus somewhere, this seems to be the lesser of two evils.
                             if (miface.getOperstatus() == SnmpMinimalPollInterface.IF_DOWN) {
                                 sendOperDownEvent(iface);
                             }


### PR DESCRIPTION
* JIRA: https://issues.opennms.org/browse/NMS-10353

These commits add support for suppressing *almost* all events related to changes in ifAdminStatus.

If the status change is because of ifAdminStatus:
- ifOperStatus DOWN will *only* be sent when ifAdminStatus goes UP
  while ifOperStatus remains DOWN.
- All ifAdminStatus events will be suppressed when suppressAdminDownEvent
  is enabled. The UP events are fairly useless without corresponding
  DOWN events.

If the status change is *not* related to a change in ifAdminStatus:
- ifOperStatus events will be sent as normal, unaffected by any
  of the changes related to re-adding suppressAdminDownEvent.

The default setting of suppressAdminDownEvent is also changed from `true` to `false`, since the option has been deprecated (and had no effect at all) since 2010.