### PR TITLE
NMS-13120: Consider metadata in threshold values.

### DIFF
--- a/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/AbstractThresholdEvaluatorState.java
+++ b/features/collection/thresholding/impl/src/main/java/org/opennms/netmgt/threshd/AbstractThresholdEvaluatorState.java
@@ -55,6 +55,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Strings;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.hash.Hasher;
@@ -195,12 +196,18 @@ public abstract class AbstractThresholdEvaluatorState<T extends AbstractThreshol
         }
         if (threshold.getValue() != null) {
             hasher.putDouble(threshold.getValue());
+        } else if (!Strings.isNullOrEmpty(threshold.getValueString())) {
+            hasher.putString(threshold.getValueString(), StandardCharsets.UTF_8);
         }
         if (threshold.getRearm() != null) {
             hasher.putDouble(threshold.getRearm());
+        } else if (!Strings.isNullOrEmpty(threshold.getRearmString())) {
+            hasher.putString(threshold.getRearmString(), StandardCharsets.UTF_8);
         }
         if (threshold.getTrigger() != null) {
             hasher.putInt(threshold.getTrigger());
+        } else if (!Strings.isNullOrEmpty(threshold.getTriggerString())) {
+            hasher.putString(threshold.getTriggerString(), StandardCharsets.UTF_8);
         }
         return hasher.hash().toString();
     }


### PR DESCRIPTION
Small update to #3336 to take care of metadata in threshold values.
Since metadata support is only added in `27.x` for threshold values this is targetted to `release-27.x`

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-13120

