### PR TITLE
NMS-12427: Allow telemetry flows to balance across Kafka partitions (alternate)

### DIFF
--- a/features/telemetry/common/build-proto.sh
+++ b/features/telemetry/common/build-proto.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+# This script will generate the TelemetryProtos.java file.
+# It requires the google protocol buffers compiler
+# Reference: https://developers.google.com/protocol-buffers/docs/javatutorial#the-protocol-buffer-api
+#
+# A few customizations need to be applied after generaton.
+#
+# The standard OpenNMS header needs to be applied
+#
+# The following imports are needed:
+#    import org.opennms.core.ipc.sink.api.Message;
+#    import org.opennms.netmgt.telemetry.api.adapter.TelemetryMessageLogEntry;
+#
+# The following class `TelemetryMessage` needs to also implement `TelemetryMessageLogEntry`
+#
+# The following method needs to be implemented in the `TelemetryMessage` class:
+#    @Override
+#    public byte[] getByteArray() {
+#      return bytes_.toByteArray();
+#    }
+#
+# The following class `TelemetryMessageLog` needs to also implement
+#  `Message` and `org.opennms.netmgt.telemetry.api.adapter.TelemetryMessageLog`
+#
+protoc -I=./src/main/resources/ --java_out=./src/main/java/ ./src/main/resources/telemetry.proto

--- a/features/telemetry/common/src/main/java/org/opennms/netmgt/telemetry/common/ipc/TelemetrySinkModule.java
+++ b/features/telemetry/common/src/main/java/org/opennms/netmgt/telemetry/common/ipc/TelemetrySinkModule.java
@@ -171,6 +171,10 @@ public class TelemetrySinkModule implements SinkModule<TelemetryMessage, Telemet
 
     @Override
     public Optional<String> getRoutingKey(final TelemetryProtos.TelemetryMessageLog message) {
+        // Allow the queue configuration to drive whether or not the routing key is used. Default to true.
+        if (!queueConfig.getUseRoutingKey().orElse(true)) {
+            return Optional.empty();
+        }
         return Optional.of(String.format("%s@%s:%d", message.getLocation(), message.getSourceAddress(), message.getSourcePort()));
     }
 

--- a/features/telemetry/common/src/main/java/org/opennms/netmgt/telemetry/common/ipc/TelemetrySinkModule.java
+++ b/features/telemetry/common/src/main/java/org/opennms/netmgt/telemetry/common/ipc/TelemetrySinkModule.java
@@ -172,10 +172,11 @@ public class TelemetrySinkModule implements SinkModule<TelemetryMessage, Telemet
     @Override
     public Optional<String> getRoutingKey(final TelemetryProtos.TelemetryMessageLog message) {
         // Allow the queue configuration to drive whether or not the routing key is used. Default to true.
-        if (!queueConfig.getUseRoutingKey().orElse(true)) {
-            return Optional.empty();
+        if (queueConfig.getUseRoutingKey().orElse(true)) {
+            return Optional.of(String.format("%s@%s:%d", message.getLocation(), message.getSourceAddress(), message.getSourcePort()));
         }
-        return Optional.of(String.format("%s@%s:%d", message.getLocation(), message.getSourceAddress(), message.getSourcePort()));
+        // We've been configured to ommit the routing key.
+        return Optional.empty();
     }
 
     public DistPollerDao getDistPollerDao() {

--- a/features/telemetry/common/src/main/resources/telemetry.proto
+++ b/features/telemetry/common/src/main/resources/telemetry.proto
@@ -1,4 +1,5 @@
-option java_package = "org.opennms.netmgt.telemetry.ipc";
+syntax = "proto2";
+option java_package = "org.opennms.netmgt.telemetry.common.ipc";
 option java_outer_classname = "TelemetryProtos";
 
 message TelemetryMessage {

--- a/features/telemetry/config/api/src/main/java/org/opennms/netmgt/telemetry/config/api/QueueDefinition.java
+++ b/features/telemetry/config/api/src/main/java/org/opennms/netmgt/telemetry/config/api/QueueDefinition.java
@@ -76,4 +76,12 @@ public interface QueueDefinition {
      * @return the queue size
      */
     Optional<Integer> getQueueSize();
+
+    /**
+     * Whether or not the routing key should be used when forwarding messages to the broker.
+     *
+     * @return whether or not to use the routing key
+     */
+    Optional<Boolean> getUseRoutingKey();
+
 }

--- a/features/telemetry/config/jaxb/src/main/java/org/opennms/netmgt/telemetry/config/model/QueueConfig.java
+++ b/features/telemetry/config/jaxb/src/main/java/org/opennms/netmgt/telemetry/config/model/QueueConfig.java
@@ -63,6 +63,9 @@ public class QueueConfig implements QueueDefinition {
     @XmlAttribute(name="queue-size")
     private Integer queueSize;
 
+    @XmlAttribute(name="use-routing-key")
+    private Boolean useRoutingKey;
+
     @XmlElement(name="adapter")
     private List<AdapterConfig> adapters = new ArrayList<>();
 
@@ -111,6 +114,15 @@ public class QueueConfig implements QueueDefinition {
         this.queueSize = queueSize;
     }
 
+    @Override
+    public Optional<Boolean> getUseRoutingKey() {
+        return Optional.ofNullable(useRoutingKey);
+    }
+
+    public void setUseRoutingKey(Boolean useRoutingKey) {
+        this.useRoutingKey = useRoutingKey;
+    }
+
     public List<AdapterConfig> getAdapters() {
         return this.adapters;
     }
@@ -129,6 +141,7 @@ public class QueueConfig implements QueueDefinition {
                 Objects.equals(this.batchSize, that.batchSize) &&
                 Objects.equals(this.batchIntervalMs, that.batchIntervalMs) &&
                 Objects.equals(this.queueSize, that.queueSize) &&
+                Objects.equals(this.useRoutingKey, that.useRoutingKey) &&
                 Objects.equals(this.adapters, that.adapters);
     }
 
@@ -140,6 +153,7 @@ public class QueueConfig implements QueueDefinition {
                 this.batchSize,
                 this.batchIntervalMs,
                 this.queueSize,
+                this.useRoutingKey,
                 this.adapters);
     }
 
@@ -151,6 +165,7 @@ public class QueueConfig implements QueueDefinition {
                 .add("batch-size", this.batchSize)
                 .add("batch-interval-ms", this.batchIntervalMs)
                 .add("queue-size", this.queueSize)
+                .add("use-routing-key", this.useRoutingKey)
                 .addValue(this.adapters)
                 .toString();
     }

--- a/features/telemetry/config/jaxb/src/main/resources/xsds/telemetryd-config.xsd
+++ b/features/telemetry/config/jaxb/src/main/resources/xsds/telemetryd-config.xsd
@@ -76,6 +76,7 @@
       <xs:element maxOccurs="unbounded" minOccurs="0" ref="tns:adapter"/>
     </xs:sequence>
     <xs:attribute name="name" type="xs:ID"/>
+    <xs:attribute name="use-routing-key" type="xs:boolean"/>
   </xs:complexType>
 
   <xs:complexType name="telemetrydConfiguration">

--- a/features/telemetry/distributed/common/src/main/java/org/opennms/netmgt/telemetry/distributed/common/MapBasedQueueDef.java
+++ b/features/telemetry/distributed/common/src/main/java/org/opennms/netmgt/telemetry/distributed/common/MapBasedQueueDef.java
@@ -38,6 +38,7 @@ public class MapBasedQueueDef implements QueueDefinition {
     private final Optional<Integer> queueSize;
     private final Optional<Integer> batchSize;
     private final Optional<Integer> batchInterval;
+    private final Optional<Boolean> useRoutingKey;
 
     public MapBasedQueueDef(final PropertyTree definition) {
         this.name = definition.getRequiredString("name");
@@ -45,6 +46,7 @@ public class MapBasedQueueDef implements QueueDefinition {
         this.queueSize = definition.getOptionalInteger("queue", "size");
         this.batchSize = definition.getOptionalInteger("batch", "size");
         this.batchInterval = definition.getOptionalInteger("batch", "interval");
+        this.useRoutingKey = definition.getOptionalBoolean("queue", "use-routing-key");
     }
 
     @Override
@@ -70,5 +72,10 @@ public class MapBasedQueueDef implements QueueDefinition {
     @Override
     public Optional<Integer> getQueueSize() {
         return queueSize;
+    }
+
+    @Override
+    public Optional<Boolean> getUseRoutingKey() {
+        return useRoutingKey;
     }
 }

--- a/features/telemetry/distributed/common/src/main/java/org/opennms/netmgt/telemetry/distributed/common/PropertyTree.java
+++ b/features/telemetry/distributed/common/src/main/java/org/opennms/netmgt/telemetry/distributed/common/PropertyTree.java
@@ -136,6 +136,18 @@ public class PropertyTree {
     }
 
     /**
+     * Get the value at the given path parsed as an {@link Boolean}.
+     *
+     * @param path the path of the node to return split into its elements
+     * @return the {@link Integer} value of the node at the given path or {@link Optional#empty()} if one of the nodes in the path does not exist
+     */
+    public Optional<Boolean> getOptionalBoolean(final String... path) {
+        return this.find(path)
+                .flatMap(Node::getValue)
+                .map(Boolean::parseBoolean);
+    }
+
+    /**
      * Get the values of all children nodes at the given path. The values are mapped by the children node names.
      *
      * @param path the path of the node to return split into its elements

--- a/opennms-doc/guide-admin/src/asciidoc/text/telemetryd/introduction.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/telemetryd/introduction.adoc
@@ -46,6 +46,44 @@ TIP: In case you have multiple _Adapters_, the execution order is the same as de
 === _Queues_
 _Queues_ are used to transfer data between _Parsers_ and _Adapters_ and are represented by a channel in the messaging system.
 
+==== Configuring _Queues_
+
+The following options are provided to help fine tune the behavior of the queues:
+
+[options="header, autowidth"]
+|===
+| Queue attribute (OpenNMS) | Key (Minion/Sentinel)  | Description | Default value
+| `threads`                 | `queue.threads`            | Number of threads used for consuming & dispatching messages | (2 * number of cores)
+| `queue-size`              | `queue.size`               | Maximum number of messages to keep in memory while waiting to be dispatched. | 10000
+| `use-routing-key`         | `queue.use-routing-key`    | Whether or not the routing key should be used when forwarding messages to the broker. This is used to enforce ordering of the messages. | true
+| `batch-size`              | `batch.size`               | Messages are aggregated in batches before being dispatched. When the batch reaches this size, it will be dispatched. | 1000
+| `batch-interval`          | `batch.interval`           | Messages are aggregated in batches before being dispatched. When the batch has been created for longer than this interval (ms) it will be dispatched, regardless of the current size. | 500
+|===
+
+TIP: When using Kafka as a message broker, setting `use-routing-key` to `false` will allow the messages to be balanced across all partitions.
+This can be safely done for flows, but is not supported for metrics when using thresholding (order is required).
+
+When setting these on OpenNMS they can be added as an attribute to the `<queue>` element.
+For example:
+[source, xml]
+----
+<queue name="IPFIX" use-routing-key="false">
+    ...
+</queue>
+----
+
+When setting these on Minion they can be added as `parser` properties, and on Sentinel as `adapter` properties:
+[source]
+----
+name=IPFIX-Listener
+class-name=org.opennms.netmgt.telemetry.listeners.UdpListener
+parameters.host=0.0.0.0
+parameters.port=4738
+parsers.0.name=IPFIX
+parsers.0.class-name=org.opennms.netmgt.telemetry.protocols.netflow.parser.IpfixUdpParser
+parsers.0.queue.use-routing-key=false
+----
+
 === Push Sensor Data through Minion
 _Listeners_ and its _Parsers_ may run on either _{opennms-product-name}_ or _Minion_, whereas adapters run on _{opennms-product-name}_ or _Sentinel_.
 If a _Listener_ its _Parsers_ is running on _Minion_, the received messages will be automatically dispatched to the associated _Adapters_ running in _{opennms-product-name}_ or _Sentinel_ via a _Queue_.


### PR DESCRIPTION
JIRA: https://issues.opennms.org/browse/NMS-12427

Here we use the queue configuration to drive the behavior of the routing key as opposed to using the listener configuration as done in: https://github.com/OpenNMS/opennms/pull/2842

This makes the solution more flexible, allow us to use different properties for different queues and avoids adding the routing-key flag to the actual messages sent.

