### PR TITLE
NMS-10541: fix debian install

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -164,7 +164,7 @@ Description: Enterprise-grade Open-source Network Management Platform (NCS)
 
 Package: opennms-common
 Architecture: all
-Depends: ${perl:Depends}, libdbi-perl, libdbd-pg-perl, libgetopt-mixed-perl
+Depends: libdbi-perl, libdbd-pg-perl, libgetopt-mixed-perl
 Recommends: libnet-snmp-perl, libxml2-utils, libwww-perl, libxml-twig-perl
 Conflicts: opennms-plugin-protocol-xml (<<${binary:Version})
 Replaces: opennms-plugin-protocol-xml (<<${binary:Version})
@@ -227,7 +227,7 @@ Description: Enterprise-grade Open-source Network Management Platform (Documenta
 
 Package: opennms-contrib
 Architecture: all
-Depends: opennms-common (=${binary:Version}), ${perl:Depends}
+Depends: opennms-common (=${binary:Version})
 Description: Enterprise-grade Open-source Network Management Platform (Contrib)
  OpenNMS is an enterprise-grade network management system written in Java.
  .


### PR DESCRIPTION
This PR fixes the `perl` dependency to not get translated on our (ubuntu 18) machines, since it's a) not backwards-compatible, and b) not necessary.

This will make generated packages compatible with older Debian/Ubuntu installs that don't support virtual dependencies again.

* JIRA: http://issues.opennms.org/browse/NMS-10541

Our [continuous integration system](http://bamboo.internal.opennms.com:8085) will test and verify your changes.
