### PR TITLE
NMS-12689: Add regex to limit threshold values

### DIFF
--- a/opennms-config-model/src/main/resources/xsds/thresholding.xsd
+++ b/opennms-config-model/src/main/resources/xsds/thresholding.xsd
@@ -376,41 +376,60 @@
       </annotation>
     </attribute>
 
-    <attribute name="value" type="string" use="required">
-      <annotation>
-        <documentation>
-          Threshold value. If the datasource value rises above this
-          value, in the case of a "high" threshold, or drops below this
-          value, in the case of a "low" threshold the threshold is
-          considered to have been exceeded and the exceeded count will
-          be incremented. Any time that the datasource value drops below
-          this value, in the case of a "high" threshold, or rises above
-          this value, in the case of a "low" threshold the exceeded
-          count is reset back to zero. Whenever the exceeded count
-          reaches the trigger value then a threshold event is generated.
-        </documentation>
-      </annotation>
+    <attribute name="value" use="required">
+      <simpleType>
+        <annotation>
+          <documentation>
+            Threshold value. If the datasource value rises above this
+            value, in the case of a "high" threshold, or drops below this
+            value, in the case of a "low" threshold the threshold is
+            considered to have been exceeded and the exceeded count will
+            be incremented. Any time that the datasource value drops below
+            this value, in the case of a "high" threshold, or rises above
+            this value, in the case of a "low" threshold the exceeded
+            count is reset back to zero. Whenever the exceeded count
+            reaches the trigger value then a threshold event is generated.
+          </documentation>
+        </annotation>
+        <restriction base="string">
+          <!-- Combines two patterns, one pattern limits values to float values and other limits to metadata pattern-->
+          <pattern value="[-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?|\$\{(.+:.+)\}"/>
+        </restriction>
+      </simpleType>
     </attribute>
 
-    <attribute name="rearm" type="string" use="required">
-      <annotation>
-        <documentation>
-          Rearm value. Identifies the value that the datasource must
-          fall below, in the case of a "high" threshold or rise above,
-          in the case of a "low" threshold, before the threshold will
-          rearm, and once again be eligible to generate an event.
-        </documentation>
-      </annotation>
+    <attribute name="rearm
+" use="required">
+      <simpleType>
+        <annotation>
+          <documentation>
+            Rearm value. Identifies the value that the datasource must
+            fall below, in the case of a "high" threshold or rise above,
+            in the case of a "low" threshold, before the threshold will
+            rearm, and once again be eligible to generate an event.
+          </documentation>
+        </annotation>
+        <restriction base="string">
+          <!-- Combines two patterns, one pattern limits values to float values and other limits to metadata pattern-->
+          <pattern value="[-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?|\$\{(.+:.+)\}"/>
+        </restriction>
+      </simpleType>
     </attribute>
 
-    <attribute name="trigger" type="string" use="required">
-      <annotation>
-        <documentation>
-          Trigger value. Identifies the number of consecutive polls that
-          the datasource value must exceed the defined threshold value
-          before a threshold event is generated.
-        </documentation>
-      </annotation>
+    <attribute name="trigger" use="required">
+      <simpleType>
+        <annotation>
+          <documentation>
+            Trigger value. Identifies the number of consecutive polls that
+            the datasource value must exceed the defined threshold value
+            before a threshold event is generated.
+          </documentation>
+        </annotation>
+        <restriction base="string">
+          <!--  Combines two patterns, one pattern limits values positive integer and other limits to metadata pattern -->
+          <pattern value="[0-9]*[1-9][0-9]*|\$\{(.+:.+)\}"/>
+        </restriction>
+      </simpleType>
     </attribute>
 
     <attribute name="ds-label" type="string" use="optional">

--- a/opennms-config-model/src/test/java/org/opennms/netmgt/config/threshd/ThresholdingConfigTest.java
+++ b/opennms-config-model/src/test/java/org/opennms/netmgt/config/threshd/ThresholdingConfigTest.java
@@ -29,8 +29,10 @@
 package org.opennms.netmgt.config.threshd;
 
 import java.text.ParseException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 
 import org.junit.runners.Parameterized.Parameters;
 import org.opennms.core.test.xml.XmlTestNoCastor;
@@ -43,10 +45,44 @@ public class ThresholdingConfigTest extends XmlTestNoCastor<ThresholdingConfig> 
 
     @Parameters
     public static Collection<Object[]> data() throws ParseException {
+        ThresholdingConfig thresholdingConfig = new ThresholdingConfig();
+        Group group = new Group();
+        group.setName("coffee");
+        group.setRrdRepository("${install.share.dir}/rrd/snmp/");
+        Expression expression = new Expression();
+        expression.setDescription("des");
+        expression.setType(ThresholdType.LOW);
+        expression.setDsType("node");
+        expression.setValue("${value:25.0|value1:23.0|25.9}");
+        expression.setRearm("-200.7e+5");
+        expression.setTrigger("003498090");
+        expression.setFilterOperator(FilterOperator.OR);
+        expression.setExpression("coffeePotLevel / coffeePotCapacity * ${percent:200.0 |100.0}");
+        Expression expression1 = new Expression();
+        expression1.setDescription("des1");
+        expression1.setType(ThresholdType.LOW);
+        expression1.setDsType("node3");
+        expression1.setValue("3456.34");
+        expression1.setRearm("0.345");
+        expression1.setTrigger("${trigger:023|345}");
+        expression1.setFilterOperator(FilterOperator.OR);
+        expression1.setExpression("coffeePotLevel / coffeePotCapacity * 250/100");
+        List<Expression> expressions = new ArrayList<>();
+        expressions.add(expression);
+        expressions.add(expression1);
+        group.setExpressions(expressions);
+        thresholdingConfig.addGroup(group);
         return Arrays.asList(new Object[][] {
             {
-                new ThresholdingConfig(),
-                "<thresholding-config/>"
+                thresholdingConfig,
+                "<thresholding-config>\n" +
+                        "   <group name=\"coffee\" rrdRepository=\"${install.share.dir}/rrd/snmp/\">\n" +
+                        "      <expression description=\"des\" type=\"low\" ds-type=\"node\" value=\"${value:25.0|value1:23.0|25.9}\" rearm=\"-200.7e+5\" " +
+                        "trigger=\"003498090\" filterOperator=\"OR\" expression=\"coffeePotLevel / coffeePotCapacity * ${percent:200.0 |100.0}\"/>\n" +
+                        "      <expression description=\"des1\" type=\"low\" ds-type=\"node3\" value=\"3456.34\" rearm=\"0.345\" " +
+                        "trigger=\"${trigger:023|345}\" filterOperator=\"OR\" expression=\"coffeePotLevel / coffeePotCapacity * 250/100\"/>\n" +
+                        "   </group>" +
+                        "</thresholding-config>"
             }
         });
     }


### PR DESCRIPTION
Add regex validation for threshold values:
Metadata notation  OR float value for  `value` and `rearm`
Metadata notation OR positive integer for `trigger`

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-12689

