### PR TITLE
Small enhancements for the smoke test api

### DIFF
--- a/smoke-test/src/main/java/org/opennms/smoketest/selenium/AbstractOpenNMSSeleniumHelper.java
+++ b/smoke-test/src/main/java/org/opennms/smoketest/selenium/AbstractOpenNMSSeleniumHelper.java
@@ -206,6 +206,11 @@ public abstract class AbstractOpenNMSSeleniumHelper {
         @Override
         protected void finished(final Description description) {
             cleanUp();
+
+            // Ensure we close the driver, otherwise the browser is still open
+            // which might cause the container to run out of memory when running either
+            // in debug mode or a parameterized test
+            getDriver().quit();
         }
 
         protected void cleanUp() {

--- a/smoke-test/src/main/java/org/opennms/smoketest/selenium/AbstractOpenNMSSeleniumHelper.java
+++ b/smoke-test/src/main/java/org/opennms/smoketest/selenium/AbstractOpenNMSSeleniumHelper.java
@@ -124,7 +124,7 @@ public abstract class AbstractOpenNMSSeleniumHelper {
     public static final String USER_NAME          = "SmokeTestUser";
     public static final String GROUP_NAME         = "SmokeTestGroup";
 
-    public static final File DOWNLOADS_FOLDER = new File("target/downloads");
+    public static final File DOWNLOADS_FOLDER = new File(System.getProperty("org.opennms.smoketest.downloads-folder", "target/downloads"));
 
     public WebDriverWait wait = null;
     public WebDriverWait requisitionWait = null;


### PR DESCRIPTION
I ran into two issues while using the new smoke/system test api:

 1. When running a test locally in Debug Mode, the Container running the WebDriver and Firefox with that may run out of memory as it does not close the firefox application properly. This may not be a problem all the time, but will blow up if you debug locally (which you can prevent by just closing the firefox application manually after each test). However the problem may cause issues with the container when running a parameterised test. With this change after each test the firefox application is closed properly, freeing the occupied memory with it.

2. When running a test in debug mode locally, the downloads folder is not `./target/downloads` but `./smoke-test/target/downloads`. I added a system property to override it, if necessary to help debug tests requiring that property, e.g. the `DatabaseReportIT`.