### PR TITLE
NMS-12206: Set max version for OpenJDK to 11

### DIFF
--- a/container/shared/src/main/resources/etc/container.init
+++ b/container/shared/src/main/resources/etc/container.init
@@ -39,7 +39,7 @@ if [ -f /etc/rc.d/init.d/functions ]; then
 fi
 
 if [ -z "$JAVA_HOME" ]; then
-	JAVA_HOME="$("$CONTAINER_HOME/bin/find-java.sh" 1.8.0 1.8.9999)"
+	JAVA_HOME="$("$CONTAINER_HOME/bin/find-java.sh" 1.8.0 11.9.9999)"
 fi
 
 if [ -r "$SYSCONFDIR/$NAME" ]; then


### PR DESCRIPTION
Set max version in find-java script from OpenJDK from 1.8 to 11.

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-12206

