### PR TITLE
HZN-1417: Escalate Situation Severity 

### DIFF
--- a/opennms-alarms/daemon/src/main/java/org/opennms/netmgt/alarmd/drools/DefaultAlarmService.java
+++ b/opennms-alarms/daemon/src/main/java/org/opennms/netmgt/alarmd/drools/DefaultAlarmService.java
@@ -148,7 +148,7 @@ public class DefaultAlarmService implements AlarmService {
     @Override
     @Transactional
     public void setSeverity(OnmsAlarm alarm, OnmsSeverity severity, Date now) {
-        LOG.info("Updating severity on alarm with id: {}", alarm.getId());
+        LOG.info("Updating severity {} on alarm with id: {}", severity, alarm.getId());
         final OnmsAlarm alarmInTrans = alarmDao.get(alarm.getId());
         if (alarmInTrans == null) {
             LOG.warn("Alarm disappeared: {}. Skipping severity update.", alarm);

--- a/opennms-alarms/daemon/src/test/java/org/opennms/netmgt/alarmd/AlarmdBlackboxIT.java
+++ b/opennms-alarms/daemon/src/test/java/org/opennms/netmgt/alarmd/AlarmdBlackboxIT.java
@@ -306,7 +306,7 @@ public class AlarmdBlackboxIT {
         // t=3, two problem alarms + 1 situation
         assertThat(results.getAlarms(3), hasSize(3)); // the situation is also an alarm, so it is counted here
         assertThat(results.getSituations(3), hasSize(1));
-        assertThat(results.getSituation(3), hasSeverity(OnmsSeverity.MAJOR));
+        assertThat(results.getSituation(3), hasSeverity(OnmsSeverity.CRITICAL)); // the situation should be escalated in severity
         // t=4, everything should be cleared
         assertThat(results.getProblemAlarm(4), hasSeverity(OnmsSeverity.CLEARED));
         assertThat(results.getSituation(4), hasSeverity(OnmsSeverity.CLEARED));

--- a/opennms-base-assembly/src/main/filtered/etc/alarmd/drools-rules.d/situations.drl
+++ b/opennms-base-assembly/src/main/filtered/etc/alarmd/drools-rules.d/situations.drl
@@ -49,11 +49,22 @@ rule "setSituationSeverityToMaxAlarmSeverity"
   when
     $situation : OnmsAlarm( isSituation() == true, $relatedAlarmIds : relatedAlarmIds )
     $relatedAlarms : LinkedList() from collect( OnmsAlarm($relatedAlarmIds contains id) )
-    $maxSeverity : OnmsSeverity() from accumulate( OnmsAlarm( $severity : severity ) from $relatedAlarms, maxSeverity( $severity ) )
+    $maxSeverity : OnmsSeverity( isLessThanOrEqual(OnmsSeverity.NORMAL) ) from accumulate( OnmsAlarm( $severity : severity ) from $relatedAlarms, maxSeverity( $severity ) )
     OnmsAlarm( this == $situation, severity != $maxSeverity )
   then
     Date now = new Date(drools.getWorkingMemory().getSessionClock().getCurrentTime());
     alarmService.setSeverity($situation, $maxSeverity, now);
+end
+
+rule "escalateSituationSeverity"
+  when
+    $situation : OnmsAlarm( isSituation() == true, $relatedAlarmIds : relatedAlarmIds )
+    $relatedAlarms : LinkedList() from collect( OnmsAlarm($relatedAlarmIds contains id) )
+    $maxSeverity : OnmsSeverity( isGreaterThan(OnmsSeverity.NORMAL) ) from accumulate( OnmsAlarm( $severity : severity ) from $relatedAlarms, maxSeverity( $severity ) )
+    OnmsAlarm( this == $situation, severity <= $maxSeverity )
+  then
+    Date now = new Date(drools.getWorkingMemory().getSessionClock().getCurrentTime());
+    alarmService.setSeverity($situation, OnmsSeverity.escalate($maxSeverity), now);
 end
 
 rule "SituationHasBeenAcknowledged"


### PR DESCRIPTION
This PR changes the behaviour of the Alarmd Situation rules such that the Situation will be escalated in severity to one level higher than the Max Severity of the related alarms if the Max Severity is greater than NORMAL.

* JIRA: https://issues.opennms.org/browse/HZN-1417 
