### PR TITLE
NMS-12695: graphite telemetry adapter

### DIFF
--- a/container/features/src/main/resources/features-sentinel.xml
+++ b/container/features/src/main/resources/features-sentinel.xml
@@ -154,6 +154,12 @@
         <bundle>mvn:org.opennms.features.distributed/org.opennms.features.distributed.collection/${project.version}</bundle>
     </feature>
 
+    <feature name="sentinel-telemetry-graphite" description="OpenNMS :: Sentinel :: Telemetry :: Adapters :: Graphite" version="${project.version}">
+        <feature>sentinel-telemetry</feature>
+        <feature>opennms-telemetry-graphite</feature>
+        <bundle>mvn:org.opennms.features.distributed/org.opennms.features.distributed.collection/${project.version}</bundle>
+    </feature>
+
     <feature name="sentinel-telemetry-bmp" description="OpenNMS :: Sentinel :: Telemetry :: Adapters :: BMP" version="${project.version}">
         <feature>sentinel-telemetry</feature>
         <feature>opennms-telemetry-bmp</feature>

--- a/container/features/src/main/resources/features.xml
+++ b/container/features/src/main/resources/features.xml
@@ -1016,6 +1016,10 @@
 	<bundle>mvn:com.google.protobuf/protobuf-java/${protobufVersion}</bundle>
         <bundle>mvn:org.opennms.features.telemetry.protocols.nxos/org.opennms.features.telemetry.protocols.nxos.adapter/${project.version}</bundle>
     </feature>
+    <feature name="opennms-telemetry-graphite" version="${project.version}" description="OpenNMS :: Telemetry :: Graphite">
+        <feature>opennms-telemetry-collection</feature>
+        <bundle>mvn:org.opennms.features.telemetry.protocols.graphite/org.opennms.features.telemetry.protocols.graphite.adapter/${project.version}</bundle>
+    </feature>
     <feature name="opennms-karaf-health" description="OpenNMS :: Karaf Health">
         <bundle start-level="100">mvn:org.opennms.features/org.opennms.features.karaf-health/${project.version}</bundle>
     </feature>

--- a/container/karaf/src/main/filtered-resources/etc/org.apache.karaf.features.cfg
+++ b/container/karaf/src/main/filtered-resources/etc/org.apache.karaf.features.cfg
@@ -104,6 +104,7 @@ featuresBoot = ( \
   opennms-telemetry-bmp,\
   opennms-telemetry-jti,\
   opennms-telemetry-nxos,\
+  opennms-telemetry-graphite,\
   opennms-dnsresolver-shell,\
   opennms-dnsresolver-netty,\
   opennms-flows,\

--- a/features/sentinel/repository/pom.xml
+++ b/features/sentinel/repository/pom.xml
@@ -64,6 +64,7 @@
                                 <feature>sentinel-jms</feature>
                                 <feature>sentinel-telemetry</feature>
                                 <feature>sentinel-telemetry-bmp</feature>
+                                <feature>sentinel-telemetry-graphite</feature>
                                 <feature>sentinel-telemetry-jti</feature>
                                 <feature>sentinel-telemetry-nxos</feature>
                                 <feature>sentinel-flows</feature>
@@ -361,6 +362,11 @@
         <dependency>
             <groupId>org.opennms.features.telemetry.protocols.sflow</groupId>
             <artifactId>org.opennms.features.telemetry.protocols.sflow.adapter</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.opennms.features.telemetry.protocols.graphite</groupId>
+            <artifactId>org.opennms.features.telemetry.protocols.graphite.adapter</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>

--- a/features/telemetry/api/src/main/java/org/opennms/netmgt/telemetry/api/adapter/TelemetryMessageLog.java
+++ b/features/telemetry/api/src/main/java/org/opennms/netmgt/telemetry/api/adapter/TelemetryMessageLog.java
@@ -31,15 +31,35 @@ package org.opennms.netmgt.telemetry.api.adapter;
 import java.util.List;
 
 public interface TelemetryMessageLog {
-
+    /**
+     * the Minion's location
+     * @return the location
+     */
     String getLocation();
 
+    /**
+     * the Minion's system ID
+     * 
+     * @return the system ID
+     */
     String getSystemId();
 
-    int getSourcePort();
-
+    /**
+     * the source address the incoming message log entries came from
+     * @return the address
+     */
     String getSourceAddress();
 
+    /**
+     * the source port the incoming message log entries came from
+     * @return the port
+     */
+    int getSourcePort();
+
+    /**
+     * raw message log entries coming in from the listener
+     * @return the log entry or entries
+     */
     List<? extends TelemetryMessageLogEntry> getMessageList();
 
 }

--- a/features/telemetry/itests/pom.xml
+++ b/features/telemetry/itests/pom.xml
@@ -136,6 +136,11 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.opennms.features.telemetry.protocols.graphite</groupId>
+      <artifactId>org.opennms.features.telemetry.protocols.graphite.adapter</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.opennms.core.test-api</groupId>
       <artifactId>org.opennms.core.test-api.camel</artifactId>
       <version>${project.version}</version>

--- a/features/telemetry/protocols/graphite/adapter/pom.xml
+++ b/features/telemetry/protocols/graphite/adapter/pom.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <parent>
+    <groupId>org.opennms.features.telemetry.protocols</groupId>
+    <artifactId>org.opennms.features.telemetry.protocols.graphite</artifactId>
+    <version>26.1.0-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.opennms.features.telemetry.protocols.graphite</groupId>
+  <artifactId>org.opennms.features.telemetry.protocols.graphite.adapter</artifactId>
+  <name>OpenNMS :: Features :: Telemetry :: Protocols :: Graphite Telemetry :: Adapter</name>
+  <packaging>bundle</packaging>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
+            <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+            <Bundle-Version>${project.version}</Bundle-Version>
+          </instructions>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+  <dependencies>
+    <dependency>
+      <groupId>org.opennms.features.telemetry.protocols</groupId>
+      <artifactId>org.opennms.features.telemetry.protocols.adapters</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.core</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/features/telemetry/protocols/graphite/adapter/src/main/java/org/opennms/netmgt/telemetry/protocols/graphite/adapter/GraphiteAdapter.java
+++ b/features/telemetry/protocols/graphite/adapter/src/main/java/org/opennms/netmgt/telemetry/protocols/graphite/adapter/GraphiteAdapter.java
@@ -100,7 +100,7 @@ public class GraphiteAdapter extends AbstractScriptedCollectionAdapter {
                     final GraphiteMetric metric = new GraphiteMetric(entry[0], entry[1], Long.valueOf(entry[2], 10));
                     final CollectionSet collectionSet = builder.build(agent, metric, metric.getTimestamp());
                     collectionSets.add(new CollectionSetWithAgent(agent, collectionSet));
-                } catch (final ScriptException e) {
+                } catch (final NumberFormatException | ScriptException e) {
                     LOG.warn("Dropping metric, unable to create collection set: {}", Arrays.asList(entry), e);
                 }
             }

--- a/features/telemetry/protocols/graphite/adapter/src/main/java/org/opennms/netmgt/telemetry/protocols/graphite/adapter/GraphiteAdapter.java
+++ b/features/telemetry/protocols/graphite/adapter/src/main/java/org/opennms/netmgt/telemetry/protocols/graphite/adapter/GraphiteAdapter.java
@@ -1,0 +1,119 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.telemetry.protocols.graphite.adapter;
+
+import java.net.InetAddress;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import javax.script.ScriptException;
+
+import org.opennms.core.utils.InetAddressUtils;
+import org.opennms.netmgt.collection.api.CollectionAgent;
+import org.opennms.netmgt.collection.api.CollectionAgentFactory;
+import org.opennms.netmgt.collection.api.CollectionSet;
+import org.opennms.netmgt.dao.api.InterfaceToNodeCache;
+import org.opennms.netmgt.telemetry.api.adapter.TelemetryMessageLog;
+import org.opennms.netmgt.telemetry.api.adapter.TelemetryMessageLogEntry;
+import org.opennms.netmgt.telemetry.config.api.AdapterDefinition;
+import org.opennms.netmgt.telemetry.protocols.collection.AbstractScriptedCollectionAdapter;
+import org.opennms.netmgt.telemetry.protocols.collection.CollectionSetWithAgent;
+import org.opennms.netmgt.telemetry.protocols.collection.ScriptedCollectionSetBuilder;
+
+import com.codahale.metrics.MetricRegistry;
+
+public class GraphiteAdapter extends AbstractScriptedCollectionAdapter {
+    private CollectionAgentFactory collectionAgentFactory;
+    private InterfaceToNodeCache interfaceToNodeCache;
+
+    public GraphiteAdapter(final AdapterDefinition adapterConfig, final MetricRegistry metricRegistry) {
+        super(adapterConfig, metricRegistry);
+    }
+
+    @Override
+    public Stream<CollectionSetWithAgent> handleCollectionMessage(final TelemetryMessageLogEntry message, final TelemetryMessageLog messageLog) {
+        final String messageText = new String(message.getByteArray());
+        LOG.trace("plaintext message: {}", messageText);
+        final String[] lines = messageText.split("\n");
+
+        CollectionAgent agent = null;
+        try {
+            final InetAddress inetAddress = InetAddressUtils.addr(messageLog.getSourceAddress());
+            final Optional<Integer> nodeId = interfaceToNodeCache.getFirstNodeId(messageLog.getLocation(), inetAddress);
+            if (nodeId.isPresent()) {
+                // NOTE: This will throw a IllegalArgumentException if the nodeId/inetAddress pair does not exist in the database
+                agent = collectionAgentFactory.createCollectionAgent(Integer.toString(nodeId.get()), inetAddress);
+            }
+        } catch (final RuntimeException e) {
+            LOG.warn("Unable to determine source address from message log.", e);
+            return Stream.empty();
+        }
+
+        if (agent == null) {
+            LOG.warn("Unable to determine collection agent from location={} and address={}", messageLog.getLocation(), messageLog.getSourceAddress());
+            return Stream.empty();
+        }
+
+        final ScriptedCollectionSetBuilder builder = getCollectionBuilder();
+        if (builder == null) {
+            LOG.error("Error compiling script '{}'. See logs for details.", this.getScript());
+            return Stream.empty();
+        }
+
+        final List<CollectionSetWithAgent> collectionSets = new ArrayList<>();
+
+        for (final String line : lines) {
+            final String[] entry = line.split(" ", 3);
+            if (entry.length != 3) {
+                LOG.warn("Unparseable graphite plaintext message: {}", line);
+            } else {
+                final GraphiteMetric metric = new GraphiteMetric(entry[0], entry[1], Long.valueOf(entry[2], 10));
+                try {
+                    final CollectionSet collectionSet = builder.build(agent, metric, metric.getTimestamp());
+                    collectionSets.add(new CollectionSetWithAgent(agent, collectionSet));
+                } catch (final ScriptException e) {
+                    LOG.warn("Dropping metric, unable to create collection set: {}", metric, e);
+                }
+            }
+        }
+
+        return collectionSets.stream();
+    }
+
+    public void setCollectionAgentFactory(final CollectionAgentFactory collectionAgentFactory) {
+        this.collectionAgentFactory = collectionAgentFactory;
+    }
+
+    public void setInterfaceToNodeCache(final InterfaceToNodeCache interfaceToNodeCache) {
+        this.interfaceToNodeCache = interfaceToNodeCache;
+    }
+
+}

--- a/features/telemetry/protocols/graphite/adapter/src/main/java/org/opennms/netmgt/telemetry/protocols/graphite/adapter/GraphiteAdapter.java
+++ b/features/telemetry/protocols/graphite/adapter/src/main/java/org/opennms/netmgt/telemetry/protocols/graphite/adapter/GraphiteAdapter.java
@@ -30,6 +30,7 @@ package org.opennms.netmgt.telemetry.protocols.graphite.adapter;
 
 import java.net.InetAddress;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -95,12 +96,12 @@ public class GraphiteAdapter extends AbstractScriptedCollectionAdapter {
             if (entry.length != 3) {
                 LOG.warn("Unparseable graphite plaintext message: {}", line);
             } else {
-                final GraphiteMetric metric = new GraphiteMetric(entry[0], entry[1], Long.valueOf(entry[2], 10));
                 try {
+                    final GraphiteMetric metric = new GraphiteMetric(entry[0], entry[1], Long.valueOf(entry[2], 10));
                     final CollectionSet collectionSet = builder.build(agent, metric, metric.getTimestamp());
                     collectionSets.add(new CollectionSetWithAgent(agent, collectionSet));
                 } catch (final ScriptException e) {
-                    LOG.warn("Dropping metric, unable to create collection set: {}", metric, e);
+                    LOG.warn("Dropping metric, unable to create collection set: {}", Arrays.asList(entry), e);
                 }
             }
         }

--- a/features/telemetry/protocols/graphite/adapter/src/main/java/org/opennms/netmgt/telemetry/protocols/graphite/adapter/GraphiteAdapterFactory.java
+++ b/features/telemetry/protocols/graphite/adapter/src/main/java/org/opennms/netmgt/telemetry/protocols/graphite/adapter/GraphiteAdapterFactory.java
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.telemetry.protocols.graphite.adapter;
+
+import org.opennms.netmgt.telemetry.api.adapter.Adapter;
+import org.opennms.netmgt.telemetry.config.api.AdapterDefinition;
+import org.opennms.netmgt.telemetry.protocols.collection.AbstractCollectionAdapterFactory;
+import org.osgi.framework.BundleContext;
+
+public class GraphiteAdapterFactory extends AbstractCollectionAdapterFactory {
+
+    public GraphiteAdapterFactory() {
+        super(null);
+    }
+
+    public GraphiteAdapterFactory(BundleContext bundleContext) {
+        super(bundleContext);
+    }
+
+    @Override
+    public Class<? extends Adapter> getBeanClass() {
+        return GraphiteAdapter.class;
+    }
+
+    @Override
+    public Adapter createBean(AdapterDefinition adapterConfig) {
+        final GraphiteAdapter adapter = new GraphiteAdapter(adapterConfig, getTelemetryRegistry().getMetricRegistry());
+        adapter.setCollectionAgentFactory(getCollectionAgentFactory());
+        adapter.setInterfaceToNodeCache(getInterfaceToNodeCache());
+        adapter.setFilterDao(getFilterDao());
+        adapter.setPersisterFactory(getPersisterFactory());
+        adapter.setThresholdingService(getThresholdingService());
+        adapter.setBundleContext(getBundleContext());
+
+        return adapter;
+    }
+
+}

--- a/features/telemetry/protocols/graphite/adapter/src/main/java/org/opennms/netmgt/telemetry/protocols/graphite/adapter/GraphiteMetric.java
+++ b/features/telemetry/protocols/graphite/adapter/src/main/java/org/opennms/netmgt/telemetry/protocols/graphite/adapter/GraphiteMetric.java
@@ -1,0 +1,131 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.telemetry.protocols.graphite.adapter;
+
+import java.time.Instant;
+import java.util.Objects;
+
+public class GraphiteMetric {
+    /**
+     * The graphite path, an arbitrary key.
+     */
+    private String path;
+
+    /**
+     * The value to be stored.
+     */
+    private String value;
+
+    /**
+     * The timestamp as a UNIX epoch.
+     */
+    private long timestamp;
+
+    public GraphiteMetric(final String path, final String value, final long timestamp) {
+        this.path = Objects.requireNonNull(path);
+        this.value = Objects.requireNonNull(value);
+        this.timestamp = timestamp;
+    }
+
+    /**
+     * The graphite path, an arbitrary key.
+     */
+    public String getPath() {
+        return this.path;
+    }
+
+    /**
+     * The raw value.
+     */
+    public String getValue() {
+        return this.value;
+    }
+
+    /**
+     * The value, as an Integer number.
+     */
+    public Integer intValue() {
+        return Integer.valueOf(this.value, 10);
+    }
+
+    /**
+     * The value, as a Long number.
+     */
+    public Long longValue() {
+        return Long.valueOf(this.value, 10);
+    }
+
+    /**
+     * The value, as a floating-point number.
+     */
+    public Float floatValue() {
+        return Float.valueOf(this.value);
+    }
+
+    /**
+     * The value, as a double-precision number.
+     */
+    public Double doubleValue() {
+        return Double.valueOf(this.value);
+    }
+
+    /**
+     * The timestamp as a UNIX epoch.
+     */
+    public long getTimestamp() {
+        return this.timestamp;
+    }
+
+    /**
+     * The timestamp as an Instant.
+     */
+    public Instant getInstant() {
+        return Instant.ofEpochMilli(this.timestamp);
+    }
+
+    @Override
+    public String toString() {
+        return "GraphiteMetric [path=" + path + ", value=" + value + ", timestamp=" + timestamp + "]";
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(path, timestamp, value);
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if (this == obj) return true;
+        if (!(obj instanceof GraphiteMetric)) return false;
+        final GraphiteMetric other = (GraphiteMetric) obj;
+        return Objects.equals(path, other.path)
+                && Objects.equals(value, other.value)
+                && timestamp == other.timestamp;
+    }
+}

--- a/features/telemetry/protocols/graphite/adapter/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/features/telemetry/protocols/graphite/adapter/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -1,0 +1,35 @@
+<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.3.0" xmlns:ext="http://aries.apache.org/blueprint/xmlns/blueprint-ext/v1.5.0"
+    xsi:schemaLocation="
+        http://www.osgi.org/xmlns/blueprint/v1.0.0
+        http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd
+        http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.3.0
+        http://aries.apache.org/schemas/blueprint-cm/blueprint-cm-1.3.0.xsd
+        http://aries.apache.org/blueprint/xmlns/blueprint-ext/v1.5.0
+        http://aries.apache.org/schemas/blueprint-ext/blueprint-ext-1.5.xsd
+">
+
+    <reference id="telemetryRegistry" interface="org.opennms.netmgt.telemetry.api.registry.TelemetryRegistry" />
+        <reference id="collectionAgentFactory" interface="org.opennms.netmgt.collection.api.CollectionAgentFactory" />
+        <reference id="interfaceToNodeCache" interface="org.opennms.netmgt.dao.api.InterfaceToNodeCache" />
+        <reference id="filterDao" interface="org.opennms.netmgt.filter.api.FilterDao" />
+        <reference id="persisterFactory" interface="org.opennms.netmgt.collection.api.PersisterFactory" />
+        <reference id="thresholdingService" interface="org.opennms.netmgt.threshd.api.ThresholdingService" />
+
+        <bean id="graphiteFactory" class="org.opennms.netmgt.telemetry.protocols.graphite.adapter.GraphiteAdapterFactory">
+            <argument ref="blueprintBundleContext" />
+            <property name="telemetryRegistry" ref="telemetryRegistry" />
+            <property name="collectionAgentFactory" ref="collectionAgentFactory" />
+            <property name="interfaceToNodeCache" ref="interfaceToNodeCache" />
+            <property name="filterDao" ref="filterDao" />
+            <property name="persisterFactory" ref="persisterFactory" />
+            <property name="thresholdingService" ref="thresholdingService" />
+        </bean>
+
+        <service id="graphiteFactoryService" ref="graphiteFactory" interface="org.opennms.netmgt.telemetry.api.adapter.AdapterFactory">
+            <service-properties>
+                <entry key="registration.export" value="true" />
+            </service-properties>
+        </service>
+
+</blueprint>

--- a/features/telemetry/protocols/graphite/pom.xml
+++ b/features/telemetry/protocols/graphite/pom.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <parent>
+    <groupId>org.opennms.features.telemetry</groupId>
+    <artifactId>org.opennms.features.telemetry.protocols</artifactId>
+    <version>26.1.0-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.opennms.features.telemetry.protocols</groupId>
+  <artifactId>org.opennms.features.telemetry.protocols.graphite</artifactId>
+  <name>OpenNMS :: Features :: Telemetry :: Protocols :: Graphite Telemetry</name>
+  <packaging>pom</packaging>
+  <modules>
+    <module>adapter</module>
+  </modules>
+</project>

--- a/features/telemetry/protocols/pom.xml
+++ b/features/telemetry/protocols/pom.xml
@@ -15,6 +15,7 @@
     <module>bmp</module>
     <module>common</module>
     <module>flows</module>
+    <module>graphite</module>
     <module>jti</module>
     <module>nxos</module>
     <module>sflow</module>

--- a/opennms-base-assembly/pom.xml
+++ b/opennms-base-assembly/pom.xml
@@ -1105,6 +1105,11 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.opennms.features.telemetry.protocols.graphite</groupId>
+      <artifactId>org.opennms.features.telemetry.protocols.graphite.adapter</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.opennms.features.telemetry</groupId>
       <artifactId>org.opennms.features.telemetry.listeners</artifactId>
       <version>${project.version}</version>

--- a/opennms-base-assembly/src/main/filtered/etc/telemetryd-adapters/graphite-telemetry-interface.groovy
+++ b/opennms-base-assembly/src/main/filtered/etc/telemetryd-adapters/graphite-telemetry-interface.groovy
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+import groovy.util.logging.Slf4j
+import org.opennms.core.utils.RrdLabelUtils
+import org.opennms.netmgt.collection.api.AttributeType
+import org.opennms.netmgt.telemetry.protocols.graphite.adapter.GraphiteMetric
+import org.opennms.netmgt.collection.support.builder.InterfaceLevelResource
+import org.opennms.netmgt.collection.support.builder.NodeLevelResource
+
+/**
+ * Simple graphite handler. No schema support, you'll have to parse/handle the message paths yourself.
+ *
+ * You can send test data easily by doing something like:
+ * <code>echo "eth0.my-metric 100 `date +%s`" | nc -u -w1 localhost 2003</code>
+ */
+@Slf4j
+class CollectionSetGenerator {
+    static generate(agent, builder, graphiteMsg) {
+        log.debug("Generating collection set for message: {}", graphiteMsg)
+        // First, build the top node-level resources, as other resource types
+        // will depend on this one
+        NodeLevelResource nodeLevelResource = new NodeLevelResource(agent.getNodeId())
+
+        if (graphiteMsg.path.startsWith("eth")) {
+            // finding the mac address for the interface is left as an exercise to the reader ;)
+            String ifaceLabel = RrdLabelUtils.computeLabelForRRD(graphiteMsg.path.split(".")[0], null, null);
+            InterfaceLevelResource interfaceResource = new InterfaceLevelResource(nodeLevelResource, interfaceLabel);
+            builder.withGauge(interfaceResource, "some-group", graphiteMsg.path.split(".")[1], graphitMsg.longValue());
+        } else {
+            log.warn("I don't know how to handle this message from graphite. :(  {}", graphiteMsg);
+        }
+    }
+}
+
+// The following variables are passed in as globals from the adapter:
+// agent: the agent (or node) against which the metrics will be associated
+// builder: a reference to a CollectionSetBuilder to which the resources/metrics should be added
+// msg: the message from which to extract the metrics
+
+// In our case, the msg will a GraphiteMetric object
+GraphiteMetric graphiteMsg = msg
+
+// Generate the CollectionSet
+CollectionSetGenerator.generate(agent, builder, graphiteMsg)

--- a/opennms-base-assembly/src/main/filtered/etc/telemetryd-configuration.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/telemetryd-configuration.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <telemetryd-config>
 
-    <!-- JTI Listener & adpaters -->
+    <!-- JTI Listener & adapters -->
     <listener name="JTI-UDP-50000" class-name="org.opennms.netmgt.telemetry.listeners.UdpListener" enabled="false">
         <parameter key="port" value="50000"/>
 
@@ -143,4 +143,26 @@
             <parameter key="kafka.bootstrap.servers" value="localhost:9092" />
         </adapter>
     </queue>
+
+    <!-- Graphite listener and adapter -->
+    <listener name="Graphite-UDP-2003" class-name="org.opennms.netmgt.telemetry.listeners.UdpListener" enabled="false">
+        <parameter key="port" value="2003"/>
+        <parser name="Graphite-Parser" class-name="org.opennms.netmgt.telemetry.protocols.common.parser.ForwardParser" queue="Graphite" />
+    </listener>
+
+    <queue name="Graphite">
+        <adapter name="Graphite" class-name="org.opennms.netmgt.telemetry.protocols.graphite.adapter.GraphiteAdapter" enabled="false">
+            <parameter key="script" value="${install.dir}/etc/telemetryd-adapters/graphite-telemetry-interface.groovy"/>
+             <package name="Graphite-Default">
+                <rrd step="300">
+                    <rra>RRA:AVERAGE:0.5:1:2016</rra>
+                    <rra>RRA:AVERAGE:0.5:12:1488</rra>
+                    <rra>RRA:AVERAGE:0.5:288:366</rra>
+                    <rra>RRA:MAX:0.5:288:366</rra>
+                    <rra>RRA:MIN:0.5:288:366</rra>
+                </rrd>
+            </package>
+        </adapter>
+    </queue>
+
 </telemetryd-config>

--- a/opennms-doc/guide-admin/src/asciidoc/index.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/index.adoc
@@ -379,6 +379,7 @@ include::text/telemetryd/protocols/netflow5.adoc[]
 include::text/telemetryd/protocols/netflow9.adoc[]
 include::text/telemetryd/protocols/nxos.adoc[]
 include::text/telemetryd/protocols/sflow.adoc[]
+include::text/telemetryd/protocols/graphite.adoc[]
 
 [[ga-elasticsearch-integration]]
 == Elasticsearch Integration

--- a/opennms-doc/guide-admin/src/asciidoc/text/telemetryd/protocols/graphite.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/telemetryd/protocols/graphite.adoc
@@ -1,0 +1,98 @@
+
+==== Graphite Telemetry
+
+The _Graphite_ telemetry adapter allows you to push telemetry data to _{opennms-product-name}_ using the link:https://graphite.readthedocs.io/en/latest/feeding-carbon.html#the-plaintext-protocol[_plaintext_ protocol].
+
+To enable support for Graphite, edit `${OPENNMS_HOME}/etc/telemetryd-configuration.xml` set `enabled=true` for the `Graphite` protocol.
+
+.Enable Graphite protocol in telemetryd-configuration.xml
+[source, xml]
+----
+    <listener name="Graphite-UDP-2003" class-name="org.opennms.netmgt.telemetry.listeners.UdpListener" enabled="true">
+        <parameter key="port" value="2003"/>
+        <parser name="Graphite-Parser" class-name="org.opennms.netmgt.telemetry.protocols.common.parser.ForwardParser" queue="Graphite" />
+    </listener>
+
+    <queue name="Graphite">
+        <adapter name="Graphite" class-name="org.opennms.netmgt.telemetry.protocols.graphite.adapter.GraphiteAdapter" enabled="true">
+            <parameter key="script" value="/Users/ranger/git/opennms-work/target/opennms-26.1.0-SNAPSHOT/etc/telemetryd-adapters/graphite-telemetry-interface.groovy"/>
+             <package name="Graphite-Default">
+                <rrd step="300">
+                    <rra>RRA:AVERAGE:0.5:1:2016</rra>
+                    <rra>RRA:AVERAGE:0.5:12:1488</rra>
+                    <rra>RRA:AVERAGE:0.5:288:366</rra>
+                    <rra>RRA:MAX:0.5:288:366</rra>
+                    <rra>RRA:MIN:0.5:288:366</rra>
+                </rrd>
+            </package>
+        </adapter>
+    </queue>
+----
+
+Apply the changes without restarting by sending a `reloadDaemonConfig` event in the CLI or the WebUI:
+
+.Send a reloadDaemonConfig event through CLI
+[source]
+----
+${OPENNMS_HOME}bin/send-event.pl -p 'daemonName Telemetryd' uei.opennms.org/internal/reloadDaemonConfig
+----
+
+By default, this will open a UDP socket bound to `0.0.0.0:2003` to which _Graphite_ messages can be forwarded.
+
+===== Configure Graphite Listener on a Minion
+
+To enable and configure an _UDP Listener_ for Graphite on Minion, connect to the _Karaf Console_ and set the following properties:
+
+[source]
+----
+$ ssh -p 8201 admin@localhost
+...
+admin@minion()> config:edit --alias udp-2003 --factory org.opennms.features.telemetry.listeners
+admin@minion()> config:property-set name Graphite
+admin@minion()> config:property-set class-name org.opennms.netmgt.telemetry.listeners.UdpListener
+admin@minion()> config:property-set parameters.port 2003
+admin@minion()> config:property-set parsers.0.name Graphite
+admin@minion()> config:property-set parsers.0.class-name org.opennms.netmgt.telemetry.protocols.common.parser.ForwardParser
+admin@minion()> config:update
+----
+
+NOTE: The protocol must also be enabled on _{opennms-product-name}_ for the messages to be processed.
+
+
+===== Graphite Adapter
+
+The Graphite adapter is used to handle _Graphite_ payloads.
+Messages are decoded and forwarded to a JSR-223 compatible script (i.e. Beanshell or Groovy) for further processing.
+Using the script extension you can extract the desired metrics from the Graphite messages and persist the results as time series data.
+
+====== Facts
+
+[options="autowidth"]
+|===
+| Class Name          | `org.opennms.netmgt.telemetry.protocols.graphite.adapter.GraphiteAdapter`
+|===
+
+====== Parameters
+
+.Adapter specific parameters for the GraphiteAdapter
+[options="header, autowidth"]
+|===
+| Parameter        | Description                                                       | Required | Default value
+| `script`         | Full path to the script used to handle the Graphite messages      | required | (none)
+|===
+
+====== Scripting
+
+The script will be invoked for every Graphite message that is received and succesfully decoded.
+
+The following globals will be passed to the script:
+
+.Globals passed to the script
+[options="header, autowidth"]
+|===
+| Parameter  | Description                                                    | Type
+| `agent`    | The agent (node) against which the metrics will be associated  | `org.opennms.netmgt.collection.api.CollectionAgent`
+| `builder`  | Builder in which the resources and metrics should be added     | `org.opennms.netmgt.collection.support.builder.CollectionSetBuilder`
+| `msg`      | Decoded message from which the metrics should be extracted     | `org.opennms.netmgt.telemetry.protocols.graphite.adapter.GraphiteMetric`
+|===
+

--- a/opennms-doc/guide-admin/src/asciidoc/text/telemetryd/protocols/graphite.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/telemetryd/protocols/graphite.adoc
@@ -1,9 +1,9 @@
 
 ==== Graphite Telemetry
 
-The _Graphite_ telemetry adapter allows you to push telemetry data to _{opennms-product-name}_ using the link:https://graphite.readthedocs.io/en/latest/feeding-carbon.html#the-plaintext-protocol[_plaintext_ protocol].
+The _Graphite_ telemetry adapter allows you to push telemetry data over UDP to _{opennms-product-name}_ using the link:https://graphite.readthedocs.io/en/latest/feeding-carbon.html#the-plaintext-protocol[_plaintext_ protocol].
 
-To enable support for Graphite, edit `${OPENNMS_HOME}/etc/telemetryd-configuration.xml` set `enabled=true` for the `Graphite` protocol.
+To enable support for plaintext Graphite over UDP, edit `${OPENNMS_HOME}/etc/telemetryd-configuration.xml` set `enabled=true` for the `Graphite` protocol.
 
 .Enable Graphite protocol in telemetryd-configuration.xml
 [source, xml]
@@ -41,7 +41,7 @@ By default, this will open a UDP socket bound to `0.0.0.0:2003` to which _Graphi
 
 ===== Configure Graphite Listener on a Minion
 
-To enable and configure an _UDP Listener_ for Graphite on Minion, connect to the _Karaf Console_ and set the following properties:
+To enable and configure a _UDP Listener_ for Graphite on Minion, connect to the _Karaf Console_ and set the following properties:
 
 [source]
 ----

--- a/opennms-full-assembly/pom.xml
+++ b/opennms-full-assembly/pom.xml
@@ -567,6 +567,7 @@
                 <feature>opennms-telemetry-bmp</feature>
                 <feature>opennms-telemetry-jti</feature>
                 <feature>opennms-telemetry-nxos</feature>
+                <feature>opennms-telemetry-graphite</feature>
                 <feature>org.opennms.features.enlinkd.service.api</feature>
                 <feature>org.opennms.features.bsm.service.api</feature>
                 <feature>org.opennms.features.bsm.shell-commands</feature>

--- a/opennms-full-assembly/src/test/java/org/opennms/assemblies/karaf/OnmsFeatureKarafIT.java
+++ b/opennms-full-assembly/src/test/java/org/opennms/assemblies/karaf/OnmsFeatureKarafIT.java
@@ -590,6 +590,12 @@ public class OnmsFeatureKarafIT extends KarafTestCase {
 		System.out.println(executeCommand("feature:list -i"));
 	}
 	@Test
+	public void testInstallFeatureOpennmsTelemetryGraphite() {
+		installFeature("opennms-dao-api"); // System classpath
+		installFeature("opennms-telemetry-graphite");
+		System.out.println(executeCommand("feature:list -i"));
+	}
+	@Test
 	public void testInstallFeatureOpennmsTelemetryNxos() {
 		installFeature("opennms-dao-api"); // System classpath
 		installFeature("opennms-telemetry-nxos");

--- a/smoke-test/pom.xml
+++ b/smoke-test/pom.xml
@@ -484,6 +484,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.opennms.features.telemetry.protocols.graphite</groupId>
+      <artifactId>org.opennms.features.telemetry.protocols.graphite.adapter</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-yaml</artifactId>
       <version>${jackson2Version}</version>

--- a/smoke-test/src/main/java/org/opennms/smoketest/containers/SentinelContainer.java
+++ b/smoke-test/src/main/java/org/opennms/smoketest/containers/SentinelContainer.java
@@ -203,6 +203,7 @@ public class SentinelContainer extends GenericContainer implements KarafContaine
         if (model.isTelemetryProcessingEnabled()) {
             featuresOnBoot.add("sentinel-flows");
             featuresOnBoot.add("sentinel-telemetry-bmp");
+            featuresOnBoot.add("sentinel-telemetry-graphite");
             featuresOnBoot.add("sentinel-telemetry-jti");
             featuresOnBoot.add("sentinel-telemetry-nxos");
         }


### PR DESCRIPTION
This PR adds basic support for the Graphite `plaintext` protocol to Telemetryd.

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-12695
* Bamboo (Continuous Integration): https://bamboo.opennms.org/

