### PR TITLE
HZN-1426 Make Older Alarms Un-Acknowledge Situations

### DIFF
--- a/core/test-api/alarms/src/main/java/org/opennms/core/test/alarms/driver/AlarmdDriver.java
+++ b/core/test-api/alarms/src/main/java/org/opennms/core/test/alarms/driver/AlarmdDriver.java
@@ -235,7 +235,7 @@ public class AlarmdDriver implements TemporaryDatabaseAware<MockDatabase>, Actio
             // Tick
             m_droolsAlarmContext.getClock().advanceTime(tickLength, TimeUnit.MILLISECONDS);
             m_droolsAlarmContext.tick();
-            results.addAlarms(now, m_transactionTemplate.execute((t) -> {
+            results.addAlarms(now + tickLength, m_transactionTemplate.execute((t) -> {
                 final List<OnmsAlarm> alarms = m_alarmDao.findAll();
                 alarms.forEach(a -> {
                     Hibernate.initialize(a.getAssociatedAlarms());

--- a/core/test-api/alarms/src/main/java/org/opennms/core/test/alarms/driver/ScenarioResults.java
+++ b/core/test-api/alarms/src/main/java/org/opennms/core/test/alarms/driver/ScenarioResults.java
@@ -50,9 +50,28 @@ public class ScenarioResults {
         return alarmsByTime.getOrDefault(time, Collections.emptyList());
     }
 
+    public OnmsAlarm getAlarmAt(long time, int id) {
+        return getAlarms(time).stream()
+                .filter(a -> a.getId() == id)
+                .findFirst()
+                .orElseThrow(() -> new RuntimeException("Alarm " + id + " not found at time: " + time));
+    }
+
     public List<OnmsAlarm> getAlarmsAtLastKnownTime() {
         final Long lastTime = getLastKnownTime();
         return alarmsByTime.get(lastTime);
+    }
+
+    public List<OnmsAlarm> getAcknowledgedAlarms(long time) {
+        return getAlarms(time).stream()
+                .filter(alarm -> alarm.getAckTime() != null && alarm.getAckUser() != null)
+                .collect(Collectors.toList());
+    }
+
+    public List<OnmsAlarm> getUnAcknowledgedAlarms(long time) {
+        return getAlarms(time).stream()
+                .filter(alarm -> alarm.getAckTime() == null && alarm.getAckUser() == null)
+                .collect(Collectors.toList());
     }
 
     public Long getLastKnownTime() {

--- a/opennms-alarms/daemon/src/main/java/org/opennms/netmgt/alarmd/AlarmPersisterImpl.java
+++ b/opennms-alarms/daemon/src/main/java/org/opennms/netmgt/alarmd/AlarmPersisterImpl.java
@@ -322,7 +322,7 @@ public class AlarmPersisterImpl implements AlarmPersister {
     private OnmsAlarm createNewAlarm(OnmsEvent e, Event event) {
         OnmsAlarm alarm = new OnmsAlarm();
         // Situations are denoted by the existance of related-reductionKeys
-        alarm.setRelatedAlarms(getRelatedAlarms(event.getParmCollection()));
+        alarm.setRelatedAlarms(getRelatedAlarms(event.getParmCollection()), event.getTime());
         alarm.setAlarmType(event.getAlarmData().getAlarmType());
         alarm.setClearKey(event.getAlarmData().getClearKey());
         alarm.setCounter(1);

--- a/opennms-alarms/daemon/src/main/java/org/opennms/netmgt/alarmd/drools/AlarmAssociationAndFact.java
+++ b/opennms-alarms/daemon/src/main/java/org/opennms/netmgt/alarmd/drools/AlarmAssociationAndFact.java
@@ -1,3 +1,31 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2018 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2018 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
 package org.opennms.netmgt.alarmd.drools;
 
 import org.kie.api.runtime.rule.FactHandle;

--- a/opennms-alarms/daemon/src/main/java/org/opennms/netmgt/alarmd/drools/AlarmAssociationAndFact.java
+++ b/opennms-alarms/daemon/src/main/java/org/opennms/netmgt/alarmd/drools/AlarmAssociationAndFact.java
@@ -1,0 +1,31 @@
+package org.opennms.netmgt.alarmd.drools;
+
+import org.kie.api.runtime.rule.FactHandle;
+import org.opennms.netmgt.model.AlarmAssociation;
+
+public class AlarmAssociationAndFact {
+
+    private AlarmAssociation alarmAssociation;
+    private FactHandle fact;
+
+    public AlarmAssociationAndFact(AlarmAssociation alarmAssociation, FactHandle fact) {
+        this.alarmAssociation = alarmAssociation;
+        this.fact = fact;
+    }
+
+    public AlarmAssociation getAlarmAssociation() {
+        return alarmAssociation;
+    }
+
+    public void setAlarmAssociation(AlarmAssociation alarmAssociation) {
+        this.alarmAssociation = alarmAssociation;
+    }
+
+    public FactHandle getFact() {
+        return fact;
+    }
+
+    public void setFact(FactHandle fact) {
+        this.fact = fact;
+    }
+}

--- a/opennms-alarms/daemon/src/main/java/org/opennms/netmgt/alarmd/drools/DefaultAlarmService.java
+++ b/opennms-alarms/daemon/src/main/java/org/opennms/netmgt/alarmd/drools/DefaultAlarmService.java
@@ -29,6 +29,7 @@
 package org.opennms.netmgt.alarmd.drools;
 
 import java.util.Date;
+import java.util.Set;
 
 import org.opennms.netmgt.dao.api.AcknowledgmentDao;
 import org.opennms.netmgt.dao.api.AlarmDao;
@@ -80,6 +81,12 @@ public class DefaultAlarmService implements AlarmService {
         if (alarmInTrans == null) {
             LOG.warn("Alarm disappeared: {}. Skipping delete.", alarm);
             return;
+        }
+        // If alarm was in Situation, fire notifications for the Situation
+        if (alarmInTrans.isPartOfSituation()) {
+            for (OnmsAlarm situation : alarmInTrans.getRelatedSituations()) {
+                alarmEntityNotifier.didUpdateRelatedAlarms(situation, situation.getRelatedAlarms());
+            }
         }
         alarmDao.delete(alarmInTrans);
         alarmEntityNotifier.didDeleteAlarm(alarmInTrans);

--- a/opennms-alarms/daemon/src/main/java/org/opennms/netmgt/alarmd/drools/DefaultAlarmService.java
+++ b/opennms-alarms/daemon/src/main/java/org/opennms/netmgt/alarmd/drools/DefaultAlarmService.java
@@ -29,6 +29,10 @@
 package org.opennms.netmgt.alarmd.drools;
 
 import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
 
 import org.opennms.netmgt.dao.api.AcknowledgmentDao;
 import org.opennms.netmgt.dao.api.AlarmDao;
@@ -81,13 +85,18 @@ public class DefaultAlarmService implements AlarmService {
             LOG.warn("Alarm disappeared: {}. Skipping delete.", alarm);
             return;
         }
-        // If alarm was in Situation, fire notifications for the Situation
+        // If alarm was in Situation, calculate notifications for the Situation
+        Map<OnmsAlarm, Set<OnmsAlarm>> priorRelatedAlarms = new HashMap<>();
         if (alarmInTrans.isPartOfSituation()) {
             for (OnmsAlarm situation : alarmInTrans.getRelatedSituations()) {
-                alarmEntityNotifier.didUpdateRelatedAlarms(situation, situation.getRelatedAlarms());
+                priorRelatedAlarms.put(situation, situation.getRelatedAlarms());
             }
         }
         alarmDao.delete(alarmInTrans);
+        // fire notifications after alarm has been deleted
+        for (Entry<OnmsAlarm, Set<OnmsAlarm>> entry : priorRelatedAlarms.entrySet()) {
+            alarmEntityNotifier.didUpdateRelatedAlarms(entry.getKey(), entry.getValue());
+        }
         alarmEntityNotifier.didDeleteAlarm(alarmInTrans);
     }
 

--- a/opennms-alarms/daemon/src/main/java/org/opennms/netmgt/alarmd/drools/DefaultAlarmService.java
+++ b/opennms-alarms/daemon/src/main/java/org/opennms/netmgt/alarmd/drools/DefaultAlarmService.java
@@ -30,6 +30,7 @@ package org.opennms.netmgt.alarmd.drools;
 
 import java.util.Date;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -89,7 +90,7 @@ public class DefaultAlarmService implements AlarmService {
         Map<OnmsAlarm, Set<OnmsAlarm>> priorRelatedAlarms = new HashMap<>();
         if (alarmInTrans.isPartOfSituation()) {
             for (OnmsAlarm situation : alarmInTrans.getRelatedSituations()) {
-                priorRelatedAlarms.put(situation, situation.getRelatedAlarms());
+                priorRelatedAlarms.put(situation, new HashSet<OnmsAlarm>(situation.getRelatedAlarms()));
             }
         }
         alarmDao.delete(alarmInTrans);

--- a/opennms-alarms/daemon/src/main/java/org/opennms/netmgt/alarmd/drools/DefaultAlarmService.java
+++ b/opennms-alarms/daemon/src/main/java/org/opennms/netmgt/alarmd/drools/DefaultAlarmService.java
@@ -29,7 +29,6 @@
 package org.opennms.netmgt.alarmd.drools;
 
 import java.util.Date;
-import java.util.Set;
 
 import org.opennms.netmgt.dao.api.AcknowledgmentDao;
 import org.opennms.netmgt.dao.api.AlarmDao;

--- a/opennms-alarms/daemon/src/main/java/org/opennms/netmgt/alarmd/drools/DroolsAlarmContext.java
+++ b/opennms-alarms/daemon/src/main/java/org/opennms/netmgt/alarmd/drools/DroolsAlarmContext.java
@@ -44,6 +44,7 @@ import org.opennms.netmgt.alarmd.Alarmd;
 import org.opennms.netmgt.alarmd.api.AlarmLifecycleListener;
 import org.opennms.netmgt.dao.api.AcknowledgmentDao;
 import org.opennms.netmgt.model.AckAction;
+import org.opennms.netmgt.model.AlarmAssociation;
 import org.opennms.netmgt.model.OnmsAcknowledgment;
 import org.opennms.netmgt.model.OnmsAlarm;
 import org.slf4j.Logger;
@@ -77,6 +78,8 @@ public class DroolsAlarmContext extends ManagedDroolsContext implements AlarmLif
     private final Map<Integer, AlarmAndFact> alarmsById = new HashMap<>();
 
     private final Map<Integer, AlarmAcknowledgementAndFact> acknowledgementsByAlarmId = new HashMap<>();
+
+    private final Map<Integer, Map<Integer, AlarmAssociationAndFact>> alarmAssociationById = new HashMap<>();
 
     public DroolsAlarmContext() {
         super(Paths.get(ConfigFileConstants.getHome(), "etc", "alarmd", "drools-rules.d").toFile(), Alarmd.NAME, "DroolsAlarmContext");
@@ -163,6 +166,7 @@ public class DroolsAlarmContext extends ManagedDroolsContext implements AlarmLif
             final FactHandle fact = kieSession.insert(alarm);
             alarmAndFact.setFact(fact);
         }
+        handleRelatedAlarms(alarm);
         handleAlarmAcknowledgements(alarm);
     }
 
@@ -180,19 +184,43 @@ public class DroolsAlarmContext extends ManagedDroolsContext implements AlarmLif
         }
     }
 
+    private void handleRelatedAlarms(OnmsAlarm situation) {
+        if (!situation.isSituation()) {
+            return;
+        }
+        Map<Integer, AlarmAssociationAndFact> associationFacts = alarmAssociationById.get(situation.getId());
+        if (associationFacts == null) {
+            associationFacts = new HashMap<>();
+            alarmAssociationById.put(situation.getId(), associationFacts);
+        }
+        for (AlarmAssociation association : situation.getAssociatedAlarms()) {
+            Integer alarmId = association.getRelatedAlarm().getId();
+            AlarmAssociationAndFact assocationFact = associationFacts.get(alarmId);
+            if (assocationFact == null) {
+                LOG.debug("Inserting alarm association into session: {}", association);
+                final FactHandle fact = getKieSession().insert(association);
+                associationFacts.put(alarmId, new AlarmAssociationAndFact(association, fact));
+            } else {
+                FactHandle fact = assocationFact.getFact();
+                LOG.trace("Updating alarm assocation in session: {}", assocationFact);
+                getKieSession().update(fact, association);
+                associationFacts.put(alarmId, new AlarmAssociationAndFact(association, fact)); 
+            }
+        }
+    }
+
     private void handleAlarmAcknowledgements(OnmsAlarm alarm) {
         final AlarmAcknowledgementAndFact acknowledgmentFact = acknowledgementsByAlarmId.get(alarm.getId());
-        final KieSession kieSession = getKieSession();
         if (acknowledgmentFact == null) {
             OnmsAcknowledgment ack = getLatestAcknowledgement(alarm);
             LOG.debug("Inserting first alarm acknowledgement into session: {}", ack);
-            final FactHandle fact = kieSession.insert(ack);
+            final FactHandle fact = getKieSession().insert(ack);
             acknowledgementsByAlarmId.put(alarm.getId(), new AlarmAcknowledgementAndFact(ack, fact));
         } else {
             FactHandle fact = acknowledgmentFact.getFact();
             OnmsAcknowledgment ack = getLatestAcknowledgement(alarm);
-            LOG.trace("Inserting acknowledgment into session: {}", ack);
-            kieSession.update(fact, ack);
+            LOG.trace("Updating acknowledgment in session: {}", ack);
+            getKieSession().update(fact, ack);
             acknowledgementsByAlarmId.put(alarm.getId(), new AlarmAcknowledgementAndFact(ack, fact));
         }
     }
@@ -223,6 +251,7 @@ public class DroolsAlarmContext extends ManagedDroolsContext implements AlarmLif
             getKieSession().delete(alarmAndFact.getFact());
         }
         deleteAlarmAcknowledgement(alarmId);
+        deleteAlarmAssociations(alarmId);
     }
 
     private void deleteAlarmAcknowledgement(int alarmId) {
@@ -230,6 +259,20 @@ public class DroolsAlarmContext extends ManagedDroolsContext implements AlarmLif
         if (acknowledgmentFact != null) {
             LOG.debug("Deleting ack from session: {}", acknowledgmentFact.getAcknowledgement());
             getKieSession().delete(acknowledgmentFact.getFact());
+        }
+    }
+
+    private void deleteAlarmAssociations(int alarmId) {
+        Map<Integer, AlarmAssociationAndFact> associationFacts = alarmAssociationById.remove(alarmId);
+        if (associationFacts == null) {
+            return;
+        }
+        for (Integer association : associationFacts.keySet()) {
+            AlarmAssociationAndFact assocationFact = associationFacts.get(association);
+            if (assocationFact != null) {
+                LOG.debug("Deleting ack from session: {}", assocationFact.getAlarmAssociation());
+                getKieSession().delete(assocationFact.getFact());
+            }
         }
     }
 

--- a/opennms-base-assembly/src/main/filtered/etc/alarmd/drools-rules.d/situations.drl
+++ b/opennms-base-assembly/src/main/filtered/etc/alarmd/drools-rules.d/situations.drl
@@ -122,7 +122,7 @@ rule "newAlarmsUnAcknowledgesSituation"
   when
     // There is an Acknowledged Situation.
     $situation : OnmsAlarm( isSituation() == true, $relatedAlarmIds : relatedAlarmIds, isAcknowledged() == true )
-    // The Acknowledgment is in Working Memory.
+    // The Situation Acknowledgment is in Working Memory.
     $situationAck : OnmsAcknowledgment( refId == $situation.id, ackAction == AckAction.ACKNOWLEDGE)
     // There is at least one un-Acknowledgment for one of the related alarms with a time after the Situation was acknowledged.
     $unAkedRelatedAlarms : LinkedList(size > 0) from collect (OnmsAcknowledgment($relatedAlarmIds contains refId, ackAction == AckAction.UNACKNOWLEDGE, ackTime > $situationAck.getAckTime() ) )
@@ -130,3 +130,20 @@ rule "newAlarmsUnAcknowledgesSituation"
     Date acknowledgeTime = new Date(drools.getWorkingMemory().getSessionClock().getCurrentTime());
    	alarmService.unacknowledgeAlarm($situation, acknowledgeTime);
 end
+
+rule "oldAlarmsUnAcknowledgesSituation"
+  when
+    // There is an Acknowledged Situation.
+    $situation : OnmsAlarm( isSituation() == true, $relatedAlarmIds : relatedAlarmIds, isAcknowledged() == true )
+    // The Situation Acknowledgment is in Working Memory.
+    $situationAck : OnmsAcknowledgment( refId == $situation.id, ackAction == AckAction.ACKNOWLEDGE)
+    // There is a related alarm that is unacknowleged
+    // The UN-ACK time for that alarm is prior to the Situation ACK
+    $unAkedRelatedAlarms : LinkedList(size > 0) from collect (OnmsAcknowledgment($relatedAlarmIds contains refId, ackAction == AckAction.UNACKNOWLEDGE, ackTime < $situationAck.getAckTime() ) )
+    // The association time of that alarm is later than the ACK time on the situation
+    $unAkedRelatedAlarms : LinkedList(size > 0) from collect (AlarmAssociation(situationAlarm == $situation, $unAkedRelatedAlarms contains relatedAlarm.getId(), mappedTime > $situationAck.getAckTime() ) )
+  then
+    Date acknowledgeTime = new Date(drools.getWorkingMemory().getSessionClock().getCurrentTime());
+   	alarmService.unacknowledgeAlarm($situation, acknowledgeTime);
+end
+

--- a/opennms-base-assembly/src/main/filtered/etc/alarmd/drools-rules.d/situations.drl
+++ b/opennms-base-assembly/src/main/filtered/etc/alarmd/drools-rules.d/situations.drl
@@ -33,6 +33,7 @@ import java.util.List;
 import org.kie.api.time.SessionClock;
 import org.opennms.netmgt.model.OnmsAcknowledgment;
 import org.opennms.netmgt.model.AckAction;
+import org.opennms.netmgt.model.AlarmAssociation;
 import org.opennms.netmgt.model.OnmsAlarm;
 import org.opennms.netmgt.model.OnmsSeverity;
 import org.opennms.netmgt.model.TroubleTicketState;
@@ -123,7 +124,7 @@ rule "newAlarmsUnAcknowledgesSituation"
     // There is an Acknowledged Situation.
     $situation : OnmsAlarm( isSituation() == true, $relatedAlarmIds : relatedAlarmIds, isAcknowledged() == true )
     // The Situation Acknowledgment is in Working Memory.
-    $situationAck : OnmsAcknowledgment( refId == $situation.id, ackAction == AckAction.ACKNOWLEDGE)
+    $situationAck : OnmsAcknowledgment( refId == $situation.id, ackAction == AckAction.ACKNOWLEDGE )
     // There is at least one un-Acknowledgment for one of the related alarms with a time after the Situation was acknowledged.
     $unAkedRelatedAlarms : LinkedList(size > 0) from collect (OnmsAcknowledgment($relatedAlarmIds contains refId, ackAction == AckAction.UNACKNOWLEDGE, ackTime > $situationAck.getAckTime() ) )
   then
@@ -136,12 +137,12 @@ rule "oldAlarmsUnAcknowledgesSituation"
     // There is an Acknowledged Situation.
     $situation : OnmsAlarm( isSituation() == true, $relatedAlarmIds : relatedAlarmIds, isAcknowledged() == true )
     // The Situation Acknowledgment is in Working Memory.
-    $situationAck : OnmsAcknowledgment( refId == $situation.id, ackAction == AckAction.ACKNOWLEDGE)
+    $situationAck : OnmsAcknowledgment( refId == $situation.id, ackAction == AckAction.ACKNOWLEDGE )
     // There is a related alarm that is unacknowleged
     // The UN-ACK time for that alarm is prior to the Situation ACK
-    $unAkedRelatedAlarms : LinkedList(size > 0) from collect (OnmsAcknowledgment($relatedAlarmIds contains refId, ackAction == AckAction.UNACKNOWLEDGE, ackTime < $situationAck.getAckTime() ) )
+    $unAcknowledgment : OnmsAcknowledgment($relatedAlarmIds contains refId, $unAkedAlarmId : refId, ackAction == AckAction.UNACKNOWLEDGE, ackTime < $situationAck.getAckTime() )
     // The association time of that alarm is later than the ACK time on the situation
-    $unAkedRelatedAlarms : LinkedList(size > 0) from collect (AlarmAssociation(situationAlarm == $situation, $unAkedRelatedAlarms contains relatedAlarm.getId(), mappedTime > $situationAck.getAckTime() ) )
+	$unAkedRelatedAlarmAssociation : AlarmAssociation(situationAlarm == $situation, $unAcknowledgment.refId == relatedAlarm.getId(), mappedTime > $situationAck.getAckTime() )
   then
     Date acknowledgeTime = new Date(drools.getWorkingMemory().getSessionClock().getCurrentTime());
    	alarmService.unacknowledgeAlarm($situation, acknowledgeTime);

--- a/opennms-base-assembly/src/main/filtered/etc/alarmd/drools-rules.d/situations.drl
+++ b/opennms-base-assembly/src/main/filtered/etc/alarmd/drools-rules.d/situations.drl
@@ -62,7 +62,7 @@ rule "escalateSituationSeverity"
     $situation : OnmsAlarm( isSituation() == true, $relatedAlarmIds : relatedAlarmIds )
     $relatedAlarms : LinkedList() from collect( OnmsAlarm($relatedAlarmIds contains id) )
     $maxSeverity : OnmsSeverity( isGreaterThan(OnmsSeverity.NORMAL) ) from accumulate( OnmsAlarm( $severity : severity ) from $relatedAlarms, maxSeverity( $severity ) )
-    OnmsAlarm( this == $situation, severity <= $maxSeverity )
+    OnmsAlarm( this == $situation, severity <= $maxSeverity, severity.isLessThan(OnmsSeverity.CRITICAL) )
   then
     Date now = new Date(drools.getWorkingMemory().getSessionClock().getCurrentTime());
     alarmService.setSeverity($situation, OnmsSeverity.escalate($maxSeverity), now);
@@ -76,12 +76,19 @@ rule "SituationHasBeenAcknowledged"
     $situationAck : OnmsAcknowledgment( refId == $situation.id, ackAction == AckAction.ACKNOWLEDGE)
     // There are NO alarm ACKs after the Situation ACK.
     $relatedAlarmAcks : LinkedList( size == 0 ) from collect (OnmsAcknowledgment($relatedAlarmIds contains refId, ackTime > $situationAck.getAckTime() ) )
-    // There is at least one related alarm that is not acknowledged.
+    // There is at least one related alarm that is not acknowledged and it was correlated before the Situation ACK.
     $relatedAlarms : LinkedList( size > 0 ) from collect( OnmsAlarm($relatedAlarmIds contains id, isAcknowledged() == false ) )
+    // There is a related alarm that is unacknowleged
+    $relatedAlarm : OnmsAlarm($relatedAlarmIds contains id, $unAkedAlarmId : id, isAcknowledged() == false )
+    // The UN-ACK time for that alarm is prior to the Situation ACK
+    $unAcknowledgment : OnmsAcknowledgment(refId == $unAkedAlarmId, ackAction == AckAction.UNACKNOWLEDGE, ackTime < $situationAck.getAckTime() )
+    // The association time of that alarm is before the ACK time on the situation
+    $unAkedRelatedAlarmAssociation : AlarmAssociation(situationAlarm == $situation, $unAcknowledgment.refId == relatedAlarm.getId(), mappedTime < $situationAck.getAckTime() )
   then
     Date acknowledgeTime = new Date(drools.getWorkingMemory().getSessionClock().getCurrentTime());
+    // Acknowledge all of the alarms in one go or we will trigger more rule evaluations
     for (int i=0; i < $relatedAlarms.size(); i++) {
-    	alarmService.acknowledgeAlarm((OnmsAlarm)$relatedAlarms.get(i), acknowledgeTime);
+       alarmService.acknowledgeAlarm((OnmsAlarm)$relatedAlarms.get(i), acknowledgeTime);
     }
 end
 

--- a/opennms-model/src/main/java/org/opennms/netmgt/model/AlarmAssociation.java
+++ b/opennms-model/src/main/java/org/opennms/netmgt/model/AlarmAssociation.java
@@ -45,7 +45,7 @@ import javax.persistence.Temporal;
 import javax.persistence.TemporalType;
 import javax.persistence.UniqueConstraint;
 
-import org.springframework.core.style.ToStringCreator;
+import com.google.common.base.MoreObjects;
 
 /**
  * <p> Entity to store situations and their associated (related) alarms with other details like mappedTime </p>
@@ -122,10 +122,10 @@ public class AlarmAssociation implements Serializable {
 
     @Override
     public String toString() {
-        return new ToStringCreator(this)
-                .append("situation", getSituationAlarm().getId())
-                .append("alarm", getRelatedAlarm().getId())
-                .append("time", getMappedTime())
+        return MoreObjects.toStringHelper(this)
+                .add("situation", getSituationAlarm().getId())
+                .add("alarm", getRelatedAlarm().getId())
+                .add("time", getMappedTime())
                 .toString();
     }
 

--- a/opennms-model/src/main/java/org/opennms/netmgt/model/AlarmAssociation.java
+++ b/opennms-model/src/main/java/org/opennms/netmgt/model/AlarmAssociation.java
@@ -45,6 +45,8 @@ import javax.persistence.Temporal;
 import javax.persistence.TemporalType;
 import javax.persistence.UniqueConstraint;
 
+import org.springframework.core.style.ToStringCreator;
+
 /**
  * <p> Entity to store situations and their associated (related) alarms with other details like mappedTime </p>
  */
@@ -118,6 +120,14 @@ public class AlarmAssociation implements Serializable {
         return mappedTime;
     }
 
+    @Override
+    public String toString() {
+        return new ToStringCreator(this)
+                .append("situation", getSituationAlarm().getId())
+                .append("alarm", getRelatedAlarm().getId())
+                .append("time", getMappedTime())
+                .toString();
+    }
 
     @Override
     public boolean equals(Object o) {

--- a/opennms-model/src/main/java/org/opennms/netmgt/model/OnmsAlarm.java
+++ b/opennms-model/src/main/java/org/opennms/netmgt/model/OnmsAlarm.java
@@ -1206,14 +1206,14 @@ public class OnmsAlarm implements Acknowledgeable, Serializable {
         m_associatedAlarms = alarms;
     }
 
-    /**
-     * <p>setDetails</p>
-     *
-     * @param alarms a {@link java.util.Set} object.
-     */
     public void setRelatedAlarms(Set<OnmsAlarm> alarms) {
         m_associatedAlarms.clear();
         alarms.forEach(relatedAlarm -> m_associatedAlarms.add(new AlarmAssociation(this, relatedAlarm)));
+    }
+
+    public void setRelatedAlarms(Set<OnmsAlarm> alarms, Date associationEventTime) {
+        m_associatedAlarms.clear();
+        alarms.forEach(relatedAlarm -> m_associatedAlarms.add(new AlarmAssociation(this, relatedAlarm, associationEventTime)));
     }
 
     public void addRelatedAlarm(OnmsAlarm alarm) {


### PR DESCRIPTION
This PR addresses the use case where an existing, un-acknowledged alarm is correlated to a Situation that is acknowledged. Previously, only the acknowledgment time of the alarm would be checked and the Situation would remain Acknowledged. Now, we additionally compare the time the Alarm is correlated to the situation and if that is later than the time at which the Situation was acknowledged, we un-acknowledge the Situation.

* JIRA: https://issues.opennms.org/browse/HZN-1426
