### PR TITLE
Fix compile issue due to missing elasticsearch dependency

### DIFF
--- a/features/alarms/history/elastic/pom.xml
+++ b/features/alarms/history/elastic/pom.xml
@@ -28,6 +28,7 @@
   </build>
 
   <properties>
+    <elasticsearchVersion>6.5.2</elasticsearchVersion>
     <elasticsearchNettyVersion>4.1.30.Final</elasticsearchNettyVersion>
   </properties>
 
@@ -183,6 +184,12 @@
       <groupId>org.opennms.core.test-api</groupId>
       <artifactId>org.opennms.core.test-api.alarm</artifactId>
       <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.codelibs.elasticsearch.module</groupId>
+      <artifactId>lang-painless</artifactId>
+      <version>${elasticsearchVersion}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
Without this I get the following error when building:

```
ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.6.2:testCompile (default-testCompile) on project org.opennms.features.alarms.history.elastic: Compilation failure: Compilation failure:
[ERROR] /Users/opennms/vmshared/opennms/features/alarms/history/elastic/src/test/java/org/opennms/features/alarms/history/elastic/ElasticAlarmHistoryRepositoryIT.java:[44,34] package org.elasticsearch.painless does not exist
[ERROR] /Users/opennms/vmshared/opennms/features/alarms/history/elastic/src/test/java/org/opennms/features/alarms/history/elastic/ElasticAlarmHistoryBlackboxIT.java:[46,34] package org.elasticsearch.painless does not exist
[ERROR] /Users/opennms/vmshared/opennms/features/alarms/history/elastic/src/test/java/org/opennms/features/alarms/history/elastic/ElasticAlarmIndexerIT.java:[44,34] package org.elasticsearch.painless does not exist
```
