### PR TITLE
Be more restrictive about namespace and container id definition

### DIFF
--- a/features/graph/api/src/main/java/org/opennms/netmgt/graph/api/generic/GenericElement.java
+++ b/features/graph/api/src/main/java/org/opennms/netmgt/graph/api/generic/GenericElement.java
@@ -32,6 +32,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
+import org.opennms.netmgt.graph.api.validation.NamespaceValidator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -50,7 +51,7 @@ public abstract class GenericElement {
     protected GenericElement (Map<String, Object> properties) {
         Objects.requireNonNull(properties);
         this.properties = ImmutableMap.copyOf(properties);
-        Objects.requireNonNull(getNamespace(), "namespace cannot be null");
+        new NamespaceValidator().validate(getNamespace());
     }
 
     public <T> T getProperty(String key) {
@@ -100,6 +101,7 @@ public abstract class GenericElement {
     
     public static abstract class GenericElementBuilder<T extends GenericElementBuilder> {
     	protected final Map<String, Object> properties = new HashMap<>();
+    	protected final NamespaceValidator namespaceValidator = new NamespaceValidator();
     	
         protected GenericElementBuilder() {}
     	
@@ -123,6 +125,10 @@ public abstract class GenericElement {
             if(name == null || value == null) {
                 LOG.debug("Property name ({}) or value ({}) is null => ignoring it.", name, value);
                 return (T) this;
+            }
+            // Ensure the namespace is valid before changing it
+            if (GenericProperties.NAMESPACE.equals(name)) {
+                namespaceValidator.validate((String) value);
             }
             properties.put(name, value);
             return (T) this;

--- a/features/graph/api/src/main/java/org/opennms/netmgt/graph/api/generic/GenericGraphContainer.java
+++ b/features/graph/api/src/main/java/org/opennms/netmgt/graph/api/generic/GenericGraphContainer.java
@@ -39,6 +39,7 @@ import java.util.stream.Collectors;
 import org.opennms.netmgt.graph.api.ImmutableGraphContainer;
 import org.opennms.netmgt.graph.api.info.GraphContainerInfo;
 import org.opennms.netmgt.graph.api.info.GraphInfo;
+import org.opennms.netmgt.graph.api.validation.GraphContainerIdValidator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -53,7 +54,7 @@ public class GenericGraphContainer implements ImmutableGraphContainer<GenericGra
     private GenericGraphContainer(GenericGraphContainerBuilder builder) {
         this.properties = ImmutableMap.copyOf(builder.properties);
         this.graphs = ImmutableList.copyOf(builder.graphs.values().stream().sorted(Comparator.comparing(GenericGraph::getNamespace)).collect(Collectors.toList()));
-        Objects.requireNonNull(getId(), "id cannot be null.");
+        new GraphContainerIdValidator().validate(getId());
     }
     
     @Override
@@ -162,6 +163,9 @@ public class GenericGraphContainer implements ImmutableGraphContainer<GenericGra
             if(name == null || value == null) {
                 LOG.debug("Property name ({}) or value ({}) is null => ignoring it.", name, value);
                 return this;
+            }
+            if (GenericProperties.ID.equals(name)) {
+                new GraphContainerIdValidator().validate((String) value);
             }
             properties.put(name, value);
             return this;

--- a/features/graph/api/src/main/java/org/opennms/netmgt/graph/api/info/GraphInfo.java
+++ b/features/graph/api/src/main/java/org/opennms/netmgt/graph/api/info/GraphInfo.java
@@ -38,8 +38,6 @@ import org.opennms.netmgt.graph.api.Vertex;
  */
 public interface GraphInfo<V extends Vertex> {
 
-    // TODO MVR ensure namespace does not contain spaces and weird characters (only a-z0-9-_.) should be allowed
-    // TODO MVR same is true for vertex,edge and container (the same may be true for id of those elements)
     /** The namespace of the graph. Should be unique overall Graphs */
     String getNamespace();
 

--- a/features/graph/api/src/main/java/org/opennms/netmgt/graph/api/validation/GraphContainerIdValidator.java
+++ b/features/graph/api/src/main/java/org/opennms/netmgt/graph/api/validation/GraphContainerIdValidator.java
@@ -1,7 +1,7 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * Copyright (C) 2019-2019 The OpenNMS Group, Inc.
  * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
@@ -26,25 +26,28 @@
  *     http://www.opennms.com/
  *******************************************************************************/
 
-package org.opennms.netmgt.graph.api.generic;
+package org.opennms.netmgt.graph.api.validation;
 
-import static org.opennms.core.test.OnmsAssert.assertThrowsException;
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
-import org.junit.Test;
-import org.opennms.netmgt.graph.api.validation.exception.InvalidNamespaceException;
+import org.opennms.netmgt.graph.api.validation.exception.InvalidGraphContainerIdException;
 
-public class GenericVertexTest {
+import com.google.common.base.Strings;
 
-    @Test
-    public void genericVertexMustHaveANamespaceAndId() {
-        GenericVertex.builder().namespace("not-null").id("not-null"); // should throw no exception
-        assertThrowsException(NullPointerException.class, ()-> GenericVertex.builder().namespace(null).id(null).build());
-        assertThrowsException(NullPointerException.class, ()-> GenericVertex.builder().namespace("not-null").id(null).build());
-        assertThrowsException(NullPointerException.class, ()-> GenericVertex.builder().namespace(null).id("not-null").build());
-    }
+public class GraphContainerIdValidator {
 
-    @Test
-    public void verifyCannotSetInvalidNamespace() {
-        assertThrowsException(InvalidNamespaceException.class, () -> GenericVertex.builder().namespace("$invalid$").build());
+    private static final Pattern PATTERN = Pattern.compile(NamespaceValidator.REG_EXP);
+
+    public void validate(String containerId) {
+        Objects.requireNonNull(containerId);
+        if (Strings.isNullOrEmpty(containerId)) {
+            throw new InvalidGraphContainerIdException("Id of container must nut be empty or null");
+        }
+        final Matcher matcher = PATTERN.matcher(containerId);
+        if (!matcher.matches()) {
+            throw new InvalidGraphContainerIdException(NamespaceValidator.REG_EXP, containerId);
+        }
     }
 }

--- a/features/graph/api/src/main/java/org/opennms/netmgt/graph/api/validation/NamespaceValidator.java
+++ b/features/graph/api/src/main/java/org/opennms/netmgt/graph/api/validation/NamespaceValidator.java
@@ -1,7 +1,7 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * Copyright (C) 2019-2019 The OpenNMS Group, Inc.
  * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
@@ -26,25 +26,27 @@
  *     http://www.opennms.com/
  *******************************************************************************/
 
-package org.opennms.netmgt.graph.api.generic;
+package org.opennms.netmgt.graph.api.validation;
 
-import static org.opennms.core.test.OnmsAssert.assertThrowsException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
-import org.junit.Test;
 import org.opennms.netmgt.graph.api.validation.exception.InvalidNamespaceException;
 
-public class GenericVertexTest {
+import com.google.common.base.Strings;
 
-    @Test
-    public void genericVertexMustHaveANamespaceAndId() {
-        GenericVertex.builder().namespace("not-null").id("not-null"); // should throw no exception
-        assertThrowsException(NullPointerException.class, ()-> GenericVertex.builder().namespace(null).id(null).build());
-        assertThrowsException(NullPointerException.class, ()-> GenericVertex.builder().namespace("not-null").id(null).build());
-        assertThrowsException(NullPointerException.class, ()-> GenericVertex.builder().namespace(null).id("not-null").build());
-    }
+public class NamespaceValidator {
 
-    @Test
-    public void verifyCannotSetInvalidNamespace() {
-        assertThrowsException(InvalidNamespaceException.class, () -> GenericVertex.builder().namespace("$invalid$").build());
+    protected static final String REG_EXP = "^[a-zA-Z0-9]+([.:\\-_]?[a-zA-Z0-9]*)*$";
+    private static final Pattern PATTERN = Pattern.compile(REG_EXP);
+
+    public void validate(String namespace) {
+        if (Strings.isNullOrEmpty(namespace)) {
+            throw new InvalidNamespaceException("Namespace must not be null or empty");
+        }
+        final Matcher matcher = PATTERN.matcher(namespace);
+        if (!matcher.matches()) {
+            throw new InvalidNamespaceException(REG_EXP, namespace);
+        }
     }
 }

--- a/features/graph/api/src/main/java/org/opennms/netmgt/graph/api/validation/exception/InvalidGraphContainerIdException.java
+++ b/features/graph/api/src/main/java/org/opennms/netmgt/graph/api/validation/exception/InvalidGraphContainerIdException.java
@@ -1,7 +1,7 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * Copyright (C) 2019-2019 The OpenNMS Group, Inc.
  * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
@@ -26,25 +26,14 @@
  *     http://www.opennms.com/
  *******************************************************************************/
 
-package org.opennms.netmgt.graph.api.generic;
+package org.opennms.netmgt.graph.api.validation.exception;
 
-import static org.opennms.core.test.OnmsAssert.assertThrowsException;
-
-import org.junit.Test;
-import org.opennms.netmgt.graph.api.validation.exception.InvalidNamespaceException;
-
-public class GenericVertexTest {
-
-    @Test
-    public void genericVertexMustHaveANamespaceAndId() {
-        GenericVertex.builder().namespace("not-null").id("not-null"); // should throw no exception
-        assertThrowsException(NullPointerException.class, ()-> GenericVertex.builder().namespace(null).id(null).build());
-        assertThrowsException(NullPointerException.class, ()-> GenericVertex.builder().namespace("not-null").id(null).build());
-        assertThrowsException(NullPointerException.class, ()-> GenericVertex.builder().namespace(null).id("not-null").build());
+public class InvalidGraphContainerIdException extends RuntimeException {
+    public InvalidGraphContainerIdException(String message) {
+        super(message);
     }
 
-    @Test
-    public void verifyCannotSetInvalidNamespace() {
-        assertThrowsException(InvalidNamespaceException.class, () -> GenericVertex.builder().namespace("$invalid$").build());
+    public InvalidGraphContainerIdException(String regExp, String containerId) {
+        this("Provided containerId '" + containerId + "' is not valid. It must match Regular Expression '" + regExp + "' but did not.");
     }
 }

--- a/features/graph/api/src/main/java/org/opennms/netmgt/graph/api/validation/exception/InvalidNamespaceException.java
+++ b/features/graph/api/src/main/java/org/opennms/netmgt/graph/api/validation/exception/InvalidNamespaceException.java
@@ -1,7 +1,7 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * Copyright (C) 2019-2019 The OpenNMS Group, Inc.
  * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
@@ -26,25 +26,15 @@
  *     http://www.opennms.com/
  *******************************************************************************/
 
-package org.opennms.netmgt.graph.api.generic;
+package org.opennms.netmgt.graph.api.validation.exception;
 
-import static org.opennms.core.test.OnmsAssert.assertThrowsException;
-
-import org.junit.Test;
-import org.opennms.netmgt.graph.api.validation.exception.InvalidNamespaceException;
-
-public class GenericVertexTest {
-
-    @Test
-    public void genericVertexMustHaveANamespaceAndId() {
-        GenericVertex.builder().namespace("not-null").id("not-null"); // should throw no exception
-        assertThrowsException(NullPointerException.class, ()-> GenericVertex.builder().namespace(null).id(null).build());
-        assertThrowsException(NullPointerException.class, ()-> GenericVertex.builder().namespace("not-null").id(null).build());
-        assertThrowsException(NullPointerException.class, ()-> GenericVertex.builder().namespace(null).id("not-null").build());
+public class InvalidNamespaceException extends RuntimeException {
+    public InvalidNamespaceException(String message) {
+        super(message);
     }
 
-    @Test
-    public void verifyCannotSetInvalidNamespace() {
-        assertThrowsException(InvalidNamespaceException.class, () -> GenericVertex.builder().namespace("$invalid$").build());
+    public InvalidNamespaceException(String regExp, String namespace) {
+        this("Provided namespace '" + namespace + "' is not valid. It must match Regular Expression '" + regExp + "' but did not.");
     }
+
 }

--- a/features/graph/api/src/test/java/org/opennms/netmgt/graph/api/generic/GenericEdgeTest.java
+++ b/features/graph/api/src/test/java/org/opennms/netmgt/graph/api/generic/GenericEdgeTest.java
@@ -32,6 +32,7 @@ import static org.opennms.core.test.OnmsAssert.assertThrowsException;
 
 import org.junit.Test;
 import org.opennms.netmgt.graph.api.VertexRef;
+import org.opennms.netmgt.graph.api.validation.exception.InvalidNamespaceException;
 
 public class GenericEdgeTest {
 
@@ -50,5 +51,15 @@ public class GenericEdgeTest {
         GenericEdge.builder().namespace(NAMESPACE).source(refWithOurNamespace1).target(refWithForeignNamespace1); // should throw no Exception
         GenericEdge.builder().namespace(NAMESPACE).source(refWithForeignNamespace1).target(refWithOurNamespace1); // should throw no Exception
         assertThrowsException(IllegalArgumentException.class, () -> GenericEdge.builder().namespace(NAMESPACE).source(refWithForeignNamespace1).target(refWithForeignNamespace2).build());
+    }
+
+    @Test
+    public void verifyCannotSetInvalidNamespace() {
+        final String namespace = "$invalid$";
+        assertThrowsException(InvalidNamespaceException.class, () -> GenericEdge.builder()
+                .namespace(namespace)
+                .source(new VertexRef(namespace,"v1"))
+                .target(new VertexRef(namespace, "v2"))
+                .build());
     }
 }

--- a/features/graph/api/src/test/java/org/opennms/netmgt/graph/api/generic/GenericGraphContainerTest.java
+++ b/features/graph/api/src/test/java/org/opennms/netmgt/graph/api/generic/GenericGraphContainerTest.java
@@ -1,7 +1,7 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * Copyright (C) 2019-2019 The OpenNMS Group, Inc.
  * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
@@ -31,20 +31,14 @@ package org.opennms.netmgt.graph.api.generic;
 import static org.opennms.core.test.OnmsAssert.assertThrowsException;
 
 import org.junit.Test;
-import org.opennms.netmgt.graph.api.validation.exception.InvalidNamespaceException;
+import org.opennms.netmgt.graph.api.validation.exception.InvalidGraphContainerIdException;
 
-public class GenericVertexTest {
-
+public class GenericGraphContainerTest {
     @Test
-    public void genericVertexMustHaveANamespaceAndId() {
-        GenericVertex.builder().namespace("not-null").id("not-null"); // should throw no exception
-        assertThrowsException(NullPointerException.class, ()-> GenericVertex.builder().namespace(null).id(null).build());
-        assertThrowsException(NullPointerException.class, ()-> GenericVertex.builder().namespace("not-null").id(null).build());
-        assertThrowsException(NullPointerException.class, ()-> GenericVertex.builder().namespace(null).id("not-null").build());
-    }
-
-    @Test
-    public void verifyCannotSetInvalidNamespace() {
-        assertThrowsException(InvalidNamespaceException.class, () -> GenericVertex.builder().namespace("$invalid$").build());
+    public void verifyCannotSetInvalidContainerId() {
+        final String containerId = "$invalid$";
+        assertThrowsException(InvalidGraphContainerIdException.class, () -> GenericGraphContainer.builder()
+                .id(containerId)
+                .build());
     }
 }

--- a/features/graph/api/src/test/java/org/opennms/netmgt/graph/api/generic/GenericGraphTest.java
+++ b/features/graph/api/src/test/java/org/opennms/netmgt/graph/api/generic/GenericGraphTest.java
@@ -42,6 +42,7 @@ import org.opennms.netmgt.graph.api.VertexRef;
 import org.opennms.netmgt.graph.api.focus.Focus;
 import org.opennms.netmgt.graph.api.focus.FocusStrategy;
 import org.opennms.netmgt.graph.api.generic.GenericGraph.GenericGraphBuilder;
+import org.opennms.netmgt.graph.api.validation.exception.InvalidNamespaceException;
 
 import com.google.common.collect.Lists;
 
@@ -110,7 +111,7 @@ public class GenericGraphTest {
         GenericGraphBuilder graphBuilder = GenericGraph.builder();
         
         // 1.) set namespace on "empty graph" => shouldn't be a problem
-        graphBuilder.namespace("some namespace");
+        graphBuilder.namespace("some-namespace");
         graphBuilder.namespace(TestObjectCreator.NAMESPACE); // should be ok as long as we haven't added an edge
         
         // 2.) set same namespace on a filled graph => should be possible
@@ -192,5 +193,10 @@ public class GenericGraphTest {
 
         final GenericGraph emptyGraph = GenericGraph.builder().namespace(namespace).build();
         assertThat(emptyGraph.resolveVertices(nodeRef), Matchers.hasSize(0));
+    }
+
+    @Test
+    public void verifyCannotSetInvalidNamespace() {
+        assertThrowsException(InvalidNamespaceException.class, () -> GenericVertex.builder().namespace("$invalid$").build());
     }
 }

--- a/features/graph/api/src/test/java/org/opennms/netmgt/graph/api/validation/NamespaceValidatorTest.java
+++ b/features/graph/api/src/test/java/org/opennms/netmgt/graph/api/validation/NamespaceValidatorTest.java
@@ -1,0 +1,85 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019-2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.graph.api.validation;
+
+import java.util.List;
+
+import org.junit.Test;
+import org.opennms.core.test.OnmsAssert;
+import org.opennms.netmgt.graph.api.validation.exception.InvalidNamespaceException;
+
+import com.google.common.collect.Lists;
+
+public class NamespaceValidatorTest {
+
+    @Test
+    public void verifyIsValid() {
+        final NamespaceValidator validator = new NamespaceValidator();
+        final List<String> acceptableNamespaces = Lists.newArrayList(
+                "nodes",
+                "application",
+                "bsm",
+                "test",
+                "vmware",
+                "acme:markets",
+                "acme:regions",
+                "nodes.ldp",
+                "nodes.xyz",
+                "test-1",
+                "test-2",
+                "test-1.1",
+                "test_1.1",
+                "test_1.1-2:hello-world2017"
+        );
+        for (String eachNamespace : acceptableNamespaces) {
+            validator.validate(eachNamespace);
+        }
+    }
+
+    @Test
+    public void verifyIsNotValid() {
+        final NamespaceValidator validator = new NamespaceValidator();
+        final List<String> invalidNamespaces = Lists.newArrayList(
+                "",
+                null,
+                "acme markets",
+                "acme+markets",
+                "+",
+                "-",
+                "_",
+                "?",
+                "$",
+                "nodes$bridge"
+        );
+        for (String invalidNamespace : invalidNamespaces) {
+            OnmsAssert.assertThrowsException(InvalidNamespaceException.class, () -> validator.validate(invalidNamespace));
+        }
+    }
+
+}


### PR DESCRIPTION
Originally the namespace was not restricted. 
With the new Graph API it is now possible to retrieve the persisted graphs or graph containers via ReST. The container is accessed via the container id and the graph via it's namespace, e.g.

```
GET /api/v2/graphs/<containerId>
GET /api/v2/graphs/<containerId>/<namespace>
```

As the namespace is an internal identifier there is no need to allow a certain amount of characters, which in return allows users to not URL encode the namespace and container id for easier access of those.

Besides restricting the namespace/containerId to certain chars/numbers we are also a bit more restrictive when adding vertices/edges to the graph to ensure the namespace actually matches.