### PR TITLE
NMS-12471: DatacollectionFailed event definitions are located in wrong file

### DIFF
--- a/opennms-base-assembly/src/main/filtered/etc/eventconf.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/eventconf.xml
@@ -13,6 +13,7 @@
    <event-file>events/opennms.alarm.events.xml</event-file>
    <event-file>events/opennms.bsm.events.xml</event-file>
    <event-file>events/opennms.capsd.events.xml</event-file>
+   <event-file>events/opennms.collectd.events.xml</event-file>
    <event-file>events/opennms.config.events.xml</event-file>
    <event-file>events/opennms.correlation.events.xml</event-file>
    <event-file>events/opennms.default.threshold.events.xml</event-file>

--- a/opennms-base-assembly/src/main/filtered/etc/events/opennms.collectd.events.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/events/opennms.collectd.events.xml
@@ -1,0 +1,25 @@
+<events xmlns="http://xmlns.opennms.org/xsd/eventconf">
+   <event>
+      <uei>uei.opennms.org/nodes/dataCollectionFailed</uei>
+      <event-label>OpenNMS-defined node event: dataCollectionFailed</event-label>
+      <descr>&lt;p>%service% data collection on interface %interface%
+            failed because of the following condition: '%parm[reason]%'.&lt;/p></descr>
+      <logmsg dest="logndisplay">
+            %service% data collection on interface %interface% failed.
+        </logmsg>
+      <severity>Minor</severity>
+      <alarm-data reduction-key="%uei%:%dpname%:%nodeid%" alarm-type="1" auto-clean="true"/>
+   </event>
+   <event>
+      <uei>uei.opennms.org/nodes/dataCollectionSucceeded</uei>
+      <event-label>OpenNMS-defined node event: dataCollectionSucceeded</event-label>
+      <descr>&lt;p>%service% data collection on interface %interface%
+            previously failed and has been restored.&lt;/p></descr>
+      <logmsg dest="logndisplay">
+            %service% data collection on interface %interface% previously
+            failed and has been restored.
+        </logmsg>
+      <severity>Normal</severity>
+      <alarm-data reduction-key="%uei%:%dpname%:%nodeid%" alarm-type="2" clear-key="uei.opennms.org/nodes/dataCollectionFailed:%dpname%:%nodeid%" auto-clean="true"/>
+   </event>
+</events>

--- a/opennms-base-assembly/src/main/filtered/etc/events/opennms.pollerd.events.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/events/opennms.pollerd.events.xml
@@ -59,29 +59,6 @@
       <severity>Warning</severity>
    </event>
    <event>
-      <uei>uei.opennms.org/nodes/dataCollectionFailed</uei>
-      <event-label>OpenNMS-defined node event: dataCollectionFailed</event-label>
-      <descr>&lt;p>%service% data collection on interface %interface%
-            failed because of the following condition: '%parm[reason]%'.&lt;/p></descr>
-      <logmsg dest="logndisplay">
-            %service% data collection on interface %interface% failed.
-        </logmsg>
-      <severity>Minor</severity>
-      <alarm-data reduction-key="%uei%:%dpname%:%nodeid%" alarm-type="1" auto-clean="true"/>
-   </event>
-   <event>
-      <uei>uei.opennms.org/nodes/dataCollectionSucceeded</uei>
-      <event-label>OpenNMS-defined node event: dataCollectionSucceeded</event-label>
-      <descr>&lt;p>%service% data collection on interface %interface%
-            previously failed and has been restored.&lt;/p></descr>
-      <logmsg dest="logndisplay">
-            %service% data collection on interface %interface% previously
-            failed and has been restored.
-        </logmsg>
-      <severity>Normal</severity>
-      <alarm-data reduction-key="%uei%:%dpname%:%nodeid%" alarm-type="2" clear-key="uei.opennms.org/nodes/dataCollectionFailed:%dpname%:%nodeid%" auto-clean="true"/>
-   </event>
-   <event>
       <uei>uei.opennms.org/nodes/deleteService</uei>
       <event-label>OpenNMS-defined node event: deleteService</event-label>
       <descr>&lt;p>Due to excessive downtime, the %service% service on


### PR DESCRIPTION
I've just moved 2 datacollection events into a separate events file since these collectd events were located in the pollerd event file.

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-12471
* Bamboo (Continuous Integration): https://bamboo.opennms.org/

