### PR TITLE
Use SessionUtils instead of TransactionOperations

### DIFF
--- a/features/flows/classification/engine/impl/src/main/java/org/opennms/netmgt/flows/classification/internal/ClassificationEngineInitializer.java
+++ b/features/flows/classification/engine/impl/src/main/java/org/opennms/netmgt/flows/classification/internal/ClassificationEngineInitializer.java
@@ -28,16 +28,16 @@
 
 package org.opennms.netmgt.flows.classification.internal;
 
+import org.opennms.netmgt.dao.api.SessionUtils;
 import org.opennms.netmgt.flows.classification.ClassificationEngine;
-import org.springframework.transaction.support.TransactionOperations;
 
 // Is required to initialize the classification engine properly, as it requires a transaction to load correctly.
 // While starting the bundle, the initialization occurs from within the blueprint container, thus no transaction is available
 // This bean wraps the loading in a transaction, ensuring loading can occurr correctly
 public class ClassificationEngineInitializer {
 
-    public ClassificationEngineInitializer(ClassificationEngine engine, TransactionOperations transactionOperations) {
-        transactionOperations.execute(callback -> {
+    public ClassificationEngineInitializer(ClassificationEngine engine, SessionUtils sessionUtils) {
+        sessionUtils.withReadOnlyTransaction(() -> {
             engine.reload();
             return null;
         });

--- a/features/flows/classification/engine/impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/features/flows/classification/engine/impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -24,7 +24,7 @@
     <reference id="classificationRuleDao" interface="org.opennms.netmgt.flows.classification.persistence.api.ClassificationRuleDao" availability="mandatory"/>
     <reference id="classificationGroupDao" interface="org.opennms.netmgt.flows.classification.persistence.api.ClassificationGroupDao" availability="mandatory"/>
     <reference id="filterDao" interface="org.opennms.netmgt.filter.api.FilterDao" availability="mandatory"/>
-    <reference id="transactionOperations" interface="org.springframework.transaction.support.TransactionOperations" availability="mandatory"/>
+    <reference id="sessionUtils" interface="org.opennms.netmgt.dao.api.SessionUtils" availability="mandatory"/>
     <reference id="sentinelIdentity" interface="org.opennms.distributed.core.api.Identity" filter="(systemType=Sentinel)" availability="optional" />
 
     <!-- CacheConfig -->
@@ -66,7 +66,7 @@
     </bean>
     <bean id="classificationEngineInitializer" class="org.opennms.netmgt.flows.classification.internal.ClassificationEngineInitializer">
         <argument ref="threadSafeClassificationEngine"/>
-        <argument ref="transactionOperations" />
+        <argument ref="sessionUtils" />
     </bean>
 
     <!-- Metrics -->
@@ -91,7 +91,7 @@
             <argument ref="classificationGroupDao"/>
             <argument ref="threadSafeClassificationEngine"/>
             <argument ref="cachingFilterService" />
-            <argument ref="transactionOperations"/>
+            <argument ref="sessionUtils"/>
         </bean>
     </service>
 

--- a/features/flows/classification/engine/impl/src/test/java/org/opennms/netmgt/flows/classification/internal/DefaultClassificationServiceIT.java
+++ b/features/flows/classification/engine/impl/src/test/java/org/opennms/netmgt/flows/classification/internal/DefaultClassificationServiceIT.java
@@ -41,6 +41,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.opennms.core.test.OpenNMSJUnit4ClassRunner;
 import org.opennms.core.test.db.annotations.JUnitTemporaryDatabase;
+import org.opennms.netmgt.dao.api.SessionUtils;
 import org.opennms.netmgt.filter.api.FilterDao;
 import org.opennms.netmgt.flows.classification.ClassificationService;
 import org.opennms.netmgt.flows.classification.FilterService;
@@ -57,7 +58,6 @@ import org.opennms.test.JUnitConfigurationEnvironment;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.transaction.support.TransactionOperations;
 
 @RunWith(OpenNMSJUnit4ClassRunner.class)
 @ContextConfiguration(locations = {
@@ -82,7 +82,7 @@ public class DefaultClassificationServiceIT {
     private FilterDao filterDao;
 
     @Autowired
-    private TransactionOperations transactionOperations;
+    private SessionUtils sessionUtils;
 
     private ClassificationService classificationService;
 
@@ -98,7 +98,7 @@ public class DefaultClassificationServiceIT {
                 new DefaultClassificationEngine(
                         new DaoClassificationRuleProvider(ruleDao), filterService),
                 filterService,
-                transactionOperations);
+                sessionUtils);
         userGroupDb = new GroupBuilder().withName(Groups.USER_DEFINED).build();
         groupDao.save(userGroupDb);
         assertThat(ruleDao.countAll(), is(0));


### PR DESCRIPTION
Here we migrate yet another module to use `SessionUtils` instead of `TransactionOperations` to get rid of weird `Dependency not resolvable` issues when refreshing a bundle and some bundles are using `TransactionOperations`