### PR TITLE
HZN-1511: Added meta-data to models of requisitioning UI.

### DIFF
--- a/core/web-assets/src/main/assets/js/apps/onms-requisitions/lib/scripts/controllers/Interface.js
+++ b/core/web-assets/src/main/assets/js/apps/onms-requisitions/lib/scripts/controllers/Interface.js
@@ -1,5 +1,7 @@
 require('../services/Requisitions');
 
+const RequisitionService = require('../model/RequisitionService');
+
 /**
 * @author Alejandro Galue <agalue@opennms.org>
 * @copyright 2014 The OpenNMS Group, Inc.
@@ -122,7 +124,7 @@ require('../services/Requisitions');
     * @methodOf InterfaceController
     */
     $scope.addService = function() {
-      $scope.requisitionInterface.services.push({ name: '' });
+      $scope.requisitionInterface.services.push(new RequisitionService({ 'service-name': '' }));
     };
 
     /**

--- a/core/web-assets/src/main/assets/js/apps/onms-requisitions/lib/scripts/model/RequisitionInterface.js
+++ b/core/web-assets/src/main/assets/js/apps/onms-requisitions/lib/scripts/model/RequisitionInterface.js
@@ -3,6 +3,9 @@
 * @copyright 2014 The OpenNMS Group, Inc.
 */
 
+const RequisitionService = require('./RequisitionService');
+const RequisitionMetaData = require('./RequisitionMetaData');
+
 /**
 * @ngdoc object
 * @name RequisitionInterface
@@ -65,25 +68,21 @@ const RequisitionInterface = function RequisitionInterface(intf) {
   self.services = [];
 
   angular.forEach(intf['monitored-service'], function(svc) {
-    self.services.push({ name: svc['service-name'] });
+    self.services.push(new RequisitionService(svc));
   });
 
   /**
-  * @description Adds a new monitored service to the interface
-  *
-  * @name RequisitionInterface:addNewService
-  * @ngdoc method
-  * @methodOf RequisitionInterface
-  * @returns {object} the new service Object
-  */
-  self.addNewService = function() {
-    self.services.push({ name: '' });
-    return self.services.length - 1;
-  };
+   * @description The meta-data entries
+   * @ngdoc property
+   * @name RequisitionInterface#metaData
+   * @propertyOf RequisitionInterface
+   * @returns {object} The meta-data entries
+   */
+  self.metaData = new RequisitionMetaData(intf['meta-data']);
 
   self.className = 'RequisitionInterface';
 
   return self;
-}
+};
 
 module.exports = RequisitionInterface;

--- a/core/web-assets/src/main/assets/js/apps/onms-requisitions/lib/scripts/model/RequisitionMetaData.js
+++ b/core/web-assets/src/main/assets/js/apps/onms-requisitions/lib/scripts/model/RequisitionMetaData.js
@@ -1,0 +1,90 @@
+/**
+* @author Dustin Frisch <dustin@opennms.org>
+* @copyright 2019 The OpenNMS Group, Inc.
+*/
+
+/**
+* @ngdoc object
+* @name RequisitionMetaData
+* @module onms-requisitions
+* @param {Object} metaData an OpenNMS meta-data JSON list
+* @constructor
+*/
+const RequisitionMetaData = function RequisitionMetaData(metaData) {
+  'use strict';
+
+  const self = this;
+
+  /**
+   * @description The array of requisition meta-data entries
+   * @ngdoc property
+   * @name RequisitionMetaData#requisition
+   * @propertyOf RequisitionMetaData
+   * @returns {object} The requisition meta-data entries
+   */
+  self.requisition = [];
+
+  /**
+   * @description The array of other meta-data entries
+   * @ngdoc property
+   * @name RequisitionMetaData#other
+   * @propertyOf RequisitionMetaData
+   * @returns {object} The other meta-data entries
+   */
+  self.other = {};
+
+  angular.forEach(metaData, function(entry) {
+    if (entry.context === 'requisition') {
+      self.requisition.push({
+        'key': entry.key,
+        'value': entry.value
+      });
+    } else {
+      if (!self.other.hasOwnProperty(entry.context)) {
+        self.other[entry.context] = []
+      }
+      self.other[entry.context].push({
+        'key': entry.key,
+        'value': entry.value
+      });
+    }
+  });
+
+  /**
+  * @description Gets the OpenNMS representation of the requisitioned meta-data
+  *
+  * @name RequisitionNode:getOnmsMetaData
+  * @ngdoc method
+  * @methodOf RequisitionMetaData
+  * @returns {object} the meta-data Object
+  */
+  self.getOnmsMetaData = function() {
+    var metaDataObject = [];
+
+    angular.forEach(self.requisition, function(entry) {
+      metaDataObject.push({
+          'context': 'requisition',
+          'key': entry.key,
+          'value': entry.value
+      });
+    });
+
+    angular.forEach(self.other, function(entries, context) {
+      angular.forEach(entries, function(entry) {
+        metaDataObject.push({
+            'context': context,
+            'key': entry.key,
+            'value': entry.value
+        });
+      });
+    });
+
+    return metaDataObject;
+  };
+
+  self.className = 'RequisitionMetaData';
+
+  return self;
+};
+
+module.exports = RequisitionMetaData;

--- a/core/web-assets/src/main/assets/js/apps/onms-requisitions/lib/scripts/model/RequisitionNode.js
+++ b/core/web-assets/src/main/assets/js/apps/onms-requisitions/lib/scripts/model/RequisitionNode.js
@@ -4,6 +4,7 @@
 */
 
 const RequisitionInterface = require('./RequisitionInterface');
+const RequisitionMetaData = require('./RequisitionMetaData');
 
 // Internal function for initialization purposes
 const isEmpty = function(str) {
@@ -156,8 +157,17 @@ const RequisitionNode = function RequisitionNode(foreignSource, node, isDeployed
    */
   self.assets = [];
 
+  /**
+   * @description The meta-data entries
+   * @ngdoc property
+   * @name RequisitionNode#metaData
+   * @propertyOf RequisitionNode
+   * @returns {object} The meta-data entries
+   */
+  self.metaData = new RequisitionMetaData(node['meta-data']);
+
   angular.forEach(node['interface'], function(intf) {
-    self.interfaces.push(new RequisitionInterface(intf));
+      self.interfaces.push(new RequisitionInterface(intf));
   });
 
   angular.forEach(node['asset'], function(asset) {
@@ -218,6 +228,23 @@ const RequisitionNode = function RequisitionNode(foreignSource, node, isDeployed
       value: ''
     });
     return self.assets.length -1;
+  };
+
+  /**
+   * @description Adds a new meta-data entry to the node
+   *
+   * @name RequisitionNode:addNewMetaData
+   * @ngdoc method
+   * @methodOf RequisitionNode
+   * @returns {object} the new meta-data Object
+   */
+  self.addNewMetaData = function() {
+    let entry = {
+        key: '',
+        value: ''
+    };
+    self.requisitionMetaData.push(entry);
+    return entry;
   };
 
   /**
@@ -294,6 +321,7 @@ const RequisitionNode = function RequisitionNode(foreignSource, node, isDeployed
       'parent-foreign-id': self.parentForeignId,
       'parent-node-label': self.parentNodeLabel,
       'asset': [],
+      'meta-data': self.metaData.getOnmsMetaData(),
       'category': []
     };
 
@@ -303,12 +331,17 @@ const RequisitionNode = function RequisitionNode(foreignSource, node, isDeployed
         'descr': intf.description,
         'snmp-primary': intf.snmpPrimary,
         'status': (intf.status || intf.status === 'managed') ? '1' : '3',
+        'meta-data': intf.metaData.getOnmsMetaData(),
         'monitored-service': []
       };
+
       angular.forEach(intf.services, function(service) {
-        interfaceObject['monitored-service'].push({
-          'service-name': service.name
-        });
+        var serviceObject = {
+          'service-name': service.name,
+          'meta-data': service.metaData.getOnmsMetaData()
+        };
+
+        interfaceObject['monitored-service'].push(serviceObject);
       });
 
       nodeObject['interface'].push(interfaceObject);

--- a/core/web-assets/src/main/assets/js/apps/onms-requisitions/lib/scripts/model/RequisitionService.js
+++ b/core/web-assets/src/main/assets/js/apps/onms-requisitions/lib/scripts/model/RequisitionService.js
@@ -1,0 +1,43 @@
+/**
+* @author Alejandro Galue <agalue@opennms.org>
+* @copyright 2014 The OpenNMS Group, Inc.
+*/
+
+const RequisitionMetaData = require('./RequisitionMetaData');
+
+/**
+* @ngdoc object
+* @name RequisitionService
+* @module onms-requisitions
+* @param {Object} svc an OpenNMS service JSON object
+* @constructor
+*/
+const RequisitionService = function RequisitionService(svc) {
+  'use strict';
+
+  const self = this;
+
+  /**
+   * @description The name of the service
+   * @ngdoc property
+   * @name RequisitionService#name
+   * @propertyOf RequisitionService
+   * @returns {string} The name of the service
+   */
+  self.name = svc['service-name'];
+
+  /**
+   * @description The meta-data entries
+   * @ngdoc property
+   * @name RequisitionNode#metaData
+   * @propertyOf RequisitionNode
+   * @returns {object} The meta-data entries
+   */
+  self.metaData = new RequisitionMetaData(svc['meta-data']);
+
+  self.className = 'RequisitionService';
+
+  return self;
+};
+
+module.exports = RequisitionService;

--- a/core/web-assets/src/main/assets/js/apps/onms-requisitions/requisitions-core/index.js
+++ b/core/web-assets/src/main/assets/js/apps/onms-requisitions/requisitions-core/index.js
@@ -18,6 +18,7 @@ require('../lib/scripts/model/QuickNode.js');
 require('../lib/scripts/model/Requisition.js');
 require('../lib/scripts/model/RequisitionInterface.js');
 require('../lib/scripts/model/RequisitionNode.js');
+require('../lib/scripts/model/RequisitionService.js');
 require('../lib/scripts/model/RequisitionsData.js');
 require('../lib/scripts/services/Requisitions.js');
 require('../lib/scripts/services/Synchronize.js');

--- a/core/web-assets/src/test/javascript/ng-requisitions/model/RequisitionNode.test.js
+++ b/core/web-assets/src/test/javascript/ng-requisitions/model/RequisitionNode.test.js
@@ -23,10 +23,19 @@ var onmsNode = {
     'descr': 'eth0',
     'snmp-primary': 'P',
     'status': '1',
+    'meta-data': [
+      {'context': 'requisition', 'key': 'foo', 'value': 'bar'},
+      {'context': 'external1', 'key': 'kickit', 'value': 'lickit'},
+    ],
     'monitored-service': [{
-      'service-name': 'ICMP'
+      'service-name': 'ICMP',
+      'meta-data': [
+        {'context': 'requisition', 'key': 'foo', 'value': 'bar'},
+        {'context': 'external1', 'key': 'kickit', 'value': 'lickit'},
+      ],
     },{
-      'service-name': 'SNMP'
+      'service-name': 'SNMP',
+      'meta-data': [],
     }]
   }],
   'asset': [{
@@ -38,7 +47,15 @@ var onmsNode = {
   }],
   'category': [{
     'name': 'Servers'
-  }]
+  }],
+  'meta-data': [
+    {'context': 'requisition', 'key': 'foo', 'value': 'bar'},
+    {'context': 'requisition', 'key': 'bar', 'value': 'foo'},
+    {'context': 'external1', 'key': 'kickit', 'value': 'mumumu'},
+    {'context': 'external1', 'key': 'lickit', 'value': 'mimimi'},
+    {'context': 'external2', 'key': 'first', 'value': 'momomo'},
+    {'context': 'external2', 'key': 'second', 'value': 'mamama'},
+  ]
 };
 
 test('Model: RequisitionsNode: verify object translation', function () {
@@ -52,10 +69,32 @@ test('Model: RequisitionsNode: verify object translation', function () {
   expect(reqNode.categories[0].name).toBe('Servers');
   expect(reqNode.interfaces.length).toBe(1);
   expect(reqNode.interfaces[0].ipAddress).toBe('10.0.0.1');
+  expect(reqNode.interfaces[0].metaData.requisition[0].key).toBe('foo');
+  expect(reqNode.interfaces[0].metaData.requisition[0].value).toBe('bar');
+  expect(reqNode.interfaces[0].metaData.other['external1'][0].key).toBe('kickit');
+  expect(reqNode.interfaces[0].metaData.other['external1'][0].value).toBe('lickit');
   expect(reqNode.interfaces[0].services.length).toBe(2);
   expect(reqNode.interfaces[0].services[0].name).toBe('ICMP');
+  expect(reqNode.interfaces[0].services[0].metaData.requisition[0].key).toBe('foo');
+  expect(reqNode.interfaces[0].services[0].metaData.requisition[0].value).toBe('bar');
+  expect(reqNode.interfaces[0].services[0].metaData.other['external1'][0].key).toBe('kickit');
+  expect(reqNode.interfaces[0].services[0].metaData.other['external1'][0].value).toBe('lickit');
   expect(reqNode.assets[1].value).toBe('Pittsboro');
+  expect(reqNode.metaData.requisition[0].key).toBe('foo');
+  expect(reqNode.metaData.requisition[0].value).toBe('bar');
+  expect(reqNode.metaData.requisition[1].key).toBe('bar');
+  expect(reqNode.metaData.requisition[1].value).toBe('foo');
+  expect(reqNode.metaData.other['external1'][0].key).toBe('kickit');
+  expect(reqNode.metaData.other['external1'][0].value).toBe('mumumu');
+  expect(reqNode.metaData.other['external1'][1].key).toBe('lickit');
+  expect(reqNode.metaData.other['external1'][1].value).toBe('mimimi');
+  expect(reqNode.metaData.other['external2'][0].key).toBe('first');
+  expect(reqNode.metaData.other['external2'][0].value).toBe('momomo');
+  expect(reqNode.metaData.other['external2'][1].key).toBe('second');
+  expect(reqNode.metaData.other['external2'][1].value).toBe('mamama');
+
   var genNode = reqNode.getOnmsRequisitionNode();
   expect(genNode).not.toBe(null);
   expect(angular.equals(genNode, onmsNode)).toBe(true);
 });
+


### PR DESCRIPTION
This does not add any UI elements, but makes the model driving the UI aware of the meta-data. It also includes the split-up between the "requisition" context and all other contexts.

By adding the meta-data to the model, this preserves existing meta-data while editing other things in the UI.

* JIRA: http://issues.opennms.org/browse/HZN-1511