### PR TITLE
NMS-12532: avoid double-loading d3/c3 dependencies

### DIFF
--- a/core/web-assets/src/main/assets/js/apps/status-box/index.js
+++ b/core/web-assets/src/main/assets/js/apps/status-box/index.js
@@ -1,6 +1,6 @@
 const $ = require('vendor/jquery-js');
-const c3 = require('c3');
-const d3 = require('d3');
+const c3 = require('vendor/c3-js');
+const d3 = require('vendor/d3-js');
 require('./status-box.css');
 
 d3.document = window.document;

--- a/core/web-assets/src/main/assets/js/vendor/c3-js.js
+++ b/core/web-assets/src/main/assets/js/vendor/c3-js.js
@@ -1,6 +1,9 @@
-require('vendor/d3-js');
-const c3 = require('c3');
+if (window['c3']) {
+  console.debug('init: c3-js already loaded'); // eslint-disable-line no-console
+} else {
+  console.info('init: c3-js'); // eslint-disable-line no-console
+  require('vendor/d3-js');
+  window['c3'] = require('c3');
+}
 
-console.log('init: c3-js'); // eslint-disable-line no-console
-
-module.exports = window['c3'] = c3;
+module.exports = window['c3'];

--- a/core/web-assets/src/main/assets/js/vendor/d3-js.js
+++ b/core/web-assets/src/main/assets/js/vendor/d3-js.js
@@ -1,5 +1,8 @@
-const d3 = require('d3');
+if (window['d3']) {
+  console.debug('init: d3-js already loaded'); // eslint-disable-line no-console
+} else {
+  console.info('init: d3-js'); // eslint-disable-line no-console
+  window['d3'] = require('d3');
+}
 
-console.log('init: d3-js'); // eslint-disable-line no-console
-
-module.exports = window['d3'] = d3;
+module.exports = window['d3'];


### PR DESCRIPTION
This PR does some small changes to make sure that `d3` and `c3` are only loaded once, to avoid event errors in the topology map.

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-12532
* Bamboo (Continuous Integration): https://bamboo.opennms.org/

