### PR TITLE
NMS-13210: Add flag to clear %dpname% variable

### DIFF
--- a/features/events/daemon/src/main/java/org/opennms/netmgt/eventd/StandardExpandableParameterResolvers.java
+++ b/features/events/daemon/src/main/java/org/opennms/netmgt/eventd/StandardExpandableParameterResolvers.java
@@ -93,6 +93,7 @@ public enum StandardExpandableParameterResolvers implements ExpandableParameterR
     },
 
     DPNAME {
+        final boolean clearDpName = Boolean.getBoolean("org.opennms.netmgt.eventd.cleardpname");
 
         @Override
         public boolean matches(String parm) {
@@ -101,6 +102,9 @@ public enum StandardExpandableParameterResolvers implements ExpandableParameterR
 
         @Override
         public String getValue(String parm, String parsedParm, Event event, EventUtil eventUtil) {
+            if (clearDpName) {
+                return "";
+            }
             return event.getDistPoller();
         }
     },

--- a/opennms-base-assembly/src/main/filtered/etc/opennms.properties
+++ b/opennms-base-assembly/src/main/filtered/etc/opennms.properties
@@ -888,4 +888,8 @@ org.opennms.newts.nan_on_counter_wrap=true
 # By default this option is disabled.
 # org.opennms.features.telemetry.ingressAndEgressRequired=false
 
+# The use of multiple Minions in one location can break the alarm life-cycle for a some OpenNMS features.
+# To avoid this problem, the %dpname% value can always be replaced by an empty string. By default this fix is disabled.
+# Check NMS-13210 for details.
+# org.opennms.netmgt.eventd.cleardpname=false
 

--- a/opennms-base-assembly/src/main/filtered/etc/opennms.properties
+++ b/opennms-base-assembly/src/main/filtered/etc/opennms.properties
@@ -888,8 +888,4 @@ org.opennms.newts.nan_on_counter_wrap=true
 # By default this option is disabled.
 # org.opennms.features.telemetry.ingressAndEgressRequired=false
 
-# The use of multiple Minions in one location can break the alarm life-cycle for a some OpenNMS features.
-# To avoid this problem, the %dpname% value can always be replaced by an empty string. By default this fix is disabled.
-# Check NMS-13210 for details.
-# org.opennms.netmgt.eventd.cleardpname=false
 

--- a/opennms-doc/guide-admin/src/asciidoc/text/events/event-configuration.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/events/event-configuration.adoc
@@ -143,6 +143,10 @@ Not all events will have values for all tokens, and some refer specifically to i
 `%primaryinterface%`::
 The primary interface IP address for the node given in `%nodeid%` if available.
 
+CAUTION: The use of multiple _Minions_ in one location can break the alarm life-cycle for a some _OpenNMS_ features.
+To avoid this problem, the `%dpname%` value can always be replaced by an empty string by setting
+`org.opennms.netmgt.eventd.cleardpname` to `true` in the file `opennms.properties`.
+
 .Asset tokens
 A node may have additional asset records stored for it.
 You can access these records using the `asset` replacement token, which takes the form:


### PR DESCRIPTION
* JIRA: https://issues.opennms.org/browse/NMS-13210

The plan is as follows:
* add flag to clear the %dpname% in foundation-2020, default is false
* remove the flag in develop and always clear %dpname%

So, when this one is merged I'll add another PR to make the changes in develop.