### PR TITLE
NMS-12297: Grafana report generation is timing out

### DIFF
--- a/features/endpoints/grafana/client/src/main/java/org/opennms/netmgt/endpoints/grafana/client/GrafanaClientImpl.java
+++ b/features/endpoints/grafana/client/src/main/java/org/opennms/netmgt/endpoints/grafana/client/GrafanaClientImpl.java
@@ -142,6 +142,8 @@ public class GrafanaClientImpl implements GrafanaClient {
                 .addQueryParameter("to", Long.toString(to))
                 .addQueryParameter("width", Integer.toString(width))
                 .addQueryParameter("height", Integer.toString(height))
+                // Set a render timeout equal to the client's read timeout
+                .addQueryParameter("timeout", Integer.toString(config.getReadTimeoutSeconds()))
                 .addQueryParameter("theme", "light"); // Use the light theme
         if (!Strings.isNullOrEmpty(utcOffset)) {
             builder.addQueryParameter("tz", utcOffset);

--- a/features/endpoints/grafana/client/src/test/java/org/opennms/netmgt/endpoints/grafana/client/GrafanaClientImplIT.java
+++ b/features/endpoints/grafana/client/src/test/java/org/opennms/netmgt/endpoints/grafana/client/GrafanaClientImplIT.java
@@ -87,7 +87,7 @@ public class GrafanaClientImplIT {
         assertThat(panel.getDatasource(), equalTo("minion-dev (Flow)"));
         assertThat(panel.getDescription(), equalTo("igb0"));
 
-        stubFor(get(urlEqualTo("/render/d-solo/eWsVEL6zz/flows?panelId=3&from=0&to=1&width=128&height=128&theme=light"))
+        stubFor(get(urlEqualTo("/render/d-solo/eWsVEL6zz/flows?panelId=3&from=0&to=1&width=128&height=128&timeout=5&theme=light"))
                 .willReturn(aResponse()
                         .withHeader("Content-Type", "image/png")
                         .withBodyFile("panel.png")));


### PR DESCRIPTION
JIRA: https://issues.opennms.org/browse/NMS-12297

Here we set the rendering timeout to be equal to the HTTP client's read timeout.