### PR TITLE
NMS-10581: Handle graceful shutdown for OpenNMS

### DIFF
--- a/container/karaf/src/main/filtered-resources/etc/system.properties
+++ b/container/karaf/src/main/filtered-resources/etc/system.properties
@@ -161,6 +161,10 @@ karaf.secured.services = (&(osgi.command.scope=*)(osgi.command.function=*))
 # OPENNMS: Enable SNMP4J Log4j logging
 snmp4j.LogFactory=org.snmp4j.log.Log4jLogFactory
 
+# OPENNMS: Disable SIGTERM in karaf as OpenNMS should handle SIGTERM.
+karaf.handle.sigterm = false
+
+
 # OPENNMS: If you're using Bouncy Castle, disable the Bouncy Castle security provider 
 # for Apache MINA SSHD because it silently fails if Bouncy Castle is in the system classpath
 #

--- a/core/daemon/src/main/java/org/opennms/netmgt/vmmgr/Manager.java
+++ b/core/daemon/src/main/java/org/opennms/netmgt/vmmgr/Manager.java
@@ -91,6 +91,13 @@ public class Manager implements ManagerMBean {
     private static final String m_osName = System.getProperty("os.name") == null? "" : System.getProperty("os.name").toLowerCase();
     private static long startTime = System.currentTimeMillis();
 
+
+    /**
+     *  Register shutdown hook to handle SIGTERM signal for the process.
+     */
+    public void init() {
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> stop()));
+    }
     /**
      * <p>stop</p>
      */

--- a/core/daemon/src/main/java/org/opennms/netmgt/vmmgr/Manager.java
+++ b/core/daemon/src/main/java/org/opennms/netmgt/vmmgr/Manager.java
@@ -39,6 +39,7 @@ import java.util.Map.Entry;
 import java.util.Timer;
 import java.util.TimerTask;
 import java.util.TreeMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import javax.management.MBeanServer;
 import javax.management.MBeanServerFactory;
@@ -90,6 +91,7 @@ public class Manager implements ManagerMBean {
     private static final String LOG4J_CATEGORY = "manager";
     private static final String m_osName = System.getProperty("os.name") == null? "" : System.getProperty("os.name").toLowerCase();
     private static long startTime = System.currentTimeMillis();
+    private static AtomicBoolean stopInitiated = new AtomicBoolean(false);
 
 
     /**
@@ -102,7 +104,11 @@ public class Manager implements ManagerMBean {
      * <p>stop</p>
      */
     @Override
-    public void stop() {
+    public synchronized void stop() {
+        if (stopInitiated.get()) {
+            return;
+        }
+        stopInitiated.set(true);
         setLogPrefix();
 
         for (MBeanServer server : getMBeanServers()) {

--- a/core/daemon/src/main/java/org/opennms/netmgt/vmmgr/ManagerMBean.java
+++ b/core/daemon/src/main/java/org/opennms/netmgt/vmmgr/ManagerMBean.java
@@ -33,6 +33,10 @@ import java.util.List;
 public interface ManagerMBean {
 
     /**
+     * <p>init</p>
+     */
+    public void init();
+    /**
      * <p>dumpThreads</p>
      */
     public void dumpThreads();

--- a/opennms-base-assembly/src/main/filtered/etc/service-configuration.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/service-configuration.xml
@@ -10,6 +10,7 @@ maintained
   <service>
     <name>OpenNMS:Name=Manager</name>
     <class-name>org.opennms.netmgt.vmmgr.Manager</class-name>
+    <invoke at="start" pass="0" method="init"/>
     <invoke at="stop" pass="1" method="doSystemExit"/>
   </service>
   <service>


### PR DESCRIPTION
Currently OpenNMS doesn't shutdown with `kill -s TERM` or `kill -s INT` 
Adding shutdown hook in Manager will allow OpenNMS to shutdown gracefully without the need for force kill.
Disable shutdown hook in karaf for OpenNMS.

* JIRA: http://issues.opennms.org/browse/NMS-10581

Our [continuous integration system](http://bamboo.internal.opennms.com:8085) will test and verify your changes.
