### PR TITLE
NMS-10543: bump PostgreSQL JDBC driver to the latest version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1352,7 +1352,7 @@
     <paxWebVersion>4.3.0</paxWebVersion>
     <protobufVersion>2.6.1</protobufVersion>
     <protobuf3Version>3.5.1</protobuf3Version>
-    <postgresqlVersion>9.4.1211</postgresqlVersion>
+    <postgresqlVersion>42.2.5</postgresqlVersion>
     <powermockVersion>1.6.4</powermockVersion>
     <!-- TODO: Update to release artifact before tagging 24.0.0 -->
     <opennmsApiVersion>1.0.0-alpha4-SNAPSHOT</opennmsApiVersion>


### PR DESCRIPTION
This PR updates to the latest PostgreSQL JDBC driver, which has support for Java 9+ modules.

* JIRA: http://issues.opennms.org/browse/NMS-10543

Our [continuous integration system](http://bamboo.internal.opennms.com:8085) will test and verify your changes.
