### PR TITLE
NMS-10640: Introduced reduction key filter for IFTTT trigger packages

### DIFF
--- a/features/ifttt/src/main/java/org/opennms/features/ifttt/IfTttDaemon.java
+++ b/features/ifttt/src/main/java/org/opennms/features/ifttt/IfTttDaemon.java
@@ -179,8 +179,10 @@ public class IfTttDaemon {
                                     .anyMatch(category -> category.getName().matches(triggerPackage.getCategoryFilter())));
                 }
 
-                if (!Strings.isNullOrEmpty(triggerPackage.getUeiFilter())) {
-                    stream = stream.filter(alarm -> alarm.getUei().matches(triggerPackage.getUeiFilter()));
+                if (!Strings.isNullOrEmpty(triggerPackage.getReductionKeyFilter())) {
+                    stream = stream
+                            .filter(alarm -> !Strings.isNullOrEmpty(alarm.getReductionKey()))
+                            .filter(alarm -> alarm.getReductionKey().matches(triggerPackage.getReductionKeyFilter()));
                 }
 
                 return stream.collect(Collectors.toList());

--- a/features/ifttt/src/main/java/org/opennms/features/ifttt/config/IfTttConfig.java
+++ b/features/ifttt/src/main/java/org/opennms/features/ifttt/config/IfTttConfig.java
@@ -95,9 +95,9 @@ public class IfTttConfig {
         this.triggerPackages = triggerPackages;
     }
 
-    public TriggerPackage getTriggerPackageForCategoryFilter(final String categoryFilter) {
+    public TriggerPackage getTriggerPackageForFilters(final String filterKey) {
         for (final TriggerPackage triggerPackage : triggerPackages) {
-            if (categoryFilter.equals(triggerPackage.getCategoryFilter())) {
+            if (filterKey.equals(triggerPackage.getFilterKey())) {
                 return triggerPackage;
             }
         }
@@ -112,9 +112,9 @@ public class IfTttConfig {
         final IfTttConfig that = (IfTttConfig) o;
 
         return Objects.equals(key, that.key) &&
-               Objects.equals(enabled, that.enabled) &&
-               Objects.equals(triggerPackages, that.triggerPackages) &&
-               Objects.equals(pollInterval, that.pollInterval);
+                Objects.equals(enabled, that.enabled) &&
+                Objects.equals(triggerPackages, that.triggerPackages) &&
+                Objects.equals(pollInterval, that.pollInterval);
     }
 
     @Override

--- a/features/ifttt/src/main/java/org/opennms/features/ifttt/config/TriggerPackage.java
+++ b/features/ifttt/src/main/java/org/opennms/features/ifttt/config/TriggerPackage.java
@@ -41,6 +41,10 @@ public class TriggerPackage {
      */
     private String categoryFilter;
     /**
+     * uei filter
+     */
+    private String ueiFilter;
+    /**
      * trigger sets for firing IFTTT events
      */
     private List<TriggerSet> triggerSets = new ArrayList<>();
@@ -51,11 +55,20 @@ public class TriggerPackage {
 
     @XmlAttribute
     public String getCategoryFilter() {
-        return categoryFilter != null ? categoryFilter : ".*";
+        return categoryFilter != null ? categoryFilter : "";
     }
 
     public void setCategoryFilter(final String categoryFilter) {
         this.categoryFilter = categoryFilter;
+    }
+
+    @XmlAttribute
+    public String getUeiFilter() {
+        return ueiFilter != null ? ueiFilter : ".*";
+    }
+
+    public void setUeiFilter(final String ueiFilter) {
+        this.ueiFilter = ueiFilter;
     }
 
     @XmlAttribute
@@ -93,12 +106,17 @@ public class TriggerPackage {
         final TriggerPackage that = (TriggerPackage) o;
 
         return Objects.equals(categoryFilter, that.categoryFilter) &&
-               Objects.equals(triggerSets, that.triggerSets) &&
-               Objects.equals(onlyUnacknowledged, that.onlyUnacknowledged);
+                Objects.equals(ueiFilter, that.ueiFilter) &&
+                Objects.equals(triggerSets, that.triggerSets) &&
+                Objects.equals(onlyUnacknowledged, that.onlyUnacknowledged);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(categoryFilter, triggerSets, onlyUnacknowledged);
+        return Objects.hash(categoryFilter, ueiFilter, triggerSets, onlyUnacknowledged);
+    }
+
+    public String getFilterKey() {
+        return getCategoryFilter() + " / " + getUeiFilter();
     }
 }

--- a/features/ifttt/src/main/java/org/opennms/features/ifttt/config/TriggerPackage.java
+++ b/features/ifttt/src/main/java/org/opennms/features/ifttt/config/TriggerPackage.java
@@ -35,6 +35,8 @@ import java.util.Objects;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
 
+import com.google.common.base.Strings;
+
 public class TriggerPackage {
     /**
      * category filter
@@ -64,7 +66,7 @@ public class TriggerPackage {
 
     @XmlAttribute
     public String getUeiFilter() {
-        return ueiFilter != null ? ueiFilter : ".*";
+        return Strings.isNullOrEmpty(ueiFilter) ? ".*" : ueiFilter;
     }
 
     public void setUeiFilter(final String ueiFilter) {

--- a/features/ifttt/src/main/java/org/opennms/features/ifttt/config/TriggerPackage.java
+++ b/features/ifttt/src/main/java/org/opennms/features/ifttt/config/TriggerPackage.java
@@ -66,7 +66,7 @@ public class TriggerPackage {
 
     @XmlAttribute
     public String getUeiFilter() {
-        return Strings.isNullOrEmpty(ueiFilter) ? ".*" : ueiFilter;
+        return ueiFilter != null ? ueiFilter : "";
     }
 
     public void setUeiFilter(final String ueiFilter) {

--- a/features/ifttt/src/main/java/org/opennms/features/ifttt/config/TriggerPackage.java
+++ b/features/ifttt/src/main/java/org/opennms/features/ifttt/config/TriggerPackage.java
@@ -41,11 +41,11 @@ public class TriggerPackage {
     /**
      * category filter
      */
-    private String categoryFilter;
+    private String categoryFilter = "";
     /**
      * uei filter
      */
-    private String ueiFilter;
+    private String reductionKeyFilter = "";
     /**
      * trigger sets for firing IFTTT events
      */
@@ -57,7 +57,7 @@ public class TriggerPackage {
 
     @XmlAttribute
     public String getCategoryFilter() {
-        return categoryFilter != null ? categoryFilter : "";
+        return categoryFilter;
     }
 
     public void setCategoryFilter(final String categoryFilter) {
@@ -65,12 +65,12 @@ public class TriggerPackage {
     }
 
     @XmlAttribute
-    public String getUeiFilter() {
-        return ueiFilter != null ? ueiFilter : "";
+    public String getReductionKeyFilter() {
+        return reductionKeyFilter;
     }
 
-    public void setUeiFilter(final String ueiFilter) {
-        this.ueiFilter = ueiFilter;
+    public void setReductionKeyFilter(final String reductionKeyFilter) {
+        this.reductionKeyFilter = reductionKeyFilter;
     }
 
     @XmlAttribute
@@ -108,17 +108,27 @@ public class TriggerPackage {
         final TriggerPackage that = (TriggerPackage) o;
 
         return Objects.equals(categoryFilter, that.categoryFilter) &&
-                Objects.equals(ueiFilter, that.ueiFilter) &&
+                Objects.equals(reductionKeyFilter, that.reductionKeyFilter) &&
                 Objects.equals(triggerSets, that.triggerSets) &&
                 Objects.equals(onlyUnacknowledged, that.onlyUnacknowledged);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(categoryFilter, ueiFilter, triggerSets, onlyUnacknowledged);
+        return Objects.hash(categoryFilter, reductionKeyFilter, triggerSets, onlyUnacknowledged);
     }
 
     public String getFilterKey() {
-        return getCategoryFilter() + " / " + getUeiFilter();
+        return getCategoryFilter() + " / " + getReductionKeyFilter();
+    }
+
+    @Override
+    public String toString() {
+        return "TriggerPackage{" +
+                "categoryFilter='" + categoryFilter + '\'' +
+                ", reductionKeyFilter='" + reductionKeyFilter + '\'' +
+                ", triggerSets=" + triggerSets +
+                ", onlyUnacknowledged=" + onlyUnacknowledged +
+                '}';
     }
 }

--- a/features/ifttt/src/main/resources/xsds/ifttt-config.xsd
+++ b/features/ifttt/src/main/resources/xsds/ifttt-config.xsd
@@ -50,12 +50,12 @@
                     </annotation>
                 </element>
             </sequence>
-            <attribute name="categoryFilter" type="string" use="required">
+            <attribute name="categoryFilter" type="string" use="optional">
                 <annotation>
                     <documentation>The categoryFilter for this trigger package.</documentation>
                 </annotation>
             </attribute>
-            <attribute name="ueiFilter" type="string" use="required">
+            <attribute name="reductionKeyFilter" type="string" use="optional">
                 <annotation>
                     <documentation>The ueiFilter for this trigger package.</documentation>
                 </annotation>

--- a/features/ifttt/src/main/resources/xsds/ifttt-config.xsd
+++ b/features/ifttt/src/main/resources/xsds/ifttt-config.xsd
@@ -55,6 +55,11 @@
                     <documentation>The categoryFilter for this trigger package.</documentation>
                 </annotation>
             </attribute>
+            <attribute name="ueiFilter" type="string" use="required">
+                <annotation>
+                    <documentation>The ueiFilter for this trigger package.</documentation>
+                </annotation>
+            </attribute>
             <attribute name="onlyUnacknowledged" type="boolean" default="true" use="optional">
                 <annotation>
                     <documentation>Whether only unacknowledged alarms are used for this trigger package.</documentation>

--- a/features/ifttt/src/test/java/org/opennms/features/ifttt/IfTttDaemonTest.java
+++ b/features/ifttt/src/test/java/org/opennms/features/ifttt/IfTttDaemonTest.java
@@ -195,7 +195,8 @@ public class IfTttDaemonTest {
 
         addAlarm(12, null, EventConstants.BUSINESS_SERVICE_PROBLEM_UEI, OnmsSeverity.MINOR);
         addAlarm(13, null, EventConstants.BUSINESS_SERVICE_PROBLEM_UEI, OnmsSeverity.CRITICAL);
-        addAlarm(14, null, EventConstants.BUSINESS_SERVICE_PROBLEM_UEI, OnmsSeverity.MAJOR);
+        addAlarm(14, null, "", OnmsSeverity.CRITICAL);
+        addAlarm(15, null, EventConstants.BUSINESS_SERVICE_PROBLEM_UEI, OnmsSeverity.MAJOR);
     }
 
     @Test
@@ -265,8 +266,8 @@ public class IfTttDaemonTest {
         await().atMost(timeout, SECONDS).until(() -> allEntrySizesMatch(receivedEntries, entryCount - 2));
         LOG.debug("#1: {}", receivedEntries);
 
-        addAlarm(15, 4, OnmsSeverity.MAJOR);
-        addAlarm(16, 4, "uei.opennms.org/bsm/serviceProblem", OnmsSeverity.MAJOR);
+        addAlarm(100, 4, OnmsSeverity.MAJOR);
+        addAlarm(101, 4, "uei.opennms.org/bsm/serviceProblem", OnmsSeverity.MAJOR);
         when(alarmDao.findMatching((Criteria) Matchers.anyObject())).thenReturn(alarmMap.values().stream().collect(Collectors.toList()));
 
         await().atMost(timeout, SECONDS).until(() -> allEntrySizesMatch(receivedEntries, entryCount - 1));

--- a/features/ifttt/src/test/java/org/opennms/features/ifttt/config/IfTttConfigTest.java
+++ b/features/ifttt/src/test/java/org/opennms/features/ifttt/config/IfTttConfigTest.java
@@ -99,6 +99,7 @@ public class IfTttConfigTest extends XmlTestNoCastor<IfTttConfig> {
 
         TriggerPackage triggerPackage2 = new TriggerPackage();
         triggerPackage2.setCategoryFilter("Foo2");
+        triggerPackage2.setReductionKeyFilter("uei.*");
         triggerPackage2.setOnlyUnacknowledged(true);
 
         TriggerSet triggerSet21 = new TriggerSet();
@@ -145,7 +146,7 @@ public class IfTttConfigTest extends XmlTestNoCastor<IfTttConfig> {
                 {
                         ifTttConfig,
                         "<ifttt-config enabled=\"true\" key=\"key\" pollInterval=\"30\">\n" +
-                                "   <trigger-package categoryFilter=\"Package1\" onlyUnacknowledged=\"true\">\n" +
+                                "   <trigger-package categoryFilter=\"Package1\" onlyUnacknowledged=\"true\" reductionKeyFilter=\"\">\n" +
                                 "      <trigger-set name=\"11\">\n" +
                                 "         <trigger delay=\"111\" eventName=\"111\">\n" +
                                 "            <value1>value1111</value1>\n" +
@@ -171,7 +172,7 @@ public class IfTttConfigTest extends XmlTestNoCastor<IfTttConfig> {
                                 "         </trigger>\n" +
                                 "      </trigger-set>\n" +
                                 "   </trigger-package>\n" +
-                                "   <trigger-package categoryFilter=\"Foo2\" onlyUnacknowledged=\"true\">\n" +
+                                "   <trigger-package categoryFilter=\"Foo2\" onlyUnacknowledged=\"true\" reductionKeyFilter=\"uei.*\">\n" +
                                 "      <trigger-set name=\"21\">\n" +
                                 "         <trigger delay=\"211\" eventName=\"211\">\n" +
                                 "            <value1>value2111</value1>\n" +
@@ -206,7 +207,13 @@ public class IfTttConfigTest extends XmlTestNoCastor<IfTttConfig> {
     @Test
     public void testUnsetCategoryFilter() {
         TriggerPackage triggerPackage = new TriggerPackage();
-        Assert.assertEquals(".*", triggerPackage.getCategoryFilter());
+        Assert.assertEquals("", triggerPackage.getCategoryFilter());
+    }
+
+    @Test
+    public void testUnsetReductionKeyFilter() {
+        TriggerPackage triggerPackage = new TriggerPackage();
+        Assert.assertEquals("", triggerPackage.getReductionKeyFilter());
     }
 
     @Test
@@ -214,6 +221,13 @@ public class IfTttConfigTest extends XmlTestNoCastor<IfTttConfig> {
         TriggerPackage triggerPackage = new TriggerPackage();
         triggerPackage.setCategoryFilter("foo|bar");
         Assert.assertEquals("foo|bar", triggerPackage.getCategoryFilter());
+    }
+
+    @Test
+    public void testSetReductionKeyFilter() {
+        TriggerPackage triggerPackage = new TriggerPackage();
+        triggerPackage.setReductionKeyFilter("uei.*");
+        Assert.assertEquals("uei.*", triggerPackage.getReductionKeyFilter());
     }
 }
 

--- a/features/ifttt/src/test/resources/etc/ifttt-config.xml
+++ b/features/ifttt/src/test/resources/etc/ifttt-config.xml
@@ -1,6 +1,6 @@
 <ifttt-config enabled="true" key="test-key" pollInterval="2">
 
-    <trigger-package categoryFilter="Bar" ueiFilter="uei.opennms.org/nodes/nodeLostService" onlyUnacknowledged="false">
+    <trigger-package categoryFilter="Bar" reductionKeyFilter="uei.opennms.org/nodes/nodeLostService" onlyUnacknowledged="false">
         <trigger-set name="ON">
             <trigger eventName="test" delay="0">
                 <value1>ON</value1>
@@ -58,7 +58,7 @@
         </trigger-set>
     </trigger-package>
 
-    <trigger-package categoryFilter="Foo" ueiFilter="uei.opennms.org/nodes/nodeLost.*" onlyUnacknowledged="true">
+    <trigger-package categoryFilter="Foo" reductionKeyFilter="uei.opennms.org/nodes/nodeLost.*" onlyUnacknowledged="true">
         <trigger-set name="ON">
             <trigger eventName="test" delay="0">
                 <value1>ON</value1>
@@ -116,7 +116,7 @@
         </trigger-set>
     </trigger-package>
 
-    <trigger-package categoryFilter="Foo|Bar" ueiFilter="uei.opennms.org/nodes/node.*" onlyUnacknowledged="true">
+    <trigger-package categoryFilter="Foo|Bar" reductionKeyFilter="uei.opennms.org/nodes/node.*" onlyUnacknowledged="true">
         <trigger-set name="ON">
             <trigger eventName="test" delay="0">
                 <value1>ON</value1>
@@ -174,7 +174,7 @@
         </trigger-set>
     </trigger-package>
 
-    <trigger-package categoryFilter="Foo|Bar" ueiFilter="uei.opennms.org/bsm/serviceProblem" onlyUnacknowledged="true">
+    <trigger-package categoryFilter="Foo|Bar" reductionKeyFilter="uei.opennms.org/bsm/serviceProblem" onlyUnacknowledged="true">
         <trigger-set name="ON">
             <trigger eventName="test" delay="0">
                 <value1>ON</value1>
@@ -232,7 +232,7 @@
         </trigger-set>
     </trigger-package>
 
-    <trigger-package categoryFilter="" ueiFilter="uei.opennms.org/bsm/serviceProb.*" onlyUnacknowledged="true">
+    <trigger-package categoryFilter="" reductionKeyFilter="uei.opennms.org/bsm/serviceProb.*" onlyUnacknowledged="true">
         <trigger-set name="ON">
             <trigger eventName="test" delay="0">
                 <value1>ON</value1>

--- a/features/ifttt/src/test/resources/etc/ifttt-config.xml
+++ b/features/ifttt/src/test/resources/etc/ifttt-config.xml
@@ -1,6 +1,6 @@
 <ifttt-config enabled="true" key="test-key" pollInterval="2">
 
-    <trigger-package categoryFilter="Bar" onlyUnacknowledged="false">
+    <trigger-package categoryFilter="Bar" ueiFilter="uei.opennms.org/nodes/nodeLostService" onlyUnacknowledged="false">
         <trigger-set name="ON">
             <trigger eventName="test" delay="0">
                 <value1>ON</value1>
@@ -58,7 +58,7 @@
         </trigger-set>
     </trigger-package>
 
-    <trigger-package categoryFilter="Foo" onlyUnacknowledged="true">
+    <trigger-package categoryFilter="Foo" ueiFilter="uei.opennms.org/nodes/nodeLost.*" onlyUnacknowledged="true">
         <trigger-set name="ON">
             <trigger eventName="test" delay="0">
                 <value1>ON</value1>
@@ -116,7 +116,123 @@
         </trigger-set>
     </trigger-package>
 
-    <trigger-package categoryFilter="Foo|Bar" onlyUnacknowledged="true">
+    <trigger-package categoryFilter="Foo|Bar" ueiFilter="uei.opennms.org/nodes/node.*" onlyUnacknowledged="true">
+        <trigger-set name="ON">
+            <trigger eventName="test" delay="0">
+                <value1>ON</value1>
+                <value2></value2>
+                <value3></value3>
+            </trigger>
+        </trigger-set>
+
+        <trigger-set name="OFF">
+            <trigger eventName="test" delay="0">
+                <value1>OFF</value1>
+                <value2></value2>
+                <value3></value3>
+            </trigger>
+        </trigger-set>
+
+        <trigger-set name="NORMAL">
+            <trigger eventName="test" delay="0">
+                <value1>#33FF00</value1>
+                <value2>0.40</value2>
+                <value3>%os%,%ns%,%oc%,%nc%</value3>
+            </trigger>
+        </trigger-set>
+
+        <trigger-set name="WARNING">
+            <trigger eventName="test" delay="0">
+                <value1>#FFCC00</value1>
+                <value2>0.50</value2>
+                <value3>%os%,%ns%,%oc%,%nc%</value3>
+            </trigger>
+        </trigger-set>
+
+        <trigger-set name="MINOR">
+            <trigger eventName="test" delay="0">
+                <value1>#FF9900</value1>
+                <value2>0.60</value2>
+                <value3>%os%,%ns%,%oc%,%nc%</value3>
+            </trigger>
+        </trigger-set>
+
+        <trigger-set name="MAJOR">
+            <trigger eventName="test" delay="0">
+                <value1>#CC3300</value1>
+                <value2>0.70</value2>
+                <value3>%os%,%ns%,%oc%,%nc%</value3>
+            </trigger>
+        </trigger-set>
+
+        <trigger-set name="CRITICAL">
+            <trigger eventName="test" delay="0">
+                <value1>#FF0000</value1>
+                <value2>0.80</value2>
+                <value3>%os%,%ns%,%oc%,%nc%</value3>
+            </trigger>
+        </trigger-set>
+    </trigger-package>
+
+    <trigger-package categoryFilter="Foo|Bar" ueiFilter="uei.opennms.org/bsm/serviceProblem" onlyUnacknowledged="true">
+        <trigger-set name="ON">
+            <trigger eventName="test" delay="0">
+                <value1>ON</value1>
+                <value2></value2>
+                <value3></value3>
+            </trigger>
+        </trigger-set>
+
+        <trigger-set name="OFF">
+            <trigger eventName="test" delay="0">
+                <value1>OFF</value1>
+                <value2></value2>
+                <value3></value3>
+            </trigger>
+        </trigger-set>
+
+        <trigger-set name="NORMAL">
+            <trigger eventName="test" delay="0">
+                <value1>#33FF00</value1>
+                <value2>0.40</value2>
+                <value3>%os%,%ns%,%oc%,%nc%</value3>
+            </trigger>
+        </trigger-set>
+
+        <trigger-set name="WARNING">
+            <trigger eventName="test" delay="0">
+                <value1>#FFCC00</value1>
+                <value2>0.50</value2>
+                <value3>%os%,%ns%,%oc%,%nc%</value3>
+            </trigger>
+        </trigger-set>
+
+        <trigger-set name="MINOR">
+            <trigger eventName="test" delay="0">
+                <value1>#FF9900</value1>
+                <value2>0.60</value2>
+                <value3>%os%,%ns%,%oc%,%nc%</value3>
+            </trigger>
+        </trigger-set>
+
+        <trigger-set name="MAJOR">
+            <trigger eventName="test" delay="0">
+                <value1>#CC3300</value1>
+                <value2>0.70</value2>
+                <value3>%os%,%ns%,%oc%,%nc%</value3>
+            </trigger>
+        </trigger-set>
+
+        <trigger-set name="CRITICAL">
+            <trigger eventName="test" delay="0">
+                <value1>#FF0000</value1>
+                <value2>0.80</value2>
+                <value3>%os%,%ns%,%oc%,%nc%</value3>
+            </trigger>
+        </trigger-set>
+    </trigger-package>
+
+    <trigger-package categoryFilter="" ueiFilter="uei.opennms.org/bsm/serviceProb.*" onlyUnacknowledged="true">
         <trigger-set name="ON">
             <trigger eventName="test" delay="0">
                 <value1>ON</value1>

--- a/opennms-base-assembly/src/main/filtered/etc/ifttt-config.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/ifttt-config.xml
@@ -1,5 +1,5 @@
 <ifttt-config enabled="false" key="your-key-here" pollInterval="30">
-    <trigger-package categoryFilter=".*" ueiFilter=".*" onlyUnacknowledged="true">
+    <trigger-package categoryFilter=".*" reductionKeyFilter=".*" onlyUnacknowledged="true">
         <trigger-set name="ON">
             <trigger eventName="test" delay="0">
                 <value1>ON</value1>

--- a/opennms-base-assembly/src/main/filtered/etc/ifttt-config.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/ifttt-config.xml
@@ -1,5 +1,5 @@
 <ifttt-config enabled="false" key="your-key-here" pollInterval="30">
-    <trigger-package categoryFilter=".*" onlyUnacknowledged="true">
+    <trigger-package categoryFilter=".*" ueiFilter=".*" onlyUnacknowledged="true">
         <trigger-set name="ON">
             <trigger eventName="test" delay="0">
                 <value1>ON</value1>

--- a/opennms-doc/guide-admin/src/asciidoc/text/ifttt/ifttt-integration.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/ifttt/ifttt-integration.adoc
@@ -7,7 +7,7 @@ Each supported service has several triggers that can be used to trigger actions 
 This allows for example to change brightness and color of a smart bulb, send messages or date to IoT devices.
 
 The _{opennms-product-name}_ integration makes uses of the so-called "Webhooks" service, that allows to trigger actions when a specific web-request was received.
-The basic operation is as follows: _{opennms-product-name}_ polls for alarms with associated nodes and matches a given category filter.
+The basic operation is as follows: _{opennms-product-name}_ polls for alarms and matches the alarm UEIs against a given UEI filter and the alarm's associated nodes against a given category filter.
 For the resulting alarm set the maximum severity and total count is computed.
 If one of these values changed compared to the last poll one or more events specified for the computed maximum severity will be sent to _IFTTT_.
 
@@ -35,10 +35,10 @@ The configuration file `ifttt-config.xml` contains so called trigger packages.
 The operation is as follows:
 _{opennms-product-name}_ retrieves all alarms that have a node associated.
 Each trigger package defines whether only acknowledged alarms should be taken into account.
-It then computes the maximum severity and alarm count for each trigger package's category filter.
+It then computes the maximum severity and alarm count for each trigger package's category filter and UEI filter.
 After that it triggers all events defined in the corresponding trigger sets for the computed maximum severity.
-The category filter accepts Java regular expressions.
-Using an empty category filter will use all unacknowledged alarms with an associated node.
+The category and UEI filter accepts Java regular expressions.
+Using an empty category filter will use all unacknowledged alarms regardless of whether these alarms have nodes assigned or not.
 
 Each trigger inside a trigger set defines the event name to be triggered and three additional values.
 These values can be used to set additional attributes for the corresponding _IFTTT_ applet action.
@@ -80,7 +80,7 @@ This is useful for sending messages or operating LED displays via _IFTTT_.
 [source, xml]
 ----
 <ifttt-config enabled="true" key="X71dfUZsH4Wkl6cjsLjdV" pollInterval="30">
-    <trigger-package categoryFilter="Routers|Switches" onlyUnacknowledged="true">
+    <trigger-package categoryFilter="Routers|Switches" ueiFilter=".*" onlyUnacknowledged="true">
         <trigger-set name="ON">
             <trigger eventName="on" delay="0">
                 <value1></value1>

--- a/opennms-doc/guide-admin/src/asciidoc/text/ifttt/ifttt-integration.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/ifttt/ifttt-integration.adoc
@@ -7,7 +7,7 @@ Each supported service has several triggers that can be used to trigger actions 
 This allows for example to change brightness and color of a smart bulb, send messages or date to IoT devices.
 
 The _{opennms-product-name}_ integration makes uses of the so-called "Webhooks" service, that allows to trigger actions when a specific web-request was received.
-The basic operation is as follows: _{opennms-product-name}_ polls for alarms and matches the alarm UEIs against a given UEI filter and the alarm's associated nodes against a given category filter.
+The basic operation is as follows: _{opennms-product-name}_ polls for alarms and matches the alarm reduction key against a given filter and the alarm's associated nodes against a given category filter.
 For the resulting alarm set the maximum severity and total count is computed.
 If one of these values changed compared to the last poll one or more events specified for the computed maximum severity will be sent to _IFTTT_.
 
@@ -35,9 +35,9 @@ The configuration file `ifttt-config.xml` contains so called trigger packages.
 The operation is as follows:
 _{opennms-product-name}_ retrieves all alarms that have a node associated.
 Each trigger package defines whether only acknowledged alarms should be taken into account.
-It then computes the maximum severity and alarm count for each trigger package's category filter and UEI filter.
+It then computes the maximum severity and alarm count for each trigger package's category filter and reduction key filter.
 After that it triggers all events defined in the corresponding trigger sets for the computed maximum severity.
-The category and UEI filter accepts Java regular expressions.
+The category and reduction key filter accepts Java regular expressions.
 Using an empty category filter will use all unacknowledged alarms regardless of whether these alarms have nodes assigned or not.
 
 Each trigger inside a trigger set defines the event name to be triggered and three additional values.
@@ -80,7 +80,7 @@ This is useful for sending messages or operating LED displays via _IFTTT_.
 [source, xml]
 ----
 <ifttt-config enabled="true" key="X71dfUZsH4Wkl6cjsLjdV" pollInterval="30">
-    <trigger-package categoryFilter="Routers|Switches" ueiFilter=".*" onlyUnacknowledged="true">
+    <trigger-package categoryFilter="Routers|Switches" reductionKeyFilter=".*" onlyUnacknowledged="true">
         <trigger-set name="ON">
             <trigger eventName="on" delay="0">
                 <value1></value1>


### PR DESCRIPTION
Currently the IFTTT-integration only filters based on categories which will only allow alarms with associated nodes. A new reductionKeyFilter allows to filter also for reduction keys, so it is possible now to trigger IFTTT events for BS alarms.
* JIRA: https://issues.opennms.org/browse/NMS-10640