### PR TITLE
Changes to compile under Java 9

### DIFF
--- a/features/minion/repository/pom.xml
+++ b/features/minion/repository/pom.xml
@@ -318,14 +318,6 @@
             <artifactId>org.opennms.protocols.xml</artifactId>
             <version>${project.version}</version>
         </dependency>
-        <!-- TODO MVR this is including 4.1.7 with java 8, but 4.2.1-SNAPSHOT with java 9. WTF? -->
-        <!-- TODO MVR temporarily disable -->
-        <!--<dependency>-->
-            <!--<groupId>org.apache.cxf.karaf</groupId>-->
-            <!--<artifactId>cxf-karaf-commands</artifactId>-->
-            <!--<version>${cxfVersion}</version>-->
-            <!--<scope>provided</scope>-->
-        <!--</dependency>-->
     </dependencies>
 
     <repositories>

--- a/features/minion/repository/pom.xml
+++ b/features/minion/repository/pom.xml
@@ -318,12 +318,14 @@
             <artifactId>org.opennms.protocols.xml</artifactId>
             <version>${project.version}</version>
         </dependency>
-        <dependency>
-            <groupId>org.apache.cxf.karaf</groupId>
-            <artifactId>cxf-karaf-commands</artifactId>
-            <version>${cxfVersion}</version>
-            <scope>provided</scope>
-        </dependency>
+        <!-- TODO MVR this is including 4.1.7 with java 8, but 4.2.1-SNAPSHOT with java 9. WTF? -->
+        <!-- TODO MVR temporarily disable -->
+        <!--<dependency>-->
+            <!--<groupId>org.apache.cxf.karaf</groupId>-->
+            <!--<artifactId>cxf-karaf-commands</artifactId>-->
+            <!--<version>${cxfVersion}</version>-->
+            <!--<scope>provided</scope>-->
+        <!--</dependency>-->
     </dependencies>
 
     <repositories>

--- a/integrations/opennms-vmware/pom.xml
+++ b/integrations/opennms-vmware/pom.xml
@@ -91,6 +91,15 @@
                     <groupId>log4j</groupId>
                     <artifactId>log4j</artifactId>
                 </exclusion>
+                <!--
+                    Lombok is a build dependency and should not leak into our project.
+                    We exclude it, otherwise it does not compile under Java 9.
+                    Please refer to https://github.com/rzwitserloot/lombok/issues/1629#issuecomment-376005025 for more details
+                -->
+                <exclusion>
+                    <groupId>org.projectlombok</groupId>
+                    <artifactId>lombok</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 


### PR DESCRIPTION
Here are some small changes to actually compile with JDK 9. 

This will only get it to compile, but not the tests run with JDK 9.