### PR TITLE
NMS-12367: Update Drools dependency to 7.18.0

### DIFF
--- a/container/features/src/main/resources/features.xml
+++ b/container/features/src/main/resources/features.xml
@@ -1133,7 +1133,7 @@
     <feature name="opennms-kafka-producer" description="OpenNMS :: Kafka :: Producer" version="${project.version}">
       <feature version="${guavaVersion}">guava</feature>
       <feature version="${kafkaStreamsVersion}">kafka-streams</feature>
-      <bundle>mvn:com.google.protobuf/protobuf-java/${protobuf3Version}</bundle>
+      <bundle>mvn:com.google.protobuf/protobuf-java/${protobufVersion}</bundle>
       <bundle>mvn:org.opennms.features.kafka/org.opennms.features.kafka.producer/${project.version}</bundle>
     </feature>
 

--- a/dependencies/drools/pom.xml
+++ b/dependencies/drools/pom.xml
@@ -15,7 +15,7 @@
     can depend on to use the drools library.
   </description>
   <properties>
-    <droolsVersion>7.8.0.Final</droolsVersion>
+    <droolsVersion>7.18.0.Final</droolsVersion>
   </properties>
   <dependencies>
     <dependency>

--- a/dependencies/drools/pom.xml
+++ b/dependencies/drools/pom.xml
@@ -15,7 +15,7 @@
     can depend on to use the drools library.
   </description>
   <properties>
-    <droolsVersion>7.7.0.Final</droolsVersion>
+    <droolsVersion>7.8.0.Final</droolsVersion>
   </properties>
   <dependencies>
     <dependency>

--- a/features/kafka/producer/pom.xml
+++ b/features/kafka/producer/pom.xml
@@ -85,7 +85,6 @@
     <dependency>
       <groupId> com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
-      <version>${protobuf3Version}</version>
     </dependency>
     <dependency>
       <groupId>org.opennms</groupId>

--- a/opennms-base-assembly/src/main/filtered/etc/examples/drools-engine.d/nodeParentRules/NodeParentRules.drl
+++ b/opennms-base-assembly/src/main/filtered/etc/examples/drools-engine.d/nodeParentRules/NodeParentRules.drl
@@ -35,7 +35,7 @@ rule "possibleCauses"
 	then
 		Long $parentNode = nodeService.getParentNode( $cause );
 		if ( $parentNode != null ) {
-			Cause $parent = possibleCause( engine, $parentNode, $e, POLL_INTERVAL );
+			Cause $parent = createPossibleCause( engine, $parentNode, $e, POLL_INTERVAL );
 			$parent.addImpacted( $c );
 			println( "No Cause for parent. Asserting: " + $parent );
 			insert( $parent );
@@ -66,7 +66,7 @@ rule "resolveIssue"
 		retract( $up );
 end
 
-function Cause possibleCause( DroolsCorrelationEngine engine, Long nodeId, Event symptom, Long POLL_INTERVAL ) {
+function Cause createPossibleCause( DroolsCorrelationEngine engine, Long nodeId, Event symptom, Long POLL_INTERVAL ) {
 	return new Cause( Type.POSSIBLE, nodeId, symptom, engine.setTimer( POLL_INTERVAL ) );
 }
 

--- a/opennms-correlation/drools-correlation-engine/src/test/java/org/opennms/netmgt/correlation/drools/DroolsCorrelationEngineBuilderIT.java
+++ b/opennms-correlation/drools-correlation-engine/src/test/java/org/opennms/netmgt/correlation/drools/DroolsCorrelationEngineBuilderIT.java
@@ -77,7 +77,7 @@ public class DroolsCorrelationEngineBuilderIT implements InitializingBean {
     public void testIt() throws Exception {
         Collection<CorrelationEngine> engines = m_mockCorrelator.getEngines();
         assertNotNull(engines);
-        assertEquals(7, m_mockCorrelator.getEngines().size());
+        assertEquals(8, m_mockCorrelator.getEngines().size());
         assertTrue(engines.iterator().next() instanceof DroolsCorrelationEngine);
         assertTrue(m_mockCorrelator.findEngineByName("locationMonitorRules") instanceof DroolsCorrelationEngine);
         DroolsCorrelationEngine engine = (DroolsCorrelationEngine) m_mockCorrelator.findEngineByName("locationMonitorRules");

--- a/opennms-correlation/drools-correlation-engine/src/test/java/org/opennms/netmgt/correlation/drools/FromModifyTest.java
+++ b/opennms-correlation/drools-correlation-engine/src/test/java/org/opennms/netmgt/correlation/drools/FromModifyTest.java
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2007-2014 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.correlation.drools;
+
+import static org.easymock.EasyMock.expect;
+import static org.junit.Assert.assertEquals;
+
+import org.drools.core.common.InternalFactHandle;
+import org.junit.Test;
+import org.kie.api.definition.type.FactType;
+import org.opennms.netmgt.events.api.EventConstants;
+import org.opennms.netmgt.model.events.EventBuilder;
+import org.opennms.netmgt.xml.event.Event;
+import org.opennms.test.mock.EasyMockUtils;
+
+public class FromModifyTest extends CorrelationRulesTestCase {
+    @Test
+    public void testMultipleRulesWithFromConstraintsAndModifyConsequences() throws Exception {
+        DroolsCorrelationEngine engine = findEngineByName("fromWithModifyRules");
+        FactType testFactType = engine.getKieSession().getKieBase()
+                .getFactType("org.opennms.netmgt.correlation.drools", "FromModifyTestFact");
+        Object testFact = testFactType.newInstance();
+        testFactType.set(testFact,"modified", "false");
+        testFactType.set(testFact,"modifiedByRule", "");
+
+        engine.getKieSession().insert(testFact);
+        engine.getKieSession().fireAllRules();
+
+        m_anticipatedMemorySize = 1;
+        Object modifiedFact = ((InternalFactHandle) engine.getKieSession().getFactHandles().iterator().next()).getObject();
+        assertEquals("FromModifyTestFact has the wrong 'modified' value", "true", testFactType.get(modifiedFact, "modified"));
+        assertEquals("FromModifyTestFact has the wrong 'modifiedByRule' value", "A",
+                testFactType.get(modifiedFact, "modifiedByRule"));
+        verify(engine);
+    }
+}

--- a/opennms-correlation/drools-correlation-engine/src/test/opennms-home/etc/drools-engine.d/fromWithModifyRules/FromWithModifyRules.drl
+++ b/opennms-correlation/drools-correlation-engine/src/test/opennms-home/etc/drools-engine.d/fromWithModifyRules/FromWithModifyRules.drl
@@ -1,0 +1,39 @@
+package org.opennms.netmgt.correlation.drools
+
+import org.opennms.netmgt.correlation.drools.DroolsCorrelationEngine;
+
+global org.opennms.netmgt.correlation.drools.DroolsCorrelationEngine engine;
+
+declare FromModifyTestFact
+  modified : String
+  modifiedByRule : String
+end
+  
+rule "fromModify Rule A"
+	salience 100
+	when
+		$fact : FromModifyTestFact()
+		FromModifyTestFact(modified == "false", modifiedByRule == "", $mbr : modifiedByRule) from $fact
+	then
+		modify($fact) { setModified("true"), setModifiedByRule($mbr + "A") };
+		System.out.println( "Rule A modified test fact: "+$fact );
+end
+
+rule "fromModify Rule B"
+	salience 90
+	when
+		$fact : FromModifyTestFact()
+		FromModifyTestFact(modified == "false", modifiedByRule == "", $mbr : modifiedByRule) from $fact
+	then
+		modify($fact) { setModified("true"), setModifiedByRule($mbr + "B") };
+		System.out.println( "Rule B modified test fact: "+$fact );
+end
+
+rule "fromModify Rule C"
+	salience 90
+	when
+		$fact : FromModifyTestFact(modified == "false", modifiedByRule == "", $mbr : modifiedByRule)
+	then
+		modify($fact) { setModified("true"), setModifiedByRule($mbr + "C") };
+		System.out.println( "Rule C modified test fact: "+$fact );
+end

--- a/opennms-correlation/drools-correlation-engine/src/test/opennms-home/etc/drools-engine.d/fromWithModifyRules/drools-engine.xml
+++ b/opennms-correlation/drools-correlation-engine/src/test/opennms-home/etc/drools-engine.d/fromWithModifyRules/drools-engine.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<engine-configuration 
+	xmlns="http://xmlns.opennms.org/xsd/drools-engine" 
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <rule-set name="fromWithModifyRules">
+    <rule-file>FromWithModifyRules.drl</rule-file>
+    <event>uei.opennms.org/nodes/nodeDown</event>
+    <event>uei.opennms.org/nodes/nodeUp</event>
+    <app-context>fromWithModifyRules-context.xml</app-context>
+  </rule-set>
+</engine-configuration>

--- a/opennms-correlation/drools-correlation-engine/src/test/opennms-home/etc/drools-engine.d/fromWithModifyRules/fromWithModifyRules-context.xml
+++ b/opennms-correlation/drools-correlation-engine/src/test/opennms-home/etc/drools-engine.d/fromWithModifyRules/fromWithModifyRules-context.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+ 		xmlns:tx="http://www.springframework.org/schema/tx"
+		xsi:schemaLocation="http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans-4.2.xsd
+        http://www.springframework.org/schema/tx
+        http://www.springframework.org/schema/tx/spring-tx-4.2.xsd">
+        
+</beans>

--- a/opennms-correlation/drools-correlation-engine/src/test/opennms-home/etc/drools-engine.d/nodeParentRules/NodeParentRules.drl
+++ b/opennms-correlation/drools-correlation-engine/src/test/opennms-home/etc/drools-engine.d/nodeParentRules/NodeParentRules.drl
@@ -3,6 +3,7 @@ package org.opennms.netmgt.correlation.drools
 import java.util.Date;
 
 import org.opennms.netmgt.correlation.drools.DroolsCorrelationEngine;
+import org.opennms.netmgt.correlation.drools.Cause;
 import org.opennms.netmgt.correlation.drools.Cause.Type;
 import org.opennms.netmgt.xml.event.Event;
 import org.opennms.netmgt.model.events.EventBuilder;
@@ -34,7 +35,7 @@ rule "possibleCauses"
 	then
 		Long $parentNode = nodeService.getParentNode( $cause );
 		if ( $parentNode != null ) {
-			Cause $parent = possibleCause( engine, $parentNode, $e, POLL_INTERVAL );
+			Cause $parent = createPossibleCause( engine, $parentNode, $e, POLL_INTERVAL );
 			$parent.addImpacted( $c );
 			println( "No Cause for parent. Asserting: " + $parent );
 			insert( $parent );
@@ -65,7 +66,7 @@ rule "resolveIssue"
 		retract( $up );
 end
 
-function Cause possibleCause( DroolsCorrelationEngine engine, Long nodeId, Event symptom, Long POLL_INTERVAL ) {
+function Cause createPossibleCause( DroolsCorrelationEngine engine, Long nodeId, Event symptom, Long POLL_INTERVAL ) {
 	return new Cause( Type.POSSIBLE, nodeId, symptom, engine.setTimer( POLL_INTERVAL ) );
 }
 

--- a/opennms-correlation/drools-correlation-engine/src/test/opennms-home/etc/drools-engine.d/nodeParentRules/NodeParentRules.drl
+++ b/opennms-correlation/drools-correlation-engine/src/test/opennms-home/etc/drools-engine.d/nodeParentRules/NodeParentRules.drl
@@ -7,9 +7,9 @@ import org.opennms.netmgt.correlation.drools.Cause;
 import org.opennms.netmgt.correlation.drools.Cause.Type;
 import org.opennms.netmgt.xml.event.Event;
 import org.opennms.netmgt.model.events.EventBuilder;
+import org.opennms.netmgt.model.events.EventUtils;
 import org.opennms.netmgt.events.api.EventConstants;
 import org.drools.core.spi.KnowledgeHelper;
-import org.opennms.netmgt.model.events.EventUtils;
 
 global org.opennms.netmgt.correlation.drools.DroolsCorrelationEngine engine;
 global org.opennms.netmgt.correlation.drools.NodeService nodeService;


### PR DESCRIPTION
The 'From with modify fires unexpected rule' bug appears to be fixed in Drools 7.8.0.
Comparing 'mvn dependency:list' does not indicate any transitive dependency impact.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-12367
* Bamboo (Continuous Integration): https://bamboo.opennms.org/

