### PR TITLE
NMS-12364: Collect and display file descriptor statistics via JMX for OpenNMS and Minion

### DIFF
--- a/opennms-base-assembly/src/main/filtered/etc/jmx-datacollection-config.d/minion.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/jmx-datacollection-config.d/minion.xml
@@ -14,6 +14,8 @@
                 <attrib name="TotalPhysicalMemorySize" alias="TotalMemory" type="gauge"/>
                 <attrib name="FreeSwapSpaceSize" alias="FreeSwapSpace" type="gauge"/>
                 <attrib name="TotalSwapSpaceSize" alias="TotalSwapSpace" type="gauge"/>
+                <attrib name="MaxFileDescriptorCount" alias="OsMaxFDCount" type="gauge"/>
+                <attrib name="OpenFileDescriptorCount" alias="OsOpenFDCount" type="gauge"/>
             </mbean>
             <mbean name="JVM Threading" objectname="java.lang:type=Threading">
                 <attrib name="ThreadCount" alias="ThreadCount" type="gauge"/>

--- a/opennms-base-assembly/src/main/filtered/etc/jmx-datacollection-config.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/jmx-datacollection-config.xml
@@ -94,6 +94,8 @@
             <attrib name="TotalPhysicalMemorySize" alias="TotalMemory" type="gauge"/>
             <attrib name="FreeSwapSpaceSize" alias="FreeSwapSpace" type="gauge"/>
             <attrib name="TotalSwapSpaceSize" alias="TotalSwapSpace" type="gauge"/>
+            <attrib name="MaxFileDescriptorCount" alias="OsMaxFDCount" type="gauge"/>
+            <attrib name="OpenFileDescriptorCount" alias="OsOpenFDCount" type="gauge"/>
          </mbean>
          <mbean name="JVM Threading" objectname="java.lang:type=Threading">
             <attrib name="ThreadCount" alias="ThreadCount" type="gauge"/>

--- a/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/opennms-jmx-fd-graph.properties
+++ b/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/opennms-jmx-fd-graph.properties
@@ -1,0 +1,31 @@
+reports=opennms.jmx.file-descriptor, opennms.jmx.file-descriptor.percentage
+
+report.opennms.jmx.file-descriptor.name=File Descriptors Usage
+report.opennms.jmx.file-descriptor.columns=OsMaxFDCount, OsOpenFDCount
+report.opennms.jmx.file-descriptor.type=interfaceSnmp
+report.opennms.jmx.file-descriptor.command=--title="File Descritors Usage" \
+ --vertical-label="# of FDs" \
+ DEF:max={rrd1}:OsMaxFDCount:AVERAGE \
+ DEF:used={rrd2}:OsOpenFDCount:AVERAGE \
+ LINE2:max#c4a000:"FD Max " \
+ GPRINT:max:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:max:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:max:MAX:" Max \\: %8.2lf %s\\n" \
+ AREA:used#8DC63F:"FD Used" \
+ GPRINT:used:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:used:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:used:MAX:" Max \\: %8.2lf %s\\n"
+
+report.opennms.jmx.file-descriptor.percentage.name=File Descriptors Usage in %
+report.opennms.jmx.file-descriptor.percentage.columns=OsMaxFDCount, OsOpenFDCount
+report.opennms.jmx.file-descriptor.percentage.type=interfaceSnmp
+report.opennms.jmx.file-descriptor.percentage.command=--title="File Descritors Usage in %" \
+ --vertical-label="Percentage" \
+ DEF:max={rrd1}:OsMaxFDCount:AVERAGE \
+ DEF:used={rrd2}:OsOpenFDCount:AVERAGE \
+ CDEF:perc=used,max,/,100,* \
+ AREA:perc#8DC63F:"FD Used %" \
+ GPRINT:perc:AVERAGE:" Avg \\: %8.2lf %s" \
+ GPRINT:perc:MIN:" Min \\: %8.2lf %s" \
+ GPRINT:perc:MAX:" Max \\: %8.2lf %s\\n"
+


### PR DESCRIPTION
The graphs have been tested on a lab environment and seem to be accurate with what you can get via `/proc`.

About the location of the metrics...

Unfortunately, it is not possible to define 2 different `mbean` tag associated with the same `objectname`. For this reason, the new 2 JMX attributes were added to the appropriate `mbean` even though the name of the `mbean` is now misleading (i.e. `JVM Memory`, where it should have been named like `JVM Operating System`).

Considering some hidden flags you can add to a `service` definition for a collection package when using the JMX collector and `storeByGroup` is enabled, it can be problematic to change the name of the `mbean`. For this reason, I left it as it is right now.

I'm targeting `foundation-2019` as this PR contains changes on the `etc` directory; although, it would be nice to have these graphs on M2018 or older.

### All Contributors

* [x] Have you read and followed our [Contribution Guidelines](https://github.com/OpenNMS/opennms/blob/develop/CONTRIBUTING.md)?
* [x] Have you [made an issue in the OpenNMS issue tracker](https://issues.opennms.org)?<br>If so, you should:
  1. update the title of this PR to be of the format: `${JIRA-ISSUE-NUMBER}: subject of pull request`
  2. update the JIRA link at the bottom of this comment to refer to the real issue number
  3. prefix your commit messages with the issue number, if possible
* [x] Have you made a comment in that issue which points back to this PR?
* [x] Have you updated the JIRA link at the bottom of this comment to link to your issue?
* [ ] If this is a new or updated feature, is there documentation for the new behavior?
* [ ] If this is new code, are there unit and/or integration tests?
* [ ] If this PR targets a `foundation-*` branch, does it avoid changing files in `$OPENNMS_HOME/etc/`?

### Pull Request Process

One or more reviewers should be assigned to each PR.

If you know that a particular person is subject matter expert in the area your PR affects, feel free to assign one or more reviewers when you create this PR, otherwise reviewers will be assigned for you.

Once the reviewer(s) accept the PR and the branch passes continuous integration in Bamboo, the PR is eligible for merge.

At that time, if you have commit access (are an OpenNMS Group employee or a member of the Order of the Green Polo) you are welcome to merge the PR.
Otherwise, a reviewer can merge it for you.

Thanks for taking time to contribute!

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-12364
* Bamboo (Continuous Integration): https://bamboo.opennms.org/

