### PR TITLE
Parsers are actually children of listeners not siblings

### DIFF
--- a/opennms-container/minion/minion-config-schema.yml
+++ b/opennms-container/minion/minion-config-schema.yml
@@ -178,14 +178,14 @@ categories:
                   name: "host"
                 label: "Host"
                 description: "TODO"
-                key: "/karaf/shell/ssh"
+                key: "/karaf/shell/ssh/host"
                 example: "TODO"
               - name: "port"
                 type:
                   name: "port"
                 label: "Port"
                 description: "TODO"
-                key: "/karaf/shell/port"
+                key: "/karaf/shell/ssh/port"
                 example: "TODO"
   # Minion Environment
   - name: "environment"

--- a/opennms-container/minion/minion-config-schema.yml
+++ b/opennms-container/minion/minion-config-schema.yml
@@ -408,35 +408,32 @@ categories:
                   label: "Parameters"
                   type:
                     name: "properties"
+                - name: "parsers"
+                  label: "Flow Parser Definition"
+                  type:
+                    name: "objects"
+                    fields:
+                      - name: "name"
+                        label: "Parser Name"
+                        type:
+                          name: "string"
+                          validation: "TODO"
+                      - name: "class-name"
+                        label: "Class Name"
+                        type:
+                          name: "string"
+                          validation: "TODO"
+                      - name: "parameters"
+                        label: "Parameters"
+                        type:
+                          name: "properties"
+                    index-type: "field"
+                    index-field: "name"
               index-type: "field"
               index-field: "listener-name"
             label: "Flow Listener Definition"
             description: "TODO"
             key: "/telemetry/flows/listeners"
-            example: "TODO"
-          - name: "flow-parser-def"
-            type:
-              name: "objects"
-              fields:
-                - name: "parser-name"
-                  label: "Parser Name"
-                  type:
-                    name: "string"
-                    validation: "TODO"
-                - name: "class-name"
-                  label: "Class Name"
-                  type:
-                    name: "string"
-                    validation: "TODO"
-                - name: "parameters"
-                  label: "Parameters"
-                  type:
-                    name: "properties"
-              index-type: "field"
-              index-field: "parser-name"
-            label: "Flow Parser Definition"
-            description: "TODO"
-            key: "/telemetry/flows/parsers"
             example: "TODO"
         categories:
           # Telemetry :: Flows :: Single Port Listener


### PR DESCRIPTION
The schema described flows configuration incorrectly. This PR updates the schema to the correct form. This schema is only a reference right now and isn't used directly.

This PR also updates the key paths for SSH host port as they were incorrect.

No Jira.

