### PR TITLE
NMS-10674: Added missing 'ON DELETE CASCADE' statement to ipNetToMedia table

### DIFF
--- a/core/schema/src/main/liquibase/24.1.0/changelog.xml
+++ b/core/schema/src/main/liquibase/24.1.0/changelog.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd" >
+
+  <changeSet author="jondevit" id="24.1.0-ipnettomedia-on-delete-cascade">
+    <dropForeignKeyConstraint baseTableName="ipNetToMedia" constraintName="fk_ipnettomedia_nodeid"/>
+    <addForeignKeyConstraint constraintName="fk_ipnettomedia_nodeid"
+                             baseTableName="ipNetToMedia" baseColumnNames="nodeid"
+                             referencedTableName="node" referencedColumnNames="nodeid" onDelete="CASCADE"/>
+  </changeSet>
+
+</databaseChangeLog>

--- a/core/schema/src/main/liquibase/24.1.0/changelog.xml
+++ b/core/schema/src/main/liquibase/24.1.0/changelog.xml
@@ -10,6 +10,10 @@
     <addForeignKeyConstraint constraintName="fk_ipnettomedia_nodeid"
                              baseTableName="ipNetToMedia" baseColumnNames="nodeid"
                              referencedTableName="node" referencedColumnNames="nodeid" onDelete="CASCADE"/>
+    <dropForeignKeyConstraint baseTableName="ipNetToMedia" constraintName="fk_ipnettomedia_sourcenodeid"/>
+    <addForeignKeyConstraint constraintName="fk_ipnettomedia_sourcenodeid"
+                             baseTableName="ipNetToMedia" baseColumnNames="nodeid"
+                             referencedTableName="node" referencedColumnNames="nodeid" onDelete="CASCADE"/>
   </changeSet>
 
 </databaseChangeLog>

--- a/core/schema/src/main/liquibase/changelog.xml
+++ b/core/schema/src/main/liquibase/changelog.xml
@@ -87,6 +87,7 @@
 	<include file="22.0.1/changelog.xml"/>
 	<include file="23.0.0/changelog.xml"/>
 	<include file="24.0.0/changelog.xml"/>
+	<include file="24.1.0/changelog.xml"/>
 
 	<include file="stored-procedures/getManagePercentAvailIntfWindow.xml" />
 	<include file="stored-procedures/getManagePercentAvailNodeWindow.xml" />

--- a/opennms-base-assembly/src/main/filtered/etc/create.sql
+++ b/opennms-base-assembly/src/main/filtered/etc/create.sql
@@ -1980,8 +1980,8 @@ create table ipNetToMedia (
     createTime     timestamp not null,
     lastPollTime   timestamp not null,
     constraint pk_ipnettomedia_id primary key (id),
-    constraint fk_ipnettomedia_nodeid foreign key (nodeid) references node (nodeid), 
-    constraint fk_ipnettomedia_sourcenodeid foreign key (sourcenodeid) references node (nodeid) 
+    constraint fk_ipnettomedia_nodeid foreign key (nodeid) references node (nodeid) on delete cascade,
+    constraint fk_ipnettomedia_sourcenodeid foreign key (sourcenodeid) references node (nodeid) on delete cascade
 );
 
 create table bridgeElement (


### PR DESCRIPTION
This replaces PR https://github.com/OpenNMS/opennms/pull/2484 in order to cleanly base off 24.1.0 and also use the correct bug ID from the start...

- Updated 'create.sql' to set delete cascade on fk_ipnettomedia_nodeid constraint
- Created new 24.1.0 changelog.xml for Liquibase and added a changeset to recreate the  fk_ipnettomedia_nodeid constraint with onDelete=CASCADE

Edit by mvrueden: 
 - JIRA: https://issues.openns.org/browse/NMS-10674