### PR TITLE
NMS-12337: Allow downloading of reports generated by Reportd in new UI

### DIFF
--- a/core/web-assets/src/main/assets/js/apps/onms-reports/persisted.html
+++ b/core/web-assets/src/main/assets/js/apps/onms-reports/persisted.html
@@ -36,8 +36,7 @@
                     <button class="btn btn-sm btn-danger" ng-click="delete(report)"><i class="fa fa-trash"></i></button>
                 </td>
                 <td>
-                    <a href="rest/reports/download?locatorId={{report.id}}&amp;format=PDF" class="mr-4"><i class="fa fa-file-pdf-o"></i> PDF</a>
-                    <a href="rest/reports/download?locatorId={{report.id}}&amp;format=CSV"><i class="fa fa-file-text-o"></i> CSV</a>
+                    <a ng-repeat="format in report.formats" href="rest/reports/download?locatorId={{report.id}}&amp;format={{format}}" class="mr-4"><i ng-class="{'fa-file-pdf-o': format === 'PDF', 'fa-file-text-o': format === 'CSV'}" class="fa"></i> {{format}}</a>
                 </td>
                 <td>{{report.title}}</td>
                 <td>{{report.reportId}}</td>

--- a/features/reporting/rest/src/main/java/org/opennms/features/reporting/rest/internal/ReportRestServiceImpl.java
+++ b/features/reporting/rest/src/main/java/org/opennms/features/reporting/rest/internal/ReportRestServiceImpl.java
@@ -241,8 +241,11 @@ public class ReportRestServiceImpl implements ReportRestService {
                 // Special Reportd behaviour:
                 // Reportd persists the reports as PDF/CSV and therefore formats is empty.
                 // In that case the format is the format of the file
+
                 final String format = eachEntry.getLocation().substring(eachEntry.getLocation().lastIndexOf(".") + 1);
-                jsonObject.put("formats", new JSONArray("[" + format.toUpperCase() +"]"));
+                final JSONArray formatsArray = new JSONArray();
+                formatsArray.put(format.toUpperCase());
+                jsonObject.put("formats", formatsArray);
             }
             jsonArray.put(jsonObject);
         }

--- a/features/reporting/rest/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/features/reporting/rest/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -14,6 +14,7 @@
     <reference id="reportWrapperService"    interface="org.opennms.reporting.core.svclayer.ReportWrapperService" availability="mandatory" />
     <reference id="reportStoreService"      interface="org.opennms.reporting.core.svclayer.ReportStoreService" availability="mandatory" />
     <reference id="reportSchedulerService"  interface="org.opennms.web.svclayer.SchedulerService" availability="mandatory" />
+    <reference id="reportCatalogDao"        interface="org.opennms.netmgt.dao.api.ReportCatalogDao" availability="mandatory" />
 
     <bean id="reportRestService" class="org.opennms.features.reporting.rest.internal.ReportRestServiceImpl">
         <argument ref="databaseReportService" />
@@ -22,6 +23,7 @@
         <argument ref="categoryConfigDao" />
         <argument ref="reportStoreService" />
         <argument ref="reportSchedulerService" />
+        <argument ref="reportCatalogDao" />
     </bean>
     <service interface="org.opennms.features.reporting.rest.ReportRestService" ref="reportRestService" >
         <service-properties>


### PR DESCRIPTION
Reports generated by Reportd cannot be downloaded from the new Report UI introduced in Horizon 25.

If you want to verify this, simply add a report to your reportd-configuration (see jira issue for an example), let it generate some reports and try to download it via the Database Reports UI.

JIRA: https://issues.opennms.org/browse/NMS-12337