### PR TITLE
NMS-12823: Application Topology Provider Status

### DIFF
--- a/features/graph/api/src/main/java/org/opennms/netmgt/graph/api/search/SearchSuggestion.java
+++ b/features/graph/api/src/main/java/org/opennms/netmgt/graph/api/search/SearchSuggestion.java
@@ -125,7 +125,7 @@ public class SearchSuggestion implements Comparable<SearchSuggestion> {
     public String toString() {
         return MoreObjects.toStringHelper(this)
                 .add("context", context)
-                .add("id", context)
+                .add("id", id)
                 .add("label", label)
                 .add("provider", provider)
                 .toString();

--- a/features/topology-map/plugins/org.opennms.features.topology.plugins.browsers/src/main/java/org/opennms/features/topology/plugins/browsers/AlarmDaoContainer.java
+++ b/features/topology-map/plugins/org.opennms.features.topology.plugins.browsers/src/main/java/org/opennms/features/topology/plugins/browsers/AlarmDaoContainer.java
@@ -80,7 +80,7 @@ public class AlarmDaoContainer extends OnmsVaadinContainer<OnmsAlarm,Integer> {
 
     @Override
     protected void addAdditionalCriteriaOptions(Criteria criteria, Page page, boolean doOrder) {
-        // we join table node, to be able eto sort by node.label
+        // we join table node, to be able to sort by node.label
         criteria.setAliases(Arrays.asList(new Alias[] {
                 new Alias("node", "node", JoinType.LEFT_JOIN)
         }));

--- a/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.application/src/main/java/org/opennms/features/topology/plugins/topo/application/LegacyApplicationTopologyProvider.java
+++ b/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.application/src/main/java/org/opennms/features/topology/plugins/topo/application/LegacyApplicationTopologyProvider.java
@@ -58,7 +58,7 @@ public class LegacyApplicationTopologyProvider extends AbstractTopologyProvider 
 
     public static final String TOPOLOGY_NAMESPACE = "application";
 
-    private GraphService graphService;
+    private final GraphService graphService;
 
     public LegacyApplicationTopologyProvider(GraphService graphService) {
         super(TOPOLOGY_NAMESPACE);
@@ -145,6 +145,7 @@ public class LegacyApplicationTopologyProvider extends AbstractTopologyProvider 
                 final Set<Integer> applicationIds = filteredVertices.stream()
                         .filter(LegacyApplicationVertex::isRoot)
                         .map(LegacyApplicationVertex::getId)
+                        .map(s -> s.startsWith("Application:") ? s.substring("Application:".length()) : s)
                         .map(Integer::valueOf)
                         .collect(Collectors.toSet());
                 return new SelectionChangedListener.IdSelection<>(applicationIds);

--- a/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.application/src/main/java/org/opennms/features/topology/plugins/topo/application/browsers/ApplicationOutage.java
+++ b/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.application/src/main/java/org/opennms/features/topology/plugins/topo/application/browsers/ApplicationOutage.java
@@ -1,0 +1,88 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ * OpenNMS(R) Licensing <license@opennms.org>
+ *      http://www.opennms.org/
+ *      http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.features.topology.plugins.topo.application.browsers;
+
+import java.util.Date;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.opennms.core.utils.InetAddressUtils;
+import org.opennms.netmgt.model.OnmsIpInterface;
+import org.opennms.netmgt.model.OnmsMonitoredService;
+import org.opennms.netmgt.model.OnmsOutage;
+import org.opennms.netmgt.model.OnmsServiceType;
+import org.opennms.netmgt.model.monitoringLocations.OnmsMonitoringLocation;
+
+/**
+ * A wrapper around an OnmsOutage object to be used in the ApplicationOutage table.
+ */
+public class ApplicationOutage {
+
+    final OnmsOutage delegate;
+
+    ApplicationOutage(final OnmsOutage delegate) {
+        this.delegate = Objects.requireNonNull(delegate);
+    }
+
+    public int getId() {
+        return delegate.getId();
+    }
+
+    public String getNodeLabel() {
+        return delegate.getNodeLabel();
+    }
+
+    public String getForeignSource() {
+        return delegate.getForeignSource();
+    }
+
+    public String getIpAddress() {
+        return Optional.ofNullable(delegate.getMonitoredService())
+                .map(OnmsMonitoredService::getIpInterface)
+                .map(OnmsIpInterface::getIpAddress)
+                .map(InetAddressUtils::toIpAddrString)
+                .orElse("null");
+    }
+
+    public String getServiceName() {
+        return Optional.ofNullable(delegate.getServiceType())
+                .map(OnmsServiceType::getName)
+                .orElse("null");
+    }
+
+    public Date getIfLostService() {
+        return delegate.getIfLostService();
+    }
+
+    public String getPerspective() {
+        return Optional.ofNullable(delegate.getPerspective())
+                .map(OnmsMonitoringLocation::getLocationName)
+                .orElse("null");
+    }
+}

--- a/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.application/src/main/java/org/opennms/features/topology/plugins/topo/application/browsers/ApplicationOutageDaoContainer.java
+++ b/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.application/src/main/java/org/opennms/features/topology/plugins/topo/application/browsers/ApplicationOutageDaoContainer.java
@@ -1,0 +1,120 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ * OpenNMS(R) Licensing <license@opennms.org>
+ *      http://www.opennms.org/
+ *      http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.features.topology.plugins.topo.application.browsers;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.opennms.core.criteria.Alias;
+import org.opennms.core.criteria.Criteria;
+import org.opennms.core.criteria.CriteriaBuilder;
+import org.opennms.core.criteria.restrictions.InRestriction;
+import org.opennms.core.criteria.restrictions.Restriction;
+import org.opennms.core.criteria.restrictions.Restrictions;
+import org.opennms.features.topology.api.browsers.ContentType;
+import org.opennms.features.topology.api.browsers.OnmsVaadinContainer;
+import org.opennms.netmgt.dao.api.ApplicationDao;
+import org.opennms.netmgt.dao.api.OutageDao;
+import org.opennms.netmgt.model.OnmsApplication;
+import org.opennms.netmgt.model.OnmsMonitoredService;
+
+public class ApplicationOutageDaoContainer extends OnmsVaadinContainer<ApplicationOutage, Integer> {
+    private static final long serialVersionUID = 1L;
+
+    private ApplicationDao applicationDao;
+
+    public ApplicationOutageDaoContainer(OutageDao dao, ApplicationDao applicationDao) {
+        super(ApplicationOutage.class, new ApplicationOutageDatasource(dao));
+        this.applicationDao = applicationDao;
+    }
+
+    @Override
+    protected Integer getId(ApplicationOutage bean) {
+        return bean == null ? null : bean.getId();
+    }
+
+    @Override
+    protected ContentType getContentType() {
+        return ContentType.Application;
+    }
+
+    @Override
+    protected void addAdditionalCriteriaOptions(Criteria criteria, Page page, boolean doOrder) {
+
+        // filter out application ids
+        Collection<Integer> applicationIds = criteria.getRestrictions().stream()
+                .filter(r -> r.getType().equals(Restriction.RestrictionType.IN))
+                .map(r-> ((InRestriction)r).getValues())
+                .flatMap(Collection::stream)
+                .map(o-> (Integer)o)
+                .collect(Collectors.toList());
+
+        // remove id restriction since we don't want to see the application itself but its outages
+        Collection<Restriction> restrictionsWithoutIdFilter = criteria.getRestrictions().stream()
+                .filter(r -> !r.getType().equals(Restriction.RestrictionType.IN))
+                .collect(Collectors.toList());
+        criteria.setRestrictions(restrictionsWithoutIdFilter);
+
+        // show only unresolved outages
+        criteria.addRestriction(Restrictions.isNull("ifRegainedService"));
+
+        // show only outages detected by a perspective poller
+        criteria.addRestriction(Restrictions.isNotNull("perspective"));
+
+        // limit to the displayed applications
+        List<OnmsApplication> applications;
+        if(applicationIds.isEmpty()) {
+            applications = Collections.emptyList();
+        } else {
+            Criteria appCriteria = new CriteriaBuilder(OnmsApplication.class).in("id", applicationIds).toCriteria();
+            applications = this.applicationDao.findMatching(appCriteria);
+        }
+        Set<OnmsMonitoredService> services = new HashSet<>();
+        for(OnmsApplication application : applications) {
+            services.addAll(application.getMonitoredServices());
+        }
+        if(services.isEmpty()) {
+            criteria.addRestriction(Restrictions.sql("1=2")); // we don't want to find anything
+        } else {
+            criteria.addRestriction(Restrictions.in("monitoredService", services));
+        }
+
+        // set aliases so that the columns can be found
+        criteria.setAliases(Arrays.asList(
+                new Alias("monitoredService.ipInterface.node", "nodeLabel", Alias.JoinType.LEFT_JOIN),
+                new Alias("monitoredService.ipInterface", "ipAddress", Alias.JoinType.LEFT_JOIN),
+                new Alias("monitoredService.serviceType", "serviceName", Alias.JoinType.LEFT_JOIN),
+                new Alias("perspective", "perspective", Alias.JoinType.LEFT_JOIN)));
+    }
+}

--- a/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.application/src/main/java/org/opennms/features/topology/plugins/topo/application/browsers/ApplicationOutageDatasource.java
+++ b/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.application/src/main/java/org/opennms/features/topology/plugins/topo/application/browsers/ApplicationOutageDatasource.java
@@ -1,0 +1,76 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ * OpenNMS(R) Licensing <license@opennms.org>
+ *      http://www.opennms.org/
+ *      http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.features.topology.plugins.topo.application.browsers;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import org.opennms.core.criteria.Criteria;
+import org.opennms.features.topology.api.browsers.OnmsContainerDatasource;
+import org.opennms.netmgt.dao.api.OutageDao;
+import org.opennms.netmgt.model.OnmsOutage;
+
+public class ApplicationOutageDatasource implements OnmsContainerDatasource<ApplicationOutage, Integer> {
+
+    private final OutageDao dao;
+
+    public ApplicationOutageDatasource(final OutageDao dao) {
+        this.dao = Objects.requireNonNull(dao);
+    }
+
+    @Override
+    public void clear() {
+        throw new UnsupportedOperationException("Cannot add new items to this container");
+    }
+
+    @Override
+    public void delete(Integer itemId) {
+        throw new UnsupportedOperationException("Cannot remove items from this container");
+    }
+
+    @Override
+    public List<ApplicationOutage> findMatching(Criteria criteria) {
+        criteria.setClass(OnmsOutage.class); // Map it back to delegate class
+        return dao.findMatching(criteria).stream()
+                .map(ApplicationOutage::new)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public int countMatching(Criteria criteria) {
+        criteria.setClass(OnmsOutage.class); // Map it back to delegate class
+        return dao.countMatching(criteria);
+    }
+
+    @Override
+    public ApplicationOutage createInstance(Class<ApplicationOutage> itemClass) {
+        return new ApplicationOutage(new OnmsOutage());
+    }
+}

--- a/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.application/src/main/java/org/opennms/features/topology/plugins/topo/application/browsers/ApplicationOutageSelectionLinkGenerator.java
+++ b/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.application/src/main/java/org/opennms/features/topology/plugins/topo/application/browsers/ApplicationOutageSelectionLinkGenerator.java
@@ -85,7 +85,7 @@ public class ApplicationOutageSelectionLinkGenerator extends AbstractSelectionLi
 				// outage still exists, show details
 				final URI currentLocation = Page.getCurrent().getLocation();
 				final String contextRoot = VaadinServlet.getCurrent().getServletContext().getContextPath();
-				final String redirectFragment = contextRoot + "/outage/detail.htm?id=" + outageId;
+				final String redirectFragment = contextRoot + "/outage/detail.htm?quiet=true&id=" + outageId;
 				LOG.debug("outage {} clicked, current location = {}, uri = {}", outageId, currentLocation, redirectFragment);
 
 				try {

--- a/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.application/src/main/java/org/opennms/features/topology/plugins/topo/application/browsers/ApplicationOutageSelectionLinkGenerator.java
+++ b/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.application/src/main/java/org/opennms/features/topology/plugins/topo/application/browsers/ApplicationOutageSelectionLinkGenerator.java
@@ -1,0 +1,102 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ * OpenNMS(R) Licensing <license@opennms.org>
+ *      http://www.opennms.org/
+ *      http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.features.topology.plugins.topo.application.browsers;
+
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URL;
+
+import org.opennms.features.topology.api.browsers.AbstractSelectionLinkGenerator;
+import org.opennms.features.topology.api.support.DialogWindow;
+import org.opennms.features.topology.api.support.InfoWindow;
+import org.opennms.netmgt.dao.api.OutageDao;
+import org.opennms.netmgt.model.OnmsOutage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.vaadin.server.Page;
+import com.vaadin.server.VaadinServlet;
+import com.vaadin.ui.Button;
+import com.vaadin.v7.data.Property;
+import com.vaadin.v7.ui.Table;
+import com.vaadin.v7.ui.themes.BaseTheme;
+
+public class ApplicationOutageSelectionLinkGenerator extends AbstractSelectionLinkGenerator {
+
+	private static final Logger LOG = LoggerFactory.getLogger(ApplicationOutageSelectionLinkGenerator.class);
+	private final String idPropertyName;
+	private final OutageDao outageDao;
+
+    public ApplicationOutageSelectionLinkGenerator(String idPropertyName, final OutageDao outageDao) {
+		this.idPropertyName = idPropertyName;
+		this.outageDao = outageDao;
+	}
+
+	@Override
+	public Object generateCell(final Table source, Object itemId, Object columnId) {
+		if (source == null) return null; // no source
+		Property<Integer> idProperty = source.getContainerProperty(itemId,  idPropertyName);
+		final Integer outageId = idProperty.getValue();
+		if (outageId == null) return null; // no value
+
+		// create Link
+		Button button = new Button("" + outageId);
+		button.setStyleName(BaseTheme.BUTTON_LINK);
+		button.addClickListener(new Button.ClickListener() {
+			private static final long serialVersionUID = 3698209256202413810L;
+
+			@Override
+			public void buttonClick(Button.ClickEvent event) {
+				// try if outage is there, otherwise show information dialog
+				OnmsOutage outage = outageDao.get(outageId);
+				if (outage == null) {
+					new DialogWindow(source.getUI(),
+							"Outage does not exist!",
+							"The outage information cannot be shown. \nThe outage does not exist anymore. \n\nPlease refresh the Outage Table.");
+					return;
+				}
+
+				// outage still exists, show details
+				final URI currentLocation = Page.getCurrent().getLocation();
+				final String contextRoot = VaadinServlet.getCurrent().getServletContext().getContextPath();
+				final String redirectFragment = contextRoot + "/outage/detail.htm?id=" + outageId;
+				LOG.debug("outage {} clicked, current location = {}, uri = {}", outageId, currentLocation, redirectFragment);
+
+				try {
+					source.getUI().addWindow(
+							new InfoWindow(new URL(currentLocation.toURL(), redirectFragment), () -> "Outage Info " + outageId));
+				} catch (MalformedURLException e) {
+					LOG.error(e.getMessage(), e);
+				}
+			}
+		});
+		return button;
+	}
+
+}

--- a/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.application/src/main/java/org/opennms/features/topology/plugins/topo/application/browsers/ApplicationOutageTable.java
+++ b/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.application/src/main/java/org/opennms/features/topology/plugins/topo/application/browsers/ApplicationOutageTable.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ * OpenNMS(R) Licensing <license@opennms.org>
+ *      http://www.opennms.org/
+ *      http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.features.topology.plugins.topo.application.browsers;
+
+import java.util.Map;
+
+import org.opennms.features.topology.api.browsers.OnmsVaadinContainer;
+import org.opennms.features.topology.api.browsers.SelectionAwareTable;
+
+// Shows outages related to the shown applications
+public class ApplicationOutageTable extends SelectionAwareTable {
+    /**
+     *  Leave OnmsVaadinContainer without generics; the Aries blueprint code cannot match up
+     *  the arguments if you put the generic types in.
+     */
+    public ApplicationOutageTable(final String caption, final OnmsVaadinContainer container) {
+        super(caption, container);
+    }
+
+    public void setColumnGenerators(Map generators) {
+        for (Object key : generators.keySet()) {
+            addGeneratedColumn(key, (ColumnGenerator)generators.get(key));
+        }
+    }
+}

--- a/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.application/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.application/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -134,7 +134,7 @@ xsi:schemaLocation="http://www.osgi.org/xmlns/blueprint/v1.0.0 https://osgi.org/
 	<bean id="applicationOutageViewContribution" class="org.opennms.features.topology.api.support.BlueprintIViewContribution">
 		<argument ref="blueprintContainer" />
 		<argument value="applicationOutageTable" />
-		<property name="title" value="Current Outages" />
+		<property name="title" value="Current Perspective Outages" />
 	</bean>
 	<service interface="org.opennms.features.topology.api.IViewContribution" ref="applicationOutageViewContribution">
 		<description>Application outage table IViewContribution service.</description>

--- a/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.application/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.application/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -3,6 +3,7 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 xsi:schemaLocation="http://www.osgi.org/xmlns/blueprint/v1.0.0 https://osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd">
 
 	<reference id="applicationDao" interface="org.opennms.netmgt.dao.api.ApplicationDao" availability="mandatory" />
+	<reference id="outageDao" interface="org.opennms.netmgt.dao.api.OutageDao" availability="mandatory" />
 	<reference id="graphService" interface="org.opennms.netmgt.graph.api.service.GraphService" availability="mandatory" />
 	<reference id="transactionTemplate" interface="org.springframework.transaction.support.TransactionOperations" availability="mandatory" />
 	<reference id="graphSearchService" interface="org.opennms.netmgt.graph.api.search.GraphSearchService" availability="mandatory" />
@@ -84,6 +85,62 @@ xsi:schemaLocation="http://www.osgi.org/xmlns/blueprint/v1.0.0 https://osgi.org/
 		<service-properties>
 			<entry key="location" value="bottom" />
 			<entry key="name" value="applicationView" />
+		</service-properties>
+	</service>
+
+	<!-- Application Outage Table -->
+	<bean id="applicationOutageTableSelectionLinkGenerator" class="org.opennms.features.topology.plugins.topo.application.browsers.ApplicationOutageSelectionLinkGenerator">
+		<argument value="id" />
+		<argument ref="outageDao" />
+	</bean>
+	<bean id="applicationOutageDaoContainer" class="org.opennms.features.topology.plugins.topo.application.browsers.ApplicationOutageDaoContainer" scope="prototype">
+		<argument ref="outageDao"/>
+		<argument ref="applicationDao"/>
+	</bean>
+	<bean id="applicationOutageTable" class="org.opennms.features.topology.plugins.topo.application.browsers.ApplicationOutageTable" scope="prototype">
+		<argument value="Application Outages"/>
+		<argument ref="applicationOutageDaoContainer"/>
+		<property name="columnReorderingAllowed" value="true" />
+		<property name="columnCollapsingAllowed" value="true" />
+		<property name="sortContainerPropertyId" value="id" />
+		<property name="columnGenerators">
+			<map>
+				<entry key="id" value-ref="applicationOutageTableSelectionLinkGenerator" />
+			</map>
+		</property>
+		<property name="visibleColumns">
+			<array>
+				<value>id</value>
+				<value>nodeLabel</value>
+				<value>foreignSource</value>
+				<value>ipAddress</value>
+				<value>serviceName</value>
+				<value>ifLostService</value>
+				<value>perspective</value>
+			</array>
+		</property>
+		<property name="columnHeaders">
+			<array>
+				<value>ID</value>
+				<value>Node</value>
+				<value>Foreign Source</value>
+				<value>Interface</value>
+				<value>Service</value>
+				<value>Down</value>
+				<value>Perspective</value>
+			</array>
+		</property>
+	</bean>
+	<bean id="applicationOutageViewContribution" class="org.opennms.features.topology.api.support.BlueprintIViewContribution">
+		<argument ref="blueprintContainer" />
+		<argument value="applicationOutageTable" />
+		<property name="title" value="Current Outages" />
+	</bean>
+	<service interface="org.opennms.features.topology.api.IViewContribution" ref="applicationOutageViewContribution">
+		<description>Application outage table IViewContribution service.</description>
+		<service-properties>
+			<entry key="location" value="bottom" />
+			<entry key="name" value="applicationOutageView" />
 		</service-properties>
 	</service>
 


### PR DESCRIPTION
This PR fixed the search for Appliations and adds a table "Current Outages" to the Application Topology Map.

* JIRA (Issue Tracker): https://issues.opennms.org/browse/NMS-12823

All current (non resolved) outages of associated monitored location of the displayed applications are shown in the table:
 
![image](https://user-images.githubusercontent.com/1060134/91670278-7c2bae00-eae1-11ea-9d2a-fe8077851562.png)

When clicked on the outage id a popop with the outage detail information is shown:

![image](https://user-images.githubusercontent.com/1060134/91670542-3ae8cd80-eae4-11ea-919a-1b3d34e93200.png)




