### PR TITLE
NMS-13217: make trapd config refresh time configurable

### DIFF
--- a/features/events/traps/src/main/resources/OSGI-INF/blueprint/blueprint-trapd-listener.xml
+++ b/features/events/traps/src/main/resources/OSGI-INF/blueprint/blueprint-trapd-listener.xml
@@ -22,6 +22,7 @@
 			<cm:property name="trapd.queue.size" value="10000" />
 			<cm:property name="trapd.batch.size" value="1000" />
 			<cm:property name="trapd.batch.interval" value="500" />
+			<cm:property name="trapd.config.interval" value="60000" />
 		</cm:default-properties>
 	</cm:property-placeholder>
 
@@ -54,9 +55,8 @@
 	<!-- The TrapdConfiguration is retreived via the OpenNMS ReST API every n ms and merged with the trapdConfiguration by invoking "trapdConfig.onUpdate"-->
 	<!-- @see http://www.davsclaus.com/2012/06/locking-down-jmx-naming-now-easier-with.html -->
 	<camelContext id="trapdListenerContext" managementNamePattern="#name#" xmlns="http://camel.apache.org/schema/blueprint">
-		<propertyPlaceholder id="minionproperties" location="blueprint:minionProperties" />
 		<route id="restClientToTrapdConfig">
-			<from uri="timer://restTrapConfigurationTimer?fixedRate=true&amp;period=60000"/>
+			<from uri="timer://restTrapConfigurationTimer?fixedRate=true&amp;period={{trapd.config.interval}}"/>
 			<bean ref="restClient" method="getSnmpV3Users"/>
 			<bean ref="unmarshaller" />
 			<bean ref="trapListener" method="setSnmpV3Users" />


### PR DESCRIPTION
Update the `restTrapConfigurationTimer` so that the interval is configurable.

Note: as soon as I started using a property for this, the `minionproperties` placeholder broke.  I suspect it wasn't even being called at runtime previously since there were no properties referenced in the `camelContext` anyway, but it didn't actively fail until we tried to resolve dynamic values.  As far as I can tell, no minion properties are used directly in the related code, except in places where those properties are already configured/defined.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-13217