### PR TITLE
HZN-1435: Remove feedback submission actions from Opennms so that OCE is the authoritative source of situation changes

### DIFF
--- a/features/situation-feedback/rest/impl/src/test/java/org/opennms/features/situationfeedback/rest/SituationFeedbackrestServiceIT.java
+++ b/features/situation-feedback/rest/impl/src/test/java/org/opennms/features/situationfeedback/rest/SituationFeedbackrestServiceIT.java
@@ -149,8 +149,12 @@ public class SituationFeedbackrestServiceIT {
         // Our listener should have received the feedback
         assertThat(alarmFeedback, equalTo(feedback));
 
+        // Note: the below check is not really useful as of HZN-1435
+        // This could potentially be improved by verifying the feedback is sent out and a new situation Event is
+        // received after the OCE has processed it (when that feature is complete)
         OnmsAlarm restrieved = alarmDao.findByReductionKey(situation.getReductionKey());
-        assertThat(restrieved.getRelatedAlarms().size(), is(1));
+        // Since alarm feedback is not processed locally in the ReST API we expect the situation to remain unchanged
+        assertThat(restrieved.getRelatedAlarms().size(), is(2));
         assertThat(restrieved.getRelatedAlarms().stream().findFirst(), is(Optional.of(linkDownAlarmOnR2)));
     }
     

--- a/opennms-alarms/daemon/src/test/java/org/opennms/netmgt/alarmd/AlarmdIT.java
+++ b/opennms-alarms/daemon/src/test/java/org/opennms/netmgt/alarmd/AlarmdIT.java
@@ -322,14 +322,14 @@ public class AlarmdIT implements TemporaryDatabaseAware<MockDatabase>, Initializ
         OnmsAlarm situation = m_alarmDao.findByReductionKey("Situation1");
         assertEquals(2, situation.getRelatedAlarms().size());
 
-        //send situation in with 3rd alarm, should result in 1 situation with 3 alarms
+        //send situation in with 3rd alarm, should result in 1 situation with 1 alarm since the situation's related
+        //alarms will be overwritten with this new related alarm
         List<String> newReductionKeys = new ArrayList<>(Arrays.asList("Alarm3"));
         sendSituationEvent("Situation1", node, newReductionKeys);
         await().atMost(1, SECONDS).until(allAnticipatedEventsWereReceived());
         situation = m_alarmDao.findByReductionKey("Situation1");
-        assertEquals(3, situation.getRelatedAlarms().size());
+        assertEquals(1, situation.getRelatedAlarms().size());
     }
-
 
     @Test
     @Transactional
@@ -386,7 +386,7 @@ public class AlarmdIT implements TemporaryDatabaseAware<MockDatabase>, Initializ
         await().atMost(1, SECONDS).until(allAnticipatedEventsWereReceived());
         situation1 = m_alarmDao.findByReductionKey("Situation1");
         // Verify that Situation3 can't be related to Situation1
-        assertEquals(2, situation1.getRelatedAlarms().size());
+        assertEquals(0, situation1.getRelatedAlarms().size());
         assertFalse(situation1.getRelatedAlarms().contains(situation4));
 
     }


### PR DESCRIPTION
This PR addresses the changes required to prevent OpenNMS from persisting situation changes when feedback is submitted and instead rely on OCE to update the situation via an event.

I have a few questions that I need to answer before this PR is merged which I've added as TODO comments.

* JIRA: http://issues.opennms.org/browse/HZN-1435

Our [continuous integration system](http://bamboo.internal.opennms.com:8085) will test and verify your changes.
