### PR TITLE
NMS-12190: Enable flow UDP listener by default on Minion and OpenNMS.

### DIFF
--- a/features/container/minion/pom.xml
+++ b/features/container/minion/pom.xml
@@ -85,7 +85,7 @@
         <dependency>
             <groupId>org.opennms.container</groupId>
             <artifactId>org.opennms.container.shared</artifactId>
-	    <version>${project.version}</version>
+            <version>${project.version}</version>
             <type>tar.gz</type>
         </dependency>
     </dependencies>

--- a/features/container/minion/src/main/filtered-resources/etc/org.opennms.features.telemetry.listeners.flows.cfg
+++ b/features/container/minion/src/main/filtered-resources/etc/org.opennms.features.telemetry.listeners.flows.cfg
@@ -1,0 +1,12 @@
+name = Flows
+class-name = org.opennms.netmgt.telemetry.listeners.UdpListener
+parameters.port = 9999
+# Parser names should match queue names set in telemetryd configuration
+parser.0.name = Netflow-5
+parser.0.class-name = org.opennms.netmgt.telemetry.protocols.netflow.parser.Netflow5UdpParser 
+parser.1.name = Netflow-9
+parser.1.class-name = org.opennms.netmgt.telemetry.protocols.netflow.parser.Netflow9UdpParser
+parser.2.name = IPFIX
+parser.2.class-name = org.opennms.netmgt.telemetry.protocols.netflow.parser.IpfixUdpParser
+parser.3.name = SFlow
+parser.3.class-name = org.opennms.netmgt.telemetry.protocols.sflow.parser.SFlowUdpParser

--- a/opennms-base-assembly/src/main/filtered/etc/telemetryd-configuration.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/telemetryd-configuration.xml
@@ -32,7 +32,7 @@
     </listener>
 
     <queue name="Netflow-5">
-        <adapter name="Netflow-5-Adapter" class-name="org.opennms.netmgt.telemetry.protocols.netflow.adapter.netflow5.Netflow5Adapter" enabled="false">
+        <adapter name="Netflow-5-Adapter" class-name="org.opennms.netmgt.telemetry.protocols.netflow.adapter.netflow5.Netflow5Adapter" enabled="true">
         </adapter>
     </queue>
 
@@ -44,7 +44,7 @@
     </listener>
 
     <queue name="Netflow-9">
-        <adapter name="Netflow-9-Adapter" class-name="org.opennms.netmgt.telemetry.protocols.netflow.adapter.netflow9.Netflow9Adapter" enabled="false">
+        <adapter name="Netflow-9-Adapter" class-name="org.opennms.netmgt.telemetry.protocols.netflow.adapter.netflow9.Netflow9Adapter" enabled="true">
         </adapter>
     </queue>
 
@@ -62,7 +62,7 @@
     </listener>
 
     <queue name="IPFIX">
-        <adapter name="IPFIX-Adapter" class-name="org.opennms.netmgt.telemetry.protocols.netflow.adapter.ipfix.IpfixAdapter" enabled="false">
+        <adapter name="IPFIX-Adapter" class-name="org.opennms.netmgt.telemetry.protocols.netflow.adapter.ipfix.IpfixAdapter" enabled="true">
         </adapter>
     </queue>
 
@@ -74,10 +74,10 @@
     </listener>
 
     <queue name="SFlow">
-        <adapter name="SFlow-Adapter" class-name="org.opennms.netmgt.telemetry.protocols.sflow.adapter.SFlowAdapter" enabled="false">
+        <adapter name="SFlow-Adapter" class-name="org.opennms.netmgt.telemetry.protocols.sflow.adapter.SFlowAdapter" enabled="true">
         </adapter>
 
-        <adapter name="SFlow-Telemetry" class-name="org.opennms.netmgt.telemetry.protocols.sflow.adapter.SFlowTelemetryAdapter" enabled="false">
+        <adapter name="SFlow-Telemetry" class-name="org.opennms.netmgt.telemetry.protocols.sflow.adapter.SFlowTelemetryAdapter" enabled="true">
             <parameter key="script" value="${install.dir}/etc/telemetryd-adapters/sflow-host.groovy"/>
 
             <package name="SFlow-Default">
@@ -93,7 +93,7 @@
     </queue>
 
     <!-- Multi-port listener for Netflow v5, Netflow v9, IPFIX and SFlow -->
-    <listener name="Multi-UDP-9999" class-name="org.opennms.netmgt.telemetry.listeners.UdpListener" enabled="false">
+    <listener name="Multi-UDP-9999" class-name="org.opennms.netmgt.telemetry.listeners.UdpListener" enabled="true">
         <parameter key="port" value="9999"/>
 
         <parser name="Netflow-5-Parser" class-name="org.opennms.netmgt.telemetry.protocols.netflow.parser.Netflow5UdpParser" queue="Netflow-5" />


### PR DESCRIPTION
JIRA: https://issues.opennms.org/browse/NMS-12190

Here we update Minion and OpenNMS to listen on UDP port 9999 for all supported flow protocols by default.