### PR TITLE
NMS-10677: custom.properties and karaf *.cfg files should be %config

### DIFF
--- a/tools/packages/minion/minion.spec
+++ b/tools/packages/minion/minion.spec
@@ -167,11 +167,27 @@ mv "%{buildroot}%{minioninstprefix}/etc/minion.conf" "%{buildroot}%{_sysconfdir}
 # container package files
 find %{buildroot}%{minioninstprefix} ! -type d | \
     grep -v %{minioninstprefix}/bin | \
+    grep -v %{minioninstprefix}/etc | \
     grep -v %{minionrepoprefix} | \
-    grep -v %{minioninstprefix}/etc/featuresBoot.d | \
-    grep -v %{minioninstprefix}/etc/org.opennms.minion.controller.cfg | \
     sed -e "s|^%{buildroot}|%attr(644,minion,minion) |" | \
     sort > %{_tmppath}/files.container
+
+# org.apache.karaf.features.cfg and org.ops4j.pax.logging.cfg should
+# be special-cased to not be replaced by default (and create .rpmnew files)
+find %{buildroot}%{minioninstprefix}/etc ! -type d | \
+    grep -E 'etc/(org.apache.karaf.features.cfg|org.ops4j.pax.logging.cfg)$' | \
+    sed -e "s|^%{buildroot}|%attr(644,minion,minion) %config(noreplace) |" | \
+    sort >> %{_tmppath}/files.container
+
+# all other etc files should replace by default (and create .rpmsave files)
+find %{buildroot}%{minioninstprefix}/etc ! -type d | \
+    grep -v etc/org.opennms. | \
+    grep -v etc/org.apache.karaf.features.cfg | \
+    grep -v etc/org.ops4j.pax.logging.cfg | \
+    grep -v etc/featuresBoot.d | \
+    sed -e "s|^%{buildroot}|%attr(644,minion,minion) %config |" | \
+    sort >> %{_tmppath}/files.container
+
 find %{buildroot}%{minioninstprefix}/bin ! -type d | \
     sed -e "s|^%{buildroot}|%attr(755,minion,minion) |" | \
     sort >> %{_tmppath}/files.container

--- a/tools/packages/opennms/opennms.spec
+++ b/tools/packages/opennms/opennms.spec
@@ -621,6 +621,8 @@ cd %{buildroot}
 # core package files
 find %{buildroot}%{instprefix}/etc ! -type d | \
 	sed -e "s,^%{buildroot},%config(noreplace) ," | \
+	grep -v -E 'etc/.*.cfg$' | \
+	grep -v 'etc/custom.properties' | \
 	grep -v '%{_initrddir}/opennms-remote-poller' | \
 	grep -v '%{_sysconfdir}/sysconfig/opennms-remote-poller' | \
 	grep -v 'jira.properties' | \
@@ -639,6 +641,14 @@ find %{buildroot}%{instprefix}/etc ! -type d | \
 	grep -v 'xmp-datacollection-config.xml' | \
 	grep -v 'tca-datacollection-config.xml' | \
 	sort > %{_tmppath}/files.main
+find %{buildroot}%{instprefix}/etc ! -type d -name \*.cfg | \
+	grep -v 'etc/org.opennms' | \
+	sed -e "s,^%{buildroot},%config ," | \
+	sort >> %{_tmppath}/files.main
+find %{buildroot}%{instprefix}/etc ! -type d -name \*.cfg | \
+	grep 'etc/org.opennms' | \
+	sed -e "s,^%{buildroot},%config(noreplace) ," | \
+	sort >> %{_tmppath}/files.main
 find %{buildroot}%{sharedir}/etc-pristine ! -type d | \
 	sed -e "s,^%{buildroot},," | \
 	grep -v '%{_initrddir}/opennms-remote-poller' | \
@@ -739,6 +749,7 @@ rm -rf %{buildroot}
 %defattr(664 root root 775)
 %attr(755,root,root)	%{profiledir}/%{name}.sh
 %attr(755,root,root)	%{logdir}
+                        %config %{instprefix}/etc/custom.properties
 %attr(640,root,root)	%config(noreplace) %{instprefix}/etc/users.xml
 			%{instprefix}/data
 			%{instprefix}/deploy

--- a/tools/packages/sentinel/sentinel.spec
+++ b/tools/packages/sentinel/sentinel.spec
@@ -125,13 +125,30 @@ mv "%{buildroot}%{sentinelinstprefix}/etc/sentinel.conf" "%{buildroot}%{_sysconf
 # sentinel package files
 find %{buildroot}%{sentinelinstprefix} ! -type d | \
     grep -v %{sentinelinstprefix}/bin | \
+    grep -v %{sentinelinstprefix}/etc | \
     grep -v %{sentinelrepoprefix} | \
-    grep -v %{sentinelinstprefix}/etc/featuresBoot.d | \
     sed -e "s|^%{buildroot}|%attr(644,sentinel,sentinel) |" | \
     sort > %{_tmppath}/files.sentinel
+
+# org.apache.karaf.features.cfg and org.ops4j.pax.logging.cfg should
+# be special-cased to not be replaced by default (and create .rpmnew files)
+find %{buildroot}%{sentinelinstprefix}/etc ! -type d | \
+    grep -E 'etc/(org.apache.karaf.features.cfg|org.ops4j.pax.logging.cfg)$' | \
+    sed -e "s|^%{buildroot}|%attr(644,sentinel,sentinel) %config(noreplace) |" | \
+    sort >> %{_tmppath}/files.sentinel
+
+# all other etc files should replace by default (and create .rpmsave files)
+find %{buildroot}%{sentinelinstprefix}/etc ! -type d | \
+    grep -v etc/org.apache.karaf.features.cfg | \
+    grep -v etc/org.ops4j.pax.logging.cfg | \
+    grep -v etc/featuresBoot.d | \
+    sed -e "s|^%{buildroot}|%attr(644,sentinel,sentinel) %config |" | \
+    sort >> %{_tmppath}/files.sentinel
+
 find %{buildroot}%{sentinelinstprefix}/bin ! -type d | \
     sed -e "s|^%{buildroot}|%attr(755,sentinel,sentinel) |" | \
     sort >> %{_tmppath}/files.sentinel
+
 # Exclude subdirs of the repository directory
 find %{buildroot}%{sentinelinstprefix} -type d | \
     grep -v %{sentinelrepoprefix}/ | \


### PR DESCRIPTION
This PR changes it so that the following config files will overwrite their existing counterparts by default, creating an `.rpmsave` file:

* `custom.properties`
* `jmx.*.cfg`
* `org.apache.*.cfg`
* `org.ops4j.*.cfg`
* `profile.cfg`

Anything that matches `org.opennms.*.cfg` will _not_ be replaced by default, instead creating an `.rpmnew` file.

*feedback wanted:* should I exclude `org.ops4j.pax.logging.cfg` since it's a reasonably common thing to override?  Or leave it in the "create `.rpmsave` by default" category?

* JIRA: http://issues.opennms.org/browse/NMS-10677

Our [continuous integration system](http://bamboo.internal.opennms.com:8085) will test and verify your changes.
