### PR TITLE
CircleCI stability updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,6 +111,11 @@ commands:
             cd opennms-container/sentinel
             docker image load -i images/container.oci
       - run:
+          name: Start our JVM process monitor
+          background: true
+          command: |
+            .circleci/scripts/jvmprocmon-start.sh
+      - run:
           name: Smoke Tests
           no_output_timeout: 30m
           command: |
@@ -124,6 +129,7 @@ commands:
             ps auxf > ~/test-results/system-logs/ps
             free -m > ~/test-results/system-logs/free
             docker stats --no-stream > ~/test-results/system-logs/docker_stats
+            cp -R /tmp/jvmprocmon ~/test-results/system-logs/
       - run:
           name: Gather test artifacts
           when: always

--- a/.circleci/scripts/jvmprocmon-start.sh
+++ b/.circleci/scripts/jvmprocmon-start.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+TARGET="/tmp/jvmprocmon"
+
+echo "Starting JVMProcMon writing to: ${TARGET}"
+mkdir -p "$TARGET"
+
+dump () {
+  echo "$(date): Collecting details for JVM with PID $1 ..."
+  cmdline=$(cat "/proc/$1/cmdline")
+  timestamp_ms=$(date +%s%N | cut -b1-13)
+  target="${TARGET}/$1/$timestamp_ms"
+  mkdir -p "${target}"
+  echo "${cmdline}" > "${target}/cmdline"
+  jstack "$1" >> "${target}/jstack" 2>&1
+  jmap -histo "$1" >> "${target}/jmap_histo" 2>&1
+  echo "$(date): Done collection JVM details."
+}
+
+dump_all() {
+  echo "$(date): Enumerating & collecting JVM details..."
+  for PID in $(sudo pgrep --ns 1 java)
+  do
+    dump "$PID"
+  done
+  echo "$(date): Enumeration complete."
+}
+
+# Now and every 5 minutes capture a thread dump of all the JVMs
+# in the primary namespace (excluding those in Docker containers)
+while true
+do 
+    dump_all
+    sleep 300
+done

--- a/core/web-assets/pom.xml
+++ b/core/web-assets/pom.xml
@@ -10,6 +10,11 @@
   <artifactId>org.opennms.core.web-assets</artifactId>
   <name>OpenNMS Web UI Assets (JavaScript &amp; CSS)</name>
   <packaging>bundle</packaging>
+
+  <properties>
+    <skipNodeJSBuild>false</skipNodeJSBuild>
+  </properties>
+
   <build>
     <pluginManagement>
       <plugins>
@@ -56,6 +61,7 @@
             </goals>
             <phase>generate-resources</phase>
             <configuration>
+              <skip>${skipNodeJSBuild}</skip>
               <nodeVersion>${nodeVersion}</nodeVersion>
               <yarnVersion>${yarnVersion}</yarnVersion>
             </configuration>
@@ -67,6 +73,7 @@
             </goals>
             <phase>generate-resources</phase>
             <configuration>
+              <skip>${skipNodeJSBuild}</skip>
               <arguments>--prefer-offline --non-interactive --frozen-lockfile --no-progress</arguments>
             </configuration>
           </execution>
@@ -77,6 +84,7 @@
             </goals>
             <phase>compile</phase>
             <configuration>
+              <skip>${skipNodeJSBuild}</skip>
               <arguments>--prefer-offline --non-interactive --frozen-lockfile --no-progress release</arguments>
             </configuration>
           </execution>
@@ -148,6 +156,13 @@
           </plugin>
         </plugins>
       </build>
+    </profile>
+    <profile>
+      <!-- When building the packages in assemble only mode don't install or run Node.js -->
+      <id>skipCompile</id>
+      <properties>
+        <skipNodeJSBuild>true</skipNodeJSBuild>
+      </properties>
     </profile>
   </profiles>
   <dependencies>

--- a/makerpm.sh
+++ b/makerpm.sh
@@ -226,6 +226,10 @@ function main()
 
         echo "=== Copying Source to Source Directory ==="
         run rsync -aqr --exclude=.git --exclude=.svn --exclude=target --delete --delete-excluded "$TOPDIR/" "$WORKDIR/tmp/$PACKAGE_NAME-$VERSION-$RELEASE/"
+        if $ASSEMBLY_ONLY; then
+            # Include any existing target/ directory from the core/web-assets project so that webpack does not need to run again
+            run rsync -aqr --delete --delete-excluded "$TOPDIR/core/web-assets/" "$WORKDIR/tmp/$PACKAGE_NAME-$VERSION-$RELEASE/core/web-assets/"
+        fi
 
         echo "=== Creating a tar.gz Archive of the Source in $WORKDIR/tmp/$PACKAGE_NAME-$VERSION-$RELEASE ==="
         run tar zcf "$WORKDIR/SOURCES/${PACKAGE_NAME}-source-$VERSION-$RELEASE.tar.gz" -C "$WORKDIR/tmp" "${PACKAGE_NAME}-$VERSION-$RELEASE"

--- a/tools/packages/minion/create-minion-assembly.sh
+++ b/tools/packages/minion/create-minion-assembly.sh
@@ -69,6 +69,7 @@ PROJECTS=""
 if [ $SKIP_COMPILE -eq 1 ]; then
 	echo "=== Compiling Assemblies ==="
 	PROJECTS="${ASSEMBLY_PROJECTS}"
+	OPTS_PROFILES="${OPTS_PROFILES} -PskipCompile"
 else
 	echo "=== Compiling Projects + Assemblies ==="
 	PROJECTS="${COMPILE_PROJECTS},${ASSEMBLY_PROJECTS}"

--- a/tools/packages/opennms/opennms.spec
+++ b/tools/packages/opennms/opennms.spec
@@ -535,7 +535,7 @@ if [ "%{skip_compile}" = 1 ]; then
 		OPTS_UPDATE_POLICY="-DupdatePolicy=always"
 	fi
 	TOPDIR=`pwd`
-	"$TOPDIR"/compile.pl -N $OPTS_SKIP_TESTS $OPTS_SETTINGS_XML $OPTS_ENABLE_SNAPSHOTS $OPTS_UPDATE_POLICY -Dinstall.version="%{version}-%{release}" -Ddist.name="%{name}-%{version}-%{release}.%{_arch}" -Dopennms.home="%{instprefix}" install --builder smart --threads ${CCI_MAXCPU:-2}
+	"$TOPDIR"/compile.pl -N $OPTS_SKIP_TESTS $OPTS_SETTINGS_XML $OPTS_ENABLE_SNAPSHOTS $OPTS_UPDATE_POLICY -PskipCompile -Dinstall.version="%{version}-%{release}" -Ddist.name="%{name}-%{version}-%{release}.%{_arch}" -Dopennms.home="%{instprefix}" install --builder smart --threads ${CCI_MAXCPU:-2}
 else
 	echo "=== RUNNING COMPILE ==="
 	./compile.pl $OPTS_SKIP_TESTS $OPTS_SETTINGS_XML $OPTS_ENABLE_SNAPSHOTS $OPTS_UPDATE_POLICY -Dbuild=all -Dinstall.version="%{version}-%{release}" -Ddist.name="%{name}-%{version}-%{release}.%{_arch}" \

--- a/tools/packages/sentinel/create-sentinel-assembly.sh
+++ b/tools/packages/sentinel/create-sentinel-assembly.sh
@@ -69,6 +69,7 @@ PROJECTS=""
 if [ $SKIP_COMPILE -eq 1 ]; then
 	echo "=== Compiling Assemblies ==="
 	PROJECTS="${ASSEMBLY_PROJECTS}"
+	OPTS_PROFILES="${OPTS_PROFILES} -PskipCompile"
 else
 	echo "=== Compiling Projects + Assemblies ==="
 	PROJECTS="${COMPILE_PROJECTS},${ASSEMBLY_PROJECTS}"


### PR DESCRIPTION
Here we update the build so that nodejs & yarn no longer run when building the RPM packages for OpenNMS/Minion/Sentinel - the artifacts are already available from the compile step.

We also add a script that will help us monitor JVM running the systems tests in order to help diagnose the intermittent "timeout due to no output" errors.
