### PR TITLE
NMS-13322: Fallback config for flow sampling interval

### DIFF
--- a/docs/modules/operation/pages/telemetryd/protocols/ipfix.adoc
+++ b/docs/modules/operation/pages/telemetryd/protocols/ipfix.adoc
@@ -30,6 +30,9 @@ The IPFIX UDP parser supports protocol detection.
 | `dnsLookupsEnabled`      | Used to enable or disable DNS resolution for flows.                                         | no       | true
 | `sequenceNumberPatience` | A value > 1 enables checking for seuqence number completeness.
                              The value gives the size of the history buffer allowing flows to be processed out of order. | no       | 32
+| `flowActiveTimeoutFallback`   | Fallback value for active flow timeout if setting value is not included in exported flows | no | null
+| `flowInactiveTimeoutFallback`   | Fallback value for inactive flow timeout if setting value is not included in exported flows | no | null
+| `flowSamplingIntervalFallback`   | Fallback value for sampling interval if setting value is not included in exported flows | no | null
 |===
 
 

--- a/docs/modules/operation/pages/telemetryd/protocols/netflow9.adoc
+++ b/docs/modules/operation/pages/telemetryd/protocols/netflow9.adoc
@@ -30,6 +30,9 @@ The Netflow v9 UDP parser supports protocol detection.
 | `dnsLookupsEnabled`      | Used to enable or disable DNS resolution for flows.                                        | no       | true
 | `sequenceNumberPatience` | A value > 1 enables checking for seuqence number completeness.
                             The value gives the size of the history buffer allowing flows to be processed out of order. | no       | 32
+| `flowActiveTimeoutFallback`   | Fallback value for active flow timeout if setting value is not included in exported flows | no | null
+| `flowInactiveTimeoutFallback`   | Fallback value for inactive flow timeout if setting value is not included in exported flows | no | null
+| `flowSamplingIntervalFallback`   | Fallback value for sampling interval if setting value is not included in exported flows | no | null
 |===
 
 [[telemetryd-netflow9-adapter]]

--- a/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/IpfixTcpParser.java
+++ b/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/IpfixTcpParser.java
@@ -121,4 +121,12 @@ public class IpfixTcpParser extends ParserBase implements TcpParser {
     public void setFlowInactiveTimeoutFallback(final Long flowInactiveTimeoutFallback) {
         this.messageBuilder.setFlowInactiveTimeoutFallback(flowInactiveTimeoutFallback);
     }
+
+    public Long getFlowSamplingIntervalFallback() {
+        return this.messageBuilder.getFlowSamplingIntervalFallback();
+    }
+
+    public void setFlowSamplingIntervalFallback(final Long flowSamplingIntervalFallback) {
+        this.messageBuilder.setFlowSamplingIntervalFallback(flowSamplingIntervalFallback);
+    }
 }

--- a/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/IpfixUdpParser.java
+++ b/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/IpfixUdpParser.java
@@ -146,4 +146,12 @@ public class IpfixUdpParser extends UdpParserBase implements UdpParser, Dispatch
     public void setFlowInactiveTimeoutFallback(final Long flowInactiveTimeoutFallback) {
         this.messageBuilder.setFlowInactiveTimeoutFallback(flowInactiveTimeoutFallback);
     }
+
+    public Long getFlowSamplingIntervalFallback() {
+        return this.messageBuilder.getFlowSamplingIntervalFallback();
+    }
+
+    public void setFlowSamplingIntervalFallback(final Long flowSamplingIntervalFallback) {
+        this.messageBuilder.setFlowSamplingIntervalFallback(flowSamplingIntervalFallback);
+    }
 }

--- a/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/Netflow9UdpParser.java
+++ b/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/Netflow9UdpParser.java
@@ -145,4 +145,12 @@ public class Netflow9UdpParser extends UdpParserBase implements UdpParser, Dispa
     public void setFlowInactiveTimeoutFallback(final Long flowInactiveTimeoutFallback) {
         this.messageBuilder.setFlowInactiveTimeoutFallback(flowInactiveTimeoutFallback);
     }
+
+    public Long getFlowSamplingIntervalFallback() {
+        return this.messageBuilder.getFlowSamplingIntervalFallback();
+    }
+
+    public void setFlowSamplingIntervalFallback(final Long flowSamplingIntervalFallback) {
+        this.messageBuilder.setFlowSamplingIntervalFallback(flowSamplingIntervalFallback);
+    }
 }

--- a/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/transport/IpFixMessageBuilder.java
+++ b/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/transport/IpFixMessageBuilder.java
@@ -56,6 +56,7 @@ public class IpFixMessageBuilder implements MessageBuilder {
 
     private Long flowActiveTimeoutFallback;
     private Long flowInactiveTimeoutFallback;
+    private Long flowSamplingIntervalFallback;
 
     public IpFixMessageBuilder() {
     }
@@ -97,7 +98,7 @@ public class IpFixMessageBuilder implements MessageBuilder {
         Long samplingAlgorithm = null;
         Long samplerMode = null;
         Long selectorAlgorithm = null;
-        Long samplingInterval = null;
+        Long samplingInterval = this.flowSamplingIntervalFallback;
         Long samplerRandomInterval = null;
         Long samplingFlowInterval = null;
         Long samplingFlowSpacing = null;
@@ -598,5 +599,13 @@ public class IpFixMessageBuilder implements MessageBuilder {
 
     public void setFlowInactiveTimeoutFallback(final Long flowInactiveTimeoutFallback) {
         this.flowInactiveTimeoutFallback = flowInactiveTimeoutFallback;
+    }
+
+    public Long getFlowSamplingIntervalFallback() {
+        return this.flowSamplingIntervalFallback;
+    }
+
+    public void setFlowSamplingIntervalFallback(final Long flowSamplingIntervalFallback) {
+        this.flowSamplingIntervalFallback = flowSamplingIntervalFallback;
     }
 }

--- a/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/transport/Netflow9MessageBuilder.java
+++ b/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/transport/Netflow9MessageBuilder.java
@@ -34,6 +34,7 @@ import static org.opennms.netmgt.telemetry.protocols.netflow.parser.transport.Me
 import static org.opennms.netmgt.telemetry.protocols.netflow.parser.transport.MessageUtils.getLongValue;
 import static org.opennms.netmgt.telemetry.protocols.netflow.parser.transport.MessageUtils.getUInt32Value;
 import static org.opennms.netmgt.telemetry.protocols.netflow.parser.transport.MessageUtils.getUInt64Value;
+import static org.opennms.netmgt.telemetry.protocols.netflow.parser.transport.MessageUtils.setDoubleValue;
 import static org.opennms.netmgt.telemetry.protocols.netflow.parser.transport.MessageUtils.setIntValue;
 import static org.opennms.netmgt.telemetry.protocols.netflow.parser.transport.MessageUtils.setLongValue;
 
@@ -51,6 +52,7 @@ public class Netflow9MessageBuilder implements MessageBuilder {
 
     private Long flowActiveTimeoutFallback;
     private Long flowInactiveTimeoutFallback;
+    private Long flowSamplingIntervalFallback;
 
     public Netflow9MessageBuilder() {
     }
@@ -81,6 +83,10 @@ public class Netflow9MessageBuilder implements MessageBuilder {
         Long lastSwitched = null;
         Long flowStartMilliseconds = null;
         Long flowEndMilliseconds = null;
+
+	if (this.flowSamplingIntervalFallback != null) {
+	    builder.setSamplingInterval(setDoubleValue(this.flowSamplingIntervalFallback));
+	}
 
         for (Value<?> value : values) {
             switch (value.getName()) {
@@ -311,5 +317,13 @@ public class Netflow9MessageBuilder implements MessageBuilder {
 
     public void setFlowInactiveTimeoutFallback(final Long flowInactiveTimeoutFallback) {
         this.flowInactiveTimeoutFallback = flowInactiveTimeoutFallback;
+    }
+
+    public Long getFlowSamplingIntervalFallback() {
+        return this.flowSamplingIntervalFallback;
+    }
+
+    public void setFlowSamplingIntervalFallback(final Long flowSamplingIntervalFallback) {
+        this.flowSamplingIntervalFallback = flowSamplingIntervalFallback;
     }
 }


### PR DESCRIPTION
Some routers do not send sampling interval configuration
values even if they are configured on the exporting device. The added
settings allow to configure a fallback for these value per
listener/parser.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-13322

