### PR TITLE
NMS-12627: Minion Docker image for develop is tagged 27.0.0-SNAPSHOT

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -476,7 +476,8 @@ jobs:
           command: |
             cd opennms-container/minion
 
-            # Create always a downloadable single OCI artifact for AMD architecture
+            # Create always a downloadable single OCI artifact for AMD architecture.
+            # This image is used in our integration test suite which relies on the tag "minion:latest".
             make VERSION="$(../pom2version.py ../../pom.xml)" \
                  DOCKER_TAG="minion:latest" \
                  BUILD_NUMBER="${CIRCLE_BUILD_NUM}" \
@@ -484,11 +485,20 @@ jobs:
                  BUILD_BRANCH="${CIRCLE_BRANCH}"
 
             # Build for multiple architectures only in release branches and push images with manifest to a registry
+            # For develop we set a floating tag "bleeding" instead the x.y.z-SNAPSHOT version number
             case "${CIRCLE_BRANCH}" in
-              "master" | "develop")
+              "master")
                 make DOCKER_ARCH="linux/amd64,linux/arm/v7,linux/arm64" \
                      DOCKER_FLAGS=--push \
                      VERSION="$(../pom2version.py ../../pom.xml)" \
+                     BUILD_NUMBER="${CIRCLE_BUILD_NUM}" \
+                     BUILD_URL="${CIRCLE_BUILD_URL}" \
+                     BUILD_BRANCH="${CIRCLE_BRANCH}"
+                ;;
+              "develop")
+                make DOCKER_ARCH="linux/amd64,linux/arm/v7,linux/arm64" \
+                     DOCKER_FLAGS=--push \
+                     VERSION="bleeding" \
                      BUILD_NUMBER="${CIRCLE_BUILD_NUM}" \
                      BUILD_URL="${CIRCLE_BUILD_URL}" \
                      BUILD_BRANCH="${CIRCLE_BRANCH}"


### PR DESCRIPTION
### All Contributors

* [x] Have you read and followed our [Contribution Guidelines](https://github.com/OpenNMS/opennms/blob/develop/CONTRIBUTING.md)?
* [x] Have you [made an issue in the OpenNMS issue tracker](https://issues.opennms.org)?<br>If so, you should:
  1. update the title of this PR to be of the format: `${JIRA-ISSUE-NUMBER}: subject of pull request`
  2. update the JIRA link at the bottom of this comment to refer to the real issue number
  3. prefix your commit messages with the issue number, if possible
* [x] Have you made a comment in that issue which points back to this PR?
* [x] Have you updated the JIRA link at the bottom of this comment to link to your issue?
* [x] If this is a new or updated feature, is there documentation for the new behavior?
* [x] If this is new code, are there unit and/or integration tests?
* [ ] If this PR targets a `foundation-*` branch, does it avoid changing files in `$OPENNMS_HOME/etc/`?

Change the publish job to use a floating tag "bleeding" for develop and use the root pom.xml version number just for master branch.

This is related to pushing Minion images to [DockerHub Minion Repo](https://hub.docker.com/repository/docker/opennms/minion/tags?page=1)

### External References

* JIRA (Issue Tracker): https://issues.opennms.org/browse/NMS-12627

