### PR TITLE
a few more changes to attempt to optimize circleci and maven

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,13 +99,29 @@ commands:
             keys:
               - maven-dependencies-v3-{{ checksum "pom-version-cache.key" }}-{{ checksum "maven-dependency-pom-cache.key" }}
               - maven-dependencies-v3-{{ checksum "pom-version-cache.key" }}-
-        - run:
-            name: Remove OpenNMS artifacts from cache
-            command: |
-              rm -rf ~/.m2/repository/org/opennms
+  update-maven-cache:
+      description: "Maven: Refresh local repository from POM files"
+      steps:
         - run:
             name: Remove old artifacts to keep workspace size down
             command: .circleci/scripts/clean-m2.sh
+        - run:
+            name: Collect Maven Dependencies
+            command: |
+              ./compile.pl -t \
+                -Dbuild.skip.tarball=true \
+                -DupdatePolicy=never \
+                --update-plugins \
+                -Daether.connector.resumeDownloads=false \
+                -Daether.connector.basic.threads=8 \
+                -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn \
+                -Pbuild-bamboo \
+                -Prun-expensive-tasks \
+                -Psmoke \
+                --legacy-local-repository \
+                --batch-mode \
+                --threads 8 \
+                de.qaware.maven:go-offline-maven-plugin:resolve-dependencies
   save-maven-cache:
     description: "Maven: Save cache"
     steps:
@@ -167,11 +183,13 @@ commands:
             sudo swapon /swapfile
             sudo sysctl vm.swappiness=5
             cat /proc/sys/vm/swappiness
+      - restore-workflow-assets:
+          cache_prefix: oci-horizon
       - run:
           name: Load Horizon OCI image
           command: |
             cd opennms-container/horizon
-            docker image load -i images/container.oci
+            docker image load -i /tmp/oci-horizon/container.oci
       - run:
           name: Monitor JVM processes
           background: true
@@ -235,6 +253,8 @@ commands:
       - cached-checkout
       - extract-pom-version
       - restore-maven-cache
+      - update-maven-cache
+      - save-maven-cache
       - restore-nodejs-cache
       - run:
           name: Compile OpenNMS
@@ -243,7 +263,8 @@ commands:
             mvn clean -DskipTests=true
             << parameters.node-memory >>
             ./compile.pl -DskipTests=true -Dbuild.skip.tarball=true \
-              -DupdatePolicy=never -Daether.connector.resumeDownloads=false \
+              -DupdatePolicy=never \
+              -Daether.connector.resumeDownloads=false \
               -Daether.connector.basic.threads=1 \
               -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn \
               -DvaadinJavaMaxMemory=<< parameters.vaadin-javamaxmem >> \
@@ -252,6 +273,7 @@ commands:
               install --batch-mode
             pushd opennms-doc
               ../compile.pl \
+                -DupdatePolicy=never \
                 -Daether.connector.resumeDownloads=false \
                 -Daether.connector.basic.threads=1 \
                 -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn \
@@ -259,7 +281,6 @@ commands:
                 -P'!jdk7+' \
                 install --batch-mode
             popd
-      - save-maven-cache
       - save-nodejs-cache
       - persist_to_workspace:
           root: ~/
@@ -327,14 +348,48 @@ commands:
           when: always
           path: ~/generated-tests
           destination: generated-tests
-  publish-cloudsmith:
+  cache-workflow-assets:
+    parameters:
+      cache_prefix:
+        description: the cache prefix
+        type: string
+      source_path:
+        description: the source path to cache
+        type: string
     steps:
-      - cloudsmith/ensure-api-key
-      - cloudsmith/install-cli
       - run:
-          name: Publish Packages
+          name: Stowing Assets in << parameters.source_path >> to cache prefix << parameters.cache_prefix >>
           command: |
-            .circleci/scripts/publish-cloudsmith.sh
+            TARGET_PATH="/tmp/<< parameters.cache_prefix >>"
+            rsync -ar "$(echo "<< parameters.source_path >>" | sed -e 's,/*$,,')/" "${TARGET_PATH}/"
+            find "${TARGET_PATH}" -type d -print0 | xargs -0 chmod 775
+            find "${TARGET_PATH}" ! -type d -print0 | xargs -0 chmod 664
+      - save_cache:
+          key: << parameters.cache_prefix >>-{{ .Environment.CIRCLE_WORKFLOW_ID }}
+          paths:
+            - "/tmp/<< parameters.cache_prefix >>"
+  restore-workflow-assets:
+    parameters:
+      cache_prefix:
+        description: the cache prefix
+        type: string
+      target_path:
+        description: the target path to restore into
+        type: string
+        default: ""
+    steps:
+      - restore_cache:
+          keys:
+            - << parameters.cache_prefix >>-{{ .Environment.CIRCLE_WORKFLOW_ID }}
+      - when:
+          condition: << parameters.target_path >>
+          steps:
+            - run:
+                name: Restoring assets to << parameters.target_path >> from cached prefix << parameters.cache_prefix >>
+                command: |
+                  SOURCE_PATH="/tmp/<< parameters.cache_prefix >>"
+                  mkdir -p "<< parameters.target_path >>"
+                  rsync -ar "${SOURCE_PATH}/" "$(echo "<< parameters.target_path >>" | sed -e 's,/*$,,')/"
 
 workflows:
   weekly-coverage:
@@ -453,6 +508,7 @@ workflows:
           # if everything passes
           requires:
             - horizon-deb-build
+            - smoke-test-minimal
             - smoke-test-full
           filters:
             branches:
@@ -506,11 +562,12 @@ jobs:
       - store_artifacts:
           path: ~/project/target/rpm/RPMS/noarch
           destination: rpms
-      - persist_to_workspace:
-          root: ~/
-          paths:
-            - project/target/rpm/RPMS/noarch/
-            - project/opennms-container/horizon/images/
+      - cache-workflow-assets:
+          cache_prefix: rpm-horizon
+          source_path: target/rpm/RPMS/noarch
+      - cache-workflow-assets:
+          cache_prefix: oci-horizon
+          source_path: opennms-container/horizon/images/
   horizon-deb-build:
     executor: debian-build-executor
     resource_class: large
@@ -560,15 +617,15 @@ jobs:
       - store_artifacts:
           path: ~/project/target/debs
           destination: debs
-      - persist_to_workspace:
-          root: ~/
-          paths:
-            - project/target/debs/
+      - cache-workflow-assets:
+          cache_prefix: deb-horizon
+          source_path: target/debs
   horizon-publish-oci:
     executor: centos-build-executor
     steps:
-      - attach_workspace:
-          at: ~/
+      - cached-checkout
+      - restore-workflow-assets:
+          cache_prefix: oci-horizon
       - setup_remote_docker:
           docker_layer_caching: true
       - dockerhub-login
@@ -576,7 +633,7 @@ jobs:
           name: Load Horizon OCI image, tag it and publish to registry
           command: |
             cd opennms-container/horizon
-            docker image load -i images/container.oci
+            docker image load -i /tmp/oci-horizon/container.oci
             ./tag.sh
             ./publish.sh
   integration-test:
@@ -734,7 +791,15 @@ jobs:
     executor: cloudsmith/default
     resource_class: small
     steps:
-      - attach_workspace:
-          at: ~/
-      - publish-cloudsmith
+      - checkout
+      - cloudsmith/ensure-api-key
+      - cloudsmith/install-cli
+      - restore-workflow-assets:
+          cache_prefix: deb-horizon
+      - restore-workflow-assets:
+          cache_prefix: rpm-horizon
+      - run:
+          name: Publish Packages
+          command: |
+            .circleci/scripts/publish-cloudsmith.sh
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,7 +120,6 @@ commands:
                 -Psmoke \
                 --legacy-local-repository \
                 --batch-mode \
-                --threads 8 \
                 de.qaware.maven:go-offline-maven-plugin:resolve-dependencies
   save-maven-cache:
     description: "Maven: Save cache"

--- a/.circleci/scripts/itest.sh
+++ b/.circleci/scripts/itest.sh
@@ -23,10 +23,7 @@ find_tests()
 }
 
 echo "#### Generate project structure .json"
-(cd /tmp && mvn -llr org.apache.maven.plugins:maven-dependency-plugin:3.1.1:get \
-      -DremoteRepositories=http://maven.opennms.org/content/groups/opennms.org-release/ \
-      -Dartifact=org.opennms.maven.plugins:structure-maven-plugin:1.0)
-mvn -Prun-expensive-tasks -Pbuild-bamboo org.opennms.maven.plugins:structure-maven-plugin:1.0:structure
+mvn --batch-mode --fail-at-end --legacy-local-repository --offline -Prun-expensive-tasks -Pbuild-bamboo org.opennms.maven.plugins:structure-maven-plugin:1.0:structure
 
 echo "#### Determining tests to run"
 cd ~/project

--- a/.circleci/scripts/publish-cloudsmith.sh
+++ b/.circleci/scripts/publish-cloudsmith.sh
@@ -27,12 +27,10 @@ case "${CIRCLE_BRANCH}" in
     ;;
 esac
 
-find target -type f | sort -u
-
 publishPackage() {
   local _tmpdir;
   _tmpdir="$(mktemp -d 2>/dev/null || mktemp -d -t 'publish_cloudsmith_')"
-  echo "$@"
+  echo "publishing:" "$@"
   "$@" >"${_tmpdir}/publish.log" 2>&1
   ret="$?"
   cat "${_tmpdir}/publish.log"
@@ -45,13 +43,13 @@ publishPackage() {
   return "$ret"
 }
 
-for FILE in target/rpm/RPMS/noarch/*.rpm; do
+for FILE in /tmp/rpm-horizon/*.rpm; do
   # give it 3 tries then die
   publishPackage cloudsmith push rpm --no-wait-for-sync "${PROJECT}/$REPO/any-distro/any-version" "$FILE" ||
   publishPackage cloudsmith push rpm --no-wait-for-sync "${PROJECT}/$REPO/any-distro/any-version" "$FILE" ||
   publishPackage cloudsmith push rpm --no-wait-for-sync "${PROJECT}/$REPO/any-distro/any-version" "$FILE" || exit 1
 done
-for FILE in target/debs/*.deb; do
+for FILE in /tmp/deb-horizon/*.deb; do
   # give it 3 tries then die
   publishPackage cloudsmith push deb --no-wait-for-sync "${PROJECT}/$REPO/any-distro/any-version" "$FILE" ||
   publishPackage cloudsmith push deb --no-wait-for-sync "${PROJECT}/$REPO/any-distro/any-version" "$FILE" ||

--- a/features/topology-map/pom.xml
+++ b/features/topology-map/pom.xml
@@ -46,7 +46,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.1</version>
         <configuration>
           <source>1.8</source>
           <target>1.8</target>

--- a/features/vaadin-components/graph/pom.xml
+++ b/features/vaadin-components/graph/pom.xml
@@ -25,7 +25,6 @@
       <plugins>
         <plugin>
           <artifactId>maven-resources-plugin</artifactId>
-          <version>2.7</version>
           <executions>
             <execution>
               <id>copy-resources</id>

--- a/opennms-full-assembly/pom.xml
+++ b/opennms-full-assembly/pom.xml
@@ -162,7 +162,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-resources-plugin</artifactId>
-        <version>2.5</version>
         <executions>
           <execution>
             <id>copy-filtered-resources</id>

--- a/pom.xml
+++ b/pom.xml
@@ -167,7 +167,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-install-plugin</artifactId>
-        <version>2.5.2</version>
+        <version>${maven.install.plugin.version}</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -810,6 +810,105 @@
           </excludes>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.jvnet.jaxb2.maven2</groupId>
+        <artifactId>maven-jaxb2-plugin</artifactId>
+        <version>0.12.3</version>
+      </plugin>
+      <plugin>
+        <groupId>de.qaware.maven</groupId>
+        <artifactId>go-offline-maven-plugin</artifactId>
+        <version>1.2.5</version>
+        <configuration>
+          <dynamicDependencies>
+            <DynamicDependency>
+              <groupId>org.apache.maven.surefire</groupId>
+              <artifactId>surefire-junit4</artifactId>
+              <version>${maven.surefire.plugin.version}</version>
+              <repositoryType>PLUGIN</repositoryType>
+            </DynamicDependency>
+            <DynamicDependency>
+              <groupId>org.apache.maven.surefire</groupId>
+              <artifactId>surefire-junit4</artifactId>
+              <version>${maven.smoke.surefire.plugin.version}</version>
+              <repositoryType>PLUGIN</repositoryType>
+            </DynamicDependency>
+            <DynamicDependency>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-antrun-plugin</artifactId>
+              <version>${maven.antrun.plugin.version}</version>
+              <repositoryType>PLUGIN</repositoryType>
+            </DynamicDependency>
+            <DynamicDependency>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-assembly-plugin</artifactId>
+              <version>2.5.5</version>
+              <repositoryType>PLUGIN</repositoryType>
+            </DynamicDependency>
+            <DynamicDependency>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-resources-plugin</artifactId>
+              <version>2.5</version> <!-- pulled in by assembly plugin -->
+              <repositoryType>PLUGIN</repositoryType>
+            </DynamicDependency>
+            <DynamicDependency>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-compiler-plugin</artifactId>
+              <version>${maven.compiler.plugin.version}</version>
+              <repositoryType>PLUGIN</repositoryType>
+            </DynamicDependency>
+            <DynamicDependency>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-failsafe-plugin</artifactId>
+              <version>${maven.smoke.surefire.plugin.version}</version>
+              <repositoryType>PLUGIN</repositoryType>
+            </DynamicDependency>
+            <DynamicDependency>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-install-plugin</artifactId>
+              <version>${maven.install.plugin.version}</version>
+              <repositoryType>PLUGIN</repositoryType>
+            </DynamicDependency>
+            <DynamicDependency>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-resources-plugin</artifactId>
+              <version>${maven.resources.plugin.version}</version>
+              <repositoryType>PLUGIN</repositoryType>
+            </DynamicDependency>
+            <DynamicDependency>
+              <groupId>org.opennms.maven.plugins</groupId>
+              <artifactId>structure-maven-plugin</artifactId>
+              <version>1.0</version>
+              <repositoryType>PLUGIN</repositoryType>
+            </DynamicDependency>
+            <!-- ugh, we have a billion versions of gson -->
+            <DynamicDependency>
+              <groupId>com.google.code.gson</groupId>
+              <artifactId>gson</artifactId>
+              <version>2.3.1</version> <!-- selenium-monitor -->
+              <repositoryType>MAIN</repositoryType>
+            </DynamicDependency>
+            <DynamicDependency>
+              <groupId>com.google.code.gson</groupId>
+              <artifactId>gson</artifactId>
+              <version>2.6.2</version> <!-- es-rest -->
+              <repositoryType>MAIN</repositoryType>
+            </DynamicDependency>
+            <DynamicDependency>
+              <groupId>com.google.code.gson</groupId>
+              <artifactId>gson</artifactId>
+              <version>2.8.5</version> <!-- smoke-tests -->
+              <repositoryType>MAIN</repositoryType>
+            </DynamicDependency>
+            <DynamicDependency>
+              <groupId>javax.samples.jnlp</groupId>
+              <artifactId>jnlp-servlet</artifactId>
+              <version>1.6.0</version>
+              <repositoryType>MAIN</repositoryType>
+            </DynamicDependency>
+          </dynamicDependencies>
+        </configuration>
+      </plugin>
     </plugins>
   </pluginManagement>
    <plugins>
@@ -877,7 +976,7 @@
      <plugin>
        <groupId>org.apache.maven.plugins</groupId>
        <artifactId>maven-resources-plugin</artifactId>
-       <version>2.7</version>
+       <version>${maven.resources.plugin.version}</version>
        <configuration>
           <encoding>UTF-8</encoding>
           <escapeString>\</escapeString>
@@ -921,7 +1020,7 @@
      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.3</version>
+        <version>${maven.compiler.plugin.version}</version>
         <configuration>
           <source>1.8</source>
           <target>1.8</target>
@@ -981,7 +1080,6 @@
       <plugin>
         <groupId>org.jvnet.jaxb2.maven2</groupId>
         <artifactId>maven-jaxb2-plugin</artifactId>
-        <version>0.12.3</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -1032,7 +1130,6 @@
       <plugin>
         <groupId>org.jvnet.jaxb2.maven2</groupId>
         <artifactId>maven-jaxb2-plugin</artifactId>
-        <version>0.12.3</version>
       </plugin>
     </plugins>
   </build>
@@ -1168,6 +1265,13 @@
     <maven.pax.plugin.version>1.5</maven.pax.plugin.version>
     <antlr.version>2.7.7</antlr.version>
     <sass.maven.plugin.version>1.1.2-ONMS-20131018-1</sass.maven.plugin.version>
+
+    <!-- other plugin versions -->
+    <maven.smoke.surefire.plugin.version>2.22.2</maven.smoke.surefire.plugin.version> <!-- see smoke-test/pom.xml -->
+    <maven.antrun.plugin.version>1.8</maven.antrun.plugin.version> <!-- see smoke-test/pom.xml -->
+    <maven.compiler.plugin.version>3.3</maven.compiler.plugin.version>
+    <maven.install.plugin.version>2.5.2</maven.install.plugin.version>
+    <maven.resources.plugin.version>3.1.0</maven.resources.plugin.version>
 
     <!-- turn down the default DEBUG logLevel. Override on the command line if you want -->
     <mock.logLevel>WARN</mock.logLevel>
@@ -1481,7 +1585,7 @@
           <plugin>
             <groupId>com.sun.tools.jxc.maven2</groupId>
             <artifactId>maven-jaxb-schemagen-plugin</artifactId>
-            <version>[1.2,2.0)</version>
+            <version>1.2</version>
             <dependencies>
               <dependency>
               <groupId>com.sun</groupId>

--- a/smoke-test/pom.xml
+++ b/smoke-test/pom.xml
@@ -77,6 +77,11 @@
         </configuration>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-install-plugin</artifactId>
+        <version>2.5.2</version>
+      </plugin>
+      <plugin>
          <groupId>org.apache.maven.plugins</groupId>
          <artifactId>maven-resources-plugin</artifactId>
          <version>3.1.0</version>


### PR DESCRIPTION
This is a rollup fix for a couple  of things, most notably attempting to do more priming of the `~/.m2/repository` cache early in the build process, rather than running into failures later down the line because of transient Maven Central errors in the middle of an expensive smoke or integration test run.

While working on this branch, I had enabled full integration tests and OCI/CloudSmith deploy (short-circuited) to make sure those changes work.  I've rebased/removed them now that it's ready to merge.

If we find more things that get (re-)downloaded during itest/smoke we can add them to the `<dynamicDependencies>` section in the `pom.xml` so they get pulled in early during the relatively cheap build phase.

* use a "go-offline" plugin to pull down all dependencies early and change it to store ~/.m2/repository back to the cache _before_ building rather than _after_.
* do not delete org.opennms.* from the ~/.m2/repository before caching (the only things that should be in there are external plugins/dependencies that we've published)
* add `cache-workflow-assets` and `restore-workflow-assets` commands to store rpms/ocis for use in later builds _without_ making the workspace bigger -- this has been causing timeouts during cloudsmith deploy, because it ends up pulling in the workspace from everything through itests and smoke.
* don't pull down `structure-maven-plugin` in itest because it should already be there from `go-offline`
* fix a bug in `pom.xml` for maven-jaxb-schemagen-plugin that the `maven-dependency-plugin` has trouble parsing
* clean up some other pom weirdness that probably only affects foundation 2016