### PR TITLE
NMS-11764: Don't add SNMP interfaces will null/blank labels to the CollectionSet

### DIFF
--- a/features/collection/snmp-collector/src/main/java/org/opennms/netmgt/collectd/SnmpIfData.java
+++ b/features/collection/snmp-collector/src/main/java/org/opennms/netmgt/collectd/SnmpIfData.java
@@ -33,6 +33,8 @@ import java.util.Map;
 
 import org.opennms.netmgt.model.OnmsSnmpInterface;
 
+import com.google.common.base.MoreObjects;
+
 /**
  * <p>SnmpIfData class.</p>
  *
@@ -143,4 +145,16 @@ public class SnmpIfData {
         return m_attributes;
     }
 
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                .add("nodeId", m_nodeId)
+                .add("collectionEnabled", m_collectionEnabled)
+                .add("ifIndex", m_ifIndex)
+                .add("ifType", m_ifType)
+                .add("rrdLabel", m_rrdLabel)
+                .add("ifAlias", m_ifAlias)
+                .add("attributes", m_attributes)
+                .toString();
+    }
 }

--- a/opennms-services/src/main/java/org/opennms/netmgt/collectd/DefaultSnmpCollectionAgent.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/collectd/DefaultSnmpCollectionAgent.java
@@ -41,6 +41,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.transaction.PlatformTransactionManager;
 
+import com.google.common.base.Strings;
+
 /**
  * Represents a remote SNMP agent on a specific IPv4 interface.
  *
@@ -203,8 +205,14 @@ public class DefaultSnmpCollectionAgent extends DefaultCollectionAgent implement
     public Set<IfInfo> getSnmpInterfaceInfo(final IfResourceType type) {
         final Set<SnmpIfData> snmpIfData = getSnmpInterfaceData();
         final Set<IfInfo> ifInfos = new LinkedHashSet<IfInfo>(snmpIfData.size());
-        
+
         for (final SnmpIfData ifData : snmpIfData) {
+            if (Strings.isNullOrEmpty(ifData.getLabelForRRD())) {
+                LOG.warn("Unable to compute resource index for interface: {}. " +
+                        "Associated metrics will not be added to the CollectionSet and will not be considered" +
+                        " for persistence,thresholding or other processing.", ifData);
+                continue;
+            }
             ifInfos.add(new IfInfo(type, this, ifData));
         }
         

--- a/opennms-services/src/test/java/org/opennms/netmgt/collectd/SnmpIfCollectorIT.java
+++ b/opennms-services/src/test/java/org/opennms/netmgt/collectd/SnmpIfCollectorIT.java
@@ -53,6 +53,7 @@ public class SnmpIfCollectorIT extends SnmpCollectorITCase {
 
 	public SnmpIfCollectorIT(int config) {
 		setVersion(config);
+		m_allowWarnings = true; // warnings are expected when we are unable to compute the resource index for SNMP interfaces
 	}
 
     private final class IfInfoVisitor extends ResourceVisitor {
@@ -192,6 +193,25 @@ public class SnmpIfCollectorIT extends SnmpCollectorITCase {
         waitForSignal();
         
         assertInterfaceMibObjectsPresent(collector.getCollectionSet(), 3);
+    }
+
+    /**
+     * See NMS-11764. Verify that the interface is ignored and not included in the collection set
+     * if the interface name is null.
+     */
+    @Test
+    public void testNullIfName() throws Exception {
+        addIfTable();
+
+        assertFalse(getAttributeList().isEmpty());
+
+        createSnmpInterface(1, 24, null, true);
+
+        SnmpIfCollector collector = createSnmpIfCollector();
+        waitForSignal();
+
+        // The interface should be skipped, and the results are not expected to be added to the CollectionSet
+        assertInterfaceMibObjectsPresent(collector.getCollectionSet(), 0);
     }
 
     // TODO: add test for very large v2 request


### PR DESCRIPTION
JIRA: https://issues.opennms.org/browse/NMS-11764

Change the behavior to avoid adding SNMP interfaces will null/blank labels to the CollectionSet rather than throwing an exception when these are processed.

This allows other resources in the CollectionSet to be processed.

Can backport further if we see fit.