### PR TITLE
NMS-6470: allow hashing of password when creating or updating users

### DIFF
--- a/opennms-doc/guide-development/src/asciidoc/text/rest/users.adoc
+++ b/opennms-doc/guide-development/src/asciidoc/text/rest/users.adoc
@@ -22,6 +22,7 @@ You may need to touch the `$OPENNMS_HOME/etc/users.xml` file on the filesystem f
 | Parameter | Description
 | `/users`  | Add a user. If supplying a password it is assumed to be hashed or encrypted already, at least as of 1.12.5.
               To indicate that the supplied password uses the salted encryption algorithm rather than the older _MD5_ based algorithm, you need to pass an element named `passwordSalt` with text `true` after the password element (or key/value pairs if using _JSON_).
+              Note: You may add the query parameter `hashPassword=true` to tell OpenNMS you are passing an unencrypted password; it will hash and salt the password when it is saved.
 |===
 
 ===== PUTs (Modifying Data)
@@ -30,6 +31,7 @@ You may need to touch the `$OPENNMS_HOME/etc/users.xml` file on the filesystem f
 |===
 | Parameter                            | Description
 | `/users/{username}`                  | Update an existing user's full-name, user-comments, password, passwordSalt and duty-schedule values.
+                                         Note: You may add the query parameter `hashPassword=true` to tell OpenNMS you are passing an unencrypted password; it will hash and salt the password when it is saved.
 | `/users/{username}/roles/{rolename}` | Add a security role to the user. (new in OpenNMS 19)
 |===
 

--- a/opennms-doc/guide-development/src/asciidoc/text/rest/users.adoc
+++ b/opennms-doc/guide-development/src/asciidoc/text/rest/users.adoc
@@ -31,7 +31,7 @@ You may need to touch the `$OPENNMS_HOME/etc/users.xml` file on the filesystem f
 |===
 | Parameter                            | Description
 | `/users/{username}`                  | Update an existing user's full-name, user-comments, password, passwordSalt and duty-schedule values.
-                                         Note: You may add the query parameter `hashPassword=true` to tell OpenNMS you are passing an unencrypted password; it will hash and salt the password when it is saved.
+                                         Note: If you are setting the password, you may also add the query parameter `hashPassword=true` to tell OpenNMS you are passing an unencrypted password; it will hash and salt the password when it is saved.
 | `/users/{username}/roles/{rolename}` | Add a security role to the user. (new in OpenNMS 19)
 |===
 

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/UserRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/UserRestService.java
@@ -146,6 +146,7 @@ public class UserRestService extends OnmsRestService {
             final OnmsUser user = getOnmsUser(userCriteria);
             LOG.debug("updateUser: updating user {}", user);
             boolean modified = false;
+            boolean passwordModified = false;
             boolean hashPassword = false;
             final BeanWrapper wrapper = PropertyAccessorFactory.forBeanPropertyAccess(user);
             for(final String key : params.keySet()) {
@@ -154,6 +155,9 @@ public class UserRestService extends OnmsRestService {
                     final Object value = wrapper.convertIfNecessary(stringValue, wrapper.getPropertyType(key));
                     wrapper.setPropertyValue(key, value);
                     modified = true;
+                }
+                if (key.equals("password")) {
+                    passwordModified = true;
                 } else if (key.equals("hashPassword")) {
                     hashPassword = Boolean.valueOf(params.getFirst("hashPassword"));
                 }
@@ -161,7 +165,7 @@ public class UserRestService extends OnmsRestService {
             if (modified) {
                 LOG.debug("updateUser: user {} updated", user);
                 try {
-                    if (hashPassword) hashPassword(user);
+                    if (passwordModified && hashPassword) hashPassword(user);
                     m_userManager.save(user);
                 } catch (final Throwable t) {
                     throw getException(Status.INTERNAL_SERVER_ERROR, t);


### PR DESCRIPTION
This PR allows optionally hashing passwords upon saving when creating or updating users in the ReSTv1 interface.  I made it an optional URL parameter to make it easy to stay backwards-compatible with any existing scripts that might be interacting with the user rest service; you have to opt-in by adding `hashPassword=true` to trigger hashing before storing.

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-6470

