### PR TITLE
NMS-13401: Add preliminary interfaces for Object replication

### DIFF
--- a/core/onms-twin/api/pom.xml
+++ b/core/onms-twin/api/pom.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>org.opennms.core.onms-twin</artifactId>
+        <groupId>org.opennms.core</groupId>
+        <version>29.0.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.opennms.core.onms-twin</groupId>
+    <artifactId>org.opennms.core.onms-twin.api</artifactId>
+    <name>OpenNMS :: Core :: OpenNMS Twin :: API</name>
+    <packaging>bundle</packaging>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Version>${project.version}</Bundle-Version>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.opennms.core.test-api</groupId>
+            <artifactId>org.opennms.core.test-api.kafka</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.jayway.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/core/onms-twin/api/src/main/java/org/opennms/core/twin/api/OnmsTwin.java
+++ b/core/onms-twin/api/src/main/java/org/opennms/core/twin/api/OnmsTwin.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2021 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.core.twin.api;
+
+public interface OnmsTwin extends OnmsTwinRequest {
+
+    int getVersion();
+
+    byte[] getObjectValue();
+}

--- a/core/onms-twin/api/src/main/java/org/opennms/core/twin/api/OnmsTwin.java
+++ b/core/onms-twin/api/src/main/java/org/opennms/core/twin/api/OnmsTwin.java
@@ -28,9 +28,16 @@
 
 package org.opennms.core.twin.api;
 
+/**
+ * Base element for all the objects that need to replicate.
+ *
+ */
 public interface OnmsTwin extends OnmsTwinRequest {
 
     int getVersion();
 
+    /*
+       Marshalled object.
+     */
     byte[] getObjectValue();
 }

--- a/core/onms-twin/api/src/main/java/org/opennms/core/twin/api/OnmsTwinRequest.java
+++ b/core/onms-twin/api/src/main/java/org/opennms/core/twin/api/OnmsTwinRequest.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2021 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.core.twin.api;
+
+public interface OnmsTwinRequest {
+
+    String getKey();
+
+    String getLocation();
+}

--- a/core/onms-twin/api/src/main/java/org/opennms/core/twin/api/OnmsTwinRequest.java
+++ b/core/onms-twin/api/src/main/java/org/opennms/core/twin/api/OnmsTwinRequest.java
@@ -36,4 +36,6 @@ public interface OnmsTwinRequest {
     String getKey();
 
     String getLocation();
+
+    int getTTL();
 }

--- a/core/onms-twin/api/src/main/java/org/opennms/core/twin/api/OnmsTwinRequest.java
+++ b/core/onms-twin/api/src/main/java/org/opennms/core/twin/api/OnmsTwinRequest.java
@@ -28,6 +28,9 @@
 
 package org.opennms.core.twin.api;
 
+/*
+   Request object with specific key that represents module.
+ */
 public interface OnmsTwinRequest {
 
     String getKey();

--- a/core/onms-twin/api/src/main/java/org/opennms/core/twin/publisher/api/OnmsTwinPublisher.java
+++ b/core/onms-twin/api/src/main/java/org/opennms/core/twin/publisher/api/OnmsTwinPublisher.java
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2021 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.core.twin.publisher.api;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.opennms.core.twin.api.OnmsTwin;
+import org.opennms.core.twin.api.OnmsTwinRequest;
+
+public interface OnmsTwinPublisher {
+
+    // Provide updates on OnmsTwin to publisher.
+    interface Callback {
+        void onUpdate(OnmsTwin onmsTwin);
+    }
+
+    // Register if you are provider of updates on OnmsTwin and provide partial updates through callback.
+    Callback register(OnmsTwin onmsTwin);
+
+    // OnmsTwinPublisher will register this interface with Broker to receive RPC requests
+    interface RpcReceiver {
+        CompletableFuture<OnmsTwin> rpcCallback(OnmsTwinRequest request);
+    }
+}

--- a/core/onms-twin/api/src/main/java/org/opennms/core/twin/publisher/api/OnmsTwinPublisher.java
+++ b/core/onms-twin/api/src/main/java/org/opennms/core/twin/publisher/api/OnmsTwinPublisher.java
@@ -41,10 +41,8 @@ public interface OnmsTwinPublisher {
     }
 
     // Register if you are provider of updates on OnmsTwin and provide partial updates through callback.
-    Callback register(OnmsTwin onmsTwin);
+    <T> Callback register(T obj, TwinPublisherModule<T> twinPublisherModule);
 
-    // OnmsTwinPublisher will register this interface with Broker to receive RPC requests
-    interface RpcReceiver {
-        CompletableFuture<OnmsTwin> rpcCallback(OnmsTwinRequest request);
-    }
+    // RPC callback from Broker.
+    CompletableFuture<OnmsTwin> rpcCallback(OnmsTwinRequest request);
 }

--- a/core/onms-twin/api/src/main/java/org/opennms/core/twin/publisher/api/TwinBrokerOnOpennms.java
+++ b/core/onms-twin/api/src/main/java/org/opennms/core/twin/publisher/api/TwinBrokerOnOpennms.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2021 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.core.twin.publisher.api;
+
+import org.opennms.core.twin.api.OnmsTwin;
+
+// Broker will only communicate with publisher.
+public interface TwinBrokerOnOpennms {
+
+    // Register a callback to receive RPC requests.
+    void register(OnmsTwinPublisher.RpcReceiver rpcReceiver);
+
+    // Get Sink updates from TwinPublisher.
+    void send(OnmsTwin sinkUpdate);
+}

--- a/core/onms-twin/api/src/main/java/org/opennms/core/twin/publisher/api/TwinPublisherModule.java
+++ b/core/onms-twin/api/src/main/java/org/opennms/core/twin/publisher/api/TwinPublisherModule.java
@@ -28,14 +28,9 @@
 
 package org.opennms.core.twin.publisher.api;
 
-import org.opennms.core.twin.api.OnmsTwin;
+public interface TwinPublisherModule<T> {
 
-// Broker will only communicate with publisher.
-public interface TwinBrokerOnOpennms {
+    Class<T> getClazz();
 
-    // Register a callback to receive RPC requests.
-    void register(OnmsTwinPublisher rpcReceiver);
-
-    // Get Sink updates from TwinPublisher.
-    void send(OnmsTwin sinkUpdate);
+    String getKey();
 }

--- a/core/onms-twin/api/src/main/java/org/opennms/core/twin/subscriber/api/OnmsTwinSubscriber.java
+++ b/core/onms-twin/api/src/main/java/org/opennms/core/twin/subscriber/api/OnmsTwinSubscriber.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2021 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.core.twin.subscriber.api;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.opennms.core.twin.api.OnmsTwin;
+
+public interface OnmsTwinSubscriber {
+    // Minion modules will get updates for OnmsTwin through callback.
+    public interface SinkCallback {
+        void sinkUpdate(OnmsTwin onmsTwin);
+    }
+    // Gets OnmsTwin through RPC  and get updates from broker through callback.
+    CompletableFuture<OnmsTwin> getObject(String key, SinkCallback callback);
+
+    interface Subscriber {
+        void subscribe(OnmsTwin onmsTwin);
+    }
+}

--- a/core/onms-twin/api/src/main/java/org/opennms/core/twin/subscriber/api/OnmsTwinSubscriber.java
+++ b/core/onms-twin/api/src/main/java/org/opennms/core/twin/subscriber/api/OnmsTwinSubscriber.java
@@ -33,14 +33,11 @@ import java.util.concurrent.CompletableFuture;
 import org.opennms.core.twin.api.OnmsTwin;
 
 public interface OnmsTwinSubscriber {
-    // Minion modules will get updates for OnmsTwin through callback.
-    public interface SinkCallback {
-        void sinkUpdate(OnmsTwin onmsTwin);
-    }
-    // Gets OnmsTwin through RPC  and get updates from broker through callback.
-    CompletableFuture<OnmsTwin> getObject(String key, SinkCallback callback);
 
-    interface Subscriber {
-        void subscribe(OnmsTwin onmsTwin);
-    }
+    // RPC request for the module.
+    <T> CompletableFuture<T> getObject(String key, TwinSubscriberModule<T> twinSubscriberModule);
+
+    // Subscribes to updates from Broker.
+    void subscribe(OnmsTwin onmsTwin);
+
 }

--- a/core/onms-twin/api/src/main/java/org/opennms/core/twin/subscriber/api/TwinBrokerOnMinion.java
+++ b/core/onms-twin/api/src/main/java/org/opennms/core/twin/subscriber/api/TwinBrokerOnMinion.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2021 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.core.twin.subscriber.api;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.opennms.core.twin.api.OnmsTwin;
+import org.opennms.core.twin.api.OnmsTwinRequest;
+
+public interface TwinBrokerOnMinion {
+
+    // OnmsTwinSubscriber will send request to broker.
+    CompletableFuture<OnmsTwin> sendRpcRequest(OnmsTwinRequest request);
+
+    // TwinSubscriber will register callback to get Sink updates.
+    void registerSinkUpdate(OnmsTwinSubscriber.Subscriber callback);
+
+
+}

--- a/core/onms-twin/api/src/main/java/org/opennms/core/twin/subscriber/api/TwinBrokerOnMinion.java
+++ b/core/onms-twin/api/src/main/java/org/opennms/core/twin/subscriber/api/TwinBrokerOnMinion.java
@@ -39,7 +39,6 @@ public interface TwinBrokerOnMinion {
     CompletableFuture<OnmsTwin> sendRpcRequest(OnmsTwinRequest request);
 
     // TwinSubscriber will register callback to get Sink updates.
-    void registerSinkUpdate(OnmsTwinSubscriber.Subscriber callback);
-
+    void registerSinkUpdate(OnmsTwinSubscriber subscriber);
 
 }

--- a/core/onms-twin/api/src/main/java/org/opennms/core/twin/subscriber/api/TwinSubscriberModule.java
+++ b/core/onms-twin/api/src/main/java/org/opennms/core/twin/subscriber/api/TwinSubscriberModule.java
@@ -26,16 +26,16 @@
  *     http://www.opennms.com/
  *******************************************************************************/
 
-package org.opennms.core.twin.publisher.api;
+package org.opennms.core.twin.subscriber.api;
 
-import org.opennms.core.twin.api.OnmsTwin;
+/**
+ * Module that makes a RPC request and also gets updates whenever Twin object updates.
+ *
+ * @param <T>
+ */
+public interface TwinSubscriberModule<T> {
+    
+    void update(T onmsTwin);
 
-// Broker will only communicate with publisher.
-public interface TwinBrokerOnOpennms {
-
-    // Register a callback to receive RPC requests.
-    void register(OnmsTwinPublisher rpcReceiver);
-
-    // Get Sink updates from TwinPublisher.
-    void send(OnmsTwin sinkUpdate);
+    Class<T> getClazz();
 }

--- a/core/onms-twin/api/src/test/java/org/opennms/core/twin/api/MockBrokerOnMinion.java
+++ b/core/onms-twin/api/src/test/java/org/opennms/core/twin/api/MockBrokerOnMinion.java
@@ -1,0 +1,169 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2021 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.core.twin.api;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Hashtable;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.opennms.core.twin.subscriber.api.OnmsTwinSubscriber;
+import org.opennms.core.twin.subscriber.api.TwinBrokerOnMinion;
+
+public class MockBrokerOnMinion implements TwinBrokerOnMinion {
+
+    private Hashtable<String, Object> kafkaConfig = new Hashtable<>();
+    private KafkaProducer<String, byte[]> producer;
+    private Map<String, CompletableFuture<OnmsTwin>> futureMap = new ConcurrentHashMap<>();
+    private OnmsTwinSubscriber.Subscriber subscriber;
+    private KafkaSinkConsumerRunner kafkaSinkConsumerRunner;
+    private KafkaConsumerRunner kafkaConsumerRunner;
+    static String rpcRequestTopic = "OpenNMS-MINION-RPC-Request-onms-twin";
+    static String rpcResponseTopic = "OpenNMS-MINION-RPC-Response-onms-twin";
+    static String sinkTopic = "OpenNMS-MINION-Sink-onms-twin";
+
+    public void init() {
+        // Listens to response from OpenNMS.
+        KafkaConsumer<String, byte[]> kafkaConsumer = new KafkaConsumer<>(kafkaConfig);
+        kafkaConsumerRunner = new KafkaConsumerRunner(kafkaConsumer);
+        Executors.newSingleThreadExecutor().execute(kafkaConsumerRunner);
+        KafkaConsumer<String, byte[]> kafkaConsumer2 = new KafkaConsumer<>(kafkaConfig);
+        kafkaSinkConsumerRunner = new KafkaSinkConsumerRunner(kafkaConsumer2);
+        Executors.newSingleThreadExecutor().execute(kafkaSinkConsumerRunner);
+    }
+
+    public MockBrokerOnMinion(Hashtable<String, Object> config) {
+        kafkaConfig.putAll(config);
+        kafkaConfig.put(ConsumerConfig.AUTO_COMMIT_INTERVAL_MS_CONFIG, "1000");
+        kafkaConfig.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getCanonicalName());
+        kafkaConfig.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class.getCanonicalName());
+        kafkaConfig.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getCanonicalName());
+        kafkaConfig.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class.getCanonicalName());
+        kafkaConfig.put(ConsumerConfig.GROUP_ID_CONFIG, "MINION");
+        producer = new KafkaProducer<>(kafkaConfig);
+    }
+
+    @Override
+    public CompletableFuture<OnmsTwin> sendRpcRequest(OnmsTwinRequest request) {
+        CompletableFuture<OnmsTwin> future = new CompletableFuture<>();
+        futureMap.put(request.getKey(), future);
+        ProducerRecord<String, byte[]> producerRecord = new ProducerRecord<>(rpcRequestTopic, request.getKey(), request.getLocation().getBytes(StandardCharsets.UTF_8));
+        producer.send(producerRecord);
+        return future;
+    }
+
+    @Override
+    public void registerSinkUpdate(OnmsTwinSubscriber.Subscriber callback) {
+        subscriber = callback;
+    }
+
+    private class KafkaConsumerRunner implements Runnable {
+
+        private final KafkaConsumer<String, byte[]> kafkaConsumer;
+        private final AtomicBoolean closed = new AtomicBoolean(false);
+
+        public KafkaConsumerRunner(KafkaConsumer<String, byte[]> kafkaConsumer) {
+            this.kafkaConsumer = kafkaConsumer;
+        }
+
+        @Override
+        public void run() {
+            try {
+                kafkaConsumer.subscribe(Arrays.asList(rpcResponseTopic));
+                while (!closed.get()) {
+                    ConsumerRecords<String, byte[]> records = kafkaConsumer.poll(Duration.ofMillis(Long.MAX_VALUE));
+                    for (ConsumerRecord<String, byte[]> record : records) {
+                        OnmsTwin onmsTwin = MockBrokerOnOpenNMS.MarshallerForOnmsTwin.getOnmsTwinFromBytes(record.key(), record.value());
+                        CompletableFuture<OnmsTwin> future = futureMap.get(record.key());
+                        future.complete(onmsTwin);
+                    }
+                }
+            } catch (Exception e) {
+                //Ignore
+            }
+        }
+
+        public void close() {
+            closed.set(true);
+        }
+    }
+
+    private class KafkaSinkConsumerRunner implements Runnable {
+
+        private final KafkaConsumer<String, byte[]> kafkaConsumer;
+        private final AtomicBoolean closed = new AtomicBoolean(false);
+
+        public KafkaSinkConsumerRunner(KafkaConsumer<String, byte[]> kafkaConsumer) {
+            this.kafkaConsumer = kafkaConsumer;
+        }
+
+        @Override
+        public void run() {
+            try {
+
+                kafkaConsumer.subscribe(Arrays.asList(sinkTopic));
+                while (!closed.get()) {
+                    ConsumerRecords<String, byte[]> records = kafkaConsumer.poll(Duration.ofMillis(Long.MAX_VALUE));
+                    for (ConsumerRecord<String, byte[]> record : records) {
+                        OnmsTwin onmsTwin = MockBrokerOnOpenNMS.MarshallerForOnmsTwin.getOnmsTwinFromBytes(record.key(), record.value());
+                        subscriber.subscribe(onmsTwin);
+                    }
+                }
+            } catch (Exception e) {
+                //Ignore
+            }
+        }
+
+        public void close() {
+            closed.set(true);
+        }
+    }
+
+    public void destroy() {
+        kafkaConsumerRunner.close();
+        kafkaSinkConsumerRunner.close();
+    }
+
+}

--- a/core/onms-twin/api/src/test/java/org/opennms/core/twin/api/MockBrokerOnMinion.java
+++ b/core/onms-twin/api/src/test/java/org/opennms/core/twin/api/MockBrokerOnMinion.java
@@ -57,7 +57,7 @@ public class MockBrokerOnMinion implements TwinBrokerOnMinion {
     private Hashtable<String, Object> kafkaConfig = new Hashtable<>();
     private KafkaProducer<String, byte[]> producer;
     private Map<String, CompletableFuture<OnmsTwin>> futureMap = new ConcurrentHashMap<>();
-    private OnmsTwinSubscriber.Subscriber subscriber;
+    private OnmsTwinSubscriber subscriber;
     private KafkaSinkConsumerRunner kafkaSinkConsumerRunner;
     private KafkaConsumerRunner kafkaConsumerRunner;
     static String rpcRequestTopic = "OpenNMS-MINION-RPC-Request-onms-twin";
@@ -95,7 +95,7 @@ public class MockBrokerOnMinion implements TwinBrokerOnMinion {
     }
 
     @Override
-    public void registerSinkUpdate(OnmsTwinSubscriber.Subscriber callback) {
+    public void registerSinkUpdate(OnmsTwinSubscriber callback) {
         subscriber = callback;
     }
 

--- a/core/onms-twin/api/src/test/java/org/opennms/core/twin/api/MockBrokerOnOpenNMS.java
+++ b/core/onms-twin/api/src/test/java/org/opennms/core/twin/api/MockBrokerOnOpenNMS.java
@@ -1,0 +1,173 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2021 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.core.twin.api;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Hashtable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.opennms.core.twin.publisher.api.OnmsTwinPublisher;
+import org.opennms.core.twin.publisher.api.TwinBrokerOnOpennms;
+
+public class MockBrokerOnOpenNMS implements TwinBrokerOnOpennms {
+
+    private OnmsTwinPublisher.RpcReceiver rpcReceiver;
+    private Hashtable<String, Object> kafkaConfig = new Hashtable<>();
+    private KafkaProducer<String, byte[]> rpcResponseProducer;
+    private KafkaConsumerRunner kafkaConsumerRunner;
+
+    public MockBrokerOnOpenNMS(Hashtable<String, Object> config) {
+        this.kafkaConfig.putAll(config);
+        kafkaConfig.put(ConsumerConfig.AUTO_COMMIT_INTERVAL_MS_CONFIG, "1000");
+        kafkaConfig.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getCanonicalName());
+        kafkaConfig.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class.getCanonicalName());
+        kafkaConfig.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getCanonicalName());
+        kafkaConfig.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class.getCanonicalName());
+        kafkaConfig.put(ConsumerConfig.GROUP_ID_CONFIG, "OpenNMS");
+    }
+
+    public void init() {
+        rpcResponseProducer = new KafkaProducer<String, byte[]>(kafkaConfig);
+        KafkaConsumer<String, byte[]> kafkaConsumer = new KafkaConsumer<>(kafkaConfig);
+        kafkaConsumerRunner = new KafkaConsumerRunner(kafkaConsumer);
+        Executors.newSingleThreadExecutor().execute(kafkaConsumerRunner);
+    }
+
+    @Override
+    public void send(OnmsTwin onmsTwin) {
+        // Publish it to broker.
+        KafkaProducer<String, byte[]> producer = new KafkaProducer<>(kafkaConfig);
+        ProducerRecord<String, byte[]> producerRecord = new ProducerRecord<>(MockBrokerOnMinion.sinkTopic, onmsTwin.getKey(), onmsTwin.getObjectValue());
+        producer.send(producerRecord);
+
+    }
+
+    @Override
+    public void register(OnmsTwinPublisher.RpcReceiver rpcReceiver) {
+        this.rpcReceiver = rpcReceiver;
+    }
+
+    private class KafkaConsumerRunner implements Runnable {
+
+        private final KafkaConsumer<String, byte[]> kafkaConsumer;
+        private final AtomicBoolean closed = new AtomicBoolean(false);
+
+        public KafkaConsumerRunner(KafkaConsumer<String, byte[]> kafkaConsumer) {
+            this.kafkaConsumer = kafkaConsumer;
+        }
+
+        @Override
+        public void run() {
+            try {
+                kafkaConsumer.subscribe(Arrays.asList(MockBrokerOnMinion.rpcRequestTopic));
+                while (!closed.get()) {
+                    ConsumerRecords<String, byte[]> records = kafkaConsumer.poll(Duration.ofMillis(Long.MAX_VALUE));
+                    for (ConsumerRecord<String, byte[]> record : records) {
+                        OnmsTwinRequest onmsTwinRequest = MarshallerForOnmsTwinRequest.getOnmsTwinFromBytes(record.key(), record.value());
+                        CompletableFuture<OnmsTwin> future = rpcReceiver.rpcCallback(onmsTwinRequest);
+                        future.whenComplete((response, ex) -> {
+                            ProducerRecord<String, byte[]> producerRecord =
+                                    new ProducerRecord<>(MockBrokerOnMinion.rpcResponseTopic, response.getKey(), response.getObjectValue());
+                            rpcResponseProducer.send(producerRecord);
+                        });
+                    }
+                }
+            } catch (Exception e) {
+                //Ignore
+            }
+        }
+
+        public void close() {
+            closed.set(true);
+        }
+    }
+
+    public void destroy() {
+        kafkaConsumerRunner.close();
+    }
+
+    static class MarshallerForOnmsTwin {
+
+        public static OnmsTwin getOnmsTwinFromBytes(String key, byte[] value) {
+            return new OnmsTwin() {
+                @Override
+                public String getKey() {
+                    return key;
+                }
+
+                @Override
+                public String getLocation() {
+                    return null;
+                }
+
+                @Override
+                public int getVersion() {
+                    return 0;
+                }
+
+                @Override
+                public byte[] getObjectValue() {
+                    return value;
+                }
+            };
+        }
+    }
+
+    static class MarshallerForOnmsTwinRequest {
+
+        public static OnmsTwinRequest getOnmsTwinFromBytes(String key, byte[] value) {
+            return new OnmsTwinRequest() {
+                @Override
+                public String getKey() {
+                    return key;
+                }
+
+                @Override
+                public String getLocation() {
+                    return new String(value, StandardCharsets.UTF_8);
+                }
+            };
+        }
+    }
+}

--- a/core/onms-twin/api/src/test/java/org/opennms/core/twin/api/MockBrokerOnOpenNMS.java
+++ b/core/onms-twin/api/src/test/java/org/opennms/core/twin/api/MockBrokerOnOpenNMS.java
@@ -52,7 +52,7 @@ import org.opennms.core.twin.publisher.api.TwinBrokerOnOpennms;
 
 public class MockBrokerOnOpenNMS implements TwinBrokerOnOpennms {
 
-    private OnmsTwinPublisher.RpcReceiver rpcReceiver;
+    private OnmsTwinPublisher rpcReceiver;
     private Hashtable<String, Object> kafkaConfig = new Hashtable<>();
     private KafkaProducer<String, byte[]> rpcResponseProducer;
     private KafkaConsumerRunner kafkaConsumerRunner;
@@ -84,7 +84,7 @@ public class MockBrokerOnOpenNMS implements TwinBrokerOnOpennms {
     }
 
     @Override
-    public void register(OnmsTwinPublisher.RpcReceiver rpcReceiver) {
+    public void register(OnmsTwinPublisher rpcReceiver) {
         this.rpcReceiver = rpcReceiver;
     }
 
@@ -142,6 +142,11 @@ public class MockBrokerOnOpenNMS implements TwinBrokerOnOpennms {
                 }
 
                 @Override
+                public int getTTL() {
+                    return 0;
+                }
+
+                @Override
                 public int getVersion() {
                     return 0;
                 }
@@ -166,6 +171,11 @@ public class MockBrokerOnOpenNMS implements TwinBrokerOnOpennms {
                 @Override
                 public String getLocation() {
                     return new String(value, StandardCharsets.UTF_8);
+                }
+
+                @Override
+                public int getTTL() {
+                    return 0;
                 }
             };
         }

--- a/core/onms-twin/api/src/test/java/org/opennms/core/twin/api/MockTwinPublisher.java
+++ b/core/onms-twin/api/src/test/java/org/opennms/core/twin/api/MockTwinPublisher.java
@@ -1,0 +1,69 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2021 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.core.twin.api;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.opennms.core.twin.publisher.api.OnmsTwinPublisher;
+import org.opennms.core.twin.publisher.api.TwinBrokerOnOpennms;
+
+public class MockTwinPublisher implements OnmsTwinPublisher {
+
+    private TwinBrokerOnOpennms twinBrokerOnOpennms;
+    private Map<String, OnmsTwin> objects = new ConcurrentHashMap<>();
+
+    public MockTwinPublisher(TwinBrokerOnOpennms twinBrokerOnOpennms) {
+        this.twinBrokerOnOpennms = twinBrokerOnOpennms;
+    }
+
+    public void init() {
+        twinBrokerOnOpennms.register(new RpcReceiver() {
+            @Override
+            public CompletableFuture<OnmsTwin> rpcCallback(OnmsTwinRequest request) {
+                OnmsTwin response = objects.get(request.getKey());
+                CompletableFuture<OnmsTwin> future = new CompletableFuture<>();
+                future.complete(response);
+                return future;
+            }
+        });
+    }
+
+    @Override
+    public Callback register(OnmsTwin onmsTwin) {
+        objects.put(onmsTwin.getKey(), onmsTwin);
+        return new Callback() {
+            @Override
+            public void onUpdate(OnmsTwin update) {
+                twinBrokerOnOpennms.send(update);
+            }
+        };
+    }
+}

--- a/core/onms-twin/api/src/test/java/org/opennms/core/twin/api/MockTwinSubscriber.java
+++ b/core/onms-twin/api/src/test/java/org/opennms/core/twin/api/MockTwinSubscriber.java
@@ -1,0 +1,84 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2021 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.core.twin.api;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.opennms.core.twin.subscriber.api.TwinBrokerOnMinion;
+import org.opennms.core.twin.subscriber.api.OnmsTwinSubscriber;
+
+public class MockTwinSubscriber implements OnmsTwinSubscriber {
+
+    private TwinBrokerOnMinion twinBrokerOnMinion;
+    private Map<String, SinkCallback> moduleCallbacks = new ConcurrentHashMap<>();
+
+    public void init() {
+        twinBrokerOnMinion.registerSinkUpdate(new Subscriber() {
+            @Override
+            public void subscribe(OnmsTwin onmsTwin) {
+                SinkCallback sinkCallback = moduleCallbacks.get(onmsTwin.getKey());
+                sinkCallback.sinkUpdate(onmsTwin);
+            }
+        });
+    }
+
+    public MockTwinSubscriber(TwinBrokerOnMinion twinBrokerOnMinion) {
+        this.twinBrokerOnMinion = twinBrokerOnMinion;
+    }
+
+    @Override
+    public CompletableFuture<OnmsTwin> getObject(String key, SinkCallback sinkCallback) {
+        moduleCallbacks.put(key, sinkCallback);
+        OnmsTwin onmsTwin = new OnmsTwin() {
+            @Override
+            public String getKey() {
+                return key;
+            }
+
+            @Override
+            public String getLocation() {
+                return "MINION";
+            }
+
+            @Override
+            public int getVersion() {
+                return 0;
+            }
+
+            @Override
+            public byte[] getObjectValue() {
+                return "onms-twin-request".getBytes(StandardCharsets.UTF_8);
+            }
+        };
+        return twinBrokerOnMinion.sendRpcRequest(onmsTwin);
+    }
+}

--- a/core/onms-twin/api/src/test/java/org/opennms/core/twin/api/OnmsTwinApiIT.java
+++ b/core/onms-twin/api/src/test/java/org/opennms/core/twin/api/OnmsTwinApiIT.java
@@ -1,0 +1,189 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2021 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.core.twin.api;
+
+import static com.jayway.awaitility.Awaitility.await;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Hashtable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.hamcrest.Matchers;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.opennms.core.test.kafka.JUnitKafkaServer;
+import org.opennms.core.twin.publisher.api.OnmsTwinPublisher;
+import org.opennms.core.twin.subscriber.api.OnmsTwinSubscriber;
+
+public class OnmsTwinApiIT {
+
+    @Rule
+    public JUnitKafkaServer kafkaServer = new JUnitKafkaServer();
+
+    private MockTwinPublisher mockTwinPublisher;
+
+    private MockTwinSubscriber mockTwinSubscriber;
+
+    private MockBrokerOnMinion mockBrokerOnMinion;
+
+    private MockBrokerOnOpenNMS mockBrokerOnOpenNMS;
+
+    private String moduleName = "mock-module";
+
+    @Before
+    public void setup() {
+        Hashtable<String, Object> kafkaConfig = new Hashtable<>();
+        kafkaConfig.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaServer.getKafkaConnectString());
+        kafkaConfig.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        mockBrokerOnMinion= new MockBrokerOnMinion(kafkaConfig);
+        mockBrokerOnOpenNMS = new MockBrokerOnOpenNMS(kafkaConfig);
+        mockBrokerOnMinion.init();
+        mockBrokerOnOpenNMS.init();
+        mockTwinPublisher = new MockTwinPublisher(mockBrokerOnOpenNMS);
+        mockTwinSubscriber = new MockTwinSubscriber(mockBrokerOnMinion);
+    }
+
+    @Test
+    public void testOnmsTwinWithMockProvider() throws ExecutionException, InterruptedException {
+        mockTwinPublisher.init();
+        mockTwinSubscriber.init();
+        MockTwinModuleMinion moduleMinion = new MockTwinModuleMinion(mockTwinSubscriber);
+        String valueToReplicate = "mock-object-value";
+        MockTwinModuleOnOpenNMS moduleOnOpenNMS = new MockTwinModuleOnOpenNMS(mockTwinPublisher, new MockOnmsTwinBean(valueToReplicate));
+        moduleOnOpenNMS.init();
+        moduleMinion.init();
+        await().atMost(30, TimeUnit.SECONDS).pollInterval(5, TimeUnit.SECONDS)
+                .until(moduleMinion::getOnmsTwin, Matchers.notNullValue());
+        Assert.assertThat(moduleMinion.getOnmsTwin().getObjectValue(), Matchers.is(valueToReplicate.getBytes(StandardCharsets.UTF_8)));
+        String updatedValue = "updated-object-value";
+        moduleOnOpenNMS.updateTwin(new MockOnmsTwinBean(updatedValue));
+        await().atMost(30, TimeUnit.SECONDS).pollInterval(5, TimeUnit.SECONDS).until(() -> moduleMinion.getOnmsTwin().getObjectValue(),
+                Matchers.is(updatedValue.getBytes(StandardCharsets.UTF_8)));
+    }
+
+    @After
+    public void destroy(){
+        mockBrokerOnOpenNMS.destroy();
+        mockBrokerOnMinion.destroy();
+    }
+
+
+    public class MockTwinModuleMinion {
+
+        private OnmsTwin onmsTwin;
+        private final OnmsTwinSubscriber twinProvider;
+
+        public MockTwinModuleMinion(OnmsTwinSubscriber twinProvider) {
+            this.twinProvider = twinProvider;
+        }
+
+        public void init() throws ExecutionException, InterruptedException {
+            // Initiate RPC call providing a subscriber that can get updates through reverse-sink
+               CompletableFuture<OnmsTwin> future = twinProvider.getObject(moduleName, new OnmsTwinSubscriber.SinkCallback() {
+                   @Override
+                   public void sinkUpdate(OnmsTwin onmsTwin) {
+                        // Partial updates.
+                        setOnmsTwin(onmsTwin);
+                   }
+               });
+               future.whenComplete((response, ex) -> {
+                   if(response != null) {
+                       setOnmsTwin(response);
+                   }
+               });
+        }
+
+        public OnmsTwin getOnmsTwin() {
+            return onmsTwin;
+        }
+
+        public void setOnmsTwin(OnmsTwin onmsTwin) {
+            this.onmsTwin = onmsTwin;
+        }
+    }
+
+    public class MockTwinModuleOnOpenNMS {
+
+        private OnmsTwin onmsTwin;
+        private final OnmsTwinPublisher twinProvider;
+        private OnmsTwinPublisher.Callback callback;
+
+        public MockTwinModuleOnOpenNMS(OnmsTwinPublisher twinProvider, OnmsTwin onmsTwin) {
+            this.twinProvider = twinProvider;
+            this.onmsTwin = onmsTwin;
+        }
+
+        public void init() {
+            callback = twinProvider.register(onmsTwin);
+        }
+
+        public void updateTwin(OnmsTwin onmsTwin) {
+            callback.onUpdate(onmsTwin);
+        }
+    }
+
+    public class MockOnmsTwinBean implements OnmsTwin {
+
+        private final String value;
+
+        public MockOnmsTwinBean(String objectValue) {
+            this.value = objectValue;
+        }
+
+        @Override
+        public String getKey() {
+            return moduleName;
+        }
+
+        @Override
+        public String getLocation() {
+            return "MINION";
+        }
+
+        @Override
+        public int getVersion() {
+            return 1;
+        }
+
+        @Override
+        public byte[] getObjectValue() {
+            return value.getBytes(StandardCharsets.UTF_8);
+        }
+    }
+
+
+
+
+}

--- a/core/onms-twin/broker/kafka/pom.xml
+++ b/core/onms-twin/broker/kafka/pom.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>org.opennms.core.onms-twin.broker</artifactId>
+        <groupId>org.opennms.core.onms-twin</groupId>
+        <version>29.0.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.opennms.core.onms-twin.broker</groupId>
+    <artifactId>org.opennms.core.onms-twin.broker.kafka</artifactId>
+    <name>OpenNMS :: Core :: OpenNMS Twin :: Broker :: Kafka</name>
+    <packaging>bundle</packaging>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Version>${project.version}</Bundle-Version>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+    <dependencies>
+        <dependency>
+            <groupId>org.opennms.core.onms-twin</groupId>
+            <artifactId>org.opennms.core.onms-twin.api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/core/onms-twin/broker/kafka/src/main/java/org/opennms/core/twin/broker/kafka/KafkaTwinBrokerOnMinion.java
+++ b/core/onms-twin/broker/kafka/src/main/java/org/opennms/core/twin/broker/kafka/KafkaTwinBrokerOnMinion.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2021 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.core.twin.broker.kafka;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.opennms.core.twin.api.OnmsTwin;
+import org.opennms.core.twin.api.OnmsTwinRequest;
+import org.opennms.core.twin.subscriber.api.OnmsTwinSubscriber;
+import org.opennms.core.twin.subscriber.api.TwinBrokerOnMinion;
+
+public class KafkaTwinBrokerOnMinion implements TwinBrokerOnMinion {
+
+    private OnmsTwinSubscriber.Subscriber subscriber;
+
+    @Override
+    public CompletableFuture<OnmsTwin> sendRpcRequest(OnmsTwinRequest request) {
+        return null;
+    }
+
+    @Override
+    public void registerSinkUpdate(OnmsTwinSubscriber.Subscriber callback) {
+       this.subscriber = callback;
+    }
+}

--- a/core/onms-twin/broker/kafka/src/main/java/org/opennms/core/twin/broker/kafka/KafkaTwinBrokerOnMinion.java
+++ b/core/onms-twin/broker/kafka/src/main/java/org/opennms/core/twin/broker/kafka/KafkaTwinBrokerOnMinion.java
@@ -37,7 +37,7 @@ import org.opennms.core.twin.subscriber.api.TwinBrokerOnMinion;
 
 public class KafkaTwinBrokerOnMinion implements TwinBrokerOnMinion {
 
-    private OnmsTwinSubscriber.Subscriber subscriber;
+    private OnmsTwinSubscriber subscriber;
 
     @Override
     public CompletableFuture<OnmsTwin> sendRpcRequest(OnmsTwinRequest request) {
@@ -45,7 +45,9 @@ public class KafkaTwinBrokerOnMinion implements TwinBrokerOnMinion {
     }
 
     @Override
-    public void registerSinkUpdate(OnmsTwinSubscriber.Subscriber callback) {
-       this.subscriber = callback;
+    public void registerSinkUpdate(OnmsTwinSubscriber subscriber) {
+        this.subscriber = subscriber;
     }
+
+
 }

--- a/core/onms-twin/broker/kafka/src/main/java/org/opennms/core/twin/broker/kafka/KafkaTwinBrokerOnOpenNMS.java
+++ b/core/onms-twin/broker/kafka/src/main/java/org/opennms/core/twin/broker/kafka/KafkaTwinBrokerOnOpenNMS.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2021 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.core.twin.broker.kafka;
+
+import org.opennms.core.twin.api.OnmsTwin;
+import org.opennms.core.twin.publisher.api.OnmsTwinPublisher;
+import org.opennms.core.twin.publisher.api.TwinBrokerOnOpennms;
+
+public class KafkaTwinBrokerOnOpenNMS implements TwinBrokerOnOpennms {
+
+    private OnmsTwinPublisher.RpcReceiver rpcReceiver;
+
+    @Override
+    public void register(OnmsTwinPublisher.RpcReceiver rpcReceiver) {
+        this.rpcReceiver = rpcReceiver;
+    }
+
+    @Override
+    public void send(OnmsTwin sinkUpdate) {
+
+    }
+}

--- a/core/onms-twin/broker/kafka/src/main/java/org/opennms/core/twin/broker/kafka/KafkaTwinBrokerOnOpenNMS.java
+++ b/core/onms-twin/broker/kafka/src/main/java/org/opennms/core/twin/broker/kafka/KafkaTwinBrokerOnOpenNMS.java
@@ -34,10 +34,10 @@ import org.opennms.core.twin.publisher.api.TwinBrokerOnOpennms;
 
 public class KafkaTwinBrokerOnOpenNMS implements TwinBrokerOnOpennms {
 
-    private OnmsTwinPublisher.RpcReceiver rpcReceiver;
+    private OnmsTwinPublisher rpcReceiver;
 
     @Override
-    public void register(OnmsTwinPublisher.RpcReceiver rpcReceiver) {
+    public void register(OnmsTwinPublisher rpcReceiver) {
         this.rpcReceiver = rpcReceiver;
     }
 

--- a/core/onms-twin/broker/pom.xml
+++ b/core/onms-twin/broker/pom.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>org.opennms.core.onms-twin</artifactId>
+        <groupId>org.opennms.core</groupId>
+        <version>29.0.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.opennms.core.onms-twin</groupId>
+    <artifactId>org.opennms.core.onms-twin.broker</artifactId>
+    <name>OpenNMS :: Core :: OpenNMS Twin :: Broker</name>
+    <packaging>pom</packaging>
+    <modules>
+        <module>kafka</module>
+    </modules>
+</project>

--- a/core/onms-twin/pom.xml
+++ b/core/onms-twin/pom.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>org.opennms.core</artifactId>
+        <groupId>org.opennms</groupId>
+        <version>29.0.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.opennms.core</groupId>
+    <artifactId>org.opennms.core.onms-twin</artifactId>
+    <name>OpenNMS :: Core :: OpenNMS Twin</name>
+    <packaging>pom</packaging>
+    <modules>
+        <module>api</module>
+        <module>publisher</module>
+        <module>subscriber</module>
+        <module>broker</module>
+    </modules>
+</project>

--- a/core/onms-twin/publisher/pom.xml
+++ b/core/onms-twin/publisher/pom.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>org.opennms.core.onms-twin</artifactId>
+        <groupId>org.opennms.core</groupId>
+        <version>29.0.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.opennms.core.onms-twin</groupId>
+    <artifactId>org.opennms.core.onms-twin.publisher</artifactId>
+    <name>OpenNMS :: Core :: OpenNMS Twin :: Publisher</name>
+    <packaging>bundle</packaging>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Version>${project.version}</Bundle-Version>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+    <dependencies>
+        <dependency>
+            <groupId>org.opennms.core.onms-twin</groupId>
+            <artifactId>org.opennms.core.onms-twin.api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/core/onms-twin/publisher/src/main/java/org/opennms/core/twin/publisher/impl/OnmsTwinPublisherImpl.java
+++ b/core/onms-twin/publisher/src/main/java/org/opennms/core/twin/publisher/impl/OnmsTwinPublisherImpl.java
@@ -1,0 +1,80 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2021 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+
+package org.opennms.core.twin.publisher.impl;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.opennms.core.twin.api.OnmsTwin;
+import org.opennms.core.twin.api.OnmsTwinRequest;
+import org.opennms.core.twin.publisher.api.OnmsTwinPublisher;
+import org.opennms.core.twin.publisher.api.TwinBrokerOnOpennms;
+
+public class OnmsTwinPublisherImpl implements OnmsTwinPublisher {
+
+    private final TwinBrokerOnOpennms twinBrokerOnOpennms;
+    // Publisher caches all objects from modules.
+    private final Map<String, OnmsTwin> objects = new ConcurrentHashMap<>();
+    private final Map<String, Callback> moduleCallbacks = new ConcurrentHashMap<>();
+
+    public OnmsTwinPublisherImpl(TwinBrokerOnOpennms twinBrokerOnOpennms) {
+        this.twinBrokerOnOpennms = twinBrokerOnOpennms;
+        twinBrokerOnOpennms.register(new RpcHandler());
+    }
+
+    @Override
+    public Callback register(OnmsTwin onmsTwin) {
+        objects.put(onmsTwin.getKey(), onmsTwin);
+        Callback callback = moduleCallbacks.get(onmsTwin.getKey());
+        if(callback != null) {
+            return callback;
+        }
+        return  new Callback() {
+            @Override
+            public void onUpdate(OnmsTwin updatedTwin) {
+                // Update broker.
+                twinBrokerOnOpennms.send(updatedTwin);
+            }
+        };
+    }
+
+    private class RpcHandler implements RpcReceiver {
+
+        @Override
+        public CompletableFuture<OnmsTwin> rpcCallback(OnmsTwinRequest request) {
+            // TODO : May need to take in account of location ?
+            OnmsTwin onmsTwin = objects.get(request.getKey());
+            CompletableFuture<OnmsTwin> future = new CompletableFuture<>();
+            future.complete(onmsTwin);
+            return future;
+        }
+    }
+}

--- a/core/onms-twin/publisher/src/main/java/org/opennms/core/twin/publisher/impl/OnmsTwinPublisherImpl.java
+++ b/core/onms-twin/publisher/src/main/java/org/opennms/core/twin/publisher/impl/OnmsTwinPublisherImpl.java
@@ -29,6 +29,7 @@
 
 package org.opennms.core.twin.publisher.impl;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
@@ -37,44 +38,76 @@ import org.opennms.core.twin.api.OnmsTwin;
 import org.opennms.core.twin.api.OnmsTwinRequest;
 import org.opennms.core.twin.publisher.api.OnmsTwinPublisher;
 import org.opennms.core.twin.publisher.api.TwinBrokerOnOpennms;
+import org.opennms.core.twin.publisher.api.TwinPublisherModule;
 
 public class OnmsTwinPublisherImpl implements OnmsTwinPublisher {
 
     private final TwinBrokerOnOpennms twinBrokerOnOpennms;
     // Publisher caches all objects from modules.
-    private final Map<String, OnmsTwin> objects = new ConcurrentHashMap<>();
+    private final Map<String, byte[]> objects = new ConcurrentHashMap<>();
     private final Map<String, Callback> moduleCallbacks = new ConcurrentHashMap<>();
 
     public OnmsTwinPublisherImpl(TwinBrokerOnOpennms twinBrokerOnOpennms) {
         this.twinBrokerOnOpennms = twinBrokerOnOpennms;
-        twinBrokerOnOpennms.register(new RpcHandler());
+        twinBrokerOnOpennms.register(this);
     }
 
     @Override
-    public Callback register(OnmsTwin onmsTwin) {
-        objects.put(onmsTwin.getKey(), onmsTwin);
-        Callback callback = moduleCallbacks.get(onmsTwin.getKey());
+    public <T> Callback register(T obj, TwinPublisherModule<T> twinPublisherModule) {
+        byte[] marshalled = marshalObject(obj, twinPublisherModule);
+        objects.put(twinPublisherModule.getKey(), marshalled);
+        Callback callback = moduleCallbacks.get(twinPublisherModule.getKey());
         if(callback != null) {
             return callback;
         }
-        return  new Callback() {
+        callback =  new Callback() {
             @Override
             public void onUpdate(OnmsTwin updatedTwin) {
                 // Update broker.
                 twinBrokerOnOpennms.send(updatedTwin);
             }
         };
+        moduleCallbacks.put(twinPublisherModule.getKey(), callback);
+        return callback;
     }
 
-    private class RpcHandler implements RpcReceiver {
-
-        @Override
-        public CompletableFuture<OnmsTwin> rpcCallback(OnmsTwinRequest request) {
-            // TODO : May need to take in account of location ?
-            OnmsTwin onmsTwin = objects.get(request.getKey());
-            CompletableFuture<OnmsTwin> future = new CompletableFuture<>();
-            future.complete(onmsTwin);
-            return future;
-        }
+    public <T> byte[] marshalObject(T obj, TwinPublisherModule<T> twinPublisherModule) {
+        return null;
     }
+
+    @Override
+    public CompletableFuture<OnmsTwin> rpcCallback(OnmsTwinRequest request) {
+        // TODO : May need to take in account of location ?
+        byte[] value = objects.get(request.getKey());
+        OnmsTwin onmsTwin = new OnmsTwin() {
+            @Override
+            public int getVersion() {
+                return 0;
+            }
+
+            @Override
+            public byte[] getObjectValue() {
+                return new byte[0];
+            }
+
+            @Override
+            public String getKey() {
+                return null;
+            }
+
+            @Override
+            public String getLocation() {
+                return null;
+            }
+
+            @Override
+            public int getTTL() {
+                return 0;
+            }
+        };
+        CompletableFuture<OnmsTwin> future = new CompletableFuture<>();
+        future.complete(onmsTwin);
+        return future;
+    }
+
 }

--- a/core/onms-twin/subscriber/pom.xml
+++ b/core/onms-twin/subscriber/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>org.opennms.core.onms-twin</artifactId>
+        <groupId>org.opennms.core</groupId>
+        <version>29.0.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.opennms.core.onms-twin</groupId>
+    <artifactId>org.opennms.core.onms-twin.subscriber</artifactId>
+    <name>OpenNMS :: Core :: OpenNMS Twin :: Subscriber</name>
+    <packaging>bundle</packaging>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Version>${project.version}</Bundle-Version>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+    <dependencies>
+        <dependency>
+            <groupId>org.opennms.core.onms-twin</groupId>
+            <artifactId>org.opennms.core.onms-twin.api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.opennms.features.distributed</groupId>
+            <artifactId>core-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/core/onms-twin/subscriber/src/main/java/org/opennms/core/twin/subscriber/impl/OnmsTwinSubscriberImpl.java
+++ b/core/onms-twin/subscriber/src/main/java/org/opennms/core/twin/subscriber/impl/OnmsTwinSubscriberImpl.java
@@ -1,0 +1,79 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2021 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.core.twin.subscriber.impl;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.opennms.core.twin.api.OnmsTwin;
+import org.opennms.core.twin.api.OnmsTwinRequest;
+import org.opennms.core.twin.subscriber.api.OnmsTwinSubscriber;
+import org.opennms.core.twin.subscriber.api.TwinBrokerOnMinion;
+import org.opennms.distributed.core.api.MinionIdentity;
+
+public class OnmsTwinSubscriberImpl implements OnmsTwinSubscriber {
+
+    private final TwinBrokerOnMinion twinBrokerOnMinion;
+    private final MinionIdentity minionIdentity;
+    private final Map<String, SinkCallback> moduleCallbacks = new ConcurrentHashMap<>();
+
+    public OnmsTwinSubscriberImpl(TwinBrokerOnMinion twinBrokerOnMinion, MinionIdentity minionIdentity) {
+        this.twinBrokerOnMinion = twinBrokerOnMinion;
+        this.minionIdentity = minionIdentity;
+        twinBrokerOnMinion.registerSinkUpdate(new SubscriberImpl());
+    }
+
+    @Override
+    public CompletableFuture<OnmsTwin> getObject(String key, SinkCallback sinkUpdate) {
+        moduleCallbacks.put(key, sinkUpdate);
+        return twinBrokerOnMinion.sendRpcRequest(new OnmsTwinRequest() {
+            @Override
+            public String getKey() {
+                return key;
+            }
+
+            @Override
+            public String getLocation() {
+                return minionIdentity.getLocation();
+            }
+        });
+    }
+
+    private class SubscriberImpl implements Subscriber {
+        @Override
+        public void subscribe(OnmsTwin onmsTwin) {
+            SinkCallback sinkCallback = moduleCallbacks.get(onmsTwin.getKey());
+            if (sinkCallback != null) {
+                sinkCallback.sinkUpdate(onmsTwin);
+            }
+        }
+    }
+
+}

--- a/features/events/traps/pom.xml
+++ b/features/events/traps/pom.xml
@@ -66,6 +66,11 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.opennms.core.onms-twin</groupId>
+      <artifactId>org.opennms.core.onms-twin.api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.opennms.features.distributed</groupId>
       <artifactId>core-api</artifactId>
       <version>${project.version}</version>

--- a/features/events/traps/src/main/java/org/opennms/netmgt/trapd/TrapListener.java
+++ b/features/events/traps/src/main/java/org/opennms/netmgt/trapd/TrapListener.java
@@ -33,10 +33,13 @@ import java.lang.reflect.UndeclaredThrowableException;
 import java.net.InetAddress;
 import java.net.SocketException;
 import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
 
 import org.opennms.core.ipc.sink.api.AsyncDispatcher;
 import org.opennms.core.ipc.sink.api.MessageDispatcherFactory;
 import org.opennms.core.logging.Logging;
+import org.opennms.core.twin.api.OnmsTwin;
+import org.opennms.core.twin.subscriber.api.OnmsTwinSubscriber;
 import org.opennms.core.utils.InetAddressUtils;
 import org.opennms.netmgt.config.TrapdConfig;
 import org.opennms.netmgt.config.TrapdConfigFactory;
@@ -64,6 +67,8 @@ public class TrapListener implements TrapNotificationListener {
     private TrapdConfig m_config;
 
     private AsyncDispatcher<TrapInformationWrapper> m_dispatcher;
+
+    private OnmsTwinSubscriber onmsTwinSubscriber;
 
     public TrapListener(final TrapdConfig config) throws SocketException {
         Objects.requireNonNull(config, "Config cannot be null");
@@ -94,6 +99,17 @@ public class TrapListener implements TrapNotificationListener {
     }
 
     public void start() {
+        CompletableFuture<OnmsTwin> future = onmsTwinSubscriber.getObject("trapd-config", new OnmsTwinSubscriber.SinkCallback() {
+            @Override
+            public void sinkUpdate(OnmsTwin onmsTwin) {
+                // Unmarshal and call setSnmpV3Users
+            }
+        });
+        future.whenComplete((response, ex) -> {
+           if(response != null) {
+               // Unmarshal and call setSnmpV3Users
+           }
+        });
         final int m_snmpTrapPort = m_config.getSnmpTrapPort();
         final InetAddress address = getInetAddress();
         try {
@@ -223,5 +239,9 @@ public class TrapListener implements TrapNotificationListener {
             return false;
         }
         return !newConfig.getSnmpV3Users().equals(m_config.getSnmpV3Users());
+    }
+
+    public void setOnmsTwinSubscriber(OnmsTwinSubscriber onmsTwinSubscriber) {
+        this.onmsTwinSubscriber = onmsTwinSubscriber;
     }
 }

--- a/features/events/traps/src/main/java/org/opennms/netmgt/trapd/TrapListener.java
+++ b/features/events/traps/src/main/java/org/opennms/netmgt/trapd/TrapListener.java
@@ -40,6 +40,7 @@ import org.opennms.core.ipc.sink.api.MessageDispatcherFactory;
 import org.opennms.core.logging.Logging;
 import org.opennms.core.twin.api.OnmsTwin;
 import org.opennms.core.twin.subscriber.api.OnmsTwinSubscriber;
+import org.opennms.core.twin.subscriber.api.TwinSubscriberModule;
 import org.opennms.core.utils.InetAddressUtils;
 import org.opennms.netmgt.config.TrapdConfig;
 import org.opennms.netmgt.config.TrapdConfigFactory;
@@ -53,7 +54,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
-public class TrapListener implements TrapNotificationListener {
+public class TrapListener implements TrapNotificationListener, TwinSubscriberModule<TrapdConfig> {
     private static final Logger LOG = LoggerFactory.getLogger(TrapListener.class);
 
     @Autowired
@@ -99,12 +100,7 @@ public class TrapListener implements TrapNotificationListener {
     }
 
     public void start() {
-        CompletableFuture<OnmsTwin> future = onmsTwinSubscriber.getObject("trapd-config", new OnmsTwinSubscriber.SinkCallback() {
-            @Override
-            public void sinkUpdate(OnmsTwin onmsTwin) {
-                // Unmarshal and call setSnmpV3Users
-            }
-        });
+        CompletableFuture<TrapdConfig> future = onmsTwinSubscriber.getObject("trapd-config", this);
         future.whenComplete((response, ex) -> {
            if(response != null) {
                // Unmarshal and call setSnmpV3Users
@@ -243,5 +239,16 @@ public class TrapListener implements TrapNotificationListener {
 
     public void setOnmsTwinSubscriber(OnmsTwinSubscriber onmsTwinSubscriber) {
         this.onmsTwinSubscriber = onmsTwinSubscriber;
+    }
+
+    @Override
+    public void update(TrapdConfig onmsTwin) {
+
+    }
+
+
+    @Override
+    public Class<TrapdConfig> getClazz() {
+        return TrapdConfig.class;
     }
 }

--- a/features/events/traps/src/main/java/org/opennms/netmgt/trapd/TrapdConfigWrapper.java
+++ b/features/events/traps/src/main/java/org/opennms/netmgt/trapd/TrapdConfigWrapper.java
@@ -1,0 +1,80 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2021 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.trapd;
+
+import org.opennms.core.twin.api.OnmsTwin;
+import org.opennms.core.twin.publisher.api.OnmsTwinPublisher;
+import org.opennms.netmgt.config.TrapdConfig;
+
+public class TrapdConfigWrapper {
+
+    private final TrapdConfig trapdConfig;
+
+    private OnmsTwinPublisher twinPublisher;
+
+    public TrapdConfigWrapper(TrapdConfig trapdConfig) {
+        this.trapdConfig = trapdConfig;
+    }
+
+    public void init() {
+        // Marshal trapdconfig and convert it to byte array.
+        byte[] marshalledConfig = marshalTrapdConfig(trapdConfig);
+        OnmsTwin onmsTwin = new OnmsTwin() {
+            @Override
+            public int getVersion() {
+                return 0;
+            }
+
+            @Override
+            public byte[] getObjectValue() {
+                return marshalledConfig;
+            }
+
+            @Override
+            public String getKey() {
+                return "trapd-config";
+            }
+
+            @Override
+            public String getLocation() {
+                return null;
+            }
+        };
+        OnmsTwinPublisher.Callback callback = twinPublisher.register(onmsTwin);
+        // Register this callback that gets updates to TrapdConfig.
+    }
+
+    public void setTwinPublisher(OnmsTwinPublisher twinPublisher) {
+        this.twinPublisher = twinPublisher;
+    }
+
+    public byte[] marshalTrapdConfig(TrapdConfig trapdConfig) {
+        return null;
+    }
+}

--- a/features/events/traps/src/main/java/org/opennms/netmgt/trapd/TrapdConfigWrapper.java
+++ b/features/events/traps/src/main/java/org/opennms/netmgt/trapd/TrapdConfigWrapper.java
@@ -30,9 +30,10 @@ package org.opennms.netmgt.trapd;
 
 import org.opennms.core.twin.api.OnmsTwin;
 import org.opennms.core.twin.publisher.api.OnmsTwinPublisher;
+import org.opennms.core.twin.publisher.api.TwinPublisherModule;
 import org.opennms.netmgt.config.TrapdConfig;
 
-public class TrapdConfigWrapper {
+public class TrapdConfigWrapper implements TwinPublisherModule<TrapdConfig> {
 
     private final TrapdConfig trapdConfig;
 
@@ -43,31 +44,10 @@ public class TrapdConfigWrapper {
     }
 
     public void init() {
-        // Marshal trapdconfig and convert it to byte array.
-        byte[] marshalledConfig = marshalTrapdConfig(trapdConfig);
-        OnmsTwin onmsTwin = new OnmsTwin() {
-            @Override
-            public int getVersion() {
-                return 0;
-            }
 
-            @Override
-            public byte[] getObjectValue() {
-                return marshalledConfig;
-            }
-
-            @Override
-            public String getKey() {
-                return "trapd-config";
-            }
-
-            @Override
-            public String getLocation() {
-                return null;
-            }
-        };
-        OnmsTwinPublisher.Callback callback = twinPublisher.register(onmsTwin);
-        // Register this callback that gets updates to TrapdConfig.
+        OnmsTwinPublisher.Callback callback = twinPublisher.register(trapdConfig, this);
+        // Update callback whenever there are updates to TrapdConfig.
+        //callback.onUpdate(onmstwin);
     }
 
     public void setTwinPublisher(OnmsTwinPublisher twinPublisher) {
@@ -76,5 +56,15 @@ public class TrapdConfigWrapper {
 
     public byte[] marshalTrapdConfig(TrapdConfig trapdConfig) {
         return null;
+    }
+
+    @Override
+    public Class<TrapdConfig> getClazz() {
+        return TrapdConfig.class;
+    }
+
+    @Override
+    public String getKey() {
+        return "trapd-config";
     }
 }

--- a/features/events/traps/src/main/resources/META-INF/opennms/applicationContext-trapDaemon.xml
+++ b/features/events/traps/src/main/resources/META-INF/opennms/applicationContext-trapDaemon.xml
@@ -32,4 +32,5 @@
     <constructor-arg ref="trapdConfig" />
   </bean>
 
+
 </beans>

--- a/features/events/traps/src/main/resources/META-INF/opennms/applicationContext-trapdConfigWrapper.xml
+++ b/features/events/traps/src/main/resources/META-INF/opennms/applicationContext-trapdConfigWrapper.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:tx="http://www.springframework.org/schema/tx"
+       xmlns:context="http://www.springframework.org/schema/context"
+       xmlns:util="http://www.springframework.org/schema/util"
+       xmlns:aop="http://www.springframework.org/schema/aop"
+       xmlns:jdbc="http://www.springframework.org/schema/jdbc"
+       xmlns:onmsgi="http://xmlns.opennms.org/xsd/spring/onms-osgi"
+       xsi:schemaLocation="
+  http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.2.xsd
+  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.2.xsd
+  http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.2.xsd
+  http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.2.xsd
+  http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-4.2.xsd
+  http://xmlns.opennms.org/xsd/spring/onms-osgi http://xmlns.opennms.org/xsd/spring/onms-osgi.xsd
+">
+
+    <context:annotation-config />
+    <tx:annotation-driven/>
+
+    <bean id="trapdConfigWrapper" class="org.opennms.netmgt.trapd.TrapdConfigWrapper"
+          init-method="init">
+        <constructor-arg ref="trapdConfig" />
+        <property name="twinPublisher" value="onmsTwinPublisher"/>
+    </bean>
+
+
+</beans>

--- a/pom.xml
+++ b/pom.xml
@@ -1960,6 +1960,11 @@
         <version>${project.version}</version>
       </dependency>
       <dependency>
+        <groupId>org.opennms.core.onms-twin</groupId>
+        <artifactId>org.opennms.core.onms-twin.api</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
         <groupId>org.opennms.core</groupId>
         <artifactId>org.opennms.core.runtime</artifactId>
         <version>${project.version}</version>


### PR DESCRIPTION
Define object replication as OnmsTwin
Define interfaces for OnmsTwin publisher/subscriber.
Define broker interfaces to interact with Onms publisher/subscriber.

Add Mock implementation with kafka broker and IT to test object replication.


### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-13401

