### PR TITLE
NMS-13082: Reduce log noise by catching harmless exception on cache miss

### DIFF
--- a/opennms-provision/opennms-provision-persistence/src/main/java/org/opennms/netmgt/provision/persist/FasterFilesystemForeignSourceRepository.java
+++ b/opennms-provision/opennms-provision-persistence/src/main/java/org/opennms/netmgt/provision/persist/FasterFilesystemForeignSourceRepository.java
@@ -89,11 +89,16 @@ public class FasterFilesystemForeignSourceRepository extends FilesystemForeignSo
             // Trust whatever is on the cache if exist for local resources only.
             if (isLocal) {
                 LOG.debug("importResourceRequisition: saving cached requisition to disk");
-                final Requisition req = getRequisitionsDirectoryWatcher().getContents(resource.getFilename());
-                if (req != null) {
-                    req.setResource(resource);
-                    save(req);
-                    return req;
+                final Requisition req;
+                try {
+                    req = getRequisitionsDirectoryWatcher().getContents(resource.getFilename());
+                    if (req != null) {
+                        req.setResource(resource);
+                        save(req);
+                        return req;
+                    }
+                } catch(FileNotFoundException e) {
+                    LOG.debug(e.getLocalizedMessage());
                 }
             }
         } catch (Exception e) {


### PR DESCRIPTION
### All Contributors

* [ Y] Have you read and followed our [Contribution Guidelines](https://github.com/OpenNMS/opennms/blob/develop/CONTRIBUTING.md)?
* [ Y] Have you [made an issue in the OpenNMS issue tracker](https://issues.opennms.org)?<br>If so, you should:
  1. update the title of this PR to be of the format: `${JIRA-ISSUE-NUMBER}: subject of pull request`
  2. update the JIRA link at the bottom of this comment to refer to the real issue number
  3. prefix your commit messages with the issue number, if possible
* [ Y] Have you made a comment in that issue which points back to this PR?
* [ Y] Have you updated the JIRA link at the bottom of this comment to link to your issue?
* [ NA] If this is a new or updated feature, is there documentation for the new behavior?
* [ N - see note] If this is new code, are there unit and/or integration tests?
* [ Y] If this PR targets a `foundation-*` branch, does it avoid changing files in `$OPENNMS_HOME/etc/`?

### Pull Request Process

One or more reviewers should be assigned to each PR.

If you know that a particular person is subject matter expert in the area your PR affects, feel free to assign one or more reviewers when you create this PR, otherwise reviewers will be assigned for you.

If you have made additions or changes to the documentation, or if you _need_ documentation for these code changes, please make sure a technical writer has looked it over.

Once the reviewer(s) accept the PR and the branch passes continuous integration, the PR is eligible for merge.

At that time, if you have commit access (are an OpenNMS Group employee or a member of the Order of the Green Polo) you are welcome to merge the PR.
Otherwise, a reviewer can merge it for you.

Thanks for taking time to contribute!

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-13082

**Note on testing**: SInce this is a log noise issue, the only way to verify it is by examining the log without and with the fix. That's what I did. However, I could not find a way to get at the log messages from a unit test. If anyone knows a way, I'd be happy to add a test case!
