### PR TITLE
HZN-1451: Prevent CME during OSGI service binding

### DIFF
--- a/features/collection/api/src/main/java/org/opennms/netmgt/collection/support/DefaultServiceCollectorRegistry.java
+++ b/features/collection/api/src/main/java/org/opennms/netmgt/collection/support/DefaultServiceCollectorRegistry.java
@@ -28,7 +28,6 @@
 
 package org.opennms.netmgt.collection.support;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.ServiceLoader;
@@ -38,6 +37,8 @@ import org.opennms.netmgt.collection.api.ServiceCollector;
 import org.opennms.netmgt.collection.api.ServiceCollectorRegistry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.ImmutableSet;
 
 /**
  * <p>
@@ -110,7 +111,7 @@ public class DefaultServiceCollectorRegistry implements ServiceCollectorRegistry
 
     @Override
     public Set<String> getCollectorClassNames() {
-        return Collections.unmodifiableSet(m_collectorsByClassName.keySet());
+        return ImmutableSet.copyOf(m_collectorsByClassName.keySet());
     }
 
     private static String getClassName(Map<?, ?> properties) {

--- a/features/poller/api/src/main/java/org/opennms/netmgt/poller/support/DefaultServiceMonitorRegistry.java
+++ b/features/poller/api/src/main/java/org/opennms/netmgt/poller/support/DefaultServiceMonitorRegistry.java
@@ -28,7 +28,6 @@
 
 package org.opennms.netmgt.poller.support;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.ServiceLoader;
@@ -38,6 +37,8 @@ import org.opennms.netmgt.poller.ServiceMonitor;
 import org.opennms.netmgt.poller.ServiceMonitorRegistry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.ImmutableSet;
 
 /**
  * <p>
@@ -110,7 +111,7 @@ public class DefaultServiceMonitorRegistry implements ServiceMonitorRegistry {
 
     @Override
     public Set<String> getMonitorClassNames() {
-        return Collections.unmodifiableSet(m_monitorsByClassName.keySet());
+        return ImmutableSet.copyOf(m_monitorsByClassName.keySet());
     }
 
     private static String getClassName(Map<?, ?> properties) {

--- a/features/topology-map/org.opennms.features.topology.app/src/main/java/org/opennms/features/topology/app/internal/support/IconRepositoryManager.java
+++ b/features/topology-map/org.opennms.features.topology.app/src/main/java/org/opennms/features/topology/app/internal/support/IconRepositoryManager.java
@@ -84,7 +84,7 @@ public class IconRepositoryManager implements IconManager {
         }
     }
 
-    private String lookupSVGIconIdForExactKey(String key) {
+    private synchronized String lookupSVGIconIdForExactKey(String key) {
         for(IconRepository iconRepo : m_iconRepositories) {
             if(iconRepo.contains(key)) {
                 return iconRepo.getSVGIconId(key);
@@ -181,7 +181,7 @@ public class IconRepositoryManager implements IconManager {
     }
 
     @Override
-    public ConfigurableIconRepository findRepositoryByIconKey(String iconKey) {
+    public synchronized ConfigurableIconRepository findRepositoryByIconKey(String iconKey) {
         // only consider configurable Repositories
         final List<ConfigurableIconRepository> configurableIconRepositories = m_iconRepositories.stream()
                 .filter(e -> e instanceof ConfigurableIconRepository)

--- a/opennms-provision/opennms-detector-registry/src/main/java/org/opennms/netmgt/provision/detector/registry/impl/ServiceDetectorRegistryImpl.java
+++ b/opennms-provision/opennms-detector-registry/src/main/java/org/opennms/netmgt/provision/detector/registry/impl/ServiceDetectorRegistryImpl.java
@@ -45,6 +45,9 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+
 public class ServiceDetectorRegistryImpl implements ServiceDetectorRegistry, InitializingBean {
     private static final Logger LOG = LoggerFactory.getLogger(ServiceDetectorRegistryImpl.class);
 
@@ -111,12 +114,12 @@ public class ServiceDetectorRegistryImpl implements ServiceDetectorRegistry, Ini
 
     @Override
     public Map<String, String> getTypes() {
-        return Collections.unmodifiableMap(m_classNameByServiceName);
+        return ImmutableMap.copyOf(m_classNameByServiceName);
     }
 
     @Override
     public Set<String> getServiceNames() {
-        return Collections.unmodifiableSet(m_factoriesByServiceName.keySet());
+        return ImmutableSet.copyOf(m_factoriesByServiceName.keySet());
     }
 
     @Override
@@ -141,7 +144,7 @@ public class ServiceDetectorRegistryImpl implements ServiceDetectorRegistry, Ini
 
     @Override
     public Set<String> getClassNames() {
-        return Collections.unmodifiableSet(m_factoriesByClassName.keySet());
+        return ImmutableSet.copyOf(m_factoriesByClassName.keySet());
     }
 
     @Override

--- a/opennms-provision/opennms-requisition-service/src/main/java/org/opennms/netmgt/provision/service/requisition/DefaultRequisitionProviderRegistry.java
+++ b/opennms-provision/opennms-requisition-service/src/main/java/org/opennms/netmgt/provision/service/requisition/DefaultRequisitionProviderRegistry.java
@@ -38,6 +38,8 @@ import org.opennms.netmgt.provision.persist.RequisitionProviderRegistry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.collect.ImmutableSet;
+
 /**
  * A registry of all available {@link RequisitionProviderRegistry} implementations
  * exposed in the OSGi registry.
@@ -87,7 +89,7 @@ public class DefaultRequisitionProviderRegistry implements RequisitionProviderRe
 
     @Override
     public Set<String> getTypes() {
-        return m_providersByType.keySet();
+        return ImmutableSet.copyOf(m_providersByType.keySet());
     }
 
     private static String getType(Map<?, ?> properties) {


### PR DESCRIPTION
I noticed a few instances of OSGI service binding where we can be vulnerable to a CME due to either explicitly iterating a non-thread-safe collection or exposing a reference to a non-thread-safe collection that a client could then iterate.

The chance of one of these actually generating a CME is probably near zero but still possible so might as well make it correct.

* JIRA: http://issues.opennms.org/browse/HZN-1451

Our [continuous integration system](http://bamboo.internal.opennms.com:8085) will test and verify your changes.
