### PR TITLE
NMS-13265: add default configuration for flow listeners to rpm/deb package but not to minion image

### DIFF
--- a/opennms-assemblies/minion/src/main/filtered/etc/org.opennms.features.telemetry.listeners-single-port-flows.cfg
+++ b/opennms-assemblies/minion/src/main/filtered/etc/org.opennms.features.telemetry.listeners-single-port-flows.cfg
@@ -1,0 +1,12 @@
+name = Flows
+class-name = org.opennms.netmgt.telemetry.listeners.UdpListener
+parameters.port = 9999
+# Parser names should match queue names set in telemetryd configuration
+parsers.0.name = Netflow-5
+parsers.0.class-name = org.opennms.netmgt.telemetry.protocols.netflow.parser.Netflow5UdpParser
+parsers.1.name = Netflow-9
+parsers.1.class-name = org.opennms.netmgt.telemetry.protocols.netflow.parser.Netflow9UdpParser
+parsers.2.name = IPFIX
+parsers.2.class-name = org.opennms.netmgt.telemetry.protocols.netflow.parser.IpfixUdpParser
+parsers.3.name = SFlow
+parsers.3.class-name = org.opennms.netmgt.telemetry.protocols.sflow.parser.SFlowUdpParser

--- a/opennms-container/minion/Dockerfile
+++ b/opennms-container/minion/Dockerfile
@@ -15,6 +15,7 @@ ADD ./tarball/minion.tar.gz /opt/
 
 # Organize files based on the build home dir /opt/minion
 RUN mv /opt/minion-* /opt/minion
+RUN rm /opt/minion/etc/org.opennms.features.telemetry.listeners-single-port-flows.cfg
 
 # Install wget and update certificates for arm/v7 otherwise SSL
 # ERROR: cannot verify repo1.maven.org's certificate, issued by 'CN=DigiCert SHA2 Secure Server CA,O=DigiCert Inc,C=US':


### PR DESCRIPTION
Issue: https://issues.opennms.org/browse/NMS-13265