### PR TITLE
NMS-12120: Add health wrapper for health:check

### DIFF
--- a/opennms-container/minion/Dockerfile
+++ b/opennms-container/minion/Dockerfile
@@ -33,8 +33,7 @@ RUN groupadd -g 10001 minion && \
 # Create SSH Key-Pair to use with the Karaf Shell
 RUN mkdir /opt/minion/.ssh && \
     chmod 700 /opt/minion/.ssh && \
-    ssh-keygen -t rsa -f /opt/minion/.ssh/id_rsa -q -N "" && \
-    chmod 600 /opt/minion/.ssh/id_rsa
+    ssh-keygen -t rsa -f /opt/minion/.ssh/id_rsa -q -N ""
 
 ##
 # Install and setup OpenNMS Minion RPMS
@@ -64,7 +63,8 @@ RUN if [[ "$(ls -1 /tmp/rpms/*.rpm 2>/dev/null | wc -l)" != 0 ]]; then dnf -y in
     echo "_g_\\:admingroup = group,admin,manager,viewer,systembundles,ssh" >> /opt/minion/etc/keys.properties && \
     chown 10001:10001 -R /opt/minion && \
     chgrp -R 0 /opt/minion && \
-    chmod -R g=u /opt/minion
+    chmod -R g=u /opt/minion && \
+    chmod 600 /opt/minion/.ssh/id_rsa
 
 COPY ./assets/* /
 

--- a/opennms-container/minion/Dockerfile
+++ b/opennms-container/minion/Dockerfile
@@ -6,7 +6,7 @@ ARG BASE_IMAGE_VERSION="11"
 
 FROM ${BASE_IMAGE}:${BASE_IMAGE_VERSION} as minion-base
 
-ARG REQUIRED_RPMS="wget gettext jicmp jicmp6"
+ARG REQUIRED_RPMS="wget gettext jicmp jicmp6 openssh-clients"
 
 ARG REPO_KEY_URL="https://yum.opennms.org/OPENNMS-GPG-KEY"
 ARG REPO_RPM="https://yum.opennms.org/repofiles/opennms-repo-stable-rhel8.noarch.rpm"
@@ -29,6 +29,12 @@ RUN setcap cap_net_raw+ep ${JAVA_HOME}/bin/java && \
 # Create Minion user with a specific group ID
 RUN groupadd -g 10001 minion && \
     adduser -u 10001 -g 10001 -d /opt/minion -s /usr/bin/bash minion
+
+# Create SSH Key-Pair to use with the Karaf Shell
+RUN mkdir /opt/minion/.ssh && \
+    chmod 700 /opt/minion/.ssh && \
+    ssh-keygen -t rsa -f /opt/minion/.ssh/id_rsa -q -N "" && \
+    chmod 600 /opt/minion/.ssh/id_rsa
 
 ##
 # Install and setup OpenNMS Minion RPMS
@@ -54,11 +60,13 @@ RUN if [[ "$(ls -1 /tmp/rpms/*.rpm 2>/dev/null | wc -l)" != 0 ]]; then dnf -y in
     dnf clean all && \
     rm -rf /var/cache/yum && \
     sed -r -i '/RUNAS/s/.*/export RUNAS=${USER}/' /etc/sysconfig/minion && \
+    echo minion=$(cat /opt/minion/.ssh/id_rsa.pub | awk '{print $2}'),viewer > /opt/minion/etc/keys.properties && \
+    echo "_g_\\:admingroup = group,admin,manager,viewer,systembundles,ssh" >> /opt/minion/etc/keys.properties && \
     chown 10001:10001 -R /opt/minion && \
     chgrp -R 0 /opt/minion && \
     chmod -R g=u /opt/minion
 
-COPY ./assets/entrypoint.sh /
+COPY ./assets/* /
 
 # Arguments for labels should not invalidate caches
 ARG BUILD_DATE="1970-01-01T00:00:00+0000"

--- a/opennms-container/minion/assets/health.sh
+++ b/opennms-container/minion/assets/health.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+if ssh -o StrictHostKeyChecking=no -p 8201 localhost health:check | grep --quiet "Everything is awesome"; then 
+  exit 0;
+else
+  exit 1;
+fi

--- a/opennms-container/sentinel/Dockerfile
+++ b/opennms-container/sentinel/Dockerfile
@@ -33,8 +33,7 @@ RUN groupadd -g 10001 sentinel && \
 # Create SSH Key-Pair to use with the Karaf Shell
 RUN mkdir /opt/sentinel/.ssh && \
     chmod 700 /opt/sentinel/.ssh && \
-    ssh-keygen -t rsa -f /opt/sentinel/.ssh/id_rsa -q -N "" && \
-    chmod 600 /opt/sentinel/.ssh/id_rsa
+    ssh-keygen -t rsa -f /opt/sentinel/.ssh/id_rsa -q -N ""
 
 ##
 # Install and setup OpenNMS Sentinel RPMS
@@ -62,7 +61,8 @@ RUN if [[ "$(ls -1 /tmp/rpms/*.rpm 2>/dev/null | wc -l)" != 0 ]]; then dnf -y in
     echo "_g_\\:admingroup = group,admin,manager,viewer,systembundles,ssh" >> /opt/sentinel/etc/keys.properties && \
     chown 10001:10001 -R /opt/sentinel && \
     chgrp -R 0 /opt/sentinel && \
-    chmod -R g=u /opt/sentinel
+    chmod -R g=u /opt/sentinel && \
+    chmod 600 /opt/sentinel/.ssh/id_rsa
 
 COPY ./assets/* /
 

--- a/opennms-container/sentinel/Dockerfile
+++ b/opennms-container/sentinel/Dockerfile
@@ -6,7 +6,7 @@ ARG BASE_IMAGE_VERSION="11"
 
 FROM ${BASE_IMAGE}:${BASE_IMAGE_VERSION} as sentinel-base
 
-ARG REQUIRED_RPMS="wget gettext"
+ARG REQUIRED_RPMS="wget gettext openssh-clients"
 
 ARG REPO_KEY_URL="https://yum.opennms.org/OPENNMS-GPG-KEY"
 ARG REPO_RPM="https://yum.opennms.org/repofiles/opennms-repo-stable-rhel8.noarch.rpm"
@@ -30,6 +30,12 @@ RUN setcap cap_net_raw+ep ${JAVA_HOME}/bin/java && \
 RUN groupadd -g 10001 sentinel && \
     adduser -u 10001 -g 10001 -d /opt/sentinel -s /usr/bin/bash sentinel
 
+# Create SSH Key-Pair to use with the Karaf Shell
+RUN mkdir /opt/sentinel/.ssh && \
+    chmod 700 /opt/sentinel/.ssh && \
+    ssh-keygen -t rsa -f /opt/sentinel/.ssh/id_rsa -q -N "" && \
+    chmod 600 /opt/sentinel/.ssh/id_rsa
+
 ##
 # Install and setup OpenNMS Sentinel RPMS
 ##
@@ -52,11 +58,13 @@ RUN if [[ "$(ls -1 /tmp/rpms/*.rpm 2>/dev/null | wc -l)" != 0 ]]; then dnf -y in
     dnf clean all && \
     rm -rf /var/cache/yum && \
     mkdir -p /opt/sentinel/data/{log,tmp} && \
+    echo sentinel=$(cat /opt/sentinel/.ssh/id_rsa.pub | awk '{print $2}'),viewer > /opt/sentinel/etc/keys.properties && \
+    echo "_g_\\:admingroup = group,admin,manager,viewer,systembundles,ssh" >> /opt/sentinel/etc/keys.properties && \
     chown 10001:10001 -R /opt/sentinel && \
     chgrp -R 0 /opt/sentinel && \
     chmod -R g=u /opt/sentinel
 
-COPY ./assets/entrypoint.sh /
+COPY ./assets/* /
 
 VOLUME [ "/opt/sentinel/deploy", "/opt/sentinel/etc", "/opt/sentinel/data" ]
 

--- a/opennms-container/sentinel/assets/health.sh
+++ b/opennms-container/sentinel/assets/health.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+if ssh -o StrictHostKeyChecking=no -p 8301 localhost health:check | grep --quiet "Everything is awesome"; then 
+  exit 0;
+else
+  exit 1;
+fi


### PR DESCRIPTION
### All Contributors

* [x] Have you read and followed our [Contribution Guidelines](https://github.com/OpenNMS/opennms/blob/develop/CONTRIBUTING.md)?
* [x] Have you [made an issue in the OpenNMS issue tracker](https://issues.opennms.org)?<br>If so, you should:
  1. update the title of this PR to be of the format: `${JIRA-ISSUE-NUMBER}: subject of pull request`
  2. update the JIRA link at the bottom of this comment to refer to the real issue number
  3. prefix your commit messages with the issue number, if possible
* [x] Have you made a comment in that issue which points back to this PR?
* [x] Have you updated the JIRA link at the bottom of this comment to link to your issue?
* [x] If this is a new or updated feature, is there documentation for the new behavior?
* [x] If this is new code, are there unit and/or integration tests?
* [x] If this PR targets a `foundation-*` branch, does it avoid changing files in `$OPENNMS_HOME/etc/`?

Using the Karaf client directly with the health check in Docker and Kubernetes doesn't work with the way the client is implemented. The output can not be correctly fetched and evaluated. A workaround would be using an SSH client and passing the credentials to the Karaf shell. This would be a) requires to install sshpass and ssh client packages in the container and b) exposing admin credentials in the health check command in Docker compose or Kubernetes.

This fix resolves the problem by creating a /tmp/file from the client command and evaluate it separately without the disadvantages described in a) and b).

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-12120
* Bamboo (Continuous Integration): https://bamboo.opennms.org/

