### PR TITLE
NMS-13016: Add docs for non-privilged ports and non-root ping

### DIFF
--- a/docs/modules/deployment/pages/core/centos-rhel/firewall-core.adoc
+++ b/docs/modules/deployment/pages/core/centos-rhel/firewall-core.adoc
@@ -1,0 +1,14 @@
+.Enable Masquerade to allow port forwarding
+[source, console]
+----
+sudo firewall-cmd --permanent --add-masquerade
+----
+
+.Forward SNMP Trap UDP port 162 to 10162
+[source, console]
+----
+sudo firewall-cmd --permanent --add-port=162/udp
+sudo firewall-cmd --permanent --add-port=10162/udp
+sudo firewall-cmd --permanent --add-forward-port=port=162:proto=udp:toport=10162
+sudo systemctl reload firewalld
+----

--- a/docs/modules/deployment/pages/core/centos-rhel/initialize-core.adoc
+++ b/docs/modules/deployment/pages/core/centos-rhel/initialize-core.adoc
@@ -1,7 +1,7 @@
 .Configure PostgreSQL database access
 [source, console]
 ----
-sudo vi /opt/opennms/etc/opennms-datasources.xml
+sudo -u opennms vi /opt/opennms/etc/opennms-datasources.xml
 ----
 
 .Set credentials to access the PostgreSQL database
@@ -53,6 +53,5 @@ sudo firewall-cmd --permanent --add-port=8980/tcp
 sudo systemctl reload firewalld
 ----
 
-TIP: To receive SNMP Traps or Syslog messages you must allow incoming traffic on your host firewall as well.
-     By default, the OpenNMS {page-component-title} SNMP trap daemon listens on 10162/udp and the Syslog daemon listens on 10514/udp.
-     The SNMP Trap daemon is enabled by default, the OpenNMS Syslog daemon is disabled.
+NOTE: The core service user must be able to send ICMP echo requests.
+      During setup, the permissions for `net.ipv4.ping_group_range` are set permanently on boot in `/etc/sysctl.d/99-opennms-non-root-icmp.conf`. 

--- a/docs/modules/deployment/pages/core/debian-ubuntu/firewall-core.adoc
+++ b/docs/modules/deployment/pages/core/debian-ubuntu/firewall-core.adoc
@@ -1,0 +1,22 @@
+.Enable Masquerade to allow port forwarding
+[source, console]
+----
+sudo vi /etc/ufw/before.rules
+----
+
+.For SNMP Trap forwarding, add the following lines at the top before the `*filter` section
+[source, console]
+----
+*nat
+:PREROUTING ACCEPT [0:0]
+-A PREROUTING -p udp --dport 162 -j REDIRECT --to-port 10162
+COMMIT
+----
+
+.Apply the firewall changes
+[source, console]
+----
+sudo ufw allow in 162/udp
+sudo ufw allow in 10162/udp
+sudo ufw reload
+----

--- a/docs/modules/deployment/pages/core/debian-ubuntu/initialize-core.adoc
+++ b/docs/modules/deployment/pages/core/debian-ubuntu/initialize-core.adoc
@@ -1,7 +1,7 @@
 .Configure PostgreSQL database access
 [source, shell]
 ----
-sudo vi /usr/share/opennms/etc/opennms-datasources.xml
+sudo -u opennms vi /usr/share/opennms/etc/opennms-datasources.xml
 ----
 
 .Set credentials to access the PostgreSQL database
@@ -40,11 +40,7 @@ sudo /usr/share/opennms/bin/runjava -s
 sudo /usr/share/opennms/bin/install -dis
 ----
 
-.Enable {page-component-title} core instance on system boot and start immediately
-[source, console]
-----
-sudo systemctl enable --now opennms
-----
+NOTE: The core service user must be able to send ICMP echo requests.
+      During setup, the permissions for `net.ipv4.ping_group_range` are set permanently on boot in `/etc/sysctl.d/99-opennms-non-root-icmp.conf` 
 
-TIP: By default the OpenNMS SNMP Trap daemon listens on 10162/udp and the Syslog daemon listens on 10514/udp.
-     The SNMP Trap daemon is enabled by default, the OpenNMS Syslog daemon is disabled.
+TIP: If you are using Uncomplicated Firewall (UFW) as your host firewall, you can allow access to the web user interface with the command `sudo ufw allow 8980/tcp`.

--- a/docs/modules/deployment/pages/core/getting-started.adoc
+++ b/docs/modules/deployment/pages/core/getting-started.adoc
@@ -125,6 +125,52 @@ include::docker/initialize.adoc[]
 endif::[]
 ====
 
+== Receive SNMP Traps/Informs
+
+OpenNMS {page-component-title} core lets you receive and process SNMP Traps/Informs out of the box.
+The OpenNMS {page-component-title} core services run as an unprivileged user and can't bind on port numbers < 1024 without escalated privileges.
+For this reason, the default port for the SNMP Trap/Inform listener is set to port number 10162/udp instead of the IANA registered port number 162/udp.
+The following example shows how to configure the local firewall daemon to forward port 162/udp to 10162/udp.
+
+TIP: If you need SNMP Trap listener on port 162/udp directly, you can add the Linux `CAP_NET_BIND_SERVICE` capability to the Java binary using `setcap`.
+     Be aware: this method allows any Java program run on your system to bind to privileged ports < 1024.
+
+[{tabs}]
+====
+CentOS/RHEL 7/8::
++
+--
+include::centos-rhel/firewall-core.adoc[]
+--
+
+ifeval::["{page-component-title}" == "Horizon"]
+Debian/Ubuntu::
++
+--
+include::debian-ubuntu/firewall-core.adoc[]
+--
+endif::[]
+====
+
+You can verify your firewall and port forwarding configuration by sending an SNMP trap from a remote system to your OpenNMS {page-component-title} core instance with the following command:
+
+[source, console]
+----
+snmptrap -v 2c -c public opennms-core-host '' 1.3.6.1.4.1.2021.991.17 .1.3.6.1.2.1.1.6.0 s "Milky Way"<1><2>
+----
+<1> By default, OpenNMS uses the community string `public`. 
+If you changed the community string in OpenNMS, use that name here.
+<2> Replace `opennms-core-host` with the IP or FQDN of your OpenNMS {page-component-title} core instance.
+
+On RHEL/CentOS the `snmptrap` command line tool is part of the `net-snmp-utils`. 
+When you run on Debian/Ubuntu, you have to install the `snmp-utils` package.
+
+Your configuration works as expected when you see an SNMP trap event in the web UI.
+
+. Log in to the web UI.
+. Click menu:Status[Events > All events].
+. Verify you received a `uei.opennms.org/generic/traps/EnterpriseDefault` event from your test host.
+
 == First login
 
 After you start the {page-component-title} Core services, access the web application at +


### PR DESCRIPTION
### All Contributors

* [x] Have you read and followed our [Contribution Guidelines](https://github.com/OpenNMS/opennms/blob/develop/CONTRIBUTING.md)?
* [x] Have you [made an issue in the OpenNMS issue tracker](https://issues.opennms.org)?<br>If so, you should:
  1. update the title of this PR to be of the format: `${JIRA-ISSUE-NUMBER}: subject of pull request`
  2. update the JIRA link at the bottom of this comment to refer to the real issue number
  3. prefix your commit messages with the issue number, if possible
* [x] Have you made a comment in that issue which points back to this PR?
* [x] Have you updated the JIRA link at the bottom of this comment to link to your issue?
* [x] If this is a new or updated feature, is there documentation for the new behavior?
* [x] If this is new code, are there unit and/or integration tests?
* [x] If this PR targets a `foundation-*` branch, does it avoid changing files in `$OPENNMS_HOME/etc/`?

### Reviewer Hint

I've created a separate section in the Installation procedure covering just the function receiving SNMP Trap/Informs which is enabled by default. I've removed the Syslogd part cause it is a) a separate feature and b) is disabled by default.  I think covering it in a documentation section that describes the Syslogd scenario would make more sense to me.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-13016

