### PR TITLE
NMS-13261: update vaadin and context menu to latest 8.x versions

### DIFF
--- a/features/topology-map/org.opennms.features.topology.app/src/main/java/org/opennms/features/topology/app/internal/menu/TopologyContextMenu.java
+++ b/features/topology-map/org.opennms.features.topology.app/src/main/java/org/opennms/features/topology/app/internal/menu/TopologyContextMenu.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2012-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2012-2021 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -98,7 +98,7 @@ public class TopologyContextMenu extends ContextMenu {
 				this.addItem(
 					eachItem.getText(),
 					eachItem.getIcon(),
-					(Command) selectedItem -> {
+					(MenuBar.Command) selectedItem -> {
 						if (eachItem.getCommand() != null) {
 							eachItem.getCommand().menuSelected(eachItem);
 						}
@@ -106,14 +106,14 @@ public class TopologyContextMenu extends ContextMenu {
 		}
 	}
 
-	private void addItems(ItemAddBehaviour<com.vaadin.contextmenu.MenuItem> behaviour, MenuBar.MenuItem child) {
-		com.vaadin.contextmenu.MenuItem contextMenuItem = behaviour.addItem();
+	private void addItems(ItemAddBehaviour<MenuBar.MenuItem> behaviour, MenuBar.MenuItem child) {
+		MenuBar.MenuItem contextMenuItem = behaviour.addItem();
 		contextMenuItem.setEnabled(child.isEnabled());
 		if (child.isSeparator()) {
 			contextMenuItem.addSeparator();
 		}
 		if (child.getCommand() != null) {
-			contextMenuItem.setCommand((Command) contextMenuItemClickEvent -> child.getCommand().menuSelected(child));
+			contextMenuItem.setCommand((MenuBar.Command) contextMenuItemClickEvent -> child.getCommand().menuSelected(child));
 		}
 		if (child.hasChildren()) {
 			for (MenuBar.MenuItem eachChild : child.getChildren()) {
@@ -121,7 +121,7 @@ public class TopologyContextMenu extends ContextMenu {
 						contextMenuItem.addItem(
 								eachChild.getText(),
 								eachChild.getIcon(),
-								(Command) selectedItem -> {
+								(MenuBar.Command) selectedItem -> {
 									if (eachChild.getCommand() != null) {
 										eachChild.getCommand().menuSelected(eachChild);
 									}

--- a/features/topology-map/org.opennms.features.topology.app/src/test/java/org/opennms/features/topology/app/internal/menu/MenuBuilderTest.java
+++ b/features/topology-map/org.opennms.features.topology.app/src/test/java/org/opennms/features/topology/app/internal/menu/MenuBuilderTest.java
@@ -132,13 +132,13 @@ public class MenuBuilderTest {
         MenuBar menubar = builder.build(Lists.newArrayList(), new TestOperationContext(null));
         TopologyContextMenu contextMenu = new TopologyContextMenu(EasyMock.niceMock(UI.class), menubar);
 
-        final List<com.vaadin.contextmenu.MenuItem> contextMenuItems = contextMenu.getItems();
+        final List<MenuBar.MenuItem> contextMenuItems = contextMenu.getItems();
         assertEquals(1, contextMenuItems.size());
         assertEquals("Layout", contextMenuItems.get(0).getText());
 
-        final List<com.vaadin.contextmenu.MenuItem> subMenuItems = contextMenuItems.get(0).getChildren();
+        final List<MenuBar.MenuItem> subMenuItems = contextMenuItems.get(0).getChildren();
         assertEquals(1, subMenuItems.size());
-        final com.vaadin.contextmenu.MenuItem submenuItem = subMenuItems.get(0);
+        final MenuBar.MenuItem submenuItem = subMenuItems.get(0);
         assertEquals("Test", submenuItem.getText());
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -1506,10 +1506,10 @@
 
     <!-- moved here from topology features -->
     <jungVersion>2.0.1</jungVersion>
-    <vaadinVersion>8.5.2</vaadinVersion>
+    <vaadinVersion>8.12.4</vaadinVersion>
     <!-- Requiring a more recent plugin version which passes the classpath via ENV -->
     <vaadin.plugin.version>${vaadinVersion}</vaadin.plugin.version>
-    <vaadinAddonContextMenuVersion>2.0.0</vaadinAddonContextMenuVersion>
+    <vaadinAddonContextMenuVersion>3.1.0</vaadinAddonContextMenuVersion>
     <vaadinAddonConfirmDialogVersion>3.2.0</vaadinAddonConfirmDialogVersion>
     <vaadinJavaMaxMemory>1g</vaadinJavaMaxMemory>
     <vaadinLocalWorkers>${maxCpus}</vaadinLocalWorkers>


### PR DESCRIPTION
This PR updates our Vaadin to the latest version, and also bumps the context menu to an updated version that works with the latest Vaadin.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/${JIRA-ISSUE-NUMBER}

