### PR TITLE
NMS-10426: Added checks for imports and foreign-sources configuration files

### DIFF
--- a/opennms-config-tester/src/main/java/org/opennms/netmgt/config/tester/ConfigTester.java
+++ b/opennms-config-tester/src/main/java/org/opennms/netmgt/config/tester/ConfigTester.java
@@ -36,6 +36,8 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
 import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
@@ -46,6 +48,7 @@ import org.apache.commons.cli.PosixParser;
 import org.opennms.core.db.DataSourceFactory;
 import org.opennms.core.spring.BeanUtils;
 import org.opennms.core.utils.ConfigFileConstants;
+import org.opennms.core.xml.JaxbUtils;
 import org.opennms.netmgt.config.tester.checks.ConfigCheckValidationException;
 import org.opennms.netmgt.config.tester.checks.PropertiesFileChecker;
 import org.opennms.netmgt.config.tester.checks.XMLFileChecker;
@@ -60,6 +63,7 @@ public class ConfigTester implements ApplicationContextAware {
 
 	private ApplicationContext m_context;
 	private Map<String, String> m_configs;
+	private final Pattern m_pattern = Pattern.compile("^directory:(.+)$");
 
 	public Map<String, String> getConfigs() {
 		return m_configs;
@@ -78,15 +82,46 @@ public class ConfigTester implements ApplicationContextAware {
 		m_context = context;
 	}
 
-	public void testConfig(String name, boolean ignoreUnknown) {
+	public void testConfig(final String name, final boolean ignoreUnknown) {
 		checkConfigNameValid(name, ignoreUnknown);
-		String beanName = m_configs.get(name);
-		if("directory".equalsIgnoreCase(beanName)){
+		final String beanName = m_configs.get(name);
+		final Matcher matcher = m_pattern.matcher(beanName);
+		if (matcher.matches()) {
+			final String xmlModelName = matcher.group(1);
+			checkDirectoryForXmlFiles(name, xmlModelName);
+		} else if("directory".equalsIgnoreCase(beanName)){
 			checkDirectoryForUnKnownFiles(name);
 		} else if ("unknown".equalsIgnoreCase(beanName)){
 			checkFileForSyntax(name);
 		} else {
 			m_context.getBean(beanName);
+		}
+	}
+
+	private void checkDirectoryForXmlFiles(final String name, final String xmlModelName) {
+		final Class clazz;
+		try {
+			clazz = Class.forName(xmlModelName);
+		} catch (ClassNotFoundException e) {
+			throw new RuntimeException(e);
+		}
+
+		final Path directory = Paths.get(ConfigFileConstants.getFilePathString(), name);
+
+		if (!Files.exists(directory)) {
+			return;
+		}
+
+		try (final DirectoryStream<Path> stream = Files.newDirectoryStream(directory, "*.xml")) {
+			for (final Path entry : stream) {
+				try {
+					JaxbUtils.unmarshal(clazz, entry.toFile(), true);
+				} catch (final Exception e) {
+					throw new ConfigCheckValidationException(e);
+				}
+			}
+		} catch (final IOException e) {
+			throw new ConfigCheckValidationException(e);
 		}
 	}
 

--- a/opennms-config-tester/src/main/java/org/opennms/netmgt/config/tester/checks/ConfigCheckValidationException.java
+++ b/opennms-config-tester/src/main/java/org/opennms/netmgt/config/tester/checks/ConfigCheckValidationException.java
@@ -36,4 +36,8 @@ public class ConfigCheckValidationException extends RuntimeException{
     public ConfigCheckValidationException(Exception e){
         super(e);
     }
+
+    public ConfigCheckValidationException(String message, Throwable cause) {
+        super(message, cause);
+    }
 }

--- a/opennms-config-tester/src/main/resources/META-INF/opennms/applicationContext-configTester.xml
+++ b/opennms-config-tester/src/main/resources/META-INF/opennms/applicationContext-configTester.xml
@@ -112,6 +112,8 @@
         <entry key="wsman-config.xml" value="wsManConfigDao"/>
         <entry key="wsman-datacollection-config.xml" value="wsManDataCollectionConfigDao"/>
         <entry key="opennms.properties.d" value="directory" />
+        <entry key="imports" value="directory:org.opennms.netmgt.provision.persist.requisition.Requisition" />
+        <entry key="foreign-sources" value="directory:org.opennms.netmgt.provision.persist.foreignsource.ForeignSource" />
       </map>
     </property>
   </bean>

--- a/opennms-config-tester/src/test/java/org/opennms/netmgt/config/tester/ConfigTesterTest.java
+++ b/opennms-config-tester/src/test/java/org/opennms/netmgt/config/tester/ConfigTesterTest.java
@@ -672,33 +672,28 @@ public class ConfigTesterTest {
         testConfigFile("opennms.properties.d");
     }
 
+    private void testXmlFile(final String directory, final String xml) throws IOException {
+        setUpOpennmsHomeInTmpDir();
+        final Path etcDir = java.nio.file.Files.createDirectories(Paths.get(this.opennmsHomeDir.getPath(), "etc/" + directory));
+        final File file = new File(etcDir.toFile(), "ABC.xml");
+        Files.write(xml, file, StandardCharsets.UTF_8);
+        testConfigFile(directory);
+    }
+
     @Test
     public void testValidImports() throws IOException {
-        setUpOpennmsHomeInTmpDir();
         final String validXml = "<model-import xmlns=\"http://xmlns.opennms.org/xsd/config/model-import\" date-stamp=\"2019-04-04T07:49:24.053+02:00\" foreign-source=\"ABC\" last-import=\"2019-04-04T07:49:30.777+02:00\"/>";
-
-        final Path etcDir = java.nio.file.Files.createDirectories(Paths.get(this.opennmsHomeDir.getPath(), "etc/imports"));
-        final File file = new File(etcDir.toFile(), "ABC.xml");
-        Files.write(validXml, file, StandardCharsets.UTF_8);
-
-        testConfigFile("imports");
+        testXmlFile("imports", validXml);
     }
 
     @Test(expected = ConfigCheckValidationException.class)
     public void testInvalidImports() throws IOException {
-        setUpOpennmsHomeInTmpDir();
-        final String validXml = "<model-import xmlns=\"http://xmlns.opennms.org/xsd/config/model-import\" date-stamp=\"2019-04-04T07:49:24.053+02:00\" foreign-source=\"ABC\" last-import=\"2019-04-04T07:49:30.777+02:00\"><foo></foo></model-import>";
-
-        final Path etcDir = java.nio.file.Files.createDirectories(Paths.get(this.opennmsHomeDir.getPath(), "etc/imports"));
-        final File file = new File(etcDir.toFile(), "ABC.xml");
-        Files.write(validXml, file, StandardCharsets.UTF_8);
-
-        testConfigFile("imports");
+        final String invalidXml = "<model-import xmlns=\"http://xmlns.opennms.org/xsd/config/model-import\" date-stamp=\"2019-04-04T07:49:24.053+02:00\" foreign-source=\"ABC\" last-import=\"2019-04-04T07:49:30.777+02:00\"><foo></foo></model-import>";
+        testXmlFile("imports", invalidXml);
     }
 
     @Test
     public void testValidForeignSources() throws IOException {
-        setUpOpennmsHomeInTmpDir();
         final String validXml = "<foreign-source xmlns=\"http://xmlns.opennms.org/xsd/config/foreign-source\" name=\"DHCP\" date-stamp=\"2019-01-24T13:57:44.250+01:00\">\n" +
                 "   <scan-interval>1d</scan-interval>\n" +
                 "   <detectors>\n" +
@@ -706,18 +701,12 @@ public class ConfigTesterTest {
                 "   </detectors>\n" +
                 "   <policies/>\n" +
                 "</foreign-source>";
-
-        final Path etcDir = java.nio.file.Files.createDirectories(Paths.get(this.opennmsHomeDir.getPath(), "etc/foreign-sources"));
-        final File file = new File(etcDir.toFile(), "ABC.xml");
-        Files.write(validXml, file, StandardCharsets.UTF_8);
-
-        testConfigFile("foreign-sources");
+        testXmlFile("foreign-sources", validXml);
     }
 
     @Test(expected = ConfigCheckValidationException.class)
     public void testInvalidForeignSources() throws IOException {
-        setUpOpennmsHomeInTmpDir();
-        final String validXml = "<foreign-source xmlns=\"http://xmlns.opennms.org/xsd/config/foreign-source\" name=\"DHCP\" date-stamp=\"2019-01-24T13:57:44.250+01:00\">\n" +
+        final String invalidXml = "<foreign-source xmlns=\"http://xmlns.opennms.org/xsd/config/foreign-source\" name=\"DHCP\" date-stamp=\"2019-01-24T13:57:44.250+01:00\">\n" +
                 "   <scan-interval>1d</scan-interval>\n" +
                 "   <detectors>\n" +
                 "      <detector name=\"ICMP\" class=\"org.opennms.netmgt.provision.detector.icmp.IcmpDetector\"/>\n" +
@@ -725,12 +714,7 @@ public class ConfigTesterTest {
                 "   <foo/>\n" +
                 "   <policies/>\n" +
                 "</foreign-source>";
-
-        final Path etcDir = java.nio.file.Files.createDirectories(Paths.get(this.opennmsHomeDir.getPath(), "etc/foreign-sources"));
-        final File file = new File(etcDir.toFile(), "ABC.xml");
-        Files.write(validXml, file, StandardCharsets.UTF_8);
-
-        testConfigFile("foreign-sources");
+        testXmlFile("foreign-sources", invalidXml);
     }
 
     @Test(expected = ConfigCheckValidationException.class)

--- a/opennms-config-tester/src/test/java/org/opennms/netmgt/config/tester/ConfigTesterTest.java
+++ b/opennms-config-tester/src/test/java/org/opennms/netmgt/config/tester/ConfigTesterTest.java
@@ -672,6 +672,67 @@ public class ConfigTesterTest {
         testConfigFile("opennms.properties.d");
     }
 
+    @Test
+    public void testValidImports() throws IOException {
+        setUpOpennmsHomeInTmpDir();
+        final String validXml = "<model-import xmlns=\"http://xmlns.opennms.org/xsd/config/model-import\" date-stamp=\"2019-04-04T07:49:24.053+02:00\" foreign-source=\"ABC\" last-import=\"2019-04-04T07:49:30.777+02:00\"/>";
+
+        final Path etcDir = java.nio.file.Files.createDirectories(Paths.get(this.opennmsHomeDir.getPath(), "etc/imports"));
+        final File file = new File(etcDir.toFile(), "ABC.xml");
+        Files.write(validXml, file, StandardCharsets.UTF_8);
+
+        testConfigFile("imports");
+    }
+
+    @Test(expected = ConfigCheckValidationException.class)
+    public void testInvalidImports() throws IOException {
+        setUpOpennmsHomeInTmpDir();
+        final String validXml = "<model-import xmlns=\"http://xmlns.opennms.org/xsd/config/model-import\" date-stamp=\"2019-04-04T07:49:24.053+02:00\" foreign-source=\"ABC\" last-import=\"2019-04-04T07:49:30.777+02:00\"><foo></foo></model-import>";
+
+        final Path etcDir = java.nio.file.Files.createDirectories(Paths.get(this.opennmsHomeDir.getPath(), "etc/imports"));
+        final File file = new File(etcDir.toFile(), "ABC.xml");
+        Files.write(validXml, file, StandardCharsets.UTF_8);
+
+        testConfigFile("imports");
+    }
+
+    @Test
+    public void testValidForeignSources() throws IOException {
+        setUpOpennmsHomeInTmpDir();
+        final String validXml = "<foreign-source xmlns=\"http://xmlns.opennms.org/xsd/config/foreign-source\" name=\"DHCP\" date-stamp=\"2019-01-24T13:57:44.250+01:00\">\n" +
+                "   <scan-interval>1d</scan-interval>\n" +
+                "   <detectors>\n" +
+                "      <detector name=\"ICMP\" class=\"org.opennms.netmgt.provision.detector.icmp.IcmpDetector\"/>\n" +
+                "   </detectors>\n" +
+                "   <policies/>\n" +
+                "</foreign-source>";
+
+        final Path etcDir = java.nio.file.Files.createDirectories(Paths.get(this.opennmsHomeDir.getPath(), "etc/foreign-sources"));
+        final File file = new File(etcDir.toFile(), "ABC.xml");
+        Files.write(validXml, file, StandardCharsets.UTF_8);
+
+        testConfigFile("foreign-sources");
+    }
+
+    @Test(expected = ConfigCheckValidationException.class)
+    public void testInvalidForeignSources() throws IOException {
+        setUpOpennmsHomeInTmpDir();
+        final String validXml = "<foreign-source xmlns=\"http://xmlns.opennms.org/xsd/config/foreign-source\" name=\"DHCP\" date-stamp=\"2019-01-24T13:57:44.250+01:00\">\n" +
+                "   <scan-interval>1d</scan-interval>\n" +
+                "   <detectors>\n" +
+                "      <detector name=\"ICMP\" class=\"org.opennms.netmgt.provision.detector.icmp.IcmpDetector\"/>\n" +
+                "   </detectors>\n" +
+                "   <foo/>\n" +
+                "   <policies/>\n" +
+                "</foreign-source>";
+
+        final Path etcDir = java.nio.file.Files.createDirectories(Paths.get(this.opennmsHomeDir.getPath(), "etc/foreign-sources"));
+        final File file = new File(etcDir.toFile(), "ABC.xml");
+        Files.write(validXml, file, StandardCharsets.UTF_8);
+
+        testConfigFile("foreign-sources");
+    }
+
     @Test(expected = ConfigCheckValidationException.class)
     public void testDetectionOfMalformedPropertiesFile() throws IOException {
 


### PR DESCRIPTION
This PR adds checking of imports and foreign-sources configuration to the config-tester.

* JIRA: https://issues.opennms.org/browse/NMS-10426