### PR TITLE
NMS-10716: Introduce rancidApiVersion property

### DIFF
--- a/container/features/src/main/resources/features.xml
+++ b/container/features/src/main/resources/features.xml
@@ -969,7 +969,7 @@
       <bundle>mvn:org.opennms.features/org.opennms.features.request-tracker/${project.version}</bundle>
 
       <!-- TODO: Make this JAR into a bundle -->
-      <bundle>wrap:mvn:org.opennms/rancid-api/1.0.3</bundle>
+      <bundle>wrap:mvn:org.opennms/rancid-api/${rancidApiVersion}</bundle>
 
       <bundle>mvn:org.opennms/opennms-web-api/${project.version}</bundle>
 

--- a/dependencies/rancid/pom.xml
+++ b/dependencies/rancid/pom.xml
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>org.opennms</groupId>
       <artifactId>rancid-api</artifactId>
-      <version>1.0.4</version>
+      <version>${rancidApiVersion}</version>
       <exclusions>
         <exclusion>
           <groupId>log4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1345,6 +1345,7 @@
     <owaspEncoderVersion>1.2.1</owaspEncoderVersion>
     <owaspHtmlSanitizerVersion>20170515.1</owaspHtmlSanitizerVersion>
     <quartzVersion>2.2.3</quartzVersion>
+    <rancidApiVersion>1.0.4</rancidApiVersion>
     <rateLimitedLoggerVersion>1.1.0</rateLimitedLoggerVersion>
     <servletApiVersion>3.1.0</servletApiVersion>
     <slf4jVersion>1.7.21</slf4jVersion>


### PR DESCRIPTION
dependencies/rancid/pom.xml has a dependency on org.opennms/rancid-api/1.0.4 while container/features/src/main/resources/features-experimental.xml has a dependency on org.opennms/rancid-api/1.0.3.

This PR introduces a new property, rancidApiVersion, and updates the two xml files to use that property.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-10716
* Bamboo (Continuous Integration): https://bamboo.opennms.org/

