### PR TITLE
NMS-13060: Truncate long datasource names to RRD limits

### DIFF
--- a/.circleci/scripts/itest.sh
+++ b/.circleci/scripts/itest.sh
@@ -47,16 +47,22 @@ echo "#### Installing other dependencies"
 # limit the sources we need to update
 sudo rm -f /etc/apt/sources.list.d/*
 # limit more sources and add mirrors
-echo 'deb mirror://mirrors.ubuntu.com/mirrors.txt trusty main restricted universe multiverse
-deb http://archive.ubuntu.com/ubuntu/ trusty main restricted
-deb-src http://archive.ubuntu.com/ubuntu/ trusty main restricted' | sudo tee /etc/apt/sources.list
+echo 'deb mirror://mirrors.ubuntu.com/mirrors.txt xenial main restricted universe multiverse
+deb http://archive.ubuntu.com/ubuntu/ xenial main restricted
+deb http://debian.opennms.org stable main' | sudo tee /etc/apt/sources.list
+
+sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9
+curl -sSf https://debian.opennms.org/OPENNMS-GPG-KEY | sudo apt-key add -
+
+sudo add-apt-repository 'deb [arch=amd64,i386] https://cran.rstudio.com/bin/linux/ubuntu xenial/'
 
 # kill other apt-gets first to avoid problems locking /var/lib/apt/lists/lock - see https://discuss.circleci.com/t/could-not-get-lock-var-lib-apt-lists-lock/28337/6
 sudo killall -9 apt-get || true && \
             sudo apt-get update && \
+            RRDTOOL_VERSION=$(apt-cache show rrdtool | grep Version: | grep -v opennms | awk '{ print $2 }') && \
             sudo apt-get -y install debconf-utils && \
             echo '* libraries/restart-without-asking boolean true' | sudo debconf-set-selections && \
-            sudo env DEBIAN_FRONTEND=noninteractive apt-get install -f R-base rrdtool || exit 1
+            sudo env DEBIAN_FRONTEND=noninteractive apt-get install -f r-base "rrdtool=$RRDTOOL_VERSION" jrrd2 jicmp jicmp6 || exit 1
 
 echo "#### Building Assembly Dependencies"
 ./compile.pl install -P'!checkstyle' \

--- a/features/measurements/impl/src/main/java/org/opennms/netmgt/measurements/impl/JRrd2FetchStrategy.java
+++ b/features/measurements/impl/src/main/java/org/opennms/netmgt/measurements/impl/JRrd2FetchStrategy.java
@@ -73,6 +73,11 @@ public class JRrd2FetchStrategy extends AbstractRrdBasedFetchStrategy {
             final String tempLabel = Integer.toString(++k);
             labelMap.put(tempLabel, source.getLabel());
 
+            // Limit datasource names to 19 chars
+            if (source.getEffectiveDataSource().length() > 19) {
+                source.setDataSource(source.getEffectiveDataSource().substring(0, 19));
+            }
+
             argv.add(String.format("DEF:%s=%s:%s:%s",
                     tempLabel, Utils.escapeColons(rrdFile), Utils.escapeColons(source.getEffectiveDataSource()),
                     source.getAggregation()));

--- a/features/measurements/impl/src/main/java/org/opennms/netmgt/measurements/impl/RrdtoolXportFetchStrategy.java
+++ b/features/measurements/impl/src/main/java/org/opennms/netmgt/measurements/impl/RrdtoolXportFetchStrategy.java
@@ -123,6 +123,11 @@ public class RrdtoolXportFetchStrategy extends AbstractRrdBasedFetchStrategy {
             final String tempLabel = Integer.toString(++k);
             labelMap.put(tempLabel, source.getLabel());
 
+            // Limit datasource names to 19 chars
+            if (source.getEffectiveDataSource().length() > 19) {
+                source.setDataSource(source.getEffectiveDataSource().substring(0, 19));
+            }
+
             cmdLine.addArgument(String.format("DEF:%s=%s:%s:%s",
                     tempLabel, Utils.escapeColons(rrdFile), Utils.escapeColons(source.getEffectiveDataSource()),
                     source.getAggregation()));

--- a/features/measurements/impl/src/test/java/org/opennms/netmgt/measurements/impl/JRrd2FetchStrategyTest.java
+++ b/features/measurements/impl/src/test/java/org/opennms/netmgt/measurements/impl/JRrd2FetchStrategyTest.java
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2010-2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.measurements.impl;
+
+import org.jrobin.core.RrdException;
+import org.junit.Test;
+import org.opennms.netmgt.measurements.model.QueryMetadata;
+import org.opennms.netmgt.measurements.model.Source;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+
+public class JRrd2FetchStrategyTest {
+    @Test
+    public void checkLongDataSourceName() throws RrdException {
+        final JRrd2FetchStrategy fetch = new JRrd2FetchStrategy();
+        final Map<Source, String> rrdsBySource = new HashMap<>();
+
+        String rrdFile = new File("src/test/resources/TlmRecordEnrichmentErrors.rrd").getAbsolutePath();
+        rrdsBySource.put(new Source("TlmRecordEnrichmentErrors","nodeSource[Minion:node1]",
+                "TlmRecordEnrichmentErrors", null, false), rrdFile);
+
+        final Map<String, Object> constants = new HashMap<>();
+        final QueryMetadata metadata = new QueryMetadata();
+
+        fetch.fetchMeasurements(1600000500000L, 1600000800000L, 363, 864,
+                rrdsBySource, constants, metadata);
+    }
+}

--- a/features/measurements/impl/src/test/java/org/opennms/netmgt/measurements/impl/RrdtoolXportFetchStrategyTest.java
+++ b/features/measurements/impl/src/test/java/org/opennms/netmgt/measurements/impl/RrdtoolXportFetchStrategyTest.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2010-2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.measurements.impl;
+
+import org.jrobin.core.RrdException;
+import org.junit.Test;
+import org.opennms.netmgt.measurements.model.QueryMetadata;
+import org.opennms.netmgt.measurements.model.Source;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+
+public class RrdtoolXportFetchStrategyTest {
+    @Test
+    public void checkLongDataSourceName() throws RrdException {
+	System.setProperty("rrd.binary", "rrdtool");
+
+        final RrdtoolXportFetchStrategy fetch = new RrdtoolXportFetchStrategy();
+        final Map<Source, String> rrdsBySource = new HashMap<>();
+
+        String rrdFile = new File("src/test/resources/TlmRecordEnrichmentErrors.rrd").getAbsolutePath();
+        rrdsBySource.put(new Source("TlmRecordEnrichmentErrors","nodeSource[Minion:node1]",
+                "TlmRecordEnrichmentErrors", null, false), rrdFile);
+
+        final Map<String, Object> constants = new HashMap<>();
+        final QueryMetadata metadata = new QueryMetadata();
+
+        fetch.fetchMeasurements(1600000500000L, 1600000800000L, 363, 864,
+                rrdsBySource, constants, metadata);
+    }
+}


### PR DESCRIPTION
The datasource names are trimmed while storing. But queries failed if
long names where used. This truncates the datasource names for queries
in the same way as they are truncated while persisting.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-13060

