### PR TITLE
NMS-13210: Clear %dpname% variable

### DIFF
--- a/features/events/daemon/src/main/java/org/opennms/netmgt/eventd/StandardExpandableParameterResolvers.java
+++ b/features/events/daemon/src/main/java/org/opennms/netmgt/eventd/StandardExpandableParameterResolvers.java
@@ -93,8 +93,6 @@ public enum StandardExpandableParameterResolvers implements ExpandableParameterR
     },
 
     DPNAME {
-        final boolean clearDpName = Boolean.getBoolean("org.opennms.netmgt.eventd.cleardpname");
-
         @Override
         public boolean matches(String parm) {
             return AbstractEventUtil.TAG_DPNAME.equals(parm);
@@ -102,10 +100,7 @@ public enum StandardExpandableParameterResolvers implements ExpandableParameterR
 
         @Override
         public String getValue(String parm, String parsedParm, Event event, EventUtil eventUtil) {
-            if (clearDpName) {
-                return "";
-            }
-            return event.getDistPoller();
+            return "";
         }
     },
 

--- a/features/events/daemon/src/test/java/org/opennms/netmgt/eventd/EventUtilIT.java
+++ b/features/events/daemon/src/test/java/org/opennms/netmgt/eventd/EventUtilIT.java
@@ -353,30 +353,11 @@ public class EventUtilIT {
         assertNull("An invalid DateAndTime should return a null", dateInvalid);
     }
 
-    private void setClearDpName(final boolean value) throws Exception {
-        final Field field = StandardExpandableParameterResolvers.DPNAME.getClass().getDeclaredField("clearDpName");
-        field.setAccessible(true);
-        final Field modifiersField = Field.class.getDeclaredField("modifiers");
-        modifiersField.setAccessible(true);
-        modifiersField.setInt(field, field.getModifiers() & ~Modifier.FINAL);
-        field.set(StandardExpandableParameterResolvers.DPNAME, value);
-    }
-
     @Test
-    public void testClearDpNameOn() throws Exception {
-        setClearDpName(true);
+    public void testClearDpName() throws Exception {
         final String minionId = UUID.randomUUID().toString();
         m_svcLostEvent.setDistPoller(minionId);
         String testString = new ExpandableParameter(AbstractEventUtil.TAG_DPNAME, eventUtil).expand(m_svcLostEvent, Maps.newHashMap());
         assertEquals("", testString);
-    }
-
-    @Test
-    public void testClearDpNameOff() throws Exception {
-        setClearDpName(false);
-        final String minionId = UUID.randomUUID().toString();
-        m_svcLostEvent.setDistPoller(minionId);
-        String testString = new ExpandableParameter(AbstractEventUtil.TAG_DPNAME, eventUtil).expand(m_svcLostEvent, Maps.newHashMap());
-        assertEquals(minionId, testString);
     }
 }

--- a/opennms-doc/guide-admin/src/asciidoc/text/events/event-configuration.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/events/event-configuration.adoc
@@ -93,7 +93,7 @@ Not all events will have values for all tokens, and some refer specifically to i
 `%shorttime%`::
     The time of the event formatted using DateFormat.SHORT for a completely numeric date/time.
 `%dpname%`::
-    The ID of the Minion (formerly distributed poller) that the event was received on.
+    Formerly used for the ID of the Minion that the event was received on. This placeholder is deprecated and will be resolved to an empty string.
 `%nodeid%`::
     The numeric node ID of the device that caused the event, if any.
 `%nodelabel%`::
@@ -142,10 +142,6 @@ Not all events will have values for all tokens, and some refer specifically to i
     The trouble ticket id associated with the event if available.
 `%primaryinterface%`::
 The primary interface IP address for the node given in `%nodeid%` if available.
-
-CAUTION: The use of multiple _Minions_ in one location can break the alarm life-cycle for a some _OpenNMS_ features.
-To avoid this problem, the `%dpname%` value can always be replaced by an empty string by setting
-`org.opennms.netmgt.eventd.cleardpname` to `true` in the file `opennms.properties`.
 
 .Asset tokens
 A node may have additional asset records stored for it.


### PR DESCRIPTION
* JIRA: https://issues.opennms.org/browse/NMS-13210

This is the follow-up for NMS-13210 for develop. %dpname% will now return an empty string.