### PR TITLE
NMS-12626: Update trapd on Minion to bind to 0.0.0.0:1162 by default

### DIFF
--- a/features/events/traps/src/main/resources/OSGI-INF/blueprint/blueprint-trapd-listener.xml
+++ b/features/events/traps/src/main/resources/OSGI-INF/blueprint/blueprint-trapd-listener.xml
@@ -15,7 +15,7 @@
 
 	<cm:property-placeholder id="trapHandlerDefaultProperties" persistent-id="org.opennms.netmgt.trapd" update-strategy="reload">
 		<cm:default-properties>
-			<cm:property name="trapd.listen.interface" value="127.0.0.1" /> <!-- the interface the TrapListener listens for traps -->
+			<cm:property name="trapd.listen.interface" value="0.0.0.0" /> <!-- the interface the TrapListener listens for traps -->
 			<cm:property name="trapd.listen.port" value="1162" /> <!-- the port the TrapListener listens for traps -->
 			<cm:property name="trapd.threads" value="0"/> <!-- the number of threads for the producer -->
 			<cm:property name="trapd.includeRawMessage" value="false" />

--- a/opennms-container/minion/CONFD_README.md
+++ b/opennms-container/minion/CONFD_README.md
@@ -144,7 +144,7 @@ Config specified will be written to `etc/org.opennms.netmgt.syslog.cfg`.
 --- 
 netmgt:
     traps:
-        trapd.listen.interface: "127.0.0.1"
+        trapd.listen.interface: "0.0.0.0"
         trapd.listen.port: 1162
         # Any other keys necessary can be specified here
 ```


### PR DESCRIPTION
JIRA: https://issues.opennms.org/browse/NMS-12626

From the JIRA description:

The Minion process currently binds to 127.0.0.1:1162 by default for handling SNMP traps. In most cases, this requires changing to a different interface once deployed.

The Syslog listener on the other hand bind to 0.0.0.0:1514 by default.

For consistency and simplicity, we should also bind to 0.0.0.0 for traps.