### PR TITLE
NMS-10474: Sync timing issues cause erroneous deletes (f18)

### DIFF
--- a/features/kafka/producer/src/main/java/org/opennms/features/kafka/producer/OpennmsKafkaProducer.java
+++ b/features/kafka/producer/src/main/java/org/opennms/features/kafka/producer/OpennmsKafkaProducer.java
@@ -92,7 +92,7 @@ public class OpennmsKafkaProducer implements AlarmLifecycleListener, EventListen
      *
      * Callbacks hold a read-lock, while the synchronization process holds a write lock.
      *
-     * A fair lock is used so that the callbacks continue to be processed in oroder.
+     * A fair lock is used so that the callbacks continue to be processed in order.
      */
     private final ReadWriteLock alarmSyncRwLock = new ReentrantReadWriteLock(true);
 

--- a/features/kafka/producer/src/main/java/org/opennms/features/kafka/producer/OpennmsKafkaProducer.java
+++ b/features/kafka/producer/src/main/java/org/opennms/features/kafka/producer/OpennmsKafkaProducer.java
@@ -35,6 +35,8 @@ import java.util.Objects;
 import java.util.Properties;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Consumer;
 
 import org.apache.kafka.clients.producer.KafkaProducer;
@@ -83,6 +85,16 @@ public class OpennmsKafkaProducer implements AlarmLifecycleListener, EventListen
     private final CountDownLatch forwardedEvent = new CountDownLatch(1);
     private final CountDownLatch forwardedAlarm = new CountDownLatch(1);
     private final CountDownLatch forwardedNode = new CountDownLatch(1);
+
+    /**
+     * This lock is used to prevent any callbacks issued by the {@link AlarmLifecycleListener} from
+     * being processed while the synchronization process is in flight.
+     *
+     * Callbacks hold a read-lock, while the synchronization process holds a write lock.
+     *
+     * A fair lock is used so that the callbacks continue to be processed in oroder.
+     */
+    private final ReadWriteLock alarmSyncRwLock = new ReentrantReadWriteLock(true);
 
     private KafkaProducer<String, byte[]> producer;
 
@@ -295,12 +307,24 @@ public class OpennmsKafkaProducer implements AlarmLifecycleListener, EventListen
 
     @Override
     public void handleNewOrUpdatedAlarm(OnmsAlarm alarm) {
-        updateAlarm(alarm.getReductionKey(), alarm);
+        // Wait until the sync operation is complete before processing the update
+        alarmSyncRwLock.readLock().lock();
+        try {
+            updateAlarm(alarm.getReductionKey(), alarm);
+        } finally {
+            alarmSyncRwLock.readLock().unlock();
+        }
     }
 
     @Override
     public void handleDeletedAlarm(int alarmId, String reductionKey) {
-        handleDeletedAlarm(reductionKey);
+        // Wait until the sync operation is complete before processing the update
+        alarmSyncRwLock.readLock().lock();
+        try {
+            handleDeletedAlarm(reductionKey);
+        } finally {
+            alarmSyncRwLock.readLock().unlock();
+        }
     }
 
     public void handleDeletedAlarm(String reductionKey) {
@@ -362,5 +386,9 @@ public class OpennmsKafkaProducer implements AlarmLifecycleListener, EventListen
 
     public CountDownLatch getNodeForwardedLatch() {
         return forwardedNode;
+    }
+
+    public ReadWriteLock getAlarmSyncRwLock() {
+        return alarmSyncRwLock;
     }
 }

--- a/features/kafka/producer/src/main/java/org/opennms/features/kafka/producer/datasync/AlarmDataStore.java
+++ b/features/kafka/producer/src/main/java/org/opennms/features/kafka/producer/datasync/AlarmDataStore.java
@@ -28,11 +28,21 @@
 
 package org.opennms.features.kafka.producer.datasync;
 
+import java.io.IOException;
 import java.util.Map;
 
 import org.opennms.features.kafka.producer.model.OpennmsModelProtos;
 
+/**
+ * This interface was created to be able to expose the methods on
+ * {@link KafkaAlarmDataSync} to the {@link org.opennms.features.kafka.producer.shell.SyncAlarms}
+ * shell command.
+ */
 public interface AlarmDataStore {
+
+    void init() throws IOException;
+
+    void destroy();
 
     boolean isEnabled();
 
@@ -43,5 +53,7 @@ public interface AlarmDataStore {
     OpennmsModelProtos.Alarm getAlarm(String reductionKey);
 
     AlarmSyncResults synchronizeAlarmsWithDb();
+
+    void setStartWithCleanState(boolean startWithCleanState);
 
 }

--- a/features/kafka/producer/src/main/java/org/opennms/features/kafka/producer/datasync/KafkaAlarmDataSync.java
+++ b/features/kafka/producer/src/main/java/org/opennms/features/kafka/producer/datasync/KafkaAlarmDataSync.java
@@ -44,6 +44,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.Lock;
 import java.util.stream.Collectors;
 
 import org.apache.kafka.common.serialization.Serdes;
@@ -220,42 +221,50 @@ public class KafkaAlarmDataSync implements AlarmDataStore, Runnable {
         // Retrieve the map of alarms by reduction key from the ktable
         final Map<String, OpennmsModelProtos.Alarm> alarmsInKtableByReductionKey = getAlarms();
 
-        // Perform the synchronization in a single transaction context
-        return transactionOperations.execute(status -> {
-            final Set<String> reductionKeysInKtable = alarmsInKtableByReductionKey.keySet();
+        // Lock the producer, preventing it from processing any callbacks while
+        // the synchronization process is performed
+        final Lock lock = kafkaProducer.getAlarmSyncRwLock().writeLock();
+        lock.lock();
+        try {
+            // Perform the synchronization in a single transaction context
+            return transactionOperations.execute(status -> {
+                final Set<String> reductionKeysInKtable = alarmsInKtableByReductionKey.keySet();
 
-            // Retrieve all of the alarms from the database and apply the filter (if any) to these
-            final List<OnmsAlarm> alarmsInDb = alarmDao.findAll().stream()
-                    .filter(kafkaProducer::shouldForwardAlarm)
-                    .collect(Collectors.toList());
+                // Retrieve all of the alarms from the database and apply the filter (if any) to these
+                final List<OnmsAlarm> alarmsInDb = alarmDao.findAll().stream()
+                        .filter(kafkaProducer::shouldForwardAlarm)
+                        .collect(Collectors.toList());
 
-            final Map<String, OnmsAlarm> alarmsInDbByReductionKey = alarmsInDb.stream()
-                    .collect(Collectors.toMap(OnmsAlarm::getReductionKey, a -> a));
-            final Set<String> reductionKeysInDb = alarmsInDbByReductionKey.keySet();
+                final Map<String, OnmsAlarm> alarmsInDbByReductionKey = alarmsInDb.stream()
+                        .collect(Collectors.toMap(OnmsAlarm::getReductionKey, a -> a));
+                final Set<String> reductionKeysInDb = alarmsInDbByReductionKey.keySet();
 
-            // Push deletes for keys that are in the ktable, but not in the database
-            final Set<String> reductionKeysNotInDb = Sets.difference(reductionKeysInKtable, reductionKeysInDb);
-            reductionKeysNotInDb.forEach(kafkaProducer::handleDeletedAlarm);
+                // Push deletes for keys that are in the ktable, but not in the database
+                final Set<String> reductionKeysNotInDb = Sets.difference(reductionKeysInKtable, reductionKeysInDb);
+                reductionKeysNotInDb.forEach(kafkaProducer::handleDeletedAlarm);
 
-            // Push new entries for keys that are in the database, but not in the ktable
-            final Set<String> reductionKeysNotInKtable = Sets.difference(reductionKeysInDb, reductionKeysInKtable);
-            reductionKeysNotInKtable.forEach(rkey -> kafkaProducer.handleNewOrUpdatedAlarm(alarmsInDbByReductionKey.get(rkey)));
+                // Push new entries for keys that are in the database, but not in the ktable
+                final Set<String> reductionKeysNotInKtable = Sets.difference(reductionKeysInDb, reductionKeysInKtable);
+                reductionKeysNotInKtable.forEach(rkey -> kafkaProducer.handleNewOrUpdatedAlarm(alarmsInDbByReductionKey.get(rkey)));
 
-            // Handle Updates
-            final Set<String> reductionKeysUpdated = new LinkedHashSet<>();
-            final Set<String> commonReductionKeys = Sets.intersection(reductionKeysInKtable, reductionKeysInDb);
-            commonReductionKeys.forEach(rkey -> {
-                final OnmsAlarm dbAlarm = alarmsInDbByReductionKey.get(rkey);
-                final OpennmsModelProtos.Alarm mappedDbAlarm = protobufMapper.toAlarm(dbAlarm).build();
-                final OpennmsModelProtos.Alarm alarmFromKtable = alarmsInKtableByReductionKey.get(rkey);
-                if (!Objects.equals(mappedDbAlarm, alarmFromKtable)) {
-                    kafkaProducer.handleNewOrUpdatedAlarm(dbAlarm);
-                    reductionKeysUpdated.add(rkey);
-                }
+                // Handle Updates
+                final Set<String> reductionKeysUpdated = new LinkedHashSet<>();
+                final Set<String> commonReductionKeys = Sets.intersection(reductionKeysInKtable, reductionKeysInDb);
+                commonReductionKeys.forEach(rkey -> {
+                    final OnmsAlarm dbAlarm = alarmsInDbByReductionKey.get(rkey);
+                    final OpennmsModelProtos.Alarm mappedDbAlarm = protobufMapper.toAlarm(dbAlarm).build();
+                    final OpennmsModelProtos.Alarm alarmFromKtable = alarmsInKtableByReductionKey.get(rkey);
+                    if (!Objects.equals(mappedDbAlarm, alarmFromKtable)) {
+                        kafkaProducer.handleNewOrUpdatedAlarm(dbAlarm);
+                        reductionKeysUpdated.add(rkey);
+                    }
+                });
+                return new AlarmSyncResults(alarmsInKtableByReductionKey, alarmsInDb, alarmsInDbByReductionKey,
+                        reductionKeysNotInKtable, reductionKeysNotInDb, reductionKeysUpdated);
             });
-            return new AlarmSyncResults(alarmsInKtableByReductionKey, alarmsInDb, alarmsInDbByReductionKey,
-                    reductionKeysNotInKtable, reductionKeysNotInDb, reductionKeysUpdated);
-        });
+        } finally {
+            lock.unlock();
+        }
     }
 
     private Properties loadStreamsProperties() throws IOException {

--- a/features/kafka/producer/src/main/java/org/opennms/features/kafka/producer/datasync/KafkaAlarmDataSync.java
+++ b/features/kafka/producer/src/main/java/org/opennms/features/kafka/producer/datasync/KafkaAlarmDataSync.java
@@ -91,6 +91,7 @@ public class KafkaAlarmDataSync implements AlarmDataStore, Runnable {
 
     private String alarmTopic;
     private long alarmSyncIntervalMs;
+    private boolean startWithCleanState = false;
 
     private KafkaStreams streams;
     private ScheduledExecutorService scheduler;
@@ -159,6 +160,10 @@ public class KafkaAlarmDataSync implements AlarmDataStore, Runnable {
         }
 
         try {
+            if (startWithCleanState) {
+                LOG.info("Performing stream state cleanup.");
+                streams.cleanUp();
+            }
             LOG.info("Starting alarm datasync stream.");
             streams.start();
             LOG.info("Starting alarm datasync started.");
@@ -299,6 +304,11 @@ public class KafkaAlarmDataSync implements AlarmDataStore, Runnable {
 
     public void setAlarmSyncIntervalMs(long intervalMs) {
         alarmSyncIntervalMs = intervalMs;
+    }
+
+    @Override
+    public void setStartWithCleanState(boolean startWithCleanState) {
+        this.startWithCleanState = startWithCleanState;
     }
 
     private ReadOnlyKeyValueStore<String, byte[]> getAlarmTableNow() throws InvalidStateStoreException {

--- a/features/kafka/producer/src/main/java/org/opennms/features/kafka/producer/shell/SyncAlarms.java
+++ b/features/kafka/producer/src/main/java/org/opennms/features/kafka/producer/shell/SyncAlarms.java
@@ -28,11 +28,13 @@
 
 package org.opennms.features.kafka.producer.shell;
 
+import java.io.IOException;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.karaf.shell.api.action.Action;
 import org.apache.karaf.shell.api.action.Command;
+import org.apache.karaf.shell.api.action.Option;
 import org.apache.karaf.shell.api.action.lifecycle.Reference;
 import org.apache.karaf.shell.api.action.lifecycle.Service;
 import org.opennms.features.kafka.producer.datasync.AlarmDataStore;
@@ -45,8 +47,17 @@ public class SyncAlarms implements Action {
     @Reference
     private AlarmDataStore alarmDataStore;
 
+    @Option(name = "-c", aliases = "--clean-state", description = "Restart the streams client with a clean state before performing the sync.")
+    private boolean startWithCleanState = false;
+
     @Override
-    public Object execute() {
+    public Object execute() throws IOException {
+        if (startWithCleanState) {
+            alarmDataStore.destroy();
+            alarmDataStore.setStartWithCleanState(true);
+            alarmDataStore.init();
+        }
+
         if (!waitForAlarmDataStore(alarmDataStore)) {
             return null;
         }

--- a/features/kafka/producer/src/main/resources/OSGI-INF/blueprint/blueprint-kafka-producer.xml
+++ b/features/kafka/producer/src/main/resources/OSGI-INF/blueprint/blueprint-kafka-producer.xml
@@ -21,6 +21,7 @@
       <cm:property name="eventFilter" value=""/>
       <cm:property name="alarmFilter" value=""/>
       <cm:property name="nodeIdToCriteriaMaxCacheSize" value="10000"/>
+      <cm:property name="startAlarmSyncWithCleanState" value="false"/>
     </cm:default-properties>
   </cm:property-placeholder>
 
@@ -71,6 +72,7 @@
     <argument ref="transactionOperations"/>
     <property name="alarmTopic" value="${alarmTopic}"/>
     <property name="alarmSyncIntervalMs" value="${alarmSyncIntervalMs}"/>
+    <property name="startWithCleanState" value="${startAlarmSyncWithCleanState}"/>
   </bean>
 
 </blueprint>

--- a/opennms-doc/guide-admin/src/asciidoc/text/kafka-producer/kafka-producer.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/kafka-producer/kafka-producer.adoc
@@ -92,6 +92,7 @@ The _Kafka Producer_ exposes the following options to help fine tune its behavio
 | `alarmSyncIntervalMs`   | `300000` (5 minutes) | Number of milliseconds at which the contents of the alarm topic will be synchronized with the local database.
                                                    Decrease this to improve accuracy at the cost of additional database look ups.
                                                    Set this value to 0 to disable alarm synchronization.
+| `startAlarmSyncWithCleanState` | `false`       | Set this to `true` to force the Kafka Streams client to start with a clean state on every boot.
 |===
 
 ==== Configuring Filtering


### PR DESCRIPTION
JIRA: https://issues.opennms.org/browse/NMS-10474

Here we add extra synchronization to the Kafka producer to help prevent the synchronization process from processing stale data.

We also add the ability to clean the state held by the Kafka Stream API.