### PR TITLE
NMS-12161: Find Java 8 and 11

### DIFF
--- a/debian/opennms-server.opennms.init
+++ b/debian/opennms-server.opennms.init
@@ -38,7 +38,7 @@ fi
 
 # Check for JAVA_HOME
 if [ -z "$JAVA_HOME" ]; then
-	for dir in `find /usr/lib/jvm/* -maxdepth 0 -type d | grep java-8 | sort -u -r`; do
+	for dir in `find /usr/lib/jvm/* -maxdepth 0 -type d | grep -E "java-(8|11)" | sort -u -r`; do
 		if [ -d "$dir" -a -f "$dir/lib/tools.jar" ]; then
 			JAVA_HOME="$dir"
 			break


### PR DESCRIPTION
Changed the Debian init script to find Java 8 and Java 11 installations. On systems which have just Java 11 installed, it is otherwise not possible to start OpenNMS.

JIRA: https://issues.opennms.org/browse/NMS-12161