### PR TITLE
NMS-8712: Handle time ranges in graphs page when rendering graphAll

### DIFF
--- a/opennms-web-api/src/main/java/org/opennms/web/svclayer/model/GraphResults.java
+++ b/opennms-web-api/src/main/java/org/opennms/web/svclayer/model/GraphResults.java
@@ -68,6 +68,7 @@ public class GraphResults {
     private static final Map<Integer, String> s_hourMap;
 
     private String[] m_reports;
+    private String m_nodeCriteria;
     
     private Date m_start;
     private Date m_end;
@@ -300,6 +301,15 @@ public class GraphResults {
     public void setReports(String[] reports) {
         m_reports = reports;
     }
+
+    public String getNodeCriteria() {
+        return m_nodeCriteria;
+    }
+
+    public void setNodeCriteria(String nodeCriteria) {
+        m_nodeCriteria = nodeCriteria;
+    }
+
 
     public class GraphResultSet {
         private List<Graph> m_graphs = null;

--- a/opennms-web-api/src/main/java/org/opennms/web/svclayer/support/DefaultGraphResultsService.java
+++ b/opennms-web-api/src/main/java/org/opennms/web/svclayer/support/DefaultGraphResultsService.java
@@ -108,8 +108,8 @@ public class DefaultGraphResultsService implements GraphResultsService, Initiali
         graphResults.setRelativeTime(relativeTime);
         graphResults.setRelativeTimePeriods(m_periods);
         graphResults.setReports(reports);
+        graphResults.setNodeCriteria(nodeCriteria);
 
-        // ResourceIds can be empty in case of GraphAll where resources are pulled from node.
         HashMap<ResourceId, List<OnmsResource>> resourcesMap = new HashMap<>();
         for (ResourceId resourceId : resourceIds) {
             LOG.debug("findResults: parent, childType, childName = {}, {}, {}", resourceId.parent, resourceId.type, resourceId.name);
@@ -138,7 +138,8 @@ public class DefaultGraphResultsService implements GraphResultsService, Initiali
             }
         }
 
-        if(!Strings.isNullOrEmpty(nodeCriteria)) {
+        // GraphAll case where all resources are fetched from node.
+        if (!Strings.isNullOrEmpty(nodeCriteria)) {
             OnmsNode node = m_nodeDao.get(nodeCriteria);
             if(node != null) {
                 OnmsResource nodeResource = m_resourceDao.getResourceForNode(node);
@@ -154,8 +155,6 @@ public class DefaultGraphResultsService implements GraphResultsService, Initiali
                 }
             }
         }
-
-
 
         graphResults.setGraphTopOffsetWithText(m_rrdDao.getGraphTopOffsetWithText());
         graphResults.setGraphLeftOffset(m_rrdDao.getGraphLeftOffset());

--- a/opennms-webapp/src/main/webapp/WEB-INF/jsp/graph/results.jsp
+++ b/opennms-webapp/src/main/webapp/WEB-INF/jsp/graph/results.jsp
@@ -68,9 +68,14 @@
     </c:if>
     <div id="customTimeForm" name="customTimeForm" ${showCustom}>
         <form role="form" class="form-inline top-buffer" id="range_form" action="${requestScope.relativeRequestPath}" method="get">
-            <c:forEach var="resultSet" items="${results.graphResultSets}">
-                <input type="hidden" name="resourceId" value="${resultSet.resource.id}"/>
-            </c:forEach>
+            <c:if test="${empty results.nodeCriteria}">
+                <c:forEach var="resultSet" items="${results.graphResultSets}">
+                    <input type="hidden" name="resourceId" value="${resultSet.resource.id}"/>
+                </c:forEach>
+            </c:if>
+            <c:if test="${not empty results.nodeCriteria}">
+                <input type="hidden" name="nodeCriteria" value="${results.nodeCriteria}"/>
+            </c:if>
             <c:forEach var="report" items="${results.reports}">
                 <input type="hidden" name="reports" value="${report}"/>
             </c:forEach>
@@ -281,9 +286,14 @@
 </div> <!-- graph-results -->
 
 <c:url var="relativeTimeReloadUrl" value="${requestScope.relativeRequestPath}">
-    <c:forEach var="resultSet" items="${results.graphResultSets}">
-        <c:param name="resourceId" value="${resultSet.resource.id}"/>
-    </c:forEach>
+    <c:if test="${empty results.nodeCriteria}">
+        <c:forEach var="resultSet" items="${results.graphResultSets}">
+            <c:param name="resourceId" value="${resultSet.resource.id}"/>
+        </c:forEach>
+   </c:if>
+   <c:if test="${not empty results.nodeCriteria}">
+        <c:param name="nodeCriteria" value="${results.nodeCriteria}"/>
+   </c:if>
     <c:forEach var="report" items="${results.reports}">
         <c:param name="reports" value="${report}"/>
     </c:forEach>


### PR DESCRIPTION
This is an extension of #2669 where applying custom time ranges may still throw `Request Header Fields Too Large` error.  This will handle those cases.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-8712
* Bamboo (Continuous Integration): https://bamboo.opennms.org/

