### PR TITLE
NMS-10619: make sure _lib.sh exists before using it in find-java.sh

### DIFF
--- a/opennms-assemblies/minion/pom.xml
+++ b/opennms-assemblies/minion/pom.xml
@@ -108,7 +108,7 @@
                   <classifier>daemon</classifier>
                   <type>tar.gz</type>
                   <outputDirectory>${project.build.directory}/unpacked/base-assembly</outputDirectory>
-                  <includes>bin/find-java.sh,bin/ensure-user-ping.sh</includes>
+                  <includes>bin/_lib.sh,bin/find-java.sh,bin/ensure-user-ping.sh</includes>
                 </artifactItem>
               </artifactItems>
             </configuration>

--- a/opennms-assemblies/sentinel/pom.xml
+++ b/opennms-assemblies/sentinel/pom.xml
@@ -100,7 +100,7 @@
                   <classifier>daemon</classifier>
                   <type>tar.gz</type>
                   <outputDirectory>${project.build.directory}/unpacked/base-assembly</outputDirectory>
-                  <includes>bin/find-java.sh,bin/ensure-user-ping.sh</includes>
+                  <includes>bin/_lib.sh,bin/find-java.sh,bin/ensure-user-ping.sh</includes>
                 </artifactItem>
               </artifactItems>
             </configuration>

--- a/opennms-base-assembly/src/main/filtered/bin/find-java.sh
+++ b/opennms-base-assembly/src/main/filtered/bin/find-java.sh
@@ -4,10 +4,12 @@ MYDIR="$(dirname "$0")"
 MYDIR="$(cd "$MYDIR" || exit 1; pwd)"
 
 # shellcheck disable=SC1090
-. "${MYDIR}/_lib.sh"
+if [ -e "${MYDIR}/_lib.sh" ]; then
+	. "${MYDIR}/_lib.sh"
 
-# if $JAVA_SEARCH_DIRS is already set, make sure it is treated as an array
-__onms_convert_to_array JAVA_SEARCH_DIRS
+	# if $JAVA_SEARCH_DIRS is already set, make sure it is treated as an array
+	__onms_convert_to_array JAVA_SEARCH_DIRS
+fi
 
 compare_versions() {
 	a="$(printf '%s.0.0.0' "${1}" | sed -e 's,^1\.\([123456789]\),\1.0,' -e 's,_,.,g')"


### PR DESCRIPTION
This PR fixes the issue where starting Minion or Sentinel will complain about `_lib.sh` and fail to call `__onms_convert_to_array`.

It is harmless unless you're trying to override the default java search directories with the `$JAVA_SEARCH_DIRS` environment variable, but it is annoying.  ;)

* JIRA: http://issues.opennms.org/browse/NMS-10619

Our [continuous integration system](http://bamboo.internal.opennms.com:8085) will test and verify your changes.
