### PR TITLE
NMS-12226: Spawn the java process directly to fetch the correct PID

### DIFF
--- a/opennms-base-assembly/src/main/filtered/bin/opennms
+++ b/opennms-base-assembly/src/main/filtered/bin/opennms
@@ -438,15 +438,15 @@ doStart(){
 		echo "end ulimit settings" >> "$REDIRECT"
 		echo "Executing command:" "${CMD[@]}" >> "$REDIRECT"
 
-		# NMS-12226 runCmd & spawns a subshell process for the function runCmd which is not the PID of the java process.
-		# To avoid this spawn the command directly so the $! is the PID of java.
-		if [[ "$NOEXECUTE" == "0" ]]; then
+      # NMS-12226 runCmd & spawns a subshell process for the function runCmd which is not the PID of the java process.
+      # To avoid this spawn the command directly so the $! is the PID of java.
+      if [[ "$NOEXECUTE" == "0" ]]; then
          "${CMD[@]}" >>"$REDIRECT" 2>&1 &
       else
-         echo "Skipping execution: ${CMD[@]}"
+         echo "Skipping execution: ${CMD[*]}"
       fi
 		OPENNMS_PID=$!
-		echo $OPENNMS_PID > "$OPENNMS_PIDFILE"
+      echo $OPENNMS_PID > "$OPENNMS_PIDFILE"
 	else
 		echo "running ulimit -a"
 		ulimit -a

--- a/opennms-base-assembly/src/main/filtered/bin/opennms
+++ b/opennms-base-assembly/src/main/filtered/bin/opennms
@@ -438,15 +438,15 @@ doStart(){
 		echo "end ulimit settings" >> "$REDIRECT"
 		echo "Executing command:" "${CMD[@]}" >> "$REDIRECT"
 
-      # NMS-12226 runCmd & spawns a subshell process for the function runCmd which is not the PID of the java process.
-      # To avoid this spawn the command directly so the $! is the PID of java.
-      if [[ "$NOEXECUTE" == "0" ]]; then
-         "${CMD[@]}" >>"$REDIRECT" 2>&1 &
-      else
-         echo "Skipping execution: ${CMD[*]}"
-      fi
-		OPENNMS_PID=$!
-      echo $OPENNMS_PID > "$OPENNMS_PIDFILE"
+        # NMS-12226 runCmd & spawns a subshell process for the function runCmd which is not the PID of the java process.
+        # To avoid this spawn the command directly so the $! is the PID of java.
+        if [[ "$NOEXECUTE" == "0" ]]; then
+            "${CMD[@]}" >>"$REDIRECT" 2>&1 &
+        else
+            echo "Skipping execution: ${CMD[*]}"
+        fi
+        OPENNMS_PID=$!
+        echo $OPENNMS_PID > "$OPENNMS_PIDFILE"
 	else
 		echo "running ulimit -a"
 		ulimit -a

--- a/opennms-base-assembly/src/main/filtered/bin/opennms
+++ b/opennms-base-assembly/src/main/filtered/bin/opennms
@@ -438,15 +438,15 @@ doStart(){
 		echo "end ulimit settings" >> "$REDIRECT"
 		echo "Executing command:" "${CMD[@]}" >> "$REDIRECT"
 
-        # NMS-12226 runCmd & spawns a subshell process for the function runCmd which is not the PID of the java process.
-        # To avoid this spawn the command directly so the $! is the PID of java.
-        if [[ "$NOEXECUTE" == "0" ]]; then
-            "${CMD[@]}" >>"$REDIRECT" 2>&1 &
-        else
-            echo "Skipping execution: ${CMD[*]}"
-        fi
-        OPENNMS_PID=$!
-        echo $OPENNMS_PID > "$OPENNMS_PIDFILE"
+		# NMS-12226 runCmd & spawns a subshell process for the function runCmd which is not the PID of the java process.
+		# To avoid this spawn the command directly so the $! is the PID of java.
+		if [[ "$NOEXECUTE" == "0" ]]; then
+			"${CMD[@]}" >>"$REDIRECT" 2>&1 &
+		else
+			echo "Skipping execution: ${CMD[*]}"
+		fi
+		OPENNMS_PID=$!
+		echo $OPENNMS_PID > "$OPENNMS_PIDFILE"
 	else
 		echo "running ulimit -a"
 		ulimit -a

--- a/opennms-base-assembly/src/main/filtered/bin/opennms
+++ b/opennms-base-assembly/src/main/filtered/bin/opennms
@@ -437,7 +437,14 @@ doStart(){
 		ulimit -a >> "$REDIRECT"
 		echo "end ulimit settings" >> "$REDIRECT"
 		echo "Executing command:" "${CMD[@]}" >> "$REDIRECT"
-		runCmd "${CMD[@]}" >>"$REDIRECT" 2>&1 &
+
+		# NMS-12226 runCmd & spawns a subshell process for the function runCmd which is not the PID of the java process.
+		# To avoid this spawn the command directly so the $! is the PID of java.
+		if [[ "$NOEXECUTE" == "0" ]]; then
+         "${CMD[@]}" >>"$REDIRECT" 2>&1 &
+      else
+         echo "Skipping execution: ${CMD[@]}"
+      fi
 		OPENNMS_PID=$!
 		echo $OPENNMS_PID > "$OPENNMS_PIDFILE"
 	else


### PR DESCRIPTION
### All Contributors

* [x] Have you read and followed our [Contribution Guidelines](https://github.com/OpenNMS/opennms/blob/develop/CONTRIBUTING.md)?
* [x] Have you [made an issue in the OpenNMS issue tracker](https://issues.opennms.org)?<br>If so, you should:
  1. update the title of this PR to be of the format: `${JIRA-ISSUE-NUMBER}: subject of pull request`
  2. update the JIRA link at the bottom of this comment to refer to the real issue number
  3. prefix your commit messages with the issue number, if possible
* [x] Have you made a comment in that issue which points back to this PR?
* [x] Have you updated the JIRA link at the bottom of this comment to link to your issue?
* [x] If this is a new or updated feature, is there documentation for the new behavior?
* [x] If this is new code, are there unit and/or integration tests?
* [x] If this PR targets a `foundation-*` branch, does it avoid changing files in `$OPENNMS_HOME/etc/`?

Spawn the java process directly instead of using the runCmd wrapper function as a background subshell process to fetch the correct PID for the PID file.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-12226

