### PR TITLE
NMS-13094: Move ServiceTracker beans to Eventd

### DIFF
--- a/features/events/daemon/src/main/resources/META-INF/opennms/applicationContext-daoEvents.xml
+++ b/features/events/daemon/src/main/resources/META-INF/opennms/applicationContext-daoEvents.xml
@@ -27,4 +27,14 @@
     <property name="eventSubscriptionService" ref="eventSubscriptionService" />
   </bean>
 
+  <bean id="filterWatcher" class="org.opennms.netmgt.dao.support.DefaultFilterWatcher" />
+  <onmsgi:service interface="org.opennms.netmgt.dao.api.FilterWatcher" ref="filterWatcher" />
+  <bean id="filterWatcherListener" class="org.opennms.netmgt.events.api.AnnotationBasedEventListenerAdapter">
+    <property name="annotatedListener" ref="filterWatcher" />
+    <property name="eventSubscriptionService" ref="eventSubscriptionService" />
+  </bean>
+
+  <bean id="serviceTracker" class="org.opennms.netmgt.dao.support.DefaultServiceTracker" />
+  <onmsgi:service interface="org.opennms.netmgt.dao.api.ServiceTracker" ref="serviceTracker" />
+
 </beans>

--- a/features/telemetry/daemon/src/main/java/org/opennms/netmgt/telemetry/daemon/ConnectorManager.java
+++ b/features/telemetry/daemon/src/main/java/org/opennms/netmgt/telemetry/daemon/ConnectorManager.java
@@ -143,6 +143,7 @@ public class ConnectorManager {
     }
 
     public void start(TelemetrydConfig config) {
+
         for (ConnectorConfig connectorConfig : config.getConnectors()) {
             if (connectorConfig.getPackages().isEmpty()) {
                 // No packages defined
@@ -242,4 +243,5 @@ public class ConnectorManager {
     public void setEntityScopeProvider(EntityScopeProvider entityScopeProvider) {
         this.entityScopeProvider = entityScopeProvider;
     }
+
 }

--- a/features/telemetry/daemon/src/main/java/org/opennms/netmgt/telemetry/daemon/ConnectorManager.java
+++ b/features/telemetry/daemon/src/main/java/org/opennms/netmgt/telemetry/daemon/ConnectorManager.java
@@ -143,7 +143,6 @@ public class ConnectorManager {
     }
 
     public void start(TelemetrydConfig config) {
-
         for (ConnectorConfig connectorConfig : config.getConnectors()) {
             if (connectorConfig.getPackages().isEmpty()) {
                 // No packages defined
@@ -243,5 +242,4 @@ public class ConnectorManager {
     public void setEntityScopeProvider(EntityScopeProvider entityScopeProvider) {
         this.entityScopeProvider = entityScopeProvider;
     }
-
 }

--- a/features/telemetry/daemon/src/main/resources/META-INF/opennms/applicationContext-telemetryDaemon.xml
+++ b/features/telemetry/daemon/src/main/resources/META-INF/opennms/applicationContext-telemetryDaemon.xml
@@ -29,18 +29,4 @@
     <property name="eventSubscriptionService" ref="eventSubscriptionService" />
   </bean>
 
-  <!-- telemetryd is the only daemon using these services so we define them here for now.
-       With the current Spring context hierarchy it is difficult to expose services that
-       depend on event listeners (since the DAO context starts before eventd)
-  -->
-  <bean id="filterWatcher" class="org.opennms.netmgt.dao.support.DefaultFilterWatcher" />
-  <onmsgi:service interface="org.opennms.netmgt.dao.api.FilterWatcher" ref="filterWatcher" />
-  <bean id="filterWatcherListener" class="org.opennms.netmgt.events.api.AnnotationBasedEventListenerAdapter">
-    <property name="annotatedListener" ref="filterWatcher" />
-    <property name="eventSubscriptionService" ref="eventSubscriptionService" />
-  </bean>
-
-  <bean id="serviceTracker" class="org.opennms.netmgt.dao.support.DefaultServiceTracker" />
-  <onmsgi:service interface="org.opennms.netmgt.dao.api.ServiceTracker" ref="serviceTracker" />
-
 </beans>

--- a/features/telemetry/daemon/src/main/resources/beanRefContext.xml
+++ b/features/telemetry/daemon/src/main/resources/beanRefContext.xml
@@ -9,7 +9,7 @@
          <value>META-INF/opennms/applicationContext-telemetryDaemon.xml</value>
        </list>
      </constructor-arg>
-     <constructor-arg ref="daoContext" />
+     <constructor-arg ref="eventDaemonContext" />
    </bean>
 
 </beans>

--- a/features/telemetry/daemon/src/main/resources/beanRefContext.xml
+++ b/features/telemetry/daemon/src/main/resources/beanRefContext.xml
@@ -9,6 +9,7 @@
          <value>META-INF/opennms/applicationContext-telemetryDaemon.xml</value>
        </list>
      </constructor-arg>
+      <!-- Telemetryd depends on ServiceTracker bean that is loaded with eventd.-->
      <constructor-arg ref="eventDaemonContext" />
    </bean>
 

--- a/features/telemetry/itests/src/test/java/org/opennms/netmgt/telemetry/itests/JtiIT.java
+++ b/features/telemetry/itests/src/test/java/org/opennms/netmgt/telemetry/itests/JtiIT.java
@@ -93,6 +93,7 @@ import com.google.common.io.Resources;
         "classpath:/META-INF/opennms/applicationContext-ipc-sink-camel-client.xml",
         "classpath:/META-INF/opennms/applicationContext-collectionAgentFactory.xml",
         "classpath:/META-INF/opennms/applicationContext-jtiAdapterFactory.xml",
+        "classpath:/META-INF/opennms/applicationContext-daoEvents.xml",
         "classpath:/META-INF/opennms/applicationContext-telemetryDaemon.xml",
         "classpath:/META-INF/opennms/applicationContext-thresholding.xml",
         "classpath:/META-INF/opennms/applicationContext-noOpBlobStore.xml",

--- a/features/telemetry/itests/src/test/java/org/opennms/netmgt/telemetry/itests/ThresholdingIT.java
+++ b/features/telemetry/itests/src/test/java/org/opennms/netmgt/telemetry/itests/ThresholdingIT.java
@@ -117,6 +117,7 @@ import org.springframework.test.context.ContextConfiguration;
         "classpath:/META-INF/opennms/applicationContext-ipc-sink-camel-client.xml",
         "classpath:/META-INF/opennms/applicationContext-collectionAgentFactory.xml",
         "classpath:/META-INF/opennms/applicationContext-jtiAdapterFactory.xml",
+        "classpath:/META-INF/opennms/applicationContext-daoEvents.xml",
         "classpath:/META-INF/opennms/applicationContext-telemetryDaemon.xml",
         "classpath:/META-INF/opennms/applicationContext-testThresholdingDaos.xml",
         "classpath:/META-INF/opennms/applicationContext-testPollerConfigDaos.xml"

--- a/features/telemetry/protocols/openconfig/itests/src/test/java/org/opennms/features/telemetry/protocols/openconfig/OpenConfigIT.java
+++ b/features/telemetry/protocols/openconfig/itests/src/test/java/org/opennms/features/telemetry/protocols/openconfig/OpenConfigIT.java
@@ -86,6 +86,7 @@ import org.springframework.test.context.ContextConfiguration;
         "classpath:/META-INF/opennms/applicationContext-ipc-sink-camel-client.xml",
         "classpath:/META-INF/opennms/applicationContext-collectionAgentFactory.xml",
         "classpath:/META-INF/opennms/applicationContext-openconfig-components.xml",
+        "classpath:/META-INF/opennms/applicationContext-daoEvents.xml",
         "classpath:/META-INF/opennms/applicationContext-telemetryDaemon.xml",
         "classpath:/META-INF/opennms/applicationContext-thresholding.xml",
         "classpath:/META-INF/opennms/applicationContext-noOpBlobStore.xml",


### PR DESCRIPTION
Any module that needs ServiceTracker need to depend on Eventd 
or need to retrieve it as OSGi Service 

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-13094

