### PR TITLE
HZN-1475: Extend topology generator and test suite to support bridge topology - release 4.0.0

### DIFF
--- a/features/enlinkd/daemon/src/main/java/org/opennms/netmgt/enlinkd/EnhancedLinkd.java
+++ b/features/enlinkd/daemon/src/main/java/org/opennms/netmgt/enlinkd/EnhancedLinkd.java
@@ -772,6 +772,9 @@ public class EnhancedLinkd extends AbstractServiceDaemon implements ReloadableTo
     @Override
     public void reloadTopology() {
         LOG.info("reloadTopology: reload enlinkd topology updaters");
+        LOG.debug("reloadTopology: Loading Bridge Topology.....");
+        m_bridgeTopologyService.load();
+        LOG.debug("reloadTopology: Bridge Topology Loaded");
         for (ProtocolSupported protocol :ProtocolSupported.values()) {
             forceTopologyUpdaterRun(protocol);
             runTopologyUpdater(protocol);

--- a/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/TopologyGenerator.java
+++ b/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/TopologyGenerator.java
@@ -30,6 +30,7 @@ package org.opennms.enlinkd.generator;
 
 import java.util.function.Consumer;
 
+import org.opennms.enlinkd.generator.protocol.BridgeProtocol;
 import org.opennms.enlinkd.generator.protocol.CdpProtocol;
 import org.opennms.enlinkd.generator.protocol.IsIsProtocol;
 import org.opennms.enlinkd.generator.protocol.LldpProtocol;
@@ -97,6 +98,8 @@ public class TopologyGenerator {
             return new LldpProtocol(topologySettings, topologyContext);
         } else if (Protocol.ospf == protocol) {
             return new OspfProtocol(topologySettings, topologyContext);
+        } else if (Protocol.bridgeBridge == protocol) {
+            return new BridgeProtocol(topologySettings, topologyContext);
         } else {
             throw new IllegalArgumentException("Don't know this protocol: " + topologySettings.getProtocol());
         }

--- a/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/TopologyGenerator.java
+++ b/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/TopologyGenerator.java
@@ -66,7 +66,7 @@ public class TopologyGenerator {
     }
 
     public enum Protocol {
-        cdp, isis, lldp, ospf, bridgeBridge
+        cdp, isis, lldp, ospf, bridge
     }
 
     private TopologyContext topologyContext;
@@ -98,7 +98,7 @@ public class TopologyGenerator {
             return new LldpProtocol(topologySettings, topologyContext);
         } else if (Protocol.ospf == protocol) {
             return new OspfProtocol(topologySettings, topologyContext);
-        } else if (Protocol.bridgeBridge == protocol) {
+        } else if (Protocol.bridge == protocol) {
             return new BridgeProtocol(topologySettings, topologyContext);
         } else {
             throw new IllegalArgumentException("Don't know this protocol: " + topologySettings.getProtocol());

--- a/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/TopologyGenerator.java
+++ b/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/TopologyGenerator.java
@@ -65,7 +65,7 @@ public class TopologyGenerator {
     }
 
     public enum Protocol {
-        cdp, isis, lldp, ospf
+        cdp, isis, lldp, ospf, bridgeBridge
     }
 
     private TopologyContext topologyContext;

--- a/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/TopologyGenerator.java
+++ b/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/TopologyGenerator.java
@@ -79,9 +79,9 @@ public class TopologyGenerator {
 
 
     public void generateTopology(TopologySettings topologySettings) {
-        topologySettings.verify();
+        org.opennms.enlinkd.generator.protocol.Protocol protocol = getProtocol(topologySettings);
         deleteTopology(); // Let's first get rid of old generated topologies
-        getProtocol(topologySettings).createAndPersistNetwork();
+        protocol.createAndPersistNetwork();
     }
 
     public void deleteTopology() {

--- a/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/TopologyPersister.java
+++ b/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/TopologyPersister.java
@@ -32,6 +32,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.opennms.netmgt.dao.api.GenericPersistenceAccessor;
+import org.opennms.netmgt.enlinkd.model.BridgeBridgeLink;
 import org.opennms.netmgt.enlinkd.model.CdpElement;
 import org.opennms.netmgt.enlinkd.model.CdpLink;
 import org.opennms.netmgt.enlinkd.model.IsIsElement;
@@ -88,6 +89,7 @@ public class TopologyPersister {
                 IsIsElement.class,
                 LldpElement.class,
                 OspfLink.class,
+                BridgeBridgeLink.class,
                 OnmsIpInterface.class,
                 OnmsSnmpInterface.class);
 

--- a/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/TopologyPersister.java
+++ b/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/TopologyPersister.java
@@ -33,6 +33,7 @@ import java.util.List;
 
 import org.opennms.netmgt.dao.api.GenericPersistenceAccessor;
 import org.opennms.netmgt.enlinkd.model.BridgeBridgeLink;
+import org.opennms.netmgt.enlinkd.model.BridgeElement;
 import org.opennms.netmgt.enlinkd.model.CdpElement;
 import org.opennms.netmgt.enlinkd.model.CdpLink;
 import org.opennms.netmgt.enlinkd.model.IpNetToMedia;
@@ -95,6 +96,7 @@ public class TopologyPersister {
                 LldpElement.class,
                 OspfLink.class,
                 BridgeBridgeLink.class,
+                BridgeElement.class,
                 OnmsIpInterface.class,
                 OnmsSnmpInterface.class,
                 IpNetToMedia.class);

--- a/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/TopologyPersister.java
+++ b/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/TopologyPersister.java
@@ -35,6 +35,7 @@ import org.opennms.netmgt.dao.api.GenericPersistenceAccessor;
 import org.opennms.netmgt.enlinkd.model.BridgeBridgeLink;
 import org.opennms.netmgt.enlinkd.model.CdpElement;
 import org.opennms.netmgt.enlinkd.model.CdpLink;
+import org.opennms.netmgt.enlinkd.model.IpNetToMedia;
 import org.opennms.netmgt.enlinkd.model.IsIsElement;
 import org.opennms.netmgt.enlinkd.model.IsIsLink;
 import org.opennms.netmgt.enlinkd.model.LldpElement;
@@ -95,7 +96,8 @@ public class TopologyPersister {
                 OspfLink.class,
                 BridgeBridgeLink.class,
                 OnmsIpInterface.class,
-                OnmsSnmpInterface.class);
+                OnmsSnmpInterface.class,
+                IpNetToMedia.class);
 
         for (Class<?> clazz : deleteOperations) {
             deleteEntities(clazz);

--- a/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/TopologyPersister.java
+++ b/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/TopologyPersister.java
@@ -64,6 +64,10 @@ public class TopologyPersister {
         progressCallback.currentProgress("    Inserting of %s done.", entity.getClass().getSimpleName());
     }
 
+    public <E> void persist(E ... elements) {
+        persist(Arrays.asList(elements));
+    }
+
     public <E> void persist(List<E> elements) {
         if (elements.size() < 1) {
             return; // nothing do do

--- a/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/TopologyPersister.java
+++ b/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/TopologyPersister.java
@@ -34,6 +34,7 @@ import java.util.List;
 import org.opennms.netmgt.dao.api.GenericPersistenceAccessor;
 import org.opennms.netmgt.enlinkd.model.BridgeBridgeLink;
 import org.opennms.netmgt.enlinkd.model.BridgeElement;
+import org.opennms.netmgt.enlinkd.model.BridgeMacLink;
 import org.opennms.netmgt.enlinkd.model.CdpElement;
 import org.opennms.netmgt.enlinkd.model.CdpLink;
 import org.opennms.netmgt.enlinkd.model.IpNetToMedia;
@@ -96,6 +97,7 @@ public class TopologyPersister {
                 LldpElement.class,
                 OspfLink.class,
                 BridgeBridgeLink.class,
+                BridgeMacLink.class,
                 BridgeElement.class,
                 OnmsIpInterface.class,
                 OnmsSnmpInterface.class,

--- a/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/BridgeProtocol.java
+++ b/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/BridgeProtocol.java
@@ -81,143 +81,230 @@ public class BridgeProtocol extends Protocol<BridgeBridgeLink> {
         // Call with: enlinkd:generate-topology --protocol bridgeBridge --nodes 10 --snmpinterfaces 0 --ipinterfaces 0
         //      here is complete example of bridge topology
        // 4 nodes are bridges: nodeBridgeA, nodeBridgeB, nodeBridgeC, nodeBridgeD
-       //              B
+       //            bridge2
        //           --------  
        //           |      |
-       //           A      C
+       //        bridge1   bridge3
        //         -----
        //           |
-       //           D 
-       // 6 nodes are hosts: nodeHostE, nodeHostF, nodeHostG, nodeHostH, nodeHostI, nodeHostL 
+       //        bridge4
+       // 6 nodes are hosts: host5, host6, host7, host8, host9, host10 
        // generate 4 ipnettomedia without a corresponding node  
        // consider also that on port 1 of C is connected an HUB with a group of hosts connected
        // the hub has no snmp agent and therefore we are not to explore his mab forwarding table 
+       // we also follow the convention to start the port countin from the if of the node
+       // following an integer: so port11 -> is the first generated port of node with id 1
+       //                          port12 -> is the second generated port of node with id 1 
+       //                          port21 -> is the first generated port of node with id 2 
+       //                          port53 -> is the third generated port of node with id 5 
         
-        OnmsNode nodeBridgeA =  nodes.get(0);
-        OnmsNode nodeBridgeB =  nodes.get(1);
-        OnmsNode nodeBridgeC =  nodes.get(2);
-        OnmsNode nodeBridgeD =  nodes.get(3);
+        // this is the vlan id for all the bridgebridgelinks and bridgemaclinks...
+        int vlanid = 1;
+        OnmsNode bridge1 =  nodes.get(0);
+        OnmsNode bridge2 =  nodes.get(1);
+        OnmsNode bridge3 =  nodes.get(2);
+        OnmsNode bridge4 =  nodes.get(3);
 
-        // create bridge element
-        BridgeElement bridgeA = createBridgeElement(nodeBridgeA, 1 ,"default");
-        BridgeElement bridgeB = createBridgeElement(nodeBridgeB, 1 ,"default");
-        BridgeElement bridgeC = createBridgeElement(nodeBridgeC, 1 ,"default");
-        BridgeElement bridgeD = createBridgeElement(nodeBridgeD, 1 ,"default");
-
-        this.context.getTopologyPersister().persist(bridgeA,bridgeB,bridgeC,bridgeD);
+        // save bridge element
+        this.context.getTopologyPersister().persist(
+                    createBridgeElement(bridge1, vlanid ,"default"),
+                    createBridgeElement(bridge2, vlanid ,"default"),
+                    createBridgeElement(bridge3, vlanid ,"default"),
+                    createBridgeElement(bridge4, vlanid ,"default")                
+                );
         
         //First persist bridge topology
-        // nodeBridgeB:port24 connected to nodeBridgeA port4
-        // save snmpinterface and bridgebridgelink
-        context.getTopologyPersister().persist(createSnmpInterface(4, nodeBridgeA), 
-                                               createSnmpInterface(24, nodeBridgeB));
-        context.getTopologyPersister().persist(createBridgeBridgeLink(nodeBridgeA, nodeBridgeB, 4, 24,1));
+        // bridge1:port11 connected to bridge2:port21
+        // generate and save snmpinterface and bridgebridgelink
+        int bridge1portCounter = 11;
+        int bridge2portCounter = 21;
+        context.getTopologyPersister().persist(
+                   createSnmpInterface(bridge1portCounter, bridge1), 
+                   createSnmpInterface(bridge2portCounter, bridge2)
+               );
+        context.getTopologyPersister().persist(
+               createBridgeBridgeLink(bridge1, bridge2, bridge1portCounter, bridge1portCounter,vlanid));
+        bridge1portCounter++;
+        bridge2portCounter++;
 
-        // nodeBridgeB:port23 connected to nodeBridgeC port3
+        int bridge3portCounter=31;
+        // bridge3:port31 connected to bridge2:port22
         // save snmpinterface and bridgebridgelink
-        context.getTopologyPersister().persist(createSnmpInterface(23, nodeBridgeB), createSnmpInterface(3, nodeBridgeC));
-        context.getTopologyPersister().persist(createBridgeBridgeLink(nodeBridgeC, nodeBridgeB, 3, 23,1));
+        context.getTopologyPersister().persist(
+                   createSnmpInterface(bridge1portCounter, bridge2), 
+                   createSnmpInterface(bridge2portCounter, bridge3)
+               );
+        context.getTopologyPersister().persist(
+                   createBridgeBridgeLink(bridge3, bridge2, bridge2portCounter, bridge1portCounter,vlanid)
+               );
+        bridge2portCounter++;
+        bridge1portCounter++;
 
-        // nodeBridgeD:port1 connected to nodeBridgeA port11
+        int bridge4portCounter=41;
+        // bridge4:port41 connected to bridge1:port12
         // save snmpinterface and bridgebridgelink
-        context.getTopologyPersister().persist(createSnmpInterface(1, nodeBridgeD), createSnmpInterface(11, nodeBridgeA));
-        context.getTopologyPersister().persist(createBridgeBridgeLink(nodeBridgeD, nodeBridgeA, 1, 11,1));
+        context.getTopologyPersister().persist(
+                   createSnmpInterface(bridge4portCounter, bridge4), 
+                   createSnmpInterface(bridge1portCounter, bridge1)
+               );
+        context.getTopologyPersister().persist(
+                   createBridgeBridgeLink(bridge4, bridge1, bridge4portCounter, bridge1portCounter,vlanid)
+               );
+        bridge4portCounter++;
+        bridge1portCounter++;
         
         //generate host topology
         // here ip addresses are needed
 
-        // nodeHostE port 1 is connected on port 5 of nodeBridgeA
-        // ipinterface -> nodeHostE - 192.168.0.11
-        OnmsNode nodeHostE =  nodes.get(4);
-        String macE=macGenerator.next();
-        OnmsSnmpInterface snmpInterfaceE = createSnmpInterface(1, nodeHostE);
-        context.getTopologyPersister().persist(createSnmpInterface(5, nodeBridgeA),snmpInterfaceE);
-        OnmsIpInterface ipInterfaceE = createIpInterface(snmpInterfaceE, inetGenerator.next());
-        context.getTopologyPersister().persist(ipInterfaceE);
+        // host5:port 51 connected to bridge1:port13
+        OnmsNode host5 =  nodes.get(4);
+        int host5portCounter = 51;
+        String mac5=macGenerator.next();
+        InetAddress ip5= inetGenerator.next();
+        OnmsSnmpInterface snmpInterface51 = createSnmpInterface(host5portCounter, host5);
         context.getTopologyPersister().persist(
-           createIpNetToMedia(nodeHostE, snmpInterfaceE.getIfIndex(), snmpInterfaceE.getIfName(),macE, ipInterfaceE.getIpAddress(), nodeBridgeA)
+                   createSnmpInterface(bridge1portCounter, bridge1),
+                   snmpInterface51
+               );
+        OnmsIpInterface ipInterface51 = createIpInterface(snmpInterface51, ip5);
+        context.getTopologyPersister().persist(ipInterface51);
+        context.getTopologyPersister().persist(
+                   createIpNetToMedia(host5, host5portCounter, mac5, ip5, bridge1)
                 );
-        context.getTopologyPersister().persist(createBridgeMacLink(nodeBridgeA, 5, 1, macE));
+        context.getTopologyPersister().persist(
+                   createBridgeMacLink(bridge1, bridge1portCounter, vlanid, mac5)
+               );
+        bridge1portCounter++;
+        host5portCounter++;
         
-        // nodeHostF port 1 is connected on port 5 of nodeBridgeA
-        // ipinterface -> nodeHostF - 192.168.0.12
-        OnmsNode nodeHostF =  nodes.get(5);
-        String macF=macGenerator.next();
-        OnmsSnmpInterface snmpInterfaceF = createSnmpInterface(1, nodeHostF);
-        context.getTopologyPersister().persist(createSnmpInterface(6, nodeBridgeA),snmpInterfaceF);
-        OnmsIpInterface ipInterfaceF = createIpInterface(snmpInterfaceF, inetGenerator.next());
-        context.getTopologyPersister().persist(ipInterfaceF);
+        // host6:port61 connected ton bridge1:port14
+        OnmsNode host6 =  nodes.get(5);
+        int host6portCounter = 61;
+        String mac6=macGenerator.next();
+        InetAddress ip6= inetGenerator.next();
+        OnmsSnmpInterface snmpInterface61 = createSnmpInterface(host6portCounter, host6);
         context.getTopologyPersister().persist(
-           createIpNetToMedia(nodeHostF, snmpInterfaceF.getIfIndex(), snmpInterfaceF.getIfName(),macF, ipInterfaceF.getIpAddress(), nodeBridgeA)
+                   createSnmpInterface(bridge1portCounter, bridge1),
+                   snmpInterface61
+               );
+        OnmsIpInterface ipInterface61 = createIpInterface(snmpInterface61, ip6);
+        context.getTopologyPersister().persist(ipInterface61);
+        context.getTopologyPersister().persist(
+                   createIpNetToMedia(host6, host6portCounter,mac6, ip6, bridge1)
                 );
-        context.getTopologyPersister().persist(createBridgeMacLink(nodeBridgeA, 5, 1, macF));
-        
+        context.getTopologyPersister().persist(
+                   createBridgeMacLink(bridge1, bridge1portCounter, vlanid, mac6)
+               );
+        bridge1portCounter++;
+        host6portCounter++;
 
-        // nodeHostG port 10 is connected on port 10 of nodeBridgeC
-        // ipinterface -> nodeHostF - 192.168.0.13
-        OnmsNode nodeHostG =  nodes.get(6);
-        String macG=macGenerator.next();
-        OnmsSnmpInterface snmpInterfaceG = createSnmpInterface(10, nodeHostG);
-        context.getTopologyPersister().persist(createSnmpInterface(10, nodeBridgeC),snmpInterfaceG);
-        OnmsIpInterface ipInterfaceG = createIpInterface(snmpInterfaceG, inetGenerator.next());
-        context.getTopologyPersister().persist(ipInterfaceG);
+        // host7:port71 connected bridge3:port32
+        OnmsNode host7 =  nodes.get(6);
+        int host7portCounter = 71;
+        String mac7=macGenerator.next();
+        InetAddress ip7= inetGenerator.next();
+        OnmsSnmpInterface snmpInterface71 = createSnmpInterface(host7portCounter, host7);
         context.getTopologyPersister().persist(
-           createIpNetToMedia(nodeHostG, snmpInterfaceG.getIfIndex(), snmpInterfaceG.getIfName(),macG, ipInterfaceG.getIpAddress(), nodeBridgeA)
+                   createSnmpInterface(bridge3portCounter, bridge3),
+                   snmpInterface71
+               );
+        OnmsIpInterface ipInterface7 = createIpInterface(snmpInterface71, ip7);
+        context.getTopologyPersister().persist(ipInterface7);
+        context.getTopologyPersister().persist(
+                   createIpNetToMedia(host7, host7portCounter,mac7, ip7, bridge1)
                 );
-        context.getTopologyPersister().persist(createBridgeMacLink(nodeBridgeC, 10, 1, macG));
+        context.getTopologyPersister().persist(
+                   createBridgeMacLink(bridge3, bridge3portCounter, vlanid, mac7)
+               );
+        bridge1portCounter++;
+        host7portCounter++;
 
-        // nodeHostH port 11 is connected on port 11 of nodeBridgeD
-        // ipinterface -> nodeHostH - 192.168.0.14
-        OnmsNode nodeHostH =  nodes.get(7);
-        String macH=macGenerator.next();
-        OnmsSnmpInterface snmpInterfaceH = createSnmpInterface(11, nodeHostH);
-        context.getTopologyPersister().persist(createSnmpInterface(11, nodeBridgeD),snmpInterfaceH);
-        OnmsIpInterface ipInterfaceH = createIpInterface(snmpInterfaceH, inetGenerator.next());
-        context.getTopologyPersister().persist(ipInterfaceH);
+        // host8:port81 connected bridge4:port42
+        OnmsNode host8 =  nodes.get(7);
+        int host8portCounter = 81;
+        String mac8=macGenerator.next();
+        InetAddress ip8= inetGenerator.next();
+        OnmsSnmpInterface snmpInterface81 = createSnmpInterface(host8portCounter, host8);
         context.getTopologyPersister().persist(
-           createIpNetToMedia(nodeHostH, snmpInterfaceH.getIfIndex(), snmpInterfaceH.getIfName(),macH, ipInterfaceH.getIpAddress(), nodeBridgeA)
+                   createSnmpInterface(bridge4portCounter, bridge4),
+                   snmpInterface81
+               );
+        OnmsIpInterface ipInterface8 = createIpInterface(snmpInterface81, ip8);
+        context.getTopologyPersister().persist(ipInterface8);
+        context.getTopologyPersister().persist(
+                   createIpNetToMedia(host8, host8portCounter,mac8, ip8, bridge1)
                 );
-        context.getTopologyPersister().persist(createBridgeMacLink(nodeBridgeD, 11, 1, macH));
+        context.getTopologyPersister().persist(
+                   createBridgeMacLink(bridge4, bridge4portCounter, vlanid, mac8)
+               );
+        bridge4portCounter++;
+        host8portCounter++;
  
-        // nodeHostI  is connected on port 12 of nodeBridgeD
-        // ipinterface -> nodeHostI - 192.168.0.15
-        OnmsNode nodeHostI =  nodes.get(8);
-        String macI=macGenerator.next();
-        context.getTopologyPersister().persist(createSnmpInterface(12, nodeBridgeD));
-        OnmsIpInterface ipInterfaceI = createIpInterface(null, inetGenerator.next());
-        ipInterfaceI.setNode(nodeHostI);
-        context.getTopologyPersister().persist(ipInterfaceI);
+        // host9:with-no-snmp connected bridge4:port43
+        OnmsNode host9 =  nodes.get(8);
+        String mac9=macGenerator.next();
+        InetAddress ip9= inetGenerator.next();
+        context.getTopologyPersister().persist(createSnmpInterface(bridge4portCounter, bridge4));
+        OnmsIpInterface ipInterface9 = createIpInterface(null, ip9);
+        ipInterface9.setNode(host9);
+        context.getTopologyPersister().persist(ipInterface9);
         context.getTopologyPersister().persist(
-           createIpNetToMedia(nodeHostI, null, null,macI, ipInterfaceI.getIpAddress(), nodeBridgeA)
+                   createIpNetToMedia(host9, -1,mac9, ip9, bridge1)
                 );
-        context.getTopologyPersister().persist(createBridgeMacLink(nodeBridgeD, 12, 1, macI));
-
-        // nodeHostL  is connected on port 13 of nodeBridgeD
-        // ipinterface -> nodeHostI - 192.168.0.16
-        OnmsNode nodeHostL =  nodes.get(9);
-        String macL=macGenerator.next();
-        context.getTopologyPersister().persist(createSnmpInterface(13, nodeBridgeD));
-        OnmsIpInterface ipInterfaceL = createIpInterface(null, inetGenerator.next());
-        ipInterfaceL.setNode(nodeHostL);
-        context.getTopologyPersister().persist(ipInterfaceL);
         context.getTopologyPersister().persist(
-           createIpNetToMedia(nodeHostL, null, null,macL, ipInterfaceL.getIpAddress(), nodeBridgeA)
-                );
-        context.getTopologyPersister().persist(createBridgeMacLink(nodeBridgeD, 13, 1, macL));
+                   createBridgeMacLink(bridge4, bridge4portCounter, vlanid, mac9)
+               );
+        bridge4portCounter++;
 
-        // adding some mac addresses and ip on a cloud on port 23 bridge B ---
-        for (int i=0; i<5;i++) {
+        // host9:with-no-snmp connected bridge4:port43
+        OnmsNode host10 =  nodes.get(9);
+        String mac10=macGenerator.next();
+        InetAddress ip10= inetGenerator.next();
+        context.getTopologyPersister().persist(createSnmpInterface(bridge4portCounter, bridge4));
+        OnmsIpInterface ipInterface10 = createIpInterface(null,ip10);
+        ipInterface10.setNode(host10);
+        context.getTopologyPersister().persist(ipInterface10);
+        context.getTopologyPersister().persist(
+                   createIpNetToMedia(host10, -1, mac10, ip10, bridge1)
+                );
+        context.getTopologyPersister().persist(createBridgeMacLink(bridge4, bridge4portCounter, vlanid, mac10));
+        bridge4portCounter++;
+        
+        
+        // adding 2 mac addresses and ip on a cloud bridge3:port31 connected to bridge2:port22
+        for (int i=0; i<2;i++) {
             String nextMac = macGenerator.next();
             context.getTopologyPersister().persist(
-                   createIpNetToMedia(null, null, null,nextMac, inetGenerator.next(), nodeBridgeA)
+                   createIpNetToMedia(null, null,nextMac, inetGenerator.next(), bridge1)
                     );
-            context.getTopologyPersister().persist(createBridgeMacLink(nodeBridgeB, 23, 1, nextMac));
+            context.getTopologyPersister().persist(
+                       createBridgeMacLink(bridge2, 22, vlanid, nextMac));
         }
         
-        // you can also have mac addresses without an ip address associated
-        for (int i=0; i<10;i++) {
-            context.getTopologyPersister().persist(createBridgeMacLink(nodeBridgeB, 23, 1, macGenerator.next()));
+        // adding 2 mac addresses without an ip address associated on a cloud bridge3:port31 connected to bridge2:port22
+        for (int i=0; i<2;i++) {
+            context.getTopologyPersister().persist(createBridgeMacLink(bridge2, 22, vlanid, macGenerator.next()));
         }
+
+        //persisting bridge3 port 33
+        context.getTopologyPersister().persist(
+               createSnmpInterface(bridge3portCounter, bridge3)
+           );        
+        // adding 2 mac addresses and ip on a cloud bridge3:port33 
+        for (int i=0; i<2;i++) {
+            String nextMac = macGenerator.next();
+            context.getTopologyPersister().persist(
+                   createIpNetToMedia(null, null,nextMac, inetGenerator.next(), bridge1)
+                    );
+            context.getTopologyPersister().persist(
+                       createBridgeMacLink(bridge3, bridge3portCounter, vlanid, nextMac));
+        }
+        
+        // adding 3 mac addresses without an ip address associated on a cloud bridge3:port33 
+        for (int i=0; i<3;i++) {
+            context.getTopologyPersister().persist(createBridgeMacLink(bridge3, bridge3portCounter, vlanid, macGenerator.next()));
+        }
+        bridge3portCounter++;        
     }
 
     private List<BridgeElement> createBridgeElements(OnmsNode ... nodes) {
@@ -297,16 +384,19 @@ public class BridgeProtocol extends Protocol<BridgeBridgeLink> {
         return bridgeMacLink;
     }
 
-    private IpNetToMedia createIpNetToMedia(OnmsNode node, Integer ifindex, String port, String mac, InetAddress inetAddress, OnmsNode sourceNode){
+    private IpNetToMedia createIpNetToMedia(OnmsNode node, Integer ifindex, String mac, InetAddress inetAddress, OnmsNode sourceNode){
         IpNetToMedia ipNetToMedia = new IpNetToMedia();
         ipNetToMedia.setCreateTime(new Date());
-        ipNetToMedia.setIfIndex(ifindex);
+        if (node != null && ifindex == null ) {
+            ipNetToMedia.setIfIndex(-1);
+        } else {
+            ipNetToMedia.setIfIndex(ifindex);
+        }
         ipNetToMedia.setLastPollTime(new Date());
         ipNetToMedia.setIpNetToMediaType(IpNetToMedia.IpNetToMediaType.IPNETTOMEDIA_TYPE_DYNAMIC);
         ipNetToMedia.setNetAddress(inetAddress);
         ipNetToMedia.setPhysAddress(mac);
         ipNetToMedia.setNode(node);
-        ipNetToMedia.setPort(port);
         ipNetToMedia.setSourceIfIndex(0);
         ipNetToMedia.setSourceNode(sourceNode);
         return ipNetToMedia;

--- a/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/BridgeProtocol.java
+++ b/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/BridgeProtocol.java
@@ -57,9 +57,6 @@ import org.opennms.netmgt.model.OnmsSnmpInterface;
 // +- SharedSegment.create(link)
 // +- m_bridgeMacLinkDao.findAll()
 //
-// It seems that you need also to generate ipnettomedia too.
-// In fact a bridgebridgelink is a connection between two bridges and a bridge mac link is a connection with a node.
-// but you also need to let the node binded to the mac address and then you need an ip address for the mac.
 public class BridgeProtocol extends Protocol<BridgeBridgeLink> {
 
     private final MacAddressGenerator macGenerator = new MacAddressGenerator();
@@ -77,12 +74,13 @@ public class BridgeProtocol extends Protocol<BridgeBridgeLink> {
     @Override
     protected void createAndPersistProtocolSpecificEntities(List<OnmsNode> nodes) {
 
+        context.currentProgress("Version 1"); // TODO: delete later just for testing purpose
+
         // Call with: enlinkd:generate-topology --protocol bridgeBridge --nodes 3 --snmpinterfaces 0 -- ipinterfaces 0
 
-//        NodeA is connected to port 24 of NodeB
-//        NodeC is connected to port 23 of NodeB
-//        you have tio generate three nodes nodeA(id=1) nodeB(id=2) nodeC(id=3)
-
+       // NodeA is connected to port 24 of NodeB
+       // NodeC is connected to port 23 of NodeB
+       // you have to generate three nodes nodeA(id=1) nodeB(id=2) nodeC(id=3)
         OnmsNode nodeA =  nodes.get(0);
         OnmsNode nodeB =  nodes.get(1);
         OnmsNode nodeC =  nodes.get(2);

--- a/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/BridgeProtocol.java
+++ b/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/BridgeProtocol.java
@@ -76,7 +76,6 @@ public class BridgeProtocol extends Protocol<BridgeBridgeLink> {
     @Override
     protected void createAndPersistProtocolSpecificEntities(List<OnmsNode> nodes) {
 
-        context.currentProgress("Version 7"); // TODO: delete later just for testing purpose
 
         // Call with: enlinkd:generate-topology --protocol bridgeBridge --nodes 10 --snmpinterfaces 0 --ipinterfaces 0
         //      here is complete example of bridge topology
@@ -107,10 +106,10 @@ public class BridgeProtocol extends Protocol<BridgeBridgeLink> {
 
         // save bridge element
         this.context.getTopologyPersister().persist(
-                    createBridgeElement(bridge1, vlanid ,"default"),
-                    createBridgeElement(bridge2, vlanid ,"default"),
-                    createBridgeElement(bridge3, vlanid ,"default"),
-                    createBridgeElement(bridge4, vlanid ,"default")                
+                    createBridgeElement(bridge1, vlanid),
+                    createBridgeElement(bridge2, vlanid),
+                    createBridgeElement(bridge3, vlanid),
+                    createBridgeElement(bridge4, vlanid)
                 );
         
         //First persist bridge topology
@@ -310,7 +309,7 @@ public class BridgeProtocol extends Protocol<BridgeBridgeLink> {
     private List<BridgeElement> createBridgeElements(OnmsNode ... nodes) {
         List<BridgeElement> elements = new ArrayList<>();
         for (OnmsNode node: nodes) {
-            elements.add(createBridgeElement(node, 1, "default"));
+            elements.add(createBridgeElement(node, 1));
         }
         return elements;
     }
@@ -319,12 +318,12 @@ public class BridgeProtocol extends Protocol<BridgeBridgeLink> {
         List<BridgeElement> elements = new ArrayList<>();
         for (int i = 0; i < topologySettings.getAmountLinks()/2; i++) {
             OnmsNode node = nodes.get(i);
-            elements.add(createBridgeElement(node,1,"default"));
+            elements.add(createBridgeElement(node,1));
         }
         return elements;
     }
     
-    private BridgeElement createBridgeElement(OnmsNode node, Integer vlanid, String vlanname) {
+    private BridgeElement createBridgeElement(OnmsNode node, Integer vlanid) {
         BridgeElement bridge = new BridgeElement();
         bridge.setNode(node);
         bridge.setBaseBridgeAddress(macGenerator.next().replace(":", ""));
@@ -332,31 +331,9 @@ public class BridgeProtocol extends Protocol<BridgeBridgeLink> {
         bridge.setBridgeNodeLastPollTime(new Date());
         bridge.setBaseNumPorts(topologySettings.getAmountLinks());
         bridge.setVlan(vlanid);
-        bridge.setVlanname(vlanname);
+        bridge.setVlanname("default");
         return bridge;
     }
-    
-    private List<BridgeBridgeLink> createBridgeBridgeLinks(List<OnmsNode> nodes, Integer vlanid) {
-        // Here we shold use a different strategy because we need to generate a tree
-        PairGenerator<OnmsNode> pairs = createPairGenerator(nodes);
-        List<BridgeBridgeLink> links = new ArrayList<>();
-        for (int i = 0; i < topologySettings.getAmountLinks()/2; i++) {
-
-            // We create 2 links that reference each other, see also BridgeTopologyServiceImpl.getAllPersisted()
-            Pair<OnmsNode, OnmsNode> pair = pairs.next();
-            OnmsNode sourceNode = pair.getLeft();
-            OnmsNode targetNode = pair.getRight();
-
-            BridgeBridgeLink sourceLink = createBridgeBridgeLink(sourceNode, targetNode, 1 , 2,1);
-            links.add(sourceLink);
-
-//            BridgeBridgeLink targetLink = createBridgeBridgeLink(targetNode, sourceNode, 2, 1,1);
-//           links.add(targetLink);
-            context.currentProgress(String.format("Linked node %s with node %s", sourceNode.getLabel(), targetNode.getLabel()));
-        }
-        return links;
-    }
-
 
     private BridgeBridgeLink createBridgeBridgeLink(OnmsNode node, OnmsNode designatedNode, int port, int designatedPort, Integer vlanid) {
         BridgeBridgeLink link = new BridgeBridgeLink();

--- a/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/BridgeProtocol.java
+++ b/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/BridgeProtocol.java
@@ -28,6 +28,7 @@
 
 package org.opennms.enlinkd.generator.protocol;
 
+import java.net.InetAddress;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -37,10 +38,14 @@ import org.opennms.enlinkd.generator.TopologyContext;
 import org.opennms.enlinkd.generator.TopologyGenerator;
 import org.opennms.enlinkd.generator.TopologySettings;
 import org.opennms.enlinkd.generator.topology.PairGenerator;
+import org.opennms.enlinkd.generator.util.InetAddressGenerator;
 import org.opennms.enlinkd.generator.util.MacAddressGenerator;
 import org.opennms.netmgt.enlinkd.model.BridgeBridgeLink;
 import org.opennms.netmgt.enlinkd.model.BridgeMacLink;
+import org.opennms.netmgt.enlinkd.model.IpNetToMedia;
+import org.opennms.netmgt.model.OnmsIpInterface;
 import org.opennms.netmgt.model.OnmsNode;
+import org.opennms.netmgt.model.OnmsSnmpInterface;
 
 
 // BroadcastDomain:
@@ -51,9 +56,14 @@ import org.opennms.netmgt.model.OnmsNode;
 // +- BridgePort getFromDesignatedBridgeBridgeLink(link);
 // +- SharedSegment.create(link)
 // +- m_bridgeMacLinkDao.findAll()
+//
+// It seems that you need also to generate ipnettomedia too.
+// In fact a bridgebridgelink is a connection between two bridges and a bridge mac link is a connection with a node.
+// but you also need to let the node binded to the mac address and then you need an ip address for the mac.
 public class BridgeProtocol extends Protocol<BridgeBridgeLink> {
 
     private final MacAddressGenerator macGenerator = new MacAddressGenerator();
+    private final InetAddressGenerator inetGenerator = new InetAddressGenerator();
 
     public BridgeProtocol(TopologySettings topologySettings, TopologyContext context) {
         super(topologySettings, context);
@@ -66,6 +76,39 @@ public class BridgeProtocol extends Protocol<BridgeBridgeLink> {
 
     @Override
     protected void createAndPersistProtocolSpecificEntities(List<OnmsNode> nodes) {
+
+        // Call with: enlinkd:generate-topology --protocol bridgeBridge --nodes 3 --snmpinterfaces 0 -- ipinterfaces 0
+
+//        NodeA is connected to port 24 of NodeB
+//        NodeC is connected to port 23 of NodeB
+//        you have tio generate three nodes nodeA(id=1) nodeB(id=2) nodeC(id=3)
+
+        OnmsNode nodeA =  nodes.get(0);
+        OnmsNode nodeB =  nodes.get(1);
+        OnmsNode nodeC =  nodes.get(2);
+
+        // snmpinterfaces -> nodeB ----port 1,24 ---specified ifindex name ands so on
+        OnmsSnmpInterface snmpInterfaceA = createSnmpInterface(1, nodeA);
+        OnmsSnmpInterface snmpInterfaceB = createSnmpInterface(2, nodeB);
+        OnmsSnmpInterface snmpInterfaceC = createSnmpInterface(3, nodeC);
+        context.getTopologyPersister().persist(snmpInterfaceA, snmpInterfaceB, snmpInterfaceC);
+
+        // ipinterface -> nodeA - 192.168.0.1
+        // ipinterface -> nodeB - 192.168.0.2
+        // ipinterface -> nodeC - 192.168.0.3
+        OnmsIpInterface ipInterfaceA = createIpInterface(snmpInterfaceA, inetGenerator.next());
+        OnmsIpInterface ipInterfaceB = createIpInterface(snmpInterfaceB, inetGenerator.next());
+        OnmsIpInterface ipInterfaceC = createIpInterface(snmpInterfaceC, inetGenerator.next());
+        context.getTopologyPersister().persist(ipInterfaceA, ipInterfaceB, ipInterfaceC);
+
+        // ipnettomedia -> nodeid=1 0123456789a 192.168.0.1
+        // ipnettomedia -> nodeid=1 0123456789b 192.168.0.2
+        // ipnettomedia -> nodeid=3 0123456789c 192.168.0.3
+        IpNetToMedia ipNetToMediaA = createIpNetToMedia(nodeA, "0123456789a", ipInterfaceA.getIpAddress(), nodeB);
+        IpNetToMedia ipNetToMediaB = createIpNetToMedia(nodeA, "0123456789b", ipInterfaceB.getIpAddress(), nodeB);
+        IpNetToMedia ipNetToMediaC = createIpNetToMedia(nodeC, "0123456789c", ipInterfaceC.getIpAddress(), nodeB);
+        context.getTopologyPersister().persist(ipNetToMediaA, ipNetToMediaB, ipNetToMediaC);
+
         List<BridgeBridgeLink> bridgeBridgeLinks = createBridgeBridgeLinks(nodes);
         this.context.getTopologyPersister().persist(bridgeBridgeLinks);
     }
@@ -80,10 +123,10 @@ public class BridgeProtocol extends Protocol<BridgeBridgeLink> {
             OnmsNode sourceNode = pair.getLeft();
             OnmsNode targetNode = pair.getRight();
 
-            BridgeBridgeLink sourceLink = createBridgeBridgeLink(sourceNode, targetNode);
+            BridgeBridgeLink sourceLink = createBridgeBridgeLink(sourceNode, targetNode, 1 , 2);
             links.add(sourceLink);
 
-            BridgeBridgeLink targetLink = createBridgeBridgeLink(targetNode, sourceNode);
+            BridgeBridgeLink targetLink = createBridgeBridgeLink(targetNode, sourceNode, 2, 1);
             links.add(targetLink);
             context.currentProgress(String.format("Linked node %s with node %s", sourceNode.getLabel(), targetNode.getLabel()));
         }
@@ -91,20 +134,20 @@ public class BridgeProtocol extends Protocol<BridgeBridgeLink> {
     }
 
 
-    private BridgeBridgeLink createBridgeBridgeLink(OnmsNode node, OnmsNode designatedNode) {
+    private BridgeBridgeLink createBridgeBridgeLink(OnmsNode node, OnmsNode designatedNode, int port, int designatedPort) {
         BridgeBridgeLink link = new BridgeBridgeLink();
         link.setBridgeBridgeLinkLastPollTime(new Date());
         link.setBridgePortIfIndex(3);
-        link.setBridgePort(4);
-        link.setVlan(1);
+        link.setBridgePort(port);
+        link.setVlan(23);
         link.setBridgePortIfName("xx");
         link.setNode(node);
         link.setBridgeBridgeLinkCreateTime(new Date());
         link.setDesignatedNode(designatedNode);
-        link.setDesignatedPort(5);
-        link.setDesignatedPortIfIndex(6);
+        link.setDesignatedPort(designatedPort);
+        link.setDesignatedPortIfIndex(3);
         link.setDesignatedVlan(23);
-        link.setDesignatedPortIfName("yy");
+        link.setDesignatedPortIfName("xx");
         return link;
     }
 
@@ -119,5 +162,20 @@ public class BridgeProtocol extends Protocol<BridgeBridgeLink> {
         bridgeMacLink.setLinkType(BridgeMacLink.BridgeMacLinkType.BRIDGE_LINK);
         bridgeMacLink.setMacAddress(macGenerator.next());
         return bridgeMacLink;
+    }
+
+    private IpNetToMedia createIpNetToMedia(OnmsNode node, String port, InetAddress inetAddress, OnmsNode sourceNode){
+        IpNetToMedia ipNetToMedia = new IpNetToMedia();
+        ipNetToMedia.setCreateTime(new Date());
+        ipNetToMedia.setIfIndex(0);
+        ipNetToMedia.setLastPollTime(new Date());
+        ipNetToMedia.setIpNetToMediaType(IpNetToMedia.IpNetToMediaType.IPNETTOMEDIA_TYPE_STATIC);
+        ipNetToMedia.setNetAddress(inetAddress);
+        ipNetToMedia.setPhysAddress("physAddress");
+        ipNetToMedia.setNode(node);
+        ipNetToMedia.setPort(port);
+        ipNetToMedia.setSourceIfIndex(0);
+        ipNetToMedia.setSourceNode(sourceNode);
+        return ipNetToMedia;
     }
 }

--- a/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/BridgeProtocol.java
+++ b/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/BridgeProtocol.java
@@ -1,0 +1,123 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.enlinkd.generator.protocol;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.opennms.enlinkd.generator.TopologyContext;
+import org.opennms.enlinkd.generator.TopologyGenerator;
+import org.opennms.enlinkd.generator.TopologySettings;
+import org.opennms.enlinkd.generator.topology.PairGenerator;
+import org.opennms.enlinkd.generator.util.MacAddressGenerator;
+import org.opennms.netmgt.enlinkd.model.BridgeBridgeLink;
+import org.opennms.netmgt.enlinkd.model.BridgeMacLink;
+import org.opennms.netmgt.model.OnmsNode;
+
+
+// BroadcastDomain:
+// BridgeTopologyServiceImpl.findAll()
+// + BridgeTopologyServiceImpl.getAllPersisted()
+// +- BridgeBridgeLinkDao.findAll()
+// +- BridgePort bridgeport = BridgePort.getFromBridgeBridgeLink(link);
+// +- BridgePort getFromDesignatedBridgeBridgeLink(link);
+// +- SharedSegment.create(link)
+// +- m_bridgeMacLinkDao.findAll()
+public class BridgeProtocol extends Protocol<BridgeBridgeLink> {
+
+    private final MacAddressGenerator macGenerator = new MacAddressGenerator();
+
+    public BridgeProtocol(TopologySettings topologySettings, TopologyContext context) {
+        super(topologySettings, context);
+    }
+
+    @Override
+    protected TopologyGenerator.Protocol getProtocol() {
+        return TopologyGenerator.Protocol.bridgeBridge;
+    }
+
+    @Override
+    protected void createAndPersistProtocolSpecificEntities(List<OnmsNode> nodes) {
+        List<BridgeBridgeLink> bridgeBridgeLinks = createBridgeBridgeLinks(nodes);
+        this.context.getTopologyPersister().persist(bridgeBridgeLinks);
+    }
+
+    private List<BridgeBridgeLink> createBridgeBridgeLinks(List<OnmsNode> nodes) {
+        PairGenerator<OnmsNode> pairs = createPairGenerator(nodes);
+        List<BridgeBridgeLink> links = new ArrayList<>();
+        for (int i = 0; i < topologySettings.getAmountLinks()/2; i++) {
+
+            // We create 2 links that reference each other, see also BridgeTopologyServiceImpl.getAllPersisted()
+            Pair<OnmsNode, OnmsNode> pair = pairs.next();
+            OnmsNode sourceNode = pair.getLeft();
+            OnmsNode targetNode = pair.getRight();
+
+            BridgeBridgeLink sourceLink = createBridgeBridgeLink(sourceNode, targetNode);
+            links.add(sourceLink);
+
+            BridgeBridgeLink targetLink = createBridgeBridgeLink(targetNode, sourceNode);
+            links.add(targetLink);
+            context.currentProgress(String.format("Linked node %s with node %s", sourceNode.getLabel(), targetNode.getLabel()));
+        }
+        return links;
+    }
+
+
+    private BridgeBridgeLink createBridgeBridgeLink(OnmsNode node, OnmsNode designatedNode) {
+        BridgeBridgeLink link = new BridgeBridgeLink();
+        link.setBridgeBridgeLinkLastPollTime(new Date());
+        link.setBridgePortIfIndex(3);
+        link.setBridgePort(4);
+        link.setVlan(1);
+        link.setBridgePortIfName("xx");
+        link.setNode(node);
+        link.setBridgeBridgeLinkCreateTime(new Date());
+        link.setDesignatedNode(designatedNode);
+        link.setDesignatedPort(5);
+        link.setDesignatedPortIfIndex(6);
+        link.setDesignatedVlan(23);
+        link.setDesignatedPortIfName("yy");
+        return link;
+    }
+
+    private BridgeMacLink createBridgeMacLink(){
+        BridgeMacLink bridgeMacLink = new BridgeMacLink();
+        bridgeMacLink.setBridgeMacLinkCreateTime(new Date());
+        bridgeMacLink.setBridgeMacLinkLastPollTime(new Date());
+        bridgeMacLink.setBridgePort(1);
+        bridgeMacLink.setBridgePortIfIndex(2);
+        bridgeMacLink.setBridgePortIfName("bridgePortIfName");
+        bridgeMacLink.setId(6);
+        bridgeMacLink.setLinkType(BridgeMacLink.BridgeMacLinkType.BRIDGE_LINK);
+        bridgeMacLink.setMacAddress(macGenerator.next());
+        return bridgeMacLink;
+    }
+}

--- a/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/BridgeProtocol.java
+++ b/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/BridgeProtocol.java
@@ -78,63 +78,150 @@ public class BridgeProtocol extends Protocol<BridgeBridgeLink> {
 
         context.currentProgress("Version 1"); // TODO: delete later just for testing purpose
 
-        // Call with: enlinkd:generate-topology --protocol bridgeBridge --nodes 3 --snmpinterfaces 0 -- ipinterfaces 0
-
-       // NodeA port 4 is connected to port 24 of NodeB
-       // NodeC port 3 is connected to port 23 of NodeB
-       // you have to generate three nodes nodeA(id=1) nodeB(id=2) nodeC(id=3)
+        // Call with: enlinkd:generate-topology --protocol bridgeBridge --nodes 10 --snmpinterfaces 0 -- ipinterfaces 1
+        //      here is complete example of bridge topology
+       // 4 nodes are bridges: nodeBridgeA, nodeBridgeB, nodeBridgeC, nodeBridgeD
+       //              B
+       //           --------  
+       //           |      |
+       //           A      C
+       //         -----
+       //           |
+       //           D 
+       // 6 nodes are hosts: nodeHostE, nodeHostF, nodeHostG, nodeHostH, nodeHostI, nodeHostL 
+       // generate 4 ipnettomedia without a corresponding node  
+       // consider also that on port 1 of C is connected an HUB with a group of hosts connected
+       // the hub has no snmp agent and therefore we are not to explore his mab forwarding table 
         
-        OnmsNode nodeA =  nodes.get(0);
-        OnmsNode nodeB =  nodes.get(1);
-        OnmsNode nodeC =  nodes.get(2);
+        OnmsNode nodeBridgeA =  nodes.get(0);
+        OnmsNode nodeBridgeB =  nodes.get(1);
+        OnmsNode nodeBridgeC =  nodes.get(2);
+        OnmsNode nodeBridgeD =  nodes.get(3);
 
-        // snmpinterfaces -> nodeB ----port 1,24 ---specified ifindex name ands so on
-        OnmsSnmpInterface snmpInterfaceA4 = createSnmpInterface(4, nodeA);
-        OnmsSnmpInterface snmpInterfaceB24 = createSnmpInterface(24, nodeB);
-        OnmsSnmpInterface snmpInterfaceB23 = createSnmpInterface(23, nodeB);
-        OnmsSnmpInterface snmpInterfaceC3 = createSnmpInterface(3, nodeC);
-        context.getTopologyPersister().persist(snmpInterfaceA4, snmpInterfaceB24,snmpInterfaceB23, snmpInterfaceC3);
+        // create bridge element
+        BridgeElement bridgeA = createBridgeElement(nodeBridgeA, 1 ,"default");
+        BridgeElement bridgeB = createBridgeElement(nodeBridgeB, 1 ,"default");
+        BridgeElement bridgeC = createBridgeElement(nodeBridgeC, 1 ,"default");
+        BridgeElement bridgeD = createBridgeElement(nodeBridgeD, 1 ,"default");
 
-        // in bridge only topology ip addresses are not needed
-        // ipinterface -> nodeA - 192.168.0.1
-        // ipinterface -> nodeB - 192.168.0.2
-        // ipinterface -> nodeC - 192.168.0.3
-        //OnmsIpInterface ipInterfaceA = createIpInterface(snmpInterfaceA, inetGenerator.next());
-        //OnmsIpInterface ipInterfaceB = createIpInterface(snmpInterfaceB, inetGenerator.next());
-        //OnmsIpInterface ipInterfaceC = createIpInterface(snmpInterfaceC, inetGenerator.next());
-        //context.getTopologyPersister().persist(ipInterfaceA, ipInterfaceB, ipInterfaceC);
-
-        //In Bridge only Topology no need for mac address here
-        // ipnettomedia -> nodeid=1 0123456789a 192.168.0.1
-        // ipnettomedia -> nodeid=1 0123456789b 192.168.0.2
-        // ipnettomedia -> nodeid=3 0123456789c 192.168.0.3
-        //IpNetToMedia ipNetToMediaA = createIpNetToMedia(nodeA, "0123456789a", ipInterfaceA.getIpAddress(), nodeB);
-        //IpNetToMedia ipNetToMediaB = createIpNetToMedia(nodeA, "0123456789b", ipInterfaceB.getIpAddress(), nodeB);
-        //IpNetToMedia ipNetToMediaC = createIpNetToMedia(nodeC, "0123456789c", ipInterfaceC.getIpAddress(), nodeB);
-        //context.getTopologyPersister().persist(ipNetToMediaA, ipNetToMediaB, ipNetToMediaC);
+        this.context.getTopologyPersister().persist(bridgeA,bridgeB,bridgeC,bridgeD);
         
-        BridgeElement bridgeA = createBridgeElement(nodeA);
-        BridgeElement bridgeB = createBridgeElement(nodeB);
-        BridgeElement bridgeC = createBridgeElement(nodeC);
+        //First persist bridge topology
+        // nodeBridgeB:port24 connected to nodeBridgeA port4
+        // save snmpinterface and bridgebridgelink
+        context.getTopologyPersister().persist(createSnmpInterface(4, nodeBridgeA), 
+                                               createSnmpInterface(24, nodeBridgeB));
+        context.getTopologyPersister().persist(createBridgeBridgeLink(nodeBridgeA, nodeBridgeB, 4, 24,1));
 
-        this.context.getTopologyPersister().persist(bridgeA,bridgeB,bridgeC);
-        
-        // linkBA nodeA port 4 connected to nodeB port 24
-        BridgeBridgeLink linkBA = createBridgeBridgeLink(nodeA, nodeB, 4, 24);
-        // linkBA nodeA port 3 connected to nodeB port 23
-        BridgeBridgeLink linkBC = createBridgeBridgeLink(nodeC, nodeB, 4, 23);
-        
-        
-        this.context.getTopologyPersister().persist(linkBA,linkBC);
+        // nodeBridgeB:port23 connected to nodeBridgeC port3
+        // save snmpinterface and bridgebridgelink
+        context.getTopologyPersister().persist(createSnmpInterface(23, nodeBridgeB), createSnmpInterface(3, nodeBridgeC));
+        context.getTopologyPersister().persist(createBridgeBridgeLink(nodeBridgeC, nodeBridgeB, 3, 23,1));
 
-        //        List<BridgeBridgeLink> bridgeBridgeLinks = createBridgeBridgeLinks(nodes);
-//        this.context.getTopologyPersister().persist(bridgeBridgeLinks);
+        // nodeBridgeD:port1 connected to nodeBridgeA port11
+        // save snmpinterface and bridgebridgelink
+        context.getTopologyPersister().persist(createSnmpInterface(1, nodeBridgeD), createSnmpInterface(11, nodeBridgeA));
+        context.getTopologyPersister().persist(createBridgeBridgeLink(nodeBridgeD, nodeBridgeA, 1, 11,1));
+        
+        //generate host topology
+        // here ip addresses are needed
+
+        // nodeHostE port 1 is connected on port 5 of nodeBridgeA
+        // ipinterface -> nodeHostE - 192.168.0.11
+        OnmsNode nodeHostE =  nodes.get(4);
+        String macE=macGenerator.next();
+        OnmsSnmpInterface snmpInterfaceE = createSnmpInterface(1, nodeHostE);
+        context.getTopologyPersister().persist(createSnmpInterface(5, nodeBridgeA),snmpInterfaceE);
+        OnmsIpInterface ipInterfaceE = createIpInterface(snmpInterfaceE, inetGenerator.next());
+        context.getTopologyPersister().persist(ipInterfaceE);
+        context.getTopologyPersister().persist(
+           createIpNetToMedia(nodeHostE, snmpInterfaceE.getIfIndex(), snmpInterfaceE.getIfName(),macE, ipInterfaceE.getIpAddress(), nodeBridgeA)
+                );
+        context.getTopologyPersister().persist(createBridgeMacLink(nodeBridgeA, 5, 1, macE));
+        
+        // nodeHostF port 1 is connected on port 5 of nodeBridgeA
+        // ipinterface -> nodeHostF - 192.168.0.12
+        OnmsNode nodeHostF =  nodes.get(5);
+        String macF=macGenerator.next();
+        OnmsSnmpInterface snmpInterfaceF = createSnmpInterface(1, nodeHostF);
+        context.getTopologyPersister().persist(createSnmpInterface(5, nodeBridgeA),snmpInterfaceF);
+        OnmsIpInterface ipInterfaceF = createIpInterface(snmpInterfaceF, inetGenerator.next());
+        context.getTopologyPersister().persist(ipInterfaceF);
+        context.getTopologyPersister().persist(
+           createIpNetToMedia(nodeHostF, snmpInterfaceF.getIfIndex(), snmpInterfaceF.getIfName(),macF, ipInterfaceF.getIpAddress(), nodeBridgeA)
+                );
+        context.getTopologyPersister().persist(createBridgeMacLink(nodeBridgeA, 5, 1, macF));
+        
+
+        // nodeHostG port 10 is connected on port 10 of nodeBridgeC
+        // ipinterface -> nodeHostF - 192.168.0.13
+        OnmsNode nodeHostG =  nodes.get(6);
+        String macG=macGenerator.next();
+        OnmsSnmpInterface snmpInterfaceG = createSnmpInterface(10, nodeHostG);
+        context.getTopologyPersister().persist(createSnmpInterface(10, nodeBridgeC),snmpInterfaceG);
+        OnmsIpInterface ipInterfaceG = createIpInterface(snmpInterfaceG, inetGenerator.next());
+        context.getTopologyPersister().persist(ipInterfaceG);
+        context.getTopologyPersister().persist(
+           createIpNetToMedia(nodeHostG, snmpInterfaceG.getIfIndex(), snmpInterfaceG.getIfName(),macG, ipInterfaceG.getIpAddress(), nodeBridgeA)
+                );
+        context.getTopologyPersister().persist(createBridgeMacLink(nodeBridgeC, 10, 1, macG));
+
+        // nodeHostH port 11 is connected on port 11 of nodeBridgeD
+        // ipinterface -> nodeHostH - 192.168.0.14
+        OnmsNode nodeHostH =  nodes.get(7);
+        String macH=macGenerator.next();
+        OnmsSnmpInterface snmpInterfaceH = createSnmpInterface(11, nodeHostH);
+        context.getTopologyPersister().persist(createSnmpInterface(11, nodeBridgeD),snmpInterfaceH);
+        OnmsIpInterface ipInterfaceH = createIpInterface(snmpInterfaceH, inetGenerator.next());
+        context.getTopologyPersister().persist(ipInterfaceH);
+        context.getTopologyPersister().persist(
+           createIpNetToMedia(nodeHostH, snmpInterfaceH.getIfIndex(), snmpInterfaceH.getIfName(),macH, ipInterfaceH.getIpAddress(), nodeBridgeA)
+                );
+        context.getTopologyPersister().persist(createBridgeMacLink(nodeBridgeD, 11, 1, macH));
+ 
+        // nodeHostI  is connected on port 12 of nodeBridgeD
+        // ipinterface -> nodeHostI - 192.168.0.15
+        OnmsNode nodeHostI =  nodes.get(8);
+        String macI=macGenerator.next();
+        context.getTopologyPersister().persist(createSnmpInterface(12, nodeBridgeD));
+        OnmsIpInterface ipInterfaceI = createIpInterface(null, inetGenerator.next());
+        context.getTopologyPersister().persist(ipInterfaceI);
+        context.getTopologyPersister().persist(
+           createIpNetToMedia(nodeHostI, null, null,macI, ipInterfaceI.getIpAddress(), nodeBridgeA)
+                );
+        context.getTopologyPersister().persist(createBridgeMacLink(nodeBridgeD, 12, 1, macI));
+
+        // nodeHostL  is connected on port 13 of nodeBridgeD
+        // ipinterface -> nodeHostI - 192.168.0.16
+        OnmsNode nodeHostL =  nodes.get(8);
+        String macL=macGenerator.next();
+        context.getTopologyPersister().persist(createSnmpInterface(13, nodeBridgeD));
+        OnmsIpInterface ipInterfaceL = createIpInterface(null, inetGenerator.next());
+        context.getTopologyPersister().persist(ipInterfaceL);
+        context.getTopologyPersister().persist(
+           createIpNetToMedia(nodeHostL, null, null,macL, ipInterfaceL.getIpAddress(), nodeBridgeA)
+                );
+        context.getTopologyPersister().persist(createBridgeMacLink(nodeBridgeD, 13, 1, macL));
+
+        // adding some mac addresses and ip on a cloud on port 23 bridge B ---
+        for (int i=0; i<5;i++) {
+            String nextMac = macGenerator.next();
+            context.getTopologyPersister().persist(
+                   createIpNetToMedia(null, null, null,nextMac, inetGenerator.next(), nodeBridgeA)
+                    );
+            context.getTopologyPersister().persist(createBridgeMacLink(nodeBridgeB, 23, 1, nextMac));
+        }
+        
+        // you can also have mac addresses without an ip address associated
+        for (int i=0; i<10;i++) {
+            context.getTopologyPersister().persist(createBridgeMacLink(nodeBridgeB, 23, 1, macGenerator.next()));
+        }
     }
 
     private List<BridgeElement> createBridgeElements(OnmsNode ... nodes) {
         List<BridgeElement> elements = new ArrayList<>();
         for (OnmsNode node: nodes) {
-            elements.add(createBridgeElement(node));
+            elements.add(createBridgeElement(node, 1, "default"));
         }
         return elements;
     }
@@ -143,24 +230,24 @@ public class BridgeProtocol extends Protocol<BridgeBridgeLink> {
         List<BridgeElement> elements = new ArrayList<>();
         for (int i = 0; i < topologySettings.getAmountLinks()/2; i++) {
             OnmsNode node = nodes.get(i);
-            elements.add(createBridgeElement(node));
+            elements.add(createBridgeElement(node,1,"default"));
         }
         return elements;
     }
     
-    private BridgeElement createBridgeElement(OnmsNode node) {
+    private BridgeElement createBridgeElement(OnmsNode node, Integer vlanid, String vlanname) {
         BridgeElement bridge = new BridgeElement();
         bridge.setNode(node);
         bridge.setBaseBridgeAddress(macGenerator.next());
         bridge.setBaseType(BridgeDot1dBaseType.DOT1DBASETYPE_TRANSPARENT_ONLY);
         bridge.setBridgeNodeLastPollTime(new Date());
         bridge.setBaseNumPorts(topologySettings.getAmountLinks());
-        bridge.setVlan(1);
-        bridge.setVlanname("default");
+        bridge.setVlan(vlanid);
+        bridge.setVlanname(vlanname);
         return bridge;
     }
     
-    private List<BridgeBridgeLink> createBridgeBridgeLinks(List<OnmsNode> nodes) {
+    private List<BridgeBridgeLink> createBridgeBridgeLinks(List<OnmsNode> nodes, Integer vlanid) {
         // Here we shold use a different strategy because we need to generate a tree
         PairGenerator<OnmsNode> pairs = createPairGenerator(nodes);
         List<BridgeBridgeLink> links = new ArrayList<>();
@@ -171,55 +258,51 @@ public class BridgeProtocol extends Protocol<BridgeBridgeLink> {
             OnmsNode sourceNode = pair.getLeft();
             OnmsNode targetNode = pair.getRight();
 
-            BridgeBridgeLink sourceLink = createBridgeBridgeLink(sourceNode, targetNode, 1 , 2);
+            BridgeBridgeLink sourceLink = createBridgeBridgeLink(sourceNode, targetNode, 1 , 2,1);
             links.add(sourceLink);
 
-            BridgeBridgeLink targetLink = createBridgeBridgeLink(targetNode, sourceNode, 2, 1);
-            links.add(targetLink);
+//            BridgeBridgeLink targetLink = createBridgeBridgeLink(targetNode, sourceNode, 2, 1,1);
+//           links.add(targetLink);
             context.currentProgress(String.format("Linked node %s with node %s", sourceNode.getLabel(), targetNode.getLabel()));
         }
         return links;
     }
 
 
-    private BridgeBridgeLink createBridgeBridgeLink(OnmsNode node, OnmsNode designatedNode, int port, int designatedPort) {
+    private BridgeBridgeLink createBridgeBridgeLink(OnmsNode node, OnmsNode designatedNode, int port, int designatedPort, Integer vlanid) {
         BridgeBridgeLink link = new BridgeBridgeLink();
-        link.setBridgeBridgeLinkLastPollTime(new Date());
         link.setBridgePortIfIndex(port);
         link.setBridgePort(port);
         link.setVlan(1);
-        link.setBridgePortIfName("xx");
         link.setNode(node);
-        link.setBridgeBridgeLinkCreateTime(new Date());
         link.setDesignatedNode(designatedNode);
         link.setDesignatedPort(designatedPort);
         link.setDesignatedPortIfIndex(designatedPort);
-        link.setDesignatedVlan(1);
-        link.setDesignatedPortIfName("xx");
+        link.setDesignatedVlan(vlanid);
+        link.setBridgeBridgeLinkLastPollTime(new Date());
         return link;
     }
 
-    private BridgeMacLink createBridgeMacLink(){
+    private BridgeMacLink createBridgeMacLink(OnmsNode bridge, Integer bridgePort, Integer vlan, String mac){
         BridgeMacLink bridgeMacLink = new BridgeMacLink();
-        bridgeMacLink.setBridgeMacLinkCreateTime(new Date());
-        bridgeMacLink.setBridgeMacLinkLastPollTime(new Date());
-        bridgeMacLink.setBridgePort(1);
-        bridgeMacLink.setBridgePortIfIndex(2);
-        bridgeMacLink.setBridgePortIfName("bridgePortIfName");
-        bridgeMacLink.setId(6);
+        bridgeMacLink.setNode(bridge);
+        bridgeMacLink.setBridgePort(bridgePort);
+        bridgeMacLink.setBridgePortIfIndex(bridgePort);
         bridgeMacLink.setLinkType(BridgeMacLink.BridgeMacLinkType.BRIDGE_LINK);
-        bridgeMacLink.setMacAddress(macGenerator.next());
+        bridgeMacLink.setMacAddress(mac);
+        bridgeMacLink.setVlan(vlan);
+        bridgeMacLink.setBridgeMacLinkLastPollTime(new Date());
         return bridgeMacLink;
     }
 
-    private IpNetToMedia createIpNetToMedia(OnmsNode node, String port, InetAddress inetAddress, OnmsNode sourceNode){
+    private IpNetToMedia createIpNetToMedia(OnmsNode node, Integer ifindex, String port, String mac, InetAddress inetAddress, OnmsNode sourceNode){
         IpNetToMedia ipNetToMedia = new IpNetToMedia();
         ipNetToMedia.setCreateTime(new Date());
-        ipNetToMedia.setIfIndex(0);
+        ipNetToMedia.setIfIndex(ifindex);
         ipNetToMedia.setLastPollTime(new Date());
-        ipNetToMedia.setIpNetToMediaType(IpNetToMedia.IpNetToMediaType.IPNETTOMEDIA_TYPE_STATIC);
+        ipNetToMedia.setIpNetToMediaType(IpNetToMedia.IpNetToMediaType.IPNETTOMEDIA_TYPE_DYNAMIC);
         ipNetToMedia.setNetAddress(inetAddress);
-        ipNetToMedia.setPhysAddress("physAddress");
+        ipNetToMedia.setPhysAddress(mac);
         ipNetToMedia.setNode(node);
         ipNetToMedia.setPort(port);
         ipNetToMedia.setSourceIfIndex(0);

--- a/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/BridgeProtocol.java
+++ b/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/BridgeProtocol.java
@@ -76,9 +76,9 @@ public class BridgeProtocol extends Protocol<BridgeBridgeLink> {
     @Override
     protected void createAndPersistProtocolSpecificEntities(List<OnmsNode> nodes) {
 
-        context.currentProgress("Version 1"); // TODO: delete later just for testing purpose
+        context.currentProgress("Version 7"); // TODO: delete later just for testing purpose
 
-        // Call with: enlinkd:generate-topology --protocol bridgeBridge --nodes 10 --snmpinterfaces 0 -- ipinterfaces 1
+        // Call with: enlinkd:generate-topology --protocol bridgeBridge --nodes 10 --snmpinterfaces 0 --ipinterfaces 0
         //      here is complete example of bridge topology
        // 4 nodes are bridges: nodeBridgeA, nodeBridgeB, nodeBridgeC, nodeBridgeD
        //              B
@@ -144,7 +144,7 @@ public class BridgeProtocol extends Protocol<BridgeBridgeLink> {
         OnmsNode nodeHostF =  nodes.get(5);
         String macF=macGenerator.next();
         OnmsSnmpInterface snmpInterfaceF = createSnmpInterface(1, nodeHostF);
-        context.getTopologyPersister().persist(createSnmpInterface(5, nodeBridgeA),snmpInterfaceF);
+        context.getTopologyPersister().persist(createSnmpInterface(6, nodeBridgeA),snmpInterfaceF);
         OnmsIpInterface ipInterfaceF = createIpInterface(snmpInterfaceF, inetGenerator.next());
         context.getTopologyPersister().persist(ipInterfaceF);
         context.getTopologyPersister().persist(
@@ -185,6 +185,7 @@ public class BridgeProtocol extends Protocol<BridgeBridgeLink> {
         String macI=macGenerator.next();
         context.getTopologyPersister().persist(createSnmpInterface(12, nodeBridgeD));
         OnmsIpInterface ipInterfaceI = createIpInterface(null, inetGenerator.next());
+        ipInterfaceI.setNode(nodeHostI);
         context.getTopologyPersister().persist(ipInterfaceI);
         context.getTopologyPersister().persist(
            createIpNetToMedia(nodeHostI, null, null,macI, ipInterfaceI.getIpAddress(), nodeBridgeA)
@@ -193,10 +194,11 @@ public class BridgeProtocol extends Protocol<BridgeBridgeLink> {
 
         // nodeHostL  is connected on port 13 of nodeBridgeD
         // ipinterface -> nodeHostI - 192.168.0.16
-        OnmsNode nodeHostL =  nodes.get(8);
+        OnmsNode nodeHostL =  nodes.get(9);
         String macL=macGenerator.next();
         context.getTopologyPersister().persist(createSnmpInterface(13, nodeBridgeD));
         OnmsIpInterface ipInterfaceL = createIpInterface(null, inetGenerator.next());
+        ipInterfaceL.setNode(nodeHostL);
         context.getTopologyPersister().persist(ipInterfaceL);
         context.getTopologyPersister().persist(
            createIpNetToMedia(nodeHostL, null, null,macL, ipInterfaceL.getIpAddress(), nodeBridgeA)
@@ -238,7 +240,7 @@ public class BridgeProtocol extends Protocol<BridgeBridgeLink> {
     private BridgeElement createBridgeElement(OnmsNode node, Integer vlanid, String vlanname) {
         BridgeElement bridge = new BridgeElement();
         bridge.setNode(node);
-        bridge.setBaseBridgeAddress(macGenerator.next());
+        bridge.setBaseBridgeAddress(macGenerator.next().replace(":", ""));
         bridge.setBaseType(BridgeDot1dBaseType.DOT1DBASETYPE_TRANSPARENT_ONLY);
         bridge.setBridgeNodeLastPollTime(new Date());
         bridge.setBaseNumPorts(topologySettings.getAmountLinks());

--- a/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/BridgeProtocol.java
+++ b/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/BridgeProtocol.java
@@ -69,30 +69,46 @@ public class BridgeProtocol extends Protocol<BridgeBridgeLink> {
     protected TopologyGenerator.Protocol getProtocol() {
         return TopologyGenerator.Protocol.bridgeBridge;
     }
-    
+
     private void persistBBLink(OnmsNode bridge, Integer port, OnmsNode designated, Integer designatedPort, Integer vlanid) {
+        persistBBLink(bridge, port, true, designated, designatedPort, true, vlanid);
+    }
+
+    private void persistBBLink(OnmsNode bridge, Integer port, boolean createSnmpInterface, OnmsNode designated, Integer designatedPort, boolean createdesignatedsnmpInterface, Integer vlanid) {
+        if (createSnmpInterface) {
         context.getTopologyPersister().persist(
-                       createSnmpInterface(port, bridge), 
+                       createSnmpInterface(port, bridge)
+                   );
+        }
+        if (createdesignatedsnmpInterface) {
+        context.getTopologyPersister().persist(
                        createSnmpInterface(designatedPort, designated)
                    );
+        }
         context.getTopologyPersister().persist(
            createBridgeBridgeLink(bridge, designated, port, designatedPort,vlanid)
         );
     }
-    
     private void persistBMLink(OnmsNode bridge, Integer port, Integer vlanid, OnmsNode host, Integer hostPort, OnmsNode gateway) {
+        persistBMLink(bridge, port, true, vlanid, host, hostPort, gateway);
+    }
+    
+    private void persistBMLink(OnmsNode bridge, Integer port, boolean createsnmpinterface, Integer vlanid, OnmsNode host, Integer hostPort, OnmsNode gateway) {
         String mac=macGenerator.next();
         InetAddress ip= inetGenerator.next();
+        if (createsnmpinterface) {
+            context.getTopologyPersister().persist(
+               createSnmpInterface(port, bridge)
+           );
+        }
         if (hostPort != null) {
             OnmsSnmpInterface snmpInterface = createSnmpInterface(hostPort, host);
             context.getTopologyPersister().persist(
-                   createSnmpInterface(port, bridge),
                    snmpInterface
                );
             OnmsIpInterface ipInterface = createIpInterface(snmpInterface, ip);
             context.getTopologyPersister().persist(ipInterface);
         } else {
-            context.getTopologyPersister().persist(createSnmpInterface(port, bridge));
             OnmsIpInterface ipInterface = createIpInterface(null,ip);
             ipInterface.setNode(host);
             context.getTopologyPersister().persist(ipInterface);
@@ -198,8 +214,8 @@ public class BridgeProtocol extends Protocol<BridgeBridgeLink> {
         //bridge2
         // host6 and host 7 connected to port 22 
         bridge2portCounter++;
-        persistBMLink(bridge2, bridge2portCounter, vlanid, host6, host6portCounter, bridge0);
-        persistBMLink(bridge2, bridge2portCounter, vlanid, host7, host7portCounter, bridge0);
+        persistBMLink(bridge2, bridge2portCounter, true,  vlanid, host6, host6portCounter, bridge0);
+        persistBMLink(bridge2, bridge2portCounter, false, vlanid, host7, host7portCounter, bridge0);
         
         // bridge3
         // host8:with-no-snmp connected bridge3:port32

--- a/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/BridgeProtocol.java
+++ b/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/BridgeProtocol.java
@@ -167,8 +167,8 @@ public class BridgeProtocol extends Protocol<BridgeBridgeLink> {
         OnmsNode bridge2 =  nodes.get(2);
         OnmsNode bridge3 =  nodes.get(3);
         OnmsNode host4   =  nodes.get(4);
-        OnmsNode host5   =  nodes.get(4);
-        OnmsNode host6   =  nodes.get(5);
+        OnmsNode host5   =  nodes.get(5);
+        OnmsNode host6   =  nodes.get(6);
         OnmsNode host7   =  nodes.get(7);
         OnmsNode host8   =  nodes.get(8);
         OnmsNode host9   =  nodes.get(9);

--- a/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/BridgeProtocol.java
+++ b/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/BridgeProtocol.java
@@ -216,7 +216,7 @@ public class BridgeProtocol extends Protocol<BridgeBridgeLink> {
         context.getTopologyPersister().persist(
                    createBridgeMacLink(bridge3, bridge3portCounter, vlanid, mac7)
                );
-        bridge1portCounter++;
+        bridge3portCounter++;
         host7portCounter++;
 
         // host8:port81 connected bridge4:port42

--- a/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/BridgeProtocol.java
+++ b/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/BridgeProtocol.java
@@ -50,7 +50,7 @@ import org.opennms.netmgt.model.OnmsNode;
  *           |      |          |        |       |
  *        bridge1  bridge3  bridge4  bridge5  Macs/Ip
  *           |          |               |     no node
- *        -------    --------          ...
+ *        -------    --------     ...subtree...
  *        |          |      |
  *     Segment     host8    host9
  *   -----------

--- a/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/BridgeProtocol.java
+++ b/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/BridgeProtocol.java
@@ -35,6 +35,8 @@ import java.util.List;
 import org.opennms.enlinkd.generator.TopologyContext;
 import org.opennms.enlinkd.generator.TopologyGenerator;
 import org.opennms.enlinkd.generator.TopologySettings;
+import org.opennms.enlinkd.generator.protocol.bridge.BridgeBuilder;
+import org.opennms.enlinkd.generator.protocol.bridge.BridgeBuilderContext;
 import org.opennms.enlinkd.generator.util.IdGenerator;
 import org.opennms.enlinkd.generator.util.InetAddressGenerator;
 import org.opennms.enlinkd.generator.util.MacAddressGenerator;
@@ -115,36 +117,59 @@ public class BridgeProtocol extends Protocol<BridgeBridgeLink> {
         int host5portCounter = 51;
         int host6portCounter = 61;
         int host7portCounter = 71;
-        
+
+        BridgeBuilderContext context = new BridgeBuilderContext(this.context.getTopologyPersister(), this.macGenerator, this.inetGenerator);
+        BridgeBuilder bridge0B = new BridgeBuilder(bridge0, bridge0portCounter - 1, context);
+
+
         // save bridge element
         this.context.getTopologyPersister().persist(
             createBridgeElement(bridge0),
+                // instead of:
             createBridgeElement(bridge1),
             createBridgeElement(bridge2),
-            createBridgeElement(bridge3)
+                // instead of:
+                createBridgeElement(bridge3)
         );
         
         //bridge0
         //bridge0:port1 connected to up bridge1:port11
-        createAndPersistBridgeBridgeLink(bridge0, bridge0portCounter, bridge1, bridge1portCounter);
+        BridgeBuilder bridge1B = bridge0B.connectToNewBridge(bridge1, bridge1portCounter);
+        // instead of:
+        // createAndPersistBridgeBridgeLink(bridge1, bridge1portCounter, bridge0, bridge0portCounter);
+
         //bridge3:port31 connected to up bridge0:port2
+        bridge0B.connectToNewBridge(bridge3, bridge3portCounter);
         bridge0portCounter++;
-        createAndPersistBridgeBridgeLink(bridge3, bridge3portCounter, bridge0, bridge0portCounter);
+        // instead of:
+        // createAndPersistBridgeBridgeLink(bridge3, bridge3portCounter, bridge0, bridge0portCounter);
+
         //bridge0:port3 connected to cloud
         bridge0portCounter++;
+        // bridge0B.createAndPersistCloud(2, 2);
+        // instead off:
         createAndPersistCloud(bridge0, bridge0portCounter, 2, 2);
+
         // bridge0:port4 connected to host4:port41
         bridge0portCounter++;
+        // bridge0B.createAndPersistBridgeMacLink(host4, host4portCounter);
+        // instead of:
         createAndPersistBridgeMacLink(bridge0, bridge0portCounter, host4, host4portCounter, bridge0);
+
         // bridge0:port5 connected to host5:port51
         bridge0portCounter++;
+        // bridge0B.createAndPersistBridgeMacLink(host5, host5portCounter);
+        // instead of:
         createAndPersistBridgeMacLink(bridge0, bridge0portCounter, host5, host5portCounter, bridge0);
 
         //bridge1
         //bridge2:port21 connected to bridge1:port12 with clouds
         bridge1portCounter++;
-        createAndPersistBridgeBridgeLink(bridge2, bridge2portCounter, bridge1, bridge1portCounter);
-        createAndPersistCloud(bridge1, bridge1portCounter, 2, 2);
+        bridge1B.connectToNewBridge(bridge2, bridge2portCounter);
+// instead of
+  // createAndPersistBridgeBridgeLink(bridge2, bridge2portCounter, bridge1, bridge1portCounter);
+//         bridge1B.createAndPersistCloud(2, 2);
+         createAndPersistCloud(bridge1, bridge1portCounter, 2, 2);
         
         //bridge2
         // host6 and host 7 connected to port 22 
@@ -161,7 +186,7 @@ public class BridgeProtocol extends Protocol<BridgeBridgeLink> {
         createAndPersistBridgeMacLink(bridge3, bridge3portCounter, host9, null, bridge0);
     }
 
-    private void createAndPersistBridgeBridgeLink(OnmsNode bridge, Integer port, OnmsNode designated, Integer designatedPort) {
+    private void createAndPersistBridgeBridgeLink(final OnmsNode bridge, final Integer port, final OnmsNode designated, final Integer designatedPort) {
         createAndPersistBridgeBridgeLink(bridge, port, true, designated, designatedPort, true);
     }
 
@@ -180,6 +205,7 @@ public class BridgeProtocol extends Protocol<BridgeBridgeLink> {
                 createBridgeBridgeLink(bridge, designated, port, designatedPort)
         );
     }
+
     private void createAndPersistBridgeMacLink(OnmsNode bridge, Integer port, OnmsNode host, Integer hostPort, OnmsNode gateway) {
         createAndPersistBridgeMacLink(bridge, port, true, host, hostPort, gateway);
     }

--- a/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/BridgeProtocol.java
+++ b/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/BridgeProtocol.java
@@ -77,23 +77,27 @@ public class BridgeProtocol extends Protocol<BridgeBridgeLink> {
     protected void printProtocolSpecificMessage() {
         // the bridge topology is different as the other topologies since it consists of different node types -> we need
         // a different implementation of this method
-        this.context.currentProgress("%nCreating %s topology with %s Nodes. All other settings are ignored since they not relevant for this topology",
+        this.context.currentProgress("%nCreating %s topology with %s Nodes. Other settings are ignored since they not relevant for this topology",
                 this.getProtocol(),
                 topologySettings.getAmountNodes());
     }
 
     @Override
     protected TopologySettings adoptAndVerifySettings(TopologySettings topologySettings) {
+        // make amount of nodes multiple of 10 since each (sub)tree needs 10 nodes:
         int amountNodes;
-        TopologySettings.TopologySettingsBuilder builder = TopologySettings.builder();
-        // make amount of nodes multiple of 10:
         if (topologySettings.getAmountNodes() < 10) {
-            builder.amountNodes(10);
+            amountNodes = 10;
         } else {
-            int nodes = topologySettings.getAmountNodes() + topologySettings.getAmountNodes() % 10;
-            builder.amountNodes(nodes);
+            int modulo = topologySettings.getAmountNodes() % 10;
+            amountNodes = topologySettings.getAmountNodes();
+            if(modulo != 0){
+                amountNodes += 10-modulo;
+            }
         }
-        return builder.amountSnmpInterfaces(0)
+        return TopologySettings.builder()
+                .amountNodes(amountNodes)
+                .amountSnmpInterfaces(0)
                 .amountIpInterfaces(0)
                 .amountLinks(0)
                 .amountElements(0)

--- a/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/BridgeProtocol.java
+++ b/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/BridgeProtocol.java
@@ -109,219 +109,45 @@ public class BridgeProtocol extends Protocol<BridgeBridgeLink> {
         OnmsNode host7   =  nodes.get(7);
         OnmsNode host8   =  nodes.get(8);
         OnmsNode host9   =  nodes.get(9);
-        int bridge0portCounter=1;
-        int bridge1portCounter=11;
-        int bridge2portCounter=21;
-        int bridge3portCounter=31;
-        int host4portCounter = 41;
-        int host5portCounter = 51;
-        int host6portCounter = 61;
-        int host7portCounter = 71;
 
         BridgeBuilderContext context = new BridgeBuilderContext(this.context.getTopologyPersister(), this.macGenerator, this.inetGenerator);
-        BridgeBuilder bridge0B = new BridgeBuilder(bridge0, bridge0portCounter - 1, context);
-
-
-        // save bridge element
-//        this.context.getTopologyPersister().persist(
-//            createBridgeElement(bridge0),
-//                // instead of:
-//            createBridgeElement(bridge1),
-//            createBridgeElement(bridge2),
-//                // instead of:
-//                createBridgeElement(bridge3)
-//        );
+        BridgeBuilder bridge0B = new BridgeBuilder(bridge0, 0, context);
         
         //bridge0
         //bridge0:port1 connected to up bridge1:port11
-        BridgeBuilder bridge1B = bridge0B.connectToNewBridge(bridge1, bridge1portCounter);
-        // instead of:
-        // createAndPersistBridgeBridgeLink(bridge1, bridge1portCounter, bridge0, bridge0portCounter);
+        BridgeBuilder bridge1B = bridge0B.connectToNewBridge(bridge1, 11);
 
         //bridge3:port31 connected to up bridge0:port2
-        BridgeBuilder bridge3B = bridge0B.connectToNewBridge(bridge3, bridge3portCounter);
-        bridge0portCounter++;
-        // instead of:
-        // createAndPersistBridgeBridgeLink(bridge3, bridge3portCounter, bridge0, bridge0portCounter);
+        BridgeBuilder bridge3B = bridge0B.connectToNewBridge(bridge3, 31);
 
         //bridge0:port3 connected to cloud
-        bridge0portCounter++;
         bridge0B.increasePortCounter();
         bridge0B.createAndPersistCloud(2, 2);
-        // instead off:
-        // createAndPersistCloud(bridge0, bridge0portCounter, 2, 2);
 
         // bridge0:port4 connected to host4:port41
-        bridge0portCounter++;
         bridge0B.increasePortCounter();
-        bridge0B.createAndPersistBridgeMacLink(host4, host4portCounter, bridge0);
-        // instead of:
-        // createAndPersistBridgeMacLink(bridge0, bridge0portCounter, host4, host4portCounter, bridge0);
+        bridge0B.createAndPersistBridgeMacLink(host4, 41, bridge0);
 
-        // bridge0:port5 connected to host5:port51
-        bridge0portCounter++;
         bridge0B.increasePortCounter();
-        bridge0B.createAndPersistBridgeMacLink(host5, host5portCounter, bridge0);
-        // instead of:
-        // createAndPersistBridgeMacLink(bridge0, bridge0portCounter, host5, host5portCounter, bridge0);
+        bridge0B.createAndPersistBridgeMacLink(host5, 51, bridge0);
 
         //bridge1
         //bridge2:port21 connected to bridge1:port12 with clouds
-        bridge1portCounter++;
-        BridgeBuilder bridge2B = bridge1B.connectToNewBridge(bridge2, bridge2portCounter);
-// instead of
-  // createAndPersistBridgeBridgeLink(bridge2, bridge2portCounter, bridge1, bridge1portCounter);
-
+        BridgeBuilder bridge2B = bridge1B.connectToNewBridge(bridge2, 21);
         bridge1B.createAndPersistCloud(2, 2);
-  // instead of
-         // createAndPersistCloud(bridge1, bridge1portCounter, 2, 2);
         
         //bridge2
         // host6 and host 7 connected to port 22 : "cloud" symbol
-        bridge2portCounter++;
         bridge2B.increasePortCounter();
-        bridge2B.createAndPersistBridgeMacLink(true,  host6, host6portCounter, bridge0);
-        // instead of
-        // createAndPersistBridgeMacLink(bridge2, bridge2portCounter, true,  host6, host6portCounter, bridge0);
-        bridge2B.createAndPersistBridgeMacLink(false, host7, host7portCounter, bridge0);
-        // instead of
-        // createAndPersistBridgeMacLink(bridge2, bridge2portCounter, false, host7, host7portCounter, bridge0);
+        bridge2B.createAndPersistBridgeMacLink(true,  host6, 61, bridge0);
+        bridge2B.createAndPersistBridgeMacLink(false, host7, 71, bridge0);
         
         // bridge3
         // host8:with-no-snmp connected bridge3:port32
-        bridge3portCounter++;
         bridge3B.increasePortCounter();
         bridge3B.createAndPersistBridgeMacLink(host8, null, bridge0);
-        // instead of
-        // createAndPersistBridgeMacLink(bridge3, bridge3portCounter, host8, null, bridge0);
-        // host9:with-no-snmp connected bridge3:port33
-        bridge3portCounter++;
         bridge3B.increasePortCounter();
         bridge3B.createAndPersistBridgeMacLink(host9, null, bridge0);
-        // instead of
-        // createAndPersistBridgeMacLink(bridge3, bridge3portCounter, host9, null, bridge0);
     }
 
-    private void createAndPersistBridgeBridgeLink(final OnmsNode bridge, final Integer port, final OnmsNode designated, final Integer designatedPort) {
-        createAndPersistBridgeBridgeLink(bridge, port, true, designated, designatedPort, true);
-    }
-
-    private void createAndPersistBridgeBridgeLink(OnmsNode bridge, Integer port, boolean createSnmpInterface, OnmsNode designated, Integer designatedPort, boolean createdesignatedsnmpInterface) {
-        if (createSnmpInterface) {
-            context.getTopologyPersister().persist(
-                    createSnmpInterface(port, bridge)
-            );
-        }
-        if (createdesignatedsnmpInterface) {
-            context.getTopologyPersister().persist(
-                    createSnmpInterface(designatedPort, designated)
-            );
-        }
-        context.getTopologyPersister().persist(
-                createBridgeBridgeLink(bridge, designated, port, designatedPort)
-        );
-    }
-
-    private void createAndPersistBridgeMacLink(OnmsNode bridge, Integer port, OnmsNode host, Integer hostPort, OnmsNode gateway) {
-        createAndPersistBridgeMacLink(bridge, port, true, host, hostPort, gateway);
-    }
-
-    private void createAndPersistBridgeMacLink(OnmsNode bridge, Integer port, boolean createsnmpinterface, OnmsNode host, Integer hostPort, OnmsNode gateway) {
-        String mac=macGenerator.next();
-        InetAddress ip= inetGenerator.next();
-        if (createsnmpinterface) {
-            context.getTopologyPersister().persist(
-                    createSnmpInterface(port, bridge)
-            );
-        }
-        if (hostPort != null) {
-            OnmsSnmpInterface snmpInterface = createSnmpInterface(hostPort, host);
-            context.getTopologyPersister().persist(
-                    snmpInterface
-            );
-            OnmsIpInterface ipInterface = createIpInterface(snmpInterface, ip);
-            context.getTopologyPersister().persist(ipInterface);
-        } else {
-            OnmsIpInterface ipInterface = createIpInterface(null,ip);
-            ipInterface.setNode(host);
-            context.getTopologyPersister().persist(ipInterface);
-        }
-        context.getTopologyPersister().persist(
-                createIpNetToMedia(host, hostPort, mac, ip, gateway)
-        );
-        context.getTopologyPersister().persist(
-                createBridgeMacLink(bridge, port, mac)
-        );
-    }
-
-    private void createAndPersistCloud(OnmsNode bridge, Integer port, int macaddresses, int ipaddresses) {
-        for (int i=0; i<ipaddresses;i++) {
-            String nextMac = macGenerator.next();
-            context.getTopologyPersister().persist(
-                    createIpNetToMedia(null, null, nextMac, inetGenerator.next(), bridge)
-            );
-            context.getTopologyPersister().persist(
-                    createBridgeMacLink(bridge, port, nextMac));
-        }
-
-        for (int i=0; i<macaddresses;i++) {
-            context.getTopologyPersister().persist(createBridgeMacLink(bridge, port, macGenerator.next()));
-        }
-    }
-
-    private BridgeElement createBridgeElement(OnmsNode node) {
-        BridgeElement bridge = new BridgeElement();
-        bridge.setNode(node);
-        bridge.setBaseBridgeAddress(macGenerator.next());
-        bridge.setBaseType(BridgeDot1dBaseType.DOT1DBASETYPE_TRANSPARENT_ONLY);
-        bridge.setBridgeNodeLastPollTime(new Date());
-        bridge.setBaseNumPorts(topologySettings.getAmountLinks());
-        bridge.setVlan(VLAN_ID);
-        bridge.setVlanname("default");
-        return bridge;
-    }
-
-    private BridgeBridgeLink createBridgeBridgeLink(OnmsNode node, OnmsNode designatedNode, int port, int designatedPort) {
-        BridgeBridgeLink link = new BridgeBridgeLink();
-        link.setBridgePortIfIndex(port);
-        link.setBridgePort(port);
-        link.setVlan(1);
-        link.setNode(node);
-        link.setDesignatedNode(designatedNode);
-        link.setDesignatedPort(designatedPort);
-        link.setDesignatedPortIfIndex(designatedPort);
-        link.setDesignatedVlan(VLAN_ID);
-        link.setBridgeBridgeLinkLastPollTime(new Date());
-        return link;
-    }
-
-    private BridgeMacLink createBridgeMacLink(OnmsNode bridge, Integer bridgePort, String mac){
-        BridgeMacLink bridgeMacLink = new BridgeMacLink();
-        bridgeMacLink.setNode(bridge);
-        bridgeMacLink.setBridgePort(bridgePort);
-        bridgeMacLink.setBridgePortIfIndex(bridgePort);
-        bridgeMacLink.setLinkType(BridgeMacLink.BridgeMacLinkType.BRIDGE_LINK);
-        bridgeMacLink.setMacAddress(mac);
-        bridgeMacLink.setVlan(VLAN_ID);
-        bridgeMacLink.setBridgeMacLinkLastPollTime(new Date());
-        return bridgeMacLink;
-    }
-
-    private IpNetToMedia createIpNetToMedia(OnmsNode node, Integer ifindex, String mac, InetAddress inetAddress, OnmsNode sourceNode){
-        IpNetToMedia ipNetToMedia = new IpNetToMedia();
-        ipNetToMedia.setCreateTime(new Date());
-        if (node != null && ifindex == null ) {
-            ipNetToMedia.setIfIndex(-1);
-        } else {
-            ipNetToMedia.setIfIndex(ifindex);
-        }
-        ipNetToMedia.setLastPollTime(new Date());
-        ipNetToMedia.setIpNetToMediaType(IpNetToMedia.IpNetToMediaType.IPNETTOMEDIA_TYPE_DYNAMIC);
-        ipNetToMedia.setNetAddress(inetAddress);
-        ipNetToMedia.setPhysAddress(mac);
-        ipNetToMedia.setNode(node);
-        ipNetToMedia.setSourceIfIndex(0);
-        ipNetToMedia.setSourceNode(sourceNode);
-        return ipNetToMedia;
-    }
 }

--- a/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/BridgeProtocol.java
+++ b/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/BridgeProtocol.java
@@ -98,22 +98,27 @@ public class BridgeProtocol extends Protocol<BridgeBridgeLink> {
 
     @Override
     protected void createAndPersistProtocolSpecificEntities(List<OnmsNode> nodes) {
-
-        OnmsNode bridge0 =  nodes.get(0);
-        OnmsNode bridge1 =  nodes.get(1);
-        OnmsNode bridge2 =  nodes.get(2);
-        OnmsNode bridge3 =  nodes.get(3);
-        OnmsNode host4   =  nodes.get(4);
-        OnmsNode host5   =  nodes.get(5);
-        OnmsNode host6   =  nodes.get(6);
-        OnmsNode host7   =  nodes.get(7);
-        OnmsNode host8   =  nodes.get(8);
-        OnmsNode host9   =  nodes.get(9);
-
+        OnmsNode bridge0 = nodes.get(0);
         BridgeBuilderContext context = new BridgeBuilderContext(this.context.getTopologyPersister(), this.macGenerator, this.inetGenerator);
         BridgeBuilder bridge0B = new BridgeBuilder(bridge0, 0, context);
-        
-        //bridge0
+        createAndPersistProtocolSpecificEntities(nodes, bridge0B, bridge0, 0);
+
+    }
+
+     protected void createAndPersistProtocolSpecificEntities(List<OnmsNode> nodes, BridgeBuilder bridge0B, OnmsNode gateway, int iteration) {
+
+            int offset = iteration * 10;
+            OnmsNode bridge1 = nodes.get(1 + offset);
+            OnmsNode bridge2 = nodes.get(2 + offset);
+            OnmsNode bridge3 = nodes.get(3 + offset);
+            OnmsNode host4 = nodes.get(4 + offset);
+            OnmsNode bridge5 = nodes.get(5 + offset);
+            OnmsNode host6 = nodes.get(6 + offset);
+            OnmsNode host7 = nodes.get(7 + offset);
+            OnmsNode host8 = nodes.get(8 + offset);
+            OnmsNode host9 = nodes.get(9 + offset);
+
+            //bridge0
         //bridge0:port1 connected to up bridge1:port11
         BridgeBuilder bridge1B = bridge0B.connectToNewBridge(bridge1, 11);
 
@@ -126,10 +131,11 @@ public class BridgeProtocol extends Protocol<BridgeBridgeLink> {
 
         // bridge0:port4 connected to host4:port41
         bridge0B.increasePortCounter();
-        bridge0B.createAndPersistBridgeMacLink(host4, 41, bridge0);
+        bridge0B.createAndPersistBridgeMacLink(host4, 41, gateway);
 
-        bridge0B.increasePortCounter();
-        bridge0B.createAndPersistBridgeMacLink(host5, 51, bridge0);
+        // bridge0B.increasePortCounter();
+        BridgeBuilder bridge5B = bridge0B.connectToNewBridge(bridge5, 51);
+                // bridge0B.createAndPersistBridgeMacLink(host5, 51, gateway);
 
         //bridge1
         //bridge2:port21 connected to bridge1:port12 with clouds
@@ -139,15 +145,18 @@ public class BridgeProtocol extends Protocol<BridgeBridgeLink> {
         //bridge2
         // host6 and host 7 connected to port 22 : "cloud" symbol
         bridge2B.increasePortCounter();
-        bridge2B.createAndPersistBridgeMacLink(true,  host6, 61, bridge0);
-        bridge2B.createAndPersistBridgeMacLink(false, host7, 71, bridge0);
+        bridge2B.createAndPersistBridgeMacLink(true,  host6, 61, gateway);
+        bridge2B.createAndPersistBridgeMacLink(false, host7, 71, gateway);
         
         // bridge3
         // host8:with-no-snmp connected bridge3:port32
         bridge3B.increasePortCounter();
-        bridge3B.createAndPersistBridgeMacLink(host8, null, bridge0);
+        bridge3B.createAndPersistBridgeMacLink(host8, null, gateway);
         bridge3B.increasePortCounter();
-        bridge3B.createAndPersistBridgeMacLink(host9, null, bridge0);
-    }
+        bridge3B.createAndPersistBridgeMacLink(host9, null, gateway);
 
+        if(nodes.size() >= offset + 20 ) {
+            createAndPersistProtocolSpecificEntities(nodes, bridge5B, gateway, iteration+1);
+        }
+    }
 }

--- a/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/BridgeProtocol.java
+++ b/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/BridgeProtocol.java
@@ -123,14 +123,14 @@ public class BridgeProtocol extends Protocol<BridgeBridgeLink> {
 
 
         // save bridge element
-        this.context.getTopologyPersister().persist(
-            createBridgeElement(bridge0),
-                // instead of:
-            createBridgeElement(bridge1),
-            createBridgeElement(bridge2),
-                // instead of:
-                createBridgeElement(bridge3)
-        );
+//        this.context.getTopologyPersister().persist(
+//            createBridgeElement(bridge0),
+//                // instead of:
+//            createBridgeElement(bridge1),
+//            createBridgeElement(bridge2),
+//                // instead of:
+//                createBridgeElement(bridge3)
+//        );
         
         //bridge0
         //bridge0:port1 connected to up bridge1:port11
@@ -139,51 +139,67 @@ public class BridgeProtocol extends Protocol<BridgeBridgeLink> {
         // createAndPersistBridgeBridgeLink(bridge1, bridge1portCounter, bridge0, bridge0portCounter);
 
         //bridge3:port31 connected to up bridge0:port2
-        bridge0B.connectToNewBridge(bridge3, bridge3portCounter);
+        BridgeBuilder bridge3B = bridge0B.connectToNewBridge(bridge3, bridge3portCounter);
         bridge0portCounter++;
         // instead of:
         // createAndPersistBridgeBridgeLink(bridge3, bridge3portCounter, bridge0, bridge0portCounter);
 
         //bridge0:port3 connected to cloud
         bridge0portCounter++;
-        // bridge0B.createAndPersistCloud(2, 2);
+        bridge0B.increasePortCounter();
+        bridge0B.createAndPersistCloud(2, 2);
         // instead off:
-        createAndPersistCloud(bridge0, bridge0portCounter, 2, 2);
+        // createAndPersistCloud(bridge0, bridge0portCounter, 2, 2);
 
         // bridge0:port4 connected to host4:port41
         bridge0portCounter++;
-        // bridge0B.createAndPersistBridgeMacLink(host4, host4portCounter);
+        bridge0B.increasePortCounter();
+        bridge0B.createAndPersistBridgeMacLink(host4, host4portCounter, bridge0);
         // instead of:
-        createAndPersistBridgeMacLink(bridge0, bridge0portCounter, host4, host4portCounter, bridge0);
+        // createAndPersistBridgeMacLink(bridge0, bridge0portCounter, host4, host4portCounter, bridge0);
 
         // bridge0:port5 connected to host5:port51
         bridge0portCounter++;
-        // bridge0B.createAndPersistBridgeMacLink(host5, host5portCounter);
+        bridge0B.increasePortCounter();
+        bridge0B.createAndPersistBridgeMacLink(host5, host5portCounter, bridge0);
         // instead of:
-        createAndPersistBridgeMacLink(bridge0, bridge0portCounter, host5, host5portCounter, bridge0);
+        // createAndPersistBridgeMacLink(bridge0, bridge0portCounter, host5, host5portCounter, bridge0);
 
         //bridge1
         //bridge2:port21 connected to bridge1:port12 with clouds
         bridge1portCounter++;
-        bridge1B.connectToNewBridge(bridge2, bridge2portCounter);
+        BridgeBuilder bridge2B = bridge1B.connectToNewBridge(bridge2, bridge2portCounter);
 // instead of
   // createAndPersistBridgeBridgeLink(bridge2, bridge2portCounter, bridge1, bridge1portCounter);
-//         bridge1B.createAndPersistCloud(2, 2);
-         createAndPersistCloud(bridge1, bridge1portCounter, 2, 2);
+
+        bridge1B.createAndPersistCloud(2, 2);
+  // instead of
+         // createAndPersistCloud(bridge1, bridge1portCounter, 2, 2);
         
         //bridge2
-        // host6 and host 7 connected to port 22 
+        // host6 and host 7 connected to port 22 : "cloud" symbol
         bridge2portCounter++;
-        createAndPersistBridgeMacLink(bridge2, bridge2portCounter, true,  host6, host6portCounter, bridge0);
-        createAndPersistBridgeMacLink(bridge2, bridge2portCounter, false, host7, host7portCounter, bridge0);
+        bridge2B.increasePortCounter();
+        bridge2B.createAndPersistBridgeMacLink(true,  host6, host6portCounter, bridge0);
+        // instead of
+        // createAndPersistBridgeMacLink(bridge2, bridge2portCounter, true,  host6, host6portCounter, bridge0);
+        bridge2B.createAndPersistBridgeMacLink(false, host7, host7portCounter, bridge0);
+        // instead of
+        // createAndPersistBridgeMacLink(bridge2, bridge2portCounter, false, host7, host7portCounter, bridge0);
         
         // bridge3
         // host8:with-no-snmp connected bridge3:port32
         bridge3portCounter++;
-        createAndPersistBridgeMacLink(bridge3, bridge3portCounter, host8, null, bridge0);
+        bridge3B.increasePortCounter();
+        bridge3B.createAndPersistBridgeMacLink(host8, null, bridge0);
+        // instead of
+        // createAndPersistBridgeMacLink(bridge3, bridge3portCounter, host8, null, bridge0);
         // host9:with-no-snmp connected bridge3:port33
         bridge3portCounter++;
-        createAndPersistBridgeMacLink(bridge3, bridge3portCounter, host9, null, bridge0);
+        bridge3B.increasePortCounter();
+        bridge3B.createAndPersistBridgeMacLink(host9, null, bridge0);
+        // instead of
+        // createAndPersistBridgeMacLink(bridge3, bridge3portCounter, host9, null, bridge0);
     }
 
     private void createAndPersistBridgeBridgeLink(final OnmsNode bridge, final Integer port, final OnmsNode designated, final Integer designatedPort) {

--- a/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/BridgeProtocol.java
+++ b/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/BridgeProtocol.java
@@ -42,8 +42,8 @@ import org.opennms.netmgt.model.OnmsNode;
 
 /**
  * Creates a topology with Bridges and Segments.
- * Call with: enlinkd:generate-topology --protocol bridge --nodes
- * Example:
+ * Call with: enlinkd:generate-topology --protocol bridge --nodes 10
+ * will result in:
  *
  *                           bridge0
  *           ------------------------------------
@@ -59,15 +59,7 @@ import org.opennms.netmgt.model.OnmsNode;
  * no node     |
  *          Segment
  *
- * 6 nodes are hosts: host4,host5, host6, host7, host8, host9
- * generate 4 ipnettomedia without a corresponding node
- * consider also that on port 1 of C is connected an HUB with a group of hosts connected
- * the hub has no snmp agent and therefore we are not to explore his mab forwarding table
- * we also follow the convention to start the port countin from the if of the node
- * following an integer: so port11 -> is the first generated port of node with id 1
- * port12 -> is the second generated port of node with id 1
- * port21 -> is the first generated port of node with id 2
- * port53 -> is the third generated port of node with id 5
+ * If more than 10 nodes are requested then the tree repeats itself with bridge5 as the root node of the new subtree.
  */
 public class BridgeProtocol extends Protocol<BridgeBridgeLink> {
 
@@ -122,7 +114,7 @@ public class BridgeProtocol extends Protocol<BridgeBridgeLink> {
 
     }
 
-    protected void createAndPersistProtocolSpecificEntities(List<OnmsNode> nodes, BridgeBuilder bridge0B, OnmsNode gateway, int iteration) {
+    private void createAndPersistProtocolSpecificEntities(List<OnmsNode> nodes, BridgeBuilder bridge0B, OnmsNode gateway, int iteration) {
 
         int offset = iteration * 10;
         OnmsNode bridge1 = nodes.get(1 + offset);
@@ -171,6 +163,7 @@ public class BridgeProtocol extends Protocol<BridgeBridgeLink> {
         bridge3B.increasePortCounter();
         bridge3B.createAndPersistBridgeMacLink(host9, null, gateway);
 
+        // create sub tree on bridge5:
         if (nodes.size() >= offset + 20) {
             createAndPersistProtocolSpecificEntities(nodes, bridge5B, gateway, iteration + 1);
         }

--- a/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/Protocol.java
+++ b/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/Protocol.java
@@ -130,7 +130,7 @@ public abstract class Protocol<Element> {
         return interfaces;
     }
 
-    private OnmsSnmpInterface createSnmpInterface(int ifIndex, OnmsNode node) {
+    protected OnmsSnmpInterface createSnmpInterface(int ifIndex, OnmsNode node) {
         OnmsSnmpInterface onmsSnmpInterface = new OnmsSnmpInterface();
         onmsSnmpInterface.setId((node.getId() * topologySettings.getAmountSnmpInterfaces()) + ifIndex);
         onmsSnmpInterface.setNode(node);
@@ -155,7 +155,7 @@ public abstract class Protocol<Element> {
         return interfaces;
     }
 
-    private OnmsIpInterface createIpInterface(OnmsSnmpInterface snmp, InetAddress inetAddress) {
+    protected OnmsIpInterface createIpInterface(OnmsSnmpInterface snmp, InetAddress inetAddress) {
         OnmsIpInterface ip = new OnmsIpInterface();
         ip.setId(snmp.getId());
         ip.setSnmpInterface(snmp);

--- a/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/Protocol.java
+++ b/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/Protocol.java
@@ -60,19 +60,12 @@ public abstract class Protocol<Element> {
     final Map<Integer, Integer> nodeIfIndexes = new HashMap<>();
 
     public Protocol(TopologySettings topologySettings, TopologyContext context) {
-        this.topologySettings = topologySettings;
+        this.topologySettings = adoptAndVerifySettings(topologySettings);
         this.context = context;
     }
 
     public void createAndPersistNetwork() {
-        this.context.currentProgress("%nCreating %s %s topology with %s Nodes, %s Elements, %s Links, %s SnmpInterfaces, %s IpInterfaces:",
-                topologySettings.getTopology(),
-                this.getProtocol(),
-                topologySettings.getAmountNodes(),
-                topologySettings.getAmountElements(),
-                topologySettings.getAmountElements(),
-                topologySettings.getAmountSnmpInterfaces(),
-                topologySettings.getAmountIpInterfaces());
+        printProtocolSpecificMessage();
         OnmsCategory category = createCategory();
         context.getTopologyPersister().persist(category);
         List<OnmsNode> nodes = createNodes(topologySettings.getAmountNodes(), category);
@@ -85,11 +78,27 @@ public abstract class Protocol<Element> {
         createAndPersistProtocolSpecificEntities(nodes);
     }
 
+    protected void printProtocolSpecificMessage() {
+        this.context.currentProgress("%nCreating %s %s topology with %s Nodes, %s Elements, %s Links, %s SnmpInterfaces, %s IpInterfaces:",
+                topologySettings.getTopology(),
+                this.getProtocol(),
+                topologySettings.getAmountNodes(),
+                topologySettings.getAmountElements(),
+                topologySettings.getAmountElements(),
+                topologySettings.getAmountSnmpInterfaces(),
+                topologySettings.getAmountIpInterfaces());
+    }
+
     protected abstract void createAndPersistProtocolSpecificEntities(List<OnmsNode> nodes);
 
     protected abstract TopologyGenerator.Protocol getProtocol();
 
-    private OnmsCategory createCategory() {
+    protected TopologySettings adoptAndVerifySettings(TopologySettings topologySettings) {
+        topologySettings.verify();
+        return topologySettings;
+    }
+
+    protected OnmsCategory createCategory() {
         OnmsCategory category = new OnmsCategory();
         category.setName(TopologyGenerator.CATEGORY_NAME);
         return category;

--- a/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/Protocol.java
+++ b/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/Protocol.java
@@ -34,6 +34,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import org.opennms.enlinkd.generator.TopologyContext;
 import org.opennms.enlinkd.generator.TopologyGenerator;
@@ -160,7 +161,7 @@ public abstract class Protocol<Element> {
         ip.setId(snmp.getId());
         ip.setSnmpInterface(snmp);
         ip.setIpLastCapsdPoll(new Date());
-        ip.setNode(snmp.getNode());
+        ip.setNode(Optional.ofNullable(snmp).map(OnmsSnmpInterface::getNode).orElse(null));
         ip.setIpAddress(inetAddress);
         return ip;
     }

--- a/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/bridge/BridgeBuilder.java
+++ b/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/bridge/BridgeBuilder.java
@@ -1,0 +1,217 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.enlinkd.generator.protocol.bridge;
+
+import java.net.InetAddress;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+
+import org.opennms.enlinkd.generator.TopologyPersister;
+import org.opennms.netmgt.enlinkd.model.BridgeBridgeLink;
+import org.opennms.netmgt.enlinkd.model.BridgeElement;
+import org.opennms.netmgt.enlinkd.model.BridgeMacLink;
+import org.opennms.netmgt.enlinkd.model.IpNetToMedia;
+import org.opennms.netmgt.model.OnmsIpInterface;
+import org.opennms.netmgt.model.OnmsNode;
+import org.opennms.netmgt.model.OnmsSnmpInterface;
+
+public class BridgeBuilder {
+
+    /* this is the vlan id for all the bridgebridgelinks and bridgemaclinks */
+    private final static int VLAN_ID = 1;
+
+    private OnmsNode node;
+    private int bridgePortCounter;
+    private BridgeBuilderContext context;
+    private List<Object> objectsToPersist;
+
+    public BridgeBuilder(OnmsNode node, int bridgePortCounter, BridgeBuilderContext context) {
+        this.node = node;
+        this.bridgePortCounter = bridgePortCounter;
+        this.context = context;
+    }
+
+    public BridgeBuilder connectToNewBridge(OnmsNode targetNode, int targetNodePortCounter) {
+//        BridgeElement bridgeElement = createBridgeElement(targetNode);
+//        this.context.getTopologyPersister().persist(bridgeElement);
+        this.bridgePortCounter ++;
+        createAndPersistBridgeBridgeLink(targetNode, targetNodePortCounter, this.node, this.bridgePortCounter);
+        return new BridgeBuilder(targetNode, targetNodePortCounter , this.context);
+    }
+
+    private BridgeElement createBridgeElement(OnmsNode node) {
+        BridgeElement bridge = new BridgeElement();
+        bridge.setNode(node);
+        bridge.setBaseBridgeAddress(this.context.getNextMacAddress());
+        bridge.setBaseType(BridgeElement.BridgeDot1dBaseType.DOT1DBASETYPE_TRANSPARENT_ONLY);
+        bridge.setBridgeNodeLastPollTime(new Date());
+        bridge.setBaseNumPorts(3);
+        bridge.setVlan(VLAN_ID);
+        bridge.setVlanname("default");
+        return bridge;
+    }
+
+    private void createAndPersistBridgeBridgeLink(OnmsNode bridge, Integer port, OnmsNode designated, Integer designatedPort) {
+        createAndPersistBridgeBridgeLink(bridge, port, true, designated, designatedPort, true);
+    }
+
+    private void createAndPersistBridgeBridgeLink(OnmsNode bridge, Integer port, boolean createSnmpInterface, OnmsNode designated, Integer designatedPort, boolean createdesignatedsnmpInterface) {
+        if (createSnmpInterface) {
+            context.getTopologyPersister().persist(
+                    createSnmpInterface(port, bridge)
+            );
+        }
+        if (createdesignatedsnmpInterface) {
+            context.getTopologyPersister().persist(
+                    createSnmpInterface(designatedPort, designated)
+            );
+        }
+        context.getTopologyPersister().persist(
+                createBridgeBridgeLink(bridge, designated, port, designatedPort)
+        );
+    }
+
+    public void createAndPersistCloud(int macaddresses, int ipaddresses) {
+        for (int i=0; i<ipaddresses;i++) {
+            String nextMac = context.getNextMacAddress();
+            context.getTopologyPersister().persist(
+                    createIpNetToMedia(null, null, nextMac, context.getInetAddress(), this.node)
+            );
+            context.getTopologyPersister().persist(
+                    createBridgeMacLink(this.node, this.bridgePortCounter, nextMac));
+        }
+
+        for (int i=0; i<macaddresses;i++) {
+            context.getTopologyPersister().persist(createBridgeMacLink(this.node, this.bridgePortCounter, context.getNextMacAddress()));
+        }
+
+    }
+
+    public void createAndPersistBridgeMacLink(OnmsNode host, Integer hostPort) {
+        createAndPersistBridgeMacLink(true, host, hostPort);
+    }
+
+    private void createAndPersistBridgeMacLink(boolean createsnmpinterface, OnmsNode host, Integer hostPort) {
+        this.bridgePortCounter ++;
+        String mac=this.context.getNextMacAddress();
+        InetAddress ip= this.context.getInetAddress();
+        if (createsnmpinterface) {
+            context.getTopologyPersister().persist(
+                    createSnmpInterface(this.bridgePortCounter, this.node)
+            );
+        }
+        if (hostPort != null) {
+            OnmsSnmpInterface snmpInterface = createSnmpInterface(hostPort, host);
+            context.getTopologyPersister().persist(
+                    snmpInterface
+            );
+            OnmsIpInterface ipInterface = createIpInterface(snmpInterface, ip);
+            context.getTopologyPersister().persist(ipInterface);
+        } else {
+            OnmsIpInterface ipInterface = createIpInterface(null,ip);
+            ipInterface.setNode(host);
+            context.getTopologyPersister().persist(ipInterface);
+        }
+        context.getTopologyPersister().persist(
+                createIpNetToMedia(host, hostPort, mac, ip, this.node)
+        );
+        context.getTopologyPersister().persist(
+                createBridgeMacLink(this.node, this.bridgePortCounter, mac)
+        );
+
+    }
+
+    protected OnmsIpInterface createIpInterface(OnmsSnmpInterface snmp, InetAddress inetAddress) {
+        OnmsIpInterface ip = new OnmsIpInterface();
+        ip.setSnmpInterface(snmp);
+        ip.setIpLastCapsdPoll(new Date());
+        ip.setNode(Optional.ofNullable(snmp).map(OnmsSnmpInterface::getNode).orElse(null));
+        ip.setIpAddress(inetAddress);
+        return ip;
+    }
+
+    private BridgeMacLink createBridgeMacLink(OnmsNode bridge, Integer bridgePort, String mac){
+        BridgeMacLink bridgeMacLink = new BridgeMacLink();
+        bridgeMacLink.setNode(bridge);
+        bridgeMacLink.setBridgePort(bridgePort);
+        bridgeMacLink.setBridgePortIfIndex(bridgePort);
+        bridgeMacLink.setLinkType(BridgeMacLink.BridgeMacLinkType.BRIDGE_LINK);
+        bridgeMacLink.setMacAddress(mac);
+        bridgeMacLink.setVlan(VLAN_ID);
+        bridgeMacLink.setBridgeMacLinkLastPollTime(new Date());
+        return bridgeMacLink;
+    }
+
+    protected OnmsSnmpInterface createSnmpInterface(int ifIndex, OnmsNode node) {
+        OnmsSnmpInterface onmsSnmpInterface = new OnmsSnmpInterface();
+        onmsSnmpInterface.setNode(node);
+        onmsSnmpInterface.setIfIndex(ifIndex);
+        onmsSnmpInterface.setIfType(4);
+        onmsSnmpInterface.setIfSpeed(5L);
+        onmsSnmpInterface.setIfAdminStatus(6);
+        onmsSnmpInterface.setIfOperStatus(7);
+        onmsSnmpInterface.setLastCapsdPoll(new Date());
+        onmsSnmpInterface.setLastSnmpPoll(new Date());
+
+        return onmsSnmpInterface;
+    }
+
+    private BridgeBridgeLink createBridgeBridgeLink(OnmsNode node, OnmsNode designatedNode, int port, int designatedPort) {
+        BridgeBridgeLink link = new BridgeBridgeLink();
+        link.setBridgePortIfIndex(port);
+        link.setBridgePort(port);
+        link.setVlan(1);
+        link.setNode(node);
+        link.setDesignatedNode(designatedNode);
+        link.setDesignatedPort(designatedPort);
+        link.setDesignatedPortIfIndex(designatedPort);
+        link.setDesignatedVlan(VLAN_ID);
+        link.setBridgeBridgeLinkLastPollTime(new Date());
+        return link;
+    }
+
+    private IpNetToMedia createIpNetToMedia(OnmsNode node, Integer ifindex, String mac, InetAddress inetAddress, OnmsNode sourceNode){
+        IpNetToMedia ipNetToMedia = new IpNetToMedia();
+        ipNetToMedia.setCreateTime(new Date());
+        if (node != null && ifindex == null ) {
+            ipNetToMedia.setIfIndex(-1);
+        } else {
+            ipNetToMedia.setIfIndex(ifindex);
+        }
+        ipNetToMedia.setLastPollTime(new Date());
+        ipNetToMedia.setIpNetToMediaType(IpNetToMedia.IpNetToMediaType.IPNETTOMEDIA_TYPE_DYNAMIC);
+        ipNetToMedia.setNetAddress(inetAddress);
+        ipNetToMedia.setPhysAddress(mac);
+        ipNetToMedia.setNode(node);
+        ipNetToMedia.setSourceIfIndex(0);
+        ipNetToMedia.setSourceNode(sourceNode);
+        return ipNetToMedia;
+    }
+}

--- a/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/bridge/BridgeBuilder.java
+++ b/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/bridge/BridgeBuilder.java
@@ -49,7 +49,6 @@ public class BridgeBuilder {
     private OnmsNode node;
     private int bridgePortCounter;
     private BridgeBuilderContext context;
-    private List<Object> objectsToPersist;
 
     public BridgeBuilder(OnmsNode node, int bridgePortCounter, BridgeBuilderContext context) {
         this.node = node;
@@ -102,7 +101,6 @@ public class BridgeBuilder {
     }
 
     public void createAndPersistCloud(int macaddresses, int ipaddresses) {
-        // this.bridgePortCounter ++;
         for (int i=0; i<ipaddresses;i++) {
             String nextMac = context.getNextMacAddress();
             context.getTopologyPersister().persist(

--- a/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/bridge/BridgeBuilder.java
+++ b/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/bridge/BridgeBuilder.java
@@ -30,7 +30,6 @@ package org.opennms.enlinkd.generator.protocol.bridge;
 
 import java.net.InetAddress;
 import java.util.Date;
-import java.util.List;
 import java.util.Optional;
 
 import org.opennms.netmgt.enlinkd.model.BridgeBridgeLink;

--- a/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/bridge/BridgeBuilderContext.java
+++ b/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/bridge/BridgeBuilderContext.java
@@ -50,7 +50,7 @@ public class BridgeBuilderContext {
         return macGenerator.next();
     }
 
-    public InetAddress getInetAddress(){
+    public InetAddress getNextInetAddress(){
         return inetGenerator.next();
     }
 

--- a/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/bridge/BridgeBuilderContext.java
+++ b/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/protocol/bridge/BridgeBuilderContext.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.enlinkd.generator.protocol.bridge;
+
+import java.net.InetAddress;
+
+import org.opennms.enlinkd.generator.TopologyPersister;
+import org.opennms.enlinkd.generator.util.InetAddressGenerator;
+import org.opennms.enlinkd.generator.util.MacAddressGenerator;
+
+public class BridgeBuilderContext {
+
+    private final TopologyPersister topologyPersister;
+    private final MacAddressGenerator macGenerator;
+    private final InetAddressGenerator inetGenerator;
+
+    public BridgeBuilderContext(TopologyPersister topologyPersister, MacAddressGenerator macGenerator, InetAddressGenerator inetGenerator) {
+        this.topologyPersister = topologyPersister;
+        this.macGenerator = macGenerator;
+        this.inetGenerator = inetGenerator;
+    }
+
+    public String getNextMacAddress(){
+        return macGenerator.next();
+    }
+
+    public InetAddress getInetAddress(){
+        return inetGenerator.next();
+    }
+
+    public TopologyPersister getTopologyPersister(){
+        return topologyPersister;
+    }
+}

--- a/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/util/MacAddressGenerator.java
+++ b/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/util/MacAddressGenerator.java
@@ -35,6 +35,13 @@ public class MacAddressGenerator {
     public String next() {
         String s = String.format("%1$" + 12 + "s", Integer.toHexString(last)); // example: "           1"
         s = s.replace(' ', '0'); // example: "000000000001"
+        last++;
+        return s;
+    }
+
+    public String nextWithSeparator() {
+
+        String s = next();
         s = s.substring(0, 2)
                 + ':' + s.substring(2, 4)
                 + ':' + s.substring(4, 6)

--- a/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/util/MacAddressGenerator.java
+++ b/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/util/MacAddressGenerator.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.enlinkd.generator.util;
+
+public class MacAddressGenerator {
+
+    private int last = 0;
+
+    public String next() {
+        String s = String.format("%1$" + 12 + "s", Integer.toHexString(last)); // example: "           1"
+        s = s.replace(' ', '0'); // example: "000000000001"
+        s = s.substring(0, 2)
+                + ':' + s.substring(2, 4)
+                + ':' + s.substring(4, 6)
+                + ':' + s.substring(6, 8)
+                + ':' + s.substring(8, 10)
+                + ':' + s.substring(10, 12);
+        last++;
+        return s;
+    }
+}

--- a/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/util/MacAddressGenerator.java
+++ b/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/util/MacAddressGenerator.java
@@ -30,7 +30,8 @@ package org.opennms.enlinkd.generator.util;
 
 public class MacAddressGenerator {
 
-    private int last = 0;
+    //0000:0000:0000 is an invalid mac address
+    private int last = 1;
 
     public String next() {
         String s = String.format("%1$" + 12 + "s", Integer.toHexString(last)); // example: "           1"

--- a/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/util/MacAddressGenerator.java
+++ b/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/util/MacAddressGenerator.java
@@ -30,25 +30,12 @@ package org.opennms.enlinkd.generator.util;
 
 public class MacAddressGenerator {
 
-    //0000:0000:0000 is an invalid mac address
+    // we start with 1 since 0000:0000:0000 is an invalid mac address
     private int last = 1;
 
     public String next() {
         String s = String.format("%1$" + 12 + "s", Integer.toHexString(last)); // example: "           1"
         s = s.replace(' ', '0'); // example: "000000000001"
-        last++;
-        return s;
-    }
-
-    public String nextWithSeparator() {
-
-        String s = next();
-        s = s.substring(0, 2)
-                + ':' + s.substring(2, 4)
-                + ':' + s.substring(4, 6)
-                + ':' + s.substring(6, 8)
-                + ':' + s.substring(8, 10)
-                + ':' + s.substring(10, 12);
         last++;
         return s;
     }

--- a/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/util/MacAddressGenerator.java
+++ b/features/enlinkd/generator/src/main/java/org/opennms/enlinkd/generator/util/MacAddressGenerator.java
@@ -31,12 +31,12 @@ package org.opennms.enlinkd.generator.util;
 public class MacAddressGenerator {
 
     // we start with 1 since 0000:0000:0000 is an invalid mac address
-    private int last = 1;
+    private int next = 1;
 
     public String next() {
-        String s = String.format("%1$" + 12 + "s", Integer.toHexString(last)); // example: "           1"
+        String s = String.format("%1$" + 12 + "s", Integer.toHexString(next)); // example: "           1"
         s = s.replace(' ', '0'); // example: "000000000001"
-        last++;
+        next++;
         return s;
     }
 }

--- a/features/enlinkd/generator/src/test/java/org/opennms/enlinkd/generator/protocol/BridgeProtocolTest.java
+++ b/features/enlinkd/generator/src/test/java/org/opennms/enlinkd/generator/protocol/BridgeProtocolTest.java
@@ -38,14 +38,14 @@ public class BridgeProtocolTest {
 
     @Test
     public void testAdoptAndVerifySettings() {
-        testAmountNodes(10, -1);
-        testAmountNodes(10, 0);
-        testAmountNodes(10, 9);
-        testAmountNodes(10, 10);
-        testAmountNodes(20, 11);
-        testAmountNodes(20, 19);
-        testAmountNodes(20, 20);
-        testAmountNodes(30, 21);
+        testAmountNodes(11, -1);
+        testAmountNodes(11, 0);
+        testAmountNodes(11, 10);
+        testAmountNodes(11, 11);
+        testAmountNodes(21, 12);
+        testAmountNodes(21, 20);
+        testAmountNodes(21, 21);
+        testAmountNodes(31, 22);
     }
 
     private void testAmountNodes(int expected, int initialSetting) {

--- a/features/enlinkd/generator/src/test/java/org/opennms/enlinkd/generator/protocol/BridgeProtocolTest.java
+++ b/features/enlinkd/generator/src/test/java/org/opennms/enlinkd/generator/protocol/BridgeProtocolTest.java
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.enlinkd.generator.protocol;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+import org.opennms.enlinkd.generator.TopologySettings;
+
+
+public class BridgeProtocolTest {
+
+    @Test
+    public void testAdoptAndVerifySettings() {
+        testAmountNodes(10, -1);
+        testAmountNodes(10, 0);
+        testAmountNodes(10, 9);
+        testAmountNodes(10, 10);
+        testAmountNodes(20, 11);
+        testAmountNodes(20, 19);
+        testAmountNodes(20, 20);
+        testAmountNodes(30, 21);
+    }
+
+    private void testAmountNodes(int expected, int initialSetting) {
+        BridgeProtocol protocol = new BridgeProtocol(TopologySettings.builder().build(), null);
+        TopologySettings settings = protocol.adoptAndVerifySettings(TopologySettings.builder().amountNodes(initialSetting).build());
+        assertEquals(expected, settings.getAmountNodes());
+    }
+}

--- a/features/enlinkd/generator/src/test/java/org/opennms/enlinkd/generator/util/MacAddressGeneratorTest.java
+++ b/features/enlinkd/generator/src/test/java/org/opennms/enlinkd/generator/util/MacAddressGeneratorTest.java
@@ -1,0 +1,75 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.enlinkd.generator.util;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class MacAddressGeneratorTest {
+
+    @Test
+    public void shouldProduceStreamOfMacAddresses() {
+        MacAddressGenerator gen = new MacAddressGenerator();
+        assertEquals("00:00:00:00:00:00", gen.next());
+        assertEquals("00:00:00:00:00:01", gen.next());
+        assertEquals("00:00:00:00:00:02", gen.next());
+        assertEquals("00:00:00:00:00:03", gen.next());
+        assertEquals("00:00:00:00:00:04", gen.next());
+        assertEquals("00:00:00:00:00:05", gen.next());
+        assertEquals("00:00:00:00:00:06", gen.next());
+        assertEquals("00:00:00:00:00:07", gen.next());
+        assertEquals("00:00:00:00:00:08", gen.next());
+        assertEquals("00:00:00:00:00:09", gen.next());
+        assertEquals("00:00:00:00:00:0a", gen.next());
+        assertEquals("00:00:00:00:00:0b", gen.next());
+        assertEquals("00:00:00:00:00:0c", gen.next());
+        assertEquals("00:00:00:00:00:0d", gen.next());
+        assertEquals("00:00:00:00:00:0e", gen.next());
+        assertEquals("00:00:00:00:00:0f", gen.next());
+
+        assertEquals("00:00:00:00:00:10", gen.next());
+        assertEquals("00:00:00:00:00:11", gen.next());
+        assertEquals("00:00:00:00:00:12", gen.next());
+        assertEquals("00:00:00:00:00:13", gen.next());
+        assertEquals("00:00:00:00:00:14", gen.next());
+        assertEquals("00:00:00:00:00:15", gen.next());
+        assertEquals("00:00:00:00:00:16", gen.next());
+        assertEquals("00:00:00:00:00:17", gen.next());
+        assertEquals("00:00:00:00:00:18", gen.next());
+        assertEquals("00:00:00:00:00:19", gen.next());
+        assertEquals("00:00:00:00:00:1a", gen.next());
+        assertEquals("00:00:00:00:00:1b", gen.next());
+        assertEquals("00:00:00:00:00:1c", gen.next());
+        assertEquals("00:00:00:00:00:1d", gen.next());
+        assertEquals("00:00:00:00:00:1e", gen.next());
+        assertEquals("00:00:00:00:00:1f", gen.next());
+
+    }
+}

--- a/features/enlinkd/generator/src/test/java/org/opennms/enlinkd/generator/util/MacAddressGeneratorTest.java
+++ b/features/enlinkd/generator/src/test/java/org/opennms/enlinkd/generator/util/MacAddressGeneratorTest.java
@@ -37,39 +37,39 @@ public class MacAddressGeneratorTest {
     @Test
     public void shouldProduceStreamOfMacAddresses() {
         MacAddressGenerator gen = new MacAddressGenerator();
-        assertEquals("00:00:00:00:00:00", gen.next());
-        assertEquals("00:00:00:00:00:01", gen.next());
-        assertEquals("00:00:00:00:00:02", gen.next());
-        assertEquals("00:00:00:00:00:03", gen.next());
-        assertEquals("00:00:00:00:00:04", gen.next());
-        assertEquals("00:00:00:00:00:05", gen.next());
-        assertEquals("00:00:00:00:00:06", gen.next());
-        assertEquals("00:00:00:00:00:07", gen.next());
-        assertEquals("00:00:00:00:00:08", gen.next());
-        assertEquals("00:00:00:00:00:09", gen.next());
-        assertEquals("00:00:00:00:00:0a", gen.next());
-        assertEquals("00:00:00:00:00:0b", gen.next());
-        assertEquals("00:00:00:00:00:0c", gen.next());
-        assertEquals("00:00:00:00:00:0d", gen.next());
-        assertEquals("00:00:00:00:00:0e", gen.next());
-        assertEquals("00:00:00:00:00:0f", gen.next());
+        assertEquals("00000000000000000", gen.next());
+        assertEquals("00000000000000001", gen.next());
+        assertEquals("00000000000000002", gen.next());
+        assertEquals("00000000000000003", gen.next());
+        assertEquals("00000000000000004", gen.next());
+        assertEquals("00000000000000005", gen.next());
+        assertEquals("00000000000000006", gen.next());
+        assertEquals("00000000000000007", gen.next());
+        assertEquals("00000000000000008", gen.next());
+        assertEquals("00000000000000009", gen.next());
+        assertEquals("0000000000000000a", gen.next());
+        assertEquals("0000000000000000b", gen.next());
+        assertEquals("0000000000000000c", gen.next());
+        assertEquals("0000000000000000d", gen.next());
+        assertEquals("0000000000000000e", gen.next());
+        assertEquals("0000000000000000f", gen.next());
 
-        assertEquals("00:00:00:00:00:10", gen.next());
-        assertEquals("00:00:00:00:00:11", gen.next());
-        assertEquals("00:00:00:00:00:12", gen.next());
-        assertEquals("00:00:00:00:00:13", gen.next());
-        assertEquals("00:00:00:00:00:14", gen.next());
-        assertEquals("00:00:00:00:00:15", gen.next());
-        assertEquals("00:00:00:00:00:16", gen.next());
-        assertEquals("00:00:00:00:00:17", gen.next());
-        assertEquals("00:00:00:00:00:18", gen.next());
-        assertEquals("00:00:00:00:00:19", gen.next());
-        assertEquals("00:00:00:00:00:1a", gen.next());
-        assertEquals("00:00:00:00:00:1b", gen.next());
-        assertEquals("00:00:00:00:00:1c", gen.next());
-        assertEquals("00:00:00:00:00:1d", gen.next());
-        assertEquals("00:00:00:00:00:1e", gen.next());
-        assertEquals("00:00:00:00:00:1f", gen.next());
+        assertEquals("00000000000000010", gen.next());
+        assertEquals("00000000000000011", gen.next());
+        assertEquals("00000000000000012", gen.next());
+        assertEquals("00000000000000013", gen.next());
+        assertEquals("00000000000000014", gen.next());
+        assertEquals("00000000000000015", gen.next());
+        assertEquals("00000000000000016", gen.next());
+        assertEquals("00000000000000017", gen.next());
+        assertEquals("00000000000000018", gen.next());
+        assertEquals("00000000000000019", gen.next());
+        assertEquals("0000000000000001a", gen.next());
+        assertEquals("0000000000000001b", gen.next());
+        assertEquals("0000000000000001c", gen.next());
+        assertEquals("0000000000000001d", gen.next());
+        assertEquals("0000000000000001e", gen.next());
+        assertEquals("0000000000000001f", gen.next());
 
     }
 }

--- a/features/enlinkd/generator/src/test/java/org/opennms/enlinkd/generator/util/MacAddressGeneratorTest.java
+++ b/features/enlinkd/generator/src/test/java/org/opennms/enlinkd/generator/util/MacAddressGeneratorTest.java
@@ -37,39 +37,38 @@ public class MacAddressGeneratorTest {
     @Test
     public void shouldProduceStreamOfMacAddresses() {
         MacAddressGenerator gen = new MacAddressGenerator();
-        assertEquals("00000000000000000", gen.next());
-        assertEquals("00000000000000001", gen.next());
-        assertEquals("00000000000000002", gen.next());
-        assertEquals("00000000000000003", gen.next());
-        assertEquals("00000000000000004", gen.next());
-        assertEquals("00000000000000005", gen.next());
-        assertEquals("00000000000000006", gen.next());
-        assertEquals("00000000000000007", gen.next());
-        assertEquals("00000000000000008", gen.next());
-        assertEquals("00000000000000009", gen.next());
-        assertEquals("0000000000000000a", gen.next());
-        assertEquals("0000000000000000b", gen.next());
-        assertEquals("0000000000000000c", gen.next());
-        assertEquals("0000000000000000d", gen.next());
-        assertEquals("0000000000000000e", gen.next());
-        assertEquals("0000000000000000f", gen.next());
+        assertEquals("000000000001", gen.next());
+        assertEquals("000000000002", gen.next());
+        assertEquals("000000000003", gen.next());
+        assertEquals("000000000004", gen.next());
+        assertEquals("000000000005", gen.next());
+        assertEquals("000000000006", gen.next());
+        assertEquals("000000000007", gen.next());
+        assertEquals("000000000008", gen.next());
+        assertEquals("000000000009", gen.next());
+        assertEquals("00000000000a", gen.next());
+        assertEquals("00000000000b", gen.next());
+        assertEquals("00000000000c", gen.next());
+        assertEquals("00000000000d", gen.next());
+        assertEquals("00000000000e", gen.next());
+        assertEquals("00000000000f", gen.next());
 
-        assertEquals("00000000000000010", gen.next());
-        assertEquals("00000000000000011", gen.next());
-        assertEquals("00000000000000012", gen.next());
-        assertEquals("00000000000000013", gen.next());
-        assertEquals("00000000000000014", gen.next());
-        assertEquals("00000000000000015", gen.next());
-        assertEquals("00000000000000016", gen.next());
-        assertEquals("00000000000000017", gen.next());
-        assertEquals("00000000000000018", gen.next());
-        assertEquals("00000000000000019", gen.next());
-        assertEquals("0000000000000001a", gen.next());
-        assertEquals("0000000000000001b", gen.next());
-        assertEquals("0000000000000001c", gen.next());
-        assertEquals("0000000000000001d", gen.next());
-        assertEquals("0000000000000001e", gen.next());
-        assertEquals("0000000000000001f", gen.next());
+        assertEquals("000000000010", gen.next());
+        assertEquals("000000000011", gen.next());
+        assertEquals("000000000012", gen.next());
+        assertEquals("000000000013", gen.next());
+        assertEquals("000000000014", gen.next());
+        assertEquals("000000000015", gen.next());
+        assertEquals("000000000016", gen.next());
+        assertEquals("000000000017", gen.next());
+        assertEquals("000000000018", gen.next());
+        assertEquals("000000000019", gen.next());
+        assertEquals("00000000001a", gen.next());
+        assertEquals("00000000001b", gen.next());
+        assertEquals("00000000001c", gen.next());
+        assertEquals("00000000001d", gen.next());
+        assertEquals("00000000001e", gen.next());
+        assertEquals("00000000001f", gen.next());
 
     }
 }

--- a/features/enlinkd/service/impl/src/main/java/org/opennms/netmgt/enlinkd/service/impl/BridgeTopologyServiceImpl.java
+++ b/features/enlinkd/service/impl/src/main/java/org/opennms/netmgt/enlinkd/service/impl/BridgeTopologyServiceImpl.java
@@ -785,6 +785,10 @@ SEG:        for (SharedSegment segment : bmlsegments) {
 
     @Override
     public List<TopologyShared> match() {
+        // make sure the domains were loaded before calling this method, otherwise we end in a Nullpointer
+        if(m_domains == null){
+            load();
+        }
         final List<TopologyShared> links = new ArrayList<>();
         final List<MacPort> macPortMap = getMacPorts();
         

--- a/features/enlinkd/service/impl/src/main/java/org/opennms/netmgt/enlinkd/service/impl/BridgeTopologyServiceImpl.java
+++ b/features/enlinkd/service/impl/src/main/java/org/opennms/netmgt/enlinkd/service/impl/BridgeTopologyServiceImpl.java
@@ -784,11 +784,7 @@ SEG:        for (SharedSegment segment : bmlsegments) {
     }
 
     @Override
-    public List<TopologyShared> match() {
-        // make sure the domains were loaded before calling this method, otherwise we end in a Nullpointer
-        if(m_domains == null){
-            load();
-        }
+    public List<TopologyShared> match() {       
         final List<TopologyShared> links = new ArrayList<>();
         final List<MacPort> macPortMap = getMacPorts();
         

--- a/features/enlinkd/shell/src/main/java/org/opennms/features/enlinkd/shell/GenerateTopologyCommand.java
+++ b/features/enlinkd/shell/src/main/java/org/opennms/features/enlinkd/shell/GenerateTopologyCommand.java
@@ -41,6 +41,7 @@ import org.opennms.netmgt.enlinkd.api.ReloadableTopologyDaemon;
 
 /**
  * Generate a enlinkd topology via karaf command.
+ * Log into console via: ssh -p 8101 admin@localhost
  * Install: feature:install opennms-enlinkd-shell
  * Usage: type 'enlinkd:generate-topology' in karaf console
  */

--- a/features/enlinkd/shell/src/main/java/org/opennms/features/enlinkd/shell/GenerateTopologyCommand.java
+++ b/features/enlinkd/shell/src/main/java/org/opennms/features/enlinkd/shell/GenerateTopologyCommand.java
@@ -67,7 +67,7 @@ public class GenerateTopologyCommand implements Action {
     @Option(name = "--topology", description = "type of topology (complete | ring | random). Default: random.")
     private String topology;
 
-    @Option(name = "--protocol", description = "type of protocol (cdp | isis | lldp | ospf | bridgeBridge). Default: cdp.")
+    @Option(name = "--protocol", description = "type of protocol (cdp | isis | lldp | ospf | bridge). Default: cdp.")
     private String protocol;
 
     @Reference

--- a/features/enlinkd/shell/src/main/java/org/opennms/features/enlinkd/shell/GenerateTopologyCommand.java
+++ b/features/enlinkd/shell/src/main/java/org/opennms/features/enlinkd/shell/GenerateTopologyCommand.java
@@ -67,7 +67,7 @@ public class GenerateTopologyCommand implements Action {
     @Option(name = "--topology", description = "type of topology (complete | ring | random). Default: random.")
     private String topology;
 
-    @Option(name = "--protocol", description = "type of protocol (cdp | isis | lldp | ospf). Default: cdp.")
+    @Option(name = "--protocol", description = "type of protocol (cdp | isis | lldp | ospf | bridgeBridge). Default: cdp.")
     private String protocol;
 
     @Reference

--- a/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.linkd/pom.xml
+++ b/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.linkd/pom.xml
@@ -148,37 +148,43 @@
       <groupId>org.opennms.features.enlinkd</groupId>
       <artifactId>org.opennms.features.enlinkd.adapters.common</artifactId>
       <version>${project.version}</version>
-          <scope>test</scope>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.opennms.features.enlinkd</groupId>
       <artifactId>org.opennms.features.enlinkd.adapters.updaters.nodes</artifactId>
       <version>${project.version}</version>
-          <scope>test</scope>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.opennms.features.enlinkd</groupId>
       <artifactId>org.opennms.features.enlinkd.adapters.updaters.lldp</artifactId>
       <version>${project.version}</version>
-          <scope>test</scope>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.opennms.features.enlinkd</groupId>
       <artifactId>org.opennms.features.enlinkd.adapters.updaters.cdp</artifactId>
       <version>${project.version}</version>
-          <scope>test</scope>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.opennms.features.enlinkd</groupId>
       <artifactId>org.opennms.features.enlinkd.adapters.updaters.isis</artifactId>
       <version>${project.version}</version>
-          <scope>test</scope>
+      <scope>test</scope>
     </dependency>
         <dependency>
       <groupId>org.opennms.features.enlinkd</groupId>
       <artifactId>org.opennms.features.enlinkd.adapters.updaters.ospf</artifactId>
       <version>${project.version}</version>
-          <scope>test</scope>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.opennms.features.enlinkd</groupId>
+      <artifactId>org.opennms.features.enlinkd.adapters.updaters.bridge</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.opennms.features.enlinkd</groupId>

--- a/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.linkd/src/test/java/org/opennms/features/topology/plugins/topo/linkd/internal/LinkdTopologyProviderTestIT.java
+++ b/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.linkd/src/test/java/org/opennms/features/topology/plugins/topo/linkd/internal/LinkdTopologyProviderTestIT.java
@@ -155,7 +155,7 @@ public class LinkdTopologyProviderTestIT {
     @Test
     @Transactional
     public void testBridgeBridge() throws Exception {
-        test(TopologyGenerator.Protocol.bridgeBridge);
+        test(TopologyGenerator.Protocol.bridge);
     }
 
     private void test(TopologyGenerator.Protocol protocol) throws OnmsTopologyException{

--- a/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.linkd/src/test/java/org/opennms/features/topology/plugins/topo/linkd/internal/LinkdTopologyProviderTestIT.java
+++ b/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.linkd/src/test/java/org/opennms/features/topology/plugins/topo/linkd/internal/LinkdTopologyProviderTestIT.java
@@ -178,7 +178,7 @@ public class LinkdTopologyProviderTestIT {
 
     @Test
     @Transactional
-    public void testBridgeBridge() throws Exception {
+    public void testBridge() throws Exception {
         // The testing of bridge topologies is a bit different than for the other protocols since we have a hierarchical
         // topology with different node types.
 
@@ -193,17 +193,21 @@ public class LinkdTopologyProviderTestIT {
 
         // 2.) map the nodes by it's label name.
         final Map<String, Vertex> vertices = new HashMap<>();
+        final Map<Integer,Vertex> verticesById = new HashMap<>();
         for(Vertex vertex : linkdTopologyProvider.getVerticesWithoutGroups()) {
             String label = vertex.getLabel();
             if("Segment".equals(label)) { // enhance Segment to make it unique
                 label = StringUtils.substringAfter(vertex.getTooltipText(), "nodeid:["); // Shared Segment': nodeid:[13561], bridgeport
                 label = StringUtils.substringBefore(label, "]");
-                label = "Segment[nodeid:"+label+"]";
+                label = verticesById.get(Integer.parseInt(label)).getLabel(); // get label by id of node
+                label = "Segment["+label+"]";
             } else if (label.contains("without node")) {
                 // shared addresses: ([000000000007, 000000000008]ip:[0.0.0.1 ], mac:[000000000005]ip:[0.0.0.2 ], mac:[000000000006])(Unknown/Not an OpenNMS Node)
                 label = StringUtils.substringAfter(vertex.getTooltipText(), "shared addresses: ([");
                 label = StringUtils.substringBefore(label, ",");
                 label = "NoNode["+label+"]";
+            } else {
+                verticesById.put(vertex.getNodeID(), vertex);
             }
             vertices.put(label, vertex);
         }
@@ -218,18 +222,18 @@ public class LinkdTopologyProviderTestIT {
         verifyLinkingBetweenNodes(vertices.get("Node0"), vertices.get("NoNode[000000000007]"));
 
         // Level 1 -> 2
-        verifyLinkingBetweenNodes(vertices.get("Node1"), vertices.get("Segment[nodeid:2]"));
+        verifyLinkingBetweenNodes(vertices.get("Node1"), vertices.get("Segment[Node1]"));
         verifyLinkingBetweenNodes(vertices.get("Node3"), vertices.get("Node8"));
         verifyLinkingBetweenNodes(vertices.get("Node3"), vertices.get("Node9"));
 
         // Level 2 -> 3
-        verifyLinkingBetweenNodes(vertices.get("Segment[nodeid:2]"), vertices.get("NoNode[00000000000e]"));
-        verifyLinkingBetweenNodes(vertices.get("Segment[nodeid:2]"), vertices.get("Node2"));
+        verifyLinkingBetweenNodes(vertices.get("Segment[Node1]"), vertices.get("NoNode[00000000000e]"));
+        verifyLinkingBetweenNodes(vertices.get("Segment[Node1]"), vertices.get("Node2"));
 
         // Level 3 -> 4
-        verifyLinkingBetweenNodes(vertices.get("Node2"), vertices.get("Segment[nodeid:3]"));
-        verifyLinkingBetweenNodes(vertices.get("Segment[nodeid:3]"), vertices.get("Node6"));
-        verifyLinkingBetweenNodes(vertices.get("Segment[nodeid:3]"), vertices.get("Node7"));
+        verifyLinkingBetweenNodes(vertices.get("Node2"), vertices.get("Segment[Node2]"));
+        verifyLinkingBetweenNodes(vertices.get("Segment[Node2]"), vertices.get("Node6"));
+        verifyLinkingBetweenNodes(vertices.get("Segment[Node2]"), vertices.get("Node7"));
 
     }
 

--- a/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.linkd/src/test/java/org/opennms/features/topology/plugins/topo/linkd/internal/LinkdTopologyProviderTestIT.java
+++ b/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.linkd/src/test/java/org/opennms/features/topology/plugins/topo/linkd/internal/LinkdTopologyProviderTestIT.java
@@ -69,8 +69,6 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.transaction.BeforeTransaction;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.google.common.base.Strings;
-
 @RunWith(OpenNMSJUnit4ClassRunner.class)
 @ContextConfiguration(locations={
         "classpath:/META-INF/opennms/applicationContext-soa.xml",

--- a/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.linkd/src/test/java/org/opennms/features/topology/plugins/topo/linkd/internal/LinkdTopologyProviderTestIT.java
+++ b/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.linkd/src/test/java/org/opennms/features/topology/plugins/topo/linkd/internal/LinkdTopologyProviderTestIT.java
@@ -158,9 +158,9 @@ public class LinkdTopologyProviderTestIT {
      *
      *                      bridge0
      *                         |
-     *           ----------------------------------------
-     *           |          |          |        |       |
-     *        bridge1    bridge3    bridge4  bridge5  Macs/Ip
+     *           ------------------------------------------------
+     *           |          |          |        |       |       |
+     *        bridge1    bridge3    bridge4  bridge5  Macs/Ip bridge10
      *           |          |                         no node
      *        -------    --------
      *        |          |      |
@@ -175,7 +175,7 @@ public class LinkdTopologyProviderTestIT {
 
     @Test
     @Transactional
-    public void testBridge() throws Exception {
+    public void testBridge() {
         // The testing of bridge topologies is a bit different than for the other protocols since we have a hierarchical
         // topology with different node types.
 
@@ -217,6 +217,7 @@ public class LinkdTopologyProviderTestIT {
         verifyLinkingBetweenNodes(vertices.get("Node0"), vertices.get("Node4"));
         verifyLinkingBetweenNodes(vertices.get("Node0"), vertices.get("Node5"));
         verifyLinkingBetweenNodes(vertices.get("Node0"), vertices.get("NoNode[000000000007]"));
+        verifyLinkingBetweenNodes(vertices.get("Node0"), vertices.get("Node10"));
 
         // Level 1 -> 2
         verifyLinkingBetweenNodes(vertices.get("Node1"), vertices.get("Segment[Node1]"));

--- a/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.linkd/src/test/java/org/opennms/features/topology/plugins/topo/linkd/internal/LinkdTopologyProviderTestIT.java
+++ b/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.linkd/src/test/java/org/opennms/features/topology/plugins/topo/linkd/internal/LinkdTopologyProviderTestIT.java
@@ -179,9 +179,8 @@ public class LinkdTopologyProviderTestIT {
     @Test
     @Transactional
     public void testBridgeBridge() throws Exception {
-        // The testing of bridge topologies is a bit different thean for the other protocols since we have a hierarchical
+        // The testing of bridge topologies is a bit different than for the other protocols since we have a hierarchical
         // topology with different node types.
-
 
         // 1.) Generate Topology
         TopologySettings settings = TopologySettings.builder()

--- a/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.linkd/src/test/java/org/opennms/features/topology/plugins/topo/linkd/internal/LinkdTopologyProviderTestIT.java
+++ b/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.linkd/src/test/java/org/opennms/features/topology/plugins/topo/linkd/internal/LinkdTopologyProviderTestIT.java
@@ -142,9 +142,16 @@ public class LinkdTopologyProviderTestIT {
         test(TopologyGenerator.Protocol.ospf);
     }
 
-    private void test(TopologyGenerator.Protocol protocol) {
+    private void test(TopologyGenerator.Protocol protocol) throws OnmsTopologyException{
         testAmounts(protocol);
         testLinkingBetweenNodes(protocol);
+    }
+
+    private void test(TopologyGenerator.Protocol protocol) {
+    @Test
+    @Transactional
+    public void testBridgeBridge() throws Exception {
+        test(TopologyGenerator.Protocol.bridgeBridge);
     }
 
     private void testAmounts(TopologyGenerator.Protocol protocol) {

--- a/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.linkd/src/test/java/org/opennms/features/topology/plugins/topo/linkd/internal/LinkdTopologyProviderTestIT.java
+++ b/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.linkd/src/test/java/org/opennms/features/topology/plugins/topo/linkd/internal/LinkdTopologyProviderTestIT.java
@@ -61,7 +61,6 @@ import org.opennms.netmgt.enlinkd.NodesOnmsTopologyUpdater;
 import org.opennms.netmgt.enlinkd.OspfOnmsTopologyUpdater;
 import org.opennms.netmgt.enlinkd.persistence.api.TopologyEntityCache;
 import org.opennms.netmgt.enlinkd.service.api.BridgeTopologyService;
-import org.opennms.netmgt.topologies.service.api.OnmsTopologyException;
 import org.opennms.test.JUnitConfigurationEnvironment;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -237,7 +236,7 @@ public class LinkdTopologyProviderTestIT {
 
     }
 
-    private void test(TopologyGenerator.Protocol protocol) throws OnmsTopologyException{
+    private void test(TopologyGenerator.Protocol protocol) {
         testAmounts(protocol);
         testLinkingBetweenNodes(protocol);
     }

--- a/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.linkd/src/test/resources/META-INF/opennms/applicationContext-LinkdTopologyProviderTestIT.xml
+++ b/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.linkd/src/test/resources/META-INF/opennms/applicationContext-LinkdTopologyProviderTestIT.xml
@@ -67,6 +67,18 @@
         <property name="sessionFactory" ref="sessionFactory" />
     </bean>
 
+    <bean id="bridgeBridgeLinkDao" class="org.opennms.netmgt.enlinkd.persistence.impl.BridgeBridgeLinkDaoHibernate">
+        <property name="sessionFactory" ref="sessionFactory" />
+    </bean>
+
+    <bean id="bridgeMacLinkDao" class="org.opennms.netmgt.enlinkd.persistence.impl.BridgeMacLinkDaoHibernate">
+        <property name="sessionFactory" ref="sessionFactory" />
+    </bean>
+
+    <bean id="bridgeElementDao" class="org.opennms.netmgt.enlinkd.persistence.impl.BridgeElementDaoHibernate">
+        <property name="sessionFactory" ref="sessionFactory" />
+    </bean>
+
     <bean id="cdpElementDao" class="org.opennms.netmgt.enlinkd.persistence.impl.CdpElementDaoHibernate">
         <property name="sessionFactory" ref="sessionFactory" />
     </bean>
@@ -95,6 +107,10 @@
         <property name="sessionFactory" ref="sessionFactory" />
     </bean>
 
+    <bean id="ipNetToMediaDao" class="org.opennms.netmgt.enlinkd.persistence.impl.IpNetToMediaDaoHibernate">
+        <property name="sessionFactory" ref="sessionFactory" />
+    </bean>
+
     <bean id="metricRegistry" class="com.codahale.metrics.MetricRegistry" />
 
     <bean id="onmsTopologyDao" class="org.opennms.netmgt.topologies.service.impl.OnmsTopologyDaoInMemoryImpl"/>
@@ -111,7 +127,15 @@
       <property name="nodeDao" ref="nodeDao" />
       <property name="topologyEntityCache" ref="topologyEntityCache" />
     </bean>
-        
+
+    <bean id="bridgeTopologyService" class="org.opennms.netmgt.enlinkd.service.impl.BridgeTopologyServiceImpl">
+        <property name="topologyEntityCache" ref="topologyEntityCache" />
+        <property name="bridgeBridgeLinkDao" ref="bridgeBridgeLinkDao" />
+        <property name="bridgeElementDao" ref="bridgeElementDao" />
+        <property name="bridgeMacLinkDao" ref="bridgeMacLinkDao" />
+        <property name="ipNetToMediaDao" ref="ipNetToMediaDao" />
+    </bean>
+
    <bean id="cdpTopologyService" class="org.opennms.netmgt.enlinkd.service.impl.CdpTopologyServiceImpl">
       <property name="topologyEntityCache" ref="topologyEntityCache" />
       <property name="cdpLinkDao" ref="cdpLinkDao" />
@@ -135,6 +159,12 @@
       <property name="ospfLinkDao" ref="ospfLinkDao" />
       <property name="ospfElementDao" ref="ospfElementDao" />
    </bean>
+
+    <bean id ="bridgeOnmsTopologyUpdater" class="org.opennms.netmgt.enlinkd.BridgeOnmsTopologyUpdater">
+        <constructor-arg ref="onmsTopologyDao" />
+        <constructor-arg ref="bridgeTopologyService" />
+        <constructor-arg ref="nodeTopologyService" />
+    </bean>
 
 	<bean id ="nodesOnmsTopologyUpdater" class="org.opennms.netmgt.enlinkd.NodesOnmsTopologyUpdater">
 		<constructor-arg ref="onmsTopologyDao" />


### PR DESCRIPTION

*  JIRA: https://issues.opennms.org/browse/HZN-1475

Our continuous integration system will test and verify your changes.

Replaces https://github.com/OpenNMS/opennms/pull/2368

What is in this PR?

* Enhancement of the topology generator by the protocol "bridge". The bridge protocol is a bit different in that it contains multiple node types. The generator builds a tree consisting of hosts, bridges, segments and" Mac/IpAdresses on Segment without node". The tree is repeated depending on the amount of nodes (multiple of 10).
* The generated tree is tested in LinkdTopologyProviderTestIT.testBridge()
* I introduced a "BridgeBuilder" that allows for easier generating of such topologies. It is sufficient for my use case but could be enhanced in the future. It tries to abstract the low level stitching together of the different database entries.

Thanks again to @rssntn67 who provided me with a working example and lots of explanation.