### PR TITLE
NMS-12104: Ensure order in flow queries

### DIFF
--- a/features/flows/api/src/main/java/org/opennms/netmgt/flows/api/TrafficSummary.java
+++ b/features/flows/api/src/main/java/org/opennms/netmgt/flows/api/TrafficSummary.java
@@ -30,17 +30,21 @@ package org.opennms.netmgt.flows.api;
 
 import java.util.Objects;
 
+import com.google.common.base.MoreObjects;
+
 /**
  * Total bytes in/out related to some entity.
  */
 public class TrafficSummary<T> {
 
     private final T entity;
-    private long bytesIn;
-    private long bytesOut;
+    private final long bytesIn;
+    private final long bytesOut;
 
-    public TrafficSummary(T entity) {
-        this.entity = Objects.requireNonNull(entity);
+    public TrafficSummary(final TrafficSummary.Builder<T> builder) {
+        this.entity = Objects.requireNonNull(builder.entity);
+        this.bytesIn = builder.bytesIn;
+        this.bytesOut = builder.bytesOut;
     }
 
     public T getEntity() {
@@ -51,22 +55,86 @@ public class TrafficSummary<T> {
         return bytesIn;
     }
 
-    public void setBytesIn(long bytesIn) {
-        this.bytesIn = bytesIn;
-    }
-
     public long getBytesOut() {
         return bytesOut;
     }
 
-    public void setBytesOut(long bytesOut) {
-        this.bytesOut = bytesOut;
+    public static class Builder<T> {
+        private T entity;
+        private long bytesIn;
+        private long bytesOut;
+
+        private Builder() {
+        }
+
+        public Builder<T> withEntity(final T entity) {
+            this.entity = Objects.requireNonNull(entity);
+            return this;
+        }
+
+        public Builder<T> withBytesIn(final long bytesIn) {
+            this.bytesIn = bytesIn;
+            return this;
+        }
+
+        public Builder<T> withBytesOut(final long bytesOut) {
+            this.bytesOut = bytesOut;
+            return this;
+        }
+
+        public Builder<T> withBytes(final long bytesIn, final long bytesOut) {
+            return this
+                    .withBytesIn(bytesIn)
+                    .withBytesOut(bytesOut);
+        }
+
+        public Builder<T> withBytesFrom(final TrafficSummary<?> source) {
+            Objects.requireNonNull(source);
+            this.bytesIn = source.getBytesIn();
+            this.bytesOut = source.getBytesOut();
+            return this;
+        }
+
+        public TrafficSummary<T> build() {
+            return new TrafficSummary<>(this);
+        }
     }
-    
-    public TrafficSummary<T> withBytesFrom(final TrafficSummary<?> source) {
-        Objects.requireNonNull(source);
-        bytesIn = source.getBytesIn();
-        bytesOut = source.getBytesOut();
-        return this;
+
+    public static <T> TrafficSummary.Builder<T> builder() {
+        return new TrafficSummary.Builder<>();
+    }
+
+    public static <T> TrafficSummary.Builder<T> from(final T entity) {
+        return new TrafficSummary.Builder<T>()
+                .withEntity(entity);
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof TrafficSummary)) {
+            return false;
+        }
+
+        final TrafficSummary<?> that = (TrafficSummary<?>) o;
+        return this.bytesIn == that.bytesIn &&
+               this.bytesOut == that.bytesOut &&
+               Objects.equals(this.entity, that.entity);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(this.entity, this.bytesIn, this.bytesOut);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                .add("entity", this.entity)
+                .add("bytesIn", this.bytesIn)
+                .add("bytesOut", this.bytesOut)
+                .toString();
     }
 }

--- a/features/flows/elastic/src/test/java/org/opennms/netmgt/flows/elastic/FlowQueryIT.java
+++ b/features/flows/elastic/src/test/java/org/opennms/netmgt/flows/elastic/FlowQueryIT.java
@@ -59,7 +59,6 @@ import org.opennms.core.test.MockLogAppender;
 import org.opennms.core.test.elastic.ElasticSearchRule;
 import org.opennms.core.test.elastic.ElasticSearchServerConfig;
 import org.opennms.elasticsearch.plugin.DriftPlugin;
-import org.opennms.netmgt.dao.api.SessionUtils;
 import org.opennms.netmgt.dao.mock.MockNodeDao;
 import org.opennms.netmgt.dao.mock.MockSessionUtils;
 import org.opennms.netmgt.dao.mock.MockSnmpInterfaceDao;
@@ -114,13 +113,13 @@ public class FlowQueryIT {
 
         // The repository should be empty
         assertThat(flowRepository.getFlowCount(Collections.singletonList(new TimeRangeFilter(0, 0))).get(), equalTo(0L));
-
-        // Load the default set of flows
-        loadDefaultFlows();
     }
 
     @Test
-    public void canGetApplications() throws ExecutionException, InterruptedException {
+    public void canGetApplications() throws Exception {
+        // Load the default set of flows
+        loadDefaultFlows();
+
         // Get only the first application
         List<String> applications = flowRepository.getApplications("", 1, getFilters()).get();
         assertThat(applications, equalTo(Collections.singletonList("http")));
@@ -141,7 +140,10 @@ public class FlowQueryIT {
     }
 
     @Test
-    public void canGetTopNApplicationSummaries() throws ExecutionException, InterruptedException {
+    public void canGetTopNApplicationSummaries() throws Exception {
+        // Load the default set of flows
+        loadDefaultFlows();
+
         // Retrieve the Top N applications over the entire time range
         List<TrafficSummary<String>> appTrafficSummary = flowRepository.getTopNApplicationSummaries(10, true, getFilters()).get();
 
@@ -198,7 +200,10 @@ public class FlowQueryIT {
     }
 
     @Test
-    public void canGetAppSummaries() throws ExecutionException, InterruptedException {
+    public void canGetAppSummaries() throws Exception {
+        // Load the default set of flows
+        loadDefaultFlows();
+
         List<TrafficSummary<String>> appTrafficSummary =
                 flowRepository.getApplicationSummaries(Collections.singleton("https"), false, getFilters()).get();
         assertThat(appTrafficSummary, hasSize(1));
@@ -219,7 +224,10 @@ public class FlowQueryIT {
     }
 
     @Test
-    public void canGetTopNAppsSeries() throws ExecutionException, InterruptedException {
+    public void canGetTopNAppsSeries() throws Exception {
+        // Load the default set of flows
+        loadDefaultFlows();
+
         // Top 10
         Table<Directional<String>, Long, Double> appTraffic = flowRepository.getTopNApplicationSeries(10, 10, false,
                 getFilters()).get();
@@ -239,7 +247,10 @@ public class FlowQueryIT {
     }
 
     @Test
-    public void canGetAppSeries() throws ExecutionException, InterruptedException {
+    public void canGetAppSeries() throws Exception {
+        // Load the default set of flows
+        loadDefaultFlows();
+
         // Get just https
         Table<Directional<String>, Long, Double> appTraffic =
                 flowRepository.getApplicationSeries(Collections.singleton("https"), 10,
@@ -264,7 +275,10 @@ public class FlowQueryIT {
     }
 
     @Test
-    public void canGetTopNApplicationsWithPartialSums() throws ExecutionException, InterruptedException {
+    public void canGetTopNApplicationsWithPartialSums() throws Exception {
+        // Load the default set of flows
+        loadDefaultFlows();
+
         // Retrieve the Top N applications over a subset of the range
         final List<TrafficSummary<String>> appTrafficSummary = flowRepository.getTopNApplicationSummaries(1, false,
                 Lists.newArrayList(new TimeRangeFilter(10,  20))).get();
@@ -278,7 +292,10 @@ public class FlowQueryIT {
     }
 
     @Test
-    public void canGetHosts() throws ExecutionException, InterruptedException {
+    public void canGetHosts() throws Exception {
+        // Load the default set of flows
+        loadDefaultFlows();
+
         // Get only the first host
         List<String> hosts = flowRepository.getHosts(".*", 1, getFilters()).get();
         assertThat(hosts, equalTo(Collections.singletonList("10.1.1.11")));
@@ -299,7 +316,10 @@ public class FlowQueryIT {
     }
 
     @Test
-    public void canGetTopNHostSummaries() throws ExecutionException, InterruptedException {
+    public void canGetTopNHostSummaries() throws Exception {
+        // Load the default set of flows
+        loadDefaultFlows();
+
         // Retrieve the Top N applications over the entire time range
         List<TrafficSummary<Host>> hostTrafficSummary = flowRepository.getTopNHostSummaries(10, false, getFilters()).get();
 
@@ -344,7 +364,10 @@ public class FlowQueryIT {
     }
 
     @Test
-    public void canGetHostSummaries() throws ExecutionException, InterruptedException {
+    public void canGetHostSummaries() throws Exception {
+        // Load the default set of flows
+        loadDefaultFlows();
+
         // Get one specific host and no others
         List<TrafficSummary<Host>> hostTrafficSummary =
                 flowRepository.getHostSummaries(Collections.singleton("10.1.1.12"), false, getFilters()).get();
@@ -381,7 +404,10 @@ public class FlowQueryIT {
     }
 
     @Test
-    public void canGetTopNHostSeries() throws ExecutionException, InterruptedException {
+    public void canGetTopNHostSeries() throws Exception {
+        // Load the default set of flows
+        loadDefaultFlows();
+
         // Top 10
         Table<Directional<Host>, Long, Double> hostTraffic = flowRepository.getTopNHostSeries(10, 10, false,
                 getFilters()).get();
@@ -401,7 +427,10 @@ public class FlowQueryIT {
     }
 
     @Test
-    public void canGetHostSeries() throws ExecutionException, InterruptedException {
+    public void canGetHostSeries() throws Exception {
+        // Load the default set of flows
+        loadDefaultFlows();
+
         // Get just https
         Table<Directional<Host>, Long, Double> hostTraffic =
                 flowRepository.getHostSeries(Collections.singleton("10.1.1.12"), 10,
@@ -427,7 +456,10 @@ public class FlowQueryIT {
 
     @Ignore
     @Test
-    public void canGetConversations() throws ExecutionException, InterruptedException {
+    public void canGetConversations() throws Exception {
+        // Load the default set of flows
+        loadDefaultFlows();
+
         // Get all the conversations
         List<String> conversations =
                 flowRepository.getConversations(".*", ".*", ".*", ".*", ".*", 10, getFilters()).get();
@@ -452,7 +484,10 @@ public class FlowQueryIT {
     }
 
     @Test
-    public void canGetTopNConversationSummaries() throws ExecutionException, InterruptedException {
+    public void canGetTopNConversationSummaries() throws Exception {
+        // Load the default set of flows
+        loadDefaultFlows();
+
         // Retrieve the Top N conversation over the entire time range
         List<TrafficSummary<Conversation>> convoTrafficSummary = flowRepository.getTopNConversationSummaries(2, false, getFilters()).get();
         assertThat(convoTrafficSummary, hasSize(2));
@@ -494,7 +529,10 @@ public class FlowQueryIT {
     }
 
     @Test
-    public void canGetConversationSummaries() throws ExecutionException, InterruptedException {
+    public void canGetConversationSummaries() throws Exception {
+        // Load the default set of flows
+        loadDefaultFlows();
+
         // Get a specific conversation
         List<TrafficSummary<Conversation>> convoTrafficSummary =
                 flowRepository.getConversationSummaries(ImmutableSet.of("[\"test\",6,\"10.1.1.11\",\"192.168.1.100\",\"http\"]"),
@@ -529,7 +567,10 @@ public class FlowQueryIT {
     }
 
     @Test
-    public void canGetConversationSeries() throws ExecutionException, InterruptedException {
+    public void canGetConversationSeries() throws Exception {
+        // Load the default set of flows
+        loadDefaultFlows();
+
         // Get series for specific host
         Table<Directional<Conversation>, Long, Double> convoTraffic = flowRepository.getConversationSeries(ImmutableSet.of("[\"test\",6,\"10.1.1.12\",\"192.168.1.100\",\"https\"]"), 10, false, getFilters()).get();
         assertThat(convoTraffic.rowKeySet(), hasSize(2));
@@ -547,7 +588,10 @@ public class FlowQueryIT {
     }
 
     @Test
-    public void canRetrieveTopNConversationsSeries() throws ExecutionException, InterruptedException {
+    public void canRetrieveTopNConversationsSeries() throws Exception {
+        // Load the default set of flows
+        loadDefaultFlows();
+
         // Top 10
         Table<Directional<Conversation>, Long, Double> convoTraffic = flowRepository.getTopNConversationSeries(10, 10, false, getFilters()).get();
         assertThat(convoTraffic.rowKeySet(), hasSize(8));
@@ -555,6 +599,51 @@ public class FlowQueryIT {
         // Top 2 with others
         convoTraffic = flowRepository.getTopNConversationSeries(2, 10, true, getFilters()).get();
         assertThat(convoTraffic.rowKeySet(), hasSize(6));
+    }
+
+    @Test
+    public void hasCorrectOrdering() throws Exception {
+        this.loadFlows(new FlowBuilder()
+                .withExporter("SomeFs", "SomeFid", 99)
+                .withSnmpInterfaceId(98)
+                .withDirection(Direction.INGRESS)
+
+                // More documents - less data
+                .withFlow(new Date(0), new Date(10), "192.168.0.1", 1234, "192.168.1.1", 1234, 100)
+                .withFlow(new Date(0), new Date(10), "192.168.0.1", 1234, "192.168.1.1", 1234, 100)
+                .withFlow(new Date(0), new Date(10), "192.168.0.1", 1234, "192.168.1.1", 1234, 100)
+                .withFlow(new Date(0), new Date(10), "192.168.0.1", 1234, "192.168.1.1", 1234, 100)
+                .withFlow(new Date(0), new Date(10), "192.168.0.1", 1234, "192.168.1.1", 1234, 100)
+
+
+                .withFlow(new Date(0), new Date(10), "192.168.0.2", 1234, "192.168.1.2", 1234, 1000)
+                .withFlow(new Date(0), new Date(10), "192.168.0.2", 1234, "192.168.1.2", 1234, 1000)
+                .withFlow(new Date(0), new Date(10), "192.168.0.2", 1234, "192.168.1.2", 1234, 1000)
+
+                // Less documents - more data
+                .withFlow(new Date(0), new Date(10), "192.168.0.3", 1234, "192.168.1.3", 1234, 10000)
+
+                .build());
+
+        final List<TrafficSummary<Host>> summary = flowRepository.getTopNHostSummaries(10, false, getFilters()).get();
+        assertThat(summary, contains(
+                TrafficSummary.from(Host.from("192.168.0.3").build()).withBytes(10000, 0).build(),
+                TrafficSummary.from(Host.from("192.168.1.3").build()).withBytes(10000, 0).build(),
+                TrafficSummary.from(Host.from("192.168.0.2").build()).withBytes(3000, 0).build(),
+                TrafficSummary.from(Host.from("192.168.1.2").build()).withBytes(3000, 0).build(),
+                TrafficSummary.from(Host.from("192.168.0.1").build()).withBytes(500, 0).build(),
+                TrafficSummary.from(Host.from("192.168.1.1").build()).withBytes(500, 0).build()
+        ));
+
+        final Table<Directional<Host>, Long, Double> series = flowRepository.getTopNHostSeries(10, 10, false, getFilters()).get();
+        assertThat(series.rowKeySet(), contains(
+                new Directional<>(Host.from("192.168.0.3").build(), true),
+                new Directional<>(Host.from("192.168.1.3").build(), true),
+                new Directional<>(Host.from("192.168.0.2").build(), true),
+                new Directional<>(Host.from("192.168.1.2").build(), true),
+                new Directional<>(Host.from("192.168.0.1").build(), true),
+                new Directional<>(Host.from("192.168.1.1").build(), true)
+        ));
     }
 
     private <L> void verifyHttpsSeries(Table<Directional<L>, Long, Double> appTraffic, L label) {
@@ -656,6 +745,11 @@ public class FlowQueryIT {
                 .withDirection(Direction.EGRESS)
                 .withFlow(new Date(50), new Date(52), "10.1.1.13", 50001, "192.168.1.102", 50000, 100)
                 .build();
+
+        this.loadFlows(flows);
+    }
+
+    private void loadFlows(final List<FlowDocument> flows) throws FlowException {
         flowRepository.enrichAndPersistFlows(flows, new FlowSource("test", "127.0.0.1"));
 
         // Retrieve all the flows we just persisted


### PR DESCRIPTION
This adds a test which ensures the order of flow series and summaries is
correctly sorted.

In addition, this makes some clean-ups to the used datastructures which
makes it easier for testing.

JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-12104

