### PR TITLE
Refactoring: Use SessionUtils instead

### DIFF
--- a/features/flows/rest/impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/features/flows/rest/impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -12,7 +12,7 @@
     <reference id="flowRepository" interface="org.opennms.netmgt.flows.api.FlowRepository" availability="mandatory"/>
     <reference id="nodeDao" interface="org.opennms.netmgt.dao.api.NodeDao" availability="mandatory"/>
     <reference id="snmpInterfaceDao" interface="org.opennms.netmgt.dao.api.SnmpInterfaceDao" availability="mandatory"/>
-    <reference id="transactionOperations" interface="org.springframework.transaction.support.TransactionOperations" availability="mandatory"/>
+    <reference id="sessionUtils" interface="org.opennms.netmgt.dao.api.SessionUtils" availability="mandatory"/>
     <reference id="classificationService" interface="org.opennms.netmgt.flows.classification.ClassificationService" availability="mandatory"/>
 
   <!-- Configuration properties -->
@@ -26,7 +26,7 @@
         <argument ref="flowRepository" />
         <argument ref="nodeDao" />
         <argument ref="snmpInterfaceDao" />
-        <argument ref="transactionOperations" />
+        <argument ref="sessionUtils" />
         <property name="flowGraphUrl" value="${flowGraphUrl}" />
     </bean>
 

--- a/features/flows/rest/impl/src/test/java/org/opennms/netmgt/flows/rest/internal/FlowRestServiceTest.java
+++ b/features/flows/rest/impl/src/test/java/org/opennms/netmgt/flows/rest/internal/FlowRestServiceTest.java
@@ -29,24 +29,24 @@
 package org.opennms.netmgt.flows.rest.internal;
 
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.isA;
-import static org.hamcrest.Matchers.contains;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.any;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 import javax.ws.rs.core.MultivaluedHashMap;
-import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.UriInfo;
 
 import org.junit.Test;
 import org.opennms.netmgt.dao.api.NodeDao;
+import org.opennms.netmgt.dao.api.SessionUtils;
 import org.opennms.netmgt.dao.api.SnmpInterfaceDao;
 import org.opennms.netmgt.flows.api.FlowRepository;
 import org.opennms.netmgt.flows.filter.api.ExporterNodeFilter;
@@ -54,9 +54,7 @@ import org.opennms.netmgt.flows.filter.api.Filter;
 import org.opennms.netmgt.flows.filter.api.NodeCriteria;
 import org.opennms.netmgt.flows.filter.api.SnmpInterfaceIdFilter;
 import org.opennms.netmgt.flows.filter.api.TimeRangeFilter;
-import org.opennms.netmgt.flows.rest.FlowRestService;
 import org.opennms.netmgt.flows.rest.model.FlowGraphUrlInfo;
-import org.springframework.transaction.support.TransactionOperations;
 
 public class FlowRestServiceTest {
 
@@ -98,8 +96,8 @@ public class FlowRestServiceTest {
         when(flowRepository.getFlowCount(any())).thenReturn(CompletableFuture.completedFuture(1L));
         NodeDao nodeDao = mock(NodeDao.class);
         SnmpInterfaceDao snmpInterfaceDao = mock(SnmpInterfaceDao.class);
-        TransactionOperations transactionOperations = mock(TransactionOperations.class);
-        FlowRestServiceImpl flowRestService = new FlowRestServiceImpl(flowRepository, nodeDao, snmpInterfaceDao, transactionOperations);
+        SessionUtils sessionUtils = mock(SessionUtils.class);
+        FlowRestServiceImpl flowRestService = new FlowRestServiceImpl(flowRepository, nodeDao, snmpInterfaceDao, sessionUtils);
 
         // Set the URL
         flowRestService.setFlowGraphUrl("https://grafana:3000/d/eWsVEL6zz/flows?orgId=1&var-node=$nodeId&var-interface=$ifIndex&from=$start&to=$end");


### PR DESCRIPTION
Some more changes to use `SessionUtils` instead of `TransactionOperations`.