### PR TITLE
NMS-12768: Add ignore certificates property for ElasticSearch

### DIFF
--- a/features/alarms/history/elastic/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/features/alarms/history/elastic/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -26,6 +26,7 @@
             <cm:property name="proxy" value=""/>
             <cm:property name="retryCooldown" value="500" />
             <cm:property name="httpCompression" value="false"/>
+            <cm:property name="ignoreCertificates" value="false"/>
             <cm:property name="connTimeout" value="5000" /> <!-- 5 second timeout for Elasticsearch operations -->
             <cm:property name="readTimeout" value="30000" /> <!-- 30 second timeout for Elasticsearch socket reads -->
             <cm:property name="retries" value="0" /> <!-- Disable retries by default -->
@@ -106,6 +107,7 @@
         <property name="connTimeout" value="${connTimeout}" />
         <property name="readTimeout" value="${readTimeout}" />
         <property name="retries" value="${retries}" />
+        <property name="ignoreCertificates" value="${ignoreCertificates}"/>
     </bean>
 
     <!-- Actually creates the client, but only once -->

--- a/features/flows/elastic/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/features/flows/elastic/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -27,6 +27,7 @@
             <cm:property name="proxy" value=""/>
             <cm:property name="retryCooldown" value="500" />
             <cm:property name="httpCompression" value="false"/>
+            <cm:property name="ignoreCertificates" value="false"/>
             <cm:property name="connTimeout" value="5000" /> <!-- 5 second timeout for Elasticsearch operations -->
             <cm:property name="readTimeout" value="30000" /> <!-- 30 second timeout for Elasticsearch socket reads -->
             <cm:property name="retries" value="0" /> <!-- Disable retries by default -->
@@ -99,6 +100,7 @@
         <property name="connTimeout" value="${connTimeout}" />
         <property name="readTimeout" value="${readTimeout}" />
         <property name="retries" value="${retries}" />
+        <property name="ignoreCertificates" value="${ignoreCertificates}"/>
     </bean>
 
     <!-- Actually creates the client, but only once -->

--- a/features/opennms-es-rest/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/features/opennms-es-rest/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -21,6 +21,7 @@
       <cm:property name="elasticIndexStrategy" value="monthly" />
       <cm:property name="defaultMaxTotalConnectionPerRoute" value="-1" />
       <cm:property name="maxTotalConnection" value="-1" />
+      <cm:property name="ignoreCertificates" value="false"/>
       <cm:property name="nodeDiscovery" value="false" />
       <cm:property name="nodeDiscoveryFrequency" value="0" />
       <cm:property name="proxy" value=""/>
@@ -106,6 +107,7 @@
     <property name="connTimeout" value="${connTimeout}" />
     <property name="readTimeout" value="${readTimeout}" />
     <property name="retries" value="${retries}" />
+    <property name="ignoreCertificates" value="${ignoreCertificates}"/>
   </bean>
   <bean id="restClient" factory-ref="restClientFactory" factory-method="createClient" destroy-method="shutdownClient"/>
 

--- a/features/situation-feedback/elastic/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/features/situation-feedback/elastic/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -21,6 +21,7 @@
             <cm:property name="elasticIndexStrategy" value="monthly" />
             <cm:property name="defaultMaxTotalConnectionPerRoute" value="-1" />
             <cm:property name="maxTotalConnection" value="-1" />
+            <cm:property name="ignoreCertificates" value="false"/>
             <cm:property name="nodeDiscovery" value="false" />
             <cm:property name="nodeDiscoveryFrequency" value="0" />
             <cm:property name="proxy" value=""/>
@@ -66,6 +67,7 @@
         <property name="connTimeout" value="${connTimeout}" />
         <property name="readTimeout" value="${readTimeout}" />
         <property name="retries" value="${retries}" />
+        <property name="ignoreCertificates" value="${ignoreCertificates}"/>
     </bean>
 
     <bean id="jestClient" factory-ref="clientFactory" factory-method="createClient" destroy-method="shutdownClient"/>


### PR DESCRIPTION
Add property to allow insecure SSL/HTTPS connections


### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-12768

