### PR TITLE
NMS-10561: Fix sentinel-core feature dependency issue

### DIFF
--- a/container/features/src/main/resources/features.xml
+++ b/container/features/src/main/resources/features.xml
@@ -1304,6 +1304,7 @@
 
         <bundle dependency="true">mvn:com.google.guava/guava/18.0</bundle>
         <bundle dependency="true">mvn:org.opennms.core/org.opennms.core.soa/${project.version}</bundle>
+        <bundle dependency="true">mvn:org.opennms.core/org.opennms.core.sysprops/${project.version}</bundle>
         <bundle>mvn:org.opennms.container/spring-extender/${project.version}</bundle>
     </feature>
 


### PR DESCRIPTION
Standalone sentinel-core feature doesn't install because of missing dependency.

* JIRA: http://issues.opennms.org/browse/NMS-10561

Our [continuous integration system](http://bamboo.internal.opennms.com:8085) will test and verify your changes.
