### PR TITLE
NMS-10455: Add checkstyle rule to enforce MoreObjects.toStringHelper

### DIFF
--- a/checkstyle/src/main/resources/nms_checks.xml
+++ b/checkstyle/src/main/resources/nms_checks.xml
@@ -14,6 +14,12 @@
             <property name="forbiddenImportsExcludesRegexp" value="" />
             <message key="forbid.certain.imports" value="Use ''java.nio.charset.StandardCharsets'' instead of ''{0}''" />
         </module>
+        <module name="com.github.sevntu.checkstyle.checks.coding.ForbidCertainImportsCheck">
+            <property name="packageNameRegexp" value=".*" />
+            <property name="forbiddenImportsRegexp" value="org.springframework.core.style.ToStringCreator" />
+            <property name="forbiddenImportsExcludesRegexp" value="" />
+            <message key="forbid.certain.imports" value="Use ''com.google.common.base.MoreObjects'' instead of ''{0}''" />
+        </module>
         <module name="IllegalTokenText">
             <property name="tokens" value="STRING_LITERAL"/>
             <property name="format" value="^UTF-8$"/>

--- a/opennms-correlation/drools-correlation-engine/src/main/java/org/opennms/netmgt/correlation/drools/FlapCount.java
+++ b/opennms-correlation/drools-correlation-engine/src/main/java/org/opennms/netmgt/correlation/drools/FlapCount.java
@@ -32,7 +32,7 @@ import java.io.Serializable;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.core.style.ToStringCreator;
+import com.google.common.base.MoreObjects;
 
 /**
  * <p>FlapCount class.</p>
@@ -202,12 +202,12 @@ public class FlapCount implements Serializable {
      */
     @Override
     public String toString() {
-        return new ToStringCreator(this)
-        	.append("nodeid", m_nodeid)
-        	.append("ipAddr", m_ipAddr)
-        	.append("svcName", m_svcName)
-        	.append("locMon", m_locationMonitor)
-        	.append("count", m_count)
-        	.toString();
+        return MoreObjects.toStringHelper(this)
+		.add("nodeid", m_nodeid)
+		.add("ipAddr", m_ipAddr)
+		.add("svcName", m_svcName)
+		.add("locMon", m_locationMonitor)
+		.add("count", m_count)
+		.toString();
     }
 }

--- a/opennms-provision/opennms-provisiond/src/test/java/org/opennms/netmgt/provision/service/ProvisionerIT.java
+++ b/opennms-provision/opennms-provisiond/src/test/java/org/opennms/netmgt/provision/service/ProvisionerIT.java
@@ -125,7 +125,7 @@ import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.DefaultResourceLoader;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.core.io.UrlResource;
-import org.springframework.core.style.ToStringCreator;
+import com.google.common.base.MoreObjects;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.context.ContextConfiguration;
@@ -1995,22 +1995,22 @@ public class ProvisionerIT extends ProvisioningITCase implements InitializingBea
 
         @Override
         public String toString() {
-            return (new ToStringCreator(this)
-            .append("modelImportCount", getModelImportCount())
-            .append("modelImportCompletedCount", getModelImportCompletedCount())
-            .append("nodeCount", getNodeCount())
-            .append("nodeCompletedCount", getNodeCompletedCount())
-            .append("nodeCategoryCount", getNodeCategoryCount())
-            .append("nodeCategoryCompletedCount", getNodeCategoryCompletedCount())
-            .append("interfaceCount", getInterfaceCount())
-            .append("interfaceCompletedCount", getInterfaceCompletedCount())
-            .append("monitoredServiceCount", getMonitoredServiceCount())
-            .append("monitoredServiceCompletedCount", getMonitoredServiceCompletedCount())
-            .append("serviceCategoryCount", getServiceCategoryCount())
-            .append("serviceCategoryCompletedCount", getServiceCategoryCompletedCount())
-            .append("assetCount", getAssetCount())
-            .append("assetCompletedCount", getAssetCompletedCount())
-            .toString());
+            return MoreObjects.toStringHelper(this)
+            .add("modelImportCount", getModelImportCount())
+            .add("modelImportCompletedCount", getModelImportCompletedCount())
+            .add("nodeCount", getNodeCount())
+            .add("nodeCompletedCount", getNodeCompletedCount())
+            .add("nodeCategoryCount", getNodeCategoryCount())
+            .add("nodeCategoryCompletedCount", getNodeCategoryCompletedCount())
+            .add("interfaceCount", getInterfaceCount())
+            .add("interfaceCompletedCount", getInterfaceCompletedCount())
+            .add("monitoredServiceCount", getMonitoredServiceCount())
+            .add("monitoredServiceCompletedCount", getMonitoredServiceCompletedCount())
+            .add("serviceCategoryCount", getServiceCategoryCount())
+            .add("serviceCategoryCompletedCount", getServiceCategoryCompletedCount())
+            .add("assetCount", getAssetCount())
+            .add("assetCompletedCount", getAssetCompletedCount())
+            .toString();
         }
 
         @Override

--- a/opennms-tools/access-point-monitor/src/main/java/org/opennms/netmgt/model/OnmsAccessPoint.java
+++ b/opennms-tools/access-point-monitor/src/main/java/org/opennms/netmgt/model/OnmsAccessPoint.java
@@ -43,7 +43,7 @@ import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
 import org.hibernate.annotations.Type;
 import org.opennms.core.network.InetAddressXmlAdapter;
-import org.springframework.core.style.ToStringCreator;
+import com.google.common.base.MoreObjects;
 
 /**
  * <p>
@@ -230,11 +230,11 @@ public class OnmsAccessPoint implements Serializable, Comparable<OnmsAccessPoint
      */
     @Override
     public String toString() {
-        return new ToStringCreator(this)
-            .append("physAddr", getPhysAddr())
-            .append("pollingPackage", getPollingPackage())
-            .append("status", getStatus())
-            .append("controllerIpAddr", getControllerIpAddress())
+        return MoreObjects.toStringHelper(this)
+            .add("physAddr", getPhysAddr())
+            .add("pollingPackage", getPollingPackage())
+            .add("status", getStatus())
+            .add("controllerIpAddr", getControllerIpAddress())
             .toString();
     }
 


### PR DESCRIPTION
This PR adds a Checkstyle rule that will prevent contributors from using the SpringFramework's ToStringCreator

JIRA: http://issues.opennms.org/browse/NMS-10455

