### PR TITLE
NMS-12225: Set the lastgood & lastfail columns on ifservices after a poll

### DIFF
--- a/opennms-doc/guide-admin/src/asciidoc/text/service-assurance/introduction.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/service-assurance/introduction.adoc
@@ -5,7 +5,7 @@
 This section will cover the basic functionalities how _{opennms-product-name}_ tests if a service or device available and measure his latency.
 
 In _{opennms-product-name}_ this task is provided by a _Service Monitor_ framework.
-The main component is _Pollerd_ which provides the following functionalities:
+The main component is _Pollerd_ which provides the following functionality:
 
 * Track the status of a management resource or an application for availability calculations
 * Measure response times for service quality
@@ -25,6 +25,9 @@ The availability is calculated over the last 24 hours and is shown in the _Surve
 Response times are displayed as _Resource Graphs_ of the _IP Interface_ on the _Node Detail Page_.
 Configuration parameters of the _Service Monitor_ can be seen in the _Service Page_ by clicking on the _Service Name_ on the _Node Detail Page_.
 The status of a _Service_ can be _Up_ or _Down_.
+
+TIP: The _Service Page_ also includes timestamps indicating the last time at which the service was polled and found to to be _Up_ (Last Good) or _Down_ (Last Fail).
+These fields can be used to validate that _Pollerd_ is polling the services as expected.
 
 When a _Service Monitor_ detects an outage, _Pollerd_ sends an _Event_ which is used to create an _Alarm_.
 _Events_ can also be used to generate _Notifications_ for on-call network or server administrators.

--- a/opennms-services/pom.xml
+++ b/opennms-services/pom.xml
@@ -422,6 +422,12 @@
       <groupId>org.opennms.features.collection</groupId>
       <artifactId>org.opennms.features.collection.test-api</artifactId>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.opennms.core.ipc.rpc</groupId>
@@ -438,11 +444,6 @@
     <dependency>
       <groupId>com.jayway.awaitility</groupId>
       <artifactId>awaitility</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-library</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/opennms-services/src/main/java/org/opennms/netmgt/poller/DefaultPollContext.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/poller/DefaultPollContext.java
@@ -84,7 +84,13 @@ public class DefaultPollContext implements PollContext, EventListener {
         EventConstants.NODE_DOWN_EVENT_UEI,
         EventConstants.NODE_UP_EVENT_UEI
     };
-    
+
+    /**
+     * Poll timestamps are updated using a DB transaction in the same thread and immediately following the poll.
+     * This may cause unnecessary overhead in extreme cases, so we add the ability to disable this functionality.
+     */
+    private static final boolean DISABLE_POLL_TIMESTAMP_TRACKING = Boolean.getBoolean("org.opennms.netmgt.poller.disablePollTimestampTracking");
+
     private volatile PollerConfig m_pollerConfig;
     private volatile QueryManager m_queryManager;
     private volatile EventIpcManager m_eventManager;
@@ -434,6 +440,17 @@ public class DefaultPollContext implements PollContext, EventListener {
             // If the event was not completed and it is still pending, then don't do anything to it
         }
         LOG.debug("onEvent: Finished processing event: {} uei: {}, dbid: {}", event, event.getUei(), event.getDbid());
+    }
+
+    @Override
+    public void trackPoll(PollableService service, PollStatus result) {
+        try {
+            if (!result.isUnknown() && !DISABLE_POLL_TIMESTAMP_TRACKING) {
+                getQueryManager().updateLastGoodOrFail(service.getNodeId(), service.getAddress(), service.getSvcName(), result);
+            }
+        } catch (Exception e) {
+            LOG.warn("Error occurred while tracking poll for service: {}", service, e);
+        }
     }
 
     private static void processPending(final PendingPollEvent pollEvent) {

--- a/opennms-services/src/main/java/org/opennms/netmgt/poller/DefaultPollContext.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/poller/DefaultPollContext.java
@@ -89,7 +89,7 @@ public class DefaultPollContext implements PollContext, EventListener {
      * Poll timestamps are updated using a DB transaction in the same thread and immediately following the poll.
      * This may cause unnecessary overhead in extreme cases, so we add the ability to disable this functionality.
      */
-    private static final boolean DISABLE_POLL_TIMESTAMP_TRACKING = Boolean.getBoolean("org.opennms.netmgt.poller.disablePollTimestampTracking");
+    public static final boolean DISABLE_POLL_TIMESTAMP_TRACKING = Boolean.getBoolean("org.opennms.netmgt.poller.disablePollTimestampTracking");
 
     private volatile PollerConfig m_pollerConfig;
     private volatile QueryManager m_queryManager;

--- a/opennms-services/src/main/java/org/opennms/netmgt/poller/QueryManager.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/poller/QueryManager.java
@@ -28,9 +28,12 @@
 
 package org.opennms.netmgt.poller;
 
+import java.net.InetAddress;
 import java.sql.SQLException;
 import java.util.Date;
 import java.util.List;
+
+import org.opennms.netmgt.poller.pollables.PollableService;
 
 /**
  * <p>QueryManager interface.</p>
@@ -90,5 +93,7 @@ public interface QueryManager {
     void closeOutagesForService(Date closeDate, int eventId, int nodeId, String ipAddr, String serviceName);
 
     void updateServiceStatus(int nodeId, String ipAddr, String serviceName, String status);
+
+    void updateLastGoodOrFail(int nodeId, InetAddress ipAddr, String serviceName, PollStatus status);
 
 }

--- a/opennms-services/src/main/java/org/opennms/netmgt/poller/pollables/PollContext.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/poller/pollables/PollContext.java
@@ -31,6 +31,7 @@ package org.opennms.netmgt.poller.pollables;
 import java.net.InetAddress;
 import java.util.Date;
 
+import org.opennms.netmgt.poller.PollStatus;
 import org.opennms.netmgt.xml.event.Event;
 
 /**
@@ -105,4 +106,5 @@ public interface PollContext {
      */
     public boolean isServiceUnresponsiveEnabled();
 
+    void trackPoll(PollableService service, PollStatus result);
 }

--- a/opennms-services/src/main/java/org/opennms/netmgt/poller/pollables/PollableServiceConfig.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/poller/pollables/PollableServiceConfig.java
@@ -132,6 +132,10 @@ public class PollableServiceConfig implements PollConfig, ScheduleInterval {
                 .execute()
                 .get().getPollStatus();
             LOG.debug("Finish polling {} using pkg {} result = {}", m_service, packageName, result);
+
+            // Track the results of the poll
+            m_service.getContext().trackPoll(m_service, result);
+
             return result;
         } catch (Throwable e) {
             return RpcExceptionUtils.handleException(e, new RpcExceptionHandler<PollStatus>() {

--- a/opennms-services/src/test/java/org/opennms/netmgt/mock/MockQueryManager.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/mock/MockQueryManager.java
@@ -28,6 +28,7 @@
 
 package org.opennms.netmgt.mock;
 
+import java.net.InetAddress;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Date;
@@ -35,6 +36,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import org.opennms.netmgt.poller.PollStatus;
 import org.opennms.netmgt.poller.QueryManager;
 
 public class MockQueryManager implements QueryManager {
@@ -176,5 +178,10 @@ public class MockQueryManager implements QueryManager {
 		// TODO Auto-generated method stub
 		
 	}
+
+    @Override
+    public void updateLastGoodOrFail(int nodeId, InetAddress ipAddr, String serviceName, PollStatus status) {
+        // pass
+    }
 
 }

--- a/opennms-services/src/test/java/org/opennms/netmgt/poller/PollerIT.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/poller/PollerIT.java
@@ -28,6 +28,10 @@
 
 package org.opennms.netmgt.poller;
 
+import static com.jayway.awaitility.Awaitility.await;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -40,12 +44,14 @@ import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Date;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.After;
 import org.junit.Before;
@@ -114,7 +120,8 @@ import com.google.common.collect.Sets;
         "classpath:/META-INF/opennms/applicationContext-pollerdTest.xml"
 })
 @JUnitConfigurationEnvironment(systemProperties={
-        "org.opennms.netmgt.icmp.pingerClass=org.opennms.netmgt.icmp.jna.JnaPinger"
+        // We don't need a real pinger here
+        "org.opennms.netmgt.icmp.pingerClass=org.opennms.netmgt.icmp.NullPinger"
 })
 @JUnitTemporaryDatabase(tempDbClass=MockDatabase.class,reuseDatabase=false)
 public class PollerIT implements TemporaryDatabaseAware<MockDatabase> {
@@ -1605,6 +1612,34 @@ public class PollerIT implements TemporaryDatabaseAware<MockDatabase> {
         // Sleep some more and verify that no invalid polls have occurred
         sleep(3000);
         assertEquals("Received a poll for an element that doesn't exist", 0, m_network.getInvalidPollCount());
+    }
+
+    @Test
+    public void canUpdateLastGoodAndLastFailTimestamps() {
+        final Date startOfTest = new Date();
+
+        MockInterface iface = m_network.getInterface(3, "192.168.1.4");
+        MockService svc = iface.getService("SMTP");
+        assertThat(svc, notNullValue());
+
+        // Start the poller
+        startDaemons();
+
+        // Wait until we poll the service
+        await().atMost(1, TimeUnit.MINUTES)
+                .ignoreExceptions()
+                .until(() -> m_monitoredServiceDao.get(svc.getNodeId(), svc.getAddress(), svc.getSvcName()).getLastGood(),
+                        greaterThanOrEqualTo(startOfTest));
+
+        // Now take the service offline
+        final Date beforeDown = new Date();
+        svc.bringDown();
+
+        // Wait until we detect the service to be offline
+        await().atMost(1, TimeUnit.MINUTES)
+                .ignoreExceptions()
+                .until(() -> m_monitoredServiceDao.get(svc.getNodeId(), svc.getAddress(), svc.getSvcName()).getLastFail(),
+                        greaterThanOrEqualTo(beforeDown));
     }
 
     //

--- a/opennms-services/src/test/java/org/opennms/netmgt/poller/mock/MockPollContext.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/poller/mock/MockPollContext.java
@@ -43,6 +43,7 @@ import org.opennms.netmgt.mock.MockEventUtil;
 import org.opennms.netmgt.mock.MockNetwork;
 import org.opennms.netmgt.mock.MockService;
 import org.opennms.netmgt.model.events.EventBuilder;
+import org.opennms.netmgt.poller.PollStatus;
 import org.opennms.netmgt.poller.pollables.PendingPollEvent;
 import org.opennms.netmgt.poller.pollables.PollContext;
 import org.opennms.netmgt.poller.pollables.PollEvent;
@@ -166,6 +167,11 @@ public class MockPollContext implements PollContext, EventListener {
     @Override
     public boolean isServiceUnresponsiveEnabled() {
         return m_serviceUnresponsiveEnabled;
+    }
+
+    @Override
+    public void trackPoll(PollableService service, PollStatus result) {
+        // pass, nothing to track
     }
 
     public void setServiceUnresponsiveEnabled(boolean serviceUnresponsiveEnabled) {

--- a/opennms-webapp/src/main/webapp/WEB-INF/jsp/element/service.jsp
+++ b/opennms-webapp/src/main/webapp/WEB-INF/jsp/element/service.jsp
@@ -49,6 +49,7 @@
 <%@taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
 <%@taglib uri="http://java.sun.com/jsp/jstl/functions" prefix="fn" %>
 <%@ taglib prefix="sec" uri="http://www.springframework.org/security/tags" %>
+<%@taglib uri="/WEB-INF/taglib.tld" prefix="onms" %>
 
 <%
     OnmsMonitoredService service = (OnmsMonitoredService)request.getAttribute("service");
@@ -215,6 +216,20 @@ function doDelete() {
                         <c:otherwise><td>Unknown</td></c:otherwise>
                     </c:choose>
                 </tr>
+              <tr>
+                <th>Last Good</th>
+                <c:choose>
+                    <c:when test="${service.lastGood != null}"><td><onms:datetime date="${service.lastGood}" /></td></c:when>
+                    <c:otherwise><td>Unknown</td></c:otherwise>
+                </c:choose>
+              </tr>
+              <tr>
+                <th>Last Fail</th>
+                <c:choose>
+                    <c:when test="${service.lastFail != null}"><td><onms:datetime date="${service.lastFail}" /></td></c:when>
+                    <c:otherwise><td>Unknown</td></c:otherwise>
+                </c:choose>
+              </tr>
             </table>
             </div>
             <!-- simple parameters box -->

--- a/opennms-webapp/src/main/webapp/WEB-INF/jsp/element/service.jsp
+++ b/opennms-webapp/src/main/webapp/WEB-INF/jsp/element/service.jsp
@@ -42,7 +42,8 @@
         org.opennms.netmgt.config.poller.Service,
         org.opennms.netmgt.config.poller.Parameter,
         org.opennms.netmgt.model.OnmsMonitoredService,
-        org.opennms.netmgt.poller.ServiceMonitor
+        org.opennms.netmgt.poller.ServiceMonitor,
+        org.opennms.netmgt.poller.DefaultPollContext
 	"
 %>
 <%@taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
@@ -216,20 +217,25 @@ function doDelete() {
                         <c:otherwise><td>Unknown</td></c:otherwise>
                     </c:choose>
                 </tr>
-              <tr>
-                <th>Last Good</th>
-                <c:choose>
-                    <c:when test="${service.lastGood != null}"><td><onms:datetime date="${service.lastGood}" /></td></c:when>
-                    <c:otherwise><td>Unknown</td></c:otherwise>
-                </c:choose>
-              </tr>
-              <tr>
-                <th>Last Fail</th>
-                <c:choose>
-                    <c:when test="${service.lastFail != null}"><td><onms:datetime date="${service.lastFail}" /></td></c:when>
-                    <c:otherwise><td>Unknown</td></c:otherwise>
-                </c:choose>
-              </tr>
+              <c:choose>
+                <%-- Hide the last good/fail timestamp rows when poll timestamp tracking is disabled. --%>
+                <c:when test="${!DefaultPollContext.DISABLE_POLL_TIMESTAMP_TRACKING}">
+                  <tr>
+                    <th>Last Good</th>
+                    <c:choose>
+                        <c:when test="${service.lastGood != null}"><td><onms:datetime date="${service.lastGood}" /></td></c:when>
+                        <c:otherwise><td>Unknown</td></c:otherwise>
+                    </c:choose>
+                  </tr>
+                  <tr>
+                    <th>Last Fail</th>
+                    <c:choose>
+                        <c:when test="${service.lastFail != null}"><td><onms:datetime date="${service.lastFail}" /></td></c:when>
+                        <c:otherwise><td>Unknown</td></c:otherwise>
+                    </c:choose>
+                  </tr>
+                </c:when>
+              </c:choose>
             </table>
             </div>
             <!-- simple parameters box -->


### PR DESCRIPTION
JIRA: https://issues.opennms.org/browse/NMS-12225

Here we update the poller to store the lastgood & lastfail timestamps in the ifservices table and update the UI to display these.

Good with no failures:
![image](https://user-images.githubusercontent.com/1379749/62968353-dc698800-bdd8-11e9-85e3-e61ffb4428bc.png)

After an outage:
![image](https://user-images.githubusercontent.com/1379749/62968458-18045200-bdd9-11e9-80d2-f69b33274e0c.png)
