### PR TITLE
NMS-13197: Compile OpenNMS with JDK11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,15 +3,16 @@ version: 2.1
 executors:
   centos-build-executor:
     docker:
-      - image: opennms/build-env:1.8.0.272.b10-3.6.3-b5769
+      - image: opennms/build-env:11.0.9.11-3.6.3-b5958
   debian-build-executor:
     docker:
-      - image: opennms/build-env:debian-jdk8-b5875
+      - image: opennms/build-env:debian-jdk11-b6222
   docker-executor:
     docker:
       - image: docker:20.10.1-git
   integration-test-executor:
-    machine: true
+    machine:
+     image: ubuntu-2004:202010-01
   smoke-test-executor:
     machine:
       image: ubuntu-2004:202010-01
@@ -328,8 +329,18 @@ commands:
     steps:
       - update-maven-cache
       - run:
+          name: Monitor JVM processes
+          background: true
+          command: |
+            .circleci/scripts/jvmprocmon-start.sh
+      - run:
+          name: Monitor memory usage
+          background: true
+          command: |
+            free -m -c 500 -s 30
+      - run:
           name: Integration Tests
-          no_output_timeout: 1.0h
+          no_output_timeout: 15m
           command: |
             export CCI_CODE_COVERAGE=<< parameters.run-code-coverage >>
             export CCI_RERUN_FAILTEST=<< parameters.rerun-failtest-count >>
@@ -341,8 +352,8 @@ commands:
           when: always
           command: |
             mkdir -p ~/test-results/junit
-            find . -type f -regex ".*/target/surefire-reports-[0-9]+/.*xml" -exec cp {} ~/test-results/junit/ \;
-            find . -type f -regex ".*/target/failsafe-reports-[0-9]+/.*xml" -exec cp {} ~/test-results/junit/ \;
+            find . -type f -regex ".*/target/.*-reports-[0-9]+/.*xml" -exec cp {} ~/test-results/junit/ \;
+            find . -type f -regex ".*/target/.*-reports-[0-9]+/.*dump.*" -exec cp {} ~/test-results/junit/ \;
       - run:
           name: Gather tests
           when: always
@@ -363,12 +374,26 @@ commands:
                 root: ~/
                 paths:
                   - code-coverage
+      - run:
+          name: Gather system logs
+          when: always
+          command: |
+            mkdir -p ~/build-results/system-logs
+            (dmesg || :) > ~/build-results/system-logs/dmesg 2>&1
+            (ps auxf || :) > ~/build-results/system-logs/ps 2>&1
+            (free -m || :) > ~/build-results/system-logs/free 2>&1
+            (docker stats --no-stream || :) > ~/build-results/system-logs/docker_stats 2>&1
+            cp -R /tmp/jvmprocmon ~/build-results/system-logs/ || :
       - store_test_results:
           path: ~/test-results
       - store_artifacts:
           when: always
           path: ~/test-results
           destination: test-results
+      - store_artifacts:
+          when: always
+          path: ~/build-results
+          destination: build-results
       - store_artifacts:
           when: always
           path: ~/generated-tests
@@ -748,11 +773,12 @@ jobs:
     machine:
       image: ubuntu-2004:202010-01
       docker_layer_caching: true
+    resource_class: large
     environment:
       DOCKER_CLI_EXPERIMENTAL: enabled
     parameters:
       number-vcpu:
-        default: 2
+        default: 4
         type: integer
       vaadin-javamaxmem:
         default: 1g
@@ -775,6 +801,7 @@ jobs:
           command: |
             export MAVEN_OPTS="-Xmx4g -Xms4g"
             # general assembly
+            date
             ./compile.pl -DskipTests=true -Dbuild.skip.tarball=false \
               -DupdatePolicy=never \
               -Daether.connector.resumeDownloads=false \
@@ -787,6 +814,7 @@ jobs:
               -Dopennms.home=/opt/opennms \
               install --batch-mode
             # javadoc
+            date
             ./compile.pl -DskipTests=true -Dbuild.skip.tarball=false \
               -DupdatePolicy=never \
               -Daether.connector.resumeDownloads=false \
@@ -798,6 +826,7 @@ jobs:
               -Prun-expensive-tasks \
               -Dopennms.home=/opt/opennms \
               javadoc:aggregate --batch-mode
+            date
       - run:
           name: Collect Artifacts
           command: |

--- a/.circleci/scripts/itest.sh
+++ b/.circleci/scripts/itest.sh
@@ -5,7 +5,7 @@ find_tests()
     # Generate surefire & failsafe test list based on current
     # branch and the list of files changed
     # (The format of the output files contains the canonical class names i.e. org.opennms.core.soa.filter.FilterTest)
-    pyenv local 3.5.2
+    pyenv local 3.8.5
     python3 .circleci/scripts/find-tests/find-tests.py generate-test-lists \
       --changes-only="${CCI_CHANGES_ONLY:-true}" \
       --output-unit-test-classes=surefire_classnames \
@@ -36,6 +36,9 @@ if [ ! -s /tmp/this_node_projects ]; then
   exit 0
 fi
 
+echo "#### Set loopback to 127.0.0.1"
+sudo sed -i 's/127.0.1.1/127.0.0.1/g' /etc/hosts
+
 echo "#### Allowing non-root ICMP"
 sudo sysctl net.ipv4.ping_group_range='0 429496729'
 
@@ -44,19 +47,16 @@ cd ~/project
 ./.circleci/scripts/postgres.sh
 
 echo "#### Installing other dependencies"
-# limit the sources we need to update
-sudo rm -f /etc/apt/sources.list.d/*
-# limit more sources and add mirrors
-echo 'deb mirror://mirrors.ubuntu.com/mirrors.txt trusty main restricted universe multiverse
-deb http://archive.ubuntu.com/ubuntu/ trusty main restricted
-deb-src http://archive.ubuntu.com/ubuntu/ trusty main restricted' | sudo tee /etc/apt/sources.list
+sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9
+sudo add-apt-repository 'deb https://cloud.r-project.org/bin/linux/ubuntu focal-cran40/'
 
 # kill other apt-gets first to avoid problems locking /var/lib/apt/lists/lock - see https://discuss.circleci.com/t/could-not-get-lock-var-lib-apt-lists-lock/28337/6
-sudo killall -9 apt-get || true && \
-            sudo apt-get update && \
-            sudo apt-get -y install debconf-utils && \
+sudo killall -9 apt || true && \
+            sudo apt update && \
+            sudo apt -y install debconf-utils && \
             echo '* libraries/restart-without-asking boolean true' | sudo debconf-set-selections && \
-            sudo env DEBIAN_FRONTEND=noninteractive apt-get install -f R-base rrdtool || exit 1
+            sudo env DEBIAN_FRONTEND=noninteractive apt install -f r-base rrdtool
+export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
 
 echo "#### Building Assembly Dependencies"
 ./compile.pl install -P'!checkstyle' \

--- a/bin/functions.pl
+++ b/bin/functions.pl
@@ -31,7 +31,6 @@ use vars qw(
 	$TESTS
 	$SINGLE_TEST
 	$VERBOSE
-	$JDK9_OR_GT
 	@DEFAULT_GOALS
 	@ARGS
 );
@@ -43,7 +42,6 @@ $LOGLEVEL      = 'debug' unless (defined $LOGLEVEL);
 $PATHSEP       = $Config{'path_sep'};
 $SKIP_OPENJDK  = $ENV{'SKIP_OPENJDK'};
 $VERBOSE       = undef;
-$JDK9_OR_GT    = undef;
 @DEFAULT_GOALS = ( "install" );
 
 @JAVA_SEARCH_DIRS = qw(
@@ -214,20 +212,6 @@ if (defined $JAVA_HOME and $JAVA_HOME ne "") {
 	info("Using \$JAVA_HOME=$JAVA_HOME");
 	$ENV{'JAVA_HOME'} = $JAVA_HOME;
 	$ENV{'PATH'}      = File::Spec->catfile($JAVA_HOME, 'bin') . $PATHSEP . $ENV{'PATH'};
-
-        my ($shortversion) = get_version_from_java(File::Spec->catfile($JAVA_HOME, 'bin', 'java'));
-        if ($shortversion >= 9 && $shortversion < 11) {
-                $JDK9_OR_GT = 1;
-        };
-}
-
-if ($JDK9_OR_GT) {
-        # Expose the required modules, packages and types
-        $MAVEN_OPTS .= " --add-modules java.activation,java.xml.bind";
-        $MAVEN_OPTS .= " --add-exports java.xml/com.sun.org.apache.xml.internal.resolver=ALL-UNNAMED";
-        $MAVEN_OPTS .= " --add-exports java.xml/com.sun.org.apache.xml.internal.resolver.tools=ALL-UNNAMED";
-        $MAVEN_OPTS .= " --add-opens java.base/java.lang=ALL-UNNAMED";
-        $MAVEN_OPTS .= " --add-opens java.base/java.util.regex=ALL-UNNAMED";
 }
 
 if (not exists $ENV{'JAVA_VENDOR'}) {

--- a/checkstyle/pom.xml
+++ b/checkstyle/pom.xml
@@ -31,7 +31,7 @@
                   <version>[3.5,)</version>
                 </requireMavenVersion>
                 <requireJavaVersion>
-                  <version>[1.8,9)</version>
+                  <version>[11,12)</version>
                 </requireJavaVersion>
               </rules>
             </configuration>

--- a/core/api/pom.xml
+++ b/core/api/pom.xml
@@ -44,6 +44,10 @@
       <artifactId>org.osgi.core</artifactId>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>jakarta.xml.bind</groupId>
+      <artifactId>jakarta.xml.bind-api</artifactId>
+    </dependency>
 
     <!-- Test -->
     <dependency>

--- a/core/cli/pom.xml
+++ b/core/cli/pom.xml
@@ -78,6 +78,7 @@
                 <phase>test</phase>
                 <goals><goal>exec</goal></goals>
                 <configuration>
+                  <skip>${skipTests}</skip>
                   <executable>${project.basedir}/src/test/shell/run-tests.sh</executable>
                 </configuration>
               </execution>

--- a/core/ipc/grpc/common/pom.xml
+++ b/core/ipc/grpc/common/pom.xml
@@ -52,5 +52,9 @@
       <artifactId>protobuf-java</artifactId>
       <version>${protobufVersion}</version>
     </dependency>
+    <dependency>
+      <groupId>javax.annotation</groupId>
+      <artifactId>jsr250-api</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/core/snmp/api/pom.xml
+++ b/core/snmp/api/pom.xml
@@ -43,6 +43,10 @@
       <version>${jsonVersion}</version>
     </dependency>
     <dependency>
+      <groupId>jakarta.xml.bind</groupId>
+      <artifactId>jakarta.xml.bind-api</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-library</artifactId>
       <scope>test</scope>

--- a/core/test-api/lib/src/main/java/org/opennms/core/test/ConfigurationTestUtils.java
+++ b/core/test-api/lib/src/main/java/org/opennms/core/test/ConfigurationTestUtils.java
@@ -154,6 +154,18 @@ public abstract class ConfigurationTestUtils extends Assert {
         assertNotNull("could not get resource '" + resource + "' as an input stream", is);
         return is;
     }
+
+    /**
+     * <p>getInputStreamForResource</p>
+     *
+     * @param resource a {@link java.lang.String} object.
+     * @return a {@link java.io.InputStream} object.
+     */
+    public static InputStream getInputStreamForResource(String resource) {
+        InputStream is = ConfigurationTestUtils.class.getResourceAsStream(resource);
+        assertNotNull("could not get resource '" + resource + "' as an input stream", is);
+        return is;
+    }
     
     /**
      * <p>getReaderForResourceWithReplacements</p>

--- a/debian/control
+++ b/debian/control
@@ -2,13 +2,13 @@ Source: opennms
 Section: contrib/net
 Priority: optional
 Maintainer: Jeff Gehlbach <jeffg@opennms.org>
-Build-Depends: oracle-java8-installer | adoptopenjdk-8-openj9xl | adoptopenjdk-8-openj9 | adoptopenjdk-8-hotspot | openjdk-8-jdk-headless | openjdk-8-jdk | java8-jdk, debhelper (>= 5.0.42), dh-systemd (>= 1.5), po-debconf (>= 1.0.5), rsync
+Build-Depends: oracle-java11-installer | adoptopenjdk-11-openj9xl | adoptopenjdk-11-openj9 | adoptopenjdk-11-hotspot | openjdk-11-jdk-headless | openjdk-11-jdk | java11-jdk, debhelper (>= 5.0.42), dh-systemd (>= 1.5), po-debconf (>= 1.0.5), rsync
 Standards-Version: 3.7.3
 
 Package: opennms
 Architecture: all
 Depends: opennms-db (=${binary:Version}), opennms-server (=${binary:Version}), opennms-webapp-jetty (=${binary:Version})
-Recommends: opennms-source (=${binary:Version}), openjdk-11-jdk-headless | openjdk-11-jdk | adoptopenjdk-11-openj9xl | adoptopenjdk-11-openj9 | adoptopenjdk-11-hotspot | oracle-java8-installer | adoptopenjdk-8-openj9xl | adoptopenjdk-8-openj9 | adoptopenjdk-8-hotspot | openjdk-8-jdk-headless | openjdk-8-jdk | java8-jdk
+Recommends: opennms-source (=${binary:Version}), openjdk-11-jdk-headless | openjdk-11-jdk | adoptopenjdk-11-openj9xl | adoptopenjdk-11-openj9 | adoptopenjdk-11-hotspot | java11-jdk
 Suggests: opennms-doc
 Description: Enterprise-grade Open-source Network Management Platform (Full Install)
  OpenNMS is an enterprise-grade network management system written in Java.
@@ -74,7 +74,7 @@ Description: Enterprise-grade Open-source Network Management Platform (Daemon)
 
 Package: opennms-jmx-config-generator
 Architecture: all
-Depends: adoptopenjdk-11-openj9xl-jre | adoptopenjdk-11-openj9-jre | adoptopenjdk-11-hotspot-jre | openjdk-11-jre-headless | openjdk-11-jre | oracle-java8-installer | adoptopenjdk-8-openj9xl-jre | adoptopenjdk-8-openj9-jre | adoptopenjdk-8-hotspot-jre | openjdk-8-jre-headless | openjdk-8-jre | java8-runtime-headless | java8-runtime
+Depends: adoptopenjdk-11-openj9xl-jre | adoptopenjdk-11-openj9-jre | adoptopenjdk-11-hotspot-jre | openjdk-11-jre-headless | openjdk-11-jre
 Description: Enterprise-grade Open-source Network Management Platform (JMX Config Generator)
  OpenNMS is an enterprise-grade network management system written in Java.
  .

--- a/dependencies/jaxb/pom.xml
+++ b/dependencies/jaxb/pom.xml
@@ -12,6 +12,15 @@
   <name>OpenNMS :: Dependencies :: JAXB</name>
   <dependencies>
     <dependency>
+      <groupId>jakarta.xml.bind</groupId>
+      <artifactId>jakarta.xml.bind-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jaxb</groupId>
+      <artifactId>jaxb-runtime</artifactId>
+      <version>2.3.2</version>
+    </dependency>
+    <dependency>
       <groupId>org.eclipse.persistence</groupId>
       <artifactId>org.eclipse.persistence.moxy</artifactId>
       <version>${eclipselinkVersion}</version>

--- a/features/alarms/history/elastic/pom.xml
+++ b/features/alarms/history/elastic/pom.xml
@@ -97,7 +97,7 @@
     </dependency>
     <dependency>
       <groupId>org.mapstruct</groupId>
-      <artifactId>mapstruct-jdk8</artifactId>
+      <artifactId>mapstruct</artifactId>
       <version>${mapstructVersion}</version>
     </dependency>
 

--- a/features/eif-adapter/src/test/java/org/opennms/features/eifadapter/EifTranslatorTest.java
+++ b/features/eif-adapter/src/test/java/org/opennms/features/eifadapter/EifTranslatorTest.java
@@ -33,12 +33,15 @@ import static org.junit.Assert.assertTrue;
 import static org.opennms.features.eifadapter.EifParser.parseEifSlots;
 import static org.opennms.features.eifadapter.EifParser.translateEifToOpenNMS;
 
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.util.List;
 import java.util.Map;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.opennms.core.test.MockLogAppender;
 import org.opennms.core.test.OpenNMSJUnit4ClassRunner;
 import org.opennms.netmgt.dao.mock.MockMonitoringLocationDao;
 import org.opennms.netmgt.dao.mock.MockNodeDao;
@@ -47,6 +50,7 @@ import org.opennms.netmgt.xml.event.Event;
 import org.opennms.test.JUnitConfigurationEnvironment;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
+import org.xbill.DNS.Address;
 
 @RunWith(OpenNMSJUnit4ClassRunner.class)
 @ContextConfiguration(locations = {
@@ -63,11 +67,14 @@ public class EifTranslatorTest {
     private MockNodeDao m_nodeDao;
 
     @Before
-    public void setUp() {
+    public void setUp() throws UnknownHostException {
+        // Enable DEBUG logging
+        MockLogAppender.setupLogging();
+
         OnmsNode fqhostnameNode = new OnmsNode(m_locationDao.getDefaultLocation(), "localhost.localdomain");
         OnmsNode shortnameNode = new OnmsNode(m_locationDao.getDefaultLocation(), "localhost");
         OnmsNode originNode = new OnmsNode(m_locationDao.getDefaultLocation(), "10.0.0.7");
-        OnmsNode localhostIpNode = new OnmsNode(m_locationDao.getDefaultLocation(),"127.0.0.1");
+        OnmsNode localhostIpNode = new OnmsNode(m_locationDao.getDefaultLocation(), Address.getHostName(InetAddress.getLocalHost()));
 
         fqhostnameNode.setForeignSource("eifTestSource");
         fqhostnameNode.setForeignId("eifTestId");

--- a/features/endpoints/grafana/client/pom.xml
+++ b/features/endpoints/grafana/client/pom.xml
@@ -24,9 +24,16 @@
             <Embed-Dependency>*;artifactId=okhttp|gson|okio</Embed-Dependency>
             <Embed-Transitive>true</Embed-Transitive>
             <Import-Package>
+              dalvik.system;resolution:=optional,
+              android.net;resolution:=optional,
+              android.net.http;resolution:=optional,
               android.os;resolution:=optional,
+              android.security;resolution:=optional,
               android.util;resolution:=optional,
+              org.apache.harmony.xnet.provider.jsse;resolution:=optional,
               org.conscrypt;resolution:=optional,
+              com.android.org.conscrypt;resolution:=optional,
+              sun.security.ssl;resolution:=optional,
               *
             </Import-Package>
           </instructions>

--- a/features/events/syslog/src/test/java/org/opennms/netmgt/syslogd/SyslogdEventdLoadIT.java
+++ b/features/events/syslog/src/test/java/org/opennms/netmgt/syslogd/SyslogdEventdLoadIT.java
@@ -46,6 +46,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.commons.io.IOUtils;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.opennms.core.ipc.sink.mock.MockMessageDispatcherFactory;
@@ -277,6 +278,7 @@ public class SyslogdEventdLoadIT implements InitializingBean {
         assertEquals(1, m_eventCounter.getCount());
     }
 
+    @Ignore("can be used/disabled to perform adhoc load tests")
     @Test(timeout=120000)
     @Transactional
     public void testEventd() throws Exception {

--- a/features/flows/itests/pom.xml
+++ b/features/flows/itests/pom.xml
@@ -47,12 +47,13 @@
                     <workingDirectory>${project.build.directory}</workingDirectory>
                     <skipIfExist>true</skipIfExist>
                     <alias>localhost</alias>
-                    <keysize>1024</keysize>
-                    <keyalg>DSA</keyalg>
+                    <keysize>2048</keysize>
+                    <keyalg>RSA</keyalg>
                     <dname>CN=localhost, OU=Flows baby flows, O=The OpenNMS Group, C=US</dname>
                     <keystore>${project.build.directory}/test-keystore.jks</keystore>
-                    <storepass>password</storepass>
+                    <storepass>changeit</storepass>
                     <validity>2</validity>
+                    <ext>SubjectAlternativeName=dns:localhost</ext>
                 </configuration>
             </plugin>
         </plugins>
@@ -161,6 +162,7 @@
         <dependency>
             <groupId>org.opennms.core.test-api</groupId>
             <artifactId>org.opennms.core.test-api.kafka</artifactId>
+            <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -260,12 +262,6 @@
         <dependency>
             <groupId>org.opennms.features.flows</groupId>
             <artifactId>org.opennms.features.flows.kafka-persistence</artifactId>
-            <version>${project.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.opennms.core.test-api</groupId>
-            <artifactId>org.opennms.core.test-api.kafka</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>

--- a/features/geocoder/google/pom.xml
+++ b/features/geocoder/google/pom.xml
@@ -34,11 +34,16 @@
             <Embed-Dependency>*;artifactId=google-maps-services|gson|okhttp|okio</Embed-Dependency>
             <Embed-Transitive>true</Embed-Transitive>
             <Import-Package>
+              dalvik.system;resolution:=optional,
+              android.net.http;resolution:=optional,
               android.os;resolution:=optional,
+              android.security;resolution:=optional,
               android.util;resolution:=optional,
               org.conscrypt;resolution:=optional,
+              com.android.org.conscrypt;resolution:=optional,
               com.google.appengine.api.urlfetch;resolution:=optional,
               javax.annotation.meta;resolution:=optional,
+              sun.security.ssl;resolution:=optional,
               *
             </Import-Package>
           </instructions>

--- a/features/ifttt/pom.xml
+++ b/features/ifttt/pom.xml
@@ -104,18 +104,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-module-junit4</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito2</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
+            <artifactId>mockito-inline</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/features/ifttt/src/test/java/org/opennms/features/ifttt/IfTttDaemonTest.java
+++ b/features/ifttt/src/test/java/org/opennms/features/ifttt/IfTttDaemonTest.java
@@ -30,9 +30,9 @@ package org.opennms.features.ifttt;
 
 import static com.jayway.awaitility.Awaitility.await;
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.powermock.api.mockito.PowerMockito.mock;
-import static org.powermock.api.mockito.PowerMockito.when;
-import static org.mockito.ArgumentMatchers.anyObject;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -47,8 +47,6 @@ import java.util.stream.Collectors;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.opennms.core.criteria.Criteria;
 import org.opennms.core.test.MockLogAppender;
@@ -62,13 +60,11 @@ import org.opennms.netmgt.model.OnmsCategory;
 import org.opennms.netmgt.model.OnmsEvent;
 import org.opennms.netmgt.model.OnmsNode;
 import org.opennms.netmgt.model.OnmsSeverity;
-import org.powermock.modules.junit4.PowerMockRunner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.transaction.support.TransactionCallbackWithoutResult;
 import org.springframework.transaction.support.TransactionOperations;
 
-@RunWith(PowerMockRunner.class)
 public class IfTttDaemonTest {
     private static final Logger LOG = LoggerFactory.getLogger(IfTttDaemonTest.class);
 
@@ -227,10 +223,10 @@ public class IfTttDaemonTest {
 
     public Map<String, List<ResultEntry>> runIfTttDaemonTest(final int timeout, final int entryCount) throws Exception {
         final AlarmDao alarmDao = mock(AlarmDao.class);
-        when(alarmDao.findMatching((Criteria) anyObject())).thenReturn(alarmMap.values().stream().collect(Collectors.toList()));
+        when(alarmDao.findMatching((Criteria) any())).thenReturn(new ArrayList<>(alarmMap.values()));
 
         final TransactionOperations transactionOperations = mock(TransactionOperations.class);
-        when(transactionOperations.execute(anyObject())).thenAnswer((Answer<Void>) invocationOnMock -> {
+        when(transactionOperations.execute(any())).thenAnswer((Answer<Void>) invocationOnMock -> {
             TransactionCallbackWithoutResult transactionCallbackWithoutResult = invocationOnMock.getArgument(0);
             transactionCallbackWithoutResult.doInTransaction(null);
             return null;
@@ -255,7 +251,7 @@ public class IfTttDaemonTest {
 
         addAlarm(100, 4, EventConstants.NODE_LOST_SERVICE_EVENT_UEI, OnmsSeverity.MAJOR, false);
         addAlarm(101, 4, "uei.opennms.org/bsm/serviceProblem", OnmsSeverity.MAJOR, false);
-        when(alarmDao.findMatching((Criteria) anyObject())).thenReturn(alarmMap.values().stream().collect(Collectors.toList()));
+        when(alarmDao.findMatching((Criteria) any())).thenReturn(new ArrayList<>(alarmMap.values()));
 
         await().atMost(timeout, SECONDS).until(() -> allEntrySizesMatch(receivedEntries, entryCount - 1));
         LOG.debug("#2: {}", receivedEntries);

--- a/features/ifttt/src/test/java/org/opennms/features/ifttt/helper/IfTttTriggerTest.java
+++ b/features/ifttt/src/test/java/org/opennms/features/ifttt/helper/IfTttTriggerTest.java
@@ -27,10 +27,10 @@
  *******************************************************************************/
 package org.opennms.features.ifttt.helper;
 
-import static org.powermock.api.mockito.PowerMockito.mock;
-import static org.powermock.api.mockito.PowerMockito.mockStatic;
-import static org.powermock.api.mockito.PowerMockito.when;
-import static org.mockito.ArgumentMatchers.anyObject;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 
@@ -44,15 +44,10 @@ import org.apache.http.message.BasicStatusLine;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.opennms.core.test.MockLogAppender;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest(HttpClients.class)
 public class IfTttTriggerTest {
     private static final String TEST_KEY = "abc123def456";
     private static final String TEST_EVENT = "xyz";
@@ -71,7 +66,7 @@ public class IfTttTriggerTest {
 
         final CloseableHttpClient closeableHttpClient = mock(CloseableHttpClient.class);
 
-        when(closeableHttpClient.execute(anyObject())).thenAnswer(new Answer<Object>() {
+        when(closeableHttpClient.execute(any())).thenAnswer(new Answer<Object>() {
             @Override
             public Object answer(InvocationOnMock invocationOnMock) throws Throwable {
                 HttpPost httpPost = invocationOnMock.getArgument(0);

--- a/features/minion/dominion/grpc-client/pom.xml
+++ b/features/minion/dominion/grpc-client/pom.xml
@@ -56,6 +56,10 @@
             <artifactId>grpc-protobuf</artifactId>
             <version>${grpcVersion}</version>
         </dependency>
+        <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>jsr250-api</artifactId>
+        </dependency>
     </dependencies>
 
 </project>

--- a/features/newts-repository-converter/pom.xml
+++ b/features/newts-repository-converter/pom.xml
@@ -124,6 +124,12 @@
       <version>1.5.0</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.cassandraunit</groupId>
+      <artifactId>cassandra-unit</artifactId>
+      <version>${cassandraUnitVersion}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/features/newts/pom.xml
+++ b/features/newts/pom.xml
@@ -139,5 +139,11 @@
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.cassandraunit</groupId>
+      <artifactId>cassandra-unit</artifactId>
+      <version>${cassandraUnitVersion}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/features/newts/src/test/java/org/opennms/netmgt/measurements/impl/NewtsFetchStrategyTest.java
+++ b/features/newts/src/test/java/org/opennms/netmgt/measurements/impl/NewtsFetchStrategyTest.java
@@ -39,6 +39,7 @@ import java.util.Map.Entry;
 import java.util.Set;
 
 import org.easymock.Capture;
+import org.easymock.CaptureType;
 import org.easymock.EasyMock;
 import org.junit.After;
 import org.junit.Before;
@@ -76,7 +77,7 @@ public class NewtsFetchStrategyTest {
 
     private Map<ResourceId, OnmsResource> m_resources = Maps.newHashMap();
 
-    private Capture<ResultDescriptor> lastCapturedResultDescriptor = new Capture<>();
+    private Capture<ResultDescriptor> lastCapturedResultDescriptor = Capture.newInstance(CaptureType.LAST);
 
     @Before
     public void setUp() throws Exception {

--- a/features/openconfig/common/pom.xml
+++ b/features/openconfig/common/pom.xml
@@ -74,6 +74,10 @@
       <artifactId>grpc-stub</artifactId>
       <version>${grpcVersion}</version>
     </dependency>
+    <dependency>
+      <groupId>javax.annotation</groupId>
+      <artifactId>jsr250-api</artifactId>
+    </dependency>
   </dependencies>
 
 </project>

--- a/features/poller/monitors/core/src/test/java/org/opennms/netmgt/poller/monitors/TlsExperiment.java
+++ b/features/poller/monitors/core/src/test/java/org/opennms/netmgt/poller/monitors/TlsExperiment.java
@@ -93,15 +93,6 @@ public class TlsExperiment {
     static {
         System.out.println("vendor : " + System.getProperty("java.vendor"));
         System.out.println("version: " + System.getProperty("java.version"));
-
-        // checks if TLS support 1.3 must be enabled by setting system properties
-        String javaVersion = System.getProperty("java.version");
-        if (javaVersion != null && javaVersion.startsWith("1.8")) {
-            if (Enum.class.isAssignableFrom(sun.security.ssl.ProtocolVersion.class)) {
-                System.setProperty("jdk.tls.client.protocols", "TLSv1.1,TLSv1.2,TLSv1.3");
-                System.setProperty("https.protocols", "TLSv1.1,TLSv1.2,TLSv1.3");
-            }
-        }
     }
 
     // starts an echo server that waits for connections

--- a/features/reporting/model/pom.xml
+++ b/features/reporting/model/pom.xml
@@ -56,6 +56,10 @@
   </build>
   <dependencies>
     <dependency>
+      <groupId>jakarta.xml.bind</groupId>
+      <artifactId>jakarta.xml.bind-api</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.opennms.core.test-api</groupId>
       <artifactId>org.opennms.core.test-api.xml</artifactId>
     </dependency>

--- a/features/reporting/sdo/pom.xml
+++ b/features/reporting/sdo/pom.xml
@@ -33,6 +33,10 @@
       <groupId>commons-beanutils</groupId>
       <artifactId>commons-beanutils</artifactId>
     </dependency>
+    <dependency>
+      <groupId>jakarta.xml.bind</groupId>
+      <artifactId>jakarta.xml.bind-api</artifactId>
+    </dependency>
     <!-- logging -->
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/features/rest/common/pom.xml
+++ b/features/rest/common/pom.xml
@@ -31,6 +31,10 @@
             <artifactId>jackson-mapper-asl</artifactId>
         </dependency>
         <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/features/rest/mapper/pom.xml
+++ b/features/rest/mapper/pom.xml
@@ -79,7 +79,7 @@
     </dependency>
     <dependency>
       <groupId>org.mapstruct</groupId>
-      <artifactId>mapstruct-jdk8</artifactId>
+      <artifactId>mapstruct</artifactId>
       <version>${mapstructVersion}</version>
     </dependency>
 

--- a/features/system-report/src/test/java/org/opennms/systemreport/system/ThreadReportPluginIT.java
+++ b/features/system-report/src/test/java/org/opennms/systemreport/system/ThreadReportPluginIT.java
@@ -54,6 +54,6 @@ public class ThreadReportPluginIT extends ReportPluginITCase {
         final Map<String, org.springframework.core.io.Resource> entries = m_threadReportPlugin.getEntries();
         final org.springframework.core.io.Resource resource = entries.get("ThreadDump.txt");
         final String contents = IOUtils.toString(resource.getInputStream());
-        assertTrue(contents.contains("at sun.management.ThreadImpl.dumpAllThreads"));
+        assertTrue(contents.contains("/sun.management.ThreadImpl.dumpAllThreads"));
     }
 }

--- a/features/telemetry/daemon/src/main/java/org/opennms/netmgt/telemetry/daemon/Telemetryd.java
+++ b/features/telemetry/daemon/src/main/java/org/opennms/netmgt/telemetry/daemon/Telemetryd.java
@@ -138,6 +138,9 @@ public class Telemetryd implements SpringServiceDaemon {
                 continue;
             }
             final Listener listener = telemetryRegistry.getListener(listenerConfig);
+            if (listener == null) {
+                throw new IllegalStateException("Failed to create listener from registry for listener named: " + listenerConfig.getName());
+            }
             listeners.add(listener);
         }
 

--- a/integrations/opennms-jasper-extensions/pom.xml
+++ b/integrations/opennms-jasper-extensions/pom.xml
@@ -49,12 +49,12 @@
           <workingDirectory>${project.build.directory}</workingDirectory>
           <skipIfExist>true</skipIfExist>
           <alias>localhost</alias>
-          <keysize>1024</keysize>
-          <keyalg>DSA</keyalg>
+          <keysize>2048</keysize>
+          <keyalg>RSA</keyalg>
           <dname>CN=localhost, OU=Measurement API Wire Mock, O=The OpenNMS Group, C=US</dname>
           <keystore>${project.build.directory}/test-keystore.jks</keystore>
-          <storepass>password</storepass>
-          <validity>2</validity>
+          <storepass>changeit</storepass>
+          <storetype>jks</storetype>
         </configuration>
       </plugin>
     </plugins>

--- a/integrations/opennms-jasper-extensions/src/test/java/org/opennms/netmgt/jasper/measurement/MeasurementQueryExecutorLocalIT.java
+++ b/integrations/opennms-jasper-extensions/src/test/java/org/opennms/netmgt/jasper/measurement/MeasurementQueryExecutorLocalIT.java
@@ -34,7 +34,6 @@ import java.util.Map;
 
 import javax.inject.Inject;
 
-import net.sf.jasperreports.engine.JRException;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -45,6 +44,8 @@ import org.opennms.core.test.OpenNMSJUnit4ClassRunner;
 import org.opennms.netmgt.jasper.helper.MeasurementsHelper;
 import org.springframework.context.ApplicationContext;
 import org.springframework.test.context.ContextConfiguration;
+
+import net.sf.jasperreports.engine.JRException;
 
 /**
  * Verifies that the {@link MeasurementQueryExecutor} works correctly when running locally in JVM mode.

--- a/integrations/opennms-jasper-extensions/src/test/java/org/opennms/netmgt/jasper/measurement/MeasurementQueryExecutorRemoteIT.java
+++ b/integrations/opennms-jasper-extensions/src/test/java/org/opennms/netmgt/jasper/measurement/MeasurementQueryExecutorRemoteIT.java
@@ -33,12 +33,6 @@ import java.io.IOException;
 import java.util.Date;
 import java.util.Map;
 
-import com.github.tomakehurst.wiremock.client.WireMock;
-import com.google.common.collect.Table;
-import com.google.common.collect.TreeBasedTable;
-
-import net.sf.jasperreports.engine.JRException;
-import net.sf.jasperreports.engine.JRParameter;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVRecord;
@@ -46,6 +40,13 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.opennms.netmgt.jasper.helper.MeasurementsHelper;
+
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.google.common.collect.Table;
+import com.google.common.collect.TreeBasedTable;
+
+import net.sf.jasperreports.engine.JRException;
+import net.sf.jasperreports.engine.JRParameter;
 
 /**
  * Verifies that the {@link MeasurementQueryExecutor} works correctly when running not in jvm mode.

--- a/opennms-assemblies/minion/src/main/filtered/debian/control
+++ b/opennms-assemblies/minion/src/main/filtered/debian/control
@@ -3,12 +3,12 @@ Maintainer: Benjamin Reed <ranger@opennms.org>
 Section: contrib/net
 Priority: optional
 Standards-Version: 3.9.2
-Build-Depends: debhelper (>= 9), dh-systemd, oracle-java8-installer | adoptopenjdk-8-openj9xl | adoptopenjdk-8-openj9 | adoptopenjdk-8-hotspot | openjdk-8-jdk-headless | openjdk-8-jdk | java8-jdk, rsync
+Build-Depends: debhelper (>= 9), dh-systemd, oracle-java11-installer | adoptopenjdk-11-openj9xl | adoptopenjdk-11-openj9 | adoptopenjdk-11-hotspot | openjdk-11-jdk-headless | openjdk-11-jdk | java11-jdk, rsync
 
 Package: opennms-minion
 Architecture: all
 Depends: adduser, openssh-client, uuid-runtime, sudo
-Recommends: openjdk-11-jre-headless | openjdk-11-jre | adoptopenjdk-11-openj9xl-jre | adoptopenjdk-11-openj9-jre | adoptopenjdk-11-hotspot-jre | oracle-java8-installer | adoptopenjdk-8-openj9xl-jre | adoptopenjdk-8-openj9-jre | adoptopenjdk-8-hotspot-jre | openjdk-8-jre-headless | openjdk-8-jre | java8-runtime-headless | java8-runtime, haveged, jicmp (>= 2.0.0), jicmp6 (>= 2.0.0)
+Recommends: openjdk-11-jre-headless | openjdk-11-jre | adoptopenjdk-11-openj9xl-jre | adoptopenjdk-11-openj9-jre | adoptopenjdk-11-hotspot-jre, haveged, jicmp (>= 2.0.0), jicmp6 (>= 2.0.0)
 Conflicts: opennms-minion-container (<< 25.0.0), opennms-minion-features-core (<<25.0.0), opennms-minion-features-default (<<25.0.0)
 Description: distributed OpenNMS monitoring client
  OpenNMS Minion is a container infrastructure for distributed, scalable network

--- a/opennms-assemblies/sentinel/src/main/filtered/debian/control
+++ b/opennms-assemblies/sentinel/src/main/filtered/debian/control
@@ -3,12 +3,12 @@ Maintainer: Benjamin Reed <ranger@opennms.org>
 Section: contrib/net
 Priority: optional
 Standards-Version: 3.9.2
-Build-Depends: debhelper (>= 9), dh-systemd, oracle-java8-installer | adoptopenjdk-8-openj9xl | adoptopenjdk-8-openj9 | adoptopenjdk-8-hotspot | openjdk-8-jdk-headless | openjdk-8-jdk | java8-jdk, rsync
+Build-Depends: debhelper (>= 9), dh-systemd, oracle-java11-installer | adoptopenjdk-11-openj9xl | adoptopenjdk-11-openj9 | adoptopenjdk-11-hotspot | openjdk-11-jdk-headless | openjdk-11-jdk | java11-jdk, rsync
 
 Package: opennms-sentinel
 Architecture: all
 Depends: adduser, openssh-client, uuid-runtime, sudo
-Recommends: openjdk-11-jre-headless | openjdk-11-jre | adoptopenjdk-11-openj9xl-jre | adoptopenjdk-11-openj9-jre | adoptopenjdk-11-hotspot-jre | oracle-java8-installer | adoptopenjdk-8-openj9xl-jre | adoptopenjdk-8-openj9-jre | adoptopenjdk-8-hotspot-jre | openjdk-8-jre-headless | openjdk-8-jre | java8-runtime-headless | java8-runtime, haveged, jicmp (>= 2.0.0), jicmp6 (>= 2.0.0)
+Recommends: openjdk-11-jre-headless | openjdk-11-jre | adoptopenjdk-11-openj9xl-jre | adoptopenjdk-11-openj9-jre | adoptopenjdk-11-hotspot-jre, haveged, jicmp (>= 2.0.0), jicmp6 (>= 2.0.0)
 Description: horizontal scaling for OpenNMS
  OpenNMS Sentinel is a container for running a subset of OpenNMS
  services in a standalone container, suitable for horizontally

--- a/opennms-base-assembly/pom.xml
+++ b/opennms-base-assembly/pom.xml
@@ -216,6 +216,7 @@
                   <arguments>
                     <argument>${project.basedir}/src/test/shell</argument>
                   </arguments>
+                  <skip>${skipTests}</skip>
                 </configuration>
               </execution>
             </executions>

--- a/opennms-bootstrap/src/main/java/org/opennms/bootstrap/Bootstrap.java
+++ b/opennms-bootstrap/src/main/java/org/opennms/bootstrap/Bootstrap.java
@@ -125,17 +125,6 @@ public abstract class Bootstrap {
 
     static {
 
-        // enable TLS 1.3 support for clients if running on Java 8 and TLS 1.3 support is available
-        // cf. https://docs.oracle.com/javase/8/docs/technotes/guides/security/jsse/JSSERefGuide.html#enabling-tls-1.3
-        String javaVersion = System.getProperty("java.version");
-        if (javaVersion != null && javaVersion.startsWith("1.8")) {
-            // the ProtocolVersion class changed into an enum when TLS 1.3 support was added
-            if (Enum.class.isAssignableFrom(sun.security.ssl.ProtocolVersion.class)) {
-                System.setProperty("jdk.tls.client.protocols", "TLSv1.1,TLSv1.2,TLSv1.3");
-                System.setProperty("https.protocols", "TLSv1.1,TLSv1.2,TLSv1.3");
-            }
-        }
-
         // Here we determine the canonical files for the excluded sub-folders under
         // $OPENNMS_HOME, and add them to the list of excludes
         try {

--- a/opennms-provision/opennms-detector-lineoriented/pom.xml
+++ b/opennms-provision/opennms-detector-lineoriented/pom.xml
@@ -49,9 +49,15 @@
     </dependency>
     <dependency>
       <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock</artifactId>
-      <version>1.57</version>
+      <artifactId>wiremock-jre8</artifactId>
+      <version>2.23.2</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>javax.xml.bind</groupId>
+          <artifactId>jaxb-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.opennms</groupId>

--- a/opennms-provision/opennms-detector-lineoriented/src/test/java/org/opennms/netmgt/provision/detector/HttpsDetectorTest.java
+++ b/opennms-provision/opennms-detector-lineoriented/src/test/java/org/opennms/netmgt/provision/detector/HttpsDetectorTest.java
@@ -35,10 +35,8 @@ import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMoc
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import java.io.IOException;
 import java.util.HashMap;
 
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -59,7 +57,6 @@ import com.github.tomakehurst.wiremock.junit.WireMockRule;
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations={"classpath:/META-INF/opennms/detectors.xml"})
 public class HttpsDetectorTest {
-    private static final int SSL_PORT = 7142;
 
     @Autowired
     private HttpsDetectorFactory m_detectorFactory;
@@ -67,7 +64,9 @@ public class HttpsDetectorTest {
     private HttpsDetector m_detector;
 
     @Rule
-    public WireMockRule m_wireMockRule = new WireMockRule(wireMockConfig().httpsPort(SSL_PORT));
+    public WireMockRule m_wireMockRule = new WireMockRule(wireMockConfig()
+            .dynamicPort()
+            .dynamicHttpsPort());
 
     private ResponseDefinitionBuilder getOKResponse() {
         return aResponse()
@@ -94,7 +93,7 @@ public class HttpsDetectorTest {
         m_detector = m_detectorFactory.createDetector(new HashMap<>());
 
         /* make sure defaults are initialized */
-        m_detector.setPort(SSL_PORT);
+        m_detector.setPort(m_wireMockRule.httpsPort());
         m_detector.setUseSSLFilter(true);
         m_detector.setUrl("/");
         m_detector.setCheckRetCode(false);
@@ -171,7 +170,7 @@ public class HttpsDetectorTest {
     public void testDetectorSucessCheckCodeTrue() throws Exception {
         m_detector.setCheckRetCode(true);
         m_detector.setUrl("http://localhost/");
-        m_detector.setPort(SSL_PORT);
+        m_detector.setPort(m_wireMockRule.httpsPort());
         m_detector.init();
         m_detector.setIdleTime(1000);
 

--- a/opennms-services/src/test/java/org/opennms/netmgt/collectd/CollectdIntegrationTest.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/collectd/CollectdIntegrationTest.java
@@ -51,6 +51,7 @@ import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
 import org.opennms.core.test.OpenNMSJUnit4ClassRunner;
 import org.opennms.core.utils.InsufficientInformationException;
+import org.opennms.netmgt.collection.api.CollectionSet;
 import org.opennms.netmgt.collection.support.DefaultServiceCollectorRegistry;
 import org.opennms.netmgt.collection.test.api.CollectorTestUtils;
 import org.opennms.netmgt.config.CollectdConfigFactory;
@@ -184,6 +185,9 @@ public class CollectdIntegrationTest {
         EasyMock.expect(mockThresholdingService.createSession(EasyMock.anyInt(), EasyMock.anyString(), EasyMock.anyString(), EasyMock.anyObject(),
                                                               EasyMock.anyObject())).andReturn(mockThresholdingSession);
         m_collectd.setThresholdingService(mockThresholdingService);
+
+        mockThresholdingSession.accept(anyObject(CollectionSet.class));
+        EasyMock.expectLastCall().anyTimes();
 
         OnmsServiceType snmp = new OnmsServiceType("SNMP");
         NetworkBuilder netBuilder = new NetworkBuilder();

--- a/opennms-services/src/test/resources/META-INF/opennms/applicationContext-collectdTest.xml
+++ b/opennms-services/src/test/resources/META-INF/opennms/applicationContext-collectdTest.xml
@@ -21,8 +21,6 @@
 
 	<!-- Override the collectd-configuration with one that includes the HttpCollector -->
 	<bean id="collectdConfigStream" class="org.opennms.core.test.ConfigurationTestUtils" factory-method="getInputStreamForResource">
-		<!-- Dummy string value that will fetch the current classloader -->
-		<constructor-arg value="SOME_JAVA_LANG_STRING"/>
 		<!-- Classpath resource that contains a minimal capsd configuration -->
 		<constructor-arg value="/org/opennms/netmgt/capsd/collectd-configuration.xml"/>
 	</bean>

--- a/opennms-web-api/src/test/java/org/opennms/web/api/UtilTest.java
+++ b/opennms-web-api/src/test/java/org/opennms/web/api/UtilTest.java
@@ -51,7 +51,7 @@ public class UtilTest {
     public void testFormatDateToUIStringOK() throws ParseException {
         final Date inputDate = new SimpleDateFormat("yyyy-MM-dd").parse("2014-10-30");
         final String formattedDate = Util.formatDateToUIString(inputDate);
-        Assert.assertEquals("10/30/14 12:00:00 AM", formattedDate);
+        Assert.assertEquals("10/30/14, 12:00:00 AM", formattedDate);
     }
 
     @Test

--- a/opennms-webapp/src/test/java/org/opennms/web/services/FilterFavoriteServiceIT.java
+++ b/opennms-webapp/src/test/java/org/opennms/web/services/FilterFavoriteServiceIT.java
@@ -58,7 +58,7 @@ import org.springframework.test.context.ContextConfiguration;
         "classpath:/META-INF/opennms/applicationContext-minimal-conf.xml"
 })
 @JUnitConfigurationEnvironment
-@JUnitTemporaryDatabase(dirtiesContext=false)
+@JUnitTemporaryDatabase(dirtiesContext=false,reuseDatabase=false)
 public class FilterFavoriteServiceIT {
 
 	@Autowired

--- a/pom.xml
+++ b/pom.xml
@@ -223,7 +223,7 @@
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
-        <version>3.0.1</version>
+        <version>5.1.1</version>
         <extensions>true</extensions>
         <configuration>
           <obrRepository>NONE</obrRepository>
@@ -871,7 +871,7 @@
                  <version>[3.5,)</version>
                </requireMavenVersion>
                <requireJavaVersion>
-                 <version>[1.8.0,9)</version>
+                 <version>[11,12)</version>
                </requireJavaVersion>
              </rules>
            </configuration>
@@ -981,8 +981,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>${maven.compiler.plugin.version}</version>
         <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
+          <source>11</source>
+          <target>11</target>
           <encoding>UTF-8</encoding>
           <optimize>true</optimize>
         </configuration>
@@ -1038,6 +1038,8 @@
           <reuseForks>false</reuseForks>
           <rerunFailingTestsCount>${ci.rerunFailingTestsCount}</rerunFailingTestsCount>
           <reportsDirectory>${project.build.directory}/surefire-reports-${ci.instance}</reportsDirectory>
+          <useModulePath>false</useModulePath>
+          <forkedProcessExitTimeoutInSeconds>120</forkedProcessExitTimeoutInSeconds>
         </configuration>
       </plugin>
       <plugin>
@@ -1049,9 +1051,9 @@
             <java.locale.providers>CLDR,COMPAT</java.locale.providers>
             <!-- The javax.net.ssl ones are used by integrations/opennms-jasper-extensions -->
             <javax.net.ssl.keyStore>target/test-keystore.jks</javax.net.ssl.keyStore>
-            <javax.net.ssl.keyStorePassword>password</javax.net.ssl.keyStorePassword>
+            <javax.net.ssl.keyStorePassword>changeit</javax.net.ssl.keyStorePassword>
             <javax.net.ssl.trustStore>target/test-keystore.jks</javax.net.ssl.trustStore>
-            <javax.net.ssl.trustStorePassword>password</javax.net.ssl.trustStorePassword>
+            <javax.net.ssl.trustStorePassword>changeit</javax.net.ssl.trustStorePassword>
             <!-- <ssl.debug>true</ssl.debug> -->
             <!-- <javax.net.debug>ssl,handshake,verbose</javax.net.debug> -->
           </systemPropertyVariables>
@@ -1068,6 +1070,7 @@
           <rerunFailingTestsCount>${ci.rerunFailingTestsCount}</rerunFailingTestsCount>
           <skipITs>${skipITs}</skipITs>
           <reportsDirectory>${project.build.directory}/failsafe-reports-${ci.instance}</reportsDirectory>
+          <useModulePath>false</useModulePath>
         </configuration>
         <executions>
           <execution>
@@ -1209,15 +1212,13 @@
       Surefire forked JVM arguments
       @see http://maven.apache.org/surefire/maven-surefire-plugin/examples/system-properties.html
 
-      Use 1GB of heap for running tests.
+      Use 1.5GB of heap for running tests.
 
       Set java.security.egd so that entropy exhaustion doesn't cause
       problematic pauses when starting MockSnmpAgent in unit tests.
-
-      Add target/endorsed as an endorsed API directory in case projects require it.
     -->
-    <argLineMemory>-Xmx1g</argLineMemory>
-    <argLine>${argLineMemory} -Djava.security.egd=/dev/./urandom -Djava.endorsed.dirs=${basedir}/target/endorsed</argLine>
+    <argLineMemory>-Xmx1536m</argLineMemory>
+    <argLine>${argLineMemory} -Djava.security.egd=/dev/./urandom</argLine>
     <skipITs>true</skipITs>
 
     <!--
@@ -1237,15 +1238,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
     <!-- maven surefire/failsafe version added here so it could be overridden -->
-    <!--
-      CAUTION: Do not upgrade to 2.18.1, 2.19, or 2.19.1 because the
-      org.opennms.core.test.karaf.KarafTestCase classes are experiencing
-      the following bug in those versions (even thought it is claimed to
-      have been fixed in 2.19.1):
-
-      https://issues.apache.org/jira/browse/SUREFIRE-1193
-    -->
-    <maven.testing.plugin.version>2.18</maven.testing.plugin.version>
+    <maven.testing.plugin.version>3.0.0-M5</maven.testing.plugin.version>
     <maven.failsafe.plugin.version>${maven.testing.plugin.version}</maven.failsafe.plugin.version>
     <maven.surefire.plugin.version>${maven.testing.plugin.version}</maven.surefire.plugin.version>
     <maven.surefire.report.plugin.version>${maven.testing.plugin.version}</maven.surefire.report.plugin.version>
@@ -1380,7 +1373,7 @@
     <concurrentTreesVersion>2.5.0</concurrentTreesVersion>
     <c3p0Version>0.9.5.4</c3p0Version>
     <curatorVersion>3.2.1</curatorVersion>
-    <cxfVersion>3.2.8</cxfVersion>
+    <cxfVersion>3.4.2</cxfVersion>
     <cxfXjcVersion>3.3.0</cxfXjcVersion>
     <dhcp4javaVersion>1.1.0</dhcp4javaVersion>
     <dnsjavaVersion>2.1.9_1</dnsjavaVersion>
@@ -1440,8 +1433,8 @@
     <lmaxDisruptorVersion>3.3.2</lmaxDisruptorVersion>
     <log4jVersion>99.99.99-use-log4j2</log4jVersion>
     <log4j2Version>2.13.2</log4j2Version>
-    <mapstructVersion>1.3.0.Final</mapstructVersion>
-    <minaVersion>2.0.16</minaVersion>
+    <mapstructVersion>1.4.1.Final</mapstructVersion>
+    <minaVersion>2.1.4</minaVersion>
     <mockitoVersion>3.4.6</mockitoVersion>
     <netty4Version>4.1.48.Final</netty4Version>
     <newtsVersion>1.5.5</newtsVersion>
@@ -1451,7 +1444,7 @@
     <protobufVersion>3.12.0</protobufVersion>
     <protobuf2Version>2.6.1</protobuf2Version>
     <postgresqlVersion>42.2.18</postgresqlVersion>
-    <powermockVersion>2.0.7</powermockVersion>
+    <powermockVersion>2.0.9</powermockVersion>
     <okhttpVersion>3.10.0</okhttpVersion>
     <okioVersion>1.14.0</okioVersion>
     <opennmsApiVersion>0.5.1</opennmsApiVersion>
@@ -1862,13 +1855,6 @@
         <groupId>org.opennms.api.integration</groupId>
         <artifactId>opennms-provisioning</artifactId>
         <version>1.0.0</version>
-      </dependency>
-      <dependency>
-        <groupId>com.sun</groupId>
-        <artifactId>tools</artifactId>
-        <version>1.8</version>
-        <scope>system</scope>
-        <systemPath>${java.home}/../lib/tools.jar</systemPath>
       </dependency>
 
       <!--  opennms dependencies -->
@@ -3627,7 +3613,7 @@
       <dependency>
         <groupId>org.easymock</groupId>
         <artifactId>easymock</artifactId>
-        <version>3.4</version>
+        <version>4.2</version>
         <scope>test</scope>
       </dependency>
       <dependency>
@@ -3867,6 +3853,11 @@
         <version>1.1</version>
       </dependency>
       <dependency>
+        <groupId>jakarta.xml.bind</groupId>
+        <artifactId>jakarta.xml.bind-api</artifactId>
+        <version>2.3.3</version>
+      </dependency>
+      <dependency>
         <groupId>javax.xml.bind</groupId>
         <artifactId>jaxb-api</artifactId>
         <version>99.99.99-use-opennms-jaxb</version>
@@ -3990,6 +3981,12 @@
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
+        <version>${mockitoVersion}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-inline</artifactId>
         <version>${mockitoVersion}</version>
         <scope>test</scope>
       </dependency>

--- a/protocols/cifs/pom.xml
+++ b/protocols/cifs/pom.xml
@@ -74,6 +74,13 @@
             <artifactId>opennms-dao</artifactId>
             <scope>compile</scope>
         </dependency>
+        <!-- Use a later version of javassist to fix issues with PowerMock on JDK11 -->
+        <dependency>
+            <groupId>org.javassist</groupId>
+            <artifactId>javassist</artifactId>
+            <version>3.27.0-GA</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <repositories>

--- a/protocols/cifs/src/test/java/org/opennms/netmgt/poller/monitors/TimeoutTest.java
+++ b/protocols/cifs/src/test/java/org/opennms/netmgt/poller/monitors/TimeoutTest.java
@@ -73,7 +73,7 @@ public class TimeoutTest {
     public void testTimeouts() throws Exception {
         // first call took more time
         // jcifs-ng seems to take a lot longer but does vary based on the timeout provided
-        testTimout("169.254.123.123",500, 12000);
+        testTimout("169.254.123.123",500, 30000);
         // but after that the timeouts are correctly applied
         testTimout("169.254.123.124",1000, 8000);
         testTimout("169.254.123.125",2000, 9000);

--- a/smoke-test/pom.xml
+++ b/smoke-test/pom.xml
@@ -386,12 +386,24 @@
       <groupId>org.opennms.features.telemetry.protocols.bmp</groupId>
       <artifactId>org.opennms.features.telemetry.protocols.bmp.adapter</artifactId>
       <version>${project.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.codehaus.groovy</groupId>
+          <artifactId>groovy-all</artifactId>
+        </exclusion>
+      </exclusions>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.opennms.features.telemetry.protocols.netflow</groupId>
       <artifactId>org.opennms.features.telemetry.protocols.netflow.adapter</artifactId>
       <version>${project.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.codehaus.groovy</groupId>
+          <artifactId>groovy-all</artifactId>
+        </exclusion>
+      </exclusions>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -415,7 +427,7 @@
     <dependency>
       <groupId>io.rest-assured</groupId>
       <artifactId>rest-assured</artifactId>
-      <version>3.0.3</version>
+      <version>4.3.3</version>
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
@@ -536,12 +548,24 @@
       <groupId>org.opennms.features.telemetry.protocols.jti</groupId>
       <artifactId>org.opennms.features.telemetry.protocols.jti.adapter</artifactId>
       <version>${project.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.codehaus.groovy</groupId>
+          <artifactId>groovy-all</artifactId>
+        </exclusion>
+      </exclusions>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.opennms.features.telemetry.protocols.graphite</groupId>
       <artifactId>org.opennms.features.telemetry.protocols.graphite.adapter</artifactId>
       <version>${project.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.codehaus.groovy</groupId>
+          <artifactId>groovy-all</artifactId>
+        </exclusion>
+      </exclusions>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/smoke-test/src/main/java/org/opennms/smoketest/containers/OpenNMSContainer.java
+++ b/smoke-test/src/main/java/org/opennms/smoketest/containers/OpenNMSContainer.java
@@ -411,7 +411,7 @@ public class OpenNMSContainer extends GenericContainer implements KarafContainer
             // This helps ensure that all of the sockets that should be up and listening i.e. teletrymd flows
             // have been given a chance to bind
             LOG.info("Waiting for startup to complete.");
-            await().atMost(4, MINUTES).until(() -> TestContainerUtils.getFileFromContainerAsString(container, managerLog),
+            await().atMost(5, MINUTES).until(() -> TestContainerUtils.getFileFromContainerAsString(container, managerLog),
                     containsString("Starter: Startup complete"));
             LOG.info("OpenNMS has started.");
 

--- a/smoke-test/src/test/java/org/opennms/smoketest/graph/GraphRestServiceIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/graph/GraphRestServiceIT.java
@@ -142,41 +142,41 @@ public class GraphRestServiceIT extends OpenNMSSeleniumIT {
         given().accept(ContentType.JSON).get()
                 .then().statusCode(200)
                 .contentType(ContentType.JSON)
-                .content("[0].id", Matchers.is("application"))
-                .content("[0].label", Matchers.is("Application Graph"))
-                .content("[0].graphs.size()", Matchers.is(1))
-                .content("[0].graphs[0].namespace", Matchers.is("application"))
-                .content("[0].graphs[0].label", Matchers.is("Application Graph"))
-                .content("[0].graphs[0].description", Matchers.is("Displays all defined applications and their calculated states."))
+                .body("[0].id", Matchers.is("application"))
+                .body("[0].label", Matchers.is("Application Graph"))
+                .body("[0].graphs.size()", Matchers.is(1))
+                .body("[0].graphs[0].namespace", Matchers.is("application"))
+                .body("[0].graphs[0].label", Matchers.is("Application Graph"))
+                .body("[0].graphs[0].description", Matchers.is("Displays all defined applications and their calculated states."))
 
-                .content("[1].id", Matchers.is("bsm"))
-                .content("[1].label", Matchers.is("Business Service Graph"))
-                .content("[1].graphs.size()", Matchers.is(1))
-                .content("[1].graphs[0].namespace", Matchers.is("bsm"))
-                .content("[1].graphs[0].label", Matchers.is("Business Service Graph"))
-                .content("[1].graphs[0].description", Matchers.is("Displays the hierarchy of the defined Business Services and their computed operational states."))
+                .body("[1].id", Matchers.is("bsm"))
+                .body("[1].label", Matchers.is("Business Service Graph"))
+                .body("[1].graphs.size()", Matchers.is(1))
+                .body("[1].graphs[0].namespace", Matchers.is("bsm"))
+                .body("[1].graphs[0].label", Matchers.is("Business Service Graph"))
+                .body("[1].graphs[0].description", Matchers.is("Displays the hierarchy of the defined Business Services and their computed operational states."))
 
-                .content("[2].id", Matchers.is("nodes"))
-                .content("[2].label", Matchers.is("Enhanced Linkd Topology Provider"))
-                .content("[2].graphs.size()", Matchers.is(1))
-                .content("[2].graphs[0].namespace", Matchers.is("nodes"))
-                .content("[2].graphs[0].label", Matchers.is("Enhanced Linkd Topology Provider"))
-                .content("[2].graphs[0].description", Matchers.is("This Topology Provider displays the topology information discovered by the Enhanced Linkd daemon. It uses the SNMP information of several protocols like OSPF, ISIS, LLDP and CDP to generate an overall topology."))
+                .body("[2].id", Matchers.is("nodes"))
+                .body("[2].label", Matchers.is("Enhanced Linkd Topology Provider"))
+                .body("[2].graphs.size()", Matchers.is(1))
+                .body("[2].graphs[0].namespace", Matchers.is("nodes"))
+                .body("[2].graphs[0].label", Matchers.is("Enhanced Linkd Topology Provider"))
+                .body("[2].graphs[0].description", Matchers.is("This Topology Provider displays the topology information discovered by the Enhanced Linkd daemon. It uses the SNMP information of several protocols like OSPF, ISIS, LLDP and CDP to generate an overall topology."))
 
-                .content("[3].id", Matchers.is(CONTAINER_ID))
-                .content("[3].label", Matchers.is(GraphMLTopologyIT.LABEL))
-                .content("[3].graphs.size()", Matchers.is(2))
-                .content("[3].graphs[0].namespace", Matchers.is("acme:markets"))
-                .content("[3].graphs[0].label", Matchers.is("Markets"))
-                .content("[3].graphs[0].description", Matchers.is("The Markets Layer"))
-                .content("[3].graphs[1].namespace", Matchers.is("acme:regions"))
+                .body("[3].id", Matchers.is(CONTAINER_ID))
+                .body("[3].label", Matchers.is(GraphMLTopologyIT.LABEL))
+                .body("[3].graphs.size()", Matchers.is(2))
+                .body("[3].graphs[0].namespace", Matchers.is("acme:markets"))
+                .body("[3].graphs[0].label", Matchers.is("Markets"))
+                .body("[3].graphs[0].description", Matchers.is("The Markets Layer"))
+                .body("[3].graphs[1].namespace", Matchers.is("acme:regions"))
 
-                .content("[4].id", Matchers.is("vmware"))
-                .content("[4].label", Matchers.is("VMware Topology Provider"))
-                .content("[4].graphs.size()", Matchers.is(1))
-                .content("[4].graphs[0].namespace", Matchers.is("vmware"))
-                .content("[4].graphs[0].label", Matchers.is("VMware Topology Provider"))
-                .content("[4].graphs[0].description", Matchers.is("The VMware Topology Provider displays the infrastructure information gathered by the VMware Provisioning process."))
+                .body("[4].id", Matchers.is("vmware"))
+                .body("[4].label", Matchers.is("VMware Topology Provider"))
+                .body("[4].graphs.size()", Matchers.is(1))
+                .body("[4].graphs[0].namespace", Matchers.is("vmware"))
+                .body("[4].graphs[0].label", Matchers.is("VMware Topology Provider"))
+                .body("[4].graphs[0].description", Matchers.is("The VMware Topology Provider displays the infrastructure information gathered by the VMware Provisioning process."))
                 ;
     }
 
@@ -185,21 +185,21 @@ public class GraphRestServiceIT extends OpenNMSSeleniumIT {
         createGraphMLAndWaitUntilDone(graphmlDocument);
         given().get(CONTAINER_ID).then()
                 .contentType(ContentType.JSON)
-                .content("graphs", Matchers.hasSize(2))
-                .content("graphs[0].id", Matchers.is("markets"))
-                .content("graphs[0].namespace", Matchers.is("acme:markets"))
-                .content("graphs[0].defaultFocus.type", Matchers.is("SELECTION"))
-                .content("graphs[0].defaultFocus.vertexIds.size()", Matchers.is(1))
-                .content("graphs[0].defaultFocus.vertexIds[0].id", Matchers.is("north.4"))
-                .content("graphs[0].vertices", Matchers.hasSize(16))
-                .content("graphs[0].edges", Matchers.hasSize(0))
+                .body("graphs", Matchers.hasSize(2))
+                .body("graphs[0].id", Matchers.is("markets"))
+                .body("graphs[0].namespace", Matchers.is("acme:markets"))
+                .body("graphs[0].defaultFocus.type", Matchers.is("SELECTION"))
+                .body("graphs[0].defaultFocus.vertexIds.size()", Matchers.is(1))
+                .body("graphs[0].defaultFocus.vertexIds[0].id", Matchers.is("north.4"))
+                .body("graphs[0].vertices", Matchers.hasSize(16))
+                .body("graphs[0].edges", Matchers.hasSize(0))
 
-                .content("graphs[1].id", Matchers.is("regions"))
-                .content("graphs[1].namespace", Matchers.is("acme:regions"))
-                .content("graphs[1].defaultFocus.type", Matchers.is("ALL"))
-                .content("graphs[1].defaultFocus.vertexIds.size()", Matchers.is(4))
-                .content("graphs[1].vertices", Matchers.hasSize(4))
-                .content("graphs[1].edges", Matchers.hasSize(16));
+                .body("graphs[1].id", Matchers.is("regions"))
+                .body("graphs[1].namespace", Matchers.is("acme:regions"))
+                .body("graphs[1].defaultFocus.type", Matchers.is("ALL"))
+                .body("graphs[1].defaultFocus.vertexIds.size()", Matchers.is(4))
+                .body("graphs[1].vertices", Matchers.hasSize(4))
+                .body("graphs[1].edges", Matchers.hasSize(16));
     }
 
     @Test
@@ -208,21 +208,21 @@ public class GraphRestServiceIT extends OpenNMSSeleniumIT {
         given().get(CONTAINER_ID + "/{namespace}", "acme:markets")
                 .then()
                 .contentType(ContentType.JSON)
-                .content("id", Matchers.is("markets"))
-                .content("defaultFocus.type", Matchers.is("SELECTION"))
-                .content("defaultFocus.vertexIds.size()", Matchers.is(1))
-                .content("defaultFocus.vertexIds[0].id", Matchers.is("north.4"))
-                .content("vertices", Matchers.hasSize(16))
-                .content("edges", Matchers.hasSize(0));
+                .body("id", Matchers.is("markets"))
+                .body("defaultFocus.type", Matchers.is("SELECTION"))
+                .body("defaultFocus.vertexIds.size()", Matchers.is(1))
+                .body("defaultFocus.vertexIds[0].id", Matchers.is("north.4"))
+                .body("vertices", Matchers.hasSize(16))
+                .body("edges", Matchers.hasSize(0));
         given().get(CONTAINER_ID + "/{namespace}", "acme:regions")
                 .then()
                 .contentType(ContentType.JSON)
-                .content("id", Matchers.is("regions"))
-                .content("namespace", Matchers.is("acme:regions"))
-                .content("defaultFocus.type", Matchers.is("ALL"))
-                .content("defaultFocus.vertexIds.size()", Matchers.is(4))
-                .content("vertices", Matchers.hasSize(4))
-                .content("edges", Matchers.hasSize(16));
+                .body("id", Matchers.is("regions"))
+                .body("namespace", Matchers.is("acme:regions"))
+                .body("defaultFocus.type", Matchers.is("ALL"))
+                .body("defaultFocus.vertexIds.size()", Matchers.is(4))
+                .body("vertices", Matchers.hasSize(4))
+                .body("edges", Matchers.hasSize(16));
     }
 
     @Test
@@ -242,10 +242,10 @@ public class GraphRestServiceIT extends OpenNMSSeleniumIT {
                .then().log().ifValidationFails()
                .statusCode(200)
                .contentType(ContentType.JSON)
-               .content("[0].context", Matchers.is("GenericVertex"))
-               .content("[0].label", Matchers.is("North Region"))      
-               .content("[0].provider", Matchers.is("LabelSearchProvider"))
-               .content("", Matchers.hasSize(1));
+               .body("[0].context", Matchers.is("GenericVertex"))
+               .body("[0].label", Matchers.is("North Region"))      
+               .body("[0].provider", Matchers.is("LabelSearchProvider"))
+               .body("", Matchers.hasSize(1));
     }
 
     @Test
@@ -267,9 +267,9 @@ public class GraphRestServiceIT extends OpenNMSSeleniumIT {
                .then().log().ifValidationFails()
                .statusCode(200)
                .contentType(ContentType.JSON)
-               .content("[0].namespace", Matchers.is("acme:regions"))
-               .content("[0].id", Matchers.is("north"))
-               .content("", Matchers.hasSize(1));
+               .body("[0].namespace", Matchers.is("acme:regions"))
+               .body("[0].id", Matchers.is("north"))
+               .body("", Matchers.hasSize(1));
     }
 
     @Test
@@ -286,14 +286,14 @@ public class GraphRestServiceIT extends OpenNMSSeleniumIT {
                 .then()
                 .log().ifValidationFails()
                 .contentType(ContentType.JSON)
-                .content("id", Matchers.is("test"))
-                .content("namespace", Matchers.is("test"))
-                .content("focus.semanticZoomLevel", Matchers.is(1))
-                .content("focus.vertices", Matchers.hasSize(1))
-                .content("vertices", Matchers.hasSize(2))
-                .content("edges", Matchers.hasSize(1))
-                .content("vertices[0].id", Matchers.is("v1.1"))
-                .content("vertices[1].id", Matchers.is("v1.1.2"));
+                .body("id", Matchers.is("test"))
+                .body("namespace", Matchers.is("test"))
+                .body("focus.semanticZoomLevel", Matchers.is(1))
+                .body("focus.vertices", Matchers.hasSize(1))
+                .body("vertices", Matchers.hasSize(2))
+                .body("edges", Matchers.hasSize(1))
+                .body("vertices[0].id", Matchers.is("v1.1"))
+                .body("vertices[1].id", Matchers.is("v1.1.2"));
     }
 
     @Test
@@ -313,12 +313,12 @@ public class GraphRestServiceIT extends OpenNMSSeleniumIT {
                 .then()
                 .log().ifValidationFails()
                 .contentType(ContentType.JSON)
-                .content("id", Matchers.is("test"))
-                .content("namespace", Matchers.is("test"))
-                .content("vertices", Matchers.hasSize(2))
-                .content("edges", Matchers.hasSize(1))
-                .content("vertices[0].id", Matchers.is("v1.1"))
-                .content("vertices[1].id", Matchers.is("v1.1.1"));
+                .body("id", Matchers.is("test"))
+                .body("namespace", Matchers.is("test"))
+                .body("vertices", Matchers.hasSize(2))
+                .body("edges", Matchers.hasSize(1))
+                .body("vertices[0].id", Matchers.is("v1.1"))
+                .body("vertices[1].id", Matchers.is("v1.1.1"));
 
         //  Increase SZL
         query.put("semanticZoomLevel", 2);
@@ -329,14 +329,14 @@ public class GraphRestServiceIT extends OpenNMSSeleniumIT {
                 .then()
                 .log().ifValidationFails()
                 .contentType(ContentType.JSON)
-                .content("id", Matchers.is("test"))
-                .content("namespace", Matchers.is("test"))
-                .content("vertices", Matchers.hasSize(4))
-                .content("edges", Matchers.hasSize(3))
-                .content("vertices[0].id", Matchers.is("v1"))
-                .content("vertices[1].id", Matchers.is("v1.1"))
-                .content("vertices[2].id", Matchers.is("v1.1.1"))
-                .content("vertices[3].id", Matchers.is("v1.1.2"));
+                .body("id", Matchers.is("test"))
+                .body("namespace", Matchers.is("test"))
+                .body("vertices", Matchers.hasSize(4))
+                .body("edges", Matchers.hasSize(3))
+                .body("vertices[0].id", Matchers.is("v1"))
+                .body("vertices[1].id", Matchers.is("v1.1"))
+                .body("vertices[2].id", Matchers.is("v1.1.1"))
+                .body("vertices[3].id", Matchers.is("v1.1.2"));
     }
 
     @Test
@@ -353,10 +353,10 @@ public class GraphRestServiceIT extends OpenNMSSeleniumIT {
                 .then().log().ifValidationFails()
                 .statusCode(200)
                 .contentType(ContentType.JSON)
-                .content("[0].context", Matchers.is("Node"))
-                .content("[0].label", Matchers.is("Node A"))
-                .content("[0].provider", Matchers.is("NodeSearchProvider"))
-                .content("", Matchers.hasSize(1))
+                .body("[0].context", Matchers.is("Node"))
+                .body("[0].label", Matchers.is("Node A"))
+                .body("[0].provider", Matchers.is("NodeSearchProvider"))
+                .body("", Matchers.hasSize(1))
                 .extract().response().asString();
         final JSONArray result = new JSONArray(new JSONTokener(response));
         assertThat(result.length(), Matchers.is(1));
@@ -372,9 +372,9 @@ public class GraphRestServiceIT extends OpenNMSSeleniumIT {
                 .then().log().ifValidationFails()
                 .statusCode(200)
                 .contentType(ContentType.JSON)
-                .content("[0].namespace", Matchers.is("acme:markets"))
-                .content("[0].id", Matchers.is("north.2"))
-                .content("", Matchers.hasSize(1));
+                .body("[0].namespace", Matchers.is("acme:markets"))
+                .body("[0].id", Matchers.is("north.2"))
+                .body("", Matchers.hasSize(1));
     }
 
     @Test
@@ -394,21 +394,21 @@ public class GraphRestServiceIT extends OpenNMSSeleniumIT {
                 .then()
                 .log().ifValidationFails()
                 .contentType(ContentType.JSON)
-                .content("id", Matchers.is("markets"))
-                .content("namespace", Matchers.is("acme:markets"))
-                .content("vertices", Matchers.hasSize(3))
-                .content("edges", Matchers.hasSize(0))
-                .content("vertices[0].id", Matchers.is("north.1"))
-                .content("vertices[1].id", Matchers.is("north.2"))
-                .content("vertices[1].nodeInfo.foreignSource", Matchers.is(REQUISITION_NAME))
-                .content("vertices[1].nodeInfo.foreignId", Matchers.is("node1"))
-                .content("vertices[1].nodeInfo.label", Matchers.is("Node A"))
-                .content("vertices[1].nodeInfo.categories", Matchers.hasItems("Test", "Server"))
-                .content("vertices[2].id", Matchers.is("north.3"))
-                .content("vertices[2].nodeInfo.foreignSource", Matchers.is(REQUISITION_NAME))
-                .content("vertices[2].nodeInfo.foreignId", Matchers.is("node2"))
-                .content("vertices[2].nodeInfo.label", Matchers.is("Node B"))
-                .content("vertices[2].nodeInfo.categories", Matchers.hasItems("Test", "Node"));
+                .body("id", Matchers.is("markets"))
+                .body("namespace", Matchers.is("acme:markets"))
+                .body("vertices", Matchers.hasSize(3))
+                .body("edges", Matchers.hasSize(0))
+                .body("vertices[0].id", Matchers.is("north.1"))
+                .body("vertices[1].id", Matchers.is("north.2"))
+                .body("vertices[1].nodeInfo.foreignSource", Matchers.is(REQUISITION_NAME))
+                .body("vertices[1].nodeInfo.foreignId", Matchers.is("node1"))
+                .body("vertices[1].nodeInfo.label", Matchers.is("Node A"))
+                .body("vertices[1].nodeInfo.categories", Matchers.hasItems("Test", "Server"))
+                .body("vertices[2].id", Matchers.is("north.3"))
+                .body("vertices[2].nodeInfo.foreignSource", Matchers.is(REQUISITION_NAME))
+                .body("vertices[2].nodeInfo.foreignId", Matchers.is("node2"))
+                .body("vertices[2].nodeInfo.label", Matchers.is("Node B"))
+                .body("vertices[2].nodeInfo.categories", Matchers.hasItems("Test", "Node"));
     }
 
     @Test
@@ -426,8 +426,8 @@ public class GraphRestServiceIT extends OpenNMSSeleniumIT {
                     .log().ifValidationFails()
                     .statusCode(200)
                     .contentType(ContentType.JSON)
-                    .content("vertices", Matchers.hasSize(1))
-                    .content("vertices[0].status", Matchers.is("Normal"));
+                    .body("vertices", Matchers.hasSize(1))
+                    .body("vertices[0].status", Matchers.is("Normal"));
         } finally {
             karafShell.runCommand("opennms:bsm-delete-generated-hierarchies");
         }
@@ -501,13 +501,13 @@ public class GraphRestServiceIT extends OpenNMSSeleniumIT {
                 .log().ifValidationFails()
                 .statusCode(200)
                 .contentType(ContentType.JSON)
-                .content("vertices", Matchers.hasSize(3))
-                .content("vertices[0].status.severity", Matchers.is("Normal"))
-                .content("vertices[1].status.severity", Matchers.is("Normal"))
-                .content("vertices[2].status.severity", Matchers.is("Normal"))
-                .content("vertices[0].status.count", Matchers.is(0))
-                .content("vertices[1].status.count", Matchers.is(0))
-                .content("vertices[2].status.count", Matchers.is(0));
+                .body("vertices", Matchers.hasSize(3))
+                .body("vertices[0].status.severity", Matchers.is("Normal"))
+                .body("vertices[1].status.severity", Matchers.is("Normal"))
+                .body("vertices[2].status.severity", Matchers.is("Normal"))
+                .body("vertices[0].status.count", Matchers.is(0))
+                .body("vertices[1].status.count", Matchers.is(0))
+                .body("vertices[2].status.count", Matchers.is(0));
 
         // Prepare simulated outages
         final Event nodeLostServiceEvent = new EventBuilder(EventConstants.PERSPECTIVE_NODE_LOST_SERVICE_UEI, getClass().getSimpleName())
@@ -644,12 +644,12 @@ public class GraphRestServiceIT extends OpenNMSSeleniumIT {
                 .log().ifValidationFails()
                 .statusCode(200)
                 .contentType(ContentType.JSON)
-                .content("vertices", Matchers.hasSize(5))
-                .content("vertices[0].reduceFunction.type", Matchers.is("highestseverity"))
-                .content("vertices[1].reduceFunction.type", Matchers.is("highestseverity"))
-                .content("vertices[2].reduceFunction.type", Matchers.is("highestseverity"))
-                .content("vertices[3].reduceFunction.type", Matchers.is("highestseverity"))
-                .content("vertices[4].reduceFunction.type", Matchers.is("highestseverity"));
+                .body("vertices", Matchers.hasSize(5))
+                .body("vertices[0].reduceFunction.type", Matchers.is("highestseverity"))
+                .body("vertices[1].reduceFunction.type", Matchers.is("highestseverity"))
+                .body("vertices[2].reduceFunction.type", Matchers.is("highestseverity"))
+                .body("vertices[3].reduceFunction.type", Matchers.is("highestseverity"))
+                .body("vertices[4].reduceFunction.type", Matchers.is("highestseverity"));
         } finally {
             karafShell.runCommand("opennms:bsm-delete-generated-hierarchies");
         }
@@ -661,11 +661,11 @@ public class GraphRestServiceIT extends OpenNMSSeleniumIT {
             given().accept(ContentType.JSON).get()
                     .then().statusCode(200)
                     .contentType(ContentType.JSON)
-                    .content("[0].id", Matchers.is("application"))
-                    .content("[1].id", Matchers.is("bsm"))
-                    .content("[2].id", Matchers.is("nodes"))
-                    .content("[3].id", Matchers.is(CONTAINER_ID))
-                    .content("[4].id", Matchers.is("vmware"));
+                    .body("[0].id", Matchers.is("application"))
+                    .body("[1].id", Matchers.is("bsm"))
+                    .body("[2].id", Matchers.is("nodes"))
+                    .body("[3].id", Matchers.is(CONTAINER_ID))
+                    .body("[4].id", Matchers.is("vmware"));
         });
     }
     private void createRequisition() {

--- a/smoke-test/src/test/java/org/opennms/smoketest/minion/JolokiaRestIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/minion/JolokiaRestIT.java
@@ -69,10 +69,10 @@ public class JolokiaRestIT {
                 .statusCode(200);
 
         given().get("/read/java.lang:type=Memory/HeapMemoryUsage")
-                .then().assertThat().content(Matchers.containsString("HeapMemoryUsage"));
+                .then().assertThat().body(Matchers.containsString("HeapMemoryUsage"));
 
         given().get("/read/org.opennms.core.ipc.sink.producer:name=*.dispatch")
-                .then().assertThat().content(Matchers.containsString("Heartbeat"));
+                .then().assertThat().body(Matchers.containsString("Heartbeat"));
     }
 
 

--- a/tools/packages/minion/minion.spec
+++ b/tools/packages/minion/minion.spec
@@ -18,7 +18,7 @@
 %{!?_descr:%define _descr OpenNMS}
 %{!?packagedir:%define packagedir %{_name}-%version-%{releasenumber}}
 
-%{!?_java:%define _java java-1.8.0-openjdk-devel}
+%{!?_java:%define _java java-11-openjdk-devel}
 
 %{!?extrainfo:%define extrainfo %{nil}}
 %{!?extrainfo2:%define extrainfo2 %{nil}}

--- a/tools/packages/sentinel/sentinel.spec
+++ b/tools/packages/sentinel/sentinel.spec
@@ -18,7 +18,7 @@
 %{!?_descr:%define _descr OpenNMS}
 %{!?packagedir:%define packagedir %{_name}-%version-%{releasenumber}}
 
-%{!?_java:%define _java java-1.8.0-openjdk-devel}
+%{!?_java:%define _java java-11-openjdk-devel}
 
 %{!?extrainfo:%define extrainfo %{nil}}
 %{!?extrainfo2:%define extrainfo2 %{nil}}


### PR DESCRIPTION
JIRA: https://issues.opennms.org/browse/NMS-13197

This patch includes build system and library upgrades to support compiling JDK11.
The tree can no longer be compiled or run with JDK8 once this is merged.
