### PR TITLE
NMS-12247: Add support for meta-data fields in thresholding expressions

### DIFF
--- a/core/ipc/rpc/utils/src/main/java/org/opennms/core/rpc/utils/mate/EntityScopeProviderImpl.java
+++ b/core/ipc/rpc/utils/src/main/java/org/opennms/core/rpc/utils/mate/EntityScopeProviderImpl.java
@@ -31,6 +31,7 @@ package org.opennms.core.rpc.utils.mate;
 import java.net.InetAddress;
 import java.util.Collection;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -121,7 +122,6 @@ public class EntityScopeProviderImpl implements EntityScopeProvider {
         return metaDataScope;
     }
 
-
     @Override
     public Scope getScopeForService(final Integer nodeId, final InetAddress ipAddress, final String serviceName) {
         if (nodeId == null || ipAddress == null || Strings.isNullOrEmpty(serviceName)) {
@@ -147,5 +147,21 @@ public class EntityScopeProviderImpl implements EntityScopeProvider {
         final Map<ContextKey, String> map = metaData.stream()
                 .collect(Collectors.toMap(e -> new ContextKey(e.getContext(), e.getKey()), e -> e.getValue()));
         return new MapScope(map);
+    }
+
+    public void setNodeDao(NodeDao nodeDao) {
+        this.nodeDao = Objects.requireNonNull(nodeDao);
+    }
+
+    public void setIpInterfaceDao(IpInterfaceDao ipInterfaceDao) {
+        this.ipInterfaceDao = Objects.requireNonNull(ipInterfaceDao);
+    }
+
+    public void setMonitoredServiceDao(MonitoredServiceDao monitoredServiceDao) {
+        this.monitoredServiceDao = Objects.requireNonNull(monitoredServiceDao);
+    }
+
+    public void setSessionUtils(SessionUtils sessionUtils) {
+        this.sessionUtils = Objects.requireNonNull(sessionUtils);
     }
 }

--- a/core/ipc/rpc/utils/src/main/java/org/opennms/core/rpc/utils/mate/Interpolator.java
+++ b/core/ipc/rpc/utils/src/main/java/org/opennms/core/rpc/utils/mate/Interpolator.java
@@ -88,4 +88,8 @@ public class Interpolator {
         outerMatcher.appendTail(stringBuffer);
         return stringBuffer.toString();
     }
+    
+    public static boolean containsMateData(String toCheck) {
+        return toCheck != null && OUTER_PATTERN.matcher(toCheck).find();
+    }
 }

--- a/features/collection/thresholding/impl/pom.xml
+++ b/features/collection/thresholding/impl/pom.xml
@@ -117,6 +117,11 @@
       <artifactId>org.opennms.config-dao.poll-outages.api</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.opennms.core.ipc.rpc</groupId>
+      <artifactId>org.opennms.core.ipc.rpc.utils</artifactId>
+      <version>${project.version}</version>
+    </dependency>
     
     <dependency>
       <groupId>junit</groupId>

--- a/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/BaseThresholdDefConfigWrapper.java
+++ b/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/BaseThresholdDefConfigWrapper.java
@@ -31,7 +31,6 @@ package org.opennms.netmgt.threshd;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -101,15 +100,6 @@ public abstract class BaseThresholdDefConfigWrapper {
      * @return Collection of the names of datasources
      */
     public abstract Collection<String> getRequiredDatasources();
-    
-    /**
-     * Evaluate the threshold expression/datasource in terms of the named values supplied, and return that value
-     *
-     * @param values named values to use in evaluating the expression/data source
-     * @return the value of the evaluated expression
-     * @throws org.opennms.netmgt.threshd.ThresholdExpressionException if any.
-     */
-    public abstract double evaluate(Map<String, Double> values)  throws ThresholdExpressionException;
     
     /**
      * <p>getDsType</p>
@@ -259,5 +249,6 @@ public abstract class BaseThresholdDefConfigWrapper {
         m_baseDef = threshold.getBasethresholddef();
     }
     
+    public abstract void accept(ThresholdDefVisitor thresholdDefVisitor);
 }
 

--- a/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/DefaultThresholdingSetPersister.java
+++ b/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/DefaultThresholdingSetPersister.java
@@ -32,6 +32,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
+import org.opennms.core.rpc.utils.mate.EntityScopeProvider;
 import org.opennms.netmgt.config.dao.outages.api.ReadablePollOutagesDao;
 import org.opennms.netmgt.config.dao.thresholding.api.ReadableThreshdDao;
 import org.opennms.netmgt.config.dao.thresholding.api.ReadableThresholdingDao;
@@ -63,6 +64,9 @@ public class DefaultThresholdingSetPersister implements ThresholdingSetPersister
     
     @Autowired
     private IfLabel ifLabelDao;
+    
+    @Autowired
+    private EntityScopeProvider entityScopeProvider;
 
     @Override
     public void persistSet(ThresholdingSession session, ThresholdingSet set) {
@@ -78,7 +82,7 @@ public class DefaultThresholdingSetPersister implements ThresholdingSetPersister
                     ((ThresholdingSessionImpl) session).getRrdRepository(),
                     ((ThresholdingSessionImpl) session).getServiceParameters(),
                     ((ThresholdingSessionImpl) session).getResourceDao(), eventProxy, session, threshdDao,
-                    thresholdingDao, pollOutagesDao, ifLabelDao);
+                    thresholdingDao, pollOutagesDao, ifLabelDao, entityScopeProvider);
             thresholdingSets.put(key, tSet);
         }
         return tSet;
@@ -109,5 +113,9 @@ public class DefaultThresholdingSetPersister implements ThresholdingSetPersister
 
     public void setIfLabelDao(IfLabel ifLabelDao) {
         this.ifLabelDao = Objects.requireNonNull(ifLabelDao);
+    }
+
+    public void setEntityScopeProvider(EntityScopeProvider entityScopeProvider) {
+        this.entityScopeProvider = Objects.requireNonNull(entityScopeProvider);
     }
 }

--- a/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/DefaultThresholdsDao.java
+++ b/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/DefaultThresholdsDao.java
@@ -37,6 +37,7 @@ import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Set;
 
+import org.opennms.core.rpc.utils.mate.EntityScopeProvider;
 import org.opennms.netmgt.config.dao.thresholding.api.ReadableThresholdingDao;
 import org.opennms.netmgt.config.threshd.Basethresholddef;
 import org.opennms.netmgt.threshd.api.ThresholdingEventProxy;
@@ -59,6 +60,8 @@ public class DefaultThresholdsDao implements ThresholdsDao, InitializingBean {
     private ThresholdingEventProxy m_eventProxy;
     
     private ReadableThresholdingDao m_thresholdingDao;
+    
+    private EntityScopeProvider m_entityScopeProvider;
 
     /** {@inheritDoc} */
     @Override
@@ -129,7 +132,7 @@ public class DefaultThresholdsDao implements ThresholdsDao, InitializingBean {
                         thresholdMap.put(wrapper.getDatasourceExpression(), thresholdEntitySet);
                     }
                     try {
-                        ThresholdEntity thresholdEntity = new ThresholdEntity();
+                        ThresholdEntity thresholdEntity = new ThresholdEntity(m_entityScopeProvider);
                         thresholdEntity.setEventProxy(m_eventProxy);
                         thresholdEntity.addThreshold(wrapper, thresholdingSession);
                         if (merge) {
@@ -202,4 +205,7 @@ public class DefaultThresholdsDao implements ThresholdsDao, InitializingBean {
         m_eventProxy = eventProxy;
     }
 
+    public void setEntityScopeProvider(EntityScopeProvider entityScopeProvider) {
+        m_entityScopeProvider = Objects.requireNonNull(entityScopeProvider);
+    }
 }

--- a/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/ExpressionThresholdValue.java
+++ b/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/ExpressionThresholdValue.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.threshd;
+
+import java.util.function.Consumer;
+
+public interface ExpressionThresholdValue {
+    /**
+     * @param expressionConsumer a consumer for accepting the interpolated expression for caching purposes
+     * @return the expression value
+     */
+    double get(Consumer<String> expressionConsumer) throws ThresholdExpressionException;
+
+    /**
+     * @param evaluatedExpression the already interpolated expression which will be used rather than interpolating the
+     *                            expression
+     * @return the expression value
+     */
+    double get(String evaluatedExpression) throws ThresholdExpressionException;
+}

--- a/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/ThresholdConfigWrapper.java
+++ b/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/ThresholdConfigWrapper.java
@@ -71,12 +71,16 @@ public class ThresholdConfigWrapper extends BaseThresholdDefConfigWrapper {
     }
 
     /** {@inheritDoc} */
-    @Override
-    public double evaluate(Map<String, Double> values)  throws ThresholdExpressionException {
+    public double evaluate(Map<String, Double> values) {
         Double result=values.get(m_threshold.getDsName());
         if(result==null) {
             return 0.0;
         }
         return result.doubleValue();
+    }
+
+    @Override
+    public void accept(ThresholdDefVisitor thresholdDefVisitor) {
+        thresholdDefVisitor.visit(this);
     }
 }

--- a/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/ThresholdDefVisitor.java
+++ b/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/ThresholdDefVisitor.java
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.threshd;
+
+public interface ThresholdDefVisitor {
+    void visit(ThresholdConfigWrapper thresholdConfigWrapper);
+    void visit(ExpressionConfigWrapper expressionConfigWrapper);
+}

--- a/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/ThresholdEntity.java
+++ b/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/ThresholdEntity.java
@@ -35,8 +35,15 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 
+import org.opennms.core.rpc.utils.mate.EmptyScope;
+import org.opennms.core.rpc.utils.mate.EntityScopeProvider;
+import org.opennms.core.rpc.utils.mate.FallbackScope;
+import org.opennms.core.rpc.utils.mate.Scope;
 import org.opennms.netmgt.threshd.ThresholdEvaluatorState.Status;
 import org.opennms.netmgt.threshd.api.ThresholdingEventProxy;
 import org.opennms.netmgt.threshd.api.ThresholdingSession;
@@ -45,6 +52,8 @@ import org.opennms.netmgt.xml.event.Parm;
 import org.opennms.netmgt.xml.event.Value;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.google.common.net.InetAddresses;
 
 /**
  * Wraps the XML created org.opennms.netmgt.config.threshd.Threshold class
@@ -74,12 +83,15 @@ public final class ThresholdEntity implements Cloneable {
         s_thresholdEvaluators.add(new ThresholdEvaluatorRearmingAbsoluteChange());
     }
 
+    private final EntityScopeProvider m_entityScopeProvider;
+
     /**
      * Constructor.
      */
-    public ThresholdEntity() {
+    public ThresholdEntity(EntityScopeProvider entityScopeProvider) {
         //Put in a default list for the "null" key (the default evaluators)
         m_thresholdEvaluatorStates.put(null, new LinkedList<ThresholdEvaluatorState>());
+        m_entityScopeProvider = Objects.requireNonNull(entityScopeProvider);
     }
 
     /**
@@ -162,7 +174,7 @@ public final class ThresholdEntity implements Cloneable {
      */
     @Override
     public ThresholdEntity clone() {
-        ThresholdEntity clone = new ThresholdEntity();
+        ThresholdEntity clone = new ThresholdEntity(m_entityScopeProvider);
         for (ThresholdEvaluatorState thresholdItem : getThresholdEvaluatorStates(null)) {
             clone.addThreshold(thresholdItem.getThresholdConfig(), thresholdItem.getThresholdingSession());
         }
@@ -233,7 +245,6 @@ public final class ThresholdEntity implements Cloneable {
      */
     public List<Event> evaluateAndCreateEvents(CollectionResourceWrapper resource, Map<String, Double> values, Date date) {
         List<Event> events = new LinkedList<Event>();
-        double dsValue=0.0;
 
         String instance = null;
         if (resource != null) {
@@ -243,22 +254,82 @@ public final class ThresholdEntity implements Cloneable {
             // such as the SiblingColumnStorageStrategy
             instance = resource.getInstanceLabel();
         }
-        try {
-            if (getThresholdEvaluatorStates(instance).size() > 0) {
-                dsValue=getThresholdConfig().evaluate(values);
-            } else {
-                throw new IllegalStateException("No thresholds have been added.");
-            }
-        } catch (ThresholdExpressionException e) {
-            LOG.warn("Failed to evaluate: ", e);
-            return events; //No events to report
-        }
-        
-        LOG.debug("evaluate: value= {} against threshold: {}", dsValue, this);
 
+        if (getThresholdEvaluatorStates(instance).isEmpty()) {
+            throw new IllegalStateException("No thresholds have been added.");
+        }
+
+        // This reference contains the function that will be used by each evaluator to retrieve the status
+        AtomicReference<EvaluateFunction> evaluateFunctionRef = new AtomicReference<>(null);
+
+        // Depending on the type of threshold, we want to evaluate it differently
+        // Specifically expression based thresholds are treated special because their behavior must change depending on
+        // whether or not a given expression has been interpolated already
+        getThresholdConfig().accept(new ThresholdDefVisitor() {
+            @Override
+            public void visit(ThresholdConfigWrapper thresholdConfigWrapper) {
+                double computedValue = thresholdConfigWrapper.evaluate(values);
+                evaluateFunctionRef.set(item -> new ThresholdEvaluatorState.ValueStatus(computedValue,
+                        item.evaluate(computedValue, resource == null ? null : resource.getSequenceNumber())));
+            }
+
+            @Override
+            public void visit(ExpressionConfigWrapper expressionConfigWrapper) {
+                ExpressionThresholdValue expressionThresholdValue = new ExpressionThresholdValue() {
+                    // This covers the case where an expression has not yet been interpolated, we want to evaluate and
+                    // also retrieve the interpolated expression so we can persist it in our state going forward
+                    @Override
+                    public double get(Consumer<String> expressionConsumer) throws ThresholdExpressionException {
+                        // Default to empty scopes and then attempt to populate each of node, interface, and service
+                        // scopes below
+                        Scope[] scopes = new Scope[]{EmptyScope.EMPTY, EmptyScope.EMPTY, EmptyScope.EMPTY};
+
+                        if (resource != null) {
+                            scopes[0] = m_entityScopeProvider.getScopeForNode(resource.getNodeId());
+                            String interfaceIp = resource.getHostAddress();
+                            if (interfaceIp != null) {
+                                scopes[1] = m_entityScopeProvider.getScopeForInterface(resource.getNodeId(),
+                                        interfaceIp);
+                                scopes[2] = m_entityScopeProvider.getScopeForService(resource.getNodeId(),
+                                        InetAddresses.forString(interfaceIp), resource.getServiceName());
+                            }
+                        }
+
+                        FallbackScope fallbackScope = new FallbackScope(scopes);
+
+                        ExpressionConfigWrapper.ExpressionValue expressionValue = expressionConfigWrapper
+                                .interpolateAndEvaluate(values, fallbackScope);
+                        expressionConsumer.accept(expressionValue.expression);
+
+                        return expressionValue.value;
+                    }
+
+                    // This covers the case where an expression has already been interpolated and the evaluator is
+                    // providing us that expression that it has persisted along with its state so that we do not need to
+                    // perform interpolation again
+                    @Override
+                    public double get(String evaluatedExpression) throws ThresholdExpressionException {
+                        return expressionConfigWrapper.evaluate(evaluatedExpression, values);
+                    }
+                };
+
+                evaluateFunctionRef.set(item -> item.evaluate(expressionThresholdValue, resource == null ? null :
+                        resource.getSequenceNumber()));
+            }
+        });
+
+        EvaluateFunction evaluateFunction = evaluateFunctionRef.get();
         for (ThresholdEvaluatorState item : getThresholdEvaluatorStates(instance)) {
-            Status status = item.evaluate(dsValue, resource == null ? null : resource.getSequenceNumber());
-            Event event = item.getEventForState(status, date, dsValue, resource);
+            ThresholdEvaluatorState.ValueStatus result;
+            try {
+                result = evaluateFunction.evaluate(item);
+            } catch (ThresholdExpressionException e) {
+                LOG.warn("Error evaluating: threshold: {} and evaluator: {}", this, item, e);
+                continue;
+            }
+            Status status = result.status;
+            Event event = item.getEventForState(status, date, result.value, resource);
+            LOG.debug("evaluated: value= {} against threshold: {} and evaluator: {}", result.value, this, item);
             if (event != null) {
                 events.add(event);
             }
@@ -372,5 +443,11 @@ public final class ThresholdEntity implements Cloneable {
 
     public void setEventProxy(ThresholdingEventProxy eventProxy) {
         m_thresholdingEventProxy = eventProxy;
+    }
+
+    @FunctionalInterface
+    private interface EvaluateFunction {
+        ThresholdEvaluatorState.ValueStatus evaluate(ThresholdEvaluatorState thresholdEvaluatorState)
+                throws ThresholdExpressionException;
     }
 }

--- a/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/ThresholdEvaluatorAbsoluteChange.java
+++ b/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/ThresholdEvaluatorAbsoluteChange.java
@@ -68,7 +68,7 @@ public class ThresholdEvaluatorAbsoluteChange implements ThresholdEvaluator {
         private BaseThresholdDefConfigWrapper m_thresholdConfig;
         private double m_change;
 
-        static class State implements Serializable {
+        static class State extends AbstractThresholdEvaluatorState.AbstractState {
             private static final long serialVersionUID = 1L;
             private double m_lastSample = Double.NaN;
             private double m_previousTriggeringSample;
@@ -76,7 +76,8 @@ public class ThresholdEvaluatorAbsoluteChange implements ThresholdEvaluator {
             @Override
             public String toString() {
                 return "lastSample=" + m_lastSample +
-                        "\npreviousTriggeringSample=" + m_previousTriggeringSample;
+                        "\npreviousTriggeringSample=" + m_previousTriggeringSample +
+                        "\n" + super.toString();
             }
         }
 

--- a/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/ThresholdEvaluatorHighLow.java
+++ b/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/ThresholdEvaluatorHighLow.java
@@ -76,7 +76,7 @@ public class ThresholdEvaluatorHighLow implements ThresholdEvaluator {
          */
         private BaseThresholdDefConfigWrapper m_thresholdConfig;
 
-        static class State implements Serializable {
+        static class State extends AbstractThresholdEvaluatorState.AbstractState {
             private static final long serialVersionUID = 1L;
 
             /**
@@ -99,7 +99,8 @@ public class ThresholdEvaluatorHighLow implements ThresholdEvaluator {
             @Override
             public String toString() {
                 return "exceededCount=" + m_exceededCount +
-                        "\narmed=" + m_armed;
+                        "\narmed=" + m_armed +
+                        "\n" + super.toString();
             }
         }
         

--- a/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/ThresholdEvaluatorRearmingAbsoluteChange.java
+++ b/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/ThresholdEvaluatorRearmingAbsoluteChange.java
@@ -67,7 +67,7 @@ public class ThresholdEvaluatorRearmingAbsoluteChange implements ThresholdEvalua
     public static class ThresholdEvaluatorStateRearmingAbsoluteChange extends AbstractThresholdEvaluatorState<ThresholdEvaluatorStateRearmingAbsoluteChange.State> {
         private BaseThresholdDefConfigWrapper m_thresholdConfig;
 
-        static class State implements Serializable {
+        static class State extends AbstractThresholdEvaluatorState.AbstractState {
             private static final long serialVersionUID = 1L;
             private double m_lastSample = Double.NaN;
             private double m_previousTriggeringSample = Double.NaN;
@@ -77,7 +77,8 @@ public class ThresholdEvaluatorRearmingAbsoluteChange implements ThresholdEvalua
             public String toString() {
                 return "lastSample=" + m_lastSample +
                         "\npreviousTriggeringSample=" + m_previousTriggeringSample +
-                        "\ntriggerCount=" + m_triggerCount;
+                        "\ntriggerCount=" + m_triggerCount +
+                        "\n" + super.toString();
             }
         }
 

--- a/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/ThresholdEvaluatorRelativeChange.java
+++ b/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/ThresholdEvaluatorRelativeChange.java
@@ -73,7 +73,7 @@ public class ThresholdEvaluatorRelativeChange implements ThresholdEvaluator {
     public static class ThresholdEvaluatorStateRelativeChange extends AbstractThresholdEvaluatorState<ThresholdEvaluatorStateRelativeChange.State> {
         private BaseThresholdDefConfigWrapper m_thresholdConfig;
 
-        static class State implements Serializable {
+        static class State extends AbstractThresholdEvaluatorState.AbstractState {
             private static final long serialVersionUID = 1L;
             private double m_multiplier;
             private double m_lastSample = 0.0;
@@ -83,7 +83,8 @@ public class ThresholdEvaluatorRelativeChange implements ThresholdEvaluator {
             public String toString() {
                 return "multiplier=" + m_multiplier +
                         "\nlastSample=" + m_lastSample +
-                        "\npreviousTriggeringSample=" + m_previousTriggeringSample;
+                        "\npreviousTriggeringSample=" + m_previousTriggeringSample +
+                        "\n" + super.toString();
             }
         }
 

--- a/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/ThresholdEvaluatorState.java
+++ b/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/ThresholdEvaluatorState.java
@@ -29,6 +29,8 @@
 package org.opennms.netmgt.threshd;
 
 import java.util.Date;
+import java.util.Map;
+import java.util.Objects;
 
 import org.opennms.netmgt.threshd.api.ThresholdingSession;
 import org.opennms.netmgt.xml.event.Event;
@@ -59,9 +61,15 @@ public interface ThresholdEvaluatorState {
     default Status evaluate(double dsValue) {
         return evaluate(dsValue, null);
     }
-    
+
     Status evaluate(double dsValue, Long sequenceNumber);
 
+    /**
+     * @return the value that was evaluated along with the resulting status
+     */
+    ValueStatus evaluate(ExpressionThresholdValue valueSupplier, Long sequenceNumber)
+            throws ThresholdExpressionException;
+    
     /**
      * <p>getEventForState</p>
      *
@@ -98,6 +106,38 @@ public interface ThresholdEvaluatorState {
      * @return a {@link org.opennms.netmgt.threshd.ThresholdEvaluatorState} object.
      */
     public ThresholdEvaluatorState getCleanClone();
-    
+
     ThresholdingSession getThresholdingSession();
+
+    class ValueStatus {
+        public final double value;
+        public final Status status;
+
+        public ValueStatus(double value, Status status) {
+            this.value = value;
+            this.status = Objects.requireNonNull(status);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            ValueStatus that = (ValueStatus) o;
+            return Double.compare(that.value, value) == 0 &&
+                    status == that.status;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(value, status);
+        }
+
+        @Override
+        public String toString() {
+            return "ValueStatus{" +
+                    "value=" + value +
+                    ", status=" + status +
+                    '}';
+        }
+    }
 }

--- a/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/ThresholdingSetImpl.java
+++ b/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/ThresholdingSetImpl.java
@@ -46,6 +46,7 @@ import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 import java.util.stream.Collectors;
 
+import org.opennms.core.rpc.utils.mate.EntityScopeProvider;
 import org.opennms.netmgt.collectd.AliasedResource;
 import org.opennms.netmgt.collection.api.CollectionAttribute;
 import org.opennms.netmgt.collection.api.CollectionResource;
@@ -100,11 +101,12 @@ public class ThresholdingSetImpl implements ThresholdingSet {
     private final ReadableThresholdingDao m_thresholdingDao;
     private final ReadablePollOutagesDao m_pollOutagesDao;
     private final IfLabel m_ifLabelDao;
+    private final EntityScopeProvider m_entityScopeProvider;
 
     public ThresholdingSetImpl(int nodeId, String hostAddress, String serviceName, RrdRepository repository, ServiceParameters svcParams, ResourceStorageDao resourceStorageDao,
-            ThresholdingEventProxy eventProxy, ThresholdingSession thresholdingSession, ReadableThreshdDao threshdDao,
+                               ThresholdingEventProxy eventProxy, ThresholdingSession thresholdingSession, ReadableThreshdDao threshdDao,
                                ReadableThresholdingDao thresholdingDao, ReadablePollOutagesDao pollOutagesDao,
-                               IfLabel ifLabelDao)
+                               IfLabel ifLabelDao, EntityScopeProvider entityScopeProvider)
             throws ThresholdInitializationException {
         m_nodeId = nodeId;
         m_hostAddress = (hostAddress == null ? null : hostAddress.intern());
@@ -118,6 +120,7 @@ public class ThresholdingSetImpl implements ThresholdingSet {
         m_thresholdingDao = Objects.requireNonNull(thresholdingDao);
         m_pollOutagesDao = Objects.requireNonNull(pollOutagesDao);
         m_ifLabelDao = Objects.requireNonNull(ifLabelDao);
+        m_entityScopeProvider = Objects.requireNonNull(entityScopeProvider);
         
         initThresholdsDao();
         initialize();
@@ -397,6 +400,7 @@ public class ThresholdingSetImpl implements ThresholdingSet {
                 m_thresholdingDao.reload();
                 defaultThresholdsDao.setThresholdingDao(m_thresholdingDao);
                 defaultThresholdsDao.setEventProxy(m_eventProxy);
+                defaultThresholdsDao.setEntityScopeProvider(m_entityScopeProvider);
                 defaultThresholdsDao.afterPropertiesSet();
             } catch (final Throwable t) {
                 final ThresholdInitializationException tie = new ThresholdInitializationException("Could not initialize DefaultThresholdsDao.", t);

--- a/features/collection/thresholding/impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/features/collection/thresholding/impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -3,11 +3,24 @@
     <reference id="thresholdingDao" interface="org.opennms.netmgt.config.dao.thresholding.api.ReadableThresholdingDao"/>
     <reference id="pollOutagesDao" interface="org.opennms.netmgt.config.dao.outages.api.ReadablePollOutagesDao"/>
     <reference id="ifLabelDao" interface="org.opennms.netmgt.dao.api.IfLabel"/>
+    <reference id="nodeDao" interface="org.opennms.netmgt.dao.api.NodeDao"/>
+    <reference id="ipInterfaceDao" interface="org.opennms.netmgt.dao.api.IpInterfaceDao"/>
+    <reference id="monitoredServiceDao" interface="org.opennms.netmgt.dao.api.MonitoredServiceDao"/>
+    <reference id="sessionUtils" interface="org.opennms.netmgt.dao.api.SessionUtils"/>
+
+    <bean id="entityScopeProvider" class="org.opennms.core.rpc.utils.mate.EntityScopeProviderImpl">
+        <property name="nodeDao" ref="nodeDao"/>
+        <property name="ipInterfaceDao" ref="ipInterfaceDao"/>
+        <property name="monitoredServiceDao" ref="monitoredServiceDao"/>
+        <property name="sessionUtils" ref="sessionUtils"/>
+    </bean>
+    
     <bean id="thresholdingSetPersister" class="org.opennms.netmgt.threshd.DefaultThresholdingSetPersister">
         <property name="threshdDao" ref="threshdDao"/>
         <property name="thresholdingDao" ref="thresholdingDao"/>
         <property name="pollOutagesDao" ref="pollOutagesDao"/>
         <property name="ifLabelDao" ref="ifLabelDao"/>
+        <property name="entityScopeProvider" ref="entityScopeProvider"/>
     </bean>
     
     <reference id="eventForwarder" interface="org.opennms.netmgt.events.api.EventForwarder" />

--- a/features/collection/thresholding/impl/src/test/java/org/opennms/netmgt/threshd/ThresholdExpressionTestCase.java
+++ b/features/collection/thresholding/impl/src/test/java/org/opennms/netmgt/threshd/ThresholdExpressionTestCase.java
@@ -28,10 +28,14 @@
 
 package org.opennms.netmgt.threshd;
 
+import static org.mockito.Mockito.mock;
+
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.opennms.core.rpc.utils.mate.EntityScopeProvider;
+import org.opennms.core.rpc.utils.mate.Scope;
 import org.opennms.netmgt.config.threshd.Expression;
 import org.opennms.netmgt.config.threshd.ThresholdType;
 
@@ -50,6 +54,8 @@ import junit.framework.TestCase;
 public class ThresholdExpressionTestCase extends TestCase {
     
     Expression expression;
+    
+    private final Scope scope = mock(Scope.class);
     
     @Override
     public void setUp() {
@@ -71,7 +77,7 @@ public class ThresholdExpressionTestCase extends TestCase {
         
         Map<String, Double> values=new HashMap<String,Double>();
         values.put("dsname",1000.0);
-        double result=wrapper.evaluate(values);
+        double result=wrapper.interpolateAndEvaluate(values, scope).value;
         assertEquals("Threshold Expression result", Double.valueOf(result), Double.valueOf(100.0));
     }
     
@@ -85,7 +91,7 @@ public class ThresholdExpressionTestCase extends TestCase {
         
         Map<String, Double> values=new HashMap<String,Double>();
         values.put("dsname",100.0);
-        double result=wrapper.evaluate(values);
+        double result=wrapper.interpolateAndEvaluate(values, scope).value;
         assertEquals("Threshold Expression result", Double.valueOf(result), Double.valueOf(1000.0));
     }
     
@@ -99,7 +105,7 @@ public class ThresholdExpressionTestCase extends TestCase {
         
         Map<String, Double> values=new HashMap<String,Double>();
         values.put("dsname",100.0);
-        double result=wrapper.evaluate(values);
+        double result=wrapper.interpolateAndEvaluate(values, scope).value;
         assertEquals("Threshold Expression result", Double.valueOf(result), Double.valueOf(90.0));
     }
 
@@ -113,7 +119,7 @@ public class ThresholdExpressionTestCase extends TestCase {
         
         Map<String, Double> values=new HashMap<String,Double>();
         values.put("dsname",100.0);
-        double result=wrapper.evaluate(values);
+        double result=wrapper.interpolateAndEvaluate(values, scope).value;
         assertEquals("Threshold Expression result", Double.valueOf(result), Double.valueOf(110.0));
     }
     
@@ -128,7 +134,7 @@ public class ThresholdExpressionTestCase extends TestCase {
         Map<String, Double> values=new HashMap<String,Double>();
         values.put("dsname1",100.0);
         values.put("dsname2",5.0);
-        double result=wrapper.evaluate(values);
+        double result=wrapper.interpolateAndEvaluate(values, scope).value;
         assertEquals("Threshold Expression result", Double.valueOf(result), Double.valueOf(20.0));
     }
     
@@ -143,7 +149,7 @@ public class ThresholdExpressionTestCase extends TestCase {
         Map<String, Double> values=new HashMap<String,Double>();
         values.put("dsname1",20.0);
         values.put("dsname2",5.0);
-        double result=wrapper.evaluate(values);
+        double result=wrapper.interpolateAndEvaluate(values, scope).value;
         assertEquals("Threshold Expression result", Double.valueOf(result), Double.valueOf(100.0));
     }
     
@@ -158,7 +164,7 @@ public class ThresholdExpressionTestCase extends TestCase {
         Map<String, Double> values=new HashMap<String,Double>();
         values.put("dsname1",20.0);
         values.put("dsname2",5.0);
-        double result=wrapper.evaluate(values);
+        double result=wrapper.interpolateAndEvaluate(values, scope).value;
         assertEquals("Threshold Expression result", Double.valueOf(result), Double.valueOf(25.0));
     }
     
@@ -173,7 +179,7 @@ public class ThresholdExpressionTestCase extends TestCase {
         Map<String, Double> values=new HashMap<String,Double>();
         values.put("dsname1",20.0);
         values.put("dsname2",5.0);
-        double result=wrapper.evaluate(values);
+        double result=wrapper.interpolateAndEvaluate(values, scope).value;
         assertEquals("Threshold Expression result", Double.valueOf(result), Double.valueOf(15.0));
     }
     
@@ -194,14 +200,14 @@ public class ThresholdExpressionTestCase extends TestCase {
         values.put("hrStorageAllocationUnits",1024.0); //1K units
         values.put("hrStorageSize",2048.0); //2MB total size
         values.put("hrStorageUsed",1024.0); //1MB used
-        double result=wrapper.evaluate(values);
+        double result=wrapper.interpolateAndEvaluate(values, scope).value;
         
         //1MB free, hopefully
         assertEquals("Threshold Expression result", Double.valueOf(result), Double.valueOf(1024.0*1024.0));
     }
     
     public void testThresholdEntityRequiredDataSources() throws Exception {
-        ThresholdEntity entity=new ThresholdEntity();
+        ThresholdEntity entity=new ThresholdEntity(mock(EntityScopeProvider.class));
         expression.setExpression("(hrStorageSize-hrStorageUsed)*hrStorageAllocationUnits");
         BaseThresholdDefConfigWrapper wrapper=BaseThresholdDefConfigWrapper.getConfigWrapper(expression);
         assertEquals(3, wrapper.getRequiredDatasources().size());
@@ -242,7 +248,7 @@ public class ThresholdExpressionTestCase extends TestCase {
         values.put("trueval",3.0);
         values.put("falseval",7.0);
         
-        double result=wrapper.evaluate(values);
+        double result=wrapper.interpolateAndEvaluate(values, scope).value;
         assertEquals("Conditional Expression result", Double.valueOf(result), Double.valueOf(7.0));
     }
     
@@ -266,7 +272,7 @@ public class ThresholdExpressionTestCase extends TestCase {
         values.put("trueval",3.0);
         values.put("falseval",7.0);
         
-        double result=wrapper.evaluate(values);
+        double result=wrapper.interpolateAndEvaluate(values, scope).value;
         assertEquals("Conditional Expression result", Double.valueOf(result), Double.valueOf(3.0));
     }
     
@@ -281,13 +287,13 @@ public class ThresholdExpressionTestCase extends TestCase {
         Map<String,Double> values=new HashMap<String,Double>();
         values.put("variable", -25.0);
         
-        double result = wrapper.evaluate(values);
+        double result = wrapper.interpolateAndEvaluate(values, scope).value;
         assertEquals("Conditional Expression result", Double.valueOf(20.0), result);
         
         values.clear();
         values.put("variable", 25.0);
         
-        result = wrapper.evaluate(values);
+        result = wrapper.interpolateAndEvaluate(values, scope).value;
         assertEquals("Conditional Expression result", Double.valueOf(30.0), result);
     }
 }

--- a/features/collection/thresholding/itests/src/test/java/org/opennms/netmgt/threshd/LatencyThresholdingSetIT.java
+++ b/features/collection/thresholding/itests/src/test/java/org/opennms/netmgt/threshd/LatencyThresholdingSetIT.java
@@ -118,7 +118,8 @@ import org.springframework.test.context.ContextConfiguration;
         "classpath:/META-INF/opennms/applicationContext-testPostgresBlobStore.xml",
         "classpath:/META-INF/opennms/mockEventIpcManager.xml",
         "classpath:/META-INF/opennms/applicationContext-testThresholdingDaos.xml",
-        "classpath:/META-INF/opennms/applicationContext-testPollerConfigDaos.xml"
+        "classpath:/META-INF/opennms/applicationContext-testPollerConfigDaos.xml",
+        "classpath:/META-INF/opennms/applicationContext-rpc-utils.xml"
 })
 @JUnitConfigurationEnvironment
 @JUnitTemporaryDatabase(tempDbClass=MockDatabase.class)

--- a/features/collection/thresholding/itests/src/test/java/org/opennms/netmgt/threshd/ThresholdingSessionIT.java
+++ b/features/collection/thresholding/itests/src/test/java/org/opennms/netmgt/threshd/ThresholdingSessionIT.java
@@ -68,7 +68,8 @@ import org.springframework.test.context.ContextConfiguration;
         "classpath:/META-INF/opennms/applicationContext-thresholding.xml",
         "classpath:/META-INF/opennms/applicationContext-testPostgresBlobStore.xml",
         "classpath:/META-INF/opennms/applicationContext-testThresholdingDaos.xml",
-        "classpath:/META-INF/opennms/applicationContext-testPollerConfigDaos.xml"
+        "classpath:/META-INF/opennms/applicationContext-testPollerConfigDaos.xml",
+        "classpath:/META-INF/opennms/applicationContext-rpc-utils.xml"
 })
 @JUnitConfigurationEnvironment
 @JUnitTemporaryDatabase(tempDbClass=MockDatabase.class)

--- a/features/collection/thresholding/itests/src/test/java/org/opennms/netmgt/threshd/ThresholdingVisitorIT.java
+++ b/features/collection/thresholding/itests/src/test/java/org/opennms/netmgt/threshd/ThresholdingVisitorIT.java
@@ -59,6 +59,7 @@ import org.junit.runner.RunWith;
 import org.opennms.core.collection.test.MockCollectionAgent;
 import org.opennms.core.db.DataSourceFactory;
 import org.opennms.core.rpc.mock.MockRpcClientFactory;
+import org.opennms.core.rpc.utils.mate.EntityScopeProvider;
 import org.opennms.core.test.Level;
 import org.opennms.core.test.LoggingEvent;
 import org.opennms.core.test.MockLogAppender;
@@ -145,6 +146,7 @@ import org.springframework.test.context.ContextConfiguration;
         "classpath:/META-INF/opennms/applicationContext-commonConfigs.xml",
         "classpath:/META-INF/opennms/applicationContext-soa.xml",
         "classpath:/META-INF/opennms/applicationContext-dao.xml",
+        "classpath:/META-INF/opennms/applicationContext-rpc-utils.xml",
 })
 @JUnitConfigurationEnvironment
 @JUnitTemporaryDatabase
@@ -172,6 +174,9 @@ public class ThresholdingVisitorIT {
     
     @Autowired
     private IfLabel m_ifLabelDao;
+    
+    @Autowired
+    private EntityScopeProvider m_entityScopeProvider;
 
     private static final Comparator<Parm> PARM_COMPARATOR = new Comparator<Parm>() {
         @Override
@@ -1687,7 +1692,7 @@ public class ThresholdingVisitorIT {
         ThresholdingEventProxyImpl eventProxy = new ThresholdingEventProxyImpl(eventMgr);
         ThresholdingSetImpl thresholdingSet = new ThresholdingSetImpl(node, location, serviceName, getRepository(),
                 svcParams, m_resourceStorageDao, eventProxy, MockSession.getSession(), m_threshdDao, m_thresholdingDao,
-                m_pollOutagesDao, m_ifLabelDao);
+                m_pollOutagesDao, m_ifLabelDao, m_entityScopeProvider);
         ThresholdingVisitor visitor = new ThresholdingVisitorImpl(thresholdingSet, m_resourceStorageDao, eventProxy, null);
         assertNotNull(visitor);
         return visitor;

--- a/features/distributed/dao/impl/pom.xml
+++ b/features/distributed/dao/impl/pom.xml
@@ -62,6 +62,7 @@
                             org.slf4j,
 
                             org.hibernate,
+                            org.hibernate.classic,
                             org.hibernate.criterion,
                             org.hibernate.metadata,
                             org.hibernate.transform,

--- a/opennms-services/src/test/java/org/opennms/netmgt/poller/pollables/LatencyStoringServiceMonitorAdaptorIT.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/poller/pollables/LatencyStoringServiceMonitorAdaptorIT.java
@@ -90,7 +90,8 @@ import org.springframework.test.context.ContextConfiguration;
         "classpath:/META-INF/opennms/applicationContext-thresholding.xml",
         "classpath:/META-INF/opennms/applicationContext-testPostgresBlobStore.xml",
         "classpath:/META-INF/opennms/applicationContext-testThresholdingDaos.xml",
-        "classpath:/META-INF/opennms/applicationContext-testPollerConfigDaos.xml"
+        "classpath:/META-INF/opennms/applicationContext-testPollerConfigDaos.xml",
+        "classpath:/META-INF/opennms/applicationContext-rpc-utils.xml"
 })
 @JUnitConfigurationEnvironment
 @JUnitTemporaryDatabase(tempDbClass=MockDatabase.class)

--- a/smoke-test/src/test/java/org/opennms/smoketest/sentinel/AbstractAdapterIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/sentinel/AbstractAdapterIT.java
@@ -38,6 +38,7 @@ import static org.junit.Assert.assertNotNull;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
@@ -55,6 +56,7 @@ import org.opennms.netmgt.model.OnmsNode;
 import org.opennms.netmgt.model.PrimaryType;
 import org.opennms.netmgt.provision.persist.requisition.Requisition;
 import org.opennms.netmgt.provision.persist.requisition.RequisitionInterface;
+import org.opennms.netmgt.provision.persist.requisition.RequisitionMetaData;
 import org.opennms.netmgt.provision.persist.requisition.RequisitionNode;
 import org.opennms.smoketest.containers.OpenNMSContainer;
 import org.opennms.smoketest.stacks.OpenNMSStack;
@@ -83,6 +85,7 @@ public abstract class AbstractAdapterIT {
         protected String foreignId;
         protected String foreignSource;
         protected String ipAddress;
+        protected List<RequisitionMetaData> metaData;
 
         public Requisition createRequisition() {
             Objects.requireNonNull(location);
@@ -104,6 +107,7 @@ public abstract class AbstractAdapterIT {
             node.setForeignId(foreignId);
             node.setLocation(location);
             node.setInterfaces(interfaces);
+            node.setMetaData(metaData != null ? metaData : Collections.emptyList());
             requisition.insertNode(node);
 
             return requisition;

--- a/smoke-test/src/test/java/org/opennms/smoketest/sentinel/SentinelThresholdingIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/sentinel/SentinelThresholdingIT.java
@@ -37,6 +37,7 @@ import static org.opennms.netmgt.events.api.EventConstants.HIGH_THRESHOLD_EVENT_
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.AbstractMap;
+import java.util.Collections;
 import java.util.Date;
 import java.util.Map;
 import java.util.Random;
@@ -45,11 +46,11 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.opennms.netmgt.model.OnmsAlarmCollection;
 import org.opennms.netmgt.model.OnmsNode;
 import org.opennms.netmgt.model.OnmsSeverity;
+import org.opennms.netmgt.provision.persist.requisition.RequisitionMetaData;
 import org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.Port;
 import org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.TelemetryTop;
 import org.opennms.smoketest.stacks.BlobStoreStrategy;
@@ -58,14 +59,15 @@ import org.opennms.smoketest.stacks.JsonStoreStrategy;
 import org.opennms.smoketest.stacks.NetworkProtocol;
 import org.opennms.smoketest.stacks.OpenNMSProfile;
 import org.opennms.smoketest.stacks.OpenNMSStack;
+import org.opennms.smoketest.stacks.SentinelProfile;
 import org.opennms.smoketest.stacks.StackModel;
 import org.opennms.smoketest.telemetry.Packet;
 import org.opennms.smoketest.utils.KarafShell;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class SentinelThrehsoldingIT {
-    private static final Logger LOG = LoggerFactory.getLogger(SentinelThrehsoldingIT.class);
+public class SentinelThresholdingIT {
+    private static final Logger LOG = LoggerFactory.getLogger(SentinelThresholdingIT.class);
     private static final String NODE_IP = "192.168.1.1";
     private static final String INTERFACE_ID = "eth0_system_test";
 
@@ -136,6 +138,11 @@ public class SentinelThrehsoldingIT {
         requisitionCreateInfo.foreignSource = "telemetry-jti";
         requisitionCreateInfo.foreignId = "dummy-node";
         requisitionCreateInfo.nodeLabel = "Dummy Node";
+        RequisitionMetaData metaData = new RequisitionMetaData();
+        metaData.setKey("multiplier");
+        metaData.setValue("1");
+        metaData.setContext("requisition");
+        requisitionCreateInfo.metaData = Collections.singletonList(metaData);
         return requisitionCreateInfo;
     }
 

--- a/smoke-test/src/test/resources/sentinel-thresholding/thresholds.xml
+++ b/smoke-test/src/test/resources/sentinel-thresholding/thresholds.xml
@@ -1,5 +1,5 @@
 <thresholding-config xmlns="http://xmlns.opennms.org/xsd/config/thresholding">
     <group name="jti" rrdRepository="/opt/opennms/share/rrd/snmp/">
-        <expression description="Test" type="high" ds-type="if" value="100000" rearm="75000" trigger="1" ds-label="ifName" filterOperator="OR" expression="ifInOctets + ifOutOctets"/>
+        <expression description="Test" type="high" ds-type="if" value="100000" rearm="75000" trigger="1" ds-label="ifName" filterOperator="OR" expression="ifInOctets + ifOutOctets * ${requisition:multiplier|0}"/>
     </group>
 </thresholding-config>


### PR DESCRIPTION
This PR enhances expression based thresholds to allow one or more meta-data expressions to be included in the threshold expression. These will then be interpolated and cached the first time the threshold is evaluated.

With this enhancement the same threshold can be evaluated with a different expression depending on the resource and meta data configuration. For example a thresholded collection may be evaluated using different values for two nodes by giving each node a different value for the node-level meta data being used in the expression.

Note that this feature currently strictly requires all meta-data expressions that are inserted into a threshold expression to include a default value.

I've tested this manually on OpenNMS and verified on Sentinel via smoke test.

For automated testing, I've simply updated some existing expression test coverage to include meta-data expressions such that they would fail if meta-data interpolation did not work (IT and smoke test which covers Sentinel). Can add more dedicated test coverage if it looks like we need it.

I haven't updated any documentation as I'm assuming that will be done as part of the release 25 documentation updates for thresholding.

### All Contributors

* [x] Have you read and followed our [Contribution Guidelines](https://github.com/OpenNMS/opennms/blob/develop/CONTRIBUTING.md)?
* [x] Have you [made an issue in the OpenNMS issue tracker](https://issues.opennms.org)?<br>If so, you should:
  1. update the title of this PR to be of the format: `${JIRA-ISSUE-NUMBER}: subject of pull request`
  2. update the JIRA link at the bottom of this comment to refer to the real issue number
  3. prefix your commit messages with the issue number, if possible
* [x] Have you made a comment in that issue which points back to this PR?
* [x] Have you updated the JIRA link at the bottom of this comment to link to your issue?
* [ ] If this is a new or updated feature, is there documentation for the new behavior?
* [x] If this is new code, are there unit and/or integration tests?
* [x] If this PR targets a `foundation-*` branch, does it avoid changing files in `$OPENNMS_HOME/etc/`?

### Pull Request Process

One or more reviewers should be assigned to each PR.

If you know that a particular person is subject matter expert in the area your PR affects, feel free to assign one or more reviewers when you create this PR, otherwise reviewers will be assigned for you.

Once the reviewer(s) accept the PR and the branch passes continuous integration in Bamboo, the PR is eligible for merge.

At that time, if you have commit access (are an OpenNMS Group employee or a member of the Order of the Green Polo) you are welcome to merge the PR.
Otherwise, a reviewer can merge it for you.

Thanks for taking time to contribute!

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-12247
* Bamboo (Continuous Integration): https://bamboo.opennms.org/

