### PR TITLE
NMS-13070: fix timezone handling in scheduled reports

### DIFF
--- a/core/web-assets/package-lock.json
+++ b/core/web-assets/package-lock.json
@@ -3182,6 +3182,15 @@
                 }
             }
         },
+        "call-bind": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+            "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+            "requires": {
+                "function-bind": "^1.1.1",
+                "get-intrinsic": "^1.0.2"
+            }
+        },
         "caller-callsite": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/caller-callsite/-/caller-callsite-2.0.0.tgz",
@@ -3790,6 +3799,15 @@
                 "sha.js": "^2.4.8"
             }
         },
+        "cron-parser": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-3.1.0.tgz",
+            "integrity": "sha512-4Spe1gRbiQza3BqklhB/8dMi8PZAWalhLK1p+k3iYJjcxIK6t4YYGL0lKdHT0e743jDTJEDBz1NEAzY88kyNWQ==",
+            "requires": {
+                "is-nan": "^1.3.0",
+                "luxon": "^1.25.0"
+            }
+        },
         "cross-env": {
             "version": "6.0.3",
             "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-6.0.3.tgz",
@@ -4153,7 +4171,6 @@
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
             "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
-            "dev": true,
             "requires": {
                 "object-keys": "^1.0.12"
             }
@@ -5979,8 +5996,7 @@
         "function-bind": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-            "dev": true
+            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
         },
         "functional-red-black-tree": {
             "version": "1.0.1",
@@ -6040,6 +6056,23 @@
             "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
             "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
             "dev": true
+        },
+        "get-intrinsic": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.0.2.tgz",
+            "integrity": "sha512-aeX0vrFm21ILl3+JpFFRNe9aUvp6VFZb2/CTbgLb8j75kOhvoNYjt9d8KA/tJG4gSo8nzEDedRl0h7vDmBYRVg==",
+            "requires": {
+                "function-bind": "^1.1.1",
+                "has": "^1.0.3",
+                "has-symbols": "^1.0.1"
+            },
+            "dependencies": {
+                "has-symbols": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+                    "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
+                }
+            }
         },
         "get-stdin": {
             "version": "4.0.1",
@@ -6272,7 +6305,6 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
             "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-            "dev": true,
             "requires": {
                 "function-bind": "^1.1.1"
             }
@@ -6930,6 +6962,15 @@
             "dev": true,
             "requires": {
                 "is-extglob": "^2.1.1"
+            }
+        },
+        "is-nan": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.2.tgz",
+            "integrity": "sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==",
+            "requires": {
+                "call-bind": "^1.0.0",
+                "define-properties": "^1.1.3"
             }
         },
         "is-negated-glob": {
@@ -8233,6 +8274,11 @@
                 "yallist": "^3.0.2"
             }
         },
+        "luxon": {
+            "version": "1.25.0",
+            "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.25.0.tgz",
+            "integrity": "sha512-hEgLurSH8kQRjY6i4YLey+mcKVAWXbDNlZRmM6AgWDJ1cY3atl8Ztf5wEY7VBReFbmGnwQPz7KYJblL8B2k0jQ=="
+        },
         "main-bower-files": {
             "version": "2.13.3",
             "resolved": "https://registry.npmjs.org/main-bower-files/-/main-bower-files-2.13.3.tgz",
@@ -9178,8 +9224,7 @@
         "object-keys": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-            "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-            "dev": true
+            "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
         },
         "object-visit": {
             "version": "1.0.1",

--- a/core/web-assets/package.json
+++ b/core/web-assets/package.json
@@ -92,6 +92,7 @@
         "bootstrap": "~4.3.1",
         "c3": "~0.4.18",
         "core-js": "^3.2.1",
+        "cron-parser": "^3.1.0",
         "cross-env": "^6.0.3",
         "d3": "^3.5.17",
         "flot": "https://github.com/flot/flot.git#v0.8.3",

--- a/core/web-assets/src/main/assets/js/apps/onms-reports/ReportDetails.js
+++ b/core/web-assets/src/main/assets/js/apps/onms-reports/ReportDetails.js
@@ -1,6 +1,8 @@
 import Types from '../../lib/onms-schedule-editor/scripts/Types';
 import ScheduleOptions from '../../lib/onms-schedule-editor/scripts/ScheduleOptions';
 import ContextError from '../../lib/onms-http/ContextError';
+import Util from 'lib/util';
+
 import moment from 'moment';
 require('moment-timezone');
 
@@ -70,6 +72,45 @@ export default class ReportDetails {
         if (this.supportedFormats.indexOf(this.deliveryOptions.format) === -1) {
             this.deliveryOptions.format = this.format;
         }
+
+        if (window._onmsZoneId) {
+            this.scheduleOptions.serverZone = window._onmsZoneId;
+        } else {
+            const xhr = new XMLHttpRequest();
+            const checkResponseText = () => {
+                try {
+                    if (xhr.readyState === XMLHttpRequest.DONE) {
+                        if (xhr.status === 200) {
+                            const config = JSON.parse(xhr.responseText);
+                            if (config.datetimeformatConfig && config.datetimeformatConfig.zoneId) {
+                                window._onmsZoneId = config.datetimeformatConfig.zoneId;
+                                this.scheduleOptions.serverZone = config.datetimeformatConfig.zoneId;
+                                return;
+                            }
+                        }
+                        // eslint-disable-next-line no-console
+                        console.error('Failed to request server time zone: ' + xhr.status + ' ' + xhr.statusText);
+                        this.scheduleOptions.serverZone = null;
+                    }
+                } catch (e) {
+                    // eslint-disable-next-line no-console
+                    console.error('An error occurred getting the server time zone:', e);
+                    this.scheduleOptions.serverZone = null;
+                }
+            };
+
+            xhr.onreadystatechange = () => {
+                if (input && input.scope) {
+                    input.scope.$evalAsync(checkResponseText);
+                } else {
+                    checkResponseText();
+                }
+            };
+            xhr.open('GET', Util.getBaseHref() + 'rest/info');
+            xhr.setRequestHeader('Accept', 'application/json');
+            xhr.send();
+        }
+
     }
 
     hasErrors() {
@@ -166,6 +207,9 @@ export default class ReportDetails {
                 // to just not do anything
             }
         });
+        if (this.parametersByName['timezone']) {
+            this.scheduleOptions.timezone = this.parametersByName['timezone'].value;
+        }
     }
 
     updateTimezoneParameter(selected) {
@@ -176,6 +220,7 @@ export default class ReportDetails {
             timezone = 'UTC';
         }
         this.parametersByName['timezone'].value = timezone;
+        this.scheduleOptions.timezone = timezone;
         this.validateTimezone();
     }
 

--- a/core/web-assets/src/main/assets/js/apps/onms-reports/index.js
+++ b/core/web-assets/src/main/assets/js/apps/onms-reports/index.js
@@ -257,6 +257,7 @@ const handleGrafanaError = function(response, report, optionalCallbackIfNoContex
                             scope.report.parametersByName['timezone'].value = after;
                         }
                         scope.oldTimeZone = after;
+                        scope.report.validateTimezone();
                     };
 
                     scope.endpointChanged = function () {
@@ -418,7 +419,7 @@ const handleGrafanaError = function(response, report, optionalCallbackIfNoContex
                 online: $stateParams.online === 'true'
             };
 
-            $scope.report = new ReportDetails({id: $scope.meta.reportId});
+            $scope.report = new ReportDetails({id: $scope.meta.reportId, scope: $scope});
             $scope.options = {};
             $scope.loading = false;
             $scope.reportForm = { $invalid: false };
@@ -451,7 +452,7 @@ const handleGrafanaError = function(response, report, optionalCallbackIfNoContex
 
                 ReportTemplateResource.get(requestParameters, function(response) {
                     $scope.loading = false;
-                    $scope.report = new ReportDetails(response);
+                    $scope.report = new ReportDetails(Object.assign(response, {scope: $scope}));
                 }, function(response) {
                     $scope.loading = false;
                     $scope.setGlobalError(response);
@@ -635,7 +636,7 @@ const handleGrafanaError = function(response, report, optionalCallbackIfNoContex
         .controller('ScheduleEditController', ['$scope', 'userInfo', 'meta', 'setGlobalError', 'ReportScheduleResource', function($scope, userInfo, meta, setGlobalError, ReportScheduleResource) {
             $scope.meta = meta;
             $scope.userInfo = userInfo;
-            $scope.report = new ReportDetails({id: $scope.meta.reportId});
+            $scope.report = new ReportDetails({id: $scope.meta.reportId, scope: $scope});
             $scope.options = {};
             $scope.loading = false;
             $scope.reportForm = { $invalid : false };
@@ -668,7 +669,7 @@ const handleGrafanaError = function(response, report, optionalCallbackIfNoContex
 
                 ReportScheduleResource.get({id: $scope.meta.triggerName}, function(response) {
                     $scope.loading = false;
-                    $scope.report = new ReportDetails(response);
+                    $scope.report = new ReportDetails(Object.assign(response, {scope: $scope}));
                 }, function(response) {
                     $scope.loading = false;
                     $scope.setGlobalError(response);

--- a/core/web-assets/src/main/assets/js/lib/onms-schedule-editor/scripts/ScheduleOptions.js
+++ b/core/web-assets/src/main/assets/js/lib/onms-schedule-editor/scripts/ScheduleOptions.js
@@ -10,6 +10,10 @@ import DayOfMonthParser from './parsers/DayOfMonthParser';
 import ContextError from './ContextError';
 import Intervals from './Intervals';
 
+import CronParser from 'cron-parser';
+import moment from 'moment';
+require('moment-timezone');
+
 export default class ScheduleOptions {
 
     /* eslint-disable complexity */
@@ -40,6 +44,9 @@ export default class ScheduleOptions {
 
         // Custom
         this.cronExpression = options.cronExpression || '0 0/5 * * * ?';
+
+        // Report Time Zone to use (if any)
+        this.timezone = options.timezone || undefined;
 
         // Enable debugging?
         this.showDebugOptions = options.showDebugOptions || false;
@@ -175,6 +182,23 @@ export default class ScheduleOptions {
                 throw new ContextError('to', 'To time must be equal or after from time');
             }
         }
+    }
+
+    getServerZone() {
+        return this.serverZone || window._onmsZoneId;
+    }
+
+    getBrowserZone() {
+        return moment.tz.guess();
+    }
+
+    getNextExecution(displayZone) {
+        const interval = CronParser.parseExpression(this.getCronExpression(), {
+            tz: this.timezone,
+        });
+
+        const d = interval.next().toDate();
+        return moment.tz(d, displayZone || this.timezone || moment.tz.guess());
     }
 
     isValid() {

--- a/core/web-assets/src/main/assets/js/lib/onms-schedule-editor/templates/schedule-editor.tpl.html
+++ b/core/web-assets/src/main/assets/js/lib/onms-schedule-editor/templates/schedule-editor.tpl.html
@@ -1,3 +1,24 @@
+<style type="text/css">
+    onms-time-input {
+        display: inline-block;
+    }
+    .iso-datetime {
+        font-family: monospace;
+    }
+    .zone {
+        display: inline;
+        margin: unset;
+        padding: 0.5rem;
+        vertical-align: middle;
+    }
+    .next-scheduled-time {
+        padding-top: 1rem;
+        padding-bottom: 1rem;
+    }
+    td {
+        padding-right: 0.4rem;
+    }
+</style>
 <form class="form" novalidate>
     <div class="">
         <div class="form-check">
@@ -53,6 +74,7 @@
                     ng-model="options.at"
                     options="options.at"
             />
+            <span class="zone">{{options.timezone}}</span>
         </div>
 
         <!-- Other options -->
@@ -81,6 +103,7 @@
                     ng-model="options.at"
                     options="options.at"
             />
+            <span class="zone">{{options.timezone}}</span>
         </div>
 
         <div class="">
@@ -153,11 +176,53 @@
     <div class="" ng-if="options.type === 'custom'">
         <div class="form-inline">
             <input id="customCronExpressionInput" type="text" class="form-control" ng-class="{'is-invalid': errors.cronExpression}" ng-model="options.cronExpression "/>
+            <span class="zone">{{options.timezone}}</span>
             <a href="http://www.quartz-scheduler.org/documentation/quartz-2.2.2/tutorials/crontrigger.html" class="ml-2" target="_blank" title="Help me">
                 <i class="fa fa-question-circle" aria-hidden="true"></i>
             </a>
             <p class="invalid-feedback" ng-if="errors.cronExpression">{{errors.cronExpression}}</p>
         </div>
+    </div>
+
+    <div class="next-scheduled-time">
+        <label>
+            Next scheduled time:
+        </label>
+        <table>
+            <tr>
+                <td>
+                    Report:
+                </td>
+                <td>
+                    <span class="iso-datetime">{{options.getNextExecution(options.timezone).format("llll")}}</span>
+                </td>
+                <td>
+                    ({{options.timezone}})
+                </td>
+            </tr>
+            <tr ng-if="options.getServerZone()">
+                <td>
+                    Server:
+                </td>
+                <td>
+                    <span class="iso-datetime">{{options.getNextExecution(options.getServerZone()).format("llll")}}</span>
+                </td>
+                <td>
+                    ({{options.getServerZone()}})
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    Browser:
+                </td>
+                <td>
+                    <span class="iso-datetime">{{options.getNextExecution(options.getBrowserZone()).format("llll")}}</span>
+                </td>
+                <td>
+                    ({{options.getBrowserZone()}})
+                </td>
+            </tr>
+        </table>
     </div>
 
     <div class="text-muted mt-2" ng-if="options.showDebugOptions">

--- a/features/endpoints/grafana/api/src/main/java/org/opennms/netmgt/endpoints/grafana/api/GrafanaClient.java
+++ b/features/endpoints/grafana/api/src/main/java/org/opennms/netmgt/endpoints/grafana/api/GrafanaClient.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2019 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ * Copyright (C) 2019-2021 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -39,5 +39,5 @@ public interface GrafanaClient {
 
     Dashboard getDashboardByUid(String uid) throws IOException;
 
-    CompletableFuture<byte[]> renderPngForPanel(Dashboard dashboard, Panel panel, int width, int height, long from, long to, final String utcOffset, final Map<String, String> variables);
+    CompletableFuture<byte[]> renderPngForPanel(Dashboard dashboard, Panel panel, int width, int height, long from, long to, final String timezone, final Map<String, String> variables);
 }

--- a/features/endpoints/grafana/client/src/main/java/org/opennms/netmgt/endpoints/grafana/client/GrafanaClientImpl.java
+++ b/features/endpoints/grafana/client/src/main/java/org/opennms/netmgt/endpoints/grafana/client/GrafanaClientImpl.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2019 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ * Copyright (C) 2019-2021 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -129,7 +129,7 @@ public class GrafanaClientImpl implements GrafanaClient {
     }
 
     @Override
-    public CompletableFuture<byte[]> renderPngForPanel(Dashboard dashboard, Panel panel, int width, int height, long from, long to, String utcOffset, Map<String, String> variables) {
+    public CompletableFuture<byte[]> renderPngForPanel(Dashboard dashboard, Panel panel, int width, int height, long from, long to, String timezone, Map<String, String> variables) {
         final HttpUrl.Builder builder = baseUrl.newBuilder()
                 .addPathSegment("render")
                 .addPathSegment("d-solo")
@@ -145,8 +145,8 @@ public class GrafanaClientImpl implements GrafanaClient {
                 // Set a render timeout equal to the client's read timeout
                 .addQueryParameter("timeout", Integer.toString(config.getReadTimeoutSeconds()))
                 .addQueryParameter("theme", "light"); // Use the light theme
-        if (!Strings.isNullOrEmpty(utcOffset)) {
-            builder.addQueryParameter("tz", utcOffset);
+        if (!Strings.isNullOrEmpty(timezone)) {
+            builder.addQueryParameter("tz", timezone);
         }
         variables.forEach((k,v) -> builder.addQueryParameter("var-"+ k, v));
 

--- a/integrations/opennms-jasper-extensions/src/main/java/org/opennms/netmgt/jasper/grafana/GrafanaPanelDatasource.java
+++ b/integrations/opennms-jasper-extensions/src/main/java/org/opennms/netmgt/jasper/grafana/GrafanaPanelDatasource.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2019 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ * Copyright (C) 2019-2021 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -30,7 +30,6 @@ package org.opennms.netmgt.jasper.grafana;
 
 import static org.opennms.netmgt.jasper.grafana.ExceptionToPngRenderer.renderExceptionToPng;
 
-import java.time.ZoneId;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -46,7 +45,6 @@ import java.util.stream.Stream;
 import org.opennms.netmgt.endpoints.grafana.api.Dashboard;
 import org.opennms.netmgt.endpoints.grafana.api.GrafanaClient;
 import org.opennms.netmgt.endpoints.grafana.api.Panel;
-import org.opennms.netmgt.jasper.helper.TimezoneHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -104,7 +102,7 @@ public class GrafanaPanelDatasource implements JRRewindableDataSource {
     }
 
     @Override
-    public Object getFieldValue(JRField jrField) {
+    public Object getFieldValue(final JRField jrField) {
         final String fieldName = jrField.getName();
         if (Objects.equals(WIDTH_FIELD_NAME, fieldName)) {
             return query.getWidth();
@@ -143,21 +141,12 @@ public class GrafanaPanelDatasource implements JRRewindableDataSource {
 
         // Issue the requests for all of the panels simultaneously
         LOG.debug("Triggering asynchronous rendering of PNGs for {} panels for dashboard: {}", panels.size(), dashboard.getTitle());
-        final String utcOffset = getUtcOffset(query);
+        // final String utcOffset = getUtcOffset(query);
         for (Panel panel : panels) {
             final CompletableFuture<byte[]> panelImageBytes = client.renderPngForPanel(dashboard, panel, query.getWidth(), query.getHeight(),
-                    query.getFrom().getTime(), query.getTo().getTime(), utcOffset, query.getVariables());
+                    query.getFrom().getTime(), query.getTo().getTime(), query.getTimezone(), query.getVariables());
             panelRenders.put(panel, panelImageBytes);
         }
-    }
-
-    private static String getUtcOffset(GrafanaQuery query) {
-        if (query.getTimezone() != null) {
-            final ZoneId zoneId = ZoneId.of(query.getTimezone());
-            final String utcOffset = TimezoneHelper.getUtcOffset(zoneId, query.getFrom());
-            return utcOffset;
-        }
-        return null;
     }
 
 }

--- a/integrations/opennms-jasper-extensions/src/main/java/org/opennms/netmgt/jasper/helper/TimezoneHelper.java
+++ b/integrations/opennms-jasper-extensions/src/main/java/org/opennms/netmgt/jasper/helper/TimezoneHelper.java
@@ -75,6 +75,13 @@ public class TimezoneHelper {
 		return format.format(rezoned);
 	}
 
+	public static String now(final ZoneId zoneId, final String pattern) throws ParseException {
+		final Date now = new Date();
+		final SimpleDateFormat format = new SimpleDateFormat(pattern);
+		format.setTimeZone(TimeZone.getTimeZone(zoneId));
+		return format.format(now);
+	}
+
     public static String getUtcOffset(final ZoneId zoneId, final Date referenceDate) {
         if (zoneId == null || referenceDate == null) {
             return "";

--- a/opennms-base-assembly/src/main/filtered/etc/report-templates/Grafana-Dashboard-Report-1ppp.jrxml
+++ b/opennms-base-assembly/src/main/filtered/etc/report-templates/Grafana-Dashboard-Report-1ppp.jrxml
@@ -181,12 +181,12 @@ new GregorianCalendar(new GregorianCalendar().get(Calendar.YEAR), new GregorianC
           </textElement>
           <text><![CDATA[Rendered at:]]></text>
         </staticText>
-        <textField pattern="EEE dd MMM yyyy HH:mm:ss z">
+        <textField>
           <reportElement x="80" y="2" width="200" height="20" uuid="72447933-df4d-4da8-8c10-e8b5f08f41d0"/>
           <textElement verticalAlignment="Middle">
             <font size="10" isBold="false"/>
           </textElement>
-          <textFieldExpression><![CDATA[new java.util.Date()]]></textFieldExpression>
+          <textFieldExpression><![CDATA[org.opennms.netmgt.jasper.helper.TimezoneHelper.now($P{timezone}, "EEE dd MMM yyyy HH:mm:ss z")]]></textFieldExpression>
         </textField>
       </frame>
     </band>

--- a/opennms-base-assembly/src/main/filtered/etc/report-templates/Grafana-Dashboard-Report-2ppp.jrxml
+++ b/opennms-base-assembly/src/main/filtered/etc/report-templates/Grafana-Dashboard-Report-2ppp.jrxml
@@ -181,12 +181,12 @@ new GregorianCalendar(new GregorianCalendar().get(Calendar.YEAR), new GregorianC
           </textElement>
           <text><![CDATA[Rendered at:]]></text>
         </staticText>
-        <textField pattern="EEE dd MMM yyyy HH:mm:ss z">
+        <textField>
           <reportElement x="80" y="2" width="200" height="20" uuid="72447933-df4d-4da8-8c10-e8b5f08f41d0"/>
           <textElement verticalAlignment="Middle">
             <font size="10" isBold="false"/>
           </textElement>
-          <textFieldExpression><![CDATA[new java.util.Date()]]></textFieldExpression>
+          <textFieldExpression><![CDATA[org.opennms.netmgt.jasper.helper.TimezoneHelper.now($P{timezone}, "EEE dd MMM yyyy HH:mm:ss z")]]></textFieldExpression>
         </textField>
       </frame>
     </band>

--- a/opennms-base-assembly/src/main/filtered/etc/report-templates/Grafana-Dashboard-Report-4ppp.jrxml
+++ b/opennms-base-assembly/src/main/filtered/etc/report-templates/Grafana-Dashboard-Report-4ppp.jrxml
@@ -101,7 +101,7 @@ new GregorianCalendar(new GregorianCalendar().get(Calendar.YEAR), new GregorianC
         </textElement>
         <textFieldExpression><![CDATA[org.opennms.netmgt.jasper.helper.TimezoneHelper.formatDate($P{startDate}, $P{timezone}, $P{dateFormat})]]></textFieldExpression>
       </textField>
-      <textField pattern="EEE dd MMM yyyy HH:mm:ss">
+      <textField>
         <reportElement x="700" y="89" width="219" height="20" forecolor="#000000" uuid="558f5fde-80e7-4515-976e-643bc23ad397"/>
         <textElement verticalAlignment="Middle">
           <font size="12" isBold="false"/>
@@ -181,12 +181,12 @@ new GregorianCalendar(new GregorianCalendar().get(Calendar.YEAR), new GregorianC
           </textElement>
           <text><![CDATA[Rendered at:]]></text>
         </staticText>
-        <textField pattern="EEE dd MMM yyyy HH:mm:ss z">
+        <textField>
           <reportElement x="80" y="2" width="200" height="20" uuid="72447933-df4d-4da8-8c10-e8b5f08f41d0"/>
           <textElement verticalAlignment="Middle">
             <font size="10" isBold="false"/>
           </textElement>
-          <textFieldExpression><![CDATA[new java.util.Date()]]></textFieldExpression>
+          <textFieldExpression><![CDATA[org.opennms.netmgt.jasper.helper.TimezoneHelper.now($P{timezone}, "EEE dd MMM yyyy HH:mm:ss z")]]></textFieldExpression>
         </textField>
       </frame>
     </band>


### PR DESCRIPTION
I took a two-pronged approach to handling this.

1. Always perform all operations from the point-of-view of the report time zone. Schedule reports based on that zone, render dates in the Grafana reports based on that zone, etc.
2. Give the user visibility into the time zone when scheduling the report.  This means:
   * show the time zone right next to the "time" input when scheduling
   * based on the schedule, show the next time it would run, in the report's time zone, the server's time zone, and the user's time zone

<img width="484" alt="Screen Shot 2021-01-20 at 4 43 33 PM" src="https://user-images.githubusercontent.com/89252/105403628-f70f7580-5bf6-11eb-8ebe-eae160dec94b.png">


### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-13070

