### PR TITLE
NMS-12189: Use cron expression from cron trigger instead of persisting it

### DIFF
--- a/opennms-web-api/src/main/java/org/opennms/web/svclayer/support/DefaultSchedulerService.java
+++ b/opennms-web-api/src/main/java/org/opennms/web/svclayer/support/DefaultSchedulerService.java
@@ -113,9 +113,10 @@ public class DefaultSchedulerService implements InitializingBean, SchedulerServi
                 description.setReportId((String)trigger.getJobDataMap().get("reportId"));
                 description.setDeliveryOptions((DeliveryOptions) trigger.getJobDataMap().get("deliveryOptions"));
                 description.setReportParameters(((ReportParameters) trigger.getJobDataMap().get("criteria")).getReportParms());
-                description.setCronExpression((String) trigger.getJobDataMap().get("cronExpression"));
+                if (trigger instanceof CronTriggerImpl) {
+                    description.setCronExpression(((CronTriggerImpl)trigger).getCronExpression());
+                }
                 triggerDescriptions.add(description);
-
             }
         } catch (SchedulerException e) {
             LOG.error("exception lretrieving trigger descriptions", e);
@@ -208,7 +209,6 @@ public class DefaultSchedulerService implements InitializingBean, SchedulerServi
                 cronTrigger.getJobDataMap().put("reportId", id);
                 cronTrigger.getJobDataMap().put("mode", ReportMode.SCHEDULED);
                 cronTrigger.getJobDataMap().put("deliveryOptions", deliveryOptions);
-                cronTrigger.getJobDataMap().put("cronExpression", cronExpression);
                 try {
                     m_scheduler.scheduleJob(cronTrigger);
                 } catch (SchedulerException e) {

--- a/smoke-test/src/test/java/org/opennms/smoketest/DatabaseReportPageIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/DatabaseReportPageIT.java
@@ -120,6 +120,7 @@ public class DatabaseReportPageIT extends UiPageTest {
                 .filter((input) -> input.templateName.equals(EarlyMorningReport.id) && input.cronExpression.equals(cronExpression))
                 .findAny();
         assertThat(any.isPresent(), is(true));
+        assertThat(any.get().cronExpression, is(cronExpression));
     }
 
     private void closeDialogue() {


### PR DESCRIPTION
* JIRA: https://issues.opennms.org/browse/NMS-12189

Here we fix an issue that the cron expression is only shown if the report was scheduled with the new UI. As reports may already have been scheduled, the cron expression should also be visible for those.