### PR TITLE
NMS-12133: Allow to install Horizon from a tarball

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ yarn-error.log
 # Ignore Docker OCI image files
 *.oci
 opennms-container/horizon/rpms/*.rpm
+opennms-container/horizon/tarball/*.tar.gz
 opennms-container/minion/rpms/*.rpm
 opennms-container/sentinel/rpms/*.rpm
 

--- a/opennms-container/horizon/Dockerfile
+++ b/opennms-container/horizon/Dockerfile
@@ -33,24 +33,28 @@ ARG ONMS_PACKAGES="opennms-core opennms-webapp-jetty opennms-webapp-remoting ope
 ARG ADD_YUM_PACKAGES
 
 COPY ./rpms /tmp/rpms
+COPY ./tarball /tmp/tarball
 
 SHELL ["/bin/bash", "-c"]
 
 # Install repositories, system and OpenNMS packages and do some cleanup
-RUN if [[ "$(ls -1 /tmp/rpms/*.rpm 2>/dev/null | wc -l)" != 0 ]]; then yum -y localinstall /tmp/rpms/*.rpm; else yum install -y ${ONMS_PACKAGES}; fi && \
+# 1. Try to install from tarball
+# 2. Try to install from local RPMS
+# 3. Try to install from public yum repository
+RUN if [[ "$(ls -1 /tmp/tarball/*.tar.gz 2>/dev/null | wc -l)" != 0 ]]; then mkdir -p /opt/opennms && tar xzf /tmp/tarball/opennms-*.tar.gz -C /opt/opennms && cp -r /opt/opennms/etc /opt/opennms/share/etc-pristine; elif [[ "$(ls -1 /tmp/rpms/*.rpm 2>/dev/null | wc -l)" != 0 ]]; then yum -y localinstall /tmp/rpms/*.rpm; else yum install -y ${ONMS_PACKAGES}; fi && \
     if [[ -n ${ADD_YUM_PACKAGES} ]]; then yum -y install ${ADD_YUM_PACKAGES}; fi && \
-    rm -rf /tmp/rpms && \
+    rm -rf /tmp/rpms /tmp/tarball && \
     yum clean all && \
     rm -rf /var/cache/yum && \
     rm -rf /opt/opennms/logs \
-           /var/opennms/rrd \
-           /var/opennms/reports && \
+           /opt/opennms/share/rrd \
+           /opt/opennms/share/reports && \
     mkdir -p /opennms-data/logs \
              /opennms-data/rrd \
              /opennms-data/reports && \
     ln -s /opennms-data/logs /opt/opennms/logs && \
-    ln -s /opennms-data/rrd /var/opennms/rrd && \
-    ln -s /opennms-data/reports /var/opennms/reports
+    ln -s /opennms-data/rrd /opt/opennms/share/rrd && \
+    ln -s /opennms-data/reports /opt/opennms/share/reports
 
 # Add templates replaced at runtime and entrypoint
 COPY ./assets/*.tpl /root/

--- a/opennms-container/horizon/Dockerfile
+++ b/opennms-container/horizon/Dockerfile
@@ -41,7 +41,12 @@ SHELL ["/bin/bash", "-c"]
 # 1. Try to install from tarball
 # 2. Try to install from local RPMS
 # 3. Try to install from public yum repository
-RUN if [[ "$(ls -1 /tmp/tarball/*.tar.gz 2>/dev/null | wc -l)" != 0 ]]; then mkdir -p /opt/opennms && tar xzf /tmp/tarball/opennms-*.tar.gz -C /opt/opennms && cp -r /opt/opennms/etc /opt/opennms/share/etc-pristine; elif [[ "$(ls -1 /tmp/rpms/*.rpm 2>/dev/null | wc -l)" != 0 ]]; then yum -y localinstall /tmp/rpms/*.rpm; else yum install -y ${ONMS_PACKAGES}; fi && \
+RUN if [[ "$(ls -1 /tmp/tarball/*.tar.gz 2>/dev/null | wc -l)" != 0 ]]; then \
+        mkdir -p /opt/opennms && tar xzf /tmp/tarball/opennms-*.tar.gz -C /opt/opennms && \
+        cp -r /opt/opennms/etc /opt/opennms/share/etc-pristine; \
+        elif [[ "$(ls -1 /tmp/rpms/*.rpm 2>/dev/null | wc -l)" != 0 ]]; then \
+        yum -y localinstall /tmp/rpms/*.rpm; \
+        else yum install -y ${ONMS_PACKAGES}; fi && \
     if [[ -n ${ADD_YUM_PACKAGES} ]]; then yum -y install ${ADD_YUM_PACKAGES}; fi && \
     rm -rf /tmp/rpms /tmp/tarball && \
     yum clean all && \

--- a/opennms-container/horizon/tarball/.gitkeep
+++ b/opennms-container/horizon/tarball/.gitkeep
@@ -1,0 +1,1 @@
+gitkeep

--- a/smoke-test/README.md
+++ b/smoke-test/README.md
@@ -51,6 +51,12 @@ cd smoke-test
 mvn -DskipITs=false integration-test```
 ```
 
+### Run tests from local tarball
+
+If you have the code compiled and assembled locally, you can use the tarball build for container images, so you don't have to wait for the CI/CD to download the container image artifact.
+Drop the assembled OpenNMS-tar.gz file in `opennms-container/horizon/tarball` and run `docker build -t horizon .`
+Smoke tests will run the image named `horizon` in your local Docker image repo.
+
 ## Writing system tests
 
 When writing a new test, use the stack rule to setup the environment:
@@ -91,7 +97,7 @@ If a test is failing and we have a patched .jar we want to deploy, how can we re
 #### OSGi
 
 1. Link m2s by setting `-Dorg.opennms.dev.m2=/home/jesse/.m2/repository`
-1. Set a breakpoink in the test before the exercised feature is used and re-run it in debug mode
+2. Set a breakpoink in the test before the exercised feature is used and re-run it in debug mode
 3. Reload the bundles in Karaf using: `bundle:watch *`
 
 #### Filesystem


### PR DESCRIPTION
Add capability to install OpenNMS Horizon OCI based on a tarball artifact. The logic to install from different sources is implemented as the following:

1. Try to install from a tar.gz file in horizon/tarball
2. Try to install from local RPM files in horizon/rpms
3. Try to install from public remote mirrors

For the reason a tarball assembly doesn't have etc-pristine, we create it from a plain install so we can use the same principle to initialize configurations. Additionally the path to deal with persisted files is normalized to the /opt/opennms directory instead of using the linked ones.

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-12133


