### PR TITLE
NMS-13201: upgrade Jetty dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1410,7 +1410,7 @@
     <jasperreportsMavenPluginVersion>1.0-beta-4-OPENNMS-20160912-1</jasperreportsMavenPluginVersion>
     <jcifsVersion>1.3.14</jcifsVersion>
     <jcommonVersion>1.0.23</jcommonVersion>
-    <jettyVersion>9.4.34.v20201102</jettyVersion>
+    <jettyVersion>9.4.38.v20210224</jettyVersion>
     <jfreechartVersion>1.0.19</jfreechartVersion>
     <jinteropVersion>2.0.8</jinteropVersion>
     <jldapVersion>4.3</jldapVersion>


### PR DESCRIPTION
This PR bumps our Jetty to the latest 9.4 version.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-13201

