### PR TITLE
NMS-12166: Hide Vaadin Apps headers inside iFrames

### DIFF
--- a/features/topology-map/org.opennms.features.topology.api/src/main/java/org/opennms/features/topology/api/HeaderUtil.java
+++ b/features/topology-map/org.opennms.features.topology.api/src/main/java/org/opennms/features/topology/api/HeaderUtil.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.features.topology.api;
+
+import com.vaadin.server.ClientConnector;
+
+public class HeaderUtil {
+    public static ClientConnector.AttachListener getAttachListener() {
+        return new ClientConnector.AttachListener() {
+            @Override
+            public void attach(ClientConnector.AttachEvent event) {
+                checkHeaderVisibility();
+            }
+        };
+    }
+
+    public static void checkHeaderVisibility() {
+        com.vaadin.ui.JavaScript.getCurrent().execute(
+                "if (window.location != window.parent.location && window.name.indexOf('-with-header') == -1) {$('#header').hide(); $('body.fixed-nav').attr('style', 'padding-top: 0px !important');}"
+        );
+    }
+}

--- a/features/topology-map/org.opennms.features.topology.app/src/main/java/org/opennms/features/topology/app/internal/TopologyUI.java
+++ b/features/topology-map/org.opennms.features.topology.app/src/main/java/org/opennms/features/topology/app/internal/TopologyUI.java
@@ -48,6 +48,7 @@ import javax.servlet.http.HttpServletRequest;
 import org.opennms.features.topology.api.CheckedOperation;
 import org.opennms.features.topology.api.GraphContainer;
 import org.opennms.features.topology.api.HasExtraComponents;
+import org.opennms.features.topology.api.HeaderUtil;
 import org.opennms.features.topology.api.HistoryManager;
 import org.opennms.features.topology.api.IViewContribution;
 import org.opennms.features.topology.api.MapViewManager;
@@ -114,7 +115,6 @@ import com.google.common.collect.Lists;
 import com.vaadin.annotations.PreserveOnRefresh;
 import com.vaadin.annotations.Theme;
 import com.vaadin.annotations.Title;
-import com.vaadin.v7.data.Property;
 import com.vaadin.event.UIEvents;
 import com.vaadin.server.DefaultErrorHandler;
 import com.vaadin.server.Page.UriFragmentChangedEvent;
@@ -129,16 +129,17 @@ import com.vaadin.ui.AbsoluteLayout;
 import com.vaadin.ui.Alignment;
 import com.vaadin.ui.Component;
 import com.vaadin.ui.CustomLayout;
-import com.vaadin.v7.ui.HorizontalLayout;
-import com.vaadin.v7.ui.Label;
 import com.vaadin.ui.Notification;
 import com.vaadin.ui.TabSheet;
 import com.vaadin.ui.TabSheet.SelectedTabChangeEvent;
 import com.vaadin.ui.TabSheet.SelectedTabChangeListener;
 import com.vaadin.ui.UI;
-import com.vaadin.v7.ui.VerticalLayout;
 import com.vaadin.ui.VerticalSplitPanel;
 import com.vaadin.ui.Window;
+import com.vaadin.v7.data.Property;
+import com.vaadin.v7.ui.HorizontalLayout;
+import com.vaadin.v7.ui.Label;
+import com.vaadin.v7.ui.VerticalLayout;
 
 @SuppressWarnings("serial")
 @Theme("topo_default")
@@ -329,6 +330,14 @@ public class TopologyUI extends UI implements MenuUpdateListener, ContextMenuHan
             }
             return false;
         }
+    }
+
+    @Override
+    protected void refresh(VaadinRequest request) {
+        super.refresh(request);
+        // The topology UI uses @PreserveOnRefresh, so on reload the components will not be detached/attached.
+        // Since the attach listener will not work on page reload we have to check for header visibility manually.
+        HeaderUtil.checkHeaderVisibility();
     }
 
     /**
@@ -722,6 +731,10 @@ public class TopologyUI extends UI implements MenuUpdateListener, ContextMenuHan
                 final CustomLayout headerLayout = new CustomLayout(is);
                 headerLayout.setWidth("100%");
                 headerLayout.addStyleName("onmsheader");
+
+                // check for header visibility when component is attached
+                headerLayout.addAttachListener(HeaderUtil.getAttachListener());
+
                 m_rootLayout.addComponent(headerLayout);
             } catch (final IOException e) {
                 try {

--- a/features/vaadin-dashlets/dashlet-map/src/main/java/org/opennms/features/vaadin/dashboard/dashlets/MapDashlet.java
+++ b/features/vaadin-dashlets/dashlet-map/src/main/java/org/opennms/features/vaadin/dashboard/dashlets/MapDashlet.java
@@ -82,6 +82,7 @@ public class MapDashlet extends AbstractDashlet {
 
                     BrowserFrame browserFrame = new BrowserFrame(null, new ExternalResource("/opennms/node-maps#search/" + searchString));
                     browserFrame.setSizeFull();
+                    browserFrame.setId("opsboard-map-iframe");
                     m_verticalLayout.addComponent(browserFrame);
                 }
 

--- a/features/vaadin-dashlets/dashlet-topology/src/main/java/org/opennms/features/vaadin/dashboard/dashlets/TopologyDashlet.java
+++ b/features/vaadin-dashlets/dashlet-topology/src/main/java/org/opennms/features/vaadin/dashboard/dashlets/TopologyDashlet.java
@@ -88,6 +88,7 @@ public class TopologyDashlet extends AbstractDashlet {
                     //creating browser frame to display the topology
                     BrowserFrame browserFrame = new BrowserFrame(null, new ExternalResource(linkBuilder.getLink()));
                     browserFrame.setSizeFull();
+                    browserFrame.setId("opsboard-topology-iframe");
                     m_verticalLayout.addComponent(browserFrame);
                 }
 

--- a/features/vaadin-node-maps/src/main/java/org/opennms/features/vaadin/nodemaps/internal/NodeMapsApplication.java
+++ b/features/vaadin-node-maps/src/main/java/org/opennms/features/vaadin/nodemaps/internal/NodeMapsApplication.java
@@ -38,6 +38,7 @@ import javax.servlet.http.HttpServletRequest;
 
 import org.opennms.core.sysprops.SystemProperties;
 import org.opennms.features.topology.api.HasExtraComponents;
+import org.opennms.features.topology.api.HeaderUtil;
 import org.opennms.features.topology.api.VerticesUpdateManager.VerticesUpdateEvent;
 import org.opennms.features.topology.api.browsers.SelectionAwareTable;
 import org.opennms.features.topology.api.browsers.SelectionChangedListener;
@@ -62,13 +63,13 @@ import com.vaadin.ui.AbsoluteLayout;
 import com.vaadin.ui.Alignment;
 import com.vaadin.ui.Component;
 import com.vaadin.ui.CustomLayout;
-import com.vaadin.v7.ui.HorizontalLayout;
 import com.vaadin.ui.TabSheet;
 import com.vaadin.ui.TabSheet.SelectedTabChangeEvent;
 import com.vaadin.ui.TabSheet.SelectedTabChangeListener;
 import com.vaadin.ui.UI;
-import com.vaadin.v7.ui.VerticalLayout;
 import com.vaadin.ui.VerticalSplitPanel;
+import com.vaadin.v7.ui.HorizontalLayout;
+import com.vaadin.v7.ui.VerticalLayout;
 
 /**
  * The Class Node Maps Application.
@@ -325,6 +326,10 @@ public class NodeMapsApplication extends UI {
                 final CustomLayout headerLayout = new CustomLayout(is);
                 headerLayout.setWidth("100%");
                 headerLayout.addStyleName("onmsheader");
+
+                // check for header visibility when component is attached
+                headerLayout.addAttachListener(HeaderUtil.getAttachListener());
+
                 m_rootLayout.addComponent(headerLayout);
             } catch (final IOException e) {
                 closeQuietly(is);


### PR DESCRIPTION
* JIRA: https://issues.opennms.org/browse/NMS-12166

The code for hiding the header is still in place and works for normal pages. Our Vaadin UIs include the html/script code in a CustomLayout but Vaadin strips script-tags so the JavaScript-stuff is never executed. I added an AttachListener to execute the JavaScript-Code. The Topology UI uses the @PreserveOnRefresh annotation which means that a page reload will not fire detach/attach listeners. So, I added a custom refresh-method that invokes the JS-code manually on page reload.