### PR TITLE
NMS-12360 - Fix requisition cache when accessing the Requisitions UI via "Edit in Requisition"

### DIFF
--- a/core/web-assets/src/main/assets/js/apps/onms-requisitions/lib/scripts/services/Requisitions.js
+++ b/core/web-assets/src/main/assets/js/apps/onms-requisitions/lib/scripts/services/Requisitions.js
@@ -461,12 +461,19 @@ const RequisitionNode  = require('../model/RequisitionNode');
       .success(function(data) {
         const req = new Requisition(data);
         $log.debug('getRequisition: got requisition ' + foreignSource);
-        const requisitionsData = requisitionsService.internal.getCachedRequisitionsData();
-        if (requisitionsData) {
-          $log.debug('getRequisition: updating cache for requisition ' + foreignSource);
-          requisitionsData.setRequisition(req);
-        }
-        deferred.resolve(req);
+        requisitionsService.updateDeployedStatsForRequisition(req).then(
+          function() { // success;
+            const requisitionsData = requisitionsService.internal.getCachedRequisitionsData();
+            if (requisitionsData) {
+              $log.debug('getRequisition: updating cache for requisition ' + foreignSource);
+              requisitionsData.setRequisition(req);
+            }
+            deferred.resolve(req);
+          },
+          function(error) { // error
+            deferred.reject(error);
+          }
+        );
       })
       .error(function(error, status) {
         $log.error('getRequisition: GET ' + url + ' failed:', error, status);

--- a/core/web-assets/src/test/javascript/ng-requisitions/services/Requisitions.test.js
+++ b/core/web-assets/src/test/javascript/ng-requisitions/services/Requisitions.test.js
@@ -17,25 +17,32 @@ const QuickNode = require('../../../../../src/main/assets/js/apps/onms-requisiti
 const Requisition = require('../../../../../src/main/assets/js/apps/onms-requisitions/lib/scripts/model/Requisition');
 const RequisitionNode = require('../../../../../src/main/assets/js/apps/onms-requisitions/lib/scripts/model/RequisitionNode');
 
+var deployedStatsTestNetwork = {
+  'name' : 'test-network',
+  'count': 2,
+  'totalCount': 2,
+  'foreign-id': [
+    '1001',
+    '1003'
+  ]
+};
+
+var deployedStatsTestMonitoring = {
+  'name' : 'test-monitoring',
+  'count': 1,
+  'totalCount': 1,
+  'foreign-id': [
+    'onms'
+  ]
+};
+
 var deployedStats = {
   'count': 2,
   'totalCount': 2,
-  'foreign-source': [{
-    'name' : 'test-network',
-    'count': 2,
-    'totalCount': 2,
-    'foreign-id': [
-      '1001',
-      '1003'
-    ]
-  },{
-    'name' : 'test-monitoring',
-    'count': 1,
-    'totalCount': 1,
-    'foreign-id': [
-      'onms'
-    ]
-  }]
+  'foreign-source': [
+    deployedStatsTestNetwork,
+    deployedStatsTestMonitoring
+  ]
 };
 
 var requisitions = {
@@ -347,10 +354,16 @@ test('Service: RequisitionsService: getRequisition', function() {
   var fs  = req['foreign-source'];
   var requisitionUrl = requisitionsService.internal.requisitionsUrl + '/' + fs;
   $httpBackend.expect('GET', requisitionUrl).respond(req);
+  var statsUrl = requisitionsService.internal.requisitionsUrl + '/deployed/stats/test-network';
+  $httpBackend.expect('GET', statsUrl).respond(deployedStatsTestNetwork);
 
   return runDigest(requisitionsService.getRequisition(fs).then(function(data) {
     expect(data).not.toBe(null);
     expect(data.nodes.length).toBe(3);
+    expect(data.nodesInDatabase).toBe(2);
+    expect(data.nodes[0].deployed).toBe(true);
+    expect(data.nodes[1].deployed).toBe(undefined);
+    expect(data.nodes[2].deployed).toBe(true);
   }, errorHandlerFn));
 });
 


### PR DESCRIPTION
Fix requisition cache when accessing the Requisitions UI via "Edit in Requisition".

There is a Jest test to verify that loading a requisition without cache will retrieve the requisition statistics to avoid red nodes unless they are not on the database.

I built a test environment to verify the solution and it works.

### All Contributors

* [x] Have you read and followed our [Contribution Guidelines](https://github.com/OpenNMS/opennms/blob/develop/CONTRIBUTING.md)?
* [x] Have you [made an issue in the OpenNMS issue tracker](https://issues.opennms.org)?<br>If so, you should:
  1. update the title of this PR to be of the format: `${JIRA-ISSUE-NUMBER}: subject of pull request`
  2. update the JIRA link at the bottom of this comment to refer to the real issue number
  3. prefix your commit messages with the issue number, if possible
* [x] Have you made a comment in that issue which points back to this PR?
* [x] Have you updated the JIRA link at the bottom of this comment to link to your issue?
* [ ] If this is a new or updated feature, is there documentation for the new behavior?
* [x] If this is new code, are there unit and/or integration tests?
* [ ] If this PR targets a `foundation-*` branch, does it avoid changing files in `$OPENNMS_HOME/etc/`?

### Pull Request Process

One or more reviewers should be assigned to each PR.

If you know that a particular person is subject matter expert in the area your PR affects, feel free to assign one or more reviewers when you create this PR, otherwise reviewers will be assigned for you.

Once the reviewer(s) accept the PR and the branch passes continuous integration in Bamboo, the PR is eligible for merge.

At that time, if you have commit access (are an OpenNMS Group employee or a member of the Order of the Green Polo) you are welcome to merge the PR.
Otherwise, a reviewer can merge it for you.

Thanks for taking time to contribute!

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-12360
* Bamboo (Continuous Integration): https://bamboo.opennms.org/

