### PR TITLE
NMS-10381: speed up webpack build

### DIFF
--- a/core/web-assets/README.md
+++ b/core/web-assets/README.md
@@ -62,7 +62,7 @@ Then, there are a number of commands you can run while developing:
 * `yarn build`: build all assets in "development" mode -- `.min.js` assets will not be generated (more on this below)
 * `yarn release`: build all assets in "production" mode -- this generates both normal `.js` assets and prod `.min.js` assets
 * `yarn watch`: build "development" assets continually, whenever files change
-* `yarn release`: build "production" assets continually, whenever files change
+* `yarn watch-release`: build "production" assets continually, whenever files change
 * `yarn lint`: check for errors or warnings in your JavaScript code
 * `yarn test`: run unit tests
 

--- a/core/web-assets/pom.xml
+++ b/core/web-assets/pom.xml
@@ -22,6 +22,7 @@
             <nodeDownloadRoot>http://mirror.internal.opennms.com/nodejs/dist/</nodeDownloadRoot>
             <npmDownloadRoot>http://mirror.internal.opennms.com/npmjs/npm/-/</npmDownloadRoot>
             <installDirectory>target</installDirectory>
+            <srcdir>${basedir}/src/main/assets</srcdir>
             <triggerfiles>
               <triggerfile>package.json</triggerfile>
             </triggerfiles>

--- a/core/web-assets/pom.xml
+++ b/core/web-assets/pom.xml
@@ -161,6 +161,10 @@
       <artifactId>org.opennms.core.lib</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.opennms.core</groupId>
+      <artifactId>org.opennms.core.logging</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.opennms.dependencies</groupId>
       <artifactId>servlet-dependencies</artifactId>
       <type>pom</type>

--- a/core/web-assets/src/main/java/org/opennms/web/assets/impl/AssetLocatorImpl.java
+++ b/core/web-assets/src/main/java/org/opennms/web/assets/impl/AssetLocatorImpl.java
@@ -34,6 +34,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -42,6 +44,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.Callable;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -50,6 +53,7 @@ import javax.servlet.http.HttpServletRequest;
 
 import org.json.JSONArray;
 import org.json.JSONObject;
+import org.opennms.core.logging.Logging;
 import org.opennms.core.utils.StringUtils;
 import org.opennms.web.assets.api.AssetLocator;
 import org.opennms.web.assets.api.AssetResource;
@@ -68,28 +72,26 @@ import org.springframework.web.servlet.resource.ResourceResolverChain;
 public class AssetLocatorImpl extends AbstractResourceResolver implements AssetLocator, InitializingBean {
     private static Logger LOG = LoggerFactory.getLogger(AssetLocatorImpl.class);
 
-    private static final boolean s_useMinified = Boolean.parseBoolean(System.getProperty("org.opennms.web.assets.minified", "true"));
-    private static final String s_filesystemPath = System.getProperty("org.opennms.web.assets.path");
-    private static final Long s_reload = Long.getLong("org.opennms.web.assets.reload", 5l);
     private static AssetLocator s_instance;
-
     private static final Resource s_assetsPath = new ClassPathResource("/assets/");
 
     private ScheduledExecutorService m_executor = null;
 
     private Map<String,List<AssetResource>> m_unminified = new HashMap<>();
     private Map<String,List<AssetResource>> m_minified   = new HashMap<>();
-    private long m_lastModified = 0;
-    private long m_reload;
-    private boolean m_useMinified;
+    long m_lastModified = 0;
+    long m_reload;
+    String m_filesystemPath;
+    boolean m_useMinified;
 
     public static AssetLocator getInstance() {
         return s_instance;
     }
 
     public AssetLocatorImpl() {
-        m_useMinified = s_useMinified;
-        m_reload = s_reload;
+        m_filesystemPath = System.getProperty("org.opennms.web.assets.path");
+        m_useMinified = Boolean.parseBoolean(System.getProperty("org.opennms.web.assets.minified", "true"));
+        m_reload = Long.getLong("org.opennms.web.assets.reload", 5l);
     }
 
     @Override
@@ -99,7 +101,7 @@ public class AssetLocatorImpl extends AbstractResourceResolver implements AssetL
 
     @Override
     public Collection<String> getAssets() {
-        return getAssets(s_useMinified);
+        return getAssets(m_useMinified);
     }
 
     @Override
@@ -109,7 +111,7 @@ public class AssetLocatorImpl extends AbstractResourceResolver implements AssetL
 
     @Override
     public Optional<Collection<AssetResource>> getResources(final String assetName) {
-        return getResources(assetName, s_useMinified);
+        return getResources(assetName, m_useMinified);
     }
 
     @Override
@@ -119,7 +121,7 @@ public class AssetLocatorImpl extends AbstractResourceResolver implements AssetL
 
     @Override
     public Optional<AssetResource> getResource(final String assetName, final String type) {
-        return getResource(assetName, type, s_useMinified);
+        return getResource(assetName, type, m_useMinified);
     }
 
     @Override
@@ -136,33 +138,35 @@ public class AssetLocatorImpl extends AbstractResourceResolver implements AssetL
 
     @Override
     public Optional<InputStream> open(final String assetName, final String type) throws IOException {
-        return open(assetName, type, s_useMinified);
+        return open(assetName, type, m_useMinified);
     }
 
     @Override
     public Optional<InputStream> open(final String assetName, final String type, final boolean minified) throws IOException {
-        final Optional<AssetResource> r = getResource(assetName, type, minified);
-        if (!r.isPresent()) {
-            LOG.info("Unable to locate asset resource {}:{}", assetName, type);
-            return Optional.empty();
-        }
-        final AssetResource resource = r.get();
-
-        if (s_filesystemPath != null) {
-            final Path p = Paths.get(s_filesystemPath).resolve(resource.getPath());
-            LOG.debug("assets path is set, attempting to load {}:{} from {}", assetName, type, p);
-            if (p.toFile().exists()) {
-                return Optional.of(new FileInputStream(p.toFile()));
+        return withLogPrefix(() -> {
+            final Optional<AssetResource> r = getResource(assetName, type, minified);
+            if (!r.isPresent()) {
+                LOG.info("Unable to locate asset resource {}:{}", assetName, type);
+                return Optional.empty();
             }
-        }
+            final AssetResource resource = r.get();
 
-        final String resourcePath = resource.getPath();
-        LOG.debug("Opening resource {} for asset {}", resourcePath, r);
-        final URL url = getClass().getResource(resourcePath);
-        if (url != null) {
-            return Optional.of(url.openStream());
-        }
-        return Optional.of(new ClassPathResource(resourcePath).getInputStream());
+            if (m_filesystemPath != null) {
+                final Path p = Paths.get(m_filesystemPath).resolve(resource.getPath());
+                LOG.debug("assets path is set, attempting to load {}:{} from {}", assetName, type, p);
+                if (p.toFile().exists()) {
+                    return Optional.of(new FileInputStream(p.toFile()));
+                }
+            }
+
+            final String resourcePath = resource.getPath();
+            LOG.debug("Opening resource {} for asset {}", resourcePath, r);
+            final URL url = getClass().getResource(resourcePath);
+            if (url != null) {
+                return Optional.of(url.openStream());
+            }
+            return Optional.of(new ClassPathResource(resourcePath).getInputStream());
+        });
     }
 
     @Override
@@ -180,11 +184,11 @@ public class AssetLocatorImpl extends AbstractResourceResolver implements AssetL
 
     @Override
     public void afterPropertiesSet() throws Exception {
-        if (s_reload != null && s_reload > 0) {
+        if (m_reload > 0) {
             m_executor = Executors.newSingleThreadScheduledExecutor();
             m_executor.scheduleAtFixedRate(() -> {
                 reload();
-            }, s_reload, s_reload, TimeUnit.MINUTES);
+            }, m_reload, m_reload, TimeUnit.MINUTES);
         }
 
         // always load at least once
@@ -210,54 +214,70 @@ public class AssetLocatorImpl extends AbstractResourceResolver implements AssetL
     }
 
     private Map<String,List<AssetResource>> loadAssets(final boolean minified) {
-        try {
-            final Map<String,List<AssetResource>> newAssets = new HashMap<>();
+        return withLogPrefix(() ->  {
+            try {
+                final Map<String,List<AssetResource>> newAssets = new HashMap<>();
 
-            Resource r = new ClassPathResource(minified? "/assets/assets.min.json" : "/assets/assets.json");
+                Resource r = new ClassPathResource(minified? "/assets/assets.min.json" : "/assets/assets.json");
 
-            if (s_filesystemPath != null) {
-                final Path p = Paths.get(s_filesystemPath).resolve(minified? "assets.min.json" : "assets.json");
-                if (p.toFile().exists()) {
-                    r = new FileSystemResource(p.toFile());
-                }
-            }
-
-            LOG.info("Loading asset data from {}", r);
-            byte[] bdata = FileCopyUtils.copyToByteArray(r.getInputStream());
-
-            final String json = new String(bdata, StandardCharsets.UTF_8);
-            final JSONObject assetsObj = new JSONObject(json);
-            final JSONArray names = assetsObj.names();
-            for (int i=0; i < names.length(); i++) {
-                final String assetName = names.getString(i);
-                final JSONObject assetObj = assetsObj.getJSONObject(assetName);
-                final List<AssetResource> assets = new ArrayList<>(assetObj.length());
-                final JSONArray keys = assetObj.names();
-                int count = 0;
-                for (int j=0; j < keys.length(); j++) {
-                    final String type = keys.getString(j);
-                    if (!assetObj.isNull(type)) {
-                        final Object item = assetObj.get(type);
-                        if (item instanceof JSONArray) {
-                            LOG.debug("{} is an anonymous type resource; skipping indexing", type);
-                        } else {
-                            final String path = assetObj.getString(type);
-                            assets.add(new AssetResource(assetName, type, path));
-                            count++;
-                        }
+                if (m_filesystemPath != null) {
+                    final Path p = Paths.get(m_filesystemPath).resolve(minified? "assets.min.json" : "assets.json");
+                    if (p.toFile().exists()) {
+                        r = new FileSystemResource(p.toFile());
                     }
                 }
-                if (count > 0) {
-                    newAssets.put(assetName, assets);
-                }
-            }
 
-            m_lastModified = r.lastModified();
-            return newAssets;
-        } catch (final Exception e) {
-            LOG.warn("Failed to load asset manifest.", e);
+                LOG.info("Loading asset data from {}", r);
+                byte[] bdata = FileCopyUtils.copyToByteArray(r.getInputStream());
+
+                final String json = new String(bdata, StandardCharsets.UTF_8);
+                final JSONObject assetsObj = new JSONObject(json);
+                final JSONArray names = assetsObj.names();
+                for (int i=0; i < names.length(); i++) {
+                    final String assetName = names.getString(i);
+                    final JSONObject assetObj = assetsObj.getJSONObject(assetName);
+                    final List<AssetResource> assets = new ArrayList<>(assetObj.length());
+                    final JSONArray keys = assetObj.names();
+                    int count = 0;
+                    for (int j=0; j < keys.length(); j++) {
+                        final String type = keys.getString(j);
+                        if (!assetObj.isNull(type)) {
+                            final Object item = assetObj.get(type);
+                            if (item instanceof JSONArray) {
+                                LOG.debug("{} is an anonymous type resource; skipping indexing", type);
+                            } else {
+                                final String path = assetObj.getString(type);
+                                assets.add(new AssetResource(assetName, type, path));
+                                count++;
+                            }
+                        }
+                    }
+                    if (count > 0) {
+                        newAssets.put(assetName, assets);
+                    }
+                }
+
+                m_lastModified = Math.max(getLastModified(), r.lastModified());
+                return newAssets;
+            } catch (final Exception e) {
+                LOG.warn("Failed to load asset manifest.", e);
+            }
+            return null;
+        });
+    }
+
+    private long getLastModified() {
+        long lastModified = 0;
+        if (m_filesystemPath != null) {
+            try (final DirectoryStream<Path> stream = Files.newDirectoryStream(Paths.get(m_filesystemPath))) {
+                for (final Path path : stream) {
+                    lastModified = Math.max(path.toFile().lastModified(), lastModified);
+                }
+            } catch (final IOException e) {
+                LOG.warn("Failed to scan {} for modified files.", m_filesystemPath);
+            }
         }
-        return null;
+        return lastModified;
     }
 
     @Override
@@ -266,49 +286,53 @@ public class AssetLocatorImpl extends AbstractResourceResolver implements AssetL
     }
 
     protected Resource getResource(final String requestPath, final List<? extends Resource> locations) {
-        for (final Resource location : locations) {
-            try {
-                if (resourcesMatch(s_assetsPath, location)) {
-                    final Resource resource = location.createRelative(requestPath);
-                    LOG.debug("checking request {} in location {}", requestPath, location);
-                    final String fileName = resource.getFilename();
+        return withLogPrefix(() -> {
+            for (final Resource location : locations) {
+                try {
+                    if (resourcesMatch(s_assetsPath, location)) {
+                        final Resource resource = location.createRelative(requestPath);
+                        LOG.debug("checking request {} in location {}", requestPath, location);
+                        final String fileName = resource.getFilename();
 
-                    if (s_filesystemPath != null) {
-                        final File f = Paths.get(s_filesystemPath, fileName).toFile();
-                        LOG.debug("Checking for resource in filesystem: {}", f);
-                        if (f.exists() && f.canRead()) {
-                            LOG.trace("File exists and is readable: {}", f);
-                            return new FileSystemResource(f);
-                        }
-                    }
-
-                    final int index = fileName.lastIndexOf(".");
-                    if (index > 0) {
-                        final String assetName = fileName.substring(0,  index);
-                        final String type = fileName.substring(index + 1);
-                        final Optional<AssetResource> assetResource = getResource(assetName, type);
-                        LOG.debug("Checking for resource in classpath: {}.{} ({})", assetName, type, assetResource);
-                        if (assetResource.isPresent()) {
-                            final Resource found = new ClassPathResource(assetResource.get().getPath());
-                            LOG.debug("Found ClassPathResource: {}", found);
-                            if (found.exists() && found.isReadable()) {
-                                LOG.trace("Resource exists and is readable: {}", found);
-                                return found;
+                        if (m_filesystemPath != null) {
+                            final File f = Paths.get(m_filesystemPath, fileName).toFile();
+                            LOG.debug("Checking for resource in filesystem: {}", f);
+                            if (f.exists() && f.canRead()) {
+                                LOG.trace("File exists and is readable: {}", f);
+                                return new FileSystemResource(f);
                             }
                         }
+
+                        final int index = fileName.lastIndexOf(".");
+                        if (index > 0) {
+                            final String assetName = fileName.substring(0,  index);
+                            final String type = fileName.substring(index + 1);
+                            final Optional<AssetResource> assetResource = getResource(assetName, type);
+                            LOG.debug("Checking for resource in classpath: {}.{} ({})", assetName, type, assetResource);
+                            if (assetResource.isPresent()) {
+                                final Resource relativeResource = new ClassPathResource("/" + assetResource.get().getPath());
+                                LOG.debug("Using ClassPathResource: {}", relativeResource);
+                                if (relativeResource.exists() && relativeResource.isReadable()) {
+                                    LOG.trace("Resource exists and is readable: {}", relativeResource);
+                                    return relativeResource;
+                                }
+                            } else {
+                                LOG.debug("Asset resource was not found: {}:{}", assetName, type);
+                            }
+                        }
+
+                        if (resource.exists()) {
+                            return resource;
+                        }
                     }
 
-                    if (resource.exists()) {
-                        return resource;
-                    }
+                    LOG.debug("unhandled location {} for request path {}", location, requestPath);
+                } catch (final IOException e) {
+                    LOG.debug("Failed to create relative path from {} in {}. Trying next location.", requestPath, location, e);
                 }
-
-                LOG.debug("unhandled location {} for request path {}", location, requestPath);
-            } catch (final IOException e) {
-                LOG.debug("Failed to create relative path from {} in {}. Trying next location.", requestPath, location, e);
             }
-        }
-        return null;
+            return null;
+        });
     }
 
     private boolean resourcesMatch(final Resource a, final Resource b) {
@@ -344,5 +368,17 @@ public class AssetLocatorImpl extends AbstractResourceResolver implements AssetL
     @Override
     protected String resolveUrlPathInternal(final String resourcePath, final List<? extends Resource> locations, final ResourceResolverChain chain) {
         return (StringUtils.hasText(resourcePath) && getResource(resourcePath, locations) != null ? resourcePath : null);
+    }
+
+    private <T>T withLogPrefix(final Callable<T> cb) {
+        try {
+            return Logging.withPrefix("web", cb);
+        } catch (final Exception e) {
+            if (e instanceof RuntimeException) {
+                throw (RuntimeException)e;
+            } else {
+                throw new RuntimeException(e);
+            }
+        }
     }
 }

--- a/core/web-assets/src/test/java/org/opennms/web/assets/impl/AssetLocatorImplTest.java
+++ b/core/web-assets/src/test/java/org/opennms/web/assets/impl/AssetLocatorImplTest.java
@@ -36,6 +36,7 @@ import static org.junit.Assert.assertTrue;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URL;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Optional;
@@ -45,6 +46,7 @@ import org.junit.Test;
 import org.opennms.core.test.MockLogAppender;
 import org.opennms.web.assets.api.AssetResource;
 import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.io.Resource;
 import org.springframework.util.FileCopyUtils;
 
@@ -136,7 +138,7 @@ public class AssetLocatorImplTest {
 
     @Test
     public void testResolveFromClasspath() throws Exception {
-        final Resource location = new ClassPathResource("/assets/", AssetLocatorImpl.class);
+        final Resource location = new ClassPathResource("/assets/");
         final String requestPath = "test-asset.js";
         final Resource actual = m_locator.resolveResource(null, requestPath, Arrays.asList(location), null);
         assertNotNull(actual);
@@ -147,11 +149,13 @@ public class AssetLocatorImplTest {
 
     @Test
     public void testResolveFromFileystem() throws Exception {
-        final Resource location = new ClassPathResource("/assets/", AssetLocatorImpl.class);
+        final AssetLocatorImpl locator = new AssetLocatorImpl();
+        locator.m_filesystemPath = Paths.get("src", "test", "resources", "assets").toAbsolutePath().toString();
         final String requestPath = "test.js";
-        final Resource actual = m_locator.resolveResource(null, requestPath, Arrays.asList(location), null);
+        final Resource actual = locator.resolveResource(null, requestPath, Arrays.asList(new ClassPathResource("/assets/")), null);
         assertNotNull(actual);
-        final URL expected = location.createRelative("test.js").getURL();
+        assertTrue(actual instanceof FileSystemResource);
+        final URL expected = new FileSystemResource(locator.m_filesystemPath + "/").createRelative("test.js").getURL();
         final URL found = actual.getURL();
         assertEquals(expected, found);
    }

--- a/core/web-assets/webpack.config.js
+++ b/core/web-assets/webpack.config.js
@@ -27,13 +27,20 @@ var opennmsVersion = pkginfo.version;
 
 var argv = require('yargs').argv;
 var isProduction = argv.env === 'production';
+var doVaadin = true;
+if (typeof argv.vaadin !== 'undefined') {
+  doVaadin = argv.vaadin;
+}
 var distdir = path.join(__dirname, 'target', 'dist', 'assets');
 var variants = {
   production: [ false ]
 };
 
 if (isProduction) {
-  variants.production = [ true, false, 'vaadin' ];
+  variants.production = [ true, false ];
+  if (doVaadin) {
+    variants.production.push('vaadin');
+  }
 }
 
 console.log('=== running ' + (isProduction? 'production':'development') + ' build of OpenNMS ' + opennmsVersion + ' assets ===');


### PR DESCRIPTION
This PR includes a number of fixes and improvements to the webpack build:

* speed up development builds by skipping the Vaadin bits
* an update to the webpack build to check for changes and skip building if source materials are unchanged
* a rework of the `AssetLocator` implementation to detect filesystem changes properly while in "development" mode

JIRA: http://issues.opennms.org/browse/NMS-10381

Our [continuous integration system](http://bamboo.internal.opennms.com:8085) will test and verify your changes.
