### PR TITLE
NMS-10549: Fix typo in registerNorthnounders method

### DIFF
--- a/opennms-alarms/bsf-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/bsf/BSFNorthbounderManager.java
+++ b/opennms-alarms/bsf-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/bsf/BSFNorthbounderManager.java
@@ -85,15 +85,15 @@ public class BSFNorthbounderManager implements InitializingBean, Northbounder, D
         m_registrations.put(getName(), m_serviceRegistry.register(this, Northbounder.class));
 
         // Registering each destination as a northbounder
-        registerNorthnounders();
+        registerNorthbounders();
     }
 
     /**
-     * Register northnounders.
+     * Register northbounders.
      *
      * @throws Exception the exception
      */
-    private void registerNorthnounders() throws Exception {
+    private void registerNorthbounders() throws Exception {
         if (! m_configDao.getConfig().isEnabled()) {
             LOG.warn("The BSF NBI is globally disabled, the destinations won't be registered which means all the alarms will be rejected.");
             return;
@@ -172,7 +172,7 @@ public class BSFNorthbounderManager implements InitializingBean, Northbounder, D
         try {
             m_configDao.reload();
             m_registrations.forEach((k,v) -> { if (k != getName()) v.unregister();});
-            registerNorthnounders();
+            registerNorthbounders();
         } catch (Exception e) {
             throw new NorthbounderException("Can't reload the BSF trap northbound configuration", e);
         }

--- a/opennms-alarms/drools-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/drools/DroolsNorthbounderManager.java
+++ b/opennms-alarms/drools-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/drools/DroolsNorthbounderManager.java
@@ -87,15 +87,15 @@ public class DroolsNorthbounderManager implements Northbounder, InitializingBean
         Assert.notNull(m_serviceRegistry);
 
         m_registrations.put(getName(), m_serviceRegistry.register(this, Northbounder.class));
-        registerNorthnounders();
+        registerNorthbounders();
     }
 
     /**
-     * Register northnounders.
+     * Register northbounders.
      *
      * @throws Exception the exception
      */
-    private void registerNorthnounders() throws Exception {
+    private void registerNorthbounders() throws Exception {
         if (! m_configDao.getConfig().isEnabled()) {
             LOG.warn("The Drools NBI is globally disabled, the destinations won't be registered which means all the alarms will be rejected.");
             return;
@@ -174,7 +174,7 @@ public class DroolsNorthbounderManager implements Northbounder, InitializingBean
         try {
             m_configDao.reload();
             m_registrations.forEach((k,v) -> { if (k != getName()) v.unregister();});
-            registerNorthnounders();
+            registerNorthbounders();
         } catch (Exception e) {
             throw new NorthbounderException("Can't reload the Drools northbound configuration", e);
         }

--- a/opennms-alarms/email-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/email/EmailNorthbounderManager.java
+++ b/opennms-alarms/email-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/email/EmailNorthbounderManager.java
@@ -83,15 +83,15 @@ public class EmailNorthbounderManager implements InitializingBean, Northbounder,
         m_registrations.put(getName(), m_serviceRegistry.register(this, Northbounder.class));
 
         // Registering each destination as a northbounder
-        registerNorthnounders();
+        registerNorthbounders();
     }
 
     /**
-     * Register northnounders.
+     * Register northbounders.
      *
      * @throws Exception the exception
      */
-    private void registerNorthnounders() throws Exception {
+    private void registerNorthbounders() throws Exception {
         if (! m_configDao.getConfig().isEnabled()) {
             LOG.warn("The Email NBI is globally disabled, the destinations won't be registered which means all the alarms will be rejected.");
             return;
@@ -170,7 +170,7 @@ public class EmailNorthbounderManager implements InitializingBean, Northbounder,
             m_configDao.reload();
             m_javaMailDao.reloadConfiguration();
             m_registrations.forEach((k,v) -> { if (k != getName()) v.unregister();});
-            registerNorthnounders();
+            registerNorthbounders();
         } catch (Exception e) {
             throw new NorthbounderException("Can't reload the SNMP trap northbound configuration", e);
         }

--- a/opennms-alarms/jms-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/jms/JmsNorthbounderManager.java
+++ b/opennms-alarms/jms-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/jms/JmsNorthbounderManager.java
@@ -83,15 +83,15 @@ public class JmsNorthbounderManager implements InitializingBean, Northbounder, D
         m_registrations.put(getName(), m_serviceRegistry.register(this, Northbounder.class));
 
         // Registering each destination as a northbounder
-        registerNorthnounders();
+        registerNorthbounders();
     }
 
     /**
-     * Register northnounders.
+     * Register northbounders.
      *
      * @throws Exception the exception
      */
-    private void registerNorthnounders() throws Exception {
+    private void registerNorthbounders() throws Exception {
         if (! m_configDao.getConfig().isEnabled()) {
             LOG.warn("The JMS NBI is globally disabled, the destinations won't be registered which means all the alarms will be rejected.");
             return;
@@ -158,7 +158,7 @@ public class JmsNorthbounderManager implements InitializingBean, Northbounder, D
         try {
             m_configDao.reload();
             m_registrations.forEach((k,v) -> { if (k != getName()) v.unregister();});
-            registerNorthnounders();
+            registerNorthbounders();
         } catch (Exception e) {
             throw new NorthbounderException("Can't reload the JMS northbound configuration", e);
         }

--- a/opennms-alarms/snmptrap-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/snmptrap/SnmpTrapNorthbounderManager.java
+++ b/opennms-alarms/snmptrap-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/snmptrap/SnmpTrapNorthbounderManager.java
@@ -82,15 +82,15 @@ public class SnmpTrapNorthbounderManager implements InitializingBean, Northbound
         m_registrations.put(getName(), m_serviceRegistry.register(this, Northbounder.class));
 
         // Registering each destination as a northbounder
-        registerNorthnounders();
+        registerNorthbounders();
     }
 
     /**
-     * Register northnounders.
+     * Register northbounders.
      *
      * @throws Exception the exception
      */
-    private void registerNorthnounders() throws Exception {
+    private void registerNorthbounders() throws Exception {
         if (! m_configDao.getConfig().isEnabled()) {
             LOG.warn("The SNMP Trap NBI is globally disabled, the destinations won't be registered which means all the alarms will be rejected.");
             return;
@@ -168,7 +168,7 @@ public class SnmpTrapNorthbounderManager implements InitializingBean, Northbound
         try {
             m_configDao.reload();
             m_registrations.forEach((k,v) -> { if (k != getName()) v.unregister();});
-            registerNorthnounders();
+            registerNorthbounders();
         } catch (Exception e) {
             throw new NorthbounderException("Can't reload the SNMP trap northbound configuration", e);
         }

--- a/opennms-alarms/syslog-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/syslog/SyslogNorthbounderManager.java
+++ b/opennms-alarms/syslog-northbounder/src/main/java/org/opennms/netmgt/alarmd/northbounder/syslog/SyslogNorthbounderManager.java
@@ -80,15 +80,15 @@ public class SyslogNorthbounderManager implements InitializingBean, Northbounder
         m_registrations.put(getName(), m_serviceRegistry.register(this, Northbounder.class));
 
         // Registering each destination as a northbounder
-        registerNorthnounders();
+        registerNorthbounders();
     }
 
     /**
-     * Register northnounders.
+     * Register northbounders.
      *
      * @throws Exception the exception
      */
-    private void registerNorthnounders() throws Exception {
+    private void registerNorthbounders() throws Exception {
         if (! m_configDao.getConfig().isEnabled()) {
             LOG.warn("The Syslog NBI is globally disabled, the destinations won't be registered which means all the alarms will be rejected.");
             return;
@@ -172,7 +172,7 @@ public class SyslogNorthbounderManager implements InitializingBean, Northbounder
             m_configDao.reload();
             m_registrations.forEach((k,v) -> { if (k != getName()) v.unregister();}); // Unregistering Syslog destinations
             Syslog.shutdown(); // Shutdown all Syslog instances.
-            registerNorthnounders(); // Re-registering all Syslog destinations.
+            registerNorthbounders(); // Re-registering all Syslog destinations.
         } catch (Exception e) {
             throw new NorthbounderException("Can't reload the Syslog northbound configuration", e);
         }


### PR DESCRIPTION
While debugging functionality of the Syslog Northbounder, I've ran in a typo issue in the method names. This typo fix requires to pass CI/CD tests.

* JIRA: http://issues.opennms.org/browse/NMS-10549
