### PR TITLE
NMS-10418: Create views for SQL based reporting

### DIFF
--- a/core/schema/src/main/liquibase/24.0.0/changelog.xml
+++ b/core/schema/src/main/liquibase/24.0.0/changelog.xml
@@ -24,5 +24,220 @@
     <dropTable tableName="ncscomponent" />
   </changeSet>
 
+  <changeSet author="ronny" id="24.0.0-node-categories-nms-10418">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <viewExists viewName="node_categories"/>
+      </not>
+    </preConditions>
+    <sql>
+      CREATE VIEW node_categories AS (
+        SELECT
+          n.*,
+          COALESCE(s_cat.categoryname, 'no category') AS categoryname
+        FROM
+          node n
+        LEFT JOIN
+          category_node cn
+        ON
+          n.nodeid = cn.nodeid
+        LEFT JOIN
+          categories s_cat
+        ON
+          cn.categoryid = s_cat.categoryid
+      );
+    </sql>
+  </changeSet>
+
+  <changeSet author="ronny" id="24.0.0-node-alarms-nms-10418">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <viewExists viewName="node_alarms"/>
+      </not>
+    </preConditions>
+    <sql>
+      CREATE VIEW node_alarms AS (
+        SELECT
+          n.nodeid,
+          n.nodecreatetime,
+          n.nodeparentid,
+          n.nodetype,
+          n.nodesysoid,
+          n.nodesysname,
+          n.nodesysdescription,
+          n.nodesyslocation,
+          n.nodesyscontact,
+          n.nodelabel,
+          n.nodelabelsource,
+          n.nodenetbiosname,
+          n.nodedomainname,
+          n.operatingsystem,
+          n.lastcapsdpoll,
+          n.foreignsource,
+          n.foreignid,
+          n.location,
+          a.alarmid,
+          a.eventuei,
+          a.ipaddr,
+          a.reductionkey,
+          a.alarmtype,
+          a.counter,
+          a.severity,
+          a.lasteventid,
+          a.firsteventtime,
+          a.lasteventtime,
+          a.firstautomationtime,
+          a.lastautomationtime,
+          a.description,
+          a.logmsg,
+          a.operinstruct,
+          a.tticketid,
+          a.tticketstate,
+          a.suppresseduntil,
+          a.suppresseduser,
+          a.suppressedtime,
+          a.alarmackuser,
+          a.alarmacktime,
+          a.managedobjectinstance,
+          a.managedobjecttype,
+          a.applicationdn,
+          a.ossprimarykey,
+          a.x733alarmtype,
+          a.qosalarmstate,
+          a.clearkey,
+          a.ifindex,
+          a.stickymemo,
+          a.systemid,
+          (a.alarmacktime NOTNULL) AS acknowledged,
+          COALESCE(s_cat.categoryname, 'no category') AS categoryname,
+          s_cat.categorydescription,
+          s.servicename,
+          nas.max_alarm_severity,
+          nas.max_alarm_severity_unack,
+          nas.alarm_count_unack,
+          nas.alarm_count
+        FROM
+          node n
+        JOIN
+          alarms a
+        ON
+          n.nodeid = a.nodeid
+        JOIN
+          node_alarm_status nas
+        ON
+          a.nodeid = nas.nodeid
+        LEFT JOIN
+          service s
+        ON
+          a.serviceid = s.serviceid
+        LEFT JOIN
+          category_node cat
+        ON
+          n.nodeid = cat.nodeid
+        LEFT JOIN
+          categories s_cat
+        ON
+          cat.categoryid = s_cat.categoryid
+      );
+    </sql>
+  </changeSet>
+
+  <changeSet author="ronny" id="24.0.0-node-outages-nms-10418">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <viewExists viewName="node_outages"/>
+      </not>
+    </preConditions>
+    <sql>
+      CREATE VIEW node_outages AS (
+        SELECT
+          outages.outageid,
+          outages.svclosteventid,
+          outages.svcregainedeventid,
+          outages.iflostservice,
+          outages.ifregainedservice,
+          outages.ifserviceid,
+          e.eventuei AS svclosteventuei,
+          e.eventsource,
+          e.alarmid,
+          e.eventseverity,
+          (ifregainedservice NOTNULL) AS resolved,
+          s.servicename,
+          i.serviceid,
+          ipif.ipaddr,
+          COALESCE(outages.ifregainedservice - outages.iflostservice, now() - outages.iflostservice) AS duration,
+          nos.max_outage_severity,
+          nc.*
+        FROM
+          outages
+        JOIN
+          events e
+        ON
+          outages.svclosteventid = e.eventid
+        JOIN
+          ifservices i
+        ON
+          outages.ifserviceid = i.id
+        JOIN
+          service s
+        ON
+          i.serviceid = s.serviceid
+        JOIN
+          ipinterface ipif
+        ON
+          i.ipinterfaceid = ipif.id
+        JOIN
+          node_categories nc
+        ON
+          nc.nodeid = e.nodeid
+        JOIN
+          node_outage_status nos
+        ON
+          nc.nodeid = nos.nodeid
+      );
+    </sql>
+  </changeSet>
+
+  <changeSet author="ronny" id="24.0.0-node-ip-services-nms-10418">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <viewExists viewName="node_ip_services"/>
+      </not>
+    </preConditions>
+    <sql>
+      CREATE VIEW node_ip_services AS (
+        SELECT
+          n.*,
+          ip_if.id AS ip_if_id,
+          ip_if.ipaddr,
+          ip_if.iphostname,
+          ip_if.ismanaged,
+          ip_if.ipstatus,
+          ip_if.iplastcapsdpoll,
+          ip_if.issnmpprimary,
+          ip_if.snmpinterfaceid,
+          ip_if.netmask,
+          svc.serviceid,
+          svc.servicename,
+          if_svc.id AS if_svc_id,
+          if_svc.ifindex AS if_svc_ifindex,
+          if_svc.status AS if_svc_status
+        FROM
+          node_categories n
+        LEFT JOIN
+          ipinterface ip_if
+        ON
+          ip_if.nodeid = n.nodeid
+        LEFT JOIN
+          ifservices if_svc
+        ON
+          ip_if.id = if_svc.ipinterfaceid
+        LEFT JOIN
+          service svc
+        ON
+          if_svc.serviceid = svc.serviceid
+      );
+    </sql>
+  </changeSet>
 </databaseChangeLog>
 

--- a/opennms-base-assembly/src/main/filtered/etc/create.sql
+++ b/opennms-base-assembly/src/main/filtered/etc/create.sql
@@ -2441,6 +2441,190 @@ CREATE VIEW node_outage_status AS
  RIGHT JOIN node ON tmp.nodeid = node.nodeid;
 
 --##################################################################
+--# 24.0.0-node-categories-nms-10418
+--##################################################################
+
+CREATE VIEW node_categories AS (
+    SELECT
+        n.*,
+        COALESCE(s_cat.categoryname, 'no category') AS categoryname
+    FROM
+        node n
+    LEFT JOIN
+        category_node cn
+    ON
+        n.nodeid = cn.nodeid
+    LEFT JOIN
+        categories s_cat
+    ON
+        cn.categoryid = s_cat.categoryid
+);
+
+CREATE VIEW node_alarms AS (
+    SELECT
+        n.nodeid,
+        n.nodecreatetime,
+        n.nodeparentid,
+        n.nodetype,
+        n.nodesysoid,
+        n.nodesysname,
+        n.nodesysdescription,
+        n.nodesyslocation,
+        n.nodesyscontact,
+        n.nodelabel,
+        n.nodelabelsource,
+        n.nodenetbiosname,
+        n.nodedomainname,
+        n.operatingsystem,
+        n.lastcapsdpoll,
+        n.foreignsource,
+        n.foreignid,
+        n.location,
+        a.alarmid,
+        a.eventuei,
+        a.ipaddr,
+        a.reductionkey,
+        a.alarmtype,
+        a.counter,
+        a.severity,
+        a.lasteventid,
+        a.firsteventtime,
+        a.lasteventtime,
+        a.firstautomationtime,
+        a.lastautomationtime,
+        a.description,
+        a.logmsg,
+        a.operinstruct,
+        a.tticketid,
+        a.tticketstate,
+        a.suppresseduntil,
+        a.suppresseduser,
+        a.suppressedtime,
+        a.alarmackuser,
+        a.alarmacktime,
+        a.managedobjectinstance,
+        a.managedobjecttype,
+        a.applicationdn,
+        a.ossprimarykey,
+        a.x733alarmtype,
+        a.qosalarmstate,
+        a.clearkey,
+        a.ifindex,
+        a.stickymemo,
+        a.systemid,
+        (a.alarmacktime NOTNULL) AS acknowledged,
+        COALESCE(s_cat.categoryname, 'no category') AS categoryname,
+        s_cat.categorydescription,
+        s.servicename,
+        nas.max_alarm_severity,
+        nas.max_alarm_severity_unack,
+        nas.alarm_count_unack,
+        nas.alarm_count
+    FROM
+        node n
+    JOIN
+        alarms a
+    ON
+        n.nodeid = a.nodeid
+    JOIN
+        node_alarm_status nas
+    ON
+        a.nodeid = nas.nodeid
+    LEFT JOIN
+        service s
+    ON
+        a.serviceid = s.serviceid
+    LEFT JOIN
+        category_node cat
+    ON
+        n.nodeid = cat.nodeid
+    LEFT JOIN
+        categories s_cat
+    ON
+        cat.categoryid = s_cat.categoryid
+);
+
+CREATE VIEW node_outages AS (
+    SELECT
+        outages.outageid,
+        outages.svclosteventid,
+        outages.svcregainedeventid,
+        outages.iflostservice,
+        outages.ifregainedservice,
+        outages.ifserviceid,
+        e.eventuei AS svclosteventuei,
+        e.eventsource,
+        e.alarmid,
+        e.eventseverity,
+        (ifregainedservice NOTNULL) AS resolved,
+        s.servicename,
+        i.serviceid,
+        ipif.ipaddr,
+        COALESCE(outages.ifregainedservice - outages.iflostservice, now() - outages.iflostservice) AS duration,
+        nos.max_outage_severity,
+        nc.*
+    FROM
+        outages
+    JOIN
+        events e
+    ON
+        outages.svclosteventid = e.eventid
+    JOIN
+        ifservices i
+    ON
+        outages.ifserviceid = i.id
+    JOIN
+        service s
+    ON
+        i.serviceid = s.serviceid
+    JOIN
+        ipinterface ipif
+    ON
+        i.ipinterfaceid = ipif.id
+    JOIN
+        node_categories nc
+    ON
+        nc.nodeid = e.nodeid
+    JOIN
+        node_outage_status nos
+    ON
+        nc.nodeid = nos.nodeid
+);
+
+CREATE VIEW node_ip_services AS (
+    SELECT
+        n.*,
+        ip_if.id AS ip_if_id,
+        ip_if.ipaddr,
+        ip_if.iphostname,
+        ip_if.ismanaged,
+        ip_if.ipstatus,
+        ip_if.iplastcapsdpoll,
+        ip_if.issnmpprimary,
+        ip_if.snmpinterfaceid,
+        ip_if.netmask,
+        svc.serviceid,
+        svc.servicename,
+        if_svc.id AS if_svc_id,
+        if_svc.ifindex AS if_svc_ifindex,
+        if_svc.status AS if_svc_status
+    FROM
+        node_categories n
+    LEFT JOIN
+        ipinterface ip_if
+    ON
+        ip_if.nodeid = n.nodeid
+    LEFT JOIN
+        ifservices if_svc
+    ON
+        ip_if.id = if_svc.ipinterfaceid
+    LEFT JOIN
+        service svc
+    ON
+        if_svc.serviceid = svc.serviceid
+);
+
+--##################################################################
 --# Classification tables
 --##################################################################
 CREATE TABLE classification_groups (

--- a/opennms-dao/src/test/java/org/opennms/netmgt/dao/ReportingSqlViewTestIT.java
+++ b/opennms-dao/src/test/java/org/opennms/netmgt/dao/ReportingSqlViewTestIT.java
@@ -1,0 +1,88 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2017-2018 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.dao;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.opennms.core.test.OpenNMSJUnit4ClassRunner;
+import org.opennms.core.test.db.annotations.JUnitTemporaryDatabase;
+import org.opennms.test.JUnitConfigurationEnvironment;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ContextConfiguration;
+
+@RunWith(OpenNMSJUnit4ClassRunner.class)
+@ContextConfiguration(locations = {
+        "classpath:/META-INF/opennms/applicationContext-commonConfigs.xml",
+        "classpath:/META-INF/opennms/applicationContext-soa.xml",
+        "classpath:/META-INF/opennms/applicationContext-dao.xml",
+        "classpath:/META-INF/opennms/applicationContext-databasePopulator.xml"})
+@JUnitConfigurationEnvironment
+@JUnitTemporaryDatabase
+public class ReportingSqlViewTestIT {
+
+    @Autowired
+    private DatabasePopulator databasePopulator;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Before
+    public void before() {
+        databasePopulator.populateDatabase();
+    }
+
+    @After
+    public void after() {
+        databasePopulator.resetDatabase();
+    }
+
+    @Test
+    public void verifyNodeOutagesViewExist() {
+        Assert.assertNotNull(jdbcTemplate.queryForList("SELECT outageid,nodelabel FROM node_outages;"));
+    }
+
+    @Test
+    public void verifyNodeCategoriesViewExist() {
+        Assert.assertNotNull(jdbcTemplate.queryForList("SELECT nodelabel,categoryname FROM node_categories;"));
+    }
+
+    @Test
+    public void verifyNodeAlarmsViewExist() {
+        Assert.assertNotNull(jdbcTemplate.queryForList("SELECT alarmid,nodelabel FROM node_alarms;"));
+    }
+
+    @Test
+    public void verifyNodeIpServicesViewExist() {
+        Assert.assertNotNull(jdbcTemplate.queryForList("SELECT nodelabel,ipaddr,servicename FROM node_ip_services;"));
+    }
+}


### PR DESCRIPTION
Created four views to simplify SQL based reporting which also denormalise the data:

* node_categories: Nodes with categories
* node_alarms: Alarm status from nodes and allow filtering on categories
* node_outages: Outages of nodes and allow filtering on categories
* node_ip_services: Denormalise Nodes and IP services

JIRA: http://issues.opennms.org/browse/NMS-10418
