### PR TITLE
NMS-10676: fix shell exit codes for stop/start

### DIFF
--- a/container/shared/src/main/resources/etc/container.init
+++ b/container/shared/src/main/resources/etc/container.init
@@ -90,6 +90,35 @@ run_as() {
 	fi
 }
 
+check_upgrade_files() {
+	for EXTENSION in rpmnew rpmsave dpkg-dist; do
+		if [ "$(find "$CONTAINER_HOME" -name \*."$EXTENSION" 2>/dev/null | wc -l)" -gt 0 ]; then
+			cat <<END >&2
+
+WARNING!  You have files that end in .$EXTENSION in your
+$CONTAINER_HOME directory.
+
+The format of the original files may have changed since
+you modified them before installing a new version.
+Please double-check that your configuration files are
+up-to-date and delete any leftover .$EXTENSION files or
+$DESC will not start.
+
+END
+			case "$COMMAND" in
+				status)
+					# when calling with `status` return 3 for "stopped"
+					return 3	# From LSB: 3 - program is stopped
+					;;
+				*)
+					# any other init command should return 6 on error
+					return 6	# From LSB: 6 - program is not configured
+					;;
+			esac
+		fi
+	done
+}
+
 get_root_pid() {
 	ROOT_INSTANCE_PID=0
 	if [ -f "$CONTAINER_HOME/instances/instance.properties" ];
@@ -132,6 +161,10 @@ case "$COMMAND" in
 		if is_running; then
 			echo "$DESC is running."
 			exit 0
+		fi
+
+		if ! check_upgrade_files; then
+			exit $?
 		fi
 
 		case "$PING_REQUIRED" in
@@ -192,6 +225,10 @@ case "$COMMAND" in
 		;;
 
 	restart)
+		if ! check_upgrade_files; then
+			exit $?
+		fi
+
 		$0 stop >/dev/null 2>&1
 		sleep 2
 		$0 start

--- a/debian/opennms-server.opennms.default
+++ b/debian/opennms-server.opennms.default
@@ -1,2 +1,0 @@
-# Set JAVA_HOME if it cannot be auto-detected
-#JAVA_HOME=/usr/lib/jvm/java-8-oracle

--- a/debian/opennms-server.opennms.init
+++ b/debian/opennms-server.opennms.init
@@ -56,16 +56,20 @@ export JAVA_HOME
 case "$1" in
   start)
 	echo -n "Starting $DESC: $NAME"
-	DAEMON_MESSAGES=$($DAEMON start)
+	DAEMON_MESSAGES="$($DAEMON start)"
+	__ret="$?"
 	# hide message if opennms says it's ok
-	echo $OUTPUT | grep -v "Starting OpenNMS: ok"
+	echo "$DAEMON_MESSAGES" | grep -v "Starting OpenNMS: ok"
 	echo "."
+	exit "$__ret"
 	;;
   stop)
 	echo -n "Stopping $DESC: $NAME"
-	DAEMON_MESSAGES=$($DAEMON stop)
+	DAEMON_MESSAGES="$($DAEMON stop)"
+	__ret="$?"
 	rm -f /var/run/$NAME.pid
 	echo "."
+	exit "$__ret"
 	;;
   restart|force-reload)
 	$0 stop

--- a/debian/opennms-server.postinst
+++ b/debian/opennms-server.postinst
@@ -13,9 +13,14 @@ case "$1" in
         ( grep -v JAVA_HOME /etc/default/opennms || : ) > /etc/default/opennms.new
         mv /etc/default/opennms.new /etc/default/opennms
 
+        # try to detect java if possible
+        if [ ! -e /etc/opennms/java.conf ]; then
+            /usr/share/opennms/bin/runjava -s || :
+        fi
+
         if [ -d "/usr/share/opennms/data" ]; then
-            find /usr/share/opennms/data/* -maxdepth 0 -name tmp -o -name history.txt -prune -o -print | xargs rm -rf
-            find /usr/share/opennms/data/tmp/* -maxdepth 0 -name README -prune -o -print | xargs rm -rf
+            find /usr/share/opennms/data/* -maxdepth 0 -name tmp -o -name history.txt -prune -o -print0 | xargs -0 rm -rf
+            find /usr/share/opennms/data/tmp/* -maxdepth 0 -name README -prune -o -print0 | xargs -0 rm -rf
         fi
 
         echo ""

--- a/debian/opennms-server.postinst
+++ b/debian/opennms-server.postinst
@@ -9,17 +9,9 @@ set -e
 
 case "$1" in
     configure)
-        for version in 8; do
-            for postfix in oracle sun openjdk; do
-                dir="/usr/lib/jvm/java-$version-$postfix"
-                if [ -x "$dir"/bin/java ]; then
-                    /usr/share/opennms/bin/runjava -q -S "$dir"/bin/java
-                    (grep -v ^JAVA_HOME /etc/default/opennms || : ; echo "JAVA_HOME='$dir'") > /etc/default/opennms.new
-                    mv /etc/default/opennms.new /etc/default/opennms
-                    break 2
-                fi
-            done
-        done
+        # NEVER override JAVA_HOME in /etc/default/opennms, let java.conf do its job
+        ( grep -v JAVA_HOME /etc/default/opennms || : ) > /etc/default/opennms.new
+        mv /etc/default/opennms.new /etc/default/opennms
 
         if [ -d "/usr/share/opennms/data" ]; then
             find /usr/share/opennms/data/* -maxdepth 0 -name tmp -o -name history.txt -prune -o -print | xargs rm -rf

--- a/opennms-base-assembly/src/main/filtered/bin/find-java.sh
+++ b/opennms-base-assembly/src/main/filtered/bin/find-java.sh
@@ -158,7 +158,7 @@ main() {
 	for dir in "${JAVA_SEARCH_DIRS[@]}"; do
 		if [ -e "${dir}" ]; then
 			[ -n "$DEBUG" ] && (>&2 printf 'Scanning: %s\n' "${dir}")
-			find "$dir" -type f -name java 2>/dev/null | grep -E '/bin/java$' | sort -u > /tmp/$$.javabins
+			find -L "$dir" -type f -name java 2>/dev/null | grep -E '/bin/java$' | sort -u > /tmp/$$.javabins
 			while read -r javabin; do
 				javabin="$(get_real_path "${javabin}")"
 				javahome="$(printf '%s' "${javabin}" | sed -e 's,/bin/java$,,')"

--- a/opennms-base-assembly/src/main/filtered/bin/opennms
+++ b/opennms-base-assembly/src/main/filtered/bin/opennms
@@ -204,7 +204,7 @@ checkXmlFiles(){
 
 	if [ -n "$XMLLINT" ] && [ -x "$XMLLINT" ]; then
 		TEMPFILE="$(getTempFile)"
-		find "$OPENNMS_HOME/etc" -type f -name \*.xml 2>/dev/null | while read -r "FILE"; do
+		find -L "$OPENNMS_HOME/etc" -type f -name \*.xml 2>/dev/null | while read -r "FILE"; do
 			if ! "$XMLLINT" "$FILE" >/dev/null 2>&1; then
 				echo "ERROR: XML validation failed: $FILE"
 				echo "	   run '$XMLLINT $FILE' for details"
@@ -229,7 +229,7 @@ checkXmlFiles(){
 	fi
 
 	TEMPFILE="$(getTempFile)"
-	find "$OPENNMS_HOME/etc/imports" -type f -name \*.xml 2>/dev/null | while read -r "FILE"; do
+	find -L "$OPENNMS_HOME/etc/imports" -type f -name \*.xml 2>/dev/null | while read -r "FILE"; do
 		if grep "non-ip-snmp-primary" "$FILE" >/dev/null 2>&1 || grep "non-ip-interfaces" "$FILE" >/dev/null 2>&1; then
 			echo "$FILE" >&2
 		fi
@@ -268,7 +268,7 @@ checkRpmFiles(){
 	done
 
 	for EXTENSION in rpmnew rpmsave dpkg-dist; do
-		if [ "$(find "$CHECKDIRS" -name \*."$EXTENSION" 2>/dev/null | wc -l)" -gt 0 ]; then
+		if [ "$(find -L "$CHECKDIRS" -name \*."$EXTENSION" 2>/dev/null | wc -l)" -gt 0 ]; then
 			cat <<END >&2
 
 WARNING!  You have files that end in .$EXTENSION in your

--- a/opennms-base-assembly/src/main/filtered/bin/opennms
+++ b/opennms-base-assembly/src/main/filtered/bin/opennms
@@ -231,11 +231,11 @@ checkXmlFiles(){
 	TEMPFILE="$(getTempFile)"
 	find -L "$OPENNMS_HOME/etc/imports" -type f -name \*.xml 2>/dev/null | while read -r "FILE"; do
 		if grep "non-ip-snmp-primary" "$FILE" >/dev/null 2>&1 || grep "non-ip-interfaces" "$FILE" >/dev/null 2>&1; then
-			echo "$FILE" >&2
+			echo "ERROR: Old attributes found: $FILE" >&2
 		fi
 	done >/dev/null 2>"$TEMPFILE"
 
-	FAILCOUNT="$(wc -l < "$TEMPFILE")"
+	FAILCOUNT="$(grep -c 'Old attributes found' < "$TEMPFILE")"
 	if [ "$FAILCOUNT" -gt 0 ]; then
 		cat <<END
 
@@ -259,17 +259,18 @@ END
 }
 
 checkRpmFiles(){
-	CHECKDIRS="$OPENNMS_HOME/etc"
+	CHECKDIRS=("$OPENNMS_HOME/etc")
 
 	for dir in "$OPENNMS_HOME"/*webapps/*; do
 		if [ -d "$dir/WEB-INF" ]; then
-			CHECKDIRS="$CHECKDIRS $dir/WEB-INF"
+			CHECKDIRS+=("$dir/WEB-INF")
 		fi
 	done
 
 	for EXTENSION in rpmnew rpmsave dpkg-dist; do
-		if [ "$(find -L "$CHECKDIRS" -name \*."$EXTENSION" 2>/dev/null | wc -l)" -gt 0 ]; then
-			cat <<END >&2
+		for CHECKDIR in "${CHECKDIRS[@]}"; do
+			if [ "$(find -L "$CHECKDIR" -name \*."$EXTENSION" 2>/dev/null | wc -l)" -gt 0 ]; then
+				cat <<END >&2
 
 WARNING!  You have files that end in .$EXTENSION in your
 OPENNMS_HOME ($OPENNMS_HOME) directory.
@@ -281,17 +282,18 @@ up-to-date and delete any leftover .$EXTENSION files or
 ${install.package.description} will not start.
 
 END
-			case "$COMMAND" in
-				status)
-					# when calling `opennms status` return 3 for "stopped"
-					return 3	# From LSB: 3 - program is stopped
-					;;
-				*)
-					# any other init command should return 6 on error
-					return 6	# From LSB: 6 - program is not configured
-					;;
-			esac
-		fi
+				case "$COMMAND" in
+					status)
+						# when calling `opennms status` return 3 for "stopped"
+						return 3	# From LSB: 3 - program is stopped
+						;;
+					*)
+						# any other init command should return 6 on error
+						return 6	# From LSB: 6 - program is not configured
+						;;
+				esac
+			fi
+		done
 	done
 
 	return 0

--- a/opennms-base-assembly/src/main/filtered/bin/opennms
+++ b/opennms-base-assembly/src/main/filtered/bin/opennms
@@ -398,7 +398,7 @@ doStart(){
 	###########################################################################
 	if [ "$TEST" -gt 0 ]; then
 		echo "- enabling JPDA debugging on port 8001" >&2
-		JPDA=("-agentlib:jdwp=transport=dt_socket,server=y,address=8001,suspend=n")
+		JPDA=("-agentlib:jdwp=transport=dt_socket,server=y,address=*:8001,suspend=n")
 	fi
 
 	# See: http://www.khelekore.org/jmp/tijmp/

--- a/opennms-base-assembly/src/main/filtered/bin/opennms
+++ b/opennms-base-assembly/src/main/filtered/bin/opennms
@@ -863,13 +863,14 @@ case "$COMMAND" in
 	start|spawn)
 		$opennms_echo "Starting ${install.package.description}: \c"
 
-		if [ -f /etc/SuSE-release ]; then
-			doStart "$@"
+		doStart "$@"
+		__ret="$?"
 
+		if [ -f /etc/SuSE-release ]; then
 			# Remember status and be verbose
 			rc_status -v
 		elif [ "$FUNCTIONS_LOADED" -ne 0 ]; then
-			if doStart "$@"; then
+			if [ "$__ret" -eq 0 ]; then
 				echo_success
 				if [ -w /var/lock/subsys ]; then
 					touch /var/lock/subsys/${NAME}
@@ -879,25 +880,31 @@ case "$COMMAND" in
 			fi
 			echo ""
 		else
-			if doStart "$@"; then
+			if [ "$__ret" -eq 0 ]; then
 				echo "ok"
 			else
 				echo "failed"
 			fi
 		fi
+		exit "$__ret"
 		;;
 
 	stop)
 		$opennms_echo "Stopping ${install.package.description}: \c"
-		if [ -f /etc/SuSE-release ]; then
-			doStop "$@"
 
+		doStop "$@"
+		__ret="$?"
+
+		if [ "$__ret" -gt 0 ]; then
+			doKill "$@"
+			__ret="$?"
+		fi
+
+		if [ -f /etc/SuSE-release ]; then
 			# Remember status and be verbose
 			rc_status -v
-
-			doKill "$@"
 		elif [ "$FUNCTIONS_LOADED" -ne 0 ]; then
-			if doStop "$@"; then
+			if [ "$__ret" -eq 0 ]; then
 				echo_success
 			else
 				echo_failure
@@ -906,17 +913,14 @@ case "$COMMAND" in
 				rm -f /var/lock/subsys/${NAME}
 			fi
 			echo ""
-
-			doKill "$@"
 		else
-			if doStop "$@"; then
+			if [ "$__ret" -eq 0 ]; then
 				echo "stopped"
 			else
 				echo "failed"
 			fi
-
-			doKill "$@"
 		fi
+		exit "$__ret"
 		;;
 
 	restart)

--- a/opennms-base-assembly/src/main/filtered/bin/opennms
+++ b/opennms-base-assembly/src/main/filtered/bin/opennms
@@ -309,6 +309,36 @@ checkLogDir(){
 	return 0
 }
 
+checkConfigured() {
+	if [ ! -f "$OPENNMS_HOME/etc/configured" ]; then
+		cat <<END >&2
+$0: ${install.package.description} not configured.
+$OPENNMS_HOME/etc/configured does not exist.
+
+You need to run the installer to set up the database.  In most
+cases, it is enough to run:
+
+  $OPENNMS_HOME/bin/install -dis
+
+For details, see the install guide at:
+
+http://www.opennms.org/index.php/QuickStart#Initialize_OpenNMS_and_the_Database
+
+END
+
+		case "$COMMAND" in
+			status)
+				# when calling `opennms status` return 3 for "stopped"
+				return 3	# From LSB: 3 - program is stopped
+				;;
+			*)
+				# any other init command should return 6 on error
+				return 6	# From LSB: 6 - program is not configured
+				;;
+		esac
+	fi
+}
+
 runCmd(){
 	if [ "$NOEXECUTE" -eq 1 ]; then
 		__tmp_array=()
@@ -322,9 +352,10 @@ runCmd(){
 }
 
 doStart(){
-	checkXmlFiles || return $?
-	checkRpmFiles || return $?
-	checkLogDir   || return $?
+	checkConfigured || return 1
+	checkXmlFiles   || return 1
+	checkRpmFiles   || return 1
+	checkLogDir     || return 1
 
 	doStatus "$@"
 	status=$?
@@ -823,34 +854,6 @@ fi
 
 if [ x"$VERBOSE_GC" != x"" ]; then
 	MANAGER_OPTIONS+=("-verbose:gc")
-fi
-
-if [ ! -f "$OPENNMS_HOME/etc/configured" ]; then
-	cat <<END >&2
-$0: ${install.package.description} not configured.
-$OPENNMS_HOME/etc/configured does not exist.
-
-You need to run the installer to set up the database.  In most
-cases, it is enough to run:
-
-  $OPENNMS_HOME/bin/install -dis
-
-For details, see the install guide at:
-
-http://www.opennms.org/index.php/QuickStart#Initialize_OpenNMS_and_the_Database
-
-END
-
-	case "$COMMAND" in
-		status)
-			# when calling `opennms status` return 3 for "stopped"
-			exit 3	# From LSB: 3 - program is stopped
-			;;
-		*)
-			# any other init command should return 6 on error
-			exit 6	# From LSB: 6 - program is not configured
-			;;
-	esac
 fi
 
 myuser="$(id -u -n)"

--- a/opennms-base-assembly/src/main/filtered/bin/runjava
+++ b/opennms-base-assembly/src/main/filtered/bin/runjava
@@ -227,7 +227,7 @@ javaPaths() {
                 # We search "j2*" for the Sun-supplied Java packages ("j2sdk"),
                 # "java" for the Java installation shipped with SuSE, and "Home"
                 # to catch /Library/Java/Home on Mac OS X.
-                jdirs="$(find "$searchdir" -maxdepth 3 \( -name "j2*" -o -name "jdk*" -o -name "java" -o -name "Home" \) -print 2>/dev/null)"
+                jdirs="$(find -L "$searchdir" -maxdepth 3 \( -name "j2*" -o -name "jdk*" -o -name "java" -o -name "Home" \) -print 2>/dev/null)"
                 for jdir in "$searchdir/java/default" "$searchdir/java/latest" $jdirs; do
                         if [ -x "$jdir/bin/java" ]; then
                                 JP="$jdir/bin/java"

--- a/opennms-base-assembly/src/test/shell/spec/opennms.spec.sh
+++ b/opennms-base-assembly/src/test/shell/spec/opennms.spec.sh
@@ -29,7 +29,7 @@ setUp() {
 	done
 
 	"$INSTPREFIX/bin/runjava" "-q" "-s"
-	assertEquals 'runjava should have succeeded' "$?" 0
+	assertEquals 'runjava should have succeeded' 0 "$?"
 
 	touch "$INSTPREFIX/etc/configured"
 	echo "STATUS_WAIT=1" > "$INSTPREFIX/etc/opennms.conf"
@@ -161,6 +161,33 @@ testJessieJavaConf() {
 	assertContains "$output" "'-XX:NumberOfGCLogFiles=4'"
 	assertContains "$output" "'-XX:GCLogFileSize=20M'"
 	assertContains "$output" "'-Xmx8196m'"
+}
+
+testRpmnewFailure() {
+	export OPENNMS_UNIT_TEST_STATUS=3
+	touch "$INSTPREFIX/etc/foo.rpmnew"
+	output="$(runOpennms -f start 2>&1)"
+	assertContains "$output" "The format of the original files may have changed since"
+	runOpennms -f start >/dev/null 2>&1
+	assertEquals '"opennms start" should have failed' 6 "$?"
+}
+
+testRpmsaveFailure() {
+	export OPENNMS_UNIT_TEST_STATUS=3
+	touch "$INSTPREFIX/etc/foo.rpmsave"
+	output="$(runOpennms -f start 2>&1)"
+	assertContains "$output" "The format of the original files may have changed since"
+	runOpennms -f start >/dev/null 2>&1
+	assertEquals '"opennms start" should have failed' 6 "$?"
+}
+
+testDpkgDistFailure() {
+	export OPENNMS_UNIT_TEST_STATUS=3
+	touch "$INSTPREFIX/etc/foo.dpkg-dist"
+	output="$(runOpennms -f start 2>&1)"
+	assertContains "$output" "The format of the original files may have changed since"
+	runOpennms -f start >/dev/null 2>&1
+	assertEquals '"opennms start" should have failed' 6 "$?"
 }
 
 . ../shunit2

--- a/opennms-base-assembly/src/test/shell/spec/opennms.spec.sh
+++ b/opennms-base-assembly/src/test/shell/spec/opennms.spec.sh
@@ -169,7 +169,7 @@ testRpmnewFailure() {
 	output="$(runOpennms -f start 2>&1)"
 	assertContains "$output" "The format of the original files may have changed since"
 	runOpennms -f start >/dev/null 2>&1
-	assertEquals '"opennms start" should have failed' 6 "$?"
+	assertEquals '"opennms start" should have failed' 1 "$?"
 }
 
 testRpmsaveFailure() {
@@ -178,7 +178,7 @@ testRpmsaveFailure() {
 	output="$(runOpennms -f start 2>&1)"
 	assertContains "$output" "The format of the original files may have changed since"
 	runOpennms -f start >/dev/null 2>&1
-	assertEquals '"opennms start" should have failed' 6 "$?"
+	assertEquals '"opennms start" should have failed' 1 "$?"
 }
 
 testDpkgDistFailure() {
@@ -187,7 +187,7 @@ testDpkgDistFailure() {
 	output="$(runOpennms -f start 2>&1)"
 	assertContains "$output" "The format of the original files may have changed since"
 	runOpennms -f start >/dev/null 2>&1
-	assertEquals '"opennms start" should have failed' 6 "$?"
+	assertEquals '"opennms start" should have failed' 1 "$?"
 }
 
 . ../shunit2


### PR DESCRIPTION
This PR fixes exit-code handling in a few of the functions and adds test coverage for `.rpmnew`/`.rpmsave`/`.dpkg-dist` checking.

* JIRA: http://issues.opennms.org/browse/NMS-10676

Our [continuous integration system](http://bamboo.internal.opennms.com:8085) will test and verify your changes.
