### PR TITLE
OIA-26: Expose intrinsic tag names as constants for TSS API

### DIFF
--- a/features/timeseries/src/main/java/org/opennms/netmgt/timeseries/integration/NewtsConverterUtils.java
+++ b/features/timeseries/src/main/java/org/opennms/netmgt/timeseries/integration/NewtsConverterUtils.java
@@ -40,6 +40,7 @@ import java.util.stream.Collectors;
 import org.opennms.integration.api.v1.timeseries.Metric;
 import org.opennms.integration.api.v1.timeseries.Sample;
 import org.opennms.integration.api.v1.timeseries.immutables.ImmutableSample;
+import org.opennms.integration.api.v1.timeseries.IntrinsicTagNames;
 import org.opennms.netmgt.measurements.model.Source;
 import org.opennms.newts.api.Context;
 import org.opennms.newts.api.Counter;
@@ -72,8 +73,8 @@ public class NewtsConverterUtils {
         final Timestamp timestamp = Timestamp.fromEpochMillis(sample.getTime().toEpochMilli());;
         final Context context = new Context("not relevant");
         final Resource resource = new Resource(sample.getMetric().getFirstTagByKey("resourceId").getValue(), resourceAttributes);;
-        final String name = sample.getMetric().getFirstTagByKey(CommonTagNames.name).getValue();
-        final MetricType type = toNewts(Metric.Mtype.valueOf(sample.getMetric().getFirstTagByKey(CommonTagNames.mtype).getValue()));
+        final String name = sample.getMetric().getFirstTagByKey(IntrinsicTagNames.name).getValue();
+        final MetricType type = toNewts(Metric.Mtype.valueOf(sample.getMetric().getFirstTagByKey(IntrinsicTagNames.mtype).getValue()));
         final ValueType<?> value = toNewtsValue(sample);
         final Map<String, String> attributes = new HashMap<>();
 
@@ -96,7 +97,7 @@ public class NewtsConverterUtils {
     }
 
     private static ValueType<?> toNewtsValue(final Sample sample) {
-        final Metric.Mtype mtype = Metric.Mtype.valueOf(sample.getMetric().getFirstTagByKey(CommonTagNames.mtype).getValue());
+        final Metric.Mtype mtype = Metric.Mtype.valueOf(sample.getMetric().getFirstTagByKey(IntrinsicTagNames.mtype).getValue());
         if(Metric.Mtype.count == mtype) {
             return new Counter(sample.getValue().longValue());
         } else if(Metric.Mtype.gauge == mtype) {

--- a/features/timeseries/src/main/java/org/opennms/netmgt/timeseries/integration/TimeseriesFetchStrategy.java
+++ b/features/timeseries/src/main/java/org/opennms/netmgt/timeseries/integration/TimeseriesFetchStrategy.java
@@ -52,6 +52,7 @@ import java.util.stream.Collectors;
 
 import org.opennms.core.sysprops.SystemProperties;
 import org.opennms.integration.api.v1.timeseries.Aggregation;
+import org.opennms.integration.api.v1.timeseries.IntrinsicTagNames;
 import org.opennms.integration.api.v1.timeseries.Sample;
 import org.opennms.integration.api.v1.timeseries.TimeSeriesFetchRequest;
 import org.opennms.integration.api.v1.timeseries.immutables.ImmutableMetric;
@@ -277,8 +278,8 @@ public class TimeseriesFetchStrategy implements MeasurementFetchStrategy {
                     final boolean shouldAggregateNatively = storageManager.get().supportsAggregation(aggregation);
 
                     final ImmutableMetric metric = ImmutableMetric.builder()
-                            .intrinsicTag(CommonTagNames.resourceId, resourceId)
-                            .intrinsicTag(CommonTagNames.name, metricName)
+                            .intrinsicTag(IntrinsicTagNames.resourceId, resourceId)
+                            .intrinsicTag(IntrinsicTagNames.name, metricName)
                             .build();
 
                     Instant startInstant = Instant.ofEpochMilli(start.or(Timestamp.fromEpochMillis(0)).asMillis());

--- a/features/timeseries/src/main/java/org/opennms/netmgt/timeseries/integration/TimeseriesWriter.java
+++ b/features/timeseries/src/main/java/org/opennms/netmgt/timeseries/integration/TimeseriesWriter.java
@@ -29,8 +29,8 @@
 package org.opennms.netmgt.timeseries.integration;
 
 import java.sql.SQLException;
-import java.time.Instant;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -44,6 +44,7 @@ import javax.inject.Inject;
 import javax.inject.Named;
 
 import org.opennms.core.logging.Logging;
+import org.opennms.integration.api.v1.timeseries.IntrinsicTagNames;
 import org.opennms.integration.api.v1.timeseries.StorageException;
 import org.opennms.integration.api.v1.timeseries.Tag;
 import org.opennms.integration.api.v1.timeseries.immutables.ImmutableMetric;
@@ -249,8 +250,8 @@ public class TimeseriesWriter implements WorkHandler<SampleBatchEvent>, Disposab
     private org.opennms.integration.api.v1.timeseries.Sample toApiSample(final Sample sample) {
 
         ImmutableMetric.MetricBuilder builder = ImmutableMetric.builder()
-                .intrinsicTag(CommonTagNames.resourceId, sample.getResource().getId())
-                .intrinsicTag(CommonTagNames.name, sample.getName())
+                .intrinsicTag(IntrinsicTagNames.resourceId, sample.getResource().getId())
+                .intrinsicTag(IntrinsicTagNames.name, sample.getName())
                 .metaTag(typeToTag(sample.getType()));
 
         if(sample.getResource().getAttributes().isPresent()) {
@@ -274,7 +275,7 @@ public class TimeseriesWriter implements WorkHandler<SampleBatchEvent>, Disposab
             throw new IllegalArgumentException(String.format("I can't find a matching %s for %s",
                     ImmutableMetric.Mtype.class.getSimpleName(), type.toString()));
         }
-        return new ImmutableTag(CommonTagNames.mtype, mtype.name());
+        return new ImmutableTag(IntrinsicTagNames.mtype, mtype.name());
     }
 
     private static final EventTranslatorOneArg<SampleBatchEvent, List<Sample>> TRANSLATOR =

--- a/features/timeseries/src/main/java/org/opennms/netmgt/timeseries/integration/dao/TimeseriesResourceStorageDao.java
+++ b/features/timeseries/src/main/java/org/opennms/netmgt/timeseries/integration/dao/TimeseriesResourceStorageDao.java
@@ -43,6 +43,7 @@ import java.util.concurrent.Future;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import org.opennms.integration.api.v1.timeseries.IntrinsicTagNames;
 import org.opennms.integration.api.v1.timeseries.Metric;
 import org.opennms.integration.api.v1.timeseries.StorageException;
 import org.opennms.integration.api.v1.timeseries.immutables.ImmutableMetric;
@@ -53,7 +54,6 @@ import org.opennms.netmgt.model.ResourceTypeUtils;
 import org.opennms.netmgt.model.RrdGraphAttribute;
 import org.opennms.netmgt.model.StringPropertyAttribute;
 import org.opennms.netmgt.timeseries.impl.TimeseriesStorageManager;
-import org.opennms.netmgt.timeseries.integration.CommonTagNames;
 import org.opennms.netmgt.timeseries.integration.TimeseriesWriter;
 import org.opennms.netmgt.timeseries.integration.dao.SearchResults.Result;
 import org.opennms.netmgt.timeseries.integration.support.SearchableResourceMetadataCache;
@@ -159,8 +159,8 @@ public class TimeseriesResourceStorageDao implements ResourceStorageDao {
         for (final Result result : results) {
             for(String metricName: result.getMetrics()) {
                 Metric metric = ImmutableMetric.builder()
-                        .intrinsicTag(CommonTagNames.resourceId, result.getResource().getId())
-                        .intrinsicTag(CommonTagNames.name, metricName)
+                        .intrinsicTag(IntrinsicTagNames.resourceId, result.getResource().getId())
+                        .intrinsicTag(IntrinsicTagNames.name, metricName)
                         .build();
                 try {
                     storageManager.get().delete(metric);

--- a/features/timeseries/src/main/java/org/opennms/netmgt/timeseries/integration/dao/TimeseriesSearcher.java
+++ b/features/timeseries/src/main/java/org/opennms/netmgt/timeseries/integration/dao/TimeseriesSearcher.java
@@ -36,13 +36,13 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.opennms.integration.api.v1.timeseries.IntrinsicTagNames;
 import org.opennms.integration.api.v1.timeseries.Metric;
 import org.opennms.integration.api.v1.timeseries.StorageException;
 import org.opennms.integration.api.v1.timeseries.Tag;
 import org.opennms.integration.api.v1.timeseries.immutables.ImmutableTag;
 import org.opennms.netmgt.model.ResourcePath;
 import org.opennms.netmgt.timeseries.impl.TimeseriesStorageManager;
-import org.opennms.netmgt.timeseries.integration.CommonTagNames;
 import org.opennms.netmgt.timeseries.meta.TimeSeriesMetaDataDao;
 import org.opennms.newts.api.Resource;
 import org.slf4j.Logger;
@@ -87,17 +87,17 @@ public class TimeseriesSearcher {
 
 
         for(Metric metric : metrics) {
-            String resourceId = metric.getFirstTagByKey(CommonTagNames.resourceId).getValue();
+            String resourceId = metric.getFirstTagByKey(IntrinsicTagNames.resourceId).getValue();
             SearchResults.Result result = resultPerResources.get(resourceId);
             if(result == null) {
                 Map<String, String> attributes = new HashMap<>();
                 metric.getMetaTags().forEach(entry -> attributes.put(entry.getKey(), entry.getValue()));
-                Resource resource = new Resource(metric.getFirstTagByKey(CommonTagNames.resourceId).getValue(),
+                Resource resource = new Resource(metric.getFirstTagByKey(IntrinsicTagNames.resourceId).getValue(),
                         Optional.of(attributes));
                 result = new SearchResults.Result(resource, new ArrayList<>());
                 resultPerResources.put(resourceId, result);
             }
-            result.getMetrics().add(metric.getFirstTagByKey(CommonTagNames.name).getValue());
+            result.getMetrics().add(metric.getFirstTagByKey(IntrinsicTagNames.name).getValue());
         }
 
         SearchResults results = new SearchResults();

--- a/features/timeseries/src/test/java/org/opennms/netmgt/timeseries/integration/TimeseriesFetchStrategyTest.java
+++ b/features/timeseries/src/test/java/org/opennms/netmgt/timeseries/integration/TimeseriesFetchStrategyTest.java
@@ -50,6 +50,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.opennms.integration.api.v1.timeseries.Aggregation;
+import org.opennms.integration.api.v1.timeseries.IntrinsicTagNames;
 import org.opennms.integration.api.v1.timeseries.Sample;
 import org.opennms.integration.api.v1.timeseries.StorageException;
 import org.opennms.integration.api.v1.timeseries.TimeSeriesFetchRequest;
@@ -288,8 +289,8 @@ public class TimeseriesFetchStrategyTest {
 
         String name = ds != null ? ds : attr;
         ImmutableMetric metric = ImmutableMetric.builder()
-                .intrinsicTag(CommonTagNames.resourceId, newtsResourceId)
-                .intrinsicTag(CommonTagNames.name, name)
+                .intrinsicTag(IntrinsicTagNames.resourceId, newtsResourceId)
+                .intrinsicTag(IntrinsicTagNames.name, name)
                 .build();
         Sample sample = ImmutableSample.builder()
                 .metric(metric)

--- a/features/timeseries/src/test/java/org/opennms/netmgt/timeseries/integration/TimeseriesRoundtripIT.java
+++ b/features/timeseries/src/test/java/org/opennms/netmgt/timeseries/integration/TimeseriesRoundtripIT.java
@@ -48,6 +48,7 @@ import org.junit.runner.RunWith;
 import org.opennms.core.test.OpenNMSJUnit4ClassRunner;
 import org.opennms.core.test.db.annotations.JUnitTemporaryDatabase;
 import org.opennms.integration.api.v1.timeseries.Aggregation;
+import org.opennms.integration.api.v1.timeseries.IntrinsicTagNames;
 import org.opennms.integration.api.v1.timeseries.Metric;
 import org.opennms.integration.api.v1.timeseries.Sample;
 import org.opennms.integration.api.v1.timeseries.StorageException;
@@ -176,8 +177,8 @@ public class TimeseriesRoundtripIT {
     private void testForNumericAttribute(String resourceId, String name, Double expectedValue) throws StorageException {
 
         List<Metric> metrics = timeseriesStorageManager.get().getMetrics(Arrays.asList(
-                new ImmutableTag(CommonTagNames.resourceId, resourceId),
-                new ImmutableTag(CommonTagNames.name, name)));
+                new ImmutableTag(IntrinsicTagNames.resourceId, resourceId),
+                new ImmutableTag(IntrinsicTagNames.name, name)));
         assertEquals(1, metrics.size());
 
         TimeSeriesFetchRequest request = ImmutableTimeSeriesFetchRequest.builder()

--- a/features/timeseries/src/test/java/org/opennms/netmgt/timeseries/integration/aggregation/SampleAggregatorTest.java
+++ b/features/timeseries/src/test/java/org/opennms/netmgt/timeseries/integration/aggregation/SampleAggregatorTest.java
@@ -40,6 +40,7 @@ import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
 import org.opennms.integration.api.v1.timeseries.Aggregation;
+import org.opennms.integration.api.v1.timeseries.IntrinsicTagNames;
 import org.opennms.integration.api.v1.timeseries.Sample;
 import org.opennms.integration.api.v1.timeseries.immutables.ImmutableMetric;
 import org.opennms.integration.api.v1.timeseries.immutables.ImmutableSample;
@@ -56,7 +57,7 @@ public class SampleAggregatorTest {
     }
 
     private final ImmutableMetric metric = ImmutableMetric.builder()
-            .intrinsicTag(CommonTagNames.resourceId, "123").build();
+            .intrinsicTag(IntrinsicTagNames.resourceId, "123").build();
 
     @Test
     public void shouldAggregateToAverage() {

--- a/features/timeseries/src/test/java/org/opennms/netmgt/timeseries/integration/persistence/TimeseriesPersisterIT.java
+++ b/features/timeseries/src/test/java/org/opennms/netmgt/timeseries/integration/persistence/TimeseriesPersisterIT.java
@@ -44,6 +44,7 @@ import org.junit.runner.RunWith;
 import org.opennms.core.test.OpenNMSJUnit4ClassRunner;
 import org.opennms.core.test.db.annotations.JUnitTemporaryDatabase;
 import org.opennms.integration.api.v1.timeseries.Aggregation;
+import org.opennms.integration.api.v1.timeseries.IntrinsicTagNames;
 import org.opennms.integration.api.v1.timeseries.Sample;
 import org.opennms.integration.api.v1.timeseries.StorageException;
 import org.opennms.integration.api.v1.timeseries.TimeSeriesFetchRequest;
@@ -59,7 +60,6 @@ import org.opennms.netmgt.collection.support.builder.NodeLevelResource;
 import org.opennms.netmgt.model.ResourcePath;
 import org.opennms.netmgt.rrd.RrdRepository;
 import org.opennms.netmgt.timeseries.impl.TimeseriesStorageManager;
-import org.opennms.netmgt.timeseries.integration.CommonTagNames;
 import org.opennms.newts.api.Resource;
 import org.opennms.test.JUnitConfigurationEnvironment;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -123,8 +123,8 @@ public class TimeseriesPersisterIT {
         Instant end = Instant.now();
 
         ImmutableMetric metric = ImmutableMetric.builder()
-                .intrinsicTag(CommonTagNames.resourceId, resource.getId())
-                .intrinsicTag(CommonTagNames.name, "metric")
+                .intrinsicTag(IntrinsicTagNames.resourceId, resource.getId())
+                .intrinsicTag(IntrinsicTagNames.name, "metric")
                 .build();
         TimeSeriesFetchRequest request = ImmutableTimeSeriesFetchRequest.builder()
                 .start(now)

--- a/pom.xml
+++ b/pom.xml
@@ -1414,8 +1414,8 @@
     <powermockVersion>1.6.4</powermockVersion>
     <okhttpVersion>3.10.0</okhttpVersion>
     <okioVersion>1.14.0</okioVersion>
-    <opennmsApiVersion>0.4.1</opennmsApiVersion>
-    <opennmsApiVersionOsgi>0.4.1</opennmsApiVersionOsgi>
+    <opennmsApiVersion>0.4.2-SNAPSHOT</opennmsApiVersion>
+    <opennmsApiVersionOsgi>0.4.2-SNAPSHOT</opennmsApiVersionOsgi>
     <osgiVersion>6.0.0</osgiVersion>
     <osgiCompendiumVersion>5.0.0</osgiCompendiumVersion>
     <osgiEnterpriseVersion>5.0.0</osgiEnterpriseVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -1415,7 +1415,7 @@
     <okhttpVersion>3.10.0</okhttpVersion>
     <okioVersion>1.14.0</okioVersion>
     <opennmsApiVersion>0.4.2-SNAPSHOT</opennmsApiVersion>
-    <opennmsApiVersionOsgi>0.4.2-SNAPSHOT</opennmsApiVersionOsgi>
+    <opennmsApiVersionOsgi>0.4.2.SNAPSHOT</opennmsApiVersionOsgi>
     <osgiVersion>6.0.0</osgiVersion>
     <osgiCompendiumVersion>5.0.0</osgiCompendiumVersion>
     <osgiEnterpriseVersion>5.0.0</osgiEnterpriseVersion>


### PR DESCRIPTION
Moves the constants from OpenNMS to the to the Integration API.

### External References

* Integration API PR: https://github.com/OpenNMS/opennms-integration-api/pull/28
* JIRA (Issue Tracker): https://issues.opennms.org/browse/OIA-26

