### PR TITLE
 NMS-12605: Provisiond accepts multiple primary SNMP interfaces

### DIFF
--- a/core/web-assets/src/main/assets/js/apps/onms-requisitions/lib/scripts/controllers/Interface.js
+++ b/core/web-assets/src/main/assets/js/apps/onms-requisitions/lib/scripts/controllers/Interface.js
@@ -28,7 +28,7 @@ const RequisitionService = require('../model/RequisitionService');
   *
   * @description The controller for manage the modal dialog for add/edit IP interfaces of requisitioned nodes
   */
-  .controller('InterfaceController', ['$scope', '$uibModalInstance', 'RequisitionsService', 'foreignSource', 'foreignId', 'requisitionInterface', 'ipBlackList', 'isPrimaryExists', function($scope, $uibModalInstance, RequisitionsService, foreignSource, foreignId, requisitionInterface, ipBlackList, isPrimaryExists) {
+  .controller('InterfaceController', ['$scope', '$uibModalInstance', 'RequisitionsService', 'foreignSource', 'foreignId', 'requisitionInterface', 'ipBlackList', 'primaryInterface', function($scope, $uibModalInstance, RequisitionsService, foreignSource, foreignId, requisitionInterface, ipBlackList, primaryInterface) {
 
     /**
     * @description The foreign source (a.k.a the name of the requisition).
@@ -71,7 +71,7 @@ const RequisitionService = require('../model/RequisitionService');
     $scope.ipBlackList = ipBlackList;
 
 
-    $scope.isPrimaryExists = isPrimaryExists;
+    $scope.primaryInterface = primaryInterface;
 
     /**
     * @description An array map with the valid values for snmp-primary
@@ -108,9 +108,9 @@ const RequisitionService = require('../model/RequisitionService');
       $uibModalInstance.close($scope.requisitionInterface);
     };
 
-    $scope.getSnmpPrimaryValues = function() {
-
-      if($scope.isPrimaryExists) {
+    $scope.getSnmpPrimaryValues = function(ipAddress) {
+      const isPrimaryExists = $scope.primaryInterface !== null ? true : false;
+      if(isPrimaryExists && ipAddress !== $scope.primaryInterface) {
         const snmpPrimary = $scope.snmpPrimaryFields.filter(field => field.id !== 'P');
         return snmpPrimary;
       }

--- a/core/web-assets/src/main/assets/js/apps/onms-requisitions/lib/scripts/controllers/Interface.js
+++ b/core/web-assets/src/main/assets/js/apps/onms-requisitions/lib/scripts/controllers/Interface.js
@@ -28,7 +28,7 @@ const RequisitionService = require('../model/RequisitionService');
   *
   * @description The controller for manage the modal dialog for add/edit IP interfaces of requisitioned nodes
   */
-  .controller('InterfaceController', ['$scope', '$uibModalInstance', 'RequisitionsService', 'foreignSource', 'foreignId', 'requisitionInterface', 'ipBlackList', function($scope, $uibModalInstance, RequisitionsService, foreignSource, foreignId, requisitionInterface, ipBlackList) {
+  .controller('InterfaceController', ['$scope', '$uibModalInstance', 'RequisitionsService', 'foreignSource', 'foreignId', 'requisitionInterface', 'ipBlackList', 'isPrimaryExists', function($scope, $uibModalInstance, RequisitionsService, foreignSource, foreignId, requisitionInterface, ipBlackList, isPrimaryExists) {
 
     /**
     * @description The foreign source (a.k.a the name of the requisition).
@@ -70,6 +70,9 @@ const RequisitionService = require('../model/RequisitionService');
     */
     $scope.ipBlackList = ipBlackList;
 
+
+    $scope.isPrimaryExists = isPrimaryExists;
+
     /**
     * @description An array map with the valid values for snmp-primary
     *
@@ -103,6 +106,15 @@ const RequisitionService = require('../model/RequisitionService');
     */
     $scope.save = function () {
       $uibModalInstance.close($scope.requisitionInterface);
+    };
+
+    $scope.getSnmpPrimaryValues = function() {
+
+      if($scope.isPrimaryExists) {
+        const snmpPrimary = $scope.snmpPrimaryFields.filter(field => field.id !== 'P');
+        return snmpPrimary;
+      }
+      return $scope.snmpPrimaryFields;
     };
 
     /**

--- a/core/web-assets/src/main/assets/js/apps/onms-requisitions/lib/scripts/controllers/Node.js
+++ b/core/web-assets/src/main/assets/js/apps/onms-requisitions/lib/scripts/controllers/Node.js
@@ -387,6 +387,7 @@ const RequisitionMetaDataEntry = require('../model/RequisitionMetaDataEntry');
       var foreignSource = $scope.foreignSource;
       var foreignId = $scope.foreignId;
       var ipBlackList = [];
+      const isPrimaryExists = $scope.getPrimaryAddress() ? true : false;
       angular.forEach($scope.node.interfaces, function(intf) {
         ipBlackList.push(intf.ipAddress);
       });
@@ -400,7 +401,8 @@ const RequisitionMetaDataEntry = require('../model/RequisitionMetaDataEntry');
           foreignId: function() { return foreignId; },
           foreignSource: function() { return foreignSource; },
           requisitionInterface: function() { return angular.copy(intfToEdit); },
-          ipBlackList: function() { return ipBlackList; }
+          ipBlackList: function() { return ipBlackList; },
+          isPrimaryExists : function() { return isPrimaryExists;}
         }
       });
 
@@ -533,8 +535,8 @@ const RequisitionMetaDataEntry = require('../model/RequisitionMetaDataEntry');
     * @returns {string} the primary IP address or 'N/A' if it doesn't exist.
     */
     $scope.getPrimaryAddress = function() {
-      var ip = $scope.node.getPrimaryIpAddress();
-      return ip ? ip : 'N/A';
+      const ip = $scope.node.getPrimaryIpAddress();
+      return ip ? ip : null;
     };
 
     // Initialization of the node's page for either adding a new node or editing an existing node

--- a/core/web-assets/src/main/assets/js/apps/onms-requisitions/lib/scripts/controllers/Node.js
+++ b/core/web-assets/src/main/assets/js/apps/onms-requisitions/lib/scripts/controllers/Node.js
@@ -387,7 +387,6 @@ const RequisitionMetaDataEntry = require('../model/RequisitionMetaDataEntry');
       var foreignSource = $scope.foreignSource;
       var foreignId = $scope.foreignId;
       var ipBlackList = [];
-      const isPrimaryExists = $scope.getPrimaryAddress() ? true : false;
       angular.forEach($scope.node.interfaces, function(intf) {
         ipBlackList.push(intf.ipAddress);
       });
@@ -402,7 +401,7 @@ const RequisitionMetaDataEntry = require('../model/RequisitionMetaDataEntry');
           foreignSource: function() { return foreignSource; },
           requisitionInterface: function() { return angular.copy(intfToEdit); },
           ipBlackList: function() { return ipBlackList; },
-          isPrimaryExists : function() { return isPrimaryExists;}
+          primaryInterface : function() { return $scope.getPrimaryAddress();}
         }
       });
 

--- a/core/web-assets/src/main/assets/js/apps/onms-requisitions/lib/views/interface.html
+++ b/core/web-assets/src/main/assets/js/apps/onms-requisitions/lib/views/interface.html
@@ -21,9 +21,9 @@
       <label class="col-form-label" for="snmpPrimary">SNMP Primary</label>
       <input class="form-control" type="text" id="snmpPrimary" name="snmpPrimary" placeholder="SNMP Primary Flag (choose one from the list)"
              ng-model="requisitionInterface.snmpPrimary" typeahead-editable="false" typeahead-min-length="0"
-             uib-typeahead="a.id as a.title for a in snmpPrimaryFields | filter:$viewValue" required
+             uib-typeahead="a.id as a.title for a in getSnmpPrimaryValues() | filter:$viewValue" required
              ng-class="{ 'is-invalid' : intfForm.snmpPrimary.$invalid }">
-      <p ng-show="intfForm.snmpPrimary.$invalid" class="invalid-feedback">A valid SNMP Primary Flag is required.</p>
+      <p ng-show="intfForm.snmpPrimary.$invalid" class="invalid-feedback">A valid SNMP Primary Flag is required, only one primary interface is allowed within the node.</p>
     </div>
     <label ng-show="requisitionInterface.services.length > 0">Services</label>
     <ng-form name="serviceForm" ng-repeat="service in requisitionInterface.services">

--- a/core/web-assets/src/main/assets/js/apps/onms-requisitions/lib/views/interface.html
+++ b/core/web-assets/src/main/assets/js/apps/onms-requisitions/lib/views/interface.html
@@ -21,7 +21,7 @@
       <label class="col-form-label" for="snmpPrimary">SNMP Primary</label>
       <input class="form-control" type="text" id="snmpPrimary" name="snmpPrimary" placeholder="SNMP Primary Flag (choose one from the list)"
              ng-model="requisitionInterface.snmpPrimary" typeahead-editable="false" typeahead-min-length="0"
-             uib-typeahead="a.id as a.title for a in getSnmpPrimaryValues() | filter:$viewValue" required
+             uib-typeahead="a.id as a.title for a in getSnmpPrimaryValues(requisitionInterface.ipAddress) | filter:$viewValue" required
              ng-class="{ 'is-invalid' : intfForm.snmpPrimary.$invalid }">
       <p ng-show="intfForm.snmpPrimary.$invalid" class="invalid-feedback">A valid SNMP Primary Flag is required, only one primary interface is allowed within the node.</p>
     </div>

--- a/core/web-assets/src/test/javascript/ng-requisitions/controllers/Interface.test.js
+++ b/core/web-assets/src/test/javascript/ng-requisitions/controllers/Interface.test.js
@@ -30,6 +30,7 @@ function createController() {
     foreignSource: foreignSource,
     foreignId: foreignId,
     requisitionInterface: node.interfaces[0],
+    primaryInterface: '10.0.0.1',
     ipBlackList: []
   });
 }

--- a/opennms-provision/opennms-provision-persistence/src/main/java/org/opennms/netmgt/provision/persist/requisition/RequisitionNode.java
+++ b/opennms-provision/opennms-provision-persistence/src/main/java/org/opennms/netmgt/provision/persist/requisition/RequisitionNode.java
@@ -44,6 +44,8 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlTransient;
 import javax.xml.bind.annotation.XmlType;
 
+import org.opennms.netmgt.model.PrimaryType;
+
 
 /**
  * <p>RequisitionNode class.</p>
@@ -542,6 +544,10 @@ public class RequisitionNode {
         if (m_interfaces != null) {
             for (final RequisitionInterface iface : m_interfaces) {
                 iface.validate();
+            }
+            // there can be only one primary interface per node
+            if(m_interfaces.stream().filter(iface -> PrimaryType.PRIMARY == iface.m_snmpPrimary).count() > 1) {
+                throw new ValidationException("Node foreign ID (" + m_foreignId + ") contains multiple primary interfaces. Maximum one is allowed.");
             }
         }
         if (m_categories != null) {

--- a/opennms-provision/opennms-provisiond/src/test/java/org/opennms/netmgt/provision/service/InvalidRequisitionDataIT.java
+++ b/opennms-provision/opennms-provisiond/src/test/java/org/opennms/netmgt/provision/service/InvalidRequisitionDataIT.java
@@ -204,6 +204,25 @@ public class InvalidRequisitionDataIT extends ProvisioningITCase implements Init
         
     }
 
+    @Test
+    public void shouldDisallowMultiplePrimaryInterfaces() throws Exception {
+        assertEquals(0, m_nodeDao.countAll());
+
+        final Resource invalidRequisitionResource = getResource("classpath:/import_multiplePrimaryInterfaces.xml");
+
+        m_eventManager.getEventAnticipator().anticipateEvent(getStarted(invalidRequisitionResource));
+        m_eventManager.getEventAnticipator().anticipateEvent(getFailed(invalidRequisitionResource));
+
+        // This requisition has two "snmp-primary" interfaces which is not allowed.
+        m_provisioner.doImport(invalidRequisitionResource.getURL().toString(), Boolean.TRUE.toString());
+        waitForEverything();
+        m_eventManager.getEventAnticipator().verifyAnticipated();
+
+        // should fail to import the node since two "snmp-primary" interfaces are not allowed.
+        assertEquals(0, m_nodeDao.countAll());
+
+    }
+
     private Event getStarted(final Resource resource) {
         return new EventBuilder( EventConstants.IMPORT_STARTED_UEI, "Provisiond" )
         .addParam( EventConstants.PARM_IMPORT_RESOURCE, resource.toString() )

--- a/opennms-provision/opennms-provisiond/src/test/resources/import_multiplePrimaryInterfaces.xml
+++ b/opennms-provision/opennms-provisiond/src/test/resources/import_multiplePrimaryInterfaces.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model-import xmlns="http://xmlns.opennms.org/xsd/config/model-import" foreign-source="muppetworkshop" date-stamp="2005-12-27T09:12:54">
+	<node node-label="test" foreign-id="test">
+		<interface ip-addr="10.0.0.1" snmp-primary="P">
+			<monitored-service service-name="ICMP"/>
+		</interface>
+		<interface ip-addr="10.0.0.2" snmp-primary="P">
+			<monitored-service service-name="ICMP"/>
+			<monitored-service service-name="SNMP"/>
+		</interface>
+	</node>
+</model-import>

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/RequisitionRestServiceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/RequisitionRestServiceIT.java
@@ -179,10 +179,10 @@ public class RequisitionRestServiceIT extends AbstractSpringJerseyRestTestCase {
         assertFalse(xml, xml.contains("192.0.2.201"));
 
         // set attributes
-        sendPut(url, "status=3&descr=Total+Crap&snmp-primary=P", 202, "/nodes/4243/interfaces/192.0.2.204");
+        sendPut(url, "status=3&descr=Total+Crap&snmp-primary=N", 202, "/nodes/4243/interfaces/192.0.2.204");
         xml = sendRequest(GET, url, 200);
         assertTrue(xml, xml.contains("descr=\"Total Crap\""));
-        assertTrue(xml, xml.contains("snmp-primary=\"P\""));
+        assertTrue(xml, xml.contains("snmp-primary=\"N\""));
         assertTrue(xml, xml.contains("status=\"3\""));
  
         // delete interface

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/json/RequisitionRestServiceJsonIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/json/RequisitionRestServiceJsonIT.java
@@ -244,11 +244,11 @@ public class RequisitionRestServiceJsonIT extends AbstractSpringJerseyRestJsonTe
         assertEquals("VPN interface", intf.getString("descr"));
 
         // set attributes
-        sendPut(url, "status=3&descr=Total+Crap&snmp-primary=P", 202, "/nodes/4243/interfaces/192.0.2.204");
+        sendPut(url, "status=3&descr=Total+Crap&snmp-primary=N", 202, "/nodes/4243/interfaces/192.0.2.204");
         json = sendRequest(GET, url, 200);
         intf = new JSONObject(json);
         assertEquals("Total Crap", intf.getString("descr"));
-        assertEquals("P", intf.getString("snmp-primary"));
+        assertEquals("N", intf.getString("snmp-primary"));
         assertEquals(3, intf.getInt("status"));
 
         // delete interface


### PR DESCRIPTION
There should be only one primary interface allowed per node. But provisiond accepts node definitions with two primary tagged snmp interfaces.
This Pull Request addresses that problem and disallows the import of nodes with multiple primary interfaces (an error is thrown during validation phase).

This fix works also for the import via the Rest API: multiple primaries will lead to a HTTP 400 with a descriptive error message.

* JIRA (Issue Tracker): https://issues.opennms.org/browse/NMS-12605

