### PR TITLE
NMS-13157: Assure that colons are properly escaped every time

### DIFF
--- a/features/timeseries/src/main/java/org/opennms/netmgt/timeseries/resource/TimeseriesSearcher.java
+++ b/features/timeseries/src/main/java/org/opennms/netmgt/timeseries/resource/TimeseriesSearcher.java
@@ -120,7 +120,7 @@ public class TimeseriesSearcher {
         // in order not to call the TimeseriesStorage implementation for every resource, we query all resources below a certain
         // depth (defined as WILDCARD_INDEX_NO). We have a special index, the "wildcard" index for that.
         if (path.elements().length >= WILDCARD_INDEX_NO) {
-            String wildcardPath = String.join(":", Arrays.asList(path.elements()).subList(0, WILDCARD_INDEX_NO));
+            String wildcardPath = toResourceId(ResourcePath.get(Arrays.asList(path.elements()).subList(0, WILDCARD_INDEX_NO)));
             Set<Metric> metricsFromWildcard = getMetricsBelowWildcardPath(wildcardPath);
             for (Metric metric : metricsFromWildcard) {
                 metric.getMetaTags().stream()


### PR DESCRIPTION
* JIRA: https://issues.opennms.org/browse/NMS-13157

The issue was really tricky. The error pattern was as follows: For nodes queried directly via OpenNMS, no response graphs of IPv6 addresses appeared at all, i.e. there were no errors at all. It just seemed that they were simply not present. In the case a Minion was used the response time graphs for IPv6 interfaces were listed but the graphs gave "Query failed." error messages.

It was actually a combination of two errors. In one special case the search()-method of the TimeseriesSearcher class did only line up the path elements without escaping the colons. Furthermore, the cortex plugin did not escape the backslashes itself. This resulted to a query error sind the backslash is the escape character itself and needs to be escaped by a backslash itself.

A second PR exists for the changes in the cortex plugin:
* PR: https://github.com/OpenNMS/opennms-cortex-tss-plugin/pull/9