### PR TITLE
HELM-121: add nodeLabel to alarm summary

### DIFF
--- a/features/rest/mapper/pom.xml
+++ b/features/rest/mapper/pom.xml
@@ -11,6 +11,10 @@
   <packaging>bundle</packaging>
   <name>OpenNMS :: Features :: REST :: Mapper</name>
 
+  <properties>
+    <!-- automatically run annotation processors within the incremental compilation -->
+    <m2e.apt.activation>jdt_apt</m2e.apt.activation>
+  </properties>
   <build>
     <plugins>
       <plugin>

--- a/features/rest/mapper/src/main/java/org/opennms/web/rest/mapper/v2/AlarmMapper.java
+++ b/features/rest/mapper/src/main/java/org/opennms/web/rest/mapper/v2/AlarmMapper.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2017-2017 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
+ * Copyright (C) 2017-2018 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2018 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -97,7 +97,7 @@ public abstract class AlarmMapper {
         // the field will not be serialized.
         if (alarm.isSituation()) {
             alarmDTO.setRelatedAlarms(alarm.getRelatedAlarms().stream()
-                                      .map(a -> alarmToAlarmSummaryDTO(a))
+                                      .map(this::alarmToAlarmSummaryDTO)
                                       .sorted(Comparator.comparing(AlarmSummaryDTO::getId))
                                       .collect(Collectors.toList()));
         }
@@ -126,6 +126,7 @@ public abstract class AlarmMapper {
         @Mapping(source = "reductionKey", target = "reductionKey"),
         @Mapping(source = "description", target = "description"),
         @Mapping(source = "lastEvent.eventUei", target = "uei"),
+        @Mapping(source = "nodeLabel", target = "nodeLabel"),
         @Mapping(source = "logMsg", target = "logMessage"),
     })
     public abstract AlarmSummaryDTO alarmToAlarmSummaryDTO(OnmsAlarm alarm);

--- a/features/rest/mapper/src/test/resources/situation.16.dto.json
+++ b/features/rest/mapper/src/test/resources/situation.16.dto.json
@@ -59,6 +59,7 @@
       "severity" : "MAJOR",
       "reductionKey" : "ALARM2",
       "label" : "OpenNMS-defined node event: interfaceDown",
+      "nodeLabel": "n2",
       "logMessage" : "logit again"
     }, {
       "id" : 34,
@@ -67,6 +68,7 @@
       "reductionKey" : "ALARM1",
       "description" : "ALARM1-DESC",
       "label" : "OpenNMS-defined node event: interfaceDown",
+      "nodeLabel": "n1",
       "logMessage" : "logit"
     } ],
   "affectedNodeCount" : 2

--- a/features/rest/mapper/src/test/resources/situation.16.dto.xml
+++ b/features/rest/mapper/src/test/resources/situation.16.dto.xml
@@ -42,12 +42,14 @@
    <relatedAlarms id="32" type="2" severity="MAJOR">
       <reductionKey>ALARM2</reductionKey>
       <label>OpenNMS-defined node event: interfaceDown</label>
+      <nodeLabel>n2</nodeLabel>
       <logMessage>logit again</logMessage>
    </relatedAlarms>
    <relatedAlarms id="34" type="2" severity="CRITICAL">
       <reductionKey>ALARM1</reductionKey>
       <description>ALARM1-DESC</description>
       <label>OpenNMS-defined node event: interfaceDown</label>
+      <nodeLabel>n1</nodeLabel>
       <logMessage>logit</logMessage>
    </relatedAlarms>
    <affectedNodeCount>2</affectedNodeCount>

--- a/features/rest/model/src/main/java/org/opennms/web/rest/model/v2/AlarmSummaryDTO.java
+++ b/features/rest/model/src/main/java/org/opennms/web/rest/model/v2/AlarmSummaryDTO.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2017-2017 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
+ * Copyright (C) 2017-2018 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2018 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -59,6 +59,9 @@ public class AlarmSummaryDTO {
     @XmlElement(name="label")
     private String label;
 
+    @XmlElement(name="nodeLabel")
+    private String nodeLabel;
+
     @XmlElement(name="logMessage")
     private String logMessage;
 
@@ -112,6 +115,14 @@ public class AlarmSummaryDTO {
         this.label = label;
     }
 
+    public String getNodeLabel() {
+        return label;
+    }
+
+    public void setNodeLabel(final String nodeLabel) {
+        this.nodeLabel = nodeLabel;
+    }
+
     public String getLogMessage() {
         return logMessage;
     }
@@ -140,12 +151,13 @@ public class AlarmSummaryDTO {
                 Objects.equals(severity, alarmDTO.severity) &&
                 Objects.equals(description, alarmDTO.description) &&
                 Objects.equals(label, alarmDTO.label) &&
+                Objects.equals(nodeLabel, alarmDTO.nodeLabel) &&
                 Objects.equals(logMessage, alarmDTO.logMessage);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, reductionKey, type, severity, description, label, logMessage);
+        return Objects.hash(id, reductionKey, type, severity, description, label, nodeLabel, logMessage);
     }
 
 }


### PR DESCRIPTION
This PR adds the node label to the alarm summary object, used by Helm.

Additional changes will be needed in opennms.js and Helm to display this data.

* JIRA: http://issues.opennms.org/browse/HELM-121

Our [continuous integration system](http://bamboo.internal.opennms.com:8085) will test and verify your changes.
