### PR TITLE
NMS-12212: Show configured rule groups

### DIFF
--- a/core/web-assets/src/main/assets/js/apps/onms-classifications/index.js
+++ b/core/web-assets/src/main/assets/js/apps/onms-classifications/index.js
@@ -302,6 +302,9 @@ const confirmTopoverTemplate = require('./views/modals/popover.html');
                         },
                         group: function() {
                             return group;
+                        },
+                        groups: function () {
+                            return $scope.groups;
                         }
                     }
                 });
@@ -485,13 +488,14 @@ const confirmTopoverTemplate = require('./views/modals/popover.html');
             };
 
         }])
-        .controller('ClassificationModalController', ['$scope', '$uibModalInstance', 'ProtocolService', 'ClassificationRuleService', 'classification', 'group', function($scope, $uibModalInstance, ProtocolService, ClassificationRuleService, classification, group) {
-            $scope.classification = classification || {};
+        .controller('ClassificationModalController', ['$scope', '$uibModalInstance', 'ProtocolService', 'ClassificationRuleService', 'classification', 'group', 'groups', function($scope, $uibModalInstance, ProtocolService, ClassificationRuleService, classification, group, groups) {
+            $scope.classification = classification || {group:group};
             $scope.protocols = [];
             $scope.currentSelection = undefined;
             $scope.selectedProtocols = [];
             $scope.buttonName = $scope.classification.id ? 'Update' : 'Create';
             $scope.group = group;
+            $scope.selectableGroups = groups.filter((group) => group.readOnly === false);
 
             var convertStringArrayToProtocolsArray = function(string) {
                 return string.map(function(protocol) {

--- a/core/web-assets/src/main/assets/js/apps/onms-classifications/views/modals/new-rule-modal.html
+++ b/core/web-assets/src/main/assets/js/apps/onms-classifications/views/modals/new-rule-modal.html
@@ -9,6 +9,13 @@
         <div ng-show="error.entity" class="form-text text-muted">{{error.entity}}</div>
       </div>
       <div class="form-group form-row">
+        <label class="col-form-label" for="rule.group">Group</label>
+        <select class="form-control"
+                ng-options="group as group.name for group in selectableGroups track by group.id"
+                ng-model="classification.group"
+                id="rule.group" ></select>
+      </div>
+      <div class="form-group form-row">
         <label class="col-form-label" for="rule.position">Position</label>
         <button class="btn btn-link"
                 uib-popover-html="'<div>Rules on low positions will be evaluated first:<br>Position 0 -&gt; Position 1 -&gt; Position 2 -&gt; ...</div>'"

--- a/features/flows/classification/engine/api/src/main/java/org/opennms/netmgt/flows/classification/ClassificationService.java
+++ b/features/flows/classification/engine/api/src/main/java/org/opennms/netmgt/flows/classification/ClassificationService.java
@@ -58,6 +58,8 @@ public interface ClassificationService {
 
     Group getGroup(int groupId);
 
+    Integer saveGroup(Group group);
+
     void deleteGroup(int groupId);
 
     void updateGroup(Group group);

--- a/features/flows/classification/engine/impl/src/main/java/org/opennms/netmgt/flows/classification/internal/DefaultClassificationService.java
+++ b/features/flows/classification/engine/impl/src/main/java/org/opennms/netmgt/flows/classification/internal/DefaultClassificationService.java
@@ -240,6 +240,11 @@ public class DefaultClassificationService implements ClassificationService {
     }
 
     @Override
+    public Integer saveGroup(Group group) {
+        return runInTransaction((status) -> classificationGroupDao.save(group));
+    }
+
+    @Override
     public void deleteGroup(int groupId) {
         runInTransaction(status -> {
             final Group group = classificationGroupDao.get(groupId);

--- a/features/flows/classification/engine/impl/src/main/java/org/opennms/netmgt/flows/classification/internal/DefaultClassificationService.java
+++ b/features/flows/classification/engine/impl/src/main/java/org/opennms/netmgt/flows/classification/internal/DefaultClassificationService.java
@@ -202,7 +202,7 @@ public class DefaultClassificationService implements ClassificationService {
     }
 
     @Override
-    public void updateRule(Rule rule) {
+    public void updateRule(final Rule rule) {
         if (rule.getId() == null) throw new NoSuchElementException();
 
         // Persist
@@ -210,8 +210,9 @@ public class DefaultClassificationService implements ClassificationService {
             ruleValidator.validate(rule);
             groupValidator.validate(rule.getGroup(), rule);
             classificationRuleDao.saveOrUpdate(rule);
-            Group group = getGroup(rule.getGroup().getId()); // reload group since we might just have been added
-            updateRulePositionsAndReloadEngine(RulePositionUtil.sortRulePositions(rule));
+            // reload to get updated group since we might just have switched groups
+            Rule reloaded = classificationRuleDao.get(rule.getId());
+            updateRulePositionsAndReloadEngine(RulePositionUtil.sortRulePositions(reloaded));
             return null;
         });
     }

--- a/features/flows/classification/engine/impl/src/main/java/org/opennms/netmgt/flows/classification/internal/RulePositionUtil.java
+++ b/features/flows/classification/engine/impl/src/main/java/org/opennms/netmgt/flows/classification/internal/RulePositionUtil.java
@@ -36,7 +36,7 @@ import org.opennms.netmgt.flows.classification.persistence.api.Rule;
 class RulePositionUtil {
 
     /** Sorts the rules by its position. The given rule gets the lower position as another rule with the same position
-     * => the given rule will be evaluated before another rule wit the same position. */
+     * => the given rule will be evaluated before another rule with the same position. */
     static List<Rule> sortRulePositions(Rule rule) {
         // Load all rules of group and sort by priority (highest first) in that group
         final List<Rule> rules = rule.getGroup().getRules();

--- a/features/flows/rest/api/src/main/java/org/opennms/netmgt/flows/rest/classification/ClassificationRestService.java
+++ b/features/flows/rest/api/src/main/java/org/opennms/netmgt/flows/rest/classification/ClassificationRestService.java
@@ -88,6 +88,10 @@ public interface ClassificationRestService {
                       @QueryParam("filename") String requestedFilename,
                       @HeaderParam("Accept") String acceptHeader);
 
+    @POST
+    @Path("groups")
+    Response saveGroup(GroupDTO groupDTO);
+
     @DELETE
     @Path("groups/{id}")
     Response deleteGroup(int groupId);

--- a/features/flows/rest/api/src/main/java/org/opennms/netmgt/flows/rest/classification/GroupDTOBuilder.java
+++ b/features/flows/rest/api/src/main/java/org/opennms/netmgt/flows/rest/classification/GroupDTOBuilder.java
@@ -1,0 +1,72 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2018-2018 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2018 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.flows.rest.classification;
+
+public class GroupDTOBuilder {
+    private final GroupDTO groupDTO = new GroupDTO();
+
+    public GroupDTOBuilder withId(Integer id){
+        this.groupDTO.setId(id);
+        return this;
+    }
+
+    public GroupDTOBuilder withPriority(Integer priority){
+        this.groupDTO.setPriority(priority);
+        return this;
+    }
+
+    public GroupDTOBuilder withName(String name){
+        this.groupDTO.setName(name);
+        return this;
+    }
+
+    public GroupDTOBuilder withDescription(String description){
+        this.groupDTO.setDescription(description);
+        return this;
+    }
+
+    public GroupDTOBuilder withEnabled(Boolean enabled){
+        this.groupDTO.setEnabled(enabled);
+        return this;
+    }
+
+    public GroupDTOBuilder withReadOnly(Boolean readOnly){
+        this.groupDTO.setReadOnly(readOnly);
+        return this;
+    }
+
+    public GroupDTOBuilder withRuleCount(Integer ruleCount){
+        this.groupDTO.setRuleCount(ruleCount);
+        return this;
+    }
+
+    public GroupDTO build() {
+        return groupDTO;
+    }
+}

--- a/features/flows/rest/api/src/main/java/org/opennms/netmgt/flows/rest/classification/GroupDTOBuilder.java
+++ b/features/flows/rest/api/src/main/java/org/opennms/netmgt/flows/rest/classification/GroupDTOBuilder.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2018-2018 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2018 The OpenNMS Group, Inc.
+ * Copyright (C) 2019-2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *

--- a/features/flows/rest/api/src/main/java/org/opennms/netmgt/flows/rest/classification/RuleDTOBuilder.java
+++ b/features/flows/rest/api/src/main/java/org/opennms/netmgt/flows/rest/classification/RuleDTOBuilder.java
@@ -76,6 +76,11 @@ public class RuleDTOBuilder {
         return this;
     }
 
+    public RuleDTOBuilder withGroup(GroupDTO group) {
+        this.ruleDTO.setGroup(group);
+        return this;
+    }
+
     public RuleDTO build() {
         return ruleDTO;
     }

--- a/features/flows/rest/impl/src/main/java/org/opennms/netmgt/flows/rest/internal/classification/ClassificationRestServiceImpl.java
+++ b/features/flows/rest/impl/src/main/java/org/opennms/netmgt/flows/rest/internal/classification/ClassificationRestServiceImpl.java
@@ -269,7 +269,13 @@ public class ClassificationRestServiceImpl implements ClassificationRestService 
     public Response saveGroup(GroupDTO groupDTO) {
         final Group group = convert(groupDTO);
         group.setId(null);
-
+        if(classificationService.countMatchingGroups(new CriteriaBuilder(Group.class)
+                .eq("name", group.getName()).toCriteria()) > 0){
+            return Response
+                    .status(Response.Status.BAD_REQUEST)
+                    .entity(String.format("{ context: 'name', message: 'A group with name \"%s\" already exists' }", group.getName()))
+                            .build();
+        }
         final int groupId = classificationService.saveGroup(group);
         final UriBuilder builder = UriBuilder.fromResource(ClassificationRestService.class);
         final URI uri = builder.path(ClassificationRestService.class, "getGroup").build(groupId);

--- a/features/flows/rest/impl/src/main/java/org/opennms/netmgt/flows/rest/internal/classification/ClassificationRestServiceImpl.java
+++ b/features/flows/rest/impl/src/main/java/org/opennms/netmgt/flows/rest/internal/classification/ClassificationRestServiceImpl.java
@@ -266,6 +266,17 @@ public class ClassificationRestServiceImpl implements ClassificationRestService 
     }
 
     @Override
+    public Response saveGroup(GroupDTO groupDTO) {
+        final Group group = convert(groupDTO);
+        group.setId(null);
+
+        final int groupId = classificationService.saveGroup(group);
+        final UriBuilder builder = UriBuilder.fromResource(ClassificationRestService.class);
+        final URI uri = builder.path(ClassificationRestService.class, "getGroup").build(groupId);
+        return Response.created(uri).build();
+    }
+
+    @Override
     public Response deleteGroup(int groupId) {
         classificationService.deleteGroup(groupId);
         return Response.noContent().build();

--- a/smoke-test/src/test/java/org/opennms/smoketest/flow/ClassificationRestIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/flow/ClassificationRestIT.java
@@ -176,8 +176,6 @@ public class ClassificationRestIT {
 
     @Test
     public void verifyChangeGroupOfRule() {
-        // Verify GET Groups (system-defined and user-defined rules should be there)
-        given().get("/groups").then().assertThat().statusCode(200).body("", hasSize(2));
 
         // POST (create) two groups
         final GroupDTO group3 = saveAndRetrieveGroup(new GroupDTOBuilder().withName("group3").withDescription("another user defined group with name group3")


### PR DESCRIPTION
* Jira: https://issues.opennms.org/browse/NMS-12212

# Test Instructions:
* Manually add new rule group into database, e.g. `INSERT INTO classification_groups ("id","name", "description", "readonly", "enabled", "priority") VALUES ('5','group5', 'another user defined group', false, true, 40);`
* group should show up in ui
* add rule
* edit rule and select different group: rule should be moved to different group. Positions in both group should have been rearranged
