### PR TITLE
NMS-12182: Collect and graph packet reception rates for telemetryd listeners

### DIFF
--- a/container/features/src/main/resources/features-minion.xml
+++ b/container/features/src/main/resources/features-minion.xml
@@ -130,6 +130,7 @@
     <feature name="minion-telemetryd-receivers" description="Minion :: Telemetry :: Receivers" version="${project.version}">
       <!-- Not fully needed, but a convenient way to install netty4 -->
       <feature>camel-netty4</feature>
+      <feature>dropwizard-metrics</feature>
       <bundle>mvn:com.google.protobuf/protobuf-java/${protobufVersion}</bundle>
       <bundle>mvn:org.mongodb/bson/${bsonVersion}</bundle>
       <bundle>mvn:org.apache.commons/commons-csv/${commonsCsvVersion}</bundle>

--- a/container/features/src/main/resources/features-sentinel.xml
+++ b/container/features/src/main/resources/features-sentinel.xml
@@ -86,6 +86,7 @@
     <feature name="sentinel-telemetry" description="OpenNMS :: Sentinel :: Telemetry" version="${project.version}">
         <feature>sentinel-persistence</feature>
 
+        <feature>dropwizard-metrics</feature>
         <feature>camel-netty4</feature>
         <!-- Needed to bootstrap opennms-core-ipc-sink-api Spring context -->
         <feature>camel-spring</feature>

--- a/container/features/src/main/resources/features.xml
+++ b/container/features/src/main/resources/features.xml
@@ -943,6 +943,7 @@
     <feature name="opennms-telemetry-collection" version="${project.version}" description="OpenNMS :: Telemetry :: Collection">
         <feature>guava</feature>
         <feature>camel-netty4</feature>
+        <feature>dropwizard-metrics</feature>
         <feature>opennms-collection-api</feature>
         <feature>opennms-thresholding-api</feature>
         <feature>opennms-osgi-jsr223</feature>
@@ -957,6 +958,7 @@
     <feature name="opennms-telemetry-daemon" version="${project.version}" description="OpenNMS :: Telemetry :: Daemon">
         <feature>camel-netty4</feature>
         <feature>camel-spring</feature>
+        <feature>dropwizard-metrics</feature>
         <feature>opennms-core-daemon</feature>
         <feature>opennms-core-ipc-sink-api</feature>
         <feature>opennms-dao-api</feature>
@@ -1404,7 +1406,7 @@
     <feature name="opennms-es-rest" version="${project.version}" description="OpenNMS :: Features :: ElasticSearch Rest">
         <details>OpenNMS :: Features :: ElasticSearch Rest</details>
         <feature>opennms-jest</feature>
-        <bundle>mvn:io.dropwizard.metrics/metrics-core/3.1.2</bundle>
+        <feature>dropwizard-metrics</feature>
         <bundle>mvn:joda-time/joda-time/${jodaTimeVersion}</bundle>
         <bundle>wrap:mvn:com.swrve/rate-limited-logger/${rateLimitedLoggerVersion}</bundle>
         <bundle>mvn:org.opennms.core.ipc.sink/org.opennms.core.ipc.sink.api/${project.version}</bundle>

--- a/features/telemetry/api/pom.xml
+++ b/features/telemetry/api/pom.xml
@@ -41,5 +41,9 @@
       <artifactId>spring-dependencies</artifactId>
       <type>pom</type>
     </dependency>
+    <dependency>
+      <groupId>io.dropwizard.metrics</groupId>
+      <artifactId>metrics-core</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/features/telemetry/api/src/main/java/org/opennms/netmgt/telemetry/api/registry/TelemetryRegistry.java
+++ b/features/telemetry/api/src/main/java/org/opennms/netmgt/telemetry/api/registry/TelemetryRegistry.java
@@ -39,6 +39,8 @@ import org.opennms.netmgt.telemetry.config.api.AdapterDefinition;
 import org.opennms.netmgt.telemetry.config.api.ListenerDefinition;
 import org.opennms.netmgt.telemetry.config.api.ParserDefinition;
 
+import com.codahale.metrics.MetricRegistry;
+
 public interface TelemetryRegistry {
     Adapter getAdapter(AdapterDefinition adapterDefinition);
     Listener getListener(ListenerDefinition listenerDefinition);
@@ -49,4 +51,6 @@ public interface TelemetryRegistry {
     void removeDispatcher(String queueName);
     Collection<AsyncDispatcher<TelemetryMessage>> getDispatchers();
     AsyncDispatcher<TelemetryMessage> getDispatcher(String queueName);
+
+    MetricRegistry getMetricRegistry();
 }

--- a/features/telemetry/listeners/src/main/java/org/opennms/netmgt/telemetry/listeners/factory/TcpListenerFactory.java
+++ b/features/telemetry/listeners/src/main/java/org/opennms/netmgt/telemetry/listeners/factory/TcpListenerFactory.java
@@ -68,7 +68,7 @@ public class TcpListenerFactory implements ListenerFactory {
         if (parser.size() != listenerDefinition.getParsers().size()) {
             throw new IllegalArgumentException("Each parser must be of type TcpParser but was not.");
         }
-        final TcpListener listener = new TcpListener(listenerDefinition.getName(), parser.iterator().next());
+        final TcpListener listener = new TcpListener(listenerDefinition.getName(), parser.iterator().next(), telemetryRegistry.getMetricRegistry());
         final BeanWrapper wrapper = PropertyAccessorFactory.forBeanPropertyAccess(listener);
         wrapper.setPropertyValues(listenerDefinition.getParameterMap());
         return listener;

--- a/features/telemetry/listeners/src/main/java/org/opennms/netmgt/telemetry/listeners/factory/UdpListenerFactory.java
+++ b/features/telemetry/listeners/src/main/java/org/opennms/netmgt/telemetry/listeners/factory/UdpListenerFactory.java
@@ -59,12 +59,12 @@ public class UdpListenerFactory implements ListenerFactory {
         // Ensure each defined parser is of type UdpParser
         final List<UdpParser> parsers = listenerDefinition.getParsers().stream()
                 .map(p -> telemetryRegistry.getParser(p))
-                .filter(p -> p instanceof UdpParser && p != null)
+                .filter(p -> p instanceof UdpParser)
                 .map(p -> (UdpParser) p).collect(Collectors.toList());
         if (parsers.size() != listenerDefinition.getParsers().size()) {
             throw new IllegalArgumentException("Each parser must be of type UdpParser but was not.");
         }
-        final Listener listener = new UdpListener(listenerDefinition.getName(), parsers);
+        final Listener listener = new UdpListener(listenerDefinition.getName(), parsers, telemetryRegistry.getMetricRegistry());
         final BeanWrapper wrapper = PropertyAccessorFactory.forBeanPropertyAccess(listener);
         wrapper.setPropertyValues(listenerDefinition.getParameterMap());
         return listener;

--- a/features/telemetry/protocols/collection/src/main/java/org/opennms/netmgt/telemetry/protocols/collection/AbstractCollectionAdapterFactory.java
+++ b/features/telemetry/protocols/collection/src/main/java/org/opennms/netmgt/telemetry/protocols/collection/AbstractCollectionAdapterFactory.java
@@ -34,12 +34,16 @@ import org.opennms.netmgt.dao.api.InterfaceToNodeCache;
 import org.opennms.netmgt.dao.api.NodeDao;
 import org.opennms.netmgt.filter.api.FilterDao;
 import org.opennms.netmgt.telemetry.api.adapter.AdapterFactory;
+import org.opennms.netmgt.telemetry.api.registry.TelemetryRegistry;
 import org.opennms.netmgt.threshd.api.ThresholdingService;
 import org.osgi.framework.BundleContext;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.support.TransactionOperations;
 
 public abstract class AbstractCollectionAdapterFactory implements AdapterFactory {
+
+    @Autowired
+    private TelemetryRegistry telemetryRegistry;
 
     @Autowired
     private CollectionAgentFactory collectionAgentFactory;
@@ -63,6 +67,14 @@ public abstract class AbstractCollectionAdapterFactory implements AdapterFactory
     private ThresholdingService thresholdingService;
 
     private final BundleContext bundleContext;
+
+    public TelemetryRegistry getTelemetryRegistry() {
+        return telemetryRegistry;
+    }
+
+    public void setTelemetryRegistry(TelemetryRegistry telemetryRegistry) {
+        this.telemetryRegistry = telemetryRegistry;
+    }
 
     public AbstractCollectionAdapterFactory(BundleContext bundleContext) {
         this.bundleContext = bundleContext;

--- a/features/telemetry/protocols/flows/src/main/java/org/opennms/netmgt/telemetry/protocols/flows/AbstractFlowAdapter.java
+++ b/features/telemetry/protocols/flows/src/main/java/org/opennms/netmgt/telemetry/protocols/flows/AbstractFlowAdapter.java
@@ -28,6 +28,8 @@
 
 package org.opennms.netmgt.telemetry.protocols.flows;
 
+import static com.codahale.metrics.MetricRegistry.name;
+
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
@@ -66,14 +68,17 @@ public abstract class AbstractFlowAdapter<P> implements Adapter {
      */
     private final Histogram packetsPerLogHistogram;
 
-    public AbstractFlowAdapter(final MetricRegistry metricRegistry,
-                           final FlowRepository flowRepository,
-                           final Converter<P> converter) {
+    public AbstractFlowAdapter(final String name,
+                               final MetricRegistry metricRegistry,
+                               final FlowRepository flowRepository,
+                               final Converter<P> converter) {
+        Objects.requireNonNull(name);
+        Objects.requireNonNull(metricRegistry);
         this.flowRepository = Objects.requireNonNull(flowRepository);
         this.converter = Objects.requireNonNull(converter);
 
-        logParsingTimer = metricRegistry.timer("logParsing");
-        packetsPerLogHistogram = metricRegistry.histogram("packetsPerLog");
+        logParsingTimer = metricRegistry.timer(name("adapters", name, "logParsing"));
+        packetsPerLogHistogram = metricRegistry.histogram(name("adapters", name, "packetsPerLog"));
     }
 
     @Override

--- a/features/telemetry/protocols/jti/adapter/src/main/java/org/opennms/netmgt/telemetry/protocols/jti/adapter/JtiAdapterFactory.java
+++ b/features/telemetry/protocols/jti/adapter/src/main/java/org/opennms/netmgt/telemetry/protocols/jti/adapter/JtiAdapterFactory.java
@@ -53,7 +53,7 @@ public class JtiAdapterFactory extends AbstractCollectionAdapterFactory {
 
     @Override
     public Adapter createBean(final AdapterDefinition adapterConfig) {
-        final JtiGpbAdapter adapter = new JtiGpbAdapter();
+        final JtiGpbAdapter adapter = new JtiGpbAdapter(adapterConfig.getName(), getTelemetryRegistry().getMetricRegistry());
         adapter.setConfig(adapterConfig);
         adapter.setCollectionAgentFactory(getCollectionAgentFactory());
         adapter.setInterfaceToNodeCache(getInterfaceToNodeCache());

--- a/features/telemetry/protocols/jti/adapter/src/main/java/org/opennms/netmgt/telemetry/protocols/jti/adapter/JtiGpbAdapter.java
+++ b/features/telemetry/protocols/jti/adapter/src/main/java/org/opennms/netmgt/telemetry/protocols/jti/adapter/JtiGpbAdapter.java
@@ -60,6 +60,7 @@ import org.springframework.transaction.TransactionStatus;
 import org.springframework.transaction.support.TransactionCallback;
 import org.springframework.transaction.support.TransactionOperations;
 
+import com.codahale.metrics.MetricRegistry;
 import com.google.common.collect.Iterables;
 import com.google.protobuf.ExtensionRegistry;
 import com.google.protobuf.InvalidProtocolBufferException;
@@ -93,6 +94,10 @@ public class JtiGpbAdapter extends AbstractPersistingAdapter {
     private NodeDao nodeDao;
 
     private TransactionOperations transactionTemplate;
+
+    public JtiGpbAdapter(String name, MetricRegistry metricRegistry) {
+        super(name, metricRegistry);
+    }
 
     @Override
     public Stream<CollectionSetWithAgent> handleMessage(TelemetryMessageLogEntry message, TelemetryMessageLog messageLog) {

--- a/features/telemetry/protocols/jti/adapter/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/features/telemetry/protocols/jti/adapter/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -11,6 +11,7 @@
 
 	<bean id="jtiFactory" class="org.opennms.netmgt.telemetry.protocols.jti.adapter.JtiAdapterFactory">
 		<argument ref="blueprintBundleContext" />
+		<property name="telemetryRegistry" ref="telemetryRegistry" />
 		<property name="collectionAgentFactory" ref="collectionAgentFactory" />
 		<property name="interfaceToNodeCache" ref="interfaceToNodeCache" />
 		<property name="nodeDao" ref="nodeDao" />
@@ -25,6 +26,7 @@
 		</service-properties>
 	</service>
 
+	<reference id="telemetryRegistry" interface="org.opennms.netmgt.telemetry.api.registry.TelemetryRegistry" />
 	<reference id="collectionAgentFactory" interface="org.opennms.netmgt.collection.api.CollectionAgentFactory" />
 	<reference id="interfaceToNodeCache" interface="org.opennms.netmgt.dao.api.InterfaceToNodeCache" />
 	<reference id="nodeDao" interface="org.opennms.netmgt.dao.api.NodeDao" />

--- a/features/telemetry/protocols/netflow/adapter/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/adapter/ipfix/IpfixAdapter.java
+++ b/features/telemetry/protocols/netflow/adapter/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/adapter/ipfix/IpfixAdapter.java
@@ -38,9 +38,10 @@ import com.codahale.metrics.MetricRegistry;
 
 public class IpfixAdapter extends AbstractFlowAdapter<BsonDocument> {
 
-    public IpfixAdapter(final MetricRegistry metricRegistry,
+    public IpfixAdapter(final String name,
+                        final MetricRegistry metricRegistry,
                         final FlowRepository flowRepository) {
-        super(metricRegistry, flowRepository, new IpfixConverter());
+        super(name, metricRegistry, flowRepository, new IpfixConverter());
     }
 
     @Override

--- a/features/telemetry/protocols/netflow/adapter/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/adapter/ipfix/IpfixAdapterFactory.java
+++ b/features/telemetry/protocols/netflow/adapter/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/adapter/ipfix/IpfixAdapterFactory.java
@@ -33,12 +33,13 @@ import java.util.Objects;
 import org.opennms.netmgt.flows.api.FlowRepository;
 import org.opennms.netmgt.telemetry.api.adapter.Adapter;
 import org.opennms.netmgt.telemetry.api.adapter.AdapterFactory;
+import org.opennms.netmgt.telemetry.api.registry.TelemetryRegistry;
 import org.opennms.netmgt.telemetry.config.api.AdapterDefinition;
 
 import com.codahale.metrics.MetricRegistry;
 
 public class IpfixAdapterFactory implements AdapterFactory {
-    private MetricRegistry metricRegistry;
+    private TelemetryRegistry telemetryRegistry;
     private FlowRepository flowRepository;
 
     @Override
@@ -48,14 +49,14 @@ public class IpfixAdapterFactory implements AdapterFactory {
 
     @Override
     public Adapter createBean(final AdapterDefinition adapterConfig) {
-        Objects.requireNonNull(metricRegistry);
+        Objects.requireNonNull(telemetryRegistry);
         Objects.requireNonNull(flowRepository);
 
-        return new IpfixAdapter(metricRegistry, flowRepository);
+        return new IpfixAdapter(adapterConfig.getName(), telemetryRegistry.getMetricRegistry(), flowRepository);
     }
 
-    public void setMetricRegistry(MetricRegistry metricRegistry) {
-        this.metricRegistry = metricRegistry;
+    public void setTelemetryRegistry(TelemetryRegistry telemetryRegistry) {
+        this.telemetryRegistry = telemetryRegistry;
     }
 
     public void setFlowRepository(FlowRepository flowRepository) {

--- a/features/telemetry/protocols/netflow/adapter/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/adapter/netflow5/Netflow5Adapter.java
+++ b/features/telemetry/protocols/netflow/adapter/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/adapter/netflow5/Netflow5Adapter.java
@@ -40,9 +40,10 @@ import com.codahale.metrics.MetricRegistry;
 
 public class Netflow5Adapter extends AbstractFlowAdapter<BsonDocument> {
 
-    public Netflow5Adapter(final MetricRegistry metricRegistry,
+    public Netflow5Adapter(final String name,
+                           final MetricRegistry metricRegistry,
                            final FlowRepository flowRepository) {
-        super(metricRegistry, flowRepository, new Netflow5Converter());
+        super(name, metricRegistry, flowRepository, new Netflow5Converter());
     }
 
     @Override

--- a/features/telemetry/protocols/netflow/adapter/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/adapter/netflow5/Netflow5AdapterFactory.java
+++ b/features/telemetry/protocols/netflow/adapter/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/adapter/netflow5/Netflow5AdapterFactory.java
@@ -33,12 +33,13 @@ import java.util.Objects;
 import org.opennms.netmgt.flows.api.FlowRepository;
 import org.opennms.netmgt.telemetry.api.adapter.Adapter;
 import org.opennms.netmgt.telemetry.api.adapter.AdapterFactory;
+import org.opennms.netmgt.telemetry.api.registry.TelemetryRegistry;
 import org.opennms.netmgt.telemetry.config.api.AdapterDefinition;
 
 import com.codahale.metrics.MetricRegistry;
 
 public class Netflow5AdapterFactory implements AdapterFactory {
-    private MetricRegistry metricRegistry;
+    private TelemetryRegistry telemetryRegistry;
     private FlowRepository flowRepository;
 
     @Override
@@ -48,14 +49,14 @@ public class Netflow5AdapterFactory implements AdapterFactory {
 
     @Override
     public Adapter createBean(final AdapterDefinition adapterConfig) {
-        Objects.requireNonNull(metricRegistry);
+        Objects.requireNonNull(telemetryRegistry);
         Objects.requireNonNull(flowRepository);
 
-        return new Netflow5Adapter(metricRegistry, flowRepository);
+        return new Netflow5Adapter(adapterConfig.getName(), telemetryRegistry.getMetricRegistry(), flowRepository);
     }
 
-    public void setMetricRegistry(MetricRegistry metricRegistry) {
-        this.metricRegistry = metricRegistry;
+    public void setTelemetryRegistry(TelemetryRegistry telemetryRegistry) {
+        this.telemetryRegistry = telemetryRegistry;
     }
 
     public void setFlowRepository(FlowRepository flowRepository) {

--- a/features/telemetry/protocols/netflow/adapter/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/adapter/netflow9/Netflow9Adapter.java
+++ b/features/telemetry/protocols/netflow/adapter/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/adapter/netflow9/Netflow9Adapter.java
@@ -38,9 +38,10 @@ import com.codahale.metrics.MetricRegistry;
 
 public class Netflow9Adapter extends AbstractFlowAdapter<BsonDocument> {
 
-    public Netflow9Adapter(final MetricRegistry metricRegistry,
+    public Netflow9Adapter(final String name,
+                           final MetricRegistry metricRegistry,
                            final FlowRepository flowRepository) {
-        super(metricRegistry, flowRepository, new Netflow9Converter());
+        super(name, metricRegistry, flowRepository, new Netflow9Converter());
     }
 
     @Override

--- a/features/telemetry/protocols/netflow/adapter/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/adapter/netflow9/Netflow9AdapterFactory.java
+++ b/features/telemetry/protocols/netflow/adapter/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/adapter/netflow9/Netflow9AdapterFactory.java
@@ -33,12 +33,13 @@ import java.util.Objects;
 import org.opennms.netmgt.flows.api.FlowRepository;
 import org.opennms.netmgt.telemetry.api.adapter.Adapter;
 import org.opennms.netmgt.telemetry.api.adapter.AdapterFactory;
+import org.opennms.netmgt.telemetry.api.registry.TelemetryRegistry;
 import org.opennms.netmgt.telemetry.config.api.AdapterDefinition;
 
 import com.codahale.metrics.MetricRegistry;
 
 public class Netflow9AdapterFactory implements AdapterFactory {
-    private MetricRegistry metricRegistry;
+    private TelemetryRegistry telemetryRegistry;
     private FlowRepository flowRepository;
 
     @Override
@@ -48,14 +49,14 @@ public class Netflow9AdapterFactory implements AdapterFactory {
 
     @Override
     public Adapter createBean(final AdapterDefinition adapterConfig) {
-        Objects.requireNonNull(metricRegistry);
+        Objects.requireNonNull(telemetryRegistry);
         Objects.requireNonNull(flowRepository);
 
-        return new Netflow9Adapter(metricRegistry, flowRepository);
+        return new Netflow9Adapter(adapterConfig.getName(), telemetryRegistry.getMetricRegistry(), flowRepository);
     }
 
-    public void setMetricRegistry(MetricRegistry metricRegistry) {
-        this.metricRegistry = metricRegistry;
+    public void setTelemetryRegistry(TelemetryRegistry telemetryRegistry) {
+        this.telemetryRegistry = telemetryRegistry;
     }
 
     public void setFlowRepository(FlowRepository flowRepository) {

--- a/features/telemetry/protocols/netflow/adapter/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/features/telemetry/protocols/netflow/adapter/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -9,10 +9,11 @@
 		http://aries.apache.org/schemas/blueprint-ext/blueprint-ext-1.1.xsd
 ">
 	<reference id="flowRepository" interface="org.opennms.netmgt.flows.api.FlowRepository" availability="mandatory" />
+	<reference id="telemetryRegistry" interface="org.opennms.netmgt.telemetry.api.registry.TelemetryRegistry" availability="mandatory" />
 
 	<!-- Netflow5 Factory and Adapter -->
 	<bean id="netflow5Factory" class="org.opennms.netmgt.telemetry.protocols.netflow.adapter.netflow5.Netflow5AdapterFactory">
-		<property name="metricRegistry" ref="netflow5MetricRegistry"/>
+		<property name="telemetryRegistry" ref="telemetryRegistry"/>
 		<property name="flowRepository" ref="flowRepository" />
 	</bean>
 	<service ref="netflow5Factory" interface="org.opennms.netmgt.telemetry.api.adapter.AdapterFactory">
@@ -23,7 +24,7 @@
 
 	<!-- Netflow9 Factory and Adapter -->
 	<bean id="netflow9Factory" class="org.opennms.netmgt.telemetry.protocols.netflow.adapter.netflow9.Netflow9AdapterFactory">
-		<property name="metricRegistry" ref="netflow9MetricRegistry"/>
+		<property name="telemetryRegistry" ref="telemetryRegistry"/>
 		<property name="flowRepository" ref="flowRepository" />
 	</bean>
 	<service ref="netflow9Factory" interface="org.opennms.netmgt.telemetry.api.adapter.AdapterFactory">
@@ -34,7 +35,7 @@
 
 	<!-- IPFix Factory and Adapter -->
 	<bean id="ipfixFactory" class="org.opennms.netmgt.telemetry.protocols.netflow.adapter.ipfix.IpfixAdapterFactory">
-		<property name="metricRegistry" ref="ipfixMetricRegistry"/>
+		<property name="telemetryRegistry" ref="telemetryRegistry"/>
 		<property name="flowRepository" ref="flowRepository" />
 	</bean>
 	<service ref="ipfixFactory" interface="org.opennms.netmgt.telemetry.api.adapter.AdapterFactory">
@@ -43,63 +44,4 @@
 		</service-properties>
 	</service>
 
-	<!-- Metrics v5 -->
-	<bean id="netflow5MetricRegistry" class="com.codahale.metrics.MetricRegistry"/>
-	<service ref="netflow5MetricRegistry" interface="com.codahale.metrics.MetricSet">
-		<service-properties>
-			<entry key="name" value="Netflow v5" />
-			<entry key="description" value="Consolidated metrics for all adapters processing Netflow v5 flows" />
-		</service-properties>
-	</service>
-	<bean id="netflow5MetricRegistryJmxReporterBuilder" class="com.codahale.metrics.JmxReporter" factory-method="forRegistry">
-		<argument ref="netflow5MetricRegistry"/>
-	</bean>
-	<bean id="netflow5MetricRegistryDomainedJmxReporterBuilder" factory-ref="netflow5MetricRegistryJmxReporterBuilder" factory-method="inDomain">
-		<argument value="org.opennms.netmgt.telemetry.protocols.netflow5"/>
-	</bean>
-	<bean id="netflow5MetricRegistryJmxReporter"
-		  factory-ref="netflow5MetricRegistryJmxReporterBuilder"
-		  factory-method="build"
-		  init-method="start"
-		  destroy-method="stop" />
-
-	<!-- Metrics v9 -->
-	<bean id="netflow9MetricRegistry" class="com.codahale.metrics.MetricRegistry"/>
-	<service ref="netflow9MetricRegistry" interface="com.codahale.metrics.MetricSet">
-		<service-properties>
-			<entry key="name" value="Netflow v9" />
-			<entry key="description" value="Consolidated metrics for all adapters processing Netflow v9 flows" />
-		</service-properties>
-	</service>
-	<bean id="netflow9MetricRegistryJmxReporterBuilder" class="com.codahale.metrics.JmxReporter" factory-method="forRegistry">
-		<argument ref="netflow9MetricRegistry"/>
-	</bean>
-	<bean id="netflow9MetricRegistryDomainedJmxReporterBuilder" factory-ref="netflow9MetricRegistryJmxReporterBuilder" factory-method="inDomain">
-		<argument value="org.opennms.netmgt.telemetry.protocols.netflow9"/>
-	</bean>
-	<bean id="netflow9MetricRegistryJmxReporter"
-		  factory-ref="netflow9MetricRegistryDomainedJmxReporterBuilder"
-		  factory-method="build"
-		  init-method="start"
-		  destroy-method="stop" />
-
-	<!-- Metrics IPFix -->
-	<bean id="ipfixMetricRegistry" class="com.codahale.metrics.MetricRegistry"/>
-	<service ref="ipfixMetricRegistry" interface="com.codahale.metrics.MetricSet">
-		<service-properties>
-			<entry key="name" value="IPFix" />
-			<entry key="description" value="Consolidated metrics for all adapters processing IPFix flows" />
-		</service-properties>
-	</service>
-	<bean id="ipfixMetricRegistryJmxReporterBuilder" class="com.codahale.metrics.JmxReporter" factory-method="forRegistry">
-		<argument ref="ipfixMetricRegistry"/>
-	</bean>
-	<bean id="ipfixMetricRegistryDomainedJmxReporterBuilder" factory-ref="ipfixMetricRegistryJmxReporterBuilder" factory-method="inDomain">
-		<argument value="org.opennms.netmgt.telemetry.protocols.ipfix"/>
-	</bean>
-	<bean id="ipfixMetricRegistryJmxReporter"
-		  factory-ref="ipfixMetricRegistryJmxReporterBuilder"
-		  factory-method="build"
-		  init-method="start"
-		  destroy-method="stop" />
 </blueprint>

--- a/features/telemetry/protocols/nxos/adapter/src/main/java/org/opennms/netmgt/telemetry/protocols/nxos/adapter/NxosAdapterFactory.java
+++ b/features/telemetry/protocols/nxos/adapter/src/main/java/org/opennms/netmgt/telemetry/protocols/nxos/adapter/NxosAdapterFactory.java
@@ -49,7 +49,7 @@ public class NxosAdapterFactory extends AbstractCollectionAdapterFactory {
 
     @Override
     public Adapter createBean(final AdapterDefinition adapterConfig) {
-        final NxosGpbAdapter adapter = new NxosGpbAdapter();
+        final NxosGpbAdapter adapter = new NxosGpbAdapter(adapterConfig.getName(), getTelemetryRegistry().getMetricRegistry());
         adapter.setConfig(adapterConfig);
         adapter.setCollectionAgentFactory(getCollectionAgentFactory());
         adapter.setInterfaceToNodeCache(getInterfaceToNodeCache());

--- a/features/telemetry/protocols/nxos/adapter/src/main/java/org/opennms/netmgt/telemetry/protocols/nxos/adapter/NxosGpbAdapter.java
+++ b/features/telemetry/protocols/nxos/adapter/src/main/java/org/opennms/netmgt/telemetry/protocols/nxos/adapter/NxosGpbAdapter.java
@@ -57,6 +57,7 @@ import org.springframework.transaction.TransactionStatus;
 import org.springframework.transaction.support.TransactionCallback;
 import org.springframework.transaction.support.TransactionOperations;
 
+import com.codahale.metrics.MetricRegistry;
 import com.google.common.collect.Iterables;
 import com.google.protobuf.ExtensionRegistry;
 import com.google.protobuf.InvalidProtocolBufferException;
@@ -82,6 +83,10 @@ public class NxosGpbAdapter extends AbstractPersistingAdapter {
 
     @Autowired
     private TransactionOperations transactionTemplate;
+
+    public NxosGpbAdapter(String name, MetricRegistry metricRegistry) {
+        super(name, metricRegistry);
+    }
 
     @Override
     public Stream<CollectionSetWithAgent> handleMessage(TelemetryMessageLogEntry message, TelemetryMessageLog messageLog) {

--- a/features/telemetry/protocols/nxos/adapter/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/features/telemetry/protocols/nxos/adapter/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -11,6 +11,7 @@
 
 	<bean id="nxosAdapterFactory" class="org.opennms.netmgt.telemetry.protocols.nxos.adapter.NxosAdapterFactory">
 		<argument ref="blueprintBundleContext" />
+		<property name="telemetryRegistry" ref="telemetryRegistry" />
 		<property name="collectionAgentFactory" ref="collectionAgentFactory" />
 		<property name="interfaceToNodeCache" ref="interfaceToNodeCache" />
 		<property name="nodeDao" ref="nodeDao" />
@@ -25,6 +26,7 @@
 		</service-properties>
 	</service>
 
+	<reference id="telemetryRegistry" interface="org.opennms.netmgt.telemetry.api.registry.TelemetryRegistry" />
 	<reference id="collectionAgentFactory" interface="org.opennms.netmgt.collection.api.CollectionAgentFactory" />
 	<reference id="interfaceToNodeCache" interface="org.opennms.netmgt.dao.api.InterfaceToNodeCache" />
 	<reference id="nodeDao" interface="org.opennms.netmgt.dao.api.NodeDao" />

--- a/features/telemetry/protocols/sflow/adapter/src/main/java/org/opennms/netmgt/telemetry/protocols/sflow/adapter/SFlowAdapter.java
+++ b/features/telemetry/protocols/sflow/adapter/src/main/java/org/opennms/netmgt/telemetry/protocols/sflow/adapter/SFlowAdapter.java
@@ -38,9 +38,10 @@ import com.codahale.metrics.MetricRegistry;
 
 public class SFlowAdapter extends AbstractFlowAdapter<BsonDocument> {
 
-    public SFlowAdapter(final MetricRegistry metricRegistry,
+    public SFlowAdapter(final String name,
+                        final MetricRegistry metricRegistry,
                         final FlowRepository flowRepository) {
-        super(metricRegistry, flowRepository, new SFlowConverter());
+        super(name, metricRegistry, flowRepository, new SFlowConverter());
     }
 
     @Override

--- a/features/telemetry/protocols/sflow/adapter/src/main/java/org/opennms/netmgt/telemetry/protocols/sflow/adapter/SFlowAdapterFactory.java
+++ b/features/telemetry/protocols/sflow/adapter/src/main/java/org/opennms/netmgt/telemetry/protocols/sflow/adapter/SFlowAdapterFactory.java
@@ -33,12 +33,13 @@ import java.util.Objects;
 import org.opennms.netmgt.flows.api.FlowRepository;
 import org.opennms.netmgt.telemetry.api.adapter.Adapter;
 import org.opennms.netmgt.telemetry.api.adapter.AdapterFactory;
+import org.opennms.netmgt.telemetry.api.registry.TelemetryRegistry;
 import org.opennms.netmgt.telemetry.config.api.AdapterDefinition;
 
 import com.codahale.metrics.MetricRegistry;
 
 public class SFlowAdapterFactory implements AdapterFactory {
-    private MetricRegistry metricRegistry;
+    private TelemetryRegistry telemetryRegistry;
     private FlowRepository flowRepository;
 
     @Override
@@ -48,14 +49,14 @@ public class SFlowAdapterFactory implements AdapterFactory {
 
     @Override
     public Adapter createBean(final AdapterDefinition adapterConfig) {
-        Objects.requireNonNull(metricRegistry);
+        Objects.requireNonNull(telemetryRegistry);
         Objects.requireNonNull(flowRepository);
 
-        return new SFlowAdapter(metricRegistry, flowRepository);
+        return new SFlowAdapter(adapterConfig.getName(), telemetryRegistry.getMetricRegistry(), flowRepository);
     }
 
-    public void setMetricRegistry(MetricRegistry metricRegistry) {
-        this.metricRegistry = metricRegistry;
+    public void setTelemetryRegistry(TelemetryRegistry telemetryRegistry) {
+        this.telemetryRegistry = telemetryRegistry;
     }
 
     public void setFlowRepository(FlowRepository flowRepository) {

--- a/features/telemetry/protocols/sflow/adapter/src/main/java/org/opennms/netmgt/telemetry/protocols/sflow/adapter/SFlowTelemetryAdapter.java
+++ b/features/telemetry/protocols/sflow/adapter/src/main/java/org/opennms/netmgt/telemetry/protocols/sflow/adapter/SFlowTelemetryAdapter.java
@@ -53,6 +53,8 @@ import org.opennms.netmgt.telemetry.protocols.collection.ScriptedCollectionSetBu
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.codahale.metrics.MetricRegistry;
+
 public class SFlowTelemetryAdapter extends AbstractPersistingAdapter {
 
     private static final Logger LOG = LoggerFactory.getLogger(SFlowTelemetryAdapter.class);
@@ -61,7 +63,8 @@ public class SFlowTelemetryAdapter extends AbstractPersistingAdapter {
 
     private InterfaceToNodeCache interfaceToNodeCache;
 
-    public SFlowTelemetryAdapter() {
+    public SFlowTelemetryAdapter(String name, MetricRegistry metricRegistry) {
+        super(name, metricRegistry);
     }
 
     @Override

--- a/features/telemetry/protocols/sflow/adapter/src/main/java/org/opennms/netmgt/telemetry/protocols/sflow/adapter/SFlowTelemetryAdapterFactory.java
+++ b/features/telemetry/protocols/sflow/adapter/src/main/java/org/opennms/netmgt/telemetry/protocols/sflow/adapter/SFlowTelemetryAdapterFactory.java
@@ -53,7 +53,7 @@ public class SFlowTelemetryAdapterFactory extends AbstractCollectionAdapterFacto
 
     @Override
     public Adapter createBean(final AdapterDefinition adapterConfig) {
-        final SFlowTelemetryAdapter adapter = new SFlowTelemetryAdapter();
+        final SFlowTelemetryAdapter adapter = new SFlowTelemetryAdapter(adapterConfig.getName(), getTelemetryRegistry().getMetricRegistry());
         adapter.setConfig(adapterConfig);
         adapter.setCollectionAgentFactory(getCollectionAgentFactory());
         adapter.setPersisterFactory(getPersisterFactory());

--- a/features/telemetry/protocols/sflow/adapter/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/features/telemetry/protocols/sflow/adapter/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -9,6 +9,7 @@
 		http://aries.apache.org/schemas/blueprint-ext/blueprint-ext-1.1.xsd
 ">
 	<reference id="flowRepository" interface="org.opennms.netmgt.flows.api.FlowRepository" availability="mandatory" />
+	<reference id="telemetryRegistry" interface="org.opennms.netmgt.telemetry.api.registry.TelemetryRegistry" availability="mandatory" />
 
 	<reference id="collectionAgentFactory" interface="org.opennms.netmgt.collection.api.CollectionAgentFactory" />
 	<reference id="interfaceToNodeCache" interface="org.opennms.netmgt.dao.api.InterfaceToNodeCache" />
@@ -22,7 +23,7 @@
 
 	<!-- SFlow Factory and Adapter -->
 	<bean id="sflowFactory" class="org.opennms.netmgt.telemetry.protocols.sflow.adapter.SFlowAdapterFactory">
-		<property name="metricRegistry" ref="sflowAdapterMetricRegistry"/>
+		<property name="telemetryRegistry" ref="telemetryRegistry"/>
 		<property name="flowRepository" ref="flowRepository" />
 	</bean>
 	<service ref="sflowFactory" interface="org.opennms.netmgt.telemetry.api.adapter.AdapterFactory">
@@ -33,6 +34,7 @@
 
 	<bean id="sflowTelemetryFactory" class="org.opennms.netmgt.telemetry.protocols.sflow.adapter.SFlowTelemetryAdapterFactory">
 		<argument ref="blueprintBundleContext" />
+		<property name="telemetryRegistry" ref="telemetryRegistry"/>
 		<property name="collectionAgentFactory" ref="collectionAgentFactory" />
 		<property name="interfaceToNodeCache" ref="interfaceToNodeCache" />
 		<property name="nodeDao" ref="nodeDao" />
@@ -45,25 +47,5 @@
 			<entry key="registration.export" value="true" />
 		</service-properties>
 	</service>
-
-	<!-- Metrics -->
-	<bean id="sflowAdapterMetricRegistry" class="com.codahale.metrics.MetricRegistry"/>
-	<service ref="sflowAdapterMetricRegistry" interface="com.codahale.metrics.MetricSet">
-		<service-properties>
-			<entry key="name" value="SFlow" />
-			<entry key="description" value="Consolidated metrics for all adapters processing SFlow flows" />
-		</service-properties>
-	</service>
-	<bean id="sflowAdapterMetricRegistryJmxReporterBuilder" class="com.codahale.metrics.JmxReporter" factory-method="forRegistry">
-		<argument ref="sflowAdapterMetricRegistry"/>
-	</bean>
-	<bean id="sflowAdapterMetricRegistryDomainedJmxReporterBuilder" factory-ref="sflowAdapterMetricRegistryJmxReporterBuilder" factory-method="inDomain">
-		<argument value="org.opennms.netmgt.telemetry.protocols.sflow"/>
-	</bean>
-	<bean id="sflowAdapterMetricRegistryJmxReporter"
-		  factory-ref="sflowAdapterMetricRegistryJmxReporterBuilder"
-		  factory-method="build"
-		  init-method="start"
-		  destroy-method="stop" />
 
 </blueprint>

--- a/features/telemetry/registry/src/main/java/org/opennms/netmgt/telemetry/protocols/registry/impl/TelemetryRegistryImpl.java
+++ b/features/telemetry/registry/src/main/java/org/opennms/netmgt/telemetry/protocols/registry/impl/TelemetryRegistryImpl.java
@@ -45,6 +45,8 @@ import org.opennms.netmgt.telemetry.config.api.ParserDefinition;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 
+import com.codahale.metrics.MetricRegistry;
+
 public class TelemetryRegistryImpl implements TelemetryRegistry {
 
     @Autowired
@@ -58,6 +60,10 @@ public class TelemetryRegistryImpl implements TelemetryRegistry {
     @Autowired
     @Qualifier("parserRegistry")
     private TelemetryServiceRegistry<ParserDefinition, Parser> parserRegistryDelegate;
+
+    @Autowired
+    @Qualifier("telemetryMetricRegistry")
+    private MetricRegistry metricRegistry;
 
     private final Map<String, AsyncDispatcher<TelemetryMessage>> dispatchers = new HashMap<>();
 
@@ -114,5 +120,14 @@ public class TelemetryRegistryImpl implements TelemetryRegistry {
 
     public void setParserRegistryDelegate(TelemetryServiceRegistry<ParserDefinition, Parser> parserRegistryDelegate) {
         this.parserRegistryDelegate = parserRegistryDelegate;
+    }
+
+    @Override
+    public MetricRegistry getMetricRegistry() {
+        return metricRegistry;
+    }
+
+    public void setMetricRegistry(MetricRegistry metricRegistry) {
+        this.metricRegistry = metricRegistry;
     }
 }

--- a/features/telemetry/registry/src/main/java/org/opennms/netmgt/telemetry/protocols/registry/impl/TelemetryRegistryImpl.java
+++ b/features/telemetry/registry/src/main/java/org/opennms/netmgt/telemetry/protocols/registry/impl/TelemetryRegistryImpl.java
@@ -61,8 +61,6 @@ public class TelemetryRegistryImpl implements TelemetryRegistry {
     @Qualifier("parserRegistry")
     private TelemetryServiceRegistry<ParserDefinition, Parser> parserRegistryDelegate;
 
-    @Autowired
-    @Qualifier("telemetryMetricRegistry")
     private MetricRegistry metricRegistry;
 
     private final Map<String, AsyncDispatcher<TelemetryMessage>> dispatchers = new HashMap<>();

--- a/features/telemetry/registry/src/main/resources/META-INF/opennms/component-dao.xml
+++ b/features/telemetry/registry/src/main/resources/META-INF/opennms/component-dao.xml
@@ -25,9 +25,7 @@
 		<onmsgi:listener ref="parserRegistry" bind-method="onBind" unbind-method="onUnbind" />
 	</onmsgi:list>
 
-	<bean id="metricRegistry" class="com.codahale.metrics.MetricRegistry">
-		<qualifier value="telemetryMetricRegistry" />
-	</bean>
+	<bean id="metricRegistry" class="com.codahale.metrics.MetricRegistry" autowire-candidate="false" />
 	<onmsgi:service interface="com.codahale.metrics.MetricSet" ref="metricRegistry">
 		<onmsgi:service-properties>
 			<entry key="registration.export" value="true" />
@@ -47,7 +45,9 @@
 		  init-method="start"
 		  destroy-method="stop" />
 
-	<bean id="telemetryRegistry" class="org.opennms.netmgt.telemetry.protocols.registry.impl.TelemetryRegistryImpl" />
+	<bean id="telemetryRegistry" class="org.opennms.netmgt.telemetry.protocols.registry.impl.TelemetryRegistryImpl">
+		<property name="metricRegistry" ref="metricRegistry"/>
+	</bean>
 	<onmsgi:service interface="org.opennms.netmgt.telemetry.api.registry.TelemetryRegistry" ref="telemetryRegistry" />
 
 </beans>

--- a/features/telemetry/registry/src/main/resources/META-INF/opennms/component-dao.xml
+++ b/features/telemetry/registry/src/main/resources/META-INF/opennms/component-dao.xml
@@ -25,6 +25,28 @@
 		<onmsgi:listener ref="parserRegistry" bind-method="onBind" unbind-method="onUnbind" />
 	</onmsgi:list>
 
+	<bean id="metricRegistry" class="com.codahale.metrics.MetricRegistry">
+		<qualifier value="telemetryMetricRegistry" />
+	</bean>
+	<onmsgi:service interface="com.codahale.metrics.MetricSet" ref="metricRegistry">
+		<onmsgi:service-properties>
+			<entry key="registration.export" value="true" />
+			<entry key="name" value="Telemetryd" />
+			<entry key="description" value="Telemetryd related metrics" />
+		</onmsgi:service-properties>
+	</onmsgi:service>
+	<bean id="metricRegistryJmxReporterBuilder" class="com.codahale.metrics.JmxReporter" factory-method="forRegistry">
+		<constructor-arg ref="metricRegistry"/>
+	</bean>
+	<bean id="metricRegistryDomainedJmxReporterBuilder" factory-bean="metricRegistryJmxReporterBuilder" factory-method="inDomain">
+		<constructor-arg value="org.opennms.netmgt.telemetry"/>
+	</bean>
+	<bean id="metricRegistryJmxReporter"
+		  factory-bean="metricRegistryDomainedJmxReporterBuilder"
+		  factory-method="build"
+		  init-method="start"
+		  destroy-method="stop" />
+
 	<bean id="telemetryRegistry" class="org.opennms.netmgt.telemetry.protocols.registry.impl.TelemetryRegistryImpl" />
 	<onmsgi:service interface="org.opennms.netmgt.telemetry.api.registry.TelemetryRegistry" ref="telemetryRegistry" />
 

--- a/features/telemetry/registry/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/features/telemetry/registry/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -34,7 +34,7 @@
         </service-properties>
     </service>
     <bean id="metricRegistryJmxReporterBuilder" class="com.codahale.metrics.JmxReporter" factory-method="forRegistry">
-        <argument ref="telemetryMetricRegistry"/>
+        <argument ref="metricRegistry"/>
     </bean>
     <bean id="metricRegistryDomainedJmxReporterBuilder" factory-ref="metricRegistryJmxReporterBuilder" factory-method="inDomain">
         <argument value="org.opennms.netmgt.telemetry"/>

--- a/features/telemetry/registry/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/features/telemetry/registry/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -25,10 +25,31 @@
         <reference-listener bind-method="onBind" unbind-method="onUnbind" ref="parserRegistry" />
     </reference-list>
 
+    <!-- Metrics -->
+    <bean id="metricRegistry" class="com.codahale.metrics.MetricRegistry"/>
+    <service ref="metricRegistry" interface="com.codahale.metrics.MetricSet">
+        <service-properties>
+            <entry key="name" value="Telemetryd" />
+            <entry key="description" value="Telemetryd related metrics" />
+        </service-properties>
+    </service>
+    <bean id="metricRegistryJmxReporterBuilder" class="com.codahale.metrics.JmxReporter" factory-method="forRegistry">
+        <argument ref="telemetryMetricRegistry"/>
+    </bean>
+    <bean id="metricRegistryDomainedJmxReporterBuilder" factory-ref="metricRegistryJmxReporterBuilder" factory-method="inDomain">
+        <argument value="org.opennms.netmgt.telemetry"/>
+    </bean>
+    <bean id="metricRegistryJmxReporter"
+          factory-ref="metricRegistryJmxReporterBuilder"
+          factory-method="build"
+          init-method="start"
+          destroy-method="stop" />
+
     <bean id="telemetryRegistry" class="org.opennms.netmgt.telemetry.protocols.registry.impl.TelemetryRegistryImpl" >
         <property name="adapterRegistryDelegate" ref="adapterRegistry"/>
         <property name="listenerRegistryDelegate" ref="listenerRegistry"/>
         <property name="parserRegistryDelegate" ref="parserRegistry"/>
+        <property name="metricRegistry" ref="metricRegistry"/>
     </bean>
     <service interface="org.opennms.netmgt.telemetry.api.registry.TelemetryRegistry" ref="telemetryRegistry" />
 </blueprint>

--- a/opennms-base-assembly/src/main/filtered/etc/jmx-datacollection-config.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/jmx-datacollection-config.xml
@@ -367,24 +367,29 @@
             <attrib name="OneMinuteRate" alias="FlowLogPerst1m" type="gauge"/>
             <attrib name="FiveMinuteRate" alias="FlowLogPerst5m" type="gauge"/>
          </mbean>
-         <mbean name="org.opennms.netmgt.telemetry.protocols.packetsPerLog" resource-type="netflow" objectname="org.opennms.netmgt.telemetry.protocols.*:name=packetsPerLog">
-            <attrib name="50thPercentile" alias="FlowPktsPerLog50" type="gauge"/>
-            <attrib name="75thPercentile" alias="FlowPktsPerLog75" type="gauge"/>
-            <attrib name="95thPercentile" alias="FlowPktsPerLog95" type="gauge"/>
-            <attrib name="98thPercentile" alias="FlowPktsPerLog98" type="gauge"/>
-            <attrib name="99thPercentile" alias="FlowPktsPerLog99" type="gauge"/>
-            <attrib name="999thPercentile" alias="FlowPktsPerLog999" type="gauge"/>
-            <attrib name="Count" alias="FlowPktsPerLogCnt" type="counter"/>
+         <mbean name="org.opennms.netmgt.telemetry.adapters.packetsPerLog" resource-type="telemetryAdapters" objectname="org.opennms.netmgt.telemetry:name=adapters.*packetsPerLog">
+            <attrib name="50thPercentile" alias="TlmPktsPerLog50" type="gauge"/>
+            <attrib name="75thPercentile" alias="TlmPktsPerLog75" type="gauge"/>
+            <attrib name="95thPercentile" alias="TlmPktsPerLog95" type="gauge"/>
+            <attrib name="98thPercentile" alias="TlmPktsPerLog98" type="gauge"/>
+            <attrib name="99thPercentile" alias="TlmPktsPerLog99" type="gauge"/>
+            <attrib name="999thPercentile" alias="TlmPktsPerLog999" type="gauge"/>
+            <attrib name="Count" alias="TlmPktsPerLogCnt" type="counter"/>
          </mbean>
-         <mbean name="org.opennms.netmgt.telemetry.protocols.logParsing" resource-type="netflow" objectname="org.opennms.netmgt.telemetry.protocols.*:name=logParsing">
-            <attrib name="50thPercentile" alias="FlowLogParse50" type="gauge"/>
-            <attrib name="75thPercentile" alias="FlowLogParse75" type="gauge"/>
-            <attrib name="95thPercentile" alias="FlowLogParse95" type="gauge"/>
-            <attrib name="98thPercentile" alias="FlowLogParse98" type="gauge"/>
-            <attrib name="99thPercentile" alias="FlowLogParse99" type="gauge"/>
-            <attrib name="999thPercentile" alias="FlowLogParse999" type="gauge"/>
-            <attrib name="OneMinuteRate" alias="FlowLogParse1m" type="gauge"/>
-            <attrib name="FiveMinuteRate" alias="FlowLogParse5m" type="gauge"/>
+         <mbean name="org.opennms.netmgt.telemetry.adapters.logParsing" resource-type="telemetryAdapters" objectname="org.opennms.netmgt.telemetry:name=adapters.*logParsing">
+            <attrib name="50thPercentile" alias="TlmLogParse50" type="gauge"/>
+            <attrib name="75thPercentile" alias="TlmLogParse75" type="gauge"/>
+            <attrib name="95thPercentile" alias="TlmLogParse95" type="gauge"/>
+            <attrib name="98thPercentile" alias="TlmLogParse98" type="gauge"/>
+            <attrib name="99thPercentile" alias="TlmLogParse99" type="gauge"/>
+            <attrib name="999thPercentile" alias="TlmLogParse999" type="gauge"/>
+            <attrib name="OneMinuteRate" alias="TlmLogParse1m" type="gauge"/>
+            <attrib name="FiveMinuteRate" alias="TlmLogParse5m" type="gauge"/>
+         </mbean>
+         <mbean name="org.opennms.netmgt.telemetry.listeners.packetsReceived" resource-type="telemetryListeners" objectname="org.opennms.netmgt.telemetry:name=listeners.*packetsReceived">
+            <attrib name="Count" alias="TlmPacketsRcvd" type="counter"/>
+            <attrib name="OneMinuteRate" alias="TlmPacketsRcvd1m" type="gauge"/>
+            <attrib name="FiveMinuteRate" alias="TlmPacketsRcvd5m" type="gauge"/>
          </mbean>
 
          <!-- Sink Producer Metrics -->

--- a/opennms-base-assembly/src/main/filtered/etc/resource-types.d/jmx-resource.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/resource-types.d/jmx-resource.xml
@@ -17,14 +17,22 @@
       </storageStrategy>
     </resourceType>
 
-    <!-- Netflow -->
-    <resourceType name="netflow" label="Flow Protocol" resourceLabel="${index}">
+    <!-- Telemetry -->
+    <resourceType name="telemetryAdapters" label="Telemetry Adapters" resourceLabel="${index}">
         <persistenceSelectorStrategy class="org.opennms.netmgt.collection.support.PersistAllSelectorStrategy"/>
         <storageStrategy class="org.opennms.netmgt.dao.support.SiblingColumnStorageStrategy">
-            <parameter key="sibling-column-name" value="domain"/>
-            <parameter key="replace-all" value="s/\s//"/>
-            <parameter key="replace-all" value="s/:.*//"/>
-            <parameter key="replace-all" value="s/.*\.//"/>
+            <parameter key="sibling-column-name" value="name"/>
+            <parameter key="replace-first" value="s/.*?\.//"/>
+            <parameter key="replace-all" value="s/\..*//"/>
+        </storageStrategy>
+    </resourceType>
+
+    <resourceType name="telemetryListeners" label="Telemetry Listeners" resourceLabel="${index}">
+        <persistenceSelectorStrategy class="org.opennms.netmgt.collection.support.PersistAllSelectorStrategy"/>
+        <storageStrategy class="org.opennms.netmgt.dao.support.SiblingColumnStorageStrategy">
+            <parameter key="sibling-column-name" value="name"/>
+            <parameter key="replace-first" value="s/.*?\.//"/>
+            <parameter key="replace-all" value="s/\..*//"/>
         </storageStrategy>
     </resourceType>
 

--- a/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/opennms-netflow-graph.properties
+++ b/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/opennms-netflow-graph.properties
@@ -9,9 +9,7 @@ reports=OpenNMS.Flows.FlowsPersisted, \
 OpenNMS.Flows.FlowsPerLog, \
 OpenNMS.Flows.Conversion.Latency, \
 OpenNMS.Flows.Enrichment.Latency, \
-OpenNMS.Flows.Persisting.Latency, \
-OpenNMS.Flows.PacketsPerLog, \
-OpenNMS.Flows.Parsing.Latency
+OpenNMS.Flows.Persisting.Latency
 
 report.OpenNMS.Flows.FlowsPersisted.name=Flows Persisted
 report.OpenNMS.Flows.FlowsPersisted.columns=FlowPerst5m
@@ -143,78 +141,6 @@ report.OpenNMS.Flows.Persisting.Latency.command=--title="Flow Log Persisting Lat
  DEF:95th={rrd4}:FlowLogPerst95:AVERAGE \
  DEF:75th={rrd5}:FlowLogPerst75:AVERAGE \
  DEF:50th={rrd6}:FlowLogPerst50:AVERAGE \
- AREA:999th#542437:"999th percentile" \
- GPRINT:999th:AVERAGE:" Avg \\: %8.2lf %s" \
- GPRINT:999th:MIN:" Min \\: %8.2lf %s" \
- GPRINT:999th:MAX:" Max \\: %8.2lf %s\\n" \
- AREA:99th#C44D58:"99th percentile" \
- GPRINT:99th:AVERAGE:" Avg \\: %8.2lf %s" \
- GPRINT:99th:MIN:" Min \\: %8.2lf %s" \
- GPRINT:99th:MAX:" Max \\: %8.2lf %s\\n" \
- AREA:98th#FF6B6B:"98th percentile" \
- GPRINT:98th:AVERAGE:" Avg \\: %8.2lf %s" \
- GPRINT:98th:MIN:" Min \\: %8.2lf %s" \
- GPRINT:98th:MAX:" Max \\: %8.2lf %s\\n" \
- AREA:95th#556270:"95th percentile" \
- GPRINT:95th:AVERAGE:" Avg \\: %8.2lf %s" \
- GPRINT:95th:MIN:" Min \\: %8.2lf %s" \
- GPRINT:95th:MAX:" Max \\: %8.2lf %s\\n" \
- AREA:75th#4ECDC4:"75th percentile" \
- GPRINT:75th:AVERAGE:" Avg \\: %8.2lf %s" \
- GPRINT:75th:MIN:" Min \\: %8.2lf %s" \
- GPRINT:75th:MAX:" Max \\: %8.2lf %s\\n" \
- AREA:50th#C7F464:"50th percentile" \
- GPRINT:50th:AVERAGE:" Avg \\: %8.2lf %s" \
- GPRINT:50th:MIN:" Min \\: %8.2lf %s" \
- GPRINT:50th:MAX:" Max \\: %8.2lf %s\\n"
-
-report.OpenNMS.Flows.PacketsPerLog.name=Flow Packets Per Log
-report.OpenNMS.Flows.PacketsPerLog.columns=FlowPktsPerLog999,FlowPktsPerLog99,FlowPktsPerLog98,FlowPktsPerLog95,FlowPktsPerLog75,FlowPktsPerLog50
-report.OpenNMS.Flows.PacketsPerLog.type=netflow
-report.OpenNMS.Flows.PacketsPerLog.command=--title="Flows: Packets Per Log" \
- --color GRID#f2f2f288  --color MGRID#c2c2d688  --vertical-label="Packets" \
- DEF:999th={rrd1}:FlowPktsPerLog999:AVERAGE \
- DEF:99th={rrd2}:FlowPktsPerLog99:AVERAGE \
- DEF:98th={rrd3}:FlowPktsPerLog98:AVERAGE \
- DEF:95th={rrd4}:FlowPktsPerLog95:AVERAGE \
- DEF:75th={rrd5}:FlowPktsPerLog75:AVERAGE \
- DEF:50th={rrd6}:FlowPktsPerLog50:AVERAGE \
- AREA:999th#542437:"999th percentile" \
- GPRINT:999th:AVERAGE:" Avg \\: %8.2lf %s" \
- GPRINT:999th:MIN:" Min \\: %8.2lf %s" \
- GPRINT:999th:MAX:" Max \\: %8.2lf %s\\n" \
- AREA:99th#C44D58:"99th percentile" \
- GPRINT:99th:AVERAGE:" Avg \\: %8.2lf %s" \
- GPRINT:99th:MIN:" Min \\: %8.2lf %s" \
- GPRINT:99th:MAX:" Max \\: %8.2lf %s\\n" \
- AREA:98th#FF6B6B:"98th percentile" \
- GPRINT:98th:AVERAGE:" Avg \\: %8.2lf %s" \
- GPRINT:98th:MIN:" Min \\: %8.2lf %s" \
- GPRINT:98th:MAX:" Max \\: %8.2lf %s\\n" \
- AREA:95th#556270:"95th percentile" \
- GPRINT:95th:AVERAGE:" Avg \\: %8.2lf %s" \
- GPRINT:95th:MIN:" Min \\: %8.2lf %s" \
- GPRINT:95th:MAX:" Max \\: %8.2lf %s\\n" \
- AREA:75th#4ECDC4:"75th percentile" \
- GPRINT:75th:AVERAGE:" Avg \\: %8.2lf %s" \
- GPRINT:75th:MIN:" Min \\: %8.2lf %s" \
- GPRINT:75th:MAX:" Max \\: %8.2lf %s\\n" \
- AREA:50th#C7F464:"50th percentile" \
- GPRINT:50th:AVERAGE:" Avg \\: %8.2lf %s" \
- GPRINT:50th:MIN:" Min \\: %8.2lf %s" \
- GPRINT:50th:MAX:" Max \\: %8.2lf %s\\n"
-
-report.OpenNMS.Flows.Parsing.Latency.name=Flow Log Parsing Latency
-report.OpenNMS.Flows.Parsing.Latency.columns=FlowLogParse999,FlowLogParse99,FlowLogParse98,FlowLogParse95,FlowLogParse75,FlowLogParse50
-report.OpenNMS.Flows.Parsing.Latency.type=netflow
-report.OpenNMS.Flows.Parsing.Latency.command=--title="Flows: Log Parsing Latency" \
- --color GRID#f2f2f288  --color MGRID#c2c2d688  --vertical-label="Milliseconds" \
- DEF:999th={rrd1}:FlowLogParse999:AVERAGE \
- DEF:99th={rrd2}:FlowLogParse99:AVERAGE \
- DEF:98th={rrd3}:FlowLogParse98:AVERAGE \
- DEF:95th={rrd4}:FlowLogParse95:AVERAGE \
- DEF:75th={rrd5}:FlowLogParse75:AVERAGE \
- DEF:50th={rrd6}:FlowLogParse50:AVERAGE \
  AREA:999th#542437:"999th percentile" \
  GPRINT:999th:AVERAGE:" Avg \\: %8.2lf %s" \
  GPRINT:999th:MIN:" Min \\: %8.2lf %s" \

--- a/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/opennms-telemetryd-graph.properties
+++ b/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/opennms-telemetryd-graph.properties
@@ -1,0 +1,95 @@
+##############################################################################
+##
+##  Please add report definition in a new line to make it easier
+##  for script based sanity checks
+##
+##################################################
+
+reports=OpenNMS.Telemetryd.Adapters.PacketsPerLog, \
+OpenNMS.Telemetryd.Adapters.LogParsing, \
+OpenNMS.Telemetryd.Listeners.PacketsReceived
+
+report.OpenNMS.Telemetryd.Adapters.PacketsPerLog.name=Packets Per Log
+report.OpenNMS.Telemetryd.Adapters.PacketsPerLog.columns=TlmPktsPerLog999,TlmPktsPerLog99,TlmPktsPerLog98,TlmPktsPerLog95,TlmPktsPerLog75,TlmPktsPerLog50
+report.OpenNMS.Telemetryd.Adapters.PacketsPerLog.type=telemetryAdapters
+report.OpenNMS.Telemetryd.Adapters.PacketsPerLog.command=--title="Telemetry Adapter: Packets Per Log" \
+ --color GRID#f2f2f288  --color MGRID#c2c2d688  --vertical-label="Packets" \
+ DEF:999th={rrd1}:TlmPktsPerLog999:AVERAGE \
+ DEF:99th={rrd2}:TlmPktsPerLog99:AVERAGE \
+ DEF:98th={rrd3}:TlmPktsPerLog98:AVERAGE \
+ DEF:95th={rrd4}:TlmPktsPerLog95:AVERAGE \
+ DEF:75th={rrd5}:TlmPktsPerLog75:AVERAGE \
+ DEF:50th={rrd6}:TlmPktsPerLog50:AVERAGE \
+ AREA:999th#542437:"999th percentile" \
+ GPRINT:999th:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:999th:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:999th:MAX:" Max \\: %8.2lf %s\\n" \
+ AREA:99th#C44D58:"99th percentile" \
+ GPRINT:99th:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:99th:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:99th:MAX:" Max \\: %8.2lf %s\\n" \
+ AREA:98th#FF6B6B:"98th percentile" \
+ GPRINT:98th:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:98th:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:98th:MAX:" Max \\: %8.2lf %s\\n" \
+ AREA:95th#556270:"95th percentile" \
+ GPRINT:95th:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:95th:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:95th:MAX:" Max \\: %8.2lf %s\\n" \
+ AREA:75th#4ECDC4:"75th percentile" \
+ GPRINT:75th:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:75th:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:75th:MAX:" Max \\: %8.2lf %s\\n" \
+ AREA:50th#C7F464:"50th percentile" \
+ GPRINT:50th:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:50th:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:50th:MAX:" Max \\: %8.2lf %s\\n"
+
+report.OpenNMS.Telemetryd.Adapters.LogParsing.name=Log Parsing Latency
+report.OpenNMS.Telemetryd.Adapters.LogParsing.columns=TlmLogParse999,TlmLogParse99,TlmLogParse98,TlmLogParse95,TlmLogParse75,TlmLogParse50
+report.OpenNMS.Telemetryd.Adapters.LogParsing.type=telemetryAdapters
+report.OpenNMS.Telemetryd.Adapters.LogParsing.command=--title="Telemetry Adapter: Log Parsing Latency" \
+ --color GRID#f2f2f288  --color MGRID#c2c2d688  --vertical-label="Milliseconds" \
+ DEF:999th={rrd1}:TlmLogParse999:AVERAGE \
+ DEF:99th={rrd2}:TlmLogParse99:AVERAGE \
+ DEF:98th={rrd3}:TlmLogParse98:AVERAGE \
+ DEF:95th={rrd4}:TlmLogParse95:AVERAGE \
+ DEF:75th={rrd5}:TlmLogParse75:AVERAGE \
+ DEF:50th={rrd6}:TlmLogParse50:AVERAGE \
+ AREA:999th#542437:"999th percentile" \
+ GPRINT:999th:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:999th:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:999th:MAX:" Max \\: %8.2lf %s\\n" \
+ AREA:99th#C44D58:"99th percentile" \
+ GPRINT:99th:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:99th:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:99th:MAX:" Max \\: %8.2lf %s\\n" \
+ AREA:98th#FF6B6B:"98th percentile" \
+ GPRINT:98th:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:98th:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:98th:MAX:" Max \\: %8.2lf %s\\n" \
+ AREA:95th#556270:"95th percentile" \
+ GPRINT:95th:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:95th:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:95th:MAX:" Max \\: %8.2lf %s\\n" \
+ AREA:75th#4ECDC4:"75th percentile" \
+ GPRINT:75th:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:75th:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:75th:MAX:" Max \\: %8.2lf %s\\n" \
+ AREA:50th#C7F464:"50th percentile" \
+ GPRINT:50th:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:50th:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:50th:MAX:" Max \\: %8.2lf %s\\n"
+
+report.OpenNMS.Telemetryd.Listeners.PacketsReceived.name=Listener Packets Received
+report.OpenNMS.Telemetryd.Listeners.PacketsReceived.columns=TlmPacketsRcvd1m
+report.OpenNMS.Telemetryd.Listeners.PacketsReceived.type=telemetryListeners
+report.OpenNMS.Telemetryd.Listeners.PacketsReceived.command=--title="Telemetry Listener: Packets Received" \
+ --vertical-label="Packets per second" \
+ DEF:rate={rrd1}:TlmPacketsRcvd1m:AVERAGE \
+ AREA:rate#C7F464:"Packets per second" \
+ GPRINT:rate:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:rate:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:rate:MAX:" Max \\: %8.2lf %s"
+
+# EOF

--- a/pom.xml
+++ b/pom.xml
@@ -3660,6 +3660,11 @@
         <version>99.99.99-exclude-and-use-org.apache.servicemix.bundles.jdom-instead</version>
       </dependency>
       <dependency>
+        <groupId>io.dropwizard.metrics</groupId>
+        <artifactId>metrics-core</artifactId>
+        <version>${dropwizardMetricsVersion}</version>
+      </dependency>
+      <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>apache-jsp</artifactId>
         <version>${jettyVersion}</version>


### PR DESCRIPTION
JIRA: https://issues.opennms.org/browse/NMS-12182

Here we re-work the way that telemetryd expose metrics and make it easier to expose listener/adapter statistics.

We leverage this functionality to expose the rate at which packets are received by the listeners, and update the JMX collection configs to collect and graph these.
