### PR TITLE
update CircleCI checksums to conserve space/bandwidth

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,11 +42,12 @@ commands:
         - run:
             name: Calculate cache key from pom files
             command: |
-              find . -type f -name "pom.xml" -exec sha256sum "{}" \; | sort -nr >> maven-dependency-cache.key
+              grep -E '<version>' pom.xml | head -n 1 | sed -e 's,^[^>]*>,,' -e 's,<.*$,,' > maven-dependency-version-cache.key
+              find . -type f -name "pom.xml" | grep -v /target/ | sort -u | xargs cat > maven-dependency-pom-cache.key
         - restore_cache:
             keys:
-              - maven-dependencies-v2-{{ checksum "maven-dependency-cache.key" }}
-              - maven-dependencies-v2-
+              - maven-dependencies-v3-{{ checksum "maven-dependency-version-cache.key" }}-{{ checksum "maven-dependency-pom-cache.key" }}
+              - maven-dependencies-v3-{{ checksum "maven-dependency-version-cache.key" }}-
         - run:
             name: Remove OpenNMS artifacts from cache
             command: |
@@ -55,7 +56,7 @@ commands:
     description: "Maven: Save cache"
     steps:
       - save_cache:
-          key: maven-dependencies-v2-{{ checksum "maven-dependency-cache.key" }}
+          key: maven-dependencies-v3-{{ checksum "maven-dependency-version-cache.key" }}-{{ checksum "maven-dependency-pom-cache.key" }}
           paths:
             - ~/.m2
   restore-nodejs-cache:
@@ -64,31 +65,35 @@ commands:
         - run:
             name: Calculate cache key
             command: |
-              sha256sum opennms-webapp/bower.json > nodejs-dependency-cache.key
-              sha256sum opennms-webapp/package.json >> nodejs-dependency-cache.key
+              find opennms-webapp -name package\*.json -o -name bower.json | grep -v /target/ | sort -u | xargs cat > nodejs-dependency-json-cache.key
+              grep -E '<version>' pom.xml | head -n 1 | sed -e 's,^[^>]*>,,' -e 's,<.*$,,' > nodejs-dependency-version-cache.key
         - restore_cache:
             keys:
-              - nodejs-dependencies-v1-{{ checksum "nodejs-dependency-cache.key" }}
-              - nodejs-dependencies-v1-
+              - nodejs-dependencies-v2-{{ checksum "nodejs-dependency-version-cache.key" }}-{{ checksum "nodejs-dependency-json-cache.key" }}
+              - nodejs-dependencies-v2-{{ checksum "nodejs-dependency-version-cache.key" }}-
   save-nodejs-cache:
     description: "NodeJS: Save cache"
     steps:
       - save_cache:
-          key: nodejs-dependencies-v1-{{ checksum "nodejs-dependency-cache.key" }}
+          key: nodejs-dependencies-v2-{{ checksum "nodejs-dependency-version-cache.key" }}-{{ checksum "nodejs-dependency-json-cache.key" }}
           paths:
             - opennms-webapp/bower_components
             - opennms-webapp/node_modules
   restore-sonar-cache:
       description: "Sonar: Restore sonar cache"
       steps:
+        - run:
+            name: Calculate cache key
+            command: |
+              grep -E '<version>' pom.xml | head -n 1 | sed -e 's,^[^>]*>,,' -e 's,<.*$,,' > sonar-dependency-version-cache.key
         - restore_cache:
             keys:
-              - sonar-cache-v1-
+              - sonar-cache-v2-{{ checksum "sonar-dependency-version-cache.key" }}
   save-sonar-cache:
       description: "Sonar: Save sonar cache"
       steps:
         - save_cache:
-            key: sonar-cache-v1-
+            key: sonar-cache-v2-{{ checksum "sonar-dependency-version-cache.key" }}
             paths:
               - ~/.sonar
   dockerhub-login:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,13 @@ orbs:
   sign-packages: opennms/sign-packages@2.1.1
 
 commands:
+  extract-pom-version:
+      description: "Extracting Maven POM version"
+      steps:
+        - run:
+            name: Extract Maven POM version
+            command: |
+              grep -E '<version>' pom.xml | head -n 1 | sed -e 's,^[^>]*>,,' -e 's,<.*$,,' > pom-version-cache.key
   cached-checkout:
       description: "Checkout with caching"
       steps:
@@ -41,13 +48,11 @@ commands:
       steps:
         - run:
             name: Calculate cache key from pom files
-            command: |
-              grep -E '<version>' pom.xml | head -n 1 | sed -e 's,^[^>]*>,,' -e 's,<.*$,,' > maven-dependency-version-cache.key
-              find . -type f -name "pom.xml" | grep -v /target/ | sort -u | xargs cat > maven-dependency-pom-cache.key
+            command: find . -type f -name "pom.xml" | grep -v /target/ | sort -u | xargs cat > maven-dependency-pom-cache.key
         - restore_cache:
             keys:
-              - maven-dependencies-v3-{{ checksum "maven-dependency-version-cache.key" }}-{{ checksum "maven-dependency-pom-cache.key" }}
-              - maven-dependencies-v3-{{ checksum "maven-dependency-version-cache.key" }}-
+              - maven-dependencies-v3-{{ checksum "pom-version-cache.key" }}-{{ checksum "maven-dependency-pom-cache.key" }}
+              - maven-dependencies-v3-{{ checksum "pom-version-cache.key" }}-
         - run:
             name: Remove OpenNMS artifacts from cache
             command: |
@@ -56,7 +61,7 @@ commands:
     description: "Maven: Save cache"
     steps:
       - save_cache:
-          key: maven-dependencies-v3-{{ checksum "maven-dependency-version-cache.key" }}-{{ checksum "maven-dependency-pom-cache.key" }}
+          key: maven-dependencies-v3-{{ checksum "pom-version-cache.key" }}-{{ checksum "maven-dependency-pom-cache.key" }}
           paths:
             - ~/.m2
   restore-nodejs-cache:
@@ -64,36 +69,30 @@ commands:
       steps:
         - run:
             name: Calculate cache key
-            command: |
-              find opennms-webapp -name package\*.json -o -name bower.json | grep -v /target/ | sort -u | xargs cat > nodejs-dependency-json-cache.key
-              grep -E '<version>' pom.xml | head -n 1 | sed -e 's,^[^>]*>,,' -e 's,<.*$,,' > nodejs-dependency-version-cache.key
+            command: find opennms-webapp -name package\*.json -o -name bower.json | grep -v /target/ | sort -u | xargs cat > nodejs-dependency-json-cache.key
         - restore_cache:
             keys:
-              - nodejs-dependencies-v2-{{ checksum "nodejs-dependency-version-cache.key" }}-{{ checksum "nodejs-dependency-json-cache.key" }}
-              - nodejs-dependencies-v2-{{ checksum "nodejs-dependency-version-cache.key" }}-
+              - nodejs-dependencies-v2-{{ checksum "pom-version-cache.key" }}-{{ checksum "nodejs-dependency-json-cache.key" }}
+              - nodejs-dependencies-v2-{{ checksum "pom-version-cache.key" }}-
   save-nodejs-cache:
     description: "NodeJS: Save cache"
     steps:
       - save_cache:
-          key: nodejs-dependencies-v2-{{ checksum "nodejs-dependency-version-cache.key" }}-{{ checksum "nodejs-dependency-json-cache.key" }}
+          key: nodejs-dependencies-v2-{{ checksum "pom-version-cache.key" }}-{{ checksum "nodejs-dependency-json-cache.key" }}
           paths:
             - opennms-webapp/bower_components
             - opennms-webapp/node_modules
   restore-sonar-cache:
       description: "Sonar: Restore sonar cache"
       steps:
-        - run:
-            name: Calculate cache key
-            command: |
-              grep -E '<version>' pom.xml | head -n 1 | sed -e 's,^[^>]*>,,' -e 's,<.*$,,' > sonar-dependency-version-cache.key
         - restore_cache:
             keys:
-              - sonar-cache-v2-{{ checksum "sonar-dependency-version-cache.key" }}
+              - sonar-cache-v2-{{ checksum "pom-version-cache.key" }}
   save-sonar-cache:
       description: "Sonar: Save sonar cache"
       steps:
         - save_cache:
-            key: sonar-cache-v2-{{ checksum "sonar-dependency-version-cache.key" }}
+            key: sonar-cache-v2-{{ checksum "pom-version-cache.key" }}
             paths:
               - ~/.sonar
   dockerhub-login:
@@ -185,6 +184,7 @@ commands:
         type: string
     steps:
       - cached-checkout
+      - extract-pom-version
       - restore-maven-cache
       - restore-nodejs-cache
       - run:
@@ -489,6 +489,7 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/
+      - extract-pom-version
       - restore-sonar-cache
       - run:
           name: Restore Target Directories (Code Coverage)


### PR DESCRIPTION
These changes make builds take anywhere from a few seconds to a few minutes less time, by reducing the amount of workspace junk that gets passed around from different caches.

In general, the major thing it does is add a level of caching based on the `<version>` tag in `pom.xml`, since dependency churn among single versions is less common.  This greatly reduces the size of the cache that's passed around between workspaces (in some cases up to 1GB!).

I also got rid of the "generic" keys for nodejs and maven dependencies since they increase the chances of passing old junk along, at the expense of the first build of a pom version being a bit slower (since it needs to download new dependencies).  This will have the side-effect of catching if upstream dependencies go away, which we're probably pretty immune to now and could make it hard to know that upstream repos are permanently gone or changed.

Finally, I got rid of checksumming-the-checksums in favor of just catting everything together in a repeatable way.