### PR TITLE
NMS-10566: Make the RadixTreeSyslogParser the default syslog parser.

### DIFF
--- a/opennms-base-assembly/src/main/filtered/etc/syslogd-configuration.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/syslogd-configuration.xml
@@ -8,7 +8,7 @@
     <configuration
             syslog-port="10514"
             new-suspect-on-message="false"
-            parser="org.opennms.netmgt.syslogd.CustomSyslogParser"
+            parser="org.opennms.netmgt.syslogd.RadixTreeSyslogParser"
             forwarding-regexp="^.*\s(19|20)\d\d([-/.])(0[1-9]|1[012])\2(0[1-9]|[12][0-9]|3[01])(\s+)(\S+)(\s)(\S.+)"
             matching-group-host="6"
             matching-group-message="8"

--- a/opennms-doc/guide-admin/src/asciidoc/text/events/sources/syslog.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/events/sources/syslog.adoc
@@ -16,7 +16,7 @@ Different parsers can be used to convert the syslog message fields into {opennms
 [options="header, autowidth"]
 |===
 | Parser  | Description
-| `org.opennms.netmgt.syslogd.CustomSyslogParser`    | Default parser that uses a regex statement to parse the syslog header.
+| `org.opennms.netmgt.syslogd.CustomSyslogParser`    | Parser that uses a regex statement to parse the syslog header.
 | `org.opennms.netmgt.syslogd.RadixTreeSyslogParser` | Parser that uses an internal list of _grok_-style statements to parse the syslog header.
 | `org.opennms.netmgt.syslogd.SyslogNGParser`        | Parser that strictly parses messages in the default pattern of syslog-ng.
 | `org.opennms.netmgt.syslogd.Rfc5424SyslogParser`   | Parser that strictly parses the RFC 5424 format for syslog messages.

--- a/opennms-doc/releasenotes/src/asciidoc/releasenotes/whatsnew.adoc
+++ b/opennms-doc/releasenotes/src/asciidoc/releasenotes/whatsnew.adoc
@@ -32,6 +32,7 @@ EOF
 ```
 * *Dhcpd*: The *Dhcpd* plugin (and its configuration) was removed in favor of a Minion-capable implementation.
   The new *DhcpMonitor* options can be set in the `poller-configuration.xml` file.
+* The default parser used for Syslog messages has been switched from the `CustomSyslogParser` to the `RadixTreeSyslogParser`.
 
 === New Features
 


### PR DESCRIPTION
JIRA: https://issues.opennms.org/browse/NMS-10566

Use the `RadixTreeSyslogParser` by default, since it can successfully parse many more formats than the current `CustomSyslogParser`.