### PR TITLE
NMS-13276: Use updated deploy-base image with tzdata package

### DIFF
--- a/opennms-container/minion/Dockerfile
+++ b/opennms-container/minion/Dockerfile
@@ -4,7 +4,7 @@
 # To avoid issues, we rearrange the directories in pre-stage to avoid injecting these
 # as addtional layers into the final image.
 ##
-ARG BASE_IMAGE="opennms/deploy-base:jre-1.0.0.b39"
+ARG BASE_IMAGE="opennms/deploy-base:jre-1.2.0.b58"
 
 FROM ${BASE_IMAGE} as minion-base
 

--- a/opennms-container/minion/Makefile
+++ b/opennms-container/minion/Makefile
@@ -8,7 +8,7 @@
 VERSION                 := localbuild
 SHELL                   := /bin/bash -o nounset -o pipefail -o errexit
 BUILD_DATE              := $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
-BASE_IMAGE              := opennms/deploy-base:jre-1.0.0.b39
+BASE_IMAGE              := opennms/deploy-base:jre-1.2.0.b58
 DOCKER_CLI_EXPERIMENTAL := enabled
 DOCKERX_INSTANCE        := env-minion-oci
 DOCKER_REGISTRY         := docker.io


### PR DESCRIPTION
### All Contributors

* [x] Have you read and followed our [Contribution Guidelines](https://github.com/OpenNMS/opennms/blob/develop/CONTRIBUTING.md)?
* [x] Have you [made an issue in the OpenNMS issue tracker](https://issues.opennms.org)?<br>If so, you should:
  1. update the title of this PR to be of the format: `${JIRA-ISSUE-NUMBER}: subject of pull request`
  2. update the JIRA link at the bottom of this comment to refer to the real issue number
  3. prefix your commit messages with the issue number, if possible
* [x] Have you made a comment in that issue which points back to this PR?
* [x] Have you updated the JIRA link at the bottom of this comment to link to your issue?
* [x] If this is a new or updated feature, is there documentation for the new behavior?
* [x] If this is new code, are there unit and/or integration tests?
* [x] If this PR targets a `foundation-*` branch, does it avoid changing files in `$OPENNMS_HOME/etc/`?

Updating the Minion deploy base image from 1.0.0 which used OpenJDK 11.0.6 to 1.2.0 with OpenJDK 11.0.7 plus the tzdata package for handling time zones. I ran the smoke tests as well to make sure I don't break them with the JDK and base image version bump :)

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-13276
