### PR TITLE
NMS-12194: Update warmerge plugin dependency to 0.5

### DIFF
--- a/opennms-assemblies/webapp-full/pom.xml
+++ b/opennms-assemblies/webapp-full/pom.xml
@@ -49,7 +49,7 @@
       <plugin>
         <groupId>org.opennms.maven.plugins</groupId>
         <artifactId>opennms-warmerge-plugin</artifactId>
-        <version>0.4</version>
+        <version>0.5</version>
         <executions>
           <execution>
             <goals>


### PR DESCRIPTION
This PR updates the dependency version of opennms-warmerge-plugin to fix some build issues that were present with 0.4.

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-12194
* Bamboo (Continuous Integration): https://bamboo.opennms.org/

