### PR TITLE
HZN-1478: Upgrade Apache CXF to 3.2.8

### DIFF
--- a/container/features/src/main/resources/features.xml
+++ b/container/features/src/main/resources/features.xml
@@ -695,7 +695,7 @@
         <bundle>mvn:org.opennms.features.events/org.opennms.features.events.traps/${project.version}</bundle>
     </feature>
     <feature name="tsrm-troubleticketer" version="${project.version}" description="OpenNMS :: Features :: Ticketing :: Tivoli Service Request Manager (TSRM)">
-        <feature version="3.1.11">cxf-jaxws</feature>
+        <feature version="${cxfVersion}">cxf-jaxws</feature>
         <feature>javax.servlet</feature>
         <bundle>mvn:org.opennms.features.ticketing/org.opennms.features.ticketing.api/${project.version}</bundle>
         <bundle>mvn:org.opennms.features/opennms-integration-tsrm/${project.version}</bundle>

--- a/features/minion/repository/pom.xml
+++ b/features/minion/repository/pom.xml
@@ -59,6 +59,7 @@
                                 <feature>minion-icmp-proxy</feature>
                                 <feature>minion-telemetryd-receivers</feature>
                                 <feature>hawtio-offline</feature>
+				<feature>cxf-commands/${cxfVersion}</feature>
                             </features>
                             <repository>${project.build.directory}/maven-repo</repository>
                         </configuration>
@@ -305,6 +306,12 @@
             <groupId>org.opennms.protocols</groupId>
             <artifactId>org.opennms.protocols.xml</artifactId>
             <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.cxf.karaf</groupId>
+            <artifactId>cxf-karaf-commands</artifactId>
+            <version>${cxfVersion}</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/features/ticketing/otrs-integration-31/pom.xml
+++ b/features/ticketing/otrs-integration-31/pom.xml
@@ -114,6 +114,10 @@
 			<version>${cxfXjcVersion}</version>
 			<exclusions>
 				<exclusion>
+					<groupId>jakarta.xml.bind</groupId>
+					<artifactId>jakarta.xml.bind-api</artifactId>
+				</exclusion>
+				<exclusion>
 					<groupId>javax.xml.bind</groupId>
 					<artifactId>jaxb-api</artifactId>
 				</exclusion>

--- a/features/ticketing/tsrm-integration/pom.xml
+++ b/features/ticketing/tsrm-integration/pom.xml
@@ -15,6 +15,18 @@
 				<groupId>org.apache.cxf</groupId>
 				<artifactId>cxf-codegen-plugin</artifactId>
 				<version>${cxfVersion}</version>
+                                <dependencies>
+                                   <dependency>
+                                      <groupId>com.sun.xml.bind</groupId>
+                                      <artifactId>jaxb-impl</artifactId>
+                                      <version>2.2.11</version>
+                                   </dependency>
+                                   <dependency>
+                                      <groupId>com.sun.xml.bind</groupId>
+                                      <artifactId>jaxb-xjc</artifactId>
+                                      <version>2.2.11</version>
+                                   </dependency>
+                                </dependencies>
 				<executions>
 					<execution>
 						<id>generate-sources</id>

--- a/features/ticketing/tsrm-integration/pom.xml
+++ b/features/ticketing/tsrm-integration/pom.xml
@@ -122,6 +122,10 @@
 			<version>${cxfXjcVersion}</version>
 			<exclusions>
 				<exclusion>
+					<groupId>jakarta.xml.bind</groupId>
+					<artifactId>jakarta.xml.bind-api</artifactId>
+				</exclusion>
+				<exclusion>
 					<groupId>javax.xml.bind</groupId>
 					<artifactId>jaxb-api</artifactId>
 				</exclusion>

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/EventRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/EventRestService.java
@@ -37,10 +37,8 @@ import java.util.Set;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
-import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import javax.ws.rs.core.SecurityContext;
 import javax.ws.rs.core.UriInfo;
 
 import org.apache.cxf.jaxrs.ext.search.SearchBean;
@@ -52,8 +50,8 @@ import org.opennms.netmgt.dao.api.EventDao;
 import org.opennms.netmgt.model.OnmsEvent;
 import org.opennms.netmgt.xml.event.Event;
 import org.opennms.web.rest.mapper.v2.EventMapper;
-import org.opennms.web.rest.model.v2.EventDTO;
 import org.opennms.web.rest.model.v2.EventCollectionDTO;
+import org.opennms.web.rest.model.v2.EventDTO;
 import org.opennms.web.rest.support.Aliases;
 import org.opennms.web.rest.support.CriteriaBehavior;
 import org.opennms.web.rest.support.CriteriaBehaviors;
@@ -171,16 +169,28 @@ public class EventRestService extends AbstractDaoRestServiceWithDTO<OnmsEvent,Ev
         return getDao().get(id);
     }
 
+    /**
+     * NOTE: This method defines an unused parameter of 0 length in the @Path annotation
+     * in order to get CXF to prioritize this method definition instead of the create method
+     * defined in the parent class.
+     *
+     * We cannot simply override the parent method, since the class types are different:
+     * we want to receive a {@link org.opennms.netmgt.xml.event.Event} whereas the parent class
+     * receives a {@link  org.opennms.netmgt.model.OnmsEvent}.
+     *
+     * @param event the event to forward
+     * @return a response containing "no content" (204) when the event was succesfully forwarded
+     */
     @POST
+    @Path("{tiebreaker: $}")
     @Consumes({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
-    public Response create(@Context final SecurityContext securityContext, @Context final UriInfo uriInfo, Event event) {
+    public Response create(Event event) {
         if (event.getTime() == null) event.setTime(new Date());
         if (event.getSource() == null) event.setSource("ReST");
 
         sendEvent(event);
         return Response.noContent().build();
     }
-
 
     @Override
     public EventDTO mapEntityToDTO(OnmsEvent entity) {

--- a/pom.xml
+++ b/pom.xml
@@ -1264,8 +1264,8 @@
     <commonsValidatorVersion>1.6</commonsValidatorVersion>
     <c3p0Version>0.9.5.2</c3p0Version>
     <curatorVersion>3.2.1</curatorVersion>
-    <cxfVersion>3.1.11</cxfVersion>
-    <cxfXjcVersion>3.1.0</cxfXjcVersion>
+    <cxfVersion>3.2.8</cxfVersion>
+    <cxfXjcVersion>3.3.0</cxfXjcVersion>
     <dhcp4javaVersion>1.1.0</dhcp4javaVersion>
     <dnsjavaVersion>2.1.3</dnsjavaVersion>
     <dropwizardMetricsVersion>3.1.2</dropwizardMetricsVersion>
@@ -3619,7 +3619,7 @@
       <dependency>
         <groupId>javax.ws.rs</groupId>
         <artifactId>javax.ws.rs-api</artifactId>
-        <version>2.0.1</version>
+        <version>2.1.1</version>
       </dependency>
       <dependency>
         <groupId>javax.websocket</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1337,7 +1337,7 @@
     <osgiEnterpriseVersion>5.0.0</osgiEnterpriseVersion>
     <owaspEncoderVersion>1.2.1</owaspEncoderVersion>
     <owaspHtmlSanitizerVersion>20170515.1</owaspHtmlSanitizerVersion>
-    <osgiJaxRsVersion>1.0.1-SNAPSHOT</osgiJaxRsVersion>
+    <osgiJaxRsVersion>1.0.2-SNAPSHOT</osgiJaxRsVersion>
     <opencsvVersion>2.3</opencsvVersion>
     <quartzVersion>2.2.3</quartzVersion>
     <rateLimitedLoggerVersion>1.1.0</rateLimitedLoggerVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -1337,7 +1337,7 @@
     <osgiEnterpriseVersion>5.0.0</osgiEnterpriseVersion>
     <owaspEncoderVersion>1.2.1</owaspEncoderVersion>
     <owaspHtmlSanitizerVersion>20170515.1</owaspHtmlSanitizerVersion>
-    <osgiJaxRsVersion>1.0.0-ONMS</osgiJaxRsVersion>
+    <osgiJaxRsVersion>1.0.1-SNAPSHOT</osgiJaxRsVersion>
     <opencsvVersion>2.3</opencsvVersion>
     <quartzVersion>2.2.3</quartzVersion>
     <rateLimitedLoggerVersion>1.1.0</rateLimitedLoggerVersion>


### PR DESCRIPTION
Here we migrate to Apache CXF to 3.2.8.
Most changes were made to the osgi-jax-rs-connector project.
Technically we now require Java 9 to run. 
However I made it work temporarily with Java 8.
Before we release 24.0.0 we should make Java 9 the requirement

We should also consider upgrading the maven-bundle-plugin to the latest version. That version also determines the required java runtime environment for each bundle.

* jira: https://issues.opennms.org/browse/HZN-1478

