### PR TITLE
NMS-12265: Fixed ServiceInstancePool housekeeping timer

### DIFF
--- a/integrations/opennms-vmware/src/main/java/org/opennms/protocols/vmware/ServiceInstancePool.java
+++ b/integrations/opennms-vmware/src/main/java/org/opennms/protocols/vmware/ServiceInstancePool.java
@@ -49,7 +49,7 @@ public class ServiceInstancePool {
     );
 
     private final Map<String, ServiceInstancePoolEntry> serviceInstancePoolEntries = new ConcurrentHashMap<>();
-    private final Timer timer = new Timer("ServiceInstancePool-Timer", false);
+    private final Timer timer = new Timer("ServiceInstancePool-Timer", true);
 
     public ServiceInstancePool() {
         this.timer.schedule(new TimerTask() {


### PR DESCRIPTION
The ServiceInstancePool housekeeping timer wasn't declared as daemon thread.
* JIRA: https://issues.opennms.org/browse/NMS-12265