### PR TITLE
NMS-10372: Update MBeans to work with Horizon 22

### DIFF
--- a/opennms-base-assembly/src/main/filtered/etc/jmx-datacollection-config.d/minion.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/jmx-datacollection-config.d/minion.xml
@@ -21,7 +21,7 @@
                 <attrib name="DaemonThreadCount" alias="DaemonThreadCount" type="gauge"/>
                 <attrib name="CurrentThreadCpuTime" alias="CurThreadCpuTime" type="gauge"/>
             </mbean>
-            <mbean name="JVM GarbageCollector:MarkSweepCompact" objectname="java.lang:type=GarbageCollector,name=MarkSweepCompact">
+            <mbean name="JVM GarbageCollector:MarkSweepCompact" objectname="java.lang:name=PS MarkSweep,type=GarbageCollector">
                 <attrib name="CollectionCount" alias="MSCCollCnt" type="counter"/>
                 <attrib name="CollectionTime" alias="MSCCollTime" type="counter"/>
                 <comp-attrib name="LastGcInfo" type="Composite" alias="MSCLastGcInfo">
@@ -46,7 +46,7 @@
 
 
             <!-- Route stats for RPC.Server.Detect -->
-            <mbean name="Provisioning Detectors RPC Server" objectname="org.apache.camel:context=org.opennms.core.ipc.rpc.camel-impl,type=routes,name=&quot;RPC.Server.Detect&quot;">
+            <mbean name="Provisioning Detectors RPC Server" objectname="org.apache.camel:context=org.opennms.core.ipc.rpc.jms-impl-rpcServer,name=&quot;RPC.Server.Detect&quot;,type=routes">
                 <attrib name="ExchangesCompleted" alias="DetectComplete" type="counter"/>
                 <attrib name="ExchangesFailed" alias="DetectFailed" type="counter"/>
                 <attrib name="ExchangesTotal" alias="DetectTotal" type="counter"/>
@@ -59,7 +59,7 @@
 
 
             <!-- Route stats for RPC.Server.DNS -->
-            <mbean name="DNS RPC Server" objectname="org.apache.camel:context=org.opennms.core.ipc.rpc.camel-impl,type=routes,name=&quot;RPC.Server.DNS&quot;">
+            <mbean name="DNS RPC Server" objectname="org.apache.camel:context=org.opennms.core.ipc.rpc.jms-impl-rpcServer,name=&quot;RPC.Server.DNS&quot;,type=routes">
                 <attrib name="ExchangesCompleted" alias="DnsComplete" type="counter"/>
                 <attrib name="ExchangesFailed" alias="DnsFailed" type="counter"/>
                 <attrib name="ExchangesTotal" alias="DnsTotal" type="counter"/>
@@ -72,7 +72,7 @@
 
 
             <!-- Route stats for RPC.Server.PING -->
-            <mbean name="Ping RPC Server" objectname="org.apache.camel:context=org.opennms.core.ipc.rpc.camel-impl,type=routes,name=&quot;RPC.Server.PING&quot;">
+            <mbean name="Ping RPC Server" objectname="org.apache.camel:context=org.opennms.core.ipc.rpc.jms-impl-rpcServer,name=&quot;RPC.Server.PING&quot;,type=routes">
                 <attrib name="ExchangesCompleted" alias="PingComplete" type="counter"/>
                 <attrib name="ExchangesFailed" alias="PingFailed" type="counter"/>
                 <attrib name="ExchangesTotal" alias="PingTotal" type="counter"/>
@@ -85,7 +85,7 @@
 
 
             <!-- Route stats for RPC.Server.PING-SWEEP -->
-            <mbean name="Ping Sweep RPC Server" objectname="org.apache.camel:context=org.opennms.core.ipc.rpc.camel-impl,type=routes,name=&quot;RPC.Server.PING-SWEEP&quot;">
+            <mbean name="Ping Sweep RPC Server" objectname="org.apache.camel:context=org.opennms.core.ipc.rpc.jms-impl-rpcServer,name=&quot;RPC.Server.PING-SWEEP&quot;,type=routes">
                 <attrib name="ExchangesCompleted" alias="SweepComplete" type="counter"/>
                 <attrib name="ExchangesFailed" alias="SweepFailed" type="counter"/>
                 <attrib name="ExchangesTotal" alias="SweepTotal" type="counter"/>
@@ -98,7 +98,7 @@
 
 
             <!-- Route stats for RPC.Server.Poller -->
-            <mbean name="Poller RPC Server" objectname="org.apache.camel:context=org.opennms.core.ipc.rpc.camel-impl,type=routes,name=&quot;RPC.Server.Poller&quot;">
+            <mbean name="Poller RPC Server" objectname="org.apache.camel:context=org.opennms.core.ipc.rpc.jms-impl-rpcServer,name=&quot;RPC.Server.Poller&quot;,type=routes">
                 <attrib name="ExchangesCompleted" alias="PollComplete" type="counter"/>
                 <attrib name="ExchangesFailed" alias="PollFailed" type="counter"/>
                 <attrib name="ExchangesTotal" alias="PollTotal" type="counter"/>
@@ -111,7 +111,7 @@
 
 
             <!-- Route stats for RPC.Server.SNMP -->
-            <mbean name="SNMP RPC Server" objectname="org.apache.camel:context=org.opennms.core.ipc.rpc.camel-impl,type=routes,name=&quot;RPC.Server.SNMP&quot;">
+            <mbean name="SNMP RPC Server" objectname="org.apache.camel:context=org.opennms.core.ipc.rpc.jms-impl-rpcServer,name=&quot;RPC.Server.SNMP&quot;,type=routes">
                 <attrib name="ExchangesCompleted" alias="SnmpComplete" type="counter"/>
                 <attrib name="ExchangesFailed" alias="SnmpFailed" type="counter"/>
                 <attrib name="ExchangesTotal" alias="SnmpTotal" type="counter"/>


### PR DESCRIPTION
* JIRA: https://issues.opennms.org/browse/NMS-10372

This pull requests updates the MBeans in minion.xml to work with minions running on 22.0.4.

(NB: I have used foundation-2018 as the base, but I'm not sure if this could create problems for Meridian, if they still use the old object names.)