### PR TITLE
NMS-12211: Set format to PEM for SSH host key generation for Karaf

### DIFF
--- a/opennms-assemblies/minion/src/main/filtered/debian/opennms-minion-container.postinst
+++ b/opennms-assemblies/minion/src/main/filtered/debian/opennms-minion-container.postinst
@@ -11,7 +11,7 @@ MINIONLOG="/var/log/minion"
 rm -rf "${MINIONHOME}/data"/* || true
 
 if [ ! -f "${ETCDIR}/host.key" ]; then
-	ssh-keygen -t rsa -N "" -b 4096 -f "${ETCDIR}/host.key"
+	ssh-keygen -m PEM -t rsa -N "" -b 4096 -f "${ETCDIR}/host.key"
 	chown "${MINIONUSER}:${MINIONUSER}" "${ETCDIR}/host.key"
 fi
 

--- a/opennms-assemblies/sentinel/src/main/filtered/debian/opennms-sentinel.postinst
+++ b/opennms-assemblies/sentinel/src/main/filtered/debian/opennms-sentinel.postinst
@@ -11,7 +11,7 @@ SENTINELLOG="/var/log/sentinel"
 rm -rf "${SENTINELHOME}/data"/* || true
 
 if [ ! -f "${ETCDIR}/host.key" ]; then
-	ssh-keygen -t rsa -N "" -b 4096 -f "${ETCDIR}/host.key"
+	ssh-keygen -m PEM -t rsa -N "" -b 4096 -f "${ETCDIR}/host.key"
 	chown "${SENTINELUSER}:${SENTINELUSER}" "${ETCDIR}/host.key"
 fi
 

--- a/tools/packages/minion/minion.spec
+++ b/tools/packages/minion/minion.spec
@@ -238,7 +238,7 @@ fi
 
 # Generate an SSH key if necessary
 if [ ! -f "${ROOT_INST}/etc/host.key" ]; then
-    /usr/bin/ssh-keygen -t rsa -N "" -b 4096 -f "${ROOT_INST}/etc/host.key"
+    /usr/bin/ssh-keygen -m PEM -t rsa -N "" -b 4096 -f "${ROOT_INST}/etc/host.key"
     chown minion:minion "${ROOT_INST}/etc/"host.key*
 fi
 

--- a/tools/packages/sentinel/sentinel.spec
+++ b/tools/packages/sentinel/sentinel.spec
@@ -192,7 +192,7 @@ rm -rf "${ROOT_INST}/.m2"
 
 # Generate an SSH key if necessary
 if [ ! -f "${ROOT_INST}/etc/host.key" ]; then
-    /usr/bin/ssh-keygen -t rsa -N "" -b 4096 -f "${ROOT_INST}/etc/host.key"
+    /usr/bin/ssh-keygen -m PEM -t rsa -N "" -b 4096 -f "${ROOT_INST}/etc/host.key"
     chown sentinel:sentinel "${ROOT_INST}/etc/"host.key*
 fi
 


### PR DESCRIPTION
With OpenSSH 7.8+ the default format for RSA key pairs has been changed and writes by default the OpenSSH format. This file can't be processed correctly from our current Karaf version. The key needs to be generated with the old PEM format which is here enforced by adding the "-m PEM" as arguments.

* JIRA: http://issues.opennms.org/browse/NMS-12211

