### PR TITLE
HELM-84: add metadata to measurements queries

### DIFF
--- a/features/measurements/api/src/main/java/org/opennms/netmgt/measurements/api/DefaultMeasurementsService.java
+++ b/features/measurements/api/src/main/java/org/opennms/netmgt/measurements/api/DefaultMeasurementsService.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2010-2016 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2016 The OpenNMS Group, Inc.
+ * Copyright (C) 2010-2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -88,7 +88,7 @@ public class DefaultMeasurementsService implements MeasurementsService {
         if (!request.getFilters().isEmpty()) {
             RowSortedTable<Long, String, Double> table = results.asRowSortedTable();
             filterEngine.filter(request.getFilters(), table);
-            results = new FetchResults(table, results.getStep(), results.getConstants());
+            results = new FetchResults(table, results.getStep(), results.getConstants(), results.getMetadata());
         }
 
         // Remove any transient values belonging to sources
@@ -107,6 +107,7 @@ public class DefaultMeasurementsService implements MeasurementsService {
         response.setTimestamps(results.getTimestamps());
         response.setColumns(results.getColumns());
         response.setConstants(results.getConstants());
+        response.setMetadata(results.getMetadata());
         return response;
     }
 

--- a/features/measurements/api/src/main/java/org/opennms/netmgt/measurements/api/FetchResults.java
+++ b/features/measurements/api/src/main/java/org/opennms/netmgt/measurements/api/FetchResults.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2010-2015 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2015 The OpenNMS Group, Inc.
+ * Copyright (C) 2010-2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -31,7 +31,9 @@ package org.opennms.netmgt.measurements.api;
 import java.util.Arrays;
 import java.util.Map;
 
-import com.google.common.base.Objects;
+import org.opennms.netmgt.measurements.model.QueryMetadata;
+
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
 import com.google.common.collect.RowSortedTable;
@@ -52,7 +54,9 @@ public class FetchResults {
 
     private final Map<String, Object> m_constants;
 
-    public FetchResults(final long[] timestamps, Map<String, double[]> columns, final long step, final Map<String, Object> constants) {
+    private final QueryMetadata m_metadata;
+
+    public FetchResults(final long[] timestamps, Map<String, double[]> columns, final long step, final Map<String, Object> constants, final QueryMetadata metadata) {
         Preconditions.checkNotNull(timestamps, "timestamps argument");
         Preconditions.checkNotNull(columns, "columns argument");
         Preconditions.checkNotNull(constants, "constants argument");
@@ -61,17 +65,19 @@ public class FetchResults {
         m_columns = columns;
         m_step = step;
         m_constants = constants;
+        m_metadata = metadata;
     }
 
     /**
      * Used when applying filters.
      */
-    public FetchResults(final RowSortedTable<Long, String, Double> table, final long step, final Map<String, Object> constants) {
+    public FetchResults(final RowSortedTable<Long, String, Double> table, final long step, final Map<String, Object> constants, final QueryMetadata metadata) {
         Preconditions.checkNotNull(table, "table argument");
         Preconditions.checkNotNull(constants, "constants argument");
 
         m_step = step;
         m_constants = constants;
+        m_metadata = metadata;
 
         if (table.size() < 1) {
             // No rows
@@ -136,12 +142,17 @@ public class FetchResults {
         return m_constants;
     }
 
+    public QueryMetadata getMetadata() {
+        return m_metadata;
+    }
+
     public String toString() {
-       return Objects.toStringHelper(this.getClass())
+       return MoreObjects.toStringHelper(this.getClass())
             .add("timestamps", Arrays.toString(m_timestamps))
             .add("columns", m_columns)
             .add("step", m_step)
             .add("constants", m_constants)
+            .add("metadata", m_metadata)
             .toString();
     }
 

--- a/features/measurements/api/src/main/java/org/opennms/netmgt/measurements/model/QueryMetadata.java
+++ b/features/measurements/api/src/main/java/org/opennms/netmgt/measurements/model/QueryMetadata.java
@@ -1,0 +1,108 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.measurements.model;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlElementWrapper;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import com.google.common.collect.Sets;
+
+@XmlAccessorType(XmlAccessType.NONE)
+@XmlRootElement(name="metadata")
+public class QueryMetadata {
+    @XmlElementWrapper(name="resources")
+    @XmlElement(name="resource")
+    private final List<QueryResource> resources;
+
+    @XmlElementWrapper(name="nodes")
+    @XmlElement(name="node")
+    private final Set<QueryNode> nodes;
+
+    public QueryMetadata() {
+        this.resources = null;
+        this.nodes = null;
+    }
+
+    public QueryMetadata(final List<QueryResource> resources) {
+        this.resources = resources;
+        if (resources != null) {
+            final Set<QueryNode> nodes = Sets.newTreeSet();
+            for (final QueryResource resource : resources) {
+                final QueryNode node = resource.getNode();
+                if (node != null) {
+                    nodes.add(node);
+                }
+            }
+            this.nodes = nodes;
+        } else {
+            this.nodes = null;
+        }
+    }
+
+    public List<QueryResource> getResources() {
+        return this.resources == null? new ArrayList<QueryResource>() : this.resources;
+    }
+
+    public Set<QueryNode> getNodes() {
+        return this.nodes == null? new HashSet<QueryNode>() : this.nodes;
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final QueryMetadata other = (QueryMetadata) obj;
+
+        return Objects.equals(this.resources, other.resources);
+    }
+    @Override
+    public int hashCode() {
+        return Objects.hash(this.resources);
+    }
+    @Override
+    public String toString() {
+        return com.google.common.base.MoreObjects.toStringHelper(this)
+                .add("resources", this.resources)
+                .add("nodes", this.nodes)
+                .toString();
+    }
+}

--- a/features/measurements/api/src/main/java/org/opennms/netmgt/measurements/model/QueryNode.java
+++ b/features/measurements/api/src/main/java/org/opennms/netmgt/measurements/model/QueryNode.java
@@ -1,0 +1,103 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.measurements.model;
+
+import java.util.Objects;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlRootElement;
+
+@XmlRootElement(name = "query-request")
+@XmlAccessorType(XmlAccessType.NONE)
+public class QueryNode implements Comparable<QueryNode> {
+    @XmlAttribute private final Integer id;
+    @XmlAttribute(name="foreign-source") private final String foreignSource;
+    @XmlAttribute(name="foreign-id") private final String foreignId;
+    @XmlAttribute private final String label;
+
+    public QueryNode() {
+        this.id = null;
+        this.foreignSource = null;
+        this.foreignId = null;
+        this.label = null;
+    }
+
+    public QueryNode(final Integer id, final String foreignSource, final String foreignId, final String label) {
+        this.id = id;
+        this.foreignSource = foreignSource;
+        this.foreignId = foreignId;
+        this.label = label;
+    }
+
+    public Integer getId() {
+        return id;
+    }
+    public String getForeignSource() {
+        return foreignSource;
+    }
+    public String getForeignId() {
+        return foreignId;
+    }
+    public String getLabel() {
+        return label;
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final QueryNode other = (QueryNode) obj;
+
+        return Objects.equals(this.id, other.id);
+    }
+    @Override
+    public int hashCode() {
+        return Objects.hash(this.id);
+    }
+    @Override
+    public String toString() {
+        return com.google.common.base.MoreObjects.toStringHelper(this)
+                .add("id", this.id)
+                .add("foreignSource", this.foreignSource)
+                .add("foreignId", this.foreignId)
+                .add("label", this.label)
+                .toString();
+    }
+
+    @Override
+    public int compareTo(final QueryNode other) {
+        return this.getId() - other.getId();
+    }
+}

--- a/features/measurements/api/src/main/java/org/opennms/netmgt/measurements/model/QueryResource.java
+++ b/features/measurements/api/src/main/java/org/opennms/netmgt/measurements/model/QueryResource.java
@@ -1,0 +1,125 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.measurements.model;
+
+import java.util.Objects;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlID;
+import javax.xml.bind.annotation.XmlRootElement;
+
+@XmlAccessorType(XmlAccessType.NONE)
+@XmlRootElement(name="resource")
+public class QueryResource {
+    @XmlAttribute @XmlID private String id;
+    @XmlAttribute(name="parent-id") private String parentId;
+    @XmlAttribute private String label;
+    @XmlAttribute private String name;
+
+    /** implemented below in getNodeId() because Jackson JSON doesn't honor @XmlIDREF */
+    private QueryNode node;
+
+    public QueryResource() {
+        this.id = null;
+        this.parentId = null;
+        this.label = null;
+        this.name = null;
+        this.node = null;
+    }
+
+    public QueryResource(final String id, final String parentId, final String label, final String name, final QueryNode node) {
+        this.id = id;
+        this.parentId = parentId;
+        this.label = label;
+        this.name = name;
+        this.node = node;
+    }
+
+    public String getId() {
+        return this.id;
+    }
+
+    public String getParentId() {
+        return this.parentId;
+    }
+
+    public String getLabel() {
+        return this.label;
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public QueryNode getNode() {
+        return this.node;
+    }
+
+    @XmlAttribute(name="node-id")
+    public Integer getNodeId() {
+        return this.node == null? null : this.node.getId();
+    }
+
+    public void setNodeId(final Integer id) {
+        this.node = new QueryNode(id, null, null, null);
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final QueryResource other = (QueryResource) obj;
+
+        return Objects.equals(this.id, other.id)
+                && Objects.equals(this.parentId, other.parentId)
+                && Objects.equals(this.label, other.label)
+                && Objects.equals(this.name, other.name)
+                && Objects.equals(this.node, other.node);
+    }
+    @Override
+    public int hashCode() {
+        return Objects.hash(this.id, this.parentId, this.label, this.name, this.node);
+    }
+    @Override
+    public String toString() {
+        return com.google.common.base.MoreObjects.toStringHelper(this)
+                .add("id", this.id)
+                .add("parentId", this.parentId)
+                .add("label", this.label)
+                .add("name", this.name)
+                .add("node", this.node)
+                .toString();
+    }
+}

--- a/features/measurements/api/src/main/java/org/opennms/netmgt/measurements/model/QueryResponse.java
+++ b/features/measurements/api/src/main/java/org/opennms/netmgt/measurements/model/QueryResponse.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2010-2015 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2015 The OpenNMS Group, Inc.
+ * Copyright (C) 2010-2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -87,6 +87,11 @@ public class QueryResponse {
      * String constants
      */
     private List<QueryConstant> constants;
+
+    /**
+     * Source resource metadata
+     */
+    private QueryMetadata metadata;
 
     @XmlAttribute(name = "step")
     public long getStep() {
@@ -190,6 +195,15 @@ public class QueryResponse {
         this.constants = c;
     }
 
+    @XmlElement(name="metadata")
+    public QueryMetadata getMetadata() {
+        return this.metadata;
+    }
+
+    public void setMetadata(final QueryMetadata metadata) {
+        this.metadata = metadata;
+    }
+
     /**
      * Convenience method.
      */
@@ -217,6 +231,7 @@ public class QueryResponse {
              && com.google.common.base.Objects.equal(this.start, other.start)
              && com.google.common.base.Objects.equal(this.end, other.end)
              && com.google.common.base.Objects.equal(this.constants, other.constants)
+             && com.google.common.base.Objects.equal(this.metadata, other.metadata)
              && Arrays.equals(this.timestamps, other.timestamps)
              && Arrays.equals(this.labels, other.labels)
              && Arrays.equals(this.columns, other.columns);
@@ -225,12 +240,12 @@ public class QueryResponse {
     @Override
     public int hashCode() {
        return com.google.common.base.Objects.hashCode(
-                 this.step, this.start, this.end, this.timestamps, this.labels, this.columns, this.constants);
+                 this.step, this.start, this.end, this.timestamps, this.labels, this.columns, this.constants, this.metadata);
     }
 
     @Override
     public String toString() {
-       return com.google.common.base.Objects.toStringHelper(this)
+       return com.google.common.base.MoreObjects.toStringHelper(this)
                  .add("Step", this.step)
                  .add("Start", this.start)
                  .add("End", this.end)
@@ -238,6 +253,7 @@ public class QueryResponse {
                  .add("Labels", Arrays.toString(this.labels))
                  .add("Columns", Arrays.toString(this.columns))
                  .add("Constants", this.constants)
+                 .add("Metadata",  this.metadata)
                  .toString();
     }
 
@@ -288,7 +304,7 @@ public class QueryResponse {
 
         @Override
         public String toString() {
-           return com.google.common.base.Objects.toStringHelper(this)
+           return com.google.common.base.MoreObjects.toStringHelper(this)
                      .add("Values", Arrays.toString(this.values))
                      .toString();
         }

--- a/features/measurements/api/src/main/java/org/opennms/netmgt/measurements/utils/Utils.java
+++ b/features/measurements/api/src/main/java/org/opennms/netmgt/measurements/utils/Utils.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2010-2015 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2015 The OpenNMS Group, Inc.
+ * Copyright (C) 2010-2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -34,6 +34,7 @@ import java.util.Map;
 import java.util.Objects;
 
 import org.opennms.netmgt.measurements.api.FetchResults;
+import org.opennms.netmgt.measurements.model.QueryMetadata;
 import org.opennms.netmgt.measurements.model.Source;
 
 /**
@@ -110,6 +111,6 @@ public class Utils {
 
     public static FetchResults createEmtpyFetchResults(final long step, final Map<String, Object> constants) {
         final Map<String, double[]> columns = new HashMap<>();
-        return new FetchResults(new long[0], columns, step, constants);
+        return new FetchResults(new long[0], columns, step, constants, new QueryMetadata());
     }
 }

--- a/features/measurements/api/src/test/java/org/opennms/netmgt/measurements/model/FetchResultsTest.java
+++ b/features/measurements/api/src/test/java/org/opennms/netmgt/measurements/model/FetchResultsTest.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2010-2015 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2015 The OpenNMS Group, Inc.
+ * Copyright (C) 2010-2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -32,6 +32,7 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import java.util.Collections;
 import java.util.Map;
 
 import org.junit.Test;
@@ -39,7 +40,6 @@ import org.opennms.netmgt.measurements.api.FetchResults;
 import org.opennms.netmgt.measurements.api.Filter;
 
 import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import com.google.common.collect.RowSortedTable;
 import com.google.common.collect.TreeBasedTable;
 
@@ -62,8 +62,7 @@ public class FetchResultsTest {
         table.put(2L, "y", 99d);
 
         // Create the fetch results using the table
-        Map<String, Object> constants = Maps.newHashMap();
-        FetchResults results = new FetchResults(table, 300, constants);
+        FetchResults results = new FetchResults(table, 300, Collections.emptyMap(), null);
 
         // Verify
         Map<String, double[]> columns = results.getColumns();

--- a/features/measurements/api/src/test/java/org/opennms/netmgt/measurements/model/QueryResponseTest.java
+++ b/features/measurements/api/src/test/java/org/opennms/netmgt/measurements/model/QueryResponseTest.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2010-2015 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2015 The OpenNMS Group, Inc.
+ * Copyright (C) 2010-2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -29,12 +29,15 @@
 package org.opennms.netmgt.measurements.model;
 
 import java.text.ParseException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 
 import org.junit.runners.Parameterized;
 import org.opennms.core.test.xml.XmlTestNoCastor;
+import org.opennms.core.xml.JaxbUtils;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -59,6 +62,13 @@ public class QueryResponseTest extends XmlTestNoCastor<QueryResponse> {
         columns.put("y", new double[]{2.0d, 2.1d});
         response.setColumns(columns);
 
+        // add them out of order, but they should always end up ordered by source label
+        final List<QueryResource> resources = new ArrayList<>();
+        resources.add(new QueryResource("idY", "parentY", "labelY", "nameY", new QueryNode(2, "test", "nodeY", "nodeY")));
+        resources.add(new QueryResource("idX", null, "labelX", "nameX",  new QueryNode(1, "test", "nodeX", "nodeX")));
+        response.setMetadata(new QueryMetadata(resources));
+
+        System.err.println(JaxbUtils.marshal(response));
         return Arrays.asList(new Object[][]{{
                 response,
                 "<query-response step=\"300\" start=\"1000\" end=\"2000\">" +
@@ -72,6 +82,16 @@ public class QueryResponseTest extends XmlTestNoCastor<QueryResponse> {
                     "</columns>" +
                     "<labels>x</labels>" +
                     "<labels>y</labels>" +
+                    "<metadata>" +
+                       "<resources>" +
+                          "<resource id=\"idY\" parent-id=\"parentY\" label=\"labelY\" name=\"nameY\" node-id=\"2\" />" +
+                          "<resource id=\"idX\" label=\"labelX\" name=\"nameX\" node-id=\"1\" />" +
+                       "</resources>" +
+                       "<nodes>" +
+                          "<node id=\"1\" foreign-source=\"test\" foreign-id=\"nodeX\" label=\"nodeX\" />" +
+                          "<node id=\"2\" foreign-source=\"test\" foreign-id=\"nodeY\" label=\"nodeY\" />" +
+                       "</nodes>" +
+                    "</metadata>" +
                     "<timestamps>1</timestamps>" +
                     "<timestamps>2</timestamps>" +
                 "</query-response>",

--- a/features/measurements/impl/src/main/java/org/opennms/netmgt/measurements/impl/AbstractRrdBasedFetchStrategy.java
+++ b/features/measurements/impl/src/main/java/org/opennms/netmgt/measurements/impl/AbstractRrdBasedFetchStrategy.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2010-2015 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2015 The OpenNMS Group, Inc.
+ * Copyright (C) 2010-2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -29,6 +29,8 @@
 package org.opennms.netmgt.measurements.impl;
 
 import java.io.File;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -36,14 +38,20 @@ import org.jrobin.core.RrdException;
 import org.opennms.netmgt.dao.api.ResourceDao;
 import org.opennms.netmgt.measurements.api.FetchResults;
 import org.opennms.netmgt.measurements.api.MeasurementFetchStrategy;
+import org.opennms.netmgt.measurements.model.QueryMetadata;
+import org.opennms.netmgt.measurements.model.QueryNode;
+import org.opennms.netmgt.measurements.model.QueryResource;
 import org.opennms.netmgt.measurements.model.Source;
 import org.opennms.netmgt.measurements.utils.Utils;
+import org.opennms.netmgt.model.OnmsNode;
 import org.opennms.netmgt.model.OnmsResource;
 import org.opennms.netmgt.model.ResourceId;
+import org.opennms.netmgt.model.ResourceTypeUtils;
 import org.opennms.netmgt.model.RrdGraphAttribute;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.orm.ObjectRetrievalFailureException;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.Maps;
@@ -69,8 +77,12 @@ public abstract class AbstractRrdBasedFetchStrategy implements MeasurementFetchS
 
         final Map<String, Object> constants = Maps.newHashMap();
 
+        final List<QueryResource> resources = new ArrayList<>();
+
         final Map<Source, String> rrdsBySource = Maps.newHashMap();
         
+        final Map<ResourceId, OnmsResource> resourceCache = new HashMap<>();
+
         for (final Source source : sources) {
             final ResourceId resourceId;
             try {
@@ -78,16 +90,23 @@ public abstract class AbstractRrdBasedFetchStrategy implements MeasurementFetchS
             } catch (final IllegalArgumentException ex) {
                 if (relaxed) continue;
                 LOG.error("Ill-formed resource id: {}", source.getResourceId(), ex);
+                resources.add(null);
                 return null;
             }
 
             // Grab the resource
-            final OnmsResource resource = m_resourceDao.getResourceById(resourceId);
+            final OnmsResource resource = resourceCache.computeIfAbsent(resourceId, r -> m_resourceDao.getResourceById(r));
+
             if (resource == null) {
                 if (relaxed) continue;
                 LOG.error("No resource with id: {}", source.getResourceId());
+                resources.add(null);
                 return null;
             }
+
+            final QueryResource resourceInfo = getResourceInfo(resource, source);
+            resources.add(resourceInfo);
+            System.err.println("resource=" + resourceInfo);
 
             // Grab the attribute
             RrdGraphAttribute rrdGraphAttribute = resource.getRrdGraphAttributes().get(source.getAttribute());
@@ -116,7 +135,7 @@ public abstract class AbstractRrdBasedFetchStrategy implements MeasurementFetchS
         }
 
         // Fetch
-        return fetchMeasurements(start, end, step, maxrows, rrdsBySource, constants, sources, relaxed);
+        return fetchMeasurements(start, end, step, maxrows, rrdsBySource, constants, sources, new QueryMetadata(resources), relaxed);
     }
 
     /**
@@ -130,13 +149,13 @@ public abstract class AbstractRrdBasedFetchStrategy implements MeasurementFetchS
      */
     private FetchResults fetchMeasurements(long start, long end, long step, int maxrows,
                                            Map<Source, String> rrdsBySource, Map<String, Object> constants,
-                                           List<Source> sources, boolean relaxed) throws RrdException {
+                                           List<Source> sources, QueryMetadata metadata, boolean relaxed) throws RrdException {
         // NMS-8665: Avoid making calls to XPORT with no definitions
         if (relaxed && rrdsBySource.isEmpty()) {
             return Utils.createEmtpyFetchResults(step, constants);
         }
 
-        FetchResults fetchResults = fetchMeasurements(start, end, step, maxrows, rrdsBySource, constants);
+        FetchResults fetchResults = fetchMeasurements(start, end, step, maxrows, rrdsBySource, constants, metadata);
         if (relaxed) {
             Utils.fillMissingValues(fetchResults, sources);
         }
@@ -147,6 +166,22 @@ public abstract class AbstractRrdBasedFetchStrategy implements MeasurementFetchS
      * Performs the actual retrieval of the values from the RRD/JRB files.
      */
     protected abstract FetchResults fetchMeasurements(long start, long end, long step, int maxrows,
-            Map<Source, String> rrdsBySource, Map<String, Object> constants) throws RrdException;
+            Map<Source, String> rrdsBySource, Map<String, Object> constants, QueryMetadata metadata) throws RrdException;
 
+    private static QueryResource getResourceInfo(final OnmsResource resource, final Source source) {
+        if (resource == null) return null;
+        OnmsNode node = null;
+        try {
+            node = ResourceTypeUtils.getNodeFromResourceRoot(resource);
+        } catch (final ObjectRetrievalFailureException e) {
+            LOG.warn("Failed to get node info from resource: {}", resource, e);
+        }
+        return new QueryResource(
+                                resource.getId().toString(),
+                                resource.getParent() == null? null : resource.getParent().getId().toString(),
+                                resource.getLabel(),
+                                resource.getName(),
+                                node == null? null : new QueryNode(node.getId(), node.getForeignSource(), node.getForeignId(), node.getLabel())
+                );
+    }
 }

--- a/features/measurements/impl/src/main/java/org/opennms/netmgt/measurements/impl/JRrd2FetchStrategy.java
+++ b/features/measurements/impl/src/main/java/org/opennms/netmgt/measurements/impl/JRrd2FetchStrategy.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2010-2015 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2015 The OpenNMS Group, Inc.
+ * Copyright (C) 2010-2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -34,6 +34,7 @@ import java.util.Map.Entry;
 
 import org.jrobin.core.RrdException;
 import org.opennms.netmgt.measurements.api.FetchResults;
+import org.opennms.netmgt.measurements.model.QueryMetadata;
 import org.opennms.netmgt.measurements.model.Source;
 import org.opennms.netmgt.rrd.jrrd2.api.JRrd2;
 import org.opennms.netmgt.rrd.jrrd2.api.JRrd2Exception;
@@ -49,7 +50,7 @@ public class JRrd2FetchStrategy extends AbstractRrdBasedFetchStrategy {
     @Override
     protected FetchResults fetchMeasurements(long start, long end, long step,
             int maxrows, Map<Source, String> rrdsBySource,
-            Map<String, Object> constants) throws RrdException {
+            Map<String, Object> constants, QueryMetadata metadata) throws RrdException {
 
         final long startInSeconds = (long) Math.floor(start / 1000d);
         final long endInSeconds = (long) Math.floor(end / 1000d);
@@ -99,6 +100,6 @@ public class JRrd2FetchStrategy extends AbstractRrdBasedFetchStrategy {
         	valuesByLabel.put(labelMap.get(entry.getKey()), entry.getValue());
         }
 
-        return new FetchResults(timestamps, valuesByLabel, xportResults.getStep() * 1000, constants);
+        return new FetchResults(timestamps, valuesByLabel, xportResults.getStep() * 1000, constants, metadata);
     }
 }

--- a/features/measurements/impl/src/main/java/org/opennms/netmgt/measurements/impl/JrobinFetchStrategy.java
+++ b/features/measurements/impl/src/main/java/org/opennms/netmgt/measurements/impl/JrobinFetchStrategy.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2010-2015 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2015 The OpenNMS Group, Inc.
+ * Copyright (C) 2010-2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -34,6 +34,7 @@ import java.util.Map;
 import org.jrobin.core.RrdException;
 import org.jrobin.data.DataProcessor;
 import org.opennms.netmgt.measurements.api.FetchResults;
+import org.opennms.netmgt.measurements.model.QueryMetadata;
 import org.opennms.netmgt.measurements.model.Source;
 
 import com.google.common.collect.Maps;
@@ -51,7 +52,7 @@ public class JrobinFetchStrategy extends AbstractRrdBasedFetchStrategy {
      */
     @Override
     protected FetchResults fetchMeasurements(long start, long end, long step, int maxrows,
-            Map<Source, String> rrdsBySource, Map<String, Object> constants) throws RrdException {
+            Map<Source, String> rrdsBySource, Map<String, Object> constants, QueryMetadata metadata) throws RrdException {
 
         final long startInSeconds = (long) Math.floor(start / 1000d);
         final long endInSeconds = (long) Math.floor(end / 1000d);
@@ -93,6 +94,6 @@ public class JrobinFetchStrategy extends AbstractRrdBasedFetchStrategy {
             columns.put(source.getLabel(), dproc.getValues(source.getLabel()));
         }
 
-        return new FetchResults(timestamps, columns, dproc.getStep() * 1000, constants);
+        return new FetchResults(timestamps, columns, dproc.getStep() * 1000, constants, metadata);
     }
 }

--- a/features/measurements/impl/src/main/java/org/opennms/netmgt/measurements/impl/RrdtoolXportFetchStrategy.java
+++ b/features/measurements/impl/src/main/java/org/opennms/netmgt/measurements/impl/RrdtoolXportFetchStrategy.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2010-2015 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2015 The OpenNMS Group, Inc.
+ * Copyright (C) 2010-2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -45,6 +45,7 @@ import org.apache.commons.exec.PumpStreamHandler;
 import org.apache.commons.lang.StringUtils;
 import org.jrobin.core.RrdException;
 import org.opennms.netmgt.measurements.api.FetchResults;
+import org.opennms.netmgt.measurements.model.QueryMetadata;
 import org.opennms.netmgt.measurements.model.Source;
 import org.opennms.netmgt.rrd.model.RrdXport;
 import org.opennms.netmgt.rrd.model.XRow;
@@ -82,7 +83,7 @@ public class RrdtoolXportFetchStrategy extends AbstractRrdBasedFetchStrategy {
      */
     @Override
     protected FetchResults fetchMeasurements(long start, long end, long step, int maxrows,
-            Map<Source, String> rrdsBySource, Map<String, Object> constants) throws RrdException {
+            Map<Source, String> rrdsBySource, Map<String, Object> constants, QueryMetadata metadata) throws RrdException {
 
         String rrdBinary = System.getProperty("rrd.binary");
         if (rrdBinary == null) {
@@ -196,7 +197,7 @@ public class RrdtoolXportFetchStrategy extends AbstractRrdBasedFetchStrategy {
             columns.put(labelMap.get(label), values[i++]);
         }
 
-        return new FetchResults(timestamps, columns, xportStepInMs, constants);
+        return new FetchResults(timestamps, columns, xportStepInMs, constants, metadata);
     }
 
 }

--- a/features/measurements/impl/src/test/java/org/opennms/netmgt/measurements/impl/JEXLExpressionEngineEnhancedTest.java
+++ b/features/measurements/impl/src/test/java/org/opennms/netmgt/measurements/impl/JEXLExpressionEngineEnhancedTest.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2010-2015 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2015 The OpenNMS Group, Inc.
+ * Copyright (C) 2010-2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -288,7 +288,7 @@ public class JEXLExpressionEngineEnhancedTest {
 		}
 		Map<String, double[]> values = Maps.newHashMap();
 		values.put("x", xValues);
-		FetchResults results = new FetchResults(timestamps, values, 1, constants);
+		FetchResults results = new FetchResults(timestamps, values, 1, constants, null);
 
 		// Use the engine to evaluate the expression
 		jexlExpressionEngine.applyExpressions(request, results);

--- a/features/measurements/impl/src/test/java/org/opennms/netmgt/measurements/impl/JEXLExpressionEngineTest.java
+++ b/features/measurements/impl/src/test/java/org/opennms/netmgt/measurements/impl/JEXLExpressionEngineTest.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2010-2015 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2015 The OpenNMS Group, Inc.
+ * Copyright (C) 2010-2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -412,7 +412,7 @@ public class JEXLExpressionEngineTest {
         }
         Map<String, double[]> values = Maps.newHashMap();
         values.put("x", xValues);
-        FetchResults results = new FetchResults(timestamps, values, 1, constants);
+        FetchResults results = new FetchResults(timestamps, values, 1, constants, null);
 
         // Use the engine to evaluate the expression
         jexlExpressionEngine.applyExpressions(request, results);

--- a/features/measurements/rest/src/test/java/org/opennms/web/rest/v1/MeasurementRestServiceIT.java
+++ b/features/measurements/rest/src/test/java/org/opennms/web/rest/v1/MeasurementRestServiceIT.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2008-2015 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2015 The OpenNMS Group, Inc.
+ * Copyright (C) 2008-2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -175,7 +175,10 @@ public class MeasurementRestServiceIT extends AbstractSpringJerseyRestTestCase {
         String json = sendRequest(request, 200);
 
         assertThat(xml, containsString("<columns>"));
+        assertThat(xml, containsString("<resources>"));
+        assertThat(xml, containsString("<resource id="));
         assertThat(json, containsString("\"columns\":"));
+        assertThat(json, containsString("\"resources\":"));
     }
 
     /**

--- a/features/measurements/rest/src/test/java/org/opennms/web/rest/v1/MeasurementRestServiceIT.java
+++ b/features/measurements/rest/src/test/java/org/opennms/web/rest/v1/MeasurementRestServiceIT.java
@@ -205,7 +205,7 @@ public class MeasurementRestServiceIT extends AbstractSpringJerseyRestTestCase {
         assertThat(filtersXml, containsString("Chomp"));
 
         // Retrieve a specific filter by name
-        String filterXml = sendRequest(GET, "/measurements/filters/chomp", 200);
+        filtersXml = sendRequest(GET, "/measurements/filters/chomp", 200);
         assertThat(filtersXml, containsString("Chomp"));
     }
 }

--- a/features/newts/src/main/java/org/opennms/netmgt/measurements/impl/NewtsFetchStrategy.java
+++ b/features/newts/src/main/java/org/opennms/netmgt/measurements/impl/NewtsFetchStrategy.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2010-2015 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2015 The OpenNMS Group, Inc.
+ * Copyright (C) 2010-2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -29,6 +29,7 @@
 package org.opennms.netmgt.measurements.impl;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -45,10 +46,15 @@ import java.util.stream.Collectors;
 import org.opennms.netmgt.dao.api.ResourceDao;
 import org.opennms.netmgt.measurements.api.FetchResults;
 import org.opennms.netmgt.measurements.api.MeasurementFetchStrategy;
+import org.opennms.netmgt.measurements.model.QueryMetadata;
+import org.opennms.netmgt.measurements.model.QueryNode;
+import org.opennms.netmgt.measurements.model.QueryResource;
 import org.opennms.netmgt.measurements.model.Source;
 import org.opennms.netmgt.measurements.utils.Utils;
+import org.opennms.netmgt.model.OnmsNode;
 import org.opennms.netmgt.model.OnmsResource;
 import org.opennms.netmgt.model.ResourceId;
+import org.opennms.netmgt.model.ResourceTypeUtils;
 import org.opennms.netmgt.model.RrdGraphAttribute;
 import org.opennms.newts.api.Context;
 import org.opennms.newts.api.Duration;
@@ -65,6 +71,7 @@ import org.opennms.newts.api.query.StandardAggregationFunctions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.orm.ObjectRetrievalFailureException;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Optional;
@@ -122,6 +129,7 @@ public class NewtsFetchStrategy implements MeasurementFetchStrategy {
         final Optional<Timestamp> startTs = Optional.of(Timestamp.fromEpochMillis(start));
         final Optional<Timestamp> endTs = Optional.of(Timestamp.fromEpochMillis(end));
         final Map<String, Object> constants = Maps.newHashMap();
+        final List<QueryResource> resources = new ArrayList<>();
 
         // Group the sources by resource id to avoid calling the ResourceDao
         // multiple times for the same resource
@@ -157,6 +165,8 @@ public class NewtsFetchStrategy implements MeasurementFetchStrategy {
             for (Source source : entry.getValue()) {
                 // Gather the values from strings.properties
                 Utils.convertStringAttributesToConstants(source.getLabel(), resource.getStringPropertyAttributes(), constants);
+
+                resources.add(getResourceInfo(resource, source));
 
                 // Grab the attribute that matches the source
                 RrdGraphAttribute rrdGraphAttribute = resource.getRrdGraphAttributes().get(source.getAttribute());
@@ -235,7 +245,7 @@ public class NewtsFetchStrategy implements MeasurementFetchStrategy {
             }
         }
 
-        FetchResults fetchResults = new FetchResults(timestamps, columns, lag.getStep(), constants);
+        FetchResults fetchResults = new FetchResults(timestamps, columns, lag.getStep(), constants, new QueryMetadata(resources));
         if (relaxed) {
             Utils.fillMissingValues(fetchResults, sources);
         }
@@ -410,5 +420,30 @@ public class NewtsFetchStrategy implements MeasurementFetchStrategy {
     @VisibleForTesting
     protected void setContext(Context context) {
         m_context = context;
+    }
+
+    private OnmsNode getNode(final OnmsResource resource, final Source source) {
+        OnmsNode node = null;
+        try {
+            node = ResourceTypeUtils.getNodeFromResourceRoot(resource);
+        } catch (final ObjectRetrievalFailureException e) {
+        }
+        if (node == null) {
+            final OnmsResource otherResource = m_resourceDao.getResourceById(ResourceId.fromString(source.getResourceId()).getParent());
+            node = ResourceTypeUtils.getNodeFromResource(otherResource);
+        }
+        return node;
+    }
+
+    private QueryResource getResourceInfo(final OnmsResource resource, final Source source) {
+        if (resource == null) return null;
+        final OnmsNode node = getNode(resource, source);
+        return new QueryResource(
+                                resource.getId().toString(),
+                                resource.getParent() == null? null : resource.getParent().getId().toString(),
+                                resource.getLabel(),
+                                resource.getName(),
+                                node == null? null : new QueryNode(node.getId(), node.getForeignSource(), node.getForeignId(), node.getLabel())
+                );
     }
 }

--- a/integrations/opennms-jasper-extensions/src/test/java/org/opennms/netmgt/jasper/measurement/CustomSpringConfiguration.java
+++ b/integrations/opennms-jasper-extensions/src/test/java/org/opennms/netmgt/jasper/measurement/CustomSpringConfiguration.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2015 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2015 The OpenNMS Group, Inc.
+ * Copyright (C) 2015-2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -40,6 +40,7 @@ import org.opennms.netmgt.dao.support.InterfaceSnmpResourceType;
 import org.opennms.netmgt.measurements.api.FetchResults;
 import org.opennms.netmgt.measurements.api.MeasurementFetchStrategy;
 import org.opennms.netmgt.measurements.impl.AbstractRrdBasedFetchStrategy;
+import org.opennms.netmgt.measurements.model.QueryMetadata;
 import org.opennms.netmgt.measurements.model.Source;
 import org.opennms.netmgt.model.OnmsAttribute;
 import org.opennms.netmgt.model.OnmsIpInterface;
@@ -63,7 +64,7 @@ public class CustomSpringConfiguration {
         return new AbstractRrdBasedFetchStrategy() {
 
             @Override
-            protected FetchResults fetchMeasurements(long start, long end, long step, int maxrows, Map<Source, String> rrdsBySource, Map<String, Object> constants) throws RrdException {
+            protected FetchResults fetchMeasurements(long start, long end, long step, int maxrows, Map<Source, String> rrdsBySource, Map<String, Object> constants, QueryMetadata metadata) throws RrdException {
                 final long[] timestamps = new long[] {start, end};
                 final Map columnMap = new HashMap<>();
                 if (!rrdsBySource.isEmpty()) {
@@ -71,7 +72,7 @@ public class CustomSpringConfiguration {
                         columnMap.put(eachKey.getLabel(), new double[]{13, 17});
                     }
                 }
-                return new FetchResults(timestamps, columnMap, step, constants);
+                return new FetchResults(timestamps, columnMap, step, constants, metadata);
             }
         };
     }

--- a/opennms-dao/src/test/java/org/opennms/netmgt/dao/support/RrdStatisticAttributeVisitorTest.java
+++ b/opennms-dao/src/test/java/org/opennms/netmgt/dao/support/RrdStatisticAttributeVisitorTest.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2007-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2007-2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -189,7 +189,8 @@ public class RrdStatisticAttributeVisitorTest extends TestCase {
         FetchResults results = new FetchResults(new long[] {m_startTime},
                                                 Collections.singletonMap("result", new double[] {1.0}),
                                                 m_endTime - m_startTime,
-                                                Collections.emptyMap());
+                                                Collections.emptyMap(),
+                                                null);
 
         expect(m_fetchStrategy.fetch(m_startTime,
                                      m_endTime,
@@ -247,7 +248,8 @@ public class RrdStatisticAttributeVisitorTest extends TestCase {
         FetchResults results = new FetchResults(new long[] {},
                                                 Collections.singletonMap("result", new double[] {}),
                                                 m_endTime - m_startTime,
-                                                Collections.emptyMap());
+                                                Collections.emptyMap(),
+                                                null);
         expect(m_fetchStrategy.fetch(m_startTime,
                                      m_endTime,
                                      1,
@@ -303,7 +305,8 @@ public class RrdStatisticAttributeVisitorTest extends TestCase {
                 .andReturn(new FetchResults(new long[]{m_startTime},
                                             Collections.singletonMap("result", new double[]{1.0}),
                                             m_endTime - m_startTime,
-                                            Collections.emptyMap()));
+                                            Collections.emptyMap(),
+                                            null));
         m_statisticVisitor.visit(attribute, 1.0);
 
         expect(m_fetchStrategy.fetch(m_startTime,
@@ -317,7 +320,8 @@ public class RrdStatisticAttributeVisitorTest extends TestCase {
                 .andReturn(new FetchResults(new long[]{m_startTime},
                                             Collections.singletonMap("result", new double[]{2.0}),
                                             m_endTime - m_startTime,
-                                            Collections.emptyMap()));
+                                            Collections.emptyMap(),
+                                            null));
         m_statisticVisitor.visit(attribute, 2.0);
 
         m_mocks.replayAll();

--- a/opennms-doc/guide-development/src/asciidoc/text/rest/measurements.adoc
+++ b/opennms-doc/guide-development/src/asciidoc/text/rest/measurements.adoc
@@ -61,6 +61,14 @@ curl -u admin:admin "http://127.0.0.1:8980/opennms/rest/measurements/node%5B1%5D
     ...
   </columns>
   <labels>CpuRawUser</labels>
+  <metadata>
+    <resources>
+      ...
+    </resources>
+    <nodes>
+      ...
+    </nodes>
+  </metadata>
   <timestamps>1425581100000</timestamps>
   <timestamps>1425581400000</timestamps>
   <timestamps>1425581700000</timestamps>
@@ -157,7 +165,33 @@ curl -X POST  -H "Accept: application/json" -H "Content-Type: application/json" 
                 ...
             ]
         }
-    ]
+    ],
+    "metadata": {
+        "resources": [
+            {
+                "id": "nodeSource[Servers:1424038123222].interfaceSnmp[eth0-04013f75f101]",
+                "label": "eth0-04013f75f101",
+                "name": "eth0-04013f75f101",
+                "parent-id": "nodeSource[Servers:1424038123222]",
+                "node-id": 1
+            },
+            {
+                "id": "nodeSource[Servers:1424038123222].interfaceSnmp[eth0-04013f75f101]",
+                "label": "eth0-04013f75f101",
+                "name": "eth0-04013f75f101",
+                "parent-id": "nodeSource[Servers:1424038123222]",
+                "node-id": 1
+            }
+            ],
+            "nodes": [
+            {
+                "id": 1,
+                "label": "Test Server",
+                "foreign-source": "Servers",
+                "foreign-id": "1424038123222"
+            }
+        ]
+    }
 }
 ----
 ===== More Advanced Expressions

--- a/opennms-model/src/main/java/org/opennms/netmgt/model/ResourceId.java
+++ b/opennms-model/src/main/java/org/opennms/netmgt/model/ResourceId.java
@@ -62,6 +62,10 @@ public class ResourceId implements Comparable<ResourceId> {
         this.name = name == null ? "" : name;
     }
 
+    public ResourceId getParent() {
+        return this.parent;
+    }
+
     public ResourceId resolve(final String type,
                               final String name) {
         return new ResourceId(this, type, name);

--- a/opennms-model/src/main/java/org/opennms/netmgt/model/ResourceTypeUtils.java
+++ b/opennms-model/src/main/java/org/opennms/netmgt/model/ResourceTypeUtils.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2007-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2007-2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -121,6 +121,37 @@ public abstract class ResourceTypeUtils {
 
         // Grab the entity
         final OnmsEntity entity = resource.getEntity();
+        if (entity == null) {
+            throw new ObjectRetrievalFailureException(OnmsNode.class, "Resource entity must be non-null: " + resource);
+        }
+
+        // Type check
+        if (!(entity instanceof OnmsNode)) {
+            throw new ObjectRetrievalFailureException(OnmsNode.class, "Resource entity must be an instance of OnmsNode: " + resource);
+        }
+
+        return (OnmsNode)entity;
+    }
+
+    /**
+     * Convenience method for retrieving the OnmsNode entity from
+     * an abstract resource's ancestor.
+     *
+     * @throws ObjectRetrievalFailureException on failure
+     */
+    public static OnmsNode getNodeFromResourceRoot(final OnmsResource resource) {
+        OnmsResource res = resource;
+        while (res != null && res.getParent() != null) {
+            res = res.getParent();
+        }
+
+        // Null check
+        if (res == null) {
+            throw new ObjectRetrievalFailureException(OnmsNode.class, "Resource must be non-null.");
+        }
+
+        // Grab the entity
+        final OnmsEntity entity = res.getEntity();
         if (entity == null) {
             throw new ObjectRetrievalFailureException(OnmsNode.class, "Resource entity must be non-null: " + resource);
         }

--- a/opennms-services/src/test/java/org/opennms/netmgt/statsd/ReportDefinitionTest.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/statsd/ReportDefinitionTest.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2008-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2008-2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -35,8 +35,6 @@ import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
-import junit.framework.TestCase;
-
 import org.easymock.EasyMock;
 import org.opennms.netmgt.config.statsd.model.PackageReport;
 import org.opennms.netmgt.config.statsd.model.StatsdPackage;
@@ -57,6 +55,8 @@ import org.opennms.netmgt.model.ResourcePath;
 import org.opennms.netmgt.model.RrdGraphAttribute;
 import org.opennms.test.ThrowableAnticipator;
 import org.opennms.test.mock.EasyMockUtils;
+
+import junit.framework.TestCase;
 
 /**
  * 
@@ -166,7 +166,8 @@ public class ReportDefinitionTest extends TestCase {
         FetchResults results = new FetchResults(new long[] {report.getStartTime()},
                                                 Collections.singletonMap("result", new double[] {100.0}),
                                                 report.getEndTime() - report.getStartTime(),
-                                                Collections.emptyMap());
+                                                Collections.emptyMap(),
+                                                null);
         EasyMock.expect(m_fetchStrategy.fetch(report.getStartTime(),
                                               report.getEndTime(),
                                               1,
@@ -256,7 +257,8 @@ public class ReportDefinitionTest extends TestCase {
         FetchResults results = new FetchResults(new long[] {report.getStartTime()},
                                                 Collections.singletonMap("result", new double[] {100.0}),
                                                 report.getEndTime() - report.getStartTime(),
-                                                Collections.emptyMap());
+                                                Collections.emptyMap(),
+                                                null);
         EasyMock.expect(m_fetchStrategy.fetch(report.getStartTime(),
                                               report.getEndTime(),
                                               1,


### PR DESCRIPTION
This PR adds the metadata necessary to implement HELM-84.  It does so by enhancing the query response from measurements requests to include a `metadata` block that contains info about nodes and resources related to the query.

* JIRA: http://issues.opennms.org/browse/HELM-84

Our [continuous integration system](http://bamboo.internal.opennms.com:8085) will test and verify your changes.
