### PR TITLE
NMS-12674: Enable node enrichment for Topology providers coming from the Integration Api

### DIFF
--- a/features/graph/api/src/main/java/org/opennms/netmgt/graph/api/enrichment/EnrichmentGraphBuilder.java
+++ b/features/graph/api/src/main/java/org/opennms/netmgt/graph/api/enrichment/EnrichmentGraphBuilder.java
@@ -129,7 +129,8 @@ public final class EnrichmentGraphBuilder {
     public GenericGraph build() {
         final GenericGraph.GenericGraphBuilder genericGraphBuilder = GenericGraph.builder()
                 .properties(view.getProperties())
-                .properties(graphProperties);
+                .properties(graphProperties)
+                .focus(view.getDefaultFocus());
         view.getVertices().forEach(vertex -> {
             final GenericVertex enrichedVertex = GenericVertex.builder().vertex(vertex).properties(getVertexProperties(vertex.getVertexRef())).build();
             genericGraphBuilder.addVertex(enrichedVertex);

--- a/features/graph/provider/topology/src/main/java/org/opennms/netmgt/graph/provider/topology/GraphContainerProviderManager.java
+++ b/features/graph/provider/topology/src/main/java/org/opennms/netmgt/graph/provider/topology/GraphContainerProviderManager.java
@@ -40,6 +40,7 @@ import org.opennms.features.topology.api.topo.SearchProvider;
 import org.opennms.features.topology.api.topo.StatusProvider;
 import org.opennms.netmgt.dao.api.AlarmDao;
 import org.opennms.netmgt.dao.api.NodeDao;
+import org.opennms.netmgt.graph.api.enrichment.EnrichmentService;
 import org.opennms.netmgt.graph.api.info.GraphContainerInfo;
 import org.opennms.netmgt.graph.api.service.GraphContainerProvider;
 import org.opennms.netmgt.graph.api.service.GraphService;
@@ -55,12 +56,15 @@ public class GraphContainerProviderManager {
     private final BundleContext bundleContext;
     private final Map<GraphContainerProvider, List<ServiceRegistration<?>>> serviceRegistrations = Maps.newHashMap();
     private final GraphService graphService;
+    private final EnrichmentService enrichmentService;
     private final NodeDao nodeDao;
     private final AlarmDao alarmDao ;
 
-    public GraphContainerProviderManager(final BundleContext bundlecontext, final GraphService graphService, final NodeDao nodeDao, final AlarmDao alarmDao) {
+    public GraphContainerProviderManager(final BundleContext bundlecontext, final GraphService graphService, final EnrichmentService enrichmentService,
+                                         final NodeDao nodeDao, final AlarmDao alarmDao) {
         this.bundleContext = Objects.requireNonNull(bundlecontext);
         this.graphService = Objects.requireNonNull(graphService);
+        this.enrichmentService = Objects.requireNonNull(enrichmentService);
         this.nodeDao = Objects.requireNonNull(nodeDao);
         this.alarmDao = Objects.requireNonNull(alarmDao);
     }
@@ -77,7 +81,7 @@ public class GraphContainerProviderManager {
             final Hashtable<String, String> serviceProperties = new Hashtable<>();
             serviceProperties.put("label", containerInfo.getLabel());
 
-            final MetaTopologyProvider metaTopologyProvider = new LegacyMetaTopologyProvider(configuration, nodeDao, graphService, containerId);
+            final MetaTopologyProvider metaTopologyProvider = new LegacyMetaTopologyProvider(configuration, nodeDao, graphService, enrichmentService, containerId);
             final ServiceRegistration<MetaTopologyProvider> metaTopologyProviderServiceRegistration = bundleContext.registerService(MetaTopologyProvider.class, metaTopologyProvider, serviceProperties);
 
             // Register Search provider

--- a/features/graph/provider/topology/src/main/java/org/opennms/netmgt/graph/provider/topology/LegacyMetaTopologyProvider.java
+++ b/features/graph/provider/topology/src/main/java/org/opennms/netmgt/graph/provider/topology/LegacyMetaTopologyProvider.java
@@ -43,21 +43,27 @@ import org.opennms.features.topology.api.topo.GraphProvider;
 import org.opennms.features.topology.api.topo.MetaTopologyProvider;
 import org.opennms.features.topology.api.topo.VertexRef;
 import org.opennms.netmgt.dao.api.NodeDao;
+import org.opennms.netmgt.graph.api.enrichment.EnrichmentService;
 import org.opennms.netmgt.graph.api.service.GraphService;
 
 public class LegacyMetaTopologyProvider implements MetaTopologyProvider {
 
     private final GraphService graphService;
+    private final EnrichmentService enrichmentService;
     private final String containerId;
     private final Map<String, GraphProvider> providers;
 
-    public LegacyMetaTopologyProvider(final LegacyTopologyConfiguration configuration, final NodeDao nodeDao, final GraphService graphService, final String containerId) {
+    public LegacyMetaTopologyProvider(final LegacyTopologyConfiguration configuration, final NodeDao nodeDao,
+                                      final GraphService graphService,
+                                      final EnrichmentService enrichmentService,
+                                      final String containerId) {
         this.graphService = Objects.requireNonNull(graphService);
+        this.enrichmentService = Objects.requireNonNull(enrichmentService);
         this.containerId = Objects.requireNonNull(containerId);
 
         // Build TopologyProvider delegations
         this.providers = graphService.getGraphContainerInfo(containerId).getNamespaces().stream()
-                .map(namespace -> new LegacyTopologyProvider(configuration, nodeDao, graphService, containerId, namespace))
+                .map(namespace -> new LegacyTopologyProvider(configuration, nodeDao, graphService, enrichmentService, containerId, namespace))
                 .collect(Collectors.toMap(LegacyTopologyProvider::getNamespace, Function.identity()));
     }
 

--- a/features/graph/provider/topology/src/main/java/org/opennms/netmgt/graph/provider/topology/LegacyTopologyProvider.java
+++ b/features/graph/provider/topology/src/main/java/org/opennms/netmgt/graph/provider/topology/LegacyTopologyProvider.java
@@ -43,7 +43,7 @@ import org.opennms.features.topology.api.topo.GraphProvider;
 import org.opennms.features.topology.api.topo.TopologyProviderInfo;
 import org.opennms.features.topology.api.topo.VertexRef;
 import org.opennms.netmgt.dao.api.NodeDao;
-import org.opennms.netmgt.graph.api.NodeRef;
+import org.opennms.netmgt.graph.api.enrichment.EnrichmentService;
 import org.opennms.netmgt.graph.api.generic.GenericGraph;
 import org.opennms.netmgt.graph.api.service.GraphService;
 
@@ -58,13 +58,17 @@ public class LegacyTopologyProvider implements GraphProvider {
     private final GraphService graphService;
     private final NodeDao nodeDao;
     private final boolean resolveNodeIds;
+    private final EnrichmentService enrichmentService;
 
     private LegacyBackendGraph backendGraph;
 
-    public LegacyTopologyProvider(final LegacyTopologyConfiguration configuration, final NodeDao nodeDao, final GraphService graphService, final String containerId, final String graphNamespace) {
+    public LegacyTopologyProvider(final LegacyTopologyConfiguration configuration, final NodeDao nodeDao,
+                                  final GraphService graphService, final EnrichmentService enrichmentService,
+                                  final String containerId, final String graphNamespace) {
         this.containerId = Objects.requireNonNull(containerId);
         this.namespace = Objects.requireNonNull(graphNamespace);
         this.graphService = Objects.requireNonNull(graphService);
+        this.enrichmentService = Objects.requireNonNull(enrichmentService);
         this.nodeDao = Objects.requireNonNull(nodeDao);
         this.resolveNodeIds = Objects.requireNonNull(configuration).isResolveNodeIds();
     }
@@ -76,24 +80,14 @@ public class LegacyTopologyProvider implements GraphProvider {
 
     @Override
     public void refresh() {
-        final GenericGraph graph = graphService.getGraph(containerId, namespace);
-        this.backendGraph = new LegacyBackendGraph(graph);
+        GenericGraph graph = graphService.getGraph(containerId, namespace);
 
-        // Optionally resolve the nodIds of vertices providing information related to nodes
+        // Enrichment
         if (resolveNodeIds) {
-            // Update nodeId information as enrichment is not implemented at the moment
-            final Map<String, Map<String, Integer>> nodeIdMap = getNodeIdMap(graph);
-            graph.getVertices().stream()
-                .filter(v -> v.getNodeRef() != null && v.getNodeRef().getNodeId() == null)
-                .forEach(vertex -> {
-                    final NodeRef nodeRef = vertex.getNodeRef();
-                    final Map<String, Integer> foreignIdNodeIdMap = nodeIdMap.get(nodeRef.getForeignSource());
-                    final Integer nodeId = foreignIdNodeIdMap.get(nodeRef.getForeignId());
-                    if (nodeId != null) {
-                        backendGraph.getVertex(getNamespace(), vertex.getId()).setNodeID(nodeId);
-                    }
-                });
+            graph = this.enrichmentService.enrich(graph);
         }
+
+        this.backendGraph = new LegacyBackendGraph(graph);
     }
 
     @Override

--- a/features/graph/provider/topology/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/features/graph/provider/topology/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -9,11 +9,13 @@
         http://aries.apache.org/schemas/blueprint-ext/blueprint-ext-1.5.xsd
 ">
     <reference id="graphService" interface="org.opennms.netmgt.graph.api.service.GraphService" />
+    <reference id="enrichmentService" interface="org.opennms.netmgt.graph.api.enrichment.EnrichmentService" />
     <reference id="nodeDao" interface="org.opennms.netmgt.dao.api.NodeDao" availability="mandatory" />
     <reference id="alarmDao" interface="org.opennms.netmgt.dao.api.AlarmDao" availability="mandatory" />
     <bean id="graphContainerProviderManager" class="org.opennms.netmgt.graph.provider.topology.GraphContainerProviderManager">
         <argument ref="blueprintBundleContext" />
         <argument ref="graphService" />
+        <argument ref="enrichmentService" />
         <argument ref="nodeDao" />
         <argument ref="alarmDao" />
     </bean>


### PR DESCRIPTION
This Pull Request makes the Vertex Enrichment available to the topology map (so far it was only accessible via REST).

Note: in order to have the enrichment work the Vertex needs to have set the property: GenericProperties.NODE_CRITERIA 

Jira: https://issues.opennms.org/browse/NMS-12674