### PR TITLE
NMS-12527: Migrate config-tester wiki to the docs

### DIFF
--- a/opennms-doc/guide-admin/src/asciidoc/index.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/index.adoc
@@ -290,6 +290,7 @@ include::text/operation/ssl/ssl.adoc[]
 include::text/operation/request-logging.adoc[]
 include::text/operation/geocoder.adoc[]
 include::text/operation/newts-repository-converter.adoc[]
+include::text/operation/config-tester.adoc[]
 
 [[ga-opennms-operation-newts]]
 === Newts

--- a/opennms-doc/guide-admin/src/asciidoc/text/operation/config-tester.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/operation/config-tester.adoc
@@ -6,7 +6,7 @@
 === Configuration Tester
 
 To identify configuration problems there is a config-tester located in `$OPENNMS_HOME/bin/`.
-The `config-tester` runs while OpenNMS starts and checks a number of configuration files. 
+Use `config-tester` to check configuration files. 
 Type `-l, --list` to view the list of files checked. 
 It prints issues into `output.log`.
 The tool can be used while OpenNMS is running to check configuration beforehand.

--- a/opennms-doc/guide-admin/src/asciidoc/text/operation/config-tester.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/operation/config-tester.adoc
@@ -1,0 +1,27 @@
+
+// Allow GitHub image rendering
+:imagesdir: ../../../images
+
+[[ga-operation-config-tester]]
+=== Configuration Tester
+
+To identify configuration problems there is a config-tester located in `$OPENNMS_HOME/bin/`.
+The `config-tester` will be run while OpenNMS starts and prints the issues into `output.log`.
+But the tool can be used while OpenNMS is running to check configuration beforehand.
+
+Possible Parameters:
+
+[source,bash]
+---
+ $OPENNMS_HOME/bin/config-tester -h
+ usage: config-tester -a
+                     OR: config-tester [config files]
+                     OR: config-tester -l
+                     OR: config-tester -h
+ -a,--all              check all supported configuration files
+ -h,--help             print this help and exit
+ -i,--ignore-unknown   ignore unknown configuration files and continue
+                       processing
+ -l,--list             list supported configuration files and exit
+ -v,--verbose          list each configuration file as it is tested
+---

--- a/opennms-doc/guide-admin/src/asciidoc/text/operation/config-tester.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/operation/config-tester.adoc
@@ -6,7 +6,8 @@
 === Configuration Tester
 
 To identify configuration problems there is a config-tester located in `$OPENNMS_HOME/bin/`.
-The `config-tester` will be run while OpenNMS starts and prints the issues into `output.log`.
+The `config-tester` runs while OpenNMS starts and checks a number of configuration files. Type `-l, --list` to view the list of files checked. 
+It prints issues into `output.log`.
 The tool can be used while OpenNMS is running to check configuration beforehand.
 
 Possible Parameters:

--- a/opennms-doc/guide-admin/src/asciidoc/text/operation/config-tester.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/operation/config-tester.adoc
@@ -6,7 +6,8 @@
 === Configuration Tester
 
 To identify configuration problems there is a config-tester located in `$OPENNMS_HOME/bin/`.
-The `config-tester` runs while OpenNMS starts and checks a number of configuration files. Type `-l, --list` to view the list of files checked. 
+The `config-tester` runs while OpenNMS starts and checks a number of configuration files. 
+Type `-l, --list` to view the list of files checked. 
 It prints issues into `output.log`.
 The tool can be used while OpenNMS is running to check configuration beforehand.
 

--- a/opennms-doc/guide-admin/src/asciidoc/text/operation/config-tester.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/operation/config-tester.adoc
@@ -7,7 +7,7 @@
 
 To identify configuration problems there is a config-tester located in `$OPENNMS_HOME/bin/`.
 The `config-tester` will be run while OpenNMS starts and prints the issues into `output.log`.
-But the tool can be used while OpenNMS is running to check configuration beforehand.
+The tool can be used while OpenNMS is running to check configuration beforehand.
 
 Possible Parameters:
 


### PR DESCRIPTION
Due to the [wiki cleanup project](https://opennms.discourse.group/t/project-vacu-suck) I found the config-tester wiki page that needs to be migrated to the docs.

We should add some information about the things the tool is checking.
All I know is that a XML syntax check is done.
@indigo423 Do we have information about the content the tool is checking?

@Bonrob2 Added you here because I thought it is a good idea to add the technical documentation person :man_shrugging:  Feel free to ignore me if my thoughts are completely wrong :-)

Just as reminder: After merging this PR the config-tester wiki page should be deleted and the [troubleshoot post](https://opennms.discourse.group/t/project-vacu-suck) needs an URL upgrade that points to the docs instead.

### External References

* JIRA (Issue Tracker): https://issues.opennms.org/browse/NMS-12527
* Bamboo (Continuous Integration): https://bamboo.opennms.org/

