### PR TITLE
NMS-10597: Limit SNMP Datacollection by Table Index

### DIFF
--- a/opennms-services/src/main/java/org/opennms/netmgt/collectd/PersistRegexSelectorStrategy.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/collectd/PersistRegexSelectorStrategy.java
@@ -89,6 +89,7 @@ public class PersistRegexSelectorStrategy implements PersistenceSelectorStrategy
         }
         EvaluatorContextVisitor visitor = new EvaluatorContextVisitor();
         resource.visit(visitor);
+        visitor.getEvaluationContext().setVariable("instance", resource.getInstance());
         ExpressionParser parser = new SpelExpressionParser();
         for (Parameter param : m_parameterCollection) {
             if (param.getKey().equals(MATCH_EXPRESSION)) {

--- a/opennms-services/src/test/java/org/opennms/netmgt/collectd/PersistRegexSelectorStrategyTest.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/collectd/PersistRegexSelectorStrategyTest.java
@@ -150,7 +150,7 @@ public class PersistRegexSelectorStrategyTest {
         persistenceSelectorStrategyInst.setClazz("org.opennms.netmgt.collectd.PersistRegexSelectorStrategy");
         Parameter paramInst = new Parameter();
         paramInst.setKey(PersistRegexSelectorStrategy.MATCH_EXPRESSION);
-        paramInst.setValue("#instance matches '.3$'");
+        paramInst.setValue("#instance matches '.*\\.3$'");
         persistenceSelectorStrategyInst.addParameter(paramInst);
         rtInst.setPersistenceSelectorStrategy(persistenceSelectorStrategyInst);
         GenericIndexResourceType resourceTypeInst = new GenericIndexResourceType(agent, snmpCollection, rtInst);

--- a/opennms-services/src/test/java/org/opennms/netmgt/collectd/PersistRegexSelectorStrategyTest.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/collectd/PersistRegexSelectorStrategyTest.java
@@ -75,6 +75,8 @@ public class PersistRegexSelectorStrategyTest {
     private IpInterfaceDao ipInterfaceDao;
     private GenericIndexResource resourceA;
     private GenericIndexResource resourceB;
+    private GenericIndexResource resourceC;
+    private GenericIndexResource resourceD;
     private ServiceParameters serviceParams;
 
     @Before
@@ -139,6 +141,24 @@ public class PersistRegexSelectorStrategyTest {
         resourceA.setAttributeValue(attributeType, snmpValue);
         
         resourceB = new GenericIndexResource(resourceType, rt.getName(), new SnmpInstId("1.2.3.4.5.6.7.8.9.1.2"));
+
+        // selector sensitive to instance IDs
+        org.opennms.netmgt.config.datacollection.ResourceType rtInst = new org.opennms.netmgt.config.datacollection.ResourceType();
+        rtInst.setName("myResourceType");
+        rtInst.setStorageStrategy(storageStrategy);
+        PersistenceSelectorStrategy persistenceSelectorStrategyInst = new PersistenceSelectorStrategy();
+        persistenceSelectorStrategyInst.setClazz("org.opennms.netmgt.collectd.PersistRegexSelectorStrategy");
+        Parameter paramInst = new Parameter();
+        paramInst.setKey(PersistRegexSelectorStrategy.MATCH_EXPRESSION);
+        paramInst.setValue("#instance matches '.3$'");
+        persistenceSelectorStrategyInst.addParameter(paramInst);
+        rtInst.setPersistenceSelectorStrategy(persistenceSelectorStrategyInst);
+        GenericIndexResourceType resourceTypeInst = new GenericIndexResourceType(agent, snmpCollection, rtInst);
+
+
+        resourceC = new GenericIndexResource(resourceTypeInst, rt.getName(), new SnmpInstId("1.2.3.4.5.6.7.8.9.1.3"));
+        resourceD = new GenericIndexResource(resourceTypeInst, rt.getName(), new SnmpInstId("1.2.3.4.5.6.7.8.9.1.4"));
+
     }
 
     @After
@@ -150,6 +170,8 @@ public class PersistRegexSelectorStrategyTest {
     public void testPersistSelector() throws Exception {
         Assert.assertTrue(resourceA.shouldPersist(serviceParams));
         Assert.assertFalse(resourceB.shouldPersist(serviceParams));
+        Assert.assertTrue(resourceC.shouldPersist(serviceParams));
+        Assert.assertFalse(resourceD.shouldPersist(serviceParams));
     }
 
     @Test

--- a/opennms-services/src/test/java/org/opennms/netmgt/collectd/PersistRegexSelectorStrategyTest.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/collectd/PersistRegexSelectorStrategyTest.java
@@ -144,7 +144,7 @@ public class PersistRegexSelectorStrategyTest {
 
         // selector sensitive to instance IDs
         org.opennms.netmgt.config.datacollection.ResourceType rtInst = new org.opennms.netmgt.config.datacollection.ResourceType();
-        rtInst.setName("myResourceType");
+        rtInst.setName("myResourceTypeTwo");
         rtInst.setStorageStrategy(storageStrategy);
         PersistenceSelectorStrategy persistenceSelectorStrategyInst = new PersistenceSelectorStrategy();
         persistenceSelectorStrategyInst.setClazz("org.opennms.netmgt.collectd.PersistRegexSelectorStrategy");
@@ -155,9 +155,8 @@ public class PersistRegexSelectorStrategyTest {
         rtInst.setPersistenceSelectorStrategy(persistenceSelectorStrategyInst);
         GenericIndexResourceType resourceTypeInst = new GenericIndexResourceType(agent, snmpCollection, rtInst);
 
-
-        resourceC = new GenericIndexResource(resourceTypeInst, rt.getName(), new SnmpInstId("1.2.3.4.5.6.7.8.9.1.3"));
-        resourceD = new GenericIndexResource(resourceTypeInst, rt.getName(), new SnmpInstId("1.2.3.4.5.6.7.8.9.1.4"));
+        resourceC = new GenericIndexResource(resourceTypeInst, rtInst.getName(), new SnmpInstId("1.2.3.4.5.6.7.8.9.1.3"));
+        resourceD = new GenericIndexResource(resourceTypeInst, rtInst.getName(), new SnmpInstId("1.2.3.4.5.6.7.8.9.1.4"));
 
     }
 

--- a/opennms-services/src/test/java/org/opennms/netmgt/collectd/PersistRegexSelectorStrategyTest.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/collectd/PersistRegexSelectorStrategyTest.java
@@ -157,7 +157,6 @@ public class PersistRegexSelectorStrategyTest {
 
         resourceC = new GenericIndexResource(resourceTypeInst, rtInst.getName(), new SnmpInstId("1.2.3.4.5.6.7.8.9.1.3"));
         resourceD = new GenericIndexResource(resourceTypeInst, rtInst.getName(), new SnmpInstId("1.2.3.4.5.6.7.8.9.1.4"));
-
     }
 
     @After
@@ -167,10 +166,10 @@ public class PersistRegexSelectorStrategyTest {
 
     @Test
     public void testPersistSelector() throws Exception {
-        Assert.assertTrue(resourceA.shouldPersist(serviceParams));
-        Assert.assertFalse(resourceB.shouldPersist(serviceParams));
-        Assert.assertTrue(resourceC.shouldPersist(serviceParams));
-        Assert.assertFalse(resourceD.shouldPersist(serviceParams));
+        Assert.assertTrue("resourceA matches parameter expression", resourceA.shouldPersist(serviceParams));
+        Assert.assertFalse("resourceB doesn't matche parameter expression", resourceB.shouldPersist(serviceParams));
+        Assert.assertTrue("resourceC matches instance expression", resourceC.shouldPersist(serviceParams));
+        Assert.assertFalse("resourceD doesn't match instance expression", resourceD.shouldPersist(serviceParams));
     }
 
     @Test


### PR DESCRIPTION
This add a new "instance" variable to the expression context
for PersistRegexSelectorStrategy, which makes it possible
to only collect specific rows from a table based upon their
index.

* JIRA: https://issues.opennms.org/browse/NMS-10597

I'll look at adapting any existing tests to verify this works as expected.