### PR TITLE
NMS-10662: Map the notifd autoacknowledgement to alarms

### DIFF
--- a/opennms-base-assembly/src/main/filtered/etc/notifd-configuration.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/notifd-configuration.xml
@@ -1,26 +1,5 @@
-<notifd-configuration xmlns="http://xmlns.opennms.org/xsd/config/notifd" status="off" match-all="true">
-   <auto-acknowledge resolution-prefix="RESOLVED: " uei="uei.opennms.org/nodes/serviceResponsive" acknowledge="uei.opennms.org/nodes/serviceUnresponsive">
-      <match>nodeid</match>
-      <match>interfaceid</match>
-      <match>serviceid</match>
-   </auto-acknowledge>
-   <auto-acknowledge resolution-prefix="RESOLVED: " uei="uei.opennms.org/nodes/nodeRegainedService" acknowledge="uei.opennms.org/nodes/nodeLostService">
-      <match>nodeid</match>
-      <match>interfaceid</match>
-      <match>serviceid</match>
-   </auto-acknowledge>
-   <auto-acknowledge resolution-prefix="RESOLVED: " uei="uei.opennms.org/nodes/interfaceUp" acknowledge="uei.opennms.org/nodes/interfaceDown">
-      <match>nodeid</match>
-      <match>interfaceid</match>
-   </auto-acknowledge>
-   <auto-acknowledge resolution-prefix="RESOLVED: " uei="uei.opennms.org/nodes/nodeUp" acknowledge="uei.opennms.org/nodes/nodeDown">
-      <match>nodeid</match>
-   </auto-acknowledge>
-   <auto-acknowledge resolution-prefix="RESOLVED: " uei="uei.opennms.org/correlation/remote/wideSpreadOutageResolved" acknowledge="uei.opennms.org/correlation/remote/wideSpreadOutage">
-      <match>nodeid</match>
-      <match>interfaceid</match>
-      <match>serviceid</match>
-   </auto-acknowledge>
+<notifd-configuration xmlns="http://xmlns.opennms.org/xsd/config/notifd" status="on" match-all="true">
+   <auto-acknowledge-alarm resolution-prefix="RESOLVED: "/>
    <queue>
       <queue-id>default</queue-id>
       <interval>20s</interval>
@@ -29,3 +8,4 @@
       </handler-class>
    </queue>
 </notifd-configuration>
+


### PR DESCRIPTION
### All Contributors

* [x] Have you read and followed our [Contribution Guidelines](https://github.com/OpenNMS/opennms/blob/develop/CONTRIBUTING.md)?
* [x] Have you [made an issue in the OpenNMS issue tracker](https://issues.opennms.org)?<br>If so, you should:
  1. update the title of this PR to be of the format: `${JIRA-ISSUE-NUMBER}: subject of pull request`
  2. update the JIRA link at the bottom of this comment to refer to the real issue number
  3. prefix your commit messages with the issue number, if possible
* [x] Have you made a comment in that issue which points back to this PR?
* [x] Have you updated the JIRA link at the bottom of this comment to link to your issue?
* [x] If this is a new or updated feature, is there documentation for the new behavior?
* [x] If this is new code, are there unit and/or integration tests?
* [x] If this PR targets a `foundation-*` branch, does it avoid changing files in `$OPENNMS_HOME/etc/`?

Tested the notification for nodeDown/nodeLostService and interfaceDown successfully.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-10662


