### PR TITLE
NMS-12311, NMS-12312: Fix Minion and Sentinel non-root environment

### DIFF
--- a/opennms-container/horizon/Dockerfile
+++ b/opennms-container/horizon/Dockerfile
@@ -32,7 +32,7 @@ RUN setcap cap_net_raw+ep ${JAVA_HOME}/bin/java && \
     echo ${JAVA_HOME}/lib/jli > /etc/ld.so.conf.d/java-latest.conf && \
     ldconfig
 
-# Set gid=0 and make group perms==owner perms
+# Create OpenNMS user with a specific group ID
 RUN groupadd -g 10001 opennms && \
     adduser -u 10001 -g 10001 -d /opt/opennms -s /usr/bin/bash opennms
 ##
@@ -132,6 +132,7 @@ LABEL maintainer="The OpenNMS Group" \
 
 WORKDIR /opt/opennms
 
+### Containers should NOT run as root as a good practice
 USER 10001
 
 ENTRYPOINT [ "/entrypoint.sh" ]

--- a/opennms-container/minion/Dockerfile
+++ b/opennms-container/minion/Dockerfile
@@ -26,6 +26,10 @@ RUN setcap cap_net_raw+ep ${JAVA_HOME}/bin/java && \
     echo ${JAVA_HOME}/lib/jli > /etc/ld.so.conf.d/java-latest.conf && \
     ldconfig
 
+# Create Minion user with a specific group ID
+RUN groupadd -g 10001 minion && \
+    adduser -u 10001 -g 10001 -d /opt/minion -s /usr/bin/bash minion
+
 ##
 # Install and setup OpenNMS Minion RPMS
 ##
@@ -75,14 +79,14 @@ LABEL maintainer="The OpenNMS Group" \
 
 WORKDIR /opt/minion
 
+### Containers should NOT run as root as a good practice
+USER 10001
+
 ENTRYPOINT [ "/entrypoint.sh" ]
 
 STOPSIGNAL SIGTERM
 
 CMD [ "-f" ]
-
-### Containers should NOT run as root as a good practice
-USER 10001
 
 ### Runtime information and not relevant at build time
 ENV MINION_ID="00000000-0000-0000-0000-deadbeef0001" \

--- a/opennms-container/minion/Dockerfile
+++ b/opennms-container/minion/Dockerfile
@@ -54,6 +54,7 @@ RUN if [[ "$(ls -1 /tmp/rpms/*.rpm 2>/dev/null | wc -l)" != 0 ]]; then yum -y lo
     yum clean all && \
     rm -rf /var/cache/yum && \
     sed -r -i '/RUNAS/s/.*/export RUNAS=${USER}/' /etc/sysconfig/minion && \
+    chown 10001:10001 -R /opt/minion && \
     chgrp -R 0 /opt/minion && \
     chmod -R g=u /opt/minion
 

--- a/opennms-container/minion/assets/entrypoint.sh
+++ b/opennms-container/minion/assets/entrypoint.sh
@@ -10,8 +10,7 @@
 # Cause false/positives
 # shellcheck disable=SC2086
 
-set -x
-
+umask 002
 MINION_HOME="/opt/minion"
 MINION_CONFIG="/opt/minion/etc/org.opennms.minion.controller.cfg"
 MINION_OVERLAY_ETC="/opt/minion-etc-overlay"

--- a/opennms-container/sentinel/Dockerfile
+++ b/opennms-container/sentinel/Dockerfile
@@ -51,6 +51,7 @@ RUN if [[ "$(ls -1 /tmp/rpms/*.rpm 2>/dev/null | wc -l)" != 0 ]]; then yum -y lo
     rm -rf /tmp/rpms && \
     yum clean all && \
     rm -rf /var/cache/yum && \
+    chown 10001:10001 -R /opt/sentinel && \
     chgrp -R 0 /opt/sentinel && \
     chmod -R g=u /opt/sentinel
 

--- a/opennms-container/sentinel/Dockerfile
+++ b/opennms-container/sentinel/Dockerfile
@@ -51,6 +51,7 @@ RUN if [[ "$(ls -1 /tmp/rpms/*.rpm 2>/dev/null | wc -l)" != 0 ]]; then yum -y lo
     rm -rf /tmp/rpms && \
     yum clean all && \
     rm -rf /var/cache/yum && \
+    mkdir -p mkdir /opt/sentinel/data/{log,tmp} && \
     chown 10001:10001 -R /opt/sentinel && \
     chgrp -R 0 /opt/sentinel && \
     chmod -R g=u /opt/sentinel

--- a/opennms-container/sentinel/Dockerfile
+++ b/opennms-container/sentinel/Dockerfile
@@ -26,6 +26,10 @@ RUN setcap cap_net_raw+ep ${JAVA_HOME}/bin/java && \
     echo ${JAVA_HOME}/lib/jli > /etc/ld.so.conf.d/java-latest.conf && \
     ldconfig
 
+# Create Sentinel user with a specific group ID
+RUN groupadd -g 10001 sentinel && \
+    adduser -u 10001 -g 10001 -d /opt/sentinel -s /usr/bin/bash sentinel
+
 ##
 # Install and setup OpenNMS Sentinel RPMS
 ##
@@ -46,13 +50,18 @@ RUN if [[ "$(ls -1 /tmp/rpms/*.rpm 2>/dev/null | wc -l)" != 0 ]]; then yum -y lo
     if [[ -n ${ADD_YUM_PACKAGES} ]]; then yum -y install ${ADD_YUM_PACKAGES}; fi && \
     rm -rf /tmp/rpms && \
     yum clean all && \
-    rm -rf /var/cache/yum
+    rm -rf /var/cache/yum && \
+    chgrp -R 0 /opt/sentinel && \
+    chmod -R g=u /opt/sentinel
 
 COPY ./assets/entrypoint.sh /
 
 VOLUME [ "/opt/sentinel/deploy", "/opt/sentinel/etc", "/opt/sentinel/data" ]
 
 WORKDIR /opt/sentinel
+
+### Containers should NOT run as root as a good practice
+USER 10001
 
 ENTRYPOINT [ "/entrypoint.sh" ]
 

--- a/opennms-container/sentinel/assets/entrypoint.sh
+++ b/opennms-container/sentinel/assets/entrypoint.sh
@@ -10,6 +10,7 @@
 # Cause false/positives
 # shellcheck disable=SC2086
 
+umask 002
 SENTINEL_OVERLAY_ETC="/opt/sentinel-etc-overlay"
 SENTINEL_OVERLAY="/opt/sentinel-overlay"
 


### PR DESCRIPTION
Create a user Minion and Sentinel with a bash environment and specific UIDs during Docker build. Chown the permissions for the users and set the UID instead of running as root in Sentinel.

### All Contributors

* [x] Have you read and followed our [Contribution Guidelines](https://github.com/OpenNMS/opennms/blob/develop/CONTRIBUTING.md)?
* [x] Have you [made an issue in the OpenNMS issue tracker](https://issues.opennms.org)?<br>If so, you should:
  1. update the title of this PR to be of the format: `${JIRA-ISSUE-NUMBER}: subject of pull request`
  2. update the JIRA link at the bottom of this comment to refer to the real issue number
  3. prefix your commit messages with the issue number, if possible
* [x] Have you made a comment in that issue which points back to this PR?
* [x] Have you updated the JIRA link at the bottom of this comment to link to your issue?
* [x] If this is a new or updated feature, is there documentation for the new behavior?
* [x] If this is new code, are there unit and/or integration tests?
* [x] If this PR targets a `foundation-*` branch, does it avoid changing files in `$OPENNMS_HOME/etc/`?

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-12311
* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-12312


