### PR TITLE
Update maven-war-plugin to 3.2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -469,7 +469,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-war-plugin</artifactId>
-        <version>2.6</version>
+        <version>3.2.2</version>
         <configuration>
           <archiveClasses>true</archiveClasses>
           <outputFileNameMapping>@{artifactId}@-@{baseVersion}@.@{extension}@</outputFileNameMapping>


### PR DESCRIPTION
This PR bumps the Maven-War-Plugin version to 3.2.2 (was 2.6)

* https://issues.opennms.org/browse/HZN-1231
