### PR TITLE
NMS-12217: Fix node location change in Requisition UI

### DIFF
--- a/opennms-webapp/src/main/webapp/js/onms-requisitions/views/node-basic.html
+++ b/opennms-webapp/src/main/webapp/js/onms-requisitions/views/node-basic.html
@@ -19,7 +19,8 @@
 <div class="form-group">
   <label class="control-label" for="nodeLabel">Minion Location</label>
   <input class="form-control" type="text" id="location" name="location" placeholder="Location [optional]" ng-model="node.location" ng-disabled="availableLocations.length == 0"
-         typeahead-min-length="0" typeahead-editable="false" uib-typeahead="location for location in availableLocations"></input>
+         typeahead-min-length="0" typeahead-editable="false" uib-typeahead="location for location in availableLocations" typeahead-on-select='nodeForm.$setDirty();'>
+  </input>
   <p ng-show="availableLocations.length == 0" class="help-block">There are no locations available.</p>
 </div>
 <div class="form-group">


### PR DESCRIPTION
typeahead select won't make form dirty. Trigger this explicitly with typeahead-on-select

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-12217
* Bamboo (Continuous Integration): https://bamboo.opennms.org/

