### PR TITLE
NMS-12354: Set a fixed dependency for OpenJDK 11 to a fixed build art…

### DIFF
--- a/opennms-container/horizon/Dockerfile
+++ b/opennms-container/horizon/Dockerfile
@@ -113,22 +113,27 @@ COPY --chown=10001:0 ./container-fs/entrypoint.sh /
 
 # Arguments for labels should not invalidate caches
 ARG BUILD_DATE="1970-01-01T00:00:00+0000"
-ARG VERSION=${BASE_IMAGE_VERSION}
+ARG VERSION
+ARG SOURCE
+ARG REVISION
+ARG BUILD_JOB_ID
 ARG BUILD_NUMBER
 ARG BUILD_URL
 ARG BUILD_BRANCH
-ARG BUILD_SHA1
 
-LABEL maintainer="The OpenNMS Group" \
-      license="AGPLv3" \
-      name="Horizon" \
-      version="${VERSION}" \
-      vendor="OpenNMS Community" \
-      cicd.build.date="${BUILD_DATE}" \
-      cicd.build.number="${BUILD_NUMBER}" \
-      cicd.build.url="${BUILD_URL}" \
-      cicd.build.branch="${BUILD_BRANCH}" \
-      cicd.build.sha1="${CIRCLE_SHA1}"
+LABEL org.opencontainers.image.created="${BUILD_DATE}" \
+      org.opencontainers.image.title="OpenNMS Horizon ${VERSION}" \
+      org.opencontainers.image.source="${SOURCE}" \
+      org.opencontainers.image.revision="${REVISION}" \
+      org.opencontainers.image.version="${VERSION}" \
+      org.opencontainers.image.vendor="The OpenNMS Group, Inc." \
+      org.opencontainers.image.authors="OpenNMS Community" \
+      org.opencontainers.image.licenses="AGPL-3.0" \
+      org.opennms.image.base="${BASE_IMAGE}:${BASE_IMAGE_VERSION}" \
+      org.opennme.cicd.jobid="${BUILD_JOB_ID}" \
+      org.opennms.cicd.buildnumber="${BUILD_NUMBER}" \
+      org.opennms.cicd.buildurl="${BUILD_URL}" \
+      org.opennms.cicd.branch="${BUILD_BRANCH}"
 
 WORKDIR /opt/opennms
 

--- a/opennms-container/horizon/build_container_image.sh
+++ b/opennms-container/horizon/build_container_image.sh
@@ -22,12 +22,18 @@ done
 docker build -t horizon \
   --build-arg BUILD_DATE="$(date -u +\"%Y-%m-%dT%H:%M:%S%z\")" \
   --build-arg BASE_IMAGE="opennms/openjdk" \
-  --build-arg BASE_IMAGE_VERSION="11.0.4.11" \
+  --build-arg BASE_IMAGE_VERSION="11.0.4.11-b2418" \
   --build-arg VERSION="${VERSION}" \
+  --build-arg SOURCE="${CIRCLE_REPOSITORY_URL}" \
+  --build-arg REVISION="$(git describe --always)" \
+  --build-arg BUILD_JOB_ID="${CIRCLE_WORKFLOW_JOB_ID}" \
   --build-arg BUILD_NUMBER="${CIRCLE_BUILD_NUM}" \
   --build-arg BUILD_URL="${CIRCLE_BUILD_URL}" \
   --build-arg BUILD_BRANCH="${CIRCLE_BRANCH}" \
-  --build-arg BUILD_SHA1="${CIRCLE_SHA1}" \
   .
+
+if [ -n "${CIRCLE_BUILD_NUM}" ]; then
+  IMAGE_VERSION+=("${BASE_IMAGE_VERSION}-b${CIRCLE_BUILD_NUM}")
+fi
 
 docker image save horizon -o images/container.oci

--- a/opennms-container/minion/Dockerfile
+++ b/opennms-container/minion/Dockerfile
@@ -55,23 +55,29 @@ RUN if [[ "$(ls -1 /tmp/rpms/*.rpm 2>/dev/null | wc -l)" != 0 ]]; then yum -y lo
 
 COPY ./assets/entrypoint.sh /
 
+# Arguments for labels should not invalidate caches
 ARG BUILD_DATE="1970-01-01T00:00:00+0000"
-ARG VERSION=${BASE_IMAGE_VERSION}
+ARG VERSION
+ARG SOURCE
+ARG REVISION
+ARG BUILD_JOB_ID
 ARG BUILD_NUMBER
 ARG BUILD_URL
 ARG BUILD_BRANCH
-ARG BUILD_SHA1
 
-LABEL maintainer="The OpenNMS Group" \
-      license="AGPLv3" \
-      name="Minion" \
-      version="${VERSION}" \
-      vendor="OpenNMS Community" \
-      cicd.build.date="${BUILD_DATE}" \
-      cicd.build.number="${BUILD_NUMBER}" \
-      cicd.build.url="${BUILD_URL}" \
-      cicd.build.branch="${BUILD_BRANCH}" \
-      cicd.build.sha1="${CIRCLE_SHA1}"
+LABEL org.opencontainers.image.created="${BUILD_DATE}" \
+      org.opencontainers.image.title="OpenNMS Minion ${VERSION}" \
+      org.opencontainers.image.source="${SOURCE}" \
+      org.opencontainers.image.revision="${REVISION}" \
+      org.opencontainers.image.version="${VERSION}" \
+      org.opencontainers.image.vendor="The OpenNMS Group, Inc." \
+      org.opencontainers.image.authors="OpenNMS Community" \
+      org.opencontainers.image.licenses="AGPL-3.0" \
+      org.opennms.image.base="${BASE_IMAGE}:${BASE_IMAGE_VERSION}" \
+      org.opennme.cicd.jobid="${BUILD_JOB_ID}" \
+      org.opennms.cicd.buildnumber="${BUILD_NUMBER}" \
+      org.opennms.cicd.buildurl="${BUILD_URL}" \
+      org.opennms.cicd.branch="${BUILD_BRANCH}"
 
 WORKDIR /opt/minion
 

--- a/opennms-container/minion/build_container_image.sh
+++ b/opennms-container/minion/build_container_image.sh
@@ -22,12 +22,14 @@ done
 docker build -t minion \
   --build-arg BUILD_DATE="$(date -u +\"%Y-%m-%dT%H:%M:%S%z\")" \
   --build-arg BASE_IMAGE="opennms/openjdk" \
-  --build-arg BASE_IMAGE_VERSION="11.0.4.11" \
+  --build-arg BASE_IMAGE_VERSION="11.0.4.11-b2418" \
   --build-arg VERSION="${VERSION}" \
+  --build-arg SOURCE="${CIRCLE_REPOSITORY_URL}" \
+  --build-arg REVISION="$(git describe --always)" \
+  --build-arg BUILD_JOB_ID="${CIRCLE_WORKFLOW_JOB_ID}" \
   --build-arg BUILD_NUMBER="${CIRCLE_BUILD_NUM}" \
   --build-arg BUILD_URL="${CIRCLE_BUILD_URL}" \
   --build-arg BUILD_BRANCH="${CIRCLE_BRANCH}" \
-  --build-arg BUILD_SHA1="${CIRCLE_SHA1}" \
   .
 
 docker image save minion -o images/container.oci

--- a/opennms-container/sentinel/Dockerfile
+++ b/opennms-container/sentinel/Dockerfile
@@ -60,23 +60,29 @@ STOPSIGNAL SIGTERM
 
 CMD [ "-f" ]
 
+# Arguments for labels should not invalidate caches
 ARG BUILD_DATE="1970-01-01T00:00:00+0000"
 ARG VERSION
+ARG SOURCE
+ARG REVISION
+ARG BUILD_JOB_ID
 ARG BUILD_NUMBER
 ARG BUILD_URL
 ARG BUILD_BRANCH
-ARG BUILD_SHA1
 
-LABEL maintainer="The OpenNMS Group" \
-      license="AGPLv3" \
-      name="Sentinel" \
-      version="${VERSION}" \
-      vendor="OpenNMS Community" \
-      cicd.build.date="${BUILD_DATE}" \
-      cicd.build.number="${BUILD_NUMBER}" \
-      cicd.build.url="${BUILD_URL}" \
-      cicd.build.branch="${BUILD_BRANCH}" \
-      cicd.build.sha1="${CIRCLE_SHA1}"
+LABEL org.opencontainers.image.created="${BUILD_DATE}" \
+      org.opencontainers.image.title="OpenNMS Sentinel ${VERSION}" \
+      org.opencontainers.image.source="${SOURCE}" \
+      org.opencontainers.image.revision="${REVISION}" \
+      org.opencontainers.image.version="${VERSION}" \
+      org.opencontainers.image.vendor="The OpenNMS Group, Inc." \
+      org.opencontainers.image.authors="OpenNMS Community" \
+      org.opencontainers.image.licenses="AGPL-3.0" \
+      org.opennms.image.base="${BASE_IMAGE}:${BASE_IMAGE_VERSION}" \
+      org.opennme.cicd.jobid="${BUILD_JOB_ID}" \
+      org.opennms.cicd.buildnumber="${BUILD_NUMBER}" \
+      org.opennms.cicd.buildurl="${BUILD_URL}" \
+      org.opennms.cicd.branch="${BUILD_BRANCH}"
 
 ### Runtime information and not relevant at build time
 

--- a/opennms-container/sentinel/build_container_image.sh
+++ b/opennms-container/sentinel/build_container_image.sh
@@ -22,12 +22,14 @@ done
 docker build -t sentinel \
   --build-arg BUILD_DATE="$(date -u +\"%Y-%m-%dT%H:%M:%S%z\")" \
   --build-arg BASE_IMAGE="opennms/openjdk" \
-  --build-arg BASE_IMAGE_VERSION="11.0.4.11" \
+  --build-arg BASE_IMAGE_VERSION="11.0.4.11-b2418" \
   --build-arg VERSION="${VERSION}" \
+  --build-arg SOURCE="${CIRCLE_REPOSITORY_URL}" \
+  --build-arg REVISION="$(git describe --always)" \
+  --build-arg BUILD_JOB_ID="${CIRCLE_WORKFLOW_JOB_ID}" \
   --build-arg BUILD_NUMBER="${CIRCLE_BUILD_NUM}" \
   --build-arg BUILD_URL="${CIRCLE_BUILD_URL}" \
   --build-arg BUILD_BRANCH="${CIRCLE_BRANCH}" \
-  --build-arg BUILD_SHA1="${CIRCLE_SHA1}" \
   .
 
 docker image save sentinel -o images/container.oci


### PR DESCRIPTION
### All Contributors

* [x] Have you read and followed our [Contribution Guidelines](https://github.com/OpenNMS/opennms/blob/develop/CONTRIBUTING.md)?
* [x] Have you [made an issue in the OpenNMS issue tracker](https://issues.opennms.org)?<br>If so, you should:
  1. update the title of this PR to be of the format: `${JIRA-ISSUE-NUMBER}: subject of pull request`
  2. update the JIRA link at the bottom of this comment to refer to the real issue number
  3. prefix your commit messages with the issue number, if possible
* [x] Have you made a comment in that issue which points back to this PR?
* [x] Have you updated the JIRA link at the bottom of this comment to link to your issue?
* [x] If this is a new or updated feature, is there documentation for the new behavior?
* [x] If this is new code, are there unit and/or integration tests?
* [x] If this PR targets a `foundation-*` branch, does it avoid changing files in `$OPENNMS_HOME/etc/`?

Set a fixed dependency for OpenJDK 11 to a fixed build artifact. This is required to avoid problems when updating our base image. Without this change, it is hard to update our base images to use CentOS 8 cause they will break upcoming builds and we introduce uncontrolled changes. With floating versions, there is also no way to roll back to use previous versions in case we broke something. With setting them to a fixed artifact we have control for updates and keep current builds working. I use the CircleCI build number as a version suffix to have a unique identifiable artifact reference, e.g. `-b2418`

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-12354
* Bamboo (Continuous Integration): https://bamboo.opennms.org/

