### PR TITLE
NMS-12153: Provide webhook delivery option for database reports

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -296,6 +296,7 @@ workflows:
                 - /^features.*/
                 - /.*smoke.*/
                 - mvr/health-rest-service
+                - jira/NMS-12153
       - smoke-test-minimal:
           requires:
             - horizon-package-build
@@ -311,6 +312,7 @@ workflows:
                 - /^features.*/
                 - /.*smoke.*/
                 - mvr/health-rest-service
+                - jira/NMS-12153
       - horizon-publish-oci:
           requires:
             - horizon-package-build

--- a/core/web-assets/src/main/assets/js/apps/onms-reports/report-details.html
+++ b/core/web-assets/src/main/assets/js/apps/onms-reports/report-details.html
@@ -268,7 +268,7 @@
                 <div ng-show="report.errors.format" class="invalid-feedback">{{report.errors.format}}</div>
             </div>
             <div class="form-group ml-4">
-                <input type="checkbox" id="persistToggle" ng-model="report.deliveryOptions.persist" class="form-check-input" ng-class="{ 'is-invalid' : report.errors.sendMail_persist }"/>
+                <input type="checkbox" id="persistToggle" ng-model="report.deliveryOptions.persist" class="form-check-input" ng-class="{ 'is-invalid' : report.errors.sendMail_persist_webhook }"/>
                 <label class="form-check-label"
                        data-toggle="tooltip"
                        data-placement="right"
@@ -278,13 +278,18 @@
                 </label>
             </div>
             <div class="form-group ml-4">
-                <input type="checkbox" id="sendMailToggle" ng-model="report.deliveryOptions.sendMail" class="form-check-input" ng-class="{ 'is-invalid' : report.errors.sendMail_persist }" />
+                <input type="checkbox" id="sendMailToggle" ng-model="report.deliveryOptions.sendMail" class="form-check-input" ng-class="{ 'is-invalid' : report.errors.sendMail_persist_webhook }" />
                 <label class="form-check-label" for="sendMailToggle" data-toggle="tooltip" data-placement="right" title="Indicates whether the generated report is send via email to the defined recipient.">
                     Email report
                 </label>
-                <div ng-show="report.errors.sendMail_persist" class="invalid-feedback">Please select at least one delivery method</div>
             </div>
-
+            <div class="form-group ml-4">
+                <input type="checkbox" id="webhookToggle" ng-model="report.deliveryOptions.webhook" class="form-check-input" ng-class="{ 'is-invalid' : report.errors.sendMail_persist_webhook }" />
+                <label class="form-check-label" for="webhookToggle" data-toggle="tooltip" data-placement="right" title="Indicates wheter the generated report is pushed to an URL">
+                    Webhook
+                </label>
+                <div ng-show="report.errors.sendMail_persist_webhook" class="invalid-feedback">Please select at least one delivery method</div>
+            </div>
             <div class="form-group" ng-if="report.deliveryOptions.sendMail">
                 <label for="mailRecipient">Recipient</label>
                 <button class="btn btn-link text-secondary px-0"
@@ -306,6 +311,28 @@
                 />
                 <div ng-show="reportForm.mailRecipient.$invalid" class="invalid-feedback">Please provide a valid email.</div>
                 <div ng-show="report.errors.mailTo" class="invalid-feedback">{{report.errors.mailTo}}</div>
+            </div>
+            <div class="form-group" ng-if="report.deliveryOptions.webhook">
+                <label for="mailRecipient">Webhook URL</label>
+                <button class="btn btn-link text-secondary px-0"
+                        popover-trigger="'mouseenter'"
+                        uib-popover="TODO MVR.... blablab POST blabla"><i class="fa fa-info-circle"/>
+                </button>
+                <!-- TODO MVR url validation -->
+                <input id="webhookUrl"
+                       name="webhookUrl"
+                       ng-model="report.deliveryOptions.webhookUrl"
+                       placeholder="https://example.org/:reportId/?:instanceId"
+                       type="text"
+                       class="form-control"
+                       ng-class="{ 'is-invalid' : reportForm.webhookUrl.$invalid || report.errors.webhookUrl }"
+                       data-toggle="tooltip"
+                       data-placement="right"
+                       title="TODO MVR"
+                       required
+                />
+                <div ng-show="reportForm.webhookUrl.$invalid" class="invalid-feedback">Please provide a valid webhook url.</div>
+                <div ng-show="report.errors.webhookUrl" class="invalid-feedback">{{report.errors.webhookUrl}}</div>
             </div>
         </div>
         <hr class="mb-4"/>

--- a/core/web-assets/src/main/assets/js/apps/onms-reports/report-details.html
+++ b/core/web-assets/src/main/assets/js/apps/onms-reports/report-details.html
@@ -315,10 +315,20 @@
             <div class="form-group" ng-if="report.deliveryOptions.webhook">
                 <label for="mailRecipient">Webhook URL</label>
                 <button class="btn btn-link text-secondary px-0"
-                        popover-trigger="'mouseenter'"
-                        uib-popover="TODO MVR.... blablab POST blabla"><i class="fa fa-info-circle"/>
+                        popover-trigger="'outsideClick'"
+                        uib-popover-html="'
+                        <div>
+                            Posts the generated report to this http endpoint.
+                            If url parameters are required, substitution of the URL supports the following parameters: <br/> <br/>
+                            - <strong>format</strong> Format of the report <br/>
+                            - <strong>instanceId</strong> Unique name of the report <br/>
+                            - <strong>parameter_&lt;parameterName&gt;</strong> Any report parameter <br/> <br/>
+
+                            <strong>Example</strong> <br/>
+                            <span>http://localhost:8080/files?instanceId=:instanceId&format=:format&option=:parameter_option</pre>
+                        </div>'">
+                    <i class="fa fa-info-circle"></i>
                 </button>
-                <!-- TODO MVR url validation -->
                 <input id="webhookUrl"
                        name="webhookUrl"
                        ng-model="report.deliveryOptions.webhookUrl"
@@ -328,7 +338,7 @@
                        ng-class="{ 'is-invalid' : reportForm.webhookUrl.$invalid || report.errors.webhookUrl }"
                        data-toggle="tooltip"
                        data-placement="right"
-                       title="TODO MVR"
+                       title="The report is sent to this URL with an http post request after generated"
                        required
                 />
                 <div ng-show="reportForm.webhookUrl.$invalid" class="invalid-feedback">Please provide a valid webhook url.</div>

--- a/core/web-assets/src/main/assets/js/apps/onms-reports/schedules.html
+++ b/core/web-assets/src/main/assets/js/apps/onms-reports/schedules.html
@@ -26,7 +26,7 @@
                 <th ng-if="userInfo.isReportDesigner() || userInfo.isAdmin()">Action(s)</th>
                 <th>Template</th>
                 <th>Format</th>
-                <th colspan="2">Delivery Options</th>
+                <th colspan="3">Delivery Options</th>
                 <th>Cron Expression</th>
                 <th>Trigger Name</th>
                 <th>Next fire time</th>
@@ -49,8 +49,13 @@
                     </span>
                 </td>
                 <td>
-                    <span ng-if="schedule.deliveryOptions.sendMail || false" title="Mail to">
-                        <i class="fa fa-share"></i> <small>{{schedule.deliveryOptions.mailTo}}</small>
+                    <span ng-if="schedule.deliveryOptions.sendMail || false" title="Mail to {{schedule.deliveryOptions.mailTo}}">
+                        <i class="fa fa-envelope-o"></i>
+                    </span>
+                </td>
+                <td>
+                    <span ng-if="schedule.deliveryOptions.webhook || false" title="POST to {{schedule.deliveryOptions.webhookUrl}}">
+                        <i class="fa fa-paper-plane-o"></i>
                     </span>
                 </td>
                 <td>

--- a/features/reporting/core/pom.xml
+++ b/features/reporting/core/pom.xml
@@ -107,5 +107,10 @@
       <artifactId>quartz-dependencies</artifactId>
       <type>pom</type>
     </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-library</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/features/reporting/core/src/main/java/org/opennms/reporting/core/DeliveryOptions.java
+++ b/features/reporting/core/src/main/java/org/opennms/reporting/core/DeliveryOptions.java
@@ -41,6 +41,8 @@ public class DeliveryOptions implements Serializable {
     protected Boolean m_sendMail;
     protected ReportFormat m_format;
     protected String m_instanceId;
+    protected Boolean m_webhook;
+    protected String m_webhookUrl;
 
     public String getMailTo() {
         return m_mailTo;
@@ -80,6 +82,26 @@ public class DeliveryOptions implements Serializable {
 
     public void setInstanceId(String instanceId) {
         m_instanceId = instanceId;
+    }
+
+    public String getWebhookUrl() {
+        return m_webhookUrl;
+    }
+
+    public boolean isWebhook() {
+        return m_webhook == null ? false : m_webhook;
+    }
+
+    public Boolean getWebhook() {
+        return m_webhook;
+    }
+
+    public void setWebhook(boolean webhook) {
+        m_webhook = webhook;
+    }
+
+    public void setWebhookUrl(String url) {
+        m_webhookUrl = url;
     }
 
 }

--- a/features/reporting/core/src/main/java/org/opennms/reporting/core/svclayer/support/DefaultReportWrapperService.java
+++ b/features/reporting/core/src/main/java/org/opennms/reporting/core/svclayer/support/DefaultReportWrapperService.java
@@ -31,14 +31,25 @@ package org.opennms.reporting.core.svclayer.support;
 import java.io.BufferedOutputStream;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.io.OutputStream;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.nio.file.Paths;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.Callable;
 
 import org.apache.commons.io.IOUtils;
+import org.apache.http.HttpEntity;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.mime.MultipartEntityBuilder;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
 import org.opennms.api.reporting.ReportException;
 import org.opennms.api.reporting.ReportFormat;
 import org.opennms.api.reporting.ReportMode;
@@ -157,24 +168,38 @@ public class DefaultReportWrapperService implements ReportWrapperService {
                 try {
                     out = new ByteArrayOutputStream();
                     bout = new BufferedOutputStream(out);
+
+                    final Map<String, Object> reportParameters = parameters.getReportParms(mode);
                     if (!deliveryOptions.isPersist()) {
                         try {
-                            getReportService(reportId).runAndRender(parameters.getReportParms(mode), reportId, deliveryOptions.getFormat(), bout);
+                            getReportService(reportId).runAndRender(reportParameters, reportId, deliveryOptions.getFormat(), bout);
+                            if (deliveryOptions.isSendMail() && deliveryOptions.getMailTo().length() != 0) {
+                                mailReport(deliveryOptions, out);
+                            }
+                            if (deliveryOptions.isWebhook()) {
+                                postReport(deliveryOptions, reportParameters, out, deliveryOptions.getInstanceId() + "." + deliveryOptions.getFormat().name().toLowerCase());
+                            }
                         } catch (final ReportException reportException) {
                             logError(reportId, reportException);
                         }
-                        mailReport(deliveryOptions, out);
                     } else {
-                        final String outputPath = getReportService(reportId).run(parameters.getReportParms(mode), reportId);
+                        final String outputPath = getReportService(reportId).run(reportParameters, reportId);
                         final ReportCatalogEntry catalogEntry = new ReportCatalogEntry();
                         catalogEntry.setReportId(reportId);
                         catalogEntry.setTitle(deliveryOptions.getInstanceId());
                         catalogEntry.setLocation(outputPath);
                         catalogEntry.setDate(new Date());
                         m_reportStoreService.save(catalogEntry);
-                        if (deliveryOptions.isSendMail() && deliveryOptions.getMailTo().length() != 0) {
+
+                        if (deliveryOptions.isSendMail() || deliveryOptions.isWebhook()) {
                             getReportService(reportId).render(reportId, outputPath, deliveryOptions.getFormat(), bout);
-                            mailReport(deliveryOptions, out);
+                            if (deliveryOptions.isSendMail() && deliveryOptions.getMailTo().length() != 0) {
+                                mailReport(deliveryOptions, out);
+                            }
+                            if (deliveryOptions.isWebhook()) {
+                                final String fileName = Paths.get(catalogEntry.getLocation()).getFileName().toString().replaceAll("jrprint", "");
+                                postReport(deliveryOptions, reportParameters, out, fileName + deliveryOptions.getFormat().name().toLowerCase());
+                            }
                         }
                     }
                 } catch (final Exception e) {
@@ -189,6 +214,51 @@ public class DefaultReportWrapperService implements ReportWrapperService {
 
     private static void logError(final String reportId, final Exception exception) {
         LOG.error("failed to run or render report: {}", reportId, exception);
+    }
+
+    private static void postReport(final DeliveryOptions deliveryOptions, final Map<String, Object> reportParameters, final ByteArrayOutputStream outputStream, final String fileName) {
+        final String url = deliveryOptions.getWebhookUrl();
+        final String substitutedUrl = substituteUrl(url, deliveryOptions, reportParameters);
+        try (final ByteArrayInputStream inputStream = new ByteArrayInputStream(outputStream.toByteArray());
+             final CloseableHttpClient client = HttpClients.createDefault();
+        ) {
+            LOG.debug("Posting generated report with name {} to endpoint {} (input was {})", fileName, substitutedUrl, url);
+            final HttpEntity entity = MultipartEntityBuilder.create()
+                    .addBinaryBody(deliveryOptions.getInstanceId(), inputStream, ContentType.DEFAULT_BINARY, fileName)
+                    .build();
+            final HttpPost httpPost = new HttpPost(substitutedUrl);
+            httpPost.setEntity(entity);
+            client.execute(httpPost);
+        } catch (IOException ex) {
+            LOG.error("Error while posting data to endpoint {}: {}", url, ex.getMessage(), ex);
+        }
+    }
+
+    protected static String substituteUrl(String url, DeliveryOptions deliveryOptions, Map<String, Object> reportParameters) {
+        final Map<String, Object> parameters = new HashMap<>();
+        reportParameters.entrySet().forEach(e -> parameters.put("parameter_" + e.getKey(), e.getValue()));
+        parameters.put("instanceId", deliveryOptions.getInstanceId());
+        parameters.put("format", deliveryOptions.getFormat().name());
+
+        final String newUrl = substituteUrl(url, parameters);
+        return newUrl;
+    }
+
+    protected static String substituteUrl(String url, Map<String, Object> parameters) {
+        if (url.contains(":")) {
+            String newUrl = url;
+            for (Entry<String, Object> entry : parameters.entrySet()) {
+                if (entry.getValue() != null) {
+                    try {
+                        newUrl = newUrl.replaceAll(":" + entry.getKey(), URLEncoder.encode(entry.getValue().toString(), "UTF-8"));
+                    } catch (UnsupportedEncodingException e) {
+                        LOG.error("Could not find encoder: {}", e.getMessage(), e);
+                    }
+                }
+            }
+            return newUrl;
+        }
+        return url;
     }
 
     private static void mailReport(final DeliveryOptions deliveryOptions, final ByteArrayOutputStream outputStream) {

--- a/features/reporting/core/src/main/java/org/opennms/reporting/core/svclayer/support/DefaultReportWrapperService.java
+++ b/features/reporting/core/src/main/java/org/opennms/reporting/core/svclayer/support/DefaultReportWrapperService.java
@@ -224,7 +224,7 @@ public class DefaultReportWrapperService implements ReportWrapperService {
         ) {
             LOG.debug("Posting generated report with name {} to endpoint {} (input was {})", fileName, substitutedUrl, url);
             final HttpEntity entity = MultipartEntityBuilder.create()
-                    .addBinaryBody(deliveryOptions.getInstanceId(), inputStream, ContentType.DEFAULT_BINARY, fileName)
+                    .addBinaryBody("file", inputStream, ContentType.DEFAULT_BINARY, fileName)
                     .build();
             final HttpPost httpPost = new HttpPost(substitutedUrl);
             httpPost.setEntity(entity);

--- a/features/reporting/core/src/main/java/org/opennms/reporting/core/svclayer/support/DefaultReportWrapperService.java
+++ b/features/reporting/core/src/main/java/org/opennms/reporting/core/svclayer/support/DefaultReportWrapperService.java
@@ -235,8 +235,8 @@ public class DefaultReportWrapperService implements ReportWrapperService {
             try (CloseableHttpResponse response = client.execute(httpPost)) {
                 LOG.debug("Request performed. Received response: {}", response);
                 final int statusCode = response.getStatusLine().getStatusCode();
-                if (statusCode < 200 || statusCode >= 300) {
-                    throw new IOException("Expected status code of >= 200 and <= 300 but received: " + statusCode + ". Reason: " + response.getStatusLine().toString());
+                if (statusCode < 200 || statusCode > 299) {
+                    throw new IOException("Expected status code of >= 200 and <= 299 but received: " + statusCode + ". Reason: " + response.getStatusLine().getReasonPhrase());
                 }
             }
         } catch (IOException ex) {

--- a/features/reporting/core/src/test/java/org/opennms/reporting/core/svclayer/support/DefaultReportWrapperServiceTest.java
+++ b/features/reporting/core/src/test/java/org/opennms/reporting/core/svclayer/support/DefaultReportWrapperServiceTest.java
@@ -1,0 +1,76 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019-2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.reporting.core.svclayer.support;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.opennms.reporting.core.svclayer.support.DefaultReportWrapperService.substituteUrl;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.hamcrest.Matchers;
+import org.junit.Test;
+import org.opennms.api.reporting.ReportFormat;
+import org.opennms.reporting.core.DeliveryOptions;
+
+import com.google.common.collect.Maps;
+
+public class DefaultReportWrapperServiceTest {
+
+    @Test
+    public void verifySubstituteUrl() {
+        assertThat(substituteUrl("http://localhost:8000", Maps.newHashMap()), is("http://localhost:8000"));
+
+        final DeliveryOptions deliveryOptions = new DeliveryOptions();
+        deliveryOptions.setFormat(ReportFormat.CSV);
+        deliveryOptions.setInstanceId("opennms-report-1");
+
+        final String inputUrl = "http://localhost:8000/:instanceId/:format";
+        assertThat(substituteUrl(inputUrl, deliveryOptions, Maps.newHashMap()), is("http://localhost:8000/opennms-report-1/CSV"));
+
+        deliveryOptions.setInstanceId("opennms report 1");
+        assertThat(substituteUrl(inputUrl, deliveryOptions, Maps.newHashMap()), is("http://localhost:8000/opennms+report+1/CSV"));
+    }
+
+    @Test
+    public void verifySubstituteUrlWithParamters() {
+        final String inputUrl = "http://localhost:8000/endpoint/:instanceId/:format?author=:parameter_author&option=:parameter_option&format=:format";
+        final DeliveryOptions deliveryOptions = new DeliveryOptions();
+        deliveryOptions.setFormat(ReportFormat.PDF);
+        deliveryOptions.setInstanceId("report");
+
+        final Map<String, Object> parameters = new HashMap<>();
+        parameters.put("author", "ulf");
+        parameters.put("option", true);
+
+        assertThat(substituteUrl(inputUrl, deliveryOptions, parameters), Matchers.is("http://localhost:8000/endpoint/report/PDF?author=ulf&option=true&format=PDF"));
+    }
+
+}

--- a/features/reporting/rest/src/main/java/org/opennms/features/reporting/rest/internal/ReportRestServiceImpl.java
+++ b/features/reporting/rest/src/main/java/org/opennms/features/reporting/rest/internal/ReportRestServiceImpl.java
@@ -479,7 +479,9 @@ public class ReportRestServiceImpl implements ReportRestService {
         if (options.isSendMail() && jsonOptions.has("mailTo")) {
             options.setMailTo(jsonOptions.getString("mailTo"));
         }
-        options.setWebhook(jsonOptions.getBoolean("webhook"));
+        if (jsonOptions.has("webhook")) {
+            options.setWebhook(jsonOptions.getBoolean("webhook"));
+        }
         if (options.isWebhook() && jsonOptions.has("webhookUrl")) {
             options.setWebhookUrl(jsonOptions.getString("webhookUrl"));
         }

--- a/features/reporting/rest/src/main/java/org/opennms/features/reporting/rest/internal/ReportRestServiceImpl.java
+++ b/features/reporting/rest/src/main/java/org/opennms/features/reporting/rest/internal/ReportRestServiceImpl.java
@@ -479,6 +479,10 @@ public class ReportRestServiceImpl implements ReportRestService {
         if (options.isSendMail() && jsonOptions.has("mailTo")) {
             options.setMailTo(jsonOptions.getString("mailTo"));
         }
+        options.setWebhook(jsonOptions.getBoolean("webhook"));
+        if (options.isWebhook() && jsonOptions.has("webhookUrl")) {
+            options.setWebhookUrl(jsonOptions.getString("webhookUrl"));
+        }
         options.setPersist(jsonOptions.getBoolean("persist"));
         options.setFormat(parseReportFormat(jsonOptions.getString("format")));
         return options;

--- a/opennms-web-api/src/main/java/org/opennms/web/svclayer/support/DefaultSchedulerService.java
+++ b/opennms-web-api/src/main/java/org/opennms/web/svclayer/support/DefaultSchedulerService.java
@@ -30,6 +30,8 @@ package org.opennms.web.svclayer.support;
 
 import static org.opennms.api.reporting.ReportParameterBuilder.Intervals;
 
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Date;
@@ -264,8 +266,8 @@ public class DefaultSchedulerService implements InitializingBean, SchedulerServi
                 }
             }
 
-            if (!deliveryOptions.isSendMail() && !deliveryOptions.isPersist()) {
-                throw new SchedulerContextException("sendMail_persist", "Either sendMail or persist must be set");
+            if (!deliveryOptions.isSendMail() && !deliveryOptions.isPersist() && !deliveryOptions.isWebhook()) {
+                throw new SchedulerContextException("sendMail_persist_webhook", "Either sendMail, webhook or persist must be set");
             }
             if (deliveryOptions.getFormat() == null) {
                 throw new SchedulerContextException("format", PROVIDE_A_VALUE_TEXT);
@@ -279,6 +281,16 @@ public class DefaultSchedulerService implements InitializingBean, SchedulerServi
                     InternetAddress.parse(deliveryOptions.getMailTo(), false);
                 } catch (AddressException e) {
                     throw new SchedulerContextException("mailTo", "Provided recipients could not be parsed: {0}", e.getMessage(), e);
+                }
+            }
+            if (deliveryOptions.isWebhook()) {
+                if (Strings.isNullOrEmpty(deliveryOptions.getWebhookUrl())) {
+                    throw new SchedulerContextException("webhookUrl", PROVIDE_A_VALUE_TEXT);
+                }
+                try {
+                    new URL(deliveryOptions.getWebhookUrl());
+                } catch (MalformedURLException ex) {
+                    throw new SchedulerContextException("webhookUrl", "The provided URL ''{0}'' is not valid: ''{1}''", deliveryOptions.getWebhookUrl(), ex.getMessage());
                 }
             }
         } catch (SchedulerException e) {

--- a/opennms-webapp/src/test/java/org/opennms/web/svclayer/support/DefaultSchedulerServiceIT.java
+++ b/opennms-webapp/src/test/java/org/opennms/web/svclayer/support/DefaultSchedulerServiceIT.java
@@ -138,14 +138,14 @@ public class DefaultSchedulerServiceIT {
     }
 
     @Test
-    public void testEitherSendMailOrPersistMustBeSet() {
+    public void testEitherSendMailPersistOrWebhookMustBeSet() {
         deliveryOptions.setPersist(false);
 
         try {
             m_schedulerService.execute(new DeliveryConfig(reportParameters, deliveryOptions));
             fail("Expected exception, but wasn't thrown");
         } catch (org.opennms.web.svclayer.support.SchedulerContextException ex) {
-            assertThat(ex.getContext(), is("sendMail_persist"));
+            assertThat(ex.getContext(), is("sendMail_persist_webhook"));
         }
     }
 

--- a/smoke-test/src/main/java/org/opennms/smoketest/containers/WebhookEndpointContainer.java
+++ b/smoke-test/src/main/java/org/opennms/smoketest/containers/WebhookEndpointContainer.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019-2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.smoketest.containers;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
+
+public class WebhookEndpointContainer extends GenericContainer<WebhookEndpointContainer> {
+
+    private static final String ALIAS = "opennms-dummy-http-endpoint";
+    private static final int PORT = 8080;
+
+    public WebhookEndpointContainer() {
+        super("opennms/dummy-http-endpoint:0.0.2");
+        addExposedPort(8080);
+        withNetwork(Network.SHARED);
+        withNetworkAliases(ALIAS);
+    }
+
+    public int getWebPort() {
+        return getMappedPort(PORT);
+    }
+
+    public URL getBaseUrlExternal() {
+        try {
+            return new URL(String.format("http://%s:%d/", getContainerIpAddress(), getMappedPort(PORT)));
+        } catch (MalformedURLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/smoke-test/src/test/java/org/opennms/smoketest/DatabaseReportPageIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/DatabaseReportPageIT.java
@@ -28,6 +28,7 @@
 
 package org.opennms.smoketest;
 
+import static io.restassured.RestAssured.given;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.awaitility.Awaitility.await;
@@ -35,7 +36,10 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.openqa.selenium.support.ui.ExpectedConditions.elementToBeClickable;
 
+import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
@@ -43,10 +47,12 @@ import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Optional;
 
-import org.apache.logging.log4j.util.Strings;
 import org.hamcrest.Matchers;
+import org.json.JSONArray;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Test;
+import org.opennms.smoketest.containers.WebhookEndpointContainer;
 import org.opennms.smoketest.ui.framework.Button;
 import org.opennms.smoketest.ui.framework.CheckBox;
 import org.opennms.smoketest.ui.framework.DeleteAllButton;
@@ -65,10 +71,17 @@ import org.slf4j.LoggerFactory;
 import org.testcontainers.shaded.com.google.common.collect.Lists;
 
 import com.google.common.base.MoreObjects;
+import com.google.common.base.Strings;
+import com.google.common.io.ByteStreams;
+
+import io.restassured.RestAssured;
 
 public class DatabaseReportPageIT extends UiPageTest {
 
     private static Logger LOG = LoggerFactory.getLogger(DatabaseReportPageIT.class);
+
+    @ClassRule
+    public static WebhookEndpointContainer webhookEndpointContainer = new WebhookEndpointContainer();
 
     private DatabaseReportPage page;
 
@@ -175,6 +188,55 @@ public class DatabaseReportPageIT extends UiPageTest {
                 .findAny();
         LOG.debug("Schedule was edited, now verify exactly one schedule matches: {}", findMe.isPresent());
         assertThat(findMe.isPresent(), is(true));
+    }
+
+
+    // Verifies that a generated Report can be send to an HTTP Endpoint
+    @Test
+    public void verifyWebhookDelivery() throws IOException {
+        // Setup the Http Endpoint
+        RestAssured.baseURI = webhookEndpointContainer.getBaseUrlExternal().toString();
+        RestAssured.port = webhookEndpointContainer.getWebPort();
+
+        // Verify nothing was posted yet
+        given().basePath("/files").get()
+            .then()
+            .statusCode(200)
+            .body("size()", is(0));
+
+        // Trigger Delivery of the report
+        new ReportTemplateTab(getDriver()).open()
+            .select(EarlyMorningReport.name)
+            .deliverReport(new DeliveryOptions()
+                .format(Formats.PDF)
+                .postToEndpoint("http://opennms-dummy-http-endpoint:8080/files?instanceId=:instanceId")
+            );
+
+        // Ensure it was posted
+        await().atMost(2, MINUTES).pollInterval(10, SECONDS).until(
+            () -> {
+                final String response = given().basePath("/files").get()
+                        .then()
+                        .statusCode(200)
+                        .extract().response().asString();
+                final JSONArray array = new JSONArray(response);
+                if (array.length() == 1) {
+                    // Read PDF
+                    final String filename = array.getJSONObject(0).getString("name");
+                    final InputStream input = given().basePath("/files/" + filename).get()
+                        .then()
+                        .statusCode(200)
+                        .contentType("application/pdf")
+                        .extract().body().asInputStream();
+                    final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+                    ByteStreams.copy(input, outputStream);;
+                    final byte[] receivedBytes = outputStream.toByteArray();
+                    if (receivedBytes.length > 0) {
+                        return true;
+                    }
+                }
+                return false;
+            });
     }
 
     public interface EarlyMorningReport {
@@ -337,6 +399,12 @@ public class DatabaseReportPageIT extends UiPageTest {
                 new TextInput(getDriver(), "mailRecipient").setInput(emailRecipients);
             }
 
+            // Post to HTTP Endpoint?
+            if (!Strings.isNullOrEmpty(options.webhookEndpoint)) {
+                new CheckBox(getDriver(), "webhookToggle").setSelected(true);
+                new TextInput(getDriver(), "webhookUrl").setInput(options.webhookEndpoint);
+            }
+
             // Format
             new Select(driver, "format").setValueByText(options.format);
             return this;
@@ -465,7 +533,8 @@ public class DatabaseReportPageIT extends UiPageTest {
 
         private String format;
         private boolean persistToDisk;
-        private List<String> emailRecipients;
+        private List<String> emailRecipients = Lists.newArrayList();
+        private String webhookEndpoint;
 
         private DeliveryOptions format(String format) {
             this.format = Objects.requireNonNull(format);
@@ -482,11 +551,17 @@ public class DatabaseReportPageIT extends UiPageTest {
             return this;
         }
 
+        public DeliveryOptions postToEndpoint(String webhookEndpoint) {
+            this.webhookEndpoint = Objects.requireNonNull(webhookEndpoint);
+            return this;
+        }
+
         public String toString() {
             return MoreObjects.toStringHelper(this)
                     .add("format", format)
                     .add("persistToDisk", persistToDisk)
                     .add("emailRecipients", emailRecipients)
+                    .add("webhookEndpoint", webhookEndpoint)
                     .toString();
         }
     }

--- a/smoke-test/src/test/java/org/opennms/smoketest/DatabaseReportPageIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/DatabaseReportPageIT.java
@@ -498,8 +498,8 @@ public class DatabaseReportPageIT extends UiPageTest {
                 final ReportScheduleElement element = new ReportScheduleElement(getDriver());
                 element.setTemplateName(columns.get(1).getText());
                 element.setFormat(columns.get(2).getText());
-                element.setCronExpression(columns.get(5).getText());
-                element.setTriggerName(columns.get(6).getText());
+                element.setCronExpression(columns.get(6).getText());
+                element.setTriggerName(columns.get(7).getText());
                 results.add(element);
             }
             return results;

--- a/smoke-test/src/test/java/org/opennms/smoketest/DatabaseReportPageIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/DatabaseReportPageIT.java
@@ -395,7 +395,7 @@ public class DatabaseReportPageIT extends UiPageTest {
             final CheckBox recipientCheckbox = new CheckBox(getDriver(), "sendMailToggle");
             recipientCheckbox.setSelected(!options.emailRecipients.isEmpty());
             if (!options.emailRecipients.isEmpty()) {
-                final String emailRecipients = Strings.join(options.emailRecipients, ',');
+                final String emailRecipients = String.join(",", options.emailRecipients);
                 new TextInput(getDriver(), "mailRecipient").setInput(emailRecipients);
             }
 


### PR DESCRIPTION
Here we add the possibility to define a Webhook URL when delivering a Database Report.

If parameters are required, the URL can be substituted by the following parameters:

-  `format`
- `instanceId`
- `parameter_<parameterName>`

A webhook URL could look like this: `http://localhost:8080/files?instanceId=:instanceId&format=:format&option=:parameter_option`

I tested this with a Java and PHP dummy endpoint implementation. 
The PHP endpoint I used looks like this:

```PHP
<?php
foreach ($_FILES as $key => $value) {
    $filename = $value["name"];
    if (!file_exists("./uploads")) {
        mkdir("./uploads");
    }
    move_uploaded_file($value["tmp_name"], "./uploads/".$filename);
}
```

A dummy Java endpoint implementation can be found [here](https://github.com/opennms-forge/dummy-http-endpoint).

I also tried defining reports in H24 and after the upgrade everything still works.

JIRA: https://issues.opennms.org/browse/NMS-12153
