### PR TITLE
NMS-13065: Resolve hostname only once

### DIFF
--- a/features/flows/elastic/src/main/java/org/opennms/netmgt/flows/elastic/ElasticFlowQueryService.java
+++ b/features/flows/elastic/src/main/java/org/opennms/netmgt/flows/elastic/ElasticFlowQueryService.java
@@ -28,6 +28,7 @@
 
 package org.opennms.netmgt.flows.elastic;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -96,10 +97,11 @@ public abstract class ElasticFlowQueryService implements FlowQueryService {
                 });
     }
 
-    protected static <T, A, R> CompletableFuture<R> transpose(final Collection<CompletableFuture<T>> futures,
+    protected static <T, A, R> CompletableFuture<R> transpose(final Iterable<CompletableFuture<T>> futures,
                                                               final Collector<? super T, A, R> collector) {
-        return CompletableFuture.allOf(Iterables.toArray(futures, CompletableFuture.class))
-                .thenApply(v -> futures.stream()
+        final CompletableFuture<T>[] array = Iterables.toArray(futures, CompletableFuture.class);
+        return CompletableFuture.allOf(array)
+                                .thenApply(v -> Arrays.stream(array)
                         .map(CompletableFuture::join)
                         .collect(collector));
     }


### PR DESCRIPTION
Querying aggregated data sotred by nephron involves to resolve hostnames
for queries by host and by conversation. When querying for time-series,
the hostnames are now queryied only once by key instead of every
time-bucket.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-13065

