### PR TITLE
NMS-10667: Fix health:check getting stuck

### DIFF
--- a/core/health/api/src/main/java/org/opennms/core/health/api/Health.java
+++ b/core/health/api/src/main/java/org/opennms/core/health/api/Health.java
@@ -76,4 +76,8 @@ public class Health {
     public String getErrorMessage() {
         return errorMessage;
     }
+
+    public List<Response> getResponses() {
+        return new ArrayList<>(responses);
+    }
 }

--- a/core/health/impl/pom.xml
+++ b/core/health/impl/pom.xml
@@ -26,6 +26,11 @@
     </build>
     <dependencies>
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.karaf.shell</groupId>
             <artifactId>org.apache.karaf.shell.core</artifactId>
             <version>${karafVersion}</version>
@@ -51,6 +56,16 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.opennms.core.test-api</groupId>
+            <artifactId>org.opennms.core.test-api.lib</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/core/health/impl/src/main/java/org/opennms/core/health/impl/DefaultHealthCheckService.java
+++ b/core/health/impl/src/main/java/org/opennms/core/health/impl/DefaultHealthCheckService.java
@@ -66,7 +66,7 @@ public class DefaultHealthCheckService implements HealthCheckService {
     private static final Logger LOG = LoggerFactory.getLogger(DefaultHealthCheckService.class);
 
     // HealthChecks are performed asynchronously with this executor.
-    private final ExecutorService executorService = Executors.newFixedThreadPool(1, new ThreadFactoryBuilder().setNameFormat("health-check-%d").build());
+    private final ExecutorService executorService = Executors.newCachedThreadPool(new ThreadFactoryBuilder().setNameFormat("health-check-%d").build());
 
     // Context to load the services
     private BundleContext bundleContext;

--- a/core/health/impl/src/main/java/org/opennms/core/health/impl/DefaultHealthCheckService.java
+++ b/core/health/impl/src/main/java/org/opennms/core/health/impl/DefaultHealthCheckService.java
@@ -76,7 +76,7 @@ public class DefaultHealthCheckService implements HealthCheckService {
     }
 
     // Resolve all HealthChecks from the OSGi registry
-    private List<HealthCheck> getHealthChecks() throws InvalidSyntaxException {
+    protected List<HealthCheck> getHealthChecks() throws InvalidSyntaxException {
         final Collection<ServiceReference<HealthCheck>> serviceReferences = bundleContext.getServiceReferences(HealthCheck.class, null);
         return serviceReferences.stream()
                 .sorted(Comparator.comparingLong(ref -> ref.getBundle().getBundleId()))

--- a/core/health/impl/src/test/java/org/opennms/core/health/impl/DefaultHealthCheckServiceTest.java
+++ b/core/health/impl/src/test/java/org/opennms/core/health/impl/DefaultHealthCheckServiceTest.java
@@ -1,0 +1,112 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019-2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.core.health.impl;
+
+import static org.hamcrest.CoreMatchers.is;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import org.easymock.EasyMock;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+import org.opennms.core.health.api.Context;
+import org.opennms.core.health.api.Health;
+import org.opennms.core.health.api.HealthCheck;
+import org.opennms.core.health.api.Response;
+import org.opennms.core.health.api.SimpleHealthCheck;
+import org.opennms.core.health.api.Status;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.InvalidSyntaxException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.Lists;
+
+public class DefaultHealthCheckServiceTest {
+
+    private static class BlockingHealthCheck implements HealthCheck {
+        @Override
+        public String getDescription() {
+            return getClass().getSimpleName();
+        }
+
+        @Override
+        public Response perform(Context context) {
+            long start = System.currentTimeMillis();
+            long spent = 0;
+            while (spent < 5000) {
+                try {
+                    Thread.sleep(5000);
+                } catch (InterruptedException ex) {
+                }
+                spent += System.currentTimeMillis() - start;
+            }
+            return new Response(Status.Success, "\\o/");
+        }
+    }
+
+    private static final Logger LOG = LoggerFactory.getLogger(DefaultHealthCheckServiceTest.class);
+
+    @Rule
+    public Timeout timeout = new Timeout(60, TimeUnit.SECONDS);
+
+    @Test
+    public void verifyHealthCheckServiceDoesNotBlock() throws InvalidSyntaxException, ExecutionException, InterruptedException {
+        final BlockingHealthCheck blockingHealthCheck = new BlockingHealthCheck();
+        final SimpleHealthCheck successHealthCheck = new SimpleHealthCheck(() -> "Always green :)");
+        successHealthCheck.markSucess();
+
+        final DefaultHealthCheckService healthCheckService = new DefaultHealthCheckService(EasyMock.createNiceMock(BundleContext.class)) {
+            @Override
+            protected List<HealthCheck> getHealthChecks() {
+                return Lists.newArrayList(blockingHealthCheck, successHealthCheck);
+            }
+        };
+
+        final Context context = new Context();
+        context.setTimeout(1000); // ms
+
+        for (int i=0; i<2; i++) {
+            final CompletableFuture<Health> future = healthCheckService
+                    .performAsyncHealthCheck(context,
+                            healthCheck -> LOG.info("Executing: {}", healthCheck.getDescription()),
+                            response -> LOG.info("=> {} : {}", response.getStatus().name(), response.getMessage()));
+            final Health health = future.get();
+            final List<Response> timedOutResponsed = health.getResponses().stream().filter(r -> r.getStatus() == Status.Timeout).collect(Collectors.toList());
+            Assert.assertThat(timedOutResponsed.size(), is(1));
+        }
+    }
+
+}


### PR DESCRIPTION
* JIRA: https://issues.opennms.org/browse/NMS-10667

Tested this by providing a dummy health check blocking for 5 Minutes and not implementing Thread interrupts properly.