### PR TITLE
support server certificates

### DIFF
--- a/opennms-container/minion/container-fs/confd/conf.d/org.opennms.minion.server-certificates.toml
+++ b/opennms-container/minion/container-fs/confd/conf.d/org.opennms.minion.server-certificates.toml
@@ -1,0 +1,7 @@
+[template]
+src = "org.opennms.minion.server-certificates.tmpl"
+dest = "/opt/minion/etc/minion-server-certs.env"
+keys = [
+    "/server-certs"
+]
+reload_cmd = "/opt/minion/confd/scripts/remove-if-empty /opt/minion/etc/minion-server-certs.env"

--- a/opennms-container/minion/container-fs/confd/templates/org.opennms.minion.server-certificates.tmpl
+++ b/opennms-container/minion/container-fs/confd/templates/org.opennms.minion.server-certificates.tmpl
@@ -1,0 +1,8 @@
+{{range $idx, $elm := getvs "/server-certs/*" -}}
+{{if not $idx -}}
+#
+# DON'T EDIT THIS FILE :: GENERATED WITH CONFD
+#
+{{end -}}
+{{.}}
+{{end -}}


### PR DESCRIPTION
* copies Java's default trust store and imports configured certificates
* cherry picked from develop (`git cherry-pick 22e5990057dce49818b170c29318094ba88a8726 --no-commit -m 1`)