### PR TITLE
NMS-10554: Added foreignId to the event definition

### DIFF
--- a/opennms-base-assembly/src/main/filtered/etc/events/opennms.pollerd.events.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/events/opennms.pollerd.events.xml
@@ -252,7 +252,7 @@
    <event>
       <uei>uei.opennms.org/nodes/nodeDeleted</uei>
       <event-label>OpenNMS-defined node event: nodeDeleted</event-label>
-      <descr>&lt;p>%parm[nodelabel]% in location %parm[location]% was deleted from requisition %parm[foreignSource]%.&lt;/p>
+      <descr>&lt;p>%parm[nodelabel]% (%parm[foreignSource]%:%parm[foreignId]%) in location %parm[location]% was deleted from requisition %parm[foreignSource]%.&lt;/p>
              &lt;p>This can have multiple reasons.
              &lt;ul>
              &lt;li>OpenNMS default config will delete any node that is down for seven consecutive days.&lt;/li>


### PR DESCRIPTION
* JIRA: https://issues.opennms.org/browse/NMS-10554

Small correction to the event definition to include also the foreignId.