### PR TITLE
NMS-10672: redesigned threshold default events

### DIFF
--- a/opennms-base-assembly/src/main/filtered/etc/events/opennms.default.threshold.events.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/events/opennms.default.threshold.events.xml
@@ -2,7 +2,7 @@
    <event>
       <uei>uei.opennms.org/threshold/highThresholdExceeded</uei>
       <event-label>OpenNMS-defined threshold event: highThresholdExceeded</event-label>
-      <descr>A threshold for the following metric exceeded: %parm[all]%</descr>
+      <descr>A high threshold for the following metric exceeded: %parm[all]%</descr>
       <logmsg dest="logndisplay">
             High threshold exceeded for service %service% metric %parm[ds]% on interface %parm[label]%/%interface%
         </logmsg>
@@ -12,7 +12,7 @@
    <event>
       <uei>uei.opennms.org/threshold/lowThresholdExceeded</uei>
       <event-label>OpenNMS-defined threshold event: lowThresholdExceeded</event-label>
-      <descr>A threshold for the following metric exceeded: %parm[all]%</descr>
+      <descr>Low threshold for the following metric exceeded: %parm[all]%</descr>
       <logmsg dest="logndisplay">
             Low threshold exceeded for service %service% metric %parm[ds]% on interface %parm[label]%/%interface%
         </logmsg>

--- a/opennms-base-assembly/src/main/filtered/etc/events/opennms.default.threshold.events.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/events/opennms.default.threshold.events.xml
@@ -2,21 +2,9 @@
    <event>
       <uei>uei.opennms.org/threshold/highThresholdExceeded</uei>
       <event-label>OpenNMS-defined threshold event: highThresholdExceeded</event-label>
-      <descr>&lt;p>High threshold exceeded for %service% datasource
-            %parm[ds]% on interface %interface%, parms: %parm[all]%&lt;/p>
-            &lt;p>By default, OpenNMS watches some key parameters
-            on devices in your network and will alert you with
-            an event if certain conditions arise. For example, if
-            the CPU utilization on your Cisco router maintains an
-            inordinately high percentage of utilization for an extended
-            period, an event will be generated. These thresholds are
-            determined and configured based on vendor recommendations,
-            tempered with real-world experience in working
-            deployments.&lt;/p> &lt;p>This specific event
-            indicates that a high threshold was exceeded.&lt;/p></descr>
+      <descr>%parm[all]%</descr>
       <logmsg dest="logndisplay">
-            High threshold exceeded for %service% datasource %parm[ds]% on interface
-            %interface%, parms: %parm[all]%
+            High threshold exceeded for service %service% metric %parm[ds]% on interface %parm[label]%/%interface%
         </logmsg>
       <severity>Warning</severity>
       <alarm-data reduction-key="%uei%:%dpname%:%nodeid%:%interface%:%parm[ds]%:%parm[threshold]%:%parm[trigger]%:%parm[rearm]%:%parm[label]%" alarm-type="1" auto-clean="false"/>
@@ -24,21 +12,9 @@
    <event>
       <uei>uei.opennms.org/threshold/lowThresholdExceeded</uei>
       <event-label>OpenNMS-defined threshold event: lowThresholdExceeded</event-label>
-      <descr>&lt;p>Low threshold exceeded for %service% datasource
-            %parm[ds]% on interface %interface%, parms: %parm[all]%.&lt;/p>
-            &lt;p>By default, OpenNMS watches some key parameters
-            on devices in your network and will alert you with
-            an event if certain conditions arise. For example, if
-            the CPU utilization on your Cisco router maintains an
-            inordinately high percentage of utilization for an extended
-            period, an event will be generated. These thresholds are
-            determined and configured based on working experience with
-            real deployments, not vendor recommendation alone.&lt;/p>
-            &lt;p>This specific event indicates that a low threshold
-            was exceeded.&lt;/p></descr>
+      <descr>%parm[all]%</descr>
       <logmsg dest="logndisplay">
-            Low threshold exceeded for %service% datasource %parm[ds]% on interface
-            %interface%, parms: %parm[all]%
+            Low threshold exceeded for service %service% metric %parm[ds]% on interface %parm[label]%/%interface%
         </logmsg>
       <severity>Warning</severity>
       <alarm-data reduction-key="%uei%:%dpname%:%nodeid%:%interface%:%parm[ds]%:%parm[threshold]%:%parm[trigger]%:%parm[rearm]%:%parm[label]%" alarm-type="1" auto-clean="false"/>
@@ -46,22 +22,9 @@
    <event>
       <uei>uei.opennms.org/threshold/highThresholdRearmed</uei>
       <event-label>OpenNMS-defined threshold event: highThresholdRearmed</event-label>
-      <descr>&lt;p>High threshold has been rearmed for %service% datasource
-            %parm[ds]% on interface %interface%, parms: %parm[all]%&lt;/p>
-            &lt;p>By default, OpenNMS watches some key parameters
-            on devices in your network and will alert you with
-            an event if certain conditions arise. For example, if
-            the CPU utilization on your Cisco router maintains an
-            inordinately high percentage of utilization for an extended
-            period, an event will be generated. These thresholds are
-            determined and configured based on vendor recommendations,
-            tempered with real-world experience in working
-            deployments.&lt;/p> &lt;p>This specific event
-            indicates that a high threshold was exceeded but then dropped
-            below the rearm threshold..&lt;/p></descr>
+      <descr>%parm[all]%</descr>
       <logmsg dest="logndisplay">
-            High threshold rearmed for %service% datasource %parm[ds]% on interface
-            %interface%, parms: %parm[all]%
+            High threshold rearmed for service %service% metric %parm[ds]% on interface %parm[label]%/%interface%
         </logmsg>
       <severity>Normal</severity>
       <alarm-data reduction-key="%uei%:%dpname%:%nodeid%:%interface%:%parm[ds]%:%parm[threshold]%:%parm[trigger]%:%parm[rearm]%:%parm[label]%" alarm-type="2" clear-key="uei.opennms.org/threshold/highThresholdExceeded:%dpname%:%nodeid%:%interface%:%parm[ds]%:%parm[threshold]%:%parm[trigger]%:%parm[rearm]%:%parm[label]%" auto-clean="false"/>
@@ -69,21 +32,9 @@
    <event>
       <uei>uei.opennms.org/threshold/lowThresholdRearmed</uei>
       <event-label>OpenNMS-defined threshold event: lowThresholdRearmed</event-label>
-      <descr>&lt;p>Low threshold has been rearmed for %service% datasource
-            %parm[ds]% on interface %interface%, parms: %parm[all]%.&lt;/p>
-            &lt;p>By default, OpenNMS watches some key parameters
-            on devices in your network and will alert you with
-            an event if certain conditions arise. For example, if
-            the CPU utilization on your Cisco router maintains an
-            inordinately high percentage of utilization for an extended
-            period, an event will be generated. These thresholds are
-            determined and configured based on working experience with
-            real deployments, not vendor recommendation alone.&lt;/p>
-            &lt;p>This specific event indicates that a low threshold
-            was exceeded but then dropped below the rearm threshold.&lt;/p></descr>
+      <descr>%parm[all]%</descr>
       <logmsg dest="logndisplay">
-            Low threshold rearmed for %service% datasource %parm[ds]% on interface
-            %interface%, parms: %parm[all]%
+            Low threshold rearmed for service %service% metric %parm[ds]% on interface %parm[label]%/%interface%
         </logmsg>
       <severity>Normal</severity>
       <alarm-data reduction-key="%uei%:%dpname%:%nodeid%:%interface%:%parm[ds]%:%parm[threshold]%:%parm[trigger]%:%parm[rearm]%:%parm[label]%" alarm-type="2" clear-key="uei.opennms.org/threshold/lowThresholdExceeded:%dpname%:%nodeid%:%interface%:%parm[ds]%:%parm[threshold]%:%parm[trigger]%:%parm[rearm]%:%parm[label]%" auto-clean="false"/>
@@ -91,20 +42,18 @@
    <event>
       <uei>uei.opennms.org/threshold/relativeChangeExceeded</uei>
       <event-label>OpenNMS-defined threshold event: relativeChangeExceeded</event-label>
-      <descr>&lt;p>Relative change exceeded for %service% datasource %parm[ds]% on interface %interface%, parms:
-            %parm[all]%&lt;/p></descr>
+      <descr>%parm[all]%</descr>
       <logmsg dest="logndisplay">
-            Relative change exceeded for %service% datasource %parm[ds]% on interface %interface%, parms: %parm[all]%
+            Relative change exceeded for service %service% metric %parm[ds]% on interface %parm[label]%/%interface%
         </logmsg>
       <severity>Warning</severity>
    </event>
    <event>
       <uei>uei.opennms.org/threshold/absoluteChangeExceeded</uei>
       <event-label>OpenNMS-defined threshold event: absoluteChangeExceeded</event-label>
-      <descr>&lt;p>Absolute change exceeded for %service% datasource %parm[ds]% on interface %interface%, parms:
-            %parm[all]%&lt;/p></descr>
+      <descr>%parm[all]%</descr>
       <logmsg dest="logndisplay">
-            Absolute change exceeded for %service% datasource %parm[ds]% on interface %interface%, parms: %parm[all]%
+            Absolute change exceeded for service %service% metric %parm[ds]% on interface %parm[label]%/%interface%
         </logmsg>
       <severity>Warning</severity>
    </event>

--- a/opennms-base-assembly/src/main/filtered/etc/events/opennms.default.threshold.events.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/events/opennms.default.threshold.events.xml
@@ -2,7 +2,7 @@
    <event>
       <uei>uei.opennms.org/threshold/highThresholdExceeded</uei>
       <event-label>OpenNMS-defined threshold event: highThresholdExceeded</event-label>
-      <descr>A threshold alarm for the following metric occured: %parm[all]%</descr>
+      <descr>A threshold for the following metric exceeded: %parm[all]%</descr>
       <logmsg dest="logndisplay">
             High threshold exceeded for service %service% metric %parm[ds]% on interface %parm[label]%/%interface%
         </logmsg>
@@ -12,7 +12,7 @@
    <event>
       <uei>uei.opennms.org/threshold/lowThresholdExceeded</uei>
       <event-label>OpenNMS-defined threshold event: lowThresholdExceeded</event-label>
-      <descr>A threshold alarm for the following metric occured: %parm[all]%</descr>
+      <descr>A threshold for the following metric exceeded: %parm[all]%</descr>
       <logmsg dest="logndisplay">
             Low threshold exceeded for service %service% metric %parm[ds]% on interface %parm[label]%/%interface%
         </logmsg>
@@ -22,7 +22,7 @@
    <event>
       <uei>uei.opennms.org/threshold/highThresholdRearmed</uei>
       <event-label>OpenNMS-defined threshold event: highThresholdRearmed</event-label>
-      <descr>A threshold alarm for the following metric occured: %parm[all]%</descr>
+      <descr>High threshold has been rearmed for the following metric: %parm[all]%</descr>
       <logmsg dest="logndisplay">
             High threshold rearmed for service %service% metric %parm[ds]% on interface %parm[label]%/%interface%
         </logmsg>
@@ -32,7 +32,7 @@
    <event>
       <uei>uei.opennms.org/threshold/lowThresholdRearmed</uei>
       <event-label>OpenNMS-defined threshold event: lowThresholdRearmed</event-label>
-      <descr>A threshold alarm for the following metric occured: %parm[all]%</descr>
+      <descr>Low threshold has been rearmed for the following metric: %parm[all]%</descr>
       <logmsg dest="logndisplay">
             Low threshold rearmed for service %service% metric %parm[ds]% on interface %parm[label]%/%interface%
         </logmsg>
@@ -42,16 +42,16 @@
    <event>
       <uei>uei.opennms.org/threshold/relativeChangeExceeded</uei>
       <event-label>OpenNMS-defined threshold event: relativeChangeExceeded</event-label>
-      <descr>A threshold alarm for the following metric occured: %parm[all]%</descr>
+      <descr>Relative change threshold for the following metric exceeded: %parm[all]%</descr>
       <logmsg dest="logndisplay">
-            Relative change exceeded for service %service% metric %parm[ds]% on interface %parm[label]%/%interface%
+            Relative change change exceeded for service %service% metric %parm[ds]% on interface %parm[label]%/%interface%
         </logmsg>
       <severity>Warning</severity>
    </event>
    <event>
       <uei>uei.opennms.org/threshold/absoluteChangeExceeded</uei>
       <event-label>OpenNMS-defined threshold event: absoluteChangeExceeded</event-label>
-      <descr>A threshold alarm for the following metric occured: %parm[all]%</descr>
+      <descr>Absolute change threshold for the following metric exceeded: %parm[all]%</descr>
       <logmsg dest="logndisplay">
             Absolute change exceeded for service %service% metric %parm[ds]% on interface %parm[label]%/%interface%
         </logmsg>

--- a/opennms-base-assembly/src/main/filtered/etc/events/opennms.default.threshold.events.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/events/opennms.default.threshold.events.xml
@@ -2,7 +2,7 @@
    <event>
       <uei>uei.opennms.org/threshold/highThresholdExceeded</uei>
       <event-label>OpenNMS-defined threshold event: highThresholdExceeded</event-label>
-      <descr>%parm[all]%</descr>
+      <descr>A threshold alarm for the following metric occured: %parm[all]%</descr>
       <logmsg dest="logndisplay">
             High threshold exceeded for service %service% metric %parm[ds]% on interface %parm[label]%/%interface%
         </logmsg>
@@ -12,7 +12,7 @@
    <event>
       <uei>uei.opennms.org/threshold/lowThresholdExceeded</uei>
       <event-label>OpenNMS-defined threshold event: lowThresholdExceeded</event-label>
-      <descr>%parm[all]%</descr>
+      <descr>A threshold alarm for the following metric occured: %parm[all]%</descr>
       <logmsg dest="logndisplay">
             Low threshold exceeded for service %service% metric %parm[ds]% on interface %parm[label]%/%interface%
         </logmsg>
@@ -22,7 +22,7 @@
    <event>
       <uei>uei.opennms.org/threshold/highThresholdRearmed</uei>
       <event-label>OpenNMS-defined threshold event: highThresholdRearmed</event-label>
-      <descr>%parm[all]%</descr>
+      <descr>A threshold alarm for the following metric occured: %parm[all]%</descr>
       <logmsg dest="logndisplay">
             High threshold rearmed for service %service% metric %parm[ds]% on interface %parm[label]%/%interface%
         </logmsg>
@@ -32,7 +32,7 @@
    <event>
       <uei>uei.opennms.org/threshold/lowThresholdRearmed</uei>
       <event-label>OpenNMS-defined threshold event: lowThresholdRearmed</event-label>
-      <descr>%parm[all]%</descr>
+      <descr>A threshold alarm for the following metric occured: %parm[all]%</descr>
       <logmsg dest="logndisplay">
             Low threshold rearmed for service %service% metric %parm[ds]% on interface %parm[label]%/%interface%
         </logmsg>
@@ -42,7 +42,7 @@
    <event>
       <uei>uei.opennms.org/threshold/relativeChangeExceeded</uei>
       <event-label>OpenNMS-defined threshold event: relativeChangeExceeded</event-label>
-      <descr>%parm[all]%</descr>
+      <descr>A threshold alarm for the following metric occured: %parm[all]%</descr>
       <logmsg dest="logndisplay">
             Relative change exceeded for service %service% metric %parm[ds]% on interface %parm[label]%/%interface%
         </logmsg>
@@ -51,7 +51,7 @@
    <event>
       <uei>uei.opennms.org/threshold/absoluteChangeExceeded</uei>
       <event-label>OpenNMS-defined threshold event: absoluteChangeExceeded</event-label>
-      <descr>%parm[all]%</descr>
+      <descr>A threshold alarm for the following metric occured: %parm[all]%</descr>
       <logmsg dest="logndisplay">
             Absolute change exceeded for service %service% metric %parm[ds]% on interface %parm[label]%/%interface%
         </logmsg>


### PR DESCRIPTION
* JIRA: https://issues.opennms.org/browse/NMS-10672

Here an example based on HIGH *threshold*.

**Current logmsg:**

> High threshold exceeded for SNMP datasource ifInOctets * 8 / 1000000 / ifHighSpeed * 100 on interface 172.21.65.4, parms: ifLabel="lo" ifIndex="1" label="lo" ds="ifInOctets * 8 / 1000000 / ifHighSpeed * 100" description="Trigger an alert if incoming usage of any interface reaches or goes above 90% of its maximum speed for three consecutive measurement intervals (only for interfaces that have a maximum speed value defined)" value="2591.77" instance="1" instanceLabel="lo" resourceType="if" resourceId="nodeSource[IT:frapevh004].interfaceSnmp[lo]" threshold="90.0" trigger="3" rearm="75.0" 


**New logmsg:**
> High threshold exceeded for SNMP metric ifInOctets * 8 / 1000000 / ifHighSpeed * 100 on interface lo/172.21.65.4

It's shortened and the important information is not missing.

**Current description:**

> High threshold exceeded for SNMP datasource ifInOctets * 8 / 1000000 / ifHighSpeed * 100 on interface 172.21.65.4, parms: ifLabel="lo" ifIndex="1" label="lo" ds="ifInOctets * 8 / 1000000 / ifHighSpeed * 100" description="Trigger an alert if incoming usage of any interface reaches or goes above 90% of its maximum speed for three consecutive measurement intervals (only for interfaces that have a maximum speed value defined)" value="2591.77" instance="1" instanceLabel="lo" resourceType="if" resourceId="nodeSource[IT:frapevh004].interfaceSnmp[lo]" threshold="90.0" trigger="3" rearm="75.0"
> 
> By default, OpenNMS watches some key parameters on devices in your network and will alert you with an event if certain conditions arise. For example, if the CPU utilization on your Cisco router maintains an inordinately high percentage of utilization for an extended period, an event will be generated. These thresholds are determined and configured based on vendor recommendations, tempered with real-world experience in working deployments.
> 
> This specific event indicates that a high threshold was exceeded.


**New description:**

> High threshold for the following metric exceeded: ifLabel="lo" ifIndex="1" label="lo" ds="ifInOctets * 8 / 1000000 / ifHighSpeed * 100" description="Trigger an alert if incoming usage of any interface reaches or goes above 90% of its maximum speed for three consecutive measurement intervals (only for interfaces that have a maximum speed value defined)" value="2591.77" instance="1" instanceLabel="lo" resourceType="if" resourceId="nodeSource[IT:frapevh004].interfaceSnmp[lo]" threshold="90.0" trigger="3" rearm="75.0"

It's only a %parm[all]% since it fits always/often.

I think we could also add a formatting like this (which I really like since it is much more clearer):
![grafik](https://user-images.githubusercontent.com/4995222/56963141-8b4ec480-6b58-11e9-8d53-74b1883f1efe.png)
(without the graph part)

but then we need to add HTML code for that like this:

```xml
HIgh threshold alarm for the following metric exceeded. &lt;br>&lt;table style='width:50%; white-space: nowrap;'>
        &lt;tr>&lt;td>Data Source&lt;/td>&lt;td>%parm[ds]%&lt;/td>&lt;/tr>
        &lt;tr>&lt;td>Resource Label&lt;/td>&lt;td>%parm[label]%&lt;/td>&lt;/tr>
        &lt;tr>&lt;td>Resource Instance&lt;/td>&lt;td>%parm[instance]%&lt;/td>&lt;/tr>
        &lt;tr>&lt;td>Current Metric Value&lt;/td>&lt;td>%parm[value]%&lt;/td>&lt;/tr>
        &lt;tr>&lt;td>Threshold Value&lt;/td>&lt;td>%parm[threshold]%&lt;/td>&lt;/tr>
        &lt;tr>&lt;td>Rearm Value&lt;/td>&lt;td>%parm[rearm]%&lt;/td>&lt;/tr>
        &lt;tr>&lt;td>Trigger Value&lt;/td>&lt;td>%parm[trigger]%&lt;/td>&lt;/tr>
&lt;/table>
```


