### PR TITLE
NMS-12290: Set default values to use RRDTool and allow to change it with Environment variables

### DIFF
--- a/opennms-container/horizon/container-fs/confd/conf.d/timeseries.properties.toml
+++ b/opennms-container/horizon/container-fs/confd/conf.d/timeseries.properties.toml
@@ -3,5 +3,8 @@ src = "timeseries.properties.tpl"
 dest = "/opt/opennms/etc/opennms.properties.d/_confd.timeseries.properties"
 keys = [
     "opennms/timeseries/strategy",
-    "opennms/rrd/storebyforeignsource"
+    "opennms/rrd/storebyforeignsource",
+    "opennms/rrd/strategyclass",
+    "opennms/rrd/interfacejar",
+    "opennms/library/jrrd2"
 ]

--- a/opennms-container/horizon/container-fs/confd/templates/timeseries.properties.tpl
+++ b/opennms-container/horizon/container-fs/confd/templates/timeseries.properties.tpl
@@ -5,3 +5,6 @@
 # Configure storage strategy
 org.opennms.rrd.storeByForeignSource={{getv "/opennms/rrd/storebyforeignsource" "true"}}
 org.opennms.timeseries.strategy={{getv "/opennms/timeseries/strategy" "rrd"}}
+org.opennms.rrd.interfaceJar={{getv "/opennms/rrd/interfacejar" "/usr/share/java/jrrd2.jar"}}
+org.opennms.rrd.strategyClass={{getv "/opennms/rrd/strategyclass" "org.opennms.netmgt.rrd.rrdtool.MultithreadedJniRrdStrategy"}}
+opennms.library.jrrd2={{getv "/opennms/library/jrrd2" "/usr/lib64/libjrrd2.so"}}

--- a/opennms-container/horizon/container-fs/entrypoint.sh
+++ b/opennms-container/horizon/container-fs/entrypoint.sh
@@ -53,7 +53,7 @@ initOrUpdate() {
     if [[ "${OPENNMS_TIMESERIES_STRATEGY}" == "newts" ]]; then
       ${JAVA_HOME}/bin/java -Dopennms.manager.class="org.opennms.netmgt.newts.cli.Newts" -Dopennms.home="${OPENNMS_HOME}" -Dlog4j.configurationFile="${OPENNMS_HOME}"/etc/log4j2-tools.xml -jar ${OPENNMS_HOME}/lib/opennms_bootstrap.jar init -r ${REPLICATION_FACTOR-1} || exit ${E_INIT_CONFIG}
     else
-      echo "The time series strategy ${OPENNMS_TIMESERIES_STRATEGY} is selected, skip Newts keyspace initialisation."
+      echo "The time series strategy ${OPENNMS_TIMESERIES_STRATEGY} is selected, skip Newts keyspace initialisation. If unset defaults to rrd to use RRDTool."
     fi
   fi
 }


### PR DESCRIPTION
### All Contributors

* [x] Have you read and followed our [Contribution Guidelines](https://github.com/OpenNMS/opennms/blob/develop/CONTRIBUTING.md)?
* [x] Have you [made an issue in the OpenNMS issue tracker](https://issues.opennms.org)?<br>If so, you should:
  1. update the title of this PR to be of the format: `${JIRA-ISSUE-NUMBER}: subject of pull request`
  2. update the JIRA link at the bottom of this comment to refer to the real issue number
  3. prefix your commit messages with the issue number, if possible
* [x] Have you made a comment in that issue which points back to this PR?
* [x] Have you updated the JIRA link at the bottom of this comment to link to your issue?
* [x] If this is a new or updated feature, is there documentation for the new behavior?
* [x] If this is new code, are there unit and/or integration tests?
* [x] If this PR targets a `foundation-*` branch, does it avoid changing files in `$OPENNMS_HOME/etc/`?

The strategy was set to "rrd" but the StrategyClass was still set to use JRobin. With this PR we set the defaults if no environment variable is set to use RRDTool and allow to configure different strategies to be configured through environment variables.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-12290
* Bamboo (Continuous Integration): https://bamboo.opennms.org/

