### PR TITLE
HZN-1449: Optimize implementation of  findLatestAcks() for systems with lots of acks

### DIFF
--- a/core/schema/src/main/liquibase/24.0.0/changelog.xml
+++ b/core/schema/src/main/liquibase/24.0.0/changelog.xml
@@ -288,5 +288,16 @@
                              referencedTableName="applications" referencedColumnNames="id" onDelete="CASCADE"/>
   </changeSet>
 
+  <changeSet author="jwhite" id="24.0.0-create-refid-index-on-acks">
+    <preConditions onFail="MARK_RAN">
+      <tableExists tableName="acks"/>
+    </preConditions>
+
+    <!-- Create index-->
+    <sql>
+      CREATE INDEX ack_refid_idx ON acks USING btree (refid);
+    </sql>
+  </changeSet>
+
 </databaseChangeLog>
 

--- a/features/measurements/api/src/test/java/org/opennms/netmgt/measurements/model/FetchResultsTest.java
+++ b/features/measurements/api/src/test/java/org/opennms/netmgt/measurements/model/FetchResultsTest.java
@@ -33,6 +33,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 import org.junit.Test;
@@ -62,7 +63,7 @@ public class FetchResultsTest {
         table.put(2L, "y", 99d);
 
         // Create the fetch results using the table
-        FetchResults results = new FetchResults(table, 300, Collections.emptyMap(), null);
+        FetchResults results = new FetchResults(table, 300, new HashMap<String,Object>(), null);
 
         // Verify
         Map<String, double[]> columns = results.getColumns();

--- a/opennms-alarms/daemon/src/main/java/org/opennms/netmgt/alarmd/drools/DroolsAlarmContext.java
+++ b/opennms-alarms/daemon/src/main/java/org/opennms/netmgt/alarmd/drools/DroolsAlarmContext.java
@@ -334,7 +334,7 @@ public class DroolsAlarmContext extends ManagedDroolsContext implements AlarmLif
                         // Let's log an error, and return some date for sanity
                         final LocalDateTime oneMonthAgoLdt = LocalDateTime.now().minusMonths(1);
                         final Date oneMonthAgo = Date.from(oneMonthAgoLdt.atZone(ZoneId.systemDefault()).toInstant());
-                        LOG.error("Could not find minimum alarm creation time for alarms: {}. Using: {}", oneMonthAgo);
+                        LOG.error("Could not find minimum alarm creation time for alarms: {}. Using: {}", alarms, oneMonthAgo);
                         return oneMonthAgo;
                     });
             acks.addAll(acknowledgmentDao.findLatestAcks(earliestAlarm));

--- a/opennms-alarms/daemon/src/main/java/org/opennms/netmgt/alarmd/drools/DroolsAlarmContext.java
+++ b/opennms-alarms/daemon/src/main/java/org/opennms/netmgt/alarmd/drools/DroolsAlarmContext.java
@@ -30,7 +30,11 @@ package org.opennms.netmgt.alarmd.drools;
 
 import java.io.File;
 import java.nio.file.Paths;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Collections;
+import java.util.Comparator;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -319,7 +323,21 @@ public class DroolsAlarmContext extends ManagedDroolsContext implements AlarmLif
                     .getId())
                     .ifPresent(acks::add);
         } else {
-            acks.addAll(acknowledgmentDao.findLatestAcks());
+            // Calculate the creation time of the earliest alarm
+            final Date earliestAlarm  = alarms.stream()
+                    .map(OnmsAlarm::getFirstEventTime)
+                    .filter(Objects::nonNull)
+                    .min(Comparator.naturalOrder())
+                    .orElseGet(() -> {
+                        // We didn't find any dates - either the set is empty (in which case this function
+                        // wouldn't be called) or all the dates are null (which they shouldn't be.)
+                        // Let's log an error, and return some date for sanity
+                        final LocalDateTime oneMonthAgoLdt = LocalDateTime.now().minusMonths(1);
+                        final Date oneMonthAgo = Date.from(oneMonthAgoLdt.atZone(ZoneId.systemDefault()).toInstant());
+                        LOG.error("Could not find minimum alarm creation time for alarms: {}. Using: {}", oneMonthAgo);
+                        return oneMonthAgo;
+                    });
+            acks.addAll(acknowledgmentDao.findLatestAcks(earliestAlarm));
         }
 
         // Handle all the alarms for which an ack could be found

--- a/opennms-alarms/daemon/src/test/java/org/opennms/netmgt/alarmd/drools/DroolsAlarmContextIT.java
+++ b/opennms-alarms/daemon/src/test/java/org/opennms/netmgt/alarmd/drools/DroolsAlarmContextIT.java
@@ -596,7 +596,7 @@ public class DroolsAlarmContextIT {
         OnmsAlarm alarm1 = generateAlarm(1);
         OnmsAlarm alarm2 = generateAlarm(2);
         dac.handleAlarmSnapshot(Arrays.asList(alarm1, alarm2));
-        verify(acknowledgmentDao, times(1)).findLatestAcks();
+        verify(acknowledgmentDao, times(1)).findLatestAcks(any(Date.class));
         assertThat(dac.getAckByAlarmId(alarm1.getId()).getAckAction(), equalTo(AckAction.UNACKNOWLEDGE));
         assertThat(dac.getAckByAlarmId(alarm2.getId()).getAckAction(), equalTo(AckAction.UNACKNOWLEDGE));
 
@@ -619,9 +619,9 @@ public class DroolsAlarmContextIT {
                 alarm2.getFirstEventTime());
         ack2.setAckAction(AckAction.ESCALATE);
 
-        when(acknowledgmentDao.findLatestAcks()).thenReturn(Arrays.asList(ack1, ack2));
+        when(acknowledgmentDao.findLatestAcks(any(Date.class))).thenReturn(Arrays.asList(ack1, ack2));
         dac.handleAlarmSnapshot(Arrays.asList(alarm1, alarm2));
-        verify(acknowledgmentDao, times(1)).findLatestAcks();
+        verify(acknowledgmentDao, times(1)).findLatestAcks(any(Date.class));
         assertThat(dac.getAckByAlarmId(alarm1.getId()).getAckAction(), equalTo(ack1.getAckAction()));
         assertThat(dac.getAckByAlarmId(alarm2.getId()).getAckAction(), equalTo(ack2.getAckAction()));
 

--- a/opennms-base-assembly/src/main/filtered/etc/create.sql
+++ b/opennms-base-assembly/src/main/filtered/etc/create.sql
@@ -1773,6 +1773,7 @@ CREATE TABLE acks (
 
 create index ack_time_idx on acks(ackTime);
 create index ack_user_idx on acks(ackUser);
+create index ack_refid_idx on acks(refId);
 
 --########################################################################
 --#

--- a/opennms-dao-api/src/main/java/org/opennms/netmgt/dao/api/AcknowledgmentDao.java
+++ b/opennms-dao-api/src/main/java/org/opennms/netmgt/dao/api/AcknowledgmentDao.java
@@ -31,6 +31,7 @@ package org.opennms.netmgt.dao.api;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import java.util.Date;
 
 import org.opennms.netmgt.model.Acknowledgeable;
 import org.opennms.netmgt.model.OnmsAcknowledgment;
@@ -78,10 +79,11 @@ public interface AcknowledgmentDao extends OnmsDao<OnmsAcknowledgment, Integer> 
      * 
      * Finds the latest acknowledgement for each refId. The latest acknowledgement is selected based on the most recent
      * ackTime (and highest Id in the case of multiple occuring at the same time).
-     * 
+     *
+     * @param from limit results to acks created on or after
      * @return the list of latest acks (empty list in the case of no acks found)
      */
-    List<OnmsAcknowledgment> findLatestAcks();
+    List<OnmsAcknowledgment> findLatestAcks(Date from);
 
     /**
      * <p>findLatestAckForRefId</p>

--- a/opennms-dao-mock/src/main/java/org/opennms/netmgt/dao/mock/MockAcknowledgmentDao.java
+++ b/opennms-dao-mock/src/main/java/org/opennms/netmgt/dao/mock/MockAcknowledgmentDao.java
@@ -29,6 +29,7 @@
 package org.opennms.netmgt.dao.mock;
 
 import java.util.Collection;
+import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -71,7 +72,7 @@ public class MockAcknowledgmentDao extends AbstractMockDao<OnmsAcknowledgment, I
     }
 
     @Override
-    public List<OnmsAcknowledgment> findLatestAcks() {
+    public List<OnmsAcknowledgment> findLatestAcks(Date from) {
         throw new UnsupportedOperationException("Not yet implemented!");
     }
 

--- a/opennms-dao/src/main/java/org/opennms/netmgt/dao/hibernate/AcknowledgmentDaoHibernate.java
+++ b/opennms-dao/src/main/java/org/opennms/netmgt/dao/hibernate/AcknowledgmentDaoHibernate.java
@@ -28,6 +28,9 @@
 
 package org.opennms.netmgt.dao.hibernate;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
@@ -268,12 +271,17 @@ public class AcknowledgmentDaoHibernate extends AbstractDaoHibernate<OnmsAcknowl
     @Override
     @Transactional
     @SuppressWarnings("unchecked")
-    public List<OnmsAcknowledgment> findLatestAcks() {
-        String hqlQuery = "SELECT acks FROM OnmsAcknowledgment acks WHERE " +
-                "acks.ackTime = (SELECT MAX(filteredAcks.ackTime) FROM OnmsAcknowledgment filteredAcks WHERE " +
-                "filteredAcks.refId = acks.refId) AND acks.id = (SELECT MAX(filteredAcks.id) FROM " +
-                "OnmsAcknowledgment filteredAcks WHERE filteredAcks.refId = acks.refId)";
-        return (List<OnmsAcknowledgment>) getHibernateTemplate().find(hqlQuery);
+    public List<OnmsAcknowledgment> findLatestAcks(Date from) {
+        final String hqlQuery = "SELECT acks FROM OnmsAcknowledgment acks " +
+                "WHERE acks.ackTime = (" +
+                    "SELECT MAX(filteredAcks.ackTime) " +
+                    "FROM OnmsAcknowledgment filteredAcks " +
+                    "WHERE filteredAcks.refId = acks.refId) " +
+                "AND acks.id = (" +
+                    "SELECT MAX(filteredAcks.id) FROM OnmsAcknowledgment filteredAcks " +
+                    "WHERE filteredAcks.refId = acks.refId) " +
+                "AND acks.ackTime >= (:minAckTimeParm)";
+        return (List<OnmsAcknowledgment>) getHibernateTemplate().findByNamedParam(hqlQuery, "minAckTimeParm", from);
     }
 
     @Override

--- a/opennms-dao/src/test/java/org/opennms/netmgt/dao/AcknowledgmentDaoIT.java
+++ b/opennms-dao/src/test/java/org/opennms/netmgt/dao/AcknowledgmentDaoIT.java
@@ -249,7 +249,8 @@ public class AcknowledgmentDaoIT implements InitializingBean {
     @Test
     @Transactional
     public void testFindLatestAcks() {
-        assertThat(m_acknowledgmentDao.findLatestAcks(), hasSize(0));
+        Date beginningOfTime = new Date(0);
+        assertThat(m_acknowledgmentDao.findLatestAcks(beginningOfTime), hasSize(0));
 
         int numAcks = 100;
         Map<Integer, Integer> dbIdsByRefId = new HashMap<>();
@@ -258,7 +259,7 @@ public class AcknowledgmentDaoIT implements InitializingBean {
         dbIdsByRefId.put(3, generateAcks(3, numAcks));
         assertThat(m_acknowledgmentDao.findAll(), hasSize(greaterThan(3)));
 
-        List<OnmsAcknowledgment> acks = m_acknowledgmentDao.findLatestAcks();        
+        List<OnmsAcknowledgment> acks = m_acknowledgmentDao.findLatestAcks(beginningOfTime);
         assertThat(acks, hasSize(3));
         // Check that we got an ack back for each of the refIds we expect
         assertThat(acks.stream()


### PR DESCRIPTION
JIRA: https://issues.opennms.org/browse/HZN-1449

Add an index to acks table to speed up grouping by refId.

Also limit the findLatestAcks query by time to avoid loading/returning unnecessary entries.
