### PR TITLE
NMS-10552: Slack-compatible notification strategies expect "url" for switch name, should be "-url"

### DIFF
--- a/opennms-services/pom.xml
+++ b/opennms-services/pom.xml
@@ -395,6 +395,12 @@
       <artifactId>hamcrest-library</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-library</artifactId>
+      <version>1.3</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <repositories>

--- a/opennms-services/src/main/java/org/opennms/netmgt/notifd/AbstractSlackCompatibleNotificationStrategy.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/notifd/AbstractSlackCompatibleNotificationStrategy.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2015-2019 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2016 The OpenNMS Group, Inc.
+ * Copyright (C) 2015-2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *

--- a/opennms-services/src/main/java/org/opennms/netmgt/notifd/AbstractSlackCompatibleNotificationStrategy.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/notifd/AbstractSlackCompatibleNotificationStrategy.java
@@ -143,7 +143,7 @@ public abstract class AbstractSlackCompatibleNotificationStrategy implements Not
 	}
 
 	protected String getUrl() {
-		String url = getValueFromSwitchOrProp("Webhook URL", "url", getUrlPropertyName());
+		String url = getValueFromSwitchOrProp("Webhook URL", "-url", getUrlPropertyName());
 	
 		if (url == null) {
 			LOG.error("No webhook URL specified as a notification command switch or via system property {}. Cannot continue.", getUrlPropertyName());
@@ -152,7 +152,7 @@ public abstract class AbstractSlackCompatibleNotificationStrategy implements Not
 	}
 
 	protected String getUsername() {
-		String username = getValueFromSwitchOrProp("Bot username", "username", getUsernamePropertyName());
+		String username = getValueFromSwitchOrProp("Bot username", "-username", getUsernamePropertyName());
 		
 		if (username == null) {
 			LOG.warn("No bot username specified as a notification command switch or via system property {}. Using default value opennms.", getUsernamePropertyName());
@@ -162,7 +162,7 @@ public abstract class AbstractSlackCompatibleNotificationStrategy implements Not
 	}
 
 	protected String getIconUrl() {
-		String iconurl = getValueFromSwitchOrProp("Icon URL", "iconurl", getIconUrlPropertyName());
+		String iconurl = getValueFromSwitchOrProp("Icon URL", "-iconurl", getIconUrlPropertyName());
 		
 		if (iconurl == null) {
 			LOG.info("No icon URL specified as a notification command switch or via system property {}. Not setting one.", getIconUrlPropertyName());
@@ -171,7 +171,7 @@ public abstract class AbstractSlackCompatibleNotificationStrategy implements Not
 	}
 
 	protected String getIconEmoji() {
-		String iconemoji = getValueFromSwitchOrProp("Icon Emoji", "iconemoji", getIconEmojiPropertyName());
+		String iconemoji = getValueFromSwitchOrProp("Icon Emoji", "-iconemoji", getIconEmojiPropertyName());
 		
 		if (iconemoji == null) {
 			LOG.info("No icon emoji specified as a notification command switch or via system property {}. Not setting one.", getIconEmojiPropertyName());
@@ -183,7 +183,7 @@ public abstract class AbstractSlackCompatibleNotificationStrategy implements Not
 	}
 
 	protected String getChannel() {
-		String channel = getValueFromSwitchOrProp("Channel name", "channel", getChannelPropertyName());
+		String channel = getValueFromSwitchOrProp("Channel name", "-channel", getChannelPropertyName());
 		
 		if (channel == null) {
 			LOG.info("No channel specified as a notification command switch or via system property {}. Not setting one.", getChannelPropertyName());
@@ -192,6 +192,9 @@ public abstract class AbstractSlackCompatibleNotificationStrategy implements Not
 	}
 
 	protected String getValueFromSwitchOrProp(String what, String switchName, String propName) {
+		if (switchName != null && ! switchName.startsWith("-")) {
+			LOG.warn("Specifying switch names (e.g. '{}') without a leading dash is no longer supported. You must update your notification command definitions. See https://issues.opennms.org/browse/NMS-10552", switchName);
+		}
 		LOG.debug("Trying to get {} from notification switch {}", what, switchName);
 		String val = getSwitchValue(switchName);
 		if (val != null) {

--- a/opennms-services/src/main/java/org/opennms/netmgt/notifd/AbstractSlackCompatibleNotificationStrategy.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/notifd/AbstractSlackCompatibleNotificationStrategy.java
@@ -1,7 +1,7 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2015-2016 The OpenNMS Group, Inc.
+ * Copyright (C) 2015-2019 The OpenNMS Group, Inc.
  * OpenNMS(R) is Copyright (C) 1999-2016 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
@@ -193,7 +193,8 @@ public abstract class AbstractSlackCompatibleNotificationStrategy implements Not
 
 	protected String getValueFromSwitchOrProp(String what, String switchName, String propName) {
 		if (switchName != null && ! switchName.startsWith("-")) {
-			LOG.warn("Specifying switch names (e.g. '{}') without a leading dash is no longer supported. You must update your notification command definitions. See https://issues.opennms.org/browse/NMS-10552", switchName);
+			switchName = "-" + switchName;
+			LOG.warn("Specifying switch names (e.g. '{}') without a leading dash is deprecated. Please update your notification command definition to use '-{}' instead. See https://issues.opennms.org/browse/NMS-10552", switchName, switchName);
 		}
 		LOG.debug("Trying to get {} from notification switch {}", what, switchName);
 		String val = getSwitchValue(switchName);

--- a/opennms-services/src/main/java/org/opennms/netmgt/notifd/MattermostNotificationStrategy.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/notifd/MattermostNotificationStrategy.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2015-2016 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2016 The OpenNMS Group, Inc.
+ * Copyright (C) 2015-2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *

--- a/opennms-services/src/main/java/org/opennms/netmgt/notifd/MattermostNotificationStrategy.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/notifd/MattermostNotificationStrategy.java
@@ -34,8 +34,6 @@ import org.json.simple.parser.ParseException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.opennms.netmgt.model.notifd.NotificationStrategy;
-
 /**
  * <p>MattermostNotificationStrategy class.</p>
  *
@@ -50,8 +48,8 @@ public class MattermostNotificationStrategy extends AbstractSlackCompatibleNotif
     private static final String MM_ICONURL_PROPERTY = "org.opennms.netmgt.notifd.mattermost.iconURL";
     private static final String MM_ICONEMOJI_PROPERTY = "org.opennms.netmgt.notifd.mattermost.iconEmoji";
     private static final String MM_CHANNEL_PROPERTY = "org.opennms.netmgt.notifd.mattermost.channel";
-    
-    @Override
+
+	@Override
 	protected String formatWebhookErrorResponse(int statusCode, String contents) {
     	StringBuilder bldr = new StringBuilder("Response code: ");
     	bldr.append(statusCode);

--- a/opennms-services/src/test/java/org/opennms/netmgt/notifd/MattermostNotificationStrategyIT.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/notifd/MattermostNotificationStrategyIT.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2015-2016 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2016 The OpenNMS Group, Inc.
+ * Copyright (C) 2015-2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *

--- a/opennms-services/src/test/java/org/opennms/netmgt/notifd/MattermostNotificationStrategyIT.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/notifd/MattermostNotificationStrategyIT.java
@@ -31,11 +31,9 @@ package org.opennms.netmgt.notifd;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 import org.json.simple.JSONObject;
 import org.junit.Test;
@@ -73,59 +71,75 @@ public class MattermostNotificationStrategyIT {
     public void testSendValidJustArgs() {
         final int port = JUnitHttpServerExecutionListener.getPort();
         assertTrue(port > 0);
-        try {
 
-            final NotificationStrategy ns = new MattermostNotificationStrategy();
-            final List<Argument> arguments = new ArrayList<Argument>();
+        final NotificationStrategy ns = new MattermostNotificationStrategy();
+        final List<Argument> arguments = new ArrayList<Argument>();
 
-            // Set these properties. We will override them with Args on the first run.
-            System.setProperty("org.opennms.netmgt.notifd.mattermost.webhookURL", "http://localhost:" + port + "/hooks/abunchofstuffthatidentifiesawebhook");
-            System.setProperty("org.opennms.netmgt.notifd.mattermost.channel", "integrationtestsXX");
-            System.setProperty("org.opennms.netmgt.notifd.mattermost.iconURL", "http://opennms.org/logo.pngXX");
-            System.setProperty("org.opennms.netmgt.notifd.mattermost.iconEmoji", ":shipitXX:");
-            System.setProperty("org.opennms.netmgt.notifd.mattermost.username", "opennmsXX");
+        // Set these properties. We will override them with Args on the first run.
+        System.setProperty("org.opennms.netmgt.notifd.mattermost.webhookURL", "http://localhost:" + port + "/hooks/abunchofstuffthatidentifiesawebhook");
+        System.setProperty("org.opennms.netmgt.notifd.mattermost.channel", "integrationtestsXX");
+        System.setProperty("org.opennms.netmgt.notifd.mattermost.iconURL", "http://opennms.org/logo.pngXX");
+        System.setProperty("org.opennms.netmgt.notifd.mattermost.iconEmoji", ":shipitXX:");
+        System.setProperty("org.opennms.netmgt.notifd.mattermost.username", "opennmsXX");
 
-            arguments.add(new Argument("-url", null, "http://localhost:" + port + "/hooks/abunchofstuffthatidentifiesawebhook", false));
-            arguments.add(new Argument("-channel", null, "integrationtests", false));
-            arguments.add(new Argument("-username", null, "opennms", false));
-            arguments.add(new Argument("-iconurl", null, "http://opennms.org/logo.png", false));
-            arguments.add(new Argument("-iconemoji", null, ":shipit:", false));
-            arguments.add(new Argument("-subject", null, "Test", false));
-            arguments.add(new Argument("-tm", null, "This is only a test", false));
-            
-            int statusCode = ns.send(arguments);
-            assertEquals(0, statusCode);
-            
-            JSONObject inputJson = MattermostNotificationStrategyTestServlet.getInputJson();
-            assertNotNull(inputJson);
-            assertEquals("opennms", inputJson.get("username"));
-            assertEquals("#### Test\nThis is only a test", inputJson.get("text"));
-            assertEquals("integrationtests", inputJson.get("channel"));
-            assertEquals("http://opennms.org/logo.png", inputJson.get("icon_url"));
-            assertEquals(":shipit:", inputJson.get("icon_emoji"));
-            assertEquals(5, inputJson.size());
-            
-            // Now do it again, without the Args, and verify that the property values come out
-            arguments.clear();
-            arguments.add(new Argument("-subject", null, "Test again", false));
-            arguments.add(new Argument("-tm", null, "This is only a second test", false));
-            
-            statusCode = ns.send(arguments);
-            assertEquals(0, statusCode);
-            
-            inputJson = MattermostNotificationStrategyTestServlet.getInputJson();
-            assertNotNull(inputJson);
-            assertEquals("opennmsXX", inputJson.get("username"));
-            assertEquals("#### Test again\nThis is only a second test", inputJson.get("text"));
-            assertEquals("integrationtestsXX", inputJson.get("channel"));
-            assertEquals("http://opennms.org/logo.pngXX", inputJson.get("icon_url"));
-            assertEquals(":shipitXX:", inputJson.get("icon_emoji"));
-            assertEquals(5, inputJson.size());
+        arguments.add(new Argument("-url", null, "http://localhost:" + port + "/hooks/abunchofstuffthatidentifiesawebhook", false));
+        arguments.add(new Argument("-channel", null, "integrationtests", false));
+        arguments.add(new Argument("-username", null, "opennms", false));
+        arguments.add(new Argument("-iconurl", null, "http://opennms.org/logo.png", false));
+        arguments.add(new Argument("-iconemoji", null, ":shipit:", false));
+        arguments.add(new Argument("-subject", null, "Test", false));
+        arguments.add(new Argument("-tm", null, "This is only a test", false));
 
-        } catch (Throwable e) {
-            e.printStackTrace();
-            fail("Caught Exception: " + e.getMessage());
-        }
+        int statusCode = ns.send(arguments);
+        assertEquals(0, statusCode);
+
+        JSONObject inputJson = MattermostNotificationStrategyTestServlet.getInputJson();
+        assertNotNull(inputJson);
+        assertEquals("opennms", inputJson.get("username"));
+        assertEquals("#### Test\nThis is only a test", inputJson.get("text"));
+        assertEquals("integrationtests", inputJson.get("channel"));
+        assertEquals("http://opennms.org/logo.png", inputJson.get("icon_url"));
+        assertEquals(":shipit:", inputJson.get("icon_emoji"));
+        assertEquals(5, inputJson.size());
+
+        // Now do it again, without the Args, and verify that the property values come out
+        arguments.clear();
+        arguments.add(new Argument("-subject", null, "Test again", false));
+        arguments.add(new Argument("-tm", null, "This is only a second test", false));
+
+        statusCode = ns.send(arguments);
+        assertEquals(0, statusCode);
+
+        inputJson = MattermostNotificationStrategyTestServlet.getInputJson();
+        assertNotNull(inputJson);
+        assertEquals("opennmsXX", inputJson.get("username"));
+        assertEquals("#### Test again\nThis is only a second test", inputJson.get("text"));
+        assertEquals("integrationtestsXX", inputJson.get("channel"));
+        assertEquals("http://opennms.org/logo.pngXX", inputJson.get("icon_url"));
+        assertEquals(":shipitXX:", inputJson.get("icon_emoji"));
+        assertEquals(5, inputJson.size());
+
+        // Now do it again without the leading - in switch names
+        arguments.clear();
+        arguments.add(new Argument("url", null, "http://localhost:" + port + "/hooks/abunchofstuffthatidentifiesawebhook", false));
+        arguments.add(new Argument("channel", null, "integrationtests", false));
+        arguments.add(new Argument("username", null, "opennms", false));
+        arguments.add(new Argument("iconurl", null, "http://opennms.org/logo.png", false));
+        arguments.add(new Argument("iconemoji", null, ":shipit:", false));
+        arguments.add(new Argument("subject", null, "Test", false));
+        arguments.add(new Argument("tm", null, "This is only a test", false));
+
+        statusCode = ns.send(arguments);
+        assertEquals(0, statusCode);
+
+        inputJson = MattermostNotificationStrategyTestServlet.getInputJson();
+        assertNotNull(inputJson);
+        assertEquals("opennms", inputJson.get("username"));
+        assertEquals("#### Test\nThis is only a test", inputJson.get("text"));
+        assertEquals("integrationtests", inputJson.get("channel"));
+        assertEquals("http://opennms.org/logo.png", inputJson.get("icon_url"));
+        assertEquals(":shipit:", inputJson.get("icon_emoji"));
+        assertEquals(5, inputJson.size());
     }
 
 }

--- a/opennms-services/src/test/java/org/opennms/netmgt/notifd/MattermostNotificationStrategyIT.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/notifd/MattermostNotificationStrategyIT.java
@@ -85,11 +85,11 @@ public class MattermostNotificationStrategyIT {
             System.setProperty("org.opennms.netmgt.notifd.mattermost.iconEmoji", ":shipitXX:");
             System.setProperty("org.opennms.netmgt.notifd.mattermost.username", "opennmsXX");
 
-            arguments.add(new Argument("url", null, "http://localhost:" + port + "/hooks/abunchofstuffthatidentifiesawebhook", false));
-            arguments.add(new Argument("channel", null, "integrationtests", false));
-            arguments.add(new Argument("username", null, "opennms", false));
-            arguments.add(new Argument("iconurl", null, "http://opennms.org/logo.png", false));
-            arguments.add(new Argument("iconemoji", null, ":shipit:", false));
+            arguments.add(new Argument("-url", null, "http://localhost:" + port + "/hooks/abunchofstuffthatidentifiesawebhook", false));
+            arguments.add(new Argument("-channel", null, "integrationtests", false));
+            arguments.add(new Argument("-username", null, "opennms", false));
+            arguments.add(new Argument("-iconurl", null, "http://opennms.org/logo.png", false));
+            arguments.add(new Argument("-iconemoji", null, ":shipit:", false));
             arguments.add(new Argument("-subject", null, "Test", false));
             arguments.add(new Argument("-tm", null, "This is only a test", false));
             

--- a/opennms-services/src/test/java/org/opennms/netmgt/notifd/MattermostNotificationStrategyIT.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/notifd/MattermostNotificationStrategyIT.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2015-2019 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ * Copyright (C) 2015-2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *

--- a/opennms-services/src/test/java/org/opennms/netmgt/notifd/SlackCompatibleNotificationStrategyTest.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/notifd/SlackCompatibleNotificationStrategyTest.java
@@ -28,21 +28,44 @@
 
 package org.opennms.netmgt.notifd;
 
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 
-import org.hamcrest.Matchers;
-import org.junit.Assert;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.opennms.netmgt.model.notifd.Argument;
 
 import com.google.common.collect.Lists;
 
+@RunWith(Parameterized.class)
 public class SlackCompatibleNotificationStrategyTest {
 
+    @Parameterized.Parameters
+    public static Collection<Object[]> params() {
+        return Arrays.asList(
+            new Object[][] {
+                { new MattermostNotificationStrategy(), "org.opennms.netmgt.notifd.mattermost" },
+                { new SlackNotificationStrategy(), "org.opennms.netmgt.notifd.slack" }
+        });
+    }
+
+    private final AbstractSlackCompatibleNotificationStrategy strategy;
+    private final String systemPropertiesPrefix;
+
+    public SlackCompatibleNotificationStrategyTest(final AbstractSlackCompatibleNotificationStrategy strategy, final String systemPropertiesPrefix) {
+        this.strategy = strategy;
+        this.systemPropertiesPrefix = systemPropertiesPrefix;
+    }
+
     @Test
-    public void verifyArguments() {
+    public void verifyArgumentsWorkWithAndWithoutSlash() {
         final List<Argument> arguments = Lists.newArrayList();
-        arguments.add(new Argument("-url", null, "url", false));
+        arguments.add(new Argument("-url", null, "http://localhost:1234/hooks/hooky", false));
         arguments.add(new Argument("-channel", null, "channel", false));
         arguments.add(new Argument("-username", null, "opennms", false));
         arguments.add(new Argument("-iconurl", null, "http://opennms.org/logo.png", false));
@@ -50,11 +73,46 @@ public class SlackCompatibleNotificationStrategyTest {
         arguments.add(new Argument("-subject", null, "Test", false));
         arguments.add(new Argument("-tm", null, "This is only a test", false));
 
-        final AbstractSlackCompatibleNotificationStrategy mattermostNotificationStrategy = new MattermostNotificationStrategy();
-        Assert.assertThat(mattermostNotificationStrategy.getUrl(), Matchers.is("url"));
-        mattermostNotificationStrategy.getChannel();
-        mattermostNotificationStrategy.getIconEmoji();
-        mattermostNotificationStrategy.getIconUrl();
-        mattermostNotificationStrategy.getUsername();
+        strategy.setArguments(arguments);
+        assertThat(strategy.getValue("url"), is("http://localhost:1234/hooks/hooky"));
+        assertThat(strategy.getValue("-url"), is("http://localhost:1234/hooks/hooky"));
+
+        assertThat(strategy.getValue("channel"), is("channel"));
+        assertThat(strategy.getValue("-channel"), is("channel"));
+
+        assertThat(strategy.getValue("username"), is("opennms"));
+        assertThat(strategy.getValue("-username"), is("opennms"));
+
+        assertThat(strategy.getValue("iconurl"), is("http://opennms.org/logo.png"));
+        assertThat(strategy.getValue("-iconurl"), is("http://opennms.org/logo.png"));
+
+        assertThat(strategy.getValue("iconemoji"), is(":shipit:"));
+        assertThat(strategy.getValue("-iconemoji"), is(":shipit:"));
+
+        assertThat(strategy.getValue("subject"), is("Test"));
+        assertThat(strategy.getValue("-subject"), is("Test"));
+
+        assertThat(strategy.getValue("tm"), is("This is only a test"));
+        assertThat(strategy.getValue("-tm"), is("This is only a test"));
+    }
+
+    @Test
+    public void verifyArgumentsFallbackToSystemProperty() {
+        System.setProperty(getPropertyName("webhookURL"), "http://localhost:4321/hooks/abunchofstuffthatidentifiesawebhook");
+        System.setProperty(getPropertyName("channel"), "integrationtestsXX");
+        System.setProperty(getPropertyName("iconURL"), "http://opennms.org/logo.pngXX");
+        System.setProperty(getPropertyName("iconEmoji"), ":shipitXX:");
+        System.setProperty(getPropertyName("username"), "opennmsXX");
+
+        final AbstractSlackCompatibleNotificationStrategy strategy = new MattermostNotificationStrategy();
+        assertThat(strategy.getValue("-url", getPropertyName("webhookURL")), is("http://localhost:4321/hooks/abunchofstuffthatidentifiesawebhook"));
+        assertThat(strategy.getValue("-channel", getPropertyName("channel")), is("integrationtestsXX"));
+        assertThat(strategy.getValue("-iconurl", getPropertyName("iconURL")), is("http://opennms.org/logo.pngXX"));
+        assertThat(strategy.getValue("-iconemoji", getPropertyName("iconEmoji")), is(":shipitXX:"));
+        assertThat(strategy.getValue("-username", getPropertyName("username")), is("opennmsXX"));
+    }
+
+    private String getPropertyName(String name) {
+        return String.format("%s.%s", systemPropertiesPrefix, name);
     }
 }

--- a/opennms-services/src/test/java/org/opennms/netmgt/notifd/SlackCompatibleNotificationStrategyTest.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/notifd/SlackCompatibleNotificationStrategyTest.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019-2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.notifd;
+
+import java.util.List;
+
+import org.hamcrest.Matchers;
+import org.junit.Assert;
+import org.junit.Test;
+import org.opennms.netmgt.model.notifd.Argument;
+
+import com.google.common.collect.Lists;
+
+public class SlackCompatibleNotificationStrategyTest {
+
+    @Test
+    public void verifyArguments() {
+        final List<Argument> arguments = Lists.newArrayList();
+        arguments.add(new Argument("-url", null, "url", false));
+        arguments.add(new Argument("-channel", null, "channel", false));
+        arguments.add(new Argument("-username", null, "opennms", false));
+        arguments.add(new Argument("-iconurl", null, "http://opennms.org/logo.png", false));
+        arguments.add(new Argument("-iconemoji", null, ":shipit:", false));
+        arguments.add(new Argument("-subject", null, "Test", false));
+        arguments.add(new Argument("-tm", null, "This is only a test", false));
+
+        final AbstractSlackCompatibleNotificationStrategy mattermostNotificationStrategy = new MattermostNotificationStrategy();
+        Assert.assertThat(mattermostNotificationStrategy.getUrl(), Matchers.is("url"));
+        mattermostNotificationStrategy.getChannel();
+        mattermostNotificationStrategy.getIconEmoji();
+        mattermostNotificationStrategy.getIconUrl();
+        mattermostNotificationStrategy.getUsername();
+    }
+}

--- a/opennms-services/src/test/java/org/opennms/netmgt/notifd/SlackCompatibleNotificationStrategyTest.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/notifd/SlackCompatibleNotificationStrategyTest.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2019-2019 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ * Copyright (C) 2019-2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *

--- a/opennms-services/src/test/java/org/opennms/netmgt/notifd/SlackNotificationStrategyIT.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/notifd/SlackNotificationStrategyIT.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2016 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2016 The OpenNMS Group, Inc.
+ * Copyright (C) 2016-2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *

--- a/opennms-services/src/test/java/org/opennms/netmgt/notifd/SlackNotificationStrategyIT.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/notifd/SlackNotificationStrategyIT.java
@@ -31,11 +31,9 @@ package org.opennms.netmgt.notifd;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 import org.json.simple.JSONObject;
 import org.junit.Test;
@@ -73,59 +71,75 @@ public class SlackNotificationStrategyIT {
     public void testSendValidMessage() {
         final int port = JUnitHttpServerExecutionListener.getPort();
         assertTrue(port > 0);
-        try {
 
-            final NotificationStrategy ns = new SlackNotificationStrategy();
-            final List<Argument> arguments = new ArrayList<Argument>();
+        final NotificationStrategy ns = new SlackNotificationStrategy();
+        final List<Argument> arguments = new ArrayList<Argument>();
 
-            // Set these properties. We will override them with Args on the first run.
-            System.setProperty("org.opennms.netmgt.notifd.slack.webhookURL", "http://localhost:" + port + "/hooks/abunchofstuffthatidentifiesawebhook");
-            System.setProperty("org.opennms.netmgt.notifd.slack.channel", "integrationtestsXX");
-            System.setProperty("org.opennms.netmgt.notifd.slack.iconURL", "http://opennms.org/logo.pngXX");
-            System.setProperty("org.opennms.netmgt.notifd.slack.iconEmoji", ":shipitXX:");
-            System.setProperty("org.opennms.netmgt.notifd.slack.username", "opennmsXX");
+        // Set these properties. We will override them with Args on the first run.
+        System.setProperty("org.opennms.netmgt.notifd.slack.webhookURL", "http://localhost:" + port + "/hooks/abunchofstuffthatidentifiesawebhook");
+        System.setProperty("org.opennms.netmgt.notifd.slack.channel", "integrationtestsXX");
+        System.setProperty("org.opennms.netmgt.notifd.slack.iconURL", "http://opennms.org/logo.pngXX");
+        System.setProperty("org.opennms.netmgt.notifd.slack.iconEmoji", ":shipitXX:");
+        System.setProperty("org.opennms.netmgt.notifd.slack.username", "opennmsXX");
 
-            arguments.add(new Argument("-url", null, "http://localhost:" + port + "/hooks/abunchofstuffthatidentifiesawebhook", false));
-            arguments.add(new Argument("-channel", null, "integrationtests", false));
-            arguments.add(new Argument("-username", null, "opennms", false));
-            arguments.add(new Argument("-iconurl", null, "http://opennms.org/logo.png", false));
-            arguments.add(new Argument("-iconemoji", null, ":shipit:", false));
-            arguments.add(new Argument("-subject", null, "Test", false));
-            arguments.add(new Argument("-tm", null, "This is only a test", false));
-            
-            int statusCode = ns.send(arguments);
-            assertEquals(0, statusCode);
-            
-            JSONObject inputJson = MattermostNotificationStrategyTestServlet.getInputJson();
-            assertNotNull(inputJson);
-            assertEquals("opennms", inputJson.get("username"));
-            assertEquals("*Test*\nThis is only a test", inputJson.get("text"));
-            assertEquals("integrationtests", inputJson.get("channel"));
-            assertEquals("http://opennms.org/logo.png", inputJson.get("icon_url"));
-            assertEquals(":shipit:", inputJson.get("icon_emoji"));
-            assertEquals(5, inputJson.size());
-            
-            // Now do it again, without the Args, and verify that the property values come out
-            arguments.clear();
-            arguments.add(new Argument("-subject", null, "Test again", false));
-            arguments.add(new Argument("-tm", null, "This is only a second test", false));
-            
-            statusCode = ns.send(arguments);
-            assertEquals(0, statusCode);
-            
-            inputJson = MattermostNotificationStrategyTestServlet.getInputJson();
-            assertNotNull(inputJson);
-            assertEquals("opennmsXX", inputJson.get("username"));
-            assertEquals("*Test again*\nThis is only a second test", inputJson.get("text"));
-            assertEquals("integrationtestsXX", inputJson.get("channel"));
-            assertEquals("http://opennms.org/logo.pngXX", inputJson.get("icon_url"));
-            assertEquals(":shipitXX:", inputJson.get("icon_emoji"));
-            assertEquals(5, inputJson.size());
+        arguments.add(new Argument("-url", null, "http://localhost:" + port + "/hooks/abunchofstuffthatidentifiesawebhook", false));
+        arguments.add(new Argument("-channel", null, "integrationtests", false));
+        arguments.add(new Argument("-username", null, "opennms", false));
+        arguments.add(new Argument("-iconurl", null, "http://opennms.org/logo.png", false));
+        arguments.add(new Argument("-iconemoji", null, ":shipit:", false));
+        arguments.add(new Argument("-subject", null, "Test", false));
+        arguments.add(new Argument("-tm", null, "This is only a test", false));
 
-        } catch (Throwable e) {
-            e.printStackTrace();
-            fail("Caught Exception: " + e.getMessage());
-        }
+        int statusCode = ns.send(arguments);
+        assertEquals(0, statusCode);
+
+        JSONObject inputJson = MattermostNotificationStrategyTestServlet.getInputJson();
+        assertNotNull(inputJson);
+        assertEquals("opennms", inputJson.get("username"));
+        assertEquals("*Test*\nThis is only a test", inputJson.get("text"));
+        assertEquals("integrationtests", inputJson.get("channel"));
+        assertEquals("http://opennms.org/logo.png", inputJson.get("icon_url"));
+        assertEquals(":shipit:", inputJson.get("icon_emoji"));
+        assertEquals(5, inputJson.size());
+
+        // Now do it again, without the Args, and verify that the property values come out
+        arguments.clear();
+        arguments.add(new Argument("-subject", null, "Test again", false));
+        arguments.add(new Argument("-tm", null, "This is only a second test", false));
+
+        statusCode = ns.send(arguments);
+        assertEquals(0, statusCode);
+
+        inputJson = MattermostNotificationStrategyTestServlet.getInputJson();
+        assertNotNull(inputJson);
+        assertEquals("opennmsXX", inputJson.get("username"));
+        assertEquals("*Test again*\nThis is only a second test", inputJson.get("text"));
+        assertEquals("integrationtestsXX", inputJson.get("channel"));
+        assertEquals("http://opennms.org/logo.pngXX", inputJson.get("icon_url"));
+        assertEquals(":shipitXX:", inputJson.get("icon_emoji"));
+        assertEquals(5, inputJson.size());
+
+        // Now do it again without the leading - in switch names
+        arguments.clear();
+        arguments.add(new Argument("url", null, "http://localhost:" + port + "/hooks/abunchofstuffthatidentifiesawebhook", false));
+        arguments.add(new Argument("channel", null, "integrationtests", false));
+        arguments.add(new Argument("username", null, "opennms", false));
+        arguments.add(new Argument("iconurl", null, "http://opennms.org/logo.png", false));
+        arguments.add(new Argument("iconemoji", null, ":shipit:", false));
+        arguments.add(new Argument("subject", null, "Test", false));
+        arguments.add(new Argument("tm", null, "This is only a test", false));
+
+        statusCode = ns.send(arguments);
+        assertEquals(0, statusCode);
+
+        inputJson = MattermostNotificationStrategyTestServlet.getInputJson();
+        assertNotNull(inputJson);
+        assertEquals("opennms", inputJson.get("username"));
+        assertEquals("*Test*\nThis is only a test", inputJson.get("text"));
+        assertEquals("integrationtests", inputJson.get("channel"));
+        assertEquals("http://opennms.org/logo.png", inputJson.get("icon_url"));
+        assertEquals(":shipit:", inputJson.get("icon_emoji"));
+        assertEquals(5, inputJson.size());
     }
 
 }

--- a/opennms-services/src/test/java/org/opennms/netmgt/notifd/SlackNotificationStrategyIT.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/notifd/SlackNotificationStrategyIT.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2016-2019 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ * Copyright (C) 2016-2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *

--- a/opennms-services/src/test/java/org/opennms/netmgt/notifd/SlackNotificationStrategyIT.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/notifd/SlackNotificationStrategyIT.java
@@ -85,11 +85,11 @@ public class SlackNotificationStrategyIT {
             System.setProperty("org.opennms.netmgt.notifd.slack.iconEmoji", ":shipitXX:");
             System.setProperty("org.opennms.netmgt.notifd.slack.username", "opennmsXX");
 
-            arguments.add(new Argument("url", null, "http://localhost:" + port + "/hooks/abunchofstuffthatidentifiesawebhook", false));
-            arguments.add(new Argument("channel", null, "integrationtests", false));
-            arguments.add(new Argument("username", null, "opennms", false));
-            arguments.add(new Argument("iconurl", null, "http://opennms.org/logo.png", false));
-            arguments.add(new Argument("iconemoji", null, ":shipit:", false));
+            arguments.add(new Argument("-url", null, "http://localhost:" + port + "/hooks/abunchofstuffthatidentifiesawebhook", false));
+            arguments.add(new Argument("-channel", null, "integrationtests", false));
+            arguments.add(new Argument("-username", null, "opennms", false));
+            arguments.add(new Argument("-iconurl", null, "http://opennms.org/logo.png", false));
+            arguments.add(new Argument("-iconemoji", null, ":shipit:", false));
             arguments.add(new Argument("-subject", null, "Test", false));
             arguments.add(new Argument("-tm", null, "This is only a test", false));
             


### PR DESCRIPTION
Fix it so leading dashes are expected. Include a warning message if we see a switch name without
a leading dash, so that people can be prompted to update their notification command definitions.
Since we have never shipped a config with such a command on by default, this warning should do
the job.

* JIRA: http://issues.opennms.org/browse/NMS-10552