### PR TITLE
NMS-12552: Add unknown variants for BMP and BGP

### DIFF
--- a/features/telemetry/protocols/bmp/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/bmp/parser/proto/bgp/Header.java
+++ b/features/telemetry/protocols/bmp/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/bmp/parser/proto/bgp/Header.java
@@ -36,10 +36,12 @@ import java.util.Arrays;
 import java.util.Objects;
 import java.util.Optional;
 
+import org.opennms.netmgt.telemetry.protocols.bmp.parser.BmpParser;
 import org.opennms.netmgt.telemetry.protocols.bmp.parser.InvalidPacketException;
 import org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bgp.packets.KeepalivePacket;
 import org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bgp.packets.NotificationPacket;
 import org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bgp.packets.OpenPacket;
+import org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bgp.packets.UnknownPacket;
 import org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bgp.packets.UpdatePacket;
 import org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bmp.PeerFlags;
 import org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bmp.PeerInfo;
@@ -75,6 +77,7 @@ public class Header {
         UPDATE(UpdatePacket::new),
         NOTIFICATION(NotificationPacket::new),
         KEEPALIVE(KeepalivePacket::new),
+        UNKNOWN(UnknownPacket::new),
         ;
 
         private final Packet.Parser parser;
@@ -95,7 +98,8 @@ public class Header {
                 case 4:
                     return KEEPALIVE;
                 default:
-                    throw new InvalidPacketException(buffer, "Unknown type: %d", type);
+                    BmpParser.RATE_LIMITED_LOG.debug("Unknown BGP Packet Type: {}", type);
+                    return UNKNOWN;
             }
         }
 

--- a/features/telemetry/protocols/bmp/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/bmp/parser/proto/bgp/Packet.java
+++ b/features/telemetry/protocols/bmp/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/bmp/parser/proto/bgp/Packet.java
@@ -34,6 +34,7 @@ import org.opennms.netmgt.telemetry.protocols.bmp.parser.InvalidPacketException;
 import org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bgp.packets.KeepalivePacket;
 import org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bgp.packets.NotificationPacket;
 import org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bgp.packets.OpenPacket;
+import org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bgp.packets.UnknownPacket;
 import org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bgp.packets.UpdatePacket;
 import org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bmp.PeerFlags;
 import org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bmp.PeerInfo;
@@ -52,6 +53,7 @@ public interface Packet {
         void visit(final UpdatePacket packet);
         void visit(final NotificationPacket packet);
         void visit(final KeepalivePacket packet);
+        void visit(final UnknownPacket packet);
     }
 
     static Packet parse(final ByteBuf buffer, final PeerFlags flags, final Optional<PeerInfo> peerInfo) throws InvalidPacketException {

--- a/features/telemetry/protocols/bmp/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/bmp/parser/proto/bgp/packets/UnknownPacket.java
+++ b/features/telemetry/protocols/bmp/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/bmp/parser/proto/bgp/packets/UnknownPacket.java
@@ -26,11 +26,13 @@
  *     http://www.opennms.com/
  *******************************************************************************/
 
-package org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bmp.packets.down;
+package org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bgp.packets;
 
+import java.util.Objects;
 import java.util.Optional;
 
-import org.opennms.netmgt.telemetry.protocols.bmp.parser.InvalidPacketException;
+import org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bgp.Header;
+import org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bgp.Packet;
 import org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bmp.PeerFlags;
 import org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bmp.PeerInfo;
 
@@ -38,8 +40,11 @@ import com.google.common.base.MoreObjects;
 
 import io.netty.buffer.ByteBuf;
 
-public class Unknown implements Reason {
-    public Unknown(final ByteBuf buffer, final PeerFlags flags, final Optional<PeerInfo> peerInfo) throws InvalidPacketException {
+public class UnknownPacket implements Packet {
+    public final Header header;
+
+    public UnknownPacket(final Header header, final ByteBuf buffer, final PeerFlags flags, final Optional<PeerInfo> peerInfo) {
+        this.header = Objects.requireNonNull(header);
     }
 
     @Override
@@ -50,6 +55,7 @@ public class Unknown implements Reason {
     @Override
     public String toString() {
         return MoreObjects.toStringHelper(this)
+                .add("header", this.header)
                 .toString();
     }
 }

--- a/features/telemetry/protocols/bmp/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/bmp/parser/proto/bgp/packets/pathattr/MultiprotocolReachableNlri.java
+++ b/features/telemetry/protocols/bmp/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/bmp/parser/proto/bgp/packets/pathattr/MultiprotocolReachableNlri.java
@@ -116,7 +116,7 @@ public class MultiprotocolReachableNlri implements Attribute {
                 break;
             case BGP_AFI_BGPLS:
                 nextHop = InetAddressUtils.getInetAddress(nextHopBytes);
-                LOG.info("MP_REACH AFI=bgp-ls SAFI=%d is not implemented yet, skipping for now", safi);
+                LOG.info("MP_REACH AFI=bgp-ls SAFI={} is not implemented yet, skipping for now", safi);
                 break;
             case BGP_AFI_L2VPN:
                 if (nextHopBytes.length > 16) {
@@ -124,10 +124,10 @@ public class MultiprotocolReachableNlri implements Attribute {
                 } else {
                     nextHop = InetAddressUtils.getInetAddress(nextHopBytes);
                 }
-                LOG.info("EVPN AFI=bgp_afi_l2vpn SAFI=%d is not implemented yet, skipping", safi);
+                LOG.info("EVPN AFI=bgp_afi_l2vpn SAFI={} is not implemented yet, skipping", safi);
                 break;
             default:
-                LOG.info("MP_REACH AFI=%d is not implemented yet, skipping", afi);
+                LOG.info("MP_REACH AFI={} is not implemented yet, skipping", afi);
                 break;
         }
     }
@@ -165,12 +165,12 @@ public class MultiprotocolReachableNlri implements Attribute {
                 this.vpnAdvertised = parseNlriData_LabelIPv4IPv6(isIPv4, buffer, peerInfo, true);
                 break;
             default:
-                LOG.info("MP_REACH AFI=ipv4/ipv6 (%d) SAFI=%d is not implemented yet, skipping for now", isIPv4, this.safi);
+                LOG.info("MP_REACH AFI=ipv4/ipv6 ({}) SAFI={} is not implemented yet, skipping for now", isIPv4, this.safi);
         }
     }
 
     static List<UpdatePacket.Prefix> parseNlriData_IPv4IPv6(boolean isIPv4, final ByteBuf buffer, final Optional<PeerInfo> peerInfo) {
-        final boolean addPathCapabilityEnabled = peerInfo.isPresent() ? peerInfo.get().isAddPathEnabled(isIPv4 ? BGP_AFI_IPV4 : BGP_AFI_IPV6, BGP_SAFI_UNICAST) : false;
+        final boolean addPathCapabilityEnabled = peerInfo.map(info -> info.isAddPathEnabled(isIPv4 ? BGP_AFI_IPV4 : BGP_AFI_IPV6, BGP_SAFI_UNICAST)).orElse(false);
 
         return BufferUtils.repeatRemaining(buffer, b -> {
             final UpdatePacket.Prefix tuple = new UpdatePacket.Prefix();
@@ -190,7 +190,7 @@ public class MultiprotocolReachableNlri implements Attribute {
     }
 
     static List<UpdatePacket.Prefix> parseNlriData_LabelIPv4IPv6(boolean isIPv4, final ByteBuf buffer, final Optional<PeerInfo> peerInfo, boolean isVPN) throws Exception {
-        final boolean addPathCapabilityEnabled = peerInfo.isPresent() ? peerInfo.get().isAddPathEnabled(isIPv4 ? BGP_AFI_IPV4 : BGP_AFI_IPV6, isVPN ? BGP_SAFI_MPLS : BGP_SAFI_NLRI_LABEL) : false;
+        final boolean addPathCapabilityEnabled = peerInfo.map(info -> info.isAddPathEnabled(isIPv4 ? BGP_AFI_IPV4 : BGP_AFI_IPV6, isVPN ? BGP_SAFI_MPLS : BGP_SAFI_NLRI_LABEL)).orElse(false);
         return BufferUtils.repeatRemaining(buffer, b -> {
             final UpdatePacket.Prefix tuple = new UpdatePacket.Prefix();
 

--- a/features/telemetry/protocols/bmp/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/bmp/parser/proto/bgp/packets/pathattr/MultiprotocolUnreachableNlri.java
+++ b/features/telemetry/protocols/bmp/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/bmp/parser/proto/bgp/packets/pathattr/MultiprotocolUnreachableNlri.java
@@ -73,13 +73,13 @@ public class MultiprotocolUnreachableNlri implements Attribute {
                 parseAfi_IPv4IPv6(true, buffer, peerInfo);
                 break;
             case MultiprotocolReachableNlri.BGP_AFI_BGPLS:
-                LOG.info("MP_UNREACH AFI=bgp-ls SAFI=%d is not implemented yet, skipping for now", safi);
+                LOG.info("MP_UNREACH AFI=bgp-ls SAFI={} is not implemented yet, skipping for now", safi);
                 break;
             case MultiprotocolReachableNlri.BGP_AFI_L2VPN:
-                LOG.info("EVPN AFI=bgp_afi_l2vpn SAFI=%d is not implemented yet, skipping", safi);
+                LOG.info("EVPN AFI=bgp_afi_l2vpn SAFI={} is not implemented yet, skipping", safi);
                 break;
             default:
-                LOG.info("MP_UNREACH AFI=%d is not implemented yet, skipping", afi);
+                LOG.info("MP_UNREACH AFI={} is not implemented yet, skipping", afi);
                 break;
         }
     }
@@ -96,7 +96,7 @@ public class MultiprotocolUnreachableNlri implements Attribute {
                 this.vpnWithdrawn = MultiprotocolReachableNlri.parseNlriData_LabelIPv4IPv6(isIPv4, buffer, peerInfo, true);
                 break;
             default:
-                LOG.info("MP_UNREACH AFI=ipv4/ipv6 (%d) SAFI=%d is not implemented yet, skipping for now", isIPv4, this.safi);
+                LOG.info("MP_UNREACH AFI=ipv4/ipv6 ({}) SAFI={} is not implemented yet, skipping for now", isIPv4, this.safi);
         }
     }
 

--- a/features/telemetry/protocols/bmp/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/bmp/parser/proto/bmp/Header.java
+++ b/features/telemetry/protocols/bmp/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/bmp/parser/proto/bmp/Header.java
@@ -34,6 +34,7 @@ import static org.opennms.netmgt.telemetry.listeners.utils.BufferUtils.uint8;
 import java.util.Objects;
 import java.util.function.Function;
 
+import org.opennms.netmgt.telemetry.protocols.bmp.parser.BmpParser;
 import org.opennms.netmgt.telemetry.protocols.bmp.parser.InvalidPacketException;
 import org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bmp.packets.InitiationPacket;
 import org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bmp.packets.PeerDownPacket;
@@ -42,6 +43,7 @@ import org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bmp.packets.Route
 import org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bmp.packets.RouteMonitoringPacket;
 import org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bmp.packets.StatisticsReportPacket;
 import org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bmp.packets.TerminationPacket;
+import org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bmp.packets.UnknownPacket;
 
 import com.google.common.base.MoreObjects;
 
@@ -86,6 +88,7 @@ public class Header {
         INITIATION_MESSAGE(InitiationPacket::new),
         TERMINATION_MESSAGE(TerminationPacket::new),
         ROUTE_MIRRORING_MESSAGE(RouteMirroringPacket::new),
+        UNKNOWN(UnknownPacket::new),
         ;
 
         private final Packet.Parser parser;
@@ -116,7 +119,8 @@ public class Header {
                 case 6:
                     return ROUTE_MIRRORING_MESSAGE;
                 default:
-                    throw new InvalidPacketException(buffer, "Unknown type: %d", type);
+                    BmpParser.RATE_LIMITED_LOG.debug("Unknown BMP Packet Type: {}", type);
+                    return UNKNOWN;
             }
         }
 

--- a/features/telemetry/protocols/bmp/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/bmp/parser/proto/bmp/InformationElement.java
+++ b/features/telemetry/protocols/bmp/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/bmp/parser/proto/bmp/InformationElement.java
@@ -85,12 +85,10 @@ public class InformationElement extends TLV<InformationElement.Type, String, Voi
             @Override
             public String parse(final ByteBuf buffer, final Void parameter, final Optional<PeerInfo> peerInfo) {
                 return InetAddressUtils.toIpAddrString(bytes(buffer, buffer.readableBytes()));
-	    }
-	},
+	        }
+	    },
 
-        UNKNOWN
-
-        {
+        UNKNOWN {
             @Override
             public String parse(final ByteBuf buffer, final Void parameter, final Optional<PeerInfo> peerInfo) {
                 return "Unknown";

--- a/features/telemetry/protocols/bmp/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/bmp/parser/proto/bmp/Packet.java
+++ b/features/telemetry/protocols/bmp/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/bmp/parser/proto/bmp/Packet.java
@@ -39,6 +39,7 @@ import org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bmp.packets.Route
 import org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bmp.packets.RouteMonitoringPacket;
 import org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bmp.packets.StatisticsReportPacket;
 import org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bmp.packets.TerminationPacket;
+import org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bmp.packets.UnknownPacket;
 
 import io.netty.buffer.ByteBuf;
 
@@ -58,15 +59,17 @@ public interface Packet {
         void visit(final StatisticsReportPacket packet);
         void visit(final RouteMonitoringPacket packet);
         void visit(final RouteMirroringPacket packet);
+        void visit(final UnknownPacket packet);
 
         class Adapter implements Visitor {
-            public void visit(RouteMonitoringPacket packet) {}
-            public void visit(StatisticsReportPacket packet) {}
-            public void visit(PeerDownPacket packet) {}
-            public void visit(PeerUpPacket packet) {}
-            public void visit(InitiationPacket packet) {}
-            public void visit(TerminationPacket packet) {}
-            public void visit(RouteMirroringPacket packet) {}
+            public void visit(final RouteMonitoringPacket packet) {}
+            public void visit(final StatisticsReportPacket packet) {}
+            public void visit(final PeerDownPacket packet) {}
+            public void visit(final PeerUpPacket packet) {}
+            public void visit(final InitiationPacket packet) {}
+            public void visit(final TerminationPacket packet) {}
+            public void visit(final RouteMirroringPacket packet) {}
+            public void visit(final UnknownPacket packet) {}
         }
     }
 
@@ -78,6 +81,7 @@ public interface Packet {
         R map(final StatisticsReportPacket packet);
         R map(final RouteMonitoringPacket packet);
         R map(final RouteMirroringPacket packet);
+        R map(final UnknownPacket packet);
 
         class Adapter<R> implements Mapper<R> {
             private final R defaultValue;
@@ -93,6 +97,7 @@ public interface Packet {
             public R map(final StatisticsReportPacket packet) { return this.defaultValue; }
             public R map(final RouteMonitoringPacket packet) { return this.defaultValue; }
             public R map(final RouteMirroringPacket packet) { return this.defaultValue; }
+            public R map(final UnknownPacket packet) { return this.defaultValue; }
         }
     }
 
@@ -132,6 +137,11 @@ public interface Packet {
             @Override
             public Optional<PeerHeader> map(final RouteMirroringPacket packet) {
                 return Optional.of(packet.peerHeader);
+            }
+
+            @Override
+            public Optional<PeerHeader> map(final UnknownPacket packet) {
+                return Optional.empty();
             }
         });
     }

--- a/features/telemetry/protocols/bmp/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/bmp/parser/proto/bmp/packets/PeerDownPacket.java
+++ b/features/telemetry/protocols/bmp/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/bmp/parser/proto/bmp/packets/PeerDownPacket.java
@@ -95,7 +95,7 @@ public class PeerDownPacket implements Packet {
         UNKNOWN {
             @Override
             public Reason parse(final ByteBuf buffer, final PeerFlags flags, final Optional<PeerInfo> peerInfo) throws InvalidPacketException {
-                return new Unknown(buffer, flags);
+                return new Unknown(buffer, flags, peerInfo);
             }
         };
 

--- a/features/telemetry/protocols/bmp/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/bmp/parser/proto/bmp/packets/PeerUpPacket.java
+++ b/features/telemetry/protocols/bmp/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/bmp/parser/proto/bmp/packets/PeerUpPacket.java
@@ -33,6 +33,7 @@ import static org.opennms.netmgt.telemetry.listeners.utils.BufferUtils.uint16;
 
 import java.net.InetAddress;
 import java.util.Objects;
+import java.util.Optional;
 
 import org.opennms.netmgt.telemetry.protocols.bmp.parser.InvalidPacketException;
 import org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bgp.packets.OpenPacket;
@@ -55,8 +56,8 @@ public class PeerUpPacket implements Packet {
     public final int localPort;  // uint16
     public final int remotePort; // uint16
 
-    public final OpenPacket sendOpenMessage;
-    public final OpenPacket recvOpenMessage;
+    public final Optional<OpenPacket> sendOpenMessage;
+    public final Optional<OpenPacket> recvOpenMessage;
 
     public final TLV.List<InformationElement, InformationElement.Type, String> information;
 

--- a/features/telemetry/protocols/bmp/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/bmp/parser/proto/bmp/packets/RouteMirroringPacket.java
+++ b/features/telemetry/protocols/bmp/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/bmp/parser/proto/bmp/packets/RouteMirroringPacket.java
@@ -45,6 +45,7 @@ import org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bmp.TLV;
 import org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bmp.packets.mirroring.BgpMessage;
 import org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bmp.packets.mirroring.Information;
 import org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bmp.packets.mirroring.Mirroring;
+import org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bmp.packets.mirroring.Unknown;
 
 import com.google.common.base.MoreObjects;
 
@@ -94,8 +95,8 @@ public class RouteMirroringPacket implements Packet {
             },
             UNKNOWN{
                 @Override
-                public Mirroring parse(final ByteBuf buffer, final PeerFlags parameter, final Optional<PeerInfo> peerInfo) throws InvalidPacketException {
-                    return null;
+                public Mirroring parse(final ByteBuf buffer, final PeerFlags flags, final Optional<PeerInfo> peerInfo) throws InvalidPacketException {
+                    return new Unknown(buffer, flags, peerInfo);
                 }
             };
 

--- a/features/telemetry/protocols/bmp/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/bmp/parser/proto/bmp/packets/RouteMonitoringPacket.java
+++ b/features/telemetry/protocols/bmp/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/bmp/parser/proto/bmp/packets/RouteMonitoringPacket.java
@@ -29,6 +29,7 @@
 package org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bmp.packets;
 
 import java.util.Objects;
+import java.util.Optional;
 
 import org.opennms.netmgt.telemetry.protocols.bmp.parser.InvalidPacketException;
 import org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bgp.packets.UpdatePacket;
@@ -45,7 +46,7 @@ public class RouteMonitoringPacket implements Packet {
     public final Header header;
     public final PeerHeader peerHeader;
 
-    public final UpdatePacket updateMessage;
+    public final Optional<UpdatePacket> updateMessage;
 
     public RouteMonitoringPacket(final Header header, final ByteBuf buffer, final PeerAccessor peerAccessor) throws InvalidPacketException {
         this.header = Objects.requireNonNull(header);

--- a/features/telemetry/protocols/bmp/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/bmp/parser/proto/bmp/packets/StatisticsReportPacket.java
+++ b/features/telemetry/protocols/bmp/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/bmp/parser/proto/bmp/packets/StatisticsReportPacket.java
@@ -152,7 +152,7 @@ public class StatisticsReportPacket implements Packet {
             }
 
             @Override
-            public Metric parse(final ByteBuf buffer, final Void parameter, final Optional<PeerInfo> peerInfo) throws InvalidPacketException {
+            public Metric parse(final ByteBuf buffer, final Void parameter, final Optional<PeerInfo> peerInfo) {
                 return this.parser.apply(buffer);
             }
         }

--- a/features/telemetry/protocols/bmp/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/bmp/parser/proto/bmp/packets/UnknownPacket.java
+++ b/features/telemetry/protocols/bmp/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/bmp/parser/proto/bmp/packets/UnknownPacket.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2019 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ * Copyright (C) 2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -26,20 +26,25 @@
  *     http://www.opennms.com/
  *******************************************************************************/
 
-package org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bmp.packets.down;
+package org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bmp.packets;
 
-import java.util.Optional;
+import java.util.Objects;
 
 import org.opennms.netmgt.telemetry.protocols.bmp.parser.InvalidPacketException;
-import org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bmp.PeerFlags;
-import org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bmp.PeerInfo;
+import org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bmp.Header;
+import org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bmp.Packet;
+import org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bmp.PeerAccessor;
+import org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bmp.packets.stats.Metric;
 
 import com.google.common.base.MoreObjects;
 
 import io.netty.buffer.ByteBuf;
 
-public class Unknown implements Reason {
-    public Unknown(final ByteBuf buffer, final PeerFlags flags, final Optional<PeerInfo> peerInfo) throws InvalidPacketException {
+public class UnknownPacket implements Packet {
+    public final Header header;
+
+    public UnknownPacket(final Header header, final ByteBuf buffer, final PeerAccessor peerAccessor) throws InvalidPacketException {
+        this.header = Objects.requireNonNull(header);
     }
 
     @Override
@@ -48,8 +53,14 @@ public class Unknown implements Reason {
     }
 
     @Override
+    public <R> R map(final Mapper<R> mapper) {
+        return mapper.map(this);
+    }
+
+    @Override
     public String toString() {
         return MoreObjects.toStringHelper(this)
-                .toString();
+                          .add("header", this.header)
+                          .toString();
     }
 }

--- a/features/telemetry/protocols/bmp/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/bmp/parser/proto/bmp/packets/down/LocalBgpNotification.java
+++ b/features/telemetry/protocols/bmp/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/bmp/parser/proto/bmp/packets/down/LocalBgpNotification.java
@@ -40,7 +40,7 @@ import com.google.common.base.MoreObjects;
 import io.netty.buffer.ByteBuf;
 
 public class LocalBgpNotification implements Reason {
-    public final NotificationPacket notification;
+    public final Optional<NotificationPacket> notification;
 
     public LocalBgpNotification(final ByteBuf buffer, final PeerFlags flags, final Optional<PeerInfo> peerInfo) throws InvalidPacketException {
         this.notification = NotificationPacket.parse(buffer, flags, peerInfo);

--- a/features/telemetry/protocols/bmp/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/bmp/parser/proto/bmp/packets/down/RemoteBgpNotification.java
+++ b/features/telemetry/protocols/bmp/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/bmp/parser/proto/bmp/packets/down/RemoteBgpNotification.java
@@ -40,7 +40,7 @@ import com.google.common.base.MoreObjects;
 import io.netty.buffer.ByteBuf;
 
 public class RemoteBgpNotification implements Reason {
-    public final NotificationPacket notification;
+    public final Optional<NotificationPacket> notification;
 
     public RemoteBgpNotification(final ByteBuf buffer, final PeerFlags flags, final Optional<PeerInfo> peerInfo) throws InvalidPacketException {
         this.notification = NotificationPacket.parse(buffer, flags, peerInfo);

--- a/features/telemetry/protocols/bmp/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/bmp/parser/proto/bmp/packets/mirroring/Unknown.java
+++ b/features/telemetry/protocols/bmp/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/bmp/parser/proto/bmp/packets/mirroring/Unknown.java
@@ -28,15 +28,16 @@
 
 package org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bmp.packets.mirroring;
 
-import static org.opennms.netmgt.telemetry.listeners.utils.BufferUtils.uint16;
+import java.util.Optional;
 
 import org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bmp.PeerFlags;
+import org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bmp.PeerInfo;
 
 import io.netty.buffer.ByteBuf;
 
 public class Unknown implements Mirroring {
 
-    public Unknown(final ByteBuf buffer, final PeerFlags flags) {
+    public Unknown(final ByteBuf buffer, final PeerFlags flags, final Optional<PeerInfo> peerInfo) {
     }
 
     @Override

--- a/features/telemetry/protocols/bmp/parser/src/test/java/org/opennms/netmgt/telemetry/protocols/bmp/parser/BlackboxTest.java
+++ b/features/telemetry/protocols/bmp/parser/src/test/java/org/opennms/netmgt/telemetry/protocols/bmp/parser/BlackboxTest.java
@@ -84,6 +84,7 @@ import org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bmp.packets.Route
 import org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bmp.packets.RouteMonitoringPacket;
 import org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bmp.packets.StatisticsReportPacket;
 import org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bmp.packets.TerminationPacket;
+import org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bmp.packets.UnknownPacket;
 import org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bmp.packets.down.LocalBgpNotification;
 import org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bmp.packets.down.LocalNoNotification;
 import org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bmp.packets.down.Reason;
@@ -393,8 +394,8 @@ public class BlackboxTest implements Packet.Visitor {
 
             @Override
             public void visit(RemoteBgpNotification remoteNotification) {
-                assertThat(remoteNotification.notification.header.length, is(21));
-                assertThat(remoteNotification.notification.header.type, is(org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bgp.Header.Type.NOTIFICATION));
+                assertThat(remoteNotification.notification.get().header.length, is(21));
+                assertThat(remoteNotification.notification.get().header.type, is(org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bgp.Header.Type.NOTIFICATION));
             }
 
             @Override
@@ -423,18 +424,18 @@ public class BlackboxTest implements Packet.Visitor {
         assertThat(packet.localAddress, is(InetAddressUtils.addr("10.0.255.7")));
         assertThat(packet.localPort, is(179));
         assertThat(packet.remotePort, is(49103));
-        assertThat(packet.sendOpenMessage.header.length, is(45));
-        assertThat(packet.sendOpenMessage.header.type, is(org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bgp.Header.Type.OPEN));
-        assertThat(packet.sendOpenMessage.version, is(4));
-        assertThat(packet.sendOpenMessage.as, is(65002));
-        assertThat(packet.sendOpenMessage.id, is(InetAddressUtils.addr("192.168.10.7")));
-        assertThat(packet.sendOpenMessage.holdTime, is(90));
-        assertThat(packet.recvOpenMessage.header.length, is(45));
-        assertThat(packet.recvOpenMessage.header.type, is(org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bgp.Header.Type.OPEN));
-        assertThat(packet.recvOpenMessage.version, is(4));
-        assertThat(packet.recvOpenMessage.as, is(64512));
-        assertThat(packet.recvOpenMessage.id, is(InetAddressUtils.addr("192.168.10.5")));
-        assertThat(packet.recvOpenMessage.holdTime, is(90));
+        assertThat(packet.sendOpenMessage.get().header.length, is(45));
+        assertThat(packet.sendOpenMessage.get().header.type, is(org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bgp.Header.Type.OPEN));
+        assertThat(packet.sendOpenMessage.get().version, is(4));
+        assertThat(packet.sendOpenMessage.get().as, is(65002));
+        assertThat(packet.sendOpenMessage.get().id, is(InetAddressUtils.addr("192.168.10.7")));
+        assertThat(packet.sendOpenMessage.get().holdTime, is(90));
+        assertThat(packet.recvOpenMessage.get().header.length, is(45));
+        assertThat(packet.recvOpenMessage.get().header.type, is(org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bgp.Header.Type.OPEN));
+        assertThat(packet.recvOpenMessage.get().version, is(4));
+        assertThat(packet.recvOpenMessage.get().as, is(64512));
+        assertThat(packet.recvOpenMessage.get().id, is(InetAddressUtils.addr("192.168.10.5")));
+        assertThat(packet.recvOpenMessage.get().holdTime, is(90));
         assertThat(packet.information.size(), is(0));
     }
 
@@ -450,42 +451,42 @@ public class BlackboxTest implements Packet.Visitor {
         assertThat(packet.peerHeader.id, is(InetAddressUtils.addr("192.168.10.5")));
         assertThat(packet.peerHeader.timestamp, either(is(Instant.ofEpochSecond(1574257996L))).or(is(Instant.ofEpochSecond(1574257061L))));
 
-        assertThat(packet.updateMessage.header.length, either(is(27)).or(is(47)));
-        assertThat(packet.updateMessage.header.type, is(org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bgp.Header.Type.UPDATE));
+        assertThat(packet.updateMessage.get().header.length, either(is(27)).or(is(47)));
+        assertThat(packet.updateMessage.get().header.type, is(org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bgp.Header.Type.UPDATE));
 
-        if (!packet.updateMessage.withdrawRoutes.isEmpty()) {
-            assertThat(packet.updateMessage.reachableRoutes, is(empty()));
-            assertThat(packet.updateMessage.withdrawRoutes.get(0).length, is(24));
-            assertThat(packet.updateMessage.withdrawRoutes.get(0).prefix, is(InetAddressUtils.addr("192.168.254.0")));
+        if (!packet.updateMessage.get().withdrawRoutes.isEmpty()) {
+            assertThat(packet.updateMessage.get().reachableRoutes, is(empty()));
+            assertThat(packet.updateMessage.get().withdrawRoutes.get(0).length, is(24));
+            assertThat(packet.updateMessage.get().withdrawRoutes.get(0).prefix, is(InetAddressUtils.addr("192.168.254.0")));
         } else {
-            assertThat(packet.updateMessage.withdrawRoutes, is(empty()));
-            assertThat(packet.updateMessage.reachableRoutes.get(0).length, is(24));
-            assertThat(packet.updateMessage.reachableRoutes.get(0).prefix, is(InetAddressUtils.addr("192.168.255.0")));
+            assertThat(packet.updateMessage.get().withdrawRoutes, is(empty()));
+            assertThat(packet.updateMessage.get().reachableRoutes.get(0).length, is(24));
+            assertThat(packet.updateMessage.get().reachableRoutes.get(0).prefix, is(InetAddressUtils.addr("192.168.255.0")));
         }
 
-        assertThat(packet.updateMessage.pathAttributes.size(), either(is(0)).or(is(3)));
+        assertThat(packet.updateMessage.get().pathAttributes.size(), either(is(0)).or(is(3)));
 
-        if (packet.updateMessage.pathAttributes.size() > 0) {
-            assertThat(packet.updateMessage.pathAttributes.get(0).optional, is(false));
-            assertThat(packet.updateMessage.pathAttributes.get(0).transitive, is(true));
-            assertThat(packet.updateMessage.pathAttributes.get(0).partial, is(false));
-            assertThat(packet.updateMessage.pathAttributes.get(0).extended, is(false));
-            assertThat(packet.updateMessage.pathAttributes.get(0).type, is(UpdatePacket.PathAttribute.Type.ORIGIN));
-            assertThat(packet.updateMessage.pathAttributes.get(0).length, is(1));
-            packet.updateMessage.pathAttributes.get(0).attribute.accept(new AttributeVisitorAdapter() {
+        if (packet.updateMessage.get().pathAttributes.size() > 0) {
+            assertThat(packet.updateMessage.get().pathAttributes.get(0).optional, is(false));
+            assertThat(packet.updateMessage.get().pathAttributes.get(0).transitive, is(true));
+            assertThat(packet.updateMessage.get().pathAttributes.get(0).partial, is(false));
+            assertThat(packet.updateMessage.get().pathAttributes.get(0).extended, is(false));
+            assertThat(packet.updateMessage.get().pathAttributes.get(0).type, is(UpdatePacket.PathAttribute.Type.ORIGIN));
+            assertThat(packet.updateMessage.get().pathAttributes.get(0).length, is(1));
+            packet.updateMessage.get().pathAttributes.get(0).attribute.accept(new AttributeVisitorAdapter() {
                 @Override
                 public void visit(Origin origin) {
                     assertThat(origin.value, is(Origin.Value.INCOMPLETE));
                 }
             });
 
-            assertThat(packet.updateMessage.pathAttributes.get(1).optional, is(false));
-            assertThat(packet.updateMessage.pathAttributes.get(1).transitive, is(true));
-            assertThat(packet.updateMessage.pathAttributes.get(1).partial, is(false));
-            assertThat(packet.updateMessage.pathAttributes.get(1).extended, is(false));
-            assertThat(packet.updateMessage.pathAttributes.get(1).type, is(UpdatePacket.PathAttribute.Type.AS_PATH));
-            assertThat(packet.updateMessage.pathAttributes.get(1).length, is(6));
-            packet.updateMessage.pathAttributes.get(1).attribute.accept(new AttributeVisitorAdapter() {
+            assertThat(packet.updateMessage.get().pathAttributes.get(1).optional, is(false));
+            assertThat(packet.updateMessage.get().pathAttributes.get(1).transitive, is(true));
+            assertThat(packet.updateMessage.get().pathAttributes.get(1).partial, is(false));
+            assertThat(packet.updateMessage.get().pathAttributes.get(1).extended, is(false));
+            assertThat(packet.updateMessage.get().pathAttributes.get(1).type, is(UpdatePacket.PathAttribute.Type.AS_PATH));
+            assertThat(packet.updateMessage.get().pathAttributes.get(1).length, is(6));
+            packet.updateMessage.get().pathAttributes.get(1).attribute.accept(new AttributeVisitorAdapter() {
                 @Override
                 public void visit(AsPath asPath) {
                     assertThat(asPath.segments.size(), is(1));
@@ -494,13 +495,13 @@ public class BlackboxTest implements Packet.Visitor {
                 }
             });
 
-            assertThat(packet.updateMessage.pathAttributes.get(2).optional, is(false));
-            assertThat(packet.updateMessage.pathAttributes.get(2).transitive, is(true));
-            assertThat(packet.updateMessage.pathAttributes.get(2).partial, is(false));
-            assertThat(packet.updateMessage.pathAttributes.get(2).extended, is(false));
-            assertThat(packet.updateMessage.pathAttributes.get(2).type, is(UpdatePacket.PathAttribute.Type.NEXT_HOP));
-            assertThat(packet.updateMessage.pathAttributes.get(2).length, is(4));
-            packet.updateMessage.pathAttributes.get(2).attribute.accept(new AttributeVisitorAdapter() {
+            assertThat(packet.updateMessage.get().pathAttributes.get(2).optional, is(false));
+            assertThat(packet.updateMessage.get().pathAttributes.get(2).transitive, is(true));
+            assertThat(packet.updateMessage.get().pathAttributes.get(2).partial, is(false));
+            assertThat(packet.updateMessage.get().pathAttributes.get(2).extended, is(false));
+            assertThat(packet.updateMessage.get().pathAttributes.get(2).type, is(UpdatePacket.PathAttribute.Type.NEXT_HOP));
+            assertThat(packet.updateMessage.get().pathAttributes.get(2).length, is(4));
+            packet.updateMessage.get().pathAttributes.get(2).attribute.accept(new AttributeVisitorAdapter() {
                 @Override
                 public void visit(NextHop nextHop) {
                     assertThat(nextHop.address, is(InetAddressUtils.addr("10.0.255.5")));
@@ -564,5 +565,10 @@ public class BlackboxTest implements Packet.Visitor {
     @Override
     public void visit(RouteMirroringPacket packet) {
         fail("Wrong Packet RouteMirroringPacket");
+    }
+
+    @Override
+    public void visit(final UnknownPacket packet) {
+        fail("Wrong Packet UnknownPacket");
     }
 }

--- a/features/telemetry/protocols/bmp/parser/src/test/java/org/opennms/netmgt/telemetry/protocols/bmp/parser/ParserTest.java
+++ b/features/telemetry/protocols/bmp/parser/src/test/java/org/opennms/netmgt/telemetry/protocols/bmp/parser/ParserTest.java
@@ -49,11 +49,12 @@ import org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bmp.packets.Route
 import org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bmp.packets.RouteMonitoringPacket;
 import org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bmp.packets.StatisticsReportPacket;
 import org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bmp.packets.TerminationPacket;
+import org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bmp.packets.UnknownPacket;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 
-public class ParserTest implements Packet.Visitor {
+public class ParserTest {
     private final static Path FILE_NMS_12643 = Paths.get("src/test/resources/NMS-12643.raw");
     private final static Path FILE_NMS_12649 = Paths.get("src/test/resources/NMS-12649.raw");
 
@@ -67,11 +68,10 @@ public class ParserTest implements Packet.Visitor {
                 final Header header = new Header(slice(buf, Header.SIZE));
                 final Packet packet = header.parsePayload(slice(buf, header.length - Header.SIZE), new PeerAccessor() {
                     @Override
-                    public Optional<PeerInfo> getPeerInfo(PeerHeader peerHeader) {
+                    public Optional<PeerInfo> getPeerInfo(final PeerHeader peerHeader) {
                         return Optional.empty();
                     }
                 });
-                packet.accept(this);
             }
         }
     }
@@ -84,33 +84,5 @@ public class ParserTest implements Packet.Visitor {
     @Test
     public void testNMS12649() throws Exception {
         checkFile(FILE_NMS_12649);
-    }
-
-    @Override
-    public void visit(InitiationPacket packet) {
-    }
-
-    @Override
-    public void visit(TerminationPacket packet) {
-    }
-
-    @Override
-    public void visit(PeerUpPacket packet) {
-    }
-
-    @Override
-    public void visit(PeerDownPacket packet) {
-    }
-
-    @Override
-    public void visit(StatisticsReportPacket packet) {
-    }
-
-    @Override
-    public void visit(RouteMonitoringPacket packet) {
-    }
-
-    @Override
-    public void visit(RouteMirroringPacket packet) {
     }
 }


### PR DESCRIPTION
This makes the parser more error resilient.

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-12552

