### PR TITLE
Cleanup: Use SessionUtils instead of TransactionOperations in module features/flows/elastic

### DIFF
--- a/features/flows/elastic/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/features/flows/elastic/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -103,14 +103,14 @@
     <reference id="interfaceToNodeCache" interface="org.opennms.netmgt.dao.api.InterfaceToNodeCache" availability="mandatory" />
     <reference id="nodeDao" interface="org.opennms.netmgt.dao.api.NodeDao" availability="mandatory" />
     <reference id="snmpInterfaceDao" interface="org.opennms.netmgt.dao.api.SnmpInterfaceDao" availability="mandatory" />
-    <reference id="transactionOperations" interface="org.springframework.transaction.support.TransactionOperations" availability="mandatory" />
+    <reference id="sessionUtils" interface="org.opennms.netmgt.dao.api.SessionUtils" availability="mandatory" />
     <reference id="classificationEngine" interface="org.opennms.netmgt.flows.classification.ClassificationEngine" availability="mandatory" />
     <bean id="documentEnricher" class="org.opennms.netmgt.flows.elastic.DocumentEnricher">
         <argument ref="flowRepositoryMetricRegistry" />
         <argument ref="classificationEngine" />
         <argument ref="nodeDao" />
         <argument ref="interfaceToNodeCache" />
-        <argument ref="transactionOperations" />
+        <argument ref="sessionUtils" />
         <argument ref="nodeCacheConfig" />
     </bean>
 
@@ -138,7 +138,7 @@
         <argument ref="indexStrategy"/>
         <argument ref="documentEnricher"/>
         <argument ref="classificationEngine"/>
-        <argument ref="transactionOperations"/>
+        <argument ref="sessionUtils"/>
         <argument ref="nodeDao"/>
         <argument ref="snmpInterfaceDao"/>
         <argument ref="identity"/>

--- a/features/flows/elastic/src/test/java/org/opennms/netmgt/flows/elastic/DefaultDirectionIT.java
+++ b/features/flows/elastic/src/test/java/org/opennms/netmgt/flows/elastic/DefaultDirectionIT.java
@@ -46,9 +46,8 @@ import org.junit.Test;
 import org.opennms.core.test.elastic.ElasticSearchRule;
 import org.opennms.core.test.elastic.ElasticSearchServerConfig;
 import org.opennms.netmgt.dao.mock.MockNodeDao;
+import org.opennms.netmgt.dao.mock.MockSessionUtils;
 import org.opennms.netmgt.dao.mock.MockSnmpInterfaceDao;
-import org.opennms.netmgt.dao.mock.MockTransactionManager;
-import org.opennms.netmgt.dao.mock.MockTransactionTemplate;
 import org.opennms.netmgt.flows.api.Flow;
 import org.opennms.netmgt.flows.api.FlowRepository;
 import org.opennms.netmgt.flows.classification.ClassificationEngine;
@@ -99,13 +98,9 @@ public class DefaultDirectionIT {
             final MockDocumentEnricherFactory mockDocumentEnricherFactory = new MockDocumentEnricherFactory();
             final DocumentEnricher documentEnricher = mockDocumentEnricherFactory.getEnricher();
             final ClassificationEngine classificationEngine = mockDocumentEnricherFactory.getClassificationEngine();
-            final MockTransactionTemplate mockTransactionTemplate = new MockTransactionTemplate();
-
-            mockTransactionTemplate.setTransactionManager(new MockTransactionManager());
-
             final FlowRepository elasticFlowRepository = new InitializingFlowRepository(
                     new ElasticFlowRepository(new MetricRegistry(), jestClient, IndexStrategy.MONTHLY, documentEnricher,
-                            classificationEngine, mockTransactionTemplate, new MockNodeDao(), new MockSnmpInterfaceDao(),
+                            classificationEngine, new MockSessionUtils(), new MockNodeDao(), new MockSnmpInterfaceDao(),
                             new MockIdentity(), new MockTracerRegistry(), new IndexSettings(),
                             3, 12000), jestClient);
             // persist data

--- a/features/flows/elastic/src/test/java/org/opennms/netmgt/flows/elastic/ElasticFlowRepositoryIT.java
+++ b/features/flows/elastic/src/test/java/org/opennms/netmgt/flows/elastic/ElasticFlowRepositoryIT.java
@@ -37,9 +37,8 @@ import java.io.IOException;
 import org.junit.Rule;
 import org.junit.Test;
 import org.opennms.netmgt.dao.mock.MockNodeDao;
+import org.opennms.netmgt.dao.mock.MockSessionUtils;
 import org.opennms.netmgt.dao.mock.MockSnmpInterfaceDao;
-import org.opennms.netmgt.dao.mock.MockTransactionManager;
-import org.opennms.netmgt.dao.mock.MockTransactionTemplate;
 import org.opennms.netmgt.flows.api.FlowException;
 import org.opennms.netmgt.flows.classification.ClassificationEngine;
 import org.opennms.plugins.elasticsearch.rest.index.IndexStrategy;
@@ -78,12 +77,9 @@ public class ElasticFlowRepositoryIT {
         final JestClientFactory factory = new JestClientFactory();
         factory.setHttpClientConfig(new HttpClientConfig.Builder("http://localhost:" + wireMockRule.port()).build());
         try (JestClient client = factory.getObject()) {
-            final MockTransactionTemplate mockTransactionTemplate = new MockTransactionTemplate();
-            mockTransactionTemplate.setTransactionManager(new MockTransactionManager());
-
             final ElasticFlowRepository elasticFlowRepository = new ElasticFlowRepository(new MetricRegistry(),
                     client, IndexStrategy.MONTHLY, documentEnricher, classificationEngine,
-                    mockTransactionTemplate, new MockNodeDao(), new MockSnmpInterfaceDao(),
+                    new MockSessionUtils(), new MockNodeDao(), new MockSnmpInterfaceDao(),
                     new MockIdentity(), new MockTracerRegistry(), new IndexSettings(),
                     3, 12000);
 

--- a/features/flows/elastic/src/test/java/org/opennms/netmgt/flows/elastic/ElasticFlowRepositoryRetryIT.java
+++ b/features/flows/elastic/src/test/java/org/opennms/netmgt/flows/elastic/ElasticFlowRepositoryRetryIT.java
@@ -37,10 +37,10 @@ import org.junit.rules.Timeout;
 import org.opennms.core.test.elastic.ElasticSearchRule;
 import org.opennms.core.test.elastic.ElasticSearchServerConfig;
 import org.opennms.core.test.elastic.ExecutionTime;
+import org.opennms.netmgt.dao.api.SessionUtils;
 import org.opennms.netmgt.dao.mock.MockNodeDao;
+import org.opennms.netmgt.dao.mock.MockSessionUtils;
 import org.opennms.netmgt.dao.mock.MockSnmpInterfaceDao;
-import org.opennms.netmgt.dao.mock.MockTransactionManager;
-import org.opennms.netmgt.dao.mock.MockTransactionTemplate;
 import org.opennms.netmgt.flows.api.FlowException;
 import org.opennms.netmgt.flows.api.FlowRepository;
 import org.opennms.netmgt.flows.classification.ClassificationEngine;
@@ -98,12 +98,9 @@ public class ElasticFlowRepositoryRetryIT {
             final MockDocumentEnricherFactory mockDocumentEnricherFactory = new MockDocumentEnricherFactory();
             final DocumentEnricher documentEnricher = mockDocumentEnricherFactory.getEnricher();
             final ClassificationEngine classificationEngine = mockDocumentEnricherFactory.getClassificationEngine();
-            final MockTransactionTemplate mockTransactionTemplate = new MockTransactionTemplate();
-            mockTransactionTemplate.setTransactionManager(new MockTransactionManager());
-
             final FlowRepository elasticFlowRepository = new InitializingFlowRepository(
                     new ElasticFlowRepository(new MetricRegistry(), client, IndexStrategy.MONTHLY, documentEnricher,
-                            classificationEngine, mockTransactionTemplate, new MockNodeDao(), new MockSnmpInterfaceDao(),
+                            classificationEngine, new MockSessionUtils(), new MockNodeDao(), new MockSnmpInterfaceDao(),
                             new MockIdentity(), new MockTracerRegistry(), new IndexSettings(),3, 12000), client);
 
             consumer.accept(elasticFlowRepository);

--- a/features/flows/elastic/src/test/java/org/opennms/netmgt/flows/elastic/FlowQueryIT.java
+++ b/features/flows/elastic/src/test/java/org/opennms/netmgt/flows/elastic/FlowQueryIT.java
@@ -34,7 +34,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasSize;
-import static org.opennms.core.test.elastic.ElasticSearchServerConfig.ES_HTTP_PORT;
 
 import java.net.MalformedURLException;
 import java.util.ArrayList;
@@ -60,10 +59,10 @@ import org.opennms.core.test.MockLogAppender;
 import org.opennms.core.test.elastic.ElasticSearchRule;
 import org.opennms.core.test.elastic.ElasticSearchServerConfig;
 import org.opennms.elasticsearch.plugin.DriftPlugin;
+import org.opennms.netmgt.dao.api.SessionUtils;
 import org.opennms.netmgt.dao.mock.MockNodeDao;
+import org.opennms.netmgt.dao.mock.MockSessionUtils;
 import org.opennms.netmgt.dao.mock.MockSnmpInterfaceDao;
-import org.opennms.netmgt.dao.mock.MockTransactionManager;
-import org.opennms.netmgt.dao.mock.MockTransactionTemplate;
 import org.opennms.netmgt.flows.api.Conversation;
 import org.opennms.netmgt.flows.api.Directional;
 import org.opennms.netmgt.flows.api.FlowException;
@@ -103,10 +102,8 @@ public class FlowQueryIT {
         final MetricRegistry metricRegistry = new MetricRegistry();
         final RestClientFactory restClientFactory = new RestClientFactory(elasticSearchRule.getUrl());
         final JestClient client = restClientFactory.createClient();
-        final MockTransactionTemplate mockTransactionTemplate = new MockTransactionTemplate();
-        mockTransactionTemplate.setTransactionManager(new MockTransactionManager());
         flowRepository = new ElasticFlowRepository(metricRegistry, client, IndexStrategy.MONTHLY, documentEnricher,
-                classificationEngine, mockTransactionTemplate, new MockNodeDao(), new MockSnmpInterfaceDao(),
+                classificationEngine, new MockSessionUtils(), new MockNodeDao(), new MockSnmpInterfaceDao(),
                 new MockIdentity(), new MockTracerRegistry(), new IndexSettings(), 3, 12000);
         final IndexSettings settings = new IndexSettings();
         final ElasticFlowRepositoryInitializer initializer = new ElasticFlowRepositoryInitializer(client, settings);

--- a/features/flows/elastic/src/test/java/org/opennms/netmgt/flows/elastic/MarkerCacheIT.java
+++ b/features/flows/elastic/src/test/java/org/opennms/netmgt/flows/elastic/MarkerCacheIT.java
@@ -54,6 +54,7 @@ import org.opennms.netmgt.dao.DatabasePopulator;
 import org.opennms.netmgt.dao.api.InterfaceToNodeCache;
 import org.opennms.netmgt.dao.api.MonitoringLocationDao;
 import org.opennms.netmgt.dao.api.NodeDao;
+import org.opennms.netmgt.dao.api.SessionUtils;
 import org.opennms.netmgt.dao.api.SnmpInterfaceDao;
 import org.opennms.netmgt.flows.api.Flow;
 import org.opennms.netmgt.flows.api.FlowSource;
@@ -66,7 +67,6 @@ import org.opennms.plugins.elasticsearch.rest.template.IndexSettings;
 import org.opennms.test.JUnitConfigurationEnvironment;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.transaction.support.TransactionOperations;
 
 import com.codahale.metrics.MetricRegistry;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
@@ -96,7 +96,7 @@ public class MarkerCacheIT {
     private DatabasePopulator databasePopulator;
 
     @Autowired
-    private TransactionOperations transactionOperations;
+    private SessionUtils sessionUtils;
 
     @Autowired
     private NodeDao nodeDao;
@@ -153,7 +153,7 @@ public class MarkerCacheIT {
         ), FilterService.NOOP);
 
         final DocumentEnricher documentEnricher = new DocumentEnricher(
-                new MetricRegistry(), nodeDao, interfaceToNodeCache, transactionOperations, classificationEngine,
+                new MetricRegistry(), nodeDao, interfaceToNodeCache, sessionUtils, classificationEngine,
                 new CacheConfigBuilder()
                         .withName("flows.node")
                         .withMaximumSize(1000)
@@ -167,7 +167,7 @@ public class MarkerCacheIT {
         try (JestClient client = factory.getObject()) {
             final ElasticFlowRepository elasticFlowRepository = new ElasticFlowRepository(new MetricRegistry(),
                     client, IndexStrategy.MONTHLY, documentEnricher, classificationEngine,
-                    transactionOperations, nodeDao, snmpInterfaceDao,
+                    sessionUtils, nodeDao, snmpInterfaceDao,
                     new MockIdentity(), new MockTracerRegistry(), new IndexSettings(),
                     3, 12000);
 

--- a/features/flows/elastic/src/test/java/org/opennms/netmgt/flows/elastic/MockDocumentEnricherFactory.java
+++ b/features/flows/elastic/src/test/java/org/opennms/netmgt/flows/elastic/MockDocumentEnricherFactory.java
@@ -44,7 +44,7 @@ import org.opennms.netmgt.dao.mock.MockAssetRecordDao;
 import org.opennms.netmgt.dao.mock.MockCategoryDao;
 import org.opennms.netmgt.dao.mock.MockInterfaceToNodeCache;
 import org.opennms.netmgt.dao.mock.MockNodeDao;
-import org.opennms.netmgt.dao.mock.MockTransactionTemplate;
+import org.opennms.netmgt.dao.mock.MockSessionUtils;
 import org.opennms.netmgt.flows.classification.ClassificationEngine;
 import org.opennms.netmgt.flows.classification.FilterService;
 import org.opennms.netmgt.flows.classification.internal.DefaultClassificationEngine;
@@ -57,7 +57,6 @@ public class MockDocumentEnricherFactory {
 
     private final NodeDao nodeDao;
     private final InterfaceToNodeCache interfaceToNodeCache;
-    private final MockTransactionTemplate transactionTemplate;
     private final MockAssetRecordDao assetRecordDao;
     private final MockCategoryDao categoryDao;
     private final DocumentEnricher enricher;
@@ -68,8 +67,6 @@ public class MockDocumentEnricherFactory {
     public MockDocumentEnricherFactory() {
         nodeDao = createNodeDao();
         interfaceToNodeCache = new MockInterfaceToNodeCache();
-        transactionTemplate = new MockTransactionTemplate();
-        transactionTemplate.afterPropertiesSet();
         assetRecordDao = new MockAssetRecordDao();
         categoryDao = new MockCategoryDao();
 
@@ -80,7 +77,7 @@ public class MockDocumentEnricherFactory {
                 new RuleBuilder().withName("https").withSrcPort("443").withProtocol("tcp,udp").build()
         ), FilterService.NOOP);
         enricher = new DocumentEnricher(
-                new MetricRegistry(), nodeDao, interfaceToNodeCache, transactionTemplate, classificationEngine,
+                new MetricRegistry(), nodeDao, interfaceToNodeCache, new MockSessionUtils(), classificationEngine,
                 new CacheConfigBuilder()
                     .withName("flows.node")
                     .withMaximumSize(1000)
@@ -102,10 +99,6 @@ public class MockDocumentEnricherFactory {
 
     public InterfaceToNodeCache getInterfaceToNodeCache() {
         return interfaceToNodeCache;
-    }
-
-    public MockTransactionTemplate getTransactionTemplate() {
-        return transactionTemplate;
     }
 
     public DocumentEnricher getEnricher() {


### PR DESCRIPTION
Here I remove all `TransactionOperations` references and use `SessionUtils` instead (module `features/flows/elastic`). 
This removes the issue when sometimes the dependency to `TransactionOperations` is no longer resolvable after e.g. a bundle refresh (most likely caused by a manual `bundle:watch *`)