### PR TITLE
NMS-10027 - The JMX-Cassandra service goes down for all the cluster when a single instance is down

### DIFF
--- a/opennms-base-assembly/src/main/filtered/etc/poller-configuration.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/poller-configuration.xml
@@ -27,7 +27,6 @@
          <parameter key="beans.storage" value="org.apache.cassandra.db:type=StorageService"/>
          <parameter key="tests.operational" value="storage.OperationMode == 'NORMAL'"/>
          <parameter key="tests.joined" value="storage.Joined"/>
-         <parameter key="tests.unreachables" value="empty(storage.UnreachableNodes)"/>
       </service>
       <service name="JMX-Cassandra-Newts" interval="300000" user-defined="false" status="on">
          <parameter key="port" value="7199"/>


### PR DESCRIPTION
The JMX-Cassandra service goes down for all the cluster when a single instance is down.

### All Contributors

* [x] Have you read and followed our [Contribution Guidelines](https://github.com/OpenNMS/opennms/blob/develop/CONTRIBUTING.md)?
* [x] Have you [made an issue in the OpenNMS issue tracker](https://issues.opennms.org)?<br>If so, you should:
  1. update the title of this PR to be of the format: `${JIRA-ISSUE-NUMBER}: subject of pull request`
  2. update the JIRA link at the bottom of this comment to refer to the real issue number
  3. prefix your commit messages with the issue number, if possible
* [x] Have you made a comment in that issue which points back to this PR?
* [x] Have you updated the JIRA link at the bottom of this comment to link to your issue?
* [ ] If this is a new or updated feature, is there documentation for the new behavior?
* [ ] If this is new code, are there unit and/or integration tests?
* [ ] If this PR targets a `foundation-*` branch, does it avoid changing files in `$OPENNMS_HOME/etc/`?

### Pull Request Process

One or more reviewers should be assigned to each PR.

If you know that a particular person is subject matter expert in the area your PR affects, feel free to assign one or more reviewers when you create this PR, otherwise reviewers will be assigned for you.

Once the reviewer(s) accept the PR and the branch passes continuous integration in Bamboo, the PR is eligible for merge.

At that time, if you have commit access (are an OpenNMS Group employee or a member of the Order of the Green Polo) you are welcome to merge the PR.
Otherwise, a reviewer can merge it for you.

Thanks for taking time to contribute!

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-10027
* Bamboo (Continuous Integration): https://bamboo.opennms.org/

