### PR TITLE
NMS-12586: Fix restoring of facts on DroolsCorrelationEngine reload

### DIFF
--- a/opennms-correlation/drools-correlation-engine/src/main/java/org/opennms/netmgt/correlation/drools/DroolsCorrelationEngine.java
+++ b/opennms-correlation/drools-correlation-engine/src/main/java/org/opennms/netmgt/correlation/drools/DroolsCorrelationEngine.java
@@ -516,6 +516,11 @@ public class DroolsCorrelationEngine extends AbstractCorrelationEngine {
         return factObjects;
     }
 
+    /**
+     * This checks if fact is declared in drl.
+     * Facts which are inserted in the session will throw exception.
+     * Currently, there is no better way to find if the fact is a declared fact or not.
+     */
     private FactType getDeclaredFactType(String packageName, String className) {
         try {
             return m_kieBase.getFactType(packageName, className);

--- a/opennms-correlation/drools-correlation-engine/src/main/java/org/opennms/netmgt/correlation/drools/DroolsCorrelationEngine.java
+++ b/opennms-correlation/drools-correlation-engine/src/main/java/org/opennms/netmgt/correlation/drools/DroolsCorrelationEngine.java
@@ -40,29 +40,29 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.Consumer;
-import java.util.stream.Collectors;
 
 import org.apache.commons.lang.exception.ExceptionUtils;
 import org.drools.compiler.compiler.DroolsParserException;
 import org.drools.core.RuleBaseConfiguration;
 import org.drools.core.RuleBaseConfiguration.AssertBehaviour;
+import org.drools.core.util.DroolsStreamUtils;
 import org.kie.api.KieBase;
 import org.kie.api.KieServices;
 import org.kie.api.builder.KieBuilder;
 import org.kie.api.builder.KieFileSystem;
 import org.kie.api.builder.Message.Level;
 import org.kie.api.conf.EventProcessingOption;
+import org.kie.api.definition.type.FactType;
 import org.kie.api.marshalling.KieMarshallers;
 import org.kie.api.marshalling.Marshaller;
 import org.kie.api.marshalling.ObjectMarshallingStrategy;
 import org.kie.api.runtime.KieContainer;
 import org.kie.api.runtime.KieSession;
+import org.kie.api.runtime.rule.FactHandle;
 import org.opennms.core.logging.Logging;
 import org.opennms.core.xml.JaxbUtils;
 import org.opennms.netmgt.correlation.AbstractCorrelationEngine;
@@ -115,7 +115,7 @@ public class DroolsCorrelationEngine extends AbstractCorrelationEngine {
     private Boolean m_persistState;
     private Resource m_configPath;
     private ApplicationContext m_configContext;
-    private List<Object> factObjects;
+    private Map<byte[], Class<?>> factObjects = new HashMap<>();
 
     /**
      * Holds a reference to the thread that calls {@link KieSession#fireUntilHalt()}
@@ -270,7 +270,7 @@ public class DroolsCorrelationEngine extends AbstractCorrelationEngine {
         }
 
         if (factObjects != null) {
-            factObjects.forEach(fact -> m_kieSession.insert(fact));
+            factObjects.forEach(this::unmarshalAndInsert);
             factObjects.clear();
         }
 
@@ -505,17 +505,51 @@ public class DroolsCorrelationEngine extends AbstractCorrelationEngine {
         shutDownKieSession(() -> {
             try {
                 // Capture the current set of facts
-                factObjects  = m_kieSession.getFactHandles().stream()
-                        .map(fact -> m_kieSession.getObject(fact))
-                        .collect(Collectors.toList());
+                m_kieSession.getFactHandles().forEach(this::marshalAndSaveFact);
             } catch (Exception e) {
                 LOG.warn("Failed to save facts", e);
             }
         });
     }
 
-    List<Object> getFactObjects() {
+    Map<byte[], Class<?>> getFactObjects() {
         return factObjects;
+    }
+
+    private FactType getDeclaredFactType(String packageName, String className) {
+        try {
+            return m_kieBase.getFactType(packageName, className);
+        } catch (Exception e) {
+            // Any objects that are not declared in drl will throw exception.
+        }
+        return null;
+    }
+
+    private void marshalAndSaveFact(FactHandle factHandle) {
+        Object factObject = m_kieSession.getObject(factHandle);
+        try {
+            factObjects.put(DroolsStreamUtils.streamOut(factObject), factObject.getClass());
+        } catch (IOException e) {
+            LOG.error("Exception while marshalling fact {} with Class {}", factObject, factObject.getClass().getCanonicalName(), e);
+        }
+    }
+
+
+    private void unmarshalAndInsert(byte[] factBytes, Class<?> clazz) {
+
+        try {
+            String packageName = clazz.getPackage().getName();
+            String className = clazz.getSimpleName();
+            // Check if this is a declared fact in drl.
+            FactType factType = getDeclaredFactType(packageName, className);
+            if (factType != null) {
+                m_kieSession.insert(DroolsStreamUtils.streamIn(factBytes, factType.getFactClass().getClassLoader()));
+            } else {
+                m_kieSession.insert(DroolsStreamUtils.streamIn(factBytes, clazz.getClassLoader()));
+            }
+        } catch (IOException | ClassNotFoundException e) {
+            LOG.error("Exception while unmarshalling fact of size {} with Class {}", factBytes.length, clazz.getCanonicalName());
+        }
     }
 
 }

--- a/opennms-correlation/drools-correlation-engine/src/test/java/org/opennms/netmgt/correlation/drools/DroolsReloadFactsTest.java
+++ b/opennms-correlation/drools-correlation-engine/src/test/java/org/opennms/netmgt/correlation/drools/DroolsReloadFactsTest.java
@@ -34,6 +34,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import org.hamcrest.Matchers;
@@ -73,13 +74,13 @@ public class DroolsReloadFactsTest {
         // save facts.
         droolsCorrelationEngine.saveFacts();
         // Verify that it should have atleast 4 objects from the rule
-        List<Object> factObjects = droolsCorrelationEngine.getFactObjects();
+        Map<byte[], Class<?>> factObjects = droolsCorrelationEngine.getFactObjects();
         assertThat(factObjects.size(), Matchers.greaterThanOrEqualTo(4));
         // Now initialize again.
         droolsCorrelationEngine.initialize();
         // Now that facts are loaded and there shouldn't be any facts in factObjects.
         factObjects = droolsCorrelationEngine.getFactObjects();
-        assertThat(factObjects, Matchers.hasSize(0));
+        assertThat(factObjects.size(), Matchers.is(0));
         // Save facts from engine and Verify that all saved facts are loaded properly.
         droolsCorrelationEngine.saveFacts();
         factObjects = droolsCorrelationEngine.getFactObjects();

--- a/opennms-correlation/drools-correlation-engine/src/test/opennms-home/etc/drools-engine.d/persistState/PersistState.drl
+++ b/opennms-correlation/drools-correlation-engine/src/test/opennms-home/etc/drools-engine.d/persistState/PersistState.drl
@@ -3,12 +3,21 @@ package org.opennms.netmgt.correlation.drools;
 import org.opennms.netmgt.correlation.drools.DroolsCorrelationEngine;
 import org.opennms.netmgt.xml.event.Event;
 import org.opennms.netmgt.model.events.EventBuilder;
-import org.drools.core.spi.KnowledgeHelper;
+import org.drools.core.spi.KnowledgeHelper
+import org.drools.core.QueryResultsImpl;
 
 global DroolsCorrelationEngine engine;
 
 declare Thing
 	name: String
+end
+
+declare PersistedTestFact
+  factId: String
+end
+
+query "find PersistedTestFact by factId" (String searchFactId)
+  pf : PersistedTestFact(factId.equals(searchFactId))
 end
 
 rule "test-got-something"
@@ -22,3 +31,39 @@ then
     insert(eventBuilder.getEvent());
     insert(new Thing());
 end
+
+rule insertFact when
+  $e : Event(uei == "uei.opennms.org/junit/insertPersistenceTestFact", source != "", $source : source)
+then
+  delete($e);
+  insert(new PersistedTestFact($source));
+end
+
+rule "find and delete persisted test fact by Drools query"
+  when
+    $e : Event(uei == "uei.opennms.org/junit/deletePersistenceTestFact", source != "", $source : source)
+  then
+    delete($e);
+    engine.getKieSessionObjects().stream().filter(fh -> fh.getClass().getCanonicalName().equals(
+        "org.opennms.netmgt.correlation.drools.PersistedTestFact")).forEach(
+            factHandle -> {
+              try {
+                PersistedTestFact ptfFh = (PersistedTestFact) factHandle;
+                String factId = ptfFh.getFactId();
+                if (factId.equals($source)) {
+                  System.err.println("This fact should be deleted by this rule: " + ptfFh);
+                } else {
+                  System.err.println("This fact should not be deleted by this rule: " + ptfFh);
+                }
+              } catch (Exception ex) {
+                System.err.println("Caught exception: " + ex);
+              }
+          }
+        );
+    QueryResultsImpl qri = (QueryResultsImpl)kcontext.getKieRuntime().getQueryResults(
+        "find PersistedTestFact by factId", new Object[] {$source});
+    for (org.kie.api.runtime.rule.QueryResultsRow row : qri) {
+      PersistedTestFact ptf = (PersistedTestFact) row.get("pf");
+      delete(ptf);
+    }
+  end


### PR DESCRIPTION
Marshal objects that are in the session before reload.
Unmarshal with specific class loader while restoring

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-12586
* Bamboo (Continuous Integration): https://bamboo.opennms.org/

