### PR TITLE
NMS-10624: Upgrade kafka components to 2.2.0

### DIFF
--- a/container/features/src/main/resources/features.xml
+++ b/container/features/src/main/resources/features.xml
@@ -436,7 +436,7 @@
         <bundle dependency="true">wrap:mvn:com.yammer.metrics/metrics-core/2.2.0$Bundle-Version=2.2.0&amp;Export-Package=*;-noimport:=true;version="2.2.0"</bundle>
         <bundle dependency="true">wrap:mvn:com.yammer.metrics/metrics-annotation/2.2.0$Bundle-Version=2.2.0&amp;Export-Package=*;-noimport:=true;version="2.2.0"</bundle>
         <bundle dependency="true">mvn:org.apache.kafka/kafka_2.12/${kafkaStreamsVersion}</bundle>
-        <bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.kafka-clients/${kafkaStreamsBundleVersion}</bundle>
+	<bundle dependency="true">mvn:org.apache.kafka/kafka-clients/${kafkaStreamsVersion}</bundle>
     </feature>
     <feature name="opennms-aws-sqs" version="${project.version}" description="OpenNMS :: Features :: AWS SQS">
         <bundle dependency="true">wrap:mvn:com.amazonaws/aws-java-sdk-core/${awsSdkVersion}</bundle>
@@ -888,7 +888,7 @@
     <feature name="kafka-streams" description="Kafka Streams" version="${kafkaStreamsVersion}">
         <!-- Wrap the kafka-streams bundle instead of using the servicemix implementation since the later doesn't include the required imports for rocksdb -->
         <bundle dependency="true">wrap:mvn:org.apache.kafka/kafka-streams/${kafkaStreamsVersion}$Bundle-Version=${kafkaStreamsVersion}&amp;Export-Package=*;-noimport:=true:version="${kafkaStreamsVersion}"</bundle>
-        <bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.kafka-clients/${kafkaStreamsBundleVersion}</bundle>
+        <bundle dependency="true">mvn:org.apache.kafka/kafka-clients/${kafkaStreamsVersion}</bundle>
         <bundle dependency="true">wrap:mvn:org.apache.kafka/connect-json/${kafkaStreamsVersion}</bundle>
         <bundle dependency="true">wrap:mvn:org.apache.kafka/connect-api/${kafkaStreamsVersion}</bundle>
         <bundle dependency="true">mvn:org.lz4/lz4-java/1.4</bundle>

--- a/container/features/src/main/resources/features.xml
+++ b/container/features/src/main/resources/features.xml
@@ -428,15 +428,16 @@
         <bundle>mvn:org.opennms/opennms-config/${project.version}</bundle>
     </feature>
     <feature name="opennms-kafka" version="${project.version}" description="OpenNMS :: Features :: Kafka">
-        <bundle dependency="true">mvn:org.scala-lang/scala-library/2.12.8</bundle>
+        <bundle dependency="true">mvn:org.scala-lang/scala-library/${scalaLibraryVersion}</bundle>
         <bundle dependency="true">mvn:org.apache.zookeeper/zookeeper/3.4.10</bundle>
-        <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-databind/2.9.1</bundle>
-        <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-annotations/2.9.0</bundle>
-        <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-core/2.9.1</bundle>
+        <bundle dependency="true">mvn:com.typesafe.scala-logging/scala-logging_${scalaVersion}/${scalaLoggingVersion}</bundle>
+        <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-databind/${jackson2Version}</bundle>
+        <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-annotations/${jackson2Version}</bundle>
+        <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-core/${jackson2Version}</bundle>
         <bundle dependency="true">wrap:mvn:com.yammer.metrics/metrics-core/2.2.0$Bundle-Version=2.2.0&amp;Export-Package=*;-noimport:=true;version="2.2.0"</bundle>
         <bundle dependency="true">wrap:mvn:com.yammer.metrics/metrics-annotation/2.2.0$Bundle-Version=2.2.0&amp;Export-Package=*;-noimport:=true;version="2.2.0"</bundle>
-        <bundle dependency="true">mvn:org.apache.kafka/kafka_2.12/${kafkaStreamsVersion}</bundle>
-	<bundle dependency="true">mvn:org.apache.kafka/kafka-clients/${kafkaStreamsVersion}</bundle>
+        <bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.kafka_${scalaVersion}/${kafkaBundleVersion}</bundle>
+        <bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.kafka-clients/${kafkaBundleVersion}</bundle>
     </feature>
     <feature name="opennms-aws-sqs" version="${project.version}" description="OpenNMS :: Features :: AWS SQS">
         <bundle dependency="true">wrap:mvn:com.amazonaws/aws-java-sdk-core/${awsSdkVersion}</bundle>
@@ -885,23 +886,26 @@
         <bundle>mvn:org.opennms.features.alarms.history/org.opennms.features.alarms.history.elastic/${project.version}</bundle>
     </feature>
 
-    <feature name="kafka-streams" description="Kafka Streams" version="${kafkaStreamsVersion}">
+    <feature name="kafka-streams" description="Kafka Streams" version="${kafkaVersion}">
         <!-- Wrap the kafka-streams bundle instead of using the servicemix implementation since the later doesn't include the required imports for rocksdb -->
-        <bundle dependency="true">wrap:mvn:org.apache.kafka/kafka-streams/${kafkaStreamsVersion}$Bundle-Version=${kafkaStreamsVersion}&amp;Export-Package=*;-noimport:=true:version="${kafkaStreamsVersion}"</bundle>
-        <bundle dependency="true">mvn:org.apache.kafka/kafka-clients/${kafkaStreamsVersion}</bundle>
-        <bundle dependency="true">wrap:mvn:org.apache.kafka/connect-json/${kafkaStreamsVersion}</bundle>
-        <bundle dependency="true">wrap:mvn:org.apache.kafka/connect-api/${kafkaStreamsVersion}</bundle>
+        <bundle dependency="true">wrap:mvn:org.apache.kafka/kafka-streams/${kafkaVersion}$Bundle-Version=${kafkaVersion}&amp;Export-Package=*;-noimport:=true:version="${kafkaVersion}"</bundle>
+        <bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.kafka-clients/${kafkaBundleVersion}</bundle>
+        <bundle dependency="true">wrap:mvn:org.apache.kafka/connect-json/${kafkaVersion}</bundle>
+        <bundle dependency="true">wrap:mvn:org.apache.kafka/connect-api/${kafkaVersion}</bundle>
         <bundle dependency="true">mvn:org.lz4/lz4-java/1.4</bundle>
         <bundle dependency="true">mvn:org.xerial.snappy/snappy-java/1.1.4</bundle>
+        <bundle dependency="true">mvn:com.typesafe.scala-logging/scala-logging_${scalaVersion}/${scalaLoggingVersion}</bundle>
         <!-- These are only needed for  servicemix implementation of kafka streams -->
-        <!--       <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-databind/2.9.1</bundle>
-              <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-annotations/2.9.0</bundle>
-              <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-core/2.9.1</bundle> -->
-        <bundle dependency="true">wrap:mvn:org.rocksdb/rocksdbjni/5.7.3</bundle>
+        <!--
+        <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-databind/${jackson2Version}</bundle>
+        <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-annotations/${jackson2Version}</bundle>
+        <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-core/${jackson2Version}</bundle>
+        -->
+        <bundle dependency="true">wrap:mvn:org.rocksdb/rocksdbjni/${rocksdbjniVersion}</bundle>
     </feature>
     <feature name="opennms-kafka-producer" version="${project.version}" description="OpenNMS :: Kafka :: Producer">
         <feature version="${guavaVersion}">guava</feature>
-        <feature version="${kafkaStreamsVersion}">kafka-streams</feature>
+        <feature version="${kafkaVersion}">kafka-streams</feature>
         <feature>opennms-collection-api</feature>
         <feature>opennms-situation-feedback-api</feature>
         <bundle>mvn:com.google.protobuf/protobuf-java/${protobuf3Version}</bundle>

--- a/container/features/src/main/resources/features.xml
+++ b/container/features/src/main/resources/features.xml
@@ -428,14 +428,14 @@
         <bundle>mvn:org.opennms/opennms-config/${project.version}</bundle>
     </feature>
     <feature name="opennms-kafka" version="${project.version}" description="OpenNMS :: Features :: Kafka">
-        <bundle dependency="true">mvn:org.scala-lang/scala-library/2.11.11</bundle>
+        <bundle dependency="true">mvn:org.scala-lang/scala-library/2.12.8</bundle>
         <bundle dependency="true">mvn:org.apache.zookeeper/zookeeper/3.4.10</bundle>
         <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-databind/2.9.1</bundle>
         <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-annotations/2.9.0</bundle>
         <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-core/2.9.1</bundle>
         <bundle dependency="true">wrap:mvn:com.yammer.metrics/metrics-core/2.2.0$Bundle-Version=2.2.0&amp;Export-Package=*;-noimport:=true;version="2.2.0"</bundle>
         <bundle dependency="true">wrap:mvn:com.yammer.metrics/metrics-annotation/2.2.0$Bundle-Version=2.2.0&amp;Export-Package=*;-noimport:=true;version="2.2.0"</bundle>
-        <bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.kafka_2.11/${kafkaStreamsBundleVersion}</bundle>
+        <bundle dependency="true">mvn:org.apache.kafka/kafka_2.12/${kafkaStreamsVersion}</bundle>
         <bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.kafka-clients/${kafkaStreamsBundleVersion}</bundle>
     </feature>
     <feature name="opennms-aws-sqs" version="${project.version}" description="OpenNMS :: Features :: AWS SQS">

--- a/core/ipc/common/kafka/pom.xml
+++ b/core/ipc/common/kafka/pom.xml
@@ -64,9 +64,9 @@
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.servicemix.bundles</groupId>
-        <artifactId>org.apache.servicemix.bundles.kafka_2.11</artifactId>
-        <version>${kafkaStreamsBundleVersion}</version>
+        <groupId>org.apache.kafka</groupId>
+        <artifactId>kafka_2.12</artifactId>
+        <version>${kafkaStreamsVersion}</version>
         <exclusions>
           <exclusion>
             <artifactId>log4j</artifactId>
@@ -81,7 +81,7 @@
       <dependency>
         <groupId>org.scala-lang</groupId>
         <artifactId>scala-library</artifactId>
-        <version>2.11.11</version>
+        <version>2.12.8</version>
       </dependency>
       <dependency>
         <groupId>org.opennms.core.health</groupId>

--- a/core/ipc/common/kafka/pom.xml
+++ b/core/ipc/common/kafka/pom.xml
@@ -49,9 +49,9 @@
         <artifactId>org.opennms.core.camel</artifactId>
       </dependency>
       <dependency>
-        <groupId>org.apache.servicemix.bundles</groupId>
-        <artifactId>org.apache.servicemix.bundles.kafka-clients</artifactId>
-        <version>${kafkaStreamsBundleVersion}</version>
+        <groupId>org.apache.kafka</groupId>
+        <artifactId>kafka-clients</artifactId>
+        <version>${kafkaStreamsVersion}</version>
         <exclusions>
           <exclusion>
             <artifactId>log4j</artifactId>

--- a/core/ipc/common/kafka/pom.xml
+++ b/core/ipc/common/kafka/pom.xml
@@ -49,9 +49,9 @@
         <artifactId>org.opennms.core.camel</artifactId>
       </dependency>
       <dependency>
-        <groupId>org.apache.kafka</groupId>
-        <artifactId>kafka-clients</artifactId>
-        <version>${kafkaStreamsVersion}</version>
+        <groupId>org.apache.servicemix.bundles</groupId>
+        <artifactId>org.apache.servicemix.bundles.kafka-clients</artifactId>
+        <version>${kafkaBundleVersion}</version>
         <exclusions>
           <exclusion>
             <artifactId>log4j</artifactId>
@@ -64,9 +64,9 @@
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.kafka</groupId>
-        <artifactId>kafka_2.12</artifactId>
-        <version>${kafkaStreamsVersion}</version>
+        <groupId>org.apache.servicemix.bundles</groupId>
+        <artifactId>org.apache.servicemix.bundles.kafka_${scalaVersion}</artifactId>
+        <version>${kafkaBundleVersion}</version>
         <exclusions>
           <exclusion>
             <artifactId>log4j</artifactId>
@@ -75,13 +75,17 @@
           <exclusion>
             <artifactId>slf4j-log4j12</artifactId>
             <groupId>org.slf4j</groupId>
+          </exclusion>
+          <exclusion>
+            <artifactId>kafka-clients</artifactId>
+            <groupId>org.apache.kafka</groupId>
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
         <groupId>org.scala-lang</groupId>
         <artifactId>scala-library</artifactId>
-        <version>2.12.8</version>
+        <version>${scalaLibraryVersion}</version>
       </dependency>
       <dependency>
         <groupId>org.opennms.core.health</groupId>

--- a/core/ipc/sink/kafka/server/src/main/java/org/opennms/core/ipc/sink/kafka/server/offset/KafkaOffsetProvider.java
+++ b/core/ipc/sink/kafka/server/src/main/java/org/opennms/core/ipc/sink/kafka/server/offset/KafkaOffsetProvider.java
@@ -297,10 +297,9 @@ public class KafkaOffsetProvider {
     }
 
     public void closeConnection() throws InterruptedException {
-        for (KafkaConsumer consumer : consumerMap.values()) {
-            //TODO Find a replacement for SimpleConsumer.host() for logging
-            LOGGER.info("Closing connection for: <Unknown Consumer Host>");
-            consumer.close();
+        for (Map.Entry<String, KafkaConsumer> consumer : consumerMap.entrySet()) {
+            LOGGER.info("Closing connection for: " + consumer.getKey());
+            consumer.getValue().close();
         }
     }
 

--- a/core/test-api/kafka/pom.xml
+++ b/core/test-api/kafka/pom.xml
@@ -62,9 +62,9 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.apache.servicemix.bundles</groupId>
-      <artifactId>org.apache.servicemix.bundles.kafka_2.11</artifactId>
-      <version>${kafkaStreamsBundleVersion}</version>
+      <groupId>org.apache.kafka</groupId>
+      <artifactId>kafka_2.12</artifactId>
+      <version>${kafkaStreamsVersion}</version>
       <exclusions>
         <exclusion>
           <artifactId>log4j</artifactId>
@@ -99,7 +99,7 @@
     <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-library</artifactId>
-      <version>2.11.11</version>
+      <version>2.12.8</version>
     </dependency>
     <dependency>
       <groupId>com.yammer.metrics</groupId>

--- a/core/test-api/kafka/pom.xml
+++ b/core/test-api/kafka/pom.xml
@@ -47,9 +47,9 @@
       <artifactId>commons-io</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.servicemix.bundles</groupId>
-      <artifactId>org.apache.servicemix.bundles.kafka-clients</artifactId>
-      <version>${kafkaStreamsBundleVersion}</version>
+      <groupId>org.apache.kafka</groupId>
+      <artifactId>kafka-clients</artifactId>
+      <version>${kafkaStreamsVersion}</version>
       <exclusions>
         <exclusion>
           <artifactId>log4j</artifactId>

--- a/core/test-api/kafka/pom.xml
+++ b/core/test-api/kafka/pom.xml
@@ -47,9 +47,9 @@
       <artifactId>commons-io</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.kafka</groupId>
-      <artifactId>kafka-clients</artifactId>
-      <version>${kafkaStreamsVersion}</version>
+      <groupId>org.apache.servicemix.bundles</groupId>
+      <artifactId>org.apache.servicemix.bundles.kafka-clients</artifactId>
+      <version>${kafkaBundleVersion}</version>
       <exclusions>
         <exclusion>
           <artifactId>log4j</artifactId>
@@ -62,9 +62,9 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.apache.kafka</groupId>
-      <artifactId>kafka_2.12</artifactId>
-      <version>${kafkaStreamsVersion}</version>
+      <groupId>org.apache.servicemix.bundles</groupId>
+      <artifactId>org.apache.servicemix.bundles.kafka_${scalaVersion}</artifactId>
+      <version>${kafkaBundleVersion}</version>
       <exclusions>
         <exclusion>
           <artifactId>log4j</artifactId>
@@ -73,6 +73,10 @@
         <exclusion>
           <artifactId>slf4j-log4j12</artifactId>
           <groupId>org.slf4j</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>kafka-clients</artifactId>
+          <groupId>org.apache.kafka</groupId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -99,7 +103,7 @@
     <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-library</artifactId>
-      <version>2.12.8</version>
+      <version>${scalaLibraryVersion}</version>
     </dependency>
     <dependency>
       <groupId>com.yammer.metrics</groupId>
@@ -115,6 +119,26 @@
       <groupId>org.apache.curator</groupId>
       <artifactId>curator-test</artifactId>
       <version>2.11.1</version>
+    </dependency>
+    <dependency>
+      <groupId>com.typesafe.scala-logging</groupId>
+      <artifactId>scala-logging_${scalaVersion}</artifactId>
+      <version>${scalaLoggingVersion}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>${jackson2Version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+      <version>${jackson2Version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+      <version>${jackson2Version}</version>
     </dependency>
   </dependencies>
 </project>

--- a/features/kafka/producer/pom.xml
+++ b/features/kafka/producer/pom.xml
@@ -77,9 +77,9 @@
       <version>${kafkaStreamsVersion}</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.servicemix.bundles</groupId>
-      <artifactId>org.apache.servicemix.bundles.kafka-clients</artifactId>
-      <version>${kafkaStreamsBundleVersion}</version>
+      <groupId>org.apache.kafka</groupId>
+      <artifactId>kafka-clients</artifactId>
+      <version>${kafkaStreamsVersion}</version>
       <exclusions>
         <exclusion>
           <artifactId>log4j</artifactId>

--- a/features/kafka/producer/pom.xml
+++ b/features/kafka/producer/pom.xml
@@ -74,12 +74,18 @@
     <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>kafka-streams</artifactId>
-      <version>${kafkaStreamsVersion}</version>
+      <version>${kafkaVersion}</version>
+      <exclusions>
+        <exclusion>
+          <artifactId>kafka-clients</artifactId>
+          <groupId>org.apache.kafka</groupId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.apache.kafka</groupId>
-      <artifactId>kafka-clients</artifactId>
-      <version>${kafkaStreamsVersion}</version>
+      <groupId>org.apache.servicemix.bundles</groupId>
+      <artifactId>org.apache.servicemix.bundles.kafka-clients</artifactId>
+      <version>${kafkaBundleVersion}</version>
       <exclusions>
         <exclusion>
           <artifactId>log4j</artifactId>

--- a/features/kafka/producer/src/main/java/org/opennms/features/kafka/producer/datasync/KafkaAlarmDataSync.java
+++ b/features/kafka/producer/src/main/java/org/opennms/features/kafka/producer/datasync/KafkaAlarmDataSync.java
@@ -47,7 +47,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
 import org.apache.kafka.common.serialization.Serdes;
-import org.apache.kafka.streams.Consumed;
+import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;

--- a/pom.xml
+++ b/pom.xml
@@ -1311,8 +1311,8 @@
     <jsonlibVersion>2.4</jsonlibVersion>
     <jsonlibBundleVersion>2.4_1</jsonlibBundleVersion>
     <karafVersion>4.2.3</karafVersion>
-    <kafkaStreamsVersion>1.0.1</kafkaStreamsVersion>
-    <kafkaStreamsBundleVersion>1.0.1_1</kafkaStreamsBundleVersion>
+    <kafkaStreamsVersion>2.1.1</kafkaStreamsVersion>
+    <kafkaStreamsBundleVersion>2.1.1_1</kafkaStreamsBundleVersion>
     <felixBridgeVersion>4.0.4</felixBridgeVersion>
     <felixProxyVersion>3.0.4</felixProxyVersion>
     <liquibaseVersion>3.6.3</liquibaseVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -1311,8 +1311,8 @@
     <jsonlibVersion>2.4</jsonlibVersion>
     <jsonlibBundleVersion>2.4_1</jsonlibBundleVersion>
     <karafVersion>4.2.3</karafVersion>
-    <kafkaStreamsVersion>2.1.1</kafkaStreamsVersion>
-    <kafkaStreamsBundleVersion>2.1.1_1</kafkaStreamsBundleVersion>
+    <kafkaStreamsVersion>2.2.0</kafkaStreamsVersion>
+    <kafkaStreamsBundleVersion>2.2.0_1</kafkaStreamsBundleVersion>
     <felixBridgeVersion>4.0.4</felixBridgeVersion>
     <felixProxyVersion>3.0.4</felixProxyVersion>
     <liquibaseVersion>3.6.3</liquibaseVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -1274,6 +1274,8 @@
     <eclipseGeminiVersion>2.0.0.RELEASE</eclipseGeminiVersion>
     <eclipselinkVersion>2.5.1</eclipselinkVersion>
     <elasticsearchNettyVersion>4.1.30.Final</elasticsearchNettyVersion>
+    <felixBridgeVersion>4.0.4</felixBridgeVersion>
+    <felixProxyVersion>3.0.4</felixProxyVersion>
     <fopVersion>1.0</fopVersion>
     <freemarkerVersion>2.3.23</freemarkerVersion>
     <geronimoVersion>1.1.1</geronimoVersion>
@@ -1291,7 +1293,7 @@
     <httpclientVersion>4.5.2</httpclientVersion>
     <httpasyncclientVersion>4.1.3</httpasyncclientVersion>
     <jacksonVersion>1.9.13</jacksonVersion>
-    <jackson2Version>2.6.6</jackson2Version>
+    <jackson2Version>2.9.8</jackson2Version>
     <jasperreportsVersion>6.3.0</jasperreportsVersion>
     <jasperreportsMavenPluginVersion>1.0-beta-4-OPENNMS-20160912-1</jasperreportsMavenPluginVersion>
     <jcifsVersion>1.3.14</jcifsVersion>
@@ -1311,10 +1313,8 @@
     <jsonlibVersion>2.4</jsonlibVersion>
     <jsonlibBundleVersion>2.4_1</jsonlibBundleVersion>
     <karafVersion>4.2.3</karafVersion>
-    <kafkaStreamsVersion>2.2.0</kafkaStreamsVersion>
-    <kafkaStreamsBundleVersion>2.2.0_1</kafkaStreamsBundleVersion>
-    <felixBridgeVersion>4.0.4</felixBridgeVersion>
-    <felixProxyVersion>3.0.4</felixProxyVersion>
+    <kafkaBundleVersion>2.2.0_1</kafkaBundleVersion>
+    <kafkaVersion>2.2.0</kafkaVersion>
     <liquibaseVersion>3.6.3</liquibaseVersion>
     <lmaxDisruptorVersion>3.3.2</lmaxDisruptorVersion>
     <log4jVersion>99.99.99-use-log4j2</log4jVersion>
@@ -1343,6 +1343,10 @@
     <jeagertracingVersion>0.34.0</jeagertracingVersion>
     <quartzVersion>2.2.3</quartzVersion>
     <rateLimitedLoggerVersion>1.1.0</rateLimitedLoggerVersion>
+    <rocksdbjniVersion>5.15.10</rocksdbjniVersion>
+    <scalaLibraryVersion>2.12.8</scalaLibraryVersion>
+    <scalaLoggingVersion>3.9.0</scalaLoggingVersion>
+    <scalaVersion>2.12</scalaVersion>
     <servletApiVersion>3.1.0</servletApiVersion>
     <slf4jVersion>1.7.21</slf4jVersion>
     <snmp4jVersion>2.5.5</snmp4jVersion>

--- a/smoke-test/pom.xml
+++ b/smoke-test/pom.xml
@@ -11,7 +11,7 @@
     <updatePolicy>interval:60</updatePolicy>
     <camelVersion>2.19.1</camelVersion>
     <frontendPluginVersion>0.0.29</frontendPluginVersion>
-    <jackson2Version>2.6.6</jackson2Version>
+    <jackson2Version>2.9.8</jackson2Version>
     <jestVersion>5.3.3</jestVersion>
     <karafVersion>4.2.3</karafVersion>
     <test.fork.count>1</test.fork.count>


### PR DESCRIPTION
This PR will upgrade kafka components to 2.2.0 from 1.0.1

The major changes were to KafkaOffsetProvider which used deprecated Scala functions, these were changed to the newer API. Impact should be minimal as this is only used by the test KafkaOffsetIT

Main code changes were minor to KafkaAlarmDataSync which moved the import path of Consumed

* JIRA: http://issues.opennms.org/browse/NMS-10624