### PR TITLE
NMS-12673: Don't trust serialized object messages.

### DIFF
--- a/core/daemon/src/main/resources/META-INF/opennms/applicationContext-daemon.xml
+++ b/core/daemon/src/main/resources/META-INF/opennms/applicationContext-daemon.xml
@@ -36,8 +36,6 @@
     <property name="brokerURL" value="#{T(java.lang.System).getProperty('org.opennms.activemq.broker.url', 'vm://localhost?create=false&amp;jms.useAsyncSend=true')}" />
     <property name="userName" value="#{T(java.lang.System).getProperty('org.opennms.activemq.broker.username', '')}" />
     <property name="password" value="#{T(java.lang.System).getProperty('org.opennms.activemq.broker.password', '')}" />
-    <!-- TODO: Remove this parameter after we stop using serialized object messages -->
-    <property name="trustAllPackages" value="true"/>
   </bean>
 
   <bean id="pooledConnectionFactory" class="org.opennms.features.activemq.PooledConnectionFactory"


### PR DESCRIPTION
JIRA: https://issues.opennms.org/browse/NMS-12673

We no longer use Java serialization for messages.