### PR TITLE
NMS-9659: change BestMatchPingerFactory to use loopback address for testing

### DIFF
--- a/core/lib/src/main/java/org/opennms/core/utils/InetAddressUtils.java
+++ b/core/lib/src/main/java/org/opennms/core/utils/InetAddressUtils.java
@@ -35,9 +35,12 @@ import java.net.InetAddress;
 import java.net.NetworkInterface;
 import java.net.UnknownHostException;
 import java.text.DecimalFormat;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.Enumeration;
 import java.util.List;
+import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -54,8 +57,23 @@ import org.slf4j.LoggerFactory;
  * @version $Id: $
  */
 public abstract class InetAddressUtils {
-
     private static final Logger LOG = LoggerFactory.getLogger(InetAddressUtils.class);
+    private static final Comparator<InetAddress> IFACE_COMPARATOR = new Comparator<InetAddress>() {
+        @Override
+        public int compare(final InetAddress o1, final InetAddress o2) {
+            if (o1 == null) {
+                if (o2 == null) {
+                    return 0;
+                }
+                return 1;
+            } else {
+                if (o2 == null) {
+                    return -1;
+                }
+                return o1.getClass().getName().compareTo(o2.getClass().getName());
+            }
+        }
+    };
 
     /**
      * Always print at least one digit after the decimal point,
@@ -122,8 +140,9 @@ public abstract class InetAddressUtils {
         return localhost == null? "127.0.0.1" : localhost;
     }
 
-    public static InetAddress getLocalLoopbackAddress() {
+    public static Optional<InetAddress> getLocalLoopbackAddress() {
         try {
+            final List<InetAddress> loopbackAddresses = new ArrayList<>();
             final Enumeration<NetworkInterface> ifaces = NetworkInterface.getNetworkInterfaces();
             while (ifaces.hasMoreElements()) {
                 final NetworkInterface iface = ifaces.nextElement();
@@ -131,16 +150,21 @@ public abstract class InetAddressUtils {
                     final Enumeration<InetAddress> addrs = iface.getInetAddresses();
                     while (addrs.hasMoreElements()) {
                         final InetAddress addr = addrs.nextElement();
-                        if (addr instanceof Inet4Address && !addr.isMulticastAddress() && (addr.isLinkLocalAddress() || addr.isLoopbackAddress() || addr.isAnyLocalAddress())) {
-                            return addr;
+                        if (!addr.isMulticastAddress() && (addr.isLinkLocalAddress() || addr.isLoopbackAddress() || addr.isAnyLocalAddress())) {
+                            loopbackAddresses.add(addr);
                         }
                     }
                 }
             }
+            if (!loopbackAddresses.isEmpty()) {
+                // prefer IPv4 loopback addresses to IPv6
+                loopbackAddresses.sort(IFACE_COMPARATOR);
+                return Optional.of(loopbackAddresses.get(0));
+            }
         } catch (final Exception e) {
             LOG.warn("getLocalLoopbackAddress: an exception occurred while attempting to determine the local loopback address.",e);
         }
-        return null;
+        return Optional.empty();
     }
 
     public static String getLocalHostName() {

--- a/opennms-icmp/opennms-icmp-best/src/main/java/org/opennms/netmgt/icmp/best/BestMatchPingerFactory.java
+++ b/opennms-icmp/opennms-icmp-best/src/main/java/org/opennms/netmgt/icmp/best/BestMatchPingerFactory.java
@@ -28,6 +28,7 @@
 
 package org.opennms.netmgt.icmp.best;
 
+import java.net.InetAddress;
 import java.util.Arrays;
 
 import org.opennms.core.utils.InetAddressUtils;
@@ -85,7 +86,8 @@ public class BestMatchPingerFactory extends AbstractPingerFactory {
 
         try {
             final long timeout = Long.valueOf(System.getProperty("org.opennms.netmgt.icmp.best.timeout", "500"), 10);
-            final Number result = pinger.ping(InetAddressUtils.getLocalLoopbackAddress(), timeout, 0);
+            final InetAddress addr = InetAddressUtils.getLocalLoopbackAddress().orElseThrow(() -> new IllegalStateException("No pingable address found."));
+            final Number result = pinger.ping(addr, timeout, 0);
             if (result == null) {
                 throw new IllegalStateException("No result pinging localhost.");
             }

--- a/opennms-icmp/opennms-icmp-best/src/main/java/org/opennms/netmgt/icmp/best/BestMatchPingerFactory.java
+++ b/opennms-icmp/opennms-icmp-best/src/main/java/org/opennms/netmgt/icmp/best/BestMatchPingerFactory.java
@@ -85,7 +85,7 @@ public class BestMatchPingerFactory extends AbstractPingerFactory {
 
         try {
             final long timeout = Long.valueOf(System.getProperty("org.opennms.netmgt.icmp.best.timeout", "500"), 10);
-            final Number result = pinger.ping(InetAddressUtils.getLocalHostAddress(), timeout, 0);
+            final Number result = pinger.ping(InetAddressUtils.getLocalLoopbackAddress(), timeout, 0);
             if (result == null) {
                 throw new IllegalStateException("No result pinging localhost.");
             }

--- a/opennms-icmp/opennms-icmp-best/src/main/java/org/opennms/netmgt/icmp/best/BestMatchPingerFactory.java
+++ b/opennms-icmp/opennms-icmp-best/src/main/java/org/opennms/netmgt/icmp/best/BestMatchPingerFactory.java
@@ -31,6 +31,8 @@ package org.opennms.netmgt.icmp.best;
 import java.net.InetAddress;
 import java.util.Arrays;
 
+import static org.opennms.core.utils.InetAddressUtils.addr;
+
 import org.opennms.core.utils.InetAddressUtils;
 import org.opennms.netmgt.icmp.AbstractPingerFactory;
 import org.opennms.netmgt.icmp.NullPinger;
@@ -43,6 +45,8 @@ import org.slf4j.LoggerFactory;
 
 public class BestMatchPingerFactory extends AbstractPingerFactory {
     private static Logger LOG = LoggerFactory.getLogger(BestMatchPingerFactory.class);
+    private static InetAddress LOOPBACK = InetAddressUtils.getLocalLoopbackAddress().orElse(addr("127.0.0.1"));
+
     Class<? extends Pinger> m_pingerClass = null;
 
     @Override
@@ -84,28 +88,32 @@ public class BestMatchPingerFactory extends AbstractPingerFactory {
             LOG.trace("Failed to initialize {} for IPv4.", pingerClass, t);
         }
 
-        try {
-            final long timeout = Long.valueOf(System.getProperty("org.opennms.netmgt.icmp.best.timeout", "500"), 10);
-            final InetAddress addr = InetAddressUtils.getLocalLoopbackAddress().orElseThrow(() -> new IllegalStateException("No pingable address found."));
-            final Number result = pinger.ping(addr, timeout, 0);
-            if (result == null) {
-                throw new IllegalStateException("No result pinging localhost.");
+        final long timeout = Long.valueOf(System.getProperty("org.opennms.netmgt.icmp.best.timeout", "500"), 10);
+
+        // try the found loopback, fall back to 127.0.0.1 or ::1 as a last resort
+        for (final InetAddress tryme : new InetAddress[] { LOOPBACK, addr("127.0.0.1"), addr("::1") }) {
+            try {
+                final Number result = pinger.ping(tryme, timeout, 0);
+                if (result == null) {
+                    throw new IllegalStateException("No result pinging localhost.");
+                }
+
+                // as long as we have v4 and/or v6, return success if pinger.ping() passes
+                if (v4 && v6) {
+                    return PingerMatch.IPv46;
+                } else if (v6) {
+                    return PingerMatch.IPv6;
+                } else if (v4) {
+                    return PingerMatch.IPv4;
+                }
+            } catch (final Throwable t) {
+                LOG.info("Found pinger {}, but it was unable to ping localhost: {}", pingerClass, t.getMessage());
+                LOG.trace("Pinger failure:", t);
             }
-        } catch (final Throwable t) {
-            LOG.info("Found pinger {}, but it was unable to ping localhost: {}", pingerClass, t.getMessage());
-            LOG.trace("Found pinger {}, but it was unable to ping localhost.", pingerClass, t);
-            return PingerMatch.NONE;
         }
 
-        if (v4 && v6) {
-            return PingerMatch.IPv46;
-        } else if (v6) {
-            return PingerMatch.IPv6;
-        } else if (v4) {
-            return PingerMatch.IPv4;
-        } else {
-            return PingerMatch.NONE;
-        }
+        // if none of the loopback addresses works, give up
+        return PingerMatch.NONE;
     }
 
     static Class<? extends Pinger> findPinger() {


### PR DESCRIPTION
This PR creates a new method for specifically detecting a loopback address, and the `BestMatchPingerFactory` uses that to determine whether ping works.

* JIRA: http://issues.opennms.org/browse/NMS-9659

Our [continuous integration system](http://bamboo.internal.opennms.com:8085) will test and verify your changes.
