### PR TITLE
NMS-13069: remove all references and deps to nsis

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -734,8 +734,6 @@ jobs:
       - run:
           name: Assemble tarballs and related artifacts
           command: |
-            # install fake makensis to satisfy the assemble dependency
-            sudo cp .circleci/scripts/makensis.py /usr/local/bin/makensis
             export MAVEN_OPTS="-Xmx4g -Xms4g"
             # general assembly
             ./compile.pl -DskipTests=true -Dbuild.skip.tarball=false \

--- a/.circleci/scripts/itest.sh
+++ b/.circleci/scripts/itest.sh
@@ -56,7 +56,7 @@ sudo killall -9 apt-get || true && \
             sudo apt-get update && \
 	    sudo apt-get -y install debconf-utils && \
 	    echo '* libraries/restart-without-asking boolean true' | sudo debconf-set-selections && \
-            sudo env DEBIAN_FRONTEND=noninteractive apt-get install -f nsis R-base rrdtool
+            sudo env DEBIAN_FRONTEND=noninteractive apt-get install -f R-base rrdtool
 
 echo "#### Building Assembly Dependencies"
 ./compile.pl install -P'!checkstyle' \
@@ -67,7 +67,6 @@ echo "#### Building Assembly Dependencies"
            -DskipTests=true \
            -DskipITs=true \
            -Dci.instance="${CIRCLE_NODE_INDEX:-0}" \
-           -Dnsis.makensis.bin="$(which makensis)" \
            --batch-mode \
            "${CCI_FAILURE_OPTION:--fae}" \
            --also-make \
@@ -83,7 +82,6 @@ echo "#### Executing tests"
            -Dci.instance="${CIRCLE_NODE_INDEX:-0}" \
            -Dci.rerunFailingTestsCount="${CCI_RERUN_FAILTEST:-0}" \
            -Dcode.coverage="${CCI_CODE_COVERAGE:-false}" \
-           -Dnsis.makensis.bin="$(which makensis)" \
            --batch-mode \
            "${CCI_FAILURE_OPTION:--fae}" \
            -Dorg.opennms.core.test-api.dbCreateThreads=1 \

--- a/.circleci/scripts/makensis.py
+++ b/.circleci/scripts/makensis.py
@@ -1,6 +1,0 @@
-#!/usr/bin/env python2
-import sys
-import re
-
-m = re.search('-XOutFile (.*?) ', ' '.join(sys.argv))
-open(m.group(1), "w").close()

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: opennms
 Section: contrib/net
 Priority: optional
 Maintainer: Jeff Gehlbach <jeffg@opennms.org>
-Build-Depends: oracle-java8-installer | adoptopenjdk-8-openj9xl | adoptopenjdk-8-openj9 | adoptopenjdk-8-hotspot | openjdk-8-jdk-headless | openjdk-8-jdk | java8-jdk, debhelper (>= 5.0.42), dh-systemd (>= 1.5), po-debconf (>= 1.0.5), rsync, nsis
+Build-Depends: oracle-java8-installer | adoptopenjdk-8-openj9xl | adoptopenjdk-8-openj9 | adoptopenjdk-8-hotspot | openjdk-8-jdk-headless | openjdk-8-jdk | java8-jdk, debhelper (>= 5.0.42), dh-systemd (>= 1.5), po-debconf (>= 1.0.5), rsync
 Standards-Version: 3.7.3
 
 Package: opennms

--- a/makedeb.sh
+++ b/makedeb.sh
@@ -140,7 +140,7 @@ for BIN in $BINARIES; do
     EXECUTABLE=`which $BIN 2>/dev/null || :`
     if [ -z "$EXECUTABLE" ] || [ ! -x "$EXECUTABLE" ]; then
         echo "ERROR: $BIN not found"
-        echo "       try 'sudo apt install debhelper devscripts dh-systemd dpkg-dev dpkg-sig expect nsis po-debconf'"
+        echo "       try 'sudo apt install debhelper devscripts dh-systemd dpkg-dev dpkg-sig expect po-debconf'"
         exit 1
     fi
 done

--- a/makerpm.sh
+++ b/makerpm.sh
@@ -14,7 +14,7 @@ export PATH="$TOPDIR/maven/bin:$JAVA_HOME/bin:$PATH"
 
 cd "$TOPDIR"
 
-BINARIES="expect rpmbuild rsync makensis"
+BINARIES="expect rpmbuild rsync"
 
 function exists() {
     which "$1" >/dev/null 2>&1

--- a/opennms-doc/guide-development/src/asciidoc/text/dev-guide.adoc
+++ b/opennms-doc/guide-development/src/asciidoc/text/dev-guide.adoc
@@ -33,7 +33,6 @@ apt-get update
 # install stuff
 apt-get install -y software-properties-common
 apt-get install -y git-core
-apt-get install -y nsis
 
 # install Oracle Java 8 JDK
 # this setup is based on: http://www.webupd8.org/2014/03/how-to-install-oracle-java-8-in-debian.html


### PR DESCRIPTION
With the removal of Windows support and the remote poller installer, we should no longer need anything related to `makensis`.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-13069

