### PR TITLE
Remove duplicate org.hamcrest:hamcrest-library dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3810,12 +3810,6 @@
         <scope>test</scope>
       </dependency>
       <dependency>
-        <groupId>org.hamcrest</groupId>
-        <artifactId>hamcrest-library</artifactId>
-        <version>1.3</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
         <groupId>net.sourceforge.jwebunit</groupId>
         <artifactId>jwebunit-htmlunit-plugin</artifactId>
         <version>2.5</version>


### PR DESCRIPTION
This fixes this warning:

```
[WARNING] Some problems were encountered while building the effective model for org.opennms:opennms:pom:25.0.0-SNAPSHOT
[WARNING] 'dependencyManagement.dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: org.hamcrest:hamcrest-library:jar -> duplicate declaration of version 1.3 @ line 3812, column 19
```