### PR TITLE
NMS-13009: bump jetty to 9.4.34 for CVE-2020-27216

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1400,7 +1400,7 @@
     <jasperreportsMavenPluginVersion>1.0-beta-4-OPENNMS-20160912-1</jasperreportsMavenPluginVersion>
     <jcifsVersion>1.3.14</jcifsVersion>
     <jcommonVersion>1.0.23</jcommonVersion>
-    <jettyVersion>9.4.30.v20200611</jettyVersion>
+    <jettyVersion>9.4.34.v20201102</jettyVersion>
     <jfreechartVersion>1.0.19</jfreechartVersion>
     <jinteropVersion>2.0.8</jinteropVersion>
     <jldapVersion>4.3</jldapVersion>


### PR DESCRIPTION
This PR updates to the latest Jetty 9.4.  I ran smoke tests against 2017, 2019, 2020, and 27.x and they all passed.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-13009

