### PR TITLE
NMS-10569: Address table column spreading and spacing/orientation related issues

### DIFF
--- a/core/web-assets/src/main/assets/js/apps/angular-status/views/applications.html
+++ b/core/web-assets/src/main/assets/js/apps/angular-status/views/applications.html
@@ -7,12 +7,12 @@
             <table class="table table-bordered severity">
                 <tbody>
                 <tr>
-                    <th class="col-md-3 text-nowrap">
+                    <th>
                         <a href ng-click="changeOrderBy('severity')">Severity</a>
                         <i ng-show="query.orderBy === 'severity' &amp;&amp; query.order === 'asc'" class="fa fa-sort-asc"/>
                         <i ng-show="query.orderBy === 'severity' &amp;&amp; query.order === 'desc'" class="fa fa-sort-desc"/>
                     </th>
-                    <th class="col-md-9 text-nowrap">
+                    <th>
                         <a href ng-click="changeOrderBy('name')">Name</a>
                         <i ng-show="query.orderBy === 'name' &amp;&amp; query.order === 'asc'" class="fa fa-sort-asc"/>
                         <i ng-show="query.orderBy === 'name' &amp;&amp; query.order === 'desc'" class="fa fa-sort-desc"/>
@@ -20,10 +20,10 @@
                 </tr>
 
                 <tr ng-repeat="item in items" class="severity-{{item.severity | lowercase}}">
-                    <td class="text-nowrap divider bright">
+                    <td class="divider bright">
                         {{item['severity'] | severity}}
                     </td>
-                    <td class="text-nowrap">
+                    <td>
                         <a href="topology?provider=Application&focus-vertices={{item['id']}}&layout=Hierarchy Layout">
                             {{item['name']}}
                         </a>

--- a/core/web-assets/src/main/assets/js/apps/angular-status/views/business-services.html
+++ b/core/web-assets/src/main/assets/js/apps/angular-status/views/business-services.html
@@ -8,12 +8,12 @@
             <table class="table table-bordered severity">
                 <tbody>
                 <tr>
-                    <th class="col-md-3 text-nowrap">
+                    <th>
                         <a href ng-click="changeOrderBy('severity')">Severity</a>
                         <i ng-show="query.orderBy === 'severity' &amp;&amp; query.order === 'asc'" class="fa fa-sort-asc"/>
                         <i ng-show="query.orderBy === 'severity' &amp;&amp; query.order === 'desc'" class="fa fa-sort-desc"/>
                     </th>
-                    <th class="col-md-9 text-nowrap">
+                    <th>
                         <a href ng-click="changeOrderBy('name')">Name</a>
                         <i ng-show="query.orderBy === 'name' &amp;&amp; query.order === 'asc'" class="fa fa-sort-asc"/>
                         <i ng-show="query.orderBy === 'name' &amp;&amp; query.order === 'desc'" class="fa fa-sort-desc"/>
@@ -21,10 +21,10 @@
                 </tr>
 
                 <tr ng-repeat="item in items" class="severity-{{item.severity | lowercase}}">
-                    <td class="text-nowrap divider bright">
+                    <td class="divider bright">
                         {{item['severity'] | severity}}
                     </td>
-                    <td class="text-nowrap">
+                    <td>
                         <a href="topology?provider=Business Services&focus-vertices={{item['id']}}&layout=Hierarchy Layout">
                             {{item['name']}}
                         </a>

--- a/core/web-assets/src/main/assets/js/apps/angular-status/views/nodes.html
+++ b/core/web-assets/src/main/assets/js/apps/angular-status/views/nodes.html
@@ -11,26 +11,26 @@
             <table class="table table-bordered severity">
                 <tbody>
                 <tr>
-                    <th class="col-md-3 text-nowrap">
+                    <th>
                         <a href ng-click="changeOrderBy('severity')">Severity</a>
                         <i ng-show="query.orderBy === 'severity' &amp;&amp; query.order === 'asc'" class="fa fa-sort-asc"/>
                         <i ng-show="query.orderBy === 'severity' &amp;&amp; query.order === 'desc'" class="fa fa-sort-desc"/>
                     </th>
-                    <th class="col-md-5 text-nowrap">
+                    <th>
                         <a href ng-click="changeOrderBy('label')">Node Label</a>
                         <i ng-show="query.orderBy === 'label' &amp;&amp; query.order === 'asc'" class="fa fa-sort-asc"/>
                         <i ng-show="query.orderBy === 'label' &amp;&amp; query.order === 'desc'" class="fa fa-sort-desc"/>
                     </th>
-                    <th class="col-md-4">
+                    <th>
                         Actions
                     </th>
                 </tr>
 
                 <tr ng-repeat="item in items" class="severity-{{item.severity | lowercase}}">
-                    <td class="text-nowrap divider bright">
+                    <td class="divider bright">
                         {{item['severity'] | severity}}
                     </td>
-                    <td class="text-nowrap">
+                    <td>
                         <a href="element/node.jsp?node={{item['id']}}">
                             {{item['name']}}
                         </a>

--- a/core/web-assets/src/main/assets/js/apps/onms-classifications/index.js
+++ b/core/web-assets/src/main/assets/js/apps/onms-classifications/index.js
@@ -314,6 +314,7 @@ const confirmTopoverTemplate = require('./views/modals/popover.html');
 
             $scope.importRules = function() {
                 var modalInstance = $uibModal.open({
+                    size: 'lg',
                     backdrop: false,
                     controller: 'ClassificationImportController',
                     templateUrl: importModalTemplate,

--- a/core/web-assets/src/main/assets/js/apps/onms-classifications/views/config.html
+++ b/core/web-assets/src/main/assets/js/apps/onms-classifications/views/config.html
@@ -4,9 +4,9 @@
     </div>
     <div ng-show="groups.length == 0">No groups defined.</div>
     <pagination model="query" ng-show="groups.length > 0" position="bottom" on-change="refresh">
-        <table class="table table-bordered table-striped">
+        <table class="table table-striped">
             <thead>
-            <tr>
+            <tr class="d-flex">
                 <th class="col-md-1 text-nowrap">Priority</th>
                 <th class="col-md-3 text-nowrap">Name</th>
                 <th class="col-md-5 text-nowrap">Description</th>
@@ -15,12 +15,12 @@
             </tr>
             </thead>
             <tbody>
-            <tr ng-repeat="group in groups" data-row="{{group.name}}">
-                <td class="text-nowrap">{{group['priority']}}</td>
-                <td class="text-nowrap">{{group['name']}}</td>
-                <td class="text-nowrap">{{group['description']}}</td>
-                <td class="text-nowrap">{{!group['readOnly']}}</td>
-                <td class="text-nowrap">
+            <tr class="d-flex" ng-repeat="group in groups" data-row="{{group.name}}">
+                <td class="col-md-1 text-nowrap">{{group['priority']}}</td>
+                <td class="col-md-3 text-nowrap">{{group['name']}}</td>
+                <td class="col-md-5 text-nowrap">{{group['description']}}</td>
+                <td class="col-md-1 text-nowrap">{{!group['readOnly']}}</td>
+                <td class="col-md-2 text-nowrap">
                     <toggle id="action.{{group.name}}.toggle" size="btn-sm" ng-model="group['enabled']" ng-change="updateGroup(group)"></toggle>
                 </td>
             </tr>

--- a/core/web-assets/src/main/assets/js/apps/onms-classifications/views/group.html
+++ b/core/web-assets/src/main/assets/js/apps/onms-classifications/views/group.html
@@ -43,7 +43,7 @@
     <h5 class="pt-2">{{group.description}} <span class="badge badge-secondary" ng-if="group.readOnly">read-only</span></h5>
     <div class="text-center mt-4" ng-show="rules.length == 0"><pre>No rules defined.</pre></div>
     <pagination model="query" ng-show="rules.length > 0" position="bottom" on-change="refresh">
-        <table class="table table-striped table-sm">
+        <table class="table table-striped">
             <thead>
             <tr class="d-flex">
                 <th class="col-md-1 text-nowrap">

--- a/core/web-assets/src/main/assets/js/apps/onms-classifications/views/modals/import-modal.html
+++ b/core/web-assets/src/main/assets/js/apps/onms-classifications/views/modals/import-modal.html
@@ -46,14 +46,14 @@
     <pagination model="pagination" position="bottom" on-change="navigateWithinErrors">
       <table class="table table-bordered table-striped">
         <tbody>
-        <tr>
-          <th class="col-md-1 text-nowrap">Row Index</th>
-          <th class="col-md-11 text-nowrap">Error Message</th>
+        <tr class="d-flex">
+          <th class="col-md-1">Row Index</th>
+          <th class="col-md-11">Error Message</th>
         </tr>
 
-        <tr ng-repeat="failedRow in failedRows">
-          <td class="text-nowwrap">{{failedRow['index']}}</td>
-          <td class="text-nowwrap">{{failedRow['message']}}</td>
+        <tr class="d-flex" ng-repeat="failedRow in failedRows">
+          <td class="col-md-1">{{failedRow['index']}}</td>
+          <td class="col-md-11">{{failedRow['message']}}</td>
         </tr>
         </tbody>
       </table>

--- a/core/web-assets/src/main/assets/js/apps/onms-elementList/minion-elementList/main.html
+++ b/core/web-assets/src/main/assets/js/apps/onms-elementList/minion-elementList/main.html
@@ -160,40 +160,40 @@
 		<table class="table table-bordered table-striped" style="font-size:100%">
 			<tbody>
 				<tr>
-					<th class="col-sm-2 text-nowrap">
+					<th>
 						<a href ng-click="changeOrderBy('id')">ID</a>
 						<i ng-show="query.orderBy === 'id' &amp;&amp; query.order === 'asc'" class="fa fa-sort-asc"/>
 						<i ng-show="query.orderBy === 'id' &amp;&amp; query.order === 'desc'" class="fa fa-sort-desc"/>
 					</th>
-					<th class="col-sm-2 text-nowrap">
+					<th>
 						<a href ng-click="changeOrderBy('label')">Label</a>
 						<i ng-show="query.orderBy === 'label' &amp;&amp; query.order === 'asc'" class="fa fa-sort-asc"/>
 						<i ng-show="query.orderBy === 'label' &amp;&amp; query.order === 'desc'" class="fa fa-sort-desc"/>
 					</th>
-					<th class="col-sm-1 text-nowrap">
+					<th>
 						<a href ng-click="changeOrderBy('location')">Location</a>
 						<i ng-show="query.orderBy === 'location' &amp;&amp; query.order === 'asc'" class="fa fa-sort-asc"/>
 						<i ng-show="query.orderBy === 'location' &amp;&amp; query.order === 'desc'" class="fa fa-sort-desc"/>
 					</th>
-					<th class="col-sm-1 text-nowrap">
+					<th>
 						<a href ng-click="changeOrderBy('type')">Type</a>
 						<i ng-show="query.orderBy === 'type' &amp;&amp; query.order === 'asc'" class="fa fa-sort-asc"/>
 						<i ng-show="query.orderBy === 'type' &amp;&amp; query.order === 'desc'" class="fa fa-sort-desc"/>
 					</th>
-					<th class="col-sm-1 text-nowrap">
+					<th>
 						<a href ng-click="changeOrderBy('status')">Status</a>
 						<i ng-show="query.orderBy === 'status' &amp;&amp; query.order === 'asc'" class="fa fa-sort-asc"/>
 						<i ng-show="query.orderBy === 'status' &amp;&amp; query.order === 'desc'" class="fa fa-sort-desc"/>
 					</th>
-					<th class="col-sm-2 text-nowrap">
+					<th>
 						<a href ng-click="changeOrderBy('date')">Last Updated</a>
 						<i ng-show="query.orderBy === 'date' &amp;&amp; query.order === 'asc'" class="fa fa-sort-asc"/>
 						<i ng-show="query.orderBy === 'date' &amp;&amp; query.order === 'desc'" class="fa fa-sort-desc"/>
 					</th>
-					<th class="col-sm-2 text-nowrap">
+					<th>
 						Properties
 					</th>
-					<th class="col-sm-1 text-nowrap">
+					<th>
 						Actions
 					</th>
 				</tr>

--- a/core/web-assets/src/main/assets/js/apps/onms-elementList/monitoringLocation-elementList/main.html
+++ b/core/web-assets/src/main/assets/js/apps/onms-elementList/monitoringLocation-elementList/main.html
@@ -203,40 +203,40 @@
 		<table class="table table-bordered table-striped" style="font-size:100%">
 			<tbody>
 				<tr>
-					<th class="col-sm-2 text-nowrap">
+					<th>
 						<a href ng-click="changeOrderBy('locationName')">Location Name</a>
 						<i ng-show="query.orderBy === 'locationName' &amp;&amp; query.order === 'asc'" class="fa fa-sort-asc"/>
 						<i ng-show="query.orderBy === 'locationName' &amp;&amp; query.order === 'desc'" class="fa fa-sort-desc"/>
 					</th>
-					<th class="col-sm-1 text-nowrap">
+					<th>
 						<a href ng-click="changeOrderBy('monitoringArea')">Monitoring Area</a>
 						<i ng-show="query.orderBy === 'monitoringArea' &amp;&amp; query.order === 'asc'" class="fa fa-sort-asc"/>
 						<i ng-show="query.orderBy === 'monitoringArea' &amp;&amp; query.order === 'desc'" class="fa fa-sort-desc"/>
 					</th>
-					<th class="col-sm-2 text-nowrap">
+					<th>
 						<a href ng-click="changeOrderBy('geolocation')">Geolocation</a>
 						<i ng-show="query.orderBy === 'geolocation' &amp;&amp; query.order === 'asc'" class="fa fa-sort-asc"/>
 						<i ng-show="query.orderBy === 'geolocation' &amp;&amp; query.order === 'desc'" class="fa fa-sort-desc"/>
 					</th>
-					<th class="col-sm-1 text-nowrap">
+					<th>
 						<a href ng-click="changeOrderBy('latitude')">Latitude</a>
 						<i ng-show="query.orderBy === 'latitude' &amp;&amp; query.order === 'asc'" class="fa fa-sort-asc"/>
 						<i ng-show="query.orderBy === 'latitude' &amp;&amp; query.order === 'desc'" class="fa fa-sort-desc"/>
 					</th>
-					<th class="col-sm-1 text-nowrap">
+					<th>
 						<a href ng-click="changeOrderBy('longitude')">Longitude</a>
 						<i ng-show="query.orderBy === 'longitude' &amp;&amp; query.order === 'asc'" class="fa fa-sort-asc"/>
 						<i ng-show="query.orderBy === 'longitude' &amp;&amp; query.order === 'desc'" class="fa fa-sort-desc"/>
 					</th>
-					<th class="col-sm-1 text-nowrap">
+					<th>
 						<a href ng-click="changeOrderBy('priority')">Priority</a>
 						<i ng-show="query.orderBy === 'priority' &amp;&amp; query.order === 'asc'" class="fa fa-sort-asc"/>
 						<i ng-show="query.orderBy === 'priority' &amp;&amp; query.order === 'desc'" class="fa fa-sort-desc"/>
 					</th>
-					<th class="col-sm-2 text-nowrap">
+					<th>
 						Polling Packages
 					</th>
-					<th class="col-sm-2 text-nowrap">
+					<th>
 						Collection Packages
 					</th>
 				</tr>

--- a/core/web-assets/src/main/assets/js/apps/onms-elementList/scanreport-elementList/main.html
+++ b/core/web-assets/src/main/assets/js/apps/onms-elementList/scanreport-elementList/main.html
@@ -191,22 +191,22 @@
 		<table class="table table-bordered severity" style="font-size:100%">
 			<tbody>
 				<tr>
-					<th class="col-sm-2 text-nowrap">
+					<th class="text-nowrap">
 						<a ng-click="changeOrderBy('id')">ID</a>
 						<i ng-show="query.orderBy === 'id' &amp;&amp; query.order === 'asc'" class="fa fa-sort-asc"/>
 						<i ng-show="query.orderBy === 'id' &amp;&amp; query.order === 'desc'" class="fa fa-sort-desc"/>
 					</th>
-					<th class="col-sm-2 text-nowrap">
+					<th class="text-nowrap">
 						<a ng-click="changeOrderBy('location')">Location</a>
 						<i ng-show="query.orderBy === 'location' &amp;&amp; query.order === 'asc'" class="fa fa-sort-asc"/>
 						<i ng-show="query.orderBy === 'location' &amp;&amp; query.order === 'desc'" class="fa fa-sort-desc"/>
 					</th>
-					<th class="col-sm-2 text-nowrap">
+					<th class="text-nowrap">
 						<a ng-click="changeOrderBy('applications')">Application</a>
 						<i ng-show="query.orderBy === 'applications' &amp;&amp; query.order === 'asc'" class="fa fa-sort-asc"/>
 						<i ng-show="query.orderBy === 'applications' &amp;&amp; query.order === 'desc'" class="fa fa-sort-desc"/>
 					</th>
-					<th class="col-sm-4 text-nowrap">
+					<th class="text-nowrap">
 						<a ng-click="changeOrderBy('timestamp')">Scan Time</a>
 						<i ng-show="query.orderBy === 'timestamp' &amp;&amp; query.order === 'asc'" class="fa fa-sort-asc"/>
 						<i ng-show="query.orderBy === 'timestamp' &amp;&amp; query.order === 'desc'" class="fa fa-sort-desc"/>
@@ -216,7 +216,7 @@
 						Properties
 					</th>
 					-->
-					<th class="col-sm-2 text-nowrap">
+					<th class="text-nowrap">
 						Logs
 					</th>
 				</tr>

--- a/core/web-assets/src/main/assets/js/lib/onms-pagination/pagination-toolbar.html
+++ b/core/web-assets/src/main/assets/js/lib/onms-pagination/pagination-toolbar.html
@@ -17,7 +17,7 @@
                  ng-change="onChange()">
             </div>
         </div>
-        <div class="col-md-8 col-lg-6 col-sm-12">
+        <div class="col-md-8 col-lg-6 col-sm-12 mt-4">
             <pre class="pull-right" ng-show="model.totalItems == 0">No items found.</pre>
             <pre class="pull-right" ng-show="model.totalItems > 0">{{model.totalItems / model.page === 1
             ? "Item " + (model.offset + 1)

--- a/opennms-webapp/src/main/webapp/KSC/index.jsp
+++ b/opennms-webapp/src/main/webapp/KSC/index.jsp
@@ -89,7 +89,7 @@
                 </tr>
               </thead>
               <tbody>
-                <tr name="report:{{ report.label }}" ng-class="{'table-info': report.id == reportSelected.id}" ng-click="selectReport(report)" ng-repeat="report in filteredReports | startFrom:(kscCurrentPage-1)*kscPageSize | limitTo:kscPageSize">
+                <tr name="report:{{ report.label }}" ng-class="{'table-active': report.id == reportSelected.id}" ng-click="selectReport(report)" ng-repeat="report in filteredReports | startFrom:(kscCurrentPage-1)*kscPageSize | limitTo:kscPageSize">
                   <td>{{ report.label }}</td>
                 </tr>
              </tbody>

--- a/opennms-webapp/src/main/webapp/WEB-INF/jsp/KSC/customGraphEditDetails.jsp
+++ b/opennms-webapp/src/main/webapp/WEB-INF/jsp/KSC/customGraphEditDetails.jsp
@@ -105,7 +105,7 @@
       </div>
       <table class="table">
         <tr>
-          <td align="right" class="col-md-4">
+          <td align="right" class="w-25">
             ${resultSet.title}
             <br/>
               <c:if test="${!empty resultSet.resource.parent}">
@@ -134,7 +134,7 @@
             <br/>
             <b>To</b> ${resultSet.end}
           </td>
-          <td align="left" class="col-md-8">
+          <td align="left" class="w-75">
             <div class="graph-container" data-graph-zoomable="true" data-resource-id="${resultSet.resource.id}" data-graph-name="${resultSet.prefabGraph.name}" data-graph-title="${resultSet.prefabGraph.title}" data-graph-start="${resultSet.start.time}" data-graph-end="${resultSet.end.time}"></div>
           </td>
         </tr>

--- a/opennms-webapp/src/main/webapp/WEB-INF/jsp/KSC/customReport.jsp
+++ b/opennms-webapp/src/main/webapp/WEB-INF/jsp/KSC/customReport.jsp
@@ -106,45 +106,45 @@
           <c:forEach var="graphNum" begin="0" end="${fn:length(resultSets) - 1}">
             <c:set var="resultSet" value="${resultSets[graphNum]}"/>
             <tr>
-              <td class="col-md-1">
+              <td align="right" class="w-25">
                 <div class="btn-toolbar" role="toolbar">
                   <div class="btn-group" role="group">
                     <button class="btn btn-secondary" onclick="modifyGraph(${graphNum})">Modify</button>
                     <button class="btn btn-secondary" onclick="deleteGraph(${graphNum})">Delete</button>
                   </div>
                 </div>
-              </td>
-              <td align="right" class="col-md-3">
-                ${resultSet.title}
-                <br/>
-                <c:if test="${!empty resultSet.resource.parent}">
-                  ${resultSet.resource.parent.resourceType.label}:
+                <div>
+                  ${resultSet.title}
+                  <br/>
+                  <c:if test="${!empty resultSet.resource.parent}">
+                    ${resultSet.resource.parent.resourceType.label}:
+                    <c:choose>
+                      <c:when test="${!empty resultSet.resource.parent.link}">
+                        <a href="<c:url value='${resultSet.resource.parent.link}'/>">${resultSet.resource.parent.label}</a>
+                      </c:when>
+                      <c:otherwise>
+                        ${resultSet.resource.parent.label}
+                      </c:otherwise>
+                    </c:choose>
+                    <br />
+                  </c:if>
+                  ${resultSet.resource.resourceType.label}:
                   <c:choose>
-                    <c:when test="${!empty resultSet.resource.parent.link}">
-                      <a href="<c:url value='${resultSet.resource.parent.link}'/>">${resultSet.resource.parent.label}</a>
+                    <c:when test="${!empty resultSet.resource.link}">
+                      <a href="<c:url value='${resultSet.resource.link}'/>">${resultSet.resource.label}</a>
                     </c:when>
                     <c:otherwise>
-                      ${resultSet.resource.parent.label}
+                      ${resultSet.resource.label}
                     </c:otherwise>
                   </c:choose>
-                  <br />
-                </c:if>
-                ${resultSet.resource.resourceType.label}:
-                <c:choose>
-                  <c:when test="${!empty resultSet.resource.link}">
-                    <a href="<c:url value='${resultSet.resource.link}'/>">${resultSet.resource.label}</a>
-                  </c:when>
-                  <c:otherwise>
-                    ${resultSet.resource.label}
-                  </c:otherwise>
-                </c:choose>
-                <br/>
-                <br/>
-                From: ${resultSet.start}
-                <br/>
-                To: ${resultSet.end}
+                  <br/>
+                  <br/>
+                  From: ${resultSet.start}
+                  <br/>
+                  To: ${resultSet.end}
+                </div>
               </td>
-              <td align="left" style="col-md-8">
+              <td align="left" class="w-75">
                 <div class="graph-container" data-graph-zoomable="false" data-resource-id="${resultSet.resource.id}" data-graph-name="${resultSet.prefabGraph.name}" data-graph-title="${resultSet.prefabGraph.title}" data-graph-start="${resultSet.start.time}" data-graph-end="${resultSet.end.time}"></div>
               </td>
             </tr>

--- a/opennms-webapp/src/main/webapp/admin/discovery/edit-config.jsp
+++ b/opennms-webapp/src/main/webapp/admin/discovery/edit-config.jsp
@@ -265,15 +265,15 @@ for (Requisition requisition : reqAccessService.getRequisitions()) {
       %>
 				    <table class="table table-sm">
 				      <tr>
-					<th class="col-xs-4">IP&nbsp;Address</th>
-					<th class="col-xs-2">Timeout&nbsp;(milliseconds)</th>
-					<th class="col-xs-2">Retries</th>
-					<th class="col-xs-2">Foreign&nbsp;Source</th>
-					<th class="col-xs-2">Location</th>
+					<th>IP&nbsp;Address</th>
+					<th>Timeout&nbsp;(milliseconds)</th>
+					<th>Retries</th>
+					<th>Foreign&nbsp;Source</th>
+					<th>Location</th>
 					<th>Action</th>
 				      </tr>
 				      <%for(int i=0; i<specs.length; i++){%>
-					 <tr class="text-center">
+					 <tr>
 					  <td><%=specs[i].getAddress()%></td>
 					  <td><%=specs[i].getTimeout().isPresent() ? "" + specs[i].getTimeout().get() : "<i>Use Default</i>" %></td>
 					  <td><%=specs[i].getRetries().isPresent() ? "" + specs[i].getRetries().get() : "<i>Use Default</i>" %></td>
@@ -306,15 +306,15 @@ for (Requisition requisition : reqAccessService.getRequisitions()) {
 			    %>
 				    <table class="table table-sm">
 				      <tr>
-					<th class="col-xs-4">URL</th>
-					<th class="col-xs-2">Timeout&nbsp;(milliseconds)</th>
-					<th class="col-xs-2">Retries</th>
-					<th class="col-xs-2">Foreign&nbsp;Source</th>
-					<th class="col-xs-2">Location</th>
+					<th>URL</th>
+					<th>Timeout&nbsp;(milliseconds)</th>
+					<th>Retries</th>
+					<th>Foreign&nbsp;Source</th>
+					<th>Location</th>
 					<th>Action</th>
 				      </tr>
 				      <%for(int i=0; i<urls.length; i++){%>
-					 <tr class="text-center">
+					 <tr>
 					  <td><%=urls[i].getUrl()%></td>
 					  <td><%=urls[i].getTimeout().isPresent() ? "" + urls[i].getTimeout().get() : "<i>Use Default</i>" %></td>
 					  <td><%=urls[i].getRetries().isPresent() ? "" + urls[i].getRetries().get() : "<i>Use Default</i>" %></td>
@@ -347,18 +347,18 @@ for (Requisition requisition : reqAccessService.getRequisitions()) {
 				    %>
 					    <table class="table table-sm">
 					      <tr>
-						<th class="col-xs-2">Begin&nbsp;Address</th>
-						<th class="col-xs-2">End&nbsp;Address</th>
-						<th class="col-xs-2">Timeout&nbsp;(milliseconds)</th>
-						<th class="col-xs-2">Retries</th>
-						<th class="col-xs-2">Foreign&nbsp;Source</th>
-						<th class="col-xs-2">Location</th>
+						<th>Begin&nbsp;Address</th>
+						<th>End&nbsp;Address</th>
+						<th>Timeout&nbsp;(milliseconds)</th>
+						<th>Retries</th>
+						<th>Foreign&nbsp;Source</th>
+						<th>Location</th>
 						<th>Action</th>
 					      </tr>
 					      <%for(int i=0; i<irange.length; i++){
 
 					      %>
-						 <tr class="text-center">
+						 <tr>
 						  <td><%=irange[i].getBegin()%></td>
 						  <td><%=irange[i].getEnd()%></td>
 						  <td><%=irange[i].getTimeout().isPresent() ? "" + irange[i].getTimeout().get() : "<i>Use Default</i>" %></td>
@@ -392,14 +392,14 @@ for (Requisition requisition : reqAccessService.getRequisitions()) {
 			    %>
 				    <table class="table table-sm">
 				      <tr>
-					<th class="col-xs-6">Begin</th>
-					<th class="col-xs-6">End</th>
+					<th>Begin</th>
+					<th>End</th>
 					<th>Action</th>
 				      </tr>
 				      <%for(int i=0; i<irange.length; i++){
 
 				      %>
-					 <tr class="text-center">
+					 <tr>
 					  <td><%=irange[i].getBegin()%></td>
 					  <td><%=irange[i].getEnd()%></td>
 					  <td width="1%"><button type="button" class="btn btn-sm btn-secondary" onclick="deleteER(<%=i%>);">Delete</button></td>

--- a/opennms-webapp/src/main/webapp/admin/discovery/edit-scan.jsp
+++ b/opennms-webapp/src/main/webapp/admin/discovery/edit-scan.jsp
@@ -238,17 +238,17 @@ for (Requisition requisition : reqAccessService.getRequisitions()) {
       <%if(currConfig.getSpecifics().size()>0){
             Specific[] specs = currConfig.getSpecifics().toArray(new Specific[0]);
       %>
-				    <table class="table table-bordered table-sm">
+				    <table class="table table-sm">
 				      <tr>
-					<th class="col-xs-4">IP&nbsp;Address</th>
-					<th class="col-xs-2">Timeout&nbsp;(milliseconds)</th>
-					<th class="col-xs-2">Retries</th>
-					<th class="col-xs-2">Foreign&nbsp;Source</th>
-					<th class="col-xs-2">Location</th>
+					<th>IP&nbsp;Address</th>
+					<th>Timeout&nbsp;(milliseconds)</th>
+					<th>Retries</th>
+					<th>Foreign&nbsp;Source</th>
+					<th>Location</th>
 					<th>Action</th>
 				      </tr>
 				      <%for(int i=0; i<specs.length; i++){%>
-					 <tr class="text-center">
+					 <tr>
 					  <td><%=specs[i].getAddress()%></td>
 					  <td><%=specs[i].getTimeout().isPresent() ? "" + specs[i].getTimeout().get() : "<i>Use Default</i>" %></td>
 					  <td><%=specs[i].getRetries().isPresent() ? "" + specs[i].getRetries().get() : "<i>Use Default</i>" %></td>
@@ -264,7 +264,7 @@ for (Requisition requisition : reqAccessService.getRequisitions()) {
       </div>
       <% } %>
       <div class="card-footer">
-        <button type="button" class="btn btn-secondary" onclick="addSpecific();">Add New</button>
+        <button type="button" class="btn btn-secondary pull-right" onclick="addSpecific();">Add New</button>
       </div>
     </div> <!-- panel -->
   </div> <!-- column -->
@@ -279,13 +279,13 @@ for (Requisition requisition : reqAccessService.getRequisitions()) {
 			    <%if(currConfig.getIncludeUrls().size()>0){
 			        IncludeUrl[] urls = currConfig.getIncludeUrls().toArray(new IncludeUrl[0]);
 			    %>
-				    <table class="table table-bordered table-sm">
+				    <table class="table table-sm">
 				      <tr>
-					<th class="col-xs-4">URL</th>
-					<th class="col-xs-2">Timeout&nbsp;(milliseconds)</th>
-					<th class="col-xs-2">Retries</th> 
-					<th class="col-xs-2">Foreign&nbsp;Source</th>
-					<th class="col-xs-2">Location</th>
+					<th>URL</th>
+					<th>Timeout&nbsp;(milliseconds)</th>
+					<th>Retries</th> 
+					<th>Foreign&nbsp;Source</th>
+					<th>Location</th>
 					<th>Action</th>
 				      </tr>
 				      <%for(int i=0; i<urls.length; i++){%>
@@ -305,7 +305,7 @@ for (Requisition requisition : reqAccessService.getRequisitions()) {
       </div>
       <% } %>
       <div class="card-footer">
-        <button type="button" class="btn btn-secondary" onclick="addIncludeUrl();">Add New</button>
+        <button type="button" class="btn btn-secondary pull-right" onclick="addIncludeUrl();">Add New</button>
       </div>
     </div> <!-- panel -->
   </div> <!-- column -->
@@ -320,14 +320,14 @@ for (Requisition requisition : reqAccessService.getRequisitions()) {
 				    <%if(currConfig.getIncludeRanges().size()>0){
 					    IncludeRange[] irange = currConfig.getIncludeRanges().toArray(new IncludeRange[0]);
 				    %>
-					    <table class="table table-bordered table-sm">
+					    <table class="table table-sm">
 					      <tr>
-						<th class="col-xs-2">Begin&nbsp;Address</th>
-						<th class="col-xs-2">End&nbsp;Address</th>
-						<th class="col-xs-2">Timeout&nbsp;(milliseconds)</th>
-						<th class="col-xs-2">Retries</th>
-						<th class="col-xs-2">Foreign&nbsp;Source</th>
-						<th class="col-xs-2">Location</th>
+						<th>Begin&nbsp;Address</th>
+						<th>End&nbsp;Address</th>
+						<th>Timeout&nbsp;(milliseconds)</th>
+						<th>Retries</th>
+						<th>Foreign&nbsp;Source</th>
+						<th>Location</th>
 						<th>Action</th>
 					      </tr>
 					      <%for(int i=0; i<irange.length; i++){
@@ -350,7 +350,7 @@ for (Requisition requisition : reqAccessService.getRequisitions()) {
       </div>
       <% } %>
       <div class="card-footer">
-        <button type="button" class="btn btn-secondary" onclick="addIncludeRange();">Add New</button>
+        <button type="button" class="btn btn-secondary pull-right" onclick="addIncludeRange();">Add New</button>
       </div>
     </div> <!-- panel -->
   </div> <!-- column -->
@@ -365,10 +365,10 @@ for (Requisition requisition : reqAccessService.getRequisitions()) {
 			    <%if(currConfig.getExcludeRanges().size()>0){
 				    ExcludeRange[] irange = currConfig.getExcludeRanges().toArray(new ExcludeRange[0]);
 			    %>
-				    <table class="table table-bordered table-sm">
+				    <table class="table table-sm">
 				      <tr>
-					<th class="col-xs-6">Begin</th>
-					<th class="col-xs-6">End</th>
+					<th>Begin</th>
+					<th>End</th>
 					<th>Action</th>
 				      </tr>
 				      <%for(int i=0; i<irange.length; i++){
@@ -388,7 +388,7 @@ for (Requisition requisition : reqAccessService.getRequisitions()) {
       </div>
       <% } %>
       <div class="card-footer">
-        <button type="button" class="btn btn-secondary" onclick="addExcludeRange();">Add New</button>
+        <button type="button" class="btn btn-secondary pull-right" onclick="addExcludeRange();">Add New</button>
       </div>
     </div> <!-- panel -->
   </div> <!-- column -->

--- a/opennms-webapp/src/main/webapp/notification/detail.jsp
+++ b/opennms-webapp/src/main/webapp/notification/detail.jsp
@@ -99,7 +99,7 @@
   </div>
 
   <table class="table table-sm severity">
-  <tr class="severity-<%=eventSeverity.toLowerCase()%>">
+  <tr class="d-flex severity-<%=eventSeverity.toLowerCase()%>">
     <th class="col-md-1">Notification&nbsp;Time</th>
     <td class="col-md-2"><onms:datetime date="<%=notice.getTimeSent()%>" /></td>
     <th class="col-md-1">Time&nbsp;Replied</th>
@@ -127,7 +127,7 @@
       </c:choose>
     </td>
   </tr>
-  <tr class="severity-<%=eventSeverity.toLowerCase()%>">
+  <tr class="d-flex severity-<%=eventSeverity.toLowerCase()%>">
     <th class="col-md-1">Node</th>
     <td class="col-md-2">
       <%if (nodeLabel!=null) { %>
@@ -228,10 +228,10 @@
   </div>
   <table class="table table-sm severity">
     <tr>
-      <th class="col-md-3">Sent To</th>
-      <th class="col-md-3">Sent At</th>
-      <th class="col-md-3">Media</th>
-      <th class="col-md-3">Contact Info</th>
+      <th>Sent To</th>
+      <th>Sent At</th>
+      <th>Media</th>
+      <th>Contact Info</th>
     </tr>
   
   <%  for (NoticeSentTo sentTo : notice.getSentTo()) { %>

--- a/opennms-webapp/src/main/webapp/roles/list.jsp
+++ b/opennms-webapp/src/main/webapp/roles/list.jsp
@@ -95,11 +95,11 @@
 
   <table class="table table-sm severity">
          <tr>
-          <th class="col-md-2">Name</th>
-          <th class="col-md-2">Supervisor</th>
-          <th class="col-md-2">Currently On Call</th>
-          <th class="col-md-2">Membership Group</th>
-          <th class="col-md-4">Description</th>
+          <th>Name</th>
+          <th>Supervisor</th>
+          <th>Currently On Call</th>
+          <th>Membership Group</th>
+          <th>Description</th>
 
 			<c:forEach var="role" items="${roleManager.roles}">
 				<c:set var="viewUrl" value="javascript:doView('${role.name}')" />

--- a/opennms-webapp/src/main/webapp/roles/view.jsp
+++ b/opennms-webapp/src/main/webapp/roles/view.jsp
@@ -83,24 +83,24 @@
 	</div>
 
 	<table class="table table-sm severity">
-		<tr>
-			<th class="col-md-1">Name</th>
-			<td class="col-md-5"><c:out value="${role.name}" /></td>
-			<th class="col-md-1">Currently&nbsp;On&nbsp;Call</th>
-			<td class="col-md-5">
+		<tr class="d-flex">
+			<th class="col-md-2">Name</th>
+			<td class="col-md-4"><c:out value="${role.name}" /></td>
+			<th class="col-md-2">Currently&nbsp;On&nbsp;Call</th>
+			<td class="col-md-4">
 			<c:forEach var="scheduledUser" items="${role.currentUsers}">
 				<c:out value="${scheduledUser}" />
 			</c:forEach></td>
 		</tr>
-		<tr>
-			<th>Supervisor</th>
-			<td><c:out value="${role.defaultUser}" /></td>
-			<th>Membership&nbsp;Group</th>
-			<td><c:out value="${role.membershipGroup}" /></td>
+		<tr class="d-flex">
+			<th class="col-md-2">Supervisor</th>
+			<td class="col-md-4"><c:out value="${role.defaultUser}" /></td>
+			<th class="col-md-2">Membership&nbsp;Group</th>
+			<td class="col-md-4"><c:out value="${role.membershipGroup}" /></td>
 		</tr>
-		<tr>
-			<th>Description</th>
-			<td colspan="3"><c:out value="${role.description}" /></td>
+		<tr class="d-flex">
+			<th class="col-md-2">Description</th>
+			<td class="col-md-10" colspan="3"><c:out value="${role.description}" /></td>
 		</tr>
 	</table>
 </div>


### PR DESCRIPTION
In Bootstrap 3 table columns could be spaced out using `col-*` classes.
This is no longer working without any changes.
This PR addresses those no longer working `col-*` classes and provides a suitable replacement.

In firefox and safari everything worked nicely, however in Chrome things got messy.
So to verify this patch, please verify using Chrome Browser only.

* JIRA: https://issues.opennms.org/browse/NMS-10569