### PR TITLE
NMS-12552: Make BMP parser more relaxed

### DIFF
--- a/features/telemetry/protocols/bmp/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/bmp/parser/BmpParser.java
+++ b/features/telemetry/protocols/bmp/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/bmp/parser/BmpParser.java
@@ -406,6 +406,10 @@ public class BmpParser implements TcpParser {
                     public void visit(final Rejected rejected) {
                         message.getRejectedBuilder().setCount((int) rejected.counter);
                     }
+
+                    @Override
+                    public void visit(final org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bmp.packets.stats.Unknown unknown) {
+                    }
                 });
             }
         }
@@ -453,6 +457,8 @@ public class BmpParser implements TcpParser {
                                         return Transport.RouteMonitoringPacket.PathAttribute.AsPath.Segment.Type.AS_SET;
                                     case AS_SEQUENCE:
                                         return Transport.RouteMonitoringPacket.PathAttribute.AsPath.Segment.Type.AS_SEQUENCE;
+                                    case UNKNOWN:
+                                        return Transport.RouteMonitoringPacket.PathAttribute.AsPath.Segment.Type.UNRECOGNIZED;
                                     default:
                                         throw new IllegalStateException();
                                 }
@@ -496,10 +502,16 @@ public class BmpParser implements TcpParser {
                                     return Transport.RouteMonitoringPacket.PathAttribute.Origin.EGP;
                                 case INCOMPLETE:
                                     return Transport.RouteMonitoringPacket.PathAttribute.Origin.INCOMPLETE;
+                                case UNKNOWN:
+                                    return Transport.RouteMonitoringPacket.PathAttribute.Origin.UNRECOGNIZED;
                                 default:
                                     throw new IllegalStateException();
                             }
                         }));
+                    }
+
+                    @Override
+                    public void visit(org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bgp.packets.pathattr.Unknown unknown) {
                     }
                 });
             }

--- a/features/telemetry/protocols/bmp/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/bmp/parser/proto/bgp/packets/NotificationPacket.java
+++ b/features/telemetry/protocols/bmp/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/bmp/parser/proto/bgp/packets/NotificationPacket.java
@@ -34,6 +34,7 @@ import static org.opennms.netmgt.telemetry.listeners.utils.BufferUtils.uint8;
 
 import java.util.Objects;
 
+import org.opennms.netmgt.telemetry.protocols.bmp.parser.BmpParser;
 import org.opennms.netmgt.telemetry.protocols.bmp.parser.InvalidPacketException;
 import org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bgp.Header;
 import org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bgp.Packet;
@@ -99,6 +100,8 @@ public class NotificationPacket implements Packet {
         OTHER_CONFIGURATION_CHANGE,         // 6
         CONNECTION_COLLISION_RESOLUTION,    // 7
         OUT_OF_RESOURCES,                   // 8
+
+        UNKNOWN,
         ;
 
         public static Error from(final int code, final int subcode) {
@@ -140,7 +143,8 @@ public class NotificationPacket implements Packet {
                 case (6 << 8) + 8: return OUT_OF_RESOURCES;
 
                 default:
-                    throw new IllegalArgumentException("Unknown error code: " + code + "/" + subcode);
+                    BmpParser.LOG.warn("Unknown Notification Packet Code: {}/{}", code, subcode);
+                    return UNKNOWN;
             }
         }
     }

--- a/features/telemetry/protocols/bmp/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/bmp/parser/proto/bgp/packets/UpdatePacket.java
+++ b/features/telemetry/protocols/bmp/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/bmp/parser/proto/bgp/packets/UpdatePacket.java
@@ -38,6 +38,7 @@ import java.util.List;
 import java.util.Objects;
 
 import org.opennms.core.utils.InetAddressUtils;
+import org.opennms.netmgt.telemetry.protocols.bmp.parser.BmpParser;
 import org.opennms.netmgt.telemetry.protocols.bmp.parser.InvalidPacketException;
 import org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bgp.Header;
 import org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bgp.Packet;
@@ -49,6 +50,7 @@ import org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bgp.packets.patha
 import org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bgp.packets.pathattr.MultiExistDisc;
 import org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bgp.packets.pathattr.NextHop;
 import org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bgp.packets.pathattr.Origin;
+import org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bgp.packets.pathattr.Unknown;
 import org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bmp.PeerFlags;
 
 import com.google.common.base.MoreObjects;
@@ -173,6 +175,13 @@ public class UpdatePacket implements Packet {
                 public Attribute parse(final ByteBuf buffer, final PeerFlags flags) throws InvalidPacketException {
                     return new Aggregator(buffer, flags);
                 }
+            },
+
+            UNKNOWN {
+                @Override
+                public Attribute parse(final ByteBuf buffer, final PeerFlags flags) throws InvalidPacketException {
+                    return new Unknown(buffer, flags);
+                }
             };
 
             public abstract Attribute parse(final ByteBuf buffer, final PeerFlags flags) throws InvalidPacketException;
@@ -187,7 +196,8 @@ public class UpdatePacket implements Packet {
                     case 6: return ATOMIC_AGGREGATE;
                     case 7: return AGGREGATOR;
                     default:
-                        throw new IllegalArgumentException("Unknown path attribute type: " + type);
+                        BmpParser.LOG.warn("Unknown Update Packet Type: {}", type);
+                        return UNKNOWN;
                 }
             }
         }

--- a/features/telemetry/protocols/bmp/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/bmp/parser/proto/bgp/packets/pathattr/AsPath.java
+++ b/features/telemetry/protocols/bmp/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/bmp/parser/proto/bgp/packets/pathattr/AsPath.java
@@ -35,6 +35,7 @@ import java.util.List;
 import java.util.function.Function;
 
 import org.opennms.netmgt.telemetry.listeners.utils.BufferUtils;
+import org.opennms.netmgt.telemetry.protocols.bmp.parser.BmpParser;
 import org.opennms.netmgt.telemetry.protocols.bmp.parser.InvalidPacketException;
 import org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bmp.PeerFlags;
 
@@ -60,14 +61,16 @@ public class AsPath implements Attribute {
 
         public enum Type {
             AS_SET,
-            AS_SEQUENCE;
+            AS_SEQUENCE,
+            UNKNOWN;
 
             public static Type from(final int type) {
                 switch (type) {
                     case 1: return AS_SET;
                     case 2: return AS_SEQUENCE;
                     default:
-                        throw new IllegalArgumentException("Unknown segment type: " + type);
+                        BmpParser.LOG.warn("Unknown AS Path Type: {}", type);
+                        return UNKNOWN;
                 }
             }
 

--- a/features/telemetry/protocols/bmp/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/bmp/parser/proto/bgp/packets/pathattr/Attribute.java
+++ b/features/telemetry/protocols/bmp/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/bmp/parser/proto/bgp/packets/pathattr/Attribute.java
@@ -39,5 +39,6 @@ public interface Attribute {
         void visit(final MultiExistDisc multiExistDisc);
         void visit(final NextHop nextHop);
         void visit(final Origin origin);
+        void visit(final Unknown unknown);
     }
 }

--- a/features/telemetry/protocols/bmp/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/bmp/parser/proto/bgp/packets/pathattr/Unknown.java
+++ b/features/telemetry/protocols/bmp/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/bmp/parser/proto/bgp/packets/pathattr/Unknown.java
@@ -28,44 +28,14 @@
 
 package org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bgp.packets.pathattr;
 
-import static org.opennms.netmgt.telemetry.listeners.utils.BufferUtils.uint8;
-
-import java.util.function.Function;
-
-import org.opennms.netmgt.telemetry.protocols.bmp.parser.BmpParser;
 import org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bmp.PeerFlags;
 
 import com.google.common.base.MoreObjects;
 
 import io.netty.buffer.ByteBuf;
 
-public class Origin implements Attribute {
-    public final Value value;
-
-    public Origin(final ByteBuf buffer, final PeerFlags flags) {
-        this.value = Value.from(uint8(buffer));
-    }
-
-    public enum Value {
-        IGP,
-        EGP,
-        INCOMPLETE,
-        UNKNOWN;
-
-        private static Value from(final int code) {
-            switch (code) {
-                case 0: return IGP;
-                case 1: return EGP;
-                case 2: return INCOMPLETE;
-                default:
-                    BmpParser.LOG.warn("Unknown Originator Code: {}", code);
-                    return UNKNOWN;
-            }
-        }
-
-        public <R> R map(final Function<Value, R> mapper) {
-            return mapper.apply(this);
-        }
+public class Unknown implements Attribute {
+    public Unknown(final ByteBuf buffer, final PeerFlags flags) {
     }
 
     @Override
@@ -76,7 +46,6 @@ public class Origin implements Attribute {
     @Override
     public String toString() {
         return MoreObjects.toStringHelper(this)
-                .add("value", this.value)
                 .toString();
     }
 }

--- a/features/telemetry/protocols/bmp/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/bmp/parser/proto/bmp/InformationElement.java
+++ b/features/telemetry/protocols/bmp/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/bmp/parser/proto/bmp/InformationElement.java
@@ -32,6 +32,7 @@ import static org.opennms.netmgt.telemetry.listeners.utils.BufferUtils.bytes;
 
 import java.nio.charset.StandardCharsets;
 
+import org.opennms.netmgt.telemetry.protocols.bmp.parser.BmpParser;
 import org.opennms.netmgt.telemetry.protocols.bmp.parser.InvalidPacketException;
 
 import io.netty.buffer.ByteBuf;
@@ -62,6 +63,13 @@ public class InformationElement extends TLV<InformationElement.Type, String, Voi
             public String parse(final ByteBuf buffer, final Void parameter) {
                 return new String(bytes(buffer, buffer.readableBytes()), StandardCharsets.US_ASCII);
             }
+        },
+
+        UNKNOWN {
+            @Override
+            public String parse(final ByteBuf buffer, final Void parameter) {
+                return "Unknown";
+            }
         };
 
         private static Type from(final int type) {
@@ -73,7 +81,8 @@ public class InformationElement extends TLV<InformationElement.Type, String, Voi
                 case 2:
                     return SYS_NAME;
                 default:
-                    throw new IllegalArgumentException("Unknown information type");
+                    BmpParser.LOG.warn("Unknown Information Element Type: {}", type);
+                    return UNKNOWN;
             }
         }
     }

--- a/features/telemetry/protocols/bmp/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/bmp/parser/proto/bmp/packets/PeerDownPacket.java
+++ b/features/telemetry/protocols/bmp/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/bmp/parser/proto/bmp/packets/PeerDownPacket.java
@@ -32,6 +32,7 @@ import static org.opennms.netmgt.telemetry.listeners.utils.BufferUtils.uint8;
 
 import java.util.Objects;
 
+import org.opennms.netmgt.telemetry.protocols.bmp.parser.BmpParser;
 import org.opennms.netmgt.telemetry.protocols.bmp.parser.InvalidPacketException;
 import org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bmp.Header;
 import org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bmp.Packet;
@@ -103,10 +104,9 @@ public class PeerDownPacket implements Packet {
                 case 2: return LOCAL_NO_NOTIFICATION;
                 case 3: return REMOTE_BGP_NOTIFICATION;
                 case 4: return REMOTE_NO_NOTIFICATION;
-                case 5: return UNKNOWN;
-
                 default:
-                    throw new IllegalArgumentException("Unknown statistic type");
+                    BmpParser.LOG.warn("Unknown Peer Down Type: {}", type);
+                    return UNKNOWN;
             }
         }
     }

--- a/features/telemetry/protocols/bmp/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/bmp/parser/proto/bmp/packets/RouteMirroringPacket.java
+++ b/features/telemetry/protocols/bmp/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/bmp/parser/proto/bmp/packets/RouteMirroringPacket.java
@@ -32,6 +32,7 @@ import static org.opennms.netmgt.telemetry.listeners.utils.BufferUtils.repeatRem
 
 import java.util.Objects;
 
+import org.opennms.netmgt.telemetry.protocols.bmp.parser.BmpParser;
 import org.opennms.netmgt.telemetry.protocols.bmp.parser.InvalidPacketException;
 import org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bmp.Header;
 import org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bmp.Packet;
@@ -82,16 +83,21 @@ public class RouteMirroringPacket implements Packet {
                 public Mirroring parse(final ByteBuf buffer, final PeerFlags flags) throws InvalidPacketException {
                     return new Information(buffer, flags);
                 }
+            },
+            UNKNOWN{
+                @Override
+                public Mirroring parse(final ByteBuf buffer, final PeerFlags parameter) throws InvalidPacketException {
+                    return null;
+                }
             };
 
             private static Type from(final int type) {
                 switch (type) {
-                    case 0:
-                        return BGP_MESSAGE;
-                    case 1:
-                        return INFORMATION;
+                    case 0: return BGP_MESSAGE;
+                    case 1: return INFORMATION;
                     default:
-                        throw new IllegalArgumentException("Unknown message type");
+                        BmpParser.LOG.warn("Unknown Route Mirroring Packet Type: {}", type);
+                        return UNKNOWN;
                 }
             }
         }

--- a/features/telemetry/protocols/bmp/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/bmp/parser/proto/bmp/packets/StatisticsReportPacket.java
+++ b/features/telemetry/protocols/bmp/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/bmp/parser/proto/bmp/packets/StatisticsReportPacket.java
@@ -34,6 +34,7 @@ import static org.opennms.netmgt.telemetry.listeners.utils.BufferUtils.uint32;
 import java.util.Objects;
 import java.util.function.Function;
 
+import org.opennms.netmgt.telemetry.protocols.bmp.parser.BmpParser;
 import org.opennms.netmgt.telemetry.protocols.bmp.parser.InvalidPacketException;
 import org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bmp.Header;
 import org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bmp.Packet;
@@ -55,6 +56,7 @@ import org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bmp.packets.stats
 import org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bmp.packets.stats.PerAfiLocRib;
 import org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bmp.packets.stats.PrefixTreatAsWithdraw;
 import org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bmp.packets.stats.Rejected;
+import org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bmp.packets.stats.Unknown;
 import org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bmp.packets.stats.UpdateTreatAsWithdraw;
 
 import com.google.common.base.MoreObjects;
@@ -102,6 +104,7 @@ public class StatisticsReportPacket implements Packet {
             DUPLICATE_UPDATE(DuplicateUpdate::new),
             ADJ_RIB_OUT(AdjRibOut::new),
             EXPORT_RIB(ExportRib::new),
+            UNKNOWN(Unknown::new)
             ;
 
             private final Function<ByteBuf, Metric> parser;
@@ -128,9 +131,9 @@ public class StatisticsReportPacket implements Packet {
                     case 13: return DUPLICATE_UPDATE;
                     case 14: return ADJ_RIB_OUT;
                     case 15: return EXPORT_RIB;
-
                     default:
-                        throw new IllegalArgumentException("Unknown statistic type");
+                        BmpParser.LOG.warn("Unknown Statistic Report Type: {}", type);
+                        return UNKNOWN;
                 }
             }
 

--- a/features/telemetry/protocols/bmp/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/bmp/parser/proto/bmp/packets/TerminationPacket.java
+++ b/features/telemetry/protocols/bmp/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/bmp/parser/proto/bmp/packets/TerminationPacket.java
@@ -35,6 +35,7 @@ import static org.opennms.netmgt.telemetry.listeners.utils.BufferUtils.uint16;
 import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 
+import org.opennms.netmgt.telemetry.protocols.bmp.parser.BmpParser;
 import org.opennms.netmgt.telemetry.protocols.bmp.parser.InvalidPacketException;
 import org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bmp.Header;
 import org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bmp.Packet;
@@ -92,6 +93,13 @@ public class TerminationPacket implements Packet {
                             return "Unknown reason";
                     }
                 }
+            },
+
+            UNKNOWN {
+                @Override
+                public String parse(final ByteBuf buffer, final Void parameter) throws InvalidPacketException {
+                    return "Unknown reason";
+                }
             };
 
             private static Element.Type from(final int type) {
@@ -101,7 +109,8 @@ public class TerminationPacket implements Packet {
                     case 1:
                         return REASON;
                     default:
-                        throw new IllegalArgumentException("Unknown termination type");
+                        BmpParser.LOG.warn("Unknown Termination Packet Type: {}", type);
+                        return UNKNOWN;
                 }
             }
         }

--- a/features/telemetry/protocols/bmp/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/bmp/parser/proto/bmp/packets/mirroring/Information.java
+++ b/features/telemetry/protocols/bmp/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/bmp/parser/proto/bmp/packets/mirroring/Information.java
@@ -30,6 +30,8 @@ package org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bmp.packets.mirr
 
 import static org.opennms.netmgt.telemetry.listeners.utils.BufferUtils.uint16;
 
+import org.omg.CORBA.UNKNOWN;
+import org.opennms.netmgt.telemetry.protocols.bmp.parser.BmpParser;
 import org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bmp.PeerFlags;
 
 import io.netty.buffer.ByteBuf;
@@ -48,15 +50,16 @@ public class Information implements Mirroring {
 
     public enum Code {
         ERRORED_PDU,
-        MESSAGES_LOST;
+        MESSAGES_LOST,
+        UNKNOWN;
 
         private static Code from(final int code) {
             switch (code) {
                 case 0: return ERRORED_PDU;
                 case 1: return MESSAGES_LOST;
-
                 default:
-                    throw new IllegalArgumentException("Unknown message code");
+                    BmpParser.LOG.warn("Unknown Mirroring Information Code: {}", code);
+                    return UNKNOWN;
             }
         }
     }

--- a/features/telemetry/protocols/bmp/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/bmp/parser/proto/bmp/packets/mirroring/Mirroring.java
+++ b/features/telemetry/protocols/bmp/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/bmp/parser/proto/bmp/packets/mirroring/Mirroring.java
@@ -34,5 +34,6 @@ public interface Mirroring {
     interface Visitor {
         void visit(final BgpMessage bgpMessage);
         void visit(final Information information);
+        void visit(final Unknown unknown);
     }
 }

--- a/features/telemetry/protocols/bmp/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/bmp/parser/proto/bmp/packets/mirroring/Unknown.java
+++ b/features/telemetry/protocols/bmp/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/bmp/parser/proto/bmp/packets/mirroring/Unknown.java
@@ -26,57 +26,21 @@
  *     http://www.opennms.com/
  *******************************************************************************/
 
-package org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bgp.packets.pathattr;
+package org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bmp.packets.mirroring;
 
-import static org.opennms.netmgt.telemetry.listeners.utils.BufferUtils.uint8;
+import static org.opennms.netmgt.telemetry.listeners.utils.BufferUtils.uint16;
 
-import java.util.function.Function;
-
-import org.opennms.netmgt.telemetry.protocols.bmp.parser.BmpParser;
 import org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bmp.PeerFlags;
-
-import com.google.common.base.MoreObjects;
 
 import io.netty.buffer.ByteBuf;
 
-public class Origin implements Attribute {
-    public final Value value;
+public class Unknown implements Mirroring {
 
-    public Origin(final ByteBuf buffer, final PeerFlags flags) {
-        this.value = Value.from(uint8(buffer));
-    }
-
-    public enum Value {
-        IGP,
-        EGP,
-        INCOMPLETE,
-        UNKNOWN;
-
-        private static Value from(final int code) {
-            switch (code) {
-                case 0: return IGP;
-                case 1: return EGP;
-                case 2: return INCOMPLETE;
-                default:
-                    BmpParser.LOG.warn("Unknown Originator Code: {}", code);
-                    return UNKNOWN;
-            }
-        }
-
-        public <R> R map(final Function<Value, R> mapper) {
-            return mapper.apply(this);
-        }
+    public Unknown(final ByteBuf buffer, final PeerFlags flags) {
     }
 
     @Override
     public void accept(final Visitor visitor) {
         visitor.visit(this);
-    }
-
-    @Override
-    public String toString() {
-        return MoreObjects.toStringHelper(this)
-                .add("value", this.value)
-                .toString();
     }
 }

--- a/features/telemetry/protocols/bmp/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/bmp/parser/proto/bmp/packets/stats/Metric.java
+++ b/features/telemetry/protocols/bmp/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/bmp/parser/proto/bmp/packets/stats/Metric.java
@@ -48,5 +48,6 @@ public interface Metric {
         void visit(final LocRib locRib);
         void visit(final DuplicateUpdate duplicateUpdate);
         void visit(final Rejected rejected);
+        void visit(final Unknown unknown);
     }
 }

--- a/features/telemetry/protocols/bmp/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/bmp/parser/proto/bmp/packets/stats/Unknown.java
+++ b/features/telemetry/protocols/bmp/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/bmp/parser/proto/bmp/packets/stats/Unknown.java
@@ -26,57 +26,16 @@
  *     http://www.opennms.com/
  *******************************************************************************/
 
-package org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bgp.packets.pathattr;
-
-import static org.opennms.netmgt.telemetry.listeners.utils.BufferUtils.uint8;
-
-import java.util.function.Function;
-
-import org.opennms.netmgt.telemetry.protocols.bmp.parser.BmpParser;
-import org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bmp.PeerFlags;
-
-import com.google.common.base.MoreObjects;
+package org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bmp.packets.stats;
 
 import io.netty.buffer.ByteBuf;
 
-public class Origin implements Attribute {
-    public final Value value;
-
-    public Origin(final ByteBuf buffer, final PeerFlags flags) {
-        this.value = Value.from(uint8(buffer));
-    }
-
-    public enum Value {
-        IGP,
-        EGP,
-        INCOMPLETE,
-        UNKNOWN;
-
-        private static Value from(final int code) {
-            switch (code) {
-                case 0: return IGP;
-                case 1: return EGP;
-                case 2: return INCOMPLETE;
-                default:
-                    BmpParser.LOG.warn("Unknown Originator Code: {}", code);
-                    return UNKNOWN;
-            }
-        }
-
-        public <R> R map(final Function<Value, R> mapper) {
-            return mapper.apply(this);
-        }
+public class Unknown implements Metric {
+    public Unknown(final ByteBuf buffer) {
     }
 
     @Override
     public void accept(final Visitor visitor) {
         visitor.visit(this);
-    }
-
-    @Override
-    public String toString() {
-        return MoreObjects.toStringHelper(this)
-                .add("value", this.value)
-                .toString();
     }
 }

--- a/features/telemetry/protocols/bmp/parser/src/test/java/org/opennms/netmgt/telemetry/protocols/bmp/parser/BlackboxTest.java
+++ b/features/telemetry/protocols/bmp/parser/src/test/java/org/opennms/netmgt/telemetry/protocols/bmp/parser/BlackboxTest.java
@@ -137,6 +137,11 @@ public class BlackboxTest implements Packet.Visitor {
         public void visit(Origin origin) {
             fail("Wrong Attribute Origin");
         }
+
+        @Override
+        public void visit(org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bgp.packets.pathattr.Unknown unknown) {
+            fail("Wrong Attribute Unknown");
+        }
     }
 
     private static class MetricVisitorAdapter implements org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bmp.packets.stats.Metric.Visitor {
@@ -218,6 +223,11 @@ public class BlackboxTest implements Packet.Visitor {
         @Override
         public void visit(Rejected rejected) {
             fail("Wrong Metric Rejected");
+        }
+
+        @Override
+        public void visit(org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bmp.packets.stats.Unknown unknown) {
+            fail("Wrong Attribute Unknown");
         }
     }
 


### PR DESCRIPTION
Use UNKNOWN variants for most fields and use them instead of throwing
exceptions. The UNKNOWN variants are used for most types / codes where
there are IANA registered extensions which wo (currently) do not
support.

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-12552

