### PR TITLE
NMS-13278: Making the DNS requisition location-aware

### DIFF
--- a/opennms-doc/guide-admin/src/asciidoc/text/provisioning/import-handler.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/provisioning/import-handler.adoc
@@ -103,6 +103,8 @@ We use the regular expression `^(?:.*\.|)(.*?)\.hs-fulda\.de\.$` with exactly on
 
 This will associate nodes for the host entries `foo.e46.hs-fulda.de.` and `bar.e46.hs-fulda.de.` to the location `e46` while hosts like `aaa.g51.hs-fulda.de` and `bbb.g51.hs-fulda.de` will be assigned location `g51`.
 
+TIP: You can use online tools like `https://www.urlencoder.org` to en- and decode your parameters.
+
 .DNS Setup
 
 Currently, the DNS server requires to be setup to allow a zone transfer from the {opennms-product-name} server.

--- a/opennms-doc/guide-admin/src/asciidoc/text/provisioning/import-handler.adoc
+++ b/opennms-doc/guide-admin/src/asciidoc/text/provisioning/import-handler.adoc
@@ -91,6 +91,18 @@ If your expression requires URL encoding (for example you need to use a `?` in t
 
  dns://my-dns-server/myzone.com/portland/?expression=^por[0-9]%3F
 
+You can use the `location` parameter to assign a single location to all nodes in this requisition:
+
+  dns://my-dns-server/myzone.com/portland/?location=Raleigh
+
+By preceding a `~` you can specify a properly encoded regular expression to determine the location based on the host entries.
+In the following, for example, we want to derive the location based on the subdomain.
+We use the regular expression `^(?:.*\.|)(.*?)\.hs-fulda\.de\.$` with exactly one capturing group:
+
+  dns://my-dns-server/hs-fulda.de/?location=~%5E%28%3F%3A.%2A%5C.%7C%29%28.%2A%3F%29%5C.hs-fulda%5C.de%5C.%24
+
+This will associate nodes for the host entries `foo.e46.hs-fulda.de.` and `bar.e46.hs-fulda.de.` to the location `e46` while hosts like `aaa.g51.hs-fulda.de` and `bbb.g51.hs-fulda.de` will be assigned location `g51`.
+
 .DNS Setup
 
 Currently, the DNS server requires to be setup to allow a zone transfer from the {opennms-product-name} server.

--- a/opennms-provision/opennms-requisition-dns/src/main/java/org/opennms/netmgt/provision/service/dns/DnsRequisitionProvider.java
+++ b/opennms-provision/opennms-requisition-dns/src/main/java/org/opennms/netmgt/provision/service/dns/DnsRequisitionProvider.java
@@ -52,6 +52,8 @@ import org.xbill.DNS.Type;
 import org.xbill.DNS.ZoneTransferException;
 import org.xbill.DNS.ZoneTransferIn;
 
+import com.google.common.base.Strings;
+
 public class DnsRequisitionProvider extends AbstractRequisitionProvider<DnsRequisitionRequest> {
     private static final Logger LOG = LoggerFactory.getLogger(DnsRequisitionProvider.class);
 
@@ -182,6 +184,27 @@ public class DnsRequisitionProvider extends AbstractRequisitionProvider<DnsRequi
         final String nodeLabel = StringUtils.stripEnd(StringUtils.stripStart(host, "."), ".");
 
         n.setBuilding(request.getForeignSource());
+
+        if (!Strings.isNullOrEmpty(request.getLocation())) {
+            if (request.getLocation().startsWith("~")) {
+                final Pattern pattern = Pattern.compile(request.getLocation().substring(1));
+                final Matcher matcher = pattern.matcher(host);
+                if (matcher.groupCount() != 1) {
+                    LOG.error("The pattern '{}' may contain only one capturing group.", pattern);
+                } else {
+                    if (matcher.find()) {
+                        final String match = matcher.group(1);
+                        if (!Strings.isNullOrEmpty(match)) {
+                            n.setLocation(match);
+                            LOG.debug("Node '{}' location set to {}", n.getNodeLabel(), n.getLocation());
+                        }
+                    }
+                }
+            } else {
+                n.setLocation(request.getLocation());
+                LOG.debug("Node '{}' location set to {}", n.getNodeLabel(), n.getLocation());
+            }
+        }
 
         switch (request.getForeignIdHashSource()) {
         case NODE_LABEL:

--- a/opennms-provision/opennms-requisition-dns/src/main/java/org/opennms/netmgt/provision/service/dns/DnsRequisitionRequest.java
+++ b/opennms-provision/opennms-requisition-dns/src/main/java/org/opennms/netmgt/provision/service/dns/DnsRequisitionRequest.java
@@ -72,6 +72,9 @@ public class DnsRequisitionRequest implements RequisitionRequest {
     @XmlAttribute(name = "expression")
     private String expression;
 
+    @XmlAttribute(name = "location")
+    private String location;
+
     @XmlAttribute(name = "foreign-id-hash-source")
     private ForeignIdHashSource foreignIdHashSource;
 
@@ -106,6 +109,7 @@ public class DnsRequisitionRequest implements RequisitionRequest {
             fallback = Boolean.valueOf(fallbackStr);
         }
         expression = parameters.get("expression");
+        location = parameters.get("location");
         final String foreignIdHashSourceStr = parameters.get("foreignIdHashSource");
         if (foreignIdHashSourceStr != null) {
             foreignIdHashSource = ForeignIdHashSource.valueOf(foreignIdHashSourceStr);
@@ -168,8 +172,16 @@ public class DnsRequisitionRequest implements RequisitionRequest {
         return expression;
     }
 
+    public String getLocation() {
+        return location;
+    }
+
     public void setExpression(String expression) {
         this.expression = expression;
+    }
+
+    public void setLocation(final String location) {
+        this.location = location;
     }
 
     public ForeignIdHashSource getForeignIdHashSource() {
@@ -198,13 +210,14 @@ public class DnsRequisitionRequest implements RequisitionRequest {
                 && Objects.equals(zone, castOther.zone) && Objects.equals(foreignSource, castOther.foreignSource)
                 && Objects.equals(serial, castOther.serial) && Objects.equals(fallback, castOther.fallback)
                 && Objects.equals(expression, castOther.expression)
+                && Objects.equals(location, castOther.location)
                 && Objects.equals(foreignIdHashSource, castOther.foreignIdHashSource)
                 && Objects.equals(services, castOther.services);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(host, port, zone, foreignSource, serial, fallback, expression, foreignIdHashSource,
+        return Objects.hash(host, port, zone, foreignSource, serial, fallback, expression, location, foreignIdHashSource,
                 services);
     }
 

--- a/opennms-provision/opennms-requisition-dns/src/main/java/org/opennms/netmgt/provision/service/dns/DnsRequisitionUrlConnection.java
+++ b/opennms-provision/opennms-requisition-dns/src/main/java/org/opennms/netmgt/provision/service/dns/DnsRequisitionUrlConnection.java
@@ -65,7 +65,9 @@ public class DnsRequisitionUrlConnection extends URLConnection {
     private static final String EXPRESSION_ARG = "expression";
     
     private static final String SERVICES_ARG = "services";
-    
+
+    private static final String LOCATION_ARG = "location";
+
     private static final String FID_HASH_SRC_ARG = "foreignidhashsource";
     
     private static final String[] HASH_IP_KEYWORDS = { "ip", "addr" };
@@ -101,6 +103,7 @@ public class DnsRequisitionUrlConnection extends URLConnection {
         m_request.setZone(parseZone(url));
         m_request.setForeignSource(parseForeignSource(url));
         m_request.setExpression(determineExpressionFromUrl(url));
+        m_request.setLocation(determineLocationFromUrl(url));
         m_request.setForeignIdHashSource(getForeignIdHashSource());
         m_request.setServices(Arrays.asList(getServices()));
 
@@ -218,6 +221,15 @@ public class DnsRequisitionUrlConnection extends URLConnection {
         }
     }
 
+    protected static String determineLocationFromUrl(URL url) {
+        LOG.info("determineLocationFromUrl: finding regex as parameter in query string of URL: {}", url);
+        if(getUrlArgs(url) == null) {
+            return null;
+        } else {
+            return getUrlArgs(url).get(LOCATION_ARG);
+        }
+    }
+
     private static List<String> tokenizeQueryArgs(String query) throws IllegalArgumentException {
         
         if (query == null) {
@@ -269,7 +281,7 @@ public class DnsRequisitionUrlConnection extends URLConnection {
         }
 
         final String query = url.getQuery();
-        if ((query != null) && (determineExpressionFromUrl(url) == null) && (getArgs().get(SERVICES_ARG) == null) && (getArgs().get(FID_HASH_SRC_ARG) == null)) {
+        if ((query != null) && (determineExpressionFromUrl(url) == null) && (determineLocationFromUrl(url) == null) && (getArgs().get(SERVICES_ARG) == null) && (getArgs().get(FID_HASH_SRC_ARG) == null)) {
             throw new MalformedURLException("The specified DNS URL contains an invalid query string: "+url);
         }
     }

--- a/opennms-provision/opennms-requisition-dns/src/test/java/org/opennms/netmgt/provision/service/dns/DnsRequisitionRequestTest.java
+++ b/opennms-provision/opennms-requisition-dns/src/test/java/org/opennms/netmgt/provision/service/dns/DnsRequisitionRequestTest.java
@@ -48,12 +48,13 @@ public class DnsRequisitionRequestTest extends XmlTestNoCastor<DnsRequisitionReq
         request.setZone("some-zone");
         request.setFallback(false);
         request.setForeignSource("f*s*");
+        request.setLocation("Fulda");
         request.setForeignIdHashSource(ForeignIdHashSource.IP_ADDRESS);
 
         return Arrays.asList(new Object[][] {
             {
                 request,
-                "<dns-requisition-request host=\"my-dns-server\" port=\"5353\" zone=\"some-zone\" foreign-source=\"f*s*\" fallback=\"false\" foreign-id-hash-source=\"IP_ADDRESS\"/>"
+                "<dns-requisition-request host=\"my-dns-server\" port=\"5353\" zone=\"some-zone\" foreign-source=\"f*s*\" fallback=\"false\" location=\"Fulda\" foreign-id-hash-source=\"IP_ADDRESS\"/>"
             }
         });
     }


### PR DESCRIPTION
* JIRA: https://issues.opennms.org/browse/NMS-13278

Allow a new `location` parameter in DNS requisition Urls. You can specify a single location that will be associated with all nodes by specifying for example something like `?location=Raleigh`. Furthermore, by preceding a `~` you can specify a properly encoded regular expression to determine the location based on the host entries. This expression must have exactly on capturing group. For instance you can associate a node to a location given by their subdomain with the expression `^(?:.\.|)(.?)\.example\.com\.$`.