### PR TITLE
Fix for Bug NMS-12360 - Part II

### DIFF
--- a/core/web-assets/src/main/assets/js/apps/onms-requisitions/lib/scripts/services/Requisitions.js
+++ b/core/web-assets/src/main/assets/js/apps/onms-requisitions/lib/scripts/services/Requisitions.js
@@ -409,7 +409,8 @@ const RequisitionNode  = require('../model/RequisitionNode');
     /**
     * @description Updates the requisition object with the deployed statistics.
     *
-    * After retrieving the data, the provided object will be updated.
+    * After retrieving the data successfully, the provided object will be updated.
+    * Otherwise, the provided object will be returned unmodified, and this includes HTTP errors.
     *
     * @name RequisitionsService:updateDeployedStatsForRequisition
     * @ngdoc method
@@ -428,7 +429,7 @@ const RequisitionNode  = require('../model/RequisitionNode');
       })
       .error(function(error, status) {
         $log.error('updateDeployedStatsForRequisition: GET ' + url + ' failed:', error, status);
-        deferred.reject('Cannot retrieve the deployed statistics for requisition ' + existingReq.foreignSource + '. ' + requisitionsService.internal.errorHelp);
+        deferred.resolve(existingReq);
       });
       return deferred.promise;
     };
@@ -462,16 +463,13 @@ const RequisitionNode  = require('../model/RequisitionNode');
         const req = new Requisition(data);
         $log.debug('getRequisition: got requisition ' + foreignSource);
         requisitionsService.updateDeployedStatsForRequisition(req).then(
-          function() { // success;
+          function(updatedReq) { // success;
             const requisitionsData = requisitionsService.internal.getCachedRequisitionsData();
             if (requisitionsData) {
               $log.debug('getRequisition: updating cache for requisition ' + foreignSource);
-              requisitionsData.setRequisition(req);
+              requisitionsData.setRequisition(updatedReq);
             }
-            deferred.resolve(req);
-          },
-          function(error) { // error
-            deferred.reject(error);
+            deferred.resolve(updatedReq);
           }
         );
       })


### PR DESCRIPTION
@RangerRick observed an unexpected problem when running the smoke tests with the original solution, hence the need to add some defensive code to keep the solution and avoiding side effects.

When requesting the requisition statistics for a given requisition, the end-point will return an error if the requisition doesn't exist. That is not the case when requesting all the stats, as that would return an empty array.

Because the requisition must be updated with the statistics only when they are available, the code was slightly modified to silently fail when there are errors retrieving the stats, meaning the code can continue with the requisition it already has preventing side effects.

### All Contributors

* [x] Have you read and followed our [Contribution Guidelines](https://github.com/OpenNMS/opennms/blob/develop/CONTRIBUTING.md)?
* [x] Have you [made an issue in the OpenNMS issue tracker](https://issues.opennms.org)?<br>If so, you should:
  1. update the title of this PR to be of the format: `${JIRA-ISSUE-NUMBER}: subject of pull request`
  2. update the JIRA link at the bottom of this comment to refer to the real issue number
  3. prefix your commit messages with the issue number, if possible
* [x] Have you made a comment in that issue which points back to this PR?
* [x] Have you updated the JIRA link at the bottom of this comment to link to your issue?
* [ ] If this is a new or updated feature, is there documentation for the new behavior?
* [ ] If this is new code, are there unit and/or integration tests?
* [ ] If this PR targets a `foundation-*` branch, does it avoid changing files in `$OPENNMS_HOME/etc/`?

### Pull Request Process

One or more reviewers should be assigned to each PR.

If you know that a particular person is subject matter expert in the area your PR affects, feel free to assign one or more reviewers when you create this PR, otherwise reviewers will be assigned for you.

Once the reviewer(s) accept the PR and the branch passes continuous integration in Bamboo, the PR is eligible for merge.

At that time, if you have commit access (are an OpenNMS Group employee or a member of the Order of the Green Polo) you are welcome to merge the PR.
Otherwise, a reviewer can merge it for you.

Thanks for taking time to contribute!

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-12360
* Bamboo (Continuous Integration): https://bamboo.opennms.org/

