### PR TITLE
NMS-13156: Enable newts cache priming if not disabled

### DIFF
--- a/features/newts/src/main/java/org/opennms/netmgt/newts/support/CachePrimer.java
+++ b/features/newts/src/main/java/org/opennms/netmgt/newts/support/CachePrimer.java
@@ -58,7 +58,7 @@ public class CachePrimer implements InitializingBean, Runnable {
 
     @Override
     public void afterPropertiesSet() {
-        if (!primingDisabled) {
+        if (primingDisabled) {
             LOG.debug("Cache priming disabled. Skipping cache priming.");
             return;
         }


### PR DESCRIPTION
The setting to disable the newts cache priming is now interpreted
correctly.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-13156

