### PR TITLE
NMS-13106: Allows flows to be received out of order

### DIFF
--- a/features/telemetry/protocols/netflow/adapter/src/test/java/org/opennms/netmgt/telemetry/protocols/netflow/adapter/ipfix/IpFixProtobufValidationTest.java
+++ b/features/telemetry/protocols/netflow/adapter/src/test/java/org/opennms/netmgt/telemetry/protocols/netflow/adapter/ipfix/IpFixProtobufValidationTest.java
@@ -52,11 +52,10 @@ import org.opennms.netmgt.telemetry.protocols.netflow.parser.InvalidPacketExcept
 import org.opennms.netmgt.telemetry.protocols.netflow.parser.Protocol;
 import org.opennms.netmgt.telemetry.protocols.netflow.parser.ipfix.proto.Header;
 import org.opennms.netmgt.telemetry.protocols.netflow.parser.ipfix.proto.Packet;
+import org.opennms.netmgt.telemetry.protocols.netflow.parser.session.SequenceNumberTracker;
 import org.opennms.netmgt.telemetry.protocols.netflow.parser.session.Session;
 import org.opennms.netmgt.telemetry.protocols.netflow.parser.session.TcpSession;
 import org.opennms.netmgt.telemetry.protocols.netflow.transport.FlowMessage;
-
-import com.google.protobuf.InvalidProtocolBufferException;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
@@ -135,7 +134,7 @@ public class IpFixProtobufValidationTest {
 
     private List<Flow> getFlowsForPayloadsInSession(List<byte[]> payloads) {
         final List<Flow> flows = new ArrayList<>();
-        final Session session = new TcpSession(InetAddress.getLoopbackAddress());
+        final Session session = new TcpSession(InetAddress.getLoopbackAddress(), () -> new SequenceNumberTracker(32));
         for (byte[] payload : payloads) {
             final ByteBuf buffer = Unpooled.wrappedBuffer(payload);
             final Header header;

--- a/features/telemetry/protocols/netflow/adapter/src/test/java/org/opennms/netmgt/telemetry/protocols/netflow/adapter/netflow9/Netflow9ConverterTest.java
+++ b/features/telemetry/protocols/netflow/adapter/src/test/java/org/opennms/netmgt/telemetry/protocols/netflow/adapter/netflow9/Netflow9ConverterTest.java
@@ -54,11 +54,10 @@ import org.opennms.netmgt.telemetry.protocols.netflow.parser.InvalidPacketExcept
 import org.opennms.netmgt.telemetry.protocols.netflow.parser.Protocol;
 import org.opennms.netmgt.telemetry.protocols.netflow.parser.netflow9.proto.Header;
 import org.opennms.netmgt.telemetry.protocols.netflow.parser.netflow9.proto.Packet;
+import org.opennms.netmgt.telemetry.protocols.netflow.parser.session.SequenceNumberTracker;
 import org.opennms.netmgt.telemetry.protocols.netflow.parser.session.Session;
 import org.opennms.netmgt.telemetry.protocols.netflow.parser.session.TcpSession;
 import org.opennms.netmgt.telemetry.protocols.netflow.transport.FlowMessage;
-
-import com.google.protobuf.InvalidProtocolBufferException;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
@@ -109,7 +108,7 @@ public class Netflow9ConverterTest {
 
     private List<Flow> getFlowsForPayloadsInSession(List<byte[]> payloads) {
         final List<Flow> flows = new ArrayList<>();
-        final Session session = new TcpSession(InetAddress.getLoopbackAddress());
+        final Session session = new TcpSession(InetAddress.getLoopbackAddress(), () -> new SequenceNumberTracker(32));
         for (byte[] payload : payloads) {
             final ByteBuf buffer = Unpooled.wrappedBuffer(payload);
             final Header header;

--- a/features/telemetry/protocols/netflow/adapter/src/test/java/org/opennms/netmgt/telemetry/protocols/netflow/adapter/netflow9/Netflow9ProtobufValidationTest.java
+++ b/features/telemetry/protocols/netflow/adapter/src/test/java/org/opennms/netmgt/telemetry/protocols/netflow/adapter/netflow9/Netflow9ProtobufValidationTest.java
@@ -53,11 +53,10 @@ import org.opennms.netmgt.telemetry.protocols.netflow.parser.InvalidPacketExcept
 import org.opennms.netmgt.telemetry.protocols.netflow.parser.Protocol;
 import org.opennms.netmgt.telemetry.protocols.netflow.parser.netflow9.proto.Header;
 import org.opennms.netmgt.telemetry.protocols.netflow.parser.netflow9.proto.Packet;
+import org.opennms.netmgt.telemetry.protocols.netflow.parser.session.SequenceNumberTracker;
 import org.opennms.netmgt.telemetry.protocols.netflow.parser.session.Session;
 import org.opennms.netmgt.telemetry.protocols.netflow.parser.session.TcpSession;
 import org.opennms.netmgt.telemetry.protocols.netflow.transport.FlowMessage;
-
-import com.google.protobuf.InvalidProtocolBufferException;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
@@ -140,7 +139,7 @@ public class Netflow9ProtobufValidationTest {
 
     private List<Flow> getFlowsForPayloadsInSession(List<byte[]> payloads) {
         final List<Flow> flows = new ArrayList<>();
-        final Session session = new TcpSession(InetAddress.getLoopbackAddress());
+        final Session session = new TcpSession(InetAddress.getLoopbackAddress(), () -> new SequenceNumberTracker(32));
 
         for (byte[] payload : payloads) {
             final ByteBuf buffer = Unpooled.wrappedBuffer(payload);

--- a/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/IpfixTcpParser.java
+++ b/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/IpfixTcpParser.java
@@ -63,7 +63,7 @@ public class IpfixTcpParser extends ParserBase implements TcpParser {
     @Override
     public Handler accept(final InetSocketAddress remoteAddress,
                           final InetSocketAddress localAddress) {
-        final TcpSession session = new TcpSession(remoteAddress.getAddress());
+        final TcpSession session = new TcpSession(remoteAddress.getAddress(), this::sequenceNumberTracker);
 
         return new Handler() {
             @Override

--- a/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/ParserBase.java
+++ b/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/ParserBase.java
@@ -55,10 +55,10 @@ import org.opennms.netmgt.model.events.EventBuilder;
 import org.opennms.netmgt.telemetry.api.receiver.Parser;
 import org.opennms.netmgt.telemetry.api.receiver.TelemetryMessage;
 import org.opennms.netmgt.telemetry.protocols.netflow.parser.ie.RecordProvider;
+import org.opennms.netmgt.telemetry.protocols.netflow.parser.session.SequenceNumberTracker;
 import org.opennms.netmgt.telemetry.protocols.netflow.parser.session.Session;
 import org.opennms.netmgt.telemetry.protocols.netflow.parser.transport.MessageBuilder;
 import org.opennms.netmgt.telemetry.protocols.netflow.transport.FlowMessage;
-import org.opennms.netmgt.telemetry.protocols.netflow.transport.FlowMessageOrBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -134,6 +134,8 @@ public abstract class ParserBase implements Parser {
     private long clockSkewEventRate = 0;
 
     private long illegalFlowEventRate = 0;
+
+    private int sequenceNumberPatience = 32;
 
     private boolean dnsLookupsEnabled = true;
 
@@ -257,6 +259,14 @@ public abstract class ParserBase implements Parser {
 
     public long getIllegalFlowEventRate() {
         return illegalFlowEventRate;
+    }
+
+    public int getSequenceNumberPatience() {
+        return this.sequenceNumberPatience;
+    }
+
+    public void setSequenceNumberPatience(final int sequenceNumberPatience) {
+        this.sequenceNumberPatience = sequenceNumberPatience;
     }
 
     public boolean getDnsLookupsEnabled() {
@@ -452,5 +462,9 @@ public abstract class ParserBase implements Parser {
         }
 
         return corrections;
+    }
+
+    protected SequenceNumberTracker sequenceNumberTracker() {
+        return new SequenceNumberTracker(this.sequenceNumberPatience);
     }
 }

--- a/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/UdpParserBase.java
+++ b/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/UdpParserBase.java
@@ -45,14 +45,11 @@ import org.opennms.netmgt.telemetry.protocols.netflow.parser.ie.RecordProvider;
 import org.opennms.netmgt.telemetry.protocols.netflow.parser.session.Session;
 import org.opennms.netmgt.telemetry.protocols.netflow.parser.session.UdpSessionManager;
 import org.opennms.netmgt.telemetry.protocols.netflow.parser.transport.MessageBuilder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.codahale.metrics.Counter;
 import com.codahale.metrics.Gauge;
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
-import com.swrve.ratelimitedlogger.RateLimitedLog;
 
 import io.netty.buffer.ByteBuf;
 
@@ -108,7 +105,7 @@ public abstract class UdpParserBase extends ParserBase implements UdpParser {
     @Override
     public void start(final ScheduledExecutorService executorService) {
         super.start(executorService);
-        this.sessionManager = new UdpSessionManager(this.templateTimeout);
+        this.sessionManager = new UdpSessionManager(this.templateTimeout, this::sequenceNumberTracker);
         this.housekeepingFuture = executorService.scheduleAtFixedRate(this.sessionManager::doHousekeeping,
                 HOUSEKEEPING_INTERVAL,
                 HOUSEKEEPING_INTERVAL,

--- a/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/session/SequenceNumberTracker.java
+++ b/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/session/SequenceNumberTracker.java
@@ -28,19 +28,115 @@
 
 package org.opennms.netmgt.telemetry.protocols.netflow.parser.session;
 
+import java.util.Arrays;
+
+/**
+ * Tracks sequence numbers and verify completeness.
+ *
+ * Sequence numbers passed in to the tracker using the {@link #verify(long)} method are checked for completeness. I.e.
+ * every sequence number has been passed in exactly once.
+ *
+ * While checking for completeness, the tracker allows for sequence numbers to be passed in out of order. Therefore it
+ * keeps track of a short history. The {@code patience} parameter specifies the length of this history controlling how
+ * much the expected sequence number can advance before the missing sequence number is reported as missing. If the
+ * missing sequence number is passed in before the the expected sequence number advances to much, the element is
+ * considered out-of-order but not missing and history is updated.
+ *
+ * To allow re-initialisation of sequence numbers, the tracker is lenient for huge sequence number jumps. If the passed
+ * in sequence number differs from the expected sequence number by more than what {@code patience} parameters allows,
+ * the tracker is reset and the element is considered valid.
+ */
 public class SequenceNumberTracker {
 
-    private long expected;
+    /**
+     * The highest seen sequence number.
+     */
+    private long current;
 
-    public SequenceNumberTracker() {
-        this.expected = 0L;
+    /**
+     * The history of seen sequence numbers relative to the current sequence number.
+     *
+     * The history is stored in a ring with the size of the expected {@code patience}. By doing so, marking a sequence
+     * number as gives the status of of the expected sequence number - patience.
+     */
+    private final Ring seen;
+
+    public SequenceNumberTracker(final int patience) {
+        if (patience < 0) {
+            throw new IllegalArgumentException("patience must be positive");
+        }
+
+        this.seen = new Ring(patience);
+
+        // Set to minimal value to trigger re-initialisation on first sequence number passed
+        this.current = -patience;
     }
 
-    public boolean verify(final long sequenceNumber) {
-        boolean valid = this.expected == 0 || this.expected == sequenceNumber;
+    public synchronized boolean verify(final long sequenceNumber) {
+        // Detect jumps and reinitialize
+        if (Math.abs(this.current - sequenceNumber) >= this.seen.size()) {
+            this.current = sequenceNumber;
 
-        this.expected = sequenceNumber + 1;
+            // Start over with a history where everything is marked as seen
+            this.seen.reset(true);
+            return true;
+        }
+
+        // Check if input is out of order
+        if (sequenceNumber < this.current) {
+            // Update the history marking the input as seen
+            this.seen.set(sequenceNumber, true);
+            return true;
+        }
+
+        boolean valid = true;
+
+        // Mark everything between current sequence number and input as missing
+        for (long x = this.current + 1; x < sequenceNumber; x++) {
+            valid &= this.seen.set(x, false);
+        }
+
+        // Add the sequence number to history and advance
+        valid &= this.seen.set(sequenceNumber, true);
+        this.current = sequenceNumber;
 
         return valid;
+    }
+
+    /**
+     * Number of elements that could be out of order.
+     */
+    public int getPatience() {
+        return this.seen.size();
+    }
+
+    /**
+     * A ring buffer where the elements are stored at {@code index % size}.
+     */
+    private static class Ring {
+        private final boolean[] values;
+
+        private Ring(final int size) {
+            this.values = new boolean[size];
+        }
+
+        public void reset(final boolean value) {
+            Arrays.fill(this.values, value);
+        }
+
+        public boolean set(final long index, final boolean value) {
+            // Calculate the index in the ring
+            // This cast is safe because long mod int is always int
+            final int wrapped = (int) (index % this.values.length);
+
+            final boolean prev = this.values[wrapped];
+            this.values[wrapped] = value;
+
+            return prev;
+        }
+
+        public int size() {
+            return this.values.length;
+        }
     }
 }

--- a/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/session/TcpSession.java
+++ b/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/session/TcpSession.java
@@ -168,7 +168,7 @@ public class TcpSession implements Session {
 
     @Override
     public boolean verifySequenceNumber(long observationDomainId, final long sequenceNumber) {
-        final SequenceNumberTracker tracker = this.sequenceNumbers.computeIfAbsent(observationDomainId, (k) -> new SequenceNumberTracker());
+        final SequenceNumberTracker tracker = this.sequenceNumbers.computeIfAbsent(observationDomainId, (k) -> new SequenceNumberTracker(32));
         return tracker.verify(sequenceNumber);
     }
 }

--- a/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/session/UdpSessionManager.java
+++ b/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/session/UdpSessionManager.java
@@ -149,7 +149,7 @@ public class UdpSessionManager {
         @Override
         public boolean verifySequenceNumber(final long observationDomainId, final long sequenceNumber) {
             final DomainKey key = new DomainKey(this.sessionKey, observationDomainId);
-            final SequenceNumberTracker tracker = UdpSessionManager.this.sequenceNumbers.computeIfAbsent(key, (k) -> new SequenceNumberTracker());
+            final SequenceNumberTracker tracker = UdpSessionManager.this.sequenceNumbers.computeIfAbsent(key, (k) -> new SequenceNumberTracker(32));
             return tracker.verify(sequenceNumber);
         }
     }

--- a/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/session/UdpSessionManager.java
+++ b/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/session/UdpSessionManager.java
@@ -41,6 +41,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import org.opennms.netmgt.telemetry.protocols.netflow.parser.MissingTemplateException;
@@ -149,7 +150,7 @@ public class UdpSessionManager {
         @Override
         public boolean verifySequenceNumber(final long observationDomainId, final long sequenceNumber) {
             final DomainKey key = new DomainKey(this.sessionKey, observationDomainId);
-            final SequenceNumberTracker tracker = UdpSessionManager.this.sequenceNumbers.computeIfAbsent(key, (k) -> new SequenceNumberTracker(32));
+            final SequenceNumberTracker tracker = UdpSessionManager.this.sequenceNumbers.computeIfAbsent(key, (k) -> UdpSessionManager.this.sequenceNumberTracker.get());
             return tracker.verify(sequenceNumber);
         }
     }
@@ -223,8 +224,11 @@ public class UdpSessionManager {
 
     private final Duration timeout;
 
-    public UdpSessionManager(final Duration timeout) {
+    private final Supplier<SequenceNumberTracker> sequenceNumberTracker;
+
+    public UdpSessionManager(final Duration timeout, final Supplier<SequenceNumberTracker> sequenceNumberTracker) {
         this.timeout = timeout;
+        this.sequenceNumberTracker = Objects.requireNonNull(sequenceNumberTracker);
     }
 
     public void doHousekeeping() {

--- a/features/telemetry/protocols/netflow/parser/src/test/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/NMS13006_Test.java
+++ b/features/telemetry/protocols/netflow/parser/src/test/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/NMS13006_Test.java
@@ -48,12 +48,11 @@ import org.opennms.netmgt.telemetry.protocols.netflow.parser.ie.Value;
 import org.opennms.netmgt.telemetry.protocols.netflow.parser.ie.values.UnsignedValue;
 import org.opennms.netmgt.telemetry.protocols.netflow.parser.netflow9.proto.Header;
 import org.opennms.netmgt.telemetry.protocols.netflow.parser.netflow9.proto.Packet;
+import org.opennms.netmgt.telemetry.protocols.netflow.parser.session.SequenceNumberTracker;
 import org.opennms.netmgt.telemetry.protocols.netflow.parser.session.Session;
 import org.opennms.netmgt.telemetry.protocols.netflow.parser.session.TcpSession;
 import org.opennms.netmgt.telemetry.protocols.netflow.parser.transport.Netflow9MessageBuilder;
 import org.opennms.netmgt.telemetry.protocols.netflow.transport.FlowMessage;
-
-import com.google.protobuf.InvalidProtocolBufferException;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
@@ -99,7 +98,7 @@ public class NMS13006_Test {
     }
 
     public void testFile(final String filename) throws Exception {
-        final Session session = new TcpSession(InetAddress.getLoopbackAddress());
+        final Session session = new TcpSession(InetAddress.getLoopbackAddress(), () -> new SequenceNumberTracker(32));
 
         try (final FileChannel channel = FileChannel.open(FOLDER.resolve(filename))) {
             final ByteBuffer buffer = ByteBuffer.allocate((int) channel.size());

--- a/features/telemetry/protocols/netflow/parser/src/test/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/ParserTest.java
+++ b/features/telemetry/protocols/netflow/parser/src/test/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/ParserTest.java
@@ -45,6 +45,7 @@ import java.util.function.Consumer;
 import org.junit.Test;
 import org.opennms.netmgt.telemetry.protocols.netflow.parser.ipfix.proto.Header;
 import org.opennms.netmgt.telemetry.protocols.netflow.parser.ipfix.proto.Packet;
+import org.opennms.netmgt.telemetry.protocols.netflow.parser.session.SequenceNumberTracker;
 import org.opennms.netmgt.telemetry.protocols.netflow.parser.session.TcpSession;
 import org.opennms.netmgt.telemetry.protocols.netflow.parser.session.Session;
 
@@ -60,7 +61,7 @@ public class ParserTest {
         execute("/flows/ipfix.dat", buffer -> {
             try {
 
-                final Session session = new TcpSession(InetAddress.getLoopbackAddress());
+                final Session session = new TcpSession(InetAddress.getLoopbackAddress(), () -> new SequenceNumberTracker(32));
 
                 final Header h1 = new Header(slice(buffer, Header.SIZE));
                 final Packet p1 = new Packet(session, h1, slice(buffer, h1.length - Header.SIZE));

--- a/features/telemetry/protocols/netflow/parser/src/test/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/SequenceNumberTrackerTest.java
+++ b/features/telemetry/protocols/netflow/parser/src/test/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/SequenceNumberTrackerTest.java
@@ -37,27 +37,83 @@ import org.opennms.netmgt.telemetry.protocols.netflow.parser.session.SequenceNum
 public class SequenceNumberTrackerTest {
 
     @Test
-    public void testInit() {
-        final SequenceNumberTracker tracker = new SequenceNumberTracker();
-        assertTrue(tracker.verify(5));
+    public void testInitZero() {
+        final SequenceNumberTracker tracker = new SequenceNumberTracker(32);
+        assertTrue(tracker.verify(0));
     }
 
     @Test
-    public void testExpected() {
-        final SequenceNumberTracker tracker = new SequenceNumberTracker();
-        assertTrue(tracker.verify(5));
-        assertTrue(tracker.verify(6));
-        assertTrue(tracker.verify(7));
+    public void testInitSmallerThanPatience() {
+        final SequenceNumberTracker tracker = new SequenceNumberTracker(32);
+        assertTrue(tracker.verify(16));
     }
 
     @Test
-    public void testUnexpected() {
-        final SequenceNumberTracker tracker = new SequenceNumberTracker();
-        assertTrue(tracker.verify(5));
-        assertFalse(tracker.verify(7));
-        assertTrue(tracker.verify(8));
-        assertFalse(tracker.verify(3));
-        assertTrue(tracker.verify(4));
+    public void testInitWithExactPatience() {
+        final SequenceNumberTracker tracker = new SequenceNumberTracker(32);
+        assertTrue(tracker.verify(32));
+    }
+
+    @Test
+    public void testInitLargerThanPatience() {
+        final SequenceNumberTracker tracker = new SequenceNumberTracker(32);
+        assertTrue(tracker.verify(128));
+    }
+
+    @Test
+    public void testInOrder() {
+        final SequenceNumberTracker tracker = new SequenceNumberTracker(32);
+        for (int x = 0; x <= tracker.getPatience() * 2; x++) {
+            assertTrue(tracker.verify(x));
+        }
+    }
+    
+    @Test
+    public void testOutOfOrder() {
+        final SequenceNumberTracker tracker = new SequenceNumberTracker(32);
+        for (int x = 0; x <= tracker.getPatience() * 2; x += 2) {
+            assertTrue("x=" + (x + 2), tracker.verify(x + 2));
+            assertTrue("x=" + (x + 1), tracker.verify(x + 1));
+        }
+    }
+
+    @Test
+    public void testDuplicates() {
+        final SequenceNumberTracker tracker = new SequenceNumberTracker(32);
+
+        // Fill in 100 elements
+        for (int x = 0; x <= 100; x++) {
+            assertTrue(tracker.verify(x));
+        }
+
+        // Double call with current sequence number
+        assertTrue(tracker.verify(100));
+
+        // Double call with sequence number in history
+        assertTrue(tracker.verify(90));
+    }
+
+    @Test
+    public void testLate() {
+        final SequenceNumberTracker tracker = new SequenceNumberTracker(32);
+
+        // Start with first elements
+        assertTrue(tracker.verify(95));
+        assertTrue(tracker.verify(96));
+        assertTrue(tracker.verify(97));
+        assertTrue(tracker.verify(98));
+        assertTrue(tracker.verify(99));
+
+        // Skip the 100 and insert more elements to barely adhere to the patience
+        for (int x = 1; x < tracker.getPatience(); x++) {
+            assertTrue(tracker.verify(100 + x));
+        }
+
+        // 100 has not been seen and considered late
+        assertFalse(tracker.verify(100 + tracker.getPatience()));
+
+        // Followings are there, again
+        assertTrue(tracker.verify(100 + tracker.getPatience() + 1));
     }
 
 }

--- a/features/telemetry/protocols/netflow/parser/src/test/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/SequenceNumberTrackerTest.java
+++ b/features/telemetry/protocols/netflow/parser/src/test/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/SequenceNumberTrackerTest.java
@@ -113,7 +113,71 @@ public class SequenceNumberTrackerTest {
         assertFalse(tracker.verify(100 + tracker.getPatience()));
 
         // Followings are there, again
-        assertTrue(tracker.verify(100 + tracker.getPatience() + 1));
+        for (int x = 1; x < tracker.getPatience(); x++) {
+            assertTrue(tracker.verify(100 + tracker.getPatience() + x));
+        }
     }
 
+    @Test
+    public void testReset() {
+        final SequenceNumberTracker tracker = new SequenceNumberTracker(32);
+
+        assertTrue(tracker.verify(8));
+        assertTrue(tracker.verify(9));
+        assertTrue(tracker.verify(10));
+
+        // Skipping 32 - 1 -> no reset
+        assertTrue(tracker.verify(42));
+        assertFalse(tracker.verify(43));
+        assertFalse(tracker.verify(44));
+
+        // Skipping 32 -> reset
+        assertTrue(tracker.verify(78));
+        assertTrue(tracker.verify(79));
+        assertTrue(tracker.verify(80));
+    }
+
+    @Test
+    public void testSizeTwo() {
+        final SequenceNumberTracker tracker = new SequenceNumberTracker(2);
+
+        assertTrue(tracker.verify(0));
+        assertTrue(tracker.verify(1));
+
+        // skipping 1 -> no reset
+        assertTrue(tracker.verify(3));
+        assertFalse(tracker.verify(4));
+        assertTrue(tracker.verify(5));
+
+        // skipping 2 -> reset
+        assertTrue(tracker.verify(8));
+        assertTrue(tracker.verify(9));
+        assertTrue(tracker.verify(10));
+    }
+
+    @Test
+    public void testSizeOne() {
+        final SequenceNumberTracker tracker = new SequenceNumberTracker(1);
+
+        assertTrue(tracker.verify(0));
+        assertTrue(tracker.verify(1));
+
+        assertTrue(tracker.verify(3));
+        assertTrue(tracker.verify(4));
+
+        assertTrue(tracker.verify(6));
+    }
+
+    @Test
+    public void testSizeZero() {
+        final SequenceNumberTracker tracker = new SequenceNumberTracker(0);
+
+        assertTrue(tracker.verify(0));
+        assertTrue(tracker.verify(1));
+
+        assertTrue(tracker.verify(3));
+        assertTrue(tracker.verify(4));
+
+        assertTrue(tracker.verify(6));
+    }
 }

--- a/features/telemetry/protocols/netflow/parser/src/test/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/UdpSessionManagerTest.java
+++ b/features/telemetry/protocols/netflow/parser/src/test/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/UdpSessionManagerTest.java
@@ -40,6 +40,7 @@ import org.opennms.netmgt.telemetry.protocols.netflow.parser.ie.Value;
 import org.opennms.netmgt.telemetry.protocols.netflow.parser.ie.values.StringValue;
 import org.opennms.netmgt.telemetry.protocols.netflow.parser.session.Field;
 import org.opennms.netmgt.telemetry.protocols.netflow.parser.session.Scope;
+import org.opennms.netmgt.telemetry.protocols.netflow.parser.session.SequenceNumberTracker;
 import org.opennms.netmgt.telemetry.protocols.netflow.parser.session.Session;
 import org.opennms.netmgt.telemetry.protocols.netflow.parser.session.Template;
 import org.opennms.netmgt.telemetry.protocols.netflow.parser.session.UdpSessionManager;
@@ -113,7 +114,7 @@ public class UdpSessionManagerTest {
     }
 
     private void testSessionKeys(final UdpSessionManager.SessionKey sessionKey1, final UdpSessionManager.SessionKey sessionKey2, final boolean shouldMatch) {
-        final UdpSessionManager udpSessionManager = new UdpSessionManager(Duration.ofMinutes(30));
+        final UdpSessionManager udpSessionManager = new UdpSessionManager(Duration.ofMinutes(30), () -> new SequenceNumberTracker(32));
         final Session session1 = udpSessionManager.getSession(sessionKey1);
 
         final List<Scope> scopes = new ArrayList<>();

--- a/features/telemetry/protocols/netflow/parser/src/test/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/ipfix/BlackboxTest.java
+++ b/features/telemetry/protocols/netflow/parser/src/test/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/ipfix/BlackboxTest.java
@@ -46,6 +46,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.opennms.netmgt.telemetry.protocols.netflow.parser.ipfix.proto.Header;
 import org.opennms.netmgt.telemetry.protocols.netflow.parser.ipfix.proto.Packet;
+import org.opennms.netmgt.telemetry.protocols.netflow.parser.session.SequenceNumberTracker;
 import org.opennms.netmgt.telemetry.protocols.netflow.parser.session.TcpSession;
 import org.opennms.netmgt.telemetry.protocols.netflow.parser.session.Session;
 
@@ -76,7 +77,7 @@ public class BlackboxTest {
 
     @Test
     public void testFiles() throws Exception {
-        final Session session = new TcpSession(InetAddress.getLoopbackAddress());
+        final Session session = new TcpSession(InetAddress.getLoopbackAddress(), () -> new SequenceNumberTracker(32));
 
         for (final String file : this.files) {
             try (final FileChannel channel = FileChannel.open(FOLDER.resolve(file))) {

--- a/features/telemetry/protocols/netflow/parser/src/test/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/netflow9/BlackboxTest.java
+++ b/features/telemetry/protocols/netflow/parser/src/test/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/netflow9/BlackboxTest.java
@@ -46,6 +46,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.opennms.netmgt.telemetry.protocols.netflow.parser.netflow9.proto.Header;
 import org.opennms.netmgt.telemetry.protocols.netflow.parser.netflow9.proto.Packet;
+import org.opennms.netmgt.telemetry.protocols.netflow.parser.session.SequenceNumberTracker;
 import org.opennms.netmgt.telemetry.protocols.netflow.parser.session.TcpSession;
 import org.opennms.netmgt.telemetry.protocols.netflow.parser.session.Session;
 
@@ -91,7 +92,7 @@ public class BlackboxTest {
 
     @Test
     public void testFiles() throws Exception {
-        final Session session = new TcpSession(InetAddress.getLoopbackAddress());
+        final Session session = new TcpSession(InetAddress.getLoopbackAddress(), () -> new SequenceNumberTracker(32));
 
         for (final String file : this.files) {
             try (final FileChannel channel = FileChannel.open(FOLDER.resolve(file))) {

--- a/opennms-doc/guide-admin/src/asciidoc/text/telemetryd/protocols/ipfix.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/telemetryd/protocols/ipfix.adoc
@@ -28,6 +28,7 @@ The IPFIX UDP Parser supports protocol detection.
 | `maxClockSkew`        | The maximum delta in seconds between exporter and Minion timestamps.       | no       | 0
 | `clockSkewEventRate`  | Used to rate-limit clock skew events in seconds.                           | no       | 3600
 | `dnsLookupsEnabled`      | Used to enable or disable DNS resolution for flows.                        | no       | true
+| `sequenceNumberPatience`| A value > 1 enables checking for seuqence number completeness. The value gives the size of the history buffer allowing flows to be processed out of order. | no       | 32
 |===
 
 

--- a/opennms-doc/guide-admin/src/asciidoc/text/telemetryd/protocols/netflow9.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/telemetryd/protocols/netflow9.adoc
@@ -28,6 +28,7 @@ The Netflow v9 UDP Parser supports protocol detection.
 | `maxClockSkew`       | The maximum delta in seconds between exporter and Minion timestamps.         | no       | 0
 | `clockSkewEventRate` | Used to rate-limit clock skew events in seconds.                             | no       | 3600
 | `dnsLookupsEnabled`     | Used to enable or disable DNS resolution for flows.                          | no       | true
+| `sequenceNumberPatience`| A value > 1 enables checking for seuqence number completeness. The value gives the size of the history buffer allowing flows to be processed out of order. | no       | 32
 |===
 
 [[telemetryd-netflow9-adapter]]


### PR DESCRIPTION
This allows flows to be recieved out of order, either because of network related packet reordering or parallel processing.
    
Flow sequence checks now are more patient. If a flow is missing, it is reported only after the flow sequence has advanced for a certain amount.

The patience of flow sequence tracking has a default of `32` which is sane for almost all use-cases. This makes the patience parameter per parser definition in telemetryd configuration allowing compensate for more paralelized receivers or crazy network.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-13106

### Remarks
For reviewers: The first commit improves the sequence tracking mechanism while the second makes the patience parameter configurable.

