### PR TITLE
NMS-13311: Add Minion Rest Service (health)

### DIFF
--- a/container/features/src/main/resources/features-minion.xml
+++ b/container/features/src/main/resources/features-minion.xml
@@ -181,4 +181,11 @@
         <bundle>mvn:org.opennms.features.minion/minion-rest-client/${project.version}</bundle>
     </feature>
 
+  <feature name="minion-rest-service" version="${project.version}" description="Minion :: Rest :: Service">
+    <feature>opennms-health-rest</feature>
+    <feature version="${cxfVersion}">cxf-core</feature>
+    <feature version="${cxfVersion}">cxf-jaxrs</feature>
+    <bundle>mvn:org.opennms.features.minion/minion-rest-service/${project.version}</bundle>
+  </feature>
+
 </features>

--- a/container/features/src/main/resources/features.xml
+++ b/container/features/src/main/resources/features.xml
@@ -1075,8 +1075,6 @@
     </feature>
     <feature name="opennms-health-rest" version="${project.version}" description="OpenNMS :: Health :: Rest">
         <feature>opennms-health</feature>
-        <feature>cxf-core</feature>
-        <feature version="${cxfVersion}">cxf-jaxrs</feature>
         <bundle>mvn:org.opennms.core.health/org.opennms.core.health.rest/${project.version}</bundle>
     </feature>
     <feature name="opennms-persistence" version="${project.version}" description="OpenNMS :: Persistence">

--- a/container/features/src/main/resources/features.xml
+++ b/container/features/src/main/resources/features.xml
@@ -1075,6 +1075,8 @@
     </feature>
     <feature name="opennms-health-rest" version="${project.version}" description="OpenNMS :: Health :: Rest">
         <feature>opennms-health</feature>
+        <feature>cxf-core</feature>
+        <feature version="${cxfVersion}">cxf-jaxrs</feature>
         <bundle>mvn:org.opennms.core.health/org.opennms.core.health.rest/${project.version}</bundle>
     </feature>
     <feature name="opennms-persistence" version="${project.version}" description="OpenNMS :: Persistence">

--- a/core/health/rest/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/core/health/rest/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -1,28 +1,12 @@
 <blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-           xmlns:jaxrs="http://cxf.apache.org/blueprint/jaxrs"
-           xmlns:cxf="http://cxf.apache.org/blueprint/core"
            xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.3.0"
            xsi:schemaLocation="
-             http://www.osgi.org/xmlns/blueprint/v1.0.0 http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd
-             http://cxf.apache.org/blueprint/jaxrs http://cxf.apache.org/schemas/blueprint/jaxrs.xsd
-             http://cxf.apache.org/blueprint/core http://cxf.apache.org/schemas/blueprint/core.xsd
-             ">
-    
-    <cxf:bus>
-        <cxf:features>
-            <cxf:logging/>
-        </cxf:features>
-    </cxf:bus>
-
-    <jaxrs:server id="healthCheckRest" address="/rest">
-        <jaxrs:serviceBeans>
-            <ref component-id="healthCheckRestService" />
-        </jaxrs:serviceBeans>
-        <jaxrs:providers>
-            <bean class="com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider"/>
-        </jaxrs:providers>
-    </jaxrs:server>
+                http://www.osgi.org/xmlns/blueprint/v1.0.0
+                https://osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd
+                http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.3.0
+                http://aries.apache.org/schemas/blueprint-cm/blueprint-cm-1.3.0.xsd
+">
 
     <reference id="healthCheckService" interface="org.opennms.core.health.api.HealthCheckService" availability="mandatory" />
 

--- a/core/health/rest/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/core/health/rest/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -1,12 +1,28 @@
 <blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:jaxrs="http://cxf.apache.org/blueprint/jaxrs"
+           xmlns:cxf="http://cxf.apache.org/blueprint/core"
            xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.3.0"
            xsi:schemaLocation="
-                http://www.osgi.org/xmlns/blueprint/v1.0.0
-                https://osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd
-                http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.3.0
-                http://aries.apache.org/schemas/blueprint-cm/blueprint-cm-1.3.0.xsd
-">
+             http://www.osgi.org/xmlns/blueprint/v1.0.0 http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd
+             http://cxf.apache.org/blueprint/jaxrs http://cxf.apache.org/schemas/blueprint/jaxrs.xsd
+             http://cxf.apache.org/blueprint/core http://cxf.apache.org/schemas/blueprint/core.xsd
+             ">
+    
+    <cxf:bus>
+        <cxf:features>
+            <cxf:logging/>
+        </cxf:features>
+    </cxf:bus>
+
+    <jaxrs:server id="healthCheckRest" address="/rest">
+        <jaxrs:serviceBeans>
+            <ref component-id="healthCheckRestService" />
+        </jaxrs:serviceBeans>
+        <jaxrs:providers>
+            <bean class="com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider"/>
+        </jaxrs:providers>
+    </jaxrs:server>
 
     <reference id="healthCheckService" interface="org.opennms.core.health.api.HealthCheckService" availability="mandatory" />
 

--- a/features/container/minion/src/main/filtered-resources/etc/org.apache.cxf.osgi.cfg
+++ b/features/container/minion/src/main/filtered-resources/etc/org.apache.cxf.osgi.cfg
@@ -1,0 +1,1 @@
+org.apache.cxf.servlet.context=/minion

--- a/features/minion/core/pom.xml
+++ b/features/minion/core/pom.xml
@@ -16,5 +16,6 @@
         <module>features</module>
         <module>repository</module>
         <module>minion-rest-client</module>
+      <module>rest</module>
     </modules>
 </project>

--- a/features/minion/core/rest/pom.xml
+++ b/features/minion/core/rest/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>core-parent</artifactId>
+    <groupId>org.opennms.features.minion</groupId>
+    <version>28.0.0-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>minion-rest-service</artifactId>
+  <packaging>bundle</packaging>
+  <name>OpenNMS :: Features :: Minion :: ReST Service</name>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
+            <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+            <Bundle-Version>${project.version}</Bundle-Version>
+          </instructions>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.opennms.core.health</groupId>
+      <artifactId>org.opennms.core.health.rest</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/features/minion/core/rest/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/features/minion/core/rest/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -1,0 +1,29 @@
+<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:jaxrs="http://cxf.apache.org/blueprint/jaxrs"
+           xmlns:cxf="http://cxf.apache.org/blueprint/core"
+           xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.3.0"
+           xsi:schemaLocation="
+             http://www.osgi.org/xmlns/blueprint/v1.0.0 http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd
+             http://cxf.apache.org/blueprint/jaxrs http://cxf.apache.org/schemas/blueprint/jaxrs.xsd
+             http://cxf.apache.org/blueprint/core http://cxf.apache.org/schemas/blueprint/core.xsd
+             ">
+  
+  <cxf:bus>
+    <cxf:features>
+      <cxf:logging/>
+    </cxf:features>
+  </cxf:bus>
+
+  <jaxrs:server id="healthCheckRest" address="/rest">
+    <jaxrs:serviceBeans>
+      <ref component-id="healthCheckRestService" />
+    </jaxrs:serviceBeans>
+    <jaxrs:providers>
+      <bean class="com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider"/>
+    </jaxrs:providers>
+  </jaxrs:server>
+
+  <reference id="healthCheckRestService" interface="org.opennms.core.health.rest.HealthCheckRestService" availability="mandatory" />
+
+</blueprint>

--- a/features/minion/repository/pom.xml
+++ b/features/minion/repository/pom.xml
@@ -73,6 +73,7 @@
                                 <feature>scv-jceks-impl</feature>
                                 <feature>dominion-grpc-client</feature>
                                 <feature>dominion-secure-credentials-vault</feature>
+                                <featue>opennms-health-rest</featue>
                             </features>
                             <repository>${project.build.directory}/maven-repo</repository>
                         </configuration>
@@ -414,6 +415,11 @@
         <dependency>
             <groupId>org.opennms.features.scv</groupId>
             <artifactId>org.opennms.features.scv.dominion-grpc-impl</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.opennms.core.health</groupId>
+            <artifactId>org.opennms.core.health.rest</artifactId>
             <version>${project.version}</version>
         </dependency>
     </dependencies>

--- a/features/minion/repository/pom.xml
+++ b/features/minion/repository/pom.xml
@@ -73,7 +73,7 @@
                                 <feature>scv-jceks-impl</feature>
                                 <feature>dominion-grpc-client</feature>
                                 <feature>dominion-secure-credentials-vault</feature>
-                                <featue>opennms-health-rest</featue>
+                                <featue>minion-rest-service</featue>
                             </features>
                             <repository>${project.build.directory}/maven-repo</repository>
                         </configuration>
@@ -418,8 +418,8 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.opennms.core.health</groupId>
-            <artifactId>org.opennms.core.health.rest</artifactId>
+            <groupId>org.opennms.features.minion</groupId>
+            <artifactId>minion-rest-service</artifactId>
             <version>${project.version}</version>
         </dependency>
     </dependencies>

--- a/features/minion/repository/src/main/resources/features.boot
+++ b/features/minion/repository/src/main/resources/features.boot
@@ -25,3 +25,4 @@ opennms-core-ipc-sink-offheap
 # Default SCV implementation
 scv-jceks-impl
 scv-shell
+opennms-health-rest

--- a/features/minion/repository/src/main/resources/features.boot
+++ b/features/minion/repository/src/main/resources/features.boot
@@ -25,4 +25,4 @@ opennms-core-ipc-sink-offheap
 # Default SCV implementation
 scv-jceks-impl
 scv-shell
-opennms-health-rest
+minion-rest-service

--- a/smoke-test/src/test/java/org/opennms/smoketest/minion/MinionRestServiceIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/minion/MinionRestServiceIT.java
@@ -1,7 +1,7 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2020-2021 The OpenNMS Group, Inc.
+ * Copyright (C) 2021 The OpenNMS Group, Inc.
  * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
@@ -33,7 +33,6 @@ import static io.restassured.RestAssured.preemptive;
 import static org.opennms.smoketest.selenium.AbstractOpenNMSSeleniumHelper.BASIC_AUTH_PASSWORD;
 import static org.opennms.smoketest.selenium.AbstractOpenNMSSeleniumHelper.BASIC_AUTH_USERNAME;
 
-import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -46,7 +45,7 @@ import org.slf4j.LoggerFactory;
 import io.restassured.RestAssured;
 
 @Category(MinionTests.class)
-public class JolokiaRestIT {
+public class MinionRestServiceIT {
 
     private static final Logger LOG = LoggerFactory.getLogger(JolokiaRestIT.class);
 
@@ -57,7 +56,7 @@ public class JolokiaRestIT {
     public void setUp() {
         RestAssured.baseURI = stack.minion().getWebUrl().toString();
         RestAssured.port = stack.minion().getWebPort();
-        RestAssured.basePath = "/jolokia";
+        RestAssured.basePath = "/minion/rest/health";
         RestAssured.authentication = preemptive().basic(BASIC_AUTH_USERNAME, BASIC_AUTH_PASSWORD);
     }
 
@@ -67,14 +66,6 @@ public class JolokiaRestIT {
         given().get()
                 .then().assertThat()
                 .statusCode(200);
-
-        given().get("/read/java.lang:type=Memory/HeapMemoryUsage")
-                .then().assertThat().body(Matchers.containsString("HeapMemoryUsage"));
-
-        given().get("/read/org.opennms.core.ipc.sink.producer:name=*.dispatch")
-                .then().assertThat().body(Matchers.containsString("Heartbeat"));
     }
-
-
 
 }


### PR DESCRIPTION
This PR add custom Rest service on Minion using `cxf-core` and `cxf-jaxrs`

Jetty is already enabled by `jolokia` through `pax-jetty` feature.
This should work irrespective of which one provides jetty either `felix-http` or `pax`

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-13311

