### PR TITLE
NMS-12630: Push OCI for Horizon and Sentinel as release candidate

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -357,6 +357,7 @@ workflows:
               only:
                 - master
                 - develop
+                - /^release-.*/
       - sentinel-publish-oci:
           requires:
             - sentinel-rpm-build
@@ -365,6 +366,7 @@ workflows:
               only:
                 - master
                 - develop
+                - /^release-.*/
       # These don't actually require `integration-test` but we shouldn't bother
       # spending cycles unless everything else passed
       - horizon-deb-build:

--- a/opennms-container/version-tags.sh
+++ b/opennms-container/version-tags.sh
@@ -8,6 +8,9 @@ case "${CIRCLE_BRANCH}" in
   develop)
     VERSION="bleeding"
     ;;
+  "release-"*)
+    VERSION="release-candidate"
+    ;;
   *)
     # Replace / in branch names which is not allowed in OCI tags
     VERSION="${CIRCLE_BRANCH//\//-}"


### PR DESCRIPTION
### All Contributors

* [x] Have you read and followed our [Contribution Guidelines](https://github.com/OpenNMS/opennms/blob/develop/CONTRIBUTING.md)?
* [x] Have you [made an issue in the OpenNMS issue tracker](https://issues.opennms.org)?<br>If so, you should:
  1. update the title of this PR to be of the format: `${JIRA-ISSUE-NUMBER}: subject of pull request`
  2. update the JIRA link at the bottom of this comment to refer to the real issue number
  3. prefix your commit messages with the issue number, if possible
* [x] Have you made a comment in that issue which points back to this PR?
* [x] Have you updated the JIRA link at the bottom of this comment to link to your issue?
* [x] If this is a new or updated feature, is there documentation for the new behavior?
* [x] If this is new code, are there unit and/or integration tests?
* [x] If this PR targets a `foundation-*` branch, does it avoid changing files in `$OPENNMS_HOME/etc/`?

Changed to filter for publishing the OCI images for Horizon and Sentinel to be executed also for release-* branches. We use the floating tag "release-candidate" on DockerHub.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-12630


