### PR TITLE
NMS-12249: Prevent ipHostName overwrites.

### DIFF
--- a/opennms-provision/opennms-provisiond/src/main/java/org/opennms/netmgt/provision/service/IPAddressTableTracker.java
+++ b/opennms-provision/opennms-provisiond/src/main/java/org/opennms/netmgt/provision/service/IPAddressTableTracker.java
@@ -29,7 +29,6 @@
 package org.opennms.netmgt.provision.service;
 
 import static org.opennms.core.utils.InetAddressUtils.getInetAddress;
-import static org.opennms.core.utils.InetAddressUtils.normalize;
 import static org.opennms.core.utils.InetAddressUtils.str;
 
 import java.net.InetAddress;
@@ -223,12 +222,6 @@ public class IPAddressTableTracker extends TableTracker {
                 iface.setSnmpInterface(snmpIface);
                 iface.setIfIndex(ifIndex);
             }
-
-            String hostName = null;
-            if (inetAddress != null) hostName = inetAddress.getHostName();
-            if (hostName == null) hostName = normalize(ipAddr);
-            LOG.debug("setIpHostName: {}", hostName);
-            iface.setIpHostName(hostName == null? ipAddr : hostName);
 
             return iface;
         }

--- a/opennms-provision/opennms-provisiond/src/main/java/org/opennms/netmgt/provision/service/IPInterfaceTableTracker.java
+++ b/opennms-provision/opennms-provisiond/src/main/java/org/opennms/netmgt/provision/service/IPInterfaceTableTracker.java
@@ -129,11 +129,6 @@ public class IPInterfaceTableTracker extends TableTracker {
                 iface.setIfIndex(ifIndex);
             }
 
-            String hostName = null;
-            if (inetAddress != null) hostName = inetAddress.getHostName();
-            if (hostName == null) hostName = InetAddressUtils.normalize(ipAddr);
-            iface.setIpHostName(hostName == null? ipAddr : hostName);
-            
             return iface;
         }
 

--- a/opennms-provision/opennms-provisiond/src/main/java/org/opennms/netmgt/provision/service/NodeScan.java
+++ b/opennms-provision/opennms-provisiond/src/main/java/org/opennms/netmgt/provision/service/NodeScan.java
@@ -90,7 +90,7 @@ public class NodeScan implements Scan {
      * @param nodeId a {@link java.lang.Integer} object.
      * @param foreignSource a {@link java.lang.String} object.
      * @param foreignId a {@link java.lang.String} object.
-     * @param location a {@link org.opennms.netmgt.model.monitoringLocation.OnmsMonitoringLocation} object.
+     * @param location a {@link org.opennms.netmgt.model.monitoringLocations.OnmsMonitoringLocation} object.
      * @param provisionService a {@link org.opennms.netmgt.provision.service.ProvisionService} object.
      * @param eventForwarder a {@link org.opennms.netmgt.events.api.EventForwarder} object.
      * @param agentConfigFactory a {@link org.opennms.netmgt.config.api.SnmpAgentConfigFactory} object.
@@ -141,7 +141,7 @@ public class NodeScan implements Scan {
     }
 
     private String getLocationName() {
-        return m_location == null ? null : m_location.getLocationName();
+        return m_location == null ? "Default" : m_location.getLocationName();
     }
 
     /**
@@ -450,6 +450,8 @@ public class NodeScan implements Scan {
                     if (iface != null) {
                         iface.setIpLastCapsdPoll(getScanStamp());
                         iface.setIsManaged("M");
+                        String hostName = getProvisionService().getHostnameResolver().getHostname(address, getLocationName());
+                        iface.setIpHostName(hostName);
 
                         final List<IpInterfacePolicy> policies = getProvisionService().getIpInterfacePoliciesForForeignSource(getForeignSource() == null ? "default" : getForeignSource());
                         for(final IpInterfacePolicy policy : policies) {
@@ -518,6 +520,8 @@ public class NodeScan implements Scan {
 
                         // add call to the ip interface is managed policies
                         iface.setIsManaged("M");
+                        String hostName = getProvisionService().getHostnameResolver().getHostname(address, getLocationName());
+                        iface.setIpHostName(hostName);
 
                         final List<IpInterfacePolicy> policies = getProvisionService().getIpInterfacePoliciesForForeignSource(getForeignSource() == null ? "default" : getForeignSource());
                         for(final IpInterfacePolicy policy : policies) {

--- a/opennms-provision/opennms-provisiond/src/main/java/org/opennms/netmgt/provision/service/operations/ScanManager.java
+++ b/opennms-provision/opennms-provisiond/src/main/java/org/opennms/netmgt/provision/service/operations/ScanManager.java
@@ -193,11 +193,11 @@ public class ScanManager {
             }
 
             for(final SnmpInstId ipAddr : ipAddrs) {   
-                m_ipAddrTable.updateIpInterfaceData(node, ipAddr.toString());
+                m_ipAddrTable.updateIpInterfaceData(node, InetAddressUtils.addr(ipAddr.toString()));
             }
 
             for (final InetAddress addr : ipAddresses) {
-            	m_ipAddressTable.updateIpInterfaceData(node, InetAddressUtils.str(addr));
+            	m_ipAddressTable.updateIpInterfaceData(node, addr);
             }
         } catch (final InterruptedException e) {
             LOG.info("thread interrupted while updating SNMP data", e);

--- a/opennms-provision/opennms-provisiond/src/main/java/org/opennms/netmgt/provision/service/snmp/IpAddrTable.java
+++ b/opennms-provision/opennms-provisiond/src/main/java/org/opennms/netmgt/provision/service/snmp/IpAddrTable.java
@@ -187,7 +187,7 @@ public class IpAddrTable extends SnmpTable<IpAddrTableEntry> {
      */
     public void updateIpInterfaceData(OnmsNode node) {
         for(IpAddrTableEntry entry : getEntries()) {
-            updateIpInterfaceData(node, InetAddressUtils.str(entry.getIpAdEntAddr()));
+            updateIpInterfaceData(node, entry.getIpAdEntAddr());
         }
     }
 
@@ -195,9 +195,9 @@ public class IpAddrTable extends SnmpTable<IpAddrTableEntry> {
      * <p>updateIpInterfaceData</p>
      *
      * @param node a {@link org.opennms.netmgt.model.OnmsNode} object.
-     * @param ipAddr a {@link java.lang.String} object.
+     * @param ipAddr a {@link InetAddress} object.
      */
-    public void updateIpInterfaceData(OnmsNode node, String ipAddr) {
+    public void updateIpInterfaceData(OnmsNode node, InetAddress ipAddr) {
         OnmsIpInterface ipIf = node.getIpInterfaceByIpAddress(ipAddr);
         if (ipIf == null) {
             ipIf = new OnmsIpInterface(ipAddr, node);
@@ -228,7 +228,6 @@ public class IpAddrTable extends SnmpTable<IpAddrTableEntry> {
 
         }
 
-        ipIf.setIpHostName(ipAddr);
     }
 
     /**

--- a/opennms-provision/opennms-provisiond/src/main/java/org/opennms/netmgt/provision/service/snmp/IpAddressTable.java
+++ b/opennms-provision/opennms-provisiond/src/main/java/org/opennms/netmgt/provision/service/snmp/IpAddressTable.java
@@ -195,7 +195,7 @@ public class IpAddressTable extends SnmpTable<IpAddressTableEntry> {
      */
     public void updateIpInterfaceData(final OnmsNode node) {
         for(final IpAddressTableEntry entry : getEntries()) {
-            updateIpInterfaceData(node, InetAddressUtils.str(entry.getIpAddress()));
+            updateIpInterfaceData(node, entry.getIpAddress());
         }
     }
 
@@ -205,7 +205,7 @@ public class IpAddressTable extends SnmpTable<IpAddressTableEntry> {
      * @param node a {@link org.opennms.netmgt.model.OnmsNode} object.
      * @param ipAddr a {@link java.lang.String} object.
      */
-    public void updateIpInterfaceData(final OnmsNode node, final String ipAddr) {
+    public void updateIpInterfaceData(final OnmsNode node, final InetAddress ipAddr) {
     	OnmsIpInterface ipIf = node.getIpInterfaceByIpAddress(ipAddr);
         if (ipIf == null) {
             ipIf = new OnmsIpInterface(ipAddr, node);
@@ -236,7 +236,6 @@ public class IpAddressTable extends SnmpTable<IpAddressTableEntry> {
 
         }
 
-        ipIf.setIpHostName(ipAddr);
     }
 
     /**


### PR DESCRIPTION
For `IpAddressTableTracker`,  `IpInterfaceTableTracker`, resolving the actual host name in NodeScan.
`IpAddrTable` and `IpAddressTable` seems to overwrite host name in existing interfaces, removed that.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-12249
* Bamboo (Continuous Integration): https://bamboo.opennms.org/

