### PR TITLE
NMS-13189: Trigger updatedAlarm notification for Ticket state changes

### DIFF
--- a/features/ticketing/daemon/src/main/java/org/opennms/netmgt/ticketd/DefaultTicketerServiceLayer.java
+++ b/features/ticketing/daemon/src/main/java/org/opennms/netmgt/ticketd/DefaultTicketerServiceLayer.java
@@ -355,6 +355,6 @@ public class DefaultTicketerServiceLayer implements TicketerServiceLayer, Initia
     }
 
     public void setAlarmEntityNotifier(AlarmEntityNotifier alarmEntityNotifier) {
-        this.m_alarmEntityNotifier = alarmEntityNotifier;
+        m_alarmEntityNotifier = alarmEntityNotifier;
     }
 }

--- a/features/ticketing/daemon/src/main/java/org/opennms/netmgt/ticketd/DefaultTicketerServiceLayer.java
+++ b/features/ticketing/daemon/src/main/java/org/opennms/netmgt/ticketd/DefaultTicketerServiceLayer.java
@@ -111,6 +111,7 @@ public class DefaultTicketerServiceLayer implements TicketerServiceLayer, Initia
      */
     /** {@inheritDoc} */
     @Override
+    @Transactional
     public void cancelTicketForAlarm(int alarmId, String ticketId) {
         OnmsAlarm alarm = m_alarmDao.get(alarmId);
         if (alarm == null) {
@@ -158,6 +159,7 @@ public class DefaultTicketerServiceLayer implements TicketerServiceLayer, Initia
      */
     /** {@inheritDoc} */
     @Override
+    @Transactional
     public void closeTicketForAlarm(int alarmId, String ticketId) {
         OnmsAlarm alarm = m_alarmDao.get(alarmId);
         if (alarm == null) {
@@ -277,6 +279,7 @@ public class DefaultTicketerServiceLayer implements TicketerServiceLayer, Initia
      */
     /** {@inheritDoc} */
     @Override
+    @Transactional
     public void updateTicketForAlarm(int alarmId, String ticketId) {
         OnmsAlarm alarm = m_alarmDao.get(alarmId);
         if (alarm == null) {

--- a/opennms-alarms/daemon/pom.xml
+++ b/opennms-alarms/daemon/pom.xml
@@ -94,6 +94,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.opennms.features.ticketing</groupId>
+      <artifactId>org.opennms.features.ticketing.daemon</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.opennms.core.test-api</groupId>
       <artifactId>org.opennms.core.test-api.db</artifactId>
       <scope>test</scope>

--- a/opennms-alarms/daemon/src/main/java/org/opennms/netmgt/alarmd/AlarmLifecycleListenerManager.java
+++ b/opennms-alarms/daemon/src/main/java/org/opennms/netmgt/alarmd/AlarmLifecycleListenerManager.java
@@ -47,6 +47,7 @@ import org.opennms.netmgt.model.OnmsAlarm;
 import org.opennms.netmgt.model.OnmsMemo;
 import org.opennms.netmgt.model.OnmsReductionKeyMemo;
 import org.opennms.netmgt.model.OnmsSeverity;
+import org.opennms.netmgt.model.TroubleTicketState;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.DisposableBean;
@@ -197,6 +198,11 @@ public class AlarmLifecycleListenerManager implements AlarmEntityListener, Initi
 
     @Override
     public void onRelatedAlarmsUpdated(OnmsAlarm alarm, Set<OnmsAlarm> previousRelatedAlarms) {
+        onNewOrUpdatedAlarm(alarm);
+    }
+
+    @Override
+    public void onTicketStateChanged(OnmsAlarm alarm, TroubleTicketState previousState) {
         onNewOrUpdatedAlarm(alarm);
     }
 

--- a/opennms-alarms/daemon/src/test/java/org/opennms/netmgt/alarmd/TestTicketerPlugin.java
+++ b/opennms-alarms/daemon/src/test/java/org/opennms/netmgt/alarmd/TestTicketerPlugin.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2021 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.alarmd;
+
+import org.opennms.api.integration.ticketing.Plugin;
+import org.opennms.api.integration.ticketing.PluginException;
+import org.opennms.api.integration.ticketing.Ticket;
+
+/*
+ TestTicketerPlugin used in DefaultAlarmTicketerServiceIT
+ */
+public class TestTicketerPlugin implements Plugin {
+
+    private Ticket m_ticket;
+
+    @Override
+    public Ticket get(String ticketId) throws PluginException {
+        if (ticketId.equals("testId")) {
+            return m_ticket;
+        }
+        Ticket ticket = new Ticket();
+        ticket.setId(ticketId);
+        if(ticketId.equals("testId2")) {
+            ticket.setState(Ticket.State.CANCELLED);
+        }
+        return ticket;
+    }
+
+    @Override
+    public void saveOrUpdate(Ticket ticket) throws PluginException {
+        m_ticket = ticket;
+        m_ticket.setId("testId");
+    }
+}

--- a/opennms-alarms/daemon/src/test/java/org/opennms/netmgt/alarmd/drools/DefaultAlarmTicketerServiceIT.java
+++ b/opennms-alarms/daemon/src/test/java/org/opennms/netmgt/alarmd/drools/DefaultAlarmTicketerServiceIT.java
@@ -28,25 +28,35 @@
 
 package org.opennms.netmgt.alarmd.drools;
 
+import static com.jayway.awaitility.Awaitility.await;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
 
+import java.util.Collections;
 import java.util.Date;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.opennms.core.test.OpenNMSJUnit4ClassRunner;
 import org.opennms.core.test.db.annotations.JUnitTemporaryDatabase;
+import org.opennms.netmgt.alarmd.AlarmLifecycleListenerManager;
+import org.opennms.netmgt.alarmd.api.AlarmLifecycleListener;
 import org.opennms.netmgt.dao.api.AlarmDao;
 import org.opennms.netmgt.dao.api.DistPollerDao;
 import org.opennms.netmgt.model.OnmsAlarm;
+import org.opennms.netmgt.model.OnmsSeverity;
+import org.opennms.netmgt.model.TroubleTicketState;
 import org.opennms.test.JUnitConfigurationEnvironment;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.transaction.support.TransactionTemplate;
 
 @RunWith(OpenNMSJUnit4ClassRunner.class)
-@ContextConfiguration(locations={
+@ContextConfiguration(locations = {
         "classpath:/META-INF/opennms/applicationContext-soa.xml",
         "classpath:/META-INF/opennms/applicationContext-commonConfigs.xml",
         "classpath:/META-INF/opennms/applicationContext-minimal-conf.xml",
@@ -54,11 +64,12 @@ import org.springframework.transaction.support.TransactionTemplate;
         "classpath*:/META-INF/opennms/component-dao.xml",
         "classpath:/META-INF/opennms/applicationContext-daemon.xml",
         "classpath:/META-INF/opennms/mockEventIpcManager.xml",
-        "classpath:/META-INF/opennms/applicationContext-alarmd.xml"
+        "classpath:/META-INF/opennms/applicationContext-alarmd.xml",
+        "classpath:/applicationContext-test-troubleTicketer.xml"
 })
 @JUnitConfigurationEnvironment
 @JUnitTemporaryDatabase
-public class DefaultAlarmTicketerServiceIT {
+public class DefaultAlarmTicketerServiceIT implements AlarmLifecycleListener {
 
     @Autowired
     private AlarmDao alarmDao;
@@ -72,8 +83,18 @@ public class DefaultAlarmTicketerServiceIT {
     @Autowired
     private TransactionTemplate transactionTemplate;
 
+    @Autowired
+    private AlarmLifecycleListenerManager alarmLifecycleListenerManager;
+
+    private AtomicBoolean ticketStateUpdated = new AtomicBoolean(false);
+
+    private TroubleTicketState troubleTicketState = null;
+
     @Test
     public void canUpdateLastAutomationTime() {
+
+
+        alarmLifecycleListenerManager.onListenerRegistered(this, Collections.emptyMap());
         // Create some alarm
         OnmsAlarm a1 = transactionTemplate.execute(status -> {
             OnmsAlarm alarm = new OnmsAlarm();
@@ -89,6 +110,10 @@ public class DefaultAlarmTicketerServiceIT {
         // also update the last automation time
         Date now = new Date();
         alarmTicketerService.createTicket(a1, now);
+        // Verifies that ticket state changes gets notified.
+        await().atMost(10, TimeUnit.SECONDS).untilTrue(ticketStateUpdated);
+        // clear again.
+        ticketStateUpdated.set(false);
 
         // Use a separate transaction to verify that the last automation time wa updated
         transactionTemplate.execute(status -> {
@@ -96,5 +121,74 @@ public class DefaultAlarmTicketerServiceIT {
             assertThat(alarmInTrans.getLastAutomationTime().getTime(), equalTo(now.getTime()));
             return null;
         });
+        ticketStateUpdated.set(false);
+
+    }
+
+
+    @Test
+    public void testThatUpdateAndCloseTicketsTriggersAlarmNotification() {
+
+        alarmLifecycleListenerManager.onListenerRegistered(this, Collections.emptyMap());
+        // Create some alarm
+        OnmsAlarm a1 = transactionTemplate.execute(status -> {
+            OnmsAlarm alarm = new OnmsAlarm();
+            alarm.setDistPoller(distPollerDao.whoami());
+            alarm.setCounter(1);
+            alarm.setUei("linkDown");
+            alarm.setLastAutomationTime(new Date(0));
+            alarmDao.saveOrUpdate(alarm);
+            return alarm;
+        });
+        Date now = new Date();
+        // Set different ticket Id that should be in cancelled state.
+        a1.setTTicketId("testId2");
+        alarmTicketerService.updateTicket(a1, now);
+        // Verifies that ticket state changes gets notified.
+        await().atMost(10, TimeUnit.SECONDS).untilTrue(ticketStateUpdated);
+        assertEquals(TroubleTicketState.CANCELLED, troubleTicketState);
+        // clear again
+        ticketStateUpdated.set(false);
+
+        // Close the ticket and verify that ticket state gets notified.
+        a1.setSeverity(OnmsSeverity.CLEARED);
+        transactionTemplate.execute(status -> {
+            alarmDao.saveOrUpdate(a1);
+            return a1;
+        });
+        alarmTicketerService.closeTicket(a1, now);
+        await().atMost(10, TimeUnit.SECONDS).untilTrue(ticketStateUpdated);
+        assertEquals(TroubleTicketState.CLOSED, troubleTicketState);
+        // clear again
+        ticketStateUpdated.set(false);
+
+    }
+
+    @Override
+    public void handleAlarmSnapshot(List<OnmsAlarm> alarms) {
+
+    }
+
+    @Override
+    public void preHandleAlarmSnapshot() {
+        // pass
+    }
+
+    @Override
+    public void postHandleAlarmSnapshot() {
+        // pass
+    }
+
+    @Override
+    public void handleNewOrUpdatedAlarm(OnmsAlarm alarm) {
+        if (alarm.getTTicketState() != null) {
+            ticketStateUpdated.set(true);
+            troubleTicketState = alarm.getTTicketState();
+        }
+    }
+
+    @Override
+    public void handleDeletedAlarm(int alarmId, String reductionKey) {
+
     }
 }

--- a/opennms-alarms/daemon/src/test/resources/applicationContext-test-troubleTicketer.xml
+++ b/opennms-alarms/daemon/src/test/resources/applicationContext-test-troubleTicketer.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans
+        xmlns="http://www.springframework.org/schema/beans"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns:context="http://www.springframework.org/schema/context"
+        xmlns:tx="http://www.springframework.org/schema/tx"
+        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx.xsd">
+
+  <!-- ApplicationContext for the TicketerPlugin -->
+  <context:annotation-config />
+  <tx:annotation-driven/>
+
+
+  <bean name="testTicketerPlugin" class="org.opennms.netmgt.alarmd.TestTicketerPlugin">
+  </bean>
+
+  <bean name="ticketerPlugin" class="org.opennms.netmgt.ticketd.TicketerPluginFactory">
+    <property name="pluginClass" value="org.opennms.netmgt.alarmd.TestTicketerPlugin"/>
+  </bean>
+
+  <bean name="ticketerServiceLayer" class="org.opennms.netmgt.ticketd.DefaultTicketerServiceLayer">
+    <property name="ticketerPlugin" ref="ticketerPlugin"/>
+  </bean>
+
+  <bean name="troubleTicketer" class="org.opennms.netmgt.ticketd.TroubleTicketer">
+    <property name="eventIpcManager" ref="mockEventIpcManager"/>
+    <property name="ticketerServiceLayer" ref="ticketerServiceLayer" />
+  </bean>
+
+</beans>
+
+

--- a/opennms-base-assembly/src/main/filtered/etc/alarmd/drools-rules.d/alarmd.drl
+++ b/opennms-base-assembly/src/main/filtered/etc/alarmd/drools-rules.d/alarmd.drl
@@ -172,7 +172,6 @@ rule "closeClearedAlarmTickets"
     $sessionClock : SessionClock()
     $ticketer : AlarmTicketerService(isTicketingEnabled() == true)
     $alarm : OnmsAlarm(severity == OnmsSeverity.CLEARED &&
-                       alarmType == OnmsAlarm.PROBLEM_TYPE &&
                        TTicketState == TroubleTicketState.OPEN)
     not( OnmsAlarm( this == $alarm ) over window:time( 15m ) )
   then

--- a/opennms-dao-api/src/main/java/org/opennms/netmgt/dao/api/AlarmEntityListener.java
+++ b/opennms-dao-api/src/main/java/org/opennms/netmgt/dao/api/AlarmEntityListener.java
@@ -35,6 +35,7 @@ import org.opennms.netmgt.model.OnmsAlarm;
 import org.opennms.netmgt.model.OnmsMemo;
 import org.opennms.netmgt.model.OnmsReductionKeyMemo;
 import org.opennms.netmgt.model.OnmsSeverity;
+import org.opennms.netmgt.model.TroubleTicketState;
 
 /**
  * Used to get callbacks when alarm entities are created, updated and/or deleted.
@@ -68,5 +69,7 @@ public interface AlarmEntityListener {
     void onLastAutomationTimeUpdated(OnmsAlarm alarm, Date previousLastAutomationTime);
 
     void onRelatedAlarmsUpdated(OnmsAlarm alarm, Set<OnmsAlarm> previousRelatedAlarms);
+
+    void onTicketStateChanged(OnmsAlarm alarm, TroubleTicketState previousState);
 
 }

--- a/opennms-dao-api/src/main/java/org/opennms/netmgt/dao/api/AlarmEntityNotifier.java
+++ b/opennms-dao-api/src/main/java/org/opennms/netmgt/dao/api/AlarmEntityNotifier.java
@@ -35,6 +35,7 @@ import org.opennms.netmgt.model.OnmsAlarm;
 import org.opennms.netmgt.model.OnmsMemo;
 import org.opennms.netmgt.model.OnmsReductionKeyMemo;
 import org.opennms.netmgt.model.OnmsSeverity;
+import org.opennms.netmgt.model.TroubleTicketState;
 
 /**
  * This interface provide functions that should be called
@@ -75,5 +76,7 @@ public interface AlarmEntityNotifier {
     void didUpdateLastAutomationTime(OnmsAlarm alarm, Date previousLastAutomationTime);
 
     void didUpdateRelatedAlarms(OnmsAlarm alarm, Set<OnmsAlarm> previousRelatedAlarms);
+
+    void didChangeTicketStateForAlarm(OnmsAlarm alarm, TroubleTicketState previousState);
 
 }

--- a/opennms-dao-api/src/main/java/org/opennms/netmgt/dao/api/DefaultAlarmEntityListener.java
+++ b/opennms-dao-api/src/main/java/org/opennms/netmgt/dao/api/DefaultAlarmEntityListener.java
@@ -35,6 +35,7 @@ import org.opennms.netmgt.model.OnmsAlarm;
 import org.opennms.netmgt.model.OnmsMemo;
 import org.opennms.netmgt.model.OnmsReductionKeyMemo;
 import org.opennms.netmgt.model.OnmsSeverity;
+import org.opennms.netmgt.model.TroubleTicketState;
 
 public class DefaultAlarmEntityListener implements AlarmEntityListener {
     @Override
@@ -99,6 +100,11 @@ public class DefaultAlarmEntityListener implements AlarmEntityListener {
 
     @Override
     public void onRelatedAlarmsUpdated(OnmsAlarm alarm, Set<OnmsAlarm> previousRelatedAlarms) {
+
+    }
+
+    @Override
+    public void onTicketStateChanged(OnmsAlarm alarm, TroubleTicketState previousState) {
 
     }
 }

--- a/opennms-dao/src/main/java/org/opennms/netmgt/dao/support/AlarmEntityNotifierImpl.java
+++ b/opennms-dao/src/main/java/org/opennms/netmgt/dao/support/AlarmEntityNotifierImpl.java
@@ -39,6 +39,7 @@ import org.opennms.netmgt.model.OnmsAlarm;
 import org.opennms.netmgt.model.OnmsMemo;
 import org.opennms.netmgt.model.OnmsReductionKeyMemo;
 import org.opennms.netmgt.model.OnmsSeverity;
+import org.opennms.netmgt.model.TroubleTicketState;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -113,6 +114,11 @@ public class AlarmEntityNotifierImpl implements AlarmEntityNotifier {
     @Override
     public void didUpdateRelatedAlarms(OnmsAlarm alarm, Set<OnmsAlarm> previousRelatedAlarms) {
         forEachListener(l -> l.onRelatedAlarmsUpdated(alarm, previousRelatedAlarms));
+    }
+
+    @Override
+    public void didChangeTicketStateForAlarm(OnmsAlarm alarm, TroubleTicketState previousState) {
+        forEachListener(l -> l.onTicketStateChanged(alarm, previousState));
     }
 
     private void forEachListener(Consumer<AlarmEntityListener> callback) {


### PR DESCRIPTION
Currently ticket state changes doesn't trigger any  `AlarmLifeCycleListener` changes needed to insert the updated alarm into drools again.
This results in some bugs in ticketing related workflow in Alarmd drools rules.

Hopefully this PR should fix those bugs.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-13189

