### PR TITLE
OIA-2: Add support for service detectors from integration-api

### DIFF
--- a/features/api-layer/pom.xml
+++ b/features/api-layer/pom.xml
@@ -69,6 +69,10 @@
             <artifactId>opennms-alarm-api</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.opennms</groupId>
+            <artifactId>opennms-provision-api</artifactId>
+        </dependency>
 
         <!-- Test -->
         <dependency>

--- a/features/api-layer/src/main/java/org/opennms/features/apilayer/detectors/DetectorClientImpl.java
+++ b/features/api-layer/src/main/java/org/opennms/features/apilayer/detectors/DetectorClientImpl.java
@@ -35,6 +35,9 @@ import java.util.concurrent.CompletableFuture;
 import org.opennms.integration.api.v1.detectors.DetectorClient;
 import org.opennms.netmgt.provision.LocationAwareDetectorClient;
 
+/**
+ *  Implements {@link DetectorClient} for OpenNMS instance.
+ */
 public class DetectorClientImpl implements DetectorClient {
 
     private LocationAwareDetectorClient locationAwareDetectorClient;

--- a/features/api-layer/src/main/java/org/opennms/features/apilayer/detectors/DetectorClientImpl.java
+++ b/features/api-layer/src/main/java/org/opennms/features/apilayer/detectors/DetectorClientImpl.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2018 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2018 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.features.apilayer.detectors;
+
+import java.net.InetAddress;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+import org.opennms.integration.api.v1.detectors.DetectorClient;
+import org.opennms.netmgt.provision.LocationAwareDetectorClient;
+
+public class DetectorClientImpl implements DetectorClient {
+
+    private LocationAwareDetectorClient locationAwareDetectorClient;
+
+    public DetectorClientImpl(LocationAwareDetectorClient locationAwareDetectorClient) {
+        this.locationAwareDetectorClient = locationAwareDetectorClient;
+    }
+
+    @Override
+    public CompletableFuture<Boolean> detect(String serviceName, String hostName, Map<String, String> detectorAttributes) {
+        CompletableFuture<Boolean> detected = new CompletableFuture<>();
+        try {
+            return locationAwareDetectorClient.detect()
+                    .withServiceName(serviceName)
+                    .withAddress(InetAddress.getByName(hostName))
+                    .withAttributes(detectorAttributes)
+                    .execute();
+        } catch (Exception e) {
+            detected.completeExceptionally(e);
+            return detected;
+        }
+    }
+}

--- a/features/api-layer/src/main/java/org/opennms/features/apilayer/detectors/DetectorFutureImpl.java
+++ b/features/api-layer/src/main/java/org/opennms/features/apilayer/detectors/DetectorFutureImpl.java
@@ -1,0 +1,106 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2018 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2018 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.features.apilayer.detectors;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import org.opennms.integration.api.v1.detectors.DetectResults;
+import org.opennms.netmgt.provision.DetectFuture;
+import org.opennms.netmgt.provision.DetectFutureListener;
+
+/**
+ * Maps {@link DetectResults} future with {@link DetectFuture}
+ */
+public class DetectorFutureImpl implements DetectFuture {
+
+    final CompletableFuture<DetectResults> future;
+    private boolean serviceDetected = false;
+    private Throwable throwable;
+
+    public DetectorFutureImpl(CompletableFuture<DetectResults> future) {
+        this.future = future;
+    }
+
+    @Override
+    public Throwable getException() {
+        return throwable;
+    }
+
+    @Override
+    public void setServiceDetected(boolean serviceDetected) {
+        this.serviceDetected = serviceDetected;
+    }
+
+    @Override
+    public void setException(Throwable throwable) {
+        this.throwable = throwable;
+    }
+
+    @Override
+    public void awaitFor() throws InterruptedException {
+    }
+
+    @Override
+    public void awaitForUninterruptibly() {
+        // pass
+    }
+
+    @Override
+    public boolean isDone() {
+        return future.isDone();
+    }
+
+    @Override
+    public DetectFuture addListener(DetectFutureListener<DetectFuture> listener) {
+        try {
+            DetectResults detectResults = future.get();
+            setServiceDetected(detectResults.isServiceDetected());
+        } catch (InterruptedException e) {
+            setServiceDetected(false);
+            setException(e);
+        } catch (ExecutionException e) {
+            setServiceDetected(false);
+            setException(e);
+        }
+        listener.operationComplete(this);
+        return this;
+    }
+
+    @Override
+    public boolean isServiceDetected() {
+        return this.serviceDetected;
+    }
+
+    @Override
+    public Map<String, String> getServiceAttributes() {
+        return null;
+    }
+}

--- a/features/api-layer/src/main/java/org/opennms/features/apilayer/detectors/DetectorFutureImpl.java
+++ b/features/api-layer/src/main/java/org/opennms/features/apilayer/detectors/DetectorFutureImpl.java
@@ -83,10 +83,7 @@ public class DetectorFutureImpl implements DetectFuture {
         try {
             DetectResults detectResults = future.get();
             setServiceDetected(detectResults.isServiceDetected());
-        } catch (InterruptedException e) {
-            setServiceDetected(false);
-            setException(e);
-        } catch (ExecutionException e) {
+        } catch (InterruptedException | ExecutionException e) {
             setServiceDetected(false);
             setException(e);
         }

--- a/features/api-layer/src/main/java/org/opennms/features/apilayer/detectors/DetectorManager.java
+++ b/features/api-layer/src/main/java/org/opennms/features/apilayer/detectors/DetectorManager.java
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2018 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2018 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.features.apilayer.detectors;
+
+import org.opennms.features.apilayer.utils.InterfaceMapper;
+import org.opennms.integration.api.v1.detectors.ServiceDetectorFactory;
+import org.osgi.framework.BundleContext;
+
+/**
+ * Manager to plug detectors from integration-api to provision.
+ */
+public class DetectorManager extends InterfaceMapper<ServiceDetectorFactory, org.opennms.netmgt.provision.ServiceDetectorFactory> {
+
+
+    public DetectorManager(BundleContext bundleContext) {
+        super(org.opennms.netmgt.provision.ServiceDetectorFactory.class, bundleContext);
+    }
+
+    @Override
+    public org.opennms.netmgt.provision.ServiceDetectorFactory map(ServiceDetectorFactory ext) {
+        return new ServiceDetectorFactoryImpl(ext);
+    }
+
+}

--- a/features/api-layer/src/main/java/org/opennms/features/apilayer/detectors/DetectorManager.java
+++ b/features/api-layer/src/main/java/org/opennms/features/apilayer/detectors/DetectorManager.java
@@ -33,7 +33,7 @@ import org.opennms.integration.api.v1.detectors.ServiceDetectorFactory;
 import org.osgi.framework.BundleContext;
 
 /**
- * Manager to plug detectors from integration-api to provision.
+ * Manager to plug detectors from integration-api to provisioning detectors.
  */
 public class DetectorManager extends InterfaceMapper<ServiceDetectorFactory, org.opennms.netmgt.provision.ServiceDetectorFactory> {
 

--- a/features/api-layer/src/main/java/org/opennms/features/apilayer/detectors/ServiceDetectorFactoryImpl.java
+++ b/features/api-layer/src/main/java/org/opennms/features/apilayer/detectors/ServiceDetectorFactoryImpl.java
@@ -35,11 +35,9 @@ import org.opennms.integration.api.v1.detectors.DetectRequest;
 import org.opennms.integration.api.v1.detectors.ServiceDetector;
 import org.opennms.integration.api.v1.detectors.ServiceDetectorFactory;
 import org.opennms.netmgt.provision.DetectResults;
-import org.springframework.beans.BeanWrapper;
-import org.springframework.beans.PropertyAccessorFactory;
 
 /**
- *  Maps {@link ServiceDetectorFactory} implementations to {@link org.opennms.netmgt.provision.ServiceDetectorFactory}
+ * This is a proxy object created to map {@link ServiceDetectorFactory} implementations to {@link org.opennms.netmgt.provision.ServiceDetectorFactory}
  */
 public class ServiceDetectorFactoryImpl<T extends org.opennms.netmgt.provision.ServiceDetector> implements org.opennms.netmgt.provision.ServiceDetectorFactory<T> {
 
@@ -57,9 +55,7 @@ public class ServiceDetectorFactoryImpl<T extends org.opennms.netmgt.provision.S
     @Override
     @SuppressWarnings("unchecked")
     public T createDetector(Map<String, String> properties) {
-        ServiceDetector serviceDetector = serviceDetectorFactory.createDetector();
-        BeanWrapper wrapper = PropertyAccessorFactory.forBeanPropertyAccess(serviceDetector);
-        wrapper.setPropertyValues(properties);
+        ServiceDetector serviceDetector = serviceDetectorFactory.createDetector(properties);
         return (T) new ServiceDetectorImpl(serviceDetector);
     }
 

--- a/features/api-layer/src/main/java/org/opennms/features/apilayer/detectors/ServiceDetectorFactoryImpl.java
+++ b/features/api-layer/src/main/java/org/opennms/features/apilayer/detectors/ServiceDetectorFactoryImpl.java
@@ -1,0 +1,80 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2018 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2018 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.features.apilayer.detectors;
+
+import java.net.InetAddress;
+import java.util.Map;
+
+import org.opennms.integration.api.v1.detectors.ServiceDetector;
+import org.opennms.integration.api.v1.detectors.ServiceDetectorFactory;
+import org.opennms.netmgt.provision.DetectRequest;
+import org.opennms.netmgt.provision.DetectResults;
+
+/**
+ *  Maps {@link ServiceDetectorFactory} implementations to {@link org.opennms.netmgt.provision.ServiceDetectorFactory}
+ */
+public class ServiceDetectorFactoryImpl implements org.opennms.netmgt.provision.ServiceDetectorFactory {
+
+    private final ServiceDetectorFactory serviceDetectorFactory;
+
+    public ServiceDetectorFactoryImpl(ServiceDetectorFactory serviceDetectorFactory) {
+        this.serviceDetectorFactory = serviceDetectorFactory;
+    }
+
+    @Override
+    public Class getDetectorClass() {
+        return serviceDetectorFactory.getDetectorClass();
+    }
+
+    @Override
+    public org.opennms.netmgt.provision.ServiceDetector createDetector() {
+        ServiceDetector serviceDetector = serviceDetectorFactory.createDetector();
+        return new ServiceDetectorImpl(serviceDetector);
+    }
+
+    @Override
+    public void afterDetect(DetectRequest request, DetectResults results, Integer nodeId) {
+        // pass
+    }
+
+    @Override
+    public DetectRequest buildRequest(String location, InetAddress address, Integer port, Map attributes) {
+        return new DetectRequest() {
+            @Override
+            public InetAddress getAddress() {
+                return address;
+            }
+
+            @Override
+            public Map<String, String> getRuntimeAttributes() {
+                return attributes;
+            }
+        };
+    }
+}

--- a/features/api-layer/src/main/java/org/opennms/features/apilayer/detectors/ServiceDetectorImpl.java
+++ b/features/api-layer/src/main/java/org/opennms/features/apilayer/detectors/ServiceDetectorImpl.java
@@ -37,9 +37,9 @@ import org.opennms.netmgt.provision.AsyncServiceDetector;
 import org.opennms.netmgt.provision.DetectFuture;
 
 /**
- * Maps {@link ServiceDetector} with {@link AsyncServiceDetector}
- * All service detectors from integration-api are async in nature.
- * All Setters are ignored here.
+ * This is a proxy object created to map {@link ServiceDetector} with {@link AsyncServiceDetector}
+ * {@link ServiceDetector} from integration api is Async in nature.
+ *
  */
 public class ServiceDetectorImpl implements AsyncServiceDetector {
 

--- a/features/api-layer/src/main/java/org/opennms/features/apilayer/detectors/ServiceDetectorImpl.java
+++ b/features/api-layer/src/main/java/org/opennms/features/apilayer/detectors/ServiceDetectorImpl.java
@@ -37,9 +37,9 @@ import org.opennms.netmgt.provision.AsyncServiceDetector;
 import org.opennms.netmgt.provision.DetectFuture;
 
 /**
- *   Maps {@link ServiceDetector} with {@link AsyncServiceDetector}
- *   All service detectors from integration-api are async in nature.
- *   All Setters are ignored here.
+ * Maps {@link ServiceDetector} with {@link AsyncServiceDetector}
+ * All service detectors from integration-api are async in nature.
+ * All Setters are ignored here.
  */
 public class ServiceDetectorImpl implements AsyncServiceDetector {
 
@@ -75,43 +75,67 @@ public class ServiceDetectorImpl implements AsyncServiceDetector {
         return detector.getServiceName();
     }
 
+    /**
+     * Not supported on {@link ServiceDetector}
+     * throws {@link UnsupportedOperationException}
+     */
     @Override
     public void setServiceName(String serviceName) {
-        //pass
-    }
-
-    @Override
-    public int getPort() {
-        return detector.getPort();
-    }
-
-    @Override
-    public void setPort(int port) {
-        // pass
-    }
-
-    @Override
-    public int getTimeout() {
-        return detector.getTimeout();
-    }
-
-    @Override
-    public void setTimeout(int timeout) {
-        //pass
+        throw new UnsupportedOperationException();
     }
 
     /**
-     *
-     * @return No matching api, return null
+     * Not supported on {@link ServiceDetector}
+     * throws {@link UnsupportedOperationException}
+     */
+    @Override
+    public int getPort() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Not supported on {@link ServiceDetector}
+     * throws {@link UnsupportedOperationException}
+     */
+    @Override
+    public void setPort(int port) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Not supported on {@link ServiceDetector}
+     * throws {@link UnsupportedOperationException}
+     */
+    @Override
+    public int getTimeout() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Not supported on {@link ServiceDetector}
+     * throws {@link UnsupportedOperationException}
+     */
+    @Override
+    public void setTimeout(int timeout) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Not supported on {@link ServiceDetector}
+     * throws {@link UnsupportedOperationException}
      */
     @Override
     public String getIpMatch() {
-        return null;
+        throw new UnsupportedOperationException();
     }
 
+    /**
+     * Not supported on {@link ServiceDetector}
+     * throws {@link UnsupportedOperationException}
+     */
     @Override
     public void setIpMatch(String ipMatch) {
-        // pass
+        throw new UnsupportedOperationException();
     }
 
     @Override

--- a/features/api-layer/src/main/java/org/opennms/features/apilayer/detectors/ServiceDetectorImpl.java
+++ b/features/api-layer/src/main/java/org/opennms/features/apilayer/detectors/ServiceDetectorImpl.java
@@ -1,0 +1,121 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2018 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2018 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.features.apilayer.detectors;
+
+import java.net.InetAddress;
+import java.util.Map;
+
+import org.opennms.integration.api.v1.detectors.DetectRequest;
+import org.opennms.integration.api.v1.detectors.ServiceDetector;
+import org.opennms.netmgt.provision.AsyncServiceDetector;
+import org.opennms.netmgt.provision.DetectFuture;
+
+/**
+ *   Maps {@link ServiceDetector} with {@link AsyncServiceDetector}
+ *   All service detectors from integration-api are async in nature.
+ *   All Setters are ignored here.
+ */
+public class ServiceDetectorImpl implements AsyncServiceDetector {
+
+    private final ServiceDetector detector;
+
+    public ServiceDetectorImpl(ServiceDetector detector) {
+        this.detector = detector;
+    }
+
+    @Override
+    public DetectFuture detect(org.opennms.netmgt.provision.DetectRequest request) {
+        DetectRequest detectRequest = new DetectRequest() {
+            @Override
+            public InetAddress getAddress() {
+                return request.getAddress();
+            }
+
+            @Override
+            public Map<String, String> getRuntimeAttributes() {
+                return request.getRuntimeAttributes();
+            }
+        };
+        return new DetectorFutureImpl(detector.detect(detectRequest));
+    }
+
+    @Override
+    public void init() {
+        detector.init();
+    }
+
+    @Override
+    public String getServiceName() {
+        return detector.getServiceName();
+    }
+
+    @Override
+    public void setServiceName(String serviceName) {
+        //pass
+    }
+
+    @Override
+    public int getPort() {
+        return detector.getPort();
+    }
+
+    @Override
+    public void setPort(int port) {
+        // pass
+    }
+
+    @Override
+    public int getTimeout() {
+        return detector.getTimeout();
+    }
+
+    @Override
+    public void setTimeout(int timeout) {
+        //pass
+    }
+
+    /**
+     *
+     * @return No matching api, return null
+     */
+    @Override
+    public String getIpMatch() {
+        return null;
+    }
+
+    @Override
+    public void setIpMatch(String ipMatch) {
+        // pass
+    }
+
+    @Override
+    public void dispose() {
+        detector.dispose();
+    }
+}

--- a/features/api-layer/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/features/api-layer/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -106,4 +106,11 @@
     <reference-listener bind-method="onBind" unbind-method="onUnbind" ref="detectorManager" />
   </reference-list>
 
+  <reference id="locationAwareDetectorClient" interface="org.opennms.netmgt.provision.LocationAwareDetectorClient"/>
+  <service ref="detectorClient" interface="org.opennms.integration.api.v1.detectors.DetectorClient" >
+  </service>
+  <bean id="detectorClient" class="org.opennms.features.apilayer.detectors.DetectorClientImpl">
+    <argument ref="locationAwareDetectorClient"/>
+  </bean>
+
 </blueprint>

--- a/features/api-layer/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/features/api-layer/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -98,4 +98,12 @@
     <reference-listener bind-method="onBind" unbind-method="onUnbind" ref="healthCheckManager" />
   </reference-list>
 
+  <!-- Detectors -->
+  <bean id="detectorManager" class="org.opennms.features.apilayer.detectors.DetectorManager">
+    <argument ref="blueprintBundleContext"/>
+  </bean>
+  <reference-list interface="org.opennms.integration.api.v1.detectors.ServiceDetectorFactory" availability="optional">
+    <reference-listener bind-method="onBind" unbind-method="onUnbind" ref="detectorManager" />
+  </reference-list>
+
 </blueprint>

--- a/features/wsman/src/main/java/org/opennms/netmgt/provision/detector/wsman/WsManDetectorFactory.java
+++ b/features/wsman/src/main/java/org/opennms/netmgt/provision/detector/wsman/WsManDetectorFactory.java
@@ -63,8 +63,9 @@ public class WsManDetectorFactory extends GenericServiceDetectorFactory<WsManDet
     }
 
     @Override
-    public WsManDetector createDetector() {
+    public WsManDetector createDetector(Map<String, String> properties) {
         final WsManDetector detector = new WsManDetector();
+        setBeanProperties(detector, properties);
         detector.setClientFactory(m_factory);
         return detector;
     }

--- a/features/wsman/src/main/java/org/opennms/netmgt/provision/detector/wsman/WsManWQLDetectorFactory.java
+++ b/features/wsman/src/main/java/org/opennms/netmgt/provision/detector/wsman/WsManWQLDetectorFactory.java
@@ -35,16 +35,13 @@ import org.opennms.core.wsman.WSManClientFactory;
 import org.opennms.core.wsman.cxf.CXFWSManClientFactory;
 import org.opennms.netmgt.dao.WSManConfigDao;
 import org.opennms.netmgt.dao.api.NodeDao;
-import org.opennms.netmgt.model.OnmsNode;
 import org.opennms.netmgt.provision.DetectRequest;
-import org.opennms.netmgt.provision.DetectResults;
 import org.opennms.netmgt.provision.support.DetectRequestImpl;
 import org.opennms.netmgt.provision.support.GenericServiceDetectorFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 @Component
 public class WsManWQLDetectorFactory extends GenericServiceDetectorFactory<WsManWQLDetector> {
@@ -63,7 +60,7 @@ public class WsManWQLDetectorFactory extends GenericServiceDetectorFactory<WsMan
     }
 
     @Override
-    public WsManWQLDetector createDetector() {
+    public WsManWQLDetector createDetector(Map<String, String> properties) {
         final WsManWQLDetector detector = new WsManWQLDetector();
         detector.setClientFactory(m_factory);
         return detector;

--- a/opennms-provision/opennms-detector-bsf/src/test/java/org/opennms/netmgt/provision/detector/bsf/BSFDetectorTest.java
+++ b/opennms-provision/opennms-detector-bsf/src/test/java/org/opennms/netmgt/provision/detector/bsf/BSFDetectorTest.java
@@ -34,6 +34,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.util.HashMap;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -68,7 +69,7 @@ public class BSFDetectorTest implements InitializingBean {
     @Before
     public void setUp() {
         MockLogAppender.setupLogging();
-        m_detector = m_detectorFactory.createDetector();
+        m_detector = m_detectorFactory.createDetector(new HashMap<>());
         assertNotNull(m_detector);
 
         m_detector.setFileName(null);

--- a/opennms-provision/opennms-detector-datagram/src/test/java/org/opennms/netmgt/provision/detector/NtpDetectorTest.java
+++ b/opennms-provision/opennms-detector-datagram/src/test/java/org/opennms/netmgt/provision/detector/NtpDetectorTest.java
@@ -33,6 +33,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
+import java.util.HashMap;
 
 import org.junit.After;
 import org.junit.Before;
@@ -64,7 +65,7 @@ public class NtpDetectorTest implements InitializingBean {
     public void setUp(){
         MockLogAppender.setupLogging();
 
-        m_detector = m_detectorFactory.createDetector();
+        m_detector = m_detectorFactory.createDetector(new HashMap<>());
         m_detector.setRetries(0);
         assertNotNull(m_detector);
         

--- a/opennms-provision/opennms-detector-generic/src/test/java/org/opennms/netmgt/provision/detector/generic/GpDetectorTest.java
+++ b/opennms-provision/opennms-detector-generic/src/test/java/org/opennms/netmgt/provision/detector/generic/GpDetectorTest.java
@@ -34,6 +34,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.util.HashMap;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -61,7 +62,7 @@ public class GpDetectorTest implements InitializingBean {
     @Before
     public void setUp() {
         MockLogAppender.setupLogging();
-        m_detector = m_detectorFactory.createDetector();
+        m_detector = m_detectorFactory.createDetector(new HashMap<>());
     }
 
     @Test(timeout=20000)

--- a/opennms-provision/opennms-detector-jdbc/src/test/java/org/opennms/netmgt/provision/detector/JDBCDetectorIT.java
+++ b/opennms-provision/opennms-detector-jdbc/src/test/java/org/opennms/netmgt/provision/detector/JDBCDetectorIT.java
@@ -35,6 +35,7 @@ import java.net.UnknownHostException;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.SQLException;
+import java.util.HashMap;
 
 import javax.sql.DataSource;
 
@@ -80,7 +81,7 @@ public class JDBCDetectorIT implements InitializingBean {
     @Before
     public void setUp() throws UnknownHostException, SQLException {
         MockLogAppender.setupLogging();
-        m_detector = m_detectorFactory.createDetector();
+        m_detector = m_detectorFactory.createDetector(new HashMap<>());
         String url = null;
         String username = null;
         Connection conn = null;

--- a/opennms-provision/opennms-detector-jdbc/src/test/java/org/opennms/netmgt/provision/detector/JdbcQueryDetectorIT.java
+++ b/opennms-provision/opennms-detector-jdbc/src/test/java/org/opennms/netmgt/provision/detector/JdbcQueryDetectorIT.java
@@ -35,6 +35,7 @@ import java.net.UnknownHostException;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.SQLException;
+import java.util.HashMap;
 
 import javax.sql.DataSource;
 
@@ -84,7 +85,7 @@ public class JdbcQueryDetectorIT implements InitializingBean {
     public void setUp() throws SQLException {
         MockLogAppender.setupLogging();
         
-        m_detector = m_detectorFactory.createDetector();
+        m_detector = m_detectorFactory.createDetector(new HashMap<>());
         String url = null;
         String username = null;
         Connection conn = null;

--- a/opennms-provision/opennms-detector-jdbc/src/test/java/org/opennms/netmgt/provision/detector/JdbcStoredProcedureDetectorIT.java
+++ b/opennms-provision/opennms-detector-jdbc/src/test/java/org/opennms/netmgt/provision/detector/JdbcStoredProcedureDetectorIT.java
@@ -36,6 +36,7 @@ import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.HashMap;
 
 import javax.sql.DataSource;
 
@@ -84,7 +85,7 @@ public class JdbcStoredProcedureDetectorIT implements InitializingBean {
     @Before
     public void setUp() throws SQLException{
         MockLogAppender.setupLogging();
-        m_detector = m_detectorFactory.createDetector();
+        m_detector = m_detectorFactory.createDetector(new HashMap<>());
         String createSchema = "CREATE SCHEMA test";
         String createProcedure = "CREATE FUNCTION test.isRunning () RETURNS bit AS 'BEGIN RETURN 1; END;' LANGUAGE 'plpgsql';";
 

--- a/opennms-provision/opennms-detector-jmx/src/main/java/org/opennms/netmgt/provision/detector/jmx/GenericJMXDetectorFactory.java
+++ b/opennms-provision/opennms-detector-jmx/src/main/java/org/opennms/netmgt/provision/detector/jmx/GenericJMXDetectorFactory.java
@@ -56,8 +56,8 @@ public class GenericJMXDetectorFactory<T extends JMXDetector> extends GenericSer
 
     @SuppressWarnings("unchecked")
     @Override
-    public T createDetector() {
-        return (T)super.createDetector();
+    public T createDetector(Map<String, String> properties) {
+        return (T)super.createDetector(properties);
     }
 
     @Override

--- a/opennms-provision/opennms-detector-jmx/src/test/java/org/opennms/netmgt/provision/detector/Jsr160DetectorTest.java
+++ b/opennms-provision/opennms-detector-jmx/src/test/java/org/opennms/netmgt/provision/detector/Jsr160DetectorTest.java
@@ -37,6 +37,7 @@ import java.lang.management.ManagementFactory;
 import java.net.InetAddress;
 import java.rmi.RemoteException;
 import java.rmi.registry.LocateRegistry;
+import java.util.HashMap;
 
 import javax.management.InstanceAlreadyExistsException;
 import javax.management.MBeanRegistrationException;
@@ -95,7 +96,7 @@ public class Jsr160DetectorTest implements InitializingBean {
     @Before
     public void setUp() throws IOException {
         MockLogAppender.setupLogging();
-        m_detector = m_detectorFactory.createDetector();
+        m_detector = m_detectorFactory.createDetector(new HashMap<>());
         assertNotNull(m_detector);
 
         JMXServiceURL url = new JMXServiceURL("service:jmx:rmi:///jndi/rmi://localhost:9123/server");

--- a/opennms-provision/opennms-detector-lineoriented/src/test/java/org/opennms/netmgt/provision/detector/CitrixDetectorTest.java
+++ b/opennms-provision/opennms-detector-lineoriented/src/test/java/org/opennms/netmgt/provision/detector/CitrixDetectorTest.java
@@ -33,6 +33,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
+import java.util.HashMap;
 
 import org.junit.After;
 import org.junit.Before;
@@ -66,7 +67,7 @@ public class CitrixDetectorTest {
     public void setUp() throws Exception {
         MockLogAppender.setupLogging();
 
-        m_detector = m_detectorFactory.createDetector();
+        m_detector = m_detectorFactory.createDetector(new HashMap<>());
         m_detector.setTimeout(500);
 
         m_server = getServer();

--- a/opennms-provision/opennms-detector-lineoriented/src/test/java/org/opennms/netmgt/provision/detector/DominoIIOPDetectorTest.java
+++ b/opennms-provision/opennms-detector-lineoriented/src/test/java/org/opennms/netmgt/provision/detector/DominoIIOPDetectorTest.java
@@ -31,6 +31,7 @@ package org.opennms.netmgt.provision.detector;
 import static org.junit.Assert.assertFalse;
 
 import java.net.UnknownHostException;
+import java.util.HashMap;
 
 import org.junit.Before;
 import org.junit.Ignore;
@@ -60,7 +61,7 @@ public class DominoIIOPDetectorTest {
     @Before
     public void setUp() {
         MockLogAppender.setupLogging();
-        m_detector = m_detectorFactory.createDetector(); 
+        m_detector = m_detectorFactory.createDetector(new HashMap<>());
         m_detector.setTimeout(500);
     }
 

--- a/opennms-provision/opennms-detector-lineoriented/src/test/java/org/opennms/netmgt/provision/detector/FtpDetectorTest.java
+++ b/opennms-provision/opennms-detector-lineoriented/src/test/java/org/opennms/netmgt/provision/detector/FtpDetectorTest.java
@@ -31,6 +31,8 @@ package org.opennms.netmgt.provision.detector;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import java.util.HashMap;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -58,7 +60,7 @@ public class FtpDetectorTest {
     @Before
     public void setUp() throws Exception {
         MockLogAppender.setupLogging();
-        m_detector = m_detectorFactory.createDetector();
+        m_detector = m_detectorFactory.createDetector(new HashMap<>());
         m_detector.setTimeout(500);
         m_detector.init();
 

--- a/opennms-provision/opennms-detector-lineoriented/src/test/java/org/opennms/netmgt/provision/detector/HttpDetectorTest.java
+++ b/opennms-provision/opennms-detector-lineoriented/src/test/java/org/opennms/netmgt/provision/detector/HttpDetectorTest.java
@@ -32,6 +32,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
+import java.util.HashMap;
 
 import org.junit.After;
 import org.junit.Before;
@@ -101,7 +102,7 @@ public class HttpDetectorTest {
         MockLogAppender.setupLogging();
 
         /* make sure defaults are initialized */
-        m_detector = m_detectorFactory.createDetector();
+        m_detector = m_detectorFactory.createDetector(new HashMap<>());
         m_detector.setPort(80);
         m_detector.setUrl("/");
         m_detector.setMaxRetCode(399);

--- a/opennms-provision/opennms-detector-lineoriented/src/test/java/org/opennms/netmgt/provision/detector/HttpsDetectorTest.java
+++ b/opennms-provision/opennms-detector-lineoriented/src/test/java/org/opennms/netmgt/provision/detector/HttpsDetectorTest.java
@@ -37,6 +37,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
+import java.util.HashMap;
 
 import org.junit.After;
 import org.junit.Before;
@@ -93,7 +94,7 @@ public class HttpsDetectorTest {
     @Before
     public void setUp() throws Exception {
         MockLogAppender.setupLogging();
-        m_detector = m_detectorFactory.createDetector();
+        m_detector = m_detectorFactory.createDetector(new HashMap<>());
 
         /* make sure defaults are initialized */
         m_detector.setPort(SSL_PORT);

--- a/opennms-provision/opennms-detector-lineoriented/src/test/java/org/opennms/netmgt/provision/detector/ImapDetectorTest.java
+++ b/opennms-provision/opennms-detector-lineoriented/src/test/java/org/opennms/netmgt/provision/detector/ImapDetectorTest.java
@@ -32,6 +32,8 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import java.util.HashMap;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -58,7 +60,7 @@ public class ImapDetectorTest {
     public void setUp() throws Exception{
         MockLogAppender.setupLogging();
 
-        m_detector = m_detectorFactory.createDetector();
+        m_detector = m_detectorFactory.createDetector(new HashMap<>());
         m_detector.setServiceName("Imap");
         m_detector.setPort(143);
         m_detector.setTimeout(500);

--- a/opennms-provision/opennms-detector-lineoriented/src/test/java/org/opennms/netmgt/provision/detector/LdapDetectorTest.java
+++ b/opennms-provision/opennms-detector-lineoriented/src/test/java/org/opennms/netmgt/provision/detector/LdapDetectorTest.java
@@ -32,6 +32,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.net.UnknownHostException;
+import java.util.HashMap;
 
 import org.junit.Before;
 import org.junit.Ignore;
@@ -66,7 +67,7 @@ public class LdapDetectorTest {
     @Before
     public void setUp() {
         MockLogAppender.setupLogging();
-        m_detector = m_detectorFactory.createDetector();
+        m_detector = m_detectorFactory.createDetector(new HashMap<>());
         m_detector.init();
     }
 

--- a/opennms-provision/opennms-detector-lineoriented/src/test/java/org/opennms/netmgt/provision/detector/MemcachedDetectorTest.java
+++ b/opennms-provision/opennms-detector-lineoriented/src/test/java/org/opennms/netmgt/provision/detector/MemcachedDetectorTest.java
@@ -34,6 +34,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.util.HashMap;
 
 import org.junit.After;
 import org.junit.Before;
@@ -70,7 +71,7 @@ public class MemcachedDetectorTest implements InitializingBean {
     @Before
     public void setUp() throws Exception{
         MockLogAppender.setupLogging();
-        m_detector = m_detectorFactory.createDetector();
+        m_detector = m_detectorFactory.createDetector(new HashMap<>());
         m_detector.setServiceName("Memcached");
         m_detector.setPort(1000);
         m_detector.setIdleTime(3000);

--- a/opennms-provision/opennms-detector-lineoriented/src/test/java/org/opennms/netmgt/provision/detector/NotesDetectorTest.java
+++ b/opennms-provision/opennms-detector-lineoriented/src/test/java/org/opennms/netmgt/provision/detector/NotesDetectorTest.java
@@ -32,6 +32,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
+import java.util.HashMap;
 
 import org.junit.After;
 import org.junit.Before;
@@ -101,7 +102,7 @@ public class NotesDetectorTest implements InitializingBean {
 
     @Before
     public void setUp() throws Exception {
-        m_detector = m_detectorFactory.createDetector();
+        m_detector = m_detectorFactory.createDetector(new HashMap<>());
         m_detector.setTimeout(500);
         m_detector.setPort(80);
         m_detector.setUrl("/");

--- a/opennms-provision/opennms-detector-lineoriented/src/test/java/org/opennms/netmgt/provision/detector/NrpeDetectorTest.java
+++ b/opennms-provision/opennms-detector-lineoriented/src/test/java/org/opennms/netmgt/provision/detector/NrpeDetectorTest.java
@@ -32,6 +32,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.net.UnknownHostException;
+import java.util.HashMap;
 
 import org.junit.Before;
 import org.junit.Ignore;
@@ -63,7 +64,7 @@ public class NrpeDetectorTest {
     @Before
     public void setUp() {
         MockLogAppender.setupLogging();
-        m_detector = m_detectorFactory.createDetector();
+        m_detector = m_detectorFactory.createDetector(new HashMap<>());
         m_detector.setPort(5666);
         m_detector.init();
     }

--- a/opennms-provision/opennms-detector-lineoriented/src/test/java/org/opennms/netmgt/provision/detector/Pop3DetectorTest.java
+++ b/opennms-provision/opennms-detector-lineoriented/src/test/java/org/opennms/netmgt/provision/detector/Pop3DetectorTest.java
@@ -31,6 +31,8 @@ package org.opennms.netmgt.provision.detector;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import java.util.HashMap;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -107,7 +109,7 @@ public class Pop3DetectorTest {
     }
 
     private Pop3Detector createDetector(int port) {
-        Pop3Detector detector = m_detectorFactory.createDetector();
+        Pop3Detector detector = m_detectorFactory.createDetector(new HashMap<>());
         detector.setServiceName("POP3");
         detector.setTimeout(500);
         detector.setPort(port);

--- a/opennms-provision/opennms-detector-lineoriented/src/test/java/org/opennms/netmgt/provision/detector/SmtpDetectorTest.java
+++ b/opennms-provision/opennms-detector-lineoriented/src/test/java/org/opennms/netmgt/provision/detector/SmtpDetectorTest.java
@@ -32,6 +32,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
+import java.util.HashMap;
 
 import org.junit.After;
 import org.junit.Before;
@@ -70,7 +71,7 @@ public class SmtpDetectorTest {
         m_server.init();
         m_server.startServer();
 
-        m_detector = m_detectorFactory.createDetector();
+        m_detector = m_detectorFactory.createDetector(new HashMap<>());
         m_detector.setTimeout(500);
         m_detector.init();
         m_detector.setPort(m_server.getLocalPort());

--- a/opennms-provision/opennms-detector-lineoriented/src/test/java/org/opennms/netmgt/provision/detector/TcpDetectorTest.java
+++ b/opennms-provision/opennms-detector-lineoriented/src/test/java/org/opennms/netmgt/provision/detector/TcpDetectorTest.java
@@ -34,6 +34,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.net.InetAddress;
+import java.util.HashMap;
 
 import org.junit.After;
 import org.junit.Before;
@@ -67,7 +68,7 @@ public class TcpDetectorTest {
     }
 
     private void initializeDetector() {
-        m_detector = m_detectorFactory.createDetector();
+        m_detector = m_detectorFactory.createDetector(new HashMap<>());
         m_detector.setServiceName(getServiceName());
         m_detector.setTimeout(getTimeout());
         m_detector.setBanner(getBanner());

--- a/opennms-provision/opennms-detector-lineoriented/src/test/java/org/opennms/netmgt/provision/detector/msexchange/MSExchangeDetectorTest.java
+++ b/opennms-provision/opennms-detector-lineoriented/src/test/java/org/opennms/netmgt/provision/detector/msexchange/MSExchangeDetectorTest.java
@@ -34,6 +34,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.net.UnknownHostException;
+import java.util.HashMap;
 
 import org.junit.After;
 import org.junit.Before;
@@ -92,7 +93,7 @@ public class MSExchangeDetectorTest implements InitializingBean {
         m_imapServer.init();
         m_imapServer.startServer();
 
-        m_detector = m_detectorFactory.createDetector();
+        m_detector = m_detectorFactory.createDetector(new HashMap<>());
         m_detector.setPop3Port(110);
         m_detector.setImapPort(143);
         m_detector.setTimeout(500);

--- a/opennms-provision/opennms-detector-registry/src/main/java/org/opennms/netmgt/provision/detector/registry/api/ServiceDetectorRegistry.java
+++ b/opennms-provision/opennms-detector-registry/src/main/java/org/opennms/netmgt/provision/detector/registry/api/ServiceDetectorRegistry.java
@@ -60,4 +60,6 @@ public interface ServiceDetectorRegistry {
 
     ServiceDetectorFactory<?> getDetectorFactoryByServiceName(String serviceName);
 
+    String getDetectorClassNameFromServiceName(String serviceName);
+
 }

--- a/opennms-provision/opennms-detector-registry/src/main/java/org/opennms/netmgt/provision/detector/registry/impl/ServiceDetectorRegistryImpl.java
+++ b/opennms-provision/opennms-detector-registry/src/main/java/org/opennms/netmgt/provision/detector/registry/impl/ServiceDetectorRegistryImpl.java
@@ -137,6 +137,11 @@ public class ServiceDetectorRegistryImpl implements ServiceDetectorRegistry, Ini
     }
 
     @Override
+    public String getDetectorClassNameFromServiceName(String serviceName) {
+        return m_classNameByServiceName.get(serviceName);
+    }
+
+    @Override
     public Set<String> getClassNames() {
         return Collections.unmodifiableSet(m_factoriesByClassName.keySet());
     }

--- a/opennms-provision/opennms-detector-registry/src/main/java/org/opennms/netmgt/provision/detector/registry/impl/ServiceDetectorRegistryImpl.java
+++ b/opennms-provision/opennms-detector-registry/src/main/java/org/opennms/netmgt/provision/detector/registry/impl/ServiceDetectorRegistryImpl.java
@@ -42,8 +42,6 @@ import org.opennms.netmgt.provision.ServiceDetectorFactory;
 import org.opennms.netmgt.provision.detector.registry.api.ServiceDetectorRegistry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.BeanWrapper;
-import org.springframework.beans.PropertyAccessorFactory;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -67,7 +65,7 @@ public class ServiceDetectorRegistryImpl implements ServiceDetectorRegistry, Ini
             for (ServiceDetectorFactory<?> factory : m_detectorFactories) {
                 // Determine the implementation type
                 Map<String, String> props = new HashMap<>();
-                ServiceDetector detector = factory.createDetector();
+                ServiceDetector detector = factory.createDetector(props);
                 // Register the factory
                 onBind(factory, props);
                 // Add the detector to the service registry
@@ -165,13 +163,11 @@ public class ServiceDetectorRegistryImpl implements ServiceDetectorRegistry, Ini
         if (factory == null) {
             return null;
         }
-        final ServiceDetector detector = factory.createDetector();
-        BeanWrapper wrapper = PropertyAccessorFactory.forBeanPropertyAccess(detector);
-        wrapper.setPropertyValues(properties);
+        final ServiceDetector detector = factory.createDetector(properties);
         return detector;
     }
 
     private static String getServiceName(ServiceDetectorFactory<? extends ServiceDetector> factory) {
-        return factory.createDetector().getServiceName();
+        return factory.createDetector(new HashMap<>()).getServiceName();
     }
 }

--- a/opennms-provision/opennms-detector-simple/src/main/java/org/opennms/netmgt/provision/detector/icmp/IcmpDetectorFactory.java
+++ b/opennms-provision/opennms-detector-simple/src/main/java/org/opennms/netmgt/provision/detector/icmp/IcmpDetectorFactory.java
@@ -28,6 +28,8 @@
 
 package org.opennms.netmgt.provision.detector.icmp;
 
+import java.util.Map;
+
 import org.opennms.netmgt.icmp.PingerFactory;
 import org.opennms.netmgt.provision.support.GenericServiceDetectorFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -44,8 +46,9 @@ public class IcmpDetectorFactory extends GenericServiceDetectorFactory<IcmpDetec
     }
 
     @Override
-    public IcmpDetector createDetector() {
+    public IcmpDetector createDetector(Map<String, String> properties) {
         final IcmpDetector detector = new IcmpDetector();
+        setBeanProperties(detector, properties);
         detector.setPingerFactory(pingerFactory);
         return detector;
     }

--- a/opennms-provision/opennms-detector-simple/src/main/java/org/opennms/netmgt/provision/detector/snmp/GenericSnmpDetectorFactory.java
+++ b/opennms-provision/opennms-detector-simple/src/main/java/org/opennms/netmgt/provision/detector/snmp/GenericSnmpDetectorFactory.java
@@ -49,8 +49,8 @@ public class GenericSnmpDetectorFactory<T extends SnmpDetector> extends GenericS
 
     @SuppressWarnings("unchecked")
     @Override
-    public T createDetector() {
-        return (T)super.createDetector();
+    public T createDetector(Map<String, String> properties) {
+        return (T)super.createDetector(properties);
     }
 
     @Override

--- a/opennms-provision/opennms-detector-simple/src/test/java/org/opennms/netmgt/provision/detector/BgpSessionDetectorTest.java
+++ b/opennms-provision/opennms-detector-simple/src/test/java/org/opennms/netmgt/provision/detector/BgpSessionDetectorTest.java
@@ -33,6 +33,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.net.UnknownHostException;
 import java.util.Collections;
+import java.util.HashMap;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -74,7 +75,7 @@ public class BgpSessionDetectorTest implements InitializingBean {
     @Before
     public void setUp() throws InterruptedException {
         MockLogAppender.setupLogging();
-        m_detector = m_detectorFactory.createDetector();
+        m_detector = m_detectorFactory.createDetector(new HashMap<>());
         m_detector.setBgpPeerIp("");
         m_detector.setRetries(2);
         m_detector.setTimeout(500);

--- a/opennms-provision/opennms-detector-simple/src/test/java/org/opennms/netmgt/provision/detector/CiscoIpSlaDetectorTest.java
+++ b/opennms-provision/opennms-detector-simple/src/test/java/org/opennms/netmgt/provision/detector/CiscoIpSlaDetectorTest.java
@@ -33,6 +33,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.net.UnknownHostException;
 import java.util.Collections;
+import java.util.HashMap;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -74,7 +75,7 @@ public class CiscoIpSlaDetectorTest implements InitializingBean {
     @Before
     public void setUp() throws InterruptedException {
         MockLogAppender.setupLogging();
-        m_detector = m_detectorFactory.createDetector();
+        m_detector = m_detectorFactory.createDetector(new HashMap<>());
         m_detector.setRetries(2);
         m_detector.setTimeout(500);
         m_detector.setAdminTag("to_detect");

--- a/opennms-provision/opennms-detector-simple/src/test/java/org/opennms/netmgt/provision/detector/DiskUsageDetectorTest.java
+++ b/opennms-provision/opennms-detector-simple/src/test/java/org/opennms/netmgt/provision/detector/DiskUsageDetectorTest.java
@@ -33,6 +33,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.net.UnknownHostException;
 import java.util.Collections;
+import java.util.HashMap;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -74,7 +75,7 @@ public class DiskUsageDetectorTest implements InitializingBean {
     @Before
     public void setUp() throws InterruptedException {
         MockLogAppender.setupLogging();
-        m_detector = m_detectorFactory.createDetector();
+        m_detector = m_detectorFactory.createDetector(new HashMap<>());
         m_detector.setRetries(2);
         m_detector.setTimeout(500);
         m_detector.setDisk("/Volumes/iDisk");

--- a/opennms-provision/opennms-detector-simple/src/test/java/org/opennms/netmgt/provision/detector/HostResourceSWRunDetectorTest.java
+++ b/opennms-provision/opennms-detector-simple/src/test/java/org/opennms/netmgt/provision/detector/HostResourceSWRunDetectorTest.java
@@ -33,6 +33,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.net.UnknownHostException;
 import java.util.Collections;
+import java.util.HashMap;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -74,7 +75,7 @@ public class HostResourceSWRunDetectorTest implements InitializingBean {
     @Before
     public void setUp() throws InterruptedException{
         MockLogAppender.setupLogging();
-        m_detector = m_detectorFactory.createDetector();
+        m_detector = m_detectorFactory.createDetector(new HashMap<>());
         m_detector.setServiceToDetect(null);
         m_detector.setRetries(2);
         m_detector.setTimeout(500);

--- a/opennms-provision/opennms-detector-simple/src/test/java/org/opennms/netmgt/provision/detector/IcmpDetectorIT.java
+++ b/opennms-provision/opennms-detector-simple/src/test/java/org/opennms/netmgt/provision/detector/IcmpDetectorIT.java
@@ -32,6 +32,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.net.InetAddress;
+import java.util.HashMap;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -74,7 +75,7 @@ public class IcmpDetectorIT {
     @IfProfileValue(name="runPingTests", value="true")
     public void testDetectorSuccessJni() throws Exception {
         getPingerFactory().setInstance(0, true, new JniPinger());
-        m_icmpDetector = m_detectorFactory.createDetector();
+        m_icmpDetector = m_detectorFactory.createDetector(new HashMap<>());
         assertTrue("ICMP could not be detected on localhost", m_icmpDetector.isServiceDetected(InetAddress.getLocalHost()));
     }
 
@@ -82,7 +83,7 @@ public class IcmpDetectorIT {
     @IfProfileValue(name="runPingTests", value="true")
     public void testDetectorSuccessJniDscp() throws Exception {
         getPingerFactory().setInstance(0x24, true, new JniPinger());
-        m_icmpDetector = m_detectorFactory.createDetector();
+        m_icmpDetector = m_detectorFactory.createDetector(new HashMap<>());
         assertTrue("ICMP could not be detected on localhost", m_icmpDetector.isServiceDetected(InetAddress.getLocalHost()));
     }
 
@@ -90,7 +91,7 @@ public class IcmpDetectorIT {
     @IfProfileValue(name="runPingTests", value="true")
     public void testDetectorFailJni() throws Exception {
         getPingerFactory().setInstance(0, true, new JniPinger());
-        m_icmpDetector = m_detectorFactory.createDetector();
+        m_icmpDetector = m_detectorFactory.createDetector(new HashMap<>());
         assertFalse("ICMP was incorrectly identified on " + InetAddressUtils.UNPINGABLE_ADDRESS.getHostAddress(), m_icmpDetector.isServiceDetected(InetAddressUtils.UNPINGABLE_ADDRESS));
     }
 
@@ -98,7 +99,7 @@ public class IcmpDetectorIT {
     @IfProfileValue(name="runPingTests", value="true")
     public void testDetectorSuccess() throws Exception {
         getPingerFactory().setInstance(0, true, new JnaPinger());
-        m_icmpDetector = m_detectorFactory.createDetector();
+        m_icmpDetector = m_detectorFactory.createDetector(new HashMap<>());
         assertTrue("ICMP could not be detected on localhost", m_icmpDetector.isServiceDetected(InetAddress.getLocalHost()));
     }
 
@@ -106,7 +107,7 @@ public class IcmpDetectorIT {
     @IfProfileValue(name="runPingTests", value="true")
     public void testDetectorSuccessDscp() throws Exception {
         getPingerFactory().setInstance(0x24, true, new JnaPinger());
-        m_icmpDetector = m_detectorFactory.createDetector();
+        m_icmpDetector = m_detectorFactory.createDetector(new HashMap<>());
         assertTrue("ICMP could not be detected on localhost", m_icmpDetector.isServiceDetected(InetAddress.getLocalHost()));
     }
 
@@ -114,7 +115,7 @@ public class IcmpDetectorIT {
     @IfProfileValue(name="runPingTests", value="true")
     public void testDetectorFail() throws Exception {
         getPingerFactory().setInstance(0, true, new JnaPinger());
-        m_icmpDetector = m_detectorFactory.createDetector();
+        m_icmpDetector = m_detectorFactory.createDetector(new HashMap<>());
         assertFalse("ICMP was incorrectly identified on " + InetAddressUtils.UNPINGABLE_ADDRESS.getHostAddress(), m_icmpDetector.isServiceDetected(InetAddressUtils.UNPINGABLE_ADDRESS));
     }
 

--- a/opennms-provision/opennms-detector-simple/src/test/java/org/opennms/netmgt/provision/detector/LoopDetectorTest.java
+++ b/opennms-provision/opennms-detector-simple/src/test/java/org/opennms/netmgt/provision/detector/LoopDetectorTest.java
@@ -33,6 +33,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.util.HashMap;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -57,7 +58,7 @@ public class LoopDetectorTest implements InitializingBean {
     @Before
     public void setUp(){
         MockLogAppender.setupLogging();
-        m_detector = m_detectorFactory.createDetector();
+        m_detector = m_detectorFactory.createDetector(new HashMap<>());
         m_detector.setSupported(true);
     }
     

--- a/opennms-provision/opennms-detector-simple/src/test/java/org/opennms/netmgt/provision/detector/OmsaStorageDetectorTest.java
+++ b/opennms-provision/opennms-detector-simple/src/test/java/org/opennms/netmgt/provision/detector/OmsaStorageDetectorTest.java
@@ -33,6 +33,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.net.UnknownHostException;
 import java.util.Collections;
+import java.util.HashMap;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -73,7 +74,7 @@ public class OmsaStorageDetectorTest implements InitializingBean {
     @Before
     public void setUp() throws InterruptedException {
         MockLogAppender.setupLogging();
-        m_detector = m_detectorFactory.createDetector();
+        m_detector = m_detectorFactory.createDetector(new HashMap<>());
         m_detector.setRetries(2);
         m_detector.setTimeout(5000);
         m_detector.setVirtualDiskNumber("1");

--- a/opennms-provision/opennms-detector-simple/src/test/java/org/opennms/netmgt/provision/detector/OpenManageChassisDetectorTest.java
+++ b/opennms-provision/opennms-detector-simple/src/test/java/org/opennms/netmgt/provision/detector/OpenManageChassisDetectorTest.java
@@ -33,6 +33,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.net.UnknownHostException;
 import java.util.Collections;
+import java.util.HashMap;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -73,7 +74,7 @@ public class OpenManageChassisDetectorTest implements InitializingBean {
     @Before
     public void setUp() throws InterruptedException {
         MockLogAppender.setupLogging();
-        m_detector = m_detectorFactory.createDetector();
+        m_detector = m_detectorFactory.createDetector(new HashMap<>());
         m_detector.setRetries(2);
         m_detector.setTimeout(5000);
         m_request = m_detectorFactory.buildRequest(null, InetAddressUtils.addr(TEST_IP_ADDRESS), null, Collections.emptyMap());

--- a/opennms-provision/opennms-detector-simple/src/test/java/org/opennms/netmgt/provision/detector/PercDetectorTest.java
+++ b/opennms-provision/opennms-detector-simple/src/test/java/org/opennms/netmgt/provision/detector/PercDetectorTest.java
@@ -33,6 +33,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.net.UnknownHostException;
 import java.util.Collections;
+import java.util.HashMap;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -74,7 +75,7 @@ public class PercDetectorTest implements InitializingBean {
     @Before
     public void setUp() throws InterruptedException {
         MockLogAppender.setupLogging();
-        m_detector = m_detectorFactory.createDetector();
+        m_detector = m_detectorFactory.createDetector(new HashMap<>());
         m_detector.setArrayNumber("0.0"); // the default
         m_detector.setRetries(2);
         m_detector.setTimeout(500);

--- a/opennms-provision/opennms-detector-simple/src/test/java/org/opennms/netmgt/provision/detector/SnmpDetectorTest.java
+++ b/opennms-provision/opennms-detector-simple/src/test/java/org/opennms/netmgt/provision/detector/SnmpDetectorTest.java
@@ -33,6 +33,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.net.UnknownHostException;
 import java.util.Collections;
+import java.util.HashMap;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -69,7 +70,7 @@ public class SnmpDetectorTest {
     @Before
     public void setUp() throws InterruptedException, UnknownHostException {
         MockLogAppender.setupLogging();
-        m_detector = m_detectorFactory.createDetector();
+        m_detector = m_detectorFactory.createDetector(new HashMap<>());
         m_detector.setRetries(2);
         m_detector.setTimeout(500);
         m_request = m_detectorFactory.buildRequest(null, InetAddressUtils.addr(TEST_IP_ADDRESS), null, Collections.emptyMap());

--- a/opennms-provision/opennms-detector-simple/src/test/java/org/opennms/netmgt/provision/detector/Win32ServiceDetectorTest.java
+++ b/opennms-provision/opennms-detector-simple/src/test/java/org/opennms/netmgt/provision/detector/Win32ServiceDetectorTest.java
@@ -33,6 +33,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.net.UnknownHostException;
 import java.util.Collections;
+import java.util.HashMap;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -74,7 +75,7 @@ public class Win32ServiceDetectorTest implements InitializingBean {
     @Before
     public void setUp() throws InterruptedException {
         MockLogAppender.setupLogging();
-        m_detector = m_detectorFactory.createDetector();
+        m_detector = m_detectorFactory.createDetector(new HashMap<>());
         m_detector.setRetries(2);
         m_detector.setTimeout(5000);
         m_detector.setWin32ServiceName("VMware Tools Service");

--- a/opennms-provision/opennms-detector-ssh/src/test/java/org/opennms/netmgt/provision/detector/SSHDetectorTest.java
+++ b/opennms-provision/opennms-detector-ssh/src/test/java/org/opennms/netmgt/provision/detector/SSHDetectorTest.java
@@ -32,6 +32,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.net.UnknownHostException;
+import java.util.HashMap;
 
 import org.junit.Before;
 import org.junit.Ignore;
@@ -67,7 +68,7 @@ public class SSHDetectorTest implements InitializingBean {
     @Before
     public void setUp() {
         MockLogAppender.setupLogging();
-        m_detector = m_detectorFactory.createDetector();
+        m_detector = m_detectorFactory.createDetector(new HashMap<>());
         m_detector.setTimeout(1);
     }
 

--- a/opennms-provision/opennms-detector-web/src/test/java/org/opennms/netmgt/provision/detector/web/WebDetectorTest.java
+++ b/opennms-provision/opennms-detector-web/src/test/java/org/opennms/netmgt/provision/detector/web/WebDetectorTest.java
@@ -34,6 +34,7 @@ import static org.junit.Assert.assertTrue;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.ServerSocket;
+import java.util.HashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -112,7 +113,7 @@ public class WebDetectorTest implements InitializingBean {
     @Before
     public void setUp() throws Exception {
         MockLogAppender.setupLogging();
-        m_detector = m_detectorFactory.createDetector();
+        m_detector = m_detectorFactory.createDetector(new HashMap<>());
         m_detector.setPort(80);
         m_detector.setPath("/");
         m_detector.setResponseRange("100-399");

--- a/opennms-provision/opennms-detectorclient-rpc/src/main/java/org/opennms/netmgt/provision/detector/client/rpc/DetectorRequestBuilderImpl.java
+++ b/opennms-provision/opennms-detectorclient-rpc/src/main/java/org/opennms/netmgt/provision/detector/client/rpc/DetectorRequestBuilderImpl.java
@@ -88,7 +88,7 @@ public class DetectorRequestBuilderImpl implements DetectorRequestBuilder {
         if (detector == null) {
             throw new IllegalArgumentException("No detector found with service name '" + serviceName + "'.");
         }
-        this.className = detector.getClass().getCanonicalName();
+        this.className = client.getRegistry().getDetectorClassNameFromServiceName(serviceName);
         return this;
     }
 

--- a/opennms-provision/opennms-detectorclient-rpc/src/main/resources/META-INF/opennms/applicationContext-rpc-detect.xml
+++ b/opennms-provision/opennms-detectorclient-rpc/src/main/resources/META-INF/opennms/applicationContext-rpc-detect.xml
@@ -19,4 +19,8 @@
     <bean id="locationAwareDetectorClient" class="org.opennms.netmgt.provision.detector.client.rpc.LocationAwareDetectorClientRpcImpl" />
     <onmsgi:service interface="org.opennms.netmgt.provision.LocationAwareDetectorClient" ref="locationAwareDetectorClient"/>
 
+    <onmsgi:list id="serviceDetectors" interface="org.opennms.netmgt.provision.ServiceDetectorFactory">
+        <onmsgi:listener bind-method="onBind" unbind-method="onUnbind" ref="serviceDetectorRegistry"/>
+    </onmsgi:list>
+
 </beans>

--- a/opennms-provision/opennms-provision-api/src/main/java/org/opennms/netmgt/provision/ServiceDetectorFactory.java
+++ b/opennms-provision/opennms-provision-api/src/main/java/org/opennms/netmgt/provision/ServiceDetectorFactory.java
@@ -49,8 +49,14 @@ public interface ServiceDetectorFactory<T extends ServiceDetector> {
     Class<T> getDetectorClass();
 
     /**
-     * Instantiates a new detector.
-     *
+     * Instantiates a new detector and set bean properties.
+     * One of the ways to set bean properties is using Spring @{@link org.springframework.beans.BeanWrapper}
+     * <pre>
+     * {@code
+     *         BeanWrapper wrapper = PropertyAccessorFactory.forBeanPropertyAccess(serviceDetector);
+     *         wrapper.setPropertyValues(properties);
+     * }
+     * </pre>
      * Detectors are treated as protoypes and should only be used for a
      * single call to "isServiceDetected".
      *

--- a/opennms-provision/opennms-provision-api/src/main/java/org/opennms/netmgt/provision/ServiceDetectorFactory.java
+++ b/opennms-provision/opennms-provision-api/src/main/java/org/opennms/netmgt/provision/ServiceDetectorFactory.java
@@ -31,6 +31,8 @@ package org.opennms.netmgt.provision;
 import java.net.InetAddress;
 import java.util.Map;
 
+import org.opennms.netmgt.model.OnmsNode;
+
 /**
  * Responsible for instantiating detectors, gathering state information or agent specific details,
  * and optionally handling post-processing of the requests.
@@ -52,8 +54,9 @@ public interface ServiceDetectorFactory<T extends ServiceDetector> {
      * Detectors are treated as protoypes and should only be used for a
      * single call to "isServiceDetected".
      *
+     * @param properties  are used to set properties on detector bean.
      */
-    T createDetector();
+    T createDetector(Map<String, String> properties);
 
     /**
      * Builds the request that will be used to invoke the detector.
@@ -67,10 +70,11 @@ public interface ServiceDetectorFactory<T extends ServiceDetector> {
     DetectRequest buildRequest(String location, InetAddress address, Integer port, Map<String, String> attributes);
 
     /**
-     * 
-     * @param request
-     * @param results
-     * @param nodeId
+     * Optional implementation.
+     * @param request {@link DetectRequest}
+     * @param results {@link DetectResults}
+     * @param nodeId  {@link OnmsNode#getNodeId()}
      */
     void afterDetect(DetectRequest request, DetectResults results, Integer nodeId);
+
 }

--- a/opennms-provision/opennms-provision-api/src/main/java/org/opennms/netmgt/provision/support/GenericServiceDetectorFactory.java
+++ b/opennms-provision/opennms-provision-api/src/main/java/org/opennms/netmgt/provision/support/GenericServiceDetectorFactory.java
@@ -36,6 +36,8 @@ import org.opennms.netmgt.provision.DetectRequest;
 import org.opennms.netmgt.provision.DetectResults;
 import org.opennms.netmgt.provision.ServiceDetector;
 import org.opennms.netmgt.provision.ServiceDetectorFactory;
+import org.springframework.beans.BeanWrapper;
+import org.springframework.beans.PropertyAccessorFactory;
 
 public class GenericServiceDetectorFactory<T extends ServiceDetector> implements ServiceDetectorFactory<T> {
 
@@ -46,9 +48,11 @@ public class GenericServiceDetectorFactory<T extends ServiceDetector> implements
     }
 
     @Override
-    public T createDetector() {
+    public T createDetector(Map<String, String> properties) {
         try {
-            return clazz.newInstance();
+            T detector = clazz.newInstance();
+            setBeanProperties(detector, properties);
+            return detector;
         } catch (InstantiationException | IllegalAccessException e) {
             throw new RuntimeException(e);
         }
@@ -66,6 +70,17 @@ public class GenericServiceDetectorFactory<T extends ServiceDetector> implements
 
     @Override
     public void afterDetect(DetectRequest request, DetectResults results, Integer nodeId) {
-        // pass
+        //pass
     }
+
+    /**
+     * Set detector attributes as bean properties.
+     * @param detector  {@link ServiceDetector}
+     * @param properties detector attributes from foreign source configuration
+     */
+    public void setBeanProperties(ServiceDetector detector, Map<String, String> properties) {
+        BeanWrapper wrapper = PropertyAccessorFactory.forBeanPropertyAccess(detector);
+        wrapper.setPropertyValues(properties);
+    }
+
 }

--- a/pom.xml
+++ b/pom.xml
@@ -1354,7 +1354,7 @@
     <postgresqlVersion>9.4.1211</postgresqlVersion>
     <powermockVersion>1.6.4</powermockVersion>
     <!-- TODO: Update to release artifact before tagging 24.0.0 -->
-    <opennmsApiVersion>1.0.0-alpha1-SNAPSHOT</opennmsApiVersion>
+    <opennmsApiVersion>1.0.0-alpha2-SNAPSHOT</opennmsApiVersion>
     <osgiVersion>6.0.0</osgiVersion>
     <osgiCompendiumVersion>5.0.0</osgiCompendiumVersion>
     <osgiEnterpriseVersion>5.0.0</osgiEnterpriseVersion>

--- a/protocols/dhcp/src/test/java/org/opennms/protocols/dhcp/detector/DhcpDetectorTest.java
+++ b/protocols/dhcp/src/test/java/org/opennms/protocols/dhcp/detector/DhcpDetectorTest.java
@@ -36,6 +36,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.util.Arrays;
+import java.util.HashMap;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
@@ -109,7 +110,7 @@ public class DhcpDetectorTest implements InitializingBean {
                 "</DhcpdConfiguration>");
 
         DhcpdConfigFactory.init();
-        m_detector = m_detectorFactory.createDetector();
+        m_detector = m_detectorFactory.createDetector(new HashMap<>());
         m_dhcpd = Dhcpd.getInstance();
         m_dhcpd.init();
 

--- a/protocols/nsclient/src/test/java/org/opennms/protocols/nsclient/detector/NsclientDetectorTest.java
+++ b/protocols/nsclient/src/test/java/org/opennms/protocols/nsclient/detector/NsclientDetectorTest.java
@@ -30,6 +30,7 @@ package org.opennms.protocols.nsclient.detector;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.util.HashMap;
 
 import org.junit.After;
 import org.junit.Assert;
@@ -78,7 +79,7 @@ public class NsclientDetectorTest implements InitializingBean {
     @Before
     public void setUp() throws Exception{
         MockLogAppender.setupLogging();
-        m_detector = m_detectorFactory.createDetector();
+        m_detector = m_detectorFactory.createDetector(new HashMap<>());
         // Initialize Mock NSClient Server
         m_server  = new SimpleServer() {
             @Override

--- a/protocols/radius/src/test/java/org/opennms/protocols/radius/detector/RadiusAuthDetectorTest.java
+++ b/protocols/radius/src/test/java/org/opennms/protocols/radius/detector/RadiusAuthDetectorTest.java
@@ -32,6 +32,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.net.UnknownHostException;
+import java.util.HashMap;
 
 import org.junit.After;
 import org.junit.Before;
@@ -70,7 +71,7 @@ public class RadiusAuthDetectorTest implements ApplicationContextAware, Initiali
         mockSrv = new MockRadiusServer();
         mockSrv.start(true,false);
         MockLogAppender.setupLogging();
-        m_detector = m_detectorFactory.createDetector();
+        m_detector = m_detectorFactory.createDetector(new HashMap<>());
     }
     @After
     public void tearDown(){


### PR DESCRIPTION
This is dependent on https://github.com/OpenNMS/opennms-integration-api/pull/1

* JIRA: http://issues.opennms.org/browse/OIA-2

Our [continuous integration system](http://bamboo.internal.opennms.com:8085) will test and verify your changes.
