### PR TITLE
OCE-55: Add topology(link) support to the OpenNMS Direct datasource

### DIFF
--- a/features/api-layer/pom.xml
+++ b/features/api-layer/pom.xml
@@ -140,6 +140,13 @@
             <groupId>org.opennms.features.enlinkd</groupId>
             <artifactId>org.opennms.features.enlinkd.service.api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.opennms.features.topologies</groupId>
+            <artifactId>org.opennms.features.topologies.service.api</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <repositories>

--- a/features/api-layer/pom.xml
+++ b/features/api-layer/pom.xml
@@ -132,6 +132,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.opennms.features.topologies</groupId>
+            <artifactId>org.opennms.features.topologies.service.api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.opennms.features.enlinkd</groupId>
             <artifactId>org.opennms.features.enlinkd.service.api</artifactId>
         </dependency>

--- a/features/api-layer/pom.xml
+++ b/features/api-layer/pom.xml
@@ -114,6 +114,11 @@
             <artifactId>mapstruct</artifactId>
             <version>${mapstructVersion}</version>
         </dependency>
+        <dependency>
+            <groupId>org.opennms.features.topologies</groupId>
+            <artifactId>org.opennms.features.topologies.service.api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
 
         <!-- Test -->
         <dependency>
@@ -130,11 +135,6 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.opennms.features.topologies</groupId>
-            <artifactId>org.opennms.features.topologies.service.api</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.opennms.features.enlinkd</groupId>

--- a/features/api-layer/src/main/java/org/opennms/features/apilayer/model/InMemoryEventBean.java
+++ b/features/api-layer/src/main/java/org/opennms/features/apilayer/model/InMemoryEventBean.java
@@ -98,4 +98,9 @@ public class InMemoryEventBean implements InMemoryEvent {
                 .filter(p -> Objects.equals(name, p.getName()))
                 .collect(Collectors.toList());
     }
+
+    @Override
+    public Integer getNodeId() {
+        return null;
+    }
 }

--- a/features/api-layer/src/main/java/org/opennms/features/apilayer/model/InMemoryEventBean.java
+++ b/features/api-layer/src/main/java/org/opennms/features/apilayer/model/InMemoryEventBean.java
@@ -98,9 +98,4 @@ public class InMemoryEventBean implements InMemoryEvent {
                 .filter(p -> Objects.equals(name, p.getName()))
                 .collect(Collectors.toList());
     }
-
-    @Override
-    public Integer getNodeId() {
-        return null;
-    }
 }

--- a/features/api-layer/src/main/java/org/opennms/features/apilayer/requisition/mappers/RequisitionInterfaceMapper.java
+++ b/features/api-layer/src/main/java/org/opennms/features/apilayer/requisition/mappers/RequisitionInterfaceMapper.java
@@ -40,9 +40,7 @@ public interface RequisitionInterfaceMapper {
     @Mappings({
             @Mapping(source = "ipAddr", target = "ipAddress"),
             @Mapping(source = "descr", target = "description"),
-            @Mapping(target = "monitoredService", ignore = true),
-            @Mapping(target = "monitoredServices", ignore = true),
-            @Mapping(target = "metaData", ignore = true)
+            @Mapping(target = "monitoredService", ignore = true)
     })
     RequisitionInterfaceBean map(RequisitionInterface iface);
 

--- a/features/api-layer/src/main/java/org/opennms/features/apilayer/requisition/mappers/RequisitionInterfaceMapper.java
+++ b/features/api-layer/src/main/java/org/opennms/features/apilayer/requisition/mappers/RequisitionInterfaceMapper.java
@@ -40,7 +40,9 @@ public interface RequisitionInterfaceMapper {
     @Mappings({
             @Mapping(source = "ipAddr", target = "ipAddress"),
             @Mapping(source = "descr", target = "description"),
-            @Mapping(target = "monitoredService", ignore = true)
+            @Mapping(target = "monitoredService", ignore = true),
+            @Mapping(target = "monitoredServices", ignore = true),
+            @Mapping(target = "metaData", ignore = true)
     })
     RequisitionInterfaceBean map(RequisitionInterface iface);
 

--- a/features/api-layer/src/main/java/org/opennms/features/apilayer/topology/EdgeDaoImpl.java
+++ b/features/api-layer/src/main/java/org/opennms/features/apilayer/topology/EdgeDaoImpl.java
@@ -1,0 +1,104 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.features.apilayer.topology;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Predicate;
+
+import org.opennms.features.apilayer.utils.ModelMappers;
+import org.opennms.integration.api.v1.dao.EdgeDao;
+import org.opennms.integration.api.v1.model.TopologyEdge;
+import org.opennms.netmgt.topologies.service.api.OnmsTopologyDao;
+import org.opennms.netmgt.topologies.service.api.OnmsTopologyProtocol;
+
+/**
+ * This class acts as a simple intermediary layer on top of {@link OnmsTopologyDao} to satisfy the contract of
+ * {@link EdgeDao the integration API} by exposing the functionality only via OSGI.
+ */
+public class EdgeDaoImpl implements EdgeDao {
+    private final OnmsTopologyDao onmsTopologyDao;
+
+    public EdgeDaoImpl(OnmsTopologyDao onmsTopologyDao) {
+        this.onmsTopologyDao = Objects.requireNonNull(onmsTopologyDao);
+    }
+
+    private static boolean includeAll(OnmsTopologyProtocol protocol) {
+        return true;
+    }
+
+    private long getEdgeCount(Predicate<OnmsTopologyProtocol> filter) {
+        return onmsTopologyDao.getTopologies()
+                .entrySet()
+                .stream()
+                .filter(entry -> filter.test(entry.getKey()))
+                .mapToLong(entry -> entry.getValue().getEdges().size())
+                .sum();
+    }
+
+    private Collection<TopologyEdge> getEdges(Predicate<OnmsTopologyProtocol> filter) {
+        Set<TopologyEdge> currentEdges = new HashSet<>();
+        onmsTopologyDao.getTopologies()
+                .entrySet()
+                .stream()
+                .filter(entry -> filter.test(entry.getKey()))
+                .forEach(entry -> entry.getValue().getEdges()
+                        .stream()
+                        .map(edge -> ModelMappers.toEdge(entry.getKey().getId(), edge))
+                        .forEach(currentEdges::add));
+        return currentEdges;
+    }
+
+    @Override
+    public long getEdgeCount() {
+        return getEdgeCount(EdgeDaoImpl::includeAll);
+    }
+
+    @Override
+    public long getEdgeCount(String protocol) {
+        return getEdgeCount(p -> p.getId().equals(protocol));
+    }
+
+    @Override
+    public Collection<TopologyEdge> getEdges() {
+        return getEdges(EdgeDaoImpl::includeAll);
+    }
+
+    @Override
+    public Collection<TopologyEdge> getEdges(String protocol) {
+        return getEdges(p -> p.getId().equals(protocol));
+    }
+
+    @Override
+    public Set<String> getProtocols() {
+        return onmsTopologyDao.getSupportedProtocols();
+    }
+}

--- a/features/api-layer/src/main/java/org/opennms/features/apilayer/topology/EdgeDaoImpl.java
+++ b/features/api-layer/src/main/java/org/opennms/features/apilayer/topology/EdgeDaoImpl.java
@@ -28,7 +28,6 @@
 
 package org.opennms.features.apilayer.topology;
 
-import java.util.Collection;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
@@ -66,7 +65,7 @@ public class EdgeDaoImpl implements EdgeDao {
                 .sum();
     }
 
-    private Collection<TopologyEdge> getEdges(Predicate<OnmsTopologyProtocol> filter) {
+    private Set<TopologyEdge> getEdges(Predicate<OnmsTopologyProtocol> filter) {
         Set<TopologyEdge> currentEdges = new HashSet<>();
         onmsTopologyDao.getTopologies()
                 .entrySet()
@@ -93,12 +92,12 @@ public class EdgeDaoImpl implements EdgeDao {
     }
 
     @Override
-    public Collection<TopologyEdge> getEdges() {
+    public Set<TopologyEdge> getEdges() {
         return getEdges(EdgeDaoImpl::includeAll);
     }
 
     @Override
-    public Collection<TopologyEdge> getEdges(TopologyProtocol protocol) {
+    public Set<TopologyEdge> getEdges(TopologyProtocol protocol) {
         if(protocol == TopologyProtocol.ALL) {
             return getEdges();
         }

--- a/features/api-layer/src/main/java/org/opennms/features/apilayer/topology/EdgeDaoImpl.java
+++ b/features/api-layer/src/main/java/org/opennms/features/apilayer/topology/EdgeDaoImpl.java
@@ -34,6 +34,7 @@ import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
+import org.opennms.features.apilayer.utils.EdgeMapper;
 import org.opennms.features.apilayer.utils.ModelMappers;
 import org.opennms.integration.api.v1.dao.EdgeDao;
 import org.opennms.integration.api.v1.model.TopologyEdge;
@@ -47,9 +48,11 @@ import org.opennms.netmgt.topologies.service.api.OnmsTopologyProtocol;
  */
 public class EdgeDaoImpl implements EdgeDao {
     private final OnmsTopologyDao onmsTopologyDao;
+    private final EdgeMapper edgeMapper;
 
-    public EdgeDaoImpl(OnmsTopologyDao onmsTopologyDao) {
+    public EdgeDaoImpl(OnmsTopologyDao onmsTopologyDao, EdgeMapper edgeMapper) {
         this.onmsTopologyDao = Objects.requireNonNull(onmsTopologyDao);
+        this.edgeMapper = Objects.requireNonNull(edgeMapper);
     }
 
     private static boolean includeAll(OnmsTopologyProtocol protocol) {
@@ -73,7 +76,7 @@ public class EdgeDaoImpl implements EdgeDao {
                 .filter(entry -> filter.test(entry.getKey()))
                 .forEach(entry -> entry.getValue().getEdges()
                         .stream()
-                        .map(edge -> ModelMappers.toEdge(entry.getKey(), edge))
+                        .map(edge -> edgeMapper.toEdge(entry.getKey(), edge))
                         .forEach(currentEdges::add));
         return currentEdges;
     }

--- a/features/api-layer/src/main/java/org/opennms/features/apilayer/topology/TopologyEdgeConsumerManager.java
+++ b/features/api-layer/src/main/java/org/opennms/features/apilayer/topology/TopologyEdgeConsumerManager.java
@@ -29,8 +29,8 @@
 package org.opennms.features.apilayer.topology;
 
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.opennms.features.apilayer.utils.InterfaceMapper;
 import org.opennms.features.apilayer.utils.ModelMappers;
@@ -62,21 +62,16 @@ public class TopologyEdgeConsumerManager extends InterfaceMapper<TopologyEdgeCon
 
             @Override
             public Set<OnmsTopologyProtocol> getProtocols() {
-                if(ext.getProtocols() == null) {
+                if (ext.getProtocols() == null) {
+                    LOG.debug("Protocols was null, returning empty set");
                     return Collections.emptySet();
                 }
 
-                Set<OnmsTopologyProtocol> protocols = new HashSet<>();
-
-                for (String protocol : ext.getProtocols().split(",")) {
-                    try {
-                        protocols.add(OnmsTopologyProtocol.create(protocol));
-                    } catch (Exception e) {
-                        LOG.warn("Cannot add protocol {} for consumer {}", protocol, ext, e);
-                    }
-                }
-
-                return protocols;
+                LOG.trace("Returning mapped protocols from {}", ext.getProtocols());
+                return ext.getProtocols()
+                        .stream()
+                        .map(ModelMappers::toOnmsTopologyProtocol)
+                        .collect(Collectors.toSet());
             }
 
             @Override
@@ -84,7 +79,7 @@ public class TopologyEdgeConsumerManager extends InterfaceMapper<TopologyEdgeCon
                 message.getMessagebody().accept(new TopologyVisitor() {
                     @Override
                     public void visit(OnmsTopologyEdge edge) {
-                        TopologyEdge topologyEdge = ModelMappers.toEdge(message.getProtocol().getId(), edge);
+                        TopologyEdge topologyEdge = ModelMappers.toEdge(message.getProtocol(), edge);
 
                         switch (message.getMessagestatus()) {
                             case UPDATE:

--- a/features/api-layer/src/main/java/org/opennms/features/apilayer/topology/TopologyEdgeConsumerManager.java
+++ b/features/api-layer/src/main/java/org/opennms/features/apilayer/topology/TopologyEdgeConsumerManager.java
@@ -1,0 +1,108 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.features.apilayer.topology;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.opennms.features.apilayer.utils.InterfaceMapper;
+import org.opennms.features.apilayer.utils.ModelMappers;
+import org.opennms.integration.api.v1.model.TopologyEdge;
+import org.opennms.integration.api.v1.topology.TopologyEdgeConsumer;
+import org.opennms.netmgt.topologies.service.api.OnmsTopologyConsumer;
+import org.opennms.netmgt.topologies.service.api.OnmsTopologyEdge;
+import org.opennms.netmgt.topologies.service.api.OnmsTopologyMessage;
+import org.opennms.netmgt.topologies.service.api.OnmsTopologyProtocol;
+import org.opennms.netmgt.topologies.service.api.TopologyVisitor;
+import org.osgi.framework.BundleContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class TopologyEdgeConsumerManager extends InterfaceMapper<TopologyEdgeConsumer, OnmsTopologyConsumer> {
+    private static final Logger LOG = LoggerFactory.getLogger(TopologyEdgeConsumerManager.class);
+
+    public TopologyEdgeConsumerManager(BundleContext bundleContext) {
+        super(OnmsTopologyConsumer.class, bundleContext);
+    }
+
+    @Override
+    public OnmsTopologyConsumer map(TopologyEdgeConsumer ext) {
+        return new OnmsTopologyConsumer() {
+            @Override
+            public String getName() {
+                return ext.getClass().getName();
+            }
+
+            @Override
+            public Set<OnmsTopologyProtocol> getProtocols() {
+                if(ext.getProtocols() == null) {
+                    return Collections.emptySet();
+                }
+
+                Set<OnmsTopologyProtocol> protocols = new HashSet<>();
+
+                for (String protocol : ext.getProtocols().split(",")) {
+                    try {
+                        protocols.add(OnmsTopologyProtocol.create(protocol));
+                    } catch (Exception e) {
+                        LOG.warn("Cannot add protocol {} for consumer {}", protocol, ext, e);
+                    }
+                }
+
+                return protocols;
+            }
+
+            @Override
+            public void consume(OnmsTopologyMessage message) {
+                message.getMessagebody().accept(new TopologyVisitor() {
+                    @Override
+                    public void visit(OnmsTopologyEdge edge) {
+                        TopologyEdge topologyEdge = ModelMappers.toEdge(message.getProtocol().getId(), edge);
+
+                        switch (message.getMessagestatus()) {
+                            case UPDATE:
+                                LOG.trace("Mapped topology message {} to topology edge {} for add/update", message,
+                                        topologyEdge);
+                                ext.onEdgeAddedOrUpdated(topologyEdge);
+                                break;
+                            case DELETE:
+                                LOG.trace("Mapped topology message {} to topology edge {} for delete", message,
+                                        topologyEdge);
+                                ext.onEdgeDeleted(topologyEdge);
+                                break;
+                            default:
+                                LOG.warn("Unsupported message status of {}", message.getMessagestatus());
+                        }
+                    }
+                });
+            }
+        };
+    }
+}

--- a/features/api-layer/src/main/java/org/opennms/features/apilayer/topology/TopologyEdgeConsumerManager.java
+++ b/features/api-layer/src/main/java/org/opennms/features/apilayer/topology/TopologyEdgeConsumerManager.java
@@ -29,9 +29,11 @@
 package org.opennms.features.apilayer.topology;
 
 import java.util.Collections;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.opennms.features.apilayer.utils.EdgeMapper;
 import org.opennms.features.apilayer.utils.InterfaceMapper;
 import org.opennms.features.apilayer.utils.ModelMappers;
 import org.opennms.integration.api.v1.model.TopologyEdge;
@@ -47,9 +49,11 @@ import org.slf4j.LoggerFactory;
 
 public class TopologyEdgeConsumerManager extends InterfaceMapper<TopologyEdgeConsumer, OnmsTopologyConsumer> {
     private static final Logger LOG = LoggerFactory.getLogger(TopologyEdgeConsumerManager.class);
+    private final EdgeMapper edgeMapper;
 
-    public TopologyEdgeConsumerManager(BundleContext bundleContext) {
+    public TopologyEdgeConsumerManager(BundleContext bundleContext, EdgeMapper edgeMapper) {
         super(OnmsTopologyConsumer.class, bundleContext);
+        this.edgeMapper = Objects.requireNonNull(edgeMapper);
     }
 
     @Override
@@ -79,7 +83,7 @@ public class TopologyEdgeConsumerManager extends InterfaceMapper<TopologyEdgeCon
                 message.getMessagebody().accept(new TopologyVisitor() {
                     @Override
                     public void visit(OnmsTopologyEdge edge) {
-                        TopologyEdge topologyEdge = ModelMappers.toEdge(message.getProtocol(), edge);
+                        TopologyEdge topologyEdge = edgeMapper.toEdge(message.getProtocol(), edge);
 
                         switch (message.getMessagestatus()) {
                             case UPDATE:

--- a/features/api-layer/src/main/java/org/opennms/features/apilayer/topology/UserDefinedLinkDaoImpl.java
+++ b/features/api-layer/src/main/java/org/opennms/features/apilayer/topology/UserDefinedLinkDaoImpl.java
@@ -63,34 +63,29 @@ public class UserDefinedLinkDaoImpl implements UserDefinedLinkDao {
 
     @Override
     public List<UserDefinedLink> getLinks() {
-        ensureServicesAreAvailable();
         return sessionUtils.withReadOnlyTransaction(() ->
                 userDefinedLinkDao.findAll().stream().map(UserDefinedLinkDaoImpl::toApiLink).collect(Collectors.toList()));
     }
 
     @Override
     public List<UserDefinedLink> getOutLinks(int nodeIdA) {
-        ensureServicesAreAvailable();
         return sessionUtils.withReadOnlyTransaction(() ->
                 userDefinedLinkDao.getOutLinks(nodeIdA).stream().map(UserDefinedLinkDaoImpl::toApiLink).collect(Collectors.toList()));
     }
 
     @Override
     public List<UserDefinedLink> getInLinks(int nodeIdZ) {
-        ensureServicesAreAvailable();
         return sessionUtils.withReadOnlyTransaction(() ->
                 userDefinedLinkDao.getInLinks(nodeIdZ).stream().map(UserDefinedLinkDaoImpl::toApiLink).collect(Collectors.toList()));}
 
     @Override
     public List<UserDefinedLink> getLinksWithLabel(String label) {
-        ensureServicesAreAvailable();
         return sessionUtils.withReadOnlyTransaction(() ->
                 userDefinedLinkDao.getLinksWithLabel(label).stream().map(UserDefinedLinkDaoImpl::toApiLink).collect(Collectors.toList()));
     }
 
     @Override
     public UserDefinedLink saveOrUpdate(UserDefinedLink link) {
-        ensureServicesAreAvailable();
         return sessionUtils.withTransaction(() -> {
             final org.opennms.netmgt.enlinkd.model.UserDefinedLink modelLink = toModelLink(link);
             userDefinedLinkTopologyService.saveOrUpdate(modelLink);
@@ -100,7 +95,6 @@ public class UserDefinedLinkDaoImpl implements UserDefinedLinkDao {
 
     @Override
     public void delete(UserDefinedLink link) {
-        ensureServicesAreAvailable();
         sessionUtils.withTransaction(() -> {
             userDefinedLinkTopologyService.delete(link.getDbId());
             return null;
@@ -109,19 +103,12 @@ public class UserDefinedLinkDaoImpl implements UserDefinedLinkDao {
 
     @Override
     public void delete(Collection<UserDefinedLink> links) {
-        ensureServicesAreAvailable();
         sessionUtils.withTransaction(() -> {
             for (UserDefinedLink link : links) {
                 userDefinedLinkTopologyService.delete(link.getDbId());
             }
             return null;
         });
-    }
-
-    private void ensureServicesAreAvailable() {
-        if (userDefinedLinkDao == null) {
-            throw new IllegalStateException("Required DAO is not available. Ensure the Enlinkd service is enabled.");
-        }
     }
 
     protected static UserDefinedLink toApiLink(org.opennms.netmgt.enlinkd.model.UserDefinedLink modelLink) {

--- a/features/api-layer/src/main/java/org/opennms/features/apilayer/utils/EdgeMapper.java
+++ b/features/api-layer/src/main/java/org/opennms/features/apilayer/utils/EdgeMapper.java
@@ -1,0 +1,125 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.features.apilayer.utils;
+
+import org.opennms.integration.api.v1.model.Node;
+import org.opennms.integration.api.v1.model.TopologyEdge;
+import org.opennms.integration.api.v1.model.TopologyPort;
+import org.opennms.integration.api.v1.model.TopologySegment;
+import org.opennms.integration.api.v1.model.immutables.ImmutableNode;
+import org.opennms.integration.api.v1.model.immutables.ImmutableNodeCriteria;
+import org.opennms.integration.api.v1.model.immutables.ImmutableTopologyEdge;
+import org.opennms.integration.api.v1.model.immutables.ImmutableTopologyPort;
+import org.opennms.integration.api.v1.model.immutables.ImmutableTopologySegment;
+import org.opennms.netmgt.topologies.service.api.OnmsTopologyEdge;
+import org.opennms.netmgt.topologies.service.api.OnmsTopologyPort;
+import org.opennms.netmgt.topologies.service.api.OnmsTopologyProtocol;
+
+public class EdgeMapper {
+    private final NodeCriteriaCache nodeCriteriaCache;
+
+    public EdgeMapper(NodeCriteriaCache nodeCriteriaCache) {
+        this.nodeCriteriaCache = nodeCriteriaCache;
+    }
+
+    public TopologyEdge toEdge(OnmsTopologyProtocol protocol, OnmsTopologyEdge edge) {
+        ImmutableTopologyEdge.Builder topologyEdge = ImmutableTopologyEdge.newBuilder()
+                .setId(edge.getId())
+                .setProtocol(ModelMappers.toTopologyProtocol(protocol))
+                .setTooltipText(edge.getToolTipText());
+
+        // Set the source
+        if (edge.getSource().getVertex().getNodeid() == null) {
+            // Source is a segment
+            topologyEdge.setSource(getSegment(edge.getSource(), protocol));
+        } else if (edge.getSource().getIfindex() != null && edge.getSource().getIfindex() >= 0) {
+            // Source is a port
+            topologyEdge.setSource(getPort(edge.getSource()));
+        } else {
+            // Source is a node
+            topologyEdge.setSource(getNode(edge.getSource()));
+        }
+
+        // Set the target
+        if (edge.getTarget().getVertex().getNodeid() == null) {
+            // Target is a segment
+            topologyEdge.setTarget(getSegment(edge.getTarget(), protocol));
+        } else if (edge.getTarget().getIfindex() != null && edge.getTarget().getIfindex() >= 0) {
+            // Target is a port
+            topologyEdge.setTarget(getPort(edge.getTarget()));
+        } else {
+            // Target is a node
+            topologyEdge.setTarget(getNode(edge.getTarget()));
+        }
+
+        return topologyEdge.build();
+    }
+
+    private TopologySegment getSegment(OnmsTopologyPort port, OnmsTopologyProtocol protocol) {
+        return ImmutableTopologySegment.newBuilder()
+                .setId(port.getId())
+                .setTooltipText(port.getToolTipText())
+                .setProtocol(ModelMappers.toTopologyProtocol(protocol))
+                .build();
+    }
+
+    private TopologyPort getPort(OnmsTopologyPort port) {
+        ImmutableTopologyPort.Builder portBuilder = ImmutableTopologyPort.newBuilder()
+                .setId(port.getId())
+                .setTooltipText(port.getToolTipText())
+                .setIfIndex(port.getIfindex())
+                .setIfName(port.getIfname())
+                .setIfAddress(port.getAddr());
+
+        Integer nodeId = port.getVertex().getNodeid();
+        ImmutableNodeCriteria.Builder nodeCriteriaBuilder = ImmutableNodeCriteria.newBuilder().setId(nodeId);
+
+        nodeCriteriaCache.getNodeCriteria(nodeId.longValue()).ifPresent(nc -> {
+            nodeCriteriaBuilder.setForeignSource(nc.getForeignSource());
+            nodeCriteriaBuilder.setForeignId(nc.getForeignId());
+        });
+
+        portBuilder.setNodeCriteria(nodeCriteriaBuilder.build());
+
+        return portBuilder.build();
+    }
+
+    private Node getNode(OnmsTopologyPort port) {
+        Integer nodeId = port.getVertex().getNodeid();
+        ImmutableNode.Builder nodeBuilder = ImmutableNode.newBuilder()
+                .setId(nodeId);
+
+        nodeCriteriaCache.getNodeCriteria(nodeId.longValue()).ifPresent(nc -> {
+            nodeBuilder.setForeignSource(nc.getForeignSource());
+            nodeBuilder.setForeignId(nc.getForeignId());
+        });
+
+        return nodeBuilder.build();
+    }
+}

--- a/features/api-layer/src/main/java/org/opennms/features/apilayer/utils/EdgeMapper.java
+++ b/features/api-layer/src/main/java/org/opennms/features/apilayer/utils/EdgeMapper.java
@@ -28,6 +28,8 @@
 
 package org.opennms.features.apilayer.utils;
 
+import java.util.Objects;
+
 import org.opennms.integration.api.v1.model.Node;
 import org.opennms.integration.api.v1.model.TopologyEdge;
 import org.opennms.integration.api.v1.model.TopologyPort;
@@ -45,7 +47,7 @@ public class EdgeMapper {
     private final NodeCriteriaCache nodeCriteriaCache;
 
     public EdgeMapper(NodeCriteriaCache nodeCriteriaCache) {
-        this.nodeCriteriaCache = nodeCriteriaCache;
+        this.nodeCriteriaCache = Objects.requireNonNull(nodeCriteriaCache);
     }
 
     public TopologyEdge toEdge(OnmsTopologyProtocol protocol, OnmsTopologyEdge edge) {

--- a/features/api-layer/src/main/java/org/opennms/features/apilayer/utils/ModelMappers.java
+++ b/features/api-layer/src/main/java/org/opennms/features/apilayer/utils/ModelMappers.java
@@ -158,7 +158,7 @@ public class ModelMappers {
         if (edge.getSource().getVertex().getNodeid() == null) {
             // Source is a segment
             topologyEdge.setSource(getSegment(edge.getSource(), protocol));
-        } else if (edge.getSource().getIfindex() != null) {
+        } else if (edge.getSource().getIfindex() != null && edge.getSource().getIfindex() >= 0) {
             // Source is a port
             topologyEdge.setSource(getPort(edge.getSource()));
         } else {
@@ -170,7 +170,7 @@ public class ModelMappers {
         if (edge.getTarget().getVertex().getNodeid() == null) {
             // Target is a segment
             topologyEdge.setTarget(getSegment(edge.getTarget(), protocol));
-        } else if (edge.getTarget().getIfindex() != null) {
+        } else if (edge.getTarget().getIfindex() != null && edge.getTarget().getIfindex() >= 0) {
             // Target is a port
             topologyEdge.setTarget(getPort(edge.getTarget()));
         } else {
@@ -183,7 +183,7 @@ public class ModelMappers {
 
     private static TopologySegment getSegment(OnmsTopologyPort port, OnmsTopologyProtocol protocol) {
         return ImmutableTopologySegment.newBuilder()
-                .setId(port.getVertex().getId())
+                .setId(port.getId())
                 .setTooltipText(port.getToolTipText())
                 .setProtocol(toTopologyProtocol(protocol))
                 .build();
@@ -204,7 +204,7 @@ public class ModelMappers {
 
     private static Node getNode(OnmsTopologyPort port) {
         return ImmutableNode.newBuilder()
-                .setId(Integer.parseInt(port.getId()))
+                .setId(port.getVertex().getNodeid())
                 .build();
     }
     

--- a/features/api-layer/src/main/java/org/opennms/features/apilayer/utils/ModelMappers.java
+++ b/features/api-layer/src/main/java/org/opennms/features/apilayer/utils/ModelMappers.java
@@ -43,6 +43,7 @@ import org.opennms.integration.api.v1.model.Node;
 import org.opennms.integration.api.v1.model.Severity;
 import org.opennms.integration.api.v1.model.SnmpInterface;
 import org.opennms.integration.api.v1.model.TopologyEdge;
+import org.opennms.integration.api.v1.model.TopologyProtocol;
 import org.opennms.integration.api.v1.model.immutables.ImmutableNodeCriteria;
 import org.opennms.integration.api.v1.model.immutables.ImmutableTopologyEdge;
 import org.opennms.integration.api.v1.model.immutables.ImmutableTopologyPort;
@@ -54,6 +55,7 @@ import org.opennms.netmgt.model.OnmsSeverity;
 import org.opennms.netmgt.model.OnmsSnmpInterface;
 import org.opennms.netmgt.model.events.EventBuilder;
 import org.opennms.netmgt.topologies.service.api.OnmsTopologyEdge;
+import org.opennms.netmgt.topologies.service.api.OnmsTopologyProtocol;
 import org.opennms.netmgt.xml.event.Event;
 
 /**
@@ -142,10 +144,10 @@ public class ModelMappers {
                 .build();
     }
 
-    public static TopologyEdge toEdge(String protocol, OnmsTopologyEdge edge) {
+    public static TopologyEdge toEdge(OnmsTopologyProtocol protocol, OnmsTopologyEdge edge) {
         ImmutableTopologyEdge.Builder topologyEdge = ImmutableTopologyEdge.newBuilder()
                 .setId(edge.getId())
-                .setProtocol(protocol)
+                .setProtocol(toTopologyProtocol(protocol))
                 .setTooltipText(edge.getToolTipText())
                 .setSource(ImmutableTopologyPort.newBuilder()
                         .setId(edge.getSource().getId())
@@ -163,7 +165,7 @@ public class ModelMappers {
             topologyEdge.setTargetSegment(ImmutableTopologySegment.newBuilder()
                     .setId(edge.getTarget().getVertex().getId())
                     .setTooltipText(edge.getTarget().getToolTipText())
-                    .setProtocol(protocol)
+                    .setProtocol(toTopologyProtocol(protocol))
                     .build());
         }
         // Otherwise the target is a port
@@ -181,5 +183,13 @@ public class ModelMappers {
         }
 
         return topologyEdge.build();
+    }
+    
+    public static OnmsTopologyProtocol toOnmsTopologyProtocol(TopologyProtocol protocol) {
+        return OnmsTopologyProtocol.create(protocol.name());
+    }
+    
+    public static TopologyProtocol toTopologyProtocol(OnmsTopologyProtocol protocol) {
+        return TopologyProtocol.valueOf(protocol.getId());
     }
 }

--- a/features/api-layer/src/main/java/org/opennms/features/apilayer/utils/ModelMappers.java
+++ b/features/api-layer/src/main/java/org/opennms/features/apilayer/utils/ModelMappers.java
@@ -42,23 +42,13 @@ import org.opennms.integration.api.v1.model.InMemoryEvent;
 import org.opennms.integration.api.v1.model.Node;
 import org.opennms.integration.api.v1.model.Severity;
 import org.opennms.integration.api.v1.model.SnmpInterface;
-import org.opennms.integration.api.v1.model.TopologyEdge;
-import org.opennms.integration.api.v1.model.TopologyPort;
 import org.opennms.integration.api.v1.model.TopologyProtocol;
-import org.opennms.integration.api.v1.model.TopologySegment;
-import org.opennms.integration.api.v1.model.immutables.ImmutableNode;
-import org.opennms.integration.api.v1.model.immutables.ImmutableNodeCriteria;
-import org.opennms.integration.api.v1.model.immutables.ImmutableTopologyEdge;
-import org.opennms.integration.api.v1.model.immutables.ImmutableTopologyPort;
-import org.opennms.integration.api.v1.model.immutables.ImmutableTopologySegment;
 import org.opennms.netmgt.model.OnmsAlarm;
 import org.opennms.netmgt.model.OnmsEvent;
 import org.opennms.netmgt.model.OnmsNode;
 import org.opennms.netmgt.model.OnmsSeverity;
 import org.opennms.netmgt.model.OnmsSnmpInterface;
 import org.opennms.netmgt.model.events.EventBuilder;
-import org.opennms.netmgt.topologies.service.api.OnmsTopologyEdge;
-import org.opennms.netmgt.topologies.service.api.OnmsTopologyPort;
 import org.opennms.netmgt.topologies.service.api.OnmsTopologyProtocol;
 import org.opennms.netmgt.xml.event.Event;
 
@@ -130,7 +120,7 @@ public class ModelMappers {
         }
         return Severity.INDETERMINATE;
     }
-
+    
     public static AlarmFeedback toFeedback(org.opennms.features.situationfeedback.api.AlarmFeedback feedback) {
         return feedback == null ? null : new AlarmFeedbackBean(feedback);
     }
@@ -145,66 +135,6 @@ public class ModelMappers {
                 .withSituationFingerprint(feedback.getSituationFingerprint())
                 .withSituationKey(feedback.getSituationKey())
                 .withUser(feedback.getUser())
-                .build();
-    }
-
-    public static TopologyEdge toEdge(OnmsTopologyProtocol protocol, OnmsTopologyEdge edge) {
-        ImmutableTopologyEdge.Builder topologyEdge = ImmutableTopologyEdge.newBuilder()
-                .setId(edge.getId())
-                .setProtocol(toTopologyProtocol(protocol))
-                .setTooltipText(edge.getToolTipText());
-
-        // Set the source
-        if (edge.getSource().getVertex().getNodeid() == null) {
-            // Source is a segment
-            topologyEdge.setSource(getSegment(edge.getSource(), protocol));
-        } else if (edge.getSource().getIfindex() != null && edge.getSource().getIfindex() >= 0) {
-            // Source is a port
-            topologyEdge.setSource(getPort(edge.getSource()));
-        } else {
-            // Source is a node
-            topologyEdge.setSource(getNode(edge.getSource()));
-        }
-
-        // Set the target
-        if (edge.getTarget().getVertex().getNodeid() == null) {
-            // Target is a segment
-            topologyEdge.setTarget(getSegment(edge.getTarget(), protocol));
-        } else if (edge.getTarget().getIfindex() != null && edge.getTarget().getIfindex() >= 0) {
-            // Target is a port
-            topologyEdge.setTarget(getPort(edge.getTarget()));
-        } else {
-            // Target is a node
-            topologyEdge.setTarget(getNode(edge.getTarget()));
-        }
-
-        return topologyEdge.build();
-    }
-
-    private static TopologySegment getSegment(OnmsTopologyPort port, OnmsTopologyProtocol protocol) {
-        return ImmutableTopologySegment.newBuilder()
-                .setId(port.getId())
-                .setTooltipText(port.getToolTipText())
-                .setProtocol(toTopologyProtocol(protocol))
-                .build();
-    }
-
-    private static TopologyPort getPort(OnmsTopologyPort port) {
-        return ImmutableTopologyPort.newBuilder()
-                .setId(port.getId())
-                .setTooltipText(port.getToolTipText())
-                .setIfIndex(port.getIfindex())
-                .setIfName(port.getIfname())
-                .setIfAddress(port.getAddr())
-                .setNodeCriteria(ImmutableNodeCriteria.newBuilder()
-                        .setId(port.getVertex().getNodeid())
-                        .build())
-                .build();
-    }
-
-    private static Node getNode(OnmsTopologyPort port) {
-        return ImmutableNode.newBuilder()
-                .setId(port.getVertex().getNodeid())
                 .build();
     }
     

--- a/features/api-layer/src/main/java/org/opennms/features/apilayer/utils/NodeCriteriaCache.java
+++ b/features/api-layer/src/main/java/org/opennms/features/apilayer/utils/NodeCriteriaCache.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.features.apilayer.utils;
+
+import java.util.Optional;
+
+import org.opennms.integration.api.v1.model.NodeCriteria;
+
+public interface NodeCriteriaCache {
+    Optional<NodeCriteria> getNodeCriteria(Long nodeId);
+}

--- a/features/api-layer/src/main/java/org/opennms/features/apilayer/utils/NodeCriteriaLoadingCacheImpl.java
+++ b/features/api-layer/src/main/java/org/opennms/features/apilayer/utils/NodeCriteriaLoadingCacheImpl.java
@@ -1,0 +1,84 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.features.apilayer.utils;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import org.opennms.integration.api.v1.model.NodeCriteria;
+import org.opennms.integration.api.v1.model.immutables.ImmutableNodeCriteria;
+import org.opennms.netmgt.dao.api.NodeDao;
+import org.opennms.netmgt.model.OnmsNode;
+import org.springframework.transaction.support.TransactionOperations;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+
+public class NodeCriteriaLoadingCacheImpl implements NodeCriteriaCache {
+    private final LoadingCache<Long, NodeCriteria> nodeIdToCriteriaCache;
+
+    public NodeCriteriaLoadingCacheImpl(TransactionOperations transactionOperations,
+                                        NodeDao nodeDao, long nodeIdToCriteriaMaxCacheSize) {
+        //noinspection NullableProblems
+        nodeIdToCriteriaCache = CacheBuilder.newBuilder()
+                .maximumSize(nodeIdToCriteriaMaxCacheSize)
+                .build(new CacheLoader<Long, NodeCriteria>() {
+                    public NodeCriteria load(Long nodeId) {
+                        return transactionOperations.execute(status -> {
+                            Objects.requireNonNull(nodeId);
+                            final OnmsNode node = nodeDao.get(nodeId.intValue());
+                            if (node != null && node.getForeignId() != null && node.getForeignSource() != null) {
+                                return ImmutableNodeCriteria.newBuilder()
+                                        .setId(nodeId.intValue())
+                                        .setForeignId(node.getForeignId())
+                                        .setForeignSource(node.getForeignSource())
+                                        .build();
+                            } else {
+                                return ImmutableNodeCriteria.newBuilder()
+                                        .setId(nodeId.intValue())
+                                        .build();
+                            }
+                        });
+                    }
+                });
+    }
+
+    @Override
+    public Optional<NodeCriteria> getNodeCriteria(Long nodeId) {
+        Objects.requireNonNull(nodeId);
+
+        try {
+            return Optional.of(nodeIdToCriteriaCache.get(nodeId));
+        } catch (Exception ignore) {
+        }
+
+        return Optional.empty();
+    }
+}

--- a/features/api-layer/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/features/api-layer/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -24,13 +24,10 @@
   <reference id="eventConfDao" interface="org.opennms.netmgt.config.api.EventConfDao" availability="mandatory"/>
   <reference id="eventForwarder" interface="org.opennms.netmgt.events.api.EventForwarder" availability="mandatory"/>
   <reference id="eventSubscriptionService" interface="org.opennms.netmgt.events.api.EventSubscriptionService"/>
-  <!-- Only available when Enlinkd is enabled -->
-  <reference id="userDefinedLinkDao" interface="org.opennms.netmgt.enlinkd.persistence.api.UserDefinedLinkDao" availability="optional"/>
-  <!-- Only available when Enlinkd is enabled -->
-  <reference id="userDefinedLinkTopologyService" interface="org.opennms.netmgt.enlinkd.service.api.UserDefinedLinkTopologyService" availability="optional"/>
+  <reference id="userDefinedLinkDao" interface="org.opennms.netmgt.enlinkd.persistence.api.UserDefinedLinkDao" availability="mandatory"/>
+  <reference id="userDefinedLinkTopologyService" interface="org.opennms.netmgt.enlinkd.service.api.UserDefinedLinkTopologyService" availability="mandatory"/>
   <reference id="persisterFactory" interface="org.opennms.netmgt.collection.api.PersisterFactory" />
   <reference id="collectionAgentFactory" interface="org.opennms.netmgt.collection.api.CollectionAgentFactory" />
-  <!-- TODO: Check if available when enlinkd is not -->
   <reference id="onmsTopologyDao" interface="org.opennms.netmgt.topologies.service.api.OnmsTopologyDao" availability="mandatory"/>
 
   <bean id="nodeDaoImpl" class="org.opennms.features.apilayer.dao.NodeDaoImpl">
@@ -42,13 +39,6 @@
   <!-- Runtime -->
   <service interface="org.opennms.integration.api.v1.runtime.RuntimeInfo" >
     <bean class="org.opennms.features.apilayer.RuntimeInfoImpl" />
-  </service>
-
-  <service interface="org.opennms.integration.api.v1.dao.NodeDao" >
-    <bean class="org.opennms.features.apilayer.dao.NodeDaoImpl">
-      <argument ref="nodeDao"/>
-      <argument ref="sessionUtils"/>
-    </bean>
   </service>
 
   <service interface="org.opennms.integration.api.v1.dao.AlarmDao" >
@@ -290,9 +280,10 @@
   </reference-list>
 
   <!-- Edge DAO -->
-  <bean id="edgeDaoImpl" class="org.opennms.features.apilayer.topology.EdgeDaoImpl">
-    <argument ref="onmsTopologyDao"/>
-  </bean>
-  <service ref="edgeDaoImpl" interface="org.opennms.integration.api.v1.dao.EdgeDao"/>
+  <service interface="org.opennms.integration.api.v1.dao.EdgeDao">
+    <bean class="org.opennms.features.apilayer.topology.EdgeDaoImpl">
+      <argument ref="onmsTopologyDao"/>
+    </bean>
+  </service>
 
 </blueprint>

--- a/features/api-layer/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/features/api-layer/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -30,6 +30,8 @@
   <reference id="userDefinedLinkTopologyService" interface="org.opennms.netmgt.enlinkd.service.api.UserDefinedLinkTopologyService" availability="optional"/>
   <reference id="persisterFactory" interface="org.opennms.netmgt.collection.api.PersisterFactory" />
   <reference id="collectionAgentFactory" interface="org.opennms.netmgt.collection.api.CollectionAgentFactory" />
+  <!-- TODO: Check if available when enlinkd is not -->
+  <reference id="onmsTopologyDao" interface="org.opennms.netmgt.topologies.service.api.OnmsTopologyDao" availability="mandatory"/>
 
   <bean id="nodeDaoImpl" class="org.opennms.features.apilayer.dao.NodeDaoImpl">
     <argument ref="nodeDao"/>
@@ -278,5 +280,19 @@
       <argument ref="sessionUtils"/>
     </bean>
   </service>
+
+  <!-- Topology Edge Consumers -->
+  <bean id="topologyEdgeConsumerManager" class="org.opennms.features.apilayer.topology.TopologyEdgeConsumerManager">
+    <argument ref="blueprintBundleContext"/>
+  </bean>
+  <reference-list interface="org.opennms.integration.api.v1.topology.TopologyEdgeConsumer" availability="optional">
+    <reference-listener bind-method="onBind" unbind-method="onUnbind" ref="topologyEdgeConsumerManager" />
+  </reference-list>
+
+  <!-- Edge DAO -->
+  <bean id="edgeDaoImpl" class="org.opennms.features.apilayer.topology.EdgeDaoImpl">
+    <argument ref="onmsTopologyDao"/>
+  </bean>
+  <service ref="edgeDaoImpl" interface="org.opennms.integration.api.v1.dao.EdgeDao"/>
 
 </blueprint>

--- a/features/api-layer/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/features/api-layer/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -30,7 +30,6 @@
   <reference id="persisterFactory" interface="org.opennms.netmgt.collection.api.PersisterFactory" />
   <reference id="collectionAgentFactory" interface="org.opennms.netmgt.collection.api.CollectionAgentFactory" />
   <reference id="onmsTopologyDao" interface="org.opennms.netmgt.topologies.service.api.OnmsTopologyDao" availability="mandatory"/>
-  <reference id="transactionOperations" interface="org.springframework.transaction.support.TransactionOperations" />
 
   <bean id="nodeDaoImpl" class="org.opennms.features.apilayer.dao.NodeDaoImpl">
     <argument ref="nodeDao"/>
@@ -39,7 +38,7 @@
   <service interface="org.opennms.integration.api.v1.dao.NodeDao" ref="nodeDaoImpl"/>
 
   <bean id="nodeCriteriaCache" class="org.opennms.features.apilayer.utils.NodeCriteriaLoadingCacheImpl">
-    <argument ref="transactionOperations"/>
+    <argument ref="sessionUtils"/>
     <argument ref="nodeDao"/>
     <argument value="${nodeIdToCriteriaMaxCacheSize}"/>
   </bean>

--- a/features/api-layer/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/features/api-layer/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -12,6 +12,7 @@
       <cm:property name="alarmFeedback.gracePeriodInMs" value="5000"/>
       <cm:property name="alarmFeedback.sleepTimeInMs" value="1000"/>
       <cm:property name="alarmFeedback.waitTimeMs" value="500"/>
+      <cm:property name="nodeIdToCriteriaMaxCacheSize" value="10000"/>
     </cm:default-properties>
   </cm:property-placeholder>
 
@@ -29,6 +30,7 @@
   <reference id="persisterFactory" interface="org.opennms.netmgt.collection.api.PersisterFactory" />
   <reference id="collectionAgentFactory" interface="org.opennms.netmgt.collection.api.CollectionAgentFactory" />
   <reference id="onmsTopologyDao" interface="org.opennms.netmgt.topologies.service.api.OnmsTopologyDao" availability="mandatory"/>
+  <reference id="transactionOperations" interface="org.springframework.transaction.support.TransactionOperations" />
 
   <bean id="nodeDaoImpl" class="org.opennms.features.apilayer.dao.NodeDaoImpl">
     <argument ref="nodeDao"/>
@@ -36,6 +38,13 @@
   </bean>
   <service interface="org.opennms.integration.api.v1.dao.NodeDao" ref="nodeDaoImpl"/>
 
+  <bean id="nodeCriteriaCache" class="org.opennms.features.apilayer.utils.NodeCriteriaLoadingCacheImpl">
+    <argument ref="transactionOperations"/>
+    <argument ref="nodeDao"/>
+    <argument value="${nodeIdToCriteriaMaxCacheSize}"/>
+  </bean>
+  <service interface="org.opennms.features.apilayer.utils.NodeCriteriaCache" ref="nodeCriteriaCache"/>
+  
   <!-- Runtime -->
   <service interface="org.opennms.integration.api.v1.runtime.RuntimeInfo" >
     <bean class="org.opennms.features.apilayer.RuntimeInfoImpl" />
@@ -272,8 +281,13 @@
   </service>
 
   <!-- Topology Edge Consumers -->
+  <bean id="edgeMapper" class="org.opennms.features.apilayer.utils.EdgeMapper">
+    <argument ref="nodeCriteriaCache"/>
+  </bean>
+  
   <bean id="topologyEdgeConsumerManager" class="org.opennms.features.apilayer.topology.TopologyEdgeConsumerManager">
     <argument ref="blueprintBundleContext"/>
+    <argument ref="edgeMapper"/>
   </bean>
   <reference-list interface="org.opennms.integration.api.v1.topology.TopologyEdgeConsumer" availability="optional">
     <reference-listener bind-method="onBind" unbind-method="onUnbind" ref="topologyEdgeConsumerManager" />
@@ -283,6 +297,7 @@
   <service interface="org.opennms.integration.api.v1.dao.EdgeDao">
     <bean class="org.opennms.features.apilayer.topology.EdgeDaoImpl">
       <argument ref="onmsTopologyDao"/>
+      <argument ref="edgeMapper"/>
     </bean>
   </service>
 

--- a/features/api-layer/src/test/java/org/opennms/features/apilayer/topology/EdgeDaoImplTest.java
+++ b/features/api-layer/src/test/java/org/opennms/features/apilayer/topology/EdgeDaoImplTest.java
@@ -31,6 +31,7 @@ package org.opennms.features.apilayer.topology;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.anyLong;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -38,6 +39,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import org.junit.Before;
@@ -55,12 +57,14 @@ import org.opennms.netmgt.topologies.service.api.OnmsTopologyVertex;
 
 public class EdgeDaoImplTest {
     private final OnmsTopologyDao onmsTopologyDao = mock(OnmsTopologyDao.class);
-    private final EdgeDao edgeDao = new EdgeDaoImpl(onmsTopologyDao, new EdgeMapper(mock(NodeCriteriaCache.class)));
+    private final NodeCriteriaCache mockNodeCriteriaCache = mock(NodeCriteriaCache.class);
+    private final EdgeDao edgeDao = new EdgeDaoImpl(onmsTopologyDao, new EdgeMapper(mockNodeCriteriaCache));
     private static final String CDP_EDGE_ID = "cdp.edge.id";
     private static final String ISIS_EDGE_ID = "isis.edge.id";
 
     @Before
     public void setup() {
+        when(mockNodeCriteriaCache.getNodeCriteria(anyLong())).thenReturn(Optional.empty());
         Map<OnmsTopologyProtocol, OnmsTopology> topologyMap = new HashMap<>();
 
         when(onmsTopologyDao.getSupportedProtocols()).thenReturn(

--- a/features/api-layer/src/test/java/org/opennms/features/apilayer/topology/EdgeDaoImplTest.java
+++ b/features/api-layer/src/test/java/org/opennms/features/apilayer/topology/EdgeDaoImplTest.java
@@ -42,6 +42,8 @@ import java.util.Set;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.opennms.features.apilayer.utils.EdgeMapper;
+import org.opennms.features.apilayer.utils.NodeCriteriaCache;
 import org.opennms.integration.api.v1.dao.EdgeDao;
 import org.opennms.integration.api.v1.model.TopologyProtocol;
 import org.opennms.netmgt.topologies.service.api.OnmsTopology;
@@ -53,7 +55,7 @@ import org.opennms.netmgt.topologies.service.api.OnmsTopologyVertex;
 
 public class EdgeDaoImplTest {
     private final OnmsTopologyDao onmsTopologyDao = mock(OnmsTopologyDao.class);
-    private final EdgeDao edgeDao = new EdgeDaoImpl(onmsTopologyDao);
+    private final EdgeDao edgeDao = new EdgeDaoImpl(onmsTopologyDao, new EdgeMapper(mock(NodeCriteriaCache.class)));
     private static final String CDP_EDGE_ID = "cdp.edge.id";
     private static final String ISIS_EDGE_ID = "isis.edge.id";
 

--- a/features/api-layer/src/test/java/org/opennms/features/apilayer/topology/EdgeDaoImplTest.java
+++ b/features/api-layer/src/test/java/org/opennms/features/apilayer/topology/EdgeDaoImplTest.java
@@ -1,0 +1,127 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.features.apilayer.topology;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.opennms.integration.api.v1.dao.EdgeDao;
+import org.opennms.integration.api.v1.model.TopologyProtocol;
+import org.opennms.netmgt.topologies.service.api.OnmsTopology;
+import org.opennms.netmgt.topologies.service.api.OnmsTopologyDao;
+import org.opennms.netmgt.topologies.service.api.OnmsTopologyEdge;
+import org.opennms.netmgt.topologies.service.api.OnmsTopologyPort;
+import org.opennms.netmgt.topologies.service.api.OnmsTopologyProtocol;
+import org.opennms.netmgt.topologies.service.api.OnmsTopologyVertex;
+
+public class EdgeDaoImplTest {
+    private final OnmsTopologyDao onmsTopologyDao = mock(OnmsTopologyDao.class);
+    private final EdgeDao edgeDao = new EdgeDaoImpl(onmsTopologyDao);
+    private static final String CDP_EDGE_ID = "cdp.edge.id";
+    private static final String ISIS_EDGE_ID = "isis.edge.id";
+
+    @Before
+    public void setup() {
+        Map<OnmsTopologyProtocol, OnmsTopology> topologyMap = new HashMap<>();
+
+        when(onmsTopologyDao.getSupportedProtocols()).thenReturn(
+                new HashSet<>(Arrays.asList(OnmsTopologyProtocol.create("CDP"), OnmsTopologyProtocol.create("ISIS"))));
+
+        // Create two dummy edges to respond with for calls to the DAO
+        OnmsTopology mockCDPTopology = mock(OnmsTopology.class);
+        Set<OnmsTopologyEdge> cdpEdges = new HashSet<>();
+        OnmsTopologyEdge mockCdpEdge = mock(OnmsTopologyEdge.class);
+        when(mockCdpEdge.getId()).thenReturn(CDP_EDGE_ID);
+        OnmsTopologyPort mockCdpEdgePort = mock(OnmsTopologyPort.class);
+        OnmsTopologyVertex mockCdpEdgePortVertex = mock(OnmsTopologyVertex.class);
+        when(mockCdpEdgePortVertex.getNodeid()).thenReturn(1);
+        when(mockCdpEdgePort.getId()).thenReturn(CDP_EDGE_ID);
+        when(mockCdpEdgePort.getVertex()).thenReturn(mockCdpEdgePortVertex);
+        when(mockCdpEdge.getSource()).thenReturn(mockCdpEdgePort);
+        when(mockCdpEdge.getTarget()).thenReturn(mockCdpEdgePort);
+        cdpEdges.add(mockCdpEdge);
+        when(mockCDPTopology.getEdges()).thenReturn(cdpEdges);
+        topologyMap.put(OnmsTopologyProtocol.create("CDP"), mockCDPTopology);
+
+        OnmsTopology mockIsIsTopology = mock(OnmsTopology.class);
+        Set<OnmsTopologyEdge> isisEdges = new HashSet<>();
+        OnmsTopologyEdge mockIsIsEdge = mock(OnmsTopologyEdge.class);
+        when(mockIsIsEdge.getId()).thenReturn(ISIS_EDGE_ID);
+        OnmsTopologyPort mockIsIsEdgePort = mock(OnmsTopologyPort.class);
+        OnmsTopologyVertex mockIsIsEdgePortVertex = mock(OnmsTopologyVertex.class);
+        when(mockIsIsEdgePortVertex.getNodeid()).thenReturn(2);
+        when(mockIsIsEdgePort.getId()).thenReturn(ISIS_EDGE_ID);
+        when(mockIsIsEdgePort.getVertex()).thenReturn(mockIsIsEdgePortVertex);
+        when(mockIsIsEdge.getSource()).thenReturn(mockIsIsEdgePort);
+        when(mockIsIsEdge.getTarget()).thenReturn(mockIsIsEdgePort);
+        isisEdges.add(mockIsIsEdge);
+        when(mockIsIsTopology.getEdges()).thenReturn(isisEdges);
+        topologyMap.put(OnmsTopologyProtocol.create("ISIS"), mockIsIsTopology);
+
+        when(onmsTopologyDao.getTopologies()).thenReturn(topologyMap);
+    }
+
+    @Test
+    public void canCountEdges() {
+        assertThat(edgeDao.getEdgeCount(), equalTo(2L));
+        assertThat(edgeDao.getEdgeCount(TopologyProtocol.CDP), equalTo(1L));
+        assertThat(edgeDao.getEdgeCount(TopologyProtocol.ISIS), equalTo(1L));
+        assertThat(edgeDao.getEdgeCount(TopologyProtocol.BRIDGE), equalTo(0L));
+    }
+
+    @Test
+    public void canGetEdges() {
+        assertThat(edgeDao.getEdges().size(), equalTo(2));
+
+        assertThat(edgeDao.getEdges(TopologyProtocol.CDP).size(), equalTo(1));
+        assertThat(edgeDao.getEdges(TopologyProtocol.CDP).iterator().next().getId(), equalTo(CDP_EDGE_ID));
+
+        assertThat(edgeDao.getEdges(TopologyProtocol.ISIS).size(), equalTo(1));
+        assertThat(edgeDao.getEdges(TopologyProtocol.ISIS).iterator().next().getId(), equalTo(ISIS_EDGE_ID));
+
+        assertThat(edgeDao.getEdges(TopologyProtocol.BRIDGE).size(), equalTo(0));
+    }
+
+    @Test
+    public void canGetProtocols() {
+        assertThat(edgeDao.getProtocols().size(), equalTo(2));
+        assertThat(edgeDao.getProtocols(), hasItems(TopologyProtocol.CDP, TopologyProtocol.ISIS));
+    }
+}

--- a/features/api-layer/src/test/java/org/opennms/features/apilayer/utils/ModelMappersTest.java
+++ b/features/api-layer/src/test/java/org/opennms/features/apilayer/utils/ModelMappersTest.java
@@ -1,0 +1,122 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.features.apilayer.utils;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.Test;
+import org.opennms.integration.api.v1.model.TopologyEdge;
+import org.opennms.integration.api.v1.model.TopologyPort;
+import org.opennms.integration.api.v1.model.TopologySegment;
+import org.opennms.netmgt.topologies.service.api.OnmsTopologyEdge;
+import org.opennms.netmgt.topologies.service.api.OnmsTopologyPort;
+import org.opennms.netmgt.topologies.service.api.OnmsTopologyVertex;
+
+public class ModelMappersTest {
+    @Test
+    public void canMapEdge() {
+        String id = "id";
+        String tooltipText = "tooltip";
+
+        OnmsTopologyEdge sourceEdgeMock = mock(OnmsTopologyEdge.class);
+        when(sourceEdgeMock.getId()).thenReturn(id);
+        when(sourceEdgeMock.getToolTipText()).thenReturn(tooltipText);
+
+        // Source port
+        String sourceId = "sourceId";
+        String sourceTooltipText = "sourceTooltip";
+        Integer sourceIfIndex = 1;
+        Integer sourceVertexNodeId = 1;
+        OnmsTopologyVertex sourceVertexMock = mock(OnmsTopologyVertex.class);
+        when(sourceVertexMock.getNodeid()).thenReturn(sourceVertexNodeId);
+
+        OnmsTopologyPort sourcePortMock = mock(OnmsTopologyPort.class);
+        when(sourcePortMock.getId()).thenReturn(sourceId);
+        when(sourcePortMock.getToolTipText()).thenReturn(sourceTooltipText);
+        when(sourcePortMock.getIfindex()).thenReturn(sourceIfIndex);
+        when(sourcePortMock.getVertex()).thenReturn(sourceVertexMock);
+
+        // Target port
+        String targetId = "targetId";
+        String targetTooltipText = "targetTooltip";
+        Integer targetIfIndex = 2;
+        Integer targetVertexNodeId = 2;
+        String targetVertexId = "vertex-id";
+        OnmsTopologyVertex targetVertexMock = mock(OnmsTopologyVertex.class);
+        when(targetVertexMock.getId()).thenReturn(targetVertexId);
+        when(targetVertexMock.getNodeid()).thenReturn(targetVertexNodeId);
+
+        OnmsTopologyPort targetPortMock = mock(OnmsTopologyPort.class);
+        when(targetPortMock.getId()).thenReturn(targetId);
+        when(targetPortMock.getToolTipText()).thenReturn(targetTooltipText);
+        when(targetPortMock.getIfindex()).thenReturn(targetIfIndex);
+        when(targetPortMock.getVertex()).thenReturn(targetVertexMock);
+
+        when(sourceEdgeMock.getSource()).thenReturn(sourcePortMock);
+        when(sourceEdgeMock.getTarget()).thenReturn(targetPortMock);
+
+        // Map when the target is a port
+        String protocol = "test-protocol";
+        TopologyEdge mappedEdge = ModelMappers.toEdge(protocol, sourceEdgeMock);
+
+        assertThat(mappedEdge.getId(), equalTo(id));
+        assertThat(mappedEdge.getProtocol(), equalTo(protocol));
+        assertThat(mappedEdge.getTooltipText(), equalTo(tooltipText));
+        assertThat(mappedEdge.getSource().getId(), equalTo(sourceId));
+        assertThat(mappedEdge.getSource().getIfIndex(), equalTo(sourceIfIndex));
+        assertThat(mappedEdge.getSource().getTooltipText(), equalTo(sourceTooltipText));
+        assertThat(mappedEdge.getSource().getNodeCriteria().getId(), equalTo(sourceVertexNodeId));
+
+        mappedEdge.visitTarget(new TopologyEdge.TopologyEdgeTargetVisitor() {
+            @Override
+            public void visitTargetPort(TopologyPort port) {
+                assertThat(port.getId(), equalTo(targetId));
+                assertThat(port.getIfIndex(), equalTo(targetIfIndex));
+                assertThat(port.getTooltipText(), equalTo(targetTooltipText));
+                assertThat(port.getNodeCriteria().getId(), equalTo(targetVertexNodeId));
+            }
+        });
+
+        // Map when the target is a segment
+        when(targetVertexMock.getId()).thenReturn(null);
+        mappedEdge = ModelMappers.toEdge("test-protocol", sourceEdgeMock);
+
+        mappedEdge.visitTarget(new TopologyEdge.TopologyEdgeTargetVisitor() {
+            @Override
+            public void visitTargetSegement(TopologySegment segment) {
+                assertThat(segment.getId(), equalTo(targetVertexId));
+                assertThat(segment.getTooltipText(), equalTo(targetTooltipText));
+                assertThat(segment.getSegmentCriteria(), equalTo(String.format("%s:%s", protocol, targetId)));
+            }
+        });
+    }
+}

--- a/features/api-layer/src/test/java/org/opennms/features/apilayer/utils/ModelMappersTest.java
+++ b/features/api-layer/src/test/java/org/opennms/features/apilayer/utils/ModelMappersTest.java
@@ -39,6 +39,7 @@ import org.opennms.integration.api.v1.model.TopologyPort;
 import org.opennms.integration.api.v1.model.TopologySegment;
 import org.opennms.netmgt.topologies.service.api.OnmsTopologyEdge;
 import org.opennms.netmgt.topologies.service.api.OnmsTopologyPort;
+import org.opennms.netmgt.topologies.service.api.OnmsTopologyProtocol;
 import org.opennms.netmgt.topologies.service.api.OnmsTopologyVertex;
 
 public class ModelMappersTest {
@@ -86,7 +87,7 @@ public class ModelMappersTest {
 
         // Map when the target is a port
         String protocol = "test-protocol";
-        TopologyEdge mappedEdge = ModelMappers.toEdge(protocol, sourceEdgeMock);
+        TopologyEdge mappedEdge = ModelMappers.toEdge(OnmsTopologyProtocol.create(protocol), sourceEdgeMock);
 
         assertThat(mappedEdge.getId(), equalTo(id));
         assertThat(mappedEdge.getProtocol(), equalTo(protocol));
@@ -108,7 +109,7 @@ public class ModelMappersTest {
 
         // Map when the target is a segment
         when(targetVertexMock.getId()).thenReturn(null);
-        mappedEdge = ModelMappers.toEdge("test-protocol", sourceEdgeMock);
+        mappedEdge = ModelMappers.toEdge(OnmsTopologyProtocol.create("test-protocol"), sourceEdgeMock);
 
         mappedEdge.visitTarget(new TopologyEdge.TopologyEdgeTargetVisitor() {
             @Override

--- a/features/api-layer/src/test/java/org/opennms/features/apilayer/utils/ModelMappersTest.java
+++ b/features/api-layer/src/test/java/org/opennms/features/apilayer/utils/ModelMappersTest.java
@@ -30,15 +30,20 @@ package org.opennms.features.apilayer.utils;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static org.opennms.topologies.service.api.EdgeMockUtil.PROTOCOL;
 import static org.opennms.topologies.service.api.EdgeMockUtil.SOURCE_ID;
 import static org.opennms.topologies.service.api.EdgeMockUtil.TARGET_NODE_ID;
 import static org.opennms.topologies.service.api.EdgeMockUtil.addPort;
 import static org.opennms.topologies.service.api.EdgeMockUtil.createEdge;
 
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Matchers;
 import org.opennms.integration.api.v1.model.Node;
 import org.opennms.integration.api.v1.model.TopologyEdge;
 import org.opennms.integration.api.v1.model.TopologyPort;
@@ -48,12 +53,20 @@ import org.opennms.netmgt.topologies.service.api.OnmsTopologyProtocol;
 import org.opennms.topologies.service.api.EdgeMockUtil;
 
 public class ModelMappersTest {
+    private final NodeCriteriaCache nodeCriteriaCache = mock(NodeCriteriaCache.class);
+    private final EdgeMapper edgeMapper = new EdgeMapper(nodeCriteriaCache);
+
+    @Before
+    public void setup() {
+        when(nodeCriteriaCache.getNodeCriteria(Matchers.any(Long.class))).thenReturn(Optional.empty());
+    }
+
     @Test
     public void canMapNodeToNodeEdge() {
         OnmsTopologyEdge mockEdge = createEdge();
         EdgeMockUtil.addNode(true, mockEdge);
         EdgeMockUtil.addNode(false, mockEdge);
-        TopologyEdge mappedEdge = ModelMappers.toEdge(OnmsTopologyProtocol.create(PROTOCOL), mockEdge);
+        TopologyEdge mappedEdge = edgeMapper.toEdge(OnmsTopologyProtocol.create(PROTOCOL), mockEdge);
 
         assertThat(mappedEdge.getId(), equalTo(EdgeMockUtil.EDGE_ID));
         assertThat(mappedEdge.getProtocol().name(), equalTo(PROTOCOL));
@@ -82,7 +95,7 @@ public class ModelMappersTest {
         OnmsTopologyEdge mockEdge = createEdge();
         addPort(true, mockEdge);
         addPort(false, mockEdge);
-        TopologyEdge mappedEdge = ModelMappers.toEdge(OnmsTopologyProtocol.create(PROTOCOL), mockEdge);
+        TopologyEdge mappedEdge = edgeMapper.toEdge(OnmsTopologyProtocol.create(PROTOCOL), mockEdge);
 
         assertThat(mappedEdge.getId(), equalTo(EdgeMockUtil.EDGE_ID));
         assertThat(mappedEdge.getProtocol().name(), equalTo(PROTOCOL));
@@ -117,7 +130,7 @@ public class ModelMappersTest {
         OnmsTopologyEdge mockEdge = createEdge();
         EdgeMockUtil.addSegment(true, mockEdge);
         EdgeMockUtil.addSegment(false, mockEdge);
-        TopologyEdge mappedEdge = ModelMappers.toEdge(OnmsTopologyProtocol.create(PROTOCOL), mockEdge);
+        TopologyEdge mappedEdge = edgeMapper.toEdge(OnmsTopologyProtocol.create(PROTOCOL), mockEdge);
 
         assertThat(mappedEdge.getId(), equalTo(EdgeMockUtil.EDGE_ID));
         assertThat(mappedEdge.getProtocol().name(), equalTo(PROTOCOL));
@@ -151,7 +164,7 @@ public class ModelMappersTest {
         OnmsTopologyEdge mockEdge = createEdge();
         addPort(true, mockEdge);
         EdgeMockUtil.addSegment(false, mockEdge);
-        TopologyEdge mappedEdge = ModelMappers.toEdge(OnmsTopologyProtocol.create(PROTOCOL), mockEdge);
+        TopologyEdge mappedEdge = edgeMapper.toEdge(OnmsTopologyProtocol.create(PROTOCOL), mockEdge);
 
         assertThat(mappedEdge.getId(), equalTo(EdgeMockUtil.EDGE_ID));
         assertThat(mappedEdge.getProtocol().name(), equalTo(PROTOCOL));

--- a/features/enlinkd/adapters/collectors/bridge/src/main/java/org/opennms/netmgt/enlinkd/DiscoveryBridgeDomains.java
+++ b/features/enlinkd/adapters/collectors/bridge/src/main/java/org/opennms/netmgt/enlinkd/DiscoveryBridgeDomains.java
@@ -42,6 +42,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
+import org.opennms.netmgt.enlinkd.common.Discovery;
 import org.opennms.netmgt.enlinkd.service.api.BridgeForwardingTableEntry;
 import org.opennms.netmgt.enlinkd.service.api.BridgeTopologyException;
 import org.opennms.netmgt.enlinkd.service.api.BridgeTopologyService;

--- a/features/enlinkd/adapters/collectors/bridge/src/main/java/org/opennms/netmgt/enlinkd/NodeDiscoveryBridge.java
+++ b/features/enlinkd/adapters/collectors/bridge/src/main/java/org/opennms/netmgt/enlinkd/NodeDiscoveryBridge.java
@@ -41,6 +41,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.ExecutionException;
 
+import org.opennms.netmgt.enlinkd.common.NodeCollector;
 import org.opennms.netmgt.enlinkd.model.BridgeElement;
 import org.opennms.netmgt.enlinkd.model.BridgeElement.BridgeDot1dBaseType;
 import org.opennms.netmgt.enlinkd.model.BridgeStpLink;
@@ -93,7 +94,7 @@ public final class NodeDiscoveryBridge extends NodeCollector {
         m_maxSize = maxSize;
     }
 
-    protected void collect() {
+    public void collect() {
         final Date now = new Date();
 
         SnmpAgentConfig peer = getSnmpAgentConfig();

--- a/features/enlinkd/adapters/collectors/cdp/src/main/java/org/opennms/netmgt/enlinkd/NodeDiscoveryCdp.java
+++ b/features/enlinkd/adapters/collectors/cdp/src/main/java/org/opennms/netmgt/enlinkd/NodeDiscoveryCdp.java
@@ -33,6 +33,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 
+import org.opennms.netmgt.enlinkd.common.NodeCollector;
 import org.opennms.netmgt.enlinkd.model.CdpElement;
 import org.opennms.netmgt.enlinkd.model.CdpLink;
 import org.opennms.netmgt.enlinkd.model.OspfElement.TruthValue;
@@ -72,7 +73,7 @@ public final class NodeDiscoveryCdp extends NodeCollector {
     	m_cdpTopologyService = cdpTopologyService;
     }
 
-    protected void collect() {
+    public void collect() {
 
     	final Date now = new Date(); 
         final CdpGlobalGroupTracker cdpGlobalGroup = new CdpGlobalGroupTracker();

--- a/features/enlinkd/adapters/collectors/ipnettomedia/src/main/java/org/opennms/netmgt/enlinkd/NodeDiscoveryIpNetToMedia.java
+++ b/features/enlinkd/adapters/collectors/ipnettomedia/src/main/java/org/opennms/netmgt/enlinkd/NodeDiscoveryIpNetToMedia.java
@@ -33,6 +33,7 @@ import static org.opennms.core.utils.InetAddressUtils.str;
 import java.util.Date;
 import java.util.concurrent.ExecutionException;
 
+import org.opennms.netmgt.enlinkd.common.NodeCollector;
 import org.opennms.netmgt.enlinkd.model.IpNetToMedia;
 import org.opennms.netmgt.enlinkd.model.IpNetToMedia.IpNetToMediaType;
 import org.opennms.netmgt.enlinkd.service.api.IpNetToMediaTopologyService;
@@ -72,7 +73,7 @@ public final class NodeDiscoveryIpNetToMedia extends NodeCollector {
     	m_ipNetToMediaTopologyService = ipNetToMediaTopologyService;
     }
 
-    protected void collect() {
+    public void collect() {
 
     	final Date now = new Date(); 
 

--- a/features/enlinkd/adapters/collectors/isis/src/main/java/org/opennms/netmgt/enlinkd/NodeDiscoveryIsis.java
+++ b/features/enlinkd/adapters/collectors/isis/src/main/java/org/opennms/netmgt/enlinkd/NodeDiscoveryIsis.java
@@ -33,6 +33,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 
+import org.opennms.netmgt.enlinkd.common.NodeCollector;
 import org.opennms.netmgt.enlinkd.model.IsIsLink;
 import org.opennms.netmgt.enlinkd.service.api.IsisTopologyService;
 import org.opennms.netmgt.enlinkd.service.api.Node;
@@ -73,7 +74,7 @@ public final class NodeDiscoveryIsis extends NodeCollector {
     	m_isisTopologyService = isisTopologyService;
     }
 
-    protected void collect() {
+    public void collect() {
 
     	final Date now = new Date(); 
 

--- a/features/enlinkd/adapters/collectors/lldp/src/main/java/org/opennms/netmgt/enlinkd/NodeDiscoveryLldp.java
+++ b/features/enlinkd/adapters/collectors/lldp/src/main/java/org/opennms/netmgt/enlinkd/NodeDiscoveryLldp.java
@@ -34,6 +34,7 @@ import java.util.List;
 import java.util.concurrent.ExecutionException;
 
 import org.opennms.core.utils.LldpUtils.LldpChassisIdSubType;
+import org.opennms.netmgt.enlinkd.common.NodeCollector;
 import org.opennms.netmgt.enlinkd.model.LldpLink;
 import org.opennms.netmgt.enlinkd.service.api.LldpTopologyService;
 import org.opennms.netmgt.enlinkd.service.api.Node;
@@ -79,7 +80,7 @@ public final class NodeDiscoveryLldp extends NodeCollector {
     	m_lldpTopologyService = lldpTopologyService;
     }
 
-    protected void collect() {
+    public void collect() {
 
     	final Date now = new Date(); 
 

--- a/features/enlinkd/adapters/collectors/ospf/src/main/java/org/opennms/netmgt/enlinkd/NodeDiscoveryOspf.java
+++ b/features/enlinkd/adapters/collectors/ospf/src/main/java/org/opennms/netmgt/enlinkd/NodeDiscoveryOspf.java
@@ -34,6 +34,7 @@ import java.util.List;
 import java.util.concurrent.ExecutionException;
 
 import org.opennms.core.utils.InetAddressUtils;
+import org.opennms.netmgt.enlinkd.common.NodeCollector;
 import org.opennms.netmgt.enlinkd.model.OspfElement.Status;
 import org.opennms.netmgt.enlinkd.model.OspfLink;
 import org.opennms.netmgt.enlinkd.service.api.Node;
@@ -76,7 +77,7 @@ public final class NodeDiscoveryOspf extends NodeCollector {
     	m_ospfTopologyService = ospfTopologyService;
     }
 
-    protected void collect() {
+    public void collect() {
 
     	final Date now = new Date(); 
 

--- a/features/enlinkd/adapters/common/src/main/java/org/opennms/netmgt/enlinkd/common/Discovery.java
+++ b/features/enlinkd/adapters/common/src/main/java/org/opennms/netmgt/enlinkd/common/Discovery.java
@@ -26,7 +26,7 @@
  *     http://www.opennms.com/
  *******************************************************************************/
 
-package org.opennms.netmgt.enlinkd;
+package org.opennms.netmgt.enlinkd.common;
 
 import org.opennms.netmgt.scheduler.LegacyScheduler;
 import org.opennms.netmgt.scheduler.ReadyRunnable;

--- a/features/enlinkd/adapters/common/src/main/java/org/opennms/netmgt/enlinkd/common/NodeCollector.java
+++ b/features/enlinkd/adapters/common/src/main/java/org/opennms/netmgt/enlinkd/common/NodeCollector.java
@@ -26,7 +26,7 @@
  *     http://www.opennms.com/
  *******************************************************************************/
 
-package org.opennms.netmgt.enlinkd;
+package org.opennms.netmgt.enlinkd.common;
 
 import static org.opennms.core.utils.InetAddressUtils.str;
 
@@ -68,7 +68,7 @@ public abstract class NodeCollector extends Discovery {
     }
 
 
-    protected abstract void collect(); 
+    public abstract void collect(); 
     /**
      * <p>
      * Performs the collection for the targeted IP address. The success or

--- a/features/enlinkd/adapters/updaters/bridge/src/main/java/org/opennms/netmgt/enlinkd/BridgeOnmsTopologyUpdater.java
+++ b/features/enlinkd/adapters/updaters/bridge/src/main/java/org/opennms/netmgt/enlinkd/BridgeOnmsTopologyUpdater.java
@@ -33,6 +33,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.opennms.netmgt.enlinkd.common.TopologyUpdater;
 import org.opennms.netmgt.enlinkd.model.IpInterfaceTopologyEntity;
 import org.opennms.netmgt.enlinkd.model.NodeTopologyEntity;
 import org.opennms.netmgt.enlinkd.model.SnmpInterfaceTopologyEntity;
@@ -54,7 +55,7 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.Table;
 
-public class BridgeOnmsTopologyUpdater extends TopologyUpdater  {
+public class BridgeOnmsTopologyUpdater extends TopologyUpdater {
 
     public static BridgeOnmsTopologyUpdater clone(BridgeOnmsTopologyUpdater bpu) {
         

--- a/features/enlinkd/adapters/updaters/cdp/src/main/java/org/opennms/netmgt/enlinkd/CdpOnmsTopologyUpdater.java
+++ b/features/enlinkd/adapters/updaters/cdp/src/main/java/org/opennms/netmgt/enlinkd/CdpOnmsTopologyUpdater.java
@@ -30,6 +30,7 @@ package org.opennms.netmgt.enlinkd;
 
 import java.util.Map;
 
+import org.opennms.netmgt.enlinkd.common.TopologyUpdater;
 import org.opennms.netmgt.enlinkd.model.CdpElementTopologyEntity;
 import org.opennms.netmgt.enlinkd.model.CdpLinkTopologyEntity;
 import org.opennms.netmgt.enlinkd.model.IpInterfaceTopologyEntity;

--- a/features/enlinkd/adapters/updaters/isis/src/main/java/org/opennms/netmgt/enlinkd/IsisOnmsTopologyUpdater.java
+++ b/features/enlinkd/adapters/updaters/isis/src/main/java/org/opennms/netmgt/enlinkd/IsisOnmsTopologyUpdater.java
@@ -30,6 +30,7 @@ package org.opennms.netmgt.enlinkd;
 
 import java.util.Map;
 
+import org.opennms.netmgt.enlinkd.common.TopologyUpdater;
 import org.opennms.netmgt.enlinkd.model.IpInterfaceTopologyEntity;
 import org.opennms.netmgt.enlinkd.model.IsIsElementTopologyEntity;
 import org.opennms.netmgt.enlinkd.model.IsIsLinkTopologyEntity;

--- a/features/enlinkd/adapters/updaters/lldp/src/main/java/org/opennms/netmgt/enlinkd/LldpOnmsTopologyUpdater.java
+++ b/features/enlinkd/adapters/updaters/lldp/src/main/java/org/opennms/netmgt/enlinkd/LldpOnmsTopologyUpdater.java
@@ -30,6 +30,7 @@ package org.opennms.netmgt.enlinkd;
 
 import java.util.Map;
 
+import org.opennms.netmgt.enlinkd.common.TopologyUpdater;
 import org.opennms.netmgt.enlinkd.model.IpInterfaceTopologyEntity;
 import org.opennms.netmgt.enlinkd.model.LldpElementTopologyEntity;
 import org.opennms.netmgt.enlinkd.model.LldpLinkTopologyEntity;

--- a/features/enlinkd/adapters/updaters/nodes/src/main/java/org/opennms/netmgt/enlinkd/NodesOnmsTopologyUpdater.java
+++ b/features/enlinkd/adapters/updaters/nodes/src/main/java/org/opennms/netmgt/enlinkd/NodesOnmsTopologyUpdater.java
@@ -30,6 +30,7 @@ package org.opennms.netmgt.enlinkd;
 
 import java.util.Map;
 
+import org.opennms.netmgt.enlinkd.common.TopologyUpdater;
 import org.opennms.netmgt.enlinkd.model.IpInterfaceTopologyEntity;
 import org.opennms.netmgt.enlinkd.model.NodeTopologyEntity;
 import org.opennms.netmgt.enlinkd.service.api.NodeTopologyService;

--- a/features/enlinkd/adapters/updaters/nodes/src/main/java/org/opennms/netmgt/enlinkd/UserDefinedLinkTopologyUpdater.java
+++ b/features/enlinkd/adapters/updaters/nodes/src/main/java/org/opennms/netmgt/enlinkd/UserDefinedLinkTopologyUpdater.java
@@ -36,13 +36,12 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.opennms.netmgt.enlinkd.common.TopologyUpdater;
 import org.opennms.netmgt.enlinkd.model.IpInterfaceTopologyEntity;
-import org.opennms.netmgt.enlinkd.model.LldpElementTopologyEntity;
 import org.opennms.netmgt.enlinkd.model.NodeTopologyEntity;
 import org.opennms.netmgt.enlinkd.model.UserDefinedLink;
 import org.opennms.netmgt.enlinkd.service.api.NodeTopologyService;
 import org.opennms.netmgt.enlinkd.service.api.ProtocolSupported;
-import org.opennms.netmgt.enlinkd.service.api.Topology;
 import org.opennms.netmgt.enlinkd.service.api.UserDefinedLinkTopologyService;
 import org.opennms.netmgt.topologies.service.api.OnmsTopology;
 import org.opennms.netmgt.topologies.service.api.OnmsTopologyDao;

--- a/features/enlinkd/adapters/updaters/ospf/src/main/java/org/opennms/netmgt/enlinkd/OspfOnmsTopologyUpdater.java
+++ b/features/enlinkd/adapters/updaters/ospf/src/main/java/org/opennms/netmgt/enlinkd/OspfOnmsTopologyUpdater.java
@@ -30,6 +30,7 @@ package org.opennms.netmgt.enlinkd;
 
 import java.util.Map;
 
+import org.opennms.netmgt.enlinkd.common.TopologyUpdater;
 import org.opennms.netmgt.enlinkd.model.IpInterfaceTopologyEntity;
 import org.opennms.netmgt.enlinkd.model.NodeTopologyEntity;
 import org.opennms.netmgt.enlinkd.model.OspfElement;

--- a/features/enlinkd/daemon/src/main/java/org/opennms/netmgt/enlinkd/EnhancedLinkd.java
+++ b/features/enlinkd/daemon/src/main/java/org/opennms/netmgt/enlinkd/EnhancedLinkd.java
@@ -42,6 +42,8 @@ import org.opennms.netmgt.config.EnhancedLinkdConfig;
 import org.opennms.netmgt.config.datacollection.SnmpCollection;
 import org.opennms.netmgt.daemon.AbstractServiceDaemon;
 import org.opennms.netmgt.enlinkd.api.ReloadableTopologyDaemon;
+import org.opennms.netmgt.enlinkd.common.NodeCollector;
+import org.opennms.netmgt.enlinkd.common.TopologyUpdater;
 import org.opennms.netmgt.enlinkd.service.api.BridgeTopologyException;
 import org.opennms.netmgt.enlinkd.service.api.BridgeTopologyService;
 import org.opennms.netmgt.enlinkd.service.api.CdpTopologyService;

--- a/features/enlinkd/tests/src/test/java/org/opennms/netmgt/enlinkd/EnLinkdBuilderITCase.java
+++ b/features/enlinkd/tests/src/test/java/org/opennms/netmgt/enlinkd/EnLinkdBuilderITCase.java
@@ -29,6 +29,8 @@
 package org.opennms.netmgt.enlinkd;
 
 import java.util.Properties;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.junit.After;
 import org.junit.Before;
@@ -59,6 +61,7 @@ import org.opennms.netmgt.enlinkd.service.api.BridgeTopologyService;
 import org.opennms.netmgt.enlinkd.service.api.CdpTopologyService;
 import org.opennms.netmgt.enlinkd.service.api.LldpTopologyService;
 import org.opennms.netmgt.enlinkd.service.api.NodeTopologyService;
+import org.opennms.netmgt.enlinkd.service.api.ProtocolSupported;
 import org.opennms.netmgt.model.OnmsNode;
 import org.opennms.netmgt.topologies.service.api.OnmsTopologyDao;
 import org.opennms.netmgt.topologies.service.impl.OnmsTopologyLogger;
@@ -184,6 +187,13 @@ public abstract class EnLinkdBuilderITCase extends EnLinkdTestHelper implements 
         OnmsTopologyLogger tl = new OnmsTopologyLogger(protocol);
         m_topologyDao.subscribe(tl);
         return tl;
+    }
+
+    Set<ProtocolSupported> getSupportedProtocolsAsProtocolSupported() {
+        return m_topologyDao.getSupportedProtocols()
+                .stream()
+                .map(p -> ProtocolSupported.valueOf(p.getId()))
+                .collect(Collectors.toSet());
     }
     
 }

--- a/features/enlinkd/tests/src/test/java/org/opennms/netmgt/enlinkd/Nms17216EnIT.java
+++ b/features/enlinkd/tests/src/test/java/org/opennms/netmgt/enlinkd/Nms17216EnIT.java
@@ -88,6 +88,7 @@ import org.opennms.core.test.snmp.annotations.JUnitSnmpAgents;
 import org.opennms.core.utils.InetAddressUtils;
 import org.opennms.core.utils.LldpUtils.LldpChassisIdSubType;
 import org.opennms.core.utils.LldpUtils.LldpPortIdSubType;
+import org.opennms.netmgt.enlinkd.common.TopologyUpdater;
 import org.opennms.netmgt.enlinkd.model.CdpElement;
 import org.opennms.netmgt.enlinkd.model.CdpLink;
 import org.opennms.netmgt.enlinkd.model.CdpLink.CiscoNetworkProtocolType;

--- a/features/enlinkd/tests/src/test/java/org/opennms/netmgt/enlinkd/Nms17216EnIT.java
+++ b/features/enlinkd/tests/src/test/java/org/opennms/netmgt/enlinkd/Nms17216EnIT.java
@@ -748,14 +748,14 @@ public class Nms17216EnIT extends EnLinkdBuilderITCase {
         //update configuration to support only CDP updates
         //need to reload daemon
         m_linkd.reload();
-        assertEquals(3, m_topologyDao.getSupportedProtocols().size());
-        assertTrue(m_topologyDao.getSupportedProtocols().contains(ProtocolSupported.NODES.name()));               
-        assertTrue(!m_topologyDao.getSupportedProtocols().contains(ProtocolSupported.BRIDGE.name()));
-        assertTrue(m_topologyDao.getSupportedProtocols().contains(ProtocolSupported.CDP.name()));
-        assertTrue(!m_topologyDao.getSupportedProtocols().contains(ProtocolSupported.ISIS.name()));
-        assertTrue(!m_topologyDao.getSupportedProtocols().contains(ProtocolSupported.LLDP.name()));
-        assertTrue(!m_topologyDao.getSupportedProtocols().contains(ProtocolSupported.OSPF.name()));
-        assertTrue(m_topologyDao.getSupportedProtocols().contains(ProtocolSupported.USERDEFINED.name()));
+        assertEquals(3, getSupportedProtocolsAsProtocolSupported().size());
+        assertTrue(getSupportedProtocolsAsProtocolSupported().contains(ProtocolSupported.NODES));
+        assertTrue(!getSupportedProtocolsAsProtocolSupported().contains(ProtocolSupported.BRIDGE));
+        assertTrue(getSupportedProtocolsAsProtocolSupported().contains(ProtocolSupported.CDP));
+        assertTrue(!getSupportedProtocolsAsProtocolSupported().contains(ProtocolSupported.ISIS));
+        assertTrue(!getSupportedProtocolsAsProtocolSupported().contains(ProtocolSupported.LLDP));
+        assertTrue(!getSupportedProtocolsAsProtocolSupported().contains(ProtocolSupported.OSPF));
+        assertTrue(getSupportedProtocolsAsProtocolSupported().contains(ProtocolSupported.USERDEFINED));
 
         final OnmsNode switch1 = m_nodeDao.findByForeignId("linkd", SWITCH1_NAME);
         final OnmsNode switch2 = m_nodeDao.findByForeignId("linkd", SWITCH2_NAME);
@@ -867,14 +867,14 @@ public class Nms17216EnIT extends EnLinkdBuilderITCase {
         
         // reload daemon and support only: LLDP updates
         m_linkd.reload();
-        assertTrue(m_topologyDao.getSupportedProtocols().contains(ProtocolSupported.NODES.name()));
-        assertEquals(3, m_topologyDao.getSupportedProtocols().size());
-        assertTrue(!m_topologyDao.getSupportedProtocols().contains(ProtocolSupported.BRIDGE.name()));
-        assertTrue(!m_topologyDao.getSupportedProtocols().contains(ProtocolSupported.CDP.name()));
-        assertTrue(!m_topologyDao.getSupportedProtocols().contains(ProtocolSupported.ISIS.name()));
-        assertTrue(m_topologyDao.getSupportedProtocols().contains(ProtocolSupported.LLDP.name()));
-        assertTrue(!m_topologyDao.getSupportedProtocols().contains(ProtocolSupported.OSPF.name()));
-        assertTrue(m_topologyDao.getSupportedProtocols().contains(ProtocolSupported.USERDEFINED.name()));
+        assertTrue(getSupportedProtocolsAsProtocolSupported().contains(ProtocolSupported.NODES));
+        assertEquals(3, getSupportedProtocolsAsProtocolSupported().size());
+        assertTrue(!getSupportedProtocolsAsProtocolSupported().contains(ProtocolSupported.BRIDGE));
+        assertTrue(!getSupportedProtocolsAsProtocolSupported().contains(ProtocolSupported.CDP));
+        assertTrue(!getSupportedProtocolsAsProtocolSupported().contains(ProtocolSupported.ISIS));
+        assertTrue(getSupportedProtocolsAsProtocolSupported().contains(ProtocolSupported.LLDP));
+        assertTrue(!getSupportedProtocolsAsProtocolSupported().contains(ProtocolSupported.OSPF));
+        assertTrue(getSupportedProtocolsAsProtocolSupported().contains(ProtocolSupported.USERDEFINED));
 
         final OnmsNode switch1 = m_nodeDao.findByForeignId("linkd", SWITCH1_NAME);
         final OnmsNode switch2 = m_nodeDao.findByForeignId("linkd", SWITCH2_NAME);

--- a/features/enlinkd/tests/src/test/java/org/opennms/netmgt/enlinkd/Nms7918EnIT.java
+++ b/features/enlinkd/tests/src/test/java/org/opennms/netmgt/enlinkd/Nms7918EnIT.java
@@ -61,6 +61,7 @@ import org.junit.Test;
 import org.opennms.core.test.snmp.annotations.JUnitSnmpAgent;
 import org.opennms.core.test.snmp.annotations.JUnitSnmpAgents;
 import org.opennms.core.utils.InetAddressUtils;
+import org.opennms.netmgt.enlinkd.common.TopologyUpdater;
 import org.opennms.netmgt.enlinkd.model.BridgeBridgeLink;
 import org.opennms.netmgt.enlinkd.model.BridgeMacLink;
 import org.opennms.netmgt.enlinkd.model.BridgeMacLink.BridgeMacLinkType;

--- a/features/enlinkd/tests/src/test/java/org/opennms/netmgt/enlinkd/Nms7918EnIT.java
+++ b/features/enlinkd/tests/src/test/java/org/opennms/netmgt/enlinkd/Nms7918EnIT.java
@@ -1005,14 +1005,14 @@ public class Nms7918EnIT extends EnLinkdBuilderITCase {
         assertTrue(m_linkdConfig.useBridgeDiscovery());
         assertTrue(m_linkdConfig.useIsisDiscovery());
 
-        assertEquals(7, m_topologyDao.getSupportedProtocols().size());
-        assertTrue(m_topologyDao.getSupportedProtocols().contains(ProtocolSupported.NODES.name()));
-        assertTrue(m_topologyDao.getSupportedProtocols().contains(ProtocolSupported.BRIDGE.name()));
-        assertTrue(m_topologyDao.getSupportedProtocols().contains(ProtocolSupported.CDP.name()));
-        assertTrue(m_topologyDao.getSupportedProtocols().contains(ProtocolSupported.ISIS.name()));
-        assertTrue(m_topologyDao.getSupportedProtocols().contains(ProtocolSupported.LLDP.name()));
-        assertTrue(m_topologyDao.getSupportedProtocols().contains(ProtocolSupported.OSPF.name()));
-        assertTrue(m_topologyDao.getSupportedProtocols().contains(ProtocolSupported.USERDEFINED.name()));
+        assertEquals(7, getSupportedProtocolsAsProtocolSupported().size());
+        assertTrue(getSupportedProtocolsAsProtocolSupported().contains(ProtocolSupported.NODES));
+        assertTrue(getSupportedProtocolsAsProtocolSupported().contains(ProtocolSupported.BRIDGE));
+        assertTrue(getSupportedProtocolsAsProtocolSupported().contains(ProtocolSupported.CDP));
+        assertTrue(getSupportedProtocolsAsProtocolSupported().contains(ProtocolSupported.ISIS));
+        assertTrue(getSupportedProtocolsAsProtocolSupported().contains(ProtocolSupported.LLDP));
+        assertTrue(getSupportedProtocolsAsProtocolSupported().contains(ProtocolSupported.OSPF));
+        assertTrue(getSupportedProtocolsAsProtocolSupported().contains(ProtocolSupported.USERDEFINED));
 
         //update config to suppoort only BRIDGE discovery
         m_linkdConfig.getConfiguration().setUseCdpDiscovery(false);
@@ -1029,14 +1029,14 @@ public class Nms7918EnIT extends EnLinkdBuilderITCase {
 
         //Updated configuration will lead to support only BRIDGE updates,
         m_linkd.reload();
-        assertEquals(3, m_topologyDao.getSupportedProtocols().size());
-        assertTrue(m_topologyDao.getSupportedProtocols().contains(ProtocolSupported.NODES.name()));
-        assertTrue(m_topologyDao.getSupportedProtocols().contains(ProtocolSupported.BRIDGE.name()));
-        assertTrue(m_topologyDao.getSupportedProtocols().contains(ProtocolSupported.USERDEFINED.name()));
-        assertTrue(!m_topologyDao.getSupportedProtocols().contains(ProtocolSupported.CDP.name()));
-        assertTrue(!m_topologyDao.getSupportedProtocols().contains(ProtocolSupported.ISIS.name()));
-        assertTrue(!m_topologyDao.getSupportedProtocols().contains(ProtocolSupported.LLDP.name()));
-        assertTrue(!m_topologyDao.getSupportedProtocols().contains(ProtocolSupported.OSPF.name()));
+        assertEquals(3, getSupportedProtocolsAsProtocolSupported().size());
+        assertTrue(getSupportedProtocolsAsProtocolSupported().contains(ProtocolSupported.NODES));
+        assertTrue(getSupportedProtocolsAsProtocolSupported().contains(ProtocolSupported.BRIDGE));
+        assertTrue(getSupportedProtocolsAsProtocolSupported().contains(ProtocolSupported.USERDEFINED));
+        assertTrue(!getSupportedProtocolsAsProtocolSupported().contains(ProtocolSupported.CDP));
+        assertTrue(!getSupportedProtocolsAsProtocolSupported().contains(ProtocolSupported.ISIS));
+        assertTrue(!getSupportedProtocolsAsProtocolSupported().contains(ProtocolSupported.LLDP));
+        assertTrue(!getSupportedProtocolsAsProtocolSupported().contains(ProtocolSupported.OSPF));
         
         final OnmsNode pe01 = m_nodeDao.findByForeignId("linkd", PE01_NAME);
         final OnmsNode asw01 = m_nodeDao.findByForeignId("linkd", ASW01_NAME);

--- a/features/kafka/producer/pom.xml
+++ b/features/kafka/producer/pom.xml
@@ -209,5 +209,12 @@
       <artifactId>org.opennms.features.enlinkd.service.api</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.opennms.features.topologies</groupId>
+      <artifactId>org.opennms.features.topologies.service.api</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/features/kafka/producer/src/main/java/org/opennms/features/kafka/producer/OpennmsKafkaProducer.java
+++ b/features/kafka/producer/src/main/java/org/opennms/features/kafka/producer/OpennmsKafkaProducer.java
@@ -644,11 +644,6 @@ public class OpennmsKafkaProducer implements AlarmLifecycleListener, EventListen
         }
 
         @Override
-        public void visit(OnmsTopologyVertex vertex) {
-            // Note: Handling of segments (vertices with no node Id) should go here when they are being published
-        }
-
-        @Override
         public void visit(OnmsTopologyEdge edge) {
             forwardTopologyEdgeMessage(getKeyForEdge(edge), null);
         }
@@ -665,15 +660,13 @@ public class OpennmsKafkaProducer implements AlarmLifecycleListener, EventListen
             if (forwardNodes && vertex.getNodeid() != null) {
                 maybeUpdateNode(vertex.getNodeid());
             }
-
-            // Note: Segments (vertices with no node id) are currently unsupported
         }
 
         @Override
         public void visit(OnmsTopologyEdge edge) {
             Objects.requireNonNull(onmsTopologyMessage);
             final OpennmsModelProtos.TopologyEdge mappedTopoMsg =
-                    protobufMapper.toEdgeTopologyMessage(onmsTopologyMessage.getProtocol().getId(), edge).build();
+                    protobufMapper.toEdgeTopologyMessage(onmsTopologyMessage.getProtocol(), edge);
             forwardTopologyEdgeMessage(getKeyForEdge(edge), mappedTopoMsg.toByteArray());
         }
     }

--- a/features/kafka/producer/src/main/java/org/opennms/features/kafka/producer/model/OpennmsModelProtos.java
+++ b/features/kafka/producer/src/main/java/org/opennms/features/kafka/producer/model/OpennmsModelProtos.java
@@ -18396,43 +18396,84 @@ public final class OpennmsModelProtos {
     org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologyRefOrBuilder getRefOrBuilder();
 
     /**
-     * <code>.TopologyPort source = 2;</code>
+     * <code>.TopologyPort sourcePort = 3;</code>
      */
-    boolean hasSource();
+    boolean hasSourcePort();
     /**
-     * <code>.TopologyPort source = 2;</code>
+     * <code>.TopologyPort sourcePort = 3;</code>
      */
-    org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologyPort getSource();
+    org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologyPort getSourcePort();
     /**
-     * <code>.TopologyPort source = 2;</code>
+     * <code>.TopologyPort sourcePort = 3;</code>
      */
-    org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologyPortOrBuilder getSourceOrBuilder();
+    org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologyPortOrBuilder getSourcePortOrBuilder();
 
     /**
-     * <code>.TopologyPort targetPort = 3;</code>
+     * <code>.TopologySegment sourceSegment = 4;</code>
+     */
+    boolean hasSourceSegment();
+    /**
+     * <code>.TopologySegment sourceSegment = 4;</code>
+     */
+    org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologySegment getSourceSegment();
+    /**
+     * <code>.TopologySegment sourceSegment = 4;</code>
+     */
+    org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologySegmentOrBuilder getSourceSegmentOrBuilder();
+
+    /**
+     * <code>.Node sourceNode = 5;</code>
+     */
+    boolean hasSourceNode();
+    /**
+     * <code>.Node sourceNode = 5;</code>
+     */
+    org.opennms.features.kafka.producer.model.OpennmsModelProtos.Node getSourceNode();
+    /**
+     * <code>.Node sourceNode = 5;</code>
+     */
+    org.opennms.features.kafka.producer.model.OpennmsModelProtos.NodeOrBuilder getSourceNodeOrBuilder();
+
+    /**
+     * <code>.TopologyPort targetPort = 6;</code>
      */
     boolean hasTargetPort();
     /**
-     * <code>.TopologyPort targetPort = 3;</code>
+     * <code>.TopologyPort targetPort = 6;</code>
      */
     org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologyPort getTargetPort();
     /**
-     * <code>.TopologyPort targetPort = 3;</code>
+     * <code>.TopologyPort targetPort = 6;</code>
      */
     org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologyPortOrBuilder getTargetPortOrBuilder();
 
     /**
-     * <code>.TopologySegment targetSegment = 4;</code>
+     * <code>.TopologySegment targetSegment = 7;</code>
      */
     boolean hasTargetSegment();
     /**
-     * <code>.TopologySegment targetSegment = 4;</code>
+     * <code>.TopologySegment targetSegment = 7;</code>
      */
     org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologySegment getTargetSegment();
     /**
-     * <code>.TopologySegment targetSegment = 4;</code>
+     * <code>.TopologySegment targetSegment = 7;</code>
      */
     org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologySegmentOrBuilder getTargetSegmentOrBuilder();
+
+    /**
+     * <code>.Node targetNode = 8;</code>
+     */
+    boolean hasTargetNode();
+    /**
+     * <code>.Node targetNode = 8;</code>
+     */
+    org.opennms.features.kafka.producer.model.OpennmsModelProtos.Node getTargetNode();
+    /**
+     * <code>.Node targetNode = 8;</code>
+     */
+    org.opennms.features.kafka.producer.model.OpennmsModelProtos.NodeOrBuilder getTargetNodeOrBuilder();
+
+    public org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologyEdge.SourceCase getSourceCase();
 
     public org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologyEdge.TargetCase getTargetCase();
   }
@@ -18495,22 +18536,51 @@ public final class OpennmsModelProtos {
 
               break;
             }
-            case 18: {
-              org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologyPort.Builder subBuilder = null;
-              if (source_ != null) {
-                subBuilder = source_.toBuilder();
-              }
-              source_ = input.readMessage(org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologyPort.parser(), extensionRegistry);
-              if (subBuilder != null) {
-                subBuilder.mergeFrom(source_);
-                source_ = subBuilder.buildPartial();
-              }
-
-              break;
-            }
             case 26: {
               org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologyPort.Builder subBuilder = null;
-              if (targetCase_ == 3) {
+              if (sourceCase_ == 3) {
+                subBuilder = ((org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologyPort) source_).toBuilder();
+              }
+              source_ =
+                  input.readMessage(org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologyPort.parser(), extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom((org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologyPort) source_);
+                source_ = subBuilder.buildPartial();
+              }
+              sourceCase_ = 3;
+              break;
+            }
+            case 34: {
+              org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologySegment.Builder subBuilder = null;
+              if (sourceCase_ == 4) {
+                subBuilder = ((org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologySegment) source_).toBuilder();
+              }
+              source_ =
+                  input.readMessage(org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologySegment.parser(), extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom((org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologySegment) source_);
+                source_ = subBuilder.buildPartial();
+              }
+              sourceCase_ = 4;
+              break;
+            }
+            case 42: {
+              org.opennms.features.kafka.producer.model.OpennmsModelProtos.Node.Builder subBuilder = null;
+              if (sourceCase_ == 5) {
+                subBuilder = ((org.opennms.features.kafka.producer.model.OpennmsModelProtos.Node) source_).toBuilder();
+              }
+              source_ =
+                  input.readMessage(org.opennms.features.kafka.producer.model.OpennmsModelProtos.Node.parser(), extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom((org.opennms.features.kafka.producer.model.OpennmsModelProtos.Node) source_);
+                source_ = subBuilder.buildPartial();
+              }
+              sourceCase_ = 5;
+              break;
+            }
+            case 50: {
+              org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologyPort.Builder subBuilder = null;
+              if (targetCase_ == 6) {
                 subBuilder = ((org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologyPort) target_).toBuilder();
               }
               target_ =
@@ -18519,12 +18589,12 @@ public final class OpennmsModelProtos {
                 subBuilder.mergeFrom((org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologyPort) target_);
                 target_ = subBuilder.buildPartial();
               }
-              targetCase_ = 3;
+              targetCase_ = 6;
               break;
             }
-            case 34: {
+            case 58: {
               org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologySegment.Builder subBuilder = null;
-              if (targetCase_ == 4) {
+              if (targetCase_ == 7) {
                 subBuilder = ((org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologySegment) target_).toBuilder();
               }
               target_ =
@@ -18533,7 +18603,21 @@ public final class OpennmsModelProtos {
                 subBuilder.mergeFrom((org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologySegment) target_);
                 target_ = subBuilder.buildPartial();
               }
-              targetCase_ = 4;
+              targetCase_ = 7;
+              break;
+            }
+            case 66: {
+              org.opennms.features.kafka.producer.model.OpennmsModelProtos.Node.Builder subBuilder = null;
+              if (targetCase_ == 8) {
+                subBuilder = ((org.opennms.features.kafka.producer.model.OpennmsModelProtos.Node) target_).toBuilder();
+              }
+              target_ =
+                  input.readMessage(org.opennms.features.kafka.producer.model.OpennmsModelProtos.Node.parser(), extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom((org.opennms.features.kafka.producer.model.OpennmsModelProtos.Node) target_);
+                target_ = subBuilder.buildPartial();
+              }
+              targetCase_ = 8;
               break;
             }
           }
@@ -18560,12 +18644,53 @@ public final class OpennmsModelProtos {
               org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologyEdge.class, org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologyEdge.Builder.class);
     }
 
+    private int sourceCase_ = 0;
+    private java.lang.Object source_;
+    public enum SourceCase
+        implements com.google.protobuf.Internal.EnumLite {
+      SOURCEPORT(3),
+      SOURCESEGMENT(4),
+      SOURCENODE(5),
+      SOURCE_NOT_SET(0);
+      private final int value;
+      private SourceCase(int value) {
+        this.value = value;
+      }
+      /**
+       * @deprecated Use {@link #forNumber(int)} instead.
+       */
+      @java.lang.Deprecated
+      public static SourceCase valueOf(int value) {
+        return forNumber(value);
+      }
+
+      public static SourceCase forNumber(int value) {
+        switch (value) {
+          case 3: return SOURCEPORT;
+          case 4: return SOURCESEGMENT;
+          case 5: return SOURCENODE;
+          case 0: return SOURCE_NOT_SET;
+          default: return null;
+        }
+      }
+      public int getNumber() {
+        return this.value;
+      }
+    };
+
+    public SourceCase
+    getSourceCase() {
+      return SourceCase.forNumber(
+          sourceCase_);
+    }
+
     private int targetCase_ = 0;
     private java.lang.Object target_;
     public enum TargetCase
         implements com.google.protobuf.Internal.EnumLite {
-      TARGETPORT(3),
-      TARGETSEGMENT(4),
+      TARGETPORT(6),
+      TARGETSEGMENT(7),
+      TARGETNODE(8),
       TARGET_NOT_SET(0);
       private final int value;
       private TargetCase(int value) {
@@ -18581,8 +18706,9 @@ public final class OpennmsModelProtos {
 
       public static TargetCase forNumber(int value) {
         switch (value) {
-          case 3: return TARGETPORT;
-          case 4: return TARGETSEGMENT;
+          case 6: return TARGETPORT;
+          case 7: return TARGETSEGMENT;
+          case 8: return TARGETNODE;
           case 0: return TARGET_NOT_SET;
           default: return null;
         }
@@ -18619,77 +18745,160 @@ public final class OpennmsModelProtos {
       return getRef();
     }
 
-    public static final int SOURCE_FIELD_NUMBER = 2;
-    private org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologyPort source_;
+    public static final int SOURCEPORT_FIELD_NUMBER = 3;
     /**
-     * <code>.TopologyPort source = 2;</code>
+     * <code>.TopologyPort sourcePort = 3;</code>
      */
-    public boolean hasSource() {
-      return source_ != null;
+    public boolean hasSourcePort() {
+      return sourceCase_ == 3;
     }
     /**
-     * <code>.TopologyPort source = 2;</code>
+     * <code>.TopologyPort sourcePort = 3;</code>
      */
-    public org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologyPort getSource() {
-      return source_ == null ? org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologyPort.getDefaultInstance() : source_;
+    public org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologyPort getSourcePort() {
+      if (sourceCase_ == 3) {
+         return (org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologyPort) source_;
+      }
+      return org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologyPort.getDefaultInstance();
     }
     /**
-     * <code>.TopologyPort source = 2;</code>
+     * <code>.TopologyPort sourcePort = 3;</code>
      */
-    public org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologyPortOrBuilder getSourceOrBuilder() {
-      return getSource();
+    public org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologyPortOrBuilder getSourcePortOrBuilder() {
+      if (sourceCase_ == 3) {
+         return (org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologyPort) source_;
+      }
+      return org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologyPort.getDefaultInstance();
     }
 
-    public static final int TARGETPORT_FIELD_NUMBER = 3;
+    public static final int SOURCESEGMENT_FIELD_NUMBER = 4;
     /**
-     * <code>.TopologyPort targetPort = 3;</code>
+     * <code>.TopologySegment sourceSegment = 4;</code>
+     */
+    public boolean hasSourceSegment() {
+      return sourceCase_ == 4;
+    }
+    /**
+     * <code>.TopologySegment sourceSegment = 4;</code>
+     */
+    public org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologySegment getSourceSegment() {
+      if (sourceCase_ == 4) {
+         return (org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologySegment) source_;
+      }
+      return org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologySegment.getDefaultInstance();
+    }
+    /**
+     * <code>.TopologySegment sourceSegment = 4;</code>
+     */
+    public org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologySegmentOrBuilder getSourceSegmentOrBuilder() {
+      if (sourceCase_ == 4) {
+         return (org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologySegment) source_;
+      }
+      return org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologySegment.getDefaultInstance();
+    }
+
+    public static final int SOURCENODE_FIELD_NUMBER = 5;
+    /**
+     * <code>.Node sourceNode = 5;</code>
+     */
+    public boolean hasSourceNode() {
+      return sourceCase_ == 5;
+    }
+    /**
+     * <code>.Node sourceNode = 5;</code>
+     */
+    public org.opennms.features.kafka.producer.model.OpennmsModelProtos.Node getSourceNode() {
+      if (sourceCase_ == 5) {
+         return (org.opennms.features.kafka.producer.model.OpennmsModelProtos.Node) source_;
+      }
+      return org.opennms.features.kafka.producer.model.OpennmsModelProtos.Node.getDefaultInstance();
+    }
+    /**
+     * <code>.Node sourceNode = 5;</code>
+     */
+    public org.opennms.features.kafka.producer.model.OpennmsModelProtos.NodeOrBuilder getSourceNodeOrBuilder() {
+      if (sourceCase_ == 5) {
+         return (org.opennms.features.kafka.producer.model.OpennmsModelProtos.Node) source_;
+      }
+      return org.opennms.features.kafka.producer.model.OpennmsModelProtos.Node.getDefaultInstance();
+    }
+
+    public static final int TARGETPORT_FIELD_NUMBER = 6;
+    /**
+     * <code>.TopologyPort targetPort = 6;</code>
      */
     public boolean hasTargetPort() {
-      return targetCase_ == 3;
+      return targetCase_ == 6;
     }
     /**
-     * <code>.TopologyPort targetPort = 3;</code>
+     * <code>.TopologyPort targetPort = 6;</code>
      */
     public org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologyPort getTargetPort() {
-      if (targetCase_ == 3) {
+      if (targetCase_ == 6) {
          return (org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologyPort) target_;
       }
       return org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologyPort.getDefaultInstance();
     }
     /**
-     * <code>.TopologyPort targetPort = 3;</code>
+     * <code>.TopologyPort targetPort = 6;</code>
      */
     public org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologyPortOrBuilder getTargetPortOrBuilder() {
-      if (targetCase_ == 3) {
+      if (targetCase_ == 6) {
          return (org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologyPort) target_;
       }
       return org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologyPort.getDefaultInstance();
     }
 
-    public static final int TARGETSEGMENT_FIELD_NUMBER = 4;
+    public static final int TARGETSEGMENT_FIELD_NUMBER = 7;
     /**
-     * <code>.TopologySegment targetSegment = 4;</code>
+     * <code>.TopologySegment targetSegment = 7;</code>
      */
     public boolean hasTargetSegment() {
-      return targetCase_ == 4;
+      return targetCase_ == 7;
     }
     /**
-     * <code>.TopologySegment targetSegment = 4;</code>
+     * <code>.TopologySegment targetSegment = 7;</code>
      */
     public org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologySegment getTargetSegment() {
-      if (targetCase_ == 4) {
+      if (targetCase_ == 7) {
          return (org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologySegment) target_;
       }
       return org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologySegment.getDefaultInstance();
     }
     /**
-     * <code>.TopologySegment targetSegment = 4;</code>
+     * <code>.TopologySegment targetSegment = 7;</code>
      */
     public org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologySegmentOrBuilder getTargetSegmentOrBuilder() {
-      if (targetCase_ == 4) {
+      if (targetCase_ == 7) {
          return (org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologySegment) target_;
       }
       return org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologySegment.getDefaultInstance();
+    }
+
+    public static final int TARGETNODE_FIELD_NUMBER = 8;
+    /**
+     * <code>.Node targetNode = 8;</code>
+     */
+    public boolean hasTargetNode() {
+      return targetCase_ == 8;
+    }
+    /**
+     * <code>.Node targetNode = 8;</code>
+     */
+    public org.opennms.features.kafka.producer.model.OpennmsModelProtos.Node getTargetNode() {
+      if (targetCase_ == 8) {
+         return (org.opennms.features.kafka.producer.model.OpennmsModelProtos.Node) target_;
+      }
+      return org.opennms.features.kafka.producer.model.OpennmsModelProtos.Node.getDefaultInstance();
+    }
+    /**
+     * <code>.Node targetNode = 8;</code>
+     */
+    public org.opennms.features.kafka.producer.model.OpennmsModelProtos.NodeOrBuilder getTargetNodeOrBuilder() {
+      if (targetCase_ == 8) {
+         return (org.opennms.features.kafka.producer.model.OpennmsModelProtos.Node) target_;
+      }
+      return org.opennms.features.kafka.producer.model.OpennmsModelProtos.Node.getDefaultInstance();
     }
 
     private byte memoizedIsInitialized = -1;
@@ -18707,14 +18916,23 @@ public final class OpennmsModelProtos {
       if (ref_ != null) {
         output.writeMessage(1, getRef());
       }
-      if (source_ != null) {
-        output.writeMessage(2, getSource());
+      if (sourceCase_ == 3) {
+        output.writeMessage(3, (org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologyPort) source_);
       }
-      if (targetCase_ == 3) {
-        output.writeMessage(3, (org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologyPort) target_);
+      if (sourceCase_ == 4) {
+        output.writeMessage(4, (org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologySegment) source_);
       }
-      if (targetCase_ == 4) {
-        output.writeMessage(4, (org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologySegment) target_);
+      if (sourceCase_ == 5) {
+        output.writeMessage(5, (org.opennms.features.kafka.producer.model.OpennmsModelProtos.Node) source_);
+      }
+      if (targetCase_ == 6) {
+        output.writeMessage(6, (org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologyPort) target_);
+      }
+      if (targetCase_ == 7) {
+        output.writeMessage(7, (org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologySegment) target_);
+      }
+      if (targetCase_ == 8) {
+        output.writeMessage(8, (org.opennms.features.kafka.producer.model.OpennmsModelProtos.Node) target_);
       }
       unknownFields.writeTo(output);
     }
@@ -18728,17 +18946,29 @@ public final class OpennmsModelProtos {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(1, getRef());
       }
-      if (source_ != null) {
+      if (sourceCase_ == 3) {
         size += com.google.protobuf.CodedOutputStream
-          .computeMessageSize(2, getSource());
+          .computeMessageSize(3, (org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologyPort) source_);
       }
-      if (targetCase_ == 3) {
+      if (sourceCase_ == 4) {
         size += com.google.protobuf.CodedOutputStream
-          .computeMessageSize(3, (org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologyPort) target_);
+          .computeMessageSize(4, (org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologySegment) source_);
       }
-      if (targetCase_ == 4) {
+      if (sourceCase_ == 5) {
         size += com.google.protobuf.CodedOutputStream
-          .computeMessageSize(4, (org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologySegment) target_);
+          .computeMessageSize(5, (org.opennms.features.kafka.producer.model.OpennmsModelProtos.Node) source_);
+      }
+      if (targetCase_ == 6) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(6, (org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologyPort) target_);
+      }
+      if (targetCase_ == 7) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(7, (org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologySegment) target_);
+      }
+      if (targetCase_ == 8) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(8, (org.opennms.features.kafka.producer.model.OpennmsModelProtos.Node) target_);
       }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
@@ -18761,22 +18991,40 @@ public final class OpennmsModelProtos {
         result = result && getRef()
             .equals(other.getRef());
       }
-      result = result && (hasSource() == other.hasSource());
-      if (hasSource()) {
-        result = result && getSource()
-            .equals(other.getSource());
+      result = result && getSourceCase().equals(
+          other.getSourceCase());
+      if (!result) return false;
+      switch (sourceCase_) {
+        case 3:
+          result = result && getSourcePort()
+              .equals(other.getSourcePort());
+          break;
+        case 4:
+          result = result && getSourceSegment()
+              .equals(other.getSourceSegment());
+          break;
+        case 5:
+          result = result && getSourceNode()
+              .equals(other.getSourceNode());
+          break;
+        case 0:
+        default:
       }
       result = result && getTargetCase().equals(
           other.getTargetCase());
       if (!result) return false;
       switch (targetCase_) {
-        case 3:
+        case 6:
           result = result && getTargetPort()
               .equals(other.getTargetPort());
           break;
-        case 4:
+        case 7:
           result = result && getTargetSegment()
               .equals(other.getTargetSegment());
+          break;
+        case 8:
+          result = result && getTargetNode()
+              .equals(other.getTargetNode());
           break;
         case 0:
         default:
@@ -18796,18 +19044,34 @@ public final class OpennmsModelProtos {
         hash = (37 * hash) + REF_FIELD_NUMBER;
         hash = (53 * hash) + getRef().hashCode();
       }
-      if (hasSource()) {
-        hash = (37 * hash) + SOURCE_FIELD_NUMBER;
-        hash = (53 * hash) + getSource().hashCode();
+      switch (sourceCase_) {
+        case 3:
+          hash = (37 * hash) + SOURCEPORT_FIELD_NUMBER;
+          hash = (53 * hash) + getSourcePort().hashCode();
+          break;
+        case 4:
+          hash = (37 * hash) + SOURCESEGMENT_FIELD_NUMBER;
+          hash = (53 * hash) + getSourceSegment().hashCode();
+          break;
+        case 5:
+          hash = (37 * hash) + SOURCENODE_FIELD_NUMBER;
+          hash = (53 * hash) + getSourceNode().hashCode();
+          break;
+        case 0:
+        default:
       }
       switch (targetCase_) {
-        case 3:
+        case 6:
           hash = (37 * hash) + TARGETPORT_FIELD_NUMBER;
           hash = (53 * hash) + getTargetPort().hashCode();
           break;
-        case 4:
+        case 7:
           hash = (37 * hash) + TARGETSEGMENT_FIELD_NUMBER;
           hash = (53 * hash) + getTargetSegment().hashCode();
+          break;
+        case 8:
+          hash = (37 * hash) + TARGETNODE_FIELD_NUMBER;
+          hash = (53 * hash) + getTargetNode().hashCode();
           break;
         case 0:
         default:
@@ -18947,12 +19211,8 @@ public final class OpennmsModelProtos {
           ref_ = null;
           refBuilder_ = null;
         }
-        if (sourceBuilder_ == null) {
-          source_ = null;
-        } else {
-          source_ = null;
-          sourceBuilder_ = null;
-        }
+        sourceCase_ = 0;
+        source_ = null;
         targetCase_ = 0;
         target_ = null;
         return this;
@@ -18982,25 +19242,49 @@ public final class OpennmsModelProtos {
         } else {
           result.ref_ = refBuilder_.build();
         }
-        if (sourceBuilder_ == null) {
-          result.source_ = source_;
-        } else {
-          result.source_ = sourceBuilder_.build();
+        if (sourceCase_ == 3) {
+          if (sourcePortBuilder_ == null) {
+            result.source_ = source_;
+          } else {
+            result.source_ = sourcePortBuilder_.build();
+          }
         }
-        if (targetCase_ == 3) {
+        if (sourceCase_ == 4) {
+          if (sourceSegmentBuilder_ == null) {
+            result.source_ = source_;
+          } else {
+            result.source_ = sourceSegmentBuilder_.build();
+          }
+        }
+        if (sourceCase_ == 5) {
+          if (sourceNodeBuilder_ == null) {
+            result.source_ = source_;
+          } else {
+            result.source_ = sourceNodeBuilder_.build();
+          }
+        }
+        if (targetCase_ == 6) {
           if (targetPortBuilder_ == null) {
             result.target_ = target_;
           } else {
             result.target_ = targetPortBuilder_.build();
           }
         }
-        if (targetCase_ == 4) {
+        if (targetCase_ == 7) {
           if (targetSegmentBuilder_ == null) {
             result.target_ = target_;
           } else {
             result.target_ = targetSegmentBuilder_.build();
           }
         }
+        if (targetCase_ == 8) {
+          if (targetNodeBuilder_ == null) {
+            result.target_ = target_;
+          } else {
+            result.target_ = targetNodeBuilder_.build();
+          }
+        }
+        result.sourceCase_ = sourceCase_;
         result.targetCase_ = targetCase_;
         onBuilt();
         return result;
@@ -19046,8 +19330,22 @@ public final class OpennmsModelProtos {
         if (other.hasRef()) {
           mergeRef(other.getRef());
         }
-        if (other.hasSource()) {
-          mergeSource(other.getSource());
+        switch (other.getSourceCase()) {
+          case SOURCEPORT: {
+            mergeSourcePort(other.getSourcePort());
+            break;
+          }
+          case SOURCESEGMENT: {
+            mergeSourceSegment(other.getSourceSegment());
+            break;
+          }
+          case SOURCENODE: {
+            mergeSourceNode(other.getSourceNode());
+            break;
+          }
+          case SOURCE_NOT_SET: {
+            break;
+          }
         }
         switch (other.getTargetCase()) {
           case TARGETPORT: {
@@ -19056,6 +19354,10 @@ public final class OpennmsModelProtos {
           }
           case TARGETSEGMENT: {
             mergeTargetSegment(other.getTargetSegment());
+            break;
+          }
+          case TARGETNODE: {
+            mergeTargetNode(other.getTargetNode());
             break;
           }
           case TARGET_NOT_SET: {
@@ -19088,6 +19390,21 @@ public final class OpennmsModelProtos {
         }
         return this;
       }
+      private int sourceCase_ = 0;
+      private java.lang.Object source_;
+      public SourceCase
+          getSourceCase() {
+        return SourceCase.forNumber(
+            sourceCase_);
+      }
+
+      public Builder clearSource() {
+        sourceCase_ = 0;
+        source_ = null;
+        onChanged();
+        return this;
+      }
+
       private int targetCase_ = 0;
       private java.lang.Object target_;
       public TargetCase
@@ -19221,149 +19538,440 @@ public final class OpennmsModelProtos {
         return refBuilder_;
       }
 
-      private org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologyPort source_ = null;
       private com.google.protobuf.SingleFieldBuilderV3<
-          org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologyPort, org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologyPort.Builder, org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologyPortOrBuilder> sourceBuilder_;
+          org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologyPort, org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologyPort.Builder, org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologyPortOrBuilder> sourcePortBuilder_;
       /**
-       * <code>.TopologyPort source = 2;</code>
+       * <code>.TopologyPort sourcePort = 3;</code>
        */
-      public boolean hasSource() {
-        return sourceBuilder_ != null || source_ != null;
+      public boolean hasSourcePort() {
+        return sourceCase_ == 3;
       }
       /**
-       * <code>.TopologyPort source = 2;</code>
+       * <code>.TopologyPort sourcePort = 3;</code>
        */
-      public org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologyPort getSource() {
-        if (sourceBuilder_ == null) {
-          return source_ == null ? org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologyPort.getDefaultInstance() : source_;
+      public org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologyPort getSourcePort() {
+        if (sourcePortBuilder_ == null) {
+          if (sourceCase_ == 3) {
+            return (org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologyPort) source_;
+          }
+          return org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologyPort.getDefaultInstance();
         } else {
-          return sourceBuilder_.getMessage();
+          if (sourceCase_ == 3) {
+            return sourcePortBuilder_.getMessage();
+          }
+          return org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologyPort.getDefaultInstance();
         }
       }
       /**
-       * <code>.TopologyPort source = 2;</code>
+       * <code>.TopologyPort sourcePort = 3;</code>
        */
-      public Builder setSource(org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologyPort value) {
-        if (sourceBuilder_ == null) {
+      public Builder setSourcePort(org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologyPort value) {
+        if (sourcePortBuilder_ == null) {
           if (value == null) {
             throw new NullPointerException();
           }
           source_ = value;
           onChanged();
         } else {
-          sourceBuilder_.setMessage(value);
+          sourcePortBuilder_.setMessage(value);
         }
-
+        sourceCase_ = 3;
         return this;
       }
       /**
-       * <code>.TopologyPort source = 2;</code>
+       * <code>.TopologyPort sourcePort = 3;</code>
        */
-      public Builder setSource(
+      public Builder setSourcePort(
           org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologyPort.Builder builderForValue) {
-        if (sourceBuilder_ == null) {
+        if (sourcePortBuilder_ == null) {
           source_ = builderForValue.build();
           onChanged();
         } else {
-          sourceBuilder_.setMessage(builderForValue.build());
+          sourcePortBuilder_.setMessage(builderForValue.build());
         }
-
+        sourceCase_ = 3;
         return this;
       }
       /**
-       * <code>.TopologyPort source = 2;</code>
+       * <code>.TopologyPort sourcePort = 3;</code>
        */
-      public Builder mergeSource(org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologyPort value) {
-        if (sourceBuilder_ == null) {
-          if (source_ != null) {
-            source_ =
-              org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologyPort.newBuilder(source_).mergeFrom(value).buildPartial();
+      public Builder mergeSourcePort(org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologyPort value) {
+        if (sourcePortBuilder_ == null) {
+          if (sourceCase_ == 3 &&
+              source_ != org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologyPort.getDefaultInstance()) {
+            source_ = org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologyPort.newBuilder((org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologyPort) source_)
+                .mergeFrom(value).buildPartial();
           } else {
             source_ = value;
           }
           onChanged();
         } else {
-          sourceBuilder_.mergeFrom(value);
+          if (sourceCase_ == 3) {
+            sourcePortBuilder_.mergeFrom(value);
+          }
+          sourcePortBuilder_.setMessage(value);
         }
-
+        sourceCase_ = 3;
         return this;
       }
       /**
-       * <code>.TopologyPort source = 2;</code>
+       * <code>.TopologyPort sourcePort = 3;</code>
        */
-      public Builder clearSource() {
-        if (sourceBuilder_ == null) {
-          source_ = null;
-          onChanged();
+      public Builder clearSourcePort() {
+        if (sourcePortBuilder_ == null) {
+          if (sourceCase_ == 3) {
+            sourceCase_ = 0;
+            source_ = null;
+            onChanged();
+          }
         } else {
-          source_ = null;
-          sourceBuilder_ = null;
+          if (sourceCase_ == 3) {
+            sourceCase_ = 0;
+            source_ = null;
+          }
+          sourcePortBuilder_.clear();
         }
-
         return this;
       }
       /**
-       * <code>.TopologyPort source = 2;</code>
+       * <code>.TopologyPort sourcePort = 3;</code>
        */
-      public org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologyPort.Builder getSourceBuilder() {
-        
-        onChanged();
-        return getSourceFieldBuilder().getBuilder();
+      public org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologyPort.Builder getSourcePortBuilder() {
+        return getSourcePortFieldBuilder().getBuilder();
       }
       /**
-       * <code>.TopologyPort source = 2;</code>
+       * <code>.TopologyPort sourcePort = 3;</code>
        */
-      public org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologyPortOrBuilder getSourceOrBuilder() {
-        if (sourceBuilder_ != null) {
-          return sourceBuilder_.getMessageOrBuilder();
+      public org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologyPortOrBuilder getSourcePortOrBuilder() {
+        if ((sourceCase_ == 3) && (sourcePortBuilder_ != null)) {
+          return sourcePortBuilder_.getMessageOrBuilder();
         } else {
-          return source_ == null ?
-              org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologyPort.getDefaultInstance() : source_;
+          if (sourceCase_ == 3) {
+            return (org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologyPort) source_;
+          }
+          return org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologyPort.getDefaultInstance();
         }
       }
       /**
-       * <code>.TopologyPort source = 2;</code>
+       * <code>.TopologyPort sourcePort = 3;</code>
        */
       private com.google.protobuf.SingleFieldBuilderV3<
           org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologyPort, org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologyPort.Builder, org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologyPortOrBuilder> 
-          getSourceFieldBuilder() {
-        if (sourceBuilder_ == null) {
-          sourceBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
+          getSourcePortFieldBuilder() {
+        if (sourcePortBuilder_ == null) {
+          if (!(sourceCase_ == 3)) {
+            source_ = org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologyPort.getDefaultInstance();
+          }
+          sourcePortBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
               org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologyPort, org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologyPort.Builder, org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologyPortOrBuilder>(
-                  getSource(),
+                  (org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologyPort) source_,
                   getParentForChildren(),
                   isClean());
           source_ = null;
         }
-        return sourceBuilder_;
+        sourceCase_ = 3;
+        onChanged();;
+        return sourcePortBuilder_;
+      }
+
+      private com.google.protobuf.SingleFieldBuilderV3<
+          org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologySegment, org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologySegment.Builder, org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologySegmentOrBuilder> sourceSegmentBuilder_;
+      /**
+       * <code>.TopologySegment sourceSegment = 4;</code>
+       */
+      public boolean hasSourceSegment() {
+        return sourceCase_ == 4;
+      }
+      /**
+       * <code>.TopologySegment sourceSegment = 4;</code>
+       */
+      public org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologySegment getSourceSegment() {
+        if (sourceSegmentBuilder_ == null) {
+          if (sourceCase_ == 4) {
+            return (org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologySegment) source_;
+          }
+          return org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologySegment.getDefaultInstance();
+        } else {
+          if (sourceCase_ == 4) {
+            return sourceSegmentBuilder_.getMessage();
+          }
+          return org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologySegment.getDefaultInstance();
+        }
+      }
+      /**
+       * <code>.TopologySegment sourceSegment = 4;</code>
+       */
+      public Builder setSourceSegment(org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologySegment value) {
+        if (sourceSegmentBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          source_ = value;
+          onChanged();
+        } else {
+          sourceSegmentBuilder_.setMessage(value);
+        }
+        sourceCase_ = 4;
+        return this;
+      }
+      /**
+       * <code>.TopologySegment sourceSegment = 4;</code>
+       */
+      public Builder setSourceSegment(
+          org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologySegment.Builder builderForValue) {
+        if (sourceSegmentBuilder_ == null) {
+          source_ = builderForValue.build();
+          onChanged();
+        } else {
+          sourceSegmentBuilder_.setMessage(builderForValue.build());
+        }
+        sourceCase_ = 4;
+        return this;
+      }
+      /**
+       * <code>.TopologySegment sourceSegment = 4;</code>
+       */
+      public Builder mergeSourceSegment(org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologySegment value) {
+        if (sourceSegmentBuilder_ == null) {
+          if (sourceCase_ == 4 &&
+              source_ != org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologySegment.getDefaultInstance()) {
+            source_ = org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologySegment.newBuilder((org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologySegment) source_)
+                .mergeFrom(value).buildPartial();
+          } else {
+            source_ = value;
+          }
+          onChanged();
+        } else {
+          if (sourceCase_ == 4) {
+            sourceSegmentBuilder_.mergeFrom(value);
+          }
+          sourceSegmentBuilder_.setMessage(value);
+        }
+        sourceCase_ = 4;
+        return this;
+      }
+      /**
+       * <code>.TopologySegment sourceSegment = 4;</code>
+       */
+      public Builder clearSourceSegment() {
+        if (sourceSegmentBuilder_ == null) {
+          if (sourceCase_ == 4) {
+            sourceCase_ = 0;
+            source_ = null;
+            onChanged();
+          }
+        } else {
+          if (sourceCase_ == 4) {
+            sourceCase_ = 0;
+            source_ = null;
+          }
+          sourceSegmentBuilder_.clear();
+        }
+        return this;
+      }
+      /**
+       * <code>.TopologySegment sourceSegment = 4;</code>
+       */
+      public org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologySegment.Builder getSourceSegmentBuilder() {
+        return getSourceSegmentFieldBuilder().getBuilder();
+      }
+      /**
+       * <code>.TopologySegment sourceSegment = 4;</code>
+       */
+      public org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologySegmentOrBuilder getSourceSegmentOrBuilder() {
+        if ((sourceCase_ == 4) && (sourceSegmentBuilder_ != null)) {
+          return sourceSegmentBuilder_.getMessageOrBuilder();
+        } else {
+          if (sourceCase_ == 4) {
+            return (org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologySegment) source_;
+          }
+          return org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologySegment.getDefaultInstance();
+        }
+      }
+      /**
+       * <code>.TopologySegment sourceSegment = 4;</code>
+       */
+      private com.google.protobuf.SingleFieldBuilderV3<
+          org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologySegment, org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologySegment.Builder, org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologySegmentOrBuilder> 
+          getSourceSegmentFieldBuilder() {
+        if (sourceSegmentBuilder_ == null) {
+          if (!(sourceCase_ == 4)) {
+            source_ = org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologySegment.getDefaultInstance();
+          }
+          sourceSegmentBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
+              org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologySegment, org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologySegment.Builder, org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologySegmentOrBuilder>(
+                  (org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologySegment) source_,
+                  getParentForChildren(),
+                  isClean());
+          source_ = null;
+        }
+        sourceCase_ = 4;
+        onChanged();;
+        return sourceSegmentBuilder_;
+      }
+
+      private com.google.protobuf.SingleFieldBuilderV3<
+          org.opennms.features.kafka.producer.model.OpennmsModelProtos.Node, org.opennms.features.kafka.producer.model.OpennmsModelProtos.Node.Builder, org.opennms.features.kafka.producer.model.OpennmsModelProtos.NodeOrBuilder> sourceNodeBuilder_;
+      /**
+       * <code>.Node sourceNode = 5;</code>
+       */
+      public boolean hasSourceNode() {
+        return sourceCase_ == 5;
+      }
+      /**
+       * <code>.Node sourceNode = 5;</code>
+       */
+      public org.opennms.features.kafka.producer.model.OpennmsModelProtos.Node getSourceNode() {
+        if (sourceNodeBuilder_ == null) {
+          if (sourceCase_ == 5) {
+            return (org.opennms.features.kafka.producer.model.OpennmsModelProtos.Node) source_;
+          }
+          return org.opennms.features.kafka.producer.model.OpennmsModelProtos.Node.getDefaultInstance();
+        } else {
+          if (sourceCase_ == 5) {
+            return sourceNodeBuilder_.getMessage();
+          }
+          return org.opennms.features.kafka.producer.model.OpennmsModelProtos.Node.getDefaultInstance();
+        }
+      }
+      /**
+       * <code>.Node sourceNode = 5;</code>
+       */
+      public Builder setSourceNode(org.opennms.features.kafka.producer.model.OpennmsModelProtos.Node value) {
+        if (sourceNodeBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          source_ = value;
+          onChanged();
+        } else {
+          sourceNodeBuilder_.setMessage(value);
+        }
+        sourceCase_ = 5;
+        return this;
+      }
+      /**
+       * <code>.Node sourceNode = 5;</code>
+       */
+      public Builder setSourceNode(
+          org.opennms.features.kafka.producer.model.OpennmsModelProtos.Node.Builder builderForValue) {
+        if (sourceNodeBuilder_ == null) {
+          source_ = builderForValue.build();
+          onChanged();
+        } else {
+          sourceNodeBuilder_.setMessage(builderForValue.build());
+        }
+        sourceCase_ = 5;
+        return this;
+      }
+      /**
+       * <code>.Node sourceNode = 5;</code>
+       */
+      public Builder mergeSourceNode(org.opennms.features.kafka.producer.model.OpennmsModelProtos.Node value) {
+        if (sourceNodeBuilder_ == null) {
+          if (sourceCase_ == 5 &&
+              source_ != org.opennms.features.kafka.producer.model.OpennmsModelProtos.Node.getDefaultInstance()) {
+            source_ = org.opennms.features.kafka.producer.model.OpennmsModelProtos.Node.newBuilder((org.opennms.features.kafka.producer.model.OpennmsModelProtos.Node) source_)
+                .mergeFrom(value).buildPartial();
+          } else {
+            source_ = value;
+          }
+          onChanged();
+        } else {
+          if (sourceCase_ == 5) {
+            sourceNodeBuilder_.mergeFrom(value);
+          }
+          sourceNodeBuilder_.setMessage(value);
+        }
+        sourceCase_ = 5;
+        return this;
+      }
+      /**
+       * <code>.Node sourceNode = 5;</code>
+       */
+      public Builder clearSourceNode() {
+        if (sourceNodeBuilder_ == null) {
+          if (sourceCase_ == 5) {
+            sourceCase_ = 0;
+            source_ = null;
+            onChanged();
+          }
+        } else {
+          if (sourceCase_ == 5) {
+            sourceCase_ = 0;
+            source_ = null;
+          }
+          sourceNodeBuilder_.clear();
+        }
+        return this;
+      }
+      /**
+       * <code>.Node sourceNode = 5;</code>
+       */
+      public org.opennms.features.kafka.producer.model.OpennmsModelProtos.Node.Builder getSourceNodeBuilder() {
+        return getSourceNodeFieldBuilder().getBuilder();
+      }
+      /**
+       * <code>.Node sourceNode = 5;</code>
+       */
+      public org.opennms.features.kafka.producer.model.OpennmsModelProtos.NodeOrBuilder getSourceNodeOrBuilder() {
+        if ((sourceCase_ == 5) && (sourceNodeBuilder_ != null)) {
+          return sourceNodeBuilder_.getMessageOrBuilder();
+        } else {
+          if (sourceCase_ == 5) {
+            return (org.opennms.features.kafka.producer.model.OpennmsModelProtos.Node) source_;
+          }
+          return org.opennms.features.kafka.producer.model.OpennmsModelProtos.Node.getDefaultInstance();
+        }
+      }
+      /**
+       * <code>.Node sourceNode = 5;</code>
+       */
+      private com.google.protobuf.SingleFieldBuilderV3<
+          org.opennms.features.kafka.producer.model.OpennmsModelProtos.Node, org.opennms.features.kafka.producer.model.OpennmsModelProtos.Node.Builder, org.opennms.features.kafka.producer.model.OpennmsModelProtos.NodeOrBuilder> 
+          getSourceNodeFieldBuilder() {
+        if (sourceNodeBuilder_ == null) {
+          if (!(sourceCase_ == 5)) {
+            source_ = org.opennms.features.kafka.producer.model.OpennmsModelProtos.Node.getDefaultInstance();
+          }
+          sourceNodeBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
+              org.opennms.features.kafka.producer.model.OpennmsModelProtos.Node, org.opennms.features.kafka.producer.model.OpennmsModelProtos.Node.Builder, org.opennms.features.kafka.producer.model.OpennmsModelProtos.NodeOrBuilder>(
+                  (org.opennms.features.kafka.producer.model.OpennmsModelProtos.Node) source_,
+                  getParentForChildren(),
+                  isClean());
+          source_ = null;
+        }
+        sourceCase_ = 5;
+        onChanged();;
+        return sourceNodeBuilder_;
       }
 
       private com.google.protobuf.SingleFieldBuilderV3<
           org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologyPort, org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologyPort.Builder, org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologyPortOrBuilder> targetPortBuilder_;
       /**
-       * <code>.TopologyPort targetPort = 3;</code>
+       * <code>.TopologyPort targetPort = 6;</code>
        */
       public boolean hasTargetPort() {
-        return targetCase_ == 3;
+        return targetCase_ == 6;
       }
       /**
-       * <code>.TopologyPort targetPort = 3;</code>
+       * <code>.TopologyPort targetPort = 6;</code>
        */
       public org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologyPort getTargetPort() {
         if (targetPortBuilder_ == null) {
-          if (targetCase_ == 3) {
+          if (targetCase_ == 6) {
             return (org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologyPort) target_;
           }
           return org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologyPort.getDefaultInstance();
         } else {
-          if (targetCase_ == 3) {
+          if (targetCase_ == 6) {
             return targetPortBuilder_.getMessage();
           }
           return org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologyPort.getDefaultInstance();
         }
       }
       /**
-       * <code>.TopologyPort targetPort = 3;</code>
+       * <code>.TopologyPort targetPort = 6;</code>
        */
       public Builder setTargetPort(org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologyPort value) {
         if (targetPortBuilder_ == null) {
@@ -19375,11 +19983,11 @@ public final class OpennmsModelProtos {
         } else {
           targetPortBuilder_.setMessage(value);
         }
-        targetCase_ = 3;
+        targetCase_ = 6;
         return this;
       }
       /**
-       * <code>.TopologyPort targetPort = 3;</code>
+       * <code>.TopologyPort targetPort = 6;</code>
        */
       public Builder setTargetPort(
           org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologyPort.Builder builderForValue) {
@@ -19389,15 +19997,15 @@ public final class OpennmsModelProtos {
         } else {
           targetPortBuilder_.setMessage(builderForValue.build());
         }
-        targetCase_ = 3;
+        targetCase_ = 6;
         return this;
       }
       /**
-       * <code>.TopologyPort targetPort = 3;</code>
+       * <code>.TopologyPort targetPort = 6;</code>
        */
       public Builder mergeTargetPort(org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologyPort value) {
         if (targetPortBuilder_ == null) {
-          if (targetCase_ == 3 &&
+          if (targetCase_ == 6 &&
               target_ != org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologyPort.getDefaultInstance()) {
             target_ = org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologyPort.newBuilder((org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologyPort) target_)
                 .mergeFrom(value).buildPartial();
@@ -19406,26 +20014,26 @@ public final class OpennmsModelProtos {
           }
           onChanged();
         } else {
-          if (targetCase_ == 3) {
+          if (targetCase_ == 6) {
             targetPortBuilder_.mergeFrom(value);
           }
           targetPortBuilder_.setMessage(value);
         }
-        targetCase_ = 3;
+        targetCase_ = 6;
         return this;
       }
       /**
-       * <code>.TopologyPort targetPort = 3;</code>
+       * <code>.TopologyPort targetPort = 6;</code>
        */
       public Builder clearTargetPort() {
         if (targetPortBuilder_ == null) {
-          if (targetCase_ == 3) {
+          if (targetCase_ == 6) {
             targetCase_ = 0;
             target_ = null;
             onChanged();
           }
         } else {
-          if (targetCase_ == 3) {
+          if (targetCase_ == 6) {
             targetCase_ = 0;
             target_ = null;
           }
@@ -19434,32 +20042,32 @@ public final class OpennmsModelProtos {
         return this;
       }
       /**
-       * <code>.TopologyPort targetPort = 3;</code>
+       * <code>.TopologyPort targetPort = 6;</code>
        */
       public org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologyPort.Builder getTargetPortBuilder() {
         return getTargetPortFieldBuilder().getBuilder();
       }
       /**
-       * <code>.TopologyPort targetPort = 3;</code>
+       * <code>.TopologyPort targetPort = 6;</code>
        */
       public org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologyPortOrBuilder getTargetPortOrBuilder() {
-        if ((targetCase_ == 3) && (targetPortBuilder_ != null)) {
+        if ((targetCase_ == 6) && (targetPortBuilder_ != null)) {
           return targetPortBuilder_.getMessageOrBuilder();
         } else {
-          if (targetCase_ == 3) {
+          if (targetCase_ == 6) {
             return (org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologyPort) target_;
           }
           return org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologyPort.getDefaultInstance();
         }
       }
       /**
-       * <code>.TopologyPort targetPort = 3;</code>
+       * <code>.TopologyPort targetPort = 6;</code>
        */
       private com.google.protobuf.SingleFieldBuilderV3<
           org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologyPort, org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologyPort.Builder, org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologyPortOrBuilder> 
           getTargetPortFieldBuilder() {
         if (targetPortBuilder_ == null) {
-          if (!(targetCase_ == 3)) {
+          if (!(targetCase_ == 6)) {
             target_ = org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologyPort.getDefaultInstance();
           }
           targetPortBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
@@ -19469,7 +20077,7 @@ public final class OpennmsModelProtos {
                   isClean());
           target_ = null;
         }
-        targetCase_ = 3;
+        targetCase_ = 6;
         onChanged();;
         return targetPortBuilder_;
       }
@@ -19477,29 +20085,29 @@ public final class OpennmsModelProtos {
       private com.google.protobuf.SingleFieldBuilderV3<
           org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologySegment, org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologySegment.Builder, org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologySegmentOrBuilder> targetSegmentBuilder_;
       /**
-       * <code>.TopologySegment targetSegment = 4;</code>
+       * <code>.TopologySegment targetSegment = 7;</code>
        */
       public boolean hasTargetSegment() {
-        return targetCase_ == 4;
+        return targetCase_ == 7;
       }
       /**
-       * <code>.TopologySegment targetSegment = 4;</code>
+       * <code>.TopologySegment targetSegment = 7;</code>
        */
       public org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologySegment getTargetSegment() {
         if (targetSegmentBuilder_ == null) {
-          if (targetCase_ == 4) {
+          if (targetCase_ == 7) {
             return (org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologySegment) target_;
           }
           return org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologySegment.getDefaultInstance();
         } else {
-          if (targetCase_ == 4) {
+          if (targetCase_ == 7) {
             return targetSegmentBuilder_.getMessage();
           }
           return org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologySegment.getDefaultInstance();
         }
       }
       /**
-       * <code>.TopologySegment targetSegment = 4;</code>
+       * <code>.TopologySegment targetSegment = 7;</code>
        */
       public Builder setTargetSegment(org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologySegment value) {
         if (targetSegmentBuilder_ == null) {
@@ -19511,11 +20119,11 @@ public final class OpennmsModelProtos {
         } else {
           targetSegmentBuilder_.setMessage(value);
         }
-        targetCase_ = 4;
+        targetCase_ = 7;
         return this;
       }
       /**
-       * <code>.TopologySegment targetSegment = 4;</code>
+       * <code>.TopologySegment targetSegment = 7;</code>
        */
       public Builder setTargetSegment(
           org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologySegment.Builder builderForValue) {
@@ -19525,15 +20133,15 @@ public final class OpennmsModelProtos {
         } else {
           targetSegmentBuilder_.setMessage(builderForValue.build());
         }
-        targetCase_ = 4;
+        targetCase_ = 7;
         return this;
       }
       /**
-       * <code>.TopologySegment targetSegment = 4;</code>
+       * <code>.TopologySegment targetSegment = 7;</code>
        */
       public Builder mergeTargetSegment(org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologySegment value) {
         if (targetSegmentBuilder_ == null) {
-          if (targetCase_ == 4 &&
+          if (targetCase_ == 7 &&
               target_ != org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologySegment.getDefaultInstance()) {
             target_ = org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologySegment.newBuilder((org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologySegment) target_)
                 .mergeFrom(value).buildPartial();
@@ -19542,26 +20150,26 @@ public final class OpennmsModelProtos {
           }
           onChanged();
         } else {
-          if (targetCase_ == 4) {
+          if (targetCase_ == 7) {
             targetSegmentBuilder_.mergeFrom(value);
           }
           targetSegmentBuilder_.setMessage(value);
         }
-        targetCase_ = 4;
+        targetCase_ = 7;
         return this;
       }
       /**
-       * <code>.TopologySegment targetSegment = 4;</code>
+       * <code>.TopologySegment targetSegment = 7;</code>
        */
       public Builder clearTargetSegment() {
         if (targetSegmentBuilder_ == null) {
-          if (targetCase_ == 4) {
+          if (targetCase_ == 7) {
             targetCase_ = 0;
             target_ = null;
             onChanged();
           }
         } else {
-          if (targetCase_ == 4) {
+          if (targetCase_ == 7) {
             targetCase_ = 0;
             target_ = null;
           }
@@ -19570,32 +20178,32 @@ public final class OpennmsModelProtos {
         return this;
       }
       /**
-       * <code>.TopologySegment targetSegment = 4;</code>
+       * <code>.TopologySegment targetSegment = 7;</code>
        */
       public org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologySegment.Builder getTargetSegmentBuilder() {
         return getTargetSegmentFieldBuilder().getBuilder();
       }
       /**
-       * <code>.TopologySegment targetSegment = 4;</code>
+       * <code>.TopologySegment targetSegment = 7;</code>
        */
       public org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologySegmentOrBuilder getTargetSegmentOrBuilder() {
-        if ((targetCase_ == 4) && (targetSegmentBuilder_ != null)) {
+        if ((targetCase_ == 7) && (targetSegmentBuilder_ != null)) {
           return targetSegmentBuilder_.getMessageOrBuilder();
         } else {
-          if (targetCase_ == 4) {
+          if (targetCase_ == 7) {
             return (org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologySegment) target_;
           }
           return org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologySegment.getDefaultInstance();
         }
       }
       /**
-       * <code>.TopologySegment targetSegment = 4;</code>
+       * <code>.TopologySegment targetSegment = 7;</code>
        */
       private com.google.protobuf.SingleFieldBuilderV3<
           org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologySegment, org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologySegment.Builder, org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologySegmentOrBuilder> 
           getTargetSegmentFieldBuilder() {
         if (targetSegmentBuilder_ == null) {
-          if (!(targetCase_ == 4)) {
+          if (!(targetCase_ == 7)) {
             target_ = org.opennms.features.kafka.producer.model.OpennmsModelProtos.TopologySegment.getDefaultInstance();
           }
           targetSegmentBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
@@ -19605,9 +20213,145 @@ public final class OpennmsModelProtos {
                   isClean());
           target_ = null;
         }
-        targetCase_ = 4;
+        targetCase_ = 7;
         onChanged();;
         return targetSegmentBuilder_;
+      }
+
+      private com.google.protobuf.SingleFieldBuilderV3<
+          org.opennms.features.kafka.producer.model.OpennmsModelProtos.Node, org.opennms.features.kafka.producer.model.OpennmsModelProtos.Node.Builder, org.opennms.features.kafka.producer.model.OpennmsModelProtos.NodeOrBuilder> targetNodeBuilder_;
+      /**
+       * <code>.Node targetNode = 8;</code>
+       */
+      public boolean hasTargetNode() {
+        return targetCase_ == 8;
+      }
+      /**
+       * <code>.Node targetNode = 8;</code>
+       */
+      public org.opennms.features.kafka.producer.model.OpennmsModelProtos.Node getTargetNode() {
+        if (targetNodeBuilder_ == null) {
+          if (targetCase_ == 8) {
+            return (org.opennms.features.kafka.producer.model.OpennmsModelProtos.Node) target_;
+          }
+          return org.opennms.features.kafka.producer.model.OpennmsModelProtos.Node.getDefaultInstance();
+        } else {
+          if (targetCase_ == 8) {
+            return targetNodeBuilder_.getMessage();
+          }
+          return org.opennms.features.kafka.producer.model.OpennmsModelProtos.Node.getDefaultInstance();
+        }
+      }
+      /**
+       * <code>.Node targetNode = 8;</code>
+       */
+      public Builder setTargetNode(org.opennms.features.kafka.producer.model.OpennmsModelProtos.Node value) {
+        if (targetNodeBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          target_ = value;
+          onChanged();
+        } else {
+          targetNodeBuilder_.setMessage(value);
+        }
+        targetCase_ = 8;
+        return this;
+      }
+      /**
+       * <code>.Node targetNode = 8;</code>
+       */
+      public Builder setTargetNode(
+          org.opennms.features.kafka.producer.model.OpennmsModelProtos.Node.Builder builderForValue) {
+        if (targetNodeBuilder_ == null) {
+          target_ = builderForValue.build();
+          onChanged();
+        } else {
+          targetNodeBuilder_.setMessage(builderForValue.build());
+        }
+        targetCase_ = 8;
+        return this;
+      }
+      /**
+       * <code>.Node targetNode = 8;</code>
+       */
+      public Builder mergeTargetNode(org.opennms.features.kafka.producer.model.OpennmsModelProtos.Node value) {
+        if (targetNodeBuilder_ == null) {
+          if (targetCase_ == 8 &&
+              target_ != org.opennms.features.kafka.producer.model.OpennmsModelProtos.Node.getDefaultInstance()) {
+            target_ = org.opennms.features.kafka.producer.model.OpennmsModelProtos.Node.newBuilder((org.opennms.features.kafka.producer.model.OpennmsModelProtos.Node) target_)
+                .mergeFrom(value).buildPartial();
+          } else {
+            target_ = value;
+          }
+          onChanged();
+        } else {
+          if (targetCase_ == 8) {
+            targetNodeBuilder_.mergeFrom(value);
+          }
+          targetNodeBuilder_.setMessage(value);
+        }
+        targetCase_ = 8;
+        return this;
+      }
+      /**
+       * <code>.Node targetNode = 8;</code>
+       */
+      public Builder clearTargetNode() {
+        if (targetNodeBuilder_ == null) {
+          if (targetCase_ == 8) {
+            targetCase_ = 0;
+            target_ = null;
+            onChanged();
+          }
+        } else {
+          if (targetCase_ == 8) {
+            targetCase_ = 0;
+            target_ = null;
+          }
+          targetNodeBuilder_.clear();
+        }
+        return this;
+      }
+      /**
+       * <code>.Node targetNode = 8;</code>
+       */
+      public org.opennms.features.kafka.producer.model.OpennmsModelProtos.Node.Builder getTargetNodeBuilder() {
+        return getTargetNodeFieldBuilder().getBuilder();
+      }
+      /**
+       * <code>.Node targetNode = 8;</code>
+       */
+      public org.opennms.features.kafka.producer.model.OpennmsModelProtos.NodeOrBuilder getTargetNodeOrBuilder() {
+        if ((targetCase_ == 8) && (targetNodeBuilder_ != null)) {
+          return targetNodeBuilder_.getMessageOrBuilder();
+        } else {
+          if (targetCase_ == 8) {
+            return (org.opennms.features.kafka.producer.model.OpennmsModelProtos.Node) target_;
+          }
+          return org.opennms.features.kafka.producer.model.OpennmsModelProtos.Node.getDefaultInstance();
+        }
+      }
+      /**
+       * <code>.Node targetNode = 8;</code>
+       */
+      private com.google.protobuf.SingleFieldBuilderV3<
+          org.opennms.features.kafka.producer.model.OpennmsModelProtos.Node, org.opennms.features.kafka.producer.model.OpennmsModelProtos.Node.Builder, org.opennms.features.kafka.producer.model.OpennmsModelProtos.NodeOrBuilder> 
+          getTargetNodeFieldBuilder() {
+        if (targetNodeBuilder_ == null) {
+          if (!(targetCase_ == 8)) {
+            target_ = org.opennms.features.kafka.producer.model.OpennmsModelProtos.Node.getDefaultInstance();
+          }
+          targetNodeBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
+              org.opennms.features.kafka.producer.model.OpennmsModelProtos.Node, org.opennms.features.kafka.producer.model.OpennmsModelProtos.Node.Builder, org.opennms.features.kafka.producer.model.OpennmsModelProtos.NodeOrBuilder>(
+                  (org.opennms.features.kafka.producer.model.OpennmsModelProtos.Node) target_,
+                  getParentForChildren(),
+                  isClean());
+          target_ = null;
+        }
+        targetCase_ = 8;
+        onChanged();;
+        return targetNodeBuilder_;
       }
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
@@ -19803,16 +20547,19 @@ public final class OpennmsModelProtos {
       "\022\031\n\003ref\030\001 \001(\0132\014.TopologyRef\"{\n\014TopologyP" +
       "ort\022\021\n\tvertex_id\030\001 \001(\t\022\020\n\010if_index\030\002 \001(\004" +
       "\022\017\n\007if_name\030\003 \001(\t\022\017\n\007address\030\004 \001(\t\022$\n\rno" +
-      "de_criteria\030\005 \001(\0132\r.NodeCriteria\"\242\001\n\014Top" +
-      "ologyEdge\022\031\n\003ref\030\001 \001(\0132\014.TopologyRef\022\035\n\006" +
-      "source\030\002 \001(\0132\r.TopologyPort\022#\n\ntargetPor" +
-      "t\030\003 \001(\0132\r.TopologyPortH\000\022)\n\rtargetSegmen" +
-      "t\030\004 \001(\0132\020.TopologySegmentH\000B\010\n\006target*g\n" +
-      "\010Severity\022\021\n\rINDETERMINATE\020\000\022\013\n\007CLEARED\020" +
-      "\001\022\n\n\006NORMAL\020\002\022\013\n\007WARNING\020\003\022\t\n\005MINOR\020\004\022\t\n" +
-      "\005MAJOR\020\005\022\014\n\010CRITICAL\020\006B?\n)org.opennms.fe" +
-      "atures.kafka.producer.modelB\022OpennmsMode" +
-      "lProtosb\006proto3"
+      "de_criteria\030\005 \001(\0132\r.NodeCriteria\"\227\002\n\014Top" +
+      "ologyEdge\022\031\n\003ref\030\001 \001(\0132\014.TopologyRef\022#\n\n" +
+      "sourcePort\030\003 \001(\0132\r.TopologyPortH\000\022)\n\rsou" +
+      "rceSegment\030\004 \001(\0132\020.TopologySegmentH\000\022\033\n\n" +
+      "sourceNode\030\005 \001(\0132\005.NodeH\000\022#\n\ntargetPort\030" +
+      "\006 \001(\0132\r.TopologyPortH\001\022)\n\rtargetSegment\030" +
+      "\007 \001(\0132\020.TopologySegmentH\001\022\033\n\ntargetNode\030" +
+      "\010 \001(\0132\005.NodeH\001B\010\n\006sourceB\010\n\006target*g\n\010Se" +
+      "verity\022\021\n\rINDETERMINATE\020\000\022\013\n\007CLEARED\020\001\022\n" +
+      "\n\006NORMAL\020\002\022\013\n\007WARNING\020\003\022\t\n\005MINOR\020\004\022\t\n\005MA" +
+      "JOR\020\005\022\014\n\010CRITICAL\020\006B?\n)org.opennms.featu" +
+      "res.kafka.producer.modelB\022OpennmsModelPr" +
+      "otosb\006proto3"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
@@ -19909,7 +20656,7 @@ public final class OpennmsModelProtos {
     internal_static_TopologyEdge_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_TopologyEdge_descriptor,
-        new java.lang.String[] { "Ref", "Source", "TargetPort", "TargetSegment", "Target", });
+        new java.lang.String[] { "Ref", "SourcePort", "SourceSegment", "SourceNode", "TargetPort", "TargetSegment", "TargetNode", "Source", "Target", });
   }
 
   // @@protoc_insertion_point(outer_class_scope)

--- a/features/kafka/producer/src/main/proto/opennms-kafka-producer.proto
+++ b/features/kafka/producer/src/main/proto/opennms-kafka-producer.proto
@@ -175,9 +175,14 @@ message TopologyPort {
 
 message TopologyEdge {
   TopologyRef ref = 1;
-  TopologyPort source = 2;
+  oneof source {
+    TopologyPort sourcePort = 3;
+    TopologySegment sourceSegment = 4;
+    Node sourceNode = 5;
+  }
   oneof target {
-    TopologyPort targetPort = 3;
-    TopologySegment targetSegment = 4;
+    TopologyPort targetPort = 6;
+    TopologySegment targetSegment = 7;
+    Node targetNode = 8;
   }
 }

--- a/features/kafka/producer/src/main/resources/OSGI-INF/blueprint/blueprint-kafka-producer.xml
+++ b/features/kafka/producer/src/main/resources/OSGI-INF/blueprint/blueprint-kafka-producer.xml
@@ -17,7 +17,7 @@
       <cm:property name="eventTopic" value="events"/>
       <cm:property name="alarmTopic" value="alarms"/>
       <cm:property name="nodeTopic" value="nodes"/>
-      <cm:property name="topologyProtocols" value="bridge,cdp,isis,lldp,ospf"/>
+      <cm:property name="topologyProtocols" value="bridge,cdp,isis,lldp,ospf,userdefined"/>
       <cm:property name="topologyVertexTopic" value="vertices"/>
       <cm:property name="topologyEdgeTopic" value="edges"/>
       <cm:property name="alarmFeedbackTopic" value="alarmFeedback"/>

--- a/features/kafka/producer/src/main/resources/OSGI-INF/blueprint/blueprint-kafka-producer.xml
+++ b/features/kafka/producer/src/main/resources/OSGI-INF/blueprint/blueprint-kafka-producer.xml
@@ -17,7 +17,6 @@
       <cm:property name="eventTopic" value="events"/>
       <cm:property name="alarmTopic" value="alarms"/>
       <cm:property name="nodeTopic" value="nodes"/>
-      <cm:property name="topologyProtocols" value="bridge,cdp,isis,lldp,ospf,userdefined"/>
       <cm:property name="topologyVertexTopic" value="vertices"/>
       <cm:property name="topologyEdgeTopic" value="edges"/>
       <cm:property name="alarmFeedbackTopic" value="alarmFeedback"/>
@@ -65,7 +64,6 @@
     <argument ref="eventSubscriptionService"/>
     <argument ref="onmsTopologyDao"/>
 
-    <property name="topologyProtocols" value="${topologyProtocols}"/>
     <property name="topologyVertexTopic" value="${topologyVertexTopic}"/>
     <property name="topologyEdgeTopic" value="${topologyEdgeTopic}"/>
     <property name="eventTopic" value="${eventTopic}"/>

--- a/features/topologies/service/api/pom.xml
+++ b/features/topologies/service/api/pom.xml
@@ -23,6 +23,17 @@
           </instructions>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>test-jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
   <dependencies>
@@ -43,6 +54,11 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-all</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/features/topologies/service/api/src/main/java/org/opennms/netmgt/topologies/service/api/OnmsTopologyDao.java
+++ b/features/topologies/service/api/src/main/java/org/opennms/netmgt/topologies/service/api/OnmsTopologyDao.java
@@ -28,11 +28,14 @@
 
 package org.opennms.netmgt.topologies.service.api;
 
+import java.util.Map;
 import java.util.Set;
 
 public interface OnmsTopologyDao {
 
     OnmsTopology getTopology(String protocol);
+
+    Map<OnmsTopologyProtocol, OnmsTopology> getTopologies();
 
     Set<String> getSupportedProtocols();
 

--- a/features/topologies/service/api/src/main/java/org/opennms/netmgt/topologies/service/api/OnmsTopologyDao.java
+++ b/features/topologies/service/api/src/main/java/org/opennms/netmgt/topologies/service/api/OnmsTopologyDao.java
@@ -37,7 +37,7 @@ public interface OnmsTopologyDao {
 
     Map<OnmsTopologyProtocol, OnmsTopology> getTopologies();
 
-    Set<String> getSupportedProtocols();
+    Set<OnmsTopologyProtocol> getSupportedProtocols();
 
     void register(OnmsTopologyUpdater updater);
     void unregister(OnmsTopologyUpdater updater);

--- a/features/topologies/service/api/src/main/java/org/opennms/netmgt/topologies/service/api/OnmsTopologyProtocol.java
+++ b/features/topologies/service/api/src/main/java/org/opennms/netmgt/topologies/service/api/OnmsTopologyProtocol.java
@@ -32,9 +32,15 @@ import java.util.Objects;
 
 public class OnmsTopologyProtocol {
 
+    private static final OnmsTopologyProtocol ALL_PROTOCOLS = create("ALL");
+
     public static OnmsTopologyProtocol create(String id) {
         Objects.requireNonNull(id, "id is null, cannot create protocol");
         return new OnmsTopologyProtocol(id.toUpperCase());
+    }
+    
+    public static OnmsTopologyProtocol allProtocols() {
+        return ALL_PROTOCOLS;
     }
     
     final private String m_id;

--- a/features/topologies/service/api/src/test/java/org/opennms/topologies/service/api/EdgeMockUtil.java
+++ b/features/topologies/service/api/src/test/java/org/opennms/topologies/service/api/EdgeMockUtil.java
@@ -1,0 +1,120 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.topologies.service.api;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.opennms.netmgt.topologies.service.api.OnmsTopologyEdge;
+import org.opennms.netmgt.topologies.service.api.OnmsTopologyPort;
+import org.opennms.netmgt.topologies.service.api.OnmsTopologyVertex;
+
+public class EdgeMockUtil {
+    public static final String PROTOCOL = "CDP";
+    public static final String EDGE_ID = "edge.id";
+    public static final String EDGE_TOOLTIP = "edge.tooltip";
+    public static final String SOURCE_TOOLTIP = "edge.source.tooltip";
+    public static final String TARGET_TOOLTIP = "edge.target.tooltip";
+    public static final String SOURCE_ID = "source.id";
+    public static final String TARGET_ID = "target.id";
+    public static final int SOURCE_NODE_ID = 1;
+    public static final int TARGET_NODE_ID = 2;
+    public static final int SOURCE_IFINDEX = 101;
+    public static final int TARGET_IFINDEX = 102;
+    public static final String SOURCE_VERTEX_ID = "source.vertex.id";
+    public static final String TARGET_VERTEX_ID = "target.vertex.id";
+
+    public static OnmsTopologyEdge createEdge() {
+        OnmsTopologyEdge edgeMock = mock(OnmsTopologyEdge.class);
+        when(edgeMock.getId()).thenReturn(EDGE_ID);
+        when(edgeMock.getToolTipText()).thenReturn(EDGE_TOOLTIP);
+        return edgeMock;
+    }
+
+    public static void addPort(boolean isSource, OnmsTopologyEdge edge) {
+        OnmsTopologyPort portMock = mock(OnmsTopologyPort.class);
+
+        OnmsTopologyVertex vertexPortMock = mock(OnmsTopologyVertex.class);
+        when(portMock.getVertex()).thenReturn(vertexPortMock);
+
+        if (isSource) {
+            when(edge.getSource()).thenReturn(portMock);
+            when(portMock.getIfindex()).thenReturn(SOURCE_IFINDEX);
+            when(portMock.getId()).thenReturn(SOURCE_ID);
+            when(vertexPortMock.getNodeid()).thenReturn(SOURCE_NODE_ID);
+            when(portMock.getToolTipText()).thenReturn(SOURCE_TOOLTIP);
+            when(vertexPortMock.getId()).thenReturn(SOURCE_VERTEX_ID);
+        } else {
+            when(edge.getTarget()).thenReturn(portMock);
+            when(portMock.getId()).thenReturn(TARGET_ID);
+            when(vertexPortMock.getNodeid()).thenReturn(TARGET_NODE_ID);
+            when(portMock.getIfindex()).thenReturn(TARGET_IFINDEX);
+            when(portMock.getToolTipText()).thenReturn(TARGET_TOOLTIP);
+            when(vertexPortMock.getId()).thenReturn(TARGET_VERTEX_ID);
+        }
+    }
+
+    public static void addSegment(boolean isSource, OnmsTopologyEdge edge) {
+        OnmsTopologyPort segmentMock = mock(OnmsTopologyPort.class);
+
+        OnmsTopologyVertex vertexSegmentMock = mock(OnmsTopologyVertex.class);
+        when(segmentMock.getVertex()).thenReturn(vertexSegmentMock);
+
+        if (isSource) {
+            when(edge.getSource()).thenReturn(segmentMock);
+            when(edge.getSource().getVertex().getNodeid()).thenReturn(null);
+            when(segmentMock.getId()).thenReturn(SOURCE_ID);
+            when(segmentMock.getToolTipText()).thenReturn(SOURCE_TOOLTIP);
+        } else {
+            when(edge.getTarget()).thenReturn(segmentMock);
+            when(edge.getTarget().getVertex().getNodeid()).thenReturn(null);
+            when(segmentMock.getId()).thenReturn(TARGET_ID);
+            when(segmentMock.getToolTipText()).thenReturn(TARGET_TOOLTIP);
+        }
+    }
+
+    public static void addNode(boolean isSource, OnmsTopologyEdge edge) {
+        OnmsTopologyPort nodeMock = mock(OnmsTopologyPort.class);
+
+        OnmsTopologyVertex vertexNodeMock = mock(OnmsTopologyVertex.class);
+        when(nodeMock.getVertex()).thenReturn(vertexNodeMock);
+
+        if (isSource) {
+            when(edge.getSource()).thenReturn(nodeMock);
+            when(edge.getSource().getIfindex()).thenReturn(null);
+            when(nodeMock.getId()).thenReturn(SOURCE_ID);
+            when(vertexNodeMock.getNodeid()).thenReturn(SOURCE_NODE_ID);
+        } else {
+            when(edge.getTarget()).thenReturn(nodeMock);
+            when(edge.getTarget().getIfindex()).thenReturn(null);
+            when(nodeMock.getId()).thenReturn(TARGET_ID);
+            when(vertexNodeMock.getNodeid()).thenReturn(TARGET_NODE_ID);
+        }
+    }
+}

--- a/features/topologies/service/impl/src/main/java/org/opennms/netmgt/topologies/service/impl/OnmsTopologyDaoInMemoryImpl.java
+++ b/features/topologies/service/impl/src/main/java/org/opennms/netmgt/topologies/service/impl/OnmsTopologyDaoInMemoryImpl.java
@@ -39,12 +39,14 @@ import org.opennms.netmgt.topologies.service.api.OnmsTopologyDao;
 import org.opennms.netmgt.topologies.service.api.OnmsTopologyMessage;
 import org.opennms.netmgt.topologies.service.api.OnmsTopologyProtocol;
 import org.opennms.netmgt.topologies.service.api.OnmsTopologyUpdater;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class OnmsTopologyDaoInMemoryImpl implements OnmsTopologyDao {
 
-    private final Map<OnmsTopologyProtocol, OnmsTopologyUpdater> m_updatersMap = new HashMap<OnmsTopologyProtocol,
-            OnmsTopologyUpdater>();
-    final Set<OnmsTopologyConsumer> m_consumers = new HashSet<OnmsTopologyConsumer>();
+    private static final Logger LOG = LoggerFactory.getLogger(OnmsTopologyDaoInMemoryImpl.class);
+    private final Map<OnmsTopologyProtocol, OnmsTopologyUpdater> m_updatersMap = new HashMap<>();
+    private final Set<OnmsTopologyConsumer> m_consumers = new HashSet<>();
 
     @Override
     public OnmsTopology getTopology(String protocolSupported) {
@@ -56,8 +58,18 @@ public class OnmsTopologyDaoInMemoryImpl implements OnmsTopologyDao {
     }
 
     @Override
+    public Map<OnmsTopologyProtocol, OnmsTopology> getTopologies() {
+        Map<OnmsTopologyProtocol, OnmsTopology> topologies = new HashMap<>();
+        synchronized (m_updatersMap) {
+            m_updatersMap.forEach((key, value) -> topologies.put(key, value.getTopology()));
+        }
+        return topologies;
+    }
+
+    @Override
     public void subscribe(OnmsTopologyConsumer consumer) {
         synchronized (m_consumers) {
+            LOG.debug("Consumer subscribed {}", consumer);
             m_consumers.add(consumer);
         }
     }
@@ -65,6 +77,21 @@ public class OnmsTopologyDaoInMemoryImpl implements OnmsTopologyDao {
     @Override
     public void unsubscribe(OnmsTopologyConsumer consumer) {
         synchronized (m_consumers) {
+            LOG.debug("Consumer unsubscribed {}", consumer);
+            m_consumers.remove(consumer);
+        }
+    }
+
+    public void onBind(OnmsTopologyConsumer consumer, Map<String, String> properties) {
+        synchronized (m_consumers) {
+            LOG.debug("Consumer {} bind with properties {}", consumer, properties);
+            m_consumers.add(consumer);
+        }
+    }
+
+    public void onUnbind(OnmsTopologyConsumer consumer, Map<String, String> properties) {
+        synchronized (m_consumers) {
+            LOG.debug("Consumer {} unbind with properties {}", consumer, properties);
             m_consumers.remove(consumer);
         }
     }

--- a/features/topologies/service/impl/src/main/java/org/opennms/netmgt/topologies/service/impl/OnmsTopologyDaoInMemoryImpl.java
+++ b/features/topologies/service/impl/src/main/java/org/opennms/netmgt/topologies/service/impl/OnmsTopologyDaoInMemoryImpl.java
@@ -119,12 +119,8 @@ public class OnmsTopologyDaoInMemoryImpl implements OnmsTopologyDao {
     }
 
     @Override
-    public Set<String> getSupportedProtocols() {
-        final Set<String> protocols = new HashSet<String>();
-        synchronized (m_updatersMap) {
-            m_updatersMap.keySet().stream().forEach(p -> protocols.add(p.getId()));
-        }
-        return protocols;
+    public Set<OnmsTopologyProtocol> getSupportedProtocols() {
+        return m_updatersMap.keySet();
     }
 
     @Override
@@ -144,10 +140,11 @@ public class OnmsTopologyDaoInMemoryImpl implements OnmsTopologyDao {
             m_consumers
                     .stream()
                     .filter(consumer -> {
-                        if (consumer.getProtocols() == null) {
+                        if (consumer.getProtocols() == null || consumer.getProtocols().isEmpty()) {
                             return false;
                         }
-                        return consumer.getProtocols().contains(protocol);
+                        return consumer.getProtocols().contains(OnmsTopologyProtocol.allProtocols()) ||
+                                consumer.getProtocols().contains(protocol);
                     })
                     .forEach(consumer -> consumer.consume(message));
         }

--- a/features/topologies/service/impl/src/main/resources/META-INF/opennms/component-dao.xml
+++ b/features/topologies/service/impl/src/main/resources/META-INF/opennms/component-dao.xml
@@ -14,6 +14,9 @@
     <context:annotation-config />
 
     <bean id="onmsTopologyDao" class="org.opennms.netmgt.topologies.service.impl.OnmsTopologyDaoInMemoryImpl"/>
-    <onmsgi:service interface="org.opennms.netmgt.topologies.service.api.OnmsTopologyDao" ref="onmsTopologyDao" />   
-    
+    <onmsgi:service interface="org.opennms.netmgt.topologies.service.api.OnmsTopologyDao" ref="onmsTopologyDao" />
+    <onmsgi:list id="topologyConsumers" interface="org.opennms.netmgt.topologies.service.api.OnmsTopologyConsumer">
+        <onmsgi:listener ref="onmsTopologyDao" bind-method="onBind" unbind-method="onUnbind"/>
+    </onmsgi:list>
+
 </beans>

--- a/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.linkd/src/test/java/org/opennms/features/topology/plugins/topo/linkd/internal/LinkdEdgeStatusProviderTest.java
+++ b/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.linkd/src/test/java/org/opennms/features/topology/plugins/topo/linkd/internal/LinkdEdgeStatusProviderTest.java
@@ -46,7 +46,7 @@ import org.opennms.features.topology.api.topo.EdgeProvider;
 import org.opennms.features.topology.api.topo.EdgeRef;
 import org.opennms.features.topology.api.topo.Status;
 import org.opennms.netmgt.dao.api.AlarmDao;
-import org.opennms.netmgt.enlinkd.TopologyUpdater;
+import org.opennms.netmgt.enlinkd.common.TopologyUpdater;
 import org.opennms.netmgt.enlinkd.model.NodeTopologyEntity;
 import org.opennms.netmgt.enlinkd.service.api.ProtocolSupported;
 import org.opennms.netmgt.events.api.EventConstants;

--- a/opennms-doc/guide-admin/src/asciidoc/text/kafka-producer/kafka-producer.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/kafka-producer/kafka-producer.adoc
@@ -107,7 +107,6 @@ The _Kafka Producer_ exposes the following options to help fine tune its behavio
                                                    Set this to an empty string to disable forwarding alarm feedback.                                                   
 | `nodeTopic`             | `nodes`              | Name of the topic used for nodes.
                                                    Set this to an empty string to disable forwarding nodes.
-| `topologyProtocols`             | `bridge,cdp,isis,lldp,ospf`              | Comma separated list of topologies supported protocols.
                                                    Set this to an empty string to disable forwarding topologies.
 | `topologyVertexTopic`             | `vertices`              | Name of the topic used for topology vertices.
 | `topologyEdgeTopic`             | `edges`              | Name of the topic used for topology edges.
@@ -211,36 +210,12 @@ In the example above, we disable event forwarding by setting an empty topic name
 $ ssh -p 8101 admin@localhost
 ...
 admin@opennms()> config:edit org.opennms.features.kafka.producer
-admin@opennms()> config:property-set topologyProtocols ""
-admin@opennms()> config:update
-----
-
-In the example above, we disable topology forwarding.
-
-
-[source]
-----
-$ ssh -p 8101 admin@localhost
-...
-admin@opennms()> config:edit org.opennms.features.kafka.producer
-admin@opennms()> config:property-set topologyProtocols "cdp,ospf"
-admin@opennms()> config:update
-----
-
-In the example above, we limit topology forwarding to only cdp and ospf protocol.
-
-[source]
-----
-$ ssh -p 8101 admin@localhost
-...
-admin@opennms()> config:edit org.opennms.features.kafka.producer
-admin@opennms()> config:property-set topologyProtocols "bridge"
 admin@opennms()> config:property-set topologyVertexTopic "opennms-bridge-vertex"
 admin@opennms()> config:property-set topologyEdgeTopic "opennms-edge-vertex"
 admin@opennms()> config:update
 ----
 
-In the example above, we limit topology forwarding to only bridge protocol and set vertex and edge topic to be different to default.
+In the example above, we set the vertex and edge topics to be different to default.
 
 === Shell Commands
 


### PR DESCRIPTION
- Updated topology service to support binding edge consumers from the integration API as topology consumers
- Added mapping code to convert a topology message into an integration API edge type

Had to move some files such as TopologyUpdater in order to fix a bundle dependency issue. Also fixed a bug in the topology code where topology deletes were not getting sent to consumers when using the TopologyGenerator command `enlinkd:delete-topology`.

Tested manually using the topology generator shell command.

This depends on the integration API changes in https://github.com/OpenNMS/opennms-integration-api/pull/10

JIRA: http://issues.opennms.org/browse/OCE-55
