### PR TITLE
NMS-12187: Allow arbitrary branches to be pushed to DockerHub

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -199,13 +199,13 @@ workflows:
   build-deploy:
     jobs:
       - build
-      - package-build-horizon:
+      - horizon-package-build:
           requires:
             - build
-      - package-build-minion:
+      - minion-package-build:
           requires:
             - build
-      - package-build-sentinel:
+      - sentinel-package-build:
           requires:
             - build
       - integration-test:
@@ -213,9 +213,9 @@ workflows:
             - build
       - smoke-test-full:
           requires:
-            - package-build-horizon
-            - package-build-minion
-            - package-build-sentinel
+            - horizon-package-build
+            - minion-package-build
+            - sentinel-package-build
           filters:
             branches:
               only:
@@ -227,9 +227,9 @@ workflows:
                 - /.*smoke.*/
       - smoke-test-minimal:
           requires:
-            - package-build-horizon
-            - package-build-minion
-            - package-build-sentinel
+            - horizon-package-build
+            - minion-package-build
+            - sentinel-package-build
           filters:
             branches:
               ignore:
@@ -239,25 +239,25 @@ workflows:
                 - /^foundation.*/
                 - /^features.*/
                 - /.*smoke.*/
-      - publish-horizon-oci:
+      - horizon-publish-oci:
           requires:
-            - package-build-horizon
+            - horizon-package-build
           filters:
             branches:
               only:
                 - master
                 - develop
-      - publish-minion-oci:
+      - minion-publish-oci:
           requires:
-            - package-build-minion
+            - minion-package-build
           filters:
             branches:
               only:
                 - master
                 - develop
-      - publish-sentinel-oci:
+      - sentinel-publish-oci:
           requires:
-            - package-build-sentinel
+            - sentinel-package-build
           filters:
             branches:
               only:
@@ -273,7 +273,7 @@ jobs:
     steps:
       - run-build:
           number-vcpu: 8
-  package-build-horizon:
+  horizon-package-build:
     executor: build-executor
     # Larger memory footprint required to speed up builds using Takari smartbuilder
     resource_class: large
@@ -303,10 +303,10 @@ jobs:
           root: ~/
           paths:
             - project/opennms-container/horizon/images/
-  package-build-minion:
+  minion-package-build:
     executor: build-executor
     # Larger memory footprint required to speed up builds using Takari smartbuilder
-    # Will need to increase resource class if package-build-horizon is under 15 min
+    # Will need to increase resource class if horizon-package-build is under 15 min
     resource_class: medium+
     steps:
       - attach_workspace:
@@ -335,10 +335,10 @@ jobs:
           root: ~/
           paths:
             - project/opennms-container/minion/images/
-  package-build-sentinel:
+  sentinel-package-build:
     executor: build-executor
     # Larger memory footprint required to speed up builds using Takari smartbuilder
-    # Will need to increase resource class if package-build-horizon is under 19 min
+    # Will need to increase resource class if horizon-package-build is under 19 min
     resource_class: medium+
     steps:
       - attach_workspace:
@@ -367,7 +367,7 @@ jobs:
           root: ~/
           paths:
             - project/opennms-container/sentinel/images/
-  publish-horizon-oci:
+  horizon-publish-oci:
     executor: build-executor
     steps:
       - attach_workspace:
@@ -382,7 +382,7 @@ jobs:
             docker image load -i images/container.oci
             ./tag.sh
             ./publish.sh
-  publish-minion-oci:
+  minion-publish-oci:
     executor: build-executor
     steps:
       - attach_workspace:
@@ -397,7 +397,7 @@ jobs:
             docker image load -i images/container.oci
             ./tag.sh
             ./publish.sh
-  publish-sentinel-oci:
+  sentinel-publish-oci:
     executor: build-executor
     steps:
       - attach_workspace:

--- a/opennms-container/version-tags.sh
+++ b/opennms-container/version-tags.sh
@@ -1,13 +1,19 @@
 #!/usr/bin/env bash
 
+# Use version number from pom except from develop and features branches
+case "${CIRCLE_BRANCH}" in
+  master)
+    VERSION="$(../pom2version.py ../../pom.xml)"
+    ;;
+  develop)
+    VERSION="bleeding"
+    ;;
+  *)
+    # Replace / in branch names which is not allowed in OCI tags
+    VERSION="${CIRCLE_BRANCH//\//-}"
+    ;;
+esac
+
 # shellcheck disable=SC2034
-
-# Use version number from pom except from develop
-if [[ "${CIRCLE_BRANCH}" == "develop" ]]; then
-  VERSION="bleeding"
-else
-  VERSION="$(../pom2version.py ../../pom.xml)"
-fi
-
 # Array of tags for the OCI image used in the specific projects
 OCI_TAGS=("${VERSION}")


### PR DESCRIPTION
Add possibility to use an arbitrary branch name as OCI tag so it can be pushed to a Docker registry like DockerHub. The behavior can be controlled using the branch filter directive for the publish OCI jobs in CircleCI's config.yml. The behavior for tagging is implemented as the following for the branches:

* master: Uses the version number as a tag from the root pom.xml
* develop: tagged as "bleeding" and overwrites previous ones
* otherwise: Use the branch name as tag and replace `/` with `-` in the name

### Reviewer hint:

There is a separate commit which renames our build jobs to be easier identified in the CircleCI build workflow view. The jobs are renamed like `package-build-<name>` to `<name>-package-build` and `publish-oci-<name>` to `<name>-publish-oci`.

<img width="721" alt="Screenshot 2019-07-30 at 07 23 28" src="https://user-images.githubusercontent.com/1095181/62102920-01b7ab80-b29b-11e9-8e9c-782cf1c9979d.png">

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-12187
