### PR TITLE
NMS-12201: Don't block me Drools!

### DIFF
--- a/opennms-correlation/drools-correlation-engine/src/main/java/org/opennms/netmgt/correlation/drools/DroolsCorrelationEngine.java
+++ b/opennms-correlation/drools-correlation-engine/src/main/java/org/opennms/netmgt/correlation/drools/DroolsCorrelationEngine.java
@@ -40,6 +40,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang.exception.ExceptionUtils;
@@ -74,6 +80,10 @@ import com.codahale.metrics.Gauge;
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.io.ByteStreams;
+import com.google.common.util.concurrent.SimpleTimeLimiter;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import com.google.common.util.concurrent.TimeLimiter;
+import com.google.common.util.concurrent.UncheckedTimeoutException;
 
 /**
  * <p>DroolsCorrelationEngine class.</p>
@@ -86,6 +96,10 @@ public class DroolsCorrelationEngine extends AbstractCorrelationEngine {
     private static final Logger LOG = LoggerFactory.getLogger(DroolsCorrelationEngine.class);
     // If state need to be reloaded in case of engine being reloaded because of exception in rules engine, set this system property to true.
     public static final String RELOAD_STATE_AFTER_EXCEPTION = "org.opennms.netmgt.correlation.drools.reloadStateAfterException";
+
+    private static final ExecutorService s_sessionDisposeExecutor = Executors.newCachedThreadPool(new ThreadFactoryBuilder()
+            .setNameFormat("DroolsCorrelationEngine-Dispose-Pool-%d").build());
+    private static TimeLimiter s_timeLimiter = new SimpleTimeLimiter(s_sessionDisposeExecutor);
 
     private KieBase m_kieBase;
     private KieSession m_kieSession;
@@ -102,7 +116,23 @@ public class DroolsCorrelationEngine extends AbstractCorrelationEngine {
     private Resource m_configPath;
     private ApplicationContext m_configContext;
     private List<Object> factObjects;
-    
+
+    /**
+     * Holds a reference to the thread that calls {@link KieSession#fireUntilHalt()}
+     */
+    private Thread m_streamThread;
+
+    /**
+     * Used to let the "stream thread" known that we're shutting down and that it should not
+     * treat {@link InterruptedException}s as errors.
+     */
+    private final AtomicBoolean m_shuttingDownStreamThread = new AtomicBoolean(false);
+
+    /**
+     * Used to marshall/unmarshall the session.
+     */
+    private Marshaller m_marshaller;
+
     public DroolsCorrelationEngine(final String name, final MetricRegistry metricRegistry, final Resource configPath, final ApplicationContext configContext) {
         this.m_name = name;
         this.m_configPath = configPath;
@@ -223,6 +253,11 @@ public class DroolsCorrelationEngine extends AbstractCorrelationEngine {
         ruleBaseConfig.setEventProcessingMode(eventProcessingOption);
 
         m_kieBase = kContainer.newKieBase(ruleBaseConfig);
+
+        final KieMarshallers kMarshallers = KieServices.Factory.get().getMarshallers();
+        final ObjectMarshallingStrategy oms = kMarshallers.newSerializeMarshallingStrategy();
+        m_marshaller = kMarshallers.newMarshaller( m_kieBase, new ObjectMarshallingStrategy[]{ oms } );
+
         m_kieSession = m_kieBase.newKieSession();
         m_kieSession.setGlobal("engine", this);
 
@@ -231,7 +266,7 @@ public class DroolsCorrelationEngine extends AbstractCorrelationEngine {
         }
 
         if (m_persistState != null && m_persistState) {
-            unmarshallStateFromDisk(true);
+            unmarshallStateFromDisk();
         }
 
         if (factObjects != null) {
@@ -240,16 +275,23 @@ public class DroolsCorrelationEngine extends AbstractCorrelationEngine {
         }
 
         if (m_isStreaming) {
-            new Thread(() -> {  
+            m_shuttingDownStreamThread.set(false);
+            m_streamThread = new Thread(() -> {
                 Logging.putPrefix(getClass().getSimpleName() + '-' + getName());
                 try {
                     m_kieSession.fireUntilHalt();
                 } catch (Exception e) {
+                    if (m_shuttingDownStreamThread.get()) {
+                        // We're shutting down, don't trigger a reload!
+                        return;
+                    }
                     LOG.error("Exception while running rules, reloading engine ", e);
                     doReload(e);
                 }
-            }, "FireTask").start();
+            }, "FireTask [" + m_name + "]");
+            m_streamThread.start();
         }
+
     }
 
     // This will send drools exception event which should result into Alarm and send reload event.
@@ -257,7 +299,7 @@ public class DroolsCorrelationEngine extends AbstractCorrelationEngine {
         // Trigger an alarm with the specific exception
         EventBuilder eventBldr = new EventBuilder(EventConstants.DROOLS_ENGINE_ENCOUNTERED_EXCEPTION, getName());
         eventBldr.addParam("enginename", getName());
-        eventBldr.addParam("stracktrace", ExceptionUtils.getStackTrace(exception));
+        eventBldr.addParam("stacktrace", ExceptionUtils.getStackTrace(exception));
         sendEvent(eventBldr.getEvent());
         // Send reload daemon event.
         EventBuilder reloadEventBldr = new EventBuilder(EventConstants.RELOAD_DAEMON_CONFIG_UEI, getName());
@@ -291,7 +333,7 @@ public class DroolsCorrelationEngine extends AbstractCorrelationEngine {
                 LOG.error("Cannot marshall state because there are pending time based tasks running.");
                 shutDownKieSession();
             } else {
-                marshallStateToDisk(true);
+                marshallStateToDisk();
             }
         } else {
             shutDownKieSession();
@@ -299,57 +341,80 @@ public class DroolsCorrelationEngine extends AbstractCorrelationEngine {
     }
 
     private synchronized void shutDownKieSession() {
+        shutDownKieSession(null);
+    }
+
+    private synchronized void shutDownKieSession(Runnable postHaltPreDispose) {
         if (m_kieSession == null) {
             return;
         }
+        m_shuttingDownStreamThread.set(true);
         m_kieSession.halt();
-        m_kieSession.dispose();
-        m_kieSession.destroy();
+        if (postHaltPreDispose != null) {
+            postHaltPreDispose.run();
+        }
+
+        try {
+            LOG.debug("Disposing KieSession for engine: {}", m_name);
+            // Calls to dispose have been known to cause us deadlocks - see NMS-12201
+            // Wrap it with a timeout to make sure this doesn't happen
+            s_timeLimiter.callWithTimeout(() -> {
+                m_kieSession.dispose();
+                m_kieSession.destroy();
+                LOG.debug("Successfully disposed KieSession for engine: {}", m_name);
+                return null;
+            },  10, TimeUnit.SECONDS, true);
+        }  catch (UncheckedTimeoutException e) {
+            LOG.info("KieSession for engine named '{}' was not disposed within the given timeout.", m_name);
+            if (m_streamThread != null) {
+                // If we're streaming, interrupt the thread, this has been found to clean things up properly
+                // when calling dispose() blocks.
+                LOG.info("Interrupting the stream thread for engine: {}", m_name);
+                m_streamThread.interrupt();
+            }
+        } catch (Exception e) {
+            LOG.warn("Error occurred while disposing KieSession for engine: {}", m_name, e);
+        }
+
         m_kieSession = null;
+        m_streamThread = null;
     }
 
     private Path getPathToState() {
         return Paths.get(System.getProperty("java.io.tmpdir"), "opennms.drools." + m_name + ".state");
     }
 
-    private synchronized  void marshallStateToDisk(boolean serialize) {
+    private synchronized void marshallStateToDisk() {
         if (m_kieSession == null) {
             return;
         }
         final File stateFile = getPathToState().toFile();
         LOG.debug("Saving state for engine {} in {} ...", m_name, stateFile);
-        final KieMarshallers kMarshallers = KieServices.Factory.get().getMarshallers();
-        final ObjectMarshallingStrategy oms = serialize ?
-                kMarshallers.newSerializeMarshallingStrategy() : kMarshallers.newIdentityMarshallingStrategy();
-        final Marshaller marshaller = kMarshallers.newMarshaller( m_kieBase, new ObjectMarshallingStrategy[]{ oms } );
         try (FileOutputStream fos = new FileOutputStream(stateFile)) {
-            m_kieSession.halt();
-            marshaller.marshall( fos, m_kieSession );
-            m_kieSession.dispose();
-            m_kieSession.destroy();
-            m_kieSession = null;
-            LOG.info("Sucessfully save state for engine {} in {}.", m_name, stateFile);
-        } catch (IOException e) {
+            shutDownKieSession(() -> {
+                try {
+                    m_marshaller.marshall(fos, m_kieSession);
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+            LOG.info("Successfully saved state for engine {} in {}.", m_name, stateFile);
+        } catch (Exception e) {
             LOG.error("Failed to save state for engine {} in {}.", m_name, stateFile, e);
         }
     }
 
-    private void unmarshallStateFromDisk(boolean serialize) {
+    private void unmarshallStateFromDisk() {
         final File stateFile = getPathToState().toFile();
         if (!stateFile.exists()) {
             LOG.error("Can't restore state from {} because the file doesn't exist", stateFile);
             return;
         }
         LOG.debug("Restoring state for engine {} from {} ...", m_name, stateFile);
-        final KieMarshallers kMarshallers = KieServices.Factory.get().getMarshallers();
-        final ObjectMarshallingStrategy oms = serialize ?
-                kMarshallers.newSerializeMarshallingStrategy() : kMarshallers.newIdentityMarshallingStrategy();
-        final Marshaller marshaller = kMarshallers.newMarshaller( m_kieBase, new ObjectMarshallingStrategy[]{ oms } );
-
         try (FileInputStream fin = new FileInputStream(stateFile)) {
-            marshaller.unmarshall( fin, m_kieSession );
+            m_marshaller.unmarshall( fin, m_kieSession );
             stateFile.delete();
-            LOG.info("Sucessfully restored state for engine {} from {}.", m_name, stateFile);
+            LOG.info("Successfully restored state for engine {} from {}.", m_name, stateFile);
         } catch (IOException | ClassNotFoundException e) {
             LOG.error("Failed to restore state for engine {} from {}.", m_name, stateFile, e);
         }
@@ -437,27 +502,20 @@ public class DroolsCorrelationEngine extends AbstractCorrelationEngine {
     }
 
     void saveFacts( ) {
-        if (m_kieSession == null) {
-            return;
-        }
-        m_kieSession.halt();
-        try {
-            // Capture the current set of facts
-            factObjects  = m_kieSession.getFactHandles().stream()
-                    .map(fact -> m_kieSession.getObject(fact))
-                    .collect(Collectors.toList());
-        } catch (Exception e) {
-            LOG.warn("Failed to save facts", e);
-        }
-        m_kieSession.dispose();
-        m_kieSession.destroy();
-        m_kieSession = null;
+        shutDownKieSession(() -> {
+            try {
+                // Capture the current set of facts
+                factObjects  = m_kieSession.getFactHandles().stream()
+                        .map(fact -> m_kieSession.getObject(fact))
+                        .collect(Collectors.toList());
+            } catch (Exception e) {
+                LOG.warn("Failed to save facts", e);
+            }
+        });
     }
-
 
     List<Object> getFactObjects() {
         return factObjects;
     }
-
 
 }

--- a/opennms-correlation/drools-correlation-engine/src/test/java/org/opennms/netmgt/correlation/drools/DroolsCorrelationEngineBuilderIT.java
+++ b/opennms-correlation/drools-correlation-engine/src/test/java/org/opennms/netmgt/correlation/drools/DroolsCorrelationEngineBuilderIT.java
@@ -77,7 +77,7 @@ public class DroolsCorrelationEngineBuilderIT implements InitializingBean {
     public void testIt() throws Exception {
         Collection<CorrelationEngine> engines = m_mockCorrelator.getEngines();
         assertNotNull(engines);
-        assertEquals(6, m_mockCorrelator.getEngines().size());
+        assertEquals(7, m_mockCorrelator.getEngines().size());
         assertTrue(engines.iterator().next() instanceof DroolsCorrelationEngine);
         assertTrue(m_mockCorrelator.findEngineByName("locationMonitorRules") instanceof DroolsCorrelationEngine);
         DroolsCorrelationEngine engine = (DroolsCorrelationEngine) m_mockCorrelator.findEngineByName("locationMonitorRules");

--- a/opennms-correlation/drools-correlation-engine/src/test/opennms-home/etc/drools-engine.d/persistStateStreaming/PersistStateStreaming.drl
+++ b/opennms-correlation/drools-correlation-engine/src/test/opennms-home/etc/drools-engine.d/persistStateStreaming/PersistStateStreaming.drl
@@ -1,0 +1,24 @@
+package org.opennms.netmgt.correlation.drools;
+
+import org.opennms.netmgt.correlation.drools.DroolsCorrelationEngine;
+import org.opennms.netmgt.xml.event.Event;
+import org.opennms.netmgt.model.events.EventBuilder;
+import org.drools.core.spi.KnowledgeHelper;
+
+global DroolsCorrelationEngine engine;
+
+declare Thing
+	name: String
+end
+
+rule "test-got-something"
+	salience 300
+when
+	$e : Event(uei matches "uei.opennms.org/nodes/nodeLostService")
+then
+    System.err.println("got one: " + $e);
+    EventBuilder eventBuilder = new EventBuilder("uei.opennms.org/nodes/nodeUp", "Component Correlator");
+    eventBuilder.setNodeid($e.getNodeid());
+    insert(eventBuilder.getEvent());
+    insert(new Thing());
+end

--- a/opennms-correlation/drools-correlation-engine/src/test/opennms-home/etc/drools-engine.d/persistStateStreaming/drools-engine.xml
+++ b/opennms-correlation/drools-correlation-engine/src/test/opennms-home/etc/drools-engine.d/persistStateStreaming/drools-engine.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <engine-configuration xmlns="http://xmlns.opennms.org/xsd/drools-engine">
-  <rule-set name="persistStateTest" persist-state="true">
-    <rule-file>PersistState.drl</rule-file>
+  <rule-set name="persistStateStreamingTest" persist-state="true" event-processing-mode="stream">
+    <rule-file>PersistStateStreaming.drl</rule-file>
     <event>uei.opennms.org/nodes/nodeLostService</event>
   </rule-set>  
 </engine-configuration>


### PR DESCRIPTION
JIRA: https://issues.opennms.org/browse/NMS-12201

Add a test case that reproduces a problem where a Drools session blocks
indefinitely when being shut down and add a workaround to the engine.

Problem has been reported upstream in DROOLS-4413.
