### PR TITLE
Bootstrap4: Make the Card layout more compact

### DIFF
--- a/core/web-assets/src/main/assets/style/opennms-theme.scss
+++ b/core/web-assets/src/main/assets/style/opennms-theme.scss
@@ -362,6 +362,19 @@ div.NLnode:hover span.NLdbid, div.NLnode:hover span.NLfs, div.NLnode:hover span.
   margin-bottom: $spacer * 1.5; // equivalent of mb-4
 }
 
+// The bootstrap4 blows up the whole UI. The padding is reduced to have more compact layout.
+.card-header {
+  padding: 0.25rem;
+}
+
+.card-body {
+  padding: 0.5rem;
+}
+
+.card-footer {
+  padding: 0.5rem;
+}
+
 // requisition ui uses bootbox for modals, however it is not yet bootstrap 4 compatible
 // (bootbox v5 will be, release is imminent), see https://github.com/makeusabrew/bootbox/issues/566
 // Until then use this hack

--- a/opennms-webapp/src/main/webapp/WEB-INF/templates/navbar.ftl
+++ b/opennms-webapp/src/main/webapp/WEB-INF/templates/navbar.ftl
@@ -2,7 +2,7 @@
 <nav class="navbar navbar-expand-md navbar-dark bg-dark" id="header" role="navigation">
     <!-- Brand and toggle get grouped for better mobile display -->
     <a class="navbar-brand" href="${baseHref}index.jsp">
-        <img id="logo" src="${baseHref}images/o-green-trans.png" alt="OpenNMS" onerror="this.src='${baseHref}images/o-green-trans.png'" />&nbsp;
+        <img id="logo" src="${baseHref}images/o-green-trans.svg" alt="OpenNMS" onerror="this.src='${baseHref}images/o-green-trans.png'" />&nbsp;
     </a>
     <button type="button" title="Toggle navigation" class="navbar-toggler collapsed" data-toggle="collapse" data-target="#navbar" aria-expanded="false" aria-controls="navbar">
         <span class="navbar-toggler-icon"></span>

--- a/opennms-webapp/src/main/webapp/login.jsp
+++ b/opennms-webapp/src/main/webapp/login.jsp
@@ -110,8 +110,8 @@
   </div>
 
   <div class="" style="position: absolute; bottom: 0px; right: 0px; font-size: 3em; padding: 20pt 20pt 5pt 20pt">
-    <a href="https://docs.opennms.org" class="text-light" title="Show documentation"><i class="fa fa-book" aria-hidden="true"></i></a>
-    <a href="https://github.com/OpenNMS/opennms.git" class="text-light" title="Fork us on Github"><i class="fa fa-github" aria-hidden="true"></i></a>
+    <a href="https://docs.opennms.org" class="text-light" style="padding: 0.5rem" title="Show documentation"><i class="fa fa-book" aria-hidden="true"></i></a>
+    <a href="https://github.com/OpenNMS/opennms.git" class="text-light" style="padding: 0.5rem" title="Fork us on Github"><i class="fa fa-github" aria-hidden="true"></i></a>
   </div>
 </div>
 


### PR DESCRIPTION
The bootstrap 4 card introduce a strong padding in the card components in the Web UI which leads to a blown up UI. This commit reduces the padding around the card / box components to make the UI layout more compact.

Additionally I try to use the SVG logo first and fallback to the PNG. The old version uses PNGs in both cases and add some space on the new login page for the GitHub and docs icon.

A before/after screenshot is attached.