### PR TITLE
NMS-13285: publish minion-config-schema.yml to Cloudsmith

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -811,19 +811,6 @@ jobs:
               -Dopennms.home=/opt/opennms \
               javadoc:aggregate --batch-mode
       - run:
-          name: Collect Artifacts
-          command: |
-            mkdir -p target/{artifacts,tarballs}
-            OPENNMS_VERSION="$(.circleci/scripts/pom2version.sh pom.xml)"
-            find ./target -name "*.tar.gz" -type f -not -iname '*source*' -exec cp {} "./target/tarballs/opennms-${OPENNMS_VERSION}.tar.gz" \;
-            find ./opennms-assemblies/minion/target -name "*.tar.gz" -type f -not -iname '*source*' -exec cp {} "./target/tarballs/minion-${OPENNMS_VERSION}.tar.gz" \;
-            find ./opennms-assemblies/sentinel/target -name "*.tar.gz" -type f -not -iname '*source*' -exec cp {} "./target/tarballs/sentinel-${OPENNMS_VERSION}.tar.gz" \;
-            pushd target/site/apidocs
-              tar -czf "../../artifacts/opennms-${OPENNMS_VERSION}-javadoc.tar.gz" *
-            popd
-            cp ./opennms-assemblies/xsds/target/*-xsds.tar.gz "./target/artifacts/opennms-${OPENNMS_VERSION}-xsds.tar.gz"
-            cp target/*-source.tar.gz ./target/artifacts/
-      - run:
           name: Build Minion OCI
           command: |
             cd opennms-container/minion
@@ -867,10 +854,28 @@ jobs:
                 echo "No branch to push to registry."
                 ;;
             esac
+      - run:
+          name: Collect Artifacts
+          command: |
+            mkdir -p target/{artifacts,config-schema,tarballs}
+            OPENNMS_VERSION="$(.circleci/scripts/pom2version.sh pom.xml)"
+            find ./target -name "*.tar.gz" -type f -not -iname '*source*' -exec cp {} "./target/tarballs/opennms-${OPENNMS_VERSION}.tar.gz" \;
+            find ./opennms-assemblies/minion/target -name "*.tar.gz" -type f -not -iname '*source*' -exec cp {} "./target/tarballs/minion-${OPENNMS_VERSION}.tar.gz" \;
+            find ./opennms-assemblies/sentinel/target -name "*.tar.gz" -type f -not -iname '*source*' -exec cp {} "./target/tarballs/sentinel-${OPENNMS_VERSION}.tar.gz" \;
+            pushd target/site/apidocs
+              tar -czf "../../artifacts/opennms-${OPENNMS_VERSION}-javadoc.tar.gz" *
+            popd
+            cp ./opennms-assemblies/xsds/target/*-xsds.tar.gz "./target/artifacts/opennms-${OPENNMS_VERSION}-xsds.tar.gz"
+            cp target/*-source.tar.gz ./target/artifacts/
+            cp opennms-container/minion/minion-config-schema.yml "./target/config-schema/"
       - store_artifacts:
           when: always
           path: ~/project/target/artifacts
           destination: artifacts
+      - store_artifacts:
+          when: always
+          path: ~/project/target/config-schema
+          destination: config-schema
       - store_artifacts:
           when: always
           path: ~/project/target/tarballs
@@ -878,14 +883,12 @@ jobs:
       - store_artifacts:
           path: ~/project/opennms-container/minion/images/minion.oci
           destination: minion.oci
+      - cache-workflow-assets:
+          cache_prefix: minion-config-schema
+          source_path: target/config-schema/
       - cache-oci:
           key: minion
           path: opennms-container/minion/images/
-      # any idea why we persisted this? seems like nothing later uses it
-      #- persist_to_workspace:
-      #    root: ~/
-      #    paths:
-      #      - project/target/tarballs
 
   horizon-rpm-build:
     executor: centos-build-executor
@@ -1341,6 +1344,8 @@ jobs:
           cache_prefix: rpm-minion
       - restore-workflow-assets:
           cache_prefix: rpm-sentinel
+      - restore-workflow-assets:
+          cache_prefix: minion-config-schema
       - run:
           name: Publish Packages
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -731,6 +731,7 @@ workflows:
                 - /^master-.*/
                 - /^release-.*/
                 - /^foundation.*/
+                - "jira/NMS-13285"
 
 jobs:
   build:

--- a/.circleci/scripts/publish-cloudsmith.sh
+++ b/.circleci/scripts/publish-cloudsmith.sh
@@ -3,8 +3,13 @@
 set -e
 set -o pipefail
 
+MYDIR="$(dirname "$0")"
+MYDIR="$(cd "$MYDIR" || exit 1; pwd)"
+
 PROJECT="opennms"
 REPO=""
+VERSION="$("${MYDIR}/pom2version.sh" "${MYDIR}/../../pom.xml")"
+
 case "${CIRCLE_BRANCH}" in
   develop)
     REPO="develop"
@@ -18,8 +23,8 @@ case "${CIRCLE_BRANCH}" in
   master)
     REPO="stable"
     ;;
-  ranger/cloudsmith)
-    REPO="foundation-2019"
+  jira/NMS-13285)
+    REPO="foundation-2021"
     ;;
   *)
     echo "This branch is not eligible for deployment: ${CIRCLE_BRANCH}"
@@ -43,6 +48,16 @@ publishPackage() {
   return "$ret"
 }
 
+publishPackage cloudsmith push raw \
+  --republish \
+  --version "${VERSION}" \
+  --name "${REPO}/minion-config-schema.yml" \
+  --description "minion-config-schema.yml for version ${VERSION} in the ${REPO} repository" \
+  "${PROJECT}/config-schema" \
+  "/tmp/minion-config-schema/minion-config-schema.yml"
+
+# this is just for testing, remove it later!
+exit 0
 for FILE in /tmp/rpm-horizon/*.rpm /tmp/rpm-minion/*.rpm /tmp/rpm-sentinel/*.rpm; do
   # give it 3 tries then die
   publishPackage cloudsmith push rpm --no-wait-for-sync "${PROJECT}/$REPO/any-distro/any-version" "$FILE" ||

--- a/opennms-container/horizon/build_container_image.sh
+++ b/opennms-container/horizon/build_container_image.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# Exit immediately if anything returns non-zero
+set -e
+
 # Exit script if a statement returns a non-true return value.
 set -o errexit
 

--- a/opennms-container/launch_yum_server.sh
+++ b/opennms-container/launch_yum_server.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+# Exit immediately if anything returns non-zero
 set -e
 
 # Exit script if a statement returns a non-true return value.

--- a/opennms-container/minion/Dockerfile
+++ b/opennms-container/minion/Dockerfile
@@ -47,6 +47,7 @@ COPY --chown=10001:0 --from=minion-base /opt /opt
 # Install confd.io configuration files and scripts and ensure they are executable
 COPY ./container-fs/confd/ /opt/minion/confd/
 RUN chmod +x /opt/minion/confd/scripts/*
+COPY ./minion-config-schema.yml /opt/minion/confd/
 
 # Create the directory for server certificates
 RUN mkdir /opt/minion/server-certs

--- a/opennms-container/minion/Makefile
+++ b/opennms-container/minion/Makefile
@@ -19,9 +19,16 @@ DOCKER_ARCH             := linux/amd64
 DOCKER_FLAGS            := --output=type=docker,dest=images/minion.oci
 SOURCE                  := $(shell git remote get-url origin)
 REVISION                := $(shell git describe --always)
-BUILD_NUMBER            := "unset"
+BUILD_NUMBER            := 0
 BUILD_URL               := "unset"
 BUILD_BRANCH            := $(shell git describe --always)
+
+%.yml: %.yml.in
+	@echo "Generating $@..."
+	@sed -e 's,@VERSION@,$(VERSION),' \
+		-e 's,@REVISION@,$(REVISION),' \
+		-e 's,@BRANCH@,$(BUILD_BRANCH),' \
+		-e 's,@BUILD_NUMBER@,$(BUILD_NUMBER),' $< > $@
 
 help:
 	@echo ""
@@ -65,7 +72,7 @@ test:
 	@command -v docker-buildx
 	test -f ../../opennms-assemblies/minion/target/org.opennms.assemblies.minion-*-minion.tar.gz
 
-build: test
+build: test minion-config-schema.yml
 	@echo "Copy Minion tarball to Docker context ..."
 	@find ../../opennms-assemblies/minion/target -name "*.tar.gz" -type f -not -iname '*source*' -exec cp {} ./tarball/minion.tar.gz \;
 	@echo "Initialize builder instance ..."
@@ -104,3 +111,4 @@ clean-all:
 	@echo "Delete tarball and artifacts ..."
 	@rm -rf images/*.*
 	@rm -rf tarball/*.*
+	@rm -rf minion-config-schema.yml

--- a/opennms-container/minion/build_container_image.sh
+++ b/opennms-container/minion/build_container_image.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# Exit immediately if anything returns non-zero
+set -e
+
 # Exit script if a statement returns a non-true return value.
 set -o errexit
 

--- a/opennms-container/minion/build_container_image.sh
+++ b/opennms-container/minion/build_container_image.sh
@@ -21,6 +21,12 @@ if [ -z "${MINION_TARBALL}" ]; then
 fi
 cp "${MINION_TARBALL}" tarball/minion.tar.gz
 
+sed -e "s,@VERSION@,${VERSION}," \
+  -e "s,@REVISION@,${REVISION}," \
+  -e "s,@BRANCH@,${BRANCH}," \
+  -e "s,@BUILD_NUMBER@,${BUILD_NUMBER}," \
+  minion-config-schema.yml.in > minion-config-schema.yml
+
 docker build -t minion \
   --build-arg BUILD_DATE="${BUILD_DATE}" \
   --build-arg VERSION="${VERSION}" \

--- a/opennms-container/minion/minion-config-schema.yml.in
+++ b/opennms-container/minion/minion-config-schema.yml.in
@@ -4,7 +4,10 @@
 # See the readme MINION_CONFIG_SCHEMA_README.md for more information.
 
 # Version of Minion this schema configuration is applicable to
-version: "27.0.0"
+version: "@VERSION@"
+revision: "@REVISION@"
+branch: "@BRANCH@"
+buildnumber: @BUILD_NUMBER@
 
 # The root set of categories configurable on a Minion container. Ordering here is used only to determine order for
 # display purposes.

--- a/opennms-container/sentinel/build_container_image.sh
+++ b/opennms-container/sentinel/build_container_image.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# Exit immediately if anything returns non-zero
+set -e
+
 # Exit script if a statement returns a non-true return value.
 set -o errexit
 


### PR DESCRIPTION
This PR publishes the `minion-config-schema.yml` to Cloudsmith, in a new project called `config-schema`.

The URLs should be guessable based on branch and version, ie, a released version of Horizon 28.0.1 will be at the URL:

https://packages.opennms.com/public/config-schema/raw/names/master-28-minion-config-schema.yml/versions/28.0.1/minion-config-schema.yml

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-13285

