### PR TITLE
NMS-12770: Fix docs warnings for resource-types, time series config and thresholding

### DIFF
--- a/opennms-doc/guide-admin/src/asciidoc/text/meta-data.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/meta-data.adoc
@@ -12,7 +12,7 @@ The only restriction is that the tuple of context and key must be unique in the 
 The association of metadata with nodes, interfaces and services happens during link:#ga-provisioning-meta-data[provisioning].
 Users can add, query, modify, or delete metadata through the requisition editor in the link:ga-metadata-webui[web UI], or through the xref:https://docs.opennms.org/opennms/releases/latest/guide-development/guide-development.html#_meta_data[ReST endpoints].
 
-A link:#ga-meta-data-dsl[simple domain-specific language] (DSL) allows users to access the metadata associated with the elements they are working on, and use it as a variable in parameters and expressions
+A link:#ga-meta-data-dsl[simple domain-specific language] (DSL) allows users to access the metadata associated with the elements they are working on, and use it as a variable in parameters and expressions.
 There is no limitation in defining metadata: users can decide how to define it and use it in expressions. 
 
 View metadata currently assigned to nodes, interfaces and services, on the details page associated with that entity in the web UI:

--- a/opennms-doc/guide-admin/src/asciidoc/text/operation/timeseries/configuration.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/operation/timeseries/configuration.adoc
@@ -44,7 +44,7 @@ Additional configuration options are presented in the next section.
 
 The following properties, found in `${OPENNMS_HOME}/etc/opennms.properties`, can be used to configure and tune the _Timeseries Integration Layer_.
 
-[[ga-opennms-operation-newts-properties-general]]
+[[ga-opennms-operation-timeseries-configuration-general]]
 ====== General
 [options="header, autowidth"]
 |===

--- a/opennms-doc/guide-admin/src/asciidoc/text/performance-data-collection/resource-types.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/performance-data-collection/resource-types.adoc
@@ -33,7 +33,7 @@ Here is the diskIOIndex resource type definition from `$OPENNMS_HOME/etc/datacol
 </resourceType>
 ----
 
-===== Persistence Selector Strategies
+==== Persistence Selector Strategies
 .Persistence Selector Strategies
 [options="header, autowidth"]
 |===
@@ -42,13 +42,13 @@ Here is the diskIOIndex resource type definition from `$OPENNMS_HOME/etc/datacol
 | org.opennms.netmgt.collection.support.PersistRegexSelectorStrategy | Persist indexes based on JEXL evaluation
 |===
 
-====== PersistRegexSelectorStrategy
+===== PersistRegexSelectorStrategy
 
 The PersistRegexSelectorStrategy class takes a single parameter, `match-expression`, which defines a JEXL expressions.
 On evaulation, this expression should return either true, persist index to storage, or false, discard data.
 
 
-===== Storage Strategies
+==== Storage Strategies
 .Storage Strategies
 [options="header, autowidth"]
 |===
@@ -62,11 +62,11 @@ On evaulation, this expression should return either true, persist index to stora
 | org.opennms.protocols.xml.collector.XmlStorageStrategy          | Index, but cleaned up for unix filesystems.
 |===
 
-====== IndexStorageStrategy
+===== IndexStorageStrategy
 
 The IndexStorageStrategy takes no parameters.
 
-====== JexlIndexStorageStrategy
+===== JexlIndexStorageStrategy
 
 The JexlIndexStorageStrategy takes two parameters, `index-format` which is required, and `clean-output` which is optional.
 
@@ -96,7 +96,7 @@ public class ExampleStorageStrategy extends JexlIndexStorageStrategy {
 }
 ----
 
-====== ObjectNameStorageStrategy
+===== ObjectNameStorageStrategy
 
 The ObjectNameStorageStrategy extends the JexlIndexStorageStrategy, so its requirements are the same. Extra key/values pairs are added to the JexlContext which can then be used in the `index-format` template.
 The original index string is converted to an ObjectName and can be referenced as `${ObjectName}`. The _domain_ from the ObjectName can be referenced as `${domain}`. All _key properties_
@@ -114,11 +114,11 @@ Given an MBean like `java.lang:type=MemoryPool,name=Survivor Space`, and a stora
 ----
 Then the index value would be `java_lang_MemoryPool_Survivor_Space`.
 
-====== FrameRelayStorageStrategy
+===== FrameRelayStorageStrategy
 
 The FrameRelayStorageStrategy takes no parameters.
 
-====== HostFileSystemStorageStrategy
+===== HostFileSystemStorageStrategy
 
 The HostFileSystemStorageStrategy takes no parameters.
 This class is marked as deprecated, and can be replaced with:
@@ -134,7 +134,7 @@ This class is marked as deprecated, and can be replaced with:
 </storageStrategy>
 ----
 
-====== SiblingColumnStorageStrategy
+===== SiblingColumnStorageStrategy
 
 [options="header, autowidth"]
 |===
@@ -146,7 +146,7 @@ This class is marked as deprecated, and can be replaced with:
 
 Values for `replace-first`, and `replace-all` must match the pattern _s/regex/replacement/_ or an error will be thrown.
 
-====== XmlStorageStrategy
+===== XmlStorageStrategy
 
 This XmlStorageStrategy takes no parameters.
 The index value will have all whitespace, colons, forward and back slashes, and vertical bars replaced with underscores.

--- a/opennms-doc/guide-admin/src/asciidoc/text/thresholds/thresholding.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/thresholds/thresholding.adoc
@@ -2,9 +2,6 @@
 // Allow GitHub image rendering
 :imagesdir: ../images
 
-[[ga-threshd-introduction]]
-= Thresholding
-
 Thresholding allows you to define limits against network performance metrics of a managed entity to trigger an event when a value goes above or below the specified limit. 
 
 * High


### PR DESCRIPTION
### All Contributors

* [ ] Have you read and followed our [Contribution Guidelines](https://github.com/OpenNMS/opennms/blob/develop/CONTRIBUTING.md)?
* [ ] Have you [made an issue in the OpenNMS issue tracker](https://issues.opennms.org)?<br>If so, you should:
  1. update the title of this PR to be of the format: `${JIRA-ISSUE-NUMBER}: subject of pull request`
  2. update the JIRA link at the bottom of this comment to refer to the real issue number
  3. prefix your commit messages with the issue number, if possible
* [ ] Have you made a comment in that issue which points back to this PR?
* [ ] Have you updated the JIRA link at the bottom of this comment to link to your issue?
* [ ] If this is a new or updated feature, is there documentation for the new behavior?
* [ ] If this is new code, are there unit and/or integration tests?
* [ ] If this PR targets a `foundation-*` branch, does it avoid changing files in `$OPENNMS_HOME/etc/`?

### Pull Request Process

Fix compiler warnings with titles out of order for:

* Resource-Types
* Thresholding

Fixed warning with a duplicated link ID for Newts timeseries configuration.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-12770

