### PR TITLE
NMS-13294: Add Meridian installation guide

### DIFF
--- a/docs/modules/deployment/pages/core/centos-rhel7/install-core.adoc
+++ b/docs/modules/deployment/pages/core/centos-rhel7/install-core.adoc
@@ -1,3 +1,8 @@
+////
+Repo and install: OpenNMS Horizon
+////
+
+ifeval::["{page-component-title}" == "Horizon"]
 .Add repository and import GPG key
 [source, console]
 ----
@@ -10,11 +15,39 @@ sudo rpm --import https://yum.opennms.org/OPENNMS-GPG-KEY
 ----
 sudo yum -y install opennms
 ----
+endif::[]
 
-.Install R packages for trending and forcasting (optional)
+////
+Repo and install: OpenNMS Meridian
+////
+
+ifeval::["{page-component-title}" == "Meridian"]
+.Add repository and import GPG key
+[source, console]
+----
+cat << EOF | sudo tee /etc/yum.repos.d/opennms-meridian.repo
+[meridian]
+name=Meridian for Red Hat Enterprise Linux and CentOS
+baseurl=https://REPO_USER:REPO_PASS@meridian.opennms.com/packages/2021/stable/rhel7<1>
+gpgcheck=1
+gpgkey=http://yum.opennms.org/OPENNMS-GPG-KEY
+EOF
+
+sudo rpm --import https://yum.opennms.org/OPENNMS-GPG-KEY
+----
+<1> Replace the `REPO_USER` and `REPO_PASS` with the credentials received with your Meridian subscription
+
+.Install {page-component-title} with all built-in dependencies
+[source, console]
+----
+sudo yum -y install meridian
+----
+endif::[]
+
 If you want time series trending and forecast functions you must install the link:https://www.r-project.org/[R project] packages.
 The additional download size for packages is ~390 MB.
 
+.Install R-core packages for time series trending and forecasting (optional)
 [source, console]
 ----
 sudo yum -y install epel-release
@@ -25,12 +58,23 @@ TIP: Disable the OpenNMS {page-component-title} repository after installation to
      After upgrade, {page-component-title} requires manual steps to upgrade configuration files or migrate database schemas to a new version.
      We recommend that you exclude the {page-component-title} packages from update except when you plan to perform an upgrade.
 
+ifeval::["{page-component-title}" == "Horizon"]
 .Disable auto updates for OpenNMS {page-component-title}
 [source, console]
 ----
 sudo yum -y install yum-utils
 sudo yum-config-manager --disable opennms-repo-stable-*
 ----
+endif::[]
+
+ifeval::["{page-component-title}" == "Meridian"]
+.Disable auto updates for OpenNMS {page-component-title}
+[source, console]
+----
+sudo yum -y install yum-utils
+sudo yum-config-manager --disable meridian
+----
+endif::[]
 
 .Verify directory structure with the tree command
 [source, console]

--- a/docs/modules/deployment/pages/core/centos-rhel7/install-core.adoc
+++ b/docs/modules/deployment/pages/core/centos-rhel7/install-core.adoc
@@ -35,7 +35,7 @@ EOF
 
 sudo rpm --import https://yum.opennms.org/OPENNMS-GPG-KEY
 ----
-<1> Replace the `REPO_USER` and `REPO_PASS` with the credentials received with your Meridian subscription
+<1> Replace the `REPO_USER` and `REPO_PASS` with your Meridian subscription credentials.
 
 .Install {page-component-title} with all built-in dependencies
 [source, console]

--- a/docs/modules/deployment/pages/core/centos-rhel8/install-core.adoc
+++ b/docs/modules/deployment/pages/core/centos-rhel8/install-core.adoc
@@ -1,3 +1,8 @@
+////
+Repo and install: OpenNMS Horizon
+////
+
+ifeval::["{page-component-title}" == "Horizon"]
 .Add repository and import GPG key
 [source, console]
 ----
@@ -10,12 +15,39 @@ sudo rpm --import https://yum.opennms.org/OPENNMS-GPG-KEY
 ----
 sudo dnf -y install opennms
 ----
+endif::[]
 
+////
+Repo and install: OpenNMS Meridian
+////
 
-.Install R packages for trending and forcasting (optional)
+ifeval::["{page-component-title}" == "Meridian"]
+.Add repository and import GPG key
+[source, console]
+----
+cat << EOF | sudo tee /etc/yum.repos.d/opennms-meridian.repo
+[meridian]
+name=Meridian for Red Hat Enterprise Linux and CentOS
+baseurl=https://REPO_USER:REPO_PASS@meridian.opennms.com/packages/2021/stable/rhel8<1>
+gpgcheck=1
+gpgkey=http://yum.opennms.org/OPENNMS-GPG-KEY
+EOF
+
+sudo rpm --import https://yum.opennms.org/OPENNMS-GPG-KEY
+----
+<1> Replace the `REPO_USER` and `REPO_PASS` with the credentials received from your OpenNMS subscription
+
+.Install {page-component-title} with all built-in dependencies
+[source, console]
+----
+sudo dnf -y install meridian
+----
+endif::[]
+
 If you want time series trending and forecast functions you must install the link:https://www.r-project.org/[R project] packages.
 The additional download size for packages is ~390 MB.
 
+.Install R-core packages for time series trending and forecasting (optional)
 [source, console]
 ----
 sudo dnf -y install epel-release
@@ -26,11 +58,23 @@ TIP: Disable the OpenNMS {page-component-title} repository after installation to
      After upgrade, {page-component-title} requires manual steps to upgrade configuration files or migrate database schemas to a new version.
      We recommend that you exclude the {page-component-title} packages from update except when you plan to perform an upgrade.
 
+ifeval::["{page-component-title}" == "Horizon"]
 .Disable auto updates for OpenNMS {page-component-title}
 [source, console]
 ----
+sudo dnf -y install yum-utils
 sudo dnf config-manager --disable opennms-repo-stable-*
 ----
+endif::[]
+
+ifeval::["{page-component-title}" == "Meridian"]
+.Disable auto updates for OpenNMS {page-component-title}
+[source, console]
+----
+sudo dnf -y install yum-utils
+sudo dnf config-manager --disable meridian
+----
+endif::[]
 
 .Verify directory structure with the tree command
 [source, console]

--- a/docs/modules/deployment/pages/core/centos-rhel8/install-core.adoc
+++ b/docs/modules/deployment/pages/core/centos-rhel8/install-core.adoc
@@ -35,7 +35,7 @@ EOF
 
 sudo rpm --import https://yum.opennms.org/OPENNMS-GPG-KEY
 ----
-<1> Replace the `REPO_USER` and `REPO_PASS` with the credentials received from your OpenNMS subscription
+<1> Replace the `REPO_USER` and `REPO_PASS` with your Meridian subscription credentials.
 
 .Install {page-component-title} with all built-in dependencies
 [source, console]

--- a/docs/modules/deployment/pages/core/getting-started.adoc
+++ b/docs/modules/deployment/pages/core/getting-started.adoc
@@ -17,6 +17,9 @@ endif::[]
 [[requirements-core]]
 == Requirements
 
+ifeval::["{page-component-title}" == "Meridian"]
+* Credentials to access the Meridian repositories
+endif::[]
 * Linux physical server or a virtual machine running a supported xref:deployment:core/system-requirements.adoc#operating-systems-core[Linux operating system]
 * Internet access to download the installation packages
 * DNS works and localhost and your server's host name resolve properly


### PR DESCRIPTION
Add Meridian repository installation instructions for CentOS 7 and CentOS 8.

### All Contributors

* [x] Have you read and followed our [Contribution Guidelines](https://github.com/OpenNMS/opennms/blob/develop/CONTRIBUTING.md)?
* [x] Have you [made an issue in the OpenNMS issue tracker](https://issues.opennms.org)?<br>If so, you should:
  1. update the title of this PR to be of the format: `${JIRA-ISSUE-NUMBER}: subject of pull request`
  2. update the JIRA link at the bottom of this comment to refer to the real issue number
  3. prefix your commit messages with the issue number, if possible
* [x] Have you made a comment in that issue which points back to this PR?
* [x] Have you updated the JIRA link at the bottom of this comment to link to your issue?
* [x] If this is a new or updated feature, is there documentation for the new behavior?
* [x] If this is new code, are there unit and/or integration tests?
* [x] If this PR targets a `foundation-*` branch, does it avoid changing files in `$OPENNMS_HOME/etc/`?

Added instructions installing the Meridian repositories. The credentials for Meridian repositories are added as requirements.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-13294

