### PR TITLE
NMS-10395: Fix Sink API drops messages when there is no connectivity with Kafka 

### DIFF
--- a/core/ipc/sink/kafka-impl/src/main/java/org/opennms/core/ipc/sink/kafka/KafkaRemoteMessageDispatcherFactory.java
+++ b/core/ipc/sink/kafka-impl/src/main/java/org/opennms/core/ipc/sink/kafka/KafkaRemoteMessageDispatcherFactory.java
@@ -73,16 +73,23 @@ public class KafkaRemoteMessageDispatcherFactory extends AbstractMessageDispatch
     public <S extends Message, T extends Message> void dispatch(SinkModule<S, T> module, String topic, T message) {
         try (MDCCloseable mdc = Logging.withPrefixCloseable(MessageConsumerManager.LOG_PREFIX)) {
             LOG.trace("dispatch({}): sending message {}", topic, message);
-            final ProducerRecord<String,String> record = new ProducerRecord<>(topic, module.marshal(message));
-            try {
-                // From KafkaProducer's JavaDoc: The producer is thread safe and should generally be shared among all threads for best performance.
-                final Future<RecordMetadata> future = producer.send(record);
-                // The call to dispatch() is synchronous, so we block until the message was sent
-                future.get();
-            } catch (InterruptedException e) {
-                LOG.warn("Interrupted while sending message to topic {}.", topic, e);
-            } catch (ExecutionException e) {
-                LOG.error("Error occured while sending message to topic {}.", topic, e);
+
+            final ProducerRecord<String, String> record = new ProducerRecord<>(topic, module.marshal(message));
+            // Keep sending record till it delivers successfully.
+            while(true) {
+                try {
+                    // From KafkaProducer's JavaDoc: The producer is thread safe and should generally be shared among all threads for best performance.
+                    final Future<RecordMetadata> future = producer.send(record);
+                    // The call to dispatch() is synchronous, so we block until the message was sent
+                    future.get();
+                    break;
+                } catch (InterruptedException e) {
+                    LOG.warn("Interrupted while sending message to topic {}.", topic, e);
+                    Thread.currentThread().interrupt();
+                    break;
+                } catch (ExecutionException e) {
+                    LOG.warn("Timeout occured while sending message to topic {}, it will be attempted again.", topic);
+                }
             }
         }
     }

--- a/core/ipc/sink/kafka-impl/src/test/java/org/opennms/core/ipc/sink/kafka/HeartbeatSinkIT.java
+++ b/core/ipc/sink/kafka-impl/src/test/java/org/opennms/core/ipc/sink/kafka/HeartbeatSinkIT.java
@@ -30,6 +30,7 @@ package org.opennms.core.ipc.sink.kafka;
 
 import static com.jayway.awaitility.Awaitility.await;
 import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
@@ -38,6 +39,7 @@ import static org.mockito.Mockito.when;
 
 import java.util.Hashtable;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -87,6 +89,7 @@ public class HeartbeatSinkIT {
     public void setUp() throws Exception {
         Hashtable<String, Object> kafkaConfig = new Hashtable<String, Object>();
         kafkaConfig.put("bootstrap.servers", kafkaServer.getKafkaConnectString());
+        kafkaConfig.put("max.block.ms", 10000);
         ConfigurationAdmin configAdmin = mock(ConfigurationAdmin.class, RETURNS_DEEP_STUBS);
         when(configAdmin.getConfiguration(KafkaSinkConstants.KAFKA_CONFIG_PID).getProperties())
             .thenReturn(kafkaConfig);
@@ -170,5 +173,44 @@ public class HeartbeatSinkIT {
         } finally {
             consumerManager.unregisterConsumer(consumer);
         }
+    }
+
+    @Test(timeout = 60000)
+    public void testSinkMessagesBeingNotDropped() throws Exception {
+        kafkaServer.stopKafkaServer();
+        HeartbeatModule module = new HeartbeatModule();
+
+        AtomicInteger heartbeatCount = new AtomicInteger();
+        final MessageConsumer<Heartbeat, Heartbeat> heartbeatConsumer = new MessageConsumer<Heartbeat, Heartbeat>() {
+            @Override
+            public SinkModule<Heartbeat, Heartbeat> getModule() {
+                return module;
+            }
+
+            @Override
+            public void handleMessage(final Heartbeat heartbeat) {
+                heartbeatCount.incrementAndGet();
+            }
+        };
+
+        try {
+            consumerManager.registerConsumer(heartbeatConsumer);
+
+            final SyncDispatcher<Heartbeat> localDispatcher = localMessageDispatcherFactory.createSyncDispatcher(module);
+            localDispatcher.send(new Heartbeat());
+            await().atMost(30, SECONDS).until(() -> heartbeatCount.get(), equalTo(1));
+
+            final SyncDispatcher<Heartbeat> dispatcher = remoteMessageDispatcherFactory.createSyncDispatcher(HeartbeatModule.INSTANCE);
+
+            Executors.newSingleThreadExecutor().execute(() -> dispatcher.send(new Heartbeat()));
+            Executors.newSingleThreadExecutor().execute(() -> dispatcher.send(new Heartbeat()));
+            // This sleep is needed for testing the timeout for kafka producer.send();
+            Thread.sleep(15000);
+            kafkaServer.startKafkaServer();
+            await().atMost(30, SECONDS).until(() -> heartbeatCount.get(), equalTo(3));
+        } finally {
+            consumerManager.unregisterConsumer(heartbeatConsumer);
+        }
+
     }
 }

--- a/core/test-api/kafka/src/main/java/org/opennms/core/test/kafka/JUnitKafkaServer.java
+++ b/core/test-api/kafka/src/main/java/org/opennms/core/test/kafka/JUnitKafkaServer.java
@@ -195,4 +195,15 @@ public class JUnitKafkaServer extends ExternalResource {
     public String getZookeeperConnectString() {
         return zkServer.getConnectString();
     }
+
+    public synchronized void stopKafkaServer() {
+        kafkaServer.shutdown();
+    }
+
+    public synchronized void startKafkaServer() {
+        kafkaServer.startup();
+        await().atMost(1, MINUTES).until(this::getBrokerMetadatas, hasSize(greaterThanOrEqualTo(1)));
+        System.err.println("Kafka Address: " + getKafkaConnectString());
+        System.err.println("Zookeeper Address: " + getZookeeperConnectString());
+    }
 }


### PR DESCRIPTION
Allow Kafka dispatcher to retry infinitely till it delivers the message.

* JIRA: http://issues.opennms.org/browse/NMS-10395

Our [continuous integration system](http://bamboo.internal.opennms.com:8085) will test and verify your changes.
