### PR TITLE
NMS-12301: Fix the default "90% Interface Throughput" Thresholds

### DIFF
--- a/opennms-base-assembly/src/main/filtered/etc/thresholds.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/thresholds.xml
@@ -9,10 +9,10 @@
       <expression description="Trigger an alert if outgoing usage of an interface reaches or goes above 90% of its maximum speed for three consecutive measurement intervals (only for interfaces that have a maximum speed value defined)" type="high" ds-type="if" value="90.0" rearm="75.0" trigger="3" ds-label="ifName" filterOperator="OR" expression="ifHCOutOctets * 8 / 1000000 / ifHighSpeed * 100">
          <resource-filter field="ifHighSpeed">^[1-9]+[0-9]*$</resource-filter>
       </expression>
-      <expression description="Trigger an alert if incoming usage of any interface reaches or goes above 90% of its maximum speed for three consecutive measurement intervals (only for interfaces that have a maximum speed value defined)" type="high" ds-type="if" value="90.0" rearm="75.0" trigger="3" ds-label="ifName" filterOperator="OR" expression="ifInOctets * 8 / 1000000 / ifSpeed * 100">
+      <expression description="Trigger an alert if incoming usage of any interface reaches or goes above 90% of its maximum speed for three consecutive measurement intervals (only for interfaces that have a maximum speed value defined)" type="high" ds-type="if" value="90.0" rearm="75.0" trigger="3" ds-label="ifName" filterOperator="OR" expression="ifInOctets * 8 / ifSpeed * 100">
          <resource-filter field="ifSpeed">^[1-9]+[0-9]*$</resource-filter>
       </expression>
-      <expression description="Trigger an alert if outgoing usage of an interface reaches or goes above 90% of its maximum speed for three consecutive measurement intervals (only for interfaces that have a maximum speed value defined)" type="high" ds-type="if" value="90.0" rearm="75.0" trigger="3" ds-label="ifName" filterOperator="OR" expression="ifOutOctets * 8 / 1000000 / ifSpeed * 100">
+      <expression description="Trigger an alert if outgoing usage of an interface reaches or goes above 90% of its maximum speed for three consecutive measurement intervals (only for interfaces that have a maximum speed value defined)" type="high" ds-type="if" value="90.0" rearm="75.0" trigger="3" ds-label="ifName" filterOperator="OR" expression="ifOutOctets * 8 / ifSpeed * 100">
          <resource-filter field="ifSpeed">^[1-9]+[0-9]*$</resource-filter>
       </expression>
    </group>

--- a/opennms-base-assembly/src/main/filtered/etc/thresholds.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/thresholds.xml
@@ -3,11 +3,17 @@
       <threshold description="Trigger an alert if one or more incoming packets on the whole node were not received due to an error for one measurement interval" type="high" ds-type="node" value="1.0" rearm="0.0" trigger="1" filterOperator="OR" ds-name="tcpInErrors"/>
       <expression description="Trigger an alert if one or more incoming or outgoing packets on an interface were not transmitted due to error for two consecutive measurement intervals" type="high" ds-type="if" value="1.0" rearm="0.0" trigger="2" ds-label="ifName" filterOperator="OR" expression="ifInErrors + ifOutErrors"/>
       <expression description="Trigger an alert if one or more incoming or outgoing packets on an interface were discarded even though no errors were detected (possibly to free up buffer space) for two consecutive measurement intervals" type="high" ds-type="if" value="1.0" rearm="0.0" trigger="2" ds-label="ifName" filterOperator="OR" expression="ifInDiscards + ifOutDiscards"/>
-      <expression description="Trigger an alert if incoming usage of any interface reaches or goes above 90% of its maximum speed for three consecutive measurement intervals (only for interfaces that have a maximum speed value defined)" type="high" ds-type="if" value="90.0" rearm="75.0" trigger="3" ds-label="ifName" filterOperator="OR" expression="ifInOctets * 8 / 1000000 / ifHighSpeed * 100">
+      <expression description="Trigger an alert if incoming usage of any interface reaches or goes above 90% of its maximum speed for three consecutive measurement intervals (only for interfaces that have a maximum speed value defined)" type="high" ds-type="if" value="90.0" rearm="75.0" trigger="3" ds-label="ifName" filterOperator="OR" expression="ifHCInOctets * 8 / 1000000 / ifHighSpeed * 100">
          <resource-filter field="ifHighSpeed">^[1-9]+[0-9]*$</resource-filter>
       </expression>
-      <expression description="Trigger an alert if outgoing usage of an interface reaches or goes above 90% of its maximum speed for three consecutive measurement intervals (only for interfaces that have a maximum speed value defined)" type="high" ds-type="if" value="90.0" rearm="75.0" trigger="3" ds-label="ifName" filterOperator="OR" expression="ifOutOctets * 8 / 1000000 / ifHighSpeed * 100">
+      <expression description="Trigger an alert if outgoing usage of an interface reaches or goes above 90% of its maximum speed for three consecutive measurement intervals (only for interfaces that have a maximum speed value defined)" type="high" ds-type="if" value="90.0" rearm="75.0" trigger="3" ds-label="ifName" filterOperator="OR" expression="ifHCOutOctets * 8 / 1000000 / ifHighSpeed * 100">
          <resource-filter field="ifHighSpeed">^[1-9]+[0-9]*$</resource-filter>
+      </expression>
+      <expression description="Trigger an alert if incoming usage of any interface reaches or goes above 90% of its maximum speed for three consecutive measurement intervals (only for interfaces that have a maximum speed value defined)" type="high" ds-type="if" value="90.0" rearm="75.0" trigger="3" ds-label="ifName" filterOperator="OR" expression="ifInOctets * 8 / 1000000 / ifSpeed * 100">
+         <resource-filter field="ifSpeed">^[1-9]+[0-9]*$</resource-filter>
+      </expression>
+      <expression description="Trigger an alert if outgoing usage of an interface reaches or goes above 90% of its maximum speed for three consecutive measurement intervals (only for interfaces that have a maximum speed value defined)" type="high" ds-type="if" value="90.0" rearm="75.0" trigger="3" ds-label="ifName" filterOperator="OR" expression="ifOutOctets * 8 / 1000000 / ifSpeed * 100">
+         <resource-filter field="ifSpeed">^[1-9]+[0-9]*$</resource-filter>
       </expression>
    </group>
    <group name="hrstorage" rrdRepository="${install.share.dir}/rrd/snmp/">


### PR DESCRIPTION
This updates them to use "ifHCInOctets" & "ifHCOutOctets", and adds two
additional thresholds for agents that only support "ifTable" metrics.

See https://issues.opennms.org/browse/NMS-12301

### All Contributors

* [x] Have you read and followed our [Contribution Guidelines](https://github.com/OpenNMS/opennms/blob/develop/CONTRIBUTING.md)?
* [x] Have you [made an issue in the OpenNMS issue tracker](https://issues.opennms.org)?<br>If so, you should:
  1. update the title of this PR to be of the format: `${JIRA-ISSUE-NUMBER}: subject of pull request`
  2. update the JIRA link at the bottom of this comment to refer to the real issue number
  3. prefix your commit messages with the issue number, if possible
* [x] Have you made a comment in that issue which points back to this PR?
* [x] Have you updated the JIRA link at the bottom of this comment to link to your issue?
* [x] If this is a new or updated feature, is there documentation for the new behavior?
* [x] If this is new code, are there unit and/or integration tests?
* [x] If this PR targets a `foundation-*` branch, does it avoid changing files in `$OPENNMS_HOME/etc/`?

### Pull Request Process

One or more reviewers should be assigned to each PR.

If you know that a particular person is subject matter expert in the area your PR affects, feel free to assign one or more reviewers when you create this PR, otherwise reviewers will be assigned for you.

Once the reviewer(s) accept the PR and the branch passes continuous integration in Bamboo, the PR is eligible for merge.

At that time, if you have commit access (are an OpenNMS Group employee or a member of the Order of the Green Polo) you are welcome to merge the PR.
Otherwise, a reviewer can merge it for you.

Thanks for taking time to contribute!

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-12301
* Bamboo (Continuous Integration): https://bamboo.opennms.org/

