### PR TITLE
NMS-12396: Handle SNMP profiles by default in NodeScan

### DIFF
--- a/opennms-provision/opennms-provisiond/pom.xml
+++ b/opennms-provision/opennms-provisiond/pom.xml
@@ -157,5 +157,10 @@
       <artifactId>mockito-all</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.opennms.core.ipc.rpc</groupId>
+      <artifactId>org.opennms.core.ipc.rpc.api</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/opennms-provision/opennms-provisiond/src/main/java/org/opennms/netmgt/provision/service/DefaultProvisionService.java
+++ b/opennms-provision/opennms-provisiond/src/main/java/org/opennms/netmgt/provision/service/DefaultProvisionService.java
@@ -195,7 +195,7 @@ public class DefaultProvisionService implements ProvisionService, InitializingBe
     private LocationAwareSnmpClient m_locationAwareSnmpClient;
 
     @Autowired
-    private SnmpProfileMapper snmpProfileMapper;
+    private SnmpProfileMapper m_snmpProfileMapper;
 
     private final ThreadLocal<Map<String, OnmsServiceType>> m_typeCache = new ThreadLocal<Map<String, OnmsServiceType>>();
     private final ThreadLocal<Map<String, OnmsCategory>> m_categoryCache = new ThreadLocal<Map<String, OnmsCategory>>();
@@ -1405,7 +1405,11 @@ public class DefaultProvisionService implements ProvisionService, InitializingBe
     }
 
     public SnmpProfileMapper getSnmpProfileMapper() {
-        return snmpProfileMapper;
+        return m_snmpProfileMapper;
+    }
+
+    public void setSnmpProfileMapper(SnmpProfileMapper snmpProfileMapper) {
+        m_snmpProfileMapper = snmpProfileMapper;
     }
 
     @Override

--- a/opennms-provision/opennms-provisiond/src/main/java/org/opennms/netmgt/provision/service/NodeInfoScan.java
+++ b/opennms-provision/opennms-provisiond/src/main/java/org/opennms/netmgt/provision/service/NodeInfoScan.java
@@ -159,8 +159,7 @@ final class NodeInfoScan implements RunInBatch {
                 systemGroup.updateSnmpDataForNode(getNode());
             } catch (ExecutionException e) {
                 boolean succeeded = false;
-                if ((e.getCause() instanceof SnmpAgentTimeoutException ||
-                         e.getCause() instanceof SnmpException)) {
+                if (isSnmpRelatedException(e)) {
                     succeeded = peformScanWithMatchingProfile(agentConfig, primaryAddress);
                 }
                 if(!succeeded) {
@@ -202,6 +201,16 @@ final class NodeInfoScan implements RunInBatch {
             Thread.currentThread().interrupt();
         }
     }
+
+    static boolean isSnmpRelatedException(Exception e) {
+        // All the exceptions are converted to messages with
+        // RemoteExecutionException.toErrorMessage(Throwable e)
+        return e.getCause() instanceof SnmpException ||
+                e.getCause() instanceof SnmpAgentTimeoutException ||
+                e.getMessage().contains(SnmpException.class.getSimpleName()) ||
+                e.getMessage().contains(SnmpAgentTimeoutException.class.getSimpleName());
+    }
+
 
     private boolean isConfigValid(SnmpAgentConfig currentConfig, InetAddress address) {
         String profileLabel = currentConfig.getProfileLabel();

--- a/opennms-provision/opennms-provisiond/src/main/java/org/opennms/netmgt/provision/service/ProvisionService.java
+++ b/opennms-provision/opennms-provisiond/src/main/java/org/opennms/netmgt/provision/service/ProvisionService.java
@@ -244,4 +244,6 @@ public interface ProvisionService {
     LocationAwareDnsLookupClient getLocationAwareDnsLookupClient();
 
     SnmpProfileMapper getSnmpProfileMapper();
+
+    public void setSnmpProfileMapper(SnmpProfileMapper snmpProfileMapper);
 }

--- a/opennms-provision/opennms-provisiond/src/test/java/org/opennms/netmgt/provision/service/NodeInfoScanIT.java
+++ b/opennms-provision/opennms-provisiond/src/test/java/org/opennms/netmgt/provision/service/NodeInfoScanIT.java
@@ -178,7 +178,7 @@ public class NodeInfoScanIT {
     }
 
 
-    class MockScanProgress implements ScanProgress {
+    public static class MockScanProgress implements ScanProgress {
 
         @Override
         public void abort(String message) {
@@ -193,7 +193,7 @@ public class NodeInfoScanIT {
     /**
      * This returns wrong read-community so that default snmp walk fails
      **/
-    class ProxySnmpAgentConfigFactoryExtension extends ProxySnmpAgentConfigFactory {
+    static class ProxySnmpAgentConfigFactoryExtension extends ProxySnmpAgentConfigFactory {
 
         ProxySnmpAgentConfigFactoryExtension(InputStream config) throws FileNotFoundException {
             super(config);

--- a/opennms-provision/opennms-provisiond/src/test/java/org/opennms/netmgt/provision/service/NodeScanIT.java
+++ b/opennms-provision/opennms-provisiond/src/test/java/org/opennms/netmgt/provision/service/NodeScanIT.java
@@ -1,0 +1,171 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.provision.service;
+
+import static com.jayway.awaitility.Awaitility.await;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.joda.time.Duration;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.opennms.core.concurrent.PausibleScheduledThreadPoolExecutor;
+import org.opennms.core.snmp.profile.mapper.impl.SnmpProfileMapperImpl;
+import org.opennms.core.test.MockLogAppender;
+import org.opennms.core.test.OpenNMSJUnit4ClassRunner;
+import org.opennms.core.test.snmp.ProxySnmpAgentConfigFactory;
+import org.opennms.core.test.snmp.annotations.JUnitSnmpAgent;
+import org.opennms.netmgt.config.SnmpPeerFactory;
+import org.opennms.netmgt.dao.api.NodeDao;
+import org.opennms.netmgt.dao.mock.MockEventIpcManager;
+import org.opennms.netmgt.filter.api.FilterDao;
+import org.opennms.netmgt.model.OnmsNode;
+import org.opennms.netmgt.provision.persist.ForeignSourceRepository;
+import org.opennms.netmgt.provision.persist.MockForeignSourceRepository;
+import org.opennms.netmgt.provision.persist.foreignsource.ForeignSource;
+import org.opennms.netmgt.snmp.SnmpProfileMapper;
+import org.opennms.netmgt.snmp.proxy.LocationAwareSnmpClient;
+import org.opennms.test.JUnitConfigurationEnvironment;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.core.io.ResourceLoader;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+
+@RunWith(OpenNMSJUnit4ClassRunner.class)
+@ContextConfiguration(locations={
+        "classpath:/META-INF/opennms/applicationContext-soa.xml",
+        "classpath:/META-INF/opennms/applicationContext-mockDao.xml",
+        "classpath:/META-INF/opennms/applicationContext-daemon.xml",
+        "classpath:/META-INF/opennms/applicationContext-proxy-snmp.xml",
+        "classpath:/META-INF/opennms/mockEventIpcManager.xml",
+        "classpath:/META-INF/opennms/applicationContext-provisiond.xml",
+        "classpath:/META-INF/opennms/applicationContext-snmp-profile-mapper.xml",
+        "classpath*:/META-INF/opennms/provisiond-extensions.xml",
+        "classpath*:/META-INF/opennms/detectors.xml",
+        "classpath:/mockForeignSourceContext.xml",
+        "classpath:/importerServiceTest.xml"
+})
+@JUnitConfigurationEnvironment(systemProperties="org.opennms.provisiond.enableDiscovery=false")
+@DirtiesContext
+public class NodeScanIT {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ProvisionerRescanExistingFalseIT.class);
+
+    @Autowired
+    private MockEventIpcManager m_mockEventIpcManager;
+
+    @Autowired
+    private Provisioner m_provisioner;
+
+    @Autowired
+    private NodeDao m_nodeDao;
+
+    @Autowired
+    private ResourceLoader m_resourceLoader;
+
+    @Autowired
+    private ProvisionService m_provisionService;
+
+    @Autowired
+    @Qualifier("scheduledExecutor")
+    private PausibleScheduledThreadPoolExecutor m_scheduledExecutor;
+
+    private SnmpPeerFactory m_snmpPeerFactory;
+
+    private ForeignSourceRepository m_foreignSourceRepository;
+
+    private ForeignSource m_foreignSource;
+
+    @Before
+    public void setUp() throws Exception {
+        MockLogAppender.setupLogging(true, "ERROR");
+
+        m_foreignSource = new ForeignSource();
+        m_foreignSource.setName("noRescanOnImport");
+        m_foreignSource.setScanInterval(Duration.standardDays(1));
+        m_foreignSourceRepository = new MockForeignSourceRepository();
+        m_foreignSourceRepository.save(m_foreignSource);
+        m_foreignSourceRepository.flush();
+
+        m_provisionService.setForeignSourceRepository(m_foreignSourceRepository);
+        m_scheduledExecutor.pause();
+    }
+
+    @Test(timeout=60000)
+    @JUnitSnmpAgent(host="192.0.2.201", port=161, resource = "classpath:/snmpProfileTestData.properties")
+    public void testNodeScanWithSnmpProfiles() throws Exception {
+
+        // This has profiles with valid config.
+        URL url =  getClass().getResource("/snmp-config1.xml");
+        try (InputStream configStream = url.openStream()) {
+            SnmpPeerFactory snmpPeerFactory = new ProxySnmpAgentConfigFactory(configStream);
+            // This is to not override snmp-config from etc
+            SnmpPeerFactory.setFile(new File(url.getFile()));
+            m_provisioner.setAgentConfigFactory(snmpPeerFactory);
+            LocationAwareSnmpClient locationAwareSnmpClient = m_provisionService.getLocationAwareSnmpClient();
+            FilterDao filterDao = Mockito.mock(FilterDao.class);
+            when(filterDao.isValid(Mockito.anyString(), Mockito.contains("IPLIKE"))).thenReturn(true);
+            SnmpProfileMapper profileMapper = new SnmpProfileMapperImpl(filterDao, snmpPeerFactory, locationAwareSnmpClient);
+            m_provisionService.setSnmpProfileMapper(profileMapper);
+            m_provisioner.start();
+            m_provisioner.importModelFromResource(m_resourceLoader.getResource("classpath:/testScanWithoutSnmpService.xml"),
+                    Boolean.TRUE.toString());
+
+            final List<OnmsNode> nodes = getNodeDao().findAll();
+            assertEquals(1, nodes.size());
+            // Verify node and it's location.
+            OnmsNode node = nodes.get(0);
+            assertEquals("Hyderabad", node.getLocation().getLocationName());
+            assertEquals(1, node.getIpInterfaces().size());
+            m_scheduledExecutor.resume();
+            // Verify that snmp data is updated for the node i.e. means agent has been detected.
+            await().atMost(30, TimeUnit.SECONDS).until(node::getSysObjectId, is(".1.3.6.1.4.1.8072.3.2.255"));
+        }
+        m_scheduledExecutor.pause();
+    }
+
+
+
+    public NodeDao getNodeDao() {
+        return m_nodeDao;
+    }
+
+}

--- a/opennms-provision/opennms-provisiond/src/test/java/org/opennms/netmgt/provision/service/ProvisionerTest.java
+++ b/opennms-provision/opennms-provisiond/src/test/java/org/opennms/netmgt/provision/service/ProvisionerTest.java
@@ -38,8 +38,6 @@ import static org.mockito.Mockito.when;
 
 import java.net.InetAddress;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 

--- a/opennms-provision/opennms-provisiond/src/test/java/org/opennms/netmgt/provision/service/SnmpExceptionVaidatorTest.java
+++ b/opennms-provision/opennms-provisiond/src/test/java/org/opennms/netmgt/provision/service/SnmpExceptionVaidatorTest.java
@@ -1,0 +1,76 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.provision.service;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+
+import org.junit.Test;
+import org.opennms.core.rpc.api.RemoteExecutionException;
+import org.opennms.core.rpc.api.RequestTimedOutException;
+import org.opennms.core.utils.InetAddressUtils;
+import org.opennms.netmgt.snmp.SnmpAgentTimeoutException;
+import org.opennms.netmgt.snmp.SnmpException;
+
+public class SnmpExceptionVaidatorTest {
+
+
+    @Test
+    public void testSnmpException() {
+
+        SnmpException snmpException = new SnmpException(new IOException("Invalid config"));
+        String errorMessage = RemoteExecutionException.toErrorMessage(snmpException);
+        RemoteExecutionException remoteException = new RemoteExecutionException(errorMessage);
+        ExecutionException executionException = new ExecutionException(remoteException);
+        assertTrue(NodeInfoScan.isSnmpRelatedException(executionException));
+
+        SnmpAgentTimeoutException snmpAgentTimeoutException = new
+                SnmpAgentTimeoutException("snmp-walker", InetAddressUtils.getInetAddress("10.0.0.5"));
+        errorMessage = RemoteExecutionException.toErrorMessage(snmpAgentTimeoutException);
+        remoteException = new RemoteExecutionException(errorMessage);
+        executionException = new ExecutionException(remoteException);
+        assertTrue(NodeInfoScan.isSnmpRelatedException(executionException));
+
+        executionException = new ExecutionException(snmpException);
+        assertTrue(NodeInfoScan.isSnmpRelatedException(executionException));
+
+        remoteException = new RemoteExecutionException("invalid config");
+        executionException = new ExecutionException(remoteException);
+        assertFalse(NodeInfoScan.isSnmpRelatedException(executionException));
+
+        RequestTimedOutException timedOutException = new RequestTimedOutException(new TimeoutException());
+        executionException = new ExecutionException(timedOutException);
+        assertFalse(NodeInfoScan.isSnmpRelatedException(executionException));
+
+    }
+}

--- a/opennms-provision/opennms-provisiond/src/test/java/org/opennms/netmgt/provision/service/SnmpExceptionValidatorTest.java
+++ b/opennms-provision/opennms-provisiond/src/test/java/org/opennms/netmgt/provision/service/SnmpExceptionValidatorTest.java
@@ -42,12 +42,13 @@ import org.opennms.core.utils.InetAddressUtils;
 import org.opennms.netmgt.snmp.SnmpAgentTimeoutException;
 import org.opennms.netmgt.snmp.SnmpException;
 
-public class SnmpExceptionVaidatorTest {
+public class SnmpExceptionValidatorTest {
 
 
     @Test
-    public void testSnmpException() {
+    public void testSnmpRelatedException() {
 
+        // Any SnmpException and SnmpAgentTimeoutException are valid.
         SnmpException snmpException = new SnmpException(new IOException("Invalid config"));
         String errorMessage = RemoteExecutionException.toErrorMessage(snmpException);
         RemoteExecutionException remoteException = new RemoteExecutionException(errorMessage);
@@ -59,6 +60,10 @@ public class SnmpExceptionVaidatorTest {
         errorMessage = RemoteExecutionException.toErrorMessage(snmpAgentTimeoutException);
         remoteException = new RemoteExecutionException(errorMessage);
         executionException = new ExecutionException(remoteException);
+        assertTrue(NodeInfoScan.isSnmpRelatedException(executionException));
+
+        //Nested Snmp Exceptions are also valid.
+        executionException = new ExecutionException(snmpException);
         assertTrue(NodeInfoScan.isSnmpRelatedException(executionException));
 
         executionException = new ExecutionException(snmpException);

--- a/opennms-provision/opennms-provisiond/src/test/resources/requisition_snmp_primary_but_no_service.xml
+++ b/opennms-provision/opennms-provisiond/src/test/resources/requisition_snmp_primary_but_no_service.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<model-import xmlns="http://xmlns.opennms.org/xsd/config/model-import" date-stamp="2006-03-09T00:03:09" foreign-source="snmp">
+  <node node-label="david" parent-node-label="apknd" foreign-id="4243">
+    <interface ip-addr="198.51.100.201" status="1" snmp-primary="P" descr="Management interface">
+    </interface>
+    <category name="AC"/>
+    <category name="UK"/>
+    <category name="low"/>
+    <asset name="manufacturer" value="Dell" />
+    <asset name="operatingSystem" value="Windows Pi" />
+    <asset name="description" value="Large and/or In Charge" />
+  </node>
+</model-import>

--- a/opennms-provision/opennms-provisiond/src/test/resources/testScanWithoutSnmpService.xml
+++ b/opennms-provision/opennms-provisiond/src/test/resources/testScanWithoutSnmpService.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<model-import xmlns="http://xmlns.opennms.org/xsd/config/model-import" date-stamp="2006-03-09T00:03:09" foreign-source="noRescanOnImport">
+  <node node-label="a" foreign-id="1" location="Hyderabad">
+    <interface ip-addr="192.0.2.201" status="1" snmp-primary="P" descr="a-primary">
+    </interface>
+  </node>
+</model-import>


### PR DESCRIPTION
Since SNMPDetector doesn't support SNMP profiles yet, NodeScan skips the scanning node if the default config doesn't detect SNMP service. 
This PR fixes that by always trying to detect SNMP service using config from profiles.

Also fixes a bug related to RPC exceptions.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-12396
* JIRA (Issue Tracker): https://issues.opennms.org/browse/NMS-12399
* Bamboo (Continuous Integration): https://bamboo.opennms.org/

