### PR TITLE
 NMS-13215: Fallback config for flow timeouts

### DIFF
--- a/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/IpfixTcpParser.java
+++ b/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/IpfixTcpParser.java
@@ -51,13 +51,20 @@ import io.netty.buffer.ByteBuf;
 
 public class IpfixTcpParser extends ParserBase implements TcpParser {
 
+    private final IpFixMessageBuilder messageBuilder = new IpFixMessageBuilder();
+
     public IpfixTcpParser(final String name,
                           final AsyncDispatcher<TelemetryMessage> dispatcher,
                           final EventForwarder eventForwarder,
                           final Identity identity,
                           final DnsResolver dnsResolver,
                           final MetricRegistry metricRegistry) {
-        super(Protocol.IPFIX, name, new IpFixMessageBuilder(), dispatcher, eventForwarder, identity, dnsResolver, metricRegistry);
+        super(Protocol.IPFIX, name, dispatcher, eventForwarder, identity, dnsResolver, metricRegistry);
+    }
+
+    @Override
+    public IpFixMessageBuilder getMessageBuilder() {
+        return this.messageBuilder;
     }
 
     @Override
@@ -97,5 +104,21 @@ public class IpfixTcpParser extends ParserBase implements TcpParser {
             @Override
             public void inactive() {}
         };
+    }
+
+    public Long getFlowActiveTimeoutFallback() {
+        return this.messageBuilder.getFlowActiveTimeoutFallback();
+    }
+
+    public void setFlowActiveTimeoutFallback(final Long flowActiveTimeoutFallback) {
+        this.messageBuilder.setFlowActiveTimeoutFallback(flowActiveTimeoutFallback);
+    }
+
+    public Long getFlowInactiveTimeoutFallback() {
+        return this.messageBuilder.getFlowInactiveTimeoutFallback();
+    }
+
+    public void setFlowInactiveTimeoutFallback(final Long flowInactiveTimeoutFallback) {
+        this.messageBuilder.setFlowInactiveTimeoutFallback(flowInactiveTimeoutFallback);
     }
 }

--- a/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/IpfixUdpParser.java
+++ b/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/IpfixUdpParser.java
@@ -57,13 +57,19 @@ import io.netty.buffer.ByteBuf;
 
 public class IpfixUdpParser extends UdpParserBase implements UdpParser, Dispatchable {
 
+    private final IpFixMessageBuilder messageBuilder = new IpFixMessageBuilder();
+
     public IpfixUdpParser(final String name,
                           final AsyncDispatcher<TelemetryMessage> dispatcher,
                           final EventForwarder eventForwarder,
                           final Identity identity,
                           final DnsResolver dnsResolver,
                           final MetricRegistry metricRegistry) {
-        super(Protocol.IPFIX, name, new IpFixMessageBuilder(), dispatcher, eventForwarder, identity, dnsResolver, metricRegistry);
+        super(Protocol.IPFIX, name, dispatcher, eventForwarder, identity, dnsResolver, metricRegistry);
+    }
+
+    public IpFixMessageBuilder getMessageBuilder() {
+        return this.messageBuilder;
     }
 
     @Override
@@ -125,4 +131,19 @@ public class IpfixUdpParser extends UdpParserBase implements UdpParser, Dispatch
 
     }
 
+    public Long getFlowActiveTimeoutFallback() {
+        return this.messageBuilder.getFlowActiveTimeoutFallback();
+    }
+
+    public void setFlowActiveTimeoutFallback(final Long flowActiveTimeoutFallback) {
+        this.messageBuilder.setFlowActiveTimeoutFallback(flowActiveTimeoutFallback);
+    }
+
+    public Long getFlowInactiveTimeoutFallback() {
+        return this.messageBuilder.getFlowInactiveTimeoutFallback();
+    }
+
+    public void setFlowInactiveTimeoutFallback(final Long flowInactiveTimeoutFallback) {
+        this.messageBuilder.setFlowInactiveTimeoutFallback(flowInactiveTimeoutFallback);
+    }
 }

--- a/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/Netflow5UdpParser.java
+++ b/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/Netflow5UdpParser.java
@@ -54,13 +54,19 @@ import io.netty.buffer.ByteBuf;
 
 public class Netflow5UdpParser extends UdpParserBase implements UdpParser, Dispatchable {
 
+    private final Netflow5MessageBuilder messageBuilder = new Netflow5MessageBuilder();
+
     public Netflow5UdpParser(final String name,
                              final AsyncDispatcher<TelemetryMessage> dispatcher,
                              final EventForwarder eventForwarder,
                              final Identity identity,
                              final DnsResolver dnsResolver,
                              final MetricRegistry metricRegistry) {
-        super(Protocol.NETFLOW5, name, new Netflow5MessageBuilder(), dispatcher, eventForwarder, identity, dnsResolver, metricRegistry);
+        super(Protocol.NETFLOW5, name, dispatcher, eventForwarder, identity, dnsResolver, metricRegistry);
+    }
+
+    public Netflow5MessageBuilder getMessageBuilder() {
+        return this.messageBuilder;
     }
 
     @Override

--- a/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/Netflow9UdpParser.java
+++ b/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/Netflow9UdpParser.java
@@ -33,6 +33,7 @@ import static org.opennms.netmgt.telemetry.listeners.utils.BufferUtils.uint16;
 
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.time.Duration;
 
 import org.opennms.core.ipc.sink.api.AsyncDispatcher;
 import org.opennms.distributed.core.api.Identity;
@@ -56,13 +57,20 @@ import com.google.common.base.Objects;
 import io.netty.buffer.ByteBuf;
 
 public class Netflow9UdpParser extends UdpParserBase implements UdpParser, Dispatchable {
+
+    private final Netflow9MessageBuilder messageBuilder = new Netflow9MessageBuilder();
+
     public Netflow9UdpParser(final String name,
                              final AsyncDispatcher<TelemetryMessage> dispatcher,
                              final EventForwarder eventForwarder,
                              final Identity identity,
                              final DnsResolver dnsResolver,
                              final MetricRegistry metricRegistry) {
-        super(Protocol.NETFLOW9, name, new Netflow9MessageBuilder(), dispatcher, eventForwarder, identity, dnsResolver, metricRegistry);
+        super(Protocol.NETFLOW9, name, dispatcher, eventForwarder, identity, dnsResolver, metricRegistry);
+    }
+
+    public Netflow9MessageBuilder getMessageBuilder() {
+        return this.messageBuilder;
     }
 
     @Override
@@ -120,5 +128,21 @@ public class Netflow9UdpParser extends UdpParserBase implements UdpParser, Dispa
         public InetAddress getRemoteAddress() {
             return this.remoteAddress;
         }
+    }
+
+    public Long getFlowActiveTimeoutFallback() {
+        return this.messageBuilder.getFlowActiveTimeoutFallback();
+    }
+
+    public void setFlowActiveTimeoutFallback(final Long flowActiveTimeoutFallback) {
+        this.messageBuilder.setFlowActiveTimeoutFallback(flowActiveTimeoutFallback);
+    }
+
+    public Long getFlowInactiveTimeoutFallback() {
+        return this.messageBuilder.getFlowInactiveTimeoutFallback();
+    }
+
+    public void setFlowInactiveTimeoutFallback(final Long flowInactiveTimeoutFallback) {
+        this.messageBuilder.setFlowInactiveTimeoutFallback(flowInactiveTimeoutFallback);
     }
 }

--- a/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/ParserBase.java
+++ b/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/ParserBase.java
@@ -97,8 +97,6 @@ public abstract class ParserBase implements Parser {
 
     private final String name;
 
-    private final MessageBuilder messageBuilder;
-
     private final AsyncDispatcher<TelemetryMessage> dispatcher;
 
     private final EventForwarder eventForwarder;
@@ -147,7 +145,6 @@ public abstract class ParserBase implements Parser {
 
     public ParserBase(final Protocol protocol,
                       final String name,
-                      final MessageBuilder messageBuilder,
                       final AsyncDispatcher<TelemetryMessage> dispatcher,
                       final EventForwarder eventForwarder,
                       final Identity identity,
@@ -155,7 +152,6 @@ public abstract class ParserBase implements Parser {
                       final MetricRegistry metricRegistry) {
         this.protocol = Objects.requireNonNull(protocol);
         this.name = Objects.requireNonNull(name);
-        this.messageBuilder = Objects.requireNonNull(messageBuilder);
         this.dispatcher = Objects.requireNonNull(dispatcher);
         this.eventForwarder = Objects.requireNonNull(eventForwarder);
         this.identity = Objects.requireNonNull(identity);
@@ -190,6 +186,8 @@ public abstract class ParserBase implements Parser {
         setIllegalFlowEventRate(DEFAULT_ILLEGAL_FLOW_EVENT_RATE_SECONDS);
         setThreads(DEFAULT_NUM_THREADS);
     }
+
+    protected abstract MessageBuilder getMessageBuilder();
 
     @Override
     public void start(ScheduledExecutorService executorService) {
@@ -325,7 +323,7 @@ public abstract class ParserBase implements Parser {
                         // Let's serialize
                         final FlowMessage.Builder flowMessage;
                         try {
-                            flowMessage = this.messageBuilder.buildMessage(record, enrichment);
+                            flowMessage = this.getMessageBuilder().buildMessage(record, enrichment);
                         } catch (final  Exception e) {
                             throw new RuntimeException(e);
                         }

--- a/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/UdpParserBase.java
+++ b/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/UdpParserBase.java
@@ -66,13 +66,12 @@ public abstract class UdpParserBase extends ParserBase implements UdpParser {
 
     public UdpParserBase(final Protocol protocol,
                          final String name,
-                         final MessageBuilder messageBuilder,
                          final AsyncDispatcher<TelemetryMessage> dispatcher,
                          final EventForwarder eventForwarder,
                          final Identity identity,
                          final DnsResolver dnsResolver,
                          final MetricRegistry metricRegistry) {
-        super(protocol, name, messageBuilder, dispatcher, eventForwarder, identity, dnsResolver, metricRegistry);
+        super(protocol, name, dispatcher, eventForwarder, identity, dnsResolver, metricRegistry);
 
         this.packetsReceived = metricRegistry.meter(MetricRegistry.name("parsers",  name, "packetsReceived"));
         this.parserErrors = metricRegistry.counter(MetricRegistry.name("parsers",  name, "parserErrors"));

--- a/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/transport/IpFixMessageBuilder.java
+++ b/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/transport/IpFixMessageBuilder.java
@@ -54,6 +54,9 @@ import com.google.common.primitives.UnsignedLong;
 
 public class IpFixMessageBuilder implements MessageBuilder {
 
+    private Long flowActiveTimeoutFallback;
+    private Long flowInactiveTimeoutFallback;
+
     public IpFixMessageBuilder() {
     }
 
@@ -117,8 +120,8 @@ public class IpFixMessageBuilder implements MessageBuilder {
         Long dot1qCustomerVlanId = null;
         Long postDot1qVlanId = null;
         Long postDot1qCustomerVlanId = null;
-        Long flowActiveTimeout = null;
-        Long flowInactiveTimeout = null;
+        Long flowActiveTimeout = this.flowActiveTimeoutFallback;
+        Long flowInactiveTimeout = this.flowInactiveTimeoutFallback;
 
         for (Value<?> value : values) {
             switch (value.getName()) {
@@ -579,5 +582,21 @@ public class IpFixMessageBuilder implements MessageBuilder {
 
         builder.setNetflowVersion(NetflowVersion.IPFIX);
         return builder;
+    }
+
+    public Long getFlowActiveTimeoutFallback() {
+        return this.flowActiveTimeoutFallback;
+    }
+
+    public void setFlowActiveTimeoutFallback(final Long flowActiveTimeoutFallback) {
+        this.flowActiveTimeoutFallback = flowActiveTimeoutFallback;
+    }
+
+    public Long getFlowInactiveTimeoutFallback() {
+        return this.flowInactiveTimeoutFallback;
+    }
+
+    public void setFlowInactiveTimeoutFallback(final Long flowInactiveTimeoutFallback) {
+        this.flowInactiveTimeoutFallback = flowInactiveTimeoutFallback;
     }
 }

--- a/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/transport/Netflow9MessageBuilder.java
+++ b/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/transport/Netflow9MessageBuilder.java
@@ -49,6 +49,9 @@ import org.opennms.netmgt.telemetry.protocols.netflow.transport.SamplingAlgorith
 
 public class Netflow9MessageBuilder implements MessageBuilder {
 
+    private Long flowActiveTimeoutFallback;
+    private Long flowInactiveTimeoutFallback;
+
     public Netflow9MessageBuilder() {
     }
 
@@ -70,8 +73,8 @@ public class Netflow9MessageBuilder implements MessageBuilder {
         Long ipv6SrcMask = null;
         Long srcVlan = null;
         Long dstVlan = null;
-        Long flowActiveTimeout = null;
-        Long flowInActiveTimeout = null;
+        Long flowActiveTimeout = this.flowActiveTimeoutFallback;
+        Long flowInActiveTimeout = this.flowInactiveTimeoutFallback;
         Long sysUpTime = null;
         Long unixSecs = null;
         Long firstSwitched = null;
@@ -292,5 +295,21 @@ public class Netflow9MessageBuilder implements MessageBuilder {
 
         builder.setNetflowVersion(NetflowVersion.V9);
         return builder;
+    }
+
+    public Long getFlowActiveTimeoutFallback() {
+        return this.flowActiveTimeoutFallback;
+    }
+
+    public void setFlowActiveTimeoutFallback(final Long flowActiveTimeoutFallback) {
+        this.flowActiveTimeoutFallback = flowActiveTimeoutFallback;
+    }
+
+    public Long getFlowInactiveTimeoutFallback() {
+        return this.flowInactiveTimeoutFallback;
+    }
+
+    public void setFlowInactiveTimeoutFallback(final Long flowInactiveTimeoutFallback) {
+        this.flowInactiveTimeoutFallback = flowInactiveTimeoutFallback;
     }
 }

--- a/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/transport/Timeout.java
+++ b/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/transport/Timeout.java
@@ -28,8 +28,6 @@
 
 package org.opennms.netmgt.telemetry.protocols.netflow.parser.transport;
 
-import java.util.Optional;
-
 public class Timeout {
 
     private final Long flowActiveTimeout;
@@ -61,7 +59,6 @@ public class Timeout {
         this.lastSwitched = lastSwitched;
     }
 
-
     public Long getDeltaSwitched() {
         if (flowActiveTimeout != null && flowInActiveTimeout != null) {
             long active = flowActiveTimeout * 1000;
@@ -70,10 +67,11 @@ public class Timeout {
             long numPackets = this.numPackets != null ? this.numPackets : 0;
             long firstSwitched = this.firstSwitched != null ? this.firstSwitched: 0;
             long lastSwitched = this.lastSwitched != null ? this.lastSwitched : 0;
-            return Optional.of(this)
-                    .map(timeoutValue -> (numBytes > 0 || numPackets > 0) ? active : inActive)
-                    .map(timeoutValue -> lastSwitched - timeoutValue)
-                    .map(t -> Math.max(firstSwitched, t)).orElse(firstSwitched);
+
+            long timeout = (numBytes > 0 || numPackets > 0) ? active : inActive;
+            long delta = lastSwitched - timeout;
+
+            return Math.max(firstSwitched, delta);
         }
         return firstSwitched;
     }

--- a/features/telemetry/protocols/netflow/parser/src/test/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/ClockSkewTest.java
+++ b/features/telemetry/protocols/netflow/parser/src/test/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/ClockSkewTest.java
@@ -170,12 +170,17 @@ public class ClockSkewTest {
     private class ParserBaseExt extends ParserBase {
 
         public ParserBaseExt(Protocol protocol, String name, AsyncDispatcher<TelemetryMessage> dispatcher, EventForwarder eventForwarder, Identity identity, DnsResolver dnsResolver, MetricRegistry metricRegistry) {
-            super(protocol, name, new MessageBuilder() {
+            super(protocol, name, dispatcher, eventForwarder, identity, dnsResolver, metricRegistry);
+        }
+
+        @Override
+        protected MessageBuilder getMessageBuilder() {
+            return new MessageBuilder() {
                 @Override
                 public FlowMessage.Builder buildMessage(final Iterable<Value<?>> values, final RecordEnrichment enrichment) {
                     return FlowMessage.newBuilder();
                 }
-            }, dispatcher, eventForwarder, identity, dnsResolver, metricRegistry);
+            };
         }
     }
 }

--- a/opennms-doc/guide-admin/src/asciidoc/text/telemetryd/protocols/ipfix.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/telemetryd/protocols/ipfix.adoc
@@ -29,6 +29,8 @@ The IPFIX UDP Parser supports protocol detection.
 | `clockSkewEventRate`  | Used to rate-limit clock skew events in seconds.                           | no       | 3600
 | `dnsLookupsEnabled`      | Used to enable or disable DNS resolution for flows.                        | no       | true
 | `sequenceNumberPatience`| A value > 1 enables checking for seuqence number completeness. The value gives the size of the history buffer allowing flows to be processed out of order. | no       | 32
+| `flowActiveTimeoutFallback`   | Fallback value for active flow timeout if setting value is not included in exported flows | no | null
+| `flowInactiveTimeoutFallback`   | Fallback value for inactive flow timeout if setting value is not included in exported flows | no | null
 |===
 
 

--- a/opennms-doc/guide-admin/src/asciidoc/text/telemetryd/protocols/netflow5.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/telemetryd/protocols/netflow5.adoc
@@ -27,6 +27,8 @@ The Netflow v5 UDP Parser supports protocol detection.
 | `maxClockSkew`        | The maximum delta in seconds between exporter and Minion timestamps.       | no       | 0
 | `clockSkewEventRate`  | Used to rate-limit clock skew events in seconds.                           | no       | 3600
 | `dnsLookupsEnabled`      | Used to enable or disable DNS resolution for flows.                        | no       | true
+| `flowActiveTimeoutFallback`   | Fallback value for active flow timeout if setting value is not included in exported flows | no | null
+| `flowInactiveTimeoutFallback`   | Fallback value for inactive flow timeout if setting value is not included in exported flows | no | null
 |===
 
 [[telemetryd-netflow5-adapter]]

--- a/opennms-doc/guide-admin/src/asciidoc/text/telemetryd/protocols/netflow9.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/telemetryd/protocols/netflow9.adoc
@@ -29,6 +29,8 @@ The Netflow v9 UDP Parser supports protocol detection.
 | `clockSkewEventRate` | Used to rate-limit clock skew events in seconds.                             | no       | 3600
 | `dnsLookupsEnabled`     | Used to enable or disable DNS resolution for flows.                          | no       | true
 | `sequenceNumberPatience`| A value > 1 enables checking for seuqence number completeness. The value gives the size of the history buffer allowing flows to be processed out of order. | no       | 32
+| `flowActiveTimeoutFallback`   | Fallback value for active flow timeout if setting value is not included in exported flows | no | null
+| `flowInactiveTimeoutFallback`   | Fallback value for inactive flow timeout if setting value is not included in exported flows | no | null
 |===
 
 [[telemetryd-netflow9-adapter]]


### PR DESCRIPTION
Some routers do not send active and inactive flow timeout configuration
values even if they are configured on the exporting device. The added
settings allow to configure a fallback for these value per
listener/parser.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-13215

