### PR TITLE
NMS-12958: change allowed PostgreSQL ranger to allow 13

### DIFF
--- a/core/schema/src/main/java/org/opennms/core/schema/Migrator.java
+++ b/core/schema/src/main/java/org/opennms/core/schema/Migrator.java
@@ -73,7 +73,7 @@ public class Migrator {
     private static final Logger LOG = LoggerFactory.getLogger(Migrator.class);
     private static final Pattern POSTGRESQL_VERSION_PATTERN = Pattern.compile("^(?:PostgreSQL|EnterpriseDB) (\\d+\\.\\d+)");
     private static final float POSTGRESQL_MIN_VERSION_INCLUSIVE = Float.parseFloat(System.getProperty("opennms.postgresql.minVersion", "10.0"));
-    private static final float POSTGRESQL_MAX_VERSION_EXCLUSIVE = Float.parseFloat(System.getProperty("opennms.postgresql.maxVersion", "13.0"));
+    private static final float POSTGRESQL_MAX_VERSION_EXCLUSIVE = Float.parseFloat(System.getProperty("opennms.postgresql.maxVersion", "14.0"));
 
     private static final String IPLIKE_SQL_RESOURCE = "iplike.sql";
 

--- a/debian/control
+++ b/debian/control
@@ -39,7 +39,7 @@ Description: Enterprise-grade Open-source Network Management Platform (Source)
 
 Package: opennms-db
 Architecture: all
-Depends: postgresql-12 | postgresql-11 | postgresql-10, iplike-pgsql12 | iplike-pgsql11 | iplike-pgsql10, debconf
+Depends: postgresql-13 | postgresql-12 | postgresql-11 | postgresql-10, iplike-pgsql13 | iplike-pgsql12 | iplike-pgsql11 | iplike-pgsql10, debconf
 Description: Enterprise-grade Open-source Network Management Platform (Database)
  OpenNMS is an enterprise-grade network management system written in Java.
  .
@@ -57,7 +57,7 @@ Description: Enterprise-grade Open-source Network Management Platform (Database)
 Package: opennms-server
 Architecture: all
 Depends: opennms-common (=${binary:Version}), libopennms-java (=${binary:Version}), libopennmsdeps-java (=${binary:Version}), mailx
-Suggests: jrrd2, rrdtool (>= 1.4.8), postgresql-client-12 | postgresql-client-11 | postgresql-client-10
+Suggests: jrrd2, rrdtool (>= 1.4.8), postgresql-client-13 | postgresql-client-12 | postgresql-client-11 | postgresql-client-10
 Description: Enterprise-grade Open-source Network Management Platform (Daemon)
  OpenNMS is an enterprise-grade network management system written in Java.
  .
@@ -220,7 +220,7 @@ Description: Enterprise-grade Open-source Network Management Platform (JMS Alarm
  and notification system handles both internally and externally generated
  events (such as SNMP traps), and generates notices via email, pager, SMS, etc.
  .
- The JMS Alarm Northbounder allows you to send OpenNMS alarms to an 
+ The JMS Alarm Northbounder allows you to send OpenNMS alarms to an
  external JMS listener.
 
 Package: opennms-plugin-provisioning-dns

--- a/opennms-base-assembly/src/main/filtered/etc/opennms.service
+++ b/opennms-base-assembly/src/main/filtered/etc/opennms.service
@@ -2,7 +2,7 @@
 Description=${install.package.description} server
 Wants=${install.postgresql.service}.service
 Requires=network.target network-online.target
-After=${install.postgresql.service}.service postgresql-10.service postgresql-11.service postgresql-12.service network.target network-online.target
+After=${install.postgresql.service}.service postgresql-10.service postgresql-11.service postgresql-12.service postgresql-13.service network.target network-online.target
 
 [Service]
 User=root


### PR DESCRIPTION
A small PR that bumps the acceptable PostgreSQLs to 13.  Their release notes indicate no major changes that should break things, and I did some testing personally against the latest version and everything is behaving fine.