### PR TITLE
NMS-10499: Check JMS connectivity only when JMS is enabled for Sink/RPC

### DIFF
--- a/core/ipc/rpc/jms-impl/src/main/resources/OSGI-INF/blueprint/blueprint-rpc-server.xml
+++ b/core/ipc/rpc/jms-impl/src/main/resources/OSGI-INF/blueprint/blueprint-rpc-server.xml
@@ -48,4 +48,12 @@
     <reference-list id="rpcModulesRef" interface="org.opennms.core.rpc.api.RpcModule" availability="optional">
         <reference-listener bind-method="bind" unbind-method="unbind" ref="jmsRpcServerRouteManager"/>
     </reference-list>
+
+    <!-- JMS HealthCheck -->
+    <service interface="org.opennms.core.health.api.HealthCheck">
+        <bean class="org.opennms.distributed.jms.impl.JmsConnectionHealthCheck" >
+            <argument ref="blueprintBundleContext"/>
+            <argument value="RPC" />
+        </bean>
+    </service>
 </blueprint>

--- a/core/ipc/sink/camel/client/src/main/resources/OSGI-INF/blueprint/blueprint-ipc-client.xml
+++ b/core/ipc/sink/camel/client/src/main/resources/OSGI-INF/blueprint/blueprint-ipc-client.xml
@@ -47,4 +47,12 @@
       </route>
     </camelContext>
 
+    <!-- JMS HealthCheck -->
+    <service interface="org.opennms.core.health.api.HealthCheck">
+      <bean class="org.opennms.distributed.jms.impl.JmsConnectionHealthCheck" >
+        <argument ref="blueprintBundleContext"/>
+        <argument value="Sink" />
+      </bean>
+    </service>
+
 </blueprint>

--- a/core/ipc/sink/camel/server/src/main/resources/OSGI-INF/blueprint/blueprint-ipc-server.xml
+++ b/core/ipc/sink/camel/server/src/main/resources/OSGI-INF/blueprint/blueprint-ipc-server.xml
@@ -34,4 +34,12 @@
         <!-- The routes are managed by the CamelMessageConsumerManager -->
     </camelContext>
 
+    <!-- JMS HealthCheck -->
+    <service interface="org.opennms.core.health.api.HealthCheck">
+        <bean class="org.opennms.distributed.jms.impl.JmsConnectionHealthCheck" >
+            <argument ref="blueprintBundleContext"/>
+            <argument value="Sink" />
+        </bean>
+    </service>
+
 </blueprint>

--- a/features/distributed/core/jms/src/main/java/org/opennms/distributed/jms/impl/JmsConnectionHealthCheck.java
+++ b/features/distributed/core/jms/src/main/java/org/opennms/distributed/jms/impl/JmsConnectionHealthCheck.java
@@ -53,14 +53,16 @@ import org.osgi.framework.ServiceReference;
 public class JmsConnectionHealthCheck implements HealthCheck {
 
     private final BundleContext bundleContext;
+    private final String type;
 
-    public JmsConnectionHealthCheck(BundleContext bundleContext) {
+    public JmsConnectionHealthCheck(BundleContext bundleContext, String type) {
         this.bundleContext = Objects.requireNonNull(bundleContext);
+        this.type = type;
     }
 
     @Override
     public String getDescription() {
-        return "Connecting to JMS Broker";
+        return "Connecting to JMS Broker from " + type;
     }
 
     @Override

--- a/features/distributed/core/jms/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/features/distributed/core/jms/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -49,10 +49,4 @@
         </service-properties>
     </service>
 
-    <!-- JMS HealthCheck -->
-    <service interface="org.opennms.core.health.api.HealthCheck">
-        <bean class="org.opennms.distributed.jms.impl.JmsConnectionHealthCheck" >
-            <argument ref="blueprintBundleContext"/>
-        </bean>
-    </service>
 </blueprint>


### PR DESCRIPTION
Currently we check activemq connectivity on Minion/Sentinel even if kafka is enabled for Sink/RPC.
This will allow  `health:check` to explicitly check JMS connectivity only when ActiveMQ is enabled.

Also fix `sentinel-core` feature definition as I was having issues installing it.

* JIRA: http://issues.opennms.org/browse/NMS-10499

Our [continuous integration system](http://bamboo.internal.opennms.com:8085) will test and verify your changes.
