### PR TITLE
Fix for sentinel-flows feature not installing

### DIFF
--- a/container/features/src/main/resources/features.xml
+++ b/container/features/src/main/resources/features.xml
@@ -722,6 +722,7 @@
         <feature>opennms-config</feature>
         <feature>opennms-dao-api</feature>
         <feature>opennms-collection-api</feature>
+        <feature>opennms-kvstore-api</feature> 
         <bundle>mvn:org.opennms.features.collection/org.opennms.features.collection.thresholding.api/${project.version}</bundle>
     </feature>
     <feature name="opennms-trapd" version="${project.version}" description="OpenNMS :: Trapd">


### PR DESCRIPTION
The sentinel-flows feature depends on `opennms-thresholding-api` which was recently updated and now depends on `opennms-kvstore-api`. However the feature definition was not updated to include that dependency. This PR updates that feature definition to include the new dependency. The `sentinel-flows` feature now installs correctly.

Test manually in sentinel container.

- No Jira
