### PR TITLE
NMS-12811: change UEI so it does not block alarms from trap with same UEI

### DIFF
--- a/opennms-base-assembly/src/main/filtered/etc/events/Cisco.events.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/events/Cisco.events.xml
@@ -4990,7 +4990,7 @@
    <mevalue>0</mevalue>
   </maskelement>
  </mask>
- <uei>uei.opennms.org/vendor/Cisco/traps/logonIntruder</uei>
+ <uei>uei.opennms.org/vendor/Cisco/traps/CISCO-FASTHUB-MIB/logonIntruder</uei>
  <event-label>CISCO-FASTHUB-MIB defined trap event: logonIntruder</event-label>
  <descr>&lt;p&gt;A user is repeatedly trying to log on to the Management
  Console using an invalid password. The number of attempts

--- a/opennms-config/src/test/resources/org/opennms/netmgt/config/eventd/eventconf-speedtest/events/Cisco.events.xml
+++ b/opennms-config/src/test/resources/org/opennms/netmgt/config/eventd/eventconf-speedtest/events/Cisco.events.xml
@@ -4990,7 +4990,7 @@
    <mevalue>0</mevalue>
   </maskelement>
  </mask>
- <uei>uei.opennms.org/vendor/Cisco/traps/logonIntruder</uei>
+ <uei>uei.opennms.org/vendor/Cisco/traps/CISCO-FASTHUB-MIB/logonIntruder</uei>
  <event-label>CISCO-FASTHUB-MIB defined trap event: logonIntruder</event-label>
  <descr>&lt;p&gt;A user is repeatedly trying to log on to the Management
  Console using an invalid password. The number of attempts


### PR DESCRIPTION

### All Contributors

* [X] Have you read and followed our [Contribution Guidelines](https://github.com/OpenNMS/opennms/blob/develop/CONTRIBUTING.md)?
* [X] Have you [made an issue in the OpenNMS issue tracker](https://issues.opennms.org)?<br>If so, you should:
  1. update the title of this PR to be of the format: `${JIRA-ISSUE-NUMBER}: subject of pull request`
  2. update the JIRA link at the bottom of this comment to refer to the real issue number
  3. prefix your commit messages with the issue number, if possible
* [X] Have you made a comment in that issue which points back to this PR?
* [X] Have you updated the JIRA link at the bottom of this comment to link to your issue?
* [ ] If this is a new or updated feature, is there documentation for the new behavior?
* [ ] If this is new code, are there unit and/or integration tests?
* [ ] If this PR targets a `foundation-*` branch, does it avoid changing files in `$OPENNMS_HOME/etc/`?

### Pull Request Process

One or more reviewers should be assigned to each PR.

If you know that a particular person is subject matter expert in the area your PR affects, feel free to assign one or more reviewers when you create this PR, otherwise reviewers will be assigned for you.

If you have made additions or changes to the documentation, or if you _need_ documentation for these code changes, please make sure a technical writer has looked it over.

Once the reviewer(s) accept the PR and the branch passes continuous integration, the PR is eligible for merge.

At that time, if you have commit access (are an OpenNMS Group employee or a member of the Order of the Green Polo) you are welcome to merge the PR.
Otherwise, a reviewer can merge it for you.

Thanks for taking time to contribute!

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-12811

