### PR TITLE
Update Debian build environment from Debian Stretch to Buster

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ executors:
       - image: opennms/build-env:11.0.9.11-3.6.3-b5958
   debian-build-executor:
     docker:
-      - image: opennms/build-env:debian-jdk11-b5956
+      - image: opennms/build-env:debian-jdk11-b6222
   docker-executor:
     docker:
       - image: docker:20.10.1-git


### PR DESCRIPTION
### All Contributors

* [ ] Have you read and followed our [Contribution Guidelines](https://github.com/OpenNMS/opennms/blob/develop/CONTRIBUTING.md)?
* [ ] Have you [made an issue in the OpenNMS issue tracker](https://issues.opennms.org)?<br>If so, you should:
  1. update the title of this PR to be of the format: `${JIRA-ISSUE-NUMBER}: subject of pull request`
  2. update the JIRA link at the bottom of this comment to refer to the real issue number
  3. prefix your commit messages with the issue number, if possible
* [ ] Have you made a comment in that issue which points back to this PR?
* [ ] Have you updated the JIRA link at the bottom of this comment to link to your issue?
* [ ] If this is a new or updated feature, is there documentation for the new behavior?
* [ ] If this is new code, are there unit and/or integration tests?
* [ ] If this PR targets a `foundation-*` branch, does it avoid changing files in `$OPENNMS_HOME/etc/`?

### Pull Request Process

Use build environment based on Debian Buster instead of Debian Stretch.

