### PR TITLE
NMS-12398: Use build environment just with OpenJDK 8 Development

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 executors:
   build-executor:
     docker:
-      - image: opennms/build-env:jdk8-jdk11-3.6.2-b2942
+      - image: opennms/build-env:1.8.0.232.b09-3.6.2-b3291
   integration-test-executor:
     machine: true
   smoke-test-executor:


### PR DESCRIPTION
### All Contributors

* [ ] Have you read and followed our [Contribution Guidelines](https://github.com/OpenNMS/opennms/blob/develop/CONTRIBUTING.md)?
* [ ] Have you [made an issue in the OpenNMS issue tracker](https://issues.opennms.org)?<br>If so, you should:
  1. update the title of this PR to be of the format: `${JIRA-ISSUE-NUMBER}: subject of pull request`
  2. update the JIRA link at the bottom of this comment to refer to the real issue number
  3. prefix your commit messages with the issue number, if possible
* [ ] Have you made a comment in that issue which points back to this PR?
* [ ] Have you updated the JIRA link at the bottom of this comment to link to your issue?
* [ ] If this is a new or updated feature, is there documentation for the new behavior?
* [ ] If this is new code, are there unit and/or integration tests?
* [ ] If this PR targets a `foundation-*` branch, does it avoid changing files in `$OPENNMS_HOME/etc/`?

We have removed the JRE 11 dependencies during build in our RPM spec files. We can now use the JDK 8 only build environment.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-12398
* Bamboo (Continuous Integration): https://bamboo.opennms.org/

