### PR TITLE
NMS-8959: "recommend" haveged package in OpenNMS install

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -58,6 +58,7 @@ Package: opennms-server
 Architecture: all
 Depends: opennms-common (=${binary:Version}), libopennms-java (=${binary:Version}), libopennmsdeps-java (=${binary:Version}), mailx
 Suggests: jrrd2, rrdtool (>= 1.4.8), postgresql-client-13 | postgresql-client-12 | postgresql-client-11 | postgresql-client-10
+Recommends: haveged
 Description: Enterprise-grade Open-source Network Management Platform (Daemon)
  OpenNMS is an enterprise-grade network management system written in Java.
  .

--- a/opennms-assemblies/minion/src/main/filtered/debian/control
+++ b/opennms-assemblies/minion/src/main/filtered/debian/control
@@ -8,7 +8,7 @@ Build-Depends: debhelper (>= 9), dh-systemd, oracle-java8-installer | adoptopenj
 Package: opennms-minion
 Architecture: all
 Depends: adduser, openssh-client, uuid-runtime, sudo
-Recommends: jicmp (>= 2.0.0), jicmp6 (>= 2.0.0), openjdk-11-jre-headless | openjdk-11-jre | adoptopenjdk-11-openj9xl-jre | adoptopenjdk-11-openj9-jre | adoptopenjdk-11-hotspot-jre | oracle-java8-installer | adoptopenjdk-8-openj9xl-jre | adoptopenjdk-8-openj9-jre | adoptopenjdk-8-hotspot-jre | openjdk-8-jre-headless | openjdk-8-jre | java8-runtime-headless | java8-runtime
+Recommends: openjdk-11-jre-headless | openjdk-11-jre | adoptopenjdk-11-openj9xl-jre | adoptopenjdk-11-openj9-jre | adoptopenjdk-11-hotspot-jre | oracle-java8-installer | adoptopenjdk-8-openj9xl-jre | adoptopenjdk-8-openj9-jre | adoptopenjdk-8-hotspot-jre | openjdk-8-jre-headless | openjdk-8-jre | java8-runtime-headless | java8-runtime, haveged, jicmp (>= 2.0.0), jicmp6 (>= 2.0.0)
 Conflicts: opennms-minion-container (<< 25.0.0), opennms-minion-features-core (<<25.0.0), opennms-minion-features-default (<<25.0.0)
 Description: distributed OpenNMS monitoring client
  OpenNMS Minion is a container infrastructure for distributed, scalable network

--- a/opennms-assemblies/sentinel/src/main/filtered/debian/control
+++ b/opennms-assemblies/sentinel/src/main/filtered/debian/control
@@ -8,7 +8,7 @@ Build-Depends: debhelper (>= 9), dh-systemd, oracle-java8-installer | adoptopenj
 Package: opennms-sentinel
 Architecture: all
 Depends: adduser, openssh-client, uuid-runtime, sudo
-Recommends: openjdk-11-jre-headless | openjdk-11-jre | adoptopenjdk-11-openj9xl-jre | adoptopenjdk-11-openj9-jre | adoptopenjdk-11-hotspot-jre | oracle-java8-installer | adoptopenjdk-8-openj9xl-jre | adoptopenjdk-8-openj9-jre | adoptopenjdk-8-hotspot-jre | openjdk-8-jre-headless | openjdk-8-jre | java8-runtime-headless | java8-runtime, jicmp (>= 2.0.0), jicmp6 (>= 2.0.0)
+Recommends: openjdk-11-jre-headless | openjdk-11-jre | adoptopenjdk-11-openj9xl-jre | adoptopenjdk-11-openj9-jre | adoptopenjdk-11-hotspot-jre | oracle-java8-installer | adoptopenjdk-8-openj9xl-jre | adoptopenjdk-8-openj9-jre | adoptopenjdk-8-hotspot-jre | openjdk-8-jre-headless | openjdk-8-jre | java8-runtime-headless | java8-runtime, haveged, jicmp (>= 2.0.0), jicmp6 (>= 2.0.0)
 Description: horizontal scaling for OpenNMS
  OpenNMS Sentinel is a container for running a subset of OpenNMS
  services in a standalone container, suitable for horizontally

--- a/tools/packages/minion/minion.spec
+++ b/tools/packages/minion/minion.spec
@@ -71,6 +71,7 @@ Requires:       jicmp >= 2.0.0
 Requires(pre):  jicmp >= 2.0.0
 Requires:       jicmp6 >= 2.0.0
 Requires(pre):  jicmp6 >= 2.0.0
+Recommends:	haveged
 
 Conflicts:      %{name}-container        < %{version}-%{release}
 Conflicts:      %{name}-features-core    < %{version}-%{release}

--- a/tools/packages/opennms/opennms.spec
+++ b/tools/packages/opennms/opennms.spec
@@ -105,6 +105,7 @@ Provides:	%{name}-plugin-protocol-xml = %{version}-%{release}
 Obsoletes:	%{name}-plugin-protocol-xml < %{version}
 Provides:	%{name}-plugin-protocol-dhcp = %{version}-%{release}
 Obsoletes:	%{name}-plugin-protocol-dhcp < %{version}
+Recommends:	haveged
 
 %description core
 The core backend.  This package contains the main daemon responsible

--- a/tools/packages/sentinel/sentinel.spec
+++ b/tools/packages/sentinel/sentinel.spec
@@ -67,6 +67,7 @@ Requires(pre):  /sbin/nologin
 Requires:       /sbin/nologin
 Requires:       /usr/bin/id
 Requires:       /usr/bin/sudo
+Recommends:	haveged
 
 Prefix:        %{sentinelinstprefix}
 


### PR DESCRIPTION
As of RPM 4.13, it now supports `Recommends:` and `Suggests:` like Debian does.  This PR adds a `Recommends:` to both the debian and RPM packages.  Also, I have added `haveged` to the RPM repositories in stable, so it's available without requiring the EPEL repository to be enabled.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-8959
