### PR TITLE
NMS-10639: change dependencies to OpenJDK 11

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -167,7 +167,7 @@ Description: Enterprise-grade Open-source Network Management Platform (Common Fi
 
 Package: libopennms-java
 Architecture: all
-Depends: oracle-java8-installer | openjdk-8-jre | java8-runtime | java8-runtime-headless, jicmp (>= 2.0.0), jicmp6 (>= 2.0.0)
+Depends: openjdk-11-jdk | openjdk-11-jdk-headless, jicmp (>= 2.0.0), jicmp6 (>= 2.0.0)
 Conflicts: opennms-plugin-protocol-xml (<<${binary:Version})
 Replaces: opennms-common (<< 1.3.0), libicmp-jni (<< 1.3.0), opennms-plugin-protocol-xml (<<${binary:Version})
 Description: Enterprise-grade Open-source Network Management Platform (OpenNMS Libraries)
@@ -183,7 +183,7 @@ Description: Enterprise-grade Open-source Network Management Platform (OpenNMS L
 
 Package: libopennmsdeps-java
 Architecture: all
-Depends: oracle-java8-installer | openjdk-8-jre | java8-runtime | java8-runtime-headless
+Depends: openjdk-11-jdk | openjdk-11-jdk-headless
 Description: Enterprise-grade Open-source Network Management Platform (Required Libraries)
  OpenNMS is an enterprise-grade network management system written in Java.
  .

--- a/opennms-doc/guide-install/src/asciidoc/text/basic-setup-opennms/debian/step-1-install-opennms.adoc
+++ b/opennms-doc/guide-install/src/asciidoc/text/basic-setup-opennms/debian/step-1-install-opennms.adoc
@@ -18,12 +18,11 @@ apt update
 apt -y install opennms
 ----
 
-The following packages depend on the `opennms` package and will be automatically installed:
+The following packages are required by the `opennms` package and will be automatically installed:
 
 * _jicmp6_ and _jicmp_: _Java_ bridge to allow sending _ICMP messages_ from _OpenNMS_ repository.
 * _opennms-core_: _OpenNMS_ core services, e.g. _Provisiond_, _Pollerd_ and _Collectd_ from _OpenNMS_ repository.
 * _opennms-webapp-jetty_: _OpenNMS_ web application from _OpenNMS_ repository
-* _jdk1.8_: _Oracle Java 8_ environment from _OpenNMS_ respository
 * _postgresql_: _PostgreSQL_ database server from distribution repository
 * _postgresql-libs_: _PostgreSQL_ database from distribution repository
 

--- a/opennms-doc/guide-install/src/asciidoc/text/basic-setup-opennms/rhel/step-1-install-opennms.adoc
+++ b/opennms-doc/guide-install/src/asciidoc/text/basic-setup-opennms/rhel/step-1-install-opennms.adoc
@@ -19,7 +19,6 @@ The following packages will be automatically installed:
 * _jicmp6_ and _jicmp_: _Java_ bridge to allow sending _ICMP messages_ from _{opennms-product-name}_ repository.
 * _opennms-core_: _{opennms-product-name}_ core services, e.g. _Provisiond_, _Pollerd_ and _Collectd_ from _{opennms-product-name}_ repository.
 * _opennms-webapp-jetty_: _{opennms-product-name}_ web application from _{opennms-product-name}_ repository
-* _jdk1.8_: _Oracle Java SE Development Kit 8_ environment from _{opennms-product-name}_ respository
 * _postgresql_: _PostgreSQL_ database server from distribution repository
 * _postgresql-libs_: _PostgreSQL_ database from distribution repository
 

--- a/opennms-doc/guide-install/src/asciidoc/text/basic-setup-opennms/windows/installing-on-windows.adoc
+++ b/opennms-doc/guide-install/src/asciidoc/text/basic-setup-opennms/windows/installing-on-windows.adoc
@@ -3,7 +3,7 @@
 
 The installer for _Microsoft Windows_ does not handle _PostgreSQL_ and _Java_ dependencies as on _Linux_ operating systems.
 
-IMPORTANT: Ensure you have installed _Oracle Java Development Kit 8 (JDK)_ which is available on the link:http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html[Oracle] page.
+IMPORTANT: Ensure you have installed _Oracle Java Development Kit 8 (JDK)_ or higher from link:https://www.oracle.com/technetwork/java/index.html[the Oracle web page].
 
 The following steps will be described:
 

--- a/opennms-doc/guide-install/src/asciidoc/text/basic-setup-opennms/windows/installing-on-windows.adoc
+++ b/opennms-doc/guide-install/src/asciidoc/text/basic-setup-opennms/windows/installing-on-windows.adoc
@@ -3,7 +3,7 @@
 
 The installer for _Microsoft Windows_ does not handle _PostgreSQL_ and _Java_ dependencies as on _Linux_ operating systems.
 
-IMPORTANT: Ensure you have installed _Oracle Java Development Kit 8 (JDK)_ or higher from link:https://www.oracle.com/technetwork/java/index.html[the Oracle web page].
+IMPORTANT: Ensure you have installed _Oracle Java Development Kit 8 (JDK)_ or higher from link:https://www.oracle.com/technetwork/java/index.html[the Oracle web page] or from link:https://github.com/ojdkbuild/ojdkbuild[the OpenJDK community build site].
 
 The following steps will be described:
 

--- a/opennms-doc/guide-install/src/asciidoc/text/java-environment.adoc
+++ b/opennms-doc/guide-install/src/asciidoc/text/java-environment.adoc
@@ -5,7 +5,7 @@ To locate the _Java_ system files, applications typically use the `$JAVA_HOME` e
 The environment can be set for a specific user or globally for the whole system on boot time.
 
 .Example path to Java on RHEL, Debian and Microsoft Windows systems
-* RHEL: `/usr/java/jdk1.8.0_71`
+* RHEL: `/usr/lib/jvm/java-11`
 * Debian: `/usr/lib/jvm/java-8-oracle`
 * Microsoft Windows: `C:\Program Files\Java\jre1.8.0_71`
 

--- a/smoke-test/debian-shunt/debian-shunt.spec
+++ b/smoke-test/debian-shunt/debian-shunt.spec
@@ -4,7 +4,7 @@
 Name:			debian-shunt
 Summary:		Placeholder package to make RPM on debian happy
 Version:		1.0
-Release:		2
+Release:		3
 License:		Public Domain
 Group:			Development/Tools
 BuildArch:		noarch
@@ -20,6 +20,14 @@ Provides: postgresql-server = 9.3
 Provides: jdk = 2000:1.8.0
 Provides: java-1.8.0
 Provides: jre-1.8.0
+Provides: java-11
+Provides: java-11-openjdk
+Provides: jre-11
+Provides: jre-11-openjdk
+Provides: java-11-devel
+Provides: java-11-openjdk-devel
+Provides: java-sdk-11
+Provides: java-sdk-11-openjdk
 
 %description
 This is a placeholder wrapper package to provide the dependencies necessary

--- a/tools/packages/minion/minion.spec
+++ b/tools/packages/minion/minion.spec
@@ -16,7 +16,7 @@
 %{!?_descr:%define _descr OpenNMS}
 %{!?packagedir:%define packagedir %{_name}-%version-%{releasenumber}}
 
-%{!?_java:%define _java jre-1.8.0}
+%{!?_java:%define _java jre-11}
 
 %{!?extrainfo:%define extrainfo %{nil}}
 %{!?extrainfo2:%define extrainfo2 %{nil}}
@@ -53,6 +53,8 @@ BuildRequires:	libxslt
 
 Requires(pre): %{name}-features-default = %{version}-%{release}
 Requires:      %{name}-features-default = %{version}-%{release}
+Requires(pre): %{_java}
+Requires:      %{_java}
 
 Prefix:        %{minioninstprefix}
 
@@ -69,8 +71,6 @@ http://www.opennms.org/wiki/Minion
 Summary:       Minion Container
 Group:         Applications/System
 Requires:      openssh
-Requires(pre): %{_java}
-Requires:      %{_java}
 Requires(pre): /usr/bin/getent
 Requires(pre): /usr/sbin/groupadd
 Requires(pre): /usr/sbin/useradd

--- a/tools/packages/opennms/jdk.spec
+++ b/tools/packages/opennms/jdk.spec
@@ -2,15 +2,15 @@
 %define debug_package %{nil}
 
 %{!?package_arch:%define package_arch noarch}
-%{!?package_version:%define package_version 1.8}
-%{!?package_release:%define package_release 1}
-%{!?package_epoch:%define package_epoch 2000}
+%{!?package_version:%define package_version 11.0}
+%{!?package_release:%define package_release 0}
+%{!?package_epoch:%define package_epoch 1}
 %{!?my_epoch:%define my_epoch %{package_epoch}}
 %{!?my_release:%define my_release %{package_release}}
-%{!?dep_package:%define dep_package java-%(echo %{package_version} | sed -e 's,\\\.,_,g')-sun-devel}
+%{!?dep_package:%define dep_package java-11-openjdk-devel}
 
 Name:			jdk
-Summary:		Sun JDK compatible placeholder
+Summary:		OpenJDK compatible placeholder
 Epoch:			%{my_epoch}
 Version:		%{package_version}
 Release:		%{my_release}

--- a/tools/packages/opennms/opennms.spec
+++ b/tools/packages/opennms/opennms.spec
@@ -27,7 +27,7 @@
 %{!?_descr:%define _descr "OpenNMS"}
 %{!?packagedir:%define packagedir %{_name}-%version-%{releasenumber}}
 
-%{!?jdk:%define jdk java-1.8.0}
+%{!?jdk:%define jdk java-11-openjdk-devel}
 
 %{!?extrainfo:%define extrainfo }
 %{!?extrainfo2:%define extrainfo2 }
@@ -64,6 +64,8 @@ Requires(pre):		%{name}-core        = %{version}-%{release}
 Requires:		%{name}-core        = %{version}-%{release}
 Requires(pre):		postgresql-server  >= 9.1
 Requires:		postgresql-server  >= 9.1
+Requires(pre):		%{jdk}
+Requires:		%{jdk}
 
 # don't worry about buildrequires, the shell script will bomb quick  =)
 #BuildRequires:		%{jdk}
@@ -92,8 +94,6 @@ Requires(pre):	jicmp >= 2.0.0
 Requires:	jicmp >= 2.0.0
 Requires(pre):	jicmp6 >= 2.0.0
 Requires:	jicmp6 >= 2.0.0
-Requires(pre):	%{jdk}
-Requires:	%{jdk}
 Obsoletes:	opennms < 1.3.11
 Provides:	%{name}-plugin-protocol-xml = %{version}-%{release}
 Obsoletes:	%{name}-plugin-protocol-xml < %{version}
@@ -147,8 +147,6 @@ This package contains the API and user documentation.
 %package remote-poller
 Summary:	Remote (Distributed) Poller for %{_descr}
 Group:		Applications/System
-Requires(pre):	%{jdk}
-Requires:	%{jdk}
 
 %description remote-poller
 The distributed monitor.  For details, see:
@@ -161,8 +159,6 @@ The distributed monitor.  For details, see:
 %package jmx-config-generator
 Summary:	Generate JMX Configuration
 Group:		Applications/System
-Requires(pre):	%{jdk}
-Requires:	%{jdk}
 Requires:	%{name}-core = %{version}-%{release}
 
 %description jmx-config-generator

--- a/tools/packages/sentinel/sentinel.spec
+++ b/tools/packages/sentinel/sentinel.spec
@@ -16,7 +16,7 @@
 %{!?_descr:%define _descr OpenNMS}
 %{!?packagedir:%define packagedir %{_name}-%version-%{releasenumber}}
 
-%{!?_java:%define _java jre-1.8.0}
+%{!?_java:%define _java jre-11}
 
 %{!?extrainfo:%define extrainfo %{nil}}
 %{!?extrainfo2:%define extrainfo2 %{nil}}
@@ -58,8 +58,8 @@ BuildRequires:	libxslt
 Requires:       openssh
 Requires(post): util-linux
 Requires:       util-linux
-Requires(pre):  %{_java}
-Requires:       %{_java}
+#Requires(pre):  %{_java}
+#Requires:       %{_java}
 Requires(pre):  /usr/bin/getent
 Requires(pre):  /usr/sbin/groupadd
 Requires(pre):  /usr/sbin/useradd


### PR DESCRIPTION
* change all java dependencies to OpenJDK 11
* move the java dependency to the minion meta-package
* remove the java dependency from sentinel since it doesn't
  have a meta-package

* JIRA: http://issues.opennms.org/browse/NMS-10639

Our [continuous integration system](http://bamboo.internal.opennms.com:8085) will test and verify your changes.
