### PR TITLE
NMS-12619: Revert zookeeper version to 3.4.7

### DIFF
--- a/container/features/src/main/resources/features-sentinel.xml
+++ b/container/features/src/main/resources/features-sentinel.xml
@@ -171,7 +171,7 @@
              description="OpenNMS :: Features :: Distributed :: Coordination :: Zookeeper" version="${project.version}">
         <feature version="${project.version}">sentinel-coordination-api</feature>
         <feature version="${project.version}">sentinel-coordination-common</feature>
-        <feature version="3.5.6">zookeeper-dependencies</feature>
+        <feature version="${zookeeperVersion}">zookeeper-dependencies</feature>
         <bundle>mvn:org.opennms.features.distributed/coordination-zookeeper/${project.version}</bundle>
     </feature>
 
@@ -181,8 +181,8 @@
         <bundle>mvn:org.opennms.features.distributed/coordination-shell/${project.version}</bundle>
     </feature>
 
-    <feature name="zookeeper-dependencies" version="3.5.6" description="ZooKeeper Dependencies">
-        <bundle dependency="true">wrap:mvn:org.apache.zookeeper/zookeeper/3.5.6</bundle>
+    <feature name="zookeeper-dependencies" version="${zookeeperVersion}" description="ZooKeeper Dependencies">
+        <bundle dependency="true">mvn:org.apache.zookeeper/zookeeper/${zookeeperVersion}</bundle>
         <bundle dependency="true">mvn:com.google.guava/guava/16.0.1</bundle>
         <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-core/2.10.0</bundle>
         <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-databind/2.10.0</bundle>

--- a/core/test-api/kafka/pom.xml
+++ b/core/test-api/kafka/pom.xml
@@ -83,7 +83,7 @@
     <dependency>
       <groupId>org.apache.zookeeper</groupId>
       <artifactId>zookeeper</artifactId>
-      <version>3.5.6</version>
+      <version>${zookeeperVersion}</version>
       <exclusions>
         <exclusion>
           <artifactId>log4j</artifactId>

--- a/features/distributed/coordination/zookeeper/pom.xml
+++ b/features/distributed/coordination/zookeeper/pom.xml
@@ -12,7 +12,6 @@
     <packaging>bundle</packaging>
     <name>OpenNMS :: Features :: Distributed :: Coordination :: Zookeeper</name>
     <properties>
-        <zookeeper.version>3.5.6</zookeeper.version>
         <guava16.version>16.0.1</guava16.version>
         <jackson.version>2.10.0</jackson.version>
         <curator.version>2.9.1</curator.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1325,6 +1325,7 @@
     <xmlApisVersion>1.4.01</xmlApisVersion>
     <wsdl4jVersion>1.6.3</wsdl4jVersion>
     <wsmanVersion>1.2.3</wsmanVersion>
+    <zookeeperVersion>3.4.7</zookeeperVersion>
 
     <springVersion>4.2.9.RELEASE_1</springVersion>
     <!-- ALWAYS change aspectj to match the version referenced in the spring poms -->


### PR DESCRIPTION
zookeeper upgrade broke `sentinel-coordination-zookeeper` on the sentinel.
### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-12619
* Bamboo (Continuous Integration): https://bamboo.opennms.org/

