### PR TITLE
No Jira Yet: Improve efficiency of incremental alarm handling by comparing fields directly rather than mapping to a common object

### DIFF
--- a/features/kafka/producer/src/main/java/org/opennms/features/kafka/producer/ProtobufMapper.java
+++ b/features/kafka/producer/src/main/java/org/opennms/features/kafka/producer/ProtobufMapper.java
@@ -323,17 +323,7 @@ public class ProtobufMapper {
             alarm.getRelatedAlarms().forEach(relatedAlarm -> builder.addRelatedAlarm(toAlarm(relatedAlarm)));
         }
 
-        OpennmsModelProtos.Alarm.Type type = OpennmsModelProtos.Alarm.Type.UNRECOGNIZED;
-        if (alarm.getAlarmType() != null) {
-            if (alarm.getAlarmType() == OnmsAlarm.PROBLEM_TYPE) {
-                type = OpennmsModelProtos.Alarm.Type.PROBLEM_WITH_CLEAR;
-            } else if (alarm.getAlarmType() == OnmsAlarm.RESOLUTION_TYPE) {
-                type = OpennmsModelProtos.Alarm.Type.CLEAR;
-            } else if (alarm.getAlarmType() == OnmsAlarm.PROBLEM_WITHOUT_RESOLUTION_TYPE) {
-                type = OpennmsModelProtos.Alarm.Type.PROBLEM_WITHOUT_CLEAR;
-            }
-        }
-        builder.setType(type);
+        builder.setType(toType(alarm));
 
         if (alarm.getServiceType() != null) {
             builder.setServiceName(alarm.getServiceType().getName());
@@ -344,6 +334,21 @@ public class ProtobufMapper {
         setTimeIfNotNull(alarm.getAckTime(), builder::setAckTime);
 
         return builder;
+    }
+    
+    public OpennmsModelProtos.Alarm.Type toType(OnmsAlarm alarm) {
+        OpennmsModelProtos.Alarm.Type type = OpennmsModelProtos.Alarm.Type.UNRECOGNIZED;
+        if (alarm.getAlarmType() != null) {
+            if (alarm.getAlarmType() == OnmsAlarm.PROBLEM_TYPE) {
+                type = OpennmsModelProtos.Alarm.Type.PROBLEM_WITH_CLEAR;
+            } else if (alarm.getAlarmType() == OnmsAlarm.RESOLUTION_TYPE) {
+                type = OpennmsModelProtos.Alarm.Type.CLEAR;
+            } else if (alarm.getAlarmType() == OnmsAlarm.PROBLEM_WITHOUT_RESOLUTION_TYPE) {
+                type = OpennmsModelProtos.Alarm.Type.PROBLEM_WITHOUT_CLEAR;
+            }
+        }
+        
+        return type;
     }
 
     public OpennmsModelProtos.AlarmFeedback.Builder toAlarmFeedback(AlarmFeedback alarmFeedback) {

--- a/opennms-model/src/main/java/org/opennms/netmgt/model/AlarmAssociation.java
+++ b/opennms-model/src/main/java/org/opennms/netmgt/model/AlarmAssociation.java
@@ -34,6 +34,7 @@ import java.util.Objects;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
@@ -64,6 +65,8 @@ public class AlarmAssociation implements Serializable {
 
     private Date mappedTime;
 
+    private Integer relatedAlarmId;
+
     public AlarmAssociation() {
     }
 
@@ -75,6 +78,7 @@ public class AlarmAssociation implements Serializable {
         this.mappedTime = mappedTime;
         this.situationAlarm = situationAlarm;
         this.relatedAlarm = relatedAlarm;
+        relatedAlarmId = relatedAlarm.getId();
     }
 
     @Id
@@ -89,7 +93,7 @@ public class AlarmAssociation implements Serializable {
         this.id = id;
     }
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "situation_id")
     public OnmsAlarm getSituationAlarm() {
         return situationAlarm;
@@ -99,7 +103,7 @@ public class AlarmAssociation implements Serializable {
         this.situationAlarm = situationAlarm;
     }
 
-    @OneToOne
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "related_alarm_id")
     public OnmsAlarm getRelatedAlarm() {
         return relatedAlarm;
@@ -109,6 +113,22 @@ public class AlarmAssociation implements Serializable {
         this.relatedAlarm = relatedAlarm;
     }
 
+    /**
+     * Accessor method to retrieve the related alarm Id without loading the full related alarm object. Annotated
+     * "insertable = false" and "updatable = false" to indicate that updates to this column should be done via updating
+     * the referenced related alarm object rather than updating this Id directly.
+     */
+    @Column(name = "related_alarm_id", insertable = false, updatable = false)
+    public Integer getRelatedAlarmId() {
+        return relatedAlarmId;
+    }
+
+    /**
+     * Private setter to appease hibernate. We don't actually want to call this ourselves.
+     */
+    private void setRelatedAlarmId(Integer relatedAlarmId) {
+        this.relatedAlarmId = relatedAlarmId;
+    }
 
     public void setMappedTime(Date mappedTime) {
         this.mappedTime = mappedTime;

--- a/opennms-model/src/main/java/org/opennms/netmgt/model/OnmsAlarm.java
+++ b/opennms-model/src/main/java/org/opennms/netmgt/model/OnmsAlarm.java
@@ -1196,8 +1196,8 @@ public class OnmsAlarm implements Acknowledgeable, Serializable {
     @Transient
     @XmlTransient
     public Set<Integer> getRelatedAlarmIds() {
-        return getRelatedAlarms().stream()
-                .map(OnmsAlarm::getId)
+        return getAssociatedAlarms().stream()
+                .map(AlarmAssociation::getRelatedAlarmId)
                 .collect(Collectors.toSet());
     }
 


### PR DESCRIPTION
This PR contains changes to the Kafka producer's handling of incremental alarms to make comparing alarms more efficient.

At this point, I'm not sure how significant the performance change would be but I think these changes should be used even if the performance is similar since this approach is easier to understand than the previous approach.

I've made some changes to the RelatedAlarm entity in the hopes that we can get a performance increase by comparing only related alarm Ids when looking for a difference in alarms without loading the full alarm objects from the DB. I'm not sure if I've done this correctly so please take a look.

* JIRA: http://issues.opennms.org/browse/${JIRA-ISSUE-NUMBER}

Our [continuous integration system](http://bamboo.internal.opennms.com:8085) will test and verify your changes.
