### PR TITLE
NMS-12818: Log and throw custom exception when the response  is truncated.

### DIFF
--- a/core/snmp/api/src/main/java/org/opennms/netmgt/snmp/SnmpResponseException.java
+++ b/core/snmp/api/src/main/java/org/opennms/netmgt/snmp/SnmpResponseException.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.snmp;
+
+public class SnmpResponseException extends RuntimeException {
+
+    private static final long serialVersionUID = 8253792214863599913L;
+
+    public SnmpResponseException(String message) {
+        super(message);
+    }
+
+    public SnmpResponseException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/core/snmp/proxy-rpc-impl/src/main/java/org/opennms/netmgt/snmp/proxy/common/SnmpProxyRpcModule.java
+++ b/core/snmp/proxy-rpc-impl/src/main/java/org/opennms/netmgt/snmp/proxy/common/SnmpProxyRpcModule.java
@@ -176,7 +176,8 @@ public class SnmpProxyRpcModule extends AbstractXmlRpcModule<SnmpRequestDTO, Snm
         final CompletableFuture<SnmpValue[]> future = SnmpUtils.getAsync(request.getAgent(), oids);
         return future.thenApply(values -> {
             final List<SnmpResult> results = new ArrayList<>(oids.length);
-            for (int i = 0; i < oids.length; i++) {
+            int len = Math.min(oids.length, values.length);
+            for (int i = 0; i < len; i++) {
                 final SnmpResult result = new SnmpResult(oids[i], null, values[i]);
                 results.add(result);
             }


### PR DESCRIPTION
Although call stack doesn't provide good clue on where this is happening
this looks like more probable cause for the bug.


### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-12818

