### PR TITLE
HZN-1520: Remove unused dependency net.simon04.jelementtree:jelementtree

### DIFF
--- a/opennms-base-assembly/pom.xml
+++ b/opennms-base-assembly/pom.xml
@@ -614,11 +614,6 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>net.simon04.jelementtree</groupId>
-      <artifactId>jelementtree</artifactId>
-      <version>20100506</version>
-    </dependency>
-    <dependency>
       <groupId>opensymphony</groupId>
       <artifactId>ognl</artifactId>
     </dependency>


### PR DESCRIPTION
HZN-1520 removed a dependency on net.simon04.jelementtree:jelementtree but it wasn't removed from opennms-base-assembly/pom.xml.