### PR TITLE
NMS-10481: Fixed broken links in Cassandra install docs

### DIFF
--- a/opennms-doc/guide-install/src/asciidoc/text/time-series-storage/newts/introduction.adoc
+++ b/opennms-doc/guide-install/src/asciidoc/text/time-series-storage/newts/introduction.adoc
@@ -17,5 +17,5 @@ It is recommended to install _Cassandra_ on a dedicated server, but is also poss
 This installation guide describes how to set up a single _Cassandra_ instance on the same system as _{opennms-product-name}_ for the purpose of evaluating and testing _Newts_.
 These steps are not suitable for a production _Cassandra Cluster_. If you already have a running cluster you can skip this section.
 
-For further information see link:https://wiki.apache.org/cassandra/GettingStarted[Cassandra Getting Started Guide].
-Before setting up a production cluster make sure to consult link:https://docs.datastax.com/en/cassandra/3.0/cassandra/planning/planPlanningAntiPatterns.html[Anti-patterns in Cassandra].
+For further information see link:http://cassandra.apache.org/doc/latest/getting_started/index.html[Cassandra Getting Started Guide].
+Before setting up a production cluster make sure to consult link:https://docs.datastax.com/en/dse-planning/doc/planning/planningAntiPatterns.html[Anti-patterns in Cassandra].

--- a/opennms-doc/guide-install/src/asciidoc/text/time-series-storage/newts/introduction.adoc
+++ b/opennms-doc/guide-install/src/asciidoc/text/time-series-storage/newts/introduction.adoc
@@ -17,5 +17,5 @@ It is recommended to install _Cassandra_ on a dedicated server, but is also poss
 This installation guide describes how to set up a single _Cassandra_ instance on the same system as _{opennms-product-name}_ for the purpose of evaluating and testing _Newts_.
 These steps are not suitable for a production _Cassandra Cluster_. If you already have a running cluster you can skip this section.
 
-For further information see link:http://cassandra.apache.org/doc/latest/getting_started/index.html[Cassandra Getting Started Guide].
+For further information see link:https://cassandra.apache.org/doc/latest/getting_started/index.html[Cassandra Getting Started Guide].
 Before setting up a production cluster make sure to consult link:https://docs.datastax.com/en/dse-planning/doc/planning/planningAntiPatterns.html[Anti-patterns in Cassandra].


### PR DESCRIPTION
The links to Cassandra doc in the setting up section were obsolete. I've fixed them.

* JIRA: https://issues.opennms.org/browse/NMS-10481
