### PR TITLE
NMS-13111: Make shaded version for jcifs-ng and bountycastle

### DIFF
--- a/dependencies/jcifs-shaded/pom.xml
+++ b/dependencies/jcifs-shaded/pom.xml
@@ -11,10 +11,10 @@
 
   <groupId>org.opennms.dependencies</groupId>
   <artifactId>org.opennms.dependencies.jcifs-shaded</artifactId>
-  <name>OpenNMS :: Dependencies :: JCIFs :: Extended</name>
+  <name>OpenNMS :: Dependencies :: JCIFs :: Shaded</name>
   <description>
     This module is used to provide a single artifact that the OpenNMS project
-    can depend on to use the jcifs library.
+    can depend on to use the jcifs-ng and bountycastle
   </description>
   <licenses>
     <license>
@@ -58,6 +58,7 @@
                     <exclude>META-INF/BC1024KE.SF</exclude>
                     <exclude>META-INF/BC2048KE.DSA</exclude>
                     <exclude>META-INF/BC2048KE.SF</exclude>
+                    <exclude>META-INF/services/java.security.Provider</exclude>
                   </excludes>
                 </filter>
               </filters>

--- a/dependencies/jcifs-shaded/pom.xml
+++ b/dependencies/jcifs-shaded/pom.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>dependencies</artifactId>
+    <groupId>org.opennms</groupId>
+    <version>27.1.2-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.opennms.dependencies</groupId>
+  <artifactId>org.opennms.dependencies.jcifs-shaded</artifactId>
+  <name>OpenNMS :: Dependencies :: JCIFs :: Extended</name>
+  <description>
+    This module is used to provide a single artifact that the OpenNMS project
+    can depend on to use the jcifs library.
+  </description>
+  <licenses>
+    <license>
+      <name>GNU Lesser/Library Public License, Version 3.0</name>
+      <url>http://www.gnu.org/licenses/lgpl-3.0.txt</url>
+    </license>
+    <license>
+      <name>GNU Public License, Version 3.0</name>
+      <url>http://www.gnu.org/licenses/gpl-3.0.txt</url>
+    </license>
+  </licenses>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>${maven.shade.plugin.version}</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <!--
+              Shade and relocate the bouncycastle classes to avoid it in default lib folder.
+              See https://issues.opennms.org/browse/NMS-13111
+            -->
+            <configuration>
+              <artifactSet>
+                <includes>
+                  <include>eu.agno3.jcifs:jcifs-ng</include>
+                  <include>org.bouncycastle:*</include>
+                </includes>
+              </artifactSet>
+              <!-- Unsign the content -->
+              <filters>
+                <filter>
+                  <artifact>*:*</artifact>
+                  <excludes>
+                    <exclude>META-INF/BC1024KE.DSA</exclude>
+                    <exclude>META-INF/BC1024KE.SF</exclude>
+                    <exclude>META-INF/BC2048KE.DSA</exclude>
+                    <exclude>META-INF/BC2048KE.SF</exclude>
+                  </excludes>
+                </filter>
+              </filters>
+              <relocations>
+                <relocation>
+                  <pattern>org.bouncycastle</pattern>
+                  <shadedPattern>org.opennms.shaded.org.bouncycastle</shadedPattern>
+                </relocation>
+              </relocations>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+  <dependencies>
+    <dependency>
+      <groupId>eu.agno3.jcifs</groupId>
+      <artifactId>jcifs-ng</artifactId>
+      <version>${jcifsVersion}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+  </dependencies>
+</project>

--- a/dependencies/jcifs/pom.xml
+++ b/dependencies/jcifs/pom.xml
@@ -15,15 +15,11 @@
     can depend on to use JCIFS.
   </description>
   <dependencies>
+    <!--Use shaded version of jcifs to avoid loading bountycastle-->
     <dependency>
-      <groupId>eu.agno3.jcifs</groupId>
-      <artifactId>jcifs-ng</artifactId>
-      <version>${jcifsVersion}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.bouncycastle</groupId>
-      <artifactId>bcprov-jdk15on</artifactId>
-      <version>${bouncyCastleVersion}</version>
+      <groupId>org.opennms.dependencies</groupId>
+      <artifactId>org.opennms.dependencies.jcifs-shaded</artifactId>
+      <version>${project.version}</version>
     </dependency>
   </dependencies>
   <repositories>

--- a/dependencies/jinterop/pom.xml
+++ b/dependencies/jinterop/pom.xml
@@ -24,6 +24,17 @@
       <groupId>com.github.skyghis</groupId>
       <artifactId>j-interop-ng-deps</artifactId>
       <version>${jinteropVersion}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>eu.agno3.jcifs</groupId>
+          <artifactId>jcifs-ng</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.opennms.dependencies</groupId>
+      <artifactId>org.opennms.dependencies.jcifs-shaded</artifactId>
+      <version>${project.version}</version>
     </dependency>
   </dependencies>
   <repositories>

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -60,5 +60,6 @@
     <module>spring-web</module>
     <module>tracker</module>
     <module>twitter4j</module>
+    <module>jcifs-shaded</module>
   </modules>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1247,7 +1247,7 @@
 
     <maven.eclipse.plugin.version>2.10</maven.eclipse.plugin.version>
     <maven.pax.plugin.version>1.5</maven.pax.plugin.version>
-    <maven.shade.plugin.version>2.4.3</maven.shade.plugin.version>
+    <maven.shade.plugin.version>3.2.4</maven.shade.plugin.version>
     <antlr.version>2.7.7</antlr.version>
     <sass.maven.plugin.version>1.1.2-ONMS-20131018-1</sass.maven.plugin.version>
 


### PR DESCRIPTION
This allows OpenNMS to avoid bountycastle jar in default lib.



* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-13111

