### PR TITLE
NMS-13055: Fix Snmp karaf commands

### DIFF
--- a/core/snmp/commands/src/main/java/org/opennms/netmgt/snmp/commands/FitProfileCommand.java
+++ b/core/snmp/commands/src/main/java/org/opennms/netmgt/snmp/commands/FitProfileCommand.java
@@ -131,8 +131,11 @@ public class FitProfileCommand implements Action {
                     break;
                 }
 
-            } catch (TimeoutException | InterruptedException | ExecutionException e1) {
-                System.err.printf("%s: %s%n", ipAddress, e1.getClass().getName());
+            } catch (TimeoutException e) {
+                //pass
+                System.out.print(".");
+            } catch (InterruptedException | ExecutionException e1) {
+                System.err.printf("\n %s: %s%n", ipAddress, e1.getMessage());
                 break;
             }
         }

--- a/core/snmp/commands/src/main/java/org/opennms/netmgt/snmp/commands/WalkCommand.java
+++ b/core/snmp/commands/src/main/java/org/opennms/netmgt/snmp/commands/WalkCommand.java
@@ -32,7 +32,9 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
 import org.apache.karaf.shell.api.action.Action;
@@ -76,8 +78,11 @@ public class WalkCommand extends SnmpRequestCommand implements Action {
                         System.out.println(String.format("[%s].[%s] = %s", res.getBase(), res.getInstance(), res.getValue()));
                     });
                 break;
-            } catch (Exception e) {
-                System.out.println(String.format("%s: %s", m_host, e.getClass().getName()));
+            } catch (TimeoutException e) {
+                //pass
+                System.out.print(".");
+            } catch (InterruptedException | ExecutionException e) {
+                System.out.println(String.format("\n %s: %s", m_host, e.getMessage()));
                 break;
             }
         }


### PR DESCRIPTION
Don't break for Timeout Exception as it's designed to be responsive to user to give output every 1 sec.


### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-13055
