### PR TITLE
NMS-12415: Added BMP peer status adapter

### DIFF
--- a/features/events/api/src/main/java/org/opennms/netmgt/events/api/EventConstants.java
+++ b/features/events/api/src/main/java/org/opennms/netmgt/events/api/EventConstants.java
@@ -954,6 +954,12 @@ public abstract class EventConstants {
     public static final String PARM_ENDPOINT2 = "endPoint2";
 
     //
+    // for BMP
+    //
+    public static final String BMP_PEER_DOWN = "uei.opennms.org/bmp/peerDown";
+    public static final String BMP_PEER_UP = "uei.opennms.org/bmp/peerUp";
+
+    //
     // for Bsmd
     //
     public static final String BUSINESS_SERVICE_OPERATIONAL_STATUS_CHANGED_UEI = "uei.opennms.org/bsm/serviceOperationalStatusChanged";

--- a/features/telemetry/protocols/bmp/adapter/src/main/java/org/opennms/netmgt/telemetry/protocols/bmp/adapter/BmpPeerStatusAdapter.java
+++ b/features/telemetry/protocols/bmp/adapter/src/main/java/org/opennms/netmgt/telemetry/protocols/bmp/adapter/BmpPeerStatusAdapter.java
@@ -1,0 +1,130 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2017-2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.telemetry.protocols.bmp.adapter;
+
+import static org.opennms.netmgt.telemetry.protocols.common.utils.BsonUtils.first;
+import static org.opennms.netmgt.telemetry.protocols.common.utils.BsonUtils.getInt64;
+import static org.opennms.netmgt.telemetry.protocols.common.utils.BsonUtils.getString;
+
+import java.net.InetAddress;
+import java.time.Instant;
+import java.util.Date;
+import java.util.Optional;
+
+import org.bson.BsonDocument;
+import org.bson.RawBsonDocument;
+import org.opennms.core.utils.InetAddressUtils;
+import org.opennms.netmgt.dao.api.InterfaceToNodeCache;
+import org.opennms.netmgt.events.api.EventConstants;
+import org.opennms.netmgt.events.api.EventForwarder;
+import org.opennms.netmgt.model.events.EventBuilder;
+import org.opennms.netmgt.telemetry.api.adapter.TelemetryMessageLog;
+import org.opennms.netmgt.telemetry.api.adapter.TelemetryMessageLogEntry;
+import org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bmp.Header;
+import org.opennms.netmgt.telemetry.protocols.collection.AbstractAdapter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.codahale.metrics.MetricRegistry;
+
+public class BmpPeerStatusAdapter extends AbstractAdapter {
+
+    private static final Logger LOG = LoggerFactory.getLogger(BmpPeerStatusAdapter.class);
+
+    private InterfaceToNodeCache interfaceToNodeCache;
+
+    private EventForwarder eventForwarder;
+
+    public BmpPeerStatusAdapter(final String name,
+                                final MetricRegistry metricRegistry) {
+        super(name, metricRegistry);
+    }
+
+    @Override
+    public void handleMessage(final TelemetryMessageLogEntry message,
+                              final TelemetryMessageLog messageLog) {
+        LOG.trace("Parsing packet: {}", message);
+        final BsonDocument document = new RawBsonDocument(message.getByteArray());
+
+        // This adapter only cares about peer up/down packets
+        if (!getString(document, "@type")
+                .map(type -> Header.Type.PEER_UP_NOTIFICATION.name().equals(type) ||
+                             Header.Type.PEER_DOWN_NOTIFICATION.name().equals(type))
+                .orElse(false)) {
+            return;
+        }
+
+        // Find the node for the router who has exported the peer status notification
+        final InetAddress exporterAddress = InetAddressUtils.getInetAddress(messageLog.getSourceAddress());
+        final Optional<Integer> exporterNodeId = this.interfaceToNodeCache.getFirstNodeId(messageLog.getLocation(), exporterAddress);
+        if (!exporterNodeId.isPresent()) {
+            LOG.warn("Unable to find node for exporter: {}", exporterAddress);
+            return;
+        }
+
+        final boolean up = getString(document, "@type")
+                .map(type -> Header.Type.PEER_UP_NOTIFICATION.name().equals(type))
+                .orElse(false);
+
+        final String uei = up
+                           ? EventConstants.BMP_PEER_UP
+                           : EventConstants.BMP_PEER_DOWN;
+
+        final Instant timestamp = Instant.ofEpochSecond(getInt64(document, "peer", "timestamp", "epoch").get(),
+                                                        getInt64(document, "peer", "timestamp", "nanos").orElse(0L));
+
+        final EventBuilder event = new EventBuilder(uei, "telemetryd:" + this.adapterConfig.getName(), Date.from(timestamp));
+        event.setNodeid(exporterNodeId.get());
+        event.setInterface(exporterAddress);
+
+        // Extract peer details
+        getInt64(document, "peer", "distinguisher").ifPresent(value -> event.addParam("distinguisher", Long.toString(value)));
+        getString(document, "peer", "address").ifPresent(value -> event.addParam("address", value));
+        getInt64(document, "peer", "as").ifPresent(value -> event.addParam("as", Long.toString(value)));
+        getInt64(document, "peer", "id").ifPresent(value -> event.addParam("id", Long.toString(value)));
+
+        // Extract error details
+        if (!up) {
+            getString(document, "type").ifPresent(value -> event.addParam("type", value));
+            first(getInt64(document, "code").map(code -> "Code " + code),
+                  getString(document, "error"))
+                    .ifPresent(value -> event.addParam("error", value));
+        }
+
+        this.eventForwarder.sendNow(event.getEvent());
+    }
+
+    public void setInterfaceToNodeCache(final InterfaceToNodeCache interfaceToNodeCache) {
+        this.interfaceToNodeCache = interfaceToNodeCache;
+    }
+
+    public void setEventForwarder(final EventForwarder eventForwarder) {
+        this.eventForwarder = eventForwarder;
+    }
+}

--- a/features/telemetry/protocols/bmp/adapter/src/main/java/org/opennms/netmgt/telemetry/protocols/bmp/adapter/BmpPeerStatusAdapterFactory.java
+++ b/features/telemetry/protocols/bmp/adapter/src/main/java/org/opennms/netmgt/telemetry/protocols/bmp/adapter/BmpPeerStatusAdapterFactory.java
@@ -1,0 +1,82 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2017-2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.telemetry.protocols.bmp.adapter;
+
+import org.opennms.netmgt.events.api.EventForwarder;
+import org.opennms.netmgt.telemetry.api.adapter.Adapter;
+import org.opennms.netmgt.telemetry.config.api.AdapterDefinition;
+import org.opennms.netmgt.telemetry.protocols.collection.AbstractAdapterFactory;
+import org.opennms.netmgt.telemetry.protocols.collection.AbstractCollectionAdapterFactory;
+import org.osgi.framework.BundleContext;
+import org.springframework.beans.BeanWrapper;
+import org.springframework.beans.PropertyAccessorFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import jdk.nashorn.internal.ir.annotations.Reference;
+
+public class BmpPeerStatusAdapterFactory extends AbstractAdapterFactory {
+
+    @Autowired
+    private EventForwarder eventForwarder;
+
+    public BmpPeerStatusAdapterFactory() {
+        super(null);
+    }
+
+    public BmpPeerStatusAdapterFactory(BundleContext bundleContext) {
+        super(bundleContext);
+    }
+
+    @Override
+    public Class<? extends Adapter> getBeanClass() {
+        return BmpPeerStatusAdapter.class;
+    }
+
+    @Override
+    public Adapter createBean(final AdapterDefinition adapterConfig) {
+        final BmpPeerStatusAdapter adapter = new BmpPeerStatusAdapter(adapterConfig.getName(), this.getTelemetryRegistry().getMetricRegistry());
+        adapter.setBundleContext(this.getBundleContext());
+        adapter.setConfig(adapterConfig);
+        adapter.setInterfaceToNodeCache(this.getInterfaceToNodeCache());
+        adapter.setEventForwarder(this.eventForwarder);
+
+        final BeanWrapper wrapper = PropertyAccessorFactory.forBeanPropertyAccess(adapter);
+        wrapper.setPropertyValues(adapterConfig.getParameterMap());
+
+        return adapter;
+    }
+
+    public EventForwarder getEventForwarder() {
+        return this.eventForwarder;
+    }
+
+    public void setEventForwarder(final EventForwarder eventForwarder) {
+        this.eventForwarder = eventForwarder;
+    }
+}

--- a/features/telemetry/protocols/bmp/adapter/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/features/telemetry/protocols/bmp/adapter/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -11,6 +11,7 @@
 	<reference id="transactionTemplate" interface="org.springframework.transaction.support.TransactionOperations" />
 	<reference id="persisterFactory" interface="org.opennms.netmgt.collection.api.PersisterFactory" />
 	<reference id="thresholdingService" interface="org.opennms.netmgt.threshd.api.ThresholdingService" />
+	<reference id="eventForwarder" interface="org.opennms.netmgt.events.api.EventForwarder" />
 
 	<!-- Telemetry Adapter -->
 	<bean id="bmpTelemetryFactory" class="org.opennms.netmgt.telemetry.protocols.bmp.adapter.BmpTelemetryAdapterFactory">
@@ -25,6 +26,19 @@
 		<property name="thresholdingService" ref="thresholdingService" />
 	</bean>
 	<service ref="bmpTelemetryFactory" interface="org.opennms.netmgt.telemetry.api.adapter.AdapterFactory">
+		<service-properties>
+			<entry key="registration.export" value="true" />
+		</service-properties>
+	</service>
+
+	<!-- Peer Status Adapter -->
+	<bean id="bmpPeerStatusFactory" class="org.opennms.netmgt.telemetry.protocols.bmp.adapter.BmpPeerStatusAdapterFactory">
+		<argument ref="blueprintBundleContext" />
+		<property name="telemetryRegistry" ref="telemetryRegistry" />
+		<property name="interfaceToNodeCache" ref="interfaceToNodeCache" />
+		<property name="eventForwarder" ref="eventForwarder" />
+	</bean>
+	<service ref="bmpPeerStatusFactory" interface="org.opennms.netmgt.telemetry.api.adapter.AdapterFactory">
 		<service-properties>
 			<entry key="registration.export" value="true" />
 		</service-properties>

--- a/features/telemetry/protocols/collection/src/main/java/org/opennms/netmgt/telemetry/protocols/collection/AbstractAdapter.java
+++ b/features/telemetry/protocols/collection/src/main/java/org/opennms/netmgt/telemetry/protocols/collection/AbstractAdapter.java
@@ -1,0 +1,97 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.telemetry.protocols.collection;
+
+import static com.codahale.metrics.MetricRegistry.name;
+
+import java.util.Objects;
+import java.util.stream.Stream;
+
+import org.opennms.netmgt.telemetry.api.adapter.Adapter;
+import org.opennms.netmgt.telemetry.api.adapter.TelemetryMessageLog;
+import org.opennms.netmgt.telemetry.api.adapter.TelemetryMessageLogEntry;
+import org.opennms.netmgt.telemetry.config.api.AdapterDefinition;
+import org.osgi.framework.BundleContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.codahale.metrics.Histogram;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
+
+public abstract class AbstractAdapter implements Adapter {
+    protected final Logger LOG = LoggerFactory.getLogger(AbstractAdapter.class);
+
+    /**
+     * Time taken to handle a log
+     */
+    protected final Timer logParsingTimer;
+
+    /**
+     * Number of message per log
+     */
+    protected final Histogram packetsPerLogHistogram;
+
+    protected BundleContext bundleContext;
+
+    protected AdapterDefinition adapterConfig;
+
+    public AbstractAdapter(final String name, final MetricRegistry metricRegistry) {
+        Objects.requireNonNull(name);
+        Objects.requireNonNull(metricRegistry);
+
+        this.logParsingTimer = metricRegistry.timer(name("adapters", name, "logParsing"));
+        this.packetsPerLogHistogram = metricRegistry.histogram(name("adapters", name, "packetsPerLog"));
+    }
+
+    public abstract void handleMessage(TelemetryMessageLogEntry message, TelemetryMessageLog messageLog);
+
+    @Override
+    public void handleMessageLog(final TelemetryMessageLog messageLog) {
+        try (final Timer.Context ctx = logParsingTimer.time()) {
+            for (final TelemetryMessageLogEntry message : messageLog.getMessageList()) {
+                this.handleMessage(message, messageLog);
+            }
+            packetsPerLogHistogram.update(messageLog.getMessageList().size());
+        }
+    }
+
+    @Override
+    public void destroy() {
+    }
+
+    public void setBundleContext(final BundleContext bundleContext) {
+        this.bundleContext = bundleContext;
+    }
+
+    @Override
+    public void setConfig(final AdapterDefinition adapterConfig) {
+        this.adapterConfig = adapterConfig;
+    }
+}

--- a/features/telemetry/protocols/collection/src/main/java/org/opennms/netmgt/telemetry/protocols/collection/AbstractAdapterFactory.java
+++ b/features/telemetry/protocols/collection/src/main/java/org/opennms/netmgt/telemetry/protocols/collection/AbstractAdapterFactory.java
@@ -1,0 +1,69 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.telemetry.protocols.collection;
+
+import org.opennms.netmgt.dao.api.InterfaceToNodeCache;
+import org.opennms.netmgt.telemetry.api.adapter.AdapterFactory;
+import org.opennms.netmgt.telemetry.api.registry.TelemetryRegistry;
+import org.osgi.framework.BundleContext;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public abstract class AbstractAdapterFactory implements AdapterFactory {
+    protected final BundleContext bundleContext;
+
+    @Autowired
+    private InterfaceToNodeCache interfaceToNodeCache;
+
+    @Autowired
+    private TelemetryRegistry telemetryRegistry;
+
+    public AbstractAdapterFactory(final BundleContext bundleContext) {
+        this.bundleContext = bundleContext;
+    }
+
+    public BundleContext getBundleContext() {
+        return this.bundleContext;
+    }
+
+    public InterfaceToNodeCache getInterfaceToNodeCache() {
+        return this.interfaceToNodeCache;
+    }
+
+    public void setInterfaceToNodeCache(final InterfaceToNodeCache interfaceToNodeCache) {
+        this.interfaceToNodeCache = interfaceToNodeCache;
+    }
+
+    public TelemetryRegistry getTelemetryRegistry() {
+        return this.telemetryRegistry;
+    }
+
+    public void setTelemetryRegistry(final TelemetryRegistry telemetryRegistry) {
+        this.telemetryRegistry = telemetryRegistry;
+    }
+}

--- a/features/telemetry/protocols/collection/src/main/java/org/opennms/netmgt/telemetry/protocols/collection/AbstractCollectionAdapterFactory.java
+++ b/features/telemetry/protocols/collection/src/main/java/org/opennms/netmgt/telemetry/protocols/collection/AbstractCollectionAdapterFactory.java
@@ -42,16 +42,10 @@ import org.osgi.framework.BundleContext;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.support.TransactionOperations;
 
-public abstract class AbstractCollectionAdapterFactory implements AdapterFactory {
-
-    @Autowired
-    private TelemetryRegistry telemetryRegistry;
+public abstract class AbstractCollectionAdapterFactory extends AbstractAdapterFactory {
 
     @Autowired
     private CollectionAgentFactory collectionAgentFactory;
-
-    @Autowired
-    private InterfaceToNodeCache interfaceToNodeCache;
 
     @Autowired
     private NodeDao nodeDao;
@@ -68,22 +62,8 @@ public abstract class AbstractCollectionAdapterFactory implements AdapterFactory
     @Autowired
     private ThresholdingService thresholdingService;
 
-    private final BundleContext bundleContext;
-
-    public TelemetryRegistry getTelemetryRegistry() {
-        return telemetryRegistry;
-    }
-
-    public void setTelemetryRegistry(TelemetryRegistry telemetryRegistry) {
-        this.telemetryRegistry = telemetryRegistry;
-    }
-
     public AbstractCollectionAdapterFactory(BundleContext bundleContext) {
-        this.bundleContext = bundleContext;
-    }
-
-    public BundleContext getBundleContext() {
-        return bundleContext;
+        super(bundleContext);
     }
 
     public CollectionAgentFactory getCollectionAgentFactory() {
@@ -92,14 +72,6 @@ public abstract class AbstractCollectionAdapterFactory implements AdapterFactory
 
     public void setCollectionAgentFactory(CollectionAgentFactory collectionAgentFactory) {
         this.collectionAgentFactory = collectionAgentFactory;
-    }
-
-    public InterfaceToNodeCache getInterfaceToNodeCache() {
-        return interfaceToNodeCache;
-    }
-
-    public void setInterfaceToNodeCache(InterfaceToNodeCache interfaceToNodeCache) {
-        this.interfaceToNodeCache = interfaceToNodeCache;
     }
 
     public NodeDao getNodeDao() {

--- a/features/telemetry/protocols/collection/src/main/java/org/opennms/netmgt/telemetry/protocols/collection/AbstractScriptedCollectionAdapter.java
+++ b/features/telemetry/protocols/collection/src/main/java/org/opennms/netmgt/telemetry/protocols/collection/AbstractScriptedCollectionAdapter.java
@@ -44,7 +44,7 @@ import org.osgi.framework.BundleContext;
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.base.Strings;
 
-public abstract class AbstractScriptedPersistingAdapter extends AbstractPersistingAdapter {
+public abstract class AbstractScriptedCollectionAdapter extends AbstractCollectionAdapter {
 
     private FileUpdateWatcher scriptUpdateWatcher;
 
@@ -88,7 +88,7 @@ public abstract class AbstractScriptedPersistingAdapter extends AbstractPersisti
      */
     private Map<ScriptedCollectionSetBuilder, Boolean> scriptUpdateMap = new ConcurrentHashMap<>();
 
-    public AbstractScriptedPersistingAdapter(String name, MetricRegistry metricRegistry) {
+    public AbstractScriptedCollectionAdapter(String name, MetricRegistry metricRegistry) {
         super(name, metricRegistry);
     }
 

--- a/features/telemetry/protocols/jti/adapter/src/main/java/org/opennms/netmgt/telemetry/protocols/jti/adapter/JtiGpbAdapter.java
+++ b/features/telemetry/protocols/jti/adapter/src/main/java/org/opennms/netmgt/telemetry/protocols/jti/adapter/JtiGpbAdapter.java
@@ -44,7 +44,7 @@ import org.opennms.netmgt.model.OnmsIpInterface;
 import org.opennms.netmgt.model.OnmsNode;
 import org.opennms.netmgt.telemetry.api.adapter.TelemetryMessageLog;
 import org.opennms.netmgt.telemetry.api.adapter.TelemetryMessageLogEntry;
-import org.opennms.netmgt.telemetry.protocols.collection.AbstractScriptedPersistingAdapter;
+import org.opennms.netmgt.telemetry.protocols.collection.AbstractScriptedCollectionAdapter;
 import org.opennms.netmgt.telemetry.protocols.collection.CollectionSetWithAgent;
 import org.opennms.netmgt.telemetry.protocols.collection.ScriptedCollectionSetBuilder;
 import org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.CpuMemoryUtilizationOuterClass;
@@ -73,7 +73,7 @@ import com.google.protobuf.InvalidProtocolBufferException;
  *
  * @author jwhite
  */
-public class JtiGpbAdapter extends AbstractScriptedPersistingAdapter {
+public class JtiGpbAdapter extends AbstractScriptedCollectionAdapter {
     private static final Logger LOG = LoggerFactory.getLogger(JtiGpbAdapter.class);
 
     private static final ExtensionRegistry s_registry = ExtensionRegistry.newInstance();
@@ -100,7 +100,7 @@ public class JtiGpbAdapter extends AbstractScriptedPersistingAdapter {
     }
 
     @Override
-    public Stream<CollectionSetWithAgent> handleMessage(TelemetryMessageLogEntry message, TelemetryMessageLog messageLog) {
+    public Stream<CollectionSetWithAgent> handleCollectionMessage(TelemetryMessageLogEntry message, TelemetryMessageLog messageLog) {
         final TelemetryTop.TelemetryStream jtiMsg;
         try {
             jtiMsg = TelemetryTop.TelemetryStream.parseFrom(message.getByteArray(), s_registry);

--- a/features/telemetry/protocols/nxos/adapter/src/main/java/org/opennms/netmgt/telemetry/protocols/nxos/adapter/NxosGpbAdapter.java
+++ b/features/telemetry/protocols/nxos/adapter/src/main/java/org/opennms/netmgt/telemetry/protocols/nxos/adapter/NxosGpbAdapter.java
@@ -45,7 +45,7 @@ import org.opennms.netmgt.model.OnmsIpInterface;
 import org.opennms.netmgt.model.OnmsNode;
 import org.opennms.netmgt.telemetry.api.adapter.TelemetryMessageLog;
 import org.opennms.netmgt.telemetry.api.adapter.TelemetryMessageLogEntry;
-import org.opennms.netmgt.telemetry.protocols.collection.AbstractScriptedPersistingAdapter;
+import org.opennms.netmgt.telemetry.protocols.collection.AbstractScriptedCollectionAdapter;
 import org.opennms.netmgt.telemetry.protocols.collection.CollectionSetWithAgent;
 import org.opennms.netmgt.telemetry.protocols.collection.ScriptedCollectionSetBuilder;
 import org.opennms.netmgt.telemetry.protocols.nxos.adapter.proto.TelemetryBis;
@@ -62,7 +62,7 @@ import com.google.common.collect.Iterables;
 import com.google.protobuf.ExtensionRegistry;
 import com.google.protobuf.InvalidProtocolBufferException;
 
-public class NxosGpbAdapter extends AbstractScriptedPersistingAdapter {
+public class NxosGpbAdapter extends AbstractScriptedCollectionAdapter {
 
     private static final Logger LOG = LoggerFactory.getLogger(NxosGpbAdapter.class);
 
@@ -89,7 +89,7 @@ public class NxosGpbAdapter extends AbstractScriptedPersistingAdapter {
     }
 
     @Override
-    public Stream<CollectionSetWithAgent> handleMessage(TelemetryMessageLogEntry message, TelemetryMessageLog messageLog) {
+    public Stream<CollectionSetWithAgent> handleCollectionMessage(TelemetryMessageLogEntry message, TelemetryMessageLog messageLog) {
         final Telemetry msg;
         try {
             msg = tryParsingTelemetryMessage(message.getByteArray());

--- a/features/telemetry/protocols/sflow/adapter/src/main/java/org/opennms/netmgt/telemetry/protocols/sflow/adapter/SFlowTelemetryAdapter.java
+++ b/features/telemetry/protocols/sflow/adapter/src/main/java/org/opennms/netmgt/telemetry/protocols/sflow/adapter/SFlowTelemetryAdapter.java
@@ -47,7 +47,7 @@ import org.opennms.netmgt.collection.api.CollectionSet;
 import org.opennms.netmgt.dao.api.InterfaceToNodeCache;
 import org.opennms.netmgt.telemetry.api.adapter.TelemetryMessageLog;
 import org.opennms.netmgt.telemetry.api.adapter.TelemetryMessageLogEntry;
-import org.opennms.netmgt.telemetry.protocols.collection.AbstractScriptedPersistingAdapter;
+import org.opennms.netmgt.telemetry.protocols.collection.AbstractScriptedCollectionAdapter;
 import org.opennms.netmgt.telemetry.protocols.collection.CollectionSetWithAgent;
 import org.opennms.netmgt.telemetry.protocols.collection.ScriptedCollectionSetBuilder;
 import org.slf4j.Logger;
@@ -55,7 +55,7 @@ import org.slf4j.LoggerFactory;
 
 import com.codahale.metrics.MetricRegistry;
 
-public class SFlowTelemetryAdapter extends AbstractScriptedPersistingAdapter {
+public class SFlowTelemetryAdapter extends AbstractScriptedCollectionAdapter {
 
     private static final Logger LOG = LoggerFactory.getLogger(SFlowTelemetryAdapter.class);
 
@@ -68,8 +68,8 @@ public class SFlowTelemetryAdapter extends AbstractScriptedPersistingAdapter {
     }
 
     @Override
-    public Stream<CollectionSetWithAgent> handleMessage(final TelemetryMessageLogEntry message,
-                                                        final TelemetryMessageLog messageLog) {
+    public Stream<CollectionSetWithAgent> handleCollectionMessage(final TelemetryMessageLogEntry message,
+                                                                  final TelemetryMessageLog messageLog) {
         LOG.debug("Received {} telemetry messages", messageLog.getMessageList().size());
 
         LOG.trace("Parsing packet: {}", message);

--- a/opennms-base-assembly/src/main/filtered/etc/eventconf.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/eventconf.xml
@@ -11,6 +11,7 @@
    <event-file>events/opennms.snmp.trap.translator.events.xml</event-file>
    <event-file>events/opennms.ackd.events.xml</event-file>
    <event-file>events/opennms.alarm.events.xml</event-file>
+   <event-file>events/opennms.bmp.events.xml</event-file>
    <event-file>events/opennms.bsm.events.xml</event-file>
    <event-file>events/opennms.capsd.events.xml</event-file>
    <event-file>events/opennms.config.events.xml</event-file>

--- a/opennms-base-assembly/src/main/filtered/etc/events/opennms.bmp.events.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/events/opennms.bmp.events.xml
@@ -1,0 +1,23 @@
+<events xmlns="http://xmlns.opennms.org/xsd/eventconf">
+   <event>
+      <uei>uei.opennms.org/bmp/peerDown</uei>
+      <event-label>BMP: Peer Down</event-label>
+      <descr>&lt;p>BGP session to Peer %parm[address]% at AS%parm[as]% lost (Router ID: %parm[id]%).
+                Reason: %parm[type]%. Error: %parm[error]%.&lt;/p></descr>
+      <logmsg dest="logndisplay">Router has lost the BGP session to Peer %parm[address]% at AS%parm[as]% (Router ID: %parm[id]%).</logmsg>
+      <severity>Minor</severity>
+       <alarm-data reduction-key="uei.opennms.org/bmp/peerDown:%nodeid%:%interface%:%parm[as]%:%parm[id]%"
+                   alarm-type="1" auto-clean="false">
+       </alarm-data>
+   </event>
+   <event>
+      <uei>uei.opennms.org/bmp/peerUp</uei>
+      <event-label>BMP: Peer Up</event-label>
+       <descr>&lt;p>BGP session to Peer %parm[address]% at AS%parm[as]% established (Router ID: %parm[id]%).&lt;/p></descr>
+       <logmsg dest="logndisplay">Router has established the BGP session to Peer %parm[address]% at AS%parm[as]% (Router ID: %parm[id]%).</logmsg>
+       <severity>Normal</severity>
+      <alarm-data reduction-key="uei.opennms.org/bmp/peerUp:%nodeid%:%interface%:%parm[as]%:%parm[id]%"
+                  clear-key="uei.opennms.org/bmp/peerDown:%nodeid%:%interface%:%parm[as]%:%parm[id]%"
+                  alarm-type="2" auto-clean="false"/>
+   </event>
+</events>


### PR DESCRIPTION
The new telemetryd adapter reacts to BMP peer up/down notifications and
creates events and alarms if a router lost or established a BGP session
with one of its peers.

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-12415


