### PR TITLE
NMS-13067 Admin Breadcrumbs

### DIFF
--- a/opennms-webapp/src/main/webapp/locations/index.jsp
+++ b/opennms-webapp/src/main/webapp/locations/index.jsp
@@ -34,6 +34,7 @@
 <jsp:include page="/includes/bootstrap.jsp" flush="false">
 	<jsp:param name="title" value="Monitoring Locations" />
 	<jsp:param name="headTitle" value="Monitoring Locations" />
+	<jsp:param name="breadcrumb" value="<a href='admin/index.jsp'>Admin</a>" />
 	<jsp:param name="breadcrumb" value="Monitoring Locations" />
 </jsp:include>
 

--- a/opennms-webapp/src/main/webapp/minion/index.jsp
+++ b/opennms-webapp/src/main/webapp/minion/index.jsp
@@ -34,6 +34,7 @@
 <jsp:include page="/includes/bootstrap.jsp" flush="false">
 	<jsp:param name="title" value="Manage Minions" />
 	<jsp:param name="headTitle" value="Manage Minions" />
+	<jsp:param name="breadcrumb" value="<a href='admin/index.jsp'>Admin</a>" />
 	<jsp:param name="breadcrumb" value="Manage Minions" />
 </jsp:include>
 


### PR DESCRIPTION
A couple Admin pages in the UI were missing breadcrumb links back to the main Admin page. This PR updates only the `Monitoring Locations` and `Manage Minion` jsp pages to include an additional parameter to include the additional link.

### All Contributors

* [X] Have you read and followed our [Contribution Guidelines](https://github.com/OpenNMS/opennms/blob/develop/CONTRIBUTING.md)?
* [X] Have you [made an issue in the OpenNMS issue tracker](https://issues.opennms.org)?
* [X] Have you made a comment in that issue which points back to this PR?
* [X] Have you updated the JIRA link at the bottom of this comment to link to your issue?
* [ ] If this is a new or updated feature, is there documentation for the new behavior?
* [ ] If this is new code, are there unit and/or integration tests?
* [ ] If this PR targets a `foundation-*` branch, does it avoid changing files in `$OPENNMS_HOME/etc/`?

### External References

* JIRA (Issue Tracker): https://issues.opennms.org/browse/NMS-13067
