### PR TITLE
LTS-231: backport usermode ping fixes from the 24 branch

### DIFF
--- a/opennms-assemblies/minion/pom.xml
+++ b/opennms-assemblies/minion/pom.xml
@@ -105,7 +105,7 @@
                   <classifier>daemon</classifier>
                   <type>tar.gz</type>
                   <outputDirectory>${project.build.directory}/unpacked/base-assembly</outputDirectory>
-                  <includes>bin/find-java.sh</includes>
+                  <includes>bin/find-java.sh,bin/ensure-user-ping.sh</includes>
                 </artifactItem>
               </artifactItems>
             </configuration>

--- a/opennms-assemblies/minion/src/main/filtered/etc/minion.init
+++ b/opennms-assemblies/minion/src/main/filtered/etc/minion.init
@@ -13,10 +13,8 @@
 # Default-Start:     2 3 4 5
 # Default-Stop:      0 1 6
 # Short-Description: OpenNMS Minion
-# Description:       Distributed client for OpenNMS
+# Description:       OpenNMS Minion in a Karaf Container
 ### END INIT INFO
-
-ME="$0"
 
 NAME="minion"
 DESC="Minion"
@@ -26,6 +24,7 @@ SYSCONFDIR="@SYSCONFDIR@"
 RUNAS=root
 STOP_RETRIES=10
 STOP_WAIT=5
+PING_REQUIRED=FALSE
 
 export NAME DESC PATH
 
@@ -73,36 +72,27 @@ DEFAULT_JAVA_OPTS="${DEFAULT_JAVA_OPTS} -XX:+HeapDumpOnOutOfMemoryError"
 # combine user JAVA_OPTS with the defaults from Karaf
 JAVA_OPTS="${DEFAULT_JAVA_OPTS} ${JAVA_OPTS}"
 
-validate_icmp() {
-	if [ "$RUNAS" != "root" ]; then
-		if [ "$(uname -s)" = "Linux" ]; then
-			# validate that we have permissions to ping as non-root
-			_group_range="$(sysctl net.ipv4.ping_group_range 2>/dev/null | cut -d= -f2 | sed -e 's,^ *,,' -e 's, *$,,' -e 's,\t, ,g')"
-			if [ -n "${_group_range}" ]; then
-				_group_range_start="$(echo "${_group_range}" | cut -d' ' -f1)"
-				_group_range_end="$(echo "${_group_range}" | cut -d' ' -f2)"
-				_minion_group="$(id -g minion)"
-				if [ -z "${_minion_group}" ]; then
-					>&2 printf 'ERROR: minion group does not exist!'
-					exit 6 # program is not configured
-				fi
-				if [ "${_minion_group}" -lt "${_group_range_start}" ]; then
-					>&2 printf 'ERROR: minion gid %d is not in the range of valid groups for ping (%d-%d)\n' "${_minion_group}" "${_group_range_start}" "${_group_range_end}"
-					exit 4 # insufficient privilege
-				elif [ "${_minion_group}" -gt "${_group_range_end}" ]; then
-					>&2 printf 'ERROR: minion gid %d is not in the range of valid groups for ping (%d-%d)\n' "${_minion_group}" "${_group_range_start}" "${_group_range_end}"
-					exit 4 # insufficient privilege
-				fi
-			else
-				# shellcheck disable=SC2016
-				>&2 printf 'ERROR: `sysctl net.ipv4.ping_group_range` gave no output! Unable to validate non-root ping support.\n'
-			fi
+# export any default configurable variables from sysconf
+export RUNAS JAVA_MIN_MEM JAVA_MAX_MEM MAX_FD JAVA_HOME JAVA JAVA_DEBUG_OPTS JAVA_DEBUG_PORT JAVA_OPTS CLASSPATH KARAF_DEBUG LD_LIBRARY_PATH
+
+# export any local configurable variables
+export NAME DESC PATH MINION_HOME SYSCONFDIR STOP_RETRIES STOP_WAIT
+
+run_as() {
+	if [ "$(id -n -u)" "!=" "$RUNAS" ]; then
+		DAEMON="$(daemon --user="$RUNAS" true >/dev/null 2>&1 && command -v daemon)"
+		RUNUSER="$(runuser -u "$RUNAS" true 2>/dev/null && command -v runuser)"
+		if [ -n "$DAEMON" ]; then
+			"$DAEMON" --user="$RUNAS" "$@" >/dev/null 2>&1
+		elif [ -n "$RUNUSER" ] && [ -x "$RUNUSER" ]; then
+			"$RUNUSER" -u "$RUNAS" "$@"
+		else
+			/usr/bin/sudo -u "$RUNAS" "$@"
 		fi
+	else
+		"$@"
 	fi
 }
-
-# export any default configurable variables from sysconf
-export JAVA_HOME JAVA_MIN_MEM JAVA_MAX_MEM MAX_FD JAVA JAVA_DEBUG_OPTS JAVA_DEBUG_PORT JAVA_OPTS CLASSPATH KARAF_DEBUG LD_LIBRARY_PATH
 
 get_root_pid() {
 	ROOT_INSTANCE_PID=0
@@ -123,7 +113,7 @@ is_running() {
 }
 
 stop_minion() {
-	"$MINION_HOME"/bin/stop >/dev/null
+	run_as "$MINION_HOME"/bin/stop >/dev/null
 }
 
 kill_minion() {
@@ -140,15 +130,6 @@ kill_minion() {
 
 COMMAND="$1"
 
-if [ "$(id -n -u)" "!=" "${RUNAS}" ]; then
-	RUNUSER="$(which runuser 2>/dev/null)"
-	if [ -n "${RUNUSER}" ] && [ -x "${RUNUSER}" ]; then
-		exec "${RUNUSER}" -u "${RUNAS}" "${ME}" "$@"
-	else
-		exec /usr/bin/sudo -u "${RUNAS}" "${ME}" "$@"
-	fi
-fi
-
 case "$COMMAND" in
 
 	start)
@@ -157,11 +138,21 @@ case "$COMMAND" in
 			exit 0
 		fi
 
-		validate_icmp
+		case "$PING_REQUIRED" in
+			[Tt][Rr][Uu][Ee])
+				# LSB 4 = insufficient privilege
+				"${MINION_HOME}/bin/ensure-user-ping.sh" "$RUNAS" || exit 4
+				;;
+			*)
+				QUIET=true "${MINION_HOME}/bin/ensure-user-ping.sh" "$RUNAS" || :
+				;;
+		esac
+
 		if [ ! -d "${MINION_HOME}/data/tmp" ]; then
-			mkdir -p "${MINION_HOME}/data/tmp"
+			install -d -m 755 "${MINION_HOME}/data/tmp"
+			chown -R "$RUNAS:$RUNAS" "${MINION_HOME}/data"
 		fi
-		"$MINION_HOME"/bin/start
+		run_as "$MINION_HOME"/bin/start
 		exit $?
 		;;
 
@@ -169,7 +160,7 @@ case "$COMMAND" in
 		if is_running; then
 			printf "Stopping %s: " "$DESC"
 			STOP_ATTEMPTS=0
-			while [ $STOP_ATTEMPTS -lt $STOP_RETRIES ]; do
+			while [ "$STOP_ATTEMPTS" -lt "$STOP_RETRIES" ]; do
 				stop_minion
 				if is_running; then
 					STOP_ATTEMPTS="$((STOP_ATTEMPTS + 1))"
@@ -228,7 +219,7 @@ case "$COMMAND" in
 		;;
 
 	status)
-		"$MINION_HOME"/bin/status >/dev/null
+		run_as "$MINION_HOME"/bin/status >/dev/null
 		RETVAL="$?"
 		if [ $RETVAL -eq 0 ]; then
 			echo "$DESC is running."

--- a/opennms-base-assembly/src/main/filtered/bin/ensure-user-ping.sh
+++ b/opennms-base-assembly/src/main/filtered/bin/ensure-user-ping.sh
@@ -1,0 +1,110 @@
+#!/bin/sh -e
+
+PING_USER="$1"
+
+log_error() {
+	case "$QUIET" in
+		1|[Tt][Rr][Uu][Ee])
+			# do nothing in quiet mode
+			;;
+		*)
+			# shellcheck disable=SC2059
+			>&2 printf "$@"
+			;;
+	esac
+}
+
+fail() {
+	log_error "$@"
+	exit 1
+}
+
+if [ "$(id -u)" -gt 0 ]; then
+	fail 'You must run this script as root!\n'
+fi
+
+if [ -z "$PING_USER" ]; then
+	fail 'usage: %s <user>\n' "$0"
+fi
+
+PING_USER_UID="$(id -u "${PING_USER}")"
+PING_USER_GID="$(id -g "${PING_USER}")"
+
+# root has ping permission implicitly
+if [ "${PING_USER_UID}" -eq 0 ]; then
+	exit 0
+fi
+
+# this script only applies to Linux
+if [ "$(uname -s)" != "Linux" ]; then
+	exit 0
+fi
+
+get_group_range() {
+	_group_range="$( (sysctl net.ipv4.ping_group_range 2>/dev/null || :) | cut -d= -f2 | sed -e 's,^ *,,' -e 's, *$,,' -e 's,\t, ,g')"
+	if [ -n "${_group_range}" ]; then
+		echo "${_group_range}"
+	else
+		# shellcheck disable=SC2016
+		fail 'ERROR: `sysctl net.ipv4.ping_group_range` gave no output! Unable to validate non-root ping support.\n'
+	fi
+}
+
+get_group_start() {
+	_group_range="$(get_group_range)"
+	_group_range_start="$(echo "${_group_range}" | cut -d' ' -f1)"
+	if [ -n "${_group_range_start}" ]; then
+		echo "${_group_range_start}"
+	else
+		fail 'Unable to determine group range start from "%s".\n' "${_group_range}"
+	fi
+}
+
+get_group_end() {
+	_group_range="$(get_group_range)"
+	_group_range_end="$(echo "${_group_range}" | cut -d' ' -f2)"
+	if [ -n "${_group_range_end}" ]; then
+		echo "${_group_range_end}"
+	else
+		fail 'Unable to determine group range end from "%s".\n' "${_group_range}"
+	fi
+}
+
+validate_permissions() {
+	group_start="$(get_group_start)"
+	group_end="$(get_group_end)"
+	
+	if [ "${group_start}" -lt "${PING_USER_GID}" ] && [ "${PING_USER_GID}" -le "${group_end}" ]; then
+		return 0
+	fi
+
+	fail '%s is not in the valid ping range (%s-%s)\n' "${PING_USER_GID}" "${group_start}" "${group_end}"
+}
+
+configure_permissions() {
+	group_start="$(get_group_start)"
+	group_end="$(get_group_end)"
+	
+	if [ "${PING_USER_GID}" -lt "${group_start}" ]; then
+		group_start="${PING_USER_GID}"
+	fi
+	
+	if [ "${group_end}" -lt "${PING_USER_GID}" ]; then
+		group_end="${PING_USER_GID}"
+	fi
+	
+	if [ "${group_end}" -eq 0 ]; then
+		rm -f /etc/sysctl.d/99-opennms-non-root-icmp.conf || :
+	else
+		install -d -m 755 /etc/sysctl.d
+		echo "net.ipv4.ping_group_range=${group_start} ${group_end}" > /etc/sysctl.d/99-opennms-non-root-icmp.conf
+	fi
+	
+	if ! sysctl -w "net.ipv4.ping_group_range=${group_start} ${group_end}" >/tmp/$$.sysctlout 2>&1; then
+		log_error "$(cat /tmp/$$.sysctlout)"
+	fi
+	rm -f /tmp/$$.sysctlout || :
+}
+
+configure_permissions
+validate_permissions


### PR DESCRIPTION
This PR backports the changes made post-foundation-2018 to the minion scripts to enable sentinel stuff.  It includes a number of fixes for user-mode running including a better/cleaner script for ensuring ping is set up.

* JIRA: http://issues.opennms.org/browse/LTS-231

Our [continuous integration system](http://bamboo.internal.opennms.com:8085) will test and verify your changes.
