### PR TITLE
NMS-10603: fix ackd event

### DIFF
--- a/opennms-ackd/src/test/java/org/opennms/netmgt/ackd/AckdIT.java
+++ b/opennms-ackd/src/test/java/org/opennms/netmgt/ackd/AckdIT.java
@@ -269,6 +269,12 @@ public class AckdIT implements InitializingBean {
         
     }
     
+    /*
+     * Send Ackd Notification Event for the ALARM
+     * ackAction is the default Acknowledge
+     * this will led to ack both the notification and the alarm
+     *  
+     */
     @Test
     public void testHandleEvent() throws InterruptedException {
         
@@ -289,8 +295,40 @@ public class AckdIT implements InitializingBean {
         Assert.assertEquals(alarm.getAckUser(), user);
 //        Assert.assertEquals(alarm.getAckTime(), bldr.getEvent().getTime());
     }
-    
 
+    /*
+     * Send Ackd Notification Event for the NOTIFICATION
+     * ackAction is the default Acknowledge
+     * this will led to ack both the notification and the alarm
+     *  
+     */
+    @Test
+    public void testHandleEventNotificationAck() throws InterruptedException {
+        
+        VerificationObject vo = createAckStructure();
+        EventBuilder bldr = new EventBuilder(EventConstants.ACKNOWLEDGE_EVENT_UEI, "AckdTest");
+        bldr.addParam("ackType", String.valueOf(AckType.NOTIFICATION));
+        bldr.addParam("refId", vo.m_alarmId);
+        final String user = "ackd-test-user";
+        bldr.addParam("ackUser", user);
+
+        m_daemon.handleAckEvent(bldr.getEvent());
+        
+        OnmsNotification notif = m_notificationDao.get(vo.m_notifId);
+        Assert.assertEquals(notif.getAckUser(), user);
+//        Assert.assertEquals(notif.getAckTime(), bldr.getEvent().getTime());
+        
+        OnmsAlarm alarm = m_alarmDao.get(vo.m_alarmId);
+        Assert.assertEquals(alarm.getAckUser(), user);
+//        Assert.assertEquals(alarm.getAckTime(), bldr.getEvent().getTime());
+    }
+
+    /*
+     * Send Ackd Notification Event for the ALARM
+     * AckAction is ESCALATE
+     * this will led only to escalate the alarm
+     *  
+     */
     @Test
     public void testHandleEventEscalate() throws InterruptedException {
         
@@ -315,6 +353,12 @@ public class AckdIT implements InitializingBean {
 //        Assert.assertEquals(alarm.getAckTime(), bldr.getEvent().getTime());
     }
 
+    /*
+     * Send Ackd Notification Event for the ALARM
+     * AckAction is CLEAR
+     * this will led clear the alarm
+     * and ack the notif 
+     */
     @Test
     public void testHandleEventClear() throws InterruptedException {
         
@@ -330,7 +374,7 @@ public class AckdIT implements InitializingBean {
         m_daemon.handleAckEvent(bldr.getEvent());
         
         OnmsNotification notif = m_notificationDao.get(vo.m_notifId);
-        Assert.assertEquals(notif.getAckUser(), null);
+        Assert.assertEquals(notif.getAckUser(), user);
 //        Assert.assertEquals(notif.getAckTime(), bldr.getEvent().getTime());
         
         OnmsAlarm alarm = m_alarmDao.get(vo.m_alarmId);

--- a/opennms-model/src/main/java/org/opennms/netmgt/model/OnmsAcknowledgment.java
+++ b/opennms-model/src/main/java/org/opennms/netmgt/model/OnmsAcknowledgment.java
@@ -121,25 +121,36 @@ public class OnmsAcknowledgment {
         
         for (Parm parm : parms) {
             final String parmValue = parm.getValue().getContent();
-            
-            if (!"ackType".equals(parm.getParmName()) && !"refId".equals(parm.getParmName()) && !"user".equals(parm.getParmName()) ) {
+            if (!"ackAction".equals(parm.getParmName()) && 
+                !"ackType".equals(parm.getParmName()) && !"refId".equals(parm.getParmName()) && !"user".equals(parm.getParmName()) ) {
                 throw new IllegalArgumentException("Event parm: "+parm.getParmName()+", is an invalid paramter");
-            } else {
+            } 
             
-                if ("ackType".equals(parm.getParmName())) {
+            if ("ackType".equals(parm.getParmName())) {
 
-                    if ("ALARM".equalsIgnoreCase(parmValue) || "NOTIFICATION".equalsIgnoreCase(parmValue)) {
-                        m_ackType = ("ALARM".equalsIgnoreCase(parmValue) ? AckType.ALARM : AckType.NOTIFICATION);
-                    } else {
-                        throw new IllegalArgumentException("Event parm: "+parm.getParmName()+", has invalid value, requires: \"Alarm\" or \"Notification\"." );
-                    }
-                    
-                } else if ("refId".equals(parm.getParmName())){
-                    m_refId = Integer.valueOf(parm.getValue().getContent());
+                if ("ALARM".equalsIgnoreCase(parmValue) || "NOTIFICATION".equalsIgnoreCase(parmValue)) {
+                    m_ackType = ("ALARM".equalsIgnoreCase(parmValue) ? AckType.ALARM : AckType.NOTIFICATION);
                 } else {
-                    m_ackUser = parm.getValue().getContent();
+                    throw new IllegalArgumentException("Event parm: "+parm.getParmName()+", has invalid value, requires: \"Alarm\" or \"Notification\"." );
                 }
-            }                
+                
+            } else if ("refId".equals(parm.getParmName())){
+                m_refId = Integer.valueOf(parmValue);
+            } else if ("user".equals(parm.getParmName())){
+                m_ackUser = parmValue;
+            } else {
+                if ("ACKNOWLEDGE".equalsIgnoreCase(parmValue)) {
+                    m_ackAction=AckAction.ACKNOWLEDGE;
+                } else if ("ESCALATE".equalsIgnoreCase(parmValue)) {
+                    m_ackAction=AckAction.ESCALATE;
+                } else if ("UNACKNOWLEDGE".equalsIgnoreCase(parmValue)) {
+                    m_ackAction=AckAction.UNACKNOWLEDGE;
+                } else if ("CLEAR".equalsIgnoreCase(parmValue)) {
+                    m_ackAction=AckAction.CLEAR;
+                } else {
+                    m_ackAction = AckAction.UNSPECIFIED;
+                } 
+            }
         }
     }
 

--- a/opennms-model/src/main/java/org/opennms/netmgt/model/OnmsAcknowledgment.java
+++ b/opennms-model/src/main/java/org/opennms/netmgt/model/OnmsAcknowledgment.java
@@ -122,7 +122,7 @@ public class OnmsAcknowledgment {
         for (Parm parm : parms) {
             final String parmValue = parm.getValue().getContent();
             if (!"ackAction".equals(parm.getParmName()) && 
-                !"ackType".equals(parm.getParmName()) && !"refId".equals(parm.getParmName()) && !"user".equals(parm.getParmName()) ) {
+                !"ackType".equals(parm.getParmName()) && !"refId".equals(parm.getParmName()) && !"ackUser".equals(parm.getParmName()) ) {
                 throw new IllegalArgumentException("Event parm: "+parm.getParmName()+", is an invalid paramter");
             } 
             
@@ -136,7 +136,7 @@ public class OnmsAcknowledgment {
                 
             } else if ("refId".equals(parm.getParmName())){
                 m_refId = Integer.valueOf(parmValue);
-            } else if ("user".equals(parm.getParmName())){
+            } else if ("ackUser".equals(parm.getParmName())){
                 m_ackUser = parmValue;
             } else {
                 if ("ACKNOWLEDGE".equalsIgnoreCase(parmValue)) {


### PR DESCRIPTION
supporting any ack action event


NMS-10603: fix ackd event

* JIRA: http://issues.opennms.org/browse/NMS-10603

Sending uei.opennms.org/ackd/acknowledge was triggering always ACKNOWLEDGE action,
now sending parameter ackAction it is also possible to specify other actions:
UNACKNOWLEDGE
ESCALATE
CLEAR 
