### PR TITLE
NMS-12580: Improve NodeInfoCache handling

### DIFF
--- a/features/flows/elastic/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/features/flows/elastic/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -31,8 +31,8 @@
             <cm:property name="readTimeout" value="30000" /> <!-- 30 second timeout for Elasticsearch socket reads -->
             <cm:property name="retries" value="0" /> <!-- Disable retries by default -->
             <cm:property name="nodeCache.enabled" value="true" /> <!-- Set to false to disable caching -->
-            <cm:property name="nodeCache.maximumSize" value="1000"/> <!-- Set value for unlimited size -->
-            <cm:property name="nodeCache.expireAfterWrite" value="300"/> <!-- in seconds. Set to 0 to never evict elements -->
+            <cm:property name="nodeCache.maximumSize" value="10000"/> <!-- Set value for unlimited size -->
+            <cm:property name="nodeCache.expireAfterWrite" value="0"/> <!-- in seconds. Set to 0 to never evict elements -->
             <cm:property name="nodeCache.recordStats" value="true"/> <!-- Set to false to not expose cache statistics via jmx -->
 
             <!-- Bulk Action Retry settings -->

--- a/features/flows/elastic/src/test/java/org/opennms/netmgt/flows/elastic/DocumentEnricherTest.java
+++ b/features/flows/elastic/src/test/java/org/opennms/netmgt/flows/elastic/DocumentEnricherTest.java
@@ -49,13 +49,14 @@ public class DocumentEnricherTest {
 
     private DocumentEnricher enricher;
     private AtomicInteger nodeDaoGetCounter;
+    private InterfaceToNodeCache interfaceToNodeCache;
 
     @Before
     public void setUp() {
         final MockDocumentEnricherFactory factory = new MockDocumentEnricherFactory();
         enricher = factory.getEnricher();
         final NodeDao nodeDao = factory.getNodeDao();
-        final InterfaceToNodeCache interfaceToNodeCache = factory.getInterfaceToNodeCache();
+        interfaceToNodeCache = factory.getInterfaceToNodeCache();
         nodeDaoGetCounter = factory.getNodeDaoGetCounter();
 
         interfaceToNodeCache.setNodeId("Default", InetAddressUtils.addr("10.0.0.1"), 1);
@@ -76,6 +77,24 @@ public class DocumentEnricherTest {
 
         // get is also called for each save, so we account for those as well
         assertEquals(6, nodeDaoGetCounter.get());
+
+        // Try to enrich flow documents to existing IpAddresses.
+        documents.clear();
+        documents.add(createFlowDocument("10.0.0.2", "10.0.0.3"));
+        enricher.enrich(documents.stream().map(TestFlow::new).collect(Collectors.toList()), new FlowSource("Default", "127.0.0.1", null));
+        // Since above two addresses are cached, no extra calls to nodeDao.
+        assertEquals(6, nodeDaoGetCounter.get());
+
+
+        // Add two more interfaces to the system.
+        interfaceToNodeCache.setNodeId("Default", InetAddressUtils.addr("10.0.0.4"), 2);
+        interfaceToNodeCache.setNodeId("Default", InetAddressUtils.addr("10.0.0.5"), 3);
+        documents.add(createFlowDocument("10.0.0.4", "10.0.0.5"));
+        enricher.enrich(documents.stream().map(TestFlow::new).collect(Collectors.toList()), new FlowSource("Default", "127.0.0.1", null));
+        // Since above two addresses are added to same nodes, no extra calls to nodeDao
+        assertEquals(6, nodeDaoGetCounter.get());
+
+
     }
 
     private static FlowDocument createFlowDocument(String sourceIp, String destIp) {


### PR DESCRIPTION
Query the `InterfaceNodeCache` first and if there is a relavant `nodeId` query `NodeInfoCache` for the node document.
Also modify `nodeCache` settings to cache `10000` elements and set the cache to not to expire.
### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-12580
* Bamboo (Continuous Integration): https://bamboo.opennms.org/

