### PR TITLE
NMS-13101: consider properties files under opennms.properties.d when starting Minion

### DIFF
--- a/opennms-container/minion/container-fs/entrypoint.sh
+++ b/opennms-container/minion/container-fs/entrypoint.sh
@@ -163,6 +163,14 @@ applyConfd() {
   fi
 }
 
+applyOpennmsPropertiesD() {
+  for filename in ${MINION_HOME}/etc/opennms.properties.d/*.properties; do
+    echo "appending to custom.system.properties: $filename"
+    echo "" >> ${MINION_HOME}/etc/custom.system.properties
+    cat "$filename" >> ${MINION_HOME}/etc/custom.system.properties
+  done
+}
+
 start() {
     export KARAF_EXEC="exec"
     cd ${MINION_HOME}/bin
@@ -187,6 +195,7 @@ runConfd() {
 configure() {
   initConfig
   applyConfd
+  applyOpennmsPropertiesD
   applyOverlayConfig
   if [[ -f "$MINION_PROCESS_ENV_CFG" ]]; then
     while read assignment; do


### PR DESCRIPTION
Issue: https://issues.opennms.org/browse/NMS-13101

The properties files under `opennms.properties.d` are now appended to the `custom.system.properties` file that is loaded by Karaf.