### PR TITLE
NMS-12784: Remove key for the events sent to kafka 

### DIFF
--- a/features/kafka/producer/src/main/java/org/opennms/features/kafka/producer/OpennmsKafkaProducer.java
+++ b/features/kafka/producer/src/main/java/org/opennms/features/kafka/producer/OpennmsKafkaProducer.java
@@ -80,7 +80,6 @@ import org.springframework.expression.spel.standard.SpelExpressionParser;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
-import com.google.common.primitives.Longs;
 import com.swrve.ratelimitedlogger.RateLimitedLog;
 
 public class OpennmsKafkaProducer implements AlarmLifecycleListener, EventListener, AlarmFeedbackListener, OnmsTopologyConsumer {
@@ -253,7 +252,7 @@ public class OpennmsKafkaProducer implements AlarmLifecycleListener, EventListen
         sendRecord(() -> {
             final OpennmsModelProtos.Event mappedEvent = protobufMapper.toEvent(event).build();
             LOG.debug("Sending event with UEI: {}", mappedEvent.getUei());
-            return new ProducerRecord<>(eventTopic, Longs.toByteArray(mappedEvent.getId()), mappedEvent.toByteArray());
+            return new ProducerRecord<>(eventTopic, mappedEvent.toByteArray());
         }, recordMetadata -> {
             // We've got an ACK from the server that the event was forwarded
             // Let other threads know when we've successfully forwarded an event


### PR DESCRIPTION
Chose to send events without key since number of events could be too many and this may be better way to evenly distribute these messages.


### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-12784

