### PR TITLE
NMS-13174: Use perl from environment

### DIFF
--- a/opennms-base-assembly/src/main/filtered/bin/daemon-stats.pl
+++ b/opennms-base-assembly/src/main/filtered/bin/daemon-stats.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl
 
 =head1 NAME
 

--- a/opennms-base-assembly/src/main/filtered/bin/encode-wmi-password.pl
+++ b/opennms-base-assembly/src/main/filtered/bin/encode-wmi-password.pl
@@ -1,5 +1,6 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl
 
+use warnings;
 use MIME::Base64;
 
 my $password;

--- a/opennms-base-assembly/src/main/filtered/bin/provision.pl
+++ b/opennms-base-assembly/src/main/filtered/bin/provision.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl
 
 =head1 NAME
 

--- a/opennms-base-assembly/src/main/filtered/bin/send-event.pl
+++ b/opennms-base-assembly/src/main/filtered/bin/send-event.pl
@@ -1,4 +1,4 @@
-#!${install.perl.bin}
+#!/usr/bin/env perl
 
 use strict;
 use Getopt::Long;

--- a/opennms-base-assembly/src/main/filtered/bin/send-trap.pl
+++ b/opennms-base-assembly/src/main/filtered/bin/send-trap.pl
@@ -1,4 +1,5 @@
-#!${install.perl.bin}
+#!/usr/bin/env perl
+
 #
 # a quick hack of a script to send traps
 # by Ben Reed (ben@opennms.org)
@@ -7,6 +8,7 @@
 
 $|++;
 
+use warnings;
 use lib '.';
 use Net::SNMP;
 use Getopt::Long 2.17; # Released with Perl 5.005

--- a/opennms-base-assembly/src/main/filtered/bin/xml.reader.pl
+++ b/opennms-base-assembly/src/main/filtered/bin/xml.reader.pl
@@ -1,4 +1,4 @@
-#!${install.perl.bin} -w
+#!/usr/bin/env perl
 use strict;
 
 my $BF_XML;

--- a/pom.xml
+++ b/pom.xml
@@ -1308,7 +1308,6 @@
     <install.database.driver>org.postgresql.Driver</install.database.driver>
     <install.database.bindir>/usr/bin</install.database.bindir>
     <install.rrdtool.bin>/usr/bin/rrdtool</install.rrdtool.bin>
-    <install.perl.bin>/usr/bin/perl</install.perl.bin>
 
     <runMailTests>true</runMailTests>
   

--- a/protocols/xml/src/main/contrib/3gpp-datacollection-generator.pl
+++ b/protocols/xml/src/main/contrib/3gpp-datacollection-generator.pl
@@ -1,4 +1,4 @@
-#!${install.perl.bin}
+#!/usr/bin/env perl
 
 use strict;
 use XML::Simple;

--- a/protocols/xml/src/main/contrib/3gpp-resourcetypes-generator.pl
+++ b/protocols/xml/src/main/contrib/3gpp-resourcetypes-generator.pl
@@ -1,4 +1,4 @@
-#!${install.perl.bin}
+#!/usr/bin/env perl
 
 use strict;
 use XML::Simple;

--- a/protocols/xml/src/main/contrib/3gpp-snmpgraphs-generator.pl
+++ b/protocols/xml/src/main/contrib/3gpp-snmpgraphs-generator.pl
@@ -1,4 +1,4 @@
-#!${install.perl.bin}
+#!/usr/bin/env perl
 
 use strict;
 use XML::Simple;


### PR DESCRIPTION
Do not use a hard-coded path to perl (either specified during build time
or by using a /usr/bin/perl) but query the environment for the perl
binary to use.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-13174

