### PR TITLE
NMS-13088: Adapt invalid flows instead of dropping

### DIFF
--- a/features/telemetry/protocols/netflow/adapter/src/test/java/org/opennms/netmgt/telemetry/protocols/netflow/adapter/Utils.java
+++ b/features/telemetry/protocols/netflow/adapter/src/test/java/org/opennms/netmgt/telemetry/protocols/netflow/adapter/Utils.java
@@ -59,17 +59,17 @@ import com.google.protobuf.util.JsonFormat;
 public class Utils {
 
 
-    public static byte[] buildAndSerialize(Protocol protocol, Iterable<Value<?>> record) throws IllegalFlowException {
+    public static FlowMessage.Builder buildAndSerialize(Protocol protocol, Iterable<Value<?>> record) throws IllegalFlowException {
         RecordEnrichment enrichment = (address -> Optional.empty());
         if (protocol.equals(Protocol.NETFLOW5)) {
             Netflow5MessageBuilder builder = new Netflow5MessageBuilder();
-            return builder.buildData(record, enrichment);
+            return builder.buildMessage(record, enrichment);
         } else if (protocol.equals(Protocol.NETFLOW9)) {
             Netflow9MessageBuilder builder = new Netflow9MessageBuilder();
-            return builder.buildData(record, enrichment);
+            return builder.buildMessage(record, enrichment);
         } else if (protocol.equals(Protocol.IPFIX)) {
             IpFixMessageBuilder builder = new IpFixMessageBuilder();
-            return builder.buildData(record, enrichment);
+            return builder.buildMessage(record, enrichment);
         }
         return null;
     }

--- a/features/telemetry/protocols/netflow/adapter/src/test/java/org/opennms/netmgt/telemetry/protocols/netflow/adapter/Utils.java
+++ b/features/telemetry/protocols/netflow/adapter/src/test/java/org/opennms/netmgt/telemetry/protocols/netflow/adapter/Utils.java
@@ -62,14 +62,14 @@ public class Utils {
     public static byte[] buildAndSerialize(Protocol protocol, Iterable<Value<?>> record) throws IllegalFlowException {
         RecordEnrichment enrichment = (address -> Optional.empty());
         if (protocol.equals(Protocol.NETFLOW5)) {
-            Netflow5MessageBuilder builder = new Netflow5MessageBuilder(record, enrichment);
-            return builder.buildData();
+            Netflow5MessageBuilder builder = new Netflow5MessageBuilder();
+            return builder.buildData(record, enrichment);
         } else if (protocol.equals(Protocol.NETFLOW9)) {
-            Netflow9MessageBuilder builder = new Netflow9MessageBuilder(record, enrichment);
-            return builder.buildData();
+            Netflow9MessageBuilder builder = new Netflow9MessageBuilder();
+            return builder.buildData(record, enrichment);
         } else if (protocol.equals(Protocol.IPFIX)) {
-            IpFixMessageBuilder builder = new IpFixMessageBuilder(record, enrichment);
-            return builder.buildData();
+            IpFixMessageBuilder builder = new IpFixMessageBuilder();
+            return builder.buildData(record, enrichment);
         }
         return null;
     }

--- a/features/telemetry/protocols/netflow/adapter/src/test/java/org/opennms/netmgt/telemetry/protocols/netflow/adapter/ipfix/FlowTimeoutTest.java
+++ b/features/telemetry/protocols/netflow/adapter/src/test/java/org/opennms/netmgt/telemetry/protocols/netflow/adapter/ipfix/FlowTimeoutTest.java
@@ -56,7 +56,7 @@ public class FlowTimeoutTest {
                 .build();
 
         final IpFixMessageBuilder ipFixMessageBuilder = new IpFixMessageBuilder();
-        FlowMessage flowMessage = FlowMessage.parseFrom(ipFixMessageBuilder.buildData(values, (address -> Optional.empty())));
+        FlowMessage flowMessage = ipFixMessageBuilder.buildMessage(values, (address -> Optional.empty())).build();
 
         assertThat(flowMessage.getFirstSwitched().getValue(), is(123000L));
         assertThat(flowMessage.getDeltaSwitched().getValue(), is(123000L)); // Timeout is same as first
@@ -77,7 +77,7 @@ public class FlowTimeoutTest {
 
 
         final IpFixMessageBuilder ipFixMessageBuilder = new IpFixMessageBuilder();
-        FlowMessage flowMessage = FlowMessage.parseFrom(ipFixMessageBuilder.buildData(values, (address -> Optional.empty())));
+        FlowMessage flowMessage = ipFixMessageBuilder.buildMessage(values, (address -> Optional.empty())).build();
 
         assertThat(flowMessage.getFirstSwitched().getValue(), is(123000L));
         assertThat(flowMessage.getDeltaSwitched().getValue(), is(987000L - 10000L));
@@ -96,7 +96,7 @@ public class FlowTimeoutTest {
                 .add(new UnsignedValue("flowInactiveTimeout", 300))
                 .build();
         final IpFixMessageBuilder ipFixMessageBuilder = new IpFixMessageBuilder();
-        FlowMessage flowMessage = FlowMessage.parseFrom(ipFixMessageBuilder.buildData(values, (address -> Optional.empty())));
+        FlowMessage flowMessage = ipFixMessageBuilder.buildMessage(values, (address -> Optional.empty())).build();
 
 
         assertThat(flowMessage.getFirstSwitched().getValue(), is(123000L));
@@ -114,7 +114,7 @@ public class FlowTimeoutTest {
                 .build();
 
         IpFixMessageBuilder ipFixMessageBuilder = new IpFixMessageBuilder();
-        FlowMessage flowMessage = FlowMessage.parseFrom(ipFixMessageBuilder.buildData(values, (address -> Optional.empty())));
+        FlowMessage flowMessage = ipFixMessageBuilder.buildMessage(values, (address -> Optional.empty())).build();
 
         assertThat(flowMessage.getFirstSwitched().getValue(), is(123000L));
         assertThat(flowMessage.getDeltaSwitched().getValue(), is(123000L));
@@ -126,7 +126,7 @@ public class FlowTimeoutTest {
                 .add(new UnsignedValue("flowEndSysUpTime", 4000000))
                 .build();
         ipFixMessageBuilder = new IpFixMessageBuilder();
-        flowMessage = FlowMessage.parseFrom(ipFixMessageBuilder.buildData(values, (address -> Optional.empty())));
+        flowMessage = ipFixMessageBuilder.buildMessage(values, (address -> Optional.empty())).build();
 
         assertThat(flowMessage.getFirstSwitched().getValue(), is(2000000L + 100000L));
         assertThat(flowMessage.getDeltaSwitched().getValue(), is(2000000L + 100000L));

--- a/features/telemetry/protocols/netflow/adapter/src/test/java/org/opennms/netmgt/telemetry/protocols/netflow/adapter/ipfix/FlowTimeoutTest.java
+++ b/features/telemetry/protocols/netflow/adapter/src/test/java/org/opennms/netmgt/telemetry/protocols/netflow/adapter/ipfix/FlowTimeoutTest.java
@@ -55,8 +55,8 @@ public class FlowTimeoutTest {
                 .add(new DateTimeValue("flowEndSeconds", Instant.ofEpochSecond(987)))
                 .build();
 
-        final IpFixMessageBuilder ipFixMessageBuilder = new IpFixMessageBuilder(values, (address -> Optional.empty()));
-        FlowMessage flowMessage = FlowMessage.parseFrom(ipFixMessageBuilder.buildData());
+        final IpFixMessageBuilder ipFixMessageBuilder = new IpFixMessageBuilder();
+        FlowMessage flowMessage = FlowMessage.parseFrom(ipFixMessageBuilder.buildData(values, (address -> Optional.empty())));
 
         assertThat(flowMessage.getFirstSwitched().getValue(), is(123000L));
         assertThat(flowMessage.getDeltaSwitched().getValue(), is(123000L)); // Timeout is same as first
@@ -76,8 +76,8 @@ public class FlowTimeoutTest {
                 .build();
 
 
-        final IpFixMessageBuilder ipFixMessageBuilder = new IpFixMessageBuilder(values, (address -> Optional.empty()));
-        FlowMessage flowMessage = FlowMessage.parseFrom(ipFixMessageBuilder.buildData());
+        final IpFixMessageBuilder ipFixMessageBuilder = new IpFixMessageBuilder();
+        FlowMessage flowMessage = FlowMessage.parseFrom(ipFixMessageBuilder.buildData(values, (address -> Optional.empty())));
 
         assertThat(flowMessage.getFirstSwitched().getValue(), is(123000L));
         assertThat(flowMessage.getDeltaSwitched().getValue(), is(987000L - 10000L));
@@ -95,8 +95,8 @@ public class FlowTimeoutTest {
                 .add(new UnsignedValue("flowActiveTimeout", 10))
                 .add(new UnsignedValue("flowInactiveTimeout", 300))
                 .build();
-        final IpFixMessageBuilder ipFixMessageBuilder = new IpFixMessageBuilder(values, (address -> Optional.empty()));
-        FlowMessage flowMessage = FlowMessage.parseFrom(ipFixMessageBuilder.buildData());
+        final IpFixMessageBuilder ipFixMessageBuilder = new IpFixMessageBuilder();
+        FlowMessage flowMessage = FlowMessage.parseFrom(ipFixMessageBuilder.buildData(values, (address -> Optional.empty())));
 
 
         assertThat(flowMessage.getFirstSwitched().getValue(), is(123000L));
@@ -113,8 +113,8 @@ public class FlowTimeoutTest {
                 .add(new DateTimeValue("flowEndSeconds", Instant.ofEpochSecond(987)))
                 .build();
 
-        IpFixMessageBuilder ipFixMessageBuilder = new IpFixMessageBuilder(values, (address -> Optional.empty()));
-        FlowMessage flowMessage = FlowMessage.parseFrom(ipFixMessageBuilder.buildData());
+        IpFixMessageBuilder ipFixMessageBuilder = new IpFixMessageBuilder();
+        FlowMessage flowMessage = FlowMessage.parseFrom(ipFixMessageBuilder.buildData(values, (address -> Optional.empty())));
 
         assertThat(flowMessage.getFirstSwitched().getValue(), is(123000L));
         assertThat(flowMessage.getDeltaSwitched().getValue(), is(123000L));
@@ -125,8 +125,8 @@ public class FlowTimeoutTest {
                 .add(new UnsignedValue("flowStartSysUpTime", 2000000))
                 .add(new UnsignedValue("flowEndSysUpTime", 4000000))
                 .build();
-        ipFixMessageBuilder = new IpFixMessageBuilder(values, (address -> Optional.empty()));
-        flowMessage = FlowMessage.parseFrom(ipFixMessageBuilder.buildData());
+        ipFixMessageBuilder = new IpFixMessageBuilder();
+        flowMessage = FlowMessage.parseFrom(ipFixMessageBuilder.buildData(values, (address -> Optional.empty())));
 
         assertThat(flowMessage.getFirstSwitched().getValue(), is(2000000L + 100000L));
         assertThat(flowMessage.getDeltaSwitched().getValue(), is(2000000L + 100000L));

--- a/features/telemetry/protocols/netflow/adapter/src/test/java/org/opennms/netmgt/telemetry/protocols/netflow/adapter/ipfix/IpFixProtobufValidationTest.java
+++ b/features/telemetry/protocols/netflow/adapter/src/test/java/org/opennms/netmgt/telemetry/protocols/netflow/adapter/ipfix/IpFixProtobufValidationTest.java
@@ -145,18 +145,14 @@ public class IpFixProtobufValidationTest {
                 final Packet packet = new Packet(session, header, slice(buffer, header.payloadLength()));
                 packet.getRecords().forEach(rec -> {
 
-                    byte[] message = new byte[0];
+                    final FlowMessage flowMessage;
                     try {
-                        message = Utils.buildAndSerialize(Protocol.IPFIX, rec);
+                        flowMessage = Utils.buildAndSerialize(Protocol.IPFIX, rec).build();
                     } catch (Exception e) {
                         throw new RuntimeException(e);
                     }
-                    try {
-                        FlowMessage flowMessage = FlowMessage.parseFrom(message);
-                        flows.addAll(ipFixConverter.convert(flowMessage, Instant.now()));
-                    } catch (InvalidProtocolBufferException e) {
-                        throw new RuntimeException(e);
-                    }
+
+                    flows.addAll(ipFixConverter.convert(flowMessage, Instant.now()));
                 });
             } catch (InvalidPacketException e) {
                 throw new RuntimeException(e);

--- a/features/telemetry/protocols/netflow/adapter/src/test/java/org/opennms/netmgt/telemetry/protocols/netflow/adapter/netflow5/Netflow5ConverterTest.java
+++ b/features/telemetry/protocols/netflow/adapter/src/test/java/org/opennms/netmgt/telemetry/protocols/netflow/adapter/netflow5/Netflow5ConverterTest.java
@@ -126,19 +126,14 @@ public class Netflow5ConverterTest {
                 final Packet packet = new Packet(header, buffer);
                 packet.getRecords().forEach(rec -> {
 
-                    byte[] message = new byte[0];
+                    final FlowMessage flowMessage;
                     try {
-                        message = buildAndSerialize(Protocol.NETFLOW5, rec);
+                        flowMessage = buildAndSerialize(Protocol.NETFLOW5, rec).build();
                     } catch (IllegalFlowException e) {
                         throw new RuntimeException(e);
                     }
 
-                    try {
-                        FlowMessage flowMessage = FlowMessage.parseFrom(message);
-                        flows.addAll(nf5Converter.convert(flowMessage, Instant.now()));
-                    } catch (InvalidProtocolBufferException e) {
-                        throw new RuntimeException(e);
-                    }
+                    flows.addAll(nf5Converter.convert(flowMessage, Instant.now()));
 
                 });
             } catch (InvalidPacketException e) {

--- a/features/telemetry/protocols/netflow/adapter/src/test/java/org/opennms/netmgt/telemetry/protocols/netflow/adapter/netflow9/FlowTimeoutTest.java
+++ b/features/telemetry/protocols/netflow/adapter/src/test/java/org/opennms/netmgt/telemetry/protocols/netflow/adapter/netflow9/FlowTimeoutTest.java
@@ -53,9 +53,9 @@ public class FlowTimeoutTest {
                 .add(new UnsignedValue("@sysUpTime", 0))
                 .add(new UnsignedValue("FIRST_SWITCHED", 123000))
                 .add(new UnsignedValue("LAST_SWITCHED", 987000)).build();
-        Netflow9MessageBuilder netflow9MessageBuilder = new Netflow9MessageBuilder(values, (address -> Optional.empty()));
+        Netflow9MessageBuilder netflow9MessageBuilder = new Netflow9MessageBuilder();
 
-        FlowMessage flowMessage = FlowMessage.parseFrom(netflow9MessageBuilder.buildData());
+        FlowMessage flowMessage = FlowMessage.parseFrom(netflow9MessageBuilder.buildData(values, (address -> Optional.empty())));
         assertThat(flowMessage.getFirstSwitched().getValue(), is(123000L));
         assertThat(flowMessage.getDeltaSwitched().getValue(), is(123000L));
         assertThat(flowMessage.getLastSwitched().getValue(), is(987000L));
@@ -76,9 +76,9 @@ public class FlowTimeoutTest {
                 .add(new UnsignedValue("FLOW_INACTIVE_TIMEOUT", 300))
                 .build();
 
-        Netflow9MessageBuilder netflow9MessageBuilder = new Netflow9MessageBuilder(values, (address -> Optional.empty()));
+        Netflow9MessageBuilder netflow9MessageBuilder = new Netflow9MessageBuilder();
 
-        FlowMessage flowMessage = FlowMessage.parseFrom(netflow9MessageBuilder.buildData());
+        FlowMessage flowMessage = FlowMessage.parseFrom(netflow9MessageBuilder.buildData(values, (address -> Optional.empty())));
         assertThat(flowMessage.getFirstSwitched().getValue(), is(123000L));
         assertThat(flowMessage.getDeltaSwitched().getValue(),  is(987000L - 10000L));
         assertThat(flowMessage.getLastSwitched().getValue(), is(987000L));
@@ -98,9 +98,9 @@ public class FlowTimeoutTest {
                 .add(new UnsignedValue("FLOW_INACTIVE_TIMEOUT", 300))
                 .build();
 
-        Netflow9MessageBuilder netflow9MessageBuilder = new Netflow9MessageBuilder(values, (address -> Optional.empty()));
+        Netflow9MessageBuilder netflow9MessageBuilder = new Netflow9MessageBuilder();
 
-        FlowMessage flowMessage = FlowMessage.parseFrom(netflow9MessageBuilder.buildData());
+        FlowMessage flowMessage = FlowMessage.parseFrom(netflow9MessageBuilder.buildData(values, (address -> Optional.empty())));
 
         assertThat(flowMessage.getFirstSwitched().getValue(), is(123000L));
         assertThat(flowMessage.getDeltaSwitched().getValue(), is(987000L - 300000L));

--- a/features/telemetry/protocols/netflow/adapter/src/test/java/org/opennms/netmgt/telemetry/protocols/netflow/adapter/netflow9/FlowTimeoutTest.java
+++ b/features/telemetry/protocols/netflow/adapter/src/test/java/org/opennms/netmgt/telemetry/protocols/netflow/adapter/netflow9/FlowTimeoutTest.java
@@ -55,7 +55,7 @@ public class FlowTimeoutTest {
                 .add(new UnsignedValue("LAST_SWITCHED", 987000)).build();
         Netflow9MessageBuilder netflow9MessageBuilder = new Netflow9MessageBuilder();
 
-        FlowMessage flowMessage = FlowMessage.parseFrom(netflow9MessageBuilder.buildData(values, (address -> Optional.empty())));
+        FlowMessage flowMessage = netflow9MessageBuilder.buildMessage(values, (address -> Optional.empty())).build();
         assertThat(flowMessage.getFirstSwitched().getValue(), is(123000L));
         assertThat(flowMessage.getDeltaSwitched().getValue(), is(123000L));
         assertThat(flowMessage.getLastSwitched().getValue(), is(987000L));
@@ -78,7 +78,7 @@ public class FlowTimeoutTest {
 
         Netflow9MessageBuilder netflow9MessageBuilder = new Netflow9MessageBuilder();
 
-        FlowMessage flowMessage = FlowMessage.parseFrom(netflow9MessageBuilder.buildData(values, (address -> Optional.empty())));
+        FlowMessage flowMessage = netflow9MessageBuilder.buildMessage(values, (address -> Optional.empty())).build();
         assertThat(flowMessage.getFirstSwitched().getValue(), is(123000L));
         assertThat(flowMessage.getDeltaSwitched().getValue(),  is(987000L - 10000L));
         assertThat(flowMessage.getLastSwitched().getValue(), is(987000L));
@@ -100,7 +100,7 @@ public class FlowTimeoutTest {
 
         Netflow9MessageBuilder netflow9MessageBuilder = new Netflow9MessageBuilder();
 
-        FlowMessage flowMessage = FlowMessage.parseFrom(netflow9MessageBuilder.buildData(values, (address -> Optional.empty())));
+        FlowMessage flowMessage = netflow9MessageBuilder.buildMessage(values, (address -> Optional.empty())).build();
 
         assertThat(flowMessage.getFirstSwitched().getValue(), is(123000L));
         assertThat(flowMessage.getDeltaSwitched().getValue(), is(987000L - 300000L));

--- a/features/telemetry/protocols/netflow/adapter/src/test/java/org/opennms/netmgt/telemetry/protocols/netflow/adapter/netflow9/Netflow9ConverterTest.java
+++ b/features/telemetry/protocols/netflow/adapter/src/test/java/org/opennms/netmgt/telemetry/protocols/netflow/adapter/netflow9/Netflow9ConverterTest.java
@@ -118,19 +118,14 @@ public class Netflow9ConverterTest {
                 final Packet packet = new Packet(session, header, buffer);
                 packet.getRecords().forEach(rec -> {
 
-                    byte[] message = new byte[0];
+                    final FlowMessage flowMessage;
                     try {
-                        message = buildAndSerialize(Protocol.NETFLOW9, rec);
+                        flowMessage = buildAndSerialize(Protocol.NETFLOW9, rec).build();
                     } catch (Exception e) {
                         throw new RuntimeException(e);
                     }
-                    try {
-                        FlowMessage flowMessage = FlowMessage.parseFrom(message);
-                        flows.addAll(nf9Converter.convert(flowMessage, Instant.now()));
-                    } catch (InvalidProtocolBufferException e) {
-                        throw new RuntimeException(e);
-                    }
 
+                    flows.addAll(nf9Converter.convert(flowMessage, Instant.now()));
                 });
             } catch (InvalidPacketException e) {
                 throw new RuntimeException(e);

--- a/features/telemetry/protocols/netflow/adapter/src/test/java/org/opennms/netmgt/telemetry/protocols/netflow/adapter/netflow9/Netflow9ProtobufValidationTest.java
+++ b/features/telemetry/protocols/netflow/adapter/src/test/java/org/opennms/netmgt/telemetry/protocols/netflow/adapter/netflow9/Netflow9ProtobufValidationTest.java
@@ -150,19 +150,14 @@ public class Netflow9ProtobufValidationTest {
                 final Packet packet = new Packet(session, header, buffer);
                 packet.getRecords().forEach(rec -> {
 
-                    byte[] message = new byte[0];
+                    final FlowMessage flowMessage;
                     try {
-                        message = buildAndSerialize(Protocol.NETFLOW9, rec);
+                        flowMessage = buildAndSerialize(Protocol.NETFLOW9, rec).build();
                     } catch (Exception e) {
                         throw new RuntimeException(e);
                     }
-                    try {
-                        FlowMessage flowMessage = FlowMessage.parseFrom(message);
-                        flows.addAll(nf9Converter.convert(flowMessage, Instant.now()));
-                    } catch (InvalidProtocolBufferException e) {
-                        throw new RuntimeException(e);
 
-                    }
+                    flows.addAll(nf9Converter.convert(flowMessage, Instant.now()));
                 });
             } catch (InvalidPacketException e) {
                 throw new RuntimeException(e);

--- a/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/IpfixTcpParser.java
+++ b/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/IpfixTcpParser.java
@@ -107,7 +107,7 @@ public class IpfixTcpParser extends ParserBase implements TcpParser {
 
     @Override
     protected byte[] buildMessage(Iterable<Value<?>> record, RecordEnrichment enrichment) throws IllegalFlowException {
-        IpFixMessageBuilder builder = new IpFixMessageBuilder(record, enrichment);
-        return builder.buildData();
+        IpFixMessageBuilder builder = new IpFixMessageBuilder();
+        return builder.buildData(record, enrichment);
     }
 }

--- a/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/IpfixTcpParser.java
+++ b/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/IpfixTcpParser.java
@@ -31,7 +31,6 @@ package org.opennms.netmgt.telemetry.protocols.netflow.parser;
 import static org.opennms.netmgt.telemetry.listeners.utils.BufferUtils.slice;
 
 import java.net.InetSocketAddress;
-import java.time.Duration;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
@@ -41,17 +40,12 @@ import org.opennms.netmgt.dnsresolver.api.DnsResolver;
 import org.opennms.netmgt.events.api.EventForwarder;
 import org.opennms.netmgt.telemetry.api.receiver.TelemetryMessage;
 import org.opennms.netmgt.telemetry.listeners.TcpParser;
-import org.opennms.netmgt.telemetry.protocols.netflow.parser.ie.Value;
 import org.opennms.netmgt.telemetry.protocols.netflow.parser.ipfix.proto.Header;
 import org.opennms.netmgt.telemetry.protocols.netflow.parser.ipfix.proto.Packet;
 import org.opennms.netmgt.telemetry.protocols.netflow.parser.session.TcpSession;
 import org.opennms.netmgt.telemetry.protocols.netflow.parser.transport.IpFixMessageBuilder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import com.codahale.metrics.Counter;
 import com.codahale.metrics.MetricRegistry;
-import com.swrve.ratelimitedlogger.RateLimitedLog;
 
 import io.netty.buffer.ByteBuf;
 
@@ -63,7 +57,7 @@ public class IpfixTcpParser extends ParserBase implements TcpParser {
                           final Identity identity,
                           final DnsResolver dnsResolver,
                           final MetricRegistry metricRegistry) {
-        super(Protocol.IPFIX, name, dispatcher, eventForwarder, identity, dnsResolver, metricRegistry);
+        super(Protocol.IPFIX, name, new IpFixMessageBuilder(), dispatcher, eventForwarder, identity, dnsResolver, metricRegistry);
     }
 
     @Override
@@ -103,11 +97,5 @@ public class IpfixTcpParser extends ParserBase implements TcpParser {
             @Override
             public void inactive() {}
         };
-    }
-
-    @Override
-    protected byte[] buildMessage(Iterable<Value<?>> record, RecordEnrichment enrichment) throws IllegalFlowException {
-        IpFixMessageBuilder builder = new IpFixMessageBuilder();
-        return builder.buildData(record, enrichment);
     }
 }

--- a/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/IpfixUdpParser.java
+++ b/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/IpfixUdpParser.java
@@ -89,8 +89,8 @@ public class IpfixUdpParser extends UdpParserBase implements UdpParser, Dispatch
 
     @Override
     protected byte[] buildMessage(Iterable<Value<?>> record, RecordEnrichment enrichment) throws IllegalFlowException {
-        IpFixMessageBuilder builder = new IpFixMessageBuilder(record, enrichment);
-        return builder.buildData();
+        IpFixMessageBuilder builder = new IpFixMessageBuilder();
+        return builder.buildData(record, enrichment);
     }
 
     public static class SessionKey implements UdpSessionManager.SessionKey {

--- a/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/IpfixUdpParser.java
+++ b/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/IpfixUdpParser.java
@@ -63,7 +63,7 @@ public class IpfixUdpParser extends UdpParserBase implements UdpParser, Dispatch
                           final Identity identity,
                           final DnsResolver dnsResolver,
                           final MetricRegistry metricRegistry) {
-        super(Protocol.IPFIX, name, dispatcher, eventForwarder, identity, dnsResolver, metricRegistry);
+        super(Protocol.IPFIX, name, new IpFixMessageBuilder(), dispatcher, eventForwarder, identity, dnsResolver, metricRegistry);
     }
 
     @Override
@@ -85,12 +85,6 @@ public class IpfixUdpParser extends UdpParserBase implements UdpParser, Dispatch
     @Override
     protected UdpSessionManager.SessionKey buildSessionKey(final InetSocketAddress remoteAddress, final InetSocketAddress localAddress) {
         return new SessionKey(remoteAddress, localAddress);
-    }
-
-    @Override
-    protected byte[] buildMessage(Iterable<Value<?>> record, RecordEnrichment enrichment) throws IllegalFlowException {
-        IpFixMessageBuilder builder = new IpFixMessageBuilder();
-        return builder.buildData(record, enrichment);
     }
 
     public static class SessionKey implements UdpSessionManager.SessionKey {

--- a/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/Netflow5UdpParser.java
+++ b/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/Netflow5UdpParser.java
@@ -87,7 +87,7 @@ public class Netflow5UdpParser extends UdpParserBase implements UdpParser, Dispa
 
     @Override
     protected byte[] buildMessage(Iterable<Value<?>> record, RecordEnrichment enrichment) throws IllegalFlowException {
-        Netflow5MessageBuilder builder = new Netflow5MessageBuilder(record, enrichment);
-        return builder.buildData();
+        Netflow5MessageBuilder builder = new Netflow5MessageBuilder();
+        return builder.buildData(record, enrichment);
     }
 }

--- a/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/Netflow5UdpParser.java
+++ b/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/Netflow5UdpParser.java
@@ -31,7 +31,6 @@ package org.opennms.netmgt.telemetry.protocols.netflow.parser;
 import static org.opennms.netmgt.telemetry.listeners.utils.BufferUtils.slice;
 
 import java.net.InetSocketAddress;
-import java.util.concurrent.CompletableFuture;
 
 import org.opennms.core.ipc.sink.api.AsyncDispatcher;
 import org.opennms.distributed.core.api.Identity;
@@ -61,7 +60,7 @@ public class Netflow5UdpParser extends UdpParserBase implements UdpParser, Dispa
                              final Identity identity,
                              final DnsResolver dnsResolver,
                              final MetricRegistry metricRegistry) {
-        super(Protocol.NETFLOW5, name, dispatcher, eventForwarder, identity, dnsResolver, metricRegistry);
+        super(Protocol.NETFLOW5, name, new Netflow5MessageBuilder(), dispatcher, eventForwarder, identity, dnsResolver, metricRegistry);
     }
 
     @Override
@@ -83,11 +82,5 @@ public class Netflow5UdpParser extends UdpParserBase implements UdpParser, Dispa
     protected UdpSessionManager.SessionKey buildSessionKey(final InetSocketAddress remoteAddress,
                                                            final InetSocketAddress localAddress) {
         return new Netflow9UdpParser.SessionKey(remoteAddress.getAddress(), localAddress);
-    }
-
-    @Override
-    protected byte[] buildMessage(Iterable<Value<?>> record, RecordEnrichment enrichment) throws IllegalFlowException {
-        Netflow5MessageBuilder builder = new Netflow5MessageBuilder();
-        return builder.buildData(record, enrichment);
     }
 }

--- a/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/Netflow9UdpParser.java
+++ b/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/Netflow9UdpParser.java
@@ -87,8 +87,8 @@ public class Netflow9UdpParser extends UdpParserBase implements UdpParser, Dispa
 
     @Override
     protected byte[] buildMessage(Iterable<Value<?>> record, RecordEnrichment enrichment) throws IllegalFlowException{
-        Netflow9MessageBuilder builder = new Netflow9MessageBuilder(record, enrichment);
-        return builder.buildData();
+        Netflow9MessageBuilder builder = new Netflow9MessageBuilder();
+        return builder.buildData(record, enrichment);
     }
 
     public static class SessionKey implements UdpSessionManager.SessionKey {

--- a/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/Netflow9UdpParser.java
+++ b/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/Netflow9UdpParser.java
@@ -62,7 +62,7 @@ public class Netflow9UdpParser extends UdpParserBase implements UdpParser, Dispa
                              final Identity identity,
                              final DnsResolver dnsResolver,
                              final MetricRegistry metricRegistry) {
-        super(Protocol.NETFLOW9, name, dispatcher, eventForwarder, identity, dnsResolver, metricRegistry);
+        super(Protocol.NETFLOW9, name, new Netflow9MessageBuilder(), dispatcher, eventForwarder, identity, dnsResolver, metricRegistry);
     }
 
     @Override
@@ -83,12 +83,6 @@ public class Netflow9UdpParser extends UdpParserBase implements UdpParser, Dispa
     @Override
     protected UdpSessionManager.SessionKey buildSessionKey(final InetSocketAddress remoteAddress, final InetSocketAddress localAddress) {
         return new SessionKey(remoteAddress.getAddress(), localAddress);
-    }
-
-    @Override
-    protected byte[] buildMessage(Iterable<Value<?>> record, RecordEnrichment enrichment) throws IllegalFlowException{
-        Netflow9MessageBuilder builder = new Netflow9MessageBuilder();
-        return builder.buildData(record, enrichment);
     }
 
     public static class SessionKey implements UdpSessionManager.SessionKey {

--- a/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/ParserBase.java
+++ b/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/ParserBase.java
@@ -34,6 +34,7 @@ import java.nio.ByteBuffer;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Date;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -54,8 +55,10 @@ import org.opennms.netmgt.model.events.EventBuilder;
 import org.opennms.netmgt.telemetry.api.receiver.Parser;
 import org.opennms.netmgt.telemetry.api.receiver.TelemetryMessage;
 import org.opennms.netmgt.telemetry.protocols.netflow.parser.ie.RecordProvider;
-import org.opennms.netmgt.telemetry.protocols.netflow.parser.ie.Value;
 import org.opennms.netmgt.telemetry.protocols.netflow.parser.session.Session;
+import org.opennms.netmgt.telemetry.protocols.netflow.parser.transport.MessageBuilder;
+import org.opennms.netmgt.telemetry.protocols.netflow.transport.FlowMessage;
+import org.opennms.netmgt.telemetry.protocols.netflow.transport.FlowMessageOrBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -63,15 +66,22 @@ import com.codahale.metrics.Counter;
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
+import com.google.common.base.Joiner;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
+import com.google.common.collect.Lists;
 import com.swrve.ratelimitedlogger.RateLimitedLog;
 
 public abstract class ParserBase implements Parser {
     private static final Logger LOG = LoggerFactory.getLogger(ParserBase.class);
 
     private final RateLimitedLog SEQUENCE_ERRORS_LOGGER = RateLimitedLog
+            .withRateLimit(LOG)
+            .maxRate(5).every(Duration.ofSeconds(30))
+            .build();
+
+    private final RateLimitedLog CORRECTION_LOGGER = RateLimitedLog
             .withRateLimit(LOG)
             .maxRate(5).every(Duration.ofSeconds(30))
             .build();
@@ -91,6 +101,8 @@ public abstract class ParserBase implements Parser {
     private final Protocol protocol;
 
     private final String name;
+
+    private final MessageBuilder messageBuilder;
 
     private final AsyncDispatcher<TelemetryMessage> dispatcher;
 
@@ -138,6 +150,7 @@ public abstract class ParserBase implements Parser {
 
     public ParserBase(final Protocol protocol,
                       final String name,
+                      final MessageBuilder messageBuilder,
                       final AsyncDispatcher<TelemetryMessage> dispatcher,
                       final EventForwarder eventForwarder,
                       final Identity identity,
@@ -145,6 +158,7 @@ public abstract class ParserBase implements Parser {
                       final MetricRegistry metricRegistry) {
         this.protocol = Objects.requireNonNull(protocol);
         this.name = Objects.requireNonNull(name);
+        this.messageBuilder = Objects.requireNonNull(messageBuilder);
         this.dispatcher = Objects.requireNonNull(dispatcher);
         this.eventForwarder = Objects.requireNonNull(eventForwarder);
         this.identity = Objects.requireNonNull(identity);
@@ -304,10 +318,16 @@ public abstract class ParserBase implements Parser {
                     // if we can't keep up
                     final Runnable dispatch = () -> {
                         // Let's serialize
-                        byte[] flowMessage = new byte[0];
+                        final FlowMessage.Builder flowMessage;
                         try {
-                            flowMessage = buildMessage(record, enrichment);
-                        } catch (IllegalFlowException e) {
+                            flowMessage = this.messageBuilder.buildMessage(record, enrichment);
+                        } catch (final  Exception e) {
+                            throw new RuntimeException(e);
+                        }
+
+                        // Check if the flow is valid (and maybe correct it)
+                        final List<String> corrections = this.correctFlow(flowMessage);
+                        if (!corrections.isEmpty()) {
                             this.invalidFlows.mark();
 
                             final Optional<Instant> instant = illegalFlowEventCache.getUnchecked(session.getRemoteAddress());
@@ -323,20 +343,19 @@ public abstract class ParserBase implements Parser {
                                         .setDistPoller(identity.getId())
                                         .addParam("monitoringSystemId", identity.getId())
                                         .addParam("monitoringSystemLocation", identity.getLocation())
-                                        .setParam("cause", e.getMessage())
+                                        .setParam("cause", Joiner.on('\n').join(corrections))
                                         .setParam("protocol", protocol.name())
                                         .setParam("illegalFlowEventRate", (int) getIllegalFlowEventRate())
                                         .getEvent());
 
-                                LOG.warn("Illegal flow detected from exporter {}", session.getRemoteAddress().getAddress(), e);
+                                for (final String correction : corrections) {
+                                    LOG.warn("Illegal flow detected from exporter {}: \n{}", session.getRemoteAddress().getAddress(), correction);
+                                }
                             }
-
-                            future.complete(null);
-                            return;
                         }
 
                         // Build the message to dispatch
-                        final TelemetryMessage msg = new TelemetryMessage(remoteAddress, ByteBuffer.wrap(flowMessage));
+                        final TelemetryMessage msg = new TelemetryMessage(remoteAddress, ByteBuffer.wrap(flowMessage.build().toByteArray()));
 
                         // Dispatch
                         dispatcher.send(msg).whenComplete((b, exx) -> {
@@ -389,8 +408,6 @@ public abstract class ParserBase implements Parser {
         return future;
     }
 
-    protected abstract byte[] buildMessage(Iterable<Value<?>> record, RecordEnrichment enrichment) throws IllegalFlowException;
-
     protected void detectClockSkew(final long packetTimestampMs, final InetAddress remoteAddress) {
         if (getMaxClockSkew() > 0) {
             long deltaMs = Math.abs(packetTimestampMs - System.currentTimeMillis());
@@ -418,4 +435,27 @@ public abstract class ParserBase implements Parser {
         }
     }
 
+    private List<String> correctFlow(final FlowMessage.Builder flow) {
+        final List<String> corrections = Lists.newArrayList();
+
+        if (flow.getFirstSwitched().getValue() > flow.getLastSwitched().getValue()) {
+            corrections.add(String.format("Malformed flow: lastSwitched must be greater than firstSwitched: srcAddress=%s, dstAddress=%s, firstSwitched=%d, lastSwitched=%d, duration=%d",
+                                  flow.getSrcAddress(),
+                                  flow.getDstAddress(),
+                                  flow.getFirstSwitched().getValue(),
+                                  flow.getLastSwitched().getValue(),
+                                  flow.getLastSwitched().getValue() - flow.getFirstSwitched().getValue()));
+
+            // Re-calculate a (somewhat) valid timout from the flow timestamps
+            final long timeout = (flow.hasDeltaSwitched() && flow.getDeltaSwitched().getValue() != flow.getFirstSwitched().getValue())
+                    ? (flow.getLastSwitched().getValue() - flow.getDeltaSwitched().getValue())
+                    : 0L;
+
+            flow.getLastSwitchedBuilder().setValue(flow.getTimestamp());
+            flow.getFirstSwitchedBuilder().setValue(flow.getTimestamp() - timeout);
+            flow.getDeltaSwitchedBuilder().setValue(flow.getTimestamp() - timeout);
+        }
+
+        return corrections;
+    }
 }

--- a/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/ParserBase.java
+++ b/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/ParserBase.java
@@ -81,11 +81,6 @@ public abstract class ParserBase implements Parser {
             .maxRate(5).every(Duration.ofSeconds(30))
             .build();
 
-    private final RateLimitedLog CORRECTION_LOGGER = RateLimitedLog
-            .withRateLimit(LOG)
-            .maxRate(5).every(Duration.ofSeconds(30))
-            .build();
-
     private static final int DEFAULT_NUM_THREADS = Runtime.getRuntime().availableProcessors() * 2;
 
     private static final long DEFAULT_CLOCK_SKEW_EVENT_RATE_SECONDS = TimeUnit.HOURS.toSeconds(1);

--- a/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/UdpParserBase.java
+++ b/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/UdpParserBase.java
@@ -44,6 +44,7 @@ import org.opennms.netmgt.telemetry.listeners.UdpParser;
 import org.opennms.netmgt.telemetry.protocols.netflow.parser.ie.RecordProvider;
 import org.opennms.netmgt.telemetry.protocols.netflow.parser.session.Session;
 import org.opennms.netmgt.telemetry.protocols.netflow.parser.session.UdpSessionManager;
+import org.opennms.netmgt.telemetry.protocols.netflow.parser.transport.MessageBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -68,12 +69,13 @@ public abstract class UdpParserBase extends ParserBase implements UdpParser {
 
     public UdpParserBase(final Protocol protocol,
                          final String name,
+                         final MessageBuilder messageBuilder,
                          final AsyncDispatcher<TelemetryMessage> dispatcher,
                          final EventForwarder eventForwarder,
                          final Identity identity,
                          final DnsResolver dnsResolver,
                          final MetricRegistry metricRegistry) {
-        super(protocol, name, dispatcher, eventForwarder, identity, dnsResolver, metricRegistry);
+        super(protocol, name, messageBuilder, dispatcher, eventForwarder, identity, dnsResolver, metricRegistry);
 
         this.packetsReceived = metricRegistry.meter(MetricRegistry.name("parsers",  name, "packetsReceived"));
         this.parserErrors = metricRegistry.counter(MetricRegistry.name("parsers",  name, "parserErrors"));

--- a/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/transport/IpFixMessageBuilder.java
+++ b/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/transport/IpFixMessageBuilder.java
@@ -54,89 +54,323 @@ import com.google.common.primitives.UnsignedLong;
 
 public class IpFixMessageBuilder {
 
-    private final FlowMessage.Builder builder;
-    private final Iterable<Value<?>> values;
-    private final RecordEnrichment enrichment;
-    private Long exportTime;
-    private Long octetDeltaCount;
-    private Long postOctetDeltaCount;
-    private Long layer2OctetDeltaCount;
-    private Long postLayer2OctetDeltaCount;
-    private Long transportOctetDeltaCount;
-    private InetAddress destinationIPv6Address;
-    private InetAddress destinationIPv4Address;
-    private Long destinationIPv6PrefixLength;
-    private Long destinationIPv4PrefixLength;
-    private Instant flowStartSeconds;
-    private Instant flowStartMilliseconds;
-    private Instant flowStartMicroseconds;
-    private Instant flowStartNanoseconds;
-    private Long flowStartDeltaMicroseconds;
-    private Long flowStartSysUpTime;
-    private Instant systemInitTimeMilliseconds;
-    private Instant flowEndSeconds;
-    private Instant flowEndMilliseconds;
-    private Instant flowEndMicroseconds;
-    private Instant flowEndNanoseconds;
-    private Long flowEndDeltaMicroseconds;
-    private Long flowEndSysUpTime;
-    private InetAddress ipNextHopIPv6Address;
-    private InetAddress ipNextHopIPv4Address;
-    private InetAddress bgpNextHopIPv6Address;
-    private InetAddress bgpNextHopIPv4Address;
-    private Long packetDeltaCount;
-    private Long postPacketDeltaCount;
-    private Long transportPacketDeltaCount;
-    private Long samplingAlgorithm;
-    private Long samplerMode;
-    private Long selectorAlgorithm;
-    private Long samplingInterval;
-    private Long samplerRandomInterval;
-    private Long samplingFlowInterval;
-    private Long samplingFlowSpacing;
-    private Long flowSamplingTimeInterval;
-    private Long flowSamplingTimeSpacing;
-    private Long samplingSize;
-    private Long samplingPopulation;
-    private Long samplingProbability;
-    private Long hashSelectedRangeMin;
-    private Long hashSelectedRangeMax;
-    private Long hashOutputRangeMin;
-    private Long hashOutputRangeMax;
-    private InetAddress sourceIPv6Address;
-    private InetAddress sourceIPv4Address;
-    private Long sourceIPv6PrefixLength;
-    private Long sourceIPv4PrefixLength;
-    private Long vlanId;
-    private Long postVlanId;
-    private Long dot1qVlanId;
-    private Long dot1qCustomerVlanId;
-    private Long postDot1qVlanId;
-    private Long postDot1qCustomerVlanId;
-    private Long flowActiveTimeout;
-    private Long flowInactiveTimeout;
-    private Long numBytes;
-    private Long numPackets;
-
-    public IpFixMessageBuilder(Iterable<Value<?>> values, RecordEnrichment enrichment) {
-        this.values = values;
-        this.enrichment = enrichment;
-        this.builder = FlowMessage.newBuilder();
+    public IpFixMessageBuilder() {
     }
 
-    public byte[] buildData() throws IllegalFlowException {
+    public byte[] buildData(final Iterable<Value<?>> values, final RecordEnrichment enrichment) throws IllegalFlowException {
+        final FlowMessage.Builder builder = FlowMessage.newBuilder();
 
-        values.forEach(this::addField);
+        Long exportTime = null;
+        Long octetDeltaCount = null;
+        Long postOctetDeltaCount = null;
+        Long layer2OctetDeltaCount = null;
+        Long postLayer2OctetDeltaCount = null;
+        Long transportOctetDeltaCount = null;
+        InetAddress destinationIPv6Address = null;
+        InetAddress destinationIPv4Address = null;
+        Long destinationIPv6PrefixLength = null;
+        Long destinationIPv4PrefixLength = null;
+        Instant flowStartSeconds = null;
+        Instant flowStartMilliseconds = null;
+        Instant flowStartMicroseconds = null;
+        Instant flowStartNanoseconds = null;
+        Long flowStartDeltaMicroseconds = null;
+        Long flowStartSysUpTime = null;
+        Instant systemInitTimeMilliseconds = null;
+        Instant flowEndSeconds = null;
+        Instant flowEndMilliseconds = null;
+        Instant flowEndMicroseconds = null;
+        Instant flowEndNanoseconds = null;
+        Long flowEndDeltaMicroseconds = null;
+        Long flowEndSysUpTime = null;
+        InetAddress ipNextHopIPv6Address = null;
+        InetAddress ipNextHopIPv4Address = null;
+        InetAddress bgpNextHopIPv6Address = null;
+        InetAddress bgpNextHopIPv4Address = null;
+        Long packetDeltaCount = null;
+        Long postPacketDeltaCount = null;
+        Long transportPacketDeltaCount = null;
+        Long samplingAlgorithm = null;
+        Long samplerMode = null;
+        Long selectorAlgorithm = null;
+        Long samplingInterval = null;
+        Long samplerRandomInterval = null;
+        Long samplingFlowInterval = null;
+        Long samplingFlowSpacing = null;
+        Long flowSamplingTimeInterval = null;
+        Long flowSamplingTimeSpacing = null;
+        Long samplingSize = null;
+        Long samplingPopulation = null;
+        Long samplingProbability = null;
+        Long hashSelectedRangeMin = null;
+        Long hashSelectedRangeMax = null;
+        Long hashOutputRangeMin = null;
+        Long hashOutputRangeMax = null;
+        InetAddress sourceIPv6Address = null;
+        InetAddress sourceIPv4Address = null;
+        Long sourceIPv6PrefixLength = null;
+        Long sourceIPv4PrefixLength = null;
+        Long vlanId = null;
+        Long postVlanId = null;
+        Long dot1qVlanId = null;
+        Long dot1qCustomerVlanId = null;
+        Long postDot1qVlanId = null;
+        Long postDot1qCustomerVlanId = null;
+        Long flowActiveTimeout = null;
+        Long flowInactiveTimeout = null;
+
+        for (Value<?> value : values) {
+            switch (value.getName()) {
+                case "@exportTime":
+                    exportTime = getLongValue(value);
+                    break;
+                case "octetDeltaCount":
+                    octetDeltaCount = getLongValue(value);
+                    break;
+                case "postOctetDeltaCount":
+                    postOctetDeltaCount = getLongValue(value);
+                    break;
+                case "layer2OctetDeltaCount":
+                    layer2OctetDeltaCount = getLongValue(value);
+                    break;
+                case "postLayer2OctetDeltaCount":
+                    postLayer2OctetDeltaCount = getLongValue(value);
+                    break;
+                case "transportOctetDeltaCount":
+                    transportOctetDeltaCount = getLongValue(value);
+                    break;
+                case "flowDirection":
+                    Long directionValue = getLongValue(value);
+                    Direction direction = Direction.UNRECOGNIZED;
+                    if (directionValue != null) {
+                        switch (directionValue.intValue()) {
+                            case 0:
+                                direction = Direction.INGRESS;
+                                break;
+                            case 1:
+                                direction = Direction.EGRESS;
+                                break;
+                        }
+                    }
+                    if (!direction.equals(Direction.UNRECOGNIZED)) {
+                        builder.setDirection(direction);
+                    }
+                    break;
+                case "destinationIPv6Address":
+                    destinationIPv6Address = getInetAddress(value);
+                    break;
+                case "destinationIPv4Address":
+                    destinationIPv4Address = getInetAddress(value);
+                    break;
+                case "bgpDestinationAsNumber":
+                    getUInt64Value(value).ifPresent(builder::setDstAs);
+                    break;
+                case "destinationIPv6PrefixLength":
+                    destinationIPv6PrefixLength = getLongValue(value);
+                    break;
+                case "destinationIPv4PrefixLength":
+                    destinationIPv4PrefixLength = getLongValue(value);
+                    break;
+                case "destinationTransportPort":
+                    getUInt32Value(value).ifPresent(builder::setDstPort);
+                    break;
+                case "engineId":
+                    getUInt32Value(value).ifPresent(builder::setEngineId);
+                    break;
+                case "engineType":
+                    getUInt32Value(value).ifPresent(builder::setEngineType);
+                    break;
+                case "@recordCount":
+                    getUInt32Value(value).ifPresent(builder::setNumFlowRecords);
+                    break;
+                case "@sequenceNumber":
+                    getUInt64Value(value).ifPresent(builder::setFlowSeqNum);
+                    break;
+                case "ingressInterface":
+                    getUInt32Value(value).ifPresent(builder::setInputSnmpIfindex);
+                    break;
+                case "ipVersion":
+                    Long ipVersion = getLongValue(value);
+                    if (ipVersion != null) {
+                        builder.setIpProtocolVersion(setIntValue(ipVersion.intValue()));
+                    }
+                    break;
+                case "egressInterface":
+                    getUInt32Value(value).ifPresent(builder::setOutputSnmpIfindex);
+                    break;
+                case "protocolIdentifier":
+                    getUInt32Value(value).ifPresent(builder::setProtocol);
+                    break;
+                case "tcpControlBits":
+                    getUInt32Value(value).ifPresent(builder::setTcpFlags);
+                    break;
+                case "ipClassOfService":
+                    getUInt32Value(value).ifPresent(builder::setTos);
+                    break;
+                case "@observationDomainId":
+                    Long observationDomainId = getLongValue(value);
+                    if (observationDomainId != null) {
+                        builder.setNodeIdentifier(String.valueOf(observationDomainId));
+                    }
+                    break;
+
+                case "flowStartSeconds":
+                    flowStartSeconds = getTime(value);
+                    break;
+                case "flowStartMilliseconds":
+                    flowStartMilliseconds = getTime(value);
+                    break;
+                case "flowStartMicroseconds":
+                    flowStartMicroseconds = getTime(value);
+                    break;
+                case "flowStartNanoseconds":
+                    flowStartNanoseconds = getTime(value);
+                    break;
+                case "flowStartDeltaMicroseconds":
+                    flowStartDeltaMicroseconds = getLongValue(value);
+                    break;
+                case "flowStartSysUpTime":
+                    flowStartSysUpTime = getLongValue(value);
+                    break;
+                case "systemInitTimeMilliseconds":
+                    systemInitTimeMilliseconds = getTime(value);
+                    break;
+                case "flowEndSeconds":
+                    flowEndSeconds = getTime(value);
+                    break;
+                case "flowEndMilliseconds":
+                    flowEndMilliseconds = getTime(value);
+                    break;
+                case "flowEndMicroseconds":
+                    flowEndMicroseconds = getTime(value);
+                    break;
+                case "flowEndNanoseconds":
+                    flowEndNanoseconds = getTime(value);
+                case "flowEndDeltaMicroseconds":
+                    flowEndDeltaMicroseconds = getLongValue(value);
+                    break;
+                case "flowEndSysUpTime":
+                    flowEndSysUpTime = getLongValue(value);
+                    break;
+                case "ipNextHopIPv6Address":
+                    ipNextHopIPv6Address = getInetAddress(value);
+                    break;
+                case "ipNextHopIPv4Address":
+                    ipNextHopIPv4Address = getInetAddress(value);
+                    break;
+                case "bgpNextHopIPv6Address":
+                    bgpNextHopIPv6Address = getInetAddress(value);
+                    break;
+                case "bgpNextHopIPv4Address":
+                    bgpNextHopIPv4Address = getInetAddress(value);
+                    break;
+                case "packetDeltaCount":
+                    packetDeltaCount = getLongValue(value);
+                    break;
+                case "postPacketDeltaCount":
+                    postPacketDeltaCount = getLongValue(value);
+                    break;
+                case "transportPacketDeltaCount":
+                    transportPacketDeltaCount = getLongValue(value);
+                    break;
+                case "samplingAlgorithm":
+                    samplingAlgorithm = getLongValue(value);
+                    break;
+                case "samplerMode":
+                    samplerMode = getLongValue(value);
+                    break;
+                case "selectorAlgorithm":
+                    selectorAlgorithm = getLongValue(value);
+                    break;
+                case "samplingInterval":
+                    samplingInterval = getLongValue(value);
+                    break;
+                case "samplerRandomInterval":
+                    samplerRandomInterval = getLongValue(value);
+                    break;
+                case "samplingFlowInterval":
+                    samplingFlowInterval = getLongValue(value);
+                    break;
+                case "samplingFlowSpacing":
+                    samplingFlowSpacing = getLongValue(value);
+                    break;
+                case "flowSamplingTimeInterval":
+                    flowSamplingTimeInterval = getLongValue(value);
+                    break;
+                case "flowSamplingTimeSpacing":
+                    flowSamplingTimeSpacing = getLongValue(value);
+                    break;
+                case "samplingSize":
+                    samplingSize = getLongValue(value);
+                    break;
+                case "samplingPopulation":
+                    samplingPopulation = getLongValue(value);
+                    break;
+                case "samplingProbability":
+                    samplingProbability = getLongValue(value);
+                    break;
+                case "hashSelectedRangeMin":
+                    hashSelectedRangeMin = getLongValue(value);
+                    break;
+                case "hashSelectedRangeMax":
+                    hashSelectedRangeMax = getLongValue(value);
+                    break;
+                case "hashOutputRangeMin":
+                    hashOutputRangeMin = getLongValue(value);
+                    break;
+                case "hashOutputRangeMax":
+                    hashOutputRangeMax = getLongValue(value);
+                    break;
+                case "sourceIPv6Address":
+                    sourceIPv6Address = getInetAddress(value);
+                    break;
+                case "sourceIPv4Address":
+                    sourceIPv4Address = getInetAddress(value);
+                    break;
+                case "sourceIPv6PrefixLength":
+                    sourceIPv6PrefixLength = getLongValue(value);
+                    break;
+                case "sourceIPv4PrefixLength":
+                    sourceIPv4PrefixLength = getLongValue(value);
+                    break;
+                case "sourceTransportPort":
+                    getUInt32Value(value).ifPresent(builder::setSrcPort);
+                    break;
+                case "vlanId":
+                    vlanId = getLongValue(value);
+                    break;
+                case "postVlanId":
+                    postVlanId = getLongValue(value);
+                    break;
+                case "dot1qVlanId":
+                    dot1qVlanId = getLongValue(value);
+                    break;
+                case "dot1qCustomerVlanId":
+                    dot1qCustomerVlanId = getLongValue(value);
+                    break;
+                case "postDot1qVlanId":
+                    postDot1qVlanId = getLongValue(value);
+                    break;
+                case "postDot1qCustomerVlanId":
+                    postDot1qCustomerVlanId = getLongValue(value);
+                    break;
+                case "flowActiveTimeout":
+                    flowActiveTimeout = getLongValue(value);
+                    break;
+                case "flowInactiveTimeout":
+                    flowInactiveTimeout = getLongValue(value);
+                    break;
+            }
+        }
 
         first(octetDeltaCount,
                 postOctetDeltaCount,
                 layer2OctetDeltaCount,
                 postLayer2OctetDeltaCount,
                 transportOctetDeltaCount)
-                .ifPresent(bytes -> {
-                    numBytes = bytes;
-                    builder.setNumBytes(setLongValue(bytes));
-                });
+                .ifPresent(bytes ->
+                    builder.setNumBytes(setLongValue(bytes))
+                );
 
         first(destinationIPv6Address,
                 destinationIPv4Address).ifPresent(ipAddress -> {
@@ -173,18 +407,18 @@ public class IpFixMessageBuilder {
                 dot1qCustomerVlanId,
                 postDot1qVlanId,
                 postDot1qCustomerVlanId)
-                .ifPresent(vlanId -> builder.setVlan(setIntValue(vlanId.intValue())));
+                .ifPresent(vlan -> builder.setVlan(setIntValue(vlan.intValue())));
 
-        long timeStamp = this.exportTime  != null ? exportTime * 1000 : 0;
+        long timeStamp = exportTime  != null ? exportTime * 1000 : 0;
         builder.setTimestamp(timeStamp);
 
         // Set first switched
-        Long flowStartDeltaMicroseconds = this.flowStartDeltaMicroseconds != null ?
-                this.flowStartDeltaMicroseconds + timeStamp : null;
-        Long systemInitTimeMilliseconds = this.systemInitTimeMilliseconds != null ?
-                this.systemInitTimeMilliseconds.toEpochMilli() : null;
-        Long flowStartSysUpTime = this.flowStartSysUpTime != null && systemInitTimeMilliseconds != null ?
-                this.flowStartSysUpTime + systemInitTimeMilliseconds : null;
+        Long flowStartDelta = flowStartDeltaMicroseconds != null ?
+                flowStartDeltaMicroseconds + timeStamp : null;
+        Long systemInitTime = systemInitTimeMilliseconds != null ?
+                systemInitTimeMilliseconds.toEpochMilli() : null;
+        Long flowStart = flowStartSysUpTime != null && systemInitTime != null ?
+                flowStartSysUpTime + systemInitTime : null;
 
         Optional<Long> firstSwitchedInMilli = first(flowStartSeconds,
                 flowStartMilliseconds,
@@ -193,18 +427,18 @@ public class IpFixMessageBuilder {
         if (firstSwitchedInMilli.isPresent()) {
             builder.setFirstSwitched(setLongValue(firstSwitchedInMilli.get()));
         } else {
-            first(flowStartDeltaMicroseconds,
-                    flowStartSysUpTime).ifPresent(firstSwitched -> {
+            first(flowStartDelta,
+                    flowStart).ifPresent(firstSwitched -> {
                         builder.setFirstSwitched(setLongValue(firstSwitched));
                     }
             );
         }
 
         // Set lastSwitched
-        Long flowEndDeltaMicroseconds = this.flowEndDeltaMicroseconds != null ?
-                this.flowEndDeltaMicroseconds + timeStamp : null;
-        Long flowEndSysUpTime = this.flowEndSysUpTime != null && systemInitTimeMilliseconds != null ?
-                this.flowEndSysUpTime + systemInitTimeMilliseconds : null;
+        Long flowEndDelta = flowEndDeltaMicroseconds != null ?
+                flowEndDeltaMicroseconds + timeStamp : null;
+        Long flowEnd = flowEndSysUpTime != null && systemInitTime != null ?
+                flowEndSysUpTime + systemInitTime : null;
 
         Optional<Long> lastSwitchedInMilli = first(flowEndSeconds,
                 flowEndMilliseconds,
@@ -214,8 +448,8 @@ public class IpFixMessageBuilder {
         if(lastSwitchedInMilli.isPresent()) {
             builder.setLastSwitched(setLongValue(lastSwitchedInMilli.get()));
         } else {
-            first(flowEndDeltaMicroseconds,
-                    flowEndSysUpTime).ifPresent(lastSwitchedValue -> {
+            first(flowEndDelta,
+                    flowEnd).ifPresent(lastSwitchedValue -> {
                 builder.setLastSwitched(setLongValue(lastSwitchedValue));
             });
         }
@@ -224,55 +458,51 @@ public class IpFixMessageBuilder {
                 postPacketDeltaCount,
                 transportPacketDeltaCount).ifPresent(packets -> {
             builder.setNumPackets(setLongValue(packets));
-            this.numPackets = packets;
         });
 
-        SamplingAlgorithm samplingAlgorithm = SamplingAlgorithm.UNASSIGNED;
-        final Integer deprecatedSamplingAlgorithm = first(this.samplingAlgorithm,
-                samplerMode)
+        SamplingAlgorithm sampling = SamplingAlgorithm.UNASSIGNED;
+        final Integer deprecatedSamplingAlgorithm = first(samplingAlgorithm, samplerMode)
                 .map(Long::intValue).orElse(null);
         if (deprecatedSamplingAlgorithm != null) {
             if (deprecatedSamplingAlgorithm == 1) {
-                samplingAlgorithm = SamplingAlgorithm.SYSTEMATIC_COUNT_BASED_SAMPLING;
+                sampling = SamplingAlgorithm.SYSTEMATIC_COUNT_BASED_SAMPLING;
             }
             if (deprecatedSamplingAlgorithm == 2) {
-                samplingAlgorithm = SamplingAlgorithm.RANDOM_N_OUT_OF_N_SAMPLING;
+                sampling = SamplingAlgorithm.RANDOM_N_OUT_OF_N_SAMPLING;
             }
         }
 
-        final Integer selectorAlgorithm = this.selectorAlgorithm != null ? this.selectorAlgorithm.intValue() : null;
-
         if (selectorAlgorithm != null) {
-            switch (selectorAlgorithm) {
+            switch (selectorAlgorithm.intValue()) {
                 case 0:
-                    samplingAlgorithm = SamplingAlgorithm.UNASSIGNED;
+                    sampling = SamplingAlgorithm.UNASSIGNED;
                     break;
                 case 1:
-                    samplingAlgorithm = SamplingAlgorithm.SYSTEMATIC_COUNT_BASED_SAMPLING;
+                    sampling = SamplingAlgorithm.SYSTEMATIC_COUNT_BASED_SAMPLING;
                     break;
                 case 2:
-                    samplingAlgorithm = SamplingAlgorithm.SYSTEMATIC_TIME_BASED_SAMPLING;
+                    sampling = SamplingAlgorithm.SYSTEMATIC_TIME_BASED_SAMPLING;
                     break;
                 case 3:
-                    samplingAlgorithm = SamplingAlgorithm.RANDOM_N_OUT_OF_N_SAMPLING;
+                    sampling = SamplingAlgorithm.RANDOM_N_OUT_OF_N_SAMPLING;
                     break;
                 case 4:
-                    samplingAlgorithm = SamplingAlgorithm.UNIFORM_PROBABILISTIC_SAMPLING;
+                    sampling = SamplingAlgorithm.UNIFORM_PROBABILISTIC_SAMPLING;
                     break;
                 case 5:
-                    samplingAlgorithm = SamplingAlgorithm.PROPERTY_MATCH_FILTERING;
+                    sampling = SamplingAlgorithm.PROPERTY_MATCH_FILTERING;
                     break;
                 case 6:
                 case 7:
                 case 8:
-                    samplingAlgorithm = SamplingAlgorithm.HASH_BASED_FILTERING;
+                    sampling = SamplingAlgorithm.HASH_BASED_FILTERING;
                     break;
                 case 9:
-                    samplingAlgorithm = SamplingAlgorithm.FLOW_STATE_DEPENDENT_INTERMEDIATE_FLOW_SELECTION_PROCESS;
+                    sampling = SamplingAlgorithm.FLOW_STATE_DEPENDENT_INTERMEDIATE_FLOW_SELECTION_PROCESS;
                     break;
             }
         }
-        builder.setSamplingAlgorithm(samplingAlgorithm);
+        builder.setSamplingAlgorithm(sampling);
 
         final Double deprecatedSamplingInterval = first(
                 samplingInterval,
@@ -283,52 +513,50 @@ public class IpFixMessageBuilder {
             builder.setSamplingInterval(setDoubleValue(deprecatedSamplingInterval));
         } else {
             if (selectorAlgorithm != null) {
-                switch (selectorAlgorithm) {
+                switch (selectorAlgorithm.intValue()) {
                     case 0:
                         break;
-                    case 1:
-                        Double samplingInterval = this.samplingFlowInterval != null ?
-                                samplingFlowInterval.doubleValue() : 1.0;
-                        Double samplingSpacing = samplingFlowSpacing != null ?
-                                samplingFlowSpacing.doubleValue() : 0.0;
-                        Double samplingIntervalValue = samplingInterval + samplingSpacing / samplingInterval;
+                    case 1: {
+                        double interval = samplingFlowInterval != null ?
+                                          samplingFlowInterval.doubleValue() : 1.0;
+                        double spacing = samplingFlowSpacing != null ?
+                                         samplingFlowSpacing.doubleValue() : 0.0;
+                        double samplingIntervalValue = interval + spacing / interval;
                         builder.setSamplingInterval(setDoubleValue(samplingIntervalValue));
                         break;
-                    case 2:
-                        Double flowSamplingTimeInterval = this.flowSamplingTimeInterval != null ?
-                                this.flowSamplingTimeInterval.doubleValue() : 1.0;
-                        Double flowSamplingTimeSpacing = this.flowSamplingTimeSpacing != null ?
-                                this.flowSamplingTimeSpacing.doubleValue() : 0.0;
-                        samplingIntervalValue = flowSamplingTimeInterval + flowSamplingTimeSpacing / flowSamplingTimeSpacing;
+                    }
+                    case 2: {
+                        double interval = flowSamplingTimeInterval != null ?
+                                          flowSamplingTimeInterval.doubleValue() : 1.0;
+                        double spacing = flowSamplingTimeSpacing != null ?
+                                         flowSamplingTimeSpacing.doubleValue() : 0.0;
+                        double samplingIntervalValue = interval + spacing / spacing;
                         builder.setSamplingInterval(setDoubleValue(samplingIntervalValue));
                         break;
-                    case 3:
-                        Double samplingSize = this.samplingSize != null ?
-                                this.samplingSize.doubleValue() : 1.0;
-                        Double samplingPopulation = this.samplingPopulation != null ?
-                                this.samplingPopulation.doubleValue() : 1.0;
-                        samplingIntervalValue = samplingPopulation / samplingSize;
+                    }
+                    case 3: {
+                        double size = samplingSize != null ? samplingSize.doubleValue() : 1.0;
+                        double population = samplingPopulation != null ? samplingPopulation.doubleValue() : 1.0;
+                        double samplingIntervalValue = population / size;
                         builder.setSamplingInterval(setDoubleValue(samplingIntervalValue));
                         break;
-                    case 4:
-                        Double samplingProbability = this.samplingProbability != null ?
-                                this.samplingProbability.doubleValue() : 1.0;
-                        builder.setSamplingInterval(setDoubleValue(1.0 / samplingProbability));
+                    }
+                    case 4: {
+                        Double probability = samplingProbability != null ? samplingProbability.doubleValue() : 1.0;
+                        builder.setSamplingInterval(setDoubleValue(1.0 / probability));
                         break;
+                    }
                     case 5:
                     case 6:
-                    case 7:
-                        UnsignedLong hashSelectedRangeMin = this.hashSelectedRangeMin != null ?
-                                UnsignedLong.fromLongBits(this.hashSelectedRangeMin) : UnsignedLong.ZERO;
-                        UnsignedLong hashSelectedRangeMax = this.hashSelectedRangeMax != null ?
-                                UnsignedLong.fromLongBits(this.hashSelectedRangeMax) : UnsignedLong.MAX_VALUE;
-                        UnsignedLong hashOutputRangeMin = this.hashOutputRangeMin != null ?
-                                UnsignedLong.fromLongBits(this.hashOutputRangeMin) : UnsignedLong.ZERO;
-                        UnsignedLong hashOutputRangeMax = this.hashOutputRangeMax != null ?
-                                UnsignedLong.fromLongBits(this.hashOutputRangeMax) : UnsignedLong.MAX_VALUE;
-                        samplingIntervalValue = (hashOutputRangeMax.minus(hashOutputRangeMin)).dividedBy(hashSelectedRangeMax.minus(hashSelectedRangeMin)).doubleValue();
+                    case 7: {
+                        UnsignedLong selectedRangeMin = hashSelectedRangeMin != null ? UnsignedLong.fromLongBits(hashSelectedRangeMin) : UnsignedLong.ZERO;
+                        UnsignedLong selectedRangeMax = hashSelectedRangeMax != null ? UnsignedLong.fromLongBits(hashSelectedRangeMax) : UnsignedLong.MAX_VALUE;
+                        UnsignedLong outputRangeMin = hashOutputRangeMin != null ? UnsignedLong.fromLongBits(hashOutputRangeMin) : UnsignedLong.ZERO;
+                        UnsignedLong outputRangeMax = hashOutputRangeMax != null ? UnsignedLong.fromLongBits(hashOutputRangeMax) : UnsignedLong.MAX_VALUE;
+                        double samplingIntervalValue = (outputRangeMax.minus(outputRangeMin)).dividedBy(selectedRangeMax.minus(selectedRangeMin)).doubleValue();
                         builder.setSamplingInterval(setDoubleValue(samplingIntervalValue));
                         break;
+                    }
                     case 8:
                     case 9:
                     default:
@@ -350,263 +578,15 @@ public class IpFixMessageBuilder {
         }
 
         // Build delta switched
-        Long firstSwitched = builder.hasFirstSwitched() ? builder.getFirstSwitched().getValue() : null;
-        Long lastSwitched = builder.hasLastSwitched() ? builder.getLastSwitched().getValue() : null;
-
         Timeout timeout = new Timeout(flowActiveTimeout, flowInactiveTimeout);
-        timeout.setFirstSwitched(firstSwitched);
-        timeout.setLastSwitched(lastSwitched);
-        timeout.setNumBytes(this.numBytes);
-        timeout.setNumPackets(this.numPackets);
+        timeout.setFirstSwitched(builder.hasFirstSwitched() ? builder.getFirstSwitched().getValue() : null);
+        timeout.setLastSwitched(builder.hasLastSwitched() ? builder.getLastSwitched().getValue() : null);
+        timeout.setNumBytes(builder.getNumBytes().getValue());
+        timeout.setNumPackets(builder.getNumPackets().getValue());
         Long deltaSwitched = timeout.getDeltaSwitched();
         getUInt64Value(deltaSwitched).ifPresent(builder::setDeltaSwitched);
 
         builder.setNetflowVersion(NetflowVersion.IPFIX);
         return builder.build().toByteArray();
-    }
-
-
-    private void addField(Value<?> value) {
-        switch (value.getName()) {
-            case "@exportTime":
-                exportTime = getLongValue(value);
-                break;
-            case "octetDeltaCount":
-                octetDeltaCount = getLongValue(value);
-                break;
-            case "postOctetDeltaCount":
-                postOctetDeltaCount = getLongValue(value);
-                break;
-            case "layer2OctetDeltaCount":
-                layer2OctetDeltaCount = getLongValue(value);
-                break;
-            case "postLayer2OctetDeltaCount":
-                postLayer2OctetDeltaCount = getLongValue(value);
-                break;
-            case "transportOctetDeltaCount":
-                transportOctetDeltaCount = getLongValue(value);
-                break;
-            case "flowDirection":
-                Long directionValue = getLongValue(value);
-                Direction direction = Direction.UNRECOGNIZED;
-                if (directionValue != null) {
-                    switch (directionValue.intValue()) {
-                        case 0:
-                            direction = Direction.INGRESS;
-                            break;
-                        case 1:
-                            direction = Direction.EGRESS;
-                            break;
-                    }
-                }
-                if (!direction.equals(Direction.UNRECOGNIZED)) {
-                    this.builder.setDirection(direction);
-                }
-                break;
-            case "destinationIPv6Address":
-                destinationIPv6Address = getInetAddress(value);
-                break;
-            case "destinationIPv4Address":
-                destinationIPv4Address = getInetAddress(value);
-                break;
-            case "bgpDestinationAsNumber":
-                getUInt64Value(value).ifPresent(builder::setDstAs);
-                break;
-            case "destinationIPv6PrefixLength":
-                destinationIPv6PrefixLength = getLongValue(value);
-                break;
-            case "destinationIPv4PrefixLength":
-                destinationIPv4PrefixLength = getLongValue(value);
-                break;
-            case "destinationTransportPort":
-                getUInt32Value(value).ifPresent(builder::setDstPort);
-                break;
-            case "engineId":
-                getUInt32Value(value).ifPresent(builder::setEngineId);
-                break;
-            case "engineType":
-                getUInt32Value(value).ifPresent(builder::setEngineType);
-                break;
-            case "@recordCount":
-                getUInt32Value(value).ifPresent(builder::setNumFlowRecords);
-                break;
-            case "@sequenceNumber":
-                getUInt64Value(value).ifPresent(builder::setFlowSeqNum);
-                break;
-            case "ingressInterface":
-                getUInt32Value(value).ifPresent(builder::setInputSnmpIfindex);
-                break;
-            case "ipVersion":
-                Long ipVersion = getLongValue(value);
-                if (ipVersion != null) {
-                    builder.setIpProtocolVersion(setIntValue(ipVersion.intValue()));
-                }
-                break;
-            case "egressInterface":
-                getUInt32Value(value).ifPresent( builder::setOutputSnmpIfindex);
-                break;
-            case "protocolIdentifier":
-                getUInt32Value(value).ifPresent(builder::setProtocol);
-                break;
-            case "tcpControlBits":
-                getUInt32Value(value).ifPresent(builder::setTcpFlags);
-                break;
-            case "ipClassOfService":
-                getUInt32Value(value).ifPresent(builder::setTos);
-                break;
-            case "@observationDomainId":
-                Long observationDomainId = getLongValue(value);
-                if (observationDomainId != null) {
-                    builder.setNodeIdentifier(String.valueOf(observationDomainId));
-                }
-                break;
-
-            case "flowStartSeconds":
-                flowStartSeconds = getTime(value);
-                break;
-            case "flowStartMilliseconds":
-                flowStartMilliseconds = getTime(value);
-                break;
-            case "flowStartMicroseconds":
-                flowStartMicroseconds = getTime(value);
-                break;
-            case "flowStartNanoseconds":
-                flowStartNanoseconds = getTime(value);
-                break;
-            case "flowStartDeltaMicroseconds":
-                flowStartDeltaMicroseconds = getLongValue(value);
-                break;
-            case "flowStartSysUpTime":
-                flowStartSysUpTime = getLongValue(value);
-                break;
-            case "systemInitTimeMilliseconds":
-                systemInitTimeMilliseconds = getTime(value);
-                break;
-            case "flowEndSeconds":
-                flowEndSeconds = getTime(value);
-                break;
-            case "flowEndMilliseconds":
-                flowEndMilliseconds = getTime(value);
-                break;
-            case "flowEndMicroseconds":
-                flowEndMicroseconds = getTime(value);
-                break;
-            case "flowEndNanoseconds":
-                flowEndNanoseconds = getTime(value);
-            case "flowEndDeltaMicroseconds":
-                flowEndDeltaMicroseconds = getLongValue(value);
-                break;
-            case "flowEndSysUpTime":
-                flowEndSysUpTime = getLongValue(value);
-                break;
-            case "ipNextHopIPv6Address":
-                ipNextHopIPv6Address = getInetAddress(value);
-                break;
-            case "ipNextHopIPv4Address":
-                ipNextHopIPv4Address = getInetAddress(value);
-                break;
-            case "bgpNextHopIPv6Address":
-                bgpNextHopIPv6Address = getInetAddress(value);
-                break;
-            case "bgpNextHopIPv4Address":
-                bgpNextHopIPv4Address = getInetAddress(value);
-                break;
-            case "packetDeltaCount":
-                packetDeltaCount = getLongValue(value);
-                break;
-            case "postPacketDeltaCount":
-                postPacketDeltaCount = getLongValue(value);
-                break;
-            case "transportPacketDeltaCount":
-                transportPacketDeltaCount = getLongValue(value);
-                break;
-            case "samplingAlgorithm":
-                samplingAlgorithm = getLongValue(value);
-                break;
-            case "samplerMode":
-                samplerMode = getLongValue(value);
-                break;
-            case "selectorAlgorithm":
-                selectorAlgorithm = getLongValue(value);
-                break;
-            case "samplingInterval":
-                samplingInterval = getLongValue(value);
-                break;
-            case "samplerRandomInterval":
-                samplerRandomInterval = getLongValue(value);
-                break;
-            case "samplingFlowInterval":
-                samplingFlowInterval = getLongValue(value);
-                break;
-            case "samplingFlowSpacing":
-                samplingFlowSpacing = getLongValue(value);
-                break;
-            case "flowSamplingTimeInterval":
-                flowSamplingTimeInterval = getLongValue(value);
-                break;
-            case "flowSamplingTimeSpacing":
-                flowSamplingTimeSpacing = getLongValue(value);
-                break;
-            case "samplingSize":
-                samplingSize = getLongValue(value);
-                break;
-            case "samplingPopulation":
-                samplingPopulation = getLongValue(value);
-                break;
-            case "samplingProbability":
-                samplingProbability = getLongValue(value);
-                break;
-            case "hashSelectedRangeMin":
-                hashSelectedRangeMin = getLongValue(value);
-                break;
-            case "hashSelectedRangeMax":
-                hashSelectedRangeMax = getLongValue(value);
-                break;
-            case "hashOutputRangeMin":
-                hashOutputRangeMin = getLongValue(value);
-                break;
-            case "hashOutputRangeMax":
-                hashOutputRangeMax = getLongValue(value);
-                break;
-            case "sourceIPv6Address":
-                sourceIPv6Address = getInetAddress(value);
-                break;
-            case "sourceIPv4Address":
-                sourceIPv4Address = getInetAddress(value);
-                break;
-            case "sourceIPv6PrefixLength":
-                sourceIPv6PrefixLength = getLongValue(value);
-                break;
-            case "sourceIPv4PrefixLength":
-                sourceIPv4PrefixLength = getLongValue(value);
-                break;
-            case "sourceTransportPort":
-                getUInt32Value(value).ifPresent(builder::setSrcPort);
-                break;
-            case "vlanId":
-                vlanId = getLongValue(value);
-                break;
-            case "postVlanId":
-                postVlanId = getLongValue(value);
-                break;
-            case "dot1qVlanId":
-                dot1qVlanId = getLongValue(value);
-                break;
-            case "dot1qCustomerVlanId":
-                dot1qCustomerVlanId = getLongValue(value);
-                break;
-            case "postDot1qVlanId":
-                postDot1qVlanId = getLongValue(value);
-                break;
-            case "postDot1qCustomerVlanId":
-                postDot1qCustomerVlanId = getLongValue(value);
-                break;
-            case "flowActiveTimeout":
-                flowActiveTimeout = getLongValue(value);
-                break;
-            case "flowInactiveTimeout":
-                flowInactiveTimeout = getLongValue(value);
-                break;
-        }
     }
 }

--- a/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/transport/IpFixMessageBuilder.java
+++ b/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/transport/IpFixMessageBuilder.java
@@ -52,12 +52,13 @@ import org.opennms.netmgt.telemetry.protocols.netflow.transport.SamplingAlgorith
 
 import com.google.common.primitives.UnsignedLong;
 
-public class IpFixMessageBuilder {
+public class IpFixMessageBuilder implements MessageBuilder {
 
     public IpFixMessageBuilder() {
     }
 
-    public byte[] buildData(final Iterable<Value<?>> values, final RecordEnrichment enrichment) throws IllegalFlowException {
+    @Override
+    public FlowMessage.Builder buildMessage(final Iterable<Value<?>> values, final RecordEnrichment enrichment) {
         final FlowMessage.Builder builder = FlowMessage.newBuilder();
 
         Long exportTime = null;
@@ -567,16 +568,6 @@ public class IpFixMessageBuilder {
             }
         }
 
-        if (builder.getFirstSwitched().getValue() > builder.getLastSwitched().getValue()) {
-            throw new IllegalFlowException(
-                    String.format("lastSwitched must be greater than firstSwitched: srcAddress=%s, dstAddress=%s, firstSwitched=%d, lastSwitched=%d, duration=%d",
-                            builder.getSrcAddress(),
-                            builder.getDstAddress(),
-                            builder.getFirstSwitched().getValue(),
-                            builder.getLastSwitched().getValue(),
-                            builder.getLastSwitched().getValue() - builder.getFirstSwitched().getValue()));
-        }
-
         // Build delta switched
         Timeout timeout = new Timeout(flowActiveTimeout, flowInactiveTimeout);
         timeout.setFirstSwitched(builder.hasFirstSwitched() ? builder.getFirstSwitched().getValue() : null);
@@ -587,6 +578,6 @@ public class IpFixMessageBuilder {
         getUInt64Value(deltaSwitched).ifPresent(builder::setDeltaSwitched);
 
         builder.setNetflowVersion(NetflowVersion.IPFIX);
-        return builder.build().toByteArray();
+        return builder;
     }
 }

--- a/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/transport/MessageBuilder.java
+++ b/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/transport/MessageBuilder.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2021 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.telemetry.protocols.netflow.parser.transport;
+
+import org.opennms.netmgt.telemetry.protocols.netflow.parser.RecordEnrichment;
+import org.opennms.netmgt.telemetry.protocols.netflow.parser.ie.Value;
+import org.opennms.netmgt.telemetry.protocols.netflow.transport.FlowMessage;
+
+public interface MessageBuilder {
+    FlowMessage.Builder buildMessage(final Iterable<Value<?>> values, final RecordEnrichment enrichment);
+}

--- a/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/transport/Netflow5MessageBuilder.java
+++ b/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/transport/Netflow5MessageBuilder.java
@@ -49,30 +49,127 @@ import org.opennms.netmgt.telemetry.protocols.netflow.transport.SamplingAlgorith
 
 public class Netflow5MessageBuilder {
 
-    private final FlowMessage.Builder builder;
-    private final Iterable<Value<?>> values;
-    private final RecordEnrichment enrichment;
-    private Long unixSecs;
-    private Long unixNSecs;
-    private Long sysUpTime;
-    private Long first;
-    private Long last;
-    private InetAddress srcAddr;
-    private InetAddress dstAddr;
-    private InetAddress nextHop;
-
-
-    public Netflow5MessageBuilder(Iterable<Value<?>> values, RecordEnrichment enrichment) {
-        this.values = values;
-        this.enrichment = enrichment;
-        builder = FlowMessage.newBuilder();
+    public Netflow5MessageBuilder() {
     }
 
-    public byte[] buildData() throws IllegalFlowException {
+    public byte[] buildData(final Iterable<Value<?>> values, final RecordEnrichment enrichment) throws IllegalFlowException {
+        final FlowMessage.Builder builder = FlowMessage.newBuilder();
 
-        values.forEach(this::addField);
-        long timeStamp = this.unixSecs * 1000L + this.unixNSecs / 1000_000L;
-        long bootTime = timeStamp - this.sysUpTime;
+        Long unixSecs = null;
+        Long unixNSecs = null;
+        Long sysUpTime = null;
+        Long first = null;
+        Long last = null;
+        InetAddress srcAddr = null;
+        InetAddress dstAddr = null;
+        InetAddress nextHop = null;
+
+        for (Value<?> value : values) {
+            switch (value.getName()) {
+                case "@count":
+                    getUInt32Value(value).ifPresent(builder::setNumFlowRecords);
+                    break;
+                case "@unixSecs":
+                    unixSecs = getLongValue(value);
+                    break;
+                case "@unixNSecs":
+                    unixNSecs = getLongValue(value);
+                    break;
+                case "@sysUptime":
+                    sysUpTime = getLongValue(value);
+                    break;
+                case "@flowSequence":
+                    getUInt64Value(value).ifPresent(builder::setFlowSeqNum);
+                    break;
+                case "@engineType":
+                    getUInt32Value(value).ifPresent(builder::setEngineType);
+                    break;
+                case "@engineId":
+                    getUInt32Value(value).ifPresent(builder::setEngineId);
+                    break;
+                case "@samplingAlgorithm":
+                    Long saValue = getLongValue(value);
+                    SamplingAlgorithm samplingAlgorithm = SamplingAlgorithm.UNASSIGNED;
+                    if (saValue != null) {
+                        switch (saValue.intValue()) {
+                            case 1:
+                                samplingAlgorithm = SamplingAlgorithm.SYSTEMATIC_COUNT_BASED_SAMPLING;
+                                break;
+                            case 2:
+                                samplingAlgorithm = SamplingAlgorithm.RANDOM_N_OUT_OF_N_SAMPLING;
+                                break;
+                        }
+                    }
+                    builder.setSamplingAlgorithm(samplingAlgorithm);
+                    break;
+                case "@samplingInterval":
+                    getDoubleValue(value).ifPresent(builder::setSamplingInterval);
+                    break;
+
+                case "srcAddr":
+                    srcAddr = getInetAddress(value);
+                    break;
+                case "dstAddr":
+                    dstAddr = getInetAddress(value);
+                    break;
+                case "nextHop":
+                    nextHop = getInetAddress(value);
+                    break;
+                case "input":
+                    getUInt32Value(value).ifPresent(builder::setInputSnmpIfindex);
+                    break;
+                case "output":
+                    getUInt32Value(value).ifPresent(builder::setOutputSnmpIfindex);
+                    break;
+                case "dPkts":
+                    getUInt64Value(value).ifPresent(builder::setNumPackets);
+                    break;
+                case "dOctets":
+                    getUInt64Value(value).ifPresent(builder::setNumBytes);
+                    break;
+                case "first":
+                    first = getLongValue(value);
+                    break;
+                case "last":
+                    last = getLongValue(value);
+                    break;
+                case "srcPort":
+                    getUInt32Value(value).ifPresent(builder::setSrcPort);
+                    break;
+                case "dstPort":
+                    getUInt32Value(value).ifPresent(builder::setDstPort);
+                    break;
+                case "tcpFlags":
+                    getUInt32Value(value).ifPresent(builder::setTcpFlags);
+                    break;
+                case "proto":
+                    getUInt32Value(value).ifPresent(builder::setProtocol);
+                    break;
+                case "srcAs":
+                    getUInt64Value(value).ifPresent(builder::setSrcAs);
+                    break;
+                case "dstAs":
+                    getUInt64Value(value).ifPresent(builder::setDstAs);
+                    break;
+                case "tos":
+                    getUInt32Value(value).ifPresent(builder::setTos);
+                    break;
+                case "srcMask":
+                    getUInt32Value(value).ifPresent(builder::setSrcMaskLen);
+                    break;
+                case "dstMask":
+                    getUInt32Value(value).ifPresent(builder::setDstMaskLen);
+                    break;
+                case "egress":
+                    Boolean egress = getBooleanValue(value);
+                    Direction direction = egress ? Direction.EGRESS : Direction.INGRESS;
+                    builder.setDirection(direction);
+                    break;
+            }
+        }
+
+        long timeStamp = unixSecs * 1000L + unixNSecs / 1000_000L;
+        long bootTime = timeStamp - sysUpTime;
 
         builder.setNetflowVersion(NetflowVersion.V5);
         builder.setFirstSwitched(setLongValue(bootTime + first));
@@ -105,112 +202,4 @@ public class Netflow5MessageBuilder {
         return builder.build().toByteArray();
 
     }
-
-    private void addField(Value<?> value) {
-        switch (value.getName()) {
-
-            case "@count":
-                getUInt32Value(value).ifPresent(builder::setNumFlowRecords);
-                break;
-            case "@unixSecs":
-                unixSecs = getLongValue(value);
-                break;
-            case "@unixNSecs":
-                unixNSecs = getLongValue(value);
-                break;
-            case "@sysUptime":
-                sysUpTime = getLongValue(value);
-                break;
-            case "@flowSequence":
-                getUInt64Value(value).ifPresent(builder::setFlowSeqNum);
-                break;
-            case "@engineType":
-                getUInt32Value(value).ifPresent(builder::setEngineType);
-                break;
-            case "@engineId":
-                getUInt32Value(value).ifPresent(builder::setEngineId);
-                break;
-            case "@samplingAlgorithm":
-                Long saValue = getLongValue(value);
-                SamplingAlgorithm samplingAlgorithm = SamplingAlgorithm.UNASSIGNED;
-                if (saValue != null) {
-                    switch (saValue.intValue()) {
-                        case 1:
-                            samplingAlgorithm = SamplingAlgorithm.SYSTEMATIC_COUNT_BASED_SAMPLING;
-                            break;
-                        case 2:
-                            samplingAlgorithm = SamplingAlgorithm.RANDOM_N_OUT_OF_N_SAMPLING;
-                            break;
-                    }
-                }
-                builder.setSamplingAlgorithm(samplingAlgorithm);
-                break;
-            case "@samplingInterval":
-                getDoubleValue(value).ifPresent(builder::setSamplingInterval);
-                break;
-
-            case "srcAddr":
-                srcAddr = getInetAddress(value);
-                break;
-            case "dstAddr":
-                dstAddr = getInetAddress(value);
-                break;
-            case "nextHop":
-                nextHop = getInetAddress(value);
-                break;
-            case "input":
-                getUInt32Value(value).ifPresent(builder::setInputSnmpIfindex);
-                break;
-            case "output":
-                getUInt32Value(value).ifPresent(builder::setOutputSnmpIfindex);
-                break;
-            case "dPkts":
-                getUInt64Value(value).ifPresent(builder::setNumPackets);
-                break;
-            case "dOctets":
-                getUInt64Value(value).ifPresent(builder::setNumBytes);
-                break;
-            case "first":
-                first = getLongValue(value);
-                break;
-            case "last":
-                last = getLongValue(value);
-                break;
-            case "srcPort":
-                getUInt32Value(value).ifPresent(builder::setSrcPort);
-                break;
-            case "dstPort":
-                getUInt32Value(value).ifPresent(builder::setDstPort);
-                break;
-            case "tcpFlags":
-                getUInt32Value(value).ifPresent(builder::setTcpFlags);
-                break;
-            case "proto":
-                getUInt32Value(value).ifPresent(builder::setProtocol);
-                break;
-            case "srcAs":
-                getUInt64Value(value).ifPresent(builder::setSrcAs);
-                break;
-            case "dstAs":
-                getUInt64Value(value).ifPresent(builder::setDstAs);
-                break;
-            case "tos":
-                getUInt32Value(value).ifPresent(builder::setTos);
-                break;
-            case "srcMask":
-                getUInt32Value(value).ifPresent(builder::setSrcMaskLen);
-                break;
-            case "dstMask":
-                getUInt32Value(value).ifPresent(builder::setDstMaskLen);
-                break;
-            case "egress":
-                Boolean egress = getBooleanValue(value);
-                Direction direction = egress ? Direction.EGRESS : Direction.INGRESS;
-                builder.setDirection(direction);
-                break;
-        }
-    }
-
-
-
 }

--- a/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/transport/Netflow5MessageBuilder.java
+++ b/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/transport/Netflow5MessageBuilder.java
@@ -39,7 +39,6 @@ import static org.opennms.netmgt.telemetry.protocols.netflow.parser.transport.Me
 
 import java.net.InetAddress;
 
-import org.opennms.netmgt.telemetry.protocols.netflow.parser.IllegalFlowException;
 import org.opennms.netmgt.telemetry.protocols.netflow.parser.RecordEnrichment;
 import org.opennms.netmgt.telemetry.protocols.netflow.parser.ie.Value;
 import org.opennms.netmgt.telemetry.protocols.netflow.transport.Direction;
@@ -47,12 +46,13 @@ import org.opennms.netmgt.telemetry.protocols.netflow.transport.FlowMessage;
 import org.opennms.netmgt.telemetry.protocols.netflow.transport.NetflowVersion;
 import org.opennms.netmgt.telemetry.protocols.netflow.transport.SamplingAlgorithm;
 
-public class Netflow5MessageBuilder {
+public class Netflow5MessageBuilder implements MessageBuilder {
 
     public Netflow5MessageBuilder() {
     }
 
-    public byte[] buildData(final Iterable<Value<?>> values, final RecordEnrichment enrichment) throws IllegalFlowException {
+    @Override
+    public FlowMessage.Builder buildMessage(final Iterable<Value<?>> values, final RecordEnrichment enrichment) {
         final FlowMessage.Builder builder = FlowMessage.newBuilder();
 
         Long unixSecs = null;
@@ -189,17 +189,6 @@ public class Netflow5MessageBuilder {
             enrichment.getHostnameFor(nextHop).ifPresent(builder::setNextHopHostname);
         }
 
-        if (builder.getFirstSwitched().getValue() > builder.getLastSwitched().getValue()) {
-            throw new IllegalFlowException(
-                    String.format("lastSwitched must be greater than firstSwitched: srcAddress=%s, dstAddress=%s, firstSwitched=%d, lastSwitched=%d, duration=%d",
-                            builder.getSrcAddress(),
-                            builder.getDstAddress(),
-                            builder.getFirstSwitched().getValue(),
-                            builder.getLastSwitched().getValue(),
-                            builder.getLastSwitched().getValue() - builder.getFirstSwitched().getValue()));
-        }
-
-        return builder.build().toByteArray();
-
+        return builder;
     }
 }

--- a/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/transport/Netflow9MessageBuilder.java
+++ b/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/transport/Netflow9MessageBuilder.java
@@ -47,13 +47,13 @@ import org.opennms.netmgt.telemetry.protocols.netflow.transport.FlowMessage;
 import org.opennms.netmgt.telemetry.protocols.netflow.transport.NetflowVersion;
 import org.opennms.netmgt.telemetry.protocols.netflow.transport.SamplingAlgorithm;
 
-public class Netflow9MessageBuilder {
+public class Netflow9MessageBuilder implements MessageBuilder {
 
     public Netflow9MessageBuilder() {
     }
 
-
-    public byte[] buildData(final Iterable<Value<?>> values, final RecordEnrichment enrichment) throws IllegalFlowException {
+    @Override
+    public FlowMessage.Builder buildMessage(final Iterable<Value<?>> values, final RecordEnrichment enrichment) {
         final FlowMessage.Builder builder = FlowMessage.newBuilder();
 
         InetAddress ipv4DstAddress = null;
@@ -279,16 +279,6 @@ public class Netflow9MessageBuilder {
             builder.setNextHopAddress(inetAddress.getHostAddress());
         });
 
-        if (builder.getFirstSwitched().getValue() > builder.getLastSwitched().getValue()) {
-            throw new IllegalFlowException(
-                    String.format("lastSwitched must be greater than firstSwitched: srcAddress=%s, dstAddress=%s, firstSwitched=%d, lastSwitched=%d, duration=%d",
-                            builder.getSrcAddress(),
-                            builder.getDstAddress(),
-                            builder.getFirstSwitched().getValue(),
-                            builder.getLastSwitched().getValue(),
-                            builder.getLastSwitched().getValue() - builder.getFirstSwitched().getValue()));
-        }
-
         // set vlan
         first(srcVlan, dstVlan).ifPresent( vlan -> builder.setVlan(setIntValue(vlan.intValue())));
 
@@ -301,6 +291,6 @@ public class Netflow9MessageBuilder {
         getUInt64Value(deltaSwitched).ifPresent(builder::setDeltaSwitched);
 
         builder.setNetflowVersion(NetflowVersion.V9);
-        return builder.build().toByteArray();
+        return builder;
     }
 }

--- a/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/transport/Netflow9MessageBuilder.java
+++ b/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/transport/Netflow9MessageBuilder.java
@@ -49,63 +49,209 @@ import org.opennms.netmgt.telemetry.protocols.netflow.transport.SamplingAlgorith
 
 public class Netflow9MessageBuilder {
 
-    private final FlowMessage.Builder builder;
-    private final Iterable<Value<?>> values;
-    private final RecordEnrichment enrichment;
-    private InetAddress ipv4DstAddress;
-    private InetAddress ipv6DstAddress;
-    private Long dstMask;
-    private Long ipv6DstMask;
-    private InetAddress ipv4NextHop;
-    private InetAddress ipv6NextHop;
-    private InetAddress bgpIpv4NextHop;
-    private InetAddress bgpIpv6NextHop;
-    private InetAddress ipv4SrcAddress;
-    private InetAddress ipv6SrcAddress;
-    private Long srcMask;
-    private Long ipv6SrcMask;
-    private Long srcVlan;
-    private Long dstVlan;
-    private Long flowActiveTimeout;
-    private Long flowInActiveTimeout;
-    private Long sysUpTime;
-    private Long unixSecs;
-    private Long numBytes;
-    private Long numPackets;
-    private Long firstSwitched;
-    private Long lastSwitched;
-    private Long flowStartMilliseconds;
-    private Long flowEndMilliseconds;
-
-
-    public Netflow9MessageBuilder(Iterable<Value<?>> values, RecordEnrichment enrichment) {
-        this.values = values;
-        this.enrichment = enrichment;
-        builder = FlowMessage.newBuilder();
+    public Netflow9MessageBuilder() {
     }
 
 
-    public byte[] buildData() throws IllegalFlowException {
+    public byte[] buildData(final Iterable<Value<?>> values, final RecordEnrichment enrichment) throws IllegalFlowException {
+        final FlowMessage.Builder builder = FlowMessage.newBuilder();
 
-        values.forEach(this::addField);
+        InetAddress ipv4DstAddress = null;
+        InetAddress ipv6DstAddress = null;
+        Long dstMask = null;
+        Long ipv6DstMask = null;
+        InetAddress ipv4NextHop = null;
+        InetAddress ipv6NextHop = null;
+        InetAddress bgpIpv4NextHop = null;
+        InetAddress bgpIpv6NextHop = null;
+        InetAddress ipv4SrcAddress = null;
+        InetAddress ipv6SrcAddress = null;
+        Long srcMask = null;
+        Long ipv6SrcMask = null;
+        Long srcVlan = null;
+        Long dstVlan = null;
+        Long flowActiveTimeout = null;
+        Long flowInActiveTimeout = null;
+        Long sysUpTime = null;
+        Long unixSecs = null;
+        Long firstSwitched = null;
+        Long lastSwitched = null;
+        Long flowStartMilliseconds = null;
+        Long flowEndMilliseconds = null;
 
-        long timeStampInMsecs = this.unixSecs != null ? this.unixSecs * 1000 : 0;
+        for (Value<?> value : values) {
+            switch (value.getName()) {
+                // Header
+                case "@recordCount":
+                    getUInt32Value(value).ifPresent(builder::setNumFlowRecords);
+                    break;
+                case "@sequenceNumber":
+                    getUInt64Value(value).ifPresent(builder::setFlowSeqNum);
+                    break;
+                case "@sourceId":
+                    getUInt64Value(value).ifPresent(srcId -> builder.setNodeIdentifier(String.valueOf(srcId.getValue())));
+                    break;
+                case "@sysUpTime":
+                    sysUpTime = getLongValue(value);
+                    break;
+                case "@unixSecs":
+                    unixSecs = getLongValue(value);
+                    break;
+                case "IN_BYTES":
+                    getUInt64Value(value).ifPresent(builder::setNumBytes);
+                    break;
+                case "DIRECTION":
+                    Long directionValue = getLongValue(value);
+                    Direction direction = Direction.UNRECOGNIZED;
+                    if (directionValue != null) {
+                        switch (directionValue.intValue()) {
+                            case 0:
+                                direction = Direction.INGRESS;
+                                break;
+                            case 1:
+                                direction = Direction.EGRESS;
+                                break;
+                        }
+                    }
+                    if (!direction.equals(Direction.UNRECOGNIZED)) {
+                        builder.setDirection(direction);
+                    }
+                    break;
+                case "IPV4_DST_ADDR":
+                    ipv4DstAddress = getInetAddress(value);
+                    break;
+                case "IPV6_DST_ADDR":
+                    ipv6DstAddress = getInetAddress(value);
+                    break;
+                case "DST_AS":
+                    getUInt64Value(value).ifPresent(builder::setDstAs);
+                    break;
+                case "IPV6_DST_MASK":
+                    ipv6DstMask = getLongValue(value);
+                    break;
+                case "DST_MASK":
+                    dstMask = getLongValue(value);
+                    break;
+                case "L4_DST_PORT":
+                    getUInt32Value(value).ifPresent(builder::setDstPort);
+                    break;
+                case "ENGINE_ID":
+                    getUInt32Value(value).ifPresent(builder::setEngineId);
+                    break;
+                case "ENGINE_TYPE":
+                    getUInt32Value(value).ifPresent(builder::setEngineType);
+                    break;
+                case "FIRST_SWITCHED":
+                    firstSwitched = getLongValue(value);
+                    break;
+                case "LAST_SWITCHED":
+                    lastSwitched = getLongValue(value);
+                    break;
+                case "INPUT_SNMP":
+                    getUInt32Value(value).ifPresent(builder::setInputSnmpIfindex);
+                    break;
+                case "IP_PROTOCOL_VERSION":
+                    getUInt32Value(value).ifPresent(builder::setIpProtocolVersion);
+                    break;
+                case "OUTPUT_SNMP":
+                    getUInt32Value(value).ifPresent(builder::setOutputSnmpIfindex);
+                    break;
+                case "IPV6_NEXT_HOP":
+                    ipv6NextHop = getInetAddress(value);
+                    break;
+                case "IPV4_NEXT_HOP":
+                    ipv4NextHop = getInetAddress(value);
+                    break;
+                case "BPG_IPV6_NEXT_HOP":
+                    bgpIpv6NextHop = getInetAddress(value);
+                    break;
+                case "BPG_IPV4_NEXT_HOP":
+                    bgpIpv4NextHop = getInetAddress(value);
+                    break;
+                case "IN_PKTS":
+                    getUInt64Value(value).ifPresent(builder::setNumPackets);
+                    break;
+                case "PROTOCOL":
+                    getUInt32Value(value).ifPresent(builder::setProtocol);
+                    break;
+                case "SAMPLING_ALGORITHM":
+                    Long saValue = getLongValue(value);
+                    SamplingAlgorithm samplingAlgorithm = SamplingAlgorithm.UNASSIGNED;
+                    if (saValue != null) {
+                        if (saValue.intValue() == 1) {
+                            samplingAlgorithm = SamplingAlgorithm.SYSTEMATIC_COUNT_BASED_SAMPLING;
+                        }
+                        if (saValue.intValue() == 2) {
+                            samplingAlgorithm = SamplingAlgorithm.RANDOM_N_OUT_OF_N_SAMPLING;
+                        }
+                    }
+                    builder.setSamplingAlgorithm(samplingAlgorithm);
+                    break;
+                case "SAMPLING_INTERVAL":
+                    getDoubleValue(value).ifPresent(builder::setSamplingInterval);
+                    break;
+                case "IPV6_SRC_ADDR":
+                    ipv6SrcAddress = getInetAddress(value);
+                    break;
+                case "IPV4_SRC_ADDR":
+                    ipv4SrcAddress = getInetAddress(value);
+                    break;
+                case "IPV6_SRC_MASK":
+                    ipv6SrcMask = getLongValue(value);
+                    break;
+                case "SRC_MASK":
+                    srcMask = getLongValue(value);
+                    break;
+                case "SRC_AS":
+                    getUInt64Value(value).ifPresent(builder::setSrcAs);
+                    break;
+                case "L4_SRC_PORT":
+                    getUInt32Value(value).ifPresent(builder::setSrcPort);
+                    break;
+                case "TCP_FLAGS":
+                    getUInt32Value(value).ifPresent(builder::setTcpFlags);
+                    break;
+                case "TOS":
+                    getUInt32Value(value).ifPresent(builder::setTos);
+                    break;
+                case "SRC_VLAN":
+                    srcVlan = getLongValue(value);
+                    break;
+                case "DST_VLAN":
+                    dstVlan = getLongValue(value);
+                    break;
+                case "FLOW_ACTIVE_TIMEOUT":
+                    flowActiveTimeout = getLongValue(value);
+                    break;
+                case "FLOW_INACTIVE_TIMEOUT":
+                    flowInActiveTimeout = getLongValue(value);
+                    break;
+                case "flowStartMilliseconds":
+                    flowStartMilliseconds = getLongValue(value);
+                    break;
+                case "flowEndMilliseconds":
+                    flowEndMilliseconds = getLongValue(value);
+                    break;
+            }
+        }
+
+        long timeStampInMsecs = unixSecs != null ? unixSecs * 1000 : 0;
         builder.setTimestamp(timeStampInMsecs);
 
-        long bootTime = timeStampInMsecs - this.sysUpTime;
+        long bootTime = timeStampInMsecs - sysUpTime;
 
-        if (this.firstSwitched != null) {
-            builder.setFirstSwitched(setLongValue(this.firstSwitched + bootTime));
+        if (firstSwitched != null) {
+            builder.setFirstSwitched(setLongValue(firstSwitched + bootTime));
         }
-        if(this.lastSwitched != null) {
-            builder.setLastSwitched(setLongValue(this.lastSwitched + bootTime));
+        if(lastSwitched != null) {
+            builder.setLastSwitched(setLongValue(lastSwitched + bootTime));
         }
 
         // Some Cisco platforms also support absolute timestamps in NetFlow v9 (like defined in IPFIX). See NMS-13006
-        if (this.flowStartMilliseconds != null) {
+        if (flowStartMilliseconds != null) {
             builder.setFirstSwitched(setLongValue(flowStartMilliseconds));
         }
-        if (this.flowEndMilliseconds != null) {
+        if (flowEndMilliseconds != null) {
             builder.setLastSwitched(setLongValue(flowEndMilliseconds));
         }
 
@@ -146,185 +292,15 @@ public class Netflow9MessageBuilder {
         // set vlan
         first(srcVlan, dstVlan).ifPresent( vlan -> builder.setVlan(setIntValue(vlan.intValue())));
 
-        Long firstSwitched = builder.hasFirstSwitched() ? builder.getFirstSwitched().getValue() : null;
-        Long lastSwitched = builder.hasLastSwitched() ? builder.getLastSwitched().getValue() : null;
-
         Timeout timeout = new Timeout(flowActiveTimeout, flowInActiveTimeout);
-        timeout.setFirstSwitched(firstSwitched);
-        timeout.setLastSwitched(lastSwitched);
-        timeout.setNumBytes(this.numBytes);
-        timeout.setNumPackets(this.numPackets);
+        timeout.setFirstSwitched(builder.hasFirstSwitched() ? builder.getFirstSwitched().getValue() : null);
+        timeout.setLastSwitched(builder.hasLastSwitched() ? builder.getLastSwitched().getValue() : null);
+        timeout.setNumBytes(builder.getNumBytes().getValue());
+        timeout.setNumPackets(builder.getNumPackets().getValue());
         Long deltaSwitched = timeout.getDeltaSwitched();
         getUInt64Value(deltaSwitched).ifPresent(builder::setDeltaSwitched);
 
         builder.setNetflowVersion(NetflowVersion.V9);
         return builder.build().toByteArray();
     }
-
-    private void addField(Value<?> value) {
-
-        switch (value.getName()) {
-            // Header
-            case "@recordCount":
-                getUInt32Value(value).ifPresent(builder::setNumFlowRecords);
-                break;
-            case "@sequenceNumber":
-                getUInt64Value(value).ifPresent(builder::setFlowSeqNum);
-                break;
-            case "@sourceId":
-                getUInt64Value(value).ifPresent(srcId ->
-                        builder.setNodeIdentifier(String.valueOf(srcId.getValue())));
-                break;
-            case "@sysUpTime":
-                sysUpTime = getLongValue(value);
-                break;
-            case "@unixSecs":
-                unixSecs = getLongValue(value);
-                break;
-            case "IN_BYTES":
-                getUInt64Value(value).ifPresent(bytes -> {
-                    numBytes = bytes.getValue();
-                    builder.setNumBytes(bytes);
-                });
-                break;
-            case "DIRECTION":
-                Long directionValue = getLongValue(value);
-                Direction direction = Direction.UNRECOGNIZED;
-                if (directionValue != null) {
-                    switch (directionValue.intValue()) {
-                        case 0:
-                            direction = Direction.INGRESS;
-                            break;
-                        case 1:
-                            direction = Direction.EGRESS;
-                            break;
-                    }
-                }
-                if (!direction.equals(Direction.UNRECOGNIZED)) {
-                    this.builder.setDirection(direction);
-                }
-                break;
-            case "IPV4_DST_ADDR":
-                ipv4DstAddress = getInetAddress(value);
-                break;
-            case "IPV6_DST_ADDR":
-                ipv6DstAddress = getInetAddress(value);
-                break;
-            case "DST_AS":
-                getUInt64Value(value).ifPresent(builder::setDstAs);
-                break;
-            case "IPV6_DST_MASK":
-                ipv6DstMask = getLongValue(value);
-                break;
-            case "DST_MASK":
-                dstMask = getLongValue(value);
-                break;
-            case "L4_DST_PORT":
-                getUInt32Value(value).ifPresent(builder::setDstPort);
-                break;
-            case "ENGINE_ID":
-                getUInt32Value(value).ifPresent(builder::setEngineId);
-                break;
-            case "ENGINE_TYPE":
-                getUInt32Value(value).ifPresent(builder::setEngineType);
-                break;
-            case "FIRST_SWITCHED":
-                firstSwitched = getLongValue(value);
-                break;
-            case "LAST_SWITCHED":
-                lastSwitched = getLongValue(value);
-                break;
-            case "INPUT_SNMP":
-                getUInt32Value(value).ifPresent(builder::setInputSnmpIfindex);
-                break;
-            case "IP_PROTOCOL_VERSION":
-                getUInt32Value(value).ifPresent(builder::setIpProtocolVersion);
-                break;
-            case "OUTPUT_SNMP":
-                getUInt32Value(value).ifPresent(builder::setOutputSnmpIfindex);
-                break;
-            case "IPV6_NEXT_HOP":
-                ipv6NextHop = getInetAddress(value);
-                break;
-            case "IPV4_NEXT_HOP":
-                ipv4NextHop = getInetAddress(value);
-                break;
-            case "BPG_IPV6_NEXT_HOP":
-                bgpIpv6NextHop = getInetAddress(value);
-                break;
-            case "BPG_IPV4_NEXT_HOP":
-                bgpIpv4NextHop = getInetAddress(value);
-                break;
-            case "IN_PKTS":
-                getUInt64Value(value).ifPresent(numPackets -> {
-                    this.numPackets = numPackets.getValue();
-                    builder.setNumPackets(numPackets);
-                });
-                break;
-            case "PROTOCOL":
-                getUInt32Value(value).ifPresent(builder::setProtocol);
-                break;
-            case "SAMPLING_ALGORITHM":
-                Long saValue = getLongValue(value);
-                SamplingAlgorithm samplingAlgorithm = SamplingAlgorithm.UNASSIGNED;
-                if (saValue != null) {
-                    if (saValue.intValue() == 1) {
-                        samplingAlgorithm = SamplingAlgorithm.SYSTEMATIC_COUNT_BASED_SAMPLING;
-                    }
-                    if (saValue.intValue() == 2) {
-                        samplingAlgorithm = SamplingAlgorithm.RANDOM_N_OUT_OF_N_SAMPLING;
-                    }
-                }
-                builder.setSamplingAlgorithm(samplingAlgorithm);
-                break;
-            case "SAMPLING_INTERVAL":
-                getDoubleValue(value).ifPresent(builder::setSamplingInterval);
-                break;
-            case "IPV6_SRC_ADDR":
-                ipv6SrcAddress = getInetAddress(value);
-                break;
-            case "IPV4_SRC_ADDR":
-                ipv4SrcAddress = getInetAddress(value);
-                break;
-            case "IPV6_SRC_MASK":
-                ipv6SrcMask = getLongValue(value);
-                break;
-            case "SRC_MASK":
-                srcMask = getLongValue(value);
-                break;
-            case "SRC_AS":
-                getUInt64Value(value).ifPresent(builder::setSrcAs);
-                break;
-            case "L4_SRC_PORT":
-                getUInt32Value(value).ifPresent(builder::setSrcPort);
-                break;
-            case "TCP_FLAGS":
-                getUInt32Value(value).ifPresent(builder::setTcpFlags);
-                break;
-            case "TOS":
-                getUInt32Value(value).ifPresent(builder::setTos);
-                break;
-            case "SRC_VLAN":
-                srcVlan = getLongValue(value);
-                break;
-            case "DST_VLAN":
-                dstVlan = getLongValue(value);
-                break;
-            case "FLOW_ACTIVE_TIMEOUT":
-                flowActiveTimeout = getLongValue(value);
-                break;
-            case "FLOW_INACTIVE_TIMEOUT":
-                flowInActiveTimeout = getLongValue(value);
-                break;
-            case "flowStartMilliseconds":
-                flowStartMilliseconds = getLongValue(value);
-                break;
-            case "flowEndMilliseconds":
-                flowEndMilliseconds = getLongValue(value);
-                break;
-        }
-
-    }
-
-
 }

--- a/features/telemetry/protocols/netflow/parser/src/test/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/ClockSkewTest.java
+++ b/features/telemetry/protocols/netflow/parser/src/test/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/ClockSkewTest.java
@@ -41,6 +41,8 @@ import org.opennms.netmgt.dnsresolver.api.DnsResolver;
 import org.opennms.netmgt.events.api.EventForwarder;
 import org.opennms.netmgt.telemetry.api.receiver.TelemetryMessage;
 import org.opennms.netmgt.telemetry.protocols.netflow.parser.ie.Value;
+import org.opennms.netmgt.telemetry.protocols.netflow.parser.transport.MessageBuilder;
+import org.opennms.netmgt.telemetry.protocols.netflow.transport.FlowMessage;
 import org.opennms.netmgt.xml.event.Event;
 import org.opennms.netmgt.xml.event.Log;
 
@@ -168,12 +170,12 @@ public class ClockSkewTest {
     private class ParserBaseExt extends ParserBase {
 
         public ParserBaseExt(Protocol protocol, String name, AsyncDispatcher<TelemetryMessage> dispatcher, EventForwarder eventForwarder, Identity identity, DnsResolver dnsResolver, MetricRegistry metricRegistry) {
-            super(protocol, name, dispatcher, eventForwarder, identity, dnsResolver, metricRegistry);
-        }
-
-        @Override
-        protected byte[] buildMessage(Iterable<Value<?>> record, RecordEnrichment enrichment) {
-            return new byte[0];
+            super(protocol, name, new MessageBuilder() {
+                @Override
+                public FlowMessage.Builder buildMessage(final Iterable<Value<?>> values, final RecordEnrichment enrichment) {
+                    return FlowMessage.newBuilder();
+                }
+            }, dispatcher, eventForwarder, identity, dnsResolver, metricRegistry);
         }
     }
 }

--- a/features/telemetry/protocols/netflow/parser/src/test/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/IllegalFlowTest.java
+++ b/features/telemetry/protocols/netflow/parser/src/test/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/IllegalFlowTest.java
@@ -78,8 +78,8 @@ public class IllegalFlowTest {
         // first > last, this should trigger an exception
         record.add(new UnsignedValue("FIRST_SWITCHED", 3000));
         record.add(new UnsignedValue("LAST_SWITCHED", 2000));
-        final Netflow9MessageBuilder builder = new Netflow9MessageBuilder(record, enrichment);
-        builder.buildData();
+        final Netflow9MessageBuilder builder = new Netflow9MessageBuilder();
+        builder.buildData(record, enrichment);
     }
 
     @Test
@@ -91,8 +91,8 @@ public class IllegalFlowTest {
         // first < last, this is valid
         record.add(new UnsignedValue("FIRST_SWITCHED", 2000));
         record.add(new UnsignedValue("LAST_SWITCHED", 3000));
-        final Netflow9MessageBuilder builder = new Netflow9MessageBuilder(record, enrichment);
-        builder.buildData();
+        final Netflow9MessageBuilder builder = new Netflow9MessageBuilder();
+        builder.buildData(record, enrichment);
     }
 
     @Test

--- a/features/telemetry/protocols/netflow/parser/src/test/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/IllegalFlowTest.java
+++ b/features/telemetry/protocols/netflow/parser/src/test/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/IllegalFlowTest.java
@@ -39,9 +39,7 @@ import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
@@ -55,9 +53,6 @@ import org.opennms.netmgt.dnsresolver.api.DnsResolver;
 import org.opennms.netmgt.events.api.EventForwarder;
 import org.opennms.netmgt.telemetry.api.receiver.TelemetryMessage;
 import org.opennms.netmgt.telemetry.listeners.UdpListener;
-import org.opennms.netmgt.telemetry.protocols.netflow.parser.ie.Value;
-import org.opennms.netmgt.telemetry.protocols.netflow.parser.ie.values.UnsignedValue;
-import org.opennms.netmgt.telemetry.protocols.netflow.parser.transport.Netflow9MessageBuilder;
 import org.opennms.netmgt.xml.event.Event;
 import org.opennms.netmgt.xml.event.Log;
 import org.springframework.util.SocketUtils;
@@ -68,32 +63,6 @@ public class IllegalFlowTest {
     private final static Path FOLDER = Paths.get("src/test/resources/flows");
     private final AtomicInteger messagesSent = new AtomicInteger();
     private final AtomicInteger eventCount = new AtomicInteger();
-
-    @Test(expected = IllegalFlowException.class)
-    public void illegalFlowTest() throws Exception {
-        final RecordEnrichment enrichment = (address -> Optional.empty());
-        final List<Value<?>> record = new ArrayList<>();
-        record.add(new UnsignedValue("@unixSecs", 1000));
-        record.add(new UnsignedValue("@sysUpTime", 1000));
-        // first > last, this should trigger an exception
-        record.add(new UnsignedValue("FIRST_SWITCHED", 3000));
-        record.add(new UnsignedValue("LAST_SWITCHED", 2000));
-        final Netflow9MessageBuilder builder = new Netflow9MessageBuilder();
-        builder.buildData(record, enrichment);
-    }
-
-    @Test
-    public void validFlowTest() throws Exception {
-        final RecordEnrichment enrichment = (address -> Optional.empty());
-        final List<Value<?>> record = new ArrayList<>();
-        record.add(new UnsignedValue("@unixSecs", 1000));
-        record.add(new UnsignedValue("@sysUpTime", 1000));
-        // first < last, this is valid
-        record.add(new UnsignedValue("FIRST_SWITCHED", 2000));
-        record.add(new UnsignedValue("LAST_SWITCHED", 3000));
-        final Netflow9MessageBuilder builder = new Netflow9MessageBuilder();
-        builder.buildData(record, enrichment);
-    }
 
     @Test
     public void testEventsForIllegalFlows() throws Exception {
@@ -175,10 +144,10 @@ public class IllegalFlowTest {
         await().pollDelay(250, TimeUnit.MILLISECONDS).atMost(2, TimeUnit.SECONDS).until(() -> messagesSent.get(), is(5));
         sendIllegal(udpPort);
         await().pollDelay(250, TimeUnit.MILLISECONDS).atMost(2, TimeUnit.SECONDS).until(() -> eventCount.get(), is(1));
-        await().pollDelay(250, TimeUnit.MILLISECONDS).atMost(2, TimeUnit.SECONDS).until(() -> messagesSent.get(), is(8));
+        await().pollDelay(250, TimeUnit.MILLISECONDS).atMost(2, TimeUnit.SECONDS).until(() -> messagesSent.get(), is(10));
         sendIllegal(udpPort);
         await().pollDelay(250, TimeUnit.MILLISECONDS).atMost(2, TimeUnit.SECONDS).until(() -> eventCount.get(), is(1));
-        await().pollDelay(250, TimeUnit.MILLISECONDS).atMost(2, TimeUnit.SECONDS).until(() -> messagesSent.get(), is(11));
+        await().pollDelay(250, TimeUnit.MILLISECONDS).atMost(2, TimeUnit.SECONDS).until(() -> messagesSent.get(), is(15));
 
         // reset counter
 
@@ -194,21 +163,21 @@ public class IllegalFlowTest {
 
         sendIllegal(udpPort);
         await().pollDelay(250, TimeUnit.MILLISECONDS).atMost(2, TimeUnit.SECONDS).until(() -> eventCount.get(), is(1));
-        await().pollDelay(250, TimeUnit.MILLISECONDS).atMost(2, TimeUnit.SECONDS).until(() -> messagesSent.get(), is(8));
+        await().pollDelay(250, TimeUnit.MILLISECONDS).atMost(2, TimeUnit.SECONDS).until(() -> messagesSent.get(), is(10));
 
         sendIllegal(udpPort);
         await().pollDelay(250, TimeUnit.MILLISECONDS).atMost(2, TimeUnit.SECONDS).until(() -> eventCount.get(), is(1));
-        await().pollDelay(250, TimeUnit.MILLISECONDS).atMost(2, TimeUnit.SECONDS).until(() -> messagesSent.get(), is(11));
+        await().pollDelay(250, TimeUnit.MILLISECONDS).atMost(2, TimeUnit.SECONDS).until(() -> messagesSent.get(), is(15));
 
         sendIllegal(udpPort);
         await().pollDelay(250, TimeUnit.MILLISECONDS).atMost(2, TimeUnit.SECONDS).until(() -> eventCount.get(), is(1));
-        await().pollDelay(250, TimeUnit.MILLISECONDS).atMost(2, TimeUnit.SECONDS).until(() -> messagesSent.get(), is(14));
+        await().pollDelay(250, TimeUnit.MILLISECONDS).atMost(2, TimeUnit.SECONDS).until(() -> messagesSent.get(), is(20));
 
         Thread.sleep(2000);
 
         sendIllegal(udpPort);
         await().pollDelay(250, TimeUnit.MILLISECONDS).atMost(2, TimeUnit.SECONDS).until(() -> eventCount.get(), is(2));
-        await().pollDelay(250, TimeUnit.MILLISECONDS).atMost(2, TimeUnit.SECONDS).until(() -> messagesSent.get(), is(17));
+        await().pollDelay(250, TimeUnit.MILLISECONDS).atMost(2, TimeUnit.SECONDS).until(() -> messagesSent.get(), is(25));
     }
 
     private void sendTemplate(final int udpPort) throws Exception {

--- a/features/telemetry/protocols/netflow/parser/src/test/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/NMS13006_Test.java
+++ b/features/telemetry/protocols/netflow/parser/src/test/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/NMS13006_Test.java
@@ -69,8 +69,8 @@ public class NMS13006_Test {
         record.add(new UnsignedValue("@sysUpTime", 1000));
         record.add(new UnsignedValue("FIRST_SWITCHED", 2000));
         record.add(new UnsignedValue("LAST_SWITCHED", 3000));
-        final Netflow9MessageBuilder builder = new Netflow9MessageBuilder(record, enrichment);
-        final FlowMessage flowMessage = FlowMessage.parseFrom(builder.buildData());
+        final Netflow9MessageBuilder builder = new Netflow9MessageBuilder();
+        final FlowMessage flowMessage = FlowMessage.parseFrom(builder.buildData(record, enrichment));
 
         Assert.assertEquals(1001000L, flowMessage.getFirstSwitched().getValue());
         Assert.assertEquals(1002000L, flowMessage.getLastSwitched().getValue());
@@ -85,8 +85,8 @@ public class NMS13006_Test {
         record.add(new UnsignedValue("@sysUpTime", 1000));
         record.add(new UnsignedValue("flowStartMilliseconds", 2001000));
         record.add(new UnsignedValue("flowEndMilliseconds", 2002000));
-        final Netflow9MessageBuilder builder = new Netflow9MessageBuilder(record, enrichment);
-        final FlowMessage flowMessage = FlowMessage.parseFrom(builder.buildData());
+        final Netflow9MessageBuilder builder = new Netflow9MessageBuilder();
+        final FlowMessage flowMessage = FlowMessage.parseFrom(builder.buildData(record, enrichment));
 
         Assert.assertEquals(2001000L, flowMessage.getFirstSwitched().getValue());
         Assert.assertEquals(2002000L, flowMessage.getLastSwitched().getValue());
@@ -115,11 +115,11 @@ public class NMS13006_Test {
                 final RecordEnrichment enrichment = (address -> Optional.empty());
 
                 packet.getRecords().forEach(r -> {
-                            final Netflow9MessageBuilder builder = new Netflow9MessageBuilder(r, enrichment);
+                            final Netflow9MessageBuilder builder = new Netflow9MessageBuilder();
                             final FlowMessage flowMessage;
 
                             try {
-                                flowMessage = FlowMessage.parseFrom(builder.buildData());
+                                flowMessage = FlowMessage.parseFrom(builder.buildData(r, enrichment));
                                 Assert.assertEquals(true, flowMessage.hasFirstSwitched());
                                 Assert.assertEquals(true, flowMessage.hasLastSwitched());
                                 Assert.assertEquals(true, flowMessage.hasDeltaSwitched());

--- a/features/telemetry/protocols/netflow/parser/src/test/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/NMS13006_Test.java
+++ b/features/telemetry/protocols/netflow/parser/src/test/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/NMS13006_Test.java
@@ -70,7 +70,7 @@ public class NMS13006_Test {
         record.add(new UnsignedValue("FIRST_SWITCHED", 2000));
         record.add(new UnsignedValue("LAST_SWITCHED", 3000));
         final Netflow9MessageBuilder builder = new Netflow9MessageBuilder();
-        final FlowMessage flowMessage = FlowMessage.parseFrom(builder.buildData(record, enrichment));
+        final FlowMessage flowMessage = builder.buildMessage(record, enrichment).build();
 
         Assert.assertEquals(1001000L, flowMessage.getFirstSwitched().getValue());
         Assert.assertEquals(1002000L, flowMessage.getLastSwitched().getValue());
@@ -86,7 +86,7 @@ public class NMS13006_Test {
         record.add(new UnsignedValue("flowStartMilliseconds", 2001000));
         record.add(new UnsignedValue("flowEndMilliseconds", 2002000));
         final Netflow9MessageBuilder builder = new Netflow9MessageBuilder();
-        final FlowMessage flowMessage = FlowMessage.parseFrom(builder.buildData(record, enrichment));
+        final FlowMessage flowMessage = builder.buildMessage(record, enrichment).build();
 
         Assert.assertEquals(2001000L, flowMessage.getFirstSwitched().getValue());
         Assert.assertEquals(2002000L, flowMessage.getLastSwitched().getValue());
@@ -116,20 +116,11 @@ public class NMS13006_Test {
 
                 packet.getRecords().forEach(r -> {
                             final Netflow9MessageBuilder builder = new Netflow9MessageBuilder();
-                            final FlowMessage flowMessage;
+                            final FlowMessage flowMessage = builder.buildMessage(r, enrichment).build();
 
-                            try {
-                                flowMessage = FlowMessage.parseFrom(builder.buildData(r, enrichment));
-                                Assert.assertEquals(true, flowMessage.hasFirstSwitched());
-                                Assert.assertEquals(true, flowMessage.hasLastSwitched());
-                                Assert.assertEquals(true, flowMessage.hasDeltaSwitched());
-                            } catch (InvalidProtocolBufferException e) {
-                                e.printStackTrace();
-                                fail(e.getMessage());
-                            } catch (IllegalFlowException e) {
-                                e.printStackTrace();
-                                fail(e.getMessage());
-                            }
+                            Assert.assertEquals(true, flowMessage.hasFirstSwitched());
+                            Assert.assertEquals(true, flowMessage.hasLastSwitched());
+                            Assert.assertEquals(true, flowMessage.hasDeltaSwitched());
                         }
                 );
 


### PR DESCRIPTION
Flows with invalid start and end values are asumed to exist in a short
timespan before the flow was exported. Therefore we accept the
inaccuracy in time but take the flow into account.

No flow is illegal!

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-13088

