### PR TITLE
NMS-12743: update to 9.4.29

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1381,7 +1381,7 @@
     <jasperreportsMavenPluginVersion>1.0-beta-4-OPENNMS-20160912-1</jasperreportsMavenPluginVersion>
     <jcifsVersion>1.3.14</jcifsVersion>
     <jcommonVersion>1.0.23</jcommonVersion>
-    <jettyVersion>9.4.2.v20170220</jettyVersion>
+    <jettyVersion>9.4.29.v20200521</jettyVersion>
     <jfreechartVersion>1.0.19</jfreechartVersion>
     <jinteropVersion>2.0.8</jinteropVersion>
     <jldapVersion>4.3</jldapVersion>


### PR DESCRIPTION
This PR just bumps Jetty to the latest 9.4 in `foundation-2017`.  I'll merge it forward as necessary, it will conflict with the (still very outdated) bump to jetty 9.4.14 in newer branches.

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-12743

