### PR TITLE
NMS-10627: handle "LTS" tag at the end of JDK 11 version

### DIFF
--- a/opennms-base-assembly/src/main/filtered/bin/find-java.sh
+++ b/opennms-base-assembly/src/main/filtered/bin/find-java.sh
@@ -35,7 +35,7 @@ get_java_version_string() {
 	home="$1"; shift
 	full_version_string="$("${home}"/bin/java -version 2>&1 | grep ' version ')"
 	#version_string="$(printf '%s' "${full_version_string}" | sed -e 's,^.* version ,,' -e 's,^"\(.*\)"$,\1,' -e 's,-[A-Za-z]*$,,' -e 's,^1\.,,')"
-	version_string="$(printf '%s' "${full_version_string}" | sed -e 's,^.* version ,,' -e 's, [0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]$,,' -e 's,^"\(.*\)"$,\1,' -e 's,-[A-Za-z]*$,,')"
+	version_string="$(printf '%s' "${full_version_string}" | sed -e 's,^.* version ,,' -e 's, LTS$,,' -e 's, [0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]$,,' -e 's,^"\(.*\)"$,\1,' -e 's,-[A-Za-z]*$,,')"
 	if (printf '%s' "${version_string}" | grep -Eq '^[0-9\._]+$'); then
 		# valid parsed version string, only numbers and periods
 		printf '%s\n' "${version_string}"


### PR DESCRIPTION
This PR adds support for parsing JDK version strings that have " LTS" at the end, which was causing the version regex to fail.

* JIRA: http://issues.opennms.org/browse/NMS-10627

Our [continuous integration system](http://bamboo.internal.opennms.com:8085) will test and verify your changes.
