### PR TITLE
NMS-12413: Fix remove from definitions

### DIFF
--- a/opennms-config/src/main/java/org/opennms/netmgt/config/SnmpConfigManager.java
+++ b/opennms-config/src/main/java/org/opennms/netmgt/config/SnmpConfigManager.java
@@ -159,7 +159,6 @@ public class SnmpConfigManager {
 	 * @return true when definition is removed else false.
 	 */
 	public boolean removeDefinition(final Definition definition) {
-		removeDefaults(definition);
 		MergeableDefinition removableDefinition = new MergeableDefinition(definition);
 
 		removeDefinitionsthatDontMatchLocation(definition);

--- a/opennms-config/src/main/java/org/opennms/netmgt/config/SnmpPeerFactory.java
+++ b/opennms-config/src/main/java/org/opennms/netmgt/config/SnmpPeerFactory.java
@@ -43,18 +43,21 @@ import java.net.InetAddress;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.Lock;
 
 import org.apache.commons.io.IOUtils;
 import org.opennms.core.spring.FileReloadCallback;
 import org.opennms.core.spring.FileReloadContainer;
+import org.opennms.core.utils.ByteArrayComparator;
 import org.opennms.core.utils.ConfigFileConstants;
 import org.opennms.core.utils.InetAddressUtils;
 import org.opennms.core.xml.JaxbUtils;
 import org.opennms.netmgt.config.api.SnmpAgentConfigFactory;
 import org.opennms.netmgt.config.snmp.AddressSnmpConfigVisitor;
 import org.opennms.netmgt.config.snmp.Definition;
+import org.opennms.netmgt.config.snmp.Range;
 import org.opennms.netmgt.config.snmp.SnmpConfig;
 import org.opennms.netmgt.config.snmp.SnmpProfile;
 import org.opennms.netmgt.snmp.SnmpAgentConfig;
@@ -87,6 +90,8 @@ public class SnmpPeerFactory implements SnmpAgentConfigFactory {
     private static final Logger LOG = LoggerFactory.getLogger(SnmpPeerFactory.class);
 
     private static final int VERSION_UNSPECIFIED = -1;
+
+    private static final String DEFAULT_LOCATION = "Default";
 
     private static File s_configFile;
 
@@ -449,12 +454,17 @@ public class SnmpPeerFactory implements SnmpAgentConfigFactory {
         boolean succeeded = false;
         getWriteLock().lock();
         try {
-            Definition definition = new Definition();
-            definition.setLocation(location);
-            SnmpAgentConfig agentConfig = getAgentConfig(inetAddress, location);
-            setDefinitionFromAgentConfig(definition, agentConfig);
-            final SnmpConfigManager mgr = new SnmpConfigManager(getSnmpConfig());
-            succeeded = mgr.removeDefinition(definition);
+            // Check if there is a matching definition from the config itself instead of doing getAgentConfig.
+            Definition matchingDefinition = findMatchingDefinition(inetAddress, location);
+            if(matchingDefinition !=  null) {
+                // Form a definition just with this IP Address.
+                Definition definition = createDefinition(matchingDefinition);
+                List<String> specifics = new ArrayList<>();
+                specifics.add(InetAddressUtils.toIpAddrString(inetAddress));
+                definition.setSpecifics(specifics);
+                final SnmpConfigManager mgr = new SnmpConfigManager(getSnmpConfig());
+                succeeded = mgr.removeDefinition(definition);
+            }
         } finally {
             getWriteLock().unlock();
         }
@@ -469,6 +479,84 @@ public class SnmpPeerFactory implements SnmpAgentConfigFactory {
         }
         return succeeded;
     }
+
+    private Definition findMatchingDefinition(InetAddress inetAddress, String location) {
+        SnmpConfig config = getSnmpConfig();
+        List<Definition> definitions = config.getDefinitions();
+        return definitions.stream().filter(definition -> matchDefinition(definition, inetAddress, location)).findFirst().orElse(null);
+    }
+
+    private  static Definition createDefinition(Definition matchingDefinition) {
+        Definition definition = new Definition();
+        definition.setProfileLabel(matchingDefinition.getProfileLabel());
+        definition.setLocation(matchingDefinition.getLocation());
+        // Fill configuration
+        definition.setProxyHost(matchingDefinition.getProxyHost());
+        definition.setMaxVarsPerPdu(matchingDefinition.getMaxVarsPerPdu());
+        definition.setMaxRepetitions(matchingDefinition.getMaxRepetitions());
+        definition.setMaxRequestSize(matchingDefinition.getMaxRequestSize());
+
+        definition.setSecurityName(matchingDefinition.getSecurityName());
+        definition.setSecurityLevel(matchingDefinition.getSecurityLevel());
+        definition.setAuthPassphrase(matchingDefinition.getAuthPassphrase());
+        definition.setAuthProtocol(matchingDefinition.getAuthProtocol());
+        definition.setEngineId(matchingDefinition.getEngineId());
+        definition.setContextEngineId(matchingDefinition.getContextEngineId());
+        definition.setContextName(matchingDefinition.getContextName());
+        definition.setEnterpriseId(matchingDefinition.getEnterpriseId());
+        definition.setPrivacyPassphrase(matchingDefinition.getPrivacyPassphrase());
+        definition.setPrivacyProtocol(matchingDefinition.getPrivacyProtocol());
+        definition.setVersion(matchingDefinition.getVersion());
+        definition.setReadCommunity(matchingDefinition.getReadCommunity());
+        definition.setWriteCommunity(matchingDefinition.getWriteCommunity());
+        definition.setPort(matchingDefinition.getPort());
+        definition.setTimeout(matchingDefinition.getTimeout());
+        definition.setTTL(matchingDefinition.getTTL());
+        definition.setRetry(matchingDefinition.getRetry());
+        return definition;
+    }
+
+    private boolean matchDefinition(Definition definition, InetAddress inetAddress, String location) {
+        String locationFromDefinition = definition.getLocation();
+        if(DEFAULT_LOCATION.equals(location)) {
+            location = null;
+        }
+        if(DEFAULT_LOCATION.equals(definition.getLocation())) {
+            locationFromDefinition = null;
+        }
+        boolean locationMatched = Objects.equals(location, locationFromDefinition);
+        if(locationMatched) {
+            return matchingIpAddress(inetAddress, definition);
+        }
+        return false;
+    }
+
+    private static boolean matchingIpAddress(InetAddress inetAddress, Definition definition) {
+
+         boolean matchingIpAddress = definition.getSpecifics().stream()
+                 .anyMatch(saddr -> saddr.equals(inetAddress.getHostAddress()));
+         if(!matchingIpAddress) {
+             return definition.getRanges().stream().anyMatch(range -> matchingRanges(inetAddress, range));
+         }
+         return true;
+    }
+
+    private static boolean matchingRanges(InetAddress inetAddress, Range range) {
+        final byte[] addr = inetAddress.getAddress();
+        final byte[] begin = InetAddressUtils.toIpAddrBytes(range.getBegin());
+        final byte[] end = InetAddressUtils.toIpAddrBytes(range.getEnd());
+
+        final boolean inRange;
+        final ByteArrayComparator BYTE_ARRAY_COMPARATOR = new ByteArrayComparator();
+        if (BYTE_ARRAY_COMPARATOR.compare(begin, end) <= 0) {
+            inRange = InetAddressUtils.isInetAddressInRange(addr, begin, end);
+        } else {
+            inRange = InetAddressUtils.isInetAddressInRange(addr, end, begin);
+        }
+        return inRange;
+    }
+
+
 
     @Override
     public void saveAgentConfigAsDefinition(SnmpAgentConfig snmpAgentConfig, String location, String module) {

--- a/opennms-config/src/main/java/org/opennms/netmgt/config/SnmpPeerFactory.java
+++ b/opennms-config/src/main/java/org/opennms/netmgt/config/SnmpPeerFactory.java
@@ -43,7 +43,6 @@ import java.net.InetAddress;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.Lock;
 
@@ -53,6 +52,7 @@ import org.opennms.core.spring.FileReloadContainer;
 import org.opennms.core.utils.ByteArrayComparator;
 import org.opennms.core.utils.ConfigFileConstants;
 import org.opennms.core.utils.InetAddressUtils;
+import org.opennms.core.utils.LocationUtils;
 import org.opennms.core.xml.JaxbUtils;
 import org.opennms.netmgt.config.api.SnmpAgentConfigFactory;
 import org.opennms.netmgt.config.snmp.AddressSnmpConfigVisitor;
@@ -90,8 +90,6 @@ public class SnmpPeerFactory implements SnmpAgentConfigFactory {
     private static final Logger LOG = LoggerFactory.getLogger(SnmpPeerFactory.class);
 
     private static final int VERSION_UNSPECIFIED = -1;
-
-    private static final String DEFAULT_LOCATION = "Default";
 
     private static File s_configFile;
 
@@ -517,18 +515,8 @@ public class SnmpPeerFactory implements SnmpAgentConfigFactory {
     }
 
     private boolean matchDefinition(Definition definition, InetAddress inetAddress, String location) {
-        String locationFromDefinition = definition.getLocation();
-        if(DEFAULT_LOCATION.equals(location)) {
-            location = null;
-        }
-        if(DEFAULT_LOCATION.equals(definition.getLocation())) {
-            locationFromDefinition = null;
-        }
-        boolean locationMatched = Objects.equals(location, locationFromDefinition);
-        if(locationMatched) {
-            return matchingIpAddress(inetAddress, definition);
-        }
-        return false;
+        boolean locationMatched =  LocationUtils.doesLocationsMatch(location, definition.getLocation());
+        return locationMatched && matchingIpAddress(inetAddress, definition);
     }
 
     private static boolean matchingIpAddress(InetAddress inetAddress, Definition definition) {

--- a/opennms-config/src/test/java/org/opennms/netmgt/config/SnmpEventInfoTest.java
+++ b/opennms-config/src/test/java/org/opennms/netmgt/config/SnmpEventInfoTest.java
@@ -1485,19 +1485,19 @@ public class SnmpEventInfoTest {
      * @throws IOException
      */
     @Test
-    public void testRemovalOfIpAddressFromDefinition() throws IOException {
+    public void testRemovalOfIpAddressFromRangeFromDefinition() throws IOException {
 
         String snmpConfigXml = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n" +
-                "<snmp-config retry=\"3\" timeout=\"800\" read-community=\"public\" write-community=\"private\" xmlns=\"http://xmlns.opennms.org/xsd/config/snmp\">\n" +
-                "    <definition version=\"v1\">\n" +
+                "<snmp-config port=\"161\" retry=\"3\" timeout=\"800\" read-community=\"public\" version=\"v1\" xmlns=\"http://xmlns.opennms.org/xsd/config/snmp\">\n" +
+                "    <definition version=\"v2c\" location=\"MINION\" port=\"1161\">\n" +
                 "        <range begin=\"192.168.1.15\" end=\"192.168.1.35\"/>\n" +
                 "    </definition>\n" +
                 "</snmp-config>\n" +
                 "";
 
         String expectedConfig = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n" +
-                "<snmp-config retry=\"3\" timeout=\"800\" read-community=\"public\" write-community=\"private\" xmlns=\"http://xmlns.opennms.org/xsd/config/snmp\">\n" +
-                "    <definition version=\"v1\">\n" +
+                "<snmp-config port=\"161\" retry=\"3\" timeout=\"800\" read-community=\"public\" version=\"v1\" xmlns=\"http://xmlns.opennms.org/xsd/config/snmp\">\n" +
+                "    <definition version=\"v2c\" location=\"MINION\" port=\"1161\">\n" +
                 "        <range begin=\"192.168.1.15\" end=\"192.168.1.34\"/>\n" +
                 "    </definition>\n" +
                 "</snmp-config>\n" +
@@ -1505,11 +1505,13 @@ public class SnmpEventInfoTest {
         SnmpPeerFactory.setInstance(new SnmpPeerFactory(new StringResource(snmpConfigXml)));
         assertXmlEquals(snmpConfigXml, SnmpPeerFactory.getInstance().getSnmpConfigAsString());
 
-        boolean success = SnmpPeerFactory.getInstance().removeFromDefinition(InetAddress.getByName("192.168.1.35"), null,"test" );
+        boolean success = SnmpPeerFactory.getInstance().removeFromDefinition(InetAddress.getByName("192.168.1.35"), "MINION","test" );
         assertTrue("Remove from definition should be successful", success);
         String actualConfig = SnmpPeerFactory.getInstance().getSnmpConfigAsString();
+        System.out.println(actualConfig);
         assertXmlEquals(expectedConfig, actualConfig);
     }
+
 
     /**
      * Tests removal of IP address from middle of range splits the range.
@@ -1519,16 +1521,16 @@ public class SnmpEventInfoTest {
     public void testRemovalOfIpAddressRangeShouldSplit() throws IOException {
 
         String snmpConfigXml = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n" +
-                "<snmp-config retry=\"3\" timeout=\"800\" read-community=\"public\" write-community=\"private\" xmlns=\"http://xmlns.opennms.org/xsd/config/snmp\">\n" +
-                "    <definition version=\"v1\">\n" +
+                "<snmp-config retry=\"3\" timeout=\"800\" read-community=\"public\" xmlns=\"http://xmlns.opennms.org/xsd/config/snmp\">\n" +
+                "    <definition version=\"v1\" timeout=\"3000\" write-community=\"private\"  >\n" +
                 "        <range begin=\"192.168.1.15\" end=\"192.168.1.35\"/>\n" +
                 "    </definition>\n" +
                 "</snmp-config>\n" +
                 "";
 
         String expectedConfig = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n" +
-                "<snmp-config retry=\"3\" timeout=\"800\" read-community=\"public\" write-community=\"private\" xmlns=\"http://xmlns.opennms.org/xsd/config/snmp\">\n" +
-                "    <definition version=\"v1\">\n" +
+                "<snmp-config retry=\"3\" timeout=\"800\" read-community=\"public\" xmlns=\"http://xmlns.opennms.org/xsd/config/snmp\">\n" +
+                "    <definition version=\"v1\" timeout=\"3000\" write-community=\"private\"  >\n" +
                 "        <range begin=\"192.168.1.15\" end=\"192.168.1.24\"/>\n" +
                 "        <range begin=\"192.168.1.26\" end=\"192.168.1.35\"/>\n" +
                 "    </definition>\n" +
@@ -1582,22 +1584,22 @@ public class SnmpEventInfoTest {
     public void testRemovalOfIpAddressWithDifferentLocationsInDefinitions() throws IOException {
 
         String snmpConfigXml = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n" +
-                "<snmp-config retry=\"3\" timeout=\"800\" read-community=\"public\" write-community=\"private\" xmlns=\"http://xmlns.opennms.org/xsd/config/snmp\">\n" +
-                "    <definition version=\"v1\"  timeout=\"1200\">\n" +
+                "<snmp-config retry=\"3\" timeout=\"800\" read-community=\"public\" xmlns=\"http://xmlns.opennms.org/xsd/config/snmp\">\n" +
+                "    <definition version=\"v1\"  timeout=\"1200\" write-community=\"horizon\" >\n" +
                 "        <range begin=\"192.168.1.15\" end=\"192.168.1.35\"/>\n" +
                 "    </definition>\n" +
-                "    <definition version=\"v1\" location=\"Minion\">\n" +
+                "    <definition version=\"v1\" write-community=\"horizon\" location=\"Minion\"> \n" +
                 "        <range begin=\"192.168.1.15\" end=\"192.168.1.35\"/>\n" +
                 "    </definition>\n" +
                 "</snmp-config>\n" +
                 "";
 
         String expectedConfig = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n" +
-                "<snmp-config retry=\"3\" timeout=\"800\" read-community=\"public\" write-community=\"private\" xmlns=\"http://xmlns.opennms.org/xsd/config/snmp\">\n" +
-                "    <definition version=\"v1\" timeout=\"1200\" >\n" +
+                "<snmp-config retry=\"3\" timeout=\"800\" read-community=\"public\"  xmlns=\"http://xmlns.opennms.org/xsd/config/snmp\">\n" +
+                "    <definition version=\"v1\" timeout=\"1200\" write-community=\"horizon\" >\n" +
                 "        <range begin=\"192.168.1.15\" end=\"192.168.1.35\"/>\n" +
                 "    </definition>\n" +
-                "    <definition version=\"v1\" location=\"Minion\">\n" +
+                "    <definition version=\"v1\" write-community=\"horizon\" location=\"Minion\"> \n" +
                 "        <range begin=\"192.168.1.15\" end=\"192.168.1.24\"/>\n" +
                 "        <range begin=\"192.168.1.26\" end=\"192.168.1.35\"/>\n" +
                 "    </definition>\n" +
@@ -1610,6 +1612,7 @@ public class SnmpEventInfoTest {
         SnmpAgentConfig snmpAgentConfig = SnmpPeerFactory.getInstance().getAgentConfig(InetAddress.getByName("192.168.1.25"), "Minion");
         assertFalse("Config should be derived from default location", snmpAgentConfig.isDefault());
         String actualConfig = SnmpPeerFactory.getInstance().getSnmpConfigAsString();
+
         assertXmlEquals(expectedConfig, actualConfig);
     }
 


### PR DESCRIPTION
Using `getAgentConfig`  comes with some defaults which results in equality check failure.
Get config directly from snmp config by matching specifics and ranges.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-12413
* Bamboo (Continuous Integration): https://bamboo.opennms.org/

