### PR TITLE
NMS-13135: add service status to the info ReST service

### DIFF
--- a/core/daemon/src/main/java/org/opennms/netmgt/vmmgr/StatusGetter.java
+++ b/core/daemon/src/main/java/org/opennms/netmgt/vmmgr/StatusGetter.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2005-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2005-2021 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -31,6 +31,7 @@ package org.opennms.netmgt.vmmgr;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -41,6 +42,7 @@ import org.slf4j.LoggerFactory;
 public class StatusGetter {
 
     private static final Logger LOG = LoggerFactory.getLogger(StatusGetter.class);
+    public static final Pattern SERVICE_STATUS_PATTERN = Pattern.compile("Status: OpenNMS:Name=(\\S+) = (\\S+)");
 
     public static enum Status {
         UNKNOWN, RUNNING, PARTIALLY_RUNNING, NOT_RUNNING, CONNECTION_REFUSED
@@ -54,34 +56,42 @@ public class StatusGetter {
         m_controller = controller;
     }
 
-    /**
-     * <p>getStatus</p>
-     *
-     * @return a {@link org.opennms.netmgt.vmmgr.StatusGetter.Status} object.
-     */
     public Status getStatus() {
         return m_status;
     }
 
-    /**
-     * <p>queryStatus</p>
-     *
-     * @throws java.lang.Exception if any.
-     */
-    @SuppressWarnings("unchecked")
-	public void queryStatus() throws Exception {
+    public Map<String,String> retrieveStatus() throws IllegalStateException {
+        final LinkedHashMap<String, String> results = new LinkedHashMap<String, String>();
 
-        Pattern p = Pattern.compile("Status: OpenNMS:Name=(\\S+) = (\\S+)");
-
-        LinkedHashMap<String, String> results = new LinkedHashMap<String, String>();
-
-        List<String> statusResults = Collections.emptyList();
         try {
-            statusResults = (List<String>)m_controller.doInvokeOperation("status");
-        } catch (Throwable e) {
+            final List<String> statusResults = (List<String>)m_controller.doInvokeOperation("status");
+
+            /*
+             * Once we split a status entry, it will look like this:
+             * Status: OpenNMS:Name=Eventd = RUNNING
+             */
+            for (final String result : statusResults) {
+                final Matcher m = SERVICE_STATUS_PATTERN.matcher(result);
+                if (!m.matches()) {
+                    throw new IllegalStateException("Result \"" + result + "\" does not match our regular expression");
+                }
+                results.put(m.group(1), m.group(2).toLowerCase());
+            }
+        } catch (final Throwable e) {
+            throw new IllegalStateException("Unable to retrieve status from running services.", e);
+        }
+
+        return results;
+    }
+
+	public void queryStatus() throws Exception {
+        Map<String, String> results = Collections.emptyMap();
+
+        try {
+            results = this.retrieveStatus();
+        } catch (final IllegalStateException e) {
             LOG.debug("Could not fetch status: " + e.getMessage());
             if (m_controller.isVerbose()) {
-                // TODO Should this be System.err instead?
                 System.out.println("Could not connect to the OpenNMS JVM"
                         + " (OpenNMS might not be running or "
                         + "could be starting up or shutting down): "
@@ -92,29 +102,15 @@ public class StatusGetter {
         }
 
         /*
-         * Once we split a status entry, it will look like this:
-         * Status: OpenNMS:Name=Eventd = RUNNING
-         */
-        for (String result : statusResults) {
-
-            Matcher m = p.matcher(result);
-            if (!m.matches()) {
-                throw new Exception("Result \"" + result
-                        + "\" does not match our regular expression");
-            }
-            results.put(m.group(1), m.group(2));
-        }
-
-        /*
          * We want our output to look like this:
          *     OpenNMS.Eventd         : running
          */
         String spaces = "                    ";
         int running = 0;
         int services = 0;
-        for (Entry<String, String> entry : results.entrySet()) {
+        for (final Entry<String, String> entry : results.entrySet()) {
             String daemon = entry.getKey();
-            String status = entry.getValue().toLowerCase();
+            String status = entry.getValue();
 
             services++;
             if (status.equals("running")) {

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/InfoDTO.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/InfoDTO.java
@@ -33,6 +33,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 import org.opennms.web.rest.v1.config.TicketerConfig;
 import org.opennms.web.rest.v1.config.DatetimeformatConfig;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -44,7 +45,7 @@ public class InfoDTO {
     private String packageDescription;
     private TicketerConfig ticketerConfig;
     private DatetimeformatConfig datetimeformatConfig;
-    private Map<String,String> services;
+    private Map<String,String> services = Collections.emptyMap();
 
     public DatetimeformatConfig getDatetimeformatConfig() {
         return datetimeformatConfig;

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/InfoDTO.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/InfoDTO.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2017-2017 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
+ * Copyright (C) 2017-2021 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -33,6 +33,8 @@ import javax.xml.bind.annotation.XmlRootElement;
 import org.opennms.web.rest.v1.config.TicketerConfig;
 import org.opennms.web.rest.v1.config.DatetimeformatConfig;
 
+import java.util.List;
+import java.util.Map;
 
 @XmlRootElement(name="info")
 public class InfoDTO {
@@ -42,6 +44,7 @@ public class InfoDTO {
     private String packageDescription;
     private TicketerConfig ticketerConfig;
     private DatetimeformatConfig datetimeformatConfig;
+    private Map<String,String> services;
 
     public DatetimeformatConfig getDatetimeformatConfig() {
         return datetimeformatConfig;
@@ -90,4 +93,8 @@ public class InfoDTO {
     public TicketerConfig getTicketerConfig() {
         return ticketerConfig;
     }
+
+    public void setServices(final Map<String,String> services) { this.services = services; }
+
+    public Map<String,String> getServices() { return this.services; }
 }

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/ServiceInfoDTO.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/ServiceInfoDTO.java
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2021 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.web.rest.v1;
+
+import javax.xml.bind.annotation.XmlRootElement;
+
+@XmlRootElement(name="service")
+public class ServiceInfoDTO {
+    public String name;
+    public String status;
+
+    public ServiceInfoDTO(final String name, final String status) {
+        this.name = name;
+        this.status = status;
+    }
+
+    public String getName() {
+        return this.name;
+    }
+    public void setName(final String name) {
+        this.name = name;
+    }
+
+    public String getStatus() {
+        return this.status;
+    }
+    public void setStatus(final String status) {
+        this.status = status;
+    }
+}

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/InfoRestServiceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v1/InfoRestServiceIT.java
@@ -1,0 +1,115 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2011-2017 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.web.rest.v1;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.StringUtils;
+import org.json.JSONObject;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.opennms.core.test.MockLogAppender;
+import org.opennms.core.test.OpenNMSJUnit4ClassRunner;
+import org.opennms.core.test.db.annotations.JUnitTemporaryDatabase;
+import org.opennms.core.test.rest.AbstractSpringJerseyRestTestCase;
+import org.opennms.core.xml.JaxbUtils;
+import org.opennms.netmgt.model.*;
+import org.opennms.netmgt.vmmgr.Controller;
+import org.opennms.netmgt.vmmgr.StatusGetter;
+import org.opennms.test.JUnitConfigurationEnvironment;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.web.WebAppConfiguration;
+
+import javax.servlet.ServletContext;
+import javax.ws.rs.core.MediaType;
+import java.io.FileInputStream;
+import java.util.Arrays;
+
+import static org.junit.Assert.*;
+
+@RunWith(OpenNMSJUnit4ClassRunner.class)
+@WebAppConfiguration
+@ContextConfiguration(locations={
+        "classpath:/META-INF/opennms/applicationContext-soa.xml",
+        "classpath:/META-INF/opennms/applicationContext-commonConfigs.xml",
+        "classpath:/META-INF/opennms/applicationContext-minimal-conf.xml",
+        "classpath:/META-INF/opennms/applicationContext-dao.xml",
+        "classpath*:/META-INF/opennms/component-service.xml",
+        "classpath*:/META-INF/opennms/component-dao.xml",
+        "classpath:/META-INF/opennms/applicationContext-databasePopulator.xml",
+        "classpath:/META-INF/opennms/mockEventIpcManager.xml",
+        "file:src/main/webapp/WEB-INF/applicationContext-svclayer.xml",
+        "file:src/main/webapp/WEB-INF/applicationContext-cxf-common.xml",
+
+        // Use this to prevent us from overwriting users.xml and groups.xml
+        "classpath:/META-INF/opennms/applicationContext-mock-usergroup.xml",
+        "classpath:/applicationContext-rest-test.xml"
+})
+@JUnitConfigurationEnvironment
+@JUnitTemporaryDatabase
+public class InfoRestServiceIT extends AbstractSpringJerseyRestTestCase {
+    private static final Logger LOG = LoggerFactory.getLogger(InfoRestServiceIT.class);
+
+    private Controller m_controller;
+
+    @Autowired
+    private ServletContext m_servletContext;
+
+    @Override
+    protected void beforeServletStart() throws Exception {
+        super.beforeServletStart();
+        m_controller = Mockito.mock(Controller.class);
+        Mockito.when(m_controller.doInvokeOperation("status")).thenReturn(Arrays.asList("Status: OpenNMS:Name=Eventd = RUNNING"));
+        InfoRestService.setStatusGetter(new StatusGetter(m_controller));
+    }
+
+    @Override
+    protected void afterServletStart() throws Exception {
+        MockLogAppender.setupLogging(true, "DEBUG");
+    }
+
+    @Override
+    protected void beforeServletDestroy() throws Exception {
+        Mockito.verifyNoMoreInteractions(m_controller);
+        super.beforeServletDestroy();
+    }
+
+    @Test
+    public void testInfo() throws Exception {
+        // Testing GET Collection
+        String xml = sendRequest(GET, "/info", 200);
+        Mockito.verify(m_controller, Mockito.atLeastOnce()).doInvokeOperation("status");
+        assertTrue("info should contain services", xml.contains("\"Eventd\":\"running\""));
+    }
+}

--- a/opennms-webapp/src/main/webapp/admin/sysconfig.jsp
+++ b/opennms-webapp/src/main/webapp/admin/sysconfig.jsp
@@ -2,8 +2,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2008-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2008-2021 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -55,6 +55,30 @@
                 document.snmpConfigForm.action="admin/index.jsp";
                 document.snmpConfigForm.submit();
         }
+
+        var xhr = new XMLHttpRequest();
+        xhr.onreadystatechange = function readystatechange() {
+            try {
+                if (xhr.readyState === XMLHttpRequest.DONE && xhr.status === 200) {
+                    var config = JSON.parse(xhr.responseText);
+                    console.debug('got config:', config);
+                    var services = document.getElementById('services');
+                    var contents = [];
+                    for (var key of Object.keys(config.services).sort()) {
+                        if (config.services[key] == 'running') {
+                            contents.push(key);
+                        }
+                    }
+                    services.innerHTML = contents.join('<br>');
+                }
+            } catch (err) {
+                console.error('Failed to get service info: ' + err);
+                document.getElementById('services').innerHTML = 'Unknown';
+            }
+        };
+        xhr.open('GET', 'rest/info');
+        xhr.setRequestHeader('Accept', 'application/json');
+        xhr.send();
 </script>
 
 <%
@@ -125,6 +149,10 @@
         <tr>
           <th>Syslog port:</th>
           <td><%=syslogPort%></td>
+        </tr>
+        <tr>
+            <th>Running services:</th>
+            <td id="services"></td>
         </tr>
       </table>
     </div> <!-- panel -->


### PR DESCRIPTION
This PR makes it possible to see OpenNMS service status in the `/info` ReST service.

Sample output:

```json
{
  "displayVersion": "26.1.3-SNAPSHOT",
  "version": "26.1.3",
  "packageName": "opennms",
  "packageDescription": "OpenNMS",
  "ticketerConfig": {
    "plugin": null,
    "enabled": false
  },
  "datetimeformatConfig": {
    "zoneId": "America/New_York",
    "datetimeformat": "yyyy-MM-dd'T'HH:mm:ssxxx"
  },
  "services": {
    "Eventd": "running",
    "Alarmd": "running",
    "Bsmd": "running",
    "Ticketer": "running",
    "Trapd": "running",
    "Queued": "running",
    "Actiond": "running",
    "Notifd": "running",
    "Scriptd": "running",
    "Rtcd": "running",
    "Pollerd": "running",
    "PollerBackEnd": "running",
    "EnhancedLinkd": "running",
    "Collectd": "running",
    "Discovery": "running",
    "Vacuumd": "running",
    "EventTranslator": "running",
    "PassiveStatusd": "running",
    "Statsd": "running",
    "Provisiond": "running",
    "Reportd": "running",
    "Ackd": "running",
    "JettyServer": "running",
    "KarafStartupMonitor": "running",
    "Telemetryd": "running"
  }
}
```

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-13135

