### PR TITLE
OCE-19: add 'stroke-opacity' to edge style props

### DIFF
--- a/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.graphml/src/main/java/org/opennms/features/topology/plugins/topo/graphml/status/GraphMLEdgeStatus.java
+++ b/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.graphml/src/main/java/org/opennms/features/topology/plugins/topo/graphml/status/GraphMLEdgeStatus.java
@@ -51,6 +51,7 @@ public class GraphMLEdgeStatus extends GraphMLStatus {
     public Set<String> getAllowedStyleProperties() {
         return ImmutableSet.of("stroke",
                                "stroke-width",
+                               "stroke-opacity",
                                "stroke-dasharray");
     }
 


### PR DESCRIPTION
This PR simply adds  'stroke-opacity' as supported property for edges.
This allows Groovy scripts in the /etc/graph-edge-status/ directory to set the opacity of the line to a value between 0 and 1.

* JIRA: https://issues.opennms.org/browse/OCE-19
