### PR TITLE
Windows is failing tests due to spurious cleanup errors

### DIFF
--- a/core/test-api/collection/src/main/java/org/opennms/core/collection/test/JUnitCollectorExecutionListener.java
+++ b/core/test-api/collection/src/main/java/org/opennms/core/collection/test/JUnitCollectorExecutionListener.java
@@ -154,7 +154,16 @@ public class JUnitCollectorExecutionListener extends AbstractTestExecutionListen
             }
         }
 
-        FileUtils.deleteDirectory(m_snmpRrdDirectory);
+        try {
+            FileUtils.deleteDirectory(m_snmpRrdDirectory);
+        } catch (Exception deletionException) {
+            // Windows is failing tests due to spurious cleanup errors
+            deletionException.printStackTrace();
+            String os = System.getProperty("os.name");
+            if (os == null || !os.contains("Windows")) {
+                throw deletionException;
+            }
+        }
 
         m_fileAnticipator.tearDown();
 

--- a/core/test-api/collection/src/main/java/org/opennms/core/collection/test/JUnitCollectorExecutionListener.java
+++ b/core/test-api/collection/src/main/java/org/opennms/core/collection/test/JUnitCollectorExecutionListener.java
@@ -29,6 +29,7 @@
 package org.opennms.core.collection.test;
 
 import java.io.File;
+import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Method;
 
@@ -41,6 +42,8 @@ import org.opennms.netmgt.config.DatabaseSchemaConfigFactory;
 import org.opennms.netmgt.config.DefaultDataCollectionConfigDao;
 import org.opennms.netmgt.config.HttpCollectionConfigFactory;
 import org.opennms.test.FileAnticipator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.core.io.Resource;
 import org.springframework.test.context.TestContext;
 import org.springframework.test.context.TestExecutionListener;
@@ -57,6 +60,7 @@ import org.springframework.test.context.support.AbstractTestExecutionListener;
  */
 public class JUnitCollectorExecutionListener extends AbstractTestExecutionListener {
 
+    private static final Logger LOG = LoggerFactory.getLogger(JUnitCollectorExecutionListener.class);
     private File m_snmpRrdDirectory;
     private FileAnticipator m_fileAnticipator;
 
@@ -156,16 +160,25 @@ public class JUnitCollectorExecutionListener extends AbstractTestExecutionListen
 
         try {
             FileUtils.deleteDirectory(m_snmpRrdDirectory);
-        } catch (Exception deletionException) {
+        } catch (IOException deleteDirectoryException) {
             // Windows is failing tests due to spurious cleanup errors
-            deletionException.printStackTrace();
+            LOG.warn("Failed to delete {} during cleanup.", m_snmpRrdDirectory, deleteDirectoryException);
             String os = System.getProperty("os.name");
             if (os == null || !os.contains("Windows")) {
-                throw deletionException;
+                throw deleteDirectoryException;
             }
         }
 
-        m_fileAnticipator.tearDown();
+        try {
+            m_fileAnticipator.tearDown();
+        } catch (RuntimeException anticipatorTeardownException) {
+            // Windows is failing tests due to spurious cleanup errors
+            LOG.warn("Failed to delete {} during cleanup.", m_fileAnticipator.getTempDir(), anticipatorTeardownException);
+            String os = System.getProperty("os.name");
+            if (os == null || !os.contains("Windows")) {
+                throw anticipatorTeardownException;
+            }
+        }
 
         if (e != null) {
             throw e;


### PR DESCRIPTION
This PR changes the behavior to simply print a stack trace on Windows if there is an error cleaning up after the test.

* https://issues.opennms.org/browse/NMS-12102