### PR TITLE
NMS-9581: JDBCQueryMonitor documentation

### DIFF
--- a/opennms-doc/guide-admin/src/asciidoc/text/service-assurance/monitors/JDBCQueryMonitor.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/service-assurance/monitors/JDBCQueryMonitor.adoc
@@ -22,19 +22,19 @@ This monitor implements <<ga-service-assurance-monitors-placeholder-substitution
 .Monitor specific parameters for the JDBCQueryMonitor
 [options="header, autowidth"]
 |===
-| Parameter  | Description                                                        | Required | Default value | Placeholder substitution
-| `driver`   | JDBC driver class to use                                           | required | `org.postgresql.Driver` | No
-| `url`      | JDBC URL to connect to.                                            | required | `jdbc:postgresql://:OPENNMS_JDBC_HOSTNAME/opennms` | Yes
-| `user`     | Database user                                                      | required | `postgres` | Yes
-| `password` | Database password                                                  | required | `empty string` | Yes
-| `query`    | The SQL query to run                                               | required | `-` | No
-| `action`   | What evaluation action to perform                                  | required | `row_count` | No
-| `column`   | The result column to evaluate against                              | required | `-` | No
-| `operator` | Operator to use for the evaluation                                 | required | `>=` | No
-| `operand`  | The operand to compare against the SQL query result                | required | depends on the action | No
+| Parameter  | Description                                                            | Required | Default value | Placeholder substitution
+| `driver`   | JDBC driver class to use                                               | required | `org.postgresql.Driver` | No
+| `url`      | JDBC URL to connect to                                                 | required | `jdbc:postgresql://:OPENNMS_JDBC_HOSTNAME/opennms` | Yes
+| `user`     | Database user                                                          | required | `postgres` | Yes
+| `password` | Database password                                                      | required | `empty string` | Yes
+| `query`    | The SQL query to run                                                   | required | `-` | No
+| `action`   | What evaluation action to perform                                      | required | `row_count` | No
+| `column`   | The result column to evaluate against when using compare_string method | required | `-` | No
+| `operator` | Operator to use for the evaluation                                     | required | `>=` | No
+| `operand`  | The operand to compare against the SQL query result                    | required | depends on the action | No
 | `message`  | The message to use if the service is down.
-               Both operands and the operator are added to the message too.       | optional | generic message depending on the action | No
-| `retries`  | How many retries should be performed before failing the test       | optional | `0` | No
+               Both operands and the operator are added to the message too.           | optional | generic message depending on the action | No
+| `retries`  | How many retries should be performed before failing the test           | optional | `0` | No
 |===
 
 NOTE: The +OPENNMS_JDBC_HOSTNAME+ is replaced in the +url+ parameter with the IP or resolved hostname of the interface the monitored service is assigned to.
@@ -78,7 +78,9 @@ This may be tricky or impossible when using the _Java Webstart Remote Poller_, b
 
 ===== Examples
 
-The following example checks if the number of events in the {opennms-product-name} database is fewer than 250000.
+====== Row Count
+
+The following example checks if the number of events in the {opennms-product-name} database is fewer than 250,000.
 
 [source, xml]
 ----
@@ -95,4 +97,26 @@ The following example checks if the number of events in the {opennms-product-nam
 </service>
 
 <monitor service="OpenNMS-DB-Event-Limit" class-name="org.opennms.netmgt.poller.monitors.JDBCQueryMonitor" />
+----
+
+====== String Comparison
+
+The following example checks if the queried string matches against a defined operand.
+
+[source, xml]
+----
+<service name="MariaDB-Galera" interval="300000" user-defined="false" status="on">
+  <parameter key="driver" value="org.mariadb.jdbc.Driver"/>
+  <parameter key="user" value="opennms"/>
+  <parameter key="password" value="********"/>
+  <parameter key="url" value="jdbc:mysql://OPENNMS_JDBC_HOSTNAME"/>
+  <parameter key="query" value="SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_status'"/>
+  <parameter key="column" value="VARIABLE_VALUE"/>
+  <parameter key="action" value="compare_string"/>
+  <parameter key="operator" value="="/>
+  <parameter key="operand" value="Primary"/>
+  <parameter key="message" value="Galera Node is not in primary component"/>
+</service>
+
+<monitor service="MariaDB-Galera" class-name="org.opennms.netmgt.poller.monitors.JDBCQueryMonitor" />
 ----


### PR DESCRIPTION
The docs do not have an example of a `compare_string` method. Also it is not clear that the parameter `column` is required for `compare_string` method as @pioto described here: https://issues.opennms.org/browse/NMS-9581

I've added his example which is not in OpenNMS context. Not sure if this is a problem.