### PR TITLE
NMS-12568: Add SystemExcecuteMonitor example into docs

### DIFF
--- a/opennms-doc/guide-admin/src/asciidoc/text/service-assurance/monitors/SystemExecuteMonitor.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/service-assurance/monitors/SystemExecuteMonitor.adoc
@@ -33,7 +33,7 @@ If the banner is not available in the output the status is determined as down.
 
 The parameter `args` supports variable replacement for the following set of variables.
 
-NOTE: It is recommended to set reasonable output before the script exists, because the output will be added into the event reason.
+NOTE: We recommend setting reasonable output before the script runs, because the output will be added into the event reason.
 
 This monitor implements the <<ga-service-assurance-monitors-common-parameters, Common Configuration Parameters>>.
 

--- a/opennms-doc/guide-admin/src/asciidoc/text/service-assurance/monitors/SystemExecuteMonitor.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/service-assurance/monitors/SystemExecuteMonitor.adoc
@@ -61,38 +61,6 @@ This monitor implements the <<ga-service-assurance-monitors-common-parameters, C
 <parameter key="args" value="http://${nodelabel}/${svcname}/static"/>
 ----
 
-====== Banner matching example
-
-[source, xml]
-----
-<service name="Script_Example" interval="300000" user-defined="true" status="on">
-  <parameter key="script" value="/opt/opennms/contrib/Script_Example.sh"/>
-  <parameter key="banner" value="UP"/>
-  <parameter key="timeout" value="5000"/>
-</service>
-
-<monitor service="Script_Example" class-name="org.opennms.netmgt.poller.monitors.SystemExecuteMonitor"/>
-----
-
-[source, bash]
-----
-#/opt/opennms/contrib/Script_Example.sh
-#!/bin/bash
-set -e
-set -u
-
-# Create a value 1 or 2 randomly
-VALUE=$(shuf -i 1-2 -n 1)
-
-# Depending on the value echo UP or DOWN
-if [ "$VALUE" -eq 1 ]
-then
-    echo "UP"
-else
-    echo "DOWN"
-fi
-----
-
 ====== Exit status example
 
 [source, xml]
@@ -107,20 +75,44 @@ fi
 
 [source, bash]
 ----
-#/opt/opennms/contrib/Script_Example.sh
-#!/bin/bash
-set -e
-set -u
+#!/usr/bin/env bash
 
-# Create a value 1 or 2 randomly
-VALUE=$(shuf -i 1-2 -n 1)
+# ...some test logic
 
-# Depending on the value exit with status 0 or 1
-if [ "$VALUE" -eq 1 ]
-then
-    exit 0
+RESULT="TEST OK"
+
+if [[ "TEST OK" == "${RESULT}" ]]; then
+  exit 0
 else
-    exit 1
+  exit 1
+fi
+----
+
+====== Banner matching example
+
+[source, xml]
+----
+<service name="Script_Example" interval="300000" user-defined="true" status="on">
+  <parameter key="script" value="/opt/opennms/contrib/Script_Example.sh"/>
+  <parameter key="banner" value="PASSED"/>
+  <parameter key="timeout" value="5000"/>
+</service>
+
+<monitor service="Script_Example" class-name="org.opennms.netmgt.poller.monitors.SystemExecuteMonitor"/>
+----
+
+[source, bash]
+----
+#!/usr/bin/env bash
+
+# ...some test logic
+
+RESULT="TEST OK"
+
+if [[ "TEST OK" == "${RESULT}" ]]; then
+  echo "PASSED"
+else
+  echo "FAILED"
 fi
 ----
 

--- a/opennms-doc/guide-admin/src/asciidoc/text/service-assurance/monitors/SystemExecuteMonitor.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/service-assurance/monitors/SystemExecuteMonitor.adoc
@@ -61,32 +61,66 @@ This monitor implements the <<ga-service-assurance-monitors-common-parameters, C
 <parameter key="args" value="http://${nodelabel}/${svcname}/static"/>
 ----
 
-====== Reasonable output example
+====== Banner matching example
 
 [source, xml]
 ----
-<service name="DivisibleByFive" interval="300000" user-defined="true" status="on">
-  <parameter key="script" value="/opt/opennms/contrib/DivisibleByFive.sh"/>
-  <parameter key="banner" value="Your number is divisible by 5"/>
+<service name="Script_Example" interval="300000" user-defined="true" status="on">
+  <parameter key="script" value="/opt/opennms/contrib/Script_Example.sh"/>
+  <parameter key="banner" value="UP"/>
   <parameter key="timeout" value="5000"/>
 </service>
 
-<monitor service="DivisibleByFive" class-name="org.opennms.netmgt.poller.monitors.SystemExecuteMonitor"/>
+<monitor service="Script_Example" class-name="org.opennms.netmgt.poller.monitors.SystemExecuteMonitor"/>
 ----
-
-**/opt/opennms/contrib/DivisibleByFive.sh**
 
 [source, bash]
 ----
+#/opt/opennms/contrib/Script_Example.sh
 #!/bin/bash
 set -e
 set -u
 
-if (( $RANDOM % 5 == 0 ))
+# Create a value 1 or 2 randomly
+VALUE=$(shuf -i 1-2 -n 1)
+
+# Depending on the value echo UP or DOWN
+if [ "$VALUE" -eq 1 ]
 then
-    echo "Your number is divisible by 5"
+    echo "UP"
 else
-    echo "Your number is not divisible by 5"
+    echo "DOWN"
+fi
+----
+
+====== Exit status example
+
+[source, xml]
+----
+<service name="Script_Example" interval="300000" user-defined="true" status="on">
+  <parameter key="script" value="/opt/opennms/contrib/Script_Example.sh"/>
+  <parameter key="timeout" value="5000"/>
+</service>
+
+<monitor service="Script_Example" class-name="org.opennms.netmgt.poller.monitors.SystemExecuteMonitor"/>
+----
+
+[source, bash]
+----
+#/opt/opennms/contrib/Script_Example.sh
+#!/bin/bash
+set -e
+set -u
+
+# Create a value 1 or 2 randomly
+VALUE=$(shuf -i 1-2 -n 1)
+
+# Depending on the value exit with status 0 or 1
+if [ "$VALUE" -eq 1 ]
+then
+    exit 0
+else
+    exit 1
 fi
 ----
 

--- a/opennms-doc/guide-admin/src/asciidoc/text/service-assurance/monitors/SystemExecuteMonitor.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/service-assurance/monitors/SystemExecuteMonitor.adoc
@@ -33,7 +33,7 @@ If the banner is not available in the output the status is determined as down.
 
 The parameter `args` supports variable replacement for the following set of variables.
 
-NOTE: We recommend setting reasonable output before the script runs, because the output will be added into the event reason.
+TIP: Providing always a script output with a more detailed test error makes it easier to diagnose the problem when the nodeLostDown event occurs.
 
 This monitor implements the <<ga-service-assurance-monitors-common-parameters, Common Configuration Parameters>>.
 
@@ -82,8 +82,10 @@ This monitor implements the <<ga-service-assurance-monitors-common-parameters, C
 RESULT="TEST OK"
 
 if [[ "TEST OK" == "${RESULT}" ]]; then
+  echo "This test passed"
   exit 0
 else
+  echo "This test failed because of ..."
   exit 1
 fi
 ----

--- a/opennms-doc/guide-admin/src/asciidoc/text/service-assurance/monitors/SystemExecuteMonitor.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/service-assurance/monitors/SystemExecuteMonitor.adoc
@@ -33,6 +33,8 @@ If the banner is not available in the output the status is determined as down.
 
 The parameter `args` supports variable replacement for the following set of variables.
 
+NOTE: It is recommended to set reasonable output before the script exists, because the output will be added into the event reason.
+
 This monitor implements the <<ga-service-assurance-monitors-common-parameters, Common Configuration Parameters>>.
 
 .Variables which can be used in the configuration
@@ -50,10 +52,42 @@ This monitor implements the <<ga-service-assurance-monitors-common-parameters, C
 
 ===== Examples
 
+
+====== Placeholder usage
+
 [source, xml]
 ----
 <parameter key="args" value="-i ${ipaddr} -t ${timeout}"/>
 <parameter key="args" value="http://${nodelabel}/${svcname}/static"/>
+----
+
+====== Reasonable output example
+
+[source, xml]
+----
+<service name="DivisibleByFive" interval="300000" user-defined="true" status="on">
+  <parameter key="script" value="/opt/opennms/contrib/DivisibleByFive.sh"/>
+  <parameter key="banner" value="Your number is divisible by 5"/>
+  <parameter key="timeout" value="5000"/>
+</service>
+
+<monitor service="DivisibleByFive" class-name="org.opennms.netmgt.poller.monitors.SystemExecuteMonitor"/>
+----
+
+**/opt/opennms/contrib/DivisibleByFive.sh**
+
+[source, bash]
+----
+#!/bin/bash
+set -e
+set -u
+
+if (( $RANDOM % 5 == 0 ))
+then
+    echo "Your number is divisible by 5"
+else
+    echo "Your number is not divisible by 5"
+fi
 ----
 
 ===== SystemExecuteMonitor vs GpMonitor


### PR DESCRIPTION
I got a hint from @indigo423 that should be also included in the docs. I've added an example for that.

https://issues.opennms.org/browse/NMS-12564