### PR TITLE
NMS-12422: Allow multiple values for ip address input

### DIFF
--- a/core/web-assets/src/main/assets/js/apps/onms-classifications/views/modals/new-rule-modal.html
+++ b/core/web-assets/src/main/assets/js/apps/onms-classifications/views/modals/new-rule-modal.html
@@ -35,7 +35,7 @@
       <div class="form-row">
         <div class="form-group col-md-8">
           <label class="col-form-label" for="rule.srcAddress">Source IP Address</label>
-          <input class="form-control" type="text" id="rule.srcAddress" name="srcAddress" placeholder="127.0.0.1" ng-model="classification.srcAddress"
+          <input class="form-control" type="text" id="rule.srcAddress" name="srcAddress" placeholder="127.0.0.1,10.0.0.0-10.255.255.255" ng-model="classification.srcAddress"
                  ng-class="{ 'is-invalid' : ruleForm.srcAddress.$invalid || error.srcAddress}"/>
           <div ng-show="error.srcAddress" class="invalid-feedback">{{error.srcAddress}}</div>
         </div>
@@ -49,7 +49,7 @@
       <div class="form-row">
         <div class="form-group col-md-8">
           <label class="col-form-label" for="rule.dstAddress">Destination IP Address</label>
-          <input class="form-control" type="text" id="rule.dstAddress" name="dstAddress" placeholder="127.0.0.1" ng-model="classification.dstAddress"
+          <input class="form-control" type="text" id="rule.dstAddress" name="dstAddress" placeholder="127.0.0.1,10.0.0.0-10.255.255.255" ng-model="classification.dstAddress"
                  ng-class="{ 'is-invalid' : ruleForm.dstAddress.$invalid || error.dstAddress}"/>
           <div ng-show="error.dstAddress" class="invalid-feedback">{{error.dstAddress}}</div>
         </div>

--- a/features/flows/classification/engine/api/src/main/java/org/opennms/netmgt/flows/classification/ClassificationEngine.java
+++ b/features/flows/classification/engine/api/src/main/java/org/opennms/netmgt/flows/classification/ClassificationEngine.java
@@ -28,8 +28,14 @@
 
 package org.opennms.netmgt.flows.classification;
 
+import java.util.List;
+
+import org.opennms.netmgt.flows.classification.persistence.api.Rule;
+
 public interface ClassificationEngine {
     String classify(ClassificationRequest classificationRequest);
+
+    List<Rule> getInvalidRules();
 
     void reload();
 }

--- a/features/flows/classification/engine/api/src/main/java/org/opennms/netmgt/flows/classification/ClassificationService.java
+++ b/features/flows/classification/engine/api/src/main/java/org/opennms/netmgt/flows/classification/ClassificationService.java
@@ -69,4 +69,8 @@ public interface ClassificationService {
     String exportRules(int groupId);
 
     String classify(ClassificationRequest classificationRequest);
+
+    List<Rule> getInvalidRules();
+
+    void validateRule(Rule validateMe);
 }

--- a/features/flows/classification/engine/api/src/main/java/org/opennms/netmgt/flows/classification/error/Errors.java
+++ b/features/flows/classification/engine/api/src/main/java/org/opennms/netmgt/flows/classification/error/Errors.java
@@ -54,6 +54,8 @@ public interface Errors {
     ErrorTemplate RULE_EXPORTER_FILTER_INVALID = new ErrorTemplate("rule.filter.invalid", "The provided filter ''{0}'' is invalid: {1}");
 
     ErrorTemplate RULE_IP_ADDRESS_INVALID = new ErrorTemplate("rule.ipaddress.invalid", "The provided IP Address ''{0}'' is not valid.");
+    ErrorTemplate RULE_IP_ADDRESS_RANGE_INVALID = new ErrorTemplate("rule.ipaddress.range.invalid", "The provided IP Address range ''{0}'' is not valid.");
+    ErrorTemplate RULE_IP_ADDRESS_RANGE_BEGIN_END_INVALID = new ErrorTemplate("rule.ipaddress.range.begin-end.invalid", "The beginning of IP Address range ''{0}'' must come before end of IP Address range ''{1}''");
 
     ErrorTemplate CSV_TOO_FEW_COLUMNS = new ErrorTemplate("csv.toofewcolumns", "The provided rule ''{0}'' cannot be parsed. Expected columns {2} but received {3}.");
     ErrorTemplate CSV_IMPORT_FAILED = new ErrorTemplate( "csv.unknown.error", "An unexpected ErrorTemplate occurred while parsing the CSV: {0}.");

--- a/features/flows/classification/engine/api/src/main/java/org/opennms/netmgt/flows/classification/error/Errors.java
+++ b/features/flows/classification/engine/api/src/main/java/org/opennms/netmgt/flows/classification/error/Errors.java
@@ -54,7 +54,7 @@ public interface Errors {
     ErrorTemplate RULE_EXPORTER_FILTER_INVALID = new ErrorTemplate("rule.filter.invalid", "The provided filter ''{0}'' is invalid: {1}");
 
     ErrorTemplate RULE_IP_ADDRESS_INVALID = new ErrorTemplate("rule.ipaddress.invalid", "The provided IP Address ''{0}'' is not valid.");
-    ErrorTemplate RULE_IP_ADDRESS_RANGE_INVALID = new ErrorTemplate("rule.ipaddress.range.invalid", "The provided IP Address range ''{0}'' is not valid.");
+    ErrorTemplate RULE_IP_ADDRESS_RANGE_INVALID = new ErrorTemplate("rule.ipaddress.range.invalid", "The provided IP Address range ''{0}'' is not valid. A valid range expression may be: 10.0.0.0-10.0.0.255");
     ErrorTemplate RULE_IP_ADDRESS_RANGE_BEGIN_END_INVALID = new ErrorTemplate("rule.ipaddress.range.begin-end.invalid", "The beginning of IP Address range ''{0}'' must come before end of IP Address range ''{1}''");
 
     ErrorTemplate CSV_TOO_FEW_COLUMNS = new ErrorTemplate("csv.toofewcolumns", "The provided rule ''{0}'' cannot be parsed. Expected columns {2} but received {3}.");

--- a/features/flows/classification/engine/impl/src/main/java/org/opennms/netmgt/flows/classification/internal/DefaultClassificationEngine.java
+++ b/features/flows/classification/engine/impl/src/main/java/org/opennms/netmgt/flows/classification/internal/DefaultClassificationEngine.java
@@ -52,11 +52,13 @@ import org.opennms.netmgt.flows.classification.persistence.api.DefaultRuleDefini
 import org.opennms.netmgt.flows.classification.persistence.api.Rule;
 import org.opennms.netmgt.flows.classification.persistence.api.RuleDefinition;
 import org.opennms.netmgt.flows.classification.persistence.api.RulePositionComparator;
+import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Throwables;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
+import com.google.common.collect.Lists;
 
 public class DefaultClassificationEngine implements ClassificationEngine {
 
@@ -68,6 +70,8 @@ public class DefaultClassificationEngine implements ClassificationEngine {
     private final LoadingCache<Integer, List<Classifier>> portClassifiersCache;
     private final Comparator<RuleDefinition> ruleComparator = new RulePositionComparator();
     private final ClassificationRuleProvider ruleProvider;
+    private final List<Rule> invalidRules = Lists.newArrayList();
+    private final FilterService filterService;
 
     public DefaultClassificationEngine(final ClassificationRuleProvider ruleProvider, final FilterService filterService) {
         this(ruleProvider, filterService, true);
@@ -75,6 +79,7 @@ public class DefaultClassificationEngine implements ClassificationEngine {
 
     public DefaultClassificationEngine(final ClassificationRuleProvider ruleProvider, final FilterService filterService, final boolean initialize) {
         this.ruleProvider = Objects.requireNonNull(ruleProvider);
+        this.filterService = Objects.requireNonNull(filterService);
         this.portClassifiersCache = CacheBuilder.newBuilder().build(new CacheLoader<Integer, List<Classifier>>() {
             @Override
             public List<Classifier> load(Integer port) throws Exception {
@@ -129,10 +134,23 @@ public class DefaultClassificationEngine implements ClassificationEngine {
         // Reset existing data
         ruleClassifierMap.clear();
         rulePortList.clear();
+        invalidRules.clear();
         portClassifiersCache.invalidateAll();
 
-        // Load rules and expand omnidirectional rules to reversed ones
-        final List<RuleDefinition> rules = ruleProvider.getRules().stream()
+        // Load all rules and validate them
+        final List<Rule> validRules = Lists.newArrayList();
+        ruleProvider.getRules().forEach(rule -> {
+            try {
+                new CombinedClassifier(rule, filterService);
+                validRules.add(rule);
+            } catch (Exception ex) {
+                LoggerFactory.getLogger(getClass()).error("Rule {} is not valid. Ignoring rule.", rule, ex);
+                invalidRules.add(rule);
+            }
+        });
+
+        // Expand omnidirectional rules to reversed ones
+        final List<RuleDefinition> rules = validRules.stream()
                 .flatMap(rule -> rule.isOmnidirectional() && (rule.hasSrcPortDefinition() || rule.hasSrcAddressDefinition() || rule.hasDstPortDefinition() || rule.hasDstAddressDefinition())
                         ? Stream.of(rule, reverseRule(rule))
                         : Stream.of(rule))

--- a/features/flows/classification/engine/impl/src/main/java/org/opennms/netmgt/flows/classification/internal/DefaultClassificationEngine.java
+++ b/features/flows/classification/engine/impl/src/main/java/org/opennms/netmgt/flows/classification/internal/DefaultClassificationEngine.java
@@ -213,6 +213,11 @@ public class DefaultClassificationEngine implements ClassificationEngine {
     }
 
     @Override
+    public List<Rule> getInvalidRules() {
+        return Collections.unmodifiableList(invalidRules);
+    }
+
+    @Override
     public String classify(ClassificationRequest classificationRequest) {
         final Collection<Classifier> filteredClassifiers = getClassifiers(classificationRequest);
         final Optional<String> first = filteredClassifiers.stream()

--- a/features/flows/classification/engine/impl/src/main/java/org/opennms/netmgt/flows/classification/internal/DefaultClassificationService.java
+++ b/features/flows/classification/engine/impl/src/main/java/org/opennms/netmgt/flows/classification/internal/DefaultClassificationService.java
@@ -306,6 +306,17 @@ public class DefaultClassificationService implements ClassificationService {
         });
     }
 
+    @Override
+    public List<Rule> getInvalidRules() {
+        return classificationEngine.getInvalidRules();
+    }
+
+    @Override
+    public void validateRule(final Rule validateMe) {
+        Objects.requireNonNull(validateMe);
+        ruleValidator.validate(validateMe);
+    }
+
     private <T> T runInTransaction(Supplier<T> supplier) {
         Objects.requireNonNull(supplier);
         return sessionUtils.withTransaction(supplier);

--- a/features/flows/classification/engine/impl/src/main/java/org/opennms/netmgt/flows/classification/internal/ThreadSafeClassificationEngine.java
+++ b/features/flows/classification/engine/impl/src/main/java/org/opennms/netmgt/flows/classification/internal/ThreadSafeClassificationEngine.java
@@ -28,12 +28,14 @@
 
 package org.opennms.netmgt.flows.classification.internal;
 
+import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import org.opennms.netmgt.flows.classification.ClassificationEngine;
 import org.opennms.netmgt.flows.classification.ClassificationRequest;
+import org.opennms.netmgt.flows.classification.persistence.api.Rule;
 
 public class ThreadSafeClassificationEngine implements ClassificationEngine {
 
@@ -62,6 +64,16 @@ public class ThreadSafeClassificationEngine implements ClassificationEngine {
             delegate.reload();
         } finally {
             lock.writeLock().unlock();
+        }
+    }
+
+    @Override
+    public List<Rule> getInvalidRules() {
+        lock.readLock().lock();
+        try {
+            return delegate.getInvalidRules();
+        } finally {
+            lock.readLock().unlock();
         }
     }
 }

--- a/features/flows/classification/engine/impl/src/main/java/org/opennms/netmgt/flows/classification/internal/TimingClassificationEngine.java
+++ b/features/flows/classification/engine/impl/src/main/java/org/opennms/netmgt/flows/classification/internal/TimingClassificationEngine.java
@@ -28,10 +28,12 @@
 
 package org.opennms.netmgt.flows.classification.internal;
 
+import java.util.List;
 import java.util.Objects;
 
 import org.opennms.netmgt.flows.classification.ClassificationEngine;
 import org.opennms.netmgt.flows.classification.ClassificationRequest;
+import org.opennms.netmgt.flows.classification.persistence.api.Rule;
 
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
@@ -41,11 +43,13 @@ public class TimingClassificationEngine implements ClassificationEngine {
     private final ClassificationEngine delegate;
     private final Timer classifyTimer;
     private final Timer reloadTimer;
+    private final Timer getInvalidRulesTimer;
 
     public TimingClassificationEngine(MetricRegistry metricRegistry, ClassificationEngine delegate) {
         this.delegate = Objects.requireNonNull(delegate);
         this.classifyTimer = metricRegistry.timer("classify");
         this.reloadTimer = metricRegistry.timer("reload");
+        this.getInvalidRulesTimer = metricRegistry.timer("getInvalidrules");
     }
     
     @Override
@@ -59,6 +63,13 @@ public class TimingClassificationEngine implements ClassificationEngine {
     public void reload() {
         try (final Timer.Context ctx = reloadTimer.time()) {
             delegate.reload();
+        }
+    }
+
+    @Override
+    public List<Rule> getInvalidRules() {
+        try (final Timer.Context ctx = getInvalidRulesTimer.time()) {
+            return delegate.getInvalidRules();
         }
     }
 }

--- a/features/flows/classification/engine/impl/src/main/java/org/opennms/netmgt/flows/classification/internal/matcher/IpMatcher.java
+++ b/features/flows/classification/engine/impl/src/main/java/org/opennms/netmgt/flows/classification/internal/matcher/IpMatcher.java
@@ -30,9 +30,8 @@ package org.opennms.netmgt.flows.classification.internal.matcher;
 
 import java.util.Objects;
 
-import org.opennms.core.utils.IPLike;
 import org.opennms.netmgt.flows.classification.ClassificationRequest;
-import org.opennms.netmgt.flows.classification.internal.value.StringValue;
+import org.opennms.netmgt.flows.classification.internal.value.IpValue;
 
 import com.google.common.base.Function;
 
@@ -40,22 +39,17 @@ class IpMatcher implements Matcher {
 
     // Extracts the value from the ClassificationRequest. Allows to easily distinguish between srcAddress and dstAddress
     private final Function<ClassificationRequest, String> valueExtractor;
-    private final StringValue value;
+    private final IpValue value;
 
     protected IpMatcher(String input, Function<ClassificationRequest, String> valueExtractor) {
-        this.value = new StringValue(input);
+        this.value = new IpValue(input);
         this.valueExtractor = Objects.requireNonNull(valueExtractor);
     }
 
     @Override
     public boolean matches(ClassificationRequest request) {
-        if (value.isWildcard()) {
-            return true;
-        }
         final String currentAddressValue = valueExtractor.apply(request);
-        if (value.hasWildcard()) {
-            return IPLike.matches(currentAddressValue, value.getValue());
-        }
-        return value.getValue().equals(currentAddressValue);
+        final boolean matches = value.isInRange(currentAddressValue);
+        return matches;
     }
 }

--- a/features/flows/classification/engine/impl/src/main/java/org/opennms/netmgt/flows/classification/internal/value/IpValue.java
+++ b/features/flows/classification/engine/impl/src/main/java/org/opennms/netmgt/flows/classification/internal/value/IpValue.java
@@ -1,0 +1,92 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2020-2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.flows.classification.internal.value;
+
+import java.util.List;
+import java.util.Objects;
+
+import org.opennms.core.network.IPAddressRange;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.Lists;
+import com.google.common.net.InetAddresses;
+
+public class IpValue {
+
+    private static final Logger LOG = LoggerFactory.getLogger(IpValue.class);
+    private final List<IPAddressRange> ranges = Lists.newArrayList();
+
+    public IpValue(final String input) {
+        this(new StringValue(input));
+    }
+
+    public IpValue(final StringValue input) {
+        Objects.requireNonNull(input);
+        parse(input);
+    }
+
+    private void parse(final StringValue input) {
+        if (input.isNullOrEmpty()) {
+            throw new IllegalArgumentException("input may not be null or empty");
+        }
+        final List<StringValue> actualValues = input.splitBy(",");
+        for (StringValue eachValue : actualValues) {
+            // In case it is ranged, verify the range
+            if (eachValue.isRanged()) {
+                final List<StringValue> rangedValues = eachValue.splitBy("-");
+                // either a-, or a-b-c, etc.
+                if (rangedValues.size() != 2) {
+                    LOG.warn("Received multiple ranges {}. Will only use {}", rangedValues, rangedValues.subList(0, 2));
+                }
+                // Ensure each range is an ip address
+                for (StringValue rangedValue : rangedValues) {
+                    verifyIpAddress(rangedValue);
+                }
+                // Verify the range itself
+                final IPAddressRange range = new IPAddressRange(rangedValues.get(0).getValue(), rangedValues.get(1).getValue());
+                ranges.add(range);
+            } else {
+                verifyIpAddress(eachValue);
+                ranges.add(new IPAddressRange(eachValue.getValue(), eachValue.getValue()));
+            }
+        }
+    }
+
+    public boolean isInRange(final String address) {
+        return ranges.stream().anyMatch(r -> r.contains(address));
+    }
+
+    private static void verifyIpAddress(final StringValue stringValue) {
+        Objects.requireNonNull(stringValue);
+        if (!InetAddresses.isInetAddress(stringValue.getValue())) {
+            throw new IllegalArgumentException("Invalid ");
+        }
+    }
+}

--- a/features/flows/classification/engine/impl/src/main/java/org/opennms/netmgt/flows/classification/internal/value/IpValue.java
+++ b/features/flows/classification/engine/impl/src/main/java/org/opennms/netmgt/flows/classification/internal/value/IpValue.java
@@ -86,7 +86,7 @@ public class IpValue {
     private static void verifyIpAddress(final StringValue stringValue) {
         Objects.requireNonNull(stringValue);
         if (!InetAddresses.isInetAddress(stringValue.getValue())) {
-            throw new IllegalArgumentException("Invalid ");
+            throw new IllegalArgumentException("Provided ip address '" + stringValue.getValue() + "' is invalid");
         }
     }
 }

--- a/features/flows/classification/engine/impl/src/main/java/org/opennms/netmgt/flows/classification/internal/value/StringValue.java
+++ b/features/flows/classification/engine/impl/src/main/java/org/opennms/netmgt/flows/classification/internal/value/StringValue.java
@@ -72,9 +72,9 @@ public class StringValue {
 
     public List<StringValue> splitBy(String separator) {
         return Arrays.stream(input.split(separator))
-                .map(segment -> segment.trim())
-                .filter(segment -> segment != null && segment.length() > 0)
-                .map(segment -> new StringValue(segment))
+                .map(String::trim)
+                .filter(segment -> segment.length() > 0)
+                .map(StringValue::new)
                 .collect(Collectors.toList());
     }
 }

--- a/features/flows/classification/engine/impl/src/test/java/org/opennms/netmgt/flows/classification/internal/DefaultClassificationEngineTest.java
+++ b/features/flows/classification/engine/impl/src/test/java/org/opennms/netmgt/flows/classification/internal/DefaultClassificationEngineTest.java
@@ -101,7 +101,7 @@ public class DefaultClassificationEngineTest {
                 new RuleBuilder().withName("SSH").withDstPort("22").withPosition(1).build(),
                 new RuleBuilder().withName("HTTP_CUSTOM").withDstAddress("192.168.0.1").withDstPort("80").withPosition(2).build(),
                 new RuleBuilder().withName("HTTP").withDstPort("80").withPosition(3).build(),
-                new RuleBuilder().withName("DUMMY").withDstAddress("192.168.1.0-192.168.1.255").withDstPort("8000-9000,80,8080").withPosition(4).build(),
+                new RuleBuilder().withName("DUMMY").withDstAddress("192.168.1.0-192.168.1.255,10.10.5.3").withDstPort("8000-9000,80,8080").withPosition(4).build(),
                 new RuleBuilder().withName("RANGE-TEST").withDstPort("7000-8000").withPosition(5).build(),
                 new RuleBuilder().withName("OpenNMS").withDstPort("8980").withPosition(6).build(),
                 new RuleBuilder().withName("OpenNMS Monitor").withDstPort("1077").withSrcPort("5347").withSrcAddress("10.0.0.5").withPosition(7).build()
@@ -138,6 +138,13 @@ public class DefaultClassificationEngineTest {
                         .withDstPort(80)
                         .withDstAddress("192.168.0.2")
                         .withProtocol(ProtocolType.TCP).build()));
+        assertEquals("DUMMY", engine.classify(new ClassificationRequestBuilder()
+                .withLocation("Default")
+                .withSrcAddress("127.0.0.1")
+                .withDstAddress("10.10.5.3")
+                .withSrcPort(5213)
+                .withDstPort(8080)
+                .withProtocol(ProtocolType.TCP).build()));
 
         // Verify IP Range
         final IPAddressRange ipAddresses = new IPAddressRange("192.168.1.0", "192.168.1.255");

--- a/features/flows/classification/engine/impl/src/test/java/org/opennms/netmgt/flows/classification/internal/DefaultClassificationEngineTest.java
+++ b/features/flows/classification/engine/impl/src/test/java/org/opennms/netmgt/flows/classification/internal/DefaultClassificationEngineTest.java
@@ -101,7 +101,7 @@ public class DefaultClassificationEngineTest {
                 new RuleBuilder().withName("SSH").withDstPort("22").withPosition(1).build(),
                 new RuleBuilder().withName("HTTP_CUSTOM").withDstAddress("192.168.0.1").withDstPort("80").withPosition(2).build(),
                 new RuleBuilder().withName("HTTP").withDstPort("80").withPosition(3).build(),
-                new RuleBuilder().withName("DUMMY").withDstAddress("192.168.1.*").withDstPort("8000-9000,80,8080").withPosition(4).build(),
+                new RuleBuilder().withName("DUMMY").withDstAddress("192.168.1.0-192.168.1.255").withDstPort("8000-9000,80,8080").withPosition(4).build(),
                 new RuleBuilder().withName("RANGE-TEST").withDstPort("7000-8000").withPosition(5).build(),
                 new RuleBuilder().withName("OpenNMS").withDstPort("8980").withPosition(6).build(),
                 new RuleBuilder().withName("OpenNMS Monitor").withDstPort("1077").withSrcPort("5347").withSrcAddress("10.0.0.5").withPosition(7).build()

--- a/features/flows/classification/engine/impl/src/test/java/org/opennms/netmgt/flows/classification/internal/validation/RuleValidatorTest.java
+++ b/features/flows/classification/engine/impl/src/test/java/org/opennms/netmgt/flows/classification/internal/validation/RuleValidatorTest.java
@@ -104,15 +104,16 @@ public class RuleValidatorTest {
         // Note: The errorContext can either be srcAddress or dstAddress.
 
         // Fail
+        verify(() -> RuleValidator.validateIpAddress(ErrorContext.SrcAddress, "*"), Errors.RULE_IP_ADDRESS_INVALID);
         verify(() -> RuleValidator.validateIpAddress(ErrorContext.SrcAddress, ""), Errors.RULE_IP_ADDRESS_INVALID);
         verify(() -> RuleValidator.validateIpAddress(ErrorContext.SrcAddress, null), Errors.RULE_IP_ADDRESS_INVALID);
         verify(() -> RuleValidator.validateIpAddress(ErrorContext.SrcAddress, "8.8"), Errors.RULE_IP_ADDRESS_INVALID);
+        verify(() -> RuleValidator.validateIpAddress(ErrorContext.SrcAddress, "8.8.8.*"), Errors.RULE_IP_ADDRESS_INVALID);
 
         // Succeed
-        verify(() -> RuleValidator.validateIpAddress(ErrorContext.SrcAddress, "*"));
         verify(() -> RuleValidator.validateIpAddress(ErrorContext.SrcAddress, "ff01::1"));
         verify(() -> RuleValidator.validateIpAddress(ErrorContext.SrcAddress, "127.0.0.1"));
-        verify(() -> RuleValidator.validateIpAddress(ErrorContext.SrcAddress, "8.8.8.*"));
+        verify(() -> RuleValidator.validateIpAddress(ErrorContext.SrcAddress, "10.0.0.0-10.255.255.255"));
     }
 
     @Test

--- a/features/flows/classification/engine/impl/src/test/java/org/opennms/netmgt/flows/classification/internal/value/IpValueTest.java
+++ b/features/flows/classification/engine/impl/src/test/java/org/opennms/netmgt/flows/classification/internal/value/IpValueTest.java
@@ -1,0 +1,94 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2020-2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.flows.classification.internal.value;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+import org.opennms.core.network.IPAddress;
+import org.opennms.core.network.IPAddressRange;
+
+public class IpValueTest {
+
+    @Test
+    public void verifyRangedValues() {
+        final IpValue ipValue = new IpValue("10.1.1.1-10.1.1.100");
+        final IPAddressRange range = new IPAddressRange("10.1.1.1", "10.1.1.100");
+        for (IPAddress address : range) {
+            assertThat(ipValue.isInRange(address.toUserString()), is(true));
+        }
+    }
+
+    @Test
+    public void verifySingleValue() {
+        final IpValue ipValue = new IpValue("192.168.0.1");
+        assertThat(ipValue.isInRange("192.168.0.0"), is(false));
+        assertThat(ipValue.isInRange("192.168.0.1"), is(true));
+        assertThat(ipValue.isInRange("192.168.0.2"), is(false));
+    }
+
+    @Test
+    public void verifyMultiValues() {
+        final IpValue ipValue = new IpValue("192.168.0.1, 192.168.0.2, 192.168.0.10");
+        assertThat(ipValue.isInRange("192.168.0.0"), is(false));
+        assertThat(ipValue.isInRange("192.168.0.1"), is(true));
+        assertThat(ipValue.isInRange("192.168.0.2"), is(true));
+        assertThat(ipValue.isInRange("192.168.0.3"), is(false));
+        assertThat(ipValue.isInRange("192.168.0.4"), is(false));
+        assertThat(ipValue.isInRange("192.168.0.5"), is(false));
+        assertThat(ipValue.isInRange("192.168.0.6"), is(false));
+        assertThat(ipValue.isInRange("192.168.0.7"), is(false));
+        assertThat(ipValue.isInRange("192.168.0.8"), is(false));
+        assertThat(ipValue.isInRange("192.168.0.9"), is(false));
+        assertThat(ipValue.isInRange("192.168.0.10"), is(true));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void verifyWildcard() {
+        new IpValue("*");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void verifyInvalidIpAddress() {
+        new IpValue("300.400.500.600");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void verifyInvalidIpAddressRanges() {
+        new IpValue("192.168.0.1-a.b.c.d");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void verifyInvalidIpAddressRangeEndIsBefore() {
+        new IpValue("192.168.10.255-192.168.0.1");
+    }
+
+    // TODO MVR add ip6 tests
+}

--- a/features/flows/classification/engine/impl/src/test/java/org/opennms/netmgt/flows/classification/internal/value/IpValueTest.java
+++ b/features/flows/classification/engine/impl/src/test/java/org/opennms/netmgt/flows/classification/internal/value/IpValueTest.java
@@ -90,5 +90,19 @@ public class IpValueTest {
         new IpValue("192.168.10.255-192.168.0.1");
     }
 
-    // TODO MVR add ip6 tests
+    @Test
+    public void verifySingleValueIpV6() {
+        final IpValue value = new IpValue("2001:0DB8:0:CD30::1");
+        assertThat(value.isInRange("2001:0DB8:0:CD30::1"), is(true));
+        assertThat(value.isInRange("2001:0DB8:0:CD30::2"), is(false));
+        assertThat(value.isInRange("192.168.0.1"), is(false)); // incompatible, should be false
+    }
+
+    @Test
+    public void verifyRangedValueIpV6() {
+        final IpValue value = new IpValue("2001:0DB8:0:CD30::1-2001:0DB8:0:CD30::FFFF");
+        for (IPAddress address : new IPAddressRange("2001:0DB8:0:CD30::1", "2001:0DB8:0:CD30::FFFF")) {
+            assertThat(value.isInRange(address.toUserString()), is(true));
+        }
+    }
 }

--- a/features/flows/classification/shell/src/main/java/org/opennms/netmgt/flows/clazzification/shell/ClassificationListInvalidRuleCommand.java
+++ b/features/flows/classification/shell/src/main/java/org/opennms/netmgt/flows/clazzification/shell/ClassificationListInvalidRuleCommand.java
@@ -50,7 +50,7 @@ public class ClassificationListInvalidRuleCommand implements Action {
     @Override
     public Object execute() throws Exception {
         final List<Rule> invalidRules = getInvalidRules();
-        final String TEMPLATE = "%-20s   %4s   %-20s   %-15s   %10s   %-15s   %-10s   %-15s   %-10s   %-20s   %-15s   %s";
+        final String TEMPLATE = "%-20s   %4s   %-20s   %-15s   %10s   %-40s   %-10s   %-40s   %-10s   %-20s   %-15s   %s";
         if (!invalidRules.isEmpty()) {
             System.out.println(String.format(TEMPLATE, "Group", "Pos", "Name", "Protocol", "ID", "Dest. Addr.", "Dest. Port", "Src. Addr.", "Src. Port", "Exporter Filter", "Bidirectional", "Error"));
             for (Rule rule : invalidRules) {

--- a/features/flows/classification/shell/src/main/java/org/opennms/netmgt/flows/clazzification/shell/ClassificationListInvalidRuleCommand.java
+++ b/features/flows/classification/shell/src/main/java/org/opennms/netmgt/flows/clazzification/shell/ClassificationListInvalidRuleCommand.java
@@ -1,0 +1,100 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019-2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.flows.clazzification.shell;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.apache.karaf.shell.api.action.Action;
+import org.apache.karaf.shell.api.action.Command;
+import org.apache.karaf.shell.api.action.lifecycle.Reference;
+import org.apache.karaf.shell.api.action.lifecycle.Service;
+import org.opennms.netmgt.flows.classification.ClassificationService;
+import org.opennms.netmgt.flows.classification.exception.InvalidRuleException;
+import org.opennms.netmgt.flows.classification.persistence.api.Rule;
+
+@Command(scope="opennms-classification", name="list-invalid-rules", description = "Lists invalid classification rules")
+@Service
+public class ClassificationListInvalidRuleCommand implements Action {
+
+    @Reference
+    private ClassificationService classificationService;
+
+    @Override
+    public Object execute() throws Exception {
+        final List<Rule> invalidRules = getInvalidRules();
+        final String TEMPLATE = "%-20s   %4s   %-20s   %-15s   %10s   %-15s   %-10s   %-15s   %-10s   %-20s   %-15s   %s";
+        if (!invalidRules.isEmpty()) {
+            System.out.println(String.format(TEMPLATE, "Group", "Pos", "Name", "Protocol", "ID", "Dest. Addr.", "Dest. Port", "Src. Addr.", "Src. Port", "Exporter Filter", "Bidirectional", "Error"));
+            for (Rule rule : invalidRules) {
+                final String error = getErrorReason(rule);
+                System.out.println(
+                        String.format(
+                                TEMPLATE,
+                                rule.getGroup().getName(),
+                                rule.getPosition(),
+                                rule.getName(),
+                                rule.getProtocol() == null ? "" : rule.getProtocol(),
+                                rule.getId(),
+                                rule.getDstAddress() == null ? "" : rule.getDstAddress(),
+                                rule.getDstPort() == null ? "" : rule.getDstPort(),
+                                rule.getSrcAddress() == null ? "" : rule.getSrcAddress(),
+                                rule.getSrcPort() == null ? "" : rule.getSrcPort(),
+                                rule.getExporterFilter() == null ? "" : rule.getExporterFilter(),
+                                rule.isOmnidirectional() ? "Y" : "N",
+                                error
+                        ));
+            }
+            System.out.println();
+        }
+        System.out.println("=> " + invalidRules.size() + " invalid rule(s) found.");
+        if (!invalidRules.isEmpty()) {
+            System.out.println();
+            System.out.println("Please manually fix these rules via the Flow Classification UI");
+        }
+        return null;
+    }
+
+    private List<Rule> getInvalidRules() {
+        return classificationService.getInvalidRules().stream()
+                .sorted(Comparator.comparing(Rule::getGroupPosition)
+                        .thenComparing(Rule::getPosition))
+                .collect(Collectors.toList());
+    }
+
+    private String getErrorReason(final Rule rule) {
+        try {
+            classificationService.validateRule(rule);
+            return "Unknown";
+        } catch (InvalidRuleException ex) {
+            return ex.getMessage();
+        }
+    }
+}

--- a/features/flows/classification/shell/src/main/java/org/opennms/netmgt/flows/clazzification/shell/ClassificationListRuleCommand.java
+++ b/features/flows/classification/shell/src/main/java/org/opennms/netmgt/flows/clazzification/shell/ClassificationListRuleCommand.java
@@ -60,7 +60,7 @@ public class ClassificationListRuleCommand implements Action {
                 .orderBy("position", true)
                 .toCriteria();
         final List<Rule> rules = classificationService.findMatchingRules(criteria);
-        final String TEMPLATE = "%4s   %-20s   %-15s   %10s   %-15s   %-10s   %-15s   %-10s   %-20s   %-15s   %s";
+        final String TEMPLATE = "%4s   %-20s   %-15s   %10s   %-40s   %-10s   %-40s   %-10s   %-20s   %-15s   %s";
         if (!rules.isEmpty()) {
             System.out.println(String.format(TEMPLATE, "Pos", "Name", "Protocol", "ID", "Dest. Addr.", "Dest. Port", "Src. Addr.", "Src. Port", "Exporter Filter", "Bidirectional", "Group"));
             for (Rule rule : rules) {

--- a/opennms-doc/releasenotes/src/asciidoc/releasenotes/whatsnew.adoc
+++ b/opennms-doc/releasenotes/src/asciidoc/releasenotes/whatsnew.adoc
@@ -11,6 +11,13 @@
 
 === Breaking Changes
 
+The Flow Classification UI accepted invalid ip address values, e.g. `10,192.1,168.1,5.1-160`.
+When upgrading {opennms-product-name} existing Flow Classification Rules may be considered invalid.
+In this case they are silently ignored by the Flow Classification Engine.
+In order to assure no invalid Flow Classification Rules exist, please run the OSGi shell command `opennms-classification:list-invalid-rules` to list all invalid rules.
+If there are any invalid rules, they must be manually fixed using the Flow Classification UI.
+For more details, refer to issue https://issues.opennms.org/browse/NMS-12422[NMS-12422].
+
 ==== PostgreSQL 10
 
 OpenNMS Horizon 25 is supported on PostgreSQL 10 or later.


### PR DESCRIPTION
Here we fix an issue with the ip src and dest fields when defining Classifcation Rules.
Somehow it was possible to define an IP-Like expression using commas. However that was a bit misleading and didn't work under the hood. Instead it is now possible to define actual IP-Ranges, e.g. `10.0.0.0-10.255.255.255`, as well as multiple definitions at once:
`192.168.0.1,10.0.0.0-10.255.255.255`

Support for wildcard entries was dropped.

A next step is to allow CIDR expressions (which is not done here)

It may be possible that invalid rules exist and when applying this patch to a system the classification engine may not load. 

~At the moment this is targeted for `develop` but should go into `foundation-2019`~

JIRA: https://issues.opennms.org/browse/NMS-12422

