### PR TITLE
NMS-10498: Don't make health:check fail if elastic is not configured (opennms-flows only)

### DIFF
--- a/core/health/api/src/main/java/org/opennms/core/health/api/Status.java
+++ b/core/health/api/src/main/java/org/opennms/core/health/api/Status.java
@@ -47,7 +47,7 @@ public enum Status {
     // Timeout: Health check timed out.
     Timeout,
 
-    // Failure: One or more errors occured while running the healthCheck.perform() method
+    // Failure: One or more errors occurred while running the healthCheck.perform() method
     Failure
     ;
 }

--- a/features/flows/elastic/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/features/flows/elastic/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -105,6 +105,7 @@
     <reference id="snmpInterfaceDao" interface="org.opennms.netmgt.dao.api.SnmpInterfaceDao" availability="mandatory" />
     <reference id="transactionOperations" interface="org.springframework.transaction.support.TransactionOperations" availability="mandatory" />
     <reference id="classificationEngine" interface="org.opennms.netmgt.flows.classification.ClassificationEngine" availability="mandatory" />
+    <reference id="configurationAdmin" interface="org.osgi.service.cm.ConfigurationAdmin"/>
     <bean id="documentEnricher" class="org.opennms.netmgt.flows.elastic.DocumentEnricher">
         <argument ref="flowRepositoryMetricRegistry" />
         <argument ref="classificationEngine" />
@@ -158,9 +159,11 @@
 
     <!-- Health Check -->
     <service interface="org.opennms.core.health.api.HealthCheck">
-        <bean class="org.opennms.plugins.elasticsearch.rest.ElasticHealthCheck" >
+        <bean class="org.opennms.plugins.elasticsearch.rest.RequireConfigurationElasticHealthCheck" >
             <argument ref="jestClient"/>
             <argument value="Flows"/>
+            <argument ref="configurationAdmin"/>
+            <argument value="org.opennms.features.flows.persistence.elastic" />
         </bean>
     </service>
 


### PR DESCRIPTION
Here we make the `health:check` pass the `ElasticHealthCheck` (for feature `opennms-flows`) if it is not configured. I went with `Success` over `Unknown` as anything besides `Success` is considered not awesome.

JIRA: https://issues.opennms.org/browse/NMS-10498