### PR TITLE
NMS-10473: Reduce incoming Clears against other clears

### DIFF
--- a/opennms-alarms/daemon/src/main/java/org/opennms/netmgt/alarmd/AlarmPersisterImpl.java
+++ b/opennms-alarms/daemon/src/main/java/org/opennms/netmgt/alarmd/AlarmPersisterImpl.java
@@ -138,11 +138,18 @@ public class AlarmPersisterImpl implements AlarmPersister {
         String key = reductionKey;
         String clearKey = event.getAlarmData().getClearKey();
         
+        boolean didSwapReductionKeyWithClearKey = false;
         if (!m_legacyAlarmState && clearKey != null && isResolutionEvent(event)) {
             key = clearKey;
+            didSwapReductionKeyWithClearKey = true;
         }
 
         OnmsAlarm alarm = m_alarmDao.findByReductionKey(key);
+
+        if (alarm == null && didSwapReductionKeyWithClearKey) {
+            // if the clearKey returns null, still need to check the reductionKey
+            alarm = m_alarmDao.findByReductionKey(reductionKey);
+        }
 
         if (alarm == null || (m_createNewAlarmIfClearedAlarmExists && OnmsSeverity.CLEARED.equals(alarm.getSeverity()))) {
             if (LOG.isDebugEnabled()) {


### PR DESCRIPTION
This PR changes the behaviour so that Incoming clears are checked against other clears with the if no matching problem alarm exists. Prior to this, multiple clears before the matching problem alarm would result in attempting to add the subsequent clears instead off reducing on the existing and the creates would fail at the DB level with duplicate reduction keys.

* JIRA: http://issues.opennms.org/browse/NMS-10473

