### PR TITLE
NMS-12185: Ignore sampled headers without IP

### DIFF
--- a/features/telemetry/protocols/sflow/adapter/src/main/java/org/opennms/netmgt/telemetry/protocols/sflow/adapter/SFlowConverter.java
+++ b/features/telemetry/protocols/sflow/adapter/src/main/java/org/opennms/netmgt/telemetry/protocols/sflow/adapter/SFlowConverter.java
@@ -62,7 +62,8 @@ public class SFlowConverter implements Converter<BsonDocument> {
             if ("0:1".equals(format) || "0:3".equals(format)) {
                 // Handle only (expanded) flow samples
 
-                if (first(get(sampleDocument, "data", "flows", "0:1"),
+                if (first(get(sampleDocument, "data", "flows", "0:1", "ipv4"),
+                           get(sampleDocument, "data", "flows", "0:1", "ipv6"),
                            get(sampleDocument, "data", "flows", "0:3"),
                            get(sampleDocument, "data", "flows", "0:4")).isPresent()) {
                     // Handle only flows containing IP related records

--- a/features/telemetry/protocols/sflow/adapter/src/test/java/org/opennms/netmgt/telemetry/protocols/sflow/adapter/SFlowConverterTest.java
+++ b/features/telemetry/protocols/sflow/adapter/src/test/java/org/opennms/netmgt/telemetry/protocols/sflow/adapter/SFlowConverterTest.java
@@ -61,11 +61,11 @@ public class SFlowConverterTest {
         assertThat(bsonDocument.getInt64("time"), notNullValue());
         assertThat(bsonDocument.getInt64("time").getValue(), is(1521618510235L));
         assertThat(bsonDocument.getDocument("data").getArray("samples"), notNullValue());
-        assertThat(bsonDocument.getDocument("data").getArray("samples").size(), is(6));
+        assertThat(bsonDocument.getDocument("data").getArray("samples").size(), is(7));
 
         final List<Flow> flows = new SFlowConverter().convert(bsonDocument);
 
-        // There are six flows int the document, but one is skipped, because it's ethernet only
+        // There are six flows int the document, but two are skipped, because they don't contain IPv{4,6} information
         assertThat(flows.size(), is(5));
     }
 
@@ -84,7 +84,7 @@ public class SFlowConverterTest {
         assertThat(bsonDocument.getInt64("time"), notNullValue());
         assertThat(bsonDocument.getInt64("time").getValue(), is(1521618510235L));
         assertThat(bsonDocument.getDocument("data").getArray("samples"), notNullValue());
-        assertThat(bsonDocument.getDocument("data").getArray("samples").size(), is(6));
+        assertThat(bsonDocument.getDocument("data").getArray("samples").size(), is(7));
 
         final List<Flow> flows = new SFlowConverter().convert(bsonDocument);
 

--- a/features/telemetry/protocols/sflow/adapter/src/test/resources/sflow.json
+++ b/features/telemetry/protocols/sflow/adapter/src/test/resources/sflow.json
@@ -361,6 +361,44 @@
             }
           }
         }
+      },
+      {
+        "format": "0:1",
+        "data": {
+          "sequence_number": {
+            "$numberLong": "28"
+          },
+          "source_id": {
+            "$numberLong": "33555432"
+          },
+          "sampling_rate": {
+            "$numberLong": "64"
+          },
+          "sample_pool": {
+            "$numberLong": "1792"
+          },
+          "drops": {
+            "$numberLong": "0"
+          },
+          "input": {
+            "$numberLong": "4"
+          },
+          "output": {
+            "$numberLong": "17"
+          },
+          "flows": {
+            "0:1": {
+              "protocol": 1,
+              "frame_length": {
+                "$numberLong": "203"
+              },
+              "stripped": {
+                "$numberLong": "4"
+              },
+              "ethernet": {}
+            }
+          }
+        }
       }
     ]
   }


### PR DESCRIPTION
Depending on the transported protocols, sampled headers may no contain
IP information. These samples are ignored.

JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-12185

