### PR TITLE
NMS-12407: Updated JCifs version

### DIFF
--- a/opennms-doc/guide-admin/src/asciidoc/text/service-assurance/monitors/JCifsMonitor.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/service-assurance/monitors/JCifsMonitor.adoc
@@ -66,6 +66,8 @@ The _JCifsMonitor_ can *not* test:
                         `folder_empty` and `folder_not_empty`, otherwise it will be ignored.                            | optional | `-` | No
 |===
 
+CAUTION: Due to limitations in the JCifs library, only global timeouts can be used reliably.
+
 This monitor implements the <<ga-service-assurance-monitors-common-parameters, Common Configuration Parameters>>.
 
 TIP: It makes little sense to have retries higher than `1`.

--- a/pom.xml
+++ b/pom.xml
@@ -1251,7 +1251,7 @@
     <jacocoVersion>0.8.4</jacocoVersion>
     <jasperreportsVersion>6.3.0</jasperreportsVersion>
     <jasperreportsMavenPluginVersion>1.0-beta-4-OPENNMS-20160912-1</jasperreportsMavenPluginVersion>
-    <jcifsVersion>1.3.14</jcifsVersion>
+    <jcifsVersion>1.3.19</jcifsVersion>
     <jcommonVersion>1.0.23</jcommonVersion>
     <jettyVersion>9.4.18.v20190429</jettyVersion>
     <jestVersion>5.3.3</jestVersion>

--- a/protocols/cifs/src/main/java/org/opennms/netmgt/poller/monitors/JCifsMonitor.java
+++ b/protocols/cifs/src/main/java/org/opennms/netmgt/poller/monitors/JCifsMonitor.java
@@ -233,6 +233,15 @@ public class JCifsMonitor extends ParameterSubstitutingMonitor {
         finalStaticField.set(null, value);
     }
 
+    /**
+     * Due to limitations of the JCifs library we must use this hack to modify the timeouts. Since the timeouts are set
+     * in a static fields only global timeouts will work reliably.
+     *
+     * @param t the timeout to be set
+     * @throws NoSuchFieldException
+     * @throws ClassNotFoundException
+     * @throws IllegalAccessException
+     */
     private void setJCifsTimeouts(int t) throws NoSuchFieldException, ClassNotFoundException, IllegalAccessException {
         final Class<?> clazz = Class.forName("jcifs.smb.SmbConstants");
         setFinalStatic(clazz.getField("SO_TIMEOUT"), t);

--- a/protocols/cifs/src/test/java/org/opennms/netmgt/poller/monitors/TimeoutTest.java
+++ b/protocols/cifs/src/test/java/org/opennms/netmgt/poller/monitors/TimeoutTest.java
@@ -69,7 +69,6 @@ public class TimeoutTest {
         assertTrue("Limit reached " + delta + " > " + limit, delta <= limit);
     }
 
-
     @Test
     public void testTimeouts() throws Exception {
         // first call took more time

--- a/protocols/cifs/src/test/java/org/opennms/netmgt/poller/monitors/TimeoutTest.java
+++ b/protocols/cifs/src/test/java/org/opennms/netmgt/poller/monitors/TimeoutTest.java
@@ -1,0 +1,82 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.poller.monitors;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Collections;
+import java.util.Map;
+import java.util.TreeMap;
+
+import org.junit.Test;
+import org.opennms.netmgt.poller.MonitoredService;
+import org.opennms.netmgt.poller.PollStatus;
+import org.opennms.netmgt.poller.mock.MonitorTestUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class TimeoutTest {
+    public static final Logger LOG = LoggerFactory.getLogger(TimeoutTest.class);
+
+    public void testTimout(String host, final int timeout, final int limit) throws UnknownHostException {
+        final MonitoredService svc = MonitorTestUtils.getMonitoredService(99, InetAddress.getByName(host), "JCIFS");
+        final Map<String, Object> m = Collections.synchronizedMap(new TreeMap<String, Object>());
+        final JCifsMonitor jCifsMonitor = new JCifsMonitor();
+
+        m.put("username", "user");
+        m.put("password", "pass");
+        m.put("domain", "dom");
+        m.put("mode", "PATH_EXIST");
+        m.put("path", "/share");
+        m.put("timeout", String.valueOf(timeout));
+        m.put("retry", "0");
+
+        long startTime = System.currentTimeMillis();
+        final PollStatus pollStatus = jCifsMonitor.poll(svc, m);
+        long delta = System.currentTimeMillis() - startTime;
+        assertEquals(PollStatus.down(), pollStatus);
+
+        LOG.info("Checking " + delta + " <= " + limit);
+        assertTrue("Limit reached " + delta + " > " + limit, delta <= limit);
+    }
+
+
+    @Test
+    public void testTimeouts() throws Exception {
+        // first call took more time
+        testTimout("169.254.123.123",500, 10000);
+        // but after that the timeouts are correctly applied
+        testTimout("169.254.123.124",1000, 1100);
+        testTimout("169.254.123.125",2000, 2100);
+        testTimout("169.254.123.126",3000, 3100);
+    }
+}


### PR DESCRIPTION
* JIRA: https://issues.opennms.org/browse/NMS-12407

Updated the version of JCIFS. Poller timeouts are now applied in JCifs.