### PR TITLE
NMS-12615: skip signing if run from a forked pull request

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ executors:
 
 orbs:
   cloudsmith: cloudsmith/cloudsmith@1.0.3
-  sign-packages: opennms/sign-packages@2.0.0
+  sign-packages: opennms/sign-packages@2.1.1
 
 commands:
   cached-checkout:
@@ -380,8 +380,10 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/
-      - sign-packages/install-rpm-dependencies
+      - sign-packages/install-rpm-dependencies:
+          skip_if_forked_pr: true
       - sign-packages/setup-env:
+          skip_if_forked_pr: true
           gnupg_home: ~/tmp/gpg
       - run:
           name: Build RPMs
@@ -390,6 +392,7 @@ jobs:
             export CCI_MAXCPU=4
             .circleci/scripts/makerpm.sh tools/packages/opennms/opennms.spec
       - sign-packages/sign-rpms:
+          skip_if_forked_pr: true
           gnupg_home: ~/tmp/gpg
           gnupg_key: opennms@opennms.org
           packages: target/rpm/RPMS/noarch/*.rpm
@@ -418,8 +421,10 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/
-      - sign-packages/install-deb-dependencies
+      - sign-packages/install-deb-dependencies:
+          skip_if_forked_pr: true
       - sign-packages/setup-env:
+          skip_if_forked_pr: true
           gnupg_home: ~/tmp/gpg
       - run:
           name: Build Debian Packages
@@ -428,6 +433,7 @@ jobs:
             export CCI_MAXCPU=4
             .circleci/scripts/makedeb.sh opennms
       - sign-packages/sign-debs:
+          skip_if_forked_pr: true
           gnupg_home: ~/tmp/gpg
           gnupg_key: opennms@opennms.org
           packages: target/debs/*.deb


### PR DESCRIPTION
Skip doing GPG stuff if in a forked pull request.

I've pushed this branch to 2 places: the regular opennms tree (in which it should still GPG sign things), and my own personal github repo, from which this PR originates (in which it should *not* GPG sign things).

I won't merge this until both are correct.  ;) 

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-12615

