### PR TITLE
NMS-12185: Ignore SFlow messages without IP data

### DIFF
--- a/features/telemetry/protocols/common/src/main/java/org/opennms/netmgt/telemetry/protocols/common/utils/BsonUtils.java
+++ b/features/telemetry/protocols/common/src/main/java/org/opennms/netmgt/telemetry/protocols/common/utils/BsonUtils.java
@@ -32,6 +32,7 @@ import java.time.Instant;
 import java.util.Optional;
 import java.util.stream.Stream;
 
+import org.bson.BsonArray;
 import org.bson.BsonBoolean;
 import org.bson.BsonDocument;
 import org.bson.BsonDouble;
@@ -77,6 +78,14 @@ public class BsonUtils {
 
     public static Optional<Boolean> getBool(final BsonDocument doc, final String... path) {
         return get(doc, path).map(BsonValue::asBoolean).map(BsonBoolean::getValue);
+    }
+
+    public static Optional<Iterable<BsonValue>> getArray(final BsonDocument doc, final String... path) {
+        return get(doc, path).map(BsonValue::asArray).map(BsonArray::getValues);
+    }
+
+    public static Optional<BsonDocument> getDocument(final BsonDocument doc, final String... path) {
+        return get(doc, path).map(BsonValue::asDocument);
     }
 
     public static <V> Optional<V> first(final Optional<V>... values) {

--- a/features/telemetry/protocols/sflow/adapter/src/main/java/org/opennms/netmgt/telemetry/protocols/sflow/adapter/SFlowConverter.java
+++ b/features/telemetry/protocols/sflow/adapter/src/main/java/org/opennms/netmgt/telemetry/protocols/sflow/adapter/SFlowConverter.java
@@ -28,6 +28,12 @@
 
 package org.opennms.netmgt.telemetry.protocols.sflow.adapter;
 
+import static org.opennms.netmgt.telemetry.protocols.common.utils.BsonUtils.first;
+import static org.opennms.netmgt.telemetry.protocols.common.utils.BsonUtils.getArray;
+import static org.opennms.netmgt.telemetry.protocols.common.utils.BsonUtils.getString;
+import static org.opennms.netmgt.telemetry.protocols.common.utils.BsonUtils.getDocument;
+import static org.opennms.netmgt.telemetry.protocols.common.utils.BsonUtils.get;
+
 import java.util.List;
 
 import org.bson.BsonDocument;
@@ -39,19 +45,29 @@ import com.google.common.collect.Lists;
 
 public class SFlowConverter implements Converter<BsonDocument> {
 
+    private static RuntimeException invalidDocument() {
+        throw new RuntimeException("Invalid Document");
+    }
+
     @Override
     public List<Flow> convert(final BsonDocument packet) {
         final List<Flow> result = Lists.newLinkedList();
 
         final SFlow.Header header = new SFlow.Header(packet);
 
-        for (final BsonValue sample : packet.getDocument("data").getArray("samples")) {
+        for (final BsonValue sample : getArray(packet, "data", "samples").orElseThrow(SFlowConverter::invalidDocument)) {
             final BsonDocument sampleDocument = sample.asDocument();
 
-            if ("0:1".equals(sampleDocument.get("format").asString().getValue()) ||
-                "0:3".equals(sampleDocument.get("format").asString().getValue())) {
+            final String format = getString(sampleDocument, "format").orElseThrow(SFlowConverter::invalidDocument);
+            if ("0:1".equals(format) || "0:3".equals(format)) {
                 // Handle only (expanded) flow samples
-                result.add(new SFlow(header, sampleDocument.get("data").asDocument()));
+
+                if (first(get(sampleDocument, "data", "flows", "0:1"),
+                           get(sampleDocument, "data", "flows", "0:3"),
+                           get(sampleDocument, "data", "flows", "0:4")).isPresent()) {
+                    // Handle only flows containing IP related records
+                    result.add(new SFlow(header, getDocument(sampleDocument, "data").orElseThrow(SFlowConverter::invalidDocument)));
+                }
             }
         }
 

--- a/features/telemetry/protocols/sflow/adapter/src/test/java/org/opennms/netmgt/telemetry/protocols/sflow/adapter/SFlowConverterTest.java
+++ b/features/telemetry/protocols/sflow/adapter/src/test/java/org/opennms/netmgt/telemetry/protocols/sflow/adapter/SFlowConverterTest.java
@@ -61,10 +61,11 @@ public class SFlowConverterTest {
         assertThat(bsonDocument.getInt64("time"), notNullValue());
         assertThat(bsonDocument.getInt64("time").getValue(), is(1521618510235L));
         assertThat(bsonDocument.getDocument("data").getArray("samples"), notNullValue());
-        assertThat(bsonDocument.getDocument("data").getArray("samples").size(), is(5));
+        assertThat(bsonDocument.getDocument("data").getArray("samples").size(), is(6));
 
         final List<Flow> flows = new SFlowConverter().convert(bsonDocument);
 
+        // There are six flows int the document, but one is skipped, because it's ethernet only
         assertThat(flows.size(), is(5));
     }
 
@@ -83,7 +84,7 @@ public class SFlowConverterTest {
         assertThat(bsonDocument.getInt64("time"), notNullValue());
         assertThat(bsonDocument.getInt64("time").getValue(), is(1521618510235L));
         assertThat(bsonDocument.getDocument("data").getArray("samples"), notNullValue());
-        assertThat(bsonDocument.getDocument("data").getArray("samples").size(), is(5));
+        assertThat(bsonDocument.getDocument("data").getArray("samples").size(), is(6));
 
         final List<Flow> flows = new SFlowConverter().convert(bsonDocument);
 

--- a/features/telemetry/protocols/sflow/adapter/src/test/resources/sflow.json
+++ b/features/telemetry/protocols/sflow/adapter/src/test/resources/sflow.json
@@ -323,6 +323,44 @@
             }
           }
         }
+      },
+      {
+        "format": "0:1",
+        "data": {
+          "sequence_number": {
+            "$numberLong": "28"
+          },
+          "source_id": {
+            "$numberLong": "33555432"
+          },
+          "sampling_rate": {
+            "$numberLong": "64"
+          },
+          "sample_pool": {
+            "$numberLong": "1792"
+          },
+          "drops": {
+            "$numberLong": "0"
+          },
+          "input": {
+            "$numberLong": "4"
+          },
+          "output": {
+            "$numberLong": "17"
+          },
+          "flows": {
+            "0:2": {
+              "length": {
+                "$numberLong": "1234"
+              },
+              "src_mac": "00:00:00:00:00:00",
+              "dst_mac": "00:00:00:00:00:00",
+              "type": {
+                "$numberLong": "1"
+              }
+            }
+          }
+        }
       }
     ]
   }


### PR DESCRIPTION
SFlow is capable of sending samples about other network layers beside
IP. To make a usefull flow out of the sample, the IP data is required.
Flows not containing IP related information are silently ignored now.

JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-12185

