### PR TITLE
NMS-12769: fix pid file handling

### DIFF
--- a/container/karaf/src/main/filtered-resources/etc/config.properties
+++ b/container/karaf/src/main/filtered-resources/etc/config.properties
@@ -200,7 +200,7 @@ karaf.shutdown.port.file=${karaf.data}/port
 #
 # The location of the Karaf pid file
 #
-karaf.pid.file=${karaf.base}/karaf.pid
+karaf.pid.file=${karaf.log}/karaf.pid
 
 #
 # Configuration FileMonitor properties

--- a/core/daemon/src/main/java/org/opennms/netmgt/vmmgr/Controller.java
+++ b/core/daemon/src/main/java/org/opennms/netmgt/vmmgr/Controller.java
@@ -307,10 +307,9 @@ public class Controller {
         try {
             // Check to see if the com.sun.tools.attach classes are loadable in
             // this JVM
-            Class<?> clazz;
-            clazz = Class.forName("com.sun.tools.attach.VirtualMachine");
-            clazz = Class.forName("com.sun.tools.attach.VirtualMachineDescriptor");
-            clazz = Class.forName("com.sun.tools.attach.AttachNotSupportedException");
+            Class.forName("com.sun.tools.attach.VirtualMachine");
+            Class.forName("com.sun.tools.attach.VirtualMachineDescriptor");
+            Class.forName("com.sun.tools.attach.AttachNotSupportedException");
         } catch (ClassNotFoundException e) {
             LOG.info("The Attach API is not available in this JVM, falling back to JMX over RMI");
             return m_jmxUrl;

--- a/core/daemon/src/main/java/org/opennms/netmgt/vmmgr/StatusGetter.java
+++ b/core/daemon/src/main/java/org/opennms/netmgt/vmmgr/StatusGetter.java
@@ -68,7 +68,8 @@ public class StatusGetter {
      *
      * @throws java.lang.Exception if any.
      */
-    public void queryStatus() throws Exception {
+    @SuppressWarnings("unchecked")
+	public void queryStatus() throws Exception {
 
         Pattern p = Pattern.compile("Status: OpenNMS:Name=(\\S+) = (\\S+)");
 

--- a/debian/rules
+++ b/debian/rules
@@ -6,7 +6,7 @@
 export DH_VERBOSE=1
 export SHELL=/bin/bash
 
-export JAVA_HOME=$(shell opennms-base-assembly/src/main/filtered/bin/find-java.sh 1.8 11.9999)
+export JAVA_HOME=$(shell core/cli/src/main/resources/bin/find-java.sh 1.8 1.9)
 
 export OPTS_ASSEMBLIES=-Passemblies
 export OPTS_PROFILES=-Prun-expensive-tasks
@@ -15,7 +15,7 @@ export BUILDDEFINES=\
 	-Dopennms.home=/usr/share/opennms \
 	-Ddist.dir=$(CURDIR)/debian -Ddist.name=temp \
 	-Dinstall.dir=/usr/share/opennms \
-	-Dinstall.init.dir=/etc/init.d \
+	-Dinstall.init.dir=/usr/share/opennms/bin \
 	-Dinstall.rrdtool.bin=/usr/bin/rrdtool \
 	-Dinstall.share.dir=/var/lib/opennms \
 	-Dinstall.servlet.dir=/usr/share/opennms/webapps \
@@ -231,6 +231,7 @@ install: build
 	mv debian/temp/share/xsds/* debian/opennms-common/var/lib/opennms/xsds/
 	find debian/opennms-common/etc/opennms -type f -execdir chmod 644 {} \;
 	chmod 640 debian/opennms-common/etc/opennms/users.xml
+	install -c -m 644 debian/opennms-common/etc/opennms/opennms.service debian/opennms-common.opennms.service
 	
 	# move karaf stuff to common
 	mv debian/temp/{data,deploy,system} debian/opennms-common/usr/share/opennms/
@@ -338,7 +339,7 @@ binary-indep: build install
 	dh_testdir
 	dh_testroot
 	dh_installdocs
-	dh_systemd_enable --name=opennms --no-enable debian/opennms-common/etc/opennms/opennms.service
+	dh_systemd_enable --name=opennms --no-enable
 	dh_installinit --package=opennms-server --name=opennms --no-start -u"defaults 21 19"
 	dh_installinit --package=opennms-remote-poller --no-start -u"defaults 21 19"
 	dh_systemd_start --name=opennms --no-restart-after-upgrade

--- a/makedeb.sh
+++ b/makedeb.sh
@@ -10,7 +10,7 @@ cd "$TOPDIR"
 
 JAVA_HOME=`"$TOPDIR/bin/javahome.pl"`
 
-BINARIES="dch dpkg-sig dpkg-buildpackage expect"
+BINARIES="dch dh dh_systemd_enable dpkg-sig dpkg-buildpackage expect po2debconf"
 
 function exists() {
     which "$1" >/dev/null 2>&1
@@ -139,6 +139,7 @@ for BIN in $BINARIES; do
     EXECUTABLE=`which $BIN 2>/dev/null || :`
     if [ -z "$EXECUTABLE" ] || [ ! -x "$EXECUTABLE" ]; then
         echo "ERROR: $BIN not found"
+        echo "       try 'sudo apt install debhelper devscripts dh-systemd dpkg-dev dpkg-sig expect nsis po-debconf'"
         exit 1
     fi
 done

--- a/opennms-base-assembly/src/main/filtered/bin/opennms
+++ b/opennms-base-assembly/src/main/filtered/bin/opennms
@@ -429,31 +429,33 @@ doStart(){
 	fi
 
 	CMD=("${JAVA_CMD[@]}" "${APP_VM_PARMS[@]}" -jar "$BOOTSTRAP" "${APP_PARMS_CONTROLLER[@]}" "${APP_PARMS_BEFORE[@]}" "$@" "${APP_PARMS_AFTER[@]}")
-	if [ "$BACKGROUND" = 1 ]; then
-		# shellcheck disable=SC2129
-		{
-			echo "------------------------------------------------------------------------------"
-			date
-			echo "begin ulimit settings:"
-			ulimit -a
-			echo "end ulimit settings"
-			echo "Executing command:" "${CMD[@]}"
-		} >> "$REDIRECT"
-
-		# NMS-12226 runCmd & spawns a subshell process for the function runCmd which is not the PID of the java process.
-		# To avoid this spawn the command directly so the $! is the PID of java.
-		if [[ "$NOEXECUTE" == "0" ]]; then
-			"${CMD[@]}" >>"$REDIRECT" 2>&1 &
-		else
-			echo "Skipping execution: ${CMD[*]}"
+	if [ "$SYSTEMD" = 1 ]; then
+		if [ "$BACKGROUND" = 0 ]; then
+			echo "WARNING: -s (systemd) was passed, -f (foreground) is ignored" >&2
 		fi
-		OPENNMS_PID="$!"
-		echo "$OPENNMS_PID" > "$OPENNMS_PIDFILE"
-	else
 		echo "running ulimit -a"
 		ulimit -a
-		runCmd "${CMD[@]}"
-		exit $?
+		runCmd "${CMD[@]}" &
+		exit 0
+	else
+		if [ "$BACKGROUND" = 1 ]; then
+			# shellcheck disable=SC2129
+			{
+				echo "------------------------------------------------------------------------------"
+				date
+				echo "begin ulimit settings:"
+				ulimit -a
+				echo "end ulimit settings"
+				echo "Executing command:" "${CMD[@]}"
+			} >> "$REDIRECT"
+
+			runCmd "${CMD[@]}" >> "$REDIRECT" 2>&1 &
+		else
+			echo "running ulimit -a"
+			ulimit -a
+			runCmd "${CMD[@]}"
+			exit $?
+		fi
 	fi
 
 	if [ "$START_TIMEOUT" -eq 0 ]; then
@@ -690,6 +692,10 @@ MANAGER_OPTIONS+=("-XX:+HeapDumpOnOutOfMemoryError")
 JAVA_VERSION="$("$OPENNMS_HOME/bin/runjava" -p -f 2> /dev/null)"
 JAVA_SHORT_VERSION="$(echo "$JAVA_VERSION" | cut -d. -f1)"
 
+# make sure a PID is written
+MANAGER_OPTIONS+=("-Dopennms.pidfile=${OPENNMS_PIDFILE}")
+CONTROLLER_OPTIONS+=("-Dopennms.pidfile=${OPENNMS_PIDFILE}")
+
 JAVA_MODULES=(
 	java.base \
 	java.compiler \
@@ -804,16 +810,20 @@ OPROFILE=0
 NOEXECUTE=0
 VERBOSE=0
 BACKGROUND=1
+SYSTEMD=0
 
 NAME="opennms"
 
-while getopts c:fntvpoQ c; do
+while getopts c:fsntvpoQ c; do
 	case $c in
 		c)
 			APP_PARMS_CONTROLLER+=("-t" "$OPTARG")
 			;;
 		f)
 			BACKGROUND=0
+			;;
+		s)
+			SYSTEMD=1
 			;;
 		n)
 			NOEXECUTE=1
@@ -875,6 +885,11 @@ if [ x"$myuser" = x"$RUNAS" ]; then
 else
 	echo "Error: you must run this script as $RUNAS, not '$myuser'" >&2
 	exit 4	# According to LSB: 4 - user had insufficient privileges
+fi
+
+if [ -e "${OPENNMS_PIDFILE}" ]; then
+	# if the file already exists, make sure it's writable in the future
+	chown "${RUNAS}" "${OPENNMS_PIDFILE}"
 fi
 
 case "$COMMAND" in

--- a/opennms-base-assembly/src/main/filtered/bin/opennms
+++ b/opennms-base-assembly/src/main/filtered/bin/opennms
@@ -351,6 +351,18 @@ runCmd(){
 	fi
 }
 
+clearPids(){
+	for PIDFILE in \
+		"${OPENNMS_PIDFILE}" \
+		"/karaf.pid" \
+		"${LOG_DIRECTORY}/karaf.pid" \
+	; do
+		if [ -n "${PIDFILE}" ] && [ -r "${PIDFILE}" ]; then
+			rm -f "${PIDFILE}"
+		fi
+	done
+}
+
 doStart(){
 	checkConfigured || return 1
 	checkXmlFiles   || return 1
@@ -557,7 +569,7 @@ doStop() {
 	while [ "$STATUS_ATTEMPTS" -lt "$STOP_TIMEOUT" ]; do
 		doStatus "$@"
 		if [ "$?" -eq 3 ]; then
-			echo "" > "$OPENNMS_PIDFILE"
+			clearPids
 			return 0
 		fi
 
@@ -606,7 +618,7 @@ doKill(){
 		fi
 	fi
 
-	echo "" > "$OPENNMS_PIDFILE"
+	clearPids
 	return 0
 }
 
@@ -949,6 +961,11 @@ case "$COMMAND" in
 				echo "failed"
 			fi
 		fi
+
+		if [ "$__ret" -eq 0 ]; then
+			clearPids
+		fi
+
 		exit "$__ret"
 		;;
 

--- a/opennms-base-assembly/src/main/filtered/bin/opennms
+++ b/opennms-base-assembly/src/main/filtered/bin/opennms
@@ -428,7 +428,7 @@ doStart(){
 		APP_VM_PARMS=("-Dorg.apache.jasper.compiler.disablejsr199=true" "${APP_VM_PARMS[@]}")
 	fi
 
-	CMD=("${JAVA_CMD[@]}" "${APP_VM_PARMS[@]}" -jar "$BOOTSTRAP" "${APP_PARMS_CONTROLLER[@]}" "${APP_PARMS_BEFORE[@]}" "$@" "${APP_PARMS_AFTER[@]}")
+	CMD=("${JAVA_CMD[@]}" "-Dopennms.pidfile=${OPENNMS_PIDFILE}" "${APP_VM_PARMS[@]}" -jar "$BOOTSTRAP" "${APP_PARMS_CONTROLLER[@]}" "${APP_PARMS_BEFORE[@]}" "$@" "${APP_PARMS_AFTER[@]}")
 	if [ "$SYSTEMD" = 1 ]; then
 		if [ "$BACKGROUND" = 0 ]; then
 			echo "WARNING: -s (systemd) was passed, -f (foreground) is ignored" >&2
@@ -691,10 +691,6 @@ MANAGER_OPTIONS+=("-Xmx${JAVA_HEAP_SIZE}m")
 MANAGER_OPTIONS+=("-XX:+HeapDumpOnOutOfMemoryError")
 JAVA_VERSION="$("$OPENNMS_HOME/bin/runjava" -p -f 2> /dev/null)"
 JAVA_SHORT_VERSION="$(echo "$JAVA_VERSION" | cut -d. -f1)"
-
-# make sure a PID is written
-MANAGER_OPTIONS+=("-Dopennms.pidfile=${OPENNMS_PIDFILE}")
-CONTROLLER_OPTIONS+=("-Dopennms.pidfile=${OPENNMS_PIDFILE}")
 
 JAVA_MODULES=(
 	java.base \

--- a/opennms-base-assembly/src/main/filtered/etc/opennms.service
+++ b/opennms-base-assembly/src/main/filtered/etc/opennms.service
@@ -8,10 +8,10 @@ After=${install.postgresql.service}.service postgresql-10.service postgresql-11.
 User=root
 Environment="OPENNMS_HOME=${install.dir}"
 
-Type=simple
+Type=forking
 PIDFile=${install.pid.file}
 
-ExecStart=${install.init.dir}/opennms -f start
+ExecStart=${install.init.dir}/opennms -s start
 ExecStop=${install.init.dir}/opennms stop
 
 [Install]

--- a/opennms-bootstrap/pom.xml
+++ b/opennms-bootstrap/pom.xml
@@ -36,4 +36,11 @@
       </plugin>
     </plugins>
   </build>
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
 </project>

--- a/opennms-bootstrap/src/main/java/org/opennms/bootstrap/Bootstrap.java
+++ b/opennms-bootstrap/src/main/java/org/opennms/bootstrap/Bootstrap.java
@@ -256,7 +256,7 @@ public abstract class Bootstrap {
             // Descend into sub-directories
             File[] dirlist = dir.listFiles(m_dirFilter);
             if (dirlist != null) {
-            	Arrays.sort(dirlist);
+                Arrays.sort(dirlist);
                 for (File childDir : dirlist) {
                     loadClasses(childDir, recursive, urls);
                 }
@@ -266,7 +266,7 @@ public abstract class Bootstrap {
         // Add individual JAR files
         File[] children = dir.listFiles(m_jarFilter);
         if (children != null) {
-        	Arrays.sort(children);
+            Arrays.sort(children);
             for (File childFile : children) {
                 urls.add(childFile.toURI().toURL());
             }
@@ -357,7 +357,7 @@ public abstract class Bootstrap {
                 if (DEBUG) { System.err.println("Skipping: " + propertiesFile.getAbsolutePath()); }
             }
         }
-	}
+    }
 
     /**
      * Validates the OpenNMS home directory by checking
@@ -500,11 +500,11 @@ public abstract class Bootstrap {
         }
 
         if (System.getProperty("org.opennms.protocols.icmp.interfaceJar") != null) {
-        	dir += File.pathSeparator + System.getProperty("org.opennms.protocols.icmp.interfaceJar");
+            dir += File.pathSeparator + System.getProperty("org.opennms.protocols.icmp.interfaceJar");
         }
         
         if (System.getProperty("org.opennms.rrd.interfaceJar") != null) {
-        	dir += File.pathSeparator + System.getProperty("org.opennms.rrd.interfaceJar");
+            dir += File.pathSeparator + System.getProperty("org.opennms.rrd.interfaceJar");
         }
 
         if (DEBUG) {

--- a/opennms-bootstrap/src/main/java/org/opennms/bootstrap/BootstrapUtils.java
+++ b/opennms-bootstrap/src/main/java/org/opennms/bootstrap/BootstrapUtils.java
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.bootstrap;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.RuntimeMXBean;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+public abstract class BootstrapUtils {
+
+    static String getPid() {
+        final RuntimeMXBean runtime = ManagementFactory.getRuntimeMXBean();
+        try {
+            final Method getPid = runtime.getClass().getMethod("getPid");
+            if (getPid != null) {
+                final long pid = (long) getPid.invoke(runtime);
+                return String.valueOf(pid);
+            }
+        } catch (final NoSuchMethodException e) {
+            // we're on Java 8, fall back to using `RuntimeMXBean#getName`
+        } catch (IllegalAccessException|IllegalArgumentException|InvocationTargetException|SecurityException e) {
+            System.err.println("Unable to determine PID: " + e.getLocalizedMessage());
+        }
+
+        final int at = runtime.getName().indexOf("@");
+        if (at > 0) {
+            return runtime.getName().substring(0, at);
+        } else {
+            System.err.println("WARNING: unable to determine PID from runtime: " + runtime.getName());
+        }
+
+        return "";
+    }
+
+}

--- a/opennms-bootstrap/src/test/java/org/opennms/bootstrap/BootstrapUtilsTest.java
+++ b/opennms-bootstrap/src/test/java/org/opennms/bootstrap/BootstrapUtilsTest.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.bootstrap;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class BootstrapUtilsTest {
+    static {
+        System.setProperty("opennms.home", "/");
+    }
+    @Test
+    public void testGetPid() {
+        final String pid = BootstrapUtils.getPid();
+        assertNotNull(pid);
+        assertTrue(pid.length() > 0);
+        assertTrue(Long.valueOf(pid) > 0);
+    }
+}

--- a/opennms-container/horizon/container-fs/entrypoint.sh
+++ b/opennms-container/horizon/container-fs/entrypoint.sh
@@ -134,6 +134,7 @@ start() {
   local OPENNMS_JAVA_OPTS="--add-modules=java.base,java.compiler,java.datatransfer,java.desktop,java.instrument,java.logging,java.management,java.management.rmi,java.naming,java.prefs,java.rmi,java.scripting,java.security.jgss,java.security.sasl,java.sql,java.sql.rowset,java.xml,jdk.attach,jdk.httpserver,jdk.jdi,jdk.sctp,jdk.security.auth,jdk.xml.dom \
   -Dorg.apache.jasper.compiler.disablejsr199=true
   -Dopennms.home=/opt/opennms
+  -Dopennms.pidfile=/opt/opennms/logs/opennms.pid
   -XX:+HeapDumpOnOutOfMemoryError
   -Dcom.sun.management.jmxremote.authenticate=true
   -Dcom.sun.management.jmxremote.login.config=opennms


### PR DESCRIPTION
This PR fixes 2 things:

1. writing the PID file even when running under systemd (which previously used the `-f` option to run in the foreground)
2. put `karaf.pid` back into the logs directory; I assume this got missed in a karaf upgrade/merge and reverted to writing to `$OPENNMS_HOME/karaf.pid` rather than `$OPENNMS_HOME/logs/karaf.pid`

It retrieves the PID from a supported API on Java 10+, and falls back to using the same approach as spring boot on earlier JDKs (parsing it out of `RuntimeMXBean.getName()`).

JIRA: https://issues.opennms.org/browse/NMS-12769