### PR TITLE
NMS-12232: Make RPC response handling asynchronous.

### DIFF
--- a/core/ipc/rpc/kafka/src/main/java/org/opennms/core/ipc/rpc/kafka/KafkaRpcClientFactory.java
+++ b/core/ipc/rpc/kafka/src/main/java/org/opennms/core/ipc/rpc/kafka/KafkaRpcClientFactory.java
@@ -127,14 +127,18 @@ public class KafkaRpcClientFactory implements RpcClientFactory {
     private String location;
     private KafkaProducer<String, byte[]> producer;
     private final Properties kafkaConfig = new Properties();
-    private final ThreadFactory threadFactory = new ThreadFactoryBuilder()
+    private final ThreadFactory consumerThreadFactory = new ThreadFactoryBuilder()
             .setNameFormat("rpc-client-kafka-consumer-%d")
+            .build();
+    private final ThreadFactory responseHandlerThreadFactory = new ThreadFactoryBuilder()
+            .setNameFormat("rpc-client-response-handler-%d")
             .build();
     private final ThreadFactory timerThreadFactory = new ThreadFactoryBuilder()
             .setNameFormat("rpc-client-timeout-tracker-%d")
             .build();
-    private final ExecutorService executor = Executors.newSingleThreadExecutor(threadFactory);
+    private final ExecutorService kafkaConsumerExecutor = Executors.newCachedThreadPool(consumerThreadFactory);
     private final ExecutorService timerExecutor = Executors.newSingleThreadExecutor(timerThreadFactory);
+    private final ExecutorService responseHandlerExecutor = Executors.newCachedThreadPool(responseHandlerThreadFactory);
     private final Map<String, ResponseCallback> rpcResponseMap = new ConcurrentHashMap<>();
     private KafkaConsumerRunner kafkaConsumerRunner;
     private DelayQueue<ResponseCallback> delayQueue = new DelayQueue<>();
@@ -181,6 +185,9 @@ public class KafkaRpcClientFactory implements RpcClientFactory {
                         expirationTime, loggingContext, request.getLocation(), span);
                 delayQueue.offer(responseHandler);
                 rpcResponseMap.put(rpcId, responseHandler);
+                if(kafkaConsumerRunner.isClosed() && !kafkaConsumerExecutor.isShutdown()) {
+                    startKafkaConsumer();
+                }
                 kafkaConsumerRunner.startConsumingForModule(module.getId());
                 byte[] messageInBytes = marshalRequest.getBytes();
                 int totalChunks = IntMath.divide(messageInBytes.length, MAX_BUFFER_SIZE, RoundingMode.UP);
@@ -290,9 +297,7 @@ public class KafkaRpcClientFactory implements RpcClientFactory {
             producer = new KafkaProducer<>(kafkaConfig);
             LOG.info("initializing the Kafka producer with: {}", kafkaConfig);
             // Start consumer which handles all the responses.
-            KafkaConsumer<String, byte[]> kafkaConsumer = new KafkaConsumer<>(kafkaConfig);
-            kafkaConsumerRunner = new KafkaConsumerRunner(kafkaConsumer);
-            executor.execute(kafkaConsumerRunner);
+            startKafkaConsumer();
             // Initialize metrics reporter.
             metricsReporter = JmxReporter.forRegistry(metrics).
                     inDomain(JMX_DOMAIN_RPC).build();
@@ -308,7 +313,7 @@ public class KafkaRpcClientFactory implements RpcClientFactory {
                         ResponseCallback responseCb = delayQueue.take();
                         if (!responseCb.isProcessed()) {
                             LOG.warn("RPC request with id {} timedout ", responseCb.getRpcId());
-                            responseCb.sendResponse(null);
+                            responseHandlerExecutor.execute(() -> responseCb.sendResponse(null));
                         }
                     } catch (InterruptedException e) {
                         LOG.info("interrupted while waiting for an element from delayQueue", e);
@@ -320,6 +325,12 @@ public class KafkaRpcClientFactory implements RpcClientFactory {
             });
             LOG.info("started timeout tracker");
         }
+    }
+
+    private synchronized void startKafkaConsumer() {
+        KafkaConsumer<String, byte[]> kafkaConsumer = new KafkaConsumer<>(kafkaConfig);
+        kafkaConsumerRunner = new KafkaConsumerRunner(kafkaConsumer);
+        kafkaConsumerExecutor.execute(kafkaConsumerRunner);
     }
 
     /**
@@ -380,8 +391,8 @@ public class KafkaRpcClientFactory implements RpcClientFactory {
                 span.finish();
                 rpcResponseMap.remove(rpcId);
                 messageCache.remove(rpcId);
-            } catch (Exception e) {
-                LOG.warn("error while handling response for RPC request id {}", rpcId, e);
+            } catch (Throwable e) {
+                LOG.warn("error while handling response for RPC module {} , response = \n {} \n", rpcModule.getId(), message, e);
             }
         }
 
@@ -431,27 +442,15 @@ public class KafkaRpcClientFactory implements RpcClientFactory {
             Logging.putPrefix(RpcClientFactory.LOG_PREFIX);
             if (topics.isEmpty()) {
                 // kafka consumer needs to subscribe to at least one topic for the consumer.poll to work.
-                while (!topicAdded.get()) {
-                    try {
-                        firstTopicAdded.await(1, TimeUnit.SECONDS);
-                    } catch (InterruptedException e) {
-                        LOG.info("Interrupted before first topic was added. Terminating Kafka RPC consumer thread.");
-                        return;
-                    }
-                }
+                waitTillFirstTopicIsAdded();
                 LOG.info("First topic is added, consumer will be started.");
             }
             while (!closed.get()) {
-                if (topicAdded.get()) {
-                    synchronized (topics) {
-                        // Topic subscriptions are not incremental. This list will replace the current assignment (if there is one).
-                        LOG.info("Subscribing Kafka RPC consumer to topics named: {}", topics);
-                        consumer.subscribe(topics);
-                        topicAdded.set(false);
-                    }
-                }
                 try {
-                    ConsumerRecords<String, byte[]> records = consumer.poll(Long.MAX_VALUE);
+                    //Subscribe to new topics when added.
+                    subscribeToTopics();
+
+                    ConsumerRecords<String, byte[]> records = consumer.poll(java.time.Duration.ofMillis(Long.MAX_VALUE));
                     for (ConsumerRecord<String, byte[]> record : records) {
                         // Get Response callback from key and send rpc content to callback.
                         ResponseCallback responseCb = rpcResponseMap.get(record.key());
@@ -474,9 +473,11 @@ public class KafkaRpcClientFactory implements RpcClientFactory {
                                 rpcContent = messageCache.get(rpcId);
                             }
                             if (LOG.isTraceEnabled()) {
-                                LOG.trace("Received RPC response for id {}",  rpcMessage.getRpcId());
+                                LOG.trace("Received RPC response for id {}", rpcMessage.getRpcId());
                             }
-                            responseCb.sendResponse(rpcContent.toStringUtf8());
+                            final String rpcMessageContent = rpcContent.toStringUtf8();
+                            responseHandlerExecutor.execute(() ->
+                                    responseCb.sendResponse(rpcMessageContent));
                         } else {
                             LOG.warn("Received a response for request with ID:{}, but no outstanding request was found with this id, The request may have timed out.",
                                     record.key());
@@ -485,16 +486,50 @@ public class KafkaRpcClientFactory implements RpcClientFactory {
                 } catch (InvalidProtocolBufferException e) {
                     LOG.error("error while parsing response", e);
                 } catch (WakeupException e) {
-                    LOG.info(" consumer got wakeup exception, closed = {} ", closed.get(), e);
+                    LOG.info("consumer got wakeup exception, closed = {} ", closed.get(), e);
+                } catch (Throwable e) {
+                    LOG.info("error in kafka consumer", e);
                 }
             }
             // Close consumer when while loop is closed.
             consumer.close();
+            closed.set(true);
         }
 
         public void stop() {
             closed.set(true);
             consumer.wakeup();
+        }
+
+        public boolean isClosed() {
+            return closed.get();
+        }
+
+        private void waitTillFirstTopicIsAdded() {
+            while (!topicAdded.get()) {
+                try {
+                    firstTopicAdded.await(1, TimeUnit.SECONDS);
+                } catch (InterruptedException e) {
+                    LOG.info("Interrupted before first topic was added. Terminating Kafka RPC consumer thread.", e);
+                    closed.set(true);
+                    return;
+                } catch(Throwable e) {
+                    LOG.error("Unknown exception before first topic is added, Terminating Kafka RPC consumer thread", e);
+                    closed.set(true);
+                    return;
+                }
+            }
+        }
+
+        private void subscribeToTopics() {
+            if (topicAdded.get()) {
+                synchronized (topics) {
+                    // Topic subscriptions are not incremental. This list will replace the current assignment (if there is one).
+                    LOG.info("Subscribing Kafka RPC consumer to topics named: {}", topics);
+                    consumer.subscribe(topics);
+                    topicAdded.set(false);
+                }
+            }
         }
 
         private void startConsumingForModule(String moduleId) {
@@ -521,8 +556,9 @@ public class KafkaRpcClientFactory implements RpcClientFactory {
             metricsReporter.close();
         }
         kafkaConsumerRunner.stop();
-        executor.shutdown();
+        kafkaConsumerExecutor.shutdown();
         timerExecutor.shutdown();
+        responseHandlerExecutor.shutdown();
     }
 
 

--- a/core/ipc/rpc/kafka/src/test/java/org/opennms/core/ipc/rpc/kafka/MockEchoClient.java
+++ b/core/ipc/rpc/kafka/src/test/java/org/opennms/core/ipc/rpc/kafka/MockEchoClient.java
@@ -32,6 +32,7 @@ import java.util.concurrent.CompletableFuture;
 
 import org.opennms.core.rpc.api.RpcClient;
 import org.opennms.core.rpc.api.RpcClientFactory;
+import org.opennms.core.rpc.api.RpcModule;
 import org.opennms.core.rpc.echo.EchoRequest;
 import org.opennms.core.rpc.echo.EchoResponse;
 import org.opennms.core.rpc.echo.EchoRpcModule;
@@ -39,14 +40,21 @@ import org.opennms.core.rpc.echo.EchoRpcModule;
 public class MockEchoClient implements RpcClient<EchoRequest, EchoResponse> {
     
     private final RpcClientFactory rpcProxy;
-    
+
+    private RpcModule<EchoRequest, EchoResponse> rpcModule;
+
     public MockEchoClient(RpcClientFactory rpcProxy) {
+        this(rpcProxy, new EchoRpcModule());
+    }
+
+    public MockEchoClient(RpcClientFactory rpcProxy, RpcModule<EchoRequest, EchoResponse> rpcModule) {
         this.rpcProxy = rpcProxy;
+        this.rpcModule = rpcModule;
     }
 
     @Override
     public CompletableFuture<EchoResponse> execute(EchoRequest request) {
-        return getRpcProxy().getClient(new EchoRpcModule()).execute(request);
+        return getRpcProxy().getClient(rpcModule).execute(request);
     }
 
     public RpcClientFactory getRpcProxy() {

--- a/core/ipc/rpc/kafka/src/test/java/org/opennms/core/ipc/rpc/kafka/RpcKafkaConsumerAsyncIT.java
+++ b/core/ipc/rpc/kafka/src/test/java/org/opennms/core/ipc/rpc/kafka/RpcKafkaConsumerAsyncIT.java
@@ -1,0 +1,176 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.core.ipc.rpc.kafka;
+
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Hashtable;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.opennms.core.ipc.common.kafka.OsgiKafkaConfigProvider;
+import org.opennms.core.rpc.api.RpcClient;
+import org.opennms.core.rpc.api.RpcClientFactory;
+import org.opennms.core.rpc.echo.EchoRequest;
+import org.opennms.core.rpc.echo.EchoResponse;
+import org.opennms.core.rpc.echo.EchoRpcModule;
+import org.opennms.core.test.kafka.JUnitKafkaServer;
+import org.opennms.core.tracing.api.TracerRegistry;
+import org.opennms.distributed.core.api.MinionIdentity;
+import org.opennms.test.ThreadLocker;
+import org.osgi.service.cm.ConfigurationAdmin;
+
+import io.opentracing.Tracer;
+import io.opentracing.util.GlobalTracer;
+
+/**
+ * This test verifies that the response handling is asynchronous in nature.
+ * On opennms side all module responses are retrieved in single thread then the responses are handled in different threads asynchronously.
+ */
+public class RpcKafkaConsumerAsyncIT {
+
+    private static final String KAFKA_CONFIG_PID = "org.opennms.core.ipc.rpc.kafka.";
+    private static final String REMOTE_LOCATION_NAME = "remote";
+    private static final int NTHREADS = 100;
+
+    @Rule
+    public JUnitKafkaServer kafkaServer = new JUnitKafkaServer();
+
+    private KafkaRpcClientFactory rpcClientFactory;
+
+    private KafkaRpcServerManager kafkaRpcServer;
+
+    private MinionIdentity minionIdentity;
+
+    private EchoRpcModule echoRpcModule = new EchoRpcModule();
+
+    private Hashtable<String, Object> kafkaConfig = new Hashtable<>();
+
+    @Before
+    public void setup() throws Exception {
+        System.setProperty(String.format("%s%s", KAFKA_CONFIG_PID, ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG), kafkaServer.getKafkaConnectString());
+        System.setProperty(String.format("%s%s", KAFKA_CONFIG_PID, ConsumerConfig.AUTO_OFFSET_RESET_CONFIG), "earliest");
+        rpcClientFactory = new KafkaRpcClientFactory();
+        rpcClientFactory.setTracerRegistry(tracerRegistry);
+        //echoClient = new MockEchoClient(rpcClientFactory, echoRpcModule);
+        rpcClientFactory.start();
+        kafkaConfig.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaServer.getKafkaConnectString());
+        kafkaConfig.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        ConfigurationAdmin configAdmin = mock(ConfigurationAdmin.class, RETURNS_DEEP_STUBS);
+        when(configAdmin.getConfiguration(KAFKA_CONFIG_PID).getProperties())
+                .thenReturn(kafkaConfig);
+        minionIdentity = new MockMinionIdentity(REMOTE_LOCATION_NAME);
+        kafkaRpcServer = new KafkaRpcServerManager(new OsgiKafkaConfigProvider(KAFKA_CONFIG_PID, configAdmin), minionIdentity, tracerRegistry);
+        kafkaRpcServer.init();
+        kafkaRpcServer.bind(echoRpcModule);
+    }
+
+    @Test
+    public void testKafkaRpcResponseHandlerCanExecuteAsynchronously() throws ExecutionException, InterruptedException {
+
+        ThreadLockingEchoClient client = new ThreadLockingEchoClient(rpcClientFactory, echoRpcModule);
+        CompletableFuture<Integer> runLockedFuture = client.getRunLocker().waitForThreads(NTHREADS);
+        List<CompletableFuture<EchoResponse>> futures = new ArrayList<>();
+        for (int i = 0; i < NTHREADS; i++) {
+            EchoRequest request = new EchoRequest("ping");
+            request.setTimeToLiveMs(15000L);
+            request.setSystemId(minionIdentity.getId());
+            request.setLocation(REMOTE_LOCATION_NAME);
+            futures.add(client.execute(request));
+        }
+        // Wait for all the threads calling run() to be locked
+        runLockedFuture.get();
+        // Release and verify that all the futures return
+        client.getRunLocker().release();
+        CompletableFuture.allOf(futures.toArray(new CompletableFuture<?>[NTHREADS])).get();
+    }
+
+
+    public static class ThreadLockingEchoClient implements RpcClient<EchoRequest, EchoResponse> {
+
+        private RpcClient<EchoRequest, EchoResponse> m_delegate;
+
+        private final ThreadLocker runLocker = new ThreadLocker();
+
+
+        public ThreadLockingEchoClient(RpcClientFactory rpcClientFactory, EchoRpcModule echoRpcModule) {
+            m_delegate = rpcClientFactory.getClient(echoRpcModule);
+        }
+
+        @Override
+        public CompletableFuture<EchoResponse> execute(EchoRequest request) {
+            CompletableFuture<EchoResponse> future = m_delegate.execute(request);
+            future.whenComplete((echoResponse, throwable) -> {
+                if (throwable == null) {
+                    runLocker.park();
+                    // This blocks the response handling by 5 secs.
+                    // When response handling is async, all threads blocked by 5 secs only.
+                    try {
+                        Thread.sleep(5000);
+                    } catch (InterruptedException e) {
+                        //Ignore
+                    }
+                }
+            });
+            return future;
+        }
+
+        ThreadLocker getRunLocker() {
+            return runLocker;
+        }
+
+    }
+
+
+    private TracerRegistry tracerRegistry = new TracerRegistry() {
+        @Override
+        public Tracer getTracer() {
+            return GlobalTracer.get();
+        }
+
+        @Override
+        public void init(String serviceName) {
+        }
+    };
+
+    @After
+    public void destroy() throws Exception {
+        kafkaRpcServer.unbind(echoRpcModule);
+        rpcClientFactory.stop();
+    }
+}

--- a/core/ipc/rpc/kafka/src/test/java/org/opennms/core/ipc/rpc/kafka/RpcKafkaIT.java
+++ b/core/ipc/rpc/kafka/src/test/java/org/opennms/core/ipc/rpc/kafka/RpcKafkaIT.java
@@ -210,7 +210,7 @@ public class RpcKafkaIT {
         }
     }
 
-    @Test(timeout = 60000)
+    @Test(timeout = 90000)
     public void stressTestKafkaRpcWithDifferentTimeouts() {
         EchoRequest request = new EchoRequest("Kafka-RPC");
         request.setId(System.currentTimeMillis());
@@ -223,7 +223,7 @@ public class RpcKafkaIT {
             int randomNum = ThreadLocalRandom.current().nextInt(5, 30);
             sendRequestAndVerifyResponse(request, randomNum*1000);
         }
-        await().atMost(45, TimeUnit.SECONDS).untilAtomic(count, equalTo(maxRequests));
+        await().atMost(60, TimeUnit.SECONDS).untilAtomic(count, equalTo(maxRequests));
     }
     
     @Test(timeout = 60000)


### PR DESCRIPTION
Currently  all the responses are handled by one thread which may slow down and cause lag.
Use newCachedThreadPool to handle each response (unmarshalling and module specific response processing).
Also re-enable consumer thread if it gets closed by any error.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-12232
* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-12236

* Bamboo (Continuous Integration): https://bamboo.opennms.org/

