### PR TITLE
NMS-11748: Add JAXB imports to requisition-dns pom.xml

### DIFF
--- a/opennms-provision/opennms-requisition-dns/pom.xml
+++ b/opennms-provision/opennms-requisition-dns/pom.xml
@@ -20,6 +20,13 @@
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <Bundle-SymbolicName>${project.groupId}.${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
+            <!-- Don't export any packages, expose services only. -->
+            <Export-Package></Export-Package>
+            <Import-Package>
+              org.eclipse.persistence.internal.jaxb;resolution:=optional,
+              org.eclipse.persistence.internal.jaxb.many;resolution:=optional,
+              *
+            </Import-Package>
           </instructions>
         </configuration>
       </plugin>


### PR DESCRIPTION
This fixes https://issues.opennms.org/browse/NMS-11748:

When in Karaf, issuing provision:show-import with type=dns
and a location specified, the command fails on missing libs.

