### PR TITLE
Use double quotes for ESLINT command in order to build cross platform

### DIFF
--- a/core/web-assets/package.json
+++ b/core/web-assets/package.json
@@ -162,7 +162,7 @@
         "release": "yarn run lint && yarn run build-release",
         "watch": "webpack --colors --display-error-details --watch --env=development",
         "watch-release": "webpack --colors --display-error-details --watch --env=production",
-        "lint": "eslint 'src/**/*.[jt]s'",
+        "lint": "eslint \"src/**/*.[jt]s\"",
         "maven-test": "jest --all --verbose --useStderr=false --color=false",
         "test": "jest"
     }


### PR DESCRIPTION
This PR changes the eslint command to use (escaped) doub le-quotes instead of single quotes.
The single quotes are not handled properly in the windows shell and so ./compile.pl currently fails

With the change, I was successfully able to run 'yarn lint' in both windows shell and in WSL.
