### PR TITLE
MetadataPageIT: fix test

### DIFF
--- a/smoke-test/src/test/java/org/opennms/smoketest/MetadataPageIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/MetadataPageIT.java
@@ -72,7 +72,7 @@ public class MetadataPageIT extends OpenNMSSeleniumTestCase {
         sendPost("rest/nodes/SmokeTests:TestNode/ipinterfaces", ipInterface, 201);
         LOG.debug("Interface created!");
         LOG.debug("Creating a service...");
-        final String service = "<service down=\"false\" status=\"A\" statusLong=\"Managed\">\n" +
+        final String service = "<service status=\"A\">\n" +
                 "<applications/>\n" +
                 "<serviceType id=\"1\">\n" +
                 "<name>ICMP</name>\n" +


### PR DESCRIPTION
This PR fixes the MetadataPageIT which fails on some branches when the calculated attributes are attempted to be de-serialized as there is no setter for these properties.