### PR TITLE
NMS-13360: bump Apache Httpclient to 4.5.13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1401,7 +1401,7 @@
     <hibernateValidatorVersion>4.3.2.Final</hibernateValidatorVersion>
     <hikaricpVersion>2.5.1</hikaricpVersion>
     <httpcoreVersion>4.4.4</httpcoreVersion>
-    <httpclientVersion>4.5.2</httpclientVersion>
+    <httpclientVersion>4.5.13</httpclientVersion>
     <httpasyncclientVersion>4.1.3</httpasyncclientVersion>
     <jacksonVersion>1.9.13</jacksonVersion>
     <jackson2Version>2.6.6</jackson2Version>


### PR DESCRIPTION
This PR bumps our Httpclient to the latest 4.5 version.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-13360
