### PR TITLE
NMS-13072: Add JMX prometheus exporter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ opennms-container/*/tarball/*.tar.gz
 # Python
 *.pyc
 __pycache__
+
+# Jenv local java version file
+.java-version

--- a/opennms-container/minion/CONFD_README.md
+++ b/opennms-container/minion/CONFD_README.md
@@ -9,7 +9,7 @@ specific configuration files will overwrite the corresponding config provided by
 ## Contents
 The following describes the keys that can be specified in `minion-config.yaml` to configure the Minion via confd.
 ### Minion Controller Config
-```
+```yaml
 --- 
 broker-url: "<broker url>"
 http-url: "<http url>"
@@ -22,14 +22,14 @@ Config specified will be written to `etc/org.opennms.minion.controller.cfg`.
 Supplying the http or broker username/password via yaml file for configuration via confd is not supported.
 
 ### Instance Id
-```
+```yaml
 ---
 org.opennms.instance.id: "<instance id>"
 ```
 Config specified will be written to `etc/instance-id.properties`.
 
 ### AWS SQS
-```
+```yaml
 ---
 aws:
     aws_region: "us-east-1"
@@ -48,7 +48,7 @@ ipc:
 Config specified will be written to `etc/org.opennms.core.ipc.aws.sqs.cfg`.
 
 ### Kafka RPC
-```
+```yaml
 --- 
 ipc:
     rpc:
@@ -62,7 +62,7 @@ Config specified will be written to `etc/org.opennms.core.ipc.rpc.kafka.cfg`. Ad
 `bootstrap.servers` key is specified, `etc/featuresBoot.d/kafka-rpc.boot` will also be updated.
 
 ### Kafka SINK
-```
+```yaml
 --- 
 ipc:
     sink:
@@ -79,7 +79,7 @@ Config specified will be written to `etc/org.opennms.core.ipc.sink.kafka.cfg`. A
 `bootstrap.servers` key is specified, `etc/featuresBoot.d/kafka-sink.boot` will also be updated.
 
 ### Sink Off Heap
-```
+```yaml
 --- 
 ipc:
     sink:
@@ -93,7 +93,7 @@ Config specified will be written to `etc/org.opennms.core.ipc.sink.offheap.cfg`.
 ### Single Port Flows
 To configure flows on a single port, set the following `enabled` key to `true`. Optionally parameters can be provided
 that will be included in the generated config.
-```
+```yaml
 --- 
 telemetry:
     flows:
@@ -110,7 +110,7 @@ Config specified will be written to `etc/org.opennms.features.telemtry.listeners
 ### Telemetry Flow Listeners
 Individual flow listeners can be configured. See the example below for how to specify parameters and parsers. Any number
 of uniquely named listeners can be defined.
-```
+```yaml
 --- 
 telemetry:
     flows:
@@ -130,7 +130,7 @@ telemetry:
 Config specified will be written to `etc/org.opennms.features.telemtry.listeners-<Listener-Name>.cfg`.
 
 ### Syslog
-```
+```yaml
 --- 
 netmgt:
     syslog:
@@ -141,7 +141,7 @@ netmgt:
 Config specified will be written to `etc/org.opennms.netmgt.syslog.cfg`.
 
 ### Traps
-```
+```yaml
 --- 
 netmgt:
     traps:
@@ -152,7 +152,7 @@ netmgt:
 Config specified will be written to `etc/org.opennms.netmgt.trapd.cfg`.
 
 ### System Properties
-```
+```yaml
 --- 
 system:
     properties:
@@ -164,7 +164,7 @@ Config specified will be written to `etc/confd.system.properties` which gets aut
 `jaeger-agent-host` key is specified, `etc/featuresBoot.d/jaeger.boot` will also be updated.
 
 ### Karaf Properties
-```
+```yaml
 ---
 karaf:
     shell:
@@ -185,7 +185,7 @@ Config specified will be written to:
 - `etc/org.apache.karaf.management.cfg` for content under `management`.
 
 ### Jetty Properties
-```
+```yaml
 ---
 jetty:
     web:
@@ -195,7 +195,7 @@ jetty:
 Config specified will be written to `etc/org.ops4j.pax.web.cfg`
 
 ### Secure Credentials Vault Provider
-```
+```yaml
 --- 
 scv:
     provider: "dominion"
@@ -204,7 +204,7 @@ Can be used to override the default SCV provider from the JCEKS implementation (
 based implementation which requests credentials from Dominion. If not specified the default JCEKS will be used.
 
 ### Java Options
-```
+```yaml
 ---
 process-env:
     java-opts:
@@ -214,6 +214,36 @@ process-env:
 ```
 
 Can be used to specify an arbitrary list of Java options. Config specified is written to file `/opt/minion/etc/minion-process.env` that contains `key=value` pairs that are set in the environment of the Minion process..
+
+## Prometheus JMX Exporter
+
+To provide an out of band management of the JVM with the Minion process, the Prometheus JMX exporter is shipped with this container image.
+The default configuration is set to the following values and can be set in the `minion-config.yaml` file:
+
+```yaml
+---
+java:
+  agent:
+    prom-jmx-exporter:
+      jmxUrl: "service:jmx:rmi:///jndi/rmi://127.0.0.1:1299/karaf-minion"
+      username: "admin"
+      password: "admin"
+      lowerCaseOutputName: "true"
+      lowercaseOutputLabelNames: "true"
+      whitelistObjectNames:
+      - "org.opennms.core.ipc.sink.producer:*"
+      - "org.opennms.netmgt.dnsresolver.netty:*"
+      - "org.opennms.netmgt.telemetry:*"
+```
+
+The Minion container images comes with the Prometheus JMX exporter and can be enabled with:
+
+```yaml
+---
+process-env:
+  java-opts:
+    - -javaagent:/opt/prom-jmx-exporter/jmx_prometheus_javaagent.jar=9299:/opt/prom-jmx-exporter/config.yaml
+```
 
 ## Test/Develop confd templates
 `confd` template changes can locally be tested by running a Minion container and mapping the corresponding files into the container. The following procedure might be useful:
@@ -226,7 +256,7 @@ Can be used to specify an arbitrary list of Java options. Config specified is wr
 1. If the result is not yet satisfactory then remove the container by `docker rm -f minion`, edit the files in your IDE, and start the image again
 
 
-```
+```yaml
 version: '3'
 services:
   minion:

--- a/opennms-container/minion/Dockerfile
+++ b/opennms-container/minion/Dockerfile
@@ -8,10 +8,20 @@ ARG BASE_IMAGE="opennms/deploy-base:jre-1.2.0.b54"
 
 FROM ${BASE_IMAGE} as minion-base
 
+ARG PROM_JMX_EXPORTER_VERSION="0.15.0"
+ARG PROM_JMX_EXPORTER_URL="https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/${PROM_JMX_EXPORTER_VERSION}/jmx_prometheus_javaagent-${PROM_JMX_EXPORTER_VERSION}.jar"
+
 ADD ./tarball/minion.tar.gz /opt/
 
 # Organize files based on the build home dir /opt/minion
 RUN mv /opt/minion-* /opt/minion
+
+# Install wget and update certificates for arm/v7 otherwise SSL
+# ERROR: cannot verify repo1.maven.org's certificate, issued by 'CN=DigiCert SHA2 Secure Server CA,O=DigiCert Inc,C=US':
+# To connect to repo1.maven.org insecurely, use `--no-check-certificate'.
+RUN apt-get update && apt-get -y install wget && update-ca-certificates -f
+RUN mkdir -p /opt/prom-jmx-exporter && \
+    wget "${PROM_JMX_EXPORTER_URL}" --output-document=/opt/prom-jmx-exporter/jmx_prometheus_javaagent.jar
 
 # We set the correct permissions in this stage, so we don't have this as an addtional
 # layer in our deploy image.
@@ -43,6 +53,9 @@ COPY container-fs/health.sh /
 # If you copy from /opt/minion to /opt/minion the permissions are not preserved
 # We would have 755 for minion:root instead of 775 and prevents writing lock files in /opt/minion
 COPY --chown=10001:0 --from=minion-base /opt /opt
+
+# Copy Prometheus JMX Exporter
+COPY --chown=10001:0 --from=minion-base /opt/prom-jmx-exporter /opt/prom-jmx-exporter
 
 # Install confd.io configuration files and scripts and ensure they are executable
 COPY ./container-fs/confd/ /opt/minion/confd/

--- a/opennms-container/minion/Makefile
+++ b/opennms-container/minion/Makefile
@@ -22,6 +22,7 @@ REVISION                := $(shell git describe --always)
 BUILD_NUMBER            := "unset"
 BUILD_URL               := "unset"
 BUILD_BRANCH            := $(shell git describe --always)
+PROM_JMX_EXPORTER_VERSION := 0.15.0
 
 help:
 	@echo ""
@@ -54,6 +55,7 @@ help:
 	@echo "  BUILD_NUMBER:       In case we run in CI/CD this is the build number which produced the artifact, default: $(BUILD_NUMBER)"
 	@echo "  BUILD_URL:          In case we run in CI/CD this is the URL which for the build, default: $(BUILD_URL)"
 	@echo "  BUILD_BRANCH:       In case we run in CI/CD this is the branch of the build, default: $(BUILD_BRANCH)"
+	@echo "  PROM_JMX_EXPORTER_VERSION: Version for the Prometheus JMX Exporter agent, default: $(PROM_JMX_EXPORTER_VERSION)"
 	@echo ""
 	@echo "Example:"
 	@echo "  make build DOCKER_REGISTRY=myregistry.com DOCKER_ORG=myorg DOCKER_FLAGS=--push"
@@ -82,6 +84,7 @@ build: test
 	  --build-arg BUILD_NUMBER=$(BUILD_NUMBER) \
 	  --build-arg BUILD_URL=$(BUILD_URL) \
 	  --build-arg BUILD_BRANCH=$(BUILD_BRANCH) \
+	  --build-arg PROM_JMX_EXPORTER_VERSION=$(PROM_JMX_EXPORTER_VERSION) \
 	  --tag=$(DOCKER_TAG) \
 	  $(DOCKER_FLAGS) \
 	  .

--- a/opennms-container/minion/container-fs/confd/conf.d/prom-jmx-exporter.toml
+++ b/opennms-container/minion/container-fs/confd/conf.d/prom-jmx-exporter.toml
@@ -1,0 +1,6 @@
+[template]
+src = "prom-jmx-exporter.yaml.tmpl"
+dest = "/opt/prom-jmx-exporter/config.yaml"
+keys = [
+    "/java/agent/prom-jmx-exporter"
+]

--- a/opennms-container/minion/container-fs/confd/templates/prom-jmx-exporter.yaml.tmpl
+++ b/opennms-container/minion/container-fs/confd/templates/prom-jmx-exporter.yaml.tmpl
@@ -1,0 +1,38 @@
+#
+# DON'T EDIT THIS FILE :: GENERATED WITH CONFD
+#
+{{$promJmxPath := "/java/agent/prom-jmx-exporter" -}}
+startDelaySeconds: {{getv "$promJmxPath/startDelaySeconds" "0"}}
+jmxUrl: {{getv "$promJmxPath/jmxUrl" "service:jmx:rmi:///jndi/rmi://127.0.0.1:1299/karaf-minion"}}
+username: {{getv "$promJmxPath/username" "admin"}}
+password: {{getv "$promJmxPath/password" "admin"}}
+lowercaseOutputName: {{getv "$promJmxPath/lowerCaseOutputName" "true"}}
+lowercaseOutputLabelNames: {{getv "$promJmxPath/lowercaseOutputLabelNames" "true"}}
+{{$woSize := len (getvs (print $promJmxPath "/whitelistObjectNames/*")) -}}
+{{if gt $woSize 0 -}}
+whitelistObjectNames:
+{{range getvs (print $promJmxPath "/whitelistObjectNames/*") -}}
+- "{{.}}"
+{{end -}}
+{{end -}}
+{{$boSize := len (getvs (print $promJmxPath "/blacklistObjectNames/*")) -}}
+{{if gt $boSize 0 -}}
+blacklistObjectNames:
+{{range getvs (print $promJmxPath "/blacklistObjectNames/*") -}}
+- "{{.}}"
+{{end -}}
+{{end}}
+rules:
+- pattern: org\.opennms\..+\.(.+)<name=(.+)><>Value
+  name: minion_$1_$2
+  type: GAUGE
+
+- pattern: org\.opennms\..+\.(.+)<name=(.+)><>Count
+  name: minion_$1_$2_count
+  type: COUNTER
+
+- pattern: org\.opennms\..+\.(.+)<name=(.+)><>(\d+)thPercentile
+  name: minion_$1_$2
+  type: GAUGE
+  labels:
+    quantile: "0.$3"

--- a/opennms-container/minion/minion-config-schema.yml
+++ b/opennms-container/minion/minion-config-schema.yml
@@ -120,6 +120,88 @@ categories:
             description: "Set the scv provider."
             key: "/scv/provider"
             example: "TODO"
+
+  # Java Agent
+  - name: "java"
+    label: "Java"
+    description: "Java configuration parameters."
+    categories:
+      # Java :: Agent
+      - name: "agent"
+        label: "Agent"
+        description: "Configuration parameters for Java agents."
+        categories:
+          # Prometheus JMX exporter
+          - name: "prom-jmx-exporter"
+            label: "Prometheus JMX Exporter"
+            description: "Configuration for the Prometheus JMX Exporter agent."
+            config:
+              - name: "startDelaySeconds"
+                type:
+                  name: "string"
+                label: "Start delay"
+                description: "Start delay in seconds before serving requests. Any requests within the delay period will result in an empty metrics set."
+                key: "/java/agent/prom-jmx-exporter/startDelaySeconds"
+                example: "0"
+              - name: "jmxUrl"
+                type:
+                  name: "string"
+                label: "JMX URL"
+                description: "JMX URL connecting to the local JVM."
+                key: "/java/agent/prom-jmx-exporter/jmxUrl"
+                example: "service:jmx:rmi:///jndi/rmi://127.0.0.1:1299/karaf-minion"
+              - name: "username"
+                type:
+                  name: "string"
+                label: "Username"
+                description: "Connection username to establish the JMX connection."
+                key: "/java/agent/prom-jmx-exporter/username"
+                example: "admin"
+              - name: "password"
+                type:
+                  name: "string"
+                label: "Password"
+                description: "Connection password to establish the JMX connection."
+                key: "/java/agent/prom-jmx-exporter/password"
+                example: "admin"
+              - name: "lowerCaseOutputName"
+                type:
+                  name: "boolean"
+                label: "Lowercase output name"
+                description: "Lowercase the output metric name."
+                key: "/java/agent/prom-jmx-exporter/lowerCaseOutputName"
+                example: "true"
+              - name: "lowercaseOutputLabelNames"
+                type:
+                  name: "boolean"
+                label: "Lowercase output label names"
+                description: "Lowercase the output metric label names."
+                key: "/java/agent/prom-jmx-exporter/lowercaseOutputLabelNames"
+                example: "true"
+              - name: "whitelistObjectNames"
+                type:
+                  name: "collection"
+                  strategy: "indexed"
+                  items:
+                    label: "Whitelist Object Names"
+                    type:
+                      name: "string"
+                label: "Whitelist Object Names"
+                description: "A list of ObjectNames to query."
+                key: "/java/agent/prom-jmx-exporter/whitelistObjectNames"
+                example: "org.opennms.core.ipc.sink.producer:*", "org.opennms.netmgt.dnsresolver.netty:*", "org.opennms.netmgt.telemetry:*"
+              - name: "blacklistObjectNames"
+                type:
+                  name: "collection"
+                  strategy: "indexed"
+                  items:
+                    label: "Blacklist Object Names"
+                    type:
+                      name: "string"
+                label: "Blacklist Object Names"
+                description: "A list of ObjectNames to not query. Takes precedence over whitelistObjectNames. Defaults to none."
+                key: "/java/agent/prom-jmx-exporter/blacklistObjectNames"
+                example: "org.apache.activemq:clientId=*,*"
   # Karaf
   - name: "karaf"
     label: "Karaf"


### PR DESCRIPTION
Add Prometheus JMX exporter for out of band management of the Minion Java Virtual Machine.
Set yaml formatting and add Prometheus JMX docs.

### All Contributors

* [x] Have you read and followed our [Contribution Guidelines](https://github.com/OpenNMS/opennms/blob/develop/CONTRIBUTING.md)?
* [x] Have you [made an issue in the OpenNMS issue tracker](https://issues.opennms.org)?<br>If so, you should:
  1. update the title of this PR to be of the format: `${JIRA-ISSUE-NUMBER}: subject of pull request`
  2. update the JIRA link at the bottom of this comment to refer to the real issue number
  3. prefix your commit messages with the issue number, if possible
* [x] Have you made a comment in that issue which points back to this PR?
* [x] Have you updated the JIRA link at the bottom of this comment to link to your issue?
* [x] If this is a new or updated feature, is there documentation for the new behavior?
* [x] If this is new code, are there unit and/or integration tests?
* [x] If this PR targets a `foundation-*` branch, does it avoid changing files in `$OPENNMS_HOME/etc/`?

Added JMX prometheus exporter agent which is disabled by default. It has to be explicitly enabled with the Java option `-javaagent:/opt/prom-jmx-exporter/jmx_prometheus_javaagent.jar=9299:/opt/prom-jmx-exporter/config.yaml`. The port 9299/tcp needs to be published has well.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-13072

