### PR TITLE
NMS-12794: Add support for metadata for threshold fields

### DIFF
--- a/core/lib/src/main/java/org/opennms/core/utils/StringUtils.java
+++ b/core/lib/src/main/java/org/opennms/core/utils/StringUtils.java
@@ -53,6 +53,8 @@ import javax.xml.transform.stream.StreamSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.base.Strings;
+
 public abstract class StringUtils {
 
     private static final Logger LOG = LoggerFactory.getLogger(StringUtils.class);
@@ -455,8 +457,22 @@ public abstract class StringUtils {
     }
 
     public static Integer parseInt(String value, Integer defaultValue) {
+        if(Strings.isNullOrEmpty(value)) {
+            return defaultValue;
+        }
         try {
             return Integer.parseInt(value);
+        } catch (NumberFormatException e) {
+            return defaultValue;
+        }
+    }
+
+    public static Double parseDouble(String value, Double defaultValue) {
+        if(Strings.isNullOrEmpty(value)) {
+            return defaultValue;
+        }
+        try {
+            return Double.parseDouble(value);
         } catch (NumberFormatException e) {
             return defaultValue;
         }

--- a/features/api-layer/src/main/java/org/opennms/features/apilayer/config/ThresholdingConfigExtensionManager.java
+++ b/features/api-layer/src/main/java/org/opennms/features/apilayer/config/ThresholdingConfigExtensionManager.java
@@ -128,17 +128,17 @@ public class ThresholdingConfigExtensionManager extends ConfigExtensionManager<T
         from.getDsLabel().ifPresent(to::setDsLabel);
         to.setDsType(from.getDsType());
         to.setFilterOperator(toFilterOperator(from.getFilterOperator()));
-        to.setRearm(from.getRearm());
+        to.setRearmValue(from.getRearm());
         from.getRearmedUEI().ifPresent(to::setRearmedUEI);
         to.setRelaxed(from.getRelaxed());
         to.setResourceFilters(from.getResourceFilters()
                 .stream()
                 .map(ThresholdingConfigExtensionManager::toResourceFilter)
                 .collect(Collectors.toList()));
-        to.setTrigger(from.getTrigger());
+        to.setTriggerValue(from.getTrigger());
         from.getTriggeredUEI().ifPresent(to::setTriggeredUEI);
         to.setType(toThresholdType(from.getType()));
-        to.setValue(from.getValue());
+        to.setDoubleValue(from.getValue());
     }
 
     private static FilterOperator toFilterOperator(org.opennms.integration.api.v1.config.thresholding.FilterOperator filterOperator) {

--- a/features/api-layer/src/test/java/org/opennms/features/apilayer/config/ThresholdingConfigExtensionManagerTest.java
+++ b/features/api-layer/src/test/java/org/opennms/features/apilayer/config/ThresholdingConfigExtensionManagerTest.java
@@ -181,14 +181,14 @@ public class ThresholdingConfigExtensionManagerTest {
         assertThat(basethresholddef.getDsType(), equalTo(dsType));
         assertThat(basethresholddef.getDsLabel().get(), equalTo(dsLabel));
         assertThat(basethresholddef.getFilterOperator().name(), equalTo(filterOperator.name()));
-        assertThat(basethresholddef.getRearm(), equalTo(rearm));
+        assertThat(Double.parseDouble(basethresholddef.getRearm()), equalTo(rearm));
         assertThat(basethresholddef.getRearmedUEI().get(), equalTo(rearmedUEI));
         assertThat(basethresholddef.getRelaxed(), equalTo(relaxed));
         assertThat(basethresholddef.getResourceFilters().get(0).getContent().get(), equalTo(content));
         assertThat(basethresholddef.getResourceFilters().get(0).getField(), equalTo(field));
-        assertThat(basethresholddef.getTrigger(), equalTo(trigger));
+        assertThat(Integer.parseInt(basethresholddef.getTrigger()), equalTo(trigger));
         assertThat(basethresholddef.getTriggeredUEI().get(), equalTo(triggeredUEI));
         assertThat(basethresholddef.getType().name(), equalTo(type.name()));
-        assertThat(basethresholddef.getValue(), equalTo(value));
+        assertThat(Double.parseDouble(basethresholddef.getValue()), equalTo(value));
     }
 }

--- a/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/BaseThresholdDefConfigWrapper.java
+++ b/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/BaseThresholdDefConfigWrapper.java
@@ -34,6 +34,9 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
+import org.opennms.core.rpc.utils.mate.Interpolator;
+import org.opennms.core.rpc.utils.mate.Scope;
+import org.opennms.core.utils.StringUtils;
 import org.opennms.netmgt.config.threshd.Basethresholddef;
 import org.opennms.netmgt.config.threshd.Expression;
 import org.opennms.netmgt.config.threshd.ResourceFilter;
@@ -124,7 +127,11 @@ public abstract class BaseThresholdDefConfigWrapper {
      *
      * @return a double.
      */
-    public double getRearm() {
+    public Double getRearm() {
+        return StringUtils.parseDouble(m_baseDef.getRearm(), null);
+    }
+
+    public String getRearmString() {
         return m_baseDef.getRearm();
     }
     
@@ -133,7 +140,11 @@ public abstract class BaseThresholdDefConfigWrapper {
      *
      * @return a int.
      */
-    public int getTrigger() {
+    public Integer getTrigger() {
+        return StringUtils.parseInt(m_baseDef.getTrigger(), null);
+    }
+
+    public String getTriggerString() {
         return m_baseDef.getTrigger();
     }
     
@@ -151,9 +162,15 @@ public abstract class BaseThresholdDefConfigWrapper {
      *
      * @return a double.
      */
-    public double getValue() {
+    public Double getValue() {
+        return StringUtils.parseDouble(m_baseDef.getValue(), null);
+    }
+
+
+    public String getValueString() {
         return m_baseDef.getValue();
     }
+
     
     /**
      * <p>hasRearm</p>
@@ -250,5 +267,29 @@ public abstract class BaseThresholdDefConfigWrapper {
     }
     
     public abstract void accept(ThresholdDefVisitor thresholdDefVisitor);
+
+    public ThresholdEvaluatorState.ThresholdValues interpolateThresholdValues(Scope scope) {
+        Double thresholdValue = interpolateDoubleValue(getValueString(), scope).orElse(getValue());
+        Double rearm = interpolateDoubleValue(getRearmString(), scope).orElse(getRearm());
+        Integer trigger = interpolateIntegerValue(getTriggerString(), scope).orElse(getTrigger());
+        return new ThresholdEvaluatorState.ThresholdValues(thresholdValue, rearm, trigger);
+    }
+
+    private Optional<Double> interpolateDoubleValue(String value, Scope scope) {
+        if (Interpolator.containsMateData(value)) {
+            String interpolatedValue = Interpolator.interpolate(value, scope);
+            return Optional.ofNullable(StringUtils.parseDouble(interpolatedValue, null));
+        }
+        return Optional.empty();
+    }
+
+    private Optional<Integer> interpolateIntegerValue(String value, Scope scope) {
+        if (Interpolator.containsMateData(value)) {
+            String interpolatedValue = Interpolator.interpolate(value, scope);
+            return Optional.ofNullable(StringUtils.parseInt(interpolatedValue, null));
+        }
+        return Optional.empty();
+    }
+
 }
 

--- a/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/BaseThresholdDefConfigWrapper.java
+++ b/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/BaseThresholdDefConfigWrapper.java
@@ -125,7 +125,7 @@ public abstract class BaseThresholdDefConfigWrapper {
     /**
      * <p>getRearm</p>
      *
-     * @return a double.
+     * @return a Double.
      */
     public Double getRearm() {
         return StringUtils.parseDouble(m_baseDef.getRearm(), null);
@@ -138,7 +138,7 @@ public abstract class BaseThresholdDefConfigWrapper {
     /**
      * <p>getTrigger</p>
      *
-     * @return a int.
+     * @return a Integer.
      */
     public Integer getTrigger() {
         return StringUtils.parseInt(m_baseDef.getTrigger(), null);
@@ -160,7 +160,7 @@ public abstract class BaseThresholdDefConfigWrapper {
     /**
      * <p>getValue</p>
      *
-     * @return a double.
+     * @return a Double.
      */
     public Double getValue() {
         return StringUtils.parseDouble(m_baseDef.getValue(), null);
@@ -241,9 +241,9 @@ public abstract class BaseThresholdDefConfigWrapper {
                     && Objects.equals(this.getDsLabel(), that.getDsLabel())
                     && Objects.equals(this.getTriggeredUEI(), that.getTriggeredUEI())
                     && Objects.equals(this.getRearmedUEI(), that.getRearmedUEI())
-                    && Objects.equals(this.getValue(), that.getValue())
-                    && Objects.equals(this.getRearm(), that.getRearm())
-                    && Objects.equals(this.getTrigger(), that.getTrigger())
+                    && Objects.equals(this.getValueString(), that.getValueString())
+                    && Objects.equals(this.getRearmString(), that.getRearmString())
+                    && Objects.equals(this.getTriggerString(), that.getTriggerString())
                     && Objects.equals(this.getBasethresholddef().getFilterOperator(), that.getBasethresholddef().getFilterOperator())
                     && Objects.equals(this.getBasethresholddef().getRelaxed(), that.getBasethresholddef().getRelaxed())
                     && Objects.equals(this.getBasethresholddef().getResourceFilters(), that.getBasethresholddef().getResourceFilters());

--- a/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/ExpressionConfigWrapper.java
+++ b/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/ExpressionConfigWrapper.java
@@ -34,7 +34,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.function.Consumer;
 
 import org.apache.commons.jexl2.ExpressionImpl;
 import org.apache.commons.jexl2.JexlEngine;
@@ -175,7 +174,10 @@ public class ExpressionConfigWrapper extends BaseThresholdDefConfigWrapper {
     public ExpressionValue interpolateAndEvaluate(Map<String, Double> values, Scope scope)
             throws ThresholdExpressionException {
         String interpolatedExpression = interpolateExpression(m_expression.getExpression(), scope);
-        return new ExpressionValue(interpolatedExpression, evaluate(interpolatedExpression, values));
+        ExpressionValue expressionValue = new ExpressionValue(interpolatedExpression, evaluate(interpolatedExpression, values));
+        ThresholdEvaluatorState.ThresholdValues thresholdValues = interpolateThresholdValues(scope);
+        expressionValue.setThresholdValues(thresholdValues);
+        return expressionValue;
     }
 
     @Override
@@ -197,10 +199,19 @@ public class ExpressionConfigWrapper extends BaseThresholdDefConfigWrapper {
     public static class ExpressionValue {
         public final String expression;
         public final double value;
+        private ThresholdEvaluatorState.ThresholdValues thresholdValues;
 
         public ExpressionValue(String expression, double value) {
             this.expression = Objects.requireNonNull(expression);
             this.value = value;
+        }
+
+        public ThresholdEvaluatorState.ThresholdValues getThresholdValues() {
+            return thresholdValues;
+        }
+
+        public void setThresholdValues(ThresholdEvaluatorState.ThresholdValues thresholdValues) {
+            this.thresholdValues = thresholdValues;
         }
 
         @Override

--- a/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/ExpressionConfigWrapper.java
+++ b/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/ExpressionConfigWrapper.java
@@ -171,13 +171,13 @@ public class ExpressionConfigWrapper extends BaseThresholdDefConfigWrapper {
      * Evaluate with un-interpolated expression that may contain mate data, meaning we need to interpolate it first. The
      * interpolation should happen once here and future calls to evaluate should use the resulting interpolated value.
      */
-    public ExpressionValue interpolateAndEvaluate(Map<String, Double> values, Scope scope)
+    public ExpressionThresholdValues interpolateAndEvaluate(Map<String, Double> values, Scope scope)
             throws ThresholdExpressionException {
         String interpolatedExpression = interpolateExpression(m_expression.getExpression(), scope);
-        ExpressionValue expressionValue = new ExpressionValue(interpolatedExpression, evaluate(interpolatedExpression, values));
+        ExpressionThresholdValues expressionThresholdValues = new ExpressionThresholdValues(interpolatedExpression, evaluate(interpolatedExpression, values));
         ThresholdEvaluatorState.ThresholdValues thresholdValues = interpolateThresholdValues(scope);
-        expressionValue.setThresholdValues(thresholdValues);
-        return expressionValue;
+        expressionThresholdValues.setThresholdValues(thresholdValues);
+        return expressionThresholdValues;
     }
 
     @Override
@@ -196,12 +196,12 @@ public class ExpressionConfigWrapper extends BaseThresholdDefConfigWrapper {
         return expression;
     }
     
-    public static class ExpressionValue {
+    public static class ExpressionThresholdValues {
         public final String expression;
         public final double value;
         private ThresholdEvaluatorState.ThresholdValues thresholdValues;
 
-        public ExpressionValue(String expression, double value) {
+        public ExpressionThresholdValues(String expression, double value) {
             this.expression = Objects.requireNonNull(expression);
             this.value = value;
         }
@@ -218,7 +218,7 @@ public class ExpressionConfigWrapper extends BaseThresholdDefConfigWrapper {
         public boolean equals(Object o) {
             if (this == o) return true;
             if (o == null || getClass() != o.getClass()) return false;
-            ExpressionValue that = (ExpressionValue) o;
+            ExpressionThresholdValues that = (ExpressionThresholdValues) o;
             return Double.compare(that.value, value) == 0 &&
                     Objects.equals(expression, that.expression);
         }

--- a/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/ExpressionThresholdValueSupplier.java
+++ b/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/ExpressionThresholdValueSupplier.java
@@ -28,14 +28,11 @@
 
 package org.opennms.netmgt.threshd;
 
-import java.util.function.Consumer;
-
-public interface ExpressionThresholdValue {
+public interface ExpressionThresholdValueSupplier {
     /**
-     * @param expressionConsumer a consumer for accepting the interpolated expression and threshold values for caching purposes
-     * @return the expression value
+     * @return the expression and threshold values.
      */
-    ExpressionConfigWrapper.ExpressionValue get(Consumer<ExpressionConfigWrapper.ExpressionValue> expressionConsumer) throws ThresholdExpressionException;
+    ExpressionConfigWrapper.ExpressionThresholdValues get() throws ThresholdExpressionException;
 
     /**
      * @param evaluatedExpression the already interpolated expression which will be used rather than interpolating the

--- a/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/ThresholdConfigWrapper.java
+++ b/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/ThresholdConfigWrapper.java
@@ -83,5 +83,4 @@ public class ThresholdConfigWrapper extends BaseThresholdDefConfigWrapper {
     public void accept(ThresholdDefVisitor thresholdDefVisitor) {
         thresholdDefVisitor.visit(this);
     }
-
 }

--- a/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/ThresholdConfigWrapper.java
+++ b/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/ThresholdConfigWrapper.java
@@ -83,4 +83,5 @@ public class ThresholdConfigWrapper extends BaseThresholdDefConfigWrapper {
     public void accept(ThresholdDefVisitor thresholdDefVisitor) {
         thresholdDefVisitor.visit(this);
     }
+
 }

--- a/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/ThresholdEvaluatorHighLow.java
+++ b/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/ThresholdEvaluatorHighLow.java
@@ -28,7 +28,6 @@
 
 package org.opennms.netmgt.threshd;
 
-import java.io.Serializable;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
@@ -168,21 +167,32 @@ public class ThresholdEvaluatorHighLow implements ThresholdEvaluator {
         }
 
         @Override
-        public Status evaluateAfterFetch(double dsValue) {
-            if (isThresholdExceeded(dsValue)) {
+        public Status evaluateAfterFetch(double dsValue, ThresholdValues thresholdValues) {
+            Double thresholdValue  = thresholdValues != null && thresholdValues.getThresholdValue() != null ?
+                    thresholdValues.getThresholdValue() : getThresholdConfig().getValue();
+            Double rearm  = thresholdValues != null && thresholdValues.getRearm() != null ?
+                    thresholdValues.getRearm() : getThresholdConfig().getRearm();
+            Integer trigger = thresholdValues != null && thresholdValues.getTrigger() != null ?
+                    thresholdValues.getTrigger() : getThresholdConfig().getTrigger();
+
+            if(thresholdValue == null || rearm == null || trigger == null) {
+                return Status.NO_CHANGE;
+            }
+
+            if (isThresholdExceeded(dsValue, thresholdValue)) {
                 if (isArmed()) {
                     setExceededCount(getExceededCount() + 1);
 
                     LOG.debug("evaluate: {} threshold exceeded, count={}", getType(), getExceededCount());
 
-                    if (isTriggerCountExceeded()) {
+                    if (isTriggerCountExceeded(trigger)) {
                         LOG.debug("evaluate: {} threshold triggered", getType());
                         setExceededCount(1);
                         setArmed(false);
                         return Status.TRIGGERED;
                     }
                 }
-            } else if (isRearmExceeded(dsValue)) {
+            } else if (isRearmExceeded(dsValue, rearm)) {
                 if (!isArmed()) {
                     LOG.debug("evaluate: {} threshold rearmed", getType());
                     setArmed(true);
@@ -201,32 +211,53 @@ public class ThresholdEvaluatorHighLow implements ThresholdEvaluator {
             return Status.NO_CHANGE;
         }
 
-        protected boolean isThresholdExceeded(double dsValue) {
+        protected boolean isThresholdExceeded(double dsValue, Double value) {
             if (ThresholdType.HIGH.equals(getThresholdConfig().getType())) {
-                return dsValue >= getThresholdConfig().getValue();
+                return dsValue >= value;
             } else if (ThresholdType.LOW.equals(getThresholdConfig().getType())) {
-                return dsValue <= getThresholdConfig().getValue();
+                return dsValue <= value;
+            } else {
+                throw new IllegalStateException("This thresholding strategy can only be used for thresholding types of 'high' and 'low'.");
+            }
+        }
+
+        protected boolean isThresholdExceeded(double dsValue) {
+            Double thresholdValue = state.getThresholdValues() != null && state.getThresholdValues().getThresholdValue() != null ?
+                    state.getThresholdValues().getThresholdValue() : getThresholdConfig().getValue();
+            if(thresholdValue == null) {
+                thresholdValue = getThresholdConfig().getValue();
+            }
+            return isThresholdExceeded(dsValue, thresholdValue);
+        }
+
+        protected boolean isRearmExceeded(double dsValue, Double rearm) {
+            if (ThresholdType.HIGH.equals(getThresholdConfig().getType())) {
+                return dsValue <= rearm;
+            } else if (ThresholdType.LOW.equals(getThresholdConfig().getType())) {
+                return dsValue >= rearm;
             } else {
                 throw new IllegalStateException("This thresholding strategy can only be used for thresholding types of 'high' and 'low'.");
             }
         }
 
         protected boolean isRearmExceeded(double dsValue) {
-            if (ThresholdType.HIGH.equals(getThresholdConfig().getType())) {
-                return dsValue <= getThresholdConfig().getRearm();
-            } else if (ThresholdType.LOW.equals(getThresholdConfig().getType())) {
-                return dsValue >= getThresholdConfig().getRearm();
-            } else {
-                throw new IllegalStateException("This thresholding strategy can only be used for thresholding types of 'high' and 'low'.");
-            }
+            Double rearm = state.getThresholdValues() != null && state.getThresholdValues().getRearm() != null ?
+                    state.getThresholdValues().getRearm() : getThresholdConfig().getRearm();
+            return isRearmExceeded(dsValue, rearm);
+        }
+
+        protected boolean isTriggerCountExceeded(Integer trigger) {
+            return getExceededCount() >= trigger;
         }
 
         protected boolean isTriggerCountExceeded() {
-            return getExceededCount() >= getThresholdConfig().getTrigger();
+            Integer trigger = state.getThresholdValues() != null && state.getThresholdValues().getTrigger() != null ?
+                    state.getThresholdValues().getTrigger() : getThresholdConfig().getTrigger();
+            return isTriggerCountExceeded(trigger);
         }
         
         @Override
-        public Event getEventForState(Status status, Date date, double dsValue, CollectionResourceWrapper resource) {
+        public Event getEventForState(Status status, Date date, double dsValue, ThresholdValues thresholdValues, CollectionResourceWrapper resource) {
             /*
              * If resource is null, we will use m_lastCollectionResourceUsed; else we will use provided resource.
              * For future calls we will preserve the latest not null resource on m_lastCollectionResourceUsed.
@@ -244,12 +275,12 @@ public class ThresholdEvaluatorHighLow implements ThresholdEvaluator {
                     if(uei==null || "".equals(uei)) {
                         uei=EventConstants.LOW_THRESHOLD_EVENT_UEI;
                     }
-                    return createBasicEvent(uei, date, dsValue, resource);
+                    return createBasicEvent(uei, date, dsValue, thresholdValues, resource);
                 } else if (ThresholdType.HIGH.equals(getThresholdConfig().getType())) {
                     if(uei==null || "".equals(uei)) {
                         uei=EventConstants.HIGH_THRESHOLD_EVENT_UEI;
                     }
-                    return createBasicEvent(uei, date, dsValue, resource);
+                    return createBasicEvent(uei, date, dsValue, thresholdValues, resource);
                 } else {
                     throw new IllegalArgumentException("Threshold type " + getThresholdConfig().getType() + " is not supported");
                 } 
@@ -260,12 +291,12 @@ public class ThresholdEvaluatorHighLow implements ThresholdEvaluator {
                     if(uei==null || "".equals(uei)) {
                         uei=EventConstants.LOW_THRESHOLD_REARM_EVENT_UEI;
                     }
-                    return createBasicEvent(uei, date, dsValue, resource);
+                    return createBasicEvent(uei, date, dsValue, thresholdValues , resource);
                 } else if (ThresholdType.HIGH.equals(getThresholdConfig().getType())) {
                     if(uei==null || "".equals(uei)) {
                         uei=EventConstants.HIGH_THRESHOLD_REARM_EVENT_UEI;
                     }
-                    return createBasicEvent(uei, date, dsValue, resource);
+                    return createBasicEvent(uei, date, dsValue, thresholdValues, resource);
                 } else {
                     throw new IllegalArgumentException("Threshold type " + getThresholdConfig().getType() + " is not supported");
                 } 
@@ -278,11 +309,14 @@ public class ThresholdEvaluatorHighLow implements ThresholdEvaluator {
             }
         }
         
-        private Event createBasicEvent(String uei, Date date, double dsValue, CollectionResourceWrapper resource) {
+        private Event createBasicEvent(String uei, Date date, double dsValue, ThresholdValues thresholdValues, CollectionResourceWrapper resource) {
+            if(thresholdValues == null) {
+                thresholdValues = state.getThresholdValues();
+            }
             Map<String,String> params = new HashMap<String,String>();
-            params.put("threshold", Double.toString(getThresholdConfig().getValue()));
-            params.put("trigger", Integer.toString(getThresholdConfig().getTrigger()));
-            params.put("rearm", Double.toString(getThresholdConfig().getRearm()));
+            params.put("threshold", Double.toString(thresholdValues.getThresholdValue()));
+            params.put("trigger", Integer.toString(thresholdValues.getTrigger()));
+            params.put("rearm", Double.toString(thresholdValues.getRearm()));
             return createBasicEvent(uei, date, dsValue, resource, params);
         }
         
@@ -300,6 +334,7 @@ public class ThresholdEvaluatorHighLow implements ThresholdEvaluator {
         public void clearStateBeforePersist() {
             setArmed(true);
             setExceededCount(0);
+            state.setCached(false);
         }
         
     }

--- a/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/ThresholdEvaluatorHighLow.java
+++ b/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/ThresholdEvaluatorHighLow.java
@@ -40,6 +40,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.util.Assert;
 
+import com.google.common.annotations.VisibleForTesting;
+
 /**
  * <p>ThresholdEvaluatorHighLow class.</p>
  *
@@ -221,12 +223,10 @@ public class ThresholdEvaluatorHighLow implements ThresholdEvaluator {
             }
         }
 
+        @VisibleForTesting
         protected boolean isThresholdExceeded(double dsValue) {
             Double thresholdValue = state.getThresholdValues() != null && state.getThresholdValues().getThresholdValue() != null ?
                     state.getThresholdValues().getThresholdValue() : getThresholdConfig().getValue();
-            if(thresholdValue == null) {
-                thresholdValue = getThresholdConfig().getValue();
-            }
             return isThresholdExceeded(dsValue, thresholdValue);
         }
 
@@ -240,6 +240,7 @@ public class ThresholdEvaluatorHighLow implements ThresholdEvaluator {
             }
         }
 
+        @VisibleForTesting
         protected boolean isRearmExceeded(double dsValue) {
             Double rearm = state.getThresholdValues() != null && state.getThresholdValues().getRearm() != null ?
                     state.getThresholdValues().getRearm() : getThresholdConfig().getRearm();

--- a/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/ThresholdEvaluatorState.java
+++ b/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/ThresholdEvaluatorState.java
@@ -70,13 +70,13 @@ public interface ThresholdEvaluatorState extends ReinitializableState {
     /**
      * @return the value that was evaluated along with the resulting status
      */
-    ValueStatus evaluate(ExpressionThresholdValue valueSupplier, Long sequenceNumber)
+    ValueStatus evaluate(ExpressionThresholdValueSupplier valueSupplier, Long sequenceNumber)
             throws ThresholdExpressionException;
 
     /**
      * @return the value that was evaluated along with the resulting status
      */
-    ValueStatus evaluate(ThresholdValuesConsumer thresholdValuesConsumer, Long sequenceNumber)
+    ValueStatus evaluate(ThresholdValuesSupplier thresholdValuesSupplier, Long sequenceNumber)
             throws ThresholdExpressionException;
     
     /**

--- a/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/ThresholdEvaluatorState.java
+++ b/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/ThresholdEvaluatorState.java
@@ -28,6 +28,7 @@
 
 package org.opennms.netmgt.threshd;
 
+import java.io.Serializable;
 import java.util.Date;
 import java.util.Objects;
 
@@ -64,22 +65,29 @@ public interface ThresholdEvaluatorState extends ReinitializableState {
 
     Status evaluate(double dsValue, Long sequenceNumber);
 
+    Status evaluate(double dsValue, ThresholdValues thresholdValues, Long sequenceNumber);
+
     /**
      * @return the value that was evaluated along with the resulting status
      */
     ValueStatus evaluate(ExpressionThresholdValue valueSupplier, Long sequenceNumber)
             throws ThresholdExpressionException;
+
+    /**
+     * @return the value that was evaluated along with the resulting status
+     */
+    ValueStatus evaluate(ThresholdValuesConsumer thresholdValuesConsumer, Long sequenceNumber)
+            throws ThresholdExpressionException;
     
     /**
      * <p>getEventForState</p>
-     *
-     * @param status a {@link org.opennms.netmgt.threshd.ThresholdEvaluatorState.Status} object.
-     * @param date a {@link java.util.Date} object.
+     *  @param status a {@link Status} object.
+     * @param date a {@link Date} object.
      * @param dsValue a double.
-     * @param resource a {@link org.opennms.netmgt.threshd.CollectionResourceWrapper} object.
-     * @return a {@link org.opennms.netmgt.xml.event.Event} object.
+     * @param thresholdValues
+     * @param resource a {@link CollectionResourceWrapper} object.  @return a {@link Event} object.
      */
-    public Event getEventForState(Status status, Date date, double dsValue, CollectionResourceWrapper resource);
+    public Event getEventForState(Status status, Date date, double dsValue, ThresholdValues thresholdValues, CollectionResourceWrapper resource);
     
     /**
      * Return true if current state is TRIGGERED
@@ -114,10 +122,12 @@ public interface ThresholdEvaluatorState extends ReinitializableState {
     class ValueStatus {
         public final double value;
         public final Status status;
+        public final ThresholdValues thresholdValues;
 
-        public ValueStatus(double value, Status status) {
+        public ValueStatus(double value, Status status, ThresholdValues thresholdValues) {
             this.value = value;
             this.status = Objects.requireNonNull(status);
+            this.thresholdValues = thresholdValues;
         }
 
         @Override
@@ -140,6 +150,41 @@ public interface ThresholdEvaluatorState extends ReinitializableState {
                     "value=" + value +
                     ", status=" + status +
                     '}';
+        }
+    }
+
+    class ThresholdValues implements Serializable {
+
+        private static final long serialVersionUID = -788891453989005407L;
+        private final Double threshold;
+        private final Double rearm;
+        private final Integer trigger;
+        private Double dsValue;
+
+        public ThresholdValues(Double threshold, Double rearm, Integer trigger) {
+            this.threshold = threshold;
+            this.rearm = rearm;
+            this.trigger = trigger;
+        }
+
+        public Double getThresholdValue() {
+            return threshold;
+        }
+
+        public Double getRearm() {
+            return rearm;
+        }
+
+        public Integer getTrigger() {
+            return trigger;
+        }
+
+        public Double getDsValue() {
+            return dsValue;
+        }
+
+        public void setDsValue(Double dsValue) {
+            this.dsValue = dsValue;
         }
     }
 }

--- a/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/ThresholdValuesConsumer.java
+++ b/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/ThresholdValuesConsumer.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2019 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ * Copyright (C) 2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -30,17 +30,9 @@ package org.opennms.netmgt.threshd;
 
 import java.util.function.Consumer;
 
-public interface ExpressionThresholdValue {
-    /**
-     * @param expressionConsumer a consumer for accepting the interpolated expression and threshold values for caching purposes
-     * @return the expression value
-     */
-    ExpressionConfigWrapper.ExpressionValue get(Consumer<ExpressionConfigWrapper.ExpressionValue> expressionConsumer) throws ThresholdExpressionException;
+public interface ThresholdValuesConsumer {
 
-    /**
-     * @param evaluatedExpression the already interpolated expression which will be used rather than interpolating the
-     *                            expression
-     * @return the expression value
-     */
-    double get(String evaluatedExpression) throws ThresholdExpressionException;
+    ThresholdEvaluatorState.ThresholdValues get(Consumer<ThresholdEvaluatorState.ThresholdValues> thresholdsConsumer);
+
+    Double getDsValue();
 }

--- a/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/ThresholdValuesSupplier.java
+++ b/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/ThresholdValuesSupplier.java
@@ -28,11 +28,16 @@
 
 package org.opennms.netmgt.threshd;
 
-import java.util.function.Consumer;
+public interface ThresholdValuesSupplier {
 
-public interface ThresholdValuesConsumer {
+    /**
+     * @return the ThresholdValues which consists of interpolated values of value, rearm, trigger and data source value.
+     */
+    ThresholdEvaluatorState.ThresholdValues get();
 
-    ThresholdEvaluatorState.ThresholdValues get(Consumer<ThresholdEvaluatorState.ThresholdValues> thresholdsConsumer);
 
+    /**
+     * @return the data source value.
+     */
     Double getDsValue();
 }

--- a/features/collection/thresholding/impl/src/test/java/org/opennms/netmgt/threshd/ThresholdEvaluatorAbsoluteChangeTest.java
+++ b/features/collection/thresholding/impl/src/test/java/org/opennms/netmgt/threshd/ThresholdEvaluatorAbsoluteChangeTest.java
@@ -31,6 +31,8 @@ package org.opennms.netmgt.threshd;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.util.Date;
 
@@ -51,9 +53,9 @@ public class ThresholdEvaluatorAbsoluteChangeTest extends AbstractThresholdEvalu
         threshold.setType(ThresholdType.ABSOLUTE_CHANGE);
         threshold.setDsName("ds-name");
         threshold.setDsType("interface");
-        threshold.setValue(0.9);
-        threshold.setRearm(0.5);
-        threshold.setTrigger(3);
+        threshold.setDoubleValue(0.9);
+        threshold.setRearmValue(0.5);
+        threshold.setTriggerValue(3);
         ThresholdConfigWrapper wrapper=new ThresholdConfigWrapper(threshold);
        new ThresholdEvaluatorStateAbsoluteChange(wrapper, MockSession.getSession());
     }
@@ -77,9 +79,9 @@ public class ThresholdEvaluatorAbsoluteChangeTest extends AbstractThresholdEvalu
         threshold.setType(ThresholdType.ABSOLUTE_CHANGE);
         threshold.setDsName("ds-name");
         threshold.setDsType("node");
-        threshold.setValue(0.9);
-        threshold.setRearm(0.5);
-        threshold.setTrigger(3);
+        threshold.setDoubleValue(0.9);
+        threshold.setRearmValue(0.5);
+        threshold.setTriggerValue(3);
         ThresholdConfigWrapper wrapper=new ThresholdConfigWrapper(threshold);
        ThresholdEvaluatorStateAbsoluteChange evaluator = new ThresholdEvaluatorStateAbsoluteChange(wrapper, MockSession.getSession());
         
@@ -92,9 +94,9 @@ public class ThresholdEvaluatorAbsoluteChangeTest extends AbstractThresholdEvalu
         threshold.setType(ThresholdType.ABSOLUTE_CHANGE);
         threshold.setDsName("ds-name");
         threshold.setDsType("node");
-        threshold.setValue(0.9);
-        threshold.setRearm(0.5);
-        threshold.setTrigger(3);
+        threshold.setDoubleValue(0.9);
+        threshold.setRearmValue(0.5);
+        threshold.setTriggerValue(3);
         ThresholdConfigWrapper wrapper=new ThresholdConfigWrapper(threshold);
         ThresholdEvaluatorStateAbsoluteChange evaluator = new ThresholdEvaluatorStateAbsoluteChange(wrapper, MockSession.getSession());
         
@@ -108,9 +110,9 @@ public class ThresholdEvaluatorAbsoluteChangeTest extends AbstractThresholdEvalu
         threshold.setType(ThresholdType.ABSOLUTE_CHANGE);
         threshold.setDsName("ds-name");
         threshold.setDsType("node");
-        threshold.setValue(-1.0);
-        threshold.setRearm(0.5);
-        threshold.setTrigger(3);
+        threshold.setDoubleValue(-1.0);
+        threshold.setRearmValue(0.5);
+        threshold.setTriggerValue(3);
         ThresholdConfigWrapper wrapper=new ThresholdConfigWrapper(threshold);
         ThresholdEvaluatorStateAbsoluteChange evaluator = new ThresholdEvaluatorStateAbsoluteChange(wrapper, MockSession.getSession());
         
@@ -124,9 +126,9 @@ public class ThresholdEvaluatorAbsoluteChangeTest extends AbstractThresholdEvalu
         threshold.setType(ThresholdType.ABSOLUTE_CHANGE);
         threshold.setDsName("ds-name");
         threshold.setDsType("node");
-        threshold.setValue(-1.0);
-        threshold.setRearm(0.5);
-        threshold.setTrigger(3);
+        threshold.setDoubleValue(-1.0);
+        threshold.setRearmValue(0.5);
+        threshold.setTriggerValue(3);
         ThresholdConfigWrapper wrapper=new ThresholdConfigWrapper(threshold);
         ThresholdEvaluatorStateAbsoluteChange evaluator = new ThresholdEvaluatorStateAbsoluteChange(wrapper, MockSession.getSession());
         
@@ -140,9 +142,9 @@ public class ThresholdEvaluatorAbsoluteChangeTest extends AbstractThresholdEvalu
         threshold.setType(ThresholdType.ABSOLUTE_CHANGE);
         threshold.setDsName("ds-name");
         threshold.setDsType("node");
-        threshold.setValue(-1.0);
-        threshold.setRearm(0.5);
-        threshold.setTrigger(3);
+        threshold.setDoubleValue(-1.0);
+        threshold.setRearmValue(0.5);
+        threshold.setTriggerValue(3);
         ThresholdConfigWrapper wrapper=new ThresholdConfigWrapper(threshold);
         ThresholdEvaluatorStateAbsoluteChange evaluator = new ThresholdEvaluatorStateAbsoluteChange(wrapper, MockSession.getSession());
         
@@ -156,9 +158,9 @@ public class ThresholdEvaluatorAbsoluteChangeTest extends AbstractThresholdEvalu
         threshold.setType(ThresholdType.ABSOLUTE_CHANGE);
         threshold.setDsName("ds-name");
         threshold.setDsType("node");
-        threshold.setValue(1.0);
-        threshold.setRearm(0.5);
-        threshold.setTrigger(3);
+        threshold.setDoubleValue(1.0);
+        threshold.setRearmValue(0.5);
+        threshold.setTriggerValue(3);
         ThresholdConfigWrapper wrapper=new ThresholdConfigWrapper(threshold);
         ThresholdEvaluatorStateAbsoluteChange evaluator = new ThresholdEvaluatorStateAbsoluteChange(wrapper, MockSession.getSession());
         
@@ -172,9 +174,9 @@ public class ThresholdEvaluatorAbsoluteChangeTest extends AbstractThresholdEvalu
         threshold.setType(ThresholdType.ABSOLUTE_CHANGE);
         threshold.setDsName("ds-name");
         threshold.setDsType("node");
-        threshold.setValue(1.0);
-        threshold.setRearm(0.5);
-        threshold.setTrigger(3);
+        threshold.setDoubleValue(1.0);
+        threshold.setRearmValue(0.5);
+        threshold.setTriggerValue(3);
         ThresholdConfigWrapper wrapper=new ThresholdConfigWrapper(threshold);
         ThresholdEvaluatorStateAbsoluteChange evaluator = new ThresholdEvaluatorStateAbsoluteChange(wrapper, MockSession.getSession());
         
@@ -188,9 +190,9 @@ public class ThresholdEvaluatorAbsoluteChangeTest extends AbstractThresholdEvalu
         threshold.setType(ThresholdType.ABSOLUTE_CHANGE);
         threshold.setDsName("ds-name");
         threshold.setDsType("node");
-        threshold.setValue(1.0);
-        threshold.setRearm(0.5);
-        threshold.setTrigger(3);
+        threshold.setDoubleValue(1.0);
+        threshold.setRearmValue(0.5);
+        threshold.setTriggerValue(3);
         ThresholdConfigWrapper wrapper=new ThresholdConfigWrapper(threshold);
         ThresholdEvaluatorStateAbsoluteChange evaluator = new ThresholdEvaluatorStateAbsoluteChange(wrapper, MockSession.getSession());
         
@@ -204,13 +206,13 @@ public class ThresholdEvaluatorAbsoluteChangeTest extends AbstractThresholdEvalu
         threshold.setType(ThresholdType.ABSOLUTE_CHANGE);
         threshold.setDsName("ds-name");
         threshold.setDsType("node");
-        threshold.setValue(1.1);
-        threshold.setRearm(0.5);
-        threshold.setTrigger(3);
+        threshold.setDoubleValue(1.1);
+        threshold.setRearmValue(0.5);
+        threshold.setTriggerValue(3);
         ThresholdConfigWrapper wrapper=new ThresholdConfigWrapper(threshold);
         ThresholdEvaluatorStateAbsoluteChange evaluator = new ThresholdEvaluatorStateAbsoluteChange(wrapper, MockSession.getSession());
 
-        assertNull("should not have created an event", evaluator.getEventForState(Status.NO_CHANGE, new Date(), 10.0, null));
+        assertNull("should not have created an event", evaluator.getEventForState(Status.NO_CHANGE, new Date(), 10.0, null, null));
     }
     
     @Test
@@ -219,9 +221,13 @@ public class ThresholdEvaluatorAbsoluteChangeTest extends AbstractThresholdEvalu
         threshold.setType(ThresholdType.ABSOLUTE_CHANGE);
         threshold.setDsName("ds-name");
         threshold.setDsType("node");
-        threshold.setValue(1.0);
-        threshold.setRearm(0.5);
-        threshold.setTrigger(3);
+        threshold.setDoubleValue(1.0);
+        threshold.setRearmValue(0.5);
+        threshold.setTriggerValue(3);
+        ThresholdEvaluatorState.ThresholdValues thresholdValues = mock(ThresholdEvaluatorState.ThresholdValues.class);
+        when(thresholdValues.getThresholdValue()).thenReturn(1.0);
+        when(thresholdValues.getRearm()).thenReturn(0.5);
+        when(thresholdValues.getTrigger()).thenReturn(3);
         ThresholdConfigWrapper wrapper=new ThresholdConfigWrapper(threshold);
         ThresholdEvaluatorStateAbsoluteChange evaluator = new ThresholdEvaluatorStateAbsoluteChange(wrapper, MockSession.getSession());
 
@@ -229,7 +235,7 @@ public class ThresholdEvaluatorAbsoluteChangeTest extends AbstractThresholdEvalu
         assertEquals("should trigger", Status.TRIGGERED, evaluator.evaluate(10.0));
         
         // Do it once with a null instance
-        Event event = evaluator.getEventForState(Status.TRIGGERED, new Date(), 10.0, null);
+        Event event = evaluator.getEventForState(Status.TRIGGERED, new Date(), 10.0, thresholdValues, null);
         assertNotNull("should have created an event", event);
         assertEquals("UEIs should be the same", EventConstants.ABSOLUTE_CHANGE_THRESHOLD_EVENT_UEI, event.getUei());
         
@@ -240,7 +246,7 @@ public class ThresholdEvaluatorAbsoluteChangeTest extends AbstractThresholdEvalu
         parmPresentWithValue(event, "changeThreshold", "1.0");
         
         // And again with a non-null instance
-        event = evaluator.getEventForState(Status.TRIGGERED, new Date(), 10.0, new MockCollectionResourceWrapper("testInstance"));
+        event = evaluator.getEventForState(Status.TRIGGERED, new Date(), 10.0, thresholdValues, new MockCollectionResourceWrapper("testInstance"));
         assertNotNull("should have created an event", event);
         assertEquals("UEIs should be the same", EventConstants.ABSOLUTE_CHANGE_THRESHOLD_EVENT_UEI, event.getUei());
         
@@ -258,13 +264,17 @@ public class ThresholdEvaluatorAbsoluteChangeTest extends AbstractThresholdEvalu
         threshold.setType(ThresholdType.ABSOLUTE_CHANGE);
         threshold.setDsName("ds-name");
         threshold.setDsType("node");
-        threshold.setValue(99.0);
-        threshold.setRearm(95.0);
-        threshold.setTrigger(1);
+        threshold.setDoubleValue(99.0);
+        threshold.setRearmValue(95.0);
+        threshold.setTriggerValue(1);
+       ThresholdEvaluatorState.ThresholdValues thresholdValues = mock(ThresholdEvaluatorState.ThresholdValues.class);
+        when(thresholdValues.getThresholdValue()).thenReturn(99.0);
+        when(thresholdValues.getRearm()).thenReturn(95.0);
+        when(thresholdValues.getTrigger()).thenReturn(1);
         ThresholdConfigWrapper wrapper=new ThresholdConfigWrapper(threshold);
 
         ThresholdEvaluatorStateAbsoluteChange item = new ThresholdEvaluatorStateAbsoluteChange(wrapper, MockSession.getSession());
-        Event event=item.getEventForState(Status.TRIGGERED, new Date(), 100.0, null);
+        Event event=item.getEventForState(Status.TRIGGERED, new Date(), 100.0, thresholdValues, null);
         assertEquals("UEI should be the absoluteChangeThresholdTriggered", EventConstants.ABSOLUTE_CHANGE_THRESHOLD_EVENT_UEI, event.getUei());
     }
 
@@ -275,15 +285,19 @@ public class ThresholdEvaluatorAbsoluteChangeTest extends AbstractThresholdEvalu
         threshold.setType(ThresholdType.ABSOLUTE_CHANGE);
         threshold.setDsName("ds-name");
         threshold.setDsType("node");
-        threshold.setValue(99.0);
-        threshold.setRearm(95.0);
-        threshold.setTrigger(1);
+        threshold.setDoubleValue(99.0);
+        threshold.setRearmValue(95.0);
+        threshold.setTriggerValue(1);
         threshold.setTriggeredUEI(triggeredUEI);
+        ThresholdEvaluatorState.ThresholdValues thresholdValues = mock(ThresholdEvaluatorState.ThresholdValues.class);
+        when(thresholdValues.getThresholdValue()).thenReturn(99.0);
+        when(thresholdValues.getRearm()).thenReturn(95.0);
+        when(thresholdValues.getTrigger()).thenReturn(1);
         
         ThresholdConfigWrapper wrapper=new ThresholdConfigWrapper(threshold);
 
         ThresholdEvaluatorStateAbsoluteChange item = new ThresholdEvaluatorStateAbsoluteChange(wrapper, MockSession.getSession());
-        Event event=item.getEventForState(Status.TRIGGERED, new Date(), 100.0, null);
+        Event event=item.getEventForState(Status.TRIGGERED, new Date(), 100.0, thresholdValues, null);
         assertEquals("UEI should be the "+triggeredUEI, triggeredUEI, event.getUei());
        
     }

--- a/features/collection/thresholding/impl/src/test/java/org/opennms/netmgt/threshd/ThresholdEvaluatorHighLowTest.java
+++ b/features/collection/thresholding/impl/src/test/java/org/opennms/netmgt/threshd/ThresholdEvaluatorHighLowTest.java
@@ -31,6 +31,8 @@ package org.opennms.netmgt.threshd;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.util.Date;
 
@@ -65,9 +67,9 @@ public class ThresholdEvaluatorHighLowTest extends AbstractThresholdEvaluatorTes
         Threshold threshold = new Threshold();
         threshold.setDsName("ds-name");
         threshold.setDsType("node");
-        threshold.setValue(1.0);
-        threshold.setRearm(0.5);
-        threshold.setTrigger(3);
+        threshold.setValue("1.0");
+        threshold.setRearm("0.5");
+        threshold.setTrigger("3");
         ThresholdConfigWrapper wrapper=new ThresholdConfigWrapper(threshold);
         
         try {
@@ -85,9 +87,9 @@ public class ThresholdEvaluatorHighLowTest extends AbstractThresholdEvaluatorTes
         Threshold threshold = new Threshold();
         threshold.setType(ThresholdType.HIGH);
         threshold.setDsType("node");
-        threshold.setValue(1.0);
-        threshold.setRearm(0.5);
-        threshold.setTrigger(3);
+        threshold.setValue("1.0");
+        threshold.setRearm("0.5");
+        threshold.setTrigger("3");
         ThresholdConfigWrapper wrapper=new ThresholdConfigWrapper(threshold);
         try {
             new ThresholdEvaluatorStateHighLow(wrapper, MockSession.getSession());
@@ -104,9 +106,9 @@ public class ThresholdEvaluatorHighLowTest extends AbstractThresholdEvaluatorTes
         Threshold threshold = new Threshold();
         threshold.setType(ThresholdType.HIGH);
         threshold.setDsName("ds-name");
-        threshold.setValue(1.0);
-        threshold.setRearm(0.5);
-        threshold.setTrigger(3);
+        threshold.setDoubleValue(1.0);
+        threshold.setRearmValue(0.5);
+        threshold.setTriggerValue(3);
         ThresholdConfigWrapper wrapper=new ThresholdConfigWrapper(threshold);
        
         try {
@@ -125,8 +127,8 @@ public class ThresholdEvaluatorHighLowTest extends AbstractThresholdEvaluatorTes
         threshold.setType(ThresholdType.HIGH);
         threshold.setDsName("ds-name");
         threshold.setDsType("node");
-        threshold.setRearm(0.5);
-        threshold.setTrigger(3);
+        threshold.setRearmValue(0.5);
+        threshold.setTriggerValue(3);
         ThresholdConfigWrapper wrapper=new ThresholdConfigWrapper(threshold);
        
         try {
@@ -145,8 +147,8 @@ public class ThresholdEvaluatorHighLowTest extends AbstractThresholdEvaluatorTes
         threshold.setType(ThresholdType.HIGH);
         threshold.setDsName("ds-name");
         threshold.setDsType("node");
-        threshold.setValue(1.0);
-        threshold.setTrigger(3);
+        threshold.setDoubleValue(1.0);
+        threshold.setTriggerValue(3);
         ThresholdConfigWrapper wrapper=new ThresholdConfigWrapper(threshold);
       
         try {
@@ -165,8 +167,8 @@ public class ThresholdEvaluatorHighLowTest extends AbstractThresholdEvaluatorTes
         threshold.setType(ThresholdType.HIGH);
         threshold.setDsName("ds-name");
         threshold.setDsType("node");
-        threshold.setValue(1.0);
-        threshold.setRearm(0.5);
+        threshold.setDoubleValue(1.0);
+        threshold.setRearmValue(0.5);
         ThresholdConfigWrapper wrapper=new ThresholdConfigWrapper(threshold);
         
         try {
@@ -183,9 +185,9 @@ public class ThresholdEvaluatorHighLowTest extends AbstractThresholdEvaluatorTes
         threshold.setType(ThresholdType.HIGH);
         threshold.setDsName("ds-name");
         threshold.setDsType("node");
-        threshold.setValue(101.0);
-        threshold.setRearm(0.5);
-        threshold.setTrigger(1);
+        threshold.setDoubleValue(101.0);
+        threshold.setRearmValue(0.5);
+        threshold.setTriggerValue(1);
         ThresholdConfigWrapper wrapper=new ThresholdConfigWrapper(threshold);
       
         ThresholdEvaluatorState item = new ThresholdEvaluatorStateHighLow(wrapper, MockSession.getSession());
@@ -200,9 +202,9 @@ public class ThresholdEvaluatorHighLowTest extends AbstractThresholdEvaluatorTes
         threshold.setType(ThresholdType.HIGH);
         threshold.setDsName("ds-name");
         threshold.setDsType("node");
-        threshold.setValue(99.0);
-        threshold.setRearm(0.5);
-        threshold.setTrigger(1);
+        threshold.setValue("99.0");
+        threshold.setRearm("0.5");
+        threshold.setTrigger("1");
         ThresholdConfigWrapper wrapper=new ThresholdConfigWrapper(threshold);
        
         ThresholdEvaluatorState item = new ThresholdEvaluatorStateHighLow(wrapper, MockSession.getSession());
@@ -217,9 +219,9 @@ public class ThresholdEvaluatorHighLowTest extends AbstractThresholdEvaluatorTes
         threshold.setType(ThresholdType.HIGH);
         threshold.setDsName("ds-name");
         threshold.setDsType("node");
-        threshold.setValue(99.0);
-        threshold.setRearm(0.5);
-        threshold.setTrigger(2);
+        threshold.setDoubleValue(99.0);
+        threshold.setRearmValue(0.5);
+        threshold.setTriggerValue(2);
         ThresholdConfigWrapper wrapper=new ThresholdConfigWrapper(threshold);
 
         ThresholdEvaluatorState item = new ThresholdEvaluatorStateHighLow(wrapper, MockSession.getSession());
@@ -234,9 +236,9 @@ public class ThresholdEvaluatorHighLowTest extends AbstractThresholdEvaluatorTes
         threshold.setType(ThresholdType.HIGH);
         threshold.setDsName("ds-name");
         threshold.setDsType("node");
-        threshold.setValue(99.0);
-        threshold.setRearm(0.5);
-        threshold.setTrigger(2);
+        threshold.setDoubleValue(99.0);
+        threshold.setRearmValue(0.5);
+        threshold.setTriggerValue(2);
         ThresholdConfigWrapper wrapper=new ThresholdConfigWrapper(threshold);
 
         ThresholdEvaluatorState item = new ThresholdEvaluatorStateHighLow(wrapper, MockSession.getSession());
@@ -254,9 +256,9 @@ public class ThresholdEvaluatorHighLowTest extends AbstractThresholdEvaluatorTes
         threshold.setType(ThresholdType.HIGH);
         threshold.setDsName("ds-name");
         threshold.setDsType("node");
-        threshold.setValue(99.0);
-        threshold.setRearm(0.5);
-        threshold.setTrigger(2);
+        threshold.setDoubleValue(99.0);
+        threshold.setRearmValue(0.5);
+        threshold.setTriggerValue(2);
         ThresholdConfigWrapper wrapper=new ThresholdConfigWrapper(threshold);
 
         ThresholdEvaluatorState item = new ThresholdEvaluatorStateHighLow(wrapper, MockSession.getSession());
@@ -281,9 +283,9 @@ public class ThresholdEvaluatorHighLowTest extends AbstractThresholdEvaluatorTes
         threshold.setType(ThresholdType.HIGH);
         threshold.setDsName("ds-name");
         threshold.setDsType("node");
-        threshold.setValue(99.0);
-        threshold.setRearm(0.5);
-        threshold.setTrigger(1);
+        threshold.setDoubleValue(99.0);
+        threshold.setRearmValue(0.5);
+        threshold.setTriggerValue(1);
         ThresholdConfigWrapper wrapper=new ThresholdConfigWrapper(threshold);
 
         ThresholdEvaluatorState item = new ThresholdEvaluatorStateHighLow(wrapper, MockSession.getSession());
@@ -301,9 +303,9 @@ public class ThresholdEvaluatorHighLowTest extends AbstractThresholdEvaluatorTes
         threshold.setType(ThresholdType.HIGH);
         threshold.setDsName("ds-name");
         threshold.setDsType("node");
-        threshold.setValue(99.0);
-        threshold.setRearm(0.5);
-        threshold.setTrigger(1);
+        threshold.setDoubleValue(99.0);
+        threshold.setRearmValue(0.5);
+        threshold.setTriggerValue(1);
         ThresholdConfigWrapper wrapper=new ThresholdConfigWrapper(threshold);
 
         ThresholdEvaluatorState item = new ThresholdEvaluatorStateHighLow(wrapper, MockSession.getSession());
@@ -324,9 +326,9 @@ public class ThresholdEvaluatorHighLowTest extends AbstractThresholdEvaluatorTes
         threshold.setType(ThresholdType.LOW);
         threshold.setDsName("ds-name");
         threshold.setDsType("node");
-        threshold.setValue(99.0);
-        threshold.setRearm(0.5);
-        threshold.setTrigger(1);
+        threshold.setDoubleValue(99.0);
+        threshold.setRearmValue(0.5);
+        threshold.setTriggerValue(1);
         ThresholdConfigWrapper wrapper=new ThresholdConfigWrapper(threshold);
 
         ThresholdEvaluatorState item = new ThresholdEvaluatorStateHighLow(wrapper, MockSession.getSession());
@@ -341,13 +343,13 @@ public class ThresholdEvaluatorHighLowTest extends AbstractThresholdEvaluatorTes
         threshold.setType(ThresholdType.HIGH);
         threshold.setDsName("ds-name");
         threshold.setDsType("node");
-        threshold.setValue(99.0);
-        threshold.setRearm(0.5);
-        threshold.setTrigger(1);
+        threshold.setDoubleValue(99.0);
+        threshold.setRearmValue(0.5);
+        threshold.setTriggerValue(1);
         ThresholdConfigWrapper wrapper=new ThresholdConfigWrapper(threshold);
 
         ThresholdEvaluatorStateHighLow item = new ThresholdEvaluatorStateHighLow(wrapper, MockSession.getSession());
-        assertTrue("threshold should be exceeded", item.isThresholdExceeded(100.0));
+        assertTrue("threshold should be exceeded", item.isThresholdExceeded(100.0 ));
     }
     
     @Test
@@ -356,9 +358,9 @@ public class ThresholdEvaluatorHighLowTest extends AbstractThresholdEvaluatorTes
         threshold.setType(ThresholdType.HIGH);
         threshold.setDsName("ds-name");
         threshold.setDsType("node");
-        threshold.setValue(99.0);
-        threshold.setRearm(0.5);
-        threshold.setTrigger(1);
+        threshold.setDoubleValue(99.0);
+        threshold.setRearmValue(0.5);
+        threshold.setTriggerValue(1);
         ThresholdConfigWrapper wrapper=new ThresholdConfigWrapper(threshold);
 
         ThresholdEvaluatorStateHighLow item = new ThresholdEvaluatorStateHighLow(wrapper, MockSession.getSession());
@@ -371,9 +373,9 @@ public class ThresholdEvaluatorHighLowTest extends AbstractThresholdEvaluatorTes
         threshold.setType(ThresholdType.HIGH);
         threshold.setDsName("ds-name");
         threshold.setDsType("node");
-        threshold.setValue(99.0);
-        threshold.setRearm(0.5);
-        threshold.setTrigger(1);
+        threshold.setDoubleValue(99.0);
+        threshold.setRearmValue(0.5);
+        threshold.setTriggerValue(1);
         ThresholdConfigWrapper wrapper=new ThresholdConfigWrapper(threshold);
 
         ThresholdEvaluatorStateHighLow item = new ThresholdEvaluatorStateHighLow(wrapper, MockSession.getSession());
@@ -386,9 +388,9 @@ public class ThresholdEvaluatorHighLowTest extends AbstractThresholdEvaluatorTes
         threshold.setType(ThresholdType.LOW);
         threshold.setDsName("ds-name");
         threshold.setDsType("node");
-        threshold.setValue(99.0);
-        threshold.setRearm(0.5);
-        threshold.setTrigger(1);
+        threshold.setDoubleValue(99.0);
+        threshold.setRearmValue(0.5);
+        threshold.setTriggerValue(1);
         ThresholdConfigWrapper wrapper=new ThresholdConfigWrapper(threshold);
 
         ThresholdEvaluatorStateHighLow item = new ThresholdEvaluatorStateHighLow(wrapper, MockSession.getSession());
@@ -401,9 +403,9 @@ public class ThresholdEvaluatorHighLowTest extends AbstractThresholdEvaluatorTes
         threshold.setType(ThresholdType.LOW);
         threshold.setDsName("ds-name");
         threshold.setDsType("node");
-        threshold.setValue(99.0);
-        threshold.setRearm(0.5);
-        threshold.setTrigger(1);
+        threshold.setDoubleValue(99.0);
+        threshold.setRearmValue(0.5);
+        threshold.setTriggerValue(1);
         ThresholdConfigWrapper wrapper=new ThresholdConfigWrapper(threshold);
 
         ThresholdEvaluatorStateHighLow item = new ThresholdEvaluatorStateHighLow(wrapper, MockSession.getSession());
@@ -416,9 +418,9 @@ public class ThresholdEvaluatorHighLowTest extends AbstractThresholdEvaluatorTes
         threshold.setType(ThresholdType.LOW);
         threshold.setDsName("ds-name");
         threshold.setDsType("node");
-        threshold.setValue(99.0);
-        threshold.setRearm(0.5);
-        threshold.setTrigger(1);
+        threshold.setDoubleValue(99.0);
+        threshold.setRearmValue(0.5);
+        threshold.setTriggerValue(1);
         ThresholdConfigWrapper wrapper=new ThresholdConfigWrapper(threshold);
 
         ThresholdEvaluatorStateHighLow item = new ThresholdEvaluatorStateHighLow(wrapper, MockSession.getSession());
@@ -431,9 +433,9 @@ public class ThresholdEvaluatorHighLowTest extends AbstractThresholdEvaluatorTes
         threshold.setType(ThresholdType.RELATIVE_CHANGE);
         threshold.setDsName("ds-name");
         threshold.setDsType("node");
-        threshold.setValue(99.0);
-        threshold.setRearm(0.5);
-        threshold.setTrigger(1);
+        threshold.setDoubleValue(99.0);
+        threshold.setRearmValue(0.5);
+        threshold.setTriggerValue(1);
         ThresholdConfigWrapper wrapper=new ThresholdConfigWrapper(threshold);
         ThrowableAnticipator ta = new ThrowableAnticipator();
         ta.anticipate(new IllegalStateException("This thresholding strategy can only be used for thresholding types of 'high' and 'low'."));
@@ -453,9 +455,9 @@ public class ThresholdEvaluatorHighLowTest extends AbstractThresholdEvaluatorTes
         threshold.setType(ThresholdType.HIGH);
         threshold.setDsName("ds-name");
         threshold.setDsType("node");
-        threshold.setValue(99.0);
-        threshold.setRearm(0.5);
-        threshold.setTrigger(1);
+        threshold.setDoubleValue(99.0);
+        threshold.setRearmValue(0.5);
+        threshold.setTriggerValue(1);
         ThresholdConfigWrapper wrapper=new ThresholdConfigWrapper(threshold);
 
         ThresholdEvaluatorStateHighLow item = new ThresholdEvaluatorStateHighLow(wrapper, MockSession.getSession());
@@ -468,9 +470,9 @@ public class ThresholdEvaluatorHighLowTest extends AbstractThresholdEvaluatorTes
         threshold.setType(ThresholdType.HIGH);
         threshold.setDsName("ds-name");
         threshold.setDsType("node");
-        threshold.setValue(99.0);
-        threshold.setRearm(0.5);
-        threshold.setTrigger(1);
+        threshold.setDoubleValue(99.0);
+        threshold.setRearmValue(0.5);
+        threshold.setTriggerValue(1);
         ThresholdConfigWrapper wrapper=new ThresholdConfigWrapper(threshold);
 
         ThresholdEvaluatorStateHighLow item = new ThresholdEvaluatorStateHighLow(wrapper, MockSession.getSession());
@@ -483,9 +485,9 @@ public class ThresholdEvaluatorHighLowTest extends AbstractThresholdEvaluatorTes
         threshold.setType(ThresholdType.HIGH);
         threshold.setDsName("ds-name");
         threshold.setDsType("node");
-        threshold.setValue(99.0);
-        threshold.setRearm(0.5);
-        threshold.setTrigger(1);
+        threshold.setDoubleValue(99.0);
+        threshold.setRearmValue(0.5);
+        threshold.setTriggerValue(1);
         ThresholdConfigWrapper wrapper=new ThresholdConfigWrapper(threshold);
 
         ThresholdEvaluatorStateHighLow item = new ThresholdEvaluatorStateHighLow(wrapper, MockSession.getSession());
@@ -498,9 +500,9 @@ public class ThresholdEvaluatorHighLowTest extends AbstractThresholdEvaluatorTes
         threshold.setType(ThresholdType.LOW);
         threshold.setDsName("ds-name");
         threshold.setDsType("node");
-        threshold.setValue(99.0);
-        threshold.setRearm(0.5);
-        threshold.setTrigger(1);
+        threshold.setDoubleValue(99.0);
+        threshold.setRearmValue(0.5);
+        threshold.setTriggerValue(1);
         ThresholdConfigWrapper wrapper=new ThresholdConfigWrapper(threshold);
 
         ThresholdEvaluatorStateHighLow item = new ThresholdEvaluatorStateHighLow(wrapper, MockSession.getSession());
@@ -513,9 +515,9 @@ public class ThresholdEvaluatorHighLowTest extends AbstractThresholdEvaluatorTes
         threshold.setType(ThresholdType.LOW);
         threshold.setDsName("ds-name");
         threshold.setDsType("node");
-        threshold.setValue(99.0);
-        threshold.setRearm(0.5);
-        threshold.setTrigger(1);
+        threshold.setDoubleValue(99.0);
+        threshold.setRearmValue(0.5);
+        threshold.setTriggerValue(1);
         ThresholdConfigWrapper wrapper=new ThresholdConfigWrapper(threshold);
 
         ThresholdEvaluatorStateHighLow item = new ThresholdEvaluatorStateHighLow(wrapper, MockSession.getSession());
@@ -528,9 +530,9 @@ public class ThresholdEvaluatorHighLowTest extends AbstractThresholdEvaluatorTes
         threshold.setType(ThresholdType.LOW);
         threshold.setDsName("ds-name");
         threshold.setDsType("node");
-        threshold.setValue(99.0);
-        threshold.setRearm(0.5);
-        threshold.setTrigger(1);
+        threshold.setDoubleValue(99.0);
+        threshold.setRearmValue(0.5);
+        threshold.setTriggerValue(1);
         ThresholdConfigWrapper wrapper=new ThresholdConfigWrapper(threshold);
 
         ThresholdEvaluatorStateHighLow item = new ThresholdEvaluatorStateHighLow(wrapper, MockSession.getSession());
@@ -543,9 +545,9 @@ public class ThresholdEvaluatorHighLowTest extends AbstractThresholdEvaluatorTes
         threshold.setType(ThresholdType.RELATIVE_CHANGE);
         threshold.setDsName("ds-name");
         threshold.setDsType("node");
-        threshold.setValue(99.0);
-        threshold.setRearm(0.5);
-        threshold.setTrigger(1);
+        threshold.setDoubleValue(99.0);
+        threshold.setRearmValue(0.5);
+        threshold.setTriggerValue(1);
         ThresholdConfigWrapper wrapper=new ThresholdConfigWrapper(threshold);
 
         ThrowableAnticipator ta = new ThrowableAnticipator();
@@ -566,9 +568,9 @@ public class ThresholdEvaluatorHighLowTest extends AbstractThresholdEvaluatorTes
         threshold.setType(ThresholdType.HIGH);
         threshold.setDsName("ds-name");
         threshold.setDsType("node");
-        threshold.setValue(99.0);
-        threshold.setRearm(0.5);
-        threshold.setTrigger(1);
+        threshold.setDoubleValue(99.0);
+        threshold.setRearmValue(0.5);
+        threshold.setTriggerValue(1);
         ThresholdConfigWrapper wrapper=new ThresholdConfigWrapper(threshold);
 
         ThresholdEvaluatorStateHighLow item = new ThresholdEvaluatorStateHighLow(wrapper, MockSession.getSession());
@@ -586,9 +588,9 @@ public class ThresholdEvaluatorHighLowTest extends AbstractThresholdEvaluatorTes
         threshold.setType(ThresholdType.HIGH);
         threshold.setDsName("ds-name");
         threshold.setDsType("node");
-        threshold.setValue(99.0);
-        threshold.setRearm(0.5);
-        threshold.setTrigger(2);
+        threshold.setDoubleValue(99.0);
+        threshold.setRearmValue(0.5);
+        threshold.setTriggerValue(2);
         ThresholdConfigWrapper wrapper=new ThresholdConfigWrapper(threshold);
 
         ThresholdEvaluatorStateHighLow item = new ThresholdEvaluatorStateHighLow(wrapper, MockSession.getSession());
@@ -606,9 +608,9 @@ public class ThresholdEvaluatorHighLowTest extends AbstractThresholdEvaluatorTes
         threshold.setType(ThresholdType.HIGH);
         threshold.setDsName("ds-name");
         threshold.setDsType("node");
-        threshold.setValue(99.0);
-        threshold.setRearm(0.5);
-        threshold.setTrigger(1);
+        threshold.setDoubleValue(99.0);
+        threshold.setRearmValue(0.5);
+        threshold.setTriggerValue(1);
         ThresholdConfigWrapper wrapper=new ThresholdConfigWrapper(threshold);
 
         ThresholdEvaluatorStateHighLow item = new ThresholdEvaluatorStateHighLow(wrapper, MockSession.getSession());
@@ -631,55 +633,59 @@ public class ThresholdEvaluatorHighLowTest extends AbstractThresholdEvaluatorTes
         threshold.setType(ThresholdType.HIGH);
         threshold.setDsName("ds-name");
         threshold.setDsType("node");
-        threshold.setValue(99.0);
-        threshold.setRearm(95.0);
-        threshold.setTrigger(1);
+        threshold.setDoubleValue(99.0);
+        threshold.setRearmValue(95.0);
+        threshold.setTriggerValue(1);
         ThresholdConfigWrapper wrapper=new ThresholdConfigWrapper(threshold);
+        ThresholdEvaluatorState.ThresholdValues thresholdValues = mock(ThresholdEvaluatorState.ThresholdValues.class);
+        when(thresholdValues.getThresholdValue()).thenReturn(99.0);
+        when(thresholdValues.getRearm()).thenReturn(95.0);
+        when(thresholdValues.getTrigger()).thenReturn(1);
 
         ThresholdEvaluatorStateHighLow item = new ThresholdEvaluatorStateHighLow(wrapper, MockSession.getSession());
 
         // High exceed, with null instance
-        Event event=item.getEventForState(Status.TRIGGERED, new Date(), 100.0, null);
+        Event event=item.getEventForState(Status.TRIGGERED, new Date(), 100.0, thresholdValues, null);
         assertEquals("UEI should be the highThresholdExceededUEI", EventConstants.HIGH_THRESHOLD_EVENT_UEI, event.getUei());
         parmPresentAndValueNonNull(event, "instance");
         
         // High rearm, with null instance
-        event=item.getEventForState(Status.RE_ARMED, new Date(), 94.0, null);
+        event=item.getEventForState(Status.RE_ARMED, new Date(), 94.0, thresholdValues, null);
         assertEquals("UEI should be the highThresholdRearmedUEI", EventConstants.HIGH_THRESHOLD_REARM_EVENT_UEI, event.getUei());
         parmPresentAndValueNonNull(event, "instance");
         
         // High exceed, with non-null instance
-        event=item.getEventForState(Status.TRIGGERED, new Date(), 100.0, new MockCollectionResourceWrapper("testInstance"));
+        event=item.getEventForState(Status.TRIGGERED, new Date(), 100.0, thresholdValues, new MockCollectionResourceWrapper("testInstance"));
         assertEquals("UEI should be the highThresholdExceededUEI", EventConstants.HIGH_THRESHOLD_EVENT_UEI, event.getUei());
         parmPresentWithValue(event, "instance", "testInstance");
         
         // High rearm, with non-null instance
-        event=item.getEventForState(Status.RE_ARMED, new Date(), 94.0, new MockCollectionResourceWrapper("testInstance"));
+        event=item.getEventForState(Status.RE_ARMED, new Date(), 94.0, thresholdValues, new MockCollectionResourceWrapper("testInstance"));
         assertEquals("UEI should be the highThresholdRearmedUEI", EventConstants.HIGH_THRESHOLD_REARM_EVENT_UEI, event.getUei());
         parmPresentWithValue(event, "instance", "testInstance");
         
         // Set it up again for low tests
         threshold.setType(ThresholdType.LOW);
-        threshold.setValue(95.0);
-        threshold.setRearm(99.0);
+        threshold.setDoubleValue(95.0);
+        threshold.setRearmValue(99.0);
         
         // Low exceed, with null instance
-        event=item.getEventForState(Status.TRIGGERED, new Date(), 94.0, null);
+        event=item.getEventForState(Status.TRIGGERED, new Date(), 94.0, thresholdValues, null);
         assertEquals("UEI should be the lowThresholdExceededUEI", EventConstants.LOW_THRESHOLD_EVENT_UEI, event.getUei());
         parmPresentAndValueNonNull(event, "instance");
         
         // Low rearm, with null instance
-        event=item.getEventForState(Status.RE_ARMED, new Date(), 100.0, null);
+        event=item.getEventForState(Status.RE_ARMED, new Date(), 100.0, thresholdValues, null);
         assertEquals("UEI should be the lowThresholdRearmedUEI", EventConstants.LOW_THRESHOLD_REARM_EVENT_UEI, event.getUei());
         parmPresentAndValueNonNull(event, "instance");
         
         // Low exceed, with non-null instance
-        event=item.getEventForState(Status.TRIGGERED, new Date(), 94.0, new MockCollectionResourceWrapper("testInstance"));
+        event=item.getEventForState(Status.TRIGGERED, new Date(), 94.0, thresholdValues, new MockCollectionResourceWrapper("testInstance"));
         assertEquals("UEI should be the lowThresholdExceededUEI", EventConstants.LOW_THRESHOLD_EVENT_UEI, event.getUei());
         parmPresentWithValue(event, "instance", "testInstance");
         
         // Low rearm, with non-null instance
-        event=item.getEventForState(Status.RE_ARMED, new Date(), 100.0, new MockCollectionResourceWrapper("testInstance"));
+        event=item.getEventForState(Status.RE_ARMED, new Date(), 100.0, thresholdValues, new MockCollectionResourceWrapper("testInstance"));
         assertEquals("UEI should be the lowThresholdRearmedUEI", EventConstants.LOW_THRESHOLD_REARM_EVENT_UEI, event.getUei());
         parmPresentWithValue(event, "instance", "testInstance");
     }
@@ -692,20 +698,24 @@ public class ThresholdEvaluatorHighLowTest extends AbstractThresholdEvaluatorTes
         threshold.setType(ThresholdType.HIGH);
         threshold.setDsName("ds-name");
         threshold.setDsType("node");
-        threshold.setValue(99.0);
-        threshold.setRearm(95.0);
-        threshold.setTrigger(1);
+        threshold.setDoubleValue(99.0);
+        threshold.setRearmValue(95.0);
+        threshold.setTriggerValue(1);
         threshold.setTriggeredUEI(triggeredUEI);
         threshold.setRearmedUEI(rearmedUEI);
+        ThresholdEvaluatorState.ThresholdValues thresholdValues = mock(ThresholdEvaluatorState.ThresholdValues.class);
+        when(thresholdValues.getThresholdValue()).thenReturn(99.0);
+        when(thresholdValues.getRearm()).thenReturn(95.0);
+        when(thresholdValues.getTrigger()).thenReturn(1);
         
         ThresholdConfigWrapper wrapper=new ThresholdConfigWrapper(threshold);
 
         ThresholdEvaluatorStateHighLow item = new ThresholdEvaluatorStateHighLow(wrapper, MockSession.getSession());
-        Event event=item.getEventForState(Status.TRIGGERED, new Date(), 100.0, null);
+        Event event=item.getEventForState(Status.TRIGGERED, new Date(), 100.0, thresholdValues, null);
         assertEquals("UEI should be the uei.opennms.org/custom/thresholdTriggered", triggeredUEI, event.getUei());
         parmPresentAndValueNonNull(event, "instance");
         
-        event=item.getEventForState(Status.RE_ARMED, new Date(), 94.0, null);
+        event=item.getEventForState(Status.RE_ARMED, new Date(), 94.0, thresholdValues, null);
         assertEquals("UEI should be the uei.opennms.org/custom/thresholdRearmed", rearmedUEI, event.getUei());
         parmPresentAndValueNonNull(event, "instance");        
     }

--- a/features/collection/thresholding/impl/src/test/java/org/opennms/netmgt/threshd/ThresholdEvaluatorRelativeChangeTest.java
+++ b/features/collection/thresholding/impl/src/test/java/org/opennms/netmgt/threshd/ThresholdEvaluatorRelativeChangeTest.java
@@ -31,6 +31,8 @@ package org.opennms.netmgt.threshd;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.util.Date;
 
@@ -51,9 +53,9 @@ public class ThresholdEvaluatorRelativeChangeTest extends AbstractThresholdEvalu
         threshold.setType(ThresholdType.RELATIVE_CHANGE);
         threshold.setDsName("ds-name");
         threshold.setDsType("node");
-        threshold.setValue(0.9);
-        threshold.setRearm(0.5);
-        threshold.setTrigger(3);
+        threshold.setDoubleValue(0.9);
+        threshold.setRearmValue(0.5);
+        threshold.setTriggerValue(3);
         ThresholdConfigWrapper wrapper=new ThresholdConfigWrapper(threshold);
        new ThresholdEvaluatorStateRelativeChange(wrapper, MockSession.getSession());
     }
@@ -77,9 +79,9 @@ public class ThresholdEvaluatorRelativeChangeTest extends AbstractThresholdEvalu
         threshold.setType(ThresholdType.RELATIVE_CHANGE);
         threshold.setDsName("ds-name");
         threshold.setDsType("node");
-        threshold.setValue(0.9);
-        threshold.setRearm(0.5);
-        threshold.setTrigger(3);
+        threshold.setDoubleValue(0.9);
+        threshold.setRearmValue(0.5);
+        threshold.setTriggerValue(3);
         ThresholdConfigWrapper wrapper=new ThresholdConfigWrapper(threshold);
        ThresholdEvaluatorStateRelativeChange evaluator = new ThresholdEvaluatorStateRelativeChange(wrapper, MockSession.getSession());
         
@@ -92,9 +94,9 @@ public class ThresholdEvaluatorRelativeChangeTest extends AbstractThresholdEvalu
         threshold.setType(ThresholdType.RELATIVE_CHANGE);
         threshold.setDsName("ds-name");
         threshold.setDsType("node");
-        threshold.setValue(0.9);
-        threshold.setRearm(0.5);
-        threshold.setTrigger(3);
+        threshold.setDoubleValue(0.9);
+        threshold.setRearmValue(0.5);
+        threshold.setTriggerValue(3);
         ThresholdConfigWrapper wrapper=new ThresholdConfigWrapper(threshold);
         ThresholdEvaluatorStateRelativeChange evaluator = new ThresholdEvaluatorStateRelativeChange(wrapper, MockSession.getSession());
         
@@ -108,9 +110,9 @@ public class ThresholdEvaluatorRelativeChangeTest extends AbstractThresholdEvalu
         threshold.setType(ThresholdType.RELATIVE_CHANGE);
         threshold.setDsName("ds-name");
         threshold.setDsType("node");
-        threshold.setValue(0.9);
-        threshold.setRearm(0.5);
-        threshold.setTrigger(3);
+        threshold.setDoubleValue(0.9);
+        threshold.setRearmValue(0.5);
+        threshold.setTriggerValue(3);
         ThresholdConfigWrapper wrapper=new ThresholdConfigWrapper(threshold);
         ThresholdEvaluatorStateRelativeChange evaluator = new ThresholdEvaluatorStateRelativeChange(wrapper, MockSession.getSession());
         
@@ -124,9 +126,9 @@ public class ThresholdEvaluatorRelativeChangeTest extends AbstractThresholdEvalu
         threshold.setType(ThresholdType.RELATIVE_CHANGE);
         threshold.setDsName("ds-name");
         threshold.setDsType("node");
-        threshold.setValue(0.9);
-        threshold.setRearm(0.5);
-        threshold.setTrigger(3);
+        threshold.setDoubleValue(0.9);
+        threshold.setRearmValue(0.5);
+        threshold.setTriggerValue(3);
         ThresholdConfigWrapper wrapper=new ThresholdConfigWrapper(threshold);
         ThresholdEvaluatorStateRelativeChange evaluator = new ThresholdEvaluatorStateRelativeChange(wrapper, MockSession.getSession());
         
@@ -140,9 +142,9 @@ public class ThresholdEvaluatorRelativeChangeTest extends AbstractThresholdEvalu
         threshold.setType(ThresholdType.RELATIVE_CHANGE);
         threshold.setDsName("ds-name");
         threshold.setDsType("node");
-        threshold.setValue(0.9);
-        threshold.setRearm(0.5);
-        threshold.setTrigger(3);
+        threshold.setDoubleValue(0.9);
+        threshold.setRearmValue(0.5);
+        threshold.setTriggerValue(3);
         ThresholdConfigWrapper wrapper=new ThresholdConfigWrapper(threshold);
         ThresholdEvaluatorStateRelativeChange evaluator = new ThresholdEvaluatorStateRelativeChange(wrapper, MockSession.getSession());
         
@@ -156,9 +158,9 @@ public class ThresholdEvaluatorRelativeChangeTest extends AbstractThresholdEvalu
         threshold.setType(ThresholdType.RELATIVE_CHANGE);
         threshold.setDsName("ds-name");
         threshold.setDsType("node");
-        threshold.setValue(1.1);
-        threshold.setRearm(0.5);
-        threshold.setTrigger(3);
+        threshold.setDoubleValue(1.1);
+        threshold.setRearmValue(0.5);
+        threshold.setTriggerValue(3);
         ThresholdConfigWrapper wrapper=new ThresholdConfigWrapper(threshold);
         ThresholdEvaluatorStateRelativeChange evaluator = new ThresholdEvaluatorStateRelativeChange(wrapper, MockSession.getSession());
         
@@ -172,9 +174,9 @@ public class ThresholdEvaluatorRelativeChangeTest extends AbstractThresholdEvalu
         threshold.setType(ThresholdType.RELATIVE_CHANGE);
         threshold.setDsName("ds-name");
         threshold.setDsType("node");
-        threshold.setValue(1.1);
-        threshold.setRearm(0.5);
-        threshold.setTrigger(3);
+        threshold.setDoubleValue(1.1);
+        threshold.setRearmValue(0.5);
+        threshold.setTriggerValue(3);
         ThresholdConfigWrapper wrapper=new ThresholdConfigWrapper(threshold);
         ThresholdEvaluatorStateRelativeChange evaluator = new ThresholdEvaluatorStateRelativeChange(wrapper, MockSession.getSession());
         
@@ -188,9 +190,9 @@ public class ThresholdEvaluatorRelativeChangeTest extends AbstractThresholdEvalu
         threshold.setType(ThresholdType.RELATIVE_CHANGE);
         threshold.setDsName("ds-name");
         threshold.setDsType("node");
-        threshold.setValue(1.1);
-        threshold.setRearm(0.5);
-        threshold.setTrigger(3);
+        threshold.setDoubleValue(1.1);
+        threshold.setRearmValue(0.5);
+        threshold.setTriggerValue(3);
         ThresholdConfigWrapper wrapper=new ThresholdConfigWrapper(threshold);
         ThresholdEvaluatorStateRelativeChange evaluator = new ThresholdEvaluatorStateRelativeChange(wrapper, MockSession.getSession());
         
@@ -204,9 +206,9 @@ public class ThresholdEvaluatorRelativeChangeTest extends AbstractThresholdEvalu
         threshold.setType(ThresholdType.RELATIVE_CHANGE);
         threshold.setDsName("ds-name");
         threshold.setDsType("node");
-        threshold.setValue(1.1);
-        threshold.setRearm(0.5);
-        threshold.setTrigger(3);
+        threshold.setDoubleValue(1.1);
+        threshold.setRearmValue(0.5);
+        threshold.setTriggerValue(3);
         ThresholdConfigWrapper wrapper=new ThresholdConfigWrapper(threshold);
         ThresholdEvaluatorStateRelativeChange evaluator = new ThresholdEvaluatorStateRelativeChange(wrapper, MockSession.getSession());
         
@@ -220,9 +222,9 @@ public class ThresholdEvaluatorRelativeChangeTest extends AbstractThresholdEvalu
         threshold.setType(ThresholdType.RELATIVE_CHANGE);
         threshold.setDsName("ds-name");
         threshold.setDsType("node");
-        threshold.setValue(1.1);
-        threshold.setRearm(0.5);
-        threshold.setTrigger(3);
+        threshold.setDoubleValue(1.1);
+        threshold.setRearmValue(0.5);
+        threshold.setTriggerValue(3);
         ThresholdConfigWrapper wrapper=new ThresholdConfigWrapper(threshold);
         ThresholdEvaluatorStateRelativeChange evaluator = new ThresholdEvaluatorStateRelativeChange(wrapper, MockSession.getSession());
         
@@ -237,13 +239,13 @@ public class ThresholdEvaluatorRelativeChangeTest extends AbstractThresholdEvalu
         threshold.setType(ThresholdType.RELATIVE_CHANGE);
         threshold.setDsName("ds-name");
         threshold.setDsType("node");
-        threshold.setValue(1.1);
-        threshold.setRearm(0.5);
-        threshold.setTrigger(3);
+        threshold.setDoubleValue(1.1);
+        threshold.setRearmValue(0.5);
+        threshold.setTriggerValue(3);
         ThresholdConfigWrapper wrapper=new ThresholdConfigWrapper(threshold);
         ThresholdEvaluatorStateRelativeChange evaluator = new ThresholdEvaluatorStateRelativeChange(wrapper, MockSession.getSession());
 
-        assertNull("should not have created an event", evaluator.getEventForState(Status.NO_CHANGE, new Date(), 10.0, null));
+        assertNull("should not have created an event", evaluator.getEventForState(Status.NO_CHANGE, new Date(), 10.0, null, null));
     }
     
     @Test
@@ -252,9 +254,14 @@ public class ThresholdEvaluatorRelativeChangeTest extends AbstractThresholdEvalu
         threshold.setType(ThresholdType.RELATIVE_CHANGE);
         threshold.setDsName("ds-name");
         threshold.setDsType("node");
-        threshold.setValue(1.1);
-        threshold.setRearm(0.5);
-        threshold.setTrigger(3);
+        threshold.setDoubleValue(1.1);
+        threshold.setRearmValue(0.5);
+        threshold.setTriggerValue(3);
+        ThresholdEvaluatorState.ThresholdValues thresholdValues = mock(ThresholdEvaluatorState.ThresholdValues.class);
+        when(thresholdValues.getThresholdValue()).thenReturn(1.1);
+        when(thresholdValues.getRearm()).thenReturn(0.5);
+        when(thresholdValues.getTrigger()).thenReturn(3);
+
         ThresholdConfigWrapper wrapper=new ThresholdConfigWrapper(threshold);
         ThresholdEvaluatorStateRelativeChange evaluator = new ThresholdEvaluatorStateRelativeChange(wrapper, MockSession.getSession());
 
@@ -262,7 +269,7 @@ public class ThresholdEvaluatorRelativeChangeTest extends AbstractThresholdEvalu
         assertEquals("should trigger", Status.TRIGGERED, evaluator.evaluate(10.0));
         
         // Do it once with a null instance
-        Event event = evaluator.getEventForState(Status.TRIGGERED, new Date(), 10.0, null);
+        Event event = evaluator.getEventForState(Status.TRIGGERED, new Date(), 10.0, thresholdValues, null);
         assertNotNull("should have created an event", event);
         assertEquals("UEIs should be the same", EventConstants.RELATIVE_CHANGE_THRESHOLD_EVENT_UEI, event.getUei());
         assertNotNull("event should have parms", event.getParmCollection());
@@ -272,7 +279,7 @@ public class ThresholdEvaluatorRelativeChangeTest extends AbstractThresholdEvalu
         parmPresentWithValue(event, "multiplier", "1.1");
         
         // And again with a non-null instance
-        event = evaluator.getEventForState(Status.TRIGGERED, new Date(), 10.0, new MockCollectionResourceWrapper("testInstance"));
+        event = evaluator.getEventForState(Status.TRIGGERED, new Date(), 10.0, thresholdValues, new MockCollectionResourceWrapper("testInstance"));
         assertNotNull("should have created an event", event);
         assertEquals("UEIs should be the same", EventConstants.RELATIVE_CHANGE_THRESHOLD_EVENT_UEI, event.getUei());
         assertNotNull("event should have parms", event.getParmCollection());
@@ -288,13 +295,17 @@ public class ThresholdEvaluatorRelativeChangeTest extends AbstractThresholdEvalu
         threshold.setType(ThresholdType.RELATIVE_CHANGE);
         threshold.setDsName("ds-name");
         threshold.setDsType("node");
-        threshold.setValue(99.0);
-        threshold.setRearm(95.0);
-        threshold.setTrigger(1);
+        threshold.setDoubleValue(99.0);
+        threshold.setRearmValue(95.0);
+        threshold.setTriggerValue(1);
         ThresholdConfigWrapper wrapper=new ThresholdConfigWrapper(threshold);
+        ThresholdEvaluatorState.ThresholdValues thresholdValues = mock(ThresholdEvaluatorState.ThresholdValues.class);
+        when(thresholdValues.getThresholdValue()).thenReturn(99.0);
+        when(thresholdValues.getRearm()).thenReturn(95.0);
+        when(thresholdValues.getTrigger()).thenReturn(1);
 
         ThresholdEvaluatorStateRelativeChange item = new ThresholdEvaluatorStateRelativeChange(wrapper, MockSession.getSession());
-        Event event=item.getEventForState(Status.TRIGGERED, new Date(), 100.0, null);
+        Event event=item.getEventForState(Status.TRIGGERED, new Date(), 100.0, thresholdValues, null);
         assertEquals("UEI should be the relativeChangeThresholdTriggerd", EventConstants.RELATIVE_CHANGE_THRESHOLD_EVENT_UEI, event.getUei());
     }
 
@@ -305,15 +316,19 @@ public class ThresholdEvaluatorRelativeChangeTest extends AbstractThresholdEvalu
         threshold.setType(ThresholdType.RELATIVE_CHANGE);
         threshold.setDsName("ds-name");
         threshold.setDsType("node");
-        threshold.setValue(99.0);
-        threshold.setRearm(95.0);
-        threshold.setTrigger(1);
+        threshold.setDoubleValue(99.0);
+        threshold.setRearmValue(95.0);
+        threshold.setTriggerValue(1);
         threshold.setTriggeredUEI(triggeredUEI);
+        ThresholdEvaluatorState.ThresholdValues thresholdValues = mock(ThresholdEvaluatorState.ThresholdValues.class);
+        when(thresholdValues.getThresholdValue()).thenReturn(99.0);
+        when(thresholdValues.getRearm()).thenReturn(95.0);
+        when(thresholdValues.getTrigger()).thenReturn(1);
         
         ThresholdConfigWrapper wrapper=new ThresholdConfigWrapper(threshold);
 
         ThresholdEvaluatorStateRelativeChange item = new ThresholdEvaluatorStateRelativeChange(wrapper, MockSession.getSession());
-        Event event=item.getEventForState(Status.TRIGGERED, new Date(), 100.0, null);
+        Event event=item.getEventForState(Status.TRIGGERED, new Date(), 100.0, thresholdValues, null);
         assertEquals("UEI should be the uei.opennms.org/custom/relativeChangeThresholdTriggered", triggeredUEI, event.getUei());
        
     }
@@ -324,9 +339,9 @@ public class ThresholdEvaluatorRelativeChangeTest extends AbstractThresholdEvalu
         threshold.setType(ThresholdType.RELATIVE_CHANGE);
         threshold.setDsName("ds-name");
         threshold.setDsType("node");
-        threshold.setValue(1.1);
-        threshold.setRearm(0.5);
-        threshold.setTrigger(3);
+        threshold.setDoubleValue(1.1);
+        threshold.setRearmValue(0.5);
+        threshold.setTriggerValue(3);
         ThresholdConfigWrapper wrapper=new ThresholdConfigWrapper(threshold);
         ThresholdEvaluatorStateRelativeChange evaluator = new ThresholdEvaluatorStateRelativeChange(wrapper, MockSession.getSession());
         
@@ -340,9 +355,9 @@ public class ThresholdEvaluatorRelativeChangeTest extends AbstractThresholdEvalu
         threshold.setType(ThresholdType.RELATIVE_CHANGE);
         threshold.setDsName("ds-name");
         threshold.setDsType("node");
-        threshold.setValue(1.1);
-        threshold.setRearm(0.5);
-        threshold.setTrigger(3);
+        threshold.setDoubleValue(1.1);
+        threshold.setRearmValue(0.5);
+        threshold.setTriggerValue(3);
         ThresholdConfigWrapper wrapper=new ThresholdConfigWrapper(threshold);
         ThresholdEvaluatorStateRelativeChange evaluator = new ThresholdEvaluatorStateRelativeChange(wrapper, MockSession.getSession());
         
@@ -356,9 +371,9 @@ public class ThresholdEvaluatorRelativeChangeTest extends AbstractThresholdEvalu
 		threshold.setType(ThresholdType.RELATIVE_CHANGE);
 		threshold.setDsName("ds-name");
 		threshold.setDsType("node");
-		threshold.setValue(0.9);
-		threshold.setRearm(0.5);
-		threshold.setTrigger(1);
+		threshold.setDoubleValue(0.9);
+		threshold.setRearmValue(0.5);
+		threshold.setTriggerValue(1);
 		ThresholdConfigWrapper wrapper = new ThresholdConfigWrapper(threshold);
 		ThresholdEvaluatorStateRelativeChange evaluator = new ThresholdEvaluatorStateRelativeChange(
 				wrapper, MockSession.getSession());

--- a/features/collection/thresholding/impl/src/test/java/org/opennms/netmgt/threshd/ThresholdExpressionTestCase.java
+++ b/features/collection/thresholding/impl/src/test/java/org/opennms/netmgt/threshd/ThresholdExpressionTestCase.java
@@ -62,9 +62,9 @@ public class ThresholdExpressionTestCase extends TestCase {
         expression=new Expression();
         expression.setType(ThresholdType.HIGH);
         expression.setDsType("node");
-        expression.setValue(99.0);
-        expression.setRearm(0.5);
-        expression.setTrigger(1);
+        expression.setDoubleValue(99.0);
+        expression.setRearmValue(0.5);
+        expression.setTriggerValue(1);
    }
     
     public void testEvaluateEvaluateSingleItemWithDivision() throws Exception {

--- a/features/collection/thresholding/impl/src/test/java/org/opennms/netmgt/threshd/ThresholdStateIT.java
+++ b/features/collection/thresholding/impl/src/test/java/org/opennms/netmgt/threshd/ThresholdStateIT.java
@@ -37,6 +37,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.After;
@@ -44,6 +45,8 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.stubbing.Answer;
+import org.opennms.core.rpc.utils.mate.ContextKey;
+import org.opennms.core.rpc.utils.mate.Scope;
 import org.opennms.core.test.OpenNMSJUnit4ClassRunner;
 import org.opennms.core.test.db.annotations.JUnitTemporaryDatabase;
 import org.opennms.features.distributed.kvstore.api.BlobStore;
@@ -71,12 +74,16 @@ public class ThresholdStateIT {
 
     private final ThresholdingSession thresholdingSession = MockSession.getSession();
     private ThresholdStateMonitor monitor;
+    private final Scope scope = mock(Scope.class);
 
     @Before
     public void setup() {
         monitor = new BlobStoreAwareMonitor(blobStore);
         when(thresholdingSession.getThresholdStateMonitor()).thenReturn(monitor);
         when(thresholdingSession.getBlobStore()).thenReturn(blobStore);
+        when(scope.get(new ContextKey("requisition", "value"))).thenReturn(Optional.of("99.0"));
+        when(scope.get(new ContextKey("requisition", "rearm"))).thenReturn(Optional.of("0.5"));
+        when(scope.get(new ContextKey("requisition", "trigger"))).thenReturn(Optional.of("2"));
     }
     
     @After
@@ -92,15 +99,16 @@ public class ThresholdStateIT {
         // it correctly sees that the threshold has been exceeded twice and triggers the threshold
         ThresholdEvaluatorState item = new ThresholdEvaluatorHighLow.ThresholdEvaluatorStateHighLow(getWrapper(),
                 thresholdingSession);
+        ThresholdEvaluatorState.ThresholdValues thresholdValues = getWrapper().interpolateThresholdValues(scope);
 
-        ThresholdEvaluatorState.Status status = item.evaluate(100.0);
+        ThresholdEvaluatorState.Status status = item.evaluate(100.0, thresholdValues, null);
         assertEquals("first threshold evaluation status", ThresholdEvaluatorState.Status.NO_CHANGE, status);
 
         // re-initialize the item to simulate another node taking over processing of this threshold and creating a new
         // threshold object to do so
         item = new ThresholdEvaluatorHighLow.ThresholdEvaluatorStateHighLow(getWrapper(), thresholdingSession);
         
-        status = item.evaluate(100.0);
+        status = item.evaluate(100.0, thresholdValues, null);
         assertEquals("second threshold evaluation status", ThresholdEvaluatorState.Status.TRIGGERED, status);
     }
     
@@ -132,8 +140,9 @@ public class ThresholdStateIT {
         // Now evaluate a threshold multiple times
         ThresholdEvaluatorState item = new ThresholdEvaluatorHighLow.ThresholdEvaluatorStateHighLow(getWrapper(),
                 thresholdingSession);
-        item.evaluate(100.0);
-        item.evaluate(100.0);
+        ThresholdEvaluatorState.ThresholdValues thresholdValues = getWrapper().interpolateThresholdValues(scope);
+        item.evaluate(100.0, thresholdValues, null);
+        item.evaluate(100.0, thresholdValues, null);
         
         // Verify that only one fetch was performed
         assertThat(fetchesPerformed.get(), equalTo(1));
@@ -141,8 +150,8 @@ public class ThresholdStateIT {
         // Now simulate being on Sentinel in distributed and redo the evaluations
         when(thresholdingSession.isDistributed()).thenReturn(true);
         fetchesPerformed.set(0);
-        item.evaluate(100.0);
-        item.evaluate(100.0);
+        item.evaluate(100.0, thresholdValues, null);
+        item.evaluate(100.0, thresholdValues, null);
 
         // Verify that multiple fetches were performed
         assertThat(fetchesPerformed.get(), greaterThan(1));
@@ -154,21 +163,22 @@ public class ThresholdStateIT {
                 thresholdingSession);
 
         // Two evaluations exceeding the threshold should trigger
-        ThresholdEvaluatorState.Status status = item.evaluate(100.0);
+        ThresholdEvaluatorState.ThresholdValues thresholdValues = getWrapper().interpolateThresholdValues(scope);
+        ThresholdEvaluatorState.Status status = item.evaluate(100.0, thresholdValues, null);
         assertEquals("first threshold evaluation status", ThresholdEvaluatorState.Status.NO_CHANGE, status);
-        status = item.evaluate(100.0);
+        status = item.evaluate(100.0, thresholdValues, null);
         assertEquals("second threshold evaluation status", ThresholdEvaluatorState.Status.TRIGGERED, status);
 
         // A third evaluation exceeding the threshold should result in no change since the evaluator is already
         // triggered
-        status = item.evaluate(100.0);
+        status = item.evaluate(100.0, thresholdValues, null);
         assertEquals("third threshold evaluation status", ThresholdEvaluatorState.Status.NO_CHANGE, status);
 
         // After performing a state clear we should now see the threshold get triggered again if we exceed the threshold
         // twice again
         monitor.reinitializeStates();
-        item.evaluate(100.0);
-        status = item.evaluate(100.0);
+        item.evaluate(100.0, thresholdValues, null);
+        status = item.evaluate(100.0, thresholdValues, null);
         assertEquals("third threshold evaluation status", ThresholdEvaluatorState.Status.TRIGGERED, status);
     }
 
@@ -177,9 +187,9 @@ public class ThresholdStateIT {
         threshold.setType(ThresholdType.HIGH);
         threshold.setDsName("ds-name");
         threshold.setDsType("node");
-        threshold.setValue(99.0);
-        threshold.setRearm(0.5);
-        threshold.setTrigger(2);
+        threshold.setValue("${requisition:value|0}");
+        threshold.setRearm("${requisition:rearm|0}");
+        threshold.setTrigger("${requisition:trigger|0}");
         ThresholdConfigWrapper wrapper=new ThresholdConfigWrapper(threshold);
         
         return wrapper;

--- a/features/collection/thresholding/impl/src/test/resources/test-thresholds-2.xml
+++ b/features/collection/thresholding/impl/src/test/resources/test-thresholds-2.xml
@@ -2,7 +2,7 @@
 <thresholding-config>
 
         <group name="generic-snmp" rrdRepository = "${install.share.dir}/rrd/snmp/">
-                <threshold type="high" ds-name="freeMem"  ds-type="node" value="4000" rearm="2000" trigger="1"/>
+                <threshold type="high" ds-name="freeMem"  ds-type="node" value="${requisition:value|4000}" rearm="${requisition:rearm|2000}" trigger="${requisition:trigger|1}"/>
                 <threshold type="high" ds-name="ifInOctets"  ds-type="if" value="90" rearm="50" trigger="1">
                 	<resource-filter field='snmpifdescr'>wlan0</resource-filter>
                 </threshold>

--- a/features/collection/thresholding/impl/src/test/resources/test-thresholds-bug2746.xml
+++ b/features/collection/thresholding/impl/src/test/resources/test-thresholds-bug2746.xml
@@ -2,7 +2,7 @@
 <thresholding-config>
 
         <group name="generic-snmp" rrdRepository = "${install.share.dir}/rrd/snmp/">
-                <threshold type="high" ds-name="bug2746"  ds-type="node" value="50" rearm="40" trigger="1"/>
+                <threshold type="high" ds-name="bug2746"  ds-type="node" value="${requisition:value|50}" rearm="40" trigger="${requisition:value|1}"/>
                 
                 <threshold type="high" ds-name="ifInOctets"  ds-type="if" value="90" rearm="50" trigger="1">
                 	<resource-filter field='snmpifdescr'>wlan0</resource-filter>

--- a/features/collection/thresholding/impl/src/test/resources/test-thresholds-bug3333.xml
+++ b/features/collection/thresholding/impl/src/test/resources/test-thresholds-bug3333.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0"?>
 <thresholding-config>
        <group name="generic-snmp" rrdRepository="${install.share.dir}/rrd/snmp/">
-               <expression type="low" ds-type="hrStorageIndex" value="10.0"
-                       rearm="15.0" trigger="1" ds-label="hrStorageDescr" expression="hrStorageSize-hrStorageUsed">
+               <expression type="low" ds-type="hrStorageIndex" value="${requisition:value|10.0}"
+                       rearm="${requisition:rearm|15.0}" trigger="${requisition:trigger|1}" ds-label="hrStorageDescr" expression="hrStorageSize-hrStorageUsed">
                        <resource-filter field="hrStorageDescr">^/opt</resource-filter>
                </expression>
-               <expression type="high" ds-type="hrStorageIndex" value="50.0"
-                       rearm="45.0" trigger="1" ds-label="hrStorageDescr" expression="hrStorageSize-hrStorageUsed">
+               <expression type="high" ds-type="hrStorageIndex" value="${requisition:value|50.0}"
+                       rearm="${requisition:rearm|45.0}" trigger="${requisition:trigger|1}" ds-label="hrStorageDescr" expression="hrStorageSize-hrStorageUsed">
                        <resource-filter field="hrStorageDescr">^/opt</resource-filter>
                </expression>
        </group>

--- a/opennms-config-model/src/main/java/org/opennms/netmgt/config/threshd/Basethresholddef.java
+++ b/opennms-config-model/src/main/java/org/opennms/netmgt/config/threshd/Basethresholddef.java
@@ -99,7 +99,7 @@ public abstract class Basethresholddef implements Serializable {
      *  reaches the trigger value then a threshold event is generated.
      */
     @XmlAttribute(name = "value", required = true)
-    private Double m_value;
+    private String m_value;
 
     /**
      * Rearm value. Identifies the value that the datasource must
@@ -108,7 +108,7 @@ public abstract class Basethresholddef implements Serializable {
      *  rearm, and once again be eligible to generate an event.
      */
     @XmlAttribute(name = "rearm", required = true)
-    private Double m_rearm;
+    private String m_rearm;
 
     /**
      * Trigger value. Identifies the number of consecutive polls that
@@ -116,7 +116,7 @@ public abstract class Basethresholddef implements Serializable {
      *  before a threshold event is generated.
      */
     @XmlAttribute(name = "trigger", required = true)
-    private Integer m_trigger;
+    private String m_trigger;
 
     /**
      * Value to retrieve from strings.properties to label this
@@ -188,28 +188,41 @@ public abstract class Basethresholddef implements Serializable {
         m_dsType = ConfigUtils.assertNotEmpty(dsType, "ds-type");
     }
 
-    public Double getValue() {
+    public String getValue() {
         return m_value;
     }
 
-    public void setValue(final Double value) {
+    public void setValue(final String value) {
         m_value = ConfigUtils.assertNotNull(value, "value");
     }
 
-    public Double getRearm() {
+    public void setDoubleValue(final Double value) {
+        m_value = String.valueOf(value);
+    }
+
+    public String getRearm() {
         return m_rearm;
     }
 
-    public void setRearm(final Double rearm) {
+    public void setRearm(final String rearm) {
         m_rearm = ConfigUtils.assertNotNull(rearm, "rearm");
     }
 
-    public Integer getTrigger() {
+    public void setRearmValue(final Double rearm) {
+        m_rearm = String.valueOf(rearm);
+    }
+
+    public String getTrigger() {
         return m_trigger;
     }
 
-    public void setTrigger(final Integer trigger) {
-        m_trigger = ConfigUtils.assertMinimumInclusive(trigger, 1, "trigger");
+    public void setTrigger(final String trigger) {
+        m_trigger = ConfigUtils.assertNotNull(trigger,  "trigger");
+    }
+
+    public void setTriggerValue(final Integer trigger) {
+        Integer triggerValue = ConfigUtils.assertMinimumInclusive(trigger, 1, "trigger");
+        m_trigger = String.valueOf(triggerValue);
     }
 
     public Optional<String> getDsLabel() {
@@ -275,7 +288,7 @@ public abstract class Basethresholddef implements Serializable {
                             m_description, 
                             m_type, 
                             m_dsType, 
-                            m_value, 
+                            m_value,
                             m_rearm, 
                             m_trigger, 
                             m_dsLabel, 

--- a/opennms-config-model/src/main/resources/xsds/thresholding.xsd
+++ b/opennms-config-model/src/main/resources/xsds/thresholding.xsd
@@ -376,7 +376,7 @@
       </annotation>
     </attribute>
 
-    <attribute name="value" type="double" use="required">
+    <attribute name="value" type="string" use="required">
       <annotation>
         <documentation>
           Threshold value. If the datasource value rises above this
@@ -392,7 +392,7 @@
       </annotation>
     </attribute>
 
-    <attribute name="rearm" type="double" use="required">
+    <attribute name="rearm" type="string" use="required">
       <annotation>
         <documentation>
           Rearm value. Identifies the value that the datasource must
@@ -403,7 +403,7 @@
       </annotation>
     </attribute>
 
-    <attribute name="trigger" use="required">
+    <attribute name="trigger" type="string" use="required">
       <annotation>
         <documentation>
           Trigger value. Identifies the number of consecutive polls that
@@ -411,12 +411,6 @@
           before a threshold event is generated.
         </documentation>
       </annotation>
-
-      <simpleType>
-        <restriction base="int">
-          <minInclusive value="1"/>
-        </restriction>
-      </simpleType>      
     </attribute>
 
     <attribute name="ds-label" type="string" use="optional">

--- a/opennms-doc/guide-admin/src/asciidoc/text/thresholds/thresholding.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/thresholds/thresholding.adoc
@@ -173,11 +173,10 @@ During evaluation of an expression, the following scopes are available:
 * Interface metadata
 * Service metadata
 
+Metadata is also supported in Value, Rearm, Trigger fields for Single-DS and expression-based thresholds.
+
 For more information on metadata and how to define it, see link:metadata[Metadata].
 
-IMPORTANT: Never attempt to use metatdata with basic thresholds. 
-Metadata works only with expression-based thresholds.
-Using metadata with a basic threshold will break the web UI, making it unusable.  
 
 This procedure uses metadata to trigger an event when the number of logged-in users exceeds 1.
 

--- a/opennms-doc/guide-admin/src/asciidoc/text/thresholds/thresholding.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/thresholds/thresholding.adoc
@@ -173,9 +173,9 @@ During evaluation of an expression, the following scopes are available:
 * Interface metadata
 * Service metadata
 
-Metadata is also supported in Value, Rearm, Trigger fields for Single-DS and expression-based thresholds.
+Metadata is also supported in Value, Re-arm, and Trigger fields for Single-DS and expression-based thresholds.
 
-For more information on metadata and how to define it, see link:metadata[Metadata].
+For more information on metadata and how to define it, see link:#ga-meta-data[Metadata].
 
 
 This procedure uses metadata to trigger an event when the number of logged-in users exceeds 1.

--- a/opennms-webapp/src/main/java/org/opennms/web/controller/admin/thresholds/ThresholdController.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/controller/admin/thresholds/ThresholdController.java
@@ -251,7 +251,7 @@ public class ThresholdController extends AbstractController implements Initializ
             //Set the two default values which need to be set for the UI to work properly
             threshold.setDsType("node");
             threshold.setType(ThresholdType.HIGH);
-            threshold.setTrigger(1); //Default to 1 - 0 will give an error, so we may as well be helpful
+            threshold.setTriggerValue(1); //Default to 1 - 0 will give an error, so we may as well be helpful
             group.addThreshold(threshold);
         }
 
@@ -304,7 +304,7 @@ public class ThresholdController extends AbstractController implements Initializ
             //Set the two default values which need to be set for the UI to work properly
             expression.setDsType("node");
             expression.setType(ThresholdType.HIGH);
-            expression.setTrigger(1); //Default to 1 - 0 will give an error, so we may as well be helpful
+            expression.setTriggerValue(1); //Default to 1 - 0 will give an error, so we may as well be helpful
             group.addExpression(expression);
         }
 
@@ -591,17 +591,17 @@ public class ThresholdController extends AbstractController implements Initializ
         baseDef.setDsType(dsType == null? null : dsType);
         baseDef.setType(thresholdType == null? null : ThresholdType.forName(thresholdType));
         try {
-            baseDef.setRearm(WebSecurityUtils.safeParseDouble(request.getParameter("rearm")));
+            baseDef.setRearm(request.getParameter("rearm"));
         } catch (final NumberFormatException e) {
             LOG.warn("Failed to parse rearm ('{}') as a number.", request.getParameter("rearm"));
         }
         try {
-            baseDef.setTrigger(WebSecurityUtils.safeParseInt(request.getParameter("trigger")));
+            baseDef.setTrigger(request.getParameter("trigger"));
         } catch (final NumberFormatException e) {
             LOG.warn("Failed to parse trigger ('{}') as a number.", request.getParameter("trigger"));
         }
         try {
-            baseDef.setValue(WebSecurityUtils.safeParseDouble(request.getParameter("value")));
+            baseDef.setValue(request.getParameter("value"));
         } catch (final NumberFormatException e) {
             LOG.warn("Failed to parse value ('{}') as a number.", request.getParameter("value"));
         }

--- a/opennms-webapp/src/main/webapp/WEB-INF/jsp/admin/thresholds/editExpression.jsp
+++ b/opennms-webapp/src/main/webapp/WEB-INF/jsp/admin/thresholds/editExpression.jsp
@@ -100,7 +100,7 @@
         <table class="table table-sm">
             <tr>
                 <th>Value</th>
-                <th>Rearm</th>
+                <th>Re-arm</th>
                 <th>Trigger</th>
             </tr>
             <tr>

--- a/opennms-webapp/src/main/webapp/WEB-INF/jsp/admin/thresholds/editExpression.jsp
+++ b/opennms-webapp/src/main/webapp/WEB-INF/jsp/admin/thresholds/editExpression.jsp
@@ -62,9 +62,6 @@
         	<th>Expression</th>
         	<th>Datasource type</th>
         	<th>Datasource label</th>
-        	<th>Value</th>
-        	<th>Re-arm</th>
-        	<th>Trigger</th>
         </tr>
         	<tr>
                 <td>
@@ -98,10 +95,19 @@
         				</c:forEach>
         			</select></td>
                 <td><input type="text" name="dsLabel" class="form-control" size="30" value="${expression.dsLabel.orElse(null)}"/></td>
-                <td><input type="text" name="value" class="form-control" size="10" value="${expression.value}"/></td>
-                <td><input type="text" name="rearm" class="form-control" size="10" value="${expression.rearm}"/></td>
-                <td><input type="text" name="trigger" class="form-control" size="10" value="${expression.trigger}"/></td>
         	</tr>
+        </table>
+        <table class="table table-sm">
+            <tr>
+                <th>Value</th>
+                <th>Rearm</th>
+                <th>Trigger</th>
+            </tr>
+            <tr>
+                <td><input type="text" name="value" class="form-control" size="60" value="${expression.value}"/></td>
+                <td><input type="text" name="rearm" class="form-control" size="60" value="${expression.rearm}"/></td>
+                <td><input type="text" name="trigger" class="form-control" size="60" value="${expression.trigger}"/></td>
+            </tr>
         </table>
         <table class="table table-sm">
              <tr>

--- a/opennms-webapp/src/main/webapp/WEB-INF/jsp/admin/thresholds/editThreshold.jsp
+++ b/opennms-webapp/src/main/webapp/WEB-INF/jsp/admin/thresholds/editThreshold.jsp
@@ -62,9 +62,6 @@
         	<th>Datasource</th>
         	<th>Datasource type</th>
         	<th>Datasource label</th>
-        	<th>Value</th>
-        	<th>Re-arm</th>
-        	<th>Trigger</th>
         </tr>
         	<tr>
         		<td>
@@ -98,10 +95,19 @@
         				</c:forEach>
         			</select></td>
                 <td><input type="text" class="form-control" name="dsLabel" size="30" value="${threshold.dsLabel.orElse(null)}"/></td>
-                <td><input type="text" class="form-control" name="value" size="10" value="${threshold.value}"/></td>
-                <td><input type="text" class="form-control" name="rearm" size="10" value="${threshold.rearm}"/></td>
-                <td><input type="text" class="form-control" name="trigger" size="10" value="${threshold.trigger}"/></td>
         	</tr>
+      </table>
+      <table class="table table-sm">
+            <tr>
+                <th>Value</th>
+                <th>Re-arm</th>
+                <th>Trigger</th>
+            </tr>
+            <tr>
+                <td><input type="text" class="form-control" name="value" size="60" value="${threshold.value}"/></td>
+                <td><input type="text" class="form-control" name="rearm" size="60" value="${threshold.rearm}"/></td>
+                <td><input type="text" class="form-control" name="trigger" size="60" value="${threshold.trigger}"/></td>
+            </tr>
       </table>
       <table class="table table-sm">
              <tr>


### PR DESCRIPTION
Support metadata in Threshold fields like `value` `rearm` `trigger` in Simple-DS and Expression threshold configs.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-12794

