### PR TITLE
cloud-473: add support for importing server certificates into trust store

### DIFF
--- a/opennms-container/minion/container-fs/confd/conf.d/org.opennms.minion.server-certificates.toml
+++ b/opennms-container/minion/container-fs/confd/conf.d/org.opennms.minion.server-certificates.toml
@@ -1,0 +1,7 @@
+[template]
+src = "org.opennms.minion.server-certificates.tmpl"
+dest = "/opt/minion/etc/minion-server-certs.env"
+keys = [
+    "/server-certs"
+]
+reload_cmd = "/opt/minion/confd/scripts/remove-if-empty /opt/minion/etc/minion-server-certs.env"

--- a/opennms-container/minion/container-fs/confd/templates/org.opennms.minion.server-certificates.tmpl
+++ b/opennms-container/minion/container-fs/confd/templates/org.opennms.minion.server-certificates.tmpl
@@ -1,0 +1,8 @@
+{{range $idx, $elm := getvs "/server-certs/*" -}}
+{{if not $idx -}}
+#
+# DON'T EDIT THIS FILE :: GENERATED WITH CONFD
+#
+{{end -}}
+{{.}}
+{{end -}}


### PR DESCRIPTION
* adds confd configuration and template for server certificates
* `entrypoint.sh` imports server certificates in a copy of the default trust store and uses that trust store