### PR TITLE
NMS-12391: Use bulkhead to restrict number of threads

### DIFF
--- a/container/features/src/main/resources/features.xml
+++ b/container/features/src/main/resources/features.xml
@@ -542,6 +542,7 @@
         <feature>opennms-kafka</feature>
         <feature>opennms-core-ipc-rpc-api</feature>
         <feature>opennms-core-ipc-kafka-shell</feature>
+        <feature>resilience4j</feature>
         <bundle>mvn:org.opennms.core.health/org.opennms.core.health.api/${project.version}</bundle>
         <bundle>mvn:org.opennms.core.ipc.common/org.opennms.core.ipc.common.kafka/${project.version}</bundle>
         <bundle>mvn:org.opennms.core.ipc.rpc/org.opennms.core.ipc.rpc.kafka/${project.version}</bundle>

--- a/core/ipc/common/kafka/src/main/java/org/opennms/core/ipc/common/kafka/KafkaRpcConstants.java
+++ b/core/ipc/common/kafka/src/main/java/org/opennms/core/ipc/common/kafka/KafkaRpcConstants.java
@@ -31,27 +31,33 @@ package org.opennms.core.ipc.common.kafka;
 import java.util.Properties;
 
 import org.opennms.core.sysprops.SystemProperties;
+import org.opennms.core.utils.PropertiesUtils;
 
 /**
  * This handles all the configuration specific to RPC and some utils common to OpenNMS/Minion.
  */
 public interface KafkaRpcConstants {
 
-    public static final String KAFKA_RPC_CONFIG_PID = "org.opennms.core.ipc.rpc.kafka";
-    public static final String KAFKA_RPC_CONFIG_SYS_PROP_PREFIX = KAFKA_RPC_CONFIG_PID + ".";
-    public static final String RPC_TOPIC_PREFIX = "rpc";
-    public static final String RPC_REQUEST_TOPIC_NAME = "rpc-request";
-    public static final String RPC_RESPONSE_TOPIC_NAME = "rpc-response";
-    public static final String SINGLE_TOPIC_FOR_ALL_MODULES = "single-topic";
+    String KAFKA_RPC_CONFIG_PID = "org.opennms.core.ipc.rpc.kafka";
+    String KAFKA_RPC_CONFIG_SYS_PROP_PREFIX = KAFKA_RPC_CONFIG_PID + ".";
+    String RPC_TOPIC_PREFIX = "rpc";
+    String RPC_REQUEST_TOPIC_NAME = "rpc-request";
+    String RPC_RESPONSE_TOPIC_NAME = "rpc-response";
+    String SINGLE_TOPIC_FOR_ALL_MODULES = "single-topic";
     //By default, kafka allows 1MB buffer sizes, here rpcContent (refer to proto/rpc.proto) is limited to 900KB to allow space for other parameters in proto file.
-    public static final int MAX_BUFFER_SIZE_CONFIGURED = 921600;
-    public static final String MAX_BUFFER_SIZE_PROPERTY = "max.buffer.size";
+    int MAX_BUFFER_SIZE_CONFIGURED = 921600;
+    String MAX_BUFFER_SIZE_PROPERTY = "max.buffer.size";
+    String MAX_CONCURRENT_CALLS_PROPERTY = "max.concurrent.calls";
+    String MAX_DURATION_BULK_HEAD = "max.wait.time";
     //Configurable buffer size in system properties but it should always be less than MAX_BUFFER_SIZE_CONFIGURED
-    public static final Integer MAX_BUFFER_SIZE = Math.min(MAX_BUFFER_SIZE_CONFIGURED, SystemProperties.getInteger(String.format("%s%s", KAFKA_RPC_CONFIG_SYS_PROP_PREFIX, MAX_BUFFER_SIZE_PROPERTY), MAX_BUFFER_SIZE_CONFIGURED));
-    public static final long DEFAULT_TTL_CONFIGURED = 20000;
-    public static final String DEFAULT_TTL_PROPERTY = "ttl";
-    public static final long DEFAULT_TTL = SystemProperties.getLong(String.format("%s%s", KAFKA_RPC_CONFIG_SYS_PROP_PREFIX, DEFAULT_TTL_PROPERTY),
+    Integer MAX_BUFFER_SIZE = Math.min(MAX_BUFFER_SIZE_CONFIGURED, SystemProperties.getInteger(String.format("%s%s", KAFKA_RPC_CONFIG_SYS_PROP_PREFIX, MAX_BUFFER_SIZE_PROPERTY), MAX_BUFFER_SIZE_CONFIGURED));
+    long DEFAULT_TTL_CONFIGURED = 20000;
+    String DEFAULT_TTL_PROPERTY = "ttl";
+    long DEFAULT_TTL = SystemProperties.getLong(String.format("%s%s", KAFKA_RPC_CONFIG_SYS_PROP_PREFIX, DEFAULT_TTL_PROPERTY),
             DEFAULT_TTL_CONFIGURED);
+    int MAX_CONCURRENT_CALLS = 1000;
+    int MAX_WAIT_DURATION_BULK_HEAD = 100; // 100msec.
+
 
     // Calculate remaining buffer size for each chunk.
     static int getBufferSize(int messageSize, int maxBufferSize, int chunk) {
@@ -67,7 +73,7 @@ public interface KafkaRpcConstants {
     static int getMaxBufferSize(Properties properties) {
         int maxBufferSize = MAX_BUFFER_SIZE_CONFIGURED;
         try {
-            maxBufferSize = Math.min(MAX_BUFFER_SIZE_CONFIGURED, Integer.parseInt(properties.getProperty(MAX_BUFFER_SIZE_PROPERTY)));
+            maxBufferSize = Math.min(MAX_BUFFER_SIZE_CONFIGURED, PropertiesUtils.getProperty(properties, MAX_BUFFER_SIZE_PROPERTY, MAX_BUFFER_SIZE));
         } catch (NumberFormatException e) {
             // pass
         }

--- a/core/ipc/rpc/api/src/main/java/org/opennms/core/rpc/api/RpcClientFactory.java
+++ b/core/ipc/rpc/api/src/main/java/org/opennms/core/rpc/api/RpcClientFactory.java
@@ -42,7 +42,8 @@ public interface RpcClientFactory {
     String LOG_PREFIX = "ipc";
     // RPC Metrics related constants.
     String JMX_DOMAIN_RPC = "org.opennms.core.ipc.rpc";
-    String RPC_COUNT = "requestSent";
+    String RPC_REQUEST_SENT = "requestSent";
+    String RPC_REQUESTS_RECEIVED = "requestsReceived";
     String RPC_FAILED = "requestFailed";
     String RPC_DURATION = "duration";
     String RPC_REQUEST_SIZE = "requestSize";
@@ -57,7 +58,7 @@ public interface RpcClientFactory {
     }
 
     static void markRpcCount(MetricRegistry metricRegistry, String location, String moduleId) {
-        Meter rpcCount = metricRegistry.meter(MetricRegistry.name(location, moduleId, RPC_COUNT));
+        Meter rpcCount = metricRegistry.meter(MetricRegistry.name(location, moduleId, RPC_REQUEST_SENT));
         rpcCount.mark();
     }
 

--- a/core/ipc/rpc/camel/src/main/java/org/opennms/core/rpc/camel/CamelRpcClientFactory.java
+++ b/core/ipc/rpc/camel/src/main/java/org/opennms/core/rpc/camel/CamelRpcClientFactory.java
@@ -214,7 +214,7 @@ public class CamelRpcClientFactory implements RpcClientFactory {
                     // Ensure that future log statements on this thread are routed properly
                     Logging.putPrefix(RpcClientFactory.LOG_PREFIX);
                 }
-                final Meter requestSentMeter = getMetrics().meter(MetricRegistry.name(request.getLocation(), module.getId(), RPC_COUNT));
+                final Meter requestSentMeter = getMetrics().meter(MetricRegistry.name(request.getLocation(), module.getId(), RPC_REQUEST_SENT));
                 requestSentMeter.mark();
                 return future;
             }

--- a/core/ipc/rpc/kafka/pom.xml
+++ b/core/ipc/rpc/kafka/pom.xml
@@ -102,6 +102,11 @@
         <artifactId>org.opennms.core.tracing.api</artifactId>
         <version>${project.version}</version>
       </dependency>
+      <dependency>
+        <groupId>io.github.resilience4j</groupId>
+        <artifactId>resilience4j-bulkhead</artifactId>
+        <version>${resilience4jVersion}</version>
+      </dependency>
      <dependency>
         <groupId>org.opennms.core.test-api</groupId>
         <artifactId>org.opennms.core.test-api.lib</artifactId>

--- a/core/ipc/rpc/kafka/src/main/java/org/opennms/core/ipc/rpc/kafka/KafkaRpcClientFactory.java
+++ b/core/ipc/rpc/kafka/src/main/java/org/opennms/core/ipc/rpc/kafka/KafkaRpcClientFactory.java
@@ -239,7 +239,7 @@ public class KafkaRpcClientFactory implements RpcClientFactory {
             }
 
             private void addMetrics(RpcRequest request, int messageLen) {
-                final Meter requestSentMeter = getMetrics().meter(MetricRegistry.name(request.getLocation(), module.getId(), RPC_COUNT));
+                final Meter requestSentMeter = getMetrics().meter(MetricRegistry.name(request.getLocation(), module.getId(), RPC_REQUEST_SENT));
                 requestSentMeter.mark();
                 final Histogram rpcRequestSize = getMetrics().histogram(MetricRegistry.name(request.getLocation(), module.getId(), RPC_REQUEST_SIZE));
                 rpcRequestSize.update(messageLen);

--- a/core/ipc/rpc/kafka/src/main/java/org/opennms/core/ipc/rpc/kafka/KafkaRpcServerManager.java
+++ b/core/ipc/rpc/kafka/src/main/java/org/opennms/core/ipc/rpc/kafka/KafkaRpcServerManager.java
@@ -31,8 +31,8 @@ package org.opennms.core.ipc.rpc.kafka;
 import static org.opennms.core.ipc.common.kafka.KafkaRpcConstants.MAX_CONCURRENT_CALLS_PROPERTY;
 import static org.opennms.core.ipc.common.kafka.KafkaRpcConstants.MAX_DURATION_BULK_HEAD;
 import static org.opennms.core.ipc.common.kafka.KafkaRpcConstants.SINGLE_TOPIC_FOR_ALL_MODULES;
-import static org.opennms.core.rpc.api.RpcClientFactory.RPC_COUNT;
 import static org.opennms.core.rpc.api.RpcClientFactory.RPC_FAILED;
+import static org.opennms.core.rpc.api.RpcClientFactory.RPC_REQUESTS_RECEIVED;
 import static org.opennms.core.tracing.api.TracerConstants.TAG_LOCATION;
 import static org.opennms.core.tracing.api.TracerConstants.TAG_RPC_FAILED;
 import static org.opennms.core.tracing.api.TracerConstants.TAG_SYSTEM_ID;
@@ -368,7 +368,7 @@ public class KafkaRpcServerManager {
             setTagsOnMinion(rpcRequestProto, request, minionSpan);
             // Modules may run the execution in their own thread pool.
             CompletableFuture<RpcResponse> future = module.execute(request);
-            final Meter requestSentMeter = getMetrics().meter(MetricRegistry.name(request.getLocation(), module.getId(), RPC_COUNT));
+            final Meter requestSentMeter = getMetrics().meter(MetricRegistry.name(module.getId(), RPC_REQUESTS_RECEIVED));
             requestSentMeter.mark();
             future.whenComplete((res, ex) -> {
                 final RpcResponse response;
@@ -378,7 +378,7 @@ public class KafkaRpcServerManager {
                     response = module.createResponseWithException(ex);
                     minionSpan.log(ex.getMessage());
                     minionSpan.setTag(TAG_RPC_FAILED, "true");
-                    Meter failedMeter = getMetrics().meter(MetricRegistry.name(request.getLocation(), module.getId(), RPC_FAILED));
+                    Meter failedMeter = getMetrics().meter(MetricRegistry.name(module.getId(), RPC_FAILED));
                     failedMeter.mark();
                 } else {
                     // No exception occurred, use the given response

--- a/core/ipc/rpc/kafka/src/main/resources/OSGI-INF/blueprint/blueprint-rpc-kafka-server.xml
+++ b/core/ipc/rpc/kafka/src/main/resources/OSGI-INF/blueprint/blueprint-rpc-kafka-server.xml
@@ -36,6 +36,7 @@
       <argument ref="kafkaConfigProvider"/>
       <argument ref="minionIdentity"/>
       <argument ref="tracerRegistry"/>
+      <argument ref="metricRegistry"/>
     </bean>
 
     <reference-list id="rpcModulesRef" interface="org.opennms.core.rpc.api.RpcModule" availability="optional">
@@ -50,5 +51,28 @@
         <argument value="RPC" />
       </bean>
     </service>
+
+     <!-- Kafka RPC Metrics -->
+    <bean id="metricRegistry" class="com.codahale.metrics.MetricRegistry"/>
+    <service ref="metricRegistry" interface="com.codahale.metrics.MetricSet">
+      <service-properties>
+        <entry key="name" value="Minion Kafka RPC" />
+        <entry key="description" value="Kafka RPC Metrics on Minion" />
+      </service-properties>
+    </service>
+
+    <bean id="metricRegistryJmxReporterBuilder" class="com.codahale.metrics.JmxReporter" factory-method="forRegistry">
+      <argument ref="metricRegistry"/>
+    </bean>
+
+    <bean id="metricRegistryDomainedJmxReporterBuilder" factory-ref="metricRegistryJmxReporterBuilder" factory-method="inDomain">
+      <argument value="org.opennms.core.ipc.rpc.kafka"/>
+    </bean>
+
+    <bean id="metricRegistryJmxReporter"
+          factory-ref="metricRegistryJmxReporterBuilder"
+          factory-method="build"
+          init-method="start"
+          destroy-method="stop" />
 
 </blueprint>

--- a/core/ipc/rpc/kafka/src/test/java/org/opennms/core/ipc/rpc/kafka/RpcKafkaConsumerAsyncIT.java
+++ b/core/ipc/rpc/kafka/src/test/java/org/opennms/core/ipc/rpc/kafka/RpcKafkaConsumerAsyncIT.java
@@ -54,6 +54,8 @@ import org.opennms.distributed.core.api.MinionIdentity;
 import org.opennms.test.ThreadLocker;
 import org.osgi.service.cm.ConfigurationAdmin;
 
+import com.codahale.metrics.MetricRegistry;
+
 /**
  * This test verifies that the response handling is asynchronous in nature.
  * On opennms side all module responses are retrieved in single thread then the responses are handled in different threads asynchronously.
@@ -91,7 +93,8 @@ public class RpcKafkaConsumerAsyncIT {
         when(configAdmin.getConfiguration(KAFKA_CONFIG_PID).getProperties())
                 .thenReturn(kafkaConfig);
         minionIdentity = new MockMinionIdentity(REMOTE_LOCATION_NAME);
-        kafkaRpcServer = new KafkaRpcServerManager(new OsgiKafkaConfigProvider(KAFKA_CONFIG_PID, configAdmin), minionIdentity, RpcKafkaIT.tracerRegistry);
+        kafkaRpcServer = new KafkaRpcServerManager(new OsgiKafkaConfigProvider(KAFKA_CONFIG_PID, configAdmin), minionIdentity, RpcKafkaIT.tracerRegistry,
+                new MetricRegistry());
         kafkaRpcServer.init();
         kafkaRpcServer.bind(echoRpcModule);
     }

--- a/core/ipc/rpc/kafka/src/test/java/org/opennms/core/ipc/rpc/kafka/RpcKafkaIT.java
+++ b/core/ipc/rpc/kafka/src/test/java/org/opennms/core/ipc/rpc/kafka/RpcKafkaIT.java
@@ -31,6 +31,7 @@ package org.opennms.core.ipc.rpc.kafka;
 import static com.jayway.awaitility.Awaitility.await;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThan;
 import static org.junit.Assert.assertEquals;
@@ -83,8 +84,10 @@ import io.opentracing.util.GlobalTracer;
 public class RpcKafkaIT {
 
     private static final String KAFKA_CONFIG_PID = "org.opennms.core.ipc.rpc.kafka.";
-    public static final String REMOTE_LOCATION_NAME = "remote";
-    public static final String MAX_BUFFER_SIZE = "1000000";
+    private static final String REMOTE_LOCATION_NAME = "remote";
+    private static final String MAX_BUFFER_SIZE = "1000000";
+    static final String MAX_CONCURRENT_CALLS = "500";
+    static final String MAX_DURATION_BULK_HEAD = "1000";
 
 
     @Rule
@@ -122,6 +125,8 @@ public class RpcKafkaIT {
         System.setProperty(String.format("%s%s", KAFKA_CONFIG_PID, ConsumerConfig.AUTO_OFFSET_RESET_CONFIG), "earliest");
         kafkaConfig.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaServer.getKafkaConnectString());
         kafkaConfig.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        kafkaConfig.put(KafkaRpcConstants.MAX_CONCURRENT_CALLS_PROPERTY, MAX_CONCURRENT_CALLS);
+        kafkaConfig.put(KafkaRpcConstants.MAX_DURATION_BULK_HEAD, MAX_DURATION_BULK_HEAD);
         ConfigurationAdmin configAdmin = mock(ConfigurationAdmin.class, RETURNS_DEEP_STUBS);
         when(configAdmin.getConfiguration(KafkaRpcConstants.KAFKA_RPC_CONFIG_PID).getProperties())
                 .thenReturn(kafkaConfig);
@@ -237,6 +242,28 @@ public class RpcKafkaIT {
         }
         await().atMost(45, TimeUnit.SECONDS).untilAtomic(count, equalTo(maxRequests));
     }
+
+
+    @Test(timeout = 60000)
+    public void testBulkAheadPatternForMinion() {
+        assertEquals(500, getKafkaRpcServer().getBulkhead().getMetrics().getMaxAllowedConcurrentCalls());
+        assertEquals(500, getKafkaRpcServer().getBulkhead().getMetrics().getAvailableConcurrentCalls());
+        EchoRequest request = new EchoRequest("Kafka-RPC");
+        request.setId(System.currentTimeMillis());
+        request.setLocation(REMOTE_LOCATION_NAME);
+        request.setDelay(5000L);
+        count.set(0);
+        // Send 1000 requests.
+        int maxRequests = 1000;
+        for (int i = 0; i < maxRequests; i++) {
+            sendRequestAndVerifyResponse(request, 0);
+        }
+        await().atMost(5, TimeUnit.SECONDS).until(() -> getKafkaRpcServer().getBulkhead().getMetrics().getAvailableConcurrentCalls(), is(0));
+
+        await().atMost(45, TimeUnit.SECONDS).untilAtomic(count, equalTo(maxRequests));
+        assertThat(getKafkaRpcServer().getBulkhead().getMetrics().getAvailableConcurrentCalls(), greaterThanOrEqualTo(500));
+    }
+
 
     @SuppressWarnings("unused")
     @Test(timeout = 60000)

--- a/core/ipc/rpc/kafka/src/test/java/org/opennms/core/ipc/rpc/kafka/RpcKafkaWithSingleTopicIT.java
+++ b/core/ipc/rpc/kafka/src/test/java/org/opennms/core/ipc/rpc/kafka/RpcKafkaWithSingleTopicIT.java
@@ -98,6 +98,8 @@ public class RpcKafkaWithSingleTopicIT extends RpcKafkaIT {
         kafkaConfig.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaServer.getKafkaConnectString());
         kafkaConfig.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
         kafkaConfig.put(KafkaRpcConstants.SINGLE_TOPIC_FOR_ALL_MODULES, "true");
+        kafkaConfig.put(KafkaRpcConstants.MAX_CONCURRENT_CALLS_PROPERTY, MAX_CONCURRENT_CALLS);
+        kafkaConfig.put(KafkaRpcConstants.MAX_DURATION_BULK_HEAD, MAX_DURATION_BULK_HEAD);
         ConfigurationAdmin configAdmin = mock(ConfigurationAdmin.class, RETURNS_DEEP_STUBS);
         when(configAdmin.getConfiguration(KafkaRpcConstants.KAFKA_RPC_CONFIG_PID).getProperties())
                 .thenReturn(kafkaConfig);

--- a/core/ipc/rpc/kafka/src/test/java/org/opennms/core/ipc/rpc/kafka/RpcKafkaWithSingleTopicIT.java
+++ b/core/ipc/rpc/kafka/src/test/java/org/opennms/core/ipc/rpc/kafka/RpcKafkaWithSingleTopicIT.java
@@ -47,6 +47,8 @@ import org.opennms.core.tracing.api.TracerRegistry;
 import org.opennms.distributed.core.api.MinionIdentity;
 import org.osgi.service.cm.ConfigurationAdmin;
 
+import com.codahale.metrics.MetricRegistry;
+
 import io.opentracing.Tracer;
 import io.opentracing.util.GlobalTracer;
 
@@ -109,7 +111,7 @@ public class RpcKafkaWithSingleTopicIT extends RpcKafkaIT {
         rpcClient.start();
         minionIdentity = new MockMinionIdentity(REMOTE_LOCATION_NAME);
         kafkaRpcServer = new KafkaRpcServerManager(new OsgiKafkaConfigProvider(KafkaRpcConstants.KAFKA_RPC_CONFIG_PID, configAdmin),
-                minionIdentity,tracerRegistry);
+                minionIdentity,tracerRegistry, new MetricRegistry());
         kafkaRpcServer.init();
         kafkaRpcServer.bind(echoRpcModule);
 

--- a/core/ipc/rpc/kafka/src/test/java/org/opennms/core/ipc/rpc/kafka/RpcTestServer.java
+++ b/core/ipc/rpc/kafka/src/test/java/org/opennms/core/ipc/rpc/kafka/RpcTestServer.java
@@ -38,6 +38,8 @@ import org.opennms.core.rpc.api.RpcResponse;
 import org.opennms.core.tracing.api.TracerRegistry;
 import org.opennms.distributed.core.api.MinionIdentity;
 
+import com.codahale.metrics.MetricRegistry;
+
 /**
  * This overrides @{@link org.opennms.core.ipc.rpc.kafka.KafkaRpcServerManager.KafkaConsumerRunner#sendMessageToKafka(RpcMessageProto, String, String)}
  * to send duplicate message or skip a chunk in between.
@@ -53,7 +55,7 @@ public class RpcTestServer extends KafkaRpcServerManager {
     private KafkaServerConsumer kafkaConsumerRunner;
 
     public RpcTestServer(KafkaConfigProvider configProvider, MinionIdentity minionIdentity, TracerRegistry tracerRegistry) {
-        super(configProvider, minionIdentity, tracerRegistry);
+        super(configProvider, minionIdentity, tracerRegistry, new MetricRegistry());
         this.minionIdentity = minionIdentity;
     }
 

--- a/opennms-doc/guide-admin/src/asciidoc/index.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/index.adoc
@@ -339,6 +339,7 @@ include::text/minion/aws-sqs.adoc[]
 include::text/minion/offheap.adoc[]
 include::text/minion/jdbc-driver.adoc[]
 include::text/minion/ttl.adoc[]
+include::text/minion/kafka-rpc.adoc[]
 
 [[ga-sentinel]]
 == Sentinel

--- a/opennms-doc/guide-admin/src/asciidoc/text/minion/kafka-rpc.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/minion/kafka-rpc.adoc
@@ -1,0 +1,20 @@
+// Allow GitHub image rendering
+:imagesdir: ../../images
+
+===  Tuning Kafka RPC on Minion
+
+To avoid too many requests hogging the system at once, Kafka RPC on Minion limits the maximum number of concurrent RPC requests.
+Currently max number of concurrent requests is set to 1000 with maximum wait time of 100ms.
+With these settings when concurrent requests reach 1000, it only allow 10 extra requests per sec.
+
+These settings can be tuned as below
+
+[source, sh]
+----
+echo 'max.concurrent.calls=1000' >> "$MINION_HOME/etc/org.opennms.core.ipc.rpc.kafka.cfg"
+----
+
+[source, sh]
+----
+echo 'max.wait.time=100' >> "$MINION_HOME/etc/org.opennms.core.ipc.rpc.kafka.cfg"
+----

--- a/opennms-doc/guide-admin/src/asciidoc/text/minion/kafka-rpc.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/minion/kafka-rpc.adoc
@@ -3,11 +3,11 @@
 
 ===  Tuning Kafka RPC on Minion
 
-To avoid too many requests hogging the system at once, Kafka RPC on Minion limits the maximum number of concurrent RPC requests.
-Currently max number of concurrent requests is set to 1000 with maximum wait time of 100ms.
-With these settings when concurrent requests reach 1000, it only allow 10 extra requests per sec.
+To avoid too many requests hogging the system at once, Kafka RPC Client on _Minion_ limits the maximum number of concurrent RPC requests.
+Currently the maximum number of concurrent requests is set to 1,000 with a maximum wait time of 100ms.
+With these settings, when concurrent requests reach 1000, Kafka RPC Client will allow only 10 extra requests per second.
 
-These settings can be tuned as below
+Tune these settings as below:
 
 [source, sh]
 ----


### PR DESCRIPTION
During node scan, one node can have 100/1000s of interfaces and those interfaces
can have 10s of services. When those nodes are on minion, OpenNMS
asynchronously sends all requests to minion. This may result in too many
concurrent requests.

Idea is to restrict number of concurrent requests at a given point.
Using bulkhead to gate requests that are incoming with tunable timeout
Default timeout is 100msecs and max concurrent calls is 1000.
So when 1000 rpc requests are processing currently, only 10 extra requests per sec
will be allowed. This will allow not having a hard limit on threads but also
gives chance to tune the system depending on the load.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-12391
