### PR TITLE
NMS-13036: Add Geohash support to the mate-data DSL.

### DIFF
--- a/container/features/src/main/resources/features.xml
+++ b/container/features/src/main/resources/features.xml
@@ -529,6 +529,7 @@
         <feature>opennms-distributed-core-api</feature>
         <feature>opennms-dao-api</feature>
         <feature>opennms-core-tracing</feature>
+        <bundle>wrap:mvn:ch.hsr/geohash/${geohashVersion}</bundle>
         <bundle>mvn:org.opennms.core.ipc.rpc/org.opennms.core.ipc.rpc.api/${project.version}</bundle>
         <bundle>mvn:org.opennms.core.ipc.rpc/org.opennms.core.ipc.rpc.utils/${project.version}</bundle>
         <bundle>mvn:org.opennms.core.ipc.rpc/org.opennms.core.ipc.rpc.xml/${project.version}</bundle>

--- a/core/ipc/rpc/utils/pom.xml
+++ b/core/ipc/rpc/utils/pom.xml
@@ -36,6 +36,11 @@
       <artifactId>opennms-dao-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>ch.hsr</groupId>
+      <artifactId>geohash</artifactId>
+      <version>${geohashVersion}</version>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/opennms-doc/guide-admin/src/asciidoc/text/meta-data.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/meta-data.adoc
@@ -50,6 +50,7 @@ The following keys are available under this context:
 | `node:sys-description` | The system description of the node
 | `node:location`        | The node's monitoring location name
 | `node:area`            | The node's monitoring location area
+| `node:geohash`         | A xref:https://en.wikipedia.org/wiki/Geohash[Geohash] of the node's latitude/longitude
 |===
 
 ==== Interface context

--- a/pom.xml
+++ b/pom.xml
@@ -1390,6 +1390,7 @@
     <fopVersion>1.0</fopVersion>
     <freemarkerVersion>2.3.23</freemarkerVersion>
     <fstVersion>2.47</fstVersion>
+    <geohashVersion>1.4.0</geohashVersion>
     <geronimoVersion>1.1.1</geronimoVersion>
     <groovyVersion>2.4.5</groovyVersion>
     <grpcVersion>1.30.0</grpcVersion>


### PR DESCRIPTION
JIRA: https://issues.opennms.org/browse/NMS-13036

This allows us to add tags to timeseries metrics that include the geohash which can be used to display metrics on a map.

OpenNMS -> gRPC -> Cortex <- PromQL <- Grafana:
![image](https://user-images.githubusercontent.com/1379749/100920595-58458300-34a9-11eb-9556-1970d077bbc1.png)
