### PR TITLE
NMS-12872: Fix Minion startup command to use credentials from environment with health-check

### DIFF
--- a/core/health/impl/src/main/java/org/opennms/core/health/impl/ContainerIntegrityHealthCheck.java
+++ b/core/health/impl/src/main/java/org/opennms/core/health/impl/ContainerIntegrityHealthCheck.java
@@ -95,7 +95,7 @@ public class ContainerIntegrityHealthCheck implements HealthCheck {
         final Health health = new Health();
         for (Bundle b : bundleContext.getBundles()) {
             if (ignoreBundles.contains(b.getSymbolicName())) {
-                LOG.debug("Bundle {} with symbolic name {} is ignored while performing health:check", b.getBundleId(), b.getSymbolicName());
+                LOG.debug("Bundle {} with symbolic name {} is ignored while performing opennms:health-check", b.getBundleId(), b.getSymbolicName());
                 continue;
             }
             final BundleInfo info = bundleService.getInfo(b);

--- a/core/health/impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/core/health/impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -16,7 +16,7 @@
     <cm:property-placeholder persistent-id="org.opennms.core.health.cfg">
         <cm:default-properties>
             <!--
-                A list of symbolic names which should be ignored while performing the health:check.
+                A list of symbolic names which should be ignored while performing the opennms:health-check.
                 A common candidate i.e. is the nominatim geocoder plugin
             -->
             <cm:property name="ignoreBundleList" value="org.opennms.features.geocoder.nominatim,org.apache.karaf.diagnostic.boot,io.hawt.hawtio-karaf-terminal"/>

--- a/opennms-container/minion/Dockerfile
+++ b/opennms-container/minion/Dockerfile
@@ -49,7 +49,7 @@ COPY ./container-fs/confd/ /opt/minion/confd/
 RUN chmod +x /opt/minion/confd/scripts/*
 
 # Create SSH Key-Pair to use with the Karaf Shell
-# This is a workaround to be able to use our health:check which does not work with the karaf/bin/client command
+# This is a workaround to be able to use our opennms:health-check which does not work with the karaf/bin/client command
 RUN mkdir /opt/minion/.ssh && \
     ssh-keygen -t rsa -f /opt/minion/.ssh/id_rsa -q -N "" && \
     chmod 700 /opt/minion/.ssh && \

--- a/opennms-doc/guide-install/src/asciidoc/text/minion-custom-messaging-system/setup-kafka/introduction.adoc
+++ b/opennms-doc/guide-install/src/asciidoc/text/minion-custom-messaging-system/setup-kafka/introduction.adoc
@@ -11,7 +11,7 @@ This section describes how to use _Apache Kafka_ as a messaging system between _
 * Configure _{opennms-product-name}_ to forward _RPC_ to a _Minion_
 * Configure _Minion_ to forward messages over the _Sink_ component to an _{opennms-product-name}_ instance
 * Disable the embedded _Active MQ_ message broker on the _Minion_.
-* Verify the functionality on the _Minion_ using the `health:check` command and ensure the _Minion_ is registered and monitored in the _{opennms-product-name}_ web interface
+* Verify the functionality on the _Minion_ using the `opennms:health-check` command and ensure the _Minion_ is registered and monitored in the _{opennms-product-name}_ web interface
 
 ==== Before you begin
 

--- a/opennms-doc/guide-install/src/asciidoc/text/minion-custom-messaging-system/setup-kafka/steps-minion.adoc
+++ b/opennms-doc/guide-install/src/asciidoc/text/minion-custom-messaging-system/setup-kafka/steps-minion.adoc
@@ -74,7 +74,7 @@ opennms-core-ipc-sink-kafka | 25.0.0           | x        | Started
 .Test connectivity to Kafka
 [source, shell]
 ----
-health:check 
+opennms:health-check 
 Verifying the health of the container
 
 Connecting to OpenNMS ReST API   [ Success  ]

--- a/opennms-doc/guide-install/src/asciidoc/text/minion-grpc/steps-minion.adoc
+++ b/opennms-doc/guide-install/src/asciidoc/text/minion-grpc/steps-minion.adoc
@@ -85,7 +85,7 @@ opennms-core-ipc-grpc-client                │ 26.1.3.SNAPSHOT  │ x        �
 .Test connectivity to Kafka
 [source, shell]
 ----
-opennms-health:check
+opennms:health-check
 Verifying the health of the container
 
 Connecting to OpenNMS ReST API   [ Success  ]

--- a/opennms-doc/guide-install/src/asciidoc/text/monitor-location-minion/docker/minion-docker.adoc
+++ b/opennms-doc/guide-install/src/asciidoc/text/monitor-location-minion/docker/minion-docker.adoc
@@ -49,7 +49,12 @@ services:
       - OPENNMS_HTTP_URL=http://horizon-instance:8980/opennms<8>
       - OPENNMS_HTTP_USER=minion-user<9>
       - OPENNMS_HTTP_PASS=minion-password
-    command: ["-f"]
+    command: ["-c"]
+    healthcheck:
+      test: "/health.sh"<10>
+      interval: 15s
+      timeout: 6s
+      retries: 1
 ----
 <1> Friendly container name
 <2> If you process UDP data like SNMP traps, Syslogs or flows, `network_mode: host` ensures the UDP source addresses are not modified
@@ -60,6 +65,7 @@ services:
 <7> Authentication for ActiveMQ broker
 <8> _REST_ endpoint to connect to the _{opennms-product-name}_ instance
 <9> Authentication for the _REST_ endpoint
+<10> Run our health check to indicate the Minion is ready. It uses internally the `opennms:health-check` running in Karaf.
 
 NOTE: In this example we haven't set credentials to connect the _Minion_ via _REST_ and the _ActiveMQ Message Broker_.
       The _Minion_ will fall back and uses the default admin/admin credentials for communication.
@@ -86,7 +92,7 @@ docker-compose up -d
 ----
 ssh admin@localhost -p 8201
 
-admin@minion> health:check
+admin@minion> opennms:health-check
 Verifying the health of the container
 
 Connecting to OpenNMS ReST API   [ Success  ]

--- a/opennms-doc/guide-install/src/asciidoc/text/monitor-location-minion/docker/minion-docker.adoc
+++ b/opennms-doc/guide-install/src/asciidoc/text/monitor-location-minion/docker/minion-docker.adoc
@@ -65,7 +65,7 @@ services:
 <7> Authentication for ActiveMQ broker
 <8> _REST_ endpoint to connect to the _{opennms-product-name}_ instance
 <9> Authentication for the _REST_ endpoint
-<10> Run our health check to indicate the Minion is ready. It uses internally the `opennms:health-check` running in Karaf.
+<10> Run our health check to indicate the Minion is ready. It uses the `opennms:health-check` internally running in Karaf.
 
 NOTE: In this example we haven't set credentials to connect the _Minion_ via _REST_ and the _ActiveMQ Message Broker_.
       The _Minion_ will fall back and uses the default admin/admin credentials for communication.

--- a/smoke-test/src/main/java/org/opennms/smoketest/utils/KarafShellUtils.java
+++ b/smoke-test/src/main/java/org/opennms/smoketest/utils/KarafShellUtils.java
@@ -48,7 +48,7 @@ public class KarafShellUtils {
 
     public static boolean testHealthCheck(InetSocketAddress sshAddr, AtomicReference<String> lastOutput) {
         try (final SshClient sshClient = new SshClient(sshAddr, OpenNMSContainer.ADMIN_USER, OpenNMSContainer.ADMIN_PASSWORD)) {
-            // Issue the 'health:check' command
+            // Issue the 'opennms:health-check' command
             PrintStream pipe = sshClient.openShell();
             pipe.println("opennms:health-check");
             pipe.println("logout");


### PR DESCRIPTION
### All Contributors

* [x] Have you read and followed our [Contribution Guidelines](https://github.com/OpenNMS/opennms/blob/develop/CONTRIBUTING.md)?
* [x] Have you [made an issue in the OpenNMS issue tracker](https://issues.opennms.org)?<br>If so, you should:
  1. update the title of this PR to be of the format: `${JIRA-ISSUE-NUMBER}: subject of pull request`
  2. update the JIRA link at the bottom of this comment to refer to the real issue number
  3. prefix your commit messages with the issue number, if possible
* [x] Have you made a comment in that issue which points back to this PR?
* [x] Have you updated the JIRA link at the bottom of this comment to link to your issue?
* [x] If this is a new or updated feature, is there documentation for the new behavior?
* [x] If this is a new code, are there unit and/or integration tests?
* [x] If this PR targets a `foundation-*` branch, does it avoid changing files in `$OPENNMS_HOME/etc/`?

In our the Minion documentation we used `-f` which uses the credentials from our Secure Credentials Vault and the credentials from the environment variables are ignored. To make the example work, I've changed it to use `-c`. Additionally we have referenced the old health:check command which doesn't work anymore and is renamed to `opennms:health-check`. I've found a few other spots as well and fixed them with a second commit as well.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-12872

