### PR TITLE
NMS-12923: Integration API: Alarm.type is unset

### DIFF
--- a/features/api-layer/src/main/java/org/opennms/features/apilayer/utils/ModelMappers.java
+++ b/features/api-layer/src/main/java/org/opennms/features/apilayer/utils/ModelMappers.java
@@ -38,6 +38,7 @@ import org.opennms.features.apilayer.model.mappers.DatabaseEventMapper;
 import org.opennms.features.apilayer.model.mappers.InMemoryEventMapper;
 import org.opennms.features.apilayer.model.mappers.NodeMapper;
 import org.opennms.features.apilayer.model.mappers.SnmpInterfaceMapper;
+import org.opennms.integration.api.v1.config.events.AlarmType;
 import org.opennms.integration.api.v1.model.Alarm;
 import org.opennms.integration.api.v1.model.AlarmFeedback;
 import org.opennms.integration.api.v1.model.DatabaseEvent;
@@ -96,6 +97,7 @@ public class ModelMappers {
                 .setId(alarm.getId())
                 .setManagedObjectInstance(alarm.getManagedObjectInstance())
                 .setManagedObjectType(alarm.getManagedObjectType())
+                .setType(AlarmType.fromId(alarm.getAlarmType()))
                 .setAttributes(alarm.getDetails())
                 .setSeverity(toSeverity(alarm.getSeverity()))
                 .setRelatedAlarms(alarm.getRelatedAlarms()


### PR DESCRIPTION
Set the AlarmType on the Alarm, so that integrations using the Integration
API can make determinations based upon whether the alarm is one that has a
possible resolution or not.

### All Contributors

* [x] Have you read and followed our [Contribution Guidelines](https://github.com/OpenNMS/opennms/blob/develop/CONTRIBUTING.md)?
* [x] Have you [made an issue in the OpenNMS issue tracker](https://issues.opennms.org)?<br>If so, you should:
  1. update the title of this PR to be of the format: `${JIRA-ISSUE-NUMBER}: subject of pull request`
  2. update the JIRA link at the bottom of this comment to refer to the real issue number
  3. prefix your commit messages with the issue number, if possible
* [x] Have you made a comment in that issue which points back to this PR?
* [x] Have you updated the JIRA link at the bottom of this comment to link to your issue?
* [ ] If this is a new or updated feature, is there documentation for the new behavior?
* [ ] If this is new code, are there unit and/or integration tests?
* [x] If this PR targets a `foundation-*` branch, does it avoid changing files in `$OPENNMS_HOME/etc/`?

### Pull Request Process

One or more reviewers should be assigned to each PR.

If you know that a particular person is subject matter expert in the area your PR affects, feel free to assign one or more reviewers when you create this PR, otherwise reviewers will be assigned for you.

If you have made additions or changes to the documentation, or if you _need_ documentation for these code changes, please make sure a technical writer has looked it over.

Once the reviewer(s) accept the PR and the branch passes continuous integration, the PR is eligible for merge.

At that time, if you have commit access (are an OpenNMS Group employee or a member of the Order of the Green Polo) you are welcome to merge the PR.
Otherwise, a reviewer can merge it for you.

Thanks for taking time to contribute!

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-12923

