### PR TITLE
NMS-10674: Added missing 'ON DELETE CASCADE' statements to ipNetToMedia table

### DIFF
--- a/core/schema/src/main/liquibase/24.0.0/changelog.xml
+++ b/core/schema/src/main/liquibase/24.0.0/changelog.xml
@@ -284,11 +284,18 @@
     </addColumn>
     
     <addForeignKeyConstraint constraintName="fk_ipnettomedia_nodeid" 
-    	baseTableName="ipnettomedia" 
-    	baseColumnNames="nodeid" 
-    	referencedTableName="node" 
-    	referencedColumnNames="nodeid" />
+        baseTableName="ipnettomedia"
+        baseColumnNames="nodeid"
+        referencedTableName="node"
+        referencedColumnNames="nodeid"
+        onDelete="CASCADE" />
     
+    <addForeignKeyConstraint constraintName="fk_ipnettomedia_sourcenodeid"
+        baseTableName="ipnettomedia"
+        baseColumnNames="sourcenodeid"
+        referencedTableName="node"
+        referencedColumnNames="nodeid"
+        onDelete="CASCADE" />
     
        <rollback>
             <dropColumn tableName="ipnettomedia" columnName="nodeid" />

--- a/opennms-base-assembly/src/main/filtered/etc/create.sql
+++ b/opennms-base-assembly/src/main/filtered/etc/create.sql
@@ -1980,8 +1980,8 @@ create table ipNetToMedia (
     createTime     timestamp not null,
     lastPollTime   timestamp not null,
     constraint pk_ipnettomedia_id primary key (id),
-    constraint fk_ipnettomedia_nodeid foreign key (nodeid) references node (nodeid), 
-    constraint fk_ipnettomedia_sourcenodeid foreign key (sourcenodeid) references node (nodeid) 
+    constraint fk_ipnettomedia_nodeid foreign key (nodeid) references node (nodeid) on delete cascade,
+    constraint fk_ipnettomedia_sourcenodeid foreign key (sourcenodeid) references node (nodeid) on delete cascade
 );
 
 create table bridgeElement (


### PR DESCRIPTION
https://issues.opennms.org/browse/NMS-10674: Added 'ON DELETE CASCADE' statements to newly introduced nodeid foreign key constraints from NMS-9273 and HZN-1499 on the ipNetToMedia table. 
This change enables provisiond to successfully delete nodes using its simple 'DELETE FROM NODE WHERE nodeid = %ID%' syntax.

(I opened this PR against my bug HZN-1562 but that was closed as a duplicate, hence this is now re-purposed against the open bug for the same problem)