### PR TITLE
NMS-12973: Adding metrics and checking sequences

### DIFF
--- a/features/flows/itests/src/test/java/org/opennms/netmgt/flows/elastic/KafkaFlowForwarderIT.java
+++ b/features/flows/itests/src/test/java/org/opennms/netmgt/flows/elastic/KafkaFlowForwarderIT.java
@@ -106,7 +106,7 @@ public class KafkaFlowForwarderIT {
         kafkaConfig.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class.getCanonicalName());
         ConfigurationAdmin configAdmin = mock(ConfigurationAdmin.class, RETURNS_DEEP_STUBS);
         when(configAdmin.getConfiguration(KafkaFlowForwarder.KAFKA_CLIENT_PID).getProperties()).thenReturn(kafkaConfig);
-        flowForwarder = new KafkaFlowForwarder(configAdmin);
+        flowForwarder = new KafkaFlowForwarder(configAdmin, new MetricRegistry());
         flowForwarder.setTopicName(topicName);
         flowForwarder.init();
     }

--- a/features/flows/kafka-persistence/src/main/java/org/opennms/netmgt/flows/persistence/KafkaFlowForwarder.java
+++ b/features/flows/kafka-persistence/src/main/java/org/opennms/netmgt/flows/persistence/KafkaFlowForwarder.java
@@ -48,6 +48,9 @@ import org.osgi.service.cm.ConfigurationAdmin;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.MetricRegistry;
 import com.swrve.ratelimitedlogger.RateLimitedLog;
 
 public class KafkaFlowForwarder implements EnrichedFlowForwarder {
@@ -63,14 +66,27 @@ public class KafkaFlowForwarder implements EnrichedFlowForwarder {
             .build();
     private Properties producerConfig;
 
-    public KafkaFlowForwarder(ConfigurationAdmin configAdmin) {
+    private final Meter forwarded;
+    private final Meter persisted;
+    private final Counter skipped;
+    private final Counter failed;
+
+    public KafkaFlowForwarder(ConfigurationAdmin configAdmin,
+                              final MetricRegistry metricRegistry) {
         this.configAdmin = configAdmin;
+
+        this.forwarded = metricRegistry.meter("forwarded");
+        this.persisted = metricRegistry.meter("persisted");
+        this.skipped = metricRegistry.counter("skipped");
+        this.failed = metricRegistry.counter("failed");
     }
 
     @Override
     public void forward(EnrichedFlow enrichedFlow) {
+        this.forwarded.mark();
 
         if (producer == null) {
+            this.skipped.inc();
             RATE_LIMITED_LOG.warn("Kafka Producer is not configured for flow forwarding.");
             return;
         }
@@ -80,8 +96,10 @@ public class KafkaFlowForwarder implements EnrichedFlowForwarder {
             final ProducerRecord<String, byte[]> record = new ProducerRecord<>(topicName, flowDocument.toByteArray());
             producer.send(record, (recordMetadata, e) -> {
                 if (e != null) {
+                    this.failed.inc();
                     RATE_LIMITED_LOG.warn("Failed to send flow document to kafka: {}.", record, e);
                 } else if (LOG.isTraceEnabled()) {
+                    this.persisted.mark();
                     LOG.trace("Persisted flow document {} to kafka.", flowDocument);
                 }
             });

--- a/features/flows/kafka-persistence/src/main/java/org/opennms/netmgt/flows/persistence/KafkaFlowForwarder.java
+++ b/features/flows/kafka-persistence/src/main/java/org/opennms/netmgt/flows/persistence/KafkaFlowForwarder.java
@@ -71,7 +71,7 @@ public class KafkaFlowForwarder implements EnrichedFlowForwarder {
     private final Counter skipped;
     private final Counter failed;
 
-    public KafkaFlowForwarder(ConfigurationAdmin configAdmin,
+    public KafkaFlowForwarder(final ConfigurationAdmin configAdmin,
                               final MetricRegistry metricRegistry) {
         this.configAdmin = configAdmin;
 

--- a/features/flows/kafka-persistence/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/features/flows/kafka-persistence/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -19,9 +19,30 @@
 
   <reference id="configurationAdmin" interface="org.osgi.service.cm.ConfigurationAdmin"/>
 
+  <!-- Metrics -->
+  <bean id="metricRegistry" class="com.codahale.metrics.MetricRegistry"/>
+  <service ref="metricRegistry" interface="com.codahale.metrics.MetricSet">
+    <service-properties>
+      <entry key="name" value="org.opennms.netmgt.flows.kafka" />
+      <entry key="description" value="Kafka Flow Forwarder" />
+    </service-properties>
+  </service>
+  <bean id="metricRegistryJmxReporterBuilder" class="com.codahale.metrics.JmxReporter" factory-method="forRegistry">
+    <argument ref="metricRegistry"/>
+  </bean>
+  <bean id="metricRegistryDomainedJmxReporterBuilder" factory-ref="metricRegistryJmxReporterBuilder" factory-method="inDomain">
+    <argument value="org.opennms.netmgt.flows.kafka"/>
+  </bean>
+  <bean id="metricRegistryJmxReporter"
+        factory-ref="metricRegistryDomainedJmxReporterBuilder"
+        factory-method="build"
+        init-method="start"
+        destroy-method="stop" />
+
   <bean id="kafkaFlowForwarder" class="org.opennms.netmgt.flows.persistence.KafkaFlowForwarder"
         init-method="init" destroy-method="destroy">
     <argument ref="configurationAdmin"/>
+    <argument ref="metricRegistry"/>
     <property name="topicName" value="${topic}"/>
   </bean>
 

--- a/features/telemetry/listeners/src/main/java/org/opennms/netmgt/telemetry/listeners/UdpListener.java
+++ b/features/telemetry/listeners/src/main/java/org/opennms/netmgt/telemetry/listeners/UdpListener.java
@@ -163,6 +163,8 @@ public class UdpListener implements Listener {
 
         @Override
         protected void initChannel(DatagramChannel ch) {
+            // Accounting
+            ch.pipeline().addFirst(new AccountingHandler());
 
             if (parsers.size() == 1) {
                 final UdpParser parser = parsers.get(0);
@@ -183,9 +185,6 @@ public class UdpListener implements Listener {
                     }
                 });
             }
-
-            // Accounting
-            ch.pipeline().addFirst(new AccountingHandler());
 
             // Add error handling
             ch.pipeline().addLast(new ChannelInboundHandlerAdapter() {

--- a/features/telemetry/protocols/netflow/parser/pom.xml
+++ b/features/telemetry/protocols/netflow/parser/pom.xml
@@ -64,6 +64,10 @@
       <artifactId>org.opennms.features.dnsresolver.api</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>com.swrve</groupId>
+      <artifactId>rate-limited-logger</artifactId>
+    </dependency>
 
     <!-- Test -->
     <dependency>

--- a/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/IpfixTcpParser.java
+++ b/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/IpfixTcpParser.java
@@ -31,6 +31,7 @@ package org.opennms.netmgt.telemetry.protocols.netflow.parser;
 import static org.opennms.netmgt.telemetry.listeners.utils.BufferUtils.slice;
 
 import java.net.InetSocketAddress;
+import java.time.Duration;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
@@ -45,8 +46,12 @@ import org.opennms.netmgt.telemetry.protocols.netflow.parser.ipfix.proto.Header;
 import org.opennms.netmgt.telemetry.protocols.netflow.parser.ipfix.proto.Packet;
 import org.opennms.netmgt.telemetry.protocols.netflow.parser.session.TcpSession;
 import org.opennms.netmgt.telemetry.protocols.netflow.parser.transport.IpFixMessageBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import com.codahale.metrics.Counter;
 import com.codahale.metrics.MetricRegistry;
+import com.swrve.ratelimitedlogger.RateLimitedLog;
 
 import io.netty.buffer.ByteBuf;
 
@@ -89,7 +94,7 @@ public class IpfixTcpParser extends ParserBase implements TcpParser {
 
                 detectClockSkew(header.exportTime * 1000L, session.getRemoteAddress());
 
-                return Optional.of(IpfixTcpParser.this.transmit(packet, remoteAddress));
+                return Optional.of(IpfixTcpParser.this.transmit(packet, session, remoteAddress));
             }
 
             @Override

--- a/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/ParserBase.java
+++ b/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/ParserBase.java
@@ -266,8 +266,7 @@ public abstract class ParserBase implements Parser {
         final CompletableFuture<CompletableFuture[]> futureOfFutures = CompletableFuture.supplyAsync(() -> {
             return packet.getRecords().map(record -> {
                 this.recordsReceived.mark();
-
-                final CompletableFuture<AsyncDispatcher.DispatchStatus> future = new CompletableFuture<>();
+                final CompletableFuture<Void> future = new CompletableFuture<>();
                 final Timer.Context timerContext = recordEnrichmentTimer.time();
                 // Trigger record enrichment (performing DNS reverse lookups for example)
                 final RecordEnricher recordEnricher = new RecordEnricher(dnsResolver, getDnsLookupsEnabled());
@@ -315,6 +314,7 @@ public abstract class ParserBase implements Parser {
                                 LOG.warn("Illegal flow detected from exporter {}", remoteAddress.getAddress(), e);
                             }
 
+                            future.complete(null);
                             return;
                         }
 
@@ -328,7 +328,7 @@ public abstract class ParserBase implements Parser {
                                 future.completeExceptionally(exx);
                             } else {
                                 this.recordsCompleted.mark();
-                                future.complete(b);
+                                future.complete(null);
                             }
                         });
 

--- a/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/UdpParserBase.java
+++ b/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/UdpParserBase.java
@@ -44,11 +44,14 @@ import org.opennms.netmgt.telemetry.listeners.UdpParser;
 import org.opennms.netmgt.telemetry.protocols.netflow.parser.ie.RecordProvider;
 import org.opennms.netmgt.telemetry.protocols.netflow.parser.session.Session;
 import org.opennms.netmgt.telemetry.protocols.netflow.parser.session.UdpSessionManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.codahale.metrics.Counter;
 import com.codahale.metrics.Gauge;
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
+import com.swrve.ratelimitedlogger.RateLimitedLog;
 
 import io.netty.buffer.ByteBuf;
 
@@ -92,7 +95,7 @@ public abstract class UdpParserBase extends ParserBase implements UdpParser {
         final Session session = this.sessionManager.getSession(sessionKey);
 
         try {
-            return this.transmit(this.parse(session, buffer), remoteAddress);
+            return this.transmit(this.parse(session, buffer), session, remoteAddress);
         } catch (Exception e) {
             this.sessionManager.drop(sessionKey);
             this.parserErrors.inc();

--- a/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/UdpParserBase.java
+++ b/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/UdpParserBase.java
@@ -75,7 +75,7 @@ public abstract class UdpParserBase extends ParserBase implements UdpParser {
         this.packetsReceived = metricRegistry.meter(MetricRegistry.name("parsers",  name, "packetsReceived"));
         this.parserErrors = metricRegistry.counter(MetricRegistry.name("parsers",  name, "parserErrors"));
 
-        metricRegistry.register(MetricRegistry.name("parsers",  name, "packetsReceived"),
+        metricRegistry.register(MetricRegistry.name("parsers",  name, "sessionCount"),
                                 (Gauge<Integer>) () -> (this.sessionManager != null) ? this.sessionManager.count() : null);
     }
 

--- a/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/UdpParserBase.java
+++ b/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/UdpParserBase.java
@@ -45,12 +45,17 @@ import org.opennms.netmgt.telemetry.protocols.netflow.parser.ie.RecordProvider;
 import org.opennms.netmgt.telemetry.protocols.netflow.parser.session.Session;
 import org.opennms.netmgt.telemetry.protocols.netflow.parser.session.UdpSessionManager;
 
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
 
 import io.netty.buffer.ByteBuf;
 
 public abstract class UdpParserBase extends ParserBase implements UdpParser {
     public final static long HOUSEKEEPING_INTERVAL = 60000;
+
+    private final Meter packetsReceived;
+    private final Meter parserErrors;
 
     private UdpSessionManager sessionManager;
 
@@ -65,6 +70,12 @@ public abstract class UdpParserBase extends ParserBase implements UdpParser {
                          final DnsResolver dnsResolver,
                          final MetricRegistry metricRegistry) {
         super(protocol, name, dispatcher, eventForwarder, identity, dnsResolver, metricRegistry);
+
+        this.packetsReceived = metricRegistry.meter(MetricRegistry.name("parsers",  name, "packetsReceived"));
+        this.parserErrors = metricRegistry.meter(MetricRegistry.name("parsers",  name, "parserErrors"));
+
+        metricRegistry.register(MetricRegistry.name("parsers",  name, "packetsReceived"),
+                                (Gauge<Integer>) () -> (this.sessionManager != null) ? this.sessionManager.count() : null);
     }
 
     protected abstract RecordProvider parse(final Session session, final ByteBuf buffer) throws Exception;
@@ -74,6 +85,8 @@ public abstract class UdpParserBase extends ParserBase implements UdpParser {
     public final CompletableFuture<?> parse(final ByteBuf buffer,
                                             final InetSocketAddress remoteAddress,
                                             final InetSocketAddress localAddress) throws Exception {
+        this.packetsReceived.mark();
+
         final UdpSessionManager.SessionKey sessionKey = this.buildSessionKey(remoteAddress, localAddress);
         final Session session = this.sessionManager.getSession(sessionKey);
 
@@ -81,6 +94,7 @@ public abstract class UdpParserBase extends ParserBase implements UdpParser {
             return this.transmit(this.parse(session, buffer), remoteAddress);
         } catch (Exception e) {
             this.sessionManager.drop(sessionKey);
+            this.parserErrors.mark();
             throw e;
         }
     }

--- a/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/ipfix/proto/Packet.java
+++ b/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/ipfix/proto/Packet.java
@@ -207,6 +207,16 @@ public final class Packet implements Iterable<FlowSet<?>>, RecordProvider {
     }
 
     @Override
+    public long getObservationDomainId() {
+        return this.header.observationDomainId;
+    }
+
+    @Override
+    public long getSequenceNumber() {
+        return this.header.sequenceNumber;
+    }
+
+    @Override
     public String toString() {
         return MoreObjects.toStringHelper(this)
                 .add("header", this.header)

--- a/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/netflow5/proto/Packet.java
+++ b/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/netflow5/proto/Packet.java
@@ -85,6 +85,16 @@ public final class Packet implements Iterable<Record>, RecordProvider {
     }
 
     @Override
+    public long getObservationDomainId() {
+        return this.header.engineType << 8 + this.header.engineId;
+    }
+
+    @Override
+    public long getSequenceNumber() {
+        return this.header.flowSequence;
+    }
+
+    @Override
     public String toString() {
         return MoreObjects.toStringHelper(this)
                 .add("header", this.header)

--- a/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/netflow9/proto/Packet.java
+++ b/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/netflow9/proto/Packet.java
@@ -192,6 +192,16 @@ public final class Packet implements Iterable<FlowSet<?>>, RecordProvider {
     }
 
     @Override
+    public long getObservationDomainId() {
+        return this.header.sourceId;
+    }
+
+    @Override
+    public long getSequenceNumber() {
+        return this.header.sequenceNumber;
+    }
+
+    @Override
     public String toString() {
         return MoreObjects.toStringHelper(this)
                 .add("header", header)

--- a/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/session/SequenceNumberTracker.java
+++ b/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/session/SequenceNumberTracker.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2017 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
+ * Copyright (C) 2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -26,22 +26,21 @@
  *     http://www.opennms.com/
  *******************************************************************************/
 
-package org.opennms.netmgt.telemetry.protocols.netflow.parser.ie;
+package org.opennms.netmgt.telemetry.protocols.netflow.parser.session;
 
-import java.util.stream.Stream;
+public class SequenceNumberTracker {
 
-public interface RecordProvider {
-    Stream<Iterable<Value<?>>> getRecords();
+    private long expected;
 
-    /** Returns the observation domain ID as specified by the underlying packet used to generate these records.
-     *
-     * @return the observation domain ID or <code>0</code> if there is no such concept available.
-     */
-    long getObservationDomainId();
+    public SequenceNumberTracker() {
+        this.expected = 0L;
+    }
 
-    /** Returns the sequence number as provided by the underlying packet used to generate these records.
-     *
-     * @return the sequence number
-     */
-    long getSequenceNumber();
+    public boolean verify(final long sequenceNumber) {
+        boolean valid = this.expected == 0 || this.expected == sequenceNumber;
+
+        this.expected = sequenceNumber + 1;
+
+        return valid;
+    }
 }

--- a/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/session/Session.java
+++ b/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/session/Session.java
@@ -29,10 +29,8 @@
 package org.opennms.netmgt.telemetry.protocols.netflow.parser.session;
 
 import java.net.InetAddress;
-import java.time.Instant;
 import java.util.Collection;
 import java.util.List;
-import java.util.Optional;
 
 import org.opennms.netmgt.telemetry.protocols.netflow.parser.MissingTemplateException;
 import org.opennms.netmgt.telemetry.protocols.netflow.parser.ie.Value;
@@ -58,4 +56,7 @@ public interface Session {
     Resolver getResolver(final long observationDomainId);
 
     InetAddress getRemoteAddress();
+
+    boolean verifySequenceNumber(final long observationDomainId,
+                                 final long sequenceNumber);
 }

--- a/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/session/UdpSessionManager.java
+++ b/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/session/UdpSessionManager.java
@@ -62,8 +62,8 @@ public class UdpSessionManager {
                 this.observationDomainId = observationDomainId;
             }
 
-            private Key key(final int templateId) {
-                return new Key(UdpSession.this.sessionKey, this.observationDomainId, templateId);
+            private TemplateKey key(final int templateId) {
+                return new TemplateKey(UdpSession.this.sessionKey, this.observationDomainId, templateId);
             }
 
             @Override
@@ -82,9 +82,9 @@ public class UdpSessionManager {
 
                 final Set<String> scoped = values.stream().map(Value::getName).collect(Collectors.toSet());
 
-                for (final Map.Entry<Key, Map<Set<Value<?>>, List<Value<?>>>> e : Iterables.filter(UdpSessionManager.this.options.entrySet(),
-                                                                                                   e -> Objects.equals(e.getKey().sessionKey, UdpSession.this.sessionKey) &&
-                                                                                                        Objects.equals(e.getKey().observationDomainId, this.observationDomainId))) {
+                for (final Map.Entry<TemplateKey, Map<Set<Value<?>>, List<Value<?>>>> e : Iterables.filter(UdpSessionManager.this.options.entrySet(),
+                                                                                                   e -> Objects.equals(e.getKey().domain.sessionKey, UdpSession.this.sessionKey) &&
+                                                                                                        Objects.equals(e.getKey().domain.observationDomainId, this.observationDomainId))) {
                     final Template template = UdpSessionManager.this.templates.get(e.getKey()).template;
 
                     if (scoped.containsAll(template.scopeNames)) {
@@ -112,19 +112,19 @@ public class UdpSessionManager {
 
         @Override
         public void addTemplate(final long observationDomainId, final Template template) {
-            final Key key = new Key(this.sessionKey, observationDomainId, template.id);
+            final TemplateKey key = new TemplateKey(this.sessionKey, observationDomainId, template.id);
             UdpSessionManager.this.templates.put(key, new TemplateWrapper(template));
         }
 
         @Override
         public void removeTemplate(final long observationDomainId, final int templateId) {
-            final Key key = new Key(this.sessionKey, observationDomainId, templateId);
+            final TemplateKey key = new TemplateKey(this.sessionKey, observationDomainId, templateId);
             UdpSessionManager.this.templates.remove(key);
         }
 
         @Override
         public void removeAllTemplate(final long observationDomainId, final Template.Type type) {
-            UdpSessionManager.this.templates.entrySet().removeIf(e -> e.getKey().observationDomainId == observationDomainId && e.getValue().template.type == type);
+            UdpSessionManager.this.templates.entrySet().removeIf(e -> e.getKey().domain.observationDomainId == observationDomainId && e.getValue().template.type == type);
         }
 
         @Override
@@ -132,7 +132,7 @@ public class UdpSessionManager {
                                final int templateId,
                                final Collection<Value<?>> scopes,
                                final List<Value<?>> values) {
-            final Key key = new Key(this.sessionKey, observationDomainId, templateId);
+            final TemplateKey key = new TemplateKey(this.sessionKey, observationDomainId, templateId);
             UdpSessionManager.this.options.computeIfAbsent(key, (k) -> new HashMap<>()).put(new HashSet<>(scopes), values);
         }
 
@@ -145,35 +145,65 @@ public class UdpSessionManager {
         public InetAddress getRemoteAddress() {
             return this.sessionKey.getRemoteAddress();
         }
+
+        @Override
+        public boolean verifySequenceNumber(final long observationDomainId, final long sequenceNumber) {
+            final DomainKey key = new DomainKey(this.sessionKey, observationDomainId);
+            final SequenceNumberTracker tracker = UdpSessionManager.this.sequenceNumbers.computeIfAbsent(key, (k) -> new SequenceNumberTracker());
+            return tracker.verify(sequenceNumber);
+        }
     }
 
-    private final static class Key {
-        private final SessionKey sessionKey;
+    private final static class DomainKey {
+        public final SessionKey sessionKey;
         public final long observationDomainId;
-        public final int templateId;
 
-        Key(final SessionKey sessionKey,
-            final long observationDomainId,
-            final int templateId) {
+        private DomainKey(final SessionKey sessionKey,
+                          final long observationDomainId) {
             this.sessionKey = Objects.requireNonNull(sessionKey);
             this.observationDomainId = observationDomainId;
+        }
+
+        @Override
+        public boolean equals(final Object o) {
+            if (this == o) return true;
+            if (!(o instanceof DomainKey)) return false;
+
+            final DomainKey that = (DomainKey) o;
+            return Objects.equals(this.observationDomainId, that.observationDomainId) &&
+                   Objects.equals(this.sessionKey, that.sessionKey);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(this.sessionKey, this.observationDomainId);
+        }
+    }
+
+    private final static class TemplateKey {
+        public final DomainKey domain;
+        public final int templateId;
+
+        TemplateKey(final SessionKey sessionKey,
+                    final long observationDomainId,
+                    final int templateId) {
+            this.domain = new DomainKey(sessionKey, observationDomainId);
             this.templateId = templateId;
         }
 
         @Override
         public boolean equals(final Object o) {
             if (this == o) return true;
-            if (!(o instanceof Key)) return false;
+            if (!(o instanceof TemplateKey)) return false;
 
-            final Key that = (Key) o;
-            return this.observationDomainId == that.observationDomainId &&
-                    this.templateId == that.templateId &&
-                    Objects.equals(this.sessionKey, that.sessionKey);
+            final TemplateKey that = (TemplateKey) o;
+            return Objects.equals(this.domain, that.domain) &&
+                   Objects.equals(this.templateId, that.templateId);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(this.sessionKey, this.observationDomainId, this.templateId);
+            return Objects.hash(this.domain, this.templateId);
         }
     }
 
@@ -187,8 +217,9 @@ public class UdpSessionManager {
         }
     }
 
-    private final Map<Key, TemplateWrapper> templates = Maps.newHashMap();
-    private final Map<Key, Map<Set<Value<?>>, List<Value<?>>>> options = Maps.newHashMap();
+    private final Map<TemplateKey, TemplateWrapper> templates = Maps.newHashMap();
+    private final Map<TemplateKey, Map<Set<Value<?>>, List<Value<?>>>> options = Maps.newHashMap();
+    private final Map<DomainKey, SequenceNumberTracker> sequenceNumbers = Maps.newHashMap();
 
     private final Duration timeout;
 
@@ -206,7 +237,7 @@ public class UdpSessionManager {
     }
 
     public void drop(final SessionKey sessionKey) {
-        this.templates.entrySet().removeIf(e -> Objects.equals(e.getKey().sessionKey, sessionKey));
+        this.templates.entrySet().removeIf(e -> Objects.equals(e.getKey().domain.sessionKey, sessionKey));
     }
 
     public int count() {

--- a/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/session/UdpSessionManager.java
+++ b/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/session/UdpSessionManager.java
@@ -208,4 +208,8 @@ public class UdpSessionManager {
     public void drop(final SessionKey sessionKey) {
         this.templates.entrySet().removeIf(e -> Objects.equals(e.getKey().sessionKey, sessionKey));
     }
+
+    public int count() {
+        return this.templates.size();
+    }
 }

--- a/features/telemetry/protocols/netflow/parser/src/test/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/SequenceNumberTrackerTest.java
+++ b/features/telemetry/protocols/netflow/parser/src/test/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/SequenceNumberTrackerTest.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.telemetry.protocols.netflow.parser;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import org.opennms.netmgt.telemetry.protocols.netflow.parser.session.SequenceNumberTracker;
+
+public class SequenceNumberTrackerTest {
+
+    @Test
+    public void testInit() {
+        final SequenceNumberTracker tracker = new SequenceNumberTracker();
+        assertTrue(tracker.verify(5));
+    }
+
+    @Test
+    public void testExpected() {
+        final SequenceNumberTracker tracker = new SequenceNumberTracker();
+        assertTrue(tracker.verify(5));
+        assertTrue(tracker.verify(6));
+        assertTrue(tracker.verify(7));
+    }
+
+    @Test
+    public void testUnexpected() {
+        final SequenceNumberTracker tracker = new SequenceNumberTracker();
+        assertTrue(tracker.verify(5));
+        assertFalse(tracker.verify(7));
+        assertTrue(tracker.verify(8));
+        assertFalse(tracker.verify(3));
+        assertTrue(tracker.verify(4));
+    }
+
+}


### PR DESCRIPTION
This is groundwork used to analyze the situation where we maybe drop flows  during processing with hostname resolution enabled.

This enables a variety of counters related to flow processing. Mostly watching out for error situations but also adding a throughput counter to every stage.

In addition, the packet sequence numbers are check and a log message is generated if a packet is detected missing.

Oh, and it fixes a memory leak if flows are considered illegal.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-12973

