### PR TITLE
NMS-12121: Opennms 24.1.0 on Ubuntu 19.04 won’t install ....

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+
+opennms (24.1.1-1) stable; urgency=medium
+
+  * New stable release.  This release is identical to 24.1.0-1 but adds support
+    for postgresql 11 as a dependency.
+
 opennms (24.1.0-1) stable; urgency=medium
 
   * New stable release. It contains a bunch of bug fixes and a few enhancements,

--- a/debian/control
+++ b/debian/control
@@ -39,7 +39,7 @@ Description: Enterprise-grade Open-source Network Management Platform (Source)
 
 Package: opennms-db
 Architecture: all
-Depends: postgresql-10 | postgresql-9.6 | postgresql-9.5 | postgresql-9.4 | postgresql-9.3 | postgresql-9.2 | postgresql-9.1, iplike-pgsql10 | iplike-pgsql96 | iplike-pgsql95 | iplike-pgsql94 | iplike-pgsql93 | iplike-pgsql92 | iplike-pgsql91, debconf
+Depends: postgresql-11 | postgresql-10 | postgresql-9.6 | postgresql-9.5 | postgresql-9.4 | postgresql-9.3 | postgresql-9.2 | postgresql-9.1, iplike-pgsql11 | iplike-pgsql10 | iplike-pgsql96 | iplike-pgsql95 | iplike-pgsql94 | iplike-pgsql93 | iplike-pgsql92 | iplike-pgsql91, debconf
 Description: Enterprise-grade Open-source Network Management Platform (Database)
  OpenNMS is an enterprise-grade network management system written in Java.
  .
@@ -57,7 +57,7 @@ Description: Enterprise-grade Open-source Network Management Platform (Database)
 Package: opennms-server
 Architecture: all
 Depends: opennms-common (=${binary:Version}), libopennms-java (=${binary:Version}), libopennmsdeps-java (=${binary:Version}), mailx
-Suggests: jrrd2, rrdtool (>= 1.4.8), postgresql-client-10 | postgresql-client-9.6 | postgresql-client-9.5 | postgresql-client-9.4 | postgresql-client-9.3 | postgresql-client-9.2 | postgresql-client-9.1
+Suggests: jrrd2, rrdtool (>= 1.4.8), postgresql-client-11 | postgresql-client-10 | postgresql-client-9.6 | postgresql-client-9.5 | postgresql-client-9.4 | postgresql-client-9.3 | postgresql-client-9.2 | postgresql-client-9.1
 Description: Enterprise-grade Open-source Network Management Platform (Daemon)
  OpenNMS is an enterprise-grade network management system written in Java.
  .


### PR DESCRIPTION
Ubuntu server 19.04 installs PostgresSQL 11 which is not in dependency list

added version 11 dependencies in proper file and added a row in changelog

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-12121
* Bamboo (Continuous Integration): https://bamboo.opennms.org/

