### PR TITLE
NMS-13367: allow setting -Xms as well

### DIFF
--- a/opennms-base-assembly/src/main/filtered/bin/opennms
+++ b/opennms-base-assembly/src/main/filtered/bin/opennms
@@ -67,8 +67,11 @@ STATUS_WAIT=5
 # attempt we sleep for STATUS_WAIT seconds.
 STOP_TIMEOUT=10
 
-# Value of the -Xmx<size>m option passed to Java.
-JAVA_HEAP_SIZE=2048
+# Initial heap size (-Xms) in megabytes
+JAVA_INITIAL_HEAP_SIZE=""
+
+# Maximum heap size (-Xmx) in megabytes
+JAVA_HEAP_SIZE="2048"
 
 # Additional options passed to Java when starting OpenNMS.
 # ADDITIONAL_MANAGER_OPTIONS=()
@@ -700,8 +703,16 @@ MANAGER_OPTIONS=()
 #MANAGER_OPTIONS+=("-DOPENNMSLAUNCH")
 MANAGER_OPTIONS+=("-Dopennms.home=$OPENNMS_HOME")
 #MANAGER_OPTIONS+=("-Djcifs.properties=$OPENNMS_HOME/etc/jcifs.properties")
-MANAGER_OPTIONS+=("-Xmx${JAVA_HEAP_SIZE}m")
 MANAGER_OPTIONS+=("-XX:+HeapDumpOnOutOfMemoryError")
+
+if [ -n "$JAVA_INITIAL_HEAP_SIZE" ] && [ "$JAVA_INITIAL_HEAP_SIZE" -gt 0 ]; then
+	MANAGER_OPTIONS+=("-Xms${JAVA_INITIAL_HEAP_SIZE}m")
+fi
+
+if [ -n "$JAVA_HEAP_SIZE" ] && [ "$JAVA_HEAP_SIZE" -gt 0 ]; then
+	MANAGER_OPTIONS+=("-Xmx${JAVA_HEAP_SIZE}m")
+fi
+
 JAVA_VERSION="$("$OPENNMS_HOME/bin/runjava" -p -f 2> /dev/null)"
 JAVA_SHORT_VERSION="$(echo "$JAVA_VERSION" | cut -d. -f1)"
 


### PR DESCRIPTION
Allow setting `-Xms` in `opennms.conf` without needing to add it to `ADDITIONAL_MANAGER_OPTIONS`

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-13367
