### PR TITLE
NMS-12767: Situation feedback configuration not loaded

### DIFF
--- a/features/situation-feedback/elastic/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/features/situation-feedback/elastic/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -1,18 +1,13 @@
-<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0"
-           xmlns:ext="http://aries.apache.org/blueprint/xmlns/blueprint-ext/v1.1.0"
-           xsi:schemaLocation="
-		http://www.osgi.org/xmlns/blueprint/v1.0.0
+<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0"
+           xsi:schemaLocation="http://www.osgi.org/xmlns/blueprint/v1.0.0
 		http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd
 
 		http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0
-		http://aries.apache.org/schemas/blueprint-cm/blueprint-cm-1.1.0.xsd
-
-		http://aries.apache.org/blueprint/xmlns/blueprint-ext/v1.1.0
-		http://aries.apache.org/schemas/blueprint-ext/blueprint-ext-1.1.xsd
-">
+		http://aries.apache.org/schemas/blueprint-cm/blueprint-cm-1.1.0.xsd">
 
     <!-- Configuration properties -->
-    <cm:property-placeholder id="elasticSituationFeedbackRepositoryProperties" persistent-id="org.opennms.features.situation-feedback.persistence.elastic" update-strategy="reload">
+    <cm:property-placeholder id="elasticSituationFeedbackRepositoryProperties" persistent-id="org.opennms.features.situationfeedback.persistence.elastic" update-strategy="reload">
         <cm:default-properties>
             <!-- Elastic Connection Settings -->
             <cm:property name="elasticUrl" value="http://localhost:9200" />

--- a/opennms-doc/guide-admin/src/asciidoc/text/alarm-correlation/situation-feedback.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/alarm-correlation/situation-feedback.adoc
@@ -29,12 +29,12 @@ From a Karaf shell on your _{opennms-product-name}_ instance, start by configuri
 ----
 $ ssh -p 8101 admin@localhost
 ...
-admin@opennms()> config:edit org.opennms.features.situation-feedback.persistence.elastic
+admin@opennms()> config:edit org.opennms.features.situationfeedback.persistence.elastic
 admin@opennms()> config:property-set elasticUrl http://elastic:9200
 admin@opennms()> config:update
 ----
 
-NOTE: This configuration is stored in `${OPENNMS_HOME/etc/org.opennms.features.situation-feedback.persistence.elastic.cfg`.
+NOTE: This configuration is stored in `${OPENNMS_HOME/etc/org.opennms.features.situationfeedback.persistence.elastic.cfg`.
       See <<ga-elasticsearch-integration, Elasticsearch Integration>> for more information.
 
 Installing the feature exposes a ReST endpoint that _OpenNMS Helm_ uses to display and submit feedback. 

--- a/opennms-doc/releasenotes/src/asciidoc/releasenotes/whatsnew.adoc
+++ b/opennms-doc/releasenotes/src/asciidoc/releasenotes/whatsnew.adoc
@@ -15,3 +15,7 @@
 Enables single topic by default for Kafka RPC which would reduce number of topics on Kafka.
 Both Minion and OpenNMS need to be updated to OpenNMS Horizon 28.
 Make sure that Kafka Lag on Sink topics be minimal before upgrading otherwise there may be loss of those sink messages.
+
+=== Situation Feedback Persistence Configuration
+
+The configuration file `etc/org.opennms.features.situation-feedback.persistence.elastic.cfg` is renamed into `etc/org.opennms.features.situationfeedback.persistence.elastic.cfg`, i.e. the minus sign is removed from the filename.


### PR DESCRIPTION
Issue: [NMS-12767](https://issues.opennms.org/browse/NMS-12767)

* rename configuration file `org.opennms.features.situation-feedback.persistence.elastic` -> `org.opennms.features.situationfeedback.persistence.elastic`

Reason: A minus sign in filenames of configuration files that are loaded by file installer has special meaning (cf. [file install configurations](https://felix.apache.org/documentation/subprojects/apache-felix-file-install.html#configurations)).