### PR TITLE
HZN-1426: Use an interim collection for removed related alarms

### DIFF
--- a/opennms-alarms/daemon/src/main/java/org/opennms/netmgt/alarmd/drools/DroolsAlarmContext.java
+++ b/opennms-alarms/daemon/src/main/java/org/opennms/netmgt/alarmd/drools/DroolsAlarmContext.java
@@ -209,7 +209,7 @@ public class DroolsAlarmContext extends ManagedDroolsContext implements AlarmLif
                 .map(fact -> fact.getAlarmAssociation().getRelatedAlarm().getId())
                     .filter(alarmId -> !situation.getRelatedAlarmIds().contains(alarmId))
                     .collect(Collectors.toSet());
-        deletedAlarmIds.stream().forEach(alarmId -> {
+        deletedAlarmIds.forEach(alarmId -> {
             final AlarmAssociationAndFact associationAndFact = associationFacts.remove(alarmId);
             if (associationAndFact != null) {
                 LOG.debug("Deleting AlarmAssociationAndFact from session: {}", associationAndFact.getAlarmAssociation());

--- a/opennms-alarms/daemon/src/main/java/org/opennms/netmgt/alarmd/drools/DroolsAlarmContext.java
+++ b/opennms-alarms/daemon/src/main/java/org/opennms/netmgt/alarmd/drools/DroolsAlarmContext.java
@@ -205,16 +205,17 @@ public class DroolsAlarmContext extends ManagedDroolsContext implements AlarmLif
             }
         }
         // Remove Fact for any Alarms no longer in the Situation
-        associationFacts.values().stream()
-            .map(fact -> fact.getAlarmAssociation().getRelatedAlarm().getId())
-                .filter(alarmId -> !situation.getRelatedAlarmIds().contains(alarmId))
-            .forEach(alarmId -> {
-                final AlarmAssociationAndFact associationAndFact = associationFacts.remove(alarmId);
-                if (associationAndFact != null) {
-                    LOG.debug("Deleting AlarmAssociationAndFact from session: {}", associationAndFact.getAlarmAssociation());
-                    getKieSession().delete(associationAndFact.getFact());
-                }
-            });
+        Set<Integer> deletedAlarmIds = associationFacts.values().stream()
+                .map(fact -> fact.getAlarmAssociation().getRelatedAlarm().getId())
+                    .filter(alarmId -> !situation.getRelatedAlarmIds().contains(alarmId))
+                    .collect(Collectors.toSet());
+        deletedAlarmIds.stream().forEach(alarmId -> {
+            final AlarmAssociationAndFact associationAndFact = associationFacts.remove(alarmId);
+            if (associationAndFact != null) {
+                LOG.debug("Deleting AlarmAssociationAndFact from session: {}", associationAndFact.getAlarmAssociation());
+                getKieSession().delete(associationAndFact.getFact());
+            }
+        });
     }
 
     private void handleAlarmAcknowledgements(OnmsAlarm alarm) {


### PR DESCRIPTION
This PR adds an interim collection to store the alarms to be removed in order to prevent a CME.

* JIRA: https://issues.opennms.org/browse/HZN-1426

