### PR TITLE
HZN-1557: Update Meta-Data documentation

### DIFF
--- a/opennms-doc/guide-admin/src/asciidoc/text/meta-data.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/meta-data.adoc
@@ -20,19 +20,19 @@ The following keys are available under this context:
 
 [options="header, autowidth"]
 |===
-| Context:Key            | Description |
-| `node:label`           | The label of the node
-| `node:foreign-source`  | The node's foreign source name
-| `node:foreign-id`      | The node's foreigne ID
-| `node:netbios-domain`  | The NetBIOS domain as provided by SNMP
-| `node:netbios-name`    | The NetBIOS name as provided by SNMP
-| `node:os`              | The node's operating system
-| `node:sys-name`        | The system name of the node
-| `node:sys-location`    | The system location of the node
-| `node:sys-contact`     | The system contact specified for the node
-| `node:sys-description` | The system description of the node
-| `node:location`        | The node's monitoring location name
-| `node:area`            | The node's monitoring location area
+| Context:Key            | Description                               |
+| `node:label`           | The label of the node                     |
+| `node:foreign-source`  | The node's foreign source name            |
+| `node:foreign-id`      | The node's foreigne ID                    |
+| `node:netbios-domain`  | The NetBIOS domain as provided by SNMP    |
+| `node:netbios-name`    | The NetBIOS name as provided by SNMP      |
+| `node:os`              | The node's operating system               |
+| `node:sys-name`        | The system name of the node               |
+| `node:sys-location`    | The system location of the node           |
+| `node:sys-contact`     | The system contact specified for the node |
+| `node:sys-description` | The system description of the node        |
+| `node:location`        | The node's monitoring location name       |
+| `node:area`            | The node's monitoring location area       |
 |===
 
 The `interface` context provides details about the interface currently processed.
@@ -40,14 +40,14 @@ The following keys are available under this context:
 
 [options="header, autowidth"]
 |===
-| Context:Key               | Description |
-| `interface:hostname       | The hostname associated with the IP address of the interface
-| `interface:address        | The IP address if the interface
-| `interface:netmask        | The netmask of the interface
-| `interface:if-index       | The SNMP interface index
-| `interface:if-alias       | The SNMP interface alias
-| `interface:if-description | The SNMP interface description
-| `interface:phy-addr       | The physical address of the interface
+| Context:Key                | Description                                                  |
+| `interface:hostname`       | The hostname associated with the IP address of the interface |
+| `interface:address`        | The IP address if the interface                              |
+| `interface:netmask`        | The netmask of the interface                                 |
+| `interface:if-index`       | The SNMP interface index                                     |
+| `interface:if-alias`       | The SNMP interface alias                                     |
+| `interface:if-description` | The SNMP interface description                               |
+| `interface:phy-addr`       | The physical address of the interface                        |
 |===
 
 The `service` context provides details about the service currently processed.
@@ -56,7 +56,7 @@ The following keys are available under this context:
 [options="header, autowidth"]
 |===
 | Context:Key        | Description |
-| `service:name      | The full name of the service
+| `service:name`     | The full name of the service |
 |===
 
 [[ga-meta-data-dsl]]


### PR DESCRIPTION
HZN-1557:Meta-Data Documentation Format Wrong

* JIRA: http://issues.opennms.org/browse/HZN-1557

Documentation formatting for meta-data context was incorrect.