### PR TITLE
NMS-10690: Fix maven pom warnings

### DIFF
--- a/features/flows/elastic/pom.xml
+++ b/features/flows/elastic/pom.xml
@@ -263,11 +263,6 @@
     </dependency>
     <dependency>
       <groupId>org.opennms</groupId>
-      <artifactId>opennms-dao-mock</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.opennms</groupId>
       <artifactId>opennms-rrd-jrobin</artifactId>
       <scope>test</scope>
     </dependency>
@@ -279,11 +274,6 @@
     <dependency>
       <groupId>org.opennms.features.collection</groupId>
       <artifactId>org.opennms.features.collection.persistence.rrd</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.opennms</groupId>
-      <artifactId>opennms-dao-mock</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/features/jest/jest-complete-osgi/pom.xml
+++ b/features/jest/jest-complete-osgi/pom.xml
@@ -194,7 +194,7 @@
     <dependency>
       <groupId>org.opennms.features.jest</groupId>
       <artifactId>org.opennms.features.jest.dependencies</artifactId>
-      <version>${parent.version}</version>
+      <version>${project.parent.version}</version>
       <type>pom</type>
       <scope>provided</scope>
     </dependency>

--- a/features/opennms-es-rest/pom.xml
+++ b/features/opennms-es-rest/pom.xml
@@ -11,7 +11,7 @@
   <groupId>org.opennms.features</groupId>
   <artifactId>org.opennms.features.opennms-es-rest</artifactId>
   <name>OpenNMS :: Features :: ElasticSearch Rest</name>
-  <description>${name}</description>
+  <description>${project.name}</description>
   <packaging>bundle</packaging>
 
   <properties>

--- a/features/vaadin-components/widgetset/pom.xml
+++ b/features/vaadin-components/widgetset/pom.xml
@@ -12,7 +12,7 @@
     <packaging>bundle</packaging>
     <name>${bundle.symbolicName}</name>
     <properties>
-        <bundle.symbolicName>${groupId}.${artifactId}</bundle.symbolicName>
+        <bundle.symbolicName>${project.groupId}.${project.artifactId}</bundle.symbolicName>
         <bundle.namespace>${bundle.symbolicName}</bundle.namespace>
     </properties>
     <build>

--- a/opennms-base-assembly/pom.xml
+++ b/opennms-base-assembly/pom.xml
@@ -989,11 +989,6 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.opennms.features.telemetry.protocols.sflow</groupId>
-      <artifactId>org.opennms.features.telemetry.protocols.sflow.parser</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
       <groupId>org.opennms.features.telemetry.protocols.nxos</groupId>
       <artifactId>org.opennms.features.telemetry.protocols.nxos.adapter</artifactId>
       <version>${project.version}</version>


### PR DESCRIPTION
This PR fixes most of these warning when building OpenNMS.
The only warning not fixed in this PR is the ${jetstVersion} warning from below

```
[WARNING] Some problems were encountered while building the effective model for org.opennms.features.flows:org.opennms.features.flows.elastic:bundle:25.0.0-SNAPSHOT
[WARNING] 'dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: org.opennms:opennms-dao-mock:jar -> duplicate declaration of version (?) @ org.opennms.features.flows:org.opennms.features.flows.elastic:[unknown-version], /Users/roskens/Documents/OpenNMS/devjam2018.git/features/flows/elastic/pom.xml, line 264, column 17
[WARNING] 'dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: org.opennms:opennms-dao-mock:jar -> duplicate declaration of version (?) @ org.opennms.features.flows:org.opennms.features.flows.elastic:[unknown-version], /Users/roskens/Documents/OpenNMS/devjam2018.git/features/flows/elastic/pom.xml, line 284, column 17
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.opennms.features.vaadin-components:widgetset:bundle:25.0.0-SNAPSHOT
[WARNING] The expression ${groupId} is deprecated. Please use ${project.groupId} instead.
[WARNING] The expression ${artifactId} is deprecated. Please use ${project.artifactId} instead.
[WARNING] The expression ${groupId} is deprecated. Please use ${project.groupId} instead.
[WARNING] The expression ${artifactId} is deprecated. Please use ${project.artifactId} instead.
[WARNING] The expression ${groupId} is deprecated. Please use ${project.groupId} instead.
[WARNING] The expression ${artifactId} is deprecated. Please use ${project.artifactId} instead.
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.opennms.features:org.opennms.features.opennms-es-rest:bundle:25.0.0-SNAPSHOT
[WARNING] The expression ${name} is deprecated. Please use ${project.name} instead.
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for io.searchbox:jest-complete-osgi:bundle:5.3.3
[WARNING] 'version' contains an expression but should be a constant. @ io.searchbox:jest-complete-osgi:${jestVersion}, /Users/roskens/Documents/OpenNMS/devjam2018.git/features/jest/jest-complete-osgi/pom.xml, line 13, column 12
[WARNING] The expression ${parent.version} is deprecated. Please use ${project.parent.version} instead.
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
```

