### PR TITLE
NMS-12642: Curl should fail when download does not work

### DIFF
--- a/opennms-container/horizon/Dockerfile
+++ b/opennms-container/horizon/Dockerfile
@@ -17,7 +17,7 @@ ARG CONFD_URL="https://github.com/kelseyhightower/confd/releases/download/v${CON
 SHELL ["/bin/bash", "-c"]
 
 # Collect generic steps in a layer for caching
-RUN curl -L ${CONFD_URL} -o /usr/bin/confd && \
+RUN curl --retry 5 --fail -L ${CONFD_URL} -o /usr/bin/confd && \
     chmod +x /usr/bin/confd
 
 RUN dnf -y install dnf-plugins-core && \


### PR DESCRIPTION
### All Contributors

* [x] Have you read and followed our [Contribution Guidelines](https://github.com/OpenNMS/opennms/blob/develop/CONTRIBUTING.md)?
* [x] Have you [made an issue in the OpenNMS issue tracker](https://issues.opennms.org)?<br>If so, you should:
  1. update the title of this PR to be of the format: `${JIRA-ISSUE-NUMBER}: subject of pull request`
  2. update the JIRA link at the bottom of this comment to refer to the real issue number
  3. prefix your commit messages with the issue number, if possible
* [x] Have you made a comment in that issue which points back to this PR?
* [x] Have you updated the JIRA link at the bottom of this comment to link to your issue?
* [x] If this is a new or updated feature, is there documentation for the new behavior?
* [x] If this is new code, are there unit and/or integration tests?
* [x] If this PR targets a `foundation-*` branch, does it avoid changing files in `$OPENNMS_HOME/etc/`?

### Pull Request Process

Let curl fail immediately when downloading confd dependency does not work. Otherwise, we may get an error HTML page and we fail late in when we run smoke tests.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-12642
