### PR TITLE
NMS-12870: Use generatedId only for Standard Resource graphs

### DIFF
--- a/core/web-assets/src/main/assets/js/apps/onms-resources/index.js
+++ b/core/web-assets/src/main/assets/js/apps/onms-resources/index.js
@@ -190,6 +190,11 @@ angular.module('onms-resources', [
   };
 
   $scope.doGraph = function (selected) {
+    // Custom report graphs doesn't support generatedId
+    if(($scope.url === "graph/adhoc2.jsp")) {
+       $scope.setResourceIds(selected);
+       return;
+    }
     // Save resources with an ID and form url with generatedId.
     if (selected.length > 0) {
       $http.post('rest/resources/generateId', selected)


### PR DESCRIPTION


### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-12870
