### PR TITLE
NMS-12081: System tests for thresholding

### DIFF
--- a/smoke-test/src/main/java/org/opennms/smoketest/stacks/MinionProfile.java
+++ b/smoke-test/src/main/java/org/opennms/smoketest/stacks/MinionProfile.java
@@ -29,11 +29,10 @@
 package org.opennms.smoketest.stacks;
 
 import java.net.MalformedURLException;
-import java.net.URL;
 import java.nio.file.Path;
 import java.util.Collections;
-import java.util.LinkedHashMap;
-import java.util.Map;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 
@@ -52,13 +51,13 @@ public class MinionProfile {
     private final String location;
     private final String id;
     private final boolean icmpSupportEnabled;
-    private final Map<URL, String> files;
+    private final List<OverlayFile> files;
 
     private MinionProfile(Builder builder) {
         location = builder.location;
         id = builder.id;
         icmpSupportEnabled = builder.icmpSupportEnabled;
-        files = Collections.unmodifiableMap(builder.files);
+        files = Collections.unmodifiableList(builder.files);
     }
 
     public static Builder newBuilder() {
@@ -69,7 +68,7 @@ public class MinionProfile {
         private String location = DEFAULT_LOCATION;
         private String id = UUID.randomUUID().toString();
         private boolean icmpSupportEnabled = false;
-        private Map<URL, String> files = new LinkedHashMap<>();
+        private List<OverlayFile> files = new LinkedList<>();
 
         public Builder withLocation(String location) {
             this.location = Objects.requireNonNull(location);
@@ -88,7 +87,7 @@ public class MinionProfile {
 
         public Builder withFile(Path source, String target) {
             try {
-                files.put(source.toUri().toURL(), target);
+                files.add(new OverlayFile(source.toUri().toURL(), target));
             } catch (MalformedURLException e) {
                 throw new RuntimeException(e);
             }
@@ -113,8 +112,9 @@ public class MinionProfile {
         return icmpSupportEnabled;
     }
 
-    public Map<URL, String> getFiles() {
+    public List<OverlayFile> getFiles() {
         return files;
     }
+
 
 }

--- a/smoke-test/src/main/java/org/opennms/smoketest/stacks/OpenNMSProfile.java
+++ b/smoke-test/src/main/java/org/opennms/smoketest/stacks/OpenNMSProfile.java
@@ -37,6 +37,8 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 
+import com.google.common.io.Resources;
+
 /**
  * All the OpenNMS related settings that need to be tweaked on
  * a per container basis.
@@ -107,6 +109,18 @@ public class OpenNMSProfile {
         /**
          * Add files to the container over
          *
+         * @param resourceName resource path
+         * @param target path the target file related to $OPENNMS_HOME/
+         * @return this builder
+         */
+        public Builder withFile(String resourceName, String target) {
+            files.add(new OverlayFile(Resources.getResource(resourceName), target));
+            return this;
+        }
+
+        /**
+         * Add files to the container over
+         *
          * @param source source URL
          * @param target path the target file related to $OPENNMS_HOME/
          * @param permissions file permissions to set
@@ -114,6 +128,19 @@ public class OpenNMSProfile {
          */
         public Builder withFile(URL source, String target, Set<PosixFilePermission> permissions) {
             files.add(new OverlayFile(source, target, permissions));
+            return this;
+        }
+
+        /**
+         * Add files to the container over
+         *
+         * @param resourceName resource path
+         * @param target path the target file related to $OPENNMS_HOME/
+         * @param permissions file permissions to set
+         * @return this builder
+         */
+        public Builder withFile(String resourceName, String target, Set<PosixFilePermission> permissions) {
+            files.add(new OverlayFile(Resources.getResource(resourceName), target, permissions));
             return this;
         }
 

--- a/smoke-test/src/main/java/org/opennms/smoketest/stacks/OpenNMSProfile.java
+++ b/smoke-test/src/main/java/org/opennms/smoketest/stacks/OpenNMSProfile.java
@@ -31,11 +31,11 @@ package org.opennms.smoketest.stacks;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermission;
 import java.util.Collections;
-import java.util.LinkedHashMap;
-import java.util.Map;
-import java.util.Objects;
-import java.util.UUID;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
 
 /**
  * All the OpenNMS related settings that need to be tweaked on
@@ -48,11 +48,11 @@ public class OpenNMSProfile {
     public static OpenNMSProfile DEFAULT = OpenNMSProfile.newBuilder().build();
 
     private final boolean kafkaProducerEnabled;
-    private final Map<URL, String> files;
+    private final List<OverlayFile> files;
 
     private OpenNMSProfile(Builder builder) {
         kafkaProducerEnabled = builder.kafkaProducerEnabled;
-        files = Collections.unmodifiableMap(builder.files);
+        files = Collections.unmodifiableList(builder.files);
     }
 
     public static Builder newBuilder() {
@@ -61,7 +61,7 @@ public class OpenNMSProfile {
 
     public static final class Builder {
         private boolean kafkaProducerEnabled = false;
-        private Map<URL, String> files = new LinkedHashMap<>();
+        private List<OverlayFile> files = new LinkedList<>();
 
         /**
          * Enable/disable the Kafka producer feature.
@@ -80,15 +80,40 @@ public class OpenNMSProfile {
          * Add files to the container over
          *
          * @param source path to the source file on disk
-         * @param target path the target file related to $OPENNMS_HOME/
+         * @param target path the target file relative to $OPENNMS_HOME/
          * @return this builder
          */
         public Builder withFile(Path source, String target) {
             try {
-                files.put(source.toUri().toURL(), target);
+                files.add(new OverlayFile(source.toUri().toURL(), target));
             } catch (MalformedURLException e) {
                 throw new RuntimeException(e);
             }
+            return this;
+        }
+
+        /**
+         * Add files to the container over
+         *
+         * @param source source URL
+         * @param target path the target file related to $OPENNMS_HOME/
+         * @return this builder
+         */
+        public Builder withFile(URL source, String target) {
+            files.add(new OverlayFile(source, target));
+            return this;
+        }
+
+        /**
+         * Add files to the container over
+         *
+         * @param source source URL
+         * @param target path the target file related to $OPENNMS_HOME/
+         * @param permissions file permissions to set
+         * @return this builder
+         */
+        public Builder withFile(URL source, String target, Set<PosixFilePermission> permissions) {
+            files.add(new OverlayFile(source, target, permissions));
             return this;
         }
 
@@ -107,7 +132,7 @@ public class OpenNMSProfile {
         return kafkaProducerEnabled;
     }
 
-    public Map<URL, String> getFiles() {
+    public List<OverlayFile> getFiles() {
         return files;
     }
 

--- a/smoke-test/src/main/java/org/opennms/smoketest/stacks/OverlayFile.java
+++ b/smoke-test/src/main/java/org/opennms/smoketest/stacks/OverlayFile.java
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.smoketest.stacks;
+
+import java.net.URL;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.Collections;
+import java.util.Objects;
+import java.util.Set;
+
+public class OverlayFile {
+
+    private final URL source;
+    private final String target;
+    private final Set<PosixFilePermission> permissions;
+
+    public OverlayFile(URL source, String target) {
+        this(source, target, Collections.emptySet());
+    }
+
+    public OverlayFile(URL source, String target, Set<PosixFilePermission> permissions) {
+        this.source = Objects.requireNonNull(source);
+        this.target = Objects.requireNonNull(target);
+        this.permissions = Collections.unmodifiableSet(Objects.requireNonNull(permissions));
+    }
+
+    public URL getSource() {
+        return source;
+    }
+
+    public String getTarget() {
+        return target;
+    }
+
+    public Set<PosixFilePermission> getPermissions() {
+        return permissions;
+    }
+}

--- a/smoke-test/src/main/java/org/opennms/smoketest/stacks/SentinelProfile.java
+++ b/smoke-test/src/main/java/org/opennms/smoketest/stacks/SentinelProfile.java
@@ -29,11 +29,10 @@
 package org.opennms.smoketest.stacks;
 
 import java.net.MalformedURLException;
-import java.net.URL;
 import java.nio.file.Path;
 import java.util.Collections;
-import java.util.LinkedHashMap;
-import java.util.Map;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 
@@ -49,11 +48,11 @@ public class SentinelProfile {
 
     private final String id;
 
-    private final Map<URL, String> files;
+    private final List<OverlayFile> files;
 
     private SentinelProfile(Builder builder) {
         id = builder.id;
-        files = Collections.unmodifiableMap(builder.files);
+        files = Collections.unmodifiableList(builder.files);
     }
 
     public static Builder newBuilder() {
@@ -62,11 +61,11 @@ public class SentinelProfile {
 
     public static final class Builder {
         private String id = UUID.randomUUID().toString();
-        private Map<URL, String> files = new LinkedHashMap<>();
+        private List<OverlayFile> files = new LinkedList<>();
 
         public Builder withFile(Path source, String target) {
             try {
-                files.put(source.toUri().toURL(), target);
+                files.add(new OverlayFile(source.toUri().toURL(), target));
             } catch (MalformedURLException e) {
                 throw new RuntimeException(e);
             }
@@ -87,7 +86,8 @@ public class SentinelProfile {
         return id;
     }
 
-    public Map<URL, String> getFiles() {
+    public List<OverlayFile> getFiles() {
         return files;
     }
+
 }

--- a/smoke-test/src/main/java/org/opennms/smoketest/utils/RestClient.java
+++ b/smoke-test/src/main/java/org/opennms/smoketest/utils/RestClient.java
@@ -59,8 +59,13 @@ import org.json.XML;
 import org.opennms.core.xml.JaxbUtils;
 import org.opennms.netmgt.measurements.model.QueryRequest;
 import org.opennms.netmgt.measurements.model.QueryResponse;
+import org.opennms.netmgt.model.OnmsAlarm;
+import org.opennms.netmgt.model.OnmsAlarmCollection;
+import org.opennms.netmgt.model.OnmsCategory;
 import org.opennms.netmgt.model.OnmsEvent;
+import org.opennms.netmgt.model.OnmsEventCollection;
 import org.opennms.netmgt.model.OnmsIpInterface;
+import org.opennms.netmgt.model.OnmsMetaData;
 import org.opennms.netmgt.model.OnmsMonitoredService;
 import org.opennms.netmgt.model.OnmsNode;
 import org.opennms.netmgt.model.minion.OnmsMinion;
@@ -102,6 +107,16 @@ public class RestClient {
     public RestClient(URL url, String username, String password) {
         this.url = url;
         authorizationHeader = "Basic " + Base64.getEncoder().encodeToString((username + ":" + password).getBytes());
+    }
+
+    /**
+     * Create a REST client that connects to http://localhost:8980/ with the default credentials.
+     * Used for testing.
+     *
+     * @return a new REST client for OpenNMS on the localhost
+     */
+    public static RestClient forLocalhost() {
+        return new RestClient(InetSocketAddress.createUnresolved("127.0.0.1", 8980));
     }
 
     private static URL toUrl(InetSocketAddress addr) {
@@ -190,7 +205,7 @@ public class RestClient {
         // Serialize service to XML and remove attributes which can't be set
         final String serviceXml = XmlUtils.filterAttributesFromXml(JaxbUtils.marshal(service),
                 // We shouldn't be adding any extra attributes here, but rather work to remove these
-                "down");
+                "down", "statusLong");
         return getBuilder(target).post(Entity.entity(serviceXml, MediaType.APPLICATION_XML));
     }
 
@@ -204,6 +219,11 @@ public class RestClient {
         final WebTarget target = getTarget().path("nodes").path(nodeCriteria).path("ipinterfaces").path(ipAddress)
                 .path("services").path(service);
         return getBuilder(target).get();
+    }
+
+    public Response deleteNode(String nodeCriteria) {
+        final WebTarget target = getTarget().path("nodes").path(nodeCriteria);
+        return getBuilder(target).delete();
     }
 
     public Response deleteService(String nodeCriteria, String ipAddress, String service) {
@@ -220,6 +240,26 @@ public class RestClient {
     public Response getResponseForInterface(String nodeCriteria, String ipAddress) {
         final WebTarget target = getTarget().path("nodes").path(nodeCriteria).path("ipinterfaces").path(ipAddress);
         return getBuilder(target).get();
+    }
+
+    public Response setNodeLevelMetadata(String nodeCriteria, OnmsMetaData metaData) {
+        final WebTarget target = getTargetV2().path("nodes").path(nodeCriteria).path("metadata");
+        return getBuilder(target).post(Entity.entity(metaData, MediaType.APPLICATION_XML));
+    }
+
+    public OnmsEventCollection getEventsForNode(int nodeId) {
+        final WebTarget target = getTarget().path("events").queryParam("node.id", nodeId);
+        return getBuilder(target).accept(MediaType.APPLICATION_XML).get(OnmsEventCollection.class);
+    }
+
+    public OnmsAlarmCollection getAlarmsByEventUei(String eventUei) {
+        final WebTarget target = getTarget().path("alarms").queryParam("uei", eventUei);
+        return getBuilder(target).accept(MediaType.APPLICATION_XML).get(OnmsAlarmCollection.class);
+    }
+
+    public OnmsAlarmCollection getAlarmsForNode(int nodeId) {
+        final WebTarget target = getTarget().path("alarms").queryParam("node.id", nodeId);
+        return getBuilder(target).accept(MediaType.APPLICATION_XML).get(OnmsAlarmCollection.class);
     }
 
     public OnmsMinion getMinion(String id) {
@@ -291,6 +331,25 @@ public class RestClient {
     public void resetGeocoderConfiguration() {
         final WebTarget target = getTargetV2().path("geocoding").path("config");
         final Response response = getBuilder(target).delete();
+        if (!Response.Status.Family.SUCCESSFUL.equals(response.getStatusInfo().getFamily())) {
+            throw new RuntimeException(String.format("Request failed with: %s:\n%s",
+                    response.getStatusInfo().getReasonPhrase(), response.hasEntity() ? response.readEntity(String.class) : ""));
+        }
+    }
+
+    public void addCategory(String categoryName) {
+        final OnmsCategory category = new OnmsCategory(categoryName);
+        final WebTarget target = getTarget().path("categories");
+        final Response response = getBuilder(target).post(Entity.entity(category, MediaType.APPLICATION_XML));
+        if (!Response.Status.Family.SUCCESSFUL.equals(response.getStatusInfo().getFamily())) {
+            throw new RuntimeException(String.format("Request failed with: %s:\n%s",
+                    response.getStatusInfo().getReasonPhrase(), response.hasEntity() ? response.readEntity(String.class) : ""));
+        }
+    }
+
+    public void addCategoryToNode(String nodeCriteria, String categoryName) {
+        final WebTarget target = getTarget().path("categories").path(categoryName).path("nodes").path(nodeCriteria);
+        final Response response = getBuilder(target).put(null);
         if (!Response.Status.Family.SUCCESSFUL.equals(response.getStatusInfo().getFamily())) {
             throw new RuntimeException(String.format("Request failed with: %s:\n%s",
                     response.getStatusInfo().getReasonPhrase(), response.hasEntity() ? response.readEntity(String.class) : ""));

--- a/smoke-test/src/test/java/org/opennms/smoketest/ThresholdingIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/ThresholdingIT.java
@@ -28,7 +28,6 @@
 
 package org.opennms.smoketest;
 
-import static com.google.common.io.Resources.getResource;
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -85,13 +84,13 @@ public class ThresholdingIT {
     @ClassRule
     public static final OpenNMSStack stack = OpenNMSStack.withModel(StackModel.newBuilder()
             .withOpenNMS(OpenNMSProfile.newBuilder()
-                    .withFile(getResource("thresholding/poller-configuration.xml"), "etc/poller-configuration.xml")
-                    .withFile(getResource("thresholding/collectd-configuration.xml"), "etc/collectd-configuration.xml")
-                    .withFile(getResource("thresholding/jdbc-datacollection-config.xml"), "etc/jdbc-datacollection-config.xml")
-                    .withFile(getResource("thresholding/resource-types.d/metadata.xml"), "etc/resource-types.d/metadata.xml")
-                    .withFile(getResource("thresholding/threshd-configuration.xml"), "etc/threshd-configuration.xml")
-                    .withFile(getResource("thresholding/thresholds.xml"), "etc/thresholds.xml")
-                    .withFile(getResource("thresholding/thresholding-test-monitor.sh"), "bin/thresholding-test-monitor.sh",
+                    .withFile("thresholding/poller-configuration.xml", "etc/poller-configuration.xml")
+                    .withFile("thresholding/collectd-configuration.xml", "etc/collectd-configuration.xml")
+                    .withFile("thresholding/jdbc-datacollection-config.xml", "etc/jdbc-datacollection-config.xml")
+                    .withFile("thresholding/resource-types.d/metadata.xml", "etc/resource-types.d/metadata.xml")
+                    .withFile("thresholding/threshd-configuration.xml", "etc/threshd-configuration.xml")
+                    .withFile("thresholding/thresholds.xml", "etc/thresholds.xml")
+                    .withFile("thresholding/thresholding-test-monitor.sh", "bin/thresholding-test-monitor.sh",
                             // Make the script executable
                             PosixFilePermissions.fromString("rwxrwxr-x"))
                     .build())

--- a/smoke-test/src/test/java/org/opennms/smoketest/ThresholdingIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/ThresholdingIT.java
@@ -101,7 +101,7 @@ public class ThresholdingIT {
 
     @Before
     public void setUp() {
-        restClient = RestClient.forLocalhost(); // stack.opennms().getRestClient();
+        restClient = stack.opennms().getRestClient();
         // Delete the test node from a possible previous run
         restClient.deleteNode(TEST_NODE_CRITERIA);
     }

--- a/smoke-test/src/test/java/org/opennms/smoketest/ThresholdingIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/ThresholdingIT.java
@@ -1,0 +1,263 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.smoketest;
+
+import static com.google.common.io.Resources.getResource;
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.not;
+import static org.opennms.netmgt.events.api.EventConstants.ABSOLUTE_CHANGE_THRESHOLD_EVENT_UEI;
+import static org.opennms.netmgt.events.api.EventConstants.HIGH_THRESHOLD_EVENT_UEI;
+
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
+
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.core.Response;
+
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.opennms.core.utils.InetAddressUtils;
+import org.opennms.netmgt.model.OnmsAlarm;
+import org.opennms.netmgt.model.OnmsAlarmCollection;
+import org.opennms.netmgt.model.OnmsCategory;
+import org.opennms.netmgt.model.OnmsEvent;
+import org.opennms.netmgt.model.OnmsEventCollection;
+import org.opennms.netmgt.model.OnmsIpInterface;
+import org.opennms.netmgt.model.OnmsMetaData;
+import org.opennms.netmgt.model.OnmsMonitoredService;
+import org.opennms.netmgt.model.OnmsNode;
+import org.opennms.netmgt.model.OnmsServiceType;
+import org.opennms.netmgt.model.OnmsSeverity;
+import org.opennms.smoketest.stacks.OpenNMSProfile;
+import org.opennms.smoketest.stacks.OpenNMSStack;
+import org.opennms.smoketest.stacks.StackModel;
+import org.opennms.smoketest.utils.RestClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Tests to validate that thresholding works.
+ *
+ * @author jwhite
+ */
+public class ThresholdingIT {
+    private static final Logger LOG = LoggerFactory.getLogger(ThresholdingIT.class);
+
+    private static final String TEST_NODE_FS = "test";
+    private static final String TEST_NODE_FID = "thresholding-test-node";
+    private static final String TEST_NODE_CRITERIA = TEST_NODE_FS + ":" + TEST_NODE_FID;
+    private static final String TEST_NODE_CATEGORY = "ThresholdingTest";
+    private static final String TEST_SVC_NAME = "SvcToThreshold";
+
+    @ClassRule
+    public static final OpenNMSStack stack = OpenNMSStack.withModel(StackModel.newBuilder()
+            .withOpenNMS(OpenNMSProfile.newBuilder()
+                    .withFile(getResource("thresholding/poller-configuration.xml"), "etc/poller-configuration.xml")
+                    .withFile(getResource("thresholding/collectd-configuration.xml"), "etc/collectd-configuration.xml")
+                    .withFile(getResource("thresholding/jdbc-datacollection-config.xml"), "etc/jdbc-datacollection-config.xml")
+                    .withFile(getResource("thresholding/resource-types.d/metadata.xml"), "etc/resource-types.d/metadata.xml")
+                    .withFile(getResource("thresholding/threshd-configuration.xml"), "etc/threshd-configuration.xml")
+                    .withFile(getResource("thresholding/thresholds.xml"), "etc/thresholds.xml")
+                    .withFile(getResource("thresholding/thresholding-test-monitor.sh"), "bin/thresholding-test-monitor.sh",
+                            // Make the script executable
+                            PosixFilePermissions.fromString("rwxrwxr-x"))
+                    .build())
+            .build());
+
+    private RestClient restClient;
+
+    @Before
+    public void setUp() {
+        restClient = RestClient.forLocalhost(); // stack.opennms().getRestClient();
+        // Delete the test node from a possible previous run
+        restClient.deleteNode(TEST_NODE_CRITERIA);
+    }
+
+    /**
+     * Goal: We want to trigger a threshold based on response time data from a service
+     * monitored by the poller.
+     *
+     * We achieve this by configuring a SystemExecuteMonitor for a node where the amount
+     * of time to sleep is passed in as a command line argument and is populated by the node
+     * meta-data. Controlling the delay then becomes as simple as changing the meta-data value.
+     *
+     */
+    @Test
+    public void canTriggerHighResponseTimeThreshold() {
+        // Create our test node
+        LOG.info("Setting up test node...");
+        final OnmsNode testNode = addNode();
+        // Validate that the was associated with the expected category
+        final Set<String> categoriesOnNode = testNode.getCategories().stream()
+                .map(OnmsCategory::getName)
+                .collect(Collectors.toSet());
+        assertThat(categoriesOnNode, hasItem(TEST_NODE_CATEGORY));
+
+        // Verify that no existing highThresholdExceeded alarm exists for the node
+        assertThat(getAlarmsUeisForNode(testNode.getId()), not(hasItem(HIGH_THRESHOLD_EVENT_UEI)));
+
+        // Increase the service delay above the threshold limit
+        setServiceDelay(6, TimeUnit.SECONDS);
+
+        // Wait for the high threshold to appear
+        LOG.info("Waiting for high threshold alarm...");
+        await().atMost(1, TimeUnit.MINUTES).pollInterval(5, TimeUnit.SECONDS)
+                .until(() -> getAlarmsUeisForNode(testNode.getId()), hasItem(HIGH_THRESHOLD_EVENT_UEI));
+
+        // Now remove the delay
+        setServiceDelay(0, TimeUnit.SECONDS);
+
+        LOG.info("Waiting for high threshold alarm to clear...");
+        await().atMost(1, TimeUnit.MINUTES).pollInterval(5, TimeUnit.SECONDS)
+                .until(() -> restClient.getAlarmsByEventUei(HIGH_THRESHOLD_EVENT_UEI)
+                        .getObjects().get(0).getSeverity(), equalTo(OnmsSeverity.CLEARED));
+    }
+
+    /**
+     * Goal: We want to trigger a threshold based on metrics collected by collectd.
+     *
+     * We achieve this by configuring the JDBC collector to collect values from the node_metadata table,
+     * storing these in generic type resources, and thresholding on these values.
+     *
+     * Controlling the thresholds becomes as simple as changing the meta-data values.
+     */
+    @Test
+    public void canTriggerAbsoluteChangeThreshold() {
+        // Create our test node
+        LOG.info("Setting up test node...");
+        final OnmsNode testNode = addNode();
+        // Validate that the was associated with the expected category
+        final Set<String> categoriesOnNode = testNode.getCategories().stream()
+                .map(OnmsCategory::getName)
+                .collect(Collectors.toSet());
+        assertThat(categoriesOnNode, hasItem(TEST_NODE_CATEGORY));
+
+        // Verify that no existing absoluteChangeExceeded event exists for the node
+        assertThat(getEventsUeisForNode(testNode.getId()), not(hasItem(ABSOLUTE_CHANGE_THRESHOLD_EVENT_UEI)));
+
+        // We use a another distinct meta-data attribute since there's a bug with JDBC collector whereby it doesn't
+        // build generic type resources if there is only one result in the result-set
+        final AtomicLong currentValue = new AtomicLong(0);
+        final int absoluteChangeThreshold = 10;
+
+        // Wait for the high threshold to appear
+        LOG.info("Waiting for absolute change threshold event...");
+        await().atMost(2, TimeUnit.MINUTES).pollInterval(10, TimeUnit.SECONDS).pollDelay(0, TimeUnit.SECONDS)
+                .until(() -> {
+                    // Keep increasing the value until the threshold is hit
+                    setServiceJitter(currentValue.getAndAdd(absoluteChangeThreshold), TimeUnit.SECONDS);
+                    return getEventsUeisForNode(testNode.getId());
+                }, hasItem(ABSOLUTE_CHANGE_THRESHOLD_EVENT_UEI));
+    }
+
+    private Set<String> getAlarmsUeisForNode(int nodeId) {
+        final OnmsAlarmCollection alarms = restClient.getAlarmsForNode(nodeId);
+        return alarms.getObjects().stream().map(OnmsAlarm::getUei).collect(Collectors.toSet());
+    }
+
+    private Set<String> getEventsUeisForNode(int nodeId) {
+        final OnmsEventCollection events = restClient.getEventsForNode(nodeId);
+        return events.getObjects().stream().map(OnmsEvent::getEventUei).collect(Collectors.toSet());
+    }
+
+    private void setServiceDelay(long duration, TimeUnit unit) {
+        LOG.info("Updating service delay to {} {}.", duration, unit);
+        OnmsMetaData metaData = new OnmsMetaData("test", "svc-delay", Long.toString(unit.toMillis(duration)));
+        Response response = restClient.setNodeLevelMetadata(TEST_NODE_CRITERIA, metaData);
+        assertThat(response.getStatus(), equalTo(HttpServletResponse.SC_NO_CONTENT));
+    }
+
+    private void setServiceJitter(long duration, TimeUnit unit) {
+        LOG.info("Updating service jitter to {} {}.", duration, unit);
+        OnmsMetaData metaData = new OnmsMetaData("test", "svc-jitter", Long.toString(unit.toMillis(duration)));
+        Response response = restClient.setNodeLevelMetadata(TEST_NODE_CRITERIA, metaData);
+        assertThat(response.getStatus(), equalTo(HttpServletResponse.SC_NO_CONTENT));
+    }
+
+    private OnmsNode addNode() {
+        // Create a node
+        OnmsNode node = new OnmsNode();
+        // Set foreignSource and foreignId to use it as nodeCriteria
+        node.setForeignSource(TEST_NODE_FS);
+        node.setForeignId(TEST_NODE_FID);
+        node.setLabel(TEST_NODE_FID);
+        node.setType(OnmsNode.NodeType.ACTIVE);
+
+        // Create the node
+        Response response = restClient.addNode(node);
+        assertThat(response.getStatus(), equalTo(HttpServletResponse.SC_CREATED));
+
+        // Create the category
+        try {
+            restClient.addCategory(TEST_NODE_CATEGORY);
+        } catch (Exception e) {
+            // Ignore exceptions if the category already exists
+        }
+
+        // Now add a category to the node
+        restClient.addCategoryToNode(TEST_NODE_CRITERIA, TEST_NODE_CATEGORY);
+
+        // Add meta-data to the node
+        OnmsMetaData metaData = new OnmsMetaData();
+        metaData.setContext("test");
+        metaData.setKey("svc-delay");
+        metaData.setValue(Integer.toString(0));
+        response = restClient.setNodeLevelMetadata(TEST_NODE_CRITERIA, metaData);
+        assertThat(response.getStatus(), equalTo(HttpServletResponse.SC_NO_CONTENT));
+
+        // Add Interface to node
+        OnmsIpInterface iface = new OnmsIpInterface();
+        iface.setNode(node);
+        iface.setIsManaged("M");
+        iface.setIpAddress(InetAddressUtils.getInetAddress("192.168.1.1"));
+        iface.setIpHostName("192.168.1.1");
+        response = restClient.addInterface(TEST_NODE_CRITERIA, iface);
+        assertThat(response.getStatus(), equalTo(HttpServletResponse.SC_CREATED));
+
+        // Add a service on interface (192.168.1.1)
+        OnmsMonitoredService svc = new OnmsMonitoredService();
+        OnmsServiceType serviceType = new OnmsServiceType();
+        serviceType.setName(TEST_SVC_NAME);
+        svc.setServiceType(serviceType);
+        svc.setStatus("A");
+        svc.setIpInterface(iface);
+        response = restClient.addService(TEST_NODE_CRITERIA, "192.168.1.1", svc);
+        assertThat(response.getStatus(), equalTo(HttpServletResponse.SC_CREATED));
+
+        // Return the effective node
+        return restClient.getNode(TEST_NODE_CRITERIA);
+    }
+}

--- a/smoke-test/src/test/java/org/opennms/smoketest/utils/OverlayUtilsTest.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/utils/OverlayUtilsTest.java
@@ -39,7 +39,10 @@ import java.nio.file.Paths;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.opennms.smoketest.stacks.OverlayFile;
 import org.testcontainers.shaded.com.google.common.collect.ImmutableMap;
+
+import com.google.common.collect.Lists;
 
 public class OverlayUtilsTest {
 
@@ -59,11 +62,10 @@ public class OverlayUtilsTest {
 
         File target = temporaryFolder.newFolder("target");
 
-        OverlayUtils.copyFiles(ImmutableMap.<URL, String>builder()
-                .put(a.toURI().toURL(), "a")
-                .put(b.toURI().toURL(), "b")
-                .put(c.toURI().toURL(), "c")
-                .build(), target.toPath());
+        OverlayUtils.copyFiles(Lists.newArrayList(new OverlayFile(a.toURI().toURL(), "a"),
+                        new OverlayFile(b.toURI().toURL(), "b"),
+                        new OverlayFile(c.toURI().toURL(), "c")),
+                target.toPath());
 
         // Verify
         assertThat(target.toPath().resolve("a").toFile().isFile(), equalTo(true));

--- a/smoke-test/src/test/resources/thresholding/collectd-configuration.xml
+++ b/smoke-test/src/test/resources/thresholding/collectd-configuration.xml
@@ -1,0 +1,17 @@
+<collectd-configuration xmlns="http://xmlns.opennms.org/xsd/config/collectd" threads="50">
+    <package name="thresholding-test">
+        <filter>catincThresholdingTest</filter>
+        <include-range begin="1.1.1.1" end="254.254.254.254"/>
+        <include-range begin="::1" end="ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"/>
+        <service name="SvcToThreshold" interval="5000" user-defined="false" status="on">
+            <parameter key="collection" value="SvcToThreshold"/>
+            <parameter key="thresholding-enabled" value="true"/>
+            <parameter key="driver" value="org.postgresql.Driver"/>
+            <parameter key="user" value="opennms"/>
+            <parameter key="password" value="opennms"/>
+            <!-- "db" matches the alias used by the PostgreSQL container in the test stack -->
+            <parameter key="url" value="jdbc:postgresql://db:5432/opennms"/>
+        </service>
+    </package>
+    <collector service="SvcToThreshold" class-name="org.opennms.netmgt.collectd.JdbcCollector"/>
+</collectd-configuration>

--- a/smoke-test/src/test/resources/thresholding/jdbc-datacollection-config.xml
+++ b/smoke-test/src/test/resources/thresholding/jdbc-datacollection-config.xml
@@ -1,0 +1,24 @@
+<jdbc-datacollection-config xmlns="http://xmlns.opennms.org/xsd/config/jdbc-datacollection" rrdRepository="/opt/opennms/share/rrd/snmp/">
+    <jdbc-collection name="SvcToThreshold">
+        <rrd step="5">
+            <rra>RRA:AVERAGE:0.5:1:2016</rra>
+            <rra>RRA:AVERAGE:0.5:12:1488</rra>
+            <rra>RRA:AVERAGE:0.5:288:366</rra>
+            <rra>RRA:MAX:0.5:288:366</rra>
+            <rra>RRA:MIN:0.5:288:366</rra>
+        </rrd>
+
+        <queries>
+            <query name="node_metadata" recheckInterval="0" ifType="all" resourceType="nodeMetadata" instance-column="key">
+                <statement>
+                    <queryString>
+                        SELECT key, value FROM node_metadata WHERE context = 'test'
+                    </queryString>
+                </statement>
+                <columns>
+                    <column name="value" data-source-name="value" type="gauge" alias="value"/>
+                </columns>
+            </query>
+        </queries>
+    </jdbc-collection>
+</jdbc-datacollection-config>

--- a/smoke-test/src/test/resources/thresholding/poller-configuration.xml
+++ b/smoke-test/src/test/resources/thresholding/poller-configuration.xml
@@ -1,0 +1,32 @@
+<poller-configuration xmlns="http://xmlns.opennms.org/xsd/config/poller" threads="30" nextOutageId="SELECT nextval('outageNxtId')" serviceUnresponsiveEnabled="false" pathOutageEnabled="false">
+   <node-outage status="on" pollAllIfNoCriticalServiceDefined="true">
+      <critical-service name="ICMP"/>
+   </node-outage>
+   <package name="thresholding-test">
+      <filter>catincThresholdingTest</filter>
+      <include-range begin="1.1.1.1" end="254.254.254.254"/>
+      <include-range begin="::1" end="ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"/>
+      <rrd step="5">
+         <rra>RRA:AVERAGE:0.5:1:2016</rra>
+         <rra>RRA:AVERAGE:0.5:12:1488</rra>
+         <rra>RRA:AVERAGE:0.5:288:366</rra>
+         <rra>RRA:MAX:0.5:288:366</rra>
+         <rra>RRA:MIN:0.5:288:366</rra>
+      </rrd>
+      <service name="SvcToThreshold" interval="5000" user-defined="true" status="on">
+         <parameter key="script" value="/opt/opennms/bin/thresholding-test-monitor.sh"/>
+         <parameter key="banner" value="OK"/>
+         <parameter key="retry" value="0"/>
+         <parameter key="args" value="${test:svc-delay}"/>
+         <parameter key="timeout" value="30000"/>
+         <parameter key="thresholding-enabled" value="true"/>
+         <parameter key="rrd-repository" value="/opt/opennms/share/rrd/response"/>
+         <parameter key="rrd-base-name" value="svc-to-thresh"/>
+         <parameter key="ds-name" value="svc-to-thresh"/>
+      </service>
+      <!-- Query every 5 seconds always -->
+      <downtime begin="0" interval="5000"/><!-- 5s -->
+   </package>
+
+   <monitor service="SvcToThreshold" class-name="org.opennms.netmgt.poller.monitors.SystemExecuteMonitor"/>
+</poller-configuration>

--- a/smoke-test/src/test/resources/thresholding/resource-types.d/metadata.xml
+++ b/smoke-test/src/test/resources/thresholding/resource-types.d/metadata.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<resource-types>
+    <resourceType name="nodeMetadata" label="meta" resourceLabel="Node Meta-Data (${instanceId})">
+        <persistenceSelectorStrategy class="org.opennms.netmgt.collection.support.PersistAllSelectorStrategy"/>
+        <storageStrategy class="org.opennms.netmgt.collection.support.IndexStorageStrategy"/>
+    </resourceType>
+</resource-types>

--- a/smoke-test/src/test/resources/thresholding/threshd-configuration.xml
+++ b/smoke-test/src/test/resources/thresholding/threshd-configuration.xml
@@ -1,0 +1,21 @@
+<threshd-configuration xmlns="http://xmlns.opennms.org/xsd/config/thresholding" threads="5">
+    <!-- For polling -->
+    <package name="ttest-latency">
+        <filter>catincThresholdingTest</filter>
+        <include-range begin="1.1.1.1" end="254.254.254.254"/>
+        <include-range begin="::1" end="ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"/>
+        <service name="SvcToThreshold" interval="5000" user-defined="false" status="on">
+            <parameter key="thresholding-group" value="ttest-latency"/>
+        </service>
+    </package>
+
+    <!-- For collection -->
+    <package name="ttest-collect">
+        <filter>catincThresholdingTest</filter>
+        <include-range begin="1.1.1.1" end="254.254.254.254"/>
+        <include-range begin="::1" end="ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"/>
+        <service name="SvcToThreshold" interval="5000" user-defined="false" status="on">
+            <parameter key="thresholding-group" value="ttest-collect"/>
+        </service>
+    </package>
+</threshd-configuration>

--- a/smoke-test/src/test/resources/thresholding/thresholding-test-monitor.sh
+++ b/smoke-test/src/test/resources/thresholding/thresholding-test-monitor.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+DELAY_IN_MS=$1
+
+re='^[0-9]+$'
+if ! [[ $DELAY_IN_MS =~ $re ]] ; then
+   echo "error: '$DELAY_IN_MS' is not a number'" >&2; exit 1
+fi
+
+DELAY_IN_SECONDS=$(echo "$DELAY_IN_MS / 1000" | bc)
+sleep "$DELAY_IN_SECONDS"
+
+echo "OK"
+exit 0

--- a/smoke-test/src/test/resources/thresholding/thresholds.xml
+++ b/smoke-test/src/test/resources/thresholding/thresholds.xml
@@ -1,0 +1,8 @@
+<thresholding-config xmlns="http://xmlns.opennms.org/xsd/config/thresholding">
+    <group name="ttest-latency" rrdRepository="/opt/opennms/share/rrd/response">
+        <threshold type="high" ds-type="if" value="5000.0" rearm="4000.0" trigger="2" ds-name="svc-to-thresh"/>
+    </group>
+    <group name="ttest-collect" rrdRepository="/opt/opennms/share/rrd/snmp">
+        <threshold type="absoluteChange" ds-type="nodeMetadata" value="10000.0" rearm="1.0" trigger="1" ds-name="value"/>
+    </group>
+</thresholding-config>


### PR DESCRIPTION
JIRA: https://issues.opennms.org/browse/NMS-12081

Here we add a new system test used to verify thresholding of response time (pollerd) and generic resources (collectd w/ JDBC collector).

We also update the system tests APIs to be able to control the file permissions for overlaid files, so that we can set the executable bit on our script.
