### PR TITLE
NMS-13208: suppress Kafka logging for unknown config

### DIFF
--- a/container/karaf/src/main/filtered-resources/etc/org.ops4j.pax.logging.cfg
+++ b/container/karaf/src/main/filtered-resources/etc/org.ops4j.pax.logging.cfg
@@ -59,6 +59,10 @@ log4j2.logger.audit.level = INFO
 log4j2.logger.audit.additivity = false
 log4j2.logger.audit.appenderRef.AuditRollingFile.ref = AuditRollingFile
 
+# OPENNMS: ignore spurious "was supplied but isn't a known config" warnings from Kafka
+log4j2.logger.kafkaAdminClientConfig.name = org.apache.kafka.clients.admin.AdminClientConfig
+log4j2.logger.kafkaAdminClientConfig.level = ERROR
+
 # OPENNMS: Reduce topology logging to WARN
 log4j2.logger.opennmsTopology.name = org.opennms.features.topology
 log4j2.logger.opennmsTopology.level = WARN


### PR DESCRIPTION
This PR suppresses some logging from Kafka for config entries it doesn't known about (that are set for other things).

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-13208

