### PR TITLE
NMS-10351: handle HTTP servers that do not response with a reason phrase

### DIFF
--- a/opennms-provision/opennms-detector-lineoriented/src/main/java/org/opennms/netmgt/provision/detector/simple/response/HttpStatusResponse.java
+++ b/opennms-provision/opennms-detector-lineoriented/src/main/java/org/opennms/netmgt/provision/detector/simple/response/HttpStatusResponse.java
@@ -32,7 +32,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class HttpStatusResponse extends LineOrientedResponse {
-    private static final Pattern HTTP_RESPONSE_REGEX = Pattern.compile("([H][T][T][P+]/[1].[0-1]) ([0-9][0-9][0-9]) ([a-zA-Z ]+)");
+    private static final Pattern HTTP_RESPONSE_REGEX = Pattern.compile("([H][T][T][P+]/[1].[0-1]) ([0-9][0-9][0-9])(?: ([\\p{Alnum} ]*))?");
 
     public HttpStatusResponse(final String response) {
         super(response);

--- a/opennms-provision/opennms-detector-lineoriented/src/main/java/org/opennms/netmgt/provision/detector/simple/response/MultilineHttpResponse.java
+++ b/opennms-provision/opennms-detector-lineoriented/src/main/java/org/opennms/netmgt/provision/detector/simple/response/MultilineHttpResponse.java
@@ -43,7 +43,7 @@ import org.slf4j.LoggerFactory;
  */
 public class MultilineHttpResponse extends MultilineOrientedResponse {
     private static final Logger LOG = LoggerFactory.getLogger(MultilineHttpResponse.class);
-    private static final Pattern HTTP_RESPONSE_REGEX = Pattern.compile("([H][T][T][P+]/[1].[0-1]) ([0-9][0-9][0-9]) ([a-zA-Z ]+)\r?\n");
+    private static final Pattern HTTP_RESPONSE_REGEX = Pattern.compile("([H][T][T][P+]/[1].[0-1]) ([0-9][0-9][0-9])(?: ([\\p{Alnum} ]*))?\r?\n");
 
     /**
      * <p>Constructor for MultilineHttpResponse.</p>

--- a/opennms-provision/opennms-detector-lineoriented/src/test/java/org/opennms/netmgt/provision/detector/HttpDetectorTest.java
+++ b/opennms-provision/opennms-detector-lineoriented/src/test/java/org/opennms/netmgt/provision/detector/HttpDetectorTest.java
@@ -199,6 +199,31 @@ public class HttpDetectorTest {
         assertTrue(doCheck(m_detector.isServiceDetected(m_server.getInetAddress())));
     }
 
+    @Test(timeout=20000)
+    public void testDetectorSuccessNoReasonPhrase() throws Exception {
+        String response = "HTTP/1.1 200\r\n"
+                + "Date: Tue, 28 Oct 2008 20:47:55 GMT\r\n"
+                + "Server: Apache/2.0.54\r\n"
+                + "Last-Modified: Fri, 16 Jun 2006 01:52:14 GMT\r\n"
+                + "ETag: \"778216aa-2f-aa66cf80\"\r\n"
+                + "Accept-Ranges: bytes\r\n"
+                + "Vary: Accept-Encoding,User-Agent\r\n"
+                + "Connection: close\r\n"
+                + "Content-Type: text/html\r\n";
+
+        response += String.format("Content-Length: %s\r\n", serverContent.length()) + "\r\n" + serverContent;
+
+        m_detector.setCheckRetCode(true);
+        m_detector.setUrl("/blog");
+        m_detector.setMaxRetCode(399);
+        m_detector.init();
+
+        m_server = createServer(response);
+        m_detector.setPort(m_server.getLocalPort());
+
+        assertTrue(doCheck(m_detector.isServiceDetected(m_server.getInetAddress())));
+    }
+
     public void setServerOKResponse(String serverOKResponse) {
         this.serverOKResponse = serverOKResponse;
     }


### PR DESCRIPTION
This changes the HTTP header regex matcher to account for missing reason phrase.

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-10351

