### PR TITLE
NMS-12974: Import Scan should be performed always for new nodes

### DIFF
--- a/opennms-provision/opennms-provisiond/src/main/java/org/opennms/netmgt/provision/service/CoreImportActivities.java
+++ b/opennms-provision/opennms-provisiond/src/main/java/org/opennms/netmgt/provision/service/CoreImportActivities.java
@@ -137,8 +137,10 @@ public class CoreImportActivities {
             return;
         }
 
-        if (rescanExisting == null || Boolean.valueOf(rescanExisting)) {
-            info("Running scan phase of {}, the parameter {} was set to {} during import.", operation, EventConstants.PARM_IMPORT_RESCAN_EXISTING, rescanExisting);
+        if (rescanExisting == null || Boolean.valueOf(rescanExisting) ||
+                // scan at import should always be performed for new nodes irrespective of rescanExisting flag.
+                operation.getOperationType().equals(ImportOperation.OperationType.INSERT)) {
+            info("Running scan phase of {}", operation);
             operation.scan();
     
             info("Finished Running scan phase of {}", operation);

--- a/opennms-provision/opennms-provisiond/src/main/java/org/opennms/netmgt/provision/service/operations/DeleteOperation.java
+++ b/opennms-provision/opennms-provisiond/src/main/java/org/opennms/netmgt/provision/service/operations/DeleteOperation.java
@@ -71,4 +71,9 @@ public class DeleteOperation extends ImportOperation {
         getProvisionService().deleteNode(m_nodeId);
     }
 
+    @Override
+    public OperationType getOperationType() {
+        return OperationType.DELETE;
+    }
+
 }

--- a/opennms-provision/opennms-provisiond/src/main/java/org/opennms/netmgt/provision/service/operations/ImportOperation.java
+++ b/opennms-provision/opennms-provisiond/src/main/java/org/opennms/netmgt/provision/service/operations/ImportOperation.java
@@ -36,7 +36,16 @@ public abstract class ImportOperation {
     private static final Logger LOG = LoggerFactory.getLogger(ImportOperation.class);
     
     private final ProvisionService m_provisionService;
-    
+
+    /**
+     *  Enum to differentiate the type of import operation.
+     */
+    public static enum OperationType {
+
+        INSERT,
+        UPDATE,
+        DELETE;
+    }
     /**
      * <p>Constructor for ImportOperation.</p>
      *
@@ -65,6 +74,8 @@ public abstract class ImportOperation {
      * <p>doPersist</p>
      */
     protected abstract void doPersist();
+
+    public abstract OperationType getOperationType();
 
 
     /**

--- a/opennms-provision/opennms-provisiond/src/main/java/org/opennms/netmgt/provision/service/operations/InsertOperation.java
+++ b/opennms-provision/opennms-provisiond/src/main/java/org/opennms/netmgt/provision/service/operations/InsertOperation.java
@@ -62,4 +62,10 @@ public class InsertOperation extends SaveOrUpdateOperation {
         getProvisionService().insertNode(getNode());
     }
 
+    @Override
+    public OperationType getOperationType() {
+        return OperationType.INSERT;
+    }
+
+
 }

--- a/opennms-provision/opennms-provisiond/src/main/java/org/opennms/netmgt/provision/service/operations/SaveOrUpdateOperation.java
+++ b/opennms-provision/opennms-provisiond/src/main/java/org/opennms/netmgt/provision/service/operations/SaveOrUpdateOperation.java
@@ -214,4 +214,9 @@ public abstract class SaveOrUpdateOperation extends ImportOperation {
         }
     }
 
+    @Override
+    public OperationType getOperationType() {
+        return OperationType.UPDATE;
+    }
+
 }


### PR DESCRIPTION
For requisitions that are synchronized with `no` or `dbonly` flags, SNMP scan is not performed in import phase.
This results SNMP service being discovered first before Node gets updated with system info.
Collectd doesn't perform any SNMP collection if `nodesysoid` is not present and it removes this from it's schedule.
Had to restart OpenNMS or reload `Collectd` to get SNMP collection working.

The solution here identifies a new node being inserted and performs SNMP scan for that node always irrespective of `rescanExisting` value.


### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-12974

