### PR TITLE
NMS-13346: Add commands to examine telemetryd

### DIFF
--- a/container/features/pom.xml
+++ b/container/features/pom.xml
@@ -464,6 +464,12 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>org.opennms.features.telemetry</groupId>
+      <artifactId>org.opennms.features.telemetry.shell</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.opennms.features.kafka</groupId>
       <artifactId>org.opennms.features.kafka.producer</artifactId>
       <version>${project.version}</version>

--- a/container/features/src/main/resources/features-minion.xml
+++ b/container/features/src/main/resources/features-minion.xml
@@ -133,6 +133,7 @@
       <feature>opennms-dnsresolver-api</feature>
       <feature>dropwizard-metrics</feature>
       <bundle>mvn:com.google.protobuf/protobuf-java/${protobufVersion}</bundle>
+      <bundle>mvn:com.google.code.gson/gson/${gsonVersion}</bundle>
       <bundle>mvn:org.mongodb/bson/${bsonVersion}</bundle>
       <bundle>mvn:org.apache.commons/commons-csv/${commonsCsvVersion}</bundle>
       <bundle>mvn:org.opennms.features.telemetry/org.opennms.features.telemetry.api/${project.version}</bundle>
@@ -141,6 +142,7 @@
       <bundle>mvn:org.opennms.features.telemetry/org.opennms.features.telemetry.common/${project.version}</bundle>
       <bundle>mvn:org.opennms.features.telemetry/org.opennms.features.telemetry.registry/${project.version}</bundle>
       <bundle>mvn:org.opennms.features.telemetry/org.opennms.features.telemetry.listeners/${project.version}</bundle>
+      <bundle>mvn:org.opennms.features.telemetry/org.opennms.features.telemetry.shell/${project.version}</bundle>
       <bundle>mvn:org.opennms.features.telemetry.protocols/org.opennms.features.telemetry.protocols.common/${project.version}</bundle>
       <bundle>mvn:org.opennms.features.telemetry.protocols.bmp/org.opennms.features.telemetry.protocols.bmp.parser/${project.version}</bundle>
       <bundle>mvn:org.opennms.features.telemetry.protocols.bmp/org.opennms.features.telemetry.protocols.bmp.transport/${project.version}</bundle>

--- a/container/features/src/main/resources/features-sentinel.xml
+++ b/container/features/src/main/resources/features-sentinel.xml
@@ -139,7 +139,6 @@
         <bundle>mvn:org.opennms.features.telemetry.protocols/org.opennms.features.telemetry.protocols.flows/${project.version}</bundle>
         <bundle>mvn:org.opennms.features.telemetry.protocols.netflow/org.opennms.features.telemetry.protocols.netflow.adapter/${project.version}</bundle>
         <bundle>mvn:org.opennms.features.telemetry.protocols.sflow/org.opennms.features.telemetry.protocols.sflow.adapter/${project.version}</bundle>
-        <bundle>mvn:org.opennms.features.flows.classification/org.opennms.features.flows.classification.shell/${project.version}</bundle>
     </feature>
 
     <feature name="sentinel-telemetry-nxos" description="OpenNMS :: Sentinel :: Telemetry :: Adapters :: NXOS" version="${project.version}">

--- a/container/features/src/main/resources/features.xml
+++ b/container/features/src/main/resources/features.xml
@@ -993,12 +993,14 @@
         <feature>opennms-thresholding-api</feature>
         <feature>opennms-osgi-jsr223</feature>
         <bundle>mvn:com.google.protobuf/protobuf-java/${protobufVersion}</bundle>
+        <bundle>mvn:com.google.code.gson/gson/${gsonVersion}</bundle>
         <bundle>mvn:org.opennms.core/org.opennms.core.lib/${project.version}</bundle>
         <bundle>mvn:org.opennms.features.telemetry.config/org.opennms.features.telemetry.config.api/${project.version}</bundle>
         <bundle>mvn:org.opennms.features.telemetry/org.opennms.features.telemetry.api/${project.version}</bundle>
         <bundle>mvn:org.opennms.features.telemetry/org.opennms.features.telemetry.common/${project.version}</bundle>
         <bundle>mvn:org.opennms.features.telemetry/org.opennms.features.telemetry.listeners/${project.version}</bundle>
         <bundle>mvn:org.opennms.features.telemetry.protocols/org.opennms.features.telemetry.protocols.adapters/${project.version}</bundle>
+        <bundle>mvn:org.opennms.features.telemetry/org.opennms.features.telemetry.shell/${project.version}</bundle>
     </feature>
 
     <feature name="opennms-telemetry-daemon" version="${project.version}" description="OpenNMS :: Telemetry :: Daemon">

--- a/container/karaf/src/main/filtered-resources/etc/custom.properties
+++ b/container/karaf/src/main/filtered-resources/etc/custom.properties
@@ -743,6 +743,7 @@ org.osgi.framework.system.packages.extra=org.apache.karaf.branding,\
         org.opennms.netmgt.snmp.snmp4j;version=${opennms.osgi.version},\
         org.opennms.netmgt.snmp.proxy;version=${opennms.osgi.version},\
         org.opennms.netmgt.syslogd;version=${opennms.osgi.version},\
+        org.opennms.netmgt.telemetry.api;version=${opennms.osgi.version},\
         org.opennms.netmgt.telemetry.api.adapter;version=${opennms.osgi.version},\
         org.opennms.netmgt.telemetry.api.receiver;version=${opennms.osgi.version},\
         org.opennms.netmgt.telemetry.api.registry;version=${opennms.osgi.version},\

--- a/features/minion/repository/pom.xml
+++ b/features/minion/repository/pom.xml
@@ -301,6 +301,11 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.opennms.features.telemetry</groupId>
+            <artifactId>org.opennms.features.telemetry.shell</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.opennms.core.ipc.rpc</groupId>
             <artifactId>org.opennms.core.ipc.rpc.jms-impl</artifactId>
             <version>${project.version}</version>

--- a/features/sentinel/repository/pom.xml
+++ b/features/sentinel/repository/pom.xml
@@ -386,6 +386,11 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.opennms.features.telemetry</groupId>
+            <artifactId>org.opennms.features.telemetry.shell</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.opennms.features</groupId>
             <artifactId>org.opennms.features.jdbc-collector</artifactId>
         </dependency>

--- a/features/telemetry/api/src/main/java/org/opennms/netmgt/telemetry/api/TelemetryManager.java
+++ b/features/telemetry/api/src/main/java/org/opennms/netmgt/telemetry/api/TelemetryManager.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2017-2017 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
+ * Copyright (C) 2021 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -26,25 +26,25 @@
  *     http://www.opennms.com/
  *******************************************************************************/
 
-package org.opennms.netmgt.telemetry.api.receiver;
+package org.opennms.netmgt.telemetry.api;
 
-import java.util.concurrent.ScheduledExecutorService;
+import java.util.List;
 
-import org.opennms.core.ipc.sink.api.AsyncDispatcher;
+import org.opennms.netmgt.telemetry.api.adapter.Adapter;
+import org.opennms.netmgt.telemetry.api.receiver.Listener;
 
-/**
- * Interface used by the daemon to manage parsers.
- *
- * When messages are received, they should be forwarded to the given {@link AsyncDispatcher}.
- *
- * @author jwhite
- */
-public interface Parser {
-    String getName();
-    String getDescription();
+public interface TelemetryManager {
+    /**
+     * Get the list of currently configured and enabled listeners.
+     *
+     * @return the listeners
+     */
+    List<Listener> getListeners();
 
-    Object dumpInternalState();
-
-    void start(final ScheduledExecutorService executorService);
-    void stop();
+    /**
+     * Get the list of currently configured and enabled adapters.
+     *
+     * @return the adapters
+     */
+    List<Adapter> getAdapters();
 }

--- a/features/telemetry/api/src/main/java/org/opennms/netmgt/telemetry/api/receiver/Listener.java
+++ b/features/telemetry/api/src/main/java/org/opennms/netmgt/telemetry/api/receiver/Listener.java
@@ -28,6 +28,8 @@
 
 package org.opennms.netmgt.telemetry.api.receiver;
 
+import java.util.Collection;
+
 /**
  * Interface used by the daemon to manage listeners.
  *
@@ -37,6 +39,9 @@ package org.opennms.netmgt.telemetry.api.receiver;
  */
 public interface Listener {
     String getName();
+    String getDescription();
+
+    Collection<? extends Parser> getParsers();
 
     void start() throws InterruptedException;
     void stop() throws InterruptedException;

--- a/features/telemetry/daemon/src/main/java/org/opennms/netmgt/telemetry/daemon/TelemetryMessageConsumer.java
+++ b/features/telemetry/daemon/src/main/java/org/opennms/netmgt/telemetry/daemon/TelemetryMessageConsumer.java
@@ -133,4 +133,8 @@ public class TelemetryMessageConsumer implements MessageConsumer<TelemetryMessag
     public void setRegistry(TelemetryRegistry telemetryRegistry) {
         this.telemetryRegistry = telemetryRegistry;
     }
+
+    public Set<Adapter> getAdapters() {
+        return this.adapters;
+    }
 }

--- a/features/telemetry/daemon/src/main/java/org/opennms/netmgt/telemetry/daemon/Telemetryd.java
+++ b/features/telemetry/daemon/src/main/java/org/opennms/netmgt/telemetry/daemon/Telemetryd.java
@@ -36,6 +36,7 @@ import org.opennms.core.ipc.sink.api.AsyncDispatcher;
 import org.opennms.core.ipc.sink.api.MessageConsumerManager;
 import org.opennms.core.ipc.sink.api.MessageDispatcherFactory;
 import org.opennms.netmgt.events.api.model.IEvent;
+import org.opennms.netmgt.telemetry.api.TelemetryManager;
 import org.opennms.netmgt.telemetry.api.registry.TelemetryRegistry;
 import org.opennms.netmgt.daemon.DaemonTools;
 import org.opennms.netmgt.daemon.SpringServiceDaemon;
@@ -65,7 +66,7 @@ import org.springframework.context.ApplicationContext;
  * @author jwhite
  */
 @EventListener(name=Telemetryd.NAME, logPrefix=Telemetryd.LOG_PREFIX)
-public class Telemetryd implements SpringServiceDaemon {
+public class Telemetryd implements SpringServiceDaemon, TelemetryManager {
     private static final Logger LOG = LoggerFactory.getLogger(Telemetryd.class);
 
     public static final String NAME = "Telemetryd";
@@ -230,4 +231,15 @@ public class Telemetryd implements SpringServiceDaemon {
         DaemonTools.handleReloadEvent(e, Telemetryd.NAME, (event) -> handleConfigurationChanged());
     }
 
+    @Override
+    public List<Listener> getListeners() {
+        return this.listeners;
+    }
+
+    @Override
+    public List<Adapter> getAdapters() {
+        return this.consumers.stream()
+                .flatMap(consumer -> consumer.getAdapters().stream())
+                .collect(Collectors.toList());
+    }
 }

--- a/features/telemetry/daemon/src/main/resources/META-INF/opennms/applicationContext-telemetryDaemon.xml
+++ b/features/telemetry/daemon/src/main/resources/META-INF/opennms/applicationContext-telemetryDaemon.xml
@@ -29,4 +29,6 @@
     <property name="eventSubscriptionService" ref="eventSubscriptionService" />
   </bean>
 
+  <onmsgi:service interface="org.opennms.netmgt.telemetry.api.TelemetryManager" ref="daemon" />
+
 </beans>

--- a/features/telemetry/distributed/minion/src/main/java/org/opennms/netmgt/telemetry/distributed/minion/ListenerManager.java
+++ b/features/telemetry/distributed/minion/src/main/java/org/opennms/netmgt/telemetry/distributed/minion/ListenerManager.java
@@ -29,17 +29,22 @@
 package org.opennms.netmgt.telemetry.distributed.minion;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Dictionary;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.opennms.core.health.api.HealthCheck;
 import org.opennms.core.ipc.sink.api.AsyncDispatcher;
 import org.opennms.core.ipc.sink.api.MessageDispatcherFactory;
 import org.opennms.netmgt.dao.api.DistPollerDao;
+import org.opennms.netmgt.telemetry.api.TelemetryManager;
+import org.opennms.netmgt.telemetry.api.adapter.Adapter;
 import org.opennms.netmgt.telemetry.api.receiver.Listener;
 import org.opennms.netmgt.telemetry.api.receiver.TelemetryMessage;
 import org.opennms.netmgt.telemetry.api.registry.TelemetryRegistry;
@@ -61,7 +66,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author jwhite
  */
-public class ListenerManager implements ManagedServiceFactory {
+public class ListenerManager implements ManagedServiceFactory, TelemetryManager {
     private static final Logger LOG = LoggerFactory.getLogger(ListenerManager.class);
 
     private MessageDispatcherFactory messageDispatcherFactory;
@@ -207,4 +212,15 @@ public class ListenerManager implements ManagedServiceFactory {
         }
     }
 
+    @Override
+    public List<Listener> getListeners() {
+        return this.entities.values().stream()
+                .map(e -> e.listener)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<Adapter> getAdapters() {
+        return Collections.emptyList();
+    }
 }

--- a/features/telemetry/distributed/minion/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/features/telemetry/distributed/minion/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -26,4 +26,5 @@
             <entry key="service.pid" value="org.opennms.features.telemetry.listeners"/>
         </service-properties>
     </service>
+    <service interface="org.opennms.netmgt.telemetry.api.TelemetryManager" ref="listenerManager" />
 </blueprint>

--- a/features/telemetry/distributed/sentinel/src/main/java/org/opennms/netmgt/telemetry/distributed/sentinel/AdapterManager.java
+++ b/features/telemetry/distributed/sentinel/src/main/java/org/opennms/netmgt/telemetry/distributed/sentinel/AdapterManager.java
@@ -29,14 +29,19 @@
 package org.opennms.netmgt.telemetry.distributed.sentinel;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Dictionary;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.opennms.core.health.api.HealthCheck;
 import org.opennms.core.ipc.sink.api.MessageConsumerManager;
 import org.opennms.netmgt.dao.api.DistPollerDao;
+import org.opennms.netmgt.telemetry.api.TelemetryManager;
+import org.opennms.netmgt.telemetry.api.adapter.Adapter;
+import org.opennms.netmgt.telemetry.api.receiver.Listener;
 import org.opennms.netmgt.telemetry.api.registry.TelemetryRegistry;
 import org.opennms.netmgt.telemetry.common.ipc.TelemetrySinkModule;
 import org.opennms.netmgt.telemetry.config.api.AdapterDefinition;
@@ -62,7 +67,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author mvrueden
  */
-public class AdapterManager implements ManagedServiceFactory {
+public class AdapterManager implements ManagedServiceFactory, TelemetryManager {
     private static final Logger LOG = LoggerFactory.getLogger(AdapterManager.class);
 
     private DistPollerDao distPollerDao;
@@ -171,5 +176,17 @@ public class AdapterManager implements ManagedServiceFactory {
 
     public void setBundleContext(BundleContext bundleContext) {
         this.bundleContext = bundleContext;
+    }
+
+    @Override
+    public List<Listener> getListeners() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public List<Adapter> getAdapters() {
+        return this.consumersById.values().stream()
+                .flatMap(consumer -> consumer.getAdapters().stream())
+                .collect(Collectors.toList());
     }
 }

--- a/features/telemetry/distributed/sentinel/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/features/telemetry/distributed/sentinel/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -29,6 +29,7 @@
             <entry key="service.pid" value="org.opennms.features.telemetry.adapters"/>
         </service-properties>
     </service>
+    <service interface="org.opennms.netmgt.telemetry.api.TelemetryManager" ref="adapterManager" />
 
     <!--
         Usually the CollectionAgentFactory is exposed via opennms-services, as that bundle is not available

--- a/features/telemetry/listeners/src/main/java/org/opennms/netmgt/telemetry/listeners/TcpListener.java
+++ b/features/telemetry/listeners/src/main/java/org/opennms/netmgt/telemetry/listeners/TcpListener.java
@@ -29,11 +29,14 @@
 package org.opennms.netmgt.telemetry.listeners;
 
 import java.net.InetSocketAddress;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 
 import org.opennms.netmgt.telemetry.api.receiver.Listener;
+import org.opennms.netmgt.telemetry.api.receiver.Parser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -198,6 +201,16 @@ public class TcpListener implements Listener {
     @Override
     public String getName() {
         return this.name;
+    }
+
+    @Override
+    public String getDescription() {
+        return String.format("TCP %s:%s",  this.host != null ? this.host : "*", this.port);
+    }
+
+    @Override
+    public Collection<? extends Parser> getParsers() {
+        return Collections.singleton(this.parser);
     }
 
     public String getHost() {

--- a/features/telemetry/listeners/src/main/java/org/opennms/netmgt/telemetry/listeners/UdpListener.java
+++ b/features/telemetry/listeners/src/main/java/org/opennms/netmgt/telemetry/listeners/UdpListener.java
@@ -29,6 +29,7 @@
 package org.opennms.netmgt.telemetry.listeners;
 
 import java.net.InetSocketAddress;
+import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 
@@ -158,6 +159,15 @@ public class UdpListener implements Listener {
         return name;
     }
 
+    @Override
+    public String getDescription() {
+        return String.format("UDP %s:%s",  this.host != null ? this.host : "*", this.port);
+    }
+
+    @Override
+    public Collection<? extends Parser> getParsers() {
+        return this.parsers;
+    }
 
     private class DefaultChannelInitializer extends ChannelInitializer<DatagramChannel> {
 

--- a/features/telemetry/pom.xml
+++ b/features/telemetry/pom.xml
@@ -20,5 +20,6 @@
     <module>listeners</module>
     <module>protocols</module>
     <module>registry</module>
+    <module>shell</module>
   </modules>
 </project>

--- a/features/telemetry/protocols/bmp/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/bmp/parser/BmpParser.java
+++ b/features/telemetry/protocols/bmp/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/bmp/parser/BmpParser.java
@@ -115,6 +115,7 @@ import org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bmp.packets.stats
 import org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bmp.packets.stats.PrefixTreatAsWithdraw;
 import org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bmp.packets.stats.Rejected;
 import org.opennms.netmgt.telemetry.protocols.bmp.parser.proto.bmp.packets.stats.UpdateTreatAsWithdraw;
+import org.opennms.netmgt.telemetry.protocols.bmp.parser.state.ParserState;
 import org.opennms.netmgt.telemetry.protocols.bmp.transport.Transport;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -131,6 +132,9 @@ import io.github.resilience4j.bulkhead.Bulkhead;
 import io.github.resilience4j.bulkhead.BulkheadFullException;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
+import io.netty.channel.group.ChannelGroup;
+import io.netty.channel.group.DefaultChannelGroup;
+import io.netty.util.concurrent.GlobalEventExecutor;
 
 public class BmpParser implements TcpParser {
     public static final Logger LOG = LoggerFactory.getLogger(BmpParser.class);
@@ -173,6 +177,11 @@ public class BmpParser implements TcpParser {
     @Override
     public String getName() {
         return this.name;
+    }
+
+    @Override
+    public String getDescription() {
+        return "BMP";
     }
 
     @Override
@@ -315,6 +324,13 @@ public class BmpParser implements TcpParser {
                 BmpParser.this.sendHeartbeat(HeartbeatMode.CHANGE, remoteAddress);
             }
         };
+    }
+
+    @Override
+    public Object dumpInternalState() {
+        return ParserState.builder()
+                .withConnections(this.connections)
+                .build();
     }
 
     private Function<Transport.Message.Builder, CompletableFuture<Transport.Message.Builder>> resolvePeer(final Packet packet) {

--- a/features/telemetry/protocols/bmp/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/bmp/parser/state/ParserState.java
+++ b/features/telemetry/protocols/bmp/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/bmp/parser/state/ParserState.java
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2021 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.telemetry.protocols.bmp.parser.state;
+
+import java.net.InetAddress;
+import java.util.List;
+import java.util.Set;
+
+import org.opennms.core.utils.InetAddressUtils;
+
+import com.google.common.collect.ImmutableList;
+
+public class ParserState {
+    public final List<String> connections;
+
+    private ParserState(final Builder builder) {
+        this.connections = builder.connections.build();
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private final ImmutableList.Builder<String> connections = ImmutableList.builder();
+
+        private Builder() {
+        }
+
+        public Builder withConnection(final InetAddress connection) {
+            this.connections.add(InetAddressUtils.str(connection));
+            return this;
+        }
+
+        public Builder withConnections(final Set<InetAddress> connections) {
+            connections.forEach(this::withConnection);
+            return this;
+        }
+
+        public ParserState build() {
+            return new ParserState(this);
+        }
+    }
+}

--- a/features/telemetry/protocols/common/src/main/java/org/opennms/netmgt/telemetry/protocols/common/parser/ForwardParser.java
+++ b/features/telemetry/protocols/common/src/main/java/org/opennms/netmgt/telemetry/protocols/common/parser/ForwardParser.java
@@ -57,6 +57,16 @@ public class ForwardParser implements UdpParser {
     }
 
     @Override
+    public String getDescription() {
+        return "Forward";
+    }
+
+    @Override
+    public Object dumpInternalState() {
+        return null;
+    }
+
+    @Override
     public void start(final ScheduledExecutorService executorService) {
     }
 

--- a/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/IpfixTcpParser.java
+++ b/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/IpfixTcpParser.java
@@ -32,6 +32,7 @@ import static org.opennms.netmgt.telemetry.listeners.utils.BufferUtils.slice;
 
 import java.net.InetSocketAddress;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
 import org.opennms.core.ipc.sink.api.AsyncDispatcher;
@@ -43,15 +44,19 @@ import org.opennms.netmgt.telemetry.listeners.TcpParser;
 import org.opennms.netmgt.telemetry.protocols.netflow.parser.ipfix.proto.Header;
 import org.opennms.netmgt.telemetry.protocols.netflow.parser.ipfix.proto.Packet;
 import org.opennms.netmgt.telemetry.protocols.netflow.parser.session.TcpSession;
+import org.opennms.netmgt.telemetry.protocols.netflow.parser.state.ParserState;
 import org.opennms.netmgt.telemetry.protocols.netflow.parser.transport.IpFixMessageBuilder;
 
 import com.codahale.metrics.MetricRegistry;
+import com.google.common.collect.Sets;
 
 import io.netty.buffer.ByteBuf;
 
 public class IpfixTcpParser extends ParserBase implements TcpParser {
 
     private final IpFixMessageBuilder messageBuilder = new IpFixMessageBuilder();
+
+    private final Set<TcpSession> sessions = Sets.newConcurrentHashSet();
 
     public IpfixTcpParser(final String name,
                           final AsyncDispatcher<TelemetryMessage> dispatcher,
@@ -99,10 +104,14 @@ public class IpfixTcpParser extends ParserBase implements TcpParser {
             }
 
             @Override
-            public void active() {}
+            public void active() {
+                sessions.add(session);
+            }
 
             @Override
-            public void inactive() {}
+            public void inactive() {
+                sessions.remove(session);
+            }
         };
     }
 
@@ -128,5 +137,16 @@ public class IpfixTcpParser extends ParserBase implements TcpParser {
 
     public void setFlowSamplingIntervalFallback(final Long flowSamplingIntervalFallback) {
         this.messageBuilder.setFlowSamplingIntervalFallback(flowSamplingIntervalFallback);
+    }
+
+    @Override
+    public Object dumpInternalState() {
+        final ParserState.Builder parser = ParserState.builder();
+
+        this.sessions.stream()
+                     .flatMap(TcpSession::dumpInternalState)
+                     .forEach(parser::withExporter);
+
+        return parser.build();
     }
 }

--- a/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/IpfixUdpParser.java
+++ b/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/IpfixUdpParser.java
@@ -35,6 +35,7 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 
 import org.opennms.core.ipc.sink.api.AsyncDispatcher;
+import org.opennms.core.utils.InetAddressUtils;
 import org.opennms.distributed.core.api.Identity;
 import org.opennms.netmgt.dnsresolver.api.DnsResolver;
 import org.opennms.netmgt.events.api.EventForwarder;
@@ -122,6 +123,11 @@ public class IpfixUdpParser extends UdpParserBase implements UdpParser, Dispatch
                     .add("remoteAddress", remoteAddress)
                     .add("localAddress", localAddress)
                     .toString();
+        }
+
+        @Override
+        public String getDescription() {
+            return String.format("%s:%s", InetAddressUtils.str(this.remoteAddress.getAddress()), this.remoteAddress.getPort());
         }
 
         @Override

--- a/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/Netflow9UdpParser.java
+++ b/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/Netflow9UdpParser.java
@@ -36,6 +36,7 @@ import java.net.InetSocketAddress;
 import java.time.Duration;
 
 import org.opennms.core.ipc.sink.api.AsyncDispatcher;
+import org.opennms.core.utils.InetAddressUtils;
 import org.opennms.distributed.core.api.Identity;
 import org.opennms.netmgt.dnsresolver.api.DnsResolver;
 import org.opennms.netmgt.events.api.EventForwarder;
@@ -122,6 +123,11 @@ public class Netflow9UdpParser extends UdpParserBase implements UdpParser, Dispa
                     .add("remoteAddress", remoteAddress)
                     .add("localAddress", localAddress)
                     .toString();
+        }
+
+        @Override
+        public String getDescription() {
+            return InetAddressUtils.str(this.remoteAddress);
         }
 
         @Override

--- a/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/ParserBase.java
+++ b/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/ParserBase.java
@@ -221,6 +221,11 @@ public abstract class ParserBase implements Parser {
         return this.name;
     }
 
+    @Override
+    public String getDescription() {
+        return this.protocol.description;
+    }
+
     public void setMaxClockSkew(final long maxClockSkew) {
         this.maxClockSkew = maxClockSkew;
     }

--- a/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/Protocol.java
+++ b/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/Protocol.java
@@ -28,14 +28,18 @@
 
 package org.opennms.netmgt.telemetry.protocols.netflow.parser;
 
+import java.util.Objects;
+
 public enum Protocol {
-    NETFLOW5(org.opennms.netmgt.telemetry.protocols.netflow.parser.netflow5.proto.Header.VERSION),
-    NETFLOW9(org.opennms.netmgt.telemetry.protocols.netflow.parser.netflow9.proto.Header.VERSION),
-    IPFIX(org.opennms.netmgt.telemetry.protocols.netflow.parser.ipfix.proto.Header.VERSION);
+    NETFLOW5(org.opennms.netmgt.telemetry.protocols.netflow.parser.netflow5.proto.Header.VERSION, "Netflow v5"),
+    NETFLOW9(org.opennms.netmgt.telemetry.protocols.netflow.parser.netflow9.proto.Header.VERSION, "Netflow v9"),
+    IPFIX(org.opennms.netmgt.telemetry.protocols.netflow.parser.ipfix.proto.Header.VERSION, "IPFix");
 
     public final int version;
+    public final String description;
 
-    Protocol(final int version) {
+    Protocol(final int version, final String description) {
         this.version = version;
+        this.description = Objects.requireNonNull(description);
     }
 }

--- a/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/UdpParserBase.java
+++ b/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/UdpParserBase.java
@@ -127,4 +127,9 @@ public abstract class UdpParserBase extends ParserBase implements UdpParser {
     public void setTemplateTimeout(final Duration templateTimeout) {
         this.templateTimeout = templateTimeout;
     }
+
+    @Override
+    public Object dumpInternalState() {
+        return this.sessionManager.dumpInternalState();
+    }
 }

--- a/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/session/UdpSessionManager.java
+++ b/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/session/UdpSessionManager.java
@@ -33,7 +33,6 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -46,65 +45,153 @@ import java.util.stream.Collectors;
 
 import org.opennms.netmgt.telemetry.protocols.netflow.parser.MissingTemplateException;
 import org.opennms.netmgt.telemetry.protocols.netflow.parser.ie.Value;
+import org.opennms.netmgt.telemetry.protocols.netflow.parser.state.ExporterState;
+import org.opennms.netmgt.telemetry.protocols.netflow.parser.state.OptionState;
+import org.opennms.netmgt.telemetry.protocols.netflow.parser.state.ParserState;
+import org.opennms.netmgt.telemetry.protocols.netflow.parser.state.TemplateState;
 
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
 
 public class UdpSessionManager {
+
+    private final Map<TemplateKey, TimeWrapper<Template>> templates = Maps.newHashMap();
+    private final Map<TemplateKey, Map<Set<Value<?>>, TimeWrapper<List<Value<?>>>>> options = Maps.newHashMap();
+    private final Map<DomainKey, SequenceNumberTracker> sequenceNumbers = Maps.newHashMap();
+    private final Duration timeout;
+    private final Supplier<SequenceNumberTracker> sequenceNumberTracker;
+
+    public UdpSessionManager(final Duration timeout, final Supplier<SequenceNumberTracker> sequenceNumberTracker) {
+        this.timeout = timeout;
+        this.sequenceNumberTracker = Objects.requireNonNull(sequenceNumberTracker);
+    }
+
+    public void doHousekeeping() {
+        final Instant timeout = Instant.now().minus(this.timeout);
+        UdpSessionManager.this.templates.entrySet().removeIf(e -> e.getValue().time.isBefore(timeout));
+    }
+
+    public Session getSession(final SessionKey sessionKey) {
+        return new UdpSession(sessionKey);
+    }
+
+    public void drop(final SessionKey sessionKey) {
+        this.templates.entrySet().removeIf(e -> Objects.equals(e.getKey().observationDomainId.sessionKey, sessionKey));
+    }
+
+    public int count() {
+        return this.templates.size();
+    }
+
+    public Object dumpInternalState() {
+        final ParserState.Builder parser = ParserState.builder();
+
+        final Set<DomainKey> domains = this.templates.keySet().stream()
+                                                     .map(key -> key.observationDomainId)
+                                                     .collect(Collectors.toSet());
+
+        domains.forEach(domain -> {
+            final String key = String.format("%s#%s", domain.sessionKey.getDescription(), domain.observationDomainId);
+
+            final ExporterState.Builder exporter = ExporterState.builder(key);
+
+            this.templates.entrySet().stream()
+                          .filter(e -> Objects.equals(e.getKey().observationDomainId, domain))
+                          .forEach(e -> exporter.withTemplate(TemplateState.builder(e.getKey().templateId)
+                                                                           .withInsertionTime(e.getValue().time)));
+
+            this.options.entrySet().stream()
+                        .filter(e -> Objects.equals(e.getKey().observationDomainId, domain))
+                        .forEach(e -> e.getValue().forEach((selectors, values) ->
+                                                                   exporter.withOptions(OptionState.builder(e.getKey().templateId)
+                                                                                                   .withInsertionTime(values.time)
+                                                                                                   .withSelectors(selectors)
+                                                                                                   .withValues(values.wrapped))));
+
+            parser.withExporter(exporter);
+        });
+
+        return parser.build();
+    }
+
     public interface SessionKey {
+        String getDescription();
+
         InetAddress getRemoteAddress();
     }
 
-    private final class UdpSession implements Session {
-        private final class Resolver implements Session.Resolver {
-            private final long observationDomainId;
+    private final static class DomainKey {
+        public final SessionKey sessionKey;
+        public final long observationDomainId;
 
-            private Resolver(final long observationDomainId) {
-                this.observationDomainId = observationDomainId;
-            }
-
-            private TemplateKey key(final int templateId) {
-                return new TemplateKey(UdpSession.this.sessionKey, this.observationDomainId, templateId);
-            }
-
-            @Override
-            public Template lookupTemplate(final int templateId) throws MissingTemplateException {
-                final TemplateWrapper templateWrapper = UdpSessionManager.this.templates.get(key(templateId));
-                if (templateWrapper != null) {
-                    return templateWrapper.template;
-                } else {
-                    throw new MissingTemplateException(templateId);
-                }
-            }
-
-            @Override
-            public List<Value<?>> lookupOptions(final List<Value<?>> values) {
-                final LinkedHashMap<String, Value<?>> options = new LinkedHashMap<>();
-
-                final Set<String> scoped = values.stream().map(Value::getName).collect(Collectors.toSet());
-
-                for (final Map.Entry<TemplateKey, Map<Set<Value<?>>, List<Value<?>>>> e : Iterables.filter(UdpSessionManager.this.options.entrySet(),
-                                                                                                   e -> Objects.equals(e.getKey().domain.sessionKey, UdpSession.this.sessionKey) &&
-                                                                                                        Objects.equals(e.getKey().domain.observationDomainId, this.observationDomainId))) {
-                    final Template template = UdpSessionManager.this.templates.get(e.getKey()).template;
-
-                    if (scoped.containsAll(template.scopeNames)) {
-                        // Found option template where scoped fields is subset of actual data fields
-
-                        final Set<Value<?>> scopeValues = values.stream()
-                                .filter(s -> template.scopeNames.contains(s.getName()))
-                                .collect(Collectors.toSet());
-
-                        for (final Value<?> value : e.getValue().getOrDefault(scopeValues, Collections.emptyList())) {
-                            options.put(value.getName(), value);
-                        }
-                    }
-                }
-
-                return new ArrayList<>(options.values());
-            }
+        private DomainKey(final SessionKey sessionKey,
+                          final long observationDomainId) {
+            this.sessionKey = Objects.requireNonNull(sessionKey);
+            this.observationDomainId = observationDomainId;
         }
 
+        @Override
+        public boolean equals(final Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof DomainKey)) {
+                return false;
+            }
+
+            final DomainKey that = (DomainKey) o;
+            return Objects.equals(this.observationDomainId, that.observationDomainId) &&
+                   Objects.equals(this.sessionKey, that.sessionKey);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(this.sessionKey, this.observationDomainId);
+        }
+    }
+
+    private final static class TemplateKey {
+        public final DomainKey observationDomainId;
+        public final int templateId;
+
+        TemplateKey(final SessionKey sessionKey,
+                    final long observationDomainId,
+                    final int templateId) {
+            this.observationDomainId = new DomainKey(sessionKey, observationDomainId);
+            this.templateId = templateId;
+        }
+
+        @Override
+        public boolean equals(final Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof TemplateKey)) {
+                return false;
+            }
+
+            final TemplateKey that = (TemplateKey) o;
+            return Objects.equals(this.observationDomainId, that.observationDomainId) &&
+                   Objects.equals(this.templateId, that.templateId);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(this.observationDomainId, this.templateId);
+        }
+    }
+
+    private final static class TimeWrapper<T> {
+        public final Instant time;
+        public final T wrapped;
+
+        private TimeWrapper(final T wrapped) {
+            this.time = Instant.now();
+            this.wrapped = wrapped;
+        }
+    }
+
+    private final class UdpSession implements Session {
         private final SessionKey sessionKey;
 
         public UdpSession(final SessionKey sessionKey) {
@@ -114,7 +201,7 @@ public class UdpSessionManager {
         @Override
         public void addTemplate(final long observationDomainId, final Template template) {
             final TemplateKey key = new TemplateKey(this.sessionKey, observationDomainId, template.id);
-            UdpSessionManager.this.templates.put(key, new TemplateWrapper(template));
+            UdpSessionManager.this.templates.put(key, new TimeWrapper<>(template));
         }
 
         @Override
@@ -125,7 +212,7 @@ public class UdpSessionManager {
 
         @Override
         public void removeAllTemplate(final long observationDomainId, final Template.Type type) {
-            UdpSessionManager.this.templates.entrySet().removeIf(e -> e.getKey().domain.observationDomainId == observationDomainId && e.getValue().template.type == type);
+            UdpSessionManager.this.templates.entrySet().removeIf(e -> e.getKey().observationDomainId.observationDomainId == observationDomainId && e.getValue().wrapped.type == type);
         }
 
         @Override
@@ -134,7 +221,7 @@ public class UdpSessionManager {
                                final Collection<Value<?>> scopes,
                                final List<Value<?>> values) {
             final TemplateKey key = new TemplateKey(this.sessionKey, observationDomainId, templateId);
-            UdpSessionManager.this.options.computeIfAbsent(key, (k) -> new HashMap<>()).put(new HashSet<>(scopes), values);
+            UdpSessionManager.this.options.computeIfAbsent(key, (k) -> new HashMap<>()).put(new HashSet<>(scopes), new TimeWrapper<>(values));
         }
 
         @Override
@@ -153,98 +240,58 @@ public class UdpSessionManager {
             final SequenceNumberTracker tracker = UdpSessionManager.this.sequenceNumbers.computeIfAbsent(key, (k) -> UdpSessionManager.this.sequenceNumberTracker.get());
             return tracker.verify(sequenceNumber);
         }
-    }
 
-    private final static class DomainKey {
-        public final SessionKey sessionKey;
-        public final long observationDomainId;
+        private final class Resolver implements Session.Resolver {
+            private final long observationDomainId;
 
-        private DomainKey(final SessionKey sessionKey,
-                          final long observationDomainId) {
-            this.sessionKey = Objects.requireNonNull(sessionKey);
-            this.observationDomainId = observationDomainId;
-        }
+            private Resolver(final long observationDomainId) {
+                this.observationDomainId = observationDomainId;
+            }
 
-        @Override
-        public boolean equals(final Object o) {
-            if (this == o) return true;
-            if (!(o instanceof DomainKey)) return false;
+            private TemplateKey key(final int templateId) {
+                return new TemplateKey(UdpSession.this.sessionKey, this.observationDomainId, templateId);
+            }
 
-            final DomainKey that = (DomainKey) o;
-            return Objects.equals(this.observationDomainId, that.observationDomainId) &&
-                   Objects.equals(this.sessionKey, that.sessionKey);
-        }
+            @Override
+            public Template lookupTemplate(final int templateId) throws MissingTemplateException {
+                final TimeWrapper<Template> templateWrapper = UdpSessionManager.this.templates.get(key(templateId));
+                if (templateWrapper != null) {
+                    return templateWrapper.wrapped;
+                } else {
+                    throw new MissingTemplateException(templateId);
+                }
+            }
 
-        @Override
-        public int hashCode() {
-            return Objects.hash(this.sessionKey, this.observationDomainId);
-        }
-    }
+            @Override
+            public List<Value<?>> lookupOptions(final List<Value<?>> values) {
+                final LinkedHashMap<String, Value<?>> options = new LinkedHashMap<>();
 
-    private final static class TemplateKey {
-        public final DomainKey domain;
-        public final int templateId;
+                final Set<String> scoped = values.stream().map(Value::getName).collect(Collectors.toSet());
 
-        TemplateKey(final SessionKey sessionKey,
-                    final long observationDomainId,
-                    final int templateId) {
-            this.domain = new DomainKey(sessionKey, observationDomainId);
-            this.templateId = templateId;
-        }
+                for (final Map.Entry<TemplateKey, Map<Set<Value<?>>, TimeWrapper<List<Value<?>>>>> e : Iterables.filter(UdpSessionManager.this.options.entrySet(),
+                                                                                                                        e -> Objects.equals(e.getKey().observationDomainId.sessionKey, UdpSession.this.sessionKey) &&
+                                                                                                                             Objects.equals(e.getKey().observationDomainId.observationDomainId, this.observationDomainId))) {
+                    final Template template = UdpSessionManager.this.templates.get(e.getKey()).wrapped;
 
-        @Override
-        public boolean equals(final Object o) {
-            if (this == o) return true;
-            if (!(o instanceof TemplateKey)) return false;
+                    if (scoped.containsAll(template.scopeNames)) {
+                        // Found option template where scoped fields is subset of actual data fields
 
-            final TemplateKey that = (TemplateKey) o;
-            return Objects.equals(this.domain, that.domain) &&
-                   Objects.equals(this.templateId, that.templateId);
-        }
+                        final Set<Value<?>> scopeValues = values.stream()
+                                                                .filter(s -> template.scopeNames.contains(s.getName()))
+                                                                .collect(Collectors.toSet());
 
-        @Override
-        public int hashCode() {
-            return Objects.hash(this.domain, this.templateId);
-        }
-    }
+                        final TimeWrapper<List<Value<?>>> optionValues = e.getValue().get(scopeValues);
+                        if (optionValues != null) {
+                            for (final Value<?> value : optionValues.wrapped) {
+                                options.put(value.getName(), value);
+                            }
+                        }
+                    }
+                }
 
-    private final static class TemplateWrapper {
-        public final Instant insertionTime;
-        public final Template template;
-
-        private TemplateWrapper(final Template template) {
-            this.insertionTime = Instant.now();
-            this.template = template;
+                return new ArrayList<>(options.values());
+            }
         }
     }
 
-    private final Map<TemplateKey, TemplateWrapper> templates = Maps.newHashMap();
-    private final Map<TemplateKey, Map<Set<Value<?>>, List<Value<?>>>> options = Maps.newHashMap();
-    private final Map<DomainKey, SequenceNumberTracker> sequenceNumbers = Maps.newHashMap();
-
-    private final Duration timeout;
-
-    private final Supplier<SequenceNumberTracker> sequenceNumberTracker;
-
-    public UdpSessionManager(final Duration timeout, final Supplier<SequenceNumberTracker> sequenceNumberTracker) {
-        this.timeout = timeout;
-        this.sequenceNumberTracker = Objects.requireNonNull(sequenceNumberTracker);
-    }
-
-    public void doHousekeeping() {
-        final Instant timeout = Instant.now().minus(this.timeout);
-        UdpSessionManager.this.templates.entrySet().removeIf(e -> e.getValue().insertionTime.isBefore(timeout));
-    }
-
-    public Session getSession(final SessionKey sessionKey) {
-        return new UdpSession(sessionKey);
-    }
-
-    public void drop(final SessionKey sessionKey) {
-        this.templates.entrySet().removeIf(e -> Objects.equals(e.getKey().domain.sessionKey, sessionKey));
-    }
-
-    public int count() {
-        return this.templates.size();
-    }
 }

--- a/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/state/ExporterState.java
+++ b/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/state/ExporterState.java
@@ -1,0 +1,85 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2021 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.telemetry.protocols.netflow.parser.state;
+
+import java.util.List;
+import java.util.Objects;
+
+import com.google.common.collect.ImmutableList;
+
+public class ExporterState {
+    public final String key;
+
+    public final List<TemplateState> templates;
+    public final List<OptionState> options;
+
+    public ExporterState(Builder builder) {
+        this.key = Objects.requireNonNull(builder.key);
+
+        this.templates = Objects.requireNonNull(builder.templates.build());
+        this.options = Objects.requireNonNull(builder.options.build());
+    }
+
+    public static Builder builder(final String sessionKey) {
+        return new Builder(sessionKey);
+    }
+
+    public static class Builder {
+        private final String key;
+
+        private final ImmutableList.Builder<TemplateState> templates = ImmutableList.builder();
+        private final ImmutableList.Builder<OptionState> options = ImmutableList.builder();
+
+        private Builder(final String key) {
+            this.key = Objects.requireNonNull(key);
+        }
+
+        public Builder withTemplate(final TemplateState state) {
+            this.templates.add(state);
+            return this;
+        }
+
+        public Builder withTemplate(final TemplateState.Builder state) {
+            return this.withTemplate(state.build());
+        }
+
+        public Builder withOptions(final OptionState state) {
+            this.options.add(state);
+            return this;
+        }
+
+        public Builder withOptions(final OptionState.Builder state) {
+            return this.withOptions(state.build());
+        }
+
+        public ExporterState build() {
+            return new ExporterState(this);
+        }
+    }
+}

--- a/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/state/OptionState.java
+++ b/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/state/OptionState.java
@@ -1,0 +1,130 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2021 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.telemetry.protocols.netflow.parser.state;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Objects;
+
+import org.opennms.netmgt.telemetry.protocols.netflow.parser.ie.Value;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+public class OptionState {
+    public final int templateId;
+
+    public final Duration age;
+
+    public final List<NamedValue> selectors;
+    public final List<NamedValue> values;
+
+    public OptionState(Builder builder) {
+        this.templateId = builder.templateId;
+
+        this.age = builder.age;
+
+        this.selectors = Objects.requireNonNull(builder.selectors.build());
+        this.values = Objects.requireNonNull(builder.values.build());
+    }
+
+    public static Builder builder(final int templateId) {
+        return new Builder(templateId);
+    }
+
+    public static class Builder {
+        private int templateId;
+
+        private Duration age;
+
+        private final ImmutableList.Builder<NamedValue> selectors = ImmutableList.builder();
+        private final ImmutableList.Builder<NamedValue> values = ImmutableList.builder();
+
+        private Builder(final int templateId) {
+            this.templateId = templateId;
+        }
+
+        public Builder withTemplateId(final int templateId) {
+            this.templateId = templateId;
+            return this;
+        }
+
+        public Builder withAge(final Duration age) {
+            this.age = age;
+            return this;
+        }
+
+        public Builder withInsertionTime(final Instant insertionTime) {
+            return this.withAge(Duration.between(insertionTime, Instant.now()));
+        }
+
+        public Builder withSelectors(final Iterable<Value<?>> selectors) {
+            for (final Value<?> selector : selectors) {
+                this.selectors.add(NamedValue.from(selector));
+            }
+            return this;
+        }
+
+        public Builder withSelector(final Value<?> selector) {
+            this.selectors.add(NamedValue.from(selector));
+            return this;
+        }
+
+        public Builder withValues(final Iterable<Value<?>> values) {
+            for (final Value<?> value : values) {
+                this.values.add(NamedValue.from(value));
+            }
+            return this;
+        }
+
+        public Builder withValue(final Value<?> value) {
+            this.values.add(NamedValue.from(value));
+            return this;
+        }
+
+        public OptionState build() {
+            return new OptionState(this);
+        }
+    }
+
+    public static class NamedValue {
+        public final String name;
+        public final String value;
+
+        public NamedValue(final String name, final String value) {
+            this.name = Objects.requireNonNull(name);
+            this.value = Objects.requireNonNull(value);
+        }
+
+        public static NamedValue from(final Value<?> value) {
+            return new NamedValue(value.getName(), value.getValue().toString());
+        }
+    }
+}

--- a/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/state/ParserState.java
+++ b/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/state/ParserState.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2017-2017 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
+ * Copyright (C) 2021 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -26,25 +26,41 @@
  *     http://www.opennms.com/
  *******************************************************************************/
 
-package org.opennms.netmgt.telemetry.api.receiver;
+package org.opennms.netmgt.telemetry.protocols.netflow.parser.state;
 
-import java.util.concurrent.ScheduledExecutorService;
+import java.util.List;
 
-import org.opennms.core.ipc.sink.api.AsyncDispatcher;
+import com.google.common.collect.ImmutableList;
 
-/**
- * Interface used by the daemon to manage parsers.
- *
- * When messages are received, they should be forwarded to the given {@link AsyncDispatcher}.
- *
- * @author jwhite
- */
-public interface Parser {
-    String getName();
-    String getDescription();
+public class ParserState {
 
-    Object dumpInternalState();
+    public final List<ExporterState> exporters;
 
-    void start(final ScheduledExecutorService executorService);
-    void stop();
+    private ParserState(final Builder builder) {
+        this.exporters = builder.exporters.build();
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private final ImmutableList.Builder<ExporterState> exporters = ImmutableList.builder();
+
+        private Builder() {
+        }
+
+        public Builder withExporter(final ExporterState state) {
+            this.exporters.add(state);
+            return this;
+        }
+
+        public Builder withExporter(final ExporterState.Builder state) {
+            return this.withExporter(state.build());
+        }
+
+        public ParserState build() {
+            return new ParserState(this);
+        }
+    }
 }

--- a/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/state/TemplateState.java
+++ b/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/state/TemplateState.java
@@ -1,0 +1,77 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2021 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.telemetry.protocols.netflow.parser.state;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Objects;
+
+public class TemplateState {
+    public final int templateId;
+
+    public final Duration age;
+
+    public TemplateState(final Builder builder) {
+        this.templateId = builder.templateId;
+
+        this.age = Objects.requireNonNull(builder.age);
+    }
+
+    public static Builder builder(final int templateId) {
+        return new Builder(templateId);
+    }
+
+    public static class Builder {
+        private int templateId;
+
+        private Duration age;
+
+        private Builder(final int templateId) {
+            this.templateId = templateId;
+        }
+
+        public Builder withTemplateId(final int templateId) {
+            this.templateId = templateId;
+            return this;
+        }
+
+        public Builder withAge(final Duration age) {
+            this.age = age;
+            return this;
+        }
+
+        public Builder withInsertionTime(final Instant insertionTime) {
+            return this.withAge(Duration.between(insertionTime, Instant.now()));
+        }
+
+        public TemplateState build() {
+            return new TemplateState(this);
+        }
+    }
+}

--- a/features/telemetry/protocols/netflow/parser/src/test/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/ClockSkewTest.java
+++ b/features/telemetry/protocols/netflow/parser/src/test/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/ClockSkewTest.java
@@ -182,5 +182,10 @@ public class ClockSkewTest {
                 }
             };
         }
+
+        @Override
+        public Object dumpInternalState() {
+            return null;
+        }
     }
 }

--- a/features/telemetry/protocols/sflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/sflow/parser/SFlowUdpParser.java
+++ b/features/telemetry/protocols/sflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/sflow/parser/SFlowUdpParser.java
@@ -180,6 +180,17 @@ public class SFlowUdpParser implements UdpParser, Dispatchable {
     }
 
     @Override
+    public String getDescription() {
+        return "SFlow";
+    }
+
+    @Override
+    public Object dumpInternalState() {
+        // There is no internal state
+        return null;
+    }
+
+    @Override
     public void start(final ScheduledExecutorService executorService) {
         executor = new ThreadPoolExecutor(
                 // corePoolSize must be > 0 since we use the RejectedExecutionHandler to block when the queue is full

--- a/features/telemetry/shell/pom.xml
+++ b/features/telemetry/shell/pom.xml
@@ -7,8 +7,8 @@
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opennms.features.telemetry</groupId>
-  <artifactId>org.opennms.features.telemetry.daemon</artifactId>
-  <name>OpenNMS :: Features :: Telemetry :: Daemon</name>
+  <artifactId>org.opennms.features.telemetry.shell</artifactId>
+  <name>OpenNMS :: Features :: Telemetry :: Shell</name>
   <packaging>bundle</packaging>
   <build>
     <plugins>
@@ -21,6 +21,7 @@
             <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
+            <Karaf-Commands>*</Karaf-Commands>
           </instructions>
         </configuration>
       </plugin>
@@ -28,44 +29,28 @@
   </build>
   <dependencies>
     <dependency>
-      <groupId>org.opennms.core</groupId>
-      <artifactId>org.opennms.core.daemon</artifactId>
-    </dependency>
-    <dependency>
-      <!-- Required for the DefaultCollectionAgentFactory implementation -->
-      <groupId>org.opennms</groupId>
-      <artifactId>opennms-services</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.opennms.features.telemetry</groupId>
-      <artifactId>org.opennms.features.telemetry.common</artifactId>
+      <artifactId>org.opennms.features.telemetry.api</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.opennms.features.telemetry.config</groupId>
-      <artifactId>org.opennms.features.telemetry.config.jaxb</artifactId>
-      <version>${project.version}</version>
+      <groupId>org.apache.karaf.shell</groupId>
+      <artifactId>org.apache.karaf.shell.core</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.opennms.core.test-api</groupId>
-      <artifactId>org.opennms.core.test-api.xml</artifactId>
-      <scope>test</scope>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.core</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.opennms.core.ipc.rpc</groupId>
-      <artifactId>org.opennms.core.ipc.rpc.mock-impl</artifactId>
-      <version>${project.version}</version>
-      <scope>test</scope>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+      <version>${gsonVersion}</version>
     </dependency>
     <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-library</artifactId>
-      <scope>test</scope>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
     </dependency>
   </dependencies>
 </project>

--- a/features/telemetry/shell/src/main/java/org/opennms/netmgt/telemetry/shell/Format.java
+++ b/features/telemetry/shell/src/main/java/org/opennms/netmgt/telemetry/shell/Format.java
@@ -1,0 +1,131 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2021 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.telemetry.shell;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+import org.apache.commons.lang3.StringUtils;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+
+public enum Format {
+    PLAIN {
+        private Stream<String> indent(final String first, final String other, final Stream<String> input) {
+            final var state = new AtomicBoolean(true);
+            return input.map(line -> String.format("%s%s",
+                                                   state.compareAndSet(true, false)
+                                                   ? first
+                                                   : other,
+                                                   line));
+        }
+
+        private Stream<String> object(final JsonObject data) {
+            return data.entrySet().stream()
+                       .flatMap(entry -> {
+                           final var name = StringUtils.capitalize(
+                                   StringUtils.join(
+                                           StringUtils.splitByCharacterTypeCamelCase(entry.getKey()),
+                                           StringUtils.SPACE));
+
+                           if (entry.getValue().isJsonNull()) {
+                               return Stream.empty();
+                           }
+
+                           if (entry.getValue().isJsonPrimitive()) {
+                               return Stream.of(String.format("%s = %s", name, entry.getValue().getAsJsonPrimitive().getAsString()));
+                           }
+
+                           if (entry.getValue().isJsonArray()) {
+                               return Stream.concat(
+                                       Stream.of(String.format("%s:", name)),
+                                       indent("  ", "  ", array(entry.getValue().getAsJsonArray())));
+                           }
+
+                           if (entry.getValue().isJsonObject()) {
+                               return Stream.concat(
+                                       Stream.of(String.format("%s:", name)),
+                                       indent("  ", "  ", object(entry.getValue().getAsJsonObject())));
+                           }
+
+                           throw new IllegalArgumentException(entry.getValue().toString());
+                       });
+
+        }
+
+        private Stream<String> array(final JsonArray data) {
+            return StreamSupport.stream(data.spliterator(), false)
+                                .flatMap(element -> {
+                                    if (element.isJsonNull()) {
+                                        return Stream.empty();
+                                    }
+
+                                    if (element.isJsonPrimitive()) {
+                                        return Stream.of(String.format("- %s", element.getAsJsonPrimitive().getAsString()));
+                                    }
+
+                                    if (element.isJsonObject()) {
+                                        return indent("- ", "  ", object(element.getAsJsonObject()));
+                                    }
+
+                                    if (element.isJsonArray()) {
+                                        return indent("- ", "  ", array(element.getAsJsonArray()));
+                                    }
+
+                                    throw new IllegalArgumentException(element.toString());
+                                });
+        }
+
+        @Override
+        public void print(final List<JsonObject> data) {
+            data.forEach(element -> {
+                final JsonObject json = Utils.GSON.toJsonTree(element)
+                                                  .getAsJsonObject();
+
+                object(json).forEach(System.out::println);
+                System.out.println();
+            });
+        }
+    },
+
+    JSON {
+        @Override
+        public void print(final List<JsonObject> data) {
+            final String json = Utils.GSON.toJson(data);
+            System.out.println(json);
+        }
+    },
+
+    ;
+
+    public abstract void print(final List<JsonObject> data);
+}

--- a/features/telemetry/shell/src/main/java/org/opennms/netmgt/telemetry/shell/Listeners.java
+++ b/features/telemetry/shell/src/main/java/org/opennms/netmgt/telemetry/shell/Listeners.java
@@ -1,0 +1,81 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2021 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.telemetry.shell;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.apache.karaf.shell.api.action.Action;
+import org.apache.karaf.shell.api.action.Argument;
+import org.apache.karaf.shell.api.action.Command;
+import org.apache.karaf.shell.api.action.Option;
+import org.apache.karaf.shell.api.action.lifecycle.Reference;
+import org.apache.karaf.shell.api.action.lifecycle.Service;
+import org.opennms.netmgt.telemetry.api.TelemetryManager;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+
+@Command(scope = "opennms", name = "telemetry-listeners", description = "Lists configured telemetry listeners")
+@Service
+public class Listeners implements Action {
+
+    @Reference
+    public TelemetryManager manager;
+
+    @Argument(index = 0, name = "listener", description = "Filter listeners shown by this RegEx", required = false)
+    public String listenerFilter = ".*";
+
+    @Option(name = "-f", aliases = "--format", description = "Dump data in given format", required = false, multiValued = false)
+    public Format format = Format.PLAIN;
+
+    @Override
+    public Object execute() {
+        final List<JsonObject> output = this.manager
+                .getListeners().stream()
+                .filter(listener -> listener.getName().matches(this.listenerFilter))
+                .map(listener -> {
+                    final JsonObject data = new JsonObject();
+                    data.addProperty("name", listener.getName());
+                    data.addProperty("description", listener.getDescription());
+
+                    data.add("properties", Utils.getWritableProperties(listener));
+
+                    final var parsers = new JsonArray();
+                    listener.getParsers().forEach(parser -> parsers.add(parser.getName()));
+                    data.add("parsers", parsers);
+
+                    return data;
+                }).collect(Collectors.toList());
+
+        this.format.print(output);
+
+        return null;
+    }
+}

--- a/features/telemetry/shell/src/main/java/org/opennms/netmgt/telemetry/shell/Parsers.java
+++ b/features/telemetry/shell/src/main/java/org/opennms/netmgt/telemetry/shell/Parsers.java
@@ -1,0 +1,98 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2021 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.telemetry.shell;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.apache.karaf.shell.api.action.Action;
+import org.apache.karaf.shell.api.action.Argument;
+import org.apache.karaf.shell.api.action.Command;
+import org.apache.karaf.shell.api.action.Option;
+import org.apache.karaf.shell.api.action.lifecycle.Reference;
+import org.apache.karaf.shell.api.action.lifecycle.Service;
+import org.opennms.netmgt.telemetry.api.TelemetryManager;
+import org.opennms.netmgt.telemetry.api.receiver.Listener;
+
+import com.google.gson.JsonObject;
+
+@Command(scope = "opennms", name = "telemetry-parsers", description = "Lists configured telemetry parsers")
+@Service
+public class Parsers implements Action {
+
+    @Reference
+    public TelemetryManager manager;
+
+    @Argument(index = 0, name = "listener", description = "The listener to show parsers for", required = true, multiValued = false)
+    public String listener;
+
+    @Argument(index = 1, name = "parser", description = "Filter parsers shown by this RegEx", required = false)
+    public String parserFilter = ".*";
+
+    @Option(name = "-s", aliases = "--state", description = "Show internal state", required = false, multiValued = false)
+    public boolean showState = false;
+
+    @Option(name = "-f", aliases = "--format", description = "Dump data in given format", required = false, multiValued = false)
+    public Format format = Format.PLAIN;
+
+    @Override
+    public Object execute() {
+        final Optional<Listener> listener = this.manager.getListeners().stream()
+                                                        .filter(l -> Objects.equals(l.getName(), this.listener))
+                                                        .findAny();
+
+        if (listener.isPresent()) {
+            final List<JsonObject> output = listener
+                    .get().getParsers().stream()
+                    .filter(parser -> parser.getName().matches(this.parserFilter))
+                    .map(parser -> {
+                        final JsonObject data = new JsonObject();
+                        data.addProperty("name", parser.getName());
+                        data.addProperty("description", parser.getDescription());
+
+                        data.add("properties", Utils.getWritableProperties(parser));
+
+                        if (this.showState) {
+                            data.add("state", Utils.GSON.toJsonTree(parser.dumpInternalState()));
+                        }
+
+                        return data;
+                    }).collect(Collectors.toList());
+
+            this.format.print(output);
+
+        } else {
+            System.err.printf("No such listener: %s\n", this.listener);
+        }
+
+        return null;
+    }
+}

--- a/features/telemetry/shell/src/main/java/org/opennms/netmgt/telemetry/shell/Utils.java
+++ b/features/telemetry/shell/src/main/java/org/opennms/netmgt/telemetry/shell/Utils.java
@@ -1,0 +1,91 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2021 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.telemetry.shell;
+
+import java.beans.PropertyDescriptor;
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.time.Duration;
+
+import org.springframework.beans.BeanWrapper;
+import org.springframework.beans.PropertyAccessorFactory;
+
+import com.google.common.base.Throwables;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonObject;
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+
+public class Utils {
+
+    public static final Gson GSON = new GsonBuilder()
+            .setPrettyPrinting()
+            .registerTypeAdapter(Duration.class, new DurationTypeAdapter())
+            .create();
+
+    /**
+     * Returns the values for all bean properties that are writable.
+     *
+     * @param bean the bean to get the properties for
+     * @return a map from property name to property value
+     */
+    public static JsonObject getWritableProperties(final Object bean) {
+        final BeanWrapper wrapper = PropertyAccessorFactory.forBeanPropertyAccess(bean);
+
+        final JsonObject result = new JsonObject();
+        for (final PropertyDescriptor desc : wrapper.getPropertyDescriptors()) {
+            if (desc.getReadMethod() == null || desc.getWriteMethod() == null) {
+                continue;
+            }
+
+            try {
+                result.add(desc.getDisplayName(),
+                           GSON.toJsonTree(desc.getReadMethod().invoke(bean)));
+            } catch (IllegalAccessException | InvocationTargetException e) {
+                throw Throwables.propagate(e);
+            }
+        }
+
+        return result;
+    }
+
+    public static class DurationTypeAdapter extends TypeAdapter<Duration> {
+        @Override
+        public void write(final JsonWriter out, final Duration value) throws IOException {
+            out.value(value.getSeconds());
+        }
+
+        @Override
+        public Duration read(final JsonReader in) throws IOException {
+            return Duration.ofSeconds(in.nextLong());
+        }
+    }
+}

--- a/opennms-base-assembly/pom.xml
+++ b/opennms-base-assembly/pom.xml
@@ -1127,6 +1127,11 @@
       <artifactId>org.opennms.features.telemetry.daemon</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.opennms.features.telemetry</groupId>
+      <artifactId>org.opennms.features.telemetry.shell</artifactId>
+      <version>${project.version}</version>
+    </dependency>
     <!-- Topologies -->
     <dependency>
       <groupId>org.opennms.features.topologies</groupId>

--- a/opennms-full-assembly/pom.xml
+++ b/opennms-full-assembly/pom.xml
@@ -1060,6 +1060,11 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.opennms.features.telemetry</groupId>
+      <artifactId>org.opennms.features.telemetry.shell</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.opennms.features.ticketing</groupId>
       <artifactId>org.opennms.features.ticketing.inmemory</artifactId>
       <version>${project.version}</version>


### PR DESCRIPTION
This adds two commands to examine the configuration and the internal
status of telemetryd. First command listens the configured listeners,
second one lists the parsers defined for a listener. The parsers can
show the internal parser specific state if requested.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-13346
