### PR TITLE
NMS-7547: fix UTF-8 comparison decoding hex strings

### DIFF
--- a/core/snmp/api/src/main/java/org/opennms/netmgt/snmp/AbstractSnmpValue.java
+++ b/core/snmp/api/src/main/java/org/opennms/netmgt/snmp/AbstractSnmpValue.java
@@ -91,6 +91,10 @@ public abstract class AbstractSnmpValue implements SnmpValue {
 
             while (i < end) {
                 i++;
+                // If there are insufficient trailing bytes, return false
+                if (i >= bytes.length) {
+                    return false;
+                }
                 octet = bytes[i];
                 if ((octet & 0xC0) != 0x80) {
                     //System.err.println("Not a valid trailing byte.");

--- a/core/snmp/api/src/test/java/org/opennms/netmgt/snmp/AbstractSnmpValueTest.java
+++ b/core/snmp/api/src/test/java/org/opennms/netmgt/snmp/AbstractSnmpValueTest.java
@@ -97,6 +97,18 @@ public class AbstractSnmpValueTest {
 		}
 	}
 
+	@Test
+	public void testHighIso8859CharDisplayable() throws UnsupportedEncodingException {
+		String highIso8859Char = "CF"; // Capital I with umlaut
+		assertTrue(new String(hexStringToBytes(highIso8859Char), "ISO-8859-1"), AbstractSnmpValue.allBytesDisplayable(hexStringToBytes(highIso8859Char)));
+
+		highIso8859Char = "EF"; // Lowercase i with umlaut
+		assertTrue(new String(hexStringToBytes(highIso8859Char), "ISO-8859-1"), AbstractSnmpValue.allBytesDisplayable(hexStringToBytes(highIso8859Char)));
+
+		highIso8859Char = "FF"; // Lowercase y with umlaut
+		assertTrue(new String(hexStringToBytes(highIso8859Char), "ISO-8859-1"), AbstractSnmpValue.allBytesDisplayable(hexStringToBytes(highIso8859Char)));
+	}
+
 	private static byte[] hexStringToBytes(String hexString) {
 		assertTrue(hexString.length() % 2 == 0);
 		byte[] retval = new byte[hexString.length() / 2];

--- a/opennms-model/src/main/java/org/opennms/netmgt/model/events/snmp/SyntaxToEvent.java
+++ b/opennms-model/src/main/java/org/opennms/netmgt/model/events/snmp/SyntaxToEvent.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2005-2016 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2016 The OpenNMS Group, Inc.
+ * Copyright (C) 2005-2014 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -111,14 +111,7 @@ public class SyntaxToEvent {
             if (m_syntaxToEvents[i].getTypeId() == -1 || m_syntaxToEvents[i].getTypeId() == value.getType()) {
                 val.setType(m_syntaxToEvents[i].getType());
                 String encoding = null;
-                boolean displayable = false;
-                try {
-                    displayable = value.isDisplayable();
-                } catch (ArrayIndexOutOfBoundsException aioobe) {
-                    // Eat it
-                    // This should not be necessary when NMS-7547 is fixed
-                }
-                if (displayable) {
+                if (value.isDisplayable()) {
                     if (name.matches(".*[Mm][Aa][Cc].*")) {
                         encoding = EventConstants.XML_ENCODING_MAC_ADDRESS;
                     } else {

--- a/opennms-services/src/main/java/org/opennms/netmgt/enlinkd/snmp/LldpLocalGroupTracker.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/enlinkd/snmp/LldpLocalGroupTracker.java
@@ -31,6 +31,7 @@ package org.opennms.netmgt.enlinkd.snmp;
 import org.opennms.core.utils.LldpUtils;
 import org.opennms.core.utils.LldpUtils.LldpChassisIdSubType;
 import org.opennms.netmgt.model.LldpElement;
+import org.opennms.netmgt.snmp.AbstractSnmpValue;
 import org.opennms.netmgt.snmp.AggregateTracker;
 import org.opennms.netmgt.snmp.ErrorStatus;
 import org.opennms.netmgt.snmp.ErrorStatusException;
@@ -92,10 +93,10 @@ public final class LldpLocalGroupTracker extends AggregateTracker {
     public static String getDisplayable(final SnmpValue snmpValue) {
         String decodedsnmpValue = snmpValue.toHexString();
         try {
-            if (snmpValue.isDisplayable())
+            if (AbstractSnmpValue.allBytesUTF_8(snmpValue.getBytes()))
                 decodedsnmpValue = snmpValue.toDisplayString();
         } catch (Exception e) {
-            LOG.debug("getDisplayable: got not displayable Value", e);
+            LOG.debug("getDisplayable: got not displayable Value {}", e.getMessage());
         }
         return decodedsnmpValue;
     }

--- a/opennms-services/src/main/java/org/opennms/netmgt/enlinkd/snmp/LldpRemTableTracker.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/enlinkd/snmp/LldpRemTableTracker.java
@@ -33,6 +33,7 @@ import org.opennms.core.utils.LldpUtils;
 import org.opennms.core.utils.LldpUtils.LldpChassisIdSubType;
 import org.opennms.core.utils.LldpUtils.LldpPortIdSubType;
 import org.opennms.netmgt.model.LldpLink;
+import org.opennms.netmgt.snmp.AbstractSnmpValue;
 import org.opennms.netmgt.snmp.RowCallback;
 import org.opennms.netmgt.snmp.SnmpInstId;
 import org.opennms.netmgt.snmp.SnmpObjId;
@@ -150,7 +151,7 @@ public class LldpRemTableTracker extends TableTracker {
             case LLDP_PORTID_SUBTYPE_INTERFACEALIAS:
             case LLDP_PORTID_SUBTYPE_INTERFACENAME:
             case LLDP_PORTID_SUBTYPE_LOCAL:
-                if (lldpportid.isDisplayable())
+                if (AbstractSnmpValue.allBytesUTF_8(lldpportid.getBytes()))
                     return lldpportid.toDisplayString();
                 else 
                     return lldpportid.toHexString();

--- a/opennms-services/src/test/java/org/opennms/netmgt/enlinkd/EnLinkdSnmpIT.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/enlinkd/EnLinkdSnmpIT.java
@@ -121,6 +121,7 @@ public class EnLinkdSnmpIT extends NmsNetworkBuilder implements InitializingBean
         p.setProperty("log4j.logger.org.opennms.mock.snmp", "WARN");
         p.setProperty("log4j.logger.org.opennms.core.test.snmp", "WARN");
         p.setProperty("log4j.logger.org.opennms.netmgt", "WARN");
+        p.setProperty("log4j.logger.org.opennms.netmgt.enlinkd", "DEBUG");
         p.setProperty("log4j.logger.org.springframework","WARN");
         p.setProperty("log4j.logger.com.mchange.v2.resourcepool", "WARN");
         MockLogAppender.setupLogging(p);


### PR DESCRIPTION
We pulled this out of the backlog this week, it's an old patch that Seth did that supposedly broke some Enlinkd tests, but we've refactored plenty of the related code and everything passes here.  I've gone ahead and made a `foundation-2019` version of it [here](https://app.circleci.com/pipelines/github/OpenNMS/opennms/6315/workflows/50ce4c23-550c-4c4c-8b2c-41bf48eed934) just to make sure it passes there too, and and as long as it does, I'd say we should hopefully be safe to merge.

JIRA: https://issues.opennms.org/browse/NMS-7547

