### PR TITLE
ULU-62: add /ipinterfaces and /snmpinterfaces endpoints

### DIFF
--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/SearchProperties.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/SearchProperties.java
@@ -506,7 +506,7 @@ public abstract class SearchProperties {
 		// Root prefix
 		IP_INTERFACE_SERVICE_PROPERTIES.addAll(IP_INTERFACE_PROPERTIES);
 		IP_INTERFACE_SERVICE_PROPERTIES.addAll(withAliasPrefix(Aliases.node, "Node", NODE_PROPERTIES));
-		IP_INTERFACE_SERVICE_PROPERTIES.addAll(withAliasPrefix(Aliases.ipInterface, "IP Interface", IP_INTERFACE_PROPERTIES));
+		IP_INTERFACE_SERVICE_PROPERTIES.addAll(withAliasPrefix(Aliases.snmpInterface, "SNMP Interface", SNMP_INTERFACE_PROPERTIES));
 		//IP_INTERFACE_SERVICE_PROPERTIES.addAll(withAliasPrefix(Aliases.monitoredService, "Monitored Service", IF_SERVICE_PROPERTIES));
 		IP_INTERFACE_SERVICE_PROPERTIES.addAll(withAliasPrefix(Aliases.assetRecord, "Asset", ASSET_RECORD_PROPERTIES));
 		IP_INTERFACE_SERVICE_PROPERTIES.addAll(withAliasPrefix(Aliases.category, "Category", CATEGORY_PROPERTIES, false));
@@ -516,7 +516,7 @@ public abstract class SearchProperties {
 		// Root prefix
 		SNMP_INTERFACE_SERVICE_PROPERTIES.addAll(SNMP_INTERFACE_PROPERTIES);
 		SNMP_INTERFACE_SERVICE_PROPERTIES.addAll(withAliasPrefix(Aliases.node, "Node", NODE_PROPERTIES));
-		IP_INTERFACE_SERVICE_PROPERTIES.addAll(withAliasPrefix(Aliases.snmpInterface, "SNMP Interface", SNMP_INTERFACE_PROPERTIES));
+		SNMP_INTERFACE_SERVICE_PROPERTIES.addAll(withAliasPrefix(Aliases.ipInterface, "IP Interface", IP_INTERFACE_PROPERTIES));
 		//SNMP_INTERFACE_SERVICE_PROPERTIES.addAll(withAliasPrefix(Aliases.monitoredService, "Monitored Service", IF_SERVICE_PROPERTIES));
 		SNMP_INTERFACE_SERVICE_PROPERTIES.addAll(withAliasPrefix(Aliases.assetRecord, "Asset", ASSET_RECORD_PROPERTIES));
 		SNMP_INTERFACE_SERVICE_PROPERTIES.addAll(withAliasPrefix(Aliases.category, "Category", CATEGORY_PROPERTIES, false));

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/SearchProperties.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/SearchProperties.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2017-2017 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
+ * Copyright (C) 2017-2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -288,7 +288,7 @@ public abstract class SearchProperties {
 	static final SortedSet<SearchProperty> IP_INTERFACE_PROPERTIES = new TreeSet<>(Arrays.asList(new SearchProperty[] {
 		new SearchProperty(OnmsIpInterface.class, "id", "ID", INTEGER),
 		new SearchProperty(OnmsIpInterface.class, "ipAddress", "IP Address", IP_ADDRESS),
-                new SearchProperty(OnmsIpInterface.class, "netMask", "Network Mask", IP_ADDRESS),
+		new SearchProperty(OnmsIpInterface.class, "netMask", "Network Mask", IP_ADDRESS),
 		new SearchProperty(OnmsIpInterface.class, "ipHostName", "Hostname", STRING),
 		new SearchProperty(OnmsIpInterface.class, "ipLastCapsdPoll", "Last Provisioning Scan", TIMESTAMP),
 		new SearchProperty(OnmsIpInterface.class, "isManaged", "Management Status", STRING)
@@ -391,6 +391,8 @@ public abstract class SearchProperties {
 	public static final Set<SearchProperty> APPLICATION_SERVICE_PROPERTIES = new LinkedHashSet<>();
 	public static final Set<SearchProperty> EVENT_SERVICE_PROPERTIES = new LinkedHashSet<>();
 	public static final Set<SearchProperty> IF_SERVICE_SERVICE_PROPERTIES = new LinkedHashSet<>();
+	public static final Set<SearchProperty> IP_INTERFACE_SERVICE_PROPERTIES = new LinkedHashSet<>();
+	public static final Set<SearchProperty> SNMP_INTERFACE_SERVICE_PROPERTIES = new LinkedHashSet<>();
 	public static final Set<SearchProperty> MINION_SERVICE_PROPERTIES = new LinkedHashSet<>();
 	public static final Set<SearchProperty> LOCATION_SERVICE_PROPERTIES = new LinkedHashSet<>();
 	public static final Set<SearchProperty> NODE_SERVICE_PROPERTIES = new LinkedHashSet<>();
@@ -500,6 +502,25 @@ public abstract class SearchProperties {
 		IF_SERVICE_SERVICE_PROPERTIES.addAll(withAliasPrefix(Aliases.node, "Node", NODE_PROPERTIES));
 		IF_SERVICE_SERVICE_PROPERTIES.addAll(withAliasPrefix(Aliases.serviceType, "Service", SERVICE_TYPE_PROPERTIES));
 		IF_SERVICE_SERVICE_PROPERTIES.addAll(withAliasPrefix(Aliases.snmpInterface, "SNMP Interface", SNMP_INTERFACE_PROPERTIES));
+
+		// Root prefix
+		IP_INTERFACE_SERVICE_PROPERTIES.addAll(IP_INTERFACE_PROPERTIES);
+		IP_INTERFACE_SERVICE_PROPERTIES.addAll(withAliasPrefix(Aliases.node, "Node", NODE_PROPERTIES));
+		IP_INTERFACE_SERVICE_PROPERTIES.addAll(withAliasPrefix(Aliases.ipInterface, "IP Interface", IP_INTERFACE_PROPERTIES));
+		//IP_INTERFACE_SERVICE_PROPERTIES.addAll(withAliasPrefix(Aliases.monitoredService, "Monitored Service", IF_SERVICE_PROPERTIES));
+		IP_INTERFACE_SERVICE_PROPERTIES.addAll(withAliasPrefix(Aliases.assetRecord, "Asset", ASSET_RECORD_PROPERTIES));
+		IP_INTERFACE_SERVICE_PROPERTIES.addAll(withAliasPrefix(Aliases.category, "Category", CATEGORY_PROPERTIES, false));
+		IP_INTERFACE_SERVICE_PROPERTIES.addAll(withAliasPrefix(Aliases.location, "Location", LOCATION_PROPERTIES));
+		IP_INTERFACE_SERVICE_PROPERTIES.addAll(withAliasPrefix(Aliases.serviceType, "Service", SERVICE_TYPE_PROPERTIES));
+
+		// Root prefix
+		SNMP_INTERFACE_SERVICE_PROPERTIES.addAll(SNMP_INTERFACE_PROPERTIES);
+		SNMP_INTERFACE_SERVICE_PROPERTIES.addAll(withAliasPrefix(Aliases.node, "Node", NODE_PROPERTIES));
+		IP_INTERFACE_SERVICE_PROPERTIES.addAll(withAliasPrefix(Aliases.snmpInterface, "SNMP Interface", SNMP_INTERFACE_PROPERTIES));
+		//SNMP_INTERFACE_SERVICE_PROPERTIES.addAll(withAliasPrefix(Aliases.monitoredService, "Monitored Service", IF_SERVICE_PROPERTIES));
+		SNMP_INTERFACE_SERVICE_PROPERTIES.addAll(withAliasPrefix(Aliases.assetRecord, "Asset", ASSET_RECORD_PROPERTIES));
+		SNMP_INTERFACE_SERVICE_PROPERTIES.addAll(withAliasPrefix(Aliases.category, "Category", CATEGORY_PROPERTIES, false));
+		SNMP_INTERFACE_SERVICE_PROPERTIES.addAll(withAliasPrefix(Aliases.location, "Location", LOCATION_PROPERTIES));
 
 		// Root prefix
 		MINION_SERVICE_PROPERTIES.addAll(MINION_PROPERTIES);

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/IpInterfaceRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/IpInterfaceRestService.java
@@ -1,0 +1,141 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.web.rest.v2;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.ws.rs.Path;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response.Status;
+import javax.ws.rs.core.UriInfo;
+
+import org.apache.cxf.jaxrs.ext.search.SearchBean;
+import org.opennms.core.config.api.JaxbListWrapper;
+import org.opennms.core.criteria.Alias.JoinType;
+import org.opennms.core.criteria.CriteriaBuilder;
+import org.opennms.netmgt.dao.api.IpInterfaceDao;
+import org.opennms.netmgt.model.OnmsIpInterface;
+import org.opennms.netmgt.model.OnmsIpInterfaceList;
+import org.opennms.web.rest.support.Aliases;
+import org.opennms.web.rest.support.CriteriaBehavior;
+import org.opennms.web.rest.support.CriteriaBehaviors;
+import org.opennms.web.rest.support.SearchProperties;
+import org.opennms.web.rest.support.SearchProperty;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Basic Web Service using REST for {@link OnmsIpInterface} entity.
+ *
+ * <p>This end-point exist to retrieve and update a set of IP interfaces,
+ * based on a given criteria.</p>
+ */
+@Component
+@Path("ipinterfaces")
+@Transactional
+public class IpInterfaceRestService extends AbstractDaoRestService<OnmsIpInterface,SearchBean,Integer,String> {
+
+    @Autowired
+    private IpInterfaceDao m_dao;
+
+    @Override
+    protected IpInterfaceDao getDao() {
+        return m_dao;
+    }
+
+    @Override
+    protected Class<OnmsIpInterface> getDaoClass() {
+        return OnmsIpInterface.class;
+    }
+
+    @Override
+    protected Class<SearchBean> getQueryBeanClass() {
+        return SearchBean.class;
+    }
+
+    @Override
+    protected CriteriaBuilder getCriteriaBuilder(final UriInfo uriInfo) {
+        final CriteriaBuilder builder = new CriteriaBuilder(getDaoClass());
+        // 1st level JOINs
+        builder.alias("node", Aliases.node.toString(), JoinType.LEFT_JOIN);
+        builder.alias("snmpInterface", Aliases.snmpInterface.toString(), JoinType.LEFT_JOIN);
+
+        // 2nd level JOINs
+        builder.alias(Aliases.node.prop("assetRecord"), Aliases.assetRecord.toString(), JoinType.LEFT_JOIN);
+        builder.alias(Aliases.node.prop("location"), Aliases.location.toString(), JoinType.LEFT_JOIN);
+
+        builder.orderBy("id");
+
+        return builder;
+    }
+
+    @Override
+    protected JaxbListWrapper<OnmsIpInterface> createListWrapper(Collection<OnmsIpInterface> list) {
+        return new OnmsIpInterfaceList(list);
+    }
+
+    @Override
+    protected Set<SearchProperty> getQueryProperties() {
+        return SearchProperties.IP_INTERFACE_SERVICE_PROPERTIES;
+    }
+
+    @Override
+    protected Map<String,CriteriaBehavior<?>> getCriteriaBehaviors() {
+        final Map<String,CriteriaBehavior<?>> map = new HashMap<>();
+
+        // Root alias
+        map.putAll(CriteriaBehaviors.IP_INTERFACE_BEHAVIORS);
+
+        // 1st level JOINs
+        map.putAll(CriteriaBehaviors.withAliasPrefix(Aliases.node, CriteriaBehaviors.NODE_BEHAVIORS));
+        map.putAll(CriteriaBehaviors.withAliasPrefix(Aliases.snmpInterface, CriteriaBehaviors.SNMP_INTERFACE_BEHAVIORS));
+
+        // 2nd level JOINs
+        map.putAll(CriteriaBehaviors.withAliasPrefix(Aliases.assetRecord, CriteriaBehaviors.ASSET_RECORD_BEHAVIORS));
+        map.putAll(CriteriaBehaviors.withAliasPrefix(Aliases.location, CriteriaBehaviors.MONITORING_LOCATION_BEHAVIORS));
+
+        return map;
+    }
+
+    @Override
+    protected OnmsIpInterface doGet(UriInfo uriInfo, String ipAddress) {
+        final List<OnmsIpInterface> addresses = getDao().findByIpAddress(ipAddress);
+        if (addresses.isEmpty()) {
+            return null;
+        } else if (addresses.size() == 1) {
+            return addresses.get(0);
+        }
+        throw new WebApplicationException("More than one IP address matches " + ipAddress, Status.BAD_REQUEST);
+    }
+}

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/IpInterfaceRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/IpInterfaceRestService.java
@@ -101,7 +101,7 @@ public class IpInterfaceRestService extends AbstractDaoRestService<OnmsIpInterfa
     }
 
     @Override
-    protected JaxbListWrapper<OnmsIpInterface> createListWrapper(Collection<OnmsIpInterface> list) {
+    protected final JaxbListWrapper<OnmsIpInterface> createListWrapper(Collection<OnmsIpInterface> list) {
         return new OnmsIpInterfaceList(list);
     }
 
@@ -129,7 +129,7 @@ public class IpInterfaceRestService extends AbstractDaoRestService<OnmsIpInterfa
     }
 
     @Override
-    protected OnmsIpInterface doGet(UriInfo uriInfo, String ipAddress) {
+    protected final OnmsIpInterface doGet(UriInfo uriInfo, String ipAddress) {
         final List<OnmsIpInterface> addresses = getDao().findByIpAddress(ipAddress);
         if (addresses.isEmpty()) {
             return null;

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/SnmpInterfaceRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/SnmpInterfaceRestService.java
@@ -1,0 +1,132 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.web.rest.v2;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import javax.ws.rs.Path;
+import javax.ws.rs.core.UriInfo;
+
+import org.apache.cxf.jaxrs.ext.search.SearchBean;
+import org.opennms.core.config.api.JaxbListWrapper;
+import org.opennms.core.criteria.Alias.JoinType;
+import org.opennms.core.criteria.CriteriaBuilder;
+import org.opennms.netmgt.dao.api.SnmpInterfaceDao;
+import org.opennms.netmgt.model.OnmsSnmpInterface;
+import org.opennms.netmgt.model.OnmsSnmpInterfaceList;
+import org.opennms.web.rest.support.Aliases;
+import org.opennms.web.rest.support.CriteriaBehavior;
+import org.opennms.web.rest.support.CriteriaBehaviors;
+import org.opennms.web.rest.support.SearchProperties;
+import org.opennms.web.rest.support.SearchProperty;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Basic Web Service using REST for {@link OnmsSnmpInterface} entity.
+ *
+ * <p>This end-point exist to retrieve and update a set of SNMP interfaces,
+ * based on a given criteria.</p>
+ */
+@Component
+@Path("snmpinterfaces")
+@Transactional
+public class SnmpInterfaceRestService extends AbstractDaoRestService<OnmsSnmpInterface,SearchBean,Integer,String> {
+
+    @Autowired
+    private SnmpInterfaceDao m_dao;
+
+    @Override
+    protected SnmpInterfaceDao getDao() {
+        return m_dao;
+    }
+
+    @Override
+    protected Class<OnmsSnmpInterface> getDaoClass() {
+        return OnmsSnmpInterface.class;
+    }
+
+    @Override
+    protected Class<SearchBean> getQueryBeanClass() {
+        return SearchBean.class;
+    }
+
+    @Override
+    protected CriteriaBuilder getCriteriaBuilder(final UriInfo uriInfo) {
+        final CriteriaBuilder builder = new CriteriaBuilder(getDaoClass());
+        // 1st level JOINs
+        builder.alias("node", Aliases.node.toString(), JoinType.LEFT_JOIN);
+        builder.alias("ipInterfaces", Aliases.ipInterface.toString(), JoinType.LEFT_JOIN);
+
+        // 2nd level JOINs
+        builder.alias(Aliases.node.prop("assetRecord"), Aliases.assetRecord.toString(), JoinType.LEFT_JOIN);
+        builder.alias(Aliases.node.prop("location"), Aliases.location.toString(), JoinType.LEFT_JOIN);
+
+        builder.orderBy("id");
+
+        return builder;
+    }
+
+    @Override
+    protected JaxbListWrapper<OnmsSnmpInterface> createListWrapper(Collection<OnmsSnmpInterface> list) {
+        return new OnmsSnmpInterfaceList(list);
+    }
+
+    @Override
+    protected Set<SearchProperty> getQueryProperties() {
+        return SearchProperties.SNMP_INTERFACE_SERVICE_PROPERTIES;
+    }
+
+    @Override
+    protected Map<String,CriteriaBehavior<?>> getCriteriaBehaviors() {
+        final Map<String,CriteriaBehavior<?>> map = new HashMap<>();
+
+        // Root alias
+        map.putAll(CriteriaBehaviors.SNMP_INTERFACE_BEHAVIORS);
+
+        // 1st level JOINs
+        map.putAll(CriteriaBehaviors.withAliasPrefix(Aliases.node, CriteriaBehaviors.NODE_BEHAVIORS));
+        map.putAll(CriteriaBehaviors.withAliasPrefix(Aliases.snmpInterface, CriteriaBehaviors.SNMP_INTERFACE_BEHAVIORS));
+
+        // 2nd level JOINs
+        map.putAll(CriteriaBehaviors.withAliasPrefix(Aliases.assetRecord, CriteriaBehaviors.ASSET_RECORD_BEHAVIORS));
+        map.putAll(CriteriaBehaviors.withAliasPrefix(Aliases.location, CriteriaBehaviors.MONITORING_LOCATION_BEHAVIORS));
+
+        return map;
+    }
+
+    @Override
+    protected OnmsSnmpInterface doGet(final UriInfo uriInfo, final String id) {
+        return getDao().get(Integer.valueOf(id));
+    }
+}

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/SnmpInterfaceRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/SnmpInterfaceRestService.java
@@ -98,7 +98,7 @@ public class SnmpInterfaceRestService extends AbstractDaoRestService<OnmsSnmpInt
     }
 
     @Override
-    protected JaxbListWrapper<OnmsSnmpInterface> createListWrapper(Collection<OnmsSnmpInterface> list) {
+    protected final JaxbListWrapper<OnmsSnmpInterface> createListWrapper(Collection<OnmsSnmpInterface> list) {
         return new OnmsSnmpInterfaceList(list);
     }
 
@@ -126,7 +126,7 @@ public class SnmpInterfaceRestService extends AbstractDaoRestService<OnmsSnmpInt
     }
 
     @Override
-    protected OnmsSnmpInterface doGet(final UriInfo uriInfo, final String id) {
+    protected final OnmsSnmpInterface doGet(final UriInfo uriInfo, final String id) {
         return getDao().get(Integer.valueOf(id));
     }
 }

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v2/IpInterfaceRestServiceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v2/IpInterfaceRestServiceIT.java
@@ -1,0 +1,153 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.web.rest.v2;
+
+import static org.junit.Assert.assertEquals;
+
+import org.jfree.util.Log;
+import org.json.JSONObject;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.opennms.core.test.MockLogAppender;
+import org.opennms.core.test.OpenNMSJUnit4ClassRunner;
+import org.opennms.core.test.db.annotations.JUnitTemporaryDatabase;
+import org.opennms.core.test.rest.AbstractSpringJerseyRestTestCase;
+import org.opennms.test.JUnitConfigurationEnvironment;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.web.WebAppConfiguration;
+
+/**
+ * TODO
+ * 1. Need to figure it out how to create a Mock for EventProxy to validate events sent by RESTful service
+ */
+@RunWith(OpenNMSJUnit4ClassRunner.class)
+@WebAppConfiguration
+@ContextConfiguration(locations={
+        "classpath:/META-INF/opennms/applicationContext-soa.xml",
+        "classpath:/META-INF/opennms/applicationContext-commonConfigs.xml",
+        "classpath:/META-INF/opennms/applicationContext-minimal-conf.xml",
+        "classpath:/META-INF/opennms/applicationContext-dao.xml",
+        "classpath*:/META-INF/opennms/component-service.xml",
+        "classpath*:/META-INF/opennms/component-dao.xml",
+        "classpath:/META-INF/opennms/applicationContext-databasePopulator.xml",
+        "classpath:/META-INF/opennms/mockEventIpcManager.xml",
+        "file:src/main/webapp/WEB-INF/applicationContext-svclayer.xml",
+        "file:src/main/webapp/WEB-INF/applicationContext-cxf-common.xml"
+})
+@JUnitConfigurationEnvironment
+@JUnitTemporaryDatabase
+public class IpInterfaceRestServiceIT extends AbstractSpringJerseyRestTestCase {
+    private static final Logger LOG = LoggerFactory.getLogger(IpInterfaceRestServiceIT.class);
+
+    public IpInterfaceRestServiceIT() {
+        super(CXF_REST_V2_CONTEXT_PATH);
+    }
+
+    @Override
+    protected void afterServletStart() throws Exception {
+        MockLogAppender.setupLogging(true, "DEBUG");
+    }
+
+    @Test
+    @JUnitTemporaryDatabase
+    public void testFiqlSearch() throws Exception {
+        // Add a node with an IP interface
+        createNode(201);
+        createIpInterface();
+
+        String url = "/ipinterfaces";
+
+        LOG.warn(sendRequest(GET, url, parseParamData("_s=ipAddress==10.10.10.10"), 200));
+        LOG.warn(sendRequest(GET, url, parseParamData("_s=node.label==*1"), 200));
+    }
+
+    @Test
+    @JUnitTemporaryDatabase
+    public void testAllEndPoints() throws Exception {
+        sendPost("/monitoringLocations", "<location location-name=\"location1\" monitoring-area=\"location1\" priority=\"1\"/>", 201);
+        String node1 = "<node type=\"A\" label=\"TestMachine1\" foreignSource=\"JUnit\" foreignId=\"TestMachine1\">" +
+                "<location>location1</location>" +
+                "<labelSource>H</labelSource>" +
+                "<sysContact>The Owner</sysContact>" +
+                "<sysDescription>" +
+                "Darwin TestMachine 9.4.0 Darwin Kernel Version 9.4.0: Mon Jun  9 19:30:53 PDT 2008; root:xnu-1228.5.20~1/RELEASE_I386 i386" +
+                "</sysDescription>" +
+                "<sysLocation>DevJam</sysLocation>" +
+                "<sysName>TestMachine1</sysName>" +
+                "<sysObjectId>.1.3.6.1.4.1.8072.3.2.255</sysObjectId>" +
+                "</node>";
+        sendPost("/nodes", node1, 201);
+
+        Log.warn(sendRequest(GET, "/nodes/1/ipinterfaces", 204));
+        Log.warn(sendRequest(GET, "/nodes/1/ipinterfaces/10.10.10.10", 404));
+        Log.warn(sendRequest(GET, "/ipinterfaces", 204));
+        Log.warn(sendRequest(GET, "/ipinterfaces/10.10.10.10", 404));
+
+        String ipInterface1 = "<ipInterface snmpPrimary=\"P\">" +
+                "<ipAddress>10.10.10.10</ipAddress>" +
+                "<nodeId>1</nodeId>" +
+                "<hostName>TestMachine1</hostName>" +
+                "</ipInterface>";
+        sendPost("/nodes/1/ipinterfaces", ipInterface1, 201);
+        LOG.warn(sendRequest(GET, "/ipinterfaces", 200));
+        LOG.warn(sendRequest(GET, "/ipinterfaces/10.10.10.10", 200)); // By IP Address
+
+        // add another node in a different location with a duplicate IP
+        sendPost("/monitoringLocations", "<location location-name=\"location2\" monitoring-area=\"location2\" priority=\"1\"/>", 201);
+        String node2 = "<node type=\"A\" label=\"TestMachine2\" foreignSource=\"JUnit\" foreignId=\"TestMachine2\">" +
+                "<location>location2</location>" +
+                "<labelSource>H</labelSource>" +
+                "<sysContact>The Owner</sysContact>" +
+                "<sysDescription>" +
+                "Darwin TestMachine 9.4.0 Darwin Kernel Version 9.4.0: Mon Jun  9 19:30:53 PDT 2008; root:xnu-1228.5.20~1/RELEASE_I386 i386" +
+                "</sysDescription>" +
+                "<sysLocation>DevJam</sysLocation>" +
+                "<sysName>TestMachine1</sysName>" +
+                "<sysObjectId>.1.3.6.1.4.1.8072.3.2.255</sysObjectId>" +
+                "</node>";
+        sendPost("/nodes", node2, 201);
+
+        String ipInterface2 = "<ipInterface snmpPrimary=\"P\">" +
+                "<ipAddress>10.10.10.10</ipAddress>" +
+                "<nodeId>2</nodeId>" +
+                "<hostName>TestMachine2</hostName>" +
+                "</ipInterface>";
+        sendPost("/nodes/2/ipinterfaces", ipInterface2, 201);
+        LOG.warn(sendRequest(GET, "/ipinterfaces", 200));
+
+        // By IP address should fail if more than one interface maches, use the query format instead
+        LOG.warn(sendRequest(GET, "/ipinterfaces/10.10.10.10", 400));
+
+        final String jsonResponse = sendRequest(GET, "/ipinterfaces", parseParamData("_s=ipAddress==10.10.10.10"), 200);
+        final JSONObject response = new org.json.JSONObject(jsonResponse);
+        assertEquals(2, response.getInt("count"));
+    }
+}

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v2/SnmpInterfaceRestServiceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v2/SnmpInterfaceRestServiceIT.java
@@ -1,0 +1,156 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.web.rest.v2;
+
+import static org.junit.Assert.assertEquals;
+
+import org.jfree.util.Log;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.opennms.core.test.MockLogAppender;
+import org.opennms.core.test.OpenNMSJUnit4ClassRunner;
+import org.opennms.core.test.db.annotations.JUnitTemporaryDatabase;
+import org.opennms.core.test.rest.AbstractSpringJerseyRestTestCase;
+import org.opennms.test.JUnitConfigurationEnvironment;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.web.WebAppConfiguration;
+
+/**
+ * TODO
+ * 1. Need to figure it out how to create a Mock for EventProxy to validate events sent by RESTful service
+ */
+@RunWith(OpenNMSJUnit4ClassRunner.class)
+@WebAppConfiguration
+@ContextConfiguration(locations={
+        "classpath:/META-INF/opennms/applicationContext-soa.xml",
+        "classpath:/META-INF/opennms/applicationContext-commonConfigs.xml",
+        "classpath:/META-INF/opennms/applicationContext-minimal-conf.xml",
+        "classpath:/META-INF/opennms/applicationContext-dao.xml",
+        "classpath*:/META-INF/opennms/component-service.xml",
+        "classpath*:/META-INF/opennms/component-dao.xml",
+        "classpath:/META-INF/opennms/applicationContext-databasePopulator.xml",
+        "classpath:/META-INF/opennms/mockEventIpcManager.xml",
+        "file:src/main/webapp/WEB-INF/applicationContext-svclayer.xml",
+        "file:src/main/webapp/WEB-INF/applicationContext-cxf-common.xml"
+})
+@JUnitConfigurationEnvironment
+@JUnitTemporaryDatabase
+public class SnmpInterfaceRestServiceIT extends AbstractSpringJerseyRestTestCase {
+    private static final Logger LOG = LoggerFactory.getLogger(SnmpInterfaceRestServiceIT.class);
+
+    public SnmpInterfaceRestServiceIT() {
+        super(CXF_REST_V2_CONTEXT_PATH);
+    }
+
+    @Override
+    protected void afterServletStart() throws Exception {
+        MockLogAppender.setupLogging(true, "DEBUG");
+    }
+
+    @Test
+    @JUnitTemporaryDatabase
+    public void testAllEndPoints() throws Exception {
+        sendPost("/monitoringLocations", "<location location-name=\"location1\" monitoring-area=\"location1\" priority=\"1\"/>", 201);
+        String node1 = "<node type=\"A\" label=\"TestMachine1\" foreignSource=\"JUnit\" foreignId=\"TestMachine1\">" +
+                "<location>location1</location>" +
+                "<labelSource>H</labelSource>" +
+                "<sysContact>The Owner</sysContact>" +
+                "<sysDescription>" +
+                "Darwin TestMachine 9.4.0 Darwin Kernel Version 9.4.0: Mon Jun  9 19:30:53 PDT 2008; root:xnu-1228.5.20~1/RELEASE_I386 i386" +
+                "</sysDescription>" +
+                "<sysLocation>DevJam</sysLocation>" +
+                "<sysName>TestMachine1</sysName>" +
+                "<sysObjectId>.1.3.6.1.4.1.8072.3.2.255</sysObjectId>" +
+                "</node>";
+        sendPost("/nodes", node1, 201);
+
+        Log.warn(sendRequest(GET, "/nodes/1/snmpinterfaces", 204));
+        Log.warn(sendRequest(GET, "/nodes/1/snmpinterfaces/6", 404));
+        Log.warn(sendRequest(GET, "/snmpinterfaces", 204));
+        Log.warn(sendRequest(GET, "/snmpinterfaces/1", 404));
+
+        String snmpInterface1 = "<snmpInterface ifIndex=\"6\">" +
+                "<ifAdminStatus>1</ifAdminStatus>" +
+                "<ifDescr>en1</ifDescr>" +
+                "<ifName>en1</ifName>" +
+                "<ifOperStatus>1</ifOperStatus>" +
+                "<ifSpeed>10000000</ifSpeed>" +
+                "<ifType>6</ifType>" +
+                "<netMask>255.255.255.0</netMask>" +
+                "<physAddr>001e5271136d</physAddr>" +
+                "</snmpInterface>";
+        sendPost("/nodes/1/snmpinterfaces", snmpInterface1, 201, "/nodes/1/snmpinterfaces/6");
+
+        LOG.warn(sendRequest(GET, "/snmpinterfaces", parseParamData("_s=ifIndex==6"), 200));
+        LOG.warn(sendRequest(GET, "/snmpinterfaces", parseParamData("_s=node.label==*1"), 200));
+        LOG.warn(sendRequest(GET, "/snmpinterfaces", parseParamData("_s=ifName==en1"), 200));
+
+        JSONObject response = new JSONObject(sendRequest(GET, "/snmpinterfaces", 200));
+        assertEquals(1, response.getInt("count"));
+        JSONArray objects = response.getJSONArray("snmpInterface");
+        JSONObject object = objects.getJSONObject(0);
+        LOG.warn(sendRequest(GET, "/snmpinterfaces/" + object.getInt("id"), 200)); // By ID
+
+        // add another node in a different location with a duplicate IP
+        sendPost("/monitoringLocations", "<location location-name=\"location2\" monitoring-area=\"location2\" priority=\"1\"/>", 201);
+        String node2 = "<node type=\"A\" label=\"TestMachine2\" foreignSource=\"JUnit\" foreignId=\"TestMachine2\">" +
+                "<location>location2</location>" +
+                "<labelSource>H</labelSource>" +
+                "<sysContact>The Owner</sysContact>" +
+                "<sysDescription>" +
+                "Darwin TestMachine 9.4.0 Darwin Kernel Version 9.4.0: Mon Jun  9 19:30:53 PDT 2008; root:xnu-1228.5.20~1/RELEASE_I386 i386" +
+                "</sysDescription>" +
+                "<sysLocation>DevJam</sysLocation>" +
+                "<sysName>TestMachine1</sysName>" +
+                "<sysObjectId>.1.3.6.1.4.1.8072.3.2.255</sysObjectId>" +
+                "</node>";
+        sendPost("/nodes", node2, 201);
+
+        String snmpInterface2 = "<snmpInterface ifIndex=\"6\">" +
+                "<ifAdminStatus>1</ifAdminStatus>" +
+                "<ifDescr>en1</ifDescr>" +
+                "<ifName>en1</ifName>" +
+                "<ifOperStatus>1</ifOperStatus>" +
+                "<ifSpeed>10000000</ifSpeed>" +
+                "<ifType>6</ifType>" +
+                "<netMask>255.255.255.0</netMask>" +
+                "<physAddr>001e5271136d</physAddr>" +
+                "</snmpInterface>";
+        sendPost("/nodes/2/snmpinterfaces", snmpInterface2, 201, "/nodes/2/snmpinterfaces/6");
+        LOG.warn(sendRequest(GET, "/snmpinterfaces", 200));
+
+        String jsonResponse = sendRequest(GET, "/snmpinterfaces", parseParamData("_s=ifIndex==6"), 200);
+        response = new org.json.JSONObject(jsonResponse);
+        assertEquals(2, response.getInt("count"));
+    }
+}


### PR DESCRIPTION
This PR adds (read-only) `/ipinterfaces` and `/snmpinterfaces` endpoints under ReSTv2.

* JIRA (Issue Tracker): http://issues.opennms.org/browse/ULU-62
* Bamboo (Continuous Integration): https://bamboo.opennms.org/

