### PR TITLE
NMS-12526: Enrich content of nodeAdded event

### DIFF
--- a/opennms-base-assembly/src/main/filtered/etc/events/opennms.pollerd.events.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/events/opennms.pollerd.events.xml
@@ -214,11 +214,9 @@
    <event>
       <uei>uei.opennms.org/nodes/nodeAdded</uei>
       <event-label>OpenNMS-defined node event: nodeAdded</event-label>
-      <descr>&lt;p>A new node (%parm[nodelabel]%) was discovered by
-            OpenNMS.&lt;/p></descr>
-      <logmsg dest="logndisplay">
-            A new node (%parm[nodelabel]%) was discovered by OpenNMS.
-        </logmsg>
+      <descr>The node (%parm[nodelabel]%) was added and is now being monitored.</descr>
+      <logmsg dest="logndisplay">A new node (%parm[nodelabel]%) was added.</logmsg>
+      <operinstruct>This event is for information only. Please make sure that the newly added device &lt;a href=&quot;element/node.jsp?node=%nodeid%&quot;>%nodeid%&lt;/a> is monitored as desired.</operinstruct>
       <severity>Warning</severity>
    </event>
    <event>

--- a/opennms-base-assembly/src/main/filtered/etc/events/opennms.pollerd.events.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/events/opennms.pollerd.events.xml
@@ -214,9 +214,9 @@
    <event>
       <uei>uei.opennms.org/nodes/nodeAdded</uei>
       <event-label>OpenNMS-defined node event: nodeAdded</event-label>
-      <descr>The node (%parm[nodelabel]%) was added and is now being monitored.</descr>
-      <logmsg dest="logndisplay">A new node (%parm[nodelabel]%) was added.</logmsg>
-      <operinstruct>This event is for information only. Please make sure that the newly added device &lt;a href=&quot;element/node.jsp?node=%nodeid%&quot;>%nodeid%&lt;/a> is monitored as desired.</operinstruct>
+      <descr>The node &quot;%parm[nodelabel]%&quot; was added and is now being monitored.</descr>
+      <logmsg dest="logndisplay">A new node &quot;%parm[nodelabel]%&quot; was added.</logmsg>
+      <operinstruct>This event is for information only. Please make sure that the newly added device &lt;a href=&quot;element/node.jsp?node=%nodeid%&quot;>&quot;%parm[nodelabel]%&quot;&lt;/a> is monitored as desired.</operinstruct>
       <severity>Warning</severity>
    </event>
    <event>


### PR DESCRIPTION
I've rewritten the content of nodeAdded event because the old text was a little too simplistic in my opinion.
I've also added the operator instruction field because I really like it if there are instructions for an user. But I'm pretty sure that we don't have default operator instructions right now in the default OpenNMS events. Is there any reason why we shouldn't?

Also I'm wondering why this event is stored in the poller event file. Is that correct? Which component is responsible for `uei.opennms.org/nodes/` events?

### External References

* https://issues.opennms.org/browse/NMS-12526

