### PR TITLE
NMS-10354: Add an option to suppress ifOperStatus events during initialization

### DIFF
--- a/opennms-base-assembly/src/main/filtered/etc/snmp-interface-poller-configuration.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/snmp-interface-poller-configuration.xml
@@ -1,4 +1,4 @@
-<snmp-interface-poller-configuration xmlns="http://xmlns.opennms.org/xsd/config/snmpinterfacepoller" threads="30" service="SNMP">
+<snmp-interface-poller-configuration xmlns="http://xmlns.opennms.org/xsd/config/snmpinterfacepoller" threads="30" service="SNMP" suppressInitializationEvent="false">
    <node-outage>
       <critical-service name="ICMP"/>
       <critical-service name="SNMP"/>

--- a/opennms-base-assembly/src/main/filtered/etc/snmp-interface-poller-configuration.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/snmp-interface-poller-configuration.xml
@@ -1,4 +1,4 @@
-<snmp-interface-poller-configuration xmlns="http://xmlns.opennms.org/xsd/config/snmpinterfacepoller" threads="30" service="SNMP" suppressInitializationEvent="false">
+<snmp-interface-poller-configuration xmlns="http://xmlns.opennms.org/xsd/config/snmpinterfacepoller" threads="30" service="SNMP">
    <node-outage>
       <critical-service name="ICMP"/>
       <critical-service name="SNMP"/>

--- a/opennms-config-model/src/main/java/org/opennms/netmgt/config/snmpinterfacepoller/SnmpInterfacePollerConfiguration.java
+++ b/opennms-config-model/src/main/java/org/opennms/netmgt/config/snmpinterfacepoller/SnmpInterfacePollerConfiguration.java
@@ -82,6 +82,12 @@ public class SnmpInterfacePollerConfiguration implements Serializable {
     private Boolean m_suppressAdminDownEvent;
 
     /**
+     * Flag which toggles suppression of OperStatus Down events during initialization.
+     */
+    @XmlAttribute(name = "suppressInitializationEvent")
+    private Boolean m_suppressInitializationEvent;
+
+    /**
      * Flag which indicates if the filters defined on packages and interface
      *  criterias must be used to select the SNMP interfaces to be tracked by the
      * poller
@@ -136,6 +142,14 @@ public class SnmpInterfacePollerConfiguration implements Serializable {
         m_suppressAdminDownEvent = suppressAdminDownEvent;
     }
 
+    public Boolean getSuppressInitializationEvent() {
+        return m_suppressInitializationEvent != null ? m_suppressInitializationEvent : Boolean.FALSE;
+    }
+
+    public void setSuppressInitializationEvent(final Boolean suppressInitializationEvent) {
+        m_suppressInitializationEvent = suppressInitializationEvent;
+    }
+
     public Boolean getUseCriteriaFilters() {
         return m_useCriteriaFilters != null ? m_useCriteriaFilters : Boolean.FALSE;
     }
@@ -177,6 +191,7 @@ public class SnmpInterfacePollerConfiguration implements Serializable {
                             m_threads, 
                             m_service, 
                             m_suppressAdminDownEvent, 
+                            m_suppressInitializationEvent,
                             m_useCriteriaFilters, 
                             m_nodeOutage, 
                             m_packages);
@@ -194,6 +209,7 @@ public class SnmpInterfacePollerConfiguration implements Serializable {
                     && Objects.equals(this.m_threads, that.m_threads)
                     && Objects.equals(this.m_service, that.m_service)
                     && Objects.equals(this.m_suppressAdminDownEvent, that.m_suppressAdminDownEvent)
+                    && Objects.equals(this.m_suppressInitializationEvent, that.m_suppressInitializationEvent)
                     && Objects.equals(this.m_useCriteriaFilters, that.m_useCriteriaFilters)
                     && Objects.equals(this.m_nodeOutage, that.m_nodeOutage)
                     && Objects.equals(this.m_packages, that.m_packages);

--- a/opennms-config-model/src/main/resources/xsds/snmp-interface-poller-configuration.xsd
+++ b/opennms-config-model/src/main/resources/xsds/snmp-interface-poller-configuration.xsd
@@ -63,6 +63,16 @@
         </annotation>
       </attribute>    
 
+      <attribute type="boolean" default="false" name="suppressInitializationEvent" use="optional">
+        <annotation>
+          <documentation>Flag which toggles suppression of OperStatus Down events during initialization.
+          When this is enabled, no OperStatus Down events will be sent immediately after OpenNMS restarts,
+          Instead, the regular poller logic will handle events for any interfaces that went down while
+          OpenNMS while OpenNMS was not running.
+          </documentation>
+        </annotation>
+      </attribute>
+
       <attribute type="boolean" default="false" name="useCriteriaFilters" use="optional">
         <annotation>
           <documentation>Flag which indicates if the filters defined on packages and interface

--- a/opennms-config/src/main/java/org/opennms/netmgt/config/SnmpInterfacePollerConfig.java
+++ b/opennms-config/src/main/java/org/opennms/netmgt/config/SnmpInterfacePollerConfig.java
@@ -59,6 +59,12 @@ public interface SnmpInterfacePollerConfig {
      */
     boolean useCriteriaFilters();
     /**
+     * <p>getSuppressInitializationEvent</p>
+     *
+     * @return a boolean.
+     */
+    boolean getSuppressInitializationEvent();
+    /**
      * <p>getService</p>
      *
      * @return a {@link java.lang.String} object.

--- a/opennms-config/src/main/java/org/opennms/netmgt/config/SnmpInterfacePollerConfigManager.java
+++ b/opennms-config/src/main/java/org/opennms/netmgt/config/SnmpInterfacePollerConfigManager.java
@@ -589,4 +589,14 @@ abstract public class SnmpInterfacePollerConfigManager implements SnmpInterfaceP
         return getConfiguration().getUseCriteriaFilters();
     }
 
+    /**
+     * <p>getSuppressInitializationEvent</p>
+     *
+     * @return a boolean.
+     */
+    @Override
+    public boolean getSuppressInitializationEvent() {
+        return getConfiguration().getSuppressInitializationEvent();
+    }
+
 }

--- a/opennms-services/src/main/java/org/opennms/netmgt/snmpinterfacepoller/SnmpPoller.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/snmpinterfacepoller/SnmpPoller.java
@@ -272,6 +272,7 @@ public class SnmpPoller extends AbstractServiceDaemon {
     private void scheduleSnmpCollection(PollableInterface nodeGroup,String pkgName) {
     	
     	String excludingCriteria = new String(" snmpifindex > 0 ");
+        boolean suppressInitializationEvent = getPollerConfig().getSuppressInitializationEvent();
         for (String pkgInterfaceName: getPollerConfig().getInterfaceOnPackage(pkgName)) {
             LOG.debug("found package interface with name: {}", pkgInterfaceName);
             if (getPollerConfig().getStatus(pkgName, pkgInterfaceName)){
@@ -294,7 +295,8 @@ public class SnmpPoller extends AbstractServiceDaemon {
                 if (hasMaxVarsPerPdu) maxVarsPerPdu = getPollerConfig().getMaxVarsPerPdu(pkgName, pkgInterfaceName);
 
                 PollableSnmpInterface node = nodeGroup.createPollableSnmpInterface(pkgInterfaceName, criteria, 
-                   port != -1, port, timeout != -1, timeout, retries != -1, retries, hasMaxVarsPerPdu, maxVarsPerPdu);
+                   port != -1, port, timeout != -1, timeout, retries != -1, retries, hasMaxVarsPerPdu, maxVarsPerPdu,
+                   suppressInitializationEvent);
 
                 node.setSnmpinterfaces(getNetwork().getContext().get(node.getParent().getNodeid(), criteria));
 
@@ -306,7 +308,7 @@ public class SnmpPoller extends AbstractServiceDaemon {
         if (!getPollerConfig().useCriteriaFilters()) {
             LOG.debug("excluding criteria used for default polling: {}", excludingCriteria);
             PollableSnmpInterface node = nodeGroup.createPollableSnmpInterface("null", excludingCriteria, 
-                false, -1, false, -1, false, -1, false, -1);
+                false, -1, false, -1, false, -1, false, -1, suppressInitializationEvent);
 
             node.setSnmpinterfaces(getNetwork().getContext().get(node.getParent().getNodeid(), excludingCriteria));
 

--- a/opennms-services/src/main/java/org/opennms/netmgt/snmpinterfacepoller/pollable/PollableInterface.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/snmpinterfacepoller/pollable/PollableInterface.java
@@ -150,11 +150,12 @@ public class PollableInterface {
    * @param retries a int.
    * @param hasMaxVarsPerPdu a boolean.
    * @param maxVarsPerPdu a int.
+   * @param suppressInitializationEvent a boolean.
    * @return a {@link org.opennms.netmgt.snmpinterfacepoller.pollable.PollableSnmpInterface} object.
    */
   public PollableSnmpInterface createPollableSnmpInterface(String name, String criteria, boolean hasPort, 
           int port, boolean hasTimeout, int timeout, boolean hasRetries, int retries, 
-          boolean hasMaxVarsPerPdu,int maxVarsPerPdu) {
+          boolean hasMaxVarsPerPdu, int maxVarsPerPdu, boolean suppressInitializationEvent) {
 
         PollableSnmpInterface iface = new PollableSnmpInterface(this);
         iface.setName(name);
@@ -168,6 +169,7 @@ public class PollableInterface {
         if (hasMaxVarsPerPdu) agentConfig.setMaxVarsPerPdu(maxVarsPerPdu);
 
         iface.setAgentConfig(agentConfig);
+        iface.setSuppressInitializationEvent(suppressInitializationEvent);
                
         m_pollablesnmpinterface.put(name,iface);
         return iface;


### PR DESCRIPTION
* JIRA: https://issues.opennms.org/browse/NMS-10354

SNMP Interface Poller would generate duplicate operStatus Down events
after every restart for interfaces that was already down.

The new config option, 'suppressInitializationEvent', will ignore all
interfaces that were already marked as down in the snmpinterface table
before the restart.

This also suppresses all events while importing new devices.

Interfaces that change from Up to Down while OpenNMS is stopped will
be handled by doPoll(), which will create the expected events.