### PR TITLE
NMS-10522: de-escalate situation severity

### DIFF
--- a/core/test-api/alarms/src/main/java/org/opennms/core/test/alarms/driver/Scenario.java
+++ b/core/test-api/alarms/src/main/java/org/opennms/core/test/alarms/driver/Scenario.java
@@ -36,6 +36,7 @@ import java.util.Objects;
 
 import org.opennms.netmgt.alarmd.AlarmPersisterImpl;
 import org.opennms.netmgt.events.api.EventConstants;
+import org.opennms.netmgt.model.OnmsAlarm;
 import org.opennms.netmgt.model.OnmsSeverity;
 import org.opennms.netmgt.model.events.EventBuilder;
 import org.opennms.netmgt.xml.event.AlarmData;
@@ -109,6 +110,24 @@ public class Scenario {
             return this;
         }
 
+        // Create an event with lower severity
+        public ScenarioBuilder withInterfaceDownEvent(long time, int nodeId) {
+            EventBuilder builder = new EventBuilder(EventConstants.INTERFACE_DOWN_EVENT_UEI, "test");
+            builder.setTime(new Date(time));
+            builder.setNodeid(nodeId);
+            builder.setSeverity(OnmsSeverity.MINOR.getLabel());
+
+            AlarmData data = new AlarmData();
+            data.setAlarmType(1);
+            data.setReductionKey(String.format("%s:%d", EventConstants.INTERFACE_DOWN_EVENT_UEI, nodeId));
+            builder.setAlarmData(data);
+
+            builder.setLogDest("logndisplay");
+            builder.setLogMessage("testing");
+            actions.add(new SendEventAction(builder.getEvent()));
+            return this;
+        }
+
         public ScenarioBuilder withAcknowledgmentForNodeDownAlarm(long time, int nodeId) {
             actions.add(new AcknowledgeAlarmAction("test", new Date(time), String.format("%s:%d", EventConstants.NODE_DOWN_EVENT_UEI, nodeId)));
             return this;
@@ -136,6 +155,24 @@ public class Scenario {
             for (int k = 0; k < nodesIds.length; k++) {
                 final String reductionKey = String.format("%s:%d", EventConstants.NODE_DOWN_EVENT_UEI, nodesIds[k]);
                 builder.addParam(AlarmPersisterImpl.RELATED_REDUCTION_KEY_PREFIX + k, reductionKey);
+            }
+
+            AlarmData data = new AlarmData();
+            data.setAlarmType(3);
+            data.setReductionKey(String.format("%s:%s", EventConstants.SITUATION_EVENT_UEI, situtationId));
+            builder.setAlarmData(data);
+
+            actions.add(new SendEventAction(builder.getEvent()));
+            return this;
+        }
+
+        // create a situation using reduction keys
+        public ScenarioBuilder withSituationForAlarmReductionKeys(long time, String situtationId, String... alarms) {
+            EventBuilder builder = new EventBuilder(EventConstants.SITUATION_EVENT_UEI, "test");
+            builder.setTime(new Date(time));
+            builder.setSeverity(OnmsSeverity.NORMAL.getLabel());
+            for (int k = 0; k < alarms.length; k++) {
+                builder.addParam(AlarmPersisterImpl.RELATED_REDUCTION_KEY_PREFIX + k, alarms[k]);
             }
 
             AlarmData data = new AlarmData();

--- a/opennms-base-assembly/src/main/filtered/etc/alarmd/drools-rules.d/situations.drl
+++ b/opennms-base-assembly/src/main/filtered/etc/alarmd/drools-rules.d/situations.drl
@@ -62,7 +62,7 @@ rule "escalateSituationSeverity"
     $situation : OnmsAlarm( isSituation() == true, $relatedAlarmIds : relatedAlarmIds )
     $relatedAlarms : LinkedList() from collect( OnmsAlarm($relatedAlarmIds contains id) )
     $maxSeverity : OnmsSeverity( isGreaterThan(OnmsSeverity.NORMAL) ) from accumulate( OnmsAlarm( $severity : severity ) from $relatedAlarms, maxSeverity( $severity ) )
-    OnmsAlarm( this == $situation, severity <= $maxSeverity, severity.isLessThan(OnmsSeverity.CRITICAL) )
+    OnmsAlarm( this == $situation, severity != OnmsSeverity.escalate($maxSeverity) )
   then
     Date now = new Date(drools.getWorkingMemory().getSessionClock().getCurrentTime());
     alarmService.setSeverity($situation, OnmsSeverity.escalate($maxSeverity), now);


### PR DESCRIPTION
This PR fixes an issues where Situation Severity is not adjusted downward as related alarms clear if the related alarms have varrying severity

* JIRA: https://issues.opennms.org/browse/NMS-10522
