### PR TITLE
NMS-12263: pass java.locale.providers to minion and sentinel containers

### DIFF
--- a/opennms-container/minion/assets/entrypoint.sh
+++ b/opennms-container/minion/assets/entrypoint.sh
@@ -16,6 +16,8 @@ MINION_HOME="/opt/minion"
 MINION_CONFIG="/opt/minion/etc/org.opennms.minion.controller.cfg"
 MINION_OVERLAY_ETC="/opt/minion-etc-overlay"
 
+export KARAF_OPTS="-Djava.locale.providers=CLDR,COMPAT"
+
 # Error codes
 E_ILLEGAL_ARGS=126
 

--- a/opennms-container/sentinel/assets/entrypoint.sh
+++ b/opennms-container/sentinel/assets/entrypoint.sh
@@ -13,6 +13,8 @@
 SENTINEL_OVERLAY_ETC="/opt/sentinel-etc-overlay"
 SENTINEL_OVERLAY="/opt/sentinel-overlay"
 
+export KARAF_OPTS="-Djava.locale.providers=CLDR,COMPAT"
+
 # Error codes
 E_ILLEGAL_ARGS=126
 


### PR DESCRIPTION
This PR just makes sure the CLDR locale setting is passed even in the minion and sentinel containers (even though they are running JDK 11 by default and, in theory, should already be getting this.)

### All Contributors

* [x] Have you read and followed our [Contribution Guidelines](https://github.com/OpenNMS/opennms/blob/develop/CONTRIBUTING.md)?
* [x] Have you [made an issue in the OpenNMS issue tracker](https://issues.opennms.org)?<br>If so, you should:
  1. update the title of this PR to be of the format: `${JIRA-ISSUE-NUMBER}: subject of pull request`
  2. update the JIRA link at the bottom of this comment to refer to the real issue number
  3. prefix your commit messages with the issue number, if possible
* [x] Have you made a comment in that issue which points back to this PR?
* [x] Have you updated the JIRA link at the bottom of this comment to link to your issue?
* [ ] If this is a new or updated feature, is there documentation for the new behavior?
* [ ] If this is new code, are there unit and/or integration tests?
* [ ] If this PR targets a `foundation-*` branch, does it avoid changing files in `$OPENNMS_HOME/etc/`?

### Pull Request Process

One or more reviewers should be assigned to each PR.

If you know that a particular person is subject matter expert in the area your PR affects, feel free to assign one or more reviewers when you create this PR, otherwise reviewers will be assigned for you.

Once the reviewer(s) accept the PR and the branch passes continuous integration in Bamboo, the PR is eligible for merge.

At that time, if you have commit access (are an OpenNMS Group employee or a member of the Order of the Green Polo) you are welcome to merge the PR.
Otherwise, a reviewer can merge it for you.

Thanks for taking time to contribute!

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-12263
* Bamboo (Continuous Integration): https://bamboo.opennms.org/

