### PR TITLE
NMS-10357: Fix Collectd and Pollerd's ThreadPool graphs

### DIFF
--- a/opennms-base-assembly/src/main/filtered/etc/jmx-datacollection-config.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/jmx-datacollection-config.xml
@@ -23,6 +23,9 @@
          </mbean>
          <mbean name="OpenNMS Pollerd" objectname="OpenNMS:Name=Pollerd">
             <attrib name="NumPolls" alias="ONMSPollCount" type="counter"/>
+            <attrib name="NumPoolThreads" alias="ONMSPollerPoolThrd" type="gauge"/>
+            <attrib name="MaxPoolThreads" alias="ONMSPollerPoolMax" type="gauge"/>
+            <attrib name="PeakPoolThreads" alias="ONMSPollerPoolPeak" type="gauge"/>
             <attrib name="ActiveThreads" alias="ONMSPollerThreadAct" type="gauge"/>
             <attrib name="TasksTotal" alias="ONMSPollerTasksTot" type="counter"/>
             <attrib name="TasksCompleted" alias="ONMSPollerTasksCpt" type="counter"/>

--- a/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/opennms-graph.properties
+++ b/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/opennms-graph.properties
@@ -1,7 +1,7 @@
 reports=onms.manager.uptime, onms.queued.updates, onms.queued.pending, \
-onms.pollerd.activeThreads, onms.pollerd.completedRatio, onms.pollerd.polls, \
+onms.pollerd.threadpool, onms.pollerd.completedRatio, onms.pollerd.polls, \
 onms.pollerd.taskqueue, \
-onms.collectd.activeThreads, onms.collectd.threadpool, \
+onms.collectd.threadpool, \
 onms.collectd.completedRatio, onms.collectd.collectableServiceCount, \
 onms.collectd.taskqueue, \
 OpenNMS.JettyServer.HttpsConnTotal.AttributeReport, \
@@ -105,16 +105,28 @@ report.onms.pollerd.polls.command=--title="OpenNMS Services Polled" \
  GPRINT:polls:MIN:"Min  \\: %8.2lf %s" \
  GPRINT:polls:MAX:"Max  \\: %8.2lf %s\\n"
 
-report.onms.pollerd.activeThreads.name=OpenNMS Poller Threads Active
-report.onms.pollerd.activeThreads.columns=ONMSPollerThreadAct
-report.onms.pollerd.activeThreads.type=interfaceSnmp
-report.onms.pollerd.activeThreads.command=--title="OpenNMS Pollerd Threads Active" \
+report.onms.pollerd.threadpool.name=OpenNMS Poller ThreadPool
+report.onms.pollerd.threadpool.columns=ONMSPollerThreadAct,ONMSPollerPoolMax,ONMSPollerPoolPeak
+report.onms.pollerd.threadpool.type=interfaceSnmp
+report.onms.pollerd.threadpool.command=--title="OpenNMS Pollerd ThreadPool" \
  --vertical-label="Threads" \
  DEF:active={rrd1}:ONMSPollerThreadAct:AVERAGE \
- LINE1:active#0000ff:"Total Active" \
- GPRINT:active:AVERAGE:" Avg  \\: %8.2lf %s" \
- GPRINT:active:MIN:"Min  \\: %8.2lf %s" \
- GPRINT:active:MAX:"Max  \\: %8.2lf %s\\n"
+ DEF:maxSize={rrd2}:ONMSPollerPoolMax:AVERAGE \
+ DEF:peak={rrd3}:ONMSPollerPoolPeak:AVERAGE \
+ AREA:peak#AFEBF8 \
+ LINE2:peak#20ABD9:"Peak Active      " \
+ GPRINT:peak:AVERAGE:"Avg\\: %5.0lf\" \
+ GPRINT:peak:MIN:"Min\\: %5.0lf" \
+ GPRINT:peak:MAX:"Max\\: %5.0lf\\n" \
+ AREA:active#F5CD9A \
+ LINE2:active#F19A2A:"Currently Active" \
+ GPRINT:active:AVERAGE:" Avg\\: %5.0lf" \
+ GPRINT:active:MIN:"Min\\: %5.0lf" \
+ GPRINT:active:MAX:"Max\\: %5.0lf\\n" \
+ LINE2:maxSize#9A27F1:"Max Pool Size    " \
+ GPRINT:maxSize:AVERAGE:"Avg\\: %5.0lf\" \
+ GPRINT:maxSize:MIN:"Min\\: %5.0lf" \
+ GPRINT:maxSize:MAX:"Max\\: %5.0lf\\n"
 
 report.onms.pollerd.completedRatio.name=OpenNMS Poller Task Completion Ratio
 report.onms.pollerd.completedRatio.columns=ONMSPollerTasksTot,ONMSPollerTasksCpt
@@ -144,40 +156,28 @@ report.onms.pollerd.taskqueue.command=--title="OpenNMS Pollerd Task Queue" \
 ###
 ## OpenNMS Collectd
 ###
-report.onms.collectd.activeThreads.name=OpenNMS Collectd Threads Active
-report.onms.collectd.activeThreads.columns=ONMSCollectThrdAct
-report.onms.collectd.activeThreads.type=interfaceSnmp
-report.onms.collectd.activeThreads.command=--title="OpenNMS Collectd Threads Active" \
- --vertical-label="Threads" \
- DEF:active={rrd1}:ONMSCollectThrdAct:AVERAGE \
- AREA:active#F5CD9A \
- LINE2:active#F19A2A:"Total Active" \
- GPRINT:active:AVERAGE:" Avg  \\: %5.0lf" \
- GPRINT:active:MIN:"Min  \\: %5.0lf" \
- GPRINT:active:MAX:"Max  \\: %5.0lf\\n"
-
 report.onms.collectd.threadpool.name=OpenNMS Collectd ThreadPool
-report.onms.collectd.threadpool.columns=ONMSCollectPoolThrd,ONMSCollectPoolMax,ONMSCollectPoolPeak
+report.onms.collectd.threadpool.columns=ONMSCollectThrdAct,ONMSCollectPoolMax,ONMSCollectPoolPeak
 report.onms.collectd.threadpool.type=interfaceSnmp
 report.onms.collectd.threadpool.command=--title="OpenNMS Collectd ThreadPool" \
  --vertical-label="Threads" \
- DEF:active={rrd1}:ONMSCollectPoolThrd:AVERAGE \
- DEF:max={rrd2}:ONMSCollectPoolMax:AVERAGE \
+ DEF:active={rrd1}:ONMSCollectThrdAct:AVERAGE \
+ DEF:maxSize={rrd2}:ONMSCollectPoolMax:AVERAGE \
  DEF:peak={rrd3}:ONMSCollectPoolPeak:AVERAGE \
- AREA:active#F5CD9A \
- LINE2:active#F19A2A:"Total Active" \
- GPRINT:active:AVERAGE:" Avg\\: %5.0lf" \
- GPRINT:active:MIN:"Min  \\: %5.0lf" \
- GPRINT:active:MAX:"Max  \\: %5.0lf\\n" \
  AREA:peak#AFEBF8 \
- LINE2:peak#20ABD9:"Peak Active" \
+ LINE2:peak#20ABD9:"Peak Active      " \
  GPRINT:peak:AVERAGE:"Avg\\: %5.0lf\" \
  GPRINT:peak:MIN:"Min\\: %5.0lf" \
  GPRINT:peak:MAX:"Max\\: %5.0lf\\n" \
- LINE2:max#9A27F1:"Maximum Active" \
- GPRINT:max:AVERAGE:"Avg\\: %5.0lf\" \
- GPRINT:max:MIN:"Min\\: %5.0lf" \
- GPRINT:max:MAX:"Max\\: %5.0lf\\n"
+ AREA:active#F5CD9A \
+ LINE2:active#F19A2A:"Currently Active" \
+ GPRINT:active:AVERAGE:" Avg\\: %5.0lf" \
+ GPRINT:active:MIN:"Min\\: %5.0lf" \
+ GPRINT:active:MAX:"Max\\: %5.0lf\\n" \
+ LINE2:maxSize#9A27F1:"Max Pool Size    " \
+ GPRINT:maxSize:AVERAGE:"Avg\\: %5.0lf\" \
+ GPRINT:maxSize:MIN:"Min\\: %5.0lf" \
+ GPRINT:maxSize:MAX:"Max\\: %5.0lf\\n"
 
 report.onms.collectd.completedRatio.name=OpenNMS Collectd Task Completion Ratio
 report.onms.collectd.completedRatio.columns=ONMSCollectTasksTot,ONMSCollectTasksCpt

--- a/opennms-services/src/main/java/org/opennms/netmgt/collectd/jmx/CollectdMBean.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/collectd/jmx/CollectdMBean.java
@@ -43,7 +43,7 @@ public interface CollectdMBean extends BaseOnmsMBean {
     public long getActiveThreads();
 
     /**
-     * @return The active number of collection threads
+     * @return The current number of threads in the pool
      */
     public long getNumPoolThreads();
 

--- a/opennms-services/src/main/java/org/opennms/netmgt/poller/jmx/Pollerd.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/poller/jmx/Pollerd.java
@@ -103,6 +103,16 @@ public class Pollerd extends AbstractSpringContextJmxServiceDaemon<org.opennms.n
     
     /** {@inheritDoc} */
     @Override
+    public long getNumPoolThreads() {
+        if (getThreadPoolStatsStatus()) {
+            return getExecutor().getPoolSize();
+        } else {
+            return 0L;
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Override
     public long getPeakPoolThreads() {
         if (getThreadPoolStatsStatus()) {
             return getExecutor().getLargestPoolSize();

--- a/opennms-services/src/main/java/org/opennms/netmgt/poller/jmx/PollerdMBean.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/poller/jmx/PollerdMBean.java
@@ -64,8 +64,12 @@ public interface PollerdMBean extends BaseOnmsMBean {
      */
     public double getTaskCompletionRatio();
     
+     /**
+     * @return The current number of threads in the pool
+     */
+    public long getNumPoolThreads();
+
     /**
-     * 
      * @return The largest size of the poller thread pool since poller startup
      */
     public long getPeakPoolThreads();


### PR DESCRIPTION
* JIRA: https://issues.opennms.org/browse/NMS-10357

Adds missing pool size attribute ('numPoolThreads') to Pollerd's
MBean, and adds all the PoolThreads attributes (num, max, peak) to
the JMX datacollection config for Pollerd.

Also makes it slightly more obvious what numPoolThreads actually is,
by changing the @return comment to match the official javadocs.

Finally, the graph properties for the ThreadPool attributes have been
changed to graph the active threads, peak threads and max pool size.

The original graph included both numPoolThreads and maxPoolThreads,
which seem to be identical when using fixed thread pools.
numPoolThreads was replaced by active threads, which made the
standalone graphs redundant.