### PR TITLE
HZN-1475: Extend topology generator and test suite to support bridge topology

### DIFF
--- a/checkstyle/pom.xml
+++ b/checkstyle/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms</groupId>
   <artifactId>org.opennms.checkstyle</artifactId>
-  <version>24.0.0-SNAPSHOT</version>
+  <version>25.0.0-SNAPSHOT</version>
   <name>OpenNMS :: Checkstyle</name>
   <build>
     <plugins>

--- a/container/branding/pom.xml
+++ b/container/branding/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>org.opennms.container</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
 
     <groupId>org.opennms.container</groupId>

--- a/container/bridge/pom.xml
+++ b/container/bridge/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.opennms</groupId>
         <artifactId>org.opennms.container</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>org.opennms.container</groupId>

--- a/container/extender/pom.xml
+++ b/container/extender/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.opennms</groupId>
         <artifactId>org.opennms.container</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.opennms.container</groupId>

--- a/container/features/pom.xml
+++ b/container/features/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>org.opennms.container</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.karaf</groupId>

--- a/container/jaas-login-module/pom.xml
+++ b/container/jaas-login-module/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.opennms</groupId>
         <artifactId>org.opennms.container</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>org.opennms.container</groupId>

--- a/container/karaf/pom.xml
+++ b/container/karaf/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.opennms</groupId>
         <artifactId>org.opennms.container</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.opennms.container</groupId>

--- a/container/pom.xml
+++ b/container/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>opennms</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>org.opennms.container</artifactId>

--- a/container/scv/pom.xml
+++ b/container/scv/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.opennms</groupId>
         <artifactId>org.opennms.container</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.opennms.container</groupId>

--- a/container/servlet/pom.xml
+++ b/container/servlet/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.opennms</groupId>
         <artifactId>org.opennms.container</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>org.opennms.container</groupId>

--- a/container/shared/pom.xml
+++ b/container/shared/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.opennms</groupId>
         <artifactId>org.opennms.container</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.opennms.container</groupId>

--- a/container/spring-extender/pom.xml
+++ b/container/spring-extender/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.opennms</groupId>
         <artifactId>org.opennms.container</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.opennms.container</groupId>

--- a/container/web/pom.xml
+++ b/container/web/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.opennms</groupId>
         <artifactId>org.opennms.container</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>org.opennms.container</groupId>

--- a/core/api/pom.xml
+++ b/core/api/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>org.opennms.core</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.core</groupId>

--- a/core/build/keystore/pom.xml
+++ b/core/build/keystore/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.core</groupId>
     <artifactId>org.opennms.core.build</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.core.build</groupId>

--- a/core/build/pom.xml
+++ b/core/build/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>org.opennms.core</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.core</groupId>

--- a/core/cache/pom.xml
+++ b/core/cache/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.opennms</groupId>
         <artifactId>org.opennms.core</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.opennms.core</groupId>

--- a/core/camel/pom.xml
+++ b/core/camel/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>org.opennms.core</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.core</groupId>

--- a/core/config/pom.xml
+++ b/core/config/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.opennms</groupId>
 		<artifactId>org.opennms.core</artifactId>
-		<version>24.0.0-SNAPSHOT</version>
+		<version>25.0.0-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.opennms.core</groupId>

--- a/core/criteria/pom.xml
+++ b/core/criteria/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>org.opennms.core</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.core</groupId>

--- a/core/daemon/pom.xml
+++ b/core/daemon/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>org.opennms.core</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.core</groupId>

--- a/core/db-install/pom.xml
+++ b/core/db-install/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>org.opennms.core</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.core</groupId>

--- a/core/db/pom.xml
+++ b/core/db/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>org.opennms.core</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.core</groupId>

--- a/core/health/api/pom.xml
+++ b/core/health/api/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.opennms.core</groupId>
         <artifactId>org.opennms.core.health</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.opennms.core.health</groupId>

--- a/core/health/impl/pom.xml
+++ b/core/health/impl/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.opennms.core</groupId>
         <artifactId>org.opennms.core.health</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.opennms.core.health</groupId>

--- a/core/health/pom.xml
+++ b/core/health/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.opennms</groupId>
         <artifactId>org.opennms.core</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.opennms.core</groupId>

--- a/core/health/shell/pom.xml
+++ b/core/health/shell/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.opennms.core</groupId>
         <artifactId>org.opennms.core.health</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.opennms.core.health</groupId>

--- a/core/icmp-jna/pom.xml
+++ b/core/icmp-jna/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>org.opennms.core</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.core</groupId>

--- a/core/ipc/common/aws-sqs/pom.xml
+++ b/core/ipc/common/aws-sqs/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.core.ipc</groupId>
     <artifactId>org.opennms.core.ipc.common</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.core.ipc.common</groupId>

--- a/core/ipc/common/kafka/pom.xml
+++ b/core/ipc/common/kafka/pom.xml
@@ -4,7 +4,7 @@
     <parent>
       <groupId>org.opennms.core.ipc</groupId>
       <artifactId>org.opennms.core.ipc.common</artifactId>
-      <version>24.0.0-SNAPSHOT</version>
+      <version>25.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.opennms.core.ipc.common</groupId>

--- a/core/ipc/common/pom.xml
+++ b/core/ipc/common/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.core</groupId>
     <artifactId>org.opennms.core.ipc</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.core.ipc</groupId>

--- a/core/ipc/pom.xml
+++ b/core/ipc/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>org.opennms.core</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.core</groupId>

--- a/core/ipc/rpc/api/pom.xml
+++ b/core/ipc/rpc/api/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.core.ipc</groupId>
     <artifactId>org.opennms.core.ipc.rpc</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.core.ipc.rpc</groupId>

--- a/core/ipc/rpc/aws-sqs-impl/pom.xml
+++ b/core/ipc/rpc/aws-sqs-impl/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.core.ipc</groupId>
     <artifactId>org.opennms.core.ipc.rpc</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.core.ipc.rpc</groupId>

--- a/core/ipc/rpc/camel/pom.xml
+++ b/core/ipc/rpc/camel/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.core.ipc</groupId>
     <artifactId>org.opennms.core.ipc.rpc</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.core.ipc.rpc</groupId>

--- a/core/ipc/rpc/common/pom.xml
+++ b/core/ipc/rpc/common/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.core.ipc</groupId>
     <artifactId>org.opennms.core.ipc.rpc</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.core.ipc.rpc</groupId>

--- a/core/ipc/rpc/jms-impl/pom.xml
+++ b/core/ipc/rpc/jms-impl/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.core.ipc</groupId>
     <artifactId>org.opennms.core.ipc.rpc</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.core.ipc.rpc</groupId>

--- a/core/ipc/rpc/kafka/pom.xml
+++ b/core/ipc/rpc/kafka/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.opennms.core.ipc</groupId>
         <artifactId>org.opennms.core.ipc.rpc</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.opennms.core.ipc.rpc</groupId>

--- a/core/ipc/rpc/mock-impl/pom.xml
+++ b/core/ipc/rpc/mock-impl/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.core.ipc</groupId>
     <artifactId>org.opennms.core.ipc.rpc</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.core.ipc.rpc</groupId>

--- a/core/ipc/rpc/pom.xml
+++ b/core/ipc/rpc/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.core</groupId>
     <artifactId>org.opennms.core.ipc</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.core.ipc</groupId>

--- a/core/ipc/rpc/shell-commands/pom.xml
+++ b/core/ipc/rpc/shell-commands/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.core.ipc</groupId>
     <artifactId>org.opennms.core.ipc.rpc</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.core.ipc.rpc</groupId>

--- a/core/ipc/rpc/utils/pom.xml
+++ b/core/ipc/rpc/utils/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.core.ipc</groupId>
     <artifactId>org.opennms.core.ipc.rpc</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.core.ipc.rpc</groupId>

--- a/core/ipc/rpc/xml/pom.xml
+++ b/core/ipc/rpc/xml/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.core.ipc</groupId>
     <artifactId>org.opennms.core.ipc.rpc</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.core.ipc.rpc</groupId>

--- a/core/ipc/sink/api/pom.xml
+++ b/core/ipc/sink/api/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.core.ipc</groupId>
     <artifactId>org.opennms.core.ipc.sink</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.core.ipc.sink</groupId>

--- a/core/ipc/sink/aws-sqs/client/pom.xml
+++ b/core/ipc/sink/aws-sqs/client/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.core.ipc.sink</groupId>
     <artifactId>org.opennms.core.ipc.sink.aws.sqs</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.core.ipc.sink.aws.sqs</groupId>

--- a/core/ipc/sink/aws-sqs/common/pom.xml
+++ b/core/ipc/sink/aws-sqs/common/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.core.ipc.sink</groupId>
     <artifactId>org.opennms.core.ipc.sink.aws.sqs</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.core.ipc.sink.aws.sqs</groupId>

--- a/core/ipc/sink/aws-sqs/itests/pom.xml
+++ b/core/ipc/sink/aws-sqs/itests/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.core.ipc.sink</groupId>
     <artifactId>org.opennms.core.ipc.sink.aws.sqs</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.core.ipc.sink.aws.sqs</groupId>

--- a/core/ipc/sink/aws-sqs/pom.xml
+++ b/core/ipc/sink/aws-sqs/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.core.ipc</groupId>
     <artifactId>org.opennms.core.ipc.sink</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.core.ipc.sink</groupId>

--- a/core/ipc/sink/aws-sqs/server/pom.xml
+++ b/core/ipc/sink/aws-sqs/server/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.core.ipc.sink</groupId>
     <artifactId>org.opennms.core.ipc.sink.aws.sqs</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.core.ipc.sink.aws.sqs</groupId>

--- a/core/ipc/sink/camel/client/pom.xml
+++ b/core/ipc/sink/camel/client/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.core.ipc.sink</groupId>
     <artifactId>org.opennms.core.ipc.sink.camel</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/core/ipc/sink/camel/common/pom.xml
+++ b/core/ipc/sink/camel/common/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.core.ipc.sink</groupId>
     <artifactId>org.opennms.core.ipc.sink.camel</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/core/ipc/sink/camel/itests/pom.xml
+++ b/core/ipc/sink/camel/itests/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.core.ipc.sink</groupId>
     <artifactId>org.opennms.core.ipc.sink.camel</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/core/ipc/sink/camel/pom.xml
+++ b/core/ipc/sink/camel/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.core.ipc</groupId>
     <artifactId>org.opennms.core.ipc.sink</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.core.ipc.sink</groupId>

--- a/core/ipc/sink/camel/server/pom.xml
+++ b/core/ipc/sink/camel/server/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.core.ipc.sink</groupId>
     <artifactId>org.opennms.core.ipc.sink.camel</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/core/ipc/sink/common/pom.xml
+++ b/core/ipc/sink/common/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.core.ipc</groupId>
     <artifactId>org.opennms.core.ipc.sink</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.core.ipc.sink</groupId>

--- a/core/ipc/sink/kafka/client/pom.xml
+++ b/core/ipc/sink/kafka/client/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.core.ipc.sink</groupId>
     <artifactId>org.opennms.core.ipc.sink.kafka</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.core.ipc.sink.kafka</groupId>

--- a/core/ipc/sink/kafka/itests/pom.xml
+++ b/core/ipc/sink/kafka/itests/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.core.ipc.sink</groupId>
     <artifactId>org.opennms.core.ipc.sink.kafka</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.core.ipc.sink.kafka</groupId>

--- a/core/ipc/sink/kafka/pom.xml
+++ b/core/ipc/sink/kafka/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.core.ipc</groupId>
     <artifactId>org.opennms.core.ipc.sink</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.core.ipc.sink</groupId>

--- a/core/ipc/sink/kafka/server/pom.xml
+++ b/core/ipc/sink/kafka/server/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.core.ipc.sink</groupId>
     <artifactId>org.opennms.core.ipc.sink.kafka</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.core.ipc.sink.kafka</groupId>

--- a/core/ipc/sink/mock-impl/pom.xml
+++ b/core/ipc/sink/mock-impl/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.core.ipc</groupId>
     <artifactId>org.opennms.core.ipc.sink</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.core.ipc.sink</groupId>

--- a/core/ipc/sink/off-heap/pom.xml
+++ b/core/ipc/sink/off-heap/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.core.ipc</groupId>
     <artifactId>org.opennms.core.ipc.sink</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.core.ipc.sink</groupId>

--- a/core/ipc/sink/pom.xml
+++ b/core/ipc/sink/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.core</groupId>
     <artifactId>org.opennms.core.ipc</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.core.ipc</groupId>

--- a/core/ipc/sink/xml/pom.xml
+++ b/core/ipc/sink/xml/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.core.ipc</groupId>
     <artifactId>org.opennms.core.ipc.sink</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.core.ipc.sink</groupId>

--- a/core/jmx/api/pom.xml
+++ b/core/jmx/api/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.core</groupId>
     <artifactId>org.opennms.core.jmx</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
 	 <relativePath>..</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/core/jmx/impl/pom.xml
+++ b/core/jmx/impl/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.core</groupId>
     <artifactId>org.opennms.core.jmx</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
 	 <relativePath>..</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/core/jmx/pom.xml
+++ b/core/jmx/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>org.opennms.core</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.core</groupId>

--- a/core/jstl-support/pom.xml
+++ b/core/jstl-support/pom.xml
@@ -2,7 +2,7 @@
 <parent>
     <groupId>org.opennms</groupId>
     <artifactId>org.opennms.core</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
 </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.core</groupId>

--- a/core/lib/pom.xml
+++ b/core/lib/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>org.opennms.core</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.core</groupId>

--- a/core/logging-api/pom.xml
+++ b/core/logging-api/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>org.opennms.core</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.core</groupId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>opennms</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>org.opennms.core</artifactId>

--- a/core/profiler/pom.xml
+++ b/core/profiler/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.opennms</groupId>
         <artifactId>org.opennms.core</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.opennms.core</groupId>

--- a/core/runtime/pom.xml
+++ b/core/runtime/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>org.opennms.core</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.core</groupId>

--- a/core/schema/pom.xml
+++ b/core/schema/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>org.opennms.core</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.core</groupId>

--- a/core/snmp/api/pom.xml
+++ b/core/snmp/api/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.core</groupId>
     <artifactId>org.opennms.core.snmp</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
 	 <relativePath>..</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/core/snmp/commands/pom.xml
+++ b/core/snmp/commands/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.opennms.core</groupId>
     <artifactId>org.opennms.core.snmp</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/core/snmp/impl-joesnmp/pom.xml
+++ b/core/snmp/impl-joesnmp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.core</groupId>
     <artifactId>org.opennms.core.snmp</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
 	 <relativePath>..</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/core/snmp/impl-mock/pom.xml
+++ b/core/snmp/impl-mock/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.core</groupId>
     <artifactId>org.opennms.core.snmp</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
 	 <relativePath>..</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/core/snmp/impl-snmp4j/pom.xml
+++ b/core/snmp/impl-snmp4j/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.core</groupId>
     <artifactId>org.opennms.core.snmp</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.core.snmp</groupId>

--- a/core/snmp/integration-tests/pom.xml
+++ b/core/snmp/integration-tests/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.core</groupId>
     <artifactId>org.opennms.core.snmp</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
 	 <relativePath>..</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/core/snmp/joesnmp/pom.xml
+++ b/core/snmp/joesnmp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.core</groupId>
     <artifactId>org.opennms.core.snmp</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
 	 <relativePath>..</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/core/snmp/pom.xml
+++ b/core/snmp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>org.opennms.core</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.core</groupId>

--- a/core/snmp/proxy-rpc-impl/pom.xml
+++ b/core/snmp/proxy-rpc-impl/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.core</groupId>
     <artifactId>org.opennms.core.snmp</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.core.snmp</groupId>

--- a/core/snmp/proxy-rpc-tests/pom.xml
+++ b/core/snmp/proxy-rpc-tests/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.core</groupId>
     <artifactId>org.opennms.core.snmp</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.core.snmp</groupId>

--- a/core/soa/pom.xml
+++ b/core/soa/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>org.opennms.core</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.core</groupId>

--- a/core/spring-web/pom.xml
+++ b/core/spring-web/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>org.opennms.core</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.core</groupId>

--- a/core/spring/pom.xml
+++ b/core/spring/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>org.opennms.core</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.core</groupId>

--- a/core/sysprops/pom.xml
+++ b/core/sysprops/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>org.opennms.core</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.core</groupId>

--- a/core/tasks/pom.xml
+++ b/core/tasks/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>org.opennms.core</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.core</groupId>

--- a/core/test-api/activemq/pom.xml
+++ b/core/test-api/activemq/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.core</groupId>
     <artifactId>org.opennms.core.test-api</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.core.test-api</groupId>

--- a/core/test-api/alarms/pom.xml
+++ b/core/test-api/alarms/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.core</groupId>
     <artifactId>org.opennms.core.test-api</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.core.test-api</groupId>

--- a/core/test-api/camel/pom.xml
+++ b/core/test-api/camel/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.core</groupId>
     <artifactId>org.opennms.core.test-api</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.core.test-api</groupId>

--- a/core/test-api/collection/pom.xml
+++ b/core/test-api/collection/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.core</groupId>
     <artifactId>org.opennms.core.test-api</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.core.test-api</groupId>

--- a/core/test-api/db/pom.xml
+++ b/core/test-api/db/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.core</groupId>
     <artifactId>org.opennms.core.test-api</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.core.test-api</groupId>

--- a/core/test-api/dns/pom.xml
+++ b/core/test-api/dns/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.core</groupId>
     <artifactId>org.opennms.core.test-api</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.core.test-api</groupId>

--- a/core/test-api/elasticsearch/pom.xml
+++ b/core/test-api/elasticsearch/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.core</groupId>
     <artifactId>org.opennms.core.test-api</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.core.test-api</groupId>

--- a/core/test-api/http/pom.xml
+++ b/core/test-api/http/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.core</groupId>
     <artifactId>org.opennms.core.test-api</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.core.test-api</groupId>

--- a/core/test-api/kafka/pom.xml
+++ b/core/test-api/kafka/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.core</groupId>
     <artifactId>org.opennms.core.test-api</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.core.test-api</groupId>

--- a/core/test-api/karaf/pom.xml
+++ b/core/test-api/karaf/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.core</groupId>
     <artifactId>org.opennms.core.test-api</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.core.test-api</groupId>

--- a/core/test-api/lib/pom.xml
+++ b/core/test-api/lib/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.core</groupId>
     <artifactId>org.opennms.core.test-api</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.core.test-api</groupId>

--- a/core/test-api/pom.xml
+++ b/core/test-api/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>org.opennms.core</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.core</groupId>

--- a/core/test-api/rest/pom.xml
+++ b/core/test-api/rest/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.core</groupId>
     <artifactId>org.opennms.core.test-api</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.core.test-api</groupId>

--- a/core/test-api/schema/a/pom.xml
+++ b/core/test-api/schema/a/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.core.test-api</groupId>
     <artifactId>org.opennms.core.test-api.schema</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.core.test-api.schema</groupId>

--- a/core/test-api/schema/b/pom.xml
+++ b/core/test-api/schema/b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.core.test-api</groupId>
     <artifactId>org.opennms.core.test-api.schema</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.core.test-api.schema</groupId>

--- a/core/test-api/schema/pom.xml
+++ b/core/test-api/schema/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.core</groupId>
     <artifactId>org.opennms.core.test-api</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.core.test-api</groupId>

--- a/core/test-api/services/pom.xml
+++ b/core/test-api/services/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.core</groupId>
     <artifactId>org.opennms.core.test-api</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.core.test-api</groupId>

--- a/core/test-api/snmp/pom.xml
+++ b/core/test-api/snmp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.core</groupId>
     <artifactId>org.opennms.core.test-api</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.core.test-api</groupId>

--- a/core/test-api/xml/pom.xml
+++ b/core/test-api/xml/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.core</groupId>
     <artifactId>org.opennms.core.test-api</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.core.test-api</groupId>

--- a/core/upgrade/pom.xml
+++ b/core/upgrade/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>org.opennms.core</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.core</groupId>

--- a/core/web-assets/package.json
+++ b/core/web-assets/package.json
@@ -1,6 +1,6 @@
 {
     "name": "opennms-core-web-assets",
-    "version": "24.0.0-SNAPSHOT",
+    "version": "25.0.0-SNAPSHOT",
     "description": "JavaScript Web Components for OpenNMS",
     "license": "AGPL-3.0",
     "repository": {

--- a/core/web-assets/pom.xml
+++ b/core/web-assets/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>org.opennms.core</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.core</groupId>

--- a/core/web/pom.xml
+++ b/core/web/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>org.opennms.core</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.core</groupId>

--- a/core/xml/pom.xml
+++ b/core/xml/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>org.opennms.core</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.core</groupId>

--- a/dependencies/activemq-web/pom.xml
+++ b/dependencies/activemq-web/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>dependencies</artifactId>
     <groupId>org.opennms</groupId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.dependencies</groupId>

--- a/dependencies/activemq/pom.xml
+++ b/dependencies/activemq/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>dependencies</artifactId>
     <groupId>org.opennms</groupId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.dependencies</groupId>

--- a/dependencies/asterisk/pom.xml
+++ b/dependencies/asterisk/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>dependencies</artifactId>
     <groupId>org.opennms</groupId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.dependencies</groupId>

--- a/dependencies/atomikos/pom.xml
+++ b/dependencies/atomikos/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>dependencies</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.dependencies</groupId>

--- a/dependencies/aws/pom.xml
+++ b/dependencies/aws/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>dependencies</artifactId>
     <groupId>org.opennms</groupId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.dependencies</groupId>

--- a/dependencies/camel-test/pom.xml
+++ b/dependencies/camel-test/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>dependencies</artifactId>
     <groupId>org.opennms</groupId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.dependencies</groupId>

--- a/dependencies/camel/pom.xml
+++ b/dependencies/camel/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>dependencies</artifactId>
     <groupId>org.opennms</groupId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.dependencies</groupId>

--- a/dependencies/cxf/pom.xml
+++ b/dependencies/cxf/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>dependencies</artifactId>
     <groupId>org.opennms</groupId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.dependencies</groupId>

--- a/dependencies/dnsjava/pom.xml
+++ b/dependencies/dnsjava/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>dependencies</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.dependencies</groupId>

--- a/dependencies/drools/pom.xml
+++ b/dependencies/drools/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>dependencies</artifactId>
     <groupId>org.opennms</groupId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.dependencies</groupId>

--- a/dependencies/felix/pom.xml
+++ b/dependencies/felix/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>dependencies</artifactId>
     <groupId>org.opennms</groupId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.dependencies</groupId>

--- a/dependencies/hibernate/pom.xml
+++ b/dependencies/hibernate/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>dependencies</artifactId>
     <groupId>org.opennms</groupId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.dependencies</groupId>

--- a/dependencies/jasper/pom.xml
+++ b/dependencies/jasper/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>dependencies</artifactId>
     <groupId>org.opennms</groupId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.dependencies</groupId>

--- a/dependencies/jasypt/pom.xml
+++ b/dependencies/jasypt/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>dependencies</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.dependencies</groupId>

--- a/dependencies/javamail/pom.xml
+++ b/dependencies/javamail/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>dependencies</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.dependencies</groupId>

--- a/dependencies/jaxb/pom.xml
+++ b/dependencies/jaxb/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>dependencies</artifactId>
     <groupId>org.opennms</groupId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.dependencies</groupId>

--- a/dependencies/jcifs/pom.xml
+++ b/dependencies/jcifs/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>dependencies</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.dependencies</groupId>

--- a/dependencies/jfreechart/pom.xml
+++ b/dependencies/jfreechart/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>dependencies</artifactId>
     <groupId>org.opennms</groupId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.dependencies</groupId>

--- a/dependencies/jinterop/pom.xml
+++ b/dependencies/jinterop/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>dependencies</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.dependencies</groupId>

--- a/dependencies/jmx/pom.xml
+++ b/dependencies/jmx/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>dependencies</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/dependencies/jna/pom.xml
+++ b/dependencies/jna/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>dependencies</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.dependencies</groupId>

--- a/dependencies/jnlp/pom.xml
+++ b/dependencies/jnlp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>dependencies</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.dependencies</groupId>

--- a/dependencies/jradius-extended/pom.xml
+++ b/dependencies/jradius-extended/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>dependencies</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.dependencies</groupId>

--- a/dependencies/jradius/pom.xml
+++ b/dependencies/jradius/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>dependencies</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.dependencies</groupId>

--- a/dependencies/jrobin/pom.xml
+++ b/dependencies/jrobin/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>dependencies</artifactId>
     <groupId>org.opennms</groupId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.dependencies</groupId>

--- a/dependencies/jrrd/pom.xml
+++ b/dependencies/jrrd/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>dependencies</artifactId>
     <groupId>org.opennms</groupId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.dependencies</groupId>

--- a/dependencies/jrrd2/pom.xml
+++ b/dependencies/jrrd2/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>dependencies</artifactId>
     <groupId>org.opennms</groupId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.dependencies</groupId>

--- a/dependencies/jstl/pom.xml
+++ b/dependencies/jstl/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>dependencies</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.dependencies</groupId>

--- a/dependencies/liquibase/pom.xml
+++ b/dependencies/liquibase/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>dependencies</artifactId>
     <groupId>org.opennms</groupId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.dependencies</groupId>

--- a/dependencies/mina/pom.xml
+++ b/dependencies/mina/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>dependencies</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.dependencies</groupId>

--- a/dependencies/netty/pom.xml
+++ b/dependencies/netty/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>dependencies</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.dependencies</groupId>

--- a/dependencies/newts/pom.xml
+++ b/dependencies/newts/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>dependencies</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.dependencies</groupId>

--- a/dependencies/owasp/pom.xml
+++ b/dependencies/owasp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>dependencies</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.dependencies</groupId>

--- a/dependencies/pax-exam/pom.xml
+++ b/dependencies/pax-exam/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>dependencies</artifactId>
     <groupId>org.opennms</groupId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.dependencies</groupId>

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>opennms</artifactId>
     <groupId>org.opennms</groupId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>dependencies</artifactId>

--- a/dependencies/quartz/pom.xml
+++ b/dependencies/quartz/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>dependencies</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.dependencies</groupId>

--- a/dependencies/rancid/pom.xml
+++ b/dependencies/rancid/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>dependencies</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.dependencies</groupId>

--- a/dependencies/servlet/pom.xml
+++ b/dependencies/servlet/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>dependencies</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.dependencies</groupId>

--- a/dependencies/smack/pom.xml
+++ b/dependencies/smack/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>dependencies</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.dependencies</groupId>

--- a/dependencies/smslib/pom.xml
+++ b/dependencies/smslib/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>dependencies</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.dependencies</groupId>

--- a/dependencies/snmp-test/pom.xml
+++ b/dependencies/snmp-test/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>dependencies</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.dependencies</groupId>

--- a/dependencies/snmp/pom.xml
+++ b/dependencies/snmp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>dependencies</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.dependencies</groupId>

--- a/dependencies/snmp4j-agent/pom.xml
+++ b/dependencies/snmp4j-agent/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>dependencies</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.dependencies</groupId>

--- a/dependencies/snmp4j/pom.xml
+++ b/dependencies/snmp4j/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>dependencies</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.dependencies</groupId>

--- a/dependencies/spring-security-core/pom.xml
+++ b/dependencies/spring-security-core/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>dependencies</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.dependencies</groupId>

--- a/dependencies/spring-security/pom.xml
+++ b/dependencies/spring-security/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>dependencies</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.dependencies</groupId>

--- a/dependencies/spring-test/pom.xml
+++ b/dependencies/spring-test/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>dependencies</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.dependencies</groupId>

--- a/dependencies/spring-web/pom.xml
+++ b/dependencies/spring-web/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>dependencies</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.dependencies</groupId>

--- a/dependencies/spring/pom.xml
+++ b/dependencies/spring/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>dependencies</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.dependencies</groupId>

--- a/dependencies/tracker/pom.xml
+++ b/dependencies/tracker/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>dependencies</artifactId>
     <groupId>org.opennms</groupId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.dependencies</groupId>

--- a/dependencies/twitter4j/pom.xml
+++ b/dependencies/twitter4j/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>dependencies</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.dependencies</groupId>

--- a/features/activemq/broker/pom.xml
+++ b/features/activemq/broker/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>org.opennms.features.activemq</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/features/activemq/component/pom.xml
+++ b/features/activemq/component/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>org.opennms.features.activemq</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <packaging>bundle</packaging>
   <groupId>org.opennms.features.activemq</groupId>

--- a/features/activemq/pom.xml
+++ b/features/activemq/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>org.opennms.features</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/features/activemq/pool/pom.xml
+++ b/features/activemq/pool/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>org.opennms.features.activemq</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <packaging>bundle</packaging>
   <groupId>org.opennms.features.activemq</groupId>

--- a/features/alarm-change-notifier/README.md
+++ b/features/alarm-change-notifier/README.md
@@ -5,7 +5,7 @@
 ~~~~
 project groupId: org.opennms.plugins
 project name:    alarm-change-notifier
-version:         24.0.0-SNAPSHOT
+version:         25.0.0-SNAPSHOT
 ~~~~
 
 ## Description
@@ -77,10 +77,10 @@ ssh -p 8101 admin@localhost
 to install the feature in karaf use
 
 ~~~~
-karaf@root> feature:addurl mvn:org.opennms.plugins/alarm-change-notifier/24.0.0-SNAPSHOT/xml/features
+karaf@root> feature:addurl mvn:org.opennms.plugins/alarm-change-notifier/25.0.0-SNAPSHOT/xml/features
 karaf@root> feature:install alarm-change-notifier
 
-(or feature:install alarm-change-notifier/24.0.0-SNAPSHOT for a specific version of the feature)
+(or feature:install alarm-change-notifier/25.0.0-SNAPSHOT for a specific version of the feature)
 ~~~~
 
 

--- a/features/alarm-change-notifier/feature/pom.xml
+++ b/features/alarm-change-notifier/feature/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.plugins</groupId>
     <artifactId>alarm-change-notifier.parent</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
 
   <!-- Feature Definition -->

--- a/features/alarm-change-notifier/main-module/pom.xml
+++ b/features/alarm-change-notifier/main-module/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.opennms.plugins</groupId>
     <artifactId>alarm-change-notifier.parent</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
 
   <!-- LicenceAuthenticator -->

--- a/features/alarm-change-notifier/pg-jdbc-utils/pom.xml
+++ b/features/alarm-change-notifier/pg-jdbc-utils/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.plugins</groupId>
     <artifactId>alarm-change-notifier.parent</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
 
   <!-- LicenceAuthenticator -->

--- a/features/alarm-change-notifier/pom.xml
+++ b/features/alarm-change-notifier/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>org.opennms.features</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/features/alarm-change-notifier/product-descriptor/pom.xml
+++ b/features/alarm-change-notifier/product-descriptor/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.plugins</groupId>
     <artifactId>alarm-change-notifier.parent</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
 
   <!-- ProductDescriptor -->

--- a/features/alarms/history/api/pom.xml
+++ b/features/alarms/history/api/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features.alarms</groupId>
     <artifactId>org.opennms.features.alarms.history</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.alarms.history</groupId>

--- a/features/alarms/history/elastic/pom.xml
+++ b/features/alarms/history/elastic/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features.alarms</groupId>
     <artifactId>org.opennms.features.alarms.history</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.alarms.history</groupId>

--- a/features/alarms/history/pom.xml
+++ b/features/alarms/history/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>org.opennms.features.alarms</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.alarms</groupId>

--- a/features/alarms/history/rest/api/pom.xml
+++ b/features/alarms/history/rest/api/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features.alarms.history</groupId>
     <artifactId>org.opennms.features.alarms.history.rest</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.alarms.history.rest</groupId>

--- a/features/alarms/history/rest/impl/pom.xml
+++ b/features/alarms/history/rest/impl/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features.alarms.history</groupId>
     <artifactId>org.opennms.features.alarms.history.rest</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.alarms.history.rest</groupId>

--- a/features/alarms/history/rest/pom.xml
+++ b/features/alarms/history/rest/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features.alarms</groupId>
     <artifactId>org.opennms.features.alarms.history</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.alarms.history</groupId>

--- a/features/alarms/pom.xml
+++ b/features/alarms/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>org.opennms.features</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features</groupId>

--- a/features/amqp/alarm-northbounder/pom.xml
+++ b/features/amqp/alarm-northbounder/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>org.opennms.features.amqp</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/features/amqp/common/pom.xml
+++ b/features/amqp/common/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>org.opennms.features.amqp</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/features/amqp/event-forwarder/pom.xml
+++ b/features/amqp/event-forwarder/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>org.opennms.features.amqp</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/features/amqp/event-receiver/pom.xml
+++ b/features/amqp/event-receiver/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>org.opennms.features.amqp</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/features/amqp/pom.xml
+++ b/features/amqp/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>org.opennms.features</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/features/api-layer/pom.xml
+++ b/features/api-layer/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.opennms</groupId>
         <artifactId>org.opennms.features</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.opennms.features</groupId>

--- a/features/bsm/daemon/pom.xml
+++ b/features/bsm/daemon/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>org.opennms.features.bsm</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.bsm</groupId>

--- a/features/bsm/persistence/api/pom.xml
+++ b/features/bsm/persistence/api/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features.bsm</groupId>
     <artifactId>org.opennms.features.bsm.persistence</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>org.opennms.features.bsm.persistence.api</artifactId>

--- a/features/bsm/persistence/impl/pom.xml
+++ b/features/bsm/persistence/impl/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features.bsm</groupId>
     <artifactId>org.opennms.features.bsm.persistence</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>org.opennms.features.bsm.persistence.impl</artifactId>

--- a/features/bsm/persistence/pom.xml
+++ b/features/bsm/persistence/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>org.opennms.features.bsm</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.bsm</groupId>

--- a/features/bsm/pom.xml
+++ b/features/bsm/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>org.opennms.features</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features</groupId>

--- a/features/bsm/rest/api/pom.xml
+++ b/features/bsm/rest/api/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features.bsm</groupId>
     <artifactId>org.opennms.features.bsm.rest</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>org.opennms.features.bsm.rest.api</artifactId>

--- a/features/bsm/rest/impl/pom.xml
+++ b/features/bsm/rest/impl/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features.bsm</groupId>
     <artifactId>org.opennms.features.bsm.rest</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>org.opennms.features.bsm.rest.impl</artifactId>

--- a/features/bsm/rest/pom.xml
+++ b/features/bsm/rest/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>org.opennms.features.bsm</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.bsm</groupId>

--- a/features/bsm/service/api/pom.xml
+++ b/features/bsm/service/api/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features.bsm</groupId>
     <artifactId>org.opennms.features.bsm.service</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>org.opennms.features.bsm.service.api</artifactId>

--- a/features/bsm/service/impl/pom.xml
+++ b/features/bsm/service/impl/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features.bsm</groupId>
     <artifactId>org.opennms.features.bsm.service</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>org.opennms.features.bsm.service.impl</artifactId>

--- a/features/bsm/service/pom.xml
+++ b/features/bsm/service/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>org.opennms.features.bsm</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.bsm</groupId>

--- a/features/bsm/shell-commands/pom.xml
+++ b/features/bsm/shell-commands/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>org.opennms.features.bsm</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.bsm</groupId>

--- a/features/bsm/test-util/pom.xml
+++ b/features/bsm/test-util/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.opennms.features</groupId>
         <artifactId>org.opennms.features.bsm</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
     <groupId>org.opennms.features.bsm</groupId>
     <artifactId>test-util</artifactId>

--- a/features/bsm/vaadin-adminpage/pom.xml
+++ b/features/bsm/vaadin-adminpage/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.opennms.features</groupId>
         <artifactId>org.opennms.features.bsm</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
     <groupId>org.opennms.features.bsm</groupId>
     <artifactId>vaadin-adminpage</artifactId>

--- a/features/collection/api/pom.xml
+++ b/features/collection/api/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>org.opennms.features.collection</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.collection</groupId>

--- a/features/collection/client-rpc/pom.xml
+++ b/features/collection/client-rpc/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>org.opennms.features.collection</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.collection</groupId>

--- a/features/collection/collectors/pom.xml
+++ b/features/collection/collectors/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>org.opennms.features.collection</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.collection</groupId>

--- a/features/collection/core/pom.xml
+++ b/features/collection/core/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>org.opennms.features.collection</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.collection</groupId>

--- a/features/collection/persistence-osgi/pom.xml
+++ b/features/collection/persistence-osgi/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>org.opennms.features.collection</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.collection</groupId>

--- a/features/collection/persistence-rrd/pom.xml
+++ b/features/collection/persistence-rrd/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>org.opennms.features.collection</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.collection</groupId>

--- a/features/collection/persistence-tcp/pom.xml
+++ b/features/collection/persistence-tcp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>org.opennms.features.collection</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.collection</groupId>

--- a/features/collection/pom.xml
+++ b/features/collection/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>org.opennms.features</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features</groupId>

--- a/features/collection/sampler/pom.xml
+++ b/features/collection/sampler/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>org.opennms.features.collection</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.collection</groupId>

--- a/features/collection/shell-commands/pom.xml
+++ b/features/collection/shell-commands/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>org.opennms.features.collection</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.collection</groupId>

--- a/features/collection/test-api/pom.xml
+++ b/features/collection/test-api/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>org.opennms.features.collection</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.collection</groupId>

--- a/features/container/minion/pom.xml
+++ b/features/container/minion/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.opennms.features</groupId>
         <artifactId>container-parent</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.opennms.features.container</groupId>

--- a/features/container/pom.xml
+++ b/features/container/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.opennms</groupId>
         <artifactId>org.opennms.features</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.opennms.features</groupId>

--- a/features/container/sentinel/pom.xml
+++ b/features/container/sentinel/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.opennms.features</groupId>
         <artifactId>container-parent</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.opennms.features.container</groupId>

--- a/features/datachoices/pom.xml
+++ b/features/datachoices/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>org.opennms.features</artifactId>
         <groupId>org.opennms</groupId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>datachoices</artifactId>

--- a/features/dhcpd/pom.xml
+++ b/features/dhcpd/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.opennms</groupId>
         <artifactId>org.opennms.features</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.opennms.features</groupId>

--- a/features/discovery/pom.xml
+++ b/features/discovery/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>org.opennms.features</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features</groupId>

--- a/features/distributed/collection/pom.xml
+++ b/features/distributed/collection/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.opennms.features.distributed</groupId>
         <artifactId>distributed-parent</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.opennms.features.distributed</groupId>

--- a/features/distributed/coordination/api/pom.xml
+++ b/features/distributed/coordination/api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.opennms.features.distributed</groupId>
         <artifactId>coordination-parent</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>coordination-api</artifactId>

--- a/features/distributed/coordination/common/pom.xml
+++ b/features/distributed/coordination/common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.opennms.features.distributed</groupId>
         <artifactId>coordination-parent</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>coordination-common</artifactId>

--- a/features/distributed/coordination/pom.xml
+++ b/features/distributed/coordination/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.opennms.features.distributed</groupId>
         <artifactId>distributed-parent</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>coordination-parent</artifactId>

--- a/features/distributed/coordination/shell/pom.xml
+++ b/features/distributed/coordination/shell/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.opennms.features.distributed</groupId>
         <artifactId>coordination-parent</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>coordination-shell</artifactId>

--- a/features/distributed/coordination/zookeeper/pom.xml
+++ b/features/distributed/coordination/zookeeper/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.opennms.features.distributed</groupId>
         <artifactId>coordination-parent</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>coordination-zookeeper</artifactId>

--- a/features/distributed/core/api/pom.xml
+++ b/features/distributed/core/api/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.opennms.features.distributed</groupId>
         <artifactId>core-parent</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>core-api</artifactId>

--- a/features/distributed/core/impl/pom.xml
+++ b/features/distributed/core/impl/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.opennms.features.distributed</groupId>
         <artifactId>core-parent</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>core-impl</artifactId>

--- a/features/distributed/core/jms/pom.xml
+++ b/features/distributed/core/jms/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.opennms.features.distributed</groupId>
         <artifactId>core-parent</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>jms</artifactId>

--- a/features/distributed/core/pom.xml
+++ b/features/distributed/core/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.opennms.features.distributed</groupId>
         <artifactId>distributed-parent</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>core-parent</artifactId>

--- a/features/distributed/core/shell/pom.xml
+++ b/features/distributed/core/shell/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.opennms.features.distributed</groupId>
         <artifactId>core-parent</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>shell</artifactId>

--- a/features/distributed/dao/api/pom.xml
+++ b/features/distributed/dao/api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.opennms.features.distributed</groupId>
         <artifactId>org.opennms.features.distributed.dao</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.opennms.features.distributed</groupId>

--- a/features/distributed/dao/distributed/pom.xml
+++ b/features/distributed/dao/distributed/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features.distributed</groupId>
     <artifactId>org.opennms.features.distributed.dao</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.distributed</groupId>

--- a/features/distributed/dao/healthcheck/pom.xml
+++ b/features/distributed/dao/healthcheck/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features.distributed</groupId>
     <artifactId>org.opennms.features.distributed.dao</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.distributed</groupId>

--- a/features/distributed/dao/impl/pom.xml
+++ b/features/distributed/dao/impl/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.opennms.features.distributed</groupId>
         <artifactId>org.opennms.features.distributed.dao</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.opennms.features.distributed</groupId>

--- a/features/distributed/dao/pom.xml
+++ b/features/distributed/dao/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.opennms.features.distributed</groupId>
         <artifactId>distributed-parent</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>org.opennms.features.distributed.dao</artifactId>

--- a/features/distributed/dao/shell/pom.xml
+++ b/features/distributed/dao/shell/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.opennms.features.distributed</groupId>
         <artifactId>org.opennms.features.distributed.dao</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.opennms.features.distributed</groupId>

--- a/features/distributed/dao/test/pom.xml
+++ b/features/distributed/dao/test/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.opennms.features.distributed</groupId>
         <artifactId>org.opennms.features.distributed.dao</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.opennms.features.distributed</groupId>

--- a/features/distributed/datasource/pom.xml
+++ b/features/distributed/datasource/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.opennms.features.distributed</groupId>
         <artifactId>distributed-parent</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.opennms.features.distributed</groupId>

--- a/features/distributed/pom.xml
+++ b/features/distributed/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>org.opennms.features</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.distributed</groupId>

--- a/features/eif-adapter/pom.xml
+++ b/features/eif-adapter/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>org.opennms.features</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/features/enlinkd/adapters/collectors/bridge/pom.xml
+++ b/features/enlinkd/adapters/collectors/bridge/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features.enlinkd</groupId>
     <artifactId>org.opennms.features.enlinkd.adapters.collectors</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>org.opennms.features.enlinkd.adapters.collectors.bridge</artifactId>

--- a/features/enlinkd/adapters/collectors/cdp/pom.xml
+++ b/features/enlinkd/adapters/collectors/cdp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features.enlinkd</groupId>
     <artifactId>org.opennms.features.enlinkd.adapters.collectors</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>org.opennms.features.enlinkd.adapters.collectors.cdp</artifactId>

--- a/features/enlinkd/adapters/collectors/ipnettomedia/pom.xml
+++ b/features/enlinkd/adapters/collectors/ipnettomedia/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features.enlinkd</groupId>
     <artifactId>org.opennms.features.enlinkd.adapters.collectors</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>org.opennms.features.enlinkd.adapters.collectors.ipnettomedia</artifactId>

--- a/features/enlinkd/adapters/collectors/isis/pom.xml
+++ b/features/enlinkd/adapters/collectors/isis/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features.enlinkd</groupId>
     <artifactId>org.opennms.features.enlinkd.adapters.collectors</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>org.opennms.features.enlinkd.adapters.collectors.isis</artifactId>

--- a/features/enlinkd/adapters/collectors/lldp/pom.xml
+++ b/features/enlinkd/adapters/collectors/lldp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features.enlinkd</groupId>
     <artifactId>org.opennms.features.enlinkd.adapters.collectors</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>org.opennms.features.enlinkd.adapters.collectors.lldp</artifactId>

--- a/features/enlinkd/adapters/collectors/ospf/pom.xml
+++ b/features/enlinkd/adapters/collectors/ospf/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features.enlinkd</groupId>
     <artifactId>org.opennms.features.enlinkd.adapters.collectors</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>org.opennms.features.enlinkd.adapters.collectors.ospf</artifactId>

--- a/features/enlinkd/adapters/collectors/pom.xml
+++ b/features/enlinkd/adapters/collectors/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features.enlinkd</groupId>
     <artifactId>org.opennms.features.enlinkd.adapters</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>org.opennms.features.enlinkd.adapters.collectors</artifactId>

--- a/features/enlinkd/adapters/common/pom.xml
+++ b/features/enlinkd/adapters/common/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features.enlinkd</groupId>
     <artifactId>org.opennms.features.enlinkd.adapters</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>org.opennms.features.enlinkd.adapters.common</artifactId>

--- a/features/enlinkd/adapters/pom.xml
+++ b/features/enlinkd/adapters/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>org.opennms.features.enlinkd</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.enlinkd</groupId>

--- a/features/enlinkd/adapters/updaters/bridge/pom.xml
+++ b/features/enlinkd/adapters/updaters/bridge/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features.enlinkd</groupId>
     <artifactId>org.opennms.features.enlinkd.adapters.updaters</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>org.opennms.features.enlinkd.adapters.updaters.bridge</artifactId>

--- a/features/enlinkd/adapters/updaters/cdp/pom.xml
+++ b/features/enlinkd/adapters/updaters/cdp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features.enlinkd</groupId>
     <artifactId>org.opennms.features.enlinkd.adapters.updaters</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>org.opennms.features.enlinkd.adapters.updaters.cdp</artifactId>

--- a/features/enlinkd/adapters/updaters/isis/pom.xml
+++ b/features/enlinkd/adapters/updaters/isis/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features.enlinkd</groupId>
     <artifactId>org.opennms.features.enlinkd.adapters.updaters</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>org.opennms.features.enlinkd.adapters.updaters.isis</artifactId>

--- a/features/enlinkd/adapters/updaters/lldp/pom.xml
+++ b/features/enlinkd/adapters/updaters/lldp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features.enlinkd</groupId>
     <artifactId>org.opennms.features.enlinkd.adapters.updaters</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>org.opennms.features.enlinkd.adapters.updaters.lldp</artifactId>

--- a/features/enlinkd/adapters/updaters/nodes/pom.xml
+++ b/features/enlinkd/adapters/updaters/nodes/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features.enlinkd</groupId>
     <artifactId>org.opennms.features.enlinkd.adapters.updaters</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>org.opennms.features.enlinkd.adapters.updaters.nodes</artifactId>

--- a/features/enlinkd/adapters/updaters/ospf/pom.xml
+++ b/features/enlinkd/adapters/updaters/ospf/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features.enlinkd</groupId>
     <artifactId>org.opennms.features.enlinkd.adapters.updaters</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>org.opennms.features.enlinkd.adapters.updaters.ospf</artifactId>

--- a/features/enlinkd/adapters/updaters/pom.xml
+++ b/features/enlinkd/adapters/updaters/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features.enlinkd</groupId>
     <artifactId>org.opennms.features.enlinkd.adapters</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>org.opennms.features.enlinkd.adapters.updaters</artifactId>

--- a/features/enlinkd/api/pom.xml
+++ b/features/enlinkd/api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>org.opennms.features.enlinkd</artifactId>
         <groupId>org.opennms.features</groupId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.opennms.features.enlinkd</groupId>

--- a/features/enlinkd/config/pom.xml
+++ b/features/enlinkd/config/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>org.opennms.features.enlinkd</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.enlinkd</groupId>

--- a/features/enlinkd/daemon/pom.xml
+++ b/features/enlinkd/daemon/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>org.opennms.features.enlinkd</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.enlinkd</groupId>

--- a/features/enlinkd/daemon/src/main/java/org/opennms/netmgt/enlinkd/EnhancedLinkd.java
+++ b/features/enlinkd/daemon/src/main/java/org/opennms/netmgt/enlinkd/EnhancedLinkd.java
@@ -772,6 +772,9 @@ public class EnhancedLinkd extends AbstractServiceDaemon implements ReloadableTo
     @Override
     public void reloadTopology() {
         LOG.info("reloadTopology: reload enlinkd topology updaters");
+        LOG.debug("reloadTopology: Loading Bridge Topology.....");
+        m_bridgeTopologyService.load();
+        LOG.debug("reloadTopology: Bridge Topology Loaded");
         for (ProtocolSupported protocol :ProtocolSupported.values()) {
             forceTopologyUpdaterRun(protocol);
             runTopologyUpdater(protocol);

--- a/features/enlinkd/generator/pom.xml
+++ b/features/enlinkd/generator/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>org.opennms.features.enlinkd</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <properties>
     <bundle.symbolicName>org.opennms.features.enlinkd.generator</bundle.symbolicName>

--- a/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/TopologyGenerator.java
+++ b/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/TopologyGenerator.java
@@ -30,6 +30,7 @@ package org.opennms.enlinkd.generator;
 
 import java.util.function.Consumer;
 
+import org.opennms.enlinkd.generator.protocol.BridgeProtocol;
 import org.opennms.enlinkd.generator.protocol.CdpProtocol;
 import org.opennms.enlinkd.generator.protocol.IsIsProtocol;
 import org.opennms.enlinkd.generator.protocol.LldpProtocol;
@@ -97,6 +98,8 @@ public class TopologyGenerator {
             return new LldpProtocol(topologySettings, topologyContext);
         } else if (Protocol.ospf == protocol) {
             return new OspfProtocol(topologySettings, topologyContext);
+        } else if (Protocol.bridgeBridge == protocol) {
+            return new BridgeProtocol(topologySettings, topologyContext);
         } else {
             throw new IllegalArgumentException("Don't know this protocol: " + topologySettings.getProtocol());
         }

--- a/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/TopologyGenerator.java
+++ b/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/TopologyGenerator.java
@@ -66,7 +66,7 @@ public class TopologyGenerator {
     }
 
     public enum Protocol {
-        cdp, isis, lldp, ospf, bridgeBridge
+        cdp, isis, lldp, ospf, bridge
     }
 
     private TopologyContext topologyContext;
@@ -98,7 +98,7 @@ public class TopologyGenerator {
             return new LldpProtocol(topologySettings, topologyContext);
         } else if (Protocol.ospf == protocol) {
             return new OspfProtocol(topologySettings, topologyContext);
-        } else if (Protocol.bridgeBridge == protocol) {
+        } else if (Protocol.bridge == protocol) {
             return new BridgeProtocol(topologySettings, topologyContext);
         } else {
             throw new IllegalArgumentException("Don't know this protocol: " + topologySettings.getProtocol());

--- a/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/TopologyGenerator.java
+++ b/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/TopologyGenerator.java
@@ -65,7 +65,7 @@ public class TopologyGenerator {
     }
 
     public enum Protocol {
-        cdp, isis, lldp, ospf
+        cdp, isis, lldp, ospf, bridgeBridge
     }
 
     private TopologyContext topologyContext;

--- a/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/TopologyGenerator.java
+++ b/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/TopologyGenerator.java
@@ -79,9 +79,9 @@ public class TopologyGenerator {
 
 
     public void generateTopology(TopologySettings topologySettings) {
-        topologySettings.verify();
+        org.opennms.enlinkd.generator.protocol.Protocol protocol = getProtocol(topologySettings);
         deleteTopology(); // Let's first get rid of old generated topologies
-        getProtocol(topologySettings).createAndPersistNetwork();
+        protocol.createAndPersistNetwork();
     }
 
     public void deleteTopology() {

--- a/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/TopologyPersister.java
+++ b/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/TopologyPersister.java
@@ -32,6 +32,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.opennms.netmgt.dao.api.GenericPersistenceAccessor;
+import org.opennms.netmgt.enlinkd.model.BridgeBridgeLink;
 import org.opennms.netmgt.enlinkd.model.CdpElement;
 import org.opennms.netmgt.enlinkd.model.CdpLink;
 import org.opennms.netmgt.enlinkd.model.IsIsElement;
@@ -88,6 +89,7 @@ public class TopologyPersister {
                 IsIsElement.class,
                 LldpElement.class,
                 OspfLink.class,
+                BridgeBridgeLink.class,
                 OnmsIpInterface.class,
                 OnmsSnmpInterface.class);
 

--- a/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/TopologyPersister.java
+++ b/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/TopologyPersister.java
@@ -33,6 +33,7 @@ import java.util.List;
 
 import org.opennms.netmgt.dao.api.GenericPersistenceAccessor;
 import org.opennms.netmgt.enlinkd.model.BridgeBridgeLink;
+import org.opennms.netmgt.enlinkd.model.BridgeElement;
 import org.opennms.netmgt.enlinkd.model.CdpElement;
 import org.opennms.netmgt.enlinkd.model.CdpLink;
 import org.opennms.netmgt.enlinkd.model.IpNetToMedia;
@@ -95,6 +96,7 @@ public class TopologyPersister {
                 LldpElement.class,
                 OspfLink.class,
                 BridgeBridgeLink.class,
+                BridgeElement.class,
                 OnmsIpInterface.class,
                 OnmsSnmpInterface.class,
                 IpNetToMedia.class);

--- a/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/TopologyPersister.java
+++ b/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/TopologyPersister.java
@@ -35,6 +35,7 @@ import org.opennms.netmgt.dao.api.GenericPersistenceAccessor;
 import org.opennms.netmgt.enlinkd.model.BridgeBridgeLink;
 import org.opennms.netmgt.enlinkd.model.CdpElement;
 import org.opennms.netmgt.enlinkd.model.CdpLink;
+import org.opennms.netmgt.enlinkd.model.IpNetToMedia;
 import org.opennms.netmgt.enlinkd.model.IsIsElement;
 import org.opennms.netmgt.enlinkd.model.IsIsLink;
 import org.opennms.netmgt.enlinkd.model.LldpElement;
@@ -95,7 +96,8 @@ public class TopologyPersister {
                 OspfLink.class,
                 BridgeBridgeLink.class,
                 OnmsIpInterface.class,
-                OnmsSnmpInterface.class);
+                OnmsSnmpInterface.class,
+                IpNetToMedia.class);
 
         for (Class<?> clazz : deleteOperations) {
             deleteEntities(clazz);

--- a/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/TopologyPersister.java
+++ b/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/TopologyPersister.java
@@ -64,6 +64,10 @@ public class TopologyPersister {
         progressCallback.currentProgress("    Inserting of %s done.", entity.getClass().getSimpleName());
     }
 
+    public <E> void persist(E ... elements) {
+        persist(Arrays.asList(elements));
+    }
+
     public <E> void persist(List<E> elements) {
         if (elements.size() < 1) {
             return; // nothing do do

--- a/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/TopologyPersister.java
+++ b/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/TopologyPersister.java
@@ -34,6 +34,7 @@ import java.util.List;
 import org.opennms.netmgt.dao.api.GenericPersistenceAccessor;
 import org.opennms.netmgt.enlinkd.model.BridgeBridgeLink;
 import org.opennms.netmgt.enlinkd.model.BridgeElement;
+import org.opennms.netmgt.enlinkd.model.BridgeMacLink;
 import org.opennms.netmgt.enlinkd.model.CdpElement;
 import org.opennms.netmgt.enlinkd.model.CdpLink;
 import org.opennms.netmgt.enlinkd.model.IpNetToMedia;
@@ -96,6 +97,7 @@ public class TopologyPersister {
                 LldpElement.class,
                 OspfLink.class,
                 BridgeBridgeLink.class,
+                BridgeMacLink.class,
                 BridgeElement.class,
                 OnmsIpInterface.class,
                 OnmsSnmpInterface.class,

--- a/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/BridgeProtocol.java
+++ b/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/BridgeProtocol.java
@@ -81,143 +81,230 @@ public class BridgeProtocol extends Protocol<BridgeBridgeLink> {
         // Call with: enlinkd:generate-topology --protocol bridgeBridge --nodes 10 --snmpinterfaces 0 --ipinterfaces 0
         //      here is complete example of bridge topology
        // 4 nodes are bridges: nodeBridgeA, nodeBridgeB, nodeBridgeC, nodeBridgeD
-       //              B
+       //            bridge2
        //           --------  
        //           |      |
-       //           A      C
+       //        bridge1   bridge3
        //         -----
        //           |
-       //           D 
-       // 6 nodes are hosts: nodeHostE, nodeHostF, nodeHostG, nodeHostH, nodeHostI, nodeHostL 
+       //        bridge4
+       // 6 nodes are hosts: host5, host6, host7, host8, host9, host10 
        // generate 4 ipnettomedia without a corresponding node  
        // consider also that on port 1 of C is connected an HUB with a group of hosts connected
        // the hub has no snmp agent and therefore we are not to explore his mab forwarding table 
+       // we also follow the convention to start the port countin from the if of the node
+       // following an integer: so port11 -> is the first generated port of node with id 1
+       //                          port12 -> is the second generated port of node with id 1 
+       //                          port21 -> is the first generated port of node with id 2 
+       //                          port53 -> is the third generated port of node with id 5 
         
-        OnmsNode nodeBridgeA =  nodes.get(0);
-        OnmsNode nodeBridgeB =  nodes.get(1);
-        OnmsNode nodeBridgeC =  nodes.get(2);
-        OnmsNode nodeBridgeD =  nodes.get(3);
+        // this is the vlan id for all the bridgebridgelinks and bridgemaclinks...
+        int vlanid = 1;
+        OnmsNode bridge1 =  nodes.get(0);
+        OnmsNode bridge2 =  nodes.get(1);
+        OnmsNode bridge3 =  nodes.get(2);
+        OnmsNode bridge4 =  nodes.get(3);
 
-        // create bridge element
-        BridgeElement bridgeA = createBridgeElement(nodeBridgeA, 1 ,"default");
-        BridgeElement bridgeB = createBridgeElement(nodeBridgeB, 1 ,"default");
-        BridgeElement bridgeC = createBridgeElement(nodeBridgeC, 1 ,"default");
-        BridgeElement bridgeD = createBridgeElement(nodeBridgeD, 1 ,"default");
-
-        this.context.getTopologyPersister().persist(bridgeA,bridgeB,bridgeC,bridgeD);
+        // save bridge element
+        this.context.getTopologyPersister().persist(
+                    createBridgeElement(bridge1, vlanid ,"default"),
+                    createBridgeElement(bridge2, vlanid ,"default"),
+                    createBridgeElement(bridge3, vlanid ,"default"),
+                    createBridgeElement(bridge4, vlanid ,"default")                
+                );
         
         //First persist bridge topology
-        // nodeBridgeB:port24 connected to nodeBridgeA port4
-        // save snmpinterface and bridgebridgelink
-        context.getTopologyPersister().persist(createSnmpInterface(4, nodeBridgeA), 
-                                               createSnmpInterface(24, nodeBridgeB));
-        context.getTopologyPersister().persist(createBridgeBridgeLink(nodeBridgeA, nodeBridgeB, 4, 24,1));
+        // bridge1:port11 connected to bridge2:port21
+        // generate and save snmpinterface and bridgebridgelink
+        int bridge1portCounter = 11;
+        int bridge2portCounter = 21;
+        context.getTopologyPersister().persist(
+                   createSnmpInterface(bridge1portCounter, bridge1), 
+                   createSnmpInterface(bridge2portCounter, bridge2)
+               );
+        context.getTopologyPersister().persist(
+               createBridgeBridgeLink(bridge1, bridge2, bridge1portCounter, bridge1portCounter,vlanid));
+        bridge1portCounter++;
+        bridge2portCounter++;
 
-        // nodeBridgeB:port23 connected to nodeBridgeC port3
+        int bridge3portCounter=31;
+        // bridge3:port31 connected to bridge2:port22
         // save snmpinterface and bridgebridgelink
-        context.getTopologyPersister().persist(createSnmpInterface(23, nodeBridgeB), createSnmpInterface(3, nodeBridgeC));
-        context.getTopologyPersister().persist(createBridgeBridgeLink(nodeBridgeC, nodeBridgeB, 3, 23,1));
+        context.getTopologyPersister().persist(
+                   createSnmpInterface(bridge1portCounter, bridge2), 
+                   createSnmpInterface(bridge2portCounter, bridge3)
+               );
+        context.getTopologyPersister().persist(
+                   createBridgeBridgeLink(bridge3, bridge2, bridge2portCounter, bridge1portCounter,vlanid)
+               );
+        bridge2portCounter++;
+        bridge1portCounter++;
 
-        // nodeBridgeD:port1 connected to nodeBridgeA port11
+        int bridge4portCounter=41;
+        // bridge4:port41 connected to bridge1:port12
         // save snmpinterface and bridgebridgelink
-        context.getTopologyPersister().persist(createSnmpInterface(1, nodeBridgeD), createSnmpInterface(11, nodeBridgeA));
-        context.getTopologyPersister().persist(createBridgeBridgeLink(nodeBridgeD, nodeBridgeA, 1, 11,1));
+        context.getTopologyPersister().persist(
+                   createSnmpInterface(bridge4portCounter, bridge4), 
+                   createSnmpInterface(bridge1portCounter, bridge1)
+               );
+        context.getTopologyPersister().persist(
+                   createBridgeBridgeLink(bridge4, bridge1, bridge4portCounter, bridge1portCounter,vlanid)
+               );
+        bridge4portCounter++;
+        bridge1portCounter++;
         
         //generate host topology
         // here ip addresses are needed
 
-        // nodeHostE port 1 is connected on port 5 of nodeBridgeA
-        // ipinterface -> nodeHostE - 192.168.0.11
-        OnmsNode nodeHostE =  nodes.get(4);
-        String macE=macGenerator.next();
-        OnmsSnmpInterface snmpInterfaceE = createSnmpInterface(1, nodeHostE);
-        context.getTopologyPersister().persist(createSnmpInterface(5, nodeBridgeA),snmpInterfaceE);
-        OnmsIpInterface ipInterfaceE = createIpInterface(snmpInterfaceE, inetGenerator.next());
-        context.getTopologyPersister().persist(ipInterfaceE);
+        // host5:port 51 connected to bridge1:port13
+        OnmsNode host5 =  nodes.get(4);
+        int host5portCounter = 51;
+        String mac5=macGenerator.next();
+        InetAddress ip5= inetGenerator.next();
+        OnmsSnmpInterface snmpInterface51 = createSnmpInterface(host5portCounter, host5);
         context.getTopologyPersister().persist(
-           createIpNetToMedia(nodeHostE, snmpInterfaceE.getIfIndex(), snmpInterfaceE.getIfName(),macE, ipInterfaceE.getIpAddress(), nodeBridgeA)
+                   createSnmpInterface(bridge1portCounter, bridge1),
+                   snmpInterface51
+               );
+        OnmsIpInterface ipInterface51 = createIpInterface(snmpInterface51, ip5);
+        context.getTopologyPersister().persist(ipInterface51);
+        context.getTopologyPersister().persist(
+                   createIpNetToMedia(host5, host5portCounter, mac5, ip5, bridge1)
                 );
-        context.getTopologyPersister().persist(createBridgeMacLink(nodeBridgeA, 5, 1, macE));
+        context.getTopologyPersister().persist(
+                   createBridgeMacLink(bridge1, bridge1portCounter, vlanid, mac5)
+               );
+        bridge1portCounter++;
+        host5portCounter++;
         
-        // nodeHostF port 1 is connected on port 5 of nodeBridgeA
-        // ipinterface -> nodeHostF - 192.168.0.12
-        OnmsNode nodeHostF =  nodes.get(5);
-        String macF=macGenerator.next();
-        OnmsSnmpInterface snmpInterfaceF = createSnmpInterface(1, nodeHostF);
-        context.getTopologyPersister().persist(createSnmpInterface(6, nodeBridgeA),snmpInterfaceF);
-        OnmsIpInterface ipInterfaceF = createIpInterface(snmpInterfaceF, inetGenerator.next());
-        context.getTopologyPersister().persist(ipInterfaceF);
+        // host6:port61 connected ton bridge1:port14
+        OnmsNode host6 =  nodes.get(5);
+        int host6portCounter = 61;
+        String mac6=macGenerator.next();
+        InetAddress ip6= inetGenerator.next();
+        OnmsSnmpInterface snmpInterface61 = createSnmpInterface(host6portCounter, host6);
         context.getTopologyPersister().persist(
-           createIpNetToMedia(nodeHostF, snmpInterfaceF.getIfIndex(), snmpInterfaceF.getIfName(),macF, ipInterfaceF.getIpAddress(), nodeBridgeA)
+                   createSnmpInterface(bridge1portCounter, bridge1),
+                   snmpInterface61
+               );
+        OnmsIpInterface ipInterface61 = createIpInterface(snmpInterface61, ip6);
+        context.getTopologyPersister().persist(ipInterface61);
+        context.getTopologyPersister().persist(
+                   createIpNetToMedia(host6, host6portCounter,mac6, ip6, bridge1)
                 );
-        context.getTopologyPersister().persist(createBridgeMacLink(nodeBridgeA, 5, 1, macF));
-        
+        context.getTopologyPersister().persist(
+                   createBridgeMacLink(bridge1, bridge1portCounter, vlanid, mac6)
+               );
+        bridge1portCounter++;
+        host6portCounter++;
 
-        // nodeHostG port 10 is connected on port 10 of nodeBridgeC
-        // ipinterface -> nodeHostF - 192.168.0.13
-        OnmsNode nodeHostG =  nodes.get(6);
-        String macG=macGenerator.next();
-        OnmsSnmpInterface snmpInterfaceG = createSnmpInterface(10, nodeHostG);
-        context.getTopologyPersister().persist(createSnmpInterface(10, nodeBridgeC),snmpInterfaceG);
-        OnmsIpInterface ipInterfaceG = createIpInterface(snmpInterfaceG, inetGenerator.next());
-        context.getTopologyPersister().persist(ipInterfaceG);
+        // host7:port71 connected bridge3:port32
+        OnmsNode host7 =  nodes.get(6);
+        int host7portCounter = 71;
+        String mac7=macGenerator.next();
+        InetAddress ip7= inetGenerator.next();
+        OnmsSnmpInterface snmpInterface71 = createSnmpInterface(host7portCounter, host7);
         context.getTopologyPersister().persist(
-           createIpNetToMedia(nodeHostG, snmpInterfaceG.getIfIndex(), snmpInterfaceG.getIfName(),macG, ipInterfaceG.getIpAddress(), nodeBridgeA)
+                   createSnmpInterface(bridge3portCounter, bridge3),
+                   snmpInterface71
+               );
+        OnmsIpInterface ipInterface7 = createIpInterface(snmpInterface71, ip7);
+        context.getTopologyPersister().persist(ipInterface7);
+        context.getTopologyPersister().persist(
+                   createIpNetToMedia(host7, host7portCounter,mac7, ip7, bridge1)
                 );
-        context.getTopologyPersister().persist(createBridgeMacLink(nodeBridgeC, 10, 1, macG));
+        context.getTopologyPersister().persist(
+                   createBridgeMacLink(bridge3, bridge3portCounter, vlanid, mac7)
+               );
+        bridge1portCounter++;
+        host7portCounter++;
 
-        // nodeHostH port 11 is connected on port 11 of nodeBridgeD
-        // ipinterface -> nodeHostH - 192.168.0.14
-        OnmsNode nodeHostH =  nodes.get(7);
-        String macH=macGenerator.next();
-        OnmsSnmpInterface snmpInterfaceH = createSnmpInterface(11, nodeHostH);
-        context.getTopologyPersister().persist(createSnmpInterface(11, nodeBridgeD),snmpInterfaceH);
-        OnmsIpInterface ipInterfaceH = createIpInterface(snmpInterfaceH, inetGenerator.next());
-        context.getTopologyPersister().persist(ipInterfaceH);
+        // host8:port81 connected bridge4:port42
+        OnmsNode host8 =  nodes.get(7);
+        int host8portCounter = 81;
+        String mac8=macGenerator.next();
+        InetAddress ip8= inetGenerator.next();
+        OnmsSnmpInterface snmpInterface81 = createSnmpInterface(host8portCounter, host8);
         context.getTopologyPersister().persist(
-           createIpNetToMedia(nodeHostH, snmpInterfaceH.getIfIndex(), snmpInterfaceH.getIfName(),macH, ipInterfaceH.getIpAddress(), nodeBridgeA)
+                   createSnmpInterface(bridge4portCounter, bridge4),
+                   snmpInterface81
+               );
+        OnmsIpInterface ipInterface8 = createIpInterface(snmpInterface81, ip8);
+        context.getTopologyPersister().persist(ipInterface8);
+        context.getTopologyPersister().persist(
+                   createIpNetToMedia(host8, host8portCounter,mac8, ip8, bridge1)
                 );
-        context.getTopologyPersister().persist(createBridgeMacLink(nodeBridgeD, 11, 1, macH));
+        context.getTopologyPersister().persist(
+                   createBridgeMacLink(bridge4, bridge4portCounter, vlanid, mac8)
+               );
+        bridge4portCounter++;
+        host8portCounter++;
  
-        // nodeHostI  is connected on port 12 of nodeBridgeD
-        // ipinterface -> nodeHostI - 192.168.0.15
-        OnmsNode nodeHostI =  nodes.get(8);
-        String macI=macGenerator.next();
-        context.getTopologyPersister().persist(createSnmpInterface(12, nodeBridgeD));
-        OnmsIpInterface ipInterfaceI = createIpInterface(null, inetGenerator.next());
-        ipInterfaceI.setNode(nodeHostI);
-        context.getTopologyPersister().persist(ipInterfaceI);
+        // host9:with-no-snmp connected bridge4:port43
+        OnmsNode host9 =  nodes.get(8);
+        String mac9=macGenerator.next();
+        InetAddress ip9= inetGenerator.next();
+        context.getTopologyPersister().persist(createSnmpInterface(bridge4portCounter, bridge4));
+        OnmsIpInterface ipInterface9 = createIpInterface(null, ip9);
+        ipInterface9.setNode(host9);
+        context.getTopologyPersister().persist(ipInterface9);
         context.getTopologyPersister().persist(
-           createIpNetToMedia(nodeHostI, null, null,macI, ipInterfaceI.getIpAddress(), nodeBridgeA)
+                   createIpNetToMedia(host9, -1,mac9, ip9, bridge1)
                 );
-        context.getTopologyPersister().persist(createBridgeMacLink(nodeBridgeD, 12, 1, macI));
-
-        // nodeHostL  is connected on port 13 of nodeBridgeD
-        // ipinterface -> nodeHostI - 192.168.0.16
-        OnmsNode nodeHostL =  nodes.get(9);
-        String macL=macGenerator.next();
-        context.getTopologyPersister().persist(createSnmpInterface(13, nodeBridgeD));
-        OnmsIpInterface ipInterfaceL = createIpInterface(null, inetGenerator.next());
-        ipInterfaceL.setNode(nodeHostL);
-        context.getTopologyPersister().persist(ipInterfaceL);
         context.getTopologyPersister().persist(
-           createIpNetToMedia(nodeHostL, null, null,macL, ipInterfaceL.getIpAddress(), nodeBridgeA)
-                );
-        context.getTopologyPersister().persist(createBridgeMacLink(nodeBridgeD, 13, 1, macL));
+                   createBridgeMacLink(bridge4, bridge4portCounter, vlanid, mac9)
+               );
+        bridge4portCounter++;
 
-        // adding some mac addresses and ip on a cloud on port 23 bridge B ---
-        for (int i=0; i<5;i++) {
+        // host9:with-no-snmp connected bridge4:port43
+        OnmsNode host10 =  nodes.get(9);
+        String mac10=macGenerator.next();
+        InetAddress ip10= inetGenerator.next();
+        context.getTopologyPersister().persist(createSnmpInterface(bridge4portCounter, bridge4));
+        OnmsIpInterface ipInterface10 = createIpInterface(null,ip10);
+        ipInterface10.setNode(host10);
+        context.getTopologyPersister().persist(ipInterface10);
+        context.getTopologyPersister().persist(
+                   createIpNetToMedia(host10, -1, mac10, ip10, bridge1)
+                );
+        context.getTopologyPersister().persist(createBridgeMacLink(bridge4, bridge4portCounter, vlanid, mac10));
+        bridge4portCounter++;
+        
+        
+        // adding 2 mac addresses and ip on a cloud bridge3:port31 connected to bridge2:port22
+        for (int i=0; i<2;i++) {
             String nextMac = macGenerator.next();
             context.getTopologyPersister().persist(
-                   createIpNetToMedia(null, null, null,nextMac, inetGenerator.next(), nodeBridgeA)
+                   createIpNetToMedia(null, null,nextMac, inetGenerator.next(), bridge1)
                     );
-            context.getTopologyPersister().persist(createBridgeMacLink(nodeBridgeB, 23, 1, nextMac));
+            context.getTopologyPersister().persist(
+                       createBridgeMacLink(bridge2, 22, vlanid, nextMac));
         }
         
-        // you can also have mac addresses without an ip address associated
-        for (int i=0; i<10;i++) {
-            context.getTopologyPersister().persist(createBridgeMacLink(nodeBridgeB, 23, 1, macGenerator.next()));
+        // adding 2 mac addresses without an ip address associated on a cloud bridge3:port31 connected to bridge2:port22
+        for (int i=0; i<2;i++) {
+            context.getTopologyPersister().persist(createBridgeMacLink(bridge2, 22, vlanid, macGenerator.next()));
         }
+
+        //persisting bridge3 port 33
+        context.getTopologyPersister().persist(
+               createSnmpInterface(bridge3portCounter, bridge3)
+           );        
+        // adding 2 mac addresses and ip on a cloud bridge3:port33 
+        for (int i=0; i<2;i++) {
+            String nextMac = macGenerator.next();
+            context.getTopologyPersister().persist(
+                   createIpNetToMedia(null, null,nextMac, inetGenerator.next(), bridge1)
+                    );
+            context.getTopologyPersister().persist(
+                       createBridgeMacLink(bridge3, bridge3portCounter, vlanid, nextMac));
+        }
+        
+        // adding 3 mac addresses without an ip address associated on a cloud bridge3:port33 
+        for (int i=0; i<3;i++) {
+            context.getTopologyPersister().persist(createBridgeMacLink(bridge3, bridge3portCounter, vlanid, macGenerator.next()));
+        }
+        bridge3portCounter++;        
     }
 
     private List<BridgeElement> createBridgeElements(OnmsNode ... nodes) {
@@ -297,16 +384,19 @@ public class BridgeProtocol extends Protocol<BridgeBridgeLink> {
         return bridgeMacLink;
     }
 
-    private IpNetToMedia createIpNetToMedia(OnmsNode node, Integer ifindex, String port, String mac, InetAddress inetAddress, OnmsNode sourceNode){
+    private IpNetToMedia createIpNetToMedia(OnmsNode node, Integer ifindex, String mac, InetAddress inetAddress, OnmsNode sourceNode){
         IpNetToMedia ipNetToMedia = new IpNetToMedia();
         ipNetToMedia.setCreateTime(new Date());
-        ipNetToMedia.setIfIndex(ifindex);
+        if (node != null && ifindex == null ) {
+            ipNetToMedia.setIfIndex(-1);
+        } else {
+            ipNetToMedia.setIfIndex(ifindex);
+        }
         ipNetToMedia.setLastPollTime(new Date());
         ipNetToMedia.setIpNetToMediaType(IpNetToMedia.IpNetToMediaType.IPNETTOMEDIA_TYPE_DYNAMIC);
         ipNetToMedia.setNetAddress(inetAddress);
         ipNetToMedia.setPhysAddress(mac);
         ipNetToMedia.setNode(node);
-        ipNetToMedia.setPort(port);
         ipNetToMedia.setSourceIfIndex(0);
         ipNetToMedia.setSourceNode(sourceNode);
         return ipNetToMedia;

--- a/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/BridgeProtocol.java
+++ b/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/BridgeProtocol.java
@@ -57,9 +57,6 @@ import org.opennms.netmgt.model.OnmsSnmpInterface;
 // +- SharedSegment.create(link)
 // +- m_bridgeMacLinkDao.findAll()
 //
-// It seems that you need also to generate ipnettomedia too.
-// In fact a bridgebridgelink is a connection between two bridges and a bridge mac link is a connection with a node.
-// but you also need to let the node binded to the mac address and then you need an ip address for the mac.
 public class BridgeProtocol extends Protocol<BridgeBridgeLink> {
 
     private final MacAddressGenerator macGenerator = new MacAddressGenerator();
@@ -77,12 +74,13 @@ public class BridgeProtocol extends Protocol<BridgeBridgeLink> {
     @Override
     protected void createAndPersistProtocolSpecificEntities(List<OnmsNode> nodes) {
 
+        context.currentProgress("Version 1"); // TODO: delete later just for testing purpose
+
         // Call with: enlinkd:generate-topology --protocol bridgeBridge --nodes 3 --snmpinterfaces 0 -- ipinterfaces 0
 
-//        NodeA is connected to port 24 of NodeB
-//        NodeC is connected to port 23 of NodeB
-//        you have tio generate three nodes nodeA(id=1) nodeB(id=2) nodeC(id=3)
-
+       // NodeA is connected to port 24 of NodeB
+       // NodeC is connected to port 23 of NodeB
+       // you have to generate three nodes nodeA(id=1) nodeB(id=2) nodeC(id=3)
         OnmsNode nodeA =  nodes.get(0);
         OnmsNode nodeB =  nodes.get(1);
         OnmsNode nodeC =  nodes.get(2);

--- a/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/BridgeProtocol.java
+++ b/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/BridgeProtocol.java
@@ -76,7 +76,6 @@ public class BridgeProtocol extends Protocol<BridgeBridgeLink> {
     @Override
     protected void createAndPersistProtocolSpecificEntities(List<OnmsNode> nodes) {
 
-        context.currentProgress("Version 7"); // TODO: delete later just for testing purpose
 
         // Call with: enlinkd:generate-topology --protocol bridgeBridge --nodes 10 --snmpinterfaces 0 --ipinterfaces 0
         //      here is complete example of bridge topology
@@ -107,10 +106,10 @@ public class BridgeProtocol extends Protocol<BridgeBridgeLink> {
 
         // save bridge element
         this.context.getTopologyPersister().persist(
-                    createBridgeElement(bridge1, vlanid ,"default"),
-                    createBridgeElement(bridge2, vlanid ,"default"),
-                    createBridgeElement(bridge3, vlanid ,"default"),
-                    createBridgeElement(bridge4, vlanid ,"default")                
+                    createBridgeElement(bridge1, vlanid),
+                    createBridgeElement(bridge2, vlanid),
+                    createBridgeElement(bridge3, vlanid),
+                    createBridgeElement(bridge4, vlanid)
                 );
         
         //First persist bridge topology
@@ -310,7 +309,7 @@ public class BridgeProtocol extends Protocol<BridgeBridgeLink> {
     private List<BridgeElement> createBridgeElements(OnmsNode ... nodes) {
         List<BridgeElement> elements = new ArrayList<>();
         for (OnmsNode node: nodes) {
-            elements.add(createBridgeElement(node, 1, "default"));
+            elements.add(createBridgeElement(node, 1));
         }
         return elements;
     }
@@ -319,12 +318,12 @@ public class BridgeProtocol extends Protocol<BridgeBridgeLink> {
         List<BridgeElement> elements = new ArrayList<>();
         for (int i = 0; i < topologySettings.getAmountLinks()/2; i++) {
             OnmsNode node = nodes.get(i);
-            elements.add(createBridgeElement(node,1,"default"));
+            elements.add(createBridgeElement(node,1));
         }
         return elements;
     }
     
-    private BridgeElement createBridgeElement(OnmsNode node, Integer vlanid, String vlanname) {
+    private BridgeElement createBridgeElement(OnmsNode node, Integer vlanid) {
         BridgeElement bridge = new BridgeElement();
         bridge.setNode(node);
         bridge.setBaseBridgeAddress(macGenerator.next().replace(":", ""));
@@ -332,31 +331,9 @@ public class BridgeProtocol extends Protocol<BridgeBridgeLink> {
         bridge.setBridgeNodeLastPollTime(new Date());
         bridge.setBaseNumPorts(topologySettings.getAmountLinks());
         bridge.setVlan(vlanid);
-        bridge.setVlanname(vlanname);
+        bridge.setVlanname("default");
         return bridge;
     }
-    
-    private List<BridgeBridgeLink> createBridgeBridgeLinks(List<OnmsNode> nodes, Integer vlanid) {
-        // Here we shold use a different strategy because we need to generate a tree
-        PairGenerator<OnmsNode> pairs = createPairGenerator(nodes);
-        List<BridgeBridgeLink> links = new ArrayList<>();
-        for (int i = 0; i < topologySettings.getAmountLinks()/2; i++) {
-
-            // We create 2 links that reference each other, see also BridgeTopologyServiceImpl.getAllPersisted()
-            Pair<OnmsNode, OnmsNode> pair = pairs.next();
-            OnmsNode sourceNode = pair.getLeft();
-            OnmsNode targetNode = pair.getRight();
-
-            BridgeBridgeLink sourceLink = createBridgeBridgeLink(sourceNode, targetNode, 1 , 2,1);
-            links.add(sourceLink);
-
-//            BridgeBridgeLink targetLink = createBridgeBridgeLink(targetNode, sourceNode, 2, 1,1);
-//           links.add(targetLink);
-            context.currentProgress(String.format("Linked node %s with node %s", sourceNode.getLabel(), targetNode.getLabel()));
-        }
-        return links;
-    }
-
 
     private BridgeBridgeLink createBridgeBridgeLink(OnmsNode node, OnmsNode designatedNode, int port, int designatedPort, Integer vlanid) {
         BridgeBridgeLink link = new BridgeBridgeLink();

--- a/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/BridgeProtocol.java
+++ b/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/BridgeProtocol.java
@@ -28,6 +28,7 @@
 
 package org.opennms.enlinkd.generator.protocol;
 
+import java.net.InetAddress;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -37,10 +38,14 @@ import org.opennms.enlinkd.generator.TopologyContext;
 import org.opennms.enlinkd.generator.TopologyGenerator;
 import org.opennms.enlinkd.generator.TopologySettings;
 import org.opennms.enlinkd.generator.topology.PairGenerator;
+import org.opennms.enlinkd.generator.util.InetAddressGenerator;
 import org.opennms.enlinkd.generator.util.MacAddressGenerator;
 import org.opennms.netmgt.enlinkd.model.BridgeBridgeLink;
 import org.opennms.netmgt.enlinkd.model.BridgeMacLink;
+import org.opennms.netmgt.enlinkd.model.IpNetToMedia;
+import org.opennms.netmgt.model.OnmsIpInterface;
 import org.opennms.netmgt.model.OnmsNode;
+import org.opennms.netmgt.model.OnmsSnmpInterface;
 
 
 // BroadcastDomain:
@@ -51,9 +56,14 @@ import org.opennms.netmgt.model.OnmsNode;
 // +- BridgePort getFromDesignatedBridgeBridgeLink(link);
 // +- SharedSegment.create(link)
 // +- m_bridgeMacLinkDao.findAll()
+//
+// It seems that you need also to generate ipnettomedia too.
+// In fact a bridgebridgelink is a connection between two bridges and a bridge mac link is a connection with a node.
+// but you also need to let the node binded to the mac address and then you need an ip address for the mac.
 public class BridgeProtocol extends Protocol<BridgeBridgeLink> {
 
     private final MacAddressGenerator macGenerator = new MacAddressGenerator();
+    private final InetAddressGenerator inetGenerator = new InetAddressGenerator();
 
     public BridgeProtocol(TopologySettings topologySettings, TopologyContext context) {
         super(topologySettings, context);
@@ -66,6 +76,39 @@ public class BridgeProtocol extends Protocol<BridgeBridgeLink> {
 
     @Override
     protected void createAndPersistProtocolSpecificEntities(List<OnmsNode> nodes) {
+
+        // Call with: enlinkd:generate-topology --protocol bridgeBridge --nodes 3 --snmpinterfaces 0 -- ipinterfaces 0
+
+//        NodeA is connected to port 24 of NodeB
+//        NodeC is connected to port 23 of NodeB
+//        you have tio generate three nodes nodeA(id=1) nodeB(id=2) nodeC(id=3)
+
+        OnmsNode nodeA =  nodes.get(0);
+        OnmsNode nodeB =  nodes.get(1);
+        OnmsNode nodeC =  nodes.get(2);
+
+        // snmpinterfaces -> nodeB ----port 1,24 ---specified ifindex name ands so on
+        OnmsSnmpInterface snmpInterfaceA = createSnmpInterface(1, nodeA);
+        OnmsSnmpInterface snmpInterfaceB = createSnmpInterface(2, nodeB);
+        OnmsSnmpInterface snmpInterfaceC = createSnmpInterface(3, nodeC);
+        context.getTopologyPersister().persist(snmpInterfaceA, snmpInterfaceB, snmpInterfaceC);
+
+        // ipinterface -> nodeA - 192.168.0.1
+        // ipinterface -> nodeB - 192.168.0.2
+        // ipinterface -> nodeC - 192.168.0.3
+        OnmsIpInterface ipInterfaceA = createIpInterface(snmpInterfaceA, inetGenerator.next());
+        OnmsIpInterface ipInterfaceB = createIpInterface(snmpInterfaceB, inetGenerator.next());
+        OnmsIpInterface ipInterfaceC = createIpInterface(snmpInterfaceC, inetGenerator.next());
+        context.getTopologyPersister().persist(ipInterfaceA, ipInterfaceB, ipInterfaceC);
+
+        // ipnettomedia -> nodeid=1 0123456789a 192.168.0.1
+        // ipnettomedia -> nodeid=1 0123456789b 192.168.0.2
+        // ipnettomedia -> nodeid=3 0123456789c 192.168.0.3
+        IpNetToMedia ipNetToMediaA = createIpNetToMedia(nodeA, "0123456789a", ipInterfaceA.getIpAddress(), nodeB);
+        IpNetToMedia ipNetToMediaB = createIpNetToMedia(nodeA, "0123456789b", ipInterfaceB.getIpAddress(), nodeB);
+        IpNetToMedia ipNetToMediaC = createIpNetToMedia(nodeC, "0123456789c", ipInterfaceC.getIpAddress(), nodeB);
+        context.getTopologyPersister().persist(ipNetToMediaA, ipNetToMediaB, ipNetToMediaC);
+
         List<BridgeBridgeLink> bridgeBridgeLinks = createBridgeBridgeLinks(nodes);
         this.context.getTopologyPersister().persist(bridgeBridgeLinks);
     }
@@ -80,10 +123,10 @@ public class BridgeProtocol extends Protocol<BridgeBridgeLink> {
             OnmsNode sourceNode = pair.getLeft();
             OnmsNode targetNode = pair.getRight();
 
-            BridgeBridgeLink sourceLink = createBridgeBridgeLink(sourceNode, targetNode);
+            BridgeBridgeLink sourceLink = createBridgeBridgeLink(sourceNode, targetNode, 1 , 2);
             links.add(sourceLink);
 
-            BridgeBridgeLink targetLink = createBridgeBridgeLink(targetNode, sourceNode);
+            BridgeBridgeLink targetLink = createBridgeBridgeLink(targetNode, sourceNode, 2, 1);
             links.add(targetLink);
             context.currentProgress(String.format("Linked node %s with node %s", sourceNode.getLabel(), targetNode.getLabel()));
         }
@@ -91,20 +134,20 @@ public class BridgeProtocol extends Protocol<BridgeBridgeLink> {
     }
 
 
-    private BridgeBridgeLink createBridgeBridgeLink(OnmsNode node, OnmsNode designatedNode) {
+    private BridgeBridgeLink createBridgeBridgeLink(OnmsNode node, OnmsNode designatedNode, int port, int designatedPort) {
         BridgeBridgeLink link = new BridgeBridgeLink();
         link.setBridgeBridgeLinkLastPollTime(new Date());
         link.setBridgePortIfIndex(3);
-        link.setBridgePort(4);
-        link.setVlan(1);
+        link.setBridgePort(port);
+        link.setVlan(23);
         link.setBridgePortIfName("xx");
         link.setNode(node);
         link.setBridgeBridgeLinkCreateTime(new Date());
         link.setDesignatedNode(designatedNode);
-        link.setDesignatedPort(5);
-        link.setDesignatedPortIfIndex(6);
+        link.setDesignatedPort(designatedPort);
+        link.setDesignatedPortIfIndex(3);
         link.setDesignatedVlan(23);
-        link.setDesignatedPortIfName("yy");
+        link.setDesignatedPortIfName("xx");
         return link;
     }
 
@@ -119,5 +162,20 @@ public class BridgeProtocol extends Protocol<BridgeBridgeLink> {
         bridgeMacLink.setLinkType(BridgeMacLink.BridgeMacLinkType.BRIDGE_LINK);
         bridgeMacLink.setMacAddress(macGenerator.next());
         return bridgeMacLink;
+    }
+
+    private IpNetToMedia createIpNetToMedia(OnmsNode node, String port, InetAddress inetAddress, OnmsNode sourceNode){
+        IpNetToMedia ipNetToMedia = new IpNetToMedia();
+        ipNetToMedia.setCreateTime(new Date());
+        ipNetToMedia.setIfIndex(0);
+        ipNetToMedia.setLastPollTime(new Date());
+        ipNetToMedia.setIpNetToMediaType(IpNetToMedia.IpNetToMediaType.IPNETTOMEDIA_TYPE_STATIC);
+        ipNetToMedia.setNetAddress(inetAddress);
+        ipNetToMedia.setPhysAddress("physAddress");
+        ipNetToMedia.setNode(node);
+        ipNetToMedia.setPort(port);
+        ipNetToMedia.setSourceIfIndex(0);
+        ipNetToMedia.setSourceNode(sourceNode);
+        return ipNetToMedia;
     }
 }

--- a/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/BridgeProtocol.java
+++ b/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/BridgeProtocol.java
@@ -1,0 +1,123 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.enlinkd.generator.protocol;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.opennms.enlinkd.generator.TopologyContext;
+import org.opennms.enlinkd.generator.TopologyGenerator;
+import org.opennms.enlinkd.generator.TopologySettings;
+import org.opennms.enlinkd.generator.topology.PairGenerator;
+import org.opennms.enlinkd.generator.util.MacAddressGenerator;
+import org.opennms.netmgt.enlinkd.model.BridgeBridgeLink;
+import org.opennms.netmgt.enlinkd.model.BridgeMacLink;
+import org.opennms.netmgt.model.OnmsNode;
+
+
+// BroadcastDomain:
+// BridgeTopologyServiceImpl.findAll()
+// + BridgeTopologyServiceImpl.getAllPersisted()
+// +- BridgeBridgeLinkDao.findAll()
+// +- BridgePort bridgeport = BridgePort.getFromBridgeBridgeLink(link);
+// +- BridgePort getFromDesignatedBridgeBridgeLink(link);
+// +- SharedSegment.create(link)
+// +- m_bridgeMacLinkDao.findAll()
+public class BridgeProtocol extends Protocol<BridgeBridgeLink> {
+
+    private final MacAddressGenerator macGenerator = new MacAddressGenerator();
+
+    public BridgeProtocol(TopologySettings topologySettings, TopologyContext context) {
+        super(topologySettings, context);
+    }
+
+    @Override
+    protected TopologyGenerator.Protocol getProtocol() {
+        return TopologyGenerator.Protocol.bridgeBridge;
+    }
+
+    @Override
+    protected void createAndPersistProtocolSpecificEntities(List<OnmsNode> nodes) {
+        List<BridgeBridgeLink> bridgeBridgeLinks = createBridgeBridgeLinks(nodes);
+        this.context.getTopologyPersister().persist(bridgeBridgeLinks);
+    }
+
+    private List<BridgeBridgeLink> createBridgeBridgeLinks(List<OnmsNode> nodes) {
+        PairGenerator<OnmsNode> pairs = createPairGenerator(nodes);
+        List<BridgeBridgeLink> links = new ArrayList<>();
+        for (int i = 0; i < topologySettings.getAmountLinks()/2; i++) {
+
+            // We create 2 links that reference each other, see also BridgeTopologyServiceImpl.getAllPersisted()
+            Pair<OnmsNode, OnmsNode> pair = pairs.next();
+            OnmsNode sourceNode = pair.getLeft();
+            OnmsNode targetNode = pair.getRight();
+
+            BridgeBridgeLink sourceLink = createBridgeBridgeLink(sourceNode, targetNode);
+            links.add(sourceLink);
+
+            BridgeBridgeLink targetLink = createBridgeBridgeLink(targetNode, sourceNode);
+            links.add(targetLink);
+            context.currentProgress(String.format("Linked node %s with node %s", sourceNode.getLabel(), targetNode.getLabel()));
+        }
+        return links;
+    }
+
+
+    private BridgeBridgeLink createBridgeBridgeLink(OnmsNode node, OnmsNode designatedNode) {
+        BridgeBridgeLink link = new BridgeBridgeLink();
+        link.setBridgeBridgeLinkLastPollTime(new Date());
+        link.setBridgePortIfIndex(3);
+        link.setBridgePort(4);
+        link.setVlan(1);
+        link.setBridgePortIfName("xx");
+        link.setNode(node);
+        link.setBridgeBridgeLinkCreateTime(new Date());
+        link.setDesignatedNode(designatedNode);
+        link.setDesignatedPort(5);
+        link.setDesignatedPortIfIndex(6);
+        link.setDesignatedVlan(23);
+        link.setDesignatedPortIfName("yy");
+        return link;
+    }
+
+    private BridgeMacLink createBridgeMacLink(){
+        BridgeMacLink bridgeMacLink = new BridgeMacLink();
+        bridgeMacLink.setBridgeMacLinkCreateTime(new Date());
+        bridgeMacLink.setBridgeMacLinkLastPollTime(new Date());
+        bridgeMacLink.setBridgePort(1);
+        bridgeMacLink.setBridgePortIfIndex(2);
+        bridgeMacLink.setBridgePortIfName("bridgePortIfName");
+        bridgeMacLink.setId(6);
+        bridgeMacLink.setLinkType(BridgeMacLink.BridgeMacLinkType.BRIDGE_LINK);
+        bridgeMacLink.setMacAddress(macGenerator.next());
+        return bridgeMacLink;
+    }
+}

--- a/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/BridgeProtocol.java
+++ b/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/BridgeProtocol.java
@@ -78,63 +78,150 @@ public class BridgeProtocol extends Protocol<BridgeBridgeLink> {
 
         context.currentProgress("Version 1"); // TODO: delete later just for testing purpose
 
-        // Call with: enlinkd:generate-topology --protocol bridgeBridge --nodes 3 --snmpinterfaces 0 -- ipinterfaces 0
-
-       // NodeA port 4 is connected to port 24 of NodeB
-       // NodeC port 3 is connected to port 23 of NodeB
-       // you have to generate three nodes nodeA(id=1) nodeB(id=2) nodeC(id=3)
+        // Call with: enlinkd:generate-topology --protocol bridgeBridge --nodes 10 --snmpinterfaces 0 -- ipinterfaces 1
+        //      here is complete example of bridge topology
+       // 4 nodes are bridges: nodeBridgeA, nodeBridgeB, nodeBridgeC, nodeBridgeD
+       //              B
+       //           --------  
+       //           |      |
+       //           A      C
+       //         -----
+       //           |
+       //           D 
+       // 6 nodes are hosts: nodeHostE, nodeHostF, nodeHostG, nodeHostH, nodeHostI, nodeHostL 
+       // generate 4 ipnettomedia without a corresponding node  
+       // consider also that on port 1 of C is connected an HUB with a group of hosts connected
+       // the hub has no snmp agent and therefore we are not to explore his mab forwarding table 
         
-        OnmsNode nodeA =  nodes.get(0);
-        OnmsNode nodeB =  nodes.get(1);
-        OnmsNode nodeC =  nodes.get(2);
+        OnmsNode nodeBridgeA =  nodes.get(0);
+        OnmsNode nodeBridgeB =  nodes.get(1);
+        OnmsNode nodeBridgeC =  nodes.get(2);
+        OnmsNode nodeBridgeD =  nodes.get(3);
 
-        // snmpinterfaces -> nodeB ----port 1,24 ---specified ifindex name ands so on
-        OnmsSnmpInterface snmpInterfaceA4 = createSnmpInterface(4, nodeA);
-        OnmsSnmpInterface snmpInterfaceB24 = createSnmpInterface(24, nodeB);
-        OnmsSnmpInterface snmpInterfaceB23 = createSnmpInterface(23, nodeB);
-        OnmsSnmpInterface snmpInterfaceC3 = createSnmpInterface(3, nodeC);
-        context.getTopologyPersister().persist(snmpInterfaceA4, snmpInterfaceB24,snmpInterfaceB23, snmpInterfaceC3);
+        // create bridge element
+        BridgeElement bridgeA = createBridgeElement(nodeBridgeA, 1 ,"default");
+        BridgeElement bridgeB = createBridgeElement(nodeBridgeB, 1 ,"default");
+        BridgeElement bridgeC = createBridgeElement(nodeBridgeC, 1 ,"default");
+        BridgeElement bridgeD = createBridgeElement(nodeBridgeD, 1 ,"default");
 
-        // in bridge only topology ip addresses are not needed
-        // ipinterface -> nodeA - 192.168.0.1
-        // ipinterface -> nodeB - 192.168.0.2
-        // ipinterface -> nodeC - 192.168.0.3
-        //OnmsIpInterface ipInterfaceA = createIpInterface(snmpInterfaceA, inetGenerator.next());
-        //OnmsIpInterface ipInterfaceB = createIpInterface(snmpInterfaceB, inetGenerator.next());
-        //OnmsIpInterface ipInterfaceC = createIpInterface(snmpInterfaceC, inetGenerator.next());
-        //context.getTopologyPersister().persist(ipInterfaceA, ipInterfaceB, ipInterfaceC);
-
-        //In Bridge only Topology no need for mac address here
-        // ipnettomedia -> nodeid=1 0123456789a 192.168.0.1
-        // ipnettomedia -> nodeid=1 0123456789b 192.168.0.2
-        // ipnettomedia -> nodeid=3 0123456789c 192.168.0.3
-        //IpNetToMedia ipNetToMediaA = createIpNetToMedia(nodeA, "0123456789a", ipInterfaceA.getIpAddress(), nodeB);
-        //IpNetToMedia ipNetToMediaB = createIpNetToMedia(nodeA, "0123456789b", ipInterfaceB.getIpAddress(), nodeB);
-        //IpNetToMedia ipNetToMediaC = createIpNetToMedia(nodeC, "0123456789c", ipInterfaceC.getIpAddress(), nodeB);
-        //context.getTopologyPersister().persist(ipNetToMediaA, ipNetToMediaB, ipNetToMediaC);
+        this.context.getTopologyPersister().persist(bridgeA,bridgeB,bridgeC,bridgeD);
         
-        BridgeElement bridgeA = createBridgeElement(nodeA);
-        BridgeElement bridgeB = createBridgeElement(nodeB);
-        BridgeElement bridgeC = createBridgeElement(nodeC);
+        //First persist bridge topology
+        // nodeBridgeB:port24 connected to nodeBridgeA port4
+        // save snmpinterface and bridgebridgelink
+        context.getTopologyPersister().persist(createSnmpInterface(4, nodeBridgeA), 
+                                               createSnmpInterface(24, nodeBridgeB));
+        context.getTopologyPersister().persist(createBridgeBridgeLink(nodeBridgeA, nodeBridgeB, 4, 24,1));
 
-        this.context.getTopologyPersister().persist(bridgeA,bridgeB,bridgeC);
-        
-        // linkBA nodeA port 4 connected to nodeB port 24
-        BridgeBridgeLink linkBA = createBridgeBridgeLink(nodeA, nodeB, 4, 24);
-        // linkBA nodeA port 3 connected to nodeB port 23
-        BridgeBridgeLink linkBC = createBridgeBridgeLink(nodeC, nodeB, 4, 23);
-        
-        
-        this.context.getTopologyPersister().persist(linkBA,linkBC);
+        // nodeBridgeB:port23 connected to nodeBridgeC port3
+        // save snmpinterface and bridgebridgelink
+        context.getTopologyPersister().persist(createSnmpInterface(23, nodeBridgeB), createSnmpInterface(3, nodeBridgeC));
+        context.getTopologyPersister().persist(createBridgeBridgeLink(nodeBridgeC, nodeBridgeB, 3, 23,1));
 
-        //        List<BridgeBridgeLink> bridgeBridgeLinks = createBridgeBridgeLinks(nodes);
-//        this.context.getTopologyPersister().persist(bridgeBridgeLinks);
+        // nodeBridgeD:port1 connected to nodeBridgeA port11
+        // save snmpinterface and bridgebridgelink
+        context.getTopologyPersister().persist(createSnmpInterface(1, nodeBridgeD), createSnmpInterface(11, nodeBridgeA));
+        context.getTopologyPersister().persist(createBridgeBridgeLink(nodeBridgeD, nodeBridgeA, 1, 11,1));
+        
+        //generate host topology
+        // here ip addresses are needed
+
+        // nodeHostE port 1 is connected on port 5 of nodeBridgeA
+        // ipinterface -> nodeHostE - 192.168.0.11
+        OnmsNode nodeHostE =  nodes.get(4);
+        String macE=macGenerator.next();
+        OnmsSnmpInterface snmpInterfaceE = createSnmpInterface(1, nodeHostE);
+        context.getTopologyPersister().persist(createSnmpInterface(5, nodeBridgeA),snmpInterfaceE);
+        OnmsIpInterface ipInterfaceE = createIpInterface(snmpInterfaceE, inetGenerator.next());
+        context.getTopologyPersister().persist(ipInterfaceE);
+        context.getTopologyPersister().persist(
+           createIpNetToMedia(nodeHostE, snmpInterfaceE.getIfIndex(), snmpInterfaceE.getIfName(),macE, ipInterfaceE.getIpAddress(), nodeBridgeA)
+                );
+        context.getTopologyPersister().persist(createBridgeMacLink(nodeBridgeA, 5, 1, macE));
+        
+        // nodeHostF port 1 is connected on port 5 of nodeBridgeA
+        // ipinterface -> nodeHostF - 192.168.0.12
+        OnmsNode nodeHostF =  nodes.get(5);
+        String macF=macGenerator.next();
+        OnmsSnmpInterface snmpInterfaceF = createSnmpInterface(1, nodeHostF);
+        context.getTopologyPersister().persist(createSnmpInterface(5, nodeBridgeA),snmpInterfaceF);
+        OnmsIpInterface ipInterfaceF = createIpInterface(snmpInterfaceF, inetGenerator.next());
+        context.getTopologyPersister().persist(ipInterfaceF);
+        context.getTopologyPersister().persist(
+           createIpNetToMedia(nodeHostF, snmpInterfaceF.getIfIndex(), snmpInterfaceF.getIfName(),macF, ipInterfaceF.getIpAddress(), nodeBridgeA)
+                );
+        context.getTopologyPersister().persist(createBridgeMacLink(nodeBridgeA, 5, 1, macF));
+        
+
+        // nodeHostG port 10 is connected on port 10 of nodeBridgeC
+        // ipinterface -> nodeHostF - 192.168.0.13
+        OnmsNode nodeHostG =  nodes.get(6);
+        String macG=macGenerator.next();
+        OnmsSnmpInterface snmpInterfaceG = createSnmpInterface(10, nodeHostG);
+        context.getTopologyPersister().persist(createSnmpInterface(10, nodeBridgeC),snmpInterfaceG);
+        OnmsIpInterface ipInterfaceG = createIpInterface(snmpInterfaceG, inetGenerator.next());
+        context.getTopologyPersister().persist(ipInterfaceG);
+        context.getTopologyPersister().persist(
+           createIpNetToMedia(nodeHostG, snmpInterfaceG.getIfIndex(), snmpInterfaceG.getIfName(),macG, ipInterfaceG.getIpAddress(), nodeBridgeA)
+                );
+        context.getTopologyPersister().persist(createBridgeMacLink(nodeBridgeC, 10, 1, macG));
+
+        // nodeHostH port 11 is connected on port 11 of nodeBridgeD
+        // ipinterface -> nodeHostH - 192.168.0.14
+        OnmsNode nodeHostH =  nodes.get(7);
+        String macH=macGenerator.next();
+        OnmsSnmpInterface snmpInterfaceH = createSnmpInterface(11, nodeHostH);
+        context.getTopologyPersister().persist(createSnmpInterface(11, nodeBridgeD),snmpInterfaceH);
+        OnmsIpInterface ipInterfaceH = createIpInterface(snmpInterfaceH, inetGenerator.next());
+        context.getTopologyPersister().persist(ipInterfaceH);
+        context.getTopologyPersister().persist(
+           createIpNetToMedia(nodeHostH, snmpInterfaceH.getIfIndex(), snmpInterfaceH.getIfName(),macH, ipInterfaceH.getIpAddress(), nodeBridgeA)
+                );
+        context.getTopologyPersister().persist(createBridgeMacLink(nodeBridgeD, 11, 1, macH));
+ 
+        // nodeHostI  is connected on port 12 of nodeBridgeD
+        // ipinterface -> nodeHostI - 192.168.0.15
+        OnmsNode nodeHostI =  nodes.get(8);
+        String macI=macGenerator.next();
+        context.getTopologyPersister().persist(createSnmpInterface(12, nodeBridgeD));
+        OnmsIpInterface ipInterfaceI = createIpInterface(null, inetGenerator.next());
+        context.getTopologyPersister().persist(ipInterfaceI);
+        context.getTopologyPersister().persist(
+           createIpNetToMedia(nodeHostI, null, null,macI, ipInterfaceI.getIpAddress(), nodeBridgeA)
+                );
+        context.getTopologyPersister().persist(createBridgeMacLink(nodeBridgeD, 12, 1, macI));
+
+        // nodeHostL  is connected on port 13 of nodeBridgeD
+        // ipinterface -> nodeHostI - 192.168.0.16
+        OnmsNode nodeHostL =  nodes.get(8);
+        String macL=macGenerator.next();
+        context.getTopologyPersister().persist(createSnmpInterface(13, nodeBridgeD));
+        OnmsIpInterface ipInterfaceL = createIpInterface(null, inetGenerator.next());
+        context.getTopologyPersister().persist(ipInterfaceL);
+        context.getTopologyPersister().persist(
+           createIpNetToMedia(nodeHostL, null, null,macL, ipInterfaceL.getIpAddress(), nodeBridgeA)
+                );
+        context.getTopologyPersister().persist(createBridgeMacLink(nodeBridgeD, 13, 1, macL));
+
+        // adding some mac addresses and ip on a cloud on port 23 bridge B ---
+        for (int i=0; i<5;i++) {
+            String nextMac = macGenerator.next();
+            context.getTopologyPersister().persist(
+                   createIpNetToMedia(null, null, null,nextMac, inetGenerator.next(), nodeBridgeA)
+                    );
+            context.getTopologyPersister().persist(createBridgeMacLink(nodeBridgeB, 23, 1, nextMac));
+        }
+        
+        // you can also have mac addresses without an ip address associated
+        for (int i=0; i<10;i++) {
+            context.getTopologyPersister().persist(createBridgeMacLink(nodeBridgeB, 23, 1, macGenerator.next()));
+        }
     }
 
     private List<BridgeElement> createBridgeElements(OnmsNode ... nodes) {
         List<BridgeElement> elements = new ArrayList<>();
         for (OnmsNode node: nodes) {
-            elements.add(createBridgeElement(node));
+            elements.add(createBridgeElement(node, 1, "default"));
         }
         return elements;
     }
@@ -143,24 +230,24 @@ public class BridgeProtocol extends Protocol<BridgeBridgeLink> {
         List<BridgeElement> elements = new ArrayList<>();
         for (int i = 0; i < topologySettings.getAmountLinks()/2; i++) {
             OnmsNode node = nodes.get(i);
-            elements.add(createBridgeElement(node));
+            elements.add(createBridgeElement(node,1,"default"));
         }
         return elements;
     }
     
-    private BridgeElement createBridgeElement(OnmsNode node) {
+    private BridgeElement createBridgeElement(OnmsNode node, Integer vlanid, String vlanname) {
         BridgeElement bridge = new BridgeElement();
         bridge.setNode(node);
         bridge.setBaseBridgeAddress(macGenerator.next());
         bridge.setBaseType(BridgeDot1dBaseType.DOT1DBASETYPE_TRANSPARENT_ONLY);
         bridge.setBridgeNodeLastPollTime(new Date());
         bridge.setBaseNumPorts(topologySettings.getAmountLinks());
-        bridge.setVlan(1);
-        bridge.setVlanname("default");
+        bridge.setVlan(vlanid);
+        bridge.setVlanname(vlanname);
         return bridge;
     }
     
-    private List<BridgeBridgeLink> createBridgeBridgeLinks(List<OnmsNode> nodes) {
+    private List<BridgeBridgeLink> createBridgeBridgeLinks(List<OnmsNode> nodes, Integer vlanid) {
         // Here we shold use a different strategy because we need to generate a tree
         PairGenerator<OnmsNode> pairs = createPairGenerator(nodes);
         List<BridgeBridgeLink> links = new ArrayList<>();
@@ -171,55 +258,51 @@ public class BridgeProtocol extends Protocol<BridgeBridgeLink> {
             OnmsNode sourceNode = pair.getLeft();
             OnmsNode targetNode = pair.getRight();
 
-            BridgeBridgeLink sourceLink = createBridgeBridgeLink(sourceNode, targetNode, 1 , 2);
+            BridgeBridgeLink sourceLink = createBridgeBridgeLink(sourceNode, targetNode, 1 , 2,1);
             links.add(sourceLink);
 
-            BridgeBridgeLink targetLink = createBridgeBridgeLink(targetNode, sourceNode, 2, 1);
-            links.add(targetLink);
+//            BridgeBridgeLink targetLink = createBridgeBridgeLink(targetNode, sourceNode, 2, 1,1);
+//           links.add(targetLink);
             context.currentProgress(String.format("Linked node %s with node %s", sourceNode.getLabel(), targetNode.getLabel()));
         }
         return links;
     }
 
 
-    private BridgeBridgeLink createBridgeBridgeLink(OnmsNode node, OnmsNode designatedNode, int port, int designatedPort) {
+    private BridgeBridgeLink createBridgeBridgeLink(OnmsNode node, OnmsNode designatedNode, int port, int designatedPort, Integer vlanid) {
         BridgeBridgeLink link = new BridgeBridgeLink();
-        link.setBridgeBridgeLinkLastPollTime(new Date());
         link.setBridgePortIfIndex(port);
         link.setBridgePort(port);
         link.setVlan(1);
-        link.setBridgePortIfName("xx");
         link.setNode(node);
-        link.setBridgeBridgeLinkCreateTime(new Date());
         link.setDesignatedNode(designatedNode);
         link.setDesignatedPort(designatedPort);
         link.setDesignatedPortIfIndex(designatedPort);
-        link.setDesignatedVlan(1);
-        link.setDesignatedPortIfName("xx");
+        link.setDesignatedVlan(vlanid);
+        link.setBridgeBridgeLinkLastPollTime(new Date());
         return link;
     }
 
-    private BridgeMacLink createBridgeMacLink(){
+    private BridgeMacLink createBridgeMacLink(OnmsNode bridge, Integer bridgePort, Integer vlan, String mac){
         BridgeMacLink bridgeMacLink = new BridgeMacLink();
-        bridgeMacLink.setBridgeMacLinkCreateTime(new Date());
-        bridgeMacLink.setBridgeMacLinkLastPollTime(new Date());
-        bridgeMacLink.setBridgePort(1);
-        bridgeMacLink.setBridgePortIfIndex(2);
-        bridgeMacLink.setBridgePortIfName("bridgePortIfName");
-        bridgeMacLink.setId(6);
+        bridgeMacLink.setNode(bridge);
+        bridgeMacLink.setBridgePort(bridgePort);
+        bridgeMacLink.setBridgePortIfIndex(bridgePort);
         bridgeMacLink.setLinkType(BridgeMacLink.BridgeMacLinkType.BRIDGE_LINK);
-        bridgeMacLink.setMacAddress(macGenerator.next());
+        bridgeMacLink.setMacAddress(mac);
+        bridgeMacLink.setVlan(vlan);
+        bridgeMacLink.setBridgeMacLinkLastPollTime(new Date());
         return bridgeMacLink;
     }
 
-    private IpNetToMedia createIpNetToMedia(OnmsNode node, String port, InetAddress inetAddress, OnmsNode sourceNode){
+    private IpNetToMedia createIpNetToMedia(OnmsNode node, Integer ifindex, String port, String mac, InetAddress inetAddress, OnmsNode sourceNode){
         IpNetToMedia ipNetToMedia = new IpNetToMedia();
         ipNetToMedia.setCreateTime(new Date());
-        ipNetToMedia.setIfIndex(0);
+        ipNetToMedia.setIfIndex(ifindex);
         ipNetToMedia.setLastPollTime(new Date());
-        ipNetToMedia.setIpNetToMediaType(IpNetToMedia.IpNetToMediaType.IPNETTOMEDIA_TYPE_STATIC);
+        ipNetToMedia.setIpNetToMediaType(IpNetToMedia.IpNetToMediaType.IPNETTOMEDIA_TYPE_DYNAMIC);
         ipNetToMedia.setNetAddress(inetAddress);
-        ipNetToMedia.setPhysAddress("physAddress");
+        ipNetToMedia.setPhysAddress(mac);
         ipNetToMedia.setNode(node);
         ipNetToMedia.setPort(port);
         ipNetToMedia.setSourceIfIndex(0);

--- a/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/BridgeProtocol.java
+++ b/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/BridgeProtocol.java
@@ -76,9 +76,9 @@ public class BridgeProtocol extends Protocol<BridgeBridgeLink> {
     @Override
     protected void createAndPersistProtocolSpecificEntities(List<OnmsNode> nodes) {
 
-        context.currentProgress("Version 1"); // TODO: delete later just for testing purpose
+        context.currentProgress("Version 7"); // TODO: delete later just for testing purpose
 
-        // Call with: enlinkd:generate-topology --protocol bridgeBridge --nodes 10 --snmpinterfaces 0 -- ipinterfaces 1
+        // Call with: enlinkd:generate-topology --protocol bridgeBridge --nodes 10 --snmpinterfaces 0 --ipinterfaces 0
         //      here is complete example of bridge topology
        // 4 nodes are bridges: nodeBridgeA, nodeBridgeB, nodeBridgeC, nodeBridgeD
        //              B
@@ -144,7 +144,7 @@ public class BridgeProtocol extends Protocol<BridgeBridgeLink> {
         OnmsNode nodeHostF =  nodes.get(5);
         String macF=macGenerator.next();
         OnmsSnmpInterface snmpInterfaceF = createSnmpInterface(1, nodeHostF);
-        context.getTopologyPersister().persist(createSnmpInterface(5, nodeBridgeA),snmpInterfaceF);
+        context.getTopologyPersister().persist(createSnmpInterface(6, nodeBridgeA),snmpInterfaceF);
         OnmsIpInterface ipInterfaceF = createIpInterface(snmpInterfaceF, inetGenerator.next());
         context.getTopologyPersister().persist(ipInterfaceF);
         context.getTopologyPersister().persist(
@@ -185,6 +185,7 @@ public class BridgeProtocol extends Protocol<BridgeBridgeLink> {
         String macI=macGenerator.next();
         context.getTopologyPersister().persist(createSnmpInterface(12, nodeBridgeD));
         OnmsIpInterface ipInterfaceI = createIpInterface(null, inetGenerator.next());
+        ipInterfaceI.setNode(nodeHostI);
         context.getTopologyPersister().persist(ipInterfaceI);
         context.getTopologyPersister().persist(
            createIpNetToMedia(nodeHostI, null, null,macI, ipInterfaceI.getIpAddress(), nodeBridgeA)
@@ -193,10 +194,11 @@ public class BridgeProtocol extends Protocol<BridgeBridgeLink> {
 
         // nodeHostL  is connected on port 13 of nodeBridgeD
         // ipinterface -> nodeHostI - 192.168.0.16
-        OnmsNode nodeHostL =  nodes.get(8);
+        OnmsNode nodeHostL =  nodes.get(9);
         String macL=macGenerator.next();
         context.getTopologyPersister().persist(createSnmpInterface(13, nodeBridgeD));
         OnmsIpInterface ipInterfaceL = createIpInterface(null, inetGenerator.next());
+        ipInterfaceL.setNode(nodeHostL);
         context.getTopologyPersister().persist(ipInterfaceL);
         context.getTopologyPersister().persist(
            createIpNetToMedia(nodeHostL, null, null,macL, ipInterfaceL.getIpAddress(), nodeBridgeA)
@@ -238,7 +240,7 @@ public class BridgeProtocol extends Protocol<BridgeBridgeLink> {
     private BridgeElement createBridgeElement(OnmsNode node, Integer vlanid, String vlanname) {
         BridgeElement bridge = new BridgeElement();
         bridge.setNode(node);
-        bridge.setBaseBridgeAddress(macGenerator.next());
+        bridge.setBaseBridgeAddress(macGenerator.next().replace(":", ""));
         bridge.setBaseType(BridgeDot1dBaseType.DOT1DBASETYPE_TRANSPARENT_ONLY);
         bridge.setBridgeNodeLastPollTime(new Date());
         bridge.setBaseNumPorts(topologySettings.getAmountLinks());

--- a/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/BridgeProtocol.java
+++ b/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/BridgeProtocol.java
@@ -69,30 +69,46 @@ public class BridgeProtocol extends Protocol<BridgeBridgeLink> {
     protected TopologyGenerator.Protocol getProtocol() {
         return TopologyGenerator.Protocol.bridgeBridge;
     }
-    
+
     private void persistBBLink(OnmsNode bridge, Integer port, OnmsNode designated, Integer designatedPort, Integer vlanid) {
+        persistBBLink(bridge, port, true, designated, designatedPort, true, vlanid);
+    }
+
+    private void persistBBLink(OnmsNode bridge, Integer port, boolean createSnmpInterface, OnmsNode designated, Integer designatedPort, boolean createdesignatedsnmpInterface, Integer vlanid) {
+        if (createSnmpInterface) {
         context.getTopologyPersister().persist(
-                       createSnmpInterface(port, bridge), 
+                       createSnmpInterface(port, bridge)
+                   );
+        }
+        if (createdesignatedsnmpInterface) {
+        context.getTopologyPersister().persist(
                        createSnmpInterface(designatedPort, designated)
                    );
+        }
         context.getTopologyPersister().persist(
            createBridgeBridgeLink(bridge, designated, port, designatedPort,vlanid)
         );
     }
-    
     private void persistBMLink(OnmsNode bridge, Integer port, Integer vlanid, OnmsNode host, Integer hostPort, OnmsNode gateway) {
+        persistBMLink(bridge, port, true, vlanid, host, hostPort, gateway);
+    }
+    
+    private void persistBMLink(OnmsNode bridge, Integer port, boolean createsnmpinterface, Integer vlanid, OnmsNode host, Integer hostPort, OnmsNode gateway) {
         String mac=macGenerator.next();
         InetAddress ip= inetGenerator.next();
+        if (createsnmpinterface) {
+            context.getTopologyPersister().persist(
+               createSnmpInterface(port, bridge)
+           );
+        }
         if (hostPort != null) {
             OnmsSnmpInterface snmpInterface = createSnmpInterface(hostPort, host);
             context.getTopologyPersister().persist(
-                   createSnmpInterface(port, bridge),
                    snmpInterface
                );
             OnmsIpInterface ipInterface = createIpInterface(snmpInterface, ip);
             context.getTopologyPersister().persist(ipInterface);
         } else {
-            context.getTopologyPersister().persist(createSnmpInterface(port, bridge));
             OnmsIpInterface ipInterface = createIpInterface(null,ip);
             ipInterface.setNode(host);
             context.getTopologyPersister().persist(ipInterface);
@@ -198,8 +214,8 @@ public class BridgeProtocol extends Protocol<BridgeBridgeLink> {
         //bridge2
         // host6 and host 7 connected to port 22 
         bridge2portCounter++;
-        persistBMLink(bridge2, bridge2portCounter, vlanid, host6, host6portCounter, bridge0);
-        persistBMLink(bridge2, bridge2portCounter, vlanid, host7, host7portCounter, bridge0);
+        persistBMLink(bridge2, bridge2portCounter, true,  vlanid, host6, host6portCounter, bridge0);
+        persistBMLink(bridge2, bridge2portCounter, false, vlanid, host7, host7portCounter, bridge0);
         
         // bridge3
         // host8:with-no-snmp connected bridge3:port32

--- a/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/BridgeProtocol.java
+++ b/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/BridgeProtocol.java
@@ -167,8 +167,8 @@ public class BridgeProtocol extends Protocol<BridgeBridgeLink> {
         OnmsNode bridge2 =  nodes.get(2);
         OnmsNode bridge3 =  nodes.get(3);
         OnmsNode host4   =  nodes.get(4);
-        OnmsNode host5   =  nodes.get(4);
-        OnmsNode host6   =  nodes.get(5);
+        OnmsNode host5   =  nodes.get(5);
+        OnmsNode host6   =  nodes.get(6);
         OnmsNode host7   =  nodes.get(7);
         OnmsNode host8   =  nodes.get(8);
         OnmsNode host9   =  nodes.get(9);

--- a/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/BridgeProtocol.java
+++ b/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/BridgeProtocol.java
@@ -216,7 +216,7 @@ public class BridgeProtocol extends Protocol<BridgeBridgeLink> {
         context.getTopologyPersister().persist(
                    createBridgeMacLink(bridge3, bridge3portCounter, vlanid, mac7)
                );
-        bridge1portCounter++;
+        bridge3portCounter++;
         host7portCounter++;
 
         // host8:port81 connected bridge4:port42

--- a/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/BridgeProtocol.java
+++ b/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/BridgeProtocol.java
@@ -50,7 +50,7 @@ import org.opennms.netmgt.model.OnmsNode;
  *           |      |          |        |       |
  *        bridge1  bridge3  bridge4  bridge5  Macs/Ip
  *           |          |               |     no node
- *        -------    --------          ...
+ *        -------    --------     ...subtree...
  *        |          |      |
  *     Segment     host8    host9
  *   -----------

--- a/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/BridgeProtocol.java
+++ b/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/BridgeProtocol.java
@@ -35,6 +35,8 @@ import java.util.List;
 import org.opennms.enlinkd.generator.TopologyContext;
 import org.opennms.enlinkd.generator.TopologyGenerator;
 import org.opennms.enlinkd.generator.TopologySettings;
+import org.opennms.enlinkd.generator.protocol.bridge.BridgeBuilder;
+import org.opennms.enlinkd.generator.protocol.bridge.BridgeBuilderContext;
 import org.opennms.enlinkd.generator.util.IdGenerator;
 import org.opennms.enlinkd.generator.util.InetAddressGenerator;
 import org.opennms.enlinkd.generator.util.MacAddressGenerator;
@@ -115,36 +117,59 @@ public class BridgeProtocol extends Protocol<BridgeBridgeLink> {
         int host5portCounter = 51;
         int host6portCounter = 61;
         int host7portCounter = 71;
-        
+
+        BridgeBuilderContext context = new BridgeBuilderContext(this.context.getTopologyPersister(), this.macGenerator, this.inetGenerator);
+        BridgeBuilder bridge0B = new BridgeBuilder(bridge0, bridge0portCounter - 1, context);
+
+
         // save bridge element
         this.context.getTopologyPersister().persist(
             createBridgeElement(bridge0),
+                // instead of:
             createBridgeElement(bridge1),
             createBridgeElement(bridge2),
-            createBridgeElement(bridge3)
+                // instead of:
+                createBridgeElement(bridge3)
         );
         
         //bridge0
         //bridge0:port1 connected to up bridge1:port11
-        createAndPersistBridgeBridgeLink(bridge0, bridge0portCounter, bridge1, bridge1portCounter);
+        BridgeBuilder bridge1B = bridge0B.connectToNewBridge(bridge1, bridge1portCounter);
+        // instead of:
+        // createAndPersistBridgeBridgeLink(bridge1, bridge1portCounter, bridge0, bridge0portCounter);
+
         //bridge3:port31 connected to up bridge0:port2
+        bridge0B.connectToNewBridge(bridge3, bridge3portCounter);
         bridge0portCounter++;
-        createAndPersistBridgeBridgeLink(bridge3, bridge3portCounter, bridge0, bridge0portCounter);
+        // instead of:
+        // createAndPersistBridgeBridgeLink(bridge3, bridge3portCounter, bridge0, bridge0portCounter);
+
         //bridge0:port3 connected to cloud
         bridge0portCounter++;
+        // bridge0B.createAndPersistCloud(2, 2);
+        // instead off:
         createAndPersistCloud(bridge0, bridge0portCounter, 2, 2);
+
         // bridge0:port4 connected to host4:port41
         bridge0portCounter++;
+        // bridge0B.createAndPersistBridgeMacLink(host4, host4portCounter);
+        // instead of:
         createAndPersistBridgeMacLink(bridge0, bridge0portCounter, host4, host4portCounter, bridge0);
+
         // bridge0:port5 connected to host5:port51
         bridge0portCounter++;
+        // bridge0B.createAndPersistBridgeMacLink(host5, host5portCounter);
+        // instead of:
         createAndPersistBridgeMacLink(bridge0, bridge0portCounter, host5, host5portCounter, bridge0);
 
         //bridge1
         //bridge2:port21 connected to bridge1:port12 with clouds
         bridge1portCounter++;
-        createAndPersistBridgeBridgeLink(bridge2, bridge2portCounter, bridge1, bridge1portCounter);
-        createAndPersistCloud(bridge1, bridge1portCounter, 2, 2);
+        bridge1B.connectToNewBridge(bridge2, bridge2portCounter);
+// instead of
+  // createAndPersistBridgeBridgeLink(bridge2, bridge2portCounter, bridge1, bridge1portCounter);
+//         bridge1B.createAndPersistCloud(2, 2);
+         createAndPersistCloud(bridge1, bridge1portCounter, 2, 2);
         
         //bridge2
         // host6 and host 7 connected to port 22 
@@ -161,7 +186,7 @@ public class BridgeProtocol extends Protocol<BridgeBridgeLink> {
         createAndPersistBridgeMacLink(bridge3, bridge3portCounter, host9, null, bridge0);
     }
 
-    private void createAndPersistBridgeBridgeLink(OnmsNode bridge, Integer port, OnmsNode designated, Integer designatedPort) {
+    private void createAndPersistBridgeBridgeLink(final OnmsNode bridge, final Integer port, final OnmsNode designated, final Integer designatedPort) {
         createAndPersistBridgeBridgeLink(bridge, port, true, designated, designatedPort, true);
     }
 
@@ -180,6 +205,7 @@ public class BridgeProtocol extends Protocol<BridgeBridgeLink> {
                 createBridgeBridgeLink(bridge, designated, port, designatedPort)
         );
     }
+
     private void createAndPersistBridgeMacLink(OnmsNode bridge, Integer port, OnmsNode host, Integer hostPort, OnmsNode gateway) {
         createAndPersistBridgeMacLink(bridge, port, true, host, hostPort, gateway);
     }

--- a/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/BridgeProtocol.java
+++ b/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/BridgeProtocol.java
@@ -77,23 +77,27 @@ public class BridgeProtocol extends Protocol<BridgeBridgeLink> {
     protected void printProtocolSpecificMessage() {
         // the bridge topology is different as the other topologies since it consists of different node types -> we need
         // a different implementation of this method
-        this.context.currentProgress("%nCreating %s topology with %s Nodes. All other settings are ignored since they not relevant for this topology",
+        this.context.currentProgress("%nCreating %s topology with %s Nodes. Other settings are ignored since they not relevant for this topology",
                 this.getProtocol(),
                 topologySettings.getAmountNodes());
     }
 
     @Override
     protected TopologySettings adoptAndVerifySettings(TopologySettings topologySettings) {
+        // make amount of nodes multiple of 10 since each (sub)tree needs 10 nodes:
         int amountNodes;
-        TopologySettings.TopologySettingsBuilder builder = TopologySettings.builder();
-        // make amount of nodes multiple of 10:
         if (topologySettings.getAmountNodes() < 10) {
-            builder.amountNodes(10);
+            amountNodes = 10;
         } else {
-            int nodes = topologySettings.getAmountNodes() + topologySettings.getAmountNodes() % 10;
-            builder.amountNodes(nodes);
+            int modulo = topologySettings.getAmountNodes() % 10;
+            amountNodes = topologySettings.getAmountNodes();
+            if(modulo != 0){
+                amountNodes += 10-modulo;
+            }
         }
-        return builder.amountSnmpInterfaces(0)
+        return TopologySettings.builder()
+                .amountNodes(amountNodes)
+                .amountSnmpInterfaces(0)
                 .amountIpInterfaces(0)
                 .amountLinks(0)
                 .amountElements(0)

--- a/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/BridgeProtocol.java
+++ b/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/BridgeProtocol.java
@@ -109,219 +109,45 @@ public class BridgeProtocol extends Protocol<BridgeBridgeLink> {
         OnmsNode host7   =  nodes.get(7);
         OnmsNode host8   =  nodes.get(8);
         OnmsNode host9   =  nodes.get(9);
-        int bridge0portCounter=1;
-        int bridge1portCounter=11;
-        int bridge2portCounter=21;
-        int bridge3portCounter=31;
-        int host4portCounter = 41;
-        int host5portCounter = 51;
-        int host6portCounter = 61;
-        int host7portCounter = 71;
 
         BridgeBuilderContext context = new BridgeBuilderContext(this.context.getTopologyPersister(), this.macGenerator, this.inetGenerator);
-        BridgeBuilder bridge0B = new BridgeBuilder(bridge0, bridge0portCounter - 1, context);
-
-
-        // save bridge element
-//        this.context.getTopologyPersister().persist(
-//            createBridgeElement(bridge0),
-//                // instead of:
-//            createBridgeElement(bridge1),
-//            createBridgeElement(bridge2),
-//                // instead of:
-//                createBridgeElement(bridge3)
-//        );
+        BridgeBuilder bridge0B = new BridgeBuilder(bridge0, 0, context);
         
         //bridge0
         //bridge0:port1 connected to up bridge1:port11
-        BridgeBuilder bridge1B = bridge0B.connectToNewBridge(bridge1, bridge1portCounter);
-        // instead of:
-        // createAndPersistBridgeBridgeLink(bridge1, bridge1portCounter, bridge0, bridge0portCounter);
+        BridgeBuilder bridge1B = bridge0B.connectToNewBridge(bridge1, 11);
 
         //bridge3:port31 connected to up bridge0:port2
-        BridgeBuilder bridge3B = bridge0B.connectToNewBridge(bridge3, bridge3portCounter);
-        bridge0portCounter++;
-        // instead of:
-        // createAndPersistBridgeBridgeLink(bridge3, bridge3portCounter, bridge0, bridge0portCounter);
+        BridgeBuilder bridge3B = bridge0B.connectToNewBridge(bridge3, 31);
 
         //bridge0:port3 connected to cloud
-        bridge0portCounter++;
         bridge0B.increasePortCounter();
         bridge0B.createAndPersistCloud(2, 2);
-        // instead off:
-        // createAndPersistCloud(bridge0, bridge0portCounter, 2, 2);
 
         // bridge0:port4 connected to host4:port41
-        bridge0portCounter++;
         bridge0B.increasePortCounter();
-        bridge0B.createAndPersistBridgeMacLink(host4, host4portCounter, bridge0);
-        // instead of:
-        // createAndPersistBridgeMacLink(bridge0, bridge0portCounter, host4, host4portCounter, bridge0);
+        bridge0B.createAndPersistBridgeMacLink(host4, 41, bridge0);
 
-        // bridge0:port5 connected to host5:port51
-        bridge0portCounter++;
         bridge0B.increasePortCounter();
-        bridge0B.createAndPersistBridgeMacLink(host5, host5portCounter, bridge0);
-        // instead of:
-        // createAndPersistBridgeMacLink(bridge0, bridge0portCounter, host5, host5portCounter, bridge0);
+        bridge0B.createAndPersistBridgeMacLink(host5, 51, bridge0);
 
         //bridge1
         //bridge2:port21 connected to bridge1:port12 with clouds
-        bridge1portCounter++;
-        BridgeBuilder bridge2B = bridge1B.connectToNewBridge(bridge2, bridge2portCounter);
-// instead of
-  // createAndPersistBridgeBridgeLink(bridge2, bridge2portCounter, bridge1, bridge1portCounter);
-
+        BridgeBuilder bridge2B = bridge1B.connectToNewBridge(bridge2, 21);
         bridge1B.createAndPersistCloud(2, 2);
-  // instead of
-         // createAndPersistCloud(bridge1, bridge1portCounter, 2, 2);
         
         //bridge2
         // host6 and host 7 connected to port 22 : "cloud" symbol
-        bridge2portCounter++;
         bridge2B.increasePortCounter();
-        bridge2B.createAndPersistBridgeMacLink(true,  host6, host6portCounter, bridge0);
-        // instead of
-        // createAndPersistBridgeMacLink(bridge2, bridge2portCounter, true,  host6, host6portCounter, bridge0);
-        bridge2B.createAndPersistBridgeMacLink(false, host7, host7portCounter, bridge0);
-        // instead of
-        // createAndPersistBridgeMacLink(bridge2, bridge2portCounter, false, host7, host7portCounter, bridge0);
+        bridge2B.createAndPersistBridgeMacLink(true,  host6, 61, bridge0);
+        bridge2B.createAndPersistBridgeMacLink(false, host7, 71, bridge0);
         
         // bridge3
         // host8:with-no-snmp connected bridge3:port32
-        bridge3portCounter++;
         bridge3B.increasePortCounter();
         bridge3B.createAndPersistBridgeMacLink(host8, null, bridge0);
-        // instead of
-        // createAndPersistBridgeMacLink(bridge3, bridge3portCounter, host8, null, bridge0);
-        // host9:with-no-snmp connected bridge3:port33
-        bridge3portCounter++;
         bridge3B.increasePortCounter();
         bridge3B.createAndPersistBridgeMacLink(host9, null, bridge0);
-        // instead of
-        // createAndPersistBridgeMacLink(bridge3, bridge3portCounter, host9, null, bridge0);
     }
 
-    private void createAndPersistBridgeBridgeLink(final OnmsNode bridge, final Integer port, final OnmsNode designated, final Integer designatedPort) {
-        createAndPersistBridgeBridgeLink(bridge, port, true, designated, designatedPort, true);
-    }
-
-    private void createAndPersistBridgeBridgeLink(OnmsNode bridge, Integer port, boolean createSnmpInterface, OnmsNode designated, Integer designatedPort, boolean createdesignatedsnmpInterface) {
-        if (createSnmpInterface) {
-            context.getTopologyPersister().persist(
-                    createSnmpInterface(port, bridge)
-            );
-        }
-        if (createdesignatedsnmpInterface) {
-            context.getTopologyPersister().persist(
-                    createSnmpInterface(designatedPort, designated)
-            );
-        }
-        context.getTopologyPersister().persist(
-                createBridgeBridgeLink(bridge, designated, port, designatedPort)
-        );
-    }
-
-    private void createAndPersistBridgeMacLink(OnmsNode bridge, Integer port, OnmsNode host, Integer hostPort, OnmsNode gateway) {
-        createAndPersistBridgeMacLink(bridge, port, true, host, hostPort, gateway);
-    }
-
-    private void createAndPersistBridgeMacLink(OnmsNode bridge, Integer port, boolean createsnmpinterface, OnmsNode host, Integer hostPort, OnmsNode gateway) {
-        String mac=macGenerator.next();
-        InetAddress ip= inetGenerator.next();
-        if (createsnmpinterface) {
-            context.getTopologyPersister().persist(
-                    createSnmpInterface(port, bridge)
-            );
-        }
-        if (hostPort != null) {
-            OnmsSnmpInterface snmpInterface = createSnmpInterface(hostPort, host);
-            context.getTopologyPersister().persist(
-                    snmpInterface
-            );
-            OnmsIpInterface ipInterface = createIpInterface(snmpInterface, ip);
-            context.getTopologyPersister().persist(ipInterface);
-        } else {
-            OnmsIpInterface ipInterface = createIpInterface(null,ip);
-            ipInterface.setNode(host);
-            context.getTopologyPersister().persist(ipInterface);
-        }
-        context.getTopologyPersister().persist(
-                createIpNetToMedia(host, hostPort, mac, ip, gateway)
-        );
-        context.getTopologyPersister().persist(
-                createBridgeMacLink(bridge, port, mac)
-        );
-    }
-
-    private void createAndPersistCloud(OnmsNode bridge, Integer port, int macaddresses, int ipaddresses) {
-        for (int i=0; i<ipaddresses;i++) {
-            String nextMac = macGenerator.next();
-            context.getTopologyPersister().persist(
-                    createIpNetToMedia(null, null, nextMac, inetGenerator.next(), bridge)
-            );
-            context.getTopologyPersister().persist(
-                    createBridgeMacLink(bridge, port, nextMac));
-        }
-
-        for (int i=0; i<macaddresses;i++) {
-            context.getTopologyPersister().persist(createBridgeMacLink(bridge, port, macGenerator.next()));
-        }
-    }
-
-    private BridgeElement createBridgeElement(OnmsNode node) {
-        BridgeElement bridge = new BridgeElement();
-        bridge.setNode(node);
-        bridge.setBaseBridgeAddress(macGenerator.next());
-        bridge.setBaseType(BridgeDot1dBaseType.DOT1DBASETYPE_TRANSPARENT_ONLY);
-        bridge.setBridgeNodeLastPollTime(new Date());
-        bridge.setBaseNumPorts(topologySettings.getAmountLinks());
-        bridge.setVlan(VLAN_ID);
-        bridge.setVlanname("default");
-        return bridge;
-    }
-
-    private BridgeBridgeLink createBridgeBridgeLink(OnmsNode node, OnmsNode designatedNode, int port, int designatedPort) {
-        BridgeBridgeLink link = new BridgeBridgeLink();
-        link.setBridgePortIfIndex(port);
-        link.setBridgePort(port);
-        link.setVlan(1);
-        link.setNode(node);
-        link.setDesignatedNode(designatedNode);
-        link.setDesignatedPort(designatedPort);
-        link.setDesignatedPortIfIndex(designatedPort);
-        link.setDesignatedVlan(VLAN_ID);
-        link.setBridgeBridgeLinkLastPollTime(new Date());
-        return link;
-    }
-
-    private BridgeMacLink createBridgeMacLink(OnmsNode bridge, Integer bridgePort, String mac){
-        BridgeMacLink bridgeMacLink = new BridgeMacLink();
-        bridgeMacLink.setNode(bridge);
-        bridgeMacLink.setBridgePort(bridgePort);
-        bridgeMacLink.setBridgePortIfIndex(bridgePort);
-        bridgeMacLink.setLinkType(BridgeMacLink.BridgeMacLinkType.BRIDGE_LINK);
-        bridgeMacLink.setMacAddress(mac);
-        bridgeMacLink.setVlan(VLAN_ID);
-        bridgeMacLink.setBridgeMacLinkLastPollTime(new Date());
-        return bridgeMacLink;
-    }
-
-    private IpNetToMedia createIpNetToMedia(OnmsNode node, Integer ifindex, String mac, InetAddress inetAddress, OnmsNode sourceNode){
-        IpNetToMedia ipNetToMedia = new IpNetToMedia();
-        ipNetToMedia.setCreateTime(new Date());
-        if (node != null && ifindex == null ) {
-            ipNetToMedia.setIfIndex(-1);
-        } else {
-            ipNetToMedia.setIfIndex(ifindex);
-        }
-        ipNetToMedia.setLastPollTime(new Date());
-        ipNetToMedia.setIpNetToMediaType(IpNetToMedia.IpNetToMediaType.IPNETTOMEDIA_TYPE_DYNAMIC);
-        ipNetToMedia.setNetAddress(inetAddress);
-        ipNetToMedia.setPhysAddress(mac);
-        ipNetToMedia.setNode(node);
-        ipNetToMedia.setSourceIfIndex(0);
-        ipNetToMedia.setSourceNode(sourceNode);
-        return ipNetToMedia;
-    }
 }

--- a/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/BridgeProtocol.java
+++ b/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/BridgeProtocol.java
@@ -98,22 +98,27 @@ public class BridgeProtocol extends Protocol<BridgeBridgeLink> {
 
     @Override
     protected void createAndPersistProtocolSpecificEntities(List<OnmsNode> nodes) {
-
-        OnmsNode bridge0 =  nodes.get(0);
-        OnmsNode bridge1 =  nodes.get(1);
-        OnmsNode bridge2 =  nodes.get(2);
-        OnmsNode bridge3 =  nodes.get(3);
-        OnmsNode host4   =  nodes.get(4);
-        OnmsNode host5   =  nodes.get(5);
-        OnmsNode host6   =  nodes.get(6);
-        OnmsNode host7   =  nodes.get(7);
-        OnmsNode host8   =  nodes.get(8);
-        OnmsNode host9   =  nodes.get(9);
-
+        OnmsNode bridge0 = nodes.get(0);
         BridgeBuilderContext context = new BridgeBuilderContext(this.context.getTopologyPersister(), this.macGenerator, this.inetGenerator);
         BridgeBuilder bridge0B = new BridgeBuilder(bridge0, 0, context);
-        
-        //bridge0
+        createAndPersistProtocolSpecificEntities(nodes, bridge0B, bridge0, 0);
+
+    }
+
+     protected void createAndPersistProtocolSpecificEntities(List<OnmsNode> nodes, BridgeBuilder bridge0B, OnmsNode gateway, int iteration) {
+
+            int offset = iteration * 10;
+            OnmsNode bridge1 = nodes.get(1 + offset);
+            OnmsNode bridge2 = nodes.get(2 + offset);
+            OnmsNode bridge3 = nodes.get(3 + offset);
+            OnmsNode host4 = nodes.get(4 + offset);
+            OnmsNode bridge5 = nodes.get(5 + offset);
+            OnmsNode host6 = nodes.get(6 + offset);
+            OnmsNode host7 = nodes.get(7 + offset);
+            OnmsNode host8 = nodes.get(8 + offset);
+            OnmsNode host9 = nodes.get(9 + offset);
+
+            //bridge0
         //bridge0:port1 connected to up bridge1:port11
         BridgeBuilder bridge1B = bridge0B.connectToNewBridge(bridge1, 11);
 
@@ -126,10 +131,11 @@ public class BridgeProtocol extends Protocol<BridgeBridgeLink> {
 
         // bridge0:port4 connected to host4:port41
         bridge0B.increasePortCounter();
-        bridge0B.createAndPersistBridgeMacLink(host4, 41, bridge0);
+        bridge0B.createAndPersistBridgeMacLink(host4, 41, gateway);
 
-        bridge0B.increasePortCounter();
-        bridge0B.createAndPersistBridgeMacLink(host5, 51, bridge0);
+        // bridge0B.increasePortCounter();
+        BridgeBuilder bridge5B = bridge0B.connectToNewBridge(bridge5, 51);
+                // bridge0B.createAndPersistBridgeMacLink(host5, 51, gateway);
 
         //bridge1
         //bridge2:port21 connected to bridge1:port12 with clouds
@@ -139,15 +145,18 @@ public class BridgeProtocol extends Protocol<BridgeBridgeLink> {
         //bridge2
         // host6 and host 7 connected to port 22 : "cloud" symbol
         bridge2B.increasePortCounter();
-        bridge2B.createAndPersistBridgeMacLink(true,  host6, 61, bridge0);
-        bridge2B.createAndPersistBridgeMacLink(false, host7, 71, bridge0);
+        bridge2B.createAndPersistBridgeMacLink(true,  host6, 61, gateway);
+        bridge2B.createAndPersistBridgeMacLink(false, host7, 71, gateway);
         
         // bridge3
         // host8:with-no-snmp connected bridge3:port32
         bridge3B.increasePortCounter();
-        bridge3B.createAndPersistBridgeMacLink(host8, null, bridge0);
+        bridge3B.createAndPersistBridgeMacLink(host8, null, gateway);
         bridge3B.increasePortCounter();
-        bridge3B.createAndPersistBridgeMacLink(host9, null, bridge0);
-    }
+        bridge3B.createAndPersistBridgeMacLink(host9, null, gateway);
 
+        if(nodes.size() >= offset + 20 ) {
+            createAndPersistProtocolSpecificEntities(nodes, bridge5B, gateway, iteration+1);
+        }
+    }
 }

--- a/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/BridgeProtocol.java
+++ b/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/BridgeProtocol.java
@@ -123,14 +123,14 @@ public class BridgeProtocol extends Protocol<BridgeBridgeLink> {
 
 
         // save bridge element
-        this.context.getTopologyPersister().persist(
-            createBridgeElement(bridge0),
-                // instead of:
-            createBridgeElement(bridge1),
-            createBridgeElement(bridge2),
-                // instead of:
-                createBridgeElement(bridge3)
-        );
+//        this.context.getTopologyPersister().persist(
+//            createBridgeElement(bridge0),
+//                // instead of:
+//            createBridgeElement(bridge1),
+//            createBridgeElement(bridge2),
+//                // instead of:
+//                createBridgeElement(bridge3)
+//        );
         
         //bridge0
         //bridge0:port1 connected to up bridge1:port11
@@ -139,51 +139,67 @@ public class BridgeProtocol extends Protocol<BridgeBridgeLink> {
         // createAndPersistBridgeBridgeLink(bridge1, bridge1portCounter, bridge0, bridge0portCounter);
 
         //bridge3:port31 connected to up bridge0:port2
-        bridge0B.connectToNewBridge(bridge3, bridge3portCounter);
+        BridgeBuilder bridge3B = bridge0B.connectToNewBridge(bridge3, bridge3portCounter);
         bridge0portCounter++;
         // instead of:
         // createAndPersistBridgeBridgeLink(bridge3, bridge3portCounter, bridge0, bridge0portCounter);
 
         //bridge0:port3 connected to cloud
         bridge0portCounter++;
-        // bridge0B.createAndPersistCloud(2, 2);
+        bridge0B.increasePortCounter();
+        bridge0B.createAndPersistCloud(2, 2);
         // instead off:
-        createAndPersistCloud(bridge0, bridge0portCounter, 2, 2);
+        // createAndPersistCloud(bridge0, bridge0portCounter, 2, 2);
 
         // bridge0:port4 connected to host4:port41
         bridge0portCounter++;
-        // bridge0B.createAndPersistBridgeMacLink(host4, host4portCounter);
+        bridge0B.increasePortCounter();
+        bridge0B.createAndPersistBridgeMacLink(host4, host4portCounter, bridge0);
         // instead of:
-        createAndPersistBridgeMacLink(bridge0, bridge0portCounter, host4, host4portCounter, bridge0);
+        // createAndPersistBridgeMacLink(bridge0, bridge0portCounter, host4, host4portCounter, bridge0);
 
         // bridge0:port5 connected to host5:port51
         bridge0portCounter++;
-        // bridge0B.createAndPersistBridgeMacLink(host5, host5portCounter);
+        bridge0B.increasePortCounter();
+        bridge0B.createAndPersistBridgeMacLink(host5, host5portCounter, bridge0);
         // instead of:
-        createAndPersistBridgeMacLink(bridge0, bridge0portCounter, host5, host5portCounter, bridge0);
+        // createAndPersistBridgeMacLink(bridge0, bridge0portCounter, host5, host5portCounter, bridge0);
 
         //bridge1
         //bridge2:port21 connected to bridge1:port12 with clouds
         bridge1portCounter++;
-        bridge1B.connectToNewBridge(bridge2, bridge2portCounter);
+        BridgeBuilder bridge2B = bridge1B.connectToNewBridge(bridge2, bridge2portCounter);
 // instead of
   // createAndPersistBridgeBridgeLink(bridge2, bridge2portCounter, bridge1, bridge1portCounter);
-//         bridge1B.createAndPersistCloud(2, 2);
-         createAndPersistCloud(bridge1, bridge1portCounter, 2, 2);
+
+        bridge1B.createAndPersistCloud(2, 2);
+  // instead of
+         // createAndPersistCloud(bridge1, bridge1portCounter, 2, 2);
         
         //bridge2
-        // host6 and host 7 connected to port 22 
+        // host6 and host 7 connected to port 22 : "cloud" symbol
         bridge2portCounter++;
-        createAndPersistBridgeMacLink(bridge2, bridge2portCounter, true,  host6, host6portCounter, bridge0);
-        createAndPersistBridgeMacLink(bridge2, bridge2portCounter, false, host7, host7portCounter, bridge0);
+        bridge2B.increasePortCounter();
+        bridge2B.createAndPersistBridgeMacLink(true,  host6, host6portCounter, bridge0);
+        // instead of
+        // createAndPersistBridgeMacLink(bridge2, bridge2portCounter, true,  host6, host6portCounter, bridge0);
+        bridge2B.createAndPersistBridgeMacLink(false, host7, host7portCounter, bridge0);
+        // instead of
+        // createAndPersistBridgeMacLink(bridge2, bridge2portCounter, false, host7, host7portCounter, bridge0);
         
         // bridge3
         // host8:with-no-snmp connected bridge3:port32
         bridge3portCounter++;
-        createAndPersistBridgeMacLink(bridge3, bridge3portCounter, host8, null, bridge0);
+        bridge3B.increasePortCounter();
+        bridge3B.createAndPersistBridgeMacLink(host8, null, bridge0);
+        // instead of
+        // createAndPersistBridgeMacLink(bridge3, bridge3portCounter, host8, null, bridge0);
         // host9:with-no-snmp connected bridge3:port33
         bridge3portCounter++;
-        createAndPersistBridgeMacLink(bridge3, bridge3portCounter, host9, null, bridge0);
+        bridge3B.increasePortCounter();
+        bridge3B.createAndPersistBridgeMacLink(host9, null, bridge0);
+        // instead of
+        // createAndPersistBridgeMacLink(bridge3, bridge3portCounter, host9, null, bridge0);
     }
 
     private void createAndPersistBridgeBridgeLink(final OnmsNode bridge, final Integer port, final OnmsNode designated, final Integer designatedPort) {

--- a/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/BridgeProtocol.java
+++ b/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/BridgeProtocol.java
@@ -42,8 +42,8 @@ import org.opennms.netmgt.model.OnmsNode;
 
 /**
  * Creates a topology with Bridges and Segments.
- * Call with: enlinkd:generate-topology --protocol bridge --nodes
- * Example:
+ * Call with: enlinkd:generate-topology --protocol bridge --nodes 10
+ * will result in:
  *
  *                           bridge0
  *           ------------------------------------
@@ -59,15 +59,7 @@ import org.opennms.netmgt.model.OnmsNode;
  * no node     |
  *          Segment
  *
- * 6 nodes are hosts: host4,host5, host6, host7, host8, host9
- * generate 4 ipnettomedia without a corresponding node
- * consider also that on port 1 of C is connected an HUB with a group of hosts connected
- * the hub has no snmp agent and therefore we are not to explore his mab forwarding table
- * we also follow the convention to start the port countin from the if of the node
- * following an integer: so port11 -> is the first generated port of node with id 1
- * port12 -> is the second generated port of node with id 1
- * port21 -> is the first generated port of node with id 2
- * port53 -> is the third generated port of node with id 5
+ * If more than 10 nodes are requested then the tree repeats itself with bridge5 as the root node of the new subtree.
  */
 public class BridgeProtocol extends Protocol<BridgeBridgeLink> {
 
@@ -122,7 +114,7 @@ public class BridgeProtocol extends Protocol<BridgeBridgeLink> {
 
     }
 
-    protected void createAndPersistProtocolSpecificEntities(List<OnmsNode> nodes, BridgeBuilder bridge0B, OnmsNode gateway, int iteration) {
+    private void createAndPersistProtocolSpecificEntities(List<OnmsNode> nodes, BridgeBuilder bridge0B, OnmsNode gateway, int iteration) {
 
         int offset = iteration * 10;
         OnmsNode bridge1 = nodes.get(1 + offset);
@@ -171,6 +163,7 @@ public class BridgeProtocol extends Protocol<BridgeBridgeLink> {
         bridge3B.increasePortCounter();
         bridge3B.createAndPersistBridgeMacLink(host9, null, gateway);
 
+        // create sub tree on bridge5:
         if (nodes.size() >= offset + 20) {
             createAndPersistProtocolSpecificEntities(nodes, bridge5B, gateway, iteration + 1);
         }

--- a/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/Protocol.java
+++ b/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/Protocol.java
@@ -130,7 +130,7 @@ public abstract class Protocol<Element> {
         return interfaces;
     }
 
-    private OnmsSnmpInterface createSnmpInterface(int ifIndex, OnmsNode node) {
+    protected OnmsSnmpInterface createSnmpInterface(int ifIndex, OnmsNode node) {
         OnmsSnmpInterface onmsSnmpInterface = new OnmsSnmpInterface();
         onmsSnmpInterface.setId((node.getId() * topologySettings.getAmountSnmpInterfaces()) + ifIndex);
         onmsSnmpInterface.setNode(node);
@@ -155,7 +155,7 @@ public abstract class Protocol<Element> {
         return interfaces;
     }
 
-    private OnmsIpInterface createIpInterface(OnmsSnmpInterface snmp, InetAddress inetAddress) {
+    protected OnmsIpInterface createIpInterface(OnmsSnmpInterface snmp, InetAddress inetAddress) {
         OnmsIpInterface ip = new OnmsIpInterface();
         ip.setId(snmp.getId());
         ip.setSnmpInterface(snmp);

--- a/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/Protocol.java
+++ b/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/Protocol.java
@@ -60,19 +60,12 @@ public abstract class Protocol<Element> {
     final Map<Integer, Integer> nodeIfIndexes = new HashMap<>();
 
     public Protocol(TopologySettings topologySettings, TopologyContext context) {
-        this.topologySettings = topologySettings;
+        this.topologySettings = adoptAndVerifySettings(topologySettings);
         this.context = context;
     }
 
     public void createAndPersistNetwork() {
-        this.context.currentProgress("%nCreating %s %s topology with %s Nodes, %s Elements, %s Links, %s SnmpInterfaces, %s IpInterfaces:",
-                topologySettings.getTopology(),
-                this.getProtocol(),
-                topologySettings.getAmountNodes(),
-                topologySettings.getAmountElements(),
-                topologySettings.getAmountElements(),
-                topologySettings.getAmountSnmpInterfaces(),
-                topologySettings.getAmountIpInterfaces());
+        printProtocolSpecificMessage();
         OnmsCategory category = createCategory();
         context.getTopologyPersister().persist(category);
         List<OnmsNode> nodes = createNodes(topologySettings.getAmountNodes(), category);
@@ -85,11 +78,27 @@ public abstract class Protocol<Element> {
         createAndPersistProtocolSpecificEntities(nodes);
     }
 
+    protected void printProtocolSpecificMessage() {
+        this.context.currentProgress("%nCreating %s %s topology with %s Nodes, %s Elements, %s Links, %s SnmpInterfaces, %s IpInterfaces:",
+                topologySettings.getTopology(),
+                this.getProtocol(),
+                topologySettings.getAmountNodes(),
+                topologySettings.getAmountElements(),
+                topologySettings.getAmountElements(),
+                topologySettings.getAmountSnmpInterfaces(),
+                topologySettings.getAmountIpInterfaces());
+    }
+
     protected abstract void createAndPersistProtocolSpecificEntities(List<OnmsNode> nodes);
 
     protected abstract TopologyGenerator.Protocol getProtocol();
 
-    private OnmsCategory createCategory() {
+    protected TopologySettings adoptAndVerifySettings(TopologySettings topologySettings) {
+        topologySettings.verify();
+        return topologySettings;
+    }
+
+    protected OnmsCategory createCategory() {
         OnmsCategory category = new OnmsCategory();
         category.setName(TopologyGenerator.CATEGORY_NAME);
         return category;

--- a/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/Protocol.java
+++ b/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/Protocol.java
@@ -34,6 +34,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import org.opennms.enlinkd.generator.TopologyContext;
 import org.opennms.enlinkd.generator.TopologyGenerator;
@@ -160,7 +161,7 @@ public abstract class Protocol<Element> {
         ip.setId(snmp.getId());
         ip.setSnmpInterface(snmp);
         ip.setIpLastCapsdPoll(new Date());
-        ip.setNode(snmp.getNode());
+        ip.setNode(Optional.ofNullable(snmp).map(OnmsSnmpInterface::getNode).orElse(null));
         ip.setIpAddress(inetAddress);
         return ip;
     }

--- a/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/bridge/BridgeBuilder.java
+++ b/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/bridge/BridgeBuilder.java
@@ -1,0 +1,217 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.enlinkd.generator.protocol.bridge;
+
+import java.net.InetAddress;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+
+import org.opennms.enlinkd.generator.TopologyPersister;
+import org.opennms.netmgt.enlinkd.model.BridgeBridgeLink;
+import org.opennms.netmgt.enlinkd.model.BridgeElement;
+import org.opennms.netmgt.enlinkd.model.BridgeMacLink;
+import org.opennms.netmgt.enlinkd.model.IpNetToMedia;
+import org.opennms.netmgt.model.OnmsIpInterface;
+import org.opennms.netmgt.model.OnmsNode;
+import org.opennms.netmgt.model.OnmsSnmpInterface;
+
+public class BridgeBuilder {
+
+    /* this is the vlan id for all the bridgebridgelinks and bridgemaclinks */
+    private final static int VLAN_ID = 1;
+
+    private OnmsNode node;
+    private int bridgePortCounter;
+    private BridgeBuilderContext context;
+    private List<Object> objectsToPersist;
+
+    public BridgeBuilder(OnmsNode node, int bridgePortCounter, BridgeBuilderContext context) {
+        this.node = node;
+        this.bridgePortCounter = bridgePortCounter;
+        this.context = context;
+    }
+
+    public BridgeBuilder connectToNewBridge(OnmsNode targetNode, int targetNodePortCounter) {
+//        BridgeElement bridgeElement = createBridgeElement(targetNode);
+//        this.context.getTopologyPersister().persist(bridgeElement);
+        this.bridgePortCounter ++;
+        createAndPersistBridgeBridgeLink(targetNode, targetNodePortCounter, this.node, this.bridgePortCounter);
+        return new BridgeBuilder(targetNode, targetNodePortCounter , this.context);
+    }
+
+    private BridgeElement createBridgeElement(OnmsNode node) {
+        BridgeElement bridge = new BridgeElement();
+        bridge.setNode(node);
+        bridge.setBaseBridgeAddress(this.context.getNextMacAddress());
+        bridge.setBaseType(BridgeElement.BridgeDot1dBaseType.DOT1DBASETYPE_TRANSPARENT_ONLY);
+        bridge.setBridgeNodeLastPollTime(new Date());
+        bridge.setBaseNumPorts(3);
+        bridge.setVlan(VLAN_ID);
+        bridge.setVlanname("default");
+        return bridge;
+    }
+
+    private void createAndPersistBridgeBridgeLink(OnmsNode bridge, Integer port, OnmsNode designated, Integer designatedPort) {
+        createAndPersistBridgeBridgeLink(bridge, port, true, designated, designatedPort, true);
+    }
+
+    private void createAndPersistBridgeBridgeLink(OnmsNode bridge, Integer port, boolean createSnmpInterface, OnmsNode designated, Integer designatedPort, boolean createdesignatedsnmpInterface) {
+        if (createSnmpInterface) {
+            context.getTopologyPersister().persist(
+                    createSnmpInterface(port, bridge)
+            );
+        }
+        if (createdesignatedsnmpInterface) {
+            context.getTopologyPersister().persist(
+                    createSnmpInterface(designatedPort, designated)
+            );
+        }
+        context.getTopologyPersister().persist(
+                createBridgeBridgeLink(bridge, designated, port, designatedPort)
+        );
+    }
+
+    public void createAndPersistCloud(int macaddresses, int ipaddresses) {
+        for (int i=0; i<ipaddresses;i++) {
+            String nextMac = context.getNextMacAddress();
+            context.getTopologyPersister().persist(
+                    createIpNetToMedia(null, null, nextMac, context.getInetAddress(), this.node)
+            );
+            context.getTopologyPersister().persist(
+                    createBridgeMacLink(this.node, this.bridgePortCounter, nextMac));
+        }
+
+        for (int i=0; i<macaddresses;i++) {
+            context.getTopologyPersister().persist(createBridgeMacLink(this.node, this.bridgePortCounter, context.getNextMacAddress()));
+        }
+
+    }
+
+    public void createAndPersistBridgeMacLink(OnmsNode host, Integer hostPort) {
+        createAndPersistBridgeMacLink(true, host, hostPort);
+    }
+
+    private void createAndPersistBridgeMacLink(boolean createsnmpinterface, OnmsNode host, Integer hostPort) {
+        this.bridgePortCounter ++;
+        String mac=this.context.getNextMacAddress();
+        InetAddress ip= this.context.getInetAddress();
+        if (createsnmpinterface) {
+            context.getTopologyPersister().persist(
+                    createSnmpInterface(this.bridgePortCounter, this.node)
+            );
+        }
+        if (hostPort != null) {
+            OnmsSnmpInterface snmpInterface = createSnmpInterface(hostPort, host);
+            context.getTopologyPersister().persist(
+                    snmpInterface
+            );
+            OnmsIpInterface ipInterface = createIpInterface(snmpInterface, ip);
+            context.getTopologyPersister().persist(ipInterface);
+        } else {
+            OnmsIpInterface ipInterface = createIpInterface(null,ip);
+            ipInterface.setNode(host);
+            context.getTopologyPersister().persist(ipInterface);
+        }
+        context.getTopologyPersister().persist(
+                createIpNetToMedia(host, hostPort, mac, ip, this.node)
+        );
+        context.getTopologyPersister().persist(
+                createBridgeMacLink(this.node, this.bridgePortCounter, mac)
+        );
+
+    }
+
+    protected OnmsIpInterface createIpInterface(OnmsSnmpInterface snmp, InetAddress inetAddress) {
+        OnmsIpInterface ip = new OnmsIpInterface();
+        ip.setSnmpInterface(snmp);
+        ip.setIpLastCapsdPoll(new Date());
+        ip.setNode(Optional.ofNullable(snmp).map(OnmsSnmpInterface::getNode).orElse(null));
+        ip.setIpAddress(inetAddress);
+        return ip;
+    }
+
+    private BridgeMacLink createBridgeMacLink(OnmsNode bridge, Integer bridgePort, String mac){
+        BridgeMacLink bridgeMacLink = new BridgeMacLink();
+        bridgeMacLink.setNode(bridge);
+        bridgeMacLink.setBridgePort(bridgePort);
+        bridgeMacLink.setBridgePortIfIndex(bridgePort);
+        bridgeMacLink.setLinkType(BridgeMacLink.BridgeMacLinkType.BRIDGE_LINK);
+        bridgeMacLink.setMacAddress(mac);
+        bridgeMacLink.setVlan(VLAN_ID);
+        bridgeMacLink.setBridgeMacLinkLastPollTime(new Date());
+        return bridgeMacLink;
+    }
+
+    protected OnmsSnmpInterface createSnmpInterface(int ifIndex, OnmsNode node) {
+        OnmsSnmpInterface onmsSnmpInterface = new OnmsSnmpInterface();
+        onmsSnmpInterface.setNode(node);
+        onmsSnmpInterface.setIfIndex(ifIndex);
+        onmsSnmpInterface.setIfType(4);
+        onmsSnmpInterface.setIfSpeed(5L);
+        onmsSnmpInterface.setIfAdminStatus(6);
+        onmsSnmpInterface.setIfOperStatus(7);
+        onmsSnmpInterface.setLastCapsdPoll(new Date());
+        onmsSnmpInterface.setLastSnmpPoll(new Date());
+
+        return onmsSnmpInterface;
+    }
+
+    private BridgeBridgeLink createBridgeBridgeLink(OnmsNode node, OnmsNode designatedNode, int port, int designatedPort) {
+        BridgeBridgeLink link = new BridgeBridgeLink();
+        link.setBridgePortIfIndex(port);
+        link.setBridgePort(port);
+        link.setVlan(1);
+        link.setNode(node);
+        link.setDesignatedNode(designatedNode);
+        link.setDesignatedPort(designatedPort);
+        link.setDesignatedPortIfIndex(designatedPort);
+        link.setDesignatedVlan(VLAN_ID);
+        link.setBridgeBridgeLinkLastPollTime(new Date());
+        return link;
+    }
+
+    private IpNetToMedia createIpNetToMedia(OnmsNode node, Integer ifindex, String mac, InetAddress inetAddress, OnmsNode sourceNode){
+        IpNetToMedia ipNetToMedia = new IpNetToMedia();
+        ipNetToMedia.setCreateTime(new Date());
+        if (node != null && ifindex == null ) {
+            ipNetToMedia.setIfIndex(-1);
+        } else {
+            ipNetToMedia.setIfIndex(ifindex);
+        }
+        ipNetToMedia.setLastPollTime(new Date());
+        ipNetToMedia.setIpNetToMediaType(IpNetToMedia.IpNetToMediaType.IPNETTOMEDIA_TYPE_DYNAMIC);
+        ipNetToMedia.setNetAddress(inetAddress);
+        ipNetToMedia.setPhysAddress(mac);
+        ipNetToMedia.setNode(node);
+        ipNetToMedia.setSourceIfIndex(0);
+        ipNetToMedia.setSourceNode(sourceNode);
+        return ipNetToMedia;
+    }
+}

--- a/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/bridge/BridgeBuilder.java
+++ b/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/bridge/BridgeBuilder.java
@@ -49,7 +49,6 @@ public class BridgeBuilder {
     private OnmsNode node;
     private int bridgePortCounter;
     private BridgeBuilderContext context;
-    private List<Object> objectsToPersist;
 
     public BridgeBuilder(OnmsNode node, int bridgePortCounter, BridgeBuilderContext context) {
         this.node = node;
@@ -102,7 +101,6 @@ public class BridgeBuilder {
     }
 
     public void createAndPersistCloud(int macaddresses, int ipaddresses) {
-        // this.bridgePortCounter ++;
         for (int i=0; i<ipaddresses;i++) {
             String nextMac = context.getNextMacAddress();
             context.getTopologyPersister().persist(

--- a/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/bridge/BridgeBuilder.java
+++ b/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/bridge/BridgeBuilder.java
@@ -30,7 +30,6 @@ package org.opennms.enlinkd.generator.protocol.bridge;
 
 import java.net.InetAddress;
 import java.util.Date;
-import java.util.List;
 import java.util.Optional;
 
 import org.opennms.netmgt.enlinkd.model.BridgeBridgeLink;

--- a/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/bridge/BridgeBuilderContext.java
+++ b/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/bridge/BridgeBuilderContext.java
@@ -50,7 +50,7 @@ public class BridgeBuilderContext {
         return macGenerator.next();
     }
 
-    public InetAddress getInetAddress(){
+    public InetAddress getNextInetAddress(){
         return inetGenerator.next();
     }
 

--- a/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/bridge/BridgeBuilderContext.java
+++ b/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/bridge/BridgeBuilderContext.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.enlinkd.generator.protocol.bridge;
+
+import java.net.InetAddress;
+
+import org.opennms.enlinkd.generator.TopologyPersister;
+import org.opennms.enlinkd.generator.util.InetAddressGenerator;
+import org.opennms.enlinkd.generator.util.MacAddressGenerator;
+
+public class BridgeBuilderContext {
+
+    private final TopologyPersister topologyPersister;
+    private final MacAddressGenerator macGenerator;
+    private final InetAddressGenerator inetGenerator;
+
+    public BridgeBuilderContext(TopologyPersister topologyPersister, MacAddressGenerator macGenerator, InetAddressGenerator inetGenerator) {
+        this.topologyPersister = topologyPersister;
+        this.macGenerator = macGenerator;
+        this.inetGenerator = inetGenerator;
+    }
+
+    public String getNextMacAddress(){
+        return macGenerator.next();
+    }
+
+    public InetAddress getInetAddress(){
+        return inetGenerator.next();
+    }
+
+    public TopologyPersister getTopologyPersister(){
+        return topologyPersister;
+    }
+}

--- a/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/util/MacAddressGenerator.java
+++ b/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/util/MacAddressGenerator.java
@@ -35,6 +35,13 @@ public class MacAddressGenerator {
     public String next() {
         String s = String.format("%1$" + 12 + "s", Integer.toHexString(last)); // example: "           1"
         s = s.replace(' ', '0'); // example: "000000000001"
+        last++;
+        return s;
+    }
+
+    public String nextWithSeparator() {
+
+        String s = next();
         s = s.substring(0, 2)
                 + ':' + s.substring(2, 4)
                 + ':' + s.substring(4, 6)

--- a/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/util/MacAddressGenerator.java
+++ b/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/util/MacAddressGenerator.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.enlinkd.generator.util;
+
+public class MacAddressGenerator {
+
+    private int last = 0;
+
+    public String next() {
+        String s = String.format("%1$" + 12 + "s", Integer.toHexString(last)); // example: "           1"
+        s = s.replace(' ', '0'); // example: "000000000001"
+        s = s.substring(0, 2)
+                + ':' + s.substring(2, 4)
+                + ':' + s.substring(4, 6)
+                + ':' + s.substring(6, 8)
+                + ':' + s.substring(8, 10)
+                + ':' + s.substring(10, 12);
+        last++;
+        return s;
+    }
+}

--- a/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/util/MacAddressGenerator.java
+++ b/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/util/MacAddressGenerator.java
@@ -30,7 +30,8 @@ package org.opennms.enlinkd.generator.util;
 
 public class MacAddressGenerator {
 
-    private int last = 0;
+    //0000:0000:0000 is an invalid mac address
+    private int last = 1;
 
     public String next() {
         String s = String.format("%1$" + 12 + "s", Integer.toHexString(last)); // example: "           1"

--- a/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/util/MacAddressGenerator.java
+++ b/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/util/MacAddressGenerator.java
@@ -30,25 +30,12 @@ package org.opennms.enlinkd.generator.util;
 
 public class MacAddressGenerator {
 
-    //0000:0000:0000 is an invalid mac address
+    // we start with 1 since 0000:0000:0000 is an invalid mac address
     private int last = 1;
 
     public String next() {
         String s = String.format("%1$" + 12 + "s", Integer.toHexString(last)); // example: "           1"
         s = s.replace(' ', '0'); // example: "000000000001"
-        last++;
-        return s;
-    }
-
-    public String nextWithSeparator() {
-
-        String s = next();
-        s = s.substring(0, 2)
-                + ':' + s.substring(2, 4)
-                + ':' + s.substring(4, 6)
-                + ':' + s.substring(6, 8)
-                + ':' + s.substring(8, 10)
-                + ':' + s.substring(10, 12);
         last++;
         return s;
     }

--- a/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/util/MacAddressGenerator.java
+++ b/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/util/MacAddressGenerator.java
@@ -31,12 +31,12 @@ package org.opennms.enlinkd.generator.util;
 public class MacAddressGenerator {
 
     // we start with 1 since 0000:0000:0000 is an invalid mac address
-    private int last = 1;
+    private int next = 1;
 
     public String next() {
-        String s = String.format("%1$" + 12 + "s", Integer.toHexString(last)); // example: "           1"
+        String s = String.format("%1$" + 12 + "s", Integer.toHexString(next)); // example: "           1"
         s = s.replace(' ', '0'); // example: "000000000001"
-        last++;
+        next++;
         return s;
     }
 }

--- a/features/enlinkd/generator/src/test/java/org/opennms/enlinkd/generator/protocol/BridgeProtocolTest.java
+++ b/features/enlinkd/generator/src/test/java/org/opennms/enlinkd/generator/protocol/BridgeProtocolTest.java
@@ -38,14 +38,14 @@ public class BridgeProtocolTest {
 
     @Test
     public void testAdoptAndVerifySettings() {
-        testAmountNodes(10, -1);
-        testAmountNodes(10, 0);
-        testAmountNodes(10, 9);
-        testAmountNodes(10, 10);
-        testAmountNodes(20, 11);
-        testAmountNodes(20, 19);
-        testAmountNodes(20, 20);
-        testAmountNodes(30, 21);
+        testAmountNodes(11, -1);
+        testAmountNodes(11, 0);
+        testAmountNodes(11, 10);
+        testAmountNodes(11, 11);
+        testAmountNodes(21, 12);
+        testAmountNodes(21, 20);
+        testAmountNodes(21, 21);
+        testAmountNodes(31, 22);
     }
 
     private void testAmountNodes(int expected, int initialSetting) {

--- a/features/enlinkd/generator/src/test/java/org/opennms/enlinkd/generator/protocol/BridgeProtocolTest.java
+++ b/features/enlinkd/generator/src/test/java/org/opennms/enlinkd/generator/protocol/BridgeProtocolTest.java
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.enlinkd.generator.protocol;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+import org.opennms.enlinkd.generator.TopologySettings;
+
+
+public class BridgeProtocolTest {
+
+    @Test
+    public void testAdoptAndVerifySettings() {
+        testAmountNodes(10, -1);
+        testAmountNodes(10, 0);
+        testAmountNodes(10, 9);
+        testAmountNodes(10, 10);
+        testAmountNodes(20, 11);
+        testAmountNodes(20, 19);
+        testAmountNodes(20, 20);
+        testAmountNodes(30, 21);
+    }
+
+    private void testAmountNodes(int expected, int initialSetting) {
+        BridgeProtocol protocol = new BridgeProtocol(TopologySettings.builder().build(), null);
+        TopologySettings settings = protocol.adoptAndVerifySettings(TopologySettings.builder().amountNodes(initialSetting).build());
+        assertEquals(expected, settings.getAmountNodes());
+    }
+}

--- a/features/enlinkd/generator/src/test/java/org/opennms/enlinkd/generator/util/MacAddressGeneratorTest.java
+++ b/features/enlinkd/generator/src/test/java/org/opennms/enlinkd/generator/util/MacAddressGeneratorTest.java
@@ -1,0 +1,75 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.enlinkd.generator.util;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class MacAddressGeneratorTest {
+
+    @Test
+    public void shouldProduceStreamOfMacAddresses() {
+        MacAddressGenerator gen = new MacAddressGenerator();
+        assertEquals("00:00:00:00:00:00", gen.next());
+        assertEquals("00:00:00:00:00:01", gen.next());
+        assertEquals("00:00:00:00:00:02", gen.next());
+        assertEquals("00:00:00:00:00:03", gen.next());
+        assertEquals("00:00:00:00:00:04", gen.next());
+        assertEquals("00:00:00:00:00:05", gen.next());
+        assertEquals("00:00:00:00:00:06", gen.next());
+        assertEquals("00:00:00:00:00:07", gen.next());
+        assertEquals("00:00:00:00:00:08", gen.next());
+        assertEquals("00:00:00:00:00:09", gen.next());
+        assertEquals("00:00:00:00:00:0a", gen.next());
+        assertEquals("00:00:00:00:00:0b", gen.next());
+        assertEquals("00:00:00:00:00:0c", gen.next());
+        assertEquals("00:00:00:00:00:0d", gen.next());
+        assertEquals("00:00:00:00:00:0e", gen.next());
+        assertEquals("00:00:00:00:00:0f", gen.next());
+
+        assertEquals("00:00:00:00:00:10", gen.next());
+        assertEquals("00:00:00:00:00:11", gen.next());
+        assertEquals("00:00:00:00:00:12", gen.next());
+        assertEquals("00:00:00:00:00:13", gen.next());
+        assertEquals("00:00:00:00:00:14", gen.next());
+        assertEquals("00:00:00:00:00:15", gen.next());
+        assertEquals("00:00:00:00:00:16", gen.next());
+        assertEquals("00:00:00:00:00:17", gen.next());
+        assertEquals("00:00:00:00:00:18", gen.next());
+        assertEquals("00:00:00:00:00:19", gen.next());
+        assertEquals("00:00:00:00:00:1a", gen.next());
+        assertEquals("00:00:00:00:00:1b", gen.next());
+        assertEquals("00:00:00:00:00:1c", gen.next());
+        assertEquals("00:00:00:00:00:1d", gen.next());
+        assertEquals("00:00:00:00:00:1e", gen.next());
+        assertEquals("00:00:00:00:00:1f", gen.next());
+
+    }
+}

--- a/features/enlinkd/generator/src/test/java/org/opennms/enlinkd/generator/util/MacAddressGeneratorTest.java
+++ b/features/enlinkd/generator/src/test/java/org/opennms/enlinkd/generator/util/MacAddressGeneratorTest.java
@@ -37,39 +37,39 @@ public class MacAddressGeneratorTest {
     @Test
     public void shouldProduceStreamOfMacAddresses() {
         MacAddressGenerator gen = new MacAddressGenerator();
-        assertEquals("00:00:00:00:00:00", gen.next());
-        assertEquals("00:00:00:00:00:01", gen.next());
-        assertEquals("00:00:00:00:00:02", gen.next());
-        assertEquals("00:00:00:00:00:03", gen.next());
-        assertEquals("00:00:00:00:00:04", gen.next());
-        assertEquals("00:00:00:00:00:05", gen.next());
-        assertEquals("00:00:00:00:00:06", gen.next());
-        assertEquals("00:00:00:00:00:07", gen.next());
-        assertEquals("00:00:00:00:00:08", gen.next());
-        assertEquals("00:00:00:00:00:09", gen.next());
-        assertEquals("00:00:00:00:00:0a", gen.next());
-        assertEquals("00:00:00:00:00:0b", gen.next());
-        assertEquals("00:00:00:00:00:0c", gen.next());
-        assertEquals("00:00:00:00:00:0d", gen.next());
-        assertEquals("00:00:00:00:00:0e", gen.next());
-        assertEquals("00:00:00:00:00:0f", gen.next());
+        assertEquals("00000000000000000", gen.next());
+        assertEquals("00000000000000001", gen.next());
+        assertEquals("00000000000000002", gen.next());
+        assertEquals("00000000000000003", gen.next());
+        assertEquals("00000000000000004", gen.next());
+        assertEquals("00000000000000005", gen.next());
+        assertEquals("00000000000000006", gen.next());
+        assertEquals("00000000000000007", gen.next());
+        assertEquals("00000000000000008", gen.next());
+        assertEquals("00000000000000009", gen.next());
+        assertEquals("0000000000000000a", gen.next());
+        assertEquals("0000000000000000b", gen.next());
+        assertEquals("0000000000000000c", gen.next());
+        assertEquals("0000000000000000d", gen.next());
+        assertEquals("0000000000000000e", gen.next());
+        assertEquals("0000000000000000f", gen.next());
 
-        assertEquals("00:00:00:00:00:10", gen.next());
-        assertEquals("00:00:00:00:00:11", gen.next());
-        assertEquals("00:00:00:00:00:12", gen.next());
-        assertEquals("00:00:00:00:00:13", gen.next());
-        assertEquals("00:00:00:00:00:14", gen.next());
-        assertEquals("00:00:00:00:00:15", gen.next());
-        assertEquals("00:00:00:00:00:16", gen.next());
-        assertEquals("00:00:00:00:00:17", gen.next());
-        assertEquals("00:00:00:00:00:18", gen.next());
-        assertEquals("00:00:00:00:00:19", gen.next());
-        assertEquals("00:00:00:00:00:1a", gen.next());
-        assertEquals("00:00:00:00:00:1b", gen.next());
-        assertEquals("00:00:00:00:00:1c", gen.next());
-        assertEquals("00:00:00:00:00:1d", gen.next());
-        assertEquals("00:00:00:00:00:1e", gen.next());
-        assertEquals("00:00:00:00:00:1f", gen.next());
+        assertEquals("00000000000000010", gen.next());
+        assertEquals("00000000000000011", gen.next());
+        assertEquals("00000000000000012", gen.next());
+        assertEquals("00000000000000013", gen.next());
+        assertEquals("00000000000000014", gen.next());
+        assertEquals("00000000000000015", gen.next());
+        assertEquals("00000000000000016", gen.next());
+        assertEquals("00000000000000017", gen.next());
+        assertEquals("00000000000000018", gen.next());
+        assertEquals("00000000000000019", gen.next());
+        assertEquals("0000000000000001a", gen.next());
+        assertEquals("0000000000000001b", gen.next());
+        assertEquals("0000000000000001c", gen.next());
+        assertEquals("0000000000000001d", gen.next());
+        assertEquals("0000000000000001e", gen.next());
+        assertEquals("0000000000000001f", gen.next());
 
     }
 }

--- a/features/enlinkd/generator/src/test/java/org/opennms/enlinkd/generator/util/MacAddressGeneratorTest.java
+++ b/features/enlinkd/generator/src/test/java/org/opennms/enlinkd/generator/util/MacAddressGeneratorTest.java
@@ -37,39 +37,38 @@ public class MacAddressGeneratorTest {
     @Test
     public void shouldProduceStreamOfMacAddresses() {
         MacAddressGenerator gen = new MacAddressGenerator();
-        assertEquals("00000000000000000", gen.next());
-        assertEquals("00000000000000001", gen.next());
-        assertEquals("00000000000000002", gen.next());
-        assertEquals("00000000000000003", gen.next());
-        assertEquals("00000000000000004", gen.next());
-        assertEquals("00000000000000005", gen.next());
-        assertEquals("00000000000000006", gen.next());
-        assertEquals("00000000000000007", gen.next());
-        assertEquals("00000000000000008", gen.next());
-        assertEquals("00000000000000009", gen.next());
-        assertEquals("0000000000000000a", gen.next());
-        assertEquals("0000000000000000b", gen.next());
-        assertEquals("0000000000000000c", gen.next());
-        assertEquals("0000000000000000d", gen.next());
-        assertEquals("0000000000000000e", gen.next());
-        assertEquals("0000000000000000f", gen.next());
+        assertEquals("000000000001", gen.next());
+        assertEquals("000000000002", gen.next());
+        assertEquals("000000000003", gen.next());
+        assertEquals("000000000004", gen.next());
+        assertEquals("000000000005", gen.next());
+        assertEquals("000000000006", gen.next());
+        assertEquals("000000000007", gen.next());
+        assertEquals("000000000008", gen.next());
+        assertEquals("000000000009", gen.next());
+        assertEquals("00000000000a", gen.next());
+        assertEquals("00000000000b", gen.next());
+        assertEquals("00000000000c", gen.next());
+        assertEquals("00000000000d", gen.next());
+        assertEquals("00000000000e", gen.next());
+        assertEquals("00000000000f", gen.next());
 
-        assertEquals("00000000000000010", gen.next());
-        assertEquals("00000000000000011", gen.next());
-        assertEquals("00000000000000012", gen.next());
-        assertEquals("00000000000000013", gen.next());
-        assertEquals("00000000000000014", gen.next());
-        assertEquals("00000000000000015", gen.next());
-        assertEquals("00000000000000016", gen.next());
-        assertEquals("00000000000000017", gen.next());
-        assertEquals("00000000000000018", gen.next());
-        assertEquals("00000000000000019", gen.next());
-        assertEquals("0000000000000001a", gen.next());
-        assertEquals("0000000000000001b", gen.next());
-        assertEquals("0000000000000001c", gen.next());
-        assertEquals("0000000000000001d", gen.next());
-        assertEquals("0000000000000001e", gen.next());
-        assertEquals("0000000000000001f", gen.next());
+        assertEquals("000000000010", gen.next());
+        assertEquals("000000000011", gen.next());
+        assertEquals("000000000012", gen.next());
+        assertEquals("000000000013", gen.next());
+        assertEquals("000000000014", gen.next());
+        assertEquals("000000000015", gen.next());
+        assertEquals("000000000016", gen.next());
+        assertEquals("000000000017", gen.next());
+        assertEquals("000000000018", gen.next());
+        assertEquals("000000000019", gen.next());
+        assertEquals("00000000001a", gen.next());
+        assertEquals("00000000001b", gen.next());
+        assertEquals("00000000001c", gen.next());
+        assertEquals("00000000001d", gen.next());
+        assertEquals("00000000001e", gen.next());
+        assertEquals("00000000001f", gen.next());
 
     }
 }

--- a/features/enlinkd/persistence/api/pom.xml
+++ b/features/enlinkd/persistence/api/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features.enlinkd</groupId>
     <artifactId>org.opennms.features.enlinkd.persistence</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>org.opennms.features.enlinkd.persistence.api</artifactId>

--- a/features/enlinkd/persistence/impl/pom.xml
+++ b/features/enlinkd/persistence/impl/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features.enlinkd</groupId>
     <artifactId>org.opennms.features.enlinkd.persistence</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>org.opennms.features.enlinkd.persistence.impl</artifactId>

--- a/features/enlinkd/persistence/pom.xml
+++ b/features/enlinkd/persistence/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>org.opennms.features.enlinkd</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.enlinkd</groupId>

--- a/features/enlinkd/pom.xml
+++ b/features/enlinkd/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>org.opennms.features</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features</groupId>

--- a/features/enlinkd/service/api/pom.xml
+++ b/features/enlinkd/service/api/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features.enlinkd</groupId>
     <artifactId>org.opennms.features.enlinkd.service</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>org.opennms.features.enlinkd.service.api</artifactId>

--- a/features/enlinkd/service/impl/pom.xml
+++ b/features/enlinkd/service/impl/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features.enlinkd</groupId>
     <artifactId>org.opennms.features.enlinkd.service</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>org.opennms.features.enlinkd.service.impl</artifactId>

--- a/features/enlinkd/service/impl/src/main/java/org/opennms/netmgt/enlinkd/service/impl/BridgeTopologyServiceImpl.java
+++ b/features/enlinkd/service/impl/src/main/java/org/opennms/netmgt/enlinkd/service/impl/BridgeTopologyServiceImpl.java
@@ -785,6 +785,10 @@ SEG:        for (SharedSegment segment : bmlsegments) {
 
     @Override
     public List<TopologyShared> match() {
+        // make sure the domains were loaded before calling this method, otherwise we end in a Nullpointer
+        if(m_domains == null){
+            load();
+        }
         final List<TopologyShared> links = new ArrayList<>();
         final List<MacPort> macPortMap = getMacPorts();
         

--- a/features/enlinkd/service/impl/src/main/java/org/opennms/netmgt/enlinkd/service/impl/BridgeTopologyServiceImpl.java
+++ b/features/enlinkd/service/impl/src/main/java/org/opennms/netmgt/enlinkd/service/impl/BridgeTopologyServiceImpl.java
@@ -784,11 +784,7 @@ SEG:        for (SharedSegment segment : bmlsegments) {
     }
 
     @Override
-    public List<TopologyShared> match() {
-        // make sure the domains were loaded before calling this method, otherwise we end in a Nullpointer
-        if(m_domains == null){
-            load();
-        }
+    public List<TopologyShared> match() {       
         final List<TopologyShared> links = new ArrayList<>();
         final List<MacPort> macPortMap = getMacPorts();
         

--- a/features/enlinkd/service/pom.xml
+++ b/features/enlinkd/service/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>org.opennms.features.enlinkd</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.enlinkd</groupId>

--- a/features/enlinkd/shell/pom.xml
+++ b/features/enlinkd/shell/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>org.opennms.features.enlinkd</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <properties>
     <bundle.symbolicName>org.opennms.features.enlinkd.shell</bundle.symbolicName>

--- a/features/enlinkd/shell/src/main/java/org/opennms/features/enlinkd/shell/GenerateTopologyCommand.java
+++ b/features/enlinkd/shell/src/main/java/org/opennms/features/enlinkd/shell/GenerateTopologyCommand.java
@@ -41,6 +41,7 @@ import org.opennms.netmgt.enlinkd.api.ReloadableTopologyDaemon;
 
 /**
  * Generate a enlinkd topology via karaf command.
+ * Log into console via: ssh -p 8101 admin@localhost
  * Install: feature:install opennms-enlinkd-shell
  * Usage: type 'enlinkd:generate-topology' in karaf console
  */

--- a/features/enlinkd/shell/src/main/java/org/opennms/features/enlinkd/shell/GenerateTopologyCommand.java
+++ b/features/enlinkd/shell/src/main/java/org/opennms/features/enlinkd/shell/GenerateTopologyCommand.java
@@ -67,7 +67,7 @@ public class GenerateTopologyCommand implements Action {
     @Option(name = "--topology", description = "type of topology (complete | ring | random). Default: random.")
     private String topology;
 
-    @Option(name = "--protocol", description = "type of protocol (cdp | isis | lldp | ospf | bridgeBridge). Default: cdp.")
+    @Option(name = "--protocol", description = "type of protocol (cdp | isis | lldp | ospf | bridge). Default: cdp.")
     private String protocol;
 
     @Reference

--- a/features/enlinkd/shell/src/main/java/org/opennms/features/enlinkd/shell/GenerateTopologyCommand.java
+++ b/features/enlinkd/shell/src/main/java/org/opennms/features/enlinkd/shell/GenerateTopologyCommand.java
@@ -67,7 +67,7 @@ public class GenerateTopologyCommand implements Action {
     @Option(name = "--topology", description = "type of topology (complete | ring | random). Default: random.")
     private String topology;
 
-    @Option(name = "--protocol", description = "type of protocol (cdp | isis | lldp | ospf). Default: cdp.")
+    @Option(name = "--protocol", description = "type of protocol (cdp | isis | lldp | ospf | bridgeBridge). Default: cdp.")
     private String protocol;
 
     @Reference

--- a/features/enlinkd/tests/pom.xml
+++ b/features/enlinkd/tests/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>org.opennms.features.enlinkd</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.enlinkd</groupId>

--- a/features/events/api/pom.xml
+++ b/features/events/api/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>org.opennms.features.events</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.events</groupId>

--- a/features/events/daemon/pom.xml
+++ b/features/events/daemon/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>org.opennms.features.events</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.events</groupId>

--- a/features/events/pom.xml
+++ b/features/events/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>org.opennms.features</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features</groupId>

--- a/features/events/shell-commands/pom.xml
+++ b/features/events/shell-commands/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>org.opennms.features.events</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.events</groupId>

--- a/features/events/syslog/pom.xml
+++ b/features/events/syslog/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>org.opennms.features.events</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.events</groupId>

--- a/features/events/traps/pom.xml
+++ b/features/events/traps/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>org.opennms.features.events</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.events</groupId>

--- a/features/executor-factory/cassandra/pom.xml
+++ b/features/executor-factory/cassandra/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>org.opennms.features.executor-factory</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.executor-factory</groupId>

--- a/features/executor-factory/pom.xml
+++ b/features/executor-factory/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>org.opennms.features</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features</groupId>

--- a/features/flows/api/pom.xml
+++ b/features/flows/api/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>org.opennms.features.flows</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.flows</groupId>

--- a/features/flows/classification/engine/api/pom.xml
+++ b/features/flows/classification/engine/api/pom.xml
@@ -3,7 +3,7 @@
   <parent>
       <groupId>org.opennms.features.flows.classification</groupId>
       <artifactId>org.opennms.features.flows.classification.engine</artifactId>
-      <version>24.0.0-SNAPSHOT</version>
+      <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.flows.classification.engine</groupId>

--- a/features/flows/classification/engine/impl/pom.xml
+++ b/features/flows/classification/engine/impl/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features.flows.classification</groupId>
     <artifactId>org.opennms.features.flows.classification.engine</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.flows.classification.engine</groupId>

--- a/features/flows/classification/engine/pom.xml
+++ b/features/flows/classification/engine/pom.xml
@@ -3,7 +3,7 @@
   <parent>
       <groupId>org.opennms.features.flows</groupId>
       <artifactId>org.opennms.features.flows.classification</artifactId>
-      <version>24.0.0-SNAPSHOT</version>
+      <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.flows.classification</groupId>

--- a/features/flows/classification/persistence/api/pom.xml
+++ b/features/flows/classification/persistence/api/pom.xml
@@ -3,7 +3,7 @@
   <parent>
       <groupId>org.opennms.features.flows.classification</groupId>
       <artifactId>org.opennms.features.flows.classification.persistence</artifactId>
-      <version>24.0.0-SNAPSHOT</version>
+      <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.flows.classification.persistence</groupId>

--- a/features/flows/classification/persistence/impl/pom.xml
+++ b/features/flows/classification/persistence/impl/pom.xml
@@ -3,7 +3,7 @@
   <parent>
       <groupId>org.opennms.features.flows.classification</groupId>
       <artifactId>org.opennms.features.flows.classification.persistence</artifactId>
-      <version>24.0.0-SNAPSHOT</version>
+      <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.flows.classification.persistence</groupId>

--- a/features/flows/classification/persistence/pom.xml
+++ b/features/flows/classification/persistence/pom.xml
@@ -3,7 +3,7 @@
   <parent>
       <groupId>org.opennms.features.flows</groupId>
       <artifactId>org.opennms.features.flows.classification</artifactId>
-      <version>24.0.0-SNAPSHOT</version>
+      <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.flows.classification</groupId>

--- a/features/flows/classification/pom.xml
+++ b/features/flows/classification/pom.xml
@@ -3,7 +3,7 @@
   <parent>
       <groupId>org.opennms.features</groupId>
       <artifactId>org.opennms.features.flows</artifactId>
-      <version>24.0.0-SNAPSHOT</version>
+      <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.flows</groupId>

--- a/features/flows/elastic/pom.xml
+++ b/features/flows/elastic/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>org.opennms.features.flows</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.flows</groupId>

--- a/features/flows/pom.xml
+++ b/features/flows/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>org.opennms.features</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features</groupId>

--- a/features/flows/rest/api/pom.xml
+++ b/features/flows/rest/api/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features.flows</groupId>
     <artifactId>org.opennms.features.flows.rest</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.flows.rest</groupId>

--- a/features/flows/rest/impl/pom.xml
+++ b/features/flows/rest/impl/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features.flows</groupId>
     <artifactId>org.opennms.features.flows.rest</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.flows.rest</groupId>

--- a/features/flows/rest/pom.xml
+++ b/features/flows/rest/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>org.opennms.features.flows</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.flows</groupId>

--- a/features/geocoder/api/pom.xml
+++ b/features/geocoder/api/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>org.opennms.features.geocoder</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.geocoder</groupId>

--- a/features/geocoder/google/pom.xml
+++ b/features/geocoder/google/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>org.opennms.features.geocoder</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.geocoder</groupId>

--- a/features/geocoder/nominatim/pom.xml
+++ b/features/geocoder/nominatim/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>org.opennms.features.geocoder</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.geocoder</groupId>

--- a/features/geocoder/pom.xml
+++ b/features/geocoder/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>org.opennms.features</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features</groupId>

--- a/features/geolocation/api/pom.xml
+++ b/features/geolocation/api/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>org.opennms.features.geolocation</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.geolocation</groupId>

--- a/features/geolocation/feature/pom.xml
+++ b/features/geolocation/feature/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.opennms.features</groupId>
         <artifactId>org.opennms.features.geolocation</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.opennms.features.geolocation</groupId>

--- a/features/geolocation/pom.xml
+++ b/features/geolocation/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.opennms</groupId>
         <artifactId>org.opennms.features</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.opennms.features</groupId>

--- a/features/geolocation/rest/pom.xml
+++ b/features/geolocation/rest/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>org.opennms.features.geolocation</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.geolocation</groupId>

--- a/features/geolocation/service/pom.xml
+++ b/features/geolocation/service/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>org.opennms.features.geolocation</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.geolocation</groupId>

--- a/features/graphml/pom.xml
+++ b/features/graphml/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>org.opennms.features</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <properties>
     <bundle.symbolicName>org.opennms.features.graphml</bundle.symbolicName>

--- a/features/ifttt/pom.xml
+++ b/features/ifttt/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.opennms</groupId>
         <artifactId>org.opennms.features</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.opennms.features</groupId>

--- a/features/instrumentationLogReader/pom.xml
+++ b/features/instrumentationLogReader/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>org.opennms.features</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <groupId>org.opennms.features</groupId>
   <artifactId>org.opennms.features.instrumentationLogReader</artifactId>

--- a/features/internal-plugins-descriptor/pom.xml
+++ b/features/internal-plugins-descriptor/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>org.opennms.features</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/features/jdbc-collector/pom.xml
+++ b/features/jdbc-collector/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>org.opennms.features</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features</groupId>

--- a/features/jest/client/pom.xml
+++ b/features/jest/client/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>org.opennms.features.jest</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.jest</groupId>

--- a/features/jest/dependencies/pom.xml
+++ b/features/jest/dependencies/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.opennms.features</groupId>
         <artifactId>org.opennms.features.jest</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.opennms.features.jest</groupId>

--- a/features/jest/feature/pom.xml
+++ b/features/jest/feature/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.opennms.features</groupId>
         <artifactId>org.opennms.features.jest</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
     <groupId>org.opennms.features.jest</groupId>
     <artifactId>opennms-jest</artifactId>

--- a/features/jest/jest-complete-osgi/pom.xml
+++ b/features/jest/jest-complete-osgi/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>org.opennms.features.jest</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
 
   <!-- Feature Definition -->

--- a/features/jest/pom.xml
+++ b/features/jest/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.opennms</groupId>
         <artifactId>org.opennms.features</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>org.opennms.features.jest</artifactId>

--- a/features/jmx-config-generator/pom.xml
+++ b/features/jmx-config-generator/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>org.opennms.features</artifactId>
         <groupId>org.opennms</groupId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>jmxconfiggenerator</artifactId>

--- a/features/juniper-tca-collector/pom.xml
+++ b/features/juniper-tca-collector/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>org.opennms.features</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features</groupId>

--- a/features/kafka/pom.xml
+++ b/features/kafka/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>org.opennms.features</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/features/kafka/producer/pom.xml
+++ b/features/kafka/producer/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>org.opennms.features.kafka</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/features/measurements/api/pom.xml
+++ b/features/measurements/api/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>org.opennms.features.measurements</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.measurements</groupId>

--- a/features/measurements/impl/pom.xml
+++ b/features/measurements/impl/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>org.opennms.features.measurements</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.measurements</groupId>

--- a/features/measurements/pom.xml
+++ b/features/measurements/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>org.opennms.features</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features</groupId>

--- a/features/measurements/rest/pom.xml
+++ b/features/measurements/rest/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>org.opennms.features.measurements</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.measurements</groupId>

--- a/features/mib-compiler/pom.xml
+++ b/features/mib-compiler/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>org.opennms.features</artifactId>
     <groupId>org.opennms</groupId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features</groupId>

--- a/features/minion/core/features/pom.xml
+++ b/features/minion/core/features/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.opennms.features.minion</groupId>
         <artifactId>core-parent</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/minion/core/impl/pom.xml
+++ b/features/minion/core/impl/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.opennms.features.minion</groupId>
         <artifactId>core-parent</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>core-impl</artifactId>

--- a/features/minion/core/pom.xml
+++ b/features/minion/core/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.opennms.features.minion</groupId>
         <artifactId>minion-parent</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>core-parent</artifactId>

--- a/features/minion/core/repository/pom.xml
+++ b/features/minion/core/repository/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.opennms.features.minion</groupId>
         <artifactId>core-parent</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>core-repository</artifactId>

--- a/features/minion/heartbeat/common/pom.xml
+++ b/features/minion/heartbeat/common/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.opennms.features.minion</groupId>
         <artifactId>org.opennms.features.minion.heartbeat</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.opennms.features.minion.heartbeat</groupId>

--- a/features/minion/heartbeat/consumer/pom.xml
+++ b/features/minion/heartbeat/consumer/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.opennms.features.minion</groupId>
         <artifactId>org.opennms.features.minion.heartbeat</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.opennms.features.minion.heartbeat</groupId>

--- a/features/minion/heartbeat/pom.xml
+++ b/features/minion/heartbeat/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.opennms.features.minion</groupId>
         <artifactId>minion-parent</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>org.opennms.features.minion.heartbeat</artifactId>

--- a/features/minion/heartbeat/producer/pom.xml
+++ b/features/minion/heartbeat/producer/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.opennms.features.minion</groupId>
         <artifactId>org.opennms.features.minion.heartbeat</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.opennms.features.minion.heartbeat</groupId>

--- a/features/minion/pom.xml
+++ b/features/minion/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.opennms</groupId>
         <artifactId>org.opennms.features</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.opennms.features.minion</groupId>

--- a/features/minion/repository/pom.xml
+++ b/features/minion/repository/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.opennms.features.minion</groupId>
         <artifactId>minion-parent</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>repository</artifactId>

--- a/features/minion/shell/collection/pom.xml
+++ b/features/minion/shell/collection/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.opennms.features.minion</groupId>
         <artifactId>org.opennms.features.minion.shell</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>org.opennms.features.minion.shell</groupId>

--- a/features/minion/shell/poller/pom.xml
+++ b/features/minion/shell/poller/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.opennms.features.minion</groupId>
         <artifactId>org.opennms.features.minion.shell</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>org.opennms.features.minion.shell</groupId>

--- a/features/minion/shell/pom.xml
+++ b/features/minion/shell/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.opennms.features.minion</groupId>
         <artifactId>minion-parent</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>org.opennms.features.minion.shell</artifactId>

--- a/features/minion/shell/provision/pom.xml
+++ b/features/minion/shell/provision/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.opennms.features.minion</groupId>
         <artifactId>org.opennms.features.minion.shell</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>org.opennms.features.minion.shell</groupId>

--- a/features/minion/status/pom.xml
+++ b/features/minion/status/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.opennms.features.minion</groupId>
         <artifactId>minion-parent</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>org.opennms.features.minion.status</artifactId>

--- a/features/name-cutter/pom.xml
+++ b/features/name-cutter/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>org.opennms.features</artifactId>
         <groupId>org.opennms</groupId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>org.opennms.features.name-cutter</artifactId>

--- a/features/newts-repository-converter/pom.xml
+++ b/features/newts-repository-converter/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>org.opennms.features</artifactId>
     <groupId>org.opennms</groupId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features</groupId>

--- a/features/newts/pom.xml
+++ b/features/newts/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>org.opennms.features</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features</groupId>

--- a/features/notifications/api/pom.xml
+++ b/features/notifications/api/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>org.opennms.features.notifications</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.notifications</groupId>

--- a/features/notifications/pom.xml
+++ b/features/notifications/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>org.opennms.features</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features</groupId>

--- a/features/notifications/sms-strategy/pom.xml
+++ b/features/notifications/sms-strategy/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>org.opennms.features.notifications</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms</groupId>

--- a/features/notifications/ticket-strategy/pom.xml
+++ b/features/notifications/ticket-strategy/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>org.opennms.features.notifications</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.notifications</groupId>

--- a/features/nrtg/api/pom.xml
+++ b/features/nrtg/api/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>nrtg</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <groupId>org.opennms.features.nrtg</groupId>
   <artifactId>nrtg-api</artifactId>

--- a/features/nrtg/broker/pom.xml
+++ b/features/nrtg/broker/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>nrtg</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <groupId>org.opennms.features.nrtg</groupId>
   <artifactId>nrtg-broker</artifactId>

--- a/features/nrtg/commander/pom.xml
+++ b/features/nrtg/commander/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>nrtg</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <groupId>org.opennms.features.nrtg</groupId>
   <artifactId>nrtg-commander</artifactId>

--- a/features/nrtg/jar/nrtcollector/pom.xml
+++ b/features/nrtg/jar/nrtcollector/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.opennms.features.nrtg</groupId>
     <artifactId>jar</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>nrtg-collector-standalone</artifactId>
   <name>OpenNMS :: Features :: NRTG :: NRTCollector JAR</name>

--- a/features/nrtg/jar/pom.xml
+++ b/features/nrtg/jar/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>nrtg</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.nrtg</groupId>

--- a/features/nrtg/nrtbroker-jms/pom.xml
+++ b/features/nrtg/nrtbroker-jms/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>nrtg</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <groupId>org.opennms.features.nrtg</groupId>
   <artifactId>nrtg-nrtbroker-jms</artifactId>

--- a/features/nrtg/nrtbroker-local/pom.xml
+++ b/features/nrtg/nrtbroker-local/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>nrtg</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <groupId>org.opennms.features.nrtg</groupId>
   <artifactId>nrtg-nrtbroker-local</artifactId>

--- a/features/nrtg/nrtcollector/pom.xml
+++ b/features/nrtg/nrtcollector/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>nrtg</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <groupId>org.opennms.features.nrtg</groupId>
   <artifactId>nrtg-collector</artifactId>

--- a/features/nrtg/pom.xml
+++ b/features/nrtg/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>org.opennms.features</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/features/nrtg/protocolcollector/pom.xml
+++ b/features/nrtg/protocolcollector/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>nrtg</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <groupId>org.opennms.features.nrtg</groupId>
   <artifactId>protocol-collectors</artifactId>

--- a/features/nrtg/protocolcollector/snmp/pom.xml
+++ b/features/nrtg/protocolcollector/snmp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.opennms.features.nrtg</groupId>
     <artifactId>protocol-collectors</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <groupId>org.opennms.features.nrtg.protocolcollector</groupId>
   <artifactId>nrtg-protocolcollector-snmp</artifactId>

--- a/features/nrtg/protocolcollector/tca/pom.xml
+++ b/features/nrtg/protocolcollector/tca/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.opennms.features.nrtg</groupId>
     <artifactId>protocol-collectors</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <groupId>org.opennms.features.nrtg.protocolcollector</groupId>
   <artifactId>nrtg-protocolcollector-tca</artifactId>

--- a/features/nrtg/system-exports/pom.xml
+++ b/features/nrtg/system-exports/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>nrtg</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <groupId>org.opennms.features.nrtg</groupId>
   <artifactId>nrtg-system-exports</artifactId>

--- a/features/nrtg/web/pom.xml
+++ b/features/nrtg/web/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>nrtg</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <groupId>org.opennms.features.nrtg</groupId>
   <artifactId>nrtg-web</artifactId>

--- a/features/opennms-es-rest/README.md
+++ b/features/opennms-es-rest/README.md
@@ -4,7 +4,7 @@
 ~~~~
 project groupId: org.opennms.plugins
 project name:    opennms-es-rest
-version:         24.0.0-SNAPSHOT
+version:         25.0.0-SNAPSHOT
 ~~~~
 
 ### Description
@@ -30,10 +30,10 @@ To install the feature in karaf use
 
 ~~~~
 
-karaf@root> feature:addurl mvn:org.opennms.features/org.opennms.features.opennms-es-rest/24.0.0-SNAPSHOT/xml/features
+karaf@root> feature:addurl mvn:org.opennms.features/org.opennms.features.opennms-es-rest/25.0.0-SNAPSHOT/xml/features
 karaf@root> feature:install opennms-es-rest
 
-(or feature:install opennms-es-rest/24.0.0-SNAPSHOT for a specific version of the feature)
+(or feature:install opennms-es-rest/25.0.0-SNAPSHOT for a specific version of the feature)
 ~~~~
 
 Example searches to use in Kibana Sense

--- a/features/opennms-es-rest/pom.xml
+++ b/features/opennms-es-rest/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>org.opennms.features</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/features/opennms-osgi-core-rest/pom.xml
+++ b/features/opennms-osgi-core-rest/pom.xml
@@ -5,7 +5,7 @@
         <relativePath>../topology-map/poms/compiled/</relativePath>
         <groupId>org.opennms.features.topology.build</groupId>
         <artifactId>compiled-bundle-settings</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.opennms.osgi</groupId>

--- a/features/opennms-osgi-core/pom.xml
+++ b/features/opennms-osgi-core/pom.xml
@@ -6,7 +6,7 @@
         <relativePath>../topology-map/poms/compiled/</relativePath>
         <groupId>org.opennms.features.topology.build</groupId>
         <artifactId>compiled-bundle-settings</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/features/osgi-jsr223/pom.xml
+++ b/features/osgi-jsr223/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>org.opennms.features</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features</groupId>

--- a/features/poller/api/pom.xml
+++ b/features/poller/api/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>org.opennms.features.poller</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.poller</groupId>

--- a/features/poller/client-rpc/pom.xml
+++ b/features/poller/client-rpc/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>org.opennms.features.poller</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.poller</groupId>

--- a/features/poller/monitors/core/pom.xml
+++ b/features/poller/monitors/core/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.opennms.features.poller</groupId>
     <artifactId>org.opennms.features.poller.monitors</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.poller.monitors</groupId>

--- a/features/poller/monitors/pom.xml
+++ b/features/poller/monitors/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>org.opennms.features.poller</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.poller</groupId>

--- a/features/poller/pom.xml
+++ b/features/poller/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>org.opennms.features</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features</groupId>

--- a/features/poller/remote/pom.xml
+++ b/features/poller/remote/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>org.opennms.features.poller</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.poller</groupId>

--- a/features/poller/runtime/pom.xml
+++ b/features/poller/runtime/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>org.opennms.features.poller</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.poller</groupId>

--- a/features/poller/shell/pom.xml
+++ b/features/poller/shell/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>org.opennms.features.poller</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.poller</groupId>

--- a/features/pom.xml
+++ b/features/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>opennms</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>org.opennms.features</artifactId>

--- a/features/provisioning/api/pom.xml
+++ b/features/provisioning/api/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>org.opennms.features.provisioning</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.provisioning</groupId>

--- a/features/provisioning/lib/pom.xml
+++ b/features/provisioning/lib/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>org.opennms.features.provisioning</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.provisioning</groupId>

--- a/features/provisioning/pom.xml
+++ b/features/provisioning/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>org.opennms.features</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features</groupId>

--- a/features/remote-poller-jnlp/pom.xml
+++ b/features/remote-poller-jnlp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>org.opennms.features</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features</groupId>

--- a/features/remote-poller/pom.xml
+++ b/features/remote-poller/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>org.opennms.features</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features</groupId>

--- a/features/reporting/api/pom.xml
+++ b/features/reporting/api/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>org.opennms.features.reporting</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.reporting</groupId>

--- a/features/reporting/availability/pom.xml
+++ b/features/reporting/availability/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>org.opennms.features.reporting</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.reporting</groupId>

--- a/features/reporting/core/pom.xml
+++ b/features/reporting/core/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>org.opennms.features.reporting</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.reporting</groupId>

--- a/features/reporting/dao/pom.xml
+++ b/features/reporting/dao/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>org.opennms.features.reporting</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.reporting</groupId>

--- a/features/reporting/jasper-reports-compiler/pom.xml
+++ b/features/reporting/jasper-reports-compiler/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>org.opennms.features.reporting</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.reporting</groupId>

--- a/features/reporting/jasper-reports-filter/pom.xml
+++ b/features/reporting/jasper-reports-filter/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>org.opennms.features.reporting</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.reporting</groupId>

--- a/features/reporting/jasper-reports/pom.xml
+++ b/features/reporting/jasper-reports/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>org.opennms.features.reporting</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.reporting</groupId>

--- a/features/reporting/model/pom.xml
+++ b/features/reporting/model/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>org.opennms.features.reporting</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.reporting</groupId>

--- a/features/reporting/pom.xml
+++ b/features/reporting/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>org.opennms.features</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features</groupId>

--- a/features/reporting/repository/pom.xml
+++ b/features/reporting/repository/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>org.opennms.features.reporting</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.reporting</groupId>

--- a/features/reporting/sdo/pom.xml
+++ b/features/reporting/sdo/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>org.opennms.features.reporting</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.reporting</groupId>

--- a/features/request-tracker/pom.xml
+++ b/features/request-tracker/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>org.opennms.features</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features</groupId>

--- a/features/resource-cli/pom.xml
+++ b/features/resource-cli/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>org.opennms.features</artifactId>
         <groupId>org.opennms</groupId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>resource-cli</artifactId>

--- a/features/rest-provider/pom.xml
+++ b/features/rest-provider/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.opennms</groupId>
         <artifactId>org.opennms.features</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.opennms.features</groupId>

--- a/features/rest/common/pom.xml
+++ b/features/rest/common/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.opennms.features</groupId>
         <artifactId>org.opennms.features.rest</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.opennms.features.rest</groupId>

--- a/features/rest/mapper/pom.xml
+++ b/features/rest/mapper/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>org.opennms.features.rest</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.rest</groupId>

--- a/features/rest/model/pom.xml
+++ b/features/rest/model/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>org.opennms.features.rest</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.rest</groupId>

--- a/features/rest/pom.xml
+++ b/features/rest/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.opennms</groupId>
         <artifactId>org.opennms.features</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.opennms.features</groupId>

--- a/features/root-webapp/pom.xml
+++ b/features/root-webapp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>org.opennms.features</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features</groupId>

--- a/features/scv/api/pom.xml
+++ b/features/scv/api/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.opennms.features</groupId>
         <artifactId>org.opennms.features.scv</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.opennms.features.scv</groupId>

--- a/features/scv/jceks-impl/pom.xml
+++ b/features/scv/jceks-impl/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.opennms.features</groupId>
         <artifactId>org.opennms.features.scv</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.opennms.features.scv</groupId>

--- a/features/scv/pom.xml
+++ b/features/scv/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>org.opennms.features</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features</groupId>

--- a/features/scv/scvcli/pom.xml
+++ b/features/scv/scvcli/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.opennms.features</groupId>
         <artifactId>org.opennms.features.scv</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.opennms.features.scv</groupId>

--- a/features/scv/shell/pom.xml
+++ b/features/scv/shell/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.opennms.features</groupId>
         <artifactId>org.opennms.features.scv</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.opennms.features.scv</groupId>

--- a/features/sentinel/core/pom.xml
+++ b/features/sentinel/core/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.opennms.features.sentinel</groupId>
         <artifactId>sentinel-parent</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>core</artifactId>

--- a/features/sentinel/pom.xml
+++ b/features/sentinel/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.opennms</groupId>
         <artifactId>org.opennms.features</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.opennms.features.sentinel</groupId>

--- a/features/sentinel/repository/pom.xml
+++ b/features/sentinel/repository/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.opennms.features.sentinel</groupId>
         <artifactId>sentinel-parent</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>repository</artifactId>

--- a/features/situation-feedback/api/pom.xml
+++ b/features/situation-feedback/api/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>org.opennms.features.situation-feedback</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.situation-feedback</groupId>

--- a/features/situation-feedback/elastic/pom.xml
+++ b/features/situation-feedback/elastic/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>org.opennms.features.situation-feedback</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.situation-feedback</groupId>

--- a/features/situation-feedback/pom.xml
+++ b/features/situation-feedback/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>org.opennms.features</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features</groupId>

--- a/features/situation-feedback/rest/api/pom.xml
+++ b/features/situation-feedback/rest/api/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features.situation-feedback</groupId>
     <artifactId>org.opennms.features.situation-feedback.rest</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.situation-feedback.rest</groupId>

--- a/features/situation-feedback/rest/impl/pom.xml
+++ b/features/situation-feedback/rest/impl/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features.situation-feedback</groupId>
     <artifactId>org.opennms.features.situation-feedback.rest</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.situation-feedback.rest</groupId>

--- a/features/situation-feedback/rest/pom.xml
+++ b/features/situation-feedback/rest/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>org.opennms.features.situation-feedback</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.situation-feedback</groupId>

--- a/features/springframework-security/pom.xml
+++ b/features/springframework-security/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>org.opennms.features</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features</groupId>

--- a/features/status/api/pom.xml
+++ b/features/status/api/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>org.opennms.features.status</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.status</groupId>

--- a/features/status/pom.xml
+++ b/features/status/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.opennms</groupId>
         <artifactId>org.opennms.features</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.opennms.features</groupId>

--- a/features/status/rest/pom.xml
+++ b/features/status/rest/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.opennms.features</groupId>
         <artifactId>org.opennms.features.status</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.opennms.features.status</groupId>

--- a/features/system-report/pom.xml
+++ b/features/system-report/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>org.opennms.features</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <groupId>org.opennms.features</groupId>
   <artifactId>org.opennms.features.system-report</artifactId>

--- a/features/telemetry/api/pom.xml
+++ b/features/telemetry/api/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>org.opennms.features.telemetry</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.telemetry</groupId>

--- a/features/telemetry/common/pom.xml
+++ b/features/telemetry/common/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>org.opennms.features.telemetry</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.telemetry</groupId>

--- a/features/telemetry/config/api/pom.xml
+++ b/features/telemetry/config/api/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features.telemetry</groupId>
     <artifactId>org.opennms.features.telemetry.config</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.telemetry.config</groupId>

--- a/features/telemetry/config/jaxb/pom.xml
+++ b/features/telemetry/config/jaxb/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features.telemetry</groupId>
     <artifactId>org.opennms.features.telemetry.config</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.telemetry.config</groupId>

--- a/features/telemetry/config/pom.xml
+++ b/features/telemetry/config/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>org.opennms.features.telemetry</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.telemetry</groupId>

--- a/features/telemetry/daemon/pom.xml
+++ b/features/telemetry/daemon/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>org.opennms.features.telemetry</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.telemetry</groupId>

--- a/features/telemetry/distributed/common/pom.xml
+++ b/features/telemetry/distributed/common/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features.telemetry</groupId>
     <artifactId>org.opennms.features.telemetry.distributed</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.telemetry.distributed</groupId>

--- a/features/telemetry/distributed/minion/pom.xml
+++ b/features/telemetry/distributed/minion/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features.telemetry</groupId>
     <artifactId>org.opennms.features.telemetry.distributed</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.telemetry.distributed</groupId>

--- a/features/telemetry/distributed/pom.xml
+++ b/features/telemetry/distributed/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>org.opennms.features.telemetry</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.telemetry</groupId>

--- a/features/telemetry/distributed/sentinel/pom.xml
+++ b/features/telemetry/distributed/sentinel/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features.telemetry</groupId>
     <artifactId>org.opennms.features.telemetry.distributed</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.telemetry.distributed</groupId>

--- a/features/telemetry/itests/pom.xml
+++ b/features/telemetry/itests/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>org.opennms.features.telemetry</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.telemetry</groupId>

--- a/features/telemetry/listeners/pom.xml
+++ b/features/telemetry/listeners/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>org.opennms.features.telemetry</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.telemetry</groupId>

--- a/features/telemetry/pom.xml
+++ b/features/telemetry/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>org.opennms.features</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features</groupId>

--- a/features/telemetry/protocols/collection/pom.xml
+++ b/features/telemetry/protocols/collection/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features.telemetry</groupId>
     <artifactId>org.opennms.features.telemetry.protocols</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.telemetry.protocols</groupId>

--- a/features/telemetry/protocols/common/pom.xml
+++ b/features/telemetry/protocols/common/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features.telemetry</groupId>
     <artifactId>org.opennms.features.telemetry.protocols</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.telemetry.protocols</groupId>

--- a/features/telemetry/protocols/flows/pom.xml
+++ b/features/telemetry/protocols/flows/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features.telemetry</groupId>
     <artifactId>org.opennms.features.telemetry.protocols</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.telemetry.protocols</groupId>

--- a/features/telemetry/protocols/jti/adapter/pom.xml
+++ b/features/telemetry/protocols/jti/adapter/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features.telemetry.protocols</groupId>
     <artifactId>org.opennms.features.telemetry.protocols.jti</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.telemetry.protocols.jti</groupId>

--- a/features/telemetry/protocols/jti/pom.xml
+++ b/features/telemetry/protocols/jti/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features.telemetry</groupId>
     <artifactId>org.opennms.features.telemetry.protocols</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.telemetry.protocols</groupId>

--- a/features/telemetry/protocols/netflow/adapter/pom.xml
+++ b/features/telemetry/protocols/netflow/adapter/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features.telemetry.protocols</groupId>
     <artifactId>org.opennms.features.telemetry.protocols.netflow</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.telemetry.protocols.netflow</groupId>

--- a/features/telemetry/protocols/netflow/parser/pom.xml
+++ b/features/telemetry/protocols/netflow/parser/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features.telemetry.protocols</groupId>
     <artifactId>org.opennms.features.telemetry.protocols.netflow</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.telemetry.protocols.netflow</groupId>

--- a/features/telemetry/protocols/netflow/pom.xml
+++ b/features/telemetry/protocols/netflow/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features.telemetry</groupId>
     <artifactId>org.opennms.features.telemetry.protocols</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.telemetry.protocols</groupId>

--- a/features/telemetry/protocols/nxos/adapter/pom.xml
+++ b/features/telemetry/protocols/nxos/adapter/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features.telemetry.protocols</groupId>
     <artifactId>org.opennms.features.telemetry.protocols.nxos</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.telemetry.protocols.nxos</groupId>

--- a/features/telemetry/protocols/nxos/pom.xml
+++ b/features/telemetry/protocols/nxos/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features.telemetry</groupId>
     <artifactId>org.opennms.features.telemetry.protocols</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.telemetry.protocols</groupId>

--- a/features/telemetry/protocols/pom.xml
+++ b/features/telemetry/protocols/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>org.opennms.features.telemetry</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.telemetry</groupId>

--- a/features/telemetry/protocols/sflow/adapter/pom.xml
+++ b/features/telemetry/protocols/sflow/adapter/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features.telemetry.protocols</groupId>
     <artifactId>org.opennms.features.telemetry.protocols.sflow</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.telemetry.protocols.sflow</groupId>

--- a/features/telemetry/protocols/sflow/parser/pom.xml
+++ b/features/telemetry/protocols/sflow/parser/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features.telemetry.protocols</groupId>
     <artifactId>org.opennms.features.telemetry.protocols.sflow</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.telemetry.protocols.sflow</groupId>

--- a/features/telemetry/protocols/sflow/pom.xml
+++ b/features/telemetry/protocols/sflow/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features.telemetry</groupId>
     <artifactId>org.opennms.features.telemetry.protocols</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.telemetry.protocols</groupId>

--- a/features/telemetry/registry/pom.xml
+++ b/features/telemetry/registry/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>org.opennms.features.telemetry</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.telemetry</groupId>

--- a/features/themes/dashboard-theme/pom.xml
+++ b/features/themes/dashboard-theme/pom.xml
@@ -6,7 +6,7 @@
     <parent>
     <artifactId>themes</artifactId>
     <groupId>org.opennms.features</groupId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
 	</parent>
 
     <groupId>org.opennms.features.themes</groupId>

--- a/features/themes/jmxconfiggenerator-theme/pom.xml
+++ b/features/themes/jmxconfiggenerator-theme/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>themes</artifactId>
         <groupId>org.opennms.features</groupId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
     <groupId>org.opennms.features.themes</groupId>
     <artifactId>jmxconfiggenerator-theme</artifactId>

--- a/features/themes/onms-default-theme/pom.xml
+++ b/features/themes/onms-default-theme/pom.xml
@@ -6,7 +6,7 @@
     <parent>
     <artifactId>themes</artifactId>
     <groupId>org.opennms.features</groupId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
 
     <groupId>org.opennms.features.themes</groupId>

--- a/features/themes/pom.xml
+++ b/features/themes/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>org.opennms.features</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/features/ticketing/api/pom.xml
+++ b/features/ticketing/api/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>org.opennms.features.ticketing</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.ticketing</groupId>

--- a/features/ticketing/daemon/pom.xml
+++ b/features/ticketing/daemon/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>org.opennms.features.ticketing</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.ticketing</groupId>

--- a/features/ticketing/drools-integration/pom.xml
+++ b/features/ticketing/drools-integration/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>org.opennms.features.ticketing</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.ticketing</groupId>

--- a/features/ticketing/jira-client/pom.xml
+++ b/features/ticketing/jira-client/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.opennms.features</groupId>
         <artifactId>org.opennms.features.ticketing</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>bundle</packaging>

--- a/features/ticketing/jira-integration/pom.xml
+++ b/features/ticketing/jira-integration/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.opennms.features</groupId>
         <artifactId>org.opennms.features.ticketing</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>jira-troubleticketer</artifactId>

--- a/features/ticketing/otrs-integration-31/pom.xml
+++ b/features/ticketing/otrs-integration-31/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.opennms.features</groupId>
 		<artifactId>org.opennms.features.ticketing</artifactId>
-		<version>24.0.0-SNAPSHOT</version>
+		<version>25.0.0-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>opennms-integration-otrs-31</artifactId>

--- a/features/ticketing/otrs-integration-common/pom.xml
+++ b/features/ticketing/otrs-integration-common/pom.xml
@@ -2,7 +2,7 @@
 	<parent>
 		<groupId>org.opennms.features</groupId>
 		<artifactId>org.opennms.features.ticketing</artifactId>
-		<version>24.0.0-SNAPSHOT</version>
+		<version>25.0.0-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.opennms.features.ticketing</groupId>

--- a/features/ticketing/otrs-integration/pom.xml
+++ b/features/ticketing/otrs-integration/pom.xml
@@ -2,7 +2,7 @@
 	<parent>
 		<groupId>org.opennms.features</groupId>
 		<artifactId>org.opennms.features.ticketing</artifactId>
-		<version>24.0.0-SNAPSHOT</version>
+		<version>25.0.0-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>opennms-integration-otrs</artifactId>

--- a/features/ticketing/pom.xml
+++ b/features/ticketing/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>org.opennms.features</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features</groupId>

--- a/features/ticketing/remedy-integration/pom.xml
+++ b/features/ticketing/remedy-integration/pom.xml
@@ -2,7 +2,7 @@
 	<parent>
 		<groupId>org.opennms.features</groupId>
 		<artifactId>org.opennms.features.ticketing</artifactId>
-		<version>24.0.0-SNAPSHOT</version>
+		<version>25.0.0-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>opennms-integration-remedy</artifactId>

--- a/features/ticketing/rt-integration/pom.xml
+++ b/features/ticketing/rt-integration/pom.xml
@@ -2,7 +2,7 @@
    <parent>
       <groupId>org.opennms.features</groupId>
       <artifactId>org.opennms.features.ticketing</artifactId>
-      <version>24.0.0-SNAPSHOT</version>
+      <version>25.0.0-SNAPSHOT</version>
    </parent>
    <modelVersion>4.0.0</modelVersion>
    <artifactId>opennms-integration-rt</artifactId>

--- a/features/ticketing/tsrm-integration/pom.xml
+++ b/features/ticketing/tsrm-integration/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.opennms.features</groupId>
 		<artifactId>org.opennms.features.ticketing</artifactId>
-		<version>24.0.0-SNAPSHOT</version>
+		<version>25.0.0-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>opennms-integration-tsrm</artifactId>

--- a/features/timeformat/api/pom.xml
+++ b/features/timeformat/api/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>org.opennms.features.timeformat</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.timeformat</groupId>

--- a/features/timeformat/impl/pom.xml
+++ b/features/timeformat/impl/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.opennms.features</groupId>
         <artifactId>org.opennms.features.timeformat</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.opennms.features.timeformat</groupId>

--- a/features/timeformat/pom.xml
+++ b/features/timeformat/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>org.opennms.features</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features</groupId>

--- a/features/timeseries-evaluate/pom.xml
+++ b/features/timeseries-evaluate/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>org.opennms.features</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features</groupId>

--- a/features/topologies/pom.xml
+++ b/features/topologies/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>org.opennms.features</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features</groupId>

--- a/features/topologies/service/api/pom.xml
+++ b/features/topologies/service/api/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features.topologies</groupId>
     <artifactId>org.opennms.features.topologies.service</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>org.opennms.features.topologies.service.api</artifactId>

--- a/features/topologies/service/impl/pom.xml
+++ b/features/topologies/service/impl/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features.topologies</groupId>
     <artifactId>org.opennms.features.topologies.service</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>org.opennms.features.topologies.service.impl</artifactId>

--- a/features/topologies/service/pom.xml
+++ b/features/topologies/service/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>org.opennms.features.topologies</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.topologies</groupId>

--- a/features/topology-map/features/pom.xml
+++ b/features/topology-map/features/pom.xml
@@ -5,7 +5,7 @@
     <relativePath>../poms/compiled/</relativePath>
     <groupId>org.opennms.features.topology.build</groupId>
     <artifactId>compiled-bundle-settings</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/features/topology-map/features/runtime-base/pom.xml
+++ b/features/topology-map/features/runtime-base/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.opennms.features.topology</groupId>
     <artifactId>features</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/features/topology-map/features/runtime-graphml/pom.xml
+++ b/features/topology-map/features/runtime-graphml/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.features.topology</groupId>
     <artifactId>features</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.osgi.features.topology</groupId>

--- a/features/topology-map/org.opennms.features.topology.api/pom.xml
+++ b/features/topology-map/org.opennms.features.topology.api/pom.xml
@@ -5,7 +5,7 @@
     <relativePath>../poms/compiled/</relativePath>
     <groupId>org.opennms.features.topology.build</groupId>
     <artifactId>compiled-bundle-settings</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/features/topology-map/org.opennms.features.topology.app/pom.xml
+++ b/features/topology-map/org.opennms.features.topology.app/pom.xml
@@ -6,7 +6,7 @@
         <relativePath>../poms/compiled/</relativePath>
         <groupId>org.opennms.features.topology.build</groupId>
         <artifactId>compiled-bundle-settings</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/topology-map/org.opennms.features.topology.link/pom.xml
+++ b/features/topology-map/org.opennms.features.topology.link/pom.xml
@@ -4,7 +4,7 @@
     <relativePath>../poms/compiled/</relativePath>
     <groupId>org.opennms.features.topology.build</groupId>
     <artifactId>compiled-bundle-settings</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <properties>
     <bundle.symbolicName>org.opennms.features.topology.link</bundle.symbolicName>

--- a/features/topology-map/org.opennms.features.topology.persistence/org.opennms.features.topology.persistence.api/pom.xml
+++ b/features/topology-map/org.opennms.features.topology.persistence/org.opennms.features.topology.persistence.api/pom.xml
@@ -4,7 +4,7 @@
         <relativePath>../../poms/compiled/</relativePath>
         <groupId>org.opennms.features.topology.build</groupId>
         <artifactId>compiled-bundle-settings</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.opennms.features.topology</groupId>

--- a/features/topology-map/org.opennms.features.topology.persistence/org.opennms.features.topology.persistence.impl/pom.xml
+++ b/features/topology-map/org.opennms.features.topology.persistence/org.opennms.features.topology.persistence.impl/pom.xml
@@ -4,7 +4,7 @@
     <relativePath>../../poms/compiled/</relativePath>
     <groupId>org.opennms.features.topology.build</groupId>
     <artifactId>compiled-bundle-settings</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.topology</groupId>

--- a/features/topology-map/org.opennms.features.topology.persistence/pom.xml
+++ b/features/topology-map/org.opennms.features.topology.persistence/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.opennms.features</groupId>
         <artifactId>org.opennms.features.topology</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.opennms.features.topology</groupId>

--- a/features/topology-map/org.opennms.features.topology.shell/pom.xml
+++ b/features/topology-map/org.opennms.features.topology.shell/pom.xml
@@ -5,7 +5,7 @@
     <relativePath>../poms/compiled/</relativePath>
     <groupId>org.opennms.features.topology.build</groupId>
     <artifactId>compiled-bundle-settings</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <properties>
     <bundle.symbolicName>org.opennms.features.topology.shell</bundle.symbolicName>

--- a/features/topology-map/plugins/org.opennms.features.topology.plugins.browsers/pom.xml
+++ b/features/topology-map/plugins/org.opennms.features.topology.plugins.browsers/pom.xml
@@ -5,7 +5,7 @@
         <relativePath>../../poms/compiled/</relativePath>
         <groupId>org.opennms.features.topology.build</groupId>
         <artifactId>compiled-bundle-settings</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
     <properties>
         <bundle.symbolicName>org.opennms.features.topology.plugins.browsers</bundle.symbolicName>

--- a/features/topology-map/plugins/org.opennms.features.topology.plugins.layout/pom.xml
+++ b/features/topology-map/plugins/org.opennms.features.topology.plugins.layout/pom.xml
@@ -5,7 +5,7 @@
     <relativePath>../../poms/compiled/</relativePath>
     <groupId>org.opennms.features.topology.build</groupId>
     <artifactId>compiled-bundle-settings</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/features/topology-map/plugins/org.opennms.features.topology.plugins.netutils/pom.xml
+++ b/features/topology-map/plugins/org.opennms.features.topology.plugins.netutils/pom.xml
@@ -7,7 +7,7 @@
 		<relativePath>../../poms/compiled/</relativePath>
 		<groupId>org.opennms.features.topology.build</groupId>
 		<artifactId>compiled-bundle-settings</artifactId>
-		<version>24.0.0-SNAPSHOT</version>
+		<version>25.0.0-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.opennms.features.topology</groupId>

--- a/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.application/pom.xml
+++ b/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.application/pom.xml
@@ -5,7 +5,7 @@
     <relativePath>../../poms/compiled/</relativePath>
     <groupId>org.opennms.features.topology.build</groupId>
     <artifactId>compiled-bundle-settings</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <properties>
     <bundle.symbolicName>org.opennms.features.topology.plugins.topo.application</bundle.symbolicName>

--- a/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.asset/pom.xml
+++ b/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.asset/pom.xml
@@ -4,7 +4,7 @@
     <relativePath>../../poms/compiled/</relativePath>
     <groupId>org.opennms.features.topology.build</groupId>
     <artifactId>compiled-bundle-settings</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <properties>
     <bundle.symbolicName>org.opennms.features.topology.plugins.topo.asset</bundle.symbolicName>

--- a/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.bsm/pom.xml
+++ b/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.bsm/pom.xml
@@ -5,7 +5,7 @@
     <relativePath>../../poms/compiled/</relativePath>
     <groupId>org.opennms.features.topology.build</groupId>
     <artifactId>compiled-bundle-settings</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <properties>
     <bundle.symbolicName>org.opennms.features.topology.plugins.topo.bsm</bundle.symbolicName>

--- a/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.graphml/pom.xml
+++ b/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.graphml/pom.xml
@@ -4,7 +4,7 @@
     <relativePath>../../poms/compiled/</relativePath>
     <groupId>org.opennms.features.topology.build</groupId>
     <artifactId>compiled-bundle-settings</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <properties>
     <bundle.symbolicName>org.opennms.features.topology.plugins.topo.graphml</bundle.symbolicName>

--- a/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.history/pom.xml
+++ b/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.history/pom.xml
@@ -6,7 +6,7 @@
     <parent>
     <artifactId>org.opennms.features.topology.plugins</artifactId>
     <groupId>org.opennms.features.topology</groupId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
 
     <groupId>org.opennms.features.topology.plugins.topo</groupId>

--- a/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.linkd/pom.xml
+++ b/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.linkd/pom.xml
@@ -148,37 +148,43 @@
       <groupId>org.opennms.features.enlinkd</groupId>
       <artifactId>org.opennms.features.enlinkd.adapters.common</artifactId>
       <version>${project.version}</version>
-          <scope>test</scope>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.opennms.features.enlinkd</groupId>
       <artifactId>org.opennms.features.enlinkd.adapters.updaters.nodes</artifactId>
       <version>${project.version}</version>
-          <scope>test</scope>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.opennms.features.enlinkd</groupId>
       <artifactId>org.opennms.features.enlinkd.adapters.updaters.lldp</artifactId>
       <version>${project.version}</version>
-          <scope>test</scope>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.opennms.features.enlinkd</groupId>
       <artifactId>org.opennms.features.enlinkd.adapters.updaters.cdp</artifactId>
       <version>${project.version}</version>
-          <scope>test</scope>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.opennms.features.enlinkd</groupId>
       <artifactId>org.opennms.features.enlinkd.adapters.updaters.isis</artifactId>
       <version>${project.version}</version>
-          <scope>test</scope>
+      <scope>test</scope>
     </dependency>
         <dependency>
       <groupId>org.opennms.features.enlinkd</groupId>
       <artifactId>org.opennms.features.enlinkd.adapters.updaters.ospf</artifactId>
       <version>${project.version}</version>
-          <scope>test</scope>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.opennms.features.enlinkd</groupId>
+      <artifactId>org.opennms.features.enlinkd.adapters.updaters.bridge</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.opennms.features.enlinkd</groupId>

--- a/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.linkd/pom.xml
+++ b/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.linkd/pom.xml
@@ -5,7 +5,7 @@
     <relativePath>../../poms/compiled/</relativePath>
     <groupId>org.opennms.features.topology.build</groupId>
     <artifactId>compiled-bundle-settings</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.linkd/src/test/java/org/opennms/features/topology/plugins/topo/linkd/internal/LinkdTopologyProviderTestIT.java
+++ b/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.linkd/src/test/java/org/opennms/features/topology/plugins/topo/linkd/internal/LinkdTopologyProviderTestIT.java
@@ -155,7 +155,7 @@ public class LinkdTopologyProviderTestIT {
     @Test
     @Transactional
     public void testBridgeBridge() throws Exception {
-        test(TopologyGenerator.Protocol.bridgeBridge);
+        test(TopologyGenerator.Protocol.bridge);
     }
 
     private void test(TopologyGenerator.Protocol protocol) throws OnmsTopologyException{

--- a/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.linkd/src/test/java/org/opennms/features/topology/plugins/topo/linkd/internal/LinkdTopologyProviderTestIT.java
+++ b/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.linkd/src/test/java/org/opennms/features/topology/plugins/topo/linkd/internal/LinkdTopologyProviderTestIT.java
@@ -178,7 +178,7 @@ public class LinkdTopologyProviderTestIT {
 
     @Test
     @Transactional
-    public void testBridgeBridge() throws Exception {
+    public void testBridge() throws Exception {
         // The testing of bridge topologies is a bit different than for the other protocols since we have a hierarchical
         // topology with different node types.
 
@@ -193,17 +193,21 @@ public class LinkdTopologyProviderTestIT {
 
         // 2.) map the nodes by it's label name.
         final Map<String, Vertex> vertices = new HashMap<>();
+        final Map<Integer,Vertex> verticesById = new HashMap<>();
         for(Vertex vertex : linkdTopologyProvider.getVerticesWithoutGroups()) {
             String label = vertex.getLabel();
             if("Segment".equals(label)) { // enhance Segment to make it unique
                 label = StringUtils.substringAfter(vertex.getTooltipText(), "nodeid:["); // Shared Segment': nodeid:[13561], bridgeport
                 label = StringUtils.substringBefore(label, "]");
-                label = "Segment[nodeid:"+label+"]";
+                label = verticesById.get(Integer.parseInt(label)).getLabel(); // get label by id of node
+                label = "Segment["+label+"]";
             } else if (label.contains("without node")) {
                 // shared addresses: ([000000000007, 000000000008]ip:[0.0.0.1 ], mac:[000000000005]ip:[0.0.0.2 ], mac:[000000000006])(Unknown/Not an OpenNMS Node)
                 label = StringUtils.substringAfter(vertex.getTooltipText(), "shared addresses: ([");
                 label = StringUtils.substringBefore(label, ",");
                 label = "NoNode["+label+"]";
+            } else {
+                verticesById.put(vertex.getNodeID(), vertex);
             }
             vertices.put(label, vertex);
         }
@@ -218,18 +222,18 @@ public class LinkdTopologyProviderTestIT {
         verifyLinkingBetweenNodes(vertices.get("Node0"), vertices.get("NoNode[000000000007]"));
 
         // Level 1 -> 2
-        verifyLinkingBetweenNodes(vertices.get("Node1"), vertices.get("Segment[nodeid:2]"));
+        verifyLinkingBetweenNodes(vertices.get("Node1"), vertices.get("Segment[Node1]"));
         verifyLinkingBetweenNodes(vertices.get("Node3"), vertices.get("Node8"));
         verifyLinkingBetweenNodes(vertices.get("Node3"), vertices.get("Node9"));
 
         // Level 2 -> 3
-        verifyLinkingBetweenNodes(vertices.get("Segment[nodeid:2]"), vertices.get("NoNode[00000000000e]"));
-        verifyLinkingBetweenNodes(vertices.get("Segment[nodeid:2]"), vertices.get("Node2"));
+        verifyLinkingBetweenNodes(vertices.get("Segment[Node1]"), vertices.get("NoNode[00000000000e]"));
+        verifyLinkingBetweenNodes(vertices.get("Segment[Node1]"), vertices.get("Node2"));
 
         // Level 3 -> 4
-        verifyLinkingBetweenNodes(vertices.get("Node2"), vertices.get("Segment[nodeid:3]"));
-        verifyLinkingBetweenNodes(vertices.get("Segment[nodeid:3]"), vertices.get("Node6"));
-        verifyLinkingBetweenNodes(vertices.get("Segment[nodeid:3]"), vertices.get("Node7"));
+        verifyLinkingBetweenNodes(vertices.get("Node2"), vertices.get("Segment[Node2]"));
+        verifyLinkingBetweenNodes(vertices.get("Segment[Node2]"), vertices.get("Node6"));
+        verifyLinkingBetweenNodes(vertices.get("Segment[Node2]"), vertices.get("Node7"));
 
     }
 

--- a/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.linkd/src/test/java/org/opennms/features/topology/plugins/topo/linkd/internal/LinkdTopologyProviderTestIT.java
+++ b/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.linkd/src/test/java/org/opennms/features/topology/plugins/topo/linkd/internal/LinkdTopologyProviderTestIT.java
@@ -69,8 +69,6 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.transaction.BeforeTransaction;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.google.common.base.Strings;
-
 @RunWith(OpenNMSJUnit4ClassRunner.class)
 @ContextConfiguration(locations={
         "classpath:/META-INF/opennms/applicationContext-soa.xml",

--- a/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.linkd/src/test/java/org/opennms/features/topology/plugins/topo/linkd/internal/LinkdTopologyProviderTestIT.java
+++ b/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.linkd/src/test/java/org/opennms/features/topology/plugins/topo/linkd/internal/LinkdTopologyProviderTestIT.java
@@ -158,9 +158,9 @@ public class LinkdTopologyProviderTestIT {
      *
      *                      bridge0
      *                         |
-     *           ----------------------------------------
-     *           |          |          |        |       |
-     *        bridge1    bridge3    bridge4  bridge5  Macs/Ip
+     *           ------------------------------------------------
+     *           |          |          |        |       |       |
+     *        bridge1    bridge3    bridge4  bridge5  Macs/Ip bridge10
      *           |          |                         no node
      *        -------    --------
      *        |          |      |
@@ -175,7 +175,7 @@ public class LinkdTopologyProviderTestIT {
 
     @Test
     @Transactional
-    public void testBridge() throws Exception {
+    public void testBridge() {
         // The testing of bridge topologies is a bit different than for the other protocols since we have a hierarchical
         // topology with different node types.
 
@@ -217,6 +217,7 @@ public class LinkdTopologyProviderTestIT {
         verifyLinkingBetweenNodes(vertices.get("Node0"), vertices.get("Node4"));
         verifyLinkingBetweenNodes(vertices.get("Node0"), vertices.get("Node5"));
         verifyLinkingBetweenNodes(vertices.get("Node0"), vertices.get("NoNode[000000000007]"));
+        verifyLinkingBetweenNodes(vertices.get("Node0"), vertices.get("Node10"));
 
         // Level 1 -> 2
         verifyLinkingBetweenNodes(vertices.get("Node1"), vertices.get("Segment[Node1]"));

--- a/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.linkd/src/test/java/org/opennms/features/topology/plugins/topo/linkd/internal/LinkdTopologyProviderTestIT.java
+++ b/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.linkd/src/test/java/org/opennms/features/topology/plugins/topo/linkd/internal/LinkdTopologyProviderTestIT.java
@@ -179,9 +179,8 @@ public class LinkdTopologyProviderTestIT {
     @Test
     @Transactional
     public void testBridgeBridge() throws Exception {
-        // The testing of bridge topologies is a bit different thean for the other protocols since we have a hierarchical
+        // The testing of bridge topologies is a bit different than for the other protocols since we have a hierarchical
         // topology with different node types.
-
 
         // 1.) Generate Topology
         TopologySettings settings = TopologySettings.builder()

--- a/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.linkd/src/test/java/org/opennms/features/topology/plugins/topo/linkd/internal/LinkdTopologyProviderTestIT.java
+++ b/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.linkd/src/test/java/org/opennms/features/topology/plugins/topo/linkd/internal/LinkdTopologyProviderTestIT.java
@@ -142,9 +142,16 @@ public class LinkdTopologyProviderTestIT {
         test(TopologyGenerator.Protocol.ospf);
     }
 
-    private void test(TopologyGenerator.Protocol protocol) {
+    private void test(TopologyGenerator.Protocol protocol) throws OnmsTopologyException{
         testAmounts(protocol);
         testLinkingBetweenNodes(protocol);
+    }
+
+    private void test(TopologyGenerator.Protocol protocol) {
+    @Test
+    @Transactional
+    public void testBridgeBridge() throws Exception {
+        test(TopologyGenerator.Protocol.bridgeBridge);
     }
 
     private void testAmounts(TopologyGenerator.Protocol protocol) {

--- a/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.linkd/src/test/java/org/opennms/features/topology/plugins/topo/linkd/internal/LinkdTopologyProviderTestIT.java
+++ b/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.linkd/src/test/java/org/opennms/features/topology/plugins/topo/linkd/internal/LinkdTopologyProviderTestIT.java
@@ -61,7 +61,6 @@ import org.opennms.netmgt.enlinkd.NodesOnmsTopologyUpdater;
 import org.opennms.netmgt.enlinkd.OspfOnmsTopologyUpdater;
 import org.opennms.netmgt.enlinkd.persistence.api.TopologyEntityCache;
 import org.opennms.netmgt.enlinkd.service.api.BridgeTopologyService;
-import org.opennms.netmgt.topologies.service.api.OnmsTopologyException;
 import org.opennms.test.JUnitConfigurationEnvironment;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -237,7 +236,7 @@ public class LinkdTopologyProviderTestIT {
 
     }
 
-    private void test(TopologyGenerator.Protocol protocol) throws OnmsTopologyException{
+    private void test(TopologyGenerator.Protocol protocol) {
         testAmounts(protocol);
         testLinkingBetweenNodes(protocol);
     }

--- a/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.linkd/src/test/resources/META-INF/opennms/applicationContext-LinkdTopologyProviderTestIT.xml
+++ b/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.linkd/src/test/resources/META-INF/opennms/applicationContext-LinkdTopologyProviderTestIT.xml
@@ -67,6 +67,18 @@
         <property name="sessionFactory" ref="sessionFactory" />
     </bean>
 
+    <bean id="bridgeBridgeLinkDao" class="org.opennms.netmgt.enlinkd.persistence.impl.BridgeBridgeLinkDaoHibernate">
+        <property name="sessionFactory" ref="sessionFactory" />
+    </bean>
+
+    <bean id="bridgeMacLinkDao" class="org.opennms.netmgt.enlinkd.persistence.impl.BridgeMacLinkDaoHibernate">
+        <property name="sessionFactory" ref="sessionFactory" />
+    </bean>
+
+    <bean id="bridgeElementDao" class="org.opennms.netmgt.enlinkd.persistence.impl.BridgeElementDaoHibernate">
+        <property name="sessionFactory" ref="sessionFactory" />
+    </bean>
+
     <bean id="cdpElementDao" class="org.opennms.netmgt.enlinkd.persistence.impl.CdpElementDaoHibernate">
         <property name="sessionFactory" ref="sessionFactory" />
     </bean>
@@ -95,6 +107,10 @@
         <property name="sessionFactory" ref="sessionFactory" />
     </bean>
 
+    <bean id="ipNetToMediaDao" class="org.opennms.netmgt.enlinkd.persistence.impl.IpNetToMediaDaoHibernate">
+        <property name="sessionFactory" ref="sessionFactory" />
+    </bean>
+
     <bean id="metricRegistry" class="com.codahale.metrics.MetricRegistry" />
 
     <bean id="onmsTopologyDao" class="org.opennms.netmgt.topologies.service.impl.OnmsTopologyDaoInMemoryImpl"/>
@@ -111,7 +127,15 @@
       <property name="nodeDao" ref="nodeDao" />
       <property name="topologyEntityCache" ref="topologyEntityCache" />
     </bean>
-        
+
+    <bean id="bridgeTopologyService" class="org.opennms.netmgt.enlinkd.service.impl.BridgeTopologyServiceImpl">
+        <property name="topologyEntityCache" ref="topologyEntityCache" />
+        <property name="bridgeBridgeLinkDao" ref="bridgeBridgeLinkDao" />
+        <property name="bridgeElementDao" ref="bridgeElementDao" />
+        <property name="bridgeMacLinkDao" ref="bridgeMacLinkDao" />
+        <property name="ipNetToMediaDao" ref="ipNetToMediaDao" />
+    </bean>
+
    <bean id="cdpTopologyService" class="org.opennms.netmgt.enlinkd.service.impl.CdpTopologyServiceImpl">
       <property name="topologyEntityCache" ref="topologyEntityCache" />
       <property name="cdpLinkDao" ref="cdpLinkDao" />
@@ -135,6 +159,12 @@
       <property name="ospfLinkDao" ref="ospfLinkDao" />
       <property name="ospfElementDao" ref="ospfElementDao" />
    </bean>
+
+    <bean id ="bridgeOnmsTopologyUpdater" class="org.opennms.netmgt.enlinkd.BridgeOnmsTopologyUpdater">
+        <constructor-arg ref="onmsTopologyDao" />
+        <constructor-arg ref="bridgeTopologyService" />
+        <constructor-arg ref="nodeTopologyService" />
+    </bean>
 
 	<bean id ="nodesOnmsTopologyUpdater" class="org.opennms.netmgt.enlinkd.NodesOnmsTopologyUpdater">
 		<constructor-arg ref="onmsTopologyDao" />

--- a/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.pathoutage/pom.xml
+++ b/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.pathoutage/pom.xml
@@ -7,7 +7,7 @@
     <relativePath>../../poms/compiled/</relativePath>
     <groupId>org.opennms.features.topology.build</groupId>
     <artifactId>compiled-bundle-settings</artifactId>
-    <version>24.0.0-SNAPSHOT
+    <version>25.0.0-SNAPSHOT
     </version>
   </parent>
   <properties>

--- a/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.vmware/pom.xml
+++ b/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.vmware/pom.xml
@@ -4,7 +4,7 @@
     <relativePath>../../poms/compiled/</relativePath>
     <groupId>org.opennms.features.topology.build</groupId>
     <artifactId>compiled-bundle-settings</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <properties>
     <bundle.symbolicName>org.opennms.features.topology.plugins.topo.vmware</bundle.symbolicName>

--- a/features/topology-map/plugins/pom.xml
+++ b/features/topology-map/plugins/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>org.opennms.features.topology</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/features/topology-map/pom.xml
+++ b/features/topology-map/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>org.opennms.features</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/features/topology-map/poms/compiled/pom.xml
+++ b/features/topology-map/poms/compiled/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.opennms.features.topology.build</groupId>
     <artifactId>shared-plugin-settings</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/features/topology-map/poms/pom.xml
+++ b/features/topology-map/poms/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>org.opennms.features.topology</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/features/topology-map/poms/wrappers/pom.xml
+++ b/features/topology-map/poms/wrappers/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.opennms.features.topology.build</groupId>
     <artifactId>shared-plugin-settings</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/features/topology-map/provision/pom.xml
+++ b/features/topology-map/provision/pom.xml
@@ -5,7 +5,7 @@
     <relativePath>../poms/compiled/</relativePath>
     <groupId>org.opennms.features.topology.build</groupId>
     <artifactId>compiled-bundle-settings</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/features/topology-map/themes/default-theme/pom.xml
+++ b/features/topology-map/themes/default-theme/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>org.opennms.features.topology.themes</artifactId>
         <groupId>org.opennms.features.topology</groupId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
     <groupId>org.opennms.features.topology.themes</groupId>
     <artifactId>org.opennms.features.topology.themes.default-theme</artifactId>

--- a/features/topology-map/themes/pom.xml
+++ b/features/topology-map/themes/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>org.opennms.features.topology</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/features/vaadin-components/bundle-refresher/pom.xml
+++ b/features/vaadin-components/bundle-refresher/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.opennms.features</groupId>
         <artifactId>vaadin-components</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
     <groupId>org.opennms.features.vaadin-components</groupId>
     <artifactId>bundle-refresher</artifactId>

--- a/features/vaadin-components/core/pom.xml
+++ b/features/vaadin-components/core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.opennms.features</groupId>
         <artifactId>vaadin-components</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
     <groupId>org.opennms.features.vaadin-components</groupId>
     <artifactId>core</artifactId>

--- a/features/vaadin-components/extender-service/pom.xml
+++ b/features/vaadin-components/extender-service/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.opennms.features</groupId>
         <artifactId>vaadin-components</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
     <groupId>org.opennms.features.vaadin-components</groupId>
     <artifactId>extender-service</artifactId>

--- a/features/vaadin-components/graph/pom.xml
+++ b/features/vaadin-components/graph/pom.xml
@@ -7,7 +7,7 @@
         <relativePath>../../topology-map/poms/compiled/</relativePath>
         <groupId>org.opennms.features.topology.build</groupId>
         <artifactId>compiled-bundle-settings</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>org.opennms.features.vaadin-components</groupId>

--- a/features/vaadin-components/pom.xml
+++ b/features/vaadin-components/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>org.opennms.features</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/features/vaadin-components/widgetset/pom.xml
+++ b/features/vaadin-components/widgetset/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.opennms.features</groupId>
         <artifactId>vaadin-components</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.opennms.features.vaadin-components</groupId>

--- a/features/vaadin-dashboard/pom.xml
+++ b/features/vaadin-dashboard/pom.xml
@@ -6,7 +6,7 @@
         <relativePath>../topology-map/poms/compiled/</relativePath>
         <groupId>org.opennms.features.topology.build</groupId>
         <artifactId>compiled-bundle-settings</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>vaadin-dashboard</artifactId>

--- a/features/vaadin-dashlets/dashlet-alarms/pom.xml
+++ b/features/vaadin-dashlets/dashlet-alarms/pom.xml
@@ -6,7 +6,7 @@
         <relativePath>../../topology-map/poms/compiled/</relativePath>
         <groupId>org.opennms.features.topology.build</groupId>
         <artifactId>compiled-bundle-settings</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>org.opennms.features.vaadin-dashlets</groupId>

--- a/features/vaadin-dashlets/dashlet-bsm/pom.xml
+++ b/features/vaadin-dashlets/dashlet-bsm/pom.xml
@@ -6,7 +6,7 @@
         <relativePath>../../topology-map/poms/compiled/</relativePath>
         <groupId>org.opennms.features.topology.build</groupId>
         <artifactId>compiled-bundle-settings</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>org.opennms.features.vaadin-dashlets</groupId>

--- a/features/vaadin-dashlets/dashlet-charts/pom.xml
+++ b/features/vaadin-dashlets/dashlet-charts/pom.xml
@@ -7,7 +7,7 @@
         <relativePath>../../topology-map/poms/compiled/</relativePath>
         <groupId>org.opennms.features.topology.build</groupId>
         <artifactId>compiled-bundle-settings</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>org.opennms.features.vaadin-dashlets</groupId>

--- a/features/vaadin-dashlets/dashlet-features/pom.xml
+++ b/features/vaadin-dashlets/dashlet-features/pom.xml
@@ -7,7 +7,7 @@
         <relativePath>../../topology-map/poms/compiled/</relativePath>
         <groupId>org.opennms.features.topology.build</groupId>
         <artifactId>compiled-bundle-settings</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>org.opennms.features.vaadin-dashlets</groupId>

--- a/features/vaadin-dashlets/dashlet-grafana/pom.xml
+++ b/features/vaadin-dashlets/dashlet-grafana/pom.xml
@@ -7,7 +7,7 @@
         <relativePath>../../topology-map/poms/compiled/</relativePath>
         <groupId>org.opennms.features.topology.build</groupId>
         <artifactId>compiled-bundle-settings</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>org.opennms.features.vaadin-dashlets</groupId>

--- a/features/vaadin-dashlets/dashlet-image/pom.xml
+++ b/features/vaadin-dashlets/dashlet-image/pom.xml
@@ -7,7 +7,7 @@
         <relativePath>../../topology-map/poms/compiled/</relativePath>
         <groupId>org.opennms.features.topology.build</groupId>
         <artifactId>compiled-bundle-settings</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>org.opennms.features.vaadin-dashlets</groupId>

--- a/features/vaadin-dashlets/dashlet-ksc/pom.xml
+++ b/features/vaadin-dashlets/dashlet-ksc/pom.xml
@@ -7,7 +7,7 @@
         <relativePath>../../topology-map/poms/compiled/</relativePath>
         <groupId>org.opennms.features.topology.build</groupId>
         <artifactId>compiled-bundle-settings</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>org.opennms.features.vaadin-dashlets</groupId>

--- a/features/vaadin-dashlets/dashlet-map/pom.xml
+++ b/features/vaadin-dashlets/dashlet-map/pom.xml
@@ -7,7 +7,7 @@
         <relativePath>../../topology-map/poms/compiled/</relativePath>
         <groupId>org.opennms.features.topology.build</groupId>
         <artifactId>compiled-bundle-settings</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>org.opennms.features.vaadin-dashlets</groupId>

--- a/features/vaadin-dashlets/dashlet-rrd/pom.xml
+++ b/features/vaadin-dashlets/dashlet-rrd/pom.xml
@@ -7,7 +7,7 @@
         <relativePath>../../topology-map/poms/compiled/</relativePath>
         <groupId>org.opennms.features.topology.build</groupId>
         <artifactId>compiled-bundle-settings</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>org.opennms.features.vaadin-dashlets</groupId>

--- a/features/vaadin-dashlets/dashlet-rtc/pom.xml
+++ b/features/vaadin-dashlets/dashlet-rtc/pom.xml
@@ -7,7 +7,7 @@
         <relativePath>../../topology-map/poms/compiled/</relativePath>
         <groupId>org.opennms.features.topology.build</groupId>
         <artifactId>compiled-bundle-settings</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>org.opennms.features.vaadin-dashlets</groupId>

--- a/features/vaadin-dashlets/dashlet-summary/pom.xml
+++ b/features/vaadin-dashlets/dashlet-summary/pom.xml
@@ -6,7 +6,7 @@
         <relativePath>../../topology-map/poms/compiled/</relativePath>
         <groupId>org.opennms.features.topology.build</groupId>
         <artifactId>compiled-bundle-settings</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>org.opennms.features.vaadin-dashlets</groupId>

--- a/features/vaadin-dashlets/dashlet-surveillance/pom.xml
+++ b/features/vaadin-dashlets/dashlet-surveillance/pom.xml
@@ -7,7 +7,7 @@
         <relativePath>../../topology-map/poms/compiled/</relativePath>
         <groupId>org.opennms.features.topology.build</groupId>
         <artifactId>compiled-bundle-settings</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>org.opennms.features.vaadin-dashlets</groupId>

--- a/features/vaadin-dashlets/dashlet-topology/pom.xml
+++ b/features/vaadin-dashlets/dashlet-topology/pom.xml
@@ -7,7 +7,7 @@
         <relativePath>../../topology-map/poms/compiled/</relativePath>
         <groupId>org.opennms.features.topology.build</groupId>
         <artifactId>compiled-bundle-settings</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>org.opennms.features.vaadin-dashlets</groupId>

--- a/features/vaadin-dashlets/dashlet-url/pom.xml
+++ b/features/vaadin-dashlets/dashlet-url/pom.xml
@@ -7,7 +7,7 @@
         <relativePath>../../topology-map/poms/compiled/</relativePath>
         <groupId>org.opennms.features.topology.build</groupId>
         <artifactId>compiled-bundle-settings</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>org.opennms.features.vaadin-dashlets</groupId>

--- a/features/vaadin-dashlets/pom.xml
+++ b/features/vaadin-dashlets/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.opennms</groupId>
         <artifactId>org.opennms.features</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/vaadin-jmxconfiggenerator/pom.xml
+++ b/features/vaadin-jmxconfiggenerator/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>org.opennms.features</artifactId>
         <groupId>org.opennms</groupId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>vaadin-jmxconfiggenerator</artifactId>

--- a/features/vaadin-node-maps/pom.xml
+++ b/features/vaadin-node-maps/pom.xml
@@ -6,7 +6,7 @@
 		<relativePath>../topology-map/poms/compiled/</relativePath>
 		<groupId>org.opennms.features.topology.build</groupId>
 		<artifactId>compiled-bundle-settings</artifactId>
-		<version>24.0.0-SNAPSHOT</version>
+		<version>25.0.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.opennms.features</groupId>
 	<artifactId>vaadin-node-maps</artifactId>

--- a/features/vaadin-opennms-pluginmanager/pom.xml
+++ b/features/vaadin-opennms-pluginmanager/pom.xml
@@ -6,7 +6,7 @@
     <relativePath>../topology-map/poms/compiled/</relativePath>
     <groupId>org.opennms.features.topology.build</groupId>
     <artifactId>compiled-bundle-settings</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.opennms.plugins</groupId>

--- a/features/vaadin-snmp-events-and-metrics/pom.xml
+++ b/features/vaadin-snmp-events-and-metrics/pom.xml
@@ -6,7 +6,7 @@
     <relativePath>../topology-map/poms/compiled/</relativePath>
     <groupId>org.opennms.features.topology.build</groupId>
     <artifactId>compiled-bundle-settings</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <groupId>org.opennms.features</groupId>
   <artifactId>vaadin-snmp-events-and-metrics</artifactId>

--- a/features/vaadin-surveillance-views/pom.xml
+++ b/features/vaadin-surveillance-views/pom.xml
@@ -6,7 +6,7 @@
         <relativePath>../topology-map/poms/compiled/</relativePath>
         <groupId>org.opennms.features.topology.build</groupId>
         <artifactId>compiled-bundle-settings</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
     <groupId>org.opennms.features</groupId>
     <artifactId>vaadin-surveillance-views</artifactId>

--- a/features/vaadin/pom.xml
+++ b/features/vaadin/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>org.opennms.features</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features</groupId>

--- a/features/wsman/pom.xml
+++ b/features/wsman/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>org.opennms.features</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features</groupId>

--- a/integration-tests/config/pom.xml
+++ b/integration-tests/config/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>integration-tests</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>org.opennms.integration-tests.config</artifactId>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>opennms</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>integration-tests</artifactId>

--- a/integration-tests/remote-poller-18/pom.xml
+++ b/integration-tests/remote-poller-18/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>integration-tests</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>org.opennms.integration-tests.remote-poller-18</artifactId>

--- a/integration-tests/trend-configuration/pom.xml
+++ b/integration-tests/trend-configuration/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>integration-tests</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>org.opennms.integration-tests.trend-configuration</artifactId>

--- a/integrations/opennms-R/pom.xml
+++ b/integrations/opennms-R/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>opennms-integrations</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>opennms-R</artifactId>
   <name>OpenNMS :: Integrations :: R Interface</name>

--- a/integrations/opennms-dns-provisioning-adapter/pom.xml
+++ b/integrations/opennms-dns-provisioning-adapter/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>opennms-integrations</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>opennms-dns-provisioning-adapter</artifactId>

--- a/integrations/opennms-jasper-extensions/pom.xml
+++ b/integrations/opennms-jasper-extensions/pom.xml
@@ -4,7 +4,7 @@
 <parent>
   <groupId>org.opennms</groupId>
   <artifactId>opennms-integrations</artifactId>
-  <version>24.0.0-SNAPSHOT</version>
+  <version>25.0.0-SNAPSHOT</version>
 </parent>
   <!-- the name must alphabetically come before jasperreports jar -->
   <artifactId>jasper-extensions</artifactId>

--- a/integrations/opennms-jasperstudio-extension/pom.xml
+++ b/integrations/opennms-jasperstudio-extension/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.opennms</groupId>
         <artifactId>opennms-integrations</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>opennms-jasperstudio-extension</artifactId>
     <name>OpenNMS Integration for Jaspersoft Studio</name>

--- a/integrations/opennms-puppet-provisioning-adapter/pom.xml
+++ b/integrations/opennms-puppet-provisioning-adapter/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>opennms-integrations</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>opennms-puppet-provisioning-adapter</artifactId>

--- a/integrations/opennms-rancid-provisioning-adapter/pom.xml
+++ b/integrations/opennms-rancid-provisioning-adapter/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>opennms-integrations</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>opennms-rancid-provisioning-adapter</artifactId>

--- a/integrations/opennms-reverse-dns-provisioning-adapter/pom.xml
+++ b/integrations/opennms-reverse-dns-provisioning-adapter/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>opennms-integrations</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>opennms-reverse-dns-provisioning-adapter</artifactId>

--- a/integrations/opennms-rws/pom.xml
+++ b/integrations/opennms-rws/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>opennms-integrations</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>opennms-rws</artifactId>

--- a/integrations/opennms-snmp-asset-provisioning-adapter/pom.xml
+++ b/integrations/opennms-snmp-asset-provisioning-adapter/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>opennms-integrations</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>opennms-snmp-asset-provisioning-adapter</artifactId>

--- a/integrations/opennms-snmp-hardware-inventory-provisioning-adapter/pom.xml
+++ b/integrations/opennms-snmp-hardware-inventory-provisioning-adapter/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>opennms-integrations</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>opennms-snmp-hardware-inventory-provisioning-adapter</artifactId>

--- a/integrations/opennms-vmware/pom.xml
+++ b/integrations/opennms-vmware/pom.xml
@@ -5,7 +5,7 @@
     <parent>
       <groupId>org.opennms</groupId>
       <artifactId>opennms-integrations</artifactId>
-      <version>24.0.0-SNAPSHOT</version>
+      <version>25.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>opennms-vmware</artifactId>

--- a/integrations/opennms-vtdxml-collector-handler/pom.xml
+++ b/integrations/opennms-vtdxml-collector-handler/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>opennms-integrations</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>opennms-vtdxml-collector-handler</artifactId>

--- a/integrations/opennms-wsman-asset-provisioning-adapter/pom.xml
+++ b/integrations/opennms-wsman-asset-provisioning-adapter/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>opennms-integrations</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>opennms-wsman-asset-provisioning-adapter</artifactId>

--- a/integrations/pom.xml
+++ b/integrations/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>opennms</artifactId>
     <groupId>org.opennms</groupId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>opennms-integrations</artifactId>

--- a/opennms-ackd/pom.xml
+++ b/opennms-ackd/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>opennms</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>opennms-ackd</artifactId>

--- a/opennms-ackd/src/test/java/org/opennms/netmgt/ackd/AckdIT.java
+++ b/opennms-ackd/src/test/java/org/opennms/netmgt/ackd/AckdIT.java
@@ -269,12 +269,6 @@ public class AckdIT implements InitializingBean {
         
     }
     
-    /*
-     * Send Ackd Notification Event for the ALARM
-     * ackAction is the default Acknowledge
-     * this will led to ack both the notification and the alarm
-     *  
-     */
     @Test
     public void testHandleEvent() throws InterruptedException {
         
@@ -295,40 +289,8 @@ public class AckdIT implements InitializingBean {
         Assert.assertEquals(alarm.getAckUser(), user);
 //        Assert.assertEquals(alarm.getAckTime(), bldr.getEvent().getTime());
     }
+    
 
-    /*
-     * Send Ackd Notification Event for the NOTIFICATION
-     * ackAction is the default Acknowledge
-     * this will led to ack both the notification and the alarm
-     *  
-     */
-    @Test
-    public void testHandleEventNotificationAck() throws InterruptedException {
-        
-        VerificationObject vo = createAckStructure();
-        EventBuilder bldr = new EventBuilder(EventConstants.ACKNOWLEDGE_EVENT_UEI, "AckdTest");
-        bldr.addParam("ackType", String.valueOf(AckType.NOTIFICATION));
-        bldr.addParam("refId", vo.m_alarmId);
-        final String user = "ackd-test-user";
-        bldr.addParam("ackUser", user);
-
-        m_daemon.handleAckEvent(bldr.getEvent());
-        
-        OnmsNotification notif = m_notificationDao.get(vo.m_notifId);
-        Assert.assertEquals(notif.getAckUser(), user);
-//        Assert.assertEquals(notif.getAckTime(), bldr.getEvent().getTime());
-        
-        OnmsAlarm alarm = m_alarmDao.get(vo.m_alarmId);
-        Assert.assertEquals(alarm.getAckUser(), user);
-//        Assert.assertEquals(alarm.getAckTime(), bldr.getEvent().getTime());
-    }
-
-    /*
-     * Send Ackd Notification Event for the ALARM
-     * AckAction is ESCALATE
-     * this will led only to escalate the alarm
-     *  
-     */
     @Test
     public void testHandleEventEscalate() throws InterruptedException {
         
@@ -353,12 +315,6 @@ public class AckdIT implements InitializingBean {
 //        Assert.assertEquals(alarm.getAckTime(), bldr.getEvent().getTime());
     }
 
-    /*
-     * Send Ackd Notification Event for the ALARM
-     * AckAction is CLEAR
-     * this will led clear the alarm
-     * and ack the notif 
-     */
     @Test
     public void testHandleEventClear() throws InterruptedException {
         
@@ -374,7 +330,7 @@ public class AckdIT implements InitializingBean {
         m_daemon.handleAckEvent(bldr.getEvent());
         
         OnmsNotification notif = m_notificationDao.get(vo.m_notifId);
-        Assert.assertEquals(notif.getAckUser(), user);
+        Assert.assertEquals(notif.getAckUser(), null);
 //        Assert.assertEquals(notif.getAckTime(), bldr.getEvent().getTime());
         
         OnmsAlarm alarm = m_alarmDao.get(vo.m_alarmId);

--- a/opennms-ackd/src/test/java/org/opennms/netmgt/ackd/AckdIT.java
+++ b/opennms-ackd/src/test/java/org/opennms/netmgt/ackd/AckdIT.java
@@ -269,6 +269,12 @@ public class AckdIT implements InitializingBean {
         
     }
     
+    /*
+     * Send Ackd Notification Event for the ALARM
+     * ackAction is the default Acknowledge
+     * this will led to ack both the notification and the alarm
+     *  
+     */
     @Test
     public void testHandleEvent() throws InterruptedException {
         
@@ -289,8 +295,40 @@ public class AckdIT implements InitializingBean {
         Assert.assertEquals(alarm.getAckUser(), user);
 //        Assert.assertEquals(alarm.getAckTime(), bldr.getEvent().getTime());
     }
-    
 
+    /*
+     * Send Ackd Notification Event for the NOTIFICATION
+     * ackAction is the default Acknowledge
+     * this will led to ack both the notification and the alarm
+     *  
+     */
+    @Test
+    public void testHandleEventNotificationAck() throws InterruptedException {
+        
+        VerificationObject vo = createAckStructure();
+        EventBuilder bldr = new EventBuilder(EventConstants.ACKNOWLEDGE_EVENT_UEI, "AckdTest");
+        bldr.addParam("ackType", String.valueOf(AckType.NOTIFICATION));
+        bldr.addParam("refId", vo.m_alarmId);
+        final String user = "ackd-test-user";
+        bldr.addParam("ackUser", user);
+
+        m_daemon.handleAckEvent(bldr.getEvent());
+        
+        OnmsNotification notif = m_notificationDao.get(vo.m_notifId);
+        Assert.assertEquals(notif.getAckUser(), user);
+//        Assert.assertEquals(notif.getAckTime(), bldr.getEvent().getTime());
+        
+        OnmsAlarm alarm = m_alarmDao.get(vo.m_alarmId);
+        Assert.assertEquals(alarm.getAckUser(), user);
+//        Assert.assertEquals(alarm.getAckTime(), bldr.getEvent().getTime());
+    }
+
+    /*
+     * Send Ackd Notification Event for the ALARM
+     * AckAction is ESCALATE
+     * this will led only to escalate the alarm
+     *  
+     */
     @Test
     public void testHandleEventEscalate() throws InterruptedException {
         
@@ -315,6 +353,12 @@ public class AckdIT implements InitializingBean {
 //        Assert.assertEquals(alarm.getAckTime(), bldr.getEvent().getTime());
     }
 
+    /*
+     * Send Ackd Notification Event for the ALARM
+     * AckAction is CLEAR
+     * this will led clear the alarm
+     * and ack the notif 
+     */
     @Test
     public void testHandleEventClear() throws InterruptedException {
         
@@ -330,7 +374,7 @@ public class AckdIT implements InitializingBean {
         m_daemon.handleAckEvent(bldr.getEvent());
         
         OnmsNotification notif = m_notificationDao.get(vo.m_notifId);
-        Assert.assertEquals(notif.getAckUser(), null);
+        Assert.assertEquals(notif.getAckUser(), user);
 //        Assert.assertEquals(notif.getAckTime(), bldr.getEvent().getTime());
         
         OnmsAlarm alarm = m_alarmDao.get(vo.m_alarmId);

--- a/opennms-ackd/src/test/java/org/opennms/netmgt/ackd/AckdIT.java
+++ b/opennms-ackd/src/test/java/org/opennms/netmgt/ackd/AckdIT.java
@@ -28,8 +28,6 @@
 
 package org.opennms.netmgt.ackd;
 
-import static org.junit.Assert.assertEquals;
-
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
@@ -55,7 +53,6 @@ import org.opennms.netmgt.dao.api.NodeDao;
 import org.opennms.netmgt.dao.api.NotificationDao;
 import org.opennms.netmgt.dao.api.UserNotificationDao;
 import org.opennms.netmgt.events.api.EventConstants;
-import org.opennms.netmgt.model.AckAction;
 import org.opennms.netmgt.model.AckType;
 import org.opennms.netmgt.model.OnmsAcknowledgment;
 import org.opennms.netmgt.model.OnmsAlarm;
@@ -270,14 +267,14 @@ public class AckdIT implements InitializingBean {
     }
     
     @Test
-    public void testHandleEvent() throws InterruptedException {
+    public void testHandelEvent() throws InterruptedException {
         
         VerificationObject vo = createAckStructure();
         EventBuilder bldr = new EventBuilder(EventConstants.ACKNOWLEDGE_EVENT_UEI, "AckdTest");
         bldr.addParam("ackType", String.valueOf(AckType.ALARM));
         bldr.addParam("refId", vo.m_alarmId);
         final String user = "ackd-test-user";
-        bldr.addParam("ackUser", user);
+        bldr.addParam("user", user);
 
         m_daemon.handleAckEvent(bldr.getEvent());
         
@@ -290,69 +287,20 @@ public class AckdIT implements InitializingBean {
 //        Assert.assertEquals(alarm.getAckTime(), bldr.getEvent().getTime());
     }
     
-
-    @Test
-    public void testHandleEventEscalate() throws InterruptedException {
-        
-        VerificationObject vo = createAckStructure();
-        assertEquals(OnmsSeverity.MAJOR.getId(), vo.m_alarmSeverity);
-        EventBuilder bldr = new EventBuilder(EventConstants.ACKNOWLEDGE_EVENT_UEI, "AckdTest");
-        bldr.addParam("ackType", String.valueOf(AckType.ALARM));
-        bldr.addParam("ackAction", String.valueOf(AckAction.ESCALATE));
-        bldr.addParam("refId", vo.m_alarmId);
-        final String user = "ackd-test-user";
-        bldr.addParam("ackUser", user);
-
-        m_daemon.handleAckEvent(bldr.getEvent());
-        
-        OnmsNotification notif = m_notificationDao.get(vo.m_notifId);
-        Assert.assertEquals(notif.getAckUser(), null);
-//        Assert.assertEquals(notif.getAckTime(), bldr.getEvent().getTime());
-        
-        OnmsAlarm alarm = m_alarmDao.get(vo.m_alarmId);
-        Assert.assertEquals(alarm.getAckUser(), null);
-        Assert.assertEquals(OnmsSeverity.CRITICAL.getId(), alarm.getSeverityId().intValue());
-//        Assert.assertEquals(alarm.getAckTime(), bldr.getEvent().getTime());
-    }
-
-    @Test
-    public void testHandleEventClear() throws InterruptedException {
-        
-        VerificationObject vo = createAckStructure();
-        assertEquals(OnmsSeverity.MAJOR.getId(), vo.m_alarmSeverity);
-        EventBuilder bldr = new EventBuilder(EventConstants.ACKNOWLEDGE_EVENT_UEI, "AckdTest");
-        bldr.addParam("ackType", String.valueOf(AckType.ALARM));
-        bldr.addParam("ackAction", String.valueOf(AckAction.CLEAR));
-        bldr.addParam("refId", vo.m_alarmId);
-        final String user = "ackd-test-user";
-        bldr.addParam("ackUser", user);
-
-        m_daemon.handleAckEvent(bldr.getEvent());
-        
-        OnmsNotification notif = m_notificationDao.get(vo.m_notifId);
-        Assert.assertEquals(notif.getAckUser(), null);
-//        Assert.assertEquals(notif.getAckTime(), bldr.getEvent().getTime());
-        
-        OnmsAlarm alarm = m_alarmDao.get(vo.m_alarmId);
-        Assert.assertEquals(alarm.getAckUser(), null);
-        Assert.assertEquals(OnmsSeverity.CLEARED.getId(), alarm.getSeverityId().intValue());
-//        Assert.assertEquals(alarm.getAckTime(), bldr.getEvent().getTime());
-    }
-
+    
     class VerificationObject {
         int m_eventID;
         int m_alarmId;
         int m_nodeId;
         int m_notifId;
         int m_userNotifId;
-        int m_alarmSeverity;
     }
     
     private VerificationObject createAckStructure() {
         
         final Date time = new Date();
         VerificationObject vo = new VerificationObject();
-        vo.m_alarmSeverity = OnmsSeverity.MAJOR.getId();
+        
         List<OnmsNode> nodes = m_nodeDao.findAll();
         Assert.assertTrue("List of nodes should not be empty", nodes.size() > 0);
         OnmsNode node = m_nodeDao.get(nodes.get(0).getId());
@@ -364,7 +312,7 @@ public class AckdIT implements InitializingBean {
         
         event.setEventCreateTime(time);
         event.setEventDescr("Test node down event.");
-        event.setEventSeverity(vo.m_alarmSeverity);
+        event.setEventSeverity(OnmsSeverity.MAJOR.getId());
         event.setEventSource("AckdTest");
         event.setEventTime(time);
         event.setEventUei(EventConstants.NODE_DOWN_EVENT_UEI);

--- a/opennms-alarms/api/pom.xml
+++ b/opennms-alarms/api/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>opennms-alarms</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>opennms-alarm-api</artifactId>

--- a/opennms-alarms/bsf-northbounder/pom.xml
+++ b/opennms-alarms/bsf-northbounder/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>opennms-alarms</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>opennms-alarm-northbounder-bsf</artifactId>

--- a/opennms-alarms/daemon/pom.xml
+++ b/opennms-alarms/daemon/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>opennms-alarms</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>opennms-alarmd</artifactId>

--- a/opennms-alarms/drools-northbounder/pom.xml
+++ b/opennms-alarms/drools-northbounder/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>opennms-alarms</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>opennms-alarm-northbounder-drools</artifactId>

--- a/opennms-alarms/email-northbounder/pom.xml
+++ b/opennms-alarms/email-northbounder/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>opennms-alarms</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>opennms-alarm-northbounder-email</artifactId>

--- a/opennms-alarms/http-northbounder/pom.xml
+++ b/opennms-alarms/http-northbounder/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>opennms-alarms</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>opennms-alarm-northbounder-http</artifactId>

--- a/opennms-alarms/integration-tests/pom.xml
+++ b/opennms-alarms/integration-tests/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>opennms-alarms</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>opennms-alarm-itests</artifactId>

--- a/opennms-alarms/jms-northbounder/pom.xml
+++ b/opennms-alarms/jms-northbounder/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>opennms-alarms</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>opennms-alarm-northbounder-jms</artifactId>

--- a/opennms-alarms/pom.xml
+++ b/opennms-alarms/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>opennms</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>opennms-alarms</artifactId>

--- a/opennms-alarms/snmptrap-northbounder/pom.xml
+++ b/opennms-alarms/snmptrap-northbounder/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>opennms-alarms</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>opennms-alarm-northbounder-snmptrap</artifactId>

--- a/opennms-alarms/syslog-northbounder/pom.xml
+++ b/opennms-alarms/syslog-northbounder/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>opennms-alarms</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>opennms-alarm-northbounder-syslog</artifactId>

--- a/opennms-assemblies/http-remoting/pom.xml
+++ b/opennms-assemblies/http-remoting/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>org.opennms.assemblies</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.assemblies</groupId>

--- a/opennms-assemblies/minion/pom.xml
+++ b/opennms-assemblies/minion/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>org.opennms.assemblies</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.assemblies</groupId>

--- a/opennms-assemblies/mock-snmp-agent-onejar/pom.xml
+++ b/opennms-assemblies/mock-snmp-agent-onejar/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>org.opennms.assemblies</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.assemblies</groupId>

--- a/opennms-assemblies/pom.xml
+++ b/opennms-assemblies/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>opennms</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>org.opennms.assemblies</artifactId>

--- a/opennms-assemblies/remote-poller-nsis/pom.xml
+++ b/opennms-assemblies/remote-poller-nsis/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.assemblies</groupId>
   <artifactId>opennms-remote-poller-windows</artifactId>
-  <version>24.0.0-SNAPSHOT</version>
+  <version>25.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <!-- 
     This "name" value is displayed in the installer and used to 

--- a/opennms-assemblies/remote-poller-onejar/pom.xml
+++ b/opennms-assemblies/remote-poller-onejar/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>org.opennms.assemblies</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.assemblies</groupId>

--- a/opennms-assemblies/remote-poller-standalone/pom.xml
+++ b/opennms-assemblies/remote-poller-standalone/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>org.opennms.assemblies</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.assemblies</groupId>

--- a/opennms-assemblies/remote-poller-windows/pom.xml
+++ b/opennms-assemblies/remote-poller-windows/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>org.opennms.assemblies</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.assemblies</groupId>

--- a/opennms-assemblies/sentinel/pom.xml
+++ b/opennms-assemblies/sentinel/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>org.opennms.assemblies</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.assemblies</groupId>

--- a/opennms-assemblies/system-report-onejar/pom.xml
+++ b/opennms-assemblies/system-report-onejar/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>org.opennms.assemblies</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.assemblies</groupId>

--- a/opennms-assemblies/version/pom.xml
+++ b/opennms-assemblies/version/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>org.opennms.assemblies</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms</groupId>

--- a/opennms-assemblies/webapp-full/pom.xml
+++ b/opennms-assemblies/webapp-full/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>org.opennms.assemblies</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.assemblies</groupId>

--- a/opennms-assemblies/xsds/pom.xml
+++ b/opennms-assemblies/xsds/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>org.opennms.assemblies</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.assemblies</groupId>

--- a/opennms-asterisk/pom.xml
+++ b/opennms-asterisk/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>opennms</artifactId>
     <groupId>org.opennms</groupId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>opennms-asterisk</artifactId>

--- a/opennms-base-assembly/pom.xml
+++ b/opennms-base-assembly/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>opennms</artifactId>
     <groupId>org.opennms</groupId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>opennms-base-assembly</artifactId>

--- a/opennms-bootstrap/pom.xml
+++ b/opennms-bootstrap/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>opennms</artifactId>
     <groupId>org.opennms</groupId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>opennms-bootstrap</artifactId>

--- a/opennms-config-api/pom.xml
+++ b/opennms-config-api/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>opennms</artifactId>
     <groupId>org.opennms</groupId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>opennms-config-api</artifactId>

--- a/opennms-config-jaxb/pom.xml
+++ b/opennms-config-jaxb/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>opennms</artifactId>
     <groupId>org.opennms</groupId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>opennms-config-jaxb</artifactId>

--- a/opennms-config-model/pom.xml
+++ b/opennms-config-model/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>opennms</artifactId>
     <groupId>org.opennms</groupId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>opennms-config-model</artifactId>

--- a/opennms-config-tester/pom.xml
+++ b/opennms-config-tester/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>opennms</artifactId>
     <groupId>org.opennms</groupId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>opennms-config-tester</artifactId>

--- a/opennms-config/pom.xml
+++ b/opennms-config/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>opennms</artifactId>
     <groupId>org.opennms</groupId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>opennms-config</artifactId>

--- a/opennms-correlation/drools-correlation-engine/pom.xml
+++ b/opennms-correlation/drools-correlation-engine/pom.xml
@@ -34,7 +34,7 @@
   <parent>
     <artifactId>opennms-correlation</artifactId>
     <groupId>org.opennms</groupId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>drools-correlation-engine</artifactId>

--- a/opennms-correlation/opennms-correlator/pom.xml
+++ b/opennms-correlation/opennms-correlator/pom.xml
@@ -34,7 +34,7 @@
   <parent>
     <artifactId>opennms-correlation</artifactId>
     <groupId>org.opennms</groupId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>opennms-correlator</artifactId>

--- a/opennms-correlation/pom.xml
+++ b/opennms-correlation/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>opennms</artifactId>
     <groupId>org.opennms</groupId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>opennms-correlation</artifactId>

--- a/opennms-dao-api/pom.xml
+++ b/opennms-dao-api/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>opennms</artifactId>
     <groupId>org.opennms</groupId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>opennms-dao-api</artifactId>

--- a/opennms-dao-mock/pom.xml
+++ b/opennms-dao-mock/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>opennms</artifactId>
     <groupId>org.opennms</groupId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>opennms-dao-mock</artifactId>

--- a/opennms-dao/pom.xml
+++ b/opennms-dao/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>opennms</artifactId>
     <groupId>org.opennms</groupId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>opennms-dao</artifactId>

--- a/opennms-doc/guide-admin/pom.xml
+++ b/opennms-doc/guide-admin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.opennms.doc</groupId>
         <artifactId>parent</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>guide-admin</artifactId>
     <packaging>pom</packaging>

--- a/opennms-doc/guide-admin/src/asciidoc/text/sentinel/sentinel.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/sentinel/sentinel.adoc
@@ -159,7 +159,7 @@ featuresBoot = \
       instance/4.1.5, \
       package/4.1.5, \
       log/4.1.5, \
-      scv/24.0.0-SNAPSHOT, \
+      scv/25.0.0-SNAPSHOT, \
       ssh/4.1.5, \
       framework/4.1.5, \
       system/4.1.5, \

--- a/opennms-doc/guide-admin/src/asciidoc/text/webui/jmx-config-generator/cli.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/webui/jmx-config-generator/cli.adoc
@@ -47,7 +47,7 @@ This file can be invoked by:
 
 [source, shell]
 ----
-java -jar target/jmxconfiggenerator-24.0.0-SNAPSHOT-onejar.jar
+java -jar target/jmxconfiggenerator-25.0.0-SNAPSHOT-onejar.jar
 ----
 
 ===== Usage

--- a/opennms-doc/guide-all/pom.xml
+++ b/opennms-doc/guide-all/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.opennms.doc</groupId>
         <artifactId>parent</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>guide-all</artifactId>
     <packaging>pom</packaging>

--- a/opennms-doc/guide-development/pom.xml
+++ b/opennms-doc/guide-development/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.opennms.doc</groupId>
         <artifactId>parent</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>guide-development</artifactId>
     <packaging>pom</packaging>

--- a/opennms-doc/guide-install/pom.xml
+++ b/opennms-doc/guide-install/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.opennms.doc</groupId>
         <artifactId>parent</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>guide-install</artifactId>
     <packaging>pom</packaging>

--- a/opennms-doc/pom.xml
+++ b/opennms-doc/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.opennms</groupId>
         <artifactId>opennms</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
     <groupId>org.opennms.doc</groupId>
     <artifactId>parent</artifactId>

--- a/opennms-doc/releasenotes/pom.xml
+++ b/opennms-doc/releasenotes/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.opennms.doc</groupId>
         <artifactId>parent</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>releasenotes</artifactId>
     <packaging>pom</packaging>

--- a/opennms-enterprise-reporting/opennms-reportd/pom.xml
+++ b/opennms-enterprise-reporting/opennms-reportd/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>opennms-enterprise-reporting</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>opennms-reportd</artifactId>

--- a/opennms-enterprise-reporting/pom.xml
+++ b/opennms-enterprise-reporting/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>opennms</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>opennms-enterprise-reporting</artifactId>

--- a/opennms-full-assembly/pom.xml
+++ b/opennms-full-assembly/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>opennms</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>opennms-full-assembly</artifactId>

--- a/opennms-full-assembly/src/test/java/org/opennms/assemblies/karaf/OnmsKarafTestCase.java
+++ b/opennms-full-assembly/src/test/java/org/opennms/assemblies/karaf/OnmsKarafTestCase.java
@@ -59,7 +59,7 @@ public class OnmsKarafTestCase extends KarafTestCase {
 				.groupId("org.opennms.container")
 				.artifactId("org.opennms.container.karaf")
 				.type("tar.gz")
-				.version("24.0.0-SNAPSHOT");
+				.version("25.0.0-SNAPSHOT");
 	}
 
 	/**

--- a/opennms-icmp/commands/pom.xml
+++ b/opennms-icmp/commands/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>opennms-icmp</artifactId>
     <groupId>org.opennms</groupId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>opennms-icmp-commands</artifactId>

--- a/opennms-icmp/opennms-icmp-api/pom.xml
+++ b/opennms-icmp/opennms-icmp-api/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>opennms-icmp</artifactId>
     <groupId>org.opennms</groupId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>opennms-icmp-api</artifactId>

--- a/opennms-icmp/opennms-icmp-best/pom.xml
+++ b/opennms-icmp/opennms-icmp-best/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>opennms-icmp</artifactId>
     <groupId>org.opennms</groupId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>opennms-icmp-best</artifactId>

--- a/opennms-icmp/opennms-icmp-jna/pom.xml
+++ b/opennms-icmp/opennms-icmp-jna/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>opennms-icmp</artifactId>
     <groupId>org.opennms</groupId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>opennms-icmp-jna</artifactId>

--- a/opennms-icmp/opennms-icmp-jni/pom.xml
+++ b/opennms-icmp/opennms-icmp-jni/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>opennms-icmp</artifactId>
     <groupId>org.opennms</groupId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>opennms-icmp-jni</artifactId>

--- a/opennms-icmp/opennms-icmp-jni6/pom.xml
+++ b/opennms-icmp/opennms-icmp-jni6/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>opennms-icmp</artifactId>
     <groupId>org.opennms</groupId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>opennms-icmp-jni6</artifactId>

--- a/opennms-icmp/opennms-icmp-proxy-rpc-impl/pom.xml
+++ b/opennms-icmp/opennms-icmp-proxy-rpc-impl/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>opennms-icmp</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>org.opennms.icmp.proxy.rpc-impl</artifactId>

--- a/opennms-icmp/pom.xml
+++ b/opennms-icmp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>opennms</artifactId>
     <groupId>org.opennms</groupId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>opennms-icmp</artifactId>

--- a/opennms-install/pom.xml
+++ b/opennms-install/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>opennms</artifactId>
     <groupId>org.opennms</groupId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>opennms-install</artifactId>

--- a/opennms-javamail/opennms-javamail-api/pom.xml
+++ b/opennms-javamail/opennms-javamail-api/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>opennms-javamail</artifactId>
     <groupId>org.opennms</groupId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>opennms-javamail-api</artifactId>

--- a/opennms-javamail/pom.xml
+++ b/opennms-javamail/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>opennms</artifactId>
     <groupId>org.opennms</groupId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>opennms-javamail</artifactId>

--- a/opennms-jetty/pom.xml
+++ b/opennms-jetty/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>opennms</artifactId>
     <groupId>org.opennms</groupId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>opennms-jetty</artifactId>

--- a/opennms-model/pom.xml
+++ b/opennms-model/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>opennms</artifactId>
     <groupId>org.opennms</groupId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>opennms-model</artifactId>

--- a/opennms-model/src/main/java/org/opennms/netmgt/model/OnmsAcknowledgment.java
+++ b/opennms-model/src/main/java/org/opennms/netmgt/model/OnmsAcknowledgment.java
@@ -121,25 +121,36 @@ public class OnmsAcknowledgment {
         
         for (Parm parm : parms) {
             final String parmValue = parm.getValue().getContent();
-            
-            if (!"ackType".equals(parm.getParmName()) && !"refId".equals(parm.getParmName()) && !"user".equals(parm.getParmName()) ) {
+            if (!"ackAction".equals(parm.getParmName()) && 
+                !"ackType".equals(parm.getParmName()) && !"refId".equals(parm.getParmName()) && !"user".equals(parm.getParmName()) ) {
                 throw new IllegalArgumentException("Event parm: "+parm.getParmName()+", is an invalid paramter");
-            } else {
+            } 
             
-                if ("ackType".equals(parm.getParmName())) {
+            if ("ackType".equals(parm.getParmName())) {
 
-                    if ("ALARM".equalsIgnoreCase(parmValue) || "NOTIFICATION".equalsIgnoreCase(parmValue)) {
-                        m_ackType = ("ALARM".equalsIgnoreCase(parmValue) ? AckType.ALARM : AckType.NOTIFICATION);
-                    } else {
-                        throw new IllegalArgumentException("Event parm: "+parm.getParmName()+", has invalid value, requires: \"Alarm\" or \"Notification\"." );
-                    }
-                    
-                } else if ("refId".equals(parm.getParmName())){
-                    m_refId = Integer.valueOf(parm.getValue().getContent());
+                if ("ALARM".equalsIgnoreCase(parmValue) || "NOTIFICATION".equalsIgnoreCase(parmValue)) {
+                    m_ackType = ("ALARM".equalsIgnoreCase(parmValue) ? AckType.ALARM : AckType.NOTIFICATION);
                 } else {
-                    m_ackUser = parm.getValue().getContent();
+                    throw new IllegalArgumentException("Event parm: "+parm.getParmName()+", has invalid value, requires: \"Alarm\" or \"Notification\"." );
                 }
-            }                
+                
+            } else if ("refId".equals(parm.getParmName())){
+                m_refId = Integer.valueOf(parmValue);
+            } else if ("user".equals(parm.getParmName())){
+                m_ackUser = parmValue;
+            } else {
+                if ("ACKNOWLEDGE".equalsIgnoreCase(parmValue)) {
+                    m_ackAction=AckAction.ACKNOWLEDGE;
+                } else if ("ESCALATE".equalsIgnoreCase(parmValue)) {
+                    m_ackAction=AckAction.ESCALATE;
+                } else if ("UNACKNOWLEDGE".equalsIgnoreCase(parmValue)) {
+                    m_ackAction=AckAction.UNACKNOWLEDGE;
+                } else if ("CLEAR".equalsIgnoreCase(parmValue)) {
+                    m_ackAction=AckAction.CLEAR;
+                } else {
+                    m_ackAction = AckAction.UNSPECIFIED;
+                } 
+            }
         }
     }
 

--- a/opennms-model/src/main/java/org/opennms/netmgt/model/OnmsAcknowledgment.java
+++ b/opennms-model/src/main/java/org/opennms/netmgt/model/OnmsAcknowledgment.java
@@ -122,7 +122,7 @@ public class OnmsAcknowledgment {
         for (Parm parm : parms) {
             final String parmValue = parm.getValue().getContent();
             if (!"ackAction".equals(parm.getParmName()) && 
-                !"ackType".equals(parm.getParmName()) && !"refId".equals(parm.getParmName()) && !"user".equals(parm.getParmName()) ) {
+                !"ackType".equals(parm.getParmName()) && !"refId".equals(parm.getParmName()) && !"ackUser".equals(parm.getParmName()) ) {
                 throw new IllegalArgumentException("Event parm: "+parm.getParmName()+", is an invalid paramter");
             } 
             
@@ -136,7 +136,7 @@ public class OnmsAcknowledgment {
                 
             } else if ("refId".equals(parm.getParmName())){
                 m_refId = Integer.valueOf(parmValue);
-            } else if ("user".equals(parm.getParmName())){
+            } else if ("ackUser".equals(parm.getParmName())){
                 m_ackUser = parmValue;
             } else {
                 if ("ACKNOWLEDGE".equalsIgnoreCase(parmValue)) {

--- a/opennms-model/src/main/java/org/opennms/netmgt/model/OnmsAcknowledgment.java
+++ b/opennms-model/src/main/java/org/opennms/netmgt/model/OnmsAcknowledgment.java
@@ -121,36 +121,25 @@ public class OnmsAcknowledgment {
         
         for (Parm parm : parms) {
             final String parmValue = parm.getValue().getContent();
-            if (!"ackAction".equals(parm.getParmName()) && 
-                !"ackType".equals(parm.getParmName()) && !"refId".equals(parm.getParmName()) && !"user".equals(parm.getParmName()) ) {
-                throw new IllegalArgumentException("Event parm: "+parm.getParmName()+", is an invalid paramter");
-            } 
             
-            if ("ackType".equals(parm.getParmName())) {
-
-                if ("ALARM".equalsIgnoreCase(parmValue) || "NOTIFICATION".equalsIgnoreCase(parmValue)) {
-                    m_ackType = ("ALARM".equalsIgnoreCase(parmValue) ? AckType.ALARM : AckType.NOTIFICATION);
-                } else {
-                    throw new IllegalArgumentException("Event parm: "+parm.getParmName()+", has invalid value, requires: \"Alarm\" or \"Notification\"." );
-                }
-                
-            } else if ("refId".equals(parm.getParmName())){
-                m_refId = Integer.valueOf(parmValue);
-            } else if ("user".equals(parm.getParmName())){
-                m_ackUser = parmValue;
+            if (!"ackType".equals(parm.getParmName()) && !"refId".equals(parm.getParmName()) && !"user".equals(parm.getParmName()) ) {
+                throw new IllegalArgumentException("Event parm: "+parm.getParmName()+", is an invalid paramter");
             } else {
-                if ("ACKNOWLEDGE".equalsIgnoreCase(parmValue)) {
-                    m_ackAction=AckAction.ACKNOWLEDGE;
-                } else if ("ESCALATE".equalsIgnoreCase(parmValue)) {
-                    m_ackAction=AckAction.ESCALATE;
-                } else if ("UNACKNOWLEDGE".equalsIgnoreCase(parmValue)) {
-                    m_ackAction=AckAction.UNACKNOWLEDGE;
-                } else if ("CLEAR".equalsIgnoreCase(parmValue)) {
-                    m_ackAction=AckAction.CLEAR;
+            
+                if ("ackType".equals(parm.getParmName())) {
+
+                    if ("ALARM".equalsIgnoreCase(parmValue) || "NOTIFICATION".equalsIgnoreCase(parmValue)) {
+                        m_ackType = ("ALARM".equalsIgnoreCase(parmValue) ? AckType.ALARM : AckType.NOTIFICATION);
+                    } else {
+                        throw new IllegalArgumentException("Event parm: "+parm.getParmName()+", has invalid value, requires: \"Alarm\" or \"Notification\"." );
+                    }
+                    
+                } else if ("refId".equals(parm.getParmName())){
+                    m_refId = Integer.valueOf(parm.getValue().getContent());
                 } else {
-                    m_ackAction = AckAction.UNSPECIFIED;
-                } 
-            }
+                    m_ackUser = parm.getValue().getContent();
+                }
+            }                
         }
     }
 

--- a/opennms-model/src/main/java/org/opennms/netmgt/model/OnmsAcknowledgment.java
+++ b/opennms-model/src/main/java/org/opennms/netmgt/model/OnmsAcknowledgment.java
@@ -122,7 +122,7 @@ public class OnmsAcknowledgment {
         for (Parm parm : parms) {
             final String parmValue = parm.getValue().getContent();
             if (!"ackAction".equals(parm.getParmName()) && 
-                !"ackType".equals(parm.getParmName()) && !"refId".equals(parm.getParmName()) && !"ackUser".equals(parm.getParmName()) ) {
+                !"ackType".equals(parm.getParmName()) && !"refId".equals(parm.getParmName()) && !"user".equals(parm.getParmName()) ) {
                 throw new IllegalArgumentException("Event parm: "+parm.getParmName()+", is an invalid paramter");
             } 
             
@@ -136,7 +136,7 @@ public class OnmsAcknowledgment {
                 
             } else if ("refId".equals(parm.getParmName())){
                 m_refId = Integer.valueOf(parmValue);
-            } else if ("ackUser".equals(parm.getParmName())){
+            } else if ("user".equals(parm.getParmName())){
                 m_ackUser = parmValue;
             } else {
                 if ("ACKNOWLEDGE".equalsIgnoreCase(parmValue)) {

--- a/opennms-provision/opennms-detector-bsf/pom.xml
+++ b/opennms-provision/opennms-detector-bsf/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>opennms-provision</artifactId>
     <groupId>org.opennms</groupId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>opennms-detector-bsf</artifactId>

--- a/opennms-provision/opennms-detector-datagram/pom.xml
+++ b/opennms-provision/opennms-detector-datagram/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>opennms-provision</artifactId>
     <groupId>org.opennms</groupId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>opennms-detector-datagram</artifactId>

--- a/opennms-provision/opennms-detector-dhcp/pom.xml
+++ b/opennms-provision/opennms-detector-dhcp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>opennms-provision</artifactId>
     <groupId>org.opennms</groupId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>opennms-detector-dhcp</artifactId>

--- a/opennms-provision/opennms-detector-generic/pom.xml
+++ b/opennms-provision/opennms-detector-generic/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>opennms-provision</artifactId>
     <groupId>org.opennms</groupId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>opennms-detector-generic</artifactId>

--- a/opennms-provision/opennms-detector-jdbc/pom.xml
+++ b/opennms-provision/opennms-detector-jdbc/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>opennms-provision</artifactId>
     <groupId>org.opennms</groupId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>opennms-detector-jdbc</artifactId>

--- a/opennms-provision/opennms-detector-jmx/pom.xml
+++ b/opennms-provision/opennms-detector-jmx/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>opennms-provision</artifactId>
     <groupId>org.opennms</groupId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>opennms-detector-jmx</artifactId>

--- a/opennms-provision/opennms-detector-lineoriented/pom.xml
+++ b/opennms-provision/opennms-detector-lineoriented/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>opennms-provision</artifactId>
     <groupId>org.opennms</groupId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>opennms-detector-lineoriented</artifactId>

--- a/opennms-provision/opennms-detector-registry/pom.xml
+++ b/opennms-provision/opennms-detector-registry/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>opennms-provision</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>opennms-detector-registry</artifactId>

--- a/opennms-provision/opennms-detector-simple/pom.xml
+++ b/opennms-provision/opennms-detector-simple/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>opennms-provision</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>opennms-detector-simple</artifactId>

--- a/opennms-provision/opennms-detector-ssh/pom.xml
+++ b/opennms-provision/opennms-detector-ssh/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>opennms-provision</artifactId>
     <groupId>org.opennms</groupId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>opennms-detector-ssh</artifactId>

--- a/opennms-provision/opennms-detector-web/pom.xml
+++ b/opennms-provision/opennms-detector-web/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>opennms-provision</artifactId>
     <groupId>org.opennms</groupId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>opennms-detector-web</artifactId>

--- a/opennms-provision/opennms-detectorclient-rpc/pom.xml
+++ b/opennms-provision/opennms-detectorclient-rpc/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>opennms-provision</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>opennms-detectorclient-rpc</artifactId>

--- a/opennms-provision/opennms-mock-simpleserver/pom.xml
+++ b/opennms-provision/opennms-mock-simpleserver/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>opennms-provision</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>opennms-mock-simpleserver</artifactId>

--- a/opennms-provision/opennms-provision-api/pom.xml
+++ b/opennms-provision/opennms-provision-api/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>opennms-provision</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>opennms-provision-api</artifactId>

--- a/opennms-provision/opennms-provision-geolocation/pom.xml
+++ b/opennms-provision/opennms-provision-geolocation/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>opennms-provision</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>opennms-provision-geolocation</artifactId>

--- a/opennms-provision/opennms-provision-persistence/pom.xml
+++ b/opennms-provision/opennms-provision-persistence/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>opennms-provision</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>opennms-provision-persistence</artifactId>

--- a/opennms-provision/opennms-provision-shell/pom.xml
+++ b/opennms-provision/opennms-provision-shell/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>opennms-provision</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>opennms-provision-shell</artifactId>

--- a/opennms-provision/opennms-provisiond/pom.xml
+++ b/opennms-provision/opennms-provisiond/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>opennms-provision</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>opennms-provisiond</artifactId>

--- a/opennms-provision/opennms-requisition-dns/pom.xml
+++ b/opennms-provision/opennms-requisition-dns/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>opennms-provision</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>opennms-requisition-dns</artifactId>

--- a/opennms-provision/opennms-requisition-service/pom.xml
+++ b/opennms-provision/opennms-requisition-service/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>opennms-provision</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>opennms-requisition-service</artifactId>

--- a/opennms-provision/opennms-snmp-scanners/pom.xml
+++ b/opennms-provision/opennms-snmp-scanners/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>opennms-provision</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>opennms-snmp-scanners</artifactId>

--- a/opennms-provision/pom.xml
+++ b/opennms-provision/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>opennms</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>opennms-provision</artifactId>

--- a/opennms-reporting/pom.xml
+++ b/opennms-reporting/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>opennms</artifactId>
     <groupId>org.opennms</groupId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>opennms-reporting</artifactId>

--- a/opennms-rrd/opennms-rrd-api/pom.xml
+++ b/opennms-rrd/opennms-rrd-api/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>opennms-rrd</artifactId>
     <groupId>org.opennms</groupId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>opennms-rrd-api</artifactId>

--- a/opennms-rrd/opennms-rrd-jrobin/pom.xml
+++ b/opennms-rrd/opennms-rrd-jrobin/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>opennms-rrd</artifactId>
     <groupId>org.opennms</groupId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>opennms-rrd-jrobin</artifactId>

--- a/opennms-rrd/opennms-rrd-model/pom.xml
+++ b/opennms-rrd/opennms-rrd-model/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>opennms-rrd</artifactId>
     <groupId>org.opennms</groupId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>opennms-rrd-model</artifactId>

--- a/opennms-rrd/opennms-rrd-rrdtool/opennms-rrdtool-api/pom.xml
+++ b/opennms-rrd/opennms-rrd-rrdtool/opennms-rrdtool-api/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>opennms-rrd-rrdtool</artifactId>
     <groupId>org.opennms</groupId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>opennms-rrdtool-api</artifactId>

--- a/opennms-rrd/opennms-rrd-rrdtool/pom.xml
+++ b/opennms-rrd/opennms-rrd-rrdtool/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>opennms-rrd</artifactId>
     <groupId>org.opennms</groupId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>opennms-rrd-rrdtool</artifactId>

--- a/opennms-rrd/opennms-rrd-tcp/pom.xml
+++ b/opennms-rrd/opennms-rrd-tcp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>opennms-rrd</artifactId>
     <groupId>org.opennms</groupId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>opennms-rrd-tcp</artifactId>

--- a/opennms-rrd/pom.xml
+++ b/opennms-rrd/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>opennms</artifactId>
     <groupId>org.opennms</groupId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>opennms-rrd</artifactId>

--- a/opennms-services/pom.xml
+++ b/opennms-services/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>opennms</artifactId>
     <groupId>org.opennms</groupId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>opennms-services</artifactId>

--- a/opennms-taglib/pom.xml
+++ b/opennms-taglib/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>opennms</artifactId>
         <groupId>org.opennms</groupId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>opennms-taglib</artifactId>

--- a/opennms-tools/access-point-monitor/pom.xml
+++ b/opennms-tools/access-point-monitor/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>opennms-tools</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features</groupId>

--- a/opennms-tools/centric-troubleticketer/pom.xml
+++ b/opennms-tools/centric-troubleticketer/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>opennms-tools</artifactId>
     <groupId>org.opennms</groupId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>centric-troubleticketer</artifactId>

--- a/opennms-tools/cli-pinger/pom.xml
+++ b/opennms-tools/cli-pinger/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>opennms-tools</artifactId>
     <groupId>org.opennms</groupId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.netmgt.clipinger</groupId>

--- a/opennms-tools/config-normalizer/pom.xml
+++ b/opennms-tools/config-normalizer/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>opennms-tools</artifactId>
     <groupId>org.opennms</groupId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>org.opennms.config-normalizer</artifactId>

--- a/opennms-tools/csv-address/pom.xml
+++ b/opennms-tools/csv-address/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>opennms-tools</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>opennms-csv-assets</artifactId>
   <packaging>jar</packaging>

--- a/opennms-tools/csv-requisitions/pom.xml
+++ b/opennms-tools/csv-requisitions/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>opennms-tools</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>opennms-csv-requisition</artifactId>
   <packaging>jar</packaging>

--- a/opennms-tools/groovy-tools/pom.xml
+++ b/opennms-tools/groovy-tools/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>opennms-tools</artifactId>
     <groupId>org.opennms</groupId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>groovy-tools</artifactId>

--- a/opennms-tools/ireport-jrobin-provider/pom.xml
+++ b/opennms-tools/ireport-jrobin-provider/pom.xml
@@ -4,7 +4,7 @@
   <groupId>org.opennms.jasper</groupId>
   <artifactId>jrobin-provider</artifactId>
   <packaging>jar</packaging>
-  <version>24.0.0-SNAPSHOT</version>
+  <version>25.0.0-SNAPSHOT</version>
   <name>JRobin iReport Fields Provider</name>
   <build>
     <pluginManagement>

--- a/opennms-tools/isoc-ipv6-gui/pom.xml
+++ b/opennms-tools/isoc-ipv6-gui/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>org.opennms.features</artifactId>
     <groupId>org.opennms</groupId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
     
   <modelVersion>4.0.0</modelVersion>

--- a/opennms-tools/isoc-ipv6-participants/pom.xml
+++ b/opennms-tools/isoc-ipv6-participants/pom.xml
@@ -3,7 +3,7 @@
   <parent>
 	<artifactId>org.opennms.features</artifactId>
 	<groupId>org.opennms</groupId>
-	<version>24.0.0-SNAPSHOT</version>
+	<version>25.0.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/opennms-tools/jrb-to-rrd-converter/pom.xml
+++ b/opennms-tools/jrb-to-rrd-converter/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>opennms-tools</artifactId>
     <groupId>org.opennms</groupId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jrb-to-rrd-converter</artifactId>

--- a/opennms-tools/jrobin-spike-hunter/pom.xml
+++ b/opennms-tools/jrobin-spike-hunter/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>opennms-tools</artifactId>
     <groupId>org.opennms</groupId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>spike-hunter</artifactId>

--- a/opennms-tools/mib2events/pom.xml
+++ b/opennms-tools/mib2events/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>opennms-tools</artifactId>
     <groupId>org.opennms</groupId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.netmgt.mib2events</groupId>

--- a/opennms-tools/opennms-eventd-stresser/pom.xml
+++ b/opennms-tools/opennms-eventd-stresser/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>opennms-tools</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>opennms-eventd-stresser</artifactId>
   <packaging>jar</packaging>

--- a/opennms-tools/opennms-qosdaemon/pom.xml
+++ b/opennms-tools/opennms-qosdaemon/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>opennms</artifactId>
     <groupId>org.opennms</groupId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>opennms-qosdaemon</artifactId>

--- a/opennms-tools/opennms-rrd-converter/pom.xml
+++ b/opennms-tools/opennms-rrd-converter/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>opennms-tools</artifactId>
     <groupId>org.opennms</groupId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>opennms-rrd-converter</artifactId>

--- a/opennms-tools/opennms-tip/cxf-dependencies/pom.xml
+++ b/opennms-tools/opennms-tip/cxf-dependencies/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>opennms-tip</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.tip</groupId>

--- a/opennms-tools/opennms-tip/openejb-dependencies/pom.xml
+++ b/opennms-tools/opennms-tip/openejb-dependencies/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>opennms-tip</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.tip</groupId>

--- a/opennms-tools/opennms-tip/opennms-tip-ram/pom.xml
+++ b/opennms-tools/opennms-tip/opennms-tip-ram/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>opennms-tip</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.tip</groupId>

--- a/opennms-tools/opennms-tip/pom.xml
+++ b/opennms-tools/opennms-tip/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>opennms-tools</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms</groupId>

--- a/opennms-tools/opennms-tip/tip-framework-dependencies/pom.xml
+++ b/opennms-tools/opennms-tip/tip-framework-dependencies/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>opennms-tip</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.tip</groupId>

--- a/opennms-tools/perfdata-receiver/pom.xml
+++ b/opennms-tools/perfdata-receiver/pom.xml
@@ -53,7 +53,7 @@
     <dependency>
       <groupId>org.opennms</groupId>
       <artifactId>opennms-rrd-tcp</artifactId>
-      <version>24.0.0-SNAPSHOT</version>
+      <version>25.0.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/opennms-tools/phonebook/pom.xml
+++ b/opennms-tools/phonebook/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>opennms-tools</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features</groupId>

--- a/opennms-tools/pom.xml
+++ b/opennms-tools/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>opennms</artifactId>
     <groupId>org.opennms</groupId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>opennms-tools</artifactId>

--- a/opennms-tools/quickbase-troubleticketer/pom.xml
+++ b/opennms-tools/quickbase-troubleticketer/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>opennms-tools</artifactId>
     <groupId>org.opennms</groupId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>quickbase-troubleticketer</artifactId>

--- a/opennms-tools/remedy-troubleticketer/pom.xml
+++ b/opennms-tools/remedy-troubleticketer/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>opennms-tools</artifactId>
         <groupId>org.opennms</groupId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>remedy-troubleticketer</artifactId>

--- a/opennms-tools/scriptd-event-proxy/pom.xml
+++ b/opennms-tools/scriptd-event-proxy/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>opennms-tools</artifactId>
     <groupId>org.opennms</groupId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>scriptd-event-proxy</artifactId>

--- a/opennms-tools/selector-tracker/pom.xml
+++ b/opennms-tools/selector-tracker/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>opennms-tools</artifactId>
     <groupId>org.opennms</groupId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>selector-tracker</artifactId>

--- a/opennms-tools/spectrum-event-importer/pom.xml
+++ b/opennms-tools/spectrum-event-importer/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>opennms-tools</artifactId>
     <groupId>org.opennms</groupId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.netmgt.mib2events</groupId>

--- a/opennms-tools/syslog-profiler/pom.xml
+++ b/opennms-tools/syslog-profiler/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>opennms-tools</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.opennms-tools</groupId>

--- a/opennms-tools/syslog-profiler/profiler/pom.xml
+++ b/opennms-tools/syslog-profiler/profiler/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms.opennms-tools</groupId>
     <artifactId>org.opennms.opennms-tools.syslog-profiler</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.opennms-tools.syslog-profiler</groupId>

--- a/opennms-util/pom.xml
+++ b/opennms-util/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>opennms</artifactId>
     <groupId>org.opennms</groupId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>opennms-util</artifactId>

--- a/opennms-web-api/pom.xml
+++ b/opennms-web-api/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>opennms</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>opennms-web-api</artifactId>

--- a/opennms-web-dependencies/pom.xml
+++ b/opennms-web-dependencies/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>opennms</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms</groupId>

--- a/opennms-webapp-rest/pom.xml
+++ b/opennms-webapp-rest/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>opennms</artifactId>
     <groupId>org.opennms</groupId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>opennms-webapp-rest</artifactId>

--- a/opennms-webapp/pom.xml
+++ b/opennms-webapp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>opennms</artifactId>
     <groupId>org.opennms</groupId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>opennms-webapp</artifactId>

--- a/opennms-wmi/pom.xml
+++ b/opennms-wmi/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>opennms</artifactId>
     <groupId>org.opennms</groupId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>opennms-wmi</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms</groupId>
   <artifactId>opennms</artifactId>
-  <version>24.0.0-SNAPSHOT</version>
+  <version>25.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>OpenNMS</name>
   <url>http://opennms.org/</url>
@@ -1166,7 +1166,7 @@
     <install.version>${project.version}</install.version>
     <display.version>${install.version}</display.version>
     <opennms.home>${dist.dir}/${dist.name}</opennms.home>
-    <opennms.osgi.version>24.0.0.SNAPSHOT</opennms.osgi.version>
+    <opennms.osgi.version>25.0.0.SNAPSHOT</opennms.osgi.version>
     <maven.metadata.legacy>true</maven.metadata.legacy>
     <root.dir>${project.basedir}</root.dir>
     <dist.dir>${root.dir}/target</dist.dir>

--- a/protocols/cifs/pom.xml
+++ b/protocols/cifs/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.opennms</groupId>
         <artifactId>org.opennms.protocols</artifactId>
-        <version>24.0.0-SNAPSHOT</version>
+        <version>25.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.opennms.protocols</groupId>

--- a/protocols/nsclient/pom.xml
+++ b/protocols/nsclient/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>org.opennms.protocols</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.protocols</groupId>

--- a/protocols/pom.xml
+++ b/protocols/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>opennms</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>org.opennms.protocols</artifactId>

--- a/protocols/radius/pom.xml
+++ b/protocols/radius/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>org.opennms.protocols</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.protocols</groupId>

--- a/protocols/selenium-monitor/pom.xml
+++ b/protocols/selenium-monitor/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>org.opennms.protocols</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.protocols</groupId>

--- a/protocols/xml/pom.xml
+++ b/protocols/xml/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>org.opennms.protocols</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.protocols</groupId>

--- a/protocols/xmp/pom.xml
+++ b/protocols/xmp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>org.opennms.protocols</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.protocols</groupId>

--- a/smoke-test/pom.xml
+++ b/smoke-test/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms</groupId>
   <artifactId>smoke-test</artifactId>
-  <version>24.0.0-SNAPSHOT</version>
+  <version>25.0.0-SNAPSHOT</version>
   <name>OpenNMS Smoke Test</name>
   <properties>
     <skipITs>true</skipITs>

--- a/smoke-test/src/test/java/org/opennms/smoketest/RestInfoIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/RestInfoIT.java
@@ -61,7 +61,7 @@ public class RestInfoIT extends OpenNMSSeleniumTestCase {
         final String json = response.getResponseText();
 
         // The expected payload looks like:
-        //  {"packageDescription":"OpenNMS","displayVersion":"24.0.0-SNAPSHOT","packageName":"opennms","version":"24.0.0", "ticketerConfig":{"enabled":false, "plugin": null}}
+        //  {"packageDescription":"OpenNMS","displayVersion":"25.0.0-SNAPSHOT","packageName":"opennms","version":"25.0.0", "ticketerConfig":{"enabled":false, "plugin": null}}
         final ObjectMapper mapper = new ObjectMapper();
         final JsonNode infoObject = mapper.readTree(json);
 

--- a/tests/dao/pom.xml
+++ b/tests/dao/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>org.opennms.tests</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.tests</groupId>

--- a/tests/mock-elements/pom.xml
+++ b/tests/mock-elements/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>org.opennms.tests</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.tests</groupId>

--- a/tests/mock-snmp-agent/pom.xml
+++ b/tests/mock-snmp-agent/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>org.opennms.tests</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.tests</groupId>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.opennms</groupId>
     <artifactId>opennms</artifactId>
-    <version>24.0.0-SNAPSHOT</version>
+    <version>25.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>org.opennms.tests</artifactId>


### PR DESCRIPTION
* JIRA: https://issues.opennms.org/browse/HZN-1475

Our [continuous integration system](http://bamboo.internal.opennms.com:8085) will test and verify your changes.

@j-white , @rssntn67, could you take another look? Thanks!

What is in this PR?
1. Enhancement of the topology generator by the protocol "bridge". The bridge protocol is a bit different in that it contains multiple node types. The generator builds a tree consisting of hosts, bridges, segments and" Mac/IpAdresses on Segment without node". The tree is repeated depending on the amount of nodes (multiple of 10).
2. The generated tree is tested in LinkdTopologyProviderTestIT.testBridge()
3. I introduced a "BridgeBuilder" that allows for easier generating of such topologies. It is sufficient for my use case but could be enhanced in the future. It tries to abstract the low level stitching together of the different database entries.

Thanks again to @rssntn67 who provided me with a working example and lots of explanation.
