### PR TITLE
NMS-10701: make sure all Jetty code is using 9.4.18

### DIFF
--- a/features/springframework-security/src/main/java/org/opennms/web/springframework/security/JettyUserIdentityFilter.java
+++ b/features/springframework-security/src/main/java/org/opennms/web/springframework/security/JettyUserIdentityFilter.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2017-2017 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
+ * Copyright (C) 2017-2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -55,7 +55,6 @@ import org.springframework.security.core.context.SecurityContextHolder;
  * @author nalvarez
  */
 public class JettyUserIdentityFilter implements Filter {
-
     private static final Logger LOG = LoggerFactory.getLogger(JettyUserIdentityFilter.class);
 
     @Override
@@ -109,20 +108,29 @@ public class JettyUserIdentityFilter implements Filter {
             this.authentication = authentication;
         }
 
+        @Override
         public String getAuthMethod() {
             return null;
         }
 
+        @Override
         public UserIdentity getUserIdentity() {
             return new UserIdentityStub(authentication);
         }
 
+        @Override
         public boolean isUserInRole(UserIdentity.Scope scope, String role) {
             return false;
         }
 
+        @Override
         public void logout() {
             // pass
+        }
+
+        @Override
+        public org.eclipse.jetty.server.Authentication logout(final ServletRequest request) {
+            return null;
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -1307,7 +1307,7 @@
     <jasperreportsMavenPluginVersion>1.0-beta-4-OPENNMS-20160912-1</jasperreportsMavenPluginVersion>
     <jcifsVersion>1.3.14</jcifsVersion>
     <jcommonVersion>1.0.23</jcommonVersion>
-    <jettyVersion>9.4.14.v20181114</jettyVersion>
+    <jettyVersion>9.4.18.v20190429</jettyVersion>
     <jfreechartVersion>1.0.19</jfreechartVersion>
     <jinteropVersion>2.0.8</jinteropVersion>
     <jldapVersion>4.3</jldapVersion>


### PR DESCRIPTION
A Jetty version bump.  Also, we were not changing Karaf to match our embedded Jetty.  I've changed it to use `${jettyVersion}` instead.

* JIRA: http://issues.opennms.org/browse/NMS-10701

Our [continuous integration system](http://bamboo.internal.opennms.com:8085) will test and verify your changes.
