### PR TITLE
NMS-13224: Fix some timing issues with BMP

### DIFF
--- a/container/features/src/main/resources/features.xml
+++ b/container/features/src/main/resources/features.xml
@@ -1021,6 +1021,7 @@
     <feature name="opennms-telemetry-bmp-adapter" version="${project.version}" description="OpenNMS :: Telemetry :: BMP :: Adapter">
         <feature>opennms-telemetry-collection</feature>
         <feature>opennms-kafka</feature>
+        <feature>rate-limited-logger</feature>
         <bundle>mvn:org.opennms.core.ipc.rpc/org.opennms.core.ipc.rpc.utils/${project.version}</bundle>
         <bundle>mvn:org.opennms.features.telemetry.protocols.bmp/org.opennms.features.telemetry.protocols.bmp.adapter/${project.version}</bundle>
         <bundle>mvn:org.opennms.features.telemetry.protocols.bmp/org.opennms.features.telemetry.protocols.bmp.transport/${project.version}</bundle>

--- a/features/telemetry/protocols/adapters/src/main/java/org/opennms/netmgt/telemetry/protocols/collection/AbstractAdapter.java
+++ b/features/telemetry/protocols/adapters/src/main/java/org/opennms/netmgt/telemetry/protocols/collection/AbstractAdapter.java
@@ -31,17 +31,16 @@ package org.opennms.netmgt.telemetry.protocols.collection;
 import static com.codahale.metrics.MetricRegistry.name;
 
 import java.util.Objects;
-import java.util.stream.Stream;
 
 import org.opennms.netmgt.telemetry.api.adapter.Adapter;
 import org.opennms.netmgt.telemetry.api.adapter.TelemetryMessageLog;
 import org.opennms.netmgt.telemetry.api.adapter.TelemetryMessageLogEntry;
 import org.opennms.netmgt.telemetry.config.api.AdapterDefinition;
-import org.osgi.framework.BundleContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.codahale.metrics.Histogram;
+import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
 
@@ -58,6 +57,8 @@ public abstract class AbstractAdapter implements Adapter {
      */
     protected final Histogram packetsPerLogHistogram;
 
+    private final Meter recordsConsumed;
+
     /**
      * A single instance of an adapter will only be responsible for this one config
      */
@@ -71,6 +72,7 @@ public abstract class AbstractAdapter implements Adapter {
 
         this.logParsingTimer = metricRegistry.timer(name("adapters", adapterConfig.getFullName(), "logParsing"));
         this.packetsPerLogHistogram = metricRegistry.histogram(name("adapters", adapterConfig.getFullName(), "packetsPerLog"));
+        this.recordsConsumed = metricRegistry.meter(name("adapters", adapterConfig.getFullName(), "recordsConsumed"));
     }
 
     public abstract void handleMessage(TelemetryMessageLogEntry message, TelemetryMessageLog messageLog);
@@ -82,6 +84,7 @@ public abstract class AbstractAdapter implements Adapter {
                 this.handleMessage(message, messageLog);
             }
             packetsPerLogHistogram.update(messageLog.getMessageList().size());
+            recordsConsumed.mark(messageLog.getMessageList().size());
         }
     }
 

--- a/features/telemetry/protocols/bmp/adapter/pom.xml
+++ b/features/telemetry/protocols/bmp/adapter/pom.xml
@@ -75,6 +75,11 @@
       <artifactId>org.osgi.core</artifactId>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>com.swrve</groupId>
+      <artifactId>rate-limited-logger</artifactId>
+      <version>${rateLimitedLoggerVersion}</version>
+    </dependency>
 
     <!-- Test -->
     <dependency>

--- a/features/telemetry/protocols/bmp/persistence/api/src/main/java/org/opennms/netmgt/telemetry/protocols/bmp/persistence/api/BmpRouter.java
+++ b/features/telemetry/protocols/bmp/persistence/api/src/main/java/org/opennms/netmgt/telemetry/protocols/bmp/persistence/api/BmpRouter.java
@@ -34,6 +34,7 @@ import java.util.LinkedHashSet;
 import java.util.Objects;
 import java.util.Set;
 
+import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
@@ -109,7 +110,7 @@ public class BmpRouter implements Serializable {
     @Column(name = "connection_count")
     private Integer connectionCount;
 
-    @OneToMany(mappedBy="bmpRouter")
+    @OneToMany(mappedBy="bmpRouter", cascade = CascadeType.ALL)
     private Set<BmpPeer> bmpPeers = new LinkedHashSet<>();
 
     @Transient

--- a/opennms-doc/guide-admin/src/asciidoc/text/telemetryd/protocols/bmp.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/telemetryd/protocols/bmp.adoc
@@ -227,3 +227,6 @@ admin@opennms()> feature:install sentinel-telemetry-bmp-persist
 
 <1> needs datasource configuration. Refer to link:#ga-sentinel-persistence[Sentinel Persistence] for configuring datasource.
 <2> or `sentinel-kafka`. Refer to link:#ga-sentinel-kafka[Sentinel Kafka] for configuring Kafka on Sentinel.
+
+NOTE: When running kafka as broker, consumer config needs to have `auto.offset.reset=earliest`setting otherwise
+Bmp Adapter may miss some of the early messages like PeerUp notification which are essential for for proper BMP state.


### PR DESCRIPTION
Sometimes PeerUp notification may come up before Router initiation message.
This may result in peer not getting persisted.
Caching Peers that arrive before Router and persisting them with router should
resolve this.

Also added synchronization around persisting bmp messages.
While running multiple threads within the same session, we may have duplicates
which may result in errors.

Also add Note in doc for BMP,  When Kafka is used. `auto.offset.reset=earliest` need to be set on BMP Adapter.


### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-13224

