### PR TITLE
NMS-13186: separate smoke test builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -178,9 +178,9 @@ commands:
   run-smoke-tests:
     description: "Run the smoke tests"
     parameters:
-      minimal:
-        default: false
-        type: boolean
+      suite:
+        default: core
+        type: string
     steps:
       - run:
           name: Enable swap
@@ -211,7 +211,7 @@ commands:
           name: Smoke Tests
           no_output_timeout: 30m
           command: |
-            .circleci/scripts/smoke.sh << parameters.minimal >>
+            .circleci/scripts/smoke.sh << parameters.suite >>
       - run:
           name: Gather system logs
           when: always
@@ -544,7 +544,37 @@ workflows:
             branches:
               ignore:
                 - /^merge-foundation.*/
-      - smoke-test-full:
+      - smoke-test-core:
+          requires:
+            - horizon-rpm-build
+            - tarball-assembly
+            - sentinel-rpm-build
+          filters:
+            branches:
+              only:
+                - develop
+                - /^master-.*/
+                - /^release-.*/
+                - /^foundation.*/
+                - /^features.*/
+                - /.*smoke.*/
+                - /^dependabot.*/
+      - smoke-test-minion:
+          requires:
+            - horizon-rpm-build
+            - tarball-assembly
+            - sentinel-rpm-build
+          filters:
+            branches:
+              only:
+                - develop
+                - /^master-.*/
+                - /^release-.*/
+                - /^foundation.*/
+                - /^features.*/
+                - /.*smoke.*/
+                - /^dependabot.*/
+      - smoke-test-sentinel:
           requires:
             - horizon-rpm-build
             - tarball-assembly
@@ -641,8 +671,10 @@ workflows:
             - horizon-deb-build
             - minion-deb-build
             - sentinel-deb-build
+            - smoke-test-core
+            - smoke-test-minion
+            - smoke-test-sentinel
             - smoke-test-minimal
-            - smoke-test-full
             - integration-test
           filters:
             branches:
@@ -660,8 +692,10 @@ workflows:
           # if everything passes
           requires:
             - horizon-deb-build
+            - smoke-test-core
+            - smoke-test-minion
+            - smoke-test-sentinel
             - smoke-test-minimal
-            - smoke-test-full
             - integration-test
           filters:
             branches:
@@ -671,8 +705,10 @@ workflows:
           # if everything passes
           requires:
             - horizon-deb-build
+            - smoke-test-core
+            - smoke-test-minion
+            - smoke-test-sentinel
             - smoke-test-minimal
-            - smoke-test-full
             - integration-test
           filters:
             branches:
@@ -685,8 +721,10 @@ workflows:
             - horizon-deb-build
             - minion-deb-build
             - sentinel-deb-build
+            - smoke-test-core
+            - smoke-test-minion
+            - smoke-test-sentinel
             - smoke-test-minimal
-            - smoke-test-full
             - integration-test
           filters:
             branches:
@@ -1117,7 +1155,7 @@ jobs:
             export MAVEN_OPTS="-Xms3G -Xmx3G"
             .circleci/scripts/sonar.sh
       - save-sonar-cache
-  smoke-test-full:
+  smoke-test-core:
     executor: smoke-test-executor
     parallelism: 8
     # No resource class support for machine executors, we're constrained to use the default
@@ -1126,14 +1164,37 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/
-      - run-smoke-tests
+      - run-smoke-tests:
+          suite: core
+  smoke-test-minion:
+    executor: smoke-test-executor
+    parallelism: 8
+    # No resource class support for machine executors, we're constrained to use the default
+    # medium class which has 2 vCPUs and 8 GB RAM
+    #resource_class: large
+    steps:
+      - attach_workspace:
+          at: ~/
+      - run-smoke-tests:
+          suite: minion
+  smoke-test-sentinel:
+    executor: smoke-test-executor
+    parallelism: 8
+    # No resource class support for machine executors, we're constrained to use the default
+    # medium class which has 2 vCPUs and 8 GB RAM
+    #resource_class: large
+    steps:
+      - attach_workspace:
+          at: ~/
+      - run-smoke-tests:
+          suite: sentinel
   smoke-test-minimal:
     executor: smoke-test-executor
     steps:
       - attach_workspace:
           at: ~/
       - run-smoke-tests:
-          minimal: true
+          suite: minimal
   create-merge-foundation-branch:
     <<: *defaults
     <<: *docker_container_config

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1126,7 +1126,7 @@ jobs:
           rerun-failtest-count: 1
   integration-test-with-coverage:
     executor: integration-test-executor
-    parallelism: 12
+    parallelism: 8
     steps:
       - attach_workspace:
           at: ~/
@@ -1157,7 +1157,7 @@ jobs:
       - save-sonar-cache
   smoke-test-core:
     executor: smoke-test-executor
-    parallelism: 12
+    parallelism: 6
     # No resource class support for machine executors, we're constrained to use the default
     # medium class which has 2 vCPUs and 8 GB RAM
     #resource_class: large
@@ -1168,7 +1168,7 @@ jobs:
           suite: core
   smoke-test-minion:
     executor: smoke-test-executor
-    parallelism: 8
+    parallelism: 6
     # No resource class support for machine executors, we're constrained to use the default
     # medium class which has 2 vCPUs and 8 GB RAM
     #resource_class: large

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1157,7 +1157,7 @@ jobs:
       - save-sonar-cache
   smoke-test-core:
     executor: smoke-test-executor
-    parallelism: 8
+    parallelism: 12
     # No resource class support for machine executors, we're constrained to use the default
     # medium class which has 2 vCPUs and 8 GB RAM
     #resource_class: large

--- a/.circleci/scripts/smoke.sh
+++ b/.circleci/scripts/smoke.sh
@@ -1,9 +1,8 @@
 #!/bin/sh -e
 
-# If ran with 'true' then run a small subset of the tests
-MINIMAL=0
-if [ "$1" = "true" ]; then
-  MINIMAL=1
+SUITE="$1"; shift
+if [ -z "$SUITE" ]; then
+  SUITE="core"
 fi
 
 find_tests()
@@ -52,7 +51,7 @@ done
 export MAVEN_OPTS="-Xmx1g -Xms1g"
 
 cd ~/project/smoke-test
-if [ $MINIMAL -eq 1 ]; then
+if [ $SUITE = "minimal" ]; then
   echo "#### Executing minimal set smoke/system tests"
   # Run a set of known tests
   for TEST_CLASS in "MenuHeaderIT" "SinglePortFlowsIT"
@@ -67,7 +66,7 @@ else
   while read -r TEST_CLASS
   do
     echo "###### Testing: ${TEST_CLASS}"
-    ../compile.pl -N -DskipTests=false -DskipITs=false -DfailIfNoTests=false -Dit.test="$TEST_CLASS" install verify
+    ../compile.pl -N -DskipTests=false -DskipITs=false -DfailIfNoTests=false -Dit.test="$TEST_CLASS" "-Psmoke.$SUITE" install verify
   done < /tmp/this_node_it_tests
 fi
 

--- a/smoke-test/pom.xml
+++ b/smoke-test/pom.xml
@@ -10,6 +10,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <updatePolicy>never</updatePolicy>
     <camelVersion>2.19.1</camelVersion>
+    <failsafeVersion>2.22.2</failsafeVersion>
     <frontendPluginVersion>0.0.29</frontendPluginVersion>
     <jackson2Version>2.10.0</jackson2Version>
     <jersey.version>2.28</jersey.version>
@@ -49,6 +50,37 @@
               </pluginExecutions>
             </lifecycleMappingMetadata>
           </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-failsafe-plugin</artifactId>
+          <version>${failsafeVersion}</version>
+          <configuration>
+            <!-- Don't specify argLine here or it will override the argLine property value -->
+            <systemPropertyVariables/>
+            <!--
+              Configure failsafe to put reports in the surefire unit test directory so that
+              Bamboo and Sonar tally the test results properly.
+  
+              https://jira.atlassian.com/browse/BAM-15446
+            -->
+            <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
+            <forkCount>${test.fork.count}</forkCount>
+            <!-- We don't reuse forks - any given test should not take longer than the given timeout -->
+            <forkedProcessTimeoutInSeconds>${test.fork.timeout}</forkedProcessTimeoutInSeconds>
+            <!-- Spawn a new JVM for every test so things don't leak over from one to the next -->
+            <reuseForks>false</reuseForks>
+            <!-- Configure heap and GC -->
+            <argLine>-Xms1g -Xmx1g -XX:+UseG1GC</argLine>
+          </configuration>
+          <executions>
+            <execution>
+              <goals>
+                <goal>integration-test</goal>
+                <goal>verify</goal>
+              </goals>
+            </execution>
+          </executions>
         </plugin>
       </plugins>
     </pluginManagement>
@@ -121,37 +153,6 @@
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-failsafe-plugin</artifactId>
-        <version>2.22.2</version>
-        <configuration>
-          <!-- Don't specify argLine here or it will override the argLine property value -->
-          <systemPropertyVariables/>
-          <!--
-            Configure failsafe to put reports in the surefire unit test directory so that
-            Bamboo and Sonar tally the test results properly.
-
-            https://jira.atlassian.com/browse/BAM-15446
-          -->
-          <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
-          <forkCount>${test.fork.count}</forkCount>
-          <!-- We don't reuse forks - any given test should not take longer than the given timeout -->
-          <forkedProcessTimeoutInSeconds>${test.fork.timeout}</forkedProcessTimeoutInSeconds>
-          <!-- Spawn a new JVM for every test so things don't leak over from one to the next -->
-          <reuseForks>false</reuseForks>
-          <!-- Configure heap and GC -->
-          <argLine>-Xms1g -Xmx1g -XX:+UseG1GC</argLine>
-        </configuration>
-        <executions>
-          <execution>
-            <goals>
-              <goal>integration-test</goal>
-              <goal>verify</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
         <executions>
           <execution>
@@ -177,6 +178,50 @@
       </plugin>
     </plugins>
   </build>
+  <profiles>
+    <profile>
+      <id>smoke.core</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <configuration>
+              <excludedGroups>org.opennms.smoketest.junit.MinionTests,org.opennms.smoketest.junit.SentinelTests</excludedGroups>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>smoke.minion</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <configuration>
+              <groups>org.opennms.smoketest.junit.MinionTests</groups>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>smoke.sentinel</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <configuration>
+              <groups>org.opennms.smoketest.junit.SentinelTests</groups>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
   <dependencyManagement>
     <dependencies>
       <dependency>

--- a/smoke-test/src/main/java/org/opennms/smoketest/containers/OpenNMSContainer.java
+++ b/smoke-test/src/main/java/org/opennms/smoketest/containers/OpenNMSContainer.java
@@ -411,7 +411,7 @@ public class OpenNMSContainer extends GenericContainer implements KarafContainer
             // This helps ensure that all of the sockets that should be up and listening i.e. teletrymd flows
             // have been given a chance to bind
             LOG.info("Waiting for startup to complete.");
-            await().atMost(3, MINUTES).until(() -> TestContainerUtils.getFileFromContainerAsString(container, managerLog),
+            await().atMost(4, MINUTES).until(() -> TestContainerUtils.getFileFromContainerAsString(container, managerLog),
                     containsString("Starter: Startup complete"));
             LOG.info("OpenNMS has started.");
 

--- a/smoke-test/src/main/java/org/opennms/smoketest/junit/MinionTests.java
+++ b/smoke-test/src/main/java/org/opennms/smoketest/junit/MinionTests.java
@@ -1,7 +1,7 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2016-2021 The OpenNMS Group, Inc.
+ * Copyright (C) 2021 The OpenNMS Group, Inc.
  * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
@@ -25,24 +25,8 @@
  *     http://www.opennms.org/
  *     http://www.opennms.com/
  *******************************************************************************/
-package org.opennms.smoketest.minion;
 
-import org.junit.experimental.categories.Category;
-import org.opennms.smoketest.junit.MinionTests;
-import org.opennms.smoketest.stacks.IpcStrategy;
+package org.opennms.smoketest.junit;
 
-/**
- * This test starts up Minion with the Apache Kafka sink and makes sure
- * that heartbeat messages continue to be processed even if the Minion
- * and OpenNMS instances are restarted.
- * 
- * @author Seth
- */
-@Category(MinionTests.class)
-public class MinionHeartbeatOutageKafkaIT extends MinionHeartbeatOutageIT {
-
-    @Override
-    public IpcStrategy getIpcStrategy() {
-        return IpcStrategy.KAFKA;
-    }
+public interface MinionTests {
 }

--- a/smoke-test/src/main/java/org/opennms/smoketest/junit/SentinelTests.java
+++ b/smoke-test/src/main/java/org/opennms/smoketest/junit/SentinelTests.java
@@ -1,7 +1,7 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2016-2021 The OpenNMS Group, Inc.
+ * Copyright (C) 2021 The OpenNMS Group, Inc.
  * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
@@ -25,24 +25,8 @@
  *     http://www.opennms.org/
  *     http://www.opennms.com/
  *******************************************************************************/
-package org.opennms.smoketest.minion;
 
-import org.junit.experimental.categories.Category;
-import org.opennms.smoketest.junit.MinionTests;
-import org.opennms.smoketest.stacks.IpcStrategy;
+package org.opennms.smoketest.junit;
 
-/**
- * This test starts up Minion with the Apache Kafka sink and makes sure
- * that heartbeat messages continue to be processed even if the Minion
- * and OpenNMS instances are restarted.
- * 
- * @author Seth
- */
-@Category(MinionTests.class)
-public class MinionHeartbeatOutageKafkaIT extends MinionHeartbeatOutageIT {
-
-    @Override
-    public IpcStrategy getIpcStrategy() {
-        return IpcStrategy.KAFKA;
-    }
+public interface SentinelTests {
 }

--- a/smoke-test/src/test/java/org/opennms/smoketest/flow/ClockSkewIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/flow/ClockSkewIT.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2019 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ * Copyright (C) 2019-2021 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -37,6 +37,7 @@ import java.net.InetSocketAddress;
 
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.opennms.core.criteria.CriteriaBuilder;
 import org.opennms.netmgt.dao.api.AlarmDao;
 import org.opennms.netmgt.dao.api.EventDao;
@@ -50,6 +51,7 @@ import org.opennms.netmgt.model.PrimaryType;
 import org.opennms.netmgt.provision.persist.requisition.Requisition;
 import org.opennms.netmgt.provision.persist.requisition.RequisitionInterface;
 import org.opennms.netmgt.provision.persist.requisition.RequisitionNode;
+import org.opennms.smoketest.junit.MinionTests;
 import org.opennms.smoketest.stacks.NetworkProtocol;
 import org.opennms.smoketest.stacks.OpenNMSStack;
 import org.opennms.smoketest.stacks.StackModel;
@@ -61,6 +63,7 @@ import org.opennms.smoketest.utils.RestClient;
 
 import com.google.common.collect.ImmutableList;
 
+@Category(MinionTests.class)
 public class ClockSkewIT {
     @ClassRule
     public static final OpenNMSStack stack = OpenNMSStack.withModel(StackModel.newBuilder()

--- a/smoke-test/src/test/java/org/opennms/smoketest/graph/GraphRestServiceIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/graph/GraphRestServiceIT.java
@@ -32,9 +32,7 @@ import static com.jayway.awaitility.Awaitility.await;
 import static io.restassured.RestAssured.given;
 import static io.restassured.RestAssured.preemptive;
 import static java.util.concurrent.TimeUnit.MINUTES;
-import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 
@@ -57,7 +55,6 @@ import org.opennms.netmgt.dao.hibernate.ApplicationDaoHibernate;
 import org.opennms.netmgt.dao.hibernate.OutageDaoHibernate;
 import org.opennms.netmgt.events.api.EventConstants;
 import org.opennms.netmgt.model.OnmsApplication;
-import org.opennms.netmgt.model.OnmsEventCollection;
 import org.opennms.netmgt.model.OnmsNode;
 import org.opennms.netmgt.model.OnmsSeverity;
 import org.opennms.netmgt.model.events.EventBuilder;

--- a/smoke-test/src/test/java/org/opennms/smoketest/health/HealthCheckIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/health/HealthCheckIT.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2018-2018 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2018 The OpenNMS Group, Inc.
+ * Copyright (C) 2018-2021 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -31,10 +31,12 @@ package org.opennms.smoketest.health;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.Timeout;
 import org.opennms.smoketest.containers.OpenNMSContainer;
-import org.opennms.smoketest.stacks.OpenNMSStack;
+import org.opennms.smoketest.junit.SentinelTests;
 import org.opennms.smoketest.stacks.IpcStrategy;
+import org.opennms.smoketest.stacks.OpenNMSStack;
 import org.opennms.smoketest.stacks.StackModel;
 import org.opennms.smoketest.utils.SshClient;
 import org.slf4j.Logger;
@@ -50,6 +52,7 @@ import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 
+@Category(SentinelTests.class)
 public class HealthCheckIT {
 
     private static final Logger LOG = LoggerFactory.getLogger(HealthCheckIT.class);

--- a/smoke-test/src/test/java/org/opennms/smoketest/minion/CollectorListIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/minion/CollectorListIT.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2017-2017 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
+ * Copyright (C) 2017-2021 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -42,7 +42,9 @@ import java.util.Set;
 import org.apache.commons.lang.StringUtils;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.opennms.smoketest.containers.OpenNMSContainer;
+import org.opennms.smoketest.junit.MinionTests;
 import org.opennms.smoketest.stacks.OpenNMSStack;
 import org.opennms.smoketest.utils.CommandTestUtils;
 import org.opennms.smoketest.utils.SshClient;
@@ -54,6 +56,7 @@ import com.google.common.collect.ImmutableSet;
 /**
  * Verifies the output of "opennms:list-collectors" on both OpenNMS and Minion.
  */
+@Category(MinionTests.class)
 public class CollectorListIT {
 
     private static final Logger LOG = LoggerFactory.getLogger(CollectorListIT.class);

--- a/smoke-test/src/test/java/org/opennms/smoketest/minion/DetectorsCommandIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/minion/DetectorsCommandIT.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2016 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2016 The OpenNMS Group, Inc.
+ * Copyright (C) 2016-2021 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -43,6 +43,8 @@ import java.util.Map;
 import org.apache.commons.lang.StringUtils;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.opennms.smoketest.junit.MinionTests;
 import org.opennms.smoketest.stacks.OpenNMSStack;
 import org.opennms.smoketest.utils.CommandTestUtils;
 import org.opennms.smoketest.utils.SshClient;
@@ -62,6 +64,7 @@ import com.google.common.collect.ImmutableMap;
  * @author jwhite
  * @author chandrag
  */
+@Category(MinionTests.class)
 public class DetectorsCommandIT {
 
     private static final Logger LOG = LoggerFactory.getLogger(DetectorsCommandIT.class);

--- a/smoke-test/src/test/java/org/opennms/smoketest/minion/DetectorsOnMinionIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/minion/DetectorsOnMinionIT.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2016 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2016 The OpenNMS Group, Inc.
+ * Copyright (C) 2016-2021 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -43,17 +43,20 @@ import org.apache.commons.collections.CollectionUtils;
 import org.apache.http.client.ClientProtocolException;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.opennms.netmgt.model.OnmsMonitoredService;
 import org.opennms.netmgt.model.OnmsNode;
 import org.opennms.netmgt.model.PrimaryType;
 import org.opennms.netmgt.provision.persist.requisition.Requisition;
 import org.opennms.netmgt.provision.persist.requisition.RequisitionInterface;
 import org.opennms.netmgt.provision.persist.requisition.RequisitionNode;
+import org.opennms.smoketest.junit.MinionTests;
 import org.opennms.smoketest.stacks.OpenNMSStack;
 import org.opennms.smoketest.utils.RestClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@Category(MinionTests.class)
 public class DetectorsOnMinionIT {
 
     private static final Logger LOG = LoggerFactory.getLogger(DetectorsOnMinionIT.class);

--- a/smoke-test/src/test/java/org/opennms/smoketest/minion/DiscoveryIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/minion/DiscoveryIT.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2016-2017 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
+ * Copyright (C) 2016-2021 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -44,6 +44,7 @@ import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.client.LaxRedirectStrategy;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.opennms.core.criteria.Criteria;
 import org.opennms.core.criteria.CriteriaBuilder;
 import org.opennms.netmgt.dao.api.EventDao;
@@ -51,6 +52,7 @@ import org.opennms.netmgt.dao.hibernate.EventDaoHibernate;
 import org.opennms.netmgt.events.api.EventConstants;
 import org.opennms.netmgt.model.OnmsEvent;
 import org.opennms.smoketest.containers.OpenNMSContainer;
+import org.opennms.smoketest.junit.MinionTests;
 import org.opennms.smoketest.stacks.OpenNMSStack;
 import org.opennms.smoketest.stacks.MinionProfile;
 import org.opennms.smoketest.stacks.StackModel;
@@ -62,6 +64,7 @@ import org.opennms.smoketest.utils.HibernateDaoFactory;
  *
  * @author jwhite
  */
+@Category(MinionTests.class)
 public class DiscoveryIT {
 
     @ClassRule

--- a/smoke-test/src/test/java/org/opennms/smoketest/minion/EventSinkIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/minion/EventSinkIT.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2018-2020 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
+ * Copyright (C) 2018-2021 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -40,10 +40,12 @@ import java.util.Date;
 
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.opennms.core.criteria.CriteriaBuilder;
 import org.opennms.netmgt.dao.api.EventDao;
 import org.opennms.netmgt.dao.hibernate.EventDaoHibernate;
 import org.opennms.netmgt.model.OnmsEvent;
+import org.opennms.smoketest.junit.SentinelTests;
 import org.opennms.smoketest.stacks.IpcStrategy;
 import org.opennms.smoketest.stacks.OpenNMSStack;
 import org.opennms.smoketest.stacks.StackModel;
@@ -53,6 +55,7 @@ import org.opennms.smoketest.utils.SshClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@Category(SentinelTests.class)
 public class EventSinkIT {
 
     private static final Logger LOG = LoggerFactory.getLogger(EventSinkIT.class);

--- a/smoke-test/src/test/java/org/opennms/smoketest/minion/IpcOverGrpcIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/minion/IpcOverGrpcIT.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2020 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
+ * Copyright (C) 2020-2021 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -36,12 +36,15 @@ import static org.opennms.smoketest.minion.RpcOverKafkaIT.addRequisition;
 
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.opennms.smoketest.junit.MinionTests;
 import org.opennms.smoketest.stacks.IpcStrategy;
 import org.opennms.smoketest.stacks.OpenNMSStack;
 import org.opennms.smoketest.stacks.StackModel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@Category(MinionTests.class)
 public class IpcOverGrpcIT {
 
     private static final Logger LOG = LoggerFactory.getLogger(IpcOverGrpcIT.class);

--- a/smoke-test/src/test/java/org/opennms/smoketest/minion/JMXCollectorIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/minion/JMXCollectorIT.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2017-2017 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
+ * Copyright (C) 2017-2021 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -31,6 +31,8 @@ package org.opennms.smoketest.minion;
 import org.apache.commons.lang.StringUtils;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.opennms.smoketest.junit.MinionTests;
 import org.opennms.smoketest.stacks.OpenNMSStack;
 import org.opennms.smoketest.utils.CommandTestUtils;
 import org.opennms.smoketest.utils.SshClient;
@@ -45,6 +47,7 @@ import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.Matchers.containsString;
 
+@Category(MinionTests.class)
 public class JMXCollectorIT {
     private static final Logger LOG = LoggerFactory.getLogger(JMXCollectorIT.class);
 

--- a/smoke-test/src/test/java/org/opennms/smoketest/minion/JolokiaRestIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/minion/JolokiaRestIT.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2020 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
+ * Copyright (C) 2020-2021 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -37,12 +37,15 @@ import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.opennms.smoketest.junit.MinionTests;
 import org.opennms.smoketest.stacks.OpenNMSStack;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.restassured.RestAssured;
 
+@Category(MinionTests.class)
 public class JolokiaRestIT {
 
     private static final Logger LOG = LoggerFactory.getLogger(CollectorListIT.class);

--- a/smoke-test/src/test/java/org/opennms/smoketest/minion/JtiTelemetryIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/minion/JtiTelemetryIT.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2016-2017 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
+ * Copyright (C) 2016-2021 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -46,6 +46,7 @@ import java.util.List;
 
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.opennms.core.criteria.Criteria;
 import org.opennms.core.criteria.CriteriaBuilder;
 import org.opennms.netmgt.dao.api.EventDao;
@@ -59,6 +60,7 @@ import org.opennms.netmgt.model.resource.ResourceDTO;
 import org.opennms.netmgt.xml.event.Event;
 import org.opennms.netmgt.xml.event.Parm;
 import org.opennms.netmgt.xml.event.Value;
+import org.opennms.smoketest.junit.MinionTests;
 import org.opennms.smoketest.stacks.NetworkProtocol;
 import org.opennms.smoketest.stacks.OpenNMSStack;
 import org.opennms.smoketest.telemetry.Packet;
@@ -76,6 +78,7 @@ import org.slf4j.LoggerFactory;
  * @author cgorantla
  */
 
+@Category(MinionTests.class)
 public class JtiTelemetryIT {
 
     private static final Logger LOG = LoggerFactory.getLogger(JtiTelemetryIT.class);

--- a/smoke-test/src/test/java/org/opennms/smoketest/minion/KafkaCompressionZSTDRpcIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/minion/KafkaCompressionZSTDRpcIT.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2018 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2018 The OpenNMS Group, Inc.
+ * Copyright (C) 2018-2021 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -40,11 +40,13 @@ import java.util.List;
 import org.apache.commons.lang.StringUtils;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.opennms.netmgt.model.PrimaryType;
 import org.opennms.netmgt.provision.persist.requisition.Requisition;
 import org.opennms.netmgt.provision.persist.requisition.RequisitionInterface;
 import org.opennms.netmgt.provision.persist.requisition.RequisitionNode;
 import org.opennms.smoketest.containers.OpenNMSContainer;
+import org.opennms.smoketest.junit.MinionTests;
 import org.opennms.smoketest.stacks.IpcStrategy;
 import org.opennms.smoketest.stacks.KafkaCompressionStrategy;
 import org.opennms.smoketest.stacks.OpenNMSStack;
@@ -55,6 +57,7 @@ import org.opennms.smoketest.utils.SshClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@Category(MinionTests.class)
 public class KafkaCompressionZSTDRpcIT {
     private static final Logger LOG = LoggerFactory.getLogger(KafkaCompressionZSTDRpcIT.class);
 

--- a/smoke-test/src/test/java/org/opennms/smoketest/minion/MinionHeartBeatIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/minion/MinionHeartBeatIT.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2016 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2016 The OpenNMS Group, Inc.
+ * Copyright (C) 2016-2021 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -37,6 +37,7 @@ import java.util.Date;
 
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.opennms.core.criteria.CriteriaBuilder;
 import org.opennms.netmgt.dao.api.MinionDao;
 import org.opennms.netmgt.dao.api.NodeDao;
@@ -44,9 +45,11 @@ import org.opennms.netmgt.dao.hibernate.MinionDaoHibernate;
 import org.opennms.netmgt.dao.hibernate.NodeDaoHibernate;
 import org.opennms.netmgt.model.OnmsNode;
 import org.opennms.netmgt.model.minion.OnmsMinion;
+import org.opennms.smoketest.junit.MinionTests;
 import org.opennms.smoketest.stacks.OpenNMSStack;
 import org.opennms.smoketest.utils.DaoUtils;
 
+@Category(MinionTests.class)
 public class MinionHeartBeatIT {
 
 	@ClassRule

--- a/smoke-test/src/test/java/org/opennms/smoketest/minion/MinionHeartbeatOutageIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/minion/MinionHeartbeatOutageIT.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2016 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2016 The OpenNMS Group, Inc.
+ * Copyright (C) 2016-2021 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -39,6 +39,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.Timeout;
 import org.opennms.core.criteria.CriteriaBuilder;
 import org.opennms.netmgt.dao.hibernate.EventDaoHibernate;
@@ -49,8 +50,9 @@ import org.opennms.netmgt.model.OnmsEvent;
 import org.opennms.netmgt.model.OnmsMonitoringSystem;
 import org.opennms.netmgt.model.OnmsNode;
 import org.opennms.netmgt.model.minion.OnmsMinion;
-import org.opennms.smoketest.stacks.OpenNMSStack;
+import org.opennms.smoketest.junit.MinionTests;
 import org.opennms.smoketest.stacks.IpcStrategy;
+import org.opennms.smoketest.stacks.OpenNMSStack;
 import org.opennms.smoketest.stacks.StackModel;
 import org.opennms.smoketest.utils.DaoUtils;
 import org.opennms.smoketest.utils.TestContainerUtils;
@@ -62,6 +64,7 @@ import org.opennms.smoketest.utils.TestContainerUtils;
  * 
  * @author Seth
  */
+@Category(MinionTests.class)
 public class MinionHeartbeatOutageIT {
 
     @Rule

--- a/smoke-test/src/test/java/org/opennms/smoketest/minion/MonitorsListCommandIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/minion/MonitorsListCommandIT.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2016 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2016 The OpenNMS Group, Inc.
+ * Copyright (C) 2016-2021 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -42,6 +42,8 @@ import java.util.Set;
 import org.apache.commons.lang.StringUtils;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.opennms.smoketest.junit.MinionTests;
 import org.opennms.smoketest.stacks.OpenNMSStack;
 import org.opennms.smoketest.utils.CommandTestUtils;
 import org.opennms.smoketest.utils.SshClient;
@@ -50,6 +52,7 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.ImmutableSet;
 
+@Category(MinionTests.class)
 public class MonitorsListCommandIT {
 
     private static final Logger LOG = LoggerFactory.getLogger(MonitorsListCommandIT.class);

--- a/smoke-test/src/test/java/org/opennms/smoketest/minion/NxosTelemetryIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/minion/NxosTelemetryIT.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2017 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
+ * Copyright (C) 2017-2021 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -42,6 +42,7 @@ import java.util.List;
 
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.opennms.core.criteria.CriteriaBuilder;
 import org.opennms.netmgt.dao.api.NodeDao;
 import org.opennms.netmgt.dao.hibernate.NodeDaoHibernate;
@@ -52,6 +53,7 @@ import org.opennms.netmgt.provision.persist.requisition.Requisition;
 import org.opennms.netmgt.provision.persist.requisition.RequisitionInterface;
 import org.opennms.netmgt.provision.persist.requisition.RequisitionNode;
 import org.opennms.smoketest.stacks.OpenNMSStack;
+import org.opennms.smoketest.junit.MinionTests;
 import org.opennms.smoketest.stacks.NetworkProtocol;
 import org.opennms.smoketest.telemetry.Packet;
 import org.opennms.smoketest.telemetry.Packets;
@@ -61,6 +63,7 @@ import org.opennms.smoketest.utils.RestClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@Category(MinionTests.class)
 public class NxosTelemetryIT {
 
     private static final Logger LOG = LoggerFactory.getLogger(NxosTelemetryIT.class);

--- a/smoke-test/src/test/java/org/opennms/smoketest/minion/RpcOverKafkaIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/minion/RpcOverKafkaIT.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2018 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2018 The OpenNMS Group, Inc.
+ * Copyright (C) 2018-2021 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -40,11 +40,13 @@ import java.util.List;
 import org.apache.commons.lang.StringUtils;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.opennms.netmgt.model.PrimaryType;
 import org.opennms.netmgt.provision.persist.requisition.Requisition;
 import org.opennms.netmgt.provision.persist.requisition.RequisitionInterface;
 import org.opennms.netmgt.provision.persist.requisition.RequisitionNode;
 import org.opennms.smoketest.containers.OpenNMSContainer;
+import org.opennms.smoketest.junit.MinionTests;
 import org.opennms.smoketest.stacks.OpenNMSStack;
 import org.opennms.smoketest.stacks.IpcStrategy;
 import org.opennms.smoketest.stacks.StackModel;
@@ -54,6 +56,7 @@ import org.opennms.smoketest.utils.SshClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@Category(MinionTests.class)
 public class RpcOverKafkaIT {
     private static final Logger LOG = LoggerFactory.getLogger(RpcOverKafkaIT.class);
 

--- a/smoke-test/src/test/java/org/opennms/smoketest/minion/SyslogIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/minion/SyslogIT.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2016 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2016 The OpenNMS Group, Inc.
+ * Copyright (C) 2016-2021 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -40,6 +40,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.opennms.core.criteria.Criteria;
 import org.opennms.core.criteria.CriteriaBuilder;
 import org.opennms.netmgt.dao.api.EventDao;
@@ -48,6 +49,7 @@ import org.opennms.netmgt.dao.hibernate.MinionDaoHibernate;
 import org.opennms.netmgt.model.OnmsEvent;
 import org.opennms.netmgt.model.minion.OnmsMinion;
 import org.opennms.smoketest.containers.OpenNMSContainer;
+import org.opennms.smoketest.junit.MinionTests;
 import org.opennms.smoketest.stacks.OpenNMSStack;
 import org.opennms.smoketest.utils.DaoUtils;
 import org.opennms.smoketest.utils.SyslogUtils;
@@ -59,6 +61,7 @@ import org.opennms.smoketest.utils.SyslogUtils;
  * @author Seth
  * @author jwhite
  */
+@Category(MinionTests.class)
 public class SyslogIT {
 
     @ClassRule

--- a/smoke-test/src/test/java/org/opennms/smoketest/minion/SyslogKafkaElasticsearchIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/minion/SyslogKafkaElasticsearchIT.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2018 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2018 The OpenNMS Group, Inc.
+ * Copyright (C) 2018-2021 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -38,11 +38,13 @@ import java.util.Date;
 
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.opennms.core.criteria.CriteriaBuilder;
 import org.opennms.netmgt.dao.hibernate.MinionDaoHibernate;
 import org.opennms.netmgt.model.minion.OnmsMinion;
 import org.opennms.features.jest.client.SearchResultUtils;
 import org.opennms.smoketest.stacks.OpenNMSStack;
+import org.opennms.smoketest.junit.MinionTests;
 import org.opennms.smoketest.stacks.IpcStrategy;
 import org.opennms.smoketest.stacks.StackModel;
 import org.opennms.smoketest.utils.DaoUtils;
@@ -66,6 +68,7 @@ import io.searchbox.core.SearchResult;
  * 
  * @author Seth
  */
+@Category(MinionTests.class)
 public class SyslogKafkaElasticsearchIT {
 
     private static final Logger LOG = LoggerFactory.getLogger(SyslogKafkaElasticsearchIT.class);

--- a/smoke-test/src/test/java/org/opennms/smoketest/minion/SyslogOverlappingIpAddressIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/minion/SyslogOverlappingIpAddressIT.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2016 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2016 The OpenNMS Group, Inc.
+ * Copyright (C) 2016-2021 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -40,6 +40,7 @@ import java.util.Date;
 
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.opennms.core.criteria.CriteriaBuilder;
 import org.opennms.netmgt.dao.hibernate.EventDaoHibernate;
 import org.opennms.netmgt.dao.hibernate.NodeDaoHibernate;
@@ -50,6 +51,7 @@ import org.opennms.netmgt.provision.persist.requisition.Requisition;
 import org.opennms.netmgt.provision.persist.requisition.RequisitionInterface;
 import org.opennms.netmgt.provision.persist.requisition.RequisitionNode;
 import org.opennms.smoketest.containers.MinionContainer;
+import org.opennms.smoketest.junit.MinionTests;
 import org.opennms.smoketest.stacks.OpenNMSStack;
 import org.opennms.smoketest.stacks.MinionProfile;
 import org.opennms.smoketest.stacks.StackModel;
@@ -67,6 +69,7 @@ import com.google.common.collect.ImmutableList;
  *
  * @author fooker
  */
+@Category(MinionTests.class)
 public class SyslogOverlappingIpAddressIT {
 
     @ClassRule

--- a/smoke-test/src/test/java/org/opennms/smoketest/minion/TrapIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/minion/TrapIT.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2016 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2016 The OpenNMS Group, Inc.
+ * Copyright (C) 2016-2021 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -41,6 +41,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.opennms.core.criteria.Criteria;
 import org.opennms.core.criteria.CriteriaBuilder;
 import org.opennms.core.utils.InetAddressUtils;
@@ -56,6 +57,7 @@ import org.opennms.netmgt.snmp.SnmpTrapBuilder;
 import org.opennms.netmgt.snmp.SnmpUtils;
 import org.opennms.netmgt.snmp.SnmpV3TrapBuilder;
 import org.opennms.smoketest.stacks.OpenNMSStack;
+import org.opennms.smoketest.junit.MinionTests;
 import org.opennms.smoketest.stacks.NetworkProtocol;
 import org.opennms.smoketest.utils.DaoUtils;
 import org.opennms.smoketest.utils.HibernateDaoFactory;
@@ -68,6 +70,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author seth
  */
+@Category(MinionTests.class)
 public class TrapIT {
     private static final Logger LOG = LoggerFactory.getLogger(TrapIT.class);
 

--- a/smoke-test/src/test/java/org/opennms/smoketest/sentinel/AbstractAdapterIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/sentinel/AbstractAdapterIT.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2018-2018 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2018 The OpenNMS Group, Inc.
+ * Copyright (C) 2018-2021 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -48,6 +48,7 @@ import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.Timeout;
 import org.opennms.core.criteria.CriteriaBuilder;
 import org.opennms.netmgt.dao.api.NodeDao;
@@ -59,8 +60,9 @@ import org.opennms.netmgt.provision.persist.requisition.RequisitionInterface;
 import org.opennms.netmgt.provision.persist.requisition.RequisitionMetaData;
 import org.opennms.netmgt.provision.persist.requisition.RequisitionNode;
 import org.opennms.smoketest.containers.OpenNMSContainer;
-import org.opennms.smoketest.stacks.OpenNMSStack;
+import org.opennms.smoketest.junit.SentinelTests;
 import org.opennms.smoketest.stacks.MinionProfile;
+import org.opennms.smoketest.stacks.OpenNMSStack;
 import org.opennms.smoketest.stacks.StackModel;
 import org.opennms.smoketest.utils.DaoUtils;
 import org.opennms.smoketest.utils.HibernateDaoFactory;
@@ -76,6 +78,7 @@ import io.restassured.response.Response;
 /**
  * Consolidates all non flow telemetry adapter tests
  */
+@Category(SentinelTests.class)
 public abstract class AbstractAdapterIT {
 
     // Helper Object to create a requisition from

--- a/smoke-test/src/test/java/org/opennms/smoketest/sentinel/AbstractFlowIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/sentinel/AbstractFlowIT.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2018-2018 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2018 The OpenNMS Group, Inc.
+ * Copyright (C) 2018-2021 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -38,12 +38,14 @@ import java.util.concurrent.TimeUnit;
 
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.Timeout;
 import org.opennms.netmgt.flows.rest.classification.GroupDTO;
 import org.opennms.netmgt.flows.rest.classification.RuleDTO;
 import org.opennms.netmgt.flows.rest.classification.RuleDTOBuilder;
 import org.opennms.features.jest.client.SearchResultUtils;
 import org.opennms.smoketest.containers.OpenNMSContainer;
+import org.opennms.smoketest.junit.SentinelTests;
 import org.opennms.smoketest.stacks.OpenNMSStack;
 import org.opennms.smoketest.stacks.IpcStrategy;
 import org.opennms.smoketest.stacks.NetworkProtocol;
@@ -66,6 +68,7 @@ import io.searchbox.core.Search;
 import io.searchbox.core.SearchResult;
 import io.searchbox.indices.DeleteIndex;
 
+@Category(SentinelTests.class)
 public abstract class AbstractFlowIT {
 
     @Rule

--- a/smoke-test/src/test/java/org/opennms/smoketest/sentinel/DaoIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/sentinel/DaoIT.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2018-2018 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2018 The OpenNMS Group, Inc.
+ * Copyright (C) 2018-2021 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -40,7 +40,9 @@ import java.util.concurrent.TimeUnit;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.Timeout;
+import org.opennms.smoketest.junit.SentinelTests;
 import org.opennms.smoketest.stacks.OpenNMSStack;
 import org.opennms.smoketest.stacks.SentinelProfile;
 import org.opennms.smoketest.stacks.StackModel;
@@ -50,6 +52,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 // Verifies that all exposed service DAOs can be loaded in a sentinel container
+@Category(SentinelTests.class)
 public class DaoIT {
 
     @Rule

--- a/smoke-test/src/test/java/org/opennms/smoketest/sentinel/KafkaCompressionZSTDFlowIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/sentinel/KafkaCompressionZSTDFlowIT.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2018-2018 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2018 The OpenNMS Group, Inc.
+ * Copyright (C) 2018-2021 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -35,7 +35,9 @@ import java.net.InetSocketAddress;
 
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.opennms.features.jest.client.SearchResultUtils;
+import org.opennms.smoketest.junit.SentinelTests;
 import org.opennms.smoketest.stacks.IpcStrategy;
 import org.opennms.smoketest.stacks.KafkaCompressionStrategy;
 import org.opennms.smoketest.stacks.NetworkProtocol;
@@ -49,6 +51,7 @@ import org.opennms.smoketest.telemetry.Sender;
 import io.searchbox.core.Search;
 import io.searchbox.core.SearchResult;
 
+@Category(SentinelTests.class)
 public class KafkaCompressionZSTDFlowIT {
 
     @ClassRule

--- a/smoke-test/src/test/java/org/opennms/smoketest/sentinel/KeyValueStoresIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/sentinel/KeyValueStoresIT.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2019 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ * Copyright (C) 2019-2021 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -30,13 +30,16 @@ package org.opennms.smoketest.sentinel;
 
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.opennms.smoketest.stacks.IpcStrategy;
+import org.opennms.smoketest.junit.SentinelTests;
 import org.opennms.smoketest.stacks.BlobStoreStrategy;
 import org.opennms.smoketest.stacks.JsonStoreStrategy;
 import org.opennms.smoketest.stacks.OpenNMSStack;
 import org.opennms.smoketest.stacks.StackModel;
 import org.opennms.smoketest.utils.KarafShell;
 
+@Category(SentinelTests.class)
 public class KeyValueStoresIT {
     @ClassRule
     public static final OpenNMSStack stack = OpenNMSStack.withModel(StackModel.newBuilder()

--- a/smoke-test/src/test/java/org/opennms/smoketest/sentinel/SentinelThresholdingIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/sentinel/SentinelThresholdingIT.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2019 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ * Copyright (C) 2019-2021 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -47,12 +47,14 @@ import java.util.stream.Collectors;
 
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.opennms.netmgt.model.OnmsAlarmCollection;
 import org.opennms.netmgt.model.OnmsNode;
 import org.opennms.netmgt.model.OnmsSeverity;
 import org.opennms.netmgt.provision.persist.requisition.RequisitionMetaData;
 import org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.Port;
 import org.opennms.netmgt.telemetry.protocols.jti.adapter.proto.TelemetryTop;
+import org.opennms.smoketest.junit.SentinelTests;
 import org.opennms.smoketest.stacks.BlobStoreStrategy;
 import org.opennms.smoketest.stacks.IpcStrategy;
 import org.opennms.smoketest.stacks.JsonStoreStrategy;
@@ -67,6 +69,7 @@ import org.opennms.smoketest.utils.KarafShell;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@Category(SentinelTests.class)
 public class SentinelThresholdingIT {
     private static final Logger LOG = LoggerFactory.getLogger(SentinelThresholdingIT.class);
     private static final String NODE_IP = "192.168.1.1";

--- a/smoke-test/src/test/java/org/opennms/smoketest/sentinel/SinglePortFlowsIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/sentinel/SinglePortFlowsIT.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2018-2018 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2018 The OpenNMS Group, Inc.
+ * Copyright (C) 2018-2021 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -32,17 +32,16 @@ import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
-import java.util.List;
-import java.util.stream.Collectors;
 
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.opennms.features.jest.client.SearchResultUtils;
-import org.opennms.smoketest.stacks.OpenNMSStack;
+import org.opennms.smoketest.junit.SentinelTests;
 import org.opennms.smoketest.stacks.IpcStrategy;
 import org.opennms.smoketest.stacks.NetworkProtocol;
+import org.opennms.smoketest.stacks.OpenNMSStack;
 import org.opennms.smoketest.stacks.StackModel;
-import org.opennms.smoketest.telemetry.FlowPacket;
 import org.opennms.smoketest.telemetry.FlowTestBuilder;
 import org.opennms.smoketest.telemetry.FlowTester;
 import org.opennms.smoketest.telemetry.Packets;
@@ -51,6 +50,7 @@ import org.opennms.smoketest.telemetry.Sender;
 import io.searchbox.core.Search;
 import io.searchbox.core.SearchResult;
 
+@Category(SentinelTests.class)
 public class SinglePortFlowsIT {
 
     @ClassRule


### PR DESCRIPTION
This doesn't actually solve the issues of NMS-13186, but it helps mitigate them some by speeding up builds and separating things so a rebuild of a failed run doesn't use so many resources.

I will probably backport this to at least as far as `foundation-2019` if it goes well.  I'll do some checking on CircleCI costs first before committing to it anywhere else though.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-13186

