### PR TITLE
NMS-12412: Fix a number of problems with Drools in alarmd

### DIFF
--- a/opennms-alarms/daemon/pom.xml
+++ b/opennms-alarms/daemon/pom.xml
@@ -66,6 +66,10 @@
       <artifactId>drools-dependencies</artifactId>
       <type>pom</type>
     </dependency>
+    <dependency>
+      <groupId>com.swrve</groupId>
+      <artifactId>rate-limited-logger</artifactId>
+    </dependency>
 
     <!-- test dependencies -->
     <dependency>

--- a/opennms-alarms/daemon/src/main/java/org/opennms/netmgt/alarmd/AlarmPersisterImpl.java
+++ b/opennms-alarms/daemon/src/main/java/org/opennms/netmgt/alarmd/AlarmPersisterImpl.java
@@ -188,8 +188,8 @@ public class AlarmPersisterImpl implements AlarmPersister {
 
             // Trigger extensions, allowing them to mangle the alarm
             try {
-                final OnmsAlarm alarmCreated = alarm;
-                extensions.forEach(ext -> ext.afterAlarmUpdated(alarmCreated, event, persistedEvent));
+                final OnmsAlarm alarmUpdated = alarm;
+                extensions.forEach(ext -> ext.afterAlarmUpdated(alarmUpdated, event, persistedEvent));
             } catch (Exception ex) {
                 LOG.error("An error occurred while invoking the extension callbacks.", ex);
             }

--- a/opennms-alarms/daemon/src/main/java/org/opennms/netmgt/alarmd/drools/AlarmService.java
+++ b/opennms-alarms/daemon/src/main/java/org/opennms/netmgt/alarmd/drools/AlarmService.java
@@ -40,7 +40,7 @@ import org.opennms.netmgt.xml.event.Event;
  */
 public interface AlarmService {
 
-    void clearAlarm(OnmsAlarm alarm, Date clearTime);
+    void clearAlarm(OnmsAlarm alarm, Date now);
 
     void deleteAlarm(OnmsAlarm alarm);
 

--- a/opennms-alarms/daemon/src/main/java/org/opennms/netmgt/alarmd/drools/DefaultAlarmService.java
+++ b/opennms-alarms/daemon/src/main/java/org/opennms/netmgt/alarmd/drools/DefaultAlarmService.java
@@ -68,8 +68,8 @@ public class DefaultAlarmService implements AlarmService {
 
     @Override
     @Transactional
-    public void clearAlarm(OnmsAlarm alarm, Date clearTime) {
-        LOG.info("Clearing alarm with id: {} with current severity: {} at: {}", alarm.getId(), alarm.getSeverity(), clearTime);
+    public void clearAlarm(OnmsAlarm alarm, Date now) {
+        LOG.info("Clearing alarm with id: {} with current severity: {} at: {}", alarm.getId(), alarm.getSeverity(), now);
         final OnmsAlarm alarmInTrans = alarmDao.get(alarm.getId());
         if (alarmInTrans == null) {
             LOG.warn("Alarm disappeared: {}. Skipping clear.", alarm);
@@ -77,7 +77,7 @@ public class DefaultAlarmService implements AlarmService {
         }
         final OnmsSeverity previousSeverity = alarmInTrans.getSeverity();
         alarmInTrans.setSeverity(OnmsSeverity.CLEARED);
-        updateAutomationTime(alarmInTrans, clearTime);
+        updateAutomationTime(alarmInTrans, now);
         alarmDao.update(alarmInTrans);
         alarmEntityNotifier.didUpdateAlarmSeverity(alarmInTrans, previousSeverity);
     }
@@ -109,7 +109,7 @@ public class DefaultAlarmService implements AlarmService {
     @Override
     @Transactional
     public void unclearAlarm(OnmsAlarm alarm, Date now) {
-        LOG.info("Un-clearing alarm with id: {} at: {}", alarm.getId(), alarm.getLastEventTime());
+        LOG.info("Un-clearing alarm with id: {} at: {}", alarm.getId(), now);
         final OnmsAlarm alarmInTrans = alarmDao.get(alarm.getId());
         if (alarmInTrans == null) {
             LOG.warn("Alarm disappeared: {}. Skipping un-clear.", alarm);
@@ -125,7 +125,7 @@ public class DefaultAlarmService implements AlarmService {
     @Override
     @Transactional
     public void escalateAlarm(OnmsAlarm alarm, Date now) {
-        LOG.info("Escalating alarm with id: {}", alarm.getId());
+        LOG.info("Escalating alarm with id: {} at: {}", alarm.getId(), now);
         final OnmsAlarm alarmInTrans = alarmDao.get(alarm.getId());
         if (alarmInTrans == null) {
             LOG.warn("Alarm disappeared: {}. Skipping escalate.", alarm);

--- a/opennms-alarms/daemon/src/test/java/org/opennms/netmgt/alarmd/AlarmLifecycleListenerManagerIT.java
+++ b/opennms-alarms/daemon/src/test/java/org/opennms/netmgt/alarmd/AlarmLifecycleListenerManagerIT.java
@@ -49,11 +49,8 @@ import java.util.concurrent.Callable;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.opennms.core.criteria.Criteria;
-import org.opennms.core.criteria.restrictions.EqRestriction;
 import org.opennms.core.test.MockLogAppender;
 import org.opennms.core.test.OpenNMSJUnit4ClassRunner;
 import org.opennms.core.test.db.MockDatabase;
@@ -73,8 +70,6 @@ import org.opennms.netmgt.xml.event.AlarmData;
 import org.opennms.test.JUnitConfigurationEnvironment;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.transaction.TransactionStatus;
-import org.springframework.transaction.support.TransactionCallbackWithoutResult;
 import org.springframework.transaction.support.TransactionTemplate;
 
 /**
@@ -83,7 +78,6 @@ import org.springframework.transaction.support.TransactionTemplate;
  *
  * @author jwhite
  */
-@Ignore("flapping - see NMS-12309")
 @RunWith(OpenNMSJUnit4ClassRunner.class)
 @ContextConfiguration(locations={
         "classpath:/META-INF/opennms/applicationContext-soa.xml",
@@ -186,6 +180,11 @@ public class AlarmLifecycleListenerManagerIT implements TemporaryDatabaseAware<M
         await().until(getNodeDownAlarmFor(1), hasSeverity(OnmsSeverity.CLEARED));
         await().until(getNodeUpAlarmFor(1), hasSeverity(OnmsSeverity.NORMAL));
 
+        // Wait to ensure that the next DOWN event does not happen on the same exact
+        // millisecond as the UP event, otherwise the UP event will win and the alarm
+        // will remain cleared
+        Thread.sleep(10);
+
         // Send another nodeDown
         sendNodeDownEvent(1);
         await().until(getNodeDownAlarmFor(1), hasSeverity(OnmsSeverity.MAJOR));
@@ -193,7 +192,7 @@ public class AlarmLifecycleListenerManagerIT implements TemporaryDatabaseAware<M
     }
 
     @Test
-    public void canIssueDeleteCallbacks() {
+    public void canIssueDeleteCallbacks() throws Exception {
         // Send a nodeDown
         sendNodeDownEvent(1);
         await().until(getNodeDownAlarmFor(1), hasSeverity(OnmsSeverity.MAJOR));
@@ -202,24 +201,23 @@ public class AlarmLifecycleListenerManagerIT implements TemporaryDatabaseAware<M
         sendNodeUpEvent(1);
         await().until(getNodeDownAlarmFor(1), hasSeverity(OnmsSeverity.CLEARED));
 
+        // Wait for the clear to be flushed to the database
+        int alarmId = getNodeDownAlarmFor(1).call().getId();
+        await().until(() -> m_alarmDao.get(alarmId), hasSeverity(OnmsSeverity.CLEARED));
+
         // We need to wait for the cleanUp automation which triggers when:
         //  'lastautomationtime' and 'lasteventtime' < "5 minutes ago"
         // so we cheat a little and update the timestamps ourselves instead of waiting
-        transactionTemplate.execute(new TransactionCallbackWithoutResult() {
-            @Override
-            protected void doInTransactionWithoutResult(TransactionStatus status) {
-                Criteria criteria = new Criteria(OnmsAlarm.class);
-                criteria.addRestriction(new EqRestriction("node.id", 1));
-                criteria.addRestriction(new EqRestriction("uei", EventConstants.NODE_DOWN_EVENT_UEI));
-                for (OnmsAlarm alarm : m_alarmDao.findMatching(criteria)) {
-                    LocalDateTime tenMinutesAgo = LocalDateTime.now().minusMinutes(10);
-                    Date then = Date.from(tenMinutesAgo.toInstant(ZoneOffset.UTC));
-                    alarm.setLastAutomationTime(then);
-                    alarm.setLastEventTime(then);
-                    m_alarmDao.save(alarm);
-                }
-                m_alarmDao.flush();
-            }
+        transactionTemplate.execute(status -> {
+            OnmsAlarm alarm = m_alarmDao.get(alarmId);
+            LocalDateTime tenMinutesAgo = LocalDateTime.now().minusMinutes(10);
+            Date then = Date.from(tenMinutesAgo.toInstant(ZoneOffset.UTC));
+            alarm.setLastAutomationTime(then);
+            alarm.setLastEventTime(then);
+            alarm.setLastEvent(null);
+            m_alarmDao.save(alarm);
+            m_alarmDao.flush();
+            return null;
         });
 
         await().until(getNodeDownAlarmFor(1), nullValue());

--- a/opennms-alarms/daemon/src/test/java/org/opennms/netmgt/alarmd/AlarmLifecycleListenerManagerSnapshotTest.java
+++ b/opennms-alarms/daemon/src/test/java/org/opennms/netmgt/alarmd/AlarmLifecycleListenerManagerSnapshotTest.java
@@ -42,7 +42,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Test;
 import org.opennms.netmgt.alarmd.api.AlarmLifecycleListener;
 import org.opennms.netmgt.dao.api.AlarmDao;
-import org.opennms.netmgt.dao.mock.MockTransactionTemplate;
+import org.opennms.netmgt.dao.mock.MockSessionUtils;
 import org.opennms.netmgt.model.OnmsAlarm;
 
 import com.google.common.collect.Maps;
@@ -115,9 +115,8 @@ public class AlarmLifecycleListenerManagerSnapshotTest {
         AlarmDao alarmDao = mock(AlarmDao.class);
         when(alarmDao.findAll()).thenReturn(Collections.emptyList());
         alm.setAlarmDao(alarmDao);
-        MockTransactionTemplate mockTransactionTemplate = new MockTransactionTemplate();
-        mockTransactionTemplate.afterPropertiesSet();
-        alm.setTransactionTemplate(mockTransactionTemplate);
+        MockSessionUtils mockSessionUtils = new MockSessionUtils();
+        alm.setSessionUtils(mockSessionUtils);
         alm.onListenerRegistered(listener, Maps.newHashMap());
 
         // Trigger a snapshot on a another thread

--- a/opennms-alarms/daemon/src/test/java/org/opennms/netmgt/alarmd/AlarmdIT.java
+++ b/opennms-alarms/daemon/src/test/java/org/opennms/netmgt/alarmd/AlarmdIT.java
@@ -56,7 +56,6 @@ import java.util.stream.Collectors;
 
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.opennms.core.soa.ServiceRegistry;
@@ -93,7 +92,6 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.transaction.annotation.Transactional;
 
 
-@Ignore("flapping - see NMS-12309")
 @RunWith(OpenNMSJUnit4ClassRunner.class)
 @ContextConfiguration(locations={
         "classpath:/META-INF/opennms/applicationContext-soa.xml",

--- a/opennms-alarms/daemon/src/test/java/org/opennms/netmgt/alarmd/drools/DroolsAlarmContextIT.java
+++ b/opennms-alarms/daemon/src/test/java/org/opennms/netmgt/alarmd/drools/DroolsAlarmContextIT.java
@@ -503,6 +503,8 @@ public class DroolsAlarmContextIT {
 
         // Advance the clock and tick
         dac.handleNewOrUpdatedAlarm(trigger);
+        dac.getClock().advanceTime( 1, TimeUnit.MINUTES );
+        dac.tick();
         dac.getClock().advanceTime( 20, TimeUnit.MINUTES );
         dac.tick();
         assertThat(ticketer.didCloseTicketFor(trigger), equalTo(true));

--- a/opennms-base-assembly/src/main/filtered/etc/alarmd/drools-rules.d/alarmd.drl
+++ b/opennms-base-assembly/src/main/filtered/etc/alarmd/drools-rules.d/alarmd.drl
@@ -63,10 +63,11 @@ global org.opennms.netmgt.alarmd.drools.AlarmService alarmService;
 rule "cosmicClear"
   salience 100
   when
+    $sessionClock : SessionClock()
     $clear : OnmsAlarm(alarmType == OnmsAlarm.RESOLUTION_TYPE)
     $trigger : OnmsAlarm(alarmType == OnmsAlarm.PROBLEM_TYPE, severity.isGreaterThanOrEqual(OnmsSeverity.NORMAL), reductionKey == $clear.clearKey, lastEventTime <= $clear.lastEventTime)
   then
-    alarmService.clearAlarm($trigger, $clear.getLastEventTime());
+    alarmService.clearAlarm($trigger, $sessionClock.now());
 end
 
 /*
@@ -94,8 +95,6 @@ end
          WHERE alarmid = ${_id}
       </statement>
     </action>
-
-    The lastAutomationTime is set to the time of the clearing event.
 */
 rule "unclear"
   when

--- a/opennms-base-assembly/src/main/filtered/etc/jmx-datacollection-config.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/jmx-datacollection-config.xml
@@ -483,6 +483,10 @@
          <mbean name="drools.alarmd.actions" objectname="org.opennms.features.drools.alarmd:name=atomicActionsInFlight">
             <attrib name="Value" alias="DroolsAlarmdActions" type="gauge"/>
          </mbean>
+         <mbean name="drools.alarmd.actions.queued" objectname="org.opennms.features.drools.alarmd:name=atomicActionsQueued">
+            <attrib name="OneMinuteRate" alias="DroolsAlarmdActQu1m" type="gauge"/>
+            <attrib name="Count" alias="DroolsAlarmdActQu" type="counter"/>
+         </mbean>
          <mbean name="drools.alarmd.alarms" objectname="org.opennms.features.drools.alarmd:name=numAlarmsFromLastSnapshot">
             <attrib name="Value" alias="DroolsAlarmdAlarms" type="gauge"/>
          </mbean>

--- a/opennms-model/src/main/java/org/opennms/netmgt/model/OnmsAlarm.java
+++ b/opennms-model/src/main/java/org/opennms/netmgt/model/OnmsAlarm.java
@@ -827,6 +827,7 @@ public class OnmsAlarm implements Acknowledgeable, Serializable {
             .add("uei", getUei())
             .add("severity", getSeverity())
             .add("lastEventTime",getLastEventTime())
+            .add("counter", getCounter())
             .toString();
     }
 


### PR DESCRIPTION
JIRA: https://issues.opennms.org/browse/NMS-12412
JIRA for tests flapping: https://issues.opennms.org/browse/NMS-12309

Here we:
* Fix flapping between clear & unclear rules
* Limit # of queued actions - help prevent OOM
* Only add alarm facts to the Drools session once the related transacation has been succesfully flushed
  * This fixes flapping tests and intermittent errors related to inconsistent database states
* Fix exception handling in fire thread
