### PR TITLE
HZN-1551: View traffic for specific applications over time (flows) (backend)

### DIFF
--- a/features/flows/api/src/main/java/org/opennms/netmgt/flows/api/FlowRepository.java
+++ b/features/flows/api/src/main/java/org/opennms/netmgt/flows/api/FlowRepository.java
@@ -30,7 +30,6 @@ package org.opennms.netmgt.flows.api;
 
 import java.util.Collection;
 import java.util.List;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
 import org.opennms.netmgt.flows.filter.api.Filter;
@@ -43,8 +42,12 @@ public interface FlowRepository {
 
     CompletableFuture<Long> getFlowCount(List<Filter> filters);
 
+    CompletableFuture<List<String>> getApplications(String matchingPrefix, long limit, List<Filter> filters);
+    
     CompletableFuture<List<TrafficSummary<String>>> getTopNApplications(int N, boolean includeOther, List<Filter> filters);
 
+    CompletableFuture<Table<Directional<String>, Long, Double>> getApplicationSeries(List<String> applications, long step, boolean includeOther, List<Filter> filters);
+    
     CompletableFuture<Table<Directional<String>, Long, Double>> getTopNApplicationsSeries(int N, long step, boolean includeOther, List<Filter> filters);
 
     CompletableFuture<List<TrafficSummary<ConversationKey>>> getTopNConversations(int N, List<Filter> filters);

--- a/features/flows/api/src/main/java/org/opennms/netmgt/flows/api/FlowRepository.java
+++ b/features/flows/api/src/main/java/org/opennms/netmgt/flows/api/FlowRepository.java
@@ -30,6 +30,7 @@ package org.opennms.netmgt.flows.api;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
 import org.opennms.netmgt.flows.filter.api.Filter;
@@ -44,9 +45,11 @@ public interface FlowRepository {
 
     CompletableFuture<List<String>> getApplications(String matchingPrefix, long limit, List<Filter> filters);
     
-    CompletableFuture<List<TrafficSummary<String>>> getTopNApplications(int N, boolean includeOther, List<Filter> filters);
+    CompletableFuture<List<TrafficSummary<String>>> getTopNApplicationSummaries(int N, boolean includeOther, List<Filter> filters);
 
-    CompletableFuture<Table<Directional<String>, Long, Double>> getApplicationSeries(List<String> applications, long step, boolean includeOther, List<Filter> filters);
+    CompletableFuture<List<TrafficSummary<String>>> getApplicationSummaries(Set<String> applications, boolean includeOther, List<Filter> filters);
+
+    CompletableFuture<Table<Directional<String>, Long, Double>> getApplicationSeries(Set<String> applications, long step, boolean includeOther, List<Filter> filters);
     
     CompletableFuture<Table<Directional<String>, Long, Double>> getTopNApplicationsSeries(int N, long step, boolean includeOther, List<Filter> filters);
 

--- a/features/flows/elastic/src/main/java/org/opennms/netmgt/flows/elastic/ElasticFlowRepository.java
+++ b/features/flows/elastic/src/main/java/org/opennms/netmgt/flows/elastic/ElasticFlowRepository.java
@@ -70,6 +70,7 @@ import com.codahale.metrics.Histogram;
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableTable;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -294,12 +295,19 @@ public class ElasticFlowRepository implements FlowRepository {
     }
 
     @Override
-    public CompletableFuture<List<TrafficSummary<String>>> getTopNApplications(int N, boolean includeOther, List<Filter> filters) {
+    public CompletableFuture<List<TrafficSummary<String>>> getTopNApplicationSummaries(int N, boolean includeOther, List<Filter> filters) {
         return getTotalBytesFromTopN(N, "netflow.application", UNKNOWN_APPLICATION_NAME, includeOther, filters);
     }
 
     @Override
-    public CompletableFuture<Table<Directional<String>, Long, Double>> getApplicationSeries(List<String> applications, long step, boolean includeOther, List<Filter> filters) {
+    public CompletableFuture<List<TrafficSummary<String>>> getApplicationSummaries(Set<String> applications,
+                                                                                   boolean includeOther,
+                                                                                   List<Filter> filters) {
+        return getTotalBytesFromApplications(applications, includeOther, filters);
+    }
+
+    @Override
+    public CompletableFuture<Table<Directional<String>, Long, Double>> getApplicationSeries(Set<String> applications, long step, boolean includeOther, List<Filter> filters) {
         return getSeriesForApplications(applications, step, includeOther, filters).thenApply((res) -> mapTable(res, s -> s));
     }
 
@@ -342,7 +350,7 @@ public class ElasticFlowRepository implements FlowRepository {
                 .thenApply(res -> processGroupedByResult(res, N));
     }
 
-    private CompletableFuture<Table<Directional<String>, Long, Double>> getSeriesForApplications(List<String> applications,
+    private CompletableFuture<Table<Directional<String>, Long, Double>> getSeriesForApplications(Set<String> applications,
                                                                                                  long step,
                                                                                                  boolean includeOther,
                                                                                                  List<Filter> filters) {
@@ -365,7 +373,7 @@ public class ElasticFlowRepository implements FlowRepository {
         
         if (includeOther) {
             // We also want to gather series for all other terms
-            final String seriesFromOthersQuery = searchQueryProvider.getSeriesFromOthersQuery(applications, step,
+            final String seriesFromOthersQuery = searchQueryProvider.getSeriesFromOtherApplicationsQuery(applications, step,
                     timeRangeFilter.getStart(), timeRangeFilter.getEnd(), filters);
             seriesFuture = seriesFuture.thenCombine(searchAsync(seriesFromOthersQuery, timeRangeFilter),
                     (ignored,res) -> processOthersResult(res, builder));
@@ -384,7 +392,7 @@ public class ElasticFlowRepository implements FlowRepository {
             // If there are no entries, skip the query
             seriesFuture = CompletableFuture.completedFuture(null);
         } else {
-            final String seriesFromTopNQuery = searchQueryProvider.getSeriesFromTopNQuery(topN, step, timeRangeFilter.getStart(),
+            final String seriesFromTopNQuery = searchQueryProvider.getSeriesFromQuery(topN, step, timeRangeFilter.getStart(),
                     timeRangeFilter.getEnd(), groupByTerm, filters);
             seriesFuture = searchAsync(seriesFromTopNQuery, timeRangeFilter)
                     .thenApply(res -> {
@@ -471,9 +479,9 @@ public class ElasticFlowRepository implements FlowRepository {
                 .thenCompose((topN) -> getSeriesFromTopN(topN, step, groupByTerm, keyForMissingTerm, includeOther, filters));
     }
 
-    private CompletableFuture<List<TrafficSummary<String>>> getTotalBytesFromTopN(List<String> topN, String groupByTerm,
-                                                                                  String keyForMissingTerm,
-                                                                                  boolean includeOther, List<Filter> filters) {
+    private CompletableFuture<List<TrafficSummary<String>>> getTotalBytesFrom(List<String> from, String groupByTerm,
+                                                                              String keyForMissingTerm,
+                                                                              boolean includeOther, List<Filter> filters) {
         final TimeRangeFilter timeRangeFilter = getRequiredTimeRangeFilter(filters);
         final long start = timeRangeFilter.getStart();
         // Remove 1 from the end to make sure we have a single bucket
@@ -482,16 +490,16 @@ public class ElasticFlowRepository implements FlowRepository {
         final long step = timeRangeFilter.getEnd() - timeRangeFilter.getStart();
 
         CompletableFuture<Map<String, TrafficSummary<String>>> summariesFuture;
-        if (topN.size() < 1) {
+        if (from.size() < 1) {
             // If there are no entries, skip the query
             summariesFuture = CompletableFuture.completedFuture(new LinkedHashMap<>());
         } else {
-            final String bytesFromTopNQuery = searchQueryProvider.getSeriesFromTopNQuery(topN, step, start, end, groupByTerm, filters);
-            summariesFuture = searchAsync(bytesFromTopNQuery, timeRangeFilter).thenApply(ElasticFlowRepository::toTrafficSummaries);
+            final String bytesFromQuery = searchQueryProvider.getSeriesFromQuery(from, step, start, end, groupByTerm, filters);
+            summariesFuture = searchAsync(bytesFromQuery, timeRangeFilter).thenApply(ElasticFlowRepository::toTrafficSummaries);
         }
 
-        final boolean missingTermIncludedInTopN = keyForMissingTerm != null && topN.contains(keyForMissingTerm);
-        if (missingTermIncludedInTopN) {
+        final boolean missingTermIncluded = keyForMissingTerm != null && from.contains(keyForMissingTerm);
+        if (missingTermIncluded) {
             // We also need to query for items with a missing term, this will require a separate query
             final String bytesFromMissingQuery = searchQueryProvider.getSeriesFromMissingQuery(step, start, end,
                     groupByTerm, keyForMissingTerm, filters);
@@ -503,8 +511,8 @@ public class ElasticFlowRepository implements FlowRepository {
 
         if (includeOther) {
             // We also want to tally up traffic from other elements not part of the Top N
-            final String bytesFromOthersQuery = searchQueryProvider.getSeriesFromOthersQuery(topN, step, start, end,
-                    groupByTerm, missingTermIncludedInTopN, filters);
+            final String bytesFromOthersQuery = searchQueryProvider.getSeriesFromOthersQuery(from, step, start, end,
+                    groupByTerm, missingTermIncluded, filters);
             summariesFuture = summariesFuture.thenCombine(searchAsync(bytesFromOthersQuery, timeRangeFilter), (summaries,results) -> {
                 final MetricAggregation aggs = results.getAggregations();
                 if (aggs == null) {
@@ -539,8 +547,8 @@ public class ElasticFlowRepository implements FlowRepository {
 
         return summariesFuture.thenApply(summaries -> {
             // Now build a list in the same order as the given top N list
-            final List<TrafficSummary<String>> topNRes = new ArrayList<>(topN.size());
-            for (String topNEntry : topN) {
+            final List<TrafficSummary<String>> topNRes = new ArrayList<>(from.size());
+            for (String topNEntry : from) {
                 final TrafficSummary<String> summary = summaries.remove(topNEntry);
                 if (summary != null) {
                     topNRes.add(summary);
@@ -590,7 +598,14 @@ public class ElasticFlowRepository implements FlowRepository {
 
     private CompletableFuture<List<TrafficSummary<String>>> getTotalBytesFromTopN(int N, String groupByTerm, String keyForMissingTerm, boolean includeOther, List<Filter> filters) {
         return getTopN(N, groupByTerm, keyForMissingTerm, filters)
-                .thenCompose((topN) -> getTotalBytesFromTopN(topN, groupByTerm, keyForMissingTerm, includeOther, filters));
+                .thenCompose((topN) -> getTotalBytesFrom(topN, groupByTerm, keyForMissingTerm, includeOther, filters));
+    }
+
+    private CompletableFuture<List<TrafficSummary<String>>> getTotalBytesFromApplications(Set<String> applications,
+                                                                                          boolean includeOther,
+                                                                                          List<Filter> filters) {
+        return getTotalBytesFrom(ImmutableList.copyOf(applications), "netflow.application", null, includeOther,
+                filters);
     }
 
     private CompletableFuture<SearchResult> searchAsync(String query, TimeRangeFilter timeRangeFilter) {

--- a/features/flows/elastic/src/main/java/org/opennms/netmgt/flows/elastic/ElasticFlowRepository.java
+++ b/features/flows/elastic/src/main/java/org/opennms/netmgt/flows/elastic/ElasticFlowRepository.java
@@ -53,9 +53,6 @@ import org.opennms.netmgt.flows.api.FlowRepository;
 import org.opennms.netmgt.flows.api.FlowSource;
 import org.opennms.netmgt.flows.api.TrafficSummary;
 import org.opennms.netmgt.flows.classification.ClassificationEngine;
-import org.opennms.netmgt.flows.classification.ClassificationRequest;
-import org.opennms.netmgt.flows.classification.persistence.api.Protocol;
-import org.opennms.netmgt.flows.classification.persistence.api.Protocols;
 import org.opennms.netmgt.flows.filter.api.Filter;
 import org.opennms.netmgt.flows.filter.api.TimeRangeFilter;
 import org.opennms.netmgt.model.OnmsNode;
@@ -291,8 +288,19 @@ public class ElasticFlowRepository implements FlowRepository {
     }
 
     @Override
+    public CompletableFuture<List<String>> getApplications(String matchingPrefix, long limit, List<Filter> filters) {
+        final String query = searchQueryProvider.getApplicationsQuery(matchingPrefix, limit, filters);
+        return searchAsync(query, extractTimeRangeFilter(filters)).thenApply(res -> processGroupedByResult(res, limit));
+    }
+
+    @Override
     public CompletableFuture<List<TrafficSummary<String>>> getTopNApplications(int N, boolean includeOther, List<Filter> filters) {
         return getTotalBytesFromTopN(N, "netflow.application", UNKNOWN_APPLICATION_NAME, includeOther, filters);
+    }
+
+    @Override
+    public CompletableFuture<Table<Directional<String>, Long, Double>> getApplicationSeries(List<String> applications, long step, boolean includeOther, List<Filter> filters) {
+        return getSeriesForApplications(applications, step, includeOther, filters).thenApply((res) -> mapTable(res, s -> s));
     }
 
     @Override
@@ -331,22 +339,39 @@ public class ElasticFlowRepository implements FlowRepository {
         final int multiplier = 2;
         final String query = searchQueryProvider.getTopNQuery(multiplier*N, groupByTerm, keyForMissingTerm, filters);
         return searchAsync(query, extractTimeRangeFilter(filters))
+                .thenApply(res -> processGroupedByResult(res, N));
+    }
+
+    private CompletableFuture<Table<Directional<String>, Long, Double>> getSeriesForApplications(List<String> applications,
+                                                                                                 long step,
+                                                                                                 boolean includeOther,
+                                                                                                 List<Filter> filters) {
+        if (applications == null || applications.isEmpty()) {
+            return CompletableFuture.completedFuture(null);
+        }
+        
+        final TimeRangeFilter timeRangeFilter = getRequiredTimeRangeFilter(filters);
+        final ImmutableTable.Builder<Directional<String>, Long, Double> builder = ImmutableTable.builder();
+        final String seriesFromApplicationQuery = searchQueryProvider.getSeriesForApplicationQuery(applications, step,
+                timeRangeFilter.getStart(),
+                timeRangeFilter.getEnd(), filters);
+        CompletableFuture<Void> seriesFuture;
+
+        seriesFuture = searchAsync(seriesFromApplicationQuery, timeRangeFilter)
                 .thenApply(res -> {
-                    final MetricAggregation aggs = res.getAggregations();
-                    if (aggs == null) {
-                        // No results
-                        return Collections.emptyList();
-                    }
-                    final TermsAggregation groupedBy = aggs.getTermsAggregation("grouped_by");
-                    if (groupedBy == null) {
-                        // No results
-                        return Collections.emptyList();
-                    }
-                    return groupedBy.getBuckets().stream()
-                            .map(TermsAggregation.Entry::getKey)
-                            .limit(N)
-                            .collect(Collectors.toList());
+                    toTable(builder, res);
+                    return null;
                 });
+        
+        if (includeOther) {
+            // We also want to gather series for all other terms
+            final String seriesFromOthersQuery = searchQueryProvider.getSeriesFromOthersQuery(applications, step,
+                    timeRangeFilter.getStart(), timeRangeFilter.getEnd(), filters);
+            seriesFuture = seriesFuture.thenCombine(searchAsync(seriesFromOthersQuery, timeRangeFilter),
+                    (ignored,res) -> processOthersResult(res, builder));
+        }
+        
+        return seriesFuture.thenApply(ignored -> builder.build());
     }
 
     private CompletableFuture<Table<Directional<String>, Long, Double>> getSeriesFromTopN(List<String> topN, long step, String groupByTerm,
@@ -384,30 +409,36 @@ public class ElasticFlowRepository implements FlowRepository {
             // We also want to gather series for terms not part of the Top N
             final String seriesFromOthersQuery = searchQueryProvider.getSeriesFromOthersQuery(topN, step,
                     timeRangeFilter.getStart(), timeRangeFilter.getEnd(), groupByTerm, missingTermIncludedInTopN, filters);
-            seriesFuture = seriesFuture.thenCombine(searchAsync(seriesFromOthersQuery, timeRangeFilter), (ignored,res) -> {
-                final MetricAggregation aggs = res.getAggregations();
-                if (aggs == null) {
-                    // No results
-                    return null;
-                }
-                final TermsAggregation directionAgg = aggs.getTermsAggregation("direction");
-                if (directionAgg == null) {
-                    // No results
-                    return null;
-                }
-                for (TermsAggregation.Entry directionBucket : directionAgg.getBuckets()) {
-                    final boolean isIngress = isIngress(directionBucket);
-                    final ProportionalSumAggregation sumAgg = directionBucket.getAggregation("bytes", ProportionalSumAggregation.class);
-                    for (ProportionalSumAggregation.DateHistogram dateHistogram : sumAgg.getBuckets()) {
-                        builder.put(new Directional<>(OTHER_APPLICATION_NAME, isIngress), dateHistogram.getTime(), dateHistogram.getValue());
-                    }
-                }
-                return null;
-            });
+            seriesFuture = seriesFuture.thenCombine(searchAsync(seriesFromOthersQuery, timeRangeFilter),
+                    (ignored,res) -> processOthersResult(res, builder));
         }
 
         // Sort the table to ensure that the rows as in the same order as the Top N
         return seriesFuture.thenApply(ignored -> TableUtils.sortTableByRowKeys(builder.build(), topN));
+    }
+
+    private Void processOthersResult(SearchResult res,
+                                     ImmutableTable.Builder<Directional<String>, Long, Double> builder) {
+        final MetricAggregation aggs = res.getAggregations();
+        if (aggs == null) {
+            // No results
+            return null;
+        }
+        final TermsAggregation directionAgg = aggs.getTermsAggregation("direction");
+        if (directionAgg == null) {
+            // No results
+            return null;
+        }
+        for (TermsAggregation.Entry directionBucket : directionAgg.getBuckets()) {
+            final boolean isIngress = isIngress(directionBucket);
+            final ProportionalSumAggregation sumAgg = directionBucket.getAggregation("bytes",
+                    ProportionalSumAggregation.class);
+            for (ProportionalSumAggregation.DateHistogram dateHistogram : sumAgg.getBuckets()) {
+                builder.put(new Directional<>(OTHER_APPLICATION_NAME, isIngress), dateHistogram.getTime(),
+                        dateHistogram.getValue());
+            }
+        }
+        return null;
     }
 
     private static void toTable(ImmutableTable.Builder<Directional<String>, Long, Double> builder, SearchResult res) {
@@ -594,6 +625,23 @@ public class ElasticFlowRepository implements FlowRepository {
             }
         });
         return future;
+    }
+
+    private List<String> processGroupedByResult(SearchResult searchResult, long limit) {
+        final MetricAggregation aggs = searchResult.getAggregations();
+        if (aggs == null) {
+            // No results
+            return Collections.emptyList();
+        }
+        final TermsAggregation groupedBy = aggs.getTermsAggregation("grouped_by");
+        if (groupedBy == null) {
+            // No results
+            return Collections.emptyList();
+        }
+        return groupedBy.getBuckets().stream()
+                .map(TermsAggregation.Entry::getKey)
+                .limit(limit)
+                .collect(Collectors.toList());
     }
 
     /**

--- a/features/flows/elastic/src/main/java/org/opennms/netmgt/flows/elastic/InitializingFlowRepository.java
+++ b/features/flows/elastic/src/main/java/org/opennms/netmgt/flows/elastic/InitializingFlowRepository.java
@@ -31,6 +31,7 @@ package org.opennms.netmgt.flows.elastic;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
 import org.opennms.netmgt.flows.api.ConversationKey;
@@ -87,7 +88,7 @@ public class InitializingFlowRepository implements FlowRepository {
     }
 
     @Override
-    public CompletableFuture<Table<Directional<String>, Long, Double>> getApplicationSeries(List<String> applications,
+    public CompletableFuture<Table<Directional<String>, Long, Double>> getApplicationSeries(Set<String> applications,
                                                                                             long step,
                                                                                             boolean includeOther,
                                                                                             List<Filter> filters) {
@@ -95,8 +96,15 @@ public class InitializingFlowRepository implements FlowRepository {
     }
 
     @Override
-    public CompletableFuture<List<TrafficSummary<String>>> getTopNApplications(int N, boolean includeOther, List<Filter> filters) {
-        return delegate.getTopNApplications(N, includeOther, filters);
+    public CompletableFuture<List<TrafficSummary<String>>> getTopNApplicationSummaries(int N, boolean includeOther, List<Filter> filters) {
+        return delegate.getTopNApplicationSummaries(N, includeOther, filters);
+    }
+
+    @Override
+    public CompletableFuture<List<TrafficSummary<String>>> getApplicationSummaries(Set<String> applications,
+                                                                                   boolean includeOther,
+                                                                                   List<Filter> filters) {
+        return delegate.getApplicationSummaries(applications, includeOther, filters);
     }
 
     @Override

--- a/features/flows/elastic/src/main/java/org/opennms/netmgt/flows/elastic/InitializingFlowRepository.java
+++ b/features/flows/elastic/src/main/java/org/opennms/netmgt/flows/elastic/InitializingFlowRepository.java
@@ -82,6 +82,19 @@ public class InitializingFlowRepository implements FlowRepository {
     }
 
     @Override
+    public CompletableFuture<List<String>> getApplications(String matchingPrefix, long limit, List<Filter> filters) {
+        return delegate.getApplications(matchingPrefix, limit, filters);
+    }
+
+    @Override
+    public CompletableFuture<Table<Directional<String>, Long, Double>> getApplicationSeries(List<String> applications,
+                                                                                            long step,
+                                                                                            boolean includeOther,
+                                                                                            List<Filter> filters) {
+        return delegate.getApplicationSeries(applications, step, includeOther, filters);
+    }
+
+    @Override
     public CompletableFuture<List<TrafficSummary<String>>> getTopNApplications(int N, boolean includeOther, List<Filter> filters) {
         return delegate.getTopNApplications(N, includeOther, filters);
     }

--- a/features/flows/elastic/src/main/java/org/opennms/netmgt/flows/elastic/SearchQueryProvider.java
+++ b/features/flows/elastic/src/main/java/org/opennms/netmgt/flows/elastic/SearchQueryProvider.java
@@ -34,6 +34,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.opennms.netmgt.flows.filter.api.ExporterNodeFilter;
@@ -98,11 +99,11 @@ public class SearchQueryProvider implements FilterVisitor<String> {
                 .build());
     }
 
-    public String getSeriesFromTopNQuery(List<String> topN, long step, long start, long end,
-                                         String groupByTerm, List<Filter> filters) {
+    public String getSeriesFromQuery(List<String> from, long step, long start, long end,
+                                     String groupByTerm, List<Filter> filters) {
         return render("series_for_terms.ftl", ImmutableMap.builder()
                 .put("filters", getFilterQueries(filters))
-                .put("topN", topN)
+                .put("from", from)
                 .put("groupByTerm", groupByTerm)
                 .put("step", step)
                 .put("start", start)
@@ -110,7 +111,7 @@ public class SearchQueryProvider implements FilterVisitor<String> {
                 .build());
     }
 
-    public String getSeriesForApplicationQuery(List<String> applications, long step, long start, long end,
+    public String getSeriesForApplicationQuery(Set<String> applications, long step, long start, long end,
                                                List<Filter> filters) {
         return render("series_for_applications.ftl", ImmutableMap.builder()
                 .put("filters", getFilterQueries(filters))
@@ -133,12 +134,12 @@ public class SearchQueryProvider implements FilterVisitor<String> {
                 .build());
     }
 
-    public String getSeriesFromOthersQuery(List<String> topN, long step, long start, long end,
+    public String getSeriesFromOthersQuery(List<String> from, long step, long start, long end,
                                            String groupByTerm, boolean excludeMissing,
                                            List<Filter> filters) {
         return render("series_for_others.ftl", ImmutableMap.builder()
                 .put("filters", getFilterQueries(filters))
-                .put("topN", topN)
+                .put("from", from)
                 .put("groupByTerm", groupByTerm)
                 .put("excludeMissing", excludeMissing)
                 .put("step", step)
@@ -147,8 +148,8 @@ public class SearchQueryProvider implements FilterVisitor<String> {
                 .build());
     }
 
-    public String getSeriesFromOthersQuery(List<String> applications, long step, long start, long end,
-                                           List<Filter> filters) {
+    public String getSeriesFromOtherApplicationsQuery(Set<String> applications, long step, long start, long end,
+                                                      List<Filter> filters) {
         return render("series_for_others_applications.ftl", ImmutableMap.builder()
                 .put("filters", getFilterQueries(filters))
                 .put("applications", applications)

--- a/features/flows/elastic/src/main/java/org/opennms/netmgt/flows/elastic/SearchQueryProvider.java
+++ b/features/flows/elastic/src/main/java/org/opennms/netmgt/flows/elastic/SearchQueryProvider.java
@@ -33,6 +33,7 @@ import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import org.opennms.netmgt.flows.filter.api.ExporterNodeFilter;
@@ -109,6 +110,17 @@ public class SearchQueryProvider implements FilterVisitor<String> {
                 .build());
     }
 
+    public String getSeriesForApplicationQuery(List<String> applications, long step, long start, long end,
+                                               List<Filter> filters) {
+        return render("series_for_applications.ftl", ImmutableMap.builder()
+                .put("filters", getFilterQueries(filters))
+                .put("applications", applications)
+                .put("step", step)
+                .put("start", start)
+                .put("end", end)
+                .build());
+    }
+
     public String getSeriesFromMissingQuery(long step, long start, long end, String groupByTerm,
                                             String keyForMissingTerm, List<Filter> filters) {
         return render("series_for_missing.ftl", ImmutableMap.builder()
@@ -132,6 +144,28 @@ public class SearchQueryProvider implements FilterVisitor<String> {
                 .put("step", step)
                 .put("start", start)
                 .put("end", end)
+                .build());
+    }
+
+    public String getSeriesFromOthersQuery(List<String> applications, long step, long start, long end,
+                                           List<Filter> filters) {
+        return render("series_for_others_applications.ftl", ImmutableMap.builder()
+                .put("filters", getFilterQueries(filters))
+                .put("applications", applications)
+                .put("step", step)
+                .put("start", start)
+                .put("end", end)
+                .build());
+    }
+
+    public String getApplicationsQuery(String prefix, long limit, List<Filter> filters) {
+        Objects.requireNonNull(prefix);
+        Objects.requireNonNull(filters);
+        return render("aggregate_by_fuzzed_field.ftl", ImmutableMap.builder()
+                .put("filters", getFilterQueries(filters))
+                .put("N", limit)
+                .put("field", "netflow.application")
+                .put("prefix", prefix)
                 .build());
     }
 

--- a/features/flows/elastic/src/main/resources/org/opennms/netmgt/flows/elastic/aggregate_by_fuzzed_field.ftl
+++ b/features/flows/elastic/src/main/resources/org/opennms/netmgt/flows/elastic/aggregate_by_fuzzed_field.ftl
@@ -1,0 +1,43 @@
+{
+  "size": 0,
+  "query": {
+    "bool": {
+      "filter": [
+<#list filters as filter>${filter}<#sep>,</#list>
+      ],
+      "must": {
+        "bool": {
+          "should": [
+          {
+            "prefix": {
+              "${field?json_string}": {
+                "value": "${prefix?json_string}"
+              }
+            }
+          },
+          {
+            "fuzzy": {
+              "${field?json_string}": {
+                "value": "${prefix?json_string}",
+                "fuzziness": "AUTO",
+                "max_expansions": ${N?long?c}
+              }
+            }
+          }]
+        }
+      }
+    }
+  },
+  "aggs": {
+    "grouped_by": {
+      "terms": {
+        "field": "${field?json_string}",
+<#if keyForMissingTerm?has_content>"missing": "${keyForMissingTerm?json_string}",</#if>
+        "size": ${N?long?c},
+        "order": {
+          "_key": "asc"
+        }
+      }
+    }
+  }
+}

--- a/features/flows/elastic/src/main/resources/org/opennms/netmgt/flows/elastic/series_for_applications.ftl
+++ b/features/flows/elastic/src/main/resources/org/opennms/netmgt/flows/elastic/series_for_applications.ftl
@@ -1,0 +1,45 @@
+{
+  "size": 0,
+  "query": {
+    "bool": {
+      "filter": [
+<#list filters as filter>${filter}<#sep>,</#list>
+      ],
+      "must": {
+        "terms": {
+          "netflow.application": [<#list applications as application>"${application?json_string}"<#sep>,</#list>]
+        }
+      }
+    }
+  },
+  "aggs": {
+    "grouped_by": {
+      "terms": {
+        "field": "netflow.application"
+      },
+      "aggs": {
+        "direction": {
+          "terms": {
+            "field": "netflow.direction",
+            "size": 2
+          },
+          "aggs": {
+            "bytes": {
+              "proportional_sum": {
+                "fields": [
+                  "netflow.first_switched",
+                  "netflow.last_switched",
+                  "netflow.bytes",
+                  "netflow.sampling_interval"
+                ],
+                "interval": "${step?long?c}ms",
+                "start": ${start?long?c},
+                "end": ${end?long?c}
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/features/flows/elastic/src/main/resources/org/opennms/netmgt/flows/elastic/series_for_others.ftl
+++ b/features/flows/elastic/src/main/resources/org/opennms/netmgt/flows/elastic/series_for_others.ftl
@@ -14,7 +14,7 @@
       ],
       "must_not": {
         "terms": {
-          "${groupByTerm?json_string}": [<#list topN as topNTerm>"${topNTerm?json_string}"<#sep>,</#list>]
+          "${groupByTerm?json_string}": [<#list from as fromValue>"${fromValue?json_string}"<#sep>,</#list>]
         }
       }
     }

--- a/features/flows/elastic/src/main/resources/org/opennms/netmgt/flows/elastic/series_for_others_applications.ftl
+++ b/features/flows/elastic/src/main/resources/org/opennms/netmgt/flows/elastic/series_for_others_applications.ftl
@@ -1,0 +1,38 @@
+{
+  "size": 0,
+  "query": {
+    "bool": {
+      "filter": [
+<#list filters as filter>${filter}<#sep>,</#list>
+      ],
+      "must_not": {
+        "terms": {
+          "netflow.application": [<#list applications as application>"${application?json_string}"<#sep>,</#list>]
+        }
+      }
+    }
+  },
+  "aggs": {
+    "direction": {
+      "terms": {
+        "field": "netflow.direction",
+        "size": 2
+      },
+      "aggs": {
+        "bytes": {
+          "proportional_sum": {
+            "fields": [
+              "netflow.first_switched",
+              "netflow.last_switched",
+              "netflow.bytes",
+              "netflow.sampling_interval"
+            ],
+            "interval": "${step?long?c}ms",
+            "start": ${start?long?c},
+            "end": ${end?long?c}
+          }
+        }
+      }
+    }
+  }
+}

--- a/features/flows/elastic/src/main/resources/org/opennms/netmgt/flows/elastic/series_for_terms.ftl
+++ b/features/flows/elastic/src/main/resources/org/opennms/netmgt/flows/elastic/series_for_terms.ftl
@@ -5,7 +5,7 @@
       "filter": [
         {
           "terms": {
-            "${groupByTerm?json_string}": [<#list topN as topNTerm>"${topNTerm?json_string}"<#sep>,</#list>]
+            "${groupByTerm?json_string}": [<#list from as fromTerm>"${fromTerm?json_string}"<#sep>,</#list>]
           }
         },
 <#list filters as filter>${filter}<#sep>,</#list>
@@ -16,7 +16,7 @@
     "grouped_by": {
       "terms": {
         "field": "${groupByTerm?json_string}",
-        "size": ${topN?size?long?c}
+        "size": ${from?size?long?c}
       },
       "aggs": {
         "direction": {

--- a/features/flows/elastic/src/test/java/org/opennms/netmgt/flows/elastic/FlowQueryIT.java
+++ b/features/flows/elastic/src/test/java/org/opennms/netmgt/flows/elastic/FlowQueryIT.java
@@ -75,6 +75,7 @@ import org.opennms.plugins.elasticsearch.rest.index.IndexStrategy;
 import org.opennms.plugins.elasticsearch.rest.template.IndexSettings;
 
 import com.codahale.metrics.MetricRegistry;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Table;
 
@@ -151,7 +152,7 @@ public class FlowQueryIT {
     @Test
     public void canGetTopNApplications() throws ExecutionException, InterruptedException {
         // Retrieve the Top N applications over the entire time range
-        List<TrafficSummary<String>> appTrafficSummary = flowRepository.getTopNApplications(10, true, getFilters()).get();
+        List<TrafficSummary<String>> appTrafficSummary = flowRepository.getTopNApplicationSummaries(10, true, getFilters()).get();
 
         // Expect all of the applications, with the sum of all the bytes from all the flows
         assertThat(appTrafficSummary, hasSize(4));
@@ -177,7 +178,7 @@ public class FlowQueryIT {
         assertThat(other.getBytesOut(), equalTo(0L));
 
         // Now decrease N, expect all of the counts to pool up in "Other"
-        appTrafficSummary = flowRepository.getTopNApplications(1, true, getFilters()).get();
+        appTrafficSummary = flowRepository.getTopNApplicationSummaries(1, true, getFilters()).get();
 
         // Expect all of the applications, with the sum of all the bytes from all the flows
         assertThat(appTrafficSummary, hasSize(2));
@@ -192,11 +193,11 @@ public class FlowQueryIT {
         assertThat(other.getBytesOut(), equalTo(200L));
 
         // Now set N to zero
-        appTrafficSummary = flowRepository.getTopNApplications(0, false, getFilters()).get();
+        appTrafficSummary = flowRepository.getTopNApplicationSummaries(0, false, getFilters()).get();
         assertThat(appTrafficSummary, hasSize(0));
 
         // N=0, but include other
-        appTrafficSummary = flowRepository.getTopNApplications(0, true, getFilters()).get();
+        appTrafficSummary = flowRepository.getTopNApplicationSummaries(0, true, getFilters()).get();
         assertThat(appTrafficSummary, hasSize(1));
 
         other = appTrafficSummary.get(0);
@@ -208,7 +209,7 @@ public class FlowQueryIT {
     @Test
     public void canGetTopNApplicationsWithPartialSums() throws ExecutionException, InterruptedException {
         // Retrieve the Top N applications over a subset of the range
-        final List<TrafficSummary<String>> appTrafficSummary = flowRepository.getTopNApplications(1, false,
+        final List<TrafficSummary<String>> appTrafficSummary = flowRepository.getTopNApplicationSummaries(1, false,
                 Lists.newArrayList(new TimeRangeFilter(10,  20))).get();
 
         // Expect the top application with a partial sum of all the bytes
@@ -245,25 +246,47 @@ public class FlowQueryIT {
     public void canGetAppSeries() throws ExecutionException, InterruptedException {
         // Get just https
         Table<Directional<String>, Long, Double> appTraffic =
-                flowRepository.getApplicationSeries(Collections.singletonList("https"), 10,
+                flowRepository.getApplicationSeries(Collections.singleton("https"), 10,
                 false, getFilters()).get();
         assertThat(appTraffic.rowKeySet(), hasSize(2));
         verifyHttpsSeries(appTraffic);
 
         // Get just https and include others
-        appTraffic = flowRepository.getApplicationSeries(Collections.singletonList("https"), 10,
+        appTraffic = flowRepository.getApplicationSeries(Collections.singleton("https"), 10,
                 true, getFilters()).get();
         assertThat(appTraffic.rowKeySet(), hasSize(4));
 
         // Get https and http
-        appTraffic = flowRepository.getApplicationSeries(Arrays.asList("http", "https"), 10,
+        appTraffic = flowRepository.getApplicationSeries(ImmutableSet.of("http", "https"), 10,
                 false, getFilters()).get();
         assertThat(appTraffic.rowKeySet(), hasSize(4));
 
         // Get https and http and include others
-        appTraffic = flowRepository.getApplicationSeries(Arrays.asList("http", "https"), 10,
+        appTraffic = flowRepository.getApplicationSeries(ImmutableSet.of("http", "https"), 10,
                 true, getFilters()).get();
         assertThat(appTraffic.rowKeySet(), hasSize(6));
+    }
+
+    @Test
+    public void canGetAppSummaries() throws ExecutionException, InterruptedException {
+        List<TrafficSummary<String>> appTrafficSummary =  
+                flowRepository.getApplicationSummaries(Collections.singleton("https"), false, getFilters()).get();
+        assertThat(appTrafficSummary, hasSize(1));
+
+        //
+        appTrafficSummary =
+                flowRepository.getApplicationSummaries(ImmutableSet.of("https", "http"), false, getFilters()).get();
+
+        assertThat(appTrafficSummary, hasSize(2));
+        TrafficSummary<String> https = appTrafficSummary.get(0);
+        assertThat(https.getEntity(), equalTo("https"));
+        assertThat(https.getBytesIn(), equalTo(210L));
+        assertThat(https.getBytesOut(), equalTo(2100L));
+
+        TrafficSummary<String> http = appTrafficSummary.get(1);
+        assertThat(http.getEntity(), equalTo("http"));
+        assertThat(http.getBytesIn(), equalTo(10L));
+        assertThat(http.getBytesOut(), equalTo(100L));
     }
 
     @Test

--- a/features/flows/rest/api/src/main/java/org/opennms/netmgt/flows/rest/FlowRestService.java
+++ b/features/flows/rest/api/src/main/java/org/opennms/netmgt/flows/rest/FlowRestService.java
@@ -90,6 +90,22 @@ public interface FlowRestService {
     @Produces(MediaType.APPLICATION_JSON)
     FlowNodeDetails getFlowExporter(@PathParam("nodeId") final Integer nodeId);
 
+    /**
+     * Retrieve the list of applications.
+     *
+     * Supports filtering.
+     *
+     * @param matchingPrefix a string prefix that can be used to further filter the results
+     * @param limit the maximum number of applications to return
+     * @return the list of applications
+     */
+    @GET
+    @Path("applications/enumerate")
+    @Produces(MediaType.APPLICATION_JSON)
+    List<String> getApplications(@DefaultValue("") @QueryParam("prefix") final String matchingPrefix,
+                                 @DefaultValue(DEFAULT_LIMIT) @QueryParam("limit") final long limit,
+                                 @Context UriInfo uriInfo);
+
     @GET
     @Path("applications")
     @Produces(MediaType.APPLICATION_JSON)
@@ -102,9 +118,10 @@ public interface FlowRestService {
     @GET
     @Path("applications/series")
     @Produces(MediaType.APPLICATION_JSON)
-    FlowSeriesResponse getTopNApplicationSeries(
+    FlowSeriesResponse getApplicationSeries(
             @DefaultValue(DEFAULT_STEP_MS) @QueryParam("step") final long step,
-            @DefaultValue(DEFAULT_TOP_N) @QueryParam("N") final int N,
+            @QueryParam("N") final Integer N,
+            @QueryParam("application") final List<String> applications,
             @DefaultValue("false") @QueryParam("includeOther") boolean includeOther,
             @Context final UriInfo uriInfo
     );

--- a/features/flows/rest/api/src/main/java/org/opennms/netmgt/flows/rest/FlowRestService.java
+++ b/features/flows/rest/api/src/main/java/org/opennms/netmgt/flows/rest/FlowRestService.java
@@ -29,6 +29,7 @@
 package org.opennms.netmgt.flows.rest;
 
 import java.util.List;
+import java.util.Set;
 
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
@@ -109,8 +110,9 @@ public interface FlowRestService {
     @GET
     @Path("applications")
     @Produces(MediaType.APPLICATION_JSON)
-    FlowSummaryResponse getTopNApplications(
-            @DefaultValue(DEFAULT_TOP_N) @QueryParam("N") final int N,
+    FlowSummaryResponse getApplicationSummary(
+            @QueryParam("N") final Integer N,
+            @QueryParam("application") final Set<String> applications,
             @DefaultValue("false") @QueryParam("includeOther") boolean includeOther,
             @Context UriInfo uriInfo
     );
@@ -121,7 +123,7 @@ public interface FlowRestService {
     FlowSeriesResponse getApplicationSeries(
             @DefaultValue(DEFAULT_STEP_MS) @QueryParam("step") final long step,
             @QueryParam("N") final Integer N,
-            @QueryParam("application") final List<String> applications,
+            @QueryParam("application") final Set<String> applications,
             @DefaultValue("false") @QueryParam("includeOther") boolean includeOther,
             @Context final UriInfo uriInfo
     );

--- a/opennms-doc/guide-development/src/asciidoc/text/rest/flows.adoc
+++ b/opennms-doc/guide-development/src/asciidoc/text/rest/flows.adoc
@@ -13,7 +13,8 @@ NOTE: Unless specific otherwise, all unit of time are expressed in milliseconds.
 | `/flows/exporters`                | Retrieve basic information for the exporter nodes that have flows available
 | `/flows/exporters/{nodeCriteria}` | Retrieve detailed information about a specific exporter node
 | `/flows/applications`             | Retrieve traffic summary statistics for the top N applications
-| `/flows/applications/series`      | Retrieve time series metrics for the top N applications
+| `/flows/applications/enumerate`   | Retrieve a list of the applications with flows
+| `/flows/applications/series`      | Retrieve time series metrics for the top N applications or specific applications
 | `/flows/conversations`            | Retrieve traffic summary statistics for the top N conversations
 | `/flows/conversations/series`     | Retrieve time series metrics for the top N conversations
 |===
@@ -41,7 +42,17 @@ There is no support for using `OR` logic, or combinations thereof.
 
 The `exporters` endpoints do not support any parameters.
 
-The `applications` endpoints also support:
+The `applications/enumerate` endpoint also supports:
+
+[options="header"]
+|===
+| name               | default   | comment
+| limit              | 10        | Number of applications with flows to return
+| prefix             | ""        | If provided, filters the results to only include applications with names that start
+                                   with the given prefix (using fuzzy matching)
+|===
+
+The `applications` and `applications/series` endpoints also support:
 
 [options="header"]
 |===
@@ -50,6 +61,18 @@ The `applications` endpoints also support:
 | includeOther       | false     | When set to `true` the results will also include an additional row or column that contains
                                    the bytes transferred for the flows that fall outside of the Top N.
 |===
+
+The `applications/series` endpoint also supports:
+
+[options="header"]
+|===
+| name               | default   | comment
+| application        | none      | If provided, returns only flow series that match the given application(s). This field
+                                   can be repeated for any number of applications to be included in the query.
+|===
+
+The `application/series` endpoint requires one of `N` or `application` query parameters to be set and will return an
+error if neither or both are set.
 
 The `applications` and `conversations` endpoints also support:
 

--- a/opennms-doc/guide-development/src/asciidoc/text/rest/flows.adoc
+++ b/opennms-doc/guide-development/src/asciidoc/text/rest/flows.adoc
@@ -57,24 +57,17 @@ The `applications` and `applications/series` endpoints also support:
 [options="header"]
 |===
 | name               | default   | comment
-| N                  | 10        | Number of top entries (determined by total bytes transferred) to return
+| N                  | none      | Number of top entries (determined by total bytes transferred) to return
 | includeOther       | false     | When set to `true` the results will also include an additional row or column that contains
                                    the bytes transferred for the flows that fall outside of the Top N.
-|===
-
-The `applications/series` endpoint also supports:
-
-[options="header"]
-|===
-| name               | default   | comment
 | application        | none      | If provided, returns only flow series that match the given application(s). This field
                                    can be repeated for any number of applications to be included in the query.
 |===
 
-The `application/series` endpoint requires one of `N` or `application` query parameters to be set and will return an
-error if neither or both are set.
+Both endpoints requires one of `N` or `application` query parameters to be set and will return an error if neither or
+both are set.
 
-The `applications` and `conversations` endpoints also support:
+The `conversations` endpoint also supports:
 
 [options="header"]
 |===
@@ -82,7 +75,7 @@ The `applications` and `conversations` endpoints also support:
 | N                  | 10        | Number of top entries (determined by total bytes transferred) to return
 |===
 
-The `series` endpoints also support:
+The `converstations/series` endpoint also supports:
 
 [options="header"]
 |===


### PR DESCRIPTION
This PR adds a new ReST endpoint to enumerate the applications with flows. It also updates the `flows/applications/series` endpoint to take either a top N value or a list of specific applications to take.

In addition to the integration test updates, both endpoints have been tested manually on a local install.

* JIRA: http://issues.opennms.org/browse/HZN-1551
