### PR TITLE
NMS-12791: backport log4j update to foundation-2019

### DIFF
--- a/core/test-api/elasticsearch/pom.xml
+++ b/core/test-api/elasticsearch/pom.xml
@@ -94,12 +94,10 @@
      <dependency>
        <groupId>org.apache.logging.log4j</groupId>
        <artifactId>log4j-api</artifactId>
-       <version>2.7</version>
      </dependency>
      <dependency>
        <groupId>org.apache.logging.log4j</groupId>
        <artifactId>log4j-core</artifactId>
-       <version>2.13.2</version>
      </dependency>
      <dependency>
        <groupId>junit</groupId>

--- a/core/test-api/elasticsearch/pom.xml
+++ b/core/test-api/elasticsearch/pom.xml
@@ -99,7 +99,7 @@
      <dependency>
        <groupId>org.apache.logging.log4j</groupId>
        <artifactId>log4j-core</artifactId>
-       <version>2.7</version>
+       <version>2.13.2</version>
      </dependency>
      <dependency>
        <groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1402,7 +1402,7 @@
     <liquibaseVersion>3.6.3</liquibaseVersion>
     <lmaxDisruptorVersion>3.3.2</lmaxDisruptorVersion>
     <log4jVersion>99.99.99-use-log4j2</log4jVersion>
-    <log4j2Version>2.8.2</log4j2Version>
+    <log4j2Version>2.13.2</log4j2Version>
     <mapstructVersion>1.3.0.Final</mapstructVersion>
     <minaVersion>2.0.16</minaVersion>
     <mockitoVersion>1.10.19</mockitoVersion>


### PR DESCRIPTION
This backports the log4j updates from `release-26.x` to `foundation-2019`.  Just belt-and-suspenders making sure everything passes.