### PR TITLE
NMS-12285: Do not rebuild caches during init

### DIFF
--- a/opennms-config/src/main/java/org/opennms/netmgt/config/PollerConfig.java
+++ b/opennms-config/src/main/java/org/opennms/netmgt/config/PollerConfig.java
@@ -398,30 +398,4 @@ public interface PollerConfig extends PathOutageConfig {
      * @return a Lock
      */
     Lock getWriteLock();
-
-    default Package findPackageForService(String ipAddr, String serviceName) {
-        Enumeration<Package> en = this.enumeratePackage();
-        Package lastPkg = null;
-
-        while (en.hasMoreElements()) {
-            Package pkg = en.nextElement();
-            if (pollableServiceInPackage(ipAddr, serviceName, pkg))
-                lastPkg = pkg;
-        }
-        return lastPkg;
-    }
-
-    default boolean pollableServiceInPackage(String ipAddr, String serviceName, Package pkg) {
-        if (pkg.getRemote()) {
-            return false;
-        }
-
-        if (!this.isServiceInPackageAndEnabled(serviceName, pkg)) return false;
-
-        boolean inPkg = this.isInterfaceInPackage(ipAddr, pkg);
-        if (inPkg) return true;
-
-        this.rebuildPackageIpListMap();
-        return this.isInterfaceInPackage(ipAddr, pkg);
-    }
 }

--- a/opennms-services/src/test/java/org/opennms/netmgt/poller/PollerIT.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/poller/PollerIT.java
@@ -271,7 +271,7 @@ public class PollerIT implements TemporaryDatabaseAware<MockDatabase> {
         pkg.setRemote(true);
         Poller poller = new Poller();
         poller.setPollerConfig(new MockPollerConfig(m_network));
-        assertFalse(poller.getPollerConfig().pollableServiceInPackage(null, null, pkg));
+        assertFalse(poller.pollableServiceInPackage(null, null, pkg));
     }
 
     @Test

--- a/opennms-services/src/test/java/org/opennms/netmgt/poller/PollerQueryManagerDaoIT.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/poller/PollerQueryManagerDaoIT.java
@@ -248,7 +248,7 @@ public class PollerQueryManagerDaoIT implements TemporaryDatabaseAware<MockDatab
         pkg.setRemote(true);
         Poller poller = new Poller();
 		poller.setPollerConfig(new MockPollerConfig(m_network));
-        assertFalse(poller.getPollerConfig().pollableServiceInPackage(null, null, pkg));
+        assertFalse(poller.pollableServiceInPackage(null, null, pkg));
         poller = null;
     }
 


### PR DESCRIPTION
This prevents the poller package to interface cache to be rebuild on
every access during startup phase.

JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-12285

To be hones, I can't remember why the code was moved from `Poller` to `PollerConfig` but this reverts the move as introduced in #2445 and re-enables the test to skip the rebuild during initialization.

