### PR TITLE
NMS-12586: Use DroolsStreamUtils methods to serialize/deserialize facts

### DIFF
--- a/opennms-correlation/drools-correlation-engine/src/test/java/org/opennms/netmgt/correlation/drools/DroolsReloadFactsTest.java
+++ b/opennms-correlation/drools-correlation-engine/src/test/java/org/opennms/netmgt/correlation/drools/DroolsReloadFactsTest.java
@@ -73,7 +73,7 @@ public class DroolsReloadFactsTest {
         // save facts.
         droolsCorrelationEngine.saveFacts();
         // Verify that it should have atleast 4 objects from the rule
-        List<Object> factObjects = droolsCorrelationEngine.getFactObjects();
+        List<byte[]> factObjects = droolsCorrelationEngine.getFactObjects();
         assertThat(factObjects.size(), Matchers.greaterThanOrEqualTo(4));
         // Now initialize again.
         droolsCorrelationEngine.initialize();

--- a/opennms-correlation/drools-correlation-engine/src/test/java/org/opennms/netmgt/correlation/drools/PersistStateIT.java
+++ b/opennms-correlation/drools-correlation-engine/src/test/java/org/opennms/netmgt/correlation/drools/PersistStateIT.java
@@ -32,6 +32,7 @@ import static com.jayway.awaitility.Awaitility.await;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertEquals;
 
 import java.util.concurrent.TimeUnit;
 
@@ -86,9 +87,49 @@ public class PersistStateIT extends CorrelationRulesTestCase {
         engine.tearDown();
     }
 
+    @Test
+    public void persistedDroolsFactsAccessibleInNewSession() throws Exception {
+        String factClass = "org.opennms.netmgt.correlation.drools.PersistedTestFact";
+        DroolsCorrelationEngine engine = findEngineByName("persistStateTest");
+        assertThat(engine, notNullValue());
+        engine.initialize();
+        // Make sure working memory is clean
+        engine.getKieSession().getFactHandles().forEach(fh -> engine.getKieSession().delete(fh));
+
+        // Insert a test fact to be persisted
+        engine.correlate(createFactPersistenceTestEvent("insertPersistenceTestFact", "PersistStateIT-42"));
+        assertEquals(inventoryWorkingMemory(engine), 1, engine.getKieSessionObjects().stream().filter(fh ->
+                fh.getClass().getCanonicalName().equals(factClass)).count());
+        assertThat(inventoryWorkingMemory(engine), engine.getKieSessionObjects(), hasSize(1));
+
+        // Re-initialize and verify
+        engine.reloadConfig(true);
+        assertThat(inventoryWorkingMemory(engine), engine.getKieSessionObjects(), hasSize(1));
+
+        // Insert another test fact to ensure the query finds facts from before and after reload
+        engine.correlate(createFactPersistenceTestEvent("insertPersistenceTestFact", "PersistStateIT-42"));
+
+        // Activate the query-and-delete rule
+        engine.correlate(createFactPersistenceTestEvent("deletePersistenceTestFact", "PersistStateIT-42"));
+        assertEquals("There should be no objects in working memory\n" + inventoryWorkingMemory(engine), 0,
+            engine.getKieSessionObjects().size());
+    }
+
     private Event createNodeLostServiceEvent(int nodeid, String serviceName) {
         return new EventBuilder(EventConstants.NODE_LOST_SERVICE_EVENT_UEI, serviceName)
                 .setNodeid(nodeid)
                 .getEvent();
+    }
+
+    private Event createFactPersistenceTestEvent(String ueiSuffix, String source) {
+        return new EventBuilder("uei.opennms.org/junit/" + ueiSuffix, source).getEvent();
+    }
+
+    private String inventoryWorkingMemory(DroolsCorrelationEngine engine) {
+        StringBuilder wmInventory = new StringBuilder("Working Memory Inventory:");
+        for (Object o : engine.getKieSessionObjects()) {
+            wmInventory.append("\n\t" + o.toString());
+        }
+        return wmInventory.toString();
     }
 }

--- a/opennms-correlation/drools-correlation-engine/src/test/opennms-home/etc/drools-engine.d/persistState/PersistState.drl
+++ b/opennms-correlation/drools-correlation-engine/src/test/opennms-home/etc/drools-engine.d/persistState/PersistState.drl
@@ -3,12 +3,21 @@ package org.opennms.netmgt.correlation.drools;
 import org.opennms.netmgt.correlation.drools.DroolsCorrelationEngine;
 import org.opennms.netmgt.xml.event.Event;
 import org.opennms.netmgt.model.events.EventBuilder;
-import org.drools.core.spi.KnowledgeHelper;
+import org.drools.core.spi.KnowledgeHelper
+import org.drools.core.QueryResultsImpl;
 
 global DroolsCorrelationEngine engine;
 
 declare Thing
 	name: String
+end
+
+declare PersistedTestFact
+  factId: String
+end
+
+query "find PersistedTestFact by factId" (String searchFactId)
+  pf : PersistedTestFact(factId.equals(searchFactId))
 end
 
 rule "test-got-something"
@@ -22,3 +31,39 @@ then
     insert(eventBuilder.getEvent());
     insert(new Thing());
 end
+
+rule insertFact when
+  $e : Event(uei == "uei.opennms.org/junit/insertPersistenceTestFact", source != "", $source : source)
+then
+  delete($e);
+  insert(new PersistedTestFact($source));
+end
+
+rule "find and delete persisted test fact by Drools query"
+  when
+    $e : Event(uei == "uei.opennms.org/junit/deletePersistenceTestFact", source != "", $source : source)
+  then
+    delete($e);
+    engine.getKieSessionObjects().stream().filter(fh -> fh.getClass().getCanonicalName().equals(
+        "org.opennms.netmgt.correlation.drools.PersistedTestFact")).forEach(
+            factHandle -> {
+              try {
+                PersistedTestFact ptfFh = (PersistedTestFact) factHandle;
+                String factId = ptfFh.getFactId();
+                if (factId.equals($source)) {
+                  System.err.println("This fact should be deleted by this rule: " + ptfFh);
+                } else {
+                  System.err.println("This fact should not be deleted by this rule: " + ptfFh);
+                }
+              } catch (Exception ex) {
+                System.err.println("Caught exception: " + ex);
+              }
+          }
+        );
+    QueryResultsImpl qri = (QueryResultsImpl)kcontext.getKieRuntime().getQueryResults(
+        "find PersistedTestFact by factId", new Object[] {$source});
+    for (org.kie.api.runtime.rule.QueryResultsRow row : qri) {
+      PersistedTestFact ptf = (PersistedTestFact) row.get("pf");
+      delete(ptf);
+    }
+  end


### PR DESCRIPTION
Copying facts between sessions leads to incompatible class signatures.
Take advantage of the Drools streaming utilities and protobuf to persist
facts between sessions, instead.