### PR TITLE
HZN-1436: Packaging OpenNMS plugins

### DIFF
--- a/container/extender/pom.xml
+++ b/container/extender/pom.xml
@@ -26,7 +26,7 @@
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>osgi.core</artifactId>
-            <version>6.0.0</version>
+            <version>${osgiVersion}</version>
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
@@ -44,6 +44,11 @@
         <dependency>
             <groupId>org.apache.karaf.config</groupId>
             <artifactId>org.apache.karaf.config.core</artifactId>
+            <version>${karafVersion}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.karaf.kar</groupId>
+            <artifactId>org.apache.karaf.kar.core</artifactId>
             <version>${karafVersion}</version>
         </dependency>
         <dependency>

--- a/container/extender/src/main/java/org/opennms/karaf/extender/Feature.java
+++ b/container/extender/src/main/java/org/opennms/karaf/extender/Feature.java
@@ -31,34 +31,70 @@ package org.opennms.karaf.extender;
 import java.util.Objects;
 
 public class Feature {
-    private final String m_name;
-    private final String m_version;
+    private final String name;
+    private final String version;
+    private final String karDependency;
 
-    public Feature(String name) {
-        this(name, null);
+    private Feature(Builder builder) {
+        this.name = builder.name;
+        this.version = builder.version;
+        this.karDependency = builder.karDependency;
     }
 
-    public Feature(String name, String version) {
-        m_name = Objects.requireNonNull(name);
-        m_version = version;
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private String name;
+        private String version;
+        private String karDependency;
+
+        public Builder withName(String name) {
+            this.name = name;
+            return this;
+        }
+
+        public Builder withVersion(String version) {
+            this.version = version;
+            return this;
+        }
+
+        public Builder withKarDependency(String karDependency) {
+            this.karDependency = karDependency;
+            return this;
+        }
+
+        public Feature build() {
+            Objects.requireNonNull(name, "name is required");
+            return new Feature(this);
+        }
     }
 
     public String getName() {
-        return m_name;
+        return name;
     }
 
     public String getVersion() {
-        return m_version;
+        return version;
+    }
+
+    public String getKarDependency() {
+        return karDependency;
+    }
+
+    public String toInstallString() {
+        return getVersion() != null ? getName() + "/" + getVersion() : getName();
     }
 
     @Override
     public String toString() {
-        return String.format("Feature[name=%s, version=%s]", m_name, m_version);
+        return String.format("Feature[name=%s, version=%s, karDependency=%s]", name, version, karDependency);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(m_name, m_version);
+        return Objects.hash(name, version, karDependency);
     }
 
     @Override
@@ -70,8 +106,9 @@ public class Feature {
         if (getClass() != obj.getClass())
             return false;
         Feature other = (Feature) obj;
-        return Objects.equals(this.m_name, other.m_name) &&
-                Objects.equals(this.m_version, other.m_version);
+        return Objects.equals(this.name, other.name) &&
+                Objects.equals(this.version, other.version) &&
+                Objects.equals(this.karDependency, other.karDependency);
     }
 }
 

--- a/container/extender/src/main/java/org/opennms/karaf/extender/KarDependencyHandler.java
+++ b/container/extender/src/main/java/org/opennms/karaf/extender/KarDependencyHandler.java
@@ -1,0 +1,166 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2018 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2018 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.karaf.extender;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.karaf.features.FeaturesService;
+import org.apache.karaf.features.Repository;
+import org.apache.karaf.kar.KarService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class KarDependencyHandler implements Runnable {
+    private static final Logger LOG = LoggerFactory.getLogger(KarDependencyHandler.class);
+
+    private static final int KAR_LIST_SLEEP_MS = 5000;
+
+    private final List<Feature> features;
+    private final KarService karService;
+    private final FeaturesService featuresService;
+
+    private static final String FEATURE_CONFIG_FILE = "features.cfg";
+    private static final String KAR_STORAGE = System.getProperty("karaf.data") + File.separator + "kar";
+
+    public KarDependencyHandler(List<Feature> features, KarService karService, FeaturesService featuresService) {
+        this.features = Objects.requireNonNull(features);
+        this.karService = Objects.requireNonNull(karService);
+        this.featuresService = Objects.requireNonNull(featuresService);
+    }
+
+    @Override
+    public void run() {
+        final Set<String> allKarDependencies = features.stream()
+                .map(Feature::getKarDependency)
+                .collect(Collectors.toSet());
+        final Set<String> karsToWaitFor = new HashSet<>(allKarDependencies);
+
+        // Wait for all the .kars to be installed
+        while (true) {
+            try {
+                LOG.info("Waiting on {}", karsToWaitFor);
+                karsToWaitFor.removeAll(karService.list());
+                if (karsToWaitFor.isEmpty()) {
+                    break;
+                }
+            } catch (Exception e) {
+                LOG.warn("Enumerating installed .kar files failed. Will retry in {}ms.", KAR_LIST_SLEEP_MS, e);
+            }
+
+            try {
+                Thread.sleep(KAR_LIST_SLEEP_MS);
+            } catch (InterruptedException e) {
+                LOG.info("Interrupted. Stopping thread.");
+            }
+        }
+        LOG.info("All .kar dependencies are ready now.");
+
+        // Gather the set of known feature URIs
+        final Set<URI> availableFeatureUris = new HashSet<>();
+        try {
+            for (Repository repository : featuresService.listRepositories()) {
+                availableFeatureUris.add(repository.getURI());
+            }
+        } catch (Exception e) {
+            LOG.warn("Failed to retrieve feature repository details. " +
+                    "Assuming there are not feature repositories installed.", e);
+        }
+
+        // Ensure that all of the feature repositories for the .kar files are installed
+        final Set<URI> missingFeatureUris = new HashSet<>();
+        for (String karDependency : allKarDependencies) {
+            missingFeatureUris.addAll(getFeaturesUrisForKar(karDependency));
+        }
+        missingFeatureUris.removeAll(availableFeatureUris);
+        if (missingFeatureUris.size() < 1) {
+            LOG.debug("No missing feature repositories.");
+        } else {
+            LOG.info("Installing feature repositories: {}", missingFeatureUris);
+            for (URI featureUri : missingFeatureUris) {
+                try {
+                    featuresService.addRepository(featureUri);
+                } catch (Exception e) {
+                    LOG.error("Failed to install feature repository: {}", featureUri, e);
+                }
+            }
+        }
+
+        // All set, install the features
+        final Set<String> featuresToInstall = features.stream()
+                .map(Feature::toInstallString)
+                .collect(Collectors.toSet());
+        try {
+            LOG.info("Installing features: {}", featuresToInstall);
+            featuresService.installFeatures(featuresToInstall, EnumSet.noneOf(FeaturesService.Option.class));
+        } catch (Exception e) {
+            LOG.error("Failed to install one or more features.", e);
+        }
+    }
+
+    private List<URI> getFeaturesUrisForKar(String kar) {
+        final Path featureConfig = Paths.get(KAR_STORAGE, kar, FEATURE_CONFIG_FILE);
+        final File featureConfigFile = featureConfig.toFile();
+
+        if (!featureConfigFile.isFile()) {
+            LOG.debug("Kar '{}' is installed, but the feature configuration is not yet written. " +
+                    "Waiting up-to 30 seconds for it to show up...");
+            try {
+                for (int i = 30; i > 0 && !featureConfigFile.isFile(); i--) {
+                    Thread.sleep(1000);
+                }
+            } catch (InterruptedException e) {
+                LOG.info("Interrupted while waiting for {}. Assuming no feature repositories are used.", featureConfigFile);
+                return Collections.emptyList();
+            }
+        }
+
+        try {
+            LOG.debug("Reading feature repository list for kar '{}' in: {}", kar, featureConfig);
+            return Files.readAllLines(featureConfig).stream()
+                    .map(URI::create)
+                    .collect(Collectors.toList());
+        } catch (IOException e) {
+            LOG.warn("Cannot read feature repository list for kar '{}' in: {}. Assuming no feature repositories are used.",
+                    kar, featureConfig, e);
+            return Collections.emptyList();
+        }
+    }
+}

--- a/container/extender/src/main/java/org/opennms/karaf/extender/KarafExtender.java
+++ b/container/extender/src/main/java/org/opennms/karaf/extender/KarafExtender.java
@@ -41,17 +41,19 @@ import java.util.Dictionary;
 import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import org.apache.karaf.features.FeaturesService;
 import org.apache.karaf.features.FeaturesService.Option;
+import org.apache.karaf.kar.KarService;
 import org.ops4j.pax.url.mvn.MavenResolver;
 import org.osgi.service.cm.Configuration;
 import org.osgi.service.cm.ConfigurationAdmin;
@@ -71,10 +73,11 @@ public class KarafExtender {
     private static final String PAX_MVN_PID = "org.ops4j.pax.url.mvn";
     private static final String PAX_MVN_REPOSITORIES = "org.ops4j.pax.url.mvn.repositories";
 
+    public static final String WAIT_FOR_KAR_ATTRIBUTE = "wait-for-kar";
     public static final String FEATURES_URI = "features.uri";
     public static final String FEATURES_BOOT = "features.boot";
     private static final String COMMENT_REGEX = "^\\s*(#.*)?$";
-    private static final Pattern FEATURE_VERSION_PATTERN = Pattern.compile("(.*?)(/(.*))?");
+    private static final Pattern FEATURE_VERSION_PATTERN = Pattern.compile("(?<name>.+?)(/(?<version>.*))?(\\s+(?<attributes>.*))?");
 
     private final Path m_karafHome = Paths.get(System.getProperty("karaf.home"));
     private final Path m_repositories = m_karafHome.resolve("repositories");
@@ -83,11 +86,16 @@ public class KarafExtender {
     private ConfigurationAdmin m_configurationAdmin;
     private MavenResolver m_mavenResolver;
     private FeaturesService m_featuresService;
+    private KarService m_karService;
+
+    private Thread m_installThread;
+    private Thread m_karDependencyInstallThread;
 
     public void init() throws InterruptedException {
         Objects.requireNonNull(m_configurationAdmin, "configurationAdmin");
         Objects.requireNonNull(m_mavenResolver, "mavenResolver");
         Objects.requireNonNull(m_featuresService, "featuresService");
+        Objects.requireNonNull(m_karService, "karService");
 
         List<Repository> repositories;
         try {
@@ -111,78 +119,109 @@ public class KarafExtender {
         // Filter the list of features
         filterFeatures(featuresBoot);
 
-        // Build a comma separated list of our Maven repositories
-        final StringBuilder mavenReposSb = new StringBuilder();
-        for (Repository repository : repositories) {
-            if (mavenReposSb.length() != 0) {
-                mavenReposSb.append(",");
+        if (repositories.size() >= 1) {
+            // Build a comma separated list of our Maven repositories
+            final StringBuilder mavenReposSb = new StringBuilder();
+            for (Repository repository : repositories) {
+                if (mavenReposSb.length() != 0) {
+                    mavenReposSb.append(",");
+                }
+                mavenReposSb.append(repository.toMavenUri());
             }
-            mavenReposSb.append(repository.toMavenUri());
-        }
-        final String mavenRepos = mavenReposSb.toString();
+            final String mavenRepos = mavenReposSb.toString();
 
-        LOG.info("Updating Maven repositories to include: {}", mavenRepos);
-        try {
-            final Configuration config = m_configurationAdmin.getConfiguration(PAX_MVN_PID);
-            if (config == null) {
-                throw new IOException("The OSGi configuration (admin) registry was found for pid " + PAX_MVN_PID +
-                        ", but a configuration could not be located/generated.  This shouldn't happen.");
+            LOG.info("Updating Maven repositories to include: {}", mavenRepos);
+            try {
+                final Configuration config = m_configurationAdmin.getConfiguration(PAX_MVN_PID);
+                if (config == null) {
+                    throw new IOException("The OSGi configuration (admin) registry was found for pid " + PAX_MVN_PID +
+                            ", but a configuration could not be located/generated.  This shouldn't happen.");
+                }
+                final Dictionary<String, Object> props = config.getProperties();
+                if (!mavenRepos.equals(props.get(PAX_MVN_REPOSITORIES))) {
+                    props.put(PAX_MVN_REPOSITORIES, mavenRepos);
+                    config.update(props);
+                }
+            } catch (IOException e) {
+                LOG.error("Failed to update the list of Maven repositories to '{}'. Aborting.",
+                        mavenRepos, e);
+                return;
             }
-            final Dictionary<String, Object> props = config.getProperties();
-            if (!mavenRepos.equals(props.get(PAX_MVN_REPOSITORIES))) {
-                props.put(PAX_MVN_REPOSITORIES, mavenRepos);
-                config.update(props);
+
+            // The configuration update is async, we need to wait for the feature URLs to be resolvable before we use them
+            LOG.info("Waiting up-to 30 seconds for the Maven repositories to be updated...");
+            // Attempting to resolve a missing features writes an exception to the log
+            // We sleep fix a fixed amount of time before our first try in order to help minimize the logged
+            // exceptions, even if we catch them
+            Thread.sleep(2000);
+            for (int i = 28; i > 0 && !canResolveAllFeatureUris(repositories); i--) {
+                Thread.sleep(1000);
             }
-        } catch (IOException e) {
-            LOG.error("Failed to update the list of Maven repositories to '{}'. Aborting.",
-                    mavenRepos, e);
-            return;
-        }
 
-        // The configuration update is async, we need to wait for the feature URLs to be resolvable before we use them
-        LOG.info("Waiting up-to 30 seconds for the Maven repositories to be updated...");
-        // Attempting to resolve a missing features writes an exception to the log
-        // We sleep fix a fixed amount of time before our first try in order to help minimize the logged
-        // exceptions, even if we catch them
-        Thread.sleep(2000);
-        for (int i = 28; i > 0 && !canResolveAllFeatureUris(repositories); i--) {
-            Thread.sleep(1000);
-        }
-
-        for (Repository repository : repositories) {
-            for (URI featureUri : repository.getFeatureUris()) {
-                try {
-                    LOG.info("Adding feature repository: {}", featureUri);
-                    m_featuresService.addRepository(featureUri);
-                } catch (Exception e) {
-                    LOG.error("Failed to add feature repository '{}'. Skipping.", featureUri, e);
+            for (Repository repository : repositories) {
+                for (URI featureUri : repository.getFeatureUris()) {
+                    try {
+                        LOG.info("Adding feature repository: {}", featureUri);
+                        m_featuresService.addRepository(featureUri);
+                    } catch (Exception e) {
+                        LOG.error("Failed to add feature repository '{}'. Skipping.", featureUri, e);
+                    }
                 }
             }
+        } else {
+            LOG.debug("No repositories to install.");
         }
 
         final Set<String> featuresToInstall = featuresBoot.stream()
-            .map(f -> f.getVersion() != null ? f.getName() + "/" + f.getVersion() : f.getName())
-            .collect(Collectors.toCollection(LinkedHashSet::new));
+                .filter(f -> f.getKarDependency() == null) // Exclude any features depending on .kars
+                .map(Feature::toInstallString)
+                .collect(Collectors.toCollection(LinkedHashSet::new));
 
-        // Because of the fix for the following issue, we need to call the
-        // feature installation in another thread since this method is invoked
-        // during a feature installation itself and feature installations are
-        // now single-threaded.
-        //
-        // https://issues.apache.org/jira/browse/KARAF-3798
-        // https://github.com/apache/karaf/pull/138
-        //
-        CompletableFuture.runAsync(new Runnable() {
-            @Override
-            public void run() {
+        if (featuresToInstall.size() >= 1) {
+            // Because of the fix for the following issue, we need to call the
+            // feature installation in another thread since this method is invoked
+            // during a feature installation itself and feature installations are
+            // now single-threaded.
+            //
+            // https://issues.apache.org/jira/browse/KARAF-3798
+            // https://github.com/apache/karaf/pull/138
+            //
+            m_installThread = new Thread(() -> {
                 try {
                     LOG.info("Installing features: {}", featuresToInstall);
                     m_featuresService.installFeatures(featuresToInstall, EnumSet.noneOf(Option.class));
                 } catch (Exception e) {
                     LOG.error("Failed to install one or more features.", e);
                 }
-            }
-        });
+            });
+            m_installThread.setName("Karaf-Extender-Feature-Install");
+            m_installThread.start();
+        } else {
+            LOG.debug("No features to install.");
+        }
+
+
+        final List<Feature> featuresWithKarDependencies = featuresBoot.stream()
+                .filter(f -> f.getKarDependency() != null)
+                .collect(Collectors.toList());
+        if (featuresWithKarDependencies.size() >= 1) {
+            final KarDependencyHandler karDependencyHandler = new KarDependencyHandler(featuresWithKarDependencies,
+                    m_karService, m_featuresService);
+            m_karDependencyInstallThread = new Thread(karDependencyHandler);
+            m_karDependencyInstallThread.setName("Karaf-Extender-Feature-Install-For-Kars");
+            m_karDependencyInstallThread.start();
+        } else {
+            LOG.debug("No features with dependencies on .kar files to install.");
+        }
+    }
+
+    public void destroy() {
+        if (m_installThread != null) {
+            m_installThread.interrupt();
+        }
+        if (m_karDependencyInstallThread != null) {
+            m_karDependencyInstallThread.interrupt();
+        }
     }
 
     private boolean canResolveAllFeatureUris(List<Repository> repositories) {
@@ -231,6 +270,21 @@ public class KarafExtender {
         return repositories;
     }
 
+    private static Map<String,String> parseAttributes(String attributes) {
+        final Map<String,String> attributeMap = new LinkedHashMap<>();
+        if (attributes == null) {
+            return attributeMap;
+        }
+
+        for (String attributeKvp : attributes.split("\\s")) {
+            String tokens[] = attributeKvp.split("=");
+            if (tokens.length == 2) {
+                attributeMap.put(tokens[0].trim(), tokens[1].trim());
+            }
+        }
+        return attributeMap;
+    }
+
     public List<Feature> getFeaturesIn(Path featuresBootFile) throws IOException {
         final List<Feature> features = Lists.newLinkedList();
         for (String line : getLinesIn(featuresBootFile)) {
@@ -238,11 +292,13 @@ public class KarafExtender {
             if (!m.matches()) {
                 continue;
             }
-            if (m.group(3) == null) {
-                features.add(new Feature(m.group(1)));
-            } else {
-                features.add(new Feature(m.group(1), m.group(3)));
-            }
+            final Map<String,String> attributes = parseAttributes(m.group("attributes"));
+            final Feature feature = Feature.builder()
+                    .withName(m.group("name"))
+                    .withVersion(m.group("version"))
+                    .withKarDependency(attributes.get(WAIT_FOR_KAR_ATTRIBUTE))
+                    .build();
+            features.add(feature);
         }
         return features;
     }
@@ -282,7 +338,10 @@ public class KarafExtender {
         while (it.hasNext()) {
             final Feature feature = it.next();
             if (feature.getName().startsWith("!") && feature.getName().length() > 1) {
-                featuresToExclude.add(new Feature(feature.getName().substring(1), feature.getVersion()));
+                featuresToExclude.add(Feature.builder()
+                                .withName(feature.getName().substring(1))
+                                .withVersion(feature.getVersion())
+                                .build());
                 it.remove();
             }
         }
@@ -313,7 +372,7 @@ public class KarafExtender {
     private static List<Path> getRepositoryFolders(Path folder) throws IOException {
         final List<Path> paths = Lists.newLinkedList();
         if (!folder.toFile().exists()) {
-            LOG.warn("Repository folder {} does not exist!", folder);
+            LOG.info("Repository folder {} does not exist. No repositories will be added.", folder);
             return paths;
         }
 
@@ -351,4 +410,9 @@ public class KarafExtender {
     public void setFeaturesService(FeaturesService featuresService) {
         m_featuresService = featuresService;
     }
+
+    public void setKarService(KarService karService) {
+        m_karService = karService;
+    }
+
 }

--- a/container/extender/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/container/extender/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -8,10 +8,12 @@
     <reference id="configurationAdmin" interface="org.osgi.service.cm.ConfigurationAdmin"/>
     <reference id="mavenResolver" interface="org.ops4j.pax.url.mvn.MavenResolver"/>
     <reference id="featuresService" interface="org.apache.karaf.features.FeaturesService"/>
+    <reference id="karService" interface="org.apache.karaf.kar.KarService"/>
 
-    <bean id="controller" class="org.opennms.karaf.extender.KarafExtender" init-method="init">
+    <bean id="controller" class="org.opennms.karaf.extender.KarafExtender" init-method="init" destroy-method="destroy">
         <property name="configurationAdmin" ref="configurationAdmin" />
         <property name="mavenResolver" ref="mavenResolver" />
         <property name="featuresService" ref="featuresService" />
+        <property name="karService" ref="karService" />
     </bean>
 </blueprint>

--- a/container/extender/src/test/java/org/opennms/karaf/extender/KarafExtenderTest.java
+++ b/container/extender/src/test/java/org/opennms/karaf/extender/KarafExtenderTest.java
@@ -85,12 +85,22 @@ public class KarafExtenderTest {
         // Add another file with a name that should be sorted after the previous file
         Files.write("feature-4", new File(featuresBootDotD, "features.boot"), StandardCharsets.UTF_8);
 
+        // Wait for a kar
+        Files.write("#plugins!\n" +
+                "opennms-oce-plugin wait-for-kar=opennms-oce-plugin", new File(featuresBootDotD, "kar-plugin.boot"), StandardCharsets.UTF_8);
+
         // Read and verify
-        assertEquals(Lists.newArrayList(new Feature("feature-1"),
-                new Feature("feature-2", "18.0.0"),
-                new Feature("feature-3"),
-                new Feature("feature-4")),
-                karafExtender.getFeaturesBoot());
+        Feature feature1 = Feature.builder().withName("feature-1").build();
+        Feature feature2 = Feature.builder().withName("feature-2").withVersion("18.0.0").build();
+        Feature feature3 = Feature.builder().withName("feature-3").build();
+        Feature feature4 = Feature.builder().withName("feature-4").build();
+        Feature ocePluginFeature = Feature.builder().withName("opennms-oce-plugin").withKarDependency("opennms-oce-plugin").build();
+
+        assertEquals(Lists.newArrayList(feature1,
+                feature2,
+                feature3,
+                feature4,
+                ocePluginFeature), karafExtender.getFeaturesBoot());
         
         // Now add another file that disables features-1 and feature-2 above
         Files.write("!feature-1\n" +
@@ -102,8 +112,9 @@ public class KarafExtenderTest {
 
         // Verify
         assertEquals(Lists.newArrayList(
-                new Feature("feature-3"),
-                new Feature("feature-4")),
+                feature3,
+                feature4,
+                ocePluginFeature),
                 features);
     }
 
@@ -139,10 +150,10 @@ public class KarafExtenderTest {
                 new Repository(emptyRepository.toPath(), Collections.emptyList(), Collections.emptyList()),
                 new Repository(releaseRepository.toPath(),
                         Lists.newArrayList(new URI("mvn:group.id/artifact.id/2.0.0/xml")),
-                        Lists.newArrayList(new Feature("released-feature"))),
+                        Lists.newArrayList(Feature.builder().withName("released-feature").build())),
                 new Repository(snapshotRepository.toPath(),
                         Lists.newArrayList(new URI("mvn:other.group.id/other.artifact.id/1.0-SNAPSHOT/xml")),
-                        Lists.newArrayList(new Feature("snapshot-feature")))),
+                        Lists.newArrayList(Feature.builder().withName("snapshot-feature").build()))),
                 karafExtender.getRepositories());
     }
 

--- a/container/features/pom.xml
+++ b/container/features/pom.xml
@@ -45,7 +45,6 @@
 
             <!-- Pax JDBC -->
             <value>org.ops4j.pax.jdbc-1.0.1</value>
-
           </importRepositoryExclusions>
           <repositories>
 
@@ -68,6 +67,9 @@
 
             <!-- OpenNMS features bundle -->
             <repository>file:${project.build.outputDirectory}/features.xml</repository>
+
+            <!-- OpenNMS Karaf extensions -->
+            <repository>file:${project.build.outputDirectory}/karaf-extensions.xml</repository>
 
             <!-- OpenNMS OSGI Core feature bundle -->
             <repository>mvn:org.opennms.osgi/opennms-osgi-core-rest/${project.version}/xml/features</repository>
@@ -142,7 +144,6 @@
 
             <!-- Jest Feature -->
             <repository>mvn:org.opennms.features.jest/opennms-jest/${project.version}/xml/features</repository>
-
           </repositories>
 
           <!--
@@ -353,6 +354,8 @@
 
 	    <!-- Integration API -->
 	    <feature>opennms-api-layer</feature>
+
+	    <feature>karaf-extender</feature>
           </features>
         </configuration>
       </plugin>

--- a/container/karaf/src/main/filtered-resources/etc/org.apache.karaf.features.cfg
+++ b/container/karaf/src/main/filtered-resources/etc/org.apache.karaf.features.cfg
@@ -34,8 +34,8 @@ featuresRepositories = \
     mvn:org.opennms.karaf/opennms/${project.version}/xml/standard, \
     mvn:org.opennms.karaf/opennms/${project.version}/xml/spring, \
     mvn:org.opennms.karaf/opennms/${project.version}/xml/spring-legacy, \
-    mvn:org.opennms.karaf/opennms/${project.version}/xml/features
-
+    mvn:org.opennms.karaf/opennms/${project.version}/xml/features, \
+    mvn:org.opennms.karaf/opennms/${project.version}/xml/karaf-extensions
 #
 # Comma separated list of features to install at startup
 #
@@ -87,6 +87,7 @@ featuresBoot = ( \
   http,\
   http-whiteboard,\
   opennms-jaas-login-module,\
+  karaf-extender, \
   opennms-osgi-core-rest, \
   opennms-health,\
   datachoices, \

--- a/container/shared/src/main/filtered-resources/etc/org.ops4j.pax.url.mvn.cfg
+++ b/container/shared/src/main/filtered-resources/etc/org.ops4j.pax.url.mvn.cfg
@@ -52,8 +52,10 @@ org.ops4j.pax.url.mvn.certificateCheck=true
 # configuration, which is not always desired
 # "localRepository" is the target location for artifacts downloaded from
 # "remote repositories"
-# OPENNMS: Specify a localRepository
-org.ops4j.pax.url.mvn.localRepository=${karaf.home}/repositories/.local
+# OPENNMS: Use a Maven repository relative to ${karaf.home} since
+# the unprivileged users running the services may not have a "user.home"
+# directory
+org.ops4j.pax.url.mvn.localRepository=${karaf.home}/.m2
 
 #
 # Default this to false. It's just weird to use undocumented repos

--- a/features/container/sentinel/src/assembly/sentinel.xml
+++ b/features/container/sentinel/src/assembly/sentinel.xml
@@ -20,9 +20,6 @@
       <useDefaultExcludes>false</useDefaultExcludes>
       <directory>${project.build.directory}/unpacked/org.opennms.container.shared-${project.version}</directory>
       <outputDirectory></outputDirectory>
-      <excludes>
-        <exclude>**/etc/featuresBoot.d/**</exclude>
-      </excludes>
     </fileSet>
   </fileSets>
 </assembly>

--- a/features/container/sentinel/src/main/filtered-resources/etc/org.apache.karaf.features.cfg
+++ b/features/container/sentinel/src/main/filtered-resources/etc/org.apache.karaf.features.cfg
@@ -38,7 +38,6 @@ featuresBoot = \
     instance/${karafVersion}, \
     package/${karafVersion}, \
     log/${karafVersion}, \
-    scv/${project.version}, \
     ssh/${karafVersion}, \
     framework/${karafVersion}, \
     system/${karafVersion}, \
@@ -53,7 +52,9 @@ featuresBoot = \
     wrap, \
     bundle/${karafVersion}, \
     config/${karafVersion}, \
-    kar/${karafVersion}
+    kar/${karafVersion}, \
+    scv/${project.version}, \
+    karaf-extender/${project.version}
 
 #
 # Resource repositories (OBR) that the features resolver can use

--- a/features/container/sentinel/src/main/filtered-resources/etc/org.apache.karaf.features.cfg
+++ b/features/container/sentinel/src/main/filtered-resources/etc/org.apache.karaf.features.cfg
@@ -24,7 +24,6 @@ featuresRepositories = \
     mvn:org.apache.karaf.features/framework/${karafVersion}/xml/features, \
     mvn:org.apache.karaf.features/spring/${karafVersion}/xml/features, \
     mvn:org.opennms.karaf/opennms/${project.version}/xml/karaf-extensions, \
-    mvn:org.opennms.karaf/opennms/${project.version}/xml/opennms, \
     mvn:org.opennms.karaf/opennms/${project.version}/xml/sentinel, \
     mvn:org.apache.karaf.features/standard/${karafVersion}/xml/features, \
     mvn:org.apache.karaf.features/spring-legacy/${karafVersion}/xml/features

--- a/opennms-doc/guide-development/src/asciidoc/text/minion/container.adoc
+++ b/opennms-doc/guide-development/src/asciidoc/text/minion/container.adoc
@@ -18,11 +18,11 @@ It allows packages to register *Maven Repositories*, *Karaf Feature Repositories
 Here's an overview, used for reference, of the relevant directories that are (currently) present on a default install of the `opennms-minion` package:
 [source, shell]
 ----
+├── .m2
 ├── etc
 │   └── featuresBoot.d
 │       └── custom.boot
 ├── repositories
-│   ├── .local
 │   ├── core
 │   │   ├── features.uris
 │   │   └── features.boot

--- a/tools/packages/sentinel/sentinel.spec
+++ b/tools/packages/sentinel/sentinel.spec
@@ -119,6 +119,7 @@ mv "%{buildroot}%{sentinelinstprefix}/etc/sentinel.conf" "%{buildroot}%{_sysconf
 find %{buildroot}%{sentinelinstprefix} ! -type d | \
     grep -v %{sentinelinstprefix}/bin | \
     grep -v %{sentinelrepoprefix} | \
+    grep -v %{sentinelinstprefix}/etc/featuresBoot.d | \
     sed -e "s|^%{buildroot}|%attr(644,sentinel,sentinel) |" | \
     sort > %{_tmppath}/files.sentinel
 find %{buildroot}%{sentinelinstprefix}/bin ! -type d | \
@@ -137,6 +138,7 @@ rm -rf %{buildroot}
 %defattr(664 sentinel sentinel 775)
 %attr(755,sentinel,sentinel) %{_initrddir}/sentinel
 %attr(644,sentinel,sentinel) %config(noreplace) %{_sysconfdir}/sysconfig/sentinel
+%attr(644,sentinel,sentinel) %{sentinelinstprefix}/etc/featuresBoot.d/.readme
 
 %pre
 ROOT_INST="${RPM_INSTALL_PREFIX0}"


### PR DESCRIPTION
JIRA: https://issues.opennms.org/browse/HZN-1436

Here we add the `karaf-extender` feature both the opennms and sentinel containers.

We also extend the feature to support waiting on `.kar` files before installing the features. This gets us closer to be able to distributed plugins as .kar files, and allows us to reliably start features in the .kar files at boot.

For example, we can now do the following on either of the opennms or sentinel containers:
```
wget https://360-128952957-gh.circle-artifacts.com/0/dist/opennms-oce-plugin.kar
cp $KARAF_HOME/deploy/
echo 'oce-datasource-api wait-for-kar=opennms-oce-plugin' > $KARAF_HOME/etc/featuresBoot.d/oce.boot
```

And have the 'oce-datasource-api' feature reliably installed on startup - even when `$KARAF_HOME/data`, or `$KARAF_HOME/data/cache` is wiped.
