### PR TITLE
Database Reports/Grafana Endpoints: Fix small UI related issues, address some TODOs and get it closer for merging back

### DIFF
--- a/core/web-assets/src/main/assets/js/apps/onms-endpoints/grafana/grafana-modal.html
+++ b/core/web-assets/src/main/assets/js/apps/onms-endpoints/grafana/grafana-modal.html
@@ -1,19 +1,3 @@
-<style type="text/css">
-  .rotate {
-    -webkit-animation: rotation 2s infinite linear;
-  }
-
-  @-webkit-keyframes rotation {
-    from {
-      -webkit-transform: rotate(0deg);
-    }
-    to {
-      -webkit-transform: rotate(359deg);
-    }
-  }
-</style>
-
-
 <div id="endpointModal">
   <div class="modal-header">
     <h5 class="modal-title">{{endpoint.id === undefined ? "Add" : "Edit"}} Grafana Endpoint</h5>
@@ -82,8 +66,7 @@
     </form>
 
     <button type="button" class="btn btn-warning btn-sm" id="verify-endpoint" ng-click="verify()" ng-disabled="endpointForm.$invalid" title="Verify Connectivity"><i class="fa fa-plug"></i> Test Connection</button>
-    <span class="spinner-border spinner-border-sm"></span>
-    <span class="" ng-if="verification.state === 'running'"><i class="fa fa-spinner rotate"></i> Connecting ...</span>
+    <span class="" ng-if="verification.state === 'running'"><i class="spinner-border spinner-border-sm"></i> Connecting ...</span>
     <span class="text-success" ng-if="verification.state ==='success'"><i class="fa fa-check"></i> Connected</span>
     <span class="text-danger" ng-if="verification.state === 'failure'"><i class="fa fa-exclamation-triangle"></i> Could not connect</span>
     <div ng-if="verification.result && verification.state === 'failure'" class="alert mt-2" ng-class="{'alert-danger': verification.state === 'failure'}">

--- a/core/web-assets/src/main/assets/js/apps/onms-endpoints/grafana/grafana-modal.html
+++ b/core/web-assets/src/main/assets/js/apps/onms-endpoints/grafana/grafana-modal.html
@@ -9,9 +9,9 @@
       </div>
       <div class="form-group form-row">
         <label class="col-form-label" for="endpoint.uid">Grafana ID</label>
-        <button class="btn btn-link"
+        <button class="btn btn-link text-secondary px-0"
                 popover-trigger="'mouseenter'"
-                uib-popover="A unique identifier of this endpoint. The identifier can only contain alpha numeric values as well as  - and _ but may not start with those. The full regular expression to match is: {{uidRegex}}"><i class="fa fa-question-circle"/>
+                uib-popover="A unique identifier of this endpoint. The identifier can only contain alpha numeric values as well as  - and _ but may not start with those. The full regular expression to match is: {{uidRegex}}"><i class="fa fa-info-circle"/>
         </button>
         <input class="form-control" type="text" id="endpoint.uid" name="uid" placeholder="Unique Grafana ID" ng-model="endpoint.uid"
                ng-class="{ 'is-invalid' : endpointForm.uid.$invalid || error.uid }"
@@ -42,9 +42,9 @@
       </div>
       <div class="form-group form-row">
         <label class="col-form-label" for="endpoint.connectTimeout">Grafana Connect Timeout</label>
-        <button class="btn btn-link"
+        <button class="btn btn-link text-secondary px-0"
                 popover-trigger="'mouseenter'"
-                uib-popover="The connect timeout in seconds for this endpoint. If omitted a the the default timeout of {{defaultConnectTimeout}} seconds is applied."><i class="fa fa-question-circle"/>
+                uib-popover="The connect timeout in seconds for this endpoint. If omitted a default timeout of {{defaultConnectTimeout}} seconds is applied."><i class="fa fa-info-circle"/>
         </button>
         <input class="form-control" type="number" id="endpoint.connectTimeout" name="connectTimeout" min="0" max="9999" ng-model="endpoint.connectTimeout"
                ng-class="{ 'is-invalid' : endpointForm.connectTimeout.$invalid || error.connectTimeout}"/>
@@ -53,9 +53,9 @@
       </div>
       <div class="form-group form-row">
         <label class="col-form-label" for="endpoint.readTimeout">Grafana Read Timeout</label>
-        <button class="btn btn-link"
+        <button class="btn btn-link text-secondary px-0"
                 popover-trigger="'mouseenter'"
-                uib-popover="The read timeout in seconds for this endpoint. If omitted a the the default timeout of {{defaultReadTimeout}} seconds is applied."><i class="fa fa-question-circle"/>
+                uib-popover="The read timeout in seconds for this endpoint. If omitted a default timeout of {{defaultReadTimeout}} seconds is applied."><i class="fa fa-info-circle"/>
         </button>
 
         <input class="form-control" type="number" id="endpoint.readTimeout" name="readTimeout" min="0" max="9999" ng-model="endpoint.readTimeout"

--- a/core/web-assets/src/main/assets/js/apps/onms-endpoints/index.js
+++ b/core/web-assets/src/main/assets/js/apps/onms-endpoints/index.js
@@ -137,10 +137,8 @@ const grafanaModalTemplate = require('./grafana/grafana-modal.html');
                 result: undefined
             };
             $scope.error = {};
-            // TODO MVR apply default value
-            $scope.defaultReadTimeout = "undefined";
-            // TODO MVR apply default value
-            $scope.defaultConnectTimeout = "undefined";
+            $scope.defaultReadTimeout = 30;
+            $scope.defaultConnectTimeout = 30;
 
             var handleErrorResponse = function(response) {
                 if (response.status === 400 && response.data) {

--- a/features/endpoints/grafana/client/src/main/java/org/opennms/netmgt/endpoints/grafana/client/GrafanaClientFactoryImpl.java
+++ b/features/endpoints/grafana/client/src/main/java/org/opennms/netmgt/endpoints/grafana/client/GrafanaClientFactoryImpl.java
@@ -39,8 +39,8 @@ public class GrafanaClientFactoryImpl implements GrafanaClientFactory {
         final GrafanaServerConfiguration serverConfiguration = new GrafanaServerConfiguration(
                 grafanaEndpoint.getUrl(),
                 grafanaEndpoint.getApiKey(),
-                grafanaEndpoint.getConnectTimeout() == null ? 120 : grafanaEndpoint.getConnectTimeout(), // TODO MVR this is not a good place to do this
-                grafanaEndpoint.getReadTimeout() == null ? 120 : grafanaEndpoint.getReadTimeout()  // TODO MVR this is not a good place to do this
+                grafanaEndpoint.getConnectTimeout(),
+                grafanaEndpoint.getReadTimeout()
         );
         final GrafanaClient client = new GrafanaClientImpl(serverConfiguration);
         return client;

--- a/features/endpoints/grafana/client/src/main/java/org/opennms/netmgt/endpoints/grafana/client/GrafanaClientImpl.java
+++ b/features/endpoints/grafana/client/src/main/java/org/opennms/netmgt/endpoints/grafana/client/GrafanaClientImpl.java
@@ -39,9 +39,7 @@ import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
-import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLSession;
 import javax.net.ssl.SSLSocketFactory;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
@@ -188,7 +186,6 @@ public class GrafanaClientImpl implements GrafanaClient {
     private static OkHttpClient.Builder configureToIgnoreCertificate(OkHttpClient.Builder builder) {
         try {
 
-            // TODO MVR do we really wanna do this?
             // Create a trust manager that does not validate certificate chains
             final TrustManager[] trustAllCerts = new TrustManager[] {
                     new X509TrustManager() {
@@ -214,12 +211,7 @@ public class GrafanaClientImpl implements GrafanaClient {
             final SSLSocketFactory sslSocketFactory = sslContext.getSocketFactory();
 
             builder.sslSocketFactory(sslSocketFactory, (X509TrustManager)trustAllCerts[0]);
-            builder.hostnameVerifier(new HostnameVerifier() {
-                @Override
-                public boolean verify(String hostname, SSLSession session) {
-                    return true;
-                }
-            });
+            builder.hostnameVerifier((hostname, session) -> true);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/features/endpoints/grafana/client/src/main/java/org/opennms/netmgt/endpoints/grafana/client/GrafanaServerConfiguration.java
+++ b/features/endpoints/grafana/client/src/main/java/org/opennms/netmgt/endpoints/grafana/client/GrafanaServerConfiguration.java
@@ -36,10 +36,13 @@ import java.nio.file.Paths;
 import java.util.Objects;
 import java.util.Properties;
 
-/**
- * TODO MVR: Migrate this to immutable with builder pattern
- */
+import com.google.common.base.Preconditions;
+
 public class GrafanaServerConfiguration {
+
+    public static int DEFAULT_CONNECT_TIMEOUT_IN_SECONDS = 30;
+    public static int DEFAULT_READ_TIMEOUT_IN_SECONDS = 30;
+
     private final String url;
     private final String apiKey;
     private final int connectTimeoutSeconds;
@@ -53,20 +56,22 @@ public class GrafanaServerConfiguration {
             prop.load(input);
             final String url = prop.getProperty("url");
             final String apiKey = prop.getProperty("apiKey");
-            // TODO MVR: Be more defensive and add defaults
-            final int connectTimeout = Integer.parseInt(prop.getProperty("connectTimeout"));
-            final int readTimeout = Integer.parseInt(prop.getProperty("readTimeout"));
+            final int connectTimeout = Integer.parseInt(prop.getProperty("connectTimeout", Integer.toString(DEFAULT_CONNECT_TIMEOUT_IN_SECONDS)));
+            final int readTimeout = Integer.parseInt(prop.getProperty("readTimeout", Integer.toString(DEFAULT_READ_TIMEOUT_IN_SECONDS)));
             return new GrafanaServerConfiguration(url, apiKey, connectTimeout, readTimeout);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
     }
 
-    public GrafanaServerConfiguration(String url, String apiKey, int connectTimeoutSeconds, int readTimeoutSeconds) {
+    public GrafanaServerConfiguration(String url, String apiKey, Integer connectTimeoutSeconds, Integer readTimeoutSeconds) {
         this.url = Objects.requireNonNull(url);
         this.apiKey = Objects.requireNonNull(apiKey);
-        this.connectTimeoutSeconds = connectTimeoutSeconds;
-        this.readTimeoutSeconds = readTimeoutSeconds;
+        this.connectTimeoutSeconds = connectTimeoutSeconds == null ? DEFAULT_CONNECT_TIMEOUT_IN_SECONDS : connectTimeoutSeconds;
+        this.readTimeoutSeconds = readTimeoutSeconds == null ? DEFAULT_READ_TIMEOUT_IN_SECONDS : readTimeoutSeconds;
+
+        Preconditions.checkArgument(connectTimeoutSeconds >= 0, "connectTimeoutSeconds must be >= 0");
+        Preconditions.checkArgument(readTimeoutSeconds >= 0, "readTimeoutSeconds msut be >= 0");
     }
 
     public String getUrl() {

--- a/features/endpoints/grafana/client/src/main/java/org/opennms/netmgt/endpoints/grafana/client/GrafanaServerConfiguration.java
+++ b/features/endpoints/grafana/client/src/main/java/org/opennms/netmgt/endpoints/grafana/client/GrafanaServerConfiguration.java
@@ -49,8 +49,7 @@ public class GrafanaServerConfiguration {
     private final int readTimeoutSeconds;
 
     public static GrafanaServerConfiguration fromEnv() {
-        final File configFile = Paths.get(System.getProperty("user.home"), ".grafana", "server.properties").toFile(); // TODO MVR this is bäh
-
+        final File configFile = Paths.get(System.getProperty("user.home"), ".grafana", "server.properties").toFile();
         try (InputStream input = new FileInputStream(configFile)) {
             final Properties prop = new Properties();
             prop.load(input);

--- a/integrations/opennms-jasper-extensions/src/main/java/org/opennms/netmgt/jasper/grafana/GrafanaQueryExecutor.java
+++ b/integrations/opennms-jasper-extensions/src/main/java/org/opennms/netmgt/jasper/grafana/GrafanaQueryExecutor.java
@@ -85,7 +85,6 @@ public class GrafanaQueryExecutor extends JRAbstractQueryExecuter {
         final GrafanaClient client;
         final String grafanaEndpointUid = getStringParameterOrProperty(GRAFANA_ENDPOINT_UID_PARM);
         if (Strings.isNullOrEmpty(grafanaEndpointUid)) {
-            // TODO MVR, do we want to support this, or not
             LOG.debug("No Grafana endpoint UID was set, using server configuration from the user's environment.");
             final GrafanaServerConfiguration config = GrafanaServerConfiguration.fromEnv();
             client = new GrafanaClientImpl(config);


### PR DESCRIPTION
Here we fix some UI related issues which were introduced with the upgrade to bootstrap 4.3.1 as well as some other minor issues (i) icons instead of (?) as well as typo fixes and we apply a default connect and read timeout of 30 seconds instead of 120.