### PR TITLE
NMS-12098: Remove CircleCI build number from published DockerHub tags

### DIFF
--- a/opennms-container/version-tags.sh
+++ b/opennms-container/version-tags.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+# shellcheck disable=SC2034
+
 # Use version number from pom except from develop
 if [[ "${CIRCLE_BRANCH}" == "develop" ]]; then
   VERSION="bleeding"
@@ -7,10 +9,5 @@ else
   VERSION="$(../pom2version.py ../../pom.xml)"
 fi
 
-# List of tags for the OCI image
+# Array of tags for the OCI image used in the specific projects
 OCI_TAGS=("${VERSION}")
-
-# Add build specific OCI tag if the build runs in CI/CD
-if [[ -n "${CIRCLE_BUILD_NUM}" ]]; then
-  OCI_TAGS+=("${VERSION}-cb.${CIRCLE_BUILD_NUM}")
-fi


### PR DESCRIPTION
Remove CircleCI build number from published DockerHub tags.

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-12098


