### PR TITLE
OCE-27: Fix transaction related issues when performing managed object tagging

### DIFF
--- a/features/api-layer/src/main/java/org/opennms/features/apilayer/dao/AlarmDaoImpl.java
+++ b/features/api-layer/src/main/java/org/opennms/features/apilayer/dao/AlarmDaoImpl.java
@@ -52,12 +52,12 @@ public class AlarmDaoImpl implements AlarmDao {
     @Override
     public Long getAlarmCount() {
         final CriteriaBuilder criteriaBuilder = new CriteriaBuilder(OnmsAlarm.class);
-        return (long)alarmDao.countMatching(criteriaBuilder.toCriteria());
+        return sessionUtils.withReadOnlyTransaction(() -> (long)alarmDao.countMatching(criteriaBuilder.toCriteria()));
     }
 
     @Override
     public List<Alarm> getAlarms() {
-        return sessionUtils.withTransaction(() ->
+        return sessionUtils.withReadOnlyTransaction(() ->
                 alarmDao.findAll().stream().map(ModelMappers::toAlarm).collect(Collectors.toList()));
     }
 }

--- a/features/api-layer/src/main/java/org/opennms/features/apilayer/dao/NodeDaoImpl.java
+++ b/features/api-layer/src/main/java/org/opennms/features/apilayer/dao/NodeDaoImpl.java
@@ -54,41 +54,41 @@ public class NodeDaoImpl implements NodeDao {
 
     @Override
     public List<Node> getNodes() {
-        return sessionUtils.withTransaction(() ->
+        return sessionUtils.withReadOnlyTransaction(() ->
                 nodeDao.findAll().stream().map(ModelMappers::toNode).collect(Collectors.toList()));
     }
 
     @Override
     public Long getNodeCount() {
         final CriteriaBuilder criteriaBuilder = new CriteriaBuilder(OnmsNode.class);
-        return (long)nodeDao.countMatching(criteriaBuilder.toCriteria());
+        return sessionUtils.withReadOnlyTransaction(() -> (long)nodeDao.countMatching(criteriaBuilder.toCriteria()));
     }
 
     @Override
     public List<Integer> getNodeIds() {
-        return Lists.newArrayList(nodeDao.getNodeIds());
+        return sessionUtils.withReadOnlyTransaction(() -> Lists.newArrayList(nodeDao.getNodeIds()));
     }
 
     @Override
     public Node getNodeByCriteria(String nodeCriteria) {
-        return ModelMappers.toNode(nodeDao.get(nodeCriteria));
+        return sessionUtils.withReadOnlyTransaction(() -> ModelMappers.toNode(nodeDao.get(nodeCriteria)));
     }
 
     @Override
     public Node getNodeById(Integer nodeId) {
-        return sessionUtils.withTransaction(() -> ModelMappers.toNode(nodeDao.get(nodeId)));
+        return sessionUtils.withReadOnlyTransaction(() -> ModelMappers.toNode(nodeDao.get(nodeId)));
     }
 
     @Override
     public Node getNodeByLabel(String nodeLabel) {
-        return sessionUtils.withTransaction(() -> ModelMappers.toNode(nodeDao.findByLabel(nodeLabel).stream()
+        return sessionUtils.withReadOnlyTransaction(() -> ModelMappers.toNode(nodeDao.findByLabel(nodeLabel).stream()
                 .min(Comparator.comparingInt(OnmsNode::getId))
                 .orElse(null)));
     }
 
     @Override
     public Node getNodeByForeignSourceAndForeignId(String foreignSource, String foreignId) {
-        return sessionUtils.withTransaction(() ->
+        return sessionUtils.withReadOnlyTransaction(() ->
                 ModelMappers.toNode(nodeDao.findByForeignId(foreignSource, foreignId)));
     }
 }

--- a/features/api-layer/src/main/java/org/opennms/features/apilayer/dao/SnmpInterfaceDaoImpl.java
+++ b/features/api-layer/src/main/java/org/opennms/features/apilayer/dao/SnmpInterfaceDaoImpl.java
@@ -34,14 +34,17 @@ import org.opennms.core.criteria.CriteriaBuilder;
 import org.opennms.features.apilayer.utils.ModelMappers;
 import org.opennms.integration.api.v1.dao.SnmpInterfaceDao;
 import org.opennms.integration.api.v1.model.SnmpInterface;
+import org.opennms.netmgt.dao.api.SessionUtils;
 import org.opennms.netmgt.model.OnmsSnmpInterface;
 
 public class SnmpInterfaceDaoImpl implements SnmpInterfaceDao {
 
     private final org.opennms.netmgt.dao.api.SnmpInterfaceDao snmpInterfaceDao;
+    private final SessionUtils sessionUtils;
 
-    public SnmpInterfaceDaoImpl(org.opennms.netmgt.dao.api.SnmpInterfaceDao snmpInterfaceDao) {
+    public SnmpInterfaceDaoImpl(org.opennms.netmgt.dao.api.SnmpInterfaceDao snmpInterfaceDao, SessionUtils sessionUtils) {
         this.snmpInterfaceDao = Objects.requireNonNull(snmpInterfaceDao);
+        this.sessionUtils = Objects.requireNonNull(sessionUtils);
     }
 
     @Override
@@ -54,7 +57,7 @@ public class SnmpInterfaceDaoImpl implements SnmpInterfaceDao {
     public SnmpInterface findByNodeIdAndDescrOrName(Integer nodeId, String descrOrName) {
         // Note that the SnmpInterfaceDaoHibernate#findByNodeIdAndDescription method actually
         // searches by either the ifName or the ifDescr
-        return ModelMappers.toSnmpInterface(snmpInterfaceDao.findByNodeIdAndDescription(nodeId, descrOrName));
+        return sessionUtils.withReadOnlyTransaction(() -> ModelMappers.toSnmpInterface(snmpInterfaceDao.findByNodeIdAndDescription(nodeId, descrOrName)));
     }
 
 }

--- a/features/api-layer/src/main/java/org/opennms/features/apilayer/dao/SnmpInterfaceDaoImpl.java
+++ b/features/api-layer/src/main/java/org/opennms/features/apilayer/dao/SnmpInterfaceDaoImpl.java
@@ -50,7 +50,7 @@ public class SnmpInterfaceDaoImpl implements SnmpInterfaceDao {
     @Override
     public Long getSnmpInterfaceCount() {
         final CriteriaBuilder criteriaBuilder = new CriteriaBuilder(OnmsSnmpInterface.class);
-        return (long)snmpInterfaceDao.countMatching(criteriaBuilder.toCriteria());
+        return sessionUtils.withReadOnlyTransaction(() -> (long)snmpInterfaceDao.countMatching(criteriaBuilder.toCriteria()));
     }
 
     @Override

--- a/features/api-layer/src/main/java/org/opennms/features/apilayer/model/NodeBean.java
+++ b/features/api-layer/src/main/java/org/opennms/features/apilayer/model/NodeBean.java
@@ -44,7 +44,7 @@ public class NodeBean implements Node {
     public NodeBean(OnmsNode node) {
         this.node = Objects.requireNonNull(node);
         this.snmpInterfaces = node.getSnmpInterfaces().stream()
-                .map(s -> new SnmpInterfaceBean(s))
+                .map(SnmpInterfaceBean::new)
                 .collect(Collectors.toList());
     }
 

--- a/features/api-layer/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/features/api-layer/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -31,6 +31,7 @@
   <service interface="org.opennms.integration.api.v1.dao.SnmpInterfaceDao" >
     <bean class="org.opennms.features.apilayer.dao.SnmpInterfaceDaoImpl">
       <argument ref="snmpInterfaceDao"/>
+      <argument ref="sessionUtils"/>
     </bean>
   </service>
 

--- a/opennms-dao-api/src/main/java/org/opennms/netmgt/dao/api/SessionUtils.java
+++ b/opennms-dao-api/src/main/java/org/opennms/netmgt/dao/api/SessionUtils.java
@@ -51,6 +51,15 @@ public interface SessionUtils {
     <V> V withTransaction(Supplier<V> supplier);
 
     /**
+     * Invoked the given supplier within the context of a read-only transaction.
+     *
+     * @param supplier supplier to invoke
+     * @param <V> type returned by the supplier
+     * @return value returned by the supplier
+     */
+    <V> V withReadOnlyTransaction(Supplier<V> supplier);
+
+    /**
      * Converts the flush mode for the current session factory to MANUAL
      * for the duration of the call to the given supplier.
      *

--- a/opennms-dao-api/src/main/java/org/opennms/netmgt/dao/api/SessionUtils.java
+++ b/opennms-dao-api/src/main/java/org/opennms/netmgt/dao/api/SessionUtils.java
@@ -51,7 +51,7 @@ public interface SessionUtils {
     <V> V withTransaction(Supplier<V> supplier);
 
     /**
-     * Invoked the given supplier within the context of a read-only transaction.
+     * Invokes the given supplier within the context of a read-only transaction.
      *
      * @param supplier supplier to invoke
      * @param <V> type returned by the supplier

--- a/opennms-dao/src/main/java/org/opennms/netmgt/dao/hibernate/DefaultSessionUtils.java
+++ b/opennms-dao/src/main/java/org/opennms/netmgt/dao/hibernate/DefaultSessionUtils.java
@@ -28,15 +28,26 @@
 
 package org.opennms.netmgt.dao.hibernate;
 
+import java.lang.reflect.UndeclaredThrowableException;
 import java.util.function.Supplier;
 
 import org.hibernate.FlushMode;
 import org.hibernate.SessionFactory;
 import org.opennms.netmgt.dao.api.SessionUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.TransactionException;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.TransactionSystemException;
+import org.springframework.transaction.support.DefaultTransactionDefinition;
 import org.springframework.transaction.support.TransactionOperations;
 
 public class DefaultSessionUtils implements SessionUtils {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DefaultSessionUtils.class);
 
     @Autowired
     private SessionFactory sessionFactory;
@@ -44,9 +55,22 @@ public class DefaultSessionUtils implements SessionUtils {
     @Autowired
     private TransactionOperations transactionOperations;
 
+    @Autowired
+    private PlatformTransactionManager transactionManager;
+
+    private static final DefaultTransactionDefinition readOnlyTransactionDefinition = new DefaultTransactionDefinition();
+    static {
+        readOnlyTransactionDefinition.setReadOnly(true);
+    }
+
     @Override
     public <V> V withTransaction(Supplier<V> supplier) {
         return transactionOperations.execute(status -> supplier.get());
+    }
+
+    @Override
+    public <V> V withReadOnlyTransaction(Supplier<V> supplier) {
+        return withManualFlush(() -> executeWithTransactionDefinition(readOnlyTransactionDefinition, supplier));
     }
 
     @Override
@@ -60,4 +84,60 @@ public class DefaultSessionUtils implements SessionUtils {
         }
     }
 
+    /**
+     * NOTE: This is mostly copied from org.springframework.transaction.support.TransactionTemplate#execute
+     * but adds the ability to specify our own transaction definition.
+     */
+    private <V> V executeWithTransactionDefinition(TransactionDefinition transactionDefinition, Supplier<V> supplier) {
+        final TransactionStatus status = transactionManager.getTransaction(transactionDefinition);
+        V result;
+        try {
+            result = supplier.get();
+        }
+        catch (RuntimeException ex) {
+            // Transactional code threw application exception -> rollback
+            rollbackOnException(status, ex);
+            throw ex;
+        }
+        catch (Error err) {
+            // Transactional code threw error -> rollback
+            rollbackOnException(status, err);
+            throw err;
+        }
+        catch (Throwable ex) {
+            // Transactional code threw unexpected exception -> rollback
+            rollbackOnException(status, ex);
+            throw new UndeclaredThrowableException(ex, "TransactionCallback threw undeclared checked exception");
+        }
+        this.transactionManager.commit(status);
+        return result;
+    }
+
+    /**
+     * NOTE: This is a copy of org.springframework.transaction.support.TransactionTemplate#rollbackOnException
+     *
+     * Perform a rollback, handling rollback exceptions properly.
+     * @param status object representing the transaction
+     * @param ex the thrown application exception or error
+     * @throws TransactionException in case of a rollback error
+     */
+    private void rollbackOnException(TransactionStatus status, Throwable ex) throws TransactionException {
+        LOG.debug("Initiating transaction rollback on application exception", ex);
+        try {
+            this.transactionManager.rollback(status);
+        }
+        catch (TransactionSystemException ex2) {
+            LOG.error("Application exception overridden by rollback exception", ex);
+            ex2.initApplicationException(ex);
+            throw ex2;
+        }
+        catch (RuntimeException ex2) {
+            LOG.error("Application exception overridden by rollback exception", ex);
+            throw ex2;
+        }
+        catch (Error err) {
+            LOG.error("Application exception overridden by rollback error", ex);
+            throw err;
+        }
+    }
 }


### PR DESCRIPTION
JIRA: https://issues.opennms.org/browse/OCE-27

Here we extend the ` org.opennms.netmgt.dao.api.SessionUtils` interface to include a new `withReadOnlyTransaction` method that performs the call within read-only transaction with auto-flush disabled.

All of the existing calls in the `api-layer` module are updated to use this call, which solves the exception that was reported in the issue.

