### PR TITLE
NMS-12115: Add an optional attribute to contain the total number of returned results of the enumeration

### DIFF
--- a/opennms-doc/guide-admin/src/asciidoc/text/performance-data-collection/collectors/wsman.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/performance-data-collection/collectors/wsman.adoc
@@ -276,3 +276,19 @@ This can be achieved using the following attribute definition:
 ----
 <attrib name="OtherIdentifyingInfo" index-of="#IdentifyingDescriptions matches '.*ServiceTag'" alias="serviceTag" type="String"/>
 ----
+
+[[ga-performance-mgmt-collectors-wsman-special-attributes]]
+====== Special Attributes
+
+A group can contain the placeholder attribute `##ElementCount##` that, during collection, will be populated with the total number of results returned for that group. 
+This can be used to threshold on the number results returned by an enumeration. 
+[source, xml]
+----
+    <group name="Event-1234"
+           resource-uri="http://schemas.microsoft.com/wbem/wsman/1/wmi/root/cimv2/*"
+           dialect="http://schemas.microsoft.com/wbem/wsman/1/WQL"
+           filter="select * from Win32_NTLogEvent where LogFile = 'Some-Application-Specific-Logfile/Operational' AND EventCode = '1234'"
+           resource-type="node">
+        <attrib name="##ElementCount##" alias="elementCount" type="Gauge"/>
+    </group>
+----


### PR DESCRIPTION
This commit adds a special attribute for `WsManCollector` that, if specified as part of a group, will be populated by the total number of results returned by an enumeration.  This is needed because WQL has no support for a sql-like `count(*)` function and in some cases, it is beneficial to be able to threshold on the number of results returned by an enumeration as opposed to thresholding on the data itself, e.g. monitoring Windows eventlog for new events matching specific criteria.

* JIRA : http://issues.opennms.org/browse/NMS-12115

