### PR TITLE
NMS-12283: Be able to execute ICMP requests through Java when running as non-root

### DIFF
--- a/opennms-container/horizon/Dockerfile
+++ b/opennms-container/horizon/Dockerfile
@@ -6,7 +6,7 @@ ARG BASE_IMAGE_VERSION="11"
 
 FROM ${BASE_IMAGE}:${BASE_IMAGE_VERSION} as horizon-base
 
-ARG REQUIRED_RPMS="rrdtool jrrd2 jicmp jicmp6 R-core rsync perl-XML-Twig perl-libwww-perl gettext"
+ARG REQUIRED_RPMS="rrdtool jrrd2 jicmp jicmp6 R-core rsync perl-XML-Twig perl-libwww-perl jq"
 
 ARG REPO_KEY_URL="https://yum.opennms.org/OPENNMS-GPG-KEY"
 ARG REPO_RPM="https://yum.opennms.org/repofiles/opennms-repo-stable-rhel7.noarch.rpm"

--- a/opennms-container/horizon/build_container_image.sh
+++ b/opennms-container/horizon/build_container_image.sh
@@ -22,7 +22,7 @@ done
 docker build -t horizon \
   --build-arg BUILD_DATE="$(date -u +\"%Y-%m-%dT%H:%M:%S%z\")" \
   --build-arg BASE_IMAGE="opennms/openjdk" \
-  --build-arg BASE_IMAGE_VERSION="11.0.3.7-b1" \
+  --build-arg BASE_IMAGE_VERSION="11.0.4.11" \
   --build-arg VERSION="${VERSION}" \
   --build-arg BUILD_NUMBER="${CIRCLE_BUILD_NUM}" \
   --build-arg BUILD_URL="${CIRCLE_BUILD_URL}" \

--- a/opennms-container/minion/Dockerfile
+++ b/opennms-container/minion/Dockerfile
@@ -21,6 +21,11 @@ RUN rpm --import "${REPO_KEY_URL}" && \
     yum clean all -y && \
     rm -rf /var/cache/yum
 
+# Allow to send ICMP messages as non-root user
+RUN setcap cap_net_raw+ep ${JAVA_HOME}/bin/java && \
+    echo ${JAVA_HOME}/lib/jli > /etc/ld.so.conf.d/java-latest.conf && \
+    ldconfig
+
 ##
 # Install and setup OpenNMS Minion RPMS
 ##

--- a/opennms-container/minion/build_container_image.sh
+++ b/opennms-container/minion/build_container_image.sh
@@ -22,7 +22,7 @@ done
 docker build -t minion \
   --build-arg BUILD_DATE="$(date -u +\"%Y-%m-%dT%H:%M:%S%z\")" \
   --build-arg BASE_IMAGE="opennms/openjdk" \
-  --build-arg BASE_IMAGE_VERSION="11.0.3.7-b1" \
+  --build-arg BASE_IMAGE_VERSION="11.0.4.11" \
   --build-arg VERSION="${VERSION}" \
   --build-arg BUILD_NUMBER="${CIRCLE_BUILD_NUM}" \
   --build-arg BUILD_URL="${CIRCLE_BUILD_URL}" \

--- a/opennms-container/sentinel/Dockerfile
+++ b/opennms-container/sentinel/Dockerfile
@@ -21,6 +21,11 @@ RUN rpm --import "${REPO_KEY_URL}" && \
     yum clean all -y && \
     rm -rf /var/cache/yum
 
+# Allow to send ICMP messages as non-root user
+RUN setcap cap_net_raw+ep ${JAVA_HOME}/bin/java && \
+    echo ${JAVA_HOME}/lib/jli > /etc/ld.so.conf.d/java-latest.conf && \
+    ldconfig
+
 ##
 # Install and setup OpenNMS Sentinel RPMS
 ##

--- a/opennms-container/sentinel/build_container_image.sh
+++ b/opennms-container/sentinel/build_container_image.sh
@@ -22,7 +22,7 @@ done
 docker build -t sentinel \
   --build-arg BUILD_DATE="$(date -u +\"%Y-%m-%dT%H:%M:%S%z\")" \
   --build-arg BASE_IMAGE="opennms/openjdk" \
-  --build-arg BASE_IMAGE_VERSION="11.0.3.7-b1" \
+  --build-arg BASE_IMAGE_VERSION="11.0.4.11" \
   --build-arg VERSION="${VERSION}" \
   --build-arg BUILD_NUMBER="${CIRCLE_BUILD_NUM}" \
   --build-arg BUILD_URL="${CIRCLE_BUILD_URL}" \


### PR DESCRIPTION
### All Contributors

* [x] Have you read and followed our [Contribution Guidelines](https://github.com/OpenNMS/opennms/blob/develop/CONTRIBUTING.md)?
* [x] Have you [made an issue in the OpenNMS issue tracker](https://issues.opennms.org)?<br>If so, you should:
  1. update the title of this PR to be of the format: `${JIRA-ISSUE-NUMBER}: subject of pull request`
  2. update the JIRA link at the bottom of this comment to refer to the real issue number
  3. prefix your commit messages with the issue number, if possible
* [x] Have you made a comment in that issue which points back to this PR?
* [x] Have you updated the JIRA link at the bottom of this comment to link to your issue?
* [x] If this is a new or updated feature, is there documentation for the new behavior?
* [x] If this is new code, are there unit and/or integration tests?
* [x] If this PR targets a `foundation-*` branch, does it avoid changing files in `$OPENNMS_HOME/etc/`?

Added the network capabilities to the Java process similar as in the Horizon image to allow sending ICMP packets with Java. Additionally, the OpenJDK version is bumped to the latest available version 11.0.4.11 in the CentOS 7 repositories. We have also removed `gettext` and added `jq` which was a request to make things easier from @agalue. The 3 changes are separate commits so they can be reverted individually if necessary.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-12283
* Bamboo (Continuous Integration): https://bamboo.opennms.org/

