### PR TITLE
HZN-1489: Node category support & example for Drools in alarmd

### DIFF
--- a/opennms-alarms/daemon/src/main/java/org/opennms/netmgt/alarmd/drools/DroolsAlarmContext.java
+++ b/opennms-alarms/daemon/src/main/java/org/opennms/netmgt/alarmd/drools/DroolsAlarmContext.java
@@ -413,6 +413,10 @@ public class DroolsAlarmContext extends ManagedDroolsContext implements AlarmLif
             // The last event may be null in unit tests
             Hibernate.initialize(alarm.getLastEvent().getEventParameters());
         }
+        if (alarm.getNode() != null) {
+            // Allow rules to use the categories on the associated node
+            Hibernate.initialize(alarm.getNode().getCategories());
+        }
         final AlarmAndFact alarmAndFact = alarmsById.get(alarm.getId());
         if (alarmAndFact == null) {
             LOG.debug("Inserting alarm into session: {}", alarm);

--- a/opennms-alarms/daemon/src/test/java/org/opennms/netmgt/alarmd/examples/DroolsExampleIT.java
+++ b/opennms-alarms/daemon/src/test/java/org/opennms/netmgt/alarmd/examples/DroolsExampleIT.java
@@ -1,0 +1,111 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.alarmd.examples;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.Optional;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.rules.TemporaryFolder;
+import org.opennms.core.utils.ConfigFileConstants;
+import org.opennms.netmgt.alarmd.drools.DefaultAlarmService;
+import org.opennms.netmgt.alarmd.drools.DroolsAlarmContext;
+import org.opennms.netmgt.dao.api.AcknowledgmentDao;
+import org.opennms.netmgt.dao.api.AlarmDao;
+import org.opennms.netmgt.dao.mock.MockTransactionTemplate;
+import org.opennms.netmgt.dao.support.AlarmEntityNotifierImpl;
+import org.opennms.netmgt.events.api.EventForwarder;
+
+public abstract class DroolsExampleIT {
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    protected DroolsAlarmContext dac;
+    protected AlarmDao alarmDao;
+    protected EventForwarder eventForwarder;
+
+    public abstract String getRulesFile();
+
+    @Before
+    public void setUp() throws IOException {
+        // Copy default set of rules to a new folder
+        File rulesFolder = temporaryFolder.newFolder("rules");
+        FileUtils.copyDirectory(DroolsAlarmContext.getDefaultRulesFolder(), rulesFolder);
+
+        // Copy the rules from the example folder alongside the rules in our temporary folder
+        FileUtils.copyFile(Paths.get(ConfigFileConstants.getHome(), "etc", "examples",
+                "alarmd", "drools-rules.d", getRulesFile()).toFile(),
+                new File(rulesFolder, getRulesFile()));
+
+        // Wire up the engine with mocks
+        dac = new DroolsAlarmContext(rulesFolder);
+        dac.setUsePseudoClock(true);
+        dac.setUseManualTick(true);
+
+        MockTransactionTemplate transactionTemplate = new MockTransactionTemplate();
+        transactionTemplate.afterPropertiesSet();
+        dac.setTransactionTemplate(transactionTemplate);
+
+        alarmDao = mock(AlarmDao.class);
+        dac.setAlarmDao(alarmDao);
+
+        DefaultAlarmService alarmService = new DefaultAlarmService();
+        alarmService.setAlarmDao(alarmDao);
+        eventForwarder = mock(EventForwarder.class);
+        alarmService.setEventForwarder(eventForwarder);
+
+        AcknowledgmentDao acknowledgmentDao = mock(AcknowledgmentDao.class);
+        when(acknowledgmentDao.findLatestAckForRefId(any(Integer.class))).thenReturn(Optional.empty());
+        alarmService.setAcknowledgmentDao(acknowledgmentDao);
+
+        AlarmEntityNotifierImpl alarmEntityNotifier = mock(AlarmEntityNotifierImpl.class);
+        alarmService.setAlarmEntityNotifier(alarmEntityNotifier);
+        dac.setAlarmService(alarmService);
+        dac.setAcknowledgmentDao(acknowledgmentDao);
+
+        dac.start();
+    }
+
+    @After
+    public void tearDown() {
+        if (dac != null) {
+            dac.stop();
+        }
+    }
+}

--- a/opennms-alarms/daemon/src/test/java/org/opennms/netmgt/alarmd/examples/MiscExamplesIT.java
+++ b/opennms-alarms/daemon/src/test/java/org/opennms/netmgt/alarmd/examples/MiscExamplesIT.java
@@ -1,0 +1,127 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.alarmd.examples;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Date;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.opennms.core.test.OpenNMSJUnit4ClassRunner;
+import org.opennms.netmgt.events.api.EventConstants;
+import org.opennms.netmgt.model.OnmsAlarm;
+import org.opennms.netmgt.model.OnmsCategory;
+import org.opennms.netmgt.model.OnmsEvent;
+import org.opennms.netmgt.model.OnmsNode;
+import org.opennms.netmgt.model.OnmsSeverity;
+import org.opennms.test.JUnitConfigurationEnvironment;
+import org.springframework.test.context.ContextConfiguration;
+
+/**
+ * Verify the example rules provided in $OPENNMS_HOME/etc/examples/alarmd/drools.rules.d/misc.drl.
+ *
+ * @author jwhite
+ */
+@RunWith(OpenNMSJUnit4ClassRunner.class)
+@ContextConfiguration(locations={
+        "classpath:/META-INF/opennms/emptyContext.xml"
+})
+@JUnitConfigurationEnvironment
+public class MiscExamplesIT extends DroolsExampleIT {
+
+    @Override
+    public String getRulesFile() {
+        return "misc.drl";
+    }
+
+    @Test
+    public void canEscalateAlarmsForNodesInCategory() {
+        // Create an alarm that we know will trigger our escalate rule
+        OnmsAlarm trigger = createNodeDownAlarm(1, "EMERGENCY_F0");
+        OnmsSeverity originalSeverity = trigger.getSeverity();
+
+        // Tick
+        dac.getClock().advanceTime( 16, TimeUnit.SECONDS );
+        dac.handleNewOrUpdatedAlarm(trigger);
+        // t = 00:16.0000
+        dac.tick();
+
+        // Capture the updated alarm
+        ArgumentCaptor<OnmsAlarm> alarmCaptor = ArgumentCaptor.forClass(OnmsAlarm.class);
+        verify(alarmDao).update(alarmCaptor.capture());
+        OnmsAlarm alarm = alarmCaptor.getValue();
+
+        // Verify that the severity was updated
+        OnmsSeverity updatedSeverity = alarm.getSeverity();
+        assertThat(updatedSeverity, greaterThan(originalSeverity));
+
+        // Create an alarm that should not trigger our escalate rule
+        reset(alarmDao);
+        trigger = createNodeDownAlarm(2, "NOT_EMERGENCY_F0");
+
+        // Tick
+        dac.getClock().advanceTime( 1, TimeUnit.SECONDS );
+        dac.handleNewOrUpdatedAlarm(trigger);
+        // t = 00:17.0000
+        dac.tick();
+
+        // No updates
+        verify(alarmDao, times(0)).update(any(OnmsAlarm.class));
+    }
+
+    private OnmsAlarm createNodeDownAlarm(int id, String nodeCategory) {
+        final OnmsAlarm alarm = new OnmsAlarm();
+        alarm.setId(id);
+        alarm.setAlarmType(1);
+        alarm.setSeverity(OnmsSeverity.MAJOR);
+        alarm.setReductionKey(EventConstants.NODE_DOWN_EVENT_UEI + id);
+        alarm.setFirstEventTime(new Date(15 * 1000));
+
+        final OnmsNode node = new OnmsNode();
+        node.addCategory(new OnmsCategory(nodeCategory, ""));
+        alarm.setNode(node);
+
+        final OnmsEvent event = new OnmsEvent();
+        event.setEventUei(EventConstants.NODE_DOWN_EVENT_UEI);
+        event.setEventTime(new Date(16 * 1000));
+        alarm.setLastEvent(event);
+
+        when(alarmDao.get(alarm.getId())).thenReturn(alarm);
+        return alarm;
+    }
+}

--- a/opennms-base-assembly/src/main/filtered/etc/examples/alarmd/drools-rules.d/misc.drl
+++ b/opennms-base-assembly/src/main/filtered/etc/examples/alarmd/drools-rules.d/misc.drl
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.alarmd.usecases;
+
+import java.util.Date;
+import java.util.LinkedList;
+import org.kie.api.time.SessionClock;
+import org.opennms.netmgt.model.OnmsAlarm;
+import org.opennms.netmgt.model.OnmsCategory;
+import org.opennms.netmgt.model.OnmsSeverity;
+
+global org.opennms.netmgt.alarmd.drools.AlarmService alarmService;
+
+/**
+Miscellaneous rules that can be used as a basis and example to build your own rulesets.
+*/
+
+declare org.opennms.netmgt.model.OnmsAlarm
+    @role(event)
+    @timestamp(lastUpdateTime)
+end
+
+
+rule "escalate alarms for node in category"
+  when
+    $alarm : OnmsAlarm(alarmType == OnmsAlarm.PROBLEM_TYPE,
+                       lastEvent != null,
+                       lastEvent.eventUei in ( "uei.opennms.org/nodes/nodeDown", "uei.opennms.org/nodes/interfaceDown" ),
+                       severity.isGreaterThan(OnmsSeverity.NORMAL),
+                       severity.isLessThan(OnmsSeverity.CRITICAL),
+                       node != null)
+    LinkedList( isEmpty == false ) from collect( OnmsCategory( name == "EMERGENCY_F0" ) from $alarm.node.categories )
+  then
+    Date now = new Date(drools.getWorkingMemory().getSessionClock().getCurrentTime());
+    alarmService.escalateAlarm($alarm, now);
+end


### PR DESCRIPTION
JIRA: https://issues.opennms.org/browse/HZN-1489

Update the Drools handling for alarms so that we can refer to node category names in the LHS.

Also add an example of such a rule.
