### PR TITLE
NMS-10680: put openjdk 11 first so it is chosen by default

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,7 @@ Standards-Version: 3.7.3
 
 Package: opennms
 Architecture: all
-Depends: opennms-db (=${binary:Version}), opennms-server (=${binary:Version}), opennms-webapp-jetty (=${binary:Version}), oracle-java8-installer | openjdk-8-jdk | java8-jdk | openjdk-11-jdk | openjdk-11-jdk-headless
+Depends: opennms-db (=${binary:Version}), opennms-server (=${binary:Version}), opennms-webapp-jetty (=${binary:Version}), openjdk-11-jdk-headless | openjdk-11-jdk | oracle-java8-installer | openjdk-8-jdk-headless | openjdk-8-jdk | java8-jdk
 Recommends: opennms-source (=${binary:Version})
 Suggests: opennms-doc
 Description: Enterprise-grade Open-source Network Management Platform (Full Install)
@@ -88,7 +88,7 @@ Description: Enterprise-grade Open-source Network Management Platform (Remote Po
 
 Package: opennms-jmx-config-generator
 Architecture: all
-Depends: oracle-java8-installer | openjdk-8-jre | java8-runtime | java8-runtime-headless
+Depends: openjdk-11-jre-headless | openjdk-11-jre | oracle-java8-installer | openjdk-8-jre-headless | openjdk-8-jre | java8-runtime-headless | java8-runtime
 Description: Enterprise-grade Open-source Network Management Platform (JMX Config Generator)
  OpenNMS is an enterprise-grade network management system written in Java.
  .


### PR DESCRIPTION
This PR makes sure OpenJDK11 is chosen by default on Debian/Ubuntu (by listing it first).

It also defaults to the headless version.

* JIRA: http://issues.opennms.org/browse/NMS-10680

Our [continuous integration system](http://bamboo.internal.opennms.com:8085) will test and verify your changes.
