### PR TITLE
NMS-12125: fix log file parsing in the .cfg setup

### DIFF
--- a/opennms-assemblies/minion/src/main/filtered/debian/rules
+++ b/opennms-assemblies/minion/src/main/filtered/debian/rules
@@ -61,7 +61,7 @@ override_dh_auto_install:
 		&& rm -rf $$(pwd)/debian/$(CONTAINER_NAME)$(ETCDIR)/minion.conf
 	
 	# change the logging directory to /var/log/minion
-	sed -e "s,.{karaf.data}/log,$(LOGDIR),g" -e 's,karaf.log,minion.log,g' $$(pwd)/etc/org.ops4j.pax.logging.cfg > $$(pwd)/debian/$(CONTAINER_NAME)$(ETCDIR)/org.ops4j.pax.logging.cfg
+	sed -e "s,.{karaf.data}/log,$(LOGDIR),g" -e 's,/karaf.log,/minion.log,g' $$(pwd)/etc/org.ops4j.pax.logging.cfg > $$(pwd)/debian/$(CONTAINER_NAME)$(ETCDIR)/org.ops4j.pax.logging.cfg
 	
 	# set the default location
 	echo "location = MINION" > $$(pwd)/debian/$(CONTAINER_NAME)$(ETCDIR)/org.opennms.minion.controller.cfg \

--- a/opennms-assemblies/sentinel/src/main/filtered/debian/rules
+++ b/opennms-assemblies/sentinel/src/main/filtered/debian/rules
@@ -50,7 +50,7 @@ override_dh_auto_install:
 		&& rm -rf $$(pwd)/debian/$(PACKAGE_NAME)$(ETCDIR)/sentinel.conf
 	
 	# change the logging directory to /var/log/sentinel
-	sed -e "s,.{karaf.data}/log,$(LOGDIR),g" -e 's,karaf.log,sentinel.log,g' $$(pwd)/etc/org.ops4j.pax.logging.cfg > $$(pwd)/debian/$(PACKAGE_NAME)$(ETCDIR)/org.ops4j.pax.logging.cfg
+	sed -e "s,.{karaf.data}/log,$(LOGDIR),g" -e 's,/karaf.log,/sentinel.log,g' $$(pwd)/etc/org.ops4j.pax.logging.cfg > $$(pwd)/debian/$(PACKAGE_NAME)$(ETCDIR)/org.ops4j.pax.logging.cfg
 	
 	# install the init script
 	dh_installinit --package=$(PACKAGE_NAME) --name=sentinel --no-start -u"defaults 21 19"


### PR DESCRIPTION
When renaming the log files for the Minion and Sentinel karaf containers, the `sed` script was accidentally changing `${karaf.log}` variables to be `${minion.log}` or `${sentinel.log}` (which are unset) rather than just changing the filename of the log file itself.

This PR fixes it.

### All Contributors

* [x] Have you read and followed our [Contribution Guidelines](https://github.com/OpenNMS/opennms/blob/develop/CONTRIBUTING.md)?
* [x] Have you [made an issue in the OpenNMS issue tracker](https://issues.opennms.org)?<br>If so, you should:
  1. update the title of this PR to be of the format: `${JIRA-ISSUE-NUMBER}: subject of pull request`
  2. update the JIRA link at the bottom of this comment to refer to the real issue number
  3. prefix your commit messages with the issue number, if possible
* [x] Have you made a comment in that issue which points back to this PR?
* [x] Have you updated the JIRA link at the bottom of this comment to link to your issue?
* [ ] If this is a new or updated feature, is there documentation for the new behavior?
* [ ] If this is new code, are there unit and/or integration tests?
* [ ] If this PR targets a `foundation-*` branch, does it avoid changing files in `$OPENNMS_HOME/etc/`?

### Pull Request Process

One or more reviewers should be assigned to each PR.

If you know that a particular person is subject matter expert in the area your PR affects, feel free to assign one or more reviewers when you create this PR, otherwise reviewers will be assigned for you.

Once the reviewer(s) accept the PR and the branch passes continuous integration in Bamboo, the PR is eligible for merge.

At that time, if you have commit access (are an OpenNMS Group employee or a member of the Order of the Green Polo) you are welcome to merge the PR.
Otherwise, a reviewer can merge it for you.

Thanks for taking time to contribute!

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-12125
* Bamboo (Continuous Integration): https://bamboo.opennms.org/

