### PR TITLE
NMS-12157: Update the Netty resolver to use a cache based on Caffeine

### DIFF
--- a/container/features/src/main/resources/features.xml
+++ b/container/features/src/main/resources/features.xml
@@ -1472,6 +1472,7 @@
         <feature>opennms-events-api</feature>
         <feature>opennms-model</feature>
 
+        <bundle dependency="true">mvn:org.opennms.core.health/org.opennms.core.health.api/${project.version}</bundle>
         <bundle dependency="true">mvn:com.github.ben-manes.caffeine/caffeine/${caffeineVersion}</bundle>
         <bundle>mvn:org.opennms.features.dnsresolver/org.opennms.features.dnsresolver.netty/${project.version}</bundle>
     </feature>

--- a/container/features/src/main/resources/features.xml
+++ b/container/features/src/main/resources/features.xml
@@ -1466,6 +1466,7 @@
         <feature>opennms-events-api</feature>
         <feature>opennms-model</feature>
 
+        <bundle dependency="true">mvn:com.github.ben-manes.caffeine/caffeine/${caffeineVersion}</bundle>
         <bundle>mvn:org.opennms.features.dnsresolver/org.opennms.features.dnsresolver.netty/${project.version}</bundle>
     </feature>
 

--- a/container/features/src/main/resources/features.xml
+++ b/container/features/src/main/resources/features.xml
@@ -1483,6 +1483,7 @@
         <bundle>mvn:io.vavr/vavr-match/0.10.0</bundle>
         <bundle>mvn:io.github.resilience4j/resilience4j-core/${resilience4jVersion}</bundle>
         <bundle>mvn:io.github.resilience4j/resilience4j-circuitbreaker/${resilience4jVersion}</bundle>
+        <bundle>mvn:io.github.resilience4j/resilience4j-bulkhead/${resilience4jVersion}</bundle>
     </feature>
 
     <feature name="netty4" version="${netty4Version}" description="Netty">

--- a/features/dnsresolver/netty/pom.xml
+++ b/features/dnsresolver/netty/pom.xml
@@ -73,6 +73,11 @@
             <version>${resilience4jVersion}</version>
         </dependency>
         <dependency>
+            <groupId>io.github.resilience4j</groupId>
+            <artifactId>resilience4j-bulkhead</artifactId>
+            <version>${resilience4jVersion}</version>
+        </dependency>
+        <dependency>
             <groupId>org.opennms</groupId>
             <artifactId>opennms-model</artifactId>
         </dependency>

--- a/features/dnsresolver/netty/pom.xml
+++ b/features/dnsresolver/netty/pom.xml
@@ -79,6 +79,10 @@
             <groupId>org.opennms.features.events</groupId>
             <artifactId>org.opennms.features.events.api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+        </dependency>
 
         <!-- Test -->
         <dependency>

--- a/features/dnsresolver/netty/pom.xml
+++ b/features/dnsresolver/netty/pom.xml
@@ -35,6 +35,11 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.opennms.core.health</groupId>
+            <artifactId>org.opennms.core.health.api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>

--- a/features/dnsresolver/netty/src/main/java/org/opennms/netmgt/dnsresolver/netty/CaffeineCache.java
+++ b/features/dnsresolver/netty/src/main/java/org/opennms/netmgt/dnsresolver/netty/CaffeineCache.java
@@ -1,0 +1,138 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.dnsresolver.netty;
+
+import java.util.Collection;
+import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.concurrent.TimeUnit;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.Expiry;
+import com.github.benmanes.caffeine.cache.stats.CacheStats;
+
+/**
+ * Underlying cache used to back the {@link CaffeineDnsCache}.
+ *
+ * Uses the Caffeine caching library as opposed to Netty's io.netty.resolver.dns.Cache implementation so that we can:
+ *  1) Limit the cache's size (and intelligently evict entries)
+ *  2) Expose cache stats
+ *
+ * @author jwhite
+ */
+public abstract class CaffeineCache<E> {
+
+    private final Cache<String, Entries<E>> cache;
+
+    /**
+     * Returns {@code true} if this entry should replace all other entries that are already cached for the hostname.
+     */
+    protected abstract boolean shouldReplaceAll(E entry);
+
+    public CaffeineCache(long maxSize) {
+        final Caffeine<String, Entries> caffeine = Caffeine.newBuilder()
+                .expireAfter(new Expiry<String, Entries>() {
+                    @Override
+                    public long expireAfterCreate(String key, Entries value, long currentTime) {
+                        // Use the TTL of the first entry added for the key as the expiry time
+                        return TimeUnit.SECONDS.toNanos(value.ttl());
+                    }
+
+                    @Override
+                    public long expireAfterUpdate(String key, Entries value, long currentTime, long currentDuration) {
+                        // Don't expire after update
+                        return currentDuration;
+                    }
+
+                    @Override
+                    public long expireAfterRead(String key, Entries value, long currentTime, long currentDuration) {
+                        // Don't expire after read
+                        return currentDuration;
+                    }
+                })
+                .recordStats();
+        if (maxSize > 0) {
+            // Apply a size limit, if set
+            caffeine.maximumSize(maxSize);
+        }
+        cache = caffeine.build();
+    }
+
+    public void clear() {
+        cache.invalidateAll();
+    }
+
+    public void clear(String key) {
+        cache.invalidate(key);
+    }
+
+    public Collection<E> get(String key) {
+        final Entries<E> entries = cache.getIfPresent(key);
+        if (entries == null) {
+            return null;
+        }
+        return entries.get();
+    }
+
+    public void cache(String key, E entry, int ttl) {
+        cache.get(key, k -> new Entries<>(ttl)).add(entry, shouldReplaceAll(entry));
+    }
+
+    public long size() {
+        return cache.estimatedSize();
+    }
+
+    public CacheStats stats() {
+        return cache.stats();
+    }
+
+    private static class Entries<E> {
+        private final int ttl;
+        private final CopyOnWriteArraySet<E> container = new CopyOnWriteArraySet<>();
+
+        public Entries(int ttl) {
+            this.ttl = ttl;
+        }
+
+        public int ttl() {
+            return ttl;
+        }
+
+        public void add(E entry, boolean shouldReplaceAll) {
+            if (shouldReplaceAll) {
+                container.clear();
+            }
+            container.add(entry);
+        }
+
+        public Collection<E> get() {
+            return container;
+        }
+    }
+}

--- a/features/dnsresolver/netty/src/main/java/org/opennms/netmgt/dnsresolver/netty/CaffeineDnsCache.java
+++ b/features/dnsresolver/netty/src/main/java/org/opennms/netmgt/dnsresolver/netty/CaffeineDnsCache.java
@@ -1,0 +1,370 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+/*
+ * Copyright 2016 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package org.opennms.netmgt.dnsresolver.netty;
+
+import static io.netty.util.internal.ObjectUtil.checkNotNull;
+import static io.netty.util.internal.ObjectUtil.checkPositiveOrZero;
+
+import java.net.InetAddress;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.Metric;
+import com.codahale.metrics.MetricRegistry;
+import com.google.common.base.MoreObjects;
+
+import io.netty.channel.EventLoop;
+import io.netty.handler.codec.dns.DnsPtrRecord;
+import io.netty.handler.codec.dns.DnsRecord;
+import io.netty.resolver.dns.DnsCache;
+import io.netty.resolver.dns.DnsCacheEntry;
+import io.netty.util.internal.StringUtil;
+
+/**
+ * DNS cache implementation largely copied from Netty's
+ *   https://github.com/netty/netty/blob/netty-4.1.38.Final/resolver-dns/src/main/java/io/netty/resolver/dns/DefaultDnsCache.java
+ * but adapted slightly to work with our {@link CaffeineCache}.
+ */
+public class CaffeineDnsCache implements ExtendedDnsCache {
+
+    protected static final int MAX_SUPPORTED_TTL_SECS = (int) TimeUnit.DAYS.toSeconds(365 * 2);
+    protected static final int DEFAULT_NEGATIVE_TTL_SECS = (int) TimeUnit.MINUTES.toSeconds(5);
+    protected static final int DEFAULT_MAX_SIZE = 10000;
+
+    private final CaffeineCache<ExtendedDnsCacheEntry> resolveCache;
+
+    private final int minTtl;
+    private final int maxTtl;
+    private final int negativeTtl;
+    private final long maxSize;
+
+    // Track hits and misses ourselves since the underlying cache doesn't expose these
+    private final Meter cacheHits = new Meter();
+    private final Meter cacheMisses = new Meter();
+
+    /**
+     * Create a cache that respects the TTL returned by the DNS server
+     * and doesn't cache negative responses.
+     */
+    public CaffeineDnsCache() {
+        this(0, MAX_SUPPORTED_TTL_SECS, DEFAULT_NEGATIVE_TTL_SECS, DEFAULT_MAX_SIZE);
+    }
+
+    /**
+     * Create a cache.
+     * @param minTtl the minimum TTL
+     * @param maxTtl the maximum TTL
+     * @param negativeTtl the TTL for failed queries
+     */
+    public CaffeineDnsCache(int minTtl, int maxTtl, int negativeTtl, long maxSize) {
+        this.minTtl = Math.min(MAX_SUPPORTED_TTL_SECS, checkPositiveOrZero(minTtl, "minTtl"));
+        this.maxTtl = Math.min(MAX_SUPPORTED_TTL_SECS, checkPositiveOrZero(maxTtl, "maxTtl"));
+        if (minTtl > maxTtl) {
+            throw new IllegalArgumentException(
+                    "minTtl: " + minTtl + ", maxTtl: " + maxTtl + " (expected: 0 <= minTtl <= maxTtl)");
+        }
+        this.negativeTtl = checkPositiveOrZero(negativeTtl, "negativeTtl");
+        this.maxSize = checkPositiveOrZero(maxSize, "maxSize");
+
+        resolveCache = new CaffeineCache<ExtendedDnsCacheEntry>(maxSize) {
+            @Override
+            protected boolean shouldReplaceAll(ExtendedDnsCacheEntry entry) {
+                return entry.cause() != null;
+            }
+        };
+    }
+
+    /**
+     * Returns the minimum TTL of the cached DNS resource records (in seconds).
+     *
+     * @see #maxTtl()
+     */
+    public int minTtl() {
+        return minTtl;
+    }
+
+    /**
+     * Returns the maximum TTL of the cached DNS resource records (in seconds).
+     *
+     * @see #minTtl()
+     */
+    public int maxTtl() {
+        return maxTtl;
+    }
+
+    /**
+     * Returns the TTL of the cache for the failed DNS queries (in seconds). The default value is {@code 0}, which
+     * disables the cache for negative results.
+     */
+    public int negativeTtl() {
+        return negativeTtl;
+    }
+
+    /**
+     * Returns the maximum number of elements allows in the cache.
+     */
+    public long maxSize() {
+        return maxSize;
+    }
+
+    @Override
+    public void clear() {
+        resolveCache.clear();
+    }
+
+    @Override
+    public boolean clear(String hostname) {
+        checkNotNull(hostname, "hostname");
+        resolveCache.clear(appendDot(hostname));
+        // The backing cache doesn't provide a return value for whether or not
+        // the value was actually removed, so we always return false
+        return false;
+    }
+
+    @Override
+    public List<? extends DnsCacheEntry> get(String hostname, DnsRecord[] additionals) {
+        checkNotNull(hostname, "hostname");
+        if (!emptyAdditionals(additionals)) {
+            return Collections.<DnsCacheEntry>emptyList();
+        }
+        final Collection<? extends  DnsCacheEntry> cachedEntries = resolveCache.get(appendDot(hostname));
+        if (cachedEntries == null) {
+            cacheMisses.mark();
+            return null;
+        }
+        cacheHits.mark();
+        // Convert collection to a list
+        return new LinkedList<>(cachedEntries);
+    }
+
+    /**
+     * Positive caching for normal lookups.
+     */
+    @Override
+    public DnsCacheEntry cache(String hostname, DnsRecord[] additionals,
+                               InetAddress address, long originalTtl, EventLoop loop) {
+        checkNotNull(hostname, "hostname");
+        checkNotNull(address, "address");
+        checkNotNull(loop, "loop");
+        DefaultExtendedDnsCacheEntry e = new DefaultExtendedDnsCacheEntry(hostname, address);
+        if (maxTtl == 0 || !emptyAdditionals(additionals)) {
+            return e;
+        }
+        resolveCache.cache(appendDot(hostname), e, Math.max(minTtl, (int) Math.min(maxTtl, originalTtl)));
+        return e;
+    }
+
+    /**
+     * Positive caching for reverse lookups.
+     */
+    @Override
+    public ExtendedDnsCacheEntry cache(String hostname, DnsPtrRecord ptrRecord, EventLoop loop) {
+        checkNotNull(hostname, "hostname");
+        checkNotNull(ptrRecord, "ptrRecord");
+        checkNotNull(loop, "loop");
+        DefaultExtendedDnsCacheEntry e = new DefaultExtendedDnsCacheEntry(hostname, ptrRecord);
+        if (maxTtl == 0) {
+            return e;
+        }
+        resolveCache.cache(appendDot(hostname), e, Math.max(minTtl, (int) Math.min(maxTtl, ptrRecord.timeToLive())));
+        return e;
+    }
+
+    /**
+     * Negative caching for failures (or empty reverse lookups).
+     */
+    @Override
+    public DnsCacheEntry cache(String hostname, DnsRecord[] additionals, Throwable cause, EventLoop loop) {
+        checkNotNull(hostname, "hostname");
+        checkNotNull(cause, "cause");
+        checkNotNull(loop, "loop");
+
+        DefaultExtendedDnsCacheEntry e = new DefaultExtendedDnsCacheEntry(hostname, cause);
+        if (negativeTtl == 0 || !emptyAdditionals(additionals)) {
+            return e;
+        }
+
+        resolveCache.cache(appendDot(hostname), e, negativeTtl);
+        return e;
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(getClass())
+                .add("minTtl", minTtl)
+                .add("maxTtl", maxTtl)
+                .add("negativeTtl", negativeTtl)
+                .add("cached resolved hostname=", resolveCache.size())
+                .toString();
+    }
+
+    public long getSize() {
+        return resolveCache.size();
+    }
+
+    private enum CacheMetric {
+        SIZE("cacheSize", c -> (Gauge<Long>) c.resolveCache::size),
+        MAX_SIZE("cacheMaxSize", c -> (Gauge<Long>) c::maxSize),
+        EVICTION_COUNT("cacheEvictionCount", c -> (Gauge<Long>) c.resolveCache.stats()::evictionCount),
+        HITS("cacheHits", c -> c.cacheHits),
+        MISSES("cacheMisses", c -> c.cacheMisses);
+
+        String name;
+        Function<CaffeineDnsCache, Metric> metricSupplier;
+
+        CacheMetric(String name, Function<CaffeineDnsCache, Metric> metricSupplier) {
+            this.name = Objects.requireNonNull(name);
+            this.metricSupplier = Objects.requireNonNull(metricSupplier);
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public Metric getMetric(CaffeineDnsCache cache) {
+            return metricSupplier.apply(cache);
+        }
+    }
+
+    public void registerMetrics(MetricRegistry metrics) {
+        for (CacheMetric cm : CacheMetric.values()) {
+            metrics.register(cm.getName(), cm.getMetric(this));
+        }
+    }
+
+    public void unregisterMetrics(MetricRegistry metrics) {
+        for (CacheMetric cm : CacheMetric.values()) {
+            metrics.remove(cm.getName());
+        }
+    }
+
+    private static final class DefaultExtendedDnsCacheEntry implements ExtendedDnsCacheEntry {
+        private final String hostname;
+        private final String hostnameFromPtrRecord;
+        private final InetAddress address;
+        private final Throwable cause;
+
+        DefaultExtendedDnsCacheEntry(String hostname, InetAddress address) {
+            this.hostname = hostname;
+            this.address = address;
+            cause = null;
+            hostnameFromPtrRecord = null;
+        }
+
+        DefaultExtendedDnsCacheEntry(String hostname, Throwable cause) {
+            this.hostname = hostname;
+            this.cause = cause;
+            address = null;
+            hostnameFromPtrRecord = null;
+        }
+
+        public DefaultExtendedDnsCacheEntry(String hostname, DnsPtrRecord ptrRecord) {
+            this.hostname = hostname;
+            this.hostnameFromPtrRecord = ptrRecord.hostname();
+            address = null;
+            cause = null;
+        }
+
+        @Override
+        public InetAddress address() {
+            return address;
+        }
+
+        @Override
+        public Throwable cause() {
+            return cause;
+        }
+
+        String hostname() {
+            return hostname;
+        }
+
+        @Override
+        public String hostnameFromPtrRecord() {
+            return hostnameFromPtrRecord;
+        }
+
+        @Override
+        public String toString() {
+            if (cause != null) {
+                return hostname + '/' + cause;
+            } else if (hostnameFromPtrRecord != null) {
+                return hostname + '/' + hostnameFromPtrRecord;
+            } else {
+                return hostname + '/' + address;
+            }
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof DefaultExtendedDnsCacheEntry)) return false;
+            DefaultExtendedDnsCacheEntry that = (DefaultExtendedDnsCacheEntry) o;
+            return Objects.equals(hostname, that.hostname) &&
+                    Objects.equals(hostnameFromPtrRecord, that.hostnameFromPtrRecord) &&
+                    Objects.equals(address, that.address) &&
+                    Objects.equals(cause, that.cause);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(hostname, hostnameFromPtrRecord, address, cause);
+        }
+    }
+
+    private static boolean emptyAdditionals(DnsRecord[] additionals) {
+        return additionals == null || additionals.length == 0;
+    }
+
+    private static String appendDot(String hostname) {
+        return StringUtil.endsWith(hostname, '.') ? hostname : hostname + '.';
+    }
+}

--- a/features/dnsresolver/netty/src/main/java/org/opennms/netmgt/dnsresolver/netty/ExtendedDnsCache.java
+++ b/features/dnsresolver/netty/src/main/java/org/opennms/netmgt/dnsresolver/netty/ExtendedDnsCache.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.dnsresolver.netty;
+
+import io.netty.channel.EventLoop;
+import io.netty.handler.codec.dns.DnsPtrRecord;
+import io.netty.resolver.dns.DnsCache;
+
+public interface ExtendedDnsCache extends DnsCache {
+
+    ExtendedDnsCacheEntry cache(String hostname, DnsPtrRecord ptrRecord, EventLoop loop);
+
+}

--- a/features/dnsresolver/netty/src/main/java/org/opennms/netmgt/dnsresolver/netty/ExtendedDnsCache.java
+++ b/features/dnsresolver/netty/src/main/java/org/opennms/netmgt/dnsresolver/netty/ExtendedDnsCache.java
@@ -32,6 +32,10 @@ import io.netty.channel.EventLoop;
 import io.netty.handler.codec.dns.DnsPtrRecord;
 import io.netty.resolver.dns.DnsCache;
 
+/**
+ * An extended {@link DnsCache} with support for storing PTR records
+ * from reverse lookups.
+ */
 public interface ExtendedDnsCache extends DnsCache {
 
     ExtendedDnsCacheEntry cache(String hostname, DnsPtrRecord ptrRecord, EventLoop loop);

--- a/features/dnsresolver/netty/src/main/java/org/opennms/netmgt/dnsresolver/netty/ExtendedDnsCacheEntry.java
+++ b/features/dnsresolver/netty/src/main/java/org/opennms/netmgt/dnsresolver/netty/ExtendedDnsCacheEntry.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.dnsresolver.netty;
+
+import io.netty.resolver.dns.DnsCacheEntry;
+
+public interface ExtendedDnsCacheEntry extends DnsCacheEntry {
+
+    /**
+     * Hostname from the PTR record, or null if none is available.
+     */
+    String hostnameFromPtrRecord();
+
+}

--- a/features/dnsresolver/netty/src/main/java/org/opennms/netmgt/dnsresolver/netty/NettyDnsHealthCheck.java
+++ b/features/dnsresolver/netty/src/main/java/org/opennms/netmgt/dnsresolver/netty/NettyDnsHealthCheck.java
@@ -1,0 +1,84 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.dnsresolver.netty;
+
+import java.net.InetAddress;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.opennms.core.health.api.Context;
+import org.opennms.core.health.api.HealthCheck;
+import org.opennms.core.health.api.Response;
+import org.opennms.core.health.api.Status;
+import org.opennms.core.utils.InetAddressUtils;
+
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+
+public class NettyDnsHealthCheck implements HealthCheck {
+
+    private final NettyDnsResolver dnsResolver;
+
+    public NettyDnsHealthCheck(NettyDnsResolver dnsResolver) {
+        this.dnsResolver = Objects.requireNonNull(dnsResolver);
+    }
+
+    @Override
+    public String getDescription() {
+        return "DNS Lookups (Netty)";
+    }
+
+    @Override
+    public Response perform(Context context) throws InterruptedException, ExecutionException, TimeoutException {
+        final String hostnameToLookup = "www.opennms.com";
+        final InetAddress ipAddressToReverseLookup = InetAddressUtils.getInetAddress("1.1.1.1");
+
+        final CircuitBreaker.State cbState = dnsResolver.getCircuitBreaker().getState();
+        if (!CircuitBreaker.State.CLOSED.equals(cbState)) {
+            return new Response(Status.Failure, "Expected circuit breaker to be CLOSED, but was: " + cbState);
+        }
+
+        final Optional<InetAddress> addr = dnsResolver.lookup(hostnameToLookup)
+                .get(context.getTimeout(), TimeUnit.SECONDS);
+        if (!addr.isPresent()) {
+            return new Response(Status.Failure, String.format("Lookup failed for '%s'. No A or AAAA records.", hostnameToLookup));
+        }
+
+        final Optional<String> hostname = dnsResolver.reverseLookup(ipAddressToReverseLookup)
+                .get(context.getTimeout(), TimeUnit.SECONDS);
+        if (!hostname.isPresent()) {
+            return new Response(Status.Failure, String.format("Reverse failed for '%s'. No PTR record.", ipAddressToReverseLookup));
+        }
+
+        return new Response(Status.Success, String.format("%s -> %s (cache %d/%d)", hostnameToLookup, addr.get().getHostAddress(),
+                dnsResolver.getCache().getSize(), dnsResolver.getMaxCacheSize()));
+    }
+}

--- a/features/dnsresolver/netty/src/main/java/org/opennms/netmgt/dnsresolver/netty/NettyDnsHealthCheck.java
+++ b/features/dnsresolver/netty/src/main/java/org/opennms/netmgt/dnsresolver/netty/NettyDnsHealthCheck.java
@@ -78,7 +78,7 @@ public class NettyDnsHealthCheck implements HealthCheck {
             return new Response(Status.Failure, String.format("Reverse failed for '%s'. No PTR record.", ipAddressToReverseLookup));
         }
 
-        return new Response(Status.Success, String.format("%s -> %s (cache %d/%d)", hostnameToLookup, addr.get().getHostAddress(),
+        return new Response(Status.Success, String.format("%s is at %s (cache %d/%d)", hostnameToLookup, addr.get().getHostAddress(),
                 dnsResolver.getCache().getSize(), dnsResolver.getMaxCacheSize()));
     }
 }

--- a/features/dnsresolver/netty/src/main/java/org/opennms/netmgt/dnsresolver/netty/NettyResolverContext.java
+++ b/features/dnsresolver/netty/src/main/java/org/opennms/netmgt/dnsresolver/netty/NettyResolverContext.java
@@ -31,6 +31,7 @@ package org.opennms.netmgt.dnsresolver.netty;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -54,6 +55,7 @@ import io.netty.handler.codec.dns.DnsResponse;
 import io.netty.handler.codec.dns.DnsResponseCode;
 import io.netty.handler.codec.dns.DnsSection;
 import io.netty.resolver.dns.DnsCache;
+import io.netty.resolver.dns.DnsCacheEntry;
 import io.netty.resolver.dns.DnsNameResolver;
 import io.netty.resolver.dns.DnsNameResolverBuilder;
 import io.netty.resolver.dns.DnsNameResolverTimeoutException;
@@ -69,13 +71,13 @@ import io.netty.util.concurrent.Future;
 public class NettyResolverContext implements DnsResolver {
 
     private final NettyDnsResolver parent;
-    private final DnsCache cache;
+    private final ExtendedDnsCache cache;
     private final int idx;
 
     private EventLoopGroup group;
     private DnsNameResolver resolver;
 
-    public NettyResolverContext(NettyDnsResolver parent, DnsCache cache, int idx) {
+    public NettyResolverContext(NettyDnsResolver parent, ExtendedDnsCache cache, int idx) {
         this.parent = Objects.requireNonNull(parent);
         this.cache = Objects.requireNonNull(cache);
         this.idx = idx;
@@ -145,25 +147,53 @@ public class NettyResolverContext implements DnsResolver {
     public CompletableFuture<Optional<String>> reverseLookup(InetAddress inetAddress) {
         final CompletableFuture<Optional<String>> future = new CompletableFuture<>();
         final String name = ReverseMap.fromAddress(inetAddress).toString();
+
+        // Netty does not perform caching when we query directly for DNS questions i.e. PTR requests
+        // so we perform the caching logic ourselves
+        final List<? extends DnsCacheEntry> entries = cache.get(name, null);
+        if (entries != null) {
+            // We've got a hit, so we have some cached result for this entry
+            // Try and find a hostname, or return an empty optional if none was found
+            final Optional<String> cachedHostname = entries.stream()
+                    .filter(e -> e instanceof ExtendedDnsCacheEntry)
+                    .map(e -> ((ExtendedDnsCacheEntry)e).hostnameFromPtrRecord())
+                    .filter(Objects::nonNull)
+                    .findFirst();
+            if (cachedHostname.isPresent()) {
+                // We found a cached hostname
+                return CompletableFuture.completedFuture(Optional.of(removeTrailingDot(cachedHostname.get())));
+            } else {
+                // No hostname found return an empty result
+                return CompletableFuture.completedFuture(Optional.empty());
+            }
+        }
+
         final Future<AddressedEnvelope<DnsResponse, InetSocketAddress>> requestFuture = resolver.query(new DefaultDnsQuestion(name, DnsRecordType.PTR, DnsRecord.CLASS_IN));
         requestFuture.addListener(responseFuture -> {
             try {
                 final AddressedEnvelope<DnsResponse, InetSocketAddress> envelope = (AddressedEnvelope<DnsResponse, InetSocketAddress>) responseFuture.get();
                 final DnsResponse response = envelope.content();
                 if (response.code() != DnsResponseCode.NOERROR) {
+                    // Cache the failure (will only be cached if negative-ttl is > 0)
+                    cache.cache(name, null, new Exception("Request failed with response code: " + response.code()), group.next());
                     future.complete(Optional.empty());
                     return;
                 }
 
                 final DnsPtrRecord ptrRecord = envelope.content().recordAt(DnsSection.ANSWER);
                 if (ptrRecord == null) {
+                    // Cache the failure (will only be cached if negative-ttl is > 0)
+                    cache.cache(name, null, new Exception("No PTR record found."), group.next());
                     future.complete(Optional.empty());
                     return;
                 }
 
+                // Cache the result
+                cache.cache(name, ptrRecord, group.next());
+
                 final String hostname = ptrRecord.hostname();
                 // Strip of the trailing dot
-                final String trimmedHostname = hostname.substring(0, hostname.length() - 1);
+                final String trimmedHostname = removeTrailingDot(hostname);
                 future.complete(Optional.of(trimmedHostname));
             } catch (InterruptedException e) {
                 future.completeExceptionally(e);
@@ -177,5 +207,9 @@ public class NettyResolverContext implements DnsResolver {
             }
         });
         return future;
+    }
+
+    private static String removeTrailingDot(String hostname) {
+        return hostname.substring(0, hostname.length() - 1);
     }
 }

--- a/features/dnsresolver/netty/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/features/dnsresolver/netty/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -18,6 +18,7 @@
             <cm:property name="min-ttl-seconds" value="60" />
             <cm:property name="max-ttl-seconds" value="-1" />
             <cm:property name="negative-ttl-seconds" value="300" />
+            <cm:property name="max-cache-size" value="10000" />
         </cm:default-properties>
     </cm:property-placeholder>
 
@@ -51,7 +52,7 @@
         <property name="minTtlSeconds" value="${min-ttl-seconds}"/>
         <property name="maxTtlSeconds" value="${min-ttl-seconds}"/>
         <property name="negativeTtlSeconds" value="${negative-ttl-seconds}"/>
-
+        <property name="maxCacheSize" value="${max-cache-size}"/>
     </bean>
 
     <service ref="dnsResolver" interface="org.opennms.netmgt.dnsresolver.api.DnsResolver">

--- a/features/dnsresolver/netty/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/features/dnsresolver/netty/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -78,10 +78,12 @@
         </service-properties>
     </service>
 
-    <!-- Health check -->
+    <!-- We have a health check available but don't expose it currently since
+         it does not currently return a healthy status when ran on CI
     <service interface="org.opennms.core.health.api.HealthCheck">
         <bean class=" org.opennms.netmgt.dnsresolver.netty.NettyDnsHealthCheck" >
             <argument ref="dnsResolver"/>
         </bean>
     </service>
+    -->
 </blueprint>

--- a/features/dnsresolver/netty/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/features/dnsresolver/netty/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -26,6 +26,9 @@
             <cm:property name="breaker-wait-duration-in-open-state" value="15" />
             <cm:property name="breaker-ring-buffer-size-in-half-open-state" value="10" />
             <cm:property name="breaker-ring-buffer-size-in-closed-state" value="100" />
+            <!-- Bulkhead Settings -->
+            <cm:property name="bulkhead-max-concurrent-calls" value="1000" />
+            <cm:property name="bulkhead-max-wait-duration-millis" value="5100" /> <!-- query-timeout-millis + 100ms -->
         </cm:default-properties>
     </cm:property-placeholder>
 
@@ -65,6 +68,8 @@
         <property name="breakerWaitDurationInOpenState" value="${breaker-wait-duration-in-open-state}"/>
         <property name="breakerRingBufferSizeInHalfOpenState" value="${breaker-ring-buffer-size-in-half-open-state}"/>
         <property name="breakerRingBufferSizeInClosedState" value="${breaker-ring-buffer-size-in-closed-state}"/>
+        <property name="bulkheadMaxConcurrentCalls" value="${bulkhead-max-concurrent-calls}"/>
+        <property name="bulkheadMaxWaitDurationMillis" value="${bulkhead-max-wait-duration-millis}"/>
     </bean>
 
     <service ref="dnsResolver" interface="org.opennms.netmgt.dnsresolver.api.DnsResolver">

--- a/features/dnsresolver/netty/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/features/dnsresolver/netty/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -72,4 +72,11 @@
             <entry key="registration.export" value="true" />
         </service-properties>
     </service>
+
+    <!-- Health check -->
+    <service interface="org.opennms.core.health.api.HealthCheck">
+        <bean class=" org.opennms.netmgt.dnsresolver.netty.NettyDnsHealthCheck" >
+            <argument ref="dnsResolver"/>
+        </bean>
+    </service>
 </blueprint>

--- a/features/dnsresolver/netty/src/test/java/org/opennms/netmgt/dnsresolver/netty/CaffeineDnsCacheTest.java
+++ b/features/dnsresolver/netty/src/test/java/org/opennms/netmgt/dnsresolver/netty/CaffeineDnsCacheTest.java
@@ -1,0 +1,232 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+/*
+ * Copyright 2018 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package org.opennms.netmgt.dnsresolver.netty;
+
+import io.netty.channel.DefaultEventLoopGroup;
+import io.netty.channel.EventLoop;
+import io.netty.channel.EventLoopGroup;
+
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.resolver.dns.DnsCacheEntry;
+import io.netty.util.NetUtil;
+import org.junit.Test;
+
+import java.net.InetAddress;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+
+/**
+ * DNS cache test largely adopted from https://github.com/netty/netty/blob/netty-4.1.38.Final/resolver-dns/src/test/java/io/netty/resolver/dns/DefaultDnsCacheTest.java
+ */
+public class CaffeineDnsCacheTest {
+
+    @Test
+    public void testExpire() throws Throwable {
+        InetAddress addr1 = InetAddress.getByAddress(new byte[] { 10, 0, 0, 1 });
+        InetAddress addr2 = InetAddress.getByAddress(new byte[] { 10, 0, 0, 2 });
+        EventLoopGroup group = new DefaultEventLoopGroup(1);
+
+        try {
+            EventLoop loop = group.next();
+            final CaffeineDnsCache cache = new CaffeineDnsCache();
+            cache.cache("netty.io", null, addr1, 1, loop);
+            cache.cache("netty.io", null, addr2, 10000, loop);
+
+            Throwable error = loop.schedule(new Callable<Throwable>() {
+                @Override
+                public Throwable call() {
+                    try {
+                        assertNull(cache.get("netty.io", null));
+                        return null;
+                    } catch (Throwable cause) {
+                        return cause;
+                    }
+                }
+            }, 1, TimeUnit.SECONDS).get();
+            if (error != null) {
+                throw error;
+            }
+        } finally {
+            group.shutdownGracefully();
+        }
+    }
+
+    @Test
+    public void testExpireWithDifferentTTLs() {
+        testExpireWithTTL0(1);
+        testExpireWithTTL0(1000);
+        testExpireWithTTL0(1000000);
+    }
+
+    private static void testExpireWithTTL0(int days) {
+        EventLoopGroup group = new NioEventLoopGroup(1);
+
+        try {
+            EventLoop loop = group.next();
+            final CaffeineDnsCache cache = new CaffeineDnsCache();
+            assertNotNull(cache.cache("netty.io", null, NetUtil.LOCALHOST, days, loop));
+        } finally {
+            group.shutdownGracefully();
+        }
+    }
+
+    @Test
+    public void testExpireWithToBigMinTTL() {
+        EventLoopGroup group = new NioEventLoopGroup(1);
+
+        try {
+            EventLoop loop = group.next();
+            final CaffeineDnsCache cache = new CaffeineDnsCache(Integer.MAX_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE, 0);
+            assertNotNull(cache.cache("netty.io", null, NetUtil.LOCALHOST, 100, loop));
+        } finally {
+            group.shutdownGracefully();
+        }
+    }
+
+    @Test
+    public void testAddMultipleAddressesForSameHostname() throws Exception {
+        InetAddress addr1 = InetAddress.getByAddress(new byte[] { 10, 0, 0, 1 });
+        InetAddress addr2 = InetAddress.getByAddress(new byte[] { 10, 0, 0, 2 });
+        EventLoopGroup group = new DefaultEventLoopGroup(1);
+
+        try {
+            EventLoop loop = group.next();
+            final CaffeineDnsCache cache = new CaffeineDnsCache();
+            cache.cache("netty.io", null, addr1, 10000, loop);
+            cache.cache("netty.io", null, addr2, 10000, loop);
+
+            List<? extends DnsCacheEntry> entries = cache.get("netty.io", null);
+            assertEquals(2, entries.size());
+            assertEntry(entries.get(0), addr1);
+            assertEntry(entries.get(1), addr2);
+        } finally {
+            group.shutdownGracefully();
+        }
+    }
+
+    @Test
+    public void testAddSameAddressForSameHostname() throws Exception {
+        InetAddress addr1 = InetAddress.getByAddress(new byte[] { 10, 0, 0, 1 });
+        EventLoopGroup group = new DefaultEventLoopGroup(1);
+
+        try {
+            EventLoop loop = group.next();
+            final CaffeineDnsCache cache = new CaffeineDnsCache();
+            cache.cache("netty.io", null, addr1, 1, loop);
+            cache.cache("netty.io", null, addr1, 10000, loop);
+
+            List<? extends DnsCacheEntry> entries = cache.get("netty.io", null);
+            assertEquals(1, entries.size());
+            assertEntry(entries.get(0), addr1);
+        } finally {
+            group.shutdownGracefully();
+        }
+    }
+
+    private static void assertEntry(DnsCacheEntry entry, InetAddress address) {
+        assertEquals(address, entry.address());
+        assertNull(entry.cause());
+    }
+
+    @Test
+    public void testCacheFailed() throws Exception {
+        InetAddress addr1 = InetAddress.getByAddress(new byte[] { 10, 0, 0, 1 });
+        InetAddress addr2 = InetAddress.getByAddress(new byte[] { 10, 0, 0, 2 });
+        EventLoopGroup group = new DefaultEventLoopGroup(1);
+
+        try {
+            EventLoop loop = group.next();
+            final CaffeineDnsCache cache = new CaffeineDnsCache(1, 100, 100, 0);
+            cache.cache("netty.io", null, addr1, 10000, loop);
+            cache.cache("netty.io", null, addr2, 10000, loop);
+
+            List<? extends DnsCacheEntry> entries = cache.get("netty.io", null);
+            assertEquals(2, entries.size());
+            assertEntry(entries.get(0), addr1);
+            assertEntry(entries.get(1), addr2);
+
+            Exception exception = new Exception();
+            cache.cache("netty.io", null, exception, loop);
+            entries = cache.get("netty.io", null);
+            DnsCacheEntry entry = entries.get(0);
+            assertEquals(1, entries.size());
+            assertSame(exception, entry.cause());
+            assertNull(entry.address());
+        } finally {
+            group.shutdownGracefully();
+        }
+    }
+
+    @Test
+    public void testDotHandling() throws Exception {
+        InetAddress addr1 = InetAddress.getByAddress(new byte[] { 10, 0, 0, 1 });
+        InetAddress addr2 = InetAddress.getByAddress(new byte[] { 10, 0, 0, 2 });
+        EventLoopGroup group = new DefaultEventLoopGroup(1);
+
+        try {
+            EventLoop loop = group.next();
+            final CaffeineDnsCache cache = new CaffeineDnsCache(1, 100, 100, 0);
+            cache.cache("netty.io", null, addr1, 10000, loop);
+            cache.cache("netty.io.", null, addr2, 10000, loop);
+
+            List<? extends DnsCacheEntry> entries = cache.get("netty.io", null);
+            assertEquals(2, entries.size());
+            assertEntry(entries.get(0), addr1);
+            assertEntry(entries.get(1), addr2);
+
+            List<? extends DnsCacheEntry> entries2 = cache.get("netty.io.", null);
+            assertEquals(2, entries2.size());
+            assertEntry(entries2.get(0), addr1);
+            assertEntry(entries2.get(1), addr2);
+        } finally {
+            group.shutdownGracefully();
+        }
+    }
+}

--- a/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/RecordEnricher.java
+++ b/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/RecordEnricher.java
@@ -97,7 +97,9 @@ public class RecordEnricher {
                                 hostnamesByAddress.put(addr, null);
                             }
                         }
-                        LOG.trace("Other lookups pending: {}", Sets.difference(addressesToReverseLookup, hostnamesByAddress.keySet()));
+                        if (LOG.isTraceEnabled()) {
+                            LOG.trace("Other lookups pending: {}", Sets.difference(addressesToReverseLookup, hostnamesByAddress.keySet()));
+                        }
                     });
                 }).toArray(CompletableFuture[]::new);
 

--- a/opennms-doc/guide-admin/src/asciidoc/text/dnsresolver/introduction.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/dnsresolver/introduction.adoc
@@ -17,6 +17,7 @@ $ ssh -p 8201 admin@localhost
 admin@minion()> config:edit org.opennms.features.dnsresolver.netty
 admin@minion()> property-set nameservers 8.8.8.8,4.2.2.2:53,[::1]:5353
 admin@minion()> property-set query-timeout-millis 5000
+admin@minion()> property-set max-cache-size 10000
 admin@minion()> config:update
 ----
 

--- a/opennms-doc/guide-admin/src/asciidoc/text/dnsresolver/introduction.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/dnsresolver/introduction.adoc
@@ -27,7 +27,8 @@ The resolved host names are cached for their TTL as specified in the returned DN
 TTL handling can be customized by setting the `min-ttl-seconds`, `max-ttl-seconds` and `negative-ttl-seconds` properties in the configuration above.
 
 === Configuring Circuit Breaker
-Circuit Breaker functionality exist that helps prevent your DNS infrastructure from being flooded with requests when multiple failures occur. It is enabled by default but can be disabled by setting `breaker-enabled` to `false`
+Circuit Breaker functionality exist that helps prevent your DNS infrastructure from being flooded with requests when multiple failures occur.
+It is enabled by default but can be disabled by setting `breaker-enabled` to `false`.
 
 Additional parameters can be modified to tune the functionality of the circuit breaker:
 [source]
@@ -44,3 +45,17 @@ admin@minion()> config:update
 ----
 
 NOTE: If the circuit breaker is disabled, the lookup statistics `lookupsSuccessful` and `lookupsFailed` are no longer tracked.
+
+=== Configuring Bulkhead
+A bulkhead is used to limit the number of concurrent DNS lookups that can be made.
+
+Additional parameters can be modified to tune the functionality of the circuit breaker:
+[source]
+----
+$ ssh -p 8201 admin@localhost
+...
+admin@minion()> config:edit org.opennms.features.dnsresolver.netty
+admin@minion()> property-set bulkhead-max-concurrent-calls 1000
+admin@minion()> property-set bulkhead-max-wait-duration-millis 5100
+admin@minion()> config:update
+----

--- a/pom.xml
+++ b/pom.xml
@@ -1188,6 +1188,7 @@
     <batikVersion>1.7</batikVersion>
     <bsfVersion>2.4.0</bsfVersion>
     <bsonVersion>3.5.0</bsonVersion>
+    <caffeineVersion>2.8.0</caffeineVersion>
     <camelVersion>2.19.1</camelVersion>
     <cassandraUnitVersion>3.11.2.0</cassandraUnitVersion>
     <!-- Match Newts version -->
@@ -1267,7 +1268,7 @@
     <mapstructVersion>1.3.0.Final</mapstructVersion>
     <minaVersion>2.0.16</minaVersion>
     <mockitoVersion>1.10.19</mockitoVersion>
-    <netty4Version>4.1.37.Final</netty4Version>
+    <netty4Version>4.1.38.Final</netty4Version>
     <newtsVersion>1.5.1</newtsVersion>
     <paxExamVersion>4.13.1</paxExamVersion>
     <paxSwissboxVersion>1.8.2</paxSwissboxVersion>
@@ -3061,6 +3062,11 @@
         <groupId>org.mongodb</groupId>
         <artifactId>bson</artifactId>
         <version>${bsonVersion}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.github.ben-manes.caffeine</groupId>
+        <artifactId>caffeine</artifactId>
+        <version>${caffeineVersion}</version>
       </dependency>
       <dependency>
         <groupId>cglib</groupId>


### PR DESCRIPTION
JIRA: https://issues.opennms.org/browse/NMS-12157

Here we update the NettyDnsResolver to use a new custom cache based on Caffeine. This allows us to limit the cache size and expose resolution statistics.

While adding tests for this I found that the previous implementation didn't actually cache any of the reverse lookups that were being performed - only the standard A and AAAA lookups were cached 🤦‍♂ 

