### PR TITLE
NMS-12969: Topology Map: Application

### DIFF
--- a/features/graph/api/src/main/java/org/opennms/netmgt/graph/api/info/StatusInfo.java
+++ b/features/graph/api/src/main/java/org/opennms/netmgt/graph/api/info/StatusInfo.java
@@ -32,6 +32,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import java.util.Map;
 import java.util.Objects;
+import java.util.StringJoiner;
 
 import org.opennms.netmgt.model.OnmsSeverity;
 
@@ -148,5 +149,26 @@ public class StatusInfo {
             }
             return 0L;
         }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        StatusInfo that = (StatusInfo) o;
+        return Objects.equals(properties, that.properties);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(properties);
+    }
+
+    @Override
+    public String toString() {
+        return new StringJoiner(", ", StatusInfo.class.getSimpleName() + "[", "]")
+                .add("severity=" + getSeverity())
+                .add("count=" + getCount())
+                .toString();
     }
 }

--- a/features/graph/provider/application/src/main/java/org/opennms/netmgt/graph/provider/application/ApplicationStatusEnrichment.java
+++ b/features/graph/provider/application/src/main/java/org/opennms/netmgt/graph/provider/application/ApplicationStatusEnrichment.java
@@ -29,6 +29,7 @@
 package org.opennms.netmgt.graph.provider.application;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -107,11 +108,14 @@ public class ApplicationStatusEnrichment implements EnrichmentProcessor {
         vertexStatusMap.entrySet().forEach(entry -> graphBuilder.property(entry.getKey(), EnrichedProperties.STATUS, entry.getValue()));
     }
 
-    StatusInfo buildStatusForApplication(final GenericVertex eachRoot, final EnrichmentGraphBuilder graphBuilder, final Map<String, StatusInfo> childStatusMap) {
-        boolean allChildrenHaveActiveAlarms = true;
+    StatusInfo buildStatusForApplication(final GenericVertex application, final EnrichmentGraphBuilder graphBuilder, final Map<String, StatusInfo> childStatusMap) {
+        Collection<GenericEdge> services = graphBuilder.getView().getConnectingEdges(application);
+
+        boolean allChildrenHaveActiveAlarms = services.size() > 0;
+
         final StatusInfo.StatusInfoBuilder rootStatusBuilder = StatusInfo.from(DEFAULT_STATUS);
         // Calculate max severity
-        for (GenericEdge eachEdge : graphBuilder.getView().getConnectingEdges(eachRoot)) {
+        for (GenericEdge eachEdge : services) {
             final GenericVertex serviceVertex = graphBuilder.getView().resolveVertex(eachEdge.getTarget());
             final StatusInfo childStatus = childStatusMap.get(toId(serviceVertex));
             final Severity childSeverity = childStatus.getSeverity();

--- a/features/graph/provider/application/src/test/java/org/opennms/netmgt/graph/provider/application/ApplicationStatusEnrichmentTest.java
+++ b/features/graph/provider/application/src/test/java/org/opennms/netmgt/graph/provider/application/ApplicationStatusEnrichmentTest.java
@@ -1,3 +1,32 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019-2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+
 package org.opennms.netmgt.graph.provider.application;
 
 import static org.junit.Assert.assertEquals;

--- a/features/graph/provider/application/src/test/java/org/opennms/netmgt/graph/provider/application/ApplicationStatusEnrichmentTest.java
+++ b/features/graph/provider/application/src/test/java/org/opennms/netmgt/graph/provider/application/ApplicationStatusEnrichmentTest.java
@@ -1,0 +1,123 @@
+package org.opennms.netmgt.graph.provider.application;
+
+import static org.junit.Assert.assertEquals;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.opennms.netmgt.dao.api.ApplicationDao;
+import org.opennms.netmgt.graph.api.enrichment.EnrichmentGraphBuilder;
+import org.opennms.netmgt.graph.api.info.StatusInfo;
+import org.opennms.netmgt.graph.domain.simple.SimpleDomainEdge;
+import org.opennms.netmgt.model.OnmsApplication;
+import org.opennms.netmgt.model.OnmsIpInterface;
+import org.opennms.netmgt.model.OnmsMonitoredService;
+import org.opennms.netmgt.model.OnmsNode;
+import org.opennms.netmgt.model.OnmsServiceType;
+import org.opennms.netmgt.model.OnmsSeverity;
+
+public class ApplicationStatusEnrichmentTest {
+
+    private final OnmsNode node = new OnmsNode();
+    private int idCounter = 1;
+
+    ApplicationGraph.ApplicationGraphBuilder graph;
+    Map<String, StatusInfo> statusByServiceMap;
+    ApplicationVertex applicationVertex;
+
+    @Before
+    public void setUp() {
+        statusByServiceMap = new HashMap<>();
+        node.setId(idCounter++);
+        graph = ApplicationGraph.builder();
+
+        OnmsApplication application = new OnmsApplication();
+        application.setId(idCounter++);
+        application.setName("myApp");
+
+        applicationVertex = ApplicationVertex.builder()
+                .application(application)
+                .build();
+        graph.addVertex(applicationVertex);
+    }
+
+    @Test
+    public void noServices() {
+        StatusInfo info = getInfo();
+        assertEquals(StatusInfo.defaultStatus().build(), info);
+    }
+
+    @Test
+    public void servicesWithoutAlarm() throws UnknownHostException {
+        addServiceWithOutAlarm(new OnmsServiceType(1, "HTTP"));
+        assertEquals(StatusInfo.defaultStatus().build(), getInfo());
+    }
+
+    @Test
+    public void servicesWithOneAlarm() throws UnknownHostException {
+        addServiceWithOutAlarm(new OnmsServiceType(1, "HTTP"));
+        addServiceWithAlarm(new OnmsServiceType(2, "HTTP8080"), OnmsSeverity.MINOR, 1);
+        assertEquals(StatusInfo.builder(OnmsSeverity.MINOR).count(1).build(), getInfo());
+    }
+
+    @Test
+    public void servicesWithOneAlarmAcknowledged() throws UnknownHostException {
+        addServiceWithOutAlarm(new OnmsServiceType(1, "HTTP"));
+        addServiceWithAlarm(new OnmsServiceType(2, "HTTP8080"), OnmsSeverity.MINOR, 0);
+        assertEquals(StatusInfo.builder(OnmsSeverity.MINOR).count(0).build(), getInfo());
+    }
+
+    @Test
+    public void allServicesWithAlarms() throws UnknownHostException {
+        addServiceWithAlarm(new OnmsServiceType(1, "HTTP"), OnmsSeverity.MINOR, 1);
+        addServiceWithAlarm(new OnmsServiceType(2, "HTTP8080"), OnmsSeverity.MINOR, 1);
+        // if all services have alarms we expect the application status to be at least "Major"
+        assertEquals(StatusInfo.builder(OnmsSeverity.MAJOR).count(2).build(), getInfo());
+    }
+
+    @Test
+    public void allServicesWithAlarmsAndOneCritical() throws UnknownHostException {
+        addServiceWithAlarm(new OnmsServiceType(1, "HTTP"), OnmsSeverity.MINOR, 1);
+        addServiceWithAlarm(new OnmsServiceType(2, "HTTP8080"), OnmsSeverity.CRITICAL, 1);
+        // if all services have alarms we expect the application status to be at least "Major"
+        assertEquals(StatusInfo.builder(OnmsSeverity.CRITICAL).count(2).build(), getInfo());
+    }
+
+    private ApplicationVertex addServiceWithOutAlarm(final OnmsServiceType serviceType) throws UnknownHostException {
+        OnmsMonitoredService service = new OnmsMonitoredService();
+        service.setId(idCounter ++);
+        service.setIpInterface(new OnmsIpInterface(InetAddress.getByName("127.0.0.1"), node));
+        service.setServiceType(serviceType);
+
+        final ApplicationVertex serviceVertex = ApplicationVertex.builder().service(service).build();
+        graph.addVertex(serviceVertex);
+
+        // connect with application
+        final SimpleDomainEdge edge = SimpleDomainEdge.builder()
+                .namespace(ApplicationGraph.NAMESPACE)
+                .source(applicationVertex.getVertexRef())
+                .target(serviceVertex.getVertexRef())
+                .build();
+        graph.addEdge(edge);
+        return serviceVertex;
+    }
+
+    private ApplicationVertex addServiceWithAlarm(final OnmsServiceType serviceType, final OnmsSeverity severity, final int count) throws UnknownHostException {
+        ApplicationVertex service = addServiceWithOutAlarm(serviceType);
+        statusByServiceMap.put(ApplicationStatusEnrichment.toId(service.asGenericVertex()),
+                StatusInfo.builder(severity).count(count).build());
+        return service;
+    }
+
+    private StatusInfo getInfo() {
+        final EnrichmentGraphBuilder graphBuilder = new EnrichmentGraphBuilder(graph.build().asGenericGraph());
+        return new ApplicationStatusEnrichment(Mockito.mock(ApplicationDao.class))
+                .buildStatusForApplication(applicationVertex.asGenericVertex(), graphBuilder, this.statusByServiceMap);
+    }
+
+}

--- a/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.application/src/main/java/org/opennms/features/topology/plugins/topo/application/LegacyApplicationStatusProvider.java
+++ b/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.application/src/main/java/org/opennms/features/topology/plugins/topo/application/LegacyApplicationStatusProvider.java
@@ -87,7 +87,7 @@ public class LegacyApplicationStatusProvider implements StatusProvider {
             LegacyApplicationVertex eachRootApplication = (LegacyApplicationVertex) eachRoot;
             OnmsSeverity maxSeverity = OnmsSeverity.NORMAL;
             int count = 0;
-            boolean allChildrenHaveActiveAlarms = true;
+            boolean allChildrenHaveActiveAlarms = eachRootApplication.getChildren().size() > 0 ;
             for (VertexRef eachChild : eachRootApplication.getChildren()) {
                 LegacyApplicationVertex eachChildApplication = (LegacyApplicationVertex) eachChild;
                 Status childStatus = statusMap.get(toId(eachChildApplication));

--- a/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.application/src/main/java/org/opennms/features/topology/plugins/topo/application/LegacyApplicationStatusProvider.java
+++ b/features/topology-map/plugins/org.opennms.features.topology.plugins.topo.application/src/main/java/org/opennms/features/topology/plugins/topo/application/LegacyApplicationStatusProvider.java
@@ -33,6 +33,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import org.opennms.features.topology.api.topo.BackendGraph;
 import org.opennms.features.topology.api.topo.Criteria;
@@ -57,12 +58,12 @@ public class LegacyApplicationStatusProvider implements StatusProvider {
     @Override
     public Map<VertexRef, Status> getStatusForVertices(BackendGraph graph, Collection<VertexRef> vertices, Criteria[] criteria) {
         Map<VertexRef, Status> returnMap = new HashMap<>();
-        Map<Integer, Status> statusMap = new HashMap<>();
+        Map<String, Status> statusMap = new HashMap<>();
 
-        List<MonitoredServiceStatusEntity> result = applicationDao.getAlarmStatus();
-        for (MonitoredServiceStatusEntity eachRow : result) {
-            DefaultStatus status = createStatus(eachRow.getSeverity(), eachRow.getCount());
-            statusMap.put(eachRow.getNodeId(), status);
+        List<MonitoredServiceStatusEntity> statusEntities = applicationDao.getAlarmStatus();
+        for (MonitoredServiceStatusEntity entity : statusEntities) {
+            DefaultStatus status = createStatus(entity.getSeverity(), entity.getCount());
+            statusMap.put(toId(entity.getNodeId(), entity.getIpAddress().toString(), entity.getServiceTypeId()), status);
         }
 
         // status for all known node ids
@@ -74,7 +75,7 @@ public class LegacyApplicationStatusProvider implements StatusProvider {
         // calculate status for children
         for (VertexRef eachVertex : vertexRefs) {
             LegacyApplicationVertex applicationVertex = (LegacyApplicationVertex) eachVertex;
-            Status alarmStatus = statusMap.get(applicationVertex.getNodeID());
+            Status alarmStatus = statusMap.get(toId(applicationVertex));
             if (alarmStatus == null) {
                 alarmStatus = createStatus(OnmsSeverity.NORMAL, 0);
             }
@@ -86,19 +87,40 @@ public class LegacyApplicationStatusProvider implements StatusProvider {
             LegacyApplicationVertex eachRootApplication = (LegacyApplicationVertex) eachRoot;
             OnmsSeverity maxSeverity = OnmsSeverity.NORMAL;
             int count = 0;
+            boolean allChildrenHaveActiveAlarms = true;
             for (VertexRef eachChild : eachRootApplication.getChildren()) {
                 LegacyApplicationVertex eachChildApplication = (LegacyApplicationVertex) eachChild;
-                Integer childKey = eachChildApplication.getNodeID();
-                Status childStatus = statusMap.get(childKey);
-                if (childStatus != null && maxSeverity.isLessThan(createSeverity(childStatus.computeStatus()))) {
+                Status childStatus = statusMap.get(toId(eachChildApplication));
+                Optional<OnmsSeverity> childSeverity = Optional.ofNullable(childStatus)
+                        .map(Status::computeStatus)
+                        .map(this::createSeverity);
+                if (childSeverity.isPresent() && maxSeverity.isLessThan(childSeverity.get())) {
                     maxSeverity = createSeverity(childStatus.computeStatus());
-                    count = Integer.parseInt(childStatus.getStatusProperties().get("statusCount"));
+                } else if(!childSeverity.isPresent() || OnmsSeverity.NORMAL.equals(childSeverity.get())) {
+                    allChildrenHaveActiveAlarms = false; // at least one child has no active alarm
+                }
+
+                if(childStatus != null) {
+                    count = count + Integer.parseInt(childStatus.getStatusProperties().get("statusCount"));
                 }
             }
+
+            if (allChildrenHaveActiveAlarms && maxSeverity.isLessThan(OnmsSeverity.MAJOR)) {
+                maxSeverity = OnmsSeverity.MAJOR;
+            }
+
             returnMap.put(eachRoot, createStatus(maxSeverity, count));
         }
 
         return returnMap;
+    }
+
+    private String toId(LegacyApplicationVertex vertex) {
+        return toId(vertex.getNodeID(), vertex.getIpAddress(), vertex.getServiceTypeId());
+    }
+
+    private String toId(int nodeId, String ipAddress, int serviceTypeId) {
+        return nodeId + "-" + ipAddress + "-" +serviceTypeId;
     }
 
     private OnmsSeverity createSeverity(String label) {

--- a/opennms-dao-api/src/main/java/org/opennms/netmgt/dao/api/ApplicationDao.java
+++ b/opennms-dao-api/src/main/java/org/opennms/netmgt/dao/api/ApplicationDao.java
@@ -69,6 +69,7 @@ public interface ApplicationDao extends OnmsDao<OnmsApplication, Integer> {
      *
      * @return all alarms from the alarm table which have a node id, ip address and service type set.
      */
+
     List<MonitoredServiceStatusEntity> getAlarmStatus();
 
     List<MonitoredServiceStatusEntity> getAlarmStatus(List<OnmsApplication> applications);

--- a/opennms-dao-api/src/main/java/org/opennms/netmgt/dao/api/MonitoredServiceStatusEntity.java
+++ b/opennms-dao-api/src/main/java/org/opennms/netmgt/dao/api/MonitoredServiceStatusEntity.java
@@ -28,6 +28,7 @@
 
 package org.opennms.netmgt.dao.api;
 
+import java.net.InetAddress;
 import java.util.Date;
 
 import org.opennms.netmgt.model.OnmsSeverity;
@@ -37,9 +38,14 @@ public class MonitoredServiceStatusEntity {
     private final Date lastEventTime;
     private final OnmsSeverity severity;
     private final long alarmCount;
+    private final InetAddress ipAddress;
+    private final int serviceTypeId;
 
-    public MonitoredServiceStatusEntity(final int nodeId, final Date lastEventTime, final OnmsSeverity severity, final long alarmCount) {
+    public MonitoredServiceStatusEntity(final int nodeId, final InetAddress ipAddress, final int serviceTypeId,
+                                        final Date lastEventTime, final OnmsSeverity severity, final long alarmCount) {
         this.nodeId = nodeId;
+        this.ipAddress = ipAddress;
+        this.serviceTypeId = serviceTypeId;
         this.lastEventTime = lastEventTime;
         this.severity = severity;
         this.alarmCount = alarmCount;
@@ -55,5 +61,13 @@ public class MonitoredServiceStatusEntity {
 
     public int getNodeId() {
         return nodeId;
+    }
+
+    public int getServiceTypeId() {
+        return serviceTypeId;
+    }
+
+    public InetAddress getIpAddress() {
+        return ipAddress;
     }
 }

--- a/opennms-dao-api/src/main/java/org/opennms/netmgt/dao/util/ReductionKeyHelper.java
+++ b/opennms-dao-api/src/main/java/org/opennms/netmgt/dao/util/ReductionKeyHelper.java
@@ -31,11 +31,13 @@ package org.opennms.netmgt.dao.util;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.opennms.core.utils.InetAddressUtils;
 import org.opennms.netmgt.events.api.EventConstants;
 import org.opennms.netmgt.model.OnmsApplication;
 import org.opennms.netmgt.model.OnmsMonitoredService;
+import org.opennms.netmgt.model.monitoringLocations.OnmsMonitoringLocation;
 
 public class ReductionKeyHelper {
 
@@ -78,6 +80,22 @@ public class ReductionKeyHelper {
                 monitoredService.getNodeId(),
                 InetAddressUtils.toIpAddrString(monitoredService.getIpAddress()),
                 monitoredService.getServiceName());
+    }
+
+    public static Set<String> getNodeLostServiceFromPerspectiveReductionKeys(final OnmsMonitoredService monitoredService) {
+        Objects.requireNonNull(monitoredService);
+        return monitoredService
+                .getApplications().stream()
+                .flatMap(a -> a.getPerspectiveLocations().stream())
+                .map(OnmsMonitoringLocation::getLocationName)
+                .distinct()
+                .map(locationName -> String.format("%s:%s:%d:%s:%s",
+                        EventConstants.PERSPECTIVE_NODE_LOST_SERVICE_UEI,
+                        locationName,
+                        monitoredService.getNodeId(),
+                        InetAddressUtils.toIpAddrString(monitoredService.getIpAddress()),
+                        monitoredService.getServiceName()))
+                .collect(Collectors.toSet());
     }
 
     public static String getInterfaceDownReductionKey(final OnmsMonitoredService monitoredService) {

--- a/opennms-dao/src/main/java/org/opennms/netmgt/dao/hibernate/ApplicationDaoHibernate.java
+++ b/opennms-dao/src/main/java/org/opennms/netmgt/dao/hibernate/ApplicationDaoHibernate.java
@@ -122,28 +122,24 @@ public class ApplicationDaoHibernate extends AbstractDaoHibernate<OnmsApplicatio
 	public List<MonitoredServiceStatusEntity> getAlarmStatus(final List<OnmsApplication> applications) {
 		Objects.requireNonNull(applications);
 		final List<OnmsMonitoredService> services = applications.stream().flatMap(application -> application.getMonitoredServices().stream()).collect(Collectors.toList());
-		return getAlarmStatusForServices(services);
-	}
+		final String sql = "select alarm.node.id, alarm.ipAddr, alarm.serviceType.id, min(alarm.lastEventTime), max(alarm.severity), (count(*) - count(alarm.alarmAckTime)) " +
+				"from OnmsAlarm alarm " +
+				"where alarm.severity != " + OnmsSeverity.CLEARED.getId() + " and alarm.reductionKey in :keys " +
+				"group by alarm.node.id, alarm.ipAddr, alarm.serviceType.id";
 
-	private List<MonitoredServiceStatusEntity> getAlarmStatusForServices(final List<OnmsMonitoredService> services) {
-		Objects.requireNonNull(services);
 		// Avoid querying the database if unnecessary
 		if (services.isEmpty()) {
 			return Lists.newArrayList();
 		}
 		// Build query based on reduction keys
-		final Set<String> reductionKeys = services.stream().flatMap(service -> ReductionKeyHelper.getReductionKeys(service).stream()).collect(Collectors.toSet());
-		final StringBuilder sqlBuilder = new StringBuilder();
-		sqlBuilder.append("select distinct alarm.node.id, min(alarm.lastEventTime), max(alarm.severity), (count(*) - count(alarm.alarmAckTime)) ");
-		sqlBuilder.append("from OnmsAlarm alarm ");
-		sqlBuilder.append("where alarm.severity > 3 and alarm.alarmAckTime is null and alarm.reductionKey in :keys ");
-		sqlBuilder.append("group by alarm.node.id");
+		final Set<String> reductionKeys = services.stream().flatMap(service -> ReductionKeyHelper.getNodeLostServiceFromPerspectiveReductionKeys(service).stream()).collect(Collectors.toSet());
 
 		// Convert to object
-		final List<Object[][]> nodeIdToSeverityMapping = (List<Object[][]>) getHibernateTemplate().findByNamedParam(sqlBuilder.toString(), new String[]{"keys"}, new Object[]{reductionKeys.toArray()});
+		final List<Object[][]> perspectiveAlarmsForService = (List<Object[][]>) getHibernateTemplate().findByNamedParam(sql, new String[]{"keys"}, new Object[]{reductionKeys.toArray()});
 		final List<MonitoredServiceStatusEntity> entityList = new ArrayList<>();
-		for (Object[] eachRow : nodeIdToSeverityMapping) {
-			MonitoredServiceStatusEntity entity = new MonitoredServiceStatusEntity((Integer)eachRow[0], (Date) eachRow[1], (OnmsSeverity) eachRow[2], (Long) eachRow[3]);
+		for (Object[] eachRow : perspectiveAlarmsForService) {
+			MonitoredServiceStatusEntity entity = new MonitoredServiceStatusEntity((Integer)eachRow[0],
+					(InetAddress)eachRow[1], (Integer)eachRow[2],(Date) eachRow[3], (OnmsSeverity) eachRow[4], (Long) eachRow[5]);
 			entityList.add(entity);
 		}
 		return entityList;


### PR DESCRIPTION
This PR addresses these two issues:

-  [NMS-12969: Topology Map: Application: Color of app wrong for acknowledged alarm](https://issues.opennms.org/browse/NMS-12969)
- [NMS-12968: Display the alarm status correctly in topology map for applications](https://issues.opennms.org/browse/NMS-12969)

Background: So far we looked only at the alarms of a node now we look at the perspective alarms of a service.

This is how the map looks after the logic change:
![image](https://user-images.githubusercontent.com/1060134/97629261-d8d11980-19fb-11eb-8c1e-9e3d3d5c20ee.png)


We see that app1 has one perspective alarm on the http service. Therefor the http service is marked orange.
The other services are still green.
The alarms are acknowledged, therefor we see no numbers
The color of the app is the same color as the most severe service.

app3 shows 2 services with unacknowledged alarms. Therefor the services have numbers. The app has the sum (2) of alarms of its services.
The severity of the app is the same as the most severe service.

app3 shows 1 service with unacknowledged alarm. It has no other services. Therefor the application gets the severity "major" since all it's services are down.


