### PR TITLE
NMS-12687: Additional Confd templates for Minion configuration

### DIFF
--- a/opennms-container/minion/CONFD_README.md
+++ b/opennms-container/minion/CONFD_README.md
@@ -166,9 +166,10 @@ Config specified will be written to `etc/confd.system.properties` which gets aut
 ```
 ---
 karaf:
-    ssh:
-        host: "127.0.0.1"
-        port: 8201
+    shell:
+        ssh:
+            host: "0.0.0.0"
+            port: 8201
     management:
         rmi:
             registry:
@@ -179,5 +180,5 @@ karaf:
                 port: 45444
 ```
 Config specified will be written to:
-- `etc/org.apache.karaf.shell.cfg` for content under `ssh`.
+- `etc/org.apache.karaf.shell.cfg` for content under `shell`.
 - `etc/org.apache.karaf.management.cfg` for content under `management`.

--- a/opennms-container/minion/CONFD_README.md
+++ b/opennms-container/minion/CONFD_README.md
@@ -161,3 +161,23 @@ system:
 ```
 Config specified will be written to `etc/confd.system.properties` which gets automatically appended to `etc/system.properties`. Additionally, provided the
 `jaeger-agent-host` key is specified, `etc/featuresBoot.d/jaeger.boot` will also be updated.
+
+### Karaf Properties
+```
+---
+karaf:
+    ssh:
+        host: "127.0.0.1"
+        port: 8201
+    management:
+        rmi:
+            registry:
+                host: "127.0.0.1"
+                port: 1299
+            server:
+                host: "127.0.0.1"
+                port: 45444
+```
+Config specified will be written to:
+- `etc/org.apache.karaf.shell.cfg` for content under `ssh`.
+- `etc/org.apache.karaf.management.cfg` for content under `management`.

--- a/opennms-container/minion/CONFD_README.md
+++ b/opennms-container/minion/CONFD_README.md
@@ -183,11 +183,12 @@ Config specified will be written to:
 - `etc/org.apache.karaf.shell.cfg` for content under `shell`.
 - `etc/org.apache.karaf.management.cfg` for content under `management`.
 
-### Jolokia Properties
+### Jetty Properties
 ```
 ---
-jolokia:
+jetty:
     web:
+        host: "0.0.0.0"
         port: 8181
 ```
 Config specified will be written to `etc/org.ops4j.pax.web.cfg`

--- a/opennms-container/minion/CONFD_README.md
+++ b/opennms-container/minion/CONFD_README.md
@@ -182,3 +182,12 @@ karaf:
 Config specified will be written to:
 - `etc/org.apache.karaf.shell.cfg` for content under `shell`.
 - `etc/org.apache.karaf.management.cfg` for content under `management`.
+
+### Jolokia Properties
+```
+---
+jolokia:
+    web:
+        port: 8181
+```
+Config specified will be written to `etc/org.ops4j.pax.web.cfg`

--- a/opennms-container/minion/container-fs/confd/conf.d/org.apache.karaf.management.cfg.toml
+++ b/opennms-container/minion/container-fs/confd/conf.d/org.apache.karaf.management.cfg.toml
@@ -1,0 +1,9 @@
+[template]
+src = "org.apache.karaf.management.cfg.tmpl"
+dest = "/opt/minion/etc/org.apache.karaf.management.cfg"
+keys = [
+    "/karaf/management/rmi/registry/host",
+    "/karaf/management/rmi/registry/port",
+    "/karaf/management/rmi/server/host",
+    "/karaf/management/rmi/server/port"
+]

--- a/opennms-container/minion/container-fs/confd/conf.d/org.apache.karaf.management.cfg.toml
+++ b/opennms-container/minion/container-fs/confd/conf.d/org.apache.karaf.management.cfg.toml
@@ -2,8 +2,5 @@
 src = "org.apache.karaf.management.cfg.tmpl"
 dest = "/opt/minion/etc/org.apache.karaf.management.cfg"
 keys = [
-    "/karaf/management/rmi/registry/host",
-    "/karaf/management/rmi/registry/port",
-    "/karaf/management/rmi/server/host",
-    "/karaf/management/rmi/server/port"
+    "/karaf/management/rmi"
 ]

--- a/opennms-container/minion/container-fs/confd/conf.d/org.apache.karaf.shell.cfg.toml
+++ b/opennms-container/minion/container-fs/confd/conf.d/org.apache.karaf.shell.cfg.toml
@@ -2,6 +2,6 @@
 src = "org.apache.karaf.shell.cfg.tmpl"
 dest = "/opt/minion/etc/org.apache.karaf.shell.cfg"
 keys = [
-    "/karaf/ssh/host",
-    "/karaf/ssh/port"
+    "/karaf/shell/ssh/host",
+    "/karaf/shell/ssh/port"
 ]

--- a/opennms-container/minion/container-fs/confd/conf.d/org.apache.karaf.shell.cfg.toml
+++ b/opennms-container/minion/container-fs/confd/conf.d/org.apache.karaf.shell.cfg.toml
@@ -1,0 +1,7 @@
+[template]
+src = "org.apache.karaf.shell.cfg.tmpl"
+dest = "/opt/minion/etc/org.apache.karaf.shell.cfg"
+keys = [
+    "/karaf/ssh/host",
+    "/karaf/ssh/port"
+]

--- a/opennms-container/minion/container-fs/confd/conf.d/org.apache.karaf.shell.cfg.toml
+++ b/opennms-container/minion/container-fs/confd/conf.d/org.apache.karaf.shell.cfg.toml
@@ -2,6 +2,5 @@
 src = "org.apache.karaf.shell.cfg.tmpl"
 dest = "/opt/minion/etc/org.apache.karaf.shell.cfg"
 keys = [
-    "/karaf/shell/ssh/host",
-    "/karaf/shell/ssh/port"
+    "/karaf/shell/ssh"
 ]

--- a/opennms-container/minion/container-fs/confd/conf.d/org.ops4j.pax.web.cfg.toml
+++ b/opennms-container/minion/container-fs/confd/conf.d/org.ops4j.pax.web.cfg.toml
@@ -2,5 +2,6 @@
 src = "org.ops4j.pax.web.cfg.tmpl"
 dest = "/opt/minion/etc/org.ops4j.pax.web.cfg"
 keys = [
-    "/jolokia/web/port"
+    "/jetty/web/host",
+    "/jetty/web/port"
 ]

--- a/opennms-container/minion/container-fs/confd/conf.d/org.ops4j.pax.web.cfg.toml
+++ b/opennms-container/minion/container-fs/confd/conf.d/org.ops4j.pax.web.cfg.toml
@@ -2,6 +2,5 @@
 src = "org.ops4j.pax.web.cfg.tmpl"
 dest = "/opt/minion/etc/org.ops4j.pax.web.cfg"
 keys = [
-    "/jetty/web/host",
-    "/jetty/web/port"
+    "/jetty/web"
 ]

--- a/opennms-container/minion/container-fs/confd/conf.d/org.ops4j.pax.web.cfg.toml
+++ b/opennms-container/minion/container-fs/confd/conf.d/org.ops4j.pax.web.cfg.toml
@@ -1,0 +1,6 @@
+[template]
+src = "org.ops4j.pax.web.cfg.tmpl"
+dest = "/opt/minion/etc/org.ops4j.pax.web.cfg"
+keys = [
+    "/jolokia/web/port"
+]

--- a/opennms-container/minion/container-fs/confd/templates/org.apache.karaf.management.cfg.tmpl
+++ b/opennms-container/minion/container-fs/confd/templates/org.apache.karaf.management.cfg.tmpl
@@ -1,0 +1,104 @@
+
+#
+# The properties in this file define the configuration of Apache Karaf's JMX Management
+#
+
+#
+# Port number for RMI registry connection
+#
+rmiRegistryPort = {{getv "/karaf/management/rmi/registry/port" "1299"}}
+
+#
+# Host for RMI registry
+#
+rmiRegistryHost = {{getv "/karaf/management/rmi/registry/host" "127.0.0.1"}}
+
+#
+# Port number for RMI server connection
+#
+rmiServerPort = {{getv "/karaf/management/rmi/server/port" "45444"}}
+
+#
+# Host for RMI server
+#
+rmiServerHost = {{getv "/karaf/management/rmi/server/host" "127.0.0.1"}}
+
+#
+# Name of the JAAS realm used for authentication
+#
+jmxRealm = karaf
+
+#
+# The service URL for the JMXConnectorServer
+#
+serviceUrl = service:jmx:rmi://${rmiServerHost}:${rmiServerPort}/jndi/rmi://${rmiRegistryHost}:${rmiRegistryPort}/karaf-${karaf.name}
+
+#
+# Whether any threads started for the JMXConnectorServer should be started as daemon threads
+#
+daemon = true
+
+#
+# Whether the JMXConnectorServer should be started in a separate thread
+#
+threaded = true
+
+#
+# The ObjectName used to register the JMXConnectorServer
+#
+objectName = connector:name=rmi
+
+#
+# Timeout to lookup for the keystore in case of SSL authentication usage
+#
+#keyStoreAvailabilityTimeout = 5000
+
+#
+# The type of authentication
+#
+#authenticatorType = password
+
+#
+# Enable or not SSL/TLS
+#
+#secured = false
+
+#
+# Secure algorithm to use
+#
+#secureAlgorithm = default
+
+#
+# Secure protocol to use
+#
+#secureProtocol = TLS
+
+#
+# Keystore to use for secure mode
+#
+#keyStore = karaf.ks
+
+#
+# Alias of the key to use in the keystore
+#
+#keyAlias = karaf
+
+#
+# Truststore to use for secure mode
+#
+#trustStore = karaf.ts
+
+#
+# Create the JMX RMI registry
+#
+#createRmiRegistry = true
+
+#
+# Locate the JMX RMI registry
+#
+#locateRmiRegistry = true
+
+#
+# Locate an existing MBean server if possible (usefull when Karaf is embedded)
+#
+#locateExistingMBeanServerIfPossible = true

--- a/opennms-container/minion/container-fs/confd/templates/org.apache.karaf.management.cfg.tmpl
+++ b/opennms-container/minion/container-fs/confd/templates/org.apache.karaf.management.cfg.tmpl
@@ -1,3 +1,6 @@
+#
+# DON'T EDIT THIS FILE :: GENERATED WITH CONFD
+#
 
 #
 # The properties in this file define the configuration of Apache Karaf's JMX Management

--- a/opennms-container/minion/container-fs/confd/templates/org.apache.karaf.management.cfg.tmpl
+++ b/opennms-container/minion/container-fs/confd/templates/org.apache.karaf.management.cfg.tmpl
@@ -5,26 +5,29 @@
 #
 # The properties in this file define the configuration of Apache Karaf's JMX Management
 #
+{{$karafRmiPath := "/karaf/management/rmi" -}}
+{{$karafRmiRegistryPath := (print $karafRmiPath "/registry") -}}
+{{$karafRmiServerPath := (print $karafRmiPath "/server") -}}
 
 #
 # Port number for RMI registry connection
 #
-rmiRegistryPort = {{getv "/karaf/management/rmi/registry/port" "1299"}}
+rmiRegistryPort = {{getv (print $karafRmiRegistryPath "/port") "1299"}}
 
 #
 # Host for RMI registry
 #
-rmiRegistryHost = {{getv "/karaf/management/rmi/registry/host" "127.0.0.1"}}
+rmiRegistryHost = {{getv (print $karafRmiRegistryPath "/host") "127.0.0.1"}}
 
 #
 # Port number for RMI server connection
 #
-rmiServerPort = {{getv "/karaf/management/rmi/server/port" "45444"}}
+rmiServerPort = {{getv (print $karafRmiServerPath "/port") "45444"}}
 
 #
 # Host for RMI server
 #
-rmiServerHost = {{getv "/karaf/management/rmi/server/host" "127.0.0.1"}}
+rmiServerHost = {{getv (print $karafRmiServerPath "/host") "127.0.0.1"}}
 
 #
 # Name of the JAAS realm used for authentication

--- a/opennms-container/minion/container-fs/confd/templates/org.apache.karaf.shell.cfg.tmpl
+++ b/opennms-container/minion/container-fs/confd/templates/org.apache.karaf.shell.cfg.tmpl
@@ -1,3 +1,6 @@
+#
+# DON'T EDIT THIS FILE :: GENERATED WITH CONFD
+#
 sshPort={{getv "/karaf/shell/ssh/port" "8201"}}
 sshHost={{getv "/karaf/shell/ssh/host" "127.0.0.1"}}
 hostKeyFormat=PEM

--- a/opennms-container/minion/container-fs/confd/templates/org.apache.karaf.shell.cfg.tmpl
+++ b/opennms-container/minion/container-fs/confd/templates/org.apache.karaf.shell.cfg.tmpl
@@ -1,0 +1,5 @@
+sshPort={{getv "/karaf/ssh/port" "8201"}}
+sshHost={{getv "/karaf/ssh/host" "127.0.0.1"}}
+hostKeyFormat=PEM
+sshRealm=karaf
+hostKey=${karaf.etc}/host.key

--- a/opennms-container/minion/container-fs/confd/templates/org.apache.karaf.shell.cfg.tmpl
+++ b/opennms-container/minion/container-fs/confd/templates/org.apache.karaf.shell.cfg.tmpl
@@ -1,8 +1,9 @@
 #
 # DON'T EDIT THIS FILE :: GENERATED WITH CONFD
 #
-sshPort={{getv "/karaf/shell/ssh/port" "8201"}}
-sshHost={{getv "/karaf/shell/ssh/host" "127.0.0.1"}}
+{{$karafSshPath := "/karaf/shell/ssh" -}}
+sshPort={{getv (print $karafSshPath "/port") "8201"}}
+sshHost={{getv (print $karafSshPath "/host") "127.0.0.1"}}
 hostKeyFormat=PEM
 sshRealm=karaf
 hostKey=${karaf.etc}/host.key

--- a/opennms-container/minion/container-fs/confd/templates/org.apache.karaf.shell.cfg.tmpl
+++ b/opennms-container/minion/container-fs/confd/templates/org.apache.karaf.shell.cfg.tmpl
@@ -1,5 +1,5 @@
-sshPort={{getv "/karaf/ssh/port" "8201"}}
-sshHost={{getv "/karaf/ssh/host" "127.0.0.1"}}
+sshPort={{getv "/karaf/shell/ssh/port" "8201"}}
+sshHost={{getv "/karaf/shell/ssh/host" "127.0.0.1"}}
 hostKeyFormat=PEM
 sshRealm=karaf
 hostKey=${karaf.etc}/host.key

--- a/opennms-container/minion/container-fs/confd/templates/org.ops4j.pax.web.cfg.tmpl
+++ b/opennms-container/minion/container-fs/confd/templates/org.ops4j.pax.web.cfg.tmpl
@@ -1,4 +1,7 @@
-
-org.osgi.service.http.port={{getv "/jolokia/web/port" "8181"}}
+#
+# DON'T EDIT THIS FILE :: GENERATED WITH CONFD
+#
+org.osgi.service.http.port={{getv "/jetty/web/port" "8181"}}
+org.ops4j.pax.web.listening.addresses={{getv "/jetty/web/host" "0.0.0.0"}}
 javax.servlet.context.tempdir=${karaf.data}/pax-web-jsp
 org.ops4j.pax.web.config.file=${karaf.etc}/jetty.xml

--- a/opennms-container/minion/container-fs/confd/templates/org.ops4j.pax.web.cfg.tmpl
+++ b/opennms-container/minion/container-fs/confd/templates/org.ops4j.pax.web.cfg.tmpl
@@ -1,0 +1,4 @@
+
+org.osgi.service.http.port={{getv "/jolokia/web/port" "8181"}}
+javax.servlet.context.tempdir=${karaf.data}/pax-web-jsp
+org.ops4j.pax.web.config.file=${karaf.etc}/jetty.xml

--- a/opennms-container/minion/container-fs/confd/templates/org.ops4j.pax.web.cfg.tmpl
+++ b/opennms-container/minion/container-fs/confd/templates/org.ops4j.pax.web.cfg.tmpl
@@ -1,7 +1,8 @@
 #
 # DON'T EDIT THIS FILE :: GENERATED WITH CONFD
 #
-org.osgi.service.http.port={{getv "/jetty/web/port" "8181"}}
-org.ops4j.pax.web.listening.addresses={{getv "/jetty/web/host" "0.0.0.0"}}
+{{$jettyWebPath := "/jetty/web" -}}
+org.osgi.service.http.port={{getv (print $jettyWebPath "/port") "8181"}}
+org.ops4j.pax.web.listening.addresses={{getv (print $jettyWebPath "/host") "0.0.0.0"}}
 javax.servlet.context.tempdir=${karaf.data}/pax-web-jsp
 org.ops4j.pax.web.config.file=${karaf.etc}/jetty.xml

--- a/smoke-test/src/main/resources/minion-config/minion-config.yaml
+++ b/smoke-test/src/main/resources/minion-config/minion-config.yaml
@@ -22,3 +22,9 @@ telemetry:
 netmgt:
   traps:
     trapd.listen.interface: "0.0.0.0"
+
+karaf:
+  shell:
+    ssh:
+      host: "0.0.0.0"
+      port: 8201

--- a/smoke-test/src/main/resources/minion-config/minion-config.yaml
+++ b/smoke-test/src/main/resources/minion-config/minion-config.yaml
@@ -27,4 +27,3 @@ karaf:
   shell:
     ssh:
       host: "0.0.0.0"
-      port: 8201


### PR DESCRIPTION
This PR adds new CONFD templates for configuring minion - specifically, the karaf SSH port and the "management" ports (RMI server and registry).

### All Contributors

* [x] Have you read and followed our [Contribution Guidelines](https://github.com/OpenNMS/opennms/blob/develop/CONTRIBUTING.md)?
* [x] Have you [made an issue in the OpenNMS issue tracker](https://issues.opennms.org)?<br>If so, you should:
  1. update the title of this PR to be of the format: `${JIRA-ISSUE-NUMBER}: subject of pull request`
  2. update the JIRA link at the bottom of this comment to refer to the real issue number
  3. prefix your commit messages with the issue number, if possible
* [x] Have you made a comment in that issue which points back to this PR?
* [x] Have you updated the JIRA link at the bottom of this comment to link to your issue?
* [x] If this is a new or updated feature, is there documentation for the new behavior?
* [x] If this is new code, are there unit and/or integration tests?
* [x] If this PR targets a `foundation-*` branch, does it avoid changing files in `$OPENNMS_HOME/etc/`?

### Pull Request Process

One or more reviewers should be assigned to each PR.

If you know that a particular person is subject matter expert in the area your PR affects, feel free to assign one or more reviewers when you create this PR, otherwise reviewers will be assigned for you.

Once the reviewer(s) accept the PR and the branch passes continuous integration in Bamboo, the PR is eligible for merge.

At that time, if you have commit access (are an OpenNMS Group employee or a member of the Order of the Green Polo) you are welcome to merge the PR.
Otherwise, a reviewer can merge it for you.

Thanks for taking time to contribute!

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-12687
* Bamboo (Continuous Integration): https://bamboo.opennms.org/

