### PR TITLE
NMS-12757: update commons-beanutils to 1.9.4

### DIFF
--- a/dependencies/jradius/pom.xml
+++ b/dependencies/jradius/pom.xml
@@ -39,10 +39,6 @@
       <artifactId>commons-beanutils</artifactId>
     </dependency>
     <dependency>
-      <groupId>commons-beanutils</groupId>
-      <artifactId>commons-beanutils-core</artifactId>
-    </dependency>
-    <dependency>
       <groupId>commons-chain</groupId>
       <artifactId>commons-chain</artifactId>
     </dependency>
@@ -55,6 +51,10 @@
       <artifactId>jradius-core</artifactId>
       <version>1.1.4</version>
       <exclusions>
+        <exclusion>
+          <groupId>commons-beanutils</groupId>
+          <artifactId>commons-beanutils-core</artifactId>
+        </exclusion>
         <exclusion>
           <groupId>org.springframework</groupId>
           <artifactId>spring-context</artifactId>
@@ -82,6 +82,10 @@
       <artifactId>jradius-dictionary</artifactId>
       <version>1.1.4</version>
       <exclusions>
+        <exclusion>
+          <groupId>commons-beanutils</groupId>
+          <artifactId>commons-beanutils-core</artifactId>
+        </exclusion>
         <exclusion>
           <groupId>org.springframework</groupId>
           <artifactId>spring-context</artifactId>

--- a/features/reporting/sdo/pom.xml
+++ b/features/reporting/sdo/pom.xml
@@ -31,7 +31,7 @@
   <dependencies>
     <dependency>
       <groupId>commons-beanutils</groupId>
-      <artifactId>commons-beanutils-core</artifactId>
+      <artifactId>commons-beanutils</artifactId>
     </dependency>
     <!-- logging -->
     <dependency>

--- a/features/request-tracker/pom.xml
+++ b/features/request-tracker/pom.xml
@@ -36,8 +36,18 @@
       <artifactId>opennms-util</artifactId>
     </dependency>
     <dependency>
+      <groupId>commons-beanutils</groupId>
+      <artifactId>commons-beanutils</artifactId>
+    </dependency>
+    <dependency>
       <groupId>commons-configuration</groupId>
       <artifactId>commons-configuration</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-beanutils</groupId>
+          <artifactId>commons-beanutils-core</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>

--- a/features/ticketing/drools-integration/pom.xml
+++ b/features/ticketing/drools-integration/pom.xml
@@ -27,8 +27,18 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-        <groupId>commons-configuration</groupId>
-        <artifactId>commons-configuration</artifactId>
+      <groupId>commons-beanutils</groupId>
+      <artifactId>commons-beanutils</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>commons-configuration</groupId>
+      <artifactId>commons-configuration</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-beanutils</groupId>
+          <artifactId>commons-beanutils-core</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.opennms</groupId>

--- a/features/ticketing/otrs-integration-31/pom.xml
+++ b/features/ticketing/otrs-integration-31/pom.xml
@@ -129,8 +129,18 @@
 			<artifactId>asm-all</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>commons-beanutils</groupId>
+			<artifactId>commons-beanutils</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>commons-configuration</groupId>
 			<artifactId>commons-configuration</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>commons-beanutils</groupId>
+					<artifactId>commons-beanutils-core</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>commons-lang</groupId>

--- a/features/ticketing/otrs-integration-common/pom.xml
+++ b/features/ticketing/otrs-integration-common/pom.xml
@@ -31,8 +31,18 @@
 			<artifactId>opennms-util</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>commons-beanutils</groupId>
+			<artifactId>commons-beanutils</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>commons-configuration</groupId>
 			<artifactId>commons-configuration</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>commons-beanutils</groupId>
+					<artifactId>commons-beanutils-core</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>commons-lang</groupId>

--- a/features/ticketing/otrs-integration/pom.xml
+++ b/features/ticketing/otrs-integration/pom.xml
@@ -83,19 +83,29 @@
 			<groupId>axis</groupId>
 			<artifactId>axis</artifactId>
 			<exclusions>
-			  <exclusion>
-			    <groupId>commons-logging</groupId>
-			    <artifactId>commons-logging</artifactId>
-			  </exclusion>
-			  <exclusion>
-			    <groupId>axis</groupId>
-			    <artifactId>axis-wsdl4j</artifactId>
-			  </exclusion>
+				<exclusion>
+					<groupId>commons-logging</groupId>
+					<artifactId>commons-logging</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>axis</groupId>
+					<artifactId>axis-wsdl4j</artifactId>
+				</exclusion>
 			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>commons-beanutils</groupId>
+			<artifactId>commons-beanutils</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>commons-configuration</groupId>
 			<artifactId>commons-configuration</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>commons-beanutils</groupId>
+					<artifactId>commons-beanutils-core</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>wsdl4j</groupId>

--- a/features/ticketing/remedy-integration/pom.xml
+++ b/features/ticketing/remedy-integration/pom.xml
@@ -72,19 +72,29 @@
 			<groupId>axis</groupId>
 			<artifactId>axis</artifactId>
 			<exclusions>
-			  <exclusion>
-			    <groupId>commons-logging</groupId>
-			    <artifactId>commons-logging</artifactId>
-			  </exclusion>
-			  <exclusion>
-			    <groupId>axis</groupId>
-			    <artifactId>axis-wsdl4j</artifactId>
-			  </exclusion>
+				<exclusion>
+					<groupId>commons-logging</groupId>
+					<artifactId>commons-logging</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>axis</groupId>
+					<artifactId>axis-wsdl4j</artifactId>
+				</exclusion>
 			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>commons-beanutils</groupId>
+			<artifactId>commons-beanutils</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>commons-configuration</groupId>
 			<artifactId>commons-configuration</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>commons-beanutils</groupId>
+					<artifactId>commons-beanutils-core</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>wsdl4j</groupId>

--- a/features/ticketing/rt-integration/pom.xml
+++ b/features/ticketing/rt-integration/pom.xml
@@ -46,8 +46,18 @@
        <artifactId>opennms-util</artifactId>
      </dependency>
      <dependency>
+       <groupId>commons-beanutils</groupId>
+       <artifactId>commons-beanutils</artifactId>
+     </dependency>
+     <dependency>
        <groupId>commons-configuration</groupId>
        <artifactId>commons-configuration</artifactId>
+       <exclusions>
+         <exclusion>
+           <groupId>commons-beanutils</groupId>
+           <artifactId>commons-beanutils-core</artifactId>
+         </exclusion>
+       </exclusions>
      </dependency>
      <dependency>
        <groupId>commons-lang</groupId>

--- a/features/vaadin-node-maps/pom.xml
+++ b/features/vaadin-node-maps/pom.xml
@@ -285,10 +285,21 @@
 			<scope>test</scope>
 		</dependency>  
 		<dependency>
+		    <groupId>commons-beanutils</groupId>
+		    <artifactId>commons-beanutils</artifactId>
+		    <scope>test</scope>
+		</dependency>
+		<dependency>
 		    <groupId>com.googlecode.gwt-test-utils</groupId>
 		    <artifactId>gwt-test-utils</artifactId>
 		    <version>0.47</version>
 		    <scope>test</scope>
+		    <exclusions>
+		        <exclusion>
+		            <groupId>commons-beanutils</groupId>
+		            <artifactId>commons-beanutils-core</artifactId>
+		        </exclusion>
+		    </exclusions>
 		</dependency>
 	</dependencies>
 

--- a/opennms-base-assembly/pom.xml
+++ b/opennms-base-assembly/pom.xml
@@ -454,6 +454,10 @@
       <artifactId>log4j-slf4j-impl</artifactId>
     </dependency>                      
     <dependency>
+      <groupId>commons-beanutils</groupId>
+      <artifactId>commons-beanutils</artifactId>
+    </dependency>
+    <dependency>
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>
     </dependency>
@@ -464,6 +468,12 @@
     <dependency>
       <groupId>commons-configuration</groupId>
       <artifactId>commons-configuration</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-beanutils</groupId>
+          <artifactId>commons-beanutils-core</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>

--- a/opennms-dao/pom.xml
+++ b/opennms-dao/pom.xml
@@ -199,7 +199,7 @@
     <!-- Non-OpenNMS dependencies, sorted by groupId, artifactId -->
     <dependency>
       <groupId>commons-beanutils</groupId>
-      <artifactId>commons-beanutils-core</artifactId>
+      <artifactId>commons-beanutils</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/opennms-provision/opennms-provision-persistence/pom.xml
+++ b/opennms-provision/opennms-provision-persistence/pom.xml
@@ -86,7 +86,7 @@
   <dependencies>
     <dependency>
       <groupId>commons-beanutils</groupId>
-      <artifactId>commons-beanutils-core</artifactId>
+      <artifactId>commons-beanutils</artifactId>
     </dependency>
     <dependency>
       <groupId>org.opennms.dependencies</groupId>

--- a/opennms-webapp/src/test/resources/osgiTestWar/WEB-INF/karaf/system/org/apache/karaf/assemblies/features/standard/2.2.7/standard-2.2.7-features.xml
+++ b/opennms-webapp/src/test/resources/osgiTestWar/WEB-INF/karaf/system/org/apache/karaf/assemblies/features/standard/2.2.7/standard-2.2.7-features.xml
@@ -116,7 +116,7 @@
 
     <feature name="spring-struts" version="3.0.7.RELEASE" resolver="(obr)">
         <feature version="3.0.7.RELEASE">spring-web</feature>
-        <bundle dependency="true" start-level="30">mvn:commons-beanutils/commons-beanutils/1.8.3</bundle>
+        <bundle dependency="true" start-level="30">mvn:commons-beanutils/commons-beanutils/1.9.4</bundle>
         <bundle start-level="30">mvn:org.springframework/spring-struts/3.0.7.RELEASE</bundle>
     </feature>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1362,7 +1362,7 @@
     <atomikosVersion>3.9.2</atomikosVersion>
     <camelVersion>2.14.1</camelVersion>
     <cloverVersion>3.2.0</cloverVersion>
-    <commonsBeanutilsVersion>1.8.3</commonsBeanutilsVersion>
+    <commonsBeanutilsVersion>1.9.4</commonsBeanutilsVersion>
     <commonsCodecVersion>1.9</commonsCodecVersion>
     <commonsCollectionsVersion>3.2.2</commonsCollectionsVersion>
     <commonsConfigurationVersion>1.6</commonsConfigurationVersion>


### PR DESCRIPTION
This PR updates our `commons-beanutils` dependencies to 1.9.4, including masking out `commons-beanutils-core` as necessary for dependencies, since Apache stopped splitting up the packages as of 1.9.0.

There is a `foundation-2019` version of this branch to, to make sure karaf dependency stuff pulled in properly; if this gets approved I'll merge it and make sure similar fixes are checked against dependencies up and down the line.

JIRA: https://issues.opennms.org/browse/NMS-12757