### PR TITLE
NMS-12692: Hostname resolution for flow queries

### DIFF
--- a/features/flows/api/src/main/java/org/opennms/netmgt/flows/api/Conversation.java
+++ b/features/flows/api/src/main/java/org/opennms/netmgt/flows/api/Conversation.java
@@ -157,6 +157,15 @@ public class Conversation {
                 .withApplication(key.getApplication());
     }
 
+    public static Conversation.Builder from(final Conversation convo) {
+        return new Conversation.Builder()
+                .withLocation(convo.location)
+                .withProtocol(convo.protocol)
+                .withLowerHost(Host.from(convo.lowerHost))
+                .withUpperHost(Host.from(convo.upperHost))
+                .withApplication(convo.application);
+    }
+
     public static Conversation.Builder forOther() {
         return Conversation.builder()
                 .withLocation("Other")

--- a/features/flows/api/src/main/java/org/opennms/netmgt/flows/api/Host.java
+++ b/features/flows/api/src/main/java/org/opennms/netmgt/flows/api/Host.java
@@ -35,21 +35,21 @@ import com.google.common.base.MoreObjects;
 
 public class Host {
     private final String ip;
-    private final Optional<String> hostname;
+    private final String hostname;
 
     public Host(final String ip) {
         this.ip = Objects.requireNonNull(ip);
-        this.hostname = Optional.empty();
+        this.hostname = null;
     }
 
     public Host(final String ip, final String hostname) {
         this.ip = Objects.requireNonNull(ip);
-        this.hostname = Optional.ofNullable(hostname);
+        this.hostname = hostname;
     }
 
     public Host(final Builder builder) {
         this.ip = Objects.requireNonNull(builder.ip);
-        this.hostname = Optional.ofNullable(builder.hostname);
+        this.hostname = builder.hostname;
     }
 
     public String getIp() {
@@ -57,7 +57,7 @@ public class Host {
     }
 
     public Optional<String> getHostname() {
-        return this.hostname;
+        return Optional.ofNullable(this.hostname);
     }
 
     public static class Builder {
@@ -73,7 +73,7 @@ public class Host {
         }
 
         public Builder withHostname(final String hostname) {
-            this.hostname = Objects.requireNonNull(hostname);
+            this.hostname = hostname;
             return this;
         }
 
@@ -89,6 +89,12 @@ public class Host {
     public static Host.Builder from(final String ip) {
         return new Host.Builder()
                 .withIp(ip);
+    }
+
+    public static Host.Builder from(final Host host) {
+        return new Host.Builder()
+                .withIp(host.ip)
+                .withHostname(host.hostname);
     }
 
     public static Host.Builder forOther() {

--- a/features/flows/elastic/src/main/java/org/opennms/netmgt/flows/elastic/agg/AggregatedSearchQueryProvider.java
+++ b/features/flows/elastic/src/main/java/org/opennms/netmgt/flows/elastic/agg/AggregatedSearchQueryProvider.java
@@ -149,4 +149,10 @@ public class AggregatedSearchQueryProvider implements FilterVisitor<String> {
                 .build());
     }
 
+    public String getHostname(final String host, List<Filter> filters) {
+        return render("hostname.ftl", ImmutableMap.builder()
+                                                  .put("filters", getFilterQueries(filters))
+                                                  .put("host", host)
+                                                  .build());
+    }
 }

--- a/features/flows/elastic/src/main/java/org/opennms/netmgt/flows/elastic/agg/Types.java
+++ b/features/flows/elastic/src/main/java/org/opennms/netmgt/flows/elastic/agg/Types.java
@@ -29,8 +29,11 @@
 package org.opennms.netmgt.flows.elastic.agg;
 
 import org.opennms.netmgt.flows.api.Conversation;
+import org.opennms.netmgt.flows.api.ConversationKey;
 import org.opennms.netmgt.flows.api.Host;
 import org.opennms.netmgt.flows.elastic.ConversationKeyUtils;
+
+import io.searchbox.core.search.aggregation.TermsAggregation;
 
 /**
  * Type definitions that consolidate the logic used to query and

--- a/features/flows/elastic/src/main/resources/org/opennms/netmgt/flows/elastic/agg/hostname.ftl
+++ b/features/flows/elastic/src/main/resources/org/opennms/netmgt/flows/elastic/agg/hostname.ftl
@@ -1,0 +1,33 @@
+{
+  "size": 1,
+  "sort": [
+    { "@timestamp" : { "order": "desc" }},
+    { "host_address": { "missing": "_last" }},
+    "_score"
+  ],
+  "_source": [
+    "host_address",
+    "host_name"
+  ],
+  "query": {
+    "bool": {
+      "filter": [
+        <#list filters as filter>${filter},</#list>
+        {
+          "bool": {
+            "must_not": {
+              "term": {
+                "host_name": ""
+              }
+            }
+          }
+        },
+        {
+          "term": {
+            "host_address": "${host?json_string}"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/features/flows/elastic/src/main/resources/org/opennms/netmgt/flows/elastic/hostname_by_host.ftl
+++ b/features/flows/elastic/src/main/resources/org/opennms/netmgt/flows/elastic/hostname_by_host.ftl
@@ -28,7 +28,8 @@
             "netflow.dst_addr": "${host?json_string}"
           }
         }
-      ]
+      ],
+      "minimum_should_match": 1
     }
   }
 }

--- a/features/flows/itests/src/test/java/org/opennms/netmgt/flows/elastic/AggregatedFlowQueryIT.java
+++ b/features/flows/itests/src/test/java/org/opennms/netmgt/flows/elastic/AggregatedFlowQueryIT.java
@@ -355,7 +355,7 @@ public class AggregatedFlowQueryIT {
         // Expect all of the hosts, with the sum of all the bytes from all the flows
         assertThat(hostTrafficSummary, hasSize(6));
         TrafficSummary<Host> top = hostTrafficSummary.get(0);
-        assertThat(top.getEntity(), equalTo(new Host("10.1.1.12")));
+        assertThat(top.getEntity(), equalTo(new Host("10.1.1.12", "la.le.lu")));
         assertThat(top.getBytesIn(), equalTo(210L));
         assertThat(top.getBytesOut(), equalTo(2100L));
 
@@ -370,7 +370,7 @@ public class AggregatedFlowQueryIT {
         // Expect two summaries
         assertThat(hostTrafficSummary, hasSize(2));
         top = hostTrafficSummary.get(0);
-        assertThat(top.getEntity(), equalTo(new Host("10.1.1.12")));
+        assertThat(top.getEntity(), equalTo(new Host("10.1.1.12", "la.le.lu")));
         assertThat(top.getBytesIn(), equalTo(210L));
         assertThat(top.getBytesOut(), equalTo(2100L));
 
@@ -408,12 +408,12 @@ public class AggregatedFlowQueryIT {
 
         assertThat(hostTrafficSummary, hasSize(2));
         TrafficSummary<Host> first = hostTrafficSummary.get(0);
-        assertThat(first.getEntity().getIp(), equalTo("10.1.1.11"));
+        assertThat(first.getEntity(), equalTo(new Host("10.1.1.11")));
         assertThat(first.getBytesIn(), equalTo(10L));
         assertThat(first.getBytesOut(), equalTo(100L));
 
         TrafficSummary<Host> second = hostTrafficSummary.get(1);
-        assertThat(second.getEntity().getIp(), equalTo("10.1.1.12"));
+        assertThat(second.getEntity(), equalTo(new Host("10.1.1.12", "la.le.lu")));
         assertThat(second.getBytesIn(), equalTo(210L));
         assertThat(second.getBytesOut(), equalTo(2100L));
 
@@ -422,12 +422,12 @@ public class AggregatedFlowQueryIT {
                 flowRepository.getHostSummaries(ImmutableSet.of("10.1.1.11"), true, getFilters()).get();
         assertThat(hostTrafficSummary, hasSize(2));
         first = hostTrafficSummary.get(0);
-        assertThat(first.getEntity().getIp(), equalTo("10.1.1.11"));
+        assertThat(first.getEntity(), equalTo(new Host("10.1.1.11")));
         assertThat(first.getBytesIn(), equalTo(10L));
         assertThat(first.getBytesOut(), equalTo(100L));
 
         second = hostTrafficSummary.get(1);
-        assertThat(second.getEntity().getIp(), equalTo("Other"));
+        assertThat(second.getEntity(), equalTo(new Host("Other")));
         assertThat(second.getBytesIn(), equalTo(410L));
         assertThat(second.getBytesOut(), equalTo(2200L));
     }
@@ -450,9 +450,9 @@ public class AggregatedFlowQueryIT {
         // Top 1
         hostTraffic = flowRepository.getTopNHostSeries(1, step, false, getFilters()).get();
         assertThat(hostTraffic.rowKeySet(), hasSize(2));
-        assertThat(hostTraffic.rowKeySet(), containsInAnyOrder(new Directional<>(new Host("10.1.1.12"), true),
-                new Directional<>(new Host("10.1.1.12"), false)));
-        verifyHttpsSeriesAggregated(hostTraffic, new Host("10.1.1.12"));
+        assertThat(hostTraffic.rowKeySet(), containsInAnyOrder(new Directional<>(new Host("10.1.1.12", "la.le.lu"), true),
+                new Directional<>(new Host("10.1.1.12", "la.le.lu"), false)));
+        verifyHttpsSeriesAggregated(hostTraffic, new Host("10.1.1.12", "la.le.lu"));
     }
 
     @Test
@@ -465,7 +465,7 @@ public class AggregatedFlowQueryIT {
                 flowRepository.getHostSeries(Collections.singleton("10.1.1.12"), 10,
                         false, getFilters()).get();
         assertThat(hostTraffic.rowKeySet(), hasSize(2));
-        verifyHttpsSeries(hostTraffic, new Host("10.1.1.12"));
+        verifyHttpsSeries(hostTraffic, new Host("10.1.1.12", "la.le.lu"));
 
         // Get just 10.1.1.12 and include others
         hostTraffic = flowRepository.getHostSeries(Collections.singleton("10.1.1.12"), 10,
@@ -523,8 +523,8 @@ public class AggregatedFlowQueryIT {
 
         // Expect the conversations, with the sum of all the bytes from all the flows
         TrafficSummary<Conversation> convo = convoTrafficSummary.get(0);
-        assertThat(convo.getEntity().getLowerIp(), equalTo("10.1.1.12"));
-        assertThat(convo.getEntity().getUpperIp(), equalTo("192.168.1.101"));
+        assertThat(convo.getEntity().getLowerHost(), equalTo(new Host("10.1.1.12", "la.le.lu")));
+        assertThat(convo.getEntity().getUpperHost(), equalTo(new Host("192.168.1.101", "ingress.only")));
         // Disabled for now - see https://issues.opennms.org/browse/NMS-12692
         // assertThat(convo.getEntity().getLowerHostname(), equalTo(Optional.of("la.le.lu")));
         // assertThat(convo.getEntity().getUpperHostname(), equalTo(Optional.of("ingress.only")));
@@ -533,8 +533,8 @@ public class AggregatedFlowQueryIT {
         assertThat(convo.getBytesOut(), equalTo(1100L));
 
         convo = convoTrafficSummary.get(1);
-        assertThat(convo.getEntity().getLowerIp(), equalTo("10.1.1.12"));
-        assertThat(convo.getEntity().getUpperIp(), equalTo("192.168.1.100"));
+        assertThat(convo.getEntity().getLowerHost(), equalTo(new Host("10.1.1.12", "la.le.lu")));
+        assertThat(convo.getEntity().getUpperHost(), equalTo(new Host("192.168.1.100")));
         // Disabled for now - see https://issues.opennms.org/browse/NMS-12692
         //assertThat(convo.getEntity().getLowerHostname(), equalTo(Optional.of("la.le.lu")));
         //assertThat(convo.getEntity().getUpperHostname(), equalTo(Optional.empty()));
@@ -547,8 +547,8 @@ public class AggregatedFlowQueryIT {
         assertThat(convoTrafficSummary, hasSize(2));
 
         convo = convoTrafficSummary.get(0);
-        assertThat(convo.getEntity().getLowerIp(), equalTo("10.1.1.12"));
-        assertThat(convo.getEntity().getUpperIp(), equalTo("192.168.1.101"));
+        assertThat(convo.getEntity().getLowerHost(), equalTo(new Host("10.1.1.12", "la.le.lu")));
+        assertThat(convo.getEntity().getUpperHost(), equalTo(new Host("192.168.1.101", "ingress.only")));
         assertThat(convo.getEntity().getApplication(), equalTo("https"));
         assertThat(convo.getBytesIn(), equalTo(110L));
         assertThat(convo.getBytesOut(), equalTo(1100L));
@@ -570,8 +570,8 @@ public class AggregatedFlowQueryIT {
                         false, getFilters()).get();
         assertThat(convoTrafficSummary, hasSize(1));
         TrafficSummary<Conversation> convo = convoTrafficSummary.get(0);
-        assertThat(convo.getEntity().getLowerIp(), equalTo("10.1.1.11"));
-        assertThat(convo.getEntity().getUpperIp(), equalTo("192.168.1.100"));
+        assertThat(convo.getEntity().getLowerHost(), equalTo(new Host("10.1.1.11")));
+        assertThat(convo.getEntity().getUpperHost(), equalTo(new Host("192.168.1.100")));
         assertThat(convo.getEntity().getApplication(), equalTo("http"));
         assertThat(convo.getBytesIn(), equalTo(10L));
         assertThat(convo.getBytesOut(), equalTo(100L));
@@ -582,15 +582,15 @@ public class AggregatedFlowQueryIT {
                 getFilters()).get();
         assertThat(convoTrafficSummary, hasSize(2));
         convo = convoTrafficSummary.get(0);
-        assertThat(convo.getEntity().getLowerIp(), equalTo("10.1.1.12"));
-        assertThat(convo.getEntity().getUpperIp(), equalTo("192.168.1.100"));
+        assertThat(convo.getEntity().getLowerHost(), equalTo(new Host("10.1.1.12", "la.le.lu")));
+        assertThat(convo.getEntity().getUpperHost(), equalTo(new Host("192.168.1.100")));
         assertThat(convo.getEntity().getApplication(), equalTo("https"));
         assertThat(convo.getBytesIn(), equalTo(100L));
         assertThat(convo.getBytesOut(), equalTo(1000L));
 
         convo = convoTrafficSummary.get(1);
-        assertThat(convo.getEntity().getLowerIp(), equalTo("Other"));
-        assertThat(convo.getEntity().getUpperIp(), equalTo("Other"));
+        assertThat(convo.getEntity().getLowerHost(), equalTo(Host.forOther().build()));
+        assertThat(convo.getEntity().getUpperHost(), equalTo(Host.forOther().build()));
         assertThat(convo.getEntity().getApplication(), equalTo("Other"));
         assertThat(convo.getBytesIn(), equalTo(320L));
         assertThat(convo.getBytesOut(), equalTo(1300L));

--- a/features/flows/itests/src/test/java/org/opennms/netmgt/flows/elastic/FlowQueryIT.java
+++ b/features/flows/itests/src/test/java/org/opennms/netmgt/flows/elastic/FlowQueryIT.java
@@ -337,7 +337,7 @@ public class FlowQueryIT {
         // Expect all of the hosts, with the sum of all the bytes from all the flows
         assertThat(hostTrafficSummary, hasSize(6));
         TrafficSummary<Host> top = hostTrafficSummary.get(0);
-        assertThat(top.getEntity(), equalTo(new Host("10.1.1.12")));
+        assertThat(top.getEntity(), equalTo(new Host("10.1.1.12", "la.le.lu")));
         assertThat(top.getBytesIn(), equalTo(210L));
         assertThat(top.getBytesOut(), equalTo(2100L));
 
@@ -352,7 +352,7 @@ public class FlowQueryIT {
         // Expect two summaries
         assertThat(hostTrafficSummary, hasSize(2));
         top = hostTrafficSummary.get(0);
-        assertThat(top.getEntity(), equalTo(new Host("10.1.1.12")));
+        assertThat(top.getEntity(), equalTo(new Host("10.1.1.12", "la.le.lu")));
         assertThat(top.getBytesIn(), equalTo(210L));
         assertThat(top.getBytesOut(), equalTo(2100L));
 
@@ -390,12 +390,12 @@ public class FlowQueryIT {
 
         assertThat(hostTrafficSummary, hasSize(2));
         TrafficSummary<Host> first = hostTrafficSummary.get(0);
-        assertThat(first.getEntity().getIp(), equalTo("10.1.1.11"));
+        assertThat(first.getEntity(), equalTo(new Host("10.1.1.11")));
         assertThat(first.getBytesIn(), equalTo(10L));
         assertThat(first.getBytesOut(), equalTo(100L));
 
         TrafficSummary<Host> second = hostTrafficSummary.get(1);
-        assertThat(second.getEntity().getIp(), equalTo("10.1.1.12"));
+        assertThat(second.getEntity(), equalTo(new Host("10.1.1.12", "la.le.lu")));
         assertThat(second.getBytesIn(), equalTo(210L));
         assertThat(second.getBytesOut(), equalTo(2100L));
 
@@ -404,12 +404,12 @@ public class FlowQueryIT {
                 flowRepository.getHostSummaries(ImmutableSet.of("10.1.1.11"), true, getFilters()).get();
         assertThat(hostTrafficSummary, hasSize(2));
         first = hostTrafficSummary.get(0);
-        assertThat(first.getEntity().getIp(), equalTo("10.1.1.11"));
+        assertThat(first.getEntity(), equalTo(new Host("10.1.1.11")));
         assertThat(first.getBytesIn(), equalTo(10L));
         assertThat(first.getBytesOut(), equalTo(100L));
 
         second = hostTrafficSummary.get(1);
-        assertThat(second.getEntity().getIp(), equalTo("Other"));
+        assertThat(second.getEntity(), equalTo(new Host("Other")));
         assertThat(second.getBytesIn(), equalTo(410L));
         assertThat(second.getBytesOut(), equalTo(2200L));
     }
@@ -432,9 +432,9 @@ public class FlowQueryIT {
         // Top 1
         hostTraffic = flowRepository.getTopNHostSeries(1, 10, false, getFilters()).get();
         assertThat(hostTraffic.rowKeySet(), hasSize(2));
-        assertThat(hostTraffic.rowKeySet(), containsInAnyOrder(new Directional<>(new Host("10.1.1.12"), true),
-                new Directional<>(new Host("10.1.1.12"), false)));
-        verifyHttpsSeries(hostTraffic, new Host("10.1.1.12"));
+        assertThat(hostTraffic.rowKeySet(), containsInAnyOrder(new Directional<>(new Host("10.1.1.12", "la.le.lu"), true),
+                new Directional<>(new Host("10.1.1.12", "la.le.lu"), false)));
+        verifyHttpsSeries(hostTraffic, new Host("10.1.1.12", "la.le.lu"));
     }
 
     @Test
@@ -447,7 +447,7 @@ public class FlowQueryIT {
                 flowRepository.getHostSeries(Collections.singleton("10.1.1.12"), 10,
                         false, getFilters()).get();
         assertThat(hostTraffic.rowKeySet(), hasSize(2));
-        verifyHttpsSeries(hostTraffic, new Host("10.1.1.12"));
+        verifyHttpsSeries(hostTraffic, new Host("10.1.1.12", "la.le.lu"));
 
         // Get just 10.1.1.12 and include others
         hostTraffic = flowRepository.getHostSeries(Collections.singleton("10.1.1.12"), 10,


### PR DESCRIPTION
This implements hostname querying for aggregated flows processed by nephron
and fixes hostname querying for row flows.

This is accompanied by https://github.com/OpenNMS/nephron/pull/3.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-12692

