### PR TITLE
NMS-12616: Change key for events forwarded to kafka

### DIFF
--- a/features/kafka/producer/src/main/java/org/opennms/features/kafka/producer/OpennmsKafkaProducer.java
+++ b/features/kafka/producer/src/main/java/org/opennms/features/kafka/producer/OpennmsKafkaProducer.java
@@ -79,6 +79,7 @@ import org.springframework.expression.spel.standard.SpelExpressionParser;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
+import com.google.common.primitives.Longs;
 import com.swrve.ratelimitedlogger.RateLimitedLog;
 
 public class OpennmsKafkaProducer implements AlarmLifecycleListener, EventListener, AlarmFeedbackListener, OnmsTopologyConsumer {
@@ -251,7 +252,7 @@ public class OpennmsKafkaProducer implements AlarmLifecycleListener, EventListen
         sendRecord(() -> {
             final OpennmsModelProtos.Event mappedEvent = protobufMapper.toEvent(event).build();
             LOG.debug("Sending event with UEI: {}", mappedEvent.getUei());
-            return new ProducerRecord<>(eventTopic, mappedEvent.getUei().getBytes(encoding), mappedEvent.toByteArray());
+            return new ProducerRecord<>(eventTopic, Longs.toByteArray(mappedEvent.getId()), mappedEvent.toByteArray());
         }, recordMetadata -> {
             // We've got an ACK from the server that the event was forwarded
             // Let other threads know when we've successfully forwarded an event

--- a/features/kafka/producer/src/main/java/org/opennms/features/kafka/producer/ProtobufMapper.java
+++ b/features/kafka/producer/src/main/java/org/opennms/features/kafka/producer/ProtobufMapper.java
@@ -233,6 +233,7 @@ public class ProtobufMapper {
         }
 
         setTimeIfNotNull(event.getTime(), builder::setTime);
+        setTimeIfNotNull(event.getCreationTime(), builder::setCreateTime);
 
         return builder;
     }

--- a/features/kafka/producer/src/test/java/org/opennms/features/kafka/producer/KafkaForwarderIT.java
+++ b/features/kafka/producer/src/test/java/org/opennms/features/kafka/producer/KafkaForwarderIT.java
@@ -33,6 +33,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasItems;
@@ -313,6 +314,7 @@ public class KafkaForwarderIT implements TemporaryDatabaseAware<MockDatabase> {
                         && e.getNodeCriteria().getForeignSource() != null)
                 .collect(Collectors.toList());
         assertThat(eventsWithFsAndFid, hasSize(greaterThanOrEqualTo(2)));
+        assertThat(eventsWithFsAndFid.get(0).getCreateTime(), greaterThan(0L));
 
         // Verify the consumed alarm object
         assertThat(kafkaConsumer.getAlarmByReductionKey(alarmReductionKey).getDescription(), equalTo("node down"));

--- a/opennms-doc/guide-admin/src/asciidoc/text/kafka-producer/kafka-producer.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/kafka-producer/kafka-producer.adoc
@@ -11,7 +11,7 @@ See `opennms-kafka-producer.proto` and `collectionset.proto` in the correspondin
 ==== Events
 
 The _Kafka Producer_ listens for all events on the event bus and forwards these to a _Kafka_ topic.
-The records are keyed by event _UEI_ and contain a _GPB_ encoded model of the event.
+The records are keyed by event _Id_ and contain a _GPB_ encoded model of the event.
 
 By default, all events are forwarded to a topic named `events`.
 


### PR DESCRIPTION
To balance events across partitions, change key from `uei` to `id`
Fix event createTime in ProtobufMapper


### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-12616
* Bamboo (Continuous Integration): https://bamboo.opennms.org/

