### PR TITLE
NMS-10450: allow postgresql 11

### DIFF
--- a/core/schema/src/main/java/org/opennms/core/schema/Migrator.java
+++ b/core/schema/src/main/java/org/opennms/core/schema/Migrator.java
@@ -68,7 +68,7 @@ public class Migrator {
 	
     private static final Pattern POSTGRESQL_VERSION_PATTERN = Pattern.compile("^(?:PostgreSQL|EnterpriseDB) (\\d+\\.\\d+)");
     private static final float POSTGRESQL_MIN_VERSION_INCLUSIVE = Float.parseFloat(System.getProperty("opennms.postgresql.minVersion", "9.1"));
-    private static final float POSTGRESQL_MAX_VERSION_EXCLUSIVE = Float.parseFloat(System.getProperty("opennms.postgresql.maxVersion", "11.0"));
+    private static final float POSTGRESQL_MAX_VERSION_EXCLUSIVE = Float.parseFloat(System.getProperty("opennms.postgresql.maxVersion", "12.0"));
 
     private DataSource m_dataSource;
     private DataSource m_adminDataSource;


### PR DESCRIPTION
This PR just bumps the accepted postgresql version to < 12, now that 11 is out.

* JIRA: http://issues.opennms.org/browse/NMS-10450

Our [continuous integration system](http://bamboo.internal.opennms.com:8085) will test and verify your changes.
