### PR TITLE
NMS-12557: enable java code signing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,6 @@
 version: 2.1
 
+
 executors:
   centos-build-executor:
     docker:
@@ -15,6 +16,7 @@ executors:
 
 orbs:
   cloudsmith: cloudsmith/cloudsmith@1.0.3
+  sign-packages: opennms/sign-packages@2.0.0
 
 commands:
   cached-checkout:
@@ -192,6 +194,7 @@ commands:
       - run:
           name: Compile OpenNMS
           command: |
+            .circleci/scripts/configure-signing.sh
             mvn clean -DskipTests=true
             << parameters.node-memory >>
             ./compile.pl -DskipTests=true -Dbuild.skip.tarball=true \
@@ -439,12 +442,19 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/
+      - sign-packages/install-rpm-dependencies
+      - sign-packages/setup-env:
+          gnupg_home: ~/tmp/gpg
       - run:
           name: Build RPMs
           command: |
             export NODE_OPTIONS=--max_old_space_size=1024
             export CCI_MAXCPU=4
             .circleci/scripts/makerpm.sh tools/packages/opennms/opennms.spec
+      - sign-packages/sign-rpms:
+          gnupg_home: ~/tmp/gpg
+          gnupg_key: opennms@opennms.org
+          packages: target/rpm/RPMS/noarch/*.rpm
       - setup_remote_docker:
           docker_layer_caching: true
       - run:
@@ -471,6 +481,9 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/
+      - sign-packages/install-rpm-dependencies
+      - sign-packages/setup-env:
+          gnupg_home: ~/tmp/gpg
       - run:
           name: Build RPMs
           command: |
@@ -478,6 +491,10 @@ jobs:
             export CCI_MAXCPU=4
             export CCI_VAADINJAVAMAXMEM=768m
             .circleci/scripts/makerpm.sh tools/packages/minion/minion.spec
+      - sign-packages/sign-rpms:
+          gnupg_home: ~/tmp/gpg
+          gnupg_key: opennms@opennms.org
+          packages: target/rpm/RPMS/noarch/*.rpm
       - setup_remote_docker:
           docker_layer_caching: true
       - run:
@@ -504,6 +521,9 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/
+      - sign-packages/install-rpm-dependencies
+      - sign-packages/setup-env:
+          gnupg_home: ~/tmp/gpg
       - run:
           name: Build RPMs
           command: |
@@ -511,6 +531,10 @@ jobs:
             export CCI_MAXCPU=4
             export CCI_VAADINJAVAMAXMEM=768m
             .circleci/scripts/makerpm.sh tools/packages/sentinel/sentinel.spec
+      - sign-packages/sign-rpms:
+          gnupg_home: ~/tmp/gpg
+          gnupg_key: opennms@opennms.org
+          packages: target/rpm/RPMS/noarch/*.rpm
       - setup_remote_docker:
           docker_layer_caching: true
       - run:
@@ -536,12 +560,19 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/
+      - sign-packages/install-deb-dependencies
+      - sign-packages/setup-env:
+          gnupg_home: ~/tmp/gpg
       - run:
           name: Build Debian Packages
           command: |
             export NODE_OPTIONS=--max_old_space_size=1024
             export CCI_MAXCPU=4
             .circleci/scripts/makedeb.sh opennms
+      - sign-packages/sign-debs:
+          gnupg_home: ~/tmp/gpg
+          gnupg_key: opennms@opennms.org
+          packages: target/debs/*.deb
       - store_artifacts:
           path: ~/project/target/debs
           destination: debs
@@ -555,6 +586,9 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/
+      - sign-packages/install-deb-dependencies
+      - sign-packages/setup-env:
+          gnupg_home: ~/tmp/gpg
       - run:
           name: Build Debian Packages
           command: |
@@ -562,6 +596,10 @@ jobs:
             export CCI_MAXCPU=4
             export CCI_VAADINJAVAMAXMEM=768m
             .circleci/scripts/makedeb.sh minion
+      - sign-packages/sign-debs:
+          gnupg_home: ~/tmp/gpg
+          gnupg_key: opennms@opennms.org
+          packages: target/debs/*.deb
       - store_artifacts:
           path: ~/project/target/debs
           destination: debs
@@ -575,6 +613,9 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/
+      - sign-packages/install-deb-dependencies
+      - sign-packages/setup-env:
+          gnupg_home: ~/tmp/gpg
       - run:
           name: Build Debian Packages
           command: |
@@ -582,6 +623,10 @@ jobs:
             export CCI_MAXCPU=4
             export CCI_VAADINJAVAMAXMEM=768m
             .circleci/scripts/makedeb.sh sentinel
+      - sign-packages/sign-debs:
+          gnupg_home: ~/tmp/gpg
+          gnupg_key: opennms@opennms.org
+          packages: target/debs/*.deb
       - store_artifacts:
           path: ~/project/target/debs
           destination: debs

--- a/.circleci/scripts/configure-signing.sh
+++ b/.circleci/scripts/configure-signing.sh
@@ -1,21 +1,40 @@
 #!/bin/bash
 
-rm -rf ~/.gnupg
-install -d -m 700 ~/.gnupg
-echo use-agent >> ~/.gnupg/gpg.conf
-echo pinentry-mode loopback >> ~/.gnupg/gpg.conf
-echo "passphrase-file $HOME/.gpg-passphrase" >> ~/.gnupg/gpg.conf
-echo allow-loopback-pinentry >> ~/.gnupg/gpg-agent.conf
-echo RELOADAGENT | gpg-connect-agent
-echo "$GPG_SECRET_KEY" | base64 --decode | gpg --import --no-tty --batch --yes
-echo "$GPG_PASSPHRASE" | base64 --decode > "$HOME/.gpg-passphrase"
+#### Java code signing configuration
+#### Expects $JAVA_KEYSTORE, $JAVA_STOREPASS, $JAVA_KEYALIAS, and $JAVA_KEYPASS to be set
 
-cat <<END >~/.rpmmacros
-%_topdir $HOME/rpmbuild
-%_gpg_name 79564AEB7CC6C01488E7C64757801F6F5B9EFD43
-%_source_filedigest_algorithm 0
-%_binary_filedigest_algorithm 0
-%_source_payload w0.bzdio
-%_binary_payload w0.bzdio
-%__gpg_sign_cmd %{__gpg} gpg --batch --no-verbose --force-v3-sigs --no-armor --no-secmem-warning --batch --pinentry-mode loopback --passphrase-file $HOME/.gpg-passphrase -u "%{_gpg_name}" -sbo %{__signature_filename} %{__plaintext_filename}
+if [ -n "$JAVA_KEYSTORE" ]; then
+  install -d -m 700 "$HOME/.m2"
+  echo "JAVA_KEYSTORE is set, configuring ~/.m2/settings.xml"
+  echo "* extracting keystore"
+  printf '%s' "$JAVA_KEYSTORE" | base64 --decode > "$HOME/.m2/cert.keystore" 2>/dev/null
+
+  echo "* extracting keystore password"
+  MY_STOREPASS="$(printf '%s' "$JAVA_STOREPASS" | base64 --decode 2>/dev/null)"
+  echo "* extracting key password"
+  MY_KEYPASS="$(printf '%s' "$JAVA_KEYPASS" | base64 --decode 2>/dev/null)"
+
+  cat <<END >"$HOME/.m2/settings.xml"
+<settings>
+ <profiles>
+  <profile>
+   <id>codesign</id>
+   <properties>
+    <webstart.keystore>${HOME}/.m2/cert.keystore</webstart.keystore>
+    <webstart.keypass>${MY_KEYPASS}</webstart.keypass>
+    <webstart.storepass>${MY_STOREPASS}</webstart.storepass>
+    <webstart.keyalias>${JAVA_KEYALIAS}</webstart.keyalias>
+    <webstart.keystore.delete>false</webstart.keystore.delete>
+    <webstart.keygen>false</webstart.keygen>
+    <webstart.dnameCn>\${user.name}</webstart.dnameCn>
+    <webstart.dnameL></webstart.dnameL>
+    <webstart.dnameSt></webstart.dnameSt>
+    <webstart.dnameC></webstart.dnameC>
+   </properties>
+  </profile>
+ </profiles>
+</settings>
 END
+else
+  echo "JAVA_KEYSTORE is NOT set, skipping jar-signing configuration"
+fi

--- a/.circleci/scripts/makedeb.sh
+++ b/.circleci/scripts/makedeb.sh
@@ -14,15 +14,9 @@ PACKAGE_NAME="$1"
 # shellcheck disable=SC1090
 . "${MYDIR}/lib.sh"
 
-if [ -n "$GPG_SECRET_KEY" ] && [ -n "$GPG_PASSPHRASE" ]; then
-	echo "PGP key found... signing Debian packages"
-	# shellcheck disable=SC1090
-	. "$MYDIR/configure-signing.sh"
-	./makedeb.sh -a -d -s '***REDACTED***' -M "${ONMS_MAJOR_REVISION}" -m "${ONMS_MINOR_REVISION}" -u "${ONMS_MICRO_REVISION}" "$PACKAGE_NAME" || exit 1
-else
-	echo "PGP key not found... skipping Debian package signing"
-	./makedeb.sh -a -d -M "${ONMS_MAJOR_REVISION}" -m "${ONMS_MINOR_REVISION}" -u "${ONMS_MICRO_REVISION}" "$PACKAGE_NAME" || exit 1
-fi
+"$MYDIR/configure-signing.sh"
+
+./makedeb.sh -a -d -M "${ONMS_MAJOR_REVISION}" -m "${ONMS_MINOR_REVISION}" -u "${ONMS_MICRO_REVISION}" "$PACKAGE_NAME" || exit 1
 
 mkdir -p target/debs
 mv ../*.deb ../*.changes target/debs/

--- a/.circleci/scripts/makerpm.sh
+++ b/.circleci/scripts/makerpm.sh
@@ -14,12 +14,6 @@ SPECFILE="$1"
 # shellcheck disable=SC1090
 . "${MYDIR}/lib.sh"
 
-if [ -n "$GPG_SECRET_KEY" ] && [ -n "$GPG_PASSPHRASE" ]; then
-	echo "PGP key found... signing RPMs"
-	# shellcheck disable=SC1090
-	. "$MYDIR/configure-signing.sh"
-	./makerpm.sh -a -d -s '***REDACTED***' -M "${ONMS_MAJOR_REVISION}" -m "${ONMS_MINOR_REVISION}" -u "${ONMS_MICRO_REVISION}" -S "$SPECFILE" || exit 1
-else
-	echo "PGP key not found... skipping RPM signing"
-	./makerpm.sh -a -d -M "${ONMS_MAJOR_REVISION}" -m "${ONMS_MINOR_REVISION}" -u "${ONMS_MICRO_REVISION}" -S "$SPECFILE" || exit 1
-fi
+"$MYDIR/configure-signing.sh"
+
+./makerpm.sh -a -d -M "${ONMS_MAJOR_REVISION}" -m "${ONMS_MINOR_REVISION}" -u "${ONMS_MICRO_REVISION}" -S "$SPECFILE" || exit 1


### PR DESCRIPTION
* update makedeb/makerpm to not bother signing during package build
* convert to using the sign-packages orb for package signing
* configure ~/.m2/settings.xml for jar signing

If you want to see a completed run with it all enabled, see: [this CircleCI run](https://circleci.com/workflow-run/c648e3d2-3372-43d5-af65-e74c6e77a628)

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-12557
* Bamboo (Continuous Integration): https://bamboo.opennms.org/

