### PR TITLE
NMS-12699: Bump Docker image from OpenJDK 11.0.5.10 -> 11.0.7.10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,10 +4,10 @@ version: 2.1
 executors:
   centos-build-executor:
     docker:
-      - image: opennms/build-env:1.8.0.232.b09-3.6.2-b3291
+      - image: opennms/build-env:1.8.0.252.b09-3.6.3-b4168
   debian-build-executor:
     docker:
-      - image: opennms/build-env:debian-jdk8-b3572
+      - image: opennms/build-env:debian-jdk8-b4008
   docker-executor:
     docker:
       - image: docker:19.03.0-git

--- a/opennms-container/horizon/Dockerfile
+++ b/opennms-container/horizon/Dockerfile
@@ -2,7 +2,7 @@
 # Use Java base image and setup required RPMS as cacheable image.
 ##
 ARG BASE_IMAGE="opennms/openjdk"
-ARG BASE_IMAGE_VERSION="11.0.5.10-b3108"
+ARG BASE_IMAGE_VERSION="11.0.7.10-b4096"
 
 FROM ${BASE_IMAGE}:${BASE_IMAGE_VERSION} as horizon-base
 


### PR DESCRIPTION
### All Contributors

* [x] Have you read and followed our [Contribution Guidelines](https://github.com/OpenNMS/opennms/blob/develop/CONTRIBUTING.md)?
* [x] Have you [made an issue in the OpenNMS issue tracker](https://issues.opennms.org)?<br>If so, you should:
  1. update the title of this PR to be of the format: `${JIRA-ISSUE-NUMBER}: subject of pull request`
  2. update the JIRA link at the bottom of this comment to refer to the real issue number
  3. prefix your commit messages with the issue number, if possible
* [x] Have you made a comment in that issue which points back to this PR?
* [x] Have you updated the JIRA link at the bottom of this comment to link to your issue?
* [x] If this is a new or updated feature, is there documentation for the new behavior?
* [x] If this is new code, are there unit and/or integration tests?
* [x] If this PR targets a `foundation-*` branch, does it avoid changing files in `$OPENNMS_HOME/etc/`?

### Pull Request Process

This PR resolves the merge conflict from foundation-2016 and we bump the introduced OpenJDK 11 to the latest version.

### Reviewer hint

I'm not 100% sure if this is the right procedure to resolve auto-merge conflicts, here is what I did:

1. branched from foundation-2019
2. merged with foundation-2016 and resolved the merge conflict
3. bumped the OpenJDK 11

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-12699
