### PR TITLE
NMS-12191: Upgrade Drools from 7.7.0.Final to 7.24.0.Final

### DIFF
--- a/container/features/src/main/resources/features.xml
+++ b/container/features/src/main/resources/features.xml
@@ -938,7 +938,7 @@
         <feature version="${kafkaVersion}">kafka-streams</feature>
         <feature>opennms-collection-api</feature>
         <feature>opennms-situation-feedback-api</feature>
-        <bundle>mvn:com.google.protobuf/protobuf-java/${protobuf3Version}</bundle>
+        <bundle>mvn:com.google.protobuf/protobuf-java/${protobufVersion}</bundle>
         <bundle>mvn:org.opennms.core.ipc.common/org.opennms.core.ipc.common.kafka/${project.version}</bundle>
         <bundle>mvn:org.opennms.features.kafka/org.opennms.features.kafka.producer/${project.version}</bundle>
     </feature>
@@ -977,12 +977,12 @@
     </feature>
     <feature name="opennms-telemetry-jti" version="${project.version}" description="OpenNMS :: Telemetry :: JTI">
         <feature>opennms-telemetry-collection</feature>
-        <bundle>mvn:com.google.protobuf/protobuf-java/${protobufVersion}</bundle>
+        <bundle>mvn:com.google.protobuf/protobuf-java/${protobuf2Version}</bundle>
         <bundle>mvn:org.opennms.features.telemetry.protocols.jti/org.opennms.features.telemetry.protocols.jti.adapter/${project.version}</bundle>
     </feature>
     <feature name="opennms-telemetry-nxos" version="${project.version}" description="OpenNMS :: Telemetry :: NX-OS">
         <feature>opennms-telemetry-collection</feature>
-        <bundle>mvn:com.google.protobuf/protobuf-java/3.4.0</bundle>
+	<bundle>mvn:com.google.protobuf/protobuf-java/${protobufVersion}</bundle>
         <bundle>mvn:org.opennms.features.telemetry.protocols.nxos/org.opennms.features.telemetry.protocols.nxos.adapter/${project.version}</bundle>
     </feature>
     <feature name="opennms-bundle-refresher" description="OpenNMS :: Vaadin-Theme Bundle Refresher">

--- a/dependencies/drools/pom.xml
+++ b/dependencies/drools/pom.xml
@@ -15,7 +15,7 @@
     can depend on to use the drools library.
   </description>
   <properties>
-    <droolsVersion>7.7.0.Final</droolsVersion>
+    <droolsVersion>7.24.0.Final</droolsVersion>
   </properties>
   <dependencies>
     <dependency>

--- a/features/collection/persistence-tcp/pom.xml
+++ b/features/collection/persistence-tcp/pom.xml
@@ -50,6 +50,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-library</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-all</artifactId>
       <scope>test</scope>

--- a/features/kafka/producer/pom.xml
+++ b/features/kafka/producer/pom.xml
@@ -100,7 +100,6 @@
     <dependency>
       <groupId> com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
-      <version>${protobuf3Version}</version>
     </dependency>
     <dependency>
       <groupId>org.opennms</groupId>

--- a/features/telemetry/protocols/jti/adapter/pom.xml
+++ b/features/telemetry/protocols/jti/adapter/pom.xml
@@ -35,6 +35,7 @@
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
+      <version>${protobuf2Version}</version>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/features/telemetry/protocols/nxos/adapter/pom.xml
+++ b/features/telemetry/protocols/nxos/adapter/pom.xml
@@ -35,7 +35,6 @@
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
-      <version>3.4.0</version><!--$NO-MVN-MAN-VER$-->
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/opennms-alarms/drools-northbounder/src/test/java/org/opennms/netmgt/alarmd/northbounder/drools/DroolsNorthbounderIT.java
+++ b/opennms-alarms/drools-northbounder/src/test/java/org/opennms/netmgt/alarmd/northbounder/drools/DroolsNorthbounderIT.java
@@ -84,7 +84,7 @@ public class DroolsNorthbounderIT {
      */
     @After
     public void shutdown() throws Exception {
-        MockLogAppender.assertNoWarningsOrGreater();
+        MockLogAppender.assertNoErrorOrGreater();
     }
 
     /**

--- a/opennms-base-assembly/src/main/filtered/etc/examples/drools-engine.d/nodeParentRules/NodeParentRules.drl
+++ b/opennms-base-assembly/src/main/filtered/etc/examples/drools-engine.d/nodeParentRules/NodeParentRules.drl
@@ -35,7 +35,7 @@ rule "possibleCauses"
 	then
 		Long $parentNode = nodeService.getParentNode( $cause );
 		if ( $parentNode != null ) {
-			Cause $parent = possibleCause( engine, $parentNode, $e, POLL_INTERVAL );
+			Cause $parent = createPossibleCause( engine, $parentNode, $e, POLL_INTERVAL );
 			$parent.addImpacted( $c );
 			println( "No Cause for parent. Asserting: " + $parent );
 			insert( $parent );
@@ -66,17 +66,9 @@ rule "resolveIssue"
 		retract( $up );
 end
 
-function Cause possibleCause( DroolsCorrelationEngine engine, Long nodeId, Event symptom, Long POLL_INTERVAL ) {
+function Cause createPossibleCause( DroolsCorrelationEngine engine, Long nodeId, Event symptom, Long POLL_INTERVAL ) {
 	return new Cause( Type.POSSIBLE, nodeId, symptom, engine.setTimer( POLL_INTERVAL ) );
 }
-
-//function void foundRootCause( DroolsCorrelationEngine engine, PossibleCause cause ) {
-//	EventBuilder bldr = new EventBuilder( "rootCauseEvent", "Drools" );
-//	bldr.setNodeid((int)cause.getSymptom().getNodeid());
-//	bldr.addParam("rootCause", cause.getCause().intValue());
-//	
-//	engine.sendEvent(bldr.getEvent());
-//}
 
 function void println(Object msg) {
 	System.out.println(new Date() + " : " + msg);

--- a/opennms-correlation/drools-correlation-engine/src/test/opennms-home/etc/drools-engine.d/nodeParentRules/NodeParentRules.drl
+++ b/opennms-correlation/drools-correlation-engine/src/test/opennms-home/etc/drools-engine.d/nodeParentRules/NodeParentRules.drl
@@ -3,6 +3,7 @@ package org.opennms.netmgt.correlation.drools
 import java.util.Date;
 
 import org.opennms.netmgt.correlation.drools.DroolsCorrelationEngine;
+import org.opennms.netmgt.correlation.drools.Cause;
 import org.opennms.netmgt.correlation.drools.Cause.Type;
 import org.opennms.netmgt.xml.event.Event;
 import org.opennms.netmgt.model.events.EventBuilder;
@@ -34,7 +35,7 @@ rule "possibleCauses"
 	then
 		Long $parentNode = nodeService.getParentNode( $cause );
 		if ( $parentNode != null ) {
-			Cause $parent = possibleCause( engine, $parentNode, $e, POLL_INTERVAL );
+			Cause $parent = createPossibleCause( engine, $parentNode, $e, POLL_INTERVAL );
 			$parent.addImpacted( $c );
 			println( "No Cause for parent. Asserting: " + $parent );
 			insert( $parent );
@@ -65,17 +66,9 @@ rule "resolveIssue"
 		retract( $up );
 end
 
-function Cause possibleCause( DroolsCorrelationEngine engine, Long nodeId, Event symptom, Long POLL_INTERVAL ) {
+function Cause createPossibleCause( DroolsCorrelationEngine engine, Long nodeId, Event symptom, Long POLL_INTERVAL ) {
 	return new Cause( Type.POSSIBLE, nodeId, symptom, engine.setTimer( POLL_INTERVAL ) );
 }
-
-//function void foundRootCause( DroolsCorrelationEngine engine, PossibleCause cause ) {
-//	EventBuilder bldr = new EventBuilder( "rootCauseEvent", "Drools" );
-//	bldr.setNodeid((int)cause.getSymptom().getNodeid());
-//	bldr.addParam("rootCause", cause.getCause().intValue());
-//	
-//	engine.sendEvent(bldr.getEvent());
-//}
 
 function void println(Object msg) {
 	System.out.println(new Date() + " : " + msg);

--- a/pom.xml
+++ b/pom.xml
@@ -1272,8 +1272,8 @@
     <paxExamVersion>4.13.1</paxExamVersion>
     <paxSwissboxVersion>1.8.2</paxSwissboxVersion>
     <paxWebVersion>7.2.8</paxWebVersion>
-    <protobufVersion>2.6.1</protobufVersion>
-    <protobuf3Version>3.5.1</protobuf3Version>
+    <protobufVersion>3.6.1</protobufVersion>
+    <protobuf2Version>2.6.1</protobuf2Version>
     <postgresqlVersion>42.2.5</postgresqlVersion>
     <powermockVersion>1.6.4</powermockVersion>
     <opennmsApiVersion>0.2.1-SNAPSHOT</opennmsApiVersion>


### PR DESCRIPTION
JIRA: https://issues.opennms.org/browse/NMS-12191

Here we upgrade Drools to the latest stable release.

Protobuf 2 in the root classpath has been upgrade to Protobuf 3 - existing code that we generated for Protobuf 2 continues to work though.
