### PR TITLE
Proposal: Add lombok

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -151,6 +151,14 @@
     <module>opennms-asterisk</module>
     <module>opennms-config-dao</module>
   </modules>
+  <dependencies>
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <version>1.18.16</version>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
   <build>
   <extensions>
     <extension>
@@ -223,7 +231,7 @@
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
-        <version>3.0.1</version>
+        <version>3.5.1</version>
         <extensions>true</extensions>
         <configuration>
           <obrRepository>NONE</obrRepository>
@@ -1306,7 +1314,7 @@
     <install.perl.bin>/usr/bin/perl</install.perl.bin>
 
     <runMailTests>true</runMailTests>
-  
+
     <!-- rpm specific -->
     <rpm.install.dir>/opt/opennms</rpm.install.dir>
     <rpm.build.executable>rpmbuild</rpm.build.executable>


### PR DESCRIPTION
Lombok is a well established project and allows massive cuts of boilerplate.

I had to upgrade the Felix maven-bundle-plugin from 3.0.1 (Nov 2015) to 3.5.1 (June 2018) to make it work. (cf. [maven-bundle-plugin-fails-with-invalid-class-file-module-info-class](https://stackoverflow.com/questions/50530927/maven-bundle-plugin-fails-with-invalid-class-file-module-info-class))

In a former pull request Patrick has already shown some of its benefits: https://github.com/OpenNMS/opennms/pull/2156

I want to point out another one that I like most: The type of local variables can be inferred using the [`val`](https://projectlombok.org/features/val) identifier.

I already added many reviewers because the introduction of Lombok should be agreed upon by the team. If someone is missing as a reviewer then please add she or he.