### PR TITLE
NMS-10401: Handle new JDK versions

### DIFF
--- a/bin/functions.pl
+++ b/bin/functions.pl
@@ -355,9 +355,11 @@ sub get_version_from_java {
 	my ($output, $bindir, $shortversion, $version, $build, $java_home);
 
 	$output = `"$javacmd" -version 2>\&1`;
-	($version) = $output =~ / version \"?([\d\.]+?(?:[\+\-\_]\S+?)?)\"?$/ms;
-	($version, $build) = $version =~ /^([\d\.]+)(?:[\+\-\_](.*?))?$/;
-	($shortversion) = $version =~ /^(\d+\.\d+|\d+)/;
+	($version) = $output =~ / version \"?([\d\.]+?(?:[\+\-\_]\S+?)?)\"?(?: \d\d\d\d-\d\d-\d\d)?$/ms;
+	if (defined $version) {
+		($version, $build) = $version =~ /^([\d\.]+)(?:[\+\-\_](.*?))?$/;
+		($shortversion) = $version =~ /^(\d+\.\d+|\d+)/;
+	}
 	$build = 0 if (not defined $build);
 
 	$bindir = dirname($javacmd);

--- a/opennms-base-assembly/src/main/filtered/bin/find-java.sh
+++ b/opennms-base-assembly/src/main/filtered/bin/find-java.sh
@@ -35,7 +35,7 @@ get_java_version_string() {
 	home="$1"; shift
 	full_version_string="$("${home}"/bin/java -version 2>&1 | grep ' version ')"
 	#version_string="$(printf '%s' "${full_version_string}" | sed -e 's,^.* version ,,' -e 's,^"\(.*\)"$,\1,' -e 's,-[A-Za-z]*$,,' -e 's,^1\.,,')"
-	version_string="$(printf '%s' "${full_version_string}" | sed -e 's,^.* version ,,' -e 's,^"\(.*\)"$,\1,' -e 's,-[A-Za-z]*$,,')"
+	version_string="$(printf '%s' "${full_version_string}" | sed -e 's,^.* version ,,' -e 's, [0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]$,,' -e 's,^"\(.*\)"$,\1,' -e 's,-[A-Za-z]*$,,')"
 	if (printf '%s' "${version_string}" | grep -Eq '^[0-9\._]+$'); then
 		# valid parsed version string, only numbers and periods
 		printf '%s\n' "${version_string}"

--- a/opennms-base-assembly/src/main/filtered/bin/find-java.sh
+++ b/opennms-base-assembly/src/main/filtered/bin/find-java.sh
@@ -4,22 +4,16 @@ JAVA_SEARCH_DIRS="$JAVA_SEARCH_DIRS /usr/lib/jvm /usr/java /System/Library/Java/
 # set DEBUG=true to enable debugging
 
 compare_versions() {
-	a="$(printf '%s' "${1}" | sed -e 's,^1\.\([123456789]\),\1.0,' -e 's,_,.,g')"
-	b="$(printf '%s' "${2}" | sed -e 's,^1\.\([123456789]\),\1.0,' -e 's,_,.,g')"
+	a="$(printf '%s.0.0.0' "${1}" | sed -e 's,^1\.\([123456789]\),\1.0,' -e 's,_,.,g')"
+	b="$(printf '%s.0.0.0' "${2}" | sed -e 's,^1\.\([123456789]\),\1.0,' -e 's,_,.,g')"
+
 	for place in 1 2 3 4; do
 		aplace="$(printf '%s' "$a" | cut -d. "-f${place}")"
 		bplace="$(printf '%s' "$b" | cut -d. "-f${place}")"
 
-		if [ "x${aplace}" = "x" ]; then
-			aplace=0
-		fi
-		if [ "x${bplace}" = "x" ]; then
-			bplace=0
-		fi
-
-		if [ $aplace -eq $bplace ]; then
+		if [ "$aplace" -eq "$bplace" ]; then
 			continue
-		elif [ $aplace -lt $bplace ]; then
+		elif [ "$aplace" -lt "$bplace" ]; then
 			printf '%s' '1'
 			return
 		else
@@ -53,7 +47,7 @@ usage: $0 [-h] [-v] [minimum_jdk_version] [maximum_jdk_version]
 	-v   print the version matched, rather than the JAVA_HOME
 
 This script will print the location of the newest JDK in the range
-of minimum_jdk_version to maximum_jdk_version.
+of minimum_jdk_version (inclusive) to maximum_jdk_version (exclusive).
 
 END
 }
@@ -75,6 +69,8 @@ main() {
 			v)
 				SHOW_VERSION=1
 				#shift
+				;;
+			*)
 				;;
 		esac
 	done


### PR DESCRIPTION
This PR fixes a number of bugs when handling newer OpenJDK versions (with date-stamps at the end of the version line) and JDK 9+

Our [continuous integration system](http://bamboo.internal.opennms.com:8085) will test and verify your changes.
