### PR TITLE
NMS-10694: upgrade to latest c3p0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1261,7 +1261,7 @@
     <commonsLoggingVersion>99.99.99-use-jcl-over-slf4j</commonsLoggingVersion>
     <commonsMath3Version>3.5</commonsMath3Version>
     <commonsValidatorVersion>1.3.1</commonsValidatorVersion>
-    <c3p0Version>0.9.5.2</c3p0Version>
+    <c3p0Version>0.9.5.4</c3p0Version>
     <cxfVersion>3.1.5</cxfVersion>
     <dnsjavaVersion>2.1.3</dnsjavaVersion>
     <dropwizardMetricsVersion>3.1.2</dropwizardMetricsVersion>


### PR DESCRIPTION
This PR bumps c3p0 to the latest version.  This will apply to Foundation 2016 and up.

* JIRA: http://issues.opennms.org/browse/NMS-10694

Our [continuous integration system](http://bamboo.internal.opennms.com:8085) will test and verify your changes.
