### PR TITLE
NMS-12766: Fix race condition when loading event configurations

### DIFF
--- a/core/api/src/main/java/org/opennms/core/config/api/BeanConfigurationProvider.java
+++ b/core/api/src/main/java/org/opennms/core/config/api/BeanConfigurationProvider.java
@@ -58,4 +58,12 @@ public class BeanConfigurationProvider<T> implements ConfigurationProvider {
     public long getLastUpdate() {
         return createdAt;
     }
+
+    @Override
+    public void registeredToConfigReloadContainer() {
+    }
+
+    @Override
+    public void deregisteredFromConfigReloadContainer() {
+    }
 }

--- a/core/api/src/main/java/org/opennms/core/config/api/ConfigReloadContainer.java
+++ b/core/api/src/main/java/org/opennms/core/config/api/ConfigReloadContainer.java
@@ -214,6 +214,7 @@ public class ConfigReloadContainer<V> implements ReloadingContainer<V>, Registra
 
         if (forceReload || providers.stream().anyMatch(ConfigurationProviderState::shouldReload)) {
             reload();
+            forceReload = false;
         }
     }
 

--- a/core/api/src/main/java/org/opennms/core/config/api/ConfigurationProvider.java
+++ b/core/api/src/main/java/org/opennms/core/config/api/ConfigurationProvider.java
@@ -58,4 +58,14 @@ public interface ConfigurationProvider {
      */
     long getLastUpdate();
 
+    /**
+     * Notifies this configuration provider that it was registered with the {@link ConfigReloadContainer}.
+     */
+    void registeredToConfigReloadContainer();
+
+    /**
+     * Notifies this configuration provider that it was unregistered from the {@link ConfigReloadContainer}.
+     */
+    void deregisteredFromConfigReloadContainer();
+
 }

--- a/features/api-layer/src/main/java/org/opennms/features/apilayer/config/ConfigExtensionManager.java
+++ b/features/api-layer/src/main/java/org/opennms/features/apilayer/config/ConfigExtensionManager.java
@@ -46,7 +46,7 @@ import org.slf4j.LoggerFactory;
  * @param <C> configuration bean type
  */
 public abstract class ConfigExtensionManager<E,C> implements ConfigurationProvider {
-    private static final Logger LOG = LoggerFactory.getLogger(EventConfExtensionManager.class);
+    private static final Logger LOG = LoggerFactory.getLogger(ConfigExtensionManager.class);
 
     private final ReadWriteLock rwLock = new ReentrantReadWriteLock();
     private final Set<E> extensions = new LinkedHashSet<>();
@@ -100,6 +100,18 @@ public abstract class ConfigExtensionManager<E,C> implements ConfigurationProvid
         if (didUpdate) {
             triggerReload();
         }
+    }
+
+    @Override
+    public void registeredToConfigReloadContainer() {
+        LOG.debug("registeredToConfigReloadContainer - class: {}; clazz: {}", getClass().getCanonicalName(), clazz.getCanonicalName());
+        triggerReload();
+    }
+
+    @Override
+    public void deregisteredFromConfigReloadContainer() {
+        LOG.debug("registeredToConfigReloadContainer - class: {}; clazz: {}", getClass().getCanonicalName(), clazz.getCanonicalName());
+        triggerReload();
     }
 
     protected abstract C getConfigForExtensions(Set<E> extensions);


### PR DESCRIPTION
Issue: https://issues.opennms.org/browse/NMS-12766

* Triggers configuration reloads after configuration providers get registered/unregisterd with the `ConfigReloadContainer` (this fixes a race condition between provider registration and extension binding; cf. issue)
* Fixes subtle multi-threading issues in `ConfigReloadContainer`
* Fixes a logical error in `ConfigReloadContainer.checkForUpdates`. In case the last provider got unregistered the config object gets now set to `null`
