### PR TITLE
NMS-12082: Add support for adding prefixes to the index names in Elasticsearch

### DIFF
--- a/features/alarms/history/elastic/src/main/java/org/opennms/features/alarms/history/elastic/ElasticAlarmHistoryRepository.java
+++ b/features/alarms/history/elastic/src/main/java/org/opennms/features/alarms/history/elastic/ElasticAlarmHistoryRepository.java
@@ -42,6 +42,7 @@ import org.opennms.features.alarms.history.api.AlarmState;
 import org.opennms.features.alarms.history.elastic.dto.AlarmDocumentDTO;
 import org.opennms.plugins.elasticsearch.rest.index.IndexSelector;
 import org.opennms.plugins.elasticsearch.rest.index.IndexStrategy;
+import org.opennms.plugins.elasticsearch.rest.template.IndexSettings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -67,10 +68,10 @@ public class ElasticAlarmHistoryRepository implements AlarmHistoryRepository {
 
     private long lookbackPeriodMs = DEFAULT_LOOKBACK_PERIOD_MS;
 
-    public ElasticAlarmHistoryRepository(JestClient client, IndexStrategy indexStrategy) {
+    public ElasticAlarmHistoryRepository(JestClient client, IndexStrategy indexStrategy, IndexSettings indexSettings) {
         this.client = Objects.requireNonNull(client);
         Objects.requireNonNull(indexStrategy);
-        this.indexSelector = new IndexSelector(ElasticAlarmIndexer.INDEX_PREFIX, indexStrategy, 0);
+        this.indexSelector = new IndexSelector(indexSettings, ElasticAlarmIndexer.INDEX_PREFIX, indexStrategy, 0);
     }
 
     @Override

--- a/features/alarms/history/elastic/src/main/java/org/opennms/features/alarms/history/elastic/TemplateInitializerForAlarms.java
+++ b/features/alarms/history/elastic/src/main/java/org/opennms/features/alarms/history/elastic/TemplateInitializerForAlarms.java
@@ -45,6 +45,6 @@ public class TemplateInitializerForAlarms extends DefaultTemplateInitializer {
     }
 
     public TemplateInitializerForAlarms(JestClient client) {
-        super(client, TEMPLATE_RESOURCE, TEMPLATE_NAME, new DefaultTemplateLoader());
+        super(client, TEMPLATE_RESOURCE, TEMPLATE_NAME, new DefaultTemplateLoader(), new IndexSettings());
     }
 }

--- a/features/alarms/history/elastic/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/features/alarms/history/elastic/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -40,6 +40,7 @@
             <cm:property name="settings.index.number_of_replicas" value="" />
             <cm:property name="settings.index.refresh_interval" value="" />
             <cm:property name="settings.index.routing_partition_size" value="" />
+            <cm:property name="indexPrefix" value="" />
 
             <!-- Alarm History settings -->
             <cm:property name="indexAllUpdates" value="false" />
@@ -115,6 +116,7 @@
     </bean>
 
     <bean id="indexSettings" class="org.opennms.plugins.elasticsearch.rest.template.IndexSettings">
+        <property name="indexPrefix" value="${indexPrefix}"/>
         <property name="numberOfShards" value="${settings.index.number_of_shards}"/>
         <property name="numberOfReplicas" value="${settings.index.number_of_replicas}"/>
         <property name="refreshInterval" value="${settings.index.refresh_interval}"/>
@@ -136,6 +138,7 @@
         <argument ref="nodeCacheConfig" />
         <argument value="${taskQueueCapacity}"/>
         <argument ref="indexStrategy"/>
+        <argument ref="indexSettings"/>
         <property name="bulkRetryCount" value="${bulkRetryCount}" />
         <property name="batchSize" value="${batchIndexSize}" />
         <property name="alarmReindexDurationMs" value="${alarmReindexDurationMs}"/>
@@ -153,6 +156,7 @@
     <bean id="elasticAlarmHistoryRepository" class="org.opennms.features.alarms.history.elastic.ElasticAlarmHistoryRepository">
         <argument ref="jestClient"/>
         <argument ref="indexStrategy"/>
+        <argument ref="indexSettings"/>
         <property name="lookbackPeriodMs" value="${lookbackPeriodMs}"/>
     </bean>
     <service ref="elasticAlarmHistoryRepository" interface="org.opennms.features.alarms.history.api.AlarmHistoryRepository"/>

--- a/features/alarms/history/elastic/src/test/java/org/opennms/features/alarms/history/elastic/ElasticAlarmHistoryBlackboxIT.java
+++ b/features/alarms/history/elastic/src/test/java/org/opennms/features/alarms/history/elastic/ElasticAlarmHistoryBlackboxIT.java
@@ -59,6 +59,7 @@ import org.opennms.netmgt.model.OnmsAlarm;
 import org.opennms.netmgt.model.OnmsSeverity;
 import org.opennms.plugins.elasticsearch.rest.RestClientFactory;
 import org.opennms.plugins.elasticsearch.rest.index.IndexStrategy;
+import org.opennms.plugins.elasticsearch.rest.template.IndexSettings;
 
 import io.searchbox.client.JestClient;
 
@@ -98,7 +99,7 @@ public class ElasticAlarmHistoryBlackboxIT {
 
         RestClientFactory restClientFactory = new RestClientFactory("http://localhost:" + HTTP_PORT);
         jestClient = restClientFactory.createClient();
-        alarmHistoryRepo = new ElasticAlarmHistoryRepository(jestClient, IndexStrategy.MONTHLY);
+        alarmHistoryRepo = new ElasticAlarmHistoryRepository(jestClient, IndexStrategy.MONTHLY, new IndexSettings());
 
         // Wait until ES is up and running - initially there should be no documents
         await().atMost(1, TimeUnit.MINUTES).pollInterval(5, TimeUnit.SECONDS)

--- a/features/alarms/history/elastic/src/test/java/org/opennms/features/alarms/history/elastic/ElasticAlarmHistoryRepositoryIT.java
+++ b/features/alarms/history/elastic/src/test/java/org/opennms/features/alarms/history/elastic/ElasticAlarmHistoryRepositoryIT.java
@@ -53,6 +53,7 @@ import org.opennms.netmgt.model.OnmsAlarm;
 import org.opennms.netmgt.model.OnmsEvent;
 import org.opennms.plugins.elasticsearch.rest.RestClientFactory;
 import org.opennms.plugins.elasticsearch.rest.index.IndexStrategy;
+import org.opennms.plugins.elasticsearch.rest.template.IndexSettings;
 
 import com.codahale.metrics.MetricRegistry;
 import com.jayway.awaitility.Awaitility;
@@ -84,7 +85,7 @@ public class ElasticAlarmHistoryRepositoryIT {
     public void setUp() throws IOException {
         RestClientFactory restClientFactory = new RestClientFactory("http://localhost:" + HTTP_PORT);
         jestClient = restClientFactory.createClient();
-        repo = new ElasticAlarmHistoryRepository(jestClient, IndexStrategy.MONTHLY);
+        repo = new ElasticAlarmHistoryRepository(jestClient, IndexStrategy.MONTHLY, new IndexSettings());
 
         TemplateInitializerForAlarms templateInitializer = new TemplateInitializerForAlarms(jestClient);
         MetricRegistry metrics = new MetricRegistry();

--- a/features/alarms/history/elastic/src/test/java/org/opennms/features/alarms/history/elastic/ElasticAlarmIndexerIT.java
+++ b/features/alarms/history/elastic/src/test/java/org/opennms/features/alarms/history/elastic/ElasticAlarmIndexerIT.java
@@ -55,6 +55,7 @@ import org.opennms.netmgt.model.OnmsAlarm;
 import org.opennms.netmgt.model.OnmsEvent;
 import org.opennms.plugins.elasticsearch.rest.RestClientFactory;
 import org.opennms.plugins.elasticsearch.rest.index.IndexStrategy;
+import org.opennms.plugins.elasticsearch.rest.template.IndexSettings;
 
 import com.codahale.metrics.MetricRegistry;
 import com.jayway.awaitility.Awaitility;
@@ -91,7 +92,7 @@ public class ElasticAlarmIndexerIT {
     public void setUp() throws IOException {
         RestClientFactory restClientFactory = new RestClientFactory("http://localhost:" + HTTP_PORT);
         jestClient = restClientFactory.createClient();
-        alarmHistoryRepo = new ElasticAlarmHistoryRepository(jestClient, IndexStrategy.MONTHLY);
+        alarmHistoryRepo = new ElasticAlarmHistoryRepository(jestClient, IndexStrategy.MONTHLY, new IndexSettings());
 
         MetricRegistry metrics = new MetricRegistry();
         TemplateInitializerForAlarms templateInitializerForAlarms = new TemplateInitializerForAlarms(jestClient);

--- a/features/flows/elastic/src/main/java/org/opennms/netmgt/flows/elastic/ElasticFlowRepositoryInitializer.java
+++ b/features/flows/elastic/src/main/java/org/opennms/netmgt/flows/elastic/ElasticFlowRepositoryInitializer.java
@@ -47,10 +47,10 @@ public class ElasticFlowRepositoryInitializer extends DefaultTemplateInitializer
     }
 
     protected ElasticFlowRepositoryInitializer(JestClient client, IndexSettings indexSettings) {
-        super(client, TEMPLATE_RESOURCE, FLOW_TEMPLATE_NAME, new MergingTemplateLoader(new DefaultTemplateLoader(), indexSettings));
+        super(client, TEMPLATE_RESOURCE, FLOW_TEMPLATE_NAME, new MergingTemplateLoader(new DefaultTemplateLoader(), indexSettings), indexSettings);
     }
 
     protected ElasticFlowRepositoryInitializer(JestClient client) {
-        super(client, TEMPLATE_RESOURCE, FLOW_TEMPLATE_NAME, new DefaultTemplateLoader());
+        super(client, TEMPLATE_RESOURCE, FLOW_TEMPLATE_NAME, new DefaultTemplateLoader(), new IndexSettings());
     }
 }

--- a/features/flows/elastic/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/features/flows/elastic/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -44,6 +44,7 @@
             <cm:property name="settings.index.number_of_replicas" value="" />
             <cm:property name="settings.index.refresh_interval" value="" />
             <cm:property name="settings.index.routing_partition_size" value="" />
+            <cm:property name="indexPrefix" value="" />
         </cm:default-properties>
     </cm:property-placeholder>
 
@@ -91,6 +92,7 @@
     </bean>
 
     <bean id="indexSettings" class="org.opennms.plugins.elasticsearch.rest.template.IndexSettings">
+        <property name="indexPrefix" value="${indexPrefix}"/>
         <property name="numberOfShards" value="${settings.index.number_of_shards}"/>
         <property name="numberOfReplicas" value="${settings.index.number_of_replicas}"/>
         <property name="refreshInterval" value="${settings.index.refresh_interval}"/>
@@ -141,6 +143,7 @@
         <argument ref="snmpInterfaceDao"/>
         <argument ref="identity"/>
         <argument ref="tracerRegistry"/>
+        <argument ref="indexSettings"/>
         <argument value="${bulkRetryCount}" />
         <argument value="${maxFlowDurationMs}" />
     </bean>

--- a/features/flows/elastic/src/test/java/org/opennms/netmgt/flows/elastic/DefaultDirectionIT.java
+++ b/features/flows/elastic/src/test/java/org/opennms/netmgt/flows/elastic/DefaultDirectionIT.java
@@ -55,6 +55,7 @@ import org.opennms.netmgt.flows.api.FlowRepository;
 import org.opennms.netmgt.flows.classification.ClassificationEngine;
 import org.opennms.plugins.elasticsearch.rest.RestClientFactory;
 import org.opennms.plugins.elasticsearch.rest.index.IndexStrategy;
+import org.opennms.plugins.elasticsearch.rest.template.IndexSettings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -112,7 +113,9 @@ public class DefaultDirectionIT {
 
             final FlowRepository elasticFlowRepository = new InitializingFlowRepository(
                     new ElasticFlowRepository(new MetricRegistry(), jestClient, IndexStrategy.MONTHLY, documentEnricher,
-                            classificationEngine, mockTransactionTemplate, new MockNodeDao(), new MockSnmpInterfaceDao(), new MockIdentity(), new MockTracerRegistry(),3, 12000), jestClient);
+                            classificationEngine, mockTransactionTemplate, new MockNodeDao(), new MockSnmpInterfaceDao(),
+                            new MockIdentity(), new MockTracerRegistry(), new IndexSettings(),
+                            3, 12000), jestClient);
             // persist data
             elasticFlowRepository.persist(Lists.newArrayList(getMockFlowWithoutDirection()),
                     FlowDocumentTest.getMockFlowSource());

--- a/features/flows/elastic/src/test/java/org/opennms/netmgt/flows/elastic/ElasticFlowRepositoryIT.java
+++ b/features/flows/elastic/src/test/java/org/opennms/netmgt/flows/elastic/ElasticFlowRepositoryIT.java
@@ -43,6 +43,7 @@ import org.opennms.netmgt.dao.mock.MockTransactionTemplate;
 import org.opennms.netmgt.flows.api.FlowException;
 import org.opennms.netmgt.flows.classification.ClassificationEngine;
 import org.opennms.plugins.elasticsearch.rest.index.IndexStrategy;
+import org.opennms.plugins.elasticsearch.rest.template.IndexSettings;
 
 import com.codahale.metrics.MetricRegistry;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
@@ -83,7 +84,7 @@ public class ElasticFlowRepositoryIT {
             final ElasticFlowRepository elasticFlowRepository = new ElasticFlowRepository(new MetricRegistry(),
                     client, IndexStrategy.MONTHLY, documentEnricher, classificationEngine,
                     mockTransactionTemplate, new MockNodeDao(), new MockSnmpInterfaceDao(),
-                    new MockIdentity(), new MockTracerRegistry(),
+                    new MockIdentity(), new MockTracerRegistry(), new IndexSettings(),
                     3, 12000);
 
             // It does not matter what we persist here, as the response is fixed.

--- a/features/flows/elastic/src/test/java/org/opennms/netmgt/flows/elastic/ElasticFlowRepositoryRetryIT.java
+++ b/features/flows/elastic/src/test/java/org/opennms/netmgt/flows/elastic/ElasticFlowRepositoryRetryIT.java
@@ -47,6 +47,7 @@ import org.opennms.netmgt.flows.classification.ClassificationEngine;
 import org.opennms.plugins.elasticsearch.rest.RestClientFactory;
 import org.opennms.plugins.elasticsearch.rest.executors.DefaultRequestExecutor;
 import org.opennms.plugins.elasticsearch.rest.index.IndexStrategy;
+import org.opennms.plugins.elasticsearch.rest.template.IndexSettings;
 
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.base.Throwables;
@@ -109,7 +110,7 @@ public class ElasticFlowRepositoryRetryIT {
             final FlowRepository elasticFlowRepository = new InitializingFlowRepository(
                     new ElasticFlowRepository(new MetricRegistry(), client, IndexStrategy.MONTHLY, documentEnricher,
                             classificationEngine, mockTransactionTemplate, new MockNodeDao(), new MockSnmpInterfaceDao(),
-                            new MockIdentity(), new MockTracerRegistry(),3, 12000), client);
+                            new MockIdentity(), new MockTracerRegistry(), new IndexSettings(),3, 12000), client);
 
             consumer.accept(elasticFlowRepository);
 

--- a/features/flows/elastic/src/test/java/org/opennms/netmgt/flows/elastic/FlowQueryIT.java
+++ b/features/flows/elastic/src/test/java/org/opennms/netmgt/flows/elastic/FlowQueryIT.java
@@ -118,7 +118,7 @@ public class FlowQueryIT {
         mockTransactionTemplate.setTransactionManager(new MockTransactionManager());
         flowRepository = new ElasticFlowRepository(metricRegistry, client, IndexStrategy.MONTHLY, documentEnricher,
                 classificationEngine, mockTransactionTemplate, new MockNodeDao(), new MockSnmpInterfaceDao(),
-                new MockIdentity(), new MockTracerRegistry(),3, 12000);
+                new MockIdentity(), new MockTracerRegistry(), new IndexSettings(),3, 12000);
         final IndexSettings settings = new IndexSettings();
         final ElasticFlowRepositoryInitializer initializer = new ElasticFlowRepositoryInitializer(client, settings);
 

--- a/features/flows/elastic/src/test/java/org/opennms/netmgt/flows/elastic/MarkerCacheIT.java
+++ b/features/flows/elastic/src/test/java/org/opennms/netmgt/flows/elastic/MarkerCacheIT.java
@@ -62,6 +62,7 @@ import org.opennms.netmgt.flows.classification.FilterService;
 import org.opennms.netmgt.flows.classification.internal.DefaultClassificationEngine;
 import org.opennms.netmgt.flows.classification.persistence.api.RuleBuilder;
 import org.opennms.plugins.elasticsearch.rest.index.IndexStrategy;
+import org.opennms.plugins.elasticsearch.rest.template.IndexSettings;
 import org.opennms.test.JUnitConfigurationEnvironment;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
@@ -167,7 +168,7 @@ public class MarkerCacheIT {
             final ElasticFlowRepository elasticFlowRepository = new ElasticFlowRepository(new MetricRegistry(),
                     client, IndexStrategy.MONTHLY, documentEnricher, classificationEngine,
                     transactionOperations, nodeDao, snmpInterfaceDao,
-                    new MockIdentity(), new MockTracerRegistry(),
+                    new MockIdentity(), new MockTracerRegistry(), new IndexSettings(),
                     3, 12000);
 
             Assert.assertThat(nodeDao.findAllHavingFlows(), is(empty()));

--- a/features/jest/client/src/main/java/org/opennms/plugins/elasticsearch/rest/index/IndexStrategy.java
+++ b/features/jest/client/src/main/java/org/opennms/plugins/elasticsearch/rest/index/IndexStrategy.java
@@ -62,12 +62,12 @@ public enum IndexStrategy {
                 .withZone(UTC);
     }
 
-    public String getIndex(IndexSettings indexSettings, String indedName, TemporalAccessor temporal) {
+    public String getIndex(IndexSettings indexSettings, String indexName, TemporalAccessor temporal) {
         final StringBuilder sb = new StringBuilder();
         if (!Strings.isNullOrEmpty(indexSettings.getIndexPrefix())) {
             sb.append(indexSettings.getIndexPrefix());
         }
-        sb.append(indedName);
+        sb.append(indexName);
         sb.append("-");
         sb.append(dateFormat.format(temporal));
         return sb.toString();

--- a/features/jest/client/src/main/java/org/opennms/plugins/elasticsearch/rest/index/IndexStrategy.java
+++ b/features/jest/client/src/main/java/org/opennms/plugins/elasticsearch/rest/index/IndexStrategy.java
@@ -33,6 +33,10 @@ import java.time.format.DateTimeFormatter;
 import java.time.temporal.TemporalAccessor;
 import java.util.TimeZone;
 
+import org.opennms.plugins.elasticsearch.rest.template.IndexSettings;
+
+import com.google.common.base.Strings;
+
 /**
  * Defines a strategy on how to define the index when persisting.
  *
@@ -58,8 +62,15 @@ public enum IndexStrategy {
                 .withZone(UTC);
     }
 
-    public String getIndex(String indexPrefix, TemporalAccessor temporal) {
-        return String.format("%s-%s", indexPrefix, dateFormat.format(temporal));
+    public String getIndex(IndexSettings indexSettings, String indedName, TemporalAccessor temporal) {
+        final StringBuilder sb = new StringBuilder();
+        if (!Strings.isNullOrEmpty(indexSettings.getIndexPrefix())) {
+            sb.append(indexSettings.getIndexPrefix());
+        }
+        sb.append(indedName);
+        sb.append("-");
+        sb.append(dateFormat.format(temporal));
+        return sb.toString();
     }
 
     public String getPattern(){

--- a/features/jest/client/src/main/java/org/opennms/plugins/elasticsearch/rest/template/IndexSettings.java
+++ b/features/jest/client/src/main/java/org/opennms/plugins/elasticsearch/rest/template/IndexSettings.java
@@ -31,6 +31,9 @@ package org.opennms.plugins.elasticsearch.rest.template;
 import com.google.common.base.Strings;
 
 public class IndexSettings {
+
+    private String indexPrefix;
+
     private Integer numberOfShards;
 
     private Integer numberOfReplicas;
@@ -38,6 +41,14 @@ public class IndexSettings {
     private Integer routingPartitionSize;
 
     private String refreshInterval;
+
+    public String getIndexPrefix() {
+        return indexPrefix;
+    }
+
+    public void setIndexPrefix(String indexPrefix) {
+        this.indexPrefix = indexPrefix;
+    }
 
     public Integer getNumberOfShards() {
         return numberOfShards;
@@ -91,7 +102,10 @@ public class IndexSettings {
     }
 
     public boolean isEmpty() {
-        boolean empty = numberOfShards == null && numberOfReplicas == null && routingPartitionSize == null && refreshInterval == null;
-        return empty;
+        return indexPrefix == null
+                && numberOfShards == null
+                && numberOfReplicas == null
+                && routingPartitionSize == null
+                && refreshInterval == null;
     }
 }

--- a/features/jest/client/src/main/java/org/opennms/plugins/elasticsearch/rest/template/TemplateMerger.java
+++ b/features/jest/client/src/main/java/org/opennms/plugins/elasticsearch/rest/template/TemplateMerger.java
@@ -28,10 +28,12 @@
 
 package org.opennms.plugins.elasticsearch.rest.template;
 
+import com.google.common.base.Strings;
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import com.google.gson.JsonPrimitive;
 
 /**
  * Merges an existing elastic template with provided (optional) settings.
@@ -53,6 +55,16 @@ public class TemplateMerger {
     public JsonObject merge(final JsonObject template, final IndexSettings indexSettings) {
         if (indexSettings != null && !indexSettings.isEmpty()) {
             addMissingProperties(template);
+
+            // Prepend the index prefix to the template pattern
+            if (!Strings.isNullOrEmpty(indexSettings.getIndexPrefix())) {
+                final JsonPrimitive templateName = template.getAsJsonPrimitive("template");
+                if (templateName == null) {
+                    template.addProperty("template", indexSettings.getIndexPrefix());
+                } else {
+                    template.addProperty("template", indexSettings.getIndexPrefix() + templateName.getAsString());
+                }
+            }
 
             final JsonObject indexObject = template.get(SETTINGS_KEY).getAsJsonObject().get(INDEX_KEY).getAsJsonObject();
             if (indexSettings.getNumberOfShards() != null) {

--- a/features/jest/client/src/test/java/org/opennms/plugins/elasticsearch/rest/executors/DefaultRequestExecutorIT.java
+++ b/features/jest/client/src/test/java/org/opennms/plugins/elasticsearch/rest/executors/DefaultRequestExecutorIT.java
@@ -48,6 +48,7 @@ import org.junit.rules.Timeout;
 import org.mockito.Mockito;
 import org.opennms.plugins.elasticsearch.rest.OnmsJestClient;
 import org.opennms.plugins.elasticsearch.rest.index.IndexStrategy;
+import org.opennms.plugins.elasticsearch.rest.template.IndexSettings;
 
 import com.google.common.base.Throwables;
 
@@ -80,7 +81,7 @@ public class DefaultRequestExecutorIT {
                     final Map<String, String> object = new HashMap<>();
                     object.put("name", "Ulf");
                     object.put("location", "Pittsboro");
-                    final Index action = new Index.Builder(object).index(IndexStrategy.MONTHLY.getIndex("dummy", Instant.now())).type("persons").build();
+                    final Index action = new Index.Builder(object).index(IndexStrategy.MONTHLY.getIndex(new IndexSettings(), "dummy", Instant.now())).type("persons").build();
                     client.execute(action);
                     Assert.fail("The execution of persistNetFlow5Packets() should not have finished. Failing.");
                 } finally {

--- a/features/jest/client/src/test/java/org/opennms/plugins/elasticsearch/rest/index/IndexSelectorTest.java
+++ b/features/jest/client/src/test/java/org/opennms/plugins/elasticsearch/rest/index/IndexSelectorTest.java
@@ -39,6 +39,7 @@ import java.util.List;
 import java.util.TimeZone;
 
 import org.junit.Test;
+import org.opennms.plugins.elasticsearch.rest.template.IndexSettings;
 
 public class IndexSelectorTest {
 
@@ -317,7 +318,7 @@ public class IndexSelectorTest {
             List<String> expectedList = Arrays.asList(expected);
             long expandTimeRangeInMs = 2 * 60 * 1000; // 2 min
             assertEquals(String.format("Test failed for strategy %s from %s to %s", this.strategy.name(), this.from, this.to)
-                         , expectedList, new IndexSelector("prefix", strategy, expandTimeRangeInMs).getIndexNames(start.getTime(), end.getTime()));
+                         , expectedList, new IndexSelector(new IndexSettings(), "prefix", strategy, expandTimeRangeInMs).getIndexNames(start.getTime(), end.getTime()));
         }
     }
 }

--- a/features/jest/client/src/test/java/org/opennms/plugins/elasticsearch/rest/index/IndexStrategyTest.java
+++ b/features/jest/client/src/test/java/org/opennms/plugins/elasticsearch/rest/index/IndexStrategyTest.java
@@ -35,8 +35,11 @@ import java.util.Calendar;
 import java.util.TimeZone;
 
 import org.junit.Test;
+import org.opennms.plugins.elasticsearch.rest.template.IndexSettings;
 
 public class IndexStrategyTest {
+
+    IndexSettings indexSettings = new IndexSettings();
 
     @Test
     public void verifyGetIndex() {
@@ -59,7 +62,7 @@ public class IndexStrategyTest {
         // Verify each strategy
         final IndexStrategy[] strategies = IndexStrategy.values();
         for (int i=0; i<expectedValues.length; i++) {
-            final String actualValue = strategies[i].getIndex("opennms", cal.toInstant());
+            final String actualValue = strategies[i].getIndex(indexSettings,"opennms", cal.toInstant());
             final String expectedValue = "opennms-" + expectedValues[i];
             assertEquals(expectedValue, actualValue);
         }
@@ -74,7 +77,7 @@ public class IndexStrategyTest {
         // Set date to "Wednesday, March 28, 2018 2:55:05 AM UTC"
         // This is "Tuesday March 27, 2018 21:55:05 EST"
         final Instant instant = Instant.ofEpochMilli(1522205705000L);
-        assertEquals("opennms-2018-03-28", IndexStrategy.DAILY.getIndex("opennms", instant));
-        assertEquals("opennms-2018-03-28-02", IndexStrategy.HOURLY.getIndex("opennms", instant));
+        assertEquals("opennms-2018-03-28", IndexStrategy.DAILY.getIndex(indexSettings,"opennms", instant));
+        assertEquals("opennms-2018-03-28-02", IndexStrategy.HOURLY.getIndex(indexSettings,"opennms", instant));
     }
 }

--- a/features/jest/client/src/test/java/org/opennms/plugins/elasticsearch/rest/template/IndexSettingsTest.java
+++ b/features/jest/client/src/test/java/org/opennms/plugins/elasticsearch/rest/template/IndexSettingsTest.java
@@ -26,13 +26,12 @@
  *     http://www.opennms.com/
  *******************************************************************************/
 
-package org.opennms.netmgt.flows.elastic.template;
+package org.opennms.plugins.elasticsearch.rest.template;
 
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertThat;
 
 import org.junit.Test;
-import org.opennms.plugins.elasticsearch.rest.template.IndexSettings;
 
 public class IndexSettingsTest {
 

--- a/features/jest/client/src/test/java/org/opennms/plugins/elasticsearch/rest/template/TemplateMergerTest.java
+++ b/features/jest/client/src/test/java/org/opennms/plugins/elasticsearch/rest/template/TemplateMergerTest.java
@@ -26,13 +26,11 @@
  *     http://www.opennms.com/
  *******************************************************************************/
 
-package org.opennms.netmgt.flows.elastic.template;
+package org.opennms.plugins.elasticsearch.rest.template;
 
 import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
-import org.opennms.plugins.elasticsearch.rest.template.IndexSettings;
-import org.opennms.plugins.elasticsearch.rest.template.TemplateMerger;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
@@ -62,11 +60,13 @@ public class TemplateMergerTest {
             "      refresh_interval: 10s," +
             "      routing_partition_size: 20" +
             "    }" +
-            "  }" +
+            "  }," +
+            "  template: prefix" +
             "}";
 
         // Configure settings
         final IndexSettings settings = new IndexSettings();
+        settings.setIndexPrefix("prefix");
         settings.setNumberOfShards(5);
         settings.setNumberOfReplicas(10);
         settings.setRefreshInterval("10s");
@@ -76,5 +76,18 @@ public class TemplateMergerTest {
         final JsonElement expectedJsonObject = new JsonParser().parse(expectedJson);
         assertEquals(new Gson().toJson(expectedJsonObject), new TemplateMerger().merge("{}", settings));
         assertEquals(new JsonParser().parse(expectedJson), new TemplateMerger().merge(new JsonObject(), settings));
+    }
+
+    @Test
+    public void verifyIndexPrefixHandling() {
+        final String expectedJson = "{\"template\":\"prefix-test\",\"settings\":{\"index\":{}}}";
+
+        // Configure settings
+        final IndexSettings settings = new IndexSettings();
+        settings.setIndexPrefix("prefix-");
+
+        // Verify
+        final JsonElement expectedJsonObject = new JsonParser().parse(expectedJson);
+        assertEquals(new Gson().toJson(expectedJsonObject), new TemplateMerger().merge("{\"template\": \"test\"}", settings));
     }
 }

--- a/features/opennms-es-rest/src/main/java/org/opennms/plugins/elasticsearch/rest/EventToIndex.java
+++ b/features/opennms-es-rest/src/main/java/org/opennms/plugins/elasticsearch/rest/EventToIndex.java
@@ -59,6 +59,7 @@ import org.opennms.plugins.elasticsearch.rest.bulk.BulkException;
 import org.opennms.plugins.elasticsearch.rest.bulk.BulkRequest;
 import org.opennms.plugins.elasticsearch.rest.bulk.BulkWrapper;
 import org.opennms.plugins.elasticsearch.rest.index.IndexStrategy;
+import org.opennms.plugins.elasticsearch.rest.template.IndexSettings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -97,6 +98,8 @@ public class EventToIndex implements AutoCloseable {
 	private int threads = DEFAULT_NUMBER_OF_THREADS;
 
 	private IndexStrategy indexStrategy = IndexStrategy.MONTHLY;
+
+	private IndexSettings indexSettings = new IndexSettings();
 
 	private final ThreadPoolExecutor executor = new ThreadPoolExecutor(
 			threads,
@@ -293,7 +296,7 @@ public class EventToIndex implements AutoCloseable {
 			}
 		}
 
-		String completeIndexName = indexStrategy.getIndex(INDEX_PREFIX, cal.toInstant());
+		String completeIndexName = indexStrategy.getIndex(indexSettings, INDEX_PREFIX, cal.toInstant());
 
 		if (LOG.isDebugEnabled()){
 			String str = "populateEventIndexBodyFromEvent - index:"
@@ -380,6 +383,14 @@ public class EventToIndex implements AutoCloseable {
 				nodeCache.refreshEntry(event.getNodeid());
 			}
 		}
+	}
+
+	public IndexSettings getIndexSettings() {
+		return indexSettings;
+	}
+
+	public void setIndexSettings(IndexSettings indexSettings) {
+		this.indexSettings = Objects.requireNonNull(indexSettings);
 	}
 
 	private static final void logEsError(String operation, String index, String type, String result, int responseCode, String errorMessage) {

--- a/features/opennms-es-rest/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/features/opennms-es-rest/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -50,6 +50,7 @@
       <cm:property name="settings.index.number_of_replicas" value="" />
       <cm:property name="settings.index.refresh_interval" value="" />
       <cm:property name="settings.index.routing_partition_size" value="" />
+      <cm:property name="indexPrefix" value="" />
     </cm:default-properties>
   </cm:property-placeholder>
 
@@ -109,6 +110,7 @@
   <bean id="restClient" factory-ref="restClientFactory" factory-method="createClient" destroy-method="shutdownClient"/>
 
   <bean id="indexSettings" class="org.opennms.plugins.elasticsearch.rest.template.IndexSettings">
+    <property name="indexPrefix" value="${indexPrefix}"/>
     <property name="numberOfShards" value="${settings.index.number_of_shards}"/>
     <property name="numberOfReplicas" value="${settings.index.number_of_replicas}"/>
     <property name="refreshInterval" value="${settings.index.refresh_interval}"/>
@@ -128,6 +130,7 @@
     <property name="logAllEvents" value="${logAllEvents}" />
     <property name="threads" value="${threads}" />
     <property name="groupOidParameters" value="${groupOidParameters}" />
+    <property name="indexSettings" ref="indexSettings" />
   </bean>
 
   <bean id="elasticSearchInitializer" class="org.opennms.plugins.elasticsearch.rest.template.DefaultTemplateInitializer">

--- a/features/situation-feedback/elastic/src/main/java/org/opennms/features/situationfeedback/elastic/ElasticFeedbackRepository.java
+++ b/features/situation-feedback/elastic/src/main/java/org/opennms/features/situationfeedback/elastic/ElasticFeedbackRepository.java
@@ -43,6 +43,7 @@ import org.opennms.features.situationfeedback.api.FeedbackRepository;
 import org.opennms.plugins.elasticsearch.rest.bulk.BulkRequest;
 import org.opennms.plugins.elasticsearch.rest.bulk.BulkWrapper;
 import org.opennms.plugins.elasticsearch.rest.index.IndexStrategy;
+import org.opennms.plugins.elasticsearch.rest.template.IndexSettings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -71,6 +72,8 @@ public class ElasticFeedbackRepository implements FeedbackRepository {
 
     private final int bulkRetryCount;
 
+    private final IndexSettings indexSettings;
+
     private IndexStrategy indexStrategy;
 
     /**
@@ -83,6 +86,7 @@ public class ElasticFeedbackRepository implements FeedbackRepository {
         this.indexStrategy = indexStrategy;
         this.bulkRetryCount = bulkRetryCount;
         this.initializer = initializer;
+        this.indexSettings = initializer.getIndexSettings();
     }
 
     @Override
@@ -98,7 +102,7 @@ public class ElasticFeedbackRepository implements FeedbackRepository {
         BulkRequest<FeedbackDocument> bulkRequest = new BulkRequest<>(client, feedbackDocuments, (documents) -> {
             final Bulk.Builder bulkBuilder = new Bulk.Builder();
             for (FeedbackDocument document : documents) {
-                final String index = indexStrategy.getIndex(TYPE, Instant.ofEpochMilli(document.getTimestamp()));
+                final String index = indexStrategy.getIndex(indexSettings, TYPE, Instant.ofEpochMilli(document.getTimestamp()));
                 final Index.Builder indexBuilder = new Index.Builder(document).index(index).type(TYPE);
                 bulkBuilder.addAction(indexBuilder.build());
             }

--- a/features/situation-feedback/elastic/src/main/java/org/opennms/features/situationfeedback/elastic/ElasticFeedbackRepositoryInitializer.java
+++ b/features/situation-feedback/elastic/src/main/java/org/opennms/features/situationfeedback/elastic/ElasticFeedbackRepositoryInitializer.java
@@ -46,11 +46,13 @@ public class ElasticFeedbackRepositoryInitializer extends DefaultTemplateInitial
     }
 
     protected ElasticFeedbackRepositoryInitializer(JestClient client, IndexSettings indexSettings) {
-        super(client, TEMPLATE_RESOURCE, FEEDBACK_TEMPLATE_NAME, new MergingTemplateLoader(new DefaultTemplateLoader(), indexSettings));
+        super(client, TEMPLATE_RESOURCE, FEEDBACK_TEMPLATE_NAME, new MergingTemplateLoader(new DefaultTemplateLoader(), indexSettings), indexSettings);
     }
 
     protected ElasticFeedbackRepositoryInitializer(JestClient client) {
-        super(client, TEMPLATE_RESOURCE, FEEDBACK_TEMPLATE_NAME, new DefaultTemplateLoader());
+        super(client, TEMPLATE_RESOURCE, FEEDBACK_TEMPLATE_NAME, new DefaultTemplateLoader(), new IndexSettings());
     }
+
+
 
 }

--- a/features/situation-feedback/elastic/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/features/situation-feedback/elastic/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -38,6 +38,7 @@
             <cm:property name="settings.index.number_of_replicas" value="" />
             <cm:property name="settings.index.refresh_interval" value="" />
             <cm:property name="settings.index.routing_partition_size" value="" />
+            <cm:property name="indexPrefix" value="" />
         </cm:default-properties>
     </cm:property-placeholder>
 
@@ -74,6 +75,7 @@
     </bean>
 
     <bean id="indexSettings" class="org.opennms.plugins.elasticsearch.rest.template.IndexSettings">
+        <property name="indexPrefix" value="${indexPrefix}"/>
         <property name="numberOfShards" value="${settings.index.number_of_shards}"/>
         <property name="numberOfReplicas" value="${settings.index.number_of_replicas}"/>
         <property name="refreshInterval" value="${settings.index.refresh_interval}"/>

--- a/opennms-doc/guide-admin/src/asciidoc/text/elasticsearch/introduction.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/elasticsearch/introduction.adoc
@@ -11,7 +11,8 @@ Internally all _Elasticsearch_ integrations use the https://github.com/searchbox
 [[ga-elasticsearch-integration-configuration]]
 === Configuration
 
-The configuration is feature dependant and therefore must take place in the feature configuration file in `${OPENNMS_HOME}/etc/org.opennms.features.flows.persistence.elastic.cfg`.
+The location of the configuration file depends on the feature.
+For flows, it can be found in `${OPENNMS_HOME}/etc/org.opennms.features.flows.persistence.elastic.cfg`.
 
 The following properties can be set:
 
@@ -112,6 +113,11 @@ When bulk operations fail, only the failed items are retried.
 
 | _settings.index.routing_partition_size_
 | The number of shards a custom routing valuce can go to. Refer to link:https://www.elastic.co/guide/en/elasticsearch/reference/current/index-modules.html#index-modules-setting[Elasticsearch Reference -> Index Modules] for more details.
+| optional
+| -
+
+| _indexPrefix_
+| Prefix is prepended to the index and template names. Can be used in cases where you want to share the same Elasticsearch cluster with many _{opennms-product-name}_ instances.
 | optional
 | -
 |===


### PR DESCRIPTION
JIRA: https://issues.opennms.org/browse/NMS-12082

Here we update the features that use Elastiscearch to support a new `indexPrefix` property that can be used to prepend arbitrary stings to the currently fixed index names. Using prefixes it now becomes possible for multiple OpenNMS instances to share the same ES cluster and write to different indices.
