### PR TITLE
NMS-13011: close all CIFS resources

### DIFF
--- a/container/features/src/main/resources/features.xml
+++ b/container/features/src/main/resources/features.xml
@@ -65,8 +65,8 @@
         <bundle>wrap:mvn:org.apache.xmlgraphics/batik-util/${batikVersion}</bundle>
         <bundle>wrap:mvn:org.apache.xmlgraphics/batik-xml/${batikVersion}</bundle>
     </feature>
-    <feature name="bcprov" version="${bcprovVersion}" description="Legion of the Bouncy Castle :: Java Cryptography APIs">
-        <bundle>wrap:mvn:org.bouncycastle/bcprov-jdk15on/${bcprovVersion}</bundle>
+    <feature name="bcprov" version="${bouncyCastleVersion}" description="Legion of the Bouncy Castle :: Java Cryptography APIs">
+        <bundle>wrap:mvn:org.bouncycastle/bcprov-jdk15on/${bouncyCastleVersion}</bundle>
     </feature>
     <feature name="bsf" version="${bsfVersion}" description="Apache :: Bean Scripting Framework">
         <bundle>wrap:mvn:bsf/bsf/${bsfVersion}</bundle>

--- a/dependencies/jcifs/pom.xml
+++ b/dependencies/jcifs/pom.xml
@@ -23,7 +23,7 @@
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcprov-jdk15on</artifactId>
-      <version>${bcprovVersion}</version>
+      <version>${bouncyCastleVersion}</version>
     </dependency>
   </dependencies>
   <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -1349,7 +1349,7 @@
     <awsSqsMessagingVersion>1.0.4</awsSqsMessagingVersion>
     <awsSdkVersion>1.11.218</awsSdkVersion>
     <batikVersion>1.7</batikVersion>
-    <bcprovVersion>1.66</bcprovVersion>
+    <bouncyCastleVersion>1.67</bouncyCastleVersion>
     <bsfVersion>2.4.0</bsfVersion>
     <bsonVersion>3.5.0</bsonVersion>
     <caffeineVersion>2.8.0</caffeineVersion>
@@ -1492,8 +1492,6 @@
     <springSecurityVersion>3.2.7.RELEASE</springSecurityVersion>
     <springLdapVersion>${springSecurityVersion}</springLdapVersion>
     <springSecurityKerberosVersion>1.0.1.RELEASE</springSecurityKerberosVersion>
-
-    <bouncyCastleVersion>1.67</bouncyCastleVersion>
 
     <!-- moved here from topology features -->
     <jungVersion>2.0.1</jungVersion>
@@ -4336,12 +4334,12 @@
       </dependency>
       <dependency>
         <groupId>org.bouncycastle</groupId>
-        <artifactId>bcpkix-jdk15on </artifactId>
+        <artifactId>bcpkix-jdk15on</artifactId>
         <version>${bouncyCastleVersion}</version>
       </dependency>
       <dependency>
         <groupId>org.bouncycastle</groupId>
-        <artifactId>bcprov-jdk15on </artifactId>
+        <artifactId>bcprov-jdk15on</artifactId>
         <version>${bouncyCastleVersion}</version>
       </dependency>
     </dependencies>


### PR DESCRIPTION
This PR closes `SMBFile` and `CIFSContext` when finished polling, and fixes a BouncyCastle version mismatch.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-13011

