### PR TITLE
NMS-10398: Find out why intial loading of the topology map takes so long

### DIFF
--- a/core/lib/src/main/java/org/opennms/core/utils/PerformanceOptimizedHelper.java
+++ b/core/lib/src/main/java/org/opennms/core/utils/PerformanceOptimizedHelper.java
@@ -1,0 +1,73 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2018 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2018 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.core.utils;
+
+
+/**
+ * class can be deleted once we are happy with the performance improvements
+ * DO NOT MERGE!
+ */
+public class PerformanceOptimizedHelper {
+    public static boolean isPerformanceOptimized() {
+        return Boolean.getBoolean("topologyOptimized");
+    }
+
+    public final static class TimeLogger {
+        private final long start;
+        private String name;
+
+        public TimeLogger() {
+            this("");
+        }
+
+        public TimeLogger(String name) {
+            this.name = name;
+            this.start = System.currentTimeMillis();
+        }
+
+        public void logTimeStop() {
+            System.out.println(getMessage());
+        }
+
+        String getMessage() {
+            StackTraceElement[] stack = Thread.currentThread().getStackTrace();
+            String message = String.format("TimeLogger %s: call to %s took %s ms. Stack: %s::%s::%s",
+                    name,
+                    stack[3].getMethodName(),
+                    System.currentTimeMillis() - start,
+                    print(stack[6]),
+                    print(stack[5]),
+                    print(stack[4]));
+            return message;
+        }
+        private final static String print(StackTraceElement stackTraceElement){
+            return stackTraceElement.getClassName()+"."+stackTraceElement.getMethodName();
+        }
+    }
+}

--- a/core/lib/src/main/java/org/opennms/core/utils/PerformanceOptimizedHelper.java
+++ b/core/lib/src/main/java/org/opennms/core/utils/PerformanceOptimizedHelper.java
@@ -59,7 +59,7 @@ public class PerformanceOptimizedHelper {
             StackTraceElement[] stack = Thread.currentThread().getStackTrace();
             String message = String.format("TimeLogger %s: call to %s took %s ms. Stack: %s::%s::%s",
                     name,
-                    stack[3].getMethodName(),
+                    print(stack[3]),
                     System.currentTimeMillis() - start,
                     print(stack[6]),
                     print(stack[5]),

--- a/features/topology-map/org.opennms.features.topology.app/src/main/java/org/opennms/features/topology/app/internal/DefaultSelectionManager.java
+++ b/features/topology-map/org.opennms.features.topology.app/src/main/java/org/opennms/features/topology/app/internal/DefaultSelectionManager.java
@@ -32,6 +32,7 @@ import java.util.Collection;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
 
+import org.opennms.core.utils.PerformanceOptimizedHelper;
 import org.opennms.features.topology.api.DefaultSelectionContext;
 import org.opennms.features.topology.api.GraphContainer;
 import org.opennms.features.topology.api.SelectionContext;
@@ -137,13 +138,17 @@ public class DefaultSelectionManager implements SelectionManager {
 
 	@Override
 	public void selectionChanged(SelectionContext selectionContext) {
+
 		for(SelectionListener listener : m_listeners) {
 			LoggerFactory.getLogger(this.getClass()).debug("Invoking selectionChanged() on: {}, {}", listener.getClass().getName(), listener);
 			listener.selectionChanged(selectionContext);
 		}
+		PerformanceOptimizedHelper.TimeLogger timer;
 		for(SelectionListener listener : m_addedListeners) {
 			LoggerFactory.getLogger(this.getClass()).debug("Invoking selectionChanged() on: {}, {}", listener.getClass().getName(), listener);
+			timer = new PerformanceOptimizedHelper.TimeLogger(listener.getClass().getName());
 			listener.selectionChanged(selectionContext);
+			timer.logTimeStop();
 		}
 	}
 }

--- a/features/topology-map/org.opennms.features.topology.app/src/main/java/org/opennms/features/topology/app/internal/TopologyComponent.java
+++ b/features/topology-map/org.opennms.features.topology.app/src/main/java/org/opennms/features/topology/app/internal/TopologyComponent.java
@@ -35,6 +35,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
 
+import org.opennms.core.utils.PerformanceOptimizedHelper;
 import org.opennms.features.topology.api.BoundingBox;
 import org.opennms.features.topology.api.Graph;
 import org.opennms.features.topology.api.GraphContainer;
@@ -130,7 +131,9 @@ public class TopologyComponent extends AbstractComponent implements ChangeListen
 
         @Override
         public void vertexClicked(String vertexId, MouseEventDetails eventDetails, String platform) {
+            PerformanceOptimizedHelper.TimeLogger timer = new PerformanceOptimizedHelper.TimeLogger();
             selectVertices(eventDetails.isShiftKey(), eventDetails.isCtrlKey(), vertexId);
+            timer.logTimeStop();
         }
 
         @Override

--- a/features/topology-map/org.opennms.features.topology.app/src/main/java/org/opennms/features/topology/app/internal/TopologyUI.java
+++ b/features/topology-map/org.opennms.features.topology.app/src/main/java/org/opennms/features/topology/app/internal/TopologyUI.java
@@ -234,12 +234,7 @@ public class TopologyUI extends UI implements MenuUpdateListener, ContextMenuHan
                 }
             }
             // we redo the layout before we save the history
-            if(isPerformanceOptimized()){
-                // we do not need to redo the layout here since this method can be called from init() and from
-                // handleRequest(). The init method redoes the layout anyway.
-            } else {
-                m_graphContainer.redoLayout();
-            }
+            m_graphContainer.redoLayout();
             m_topologyComponent.getState().setPhysicalWidth(0);
             m_topologyComponent.getState().setPhysicalHeight(0);
             m_topologyComponent.markAsDirtyRecursive();

--- a/features/topology-map/org.opennms.features.topology.app/src/main/java/org/opennms/features/topology/app/internal/jung/D3TopoLayout.java
+++ b/features/topology-map/org.opennms.features.topology.app/src/main/java/org/opennms/features/topology/app/internal/jung/D3TopoLayout.java
@@ -28,6 +28,8 @@
 
 package org.opennms.features.topology.app.internal.jung;
 
+import static org.opennms.core.utils.PerformanceOptimizedHelper.isPerformanceOptimized;
+
 import java.awt.geom.Point2D;
 import java.util.HashMap;
 import java.util.Map;
@@ -53,10 +55,10 @@ public class D3TopoLayout<V, E> extends AbstractLayout<V, E> implements Iterativ
 
     private double m_alpha = 0.1;
     private Map<V, VertexData> m_vertexData = LazyMap.decorate(new HashMap<V, VertexData>(), new Factory<VertexData>(){
-
+        boolean optimized = isPerformanceOptimized();
         @Override
         public VertexData create() {
-            return new VertexData();
+            return new VertexData(optimized);
         }
     });
 
@@ -340,14 +342,24 @@ public class D3TopoLayout<V, E> extends AbstractLayout<V, E> implements Iterativ
         private double m_strength = LINK_STRENGTH;
         private int m_charge = DEFAULT_CHARGE;
         private Point2D m_previous = null;
+        private final boolean m_optimized;
+
+        VertexData(boolean optimized){
+            m_optimized = optimized;
+        }
 
         protected void offset(double x, double y)
         {
-            String before = this.toString();
-            this.x += x;
-            this.y += y;
-            String after = this.toString();
-            print(before, after);
+            if(m_optimized){
+                this.x += x;
+                this.y += y;
+            } else {
+                String before = this.toString();
+                this.x += x;
+                this.y += y;
+                String after = this.toString();
+                print(before, after);
+            }
         }
         
         protected void offsetPrevious(double x, double y) {
@@ -367,10 +379,15 @@ public class D3TopoLayout<V, E> extends AbstractLayout<V, E> implements Iterativ
 
         @Override
         public void setLocation(double x, double y) {
-            String before = this.toString();
-            super.setLocation(x, y);
-            String after = this.toString();
-            print(before, after);
+            if(m_optimized){
+                super.setLocation(x, y);
+            }
+            else {
+                String before = this.toString();
+                super.setLocation(x, y);
+                String after = this.toString();
+                print(before, after);
+            }
         }
 
         private void print(String before, String after) {
@@ -378,10 +395,14 @@ public class D3TopoLayout<V, E> extends AbstractLayout<V, E> implements Iterativ
 
         @Override
         public void setLocation(Point2D p) {
-            String before = this.toString();
-            super.setLocation(p);
-            String after = this.toString();
-            print(before, after);
+            if(m_optimized){
+                super.setLocation(p);
+            } else {
+                String before = this.toString();
+                super.setLocation(p);
+                String after = this.toString();
+                print(before, after);
+            }
         }
 
         protected double norm()

--- a/features/topology-map/org.opennms.features.topology.app/src/main/java/org/opennms/features/topology/app/internal/jung/D3TopoLayoutAlgorithm.java
+++ b/features/topology-map/org.opennms.features.topology.app/src/main/java/org/opennms/features/topology/app/internal/jung/D3TopoLayoutAlgorithm.java
@@ -33,6 +33,7 @@ import java.util.Collection;
 
 import org.opennms.features.topology.api.Graph;
 import org.opennms.features.topology.api.Layout;
+import org.opennms.core.utils.PerformanceOptimizedHelper;
 import org.opennms.features.topology.api.Point;
 import org.opennms.features.topology.api.topo.Edge;
 import org.opennms.features.topology.api.topo.EdgeRef;
@@ -67,8 +68,10 @@ public class D3TopoLayoutAlgorithm extends AbstractLayoutAlgorithm {
         // Resize the graph to accommodate the number of vertices
         layout.setSize(size);
 
-        while(!layout.done()) {
-            layout.step();
+        if(!(PerformanceOptimizedHelper.isPerformanceOptimized() && vertices.isEmpty())) { // we don't need to do all these steps on an empty layout
+            while(!layout.done()) {
+                layout.step();
+            }
         }
 
         // Store the new positions in the layout

--- a/features/topology-map/org.opennms.features.topology.app/src/main/java/org/opennms/features/topology/app/internal/operations/LayoutOperation.java
+++ b/features/topology-map/org.opennms.features.topology.app/src/main/java/org/opennms/features/topology/app/internal/operations/LayoutOperation.java
@@ -28,6 +28,8 @@
 
 package org.opennms.features.topology.app.internal.operations;
 
+import static org.opennms.core.utils.PerformanceOptimizedHelper.isPerformanceOptimized;
+
 import java.util.List;
 import java.util.Map;
 
@@ -59,7 +61,9 @@ public abstract class LayoutOperation extends AbstractCheckedOperation {
      */
     private void execute(GraphContainer container) {
         container.setLayoutAlgorithm(m_factory.getLayoutAlgorithm());
-        container.redoLayout();
+        if(!isPerformanceOptimized()){
+            container.redoLayout(); // I think we can omit this call since the redoLayout will be called later in init() and uiFragmentChanged
+        }
     }
 
     @Override

--- a/features/topology-map/org.opennms.features.topology.app/src/main/java/org/opennms/features/topology/app/internal/operations/LayoutOperation.java
+++ b/features/topology-map/org.opennms.features.topology.app/src/main/java/org/opennms/features/topology/app/internal/operations/LayoutOperation.java
@@ -61,9 +61,7 @@ public abstract class LayoutOperation extends AbstractCheckedOperation {
      */
     private void execute(GraphContainer container) {
         container.setLayoutAlgorithm(m_factory.getLayoutAlgorithm());
-        if(!isPerformanceOptimized()){
-            container.redoLayout(); // I think we can omit this call since the redoLayout will be called later in init() and uiFragmentChanged
-        }
+        container.redoLayout();
     }
 
     @Override

--- a/features/topology-map/org.opennms.features.topology.app/src/main/java/org/opennms/features/topology/app/internal/service/DefaultGraph.java
+++ b/features/topology-map/org.opennms.features.topology.app/src/main/java/org/opennms/features/topology/app/internal/service/DefaultGraph.java
@@ -32,6 +32,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
 
@@ -162,5 +163,23 @@ public class DefaultGraph implements Graph {
             }
         }
         LOG.debug("Created a graph with {} vertices and {} edges", m_displayVertices.size(), m_displayEdges.size());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        DefaultGraph that = (DefaultGraph) o;
+        return Objects.equals(m_displayVertices, that.m_displayVertices) &&
+                Objects.equals(m_displayEdges, that.m_displayEdges) &&
+                Objects.equals(m_layout, that.m_layout) &&
+                Objects.equals(edgeStatus, that.edgeStatus) &&
+                Objects.equals(vertexStatus, that.vertexStatus);
+    }
+
+    @Override
+    public int hashCode() {
+
+        return Objects.hash(m_displayVertices, m_displayEdges, m_layout, edgeStatus, vertexStatus);
     }
 }

--- a/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.linkd/src/main/java/org/opennms/features/topology/plugins/topo/linkd/internal/LinkdTopologyProvider.java
+++ b/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.linkd/src/main/java/org/opennms/features/topology/plugins/topo/linkd/internal/LinkdTopologyProvider.java
@@ -30,7 +30,6 @@ package org.opennms.features.topology.plugins.topo.linkd.internal;
 
 import java.net.InetAddress;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -40,6 +39,7 @@ import java.util.Set;
 
 import org.apache.commons.lang3.tuple.Pair;
 import org.opennms.core.utils.InetAddressUtils;
+import org.opennms.core.utils.PerformanceOptimizedHelper;
 import org.opennms.features.topology.api.browsers.ContentType;
 import org.opennms.features.topology.api.browsers.SelectionAware;
 import org.opennms.features.topology.api.browsers.SelectionChangedListener;
@@ -215,14 +215,16 @@ public class LinkdTopologyProvider extends AbstractTopologyProvider implements G
     }
     
     private void loadVertices() {
+        PerformanceOptimizedHelper.TimeLogger timer = new PerformanceOptimizedHelper.TimeLogger();
         for (OnmsNode node : m_nodeDao.findAll()) {
             OnmsIpInterface primary = m_nodeToOnmsIpPrimaryMap.get(node.getId());
             addVertices(LinkdVertex.create(node,primary));
         }
+        timer.logTimeStop();
     }
     
     private void loadEdges() {
-
+        PerformanceOptimizedHelper.TimeLogger timer = new PerformanceOptimizedHelper.TimeLogger();
         Timer.Context context = m_loadLldpLinksTimer.time();
         try{
             getLldpLinks();
@@ -272,6 +274,7 @@ public class LinkdTopologyProvider extends AbstractTopologyProvider implements G
         } finally {
             context.stop();
         }
+        timer.logTimeStop();
     }
 
 

--- a/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.linkd/src/main/java/org/opennms/features/topology/plugins/topo/linkd/internal/LinkdTopologyProvider.java
+++ b/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.linkd/src/main/java/org/opennms/features/topology/plugins/topo/linkd/internal/LinkdTopologyProvider.java
@@ -52,6 +52,7 @@ import org.opennms.features.topology.api.topo.VertexRef;
 import org.opennms.netmgt.dao.api.BridgeTopologyDao;
 import org.opennms.netmgt.dao.api.CdpElementDao;
 import org.opennms.netmgt.dao.api.CdpLinkDao;
+import org.opennms.netmgt.dao.api.CdpTopologyInfoCache;
 import org.opennms.netmgt.dao.api.IpInterfaceDao;
 import org.opennms.netmgt.dao.api.IpNetToMediaDao;
 import org.opennms.netmgt.dao.api.IsIsElementDao;
@@ -63,7 +64,7 @@ import org.opennms.netmgt.dao.api.OspfLinkDao;
 import org.opennms.netmgt.dao.api.SnmpInterfaceDao;
 import org.opennms.netmgt.dao.api.TopologyDao;
 import org.opennms.netmgt.model.CdpElement;
-import org.opennms.netmgt.model.CdpLink;
+import org.opennms.netmgt.model.CdpLinkInfo;
 import org.opennms.netmgt.model.FilterManager;
 import org.opennms.netmgt.model.IpNetToMedia;
 import org.opennms.netmgt.model.IsIsElement;
@@ -75,6 +76,7 @@ import org.opennms.netmgt.model.OnmsNode;
 import org.opennms.netmgt.model.OnmsSnmpInterface;
 import org.opennms.netmgt.model.OspfLink;
 import org.opennms.netmgt.model.PrimaryType;
+import org.opennms.netmgt.model.VertexInfo;
 import org.opennms.netmgt.model.topology.BridgePort;
 import org.opennms.netmgt.model.topology.BridgeTopologyException;
 import org.opennms.netmgt.model.topology.BroadcastDomain;
@@ -119,6 +121,7 @@ public class LinkdTopologyProvider extends AbstractTopologyProvider implements G
 
     private TransactionOperations m_transactionOperations;
     private NodeDao m_nodeDao;
+    private CdpTopologyInfoCache m_cdpTopologyInfoCache;
     private SnmpInterfaceDao m_snmpInterfaceDao;
     private IpInterfaceDao m_ipInterfaceDao;
     private TopologyDao m_topologyDao;
@@ -216,9 +219,16 @@ public class LinkdTopologyProvider extends AbstractTopologyProvider implements G
     
     private void loadVertices() {
         PerformanceOptimizedHelper.TimeLogger timer = new PerformanceOptimizedHelper.TimeLogger();
-        for (OnmsNode node : m_nodeDao.findAll()) {
-            OnmsIpInterface primary = m_nodeToOnmsIpPrimaryMap.get(node.getId());
-            addVertices(LinkdVertex.create(node,primary));
+        if(PerformanceOptimizedHelper.isPerformanceOptimized()){
+            for (VertexInfo vertex : m_cdpTopologyInfoCache.getVertices()) {
+                OnmsIpInterface primary = m_nodeToOnmsIpPrimaryMap.get(vertex.getId());
+                addVertices(LinkdVertex.create(vertex,primary));
+            }
+        } else {
+            for (OnmsNode node : m_nodeDao.findAll()) {
+                OnmsIpInterface primary = m_nodeToOnmsIpPrimaryMap.get(node.getId());
+                addVertices(LinkdVertex.create(node,primary));
+            }
         }
         timer.logTimeStop();
     }
@@ -437,26 +447,32 @@ public class LinkdTopologyProvider extends AbstractTopologyProvider implements G
         List<CdpElement> cdpElements = m_cdpElementDao.findAll();
         timerPart.logTimeStop();
         timerPart = new PerformanceOptimizedHelper.TimeLogger("CdpLinkDao.findAll()");
-        List<CdpLink> allLinks = m_cdpLinkDao.findAll();
+        List<CdpLinkInfo> allLinks = m_cdpTopologyInfoCache.getCdpLinkInfos();
         timerPart.logTimeStop();
-        List<Pair<CdpLink, CdpLink>> matchedCdpLinks = matchCdpLinks(cdpElements, allLinks);
+        List<Pair<CdpLinkInfo, CdpLinkInfo>> matchedCdpLinks = matchCdpLinks(cdpElements, allLinks);
         timerPart = new PerformanceOptimizedHelper.TimeLogger("iterate CdpLinkPairs");
-        for(Pair<CdpLink, CdpLink> pair : matchedCdpLinks) {
-            connectCdpLinkPair(pair);
+
+        for (Pair<CdpLinkInfo, CdpLinkInfo> pair : matchedCdpLinks) {
+            try {
+                connectCdpLinkPair(pair);
+            } catch (Exception e) {
+                LOG.error("Problem connectCdpLinkPair edge", e);
+            }
         }
+
         timerPart.logTimeStop();
         timer.logTimeStop();
     }
 
-    private void connectCdpLinkPair(Pair<CdpLink, CdpLink> pair){
-        CdpLink sourceLink = pair.getLeft();
-        CdpLink targetLink = pair.getRight();
-        LinkdVertex source = (LinkdVertex) getVertex(TOPOLOGY_NAMESPACE_LINKD, sourceLink.getNode().getNodeId());
+    private void connectCdpLinkPair(Pair<CdpLinkInfo, CdpLinkInfo> pair){
+        CdpLinkInfo sourceLink = pair.getLeft();
+        CdpLinkInfo targetLink = pair.getRight();
+        LinkdVertex source = (LinkdVertex) getVertex(TOPOLOGY_NAMESPACE_LINKD, sourceLink.getNodeIdAsString());
         source.getProtocolSupported().add(ProtocolSupported.CDP);
-        LinkdVertex target = (LinkdVertex) getVertex(TOPOLOGY_NAMESPACE_LINKD, targetLink.getNode().getNodeId());
+        LinkdVertex target = (LinkdVertex) getVertex(TOPOLOGY_NAMESPACE_LINKD, targetLink.getNodeIdAsString());
         target.getProtocolSupported().add(ProtocolSupported.CDP);
-        OnmsSnmpInterface sourceSnmpInterface = getSnmpInterface(sourceLink.getNode().getId(), sourceLink.getCdpCacheIfIndex());
-        OnmsSnmpInterface targetSnmpInterface = getSnmpInterface(targetLink.getNode().getId(), targetLink.getCdpCacheIfIndex());
+        OnmsSnmpInterface sourceSnmpInterface = getSnmpInterface(sourceLink.getNodeId(), sourceLink.getCdpCacheIfIndex());
+        OnmsSnmpInterface targetSnmpInterface = getSnmpInterface(targetLink.getNodeId(), targetLink.getCdpCacheIfIndex());
         connectVertices(getDefaultEdgeId(sourceLink.getId(), targetLink.getId()),
                 source, target,
                 sourceSnmpInterface, targetSnmpInterface,
@@ -465,35 +481,35 @@ public class LinkdTopologyProvider extends AbstractTopologyProvider implements G
                 ProtocolSupported.CDP);
     }
 
-    List<Pair<CdpLink, CdpLink>> matchCdpLinks(final List<CdpElement> cdpElements, final List<CdpLink> allLinks) {
+    List<Pair<CdpLinkInfo, CdpLinkInfo>> matchCdpLinks(final List<CdpElement> cdpElements, final List<CdpLinkInfo> allLinks) {
         PerformanceOptimizedHelper.TimeLogger timer = new PerformanceOptimizedHelper.TimeLogger();
         // 1. create lookup maps:
         Map<Integer, CdpElement> cdpelementmap = new HashMap<Integer, CdpElement>();
         for (CdpElement cdpelement: cdpElements) {
             cdpelementmap.put(cdpelement.getNode().getId(), cdpelement);
         }
-        Map<CompositeKey, CdpLink> targetLinkMap = new HashMap<>();
-        for (CdpLink targetLink : allLinks) {
+        Map<CompositeKey, CdpLinkInfo> targetLinkMap = new HashMap<>();
+        for (CdpLinkInfo targetLink : allLinks) {
             CompositeKey key = new CompositeKey(targetLink.getCdpCacheDevicePort(),
                     targetLink.getCdpInterfaceName(),
-                    cdpelementmap.get(targetLink.getNode().getId()).getCdpGlobalDeviceId(),
+                    cdpelementmap.get(targetLink.getNodeId()).getCdpGlobalDeviceId(),
                     targetLink.getCdpCacheDeviceId());
             targetLinkMap.put(key, targetLink);
         }
         Set<Integer> parsed = new HashSet<Integer>();
 
         // 2. iterate
-        List<Pair<CdpLink, CdpLink>> results = new ArrayList<>();
-        for (CdpLink sourceLink : allLinks) {
+        List<Pair<CdpLinkInfo, CdpLinkInfo>> results = new ArrayList<>();
+        for (CdpLinkInfo sourceLink : allLinks) {
             if (parsed.contains(sourceLink.getId())) {
                 continue;
             }
             if (LOG.isDebugEnabled()) {
-                LOG.debug("getCdpLinks: source: {} ", sourceLink.printTopology());
+                LOG.debug("getCdpLinks: source: {} ", sourceLink.toString());
             }
-            CdpElement sourceCdpElement = cdpelementmap.get(sourceLink.getNode().getId());
+            CdpElement sourceCdpElement = cdpelementmap.get(sourceLink.getNodeId());
 
-            CdpLink targetLink = targetLinkMap.get(new CompositeKey(sourceLink.getCdpInterfaceName(),
+            CdpLinkInfo targetLink = targetLinkMap.get(new CompositeKey(sourceLink.getCdpInterfaceName(),
                     sourceLink.getCdpCacheDevicePort(),
                     sourceLink.getCdpCacheDeviceId(),
                     sourceCdpElement.getCdpGlobalDeviceId()));
@@ -508,7 +524,7 @@ public class LinkdTopologyProvider extends AbstractTopologyProvider implements G
             }
 
             if (LOG.isDebugEnabled()) {
-                LOG.debug("getCdpLinks: cdp: {}, target: {} ", sourceLink.getCdpCacheDevicePort(), targetLink.printTopology());
+                LOG.debug("getCdpLinks: cdp: {}, target: {} ", sourceLink.getCdpCacheDevicePort(), targetLink.toString());
             }
 
             parsed.add(sourceLink.getId());
@@ -755,6 +771,14 @@ public class LinkdTopologyProvider extends AbstractTopologyProvider implements G
 
     public void setNodeDao(NodeDao nodeDao) {
         m_nodeDao = nodeDao;
+    }
+
+    public CdpTopologyInfoCache getCdpTopologyInfoCache() {
+        return m_cdpTopologyInfoCache;
+    }
+
+    public void setCdpTopologyInfoCache(CdpTopologyInfoCache cdpTopologyInfoCache) {
+        m_cdpTopologyInfoCache = cdpTopologyInfoCache;
     }
 
     public void setIpInterfaceDao(IpInterfaceDao ipInterfaceDao) {

--- a/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.linkd/src/main/java/org/opennms/features/topology/plugins/topo/linkd/internal/LinkdVertex.java
+++ b/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.linkd/src/main/java/org/opennms/features/topology/plugins/topo/linkd/internal/LinkdVertex.java
@@ -35,6 +35,7 @@ import java.util.Set;
 import org.opennms.core.utils.InetAddressUtils;
 import org.opennms.features.topology.api.topo.SimpleLeafVertex;
 import org.opennms.features.topology.plugins.topo.linkd.internal.LinkdTopologyProvider.ProtocolSupported;
+import org.opennms.netmgt.model.VertexInfo;
 import org.opennms.netmgt.model.OnmsIpInterface;
 import org.opennms.netmgt.model.OnmsNode;
 
@@ -60,6 +61,26 @@ public class LinkdVertex extends SimpleLeafVertex {
         vertex.setSysObjectId(node.getSysObjectId());
         if (node.getLocation() != null) {
             vertex.setLocation(node.getLocation().getLocationName());
+        }
+        vertex.setIpAddress("no ip address");
+        if (primary != null) {
+            vertex.setIpAddress(InetAddressUtils.str(primary.getIpAddress()));
+        }
+        vertex.setManaged("Unmanaged");
+        if (primary != null && primary.isManaged()) {
+            vertex.setManaged("Managed");
+        }
+        return vertex;
+    }
+
+    public static LinkdVertex create(VertexInfo node, OnmsIpInterface primary) {
+        LinkdVertex vertex = new LinkdVertex(node.getId().toString());
+        vertex.setNodeID(node.getId());
+        vertex.setLabel(node.getLabel());
+        vertex.setNodeType(s_nodeStatusMap.get(node.getType()));
+        vertex.setSysObjectId(node.getSysObjectId());
+        if (node.getLocation() != null) {
+            vertex.setLocation(node.getLocation());
         }
         vertex.setIpAddress("no ip address");
         if (primary != null) {
@@ -117,9 +138,13 @@ public class LinkdVertex extends SimpleLeafVertex {
     }
 
     private LinkdVertex(OnmsNode node) {
-        super(LinkdTopologyProvider.TOPOLOGY_NAMESPACE_LINKD, node.getNodeId(), 0, 0);
+        this(node.getNodeId());
     }
-    
+
+    private LinkdVertex(String id) {
+        super(LinkdTopologyProvider.TOPOLOGY_NAMESPACE_LINKD, id, 0, 0);
+    }
+
     @Override
     public String getIconKey() {
         if (m_sysObjectId == null) {

--- a/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.linkd/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.linkd/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -11,6 +11,7 @@ xsi:schemaLocation="http://www.osgi.org/xmlns/blueprint/v1.0.0
     <reference id="transactionOperations" interface="org.springframework.transaction.support.TransactionOperations" availability="mandatory" />
 
     <reference id="nodeDao" interface="org.opennms.netmgt.dao.api.NodeDao" availability="mandatory" />
+    <reference id="cdpTopologyInfoCache" interface="org.opennms.netmgt.dao.api.CdpTopologyInfoCache" availability="mandatory" />
     <reference id="ipInterfaceDao" interface="org.opennms.netmgt.dao.api.IpInterfaceDao" availability="mandatory" />
     <reference id="snmpInterfaceDao" interface="org.opennms.netmgt.dao.api.SnmpInterfaceDao" availability="mandatory" />
     <reference id="lldpLinkDao" interface="org.opennms.netmgt.dao.api.LldpLinkDao" availability="mandatory" />
@@ -54,6 +55,7 @@ xsi:schemaLocation="http://www.osgi.org/xmlns/blueprint/v1.0.0
         <argument ref="metricRegistry" />
         <property name="transactionOperations" ref="transactionOperations"/>
         <property name="nodeDao" ref="nodeDao" />
+        <property name="cdpTopologyInfoCache" ref="cdpTopologyInfoCache" />
         <property name="snmpInterfaceDao" ref="snmpInterfaceDao" />
         <property name="ipInterfaceDao" ref="ipInterfaceDao" />
         <property name="filterManager" ref="filterManager" />

--- a/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.linkd/src/test/resources/META-INF/opennms/applicationContext-enhanced-mock.xml
+++ b/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.linkd/src/test/resources/META-INF/opennms/applicationContext-enhanced-mock.xml
@@ -39,6 +39,10 @@
         <constructor-arg value="org.opennms.netmgt.dao.api.NodeDao"/>
     </bean>
 
+    <bean class="org.easymock.EasyMock" factory-method="createNiceMock" primary="true" id="cdpTopologyInfoCache">
+        <constructor-arg value="org.opennms.netmgt.dao.api.CdpTopologyInfoCache"/>
+    </bean>
+
     <bean class="org.easymock.EasyMock" factory-method="createNiceMock" primary="true" id="snmpInterfaceDao">
         <constructor-arg value="org.opennms.netmgt.dao.api.SnmpInterfaceDao"/>
     </bean>
@@ -75,6 +79,7 @@
         <property name="lldpElementDao" ref="lldpElementDao" />
         <property name="ospfLinkDao" ref="ospfLinkDao" />
         <property name="nodeDao" ref="nodeDao" />
+        <property name="cdpTopologyInfoCache" ref="cdpTopologyInfoCache" />
         <property name="snmpInterfaceDao" ref="snmpInterfaceDao" />
         <property name="ipInterfaceDao" ref="ipInterfaceDao" />
         <property name="ipNetToMediaDao" ref="ipNetToMediaDao" />

--- a/opennms-base-assembly/src/main/filtered/etc/opennms.properties
+++ b/opennms-base-assembly/src/main/filtered/etc/opennms.properties
@@ -5,6 +5,9 @@
 # with -Dproperty=value will be overridden by these values.
 #
 
+# to switch the performance optimizations on and off
+topologyOptimized=true
+
 # ###### ICMP ######
 # OpenNMS provides three ICMP implementations. JICMP (legacy, IPv4-only),
 # JNA (supports both IPv4 and IPv6), and JICMP6.

--- a/opennms-dao-api/src/main/java/org/opennms/netmgt/dao/api/CdpTopologyInfoCache.java
+++ b/opennms-dao-api/src/main/java/org/opennms/netmgt/dao/api/CdpTopologyInfoCache.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2018 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2018 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.dao.api;
+
+import java.util.List;
+
+import org.opennms.netmgt.model.CdpLinkInfo;
+import org.opennms.netmgt.model.VertexInfo;
+
+public interface CdpTopologyInfoCache {
+
+    List<VertexInfo> getVertices();
+
+    List<CdpLinkInfo> getCdpLinkInfos();
+
+}

--- a/opennms-dao-api/src/main/java/org/opennms/netmgt/dao/api/CdpTopologyInfoDao.java
+++ b/opennms-dao-api/src/main/java/org/opennms/netmgt/dao/api/CdpTopologyInfoDao.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2018 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2018 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.dao.api;
+
+import java.util.List;
+
+import org.opennms.netmgt.model.CdpLinkInfo;
+import org.opennms.netmgt.model.VertexInfo;
+
+public interface CdpTopologyInfoDao {
+    List<VertexInfo> getVertexInfos();
+    List<CdpLinkInfo> getCdpLinkInfo();
+}

--- a/opennms-dao/src/main/java/org/opennms/netmgt/dao/DatabasePopulator.java
+++ b/opennms-dao/src/main/java/org/opennms/netmgt/dao/DatabasePopulator.java
@@ -40,6 +40,7 @@ import org.opennms.netmgt.dao.api.AcknowledgmentDao;
 import org.opennms.netmgt.dao.api.AlarmDao;
 import org.opennms.netmgt.dao.api.AssetRecordDao;
 import org.opennms.netmgt.dao.api.CategoryDao;
+import org.opennms.netmgt.dao.api.CdpLinkDao;
 import org.opennms.netmgt.dao.api.DistPollerDao;
 import org.opennms.netmgt.dao.api.EventDao;
 import org.opennms.netmgt.dao.api.IpInterfaceDao;
@@ -55,6 +56,7 @@ import org.opennms.netmgt.dao.api.SnmpInterfaceDao;
 import org.opennms.netmgt.dao.api.UserNotificationDao;
 import org.opennms.netmgt.model.AckAction;
 import org.opennms.netmgt.model.AckType;
+import org.opennms.netmgt.model.CdpLink;
 import org.opennms.netmgt.model.NetworkBuilder;
 import org.opennms.netmgt.model.OnmsAcknowledgment;
 import org.opennms.netmgt.model.OnmsAlarm;
@@ -153,6 +155,7 @@ public class DatabasePopulator {
     private LocationMonitorDao m_locationMonitorDao;
     private AcknowledgmentDao m_acknowledgmentDao;
     private TransactionOperations m_transOperation;
+    private CdpLinkDao m_cdpLinkDao;
     
     private OnmsNode m_node1;
     private OnmsNode m_node2;
@@ -262,6 +265,9 @@ public class DatabasePopulator {
             iface.getNode().getIpInterfaces().remove(iface);
             m_ipInterfaceDao.delete(iface);
         }
+        for (final CdpLink link : m_cdpLinkDao.findAll()) {
+            m_cdpLinkDao.delete(link);
+        }
         for (final OnmsNode node : m_nodeDao.findAll()) {
             m_nodeDao.delete(node);
         }
@@ -298,6 +304,7 @@ public class DatabasePopulator {
         m_snmpInterfaceDao.flush();
         m_ipInterfaceDao.flush();
         m_nodeDao.flush();
+        m_cdpLinkDao.flush();
         m_serviceTypeDao.flush();
         
         LOG.debug("==== DatabasePopulator Reset Finished ====");
@@ -336,7 +343,11 @@ public class DatabasePopulator {
         getNodeDao().save(node6);
         getNodeDao().flush();
         setNode6(node6);
-        
+
+        CdpLink cdpLink = createCdpLink();
+        getCdpLinkDao().save(cdpLink);
+        getCdpLinkDao().flush();
+
         final OnmsEvent event = buildEvent(builder.getDistPoller());
         event.setEventCreateTime(new Date(1436881548292L));
         event.setEventTime(new Date(1436881548292L));
@@ -404,6 +415,22 @@ public class DatabasePopulator {
         LOG.debug("= DatabasePopulatorExtension Populate Finished =");
         
         LOG.debug("==== DatabasePopulator Finished ====");
+    }
+
+    private CdpLink createCdpLink() {
+        CdpLink link = new CdpLink();
+        link.setNode(getNode1());
+        link.setCdpCacheDeviceId("cdpCacheDeviceId");
+        link.setCdpInterfaceName("cdpInterfaceName");
+        link.setCdpCacheDevicePort("cdpCacheDevicePort");
+        link.setCdpCacheAddressType(CdpLink.CiscoNetworkProtocolType.chaos);
+        link.setCdpCacheAddress("CdpCacheAddress");
+        link.setCdpCacheDeviceIndex(33);
+        link.setCdpCacheDevicePlatform("CdpCacheDevicePlatform");
+        link.setCdpCacheIfIndex(33);
+        link.setCdpCacheVersion("CdpCacheVersion");
+        link.setCdpLinkLastPollTime(new Date());
+        return link;
     }
 
     private OnmsCategory getCategory(final String categoryName) {
@@ -690,6 +717,14 @@ public class DatabasePopulator {
         m_nodeDao = nodeDao;
     }
 
+    public CdpLinkDao getCdpLinkDao() {
+        return m_cdpLinkDao;
+    }
+
+
+    public void setCdpLinkDao(final CdpLinkDao cdpLinkDao) {
+        this.m_cdpLinkDao = cdpLinkDao;
+    }
 
     public NotificationDao getNotificationDao() {
         return m_notificationDao;

--- a/opennms-dao/src/main/java/org/opennms/netmgt/dao/hibernate/CdpTopologyInfoCacheImpl.java
+++ b/opennms-dao/src/main/java/org/opennms/netmgt/dao/hibernate/CdpTopologyInfoCacheImpl.java
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2018 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2018 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.dao.hibernate;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.opennms.netmgt.dao.api.CdpTopologyInfoDao;
+import org.opennms.netmgt.dao.api.CdpTopologyInfoCache;
+import org.opennms.netmgt.model.CdpLinkInfo;
+import org.opennms.netmgt.model.VertexInfo;
+
+public class CdpTopologyInfoCacheImpl implements CdpTopologyInfoCache {
+
+    private List<VertexInfo> vertices;
+    private List<CdpLinkInfo> cdpLinks;
+
+    private CdpTopologyInfoDao cdpTopologyInfoDao;
+
+    public void refresh(){
+        this.vertices = Collections.unmodifiableList(cdpTopologyInfoDao.getVertexInfos());
+        this.cdpLinks = Collections.unmodifiableList(cdpTopologyInfoDao.getCdpLinkInfo());
+    }
+
+    public List<VertexInfo> getVertices(){
+        return vertices;
+    }
+
+    public void setCdpTopologyInfoDao(CdpTopologyInfoDao cdpTopologyInfoDao){
+        this.cdpTopologyInfoDao = cdpTopologyInfoDao;
+    }
+
+    public List<CdpLinkInfo> getCdpLinkInfos(){
+        return cdpLinks;
+    }
+}

--- a/opennms-dao/src/main/java/org/opennms/netmgt/dao/hibernate/CdpTopologyInfoDaoHibernate.java
+++ b/opennms-dao/src/main/java/org/opennms/netmgt/dao/hibernate/CdpTopologyInfoDaoHibernate.java
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2018 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2018 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.dao.hibernate;
+
+import java.util.List;
+
+import org.opennms.netmgt.dao.api.CdpTopologyInfoDao;
+import org.opennms.netmgt.model.CdpLinkInfo;
+import org.opennms.netmgt.model.VertexInfo;
+import org.springframework.orm.hibernate3.support.HibernateDaoSupport;
+
+public class CdpTopologyInfoDaoHibernate extends HibernateDaoSupport implements CdpTopologyInfoDao {
+
+    @Override
+    public List<VertexInfo> getVertexInfos() {
+        return (List<VertexInfo>)getHibernateTemplate().find(
+                "select new org.opennms.netmgt.model.VertexInfo(n.id, n.type, n.sysObjectId, n.label, n.location) from org.opennms.netmgt.model.OnmsNode n");
+    }
+
+    @Override
+    public List<CdpLinkInfo> getCdpLinkInfo() {
+        return (List<CdpLinkInfo>)getHibernateTemplate().find(
+                "select new org.opennms.netmgt.model.CdpLinkInfo(l.id, l.node.id, l.cdpCacheIfIndex, " +
+                        "l.cdpInterfaceName, l.cdpCacheAddress, l.cdpCacheDeviceId, l.cdpCacheDevicePort) from org.opennms.netmgt.model.CdpLink l");
+    }
+}

--- a/opennms-dao/src/main/java/org/opennms/netmgt/dao/hibernate/NodeDaoHibernate.java
+++ b/opennms-dao/src/main/java/org/opennms/netmgt/dao/hibernate/NodeDaoHibernate.java
@@ -427,7 +427,7 @@ public class NodeDaoHibernate extends AbstractDaoHibernate<OnmsNode, Integer> im
     }
 
     Supplier<List<OnmsNode>> onmsNodes = Suppliers.memoizeWithExpiration(
-            ()-> find("from OnmsNode order by label"), 5, TimeUnit.MINUTES);
+            ()-> find("from OnmsNode order by label"), 15, TimeUnit.MINUTES);
 
     /**
      * <p>findAllProvisionedNodes</p>

--- a/opennms-dao/src/main/java/org/opennms/netmgt/dao/hibernate/NodeDaoHibernate.java
+++ b/opennms-dao/src/main/java/org/opennms/netmgt/dao/hibernate/NodeDaoHibernate.java
@@ -41,7 +41,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
-import java.util.concurrent.TimeUnit;
 
 import org.hibernate.HibernateException;
 import org.hibernate.Session;
@@ -64,9 +63,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.orm.hibernate3.HibernateCallback;
 import org.springframework.util.StringUtils;
-
-import com.google.common.base.Supplier;
-import com.google.common.base.Suppliers;
 
 /**
  * <p>NodeDaoHibernate class.</p>
@@ -414,20 +410,10 @@ public class NodeDaoHibernate extends AbstractDaoHibernate<OnmsNode, Integer> im
     @Override
     public List<OnmsNode> findAll() {
         PerformanceOptimizedHelper.TimeLogger timer = new PerformanceOptimizedHelper.TimeLogger();
-        List<OnmsNode> result;
-        if (PerformanceOptimizedHelper.isPerformanceOptimized()) {
-            // use some caching, before putting in production we need to make sure the list ist not modifiable.
-            // Unfortunately OnmsNode is :-/
-            result = onmsNodes.get();
-        } else {
-            result = find("from OnmsNode order by label");
-        }
+        List<OnmsNode> result = find("from OnmsNode order by label");
         timer.logTimeStop();
         return result;
     }
-
-    Supplier<List<OnmsNode>> onmsNodes = Suppliers.memoizeWithExpiration(
-            ()-> find("from OnmsNode order by label"), 15, TimeUnit.MINUTES);
 
     /**
      * <p>findAllProvisionedNodes</p>

--- a/opennms-dao/src/main/resources/META-INF/opennms/applicationContext-dao.xml
+++ b/opennms-dao/src/main/resources/META-INF/opennms/applicationContext-dao.xml
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="http://www.springframework.org/schema/beans" 
+<beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:cache="http://www.springframework.org/schema/cache"
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:tx="http://www.springframework.org/schema/tx"
        xmlns:util="http://www.springframework.org/schema/util"
        xmlns:onmsgi="http://xmlns.opennms.org/xsd/spring/onms-osgi"
+       xmlns:task="http://www.springframework.org/schema/task"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.2.xsd
        http://www.springframework.org/schema/cache http://www.springframework.org/schema/cache/spring-cache-4.2.xsd
        http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.2.xsd
        http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.2.xsd
        http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.2.xsd
-       http://xmlns.opennms.org/xsd/spring/onms-osgi http://xmlns.opennms.org/xsd/spring/onms-osgi.xsd
-       ">
+       http://xmlns.opennms.org/xsd/spring/onms-osgi http://xmlns.opennms.org/xsd/spring/onms-osgi.xsd http://www.springframework.org/schema/task http://www.springframework.org/schema/task/spring-task.xsd">
 
   <context:annotation-config />
   <cache:annotation-driven />
@@ -322,6 +322,24 @@
   </bean>
   
   <onmsgi:service interface="org.opennms.netmgt.dao.api.NodeDao" ref="nodeDao" />
+
+  <bean id="cdpTopologyInfoDao" class="org.opennms.netmgt.dao.hibernate.CdpTopologyInfoDaoHibernate">
+    <property name="sessionFactory" ref="sessionFactory" />
+  </bean>
+
+  <onmsgi:service interface="org.opennms.netmgt.dao.api.CdpTopologyInfoDao" ref="cdpTopologyInfoDao" />
+
+  <bean id="cdpTopologyInfoCache" class="org.opennms.netmgt.dao.hibernate.CdpTopologyInfoCacheImpl">
+    <property name="cdpTopologyInfoDao" ref="cdpTopologyInfoDao" />
+  </bean>
+
+  <onmsgi:service interface="org.opennms.netmgt.dao.api.CdpTopologyInfoCache" ref="cdpTopologyInfoCache" />
+
+  <task:scheduled-tasks scheduler="topologyRefresherScheduler">
+    <task:scheduled ref="cdpTopologyInfoCache" method="refresh" fixed-delay="300000"/>
+  </task:scheduled-tasks>
+
+  <task:scheduler id="topologyRefresherScheduler" pool-size="1"/>
 
   <bean id="nodeLabel" class="org.opennms.netmgt.dao.hibernate.NodeLabelDaoImpl"/>
   

--- a/opennms-dao/src/main/resources/META-INF/opennms/applicationContext-databasePopulator.xml
+++ b/opennms-dao/src/main/resources/META-INF/opennms/applicationContext-databasePopulator.xml
@@ -10,6 +10,7 @@
 		<property name="transactionTemplate" ref="transactionTemplate" />
 		<property name="distPollerDao" ref="distPollerDao" />
 		<property name="nodeDao" ref="nodeDao" />
+		<property name="cdpLinkDao" ref="cdpLinkDao" />
 		<property name="ipInterfaceDao" ref="ipInterfaceDao" />
 		<property name="snmpInterfaceDao" ref="snmpInterfaceDao" />
 		<property name="monitoredServiceDao" ref="monitoredServiceDao" />

--- a/opennms-dao/src/test/java/org/opennms/netmgt/dao/hibernate/CdpTopologyInfoDaoHibernateIT.java
+++ b/opennms-dao/src/test/java/org/opennms/netmgt/dao/hibernate/CdpTopologyInfoDaoHibernateIT.java
@@ -1,0 +1,104 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2002-2014 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+
+package org.opennms.netmgt.dao.hibernate;
+
+import static org.junit.Assert.*;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.opennms.core.test.OpenNMSJUnit4ClassRunner;
+import org.opennms.core.test.db.annotations.JUnitTemporaryDatabase;
+import org.opennms.netmgt.dao.DatabasePopulator;
+import org.opennms.netmgt.dao.api.CdpTopologyInfoDao;
+import org.opennms.netmgt.model.CdpLinkInfo;
+import org.opennms.netmgt.model.VertexInfo;
+import org.opennms.test.JUnitConfigurationEnvironment;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.transaction.AfterTransaction;
+import org.springframework.test.context.transaction.BeforeTransaction;
+import org.springframework.transaction.annotation.Transactional;
+
+@RunWith(OpenNMSJUnit4ClassRunner.class)
+@ContextConfiguration(locations={
+        "classpath:/META-INF/opennms/applicationContext-soa.xml",
+        "classpath:/META-INF/opennms/applicationContext-dao.xml",
+        "classpath:/META-INF/opennms/applicationContext-databasePopulator.xml",
+        "classpath*:/META-INF/opennms/component-dao.xml",
+        "classpath:/META-INF/opennms/applicationContext-commonConfigs.xml",
+        "classpath:/META-INF/opennms/applicationContext-minimal-conf.xml"
+})
+@JUnitConfigurationEnvironment
+@JUnitTemporaryDatabase
+public class CdpTopologyInfoDaoHibernateIT {
+    @Autowired
+    private CdpTopologyInfoDao cdpTopologyInfoDao;
+
+    @Autowired
+    private DatabasePopulator populator;
+
+    @BeforeTransaction
+    public void setUp() {
+        populator.populateDatabase();
+    }
+
+    @AfterTransaction
+    public void tearDown() {
+        populator.resetDatabase();
+    }
+
+    @Test
+    @Transactional
+    public void testGetAllVertices() {
+        List<VertexInfo> vertices = this.cdpTopologyInfoDao.getVertexInfos();
+        Assert.assertNotNull(vertices);
+        Assert.assertFalse(vertices.isEmpty());
+        VertexInfo vertex = vertices.get(0);
+        assertNotNull(vertex.getId());
+        assertFalse(vertex.getLocation().trim().isEmpty());
+        assertFalse(vertex.getLabel().trim().isEmpty());
+        assertNotNull(vertex.getType());
+    }
+
+    @Test
+    @Transactional
+    public void testGetAllCdpLinkInfos() {
+        List<CdpLinkInfo> cdpLinks = this.cdpTopologyInfoDao.getCdpLinkInfo();
+        Assert.assertNotNull(cdpLinks);
+        Assert.assertFalse(cdpLinks.isEmpty());
+        CdpLinkInfo info = cdpLinks.get(0);
+        assertNotNull(info.getId());
+        assertNotNull(info.getNodeId());
+    }
+
+}

--- a/opennms-model/src/main/java/org/opennms/netmgt/model/CdpLinkInfo.java
+++ b/opennms-model/src/main/java/org/opennms/netmgt/model/CdpLinkInfo.java
@@ -1,0 +1,121 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2018 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2018 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.model;
+
+import java.util.Objects;
+
+public class CdpLinkInfo {
+
+    private final Integer id;
+    private final Integer nodeId;
+    private final Integer cdpCacheIfIndex;
+    private final String cdpInterfaceName;
+    private final String cdpCacheAddress;
+    private final String cdpCacheDeviceId;
+    private final String cdpCacheDevicePort;
+
+    public CdpLinkInfo(Integer id, Integer nodeId, Integer cdpCacheIfIndex, String cdpInterfaceName, String cdpCacheAddress,
+                       String cdpCacheDeviceId, String cdpCacheDevicePort){
+        this.id = id;
+        this.nodeId = nodeId;
+        this.cdpCacheIfIndex = cdpCacheIfIndex;
+        this.cdpInterfaceName = cdpInterfaceName;
+        this.cdpCacheAddress = cdpCacheAddress;
+        this.cdpCacheDeviceId = cdpCacheDeviceId;
+        this.cdpCacheDevicePort = cdpCacheDevicePort;
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public Integer getNodeId() {
+        return nodeId;
+    }
+
+    public String getNodeIdAsString() {
+        if (getNodeId() != null) {
+            return getNodeId().toString();
+        }
+        return null;
+    }
+
+    public Integer getCdpCacheIfIndex() {
+        return cdpCacheIfIndex;
+    }
+
+    public String getCdpInterfaceName() {
+        return cdpInterfaceName;
+    }
+
+    public String getCdpCacheAddress() {
+        return cdpCacheAddress;
+    }
+
+    public String getCdpCacheDevicePort() {
+        return cdpCacheDevicePort;
+    }
+
+    public String getCdpCacheDeviceId() {
+        return cdpCacheDeviceId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        CdpLinkInfo that = (CdpLinkInfo) o;
+        return Objects.equals(id, that.id) &&
+                Objects.equals(nodeId, that.nodeId) &&
+                Objects.equals(cdpCacheIfIndex, that.cdpCacheIfIndex) &&
+                Objects.equals(cdpInterfaceName, that.cdpInterfaceName) &&
+                Objects.equals(cdpCacheAddress, that.cdpCacheAddress) &&
+                Objects.equals(cdpCacheDeviceId, that.cdpCacheDeviceId) &&
+                Objects.equals(cdpCacheDevicePort, that.cdpCacheDevicePort);
+    }
+
+    @Override
+    public int hashCode() {
+
+        return Objects.hash(id, nodeId, cdpCacheIfIndex, cdpInterfaceName, cdpCacheAddress, cdpCacheDeviceId, cdpCacheDevicePort);
+    }
+
+    @Override
+    public String toString() {
+        return "CdpLinkInfo{" +
+                "id=" + id +
+                ", nodeId=" + nodeId +
+                ", cdpCacheIfIndex=" + cdpCacheIfIndex +
+                ", cdpInterfaceName='" + cdpInterfaceName + '\'' +
+                ", cdpCacheAddress='" + cdpCacheAddress + '\'' +
+                ", cdpCacheDeviceId='" + cdpCacheDeviceId + '\'' +
+                ", cdpCacheDevicePort='" + cdpCacheDevicePort + '\'' +
+                '}';
+    }
+}

--- a/opennms-model/src/main/java/org/opennms/netmgt/model/VertexInfo.java
+++ b/opennms-model/src/main/java/org/opennms/netmgt/model/VertexInfo.java
@@ -1,0 +1,107 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2018 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2018 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.model;
+
+import java.util.Objects;
+
+import org.opennms.netmgt.model.monitoringLocations.OnmsMonitoringLocation;
+
+public class VertexInfo {
+
+    private Integer id;
+    private OnmsNode.NodeType type;
+    private String sysObjectId;
+    private String label;
+    private String location;
+
+    public VertexInfo(Integer nodeid, OnmsNode.NodeType nodetype, String nodesysoid, String nodelabel, String location){
+        this.id = nodeid;
+        this.type = nodetype;
+        this.sysObjectId = nodesysoid;
+        this.label = nodelabel;
+        this.location = location;
+    }
+
+    public VertexInfo(Integer id, OnmsNode.NodeType type, String sysObjectId, String label, OnmsMonitoringLocation location){
+        this(id, type, sysObjectId, label, location.getLocationName());
+    }
+
+
+    public Integer getId() {
+        return id;
+    }
+
+    public OnmsNode.NodeType getType() {
+        return type;
+    }
+
+
+    public String getSysObjectId() {
+        return sysObjectId;
+    }
+
+
+    public String getLabel() {
+        return label;
+    }
+
+
+    public String getLocation() {
+        return location;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        VertexInfo that = (VertexInfo) o;
+        return Objects.equals(id, that.id) &&
+                type == that.type &&
+                Objects.equals(sysObjectId, that.sysObjectId) &&
+                Objects.equals(label, that.label) &&
+                Objects.equals(location, that.location);
+    }
+
+    @Override
+    public int hashCode() {
+
+        return Objects.hash(id, type, sysObjectId, label, location);
+    }
+
+    @Override
+    public String toString() {
+        return "VertexInfo{" +
+                "id=" + id +
+                ", type=" + type +
+                ", sysObjectId='" + sysObjectId + '\'' +
+                ", label='" + label + '\'' +
+                ", location=" + location +
+                '}';
+    }
+}


### PR DESCRIPTION
* JIRA: https://issues.opennms.org/browse/NMS-10398

Our [continuous integration system](http://bamboo.internal.opennms.com:8085) will test and verify your changes.

This branch is to measure the initial loading time of the topology map and to test improvements.
It can't be merged!

In order to get a big topology into the database you can use the topology generator: https://github.com/opennms-forge/opennms-topology-generator
The improvements can be toggled on and off via the property topologyOptimized=true in opennms.properties: 

To see the performance logs do a:
grep -rnw './target/opennms-21.1.0-SNAPSHOT/logs' -e 'TimeLogger'

I was able to cut the loading time from ~23 seconds to ~10 seconds on 10,000 vertices and 20,000 links (=10,000 edges) for the initial loading with no node selected and D3 layout.

Findings:
* loading of all nodes takes up a considerable amount of time. This is probably the biggest leverage we have. It takes about 20 seconds to load 40.000 nodes on my machine.
* the same operations are done multiple times (e.g. layout operations): I made some changes so that the layout is done only once during init

Examples of performance: I tested the following:
random topology with 40000 OnmsNodes, 40000 CdpElements and 80000 CdpLinks

1. load toplogy map initially: no history present
2. reboot system, load topology map again (this time it has a history)
The findings are the following:

No optimization:
1. call to init method took 48640 ms
2. call to init method took 69028 ms
Optimized:
1. call to init method took 31692 ms
2. call to init method took 28551 ms

Full logs:
Not optimized (without history):
patrick@krassomat:/apps/git/opennms_foundation_2017$ grep -rnw './target/opennms-21.1.0-SNAPSHOT/logs' -e 'TimeLogger'
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:47:TimeLogger : call to findAll took 20136 ms. Stack: sun.reflect.NativeMethodAccessorImpl.invoke::sun.reflect.NativeMethodAccessorImpl.invoke0::org.opennms.netmgt.provision.service.DefaultProvisionService.getScheduleForNodes
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:76:TimeLogger init 1: call to init took 114 ms. Stack: com.vaadin.server.communication.UIInitHandler.synchronizedHandleRequest::com.vaadin.server.communication.UIInitHandler.getBrowserDetailsUI::com.vaadin.ui.UI.doInit
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:77:TimeLogger : call to createLayouts took 1121 ms. Stack: com.vaadin.server.communication.UIInitHandler.getBrowserDetailsUI::com.vaadin.ui.UI.doInit::org.opennms.features.topology.app.internal.TopologyUI.init
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:78:TimeLogger org.opennms.features.topology.app.internal.TopologyComponent: org.opennms.features.topology.app.internal.TopologyComponent@1eb80e94: call to fireGraphChanged took 1 ms. Stack: org.opennms.features.topology.app.internal.TopologyUI.init::org.opennms.features.topology.app.internal.TopologyUI.loadUserSettings::org.opennms.features.topology.app.internal.VEProviderGraphContainer.redoLayout
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:79:TimeLogger org.opennms.features.topology.plugins.browsers.AlarmTable: null: call to fireGraphChanged took 38 ms. Stack: org.opennms.features.topology.app.internal.TopologyUI.init::org.opennms.features.topology.app.internal.TopologyUI.loadUserSettings::org.opennms.features.topology.app.internal.VEProviderGraphContainer.redoLayout
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:80:TimeLogger org.opennms.features.topology.plugins.topo.application.browsers.ApplicationTable: null: call to fireGraphChanged took 20 ms. Stack: org.opennms.features.topology.app.internal.TopologyUI.init::org.opennms.features.topology.app.internal.TopologyUI.loadUserSettings::org.opennms.features.topology.app.internal.VEProviderGraphContainer.redoLayout
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:81:TimeLogger org.opennms.features.topology.plugins.topo.bsm.browsers.BusinessServicesTable: null: call to fireGraphChanged took 43 ms. Stack: org.opennms.features.topology.app.internal.TopologyUI.init::org.opennms.features.topology.app.internal.TopologyUI.loadUserSettings::org.opennms.features.topology.app.internal.VEProviderGraphContainer.redoLayout
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:82:TimeLogger org.opennms.features.topology.plugins.browsers.NodeTable: null: call to fireGraphChanged took 57 ms. Stack: org.opennms.features.topology.app.internal.TopologyUI.init::org.opennms.features.topology.app.internal.TopologyUI.loadUserSettings::org.opennms.features.topology.app.internal.VEProviderGraphContainer.redoLayout
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:83:TimeLogger : call to redoLayout took 170 ms. Stack: com.vaadin.ui.UI.doInit::org.opennms.features.topology.app.internal.TopologyUI.init::org.opennms.features.topology.app.internal.TopologyUI.loadUserSettings
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:84:TimeLogger : call to loadUserSettings took 173 ms. Stack: com.vaadin.server.communication.UIInitHandler.getBrowserDetailsUI::com.vaadin.ui.UI.doInit::org.opennms.features.topology.app.internal.TopologyUI.init
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:85:TimeLogger init 2: call to init took 1299 ms. Stack: com.vaadin.server.communication.UIInitHandler.synchronizedHandleRequest::com.vaadin.server.communication.UIInitHandler.getBrowserDetailsUI::com.vaadin.ui.UI.doInit
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:86:TimeLogger init 3.1: call to init took 1 ms. Stack: com.vaadin.server.communication.UIInitHandler.synchronizedHandleRequest::com.vaadin.server.communication.UIInitHandler.getBrowserDetailsUI::com.vaadin.ui.UI.doInit
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:87:TimeLogger : call to findAll took 18679 ms. Stack: org.opennms.features.topology.plugins.topo.linkd.internal.LinkdTopologyProvider.doRefresh::org.opennms.features.topology.plugins.topo.linkd.internal.LinkdTopologyProvider.loadVertices::Proxy79215b4e_7f0a_430d_b83e_e3e72c59c0e0.findAll
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:88:TimeLogger : call to loadVertices took 19459 ms. Stack: org.opennms.features.topology.api.support.VertexHopGraphProvider.refresh::org.opennms.features.topology.plugins.topo.linkd.internal.LinkdTopologyProvider.refresh::org.opennms.features.topology.plugins.topo.linkd.internal.LinkdTopologyProvider.doRefresh
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:89:TimeLogger CdpElementDao.findAll(): call to getCdpLinks took 89 ms. Stack: org.opennms.features.topology.plugins.topo.linkd.internal.LinkdTopologyProvider.refresh::org.opennms.features.topology.plugins.topo.linkd.internal.LinkdTopologyProvider.doRefresh::org.opennms.features.topology.plugins.topo.linkd.internal.LinkdTopologyProvider.loadEdges
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:90:TimeLogger CdpLinkDao.findAll(): call to getCdpLinks took 2454 ms. Stack: org.opennms.features.topology.plugins.topo.linkd.internal.LinkdTopologyProvider.refresh::org.opennms.features.topology.plugins.topo.linkd.internal.LinkdTopologyProvider.doRefresh::org.opennms.features.topology.plugins.topo.linkd.internal.LinkdTopologyProvider.loadEdges
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:91:TimeLogger : call to matchCdpLinks took 261 ms. Stack: org.opennms.features.topology.plugins.topo.linkd.internal.LinkdTopologyProvider.doRefresh::org.opennms.features.topology.plugins.topo.linkd.internal.LinkdTopologyProvider.loadEdges::org.opennms.features.topology.plugins.topo.linkd.internal.LinkdTopologyProvider.getCdpLinks
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:92:TimeLogger iterate CdpLinkPairs: call to getCdpLinks took 899 ms. Stack: org.opennms.features.topology.plugins.topo.linkd.internal.LinkdTopologyProvider.refresh::org.opennms.features.topology.plugins.topo.linkd.internal.LinkdTopologyProvider.doRefresh::org.opennms.features.topology.plugins.topo.linkd.internal.LinkdTopologyProvider.loadEdges
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:93:TimeLogger : call to getCdpLinks took 3703 ms. Stack: org.opennms.features.topology.plugins.topo.linkd.internal.LinkdTopologyProvider.refresh::org.opennms.features.topology.plugins.topo.linkd.internal.LinkdTopologyProvider.doRefresh::org.opennms.features.topology.plugins.topo.linkd.internal.LinkdTopologyProvider.loadEdges
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:94:TimeLogger : call to loadEdges took 3781 ms. Stack: org.opennms.features.topology.api.support.VertexHopGraphProvider.refresh::org.opennms.features.topology.plugins.topo.linkd.internal.LinkdTopologyProvider.refresh::org.opennms.features.topology.plugins.topo.linkd.internal.LinkdTopologyProvider.doRefresh
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:95:TimeLogger org.opennms.features.topology.api.Callbacks$$Lambda$345/1451558438@10a3d5b7: call to selectTopologyProvider took 28 ms. Stack: org.opennms.features.topology.app.internal.operations.MetaTopologySelectorOperation.execute::org.opennms.features.topology.app.internal.operations.MetaTopologySelectorOperation.execute::org.opennms.features.topology.app.internal.operations.MetaTopologySelectorOperation.execute
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:96:TimeLogger org.opennms.features.topology.app.internal.TopologyComponent: org.opennms.features.topology.app.internal.TopologyComponent@1eb80e94: call to fireGraphChanged took 1 ms. Stack: org.opennms.features.topology.app.internal.operations.MetaTopologySelectorOperation.execute::org.opennms.features.topology.app.internal.VEProviderGraphContainer.selectTopologyProvider::org.opennms.features.topology.app.internal.VEProviderGraphContainer.redoLayout
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:97:TimeLogger org.opennms.features.topology.plugins.browsers.AlarmTable: null: call to fireGraphChanged took 1329 ms. Stack: org.opennms.features.topology.app.internal.operations.MetaTopologySelectorOperation.execute::org.opennms.features.topology.app.internal.VEProviderGraphContainer.selectTopologyProvider::org.opennms.features.topology.app.internal.VEProviderGraphContainer.redoLayout
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:98:TimeLogger org.opennms.features.topology.plugins.topo.application.browsers.ApplicationTable: null: call to fireGraphChanged took 1070 ms. Stack: org.opennms.features.topology.app.internal.operations.MetaTopologySelectorOperation.execute::org.opennms.features.topology.app.internal.VEProviderGraphContainer.selectTopologyProvider::org.opennms.features.topology.app.internal.VEProviderGraphContainer.redoLayout
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:99:TimeLogger org.opennms.features.topology.plugins.topo.bsm.browsers.BusinessServicesTable: null: call to fireGraphChanged took 3170 ms. Stack: org.opennms.features.topology.app.internal.operations.MetaTopologySelectorOperation.execute::org.opennms.features.topology.app.internal.VEProviderGraphContainer.selectTopologyProvider::org.opennms.features.topology.app.internal.VEProviderGraphContainer.redoLayout
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:100:TimeLogger org.opennms.features.topology.plugins.browsers.NodeTable: null: call to fireGraphChanged took 1240 ms. Stack: org.opennms.features.topology.app.internal.operations.MetaTopologySelectorOperation.execute::org.opennms.features.topology.app.internal.VEProviderGraphContainer.selectTopologyProvider::org.opennms.features.topology.app.internal.VEProviderGraphContainer.redoLayout
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:101:TimeLogger : call to redoLayout took 7256 ms. Stack: org.opennms.features.topology.app.internal.operations.MetaTopologySelectorOperation.execute::org.opennms.features.topology.app.internal.operations.MetaTopologySelectorOperation.execute::org.opennms.features.topology.app.internal.VEProviderGraphContainer.selectTopologyProvider
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:102:TimeLogger : call to selectTopologyProvider took 30833 ms. Stack: org.opennms.features.topology.app.internal.operations.MetaTopologySelectorOperation.execute::org.opennms.features.topology.app.internal.operations.MetaTopologySelectorOperation.execute::org.opennms.features.topology.app.internal.operations.MetaTopologySelectorOperation.execute
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:103:TimeLogger init 3.2 org.opennms.features.topology.app.internal.operations.MetaTopologySelectorOperation@1f3a2120: call to init took 30836 ms. Stack: com.vaadin.server.communication.UIInitHandler.synchronizedHandleRequest::com.vaadin.server.communication.UIInitHandler.getBrowserDetailsUI::com.vaadin.ui.UI.doInit
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:104:TimeLogger org.opennms.features.topology.app.internal.TopologyComponent: org.opennms.features.topology.app.internal.TopologyComponent@1eb80e94: call to fireGraphChanged took 0 ms. Stack: org.opennms.features.topology.app.internal.TopologyUI$TopologyUIRequestHandler.access$1400::org.opennms.features.topology.app.internal.TopologyUI$TopologyUIRequestHandler.handleRequestParameter::org.opennms.features.topology.app.internal.VEProviderGraphContainer.redoLayout
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:105:TimeLogger org.opennms.features.topology.plugins.browsers.AlarmTable: null: call to fireGraphChanged took 1120 ms. Stack: org.opennms.features.topology.app.internal.TopologyUI$TopologyUIRequestHandler.access$1400::org.opennms.features.topology.app.internal.TopologyUI$TopologyUIRequestHandler.handleRequestParameter::org.opennms.features.topology.app.internal.VEProviderGraphContainer.redoLayout
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:106:TimeLogger org.opennms.features.topology.plugins.topo.application.browsers.ApplicationTable: null: call to fireGraphChanged took 1075 ms. Stack: org.opennms.features.topology.app.internal.TopologyUI$TopologyUIRequestHandler.access$1400::org.opennms.features.topology.app.internal.TopologyUI$TopologyUIRequestHandler.handleRequestParameter::org.opennms.features.topology.app.internal.VEProviderGraphContainer.redoLayout
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:107:TimeLogger org.opennms.features.topology.plugins.topo.bsm.browsers.BusinessServicesTable: null: call to fireGraphChanged took 3098 ms. Stack: org.opennms.features.topology.app.internal.TopologyUI$TopologyUIRequestHandler.access$1400::org.opennms.features.topology.app.internal.TopologyUI$TopologyUIRequestHandler.handleRequestParameter::org.opennms.features.topology.app.internal.VEProviderGraphContainer.redoLayout
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:108:TimeLogger org.opennms.features.topology.plugins.browsers.NodeTable: null: call to fireGraphChanged took 1080 ms. Stack: org.opennms.features.topology.app.internal.TopologyUI$TopologyUIRequestHandler.access$1400::org.opennms.features.topology.app.internal.TopologyUI$TopologyUIRequestHandler.handleRequestParameter::org.opennms.features.topology.app.internal.VEProviderGraphContainer.redoLayout
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:109:TimeLogger : call to redoLayout took 6374 ms. Stack: org.opennms.features.topology.app.internal.TopologyUI.init::org.opennms.features.topology.app.internal.TopologyUI$TopologyUIRequestHandler.access$1400::org.opennms.features.topology.app.internal.TopologyUI$TopologyUIRequestHandler.handleRequestParameter
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:110:TimeLogger init 3: call to init took 37253 ms. Stack: com.vaadin.server.communication.UIInitHandler.synchronizedHandleRequest::com.vaadin.server.communication.UIInitHandler.getBrowserDetailsUI::com.vaadin.ui.UI.doInit
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:111:TimeLogger org.opennms.features.topology.app.internal.TopologyComponent: org.opennms.features.topology.app.internal.TopologyComponent@1eb80e94: call to fireGraphChanged took 92 ms. Stack: com.vaadin.ui.UI.doInit::org.opennms.features.topology.app.internal.TopologyUI.init::org.opennms.features.topology.app.internal.VEProviderGraphContainer.redoLayout
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:112:TimeLogger org.opennms.features.topology.plugins.browsers.AlarmTable: null: call to fireGraphChanged took 1068 ms. Stack: com.vaadin.ui.UI.doInit::org.opennms.features.topology.app.internal.TopologyUI.init::org.opennms.features.topology.app.internal.VEProviderGraphContainer.redoLayout
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:113:TimeLogger org.opennms.features.topology.plugins.topo.application.browsers.ApplicationTable: null: call to fireGraphChanged took 1052 ms. Stack: com.vaadin.ui.UI.doInit::org.opennms.features.topology.app.internal.TopologyUI.init::org.opennms.features.topology.app.internal.VEProviderGraphContainer.redoLayout
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:114:TimeLogger org.opennms.features.topology.plugins.topo.bsm.browsers.BusinessServicesTable: null: call to fireGraphChanged took 3028 ms. Stack: com.vaadin.ui.UI.doInit::org.opennms.features.topology.app.internal.TopologyUI.init::org.opennms.features.topology.app.internal.VEProviderGraphContainer.redoLayout
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:115:TimeLogger org.opennms.features.topology.plugins.browsers.NodeTable: null: call to fireGraphChanged took 1107 ms. Stack: com.vaadin.ui.UI.doInit::org.opennms.features.topology.app.internal.TopologyUI.init::org.opennms.features.topology.app.internal.VEProviderGraphContainer.redoLayout
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:116:TimeLogger org.opennms.features.topology.app.internal.TopologyUI: org.opennms.features.topology.app.internal.TopologyUI@4a330675: call to fireGraphChanged took 1131 ms. Stack: com.vaadin.ui.UI.doInit::org.opennms.features.topology.app.internal.TopologyUI.init::org.opennms.features.topology.app.internal.VEProviderGraphContainer.redoLayout
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:117:TimeLogger org.opennms.features.topology.app.internal.ui.SearchBox: org.opennms.features.topology.app.internal.ui.SearchBox@73ef58e0: call to fireGraphChanged took 0 ms. Stack: com.vaadin.ui.UI.doInit::org.opennms.features.topology.app.internal.TopologyUI.init::org.opennms.features.topology.app.internal.VEProviderGraphContainer.redoLayout
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:118:TimeLogger org.opennms.features.topology.app.internal.OsgiVerticesUpdateManager: org.opennms.features.topology.app.internal.OsgiVerticesUpdateManager@1372cb78: call to fireGraphChanged took 36 ms. Stack: com.vaadin.ui.UI.doInit::org.opennms.features.topology.app.internal.TopologyUI.init::org.opennms.features.topology.app.internal.VEProviderGraphContainer.redoLayout
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:119:TimeLogger org.opennms.features.topology.app.internal.TopologyUI$InfoPanelItemManager: org.opennms.features.topology.app.internal.TopologyUI$InfoPanelItemManager@356849: call to fireGraphChanged took 655 ms. Stack: com.vaadin.ui.UI.doInit::org.opennms.features.topology.app.internal.TopologyUI.init::org.opennms.features.topology.app.internal.VEProviderGraphContainer.redoLayout
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:120:TimeLogger org.opennms.features.topology.app.internal.ui.ToolbarPanel: org.opennms.features.topology.app.internal.ui.ToolbarPanel@4eef7ef4: call to fireGraphChanged took 0 ms. Stack: com.vaadin.ui.UI.doInit::org.opennms.features.topology.app.internal.TopologyUI.init::org.opennms.features.topology.app.internal.VEProviderGraphContainer.redoLayout
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:121:TimeLogger org.opennms.features.topology.app.internal.ui.breadcrumbs.BreadcrumbComponent: org.opennms.features.topology.app.internal.ui.breadcrumbs.BreadcrumbComponent@4575008a: call to fireGraphChanged took 2 ms. Stack: com.vaadin.ui.UI.doInit::org.opennms.features.topology.app.internal.TopologyUI.init::org.opennms.features.topology.app.internal.VEProviderGraphContainer.redoLayout
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:122:TimeLogger org.opennms.features.topology.app.internal.ui.LayoutHintComponent: org.opennms.features.topology.app.internal.ui.LayoutHintComponent@f1bae38: call to fireGraphChanged took 781 ms. Stack: com.vaadin.ui.UI.doInit::org.opennms.features.topology.app.internal.TopologyUI.init::org.opennms.features.topology.app.internal.VEProviderGraphContainer.redoLayout
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:123:TimeLogger : call to redoLayout took 9230 ms. Stack: com.vaadin.server.communication.UIInitHandler.getBrowserDetailsUI::com.vaadin.ui.UI.doInit::org.opennms.features.topology.app.internal.TopologyUI.init
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:124:TimeLogger org.opennms.features.topology.app.internal.TopologyComponent$2: call to selectionChanged took 0 ms. Stack: com.vaadin.server.communication.UIInitHandler.getBrowserDetailsUI::com.vaadin.ui.UI.doInit::org.opennms.features.topology.app.internal.TopologyUI.init
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:125:TimeLogger org.opennms.features.topology.app.internal.TopologyUI: call to selectionChanged took 2 ms. Stack: com.vaadin.server.communication.UIInitHandler.getBrowserDetailsUI::com.vaadin.ui.UI.doInit::org.opennms.features.topology.app.internal.TopologyUI.init
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:126:TimeLogger org.opennms.features.topology.app.internal.ui.SearchBox: call to selectionChanged took 0 ms. Stack: com.vaadin.server.communication.UIInitHandler.getBrowserDetailsUI::com.vaadin.ui.UI.doInit::org.opennms.features.topology.app.internal.TopologyUI.init
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:127:TimeLogger org.opennms.features.topology.app.internal.OsgiVerticesUpdateManager: call to selectionChanged took 1 ms. Stack: com.vaadin.server.communication.UIInitHandler.getBrowserDetailsUI::com.vaadin.ui.UI.doInit::org.opennms.features.topology.app.internal.TopologyUI.init
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:128:TimeLogger org.opennms.features.topology.app.internal.TopologyUI$InfoPanelItemManager: call to selectionChanged took 683 ms. Stack: com.vaadin.server.communication.UIInitHandler.getBrowserDetailsUI::com.vaadin.ui.UI.doInit::org.opennms.features.topology.app.internal.TopologyUI.init
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:129:TimeLogger org.opennms.features.topology.app.internal.ui.ToolbarPanel: call to selectionChanged took 0 ms. Stack: com.vaadin.server.communication.UIInitHandler.getBrowserDetailsUI::com.vaadin.ui.UI.doInit::org.opennms.features.topology.app.internal.TopologyUI.init
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:130:TimeLogger init 4: call to init took 9974 ms. Stack: com.vaadin.server.communication.UIInitHandler.synchronizedHandleRequest::com.vaadin.server.communication.UIInitHandler.getBrowserDetailsUI::com.vaadin.ui.UI.doInit
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:131:TimeLogger : call to init took 48640 ms. Stack: com.vaadin.server.communication.UIInitHandler.synchronizedHandleRequest::com.vaadin.server.communication.UIInitHandler.getBrowserDetailsUI::com.vaadin.ui.UI.doInit


Not optimized (with history):
patrick@krassomat:/apps/git/opennms_foundation_2017$ grep -rnw './target/opennms-21.1.0-SNAPSHOT/logs' -e 'TimeLogger'
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:79:TimeLogger : call to findAll took 21070 ms. Stack: sun.reflect.NativeMethodAccessorImpl.invoke::sun.reflect.NativeMethodAccessorImpl.invoke0::org.opennms.netmgt.provision.service.DefaultProvisionService.getScheduleForNodes
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:204:TimeLogger init 1: call to init took 148 ms. Stack: com.vaadin.server.communication.UIInitHandler.synchronizedHandleRequest::com.vaadin.server.communication.UIInitHandler.getBrowserDetailsUI::com.vaadin.ui.UI.doInit
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:206:TimeLogger : call to createLayouts took 1239 ms. Stack: com.vaadin.server.communication.UIInitHandler.getBrowserDetailsUI::com.vaadin.ui.UI.doInit::org.opennms.features.topology.app.internal.TopologyUI.init
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:207:TimeLogger org.opennms.features.topology.plugins.topo.bsm.operations.SimulationModeOperation@34389827: call to apply took 0 ms. Stack: org.opennms.features.topology.app.internal.TopologyUI.applyHistory::Proxy4a6c5491_5cd2_47ba_aa82_ffe3fe3df03a.applyHistory::org.opennms.features.topology.plugins.topo.BundleContextHistoryManager.applyHistory
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:208:TimeLogger org.opennms.features.topology.plugins.topo.bsm.operations.HideLeafElementToggleOperation@4da8daf9: call to apply took 0 ms. Stack: org.opennms.features.topology.app.internal.TopologyUI.applyHistory::Proxy4a6c5491_5cd2_47ba_aa82_ffe3fe3df03a.applyHistory::org.opennms.features.topology.plugins.topo.BundleContextHistoryManager.applyHistory
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:209:TimeLogger org.opennms.features.topology.plugins.topo.bsm.operations.InheritStateOperation@177e7a4a: call to apply took 0 ms. Stack: org.opennms.features.topology.app.internal.TopologyUI.applyHistory::Proxy4a6c5491_5cd2_47ba_aa82_ffe3fe3df03a.applyHistory::org.opennms.features.topology.plugins.topo.BundleContextHistoryManager.applyHistory
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:210:TimeLogger org.opennms.features.topology.app.internal.operations.MetaTopologySelectorOperation@8977ac4: call to apply took 0 ms. Stack: org.opennms.features.topology.app.internal.TopologyUI.applyHistory::Proxy4a6c5491_5cd2_47ba_aa82_ffe3fe3df03a.applyHistory::org.opennms.features.topology.plugins.topo.BundleContextHistoryManager.applyHistory
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:215:TimeLogger : call to findAll took 20565 ms. Stack: org.opennms.features.topology.plugins.topo.linkd.internal.LinkdTopologyProvider.doRefresh::org.opennms.features.topology.plugins.topo.linkd.internal.LinkdTopologyProvider.loadVertices::Proxy8e63005a_3fb7_461b_a814_6ca42de8c35c.findAll
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:216:TimeLogger : call to loadVertices took 21353 ms. Stack: org.opennms.features.topology.api.support.VertexHopGraphProvider.refresh::org.opennms.features.topology.plugins.topo.linkd.internal.LinkdTopologyProvider.refresh::org.opennms.features.topology.plugins.topo.linkd.internal.LinkdTopologyProvider.doRefresh
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:217:TimeLogger CdpElementDao.findAll(): call to getCdpLinks took 110 ms. Stack: org.opennms.features.topology.plugins.topo.linkd.internal.LinkdTopologyProvider.refresh::org.opennms.features.topology.plugins.topo.linkd.internal.LinkdTopologyProvider.doRefresh::org.opennms.features.topology.plugins.topo.linkd.internal.LinkdTopologyProvider.loadEdges
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:221:TimeLogger CdpLinkDao.findAll(): call to getCdpLinks took 3546 ms. Stack: org.opennms.features.topology.plugins.topo.linkd.internal.LinkdTopologyProvider.refresh::org.opennms.features.topology.plugins.topo.linkd.internal.LinkdTopologyProvider.doRefresh::org.opennms.features.topology.plugins.topo.linkd.internal.LinkdTopologyProvider.loadEdges
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:222:TimeLogger : call to matchCdpLinks took 211 ms. Stack: org.opennms.features.topology.plugins.topo.linkd.internal.LinkdTopologyProvider.doRefresh::org.opennms.features.topology.plugins.topo.linkd.internal.LinkdTopologyProvider.loadEdges::org.opennms.features.topology.plugins.topo.linkd.internal.LinkdTopologyProvider.getCdpLinks
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:224:TimeLogger iterate CdpLinkPairs: call to getCdpLinks took 980 ms. Stack: org.opennms.features.topology.plugins.topo.linkd.internal.LinkdTopologyProvider.refresh::org.opennms.features.topology.plugins.topo.linkd.internal.LinkdTopologyProvider.doRefresh::org.opennms.features.topology.plugins.topo.linkd.internal.LinkdTopologyProvider.loadEdges
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:225:TimeLogger : call to getCdpLinks took 4847 ms. Stack: org.opennms.features.topology.plugins.topo.linkd.internal.LinkdTopologyProvider.refresh::org.opennms.features.topology.plugins.topo.linkd.internal.LinkdTopologyProvider.doRefresh::org.opennms.features.topology.plugins.topo.linkd.internal.LinkdTopologyProvider.loadEdges
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:226:TimeLogger : call to loadEdges took 4931 ms. Stack: org.opennms.features.topology.api.support.VertexHopGraphProvider.refresh::org.opennms.features.topology.plugins.topo.linkd.internal.LinkdTopologyProvider.refresh::org.opennms.features.topology.plugins.topo.linkd.internal.LinkdTopologyProvider.doRefresh
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:227:TimeLogger org.opennms.features.topology.api.Callbacks$$Lambda$326/797008171@5441a770: call to selectTopologyProvider took 35 ms. Stack: org.opennms.features.topology.app.internal.operations.MetaTopologySelectorOperation.applyHistory::org.opennms.features.topology.app.internal.operations.MetaTopologySelectorOperation.execute::org.opennms.features.topology.app.internal.operations.MetaTopologySelectorOperation.execute
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:229:TimeLogger org.opennms.features.topology.app.internal.TopologyComponent: org.opennms.features.topology.app.internal.TopologyComponent@3b0a70a2: call to fireGraphChanged took 0 ms. Stack: org.opennms.features.topology.app.internal.operations.MetaTopologySelectorOperation.execute::org.opennms.features.topology.app.internal.VEProviderGraphContainer.selectTopologyProvider::org.opennms.features.topology.app.internal.VEProviderGraphContainer.redoLayout
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:231:TimeLogger org.opennms.features.topology.plugins.browsers.AlarmTable: null: call to fireGraphChanged took 1400 ms. Stack: org.opennms.features.topology.app.internal.operations.MetaTopologySelectorOperation.execute::org.opennms.features.topology.app.internal.VEProviderGraphContainer.selectTopologyProvider::org.opennms.features.topology.app.internal.VEProviderGraphContainer.redoLayout
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:234:TimeLogger org.opennms.features.topology.plugins.topo.application.browsers.ApplicationTable: null: call to fireGraphChanged took 1244 ms. Stack: org.opennms.features.topology.app.internal.operations.MetaTopologySelectorOperation.execute::org.opennms.features.topology.app.internal.VEProviderGraphContainer.selectTopologyProvider::org.opennms.features.topology.app.internal.VEProviderGraphContainer.redoLayout
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:238:TimeLogger org.opennms.features.topology.plugins.topo.bsm.browsers.BusinessServicesTable: null: call to fireGraphChanged took 3196 ms. Stack: org.opennms.features.topology.app.internal.operations.MetaTopologySelectorOperation.execute::org.opennms.features.topology.app.internal.VEProviderGraphContainer.selectTopologyProvider::org.opennms.features.topology.app.internal.VEProviderGraphContainer.redoLayout
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:241:TimeLogger org.opennms.features.topology.plugins.browsers.NodeTable: null: call to fireGraphChanged took 1143 ms. Stack: org.opennms.features.topology.app.internal.operations.MetaTopologySelectorOperation.execute::org.opennms.features.topology.app.internal.VEProviderGraphContainer.selectTopologyProvider::org.opennms.features.topology.app.internal.VEProviderGraphContainer.redoLayout
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:242:TimeLogger : call to redoLayout took 7478 ms. Stack: org.opennms.features.topology.app.internal.operations.MetaTopologySelectorOperation.execute::org.opennms.features.topology.app.internal.operations.MetaTopologySelectorOperation.execute::org.opennms.features.topology.app.internal.VEProviderGraphContainer.selectTopologyProvider
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:243:TimeLogger : call to selectTopologyProvider took 33947 ms. Stack: org.opennms.features.topology.app.internal.operations.MetaTopologySelectorOperation.applyHistory::org.opennms.features.topology.app.internal.operations.MetaTopologySelectorOperation.execute::org.opennms.features.topology.app.internal.operations.MetaTopologySelectorOperation.execute
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:244:TimeLogger org.opennms.features.topology.app.internal.operations.MetaTopologySelectorOperation@789e3251: call to apply took 33951 ms. Stack: org.opennms.features.topology.app.internal.TopologyUI.applyHistory::Proxy4a6c5491_5cd2_47ba_aa82_ffe3fe3df03a.applyHistory::org.opennms.features.topology.plugins.topo.BundleContextHistoryManager.applyHistory
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:245:TimeLogger org.opennms.features.topology.app.internal.operations.MetaTopologySelectorOperation@11263793: call to apply took 0 ms. Stack: org.opennms.features.topology.app.internal.TopologyUI.applyHistory::Proxy4a6c5491_5cd2_47ba_aa82_ffe3fe3df03a.applyHistory::org.opennms.features.topology.plugins.topo.BundleContextHistoryManager.applyHistory
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:246:TimeLogger org.opennms.features.topology.app.internal.operations.MetaTopologySelectorOperation@482949b5: call to apply took 0 ms. Stack: org.opennms.features.topology.app.internal.TopologyUI.applyHistory::Proxy4a6c5491_5cd2_47ba_aa82_ffe3fe3df03a.applyHistory::org.opennms.features.topology.plugins.topo.BundleContextHistoryManager.applyHistory
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:247:TimeLogger org.opennms.features.topology.app.internal.operations.MetaTopologySelectorOperation@6e6bcfa1: call to apply took 0 ms. Stack: org.opennms.features.topology.app.internal.TopologyUI.applyHistory::Proxy4a6c5491_5cd2_47ba_aa82_ffe3fe3df03a.applyHistory::org.opennms.features.topology.plugins.topo.BundleContextHistoryManager.applyHistory
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:248:TimeLogger org.opennms.features.topology.app.internal.operations.HierarchyLayoutOperation@713e0a59: call to apply took 0 ms. Stack: org.opennms.features.topology.app.internal.TopologyUI.applyHistory::Proxy4a6c5491_5cd2_47ba_aa82_ffe3fe3df03a.applyHistory::org.opennms.features.topology.plugins.topo.BundleContextHistoryManager.applyHistory
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:249:TimeLogger org.opennms.features.topology.app.internal.operations.AutoRefreshToggleOperation@51042142: call to apply took 1 ms. Stack: org.opennms.features.topology.app.internal.TopologyUI.applyHistory::Proxy4a6c5491_5cd2_47ba_aa82_ffe3fe3df03a.applyHistory::org.opennms.features.topology.plugins.topo.BundleContextHistoryManager.applyHistory
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:250:TimeLogger org.opennms.features.topology.app.internal.operations.ISOMLayoutOperation@53e2ae36: call to apply took 0 ms. Stack: org.opennms.features.topology.app.internal.TopologyUI.applyHistory::Proxy4a6c5491_5cd2_47ba_aa82_ffe3fe3df03a.applyHistory::org.opennms.features.topology.plugins.topo.BundleContextHistoryManager.applyHistory
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:251:TimeLogger org.opennms.features.topology.app.internal.operations.GridLayoutOperation@6344652c: call to apply took 1 ms. Stack: org.opennms.features.topology.app.internal.TopologyUI.applyHistory::Proxy4a6c5491_5cd2_47ba_aa82_ffe3fe3df03a.applyHistory::org.opennms.features.topology.plugins.topo.BundleContextHistoryManager.applyHistory
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:252:TimeLogger org.opennms.features.topology.app.internal.operations.RealUltimateLayoutOperation@6229c7df: call to apply took 0 ms. Stack: org.opennms.features.topology.app.internal.TopologyUI.applyHistory::Proxy4a6c5491_5cd2_47ba_aa82_ffe3fe3df03a.applyHistory::org.opennms.features.topology.plugins.topo.BundleContextHistoryManager.applyHistory
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:253:TimeLogger org.opennms.features.topology.app.internal.operations.ManualLayoutOperation@1257f4e9: call to apply took 0 ms. Stack: org.opennms.features.topology.app.internal.TopologyUI.applyHistory::Proxy4a6c5491_5cd2_47ba_aa82_ffe3fe3df03a.applyHistory::org.opennms.features.topology.plugins.topo.BundleContextHistoryManager.applyHistory
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:254:TimeLogger org.opennms.features.topology.app.internal.operations.KKLayoutOperation@54027b8b: call to apply took 1 ms. Stack: org.opennms.features.topology.app.internal.TopologyUI.applyHistory::Proxy4a6c5491_5cd2_47ba_aa82_ffe3fe3df03a.applyHistory::org.opennms.features.topology.plugins.topo.BundleContextHistoryManager.applyHistory
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:255:TimeLogger org.opennms.features.topology.app.internal.operations.SpringLayoutOperation@142f0922: call to apply took 0 ms. Stack: org.opennms.features.topology.app.internal.TopologyUI.applyHistory::Proxy4a6c5491_5cd2_47ba_aa82_ffe3fe3df03a.applyHistory::org.opennms.features.topology.plugins.topo.BundleContextHistoryManager.applyHistory
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:256:TimeLogger org.opennms.features.topology.app.internal.operations.CircleLayoutOperation@38143347: call to apply took 0 ms. Stack: org.opennms.features.topology.app.internal.TopologyUI.applyHistory::Proxy4a6c5491_5cd2_47ba_aa82_ffe3fe3df03a.applyHistory::org.opennms.features.topology.plugins.topo.BundleContextHistoryManager.applyHistory
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:257:TimeLogger org.opennms.features.topology.app.internal.operations.TopoFRLayoutOperation@15496810: call to apply took 0 ms. Stack: org.opennms.features.topology.app.internal.TopologyUI.applyHistory::Proxy4a6c5491_5cd2_47ba_aa82_ffe3fe3df03a.applyHistory::org.opennms.features.topology.plugins.topo.BundleContextHistoryManager.applyHistory
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:258:TimeLogger org.opennms.features.topology.app.internal.TopologyComponent: org.opennms.features.topology.app.internal.TopologyComponent@3b0a70a2: call to fireGraphChanged took 1 ms. Stack: org.opennms.features.topology.app.internal.operations.LayoutOperation.applyHistory::org.opennms.features.topology.app.internal.operations.LayoutOperation.execute::org.opennms.features.topology.app.internal.VEProviderGraphContainer.redoLayout
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:260:TimeLogger org.opennms.features.topology.plugins.browsers.AlarmTable: null: call to fireGraphChanged took 1100 ms. Stack: org.opennms.features.topology.app.internal.operations.LayoutOperation.applyHistory::org.opennms.features.topology.app.internal.operations.LayoutOperation.execute::org.opennms.features.topology.app.internal.VEProviderGraphContainer.redoLayout
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:262:TimeLogger org.opennms.features.topology.plugins.topo.application.browsers.ApplicationTable: null: call to fireGraphChanged took 1103 ms. Stack: org.opennms.features.topology.app.internal.operations.LayoutOperation.applyHistory::org.opennms.features.topology.app.internal.operations.LayoutOperation.execute::org.opennms.features.topology.app.internal.VEProviderGraphContainer.redoLayout
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:266:TimeLogger org.opennms.features.topology.plugins.topo.bsm.browsers.BusinessServicesTable: null: call to fireGraphChanged took 3410 ms. Stack: org.opennms.features.topology.app.internal.operations.LayoutOperation.applyHistory::org.opennms.features.topology.app.internal.operations.LayoutOperation.execute::org.opennms.features.topology.app.internal.VEProviderGraphContainer.redoLayout
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:268:TimeLogger org.opennms.features.topology.plugins.browsers.NodeTable: null: call to fireGraphChanged took 1344 ms. Stack: org.opennms.features.topology.app.internal.operations.LayoutOperation.applyHistory::org.opennms.features.topology.app.internal.operations.LayoutOperation.execute::org.opennms.features.topology.app.internal.VEProviderGraphContainer.redoLayout
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:269:TimeLogger : call to redoLayout took 6960 ms. Stack: Proxyefcd5dfb_89ff_4f68_a024_225867278497.applyHistory::org.opennms.features.topology.app.internal.operations.LayoutOperation.applyHistory::org.opennms.features.topology.app.internal.operations.LayoutOperation.execute
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:270:TimeLogger org.opennms.features.topology.app.internal.operations.D3TopoLayoutOperation@52509711: call to apply took 6960 ms. Stack: org.opennms.features.topology.app.internal.TopologyUI.applyHistory::Proxy4a6c5491_5cd2_47ba_aa82_ffe3fe3df03a.applyHistory::org.opennms.features.topology.plugins.topo.BundleContextHistoryManager.applyHistory
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:271:TimeLogger history 1: call to apply took 40917 ms. Stack: org.opennms.features.topology.app.internal.TopologyUI.applyHistory::Proxy4a6c5491_5cd2_47ba_aa82_ffe3fe3df03a.applyHistory::org.opennms.features.topology.plugins.topo.BundleContextHistoryManager.applyHistory
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:272:TimeLogger history 2: call to apply took 1 ms. Stack: org.opennms.features.topology.app.internal.TopologyUI.applyHistory::Proxy4a6c5491_5cd2_47ba_aa82_ffe3fe3df03a.applyHistory::org.opennms.features.topology.plugins.topo.BundleContextHistoryManager.applyHistory
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:273:TimeLogger history 3: call to apply took 38 ms. Stack: org.opennms.features.topology.app.internal.TopologyUI.applyHistory::Proxy4a6c5491_5cd2_47ba_aa82_ffe3fe3df03a.applyHistory::org.opennms.features.topology.plugins.topo.BundleContextHistoryManager.applyHistory
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:274:TimeLogger history 4: call to apply took 1 ms. Stack: org.opennms.features.topology.app.internal.TopologyUI.applyHistory::Proxy4a6c5491_5cd2_47ba_aa82_ffe3fe3df03a.applyHistory::org.opennms.features.topology.plugins.topo.BundleContextHistoryManager.applyHistory
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:275:TimeLogger org.opennms.features.topology.app.internal.TopologyComponent: org.opennms.features.topology.app.internal.TopologyComponent@3b0a70a2: call to fireGraphChanged took 0 ms. Stack: org.opennms.features.topology.app.internal.TopologyUI.init::org.opennms.features.topology.app.internal.TopologyUI.loadUserSettings::org.opennms.features.topology.app.internal.VEProviderGraphContainer.redoLayout
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:277:TimeLogger org.opennms.features.topology.plugins.browsers.AlarmTable: null: call to fireGraphChanged took 1576 ms. Stack: org.opennms.features.topology.app.internal.TopologyUI.init::org.opennms.features.topology.app.internal.TopologyUI.loadUserSettings::org.opennms.features.topology.app.internal.VEProviderGraphContainer.redoLayout
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:279:TimeLogger org.opennms.features.topology.plugins.topo.application.browsers.ApplicationTable: null: call to fireGraphChanged took 1265 ms. Stack: org.opennms.features.topology.app.internal.TopologyUI.init::org.opennms.features.topology.app.internal.TopologyUI.loadUserSettings::org.opennms.features.topology.app.internal.VEProviderGraphContainer.redoLayout
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:282:TimeLogger org.opennms.features.topology.plugins.topo.bsm.browsers.BusinessServicesTable: null: call to fireGraphChanged took 4716 ms. Stack: org.opennms.features.topology.app.internal.TopologyUI.init::org.opennms.features.topology.app.internal.TopologyUI.loadUserSettings::org.opennms.features.topology.app.internal.VEProviderGraphContainer.redoLayout
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:284:TimeLogger org.opennms.features.topology.plugins.browsers.NodeTable: null: call to fireGraphChanged took 1506 ms. Stack: org.opennms.features.topology.app.internal.TopologyUI.init::org.opennms.features.topology.app.internal.TopologyUI.loadUserSettings::org.opennms.features.topology.app.internal.VEProviderGraphContainer.redoLayout
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:285:TimeLogger : call to redoLayout took 9282 ms. Stack: com.vaadin.ui.UI.doInit::org.opennms.features.topology.app.internal.TopologyUI.init::org.opennms.features.topology.app.internal.TopologyUI.loadUserSettings
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:286:TimeLogger : call to loadUserSettings took 50302 ms. Stack: com.vaadin.server.communication.UIInitHandler.getBrowserDetailsUI::com.vaadin.ui.UI.doInit::org.opennms.features.topology.app.internal.TopologyUI.init
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:287:TimeLogger init 2: call to init took 51550 ms. Stack: com.vaadin.server.communication.UIInitHandler.synchronizedHandleRequest::com.vaadin.server.communication.UIInitHandler.getBrowserDetailsUI::com.vaadin.ui.UI.doInit
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:288:TimeLogger org.opennms.features.topology.app.internal.TopologyComponent: org.opennms.features.topology.app.internal.TopologyComponent@3b0a70a2: call to fireGraphChanged took 0 ms. Stack: org.opennms.features.topology.app.internal.TopologyUI$TopologyUIRequestHandler.access$1400::org.opennms.features.topology.app.internal.TopologyUI$TopologyUIRequestHandler.handleRequestParameter::org.opennms.features.topology.app.internal.VEProviderGraphContainer.redoLayout
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:290:TimeLogger org.opennms.features.topology.plugins.browsers.AlarmTable: null: call to fireGraphChanged took 1211 ms. Stack: org.opennms.features.topology.app.internal.TopologyUI$TopologyUIRequestHandler.access$1400::org.opennms.features.topology.app.internal.TopologyUI$TopologyUIRequestHandler.handleRequestParameter::org.opennms.features.topology.app.internal.VEProviderGraphContainer.redoLayout
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:292:TimeLogger org.opennms.features.topology.plugins.topo.application.browsers.ApplicationTable: null: call to fireGraphChanged took 1212 ms. Stack: org.opennms.features.topology.app.internal.TopologyUI$TopologyUIRequestHandler.access$1400::org.opennms.features.topology.app.internal.TopologyUI$TopologyUIRequestHandler.handleRequestParameter::org.opennms.features.topology.app.internal.VEProviderGraphContainer.redoLayout
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:295:TimeLogger org.opennms.features.topology.plugins.topo.bsm.browsers.BusinessServicesTable: null: call to fireGraphChanged took 3350 ms. Stack: org.opennms.features.topology.app.internal.TopologyUI$TopologyUIRequestHandler.access$1400::org.opennms.features.topology.app.internal.TopologyUI$TopologyUIRequestHandler.handleRequestParameter::org.opennms.features.topology.app.internal.VEProviderGraphContainer.redoLayout
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:297:TimeLogger org.opennms.features.topology.plugins.browsers.NodeTable: null: call to fireGraphChanged took 1199 ms. Stack: org.opennms.features.topology.app.internal.TopologyUI$TopologyUIRequestHandler.access$1400::org.opennms.features.topology.app.internal.TopologyUI$TopologyUIRequestHandler.handleRequestParameter::org.opennms.features.topology.app.internal.VEProviderGraphContainer.redoLayout
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:298:TimeLogger : call to redoLayout took 6972 ms. Stack: org.opennms.features.topology.app.internal.TopologyUI.init::org.opennms.features.topology.app.internal.TopologyUI$TopologyUIRequestHandler.access$1400::org.opennms.features.topology.app.internal.TopologyUI$TopologyUIRequestHandler.handleRequestParameter
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:299:TimeLogger init 3: call to init took 7012 ms. Stack: com.vaadin.server.communication.UIInitHandler.synchronizedHandleRequest::com.vaadin.server.communication.UIInitHandler.getBrowserDetailsUI::com.vaadin.ui.UI.doInit
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:300:TimeLogger org.opennms.features.topology.app.internal.TopologyComponent: org.opennms.features.topology.app.internal.TopologyComponent@3b0a70a2: call to fireGraphChanged took 26 ms. Stack: com.vaadin.ui.UI.doInit::org.opennms.features.topology.app.internal.TopologyUI.init::org.opennms.features.topology.app.internal.VEProviderGraphContainer.redoLayout
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:302:TimeLogger org.opennms.features.topology.plugins.browsers.AlarmTable: null: call to fireGraphChanged took 1219 ms. Stack: com.vaadin.ui.UI.doInit::org.opennms.features.topology.app.internal.TopologyUI.init::org.opennms.features.topology.app.internal.VEProviderGraphContainer.redoLayout
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:304:TimeLogger org.opennms.features.topology.plugins.topo.application.browsers.ApplicationTable: null: call to fireGraphChanged took 1128 ms. Stack: com.vaadin.ui.UI.doInit::org.opennms.features.topology.app.internal.TopologyUI.init::org.opennms.features.topology.app.internal.VEProviderGraphContainer.redoLayout
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:307:TimeLogger org.opennms.features.topology.plugins.topo.bsm.browsers.BusinessServicesTable: null: call to fireGraphChanged took 3275 ms. Stack: com.vaadin.ui.UI.doInit::org.opennms.features.topology.app.internal.TopologyUI.init::org.opennms.features.topology.app.internal.VEProviderGraphContainer.redoLayout
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:309:TimeLogger org.opennms.features.topology.plugins.browsers.NodeTable: null: call to fireGraphChanged took 1139 ms. Stack: com.vaadin.ui.UI.doInit::org.opennms.features.topology.app.internal.TopologyUI.init::org.opennms.features.topology.app.internal.VEProviderGraphContainer.redoLayout
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:310:TimeLogger org.opennms.features.topology.app.internal.TopologyUI: org.opennms.features.topology.app.internal.TopologyUI@343e0418: call to fireGraphChanged took 1041 ms. Stack: com.vaadin.ui.UI.doInit::org.opennms.features.topology.app.internal.TopologyUI.init::org.opennms.features.topology.app.internal.VEProviderGraphContainer.redoLayout
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:311:TimeLogger org.opennms.features.topology.app.internal.ui.SearchBox: org.opennms.features.topology.app.internal.ui.SearchBox@43389df4: call to fireGraphChanged took 1 ms. Stack: com.vaadin.ui.UI.doInit::org.opennms.features.topology.app.internal.TopologyUI.init::org.opennms.features.topology.app.internal.VEProviderGraphContainer.redoLayout
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:312:TimeLogger org.opennms.features.topology.app.internal.OsgiVerticesUpdateManager: org.opennms.features.topology.app.internal.OsgiVerticesUpdateManager@833217f: call to fireGraphChanged took 35 ms. Stack: com.vaadin.ui.UI.doInit::org.opennms.features.topology.app.internal.TopologyUI.init::org.opennms.features.topology.app.internal.VEProviderGraphContainer.redoLayout
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:314:TimeLogger org.opennms.features.topology.app.internal.TopologyUI$InfoPanelItemManager: org.opennms.features.topology.app.internal.TopologyUI$InfoPanelItemManager@7b55ebad: call to fireGraphChanged took 704 ms. Stack: com.vaadin.ui.UI.doInit::org.opennms.features.topology.app.internal.TopologyUI.init::org.opennms.features.topology.app.internal.VEProviderGraphContainer.redoLayout
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:315:TimeLogger org.opennms.features.topology.app.internal.ui.ToolbarPanel: org.opennms.features.topology.app.internal.ui.ToolbarPanel@49349c68: call to fireGraphChanged took 0 ms. Stack: com.vaadin.ui.UI.doInit::org.opennms.features.topology.app.internal.TopologyUI.init::org.opennms.features.topology.app.internal.VEProviderGraphContainer.redoLayout
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:316:TimeLogger org.opennms.features.topology.app.internal.ui.breadcrumbs.BreadcrumbComponent: org.opennms.features.topology.app.internal.ui.breadcrumbs.BreadcrumbComponent@18fe31b: call to fireGraphChanged took 2 ms. Stack: com.vaadin.ui.UI.doInit::org.opennms.features.topology.app.internal.TopologyUI.init::org.opennms.features.topology.app.internal.VEProviderGraphContainer.redoLayout
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:317:TimeLogger org.opennms.features.topology.app.internal.ui.LayoutHintComponent: org.opennms.features.topology.app.internal.ui.LayoutHintComponent@1fa7f9fb: call to fireGraphChanged took 820 ms. Stack: com.vaadin.ui.UI.doInit::org.opennms.features.topology.app.internal.TopologyUI.init::org.opennms.features.topology.app.internal.VEProviderGraphContainer.redoLayout
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:318:TimeLogger : call to redoLayout took 9606 ms. Stack: com.vaadin.server.communication.UIInitHandler.getBrowserDetailsUI::com.vaadin.ui.UI.doInit::org.opennms.features.topology.app.internal.TopologyUI.init
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:319:TimeLogger org.opennms.features.topology.app.internal.TopologyComponent$2: call to selectionChanged took 1 ms. Stack: com.vaadin.server.communication.UIInitHandler.getBrowserDetailsUI::com.vaadin.ui.UI.doInit::org.opennms.features.topology.app.internal.TopologyUI.init
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:320:TimeLogger org.opennms.features.topology.app.internal.TopologyUI: call to selectionChanged took 2 ms. Stack: com.vaadin.server.communication.UIInitHandler.getBrowserDetailsUI::com.vaadin.ui.UI.doInit::org.opennms.features.topology.app.internal.TopologyUI.init
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:321:TimeLogger org.opennms.features.topology.app.internal.ui.SearchBox: call to selectionChanged took 0 ms. Stack: com.vaadin.server.communication.UIInitHandler.getBrowserDetailsUI::com.vaadin.ui.UI.doInit::org.opennms.features.topology.app.internal.TopologyUI.init
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:322:TimeLogger org.opennms.features.topology.app.internal.OsgiVerticesUpdateManager: call to selectionChanged took 1 ms. Stack: com.vaadin.server.communication.UIInitHandler.getBrowserDetailsUI::com.vaadin.ui.UI.doInit::org.opennms.features.topology.app.internal.TopologyUI.init
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:324:TimeLogger org.opennms.features.topology.app.internal.TopologyUI$InfoPanelItemManager: call to selectionChanged took 659 ms. Stack: com.vaadin.server.communication.UIInitHandler.getBrowserDetailsUI::com.vaadin.ui.UI.doInit::org.opennms.features.topology.app.internal.TopologyUI.init
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:325:TimeLogger org.opennms.features.topology.app.internal.ui.ToolbarPanel: call to selectionChanged took 0 ms. Stack: com.vaadin.server.communication.UIInitHandler.getBrowserDetailsUI::com.vaadin.ui.UI.doInit::org.opennms.features.topology.app.internal.TopologyUI.init
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:326:TimeLogger init 4: call to init took 10318 ms. Stack: com.vaadin.server.communication.UIInitHandler.synchronizedHandleRequest::com.vaadin.server.communication.UIInitHandler.getBrowserDetailsUI::com.vaadin.ui.UI.doInit
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:327:TimeLogger : call to init took 69028 ms. Stack: com.vaadin.server.communication.UIInitHandler.synchronizedHandleRequest::com.vaadin.server.communication.UIInitHandler.getBrowserDetailsUI::com.vaadin.ui.UI.doInit



Performance optimized (without history):

patrick@krassomat:/apps/git/opennms_foundation_2017$ grep -rnw './target/opennms-21.1.0-SNAPSHOT/logs' -e 'TimeLogger'
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:47:TimeLogger : call to findAll took 18459 ms. Stack: sun.reflect.NativeMethodAccessorImpl.invoke::sun.reflect.NativeMethodAccessorImpl.invoke0::org.opennms.netmgt.provision.service.DefaultProvisionService.getScheduleForNodes
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:76:TimeLogger init 1: call to init took 124 ms. Stack: com.vaadin.server.communication.UIInitHandler.synchronizedHandleRequest::com.vaadin.server.communication.UIInitHandler.getBrowserDetailsUI::com.vaadin.ui.UI.doInit
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:77:TimeLogger : call to createLayouts took 1256 ms. Stack: com.vaadin.server.communication.UIInitHandler.getBrowserDetailsUI::com.vaadin.ui.UI.doInit::org.opennms.features.topology.app.internal.TopologyUI.init
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:78:TimeLogger : call to loadUserSettings took 2 ms. Stack: com.vaadin.server.communication.UIInitHandler.getBrowserDetailsUI::com.vaadin.ui.UI.doInit::org.opennms.features.topology.app.internal.TopologyUI.init
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:79:TimeLogger init 2: call to init took 1263 ms. Stack: com.vaadin.server.communication.UIInitHandler.synchronizedHandleRequest::com.vaadin.server.communication.UIInitHandler.getBrowserDetailsUI::com.vaadin.ui.UI.doInit
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:80:TimeLogger init 3.1: call to init took 2 ms. Stack: com.vaadin.server.communication.UIInitHandler.synchronizedHandleRequest::com.vaadin.server.communication.UIInitHandler.getBrowserDetailsUI::com.vaadin.ui.UI.doInit
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:81:TimeLogger : call to findAll took 1 ms. Stack: org.opennms.features.topology.plugins.topo.linkd.internal.LinkdTopologyProvider.doRefresh::org.opennms.features.topology.plugins.topo.linkd.internal.LinkdTopologyProvider.loadVertices::Proxyf692d948_219d_4251_a736_8ee8e77ffc01.findAll
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:82:TimeLogger : call to loadVertices took 767 ms. Stack: org.opennms.features.topology.api.support.VertexHopGraphProvider.refresh::org.opennms.features.topology.plugins.topo.linkd.internal.LinkdTopologyProvider.refresh::org.opennms.features.topology.plugins.topo.linkd.internal.LinkdTopologyProvider.doRefresh
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:83:TimeLogger CdpElementDao.findAll(): call to getCdpLinks took 766 ms. Stack: org.opennms.features.topology.plugins.topo.linkd.internal.LinkdTopologyProvider.refresh::org.opennms.features.topology.plugins.topo.linkd.internal.LinkdTopologyProvider.doRefresh::org.opennms.features.topology.plugins.topo.linkd.internal.LinkdTopologyProvider.loadEdges
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:84:TimeLogger CdpLinkDao.findAll(): call to getCdpLinks took 1401 ms. Stack: org.opennms.features.topology.plugins.topo.linkd.internal.LinkdTopologyProvider.refresh::org.opennms.features.topology.plugins.topo.linkd.internal.LinkdTopologyProvider.doRefresh::org.opennms.features.topology.plugins.topo.linkd.internal.LinkdTopologyProvider.loadEdges
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:85:TimeLogger : call to matchCdpLinks took 199 ms. Stack: org.opennms.features.topology.plugins.topo.linkd.internal.LinkdTopologyProvider.doRefresh::org.opennms.features.topology.plugins.topo.linkd.internal.LinkdTopologyProvider.loadEdges::org.opennms.features.topology.plugins.topo.linkd.internal.LinkdTopologyProvider.getCdpLinks
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:86:TimeLogger iterate CdpLinkPairs: call to getCdpLinks took 24925 ms. Stack: org.opennms.features.topology.plugins.topo.linkd.internal.LinkdTopologyProvider.refresh::org.opennms.features.topology.plugins.topo.linkd.internal.LinkdTopologyProvider.doRefresh::org.opennms.features.topology.plugins.topo.linkd.internal.LinkdTopologyProvider.loadEdges
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:87:TimeLogger : call to getCdpLinks took 27291 ms. Stack: org.opennms.features.topology.plugins.topo.linkd.internal.LinkdTopologyProvider.refresh::org.opennms.features.topology.plugins.topo.linkd.internal.LinkdTopologyProvider.doRefresh::org.opennms.features.topology.plugins.topo.linkd.internal.LinkdTopologyProvider.loadEdges
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:88:TimeLogger : call to loadEdges took 27344 ms. Stack: org.opennms.features.topology.api.support.VertexHopGraphProvider.refresh::org.opennms.features.topology.plugins.topo.linkd.internal.LinkdTopologyProvider.refresh::org.opennms.features.topology.plugins.topo.linkd.internal.LinkdTopologyProvider.doRefresh
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:89:TimeLogger org.opennms.features.topology.api.Callbacks$$Lambda$353/736057545@c2fcfa4: call to selectTopologyProvider took 31 ms. Stack: org.opennms.features.topology.app.internal.operations.MetaTopologySelectorOperation.execute::org.opennms.features.topology.app.internal.operations.MetaTopologySelectorOperation.execute::org.opennms.features.topology.app.internal.operations.MetaTopologySelectorOperation.execute
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:90:TimeLogger : call to redoLayout took 372 ms. Stack: org.opennms.features.topology.app.internal.operations.MetaTopologySelectorOperation.execute::org.opennms.features.topology.app.internal.operations.MetaTopologySelectorOperation.execute::org.opennms.features.topology.app.internal.VEProviderGraphContainer.selectTopologyProvider
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:91:TimeLogger : call to selectTopologyProvider took 28689 ms. Stack: org.opennms.features.topology.app.internal.operations.MetaTopologySelectorOperation.execute::org.opennms.features.topology.app.internal.operations.MetaTopologySelectorOperation.execute::org.opennms.features.topology.app.internal.operations.MetaTopologySelectorOperation.execute
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:92:TimeLogger init 3.2 org.opennms.features.topology.app.internal.operations.MetaTopologySelectorOperation@1b014425: call to init took 28692 ms. Stack: com.vaadin.server.communication.UIInitHandler.synchronizedHandleRequest::com.vaadin.server.communication.UIInitHandler.getBrowserDetailsUI::com.vaadin.ui.UI.doInit
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:93:TimeLogger : call to redoLayout took 1 ms. Stack: org.opennms.features.topology.app.internal.TopologyUI.init::org.opennms.features.topology.app.internal.TopologyUI$TopologyUIRequestHandler.access$1400::org.opennms.features.topology.app.internal.TopologyUI$TopologyUIRequestHandler.handleRequestParameter
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:94:TimeLogger init 3: call to init took 28698 ms. Stack: com.vaadin.server.communication.UIInitHandler.synchronizedHandleRequest::com.vaadin.server.communication.UIInitHandler.getBrowserDetailsUI::com.vaadin.ui.UI.doInit
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:95:TimeLogger : call to redoLayout took 335 ms. Stack: com.vaadin.server.communication.UIInitHandler.getBrowserDetailsUI::com.vaadin.ui.UI.doInit::org.opennms.features.topology.app.internal.TopologyUI.init
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:96:TimeLogger org.opennms.features.topology.app.internal.TopologyComponent$2: call to selectionChanged took 0 ms. Stack: com.vaadin.server.communication.UIInitHandler.getBrowserDetailsUI::com.vaadin.ui.UI.doInit::org.opennms.features.topology.app.internal.TopologyUI.init
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:97:TimeLogger org.opennms.features.topology.app.internal.TopologyUI: call to selectionChanged took 55 ms. Stack: com.vaadin.server.communication.UIInitHandler.getBrowserDetailsUI::com.vaadin.ui.UI.doInit::org.opennms.features.topology.app.internal.TopologyUI.init
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:98:TimeLogger org.opennms.features.topology.app.internal.ui.SearchBox: call to selectionChanged took 0 ms. Stack: com.vaadin.server.communication.UIInitHandler.getBrowserDetailsUI::com.vaadin.ui.UI.doInit::org.opennms.features.topology.app.internal.TopologyUI.init
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:99:TimeLogger org.opennms.features.topology.app.internal.OsgiVerticesUpdateManager: call to selectionChanged took 7 ms. Stack: com.vaadin.server.communication.UIInitHandler.getBrowserDetailsUI::com.vaadin.ui.UI.doInit::org.opennms.features.topology.app.internal.TopologyUI.init
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:100:TimeLogger org.opennms.features.topology.app.internal.TopologyUI$InfoPanelItemManager: call to selectionChanged took 1192 ms. Stack: com.vaadin.server.communication.UIInitHandler.getBrowserDetailsUI::com.vaadin.ui.UI.doInit::org.opennms.features.topology.app.internal.TopologyUI.init
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:101:TimeLogger org.opennms.features.topology.app.internal.ui.ToolbarPanel: call to selectionChanged took 0 ms. Stack: com.vaadin.server.communication.UIInitHandler.getBrowserDetailsUI::com.vaadin.ui.UI.doInit::org.opennms.features.topology.app.internal.TopologyUI.init
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:102:TimeLogger init 4: call to init took 1607 ms. Stack: com.vaadin.server.communication.UIInitHandler.synchronizedHandleRequest::com.vaadin.server.communication.UIInitHandler.getBrowserDetailsUI::com.vaadin.ui.UI.doInit
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:103:TimeLogger : call to init took 31692 ms. Stack: com.vaadin.server.communication.UIInitHandler.synchronizedHandleRequest::com.vaadin.server.communication.UIInitHandler.getBrowserDetailsUI::com.vaadin.ui.UI.doInit

Performance Optimized (with history):
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:79:TimeLogger : call to findAll took 26361 ms. Stack: sun.reflect.NativeMethodAccessorImpl.invoke::sun.reflect.NativeMethodAccessorImpl.invoke0::org.opennms.netmgt.provision.service.DefaultProvisionService.getScheduleForNodes
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:211:TimeLogger init 1: call to init took 100 ms. Stack: com.vaadin.server.communication.UIInitHandler.synchronizedHandleRequest::com.vaadin.server.communication.UIInitHandler.getBrowserDetailsUI::com.vaadin.ui.UI.doInit
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:212:TimeLogger : call to createLayouts took 1324 ms. Stack: com.vaadin.server.communication.UIInitHandler.getBrowserDetailsUI::com.vaadin.ui.UI.doInit::org.opennms.features.topology.app.internal.TopologyUI.init
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:213:TimeLogger org.opennms.features.topology.plugins.topo.bsm.operations.HideLeafElementToggleOperation@48aaa64f: call to apply took 0 ms. Stack: org.opennms.features.topology.app.internal.TopologyUI.applyHistory::Proxy564c23f3_8023_4415_a968_ffface81310d.applyHistory::org.opennms.features.topology.plugins.topo.BundleContextHistoryManager.applyHistory
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:214:TimeLogger org.opennms.features.topology.plugins.topo.bsm.operations.InheritStateOperation@7196156f: call to apply took 1 ms. Stack: org.opennms.features.topology.app.internal.TopologyUI.applyHistory::Proxy564c23f3_8023_4415_a968_ffface81310d.applyHistory::org.opennms.features.topology.plugins.topo.BundleContextHistoryManager.applyHistory
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:215:TimeLogger org.opennms.features.topology.plugins.topo.bsm.operations.SimulationModeOperation@2cbac833: call to apply took 0 ms. Stack: org.opennms.features.topology.app.internal.TopologyUI.applyHistory::Proxy564c23f3_8023_4415_a968_ffface81310d.applyHistory::org.opennms.features.topology.plugins.topo.BundleContextHistoryManager.applyHistory
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:220:TimeLogger : call to findAll took 20480 ms. Stack: org.opennms.features.topology.plugins.topo.linkd.internal.LinkdTopologyProvider.doRefresh::org.opennms.features.topology.plugins.topo.linkd.internal.LinkdTopologyProvider.loadVertices::Proxybd5f3326_1580_4c49_ba34_f9af930e3532.findAll
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:221:TimeLogger : call to loadVertices took 21295 ms. Stack: org.opennms.features.topology.api.support.VertexHopGraphProvider.refresh::org.opennms.features.topology.plugins.topo.linkd.internal.LinkdTopologyProvider.refresh::org.opennms.features.topology.plugins.topo.linkd.internal.LinkdTopologyProvider.doRefresh
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:222:TimeLogger CdpElementDao.findAll(): call to getCdpLinks took 94 ms. Stack: org.opennms.features.topology.plugins.topo.linkd.internal.LinkdTopologyProvider.refresh::org.opennms.features.topology.plugins.topo.linkd.internal.LinkdTopologyProvider.doRefresh::org.opennms.features.topology.plugins.topo.linkd.internal.LinkdTopologyProvider.loadEdges
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:226:TimeLogger CdpLinkDao.findAll(): call to getCdpLinks took 2371 ms. Stack: org.opennms.features.topology.plugins.topo.linkd.internal.LinkdTopologyProvider.refresh::org.opennms.features.topology.plugins.topo.linkd.internal.LinkdTopologyProvider.doRefresh::org.opennms.features.topology.plugins.topo.linkd.internal.LinkdTopologyProvider.loadEdges
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:227:TimeLogger : call to matchCdpLinks took 215 ms. Stack: org.opennms.features.topology.plugins.topo.linkd.internal.LinkdTopologyProvider.doRefresh::org.opennms.features.topology.plugins.topo.linkd.internal.LinkdTopologyProvider.loadEdges::org.opennms.features.topology.plugins.topo.linkd.internal.LinkdTopologyProvider.getCdpLinks
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:229:TimeLogger iterate CdpLinkPairs: call to getCdpLinks took 858 ms. Stack: org.opennms.features.topology.plugins.topo.linkd.internal.LinkdTopologyProvider.refresh::org.opennms.features.topology.plugins.topo.linkd.internal.LinkdTopologyProvider.doRefresh::org.opennms.features.topology.plugins.topo.linkd.internal.LinkdTopologyProvider.loadEdges
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:230:TimeLogger : call to getCdpLinks took 3539 ms. Stack: org.opennms.features.topology.plugins.topo.linkd.internal.LinkdTopologyProvider.refresh::org.opennms.features.topology.plugins.topo.linkd.internal.LinkdTopologyProvider.doRefresh::org.opennms.features.topology.plugins.topo.linkd.internal.LinkdTopologyProvider.loadEdges
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:231:TimeLogger : call to loadEdges took 3613 ms. Stack: org.opennms.features.topology.api.support.VertexHopGraphProvider.refresh::org.opennms.features.topology.plugins.topo.linkd.internal.LinkdTopologyProvider.refresh::org.opennms.features.topology.plugins.topo.linkd.internal.LinkdTopologyProvider.doRefresh
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:232:TimeLogger org.opennms.features.topology.api.Callbacks$$Lambda$333/626106856@7ed288ea: call to selectTopologyProvider took 29 ms. Stack: org.opennms.features.topology.app.internal.operations.MetaTopologySelectorOperation.applyHistory::org.opennms.features.topology.app.internal.operations.MetaTopologySelectorOperation.execute::org.opennms.features.topology.app.internal.operations.MetaTopologySelectorOperation.execute
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:234:TimeLogger : call to redoLayout took 419 ms. Stack: org.opennms.features.topology.app.internal.operations.MetaTopologySelectorOperation.execute::org.opennms.features.topology.app.internal.operations.MetaTopologySelectorOperation.execute::org.opennms.features.topology.app.internal.VEProviderGraphContainer.selectTopologyProvider
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:235:TimeLogger : call to selectTopologyProvider took 25527 ms. Stack: org.opennms.features.topology.app.internal.operations.MetaTopologySelectorOperation.applyHistory::org.opennms.features.topology.app.internal.operations.MetaTopologySelectorOperation.execute::org.opennms.features.topology.app.internal.operations.MetaTopologySelectorOperation.execute
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:236:TimeLogger org.opennms.features.topology.app.internal.operations.MetaTopologySelectorOperation@435e27b7: call to apply took 25540 ms. Stack: org.opennms.features.topology.app.internal.TopologyUI.applyHistory::Proxy564c23f3_8023_4415_a968_ffface81310d.applyHistory::org.opennms.features.topology.plugins.topo.BundleContextHistoryManager.applyHistory
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:237:TimeLogger org.opennms.features.topology.app.internal.operations.MetaTopologySelectorOperation@615741e6: call to apply took 0 ms. Stack: org.opennms.features.topology.app.internal.TopologyUI.applyHistory::Proxy564c23f3_8023_4415_a968_ffface81310d.applyHistory::org.opennms.features.topology.plugins.topo.BundleContextHistoryManager.applyHistory
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:238:TimeLogger org.opennms.features.topology.app.internal.operations.MetaTopologySelectorOperation@6493c604: call to apply took 0 ms. Stack: org.opennms.features.topology.app.internal.TopologyUI.applyHistory::Proxy564c23f3_8023_4415_a968_ffface81310d.applyHistory::org.opennms.features.topology.plugins.topo.BundleContextHistoryManager.applyHistory
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:239:TimeLogger org.opennms.features.topology.app.internal.operations.MetaTopologySelectorOperation@62c48fd0: call to apply took 0 ms. Stack: org.opennms.features.topology.app.internal.TopologyUI.applyHistory::Proxy564c23f3_8023_4415_a968_ffface81310d.applyHistory::org.opennms.features.topology.plugins.topo.BundleContextHistoryManager.applyHistory
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:240:TimeLogger org.opennms.features.topology.app.internal.operations.MetaTopologySelectorOperation@4f664bb8: call to apply took 1 ms. Stack: org.opennms.features.topology.app.internal.TopologyUI.applyHistory::Proxy564c23f3_8023_4415_a968_ffface81310d.applyHistory::org.opennms.features.topology.plugins.topo.BundleContextHistoryManager.applyHistory
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:241:TimeLogger org.opennms.features.topology.app.internal.operations.RealUltimateLayoutOperation@14e57bc3: call to apply took 0 ms. Stack: org.opennms.features.topology.app.internal.TopologyUI.applyHistory::Proxy564c23f3_8023_4415_a968_ffface81310d.applyHistory::org.opennms.features.topology.plugins.topo.BundleContextHistoryManager.applyHistory
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:242:TimeLogger org.opennms.features.topology.app.internal.operations.HierarchyLayoutOperation@6e3c3cbd: call to apply took 0 ms. Stack: org.opennms.features.topology.app.internal.TopologyUI.applyHistory::Proxy564c23f3_8023_4415_a968_ffface81310d.applyHistory::org.opennms.features.topology.plugins.topo.BundleContextHistoryManager.applyHistory
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:243:TimeLogger org.opennms.features.topology.app.internal.operations.KKLayoutOperation@28c084a5: call to apply took 0 ms. Stack: org.opennms.features.topology.app.internal.TopologyUI.applyHistory::Proxy564c23f3_8023_4415_a968_ffface81310d.applyHistory::org.opennms.features.topology.plugins.topo.BundleContextHistoryManager.applyHistory
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:244:TimeLogger org.opennms.features.topology.app.internal.operations.CircleLayoutOperation@5506318e: call to apply took 1 ms. Stack: org.opennms.features.topology.app.internal.TopologyUI.applyHistory::Proxy564c23f3_8023_4415_a968_ffface81310d.applyHistory::org.opennms.features.topology.plugins.topo.BundleContextHistoryManager.applyHistory
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:245:TimeLogger : call to redoLayout took 0 ms. Stack: Proxy7d98fd70_3d0a_4973_8e9b_169e339b26eb.applyHistory::org.opennms.features.topology.app.internal.operations.LayoutOperation.applyHistory::org.opennms.features.topology.app.internal.operations.LayoutOperation.execute
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:246:TimeLogger org.opennms.features.topology.app.internal.operations.D3TopoLayoutOperation@6a02738e: call to apply took 0 ms. Stack: org.opennms.features.topology.app.internal.TopologyUI.applyHistory::Proxy564c23f3_8023_4415_a968_ffface81310d.applyHistory::org.opennms.features.topology.plugins.topo.BundleContextHistoryManager.applyHistory
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:247:TimeLogger org.opennms.features.topology.app.internal.operations.ISOMLayoutOperation@655463a7: call to apply took 1 ms. Stack: org.opennms.features.topology.app.internal.TopologyUI.applyHistory::Proxy564c23f3_8023_4415_a968_ffface81310d.applyHistory::org.opennms.features.topology.plugins.topo.BundleContextHistoryManager.applyHistory
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:248:TimeLogger org.opennms.features.topology.app.internal.operations.GridLayoutOperation@499d2604: call to apply took 0 ms. Stack: org.opennms.features.topology.app.internal.TopologyUI.applyHistory::Proxy564c23f3_8023_4415_a968_ffface81310d.applyHistory::org.opennms.features.topology.plugins.topo.BundleContextHistoryManager.applyHistory
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:249:TimeLogger org.opennms.features.topology.app.internal.operations.SpringLayoutOperation@2df3e4f8: call to apply took 0 ms. Stack: org.opennms.features.topology.app.internal.TopologyUI.applyHistory::Proxy564c23f3_8023_4415_a968_ffface81310d.applyHistory::org.opennms.features.topology.plugins.topo.BundleContextHistoryManager.applyHistory
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:250:TimeLogger org.opennms.features.topology.app.internal.operations.ManualLayoutOperation@54946ccb: call to apply took 1 ms. Stack: org.opennms.features.topology.app.internal.TopologyUI.applyHistory::Proxy564c23f3_8023_4415_a968_ffface81310d.applyHistory::org.opennms.features.topology.plugins.topo.BundleContextHistoryManager.applyHistory
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:251:TimeLogger org.opennms.features.topology.app.internal.operations.AutoRefreshToggleOperation@121b74a5: call to apply took 0 ms. Stack: org.opennms.features.topology.app.internal.TopologyUI.applyHistory::Proxy564c23f3_8023_4415_a968_ffface81310d.applyHistory::org.opennms.features.topology.plugins.topo.BundleContextHistoryManager.applyHistory
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:252:TimeLogger org.opennms.features.topology.app.internal.operations.TopoFRLayoutOperation@3216cde4: call to apply took 0 ms. Stack: org.opennms.features.topology.app.internal.TopologyUI.applyHistory::Proxy564c23f3_8023_4415_a968_ffface81310d.applyHistory::org.opennms.features.topology.plugins.topo.BundleContextHistoryManager.applyHistory
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:253:TimeLogger history 1: call to apply took 25547 ms. Stack: org.opennms.features.topology.app.internal.TopologyUI.applyHistory::Proxy564c23f3_8023_4415_a968_ffface81310d.applyHistory::org.opennms.features.topology.plugins.topo.BundleContextHistoryManager.applyHistory
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:254:TimeLogger history 2: call to apply took 1 ms. Stack: org.opennms.features.topology.app.internal.TopologyUI.applyHistory::Proxy564c23f3_8023_4415_a968_ffface81310d.applyHistory::org.opennms.features.topology.plugins.topo.BundleContextHistoryManager.applyHistory
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:255:TimeLogger history 3: call to apply took 1 ms. Stack: org.opennms.features.topology.app.internal.TopologyUI.applyHistory::Proxy564c23f3_8023_4415_a968_ffface81310d.applyHistory::org.opennms.features.topology.plugins.topo.BundleContextHistoryManager.applyHistory
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:256:TimeLogger history 4: call to apply took 2 ms. Stack: org.opennms.features.topology.app.internal.TopologyUI.applyHistory::Proxy564c23f3_8023_4415_a968_ffface81310d.applyHistory::org.opennms.features.topology.plugins.topo.BundleContextHistoryManager.applyHistory
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:257:TimeLogger : call to loadUserSettings took 25627 ms. Stack: com.vaadin.server.communication.UIInitHandler.getBrowserDetailsUI::com.vaadin.ui.UI.doInit::org.opennms.features.topology.app.internal.TopologyUI.init
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:258:TimeLogger init 2: call to init took 26955 ms. Stack: com.vaadin.server.communication.UIInitHandler.synchronizedHandleRequest::com.vaadin.server.communication.UIInitHandler.getBrowserDetailsUI::com.vaadin.ui.UI.doInit
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:260:TimeLogger : call to redoLayout took 236 ms. Stack: org.opennms.features.topology.app.internal.TopologyUI.init::org.opennms.features.topology.app.internal.TopologyUI$TopologyUIRequestHandler.access$1400::org.opennms.features.topology.app.internal.TopologyUI$TopologyUIRequestHandler.handleRequestParameter
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:261:TimeLogger init 3: call to init took 241 ms. Stack: com.vaadin.server.communication.UIInitHandler.synchronizedHandleRequest::com.vaadin.server.communication.UIInitHandler.getBrowserDetailsUI::com.vaadin.ui.UI.doInit
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:262:TimeLogger : call to redoLayout took 186 ms. Stack: com.vaadin.server.communication.UIInitHandler.getBrowserDetailsUI::com.vaadin.ui.UI.doInit::org.opennms.features.topology.app.internal.TopologyUI.init
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:263:TimeLogger org.opennms.features.topology.app.internal.TopologyComponent$2: call to selectionChanged took 7 ms. Stack: com.vaadin.server.communication.UIInitHandler.getBrowserDetailsUI::com.vaadin.ui.UI.doInit::org.opennms.features.topology.app.internal.TopologyUI.init
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:264:TimeLogger org.opennms.features.topology.app.internal.TopologyUI: call to selectionChanged took 4 ms. Stack: com.vaadin.server.communication.UIInitHandler.getBrowserDetailsUI::com.vaadin.ui.UI.doInit::org.opennms.features.topology.app.internal.TopologyUI.init
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:265:TimeLogger org.opennms.features.topology.app.internal.ui.SearchBox: call to selectionChanged took 0 ms. Stack: com.vaadin.server.communication.UIInitHandler.getBrowserDetailsUI::com.vaadin.ui.UI.doInit::org.opennms.features.topology.app.internal.TopologyUI.init
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:266:TimeLogger org.opennms.features.topology.app.internal.OsgiVerticesUpdateManager: call to selectionChanged took 2 ms. Stack: com.vaadin.server.communication.UIInitHandler.getBrowserDetailsUI::com.vaadin.ui.UI.doInit::org.opennms.features.topology.app.internal.TopologyUI.init
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:268:TimeLogger org.opennms.features.topology.app.internal.TopologyUI$InfoPanelItemManager: call to selectionChanged took 1020 ms. Stack: com.vaadin.server.communication.UIInitHandler.getBrowserDetailsUI::com.vaadin.ui.UI.doInit::org.opennms.features.topology.app.internal.TopologyUI.init
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:269:TimeLogger org.opennms.features.topology.app.internal.ui.ToolbarPanel: call to selectionChanged took 1 ms. Stack: com.vaadin.server.communication.UIInitHandler.getBrowserDetailsUI::com.vaadin.ui.UI.doInit::org.opennms.features.topology.app.internal.TopologyUI.init
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:270:TimeLogger init 4: call to init took 1255 ms. Stack: com.vaadin.server.communication.UIInitHandler.synchronizedHandleRequest::com.vaadin.server.communication.UIInitHandler.getBrowserDetailsUI::com.vaadin.ui.UI.doInit
./target/opennms-21.1.0-SNAPSHOT/logs/output.log:271:TimeLogger : call to init took 28551 ms. Stack: com.vaadin.server.communication.UIInitHandler.synchronizedHandleRequest::com.vaadin.server.communication.UIInitHandler.getBrowserDetailsUI::com.vaadin.ui.UI.doInit
