### PR TITLE
NMS-12183: check for `javac` rather than tools.jar to detect JDK

### DIFF
--- a/debian/opennms-server.opennms.init
+++ b/debian/opennms-server.opennms.init
@@ -39,7 +39,7 @@ fi
 # Check for JAVA_HOME
 if [ -z "$JAVA_HOME" ]; then
 	for dir in `find /usr/lib/jvm/* -maxdepth 0 -type d | grep -E "java-(8|11)" | sort -u -r`; do
-		if [ -d "$dir" -a -f "$dir/lib/tools.jar" ]; then
+		if [ -d "$dir" -a -x "$dir/bin/javac" ]; then
 			JAVA_HOME="$dir"
 			break
 		fi

--- a/tools/infrastructure/java_lint.sh
+++ b/tools/infrastructure/java_lint.sh
@@ -59,7 +59,7 @@ java_lint () {
 		fi
 	fi
  
-	if [ -f "$JAVA_HOME/lib/tools.jar" ] || [ "`uname`" = "Darwin" ]; then
+	if [ -x "$JAVA_HOME/bin/javac" ] || [ "`uname`" = "Darwin" ]; then
 		if [ -z "$CLASSPATH" ] ; then
 			CLASSPATH="$JAVA_HOME/lib/tools.jar" export CLASSPATH
 		else


### PR DESCRIPTION
### All Contributors

* [x] Have you read and followed our [Contribution Guidelines](https://github.com/OpenNMS/opennms/blob/develop/CONTRIBUTING.md)?
* [x] Have you [made an issue in the OpenNMS issue tracker](https://issues.opennms.org)?<br>If so, you should:
  1. update the title of this PR to be of the format: `${JIRA-ISSUE-NUMBER}: subject of pull request`
  2. update the JIRA link at the bottom of this comment to refer to the real issue number
  3. prefix your commit messages with the issue number, if possible
* [x] Have you made a comment in that issue which points back to this PR?
* [x] Have you updated the JIRA link at the bottom of this comment to link to your issue?
* [ ] If this is a new or updated feature, is there documentation for the new behavior?
* [ ] If this is new code, are there unit and/or integration tests?
* [ ] If this PR targets a `foundation-*` branch, does it avoid changing files in `$OPENNMS_HOME/etc/`?

### Pull Request Process

One or more reviewers should be assigned to each PR.

If you know that a particular person is subject matter expert in the area your PR affects, feel free to assign one or more reviewers when you create this PR, otherwise reviewers will be assigned for you.

Once the reviewer(s) accept the PR and the branch passes continuous integration in Bamboo, the PR is eligible for merge.

At that time, if you have commit access (are an OpenNMS Group employee or a member of the Order of the Green Polo) you are welcome to merge the PR.
Otherwise, a reviewer can merge it for you.

Thanks for taking time to contribute!

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-12183
* Bamboo (Continuous Integration): https://bamboo.opennms.org/

