### PR TITLE
Fix typos for millisecond unit

### DIFF
--- a/core/ipc/rpc/shell-commands/src/main/java/org/opennms/core/rpc/commands/StressCommand.java
+++ b/core/ipc/rpc/shell-commands/src/main/java/org/opennms/core/rpc/commands/StressCommand.java
@@ -61,10 +61,10 @@ public class StressCommand implements Action {
     @Option(name = "-s", aliases = "--system-id", description = "System ID")
     String systemId = null;
 
-    @Option(name = "-t", aliases = "--ttl", description = "Time to live (miliseconds)")
+    @Option(name = "-t", aliases = "--ttl", description = "Time to live (milliseconds)")
     Long ttlInMs;
 
-    @Option(name = "-d", aliases = "--delay", description = "Response delay (miliseconds)")
+    @Option(name = "-d", aliases = "--delay", description = "Response delay (milliseconds)")
     Long delay;
 
     @Option (name="-ms", aliases = "--message-size", description="Message size (number of charaters)")
@@ -130,9 +130,9 @@ public class StressCommand implements Action {
                 .build();
         reporter.report();
         reporter.close();
-        System.out.printf("Total miliseconds elapsed: %d\n", afterResponse - beforeExec);
-        System.out.printf("Miliseconds spent generating requests: %d\n", afterExec - beforeExec);
-        System.out.printf("Miliseconds spent waiting for responses: %d\n", afterResponse - afterExec);
+        System.out.printf("Total milliseconds elapsed: %d\n", afterResponse - beforeExec);
+        System.out.printf("Milliseconds spent generating requests: %d\n", afterExec - beforeExec);
+        System.out.printf("Milliseconds spent waiting for responses: %d\n", afterResponse - afterExec);
 
         return null;
     }

--- a/docs/modules/operation/pages/provisioning/import-handler.adoc
+++ b/docs/modules/operation/pages/provisioning/import-handler.adoc
@@ -27,7 +27,7 @@ In addition to the type specific parameters, the following parameters are suppor
 | `ttl`                  | The maximum number of milliseconds to wait for the handler when ran remotely    | optional | 20000
 |===
 
-See the relevant sections bellow for additional details on the support types.
+See the relevant sections below for additional details on the support types.
 
 The `opennms:show-import` command available via the _Karaf Shell_ can be used to show the results of an import (without persisting or triggering the import):
 

--- a/docs/modules/operation/pages/provisioning/import-handler.adoc
+++ b/docs/modules/operation/pages/provisioning/import-handler.adoc
@@ -24,7 +24,7 @@ In addition to the type specific parameters, the following parameters are suppor
 |===
 | Parameter              | Description                                                                    | Required | Default value
 | `location`             | The name of location at which the handler should be run                        | optional | Default
-| `ttl`                  | The maximum number of miliseconds to wait for the handler when ran remotely    | optional | 20000
+| `ttl`                  | The maximum number of milliseconds to wait for the handler when ran remotely    | optional | 20000
 |===
 
 See the relevant sections bellow for additional details on the support types.

--- a/features/poller/monitors/core/src/main/java/org/opennms/netmgt/poller/monitors/JDBCMonitor.java
+++ b/features/poller/monitors/core/src/main/java/org/opennms/netmgt/poller/monitors/JDBCMonitor.java
@@ -68,8 +68,8 @@ public class JDBCMonitor extends ParameterSubstitutingMonitor {
     public static final Logger LOG = LoggerFactory.getLogger(JDBCMonitor.class);
     
 	/**
-	 * Number of miliseconds to wait before timing out a database login using
-	 * JDBC Hint: 1 minute is 6000 miliseconds.
+	 * Number of milliseconds to wait before timing out a database login
+	 * JDBC Hint: 1 minute is 60000 milliseconds.
 	 */
 	public static final int DEFAULT_TIMEOUT = 3000;
 


### PR DESCRIPTION
### All Contributors

* [ ] Have you read and followed our [Contribution Guidelines](https://github.com/OpenNMS/opennms/blob/develop/CONTRIBUTING.md)?
* [ ] Have you [made an issue in the OpenNMS issue tracker](https://issues.opennms.org)?<br>If so, you should:
  1. update the title of this PR to be of the format: `${JIRA-ISSUE-NUMBER}: subject of pull request`
  2. update the JIRA link at the bottom of this comment to refer to the real issue number
  3. prefix your commit messages with the issue number, if possible
* [ ] Have you made a comment in that issue which points back to this PR?
* [ ] Have you updated the JIRA link at the bottom of this comment to link to your issue?
* [ ] If this is a new or updated feature, is there documentation for the new behavior?
* [ ] If this is new code, are there unit and/or integration tests?
* [ ] If this PR targets a `foundation-*` branch, does it avoid changing files in `$OPENNMS_HOME/etc/`?

## Reviewer hint

Is this here maybe a german thing? I think milliseconds needs to have two `ll` :)


