### PR TITLE
Perform code coverage weekly instead of nightly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -275,10 +275,11 @@ commands:
           destination: generated-tests
 
 workflows:
-  nightly-coverage:
+  weekly-coverage:
     triggers:
       - schedule:
-          cron: "0 0 * * *"
+          # Saturday at 12:00 AM
+          cron: "0 0 * * 5"
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -279,7 +279,7 @@ workflows:
     triggers:
       - schedule:
           # Saturday at 12:00 AM
-          cron: "0 0 * * 5"
+          cron: "0 0 * * 6"
           filters:
             branches:
               only:


### PR DESCRIPTION
Code coverage is currently performed nightly and made available here:
  https://sonarcloud.io/dashboard?id=OpenNMS_opennms

I don't think we use it enough to justify running nightly, I propose we switch this to weekly instead.