### PR TITLE
NMS-12724: Optimize queuing for throughput.

### DIFF
--- a/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/ParserBase.java
+++ b/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/ParserBase.java
@@ -148,7 +148,7 @@ public abstract class ParserBase implements Parser {
                 // corePoolSize must be > 0 since we use the RejectedExecutionHandler to block when the queue is full
                 1, threads,
                 60L, TimeUnit.SECONDS,
-                new SynchronousQueue<>(true),
+                new SynchronousQueue<>(),
                 threadFactory,
                 (r, executor) -> {
                     // We enter this block when the queue is full and the caller is attempting to submit additional tasks
@@ -217,7 +217,8 @@ public abstract class ParserBase implements Parser {
     }
 
     protected CompletableFuture<?> transmit(final RecordProvider packet, final InetSocketAddress remoteAddress) {
-        LOG.trace("Got packet: {}", packet);
+        // The packets are coming in hot - performance here is critical
+        //   LOG.trace("Got packet: {}", packet);
         // Perform the record enrichment and serialization in a thread pool allowing these to be parallelized
         final CompletableFuture<CompletableFuture[]> futureOfFutures = CompletableFuture.supplyAsync(() -> {
             return packet.getRecords().map(record -> {

--- a/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/session/Template.java
+++ b/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/session/Template.java
@@ -32,6 +32,8 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
@@ -49,6 +51,7 @@ public final class Template implements Iterable<Field> {
 
     public final List<Scope> scopes;
     public final List<Field> fields;
+    public final Set<String> scopeNames;
 
     private Template(final int id,
                      final Type type,
@@ -58,6 +61,9 @@ public final class Template implements Iterable<Field> {
         this.type = Objects.requireNonNull(type);
         this.scopes = Objects.requireNonNull(scopes);
         this.fields = Objects.requireNonNull(fields);
+        // The set of scope names are used when processing packets - so we build it here once
+        // instead of having to re-compute this everytime
+        this.scopeNames = scopes.stream().map(Scope::getName).collect(Collectors.toSet());
     }
 
     public int count() {

--- a/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/session/UdpSessionManager.java
+++ b/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/session/UdpSessionManager.java
@@ -87,13 +87,11 @@ public class UdpSessionManager {
                                                                                                         Objects.equals(e.getKey().observationDomainId, this.observationDomainId))) {
                     final Template template = UdpSessionManager.this.templates.get(e.getKey()).template;
 
-                    final Set<String> scopes = template.scopes.stream().map(Scope::getName).collect(Collectors.toSet());
-
-                    if (scoped.containsAll(scopes)) {
+                    if (scoped.containsAll(template.scopeNames)) {
                         // Found option template where scoped fields is subset of actual data fields
 
                         final Set<Value<?>> scopeValues = values.stream()
-                                .filter(s -> scopes.contains(s.getName()))
+                                .filter(s -> template.scopeNames.contains(s.getName()))
                                 .collect(Collectors.toSet());
 
                         for (final Value<?> value : e.getValue().getOrDefault(scopeValues, Collections.emptyList())) {


### PR DESCRIPTION
JIRA: https://issues.opennms.org/browse/NMS-12724

Running udpgen on against Minion with:
```
taskset -c 0 ./udpgen -x netflow9 -r 0 -p 8877
```

Performance before patch:
```
  parsers.Netflow-9.recordsDispatched
             count = 712561
         mean rate = 3617.46 events/second
     1-minute rate = 6653.68 events/second
     5-minute rate = 2046.41 events/second
    15-minute rate = 738.90 events/second
```

Performance after patch:
```
  parsers.Netflow-9.recordsDispatched
             count = 3421440
         mean rate = 22088.17 events/second
     1-minute rate = 21819.43 events/second
     5-minute rate = 12224.38 events/second
    15-minute rate = 8206.34 events/second
```