### PR TITLE
NMS-10721: Route flow messages depending on exporter

### DIFF
--- a/core/ipc/sink/api/src/main/java/org/opennms/core/ipc/sink/api/SinkModule.java
+++ b/core/ipc/sink/api/src/main/java/org/opennms/core/ipc/sink/api/SinkModule.java
@@ -28,6 +28,8 @@
 
 package org.opennms.core.ipc.sink.api;
 
+import java.util.Optional;
+
 /**
  * Defines how the messages will be routed and marshaled/unmarshaled over the wire.
  *
@@ -93,4 +95,14 @@ public interface SinkModule<S extends Message, T extends Message> {
      * messages for this module.
      */
     AsyncPolicy getAsyncPolicy();
+
+    /**
+     * Thr routing key will be used to ensure all messages of the same group is handled by the same consumer.
+     *
+     * @param message the message to generate the routing key from
+     * @return the routing key or, {@code Optional.empty()} if no routing is required
+     */
+    default Optional<String> getRoutingKey(T message) {
+        return Optional.empty();
+    }
 }

--- a/core/ipc/sink/camel/client/src/main/java/org/opennms/core/ipc/sink/camel/client/CamelRemoteMessageDispatcherFactory.java
+++ b/core/ipc/sink/camel/client/src/main/java/org/opennms/core/ipc/sink/camel/client/CamelRemoteMessageDispatcherFactory.java
@@ -30,6 +30,7 @@ package org.opennms.core.ipc.sink.camel.client;
 
 import static org.opennms.core.ipc.sink.api.Message.SINK_METRIC_PRODUCER_DOMAIN;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -78,29 +79,31 @@ public class CamelRemoteMessageDispatcherFactory extends AbstractMessageDispatch
                 CamelSinkConstants.JMS_QUEUE_PREFIX, module.getId());
         Map<String, Object> headers = new HashMap<>();
         headers.put(CamelSinkConstants.JMS_QUEUE_NAME_HEADER, queueNameFactory.getName());
-        return headers;
+        return Collections.unmodifiableMap(headers);
     }
 
     @Override
     public <S extends Message, T extends Message> void dispatch(SinkModule<S, T> module, Map<String, Object> headers, T message) {
+        final Map<String, Object> messageHeaders = new HashMap<>(headers);
+        module.getRoutingKey(message).ifPresent(id -> messageHeaders.put(CamelSinkConstants.JMS_XGROUP_ID, id));
 
-        byte[] sinkMessageBytes = module.marshal((T) message);
+        byte[] sinkMessageBytes = module.marshal(message);
         // Add tracing info to jms headers
         final Tracer tracer = tracerRegistry.getTracer();
         if (tracer.activeSpan() != null) {
             TracingInfoCarrier tracingInfoCarrier = new TracingInfoCarrier();
             tracer.inject(tracer.activeSpan().context(), Format.Builtin.TEXT_MAP, tracingInfoCarrier);
             tracer.activeSpan().setTag(TracerConstants.TAG_LOCATION, identity.getLocation());
-            if (headers.get(CamelSinkConstants.JMS_QUEUE_NAME_HEADER) instanceof String) {
-                tracer.activeSpan().setTag(TracerConstants.TAG_TOPIC, (String) headers.get(CamelSinkConstants.JMS_QUEUE_NAME_HEADER));
+            if (messageHeaders.get(CamelSinkConstants.JMS_QUEUE_NAME_HEADER) instanceof String) {
+                tracer.activeSpan().setTag(TracerConstants.TAG_TOPIC, (String) messageHeaders.get(CamelSinkConstants.JMS_QUEUE_NAME_HEADER));
             }
             tracer.activeSpan().setTag(TracerConstants.TAG_MESSAGE_SIZE, sinkMessageBytes.length);
             String tracingInfo = TracingInfoCarrier.marshalTracingInfo(tracingInfoCarrier.getTracingInfoMap());
             if (tracingInfo != null) {
-                headers.put(CamelSinkConstants.JMS_SINK_TRACING_INFO, tracingInfo);
+                messageHeaders.put(CamelSinkConstants.JMS_SINK_TRACING_INFO, tracingInfo);
             }
         }
-        template.sendBodyAndHeaders(endpoint, sinkMessageBytes, headers);
+        template.sendBodyAndHeaders(endpoint, sinkMessageBytes, messageHeaders);
     }
 
     @Override

--- a/core/ipc/sink/camel/common/src/main/java/org/opennms/core/ipc/sink/camel/CamelSinkConstants.java
+++ b/core/ipc/sink/camel/common/src/main/java/org/opennms/core/ipc/sink/camel/CamelSinkConstants.java
@@ -33,4 +33,5 @@ public interface CamelSinkConstants {
     String JMS_QUEUE_NAME_HEADER = "JmsQueueName";
     String CAMEL_JMS_REQUEST_TIMEOUT_HEADER = "CamelJmsRequestTimeout";
     String JMS_SINK_TRACING_INFO = "SinkTracingInfo";
+    String JMS_XGROUP_ID = "JMSXGroupId";
 }

--- a/core/ipc/sink/kafka/client/src/main/java/org/opennms/core/ipc/sink/kafka/client/KafkaRemoteMessageDispatcherFactory.java
+++ b/core/ipc/sink/kafka/client/src/main/java/org/opennms/core/ipc/sink/kafka/client/KafkaRemoteMessageDispatcherFactory.java
@@ -104,11 +104,12 @@ public class KafkaRemoteMessageDispatcherFactory extends AbstractMessageDispatch
             LOG.trace("dispatch({}): sending message {}", topic, message);
             byte[] sinkMessageContent = module.marshal(message);
             String messageId = UUID.randomUUID().toString();
+            final String messageKey = module.getRoutingKey(message).orElse(messageId);
             // Send this message to Kafka, If partition changed in between sending chunks of a larger message,
             // try to send message again.
             boolean partitionChanged = false;
             do {
-                partitionChanged = sendMessage(topic, messageId, sinkMessageContent);
+                partitionChanged = sendMessage(topic, messageId, messageKey, sinkMessageContent);
             } while (partitionChanged);
         }
     }
@@ -119,16 +120,17 @@ public class KafkaRemoteMessageDispatcherFactory extends AbstractMessageDispatch
      * been sent to different partitions, method will return true indicating partition change in between.
      * @param topic    The kafka topic message needs to be sent
      * @param messageId  The messageId message associated with
+     * @param messageKey  The key used to route the message
      * @param sinkMessageContent  The sink message
      * @return partitionChanged  return true if partition changed in between else return false by default.
      */
-    private boolean sendMessage(String topic, String messageId, byte[] sinkMessageContent) {
+    private boolean sendMessage(String topic, String messageId, String messageKey, byte[] sinkMessageContent) {
         int partitionNum = INVALID_PARTITION;
         boolean partitionChanged = false;
         int totalChunks = IntMath.divide(sinkMessageContent.length, maxBufferSize, RoundingMode.UP);
         for (int chunk = 0; chunk < totalChunks; chunk++) {
             byte[] messageInBytes = wrapMessageToProto(messageId, chunk, totalChunks, sinkMessageContent);
-            final ProducerRecord<String, byte[]> record = new ProducerRecord<>(topic, messageId, messageInBytes);
+            final ProducerRecord<String, byte[]> record = new ProducerRecord<>(topic, messageKey, messageInBytes);
             // Add tags to tracer active span.
             Span activeSpan = getTracer().activeSpan();
             if (activeSpan != null && (chunk + 1 == totalChunks)) {

--- a/features/telemetry/common/src/main/java/org/opennms/netmgt/telemetry/common/ipc/TelemetrySinkModule.java
+++ b/features/telemetry/common/src/main/java/org/opennms/netmgt/telemetry/common/ipc/TelemetrySinkModule.java
@@ -32,6 +32,7 @@ import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
 import java.util.Date;
 import java.util.Objects;
+import java.util.Optional;
 
 import org.opennms.core.ipc.sink.api.AggregationPolicy;
 import org.opennms.core.ipc.sink.api.AsyncPolicy;
@@ -166,6 +167,11 @@ public class TelemetrySinkModule implements SinkModule<TelemetryMessage, Telemet
                 return true;
             }
         };
+    }
+
+    @Override
+    public Optional<String> getRoutingKey(final TelemetryProtos.TelemetryMessageLog message) {
+        return Optional.of(String.format("%s@%s:%d", message.getLocation(), message.getSourceAddress(), message.getSourcePort()));
     }
 
     public DistPollerDao getDistPollerDao() {


### PR DESCRIPTION
This allows each sink module to derive a routing key for every message. Messages with the same routing key are then routed to the same consumer.