### PR TITLE
NMS-12359: Add opennms-core-tracing-jaeger feature to full assembly

### DIFF
--- a/opennms-full-assembly/pom.xml
+++ b/opennms-full-assembly/pom.xml
@@ -1012,6 +1012,16 @@
       <artifactId>org.opennms.features.measurements.shell</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.opennms.core.tracing</groupId>
+      <artifactId>org.opennms.core.tracing.jaeger-osgi</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.opennms.core.tracing</groupId>
+      <artifactId>org.opennms.core.tracing.jaeger-tracer</artifactId>
+      <version>${project.version}</version>
+    </dependency>
 
     <!-- Test dependencies -->
     <dependency>

--- a/opennms-full-assembly/pom.xml
+++ b/opennms-full-assembly/pom.xml
@@ -586,6 +586,7 @@
                 <feature>opennms-blobstore-shell</feature>
                 <feature>opennms-jsonstore-shell</feature>
                 <feature>opennms-threshold-states-shell</feature>
+                <feature>opennms-core-tracing-jaeger</feature>
 
                 <!-- Include the OpenNMS Minion features produced by container/features/pom.xml -->
                 <feature>minion-core-api</feature>


### PR DESCRIPTION
Fix feature install `opennms-core-tracing-jaeger` on OpenNMS

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-12359
* Bamboo (Continuous Integration): https://bamboo.opennms.org/

