### PR TITLE
Smith/hzn 1396

### DIFF
--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/SearchProperties.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/SearchProperties.java
@@ -80,6 +80,7 @@ public abstract class SearchProperties {
 
 	static final SortedSet<SearchProperty> ALARM_PROPERTIES = new TreeSet<>(Arrays.asList(new SearchProperty[] {
 		new SearchProperty(OnmsAlarm.class, "id", "ID", INTEGER),
+		new SearchProperty(OnmsAlarm.class, "affectedNodeCount", "affectedNodeCount", INTEGER),
 		new SearchProperty(OnmsAlarm.class, "alarmAckTime", "Acknowledged Time", TIMESTAMP),
 		new SearchProperty(OnmsAlarm.class, "alarmAckUser", "Acknowledging User", STRING),
 		new SearchProperty(OnmsAlarm.class, "alarmType", "Alarm Type", INTEGER, ImmutableMap.<String,String>builder()
@@ -108,6 +109,7 @@ public abstract class SearchProperties {
 		new SearchProperty(OnmsAlarm.class, "qosAlarmState", "QoS Alarm State", STRING),
 		new SearchProperty(OnmsAlarm.class, "reductionKey", "Reduction Key", STRING),
 		new SearchProperty(OnmsAlarm.class, "severity", "Severity", INTEGER, ONMS_SEVERITIES),
+		new SearchProperty(OnmsAlarm.class, "situationAlarmCount", "situationAlarmCount", INTEGER),
 		new SearchProperty(OnmsAlarm.class, "suppressedTime", "Suppressed Time", TIMESTAMP),
 		new SearchProperty(OnmsAlarm.class, "suppressedUntil", "Suppressed Until", TIMESTAMP),
 		new SearchProperty(OnmsAlarm.class, "suppressedUser", "Suppressed User", STRING),

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/SearchProperties.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/SearchProperties.java
@@ -80,7 +80,7 @@ public abstract class SearchProperties {
 
 	static final SortedSet<SearchProperty> ALARM_PROPERTIES = new TreeSet<>(Arrays.asList(new SearchProperty[] {
 		new SearchProperty(OnmsAlarm.class, "id", "ID", INTEGER),
-		new SearchProperty(OnmsAlarm.class, "affectedNodeCount", "affectedNodeCount", INTEGER),
+		new SearchProperty(OnmsAlarm.class, null, "affectedNodeCount", null, "affectedNodeCount", INTEGER, false, false, null),
 		new SearchProperty(OnmsAlarm.class, "alarmAckTime", "Acknowledged Time", TIMESTAMP),
 		new SearchProperty(OnmsAlarm.class, "alarmAckUser", "Acknowledging User", STRING),
 		new SearchProperty(OnmsAlarm.class, "alarmType", "Alarm Type", INTEGER, ImmutableMap.<String,String>builder()
@@ -109,7 +109,7 @@ public abstract class SearchProperties {
 		new SearchProperty(OnmsAlarm.class, "qosAlarmState", "QoS Alarm State", STRING),
 		new SearchProperty(OnmsAlarm.class, "reductionKey", "Reduction Key", STRING),
 		new SearchProperty(OnmsAlarm.class, "severity", "Severity", INTEGER, ONMS_SEVERITIES),
-		new SearchProperty(OnmsAlarm.class, "situationAlarmCount", "situationAlarmCount", INTEGER),
+		new SearchProperty(OnmsAlarm.class, null, "situationAlarmCount", null, "situationAlarmCount", INTEGER, false, false, null),
 		new SearchProperty(OnmsAlarm.class, "suppressedTime", "Suppressed Time", TIMESTAMP),
 		new SearchProperty(OnmsAlarm.class, "suppressedUntil", "Suppressed Until", TIMESTAMP),
 		new SearchProperty(OnmsAlarm.class, "suppressedUser", "Suppressed User", STRING),


### PR DESCRIPTION
This PR exposes 'affectedNodeCount' and 'situationAlarmCount' as Integer properties of the alarms rest endpoint, making the various operators appear in the HELM ui (e.g. eq, gt, ge, lt, le, etc...).
'OrderBy' is not supported by these properties.

* JIRA: https://issues.opennms.org/browse/HZN-1396
