### PR TITLE
NMS-10606: hwEntity not mapped to hwEntityAlias

### DIFF
--- a/integrations/opennms-snmp-hardware-inventory-provisioning-adapter/pom.xml
+++ b/integrations/opennms-snmp-hardware-inventory-provisioning-adapter/pom.xml
@@ -50,6 +50,11 @@
     </dependency>
     <!-- test dependencies -->
     <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-library</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.opennms</groupId>
       <artifactId>opennms-dao-mock</artifactId>
       <scope>test</scope>

--- a/integrations/opennms-snmp-hardware-inventory-provisioning-adapter/src/main/java/org/opennms/netmgt/provision/SnmpHardwareInventoryProvisioningAdapter.java
+++ b/integrations/opennms-snmp-hardware-inventory-provisioning-adapter/src/main/java/org/opennms/netmgt/provision/SnmpHardwareInventoryProvisioningAdapter.java
@@ -299,6 +299,9 @@ public class SnmpHardwareInventoryProvisioningAdapter extends SimplerQueuedProvi
         SortedSet<OnmsHwEntityAlias> aliases = aliasMap.get(entity.getEntPhysicalIndex());
         if (aliases != null) {
             entity.setEntAliases(aliases);
+            for (OnmsHwEntityAlias alias : aliases) {
+                alias.setHwEntity(entity);
+            }
         }
     }
 

--- a/integrations/opennms-snmp-hardware-inventory-provisioning-adapter/src/test/java/org/opennms/netmgt/provision/HwEntityAliasIT.java
+++ b/integrations/opennms-snmp-hardware-inventory-provisioning-adapter/src/test/java/org/opennms/netmgt/provision/HwEntityAliasIT.java
@@ -28,12 +28,12 @@
 
 package org.opennms.netmgt.provision;
 
-import java.io.FileWriter;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.opennms.core.spring.BeanUtils;
@@ -42,13 +42,11 @@ import org.opennms.core.test.OpenNMSJUnit4ClassRunner;
 import org.opennms.core.test.db.annotations.JUnitTemporaryDatabase;
 import org.opennms.core.test.snmp.annotations.JUnitSnmpAgent;
 import org.opennms.core.test.snmp.annotations.JUnitSnmpAgents;
-import org.opennms.core.xml.JaxbUtils;
-import org.opennms.netmgt.config.hardware.HwExtension;
-import org.opennms.netmgt.config.hardware.HwInventoryAdapterConfiguration;
 import org.opennms.netmgt.dao.api.HwEntityDao;
 import org.opennms.netmgt.dao.api.NodeDao;
 import org.opennms.netmgt.model.NetworkBuilder;
 import org.opennms.netmgt.model.OnmsHwEntity;
+import org.opennms.netmgt.model.OnmsHwEntityAlias;
 import org.opennms.netmgt.provision.SnmpHardwareInventoryProvisioningAdapter;
 import org.opennms.netmgt.provision.SimpleQueuedProvisioningAdapter.AdapterOperation;
 import org.opennms.netmgt.provision.SimpleQueuedProvisioningAdapter.AdapterOperationSchedule;
@@ -61,6 +59,11 @@ import org.springframework.test.context.transaction.AfterTransaction;
 import org.springframework.test.context.transaction.BeforeTransaction;
 import org.springframework.transaction.annotation.Transactional;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 /**
  * The Test Class for SnmpHardwareInventoryProvisioningAdapter.
  * 
@@ -121,8 +124,8 @@ public class HwEntityAliasIT implements InitializingBean {
     @Autowired
     private HwEntityDao m_entityDao;
 
-    /** The operations. */
-    private List<TestOperation> m_operations = new ArrayList<>();
+    /** The operation. */
+    private TestOperation testOperation;
 
     /* (non-Javadoc)
      * @see org.springframework.beans.factory.InitializingBean#afterPropertiesSet()
@@ -153,8 +156,8 @@ public class HwEntityAliasIT implements InitializingBean {
 
         Integer nodeId = m_nodeDao.findByForeignId("Cisco", Integer.toString(1)).getId();
         AdapterOperationSchedule ops = new AdapterOperationSchedule(0, 1, 1, TimeUnit.SECONDS);
-        AdapterOperation op = m_adapter.new AdapterOperation(nodeId, AdapterOperationType.ADD, ops);
-        m_operations.add(new TestOperation(nodeId, op));
+        AdapterOperation adapterOperation = m_adapter.new AdapterOperation(nodeId, AdapterOperationType.ADD, ops);
+        testOperation = new TestOperation(nodeId, adapterOperation);
     }
 
     /**
@@ -175,38 +178,30 @@ public class HwEntityAliasIT implements InitializingBean {
     @Test
     @Transactional
     public void testDiscoverSnmpEntities() throws Exception {
-        HwInventoryAdapterConfiguration config = m_adapter.getHwAdapterConfigDao().getConfiguration();
-        Assert.assertEquals(3, config.getExtensions().size());
-        Assert.assertEquals(5, config.getExtensions().get(0).getMibObjects().size());
-        Assert.assertEquals(12, config.getExtensions().get(1).getMibObjects().size());
-        Assert.assertEquals(10, config.getExtensions().get(2).getMibObjects().size());
+        m_adapter.processPendingOperationForNode(testOperation.operation);
 
-        HwExtension ext = config.getExtensions().get(0);
-        Assert.assertEquals("CISCO-ENTITY-EXT-MIB", ext.getName());
-        Assert.assertEquals(5, ext.getMibObjects().size());
+        OnmsHwEntity root = m_entityDao.findRootByNodeId(testOperation.nodeId);
+        assertThat(root, is(notNullValue()));
+        assertThat(root.isRoot(), is(true));
 
-        ext = config.getExtensions().get(1);
-        Assert.assertEquals("CISCO-ENTITY-ASSET-MIB", ext.getName());
-        Assert.assertEquals(12, ext.getMibObjects().size());
+        m_nodeDao.flush();
+        m_entityDao.flush();
 
-        Assert.assertEquals(27, m_adapter.getVendorAttributeMap().size());
-
-        for (TestOperation op : m_operations) {
-            m_adapter.processPendingOperationForNode(op.operation);
-
-            OnmsHwEntity root = m_entityDao.findRootByNodeId(op.nodeId);
-            Assert.assertNotNull(root);
-            Assert.assertTrue(root.isRoot());
-            FileWriter w = new FileWriter("target/" + op.nodeId + ".xml");
-            JaxbUtils.marshal(root, w);
-            w.close();
-
-            m_nodeDao.flush();
-            m_entityDao.flush();
+        List<OnmsHwEntityAlias> aliases = new ArrayList<>();
+        for (OnmsHwEntity entity : m_entityDao.findAll()) {
+            Set<OnmsHwEntityAlias> entAliases = entity.getEntAliases();
+            if (entAliases != null && !entAliases.isEmpty()) {
+                aliases.addAll(entAliases);
+            }
         }
 
-        // TODO - hwEntityAlias assertions
-        Assert.assertEquals(18, m_entityDao.countAll());
+        assertThat(aliases, hasSize(4));
+
+        List<String> aliasOids = aliases.stream().map(a -> a.getOid()).collect(Collectors.toList());
+        assertThat(aliasOids, hasItem(".1.3.6.1.2.1.2.2.1.1.10101"));
+        assertThat(aliasOids, hasItem(".1.3.6.1.2.1.2.2.1.1.10102"));
+        assertThat(aliasOids, hasItem(".1.3.6.1.2.1.2.2.1.1.10104"));
+        assertThat(aliasOids, hasItem(".1.3.6.1.2.1.2.2.1.1.10502"));
     }
 
 }

--- a/integrations/opennms-snmp-hardware-inventory-provisioning-adapter/src/test/java/org/opennms/netmgt/provision/HwEntityAliasIT.java
+++ b/integrations/opennms-snmp-hardware-inventory-provisioning-adapter/src/test/java/org/opennms/netmgt/provision/HwEntityAliasIT.java
@@ -81,13 +81,9 @@ import org.springframework.transaction.annotation.Transactional;
 @JUnitConfigurationEnvironment
 @JUnitTemporaryDatabase
 @JUnitSnmpAgents(value={
-        @JUnitSnmpAgent(host = "192.168.0.1", resource = "entPhysicalTable-cisco-r1.properties"),
-        @JUnitSnmpAgent(host = "192.168.0.2", resource = "entPhysicalTable-cisco-r2.properties"),
-        @JUnitSnmpAgent(host = "192.168.0.3", resource = "entPhysicalTable-cisco-r3.properties"),
-        @JUnitSnmpAgent(host = "192.168.0.4", resource = "entPhysicalTable-cisco-r4.properties"),
-        @JUnitSnmpAgent(host = "192.168.0.5", resource = "NMS-8506-cisco.properties")
+        @JUnitSnmpAgent(host = "192.168.0.1", resource = "NMS-8506-cisco.properties")
 })
-public class SnmpHardwareInventoryProvisioningAdapterIT implements InitializingBean {
+public class HwEntityAliasIT implements InitializingBean {
 
     /**
      * The Class TestOperation.
@@ -151,32 +147,14 @@ public class SnmpHardwareInventoryProvisioningAdapterIT implements InitializingB
         nb.addInterface("192.168.0.1").setIsSnmpPrimary("P").setIsManaged("P");
         m_nodeDao.save(nb.getCurrentNode());
 
-        nb.addNode("R2").setForeignSource("Cisco").setForeignId("2").setSysObjectId(".1.3.6.1.4.1.9.1.222");
-        nb.addInterface("192.168.0.2").setIsSnmpPrimary("P").setIsManaged("P");
-        m_nodeDao.save(nb.getCurrentNode());
-
-        nb.addNode("R3").setForeignSource("Cisco").setForeignId("3").setSysObjectId(".1.3.6.1.4.1.9.1.222");
-        nb.addInterface("192.168.0.3").setIsSnmpPrimary("P").setIsManaged("P");
-        m_nodeDao.save(nb.getCurrentNode());
-
-        nb.addNode("R4").setForeignSource("Cisco").setForeignId("4").setSysObjectId(".1.3.6.1.4.1.9.1.222");
-        nb.addInterface("192.168.0.4").setIsSnmpPrimary("P").setIsManaged("P");
-        m_nodeDao.save(nb.getCurrentNode());
-
-        nb.addNode("R5").setForeignSource("Cisco").setForeignId("5").setSysObjectId(".1.3.6.1.4.1.9.1.222");
-        nb.addInterface("192.168.0.5").setIsSnmpPrimary("P").setIsManaged("P");
-        m_nodeDao.save(nb.getCurrentNode());
-
         m_nodeDao.flush();
 
         m_adapter.afterPropertiesSet();
 
-        for (int i=1; i<=5; i++) {
-            Integer nodeId = m_nodeDao.findByForeignId("Cisco", Integer.toString(i)).getId();
-            AdapterOperationSchedule ops = new AdapterOperationSchedule(0, 1, 1, TimeUnit.SECONDS);        
-            AdapterOperation op = m_adapter.new AdapterOperation(nodeId, AdapterOperationType.ADD, ops);
-            m_operations.add(new TestOperation(nodeId, op));
-        }
+        Integer nodeId = m_nodeDao.findByForeignId("Cisco", Integer.toString(1)).getId();
+        AdapterOperationSchedule ops = new AdapterOperationSchedule(0, 1, 1, TimeUnit.SECONDS);
+        AdapterOperation op = m_adapter.new AdapterOperation(nodeId, AdapterOperationType.ADD, ops);
+        m_operations.add(new TestOperation(nodeId, op));
     }
 
     /**
@@ -227,7 +205,8 @@ public class SnmpHardwareInventoryProvisioningAdapterIT implements InitializingB
             m_entityDao.flush();
         }
 
-        Assert.assertEquals(130, m_entityDao.countAll());
+        // TODO - hwEntityAlias assertions
+        Assert.assertEquals(18, m_entityDao.countAll());
     }
 
 }

--- a/opennms-base-assembly/src/main/filtered/etc/create.sql
+++ b/opennms-base-assembly/src/main/filtered/etc/create.sql
@@ -2280,7 +2280,7 @@ create unique index hwEntityAttribute_unique_idx on hwEntityAttribute(hwEntityId
 
 create table hwEntityAlias (
     id          integer default nextval('opennmsNxtId') not null,
-    hwEntityId  integer ,
+    hwEntityId  integer not null,
     index       integer not null,
     oid         text not null,
     constraint pk_hwentityalias PRIMARY KEY (id),


### PR DESCRIPTION
This PR fixes an issue where entitites were not mapped to the hwEntityAliases (the reverse mapping was done but both directions are required).
This bug escaped due to a bug in the create.sql code used during integration test. That issue is also addressed here.
Additionally, a configuration with hwEnetityAliases was added to an existing test and a new test with explicit hwEnetityAlias assertions is added.

* JIRA: https://issues.opennms.org/browse/NMS-10606
