### PR TITLE
NMS-13361: bump logback-classic to 1.2.3

### DIFF
--- a/features/nrtg/api/pom.xml
+++ b/features/nrtg/api/pom.xml
@@ -25,8 +25,6 @@
       <scope>provided</scope>
     </dependency>
 
-    <!-- <dependency> <groupId>ch.qos.logback</groupId> <artifactId>logback-classic</artifactId> 
-			<version>1.0.4</version> </dependency> -->
     <!-- Testing -->
     <dependency>
       <groupId>junit</groupId>

--- a/features/nrtg/commander/pom.xml
+++ b/features/nrtg/commander/pom.xml
@@ -52,7 +52,6 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.0.4</version>
       <!--<scope>test</scope>-->
     </dependency>
     <!-- Spring -->

--- a/features/nrtg/jar/nrtcollector/pom.xml
+++ b/features/nrtg/jar/nrtcollector/pom.xml
@@ -45,7 +45,6 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.0.4</version>
       <!--<scope>provided</scope>-->
     </dependency>
     <dependency>

--- a/features/nrtg/nrtbroker-jms/pom.xml
+++ b/features/nrtg/nrtbroker-jms/pom.xml
@@ -42,7 +42,6 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.0.4</version>
       <scope>test</scope>
     </dependency>
     <!-- Spring -->

--- a/features/nrtg/nrtbroker-local/pom.xml
+++ b/features/nrtg/nrtbroker-local/pom.xml
@@ -36,7 +36,6 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.0.4</version>
             <scope>test</scope>
         </dependency>
 

--- a/features/nrtg/nrtcollector/pom.xml
+++ b/features/nrtg/nrtcollector/pom.xml
@@ -50,7 +50,6 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.0.4</version>
       <scope>test</scope>
     </dependency>
     <!-- Spring -->

--- a/features/nrtg/protocolcollector/tca/pom.xml
+++ b/features/nrtg/protocolcollector/tca/pom.xml
@@ -65,7 +65,6 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.0.4</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/features/nrtg/web/pom.xml
+++ b/features/nrtg/web/pom.xml
@@ -64,7 +64,6 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.0.4</version>
             <scope>test</scope>
         </dependency>
     

--- a/features/reporting/dao/pom.xml
+++ b/features/reporting/dao/pom.xml
@@ -48,7 +48,6 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.0.4</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/features/reporting/repository/pom.xml
+++ b/features/reporting/repository/pom.xml
@@ -62,7 +62,6 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.0.4</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/features/reporting/sdo/pom.xml
+++ b/features/reporting/sdo/pom.xml
@@ -41,7 +41,6 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.0.4</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/opennms-tools/config-normalizer/pom.xml
+++ b/opennms-tools/config-normalizer/pom.xml
@@ -52,7 +52,6 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.0.13</version>
     </dependency>
 
     <!-- Contains beans for ServiceConfigurationPublicConstructorTest -->

--- a/pom.xml
+++ b/pom.xml
@@ -1429,6 +1429,7 @@
     <lmaxDisruptorVersion>3.3.2</lmaxDisruptorVersion>
     <log4jVersion>99.99.99-use-log4j2</log4jVersion>
     <log4j2Version>2.8.2</log4j2Version>
+    <logbackClassicVersion>1.2.3</logbackClassicVersion>
     <mapstructVersion>1.2.0.CR1</mapstructVersion>
     <minaVersion>2.0.16</minaVersion>
     <minionKarafVersion>4.0.5</minionKarafVersion>
@@ -3992,6 +3993,11 @@
             <artifactId>jmxri</artifactId>
           </exclusion>
         </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>ch.qos.logback</groupId>
+        <artifactId>logback-classic</artifactId>
+        <version>${logbackClassicVersion}</version>
       </dependency>
       <dependency>
         <groupId>org.jsoup</groupId>


### PR DESCRIPTION
This PR bumps logback-classic to the latest 1.2 version, and also cleans up the dependency tree a bit.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-13361
