### PR TITLE
NMS-10370: fix misleading INFO log message

### DIFF
--- a/opennms-provision/opennms-provisiond/src/main/java/org/opennms/netmgt/provision/service/ForceRescanScan.java
+++ b/opennms-provision/opennms-provisiond/src/main/java/org/opennms/netmgt/provision/service/ForceRescanScan.java
@@ -92,8 +92,9 @@ public class ForceRescanScan implements Scan {
             OnmsIpInterface iface = m_provisionService.getPrimaryInterfaceForNode(node);
             if (iface == null) { // NMS-6380, a discovered node added with wrong SNMP settings doesn't have a primary interface yet.
                 iface = node.getIpInterfaces().isEmpty() ? null : node.getIpInterfaces().iterator().next();
-            } else {
-                LOG.info("The node with ID OP does not have a primary interface", m_nodeId);
+                if (iface != null) {
+                    LOG.info("The node with ID {} does not have a primary interface", m_nodeId);
+                }
             }
             if (iface == null) {
                 LOG.info("The node with ID {} does not have any IP addresses", m_nodeId);


### PR DESCRIPTION
* JIRA: https://issues.opennms.org/browse/NMS-10370

`2018-09-25 20:46:27,735 INFO  [scanExecutor-8] o.o.n.p.s.ForceRescanScan: The node with ID OP does not have a primary interface` will no longer be printed for nodes with valid primary SNMP interfaces.

Should the node lack a primary SNMP interface, for any reason, the log message will be printed with the proper node ID:
`2018-09-25 21:04:48,939 INFO  [scanExecutor-3] o.o.n.p.s.ForceRescanScan: The node with ID 40 does not have a primary interface`
