### PR TITLE
NMS-11720: Run as non-root

### DIFF
--- a/opennms-container/horizon/Dockerfile
+++ b/opennms-container/horizon/Dockerfile
@@ -40,15 +40,10 @@ ARG ONMS_PACKAGES="opennms-core opennms-webapp-jetty opennms-webapp-remoting ope
 # Allow to install optional packages via YUM
 ARG ADD_YUM_PACKAGES
 
-ARG OPENNMS_UID
-
 COPY ./rpms /tmp/rpms
 COPY ./tarball /tmp/tarball
 
 SHELL ["/bin/bash", "-c"]
-
-RUN groupadd -g 1000 elasticsearch && \
-adduser -u 1000 -g 1000 -d /usr/share/elasticsearch elasticsearch
 
 # Install repositories, system and OpenNMS packages and do some cleanup
 # 1. Try to install from tarball
@@ -66,21 +61,25 @@ RUN if [[ "$(ls -1 /tmp/tarball/*.tar.gz 2>/dev/null | wc -l)" != 0 ]]; then \
     rm -rf /var/cache/yum && \
     rm -rf /opt/opennms/logs \
            /opt/opennms/share/rrd \
-           /opt/opennms/share/reports && \
-    mkdir -p /opennms-data/logs \
-             /opennms-data/rrd \
-             /opennms-data/reports && \
-    ln -s /opennms-data/logs /opt/opennms/logs && \
+           /opt/opennms/share/reports \
+           /opt/opennms/share/mibs && \
+    mkdir -p /opt/opennms-etc-overlay \
+             /opt/opennms-jetty-webinf-overlay \
+             /opt/opennms/logs && \
+    mkdir -p /opennms-data/rrd \
+             /opennms-data/reports \
+             /opennms-data/mibs && \
     ln -s /opennms-data/rrd /opt/opennms/share/rrd && \
-    ln -s /opennms-data/reports /opt/opennms/share/reports
+    ln -s /opennms-data/reports /opt/opennms/share/reports && \
+    ln -s /opennms-data/mibs /opt/opennms/share/mibs
 
-RUN chown opennms:opennms -R /opt/opennms /opennms-data /opt/opennms-etc-overlay /opt/opennms-jetty-webinf-overlay && \
+RUN chown 10001:10001 -R /opt/opennms /opennms-data /opt/opennms-etc-overlay /opt/opennms-jetty-webinf-overlay && \
     chgrp -R 0 /opt/opennms /opt/opennms /opennms-data /opt/opennms-etc-overlay /opt/opennms-jetty-webinf-overlay && \
     chmod -R g=u /opt/opennms /opennms-data /opt/opennms-etc-overlay /opt/opennms-jetty-webinf-overlay
 
 # Add templates replaced at runtime and entrypoint
-COPY ./assets/*.tpl /root/
-COPY ./assets/entrypoint.sh /
+COPY --chown=10001:0 ./assets/*.tpl /tmp/
+COPY --chown=10001:0 ./assets/entrypoint.sh /
 
 # Arguments for labels should not invalidate caches
 ARG BUILD_DATE="1970-01-01T00:00:00+0000"
@@ -115,7 +114,8 @@ CMD [ "-h" ]
 
 ENV OPENNMS_KARAF_SSH_HOST="0.0.0.0" \
     OPENNMS_KARAF_SSH_PORT="8101" \
-    JAVA_OPTS=""
+    JAVA_OPTS="" \
+    OPENNMS_TRAPD_PORT=1162
 
 # Volumes for storing data outside of the container
 VOLUME [ "/opt/opennms/etc", "/opt/opennms-etc-overlay", "/opennms-data" ]
@@ -131,4 +131,4 @@ VOLUME [ "/opt/opennms/etc", "/opt/opennms-etc-overlay", "/opennms-data" ]
 ## -- OpenNMS Eventd      5817/TCP
 ## -- SNMP Trapd           162/UDP
 ## -- Syslog Receiver      514/UDP
-EXPOSE 8980 8101 61616 162/udp 514/udp
+EXPOSE 8980 8101 1162/udp 10514/udp

--- a/opennms-container/horizon/Dockerfile
+++ b/opennms-container/horizon/Dockerfile
@@ -129,6 +129,6 @@ VOLUME [ "/opt/opennms/etc", "/opt/opennms-etc-overlay", "/opennms-data" ]
 ## -- OpenNMS KARAF SSH   8101/TCP
 ## -- OpenNMS MQ         61616/TCP
 ## -- OpenNMS Eventd      5817/TCP
-## -- SNMP Trapd           162/UDP
-## -- Syslog Receiver      514/UDP
+## -- SNMP Trapd          1162/UDP
+## -- Syslog Receiver    10514/UDP
 EXPOSE 8980 8101 1162/udp 10514/udp

--- a/opennms-container/horizon/Dockerfile
+++ b/opennms-container/horizon/Dockerfile
@@ -59,22 +59,33 @@ RUN if [[ "$(ls -1 /tmp/tarball/*.tar.gz 2>/dev/null | wc -l)" != 0 ]]; then \
     rm -rf /tmp/rpms /tmp/tarball && \
     yum clean all && \
     rm -rf /var/cache/yum && \
-    rm -rf /opt/opennms/logs \
-           /opt/opennms/share/rrd \
+    rm -rf /opt/opennms/share/rrd \
            /opt/opennms/share/reports \
            /opt/opennms/share/mibs && \
     mkdir -p /opt/opennms-etc-overlay \
              /opt/opennms-jetty-webinf-overlay \
-             /opt/opennms/logs && \
+             /opt/opennms-overlay && \
     mkdir -p /opennms-data/rrd \
              /opennms-data/reports \
              /opennms-data/mibs && \
     ln -s /opennms-data/rrd /opt/opennms/share/rrd && \
     ln -s /opennms-data/reports /opt/opennms/share/reports && \
     ln -s /opennms-data/mibs /opt/opennms/share/mibs && \
-    chown 10001:10001 -R /opt/opennms /opennms-data /opt/opennms-etc-overlay /opt/opennms-jetty-webinf-overlay && \
-    chgrp -R 0 /opt/opennms /opt/opennms /opennms-data /opt/opennms-etc-overlay /opt/opennms-jetty-webinf-overlay && \
-    chmod -R g=u /opt/opennms /opennms-data /opt/opennms-etc-overlay /opt/opennms-jetty-webinf-overlay
+    chown 10001:10001 -R /opt/opennms \
+                         /opennms-data \
+                         /opt/opennms-overlay \
+                         /opt/opennms-etc-overlay \
+                         /opt/opennms-jetty-webinf-overlay && \
+    chgrp -R 0 /opt/opennms \
+               /opennms-data \
+               /opt/opennms-overlay \
+               /opt/opennms-etc-overlay \
+               /opt/opennms-jetty-webinf-overlay && \
+    chmod -R g=u /opt/opennms \
+                 /opennms-data \
+                 /opt/opennms-overlay \
+                 /opt/opennms-etc-overlay \
+                 /opt/opennms-jetty-webinf-overlay
 
 # Add templates replaced at runtime and entrypoint
 COPY --chown=10001:0 ./assets/*.tpl /tmp/

--- a/opennms-container/horizon/Dockerfile
+++ b/opennms-container/horizon/Dockerfile
@@ -71,9 +71,8 @@ RUN if [[ "$(ls -1 /tmp/tarball/*.tar.gz 2>/dev/null | wc -l)" != 0 ]]; then \
              /opennms-data/mibs && \
     ln -s /opennms-data/rrd /opt/opennms/share/rrd && \
     ln -s /opennms-data/reports /opt/opennms/share/reports && \
-    ln -s /opennms-data/mibs /opt/opennms/share/mibs
-
-RUN chown 10001:10001 -R /opt/opennms /opennms-data /opt/opennms-etc-overlay /opt/opennms-jetty-webinf-overlay && \
+    ln -s /opennms-data/mibs /opt/opennms/share/mibs && \
+    chown 10001:10001 -R /opt/opennms /opennms-data /opt/opennms-etc-overlay /opt/opennms-jetty-webinf-overlay && \
     chgrp -R 0 /opt/opennms /opt/opennms /opennms-data /opt/opennms-etc-overlay /opt/opennms-jetty-webinf-overlay && \
     chmod -R g=u /opt/opennms /opennms-data /opt/opennms-etc-overlay /opt/opennms-jetty-webinf-overlay
 

--- a/opennms-container/horizon/Dockerfile
+++ b/opennms-container/horizon/Dockerfile
@@ -21,6 +21,14 @@ RUN rpm --import "${REPO_KEY_URL}" && \
     yum clean all -y && \
     rm -rf /var/cache/yum
 
+# Allow to send ICMP messages as non-root user
+RUN setcap cap_net_raw+ep ${JAVA_HOME}/bin/java && \
+    echo ${JAVA_HOME}/lib/jli > /etc/ld.so.conf.d/java-latest.conf && \
+    ldconfig
+
+# Set gid=0 and make group perms==owner perms
+RUN groupadd -g 10001 opennms && \
+    adduser -u 10001 -g 10001 -d /opt/opennms -s /usr/bin/bash opennms
 ##
 # Install and setup OpenNMS RPMS
 ##
@@ -32,10 +40,15 @@ ARG ONMS_PACKAGES="opennms-core opennms-webapp-jetty opennms-webapp-remoting ope
 # Allow to install optional packages via YUM
 ARG ADD_YUM_PACKAGES
 
+ARG OPENNMS_UID
+
 COPY ./rpms /tmp/rpms
 COPY ./tarball /tmp/tarball
 
 SHELL ["/bin/bash", "-c"]
+
+RUN groupadd -g 1000 elasticsearch && \
+adduser -u 1000 -g 1000 -d /usr/share/elasticsearch elasticsearch
 
 # Install repositories, system and OpenNMS packages and do some cleanup
 # 1. Try to install from tarball
@@ -61,6 +74,10 @@ RUN if [[ "$(ls -1 /tmp/tarball/*.tar.gz 2>/dev/null | wc -l)" != 0 ]]; then \
     ln -s /opennms-data/rrd /opt/opennms/share/rrd && \
     ln -s /opennms-data/reports /opt/opennms/share/reports
 
+RUN chown opennms:opennms -R /opt/opennms /opennms-data /opt/opennms-etc-overlay /opt/opennms-jetty-webinf-overlay && \
+    chgrp -R 0 /opt/opennms /opt/opennms /opennms-data /opt/opennms-etc-overlay /opt/opennms-jetty-webinf-overlay && \
+    chmod -R g=u /opt/opennms /opennms-data /opt/opennms-etc-overlay /opt/opennms-jetty-webinf-overlay
+
 # Add templates replaced at runtime and entrypoint
 COPY ./assets/*.tpl /root/
 COPY ./assets/entrypoint.sh /
@@ -85,6 +102,8 @@ LABEL maintainer="The OpenNMS Group" \
       cicd.build.sha1="${CIRCLE_SHA1}"
 
 WORKDIR /opt/opennms
+
+USER 10001
 
 ENTRYPOINT [ "/entrypoint.sh" ]
 

--- a/opennms-container/horizon/Dockerfile
+++ b/opennms-container/horizon/Dockerfile
@@ -49,22 +49,30 @@ SHELL ["/bin/bash", "-c"]
 # 1. Try to install from tarball
 # 2. Try to install from local RPMS
 # 3. Try to install from public yum repository
+#
+# To avoid different behavior, between a RPM or tarball installation,
+# the directory structure is unified, the links for /opt/opennms/share
+# and /opt/opennms/logs introduced by RPM installs are removed.
 RUN if [[ "$(ls -1 /tmp/tarball/*.tar.gz 2>/dev/null | wc -l)" != 0 ]]; then \
         mkdir -p /opt/opennms && tar xzf /tmp/tarball/opennms-*.tar.gz -C /opt/opennms && \
         cp -r /opt/opennms/etc /opt/opennms/share/etc-pristine; \
     elif [[ "$(ls -1 /tmp/rpms/*.rpm 2>/dev/null | wc -l)" != 0 ]]; then \
-        yum -y localinstall /tmp/rpms/*.rpm; \
+        yum -y localinstall /tmp/rpms/*.rpm && \
+        rm -rf /opt/opennms/logs \
+               /opt/opennms/share && \
+        mv /var/opennms /opt/opennms/share && \
+        mv /var/log/opennms /opt/opennms/logs; \
     else \
-        yum install -y ${ONMS_PACKAGES}; \
+        yum install -y ${ONMS_PACKAGES} && \
+        rm -rf /opt/opennms/logs \
+               /opt/opennms/share && \
+        mv /var/opennms /opt/opennms/share && \
+        mv /var/log/opennms /opt/opennms/logs; \
     fi && \
     if [[ -n ${ADD_YUM_PACKAGES} ]]; then yum -y install ${ADD_YUM_PACKAGES}; fi && \
     rm -rf /tmp/rpms /tmp/tarball && \
     yum clean all && \
     rm -rf /var/cache/yum && \
-    rm -rf /opt/opennms/logs \
-           /opt/opennms/share && \
-    mv /var/opennms /opt/opennms/share && \
-    mv /var/log/opennms /opt/opennms/logs && \
     rm -rf /opt/opennms/share/rrd \
            /opt/opennms/share/reports \
            /opt/opennms/share/mibs && \

--- a/opennms-container/horizon/Dockerfile
+++ b/opennms-container/horizon/Dockerfile
@@ -52,13 +52,19 @@ SHELL ["/bin/bash", "-c"]
 RUN if [[ "$(ls -1 /tmp/tarball/*.tar.gz 2>/dev/null | wc -l)" != 0 ]]; then \
         mkdir -p /opt/opennms && tar xzf /tmp/tarball/opennms-*.tar.gz -C /opt/opennms && \
         cp -r /opt/opennms/etc /opt/opennms/share/etc-pristine; \
-        elif [[ "$(ls -1 /tmp/rpms/*.rpm 2>/dev/null | wc -l)" != 0 ]]; then \
+    elif [[ "$(ls -1 /tmp/rpms/*.rpm 2>/dev/null | wc -l)" != 0 ]]; then \
         yum -y localinstall /tmp/rpms/*.rpm; \
-        else yum install -y ${ONMS_PACKAGES}; fi && \
+    else \
+        yum install -y ${ONMS_PACKAGES}; \
+    fi && \
     if [[ -n ${ADD_YUM_PACKAGES} ]]; then yum -y install ${ADD_YUM_PACKAGES}; fi && \
     rm -rf /tmp/rpms /tmp/tarball && \
     yum clean all && \
     rm -rf /var/cache/yum && \
+    rm -rf /opt/opennms/logs \
+           /opt/opennms/share && \
+    mv /var/opennms /opt/opennms/share && \
+    mv /var/log/opennms /opt/opennms/logs && \
     rm -rf /opt/opennms/share/rrd \
            /opt/opennms/share/reports \
            /opt/opennms/share/mibs && \

--- a/opennms-container/horizon/assets/entrypoint.sh
+++ b/opennms-container/horizon/assets/entrypoint.sh
@@ -10,6 +10,7 @@
 # Cause false/positives
 # shellcheck disable=SC2086
 
+umask 002
 OPENNMS_HOME="/opt/opennms"
 
 OPENNMS_DATASOURCES_TPL="/tmp/opennms-datasources.xml.tpl"

--- a/opennms-container/horizon/assets/entrypoint.sh
+++ b/opennms-container/horizon/assets/entrypoint.sh
@@ -129,7 +129,7 @@ applyOverlayConfig() {
   if [ -d "${OPENNMS_OVERLAY}" ] && [ -n "$(ls -A ${OPENNMS_OVERLAY})" ]; then
     echo "Apply custom configuration from ${OPENNMS_OVERLAY}."
     # Use rsync so that we can overlay files into directories that are symlinked
-    rsync -K -a ${OPENNMS_OVERLAY}/* ${OPENNMS_HOME}/ || exit ${E_INIT_CONFIG}
+    rsync -K -rl ${OPENNMS_OVERLAY}/* ${OPENNMS_HOME}/ || exit ${E_INIT_CONFIG}
   else
     echo "No custom config found in ${OPENNMS_OVERLAY}. Use default configuration."
   fi

--- a/opennms-container/horizon/assets/entrypoint.sh
+++ b/opennms-container/horizon/assets/entrypoint.sh
@@ -10,22 +10,25 @@
 # Cause false/positives
 # shellcheck disable=SC2086
 
-OPENNMS_HOME=/opt/opennms
+OPENNMS_HOME="/opt/opennms"
 
-OPENNMS_DATASOURCES_TPL=/root/opennms-datasources.xml.tpl
-OPENNMS_DATASOURCES_CFG=${OPENNMS_HOME}/etc/opennms-datasources.xml
-OPENNMS_OVERLAY=/opt/opennms-overlay
-OPENNMS_OVERLAY_ETC=/opt/opennms-etc-overlay
-OPENNMS_OVERLAY_JETTY_WEBINF=/opt/opennms-jetty-webinf-overlay
+OPENNMS_DATASOURCES_TPL="/tmp/opennms-datasources.xml.tpl"
+OPENNMS_DATASOURCES_CFG="${OPENNMS_HOME}/etc/opennms-datasources.xml"
+OPENNMS_OVERLAY="/opt/opennms-overlay"
+OPENNMS_OVERLAY_ETC="/opt/opennms-etc-overlay"
+OPENNMS_OVERLAY_JETTY_WEBINF="/opt/opennms-jetty-webinf-overlay"
 
-OPENNMS_UPGRADE_GUARD=${OPENNMS_HOME}/etc/do-upgrade
-OPENNMS_CONFIGURED_GUARD=${OPENNMS_HOME}/etc/configured
+OPENNMS_UPGRADE_GUARD="${OPENNMS_HOME}/etc/do-upgrade"
+OPENNMS_CONFIGURED_GUARD="${OPENNMS_HOME}/etc/configured"
 
-OPENNMS_KARAF_TPL=/root/org.apache.karaf.shell.cfg.tpl
-OPENNMS_KARAF_CFG=${OPENNMS_HOME}/etc/org.apache.karaf.shell.cfg
+OPENNMS_KARAF_TPL="/tmp/org.apache.karaf.shell.cfg.tpl"
+OPENNMS_KARAF_CFG="${OPENNMS_HOME}/etc/org.apache.karaf.shell.cfg"
 
-OPENNMS_NEWTS_TPL=/root/newts.properties.tpl
-OPENNMS_NEWTS_PROPERTIES=${OPENNMS_HOME}/etc/opennms.properties.d/newts.properties
+OPENNMS_NEWTS_TPL="/tmp/newts.properties.tpl"
+OPENNMS_NEWTS_PROPERTIES="${OPENNMS_HOME}/etc/opennms.properties.d/newts.properties"
+
+OPENNMS_TRAPD_TPL="/tmp/trapd-configuration.xml.tpl"
+OPENNMS_TRAPD_CFG="${OPENNMS_HOME}/etc/trapd-configuration.xml"
 
 # Error codes
 E_ILLEGAL_ARGS=126
@@ -53,12 +56,17 @@ usage() {
   echo ""
 }
 
+install() {
+  echo "Run OpenNMS install command to initialize or upgrade the database schema and configurations."
+  ${JAVA_HOME}/bin/java -Dopennms.home="${OPENNMS_HOME}" -Dlog4j.configurationFile="${OPENNMS_HOME}"/etc/log4j2-tools.xml -cp "${OPENNMS_HOME}/lib/opennms_bootstrap.jar" org.opennms.bootstrap.InstallerBootstrap "${@}" || exit ${E_INIT_CONFIG}
+}
+
 doInitOrUpgrade() {
   if [ -f ${OPENNMS_UPGRADE_GUARD} ]; then
     echo "Enforce config and database update."
     rm -rf ${OPENNMS_CONFIGURED_GUARD}
-    ${OPENNMS_HOME}/bin/runjava -s
-    ${OPENNMS_HOME}/bin/install -dis
+    ${OPENNMS_HOME}/bin/runjava -s || exit ${E_INIT_CONFIG}
+    install -dis || exit ${E_INIT_CONFIG}
     rm -rf ${OPENNMS_UPGRADE_GUARD}
     rm -rf ${OPENNMS_OVERLAY_ETC}/do-upgrade
     rm -rf ${OPENNMS_OVERLAY}/etc/do-upgrade
@@ -81,8 +89,30 @@ initConfig() {
     echo "Initialize database and Karaf configuration and do install or upgrade the database schema."
     envsubst < ${OPENNMS_DATASOURCES_TPL} > ${OPENNMS_DATASOURCES_CFG}
     envsubst < ${OPENNMS_KARAF_TPL} > ${OPENNMS_KARAF_CFG}
+    envsubst < ${OPENNMS_TRAPD_TPL} > ${OPENNMS_TRAPD_CFG}
     ${OPENNMS_HOME}/bin/runjava -s || exit ${E_INIT_CONFIG}
-    ${OPENNMS_HOME}/bin/install -dis || exit ${E_INIT_CONFIG}
+    install -dis || exit ${E_INIT_CONFIG}
+  fi
+
+  if [[ ! -d /opennms-data/mibs ]]; then
+    echo "Mibs data directory does not exist, create directory in /opennms-data/mibs"
+    mkdir /opennms-data/mibs || exit ${E_INIT_CONFIG}
+  else
+    echo "Use existing Mibs data directory."
+  fi
+
+  if [[ ! -d /opennms-data/reports ]]; then
+    echo "Reports data directory does not exist, create directory in /opennms-data/reports"
+    mkdir /opennms-data/reports || exit ${E_INIT_CONFIG}
+  else
+    echo "Use existing Reports data directory."
+  fi
+
+  if [[ ! -d /opennms-data/rrd ]]; then
+    echo "RRD data directory does not exist, create directory in /opennms-data/rrd"
+    mkdir /opennms-data/rrd || exit ${E_INIT_CONFIG}
+  else
+    echo "Use existing RRD data directory."
   fi
 }
 
@@ -148,12 +178,17 @@ start() {
   exec ${JAVA_HOME}/bin/java ${OPENNMS_JAVA_OPTS} ${JAVA_OPTS} -jar /opt/opennms/lib/opennms_bootstrap.jar start
 }
 
+configTester() {
+  echo "Run config tester to validate existing configuration files."
+  ${JAVA_HOME}/bin/java -Dopennms.manager.class="org.opennms.netmgt.config.tester.ConfigTester" -Dopennms.home="${OPENNMS_HOME}" -Dlog4j.configurationFile="${OPENNMS_HOME}"/etc/log4j2-tools.xml -jar ${OPENNMS_HOME}/lib/opennms_bootstrap.jar "${@}" || exit ${E_INIT_CONFIG}
+}
+
 testConfig() {
   shift
   if [ "${#}" == "0" ]; then
-    ${OPENNMS_HOME}/bin/config-tester -h
+    configTester -h
   else
-    ${OPENNMS_HOME}/bin/config-tester "${@}" || exit ${E_INIT_CONFIG}
+    configTester "${@}"
   fi
 }
 

--- a/opennms-container/horizon/assets/trapd-configuration.xml.tpl
+++ b/opennms-container/horizon/assets/trapd-configuration.xml.tpl
@@ -1,0 +1,1 @@
+<trapd-configuration xmlns="http://xmlns.opennms.org/xsd/config/trapd" snmp-trap-address="*" snmp-trap-port="${OPENNMS_TRAPD_PORT}" new-suspect-on-trap="false" include-raw-message="false" threads="0" queue-size="10000" batch-size="1000" batch-interval="500"/>


### PR DESCRIPTION
Refactored the container image to run as non-root by default and runs with an arbitrary user id to be compatible to run in Open Shift. The following things are changed on a high level:

* cap_net_raw is set for the Java binary
* support [Arbitrary User IDs](https://docs.openshift.com/enterprise/3.0/creating_images/guidelines.html)
* Unify the directory structure so we don't have different situations when we install from RPM vs. tarball installation

JIRA: https://issues.opennms.org/browse/NMS-11720

As requested, I've uploaded an image to DockerHub with opennms/horizon:nms-11720.