### PR TITLE
NMS-12817: allow forcing use of SHA-256 passwords

### DIFF
--- a/core/test-api/services/src/test/resources/org/opennms/netmgt/config/mock/users.xml
+++ b/core/test-api/services/src/test/resources/org/opennms/netmgt/config/mock/users.xml
@@ -10,21 +10,21 @@
            <user-id>brozow</user-id>
            <full-name>Mathew Brozowski</full-name>
            <user-comments>Test User</user-comments>
-           <password>21232F297A57A5A743894A0E4A801FC3</password>
+           <password salt="true">gU2wmSW7k9v1xg4/MrAsaI+VyddBAhJJt4zPX5SGG0BK+qiASGnJsqM8JOug/aEL</password>
            <contact type="email" info="brozow@opennms.org"/>
        </user>
        <user>
            <user-id>admin</user-id>
            <full-name>Administrator</full-name>
            <user-comments>Default administrator, do not delete</user-comments>
-           <password>21232F297A57A5A743894A0E4A801FC3</password>
+           <password salt="true">gU2wmSW7k9v1xg4/MrAsaI+VyddBAhJJt4zPX5SGG0BK+qiASGnJsqM8JOug/aEL</password>
            <contact type="email" info="admin@opennms.org"/>
        </user>
        <user>
            <user-id>upUser</user-id>
            <full-name>User that receives up notifications</full-name>
            <user-comments>Default administrator, do not delete</user-comments>
-           <password>21232F297A57A5A743894A0E4A801FC3</password>
+           <password salt="true">gU2wmSW7k9v1xg4/MrAsaI+VyddBAhJJt4zPX5SGG0BK+qiASGnJsqM8JOug/aEL</password>
            <contact type="email" info="up@opennms.org"/>
        </user>
        <user>

--- a/core/upgrade/src/test/resources/etc/users.xml
+++ b/core/upgrade/src/test/resources/etc/users.xml
@@ -10,31 +10,31 @@
             <user-id>admin</user-id>
             <full-name>Administrator</full-name>
             <user-comments>Default administrator, do not delete</user-comments>
-            <password>21232F297A57A5A743894A0E4A801FC3</password>
+            <password salt="true">gU2wmSW7k9v1xg4/MrAsaI+VyddBAhJJt4zPX5SGG0BK+qiASGnJsqM8JOug/aEL</password>
         </user>
         <user>
             <user-id>agalue</user-id>
             <full-name>Alejandro Galue</full-name>
             <user-comments></user-comments>
-            <password>21232F297A57A5A743894A0E4A801FC3</password>
+            <password salt="true">gU2wmSW7k9v1xg4/MrAsaI+VyddBAhJJt4zPX5SGG0BK+qiASGnJsqM8JOug/aEL</password>
         </user>
         <user>
             <user-id>operator</user-id>
             <full-name>Operator</full-name>
             <user-comments></user-comments>
-            <password>21232F297A57A5A743894A0E4A801FC3</password>
+            <password salt="true">gU2wmSW7k9v1xg4/MrAsaI+VyddBAhJJt4zPX5SGG0BK+qiASGnJsqM8JOug/aEL</password>
         </user>
         <user read-only="true">
             <user-id>manager</user-id>
             <full-name>Operator</full-name>
             <user-comments></user-comments>
-            <password>21232F297A57A5A743894A0E4A801FC3</password>
+            <password salt="true">gU2wmSW7k9v1xg4/MrAsaI+VyddBAhJJt4zPX5SGG0BK+qiASGnJsqM8JOug/aEL</password>
         </user>
         <user>
             <user-id>jmx_operator</user-id>
             <full-name>JMX Operator (for JMX Remote Access Only)</full-name>
             <user-comments></user-comments>
-            <password>21232F297A57A5A743894A0E4A801FC3</password>
+            <password salt="true">gU2wmSW7k9v1xg4/MrAsaI+VyddBAhJJt4zPX5SGG0BK+qiASGnJsqM8JOug/aEL</password>
         </user>
     </users>
 </userinfo>

--- a/features/springframework-security/src/test/java/org/opennms/web/springframework/security/SpringSecurityUserDaoImplIT.java
+++ b/features/springframework-security/src/test/java/org/opennms/web/springframework/security/SpringSecurityUserDaoImplIT.java
@@ -101,7 +101,7 @@ public class SpringSecurityUserDaoImplIT implements InitializingBean {
         assertEquals("OnmsUser name", "admin", user.getUsername());
         assertEquals("Full name", "Administrator", user.getFullName());
         assertEquals("Comments", "Default administrator, do not delete", user.getComments());
-        assertEquals("Password", "21232F297A57A5A743894A0E4A801FC3", user.getPassword());
+        assertEquals("Password", "gU2wmSW7k9v1xg4/MrAsaI+VyddBAhJJt4zPX5SGG0BK+qiASGnJsqM8JOug/aEL", user.getPassword());
 
         Collection<? extends GrantedAuthority> authorities = user.getAuthorities();
         assertNotNull("authorities should not be null", authorities);

--- a/features/springframework-security/src/test/resources/org/opennms/web/springframework/security/users.xml
+++ b/features/springframework-security/src/test/resources/org/opennms/web/springframework/security/users.xml
@@ -12,7 +12,7 @@
       <user-comments>
         Default administrator, do not delete
       </user-comments>
-      <password>21232F297A57A5A743894A0E4A801FC3</password>
+      <password salt="true">gU2wmSW7k9v1xg4/MrAsaI+VyddBAhJJt4zPX5SGG0BK+qiASGnJsqM8JOug/aEL</password>
       <role>ROLE_ADMIN</role>
     </user>
     <user>

--- a/opennms-base-assembly/src/main/filtered/etc/opennms.properties
+++ b/opennms-base-assembly/src/main/filtered/etc/opennms.properties
@@ -260,6 +260,9 @@ java.awt.headless=true
 # If you change the above query to load the snmpInterfaces along with the if and node data then set this true
 # org.opennms.netmgt.collectd.DefaultCollectionAgent.loadSnmpDataOnInit=false
 
+# Set this to false to disallow creating/storing old-style MD5-hashed passwords
+# org.opennms.users.allowUnsalted=true
+
 ###### REPORTING ######
 opennms.report.template.dir=${install.dir}/etc
 opennms.report.dir=${install.share.dir}/reports

--- a/opennms-base-assembly/src/main/filtered/etc/users.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/users.xml
@@ -9,14 +9,14 @@
          <user-id>admin</user-id>
          <full-name>Administrator</full-name>
          <user-comments>Default administrator, do not delete</user-comments>
-         <password>21232F297A57A5A743894A0E4A801FC3</password>
+         <password salt="true">gU2wmSW7k9v1xg4/MrAsaI+VyddBAhJJt4zPX5SGG0BK+qiASGnJsqM8JOug/aEL</password>
          <role>ROLE_ADMIN</role>
       </user>
       <user>
          <user-id>rtc</user-id>
          <full-name>RTC</full-name>
          <user-comments>RTC user, do not delete</user-comments>
-         <password>68154466F81BFB532CD70F8C71426356</password>
+         <password salt="true">sHMy+HycWKGJC/uUMF0IGlXUXP1KhcqD0GEchFlvYTw40jT9r+zMxOb3F+phWNzX</password>
          <role>ROLE_RTC</role>
       </user>
    </users>

--- a/opennms-config/src/test/java/org/opennms/netmgt/config/UserFactoryTest.java
+++ b/opennms-config/src/test/java/org/opennms/netmgt/config/UserFactoryTest.java
@@ -1,0 +1,105 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.config;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+
+import org.junit.Test;
+import org.opennms.netmgt.config.users.User;
+import org.opennms.test.DaoTestConfigBean;
+import org.springframework.util.FileSystemUtils;
+
+import com.google.common.io.Files;
+
+public class UserFactoryTest {
+	@Test(expected=IllegalStateException.class)
+	public void testSaveUserNoMD5() throws Exception {
+		configureUserFactory(false);
+		final User user = new User();
+		user.setUserId("test");
+		user.setPassword("foo", false);
+		final UserManager um = UserFactory.getInstance();
+		um.saveUser("test", user);
+	}
+
+	@Test(expected=IllegalStateException.class)
+	public void testSaveUsersNoMD5() throws Exception {
+		configureUserFactory(false);
+		final User user1 = new User();
+		user1.setUserId("test");
+		user1.setPassword("foo", true);
+
+		final User user2 = new User();
+		user2.setUserId("test2");
+		user2.setPassword("blah", false);
+		final UserManager um = UserFactory.getInstance();
+		um.saveUsers(Arrays.asList(user1, user2));
+	}
+
+	@Test
+	public void testSaveUserAllowMD5() throws Exception {
+		configureUserFactory(true);
+		final User user = new User();
+		user.setUserId("test");
+		user.setPassword("foo", false);
+		final UserManager um = UserFactory.getInstance();
+		um.saveUser("test", user);
+	}
+
+	@Test
+	public void testSaveUsersAllowMD5() throws Exception {
+		configureUserFactory(true);
+		final User user1 = new User();
+		user1.setUserId("test");
+		user1.setPassword("foo", true);
+
+		final User user2 = new User();
+		user2.setUserId("test2");
+		user2.setPassword("blah", false);
+		final UserManager um = UserFactory.getInstance();
+		um.saveUsers(Arrays.asList(user1, user2));
+	}
+
+	private void configureUserFactory(final boolean allowUnsalted) throws Exception {
+		final DaoTestConfigBean daoTestConfig = new DaoTestConfigBean();
+		daoTestConfig.afterPropertiesSet();
+
+		final Path opennmsHome = Paths.get(System.getProperty("opennms.home"));
+		final Path tempHome = Files.createTempDir().toPath();
+
+		System.err.println("opennms.home=" + tempHome);
+		FileSystemUtils.copyRecursively(opennmsHome.resolve("etc").toFile(), tempHome.resolve("etc").toFile());
+		System.setProperty("opennms.home", tempHome.toAbsolutePath().toString());
+		System.setProperty(UserFactory.ALLOW_UNSALTED_PROPERTY, String.valueOf(allowUnsalted));
+		UserFactory.setInstance(null);
+		UserFactory.init();
+	}
+}

--- a/opennms-services/src/test/resources/org/opennms/netmgt/notifd/users.xml
+++ b/opennms-services/src/test/resources/org/opennms/netmgt/notifd/users.xml
@@ -10,28 +10,28 @@
            <user-id>trapd</user-id>
            <full-name>SNMP Trapd</full-name>
            <user-comments>User that receives trap notifications</user-comments>
-           <password>21232F297A57A5A743894A0E4A801FC3</password>
+           <password salt="true">gU2wmSW7k9v1xg4/MrAsaI+VyddBAhJJt4zPX5SGG0BK+qiASGnJsqM8JOug/aEL</password>
            <contact type="snmpTrap" info="Destination for SNMP Trap/Notifications"/>
        </user>
        <user>
            <user-id>brozow</user-id>
            <full-name>Mathew Brozowski</full-name>
            <user-comments>Test User</user-comments>
-           <password>21232F297A57A5A743894A0E4A801FC3</password>
+           <password salt="true">gU2wmSW7k9v1xg4/MrAsaI+VyddBAhJJt4zPX5SGG0BK+qiASGnJsqM8JOug/aEL</password>
            <contact type="email" info="brozow@opennms.org"/>
        </user>
        <user>
            <user-id>admin</user-id>
            <full-name>Administrator</full-name>
            <user-comments>Default administrator, do not delete</user-comments>
-           <password>21232F297A57A5A743894A0E4A801FC3</password>
+           <password salt="true">gU2wmSW7k9v1xg4/MrAsaI+VyddBAhJJt4zPX5SGG0BK+qiASGnJsqM8JOug/aEL</password>
            <contact type="email" info="admin@opennms.org"/>
        </user>
        <user>
            <user-id>upUser</user-id>
            <full-name>User that receives up notifications</full-name>
            <user-comments>Default administrator, do not delete</user-comments>
-           <password>21232F297A57A5A743894A0E4A801FC3</password>
+           <password salt="true">gU2wmSW7k9v1xg4/MrAsaI+VyddBAhJJt4zPX5SGG0BK+qiASGnJsqM8JOug/aEL</password>
            <contact type="email" info="up@opennms.org"/>
        </user>
        <user>

--- a/opennms-webapp/src/test/opennms-home/etc/users.xml
+++ b/opennms-webapp/src/test/opennms-home/etc/users.xml
@@ -12,7 +12,7 @@
       <user-comments>
         Default administrator, do not delete
       </user-comments>
-      <password>21232F297A57A5A743894A0E4A801FC3</password>
+      <password salt="true">gU2wmSW7k9v1xg4/MrAsaI+VyddBAhJJt4zPX5SGG0BK+qiASGnJsqM8JOug/aEL</password>
     </user>
   </users>
 </userinfo>


### PR DESCRIPTION
This PR makes it so you can configure OpenNMS to disallow writing old-style unsalted passwords.

JIRA: https://issues.opennms.org/browse/NMS-12817