### PR TITLE
NMS-13042: Handle error scenarios

### DIFF
--- a/core/snmp/api/src/main/java/org/opennms/netmgt/snmp/SnmpAgentTimeoutException.java
+++ b/core/snmp/api/src/main/java/org/opennms/netmgt/snmp/SnmpAgentTimeoutException.java
@@ -36,4 +36,8 @@ public class SnmpAgentTimeoutException extends Exception {
     public SnmpAgentTimeoutException(String name, InetAddress agentAddress) {
         super(String.format("Timeout retrieving '%s' for %s.", name, InetAddrUtils.str(agentAddress)));
     }
+
+    public SnmpAgentTimeoutException(InetAddress agentAddress) {
+        super(String.format("Timeout retrieving response for %s.", InetAddrUtils.str(agentAddress)));
+    }
 }

--- a/core/snmp/impl-snmp4j/src/test/java/org/opennms/netmgt/snmp/snmp4j/Snmp4JWrongResponsesTest.java
+++ b/core/snmp/impl-snmp4j/src/test/java/org/opennms/netmgt/snmp/snmp4j/Snmp4JWrongResponsesTest.java
@@ -37,6 +37,8 @@ import java.net.UnknownHostException;
 
 import org.junit.Test;
 import org.opennms.netmgt.snmp.SnmpAgentConfig;
+import org.opennms.netmgt.snmp.SnmpAgentTimeoutException;
+import org.opennms.netmgt.snmp.SnmpException;
 import org.opennms.netmgt.snmp.SnmpObjId;
 import org.opennms.netmgt.snmp.SnmpValue;
 import org.snmp4j.PDU;
@@ -48,7 +50,7 @@ public class Snmp4JWrongResponsesTest {
 
 
     @Test
-    public void testWrongResponsesHandling() throws IOException {
+    public void testWrongResponsesHandling() throws IOException, SnmpAgentTimeoutException, SnmpException {
         Snmp4JAgentConfig agentConfig = new Snmp4JAgentConfig(getAgentConfig());
         // Request with 4 oids.
         SnmpObjId[] oids = {SnmpObjId.get(".1.3.6.1.2.1.1.2.0"),

--- a/core/snmp/proxy-rpc-impl/src/main/java/org/opennms/netmgt/snmp/proxy/common/SnmpProxyRpcModule.java
+++ b/core/snmp/proxy-rpc-impl/src/main/java/org/opennms/netmgt/snmp/proxy/common/SnmpProxyRpcModule.java
@@ -85,14 +85,14 @@ public class SnmpProxyRpcModule extends AbstractXmlRpcModule<SnmpRequestDTO, Snm
                 .completedFuture(new SnmpMultiResponseDTO());
         for (SnmpGetRequestDTO getRequest : request.getGetRequests()) {
             CompletableFuture<SnmpResponseDTO> future = get(request, getRequest);
-            combinedFuture = combinedFuture.thenCombine(future, (m,s) -> {
+            combinedFuture = combinedFuture.thenCombine(future, (m, s) -> {
                 m.getResponses().add(s);
                 return m;
             });
         }
         if (request.getWalkRequest().size() > 0) {
             CompletableFuture<Collection<SnmpResponseDTO>> future = walk(request, request.getWalkRequest());
-            combinedFuture = combinedFuture.thenCombine(future, (m,s) -> {
+            combinedFuture = combinedFuture.thenCombine(future, (m, s) -> {
                 m.getResponses().addAll(s);
                 return m;
             });
@@ -180,7 +180,7 @@ public class SnmpProxyRpcModule extends AbstractXmlRpcModule<SnmpRequestDTO, Snm
         final CompletableFuture<SnmpValue[]> future = SnmpUtils.getAsync(request.getAgent(), oids);
         return future.thenApply(values -> {
             final List<SnmpResult> results = new ArrayList<>(oids.length);
-            if (values.length == 0) {
+            if (values.length < oids.length) {
                 // Should never reach here, should have thrown exception in SnmpUtils.
                 LOG.warn("Received error response from SNMP for the agent {} for oids = {}", request.getAgent(), oids);
                 final SnmpResponseDTO responseDTO = new SnmpResponseDTO();

--- a/core/snmp/proxy-rpc-impl/src/main/java/org/opennms/netmgt/snmp/proxy/common/SnmpProxyRpcModule.java
+++ b/core/snmp/proxy-rpc-impl/src/main/java/org/opennms/netmgt/snmp/proxy/common/SnmpProxyRpcModule.java
@@ -52,6 +52,8 @@ import org.opennms.netmgt.snmp.SnmpUtils;
 import org.opennms.netmgt.snmp.SnmpValue;
 import org.opennms.netmgt.snmp.SnmpWalkCallback;
 import org.opennms.netmgt.snmp.SnmpWalker;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Executes SNMP requests locally using the current {@link org.opennms.netmgt.snmp.SnmpStrategy}.
@@ -59,6 +61,8 @@ import org.opennms.netmgt.snmp.SnmpWalker;
  * @author jwhite
  */
 public class SnmpProxyRpcModule extends AbstractXmlRpcModule<SnmpRequestDTO, SnmpMultiResponseDTO> {
+
+    private static final transient Logger LOG = LoggerFactory.getLogger(SnmpProxyRpcModule.class);
 
     public static final SnmpProxyRpcModule INSTANCE = new SnmpProxyRpcModule();
 
@@ -176,9 +180,16 @@ public class SnmpProxyRpcModule extends AbstractXmlRpcModule<SnmpRequestDTO, Snm
         final CompletableFuture<SnmpValue[]> future = SnmpUtils.getAsync(request.getAgent(), oids);
         return future.thenApply(values -> {
             final List<SnmpResult> results = new ArrayList<>(oids.length);
-            for (int i = 0; i < oids.length; i++) {
-                final SnmpResult result = new SnmpResult(oids[i], null, values[i]);
-                results.add(result);
+            if (values.length == 0) {
+                // Should never reach here, should have thrown exception in SnmpUtils.
+                LOG.warn("Received error response from SNMP for the agent {} for oids = {}", request.getAgent(), oids);
+                final SnmpResponseDTO responseDTO = new SnmpResponseDTO();
+                responseDTO.setCorrelationId(get.getCorrelationId());
+            } else {
+                for (int i = 0; i < oids.length; i++) {
+                    final SnmpResult result = new SnmpResult(oids[i], null, values[i]);
+                    results.add(result);
+                }
             }
             final SnmpResponseDTO responseDTO = new SnmpResponseDTO();
             responseDTO.setCorrelationId(get.getCorrelationId());

--- a/core/snmp/proxy-rpc-tests/src/test/java/org/opennms/netmgt/snmp/proxy/common/MockSnmpStrategy.java
+++ b/core/snmp/proxy-rpc-tests/src/test/java/org/opennms/netmgt/snmp/proxy/common/MockSnmpStrategy.java
@@ -163,4 +163,7 @@ public class MockSnmpStrategy implements SnmpStrategy {
         return null;
     }
 
+    public static void setFirstCall(boolean firstCall) {
+        MockSnmpStrategy.firstCall = firstCall;
+    }
 }

--- a/core/snmp/proxy-rpc-tests/src/test/java/org/opennms/netmgt/snmp/proxy/common/SnmpProxyRpcModuleTest.java
+++ b/core/snmp/proxy-rpc-tests/src/test/java/org/opennms/netmgt/snmp/proxy/common/SnmpProxyRpcModuleTest.java
@@ -31,11 +31,14 @@ package org.opennms.netmgt.snmp.proxy.common;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
 import org.junit.After;
 import org.junit.Test;
+import org.opennms.netmgt.snmp.SnmpObjId;
 import org.opennms.netmgt.snmp.SnmpUtils;
 import org.opennms.netmgt.snmp.SnmpValue;
 
@@ -74,6 +77,34 @@ public class SnmpProxyRpcModuleTest {
             fail("did not throw!");
         } catch (ExecutionException e) {
             assertEquals("Oups", e.getCause().getMessage());
+        }
+    }
+
+    @Test      // See NMS-12818
+    public void testBehaviorWhenSnmpValueIsNullArray() throws InterruptedException, ExecutionException {
+        // Mock the strategy class
+        System.setProperty("org.opennms.snmp.strategyClass", MockSnmpStrategy.class.getName());
+        // Add some random oids.
+        SnmpRequestDTO request = new SnmpRequestDTO();
+        SnmpObjId snmpObjId1 = SnmpObjId.get(".1.3.6.1.2.1.1.2.0");
+        SnmpObjId snmpObjId2 = SnmpObjId.get(".1.3.6.1.2.1.1.2.1");
+        SnmpGetRequestDTO get1 = new SnmpGetRequestDTO();
+        List<SnmpObjId> snmpObjIds = new ArrayList<>();
+        snmpObjIds.add(snmpObjId1);
+        snmpObjIds.add(snmpObjId2);
+        get1.setOids(snmpObjIds);
+        request.getGetRequests().add(get1);
+
+        // MockSnmpStrategy returns the null array
+        SnmpValue[] retvalues = { null };
+        failedFuture.complete(retvalues);
+
+        // Now "execute" the request and verify that resulting future doesn't throw exception.
+        CompletableFuture<SnmpMultiResponseDTO> future = SnmpProxyRpcModule.INSTANCE.execute(request);
+        try {
+            future.get();
+        } catch (ExecutionException e) {
+            fail();
         }
     }
 }

--- a/core/snmp/proxy-rpc-tests/src/test/java/org/opennms/netmgt/snmp/proxy/common/SnmpProxyRpcModuleTest.java
+++ b/core/snmp/proxy-rpc-tests/src/test/java/org/opennms/netmgt/snmp/proxy/common/SnmpProxyRpcModuleTest.java
@@ -84,6 +84,8 @@ public class SnmpProxyRpcModuleTest {
     public void testBehaviorWhenSnmpValueIsNullArray() throws InterruptedException, ExecutionException {
         // Mock the strategy class
         System.setProperty("org.opennms.snmp.strategyClass", MockSnmpStrategy.class.getName());
+        // Reset first call.
+        MockSnmpStrategy.setFirstCall(true);
         // Add some random oids.
         SnmpRequestDTO request = new SnmpRequestDTO();
         SnmpObjId snmpObjId1 = SnmpObjId.get(".1.3.6.1.2.1.1.2.0");
@@ -97,7 +99,8 @@ public class SnmpProxyRpcModuleTest {
 
         // MockSnmpStrategy returns the null array
         SnmpValue[] retvalues = { null };
-        failedFuture.complete(retvalues);
+        completedFuture = new CompletableFuture<>();
+        completedFuture.complete(retvalues);
 
         // Now "execute" the request and verify that resulting future doesn't throw exception.
         CompletableFuture<SnmpMultiResponseDTO> future = SnmpProxyRpcModule.INSTANCE.execute(request);

--- a/opennms-services/src/main/java/org/opennms/netmgt/snmpinterfacepoller/SnmpPollInterfaceMonitor.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/snmpinterfacepoller/SnmpPollInterfaceMonitor.java
@@ -133,7 +133,7 @@ public class SnmpPollInterfaceMonitor {
             }
             LOG.debug("Received admin/operational statuses for interfaces in '{}' at location {}", ipAddress, m_location);
         } catch (InterruptedException | ExecutionException e) {
-            LOG.error("Exception while retrieving admin/operational statuses for interfaces in '{}' at location", ipAddress, m_location, e);
+            LOG.error("Exception while retrieving admin/operational statuses for interfaces in '{}' at location {}", ipAddress, m_location, e);
             return null;
         }
 


### PR DESCRIPTION
Currently Snmp4JStrategy doesn't throw specific exception for timeout and
error scenarios. This results in null response which cause ArrayIndexBound exception

This PR should handle those error scenarios.


### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-13042
