### PR TITLE
NMS-12353: Use CentOS 8 as base image for container images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 executors:
   build-executor:
     docker:
-      - image: opennms/build-env:8-11_1.3
+      - image: opennms/build-env:jdk8-jdk11-3.6.2-b2874
   integration-test-executor:
     machine: true
   smoke-test-executor:

--- a/opennms-container/horizon/Dockerfile
+++ b/opennms-container/horizon/Dockerfile
@@ -9,7 +9,7 @@ FROM ${BASE_IMAGE}:${BASE_IMAGE_VERSION} as horizon-base
 ARG REQUIRED_RPMS="rrdtool jrrd2 jicmp jicmp6 R-core rsync perl-XML-Twig perl-libwww-perl jq"
 
 ARG REPO_KEY_URL="https://yum.opennms.org/OPENNMS-GPG-KEY"
-ARG REPO_RPM="https://yum.opennms.org/repofiles/opennms-repo-stable-rhel7.noarch.rpm"
+ARG REPO_RPM="https://yum.opennms.org/repofiles/opennms-repo-stable-rhel8.noarch.rpm"
 
 ARG CONFD_VERSION="0.16.0"
 ARG CONFD_URL="https://github.com/kelseyhightower/confd/releases/download/v${CONFD_VERSION}/confd-${CONFD_VERSION}-linux-amd64"
@@ -20,11 +20,13 @@ SHELL ["/bin/bash", "-c"]
 RUN curl -L ${CONFD_URL} -o /usr/bin/confd && \
     chmod +x /usr/bin/confd
 
-RUN rpm --import "${REPO_KEY_URL}" && \
-    yum install -y epel-release && \
-    yum -y install "${REPO_RPM}" && \
-    yum -y install ${REQUIRED_RPMS} && \
-    yum clean all -y && \
+RUN dnf -y install dnf-plugins-core && \
+    dnf config-manager --set-enabled PowerTools && \
+    rpm --import "${REPO_KEY_URL}" && \
+    dnf -y install epel-release && \
+    dnf -y install "${REPO_RPM}" && \
+    dnf -y install ${REQUIRED_RPMS} && \
+    dnf clean all && \
     rm -rf /var/cache/yum
 
 # Allow to send ICMP messages as non-root user
@@ -63,21 +65,21 @@ RUN if [[ "$(ls -1 /tmp/tarball/*.tar.gz 2>/dev/null | wc -l)" != 0 ]]; then \
         mkdir -p /opt/opennms && tar xzf /tmp/tarball/opennms-*.tar.gz -C /opt/opennms && \
         cp -r /opt/opennms/etc /opt/opennms/share/etc-pristine; \
     elif [[ "$(ls -1 /tmp/rpms/*.rpm 2>/dev/null | wc -l)" != 0 ]]; then \
-        yum -y localinstall /tmp/rpms/*.rpm && \
+        dnf -y install /tmp/rpms/*.rpm && \
         rm -rf /opt/opennms/logs \
                /opt/opennms/share && \
         mv /var/opennms /opt/opennms/share && \
         mv /var/log/opennms /opt/opennms/logs; \
     else \
-        yum install -y ${ONMS_PACKAGES} && \
+        dnf -y install ${ONMS_PACKAGES} && \
         rm -rf /opt/opennms/logs \
                /opt/opennms/share && \
         mv /var/opennms /opt/opennms/share && \
         mv /var/log/opennms /opt/opennms/logs; \
     fi && \
-    if [[ -n ${ADD_YUM_PACKAGES} ]]; then yum -y install ${ADD_YUM_PACKAGES}; fi && \
+    if [[ -n ${ADD_YUM_PACKAGES} ]]; then dnf -y install ${ADD_YUM_PACKAGES}; fi && \
     rm -rf /tmp/rpms /tmp/tarball && \
-    yum clean all && \
+    dnf clean all && \
     rm -rf /var/cache/yum && \
     rm -rf /opt/opennms/share/rrd \
            /opt/opennms/share/reports \

--- a/opennms-container/horizon/build_container_image.sh
+++ b/opennms-container/horizon/build_container_image.sh
@@ -22,7 +22,7 @@ done
 docker build -t horizon \
   --build-arg BUILD_DATE="$(date -u +\"%Y-%m-%dT%H:%M:%S%z\")" \
   --build-arg BASE_IMAGE="opennms/openjdk" \
-  --build-arg BASE_IMAGE_VERSION="11.0.4.11-b2418" \
+  --build-arg BASE_IMAGE_VERSION="11.0.4.11-b2553" \
   --build-arg VERSION="${VERSION}" \
   --build-arg SOURCE="${CIRCLE_REPOSITORY_URL}" \
   --build-arg REVISION="$(git describe --always)" \

--- a/opennms-container/minion/Dockerfile
+++ b/opennms-container/minion/Dockerfile
@@ -9,16 +9,16 @@ FROM ${BASE_IMAGE}:${BASE_IMAGE_VERSION} as minion-base
 ARG REQUIRED_RPMS="wget gettext jicmp jicmp6"
 
 ARG REPO_KEY_URL="https://yum.opennms.org/OPENNMS-GPG-KEY"
-ARG REPO_RPM="https://yum.opennms.org/repofiles/opennms-repo-stable-rhel7.noarch.rpm"
+ARG REPO_RPM="https://yum.opennms.org/repofiles/opennms-repo-stable-rhel8.noarch.rpm"
 
 SHELL ["/bin/bash", "-c"]
 
 # Collect generic steps in a layer for caching
 RUN rpm --import "${REPO_KEY_URL}" && \
-    yum install -y epel-release && \
-    yum -y install "${REPO_RPM}" && \
-    yum -y install ${REQUIRED_RPMS} && \
-    yum clean all -y && \
+    dnf -y install epel-release && \
+    dnf -y install "${REPO_RPM}" && \
+    dnf -y install ${REQUIRED_RPMS} && \
+    dnf clean all && \
     rm -rf /var/cache/yum
 
 # Allow to send ICMP messages as non-root user
@@ -44,10 +44,10 @@ COPY ./rpms /tmp/rpms
 SHELL ["/bin/bash", "-c"]
 
 # Install repositories, system and OpenNMS packages and do some cleanup
-RUN if [[ "$(ls -1 /tmp/rpms/*.rpm 2>/dev/null | wc -l)" != 0 ]]; then yum -y localinstall /tmp/rpms/*.rpm; else yum install -y ${MINION_PACKAGES}; fi && \
-    if [[ -n ${ADD_YUM_PACKAGES} ]]; then yum -y install ${ADD_YUM_PACKAGES}; fi && \
+RUN if [[ "$(ls -1 /tmp/rpms/*.rpm 2>/dev/null | wc -l)" != 0 ]]; then dnf -y install /tmp/rpms/*.rpm; else dnf -y install ${MINION_PACKAGES}; fi && \
+    if [[ -n ${ADD_YUM_PACKAGES} ]]; then dnf -y install ${ADD_YUM_PACKAGES}; fi && \
     rm -rf /tmp/rpms && \
-    yum clean all && \
+    dnf clean all && \
     rm -rf /var/cache/yum && \
     sed -r -i '/RUNAS/s/.*/export RUNAS=${USER}/' /etc/sysconfig/minion && \
     chgrp -R 0 /opt/minion && \

--- a/opennms-container/minion/build_container_image.sh
+++ b/opennms-container/minion/build_container_image.sh
@@ -22,7 +22,7 @@ done
 docker build -t minion \
   --build-arg BUILD_DATE="$(date -u +\"%Y-%m-%dT%H:%M:%S%z\")" \
   --build-arg BASE_IMAGE="opennms/openjdk" \
-  --build-arg BASE_IMAGE_VERSION="11.0.4.11-b2418" \
+  --build-arg BASE_IMAGE_VERSION="11.0.4.11-b2553" \
   --build-arg VERSION="${VERSION}" \
   --build-arg SOURCE="${CIRCLE_REPOSITORY_URL}" \
   --build-arg REVISION="$(git describe --always)" \

--- a/opennms-container/sentinel/Dockerfile
+++ b/opennms-container/sentinel/Dockerfile
@@ -9,16 +9,16 @@ FROM ${BASE_IMAGE}:${BASE_IMAGE_VERSION} as sentinel-base
 ARG REQUIRED_RPMS="wget gettext"
 
 ARG REPO_KEY_URL="https://yum.opennms.org/OPENNMS-GPG-KEY"
-ARG REPO_RPM="https://yum.opennms.org/repofiles/opennms-repo-stable-rhel7.noarch.rpm"
+ARG REPO_RPM="https://yum.opennms.org/repofiles/opennms-repo-stable-rhel8.noarch.rpm"
 
 SHELL ["/bin/bash", "-c"]
 
 # Collect generic steps in a layer for caching
 RUN rpm --import "${REPO_KEY_URL}" && \
-    yum install -y epel-release && \
-    yum -y install "${REPO_RPM}" && \
-    yum -y install ${REQUIRED_RPMS} && \
-    yum clean all -y && \
+    dnf -y install epel-release && \
+    dnf -y install "${REPO_RPM}" && \
+    dnf -y install ${REQUIRED_RPMS} && \
+    dnf clean all && \
     rm -rf /var/cache/yum
 
 # Allow to send ICMP messages as non-root user
@@ -42,10 +42,10 @@ COPY ./rpms /tmp/rpms
 SHELL ["/bin/bash", "-c"]
 
 # Install repositories, system and OpenNMS packages and do some cleanup
-RUN if [[ "$(ls -1 /tmp/rpms/*.rpm 2>/dev/null | wc -l)" != 0 ]]; then yum -y localinstall /tmp/rpms/*.rpm; else yum install -y ${SENTINEL_PACKAGES}; fi && \
-    if [[ -n ${ADD_YUM_PACKAGES} ]]; then yum -y install ${ADD_YUM_PACKAGES}; fi && \
+RUN if [[ "$(ls -1 /tmp/rpms/*.rpm 2>/dev/null | wc -l)" != 0 ]]; then dnf -y install /tmp/rpms/*.rpm; else dnf -y install ${SENTINEL_PACKAGES}; fi && \
+    if [[ -n ${ADD_YUM_PACKAGES} ]]; then dnf -y install ${ADD_YUM_PACKAGES}; fi && \
     rm -rf /tmp/rpms && \
-    yum clean all && \
+    dnf clean all && \
     rm -rf /var/cache/yum
 
 COPY ./assets/entrypoint.sh /

--- a/opennms-container/sentinel/build_container_image.sh
+++ b/opennms-container/sentinel/build_container_image.sh
@@ -22,7 +22,7 @@ done
 docker build -t sentinel \
   --build-arg BUILD_DATE="$(date -u +\"%Y-%m-%dT%H:%M:%S%z\")" \
   --build-arg BASE_IMAGE="opennms/openjdk" \
-  --build-arg BASE_IMAGE_VERSION="11.0.4.11-b2418" \
+  --build-arg BASE_IMAGE_VERSION="11.0.4.11-b2553" \
   --build-arg VERSION="${VERSION}" \
   --build-arg SOURCE="${CIRCLE_REPOSITORY_URL}" \
   --build-arg REVISION="$(git describe --always)" \


### PR DESCRIPTION
### All Contributors

* [x] Have you read and followed our [Contribution Guidelines](https://github.com/OpenNMS/opennms/blob/develop/CONTRIBUTING.md)?
* [x] Have you [made an issue in the OpenNMS issue tracker](https://issues.opennms.org)?<br>If so, you should:
  1. update the title of this PR to be of the format: `${JIRA-ISSUE-NUMBER}: subject of pull request`
  2. update the JIRA link at the bottom of this comment to refer to the real issue number
  3. prefix your commit messages with the issue number, if possible
* [x] Have you made a comment in that issue which points back to this PR?
* [x] Have you updated the JIRA link at the bottom of this comment to link to your issue?
* [x] If this is a new or updated feature, is there documentation for the new behavior?
* [x] If this is new code, are there unit and/or integration tests?
* [x] If this PR targets a `foundation-*` branch, does it avoid changing files in `$OPENNMS_HOME/etc/`?

Update build environment, Horizon, Minion and Sentinel to use CentOS 8 as base image. Updated Maven from 3.6.1 to 3.6.2.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-12353

