### PR TITLE
NMS-12447: Remove getVertexType()

### DIFF
--- a/features/graph/api/src/main/java/org/opennms/netmgt/graph/api/generic/GenericGraph.java
+++ b/features/graph/api/src/main/java/org/opennms/netmgt/graph/api/generic/GenericGraph.java
@@ -67,7 +67,7 @@ public final class GenericGraph extends GenericElement implements ImmutableGraph
 
     // A calculation of the focus
     private final Focus defaultFocus;
-    private final GraphInfo<GenericVertex> graphInfo;
+    private final GraphInfo graphInfo;
 
     private GenericGraph(GenericGraphBuilder builder) {
         super(builder.properties);
@@ -106,11 +106,6 @@ public final class GenericGraph extends GenericElement implements ImmutableGraph
     @Override
     public String getLabel() {
         return graphInfo.getLabel();
-    }
-
-    @Override
-    public Class<GenericVertex> getVertexType() {
-        return GenericVertex.class;
     }
 
     @Override
@@ -489,7 +484,7 @@ public final class GenericGraph extends GenericElement implements ImmutableGraph
         }
     }
     
-    private class GenericGraphInfo implements GraphInfo<GenericVertex> {
+    private class GenericGraphInfo implements GraphInfo {
 
         @Override
         public String getNamespace() {
@@ -504,11 +499,6 @@ public final class GenericGraph extends GenericElement implements ImmutableGraph
         @Override
         public String getLabel() {
             return (String) properties.get(GenericProperties.LABEL);
-        }
-
-        @Override
-        public Class<GenericVertex> getVertexType() {
-            return GenericVertex.class;
         }
 
     }

--- a/features/graph/api/src/main/java/org/opennms/netmgt/graph/api/info/DefaultGraphInfo.java
+++ b/features/graph/api/src/main/java/org/opennms/netmgt/graph/api/info/DefaultGraphInfo.java
@@ -30,8 +30,6 @@ package org.opennms.netmgt.graph.api.info;
 
 import java.util.Objects;
 
-import org.opennms.netmgt.graph.api.Vertex;
-
 import com.google.common.base.MoreObjects;
 
 public class DefaultGraphInfo implements GraphInfo {
@@ -39,22 +37,16 @@ public class DefaultGraphInfo implements GraphInfo {
     private String namespace;
     private String description;
     private String label;
-    private Class<? extends Vertex> vertexType;
 
-    public DefaultGraphInfo(final String namespace, Class<? extends Vertex> vertexType) {
+    public DefaultGraphInfo(final String namespace) {
         this.namespace = Objects.requireNonNull(namespace);
-        this.vertexType = Objects.requireNonNull(vertexType);
-    }
-
-    public DefaultGraphInfo(GraphInfo copy) {
-        this(copy, copy.getVertexType());
     }
 
     /**
      * Constructor to change the vertex Type of the given GraphInfo.
      */
-    public DefaultGraphInfo(GraphInfo copy, Class<? extends Vertex> vertexType) {
-        this(copy.getNamespace(), vertexType);
+    public DefaultGraphInfo(final GraphInfo copy) {
+        this(Objects.requireNonNull(copy).getNamespace());
         setLabel(copy.getLabel());
         setDescription(copy.getDescription());
     }
@@ -72,11 +64,6 @@ public class DefaultGraphInfo implements GraphInfo {
     @Override
     public String getLabel() {
         return label;
-    }
-
-    @Override
-    public Class<? extends Vertex> getVertexType() {
-        return vertexType;
     }
 
     public void setNamespace(String namespace) {
@@ -108,13 +95,12 @@ public class DefaultGraphInfo implements GraphInfo {
         DefaultGraphInfo graphInfo = (DefaultGraphInfo) o;
         return Objects.equals(namespace, graphInfo.namespace)
                 && Objects.equals(description, graphInfo.description)
-                && Objects.equals(label, graphInfo.label)
-                && Objects.equals(vertexType, graphInfo.vertexType);
+                && Objects.equals(label, graphInfo.label);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(namespace, description, label, vertexType);
+        return Objects.hash(namespace, description, label);
     }
 
     @Override

--- a/features/graph/api/src/main/java/org/opennms/netmgt/graph/api/info/GraphInfo.java
+++ b/features/graph/api/src/main/java/org/opennms/netmgt/graph/api/info/GraphInfo.java
@@ -28,15 +28,12 @@
 
 package org.opennms.netmgt.graph.api.info;
 
-import org.opennms.netmgt.graph.api.Vertex;
-
 /**
  * Meta information of a graph.
  * This allows to fetch a minimal set of information (namespace, label, description) without loading the whole graph.
  *
- * @param <V> the vertex type
  */
-public interface GraphInfo<V extends Vertex> {
+public interface GraphInfo {
 
     /** The namespace of the graph. Should be unique over all Graphs */
     String getNamespace();
@@ -49,14 +46,4 @@ public interface GraphInfo<V extends Vertex> {
 
     /** A user friendly name/label of the graph, e.g. "Business Service Graph" */
     String getLabel();
-
-    /**
-     * Returns the parent type of the vertex within the graph.
-     * Vertices in a graph may be of different types, but they should all share the same parent vertex.
-     * The vertex type is also relevant for implementing type safe search or enrichment later on.
-     * see {@link org.opennms.netmgt.graph.api.aware.NodeRefAware} for a concrete example.
-     *
-     * @return The parent type of the vertices within the graph
-     */
-    Class<V> getVertexType();
 }

--- a/features/graph/api/src/main/java/org/opennms/netmgt/graph/api/service/GraphProvider.java
+++ b/features/graph/api/src/main/java/org/opennms/netmgt/graph/api/service/GraphProvider.java
@@ -55,5 +55,5 @@ public interface GraphProvider {
      * graph itself may change (e.g. different vertices/edges and properties (besides the ones defining the info)).
      * @return the meta information of the graph
      */
-    GraphInfo<?> getGraphInfo();
+    GraphInfo getGraphInfo();
 }

--- a/features/graph/api/src/main/java/org/opennms/netmgt/graph/api/updates/ChangeSet.java
+++ b/features/graph/api/src/main/java/org/opennms/netmgt/graph/api/updates/ChangeSet.java
@@ -253,9 +253,7 @@ public final class ChangeSet<G extends ImmutableGraph<V, E>, V extends Vertex, E
 
         private GraphInfo createGraphInfo(G graph) {
             if (graph != null) {
-                final DefaultGraphInfo graphInfo = new DefaultGraphInfo(graph.getNamespace(), graph.getVertexType());
-                graphInfo.setDescription(graph.getDescription());
-                graphInfo.setLabel(graph.getLabel());
+                final DefaultGraphInfo graphInfo = new DefaultGraphInfo(graph);
                 return graphInfo;
             }
             return null;

--- a/features/graph/api/src/test/java/org/opennms/netmgt/graph/api/updates/ChangeSetTest.java
+++ b/features/graph/api/src/test/java/org/opennms/netmgt/graph/api/updates/ChangeSetTest.java
@@ -131,7 +131,7 @@ public class ChangeSetTest {
         assertEquals("e3", changeSet.getEdgesAdded().get(0).getId());
         assertEquals("e1", changeSet.getEdgesRemoved().get(0).getId());
         assertEquals("e2", changeSet.getEdgesUpdated().get(0).getId());
-        assertEquals(new DefaultGraphInfo(NAMESPACE, GenericVertex.class)
+        assertEquals(new DefaultGraphInfo(NAMESPACE)
                 .withDescription("Some Description")
                 .withLabel("Some Label"), changeSet.getGraphInfo());
     }

--- a/features/graph/api/src/test/java/org/opennms/netmgt/graph/api/updates/ContainerChangeSetTest.java
+++ b/features/graph/api/src/test/java/org/opennms/netmgt/graph/api/updates/ContainerChangeSetTest.java
@@ -133,7 +133,7 @@ public class ContainerChangeSetTest {
         assertEquals("1", graphChangeSet.getVerticesRemoved().get(0).getId());
         assertEquals("2", graphChangeSet.getVerticesRemoved().get(1).getId());
         assertEquals("3", graphChangeSet.getVerticesUpdated().get(0).getId());
-        assertEquals(new DefaultGraphInfo(NAMESPACE, GenericVertex.class)
+        assertEquals(new DefaultGraphInfo(NAMESPACE)
                 .withDescription("Some Description")
                 .withLabel("Some Label"), graphChangeSet.getGraphInfo());
     }

--- a/features/graph/domain/src/main/java/org/opennms/netmgt/graph/domain/AbstractDomainGraph.java
+++ b/features/graph/domain/src/main/java/org/opennms/netmgt/graph/domain/AbstractDomainGraph.java
@@ -169,9 +169,6 @@ public abstract class AbstractDomainGraph<V extends AbstractDomainVertex, E exte
     }
 
     @Override
-    public abstract Class getVertexType();
-
-    @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;

--- a/features/graph/domain/src/main/java/org/opennms/netmgt/graph/domain/simple/SimpleDomainGraph.java
+++ b/features/graph/domain/src/main/java/org/opennms/netmgt/graph/domain/simple/SimpleDomainGraph.java
@@ -60,11 +60,6 @@ public final class SimpleDomainGraph extends AbstractDomainGraph<SimpleDomainVer
         return new SimpleDomainGraph(graph);
     }
 
-    @Override
-    public Class getVertexType() {
-        return SimpleDomainVertex.class;
-    }
-    
     public static SimpleDomainGraphBuilder builder() {
         return new SimpleDomainGraphBuilder();
     }

--- a/features/graph/domain/src/test/java/org/opennms/netmgt/graph/domain/simple/SimpleDomainGraphTest.java
+++ b/features/graph/domain/src/test/java/org/opennms/netmgt/graph/domain/simple/SimpleDomainGraphTest.java
@@ -86,14 +86,13 @@ public class SimpleDomainGraphTest {
 
     @Test
     public void simpleGraphShouldBeConstructedFromGraphInfo() {
-        DefaultGraphInfo info = new DefaultGraphInfo(TestObjectCreator.NAMESPACE, SimpleDomainVertex.class);
+        DefaultGraphInfo info = new DefaultGraphInfo(TestObjectCreator.NAMESPACE);
         info.setDescription("description");
         info.setLabel("label");
         SimpleDomainGraph graph = SimpleDomainGraph.builder().graphInfo(info).build();
         assertEquals(info.getNamespace(), graph.getNamespace());
         assertEquals(info.getLabel(), graph.getLabel());
         assertEquals(info.getDescription(), graph.getDescription());
-        assertEquals(info.getVertexType(), graph.getVertexType());
     }
 
 }

--- a/features/graph/provider/application/src/main/java/org/opennms/netmgt/graph/provider/application/ApplicationGraph.java
+++ b/features/graph/provider/application/src/main/java/org/opennms/netmgt/graph/provider/application/ApplicationGraph.java
@@ -56,11 +56,6 @@ public final class ApplicationGraph extends AbstractDomainGraph<ApplicationVerte
         return new ApplicationGraph(graph);
     }
 
-    @Override
-    public Class<ApplicationVertex> getVertexType() {
-        return ApplicationVertex.class;
-    }
-    
     public static ApplicationGraphBuilder builder() {
         return new ApplicationGraphBuilder();
     }

--- a/features/graph/provider/application/src/main/java/org/opennms/netmgt/graph/provider/application/ApplicationGraphProvider.java
+++ b/features/graph/provider/application/src/main/java/org/opennms/netmgt/graph/provider/application/ApplicationGraphProvider.java
@@ -57,8 +57,8 @@ public class ApplicationGraphProvider implements GraphProvider {
     }
 
     @Override
-    public GraphInfo<?> getGraphInfo() {
-        final DefaultGraphInfo graphInfo = new DefaultGraphInfo(ApplicationGraph.NAMESPACE, ApplicationVertex.class);
+    public GraphInfo getGraphInfo() {
+        final DefaultGraphInfo graphInfo = new DefaultGraphInfo(ApplicationGraph.NAMESPACE);
         graphInfo.setLabel(GRAPH_LABEL);
         graphInfo.setDescription(GRAPH_DESCRIPTION);
         return graphInfo;

--- a/features/graph/provider/bsm/src/main/java/org/opennms/netmgt/graph/provider/bsm/BusinessServiceGraph.java
+++ b/features/graph/provider/bsm/src/main/java/org/opennms/netmgt/graph/provider/bsm/BusinessServiceGraph.java
@@ -28,7 +28,6 @@
 
 package org.opennms.netmgt.graph.provider.bsm;
 
-import org.opennms.netmgt.bsm.service.model.BusinessService;
 import org.opennms.netmgt.graph.api.ImmutableGraph;
 import org.opennms.netmgt.graph.api.generic.GenericEdge;
 import org.opennms.netmgt.graph.api.generic.GenericGraph;
@@ -59,11 +58,6 @@ public final class BusinessServiceGraph extends AbstractDomainGraph<BusinessServ
         return new BusinessServiceEdge(edge);
     }
 
-    @Override
-    public Class getVertexType() {
-        return BusinessService.class;
-    }
-    
     public static BusinessServiceGraphBuilder builder() {
         return new BusinessServiceGraphBuilder();
     }

--- a/features/graph/provider/bsm/src/main/java/org/opennms/netmgt/graph/provider/bsm/BusinessServiceGraphProvider.java
+++ b/features/graph/provider/bsm/src/main/java/org/opennms/netmgt/graph/provider/bsm/BusinessServiceGraphProvider.java
@@ -51,7 +51,6 @@ import org.opennms.netmgt.graph.api.service.GraphContainerCache;
 import org.opennms.netmgt.graph.api.service.GraphProvider;
 import org.opennms.netmgt.graph.provider.bsm.BusinessServiceGraph.BusinessServiceGraphBuilder;
 import org.opennms.netmgt.model.events.EventUtils;
-import org.opennms.netmgt.xml.event.Event;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
@@ -91,8 +90,8 @@ public class BusinessServiceGraphProvider implements GraphProvider, EventListene
     }
 
     @Override
-    public GraphInfo<?> getGraphInfo() {
-        final DefaultGraphInfo graphInfo = new DefaultGraphInfo(BusinessServiceGraph.NAMESPACE, BusinessServiceVertex.class);
+    public GraphInfo getGraphInfo() {
+        final DefaultGraphInfo graphInfo = new DefaultGraphInfo(BusinessServiceGraph.NAMESPACE);
         graphInfo.setLabel("Business Service Graph"); // Business Services
         graphInfo.setDescription("Displays the hierarchy of the defined Business Services and their computed operational states.");
         return graphInfo;

--- a/features/graph/provider/legacy/src/main/java/org/opennms/netmgt/graph/provider/legacy/LegacyGraph.java
+++ b/features/graph/provider/legacy/src/main/java/org/opennms/netmgt/graph/provider/legacy/LegacyGraph.java
@@ -55,8 +55,4 @@ public class LegacyGraph extends AbstractDomainGraph<LegacyVertex, LegacyEdge> {
         return new LegacyEdge(edge);
     }
 
-    @Override
-    public Class<LegacyVertex> getVertexType() {
-        return LegacyVertex.class;
-    }
 }

--- a/features/graph/provider/legacy/src/main/java/org/opennms/netmgt/graph/provider/legacy/LegacyGraphProvider.java
+++ b/features/graph/provider/legacy/src/main/java/org/opennms/netmgt/graph/provider/legacy/LegacyGraphProvider.java
@@ -88,10 +88,10 @@ public class LegacyGraphProvider implements GraphProvider {
     }
 
     @Override
-    public GraphInfo<?> getGraphInfo() {
+    public GraphInfo getGraphInfo() {
         final org.opennms.features.topology.api.topo.GraphProvider defaultGraphProvider = delegate.getDefaultGraphProvider();
         final TopologyProviderInfo delegateInfo = defaultGraphProvider.getTopologyProviderInfo();
-        final DefaultGraphInfo graphInfo = new DefaultGraphInfo(defaultGraphProvider.getNamespace(), LegacyVertex.class);
+        final DefaultGraphInfo graphInfo = new DefaultGraphInfo(defaultGraphProvider.getNamespace());
         graphInfo.setDescription(delegateInfo.getDescription());
         graphInfo.setLabel(delegateInfo.getName());
         return graphInfo;

--- a/features/graph/provider/persistence-test/src/main/java/org/opennms/netmgt/graph/provider/persistence/CustomGraph.java
+++ b/features/graph/provider/persistence-test/src/main/java/org/opennms/netmgt/graph/provider/persistence/CustomGraph.java
@@ -52,9 +52,4 @@ public class CustomGraph extends AbstractDomainGraph<CustomVertex, CustomEdge> {
     protected CustomEdge convert(GenericEdge edge) {
         return new CustomEdge(edge);
     }
-
-    @Override
-    public Class getVertexType() {
-        return CustomVertex.class;
-    }
 }

--- a/features/graph/provider/persistence-test/src/main/java/org/opennms/netmgt/graph/provider/persistence/PersistenceGraphContainerProvider.java
+++ b/features/graph/provider/persistence-test/src/main/java/org/opennms/netmgt/graph/provider/persistence/PersistenceGraphContainerProvider.java
@@ -71,7 +71,7 @@ public class PersistenceGraphContainerProvider implements GraphContainerProvider
         defaultGraphContainerInfo.setLabel(containerInfoById.getLabel());
         containerInfoById.getGraphInfos().forEach(gi -> {
             // Override vertex type
-            final DefaultGraphInfo defaultGraphInfo = new DefaultGraphInfo(gi, CustomVertex.class);
+            final DefaultGraphInfo defaultGraphInfo = new DefaultGraphInfo(gi);
             defaultGraphContainerInfo.addGraphInfo(defaultGraphInfo);
         });
         return defaultGraphContainerInfo;
@@ -90,7 +90,7 @@ public class PersistenceGraphContainerProvider implements GraphContainerProvider
         info.setDescription("Example container which uses the GraphRepository for persistence");
         info.setLabel("Example Persistence Graph Container");
 
-        final DefaultGraphInfo graphInfo = new DefaultGraphInfo(CONTAINER_ID + ".graph", CustomVertex.class);
+        final DefaultGraphInfo graphInfo = new DefaultGraphInfo(CONTAINER_ID + ".graph");
         graphInfo.setDescription("The only graph of the container");
         graphInfo.setLabel("Graph");
         info.getGraphInfos().add(graphInfo);

--- a/features/graph/service/src/main/java/org/opennms/netmgt/graph/persistence/DefaultGraphRepository.java
+++ b/features/graph/service/src/main/java/org/opennms/netmgt/graph/persistence/DefaultGraphRepository.java
@@ -99,7 +99,7 @@ public class DefaultGraphRepository implements GraphRepository {
                 containerEntity.getGraphs().forEach(graphEntity -> {
                     // We don't know the vertex type anymore. When loading the container, the type of the vertex will be GenericVertex
                     // If another type is required, the loading instance should wrap the info accordingly
-                    final DefaultGraphInfo graphInfo = new DefaultGraphInfo(graphEntity.getNamespace(), GenericVertex.class);
+                    final DefaultGraphInfo graphInfo = new DefaultGraphInfo(graphEntity.getNamespace());
                     graphInfo.setLabel(graphEntity.getLabel());
                     graphInfo.setDescription(graphEntity.getDescription());
                     containerInfo.getGraphInfos().add(graphInfo);

--- a/features/graph/service/src/main/java/org/opennms/netmgt/graph/search/NodeSearchProvider.java
+++ b/features/graph/service/src/main/java/org/opennms/netmgt/graph/search/NodeSearchProvider.java
@@ -35,7 +35,6 @@ import org.opennms.core.criteria.Criteria;
 import org.opennms.core.criteria.CriteriaBuilder;
 import org.opennms.netmgt.dao.api.NodeDao;
 import org.opennms.netmgt.graph.api.NodeRef;
-import org.opennms.netmgt.graph.api.aware.NodeRefAware;
 import org.opennms.netmgt.graph.api.generic.GenericVertex;
 import org.opennms.netmgt.graph.api.search.SearchContext;
 import org.opennms.netmgt.graph.api.search.SearchCriteria;
@@ -58,7 +57,7 @@ public class NodeSearchProvider implements SearchProvider {
 
     @Override
     public boolean canSuggest(GraphService graphService, String namespace) {
-        return NodeRefAware.class.isAssignableFrom(graphService.getGraphInfo(namespace).getVertexType());
+        return true; // at the moment all vertices are NodeRefAware.
     }
 
     @Override

--- a/features/graph/service/src/main/java/org/opennms/netmgt/graph/service/GraphProviderManager.java
+++ b/features/graph/service/src/main/java/org/opennms/netmgt/graph/service/GraphProviderManager.java
@@ -61,7 +61,7 @@ public class GraphProviderManager {
     public void onBind(GraphProvider graphProvider, Map<String, String> properties) {
         // Determine optional defined label, description and container id.
         // Otherwise default to the ones defined in the GraphInfo.
-        final GraphInfo<?> graphInfo = graphProvider.getGraphInfo();
+        final GraphInfo graphInfo = graphProvider.getGraphInfo();
         final String label = properties.getOrDefault(LABEL_KEY, graphInfo.getLabel());
         final String description = properties.getOrDefault(DESCRIPTION_KEY, graphInfo.getDescription());
         final String containerId = properties.getOrDefault(CONTAINER_ID_KEY, graphInfo.getNamespace());

--- a/features/graph/service/src/test/java/org/opennms/netmgt/graph/persistence/DefaultGraphRepositoryIT.java
+++ b/features/graph/service/src/test/java/org/opennms/netmgt/graph/persistence/DefaultGraphRepositoryIT.java
@@ -53,15 +53,13 @@ import org.opennms.netmgt.graph.api.generic.GenericGraph.GenericGraphBuilder;
 import org.opennms.netmgt.graph.api.generic.GenericGraphContainer;
 import org.opennms.netmgt.graph.api.generic.GenericGraphContainer.GenericGraphContainerBuilder;
 import org.opennms.netmgt.graph.api.generic.GenericVertex;
-import org.opennms.netmgt.graph.api.info.GraphInfo;
 import org.opennms.netmgt.graph.api.persistence.GraphRepository;
-import org.opennms.netmgt.graph.provider.application.ApplicationGraph;
-import org.opennms.netmgt.graph.provider.application.ApplicationVertex;
 import org.opennms.netmgt.graph.domain.AbstractDomainGraphContainer;
 import org.opennms.netmgt.graph.domain.simple.SimpleDomainEdge;
 import org.opennms.netmgt.graph.domain.simple.SimpleDomainGraph;
 import org.opennms.netmgt.graph.domain.simple.SimpleDomainGraphContainer;
 import org.opennms.netmgt.graph.domain.simple.SimpleDomainVertex;
+import org.opennms.netmgt.graph.provider.application.ApplicationGraph;
 import org.opennms.test.JUnitConfigurationEnvironment;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
@@ -268,33 +266,6 @@ public class DefaultGraphRepositoryIT {
         assertThat(persistenceAccessor.findAll(AbstractGraphEntity.class), Matchers.hasSize(0));
         assertThat(persistenceAccessor.findAll(FocusEntity.class), Matchers.hasSize(0));
         assertThat(persistenceAccessor.findAll(PropertyEntity.class), Matchers.hasSize(0));
-    }
-
-    @Test
-    public void verifyVertexTypePersistence() {
-        final ApplicationGraph applicationGraph = ApplicationGraph.builder()
-                .label("Application Graph")
-                .description("The Application Graph")
-                .build();
-        final ApplicationGraphContainer applicationGraphContainer= ApplicationGraphContainer.builder()
-                .id("test")
-                .description("Test Container")
-                .addGraph(applicationGraph)
-                .build();
-        graphRepository.save(applicationGraphContainer);
-
-        // Verify that generic info contains proper domain vertex type
-        final GenericGraphContainer genericGraphContainer = graphRepository.findContainerById("test");
-        final GraphInfo genericGraphInfo = genericGraphContainer.getGraphInfo(ApplicationGraph.NAMESPACE);
-        assertEquals(GenericVertex.class, genericGraphInfo.getVertexType());
-
-        // Convert to domain container and verify types again
-        final ApplicationGraphContainer readContainer = new ApplicationGraphContainer(genericGraphContainer);
-        assertEquals(readContainer.getGraph(ApplicationGraph.NAMESPACE).getVertexType(), ApplicationVertex.class);
-
-        // Verify that reading only the container info contains the generic vertex types for the graph
-        final GraphInfo readGraphInfo = graphRepository.findContainerInfoById("test").getGraphInfo(ApplicationGraph.NAMESPACE);
-        assertEquals(GenericVertex.class, readGraphInfo.getVertexType());
     }
 
     @Test


### PR DESCRIPTION
Here we remove the method `getVertexType()` on the `GraphInfo` object. Originally we thought this might be needed, but turns out so far we don't need it. If so, a probably better approach would be to use properties instead.

JIRA: https://issues.opennms.org/browse/NMS-12447