### PR TITLE
NMS-12400: Check filter rules in poller-configuration.xml

### DIFF
--- a/features/poller/monitors/core/src/test/java/org/opennms/netmgt/poller/monitors/SmtpMonitorIT.java
+++ b/features/poller/monitors/core/src/test/java/org/opennms/netmgt/poller/monitors/SmtpMonitorIT.java
@@ -60,9 +60,10 @@ import org.springframework.test.context.ContextConfiguration;
  */
 @RunWith(OpenNMSJUnit4ClassRunner.class)
 @ContextConfiguration(locations = {"classpath:/META-INF/opennms/emptyContext.xml",
+        "classpath:/META-INF/opennms/applicationContext-mockDao.xml",
 		"classpath:/META-INF/opennms/applicationContext-commonConfigs.xml",
 		"classpath:/META-INF/opennms/applicationContext-minimal-conf.xml",
-		"classpath:/META-INF/opennms/applicationContext-soa.xml"})
+        "classpath:/META-INF/opennms/applicationContext-soa.xml"})
 @JUnitConfigurationEnvironment
 public class SmtpMonitorIT {
 

--- a/features/poller/monitors/core/src/test/java/org/opennms/netmgt/poller/monitors/SshMonitorIT.java
+++ b/features/poller/monitors/core/src/test/java/org/opennms/netmgt/poller/monitors/SshMonitorIT.java
@@ -49,7 +49,8 @@ import org.springframework.test.context.ContextConfiguration;
 
 @RunWith(OpenNMSJUnit4ClassRunner.class)
 @ContextConfiguration(locations = {"classpath:/META-INF/opennms/emptyContext.xml",
-		"classpath:/META-INF/opennms/applicationContext-commonConfigs.xml",
+        "classpath:/META-INF/opennms/applicationContext-mockDao.xml",
+        "classpath:/META-INF/opennms/applicationContext-commonConfigs.xml",
 		"classpath:/META-INF/opennms/applicationContext-minimal-conf.xml",
 		"classpath:/META-INF/opennms/applicationContext-soa.xml"})
 @JUnitConfigurationEnvironment

--- a/features/poller/monitors/core/src/test/java/org/opennms/netmgt/poller/monitors/SshMonitorIT.java
+++ b/features/poller/monitors/core/src/test/java/org/opennms/netmgt/poller/monitors/SshMonitorIT.java
@@ -51,8 +51,8 @@ import org.springframework.test.context.ContextConfiguration;
 @ContextConfiguration(locations = {"classpath:/META-INF/opennms/emptyContext.xml",
         "classpath:/META-INF/opennms/applicationContext-mockDao.xml",
         "classpath:/META-INF/opennms/applicationContext-commonConfigs.xml",
-		"classpath:/META-INF/opennms/applicationContext-minimal-conf.xml",
-		"classpath:/META-INF/opennms/applicationContext-soa.xml"})
+        "classpath:/META-INF/opennms/applicationContext-minimal-conf.xml",
+        "classpath:/META-INF/opennms/applicationContext-soa.xml"})
 @JUnitConfigurationEnvironment
 public class SshMonitorIT {
     public static final String HOST_TO_TEST = "127.0.0.1";

--- a/opennms-config/src/main/java/org/opennms/netmgt/config/PollerConfigFactory.java
+++ b/opennms-config/src/main/java/org/opennms/netmgt/config/PollerConfigFactory.java
@@ -80,6 +80,11 @@ public final class PollerConfigFactory extends PollerConfigManager {
     private long m_currentVersion = -1L;
 
     /**
+     * Poller config file
+     */
+    private static File m_pollerConfigFile;
+
+    /**
      * <p>Constructor for PollerConfigFactory.</p>
      *
      * @param currentVersion a long.
@@ -88,6 +93,17 @@ public final class PollerConfigFactory extends PollerConfigManager {
     public PollerConfigFactory(final long currentVersion, final InputStream stream) {
         super(stream);
         m_currentVersion = currentVersion;
+    }
+
+    private static File getPollerConfigFile() throws IOException {
+        if (m_pollerConfigFile == null) {
+            m_pollerConfigFile = ConfigFileConstants.getFile(ConfigFileConstants.POLLER_CONFIG_FILE_NAME);
+        }
+        return m_pollerConfigFile;
+    }
+
+    public static void setPollerConfigFile(final File pollerConfigFile) throws IOException {
+        m_pollerConfigFile = pollerConfigFile;
     }
 
     /**
@@ -105,7 +121,7 @@ public final class PollerConfigFactory extends PollerConfigManager {
             return;
         }
 
-        final File cfgFile = ConfigFileConstants.getFile(ConfigFileConstants.POLLER_CONFIG_FILE_NAME);
+        final File cfgFile = getPollerConfigFile();
 
         LOG.debug("init: config file path: {}", cfgFile.getPath());
 
@@ -184,7 +200,7 @@ public final class PollerConfigFactory extends PollerConfigManager {
             getWriteLock().lock();
             try {
                 final long timestamp = System.currentTimeMillis();
-                final File cfgFile = ConfigFileConstants.getFile(ConfigFileConstants.POLLER_CONFIG_FILE_NAME);
+                final File cfgFile = getPollerConfigFile();
                 LOG.debug("saveXml: saving config file at {}: {}", timestamp, cfgFile.getPath());
                 final Writer fileWriter = new OutputStreamWriter(new FileOutputStream(cfgFile), StandardCharsets.UTF_8);
                 fileWriter.write(xml);
@@ -206,7 +222,7 @@ public final class PollerConfigFactory extends PollerConfigManager {
     public void update() throws IOException {
         getWriteLock().lock();
         try {
-            final File cfgFile = ConfigFileConstants.getFile(ConfigFileConstants.POLLER_CONFIG_FILE_NAME);
+            final File cfgFile = getPollerConfigFile();
             if (cfgFile.lastModified() > m_currentVersion) {
                 m_currentVersion = cfgFile.lastModified();
                 LOG.debug("init: config file path: {}", cfgFile.getPath());

--- a/opennms-config/src/main/java/org/opennms/netmgt/config/PollerConfigManager.java
+++ b/opennms-config/src/main/java/org/opennms/netmgt/config/PollerConfigManager.java
@@ -77,6 +77,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Strings;
+import com.google.common.base.Throwables;
 
 /**
  * <p>Abstract PollerConfigManager class.</p>
@@ -468,6 +469,7 @@ abstract public class PollerConfigManager implements PollerConfig {
                     
                 } catch (final Throwable t) {
                     LOG.error("createPackageIpMap: failed to map package: {} to an IP List with filter \"{}\"", pkg.getName(), pkg.getFilter().getContent(), t);
+                    Throwables.propagate(t);
                 }
                 
             }

--- a/opennms-config/src/main/java/org/opennms/netmgt/config/PollerConfigManager.java
+++ b/opennms-config/src/main/java/org/opennms/netmgt/config/PollerConfigManager.java
@@ -469,7 +469,7 @@ abstract public class PollerConfigManager implements PollerConfig {
                     
                 } catch (final Throwable t) {
                     LOG.error("createPackageIpMap: failed to map package: {} to an IP List with filter \"{}\"", pkg.getName(), pkg.getFilter().getContent(), t);
-                    Throwables.propagate(t);
+                    throw Throwables.propagate(t);
                 }
                 
             }

--- a/opennms-config/src/test/resources/poller-configuration-valid1.xml
+++ b/opennms-config/src/test/resources/poller-configuration-valid1.xml
@@ -8,9 +8,6 @@
     <include-range begin="1.1.1.1" end="254.254.254.254" />
     <rrd step="300">
       <rra>RRA:AVERAGE:0.5:1:2016</rra>
-      <rra>RRA:AVERAGE:0.5:12:4464</rra>
-      <rra>RRA:MIN:0.5:12:4464</rra>
-      <rra>RRA:MAX:0.5:12:4464</rra>
     </rrd>
     <service name="ICMP" interval="300000" user-defined="false" status="on">
       <parameter key="retry" value="2" />
@@ -18,131 +15,11 @@
       <parameter key="rrd-repository" value="${install.share.dir}/rrd/response" />
       <parameter key="ds-name" value="icmp" />
     </service>
-    <service name="DNS" interval="300000" user-defined="false" status="on">
-      <parameter key="retry" value="2" />
-      <parameter key="timeout" value="5000" />
-      <parameter key="port" value="53" />
-      <parameter key="lookup" value="localhost" />
-      <parameter key="rrd-repository" value="${install.share.dir}/rrd/response" />
-      <parameter key="ds-name" value="dns" />
-    </service>
-    <service name="SMTP" interval="300000" user-defined="false" status="on">
-      <parameter key="retry" value="1" />
-      <parameter key="timeout" value="3000" />
-      <parameter key="port" value="25" />
-      <parameter key="rrd-repository" value="${install.share.dir}/rrd/response" />
-      <parameter key="ds-name" value="smtp" />
-    </service>
-    <service name="FTP" interval="300000" user-defined="false" status="on">
-      <parameter key="retry" value="1" />
-      <parameter key="timeout" value="3000" />
-      <parameter key="port" value="21" />
-      <parameter key="userid" value="" />
-      <parameter key="password" value="" />
-    </service>
-    <service name="SNMP" interval="300000" user-defined="false" status="off">
-      <parameter key="retry" value="2" />
-      <parameter key="timeout" value="3000" />
-      <parameter key="port" value="161" />
-      <parameter key="oid" value=".1.3.6.1.2.1.1.2.0" />
-    </service>
-    <service name="HTTP" interval="300000" user-defined="false" status="on">
-      <parameter key="retry" value="1" />
-      <parameter key="timeout" value="3000" />
-      <parameter key="port" value="80" />
-      <parameter key="url" value="/" />
-      <parameter key="rrd-repository" value="${install.share.dir}/rrd/response" />
-      <parameter key="ds-name" value="http" />
-    </service>
-    <service name="HTTP-8080" interval="300000" user-defined="false" status="on">
-      <parameter key="retry" value="1" />
-      <parameter key="timeout" value="3000" />
-      <parameter key="port" value="8080" />
-      <parameter key="url" value="/" />
-      <parameter key="rrd-repository" value="${install.share.dir}/rrd/response" />
-      <parameter key="ds-name" value="http-8080" />
-    </service>
-    <service name="HTTP-8000" interval="300000" user-defined="false" status="on">
-      <parameter key="retry" value="1" />
-      <parameter key="timeout" value="3000" />
-      <parameter key="port" value="8000" />
-      <parameter key="url" value="/" />
-      <parameter key="rrd-repository" value="${install.share.dir}/rrd/response" />
-      <parameter key="ds-name" value="http-8000" />
-    </service>
-    <service name="HTTPS" interval="300000" user-defined="false" status="on">
-      <parameter key="retry" value="1" />
-      <parameter key="timeout" value="5000" />
-      <parameter key="port" value="443" />
-      <parameter key="url" value="/" />
-    </service>
-    <service name="MySQL" interval="300000" user-defined="false" status="on">
-      <parameter key="retry" value="1" />
-      <parameter key="timeout" value="3000" />
-      <parameter key="port" value="3306" />
-      <parameter key="banner" value="*" />
-    </service>
-    <service name="SQLServer" interval="300000" user-defined="false" status="on">
-      <parameter key="retry" value="1" />
-      <parameter key="timeout" value="3000" />
-      <parameter key="port" value="1433" />
-      <parameter key="banner" value="*" />
-    </service>
-    <service name="Oracle" interval="300000" user-defined="false" status="on">
-      <parameter key="retry" value="1" />
-      <parameter key="timeout" value="3000" />
-      <parameter key="port" value="1521" />
-      <parameter key="banner" value="*" />
-    </service>
-    <service name="Postgres" interval="300000" user-defined="false" status="on">
-      <parameter key="retry" value="1" />
-      <parameter key="banner" value="*" />
-      <parameter key="port" value="5432" />
-      <parameter key="timeout" value="3000" />
-    </service>
-    <service name="SSH" interval="300000" user-defined="false" status="on">
-      <parameter key="retry" value="1" />
-      <parameter key="banner" value="SSH" />
-      <parameter key="port" value="22" />
-      <parameter key="timeout" value="3000" />
-      <parameter key="rrd-repository" value="${install.share.dir}/rrd/response" />
-      <parameter key="ds-name" value="ssh" />
-    </service>
-    <service name="IMAP" interval="300000" user-defined="false" status="on">
-      <parameter key="retry" value="1" />
-      <parameter key="port" value="143" />
-      <parameter key="timeout" value="3000" />
-    </service>
-    <service name="POP3" interval="300000" user-defined="false" status="on">
-      <parameter key="retry" value="1" />
-      <parameter key="port" value="110" />
-      <parameter key="timeout" value="3000" />
-      <parameter key="rrd-repository" value="${install.share.dir}/rrd/response" />
-      <parameter key="ds-name" value="pop3" />
-    </service>
+
     <outage-calendar>zzz from poll-outages.xml zzz</outage-calendar>
 
     <downtime interval="30000" begin="0" end="300000" /><!-- 30s, 0, 5m -->
-    <downtime interval="300000" begin="300000" end="43200000" /><!-- 5m, 5m, 12h -->
-    <downtime interval="600000" begin="43200000" end="432000000" /><!-- 10m, 12h, 5d -->
-    <downtime begin="432000000" delete="true" /><!-- anything after 5 days delete -->
   </package>
 
   <monitor service="ICMP" class-name="org.opennms.netmgt.poller.monitors.IcmpMonitor" />
-  <monitor service="HTTP" class-name="org.opennms.netmgt.poller.monitors.HttpMonitor" />
-  <monitor service="HTTP-8080" class-name="org.opennms.netmgt.poller.monitors.HttpMonitor" />
-  <monitor service="HTTP-8000" class-name="org.opennms.netmgt.poller.monitors.HttpMonitor" />
-  <monitor service="HTTPS" class-name="org.opennms.netmgt.poller.monitors.HttpsMonitor" />
-  <monitor service="SMTP" class-name="org.opennms.netmgt.poller.monitors.SmtpMonitor" />
-  <monitor service="DNS" class-name="org.opennms.netmgt.poller.monitors.DnsMonitor" />
-  <monitor service="FTP" class-name="org.opennms.netmgt.poller.monitors.FtpMonitor" />
-  <monitor service="SNMP" class-name="org.opennms.netmgt.poller.monitors.SnmpMonitor" />
-  <monitor service="Oracle" class-name="org.opennms.netmgt.poller.monitors.TcpMonitor" />
-  <monitor service="Postgres" class-name="org.opennms.netmgt.poller.monitors.TcpMonitor" />
-  <monitor service="MySQL" class-name="org.opennms.netmgt.poller.monitors.TcpMonitor" />
-  <monitor service="SQLServer" class-name="org.opennms.netmgt.poller.monitors.TcpMonitor" />
-  <monitor service="SSH" class-name="org.opennms.netmgt.poller.monitors.TcpMonitor" />
-  <monitor service="IMAP" class-name="org.opennms.netmgt.poller.monitors.ImapMonitor" />
-  <monitor service="POP3" class-name="org.opennms.netmgt.poller.monitors.Pop3Monitor" />
-  <monitor service="RDU-HTTP" class-name="org.opennms.netmgt.poller.monitors.HttpMonitor" />
 </poller-configuration>

--- a/opennms-config/src/test/resources/poller-configuration-valid1.xml
+++ b/opennms-config/src/test/resources/poller-configuration-valid1.xml
@@ -1,0 +1,148 @@
+<?xml version="1.0"?>
+<poller-configuration threads="30" serviceUnresponsiveEnabled="false" nextOutageId="SELECT nextval('outageNxtId')">
+  <node-outage status="on" pollAllIfNoCriticalServiceDefined="true">
+    <critical-service name="ICMP" />
+  </node-outage>
+  <package name="example1">
+    <filter>IPADDR IPLIKE 1.*.*.*</filter>
+    <include-range begin="1.1.1.1" end="254.254.254.254" />
+    <rrd step="300">
+      <rra>RRA:AVERAGE:0.5:1:2016</rra>
+      <rra>RRA:AVERAGE:0.5:12:4464</rra>
+      <rra>RRA:MIN:0.5:12:4464</rra>
+      <rra>RRA:MAX:0.5:12:4464</rra>
+    </rrd>
+    <service name="ICMP" interval="300000" user-defined="false" status="on">
+      <parameter key="retry" value="2" />
+      <parameter key="timeout" value="3000" />
+      <parameter key="rrd-repository" value="${install.share.dir}/rrd/response" />
+      <parameter key="ds-name" value="icmp" />
+    </service>
+    <service name="DNS" interval="300000" user-defined="false" status="on">
+      <parameter key="retry" value="2" />
+      <parameter key="timeout" value="5000" />
+      <parameter key="port" value="53" />
+      <parameter key="lookup" value="localhost" />
+      <parameter key="rrd-repository" value="${install.share.dir}/rrd/response" />
+      <parameter key="ds-name" value="dns" />
+    </service>
+    <service name="SMTP" interval="300000" user-defined="false" status="on">
+      <parameter key="retry" value="1" />
+      <parameter key="timeout" value="3000" />
+      <parameter key="port" value="25" />
+      <parameter key="rrd-repository" value="${install.share.dir}/rrd/response" />
+      <parameter key="ds-name" value="smtp" />
+    </service>
+    <service name="FTP" interval="300000" user-defined="false" status="on">
+      <parameter key="retry" value="1" />
+      <parameter key="timeout" value="3000" />
+      <parameter key="port" value="21" />
+      <parameter key="userid" value="" />
+      <parameter key="password" value="" />
+    </service>
+    <service name="SNMP" interval="300000" user-defined="false" status="off">
+      <parameter key="retry" value="2" />
+      <parameter key="timeout" value="3000" />
+      <parameter key="port" value="161" />
+      <parameter key="oid" value=".1.3.6.1.2.1.1.2.0" />
+    </service>
+    <service name="HTTP" interval="300000" user-defined="false" status="on">
+      <parameter key="retry" value="1" />
+      <parameter key="timeout" value="3000" />
+      <parameter key="port" value="80" />
+      <parameter key="url" value="/" />
+      <parameter key="rrd-repository" value="${install.share.dir}/rrd/response" />
+      <parameter key="ds-name" value="http" />
+    </service>
+    <service name="HTTP-8080" interval="300000" user-defined="false" status="on">
+      <parameter key="retry" value="1" />
+      <parameter key="timeout" value="3000" />
+      <parameter key="port" value="8080" />
+      <parameter key="url" value="/" />
+      <parameter key="rrd-repository" value="${install.share.dir}/rrd/response" />
+      <parameter key="ds-name" value="http-8080" />
+    </service>
+    <service name="HTTP-8000" interval="300000" user-defined="false" status="on">
+      <parameter key="retry" value="1" />
+      <parameter key="timeout" value="3000" />
+      <parameter key="port" value="8000" />
+      <parameter key="url" value="/" />
+      <parameter key="rrd-repository" value="${install.share.dir}/rrd/response" />
+      <parameter key="ds-name" value="http-8000" />
+    </service>
+    <service name="HTTPS" interval="300000" user-defined="false" status="on">
+      <parameter key="retry" value="1" />
+      <parameter key="timeout" value="5000" />
+      <parameter key="port" value="443" />
+      <parameter key="url" value="/" />
+    </service>
+    <service name="MySQL" interval="300000" user-defined="false" status="on">
+      <parameter key="retry" value="1" />
+      <parameter key="timeout" value="3000" />
+      <parameter key="port" value="3306" />
+      <parameter key="banner" value="*" />
+    </service>
+    <service name="SQLServer" interval="300000" user-defined="false" status="on">
+      <parameter key="retry" value="1" />
+      <parameter key="timeout" value="3000" />
+      <parameter key="port" value="1433" />
+      <parameter key="banner" value="*" />
+    </service>
+    <service name="Oracle" interval="300000" user-defined="false" status="on">
+      <parameter key="retry" value="1" />
+      <parameter key="timeout" value="3000" />
+      <parameter key="port" value="1521" />
+      <parameter key="banner" value="*" />
+    </service>
+    <service name="Postgres" interval="300000" user-defined="false" status="on">
+      <parameter key="retry" value="1" />
+      <parameter key="banner" value="*" />
+      <parameter key="port" value="5432" />
+      <parameter key="timeout" value="3000" />
+    </service>
+    <service name="SSH" interval="300000" user-defined="false" status="on">
+      <parameter key="retry" value="1" />
+      <parameter key="banner" value="SSH" />
+      <parameter key="port" value="22" />
+      <parameter key="timeout" value="3000" />
+      <parameter key="rrd-repository" value="${install.share.dir}/rrd/response" />
+      <parameter key="ds-name" value="ssh" />
+    </service>
+    <service name="IMAP" interval="300000" user-defined="false" status="on">
+      <parameter key="retry" value="1" />
+      <parameter key="port" value="143" />
+      <parameter key="timeout" value="3000" />
+    </service>
+    <service name="POP3" interval="300000" user-defined="false" status="on">
+      <parameter key="retry" value="1" />
+      <parameter key="port" value="110" />
+      <parameter key="timeout" value="3000" />
+      <parameter key="rrd-repository" value="${install.share.dir}/rrd/response" />
+      <parameter key="ds-name" value="pop3" />
+    </service>
+    <outage-calendar>zzz from poll-outages.xml zzz</outage-calendar>
+
+    <downtime interval="30000" begin="0" end="300000" /><!-- 30s, 0, 5m -->
+    <downtime interval="300000" begin="300000" end="43200000" /><!-- 5m, 5m, 12h -->
+    <downtime interval="600000" begin="43200000" end="432000000" /><!-- 10m, 12h, 5d -->
+    <downtime begin="432000000" delete="true" /><!-- anything after 5 days delete -->
+  </package>
+
+  <monitor service="ICMP" class-name="org.opennms.netmgt.poller.monitors.IcmpMonitor" />
+  <monitor service="HTTP" class-name="org.opennms.netmgt.poller.monitors.HttpMonitor" />
+  <monitor service="HTTP-8080" class-name="org.opennms.netmgt.poller.monitors.HttpMonitor" />
+  <monitor service="HTTP-8000" class-name="org.opennms.netmgt.poller.monitors.HttpMonitor" />
+  <monitor service="HTTPS" class-name="org.opennms.netmgt.poller.monitors.HttpsMonitor" />
+  <monitor service="SMTP" class-name="org.opennms.netmgt.poller.monitors.SmtpMonitor" />
+  <monitor service="DNS" class-name="org.opennms.netmgt.poller.monitors.DnsMonitor" />
+  <monitor service="FTP" class-name="org.opennms.netmgt.poller.monitors.FtpMonitor" />
+  <monitor service="SNMP" class-name="org.opennms.netmgt.poller.monitors.SnmpMonitor" />
+  <monitor service="Oracle" class-name="org.opennms.netmgt.poller.monitors.TcpMonitor" />
+  <monitor service="Postgres" class-name="org.opennms.netmgt.poller.monitors.TcpMonitor" />
+  <monitor service="MySQL" class-name="org.opennms.netmgt.poller.monitors.TcpMonitor" />
+  <monitor service="SQLServer" class-name="org.opennms.netmgt.poller.monitors.TcpMonitor" />
+  <monitor service="SSH" class-name="org.opennms.netmgt.poller.monitors.TcpMonitor" />
+  <monitor service="IMAP" class-name="org.opennms.netmgt.poller.monitors.ImapMonitor" />
+  <monitor service="POP3" class-name="org.opennms.netmgt.poller.monitors.Pop3Monitor" />
+  <monitor service="RDU-HTTP" class-name="org.opennms.netmgt.poller.monitors.HttpMonitor" />
+</poller-configuration>

--- a/opennms-config/src/test/resources/poller-configuration-valid2.xml
+++ b/opennms-config/src/test/resources/poller-configuration-valid2.xml
@@ -8,9 +8,6 @@
     <include-range begin="1.1.1.1" end="254.254.254.254" />
     <rrd step="300">
       <rra>RRA:AVERAGE:0.5:1:2016</rra>
-      <rra>RRA:AVERAGE:0.5:12:4464</rra>
-      <rra>RRA:MIN:0.5:12:4464</rra>
-      <rra>RRA:MAX:0.5:12:4464</rra>
     </rrd>
     <service name="ICMP" interval="300000" user-defined="false" status="on">
       <parameter key="retry" value="2" />
@@ -18,131 +15,11 @@
       <parameter key="rrd-repository" value="${install.share.dir}/rrd/response" />
       <parameter key="ds-name" value="icmp" />
     </service>
-    <service name="DNS" interval="300000" user-defined="false" status="on">
-      <parameter key="retry" value="2" />
-      <parameter key="timeout" value="5000" />
-      <parameter key="port" value="53" />
-      <parameter key="lookup" value="localhost" />
-      <parameter key="rrd-repository" value="${install.share.dir}/rrd/response" />
-      <parameter key="ds-name" value="dns" />
-    </service>
-    <service name="SMTP" interval="300000" user-defined="false" status="on">
-      <parameter key="retry" value="1" />
-      <parameter key="timeout" value="3000" />
-      <parameter key="port" value="25" />
-      <parameter key="rrd-repository" value="${install.share.dir}/rrd/response" />
-      <parameter key="ds-name" value="smtp" />
-    </service>
-    <service name="FTP" interval="300000" user-defined="false" status="on">
-      <parameter key="retry" value="1" />
-      <parameter key="timeout" value="3000" />
-      <parameter key="port" value="21" />
-      <parameter key="userid" value="" />
-      <parameter key="password" value="" />
-    </service>
-    <service name="SNMP" interval="300000" user-defined="false" status="off">
-      <parameter key="retry" value="2" />
-      <parameter key="timeout" value="3000" />
-      <parameter key="port" value="161" />
-      <parameter key="oid" value=".1.3.6.1.2.1.1.2.0" />
-    </service>
-    <service name="HTTP" interval="300000" user-defined="false" status="on">
-      <parameter key="retry" value="1" />
-      <parameter key="timeout" value="3000" />
-      <parameter key="port" value="80" />
-      <parameter key="url" value="/" />
-      <parameter key="rrd-repository" value="${install.share.dir}/rrd/response" />
-      <parameter key="ds-name" value="http" />
-    </service>
-    <service name="HTTP-8080" interval="300000" user-defined="false" status="on">
-      <parameter key="retry" value="1" />
-      <parameter key="timeout" value="3000" />
-      <parameter key="port" value="8080" />
-      <parameter key="url" value="/" />
-      <parameter key="rrd-repository" value="${install.share.dir}/rrd/response" />
-      <parameter key="ds-name" value="http-8080" />
-    </service>
-    <service name="HTTP-8000" interval="300000" user-defined="false" status="on">
-      <parameter key="retry" value="1" />
-      <parameter key="timeout" value="3000" />
-      <parameter key="port" value="8000" />
-      <parameter key="url" value="/" />
-      <parameter key="rrd-repository" value="${install.share.dir}/rrd/response" />
-      <parameter key="ds-name" value="http-8000" />
-    </service>
-    <service name="HTTPS" interval="300000" user-defined="false" status="on">
-      <parameter key="retry" value="1" />
-      <parameter key="timeout" value="5000" />
-      <parameter key="port" value="443" />
-      <parameter key="url" value="/" />
-    </service>
-    <service name="MySQL" interval="300000" user-defined="false" status="on">
-      <parameter key="retry" value="1" />
-      <parameter key="timeout" value="3000" />
-      <parameter key="port" value="3306" />
-      <parameter key="banner" value="*" />
-    </service>
-    <service name="SQLServer" interval="300000" user-defined="false" status="on">
-      <parameter key="retry" value="1" />
-      <parameter key="timeout" value="3000" />
-      <parameter key="port" value="1433" />
-      <parameter key="banner" value="*" />
-    </service>
-    <service name="Oracle" interval="300000" user-defined="false" status="on">
-      <parameter key="retry" value="1" />
-      <parameter key="timeout" value="3000" />
-      <parameter key="port" value="1521" />
-      <parameter key="banner" value="*" />
-    </service>
-    <service name="Postgres" interval="300000" user-defined="false" status="on">
-      <parameter key="retry" value="1" />
-      <parameter key="banner" value="*" />
-      <parameter key="port" value="5432" />
-      <parameter key="timeout" value="3000" />
-    </service>
-    <service name="SSH" interval="300000" user-defined="false" status="on">
-      <parameter key="retry" value="1" />
-      <parameter key="banner" value="SSH" />
-      <parameter key="port" value="22" />
-      <parameter key="timeout" value="3000" />
-      <parameter key="rrd-repository" value="${install.share.dir}/rrd/response" />
-      <parameter key="ds-name" value="ssh" />
-    </service>
-    <service name="IMAP" interval="300000" user-defined="false" status="on">
-      <parameter key="retry" value="1" />
-      <parameter key="port" value="143" />
-      <parameter key="timeout" value="3000" />
-    </service>
-    <service name="POP3" interval="300000" user-defined="false" status="on">
-      <parameter key="retry" value="1" />
-      <parameter key="port" value="110" />
-      <parameter key="timeout" value="3000" />
-      <parameter key="rrd-repository" value="${install.share.dir}/rrd/response" />
-      <parameter key="ds-name" value="pop3" />
-    </service>
+
     <outage-calendar>zzz from poll-outages.xml zzz</outage-calendar>
 
     <downtime interval="30000" begin="0" end="300000" /><!-- 30s, 0, 5m -->
-    <downtime interval="300000" begin="300000" end="43200000" /><!-- 5m, 5m, 12h -->
-    <downtime interval="600000" begin="43200000" end="432000000" /><!-- 10m, 12h, 5d -->
-    <downtime begin="432000000" delete="true" /><!-- anything after 5 days delete -->
   </package>
 
   <monitor service="ICMP" class-name="org.opennms.netmgt.poller.monitors.IcmpMonitor" />
-  <monitor service="HTTP" class-name="org.opennms.netmgt.poller.monitors.HttpMonitor" />
-  <monitor service="HTTP-8080" class-name="org.opennms.netmgt.poller.monitors.HttpMonitor" />
-  <monitor service="HTTP-8000" class-name="org.opennms.netmgt.poller.monitors.HttpMonitor" />
-  <monitor service="HTTPS" class-name="org.opennms.netmgt.poller.monitors.HttpsMonitor" />
-  <monitor service="SMTP" class-name="org.opennms.netmgt.poller.monitors.SmtpMonitor" />
-  <monitor service="DNS" class-name="org.opennms.netmgt.poller.monitors.DnsMonitor" />
-  <monitor service="FTP" class-name="org.opennms.netmgt.poller.monitors.FtpMonitor" />
-  <monitor service="SNMP" class-name="org.opennms.netmgt.poller.monitors.SnmpMonitor" />
-  <monitor service="Oracle" class-name="org.opennms.netmgt.poller.monitors.TcpMonitor" />
-  <monitor service="Postgres" class-name="org.opennms.netmgt.poller.monitors.TcpMonitor" />
-  <monitor service="MySQL" class-name="org.opennms.netmgt.poller.monitors.TcpMonitor" />
-  <monitor service="SQLServer" class-name="org.opennms.netmgt.poller.monitors.TcpMonitor" />
-  <monitor service="SSH" class-name="org.opennms.netmgt.poller.monitors.TcpMonitor" />
-  <monitor service="IMAP" class-name="org.opennms.netmgt.poller.monitors.ImapMonitor" />
-  <monitor service="POP3" class-name="org.opennms.netmgt.poller.monitors.Pop3Monitor" />
-  <monitor service="RDU-HTTP" class-name="org.opennms.netmgt.poller.monitors.HttpMonitor" />
 </poller-configuration>

--- a/opennms-config/src/test/resources/poller-configuration-valid2.xml
+++ b/opennms-config/src/test/resources/poller-configuration-valid2.xml
@@ -1,0 +1,148 @@
+<?xml version="1.0"?>
+<poller-configuration threads="30" serviceUnresponsiveEnabled="false" nextOutageId="SELECT nextval('outageNxtId')">
+  <node-outage status="on" pollAllIfNoCriticalServiceDefined="true">
+    <critical-service name="ICMP" />
+  </node-outage>
+  <package name="example1">
+    <filter>IPADDR IPLIKE 2.*.*.*</filter>
+    <include-range begin="1.1.1.1" end="254.254.254.254" />
+    <rrd step="300">
+      <rra>RRA:AVERAGE:0.5:1:2016</rra>
+      <rra>RRA:AVERAGE:0.5:12:4464</rra>
+      <rra>RRA:MIN:0.5:12:4464</rra>
+      <rra>RRA:MAX:0.5:12:4464</rra>
+    </rrd>
+    <service name="ICMP" interval="300000" user-defined="false" status="on">
+      <parameter key="retry" value="2" />
+      <parameter key="timeout" value="3000" />
+      <parameter key="rrd-repository" value="${install.share.dir}/rrd/response" />
+      <parameter key="ds-name" value="icmp" />
+    </service>
+    <service name="DNS" interval="300000" user-defined="false" status="on">
+      <parameter key="retry" value="2" />
+      <parameter key="timeout" value="5000" />
+      <parameter key="port" value="53" />
+      <parameter key="lookup" value="localhost" />
+      <parameter key="rrd-repository" value="${install.share.dir}/rrd/response" />
+      <parameter key="ds-name" value="dns" />
+    </service>
+    <service name="SMTP" interval="300000" user-defined="false" status="on">
+      <parameter key="retry" value="1" />
+      <parameter key="timeout" value="3000" />
+      <parameter key="port" value="25" />
+      <parameter key="rrd-repository" value="${install.share.dir}/rrd/response" />
+      <parameter key="ds-name" value="smtp" />
+    </service>
+    <service name="FTP" interval="300000" user-defined="false" status="on">
+      <parameter key="retry" value="1" />
+      <parameter key="timeout" value="3000" />
+      <parameter key="port" value="21" />
+      <parameter key="userid" value="" />
+      <parameter key="password" value="" />
+    </service>
+    <service name="SNMP" interval="300000" user-defined="false" status="off">
+      <parameter key="retry" value="2" />
+      <parameter key="timeout" value="3000" />
+      <parameter key="port" value="161" />
+      <parameter key="oid" value=".1.3.6.1.2.1.1.2.0" />
+    </service>
+    <service name="HTTP" interval="300000" user-defined="false" status="on">
+      <parameter key="retry" value="1" />
+      <parameter key="timeout" value="3000" />
+      <parameter key="port" value="80" />
+      <parameter key="url" value="/" />
+      <parameter key="rrd-repository" value="${install.share.dir}/rrd/response" />
+      <parameter key="ds-name" value="http" />
+    </service>
+    <service name="HTTP-8080" interval="300000" user-defined="false" status="on">
+      <parameter key="retry" value="1" />
+      <parameter key="timeout" value="3000" />
+      <parameter key="port" value="8080" />
+      <parameter key="url" value="/" />
+      <parameter key="rrd-repository" value="${install.share.dir}/rrd/response" />
+      <parameter key="ds-name" value="http-8080" />
+    </service>
+    <service name="HTTP-8000" interval="300000" user-defined="false" status="on">
+      <parameter key="retry" value="1" />
+      <parameter key="timeout" value="3000" />
+      <parameter key="port" value="8000" />
+      <parameter key="url" value="/" />
+      <parameter key="rrd-repository" value="${install.share.dir}/rrd/response" />
+      <parameter key="ds-name" value="http-8000" />
+    </service>
+    <service name="HTTPS" interval="300000" user-defined="false" status="on">
+      <parameter key="retry" value="1" />
+      <parameter key="timeout" value="5000" />
+      <parameter key="port" value="443" />
+      <parameter key="url" value="/" />
+    </service>
+    <service name="MySQL" interval="300000" user-defined="false" status="on">
+      <parameter key="retry" value="1" />
+      <parameter key="timeout" value="3000" />
+      <parameter key="port" value="3306" />
+      <parameter key="banner" value="*" />
+    </service>
+    <service name="SQLServer" interval="300000" user-defined="false" status="on">
+      <parameter key="retry" value="1" />
+      <parameter key="timeout" value="3000" />
+      <parameter key="port" value="1433" />
+      <parameter key="banner" value="*" />
+    </service>
+    <service name="Oracle" interval="300000" user-defined="false" status="on">
+      <parameter key="retry" value="1" />
+      <parameter key="timeout" value="3000" />
+      <parameter key="port" value="1521" />
+      <parameter key="banner" value="*" />
+    </service>
+    <service name="Postgres" interval="300000" user-defined="false" status="on">
+      <parameter key="retry" value="1" />
+      <parameter key="banner" value="*" />
+      <parameter key="port" value="5432" />
+      <parameter key="timeout" value="3000" />
+    </service>
+    <service name="SSH" interval="300000" user-defined="false" status="on">
+      <parameter key="retry" value="1" />
+      <parameter key="banner" value="SSH" />
+      <parameter key="port" value="22" />
+      <parameter key="timeout" value="3000" />
+      <parameter key="rrd-repository" value="${install.share.dir}/rrd/response" />
+      <parameter key="ds-name" value="ssh" />
+    </service>
+    <service name="IMAP" interval="300000" user-defined="false" status="on">
+      <parameter key="retry" value="1" />
+      <parameter key="port" value="143" />
+      <parameter key="timeout" value="3000" />
+    </service>
+    <service name="POP3" interval="300000" user-defined="false" status="on">
+      <parameter key="retry" value="1" />
+      <parameter key="port" value="110" />
+      <parameter key="timeout" value="3000" />
+      <parameter key="rrd-repository" value="${install.share.dir}/rrd/response" />
+      <parameter key="ds-name" value="pop3" />
+    </service>
+    <outage-calendar>zzz from poll-outages.xml zzz</outage-calendar>
+
+    <downtime interval="30000" begin="0" end="300000" /><!-- 30s, 0, 5m -->
+    <downtime interval="300000" begin="300000" end="43200000" /><!-- 5m, 5m, 12h -->
+    <downtime interval="600000" begin="43200000" end="432000000" /><!-- 10m, 12h, 5d -->
+    <downtime begin="432000000" delete="true" /><!-- anything after 5 days delete -->
+  </package>
+
+  <monitor service="ICMP" class-name="org.opennms.netmgt.poller.monitors.IcmpMonitor" />
+  <monitor service="HTTP" class-name="org.opennms.netmgt.poller.monitors.HttpMonitor" />
+  <monitor service="HTTP-8080" class-name="org.opennms.netmgt.poller.monitors.HttpMonitor" />
+  <monitor service="HTTP-8000" class-name="org.opennms.netmgt.poller.monitors.HttpMonitor" />
+  <monitor service="HTTPS" class-name="org.opennms.netmgt.poller.monitors.HttpsMonitor" />
+  <monitor service="SMTP" class-name="org.opennms.netmgt.poller.monitors.SmtpMonitor" />
+  <monitor service="DNS" class-name="org.opennms.netmgt.poller.monitors.DnsMonitor" />
+  <monitor service="FTP" class-name="org.opennms.netmgt.poller.monitors.FtpMonitor" />
+  <monitor service="SNMP" class-name="org.opennms.netmgt.poller.monitors.SnmpMonitor" />
+  <monitor service="Oracle" class-name="org.opennms.netmgt.poller.monitors.TcpMonitor" />
+  <monitor service="Postgres" class-name="org.opennms.netmgt.poller.monitors.TcpMonitor" />
+  <monitor service="MySQL" class-name="org.opennms.netmgt.poller.monitors.TcpMonitor" />
+  <monitor service="SQLServer" class-name="org.opennms.netmgt.poller.monitors.TcpMonitor" />
+  <monitor service="SSH" class-name="org.opennms.netmgt.poller.monitors.TcpMonitor" />
+  <monitor service="IMAP" class-name="org.opennms.netmgt.poller.monitors.ImapMonitor" />
+  <monitor service="POP3" class-name="org.opennms.netmgt.poller.monitors.Pop3Monitor" />
+  <monitor service="RDU-HTTP" class-name="org.opennms.netmgt.poller.monitors.HttpMonitor" />
+</poller-configuration>

--- a/opennms-dao-mock/src/main/java/org/opennms/netmgt/dao/mock/MockFilterDao.java
+++ b/opennms-dao-mock/src/main/java/org/opennms/netmgt/dao/mock/MockFilterDao.java
@@ -74,6 +74,7 @@ public class MockFilterDao implements FilterDao, InitializingBean {
     public List<InetAddress> getActiveIPAddressList(final String rule) throws FilterParseException {
         LOG.debug("rule = {}", rule);
         final List<InetAddress> addrs = new ArrayList<>();
+
         if (rule.equals("IPADDR != '0.0.0.0'")) {
             Assert.notNull(m_ipInterfaceDao);
             final CriteriaBuilder builder = new CriteriaBuilder(OnmsIpInterface.class);
@@ -86,6 +87,21 @@ public class MockFilterDao implements FilterDao, InitializingBean {
             }
             return addrs;
         }
+
+        if (rule.equals("foreignSource == 'Minions' AND IPADDR != '0.0.0.0'")) {
+            Assert.notNull(m_ipInterfaceDao);
+            final CriteriaBuilder builder = new CriteriaBuilder(OnmsIpInterface.class);
+            builder.ne("ipAddress", "0.0.0.0");
+            builder.ne("isManaged", "D");
+            builder.eq("node.location.locationName", "Minions");
+            builder.distinct();
+            final Criteria criteria = builder.toCriteria();
+            for (final OnmsIpInterface iface : m_ipInterfaceDao.findMatching(criteria)) {
+                addrs.add(iface.getIpAddress());
+            }
+            return addrs;
+        }
+
         throw new UnsupportedOperationException("Not yet implemented!");
     }
 
@@ -106,8 +122,10 @@ public class MockFilterDao implements FilterDao, InitializingBean {
 
     @Override
     public void validateRule(final String rule) throws FilterParseException {
+        if ("IPADDR != '0.0.0.0'".equals(rule) || "foreignSource == 'Minions' AND IPADDR != '0.0.0.0'".equals(rule))
+            return ;
+
         throw new UnsupportedOperationException("Not yet implemented!");
-        
     }
 
     public IpInterfaceDao getIpInterfaceDao() {

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/ScheduledOutagesRestServiceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/ScheduledOutagesRestServiceIT.java
@@ -123,6 +123,8 @@ public class ScheduledOutagesRestServiceIT extends AbstractSpringJerseyRestTestC
         // Setup Filter DAO
         m_filterDao = EasyMock.createMock(FilterDao.class);
         EasyMock.expect(m_filterDao.getActiveIPAddressList("IPADDR != '0.0.0.0'")).andReturn(Collections.singletonList(InetAddressUtils.getLocalHostAddress())).anyTimes();
+        m_filterDao.validateRule("IPADDR != '0.0.0.0'");
+        EasyMock.expectLastCall().anyTimes();
         m_filterDao.flushActiveIpAddressListCache();
         EasyMock.expectLastCall().anyTimes();
         EasyMock.replay(m_filterDao);


### PR DESCRIPTION
* JIRA: https://issues.opennms.org/browse/NMS-12400

OpenNMS will now fail to start with invalid filter rules inside poller-configuration.xml. Furthermore a reload to replace a valid with an invalid configuration will also fail. So in this case the old valid configuration will stay in place.