### PR TITLE
NMS-13432/NMS-13433: Move dependencies to deploy base image and publish OCI after smoke tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -581,6 +581,7 @@ workflows:
           context: "docker-content-trust"
           requires:
             - tarball-assembly
+            - smoke-test-minion
           filters:
             branches:
               only:

--- a/opennms-container/minion/Dockerfile
+++ b/opennms-container/minion/Dockerfile
@@ -4,25 +4,15 @@
 # To avoid issues, we rearrange the directories in pre-stage to avoid injecting these
 # as addtional layers into the final image.
 ##
-ARG BASE_IMAGE="opennms/deploy-base:jre-1.2.0.b88"
+ARG BASE_IMAGE="opennms/deploy-base:jre-1.2.0.b105"
 
 FROM ${BASE_IMAGE} as minion-base
-
-ARG PROM_JMX_EXPORTER_VERSION="0.15.0"
-ARG PROM_JMX_EXPORTER_URL="https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/${PROM_JMX_EXPORTER_VERSION}/jmx_prometheus_javaagent-${PROM_JMX_EXPORTER_VERSION}.jar"
 
 ADD ./tarball/minion.tar.gz /opt/
 
 # Organize files based on the build home dir /opt/minion
 RUN mv /opt/minion-* /opt/minion
 RUN rm /opt/minion/etc/org.opennms.features.telemetry.listeners-single-port-flows.cfg
-
-# Install wget and update certificates for arm/v7 otherwise SSL
-# ERROR: cannot verify repo1.maven.org's certificate, issued by 'CN=DigiCert SHA2 Secure Server CA,O=DigiCert Inc,C=US':
-# To connect to repo1.maven.org insecurely, use `--no-check-certificate'.
-RUN apt-get update && apt-get -y install wget ca-certificates && update-ca-certificates -f && apt-get clean && rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /opt/prom-jmx-exporter && \
-    wget "${PROM_JMX_EXPORTER_URL}" --output-document=/opt/prom-jmx-exporter/jmx_prometheus_javaagent.jar
 
 # We set the correct permissions in this stage, so we don't have this as an addtional
 # layer in our deploy image.

--- a/opennms-container/minion/Makefile
+++ b/opennms-container/minion/Makefile
@@ -8,7 +8,7 @@
 VERSION                 := localbuild
 SHELL                   := /bin/bash -o nounset -o pipefail -o errexit
 BUILD_DATE              := $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
-BASE_IMAGE              := opennms/deploy-base:jre-1.2.0.b58
+BASE_IMAGE              := opennms/deploy-base:jre-1.2.0.b105
 DOCKER_CLI_EXPERIMENTAL := enabled
 DOCKERX_INSTANCE        := env-minion-oci
 DOCKER_REGISTRY         := docker.io
@@ -22,7 +22,6 @@ REVISION                := $(shell git describe --always)
 BUILD_NUMBER            := 0
 BUILD_URL               := "unset"
 BUILD_BRANCH            := $(shell git describe --always)
-PROM_JMX_EXPORTER_VERSION := 0.15.0
 
 %.yml: %.yml.in
 	@echo "Generating $@..."
@@ -62,7 +61,6 @@ help:
 	@echo "  BUILD_NUMBER:       In case we run in CI/CD this is the build number which produced the artifact, default: $(BUILD_NUMBER)"
 	@echo "  BUILD_URL:          In case we run in CI/CD this is the URL which for the build, default: $(BUILD_URL)"
 	@echo "  BUILD_BRANCH:       In case we run in CI/CD this is the branch of the build, default: $(BUILD_BRANCH)"
-	@echo "  PROM_JMX_EXPORTER_VERSION: Version for the Prometheus JMX Exporter agent, default: $(PROM_JMX_EXPORTER_VERSION)"
 	@echo ""
 	@echo "Example:"
 	@echo "  make build DOCKER_REGISTRY=myregistry.com DOCKER_ORG=myorg DOCKER_FLAGS=--push"
@@ -90,7 +88,6 @@ build: test minion-config-schema.yml
 	  --build-arg BUILD_NUMBER=$(BUILD_NUMBER) \
 	  --build-arg BUILD_URL=$(BUILD_URL) \
 	  --build-arg BUILD_BRANCH=$(BUILD_BRANCH) \
-	  --build-arg PROM_JMX_EXPORTER_VERSION=$(PROM_JMX_EXPORTER_VERSION) \
 	  --tag=$(DOCKER_TAG) \
 	  $(DOCKER_FLAGS) \
 	  .


### PR DESCRIPTION
### All Contributors

* [x] Have you read and followed our [Contribution Guidelines](https://github.com/OpenNMS/opennms/blob/develop/CONTRIBUTING.md)?
* [x] Have you [made an issue in the OpenNMS issue tracker](https://issues.opennms.org)?<br>If so, you should:
  1. update the title of this PR to be of the format: `${JIRA-ISSUE-NUMBER}: subject of pull request`
  2. update the JIRA link at the bottom of this comment to refer to the real issue number
  3. prefix your commit messages with the issue number, if possible
* [x] Have you made a comment in that issue which points back to this PR?
* [x] Have you updated the JIRA link at the bottom of this comment to link to your issue?
* [x] If this is a new or updated feature, is there documentation for the new behavior?
* [x] If this is new code, are there unit and/or integration tests?
* [x] If this PR targets a `foundation-*` branch, does it avoid changing files in `$OPENNMS_HOME/etc/`?

NMS-13433: We want to avoid publishing Minion images to the registry which don't pass the Minion tests. I've added an additional requirement to finish the Minion smoke tests first before building and publishing single and multi-arch Minion images. The Minion OCI image which is used in the Minion smoke tests is built very early in the Minion tarball assembly step.

NMS-13432: Move dependencies to deploy base image
* Upgrade deploy-base image to jre-1.2.0.b105
    * Update JMX Prometheus exporter from 0.15 to 0.16
    * Update Ubuntu base image from ubuntu:focal-20201106 to ubuntu:focal-20210609
    * Update OpenJDK JRE 11.0.7+10-3ubuntu1 to 11.0.11+9-0ubuntu2~20.04
* Moved installation from apt package dependencies to deploy-base image
* Moved installation from JMX Prometheus exporter dependency to deploy-base image

### Reviewer hint

I tried to be defensive first and targeted the PR for target H29. I was unsure if foundation-2021 might have issues with bouncy castle and TLS which relates to the OpenJDK JRE update later than `11.0.7+10-3ubuntu1`. If it's safe and no objections, we can retarget to foundation-2021.



### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-13432
* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-13433

