### PR TITLE
NMS-12967: Correcting clock misconfiguration

### DIFF
--- a/features/flows/api/src/main/java/org/opennms/netmgt/flows/api/Converter.java
+++ b/features/flows/api/src/main/java/org/opennms/netmgt/flows/api/Converter.java
@@ -28,8 +28,9 @@
 
 package org.opennms.netmgt.flows.api;
 
+import java.time.Instant;
 import java.util.List;
 
 public interface Converter<P> {
-    List<Flow> convert(P packet);
+    List<Flow> convert(P packet, final Instant receivedAt);
 }

--- a/features/flows/api/src/main/java/org/opennms/netmgt/flows/api/EnrichedFlow.java
+++ b/features/flows/api/src/main/java/org/opennms/netmgt/flows/api/EnrichedFlow.java
@@ -61,6 +61,8 @@ public class EnrichedFlow {
 
     private NodeInfo exporterNodeInfo;
 
+    private long clockCorrection;
+
     public Flow getFlow() {
         return flow;
     }
@@ -145,5 +147,11 @@ public class EnrichedFlow {
         this.convoKey = convoKey;
     }
 
+    public long getClockCorrection() {
+        return this.clockCorrection;
+    }
 
+    public void setClockCorrection(final long clockCorrection) {
+        this.clockCorrection = clockCorrection;
+    }
 }

--- a/features/flows/api/src/main/java/org/opennms/netmgt/flows/api/Flow.java
+++ b/features/flows/api/src/main/java/org/opennms/netmgt/flows/api/Flow.java
@@ -28,6 +28,7 @@
 
 package org.opennms.netmgt.flows.api;
 
+import java.time.Instant;
 import java.util.Optional;
 
 public interface Flow {
@@ -56,6 +57,11 @@ public interface Flow {
         HashBasedFiltering,
         FlowStateDependentIntermediateFlowSelectionProcess;
     }
+
+    /**
+     * Time at which the flow was received by listener in milliseconds since epoch UTC.
+     */
+    long getReceivedAt();
 
     /**
      * Flow timestamp in milliseconds.

--- a/features/flows/elastic/pom.xml
+++ b/features/flows/elastic/pom.xml
@@ -137,6 +137,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>com.spotify</groupId>
+      <artifactId>hamcrest-pojo</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>

--- a/features/flows/elastic/src/main/java/org/opennms/netmgt/flows/elastic/FlowDocument.java
+++ b/features/flows/elastic/src/main/java/org/opennms/netmgt/flows/elastic/FlowDocument.java
@@ -62,6 +62,12 @@ public class FlowDocument {
     private long timestamp;
 
     /**
+     * Applied clock correction im milliseconds.
+     */
+    @SerializedName("@clock_correction")
+    private long clockCorrection;
+
+    /**
      * Schema version.
      */
     @SerializedName("@version")
@@ -351,6 +357,14 @@ public class FlowDocument {
 
     public void setTimestamp(long timestamp) {
         this.timestamp = timestamp;
+    }
+
+    public long getClockCorrection() {
+        return this.clockCorrection;
+    }
+
+    public void setClockCorrection(final long clockCorrection) {
+        this.clockCorrection = clockCorrection;
     }
 
     public Integer getVersion() {
@@ -759,6 +773,7 @@ public class FlowDocument {
         enrichedFlow.setDstNodeInfo(buildNodeInfo(flowDocument.getNodeDst()));
         enrichedFlow.setExporterNodeInfo(buildNodeInfo(flowDocument.getNodeExporter()));
         enrichedFlow.setConvoKey(flowDocument.getConvoKey());
+        enrichedFlow.setClockCorrection(flowDocument.getClockCorrection());
         return enrichedFlow;
 
     }

--- a/features/flows/elastic/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/features/flows/elastic/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -63,6 +63,9 @@
             <cm:property name="alwaysUseRawForQueries" value="true" />
             <cm:property name="timeRangeDurationAggregateThresholdMs" value="120000" /> <!-- 2 minutes -->
             <cm:property name="timeRangeEndpointAggregateThresholdMs" value="604800000" /> <!-- 7 days -->
+
+            <!-- Enrichment settings -->
+            <cm:property name="clockSkewCorrectionThreshold" value="0" />
         </cm:default-properties>
     </cm:property-placeholder>
 
@@ -144,6 +147,7 @@
         <argument ref="interfaceToNodeCache" />
         <argument ref="sessionUtils" />
         <argument ref="nodeCacheConfig" />
+        <argument value="${clockSkewCorrectionThreshold}" />
     </bean>
 
     <!-- Metrics -->

--- a/features/flows/elastic/src/main/resources/netflow-template.json
+++ b/features/flows/elastic/src/main/resources/netflow-template.json
@@ -743,6 +743,10 @@
                 "type": "date",
                 "format": "epoch_millis"
             },
+            "@clock_correction": {
+                "type": "date",
+                "format": "epoch_millis"
+            },
             "host": {
                 "type": "keyword",
                 "norms": false

--- a/features/flows/elastic/src/test/java/org/opennms/netmgt/flows/elastic/MockDocumentEnricherFactory.java
+++ b/features/flows/elastic/src/test/java/org/opennms/netmgt/flows/elastic/MockDocumentEnricherFactory.java
@@ -65,6 +65,10 @@ public class MockDocumentEnricherFactory {
     private final AtomicInteger nodeDaoGetCounter = new AtomicInteger(0);
 
     public MockDocumentEnricherFactory() {
+        this(0);
+    }
+
+    public MockDocumentEnricherFactory(final long clockSkewCorrectionThreshold) {
         nodeDao = createNodeDao();
         interfaceToNodeCache = new MockInterfaceToNodeCache();
         assetRecordDao = new MockAssetRecordDao();
@@ -82,7 +86,7 @@ public class MockDocumentEnricherFactory {
                     .withName("flows.node")
                     .withMaximumSize(1000)
                     .withExpireAfterWrite(300)
-                    .build());
+                    .build(), clockSkewCorrectionThreshold);
 
         // Required for mock node dao
         addServiceRegistry(nodeDao);

--- a/features/flows/elastic/src/test/java/org/opennms/netmgt/flows/elastic/TestFlow.java
+++ b/features/flows/elastic/src/test/java/org/opennms/netmgt/flows/elastic/TestFlow.java
@@ -37,8 +37,19 @@ public class TestFlow implements Flow {
     final FlowDocument flowDocument;
     String nodeIdentifier;
 
+    private long receivedAt = System.currentTimeMillis();
+
     public TestFlow(final FlowDocument flowDocument) {
         this.flowDocument = flowDocument;
+    }
+
+    @Override
+    public long getReceivedAt() {
+        return this.receivedAt;
+    }
+
+    public void setReceivedAt(final long receivedAt) {
+        this.receivedAt = receivedAt;
     }
 
     @Override

--- a/features/flows/elastic/src/test/resources/flow-document-netflow5.json
+++ b/features/flows/elastic/src/test/resources/flow-document-netflow5.json
@@ -1,5 +1,6 @@
 {
   "@timestamp": 0,
+  "@clock_correction": 0,
   "@version": 1,
   "host": "192.168.1.1",
   "hosts": [

--- a/features/flows/elastic/src/test/resources/netflow-template-merged.json
+++ b/features/flows/elastic/src/test/resources/netflow-template-merged.json
@@ -743,6 +743,10 @@
         "type": "date",
         "format": "epoch_millis"
       },
+      "@clock_correction": {
+        "type": "date",
+        "format": "epoch_millis"
+      },
       "host": {
         "type": "keyword",
         "norms": false

--- a/features/flows/itests/src/test/java/org/opennms/netmgt/flows/elastic/MarkerCacheIT.java
+++ b/features/flows/itests/src/test/java/org/opennms/netmgt/flows/elastic/MarkerCacheIT.java
@@ -163,7 +163,7 @@ public class MarkerCacheIT {
                         .withName("flows.node")
                         .withMaximumSize(1000)
                         .withExpireAfterWrite(300)
-                        .build());
+                        .build(), 0);
 
 
         final JestClientFactory factory = new JestClientFactory();
@@ -207,7 +207,7 @@ public class MarkerCacheIT {
                         .withName("flows.node")
                         .withMaximumSize(1000)
                         .withExpireAfterWrite(300)
-                        .build());
+                        .build(), 0);
 
         final JestClientFactory factory = new JestClientFactory();
         factory.setHttpClientConfig(new HttpClientConfig.Builder("http://localhost:" + wireMockRule.port()).build());
@@ -252,7 +252,7 @@ public class MarkerCacheIT {
                         .withName("flows.node")
                         .withMaximumSize(1000)
                         .withExpireAfterWrite(300)
-                        .build());
+                        .build(), 0);
 
         final JestClientFactory factory = new JestClientFactory();
         factory.setHttpClientConfig(new HttpClientConfig.Builder("http://localhost:" + wireMockRule.port()).build());

--- a/features/flows/itests/src/test/java/org/opennms/netmgt/flows/elastic/NodeIdentificationIT.java
+++ b/features/flows/itests/src/test/java/org/opennms/netmgt/flows/elastic/NodeIdentificationIT.java
@@ -113,7 +113,7 @@ public class NodeIdentificationIT {
                         .withName("flows.node")
                         .withMaximumSize(1000)
                         .withExpireAfterWrite(300)
-                        .build());
+                        .build(), 0);
 
         final FlowDocument flowDocument = new FlowDocument();
         flowDocument.setSrcAddr("1.1.1.1");

--- a/features/flows/kafka-persistence/src/main/java/org/opennms/netmgt/flows/persistence/FlowDocumentBuilder.java
+++ b/features/flows/kafka-persistence/src/main/java/org/opennms/netmgt/flows/persistence/FlowDocumentBuilder.java
@@ -104,6 +104,7 @@ public class FlowDocumentBuilder {
         buildNodeInfo(enrichedFlow.getSrcNodeInfo()).ifPresent(builder::setSrcNode);
         buildNodeInfo(enrichedFlow.getExporterNodeInfo()).ifPresent(builder::setExporterNode);
         buildNodeInfo(enrichedFlow.getDstNodeInfo()).ifPresent(builder::setDestNode);
+        builder.setClockCorrection(enrichedFlow.getClockCorrection());
 
         return builder.build();
     }

--- a/features/flows/kafka-persistence/src/main/java/org/opennms/netmgt/flows/persistence/model/Direction.java
+++ b/features/flows/kafka-persistence/src/main/java/org/opennms/netmgt/flows/persistence/model/Direction.java
@@ -66,6 +66,8 @@ public enum Direction
   }
 
   /**
+   * @param value The numeric wire value of the corresponding enum entry.
+   * @return The enum associated with the given numeric wire value.
    * @deprecated Use {@link #forNumber(int)} instead.
    */
   @java.lang.Deprecated
@@ -73,6 +75,10 @@ public enum Direction
     return forNumber(value);
   }
 
+  /**
+   * @param value The numeric wire value of the corresponding enum entry.
+   * @return The enum associated with the given numeric wire value.
+   */
   public static Direction forNumber(int value) {
     switch (value) {
       case 0: return INGRESS;
@@ -95,6 +101,10 @@ public enum Direction
 
   public final com.google.protobuf.Descriptors.EnumValueDescriptor
       getValueDescriptor() {
+    if (this == UNRECOGNIZED) {
+      throw new java.lang.IllegalStateException(
+          "Can't get the descriptor of an unrecognized enum value.");
+    }
     return getDescriptor().getValues().get(ordinal());
   }
   public final com.google.protobuf.Descriptors.EnumDescriptor

--- a/features/flows/kafka-persistence/src/main/java/org/opennms/netmgt/flows/persistence/model/EnrichedFlowProtos.java
+++ b/features/flows/kafka-persistence/src/main/java/org/opennms/netmgt/flows/persistence/model/EnrichedFlowProtos.java
@@ -64,7 +64,7 @@ public final class EnrichedFlowProtos {
       "\n\022flowdocument.proto\032\036google/protobuf/wr" +
       "appers.proto\"[\n\010NodeInfo\022\026\n\016foreign_sour" +
       "ce\030\001 \001(\t\022\022\n\nforegin_id\030\002 \001(\t\022\017\n\007node_id\030" +
-      "\003 \001(\r\022\022\n\ncategories\030\004 \003(\t\"\252\r\n\014FlowDocume" +
+      "\003 \001(\r\022\022\n\ncategories\030\004 \003(\t\"\304\r\n\014FlowDocume" +
       "nt\022\021\n\ttimestamp\030\001 \001(\004\022/\n\tnum_bytes\030\002 \001(\013" +
       "2\034.google.protobuf.UInt64Value\022\035\n\tdirect" +
       "ion\030\003 \001(\0162\n.Direction\022\023\n\013dst_address\030\004 \001" +
@@ -107,19 +107,20 @@ public final class EnrichedFlowProtos {
       "\010location\030( \001(\t\022\037\n\014src_locality\030) \001(\0162\t." +
       "Locality\022\037\n\014dst_locality\030* \001(\0162\t.Localit" +
       "y\022 \n\rflow_locality\030+ \001(\0162\t.Locality\022\021\n\tc" +
-      "onvo_key\030, \001(\t*$\n\tDirection\022\013\n\007INGRESS\020\000" +
-      "\022\n\n\006EGRESS\020\001*\246\002\n\021SamplingAlgorithm\022\016\n\nUN" +
-      "ASSIGNED\020\000\022#\n\037SYSTEMATIC_COUNT_BASED_SAM" +
-      "PLING\020\001\022\"\n\036SYSTEMATIC_TIME_BASED_SAMPLIN" +
-      "G\020\002\022\036\n\032RANDOM_N_OUT_OF_N_SAMPLING\020\003\022\"\n\036U" +
-      "NIFORM_PROBABILISTIC_SAMPLING\020\004\022\034\n\030PROPE" +
-      "RTY_MATCH_FILTERING\020\005\022\030\n\024HASH_BASED_FILT" +
-      "ERING\020\006\022<\n8FLOW_STATE_DEPENDENT_INTERMED" +
-      "IATE_FLOW_SELECTION_PROCESS\020\007*6\n\016Netflow" +
-      "Version\022\006\n\002V5\020\000\022\006\n\002V9\020\001\022\t\n\005IPFIX\020\002\022\t\n\005SF" +
-      "LOW\020\003*#\n\010Locality\022\n\n\006PUBLIC\020\000\022\013\n\007PRIVATE" +
-      "\020\001BB\n*org.opennms.netmgt.flows.persisten" +
-      "ce.modelB\022EnrichedFlowProtosP\001b\006proto3"
+      "onvo_key\030, \001(\t\022\030\n\020clock_correction\030- \001(\004" +
+      "*$\n\tDirection\022\013\n\007INGRESS\020\000\022\n\n\006EGRESS\020\001*\246" +
+      "\002\n\021SamplingAlgorithm\022\016\n\nUNASSIGNED\020\000\022#\n\037" +
+      "SYSTEMATIC_COUNT_BASED_SAMPLING\020\001\022\"\n\036SYS" +
+      "TEMATIC_TIME_BASED_SAMPLING\020\002\022\036\n\032RANDOM_" +
+      "N_OUT_OF_N_SAMPLING\020\003\022\"\n\036UNIFORM_PROBABI" +
+      "LISTIC_SAMPLING\020\004\022\034\n\030PROPERTY_MATCH_FILT" +
+      "ERING\020\005\022\030\n\024HASH_BASED_FILTERING\020\006\022<\n8FLO" +
+      "W_STATE_DEPENDENT_INTERMEDIATE_FLOW_SELE" +
+      "CTION_PROCESS\020\007*6\n\016NetflowVersion\022\006\n\002V5\020" +
+      "\000\022\006\n\002V9\020\001\022\t\n\005IPFIX\020\002\022\t\n\005SFLOW\020\003*#\n\010Local" +
+      "ity\022\n\n\006PUBLIC\020\000\022\013\n\007PRIVATE\020\001BB\n*org.open" +
+      "nms.netmgt.flows.persistence.modelB\022Enri" +
+      "chedFlowProtosP\001b\006proto3"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,
@@ -137,7 +138,7 @@ public final class EnrichedFlowProtos {
     internal_static_FlowDocument_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_FlowDocument_descriptor,
-        new java.lang.String[] { "Timestamp", "NumBytes", "Direction", "DstAddress", "DstHostname", "DstAs", "DstMaskLen", "DstPort", "EngineId", "EngineType", "DeltaSwitched", "FirstSwitched", "LastSwitched", "NumFlowRecords", "NumPackets", "FlowSeqNum", "InputSnmpIfindex", "OutputSnmpIfindex", "IpProtocolVersion", "NextHopAddress", "NextHopHostname", "Protocol", "SamplingAlgorithm", "SamplingInterval", "SrcAddress", "SrcHostname", "SrcAs", "SrcMaskLen", "SrcPort", "TcpFlags", "Tos", "NetflowVersion", "Vlan", "SrcNode", "ExporterNode", "DestNode", "Application", "Host", "Location", "SrcLocality", "DstLocality", "FlowLocality", "ConvoKey", });
+        new java.lang.String[] { "Timestamp", "NumBytes", "Direction", "DstAddress", "DstHostname", "DstAs", "DstMaskLen", "DstPort", "EngineId", "EngineType", "DeltaSwitched", "FirstSwitched", "LastSwitched", "NumFlowRecords", "NumPackets", "FlowSeqNum", "InputSnmpIfindex", "OutputSnmpIfindex", "IpProtocolVersion", "NextHopAddress", "NextHopHostname", "Protocol", "SamplingAlgorithm", "SamplingInterval", "SrcAddress", "SrcHostname", "SrcAs", "SrcMaskLen", "SrcPort", "TcpFlags", "Tos", "NetflowVersion", "Vlan", "SrcNode", "ExporterNode", "DestNode", "Application", "Host", "Location", "SrcLocality", "DstLocality", "FlowLocality", "ConvoKey", "ClockCorrection", });
     com.google.protobuf.WrappersProto.getDescriptor();
   }
 

--- a/features/flows/kafka-persistence/src/main/java/org/opennms/netmgt/flows/persistence/model/FlowDocument.java
+++ b/features/flows/kafka-persistence/src/main/java/org/opennms/netmgt/flows/persistence/model/FlowDocument.java
@@ -34,7 +34,7 @@ package org.opennms.netmgt.flows.persistence.model;
 /**
  * Protobuf type {@code FlowDocument}
  */
-public  final class FlowDocument extends
+public final class FlowDocument extends
     com.google.protobuf.GeneratedMessageV3 implements
     // @@protoc_insertion_point(message_implements:FlowDocument)
     FlowDocumentOrBuilder {
@@ -525,6 +525,11 @@ private static final long serialVersionUID = 0L;
             convoKey_ = s;
             break;
           }
+          case 360: {
+
+            clockCorrection_ = input.readUInt64();
+            break;
+          }
           default: {
             if (!parseUnknownField(
                 input, unknownFields, extensionRegistry, tag)) {
@@ -565,7 +570,9 @@ private static final long serialVersionUID = 0L;
    * </pre>
    *
    * <code>uint64 timestamp = 1;</code>
+   * @return The timestamp.
    */
+  @java.lang.Override
   public long getTimestamp() {
     return timestamp_;
   }
@@ -578,7 +585,9 @@ private static final long serialVersionUID = 0L;
    * </pre>
    *
    * <code>.google.protobuf.UInt64Value num_bytes = 2;</code>
+   * @return Whether the numBytes field is set.
    */
+  @java.lang.Override
   public boolean hasNumBytes() {
     return numBytes_ != null;
   }
@@ -588,7 +597,9 @@ private static final long serialVersionUID = 0L;
    * </pre>
    *
    * <code>.google.protobuf.UInt64Value num_bytes = 2;</code>
+   * @return The numBytes.
    */
+  @java.lang.Override
   public com.google.protobuf.UInt64Value getNumBytes() {
     return numBytes_ == null ? com.google.protobuf.UInt64Value.getDefaultInstance() : numBytes_;
   }
@@ -599,6 +610,7 @@ private static final long serialVersionUID = 0L;
    *
    * <code>.google.protobuf.UInt64Value num_bytes = 2;</code>
    */
+  @java.lang.Override
   public com.google.protobuf.UInt64ValueOrBuilder getNumBytesOrBuilder() {
     return getNumBytes();
   }
@@ -611,8 +623,9 @@ private static final long serialVersionUID = 0L;
    * </pre>
    *
    * <code>.Direction direction = 3;</code>
+   * @return The enum numeric value on the wire for direction.
    */
-  public int getDirectionValue() {
+  @java.lang.Override public int getDirectionValue() {
     return direction_;
   }
   /**
@@ -621,8 +634,9 @@ private static final long serialVersionUID = 0L;
    * </pre>
    *
    * <code>.Direction direction = 3;</code>
+   * @return The direction.
    */
-  public org.opennms.netmgt.flows.persistence.model.Direction getDirection() {
+  @java.lang.Override public org.opennms.netmgt.flows.persistence.model.Direction getDirection() {
     @SuppressWarnings("deprecation")
     org.opennms.netmgt.flows.persistence.model.Direction result = org.opennms.netmgt.flows.persistence.model.Direction.valueOf(direction_);
     return result == null ? org.opennms.netmgt.flows.persistence.model.Direction.UNRECOGNIZED : result;
@@ -636,7 +650,9 @@ private static final long serialVersionUID = 0L;
    * </pre>
    *
    * <code>string dst_address = 4;</code>
+   * @return The dstAddress.
    */
+  @java.lang.Override
   public java.lang.String getDstAddress() {
     java.lang.Object ref = dstAddress_;
     if (ref instanceof java.lang.String) {
@@ -655,7 +671,9 @@ private static final long serialVersionUID = 0L;
    * </pre>
    *
    * <code>string dst_address = 4;</code>
+   * @return The bytes for dstAddress.
    */
+  @java.lang.Override
   public com.google.protobuf.ByteString
       getDstAddressBytes() {
     java.lang.Object ref = dstAddress_;
@@ -678,7 +696,9 @@ private static final long serialVersionUID = 0L;
    * </pre>
    *
    * <code>string dst_hostname = 5;</code>
+   * @return The dstHostname.
    */
+  @java.lang.Override
   public java.lang.String getDstHostname() {
     java.lang.Object ref = dstHostname_;
     if (ref instanceof java.lang.String) {
@@ -697,7 +717,9 @@ private static final long serialVersionUID = 0L;
    * </pre>
    *
    * <code>string dst_hostname = 5;</code>
+   * @return The bytes for dstHostname.
    */
+  @java.lang.Override
   public com.google.protobuf.ByteString
       getDstHostnameBytes() {
     java.lang.Object ref = dstHostname_;
@@ -720,7 +742,9 @@ private static final long serialVersionUID = 0L;
    * </pre>
    *
    * <code>.google.protobuf.UInt64Value dst_as = 6;</code>
+   * @return Whether the dstAs field is set.
    */
+  @java.lang.Override
   public boolean hasDstAs() {
     return dstAs_ != null;
   }
@@ -730,7 +754,9 @@ private static final long serialVersionUID = 0L;
    * </pre>
    *
    * <code>.google.protobuf.UInt64Value dst_as = 6;</code>
+   * @return The dstAs.
    */
+  @java.lang.Override
   public com.google.protobuf.UInt64Value getDstAs() {
     return dstAs_ == null ? com.google.protobuf.UInt64Value.getDefaultInstance() : dstAs_;
   }
@@ -741,6 +767,7 @@ private static final long serialVersionUID = 0L;
    *
    * <code>.google.protobuf.UInt64Value dst_as = 6;</code>
    */
+  @java.lang.Override
   public com.google.protobuf.UInt64ValueOrBuilder getDstAsOrBuilder() {
     return getDstAs();
   }
@@ -753,7 +780,9 @@ private static final long serialVersionUID = 0L;
    * </pre>
    *
    * <code>.google.protobuf.UInt32Value dst_mask_len = 7;</code>
+   * @return Whether the dstMaskLen field is set.
    */
+  @java.lang.Override
   public boolean hasDstMaskLen() {
     return dstMaskLen_ != null;
   }
@@ -763,7 +792,9 @@ private static final long serialVersionUID = 0L;
    * </pre>
    *
    * <code>.google.protobuf.UInt32Value dst_mask_len = 7;</code>
+   * @return The dstMaskLen.
    */
+  @java.lang.Override
   public com.google.protobuf.UInt32Value getDstMaskLen() {
     return dstMaskLen_ == null ? com.google.protobuf.UInt32Value.getDefaultInstance() : dstMaskLen_;
   }
@@ -774,6 +805,7 @@ private static final long serialVersionUID = 0L;
    *
    * <code>.google.protobuf.UInt32Value dst_mask_len = 7;</code>
    */
+  @java.lang.Override
   public com.google.protobuf.UInt32ValueOrBuilder getDstMaskLenOrBuilder() {
     return getDstMaskLen();
   }
@@ -786,7 +818,9 @@ private static final long serialVersionUID = 0L;
    * </pre>
    *
    * <code>.google.protobuf.UInt32Value dst_port = 8;</code>
+   * @return Whether the dstPort field is set.
    */
+  @java.lang.Override
   public boolean hasDstPort() {
     return dstPort_ != null;
   }
@@ -796,7 +830,9 @@ private static final long serialVersionUID = 0L;
    * </pre>
    *
    * <code>.google.protobuf.UInt32Value dst_port = 8;</code>
+   * @return The dstPort.
    */
+  @java.lang.Override
   public com.google.protobuf.UInt32Value getDstPort() {
     return dstPort_ == null ? com.google.protobuf.UInt32Value.getDefaultInstance() : dstPort_;
   }
@@ -807,6 +843,7 @@ private static final long serialVersionUID = 0L;
    *
    * <code>.google.protobuf.UInt32Value dst_port = 8;</code>
    */
+  @java.lang.Override
   public com.google.protobuf.UInt32ValueOrBuilder getDstPortOrBuilder() {
     return getDstPort();
   }
@@ -819,7 +856,9 @@ private static final long serialVersionUID = 0L;
    * </pre>
    *
    * <code>.google.protobuf.UInt32Value engine_id = 9;</code>
+   * @return Whether the engineId field is set.
    */
+  @java.lang.Override
   public boolean hasEngineId() {
     return engineId_ != null;
   }
@@ -829,7 +868,9 @@ private static final long serialVersionUID = 0L;
    * </pre>
    *
    * <code>.google.protobuf.UInt32Value engine_id = 9;</code>
+   * @return The engineId.
    */
+  @java.lang.Override
   public com.google.protobuf.UInt32Value getEngineId() {
     return engineId_ == null ? com.google.protobuf.UInt32Value.getDefaultInstance() : engineId_;
   }
@@ -840,6 +881,7 @@ private static final long serialVersionUID = 0L;
    *
    * <code>.google.protobuf.UInt32Value engine_id = 9;</code>
    */
+  @java.lang.Override
   public com.google.protobuf.UInt32ValueOrBuilder getEngineIdOrBuilder() {
     return getEngineId();
   }
@@ -852,7 +894,9 @@ private static final long serialVersionUID = 0L;
    * </pre>
    *
    * <code>.google.protobuf.UInt32Value engine_type = 10;</code>
+   * @return Whether the engineType field is set.
    */
+  @java.lang.Override
   public boolean hasEngineType() {
     return engineType_ != null;
   }
@@ -862,7 +906,9 @@ private static final long serialVersionUID = 0L;
    * </pre>
    *
    * <code>.google.protobuf.UInt32Value engine_type = 10;</code>
+   * @return The engineType.
    */
+  @java.lang.Override
   public com.google.protobuf.UInt32Value getEngineType() {
     return engineType_ == null ? com.google.protobuf.UInt32Value.getDefaultInstance() : engineType_;
   }
@@ -873,6 +919,7 @@ private static final long serialVersionUID = 0L;
    *
    * <code>.google.protobuf.UInt32Value engine_type = 10;</code>
    */
+  @java.lang.Override
   public com.google.protobuf.UInt32ValueOrBuilder getEngineTypeOrBuilder() {
     return getEngineType();
   }
@@ -885,7 +932,9 @@ private static final long serialVersionUID = 0L;
    * </pre>
    *
    * <code>.google.protobuf.UInt64Value delta_switched = 11;</code>
+   * @return Whether the deltaSwitched field is set.
    */
+  @java.lang.Override
   public boolean hasDeltaSwitched() {
     return deltaSwitched_ != null;
   }
@@ -895,7 +944,9 @@ private static final long serialVersionUID = 0L;
    * </pre>
    *
    * <code>.google.protobuf.UInt64Value delta_switched = 11;</code>
+   * @return The deltaSwitched.
    */
+  @java.lang.Override
   public com.google.protobuf.UInt64Value getDeltaSwitched() {
     return deltaSwitched_ == null ? com.google.protobuf.UInt64Value.getDefaultInstance() : deltaSwitched_;
   }
@@ -906,6 +957,7 @@ private static final long serialVersionUID = 0L;
    *
    * <code>.google.protobuf.UInt64Value delta_switched = 11;</code>
    */
+  @java.lang.Override
   public com.google.protobuf.UInt64ValueOrBuilder getDeltaSwitchedOrBuilder() {
     return getDeltaSwitched();
   }
@@ -918,7 +970,9 @@ private static final long serialVersionUID = 0L;
    * </pre>
    *
    * <code>.google.protobuf.UInt64Value first_switched = 12;</code>
+   * @return Whether the firstSwitched field is set.
    */
+  @java.lang.Override
   public boolean hasFirstSwitched() {
     return firstSwitched_ != null;
   }
@@ -928,7 +982,9 @@ private static final long serialVersionUID = 0L;
    * </pre>
    *
    * <code>.google.protobuf.UInt64Value first_switched = 12;</code>
+   * @return The firstSwitched.
    */
+  @java.lang.Override
   public com.google.protobuf.UInt64Value getFirstSwitched() {
     return firstSwitched_ == null ? com.google.protobuf.UInt64Value.getDefaultInstance() : firstSwitched_;
   }
@@ -939,6 +995,7 @@ private static final long serialVersionUID = 0L;
    *
    * <code>.google.protobuf.UInt64Value first_switched = 12;</code>
    */
+  @java.lang.Override
   public com.google.protobuf.UInt64ValueOrBuilder getFirstSwitchedOrBuilder() {
     return getFirstSwitched();
   }
@@ -951,7 +1008,9 @@ private static final long serialVersionUID = 0L;
    * </pre>
    *
    * <code>.google.protobuf.UInt64Value last_switched = 13;</code>
+   * @return Whether the lastSwitched field is set.
    */
+  @java.lang.Override
   public boolean hasLastSwitched() {
     return lastSwitched_ != null;
   }
@@ -961,7 +1020,9 @@ private static final long serialVersionUID = 0L;
    * </pre>
    *
    * <code>.google.protobuf.UInt64Value last_switched = 13;</code>
+   * @return The lastSwitched.
    */
+  @java.lang.Override
   public com.google.protobuf.UInt64Value getLastSwitched() {
     return lastSwitched_ == null ? com.google.protobuf.UInt64Value.getDefaultInstance() : lastSwitched_;
   }
@@ -972,6 +1033,7 @@ private static final long serialVersionUID = 0L;
    *
    * <code>.google.protobuf.UInt64Value last_switched = 13;</code>
    */
+  @java.lang.Override
   public com.google.protobuf.UInt64ValueOrBuilder getLastSwitchedOrBuilder() {
     return getLastSwitched();
   }
@@ -984,7 +1046,9 @@ private static final long serialVersionUID = 0L;
    * </pre>
    *
    * <code>.google.protobuf.UInt32Value num_flow_records = 14;</code>
+   * @return Whether the numFlowRecords field is set.
    */
+  @java.lang.Override
   public boolean hasNumFlowRecords() {
     return numFlowRecords_ != null;
   }
@@ -994,7 +1058,9 @@ private static final long serialVersionUID = 0L;
    * </pre>
    *
    * <code>.google.protobuf.UInt32Value num_flow_records = 14;</code>
+   * @return The numFlowRecords.
    */
+  @java.lang.Override
   public com.google.protobuf.UInt32Value getNumFlowRecords() {
     return numFlowRecords_ == null ? com.google.protobuf.UInt32Value.getDefaultInstance() : numFlowRecords_;
   }
@@ -1005,6 +1071,7 @@ private static final long serialVersionUID = 0L;
    *
    * <code>.google.protobuf.UInt32Value num_flow_records = 14;</code>
    */
+  @java.lang.Override
   public com.google.protobuf.UInt32ValueOrBuilder getNumFlowRecordsOrBuilder() {
     return getNumFlowRecords();
   }
@@ -1017,7 +1084,9 @@ private static final long serialVersionUID = 0L;
    * </pre>
    *
    * <code>.google.protobuf.UInt64Value num_packets = 15;</code>
+   * @return Whether the numPackets field is set.
    */
+  @java.lang.Override
   public boolean hasNumPackets() {
     return numPackets_ != null;
   }
@@ -1027,7 +1096,9 @@ private static final long serialVersionUID = 0L;
    * </pre>
    *
    * <code>.google.protobuf.UInt64Value num_packets = 15;</code>
+   * @return The numPackets.
    */
+  @java.lang.Override
   public com.google.protobuf.UInt64Value getNumPackets() {
     return numPackets_ == null ? com.google.protobuf.UInt64Value.getDefaultInstance() : numPackets_;
   }
@@ -1038,6 +1109,7 @@ private static final long serialVersionUID = 0L;
    *
    * <code>.google.protobuf.UInt64Value num_packets = 15;</code>
    */
+  @java.lang.Override
   public com.google.protobuf.UInt64ValueOrBuilder getNumPacketsOrBuilder() {
     return getNumPackets();
   }
@@ -1050,7 +1122,9 @@ private static final long serialVersionUID = 0L;
    * </pre>
    *
    * <code>.google.protobuf.UInt64Value flow_seq_num = 16;</code>
+   * @return Whether the flowSeqNum field is set.
    */
+  @java.lang.Override
   public boolean hasFlowSeqNum() {
     return flowSeqNum_ != null;
   }
@@ -1060,7 +1134,9 @@ private static final long serialVersionUID = 0L;
    * </pre>
    *
    * <code>.google.protobuf.UInt64Value flow_seq_num = 16;</code>
+   * @return The flowSeqNum.
    */
+  @java.lang.Override
   public com.google.protobuf.UInt64Value getFlowSeqNum() {
     return flowSeqNum_ == null ? com.google.protobuf.UInt64Value.getDefaultInstance() : flowSeqNum_;
   }
@@ -1071,6 +1147,7 @@ private static final long serialVersionUID = 0L;
    *
    * <code>.google.protobuf.UInt64Value flow_seq_num = 16;</code>
    */
+  @java.lang.Override
   public com.google.protobuf.UInt64ValueOrBuilder getFlowSeqNumOrBuilder() {
     return getFlowSeqNum();
   }
@@ -1083,7 +1160,9 @@ private static final long serialVersionUID = 0L;
    * </pre>
    *
    * <code>.google.protobuf.UInt32Value input_snmp_ifindex = 17;</code>
+   * @return Whether the inputSnmpIfindex field is set.
    */
+  @java.lang.Override
   public boolean hasInputSnmpIfindex() {
     return inputSnmpIfindex_ != null;
   }
@@ -1093,7 +1172,9 @@ private static final long serialVersionUID = 0L;
    * </pre>
    *
    * <code>.google.protobuf.UInt32Value input_snmp_ifindex = 17;</code>
+   * @return The inputSnmpIfindex.
    */
+  @java.lang.Override
   public com.google.protobuf.UInt32Value getInputSnmpIfindex() {
     return inputSnmpIfindex_ == null ? com.google.protobuf.UInt32Value.getDefaultInstance() : inputSnmpIfindex_;
   }
@@ -1104,6 +1185,7 @@ private static final long serialVersionUID = 0L;
    *
    * <code>.google.protobuf.UInt32Value input_snmp_ifindex = 17;</code>
    */
+  @java.lang.Override
   public com.google.protobuf.UInt32ValueOrBuilder getInputSnmpIfindexOrBuilder() {
     return getInputSnmpIfindex();
   }
@@ -1116,7 +1198,9 @@ private static final long serialVersionUID = 0L;
    * </pre>
    *
    * <code>.google.protobuf.UInt32Value output_snmp_ifindex = 18;</code>
+   * @return Whether the outputSnmpIfindex field is set.
    */
+  @java.lang.Override
   public boolean hasOutputSnmpIfindex() {
     return outputSnmpIfindex_ != null;
   }
@@ -1126,7 +1210,9 @@ private static final long serialVersionUID = 0L;
    * </pre>
    *
    * <code>.google.protobuf.UInt32Value output_snmp_ifindex = 18;</code>
+   * @return The outputSnmpIfindex.
    */
+  @java.lang.Override
   public com.google.protobuf.UInt32Value getOutputSnmpIfindex() {
     return outputSnmpIfindex_ == null ? com.google.protobuf.UInt32Value.getDefaultInstance() : outputSnmpIfindex_;
   }
@@ -1137,6 +1223,7 @@ private static final long serialVersionUID = 0L;
    *
    * <code>.google.protobuf.UInt32Value output_snmp_ifindex = 18;</code>
    */
+  @java.lang.Override
   public com.google.protobuf.UInt32ValueOrBuilder getOutputSnmpIfindexOrBuilder() {
     return getOutputSnmpIfindex();
   }
@@ -1149,7 +1236,9 @@ private static final long serialVersionUID = 0L;
    * </pre>
    *
    * <code>.google.protobuf.UInt32Value ip_protocol_version = 19;</code>
+   * @return Whether the ipProtocolVersion field is set.
    */
+  @java.lang.Override
   public boolean hasIpProtocolVersion() {
     return ipProtocolVersion_ != null;
   }
@@ -1159,7 +1248,9 @@ private static final long serialVersionUID = 0L;
    * </pre>
    *
    * <code>.google.protobuf.UInt32Value ip_protocol_version = 19;</code>
+   * @return The ipProtocolVersion.
    */
+  @java.lang.Override
   public com.google.protobuf.UInt32Value getIpProtocolVersion() {
     return ipProtocolVersion_ == null ? com.google.protobuf.UInt32Value.getDefaultInstance() : ipProtocolVersion_;
   }
@@ -1170,6 +1261,7 @@ private static final long serialVersionUID = 0L;
    *
    * <code>.google.protobuf.UInt32Value ip_protocol_version = 19;</code>
    */
+  @java.lang.Override
   public com.google.protobuf.UInt32ValueOrBuilder getIpProtocolVersionOrBuilder() {
     return getIpProtocolVersion();
   }
@@ -1182,7 +1274,9 @@ private static final long serialVersionUID = 0L;
    * </pre>
    *
    * <code>string next_hop_address = 20;</code>
+   * @return The nextHopAddress.
    */
+  @java.lang.Override
   public java.lang.String getNextHopAddress() {
     java.lang.Object ref = nextHopAddress_;
     if (ref instanceof java.lang.String) {
@@ -1201,7 +1295,9 @@ private static final long serialVersionUID = 0L;
    * </pre>
    *
    * <code>string next_hop_address = 20;</code>
+   * @return The bytes for nextHopAddress.
    */
+  @java.lang.Override
   public com.google.protobuf.ByteString
       getNextHopAddressBytes() {
     java.lang.Object ref = nextHopAddress_;
@@ -1224,7 +1320,9 @@ private static final long serialVersionUID = 0L;
    * </pre>
    *
    * <code>string next_hop_hostname = 21;</code>
+   * @return The nextHopHostname.
    */
+  @java.lang.Override
   public java.lang.String getNextHopHostname() {
     java.lang.Object ref = nextHopHostname_;
     if (ref instanceof java.lang.String) {
@@ -1243,7 +1341,9 @@ private static final long serialVersionUID = 0L;
    * </pre>
    *
    * <code>string next_hop_hostname = 21;</code>
+   * @return The bytes for nextHopHostname.
    */
+  @java.lang.Override
   public com.google.protobuf.ByteString
       getNextHopHostnameBytes() {
     java.lang.Object ref = nextHopHostname_;
@@ -1266,7 +1366,9 @@ private static final long serialVersionUID = 0L;
    * </pre>
    *
    * <code>.google.protobuf.UInt32Value protocol = 22;</code>
+   * @return Whether the protocol field is set.
    */
+  @java.lang.Override
   public boolean hasProtocol() {
     return protocol_ != null;
   }
@@ -1276,7 +1378,9 @@ private static final long serialVersionUID = 0L;
    * </pre>
    *
    * <code>.google.protobuf.UInt32Value protocol = 22;</code>
+   * @return The protocol.
    */
+  @java.lang.Override
   public com.google.protobuf.UInt32Value getProtocol() {
     return protocol_ == null ? com.google.protobuf.UInt32Value.getDefaultInstance() : protocol_;
   }
@@ -1287,6 +1391,7 @@ private static final long serialVersionUID = 0L;
    *
    * <code>.google.protobuf.UInt32Value protocol = 22;</code>
    */
+  @java.lang.Override
   public com.google.protobuf.UInt32ValueOrBuilder getProtocolOrBuilder() {
     return getProtocol();
   }
@@ -1299,8 +1404,9 @@ private static final long serialVersionUID = 0L;
    * </pre>
    *
    * <code>.SamplingAlgorithm sampling_algorithm = 23;</code>
+   * @return The enum numeric value on the wire for samplingAlgorithm.
    */
-  public int getSamplingAlgorithmValue() {
+  @java.lang.Override public int getSamplingAlgorithmValue() {
     return samplingAlgorithm_;
   }
   /**
@@ -1309,8 +1415,9 @@ private static final long serialVersionUID = 0L;
    * </pre>
    *
    * <code>.SamplingAlgorithm sampling_algorithm = 23;</code>
+   * @return The samplingAlgorithm.
    */
-  public org.opennms.netmgt.flows.persistence.model.SamplingAlgorithm getSamplingAlgorithm() {
+  @java.lang.Override public org.opennms.netmgt.flows.persistence.model.SamplingAlgorithm getSamplingAlgorithm() {
     @SuppressWarnings("deprecation")
     org.opennms.netmgt.flows.persistence.model.SamplingAlgorithm result = org.opennms.netmgt.flows.persistence.model.SamplingAlgorithm.valueOf(samplingAlgorithm_);
     return result == null ? org.opennms.netmgt.flows.persistence.model.SamplingAlgorithm.UNRECOGNIZED : result;
@@ -1324,7 +1431,9 @@ private static final long serialVersionUID = 0L;
    * </pre>
    *
    * <code>.google.protobuf.DoubleValue sampling_interval = 24;</code>
+   * @return Whether the samplingInterval field is set.
    */
+  @java.lang.Override
   public boolean hasSamplingInterval() {
     return samplingInterval_ != null;
   }
@@ -1334,7 +1443,9 @@ private static final long serialVersionUID = 0L;
    * </pre>
    *
    * <code>.google.protobuf.DoubleValue sampling_interval = 24;</code>
+   * @return The samplingInterval.
    */
+  @java.lang.Override
   public com.google.protobuf.DoubleValue getSamplingInterval() {
     return samplingInterval_ == null ? com.google.protobuf.DoubleValue.getDefaultInstance() : samplingInterval_;
   }
@@ -1345,6 +1456,7 @@ private static final long serialVersionUID = 0L;
    *
    * <code>.google.protobuf.DoubleValue sampling_interval = 24;</code>
    */
+  @java.lang.Override
   public com.google.protobuf.DoubleValueOrBuilder getSamplingIntervalOrBuilder() {
     return getSamplingInterval();
   }
@@ -1357,7 +1469,9 @@ private static final long serialVersionUID = 0L;
    * </pre>
    *
    * <code>string src_address = 26;</code>
+   * @return The srcAddress.
    */
+  @java.lang.Override
   public java.lang.String getSrcAddress() {
     java.lang.Object ref = srcAddress_;
     if (ref instanceof java.lang.String) {
@@ -1376,7 +1490,9 @@ private static final long serialVersionUID = 0L;
    * </pre>
    *
    * <code>string src_address = 26;</code>
+   * @return The bytes for srcAddress.
    */
+  @java.lang.Override
   public com.google.protobuf.ByteString
       getSrcAddressBytes() {
     java.lang.Object ref = srcAddress_;
@@ -1399,7 +1515,9 @@ private static final long serialVersionUID = 0L;
    * </pre>
    *
    * <code>string src_hostname = 27;</code>
+   * @return The srcHostname.
    */
+  @java.lang.Override
   public java.lang.String getSrcHostname() {
     java.lang.Object ref = srcHostname_;
     if (ref instanceof java.lang.String) {
@@ -1418,7 +1536,9 @@ private static final long serialVersionUID = 0L;
    * </pre>
    *
    * <code>string src_hostname = 27;</code>
+   * @return The bytes for srcHostname.
    */
+  @java.lang.Override
   public com.google.protobuf.ByteString
       getSrcHostnameBytes() {
     java.lang.Object ref = srcHostname_;
@@ -1441,7 +1561,9 @@ private static final long serialVersionUID = 0L;
    * </pre>
    *
    * <code>.google.protobuf.UInt64Value src_as = 28;</code>
+   * @return Whether the srcAs field is set.
    */
+  @java.lang.Override
   public boolean hasSrcAs() {
     return srcAs_ != null;
   }
@@ -1451,7 +1573,9 @@ private static final long serialVersionUID = 0L;
    * </pre>
    *
    * <code>.google.protobuf.UInt64Value src_as = 28;</code>
+   * @return The srcAs.
    */
+  @java.lang.Override
   public com.google.protobuf.UInt64Value getSrcAs() {
     return srcAs_ == null ? com.google.protobuf.UInt64Value.getDefaultInstance() : srcAs_;
   }
@@ -1462,6 +1586,7 @@ private static final long serialVersionUID = 0L;
    *
    * <code>.google.protobuf.UInt64Value src_as = 28;</code>
    */
+  @java.lang.Override
   public com.google.protobuf.UInt64ValueOrBuilder getSrcAsOrBuilder() {
     return getSrcAs();
   }
@@ -1474,7 +1599,9 @@ private static final long serialVersionUID = 0L;
    * </pre>
    *
    * <code>.google.protobuf.UInt32Value src_mask_len = 29;</code>
+   * @return Whether the srcMaskLen field is set.
    */
+  @java.lang.Override
   public boolean hasSrcMaskLen() {
     return srcMaskLen_ != null;
   }
@@ -1484,7 +1611,9 @@ private static final long serialVersionUID = 0L;
    * </pre>
    *
    * <code>.google.protobuf.UInt32Value src_mask_len = 29;</code>
+   * @return The srcMaskLen.
    */
+  @java.lang.Override
   public com.google.protobuf.UInt32Value getSrcMaskLen() {
     return srcMaskLen_ == null ? com.google.protobuf.UInt32Value.getDefaultInstance() : srcMaskLen_;
   }
@@ -1495,6 +1624,7 @@ private static final long serialVersionUID = 0L;
    *
    * <code>.google.protobuf.UInt32Value src_mask_len = 29;</code>
    */
+  @java.lang.Override
   public com.google.protobuf.UInt32ValueOrBuilder getSrcMaskLenOrBuilder() {
     return getSrcMaskLen();
   }
@@ -1507,7 +1637,9 @@ private static final long serialVersionUID = 0L;
    * </pre>
    *
    * <code>.google.protobuf.UInt32Value src_port = 30;</code>
+   * @return Whether the srcPort field is set.
    */
+  @java.lang.Override
   public boolean hasSrcPort() {
     return srcPort_ != null;
   }
@@ -1517,7 +1649,9 @@ private static final long serialVersionUID = 0L;
    * </pre>
    *
    * <code>.google.protobuf.UInt32Value src_port = 30;</code>
+   * @return The srcPort.
    */
+  @java.lang.Override
   public com.google.protobuf.UInt32Value getSrcPort() {
     return srcPort_ == null ? com.google.protobuf.UInt32Value.getDefaultInstance() : srcPort_;
   }
@@ -1528,6 +1662,7 @@ private static final long serialVersionUID = 0L;
    *
    * <code>.google.protobuf.UInt32Value src_port = 30;</code>
    */
+  @java.lang.Override
   public com.google.protobuf.UInt32ValueOrBuilder getSrcPortOrBuilder() {
     return getSrcPort();
   }
@@ -1540,7 +1675,9 @@ private static final long serialVersionUID = 0L;
    * </pre>
    *
    * <code>.google.protobuf.UInt32Value tcp_flags = 31;</code>
+   * @return Whether the tcpFlags field is set.
    */
+  @java.lang.Override
   public boolean hasTcpFlags() {
     return tcpFlags_ != null;
   }
@@ -1550,7 +1687,9 @@ private static final long serialVersionUID = 0L;
    * </pre>
    *
    * <code>.google.protobuf.UInt32Value tcp_flags = 31;</code>
+   * @return The tcpFlags.
    */
+  @java.lang.Override
   public com.google.protobuf.UInt32Value getTcpFlags() {
     return tcpFlags_ == null ? com.google.protobuf.UInt32Value.getDefaultInstance() : tcpFlags_;
   }
@@ -1561,6 +1700,7 @@ private static final long serialVersionUID = 0L;
    *
    * <code>.google.protobuf.UInt32Value tcp_flags = 31;</code>
    */
+  @java.lang.Override
   public com.google.protobuf.UInt32ValueOrBuilder getTcpFlagsOrBuilder() {
     return getTcpFlags();
   }
@@ -1573,7 +1713,9 @@ private static final long serialVersionUID = 0L;
    * </pre>
    *
    * <code>.google.protobuf.UInt32Value tos = 32;</code>
+   * @return Whether the tos field is set.
    */
+  @java.lang.Override
   public boolean hasTos() {
     return tos_ != null;
   }
@@ -1583,7 +1725,9 @@ private static final long serialVersionUID = 0L;
    * </pre>
    *
    * <code>.google.protobuf.UInt32Value tos = 32;</code>
+   * @return The tos.
    */
+  @java.lang.Override
   public com.google.protobuf.UInt32Value getTos() {
     return tos_ == null ? com.google.protobuf.UInt32Value.getDefaultInstance() : tos_;
   }
@@ -1594,6 +1738,7 @@ private static final long serialVersionUID = 0L;
    *
    * <code>.google.protobuf.UInt32Value tos = 32;</code>
    */
+  @java.lang.Override
   public com.google.protobuf.UInt32ValueOrBuilder getTosOrBuilder() {
     return getTos();
   }
@@ -1606,8 +1751,9 @@ private static final long serialVersionUID = 0L;
    * </pre>
    *
    * <code>.NetflowVersion netflow_version = 33;</code>
+   * @return The enum numeric value on the wire for netflowVersion.
    */
-  public int getNetflowVersionValue() {
+  @java.lang.Override public int getNetflowVersionValue() {
     return netflowVersion_;
   }
   /**
@@ -1616,8 +1762,9 @@ private static final long serialVersionUID = 0L;
    * </pre>
    *
    * <code>.NetflowVersion netflow_version = 33;</code>
+   * @return The netflowVersion.
    */
-  public org.opennms.netmgt.flows.persistence.model.NetflowVersion getNetflowVersion() {
+  @java.lang.Override public org.opennms.netmgt.flows.persistence.model.NetflowVersion getNetflowVersion() {
     @SuppressWarnings("deprecation")
     org.opennms.netmgt.flows.persistence.model.NetflowVersion result = org.opennms.netmgt.flows.persistence.model.NetflowVersion.valueOf(netflowVersion_);
     return result == null ? org.opennms.netmgt.flows.persistence.model.NetflowVersion.UNRECOGNIZED : result;
@@ -1631,7 +1778,9 @@ private static final long serialVersionUID = 0L;
    * </pre>
    *
    * <code>string vlan = 34;</code>
+   * @return The vlan.
    */
+  @java.lang.Override
   public java.lang.String getVlan() {
     java.lang.Object ref = vlan_;
     if (ref instanceof java.lang.String) {
@@ -1650,7 +1799,9 @@ private static final long serialVersionUID = 0L;
    * </pre>
    *
    * <code>string vlan = 34;</code>
+   * @return The bytes for vlan.
    */
+  @java.lang.Override
   public com.google.protobuf.ByteString
       getVlanBytes() {
     java.lang.Object ref = vlan_;
@@ -1669,19 +1820,24 @@ private static final long serialVersionUID = 0L;
   private org.opennms.netmgt.flows.persistence.model.NodeInfo srcNode_;
   /**
    * <code>.NodeInfo src_node = 35;</code>
+   * @return Whether the srcNode field is set.
    */
+  @java.lang.Override
   public boolean hasSrcNode() {
     return srcNode_ != null;
   }
   /**
    * <code>.NodeInfo src_node = 35;</code>
+   * @return The srcNode.
    */
+  @java.lang.Override
   public org.opennms.netmgt.flows.persistence.model.NodeInfo getSrcNode() {
     return srcNode_ == null ? org.opennms.netmgt.flows.persistence.model.NodeInfo.getDefaultInstance() : srcNode_;
   }
   /**
    * <code>.NodeInfo src_node = 35;</code>
    */
+  @java.lang.Override
   public org.opennms.netmgt.flows.persistence.model.NodeInfoOrBuilder getSrcNodeOrBuilder() {
     return getSrcNode();
   }
@@ -1690,19 +1846,24 @@ private static final long serialVersionUID = 0L;
   private org.opennms.netmgt.flows.persistence.model.NodeInfo exporterNode_;
   /**
    * <code>.NodeInfo exporter_node = 36;</code>
+   * @return Whether the exporterNode field is set.
    */
+  @java.lang.Override
   public boolean hasExporterNode() {
     return exporterNode_ != null;
   }
   /**
    * <code>.NodeInfo exporter_node = 36;</code>
+   * @return The exporterNode.
    */
+  @java.lang.Override
   public org.opennms.netmgt.flows.persistence.model.NodeInfo getExporterNode() {
     return exporterNode_ == null ? org.opennms.netmgt.flows.persistence.model.NodeInfo.getDefaultInstance() : exporterNode_;
   }
   /**
    * <code>.NodeInfo exporter_node = 36;</code>
    */
+  @java.lang.Override
   public org.opennms.netmgt.flows.persistence.model.NodeInfoOrBuilder getExporterNodeOrBuilder() {
     return getExporterNode();
   }
@@ -1711,19 +1872,24 @@ private static final long serialVersionUID = 0L;
   private org.opennms.netmgt.flows.persistence.model.NodeInfo destNode_;
   /**
    * <code>.NodeInfo dest_node = 37;</code>
+   * @return Whether the destNode field is set.
    */
+  @java.lang.Override
   public boolean hasDestNode() {
     return destNode_ != null;
   }
   /**
    * <code>.NodeInfo dest_node = 37;</code>
+   * @return The destNode.
    */
+  @java.lang.Override
   public org.opennms.netmgt.flows.persistence.model.NodeInfo getDestNode() {
     return destNode_ == null ? org.opennms.netmgt.flows.persistence.model.NodeInfo.getDefaultInstance() : destNode_;
   }
   /**
    * <code>.NodeInfo dest_node = 37;</code>
    */
+  @java.lang.Override
   public org.opennms.netmgt.flows.persistence.model.NodeInfoOrBuilder getDestNodeOrBuilder() {
     return getDestNode();
   }
@@ -1732,7 +1898,9 @@ private static final long serialVersionUID = 0L;
   private volatile java.lang.Object application_;
   /**
    * <code>string application = 38;</code>
+   * @return The application.
    */
+  @java.lang.Override
   public java.lang.String getApplication() {
     java.lang.Object ref = application_;
     if (ref instanceof java.lang.String) {
@@ -1747,7 +1915,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <code>string application = 38;</code>
+   * @return The bytes for application.
    */
+  @java.lang.Override
   public com.google.protobuf.ByteString
       getApplicationBytes() {
     java.lang.Object ref = application_;
@@ -1766,7 +1936,9 @@ private static final long serialVersionUID = 0L;
   private volatile java.lang.Object host_;
   /**
    * <code>string host = 39;</code>
+   * @return The host.
    */
+  @java.lang.Override
   public java.lang.String getHost() {
     java.lang.Object ref = host_;
     if (ref instanceof java.lang.String) {
@@ -1781,7 +1953,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <code>string host = 39;</code>
+   * @return The bytes for host.
    */
+  @java.lang.Override
   public com.google.protobuf.ByteString
       getHostBytes() {
     java.lang.Object ref = host_;
@@ -1800,7 +1974,9 @@ private static final long serialVersionUID = 0L;
   private volatile java.lang.Object location_;
   /**
    * <code>string location = 40;</code>
+   * @return The location.
    */
+  @java.lang.Override
   public java.lang.String getLocation() {
     java.lang.Object ref = location_;
     if (ref instanceof java.lang.String) {
@@ -1815,7 +1991,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <code>string location = 40;</code>
+   * @return The bytes for location.
    */
+  @java.lang.Override
   public com.google.protobuf.ByteString
       getLocationBytes() {
     java.lang.Object ref = location_;
@@ -1834,14 +2012,16 @@ private static final long serialVersionUID = 0L;
   private int srcLocality_;
   /**
    * <code>.Locality src_locality = 41;</code>
+   * @return The enum numeric value on the wire for srcLocality.
    */
-  public int getSrcLocalityValue() {
+  @java.lang.Override public int getSrcLocalityValue() {
     return srcLocality_;
   }
   /**
    * <code>.Locality src_locality = 41;</code>
+   * @return The srcLocality.
    */
-  public org.opennms.netmgt.flows.persistence.model.Locality getSrcLocality() {
+  @java.lang.Override public org.opennms.netmgt.flows.persistence.model.Locality getSrcLocality() {
     @SuppressWarnings("deprecation")
     org.opennms.netmgt.flows.persistence.model.Locality result = org.opennms.netmgt.flows.persistence.model.Locality.valueOf(srcLocality_);
     return result == null ? org.opennms.netmgt.flows.persistence.model.Locality.UNRECOGNIZED : result;
@@ -1851,14 +2031,16 @@ private static final long serialVersionUID = 0L;
   private int dstLocality_;
   /**
    * <code>.Locality dst_locality = 42;</code>
+   * @return The enum numeric value on the wire for dstLocality.
    */
-  public int getDstLocalityValue() {
+  @java.lang.Override public int getDstLocalityValue() {
     return dstLocality_;
   }
   /**
    * <code>.Locality dst_locality = 42;</code>
+   * @return The dstLocality.
    */
-  public org.opennms.netmgt.flows.persistence.model.Locality getDstLocality() {
+  @java.lang.Override public org.opennms.netmgt.flows.persistence.model.Locality getDstLocality() {
     @SuppressWarnings("deprecation")
     org.opennms.netmgt.flows.persistence.model.Locality result = org.opennms.netmgt.flows.persistence.model.Locality.valueOf(dstLocality_);
     return result == null ? org.opennms.netmgt.flows.persistence.model.Locality.UNRECOGNIZED : result;
@@ -1868,14 +2050,16 @@ private static final long serialVersionUID = 0L;
   private int flowLocality_;
   /**
    * <code>.Locality flow_locality = 43;</code>
+   * @return The enum numeric value on the wire for flowLocality.
    */
-  public int getFlowLocalityValue() {
+  @java.lang.Override public int getFlowLocalityValue() {
     return flowLocality_;
   }
   /**
    * <code>.Locality flow_locality = 43;</code>
+   * @return The flowLocality.
    */
-  public org.opennms.netmgt.flows.persistence.model.Locality getFlowLocality() {
+  @java.lang.Override public org.opennms.netmgt.flows.persistence.model.Locality getFlowLocality() {
     @SuppressWarnings("deprecation")
     org.opennms.netmgt.flows.persistence.model.Locality result = org.opennms.netmgt.flows.persistence.model.Locality.valueOf(flowLocality_);
     return result == null ? org.opennms.netmgt.flows.persistence.model.Locality.UNRECOGNIZED : result;
@@ -1885,7 +2069,9 @@ private static final long serialVersionUID = 0L;
   private volatile java.lang.Object convoKey_;
   /**
    * <code>string convo_key = 44;</code>
+   * @return The convoKey.
    */
+  @java.lang.Override
   public java.lang.String getConvoKey() {
     java.lang.Object ref = convoKey_;
     if (ref instanceof java.lang.String) {
@@ -1900,7 +2086,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <code>string convo_key = 44;</code>
+   * @return The bytes for convoKey.
    */
+  @java.lang.Override
   public com.google.protobuf.ByteString
       getConvoKeyBytes() {
     java.lang.Object ref = convoKey_;
@@ -1913,6 +2101,21 @@ private static final long serialVersionUID = 0L;
     } else {
       return (com.google.protobuf.ByteString) ref;
     }
+  }
+
+  public static final int CLOCK_CORRECTION_FIELD_NUMBER = 45;
+  private long clockCorrection_;
+  /**
+   * <pre>
+   * Applied clock correction im milliseconds.
+   * </pre>
+   *
+   * <code>uint64 clock_correction = 45;</code>
+   * @return The clockCorrection.
+   */
+  @java.lang.Override
+  public long getClockCorrection() {
+    return clockCorrection_;
   }
 
   private byte memoizedIsInitialized = -1;
@@ -2057,6 +2260,9 @@ private static final long serialVersionUID = 0L;
     }
     if (!getConvoKeyBytes().isEmpty()) {
       com.google.protobuf.GeneratedMessageV3.writeString(output, 44, convoKey_);
+    }
+    if (clockCorrection_ != 0L) {
+      output.writeUInt64(45, clockCorrection_);
     }
     unknownFields.writeTo(output);
   }
@@ -2228,6 +2434,10 @@ private static final long serialVersionUID = 0L;
     if (!getConvoKeyBytes().isEmpty()) {
       size += com.google.protobuf.GeneratedMessageV3.computeStringSize(44, convoKey_);
     }
+    if (clockCorrection_ != 0L) {
+      size += com.google.protobuf.CodedOutputStream
+        .computeUInt64Size(45, clockCorrection_);
+    }
     size += unknownFields.getSerializedSize();
     memoizedSize = size;
     return size;
@@ -2398,6 +2608,8 @@ private static final long serialVersionUID = 0L;
     if (flowLocality_ != other.flowLocality_) return false;
     if (!getConvoKey()
         .equals(other.getConvoKey())) return false;
+    if (getClockCorrection()
+        != other.getClockCorrection()) return false;
     if (!unknownFields.equals(other.unknownFields)) return false;
     return true;
   }
@@ -2546,6 +2758,9 @@ private static final long serialVersionUID = 0L;
     hash = (53 * hash) + flowLocality_;
     hash = (37 * hash) + CONVO_KEY_FIELD_NUMBER;
     hash = (53 * hash) + getConvoKey().hashCode();
+    hash = (37 * hash) + CLOCK_CORRECTION_FIELD_NUMBER;
+    hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
+        getClockCorrection());
     hash = (29 * hash) + unknownFields.hashCode();
     memoizedHashCode = hash;
     return hash;
@@ -2865,6 +3080,8 @@ private static final long serialVersionUID = 0L;
 
       convoKey_ = "";
 
+      clockCorrection_ = 0L;
+
       return this;
     }
 
@@ -3034,6 +3251,7 @@ private static final long serialVersionUID = 0L;
       result.dstLocality_ = dstLocality_;
       result.flowLocality_ = flowLocality_;
       result.convoKey_ = convoKey_;
+      result.clockCorrection_ = clockCorrection_;
       onBuilt();
       return result;
     }
@@ -3222,6 +3440,9 @@ private static final long serialVersionUID = 0L;
         convoKey_ = other.convoKey_;
         onChanged();
       }
+      if (other.getClockCorrection() != 0L) {
+        setClockCorrection(other.getClockCorrection());
+      }
       this.mergeUnknownFields(other.unknownFields);
       onChanged();
       return this;
@@ -3258,7 +3479,9 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>uint64 timestamp = 1;</code>
+     * @return The timestamp.
      */
+    @java.lang.Override
     public long getTimestamp() {
       return timestamp_;
     }
@@ -3268,6 +3491,8 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>uint64 timestamp = 1;</code>
+     * @param value The timestamp to set.
+     * @return This builder for chaining.
      */
     public Builder setTimestamp(long value) {
       
@@ -3281,6 +3506,7 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>uint64 timestamp = 1;</code>
+     * @return This builder for chaining.
      */
     public Builder clearTimestamp() {
       
@@ -3298,6 +3524,7 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>.google.protobuf.UInt64Value num_bytes = 2;</code>
+     * @return Whether the numBytes field is set.
      */
     public boolean hasNumBytes() {
       return numBytesBuilder_ != null || numBytes_ != null;
@@ -3308,6 +3535,7 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>.google.protobuf.UInt64Value num_bytes = 2;</code>
+     * @return The numBytes.
      */
     public com.google.protobuf.UInt64Value getNumBytes() {
       if (numBytesBuilder_ == null) {
@@ -3449,8 +3677,9 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>.Direction direction = 3;</code>
+     * @return The enum numeric value on the wire for direction.
      */
-    public int getDirectionValue() {
+    @java.lang.Override public int getDirectionValue() {
       return direction_;
     }
     /**
@@ -3459,8 +3688,11 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>.Direction direction = 3;</code>
+     * @param value The enum numeric value on the wire for direction to set.
+     * @return This builder for chaining.
      */
     public Builder setDirectionValue(int value) {
+      
       direction_ = value;
       onChanged();
       return this;
@@ -3471,7 +3703,9 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>.Direction direction = 3;</code>
+     * @return The direction.
      */
+    @java.lang.Override
     public org.opennms.netmgt.flows.persistence.model.Direction getDirection() {
       @SuppressWarnings("deprecation")
       org.opennms.netmgt.flows.persistence.model.Direction result = org.opennms.netmgt.flows.persistence.model.Direction.valueOf(direction_);
@@ -3483,6 +3717,8 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>.Direction direction = 3;</code>
+     * @param value The direction to set.
+     * @return This builder for chaining.
      */
     public Builder setDirection(org.opennms.netmgt.flows.persistence.model.Direction value) {
       if (value == null) {
@@ -3499,6 +3735,7 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>.Direction direction = 3;</code>
+     * @return This builder for chaining.
      */
     public Builder clearDirection() {
       
@@ -3514,6 +3751,7 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>string dst_address = 4;</code>
+     * @return The dstAddress.
      */
     public java.lang.String getDstAddress() {
       java.lang.Object ref = dstAddress_;
@@ -3533,6 +3771,7 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>string dst_address = 4;</code>
+     * @return The bytes for dstAddress.
      */
     public com.google.protobuf.ByteString
         getDstAddressBytes() {
@@ -3553,6 +3792,8 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>string dst_address = 4;</code>
+     * @param value The dstAddress to set.
+     * @return This builder for chaining.
      */
     public Builder setDstAddress(
         java.lang.String value) {
@@ -3570,6 +3811,7 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>string dst_address = 4;</code>
+     * @return This builder for chaining.
      */
     public Builder clearDstAddress() {
       
@@ -3583,6 +3825,8 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>string dst_address = 4;</code>
+     * @param value The bytes for dstAddress to set.
+     * @return This builder for chaining.
      */
     public Builder setDstAddressBytes(
         com.google.protobuf.ByteString value) {
@@ -3603,6 +3847,7 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>string dst_hostname = 5;</code>
+     * @return The dstHostname.
      */
     public java.lang.String getDstHostname() {
       java.lang.Object ref = dstHostname_;
@@ -3622,6 +3867,7 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>string dst_hostname = 5;</code>
+     * @return The bytes for dstHostname.
      */
     public com.google.protobuf.ByteString
         getDstHostnameBytes() {
@@ -3642,6 +3888,8 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>string dst_hostname = 5;</code>
+     * @param value The dstHostname to set.
+     * @return This builder for chaining.
      */
     public Builder setDstHostname(
         java.lang.String value) {
@@ -3659,6 +3907,7 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>string dst_hostname = 5;</code>
+     * @return This builder for chaining.
      */
     public Builder clearDstHostname() {
       
@@ -3672,6 +3921,8 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>string dst_hostname = 5;</code>
+     * @param value The bytes for dstHostname to set.
+     * @return This builder for chaining.
      */
     public Builder setDstHostnameBytes(
         com.google.protobuf.ByteString value) {
@@ -3694,6 +3945,7 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>.google.protobuf.UInt64Value dst_as = 6;</code>
+     * @return Whether the dstAs field is set.
      */
     public boolean hasDstAs() {
       return dstAsBuilder_ != null || dstAs_ != null;
@@ -3704,6 +3956,7 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>.google.protobuf.UInt64Value dst_as = 6;</code>
+     * @return The dstAs.
      */
     public com.google.protobuf.UInt64Value getDstAs() {
       if (dstAsBuilder_ == null) {
@@ -3847,6 +4100,7 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>.google.protobuf.UInt32Value dst_mask_len = 7;</code>
+     * @return Whether the dstMaskLen field is set.
      */
     public boolean hasDstMaskLen() {
       return dstMaskLenBuilder_ != null || dstMaskLen_ != null;
@@ -3857,6 +4111,7 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>.google.protobuf.UInt32Value dst_mask_len = 7;</code>
+     * @return The dstMaskLen.
      */
     public com.google.protobuf.UInt32Value getDstMaskLen() {
       if (dstMaskLenBuilder_ == null) {
@@ -4000,6 +4255,7 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>.google.protobuf.UInt32Value dst_port = 8;</code>
+     * @return Whether the dstPort field is set.
      */
     public boolean hasDstPort() {
       return dstPortBuilder_ != null || dstPort_ != null;
@@ -4010,6 +4266,7 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>.google.protobuf.UInt32Value dst_port = 8;</code>
+     * @return The dstPort.
      */
     public com.google.protobuf.UInt32Value getDstPort() {
       if (dstPortBuilder_ == null) {
@@ -4153,6 +4410,7 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>.google.protobuf.UInt32Value engine_id = 9;</code>
+     * @return Whether the engineId field is set.
      */
     public boolean hasEngineId() {
       return engineIdBuilder_ != null || engineId_ != null;
@@ -4163,6 +4421,7 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>.google.protobuf.UInt32Value engine_id = 9;</code>
+     * @return The engineId.
      */
     public com.google.protobuf.UInt32Value getEngineId() {
       if (engineIdBuilder_ == null) {
@@ -4306,6 +4565,7 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>.google.protobuf.UInt32Value engine_type = 10;</code>
+     * @return Whether the engineType field is set.
      */
     public boolean hasEngineType() {
       return engineTypeBuilder_ != null || engineType_ != null;
@@ -4316,6 +4576,7 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>.google.protobuf.UInt32Value engine_type = 10;</code>
+     * @return The engineType.
      */
     public com.google.protobuf.UInt32Value getEngineType() {
       if (engineTypeBuilder_ == null) {
@@ -4459,6 +4720,7 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>.google.protobuf.UInt64Value delta_switched = 11;</code>
+     * @return Whether the deltaSwitched field is set.
      */
     public boolean hasDeltaSwitched() {
       return deltaSwitchedBuilder_ != null || deltaSwitched_ != null;
@@ -4469,6 +4731,7 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>.google.protobuf.UInt64Value delta_switched = 11;</code>
+     * @return The deltaSwitched.
      */
     public com.google.protobuf.UInt64Value getDeltaSwitched() {
       if (deltaSwitchedBuilder_ == null) {
@@ -4612,6 +4875,7 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>.google.protobuf.UInt64Value first_switched = 12;</code>
+     * @return Whether the firstSwitched field is set.
      */
     public boolean hasFirstSwitched() {
       return firstSwitchedBuilder_ != null || firstSwitched_ != null;
@@ -4622,6 +4886,7 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>.google.protobuf.UInt64Value first_switched = 12;</code>
+     * @return The firstSwitched.
      */
     public com.google.protobuf.UInt64Value getFirstSwitched() {
       if (firstSwitchedBuilder_ == null) {
@@ -4765,6 +5030,7 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>.google.protobuf.UInt64Value last_switched = 13;</code>
+     * @return Whether the lastSwitched field is set.
      */
     public boolean hasLastSwitched() {
       return lastSwitchedBuilder_ != null || lastSwitched_ != null;
@@ -4775,6 +5041,7 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>.google.protobuf.UInt64Value last_switched = 13;</code>
+     * @return The lastSwitched.
      */
     public com.google.protobuf.UInt64Value getLastSwitched() {
       if (lastSwitchedBuilder_ == null) {
@@ -4918,6 +5185,7 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>.google.protobuf.UInt32Value num_flow_records = 14;</code>
+     * @return Whether the numFlowRecords field is set.
      */
     public boolean hasNumFlowRecords() {
       return numFlowRecordsBuilder_ != null || numFlowRecords_ != null;
@@ -4928,6 +5196,7 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>.google.protobuf.UInt32Value num_flow_records = 14;</code>
+     * @return The numFlowRecords.
      */
     public com.google.protobuf.UInt32Value getNumFlowRecords() {
       if (numFlowRecordsBuilder_ == null) {
@@ -5071,6 +5340,7 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>.google.protobuf.UInt64Value num_packets = 15;</code>
+     * @return Whether the numPackets field is set.
      */
     public boolean hasNumPackets() {
       return numPacketsBuilder_ != null || numPackets_ != null;
@@ -5081,6 +5351,7 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>.google.protobuf.UInt64Value num_packets = 15;</code>
+     * @return The numPackets.
      */
     public com.google.protobuf.UInt64Value getNumPackets() {
       if (numPacketsBuilder_ == null) {
@@ -5224,6 +5495,7 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>.google.protobuf.UInt64Value flow_seq_num = 16;</code>
+     * @return Whether the flowSeqNum field is set.
      */
     public boolean hasFlowSeqNum() {
       return flowSeqNumBuilder_ != null || flowSeqNum_ != null;
@@ -5234,6 +5506,7 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>.google.protobuf.UInt64Value flow_seq_num = 16;</code>
+     * @return The flowSeqNum.
      */
     public com.google.protobuf.UInt64Value getFlowSeqNum() {
       if (flowSeqNumBuilder_ == null) {
@@ -5377,6 +5650,7 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>.google.protobuf.UInt32Value input_snmp_ifindex = 17;</code>
+     * @return Whether the inputSnmpIfindex field is set.
      */
     public boolean hasInputSnmpIfindex() {
       return inputSnmpIfindexBuilder_ != null || inputSnmpIfindex_ != null;
@@ -5387,6 +5661,7 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>.google.protobuf.UInt32Value input_snmp_ifindex = 17;</code>
+     * @return The inputSnmpIfindex.
      */
     public com.google.protobuf.UInt32Value getInputSnmpIfindex() {
       if (inputSnmpIfindexBuilder_ == null) {
@@ -5530,6 +5805,7 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>.google.protobuf.UInt32Value output_snmp_ifindex = 18;</code>
+     * @return Whether the outputSnmpIfindex field is set.
      */
     public boolean hasOutputSnmpIfindex() {
       return outputSnmpIfindexBuilder_ != null || outputSnmpIfindex_ != null;
@@ -5540,6 +5816,7 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>.google.protobuf.UInt32Value output_snmp_ifindex = 18;</code>
+     * @return The outputSnmpIfindex.
      */
     public com.google.protobuf.UInt32Value getOutputSnmpIfindex() {
       if (outputSnmpIfindexBuilder_ == null) {
@@ -5683,6 +5960,7 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>.google.protobuf.UInt32Value ip_protocol_version = 19;</code>
+     * @return Whether the ipProtocolVersion field is set.
      */
     public boolean hasIpProtocolVersion() {
       return ipProtocolVersionBuilder_ != null || ipProtocolVersion_ != null;
@@ -5693,6 +5971,7 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>.google.protobuf.UInt32Value ip_protocol_version = 19;</code>
+     * @return The ipProtocolVersion.
      */
     public com.google.protobuf.UInt32Value getIpProtocolVersion() {
       if (ipProtocolVersionBuilder_ == null) {
@@ -5834,6 +6113,7 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>string next_hop_address = 20;</code>
+     * @return The nextHopAddress.
      */
     public java.lang.String getNextHopAddress() {
       java.lang.Object ref = nextHopAddress_;
@@ -5853,6 +6133,7 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>string next_hop_address = 20;</code>
+     * @return The bytes for nextHopAddress.
      */
     public com.google.protobuf.ByteString
         getNextHopAddressBytes() {
@@ -5873,6 +6154,8 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>string next_hop_address = 20;</code>
+     * @param value The nextHopAddress to set.
+     * @return This builder for chaining.
      */
     public Builder setNextHopAddress(
         java.lang.String value) {
@@ -5890,6 +6173,7 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>string next_hop_address = 20;</code>
+     * @return This builder for chaining.
      */
     public Builder clearNextHopAddress() {
       
@@ -5903,6 +6187,8 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>string next_hop_address = 20;</code>
+     * @param value The bytes for nextHopAddress to set.
+     * @return This builder for chaining.
      */
     public Builder setNextHopAddressBytes(
         com.google.protobuf.ByteString value) {
@@ -5923,6 +6209,7 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>string next_hop_hostname = 21;</code>
+     * @return The nextHopHostname.
      */
     public java.lang.String getNextHopHostname() {
       java.lang.Object ref = nextHopHostname_;
@@ -5942,6 +6229,7 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>string next_hop_hostname = 21;</code>
+     * @return The bytes for nextHopHostname.
      */
     public com.google.protobuf.ByteString
         getNextHopHostnameBytes() {
@@ -5962,6 +6250,8 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>string next_hop_hostname = 21;</code>
+     * @param value The nextHopHostname to set.
+     * @return This builder for chaining.
      */
     public Builder setNextHopHostname(
         java.lang.String value) {
@@ -5979,6 +6269,7 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>string next_hop_hostname = 21;</code>
+     * @return This builder for chaining.
      */
     public Builder clearNextHopHostname() {
       
@@ -5992,6 +6283,8 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>string next_hop_hostname = 21;</code>
+     * @param value The bytes for nextHopHostname to set.
+     * @return This builder for chaining.
      */
     public Builder setNextHopHostnameBytes(
         com.google.protobuf.ByteString value) {
@@ -6014,6 +6307,7 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>.google.protobuf.UInt32Value protocol = 22;</code>
+     * @return Whether the protocol field is set.
      */
     public boolean hasProtocol() {
       return protocolBuilder_ != null || protocol_ != null;
@@ -6024,6 +6318,7 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>.google.protobuf.UInt32Value protocol = 22;</code>
+     * @return The protocol.
      */
     public com.google.protobuf.UInt32Value getProtocol() {
       if (protocolBuilder_ == null) {
@@ -6165,8 +6460,9 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>.SamplingAlgorithm sampling_algorithm = 23;</code>
+     * @return The enum numeric value on the wire for samplingAlgorithm.
      */
-    public int getSamplingAlgorithmValue() {
+    @java.lang.Override public int getSamplingAlgorithmValue() {
       return samplingAlgorithm_;
     }
     /**
@@ -6175,8 +6471,11 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>.SamplingAlgorithm sampling_algorithm = 23;</code>
+     * @param value The enum numeric value on the wire for samplingAlgorithm to set.
+     * @return This builder for chaining.
      */
     public Builder setSamplingAlgorithmValue(int value) {
+      
       samplingAlgorithm_ = value;
       onChanged();
       return this;
@@ -6187,7 +6486,9 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>.SamplingAlgorithm sampling_algorithm = 23;</code>
+     * @return The samplingAlgorithm.
      */
+    @java.lang.Override
     public org.opennms.netmgt.flows.persistence.model.SamplingAlgorithm getSamplingAlgorithm() {
       @SuppressWarnings("deprecation")
       org.opennms.netmgt.flows.persistence.model.SamplingAlgorithm result = org.opennms.netmgt.flows.persistence.model.SamplingAlgorithm.valueOf(samplingAlgorithm_);
@@ -6199,6 +6500,8 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>.SamplingAlgorithm sampling_algorithm = 23;</code>
+     * @param value The samplingAlgorithm to set.
+     * @return This builder for chaining.
      */
     public Builder setSamplingAlgorithm(org.opennms.netmgt.flows.persistence.model.SamplingAlgorithm value) {
       if (value == null) {
@@ -6215,6 +6518,7 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>.SamplingAlgorithm sampling_algorithm = 23;</code>
+     * @return This builder for chaining.
      */
     public Builder clearSamplingAlgorithm() {
       
@@ -6232,6 +6536,7 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>.google.protobuf.DoubleValue sampling_interval = 24;</code>
+     * @return Whether the samplingInterval field is set.
      */
     public boolean hasSamplingInterval() {
       return samplingIntervalBuilder_ != null || samplingInterval_ != null;
@@ -6242,6 +6547,7 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>.google.protobuf.DoubleValue sampling_interval = 24;</code>
+     * @return The samplingInterval.
      */
     public com.google.protobuf.DoubleValue getSamplingInterval() {
       if (samplingIntervalBuilder_ == null) {
@@ -6383,6 +6689,7 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>string src_address = 26;</code>
+     * @return The srcAddress.
      */
     public java.lang.String getSrcAddress() {
       java.lang.Object ref = srcAddress_;
@@ -6402,6 +6709,7 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>string src_address = 26;</code>
+     * @return The bytes for srcAddress.
      */
     public com.google.protobuf.ByteString
         getSrcAddressBytes() {
@@ -6422,6 +6730,8 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>string src_address = 26;</code>
+     * @param value The srcAddress to set.
+     * @return This builder for chaining.
      */
     public Builder setSrcAddress(
         java.lang.String value) {
@@ -6439,6 +6749,7 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>string src_address = 26;</code>
+     * @return This builder for chaining.
      */
     public Builder clearSrcAddress() {
       
@@ -6452,6 +6763,8 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>string src_address = 26;</code>
+     * @param value The bytes for srcAddress to set.
+     * @return This builder for chaining.
      */
     public Builder setSrcAddressBytes(
         com.google.protobuf.ByteString value) {
@@ -6472,6 +6785,7 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>string src_hostname = 27;</code>
+     * @return The srcHostname.
      */
     public java.lang.String getSrcHostname() {
       java.lang.Object ref = srcHostname_;
@@ -6491,6 +6805,7 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>string src_hostname = 27;</code>
+     * @return The bytes for srcHostname.
      */
     public com.google.protobuf.ByteString
         getSrcHostnameBytes() {
@@ -6511,6 +6826,8 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>string src_hostname = 27;</code>
+     * @param value The srcHostname to set.
+     * @return This builder for chaining.
      */
     public Builder setSrcHostname(
         java.lang.String value) {
@@ -6528,6 +6845,7 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>string src_hostname = 27;</code>
+     * @return This builder for chaining.
      */
     public Builder clearSrcHostname() {
       
@@ -6541,6 +6859,8 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>string src_hostname = 27;</code>
+     * @param value The bytes for srcHostname to set.
+     * @return This builder for chaining.
      */
     public Builder setSrcHostnameBytes(
         com.google.protobuf.ByteString value) {
@@ -6563,6 +6883,7 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>.google.protobuf.UInt64Value src_as = 28;</code>
+     * @return Whether the srcAs field is set.
      */
     public boolean hasSrcAs() {
       return srcAsBuilder_ != null || srcAs_ != null;
@@ -6573,6 +6894,7 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>.google.protobuf.UInt64Value src_as = 28;</code>
+     * @return The srcAs.
      */
     public com.google.protobuf.UInt64Value getSrcAs() {
       if (srcAsBuilder_ == null) {
@@ -6716,6 +7038,7 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>.google.protobuf.UInt32Value src_mask_len = 29;</code>
+     * @return Whether the srcMaskLen field is set.
      */
     public boolean hasSrcMaskLen() {
       return srcMaskLenBuilder_ != null || srcMaskLen_ != null;
@@ -6726,6 +7049,7 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>.google.protobuf.UInt32Value src_mask_len = 29;</code>
+     * @return The srcMaskLen.
      */
     public com.google.protobuf.UInt32Value getSrcMaskLen() {
       if (srcMaskLenBuilder_ == null) {
@@ -6869,6 +7193,7 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>.google.protobuf.UInt32Value src_port = 30;</code>
+     * @return Whether the srcPort field is set.
      */
     public boolean hasSrcPort() {
       return srcPortBuilder_ != null || srcPort_ != null;
@@ -6879,6 +7204,7 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>.google.protobuf.UInt32Value src_port = 30;</code>
+     * @return The srcPort.
      */
     public com.google.protobuf.UInt32Value getSrcPort() {
       if (srcPortBuilder_ == null) {
@@ -7022,6 +7348,7 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>.google.protobuf.UInt32Value tcp_flags = 31;</code>
+     * @return Whether the tcpFlags field is set.
      */
     public boolean hasTcpFlags() {
       return tcpFlagsBuilder_ != null || tcpFlags_ != null;
@@ -7032,6 +7359,7 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>.google.protobuf.UInt32Value tcp_flags = 31;</code>
+     * @return The tcpFlags.
      */
     public com.google.protobuf.UInt32Value getTcpFlags() {
       if (tcpFlagsBuilder_ == null) {
@@ -7175,6 +7503,7 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>.google.protobuf.UInt32Value tos = 32;</code>
+     * @return Whether the tos field is set.
      */
     public boolean hasTos() {
       return tosBuilder_ != null || tos_ != null;
@@ -7185,6 +7514,7 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>.google.protobuf.UInt32Value tos = 32;</code>
+     * @return The tos.
      */
     public com.google.protobuf.UInt32Value getTos() {
       if (tosBuilder_ == null) {
@@ -7326,8 +7656,9 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>.NetflowVersion netflow_version = 33;</code>
+     * @return The enum numeric value on the wire for netflowVersion.
      */
-    public int getNetflowVersionValue() {
+    @java.lang.Override public int getNetflowVersionValue() {
       return netflowVersion_;
     }
     /**
@@ -7336,8 +7667,11 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>.NetflowVersion netflow_version = 33;</code>
+     * @param value The enum numeric value on the wire for netflowVersion to set.
+     * @return This builder for chaining.
      */
     public Builder setNetflowVersionValue(int value) {
+      
       netflowVersion_ = value;
       onChanged();
       return this;
@@ -7348,7 +7682,9 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>.NetflowVersion netflow_version = 33;</code>
+     * @return The netflowVersion.
      */
+    @java.lang.Override
     public org.opennms.netmgt.flows.persistence.model.NetflowVersion getNetflowVersion() {
       @SuppressWarnings("deprecation")
       org.opennms.netmgt.flows.persistence.model.NetflowVersion result = org.opennms.netmgt.flows.persistence.model.NetflowVersion.valueOf(netflowVersion_);
@@ -7360,6 +7696,8 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>.NetflowVersion netflow_version = 33;</code>
+     * @param value The netflowVersion to set.
+     * @return This builder for chaining.
      */
     public Builder setNetflowVersion(org.opennms.netmgt.flows.persistence.model.NetflowVersion value) {
       if (value == null) {
@@ -7376,6 +7714,7 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>.NetflowVersion netflow_version = 33;</code>
+     * @return This builder for chaining.
      */
     public Builder clearNetflowVersion() {
       
@@ -7391,6 +7730,7 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>string vlan = 34;</code>
+     * @return The vlan.
      */
     public java.lang.String getVlan() {
       java.lang.Object ref = vlan_;
@@ -7410,6 +7750,7 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>string vlan = 34;</code>
+     * @return The bytes for vlan.
      */
     public com.google.protobuf.ByteString
         getVlanBytes() {
@@ -7430,6 +7771,8 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>string vlan = 34;</code>
+     * @param value The vlan to set.
+     * @return This builder for chaining.
      */
     public Builder setVlan(
         java.lang.String value) {
@@ -7447,6 +7790,7 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>string vlan = 34;</code>
+     * @return This builder for chaining.
      */
     public Builder clearVlan() {
       
@@ -7460,6 +7804,8 @@ private static final long serialVersionUID = 0L;
      * </pre>
      *
      * <code>string vlan = 34;</code>
+     * @param value The bytes for vlan to set.
+     * @return This builder for chaining.
      */
     public Builder setVlanBytes(
         com.google.protobuf.ByteString value) {
@@ -7478,12 +7824,14 @@ private static final long serialVersionUID = 0L;
         org.opennms.netmgt.flows.persistence.model.NodeInfo, org.opennms.netmgt.flows.persistence.model.NodeInfo.Builder, org.opennms.netmgt.flows.persistence.model.NodeInfoOrBuilder> srcNodeBuilder_;
     /**
      * <code>.NodeInfo src_node = 35;</code>
+     * @return Whether the srcNode field is set.
      */
     public boolean hasSrcNode() {
       return srcNodeBuilder_ != null || srcNode_ != null;
     }
     /**
      * <code>.NodeInfo src_node = 35;</code>
+     * @return The srcNode.
      */
     public org.opennms.netmgt.flows.persistence.model.NodeInfo getSrcNode() {
       if (srcNodeBuilder_ == null) {
@@ -7595,12 +7943,14 @@ private static final long serialVersionUID = 0L;
         org.opennms.netmgt.flows.persistence.model.NodeInfo, org.opennms.netmgt.flows.persistence.model.NodeInfo.Builder, org.opennms.netmgt.flows.persistence.model.NodeInfoOrBuilder> exporterNodeBuilder_;
     /**
      * <code>.NodeInfo exporter_node = 36;</code>
+     * @return Whether the exporterNode field is set.
      */
     public boolean hasExporterNode() {
       return exporterNodeBuilder_ != null || exporterNode_ != null;
     }
     /**
      * <code>.NodeInfo exporter_node = 36;</code>
+     * @return The exporterNode.
      */
     public org.opennms.netmgt.flows.persistence.model.NodeInfo getExporterNode() {
       if (exporterNodeBuilder_ == null) {
@@ -7712,12 +8062,14 @@ private static final long serialVersionUID = 0L;
         org.opennms.netmgt.flows.persistence.model.NodeInfo, org.opennms.netmgt.flows.persistence.model.NodeInfo.Builder, org.opennms.netmgt.flows.persistence.model.NodeInfoOrBuilder> destNodeBuilder_;
     /**
      * <code>.NodeInfo dest_node = 37;</code>
+     * @return Whether the destNode field is set.
      */
     public boolean hasDestNode() {
       return destNodeBuilder_ != null || destNode_ != null;
     }
     /**
      * <code>.NodeInfo dest_node = 37;</code>
+     * @return The destNode.
      */
     public org.opennms.netmgt.flows.persistence.model.NodeInfo getDestNode() {
       if (destNodeBuilder_ == null) {
@@ -7827,6 +8179,7 @@ private static final long serialVersionUID = 0L;
     private java.lang.Object application_ = "";
     /**
      * <code>string application = 38;</code>
+     * @return The application.
      */
     public java.lang.String getApplication() {
       java.lang.Object ref = application_;
@@ -7842,6 +8195,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <code>string application = 38;</code>
+     * @return The bytes for application.
      */
     public com.google.protobuf.ByteString
         getApplicationBytes() {
@@ -7858,6 +8212,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <code>string application = 38;</code>
+     * @param value The application to set.
+     * @return This builder for chaining.
      */
     public Builder setApplication(
         java.lang.String value) {
@@ -7871,6 +8227,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <code>string application = 38;</code>
+     * @return This builder for chaining.
      */
     public Builder clearApplication() {
       
@@ -7880,6 +8237,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <code>string application = 38;</code>
+     * @param value The bytes for application to set.
+     * @return This builder for chaining.
      */
     public Builder setApplicationBytes(
         com.google.protobuf.ByteString value) {
@@ -7896,6 +8255,7 @@ private static final long serialVersionUID = 0L;
     private java.lang.Object host_ = "";
     /**
      * <code>string host = 39;</code>
+     * @return The host.
      */
     public java.lang.String getHost() {
       java.lang.Object ref = host_;
@@ -7911,6 +8271,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <code>string host = 39;</code>
+     * @return The bytes for host.
      */
     public com.google.protobuf.ByteString
         getHostBytes() {
@@ -7927,6 +8288,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <code>string host = 39;</code>
+     * @param value The host to set.
+     * @return This builder for chaining.
      */
     public Builder setHost(
         java.lang.String value) {
@@ -7940,6 +8303,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <code>string host = 39;</code>
+     * @return This builder for chaining.
      */
     public Builder clearHost() {
       
@@ -7949,6 +8313,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <code>string host = 39;</code>
+     * @param value The bytes for host to set.
+     * @return This builder for chaining.
      */
     public Builder setHostBytes(
         com.google.protobuf.ByteString value) {
@@ -7965,6 +8331,7 @@ private static final long serialVersionUID = 0L;
     private java.lang.Object location_ = "";
     /**
      * <code>string location = 40;</code>
+     * @return The location.
      */
     public java.lang.String getLocation() {
       java.lang.Object ref = location_;
@@ -7980,6 +8347,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <code>string location = 40;</code>
+     * @return The bytes for location.
      */
     public com.google.protobuf.ByteString
         getLocationBytes() {
@@ -7996,6 +8364,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <code>string location = 40;</code>
+     * @param value The location to set.
+     * @return This builder for chaining.
      */
     public Builder setLocation(
         java.lang.String value) {
@@ -8009,6 +8379,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <code>string location = 40;</code>
+     * @return This builder for chaining.
      */
     public Builder clearLocation() {
       
@@ -8018,6 +8389,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <code>string location = 40;</code>
+     * @param value The bytes for location to set.
+     * @return This builder for chaining.
      */
     public Builder setLocationBytes(
         com.google.protobuf.ByteString value) {
@@ -8034,21 +8407,27 @@ private static final long serialVersionUID = 0L;
     private int srcLocality_ = 0;
     /**
      * <code>.Locality src_locality = 41;</code>
+     * @return The enum numeric value on the wire for srcLocality.
      */
-    public int getSrcLocalityValue() {
+    @java.lang.Override public int getSrcLocalityValue() {
       return srcLocality_;
     }
     /**
      * <code>.Locality src_locality = 41;</code>
+     * @param value The enum numeric value on the wire for srcLocality to set.
+     * @return This builder for chaining.
      */
     public Builder setSrcLocalityValue(int value) {
+      
       srcLocality_ = value;
       onChanged();
       return this;
     }
     /**
      * <code>.Locality src_locality = 41;</code>
+     * @return The srcLocality.
      */
+    @java.lang.Override
     public org.opennms.netmgt.flows.persistence.model.Locality getSrcLocality() {
       @SuppressWarnings("deprecation")
       org.opennms.netmgt.flows.persistence.model.Locality result = org.opennms.netmgt.flows.persistence.model.Locality.valueOf(srcLocality_);
@@ -8056,6 +8435,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <code>.Locality src_locality = 41;</code>
+     * @param value The srcLocality to set.
+     * @return This builder for chaining.
      */
     public Builder setSrcLocality(org.opennms.netmgt.flows.persistence.model.Locality value) {
       if (value == null) {
@@ -8068,6 +8449,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <code>.Locality src_locality = 41;</code>
+     * @return This builder for chaining.
      */
     public Builder clearSrcLocality() {
       
@@ -8079,21 +8461,27 @@ private static final long serialVersionUID = 0L;
     private int dstLocality_ = 0;
     /**
      * <code>.Locality dst_locality = 42;</code>
+     * @return The enum numeric value on the wire for dstLocality.
      */
-    public int getDstLocalityValue() {
+    @java.lang.Override public int getDstLocalityValue() {
       return dstLocality_;
     }
     /**
      * <code>.Locality dst_locality = 42;</code>
+     * @param value The enum numeric value on the wire for dstLocality to set.
+     * @return This builder for chaining.
      */
     public Builder setDstLocalityValue(int value) {
+      
       dstLocality_ = value;
       onChanged();
       return this;
     }
     /**
      * <code>.Locality dst_locality = 42;</code>
+     * @return The dstLocality.
      */
+    @java.lang.Override
     public org.opennms.netmgt.flows.persistence.model.Locality getDstLocality() {
       @SuppressWarnings("deprecation")
       org.opennms.netmgt.flows.persistence.model.Locality result = org.opennms.netmgt.flows.persistence.model.Locality.valueOf(dstLocality_);
@@ -8101,6 +8489,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <code>.Locality dst_locality = 42;</code>
+     * @param value The dstLocality to set.
+     * @return This builder for chaining.
      */
     public Builder setDstLocality(org.opennms.netmgt.flows.persistence.model.Locality value) {
       if (value == null) {
@@ -8113,6 +8503,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <code>.Locality dst_locality = 42;</code>
+     * @return This builder for chaining.
      */
     public Builder clearDstLocality() {
       
@@ -8124,21 +8515,27 @@ private static final long serialVersionUID = 0L;
     private int flowLocality_ = 0;
     /**
      * <code>.Locality flow_locality = 43;</code>
+     * @return The enum numeric value on the wire for flowLocality.
      */
-    public int getFlowLocalityValue() {
+    @java.lang.Override public int getFlowLocalityValue() {
       return flowLocality_;
     }
     /**
      * <code>.Locality flow_locality = 43;</code>
+     * @param value The enum numeric value on the wire for flowLocality to set.
+     * @return This builder for chaining.
      */
     public Builder setFlowLocalityValue(int value) {
+      
       flowLocality_ = value;
       onChanged();
       return this;
     }
     /**
      * <code>.Locality flow_locality = 43;</code>
+     * @return The flowLocality.
      */
+    @java.lang.Override
     public org.opennms.netmgt.flows.persistence.model.Locality getFlowLocality() {
       @SuppressWarnings("deprecation")
       org.opennms.netmgt.flows.persistence.model.Locality result = org.opennms.netmgt.flows.persistence.model.Locality.valueOf(flowLocality_);
@@ -8146,6 +8543,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <code>.Locality flow_locality = 43;</code>
+     * @param value The flowLocality to set.
+     * @return This builder for chaining.
      */
     public Builder setFlowLocality(org.opennms.netmgt.flows.persistence.model.Locality value) {
       if (value == null) {
@@ -8158,6 +8557,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <code>.Locality flow_locality = 43;</code>
+     * @return This builder for chaining.
      */
     public Builder clearFlowLocality() {
       
@@ -8169,6 +8569,7 @@ private static final long serialVersionUID = 0L;
     private java.lang.Object convoKey_ = "";
     /**
      * <code>string convo_key = 44;</code>
+     * @return The convoKey.
      */
     public java.lang.String getConvoKey() {
       java.lang.Object ref = convoKey_;
@@ -8184,6 +8585,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <code>string convo_key = 44;</code>
+     * @return The bytes for convoKey.
      */
     public com.google.protobuf.ByteString
         getConvoKeyBytes() {
@@ -8200,6 +8602,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <code>string convo_key = 44;</code>
+     * @param value The convoKey to set.
+     * @return This builder for chaining.
      */
     public Builder setConvoKey(
         java.lang.String value) {
@@ -8213,6 +8617,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <code>string convo_key = 44;</code>
+     * @return This builder for chaining.
      */
     public Builder clearConvoKey() {
       
@@ -8222,6 +8627,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <code>string convo_key = 44;</code>
+     * @param value The bytes for convoKey to set.
+     * @return This builder for chaining.
      */
     public Builder setConvoKeyBytes(
         com.google.protobuf.ByteString value) {
@@ -8231,6 +8638,49 @@ private static final long serialVersionUID = 0L;
   checkByteStringIsUtf8(value);
       
       convoKey_ = value;
+      onChanged();
+      return this;
+    }
+
+    private long clockCorrection_ ;
+    /**
+     * <pre>
+     * Applied clock correction im milliseconds.
+     * </pre>
+     *
+     * <code>uint64 clock_correction = 45;</code>
+     * @return The clockCorrection.
+     */
+    @java.lang.Override
+    public long getClockCorrection() {
+      return clockCorrection_;
+    }
+    /**
+     * <pre>
+     * Applied clock correction im milliseconds.
+     * </pre>
+     *
+     * <code>uint64 clock_correction = 45;</code>
+     * @param value The clockCorrection to set.
+     * @return This builder for chaining.
+     */
+    public Builder setClockCorrection(long value) {
+      
+      clockCorrection_ = value;
+      onChanged();
+      return this;
+    }
+    /**
+     * <pre>
+     * Applied clock correction im milliseconds.
+     * </pre>
+     *
+     * <code>uint64 clock_correction = 45;</code>
+     * @return This builder for chaining.
+     */
+    public Builder clearClockCorrection() {
+      
+      clockCorrection_ = 0L;
       onChanged();
       return this;
     }

--- a/features/flows/kafka-persistence/src/main/java/org/opennms/netmgt/flows/persistence/model/FlowDocumentOrBuilder.java
+++ b/features/flows/kafka-persistence/src/main/java/org/opennms/netmgt/flows/persistence/model/FlowDocumentOrBuilder.java
@@ -41,6 +41,7 @@ public interface FlowDocumentOrBuilder extends
    * </pre>
    *
    * <code>uint64 timestamp = 1;</code>
+   * @return The timestamp.
    */
   long getTimestamp();
 
@@ -50,6 +51,7 @@ public interface FlowDocumentOrBuilder extends
    * </pre>
    *
    * <code>.google.protobuf.UInt64Value num_bytes = 2;</code>
+   * @return Whether the numBytes field is set.
    */
   boolean hasNumBytes();
   /**
@@ -58,6 +60,7 @@ public interface FlowDocumentOrBuilder extends
    * </pre>
    *
    * <code>.google.protobuf.UInt64Value num_bytes = 2;</code>
+   * @return The numBytes.
    */
   com.google.protobuf.UInt64Value getNumBytes();
   /**
@@ -75,6 +78,7 @@ public interface FlowDocumentOrBuilder extends
    * </pre>
    *
    * <code>.Direction direction = 3;</code>
+   * @return The enum numeric value on the wire for direction.
    */
   int getDirectionValue();
   /**
@@ -83,6 +87,7 @@ public interface FlowDocumentOrBuilder extends
    * </pre>
    *
    * <code>.Direction direction = 3;</code>
+   * @return The direction.
    */
   org.opennms.netmgt.flows.persistence.model.Direction getDirection();
 
@@ -92,6 +97,7 @@ public interface FlowDocumentOrBuilder extends
    * </pre>
    *
    * <code>string dst_address = 4;</code>
+   * @return The dstAddress.
    */
   java.lang.String getDstAddress();
   /**
@@ -100,6 +106,7 @@ public interface FlowDocumentOrBuilder extends
    * </pre>
    *
    * <code>string dst_address = 4;</code>
+   * @return The bytes for dstAddress.
    */
   com.google.protobuf.ByteString
       getDstAddressBytes();
@@ -110,6 +117,7 @@ public interface FlowDocumentOrBuilder extends
    * </pre>
    *
    * <code>string dst_hostname = 5;</code>
+   * @return The dstHostname.
    */
   java.lang.String getDstHostname();
   /**
@@ -118,6 +126,7 @@ public interface FlowDocumentOrBuilder extends
    * </pre>
    *
    * <code>string dst_hostname = 5;</code>
+   * @return The bytes for dstHostname.
    */
   com.google.protobuf.ByteString
       getDstHostnameBytes();
@@ -128,6 +137,7 @@ public interface FlowDocumentOrBuilder extends
    * </pre>
    *
    * <code>.google.protobuf.UInt64Value dst_as = 6;</code>
+   * @return Whether the dstAs field is set.
    */
   boolean hasDstAs();
   /**
@@ -136,6 +146,7 @@ public interface FlowDocumentOrBuilder extends
    * </pre>
    *
    * <code>.google.protobuf.UInt64Value dst_as = 6;</code>
+   * @return The dstAs.
    */
   com.google.protobuf.UInt64Value getDstAs();
   /**
@@ -153,6 +164,7 @@ public interface FlowDocumentOrBuilder extends
    * </pre>
    *
    * <code>.google.protobuf.UInt32Value dst_mask_len = 7;</code>
+   * @return Whether the dstMaskLen field is set.
    */
   boolean hasDstMaskLen();
   /**
@@ -161,6 +173,7 @@ public interface FlowDocumentOrBuilder extends
    * </pre>
    *
    * <code>.google.protobuf.UInt32Value dst_mask_len = 7;</code>
+   * @return The dstMaskLen.
    */
   com.google.protobuf.UInt32Value getDstMaskLen();
   /**
@@ -178,6 +191,7 @@ public interface FlowDocumentOrBuilder extends
    * </pre>
    *
    * <code>.google.protobuf.UInt32Value dst_port = 8;</code>
+   * @return Whether the dstPort field is set.
    */
   boolean hasDstPort();
   /**
@@ -186,6 +200,7 @@ public interface FlowDocumentOrBuilder extends
    * </pre>
    *
    * <code>.google.protobuf.UInt32Value dst_port = 8;</code>
+   * @return The dstPort.
    */
   com.google.protobuf.UInt32Value getDstPort();
   /**
@@ -203,6 +218,7 @@ public interface FlowDocumentOrBuilder extends
    * </pre>
    *
    * <code>.google.protobuf.UInt32Value engine_id = 9;</code>
+   * @return Whether the engineId field is set.
    */
   boolean hasEngineId();
   /**
@@ -211,6 +227,7 @@ public interface FlowDocumentOrBuilder extends
    * </pre>
    *
    * <code>.google.protobuf.UInt32Value engine_id = 9;</code>
+   * @return The engineId.
    */
   com.google.protobuf.UInt32Value getEngineId();
   /**
@@ -228,6 +245,7 @@ public interface FlowDocumentOrBuilder extends
    * </pre>
    *
    * <code>.google.protobuf.UInt32Value engine_type = 10;</code>
+   * @return Whether the engineType field is set.
    */
   boolean hasEngineType();
   /**
@@ -236,6 +254,7 @@ public interface FlowDocumentOrBuilder extends
    * </pre>
    *
    * <code>.google.protobuf.UInt32Value engine_type = 10;</code>
+   * @return The engineType.
    */
   com.google.protobuf.UInt32Value getEngineType();
   /**
@@ -253,6 +272,7 @@ public interface FlowDocumentOrBuilder extends
    * </pre>
    *
    * <code>.google.protobuf.UInt64Value delta_switched = 11;</code>
+   * @return Whether the deltaSwitched field is set.
    */
   boolean hasDeltaSwitched();
   /**
@@ -261,6 +281,7 @@ public interface FlowDocumentOrBuilder extends
    * </pre>
    *
    * <code>.google.protobuf.UInt64Value delta_switched = 11;</code>
+   * @return The deltaSwitched.
    */
   com.google.protobuf.UInt64Value getDeltaSwitched();
   /**
@@ -278,6 +299,7 @@ public interface FlowDocumentOrBuilder extends
    * </pre>
    *
    * <code>.google.protobuf.UInt64Value first_switched = 12;</code>
+   * @return Whether the firstSwitched field is set.
    */
   boolean hasFirstSwitched();
   /**
@@ -286,6 +308,7 @@ public interface FlowDocumentOrBuilder extends
    * </pre>
    *
    * <code>.google.protobuf.UInt64Value first_switched = 12;</code>
+   * @return The firstSwitched.
    */
   com.google.protobuf.UInt64Value getFirstSwitched();
   /**
@@ -303,6 +326,7 @@ public interface FlowDocumentOrBuilder extends
    * </pre>
    *
    * <code>.google.protobuf.UInt64Value last_switched = 13;</code>
+   * @return Whether the lastSwitched field is set.
    */
   boolean hasLastSwitched();
   /**
@@ -311,6 +335,7 @@ public interface FlowDocumentOrBuilder extends
    * </pre>
    *
    * <code>.google.protobuf.UInt64Value last_switched = 13;</code>
+   * @return The lastSwitched.
    */
   com.google.protobuf.UInt64Value getLastSwitched();
   /**
@@ -328,6 +353,7 @@ public interface FlowDocumentOrBuilder extends
    * </pre>
    *
    * <code>.google.protobuf.UInt32Value num_flow_records = 14;</code>
+   * @return Whether the numFlowRecords field is set.
    */
   boolean hasNumFlowRecords();
   /**
@@ -336,6 +362,7 @@ public interface FlowDocumentOrBuilder extends
    * </pre>
    *
    * <code>.google.protobuf.UInt32Value num_flow_records = 14;</code>
+   * @return The numFlowRecords.
    */
   com.google.protobuf.UInt32Value getNumFlowRecords();
   /**
@@ -353,6 +380,7 @@ public interface FlowDocumentOrBuilder extends
    * </pre>
    *
    * <code>.google.protobuf.UInt64Value num_packets = 15;</code>
+   * @return Whether the numPackets field is set.
    */
   boolean hasNumPackets();
   /**
@@ -361,6 +389,7 @@ public interface FlowDocumentOrBuilder extends
    * </pre>
    *
    * <code>.google.protobuf.UInt64Value num_packets = 15;</code>
+   * @return The numPackets.
    */
   com.google.protobuf.UInt64Value getNumPackets();
   /**
@@ -378,6 +407,7 @@ public interface FlowDocumentOrBuilder extends
    * </pre>
    *
    * <code>.google.protobuf.UInt64Value flow_seq_num = 16;</code>
+   * @return Whether the flowSeqNum field is set.
    */
   boolean hasFlowSeqNum();
   /**
@@ -386,6 +416,7 @@ public interface FlowDocumentOrBuilder extends
    * </pre>
    *
    * <code>.google.protobuf.UInt64Value flow_seq_num = 16;</code>
+   * @return The flowSeqNum.
    */
   com.google.protobuf.UInt64Value getFlowSeqNum();
   /**
@@ -403,6 +434,7 @@ public interface FlowDocumentOrBuilder extends
    * </pre>
    *
    * <code>.google.protobuf.UInt32Value input_snmp_ifindex = 17;</code>
+   * @return Whether the inputSnmpIfindex field is set.
    */
   boolean hasInputSnmpIfindex();
   /**
@@ -411,6 +443,7 @@ public interface FlowDocumentOrBuilder extends
    * </pre>
    *
    * <code>.google.protobuf.UInt32Value input_snmp_ifindex = 17;</code>
+   * @return The inputSnmpIfindex.
    */
   com.google.protobuf.UInt32Value getInputSnmpIfindex();
   /**
@@ -428,6 +461,7 @@ public interface FlowDocumentOrBuilder extends
    * </pre>
    *
    * <code>.google.protobuf.UInt32Value output_snmp_ifindex = 18;</code>
+   * @return Whether the outputSnmpIfindex field is set.
    */
   boolean hasOutputSnmpIfindex();
   /**
@@ -436,6 +470,7 @@ public interface FlowDocumentOrBuilder extends
    * </pre>
    *
    * <code>.google.protobuf.UInt32Value output_snmp_ifindex = 18;</code>
+   * @return The outputSnmpIfindex.
    */
   com.google.protobuf.UInt32Value getOutputSnmpIfindex();
   /**
@@ -453,6 +488,7 @@ public interface FlowDocumentOrBuilder extends
    * </pre>
    *
    * <code>.google.protobuf.UInt32Value ip_protocol_version = 19;</code>
+   * @return Whether the ipProtocolVersion field is set.
    */
   boolean hasIpProtocolVersion();
   /**
@@ -461,6 +497,7 @@ public interface FlowDocumentOrBuilder extends
    * </pre>
    *
    * <code>.google.protobuf.UInt32Value ip_protocol_version = 19;</code>
+   * @return The ipProtocolVersion.
    */
   com.google.protobuf.UInt32Value getIpProtocolVersion();
   /**
@@ -478,6 +515,7 @@ public interface FlowDocumentOrBuilder extends
    * </pre>
    *
    * <code>string next_hop_address = 20;</code>
+   * @return The nextHopAddress.
    */
   java.lang.String getNextHopAddress();
   /**
@@ -486,6 +524,7 @@ public interface FlowDocumentOrBuilder extends
    * </pre>
    *
    * <code>string next_hop_address = 20;</code>
+   * @return The bytes for nextHopAddress.
    */
   com.google.protobuf.ByteString
       getNextHopAddressBytes();
@@ -496,6 +535,7 @@ public interface FlowDocumentOrBuilder extends
    * </pre>
    *
    * <code>string next_hop_hostname = 21;</code>
+   * @return The nextHopHostname.
    */
   java.lang.String getNextHopHostname();
   /**
@@ -504,6 +544,7 @@ public interface FlowDocumentOrBuilder extends
    * </pre>
    *
    * <code>string next_hop_hostname = 21;</code>
+   * @return The bytes for nextHopHostname.
    */
   com.google.protobuf.ByteString
       getNextHopHostnameBytes();
@@ -514,6 +555,7 @@ public interface FlowDocumentOrBuilder extends
    * </pre>
    *
    * <code>.google.protobuf.UInt32Value protocol = 22;</code>
+   * @return Whether the protocol field is set.
    */
   boolean hasProtocol();
   /**
@@ -522,6 +564,7 @@ public interface FlowDocumentOrBuilder extends
    * </pre>
    *
    * <code>.google.protobuf.UInt32Value protocol = 22;</code>
+   * @return The protocol.
    */
   com.google.protobuf.UInt32Value getProtocol();
   /**
@@ -539,6 +582,7 @@ public interface FlowDocumentOrBuilder extends
    * </pre>
    *
    * <code>.SamplingAlgorithm sampling_algorithm = 23;</code>
+   * @return The enum numeric value on the wire for samplingAlgorithm.
    */
   int getSamplingAlgorithmValue();
   /**
@@ -547,6 +591,7 @@ public interface FlowDocumentOrBuilder extends
    * </pre>
    *
    * <code>.SamplingAlgorithm sampling_algorithm = 23;</code>
+   * @return The samplingAlgorithm.
    */
   org.opennms.netmgt.flows.persistence.model.SamplingAlgorithm getSamplingAlgorithm();
 
@@ -556,6 +601,7 @@ public interface FlowDocumentOrBuilder extends
    * </pre>
    *
    * <code>.google.protobuf.DoubleValue sampling_interval = 24;</code>
+   * @return Whether the samplingInterval field is set.
    */
   boolean hasSamplingInterval();
   /**
@@ -564,6 +610,7 @@ public interface FlowDocumentOrBuilder extends
    * </pre>
    *
    * <code>.google.protobuf.DoubleValue sampling_interval = 24;</code>
+   * @return The samplingInterval.
    */
   com.google.protobuf.DoubleValue getSamplingInterval();
   /**
@@ -581,6 +628,7 @@ public interface FlowDocumentOrBuilder extends
    * </pre>
    *
    * <code>string src_address = 26;</code>
+   * @return The srcAddress.
    */
   java.lang.String getSrcAddress();
   /**
@@ -589,6 +637,7 @@ public interface FlowDocumentOrBuilder extends
    * </pre>
    *
    * <code>string src_address = 26;</code>
+   * @return The bytes for srcAddress.
    */
   com.google.protobuf.ByteString
       getSrcAddressBytes();
@@ -599,6 +648,7 @@ public interface FlowDocumentOrBuilder extends
    * </pre>
    *
    * <code>string src_hostname = 27;</code>
+   * @return The srcHostname.
    */
   java.lang.String getSrcHostname();
   /**
@@ -607,6 +657,7 @@ public interface FlowDocumentOrBuilder extends
    * </pre>
    *
    * <code>string src_hostname = 27;</code>
+   * @return The bytes for srcHostname.
    */
   com.google.protobuf.ByteString
       getSrcHostnameBytes();
@@ -617,6 +668,7 @@ public interface FlowDocumentOrBuilder extends
    * </pre>
    *
    * <code>.google.protobuf.UInt64Value src_as = 28;</code>
+   * @return Whether the srcAs field is set.
    */
   boolean hasSrcAs();
   /**
@@ -625,6 +677,7 @@ public interface FlowDocumentOrBuilder extends
    * </pre>
    *
    * <code>.google.protobuf.UInt64Value src_as = 28;</code>
+   * @return The srcAs.
    */
   com.google.protobuf.UInt64Value getSrcAs();
   /**
@@ -642,6 +695,7 @@ public interface FlowDocumentOrBuilder extends
    * </pre>
    *
    * <code>.google.protobuf.UInt32Value src_mask_len = 29;</code>
+   * @return Whether the srcMaskLen field is set.
    */
   boolean hasSrcMaskLen();
   /**
@@ -650,6 +704,7 @@ public interface FlowDocumentOrBuilder extends
    * </pre>
    *
    * <code>.google.protobuf.UInt32Value src_mask_len = 29;</code>
+   * @return The srcMaskLen.
    */
   com.google.protobuf.UInt32Value getSrcMaskLen();
   /**
@@ -667,6 +722,7 @@ public interface FlowDocumentOrBuilder extends
    * </pre>
    *
    * <code>.google.protobuf.UInt32Value src_port = 30;</code>
+   * @return Whether the srcPort field is set.
    */
   boolean hasSrcPort();
   /**
@@ -675,6 +731,7 @@ public interface FlowDocumentOrBuilder extends
    * </pre>
    *
    * <code>.google.protobuf.UInt32Value src_port = 30;</code>
+   * @return The srcPort.
    */
   com.google.protobuf.UInt32Value getSrcPort();
   /**
@@ -692,6 +749,7 @@ public interface FlowDocumentOrBuilder extends
    * </pre>
    *
    * <code>.google.protobuf.UInt32Value tcp_flags = 31;</code>
+   * @return Whether the tcpFlags field is set.
    */
   boolean hasTcpFlags();
   /**
@@ -700,6 +758,7 @@ public interface FlowDocumentOrBuilder extends
    * </pre>
    *
    * <code>.google.protobuf.UInt32Value tcp_flags = 31;</code>
+   * @return The tcpFlags.
    */
   com.google.protobuf.UInt32Value getTcpFlags();
   /**
@@ -717,6 +776,7 @@ public interface FlowDocumentOrBuilder extends
    * </pre>
    *
    * <code>.google.protobuf.UInt32Value tos = 32;</code>
+   * @return Whether the tos field is set.
    */
   boolean hasTos();
   /**
@@ -725,6 +785,7 @@ public interface FlowDocumentOrBuilder extends
    * </pre>
    *
    * <code>.google.protobuf.UInt32Value tos = 32;</code>
+   * @return The tos.
    */
   com.google.protobuf.UInt32Value getTos();
   /**
@@ -742,6 +803,7 @@ public interface FlowDocumentOrBuilder extends
    * </pre>
    *
    * <code>.NetflowVersion netflow_version = 33;</code>
+   * @return The enum numeric value on the wire for netflowVersion.
    */
   int getNetflowVersionValue();
   /**
@@ -750,6 +812,7 @@ public interface FlowDocumentOrBuilder extends
    * </pre>
    *
    * <code>.NetflowVersion netflow_version = 33;</code>
+   * @return The netflowVersion.
    */
   org.opennms.netmgt.flows.persistence.model.NetflowVersion getNetflowVersion();
 
@@ -759,6 +822,7 @@ public interface FlowDocumentOrBuilder extends
    * </pre>
    *
    * <code>string vlan = 34;</code>
+   * @return The vlan.
    */
   java.lang.String getVlan();
   /**
@@ -767,16 +831,19 @@ public interface FlowDocumentOrBuilder extends
    * </pre>
    *
    * <code>string vlan = 34;</code>
+   * @return The bytes for vlan.
    */
   com.google.protobuf.ByteString
       getVlanBytes();
 
   /**
    * <code>.NodeInfo src_node = 35;</code>
+   * @return Whether the srcNode field is set.
    */
   boolean hasSrcNode();
   /**
    * <code>.NodeInfo src_node = 35;</code>
+   * @return The srcNode.
    */
   org.opennms.netmgt.flows.persistence.model.NodeInfo getSrcNode();
   /**
@@ -786,10 +853,12 @@ public interface FlowDocumentOrBuilder extends
 
   /**
    * <code>.NodeInfo exporter_node = 36;</code>
+   * @return Whether the exporterNode field is set.
    */
   boolean hasExporterNode();
   /**
    * <code>.NodeInfo exporter_node = 36;</code>
+   * @return The exporterNode.
    */
   org.opennms.netmgt.flows.persistence.model.NodeInfo getExporterNode();
   /**
@@ -799,10 +868,12 @@ public interface FlowDocumentOrBuilder extends
 
   /**
    * <code>.NodeInfo dest_node = 37;</code>
+   * @return Whether the destNode field is set.
    */
   boolean hasDestNode();
   /**
    * <code>.NodeInfo dest_node = 37;</code>
+   * @return The destNode.
    */
   org.opennms.netmgt.flows.persistence.model.NodeInfo getDestNode();
   /**
@@ -812,68 +883,92 @@ public interface FlowDocumentOrBuilder extends
 
   /**
    * <code>string application = 38;</code>
+   * @return The application.
    */
   java.lang.String getApplication();
   /**
    * <code>string application = 38;</code>
+   * @return The bytes for application.
    */
   com.google.protobuf.ByteString
       getApplicationBytes();
 
   /**
    * <code>string host = 39;</code>
+   * @return The host.
    */
   java.lang.String getHost();
   /**
    * <code>string host = 39;</code>
+   * @return The bytes for host.
    */
   com.google.protobuf.ByteString
       getHostBytes();
 
   /**
    * <code>string location = 40;</code>
+   * @return The location.
    */
   java.lang.String getLocation();
   /**
    * <code>string location = 40;</code>
+   * @return The bytes for location.
    */
   com.google.protobuf.ByteString
       getLocationBytes();
 
   /**
    * <code>.Locality src_locality = 41;</code>
+   * @return The enum numeric value on the wire for srcLocality.
    */
   int getSrcLocalityValue();
   /**
    * <code>.Locality src_locality = 41;</code>
+   * @return The srcLocality.
    */
   org.opennms.netmgt.flows.persistence.model.Locality getSrcLocality();
 
   /**
    * <code>.Locality dst_locality = 42;</code>
+   * @return The enum numeric value on the wire for dstLocality.
    */
   int getDstLocalityValue();
   /**
    * <code>.Locality dst_locality = 42;</code>
+   * @return The dstLocality.
    */
   org.opennms.netmgt.flows.persistence.model.Locality getDstLocality();
 
   /**
    * <code>.Locality flow_locality = 43;</code>
+   * @return The enum numeric value on the wire for flowLocality.
    */
   int getFlowLocalityValue();
   /**
    * <code>.Locality flow_locality = 43;</code>
+   * @return The flowLocality.
    */
   org.opennms.netmgt.flows.persistence.model.Locality getFlowLocality();
 
   /**
    * <code>string convo_key = 44;</code>
+   * @return The convoKey.
    */
   java.lang.String getConvoKey();
   /**
    * <code>string convo_key = 44;</code>
+   * @return The bytes for convoKey.
    */
   com.google.protobuf.ByteString
       getConvoKeyBytes();
+
+  /**
+   * <pre>
+   * Applied clock correction im milliseconds.
+   * </pre>
+   *
+   * <code>uint64 clock_correction = 45;</code>
+   * @return The clockCorrection.
+   */
+  long getClockCorrection();
 }

--- a/features/flows/kafka-persistence/src/main/java/org/opennms/netmgt/flows/persistence/model/Locality.java
+++ b/features/flows/kafka-persistence/src/main/java/org/opennms/netmgt/flows/persistence/model/Locality.java
@@ -66,6 +66,8 @@ public enum Locality
   }
 
   /**
+   * @param value The numeric wire value of the corresponding enum entry.
+   * @return The enum associated with the given numeric wire value.
    * @deprecated Use {@link #forNumber(int)} instead.
    */
   @java.lang.Deprecated
@@ -73,6 +75,10 @@ public enum Locality
     return forNumber(value);
   }
 
+  /**
+   * @param value The numeric wire value of the corresponding enum entry.
+   * @return The enum associated with the given numeric wire value.
+   */
   public static Locality forNumber(int value) {
     switch (value) {
       case 0: return PUBLIC;
@@ -95,6 +101,10 @@ public enum Locality
 
   public final com.google.protobuf.Descriptors.EnumValueDescriptor
       getValueDescriptor() {
+    if (this == UNRECOGNIZED) {
+      throw new java.lang.IllegalStateException(
+          "Can't get the descriptor of an unrecognized enum value.");
+    }
     return getDescriptor().getValues().get(ordinal());
   }
   public final com.google.protobuf.Descriptors.EnumDescriptor

--- a/features/flows/kafka-persistence/src/main/java/org/opennms/netmgt/flows/persistence/model/NetflowVersion.java
+++ b/features/flows/kafka-persistence/src/main/java/org/opennms/netmgt/flows/persistence/model/NetflowVersion.java
@@ -83,6 +83,8 @@ public enum NetflowVersion
   }
 
   /**
+   * @param value The numeric wire value of the corresponding enum entry.
+   * @return The enum associated with the given numeric wire value.
    * @deprecated Use {@link #forNumber(int)} instead.
    */
   @java.lang.Deprecated
@@ -90,6 +92,10 @@ public enum NetflowVersion
     return forNumber(value);
   }
 
+  /**
+   * @param value The numeric wire value of the corresponding enum entry.
+   * @return The enum associated with the given numeric wire value.
+   */
   public static NetflowVersion forNumber(int value) {
     switch (value) {
       case 0: return V5;
@@ -114,6 +120,10 @@ public enum NetflowVersion
 
   public final com.google.protobuf.Descriptors.EnumValueDescriptor
       getValueDescriptor() {
+    if (this == UNRECOGNIZED) {
+      throw new java.lang.IllegalStateException(
+          "Can't get the descriptor of an unrecognized enum value.");
+    }
     return getDescriptor().getValues().get(ordinal());
   }
   public final com.google.protobuf.Descriptors.EnumDescriptor

--- a/features/flows/kafka-persistence/src/main/java/org/opennms/netmgt/flows/persistence/model/NodeInfo.java
+++ b/features/flows/kafka-persistence/src/main/java/org/opennms/netmgt/flows/persistence/model/NodeInfo.java
@@ -34,7 +34,7 @@ package org.opennms.netmgt.flows.persistence.model;
 /**
  * Protobuf type {@code NodeInfo}
  */
-public  final class NodeInfo extends
+public final class NodeInfo extends
     com.google.protobuf.GeneratedMessageV3 implements
     // @@protoc_insertion_point(message_implements:NodeInfo)
     NodeInfoOrBuilder {
@@ -145,7 +145,9 @@ private static final long serialVersionUID = 0L;
   private volatile java.lang.Object foreignSource_;
   /**
    * <code>string foreign_source = 1;</code>
+   * @return The foreignSource.
    */
+  @java.lang.Override
   public java.lang.String getForeignSource() {
     java.lang.Object ref = foreignSource_;
     if (ref instanceof java.lang.String) {
@@ -160,7 +162,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <code>string foreign_source = 1;</code>
+   * @return The bytes for foreignSource.
    */
+  @java.lang.Override
   public com.google.protobuf.ByteString
       getForeignSourceBytes() {
     java.lang.Object ref = foreignSource_;
@@ -179,7 +183,9 @@ private static final long serialVersionUID = 0L;
   private volatile java.lang.Object foreginId_;
   /**
    * <code>string foregin_id = 2;</code>
+   * @return The foreginId.
    */
+  @java.lang.Override
   public java.lang.String getForeginId() {
     java.lang.Object ref = foreginId_;
     if (ref instanceof java.lang.String) {
@@ -194,7 +200,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <code>string foregin_id = 2;</code>
+   * @return The bytes for foreginId.
    */
+  @java.lang.Override
   public com.google.protobuf.ByteString
       getForeginIdBytes() {
     java.lang.Object ref = foreginId_;
@@ -213,7 +221,9 @@ private static final long serialVersionUID = 0L;
   private int nodeId_;
   /**
    * <code>uint32 node_id = 3;</code>
+   * @return The nodeId.
    */
+  @java.lang.Override
   public int getNodeId() {
     return nodeId_;
   }
@@ -222,6 +232,7 @@ private static final long serialVersionUID = 0L;
   private com.google.protobuf.LazyStringList categories_;
   /**
    * <code>repeated string categories = 4;</code>
+   * @return A list containing the categories.
    */
   public com.google.protobuf.ProtocolStringList
       getCategoriesList() {
@@ -229,18 +240,23 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <code>repeated string categories = 4;</code>
+   * @return The count of categories.
    */
   public int getCategoriesCount() {
     return categories_.size();
   }
   /**
    * <code>repeated string categories = 4;</code>
+   * @param index The index of the element to return.
+   * @return The categories at the given index.
    */
   public java.lang.String getCategories(int index) {
     return categories_.get(index);
   }
   /**
    * <code>repeated string categories = 4;</code>
+   * @param index The index of the value to return.
+   * @return The bytes of the categories at the given index.
    */
   public com.google.protobuf.ByteString
       getCategoriesBytes(int index) {
@@ -622,6 +638,7 @@ private static final long serialVersionUID = 0L;
     private java.lang.Object foreignSource_ = "";
     /**
      * <code>string foreign_source = 1;</code>
+     * @return The foreignSource.
      */
     public java.lang.String getForeignSource() {
       java.lang.Object ref = foreignSource_;
@@ -637,6 +654,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <code>string foreign_source = 1;</code>
+     * @return The bytes for foreignSource.
      */
     public com.google.protobuf.ByteString
         getForeignSourceBytes() {
@@ -653,6 +671,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <code>string foreign_source = 1;</code>
+     * @param value The foreignSource to set.
+     * @return This builder for chaining.
      */
     public Builder setForeignSource(
         java.lang.String value) {
@@ -666,6 +686,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <code>string foreign_source = 1;</code>
+     * @return This builder for chaining.
      */
     public Builder clearForeignSource() {
       
@@ -675,6 +696,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <code>string foreign_source = 1;</code>
+     * @param value The bytes for foreignSource to set.
+     * @return This builder for chaining.
      */
     public Builder setForeignSourceBytes(
         com.google.protobuf.ByteString value) {
@@ -691,6 +714,7 @@ private static final long serialVersionUID = 0L;
     private java.lang.Object foreginId_ = "";
     /**
      * <code>string foregin_id = 2;</code>
+     * @return The foreginId.
      */
     public java.lang.String getForeginId() {
       java.lang.Object ref = foreginId_;
@@ -706,6 +730,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <code>string foregin_id = 2;</code>
+     * @return The bytes for foreginId.
      */
     public com.google.protobuf.ByteString
         getForeginIdBytes() {
@@ -722,6 +747,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <code>string foregin_id = 2;</code>
+     * @param value The foreginId to set.
+     * @return This builder for chaining.
      */
     public Builder setForeginId(
         java.lang.String value) {
@@ -735,6 +762,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <code>string foregin_id = 2;</code>
+     * @return This builder for chaining.
      */
     public Builder clearForeginId() {
       
@@ -744,6 +772,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <code>string foregin_id = 2;</code>
+     * @param value The bytes for foreginId to set.
+     * @return This builder for chaining.
      */
     public Builder setForeginIdBytes(
         com.google.protobuf.ByteString value) {
@@ -760,12 +790,16 @@ private static final long serialVersionUID = 0L;
     private int nodeId_ ;
     /**
      * <code>uint32 node_id = 3;</code>
+     * @return The nodeId.
      */
+    @java.lang.Override
     public int getNodeId() {
       return nodeId_;
     }
     /**
      * <code>uint32 node_id = 3;</code>
+     * @param value The nodeId to set.
+     * @return This builder for chaining.
      */
     public Builder setNodeId(int value) {
       
@@ -775,6 +809,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <code>uint32 node_id = 3;</code>
+     * @return This builder for chaining.
      */
     public Builder clearNodeId() {
       
@@ -792,6 +827,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <code>repeated string categories = 4;</code>
+     * @return A list containing the categories.
      */
     public com.google.protobuf.ProtocolStringList
         getCategoriesList() {
@@ -799,18 +835,23 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <code>repeated string categories = 4;</code>
+     * @return The count of categories.
      */
     public int getCategoriesCount() {
       return categories_.size();
     }
     /**
      * <code>repeated string categories = 4;</code>
+     * @param index The index of the element to return.
+     * @return The categories at the given index.
      */
     public java.lang.String getCategories(int index) {
       return categories_.get(index);
     }
     /**
      * <code>repeated string categories = 4;</code>
+     * @param index The index of the value to return.
+     * @return The bytes of the categories at the given index.
      */
     public com.google.protobuf.ByteString
         getCategoriesBytes(int index) {
@@ -818,6 +859,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <code>repeated string categories = 4;</code>
+     * @param index The index to set the value at.
+     * @param value The categories to set.
+     * @return This builder for chaining.
      */
     public Builder setCategories(
         int index, java.lang.String value) {
@@ -831,6 +875,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <code>repeated string categories = 4;</code>
+     * @param value The categories to add.
+     * @return This builder for chaining.
      */
     public Builder addCategories(
         java.lang.String value) {
@@ -844,6 +890,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <code>repeated string categories = 4;</code>
+     * @param values The categories to add.
+     * @return This builder for chaining.
      */
     public Builder addAllCategories(
         java.lang.Iterable<java.lang.String> values) {
@@ -855,6 +903,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <code>repeated string categories = 4;</code>
+     * @return This builder for chaining.
      */
     public Builder clearCategories() {
       categories_ = com.google.protobuf.LazyStringArrayList.EMPTY;
@@ -864,6 +913,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <code>repeated string categories = 4;</code>
+     * @param value The bytes of the categories to add.
+     * @return This builder for chaining.
      */
     public Builder addCategoriesBytes(
         com.google.protobuf.ByteString value) {

--- a/features/flows/kafka-persistence/src/main/java/org/opennms/netmgt/flows/persistence/model/NodeInfoOrBuilder.java
+++ b/features/flows/kafka-persistence/src/main/java/org/opennms/netmgt/flows/persistence/model/NodeInfoOrBuilder.java
@@ -37,44 +37,55 @@ public interface NodeInfoOrBuilder extends
 
   /**
    * <code>string foreign_source = 1;</code>
+   * @return The foreignSource.
    */
   java.lang.String getForeignSource();
   /**
    * <code>string foreign_source = 1;</code>
+   * @return The bytes for foreignSource.
    */
   com.google.protobuf.ByteString
       getForeignSourceBytes();
 
   /**
    * <code>string foregin_id = 2;</code>
+   * @return The foreginId.
    */
   java.lang.String getForeginId();
   /**
    * <code>string foregin_id = 2;</code>
+   * @return The bytes for foreginId.
    */
   com.google.protobuf.ByteString
       getForeginIdBytes();
 
   /**
    * <code>uint32 node_id = 3;</code>
+   * @return The nodeId.
    */
   int getNodeId();
 
   /**
    * <code>repeated string categories = 4;</code>
+   * @return A list containing the categories.
    */
   java.util.List<java.lang.String>
       getCategoriesList();
   /**
    * <code>repeated string categories = 4;</code>
+   * @return The count of categories.
    */
   int getCategoriesCount();
   /**
    * <code>repeated string categories = 4;</code>
+   * @param index The index of the element to return.
+   * @return The categories at the given index.
    */
   java.lang.String getCategories(int index);
   /**
    * <code>repeated string categories = 4;</code>
+   * @param index The index of the value to return.
+   * @return The bytes of the categories at the given index.
    */
   com.google.protobuf.ByteString
       getCategoriesBytes(int index);

--- a/features/flows/kafka-persistence/src/main/java/org/opennms/netmgt/flows/persistence/model/SamplingAlgorithm.java
+++ b/features/flows/kafka-persistence/src/main/java/org/opennms/netmgt/flows/persistence/model/SamplingAlgorithm.java
@@ -114,6 +114,8 @@ public enum SamplingAlgorithm
   }
 
   /**
+   * @param value The numeric wire value of the corresponding enum entry.
+   * @return The enum associated with the given numeric wire value.
    * @deprecated Use {@link #forNumber(int)} instead.
    */
   @java.lang.Deprecated
@@ -121,6 +123,10 @@ public enum SamplingAlgorithm
     return forNumber(value);
   }
 
+  /**
+   * @param value The numeric wire value of the corresponding enum entry.
+   * @return The enum associated with the given numeric wire value.
+   */
   public static SamplingAlgorithm forNumber(int value) {
     switch (value) {
       case 0: return UNASSIGNED;
@@ -149,6 +155,10 @@ public enum SamplingAlgorithm
 
   public final com.google.protobuf.Descriptors.EnumValueDescriptor
       getValueDescriptor() {
+    if (this == UNRECOGNIZED) {
+      throw new java.lang.IllegalStateException(
+          "Can't get the descriptor of an unrecognized enum value.");
+    }
     return getDescriptor().getValues().get(ordinal());
   }
   public final com.google.protobuf.Descriptors.EnumDescriptor

--- a/features/flows/kafka-persistence/src/main/proto/flowdocument.proto
+++ b/features/flows/kafka-persistence/src/main/proto/flowdocument.proto
@@ -90,4 +90,5 @@ message FlowDocument {
     Locality dst_locality = 42;
     Locality flow_locality = 43;
     string convo_key = 44;
+    uint64 clock_correction = 45; // Applied clock correction im milliseconds.
 }

--- a/features/telemetry/protocols/flows/src/main/java/org/opennms/netmgt/telemetry/protocols/flows/AbstractFlowAdapter.java
+++ b/features/telemetry/protocols/flows/src/main/java/org/opennms/netmgt/telemetry/protocols/flows/AbstractFlowAdapter.java
@@ -30,6 +30,7 @@ package org.opennms.netmgt.telemetry.protocols.flows;
 
 import static com.codahale.metrics.MetricRegistry.name;
 
+import java.time.Instant;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
@@ -117,7 +118,7 @@ public abstract class AbstractFlowAdapter<P> implements Adapter {
 
                     flowPackets += 1;
 
-                    final List<Flow> converted = converter.convert(flowPacket);
+                    final List<Flow> converted = converter.convert(flowPacket, Instant.ofEpochMilli(eachMessage.getTimestamp()));
                     flows.addAll(converted);
 
                     this.entriesConverted.mark(converted.size());

--- a/features/telemetry/protocols/netflow/adapter/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/adapter/common/NetflowConverter.java
+++ b/features/telemetry/protocols/netflow/adapter/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/adapter/common/NetflowConverter.java
@@ -28,7 +28,9 @@
 
 package org.opennms.netmgt.telemetry.protocols.netflow.adapter.common;
 
+import java.time.Instant;
 import java.util.Collections;
+import java.util.Date;
 import java.util.List;
 
 import org.opennms.netmgt.flows.api.Converter;
@@ -38,7 +40,7 @@ import org.opennms.netmgt.telemetry.protocols.netflow.transport.FlowMessage;
 public class NetflowConverter implements Converter<FlowMessage> {
 
     @Override
-    public List<Flow> convert(FlowMessage packet) {
-        return Collections.singletonList(new NetflowMessage(packet));
+    public List<Flow> convert(FlowMessage packet, final Instant receivedAt) {
+        return Collections.singletonList(new NetflowMessage(packet, receivedAt));
     }
 }

--- a/features/telemetry/protocols/netflow/adapter/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/adapter/common/NetflowMessage.java
+++ b/features/telemetry/protocols/netflow/adapter/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/adapter/common/NetflowMessage.java
@@ -28,6 +28,8 @@
 
 package org.opennms.netmgt.telemetry.protocols.netflow.adapter.common;
 
+import java.time.Instant;
+import java.util.Objects;
 import java.util.Optional;
 
 import org.opennms.netmgt.flows.api.Flow;
@@ -38,10 +40,16 @@ import com.google.common.base.Strings;
 public class NetflowMessage implements Flow {
 
     private final FlowMessage flowMessageProto;
+    private final Instant receivedAt;
 
-
-    public NetflowMessage(FlowMessage flowMessageProto) {
+    public NetflowMessage(FlowMessage flowMessageProto, final Instant receivedAt) {
         this.flowMessageProto = flowMessageProto;
+        this.receivedAt = Objects.requireNonNull(receivedAt);
+    }
+
+    @Override
+    public long getReceivedAt() {
+        return this.receivedAt.toEpochMilli();
     }
 
     @Override

--- a/features/telemetry/protocols/netflow/adapter/src/test/java/org/opennms/netmgt/telemetry/protocols/netflow/adapter/Utils.java
+++ b/features/telemetry/protocols/netflow/adapter/src/test/java/org/opennms/netmgt/telemetry/protocols/netflow/adapter/Utils.java
@@ -32,6 +32,7 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -100,7 +101,7 @@ public class Utils {
         }
 
         @Override
-        public List<Flow> convert(List<String> resources) {
+        public List<Flow> convert(List<String> resources, final Instant receivedAt) {
 
             List<Flow> flows = new ArrayList<>();
 
@@ -108,7 +109,7 @@ public class Utils {
                 try {
                     FlowMessage.Builder builder = FlowMessage.newBuilder();
                     JsonFormat.parser().merge(resource, builder);
-                    flows.add(new NetflowMessage(builder.build()));
+                    flows.add(new NetflowMessage(builder.build(), receivedAt));
                 } catch (InvalidProtocolBufferException e) {
                     //Ignore.
                 }

--- a/features/telemetry/protocols/netflow/adapter/src/test/java/org/opennms/netmgt/telemetry/protocols/netflow/adapter/ipfix/IpFixProtobufValidationTest.java
+++ b/features/telemetry/protocols/netflow/adapter/src/test/java/org/opennms/netmgt/telemetry/protocols/netflow/adapter/ipfix/IpFixProtobufValidationTest.java
@@ -38,6 +38,7 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -78,7 +79,7 @@ public class IpFixProtobufValidationTest {
         Utils.JsonConverter jsonConverter = new Utils.JsonConverter();
         List<String> jsonStrings = jsonConverter.getJsonStringFromResources("/flows/ipfix_test_1.json",
                 "/flows/ipfix_test_2.json");
-        List<Flow> jsonData = jsonConverter.convert(jsonStrings);
+        List<Flow> jsonData = jsonConverter.convert(jsonStrings, Instant.now());
         assertThat(jsonData, hasSize(8));
         for (int i = 0; i < 8; i++) {
             Assert.assertEquals(flows.get(i).getFlowSeqNum(), jsonData.get(i).getFlowSeqNum());
@@ -152,7 +153,7 @@ public class IpFixProtobufValidationTest {
                     }
                     try {
                         FlowMessage flowMessage = FlowMessage.parseFrom(message);
-                        flows.addAll(ipFixConverter.convert(flowMessage));
+                        flows.addAll(ipFixConverter.convert(flowMessage, Instant.now()));
                     } catch (InvalidProtocolBufferException e) {
                         throw new RuntimeException(e);
                     }

--- a/features/telemetry/protocols/netflow/adapter/src/test/java/org/opennms/netmgt/telemetry/protocols/netflow/adapter/netflow5/Netflow5ConverterTest.java
+++ b/features/telemetry/protocols/netflow/adapter/src/test/java/org/opennms/netmgt/telemetry/protocols/netflow/adapter/netflow5/Netflow5ConverterTest.java
@@ -41,6 +41,7 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -134,7 +135,7 @@ public class Netflow5ConverterTest {
 
                     try {
                         FlowMessage flowMessage = FlowMessage.parseFrom(message);
-                        flows.addAll(nf5Converter.convert(flowMessage));
+                        flows.addAll(nf5Converter.convert(flowMessage, Instant.now()));
                     } catch (InvalidProtocolBufferException e) {
                         throw new RuntimeException(e);
                     }

--- a/features/telemetry/protocols/netflow/adapter/src/test/java/org/opennms/netmgt/telemetry/protocols/netflow/adapter/netflow9/Netflow9ConverterTest.java
+++ b/features/telemetry/protocols/netflow/adapter/src/test/java/org/opennms/netmgt/telemetry/protocols/netflow/adapter/netflow9/Netflow9ConverterTest.java
@@ -42,6 +42,7 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -125,7 +126,7 @@ public class Netflow9ConverterTest {
                     }
                     try {
                         FlowMessage flowMessage = FlowMessage.parseFrom(message);
-                        flows.addAll(nf9Converter.convert(flowMessage));
+                        flows.addAll(nf9Converter.convert(flowMessage, Instant.now()));
                     } catch (InvalidProtocolBufferException e) {
                         throw new RuntimeException(e);
                     }

--- a/features/telemetry/protocols/netflow/adapter/src/test/java/org/opennms/netmgt/telemetry/protocols/netflow/adapter/netflow9/Netflow9ProtobufValidationTest.java
+++ b/features/telemetry/protocols/netflow/adapter/src/test/java/org/opennms/netmgt/telemetry/protocols/netflow/adapter/netflow9/Netflow9ProtobufValidationTest.java
@@ -39,6 +39,7 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -82,7 +83,7 @@ public class Netflow9ProtobufValidationTest {
         Utils.JsonConverter jsonConverter = new Utils.JsonConverter();
         List<String> jsonStrings = jsonConverter.getJsonStringFromResources("/flows/netflow9.json",
                 "/flows/netflow9_1.json");
-        List<Flow> jsonFlows = jsonConverter.convert(jsonStrings);
+        List<Flow> jsonFlows = jsonConverter.convert(jsonStrings, Instant.now());
         assertThat(jsonFlows, hasSize(12));
         for (int i = 0; i < 12; i++) {
             Assert.assertEquals(flows.get(i).getFlowSeqNum(), jsonFlows.get(i).getFlowSeqNum());
@@ -157,7 +158,7 @@ public class Netflow9ProtobufValidationTest {
                     }
                     try {
                         FlowMessage flowMessage = FlowMessage.parseFrom(message);
-                        flows.addAll(nf9Converter.convert(flowMessage));
+                        flows.addAll(nf9Converter.convert(flowMessage, Instant.now()));
                     } catch (InvalidProtocolBufferException e) {
                         throw new RuntimeException(e);
 

--- a/features/telemetry/protocols/sflow/adapter/src/main/java/org/opennms/netmgt/telemetry/protocols/sflow/adapter/SFlow.java
+++ b/features/telemetry/protocols/sflow/adapter/src/main/java/org/opennms/netmgt/telemetry/protocols/sflow/adapter/SFlow.java
@@ -32,6 +32,7 @@ import static org.opennms.netmgt.telemetry.protocols.common.utils.BsonUtils.firs
 import static org.opennms.netmgt.telemetry.protocols.common.utils.BsonUtils.get;
 import static org.opennms.netmgt.telemetry.protocols.common.utils.BsonUtils.getString;
 
+import java.time.Instant;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -70,10 +71,17 @@ public class SFlow implements Flow {
 
     private final Header header;
     private final BsonDocument document;
+    private final Instant receivedAt;
 
-    public SFlow(final Header header, final BsonDocument document) {
+    public SFlow(final Header header, final BsonDocument document, final Instant receivedAt) {
         this.header = header;
         this.document = Objects.requireNonNull(document);
+        this.receivedAt = Objects.requireNonNull(receivedAt);
+    }
+
+    @Override
+    public long getReceivedAt() {
+        return this.receivedAt.toEpochMilli();
     }
 
     @Override

--- a/features/telemetry/protocols/sflow/adapter/src/main/java/org/opennms/netmgt/telemetry/protocols/sflow/adapter/SFlowConverter.java
+++ b/features/telemetry/protocols/sflow/adapter/src/main/java/org/opennms/netmgt/telemetry/protocols/sflow/adapter/SFlowConverter.java
@@ -34,6 +34,7 @@ import static org.opennms.netmgt.telemetry.protocols.common.utils.BsonUtils.getS
 import static org.opennms.netmgt.telemetry.protocols.common.utils.BsonUtils.getDocument;
 import static org.opennms.netmgt.telemetry.protocols.common.utils.BsonUtils.get;
 
+import java.time.Instant;
 import java.util.List;
 
 import org.bson.BsonDocument;
@@ -50,7 +51,7 @@ public class SFlowConverter implements Converter<BsonDocument> {
     }
 
     @Override
-    public List<Flow> convert(final BsonDocument packet) {
+    public List<Flow> convert(final BsonDocument packet, final Instant receivedAt) {
         final List<Flow> result = Lists.newLinkedList();
 
         final SFlow.Header header = new SFlow.Header(packet);
@@ -67,7 +68,7 @@ public class SFlowConverter implements Converter<BsonDocument> {
                            get(sampleDocument, "data", "flows", "0:3"),
                            get(sampleDocument, "data", "flows", "0:4")).isPresent()) {
                     // Handle only flows containing IP related records
-                    result.add(new SFlow(header, getDocument(sampleDocument, "data").orElseThrow(SFlowConverter::invalidDocument)));
+                    result.add(new SFlow(header, getDocument(sampleDocument, "data").orElseThrow(SFlowConverter::invalidDocument), receivedAt));
                 }
             }
         }

--- a/features/telemetry/protocols/sflow/adapter/src/test/java/org/opennms/netmgt/telemetry/protocols/sflow/adapter/SFlowConverterTest.java
+++ b/features/telemetry/protocols/sflow/adapter/src/test/java/org/opennms/netmgt/telemetry/protocols/sflow/adapter/SFlowConverterTest.java
@@ -35,6 +35,7 @@ import static org.junit.Assert.assertThat;
 import java.io.File;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.time.Instant;
 import java.util.List;
 import java.util.Objects;
 
@@ -42,7 +43,6 @@ import org.bson.BsonDocument;
 import org.junit.Before;
 import org.junit.Test;
 import org.opennms.netmgt.flows.api.Flow;
-import org.opennms.netmgt.telemetry.protocols.sflow.adapter.SFlowConverter;
 
 import com.google.common.io.Files;
 
@@ -63,7 +63,7 @@ public class SFlowConverterTest {
         assertThat(bsonDocument.getDocument("data").getArray("samples"), notNullValue());
         assertThat(bsonDocument.getDocument("data").getArray("samples").size(), is(7));
 
-        final List<Flow> flows = new SFlowConverter().convert(bsonDocument);
+        final List<Flow> flows = new SFlowConverter().convert(bsonDocument, Instant.now());
 
         // There are six flows int the document, but two are skipped, because they don't contain IPv{4,6} information
         assertThat(flows.size(), is(5));
@@ -86,7 +86,7 @@ public class SFlowConverterTest {
         assertThat(bsonDocument.getDocument("data").getArray("samples"), notNullValue());
         assertThat(bsonDocument.getDocument("data").getArray("samples").size(), is(7));
 
-        final List<Flow> flows = new SFlowConverter().convert(bsonDocument);
+        final List<Flow> flows = new SFlowConverter().convert(bsonDocument, Instant.now());
 
         assertThat(compareValues(flows, 4, 17), is(true));
         assertThat(compareValues(flows, 17, 4), is(true));

--- a/features/telemetry/protocols/sflow/adapter/src/test/java/org/opennms/netmgt/telemetry/protocols/sflow/adapter/SrcDstAsTestSFLow.java
+++ b/features/telemetry/protocols/sflow/adapter/src/test/java/org/opennms/netmgt/telemetry/protocols/sflow/adapter/SrcDstAsTestSFLow.java
@@ -32,6 +32,8 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
+import java.time.Instant;
+
 import org.bson.BsonDocument;
 import org.bson.BsonDocumentWriter;
 import org.junit.Test;
@@ -55,7 +57,7 @@ public class SrcDstAsTestSFLow {
     public void testSrcDstAs() {
         long value = 2147483648L;
         final BsonDocument bson = getBsonDocument(value);
-        final SFlow flow = new SFlow(null, bson);
+        final SFlow flow = new SFlow(null, bson, Instant.now());
         assertThat(flow.getSrcAs(), is(equalTo(value)));
         assertThat(flow.getDstAs(), is(equalTo(null)));
     }

--- a/features/telemetry/protocols/sflow/parser/src/test/java/org/opennms/netmgt/telemetry/protocols/sflow/parser/proto/flows/BsonDocumentTest.java
+++ b/features/telemetry/protocols/sflow/parser/src/test/java/org/opennms/netmgt/telemetry/protocols/sflow/parser/proto/flows/BsonDocumentTest.java
@@ -33,7 +33,7 @@ import java.beans.PropertyDescriptor;
 import java.net.Inet4Address;
 import java.net.Inet6Address;
 import java.net.InetAddress;
-import java.nio.ByteBuffer;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Optional;
@@ -204,7 +204,7 @@ public class BsonDocumentTest implements SampleDatagramEnrichment {
     @Test
     public void testSampledIpv4() {
         final BsonDocument bsonDocument = createSampledIpv4();
-        final SFlow sFlow = new SFlow(SFLOW_HEADER, bsonDocument);
+        final SFlow sFlow = new SFlow(SFLOW_HEADER, bsonDocument, Instant.now());
         Assert.assertEquals(new Long(LENGTH), sFlow.getBytes());
         Assert.assertEquals(Flow.Direction.INGRESS, sFlow.getDirection());
         Assert.assertEquals(DST_IPV4_STR, sFlow.getDstAddr());
@@ -238,7 +238,7 @@ public class BsonDocumentTest implements SampleDatagramEnrichment {
     @Test
     public void testSampledIpv6() {
         final BsonDocument bsonDocument = createSampledIpv6();
-        final SFlow sFlow = new SFlow(SFLOW_HEADER, bsonDocument);
+        final SFlow sFlow = new SFlow(SFLOW_HEADER, bsonDocument, Instant.now());
         Assert.assertEquals(new Long(LENGTH), sFlow.getBytes());
         Assert.assertEquals(Flow.Direction.INGRESS, sFlow.getDirection());
         Assert.assertEquals(DST_IPV6_STR, sFlow.getDstAddr());
@@ -272,7 +272,7 @@ public class BsonDocumentTest implements SampleDatagramEnrichment {
     @Test
     public void testSampledHeaderIpv4() {
         final BsonDocument bsonDocument = createSampledHeaderIpv4();
-        final SFlow sFlow = new SFlow(SFLOW_HEADER, bsonDocument);
+        final SFlow sFlow = new SFlow(SFLOW_HEADER, bsonDocument, Instant.now());
         Assert.assertEquals(new Long(LENGTH), sFlow.getBytes());
         Assert.assertEquals(Flow.Direction.INGRESS, sFlow.getDirection());
         Assert.assertEquals(DST_IPV4_STR, sFlow.getDstAddr());
@@ -306,7 +306,7 @@ public class BsonDocumentTest implements SampleDatagramEnrichment {
     @Test
     public void testSampledHeaderIpv6() {
         final BsonDocument bsonDocument = createSampledHeaderIpv6();
-        final SFlow sFlow = new SFlow(SFLOW_HEADER, bsonDocument);
+        final SFlow sFlow = new SFlow(SFLOW_HEADER, bsonDocument, Instant.now());
         Assert.assertEquals(new Long(LENGTH), sFlow.getBytes());
         Assert.assertEquals(Flow.Direction.INGRESS, sFlow.getDirection());
         Assert.assertEquals(DST_IPV6_STR, sFlow.getDstAddr());
@@ -340,7 +340,7 @@ public class BsonDocumentTest implements SampleDatagramEnrichment {
     @Test
     public void testExtendedRouterIpv4() {
         final BsonDocument bsonDocument = createExtendedRouterIpv4();
-        final SFlow sFlow = new SFlow(SFLOW_HEADER, bsonDocument);
+        final SFlow sFlow = new SFlow(SFLOW_HEADER, bsonDocument, Instant.now());
         Assert.assertEquals(new Integer(SRC_MASK_LEN), sFlow.getSrcMaskLen());
         Assert.assertEquals(new Integer(DST_MASK_LEN), sFlow.getDstMaskLen());
         Assert.assertEquals(ROUTER_IPV4_STR, sFlow.getNextHop());
@@ -349,7 +349,7 @@ public class BsonDocumentTest implements SampleDatagramEnrichment {
     @Test
     public void testExtendedRouterIpv6() {
         final BsonDocument bsonDocument = createExtendedRouterIpv6();
-        final SFlow sFlow = new SFlow(SFLOW_HEADER, bsonDocument);
+        final SFlow sFlow = new SFlow(SFLOW_HEADER, bsonDocument, Instant.now());
         Assert.assertEquals(new Integer(SRC_MASK_LEN), sFlow.getSrcMaskLen());
         Assert.assertEquals(new Integer(DST_MASK_LEN), sFlow.getDstMaskLen());
         Assert.assertEquals(ROUTER_IPV6_STR, sFlow.getNextHop());
@@ -358,14 +358,14 @@ public class BsonDocumentTest implements SampleDatagramEnrichment {
     @Test
     public void testExtendedSwitch() {
         final BsonDocument bsonDocument = createExtendedSwitch();
-        final SFlow sFlow = new SFlow(SFLOW_HEADER, bsonDocument);
+        final SFlow sFlow = new SFlow(SFLOW_HEADER, bsonDocument, Instant.now());
         Assert.assertEquals(new Integer(SRC_VLAN), sFlow.getVlan());
     }
 
     @Test
     public void testExtendedGateway() {
         final BsonDocument bsonDocument = createExtendedGateway();
-        final SFlow sFlow = new SFlow(SFLOW_HEADER, bsonDocument);
+        final SFlow sFlow = new SFlow(SFLOW_HEADER, bsonDocument, Instant.now());
         Assert.assertEquals(new Long(SRC_AS), sFlow.getSrcAs());
     }
 
@@ -435,7 +435,7 @@ public class BsonDocumentTest implements SampleDatagramEnrichment {
     }
 
     private void testGetterForDocument(final BsonDocument bsonDocument) throws Exception {
-        final SFlow sFlow = new SFlow(SFLOW_HEADER, bsonDocument);
+        final SFlow sFlow = new SFlow(SFLOW_HEADER, bsonDocument, Instant.now());
         for (final PropertyDescriptor propertyDescriptor : Introspector.getBeanInfo(SFlow.class).getPropertyDescriptors()) {
             final Object object = propertyDescriptor.getReadMethod().invoke(sFlow);
             System.out.println(propertyDescriptor.getReadMethod().getName() + "() returns '" + object + "'");

--- a/features/telemetry/protocols/sflow/parser/src/test/java/org/opennms/netmgt/telemetry/protocols/sflow/parser/proto/flows/BsonDocumentTest.java
+++ b/features/telemetry/protocols/sflow/parser/src/test/java/org/opennms/netmgt/telemetry/protocols/sflow/parser/proto/flows/BsonDocumentTest.java
@@ -392,7 +392,7 @@ public class BsonDocumentTest implements SampleDatagramEnrichment {
         final BsonDocument bsonDocument = new BsonDocument();
         final BsonDocumentWriter bsonDocumentWriter = new BsonDocumentWriter(bsonDocument);
         flowSample.writeBson(bsonDocumentWriter, this);
-        final SFlow sFlow = new SFlow(SFLOW_HEADER, bsonDocument);
+        final SFlow sFlow = new SFlow(SFLOW_HEADER, bsonDocument, Instant.now());
         Assert.assertEquals(Flow.Direction.INGRESS, sFlow.getDirection());
     }
 
@@ -406,7 +406,7 @@ public class BsonDocumentTest implements SampleDatagramEnrichment {
         final BsonDocument bsonDocument = new BsonDocument();
         final BsonDocumentWriter bsonDocumentWriter = new BsonDocumentWriter(bsonDocument);
         flowSample.writeBson(bsonDocumentWriter, this);
-        final SFlow sFlow = new SFlow(SFLOW_HEADER, bsonDocument);
+        final SFlow sFlow = new SFlow(SFLOW_HEADER, bsonDocument, Instant.now());
         Assert.assertEquals(Flow.Direction.EGRESS, sFlow.getDirection());
     }
 

--- a/opennms-doc/guide-admin/src/asciidoc/text/flows/setup.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/flows/setup.adoc
@@ -219,13 +219,13 @@ admin@opennms()> config:update
 
 === Correcting clock skew
 
-Flow analyses uses timestamps exposed by the underlying flow management protocol.
+Flow analyses use timestamps exposed by the underlying flow management protocol.
 These timestamps will be set depending on the clock of the exporting router.
-If the routers clock differs from the actual time, this will be reflected in received flows and therefore skew up further analysis and aggregation.
+If the router's clock differs from the actual time, this will be reflected in received flows and therefore skew up further analysis and aggregation.
 
 _{opennms-product-name}_ can correct the timestamps of a received flow.
-To do so, it compares the current time of the exporting device wit tha actual time when the packet has been received.
-If these times differ by a certain amount, the receive-time will be considered more correct and all timestamps of the flow will be adapted.
+To do so, it compares the current time of the exporting device with the actual time when the packet has been received.
+If these times differ by a certain amount, the receive time will be considered more correct and all timestamps of the flow will be adapted.
 
 To enable clock correction, configure a threshold for the maximum allowed delta in milliseconds.
 Setting the threshold to `0` will disable the correction mechanism.

--- a/opennms-doc/guide-admin/src/asciidoc/text/flows/setup.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/flows/setup.adoc
@@ -216,3 +216,25 @@ admin@opennms()> config:edit org.opennms.features.flows.persistence.kafka
 admin@opennms()> config:property-set bootstrap.servers 127.0.0.1:9092
 admin@opennms()> config:update
 ----
+
+=== Correcting clock skew
+
+Flow analyses uses timestamps exposed by the underlying flow management protocol.
+These timestamps will be set depending on the clock of the exporting router.
+If the routers clock differs from the actual time, this will be reflected in received flows and therefore skew up further analysis and aggregation.
+
+_{opennms-product-name}_ can correct the timestamps of a received flow.
+To do so, it compares the current time of the exporting device wit tha actual time when the packet has been received.
+If these times differ by a certain amount, the receive-time will be considered more correct and all timestamps of the flow will be adapted.
+
+To enable clock correction, configure a threshold for the maximum allowed delta in milliseconds.
+Setting the threshold to `0` will disable the correction mechanism.
+
+[source]
+----
+$ ssh -p 8101 admin@localhost
+...
+admin@opennms()> config:edit org.opennms.features.flows.persistence.elastic
+admin@opennms()> config:property-set clockSkewCorrectionThreshold 5000
+admin@opennms()> config:update
+----

--- a/pom.xml
+++ b/pom.xml
@@ -4033,6 +4033,12 @@
         <scope>test</scope>
       </dependency>
       <dependency>
+        <groupId>com.spotify</groupId>
+        <artifactId>hamcrest-pojo</artifactId>
+        <version>1.2.0</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
         <groupId>com.jayway.awaitility</groupId>
         <artifactId>awaitility</artifactId>
         <version>1.7.0</version>


### PR DESCRIPTION
This corrects flows exported by devices with incorrect clock settings.

If the clock differs to much, the receive time is assumed to be more correct than the exported clock time. Then, all time related properties of the flows are corrected by the detected delta.

This is a follow-up of #3226.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-12967 and https://issues.opennms.org/browse/NMS-13023

