### PR TITLE
NMS-10593: Add a timeout when trying to acquire the locks in order to prevent deadlocks.

### DIFF
--- a/opennms-alarms/daemon/src/main/java/org/opennms/netmgt/alarmd/drools/DroolsAlarmContext.java
+++ b/opennms-alarms/daemon/src/main/java/org/opennms/netmgt/alarmd/drools/DroolsAlarmContext.java
@@ -336,6 +336,8 @@ public class DroolsAlarmContext extends ManagedDroolsContext implements AlarmLif
             LOG.warn("Interrupted while waiting for Drools session lock. " +
                             "{} for alarm with id={} and reduction-key={} will not be immediately reflected in the context.",
                    action, alarmId, reductionKey);
+            // Propagate the interrupt
+            Thread.currentThread().interrupt();
         }
     }
 


### PR DESCRIPTION
JIRA: https://issues.opennms.org/browse/NMS-10593

Rely on the snapshot handling to update the context if acquiring the lock fails.
