### PR TITLE
NMS-10638: bump allowed JDK to 8 through 11

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -6,7 +6,7 @@
 export DH_VERBOSE=1
 export SHELL=/bin/bash
 
-export JAVA_HOME=$(shell opennms-base-assembly/src/main/filtered/bin/find-java.sh 1.8 1.8.9999)
+export JAVA_HOME=$(shell opennms-base-assembly/src/main/filtered/bin/find-java.sh 1.8 11.9999)
 
 export OPTS_ASSEMBLIES=-Passemblies
 export OPTS_PROFILES=-Prun-expensive-tasks

--- a/opennms-assemblies/minion/src/main/filtered/debian/rules
+++ b/opennms-assemblies/minion/src/main/filtered/debian/rules
@@ -1,7 +1,7 @@
 #!/usr/bin/make -f
 
 export DH_VERBOSE=1
-export JAVA_HOME=$(shell bin/find-java.sh 1.8 1.8.9999)
+export JAVA_HOME=$(shell bin/find-java.sh 1.8 11.9999)
 export PACKAGE_NAME="opennms-minion"
 export CONTAINER_NAME="opennms-minion-container"
 

--- a/opennms-assemblies/sentinel/src/main/filtered/debian/rules
+++ b/opennms-assemblies/sentinel/src/main/filtered/debian/rules
@@ -1,7 +1,7 @@
 #!/usr/bin/make -f
 
 export DH_VERBOSE=1
-export JAVA_HOME=$(shell bin/find-java.sh 1.8 1.8.9999)
+export JAVA_HOME=$(shell bin/find-java.sh 1.8 11.9999)
 export PACKAGE_NAME="opennms-sentinel"
 
 export SENTINEL_PREFIX=/usr/share/sentinel

--- a/opennms-base-assembly/src/main/filtered/bin/runjava
+++ b/opennms-base-assembly/src/main/filtered/bin/runjava
@@ -39,7 +39,7 @@ if [ ! -d "${opennms_home}" ]; then
 fi
 
 minimum_version="1.8.0"
-maximum_version="1.8.9999"
+maximum_version="11.9999"
 
 searchdirs=("/usr/lib/jvm" "/usr/java" "/System/Library/Java/JavaVirtualMachines" "/Library/Java/JavaVirtualMachines" "/Library/Java/Home" "/usr" "/opt")
 

--- a/opennms-doc/releasenotes/src/asciidoc/releasenotes/whatsnew.adoc
+++ b/opennms-doc/releasenotes/src/asciidoc/releasenotes/whatsnew.adoc
@@ -8,8 +8,8 @@
 
 === System Requirements
 
-* *Java 8*: OpenNMS Horizon 24 requires Java 8 as the runtime environment.
-  To run Horizon 24, we recommend the most recent version of Oracle JDK 8 for your platform.
+* *Java 8 through 11*: OpenNMS Horizon 24 requires at least Java 8 as the runtime environment and now supports running on JDK 11 as well.
+  To run Horizon 24, we recommend the most recent version of Oracle JDK 8 for your platform, or the latest OpenJDK 11.
 * *PostgreSQL 9 or higher*: Horizon 24 requires Any supported version PostgreSQL 9 or higher.
   As of this writing, PostgreSQL 9.3 is the earliest version under active support, but OpenNMS is known to work with at least PostgreSQL 9.1 and up.
 


### PR DESCRIPTION
This PR bumps the allowed/detected JDK to versions `1.8.0` through `11.9999`.

* JIRA: http://issues.opennms.org/browse/NMS-10638

Our [continuous integration system](http://bamboo.internal.opennms.com:8085) will test and verify your changes.
