### PR TITLE
HZN-1466: upgrade to Jetty 9.4.14

### DIFF
--- a/opennms-webapp/pom.xml
+++ b/opennms-webapp/pom.xml
@@ -425,6 +425,12 @@
                   </exclusion>
                 </exclusions>
               </dependency>
+              <dependency>
+                <groupId>org.opennms.dependencies</groupId>
+                <artifactId>jstl-dependencies</artifactId>
+                <type>pom</type>
+                <version>${project.version}</version>
+              </dependency>
             </dependencies>
           </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -1318,7 +1318,7 @@
     <jasperreportsMavenPluginVersion>1.0-beta-4-OPENNMS-20160912-1</jasperreportsMavenPluginVersion>
     <jcifsVersion>1.3.14</jcifsVersion>
     <jcommonVersion>1.0.23</jcommonVersion>
-    <jettyVersion>9.4.2.v20170220</jettyVersion>
+    <jettyVersion>9.4.14.v20181114</jettyVersion>
     <jestVersion>5.3.3</jestVersion>
     <jestGsonVersion>${gsonVersion}</jestGsonVersion>
     <jfreechartVersion>1.0.19</jfreechartVersion>


### PR DESCRIPTION
This PR upgrades to the latest Jetty 9.4, which is a prerequisite for moving to Java 9+

* JIRA: http://issues.opennms.org/browse/HZN-1466

Our [continuous integration system](http://bamboo.internal.opennms.com:8085) will test and verify your changes.
