### PR TITLE
NMS-12635: Restore CAP_NET_RAW capabilities in Minion

### DIFF
--- a/opennms-container/minion/Dockerfile
+++ b/opennms-container/minion/Dockerfile
@@ -4,7 +4,7 @@
 # To avoid issues, we rearrange the directories in pre-stage to avoid injecting these
 # as addtional layers into the final image.
 ##
-ARG BASE_IMAGE="opennms/deploy-base:jre-1.0.0.b38"
+ARG BASE_IMAGE="opennms/deploy-base:jre-1.0.0.b39"
 
 FROM ${BASE_IMAGE} as minion-base
 
@@ -29,6 +29,12 @@ FROM ${BASE_IMAGE}
 # Create user to be able to run as non root with a known user and group id.
 RUN groupadd --gid 10001 minion && \
     useradd --system --uid 10001 --gid minion minion --home-dir /opt/minion
+
+# https://issues.opennms.org/browse/NMS-12635
+# It is possible to set sysctls: net.ipv4.ping_group_range=0 10001 which allows the container using sockets. If we run on
+# infrastructure which doesn't allow whitelisting net.ipv4.ping_group_range as a safe sysctl (Kubernetes < 1.18) the
+# minimal solution is giving the Java binary the cap_net_raw+ep capabilities.
+RUN setcap cap_net_raw+ep $(readlink -f /usr/bin/java)
 
 # Install entrypoint wrapper and health check script
 COPY container-fs/entrypoint.sh /

--- a/opennms-container/minion/Makefile
+++ b/opennms-container/minion/Makefile
@@ -8,7 +8,7 @@
 VERSION                 := localbuild
 SHELL                   := /bin/bash -o nounset -o pipefail -o errexit
 BUILD_DATE              := $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
-BASE_IMAGE              := opennms/deploy-base:jre-1.0.0.b38
+BASE_IMAGE              := opennms/deploy-base:jre-1.0.0.b39
 DOCKER_CLI_EXPERIMENTAL := enabled
 DOCKERX_INSTANCE        := env-minion-oci
 DOCKER_REGISTRY         := docker.io

--- a/smoke-test/src/main/java/org/opennms/smoketest/containers/MinionContainer.java
+++ b/smoke-test/src/main/java/org/opennms/smoketest/containers/MinionContainer.java
@@ -98,10 +98,6 @@ public class MinionContainer extends GenericContainer implements KarafContainer,
                     final CreateContainerCmd createCmd = (CreateContainerCmd)cmd;
                     TestContainerUtils.setGlobalMemAndCpuLimits(createCmd);
                     TestContainerUtils.exposePortsAsUdp(createCmd, MINION_SNMP_TRAP_PORT, MINION_TELEMETRY_FLOW_PORT, MINION_TELEMETRY_JTI_PORT, MINION_TELEMETRY_NXOS_PORT);
-                    if (profile.isIcmpSupportEnabled()) {
-                        // Run as root when ICMP is enabled
-                        createCmd.withUser("root");
-                    }
                 })
                 .withEnv("OPENNMS_HTTP_USER", "admin")
                 .withEnv("OPENNMS_HTTP_PASS", "admin")


### PR DESCRIPTION
### All Contributors

* [x] Have you read and followed our [Contribution Guidelines](https://github.com/OpenNMS/opennms/blob/develop/CONTRIBUTING.md)?
* [x] Have you [made an issue in the OpenNMS issue tracker](https://issues.opennms.org)?<br>If so, you should:
  1. update the title of this PR to be of the format: `${JIRA-ISSUE-NUMBER}: subject of pull request`
  2. update the JIRA link at the bottom of this comment to refer to the real issue number
  3. prefix your commit messages with the issue number, if possible
* [x] Have you made a comment in that issue which points back to this PR?
* [x] Have you updated the JIRA link at the bottom of this comment to link to your issue?
* [x] If this is a new or updated feature, is there documentation for the new behavior?
* [x] If this is new code, are there unit and/or integration tests?
* [x] If this PR targets a `foundation-*` branch, does it avoid changing files in `$OPENNMS_HOME/etc/`?

Set cap_net_raw capabilities to the Java binary.

## Reviewer hint

I have removed in a separate commit to run the Minion as root in our smoke test suite.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-12635
