### PR TITLE
NMS-13170: add related event view to alarm detail page

### DIFF
--- a/opennms-webapp/src/main/java/org/opennms/web/controller/alarm/AlarmDetailController.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/controller/alarm/AlarmDetailController.java
@@ -146,9 +146,7 @@ public class AlarmDetailController extends MultiActionController {
         mv.addObject("alarm", alarm);
         mv.addObject("alarmId", alarmIdString);
         mv.addObject("acknowledgments", acknowledgments);
-        if (Boolean.getBoolean("org.opennms.web.console.alarms.relatedEvents")) {
-            mv.addObject("related", this.getRelatedEvents(alarm, httpServletRequest));
-        }
+        mv.addObject("related", this.getRelatedEvents(alarm, httpServletRequest));
         return mv;
     }
 
@@ -274,8 +272,6 @@ public class AlarmDetailController extends MultiActionController {
 
     private List<Filter> getFilters(final OnmsAlarm alarm, final ServletContext context) {
         final List<Filter> filters = new ArrayList<>();
-
-        // final AlarmIDFilter alarmIDFilter = new AlarmIDFilter(alarm.getId());
 
         if (alarm.getNodeId() != null) {
             filters.add(new NodeFilter(alarm.getNodeId(), context));

--- a/opennms-webapp/src/main/java/org/opennms/web/controller/alarm/AlarmDetailController.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/controller/alarm/AlarmDetailController.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2012-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2012-2021 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -28,23 +28,35 @@
 
 package org.opennms.web.controller.alarm;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import javax.servlet.ServletContext;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.opennms.core.utils.InetAddressUtils;
+import org.opennms.core.utils.WebSecurityUtils;
 import org.opennms.netmgt.dao.api.AlarmRepository;
 import org.opennms.netmgt.model.OnmsAcknowledgment;
 import org.opennms.netmgt.model.OnmsAlarm;
 import org.opennms.web.alarm.AlarmIdNotFoundException;
+import org.opennms.web.event.Event;
+import org.opennms.web.event.SortStyle;
+import org.opennms.web.event.WebEventRepository;
+import org.opennms.web.event.filter.EventCriteria;
+import org.opennms.web.event.filter.IPAddrLikeFilter;
+import org.opennms.web.event.filter.IfIndexFilter;
+import org.opennms.web.event.filter.NodeFilter;
+import org.opennms.web.event.filter.ServiceFilter;
+import org.opennms.web.filter.Filter;
+import org.opennms.web.servlet.XssRequestWrapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.util.Assert;
 import org.springframework.web.servlet.ModelAndView;
-import org.opennms.web.servlet.XssRequestWrapper;
-
 import org.springframework.web.servlet.mvc.multiaction.MultiActionController;
 import org.springframework.web.servlet.view.RedirectView;
 
@@ -54,6 +66,10 @@ import org.springframework.web.servlet.view.RedirectView;
  * @author Ronny Trommer <ronny@opennms.org>
  */
 public class AlarmDetailController extends MultiActionController {
+    private static final int DEFAULT_SHORT_LIMIT = 20;
+    private static final int DEFAULT_MULTIPLE = 0;
+
+    private static final Logger logger = LoggerFactory.getLogger(AlarmDetailController.class);
 
     /**
      * OpenNMS alarm repository
@@ -61,19 +77,19 @@ public class AlarmDetailController extends MultiActionController {
     private AlarmRepository m_webAlarmRepository;
 
     /**
-     * Logging
+     * OpenNMS event repository
      */
-    private Logger logger = LoggerFactory.getLogger(AlarmDetailController.class);
+    private WebEventRepository m_webEventRepository;
 
-    /**
-     * <p>setWebAlarmRepository</p>
-     *
-     * @param webAlarmRepository a {@link org.opennms.netmgt.dao.api.AlarmRepository}
-     * object.
-     */
-    public void setAlarmRepository(AlarmRepository webAlarmRepository) {
-        m_webAlarmRepository = webAlarmRepository;
+    private Integer m_defaultShortLimit = DEFAULT_SHORT_LIMIT;
+
+    public void setAlarmRepository(AlarmRepository repository) {
+        m_webAlarmRepository = repository;
     }
+    public void setWebEventRepository(final WebEventRepository repository) {
+        m_webEventRepository = repository;
+    }
+    public void setDefaultShortLimit(final Integer limit) { m_defaultShortLimit = limit; }
 
     /**
      * <p>afterPropertiesSet</p>
@@ -82,6 +98,7 @@ public class AlarmDetailController extends MultiActionController {
      */
     public void afterPropertiesSet() throws Exception {
         Assert.notNull(m_webAlarmRepository, "webAlarmRepository must be set");
+        Assert.notNull(m_webEventRepository, "webEventRepository must be set");
     }
 
     /**
@@ -100,7 +117,7 @@ public class AlarmDetailController extends MultiActionController {
      */
     public ModelAndView detail(HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse) throws Exception {
 
-        OnmsAlarm m_alarm = null;
+        OnmsAlarm alarm = null;
         XssRequestWrapper safeRequest = new XssRequestWrapper(httpServletRequest);
         String alarmIdString = "";
         List<OnmsAcknowledgment> acknowledgments = Collections.emptyList();
@@ -112,23 +129,26 @@ public class AlarmDetailController extends MultiActionController {
             acknowledgments = m_webAlarmRepository.getAcknowledgments(alarmId);
 
             // Get alarm by ID
-            m_alarm = m_webAlarmRepository.getAlarm(alarmId);
-            logger.debug("Alarm retrieved: '{}'", m_alarm.toString());
+            alarm = m_webAlarmRepository.getAlarm(alarmId);
+            logger.debug("Alarm retrieved: '{}'", alarm.toString());
         } catch (NumberFormatException e) {
             logger.error("Could not parse alarm ID '{}' to integer.", safeRequest.getParameter("id"));
         } catch (Throwable e) {
             logger.error("Could not retrieve alarm from webAlarmRepository for ID='{}'", alarmIdString);
         }
 
-        if (m_alarm == null) {
+        if (alarm == null) {
             throw new AlarmIdNotFoundException("Could not find alarm with ID: " + alarmIdString, alarmIdString);
         }
 
         // return to view WEB-INF/jsp/alarm/detail.jsp
         ModelAndView mv = new ModelAndView("alarm/detail");
-        mv.addObject("alarm", m_alarm);
+        mv.addObject("alarm", alarm);
         mv.addObject("alarmId", alarmIdString);
         mv.addObject("acknowledgments", acknowledgments);
+        if (Boolean.getBoolean("org.opennms.web.console.alarms.relatedEvents")) {
+            mv.addObject("related", this.getRelatedEvents(alarm, httpServletRequest));
+        }
         return mv;
     }
 
@@ -199,5 +219,81 @@ public class AlarmDetailController extends MultiActionController {
             logger.error("Could not parse alarm ID '{}' to integer.", httpServletRequest.getParameter("alarmId"));
             throw new ServletException("Could not parse alarm ID " + httpServletRequest.getParameter("alarmId") + " to integer.");
         }
+    }
+
+    private List<RelatedEvent> getRelatedEvents(final OnmsAlarm alarm, final HttpServletRequest request) {
+        Assert.notNull(alarm);
+
+        final List<RelatedEvent> relatedEvents = new ArrayList<>();
+
+        final List<Filter> filters = getFilters(alarm, request.getServletContext());
+
+        SortStyle sortStyle = SortStyle.ID;
+        final String sortStyleString = request.getParameter("sortby");
+        if (sortStyleString != null) {
+            try {
+                sortStyle = SortStyle.getSortStyle(sortStyleString);
+            } catch (final IllegalArgumentException e) {
+                logger.error("Unable to determine SortStyle for '{}'", sortStyleString, e);
+            }
+        }
+
+        int limit = m_defaultShortLimit;
+        final String limitString = request.getParameter("limit");
+        if (limitString != null) {
+            try {
+                int newLimit = WebSecurityUtils.safeParseInt(limitString);
+                if (newLimit > 0) {
+                    limit = newLimit;
+                }
+            } catch (final NumberFormatException e) {
+                logger.error("Unable to parse query limit '{}'", limitString, e);
+            }
+        }
+
+        int multiple = DEFAULT_MULTIPLE;
+        final String multipleString = request.getParameter("multiple");
+        if (multipleString != null) {
+            try {
+                multiple = Math.max(0, WebSecurityUtils.safeParseInt(multipleString));
+            } catch (final NumberFormatException e) {
+                logger.error("Unable to parse query multiple '{}'", multipleString, e);
+            }
+        }
+
+        final EventCriteria queryCriteria = new EventCriteria(filters, sortStyle, null, limit, limit * multiple);
+        try {
+            for (final Event event : m_webEventRepository.getMatchingEvents(queryCriteria)) {
+                relatedEvents.add(new RelatedEvent(event.getId(), event.getAlarmId(), event.getCreateTime(), event.getSeverity()));
+            }
+        } catch (final Exception e) {
+            logger.error("Could not retrieve events for queryCriteria '{}'.", queryCriteria);
+        }
+        return relatedEvents;
+    }
+
+    private List<Filter> getFilters(final OnmsAlarm alarm, final ServletContext context) {
+        final List<Filter> filters = new ArrayList<>();
+
+        // final AlarmIDFilter alarmIDFilter = new AlarmIDFilter(alarm.getId());
+
+        if (alarm.getNodeId() != null) {
+            filters.add(new NodeFilter(alarm.getNodeId(), context));
+        }
+
+        if (alarm.getIpAddr() != null) {
+            filters.add(new IPAddrLikeFilter(InetAddressUtils.str(alarm.getIpAddr())));
+        }
+
+        if (alarm.getServiceType() != null) {
+            filters.add(new ServiceFilter(alarm.getServiceType().getId(), context));
+        }
+
+        if (alarm.getIfIndex() != null) {
+            filters.add(new IfIndexFilter(alarm.getIfIndex()));
+        }
+
+        return filters;
+
     }
 }

--- a/opennms-webapp/src/main/java/org/opennms/web/controller/alarm/RelatedEvent.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/controller/alarm/RelatedEvent.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2021 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.web.controller.alarm;
+
+import java.util.Date;
+
+import org.opennms.netmgt.model.OnmsSeverity;
+
+public class RelatedEvent {
+    final Integer eventId;
+    final Integer alarmId;
+    final Date creationTime;
+    final OnmsSeverity severity;
+
+    public RelatedEvent(final Integer eventId, final Integer alarmId, final Date creationTime, final OnmsSeverity severity) {
+        this.eventId = eventId;
+        this.alarmId = alarmId;
+        this.creationTime = creationTime;
+        this.severity = severity;
+    }
+
+    public Integer getEventId() {
+        return eventId;
+    }
+
+    public Integer getAlarmId() {
+        return alarmId;
+    }
+
+    public Date getCreationTime() {
+        return creationTime;
+    }
+
+    public OnmsSeverity getSeverity() {
+        return severity;
+    }
+}

--- a/opennms-webapp/src/main/webapp/WEB-INF/dispatcher-servlet.xml
+++ b/opennms-webapp/src/main/webapp/WEB-INF/dispatcher-servlet.xml
@@ -197,6 +197,8 @@
     <alias name="/alarm/detail.htm" alias="/alarm/detail.jsp"/>
     <bean name="/alarm/detail.htm" class="org.opennms.web.controller.alarm.AlarmDetailController">
         <property name="alarmRepository" ref="alarmRepository"/>
+        <property name="webEventRepository" ref="webEventRepository"/>
+        <property name="defaultShortLimit" value="20"/>
     </bean>
 
     <bean name="/alarm/saveStickyMemo.htm" class="org.opennms.web.controller.alarm.AlarmDetailController">

--- a/opennms-webapp/src/main/webapp/WEB-INF/jsp/alarm/detail.jsp
+++ b/opennms-webapp/src/main/webapp/WEB-INF/jsp/alarm/detail.jsp
@@ -2,8 +2,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2012-2016 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2016 The OpenNMS Group, Inc.
+ * Copyright (C) 2012-2021 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -69,6 +69,12 @@
 %>
 
 <%
+    final Comparator<OnmsAlarm> SORT_ALARMS_BY_ID = new Comparator<OnmsAlarm>() {
+        public int compare(final OnmsAlarm o1, final OnmsAlarm o2) {
+            return Integer.compare(o1.getId(), o2.getId());
+        }
+    };
+
     XssRequestWrapper req = new XssRequestWrapper(request);
     OnmsAlarm alarm = (OnmsAlarm) request.getAttribute("alarm");
     final String alarmId = (String)request.getAttribute("alarmId");
@@ -287,11 +293,7 @@
         </tr>
         </thead>
         <%
-            final TreeSet<OnmsAlarm> sortedSet = new TreeSet<OnmsAlarm>(new Comparator<OnmsAlarm>() {
-                public int compare(final OnmsAlarm o1, final OnmsAlarm o2) {
-                    return Integer.compare(o1.getId(), o2.getId());
-                }
-            });
+            final TreeSet<OnmsAlarm> sortedSet = new TreeSet<>(SORT_ALARMS_BY_ID);
 
             sortedSet.addAll(alarm.getRelatedSituations());
             pageContext.setAttribute("sortedSet", sortedSet);
@@ -348,11 +350,7 @@
         </tr>
         </thead>
         <%
-            final TreeSet<OnmsAlarm> sortedSet = new TreeSet<OnmsAlarm>(new Comparator<OnmsAlarm>() {
-                public int compare(final OnmsAlarm o1, final OnmsAlarm o2) {
-                    return Integer.compare(o1.getId(), o2.getId());
-                }
-            });
+            final TreeSet<OnmsAlarm> sortedSet = new TreeSet<>(SORT_ALARMS_BY_ID);
 
             sortedSet.addAll(alarm.getRelatedAlarms());
             pageContext.setAttribute("sortedSet", sortedSet);
@@ -400,6 +398,45 @@
     </table>
 </div>
 <% } %>
+
+<% if (Boolean.getBoolean("org.opennms.web.console.alarms.relatedEvents")) { %>
+<div class="card">
+    <div class="card-header">
+        <span>Related Events</span>
+    </div>
+    <%
+        final List<RelatedEvent> related = (List<RelatedEvent>)request.getAttribute("related");
+        if (related.size() > 0) {
+    %>
+    <table class="table table-sm severity">
+        <thead>
+            <tr>
+                <th class="divider" width="50em">Event</th>
+                <!-- <th class="divider" width="50em">Alarm ID</th> -->
+                <th width="200em">Creation Time</th>
+                <th class="divider" width="100em">Severity</th>
+                <th></th>
+            </tr>
+        </thead>
+        <tbody>
+            <% for (final RelatedEvent entry : related) { %>
+                <tr class="severity-<%=entry.getSeverity().getLabel().toLowerCase()%>">
+                    <td>
+                        <% if (entry.getEventId() != 0) { %>
+                            <a href="event/detail.jsp?id=<%= entry.getEventId() %>"><%= entry.getEventId() %></a>
+                        <% } %>
+                    </td>
+                    <!-- <td><%= entry.getAlarmId() %></td> -->
+                    <td><%= Util.formatDateToUIString(entry.getCreationTime()) %></td>
+                    <td><%= entry.getSeverity().getLabel() %></td>
+                    <td style="width: auto">&nbsp;</td>
+                </tr>
+            <% } %>
+        </tbody>
+    </table>
+    <% } %>
+</div>
+<% } /* org.opennms.web.console.alarms.relatedEvents */  %>
 
 <% if (acks != null && acks.size() > 0) {%>
 <div class="card severity">

--- a/opennms-webapp/src/main/webapp/WEB-INF/jsp/alarm/detail.jsp
+++ b/opennms-webapp/src/main/webapp/WEB-INF/jsp/alarm/detail.jsp
@@ -399,7 +399,6 @@
 </div>
 <% } %>
 
-<% if (Boolean.getBoolean("org.opennms.web.console.alarms.relatedEvents")) { %>
 <div class="card">
     <div class="card-header">
         <span>Related Events</span>
@@ -436,7 +435,6 @@
     </table>
     <% } %>
 </div>
-<% } /* org.opennms.web.console.alarms.relatedEvents */  %>
 
 <% if (acks != null && acks.size() > 0) {%>
 <div class="card severity">


### PR DESCRIPTION
Disabled by default.  Enable by setting
org.opennms.web.console.alarms.relatedEvents=true

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-13170
