### PR TITLE
NMS-10720: Make Events immutable (avoid CMEs and fix non-deterministic behavior) [Part 2]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -644,6 +644,7 @@ jobs:
           at: ~/
       - run-integration-tests:
           rerun-failtest-count: 1
+          failure-option: -fn
   integration-test-with-coverage:
     executor: integration-test-executor
     parallelism: 12

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -644,7 +644,6 @@ jobs:
           at: ~/
       - run-integration-tests:
           rerun-failtest-count: 1
-          failure-option: -fn
   integration-test-with-coverage:
     executor: integration-test-executor
     parallelism: 12

--- a/container/karaf/src/main/filtered-resources/etc/custom.properties
+++ b/container/karaf/src/main/filtered-resources/etc/custom.properties
@@ -704,6 +704,7 @@ org.osgi.framework.system.packages.extra=org.apache.karaf.branding,\
         org.opennms.netmgt.enlinkd.api;version=${opennms.osgi.version},\
         org.opennms.netmgt.events.api;version=${opennms.osgi.version},\
         org.opennms.netmgt.events.api.annotations;version=${opennms.osgi.version},\
+        org.opennms.netmgt.events.api.model;version=${opennms.osgi.version},\
         org.opennms.netmgt.events.api.support;version=${opennms.osgi.version},\
         org.opennms.netmgt.filter.api;version=${opennms.osgi.version},\
         org.opennms.netmgt.graph.dao.api;version=${opennms.osgi.version},\

--- a/core/daemon/src/main/java/org/opennms/netmgt/daemon/DaemonTools.java
+++ b/core/daemon/src/main/java/org/opennms/netmgt/daemon/DaemonTools.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2017-2017 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
+ * Copyright (C) 2017-2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -31,9 +31,9 @@ package org.opennms.netmgt.daemon;
 import org.apache.commons.lang.StringUtils;
 import org.opennms.netmgt.events.api.EventConstants;
 import org.opennms.netmgt.events.api.EventIpcManagerFactory;
+import org.opennms.netmgt.events.api.model.IEvent;
+import org.opennms.netmgt.events.api.model.IParm;
 import org.opennms.netmgt.model.events.EventBuilder;
-import org.opennms.netmgt.xml.event.Event;
-import org.opennms.netmgt.xml.event.Parm;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,8 +43,8 @@ public class DaemonTools {
 
     public static final Logger LOG = LoggerFactory.getLogger(DaemonTools.class);
 
-    public static void handleReloadEvent(Event e, String daemonName, Consumer<Event> handleConfigurationChanged) {
-        final Parm daemonNameParm = e.getParm(EventConstants.PARM_DAEMON_NAME);
+    public static void handleReloadEvent(IEvent e, String daemonName, Consumer<IEvent> handleConfigurationChanged) {
+        final IParm daemonNameParm = e.getParm(EventConstants.PARM_DAEMON_NAME);
         if (daemonNameParm == null || daemonNameParm.getValue() == null) {
             LOG.warn("The {} parameter has no value. Ignoring.", EventConstants.PARM_DAEMON_NAME);
             return;

--- a/features/amqp/event-forwarder/src/main/java/org/opennms/features/amqp/eventforwarder/ForwardingEventListener.java
+++ b/features/amqp/event-forwarder/src/main/java/org/opennms/features/amqp/eventforwarder/ForwardingEventListener.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2015 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2015 The OpenNMS Group, Inc.
+ * Copyright (C) 2015-2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -31,6 +31,7 @@ package org.opennms.features.amqp.eventforwarder;
 import org.opennms.netmgt.events.api.EventForwarder;
 import org.opennms.netmgt.events.api.EventIpcManager;
 import org.opennms.netmgt.events.api.EventListener;
+import org.opennms.netmgt.events.api.model.IEvent;
 import org.opennms.netmgt.xml.event.Event;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -84,9 +85,9 @@ public class ForwardingEventListener implements EventListener {
 	}
 
 	@Override
-	public void onEvent(final Event event) {
+	public void onEvent(final IEvent event) {
 		LOG.debug("Forwarding event with uei: {}", event.getUei());
-		eventForwarder.sendNow(event);
+		eventForwarder.sendNow(Event.copyFrom(event));
 	}
 
 	@Override

--- a/features/amqp/event-forwarder/src/test/java/org/opennms/features/amqp/eventforwarder/AMQPEventForwarderBlueprintTest.java
+++ b/features/amqp/event-forwarder/src/test/java/org/opennms/features/amqp/eventforwarder/AMQPEventForwarderBlueprintTest.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2015-2018 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2018 The OpenNMS Group, Inc.
+ * Copyright (C) 2015-2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -41,7 +41,7 @@ import org.opennms.netmgt.dao.api.NodeDao;
 import org.opennms.netmgt.dao.mock.MockEventIpcManager;
 import org.opennms.netmgt.dao.mock.MockNodeDao;
 import org.opennms.netmgt.events.api.EventIpcManager;
-import org.opennms.netmgt.xml.event.Event;
+import org.opennms.netmgt.events.api.model.ImmutableEvent;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 /**
@@ -84,8 +84,7 @@ public class AMQPEventForwarderBlueprintTest extends CamelBlueprintTest {
         getMockEndpoint("mock:destination").expectedMessageCount(1);
 
         // Forward a single event
-        Event event = new Event();
-        forwardingEventListener.onEvent(event);
+        forwardingEventListener.onEvent(ImmutableEvent.newBuilder().build());
 
         assertMockEndpointsSatisfied();
     }

--- a/features/amqp/event-receiver/src/test/java/org/opennms/features/amqp/eventreceiver/AMQPEventReceiverBlueprintTest.java
+++ b/features/amqp/event-receiver/src/test/java/org/opennms/features/amqp/eventreceiver/AMQPEventReceiverBlueprintTest.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2015-2018 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2018 The OpenNMS Group, Inc.
+ * Copyright (C) 2015-2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -43,6 +43,7 @@ import org.opennms.netmgt.dao.mock.MockEventIpcManager;
 import org.opennms.netmgt.dao.mock.MockNodeDao;
 import org.opennms.netmgt.events.api.EventIpcManager;
 import org.opennms.netmgt.events.api.EventListener;
+import org.opennms.netmgt.events.api.model.IEvent;
 import org.opennms.netmgt.xml.event.Event;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
@@ -86,7 +87,7 @@ public class AMQPEventReceiverBlueprintTest extends CamelBlueprintTest {
     @Test
     public void canReceiveEvent() throws Exception {
         // Register an event listener
-        final List<Event> receivedEvents = Lists.newArrayList();
+        final List<IEvent> receivedEvents = Lists.newArrayList();
         eventIpcManager.addEventListener(new EventListener() {
             @Override
             public String getName() {
@@ -94,7 +95,7 @@ public class AMQPEventReceiverBlueprintTest extends CamelBlueprintTest {
             }
 
             @Override
-            public void onEvent(Event e) {
+            public void onEvent(IEvent e) {
                 receivedEvents.add(e);
             }
         });

--- a/features/api-layer/src/main/java/org/opennms/features/apilayer/events/EventSubscriptionServiceImpl.java
+++ b/features/api-layer/src/main/java/org/opennms/features/apilayer/events/EventSubscriptionServiceImpl.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2019 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ * Copyright (C) 2019-2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -38,6 +38,7 @@ import java.util.function.Consumer;
 import org.opennms.features.apilayer.utils.ModelMappers;
 import org.opennms.integration.api.v1.events.EventListener;
 import org.opennms.integration.api.v1.events.EventSubscriptionService;
+import org.opennms.netmgt.events.api.model.IEvent;
 import org.opennms.netmgt.xml.event.Event;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -133,12 +134,12 @@ public class EventSubscriptionServiceImpl implements EventSubscriptionService {
         }
 
         @Override
-        public void onEvent(Event event) {
+        public void onEvent(IEvent event) {
             if (event == null || event.getUei() == null) {
                 return;
             }
             try {
-                delegate.onEvent(ModelMappers.toEvent(event));
+                delegate.onEvent(ModelMappers.toEvent(Event.copyFrom(event)));
             } catch (Exception e) {
                 LOG.error("Error occurred while handling event with UEI='{}' on: {}. Error: {}",
                         event.getUei(), this, e.getMessage(), e);

--- a/features/bsm/daemon/src/main/java/org/opennms/netmgt/bsm/daemon/Bsmd.java
+++ b/features/bsm/daemon/src/main/java/org/opennms/netmgt/bsm/daemon/Bsmd.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2009-2015 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2015 The OpenNMS Group, Inc.
+ * Copyright (C) 2009-2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -58,6 +58,7 @@ import org.opennms.netmgt.events.api.EventIpcManager;
 import org.opennms.netmgt.events.api.EventProxyException;
 import org.opennms.netmgt.events.api.annotations.EventHandler;
 import org.opennms.netmgt.events.api.annotations.EventListener;
+import org.opennms.netmgt.events.api.model.IEvent;
 import org.opennms.netmgt.model.OnmsAlarm;
 import org.opennms.netmgt.model.OnmsSeverity;
 import org.opennms.netmgt.model.events.EventBuilder;
@@ -207,7 +208,7 @@ public class Bsmd implements SpringServiceDaemon, BusinessServiceStateChangeHand
     }
 
     @EventHandler(ueis = {EventConstants.SERVICE_DELETED_EVENT_UEI, EventConstants.INTERFACE_DELETED_EVENT_UEI, EventConstants.NODE_DELETED_EVENT_UEI, EventConstants.APPLICATION_DELETED_EVENT_UEI})
-    public void serviceInterfaceOrNodeDeleted(Event e) {
+    public void serviceInterfaceOrNodeDeleted(IEvent e) {
         final Set<String> reductionKeys = m_stateMachine.getGraph().getReductionKeys();
 
         if (EventConstants.NODE_DELETED_EVENT_UEI.equals(e.getUei()) && reductionKeys.contains(String.format("uei.opennms.org/nodes/nodeDown::%d", e.getNodeid()))
@@ -362,7 +363,7 @@ public class Bsmd implements SpringServiceDaemon, BusinessServiceStateChangeHand
     }
 
     @EventHandler(uei = EventConstants.RELOAD_DAEMON_CONFIG_UEI)
-    public void handleReloadEvent(Event e) {
+    public void handleReloadEvent(IEvent e) {
         DaemonTools.handleReloadEvent(e, Bsmd.NAME, (event) -> handleConfigurationChanged());
     }
 

--- a/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/ThresholdingServiceImpl.java
+++ b/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/ThresholdingServiceImpl.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2019 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ * Copyright (C) 2019-2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -50,6 +50,8 @@ import org.opennms.netmgt.events.api.EventConstants;
 import org.opennms.netmgt.events.api.EventForwarder;
 import org.opennms.netmgt.events.api.EventIpcManager;
 import org.opennms.netmgt.events.api.EventListener;
+import org.opennms.netmgt.events.api.model.IEvent;
+import org.opennms.netmgt.events.api.model.IParm;
 import org.opennms.netmgt.rrd.RrdRepository;
 import org.opennms.netmgt.threshd.api.ThresholdInitializationException;
 import org.opennms.netmgt.threshd.api.ThresholdStateMonitor;
@@ -58,8 +60,6 @@ import org.opennms.netmgt.threshd.api.ThresholdingService;
 import org.opennms.netmgt.threshd.api.ThresholdingSession;
 import org.opennms.netmgt.threshd.api.ThresholdingSessionKey;
 import org.opennms.netmgt.threshd.api.ThresholdingSetPersister;
-import org.opennms.netmgt.xml.event.Event;
-import org.opennms.netmgt.xml.event.Parm;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -142,7 +142,7 @@ public class ThresholdingServiceImpl implements ThresholdingService, EventListen
     }
 
     @Override
-    public void onEvent(Event e) {
+    public void onEvent(IEvent e) {
         switch (e.getUei()) {
         case EventConstants.NODE_GAINED_SERVICE_EVENT_UEI:
             nodeGainedService(e);
@@ -162,14 +162,14 @@ public class ThresholdingServiceImpl implements ThresholdingService, EventListen
         }
     }
 
-    public void nodeGainedService(Event event) {
+    public void nodeGainedService(IEvent event) {
         LOG.debug(event.toString());
         // Trigger re-evaluation of Threshold Packages, re-evaluating Filters.
         threshdDao.rebuildPackageIpListMap();
         reinitializeThresholdingSets(event);
     }
 
-    public void handleNodeCategoryChanged(Event event) {
+    public void handleNodeCategoryChanged(IEvent event) {
         LOG.debug(event.toString());
         // Trigger re-evaluation of Threshold Packages, re-evaluating Filters.
         threshdDao.rebuildPackageIpListMap();
@@ -229,10 +229,10 @@ public class ThresholdingServiceImpl implements ThresholdingService, EventListen
         thresholdingSetPersister.clear(session);
     }
 
-    private void daemonReload(Event event) {
+    private void daemonReload(IEvent event) {
         final String thresholdsDaemonName = "Threshd";
         boolean isThresholds = false;
-        for (Parm parm : event.getParmCollection()) {
+        for (IParm parm : event.getParmCollection()) {
             if (EventConstants.PARM_DAEMON_NAME.equals(parm.getParmName()) && thresholdsDaemonName.equalsIgnoreCase(parm.getValue().getContent())) {
                 isThresholds = true;
                 break;
@@ -249,7 +249,7 @@ public class ThresholdingServiceImpl implements ThresholdingService, EventListen
         }
     }
 
-    private void reinitializeThresholdingSets(Event e) {
+    private void reinitializeThresholdingSets(IEvent e) {
         thresholdingSetPersister.reinitializeThresholdingSets();
     }
 

--- a/features/discovery/src/main/java/org/opennms/netmgt/discovery/Discovery.java
+++ b/features/discovery/src/main/java/org/opennms/netmgt/discovery/Discovery.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2002-2016 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2016 The OpenNMS Group, Inc.
+ * Copyright (C) 2002-2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -40,9 +40,9 @@ import org.opennms.netmgt.events.api.EventConstants;
 import org.opennms.netmgt.events.api.EventForwarder;
 import org.opennms.netmgt.events.api.annotations.EventHandler;
 import org.opennms.netmgt.events.api.annotations.EventListener;
+import org.opennms.netmgt.events.api.model.IEvent;
+import org.opennms.netmgt.events.api.model.IParm;
 import org.opennms.netmgt.model.events.EventBuilder;
-import org.opennms.netmgt.xml.event.Event;
-import org.opennms.netmgt.xml.event.Parm;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -162,10 +162,10 @@ public class Discovery extends AbstractServiceDaemon {
     /**
      * <p>handleDiscoveryConfigurationChanged</p>
      *
-     * @param event a {@link org.opennms.netmgt.xml.event.Event} object.
+     * @param event a {@link org.opennms.netmgt.events.api.model.IEvent} object.
      */
     @EventHandler(uei = EventConstants.DISCOVERYCONFIG_CHANGED_EVENT_UEI)
-    public void handleDiscoveryConfigurationChanged(Event event) {
+    public void handleDiscoveryConfigurationChanged(IEvent event) {
         LOG.info("handleDiscoveryConfigurationChanged: handling message that a change to configuration happened...");
         reloadAndReStart();
     }
@@ -190,10 +190,10 @@ public class Discovery extends AbstractServiceDaemon {
     /**
      * <p>reloadDaemonConfig</p>
      *
-     * @param e a {@link org.opennms.netmgt.xml.event.Event} object.
+     * @param e a {@link org.opennms.netmgt.events.api.model.IEvent} object.
      */
     @EventHandler(uei=EventConstants.RELOAD_DAEMON_CONFIG_UEI)
-    public void reloadDaemonConfig(Event e) {
+    public void reloadDaemonConfig(IEvent e) {
         LOG.info("reloadDaemonConfig: processing reload daemon event...");
         if (isReloadConfigEventTarget(e)) {
             reloadAndReStart();
@@ -201,12 +201,12 @@ public class Discovery extends AbstractServiceDaemon {
         LOG.info("reloadDaemonConfig: reload daemon event processed.");
     }
     
-    private boolean isReloadConfigEventTarget(Event event) {
+    private boolean isReloadConfigEventTarget(IEvent event) {
         boolean isTarget = false;
         
-        final List<Parm> parmCollection = event.getParmCollection();
+        final List<IParm> parmCollection = event.getParmCollection();
 
-        for (final Parm parm : parmCollection) {
+        for (final IParm parm : parmCollection) {
             if (EventConstants.PARM_DAEMON_NAME.equals(parm.getParmName()) && DAEMON_NAME.equalsIgnoreCase(parm.getValue().getContent())) {
                 isTarget = true;
                 break;
@@ -220,20 +220,20 @@ public class Discovery extends AbstractServiceDaemon {
     /**
      * <p>handleDiscoveryResume</p>
      *
-     * @param event a {@link org.opennms.netmgt.xml.event.Event} object.
+     * @param event a {@link org.opennms.netmgt.events.api.model.IEvent} object.
      */
     @EventHandler(uei=EventConstants.DISC_RESUME_EVENT_UEI)
-    public void handleDiscoveryResume(Event event) {
+    public void handleDiscoveryResume(IEvent event) {
         resume();
     }
 
     /**
      * <p>handleDiscoveryPause</p>
      *
-     * @param event a {@link org.opennms.netmgt.xml.event.Event} object.
+     * @param event a {@link org.opennms.netmgt.events.api.model.IEvent} object.
      */
     @EventHandler(uei=EventConstants.DISC_PAUSE_EVENT_UEI)
-    public void handleDiscoveryPause(Event event) {
+    public void handleDiscoveryPause(IEvent event) {
         pause();
     }
 

--- a/features/eif-adapter/src/test/java/org/opennms/features/eifadapter/EifAdapterBlueprintTest.java
+++ b/features/eif-adapter/src/test/java/org/opennms/features/eifadapter/EifAdapterBlueprintTest.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2017 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
+ * Copyright (C) 2017-2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -52,9 +52,8 @@ import org.opennms.netmgt.dao.mock.MockEventIpcManager;
 import org.opennms.netmgt.dao.mock.MockNodeDao;
 import org.opennms.netmgt.events.api.EventIpcManager;
 import org.opennms.netmgt.events.api.EventListener;
+import org.opennms.netmgt.events.api.model.IEvent;
 import org.opennms.netmgt.snmp.InetAddrUtils;
-import org.opennms.netmgt.xml.event.Event;
-
 import org.springframework.beans.factory.annotation.Autowired;
 
 public class EifAdapterBlueprintTest extends CamelBlueprintTest {
@@ -82,7 +81,7 @@ public class EifAdapterBlueprintTest extends CamelBlueprintTest {
     @Test
     public void testCanParseEifPacketsAndGenerateEvents() throws Exception {
         // Register an event listener
-        final List<Event> receivedEvents = Lists.newArrayList();
+        final List<IEvent> receivedEvents = Lists.newArrayList();
         eventIpcManager.addEventListener(new EventListener() {
             @Override
             public String getName() {
@@ -90,7 +89,7 @@ public class EifAdapterBlueprintTest extends CamelBlueprintTest {
             }
 
             @Override
-            public void onEvent(Event e) {
+            public void onEvent(IEvent e) {
                 receivedEvents.add(e);
             }
         });
@@ -102,7 +101,7 @@ public class EifAdapterBlueprintTest extends CamelBlueprintTest {
         clientSocket.close();
         
         await().atMost(15, SECONDS).until(() -> receivedEvents.size() == 6);
-        for (Event event : receivedEvents) {
+        for (IEvent event : receivedEvents) {
             assertTrue("UEI must match regex.", event.getUei().matches("^uei.opennms.org/vendor/IBM/EIF/EIF_TEST_EVENT_TYPE_\\w$"));
             assertTrue("situation_name must match regex.",event.getParm("situation_name").getValue().getContent().
                     matches("^Situation \\d{2}"));
@@ -112,7 +111,7 @@ public class EifAdapterBlueprintTest extends CamelBlueprintTest {
     @Test
     public void testCanParseEifWithSemicolonsInSlotsAndGenerateEvents() throws Exception {
         // Register an event listener
-        final List<Event> receivedEvents = Lists.newArrayList();
+        final List<IEvent> receivedEvents = Lists.newArrayList();
         eventIpcManager.addEventListener(new EventListener() {
             @Override
             public String getName() {
@@ -120,7 +119,7 @@ public class EifAdapterBlueprintTest extends CamelBlueprintTest {
             }
 
             @Override
-            public void onEvent(Event e) {
+            public void onEvent(IEvent e) {
                 receivedEvents.add(e);
             }
         });
@@ -132,7 +131,7 @@ public class EifAdapterBlueprintTest extends CamelBlueprintTest {
         clientSocket.close();
 
         await().atMost(15, SECONDS).until(() -> receivedEvents.size() == 6);
-        for (Event event : receivedEvents) {
+        for (IEvent event : receivedEvents) {
             assertTrue("UEI must match regex.", event.getUei().matches("^uei.opennms.org/vendor/IBM/EIF/EIF_TEST_EVENT_TYPE_\\w$"));
             assertTrue("situation_name must match regex.",event.getParm("situation_name").getValue().getContent().
                     matches("^Situation \\d{2}"));
@@ -142,7 +141,7 @@ public class EifAdapterBlueprintTest extends CamelBlueprintTest {
    @Test
     public void testCanParseEifWith36ByteOffset() throws Exception {
         // Register an event listener
-        final List<Event> receivedEvents = Lists.newArrayList();
+        final List<IEvent> receivedEvents = Lists.newArrayList();
         eventIpcManager.addEventListener(new EventListener() {
             @Override
             public String getName() {
@@ -150,7 +149,7 @@ public class EifAdapterBlueprintTest extends CamelBlueprintTest {
             }
 
             @Override
-            public void onEvent(Event e) {
+            public void onEvent(IEvent e) {
                 receivedEvents.add(e);
             }
         });
@@ -166,7 +165,7 @@ public class EifAdapterBlueprintTest extends CamelBlueprintTest {
         clientSocket.close();
 
         await().atMost(15, SECONDS).until(() -> receivedEvents.size() == 1);
-        for (Event event : receivedEvents) {
+        for (IEvent event : receivedEvents) {
             assertTrue("UEI must match regex.", event.getUei().matches("^uei.opennms.org/vendor/IBM/EIF/EIF_TEST_EVENT_TYPE_G$"));
         }
     }

--- a/features/enlinkd/daemon/src/main/java/org/opennms/netmgt/enlinkd/EventProcessor.java
+++ b/features/enlinkd/daemon/src/main/java/org/opennms/netmgt/enlinkd/EventProcessor.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2006-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2006-2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -36,10 +36,10 @@ import org.opennms.core.utils.InsufficientInformationException;
 import org.opennms.netmgt.events.api.EventConstants;
 import org.opennms.netmgt.events.api.annotations.EventHandler;
 import org.opennms.netmgt.events.api.annotations.EventListener;
+import org.opennms.netmgt.events.api.model.IEvent;
+import org.opennms.netmgt.events.api.model.IParm;
 import org.opennms.netmgt.model.events.EventUtils;
 import org.opennms.netmgt.topologies.service.api.OnmsTopology;
-import org.opennms.netmgt.xml.event.Event;
-import org.opennms.netmgt.xml.event.Parm;
 
 /**
  * @author <a href="mailto:antonio@opennms.it">Antonio Russo</a>
@@ -68,7 +68,7 @@ public final class EventProcessor {
      * @param event
      */
     @EventHandler(uei=EventConstants.NODE_ADDED_EVENT_UEI)
-    public void handleNodeAdded(Event event) throws InsufficientInformationException {
+    public void handleNodeAdded(IEvent event) throws InsufficientInformationException {
 
         EventUtils.checkNodeId(event);
 
@@ -81,7 +81,7 @@ public final class EventProcessor {
      * @param event
      */
     @EventHandler(uei=EventConstants.NODE_DELETED_EVENT_UEI)
-    public void handleNodeDeleted(Event event) throws InsufficientInformationException {
+    public void handleNodeDeleted(IEvent event) throws InsufficientInformationException {
 
         EventUtils.checkNodeId(event);
 
@@ -94,7 +94,7 @@ public final class EventProcessor {
      * @param event
      */
     @EventHandler(uei=EventConstants.NODE_GAINED_SERVICE_EVENT_UEI)
-    public void handleNodeGainedService(Event event) throws InsufficientInformationException {
+    public void handleNodeGainedService(IEvent event) throws InsufficientInformationException {
 
         EventUtils.checkNodeId(event);
         EventUtils.checkService(event);
@@ -109,7 +109,7 @@ public final class EventProcessor {
      * @param event
      */
     @EventHandler(uei=EventConstants.NODE_LOST_SERVICE_EVENT_UEI)
-    public void handleNodeLostService(Event event) throws InsufficientInformationException {
+    public void handleNodeLostService(IEvent event) throws InsufficientInformationException {
 
         EventUtils.checkNodeId(event);
         EventUtils.checkService(event);
@@ -124,7 +124,7 @@ public final class EventProcessor {
      * @param event
      */
     @EventHandler(uei=EventConstants.NODE_REGAINED_SERVICE_EVENT_UEI)
-    public void handleRegainedService(Event event) throws InsufficientInformationException {
+    public void handleRegainedService(IEvent event) throws InsufficientInformationException {
 
         EventUtils.checkNodeId(event);
         EventUtils.checkService(event);
@@ -136,10 +136,10 @@ public final class EventProcessor {
     /**
      * <p>handleForceRescan</p>
      *
-     * @param e a {@link org.opennms.netmgt.xml.event.Event} object.
+     * @param e a {@link org.opennms.netmgt.events.api.model.IEvent} object.
      */
     @EventHandler(uei = EventConstants.FORCE_RESCAN_EVENT_UEI)
-    public void handleForceRescan(Event e) {
+    public void handleForceRescan(IEvent e) {
     	m_linkd.rescheduleNodeCollection(new Long(e.getNodeid()).intValue());
     }
     
@@ -147,13 +147,13 @@ public final class EventProcessor {
     /**
      * <p>handleRealodDaemonconfig</p>
      *
-     * @param e a {@link org.opennms.netmgt.xml.event.Event} object.
+     * @param e a {@link org.opennms.netmgt.events.api.model.IEvent} object.
      */
     @EventHandler(uei = EventConstants.RELOAD_DAEMON_CONFIG_UEI)
-    public void handleReloadDaemonConfig(Event e) {
-        List<Parm> parmCollection = e.getParmCollection();
+    public void handleReloadDaemonConfig(IEvent e) {
+        List<IParm> parmCollection = e.getParmCollection();
 
-        for (Parm parm : parmCollection) {
+        for (IParm parm : parmCollection) {
             if (EventConstants.PARM_DAEMON_NAME.equals(parm.getParmName()) && "Enlinkd".equalsIgnoreCase(parm.getValue().getContent())) {
                 m_linkd.reloadConfig();
                 break;
@@ -162,7 +162,7 @@ public final class EventProcessor {
     }
     
     @EventHandler(uei = EventConstants.RELOAD_TOPOLOGY_UEI)
-    public void handleReloadTopology(Event e) {
+    public void handleReloadTopology(IEvent e) {
         final String topologyNamespace = EventUtils.getParm(e, PARAM_TOPOLOGY_NAMESPACE);
         if (topologyNamespace == null || "all".equalsIgnoreCase(topologyNamespace) || OnmsTopology.TOPOLOGY_NAMESPACE_LINKD.equalsIgnoreCase(topologyNamespace)) {
             m_linkd.reloadTopology();

--- a/features/events/api/src/main/java/org/opennms/netmgt/events/api/AnnotationBasedEventListenerAdapter.java
+++ b/features/events/api/src/main/java/org/opennms/netmgt/events/api/AnnotationBasedEventListenerAdapter.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2007-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2007-2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -46,7 +46,7 @@ import org.opennms.netmgt.events.api.annotations.EventHandler;
 import org.opennms.netmgt.events.api.annotations.EventListener;
 import org.opennms.netmgt.events.api.annotations.EventPostProcessor;
 import org.opennms.netmgt.events.api.annotations.EventPreProcessor;
-import org.opennms.netmgt.xml.event.Event;
+import org.opennms.netmgt.events.api.model.IEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.DisposableBean;
@@ -149,11 +149,11 @@ public class AnnotationBasedEventListenerAdapter implements StoppableEventListen
     }
 
     /* (non-Javadoc)
-     * @see org.opennms.netmgt.eventd.EventListener#onEvent(org.opennms.netmgt.xml.event.Event)
+     * @see org.opennms.netmgt.eventd.EventListener#onEvent(org.opennms.netmgt.events.api.model.IEvent)
      */
     /** {@inheritDoc} */
     @Override
-    public void onEvent(final Event event) {
+    public void onEvent(final IEvent event) {
         if (event.getUei() == null) {
             return;
         }
@@ -197,11 +197,11 @@ public class AnnotationBasedEventListenerAdapter implements StoppableEventListen
     /**
      * <p>postprocessEvent</p>
      *
-     * @param event a {@link org.opennms.netmgt.xml.event.Event} object.
+     * @param event a {@link org.opennms.netmgt.events.api.model.IEvent} object.
      * @throws java.lang.IllegalAccessException if any.
      * @throws java.lang.reflect.InvocationTargetException if any.
      */
-    protected void postprocessEvent(Event event) throws IllegalAccessException,
+    protected void postprocessEvent(IEvent event) throws IllegalAccessException,
             InvocationTargetException {
         for(Method m : m_eventPostProcessors) {
             processEvent(event, m);
@@ -211,12 +211,12 @@ public class AnnotationBasedEventListenerAdapter implements StoppableEventListen
     /**
      * <p>processEvent</p>
      *
-     * @param event a {@link org.opennms.netmgt.xml.event.Event} object.
+     * @param event a {@link org.opennms.netmgt.events.api.model.IEvent} object.
      * @param method a {@link java.lang.reflect.Method} object.
      * @throws java.lang.IllegalAccessException if any.
      * @throws java.lang.reflect.InvocationTargetException if any.
      */
-    protected void processEvent(Event event, Method method)
+    protected void processEvent(IEvent event, Method method)
             throws IllegalAccessException, InvocationTargetException {
         method.invoke(m_annotatedListener, event);
     }
@@ -224,11 +224,11 @@ public class AnnotationBasedEventListenerAdapter implements StoppableEventListen
     /**
      * <p>preprocessEvent</p>
      *
-     * @param event a {@link org.opennms.netmgt.xml.event.Event} object.
+     * @param event a {@link org.opennms.netmgt.events.api.model.IEvent} object.
      * @throws java.lang.IllegalAccessException if any.
      * @throws java.lang.reflect.InvocationTargetException if any.
      */
-    protected void preprocessEvent(Event event) throws IllegalAccessException,
+    protected void preprocessEvent(IEvent event) throws IllegalAccessException,
             InvocationTargetException {
         for(Method m : m_eventPreProcessors) {
             processEvent(event, m);
@@ -240,10 +240,10 @@ public class AnnotationBasedEventListenerAdapter implements StoppableEventListen
     /**
      * <p>handleException</p>
      *
-     * @param event a {@link org.opennms.netmgt.xml.event.Event} object.
+     * @param event a {@link org.opennms.netmgt.events.api.model.IEvent} object.
      * @param cause a {@link java.lang.Throwable} object.
      */
-    protected void handleException(Event event, Throwable cause) {
+    protected void handleException(IEvent event, Throwable cause) {
         
         for(Method method : m_exceptionHandlers) {
             if (ClassUtils.isAssignableValue(method.getParameterTypes()[1], cause)) {
@@ -333,7 +333,7 @@ public class AnnotationBasedEventListenerAdapter implements StoppableEventListen
     
     private static void validateMethodAsEventExceptionHandler(Method method) {
         Assert.state(method.getParameterTypes().length == 2, "Invalid number of parameters. EventExceptionHandler methods must take 2 arguments with types (Event, ? extends Throwable)");
-        Assert.state(ClassUtils.isAssignable(Event.class, method.getParameterTypes()[0]), "First parameter of incorrect type. EventExceptionHandler first paramenter must be of type Event");
+        Assert.state(ClassUtils.isAssignable(IEvent.class, method.getParameterTypes()[0]), "First parameter of incorrect type. EventExceptionHandler first paramenter must be of type Event");
         Assert.state(ClassUtils.isAssignable(Throwable.class, method.getParameterTypes()[1]), "Second parameter of incorrect type. EventExceptionHandler second paramenter must be of type ? extends Throwable");
     }
 
@@ -434,7 +434,7 @@ public class AnnotationBasedEventListenerAdapter implements StoppableEventListen
 
     private static void validateMethodAsEventHandler(Method method) {
         Assert.state(method.getParameterTypes().length == 1, "Invalid number of paremeters for method "+method+". EventHandler methods must take a single event argument");
-        Assert.state(method.getParameterTypes()[0].isAssignableFrom(Event.class), "Parameter of incorrent type for method "+method+". EventHandler methods must take a single event argument");
+        Assert.state(method.getParameterTypes()[0].isAssignableFrom(IEvent.class), "Parameter of incorrent type for method "+method+". EventHandler methods must take a single event argument");
     }
     
     /**

--- a/features/events/api/src/main/java/org/opennms/netmgt/events/api/EventListener.java
+++ b/features/events/api/src/main/java/org/opennms/netmgt/events/api/EventListener.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2002-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2002-2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -28,7 +28,7 @@
 
 package org.opennms.netmgt.events.api;
 
-import org.opennms.netmgt.xml.event.Event;
+import org.opennms.netmgt.events.api.model.IEvent;
 
 /**
  * The interface to be implemented by all services that wish to receive events
@@ -42,12 +42,12 @@ public interface EventListener {
      *
      * @return a {@link java.lang.String} object.
      */
-    public String getName();
+    String getName();
 
     /**
      * Process a sent event.
      *
-     * @param e a {@link org.opennms.netmgt.xml.event.Event} object.
+     * @param e a {@link org.opennms.netmgt.events.api.model.IEvent} object.
      */
-    public void onEvent(Event e);
+    void onEvent(IEvent e);
 }

--- a/features/events/api/src/main/java/org/opennms/netmgt/events/api/model/IAlarmData.java
+++ b/features/events/api/src/main/java/org/opennms/netmgt/events/api/model/IAlarmData.java
@@ -32,6 +32,9 @@ import java.util.List;
 
 /**
  * A definition corresponding to POJO '{@link org.opennms.netmgt.xml.event.AlarmData}'.
+ *
+ * The 'has...()' methods exist since the corresponding 'get...()' methods will return a default value if null.
+ * Using the 'has...()' method is the only means to determine if the backing value is null.
  */
 public interface IAlarmData {
     Integer getAlarmType();

--- a/features/events/api/src/main/java/org/opennms/netmgt/events/api/model/IAlarmData.java
+++ b/features/events/api/src/main/java/org/opennms/netmgt/events/api/model/IAlarmData.java
@@ -35,11 +35,14 @@ import java.util.List;
  */
 public interface IAlarmData {
     Integer getAlarmType();
+    Integer copyAlarmType();
     Boolean getAutoClean();
+    Boolean copyAutoClean();
     String getClearKey();
     String getReductionKey();
     String getX733AlarmType();
     Integer getX733ProbableCause();
+    Integer copyX733ProbableCause();
     Boolean isAutoClean();
     List<IUpdateField> getUpdateFieldList();
     Boolean hasUpdateFields();

--- a/features/events/api/src/main/java/org/opennms/netmgt/events/api/model/IAlarmData.java
+++ b/features/events/api/src/main/java/org/opennms/netmgt/events/api/model/IAlarmData.java
@@ -35,14 +35,14 @@ import java.util.List;
  */
 public interface IAlarmData {
     Integer getAlarmType();
-    Integer copyAlarmType();
+    boolean hasAlarmType();
     Boolean getAutoClean();
-    Boolean copyAutoClean();
+    boolean hasAutoClean();
     String getClearKey();
     String getReductionKey();
     String getX733AlarmType();
     Integer getX733ProbableCause();
-    Integer copyX733ProbableCause();
+    boolean hasX733ProbableCause();
     Boolean isAutoClean();
     List<IUpdateField> getUpdateFieldList();
     Boolean hasUpdateFields();

--- a/features/events/api/src/main/java/org/opennms/netmgt/events/api/model/IEvent.java
+++ b/features/events/api/src/main/java/org/opennms/netmgt/events/api/model/IEvent.java
@@ -35,6 +35,9 @@ import java.util.List;
 
 /**
  * A definition corresponding to POJO '{@link org.opennms.netmgt.xml.event.Event}'.
+ *
+ * The 'has...()' methods exist since the corresponding 'get...()' methods will return a default value if null.
+ * Using the 'has...()' method is the only means to determine if the backing value is null.
  */
 public interface IEvent {
     IAlarmData getAlarmData();

--- a/features/events/api/src/main/java/org/opennms/netmgt/events/api/model/IEvent.java
+++ b/features/events/api/src/main/java/org/opennms/netmgt/events/api/model/IEvent.java
@@ -46,7 +46,6 @@ public interface IEvent {
     ICorrelation getCorrelation();
     Date getCreationTime();
     Integer getDbid();
-    Integer copyDbid();
     String getDescr();
     String getDistPoller();
     IForward getForward(final int index);
@@ -55,7 +54,6 @@ public interface IEvent {
     int getForwardCount();
     String getHost();
     String getIfAlias();
-    Integer copyIfIndex();
     Integer getIfIndex();
     String getInterface();
     InetAddress getInterfaceAddress();
@@ -68,7 +66,6 @@ public interface IEvent {
     String getMasterStation();
     String getMouseovertext();
     Long getNodeid();
-    Long copyNodeid();
     IOperAction getOperaction(final int index);
     IOperAction[] getOperaction();
     List<IOperAction> getOperactionCollection();

--- a/features/events/api/src/main/java/org/opennms/netmgt/events/api/model/IEvent.java
+++ b/features/events/api/src/main/java/org/opennms/netmgt/events/api/model/IEvent.java
@@ -46,6 +46,7 @@ public interface IEvent {
     ICorrelation getCorrelation();
     Date getCreationTime();
     Integer getDbid();
+    Integer copyDbid();
     String getDescr();
     String getDistPoller();
     IForward getForward(final int index);
@@ -54,6 +55,7 @@ public interface IEvent {
     int getForwardCount();
     String getHost();
     String getIfAlias();
+    Integer copyIfIndex();
     Integer getIfIndex();
     String getInterface();
     InetAddress getInterfaceAddress();
@@ -66,6 +68,7 @@ public interface IEvent {
     String getMasterStation();
     String getMouseovertext();
     Long getNodeid();
+    Long copyNodeid();
     IOperAction getOperaction(final int index);
     IOperAction[] getOperaction();
     List<IOperAction> getOperactionCollection();

--- a/features/events/api/src/main/java/org/opennms/netmgt/events/api/model/ILogMsg.java
+++ b/features/events/api/src/main/java/org/opennms/netmgt/events/api/model/ILogMsg.java
@@ -35,4 +35,5 @@ public interface ILogMsg {
     String getContent();
     String getDest();
     Boolean getNotify();
+    Boolean copyNotify();
 }

--- a/features/events/api/src/main/java/org/opennms/netmgt/events/api/model/ILogMsg.java
+++ b/features/events/api/src/main/java/org/opennms/netmgt/events/api/model/ILogMsg.java
@@ -30,6 +30,9 @@ package org.opennms.netmgt.events.api.model;
 
 /**
  * A definition corresponding to POJO '{@link org.opennms.netmgt.xml.event.Logmsg}'.
+ *
+ * The 'has...()' methods exist since the corresponding 'get...()' methods will return a default value if null.
+ * Using the 'has...()' method is the only means to determine if the backing value is null.
  */
 public interface ILogMsg {
     String getContent();

--- a/features/events/api/src/main/java/org/opennms/netmgt/events/api/model/ILogMsg.java
+++ b/features/events/api/src/main/java/org/opennms/netmgt/events/api/model/ILogMsg.java
@@ -35,5 +35,5 @@ public interface ILogMsg {
     String getContent();
     String getDest();
     Boolean getNotify();
-    Boolean copyNotify();
+    boolean hasNotify();
 }

--- a/features/events/api/src/main/java/org/opennms/netmgt/events/api/model/IParm.java
+++ b/features/events/api/src/main/java/org/opennms/netmgt/events/api/model/IParm.java
@@ -34,4 +34,5 @@ package org.opennms.netmgt.events.api.model;
 public interface IParm {
     String getParmName();
     IValue getValue();
+    boolean isValid();
 }

--- a/features/events/api/src/main/java/org/opennms/netmgt/events/api/model/ISnmp.java
+++ b/features/events/api/src/main/java/org/opennms/netmgt/events/api/model/ISnmp.java
@@ -30,6 +30,9 @@ package org.opennms.netmgt.events.api.model;
 
 /**
  * A definition corresponding to POJO '{@link org.opennms.netmgt.xml.event.Snmp}'.
+ *
+ * The 'has...()' methods exist since the corresponding 'get...()' methods will return a default value if null.
+ * Using the 'has...()' method is the only means to determine if the backing value is null.
  */
 public interface ISnmp {
     String getCommunity();

--- a/features/events/api/src/main/java/org/opennms/netmgt/events/api/model/ISnmp.java
+++ b/features/events/api/src/main/java/org/opennms/netmgt/events/api/model/ISnmp.java
@@ -34,13 +34,10 @@ package org.opennms.netmgt.events.api.model;
 public interface ISnmp {
     String getCommunity();
     Integer getGeneric();
-    Integer copyGeneric();
     String getId();
     String getIdtext();
     Integer getSpecific();
-    Integer copySpecific();
     Long getTimeStamp();
-    Long copyTimeStamp();
     String getVersion();
     boolean hasGeneric();
     boolean hasSpecific();

--- a/features/events/api/src/main/java/org/opennms/netmgt/events/api/model/ISnmp.java
+++ b/features/events/api/src/main/java/org/opennms/netmgt/events/api/model/ISnmp.java
@@ -34,10 +34,13 @@ package org.opennms.netmgt.events.api.model;
 public interface ISnmp {
     String getCommunity();
     Integer getGeneric();
+    Integer copyGeneric();
     String getId();
     String getIdtext();
     Integer getSpecific();
+    Integer copySpecific();
     Long getTimeStamp();
+    Long copyTimeStamp();
     String getVersion();
     boolean hasGeneric();
     boolean hasSpecific();

--- a/features/events/api/src/main/java/org/opennms/netmgt/events/api/model/ImmutableAlarmData.java
+++ b/features/events/api/src/main/java/org/opennms/netmgt/events/api/model/ImmutableAlarmData.java
@@ -145,11 +145,21 @@ public final class ImmutableAlarmData implements IAlarmData {
 
     @Override
     public Integer getAlarmType() {
+        return alarmType == null ? 0 : alarmType;
+    }
+
+    @Override
+    public Integer copyAlarmType() {
         return alarmType;
     }
 
     @Override
     public Boolean getAutoClean() {
+        return autoClean == null ? false : autoClean;
+    }
+
+    @Override
+    public Boolean copyAutoClean() {
         return autoClean;
     }
 
@@ -170,6 +180,11 @@ public final class ImmutableAlarmData implements IAlarmData {
 
     @Override
     public Integer getX733ProbableCause() {
+        return x733ProbableCause == null ? 0 : x733ProbableCause;
+    }
+
+    @Override
+    public Integer copyX733ProbableCause() {
         return x733ProbableCause;
     }
 

--- a/features/events/api/src/main/java/org/opennms/netmgt/events/api/model/ImmutableAlarmData.java
+++ b/features/events/api/src/main/java/org/opennms/netmgt/events/api/model/ImmutableAlarmData.java
@@ -149,8 +149,8 @@ public final class ImmutableAlarmData implements IAlarmData {
     }
 
     @Override
-    public Integer copyAlarmType() {
-        return alarmType;
+    public boolean hasAlarmType() {
+        return alarmType != null;
     }
 
     @Override
@@ -159,8 +159,8 @@ public final class ImmutableAlarmData implements IAlarmData {
     }
 
     @Override
-    public Boolean copyAutoClean() {
-        return autoClean;
+    public boolean hasAutoClean() {
+        return autoClean != null;
     }
 
     @Override
@@ -184,8 +184,8 @@ public final class ImmutableAlarmData implements IAlarmData {
     }
 
     @Override
-    public Integer copyX733ProbableCause() {
-        return x733ProbableCause;
+    public boolean hasX733ProbableCause() {
+        return x733ProbableCause != null;
     }
 
     @Override

--- a/features/events/api/src/main/java/org/opennms/netmgt/events/api/model/ImmutableEvent.java
+++ b/features/events/api/src/main/java/org/opennms/netmgt/events/api/model/ImmutableEvent.java
@@ -432,11 +432,6 @@ public final class ImmutableEvent implements IEvent {
     }
 
     @Override
-    public Integer copyDbid() {
-        return dbId;
-    }
-
-    @Override
     public String getDescr() {
         return descr;
     }
@@ -484,11 +479,6 @@ public final class ImmutableEvent implements IEvent {
     @Override
     public Integer getIfIndex() {
         return ifIndex == null ? 0 : ifIndex;
-    }
-
-    @Override
-    public Integer copyIfIndex() {
-        return ifIndex;
     }
 
     @Override
@@ -549,11 +539,6 @@ public final class ImmutableEvent implements IEvent {
     @Override
     public Long getNodeid() {
         return nodeid == null ? 0 : nodeid;
-    }
-
-    @Override
-    public Long copyNodeid() {
-        return nodeid;
     }
 
     @Override

--- a/features/events/api/src/main/java/org/opennms/netmgt/events/api/model/ImmutableEvent.java
+++ b/features/events/api/src/main/java/org/opennms/netmgt/events/api/model/ImmutableEvent.java
@@ -432,6 +432,11 @@ public final class ImmutableEvent implements IEvent {
     }
 
     @Override
+    public Integer copyDbid() {
+        return dbId;
+    }
+
+    @Override
     public String getDescr() {
         return descr;
     }
@@ -479,6 +484,11 @@ public final class ImmutableEvent implements IEvent {
     @Override
     public Integer getIfIndex() {
         return ifIndex == null ? 0 : ifIndex;
+    }
+
+    @Override
+    public Integer copyIfIndex() {
+        return ifIndex;
     }
 
     @Override
@@ -539,6 +549,11 @@ public final class ImmutableEvent implements IEvent {
     @Override
     public Long getNodeid() {
         return nodeid == null ? 0 : nodeid;
+    }
+
+    @Override
+    public Long copyNodeid() {
+        return nodeid;
     }
 
     @Override

--- a/features/events/api/src/main/java/org/opennms/netmgt/events/api/model/ImmutableLogMsg.java
+++ b/features/events/api/src/main/java/org/opennms/netmgt/events/api/model/ImmutableLogMsg.java
@@ -100,6 +100,11 @@ public final class ImmutableLogMsg implements ILogMsg {
 
     @Override
     public Boolean getNotify() {
+        return notify == null ? false : notify;
+    }
+
+    @Override
+    public Boolean copyNotify() {
         return notify;
     }
 

--- a/features/events/api/src/main/java/org/opennms/netmgt/events/api/model/ImmutableLogMsg.java
+++ b/features/events/api/src/main/java/org/opennms/netmgt/events/api/model/ImmutableLogMsg.java
@@ -104,8 +104,8 @@ public final class ImmutableLogMsg implements ILogMsg {
     }
 
     @Override
-    public Boolean copyNotify() {
-        return notify;
+    public boolean hasNotify() {
+        return notify != null;
     }
 
     @Override

--- a/features/events/api/src/main/java/org/opennms/netmgt/events/api/model/ImmutableMapper.java
+++ b/features/events/api/src/main/java/org/opennms/netmgt/events/api/model/ImmutableMapper.java
@@ -45,11 +45,11 @@ public class ImmutableMapper {
 
         return ImmutableAlarmData.newBuilder()
                 .setReductionKey(alarmData.getReductionKey())
-                .setAlarmType(alarmData.getAlarmType())
+                .setAlarmType(alarmData.copyAlarmType())
                 .setClearKey(alarmData.getClearKey())
-                .setAutoClean(alarmData.getAutoClean())
+                .setAutoClean(alarmData.copyAutoClean())
                 .setX733AlarmType(alarmData.getX733AlarmType())
-                .setX733ProbableCause(alarmData.getX733ProbableCause())
+                .setX733ProbableCause(alarmData.copyX733ProbableCause())
                 .setUpdateFieldList(
                         alarmData.getUpdateFieldList()
                                 .stream().map(ImmutableMapper::fromMutableUpdateField)
@@ -103,14 +103,14 @@ public class ImmutableMapper {
 
         return ImmutableEvent.newBuilder()
                 .setUuid(event.getUuid())
-                .setDbId(event.getDbid())
+                .setDbId(event.copyDbid())
                 .setDistPoller(event.getDistPoller())
                 .setCreationTime(event.getCreationTime())
                 .setMasterStation(event.getMasterStation())
                 .setMask(ImmutableMapper.fromMutableMask(event.getMask()))
                 .setUei(event.getUei())
                 .setSource(event.getSource())
-                .setNodeid(event.getNodeid())
+                .setNodeid(event.copyNodeid())
                 .setTime(event.getTime())
                 .setHost(event.getHost())
                 .setInterface(event.getInterface())
@@ -142,7 +142,7 @@ public class ImmutableMapper {
                 .setScriptList(ImmutableCollections.newListOfImmutableType(
                         event.getScriptCollection().stream().map(
                                 ImmutableMapper::fromMutableScript).collect(Collectors.toList())))
-                .setIfIndex(event.getIfIndex())
+                .setIfIndex(event.copyIfIndex())
                 .setIfAlias(event.getIfAlias())
                 .setMouseOverText(event.getMouseovertext())
                 .setAlarmData(ImmutableMapper.fromMutableAlarmData(event.getAlarmData()))
@@ -168,7 +168,7 @@ public class ImmutableMapper {
         return ImmutableLogMsg.newBuilder()
                 .setContent(logMsg.getContent())
                 .setDest(logMsg.getDest())
-                .setNotify(logMsg.getNotify())
+                .setNotify(logMsg.copyNotify())
                 .build();
     }
 
@@ -247,10 +247,10 @@ public class ImmutableMapper {
                 .setId(snmp.getId())
                 .setIdText(snmp.getIdtext())
                 .setVersion(snmp.getVersion())
-                .setSpecific(snmp.getSpecific())
-                .setGeneric(snmp.getGeneric())
+                .setSpecific(snmp.copySpecific())
+                .setGeneric(snmp.copyGeneric())
                 .setCommunity(snmp.getCommunity())
-                .setTimeStamp(snmp.getTimeStamp())
+                .setTimeStamp(snmp.copyTimeStamp())
                 .build();
     }
 

--- a/features/events/api/src/main/java/org/opennms/netmgt/events/api/model/ImmutableMapper.java
+++ b/features/events/api/src/main/java/org/opennms/netmgt/events/api/model/ImmutableMapper.java
@@ -45,11 +45,11 @@ public class ImmutableMapper {
 
         return ImmutableAlarmData.newBuilder()
                 .setReductionKey(alarmData.getReductionKey())
-                .setAlarmType(alarmData.copyAlarmType())
+                .setAlarmType(alarmData.hasAlarmType() ? alarmData.getAlarmType() : null)
                 .setClearKey(alarmData.getClearKey())
-                .setAutoClean(alarmData.copyAutoClean())
+                .setAutoClean(alarmData.hasAutoClean() ? alarmData.getAutoClean() : null)
                 .setX733AlarmType(alarmData.getX733AlarmType())
-                .setX733ProbableCause(alarmData.copyX733ProbableCause())
+                .setX733ProbableCause(alarmData.hasX733ProbableCause() ? alarmData.getX733ProbableCause() : null)
                 .setUpdateFieldList(
                         alarmData.getUpdateFieldList()
                                 .stream().map(ImmutableMapper::fromMutableUpdateField)
@@ -103,14 +103,14 @@ public class ImmutableMapper {
 
         return ImmutableEvent.newBuilder()
                 .setUuid(event.getUuid())
-                .setDbId(event.copyDbid())
+                .setDbId(event.hasDbid() ? event.getDbid() : null)
                 .setDistPoller(event.getDistPoller())
                 .setCreationTime(event.getCreationTime())
                 .setMasterStation(event.getMasterStation())
                 .setMask(ImmutableMapper.fromMutableMask(event.getMask()))
                 .setUei(event.getUei())
                 .setSource(event.getSource())
-                .setNodeid(event.copyNodeid())
+                .setNodeid(event.hasNodeid() ? event.getNodeid() : null)
                 .setTime(event.getTime())
                 .setHost(event.getHost())
                 .setInterface(event.getInterface())
@@ -142,7 +142,7 @@ public class ImmutableMapper {
                 .setScriptList(ImmutableCollections.newListOfImmutableType(
                         event.getScriptCollection().stream().map(
                                 ImmutableMapper::fromMutableScript).collect(Collectors.toList())))
-                .setIfIndex(event.copyIfIndex())
+                .setIfIndex(event.hasIfIndex() ? event.getIfIndex() : null)
                 .setIfAlias(event.getIfAlias())
                 .setMouseOverText(event.getMouseovertext())
                 .setAlarmData(ImmutableMapper.fromMutableAlarmData(event.getAlarmData()))
@@ -168,7 +168,7 @@ public class ImmutableMapper {
         return ImmutableLogMsg.newBuilder()
                 .setContent(logMsg.getContent())
                 .setDest(logMsg.getDest())
-                .setNotify(logMsg.copyNotify())
+                .setNotify(logMsg.hasNotify() ? logMsg.getNotify() : null)
                 .build();
     }
 
@@ -247,10 +247,10 @@ public class ImmutableMapper {
                 .setId(snmp.getId())
                 .setIdText(snmp.getIdtext())
                 .setVersion(snmp.getVersion())
-                .setSpecific(snmp.copySpecific())
-                .setGeneric(snmp.copyGeneric())
+                .setSpecific(snmp.hasSpecific() ? snmp.getSpecific() : null)
+                .setGeneric(snmp.hasGeneric() ? snmp.getGeneric() : null)
                 .setCommunity(snmp.getCommunity())
-                .setTimeStamp(snmp.copyTimeStamp())
+                .setTimeStamp(snmp.hasTimeStamp() ? snmp.getTimeStamp() : null)
                 .build();
     }
 

--- a/features/events/api/src/main/java/org/opennms/netmgt/events/api/model/ImmutableParm.java
+++ b/features/events/api/src/main/java/org/opennms/netmgt/events/api/model/ImmutableParm.java
@@ -96,6 +96,11 @@ public final class ImmutableParm implements IParm {
     }
 
     @Override
+    public boolean isValid() {
+        return getParmName() != null && getValue() != null;
+    }
+
+    @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;

--- a/features/events/api/src/main/java/org/opennms/netmgt/events/api/model/ImmutableSnmp.java
+++ b/features/events/api/src/main/java/org/opennms/netmgt/events/api/model/ImmutableSnmp.java
@@ -146,11 +146,21 @@ public final class ImmutableSnmp implements ISnmp {
 
     @Override
     public Integer getSpecific() {
+        return specific == null ? 0 : specific;
+    }
+
+    @Override
+    public Integer copySpecific() {
         return specific;
     }
 
     @Override
     public Integer getGeneric() {
+        return generic == null ? 0 : generic;
+    }
+
+    @Override
+    public Integer copyGeneric() {
         return generic;
     }
 
@@ -161,6 +171,11 @@ public final class ImmutableSnmp implements ISnmp {
 
     @Override
     public Long getTimeStamp() {
+        return timeStamp == null ? 0 : timeStamp;
+    }
+
+    @Override
+    public Long copyTimeStamp() {
         return timeStamp;
     }
 

--- a/features/events/api/src/main/java/org/opennms/netmgt/events/api/model/ImmutableSnmp.java
+++ b/features/events/api/src/main/java/org/opennms/netmgt/events/api/model/ImmutableSnmp.java
@@ -150,18 +150,8 @@ public final class ImmutableSnmp implements ISnmp {
     }
 
     @Override
-    public Integer copySpecific() {
-        return specific;
-    }
-
-    @Override
     public Integer getGeneric() {
         return generic == null ? 0 : generic;
-    }
-
-    @Override
-    public Integer copyGeneric() {
-        return generic;
     }
 
     @Override
@@ -172,11 +162,6 @@ public final class ImmutableSnmp implements ISnmp {
     @Override
     public Long getTimeStamp() {
         return timeStamp == null ? 0 : timeStamp;
-    }
-
-    @Override
-    public Long copyTimeStamp() {
-        return timeStamp;
     }
 
     @Override

--- a/features/events/api/src/main/java/org/opennms/netmgt/xml/event/AlarmData.java
+++ b/features/events/api/src/main/java/org/opennms/netmgt/xml/event/AlarmData.java
@@ -126,11 +126,11 @@ public class AlarmData implements Serializable {
 
         AlarmData alarmData = new AlarmData();
         alarmData.setReductionKey(source.getReductionKey());
-        alarmData.setAlarmType(source.copyAlarmType());
+        alarmData.setAlarmType(source.hasAlarmType() ? source.getAlarmType() : null);
         alarmData.setClearKey(source.getClearKey());
-        alarmData.setAutoClean(source.copyAutoClean());
+        alarmData.setAutoClean(source.hasAutoClean() ? source.getAutoClean() : null);
         alarmData.setX733AlarmType(source.getX733AlarmType());
-        alarmData.setX733ProbableCause(source.copyX733ProbableCause());
+        alarmData.setX733ProbableCause(source.hasX733ProbableCause() ? source.getX733ProbableCause() : null);
         alarmData.getUpdateFieldList().addAll(
                 source.getUpdateFieldList().stream().map(UpdateField::copyFrom).collect(Collectors.toList()));
         alarmData.setManagedObject(ManagedObject.copyFrom(source.getManagedObject()));
@@ -165,10 +165,6 @@ public class AlarmData implements Serializable {
         return this._alarmType == null? 0 : this._alarmType;
     }
 
-    public Integer copyAlarmType() {
-        return _alarmType;
-    }
-
     /**
      * Returns the value of field 'autoClean'.
      * 
@@ -176,10 +172,6 @@ public class AlarmData implements Serializable {
      */
     public Boolean getAutoClean() {
         return this._autoClean == null? false : this._autoClean;
-    }
-
-    public Boolean copyAutoClean() {
-        return _autoClean;
     }
 
     /**
@@ -218,10 +210,6 @@ public class AlarmData implements Serializable {
      */
     public Integer getX733ProbableCause() {
         return this._x733ProbableCause == null ? 0 : this._x733ProbableCause;
-    }
-
-    public Integer copyX733ProbableCause() {
-        return _x733ProbableCause;
     }
 
     /**

--- a/features/events/api/src/main/java/org/opennms/netmgt/xml/event/AlarmData.java
+++ b/features/events/api/src/main/java/org/opennms/netmgt/xml/event/AlarmData.java
@@ -126,11 +126,11 @@ public class AlarmData implements Serializable {
 
         AlarmData alarmData = new AlarmData();
         alarmData.setReductionKey(source.getReductionKey());
-        alarmData.setAlarmType(source.getAlarmType());
+        alarmData.setAlarmType(source.copyAlarmType());
         alarmData.setClearKey(source.getClearKey());
-        alarmData.setAutoClean(source.getAutoClean());
+        alarmData.setAutoClean(source.copyAutoClean());
         alarmData.setX733AlarmType(source.getX733AlarmType());
-        alarmData.setX733ProbableCause(source.getX733ProbableCause());
+        alarmData.setX733ProbableCause(source.copyX733ProbableCause());
         alarmData.getUpdateFieldList().addAll(
                 source.getUpdateFieldList().stream().map(UpdateField::copyFrom).collect(Collectors.toList()));
         alarmData.setManagedObject(ManagedObject.copyFrom(source.getManagedObject()));
@@ -165,6 +165,10 @@ public class AlarmData implements Serializable {
         return this._alarmType == null? 0 : this._alarmType;
     }
 
+    public Integer copyAlarmType() {
+        return _alarmType;
+    }
+
     /**
      * Returns the value of field 'autoClean'.
      * 
@@ -172,6 +176,10 @@ public class AlarmData implements Serializable {
      */
     public Boolean getAutoClean() {
         return this._autoClean == null? false : this._autoClean;
+    }
+
+    public Boolean copyAutoClean() {
+        return _autoClean;
     }
 
     /**
@@ -210,6 +218,10 @@ public class AlarmData implements Serializable {
      */
     public Integer getX733ProbableCause() {
         return this._x733ProbableCause == null ? 0 : this._x733ProbableCause;
+    }
+
+    public Integer copyX733ProbableCause() {
+        return _x733ProbableCause;
     }
 
     /**

--- a/features/events/api/src/main/java/org/opennms/netmgt/xml/event/Event.java
+++ b/features/events/api/src/main/java/org/opennms/netmgt/xml/event/Event.java
@@ -310,14 +310,14 @@ public class Event implements Message,Serializable {
 
 		Event event = new Event();
 		event.setUuid(source.getUuid());
-		event.setDbid(source.copyDbid());
+		event.setDbid(source.hasDbid() ? source.getDbid() : null);
 		event.setDistPoller(source.getDistPoller());
 		event.setCreationTime(source.getCreationTime() == null ? null : new Date(source.getCreationTime().getTime()));
 		event.setMasterStation(source.getMasterStation());
 		event.setMask(Mask.copyFrom(source.getMask()));
 		event.setUei(source.getUei());
 		event.setSource(source.getSource());
-		event.setNodeid(source.copyNodeid());
+		event.setNodeid(source.hasNodeid() ? source.getNodeid() : null);
 		event.setTime(source.getTime() == null ? null : new Date(source.getTime().getTime()));
 		event.setHost(source.getHost());
 		event.setInterface(source.getInterface());
@@ -344,7 +344,7 @@ public class Event implements Message,Serializable {
 				source.getForwardCollection().stream().map(Forward::copyFrom).collect(Collectors.toList()));
 		event.getScriptCollection().addAll(
 				source.getScriptCollection().stream().map(Script::copyFrom).collect(Collectors.toList()));
-		event.setIfIndex(source.copyIfIndex());
+		event.setIfIndex(source.hasIfIndex() ? source.getIfIndex() : null);
 		event.setIfAlias(source.getIfAlias());
 		event.setMouseovertext(source.getMouseovertext());
 		event.setAlarmData(AlarmData.copyFrom(source.getAlarmData()));
@@ -643,10 +643,6 @@ public class Event implements Message,Serializable {
 		return _dbid == null ? 0 : _dbid;
 	}
 
-	public Integer copyDbid() {
-		return _dbid;
-	}
-
 	/**
 	 * Returns the value of field 'descr'. The field 'descr' has the following
 	 * description: The event description
@@ -745,10 +741,6 @@ public class Event implements Message,Serializable {
 	 */
 	public Integer getIfIndex() {
 		return _ifIndex == null ? 0 : _ifIndex;
-	}
-
-	public Integer copyIfIndex() {
-		return _ifIndex;
 	}
 
 	/**
@@ -869,10 +861,6 @@ public class Event implements Message,Serializable {
 	 */
 	public Long getNodeid() {
 		return _nodeid == null ? 0 : _nodeid;
-	}
-
-	public Long copyNodeid() {
-		return _nodeid;
 	}
 
 	/**

--- a/features/events/api/src/main/java/org/opennms/netmgt/xml/event/Event.java
+++ b/features/events/api/src/main/java/org/opennms/netmgt/xml/event/Event.java
@@ -310,15 +310,15 @@ public class Event implements Message,Serializable {
 
 		Event event = new Event();
 		event.setUuid(source.getUuid());
-		event.setDbid(source.getDbid());
+		event.setDbid(source.copyDbid());
 		event.setDistPoller(source.getDistPoller());
-		event.setCreationTime(source.getCreationTime());
+		event.setCreationTime(source.getCreationTime() == null ? null : new Date(source.getCreationTime().getTime()));
 		event.setMasterStation(source.getMasterStation());
 		event.setMask(Mask.copyFrom(source.getMask()));
 		event.setUei(source.getUei());
 		event.setSource(source.getSource());
-		event.setNodeid(source.getNodeid());
-		event.setTime(source.getTime());
+		event.setNodeid(source.copyNodeid());
+		event.setTime(source.getTime() == null ? null : new Date(source.getTime().getTime()));
 		event.setHost(source.getHost());
 		event.setInterface(source.getInterface());
 		event.setInterfaceAddress(source.getInterfaceAddress());
@@ -344,7 +344,7 @@ public class Event implements Message,Serializable {
 				source.getForwardCollection().stream().map(Forward::copyFrom).collect(Collectors.toList()));
 		event.getScriptCollection().addAll(
 				source.getScriptCollection().stream().map(Script::copyFrom).collect(Collectors.toList()));
-		event.setIfIndex(source.getIfIndex());
+		event.setIfIndex(source.copyIfIndex());
 		event.setIfAlias(source.getIfAlias());
 		event.setMouseovertext(source.getMouseovertext());
 		event.setAlarmData(AlarmData.copyFrom(source.getAlarmData()));
@@ -643,6 +643,10 @@ public class Event implements Message,Serializable {
 		return _dbid == null ? 0 : _dbid;
 	}
 
+	public Integer copyDbid() {
+		return _dbid;
+	}
+
 	/**
 	 * Returns the value of field 'descr'. The field 'descr' has the following
 	 * description: The event description
@@ -741,6 +745,10 @@ public class Event implements Message,Serializable {
 	 */
 	public Integer getIfIndex() {
 		return _ifIndex == null ? 0 : _ifIndex;
+	}
+
+	public Integer copyIfIndex() {
+		return _ifIndex;
 	}
 
 	/**
@@ -861,6 +869,10 @@ public class Event implements Message,Serializable {
 	 */
 	public Long getNodeid() {
 		return _nodeid == null ? 0 : _nodeid;
+	}
+
+	public Long copyNodeid() {
+		return _nodeid;
 	}
 
 	/**

--- a/features/events/api/src/main/java/org/opennms/netmgt/xml/event/Logmsg.java
+++ b/features/events/api/src/main/java/org/opennms/netmgt/xml/event/Logmsg.java
@@ -109,7 +109,7 @@ public class Logmsg implements Serializable {
         Logmsg logmsg = new Logmsg();
         logmsg.setContent(source.getContent());
         logmsg.setDest(source.getDest());
-        logmsg.setNotify(source.copyNotify());
+        logmsg.setNotify(source.hasNotify() ? source.getNotify() : null);
         return logmsg;
     }
 
@@ -153,10 +153,6 @@ public class Logmsg implements Serializable {
     public Boolean getNotify(
     ) {
         return this._notify == null? false : this._notify;
-    }
-
-    public Boolean copyNotify() {
-        return _notify;
     }
 
     /**

--- a/features/events/api/src/main/java/org/opennms/netmgt/xml/event/Logmsg.java
+++ b/features/events/api/src/main/java/org/opennms/netmgt/xml/event/Logmsg.java
@@ -109,7 +109,7 @@ public class Logmsg implements Serializable {
         Logmsg logmsg = new Logmsg();
         logmsg.setContent(source.getContent());
         logmsg.setDest(source.getDest());
-        logmsg.setNotify(source.getNotify());
+        logmsg.setNotify(source.copyNotify());
         return logmsg;
     }
 
@@ -153,6 +153,10 @@ public class Logmsg implements Serializable {
     public Boolean getNotify(
     ) {
         return this._notify == null? false : this._notify;
+    }
+
+    public Boolean copyNotify() {
+        return _notify;
     }
 
     /**

--- a/features/events/api/src/main/java/org/opennms/netmgt/xml/event/Snmp.java
+++ b/features/events/api/src/main/java/org/opennms/netmgt/xml/event/Snmp.java
@@ -120,10 +120,10 @@ public class Snmp implements Serializable {
         snmp.setId(source.getId());
         snmp.setIdtext(source.getIdtext());
         snmp.setVersion(source.getVersion());
-        snmp.setSpecific(source.copySpecific());
-        snmp.setGeneric(source.copyGeneric());
+        snmp.setSpecific(source.hasSpecific() ? source.getSpecific() : null);
+        snmp.setGeneric(source.hasGeneric() ? source.getGeneric() : null);
         snmp.setCommunity(source.getCommunity());
-        snmp.setTimeStamp(source.copyTimeStamp());
+        snmp.setTimeStamp(source.hasTimeStamp() ? source.getTimeStamp() : null);
         return snmp;
     }
 
@@ -175,10 +175,6 @@ public class Snmp implements Serializable {
         return this._generic == null? 0 : this._generic;
     }
 
-    public Integer copyGeneric() {
-        return _generic;
-    }
-
     /**
      * Returns the value of field 'id'. The field 'id' has the
      * following description: The snmp enterprise id
@@ -212,10 +208,6 @@ public class Snmp implements Serializable {
         return this._specific == null? 0 : this._specific;
     }
 
-    public Integer copySpecific() {
-        return _specific;
-    }
-
     /**
      * Returns the value of field 'timeStamp'. The field
      * 'timeStamp' has the following description: The time stamp
@@ -225,10 +217,6 @@ public class Snmp implements Serializable {
     public Long getTimeStamp(
     ) {
         return this._timeStamp == null? 0 : this._timeStamp;
-    }
-
-    public Long copyTimeStamp() {
-        return _timeStamp;
     }
 
     /**

--- a/features/events/api/src/main/java/org/opennms/netmgt/xml/event/Snmp.java
+++ b/features/events/api/src/main/java/org/opennms/netmgt/xml/event/Snmp.java
@@ -120,10 +120,10 @@ public class Snmp implements Serializable {
         snmp.setId(source.getId());
         snmp.setIdtext(source.getIdtext());
         snmp.setVersion(source.getVersion());
-        snmp.setSpecific(source.getSpecific());
-        snmp.setGeneric(source.getGeneric());
+        snmp.setSpecific(source.copySpecific());
+        snmp.setGeneric(source.copyGeneric());
         snmp.setCommunity(source.getCommunity());
-        snmp.setTimeStamp(source.getTimeStamp());
+        snmp.setTimeStamp(source.copyTimeStamp());
         return snmp;
     }
 
@@ -175,6 +175,10 @@ public class Snmp implements Serializable {
         return this._generic == null? 0 : this._generic;
     }
 
+    public Integer copyGeneric() {
+        return _generic;
+    }
+
     /**
      * Returns the value of field 'id'. The field 'id' has the
      * following description: The snmp enterprise id
@@ -208,6 +212,10 @@ public class Snmp implements Serializable {
         return this._specific == null? 0 : this._specific;
     }
 
+    public Integer copySpecific() {
+        return _specific;
+    }
+
     /**
      * Returns the value of field 'timeStamp'. The field
      * 'timeStamp' has the following description: The time stamp
@@ -217,6 +225,10 @@ public class Snmp implements Serializable {
     public Long getTimeStamp(
     ) {
         return this._timeStamp == null? 0 : this._timeStamp;
+    }
+
+    public Long copyTimeStamp() {
+        return _timeStamp;
     }
 
     /**

--- a/features/events/api/src/test/java/org/opennms/netmgt/events/api/model/ImmutableEventTest.java
+++ b/features/events/api/src/test/java/org/opennms/netmgt/events/api/model/ImmutableEventTest.java
@@ -97,9 +97,6 @@ public class ImmutableEventTest {
         Event event = new Event();
 
         // The following must have values due to the implementation of their getters.
-        event.setDbid(0);
-        event.setIfIndex(0);
-        event.setNodeid(0L);
         event.setParmCollection(Collections.emptyList());
 
         // Mutable to Immutable

--- a/features/events/daemon/src/main/java/org/opennms/netmgt/eventd/BroadcastEventProcessor.java
+++ b/features/events/daemon/src/main/java/org/opennms/netmgt/eventd/BroadcastEventProcessor.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2007-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2007-2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -32,9 +32,9 @@ import org.opennms.netmgt.config.api.EventConfDao;
 import org.opennms.netmgt.events.api.EventConstants;
 import org.opennms.netmgt.events.api.EventIpcManager;
 import org.opennms.netmgt.events.api.EventListener;
+import org.opennms.netmgt.events.api.model.IEvent;
+import org.opennms.netmgt.events.api.model.IParm;
 import org.opennms.netmgt.model.events.EventBuilder;
-import org.opennms.netmgt.xml.event.Event;
-import org.opennms.netmgt.xml.event.Parm;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.util.Assert;
@@ -119,7 +119,7 @@ public class BroadcastEventProcessor implements EventListener {
      * Event Identifier and the appropriate action is taking based on each UEI.
      */
     @Override
-    public void onEvent(Event event) {
+    public void onEvent(IEvent event) {
         
         LOG.debug("onEvent: received event, UEI = {}", event.getUei());
         EventBuilder ebldr = null;
@@ -144,11 +144,11 @@ public class BroadcastEventProcessor implements EventListener {
         }
     }
 
-    private boolean isReloadConfigEvent(Event event) {
+    private boolean isReloadConfigEvent(IEvent event) {
         boolean isTarget = false;
         
         if (EventConstants.RELOAD_DAEMON_CONFIG_UEI.equals(event.getUei())) {
-            final Parm target = event.getParm(EventConstants.PARM_DAEMON_NAME);
+            final IParm target = event.getParm(EventConstants.PARM_DAEMON_NAME);
             if (target != null && "Eventd".equalsIgnoreCase(target.getValue().getContent())) {
                 isTarget = true;
             }

--- a/features/events/daemon/src/test/java/org/opennms/netmgt/eventd/BroadcastEventProcessorTest.java
+++ b/features/events/daemon/src/test/java/org/opennms/netmgt/eventd/BroadcastEventProcessorTest.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2007-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2007-2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -33,6 +33,7 @@ import junit.framework.TestCase;
 import org.opennms.netmgt.config.api.EventConfDao;
 import org.opennms.netmgt.dao.mock.MockEventIpcManager;
 import org.opennms.netmgt.events.api.EventConstants;
+import org.opennms.netmgt.events.api.model.ImmutableMapper;
 import org.opennms.netmgt.model.events.EventBuilder;
 import org.opennms.test.ThrowableAnticipator;
 import org.opennms.test.mock.EasyMockUtils;
@@ -89,7 +90,7 @@ public class BroadcastEventProcessorTest extends TestCase {
         
         m_mocks.replayAll();
         
-        processor.onEvent(eventBuilder.getEvent());
+        processor.onEvent(ImmutableMapper.fromMutableEvent(eventBuilder.getEvent()));
         
         m_mocks.verifyAll();
     }
@@ -106,7 +107,7 @@ public class BroadcastEventProcessorTest extends TestCase {
 
         m_mocks.replayAll();
 
-        processor.onEvent(eventBuilder.getEvent());
+        processor.onEvent(ImmutableMapper.fromMutableEvent(eventBuilder.getEvent()));
 
         m_mocks.verifyAll();
     }

--- a/features/events/daemon/src/test/java/org/opennms/netmgt/eventd/EventIpcManagerDefaultImplTest.java
+++ b/features/events/daemon/src/test/java/org/opennms/netmgt/eventd/EventIpcManagerDefaultImplTest.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2008-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2008-2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -52,6 +52,8 @@ import org.opennms.netmgt.events.api.EventConstants;
 import org.opennms.netmgt.events.api.EventHandler;
 import org.opennms.netmgt.events.api.EventListener;
 import org.opennms.netmgt.events.api.ThreadAwareEventListener;
+import org.opennms.netmgt.events.api.model.IEvent;
+import org.opennms.netmgt.events.api.model.ImmutableMapper;
 import org.opennms.netmgt.model.events.EventBuilder;
 import org.opennms.netmgt.xml.event.Event;
 import org.opennms.netmgt.xml.event.Log;
@@ -211,7 +213,8 @@ public class EventIpcManagerDefaultImplTest extends TestCase {
         
         m_mocks.verifyAll();
         
-        assertTrue("could not remove broadcasted event--did it make it?", m_listener.getEvents().remove(event));
+        assertTrue("could not remove broadcasted event--did it make it?",
+                m_listener.getEvents().remove(ImmutableMapper.fromMutableEvent(event)));
     }
 
     public void testAddEventListenerTwoArgumentListNullListener() throws Exception {
@@ -252,7 +255,8 @@ public class EventIpcManagerDefaultImplTest extends TestCase {
         
         m_mocks.verifyAll();
         
-        assertTrue("could not remove broadcasted event--did it make it?", m_listener.getEvents().remove(e));
+        assertTrue("could not remove broadcasted event--did it make it?",
+                m_listener.getEvents().remove(ImmutableMapper.fromMutableEvent(e)));
     }
     
     public void testAddEventListenerTwoArgumentStringWithUeiPartAndBroadcast() throws Exception {
@@ -268,7 +272,8 @@ public class EventIpcManagerDefaultImplTest extends TestCase {
         
         m_mocks.verifyAll();
         
-        assertTrue("could not remove broadcasted event--did it make it?", m_listener.getEvents().remove(e));
+        assertTrue("could not remove broadcasted event--did it make it?",
+                m_listener.getEvents().remove(ImmutableMapper.fromMutableEvent(e)));
     }
     
     public void testAddEventListenerTwoArgumentStringWithUeiPartMultipleTrimAndBroadcast() throws Exception {
@@ -283,7 +288,8 @@ public class EventIpcManagerDefaultImplTest extends TestCase {
         
         m_mocks.verifyAll();
         
-        assertTrue("could not remove broadcasted event--did it make it?", m_listener.getEvents().remove(e));
+        assertTrue("could not remove broadcasted event--did it make it?",
+                m_listener.getEvents().remove(ImmutableMapper.fromMutableEvent(e)));
     }
     
     public void testAddEventListenerTwoArgumentStringWithUeiPartTooLittleAndBroadcast() throws Exception {
@@ -325,7 +331,8 @@ public class EventIpcManagerDefaultImplTest extends TestCase {
         
         m_mocks.verifyAll();
         
-        assertTrue("could not remove broadcasted event--did it make it?", m_listener.getEvents().remove(e));
+        assertTrue("could not remove broadcasted event--did it make it?",
+                m_listener.getEvents().remove(ImmutableMapper.fromMutableEvent(e)));
     }
     
     public void testAddEventListenerTwoArgumentStringNullListener() throws Exception {
@@ -432,7 +439,8 @@ public class EventIpcManagerDefaultImplTest extends TestCase {
         
         m_mocks.verifyAll();
         
-        assertTrue("could not remove broadcasted event--did it make it?", m_listener.getEvents().remove(e));
+        assertTrue("could not remove broadcasted event--did it make it?",
+                m_listener.getEvents().remove(ImmutableMapper.fromMutableEvent(e)));
     }
     
     public void testAddEventListenerWithUeiAndBroadcastThenAddEventListener() throws Exception {
@@ -448,7 +456,8 @@ public class EventIpcManagerDefaultImplTest extends TestCase {
         
         m_mocks.verifyAll();
         
-        assertTrue("could not remove broadcasted event--did it make it?", m_listener.getEvents().remove(e));
+        assertTrue("could not remove broadcasted event--did it make it?",
+                m_listener.getEvents().remove(ImmutableMapper.fromMutableEvent(e)));
     }
     
 
@@ -592,7 +601,7 @@ public class EventIpcManagerDefaultImplTest extends TestCase {
             }
 
             @Override
-            public void onEvent(Event event) {
+            public void onEvent(IEvent event) {
                 LOG.info("Hello, here is event: " + event.getUei());
                 try {
                     Thread.sleep(SLOW_EVENT_OPERATION_DELAY);
@@ -653,7 +662,7 @@ public class EventIpcManagerDefaultImplTest extends TestCase {
             }
 
             @Override
-            public void onEvent(Event event) {
+            public void onEvent(IEvent event) {
                 if ("uei.opennms.org/foo".equals(event.getUei())) {
                     EventBuilder bldr = new EventBuilder("uei.opennms.org/bar", "testRecursiveEvents");
                     Event e = bldr.getEvent();
@@ -676,7 +685,7 @@ public class EventIpcManagerDefaultImplTest extends TestCase {
             }
 
             @Override
-            public void onEvent(Event event) {
+            public void onEvent(IEvent event) {
                 if ("uei.opennms.org/foo".equals(event.getUei())) {
                     EventBuilder bldr = new EventBuilder("uei.opennms.org/ulf", "testRecursiveEvents");
                     Event e = bldr.getEvent();
@@ -711,7 +720,7 @@ public class EventIpcManagerDefaultImplTest extends TestCase {
     }
 
     public class MockEventListener implements EventListener {
-        private List<Event> m_events = new ArrayList<>();
+        private List<IEvent> m_events = new ArrayList<>();
         
         @Override
         public String getName() {
@@ -719,11 +728,11 @@ public class EventIpcManagerDefaultImplTest extends TestCase {
         }
 
         @Override
-        public void onEvent(Event e) {
+        public void onEvent(IEvent e) {
             m_events.add(e);
         }
         
-        public List<Event> getEvents() {
+        public List<IEvent> getEvents() {
             return m_events;
         }
     }
@@ -737,7 +746,7 @@ public class EventIpcManagerDefaultImplTest extends TestCase {
             }
 
             @Override
-            public void onEvent(Event event) {
+            public void onEvent(IEvent event) {
                 try {
                     Thread.sleep(TimeUnit.SECONDS.toMillis(2));
                 } catch (InterruptedException e) {
@@ -780,7 +789,7 @@ public class EventIpcManagerDefaultImplTest extends TestCase {
         }
 
         @Override
-        public void onEvent(Event e) {
+        public void onEvent(IEvent e) {
             locker.park();
         }
 

--- a/features/events/syslog/src/main/java/org/opennms/netmgt/syslogd/Syslogd.java
+++ b/features/events/syslog/src/main/java/org/opennms/netmgt/syslogd/Syslogd.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2006-2018 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2018 The OpenNMS Group, Inc.
+ * Copyright (C) 2006-2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -36,7 +36,7 @@ import org.opennms.netmgt.daemon.DaemonTools;
 import org.opennms.netmgt.events.api.EventConstants;
 import org.opennms.netmgt.events.api.annotations.EventHandler;
 import org.opennms.netmgt.events.api.annotations.EventListener;
-import org.opennms.netmgt.xml.event.Event;
+import org.opennms.netmgt.events.api.model.IEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -138,7 +138,7 @@ public class Syslogd extends AbstractServiceDaemon {
     }
 
     @EventHandler(uei = EventConstants.RELOAD_DAEMON_CONFIG_UEI)
-    public void handleReloadEvent(Event e) {
+    public void handleReloadEvent(IEvent e) {
         DaemonTools.handleReloadEvent(e, Syslogd.LOG4J_CATEGORY, (event) -> handleConfigurationChanged());
     }
 }

--- a/features/events/syslog/src/test/java/org/opennms/netmgt/syslogd/SyslogReloadDaemonIT.java
+++ b/features/events/syslog/src/test/java/org/opennms/netmgt/syslogd/SyslogReloadDaemonIT.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2018 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2018 The OpenNMS Group, Inc.
+ * Copyright (C) 2018-2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -50,6 +50,7 @@ import org.opennms.netmgt.config.syslogd.ProcessMatch;
 import org.opennms.netmgt.config.syslogd.UeiMatch;
 import org.opennms.netmgt.dao.api.DistPollerDao;
 import org.opennms.netmgt.dao.mock.MockEventIpcManager;
+import org.opennms.netmgt.events.api.model.ImmutableMapper;
 import org.opennms.netmgt.model.events.EventBuilder;
 import org.opennms.netmgt.syslogd.api.SyslogConnection;
 import org.opennms.netmgt.syslogd.api.SyslogMessageLogDTO;
@@ -157,7 +158,7 @@ public class SyslogReloadDaemonIT implements InitializingBean {
         System.setProperty("opennms.home", opennmsHome.getAbsolutePath());
         EventBuilder eventBuilder = new EventBuilder("uei.opennms.org/internal/reloadDaemonConfig", "syslog-test");
         eventBuilder.addParam("daemonName", "Syslogd");
-        m_syslogd.handleReloadEvent(eventBuilder.getEvent());
+        m_syslogd.handleReloadEvent(ImmutableMapper.fromMutableEvent(eventBuilder.getEvent()));
         SyslogdTestUtils.waitForSyslogdToReload();
         // test new port change in config 
         assertEquals(10515, m_config.getSyslogPort());

--- a/features/events/syslog/src/test/java/org/opennms/netmgt/syslogd/SyslogSinkConsumerNewSuspectIT.java
+++ b/features/events/syslog/src/test/java/org/opennms/netmgt/syslogd/SyslogSinkConsumerNewSuspectIT.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2010-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2010-2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -56,6 +56,7 @@ import org.opennms.netmgt.dao.mock.EventAnticipator;
 import org.opennms.netmgt.dao.mock.MockEventIpcManager;
 import org.opennms.netmgt.dao.support.InterfaceToNodeCacheEventProcessor;
 import org.opennms.netmgt.events.api.EventConstants;
+import org.opennms.netmgt.events.api.model.ImmutableMapper;
 import org.opennms.netmgt.model.events.EventBuilder;
 import org.opennms.netmgt.syslogd.api.SyslogConnection;
 import org.opennms.netmgt.syslogd.api.SyslogMessageLogDTO;
@@ -167,7 +168,7 @@ public class SyslogSinkConsumerNewSuspectIT {
         EventBuilder builder = new EventBuilder(EventConstants.NODE_GAINED_INTERFACE_EVENT_UEI, getClass().getSimpleName());
         builder.setNodeid(nodeId);
         builder.setInterface(addr);
-        m_processor.handleNodeGainedInterface(builder.getEvent());
+        m_processor.handleNodeGainedInterface(ImmutableMapper.fromMutableEvent(builder.getEvent()));
 
         // The entry was added to the cache
         assertEquals(1, m_cache.size());
@@ -183,7 +184,7 @@ public class SyslogSinkConsumerNewSuspectIT {
         builder = new EventBuilder(EventConstants.INTERFACE_DELETED_EVENT_UEI, getClass().getSimpleName());
         builder.setNodeid(nodeId);
         builder.setInterface(addr);
-        m_processor.handleInterfaceDeleted(builder.getEvent());
+        m_processor.handleInterfaceDeleted(ImmutableMapper.fromMutableEvent(builder.getEvent()));
 
         // The entry was removed from the cache
         assertEquals(0, m_cache.size());

--- a/features/events/syslog/src/test/java/org/opennms/netmgt/syslogd/SyslogdEventdLoadIT.java
+++ b/features/events/syslog/src/test/java/org/opennms/netmgt/syslogd/SyslogdEventdLoadIT.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2010-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2010-2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -61,6 +61,7 @@ import org.opennms.netmgt.eventd.Eventd;
 import org.opennms.netmgt.events.api.EventIpcManager;
 import org.opennms.netmgt.events.api.EventListener;
 import org.opennms.netmgt.events.api.EventProxy;
+import org.opennms.netmgt.events.api.model.IEvent;
 import org.opennms.netmgt.events.api.support.TcpEventProxy;
 import org.opennms.netmgt.model.events.EventBuilder;
 import org.opennms.netmgt.syslogd.api.SyslogConnection;
@@ -361,7 +362,7 @@ public class SyslogdEventdLoadIT implements InitializingBean {
         }
 
         @Override
-        public void onEvent(final Event e) {
+        public void onEvent(final IEvent e) {
             final int current = m_eventCount.incrementAndGet();
             if (current % 100 == 0) {
                 System.err.println(current + " < " + m_expectedCount);

--- a/features/events/syslog/src/test/java/org/opennms/netmgt/syslogd/SyslogdImplementationsIT.java
+++ b/features/events/syslog/src/test/java/org/opennms/netmgt/syslogd/SyslogdImplementationsIT.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2010-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2010-2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -53,9 +53,9 @@ import org.opennms.core.utils.InetAddressUtils;
 import org.opennms.netmgt.config.SyslogdConfigFactory;
 import org.opennms.netmgt.dao.mock.MockEventIpcManager;
 import org.opennms.netmgt.events.api.EventListener;
+import org.opennms.netmgt.events.api.model.IEvent;
 import org.opennms.netmgt.syslogd.api.SyslogConnection;
 import org.opennms.netmgt.syslogd.api.SyslogMessageLogDTO;
-import org.opennms.netmgt.xml.event.Event;
 import org.opennms.test.JUnitConfigurationEnvironment;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -265,7 +265,7 @@ public class SyslogdImplementationsIT implements InitializingBean {
         }
 
         @Override
-        public void onEvent(final Event e) {
+        public void onEvent(final IEvent e) {
             final int current = m_eventCount.incrementAndGet();
             if (current % 100 == 0) {
                 System.err.println(current + " out of " + m_expectedCount + " expected events received");

--- a/features/events/syslog/src/test/java/org/opennms/netmgt/syslogd/SyslogdLoadIT.java
+++ b/features/events/syslog/src/test/java/org/opennms/netmgt/syslogd/SyslogdLoadIT.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2010-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2010-2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -64,6 +64,7 @@ import org.opennms.netmgt.dao.mock.MockEventIpcManager;
 import org.opennms.netmgt.eventd.Eventd;
 import org.opennms.netmgt.events.api.EventListener;
 import org.opennms.netmgt.events.api.EventProxy;
+import org.opennms.netmgt.events.api.model.IEvent;
 import org.opennms.netmgt.events.api.support.TcpEventProxy;
 import org.opennms.netmgt.model.events.EventBuilder;
 import org.opennms.netmgt.syslogd.api.SyslogConnection;
@@ -460,7 +461,7 @@ public class SyslogdLoadIT implements InitializingBean {
         }
 
         @Override
-        public void onEvent(final Event e) {
+        public void onEvent(final IEvent e) {
             final int current = m_eventCount.incrementAndGet();
             if (current % 100 == 0) {
                 System.err.println(current + " out of " + m_expectedCount + " expected events received");

--- a/features/events/traps/src/main/java/org/opennms/netmgt/trapd/Trapd.java
+++ b/features/events/traps/src/main/java/org/opennms/netmgt/trapd/Trapd.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2005-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2005-2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -36,7 +36,7 @@ import org.opennms.netmgt.daemon.DaemonTools;
 import org.opennms.netmgt.events.api.EventConstants;
 import org.opennms.netmgt.events.api.annotations.EventHandler;
 import org.opennms.netmgt.events.api.annotations.EventListener;
-import org.opennms.netmgt.xml.event.Event;
+import org.opennms.netmgt.events.api.model.IEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -196,7 +196,7 @@ public class Trapd extends AbstractServiceDaemon {
     }
 
     @EventHandler(uei = EventConstants.RELOAD_DAEMON_CONFIG_UEI)
-    public void handleReloadEvent(Event e) {
+    public void handleReloadEvent(IEvent e) {
         DaemonTools.handleReloadEvent(e, Trapd.LOG4J_CATEGORY, (event) -> handleConfigurationChanged());
     }
 

--- a/features/events/traps/src/test/java/org/opennms/netmgt/trapd/TrapdReloadDaemonIT.java
+++ b/features/events/traps/src/test/java/org/opennms/netmgt/trapd/TrapdReloadDaemonIT.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2018 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2018 The OpenNMS Group, Inc.
+ * Copyright (C) 2018-2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -45,6 +45,7 @@ import org.opennms.core.utils.InetAddressUtils;
 import org.opennms.netmgt.config.TrapdConfigFactory;
 import org.opennms.netmgt.dao.mock.MockEventIpcManager;
 import org.opennms.netmgt.events.api.EventConstants;
+import org.opennms.netmgt.events.api.model.ImmutableMapper;
 import org.opennms.netmgt.model.events.EventBuilder;
 import org.opennms.netmgt.snmp.SnmpInstId;
 import org.opennms.netmgt.snmp.SnmpObjId;
@@ -128,7 +129,7 @@ public class TrapdReloadDaemonIT implements InitializingBean {
         reloadDaemonBuilder.addParam(EventConstants.PARM_DAEMON_NAME, m_trapd.getName());
         m_eventMgr.getEventAnticipator().anticipateEvent(reloadDaemonBuilder.getEvent());
         // Send reload event to trapd
-        m_trapd.handleReloadEvent(eventBuilder.getEvent());
+        m_trapd.handleReloadEvent(ImmutableMapper.fromMutableEvent(eventBuilder.getEvent()));
         m_eventMgr.getEventAnticipator().verifyAnticipated(5000, 0, 0, 0, 0);
         m_eventMgr.getEventAnticipator().reset();
 

--- a/features/graph/provider/bsm/src/main/java/org/opennms/netmgt/graph/provider/bsm/BusinessServiceGraphProvider.java
+++ b/features/graph/provider/bsm/src/main/java/org/opennms/netmgt/graph/provider/bsm/BusinessServiceGraphProvider.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2019-2019 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ * Copyright (C) 2019-2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -41,6 +41,7 @@ import org.opennms.netmgt.bsm.service.model.graph.GraphVertex;
 import org.opennms.netmgt.events.api.EventConstants;
 import org.opennms.netmgt.events.api.EventIpcManager;
 import org.opennms.netmgt.events.api.EventListener;
+import org.opennms.netmgt.events.api.model.IEvent;
 import org.opennms.netmgt.graph.api.ImmutableGraph;
 import org.opennms.netmgt.graph.api.VertexRef;
 import org.opennms.netmgt.graph.api.info.DefaultGraphInfo;
@@ -116,7 +117,7 @@ public class BusinessServiceGraphProvider implements GraphProvider, EventListene
     }
 
     @Override
-    public void onEvent(Event e) {
+    public void onEvent(IEvent e) {
         // BSM has been reloaded, force reload
         if (e.getUei().equals(EventConstants.RELOAD_DAEMON_CONFIG_SUCCESSFUL_UEI)) {
             String daemonName = EventUtils.getParm(e, EventConstants.PARM_DAEMON_NAME);

--- a/features/kafka/producer/src/main/java/org/opennms/features/kafka/producer/OpennmsKafkaProducer.java
+++ b/features/kafka/producer/src/main/java/org/opennms/features/kafka/producer/OpennmsKafkaProducer.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2018 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2018 The OpenNMS Group, Inc.
+ * Copyright (C) 2018-2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -60,6 +60,7 @@ import org.opennms.netmgt.alarmd.api.AlarmCallbackStateTracker;
 import org.opennms.netmgt.alarmd.api.AlarmLifecycleListener;
 import org.opennms.netmgt.events.api.EventListener;
 import org.opennms.netmgt.events.api.EventSubscriptionService;
+import org.opennms.netmgt.events.api.model.IEvent;
 import org.opennms.netmgt.model.OnmsAlarm;
 import org.opennms.netmgt.topologies.service.api.OnmsTopologyConsumer;
 import org.opennms.netmgt.topologies.service.api.OnmsTopologyDao;
@@ -472,8 +473,8 @@ public class OpennmsKafkaProducer implements AlarmLifecycleListener, EventListen
     }
 
     @Override
-    public void onEvent(Event event) {
-        forwardEvent(event);
+    public void onEvent(IEvent event) {
+        forwardEvent(Event.copyFrom(event));
     }
 
     @Override

--- a/features/minion/status/src/main/java/org/opennms/minion/status/MinionStatusTracker.java
+++ b/features/minion/status/src/main/java/org/opennms/minion/status/MinionStatusTracker.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2018 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2018 The OpenNMS Group, Inc.
+ * Copyright (C) 2018-2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -53,10 +53,10 @@ import org.opennms.netmgt.dao.api.ServiceTypeDao;
 import org.opennms.netmgt.events.api.EventConstants;
 import org.opennms.netmgt.events.api.annotations.EventHandler;
 import org.opennms.netmgt.events.api.annotations.EventListener;
+import org.opennms.netmgt.events.api.model.IEvent;
 import org.opennms.netmgt.model.OnmsNode;
 import org.opennms.netmgt.model.minion.OnmsMinion;
 import org.opennms.netmgt.model.outage.CurrentOutageDetails;
-import org.opennms.netmgt.xml.event.Event;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.InitializingBean;
@@ -145,7 +145,7 @@ public class MinionStatusTracker implements InitializingBean {
     }
 
     @EventHandler(uei=EventConstants.MONITORING_SYSTEM_ADDED_UEI)
-    public void onMonitoringSystemAdded(final Event e) {
+    public void onMonitoringSystemAdded(final IEvent e) {
         runInLoggingTransaction(() -> {
             final String id = e.getParm(EventConstants.PARAM_MONITORING_SYSTEM_ID).toString();
             LOG.debug("Monitoring system added: {}", id);
@@ -156,7 +156,7 @@ public class MinionStatusTracker implements InitializingBean {
     }
 
     @EventHandler(uei=EventConstants.MONITORING_SYSTEM_DELETED_UEI)
-    public void onMonitoringSystemDeleted(final Event e) {
+    public void onMonitoringSystemDeleted(final IEvent e) {
         runInLoggingTransaction(() -> {
             final String id = e.getParm(EventConstants.PARAM_MONITORING_SYSTEM_ID).toString();
             if (id != null) {
@@ -181,7 +181,7 @@ public class MinionStatusTracker implements InitializingBean {
     }
 
     @EventHandler(uei=EventConstants.NODE_GAINED_SERVICE_EVENT_UEI)
-    public void onNodeGainedService(final Event e) {
+    public void onNodeGainedService(final IEvent e) {
         if (!MINION_HEARTBEAT.equals(e.getService()) && !MINION_RPC.equals(e.getService())) {
             return;
         }
@@ -216,7 +216,7 @@ public class MinionStatusTracker implements InitializingBean {
     }
 
     @EventHandler(uei=EventConstants.NODE_DELETED_EVENT_UEI)
-    public void onNodeDeleted(final Event e) {
+    public void onNodeDeleted(final IEvent e) {
         runInLoggingTransaction(() -> {
             assertHasNodeId(e);
             final Integer nodeId = e.getNodeid().intValue();
@@ -235,7 +235,7 @@ public class MinionStatusTracker implements InitializingBean {
             OUTAGE_CREATED_EVENT_UEI,
             OUTAGE_RESOLVED_EVENT_UEI
     })
-    public void onOutageEvent(final Event e) {
+    public void onOutageEvent(final IEvent e) {
         final boolean isHeartbeat = MINION_HEARTBEAT.equals(e.getService());
         final boolean isRpc = MINION_RPC.equals(e.getService());
 
@@ -439,7 +439,7 @@ public class MinionStatusTracker implements InitializingBean {
         return minion;
     }
 
-    private void assertHasNodeId(final Event e) {
+    private void assertHasNodeId(final IEvent e) {
         if (e.getNodeid() == null || e.getNodeid() == 0) {
             final IllegalStateException ex = new IllegalStateException("Received a nodeGainedService event, but there is no node ID!");
             LOG.warn(ex.getMessage() + " {}", e, ex);

--- a/features/minion/status/src/test/java/org/opennms/minion/status/MinionStatusTrackerTest.java
+++ b/features/minion/status/src/test/java/org/opennms/minion/status/MinionStatusTrackerTest.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2018 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2018 The OpenNMS Group, Inc.
+ * Copyright (C) 2018-2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -62,6 +62,7 @@ import org.opennms.netmgt.dao.api.NodeDao;
 import org.opennms.netmgt.dao.api.OutageDao;
 import org.opennms.netmgt.dao.api.ServiceTypeDao;
 import org.opennms.netmgt.events.api.EventConstants;
+import org.opennms.netmgt.events.api.model.ImmutableMapper;
 import org.opennms.netmgt.model.OnmsIpInterface;
 import org.opennms.netmgt.model.OnmsMonitoredService;
 import org.opennms.netmgt.model.OnmsNode;
@@ -123,14 +124,14 @@ public class MinionStatusTrackerTest {
     public void testEventMissingNodeId() throws Exception {
         final Event e = EventUtils.createNodeGainedServiceEvent(FOREIGN_SOURCE, 1, InetAddressUtils.addr("192.168.0.1"), MINION_HEARTBEAT, null, NodeLabelSource.UNKNOWN, null, null);
         e.setNodeid(null);
-        m_tracker.onNodeGainedService(e);
+        m_tracker.onNodeGainedService(ImmutableMapper.fromMutableEvent(e));
     }
 
     @Test(expected=IllegalStateException.class)
     public void testEventMissingNode() throws Exception {
         final Event e = EventUtils.createNodeGainedServiceEvent(FOREIGN_SOURCE, 1, InetAddressUtils.addr("192.168.0.1"), MINION_HEARTBEAT, null, NodeLabelSource.UNKNOWN, null, null);
         when(m_nodeDao.get(anyInt())).thenReturn(null);
-        m_tracker.onNodeGainedService(e);
+        m_tracker.onNodeGainedService(ImmutableMapper.fromMutableEvent(e));
     }
 
     @Test
@@ -138,7 +139,7 @@ public class MinionStatusTrackerTest {
         final String foreignId = UUID.randomUUID().toString();
 
         final Event e = EventUtils.createNodeGainedServiceEvent(FOREIGN_SOURCE, 1, InetAddressUtils.addr("192.168.0.1"), "Imaginary", "one", NodeLabelSource.HOSTNAME, null, null);
-        m_tracker.onNodeGainedService(e);
+        m_tracker.onNodeGainedService(ImmutableMapper.fromMutableEvent(e));
 
         verifyNoMoreInteractions(m_nodeDao);
         verifyNoMoreInteractions(m_minionDao);
@@ -158,7 +159,7 @@ public class MinionStatusTrackerTest {
         when(m_minionDao.findById(foreignId)).thenReturn(minion);
 
         final Event e = EventUtils.createNodeGainedServiceEvent(FOREIGN_SOURCE, 1, InetAddressUtils.addr("192.168.0.1"), MINION_HEARTBEAT, "one", NodeLabelSource.HOSTNAME, null, null);
-        m_tracker.onNodeGainedService(e);
+        m_tracker.onNodeGainedService(ImmutableMapper.fromMutableEvent(e));
 
         assertEquals("there should be one minion", 1, m_tracker.getMinions().size());
         assertEquals("it should match our minion", foreignId, m_tracker.getMinions().iterator().next().getId());
@@ -179,7 +180,7 @@ public class MinionStatusTrackerTest {
         when(m_minionDao.findById(foreignId)).thenReturn(minion);
 
         final Event e = EventUtils.createNodeGainedServiceEvent(FOREIGN_SOURCE, 1, InetAddressUtils.addr("192.168.0.1"), MINION_HEARTBEAT, "one", NodeLabelSource.HOSTNAME, null, null);
-        m_tracker.onNodeGainedService(e);
+        m_tracker.onNodeGainedService(ImmutableMapper.fromMutableEvent(e));
 
         assertEquals("there should be one minion", 1, m_tracker.getMinions().size());
         assertEquals("it should match our minion", foreignId, m_tracker.getMinions().iterator().next().getId());
@@ -199,7 +200,7 @@ public class MinionStatusTrackerTest {
         when(m_minionDao.findById(foreignId)).thenReturn(minion);
 
         final Event e = EventUtils.createNodeGainedServiceEvent(FOREIGN_SOURCE, 1, InetAddressUtils.addr("192.168.0.1"), MINION_RPC, "one", NodeLabelSource.HOSTNAME, null, null);
-        m_tracker.onNodeGainedService(e);
+        m_tracker.onNodeGainedService(ImmutableMapper.fromMutableEvent(e));
 
         assertEquals("there should be one minion", 1, m_tracker.getMinions().size());
         assertEquals("it should match our minion", foreignId, m_tracker.getMinions().iterator().next().getId());
@@ -218,9 +219,9 @@ public class MinionStatusTrackerTest {
         when(m_minionDao.findById(foreignId)).thenReturn(minion);
 
         Event e = EventUtils.createNodeGainedServiceEvent(FOREIGN_SOURCE, 1, InetAddressUtils.addr("192.168.0.1"), MINION_HEARTBEAT, "one", NodeLabelSource.HOSTNAME, null, null);
-        m_tracker.onNodeGainedService(e);
+        m_tracker.onNodeGainedService(ImmutableMapper.fromMutableEvent(e));
         e = EventUtils.createNodeGainedServiceEvent(FOREIGN_SOURCE, 1, InetAddressUtils.addr("192.168.0.1"), MINION_RPC, "one", NodeLabelSource.HOSTNAME, null, null);
-        m_tracker.onNodeGainedService(e);
+        m_tracker.onNodeGainedService(ImmutableMapper.fromMutableEvent(e));
 
         assertEquals("there should be one minion", 1, m_tracker.getMinions().size());
         assertEquals("it should match our minion", foreignId, m_tracker.getMinions().iterator().next().getId());
@@ -263,7 +264,7 @@ public class MinionStatusTrackerTest {
         when(m_minionDao.findById(foreignId)).thenReturn(minion);
 
         Event e = EventUtils.createNodeDeletedEvent(FOREIGN_SOURCE, 1, "one", "one");
-        m_tracker.onNodeDeleted(e);
+        m_tracker.onNodeDeleted(ImmutableMapper.fromMutableEvent(e));
 
         assertEquals("there should still be a minion", 1, m_tracker.getMinions().size());
         final MinionStatus status = m_tracker.getStatus(minion);
@@ -539,7 +540,7 @@ public class MinionStatusTrackerTest {
                 .setService(service)
                 .setTime(time)
                 .getEvent();
-        m_tracker.onOutageEvent(e);
+        m_tracker.onOutageEvent(ImmutableMapper.fromMutableEvent(e));
         return outage;
     }
 

--- a/features/opennms-es-rest/src/main/java/org/opennms/plugins/elasticsearch/rest/ForwardingEventListener.java
+++ b/features/opennms-es-rest/src/main/java/org/opennms/plugins/elasticsearch/rest/ForwardingEventListener.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2002-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2002-2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -33,6 +33,7 @@ import java.util.Objects;
 import org.opennms.netmgt.events.api.EventForwarder;
 import org.opennms.netmgt.events.api.EventIpcManager;
 import org.opennms.netmgt.events.api.EventListener;
+import org.opennms.netmgt.events.api.model.IEvent;
 import org.opennms.netmgt.xml.event.Event;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -75,8 +76,8 @@ public class ForwardingEventListener implements EventListener {
 	 * UEI.
 	 */
 	@Override
-	public void onEvent(final Event event) {
-		eventForwarder.sendNow(event);
+	public void onEvent(final IEvent event) {
+		eventForwarder.sendNow(Event.copyFrom(event));
 	}
 
 

--- a/features/poller/remote/src/main/java/org/opennms/netmgt/poller/remote/support/PollerBackEndEventProcessor.java
+++ b/features/poller/remote/src/main/java/org/opennms/netmgt/poller/remote/support/PollerBackEndEventProcessor.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2010-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2010-2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -31,9 +31,9 @@ package org.opennms.netmgt.poller.remote.support;
 import org.opennms.netmgt.events.api.EventConstants;
 import org.opennms.netmgt.events.api.annotations.EventHandler;
 import org.opennms.netmgt.events.api.annotations.EventListener;
+import org.opennms.netmgt.events.api.model.IEvent;
 import org.opennms.netmgt.model.events.EventUtils;
 import org.opennms.netmgt.poller.remote.PollerBackEnd;
-import org.opennms.netmgt.xml.event.Event;
 
 /**
  * <p>PollerBackEndEventProcessor class.</p>
@@ -58,20 +58,20 @@ public class PollerBackEndEventProcessor {
     /**
      * <p>handleSnmpPollerConfigChanged</p>
      *
-     * @param event a {@link org.opennms.netmgt.xml.event.Event} object.
+     * @param event a {@link org.opennms.netmgt.events.api.model.IEvent} object.
      */
     @EventHandler(uei=EventConstants.SNMPPOLLERCONFIG_CHANGED_EVENT_UEI)
-    public void handleSnmpPollerConfigChanged(final Event event) {
+    public void handleSnmpPollerConfigChanged(final IEvent event) {
         m_pollerBackEnd.configurationUpdated();
     }
 
     /**
      * <p>handleDaemonConfigChanged</p>
      *
-     * @param event a {@link org.opennms.netmgt.xml.event.Event} object.
+     * @param event a {@link org.opennms.netmgt.events.api.model.IEvent} object.
      */
     @EventHandler(uei=EventConstants.RELOAD_DAEMON_CONFIG_UEI)
-    public void handleDaemonConfigChanged(final Event event) {
+    public void handleDaemonConfigChanged(final IEvent event) {
         String daemon = EventUtils.getParm(event, EventConstants.PARM_DAEMON_NAME);
         if ("PollerBackEnd".equalsIgnoreCase(daemon)) {
             m_pollerBackEnd.configurationUpdated();
@@ -81,90 +81,90 @@ public class PollerBackEndEventProcessor {
     /**
      * <p>handleNodeAdded</p>
      *
-     * @param event a {@link org.opennms.netmgt.xml.event.Event} object.
+     * @param event a {@link org.opennms.netmgt.events.api.model.IEvent} object.
      */
     @EventHandler(uei=EventConstants.NODE_ADDED_EVENT_UEI)
-    public void handleNodeAdded(final Event event) {
+    public void handleNodeAdded(final IEvent event) {
         m_pollerBackEnd.configurationUpdated();
     }
 
     /**
      * <p>handleNodeGainedInterface</p>
      *
-     * @param event a {@link org.opennms.netmgt.xml.event.Event} object.
+     * @param event a {@link org.opennms.netmgt.events.api.model.IEvent} object.
      */
     @EventHandler(uei=EventConstants.NODE_GAINED_INTERFACE_EVENT_UEI)
-    public void handleNodeGainedInterface(final Event event) {
+    public void handleNodeGainedInterface(final IEvent event) {
         m_pollerBackEnd.configurationUpdated();
     }
 
     /**
      * <p>handleNodeGainedService</p>
      *
-     * @param event a {@link org.opennms.netmgt.xml.event.Event} object.
+     * @param event a {@link org.opennms.netmgt.events.api.model.IEvent} object.
      */
     @EventHandler(uei=EventConstants.NODE_GAINED_SERVICE_EVENT_UEI)
-    public void handleNodeGainedService(final Event event) {
+    public void handleNodeGainedService(final IEvent event) {
         m_pollerBackEnd.configurationUpdated();
     }
 
     /**
      * <p>handleNodeConfigChanged</p>
      *
-     * @param event a {@link org.opennms.netmgt.xml.event.Event} object.
+     * @param event a {@link org.opennms.netmgt.events.api.model.IEvent} object.
      */
     @EventHandler(uei=EventConstants.NODE_CONFIG_CHANGE_UEI)
-    public void handleNodeConfigChanged(final Event event) {
+    public void handleNodeConfigChanged(final IEvent event) {
         m_pollerBackEnd.configurationUpdated();
     }
 
     /**
      * <p>handleNodeInfoChanged</p>
      *
-     * @param event a {@link org.opennms.netmgt.xml.event.Event} object.
+     * @param event a {@link org.opennms.netmgt.events.api.model.IEvent} object.
      */
     @EventHandler(uei=EventConstants.NODE_INFO_CHANGED_EVENT_UEI)
-    public void handleNodeInfoChanged(final Event event) {
+    public void handleNodeInfoChanged(final IEvent event) {
         m_pollerBackEnd.configurationUpdated();
     }
 
     /**
      * <p>handleServiceDeleted</p>
      *
-     * @param event a {@link org.opennms.netmgt.xml.event.Event} object.
+     * @param event a {@link org.opennms.netmgt.events.api.model.IEvent} object.
      */
     @EventHandler(uei=EventConstants.SERVICE_DELETED_EVENT_UEI)
-    public void handleServiceDeleted(final Event event) {
+    public void handleServiceDeleted(final IEvent event) {
         m_pollerBackEnd.configurationUpdated();
     }
 
     /**
      * <p>handleServiceUnmanaged</p>
      *
-     * @param event a {@link org.opennms.netmgt.xml.event.Event} object.
+     * @param event a {@link org.opennms.netmgt.events.api.model.IEvent} object.
      */
     @EventHandler(uei=EventConstants.SERVICE_UNMANAGED_EVENT_UEI)
-    public void handleServiceUnmanaged(final Event event) {
+    public void handleServiceUnmanaged(final IEvent event) {
         m_pollerBackEnd.configurationUpdated();
     }
 
     /**
      * <p>handleInterfaceDeleted</p>
      *
-     * @param event a {@link org.opennms.netmgt.xml.event.Event} object.
+     * @param event a {@link org.opennms.netmgt.events.api.model.IEvent} object.
      */
     @EventHandler(uei=EventConstants.INTERFACE_DELETED_EVENT_UEI)
-    public void handleInterfaceDeleted(final Event event) {
+    public void handleInterfaceDeleted(final IEvent event) {
         m_pollerBackEnd.configurationUpdated();
     }
 
     /**
      * <p>handleNodeDeleted</p>
      *
-     * @param event a {@link org.opennms.netmgt.xml.event.Event} object.
+     * @param event a {@link org.opennms.netmgt.events.api.model.IEvent} object.
      */
     @EventHandler(uei=EventConstants.NODE_DELETED_EVENT_UEI)
-    public void handleNodeDeleted(final Event event) {
+    public void handleNodeDeleted(final IEvent event) {
         m_pollerBackEnd.configurationUpdated();
     }
 

--- a/features/telemetry/daemon/src/main/java/org/opennms/netmgt/telemetry/daemon/Telemetryd.java
+++ b/features/telemetry/daemon/src/main/java/org/opennms/netmgt/telemetry/daemon/Telemetryd.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2017-2017 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
+ * Copyright (C) 2017-2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -35,6 +35,7 @@ import java.util.stream.Collectors;
 import org.opennms.core.ipc.sink.api.AsyncDispatcher;
 import org.opennms.core.ipc.sink.api.MessageConsumerManager;
 import org.opennms.core.ipc.sink.api.MessageDispatcherFactory;
+import org.opennms.netmgt.events.api.model.IEvent;
 import org.opennms.netmgt.telemetry.api.registry.TelemetryRegistry;
 import org.opennms.netmgt.daemon.DaemonTools;
 import org.opennms.netmgt.daemon.SpringServiceDaemon;
@@ -50,7 +51,6 @@ import org.opennms.netmgt.telemetry.config.model.AdapterConfig;
 import org.opennms.netmgt.telemetry.config.model.ListenerConfig;
 import org.opennms.netmgt.telemetry.config.model.QueueConfig;
 import org.opennms.netmgt.telemetry.config.model.TelemetrydConfig;
-import org.opennms.netmgt.xml.event.Event;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -210,7 +210,7 @@ public class Telemetryd implements SpringServiceDaemon {
     }
 
     @EventHandler(uei = EventConstants.RELOAD_DAEMON_CONFIG_UEI)
-    public void handleReloadEvent(Event e) {
+    public void handleReloadEvent(IEvent e) {
         DaemonTools.handleReloadEvent(e, Telemetryd.NAME, (event) -> handleConfigurationChanged());
     }
 

--- a/features/ticketing/daemon/src/main/java/org/opennms/netmgt/ticketd/TroubleTicketer.java
+++ b/features/ticketing/daemon/src/main/java/org/opennms/netmgt/ticketd/TroubleTicketer.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2007-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2007-2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -38,9 +38,9 @@ import org.opennms.netmgt.daemon.SpringServiceDaemon;
 import org.opennms.netmgt.events.api.EventConstants;
 import org.opennms.netmgt.events.api.EventIpcManager;
 import org.opennms.netmgt.events.api.EventListener;
+import org.opennms.netmgt.events.api.model.IEvent;
+import org.opennms.netmgt.events.api.model.IParm;
 import org.opennms.netmgt.model.events.EventUtils;
-import org.opennms.netmgt.xml.event.Event;
-import org.opennms.netmgt.xml.event.Parm;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.util.Assert;
@@ -148,7 +148,7 @@ public class TroubleTicketer implements SpringServiceDaemon, EventListener {
 	 * Event listener Interface required implementation
 	 */
     @Override
-	public void onEvent(Event e) {
+	public void onEvent(IEvent e) {
         try {
 		if (EventConstants.TROUBLETICKET_CANCEL_UEI.equals(e.getUei())) {
 			handleCancelTicket(e);
@@ -173,7 +173,7 @@ public class TroubleTicketer implements SpringServiceDaemon, EventListener {
 	 * @param e An OpenNMS event.
 	 * @throws InsufficientInformationException
 	 */
-    private void handleCloseTicket(Event e) throws InsufficientInformationException {
+    private void handleCloseTicket(IEvent e) throws InsufficientInformationException {
         EventUtils.requireParm(e, EventConstants.PARM_ALARM_ID);
         EventUtils.requireParm(e, EventConstants.PARM_ALARM_UEI);
         EventUtils.requireParm(e, EventConstants.PARM_USER);
@@ -190,7 +190,7 @@ public class TroubleTicketer implements SpringServiceDaemon, EventListener {
      * @param e An OpenNMS Event
      * @throws InsufficientInformationException
      */
-	private void handleUpdateTicket(Event e) throws InsufficientInformationException {
+	private void handleUpdateTicket(IEvent e) throws InsufficientInformationException {
         EventUtils.requireParm(e, EventConstants.PARM_ALARM_ID);
         EventUtils.requireParm(e, EventConstants.PARM_ALARM_UEI);
         EventUtils.requireParm(e, EventConstants.PARM_USER);
@@ -207,14 +207,14 @@ public class TroubleTicketer implements SpringServiceDaemon, EventListener {
 	 * @param e An OpenNMS Event
 	 * @throws InsufficientInformationException
 	 */
-	private void handleCreateTicket(Event e) throws InsufficientInformationException {
+	private void handleCreateTicket(IEvent e) throws InsufficientInformationException {
         EventUtils.requireParm(e, EventConstants.PARM_ALARM_ID);
         EventUtils.requireParm(e, EventConstants.PARM_ALARM_UEI);
         EventUtils.requireParm(e, EventConstants.PARM_USER);
 
         int alarmId = EventUtils.getIntParm(e, EventConstants.PARM_ALARM_ID, 0);
         Map<String,String> attributes = new HashMap<String, String>();
-        for (final Parm parm: e.getParmCollection()) {
+        for (final IParm parm: e.getParmCollection()) {
         	attributes.put(parm.getParmName(), parm.getValue().getContent());
         }
         
@@ -226,7 +226,7 @@ public class TroubleTicketer implements SpringServiceDaemon, EventListener {
 	 * @param e
 	 * @throws InsufficientInformationException
 	 */
-	private void handleCancelTicket(Event e) throws InsufficientInformationException {
+	private void handleCancelTicket(IEvent e) throws InsufficientInformationException {
         EventUtils.requireParm(e, EventConstants.PARM_ALARM_ID);
         EventUtils.requireParm(e, EventConstants.PARM_ALARM_UEI);
         EventUtils.requireParm(e, EventConstants.PARM_USER);
@@ -238,11 +238,11 @@ public class TroubleTicketer implements SpringServiceDaemon, EventListener {
         m_ticketerServiceLayer.cancelTicketForAlarm(alarmId, ticketId);
 	}
 
-    private boolean isReloadConfigEvent(Event event) {
+    private boolean isReloadConfigEvent(IEvent event) {
         boolean isTarget = false;
         if (EventConstants.RELOAD_DAEMON_CONFIG_UEI.equals(event.getUei())) {
-            List<Parm> parmCollection = event.getParmCollection();
-            for (Parm parm : parmCollection) {
+            List<IParm> parmCollection = event.getParmCollection();
+            for (IParm parm : parmCollection) {
                 if (EventConstants.PARM_DAEMON_NAME.equals(parm.getParmName()) && "Ticketd".equalsIgnoreCase(parm.getValue().getContent())) {
                     isTarget = true;
                     break;
@@ -252,7 +252,7 @@ public class TroubleTicketer implements SpringServiceDaemon, EventListener {
         return isTarget;
     }
     
-    private void handleTicketerReload(Event e) {
+    private void handleTicketerReload(IEvent e) {
         m_ticketerServiceLayer.reloadTicketer();
     }
 

--- a/features/topology-map/org.opennms.features.topology.app/src/main/java/org/opennms/features/topology/app/internal/service/TopologyServiceEventListener.java
+++ b/features/topology-map/org.opennms.features.topology.app/src/main/java/org/opennms/features/topology/app/internal/service/TopologyServiceEventListener.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2017-2017 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
+ * Copyright (C) 2017-2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -36,8 +36,8 @@ import java.util.Objects;
 import org.opennms.netmgt.events.api.EventConstants;
 import org.opennms.netmgt.events.api.EventIpcManager;
 import org.opennms.netmgt.events.api.EventListener;
+import org.opennms.netmgt.events.api.model.IEvent;
 import org.opennms.netmgt.model.events.EventUtils;
-import org.opennms.netmgt.xml.event.Event;
 
 import com.google.common.collect.Lists;
 
@@ -62,7 +62,7 @@ public class TopologyServiceEventListener implements EventListener {
     }
 
     @Override
-    public void onEvent(Event e) {
+    public void onEvent(IEvent e) {
         // Reload given Topology or all
         if (e.getUei().equals(EventConstants.RELOAD_TOPOLOGY_UEI)) {
             final String topologyNamespace = EventUtils.getParm(e, PARAM_TOPOLOGY_NAMESPACE);

--- a/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.asset/src/main/java/org/opennms/features/topology/plugins/topo/asset/AssetGraphMLProvider.java
+++ b/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.asset/src/main/java/org/opennms/features/topology/plugins/topo/asset/AssetGraphMLProvider.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2017-2017 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
+ * Copyright (C) 2017-2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -37,8 +37,8 @@ import org.opennms.features.graphml.model.GraphMLWriter;
 import org.opennms.features.graphml.service.GraphmlRepository;
 import org.opennms.netmgt.events.api.EventIpcManager;
 import org.opennms.netmgt.events.api.EventListener;
+import org.opennms.netmgt.events.api.model.IEvent;
 import org.opennms.netmgt.model.events.EventUtils;
-import org.opennms.netmgt.xml.event.Event;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.transaction.support.TransactionOperations;
@@ -193,7 +193,7 @@ public class AssetGraphMLProvider implements EventListener {
 	}
 
 	@Override
-	public void onEvent(Event e) {
+	public void onEvent(IEvent e) {
 		try {
 			if (CREATE_ASSET_TOPOLOGY.equals(e.getUei())) {
 				final GeneratorConfig config = GeneratorConfigBuilder.buildFrom(e);

--- a/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.asset/src/main/java/org/opennms/features/topology/plugins/topo/asset/GeneratorConfigBuilder.java
+++ b/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.asset/src/main/java/org/opennms/features/topology/plugins/topo/asset/GeneratorConfigBuilder.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2017 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
+ * Copyright (C) 2017-2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -35,8 +35,8 @@ import java.util.stream.Collectors;
 
 import org.opennms.features.topology.api.support.breadcrumbs.BreadcrumbStrategy;
 import org.opennms.features.topology.plugins.topo.asset.layers.NodeParamLabels;
+import org.opennms.netmgt.events.api.model.IEvent;
 import org.opennms.netmgt.model.events.EventUtils;
-import org.opennms.netmgt.xml.event.Event;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -125,7 +125,7 @@ public class GeneratorConfigBuilder {
 		return config;
 	}
 
-	public static GeneratorConfig buildFrom(Event e) {
+	public static GeneratorConfig buildFrom(IEvent e) {
 		final String label = EventUtils.getParm(e, EventParameterNames.LABEL);
 		final String breadcrumbStrategy = EventUtils.getParm(e, EventParameterNames.BREADCRUMB_STRATEGY);
 		final String providerId = EventUtils.getParm(e, EventParameterNames.PROVIDER_ID);

--- a/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.asset/src/test/java/org/opennms/features/topology/plugins/topo/asset/GeneratorConfigBuilderTest.java
+++ b/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.asset/src/test/java/org/opennms/features/topology/plugins/topo/asset/GeneratorConfigBuilderTest.java
@@ -31,6 +31,7 @@ package org.opennms.features.topology.plugins.topo.asset;
 import org.junit.Assert;
 import org.junit.Test;
 import org.opennms.features.topology.api.support.breadcrumbs.BreadcrumbStrategy;
+import org.opennms.netmgt.events.api.model.ImmutableMapper;
 import org.opennms.netmgt.model.events.EventBuilder;
 import org.opennms.netmgt.xml.event.Event;
 
@@ -57,7 +58,7 @@ public class GeneratorConfigBuilderTest {
         expectedConfig.setLayerHierarchies(Lists.newArrayList("a", "b", "c"));
         expectedConfig.setFilters(Lists.newArrayList("a=x","b=y"));
 
-        final GeneratorConfig actualConfig = GeneratorConfigBuilder.buildFrom(e);
+        final GeneratorConfig actualConfig = GeneratorConfigBuilder.buildFrom(ImmutableMapper.fromMutableEvent(e));
         Assert.assertEquals(expectedConfig, actualConfig);
     }
 }

--- a/integrations/opennms-rancid-provisioning-adapter/src/main/java/org/opennms/netmgt/provision/RancidProvisioningAdapter.java
+++ b/integrations/opennms-rancid-provisioning-adapter/src/main/java/org/opennms/netmgt/provision/RancidProvisioningAdapter.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2008-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2008-2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -47,13 +47,14 @@ import org.opennms.netmgt.events.api.EventConstants;
 import org.opennms.netmgt.events.api.EventForwarder;
 import org.opennms.netmgt.events.api.annotations.EventHandler;
 import org.opennms.netmgt.events.api.annotations.EventListener;
+import org.opennms.netmgt.events.api.model.IEvent;
+import org.opennms.netmgt.events.api.model.IParm;
 import org.opennms.netmgt.model.OnmsAssetRecord;
 import org.opennms.netmgt.model.OnmsCategory;
 import org.opennms.netmgt.model.OnmsIpInterface;
 import org.opennms.netmgt.model.OnmsNode;
 import org.opennms.netmgt.model.events.EventBuilder;
 import org.opennms.netmgt.xml.event.Event;
-import org.opennms.netmgt.xml.event.Parm;
 import org.opennms.rancid.ConnectionProperties;
 import org.opennms.rancid.RWSClientApi;
 import org.opennms.rancid.RancidApiException;
@@ -725,10 +726,10 @@ public class RancidProvisioningAdapter extends SimpleQueuedProvisioningAdapter i
     /**
      * <p>handleReloadConfigEvent</p>
      *
-     * @param event a {@link org.opennms.netmgt.xml.event.Event} object.
+     * @param event a {@link org.opennms.netmgt.events.api.model.IEvent} object.
      */
     @EventHandler(uei = EventConstants.RELOAD_DAEMON_CONFIG_UEI)
-    public void handleReloadConfigEvent(Event event) {
+    public void handleReloadConfigEvent(IEvent event) {
         if (isReloadConfigEventTarget(event)) {
             EventBuilder ebldr = null;
             LOG.debug("reloading the rancid adapter configuration");
@@ -761,12 +762,12 @@ public class RancidProvisioningAdapter extends SimpleQueuedProvisioningAdapter i
         }
     }
 
-    private boolean isReloadConfigEventTarget(Event event) {
+    private boolean isReloadConfigEventTarget(IEvent event) {
         boolean isTarget = false;
         
-        List<Parm> parmCollection = event.getParmCollection();
+        List<IParm> parmCollection = event.getParmCollection();
 
-        for (Parm parm : parmCollection) {
+        for (IParm parm : parmCollection) {
             if (EventConstants.PARM_DAEMON_NAME.equals(parm.getParmName()) && "Provisiond.RancidProvisioningAdapter".equalsIgnoreCase(parm.getValue().getContent())) {
                 isTarget = true;
                 break;
@@ -780,10 +781,10 @@ public class RancidProvisioningAdapter extends SimpleQueuedProvisioningAdapter i
     /**
      * <p>handleRancidDownLoadFailure</p>
      *
-     * @param e a {@link org.opennms.netmgt.xml.event.Event} object.
+     * @param e a {@link org.opennms.netmgt.events.api.model.IEvent} object.
      */
     @EventHandler(uei = EventConstants.RANCID_DOWNLOAD_FAILURE_UEI)
-    public void handleRancidDownLoadFailure(Event e) {
+    public void handleRancidDownLoadFailure(IEvent e) {
         LOG.debug("handleRancidDownLoadFailure: get Event uei/id: {} / {}", e.getDbid(), e.getUei());
         if (e.hasNodeid()) {
             int nodeId = Long.valueOf(e.getNodeid()).intValue();
@@ -798,10 +799,10 @@ public class RancidProvisioningAdapter extends SimpleQueuedProvisioningAdapter i
     /**
      * <p>handleRancidDownLoadSuccess</p>
      *
-     * @param e a {@link org.opennms.netmgt.xml.event.Event} object.
+     * @param e a {@link org.opennms.netmgt.events.api.model.IEvent} object.
      */
     @EventHandler(uei = EventConstants.RANCID_DOWNLOAD_SUCCESS_UEI)
-    public void handleRancidDownLoadSuccess(Event e) {
+    public void handleRancidDownLoadSuccess(IEvent e) {
         LOG.debug("handleRancidDownLoadSuccess: get Event uei/id: {} / {}", e.getDbid(), e.getUei());
         if (e.hasNodeid() ) {
             int nodeId = Long.valueOf(e.getNodeid()).intValue();
@@ -816,12 +817,12 @@ public class RancidProvisioningAdapter extends SimpleQueuedProvisioningAdapter i
     /**
      * <p>handleRancidGroupProcessingCompleted</p>
      *
-     * @param e a {@link org.opennms.netmgt.xml.event.Event} object.
+     * @param e a {@link org.opennms.netmgt.events.api.model.IEvent} object.
      */
     @EventHandler(uei = EventConstants.RANCID_GROUP_PROCESSING_COMPLETED_UEI)
-    public void handleRancidGroupProcessingCompleted(Event e) {
+    public void handleRancidGroupProcessingCompleted(IEvent e) {
         LOG.debug("handleRancidGroupProcessingCompleted: get Event uei/id: {} / {}", e.getDbid(), e.getUei());
-        for (Parm parm : e.getParmCollection()) {
+        for (IParm parm : e.getParmCollection()) {
             LOG.debug("handleRancidGroupProcessingCompleted: parm name: {}", parm.getParmName());
             if (parm.getParmName().equals(".1.3.6.1.4.1.31543.1.1.2.1.1.3")) {
                 updateGroupConfiguration(parm.getValue().getContent());

--- a/integrations/opennms-snmp-asset-provisioning-adapter/src/main/java/org/opennms/netmgt/provision/SnmpAssetProvisioningAdapter.java
+++ b/integrations/opennms-snmp-asset-provisioning-adapter/src/main/java/org/opennms/netmgt/provision/SnmpAssetProvisioningAdapter.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2010-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2010-2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -50,6 +50,8 @@ import org.opennms.netmgt.events.api.EventConstants;
 import org.opennms.netmgt.events.api.EventForwarder;
 import org.opennms.netmgt.events.api.annotations.EventHandler;
 import org.opennms.netmgt.events.api.annotations.EventListener;
+import org.opennms.netmgt.events.api.model.IEvent;
+import org.opennms.netmgt.events.api.model.IParm;
 import org.opennms.netmgt.model.OnmsAssetRecord;
 import org.opennms.netmgt.model.OnmsIpInterface;
 import org.opennms.netmgt.model.OnmsNode;
@@ -59,7 +61,6 @@ import org.opennms.netmgt.snmp.SnmpAgentConfig;
 import org.opennms.netmgt.snmp.SnmpObjId;
 import org.opennms.netmgt.snmp.SnmpValue;
 import org.opennms.netmgt.snmp.proxy.LocationAwareSnmpClient;
-import org.opennms.netmgt.xml.event.Event;
 import org.opennms.netmgt.xml.event.Parm;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -417,10 +418,10 @@ public class SnmpAssetProvisioningAdapter extends SimplerQueuedProvisioningAdapt
 	/**
 	 * <p>handleReloadConfigEvent</p>
 	 *
-	 * @param event a {@link org.opennms.netmgt.xml.event.Event} object.
+	 * @param event a {@link org.opennms.netmgt.events.api.model.IEvent} object.
 	 */
 	@EventHandler(uei = EventConstants.RELOAD_DAEMON_CONFIG_UEI)
-	public void handleReloadConfigEvent(final Event event) {
+	public void handleReloadConfigEvent(final IEvent event) {
 		if (isReloadConfigEventTarget(event)) {
 			EventBuilder ebldr = null;
 			LOG.debug("Reloading the SNMP asset adapter configuration");
@@ -440,10 +441,10 @@ public class SnmpAssetProvisioningAdapter extends SimplerQueuedProvisioningAdapt
 		}
 	}
 
-	private boolean isReloadConfigEventTarget(final Event event) {
+	private boolean isReloadConfigEventTarget(final IEvent event) {
 		boolean isTarget = false;
 
-		for (final Parm parm : event.getParmCollection()) {
+		for (final IParm parm : event.getParmCollection()) {
 			if (EventConstants.PARM_DAEMON_NAME.equals(parm.getParmName()) && ("Provisiond." + NAME).equalsIgnoreCase(parm.getValue().getContent())) {
 				isTarget = true;
 				break;

--- a/integrations/opennms-snmp-hardware-inventory-provisioning-adapter/src/main/java/org/opennms/netmgt/provision/SnmpHardwareInventoryProvisioningAdapter.java
+++ b/integrations/opennms-snmp-hardware-inventory-provisioning-adapter/src/main/java/org/opennms/netmgt/provision/SnmpHardwareInventoryProvisioningAdapter.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2014-2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -49,6 +49,8 @@ import org.opennms.netmgt.events.api.EventConstants;
 import org.opennms.netmgt.events.api.EventForwarder;
 import org.opennms.netmgt.events.api.annotations.EventHandler;
 import org.opennms.netmgt.events.api.annotations.EventListener;
+import org.opennms.netmgt.events.api.model.IEvent;
+import org.opennms.netmgt.events.api.model.IParm;
 import org.opennms.netmgt.model.HwEntityAttributeType;
 import org.opennms.netmgt.model.OnmsHwEntity;
 import org.opennms.netmgt.model.OnmsHwEntityAlias;
@@ -62,8 +64,6 @@ import org.opennms.netmgt.snmp.SnmpAgentConfig;
 import org.opennms.netmgt.snmp.SnmpObjId;
 import org.opennms.netmgt.snmp.SnmpResult;
 import org.opennms.netmgt.snmp.proxy.LocationAwareSnmpClient;
-import org.opennms.netmgt.xml.event.Event;
-import org.opennms.netmgt.xml.event.Parm;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.InitializingBean;
@@ -460,7 +460,7 @@ public class SnmpHardwareInventoryProvisioningAdapter extends SimplerQueuedProvi
      * @param event the event
      */
     @EventHandler(uei = EventConstants.RELOAD_DAEMON_CONFIG_UEI)
-    public void handleReloadConfigEvent(final Event event) {
+    public void handleReloadConfigEvent(final IEvent event) {
         if (isReloadConfigEventTarget(event)) {
             EventBuilder ebldr = null;
             LOG.debug("Reloading the Hardware Inventory adapter configuration");
@@ -487,9 +487,9 @@ public class SnmpHardwareInventoryProvisioningAdapter extends SimplerQueuedProvi
      * @param event the event
      * @return true, if checks if is reload configuration event target
      */
-    private boolean isReloadConfigEventTarget(final Event event) {
+    private boolean isReloadConfigEventTarget(final IEvent event) {
         boolean isTarget = false;
-        for (final Parm parm : event.getParmCollection()) {
+        for (final IParm parm : event.getParmCollection()) {
             if (EventConstants.PARM_DAEMON_NAME.equals(parm.getParmName()) && (PREFIX + NAME).equalsIgnoreCase(parm.getValue().getContent())) {
                 isTarget = true;
                 break;

--- a/integrations/opennms-wsman-asset-provisioning-adapter/src/main/java/org/opennms/netmgt/provision/WsManAssetProvisioningAdapter.java
+++ b/integrations/opennms-wsman-asset-provisioning-adapter/src/main/java/org/opennms/netmgt/provision/WsManAssetProvisioningAdapter.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2010-2019 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ * Copyright (C) 2010-2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -56,18 +56,15 @@ import org.opennms.netmgt.dao.api.NodeDao;
 import org.opennms.netmgt.events.api.EventConstants;
 import org.opennms.netmgt.events.api.annotations.EventHandler;
 import org.opennms.netmgt.events.api.annotations.EventListener;
+import org.opennms.netmgt.events.api.model.IEvent;
 import org.opennms.netmgt.model.OnmsAssetRecord;
 import org.opennms.netmgt.model.OnmsIpInterface;
 import org.opennms.netmgt.model.OnmsNode;
-import org.opennms.netmgt.xml.event.Event;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.BeanWrapper;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.PropertyAccessorFactory;
-import org.springframework.context.annotation.EnableAspectJAutoProxy;
-import org.springframework.transaction.TransactionStatus;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionCallback;
 import org.w3c.dom.Node;
 
@@ -340,8 +337,9 @@ public class WsManAssetProvisioningAdapter extends SimplerQueuedProvisioningAdap
     }
 
     @EventHandler(uei = EventConstants.RELOAD_DAEMON_CONFIG_UEI)
-    public void handleReloadEvent(Event e) {
-        DaemonTools.handleReloadEvent(e, WsManAssetProvisioningAdapter.NAME, (event) -> handleConfigurationChanged());
+    public void handleReloadEvent(IEvent e) {
+        DaemonTools.handleReloadEvent(e,
+                WsManAssetProvisioningAdapter.NAME, (event) -> handleConfigurationChanged());
     }
 
 }

--- a/opennms-ackd/src/main/java/org/opennms/netmgt/ackd/Ackd.java
+++ b/opennms-ackd/src/main/java/org/opennms/netmgt/ackd/Ackd.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2009-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2009-2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -44,10 +44,11 @@ import org.opennms.netmgt.events.api.EventConstants;
 import org.opennms.netmgt.events.api.EventForwarder;
 import org.opennms.netmgt.events.api.annotations.EventHandler;
 import org.opennms.netmgt.events.api.annotations.EventListener;
+import org.opennms.netmgt.events.api.model.IEvent;
+import org.opennms.netmgt.events.api.model.IParm;
 import org.opennms.netmgt.model.OnmsAcknowledgment;
 import org.opennms.netmgt.model.events.EventBuilder;
 import org.opennms.netmgt.xml.event.Event;
-import org.opennms.netmgt.xml.event.Parm;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.DisposableBean;
@@ -289,17 +290,17 @@ public class Ackd implements SpringServiceDaemon, DisposableBean {
      *     ackType: <code>AckType</code. representing either an <code>OnmsAlarm</code>, <code>OnmsNotification</code>, etc.
      *     refId: The ID of the <code>OnmsAcknowledgable</code>
      *
-     * @param event a {@link org.opennms.netmgt.xml.event.Event} object.
+     * @param event a {@link org.opennms.netmgt.events.api.model.IEvent} object.
      */
     @EventHandler(uei=EventConstants.ACKNOWLEDGE_EVENT_UEI)
-    public void handleAckEvent(Event event) {
+    public void handleAckEvent(IEvent event) {
         
         LOG.info("handleAckEvent: Received acknowledgment event: {}", event);
         
         OnmsAcknowledgment ack;
         
         try {
-            ack = new OnmsAcknowledgment(event);
+            ack = new OnmsAcknowledgment(Event.copyFrom(event));
             m_ackDao.processAck(ack);
         } catch (ParseException e) {
             LOG.error("handleAckEvent: unable to process acknowledgment event: {}", event, e);
@@ -309,17 +310,17 @@ public class Ackd implements SpringServiceDaemon, DisposableBean {
     /**
      * <p>handleReloadConfigEvent</p>
      *
-     * @param event a {@link org.opennms.netmgt.xml.event.Event} object.
+     * @param event a {@link org.opennms.netmgt.events.api.model.IEvent} object.
      */
     @EventHandler(uei=EventConstants.RELOAD_DAEMON_CONFIG_UEI)
-    public void handleReloadConfigEvent(Event event) {
+    public void handleReloadConfigEvent(IEvent event) {
         String specifiedDaemon = null;
 
         LOG.info("handleReloadConfigEvent: processing reload event: {}", event);
 
-        List<Parm> parms = event.getParmCollection();
+        List<IParm> parms = event.getParmCollection();
 
-        for (Parm parm : parms) {
+        for (IParm parm : parms) {
             specifiedDaemon = parm.getValue().getContent();
 
             if (EventConstants.PARM_DAEMON_NAME.equals(parm.getParmName()) 

--- a/opennms-ackd/src/test/java/org/opennms/netmgt/ackd/AckdIT.java
+++ b/opennms-ackd/src/test/java/org/opennms/netmgt/ackd/AckdIT.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2009-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2009-2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -55,6 +55,7 @@ import org.opennms.netmgt.dao.api.NodeDao;
 import org.opennms.netmgt.dao.api.NotificationDao;
 import org.opennms.netmgt.dao.api.UserNotificationDao;
 import org.opennms.netmgt.events.api.EventConstants;
+import org.opennms.netmgt.events.api.model.ImmutableMapper;
 import org.opennms.netmgt.model.AckAction;
 import org.opennms.netmgt.model.AckType;
 import org.opennms.netmgt.model.OnmsAcknowledgment;
@@ -285,7 +286,7 @@ public class AckdIT implements InitializingBean {
         final String user = "ackd-test-user";
         bldr.addParam("ackUser", user);
 
-        m_daemon.handleAckEvent(bldr.getEvent());
+        m_daemon.handleAckEvent(ImmutableMapper.fromMutableEvent(bldr.getEvent()));
         
         OnmsNotification notif = m_notificationDao.get(vo.m_notifId);
         Assert.assertEquals(notif.getAckUser(), user);
@@ -312,7 +313,7 @@ public class AckdIT implements InitializingBean {
         final String user = "ackd-test-user";
         bldr.addParam("ackUser", user);
 
-        m_daemon.handleAckEvent(bldr.getEvent());
+        m_daemon.handleAckEvent(ImmutableMapper.fromMutableEvent(bldr.getEvent()));
         
         OnmsNotification notif = m_notificationDao.get(vo.m_notifId);
         Assert.assertEquals(notif.getAckUser(), user);
@@ -341,7 +342,7 @@ public class AckdIT implements InitializingBean {
         final String user = "ackd-test-user";
         bldr.addParam("ackUser", user);
 
-        m_daemon.handleAckEvent(bldr.getEvent());
+        m_daemon.handleAckEvent(ImmutableMapper.fromMutableEvent(bldr.getEvent()));
         
         OnmsNotification notif = m_notificationDao.get(vo.m_notifId);
         Assert.assertEquals(notif.getAckUser(), null);
@@ -371,7 +372,7 @@ public class AckdIT implements InitializingBean {
         final String user = "ackd-test-user";
         bldr.addParam("ackUser", user);
 
-        m_daemon.handleAckEvent(bldr.getEvent());
+        m_daemon.handleAckEvent(ImmutableMapper.fromMutableEvent(bldr.getEvent()));
         
         OnmsNotification notif = m_notificationDao.get(vo.m_notifId);
         Assert.assertEquals(notif.getAckUser(), user);

--- a/opennms-alarms/daemon/src/main/java/org/opennms/netmgt/alarmd/Alarmd.java
+++ b/opennms-alarms/daemon/src/main/java/org/opennms/netmgt/alarmd/Alarmd.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2009-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2009-2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -35,6 +35,7 @@ import org.opennms.netmgt.daemon.DaemonTools;
 import org.opennms.netmgt.events.api.ThreadAwareEventListener;
 import org.opennms.netmgt.events.api.annotations.EventHandler;
 import org.opennms.netmgt.events.api.annotations.EventListener;
+import org.opennms.netmgt.events.api.model.IEvent;
 import org.opennms.netmgt.xml.event.Event;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -75,18 +76,18 @@ public class Alarmd extends AbstractServiceDaemon implements ThreadAwareEventLis
      *
      * This method is thread-safe.
      *
-     * @param e a {@link org.opennms.netmgt.xml.event.Event} object.
+     * @param e a {@link org.opennms.netmgt.events.api.model.IEvent} object.
      */
     @EventHandler(uei = EventHandler.ALL_UEIS)
-    public void onEvent(Event e) {
+    public void onEvent(IEvent e) {
     	if (e.getUei().equals("uei.opennms.org/internal/reloadDaemonConfig")) {
            handleReloadEvent(e);
            return;
     	}
-    	m_persister.persist(e);
+    	m_persister.persist(Event.copyFrom(e));
     }
 
-    private synchronized void handleReloadEvent(Event e) {
+    private synchronized void handleReloadEvent(IEvent e) {
         m_northbounderManager.handleReloadEvent(e);
         DaemonTools.handleReloadEvent(e, Alarmd.NAME, (event) -> onAlarmReload());
     }

--- a/opennms-alarms/daemon/src/main/java/org/opennms/netmgt/alarmd/NorthbounderManager.java
+++ b/opennms-alarms/daemon/src/main/java/org/opennms/netmgt/alarmd/NorthbounderManager.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2018 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2018 The OpenNMS Group, Inc.
+ * Copyright (C) 2018-2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -30,25 +30,20 @@ package org.opennms.netmgt.alarmd;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
 import org.opennms.netmgt.alarmd.api.NorthboundAlarm;
 import org.opennms.netmgt.alarmd.api.Northbounder;
 import org.opennms.netmgt.alarmd.api.NorthbounderException;
-import org.opennms.netmgt.dao.api.AlarmEntityListener;
 import org.opennms.netmgt.dao.api.DefaultAlarmEntityListener;
 import org.opennms.netmgt.events.api.EventConstants;
 import org.opennms.netmgt.events.api.EventProxy;
 import org.opennms.netmgt.events.api.EventProxyException;
+import org.opennms.netmgt.events.api.model.IEvent;
+import org.opennms.netmgt.events.api.model.IParm;
 import org.opennms.netmgt.model.OnmsAlarm;
-import org.opennms.netmgt.model.OnmsMemo;
-import org.opennms.netmgt.model.OnmsReductionKeyMemo;
-import org.opennms.netmgt.model.OnmsSeverity;
 import org.opennms.netmgt.model.events.EventBuilder;
-import org.opennms.netmgt.xml.event.Event;
-import org.opennms.netmgt.xml.event.Parm;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -123,9 +118,9 @@ public class NorthbounderManager extends DefaultAlarmEntityListener {
         onNorthboundersChanged();
     }
 
-    public void handleReloadEvent(Event e) {
-        List<Parm> parmCollection = e.getParmCollection();
-        for (Parm parm : parmCollection) {
+    public void handleReloadEvent(IEvent e) {
+        List<IParm> parmCollection = e.getParmCollection();
+        for (IParm parm : parmCollection) {
             String parmName = parm.getParmName();
             if ("daemonName".equals(parmName)) {
                 if (parm.getValue() == null || parm.getValue().getContent() == null) {

--- a/opennms-config/src/main/java/org/opennms/netmgt/config/SnmpEventInfo.java
+++ b/opennms-config/src/main/java/org/opennms/netmgt/config/SnmpEventInfo.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2007-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2007-2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -38,6 +38,9 @@ import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.apache.commons.lang.builder.ToStringBuilder;
 import org.apache.commons.lang.builder.ToStringStyle;
 import org.opennms.core.utils.InetAddressUtils;
+import org.opennms.netmgt.events.api.model.IEvent;
+import org.opennms.netmgt.events.api.model.IParm;
+import org.opennms.netmgt.events.api.model.IValue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.opennms.netmgt.config.snmp.Definition;
@@ -45,8 +48,6 @@ import org.opennms.netmgt.config.snmp.Range;
 import org.opennms.netmgt.events.api.EventConstants;
 import org.opennms.netmgt.model.events.EventBuilder;
 import org.opennms.netmgt.xml.event.Event;
-import org.opennms.netmgt.xml.event.Parm;
-import org.opennms.netmgt.xml.event.Value;
 
 /**
  * Class for handling data passed as parms in a configureSNMP event.  Provides for
@@ -102,19 +103,19 @@ public class SnmpEventInfo {
     /**
      * <p>Constructor for SnmpEventInfo.</p>
      *
-     * @param event a {@link org.opennms.netmgt.xml.event.Event} object.
+     * @param event a {@link org.opennms.netmgt.events.api.model.IEvent} object.
      */
 	@SuppressWarnings("deprecation")
-	public SnmpEventInfo(Event event) {
+	public SnmpEventInfo(IEvent event) {
     	 String parmName = null;
-         Value parmValue = null;
+         IValue parmValue = null;
          String parmContent = null;
          
          if (!event.getUei().equals(EventConstants.CONFIGURE_SNMP_EVENT_UEI)) {
              throw new IllegalArgumentException("Event is not an a \"configure SNMP\" event: "+event.toString());
          }
          	
-         for (Parm parm : event.getParmCollection()) {
+         for (IParm parm : event.getParmCollection()) {
             parmName = parm.getParmName();
             parmValue = parm.getValue();
             if (parmValue == null) continue;

--- a/opennms-config/src/test/java/org/opennms/netmgt/config/ConfigureSnmpTest.java
+++ b/opennms-config/src/test/java/org/opennms/netmgt/config/ConfigureSnmpTest.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2007-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2007-2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -35,6 +35,7 @@ import junit.framework.TestCase;
 import org.opennms.core.test.ConfigurationTestUtils;
 import org.opennms.core.utils.InetAddressUtils;
 import org.opennms.netmgt.events.api.EventConstants;
+import org.opennms.netmgt.events.api.model.ImmutableMapper;
 import org.opennms.netmgt.model.events.EventBuilder;
 import org.opennms.netmgt.snmp.SnmpAgentConfig;
 import org.springframework.core.io.Resource;
@@ -70,7 +71,7 @@ public class ConfigureSnmpTest extends TestCase {
     }
 
     /**
-     * Test method for {@link org.opennms.netmgt.config.SnmpPeerFactory#createSnmpEventInfo(org.opennms.netmgt.xml.event.Event)}.
+     * Test method for {@link org.opennms.netmgt.config.SnmpPeerFactory#createSnmpEventInfo(org.opennms.netmgt.events.api.model.IEvent)}.
      * Tests creating an SNMP config definition from a configureSNMP event.
      * 
      * @throws UnknownHostException 
@@ -79,7 +80,7 @@ public class ConfigureSnmpTest extends TestCase {
         EventBuilder bldr = createConfigureSnmpEventBuilder("192.168.1.1", null);
         addCommunityStringToEvent(bldr, "seemore");
         
-        SnmpEventInfo info = new SnmpEventInfo(bldr.getEvent());
+        SnmpEventInfo info = new SnmpEventInfo(ImmutableMapper.fromMutableEvent(bldr.getEvent()));
         
         assertNotNull(info);
         assertEquals("192.168.1.1", info.getFirstIPAddress());
@@ -95,7 +96,7 @@ public class ConfigureSnmpTest extends TestCase {
         final String addr = "192.168.0.5";
         EventBuilder bldr = createConfigureSnmpEventBuilder(addr, null);
         addCommunityStringToEvent(bldr, "abc");
-        SnmpEventInfo info = new SnmpEventInfo(bldr.getEvent());
+        SnmpEventInfo info = new SnmpEventInfo(ImmutableMapper.fromMutableEvent(bldr.getEvent()));
         
         SnmpPeerFactory.getInstance().define(info);
 
@@ -118,7 +119,7 @@ public class ConfigureSnmpTest extends TestCase {
         assertEquals(SnmpAgentConfig.VERSION2C, agent.getVersion());
         
         EventBuilder bldr = createConfigureSnmpEventBuilder(addr1, addr2);
-        SnmpEventInfo info = new SnmpEventInfo(bldr.getEvent());
+        SnmpEventInfo info = new SnmpEventInfo(ImmutableMapper.fromMutableEvent(bldr.getEvent()));
         info.setVersion("v2c");
         
         SnmpPeerFactory.getInstance().define(info);
@@ -142,7 +143,7 @@ public class ConfigureSnmpTest extends TestCase {
         assertEquals(SnmpAgentConfig.VERSION1, agent.getVersion());
         
         EventBuilder bldr = createConfigureSnmpEventBuilder(addr1, addr2);
-        SnmpEventInfo info = new SnmpEventInfo(bldr.getEvent());
+        SnmpEventInfo info = new SnmpEventInfo(ImmutableMapper.fromMutableEvent(bldr.getEvent()));
         info.setReadCommunityString("opennmsrules");
         
         SnmpPeerFactory.getInstance().define(info);
@@ -165,7 +166,7 @@ public class ConfigureSnmpTest extends TestCase {
         
         final String specificAddr = "10.1.1.7";
         final EventBuilder bldr = createConfigureSnmpEventBuilder(specificAddr, null);
-        final SnmpEventInfo info = new SnmpEventInfo(bldr.getEvent());
+        final SnmpEventInfo info = new SnmpEventInfo(ImmutableMapper.fromMutableEvent(bldr.getEvent()));
         info.setReadCommunityString("splice-test");
         info.setVersion("v2c");
         
@@ -192,7 +193,7 @@ public class ConfigureSnmpTest extends TestCase {
         
         final String specificAddr = "10.1.1.7";
         final EventBuilder bldr = createConfigureSnmpEventBuilder(specificAddr, null);
-        final SnmpEventInfo info = new SnmpEventInfo(bldr.getEvent());
+        final SnmpEventInfo info = new SnmpEventInfo(ImmutableMapper.fromMutableEvent(bldr.getEvent()));
         info.setReadCommunityString("splice2-test");
 
         SnmpPeerFactory.getInstance().define(info);

--- a/opennms-config/src/test/java/org/opennms/netmgt/config/SnmpEventInfoTest.java
+++ b/opennms-config/src/test/java/org/opennms/netmgt/config/SnmpEventInfoTest.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2007-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2007-2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -54,6 +54,7 @@ import org.opennms.core.network.IPAddressRangeSet;
 import org.opennms.netmgt.config.snmp.Definition;
 import org.opennms.netmgt.config.snmp.SnmpProfile;
 import org.opennms.netmgt.events.api.EventConstants;
+import org.opennms.netmgt.events.api.model.ImmutableMapper;
 import org.opennms.netmgt.snmp.SnmpAgentConfig;
 import org.opennms.netmgt.xml.event.Event;
 import org.opennms.netmgt.xml.event.Parm;
@@ -2161,7 +2162,7 @@ public class SnmpEventInfoTest {
 
 		// now map the event back to an SnmpEventInfo-object ...
 		// ... and check that second is equally to initial
-		SnmpEventInfo second = new SnmpEventInfo(event);
+		SnmpEventInfo second = new SnmpEventInfo(ImmutableMapper.fromMutableEvent(event));
 		assertEquals(initial, second);
 	}
 }

--- a/opennms-correlation/drools-correlation-engine/src/main/java/org/opennms/netmgt/correlation/drools/DroolsCorrelationEngineBuilder.java
+++ b/opennms-correlation/drools-correlation-engine/src/main/java/org/opennms/netmgt/correlation/drools/DroolsCorrelationEngineBuilder.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2007-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2007-2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -38,6 +38,8 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import org.opennms.netmgt.events.api.model.IEvent;
+import org.opennms.netmgt.events.api.model.IParm;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.opennms.core.xml.JaxbUtils;
@@ -50,8 +52,6 @@ import org.opennms.netmgt.events.api.EventIpcManager;
 import org.opennms.netmgt.events.api.EventListener;
 import org.opennms.netmgt.events.api.EventProxyException;
 import org.opennms.netmgt.model.events.EventBuilder;
-import org.opennms.netmgt.xml.event.Event;
-import org.opennms.netmgt.xml.event.Parm;
 import org.springframework.beans.PropertyEditorRegistrySupport;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -277,7 +277,7 @@ public class DroolsCorrelationEngineBuilder extends PropertyEditorRegistrySuppor
     }
 
     @Override
-    public void onEvent(Event e) {
+    public void onEvent(IEvent e) {
         if (e.getUei().equals(EventConstants.RELOAD_DAEMON_CONFIG_UEI)) {
             final String daemonName = getDaemonNameFromReloadDaemonEvent(e);
             if (daemonName != null && daemonName.equals(getName())) {
@@ -302,9 +302,9 @@ public class DroolsCorrelationEngineBuilder extends PropertyEditorRegistrySuppor
         }
     }
 
-    private String getDaemonNameFromReloadDaemonEvent(Event e) {
-        List<Parm> parmCollection = e.getParmCollection();
-        for (Parm parm : parmCollection) {
+    private String getDaemonNameFromReloadDaemonEvent(IEvent e) {
+        List<IParm> parmCollection = e.getParmCollection();
+        for (IParm parm : parmCollection) {
             String parmName = parm.getParmName();
             if (EventConstants.PARM_DAEMON_NAME.equals(parmName)) {
                 if (parm.getValue() == null || parm.getValue().getContent() == null) {

--- a/opennms-correlation/opennms-correlator/src/main/java/org/opennms/netmgt/correlation/Correlator.java
+++ b/opennms-correlation/opennms-correlator/src/main/java/org/opennms/netmgt/correlation/Correlator.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2006-2016 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2016 The OpenNMS Group, Inc.
+ * Copyright (C) 2006-2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -40,8 +40,9 @@ import org.opennms.netmgt.events.api.EventConstants;
 import org.opennms.netmgt.events.api.EventIpcManager;
 import org.opennms.netmgt.events.api.EventListener;
 import org.opennms.netmgt.events.api.annotations.EventHandler;
+import org.opennms.netmgt.events.api.model.IEvent;
+import org.opennms.netmgt.events.api.model.IParm;
 import org.opennms.netmgt.xml.event.Event;
-import org.opennms.netmgt.xml.event.Parm;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.util.Assert;
@@ -83,12 +84,12 @@ public class Correlator extends AbstractServiceDaemon implements CorrelationEngi
 		}
 
 		@Override
-		public void onEvent(final Event e) {
+		public void onEvent(final IEvent e) {
 		    if (e.getUei().equals(EventConstants.RELOAD_DAEMON_CONFIG_UEI)) {
 		        handleReloadEvent(e);
 		        return;
 		    }
-		    m_engine.correlate(e);
+		    m_engine.correlate(Event.copyFrom(e));
 		}
 
 		public void tearDown() {
@@ -106,12 +107,12 @@ public class Correlator extends AbstractServiceDaemon implements CorrelationEngi
                     }
 		}
 
-		private void handleReloadEvent(Event e) {
+		private void handleReloadEvent(IEvent e) {
 			boolean engineNameMatched = false;
 			// By default always persist state.
 			boolean persistState = true;
-		    List<Parm> parmCollection = e.getParmCollection();
-		    for (Parm parm : parmCollection) {
+		    List<IParm> parmCollection = e.getParmCollection();
+		    for (IParm parm : parmCollection) {
 		        String parmName = parm.getParmName();
 		        if(EventConstants.PARM_DAEMON_NAME.equals(parmName)) {
 		            if (parm.getValue() == null || parm.getValue().getContent() == null) {

--- a/opennms-correlation/opennms-correlator/src/test/java/org/opennms/netmgt/correlation/CorrelatorEngineAdapterTest.java
+++ b/opennms-correlation/opennms-correlator/src/test/java/org/opennms/netmgt/correlation/CorrelatorEngineAdapterTest.java
@@ -77,7 +77,8 @@ public class CorrelatorEngineAdapterTest {
         verify(eventIpcManager, times(1)).addEventListener(any(EventListener.class), any(String.class));
 
         // Now send a reloadDaemonConfig event targeting our engine
-        listener.onEvent(ImmutableMapper.fromMutableEvent(new EventBuilder(EventConstants.RELOAD_DAEMON_CONFIG_UEI, "test")
+        listener.onEvent(ImmutableMapper.fromMutableEvent(
+                new EventBuilder(EventConstants.RELOAD_DAEMON_CONFIG_UEI, "test")
                 .addParam(EventConstants.PARM_DAEMON_NAME, listener.getName())
                 .getEvent()));
         // The event listener should have been removed and re-added

--- a/opennms-correlation/opennms-correlator/src/test/java/org/opennms/netmgt/correlation/CorrelatorEngineAdapterTest.java
+++ b/opennms-correlation/opennms-correlator/src/test/java/org/opennms/netmgt/correlation/CorrelatorEngineAdapterTest.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2018 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2018 The OpenNMS Group, Inc.
+ * Copyright (C) 2018-2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -43,6 +43,7 @@ import org.mockito.ArgumentCaptor;
 import org.opennms.netmgt.events.api.EventConstants;
 import org.opennms.netmgt.events.api.EventIpcManager;
 import org.opennms.netmgt.events.api.EventListener;
+import org.opennms.netmgt.events.api.model.ImmutableMapper;
 import org.opennms.netmgt.model.events.EventBuilder;
 
 public class CorrelatorEngineAdapterTest {
@@ -68,17 +69,17 @@ public class CorrelatorEngineAdapterTest {
         EventListener listener = listenerCaptor.getValue();
 
         // Now send a reloadDaemonConfig event targeting a different daemon
-        listener.onEvent(new EventBuilder(EventConstants.RELOAD_DAEMON_CONFIG_UEI, "test")
+        listener.onEvent(ImmutableMapper.fromMutableEvent(new EventBuilder(EventConstants.RELOAD_DAEMON_CONFIG_UEI, "test")
                 .addParam(EventConstants.PARM_DAEMON_NAME, "some-other-name")
-                .getEvent());
+                .getEvent()));
         // No invocations to add/remove event listeners should have been made
         verify(eventIpcManager, never()).removeEventListener(any(EventListener.class));
         verify(eventIpcManager, times(1)).addEventListener(any(EventListener.class), any(String.class));
 
         // Now send a reloadDaemonConfig event targeting our engine
-        listener.onEvent(new EventBuilder(EventConstants.RELOAD_DAEMON_CONFIG_UEI, "test")
+        listener.onEvent(ImmutableMapper.fromMutableEvent(new EventBuilder(EventConstants.RELOAD_DAEMON_CONFIG_UEI, "test")
                 .addParam(EventConstants.PARM_DAEMON_NAME, listener.getName())
-                .getEvent());
+                .getEvent()));
         // The event listener should have been removed and re-added
         verify(eventIpcManager, times(1)).removeEventListener(any(EventListener.class));
         verify(eventIpcManager, times(2)).addEventListener(any(EventListener.class), any(String.class));

--- a/opennms-dao-mock/src/main/java/org/opennms/netmgt/dao/mock/EventAnticipator.java
+++ b/opennms-dao-mock/src/main/java/org/opennms/netmgt/dao/mock/EventAnticipator.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2004-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2004-2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -37,6 +37,7 @@ import java.util.stream.Collectors;
 
 import org.junit.Assert;
 import org.opennms.netmgt.events.api.EventListener;
+import org.opennms.netmgt.events.api.model.IEvent;
 import org.opennms.netmgt.xml.event.Event;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -262,8 +263,8 @@ public class EventAnticipator implements EventListener {
     }
 
     @Override
-    public void onEvent(Event e) {
-        eventReceived(e);
+    public void onEvent(IEvent e) {
+        eventReceived(Event.copyFrom(e));
     }
 
 }

--- a/opennms-dao-mock/src/main/java/org/opennms/netmgt/dao/mock/MockEventIpcManager.java
+++ b/opennms-dao-mock/src/main/java/org/opennms/netmgt/dao/mock/MockEventIpcManager.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2004-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2004-2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -54,6 +54,8 @@ import org.opennms.netmgt.events.api.EventListener;
 import org.opennms.netmgt.events.api.EventProxy;
 import org.opennms.netmgt.events.api.EventProxyException;
 import org.opennms.netmgt.events.api.EventWriter;
+import org.opennms.netmgt.events.api.model.IEvent;
+import org.opennms.netmgt.events.api.model.ImmutableMapper;
 import org.opennms.netmgt.xml.event.Event;
 import org.opennms.netmgt.xml.event.Log;
 import org.opennms.netmgt.xml.eventconf.Events;
@@ -93,13 +95,13 @@ public class MockEventIpcManager implements EventForwarder, EventProxy, EventIpc
             return false;
         }
 
-        private boolean eventMatches(final Event e) {
+        private boolean eventMatches(final IEvent e) {
             if (m_ueiList == null)
                 return true;
             return m_ueiList.contains(e.getUei());
         }
 
-        public void sendEventIfAppropriate(final Event e) {
+        public void sendEventIfAppropriate(final IEvent e) {
             if (eventMatches(e)) {
                 m_listener.onEvent(e);
             }
@@ -237,8 +239,9 @@ public class MockEventIpcManager implements EventForwarder, EventProxy, EventIpc
     public void broadcastNow(final Event event, boolean synchronous) {
     	LOG.debug("Sending: {}", new EventWrapper(event));
         final List<ListenerKeeper> listeners = new ArrayList<ListenerKeeper>(m_listeners);
+        final IEvent immutableEvent = ImmutableMapper.fromMutableEvent(event);
         for (final ListenerKeeper k : listeners) {
-            k.sendEventIfAppropriate(event);
+            k.sendEventIfAppropriate(immutableEvent);
         }
     }
     

--- a/opennms-dao/src/main/java/org/opennms/netmgt/dao/support/InterfaceToNodeCacheEventProcessor.java
+++ b/opennms-dao/src/main/java/org/opennms/netmgt/dao/support/InterfaceToNodeCacheEventProcessor.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2002-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2002-2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -33,8 +33,8 @@ import org.opennms.netmgt.dao.api.NodeDao;
 import org.opennms.netmgt.events.api.EventConstants;
 import org.opennms.netmgt.events.api.annotations.EventHandler;
 import org.opennms.netmgt.events.api.annotations.EventListener;
+import org.opennms.netmgt.events.api.model.IEvent;
 import org.opennms.netmgt.model.OnmsNode;
-import org.opennms.netmgt.xml.event.Event;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.InitializingBean;
@@ -65,7 +65,7 @@ public class InterfaceToNodeCacheEventProcessor implements InitializingBean {
 
     @EventHandler(uei=EventConstants.NODE_GAINED_INTERFACE_EVENT_UEI)
     @Transactional
-    public void handleNodeGainedInterface(Event event) {
+    public void handleNodeGainedInterface(IEvent event) {
         LOG.debug("Received event: {}", event.getUei());
         Long nodeId = event.getNodeid();
         if (nodeId == null) {
@@ -83,7 +83,7 @@ public class InterfaceToNodeCacheEventProcessor implements InitializingBean {
 
     @EventHandler(uei=EventConstants.INTERFACE_DELETED_EVENT_UEI)
     @Transactional
-    public void handleInterfaceDeleted(Event event) {
+    public void handleInterfaceDeleted(IEvent event) {
         LOG.debug("Received event: {}", event.getUei());
         Long nodeId = event.getNodeid();
         if (nodeId == null) {
@@ -101,7 +101,7 @@ public class InterfaceToNodeCacheEventProcessor implements InitializingBean {
 
     @EventHandler(uei=EventConstants.INTERFACE_REPARENTED_EVENT_UEI)
     @Transactional
-    public void handleInterfaceReparented(Event event) {
+    public void handleInterfaceReparented(IEvent event) {
         LOG.debug("Received event: {}", event.getUei());
 
         final String oldNodeId = event.getParm(EventConstants.PARM_OLD_NODEID).getValue().getContent();
@@ -136,7 +136,7 @@ public class InterfaceToNodeCacheEventProcessor implements InitializingBean {
 
     @EventHandler(uei = EventConstants.NODE_DELETED_EVENT_UEI)
     @Transactional
-    public void handleNodeDeleted(Event event) {
+    public void handleNodeDeleted(IEvent event) {
         Long nodeId = event.getNodeid();
         LOG.debug("Received event: {} with nodeId = {}", event.getUei(), nodeId);
         if (nodeId == null) {

--- a/opennms-enterprise-reporting/opennms-reportd/src/main/java/org/opennms/netmgt/reporting/service/Reportd.java
+++ b/opennms-enterprise-reporting/opennms-reportd/src/main/java/org/opennms/netmgt/reporting/service/Reportd.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2009-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2009-2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -39,9 +39,9 @@ import org.opennms.netmgt.events.api.EventConstants;
 import org.opennms.netmgt.events.api.EventForwarder;
 import org.opennms.netmgt.events.api.annotations.EventHandler;
 import org.opennms.netmgt.events.api.annotations.EventListener;
+import org.opennms.netmgt.events.api.model.IEvent;
+import org.opennms.netmgt.events.api.model.IParm;
 import org.opennms.netmgt.model.events.EventBuilder;
-import org.opennms.netmgt.xml.event.Event;
-import org.opennms.netmgt.xml.event.Parm;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.util.Assert;
@@ -159,13 +159,13 @@ public class Reportd implements SpringServiceDaemon {
     /**
      * <p>handleRunReportEvent</p>
      *
-     * @param e a {@link org.opennms.netmgt.xml.event.Event} object.
+     * @param e a {@link org.opennms.netmgt.events.api.model.IEvent} object.
      */
     @EventHandler(uei = EventConstants.REPORTD_RUN_REPORT)
-    public void handleRunReportEvent(Event e){
+    public void handleRunReportEvent(IEvent e){
        String reportName = "";
        
-       for(Parm parm : e.getParmCollection()){
+       for(IParm parm : e.getParmCollection()){
        
            if(EventConstants.PARM_REPORT_NAME.equals(parm.getParmName()))
                reportName = parm.getValue().getContent();
@@ -189,10 +189,10 @@ public class Reportd implements SpringServiceDaemon {
     /**
      * <p>handleReloadConfigEvent</p>
      *
-     * @param e a {@link org.opennms.netmgt.xml.event.Event} object.
+     * @param e a {@link org.opennms.netmgt.events.api.model.IEvent} object.
      */
     @EventHandler(uei = EventConstants.RELOAD_DAEMON_CONFIG_UEI)
-    public void handleReloadConfigEvent(Event e) {
+    public void handleReloadConfigEvent(IEvent e) {
 
         if (isReloadConfigEventTarget(e)) {
             LOG.info("handleReloadConfigEvent: reloading configuration...");
@@ -232,12 +232,12 @@ public class Reportd implements SpringServiceDaemon {
 
     }
 
-    private boolean isReloadConfigEventTarget(Event event) {
+    private boolean isReloadConfigEventTarget(IEvent event) {
         boolean isTarget = false;
 
-        List<Parm> parmCollection = event.getParmCollection();
+        List<IParm> parmCollection = event.getParmCollection();
 
-        for (Parm parm : parmCollection) {
+        for (IParm parm : parmCollection) {
             if (EventConstants.PARM_DAEMON_NAME.equals(parm.getParmName()) && "Reportd".equalsIgnoreCase(parm.getValue().getContent())) {
                 isTarget = true;
                 break;

--- a/opennms-model/src/main/java/org/opennms/netmgt/model/events/EventUtils.java
+++ b/opennms-model/src/main/java/org/opennms/netmgt/model/events/EventUtils.java
@@ -635,6 +635,36 @@ public abstract class EventUtils {
     }
 
     /**
+     * <p>eventsMatch</p>
+     *
+     * @param e1 a {@link org.opennms.netmgt.events.api.model.IEvent} object.
+     * @param e2 a {@link org.opennms.netmgt.events.api.model.IEvent} object.
+     * @return a boolean.
+     */
+    public static boolean eventsMatch(final IEvent e1, final IEvent e2) {
+        if (e1 == e2) {
+            return true;
+        }
+        if (e1 == null || e2 == null) {
+            return false;
+        }
+        if (!Objects.equals(e1.getUei(), e2.getUei())) {
+            return false;
+        }
+        if (!Objects.equals(e1.getNodeid(), e2.getNodeid())) {
+            return false;
+        }
+        if (!Objects.equals(e1.getInterface(), e2.getInterface())) {
+            return false;
+        }
+        if (!Objects.equals(e1.getService(), e2.getService())) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
      * Ensures the given event has an interface
      *
      * @param e

--- a/opennms-model/src/test/java/org/opennms/netmgt/model/events/AnnotationBasedEventListenerAdapterTest.java
+++ b/opennms-model/src/test/java/org/opennms/netmgt/model/events/AnnotationBasedEventListenerAdapterTest.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2007-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2007-2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -44,6 +44,8 @@ import org.opennms.netmgt.events.api.annotations.EventHandler;
 import org.opennms.netmgt.events.api.annotations.EventListener;
 import org.opennms.netmgt.events.api.annotations.EventPostProcessor;
 import org.opennms.netmgt.events.api.annotations.EventPreProcessor;
+import org.opennms.netmgt.events.api.model.IEvent;
+import org.opennms.netmgt.events.api.model.ImmutableMapper;
 import org.opennms.netmgt.xml.event.Event;
 import org.opennms.test.mock.EasyMockUtils;
 
@@ -73,37 +75,37 @@ public class AnnotationBasedEventListenerAdapterTest {
         public int genExceptionsHandled = 0;
         
         @EventHandler(uei=EventConstants.NODE_DOWN_EVENT_UEI)
-        public void handleAnEvent(Event e) {
+        public void handleAnEvent(IEvent e) {
             receivedEventCount++;
         }
         
         @EventHandler(uei=EventConstants.NODE_LOST_SERVICE_EVENT_UEI)
-        public void handleAnotherEvent(Event e) {
+        public void handleAnotherEvent(IEvent e) {
             throw new IllegalArgumentException("test generated exception");
         }
         
         @EventHandler(uei=EventConstants.ADD_NODE_EVENT_UEI)
-        public void handleYetAnotherEvent(Event e) {
+        public void handleYetAnotherEvent(IEvent e) {
             throw new IllegalStateException("test generated state exception");
         }
         
         @EventPreProcessor()
-        public void preProcess(Event e) {
+        public void preProcess(IEvent e) {
             preProcessedEvents++;
         }
         
         @EventPostProcessor
-        public void postProcess(Event e) {
+        public void postProcess(IEvent e) {
             postProcessedEvents++;
         }
         
         @EventExceptionHandler
-        public void handleException(Event e, IllegalArgumentException ex) {
+        public void handleException(IEvent e, IllegalArgumentException ex) {
             illegalArgsHandled++;
         }
         
         @EventExceptionHandler
-        public void handleException(Event e, Exception ex) {
+        public void handleException(IEvent e, Exception ex) {
             genExceptionsHandled++;
         }
         
@@ -165,7 +167,7 @@ public class AnnotationBasedEventListenerAdapterTest {
         assertEquals(0, derivedListener.receivedEventCount);
         assertEquals(0, derivedListener.postProcessedEvents);
         
-        adapter.onEvent(createEvent(EventConstants.NODE_DOWN_EVENT_UEI));
+        adapter.onEvent(ImmutableMapper.fromMutableEvent(createEvent(EventConstants.NODE_DOWN_EVENT_UEI)));
         
         assertEquals(1, derivedListener.preProcessedEvents);
         assertEquals(1, derivedListener.receivedEventCount);
@@ -207,7 +209,7 @@ public class AnnotationBasedEventListenerAdapterTest {
         assertEquals(0, m_annotatedListener.receivedEventCount);
         assertEquals(0, m_annotatedListener.postProcessedEvents);
         
-        m_adapter.onEvent(createEvent(EventConstants.NODE_DOWN_EVENT_UEI));
+        m_adapter.onEvent(ImmutableMapper.fromMutableEvent(createEvent(EventConstants.NODE_DOWN_EVENT_UEI)));
         
         assertEquals(1, m_annotatedListener.preProcessedEvents);
         assertEquals(1, m_annotatedListener.receivedEventCount);
@@ -227,12 +229,12 @@ public class AnnotationBasedEventListenerAdapterTest {
         assertEquals(0, m_annotatedListener.illegalArgsHandled);
         assertEquals(0, m_annotatedListener.genExceptionsHandled);
 
-        m_adapter.onEvent(createEvent(EventConstants.NODE_LOST_SERVICE_EVENT_UEI));
+        m_adapter.onEvent(ImmutableMapper.fromMutableEvent(createEvent(EventConstants.NODE_LOST_SERVICE_EVENT_UEI)));
         
         assertEquals(1, m_annotatedListener.illegalArgsHandled);
         assertEquals(0, m_annotatedListener.genExceptionsHandled);
         
-        m_adapter.onEvent(createEvent(EventConstants.ADD_NODE_EVENT_UEI));
+        m_adapter.onEvent(ImmutableMapper.fromMutableEvent(createEvent(EventConstants.ADD_NODE_EVENT_UEI)));
         
         assertEquals(1, m_annotatedListener.illegalArgsHandled);
         assertEquals(1, m_annotatedListener.genExceptionsHandled);

--- a/opennms-provision/opennms-provisiond/src/main/java/org/opennms/netmgt/provision/service/Provisioner.java
+++ b/opennms-provision/opennms-provisiond/src/main/java/org/opennms/netmgt/provision/service/Provisioner.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2008-2017 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
+ * Copyright (C) 2008-2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -59,6 +59,8 @@ import org.opennms.netmgt.events.api.EventConstants;
 import org.opennms.netmgt.events.api.EventForwarder;
 import org.opennms.netmgt.events.api.annotations.EventHandler;
 import org.opennms.netmgt.events.api.annotations.EventListener;
+import org.opennms.netmgt.events.api.model.IEvent;
+import org.opennms.netmgt.events.api.model.IParm;
 import org.opennms.netmgt.model.OnmsIpInterface;
 import org.opennms.netmgt.model.OnmsMonitoringSystem;
 import org.opennms.netmgt.model.OnmsNode;
@@ -71,7 +73,6 @@ import org.opennms.netmgt.provision.service.operations.NoOpProvisionMonitor;
 import org.opennms.netmgt.provision.service.operations.ProvisionMonitor;
 import org.opennms.netmgt.provision.service.operations.RequisitionImport;
 import org.opennms.netmgt.xml.event.Event;
-import org.opennms.netmgt.xml.event.Parm;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -468,23 +469,15 @@ public class Provisioner implements SpringServiceDaemon {
     }
 
     /**
-     * <p>doImport</p>
-     */
-    public void doImport() {
-        Event e = null;
-        doImport(e);
-    }
-    
-    /**
      * Begins importing from resource specified in model-importer.properties file or
      * in event parameter: url.  Import Resources are managed with a "key" called
      * "foreignSource" specified in the XML retrieved by the resource and can be overridden
      * as a parameter of an event.
      *
-     * @param event a {@link org.opennms.netmgt.xml.event.Event} object.
+     * @param event a {@link org.opennms.netmgt.events.api.model.IEvent} object.
      */
     @EventHandler(uei = EventConstants.RELOAD_IMPORT_UEI)
-    public void doImport(final Event event) {
+    public void doImport(final IEvent event) {
         final String url = getEventUrl(event);
         final String rescanExistingOnImport = getEventRescanExistingOnImport(event);
 
@@ -554,10 +547,10 @@ public class Provisioner implements SpringServiceDaemon {
     /**
      * <p>handleNodeAddedEvent</p>
      *
-     * @param e a {@link org.opennms.netmgt.xml.event.Event} object.
+     * @param e a {@link org.opennms.netmgt.events.api.model.IEvent} object.
      */
     @EventHandler(uei = EventConstants.NODE_ADDED_EVENT_UEI)
-    public void handleNodeAddedEvent(Event e) {
+    public void handleNodeAddedEvent(IEvent e) {
         NodeScanSchedule scheduleForNode = null;
         LOG.warn("node added event ({})", System.currentTimeMillis());
         try {
@@ -578,10 +571,10 @@ public class Provisioner implements SpringServiceDaemon {
     /**
      * <p>handleForceRescan</p>
      *
-     * @param e a {@link org.opennms.netmgt.xml.event.Event} object.
+     * @param e a {@link org.opennms.netmgt.events.api.model.IEvent} object.
      */
     @EventHandler(uei = EventConstants.FORCE_RESCAN_EVENT_UEI)
-    public void handleForceRescan(Event e) {
+    public void handleForceRescan(IEvent e) {
         final Integer nodeId = new Integer(e.getNodeid().intValue());
         removeNodeFromScheduleQueue(nodeId);
         Runnable r = new Runnable() {
@@ -607,12 +600,11 @@ public class Provisioner implements SpringServiceDaemon {
     }
     
     @EventHandler(uei = EventConstants.NEW_SUSPECT_INTERFACE_EVENT_UEI)
-    public void handleNewSuspectEvent(Event e) {
-        final Event event = e;
-        final String uei = e.getUei();
-        final String ip = e.getInterface();
+    public void handleNewSuspectEvent(IEvent event) {
+        final String uei = event.getUei();
+        final String ip = event.getInterface();
         final Map<String, String> paramMap = Maps.newHashMap();
-        e.getParmCollection().forEach(eachParam -> paramMap.put(eachParam.getParmName(), eachParam.getValue().getContent()));
+        event.getParmCollection().forEach(eachParam -> paramMap.put(eachParam.getParmName(), eachParam.getValue().getContent()));
 
         if (ip == null) {
             LOG.error("Received a {} event with a null ipAddress", uei);
@@ -670,10 +662,10 @@ public class Provisioner implements SpringServiceDaemon {
      * <p>handleNodeUpdated</p>
      * A re-import has occurred, attempt a rescan now.
      *
-     * @param e a {@link org.opennms.netmgt.xml.event.Event} object.
+     * @param e a {@link org.opennms.netmgt.events.api.model.IEvent} object.
      */
     @EventHandler(uei = EventConstants.NODE_UPDATED_EVENT_UEI)
-    public void handleNodeUpdated(Event e) {
+    public void handleNodeUpdated(IEvent e) {
     	LOG.debug("Node updated event received: {}", e);
     	
         if (!Boolean.valueOf(System.getProperty(SCHEDULE_RESCAN_FOR_UPDATED_NODES, "true"))) {
@@ -681,7 +673,7 @@ public class Provisioner implements SpringServiceDaemon {
         	return;
         }
         String rescanExisting = Boolean.TRUE.toString(); // Default
-        for (Parm parm : e.getParmCollection()) {
+        for (IParm parm : e.getParmCollection()) {
             if (EventConstants.PARM_RESCAN_EXISTING.equals(parm.getParmName()) && ("false".equalsIgnoreCase(parm.getValue().getContent()) || "dbonly".equalsIgnoreCase(parm.getValue().getContent()))) {
                 rescanExisting = Boolean.FALSE.toString();
             }
@@ -702,10 +694,10 @@ public class Provisioner implements SpringServiceDaemon {
     /**
      * <p>handleNodeDeletedEvent</p>
      *
-     * @param e a {@link org.opennms.netmgt.xml.event.Event} object.
+     * @param e a {@link org.opennms.netmgt.events.api.model.IEvent} object.
      */
     @EventHandler(uei = EventConstants.NODE_DELETED_EVENT_UEI)
-    public void handleNodeDeletedEvent(Event e) {
+    public void handleNodeDeletedEvent(IEvent e) {
         removeNodeFromScheduleQueue(e.getNodeid().intValue());
         
     }
@@ -713,10 +705,10 @@ public class Provisioner implements SpringServiceDaemon {
     /**
      * <p>handleReloadConfigEvent</p>
      *
-     * @param e a {@link org.opennms.netmgt.xml.event.Event} object.
+     * @param e a {@link org.opennms.netmgt.events.api.model.IEvent} object.
      */
     @EventHandler(uei = EventConstants.RELOAD_DAEMON_CONFIG_UEI)
-    public void handleReloadConfigEvent(Event e) {
+    public void handleReloadConfigEvent(IEvent e) {
         
         if (isReloadConfigEventTarget(e)) {
             LOG.info("handleReloadConfigEvent: reloading configuration...");
@@ -749,13 +741,13 @@ public class Provisioner implements SpringServiceDaemon {
         
     }
     
-    private boolean isReloadConfigEventTarget(Event event) {
+    private boolean isReloadConfigEventTarget(IEvent event) {
         boolean isTarget = false;
         
-        List<Parm> parmCollection = event.getParmCollection();
+        List<IParm> parmCollection = event.getParmCollection();
         
 
-        for (Parm parm : parmCollection) {
+        for (IParm parm : parmCollection) {
             if (EventConstants.PARM_DAEMON_NAME.equals(parm.getParmName()) && "Provisiond".equalsIgnoreCase(parm.getValue().getContent())) {
                 isTarget = true;
                 break;
@@ -769,10 +761,10 @@ public class Provisioner implements SpringServiceDaemon {
     /**
      * <p>handleAddNode</p>
      *
-     * @param event a {@link org.opennms.netmgt.xml.event.Event} object.
+     * @param event a {@link org.opennms.netmgt.events.api.model.IEvent} object.
      */
     @EventHandler(uei=EventConstants.ADD_NODE_EVENT_UEI)
-    public void handleAddNode(Event event) {
+    public void handleAddNode(IEvent event) {
         if (m_provisionService.isDiscoveryEnabled()) {
             try {
                 doAddNode(event.getInterface(), EventUtils.getParm(event, EventConstants.PARM_NODE_LABEL));
@@ -802,10 +794,10 @@ public class Provisioner implements SpringServiceDaemon {
     /**
      * <p>handleDeleteInterface</p>
      *
-     * @param event a {@link org.opennms.netmgt.xml.event.Event} object.
+     * @param event a {@link org.opennms.netmgt.events.api.model.IEvent} object.
      */
     @EventHandler(uei=EventConstants.DELETE_INTERFACE_EVENT_UEI)
-    public void handleDeleteInterface(Event event) {
+    public void handleDeleteInterface(IEvent event) {
         try {
             doDeleteInterface(event.getNodeid(), event.getInterface());
         } catch (Throwable e) {
@@ -820,10 +812,10 @@ public class Provisioner implements SpringServiceDaemon {
     /**
      * <p>handleDeleteNode</p>
      *
-     * @param event a {@link org.opennms.netmgt.xml.event.Event} object.
+     * @param event a {@link org.opennms.netmgt.events.api.model.IEvent} object.
      */
     @EventHandler(uei=EventConstants.DELETE_NODE_EVENT_UEI)
-    public void handleDeleteNode(Event event) {
+    public void handleDeleteNode(IEvent event) {
         try {
             doDeleteNode(event.getNodeid());
         } catch (Throwable e) {
@@ -838,13 +830,13 @@ public class Provisioner implements SpringServiceDaemon {
     /**
      * <p>handleDeleteService</p>
      *
-     * @param event a {@link org.opennms.netmgt.xml.event.Event} object.
+     * @param event a {@link org.opennms.netmgt.events.api.model.IEvent} object.
      */
     @EventHandler(uei=EventConstants.DELETE_SERVICE_EVENT_UEI)
-    public void handleDeleteService(Event event) {
+    public void handleDeleteService(IEvent event) {
         try {
             boolean ignoreUnmanaged = false;
-            final Parm ignoreUnmanagedParm = event.getParm(EventConstants.PARM_IGNORE_UNMANAGED);
+            final IParm ignoreUnmanagedParm = event.getParm(EventConstants.PARM_IGNORE_UNMANAGED);
             if (ignoreUnmanagedParm != null) {
                 ignoreUnmanaged = Boolean.valueOf(ignoreUnmanagedParm.getValue().getContent());
             }
@@ -858,11 +850,11 @@ public class Provisioner implements SpringServiceDaemon {
         m_provisionService.deleteService((int)nodeId, addr, service, ignoreUnmanaged);
     }
 
-    private String getEventUrl(Event event) {
+    private String getEventUrl(IEvent event) {
         return EventUtils.getParm(event, EventConstants.PARM_URL);
     }
 
-    private String getEventRescanExistingOnImport(final Event event) {
+    private String getEventRescanExistingOnImport(final IEvent event) {
         final String rescanExisting = EventUtils.getParm(event, EventConstants.PARM_IMPORT_RESCAN_EXISTING);
         
         if (rescanExisting == null) {

--- a/opennms-provision/opennms-provisiond/src/main/java/org/opennms/netmgt/provision/service/Provisioner.java
+++ b/opennms-provision/opennms-provisiond/src/main/java/org/opennms/netmgt/provision/service/Provisioner.java
@@ -604,7 +604,8 @@ public class Provisioner implements SpringServiceDaemon {
         final String uei = event.getUei();
         final String ip = event.getInterface();
         final Map<String, String> paramMap = Maps.newHashMap();
-        event.getParmCollection().forEach(eachParam -> paramMap.put(eachParam.getParmName(), eachParam.getValue().getContent()));
+        event.getParmCollection().forEach(eachParam -> paramMap.put(eachParam.getParmName(),
+                eachParam.getValue().getContent()));
 
         if (ip == null) {
             LOG.error("Received a {} event with a null ipAddress", uei);

--- a/opennms-provision/opennms-provisiond/src/main/java/org/opennms/netmgt/provision/service/ProvisioningAdapterManager.java
+++ b/opennms-provision/opennms-provisiond/src/main/java/org/opennms/netmgt/provision/service/ProvisioningAdapterManager.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2009-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2009-2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -34,9 +34,9 @@ import org.opennms.netmgt.events.api.EventConstants;
 import org.opennms.netmgt.events.api.EventForwarder;
 import org.opennms.netmgt.events.api.annotations.EventHandler;
 import org.opennms.netmgt.events.api.annotations.EventListener;
+import org.opennms.netmgt.events.api.model.IEvent;
 import org.opennms.netmgt.provision.ProvisioningAdapter;
 import org.opennms.netmgt.provision.ProvisioningAdapterException;
-import org.opennms.netmgt.xml.event.Event;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.InitializingBean;
@@ -92,10 +92,10 @@ public class ProvisioningAdapterManager implements InitializingBean {
     /**
      * <p>handleNodeAddedEvent</p>
      *
-     * @param e a {@link org.opennms.netmgt.xml.event.Event} object.
+     * @param e a {@link org.opennms.netmgt.events.api.model.IEvent} object.
      */
     @EventHandler(uei = EventConstants.NODE_ADDED_EVENT_UEI)
-    public void handleNodeAddedEvent(Event e) {
+    public void handleNodeAddedEvent(IEvent e) {
         for (ProvisioningAdapter adapter : m_adapters) {
             LOG.info("handleNodeAddedEvent: Calling adapter:{} for node: {}", e.getNodeid(), adapter.getName());
             try {
@@ -111,10 +111,10 @@ public class ProvisioningAdapterManager implements InitializingBean {
     /**
      * <p>handleNodeUpdatedEvent</p>
      *
-     * @param e a {@link org.opennms.netmgt.xml.event.Event} object.
+     * @param e a {@link org.opennms.netmgt.events.api.model.IEvent} object.
      */
     @EventHandler(uei = EventConstants.NODE_UPDATED_EVENT_UEI)
-    public void handleNodeUpdatedEvent(Event e) {
+    public void handleNodeUpdatedEvent(IEvent e) {
         for (ProvisioningAdapter adapter : m_adapters) {
             LOG.info("handleNodeUpdatedEvent: Calling adapter:{} for node: {}", e.getNodeid(), adapter.getName());
             try {
@@ -130,10 +130,10 @@ public class ProvisioningAdapterManager implements InitializingBean {
     /**
      * <p>handleNodeDeletedEvent</p>
      *
-     * @param e a {@link org.opennms.netmgt.xml.event.Event} object.
+     * @param e a {@link org.opennms.netmgt.events.api.model.IEvent} object.
      */
     @EventHandler(uei = EventConstants.NODE_DELETED_EVENT_UEI)
-    public void handleNodeDeletedEvent(Event e) {
+    public void handleNodeDeletedEvent(IEvent e) {
         for (ProvisioningAdapter adapter : m_adapters) {
             LOG.info("handleNodeDeletedEvent: Calling adapter:{} for node: {}", e.getNodeid(), adapter.getName());
             try {
@@ -152,10 +152,10 @@ public class ProvisioningAdapterManager implements InitializingBean {
      * Note: If the operations are properly scheduled and handled using the SimpleQueuedProvisioningAdapter, even though
      * this event is sent following a nodeUpdated event, the update operation task should be reduced to 1 operation on the queue.
      *
-     * @param e a {@link org.opennms.netmgt.xml.event.Event} object.
+     * @param e a {@link org.opennms.netmgt.events.api.model.IEvent} object.
      */
     @EventHandler(uei = EventConstants.PROVISION_SCAN_COMPLETE_UEI)
-    public void handleNodeScanCompletedEvent(Event e) {
+    public void handleNodeScanCompletedEvent(IEvent e) {
         for (ProvisioningAdapter adapter : m_adapters) {
             LOG.info("handleScanCompletedEvent: Calling adapter:{} for node: {}", e.getNodeid(), adapter.getName());
             try {
@@ -171,10 +171,10 @@ public class ProvisioningAdapterManager implements InitializingBean {
     /**
      * <p>handleNodeChangedEvent</p>
      *
-     * @param e a {@link org.opennms.netmgt.xml.event.Event} object.
+     * @param e a {@link org.opennms.netmgt.events.api.model.IEvent} object.
      */
     @EventHandler(uei = EventConstants.NODE_CONFIG_CHANGE_UEI)
-    public void handleNodeChangedEvent(Event e) {
+    public void handleNodeChangedEvent(IEvent e) {
         for (ProvisioningAdapter adapter : m_adapters) {
             LOG.info("handleNodeChangedEvent: Calling adapter:{} for node: {}", e.getNodeid(), adapter.getName());
             try {

--- a/opennms-provision/opennms-provisiond/src/test/java/org/opennms/netmgt/provision/service/NewSuspectScanIT.java
+++ b/opennms-provision/opennms-provisiond/src/test/java/org/opennms/netmgt/provision/service/NewSuspectScanIT.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2006-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2006-2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -35,7 +35,6 @@ import java.net.InetAddress;
 import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Executors;
 
 import org.joda.time.Duration;
 import org.junit.After;
@@ -62,6 +61,7 @@ import org.opennms.netmgt.dao.mock.EventAnticipator;
 import org.opennms.netmgt.dao.mock.MockEventIpcManager;
 import org.opennms.netmgt.dao.mock.MockNodeDao;
 import org.opennms.netmgt.events.api.EventConstants;
+import org.opennms.netmgt.events.api.model.ImmutableMapper;
 import org.opennms.netmgt.model.OnmsDistPoller;
 import org.opennms.netmgt.model.OnmsIpInterface;
 import org.opennms.netmgt.model.OnmsMonitoringSystem;
@@ -732,8 +732,8 @@ public class NewSuspectScanIT extends ProvisioningITCase implements Initializing
         anticipator.anticipateEvent(new EventBuilder(EventConstants.PROVISION_SCAN_COMPLETE_UEI, "Provisiond").setNodeid(nextNodeId).getEvent());
 
         // Send new suspect threads at once, these two shouldn't create two nodes.
-        m_provisioner.handleNewSuspectEvent(newSuspectEvent);
-        m_provisioner.handleNewSuspectEvent(newSuspectEvent1);
+        m_provisioner.handleNewSuspectEvent(ImmutableMapper.fromMutableEvent(newSuspectEvent));
+        m_provisioner.handleNewSuspectEvent(ImmutableMapper.fromMutableEvent(newSuspectEvent1));
 
         anticipator.verifyAnticipated(20000, 0, 0, 0, 0);
 

--- a/opennms-provision/opennms-provisiond/src/test/java/org/opennms/netmgt/provision/service/PolicyIT.java
+++ b/opennms-provision/opennms-provisiond/src/test/java/org/opennms/netmgt/provision/service/PolicyIT.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2010-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2010-2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -47,11 +47,11 @@ import org.opennms.core.test.snmp.annotations.JUnitSnmpAgents;
 import org.opennms.netmgt.dao.mock.MockEventIpcManager;
 import org.opennms.netmgt.events.api.EventConstants;
 import org.opennms.netmgt.events.api.EventListener;
+import org.opennms.netmgt.events.api.model.IEvent;
 import org.opennms.netmgt.model.monitoringLocations.OnmsMonitoringLocation;
 import org.opennms.netmgt.provision.persist.MockForeignSourceRepository;
 import org.opennms.netmgt.provision.persist.foreignsource.ForeignSource;
 import org.opennms.netmgt.provision.persist.foreignsource.PluginConfig;
-import org.opennms.netmgt.xml.event.Event;
 import org.opennms.test.JUnitConfigurationEnvironment;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.ResourceLoader;
@@ -223,7 +223,7 @@ public class PolicyIT {
         m_eventSubscriber.addEventListener(new EventListener() {
 
             @Override
-            public void onEvent(Event e) {
+            public void onEvent(IEvent e) {
                 eventRecieved.countDown();
             }
 

--- a/opennms-provision/opennms-provisiond/src/test/java/org/opennms/netmgt/provision/service/ProvisionerTest.java
+++ b/opennms-provision/opennms-provisiond/src/test/java/org/opennms/netmgt/provision/service/ProvisionerTest.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2018 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2018 The OpenNMS Group, Inc.
+ * Copyright (C) 2018-2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -48,6 +48,7 @@ import org.opennms.core.utils.InetAddressUtils;
 import org.opennms.netmgt.dao.api.MonitoringLocationDao;
 import org.opennms.netmgt.dao.api.MonitoringSystemDao;
 import org.opennms.netmgt.events.api.EventConstants;
+import org.opennms.netmgt.events.api.model.ImmutableMapper;
 import org.opennms.netmgt.model.events.EventBuilder;
 import org.opennms.netmgt.xml.event.Event;
 
@@ -105,7 +106,7 @@ public class ProvisionerTest {
                 .getEvent();
 
         // Trigger the newSuspect
-        provisioner.handleNewSuspectEvent(newSuspectEvent);
+        provisioner.handleNewSuspectEvent(ImmutableMapper.fromMutableEvent(newSuspectEvent));
         // Wait for the runnable to complete
         final CountDownLatch latch = new CountDownLatch(1);
         provisioner.getNewSuspectExecutor().execute(latch::countDown);
@@ -136,7 +137,7 @@ public class ProvisionerTest {
             .setInterface(InetAddressUtils.UNPINGABLE_ADDRESS)
             .setService("ICMP").getEvent();
 
-        provisioner.handleDeleteService(event);
+        provisioner.handleDeleteService(ImmutableMapper.fromMutableEvent(event));
 
         verify(provisionService).deleteService(1, InetAddressUtils.UNPINGABLE_ADDRESS, "ICMP", false);
     }
@@ -157,7 +158,7 @@ public class ProvisionerTest {
             .setInterface(InetAddressUtils.UNPINGABLE_ADDRESS)
             .setService("ICMP").addParam(EventConstants.PARM_IGNORE_UNMANAGED, "true").getEvent();
 
-        provisioner.handleDeleteService(event);
+        provisioner.handleDeleteService(ImmutableMapper.fromMutableEvent(event));
 
         verify(provisionService).deleteService(1, InetAddressUtils.UNPINGABLE_ADDRESS, "ICMP", true);
     }

--- a/opennms-provision/opennms-provisiond/src/test/java/org/opennms/netmgt/provision/service/ProvisioningITCase.java
+++ b/opennms-provision/opennms-provisiond/src/test/java/org/opennms/netmgt/provision/service/ProvisioningITCase.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2013-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2013-2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -35,7 +35,7 @@ import java.util.concurrent.TimeUnit;
 import org.opennms.core.concurrent.PausibleScheduledThreadPoolExecutor;
 import org.opennms.netmgt.dao.mock.MockEventIpcManager;
 import org.opennms.netmgt.events.api.EventListener;
-import org.opennms.netmgt.xml.event.Event;
+import org.opennms.netmgt.events.api.model.IEvent;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 
@@ -110,7 +110,7 @@ public abstract class ProvisioningITCase {
     protected CountDownLatch anticipateEvents(final int numberToMatch, final String... ueis) {
         final CountDownLatch eventReceived = new CountDownLatch(numberToMatch);
         m_eventSubscriber.addEventListener(new EventListener() {
-            @Override public void onEvent(final Event e) {
+            @Override public void onEvent(final IEvent e) {
                 eventReceived.countDown();
             }
 

--- a/opennms-services/src/main/java/org/opennms/netmgt/actiond/BroadcastEventProcessor.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/actiond/BroadcastEventProcessor.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2002-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2002-2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -33,8 +33,8 @@ import java.util.Queue;
 
 import org.opennms.netmgt.events.api.EventIpcManagerFactory;
 import org.opennms.netmgt.events.api.EventListener;
-import org.opennms.netmgt.xml.event.Autoaction;
-import org.opennms.netmgt.xml.event.Event;
+import org.opennms.netmgt.events.api.model.IAutoAction;
+import org.opennms.netmgt.events.api.model.IEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -83,7 +83,7 @@ final class BroadcastEventProcessor implements EventListener {
      * are queued to be run
      */
     @Override
-    public void onEvent(Event event) {
+    public void onEvent(IEvent event) {
 
         if (event == null) {
             return;
@@ -91,9 +91,9 @@ final class BroadcastEventProcessor implements EventListener {
 
         // Handle autoactions
         //
-        Enumeration<Autoaction> walker = event.enumerateAutoaction();
+        Enumeration<IAutoAction> walker = event.enumerateAutoaction();
         while (walker.hasMoreElements()) {
-            Autoaction aact = walker.nextElement();
+            IAutoAction aact = walker.nextElement();
             if ("on".equalsIgnoreCase(aact.getState())) {
                 m_execQ.add(aact.getContent()); // java.lang.String
             }

--- a/opennms-services/src/main/java/org/opennms/netmgt/collectd/Collectd.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/collectd/Collectd.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2002-2018 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2018 The OpenNMS Group, Inc.
+ * Copyright (C) 2002-2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -70,6 +70,9 @@ import org.opennms.netmgt.dao.api.NodeDao;
 import org.opennms.netmgt.events.api.EventConstants;
 import org.opennms.netmgt.events.api.EventIpcManager;
 import org.opennms.netmgt.events.api.EventListener;
+import org.opennms.netmgt.events.api.model.IEvent;
+import org.opennms.netmgt.events.api.model.IParm;
+import org.opennms.netmgt.events.api.model.IValue;
 import org.opennms.netmgt.filter.api.FilterDao;
 import org.opennms.netmgt.model.AbstractEntityVisitor;
 import org.opennms.netmgt.model.OnmsIpInterface;
@@ -82,9 +85,6 @@ import org.opennms.netmgt.scheduler.ReadyRunnable;
 import org.opennms.netmgt.scheduler.Scheduler;
 import org.opennms.netmgt.snmp.InetAddrUtils;
 import org.opennms.netmgt.threshd.api.ThresholdingService;
-import org.opennms.netmgt.xml.event.Event;
-import org.opennms.netmgt.xml.event.Parm;
-import org.opennms.netmgt.xml.event.Value;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -699,7 +699,7 @@ public class Collectd extends AbstractServiceDaemon implements
      * UEI.
      */
     @Override
-    public void onEvent(final Event event) {
+    public void onEvent(final IEvent event) {
         Logging.withPrefix(getName(), () -> {
             m_transTemplate.execute(new TransactionCallbackWithoutResult() {
                 @Override
@@ -710,7 +710,7 @@ public class Collectd extends AbstractServiceDaemon implements
         });
     }
 
-    private void onEventInTransaction(Event event) {
+    private void onEventInTransaction(IEvent event) {
         // print out the uei
         //
         LOG.debug("received event, uei = {}", event.getUei());
@@ -757,12 +757,12 @@ public class Collectd extends AbstractServiceDaemon implements
         LOG.info(e.getMessage());
     }
 
-    private void handleDupNodeDeleted(Event event)
+    private void handleDupNodeDeleted(IEvent event)
             throws InsufficientInformationException {
         handleNodeDeleted(event);
     }
 
-    private void handleScheduledOutagesChanged(Event event) {
+    private void handleScheduledOutagesChanged(IEvent event) {
         try {
             LOG.info("Reloading Collectd config factory");
             m_collectdConfigFactory.reload();
@@ -789,7 +789,7 @@ public class Collectd extends AbstractServiceDaemon implements
      * @param event
      *            The event to process.
      */
-    private void handleConfigureSNMP(final Event event) {
+    private void handleConfigureSNMP(final IEvent event) {
         LOG.debug("configureSNMPHandler: processing configure SNMP event...", event);
         
         SnmpEventInfo info = null;
@@ -818,7 +818,7 @@ public class Collectd extends AbstractServiceDaemon implements
      *            The event to process.
      * @throws InsufficientInformationException
      */
-    private void handleInterfaceDeleted(Event event)
+    private void handleInterfaceDeleted(IEvent event)
             throws InsufficientInformationException {
         EventUtils.checkNodeId(event);
 
@@ -882,7 +882,7 @@ public class Collectd extends AbstractServiceDaemon implements
      *            The event to process.
      * @throws InsufficientInformationException
      */
-    private void handleInterfaceReparented(Event event)
+    private void handleInterfaceReparented(IEvent event)
             throws InsufficientInformationException {
         EventUtils.checkNodeId(event);
         EventUtils.checkInterface(event);
@@ -897,10 +897,10 @@ public class Collectd extends AbstractServiceDaemon implements
         String oldNodeIdStr = null;
         String newNodeIdStr = null;
         String parmName = null;
-        Value parmValue = null;
+        IValue parmValue = null;
         String parmContent = null;
 
-        for (Parm parm : event.getParmCollection()) {
+        for (IParm parm : event.getParmCollection()) {
             parmName = parm.getParmName();
             parmValue = parm.getValue();
             if (parmValue == null)
@@ -976,7 +976,7 @@ public class Collectd extends AbstractServiceDaemon implements
      *            The event to process.
      * @throws InsufficientInformationException
      */
-    private void handleNodeDeleted(Event event)
+    private void handleNodeDeleted(IEvent event)
             throws InsufficientInformationException {
         EventUtils.checkNodeId(event);
 
@@ -994,7 +994,7 @@ public class Collectd extends AbstractServiceDaemon implements
      *            The event to process.
      * @throws InsufficientInformationException if the event does not have a nodeId
      */
-    private void handleNodeCategoryMembershipChanged(Event event) throws InsufficientInformationException {
+    private void handleNodeCategoryMembershipChanged(IEvent event) throws InsufficientInformationException {
         EventUtils.checkNodeId(event);
 
         Long nodeId = event.getNodeid();
@@ -1013,7 +1013,7 @@ public class Collectd extends AbstractServiceDaemon implements
      *            The event to process.
      * @throws InsufficientInformationException if the event does not have a nodeId
      */
-    private void handleNodeLocationChanged(Event event) throws InsufficientInformationException {
+    private void handleNodeLocationChanged(IEvent event) throws InsufficientInformationException {
         EventUtils.checkNodeId(event);
 
         Long nodeId = event.getNodeid();
@@ -1106,7 +1106,7 @@ public class Collectd extends AbstractServiceDaemon implements
      *            The event to process.
      * @throws InsufficientInformationException
      */
-    private void handleNodeGainedService(Event event)
+    private void handleNodeGainedService(IEvent event)
             throws InsufficientInformationException {
         EventUtils.checkNodeId(event);
         EventUtils.checkInterface(event);
@@ -1116,10 +1116,10 @@ public class Collectd extends AbstractServiceDaemon implements
         scheduleForCollection(event);
     }
     
-    private void handleReloadDaemonConfig(Event event) {
+    private void handleReloadDaemonConfig(IEvent event) {
         final String collectionDaemonName = "Collectd";
         boolean isCollection = false;
-        for (Parm parm : event.getParmCollection()) {
+        for (IParm parm : event.getParmCollection()) {
             if (EventConstants.PARM_DAEMON_NAME.equals(parm.getParmName()) && collectionDaemonName.equalsIgnoreCase(parm.getValue().getContent())) {
                 isCollection = true;
                 break;
@@ -1128,7 +1128,7 @@ public class Collectd extends AbstractServiceDaemon implements
         if (isCollection) {
             final String targetFile = ConfigFileConstants.getFileName(ConfigFileConstants.DATA_COLLECTION_CONF_FILE_NAME);
             boolean isDataCollectionConfig = false;
-            for (Parm parm : event.getParmCollection()) {
+            for (IParm parm : event.getParmCollection()) {
                 if (EventConstants.PARM_CONFIG_FILE_NAME.equals(parm.getParmName()) && targetFile.equalsIgnoreCase(parm.getValue().getContent())) {
                     isDataCollectionConfig = true;
                     break;
@@ -1179,7 +1179,7 @@ public class Collectd extends AbstractServiceDaemon implements
         }
     }
     
-    private void scheduleForCollection(Event event) {
+    private void scheduleForCollection(IEvent event) {
         // This moved to here from the scheduleInterface() for better behavior
         // during initialization
         
@@ -1204,7 +1204,7 @@ public class Collectd extends AbstractServiceDaemon implements
      *            The event to process.
      * @throws InsufficientInformationException
      */
-    private void handlePrimarySnmpInterfaceChanged(Event event)
+    private void handlePrimarySnmpInterfaceChanged(IEvent event)
             throws InsufficientInformationException {
         EventUtils.checkNodeId(event);
         EventUtils.checkInterface(event);
@@ -1221,10 +1221,10 @@ public class Collectd extends AbstractServiceDaemon implements
         //
         String oldPrimaryIfAddr = null;
         String parmName = null;
-        Value parmValue = null;
+        IValue parmValue = null;
         String parmContent = null;
 
-        for (Parm parm : event.getParmCollection()) {
+        for (IParm parm : event.getParmCollection()) {
             parmName = parm.getParmName();
             parmValue = parm.getValue();
             if (parmValue == null)
@@ -1305,7 +1305,7 @@ public class Collectd extends AbstractServiceDaemon implements
      *            The event to process.
      * @throws InsufficientInformationException
      */
-    private void handleReinitializePrimarySnmpInterface(Event event)
+    private void handleReinitializePrimarySnmpInterface(IEvent event)
             throws InsufficientInformationException {
         EventUtils.checkNodeId(event);
         EventUtils.checkInterface(event);
@@ -1357,7 +1357,7 @@ public class Collectd extends AbstractServiceDaemon implements
      * @throws InsufficientInformationException 
      * 
      */
-    private void handleServiceDeleted(Event event)
+    private void handleServiceDeleted(IEvent event)
             throws InsufficientInformationException {
         EventUtils.checkNodeId(event);
         EventUtils.checkInterface(event);

--- a/opennms-services/src/main/java/org/opennms/netmgt/passive/PassiveStatusKeeper.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/passive/PassiveStatusKeeper.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2002-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2002-2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -40,9 +40,9 @@ import org.opennms.netmgt.daemon.AbstractServiceDaemon;
 import org.opennms.netmgt.events.api.EventConstants;
 import org.opennms.netmgt.events.api.EventIpcManager;
 import org.opennms.netmgt.events.api.EventListener;
+import org.opennms.netmgt.events.api.model.IEvent;
 import org.opennms.netmgt.model.events.EventUtils;
 import org.opennms.netmgt.poller.PollStatus;
-import org.opennms.netmgt.xml.event.Event;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -210,10 +210,9 @@ public class PassiveStatusKeeper extends AbstractServiceDaemon implements EventL
 
     /** {@inheritDoc} */
     @Override
-    public void onEvent(Event e) {
-        
+    public void onEvent(IEvent e) {
         if (isPassiveStatusEvent(e)) {
-            LOG.debug("onEvent: received valid registered passive status event: \n", EventUtils.toString(e));
+            LOG.debug("onEvent: received valid registered passive status event: \n", e);
             PassiveStatusValue statusValue = getPassiveStatusValue(e);
             setStatus(statusValue.getKey(), statusValue.getStatus());
             LOG.debug("onEvent: passive status for: {} is: {}", statusValue.getKey(), m_statusTable.get(statusValue.getKey()));
@@ -221,11 +220,11 @@ public class PassiveStatusKeeper extends AbstractServiceDaemon implements EventL
         
         if (!isPassiveStatusEvent(e))
         {
-            LOG.debug("onEvent: received Invalid registered passive status event: \n", EventUtils.toString(e));
+            LOG.debug("onEvent: received Invalid registered passive status event: \n", e);
         }
     }
 
-    private PassiveStatusValue getPassiveStatusValue(Event e) {
+    private PassiveStatusValue getPassiveStatusValue(IEvent e) {
     		return new PassiveStatusValue(
     				EventUtils.getParm(e, EventConstants.PARM_PASSIVE_NODE_LABEL),
     				EventUtils.getParm(e, EventConstants.PARM_PASSIVE_IPADDR),
@@ -235,7 +234,7 @@ public class PassiveStatusKeeper extends AbstractServiceDaemon implements EventL
     		
 	}
 
-	boolean isPassiveStatusEvent(Event e) {
+	boolean isPassiveStatusEvent(IEvent e) {
 		return PASSIVE_STATUS_UEI.equals(e.getUei()) &&
 			EventUtils.getParm(e, EventConstants.PARM_PASSIVE_NODE_LABEL) != null &&
 			EventUtils.getParm(e, EventConstants.PARM_PASSIVE_IPADDR) != null &&

--- a/opennms-services/src/main/java/org/opennms/netmgt/poller/DefaultPollContext.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/poller/DefaultPollContext.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2005-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2005-2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -45,6 +45,8 @@ import org.opennms.netmgt.dao.hibernate.PathOutageManagerDaoImpl;
 import org.opennms.netmgt.events.api.EventConstants;
 import org.opennms.netmgt.events.api.EventIpcManager;
 import org.opennms.netmgt.events.api.EventListener;
+import org.opennms.netmgt.events.api.model.IEvent;
+import org.opennms.netmgt.events.api.model.ImmutableMapper;
 import org.opennms.netmgt.icmp.proxy.LocationAwarePingClient;
 import org.opennms.netmgt.icmp.proxy.PingSequence;
 import org.opennms.netmgt.icmp.proxy.PingSummary;
@@ -239,7 +241,7 @@ public class DefaultPollContext implements PollContext, EventListener {
     }
 
     /* (non-Javadoc)
-     * @see org.opennms.netmgt.poller.pollables.PollContext#sendEvent(org.opennms.netmgt.xml.event.Event)
+     * @see org.opennms.netmgt.poller.pollables.PollContext#sendEvent(org.opennms.netmgt.events.api.model.IEvent)
      */
     /** {@inheritDoc} */
     @Override
@@ -248,7 +250,7 @@ public class DefaultPollContext implements PollContext, EventListener {
             getEventManager().addEventListener(this, Arrays.asList(UEIS));
             m_listenerAdded = true;
         }
-        PendingPollEvent pollEvent = new PendingPollEvent(event);
+        PendingPollEvent pollEvent = new PendingPollEvent(ImmutableMapper.fromMutableEvent(event));
         m_pendingPollEvents.add(pollEvent);
 
         //log().info("Sending "+event.getUei()+" for element "+event.getNodeid()+":"+event.getInterface()+":"+event.getService(), new Exception("StackTrace"));
@@ -392,11 +394,11 @@ public class DefaultPollContext implements PollContext, EventListener {
     }
 
     /* (non-Javadoc)
-     * @see org.opennms.netmgt.eventd.EventListener#onEvent(org.opennms.netmgt.xml.event.Event)
+     * @see org.opennms.netmgt.eventd.EventListener#onEvent(org.opennms.netmgt.events.api.model.IEvent)
      */
     /** {@inheritDoc} */
     @Override
-    public void onEvent(final Event event) {
+    public void onEvent(final IEvent event) {
         if (LOG.isDebugEnabled()) {
             // CAUTION: m_pendingPollEvents.size() is not a constant-time operation
             LOG.debug("onEvent: Received event: {} uei: {}, dbid: {}, pendingEventCount: {}", event, event.getUei(), event.getDbid(), m_pendingPollEvents.size());
@@ -404,15 +406,10 @@ public class DefaultPollContext implements PollContext, EventListener {
 
         for (final PendingPollEvent pollEvent : m_pendingPollEvents) {
             LOG.trace("onEvent: comparing event to pollEvent: {}", pollEvent);
-            // TODO: This equals comparison is more like a '==' operation because
-            // I think that both events would have to be identical instances to
-            // have the same event ID. This will probably cause problems if we
-            // cluster event processing and the event instances are ever not 
-            // identical.
             if (event.equals(pollEvent.getEvent())) {
                 LOG.trace("onEvent: found matching pollEvent, completing pollEvent: {}", pollEvent);
                 // Thread-safe and idempotent
-                pollEvent.complete(event);
+                pollEvent.complete();
                 // TODO: Can we break here? I think there should only be one 
                 // instance of any given event in m_pendingPollEvents
                 // break;

--- a/opennms-services/src/main/java/org/opennms/netmgt/poller/DefaultPollContext.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/poller/DefaultPollContext.java
@@ -31,7 +31,6 @@ package org.opennms.netmgt.poller;
 import java.net.InetAddress;
 import java.sql.SQLException;
 import java.util.Arrays;
-import java.util.Comparator;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.Queue;
@@ -52,6 +51,7 @@ import org.opennms.netmgt.icmp.proxy.LocationAwarePingClient;
 import org.opennms.netmgt.icmp.proxy.PingSequence;
 import org.opennms.netmgt.icmp.proxy.PingSummary;
 import org.opennms.netmgt.model.events.EventBuilder;
+import org.opennms.netmgt.model.events.EventUtils;
 import org.opennms.netmgt.poller.pollables.PendingPollEvent;
 import org.opennms.netmgt.poller.pollables.PollContext;
 import org.opennms.netmgt.poller.pollables.PollEvent;
@@ -407,13 +407,10 @@ public class DefaultPollContext implements PollContext, EventListener {
 
         for (final PendingPollEvent pollEvent : m_pendingPollEvents) {
             LOG.trace("onEvent: comparing event to pollEvent: {}", pollEvent);
-            if (Comparator.comparing(IEvent::getUei)
-                    .thenComparing(IEvent::getNodeid)
-                    .thenComparing(IEvent::getService)
-                    .compare(pollEvent.getEvent(), event) == 0) {
+            if (EventUtils.eventsMatch(event, pollEvent.getEvent())) {
                 LOG.trace("onEvent: found matching pollEvent, completing pollEvent: {}", pollEvent);
                 // Thread-safe and idempotent
-                pollEvent.complete();
+                pollEvent.complete(event);
                 break;
             }
         }

--- a/opennms-services/src/main/java/org/opennms/netmgt/poller/DefaultPollContext.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/poller/DefaultPollContext.java
@@ -31,6 +31,7 @@ package org.opennms.netmgt.poller;
 import java.net.InetAddress;
 import java.sql.SQLException;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.Queue;
@@ -406,13 +407,14 @@ public class DefaultPollContext implements PollContext, EventListener {
 
         for (final PendingPollEvent pollEvent : m_pendingPollEvents) {
             LOG.trace("onEvent: comparing event to pollEvent: {}", pollEvent);
-            if (event.equals(pollEvent.getEvent())) {
+            if (Comparator.comparing(IEvent::getUei)
+                    .thenComparing(IEvent::getNodeid)
+                    .thenComparing(IEvent::getService)
+                    .compare(pollEvent.getEvent(), event) == 0) {
                 LOG.trace("onEvent: found matching pollEvent, completing pollEvent: {}", pollEvent);
                 // Thread-safe and idempotent
                 pollEvent.complete();
-                // TODO: Can we break here? I think there should only be one 
-                // instance of any given event in m_pendingPollEvents
-                // break;
+                break;
             }
         }
 

--- a/opennms-services/src/main/java/org/opennms/netmgt/poller/PollerEventProcessor.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/poller/PollerEventProcessor.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2002-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2002-2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -44,15 +44,15 @@ import org.opennms.netmgt.config.PollerConfig;
 import org.opennms.netmgt.events.api.EventConstants;
 import org.opennms.netmgt.events.api.EventIpcManager;
 import org.opennms.netmgt.events.api.EventListener;
+import org.opennms.netmgt.events.api.model.IEvent;
+import org.opennms.netmgt.events.api.model.IParm;
+import org.opennms.netmgt.events.api.model.IValue;
 import org.opennms.netmgt.model.events.EventBuilder;
 import org.opennms.netmgt.model.events.EventUtils;
 import org.opennms.netmgt.poller.pollables.PollableInterface;
 import org.opennms.netmgt.poller.pollables.PollableNetwork;
 import org.opennms.netmgt.poller.pollables.PollableNode;
 import org.opennms.netmgt.poller.pollables.PollableService;
-import org.opennms.netmgt.xml.event.Event;
-import org.opennms.netmgt.xml.event.Parm;
-import org.opennms.netmgt.xml.event.Value;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -186,7 +186,7 @@ final class PollerEventProcessor implements EventListener {
      *            The event to process.
      * 
      */
-    private void nodeGainedServiceHandler(final Event event) {
+    private void nodeGainedServiceHandler(final IEvent event) {
         // First make sure the service gained is in active state before trying to schedule
 
         final String ipAddr = event.getInterface();
@@ -229,7 +229,7 @@ final class PollerEventProcessor implements EventListener {
      *            The event to process.
      * 
      */
-    private void interfaceReparentedHandler(Event event) { 
+    private void interfaceReparentedHandler(IEvent event) {
         LOG.debug("interfaceReparentedHandler: processing interfaceReparented event for {}", event.getInterface());
 
         // Verify that the event has an interface associated with it
@@ -242,10 +242,10 @@ final class PollerEventProcessor implements EventListener {
         String oldNodeIdStr = null;
         String newNodeIdStr = null;
         String parmName = null;
-        Value parmValue = null;
+        IValue parmValue = null;
         String parmContent = null;
 
-        for (Parm parm : event.getParmCollection()) {
+        for (IParm parm : event.getParmCollection()) {
             parmName = parm.getParmName();
             parmValue = parm.getValue();
             if (parmValue == null)
@@ -305,7 +305,7 @@ final class PollerEventProcessor implements EventListener {
      * This method is responsible for removing a node's pollable service from
      * the pollable services list
      */
-    private void nodeRemovePollableServiceHandler(Event event) {
+    private void nodeRemovePollableServiceHandler(IEvent event) {
         Long nodeId = event.getNodeid();
         InetAddress ipAddr = event.getInterfaceAddress();
         String svcName = event.getService();
@@ -324,17 +324,17 @@ final class PollerEventProcessor implements EventListener {
      * This method is responsible for removing the node specified in the
      * nodeDeleted event from the Poller's pollable node map.
      */
-    private void nodeDeletedHandler(Event event) {
+    private void nodeDeletedHandler(IEvent event) {
         Long nodeId = event.getNodeid();
         final String sourceUei = event.getUei();
 
         // Extract node label and transaction No. from the event parms
         long txNo = -1L;
         String parmName = null;
-        Value parmValue = null;
+        IValue parmValue = null;
         String parmContent = null;
 
-        for (Parm parm : event.getParmCollection()) {
+        for (IParm parm : event.getParmCollection()) {
             parmName = parm.getParmName();
             parmValue = parm.getValue();
             if (parmValue == null)
@@ -369,13 +369,13 @@ final class PollerEventProcessor implements EventListener {
 
     }
 
-    private void nodeLabelChangedHandler(Event event) {
+    private void nodeLabelChangedHandler(IEvent event) {
         Long nodeId = event.getNodeid();
 
         // Extract node label from the event parms
-        for (Parm parm : event.getParmCollection()) {
+        for (IParm parm : event.getParmCollection()) {
             String parmName = parm.getParmName();
-            Value parmValue = parm.getValue();
+            IValue parmValue = parm.getValue();
             if (parmValue == null) {
                 continue;
             } else {
@@ -394,7 +394,7 @@ final class PollerEventProcessor implements EventListener {
         }
     }
 
-    private void interfaceDeletedHandler(Event event) {
+    private void interfaceDeletedHandler(IEvent event) {
         Long nodeId = event.getNodeid();
         String sourceUei = event.getUei();
         InetAddress ipAddr = event.getInterfaceAddress();
@@ -402,10 +402,10 @@ final class PollerEventProcessor implements EventListener {
         // Extract node label and transaction No. from the event parms
         long txNo = -1L;
         String parmName = null;
-        Value parmValue = null;
+        IValue parmValue = null;
         String parmContent = null;
 
-        for (Parm parm : event.getParmCollection()) {
+        for (IParm parm : event.getParmCollection()) {
             parmName = parm.getParmName();
             parmValue = parm.getValue();
             if (parmValue == null)
@@ -446,7 +446,7 @@ final class PollerEventProcessor implements EventListener {
      * the specified interface, so that it will not be scheduled by the poller.
      * </p>
      */
-    private void serviceDeletedHandler(Event event) {
+    private void serviceDeletedHandler(IEvent event) {
         Long nodeId = event.getNodeid();
         InetAddress ipAddr = event.getInterfaceAddress();
         String service = event.getService();
@@ -465,10 +465,10 @@ final class PollerEventProcessor implements EventListener {
 
     }
 
-    private void reloadConfigHandler(Event event) {
+    private void reloadConfigHandler(IEvent event) {
         final String daemonName = "Pollerd";
         boolean isPoller = false;
-        for (Parm parm : event.getParmCollection()) {
+        for (IParm parm : event.getParmCollection()) {
             if (EventConstants.PARM_DAEMON_NAME.equals(parm.getParmName()) && daemonName.equalsIgnoreCase(parm.getValue().getContent())) {
                 isPoller = true;
                 break;
@@ -536,7 +536,7 @@ final class PollerEventProcessor implements EventListener {
      *            The event
      */
     @Override
-    public void onEvent(Event event) {
+    public void onEvent(IEvent event) {
         if (event == null)
             return;
 
@@ -626,7 +626,7 @@ final class PollerEventProcessor implements EventListener {
 
     } // end onEvent()
 
-    private void serviceReschedule(Event event, boolean rescheduleExisting)   {
+    private void serviceReschedule(IEvent event, boolean rescheduleExisting)   {
         final Long nodeId = event.getNodeid();
 
         if (nodeId == null || nodeId <= 0) {
@@ -651,7 +651,7 @@ final class PollerEventProcessor implements EventListener {
         serviceReschedule(nodeId, nodeLabel, nodeLocation, event, rescheduleExisting);
     }
 
-    private void rescheduleAllServices(Event event) {
+    private void rescheduleAllServices(IEvent event) {
         LOG.info("Poller configuration has been changed, rescheduling services.");
         getPollerConfig().rebuildPackageIpListMap();
         for (Long nodeId : getNetwork().getNodeIds()) {
@@ -673,7 +673,7 @@ final class PollerEventProcessor implements EventListener {
         }
     }
 
-    private void serviceReschedule(Long nodeId, String nodeLabel, String nodeLocation, Event sourceEvent, boolean rescheduleExisting) {
+    private void serviceReschedule(Long nodeId, String nodeLabel, String nodeLocation, IEvent sourceEvent, boolean rescheduleExisting) {
         if (nodeId == null || nodeId <= 0) {
             LOG.warn("Invalid node ID for event, skipping service reschedule: {}", sourceEvent);
             return;
@@ -771,7 +771,7 @@ final class PollerEventProcessor implements EventListener {
         }
     }
 
-    protected void closeOutagesForService(final Event event, final Long nodeId, final Date closeDate, final Service polledService) {
+    protected void closeOutagesForService(final IEvent event, final Long nodeId, final Date closeDate, final Service polledService) {
         getPoller().getQueryManager().closeOutagesForService(closeDate, event.getDbid(), nodeId.intValue(), polledService.getAddress(), polledService.getServiceName());
     }
 

--- a/opennms-services/src/main/java/org/opennms/netmgt/poller/PollerEventProcessor.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/poller/PollerEventProcessor.java
@@ -673,7 +673,8 @@ final class PollerEventProcessor implements EventListener {
         }
     }
 
-    private void serviceReschedule(Long nodeId, String nodeLabel, String nodeLocation, IEvent sourceEvent, boolean rescheduleExisting) {
+    private void serviceReschedule(Long nodeId, String nodeLabel, String nodeLocation,
+                                   IEvent sourceEvent, boolean rescheduleExisting) {
         if (nodeId == null || nodeId <= 0) {
             LOG.warn("Invalid node ID for event, skipping service reschedule: {}", sourceEvent);
             return;
@@ -771,7 +772,8 @@ final class PollerEventProcessor implements EventListener {
         }
     }
 
-    protected void closeOutagesForService(final IEvent event, final Long nodeId, final Date closeDate, final Service polledService) {
+    protected void closeOutagesForService(final IEvent event, final Long nodeId, final Date closeDate,
+                                          final Service polledService) {
         getPoller().getQueryManager().closeOutagesForService(closeDate, event.getDbid(), nodeId.intValue(), polledService.getAddress(), polledService.getServiceName());
     }
 

--- a/opennms-services/src/main/java/org/opennms/netmgt/poller/pollables/PendingPollEvent.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/poller/pollables/PendingPollEvent.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2002-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2002-2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -34,6 +34,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.opennms.core.sysprops.SystemProperties;
+import org.opennms.netmgt.events.api.model.IEvent;
 import org.opennms.netmgt.poller.DefaultPollContext;
 import org.opennms.netmgt.xml.event.Event;
 import org.slf4j.Logger;
@@ -50,7 +51,7 @@ public class PendingPollEvent extends PollEvent {
     // how long to wait, in milliseconds, before giving up on waiting for a poll event to get an event ID, defaults to 10 minutes
     private static final long PENDING_EVENT_TIMEOUT = SystemProperties.getLong("org.opennms.netmgt.poller.pendingEventTimeout", 1000L * 60L * 10L);
 
-    private final Event m_event;
+    private final IEvent m_event;
     private final Date m_date;
     private long m_expirationTimeInMillis;
     private final AtomicBoolean m_pending = new AtomicBoolean(true);
@@ -59,9 +60,9 @@ public class PendingPollEvent extends PollEvent {
     /**
      * <p>Constructor for PendingPollEvent.</p>
      *
-     * @param event a {@link org.opennms.netmgt.xml.event.Event} object.
+     * @param event a {@link org.opennms.netmgt.events.api.model.IEvent} object.
      */
-    public PendingPollEvent(final Event event) {
+    public PendingPollEvent(final IEvent event) {
         super(Scope.fromUei(event.getUei()));
         m_event = event;
         m_date = m_event.getTime();
@@ -104,9 +105,9 @@ public class PendingPollEvent extends PollEvent {
     /**
      * <p>getEvent</p>
      *
-     * @return a {@link org.opennms.netmgt.xml.event.Event} object.
+     * @return a {@link org.opennms.netmgt.events.api.model.IEvent} object.
      */
-    public Event getEvent() {
+    public IEvent getEvent() {
         return m_event;
     }
     
@@ -135,10 +136,8 @@ public class PendingPollEvent extends PollEvent {
      * It is important that this call be thread-safe and idempotent because
      * it may be invoked by multiple {@link DefaultPollContext#onEvent(Event)}
      * threads.
-     *
-     * @param e a {@link org.opennms.netmgt.xml.event.Event} object.
      */
-    public void complete(Event e) {
+    public void complete() {
         m_pending.set(false);
     }
     
@@ -147,8 +146,6 @@ public class PendingPollEvent extends PollEvent {
      * It is important that this call be thread-safe and idempotent because
      * it may be invoked by multiple {@link DefaultPollContext#onEvent(Event)}
      * threads.
-     *
-     * @param e a {@link org.opennms.netmgt.xml.event.Event} object.
      */
     public void processPending() {
         while (!m_pendingOutages.isEmpty()) {

--- a/opennms-services/src/main/java/org/opennms/netmgt/poller/pollables/PendingPollEvent.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/poller/pollables/PendingPollEvent.java
@@ -51,7 +51,7 @@ public class PendingPollEvent extends PollEvent {
     // how long to wait, in milliseconds, before giving up on waiting for a poll event to get an event ID, defaults to 10 minutes
     private static final long PENDING_EVENT_TIMEOUT = SystemProperties.getLong("org.opennms.netmgt.poller.pendingEventTimeout", 1000L * 60L * 10L);
 
-    private final IEvent m_event;
+    private IEvent m_event;
     private final Date m_date;
     private long m_expirationTimeInMillis;
     private final AtomicBoolean m_pending = new AtomicBoolean(true);
@@ -134,10 +134,13 @@ public class PendingPollEvent extends PollEvent {
     /**
      * Changes the state of this event from "pending" to "not pending".
      * It is important that this call be thread-safe and idempotent because
-     * it may be invoked by multiple {@link DefaultPollContext#onEvent(Event)}
+     * it may be invoked by multiple {@link DefaultPollContext#onEvent(IEvent)}
      * threads.
+     *
+     * @param e a {@link org.opennms.netmgt.events.api.model.IEvent} object.
      */
-    public void complete() {
+    public void complete(IEvent e) {
+        m_event = e;
         m_pending.set(false);
     }
     

--- a/opennms-services/src/main/java/org/opennms/netmgt/queued/Queued.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/queued/Queued.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2007-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2007-2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -34,9 +34,9 @@ import org.opennms.netmgt.daemon.AbstractServiceDaemon;
 import org.opennms.netmgt.events.api.EventConstants;
 import org.opennms.netmgt.events.api.EventIpcManager;
 import org.opennms.netmgt.events.api.EventListener;
+import org.opennms.netmgt.events.api.model.IEvent;
 import org.opennms.netmgt.model.events.EventUtils;
 import org.opennms.netmgt.rrd.RrdStrategy;
-import org.opennms.netmgt.xml.event.Event;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.util.Assert;
@@ -111,7 +111,7 @@ public class Queued extends AbstractServiceDaemon implements EventListener {
 
     /** {@inheritDoc} */
     @Override
-    public void onEvent(Event e) {
+    public void onEvent(IEvent e) {
         String fileList = EventUtils.getParm(e, EventConstants.PARM_FILES_TO_PROMOTE);
         Set<String> files = commaDelimitedListToSet(fileList);
 

--- a/opennms-services/src/main/java/org/opennms/netmgt/rtc/BroadcastEventProcessor.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/rtc/BroadcastEventProcessor.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2002-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2002-2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -37,7 +37,7 @@ import org.opennms.netmgt.config.RTCConfigFactory;
 import org.opennms.netmgt.events.api.EventConstants;
 import org.opennms.netmgt.events.api.annotations.EventListener;
 import org.opennms.netmgt.events.api.annotations.EventHandler;
-import org.opennms.netmgt.xml.event.Event;
+import org.opennms.netmgt.events.api.model.IEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.InitializingBean;
@@ -92,7 +92,7 @@ public class BroadcastEventProcessor implements InitializingBean {
         // add the asset info changed event
         EventConstants.ASSET_INFO_CHANGED_EVENT_UEI
     })
-    public void onEvent(Event event) {
+    public void onEvent(IEvent event) {
         if (event == null) {
             return;
         }

--- a/opennms-services/src/main/java/org/opennms/netmgt/rtc/DataSender.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/rtc/DataSender.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2002-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2002-2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -54,11 +54,11 @@ import org.opennms.netmgt.config.RTCConfigFactory;
 import org.opennms.netmgt.events.api.EventConstants;
 import org.opennms.netmgt.events.api.annotations.EventHandler;
 import org.opennms.netmgt.events.api.annotations.EventListener;
+import org.opennms.netmgt.events.api.model.IEvent;
+import org.opennms.netmgt.events.api.model.IParm;
+import org.opennms.netmgt.events.api.model.IValue;
 import org.opennms.netmgt.rtc.datablock.HttpPostInfo;
 import org.opennms.netmgt.rtc.datablock.RTCCategory;
-import org.opennms.netmgt.xml.event.Event;
-import org.opennms.netmgt.xml.event.Parm;
-import org.opennms.netmgt.xml.event.Value;
 import org.opennms.netmgt.xml.rtc.EuiLevel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -412,9 +412,9 @@ public class DataSender implements Fiber {
      * Inform the data sender of the new listener
      */
     @EventHandler(uei=EventConstants.RTC_SUBSCRIBE_EVENT_UEI)
-    public void handleRtcSubscribe(Event event) {
+    public void handleRtcSubscribe(IEvent event) {
 
-        List<Parm> list = event.getParmCollection();
+        List<IParm> list = event.getParmCollection();
         if (list == null) {
             LOG.warn("{} ignored - info incomplete (null event parms)", event.getUei());
             return;
@@ -426,10 +426,10 @@ public class DataSender implements Fiber {
         String passwd = null;
 
         String parmName = null;
-        Value parmValue = null;
+        IValue parmValue = null;
         String parmContent = null;
 
-        for (Parm parm : list) {
+        for (IParm parm : list) {
             parmName = parm.getParmName();
             parmValue = parm.getValue();
             if (parmValue == null)
@@ -471,9 +471,9 @@ public class DataSender implements Fiber {
      * Inform the data sender of the listener unsubscribing
      */
     @EventHandler(uei=EventConstants.RTC_UNSUBSCRIBE_EVENT_UEI)
-    public void handleRtcUnsubscribe(Event event) {
+    public void handleRtcUnsubscribe(IEvent event) {
 
-        List<Parm> list = event.getParmCollection();
+        List<IParm> list = event.getParmCollection();
         if (list == null) {
             LOG.warn("{} ignored - info incomplete (null event parms)", event.getUei());
             return;
@@ -482,10 +482,10 @@ public class DataSender implements Fiber {
         String url = null;
 
         String parmName = null;
-        Value parmValue = null;
+        IValue parmValue = null;
         String parmContent = null;
 
-        for (Parm parm : list) {
+        for (IParm parm : list) {
             parmName = parm.getParmName();
             parmValue = parm.getValue();
             if (parmValue == null)

--- a/opennms-services/src/main/java/org/opennms/netmgt/rtc/DataUpdater.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/rtc/DataUpdater.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2002-2015 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2015 The OpenNMS Group, Inc.
+ * Copyright (C) 2002-2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -35,9 +35,9 @@ import java.util.Map;
 import org.opennms.core.logging.Logging;
 import org.opennms.core.utils.InetAddressUtils;
 import org.opennms.netmgt.events.api.EventConstants;
-import org.opennms.netmgt.xml.event.Event;
-import org.opennms.netmgt.xml.event.Parm;
-import org.opennms.netmgt.xml.event.Value;
+import org.opennms.netmgt.events.api.model.IEvent;
+import org.opennms.netmgt.events.api.model.IParm;
+import org.opennms.netmgt.events.api.model.IValue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -56,7 +56,7 @@ final class DataUpdater implements Runnable {
     /**
      * The event from which data is to be read
      */
-    private final Event m_event;
+    private final IEvent m_event;
 	private final DataManager m_dataManager;
 
     /**
@@ -127,7 +127,7 @@ final class DataUpdater implements Runnable {
     /**
      * Record the interfaceReparented info in the datastore
      */
-    private void handleInterfaceReparented(InetAddress ip, List<Parm> list) {
+    private void handleInterfaceReparented(InetAddress ip, List<IParm> list) {
 
         if (ip == null || list == null) {
             LOG.warn("{} ignored - info incomplete - ip/parms: {}/{}", m_event.getUei(), InetAddressUtils.str(ip), list);
@@ -141,10 +141,10 @@ final class DataUpdater implements Runnable {
         int newNodeId = -1;
 
         String parmName = null;
-        Value parmValue = null;
+        IValue parmValue = null;
         String parmContent = null;
 
-        for (Parm parm : list) {
+        for (IParm parm : list) {
             parmName = parm.getParmName();
             parmValue = parm.getValue();
             if (parmValue == null)
@@ -281,9 +281,9 @@ final class DataUpdater implements Runnable {
      * Constructs the DataUpdater object
      * @param dataManager 
      *
-     * @param event a {@link org.opennms.netmgt.xml.event.Event} object.
+     * @param event a {@link org.opennms.netmgt.events.api.model.IEvent} object.
      */
-    public DataUpdater(DataManager dataManager, Event event) {
+    public DataUpdater(DataManager dataManager, IEvent event) {
     	m_dataManager = dataManager;
         m_event = event;
     }

--- a/opennms-services/src/main/java/org/opennms/netmgt/scriptd/BroadcastEventProcessor.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/scriptd/BroadcastEventProcessor.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2002-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2002-2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -30,7 +30,7 @@ package org.opennms.netmgt.scriptd;
 
 import org.opennms.netmgt.events.api.EventIpcManagerFactory;
 import org.opennms.netmgt.events.api.EventListener;
-import org.opennms.netmgt.xml.event.Event;
+import org.opennms.netmgt.events.api.model.IEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -83,7 +83,7 @@ final class BroadcastEventProcessor implements AutoCloseable, EventListener {
      * Executor.
      */
     @Override
-    public void onEvent(Event event) {
+    public void onEvent(IEvent event) {
         if (event == null) {
             return;
         }

--- a/opennms-services/src/main/java/org/opennms/netmgt/scriptd/Executor.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/scriptd/Executor.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2003-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2003-2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -51,10 +51,10 @@ import org.opennms.netmgt.config.scriptd.Uei;
 import org.opennms.netmgt.dao.api.NodeDao;
 import org.opennms.netmgt.dao.api.SessionUtils;
 import org.opennms.netmgt.events.api.EventConstants;
+import org.opennms.netmgt.events.api.model.IEvent;
+import org.opennms.netmgt.events.api.model.IParm;
+import org.opennms.netmgt.events.api.model.IScript;
 import org.opennms.netmgt.model.OnmsNode;
-import org.opennms.netmgt.xml.event.Event;
-import org.opennms.netmgt.xml.event.Parm;
-import org.opennms.netmgt.xml.event.Script;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -162,15 +162,15 @@ public class Executor {
         }
     }
 
-    public void addTask(Event event) {
+    public void addTask(IEvent event) {
         m_executorService.execute(new ScriptdRunnable(event));
     }
 
     private class ScriptdRunnable implements Runnable {
 
-        private final Event m_event;
+        private final IEvent m_event;
 
-        public ScriptdRunnable(Event event) {
+        public ScriptdRunnable(IEvent event) {
             m_event = event;
         }
 
@@ -221,9 +221,9 @@ public class Executor {
         } // end run
     }
 
-    private void executeEventScripts(Event m_event) {
+    private void executeEventScripts(IEvent m_event) {
 
-        Script[] attachedScripts = m_event.getScript();
+        IScript[] attachedScripts = m_event.getScript();
 
         Set<EventScript> mapScripts = null;
 
@@ -252,7 +252,7 @@ public class Executor {
 
             LOG.debug("Executing attached scripts");
             if (attachedScripts.length > 0) {
-                for (final Script script : attachedScripts) {
+                for (final IScript script : attachedScripts) {
                     try {
                         m_scriptManager.exec(script.getLanguage(), "", 0, 0, script.getContent());
                     } catch (BSFException e) {
@@ -305,13 +305,13 @@ public class Executor {
     }
 
 
-    private static boolean isReloadConfigEvent(Event event) {
+    private static boolean isReloadConfigEvent(IEvent event) {
         boolean isTarget = false;
         
         if (EventConstants.RELOAD_DAEMON_CONFIG_UEI.equals(event.getUei())) {
-            List<Parm> parmCollection = event.getParmCollection();
+            List<IParm> parmCollection = event.getParmCollection();
             
-            for (Parm parm : parmCollection) {
+            for (IParm parm : parmCollection) {
                 if (EventConstants.PARM_DAEMON_NAME.equals(parm.getParmName()) && "Scriptd".equalsIgnoreCase(parm.getValue().getContent())) {
                     isTarget = true;
                     break;

--- a/opennms-services/src/main/java/org/opennms/netmgt/snmpinterfacepoller/SnmpPoller.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/snmpinterfacepoller/SnmpPoller.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2009-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2009-2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -38,14 +38,14 @@ import org.opennms.netmgt.daemon.AbstractServiceDaemon;
 import org.opennms.netmgt.events.api.EventConstants;
 import org.opennms.netmgt.events.api.annotations.EventHandler;
 import org.opennms.netmgt.events.api.annotations.EventListener;
+import org.opennms.netmgt.events.api.model.IEvent;
+import org.opennms.netmgt.events.api.model.IParm;
 import org.opennms.netmgt.model.OnmsIpInterface;
 import org.opennms.netmgt.scheduler.LegacyScheduler;
 import org.opennms.netmgt.scheduler.Scheduler;
 import org.opennms.netmgt.snmpinterfacepoller.pollable.PollableInterface;
 import org.opennms.netmgt.snmpinterfacepoller.pollable.PollableNetwork;
 import org.opennms.netmgt.snmpinterfacepoller.pollable.PollableSnmpInterface;
-import org.opennms.netmgt.xml.event.Event;
-import org.opennms.netmgt.xml.event.Parm;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -331,10 +331,10 @@ public class SnmpPoller extends AbstractServiceDaemon {
     /**
      * <p>reloadSnmpConfig</p>
      *
-     * @param event a {@link org.opennms.netmgt.xml.event.Event} object.
+     * @param event a {@link org.opennms.netmgt.events.api.model.IEvent} object.
      */
     @EventHandler(uei = EventConstants.CONFIGURE_SNMP_EVENT_UEI)
-    public void reloadSnmpConfig(Event event) {
+    public void reloadSnmpConfig(IEvent event) {
         LOG.debug("reloadSnmpConfig: managing event: {}", event.getUei());
         try {
             Thread.sleep(5000);
@@ -372,10 +372,10 @@ public class SnmpPoller extends AbstractServiceDaemon {
     /**
      * <p>reloadConfig</p>
      *
-     * @param event a {@link org.opennms.netmgt.xml.event.Event} object.
+     * @param event a {@link org.opennms.netmgt.events.api.model.IEvent} object.
      */
     @EventHandler(uei = EventConstants.SNMPPOLLERCONFIG_CHANGED_EVENT_UEI)
-    public void reloadConfig(Event event) {
+    public void reloadConfig(IEvent event) {
         LOG.debug("reloadConfig: managing event: {}", event.getUei());
         try {
             getPollerConfig().update();
@@ -389,15 +389,15 @@ public class SnmpPoller extends AbstractServiceDaemon {
     /**
      * <p>primarychangeHandler</p>
      *
-     * @param event a {@link org.opennms.netmgt.xml.event.Event} object.
+     * @param event a {@link org.opennms.netmgt.events.api.model.IEvent} object.
      */
     @EventHandler(uei = EventConstants.PRIMARY_SNMP_INTERFACE_CHANGED_EVENT_UEI)
-    public void primarychangeHandler(Event event) {
+    public void primarychangeHandler(IEvent event) {
         LOG.debug("primarychangeHandler: managing event: {}", event.getUei());
 
         getNetwork().delete(Long.valueOf(event.getNodeid()).intValue());
         
-        for (Parm parm : event.getParmCollection()){
+        for (IParm parm : event.getParmCollection()){
             if (parm.isValid() && parm.getParmName().equals("newPrimarySnmpAddress")) {
                 scheduleNewSnmpInterface(parm.getValue().getContent());
                 return;
@@ -408,50 +408,50 @@ public class SnmpPoller extends AbstractServiceDaemon {
     /**
      * <p>deleteInterfaceHaldler</p>
      *
-     * @param event a {@link org.opennms.netmgt.xml.event.Event} object.
+     * @param event a {@link org.opennms.netmgt.events.api.model.IEvent} object.
      */
     @EventHandler(uei = EventConstants.DELETE_INTERFACE_EVENT_UEI)
-    public void deleteInterfaceHaldler(Event event){
+    public void deleteInterfaceHaldler(IEvent event){
         getNetwork().delete(event.getInterface());
     }
 
     /**
      * <p>scanCompletedHaldler</p>
      *
-     * @param event a {@link org.opennms.netmgt.xml.event.Event} object.
+     * @param event a {@link org.opennms.netmgt.events.api.model.IEvent} object.
      */
     @EventHandler(uei = EventConstants.PROVISION_SCAN_COMPLETE_UEI)
-    public void scanCompletedHaldler(Event event){
+    public void scanCompletedHaldler(IEvent event){
         getNetwork().refresh(Long.valueOf(event.getNodeid()).intValue());
     }
 
     /**
      * <p>rescanCompletedHaldler</p>
      *
-     * @param event a {@link org.opennms.netmgt.xml.event.Event} object.
+     * @param event a {@link org.opennms.netmgt.events.api.model.IEvent} object.
      */
     @EventHandler(uei = EventConstants.RESCAN_COMPLETED_EVENT_UEI)
-    public void rescanCompletedHaldler(Event event){
+    public void rescanCompletedHaldler(IEvent event){
         getNetwork().refresh(Long.valueOf(event.getNodeid()).intValue());
     }
 
     /**
      * <p>nodeDeletedHandler</p>
      *
-     * @param event a {@link org.opennms.netmgt.xml.event.Event} object.
+     * @param event a {@link org.opennms.netmgt.events.api.model.IEvent} object.
      */
     @EventHandler(uei = EventConstants.NODE_DELETED_EVENT_UEI)
-    public void nodeDeletedHandler(Event event) {
+    public void nodeDeletedHandler(IEvent event) {
         getNetwork().delete(Long.valueOf(event.getNodeid()).intValue());
     }
 
     /**
      * <p>serviceGainedHandler</p>
      *
-     * @param event a {@link org.opennms.netmgt.xml.event.Event} object.
+     * @param event a {@link org.opennms.netmgt.events.api.model.IEvent} object.
      */
     @EventHandler(uei = EventConstants.NODE_GAINED_SERVICE_EVENT_UEI)
-    public void serviceGainedHandler(Event event) {
+    public void serviceGainedHandler(IEvent event) {
         if (event.getService().equals(getPollerConfig().getService())) {
             getPollerConfig().rebuildPackageIpListMap();
             scheduleNewSnmpInterface(event.getInterface());
@@ -461,10 +461,10 @@ public class SnmpPoller extends AbstractServiceDaemon {
     /**
      * <p>serviceDownHandler</p>
      *
-     * @param event a {@link org.opennms.netmgt.xml.event.Event} object.
+     * @param event a {@link org.opennms.netmgt.events.api.model.IEvent} object.
      */
     @EventHandler(uei = EventConstants.NODE_LOST_SERVICE_EVENT_UEI)
-    public void serviceDownHandler(Event event) {
+    public void serviceDownHandler(IEvent event) {
         String service = event.getService();
         String[] criticalServices = getPollerConfig().getCriticalServiceIds();
         for (int i = 0; i< criticalServices.length ; i++) {
@@ -478,10 +478,10 @@ public class SnmpPoller extends AbstractServiceDaemon {
     /**
      * <p>serviceUpHandler</p>
      *
-     * @param event a {@link org.opennms.netmgt.xml.event.Event} object.
+     * @param event a {@link org.opennms.netmgt.events.api.model.IEvent} object.
      */
     @EventHandler(uei = EventConstants.NODE_REGAINED_SERVICE_EVENT_UEI)
-    public void serviceUpHandler(Event event) {
+    public void serviceUpHandler(IEvent event) {
         String service = event.getService();
         String[] criticalServices = getPollerConfig().getCriticalServiceIds();
         for (int i = 0; i< criticalServices.length ; i++) {
@@ -496,30 +496,30 @@ public class SnmpPoller extends AbstractServiceDaemon {
     /**
      * <p>interfaceUpHandler</p>
      *
-     * @param event a {@link org.opennms.netmgt.xml.event.Event} object.
+     * @param event a {@link org.opennms.netmgt.events.api.model.IEvent} object.
      */
     @EventHandler(uei = EventConstants.INTERFACE_UP_EVENT_UEI)
-    public void interfaceUpHandler(Event event) {
+    public void interfaceUpHandler(IEvent event) {
         getNetwork().activate(event.getInterface());
     }
 
     /**
      * <p>interfaceDownHandler</p>
      *
-     * @param event a {@link org.opennms.netmgt.xml.event.Event} object.
+     * @param event a {@link org.opennms.netmgt.events.api.model.IEvent} object.
      */
     @EventHandler(uei = EventConstants.INTERFACE_DOWN_EVENT_UEI)
-    public void interfaceDownHandler(Event event) {
+    public void interfaceDownHandler(IEvent event) {
         getNetwork().suspend(event.getInterface());
     }
 
     /**
      * <p>nodeUpHandler</p>
      *
-     * @param event a {@link org.opennms.netmgt.xml.event.Event} object.
+     * @param event a {@link org.opennms.netmgt.events.api.model.IEvent} object.
      */
     @EventHandler(uei = EventConstants.NODE_UP_EVENT_UEI)
-    public void nodeUpHandler(Event event) {
+    public void nodeUpHandler(IEvent event) {
         getNetwork().activate(Long.valueOf(event.getNodeid()).intValue());
 
     }
@@ -527,10 +527,10 @@ public class SnmpPoller extends AbstractServiceDaemon {
     /**
      * <p>nodeDownHandler</p>
      *
-     * @param event a {@link org.opennms.netmgt.xml.event.Event} object.
+     * @param event a {@link org.opennms.netmgt.events.api.model.IEvent} object.
      */
     @EventHandler(uei = EventConstants.NODE_DOWN_EVENT_UEI)
-    public void nodeDownHandler(Event event) {
+    public void nodeDownHandler(IEvent event) {
         getNetwork().suspend(Long.valueOf(event.getNodeid()).intValue());
     }
 

--- a/opennms-services/src/main/java/org/opennms/netmgt/statsd/Statsd.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/statsd/Statsd.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2007-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2007-2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -37,11 +37,11 @@ import org.opennms.netmgt.events.api.EventConstants;
 import org.opennms.netmgt.events.api.EventForwarder;
 import org.opennms.netmgt.events.api.annotations.EventHandler;
 import org.opennms.netmgt.events.api.annotations.EventListener;
+import org.opennms.netmgt.events.api.model.IEvent;
 import org.opennms.netmgt.filter.api.FilterDao;
 import org.opennms.netmgt.measurements.api.MeasurementFetchStrategy;
 import org.opennms.netmgt.model.events.EventBuilder;
 import org.opennms.netmgt.model.events.EventUtils;
-import org.opennms.netmgt.xml.event.Event;
 import org.quartz.JobDetail;
 import org.quartz.JobKey;
 import org.quartz.Scheduler;
@@ -100,7 +100,7 @@ public class Statsd implements SpringServiceDaemon {
      * @param e a {@link org.opennms.netmgt.xml.event.Event} object.
      */
     @EventHandler(uei=EventConstants.RELOAD_DAEMON_CONFIG_UEI)
-    public void handleReloadConfigEvent(Event e) {
+    public void handleReloadConfigEvent(IEvent e) {
         
         if (isReloadConfigEventTarget(e)) {
             LOG.info("handleReloadConfigEvent: reloading configuration...");
@@ -133,7 +133,7 @@ public class Statsd implements SpringServiceDaemon {
         
     }
     
-    private boolean isReloadConfigEventTarget(Event event) {
+    private boolean isReloadConfigEventTarget(IEvent event) {
         boolean isTarget = false;
         
         if ("Statsd".equalsIgnoreCase(EventUtils.getParm(event, EventConstants.PARM_DAEMON_NAME))) {

--- a/opennms-services/src/main/java/org/opennms/netmgt/tl1d/Tl1d.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/tl1d/Tl1d.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2008-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2008-2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -43,9 +43,9 @@ import org.opennms.netmgt.events.api.EventConstants;
 import org.opennms.netmgt.events.api.EventForwarder;
 import org.opennms.netmgt.events.api.annotations.EventHandler;
 import org.opennms.netmgt.events.api.annotations.EventListener;
+import org.opennms.netmgt.events.api.model.IEvent;
+import org.opennms.netmgt.events.api.model.IParm;
 import org.opennms.netmgt.model.events.EventBuilder;
-import org.opennms.netmgt.xml.event.Event;
-import org.opennms.netmgt.xml.event.Parm;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -86,7 +86,7 @@ public class Tl1d extends AbstractServiceDaemon {
      * @param e a {@link org.opennms.netmgt.xml.event.Event} object.
      */
     @EventHandler(uei=EventConstants.RELOAD_DAEMON_CONFIG_UEI)
-    public void handleRelooadConfigurationEvent(Event e) {
+    public void handleRelooadConfigurationEvent(IEvent e) {
         
 
         if (isReloadConfigEventTarget(e)) {
@@ -128,12 +128,12 @@ public class Tl1d extends AbstractServiceDaemon {
         }
     }
     
-    private boolean isReloadConfigEventTarget(Event event) {
+    private boolean isReloadConfigEventTarget(IEvent event) {
         boolean isTarget = false;
         
-        List<Parm> parmCollection = event.getParmCollection();
+        List<IParm> parmCollection = event.getParmCollection();
 
-        for (Parm parm : parmCollection) {
+        for (IParm parm : parmCollection) {
             if (EventConstants.PARM_DAEMON_NAME.equals(parm.getParmName()) && "Tl1d".equalsIgnoreCase(parm.getValue().getContent())) {
                 isTarget = true;
                 break;

--- a/opennms-services/src/main/java/org/opennms/netmgt/translator/EventTranslator.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/translator/EventTranslator.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2002-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2002-2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -38,12 +38,10 @@ import org.opennms.netmgt.daemon.AbstractServiceDaemon;
 import org.opennms.netmgt.events.api.EventConstants;
 import org.opennms.netmgt.events.api.EventIpcManager;
 import org.opennms.netmgt.events.api.EventListener;
+import org.opennms.netmgt.events.api.model.IEvent;
 import org.opennms.netmgt.model.events.EventBuilder;
 import org.opennms.netmgt.model.events.EventUtils;
-import org.opennms.netmgt.xml.event.Event;
-import org.opennms.netmgt.xml.event.Events;
-import org.opennms.netmgt.xml.event.Log;
-import org.opennms.netmgt.xml.event.Parm;
+import org.opennms.netmgt.xml.event.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -144,7 +142,8 @@ public class EventTranslator extends AbstractServiceDaemon implements EventListe
 
     /** {@inheritDoc} */
     @Override
-    public void onEvent(Event e) {
+    public void onEvent(IEvent ie) {
+        Event e = Event.copyFrom(ie);
         if (isReloadConfigEvent(e)) {
             handleReloadEvent(e);
             return;

--- a/opennms-services/src/main/java/org/opennms/netmgt/vacuumd/Vacuumd.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/vacuumd/Vacuumd.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2004-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2004-2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -50,12 +50,12 @@ import org.opennms.netmgt.daemon.AbstractServiceDaemon;
 import org.opennms.netmgt.events.api.EventConstants;
 import org.opennms.netmgt.events.api.EventIpcManager;
 import org.opennms.netmgt.events.api.EventListener;
+import org.opennms.netmgt.events.api.model.IEvent;
+import org.opennms.netmgt.events.api.model.IParm;
 import org.opennms.netmgt.model.events.EventBuilder;
 import org.opennms.netmgt.scheduler.LegacyScheduler;
 import org.opennms.netmgt.scheduler.Schedule;
 import org.opennms.netmgt.scheduler.Scheduler;
-import org.opennms.netmgt.xml.event.Event;
-import org.opennms.netmgt.xml.event.Parm;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -349,8 +349,8 @@ public class Vacuumd extends AbstractServiceDaemon implements Runnable, EventLis
 
     /** {@inheritDoc} */
     @Override
-    public void onEvent(Event event) {
-        
+    public void onEvent(IEvent event) {
+
         if (isReloadConfigEvent(event)) {
             handleReloadConifgEvent();
         }
@@ -403,13 +403,13 @@ public class Vacuumd extends AbstractServiceDaemon implements Runnable, EventLis
         }
     }
 
-    private boolean isReloadConfigEvent(Event event) {
+    private boolean isReloadConfigEvent(IEvent event) {
         boolean isTarget = false;
         
         if (EventConstants.RELOAD_DAEMON_CONFIG_UEI.equals(event.getUei())) {
-            List<Parm> parmCollection = event.getParmCollection();
+            List<IParm> parmCollection = event.getParmCollection();
             
-            for (Parm parm : parmCollection) {
+            for (IParm parm : parmCollection) {
                 if (EventConstants.PARM_DAEMON_NAME.equals(parm.getParmName()) && "Vacuumd".equalsIgnoreCase(parm.getValue().getContent())) {
                     isTarget = true;
                     break;

--- a/opennms-services/src/test/java/org/opennms/netmgt/collectd/CollectdEventHandlingTest.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/collectd/CollectdEventHandlingTest.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2017-2017 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
+ * Copyright (C) 2017-2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -37,6 +37,7 @@ import org.junit.Test;
 import org.opennms.core.utils.InetAddressUtils;
 import org.opennms.netmgt.dao.mock.MockTransactionTemplate;
 import org.opennms.netmgt.events.api.EventConstants;
+import org.opennms.netmgt.events.api.model.ImmutableMapper;
 import org.opennms.netmgt.model.OnmsIpInterface;
 import org.opennms.netmgt.model.OnmsNode;
 import org.opennms.netmgt.model.events.EventBuilder;
@@ -82,7 +83,7 @@ public class CollectdEventHandlingTest {
         Event e = new EventBuilder(EventConstants.NODE_DELETED_EVENT_UEI, "test")
                 .setNodeid(svc1.getNodeId())
                 .getEvent();
-        collectd.onEvent(e);
+        collectd.onEvent(ImmutableMapper.fromMutableEvent(e));
 
         // The delete flag should be set (and only set) on svc1
         assertTrue("deletion flag was not set on svc1!", svc1.getCollectorUpdates().isDeletionFlagSet());
@@ -103,7 +104,7 @@ public class CollectdEventHandlingTest {
         Event e = new EventBuilder(EventConstants.INTERFACE_DELETED_EVENT_UEI, "test")
                 .setIpInterface(iface)
                 .getEvent();
-        collectd.onEvent(e);
+        collectd.onEvent(ImmutableMapper.fromMutableEvent(e));
 
         // The delete flag should be set (and only set) on svc1
         assertTrue("deletion flag was not set on svc1!", svc1.getCollectorUpdates().isDeletionFlagSet());
@@ -125,7 +126,7 @@ public class CollectdEventHandlingTest {
                 .setIpInterface(iface)
                 .setService(svc2.getServiceName())
                 .getEvent();
-        collectd.onEvent(e);
+        collectd.onEvent(ImmutableMapper.fromMutableEvent(e));
 
         // The delete flag should be set (and only set) on svc2
         assertFalse("deletion flag was set on svc1!", svc1.getCollectorUpdates().isDeletionFlagSet());

--- a/opennms-services/src/test/java/org/opennms/netmgt/collectd/CollectdIntegrationTest.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/collectd/CollectdIntegrationTest.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2007-2017 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
+ * Copyright (C) 2007-2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -68,6 +68,7 @@ import org.opennms.netmgt.dao.mock.MockTransactionTemplate;
 import org.opennms.netmgt.events.api.EventConstants;
 import org.opennms.netmgt.events.api.EventIpcManager;
 import org.opennms.netmgt.events.api.EventIpcManagerFactory;
+import org.opennms.netmgt.events.api.model.ImmutableMapper;
 import org.opennms.netmgt.filter.FilterDaoFactory;
 import org.opennms.netmgt.filter.api.FilterDao;
 import org.opennms.netmgt.mock.MockPersisterFactory;
@@ -250,7 +251,7 @@ public class CollectdIntegrationTest {
         bldr.setInterface(addr("192.168.1.1"));
         bldr.setService("SNMP");
 
-        m_collectd.onEvent(bldr.getEvent());
+        m_collectd.onEvent(ImmutableMapper.fromMutableEvent(bldr.getEvent()));
         
         Thread.sleep(2000);
         

--- a/opennms-services/src/test/java/org/opennms/netmgt/collectd/DuplicatePrimaryAddressIT.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/collectd/DuplicatePrimaryAddressIT.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2019 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ * Copyright (C) 2014-2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -64,6 +64,7 @@ import org.opennms.netmgt.dao.mock.MockTransactionTemplate;
 import org.opennms.netmgt.events.api.EventConstants;
 import org.opennms.netmgt.events.api.EventIpcManager;
 import org.opennms.netmgt.events.api.EventIpcManagerFactory;
+import org.opennms.netmgt.events.api.model.ImmutableMapper;
 import org.opennms.netmgt.filter.FilterDaoFactory;
 import org.opennms.netmgt.filter.api.FilterDao;
 import org.opennms.netmgt.mock.MockPersisterFactory;
@@ -163,14 +164,14 @@ public class DuplicatePrimaryAddressIT {
         // Emulate Provisiond events for node1
         nodeGained.setNodeid(1);
         reinitialize.setNodeid(1);
-        m_collectd.onEvent(nodeGained.getEvent());
-        m_collectd.onEvent(reinitialize.getEvent());
+        m_collectd.onEvent(ImmutableMapper.fromMutableEvent(nodeGained.getEvent()));
+        m_collectd.onEvent(ImmutableMapper.fromMutableEvent(reinitialize.getEvent()));
 
         // Emulate Provisiond events for node3
         nodeGained.setNodeid(3);
         reinitialize.setNodeid(3);
-        m_collectd.onEvent(nodeGained.getEvent());
-        m_collectd.onEvent(reinitialize.getEvent());
+        m_collectd.onEvent(ImmutableMapper.fromMutableEvent(nodeGained.getEvent()));
+        m_collectd.onEvent(ImmutableMapper.fromMutableEvent(reinitialize.getEvent()));
 
         verify();
     }

--- a/opennms-services/src/test/java/org/opennms/netmgt/mock/MockNetworkTest.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/mock/MockNetworkTest.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2004-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2004-2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -42,6 +42,7 @@ import org.opennms.netmgt.dao.mock.EventAnticipator;
 import org.opennms.netmgt.dao.mock.MockEventIpcManager;
 import org.opennms.netmgt.events.api.EventConstants;
 import org.opennms.netmgt.events.api.EventListener;
+import org.opennms.netmgt.events.api.model.IEvent;
 import org.opennms.netmgt.model.events.EventUtils;
 import org.opennms.netmgt.poller.MonitoredService;
 import org.opennms.netmgt.poller.PollStatus;
@@ -288,19 +289,19 @@ public class MockNetworkTest extends TestCase {
         Event sentEvent2 = MockEventUtil.createEvent("Test", EventConstants.NODE_REGAINED_SERVICE_EVENT_UEI, 1, "192.168.1.1", "NEW", null);
 
         class MockListener implements EventListener {
-            private Event receivedEvent;
+            private IEvent receivedEvent;
 
             @Override
             public String getName() {
                 return "MockListener";
             }
 
-            public Event getReceivedEvent() {
+            public IEvent getReceivedEvent() {
                 return receivedEvent;
             }
 
             @Override
-            public void onEvent(Event event) {
+            public void onEvent(IEvent event) {
                 System.err.println("onEvent: " + event.getUei());
                 receivedEvent = event;
             }
@@ -314,11 +315,13 @@ public class MockNetworkTest extends TestCase {
 
         m_eventMgr.addEventListener(listener, EventConstants.NODE_GAINED_SERVICE_EVENT_UEI);
         m_eventMgr.sendEventToListeners(sentEvent);
-        assertTrue(EventUtils.eventsMatch(sentEvent, listener.getReceivedEvent()));
+        assertTrue(EventUtils.eventsMatch(sentEvent, listener.getReceivedEvent() == null ? null :
+                Event.copyFrom(listener.getReceivedEvent())));
 
         listener.reset();
         m_eventMgr.sendEventToListeners(sentEvent2);
-        assertFalse(EventUtils.eventsMatch(sentEvent2, listener.getReceivedEvent()));
+        assertFalse(EventUtils.eventsMatch(sentEvent2, listener.getReceivedEvent() == null ? null :
+                Event.copyFrom(listener.getReceivedEvent())));
 
     }
 

--- a/opennms-services/src/test/java/org/opennms/netmgt/mock/OutageAnticipator.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/mock/OutageAnticipator.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2002-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2002-2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -40,6 +40,7 @@ import java.util.Set;
 import org.opennms.core.test.db.MockDatabase;
 import org.opennms.netmgt.dao.mock.EventWrapper;
 import org.opennms.netmgt.events.api.EventListener;
+import org.opennms.netmgt.events.api.model.IEvent;
 import org.opennms.netmgt.xml.event.Event;
 import org.opennms.test.mock.MockUtil;
 import org.slf4j.Logger;
@@ -256,10 +257,11 @@ public class OutageAnticipator implements EventListener {
     }
 
     /* (non-Javadoc)
-     * @see org.opennms.netmgt.eventd.EventListener#onEvent(org.opennms.netmgt.xml.event.Event)
+     * @see org.opennms.netmgt.eventd.EventListener#onEvent(org.opennms.netmgt.events.api.model.IEvent)
      */
     @Override
-    public synchronized void onEvent(Event e) {
+    public synchronized void onEvent(IEvent ie) {
+        Event e = Event.copyFrom(ie);
         for (Outage outage : getOutageList(m_pendingOpens, e)) {
             outage.setLostEvent(e.getDbid(), new Timestamp(e.getTime().getTime()));
             m_expectedOutages.add(outage);

--- a/opennms-services/src/test/java/org/opennms/netmgt/passive/PassiveStatusKeeperIT.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/passive/PassiveStatusKeeperIT.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2005-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2005-2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -45,6 +45,7 @@ import org.opennms.core.test.db.MockDatabase;
 import org.opennms.core.utils.InetAddressUtils;
 import org.opennms.netmgt.dao.mock.MockEventIpcManager;
 import org.opennms.netmgt.events.api.EventConstants;
+import org.opennms.netmgt.events.api.model.ImmutableMapper;
 import org.opennms.netmgt.mock.MockEventUtil;
 import org.opennms.netmgt.mock.MockNetwork;
 import org.opennms.netmgt.mock.MockService;
@@ -170,7 +171,7 @@ public class PassiveStatusKeeperIT {
     public void testEventWithPassiveStatusParms() {
         Event e = createPassiveStatusEvent("Router", "192.168.1.1", "ICMP", "Down");
 
-        assertTrue(m_psk.isPassiveStatusEvent(e));
+        assertTrue(m_psk.isPassiveStatusEvent(ImmutableMapper.fromMutableEvent(e)));
         
     }
     
@@ -183,15 +184,15 @@ public class PassiveStatusKeeperIT {
     public void testIsPassiveStatusEvent() {
         
         Event e = createPassiveStatusEvent("Router", "192.168.1.1", "ICMP", "Down");
-        assertTrue(m_psk.isPassiveStatusEvent(e));
+        assertTrue(m_psk.isPassiveStatusEvent(ImmutableMapper.fromMutableEvent(e)));
         
         //test for missing required parms
         e = createPassiveStatusEvent("Router", "192.168.1.1", null, "Down");
-        assertFalse(m_psk.isPassiveStatusEvent(e));
+        assertFalse(m_psk.isPassiveStatusEvent(ImmutableMapper.fromMutableEvent(e)));
         
         //this will test the event simply doesn't match a registered uei.
         e.setUei("bogusUei");
-        assertFalse(m_psk.isPassiveStatusEvent(e));
+        assertFalse(m_psk.isPassiveStatusEvent(ImmutableMapper.fromMutableEvent(e)));
                 
     }
     

--- a/opennms-services/src/test/java/org/opennms/netmgt/poller/mock/MockPollContext.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/poller/mock/MockPollContext.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2005-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2005-2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -39,6 +39,7 @@ import org.opennms.core.test.db.MockDatabase;
 import org.opennms.core.utils.InetAddressUtils;
 import org.opennms.netmgt.events.api.EventIpcManager;
 import org.opennms.netmgt.events.api.EventListener;
+import org.opennms.netmgt.events.api.model.ImmutableMapper;
 import org.opennms.netmgt.mock.MockEventUtil;
 import org.opennms.netmgt.mock.MockNetwork;
 import org.opennms.netmgt.mock.MockService;
@@ -49,6 +50,7 @@ import org.opennms.netmgt.poller.pollables.PollContext;
 import org.opennms.netmgt.poller.pollables.PollEvent;
 import org.opennms.netmgt.poller.pollables.PollableService;
 import org.opennms.netmgt.xml.event.Event;
+import org.opennms.netmgt.events.api.model.IEvent;
 import org.opennms.test.mock.MockUtil;
 
 
@@ -106,7 +108,7 @@ public class MockPollContext implements PollContext, EventListener {
     }
     @Override
     public PollEvent sendEvent(Event event) {
-        PendingPollEvent pollEvent = new PendingPollEvent(event);
+        PendingPollEvent pollEvent = new PendingPollEvent(ImmutableMapper.fromMutableEvent(event));
         synchronized (this) {
             m_pendingPollEvents.add(pollEvent);
         }
@@ -184,11 +186,11 @@ public class MockPollContext implements PollContext, EventListener {
     }
 
     @Override
-    public synchronized void onEvent(Event e) {
+    public synchronized void onEvent(IEvent e) {
         synchronized (m_pendingPollEvents) {
             for (PendingPollEvent pollEvent : m_pendingPollEvents) {
                 if (e.equals(pollEvent.getEvent())) {
-                    pollEvent.complete(e);
+                    pollEvent.complete();
                 }
             }
             

--- a/opennms-services/src/test/java/org/opennms/netmgt/poller/mock/MockPollContext.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/poller/mock/MockPollContext.java
@@ -44,6 +44,7 @@ import org.opennms.netmgt.mock.MockEventUtil;
 import org.opennms.netmgt.mock.MockNetwork;
 import org.opennms.netmgt.mock.MockService;
 import org.opennms.netmgt.model.events.EventBuilder;
+import org.opennms.netmgt.model.events.EventUtils;
 import org.opennms.netmgt.poller.PollStatus;
 import org.opennms.netmgt.poller.pollables.PendingPollEvent;
 import org.opennms.netmgt.poller.pollables.PollContext;
@@ -189,7 +190,7 @@ public class MockPollContext implements PollContext, EventListener {
     public synchronized void onEvent(IEvent e) {
         synchronized (m_pendingPollEvents) {
             for (PendingPollEvent pollEvent : m_pendingPollEvents) {
-                if (e.equals(pollEvent.getEvent())) {
+                if (EventUtils.eventsMatch(e, pollEvent.getEvent())) {
                     pollEvent.complete(e);
                 }
             }

--- a/opennms-services/src/test/java/org/opennms/netmgt/poller/mock/MockPollContext.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/poller/mock/MockPollContext.java
@@ -190,7 +190,7 @@ public class MockPollContext implements PollContext, EventListener {
         synchronized (m_pendingPollEvents) {
             for (PendingPollEvent pollEvent : m_pendingPollEvents) {
                 if (e.equals(pollEvent.getEvent())) {
-                    pollEvent.complete();
+                    pollEvent.complete(e);
                 }
             }
             

--- a/opennms-services/src/test/java/org/opennms/netmgt/poller/pollables/PendingPollEventTest.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/poller/pollables/PendingPollEventTest.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2013-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2013-2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -34,6 +34,7 @@ import static org.junit.Assert.assertTrue;
 import java.util.Date;
 
 import org.junit.Test;
+import org.opennms.netmgt.events.api.model.ImmutableMapper;
 import org.opennms.netmgt.model.events.EventBuilder;
 
 public class PendingPollEventTest {
@@ -41,7 +42,7 @@ public class PendingPollEventTest {
     public void testPollEventTimeout() throws Exception {
         final Date d = new Date();
         final EventBuilder eb = new EventBuilder("foo", "bar", d);
-        final PendingPollEvent ppe = new PendingPollEvent(eb.getEvent());
+        final PendingPollEvent ppe = new PendingPollEvent(ImmutableMapper.fromMutableEvent(eb.getEvent()));
         ppe.setExpirationTimeInMillis(Long.MAX_VALUE);
         assertFalse("timedOut should be false: " + ppe.isTimedOut(), ppe.isTimedOut());
         assertTrue("pending should be true: " + ppe.isPending(), ppe.isPending());

--- a/opennms-services/src/test/java/org/opennms/spring/xml/AspectJTest.java
+++ b/opennms-services/src/test/java/org/opennms/spring/xml/AspectJTest.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2007-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2007-2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -37,6 +37,7 @@ import org.opennms.core.spring.BeanUtils;
 import org.opennms.core.test.OpenNMSJUnit4ClassRunner;
 import org.opennms.netmgt.dao.mock.MockEventIpcManager;
 import org.opennms.netmgt.events.api.EventConstants;
+import org.opennms.netmgt.events.api.model.ImmutableMapper;
 import org.opennms.netmgt.model.events.EventBuilder;
 import org.opennms.netmgt.xml.event.Event;
 import org.opennms.test.JUnitConfigurationEnvironment;
@@ -81,7 +82,7 @@ public class AspectJTest implements InitializingBean {
         assertEquals(0, m_interceptor.getPreEventCount());
         assertEquals(0, m_interceptor.getPostEventCount());
         
-        m_handler.handleAnEvent(createEvent(EventConstants.NODE_LOST_SERVICE_EVENT_UEI));
+        m_handler.handleAnEvent(ImmutableMapper.fromMutableEvent(createEvent(EventConstants.NODE_LOST_SERVICE_EVENT_UEI)));
         
         assertEquals(1, m_handler.getHandlerCallCount());
         assertEquals(1, m_interceptor.getPreEventCount());

--- a/opennms-services/src/test/java/org/opennms/spring/xml/AspectJTest.java
+++ b/opennms-services/src/test/java/org/opennms/spring/xml/AspectJTest.java
@@ -82,7 +82,8 @@ public class AspectJTest implements InitializingBean {
         assertEquals(0, m_interceptor.getPreEventCount());
         assertEquals(0, m_interceptor.getPostEventCount());
         
-        m_handler.handleAnEvent(ImmutableMapper.fromMutableEvent(createEvent(EventConstants.NODE_LOST_SERVICE_EVENT_UEI)));
+        m_handler.handleAnEvent(ImmutableMapper.fromMutableEvent(
+                createEvent(EventConstants.NODE_LOST_SERVICE_EVENT_UEI)));
         
         assertEquals(1, m_handler.getHandlerCallCount());
         assertEquals(1, m_interceptor.getPreEventCount());

--- a/opennms-services/src/test/java/org/opennms/spring/xml/AspectJTestEventHandler.java
+++ b/opennms-services/src/test/java/org/opennms/spring/xml/AspectJTestEventHandler.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2002-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2002-2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -31,7 +31,7 @@ package org.opennms.spring.xml;
 import org.opennms.netmgt.events.api.EventConstants;
 import org.opennms.netmgt.events.api.annotations.EventHandler;
 import org.opennms.netmgt.events.api.annotations.EventListener;
-import org.opennms.netmgt.xml.event.Event;
+import org.opennms.netmgt.events.api.model.IEvent;
 
 @EventListener(name="AspectJTestEventHandler")
 public class AspectJTestEventHandler {
@@ -53,7 +53,7 @@ public class AspectJTestEventHandler {
     }
 
     @EventHandler(uei=EventConstants.NODE_LOST_SERVICE_EVENT_UEI)
-    public void handleAnEvent(Event e) throws Throwable {
+    public void handleAnEvent(IEvent e) throws Throwable {
         System.err.println("Received Event "+e.getUei());
         handlerCallCount++;
         if (thrownException != null) {

--- a/opennms-services/src/test/java/org/opennms/spring/xml/AspectJTestEventHandlerInteceptor.java
+++ b/opennms-services/src/test/java/org/opennms/spring/xml/AspectJTestEventHandlerInteceptor.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2007-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2007-2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -32,7 +32,7 @@ import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Pointcut;
-import org.opennms.netmgt.xml.event.Event;
+import org.opennms.netmgt.events.api.model.IEvent;
 import org.springframework.core.Ordered;
 
 /**
@@ -70,7 +70,7 @@ public class AspectJTestEventHandlerInteceptor implements Ordered {
     }
     
     @Around("testEventHandlers() && args(event)")
-    public void onEvent(ProceedingJoinPoint pjp, Event event) throws Throwable {
+    public void onEvent(ProceedingJoinPoint pjp, IEvent event) throws Throwable {
         preEvent(event);
         
         try {
@@ -81,17 +81,17 @@ public class AspectJTestEventHandlerInteceptor implements Ordered {
         }
     }
 
-    private void handleException(Event event, RuntimeException ex) {
+    private void handleException(IEvent event, RuntimeException ex) {
         System.err.println("handleException");
         m_handledExceptionCount++;
     }
 
-    private void postEvent(Event event) {
+    private void postEvent(IEvent event) {
         System.err.println("postEvent");
         m_postEventCount++;
     }
 
-    private void preEvent(Event event) {
+    private void preEvent(IEvent event) {
         System.err.println("preEvent");
         m_preEventCount++;
     }


### PR DESCRIPTION
JIRA: https://issues.opennms.org/browse/NMS-10720

-Update 'EventListener' interface to use make use of the immutable event.
-In many listener implementations, swap out mutable event for the immutable event.
-Fix mapping code for event, alarm data, logmsg, and snmp (the mutable implementations have getters that provide a default value if null).
-Update various unit tests.