### PR TITLE
NMS-13120: Make threshold state key unique for different threshold levels

### DIFF
--- a/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/AbstractThresholdEvaluatorState.java
+++ b/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/AbstractThresholdEvaluatorState.java
@@ -154,7 +154,11 @@ public abstract class AbstractThresholdEvaluatorState<T extends AbstractThreshol
         key = String.format("%d-%s-%s-%s-%s-%s", thresholdingSession.getKey().getNodeId(),
                 thresholdingSession.getKey().getLocation(), threshold.getDsType(),
                 threshold.getDatasourceExpression(), thresholdingSession.getKey().getResource(), threshold.getType());
-
+        // Multiple threshold levels for trigger/rearm may end up with the same key.
+        // Fair to assume that threshold definitions with different threshold levels will have different uei.
+        if(threshold.getTriggeredUEI().isPresent()) {
+            key = String.format("%s-%s", key, threshold.getTriggeredUEI().get());
+        }
         stateTTL = SystemProperties.getInteger("org.opennms.netmgt.threshd.state_ttl",
                 (int) TimeUnit.SECONDS.convert(24, TimeUnit.HOURS));
         initializeState();

--- a/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/AbstractThresholdEvaluatorState.java
+++ b/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/AbstractThresholdEvaluatorState.java
@@ -174,10 +174,10 @@ public abstract class AbstractThresholdEvaluatorState<T extends AbstractThreshol
         if (threshold.getRearmedUEI().isPresent()) {
             hasher.putString(threshold.getRearmedUEI().get(), StandardCharsets.UTF_8);
         }
-        hasher.putDouble(threshold.getValue());
-        hasher.putDouble(threshold.getRearm());
-        hasher.putInt(threshold.getTrigger());
-        return hasher.hashCode();
+        Optional.ofNullable(threshold.getValue()).ifPresent(hasher::putDouble);
+        Optional.ofNullable(threshold.getRearm()).ifPresent(hasher::putDouble);
+        Optional.ofNullable(threshold.getTrigger()).ifPresent(hasher::putInt);
+        return hasher.hash().asInt();
     }
 
     /**

--- a/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/AbstractThresholdEvaluatorState.java
+++ b/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/AbstractThresholdEvaluatorState.java
@@ -156,17 +156,17 @@ public abstract class AbstractThresholdEvaluatorState<T extends AbstractThreshol
 
         this.thresholdingSession = thresholdingSession;
         kvStore = getKvStoreForType(stateType, thresholdingSession.getBlobStore());
-        key = String.format("%d-%s-%s-%s-%s-%s-%d", thresholdingSession.getKey().getNodeId(),
+        key = String.format("%d-%s-%s-%s-%s-%s-%s", thresholdingSession.getKey().getNodeId(),
                 thresholdingSession.getKey().getLocation(), threshold.getDsType(),
                 threshold.getDatasourceExpression(), thresholdingSession.getKey().getResource(), threshold.getType(),
-                generateHashForThresholdState(threshold));
+                generateHashForThresholdValues(threshold));
 
         initializeState();
     }
 
     // Multiple threshold levels for trigger/rearm may end up with the same key.
     // Generate unique hashcode for threshold values.
-    private int generateHashForThresholdState(BaseThresholdDefConfigWrapper threshold) {
+    private String generateHashForThresholdValues(BaseThresholdDefConfigWrapper threshold) {
         Hasher hasher = Hashing.murmur3_128().newHasher();
         if (threshold.getTriggeredUEI().isPresent()) {
             hasher.putString(threshold.getTriggeredUEI().get(), StandardCharsets.UTF_8);
@@ -174,10 +174,16 @@ public abstract class AbstractThresholdEvaluatorState<T extends AbstractThreshol
         if (threshold.getRearmedUEI().isPresent()) {
             hasher.putString(threshold.getRearmedUEI().get(), StandardCharsets.UTF_8);
         }
-        Optional.ofNullable(threshold.getValue()).ifPresent(hasher::putDouble);
-        Optional.ofNullable(threshold.getRearm()).ifPresent(hasher::putDouble);
-        Optional.ofNullable(threshold.getTrigger()).ifPresent(hasher::putInt);
-        return hasher.hash().asInt();
+        if (threshold.getValue() != null) {
+            hasher.putDouble(threshold.getValue());
+        }
+        if (threshold.getRearm() != null) {
+            hasher.putDouble(threshold.getRearm());
+        }
+        if (threshold.getTrigger() != null) {
+            hasher.putInt(threshold.getTrigger());
+        }
+        return hasher.hash().toString();
     }
 
     /**

--- a/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/BaseThresholdDefConfigWrapper.java
+++ b/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/BaseThresholdDefConfigWrapper.java
@@ -124,7 +124,7 @@ public abstract class BaseThresholdDefConfigWrapper {
      *
      * @return a double.
      */
-    public double getRearm() {
+    public Double getRearm() {
         return m_baseDef.getRearm();
     }
     
@@ -133,7 +133,7 @@ public abstract class BaseThresholdDefConfigWrapper {
      *
      * @return a int.
      */
-    public int getTrigger() {
+    public Integer getTrigger() {
         return m_baseDef.getTrigger();
     }
     
@@ -151,7 +151,7 @@ public abstract class BaseThresholdDefConfigWrapper {
      *
      * @return a double.
      */
-    public double getValue() {
+    public Double getValue() {
         return m_baseDef.getValue();
     }
     

--- a/features/collection/thresholding/impl/src/test/resources/test-multiple-threshold-levels.xml
+++ b/features/collection/thresholding/impl/src/test/resources/test-multiple-threshold-levels.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<thresholding-config>
+
+  <group name="generic-snmp" rrdRepository = "${install.share.dir}/rrd/snmp/">
+    <threshold type="high" ds-name="myCounter"  ds-type="node" value="10" rearm="5" trigger="1" triggeredUEI="test1"/>
+    <threshold type="high" ds-name="myCounter"  ds-type="node" value="12" rearm="5" trigger="1" triggeredUEI="test2"/>
+  </group>
+
+</thresholding-config>


### PR DESCRIPTION
When there are multiple levels of thresholds for a given DS, the key that is persisted to maintain threshold state is not unique enough.
To solve this, generate stable hash for threshold values and add it to key.


### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-13120

