### PR TITLE
NMS-12722: Handle fully overlapping RRAs

### DIFF
--- a/features/newts-repository-converter/src/main/java/org/opennms/features/newts/converter/NewtsConverter.java
+++ b/features/newts-repository-converter/src/main/java/org/opennms/features/newts/converter/NewtsConverter.java
@@ -735,6 +735,12 @@ public class NewtsConverter implements AutoCloseable {
                 samples = samples.headMap((int) Math.ceil(((double) lowerRraStart) / ((double) rraStep)) * rraStep, false);
             }
 
+            if (samples.isEmpty()) {
+                // The whole timespan of this RRA is covered by an RRA with an higher resolution - so there is nothing
+                // to add from this RRA
+                continue;
+            }
+
             final AbstractRRA higherRra = rras.higher(rra);
             if (higherRra != null) {
                 final long higherRraStep = higherRra.getPdpPerRow() * rrd.getStep();


### PR DESCRIPTION
Fix handling of RRDs where there are RRAs which have a timespan which is
also covered completely by a RRA with a higher resolution.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-12722

