### PR TITLE
NMS-12223: Fixed date handling in Ops board criteria builder component

### DIFF
--- a/features/vaadin-dashboard/src/main/java/org/opennms/features/vaadin/dashboard/config/ui/editors/CriteriaBuilderHelper.java
+++ b/features/vaadin-dashboard/src/main/java/org/opennms/features/vaadin/dashboard/config/ui/editors/CriteriaBuilderHelper.java
@@ -138,7 +138,7 @@ public class CriteriaBuilderHelper {
                     .parseDefaulting(ChronoField.MINUTE_OF_HOUR, 0)
                     .toFormatter();
 
-            final String DELTA_PATTERN = "^[+-]\\d+";
+            final String DELTA_PATTERN = "^[+-]\\d+$";
 
             private ZonedDateTime parseZonedDateTinme(final String string) {
                 if ("0".equals(string)) {

--- a/features/vaadin-dashboard/src/main/java/org/opennms/features/vaadin/dashboard/config/ui/editors/CriteriaBuilderHelper.java
+++ b/features/vaadin-dashboard/src/main/java/org/opennms/features/vaadin/dashboard/config/ui/editors/CriteriaBuilderHelper.java
@@ -34,8 +34,12 @@ import java.net.InetAddress;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.net.UnknownHostException;
-import java.text.DateFormat;
-import java.text.ParseException;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.DateTimeParseException;
+import java.time.temporal.ChronoField;
+import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.Date;
@@ -128,15 +132,44 @@ public class CriteriaBuilderHelper {
         });
 
         setCriteriaParser(Date.class, new CriteriaParser<Date>() {
+            final DateTimeFormatter parserFormatter = new DateTimeFormatterBuilder()
+                    .append(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+                    .parseDefaulting(ChronoField.HOUR_OF_DAY, 0)
+                    .parseDefaulting(ChronoField.MINUTE_OF_HOUR, 0)
+                    .toFormatter();
+
+            final String DELTA_PATTERN = "^[+-]\\d+";
+
+            private ZonedDateTime parseZonedDateTinme(final String string) {
+                if ("0".equals(string)) {
+                    return ZonedDateTime.now();
+                } else {
+                    if (string.matches(DELTA_PATTERN)) {
+                        final long delta = Long.parseLong(string.substring(1));
+                        if (string.charAt(0) == '+') {
+                            return ZonedDateTime.now().plus(delta, ChronoUnit.SECONDS);
+                        } else {
+                            return ZonedDateTime.now().minus(delta, ChronoUnit.SECONDS);
+                        }
+                    } else {
+                        try {
+                            return ZonedDateTime.parse(string, parserFormatter);
+                        } catch (DateTimeParseException ex) {
+                            return null;
+                        }
+                    }
+                }
+            }
+
             @Override
             public Date parse(String string) {
-                Date date = null;
-                try {
-                    date = DateFormat.getDateInstance().parse(string);
-                } catch (ParseException e) {
+                final ZonedDateTime zonedDateTime = parseZonedDateTinme(string);
+
+                if (zonedDateTime == null) {
                     return null;
+                } else {
+                    return Date.from(zonedDateTime.toInstant());
                 }
-                return date;
             }
 
             @Override

--- a/opennms-doc/guide-admin/src/asciidoc/text/webui/opsboard/criteria-builder.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/webui/opsboard/criteria-builder.adoc
@@ -33,3 +33,5 @@ It is possible to combine multiple _Criteria_ to display just a subset of inform
 | `Not`       | database attribute | _String_  | -        | _unknown_ difference between `Ne`
 | `OrderBy`   | database attribute | -         | -        | Order the result set by a given attribute
 |===
+
+TIP: For date values, absolute value can be specified in ISO format, e.g. _2019-06-20T20:45:15.123-05:00_. Relative times can be specified by _+seconds_ and _-seconds_.


### PR DESCRIPTION
* JIRA: https://issues.opennms.org/browse/NMS-12223

You can now use "+seconds" and "-seconds" for relative values and absolute value can be given in ISO format, e.g. "2019-06-20T20:45:15.123-05:00".
