### PR TITLE
NMS-13064: fix timezone editing for existing reports

### DIFF
--- a/core/web-assets/src/main/assets/js/apps/onms-reports/index.js
+++ b/core/web-assets/src/main/assets/js/apps/onms-reports/index.js
@@ -633,13 +633,17 @@ const handleGrafanaError = function(response, report, optionalCallbackIfNoContex
 
             $scope.refresh();
         }])
-        .controller('ScheduleEditController', ['$scope', 'userInfo', 'meta', 'setGlobalError', 'ReportScheduleResource', function($scope, userInfo, meta, setGlobalError, ReportScheduleResource) {
+        .controller('ScheduleEditController', ['$http', '$q', '$scope', '$timeout', 'userInfo', 'meta', 'setGlobalError', 'ReportScheduleResource', function($http, $q, $scope, $timeout, userInfo, meta, setGlobalError, ReportScheduleResource) {
             $scope.meta = meta;
             $scope.userInfo = userInfo;
-            $scope.report = new ReportDetails({id: $scope.meta.reportId, scope: $scope});
+            $scope.report = null;
             $scope.options = {};
             $scope.loading = false;
             $scope.reportForm = { $invalid : false };
+
+            const getReportDetails = (reportId) => {
+                return $http.get('rest/reports/scheduled/' + reportId).then((res) => res.data);
+            };
 
             $scope.onReportFormInvalidStateChange = function(invalidState) {
                 $scope.reportForm.$invalid = invalidState;
@@ -650,34 +654,44 @@ const handleGrafanaError = function(response, report, optionalCallbackIfNoContex
             };
 
             $scope.loadDetails = function() {
+                if ($scope.loading) {
+                    return;
+                }
                 $scope.loading = true;
-                $scope.selected = {
-                    endpoint: undefined,
-                    dashboard: undefined
-                };
 
-                $scope.options = {
-                    showReportFormatOptions: false,    // Options are not shown, as we are editing a schedule
-                    showDeliveryOptions: true,         // always show when editing
-                    showDeliveryOptionsToggle: false,  // Toggling is disabled
-                    showScheduleOptions: true,         // always show when editing
-                    showScheduleOptionsToggle: false, // Toggling is disabled
-                    deliverReport: true,        // when editing schedule and delivery is enabled
-                    scheduleReport: true,       // when editing schedule and delivery is enabled
-                    canEditTriggerName: false,  // When in edit mode, the trigger name should be unique
-                };
+                $scope.$evalAsync(() => {
+                    $scope.selected = {
+                        endpoint: undefined,
+                        dashboard: undefined
+                    };
 
-                ReportScheduleResource.get({id: $scope.meta.triggerName}, function(response) {
-                    $scope.loading = false;
-                    $scope.report = new ReportDetails(Object.assign(response, {scope: $scope}));
-                }, function(response) {
-                    $scope.loading = false;
-                    $scope.setGlobalError(response);
-                    $scope.$close();
+                    $scope.options = {
+                        hideEndpointsChooser: true,        // endpoint should not be changed when editing
+                        showReportFormatOptions: false,    // Options are not shown, as we are editing a schedule
+                        showDeliveryOptions: true,         // always show when editing
+                        showDeliveryOptionsToggle: false,  // Toggling is disabled
+                        showScheduleOptions: true,         // always show when editing
+                        showScheduleOptionsToggle: false, // Toggling is disabled
+                        deliverReport: true,        // when editing schedule and delivery is enabled
+                        scheduleReport: true,       // when editing schedule and delivery is enabled
+                        canEditTriggerName: false,  // When in edit mode, the trigger name should be unique
+                    };
+
+                    getReportDetails($scope.meta.triggerName).then((reportData) => {
+                        $scope.report = new ReportDetails(Object.assign(reportData, {scope: $scope}));
+                    }).catch((err) => {
+                        $scope.setGlobalError(err);
+                        $scope.$close();
+                    }).finally(() => {
+                        $scope.loading = false;
+                    });
                 });
             };
 
             $scope.update = function() {
+                if (!$scope.report) {
+                    return $q.reject('report not initialized');
+                }
                 $scope.report.resetErrors();
                 const data = {
                     id: $scope.report.id,
@@ -687,14 +701,15 @@ const handleGrafanaError = function(response, report, optionalCallbackIfNoContex
                     deliveryOptions: $scope.report.deliveryOptions,
                     cronExpression: $scope.report.scheduleOptions.getCronExpression(),
                 };
-                ReportScheduleResource.update(data, function() {
-                 $scope.$close();
-              }, function(response) {
-                    handleReportError(response, $scope.report, () => {
-                        $scope.setGlobalError(response);
-                        $scope.$close();
+                return ReportScheduleResource.update(data).$promise.catch((err) => {
+                    // eslint-disable-next-line no-console
+                    console.error(err);
+                    handleReportError(err, $scope.report, () => {
+                        $scope.setGlobalError(err);
                     });
-              });
+                }).finally(() => {
+                    $scope.$close();
+                });
             };
 
             $scope.loadDetails();

--- a/core/web-assets/src/main/assets/js/apps/onms-reports/modals/schedule-edit-modal.html
+++ b/core/web-assets/src/main/assets/js/apps/onms-reports/modals/schedule-edit-modal.html
@@ -2,7 +2,7 @@
     <h3>Edit Schedule</h3>
 </div>
 <div class="modal-body">
-    <onms-report-details ng-model="report" options="options" on-invalid-change="onReportFormInvalidStateChange(invalidState)" on-global-error="setGlobalError(response)"></onms-report-details>
+    <onms-report-details ng-if="report" ng-model="report" options="options" on-invalid-change="onReportFormInvalidStateChange(invalidState)" on-global-error="setGlobalError(response)"></onms-report-details>
 </div>
 <div class="modal-footer">
     <button class="btn btn-danger" id="action.cancel.{{meta.triggerName}}" ng-click="$close()"><i class="fa fa-times"></i> Cancel</button>

--- a/core/web-assets/src/main/assets/js/apps/onms-reports/report-details.html
+++ b/core/web-assets/src/main/assets/js/apps/onms-reports/report-details.html
@@ -23,7 +23,7 @@
         <h3 class="">Report Parameters</h3>
 
         <!-- Grafana Parameters -->
-        <div ng-show="report.isGrafanaReport()" class="form-group">
+        <div ng-show="report.isGrafanaReport() && !options.hideEndpointsChooser" class="form-group">
             <label>Grafana Endpoint</label>
             <a href="/opennms/admin/endpoint/index.jsp" title="Configure Grafana Endpoints"> <i class="fa fa-plug"></i></a>
             <a href title="Reload Grafana Endpoints" ng-click="loadEndpoints()"> <i class="fa fa-refresh"></i></a>


### PR DESCRIPTION
It turns out there were a couple of weird things going on with how this was initializing.  I've made some changes to mitigate them:

1. use a straight AJAX call rather than AngularJS `$resource` which can be problematic
2. when the upstream dashboard timezone is set to `undefined` (ie, "default") we were overwriting the already-configured zone with that undefined value
3. we weren't always updating the `parametersByName['timezone']` property -- this is probably fine, but belt & suspenders I made it happen always when updating the parameter list
4. when checking for malformed zones (like `utc` rather than `UTC`) we were accepting undefined values and overwriting it
5. bonus: when editing an existing report, we don't re-initialize the "endpoint" list; the grafana endpoint should never change on edit so I hid it from the UI

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-13064

