### PR TITLE
NMS-12425: Added simple graph definitions

### DIFF
--- a/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/bmp-graph.properties
+++ b/opennms-base-assembly/src/main/filtered/etc/snmp-graph.properties.d/bmp-graph.properties
@@ -1,0 +1,196 @@
+reports=bmp.duplicate_prefix, \
+bmp.duplicate_withdraw, \
+bmp.duplicate_update, \
+bmp.adj_rib_in, \
+bmp.adj_rib_out, \
+bmp.export_rib, \
+bmp.inv_as_confed_loop, \
+bmp.inv_as_path_loop, \
+bmp.inv_cl_loop, \
+bmp.inv_originator_id, \
+bmp.per_afi_adj_rib_in, \
+bmp.prefix_withdraw, \
+bmp.update_withdraw, \
+bmp.loc_rib, \
+bmp.rejected
+
+report.bmp.duplicate_prefix.name=bmp.duplicate_prefix
+report.bmp.duplicate_prefix.columns=duplicate_prefix
+report.bmp.duplicate_prefix.propertiesValues=address,as,id
+report.bmp.duplicate_prefix.type=bmp
+report.bmp.duplicate_prefix.command=--title="BMP duplicate_prefix, Peer: {address}, AS: {as}, ID: {id}" \
+--vertical-label="duplicate_prefix" \
+DEF:a={rrd1}:duplicate_prefix:AVERAGE \
+LINE2:a#0000ff:"duplicate_prefix" \
+GPRINT:a:AVERAGE:"Avg  \\: %8.2lf %s" \
+GPRINT:a:MIN:"Min  \\: %8.2lf %s" \
+GPRINT:a:MAX:"Max  \\: %8.2lf %s\\n"
+
+report.bmp.duplicate_withdraw.name=bmp.duplicate_withdraw
+report.bmp.duplicate_withdraw.columns=duplicate_withdraw
+report.bmp.duplicate_withdraw.propertiesValues=address,as,id
+report.bmp.duplicate_withdraw.type=bmp
+report.bmp.duplicate_withdraw.command=--title="BMP duplicate_withdraw, Peer: {address}, AS: {as}, ID: {id}" \
+--vertical-label="duplicate_withdraw" \
+DEF:a={rrd1}:duplicate_withdraw:AVERAGE \
+LINE2:a#0000ff:"duplicate_withdraw" \
+GPRINT:a:AVERAGE:"Avg  \\: %8.2lf %s" \
+GPRINT:a:MIN:"Min  \\: %8.2lf %s" \
+GPRINT:a:MAX:"Max  \\: %8.2lf %s\\n"
+
+report.bmp.duplicate_update.name=bmp.duplicate_update
+report.bmp.duplicate_update.columns=duplicate_update
+report.bmp.duplicate_update.propertiesValues=address,as,id
+report.bmp.duplicate_update.type=bmp
+report.bmp.duplicate_update.command=--title="BMP duplicate_update, Peer: {address}, AS: {as}, ID: {id}" \
+--vertical-label="duplicate_update" \
+DEF:a={rrd1}:duplicate_update:AVERAGE \
+LINE2:a#0000ff:"duplicate_update" \
+GPRINT:a:AVERAGE:"Avg  \\: %8.2lf %s" \
+GPRINT:a:MIN:"Min  \\: %8.2lf %s" \
+GPRINT:a:MAX:"Max  \\: %8.2lf %s\\n"
+
+report.bmp.adj_rib_in.name=bmp.adj_rib_in
+report.bmp.adj_rib_in.columns=adj_rib_in
+report.bmp.adj_rib_in.propertiesValues=address,as,id
+report.bmp.adj_rib_in.type=bmp
+report.bmp.adj_rib_in.command=--title="BMP adj_rib_in, Peer: {address}, AS: {as}, ID: {id}" \
+--vertical-label="adj_rib_in" \
+DEF:a={rrd1}:adj_rib_in:AVERAGE \
+LINE2:a#0000ff:"adj_rib_in" \
+GPRINT:a:AVERAGE:"Avg  \\: %8.2lf %s" \
+GPRINT:a:MIN:"Min  \\: %8.2lf %s" \
+GPRINT:a:MAX:"Max  \\: %8.2lf %s\\n"
+
+report.bmp.adj_rib_out.name=bmp.adj_rib_out
+report.bmp.adj_rib_out.columns=adj_rib_out
+report.bmp.adj_rib_out.propertiesValues=address,as,id
+report.bmp.adj_rib_out.type=bmp
+report.bmp.adj_rib_out.command=--title="BMP adj_rib_out, Peer: {address}, AS: {as}, ID: {id}" \
+--vertical-label="adj_rib_out" \
+DEF:a={rrd1}:adj_rib_out:AVERAGE \
+LINE2:a#0000ff:"adj_rib_out" \
+GPRINT:a:AVERAGE:"Avg  \\: %8.2lf %s" \
+GPRINT:a:MIN:"Min  \\: %8.2lf %s" \
+GPRINT:a:MAX:"Max  \\: %8.2lf %s\\n"
+
+report.bmp.export_rib.name=bmp.export_rib
+report.bmp.export_rib.columns=export_rib
+report.bmp.export_rib.propertiesValues=address,as,id
+report.bmp.export_rib.type=bmp
+report.bmp.export_rib.command=--title="BMP export_rib, Peer: {address}, AS: {as}, ID: {id}" \
+--vertical-label="export_rib" \
+DEF:a={rrd1}:export_rib:AVERAGE \
+LINE2:a#0000ff:"export_rib" \
+GPRINT:a:AVERAGE:"Avg  \\: %8.2lf %s" \
+GPRINT:a:MIN:"Min  \\: %8.2lf %s" \
+GPRINT:a:MAX:"Max  \\: %8.2lf %s\\n"
+
+report.bmp.inv_as_confed_loop.name=bmp.inv_as_confed_loop
+report.bmp.inv_as_confed_loop.columns=inv_as_confed_loop
+report.bmp.inv_as_confed_loop.propertiesValues=address,as,id
+report.bmp.inv_as_confed_loop.type=bmp
+report.bmp.inv_as_confed_loop.command=--title="BMP inv_as_confed_loop, Peer: {address}, AS: {as}, ID: {id}" \
+--vertical-label="inv_as_confed_loop" \
+DEF:a={rrd1}:inv_as_confed_loop:AVERAGE \
+LINE2:a#0000ff:"inv_as_confed_loop" \
+GPRINT:a:AVERAGE:"Avg  \\: %8.2lf %s" \
+GPRINT:a:MIN:"Min  \\: %8.2lf %s" \
+GPRINT:a:MAX:"Max  \\: %8.2lf %s\\n"
+
+report.bmp.inv_as_path_loop.name=bmp.inv_as_path_loop
+report.bmp.inv_as_path_loop.columns=inv_as_path_loop
+report.bmp.inv_as_path_loop.propertiesValues=address,as,id
+report.bmp.inv_as_path_loop.type=bmp
+report.bmp.inv_as_path_loop.command=--title="BMP inv_as_path_loop, Peer: {address}, AS: {as}, ID: {id}" \
+--vertical-label="inv_as_path_loop" \
+DEF:a={rrd1}:inv_as_path_loop:AVERAGE \
+LINE2:a#0000ff:"inv_as_path_loop" \
+GPRINT:a:AVERAGE:"Avg  \\: %8.2lf %s" \
+GPRINT:a:MIN:"Min  \\: %8.2lf %s" \
+GPRINT:a:MAX:"Max  \\: %8.2lf %s\\n"
+
+report.bmp.inv_cl_loop.name=bmp.inv_cl_loop
+report.bmp.inv_cl_loop.columns=inv_cl_loop
+report.bmp.inv_cl_loop.propertiesValues=address,as,id
+report.bmp.inv_cl_loop.type=bmp
+report.bmp.inv_cl_loop.command=--title="BMP inv_cl_loop, Peer: {address}, AS: {as}, ID: {id}" \
+--vertical-label="inv_cl_loop" \
+DEF:a={rrd1}:inv_cl_loop:AVERAGE \
+LINE2:a#0000ff:"inv_cl_loop" \
+GPRINT:a:AVERAGE:"Avg  \\: %8.2lf %s" \
+GPRINT:a:MIN:"Min  \\: %8.2lf %s" \
+GPRINT:a:MAX:"Max  \\: %8.2lf %s\\n"
+
+report.bmp.inv_originator_id.name=bmp.inv_originator_id
+report.bmp.inv_originator_id.columns=inv_originator_id
+report.bmp.inv_originator_id.propertiesValues=address,as,id
+report.bmp.inv_originator_id.type=bmp
+report.bmp.inv_originator_id.command=--title="BMP inv_originator_id, Peer: {address}, AS: {as}, ID: {id}" \
+--vertical-label="inv_originator_id" \
+DEF:a={rrd1}:inv_originator_id:AVERAGE \
+LINE2:a#0000ff:"inv_originator_id" \
+GPRINT:a:AVERAGE:"Avg  \\: %8.2lf %s" \
+GPRINT:a:MIN:"Min  \\: %8.2lf %s" \
+GPRINT:a:MAX:"Max  \\: %8.2lf %s\\n"
+
+report.bmp.per_afi_adj_rib_in.name=bmp.per_afi_adj_rib_in
+report.bmp.per_afi_adj_rib_in.columns=per_afi_adj_rib_in
+report.bmp.per_afi_adj_rib_in.propertiesValues=address,as,id
+report.bmp.per_afi_adj_rib_in.type=bmp
+report.bmp.per_afi_adj_rib_in.command=--title="BMP per_afi_adj_rib_in, Peer: {address}, AS: {as}, ID: {id}" \
+--vertical-label="per_afi_adj_rib_in" \
+DEF:a={rrd1}:per_afi_adj_rib_in:AVERAGE \
+LINE2:a#0000ff:"per_afi_adj_rib_in" \
+GPRINT:a:AVERAGE:"Avg  \\: %8.2lf %s" \
+GPRINT:a:MIN:"Min  \\: %8.2lf %s" \
+GPRINT:a:MAX:"Max  \\: %8.2lf %s\\n"
+
+report.bmp.prefix_withdraw.name=bmp.prefix_withdraw
+report.bmp.prefix_withdraw.columns=prefix_withdraw
+report.bmp.prefix_withdraw.propertiesValues=address,as,id
+report.bmp.prefix_withdraw.type=bmp
+report.bmp.prefix_withdraw.command=--title="BMP prefix_withdraw, Peer: {address}, AS: {as}, ID: {id}" \
+--vertical-label="prefix_withdraw" \
+DEF:a={rrd1}:prefix_withdraw:AVERAGE \
+LINE2:a#0000ff:"prefix_withdraw" \
+GPRINT:a:AVERAGE:"Avg  \\: %8.2lf %s" \
+GPRINT:a:MIN:"Min  \\: %8.2lf %s" \
+GPRINT:a:MAX:"Max  \\: %8.2lf %s\\n"
+
+report.bmp.update_withdraw.name=bmp.update_withdraw
+report.bmp.update_withdraw.columns=update_withdraw
+report.bmp.update_withdraw.propertiesValues=address,as,id
+report.bmp.update_withdraw.type=bmp
+report.bmp.update_withdraw.command=--title="BMP update_withdraw, Peer: {address}, AS: {as}, ID: {id}" \
+--vertical-label="update_withdraw" \
+DEF:a={rrd1}:update_withdraw:AVERAGE \
+LINE2:a#0000ff:"update_withdraw" \
+GPRINT:a:AVERAGE:"Avg  \\: %8.2lf %s" \
+GPRINT:a:MIN:"Min  \\: %8.2lf %s" \
+GPRINT:a:MAX:"Max  \\: %8.2lf %s\\n"
+
+report.bmp.loc_rib.name=bmp.loc_rib
+report.bmp.loc_rib.columns=loc_rib
+report.bmp.loc_rib.propertiesValues=address,as,id
+report.bmp.loc_rib.type=bmp
+report.bmp.loc_rib.command=--title="BMP loc_rib, Peer: {address}, AS: {as}, ID: {id}" \
+--vertical-label="loc_rib" \
+DEF:a={rrd1}:loc_rib:AVERAGE \
+LINE2:a#0000ff:"loc_rib" \
+GPRINT:a:AVERAGE:"Avg  \\: %8.2lf %s" \
+GPRINT:a:MIN:"Min  \\: %8.2lf %s" \
+GPRINT:a:MAX:"Max  \\: %8.2lf %s\\n"
+
+report.bmp.rejected.name=bmp.rejected
+report.bmp.rejected.columns=rejected
+report.bmp.rejected.propertiesValues=address,as,id
+report.bmp.rejected.type=bmp
+report.bmp.rejected.command=--title="BMP rejected, Peer: {address}, AS: {as}, ID: {id}" \
+--vertical-label="rejected" \
+DEF:a={rrd1}:rejected:AVERAGE \
+LINE2:a#0000ff:"rejected" \
+GPRINT:a:AVERAGE:"Avg  \\: %8.2lf %s" \
+GPRINT:a:MIN:"Min  \\: %8.2lf %s" \
+GPRINT:a:MAX:"Max  \\: %8.2lf %s\\n"
+


### PR DESCRIPTION
* JIRA: https://issues.opennms.org/browse/NMS-12425

Simple graph definitions for each metric. This PR is based on branch `jira/NMS-12414` and only adds the file `etc/snmp-graph.properties.d/bmp-graph.properties`. 