### PR TITLE
NMS-12243: Leverage telemetry sequencing for better thresholding performance

### DIFF
--- a/features/collection/api/src/main/java/org/opennms/netmgt/collection/api/CollectionSet.java
+++ b/features/collection/api/src/main/java/org/opennms/netmgt/collection/api/CollectionSet.java
@@ -30,6 +30,7 @@ package org.opennms.netmgt.collection.api;
 
 import java.util.Date;
 import java.util.List;
+import java.util.OptionalLong;
 
 
 /**
@@ -54,4 +55,12 @@ public interface CollectionSet extends CollectionVisitable {
      * @return
     */
     Date getCollectionTimestamp();
+
+    /**
+     * @return an optional containing the sequence number of the source this collection set was built from if
+     * applicable, otherwise an empty optional
+     */
+    default OptionalLong getSequenceNumber() {
+        return OptionalLong.empty();
+    }
 }

--- a/features/collection/api/src/main/java/org/opennms/netmgt/collection/dto/CollectionSetDTO.java
+++ b/features/collection/api/src/main/java/org/opennms/netmgt/collection/dto/CollectionSetDTO.java
@@ -35,6 +35,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
+import java.util.OptionalLong;
 import java.util.Set;
 
 import javax.xml.bind.annotation.XmlAccessType;
@@ -79,14 +80,18 @@ public class CollectionSetDTO implements CollectionSet {
     @XmlAttribute(name="disable-counter-persistence")
     private Boolean disableCounterPersistence;
 
+    @XmlAttribute(name = "sequence-number")
+    private Long sequenceNumber;
+
     public CollectionSetDTO() { }
 
     public CollectionSetDTO(CollectionAgent agent, CollectionStatus status,
             Date timestamp, Map<Resource, List<Attribute<?>>> attributesByResource,
-            boolean disableCounterPersistence) {
+            boolean disableCounterPersistence, Long sequenceNumber) {
         this.agent = new CollectionAgentDTO(agent);
         this.status = status;
         this.timestamp = timestamp;
+        this.sequenceNumber = sequenceNumber;
         collectionResources = new ArrayList<>();
         for (Entry<Resource, List<Attribute<?>>> entry : attributesByResource.entrySet()) {
             collectionResources.add(new CollectionResourceDTO(entry.getKey(), entry.getValue()));
@@ -104,7 +109,7 @@ public class CollectionSetDTO implements CollectionSet {
 
     @Override
     public int hashCode() {
-        return Objects.hash(agent, collectionResources, status, timestamp, disableCounterPersistence);
+        return Objects.hash(agent, collectionResources, status, timestamp, disableCounterPersistence, sequenceNumber);
     }
 
     @Override
@@ -121,7 +126,8 @@ public class CollectionSetDTO implements CollectionSet {
                && Objects.equals(this.collectionResources, other.collectionResources)
                && Objects.equals(this.status, other.status)
                && Objects.equals(this.timestamp, other.timestamp)
-               && Objects.equals(this.disableCounterPersistence, other.disableCounterPersistence);
+               && Objects.equals(this.disableCounterPersistence, other.disableCounterPersistence)
+               && Objects.equals(this.sequenceNumber, other.sequenceNumber);
     }
 
     @Override
@@ -213,5 +219,10 @@ public class CollectionSetDTO implements CollectionSet {
         }
 
         visitor.completeCollectionSet(this);
+    }
+
+    @Override
+    public OptionalLong getSequenceNumber() {
+        return sequenceNumber == null ? OptionalLong.empty() : OptionalLong.of(sequenceNumber);
     }
 }

--- a/features/collection/api/src/main/java/org/opennms/netmgt/collection/support/builder/CollectionSetBuilder.java
+++ b/features/collection/api/src/main/java/org/opennms/netmgt/collection/support/builder/CollectionSetBuilder.java
@@ -66,6 +66,7 @@ public class CollectionSetBuilder {
     private Date m_timestamp = new Date();
     private Map<Resource, List<Attribute<?>>> m_attributesByResource = new LinkedHashMap<>();
     private boolean m_disableCounterPersistence = false;
+    private Long m_sequenceNumber;
 
     public CollectionSetBuilder(CollectionAgent agent) {
         m_agent = Objects.requireNonNull(agent, "agent cannot be null");
@@ -133,9 +134,16 @@ public class CollectionSetBuilder {
         m_disableCounterPersistence = disableCounterPersistence;
         return this;
     }
+    
+    public CollectionSetBuilder withSequenceNumber(Long sequenceNumber) {
+        m_sequenceNumber = sequenceNumber;
+        return this;
+    }
 
     public CollectionSetDTO build() {
-        return new CollectionSetDTO(m_agent, m_status, m_timestamp, m_attributesByResource, m_disableCounterPersistence);
+        return new CollectionSetDTO(m_agent, m_status, m_timestamp, m_attributesByResource,
+                m_disableCounterPersistence, m_sequenceNumber);
+
     }
 
     public static AbstractCollectionResource toCollectionResource(Resource resource, CollectionAgent agent) {

--- a/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/AbstractThresholdEvaluatorState.java
+++ b/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/AbstractThresholdEvaluatorState.java
@@ -155,7 +155,7 @@ public abstract class AbstractThresholdEvaluatorState<T extends Serializable> im
         // If both of those conditions are false, then we must be on a standalone instance of OpenNMS and have the state
         // already in memory so there is no need to fetch it
         if (!isDistributed() && !firstEvaluation) {
-            fetchState();
+            return;
         }
 
         try {

--- a/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/CollectionResourceWrapper.java
+++ b/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/CollectionResourceWrapper.java
@@ -76,6 +76,7 @@ public class CollectionResourceWrapper {
     private final CollectionResource m_resource;
     private final Map<String, CollectionAttribute> m_attributes;
     private final ResourceStorageDao m_resourceStorageDao;
+    private final Long m_sequenceNumber;
 
     /**
      * Keeps track of both the Double value, and when it was collected, for the static cache of attributes
@@ -146,7 +147,7 @@ public class CollectionResourceWrapper {
      */
     public CollectionResourceWrapper(Date collectionTimestamp, int nodeId, String hostAddress, String serviceName,
             RrdRepository repository, CollectionResource resource, Map<String, CollectionAttribute> attributes,
-            ResourceStorageDao resourceStorageDao, IfLabel ifLabelDao) {
+            ResourceStorageDao resourceStorageDao, IfLabel ifLabelDao, Long sequenceNumber) {
 
         if (collectionTimestamp == null) {
             throw new IllegalArgumentException(String.format("%s: Null collection timestamp when thresholding service %s on node %d (%s)", this.getClass().getSimpleName(), serviceName, nodeId, hostAddress));
@@ -160,6 +161,7 @@ public class CollectionResourceWrapper {
         m_resource = resource;
         m_attributes = attributes;
         m_resourceStorageDao = resourceStorageDao;
+        m_sequenceNumber = sequenceNumber;
 
         if (isAnInterfaceResource()) {
             if (resource instanceof AliasedResource) { // TODO What about AliasedResource's custom attributes?
@@ -520,7 +522,11 @@ public class CollectionResourceWrapper {
 
         return null;
     }
-    
+
+    public Long getSequenceNumber() {
+        return m_sequenceNumber;
+    }
+
     /** {@inheritDoc} */
     @Override
     public String toString() {

--- a/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/ThresholdEntity.java
+++ b/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/ThresholdEntity.java
@@ -257,7 +257,7 @@ public final class ThresholdEntity implements Cloneable {
         LOG.debug("evaluate: value= {} against threshold: {}", dsValue, this);
 
         for (ThresholdEvaluatorState item : getThresholdEvaluatorStates(instance)) {
-            Status status = item.evaluate(dsValue);
+            Status status = item.evaluate(dsValue, resource == null ? null : resource.getSequenceNumber());
             Event event = item.getEventForState(status, date, dsValue, resource);
             if (event != null) {
                 events.add(event);

--- a/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/ThresholdEvaluatorState.java
+++ b/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/ThresholdEvaluatorState.java
@@ -56,7 +56,11 @@ public interface ThresholdEvaluatorState {
      * @param dsValue a double.
      * @return a {@link org.opennms.netmgt.threshd.ThresholdEvaluatorState.Status} object.
      */
-    public Status evaluate(double dsValue);
+    default Status evaluate(double dsValue) {
+        return evaluate(dsValue, null);
+    }
+    
+    Status evaluate(double dsValue, Long sequenceNumber);
 
     /**
      * <p>getEventForState</p>

--- a/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/ThresholdingServiceImpl.java
+++ b/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/ThresholdingServiceImpl.java
@@ -192,9 +192,9 @@ public class ThresholdingServiceImpl implements ThresholdingService, EventListen
                 kvStore.get(), isDistributed);
     }
 
-    public ThresholdingVisitorImpl getThresholdingVistor(ThresholdingSession session) throws ThresholdInitializationException {
+    public ThresholdingVisitorImpl getThresholdingVistor(ThresholdingSession session, Long sequenceNumber) throws ThresholdInitializationException {
         ThresholdingSetImpl thresholdingSet = (ThresholdingSetImpl) thresholdingSetPersister.getThresholdingSet(session, eventProxy);
-        return new ThresholdingVisitorImpl(thresholdingSet, ((ThresholdingSessionImpl) session).getResourceDao(), eventProxy);
+        return new ThresholdingVisitorImpl(thresholdingSet, ((ThresholdingSessionImpl) session).getResourceDao(), eventProxy, sequenceNumber);
     }
 
     public EventIpcManager getEventIpcManager() {

--- a/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/ThresholdingServiceImpl.java
+++ b/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/ThresholdingServiceImpl.java
@@ -63,6 +63,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
 
 /**
@@ -265,5 +266,10 @@ public class ThresholdingServiceImpl implements ThresholdingService, EventListen
                 kvStore.set(keyValueStore);
             }
         }
+    }
+
+    @VisibleForTesting
+    public void setDistributed(boolean distributed) {
+        isDistributed = distributed;
     }
 }

--- a/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/ThresholdingSessionImpl.java
+++ b/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/ThresholdingSessionImpl.java
@@ -101,7 +101,9 @@ public class ThresholdingSessionImpl implements ThresholdingSession {
     }
 
     private void acceptCollection(CollectionSet collectionSet) throws ThresholdInitializationException {
-        ThresholdingVisitorImpl thresholdingVisitor = service.getThresholdingVistor(this);
+        Long sequenceNumber = collectionSet.getSequenceNumber().isPresent() ?
+                collectionSet.getSequenceNumber().getAsLong() : null;
+        ThresholdingVisitorImpl thresholdingVisitor = service.getThresholdingVistor(this, sequenceNumber);
 
         if (thresholdingVisitor == null) {
             LOG.error("No thresholdingVisitor for ThresholdingSession {}", sessionKey);

--- a/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/ThresholdingSetImpl.java
+++ b/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/ThresholdingSetImpl.java
@@ -529,14 +529,15 @@ public class ThresholdingSetImpl implements ThresholdingSet {
         return hasThresholds(resource.getResourceTypeName(), attribute.getName());
     }
 
-    public List<Event> applyThresholds(CollectionResource resource, Map<String, CollectionAttribute> attributesMap, Date collectionTimestamp) {
+    public List<Event> applyThresholds(CollectionResource resource, Map<String, CollectionAttribute> attributesMap,
+                                       Date collectionTimestamp, Long sequenceNumber) {
         if (!isCollectionEnabled(resource)) {
             LOG.debug("applyThresholds: Ignoring resource {} because data collection is disabled for this resource.", resource);
             return new LinkedList<>();
         }
         CollectionResourceWrapper resourceWrapper = new CollectionResourceWrapper(collectionTimestamp, m_nodeId,
                 m_hostAddress, m_serviceName, m_repository, resource, attributesMap, m_resourceStorageDao,
-                m_ifLabelDao);
+                m_ifLabelDao, sequenceNumber);
         resourceWrapper.setCounterReset(m_counterReset);
         return Collections.unmodifiableList(applyThresholds(resourceWrapper, attributesMap));
     }

--- a/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/ThresholdingVisitorImpl.java
+++ b/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/ThresholdingVisitorImpl.java
@@ -83,11 +83,15 @@ public class ThresholdingVisitorImpl extends AbstractCollectionSetVisitor implem
 	private Date m_collectionTimestamp;
 
     private ThresholdingEventProxy m_thresholdingEventProxy;
+    
+    private final Long m_sequenceNumber;
 
-    protected ThresholdingVisitorImpl(ThresholdingSetImpl thresholdingSet, ResourceStorageDao resourceStorageDao, ThresholdingEventProxy eventProxy) {
+    protected ThresholdingVisitorImpl(ThresholdingSetImpl thresholdingSet, ResourceStorageDao resourceStorageDao,
+                                      ThresholdingEventProxy eventProxy, Long sequenceNumber) {
         m_thresholdingSet = thresholdingSet;
         m_thresholdingEventProxy = eventProxy;
         m_collectionTimestamp = new Date();
+        m_sequenceNumber = sequenceNumber;
     }
     
     public void setCounterReset(boolean counterReset) {
@@ -155,7 +159,8 @@ public class ThresholdingVisitorImpl extends AbstractCollectionSetVisitor implem
      */
     @Override
     public void completeResource(CollectionResource resource) {
-        List<Event> eventList = m_thresholdingSet.applyThresholds(resource, m_attributesMap, m_collectionTimestamp);
+        List<Event> eventList = m_thresholdingSet.applyThresholds(resource, m_attributesMap, m_collectionTimestamp,
+                m_sequenceNumber);
         for (Event event : eventList) {
             m_thresholdingEventProxy.sendEvent(event);
         }

--- a/features/collection/thresholding/impl/src/test/java/org/opennms/netmgt/threshd/CollectionResourceWrapperIT.java
+++ b/features/collection/thresholding/impl/src/test/java/org/opennms/netmgt/threshd/CollectionResourceWrapperIT.java
@@ -149,7 +149,7 @@ public class CollectionResourceWrapperIT {
     @Test(expected=IllegalArgumentException.class)
     public void testBadConstructorCall() throws Throwable {
         try {
-            new CollectionResourceWrapper(null, 1, "127.0.0.1", "HTTP", null, null, null, null, null);
+            new CollectionResourceWrapper(null, 1, "127.0.0.1", "HTTP", null, null, null, null, null, null);
         } catch (Throwable e) {
             //e.printStackTrace();
             throw e;
@@ -159,7 +159,7 @@ public class CollectionResourceWrapperIT {
     @Test(expected=IllegalArgumentException.class)
     public void testBadderConstructorCall() throws Throwable {
         try {
-            new CollectionResourceWrapper(null, -1, null, null, null, null, null, null, null);
+            new CollectionResourceWrapper(null, -1, null, null, null, null, null, null, null, null);
         } catch (Throwable e) {
             e.printStackTrace();
             throw e;
@@ -571,7 +571,7 @@ public class CollectionResourceWrapperIT {
     // Wrapper interval value for counter rates calculation should be expressed in seconds.
     private CollectionResourceWrapper createWrapper(SnmpCollectionResource resource, Map<String, CollectionAttribute> attributes, Date timestamp) {
         CollectionResourceWrapper wrapper = new CollectionResourceWrapper(timestamp, 1, "127.0.0.1", "SNMP",
-                getRepository(), resource, attributes, getResourceStorageDao(), m_ifLabelDao);
+                getRepository(), resource, attributes, getResourceStorageDao(), m_ifLabelDao, null);
         return wrapper;
     }
     

--- a/features/collection/thresholding/impl/src/test/java/org/opennms/netmgt/threshd/MockCollectionResourceWrapper.java
+++ b/features/collection/thresholding/impl/src/test/java/org/opennms/netmgt/threshd/MockCollectionResourceWrapper.java
@@ -83,7 +83,7 @@ public class MockCollectionResourceWrapper extends CollectionResourceWrapper {
             public ResourcePath getPath() {
                 return null;
             }
-        }, null, null, null);
+        }, null, null, null, null);
     }
 
 }

--- a/features/collection/thresholding/itests/src/test/java/org/opennms/netmgt/threshd/ThresholdingVisitorIT.java
+++ b/features/collection/thresholding/itests/src/test/java/org/opennms/netmgt/threshd/ThresholdingVisitorIT.java
@@ -1688,7 +1688,7 @@ public class ThresholdingVisitorIT {
         ThresholdingSetImpl thresholdingSet = new ThresholdingSetImpl(node, location, serviceName, getRepository(),
                 svcParams, m_resourceStorageDao, eventProxy, MockSession.getSession(), m_threshdDao, m_thresholdingDao,
                 m_pollOutagesDao, m_ifLabelDao);
-        ThresholdingVisitor visitor = new ThresholdingVisitorImpl(thresholdingSet, m_resourceStorageDao, eventProxy);
+        ThresholdingVisitor visitor = new ThresholdingVisitorImpl(thresholdingSet, m_resourceStorageDao, eventProxy, null);
         assertNotNull(visitor);
         return visitor;
     }

--- a/features/distributed/kv-store/blob/no-op/src/main/java/org/opennms/features/distributed/kvstore/blob/noop/NoOpBlobStore.java
+++ b/features/distributed/kv-store/blob/no-op/src/main/java/org/opennms/features/distributed/kvstore/blob/noop/NoOpBlobStore.java
@@ -28,11 +28,14 @@
 
 package org.opennms.features.distributed.kvstore.blob.noop;
 
+import java.util.Collection;
 import java.util.Optional;
 import java.util.OptionalLong;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import org.opennms.features.distributed.kvstore.api.AbstractAsyncKeyValueStore;
 import org.opennms.features.distributed.kvstore.api.BlobStore;
+import org.opennms.features.distributed.kvstore.api.KeyValueStore;
 
 /**
  * A {@link BlobStore key value store} that does nothing. Since no puts result in any operation, all retrieves
@@ -42,28 +45,40 @@ import org.opennms.features.distributed.kvstore.api.BlobStore;
 public class NoOpBlobStore extends AbstractAsyncKeyValueStore<byte[]> implements BlobStore {
     private static final NoOpBlobStore INSTANCE = new NoOpBlobStore();
 
+    // A collection of listeners to facilitate testing, all of the listeners will be called with the same calls this
+    // impl receives
+    private final Collection<KeyValueStore<byte[]>> blobStoreListeners = new CopyOnWriteArrayList<>();
+
     public static BlobStore getInstance() {
         return INSTANCE;
     }
 
     @Override
     public long put(String key, byte[] value, String context, Integer ttlInSeconds) {
+        blobStoreListeners.forEach(bl -> bl.put(key, value, context, ttlInSeconds));
         return 0;
     }
 
     @Override
     public Optional<byte[]> get(String key, String context) {
+        blobStoreListeners.forEach(bl -> bl.get(key, context));
         return Optional.empty();
     }
 
     @Override
     public Optional<Optional<byte[]>> getIfStale(String key, String context, long timestamp) {
+        blobStoreListeners.forEach(bl -> bl.getIfStale(key, context, timestamp));
         return Optional.empty();
     }
 
     @Override
     public OptionalLong getLastUpdated(String key, String context) {
+        blobStoreListeners.forEach(bl -> bl.getLastUpdated(key, context));
         return OptionalLong.empty();
+    }
+
+    public void addListener(KeyValueStore<byte[]> listener) {
+        blobStoreListeners.add(listener);
     }
 
     @Override

--- a/features/telemetry/itests/src/test/java/org/opennms/netmgt/telemetry/itests/ThresholdingIT.java
+++ b/features/telemetry/itests/src/test/java/org/opennms/netmgt/telemetry/itests/ThresholdingIT.java
@@ -29,6 +29,7 @@
 package org.opennms.netmgt.telemetry.itests;
 
 import static com.jayway.awaitility.Awaitility.await;
+import static junit.framework.TestCase.fail;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasSize;
@@ -46,7 +47,10 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.Date;
+import java.util.Optional;
+import java.util.OptionalLong;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -58,6 +62,8 @@ import org.opennms.core.test.db.MockDatabase;
 import org.opennms.core.test.db.annotations.JUnitTemporaryDatabase;
 import org.opennms.core.utils.InetAddressUtils;
 import org.opennms.core.xml.JaxbUtils;
+import org.opennms.features.distributed.kvstore.api.AbstractAsyncKeyValueStore;
+import org.opennms.features.distributed.kvstore.blob.noop.NoOpBlobStore;
 import org.opennms.netmgt.collection.test.api.CollectorTestUtils;
 import org.opennms.netmgt.config.dao.thresholding.api.OverrideableThreshdDao;
 import org.opennms.netmgt.config.dao.thresholding.api.OverrideableThresholdingDao;
@@ -156,6 +162,9 @@ public class ThresholdingIT {
     @Autowired
     private OverrideableThresholdingDao thresholdingDao;
     
+    @Autowired
+    private NoOpBlobStore noOpBlobStore;
+    
     @Before
     public void setUp() throws IOException {
         rrdBaseDir = tempFolder.newFolder("rrd");
@@ -200,7 +209,7 @@ public class ThresholdingIT {
         EventAnticipator eventAnticipator = mockEventIpcManager.getEventAnticipator();
 
         // Send an initial message
-        sendTelemetryMessage("192.0.2.1", "ge_0_0_3", ifInOctets, ifOutOctets, 0);
+        sendTelemetryMessage("192.0.2.1", "ge_0_0_3", ifInOctets, ifOutOctets, 0, 0);
 
         // Wait for the RRD file to be created
         await().atMost(60, TimeUnit.SECONDS).until(ifIn1SecPktsRrdFile::exists, equalTo(true));
@@ -215,7 +224,7 @@ public class ThresholdingIT {
         // Send another message
         ifInOctets += 10000000;
         ifOutOctets += 10000000;
-        sendTelemetryMessage("192.0.2.1", "ge_0_0_3", ifInOctets, ifOutOctets, 5);
+        sendTelemetryMessage("192.0.2.1", "ge_0_0_3", ifInOctets, ifOutOctets, 5, 1);
 
         // Wait for the RRD file to be updated
         await().atMost(60, TimeUnit.SECONDS).until(ifIn1SecPktsRrdFile::lastModified, greaterThan(lastModified));
@@ -235,7 +244,7 @@ public class ThresholdingIT {
         // Send another message - this time with ifIn1SecPkts > threshold
         ifInOctets += 10000000;
         ifOutOctets += 10000000;
-        sendTelemetryMessage("192.0.2.1", "ge_0_0_3", ifInOctets, ifOutOctets, 20);
+        sendTelemetryMessage("192.0.2.1", "ge_0_0_3", ifInOctets, ifOutOctets, 20, 2);
 
         // Wait until our threshold was triggered - the anticipator will remove the event from the list once received
         await().atMost(60, TimeUnit.SECONDS).until(eventAnticipator::getAnticipatedEvents, hasSize(0));
@@ -244,9 +253,78 @@ public class ThresholdingIT {
         assertEquals(0, eventAnticipator.getUnanticipatedEvents().size());
     }
 
-    private void sendTelemetryMessage(String ipAddress, String ifName, long ifInOctets, long ifOutOctets, long ifIn1SecPkts) throws IOException {
+    @Test
+    public void canFetchAppropriatelyBasedOnSequenceNumber() throws Exception {
+        AtomicInteger fetchCounter = new AtomicInteger(0);
+        // Hook into the blob store so we can see when fetches happen
+        noOpBlobStore.addListener(new AbstractAsyncKeyValueStore<byte[]>() {
+            @Override
+            public long put(String key, byte[] value, String context, Integer ttlInSeconds) {
+                return 0;
+            }
+
+            @Override
+            public Optional<byte[]> get(String key, String context) {
+                fetchCounter.incrementAndGet();
+                return Optional.empty();
+            }
+
+            @Override
+            public Optional<Optional<byte[]>> getIfStale(String key, String context, long timestamp) {
+                fetchCounter.incrementAndGet();
+                return Optional.empty();
+            }
+
+            @Override
+            public OptionalLong getLastUpdated(String key, String context) {
+                fetchCounter.incrementAndGet();
+                return null;
+            }
+        });
+
+        // Use our custom configuration
+        updateDaoWithConfig(getConfig(port));
+
+        // Start the daemon
+        telemetryd.start();
+
+        // Load custom threshd configuration
+        initThreshdFactories("/threshd-configuration.xml", "/thresholds.xml");
+        threshdDao.rebuildPackageIpListMap();
+
+        // Send an initial message with seq 0
+        sendTelemetryMessage("192.0.2.1", "ge_0_0_3", 1, 1, 0, 0);
+
+        // We should have fetched since this is the first message
+        await().atMost(5, TimeUnit.SECONDS).until(() -> fetchCounter.get() == 1);
+
+        // Wait one second before sending the next message (RRDs require at least a one second step)
+        Thread.sleep(TimeUnit.SECONDS.toMillis(1));
+
+        // Send a message with seq 1
+        sendTelemetryMessage("192.0.2.1", "ge_0_0_3", 1, 1, 5, 1);
+
+        // We shouldn't have fetched since we dealt with the last sequence num so lets wait a bit to make sure no fetch
+        // happens
+        try {
+            await().atMost(5, TimeUnit.SECONDS).until(() -> fetchCounter.get() != 1);
+            fail("Fetched when we shouldn't have");
+        } catch (Exception ignore) {
+        }
+
+        // Wait one second before sending the next message (RRDs require at least a one second step)
+        Thread.sleep(TimeUnit.SECONDS.toMillis(1));
+
+        // Send message with seq 3
+        sendTelemetryMessage("192.0.2.1", "ge_0_0_3", 1, 1, 20, 3);
+
+        // We should have fetched again since the sequence number changed by more than one
+        await().atMost(5, TimeUnit.SECONDS).until(() -> fetchCounter.get() != 1);
+    }
+
+    private void sendTelemetryMessage(String ipAddress, String ifName, long ifInOctets, long ifOutOctets, long ifIn1SecPkts, int sequenceNum) throws IOException {
         // Send a JTI payload via a UDP socket
-        final TelemetryTop.TelemetryStream jtiMsg = buildJtiMessage(ipAddress, ifName, ifInOctets, ifOutOctets, ifIn1SecPkts);
+        final TelemetryTop.TelemetryStream jtiMsg = buildJtiMessage(ipAddress, ifName, ifInOctets, ifOutOctets, ifIn1SecPkts, sequenceNum);
         final byte[] jtiMsgBytes = jtiMsg.toByteArray();
         InetAddress address = InetAddressUtils.getLocalHostAddress();
         DatagramPacket packet = new DatagramPacket(jtiMsgBytes, jtiMsgBytes.length, address, port);
@@ -255,7 +333,7 @@ public class ThresholdingIT {
         }
     }
 
-    private static TelemetryTop.TelemetryStream buildJtiMessage(String ipAddress, String ifName, long ifInOctets, long ifOutOctets, long ifIn1SecPkts) {
+    private static TelemetryTop.TelemetryStream buildJtiMessage(String ipAddress, String ifName, long ifInOctets, long ifOutOctets, long ifIn1SecPkts, int sequenceNum) {
         final Port.GPort port = Port.GPort.newBuilder()
                 .addInterfaceStats(Port.InterfaceInfos.newBuilder()
                         .setIfName(ifName)
@@ -298,6 +376,7 @@ public class ThresholdingIT {
                 .setSequenceNumber(sequence_no++)
                 .setTimestamp(new Date().getTime())
                 .setEnterprise(sensors)
+                .setSequenceNumber(sequenceNum)
                 .build();
 
         return jtiMsg;

--- a/features/telemetry/itests/src/test/java/org/opennms/netmgt/telemetry/itests/ThresholdingIT.java
+++ b/features/telemetry/itests/src/test/java/org/opennms/netmgt/telemetry/itests/ThresholdingIT.java
@@ -109,7 +109,7 @@ import org.springframework.test.context.ContextConfiguration;
         "classpath:/META-INF/opennms/applicationContext-daemon.xml",
         "classpath:/META-INF/opennms/mockEventIpcManager.xml",
         "classpath:/META-INF/opennms/applicationContext-thresholding.xml",
-        "classpath:/META-INF/opennms/applicationContext-testPostgresBlobStore.xml",
+        "classpath:/META-INF/opennms/applicationContext-noOpBlobStore.xml",
         "classpath:/META-INF/opennms/applicationContext-queuingservice-mq-vm.xml",
         "classpath:/META-INF/opennms/applicationContext-ipc-sink-camel-server.xml",
         "classpath:/META-INF/opennms/applicationContext-ipc-sink-camel-client.xml",
@@ -287,6 +287,9 @@ public class ThresholdingIT {
             }
         });
 
+        // Need to act as in distributed mode to test the fetch behavior
+        ((ThresholdingServiceImpl) thresholdingService).setDistributed(true);
+        
         // Use our custom configuration
         updateDaoWithConfig(getConfig(port));
 
@@ -324,7 +327,7 @@ public class ThresholdingIT {
         sendTelemetryMessage("192.0.2.1", "ge_0_0_3", 1, 1, 20, 3);
 
         // We should have fetched again since the sequence number changed by more than one
-        await().atMost(5, TimeUnit.SECONDS).until(() -> fetchCounter.get() != 1);
+        await().atMost(5, TimeUnit.SECONDS).until(() -> fetchCounter.get() == 2);
     }
 
     private void sendTelemetryMessage(String ipAddress, String ifName, long ifInOctets, long ifOutOctets, long ifIn1SecPkts, int sequenceNum) throws IOException {

--- a/features/telemetry/itests/src/test/java/org/opennms/netmgt/telemetry/itests/ThresholdingIT.java
+++ b/features/telemetry/itests/src/test/java/org/opennms/netmgt/telemetry/itests/ThresholdingIT.java
@@ -280,6 +280,11 @@ public class ThresholdingIT {
                 fetchCounter.incrementAndGet();
                 return null;
             }
+
+            @Override
+            public String getName() {
+                return "test";
+            }
         });
 
         // Use our custom configuration

--- a/opennms-base-assembly/src/main/filtered/etc/telemetryd-adapters/junos-telemetry-interface.groovy
+++ b/opennms-base-assembly/src/main/filtered/etc/telemetryd-adapters/junos-telemetry-interface.groovy
@@ -47,6 +47,9 @@ class CollectionSetGenerator {
         TelemetryTop.JuniperNetworksSensors jnprSensors = entSensors.getExtension(TelemetryTop.juniperNetworks);
         Port.GPort port = jnprSensors.getExtension(Port.jnprInterfaceExt);
 
+        // Record the sequence number
+        builder.withSequenceNumber(jtiMsg.getSequenceNumber())
+
         for (Port.InterfaceInfos interfaceInfos : port.getInterfaceStatsList()) {
             // Use the given ifName for the label (we don't have the ifDescr of the physAddr in this context)
             String interfaceLabel = RrdLabelUtils.computeLabelForRRD(interfaceInfos.getIfName(), null, null);

--- a/opennms-base-assembly/src/main/filtered/etc/telemetryd-adapters/sflow-host.groovy
+++ b/opennms-base-assembly/src/main/filtered/etc/telemetryd-adapters/sflow-host.groovy
@@ -35,6 +35,9 @@ import static org.opennms.netmgt.telemetry.protocols.common.utils.BsonUtils.getI
 
 NodeLevelResource nodeLevelResource = new NodeLevelResource(agent.getNodeId())
 
+// Set a sequence number if we can find one
+getInt64(msg, "sequence_number").ifPresent(sn -> builder.withSequenceNumber(sn))
+
 get(msg, "counters", "0:2003").ifPresent { doc ->
     builder.withGauge(nodeLevelResource, "host-cpu", "load_avg_1min", getDouble(doc, "load_one").get())
     builder.withGauge(nodeLevelResource, "host-cpu", "load_avg_5min", getDouble(doc, "load_five").get())


### PR DESCRIPTION
This PR updates thresholding to take into account the sequence number of collections sets derived from JTI messages. Using the sequence number in a distributed thresholding environment, we can determine if we were the instance that thresholded the previous sequence and in this case we can avoid retrieving the thresholding state from the KV store since we know we are up to date.

With this in place, the number of reads from the KV store that will be required by thresholding in a distributed deployment should be greatly reduced, resulting in better performance. In a steady state scenario we would expect that the same instance will receive the metrics for a given agent/resource and this should represent that majority of incoming messages. In an outage/Kafka partition rebalancing scenario the sequence number will indicate to us that we need to fetch state to resume and this should not happen often.

This was tested by adding coverage to existing IT.

This only works for metrics derived from JTI messages as I did not see a sequence number equivalent for NXOS/Netflow.


### All Contributors

* [x] Have you read and followed our [Contribution Guidelines](https://github.com/OpenNMS/opennms/blob/develop/CONTRIBUTING.md)?
* [x] Have you [made an issue in the OpenNMS issue tracker](https://issues.opennms.org)?<br>If so, you should:
  1. update the title of this PR to be of the format: `${JIRA-ISSUE-NUMBER}: subject of pull request`
  2. update the JIRA link at the bottom of this comment to refer to the real issue number
  3. prefix your commit messages with the issue number, if possible
* [x] Have you made a comment in that issue which points back to this PR?
* [x] Have you updated the JIRA link at the bottom of this comment to link to your issue?
* [x] If this is a new or updated feature, is there documentation for the new behavior?
* [x] If this is new code, are there unit and/or integration tests?
* [x] If this PR targets a `foundation-*` branch, does it avoid changing files in `$OPENNMS_HOME/etc/`?

### Pull Request Process

One or more reviewers should be assigned to each PR.

If you know that a particular person is subject matter expert in the area your PR affects, feel free to assign one or more reviewers when you create this PR, otherwise reviewers will be assigned for you.

Once the reviewer(s) accept the PR and the branch passes continuous integration in Bamboo, the PR is eligible for merge.

At that time, if you have commit access (are an OpenNMS Group employee or a member of the Order of the Green Polo) you are welcome to merge the PR.
Otherwise, a reviewer can merge it for you.

Thanks for taking time to contribute!

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-12243
* Bamboo (Continuous Integration): https://bamboo.opennms.org/

