### PR TITLE
NMS-12628: implement foundation merging in foundation-2016

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,11 +8,38 @@ executors:
   debian-build-executor:
     docker:
       - image: opennms/build-env:debian-jdk8-b3572
+  docker-executor:
+    docker:
+      - image: docker:19.03.0-git
   integration-test-executor:
     machine: true
   smoke-test-executor:
     machine:
       image: ubuntu-1604:201903-01
+
+# NOTE: the "_label" versions of these are for the case when your source or target
+# branches have slashes in them, that way the merge branch gets created properly
+defaults: &defaults
+  parameters:
+    from_branch:
+      description: the auto-merge source branch
+      type: string
+      default: jira/NMS-12628
+    from_branch_label:
+      description: the auto-merge source branch (escaped, no slashes)
+      type: string
+      default: jira-NMS-12628
+    to_branch:
+      description: the auto-merge target branch
+      type: string
+      default: jira/NMS-12628-master
+    to_branch_label:
+      description: the auto-merge target branch (escaped, no slashes)
+      type: string
+      default: jira-NMS-12628-master
+
+docker_container_config: &docker_container_config
+  executor: docker-executor
 
 orbs:
   cloudsmith: cloudsmith/cloudsmith@1.0.3
@@ -296,6 +323,7 @@ workflows:
           requires:
             - integration-test-with-coverage
   build-deploy:
+    <<: *defaults
     jobs:
       - build
       - horizon-rpm-build:
@@ -350,6 +378,28 @@ workflows:
                 - /^foundation.*/
                 - /^features.*/
                 - /.*smoke.*/
+      - create-merge-foundation-branch:
+          # technically only requires the RPM/deb builds, but only publish
+          # if everything passes
+          requires:
+            - horizon-deb-build
+            - smoke-test-minimal
+            - smoke-test-full
+            - integration-test
+          filters:
+            branches:
+              only: << parameters.from_branch >>
+      - merge-foundation-branch:
+          # technically only requires the RPM/deb builds, but only publish
+          # if everything passes
+          requires:
+            - horizon-deb-build
+            - smoke-test-minimal
+            - smoke-test-full
+            - integration-test
+          filters:
+            branches:
+              only: merge-foundation/<< parameters.from_branch_label >>-to-<< parameters.to_branch_label >>
       - publish-cloudsmith:
           # technically only requires the RPM/deb builds, but only publish
           # if everything passes
@@ -514,6 +564,52 @@ jobs:
           at: ~/
       - run-smoke-tests:
           minimal: true
+  create-merge-foundation-branch:
+    <<: *defaults
+    <<: *docker_container_config
+    steps:
+      - add_ssh_keys:
+          fingerprints:
+            - "5e:70:a4:1a:f3:9f:39:ca:2a:d9:b5:9a:6c:2b:c3:66"
+      - checkout
+      - run:
+          name: Create git identity
+          command: |
+            git config user.email "cicd-system@opennms.com"
+            git config user.name "CI/CD System"
+      - run:
+          name: Checkout target branch and merge from source
+          command: |
+            export GIT_MERGE_AUTOEDIT=no
+            git checkout << parameters.to_branch >>
+            git merge origin/<< parameters.from_branch >>
+      - run:
+          name: Push to github
+          command: git push -f origin << parameters.to_branch >>:merge-foundation/<< parameters.from_branch_label >>-to-<< parameters.to_branch_label >>
+
+  merge-foundation-branch:
+    <<: *defaults
+    <<: *docker_container_config
+    steps:
+      - add_ssh_keys:
+          fingerprints:
+            - "5e:70:a4:1a:f3:9f:39:ca:2a:d9:b5:9a:6c:2b:c3:66"
+      - checkout
+      - run:
+          name: Create git identity
+          command: |
+            git config user.email "cicd-system@opennms.com"
+            git config user.name "CI/CD System"
+      - run:
+          name: Checkout target and merge with merge branch
+          command: |
+            export GIT_MERGE_AUTOEDIT=no
+            git checkout << parameters.to_branch >>
+            git merge origin/merge-foundation/<< parameters.from_branch_label >>-to-<< parameters.to_branch_label >>
+      - run:
+          name: Push to github
+          command: git push origin << parameters.to_branch >>:<< parameters.to_branch >>
+
   publish-cloudsmith:
     executor: cloudsmith/default
     resource_class: small

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,19 +24,19 @@ defaults: &defaults
     from_branch:
       description: the auto-merge source branch
       type: string
-      default: jira/NMS-12628
+      default: foundation-2016
     from_branch_label:
       description: the auto-merge source branch (escaped, no slashes)
       type: string
-      default: jira-NMS-12628
+      default: foundation-2016
     to_branch:
       description: the auto-merge target branch
       type: string
-      default: jira/NMS-12628-master
+      default: foundation-2017
     to_branch_label:
       description: the auto-merge target branch (escaped, no slashes)
       type: string
-      default: jira-NMS-12628-master
+      default: foundation-2017
 
 docker_container_config: &docker_container_config
   executor: docker-executor


### PR DESCRIPTION
This PR duplicates recent work in the Helm project for auto-merging branches forward using templating.  It's been updated to merge `foundation-2016` to `foundation-2017`, but the original proof-of-concept was done in the `jira/NMS-12628` branch.  You can see how it worked in 2 phases:

1. [create the merge branch](https://app.circleci.com/pipelines/github/OpenNMS/opennms/5229/workflows/d448cf06-7b8f-4522-9971-7d0e1776a1f1/jobs/23014)
2. [merge the merge branch into the target branch](https://app.circleci.com/pipelines/github/OpenNMS/opennms/5231/workflows/994a70ce-3716-405d-a7dd-1779b6e3b01d/jobs/23033)

Once this is merged, all that's left to do for other branches is to change the parameters at the top of the CircleCI config.  (Also adding dependencies on additional builds, like minion or sentinel that only exist in newer branches.)

https://issues.opennms.org/browse/NMS-12628