### PR TITLE
Fix/docs build warnings

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -18,7 +18,7 @@ asciidoc:
     compatible-oia: '0.2.x'
     compatible-cassandra: '3.11.x'
     compatible-elasticsearch: '6.7.0 - 7.6.2'
-    compatible-javajdk: 'OpenJDK 8, OpenJDK 11'
+    compatible-javajdk: 'OpenJDK 11'
     compatible-kafka: '1.x - 2.x'
     compatible-postgresql: '10.x - 13.x'
     compatible-rrdtool: '1.7.x'

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -18,7 +18,7 @@ asciidoc:
     compatible-oia: '0.2.x'
     compatible-cassandra: '3.11.x'
     compatible-elasticsearch: '6.7.0 - 7.6.2'
-    compatible-javajdk: 'OpenJDK 11'
+    compatible-javajdk: 'OpenJDK 8, OpenJDK 11'
     compatible-kafka: '1.x - 2.x'
     compatible-postgresql: '10.x - 13.x'
     compatible-rrdtool: '1.7.x'

--- a/docs/modules/operation/pages/provisioning/detectors/HostResourceSWRunDetector.adoc
+++ b/docs/modules/operation/pages/provisioning/detectors/HostResourceSWRunDetector.adoc
@@ -8,14 +8,14 @@ Most modern _SNMP agents_, e.g. _Net-SNMP agent_ and the _Microsoft SNMP service
 
 NOTE: This detector implements the configuration parameters inherited from the <<provisioning/detectors/SnmpDetector.adoc>>.
 
-==== Detector facts
+== Detector facts
 
 [options="autowidth"]
 |===
 | Implementation | `org.opennms.netmgt.provision.detector.snmp.HostResourceSWRunDetector`
 |===
 
-==== Configuration and Use
+== Configuration and Use
 
 .Parameters for the HostResourceSwRunDetector
 [options="header, %autowidth"]
@@ -24,8 +24,7 @@ NOTE: This detector implements the configuration parameters inherited from the <
 | `serviceToDetect` | Process name that should be detected   | required | `-`
 |===
 
-
-==== Examples
+== Examples
 
 [source,xml]
 ----

--- a/docs/modules/reference/pages/configuration/tuning-activemq.adoc
+++ b/docs/modules/reference/pages/configuration/tuning-activemq.adoc
@@ -51,14 +51,14 @@ echo 'org.opennms.instance.id=MyNMS' > "$\{OPENNMS_HOME}/etc/opennms.properties.
 ----
 
 Update the Minion's instance ID accordingly to match the {page-component-title} instance.
-The same ID instance property should be present in `${MINION_HOME}/etc/custom.system.properties`.
+The same ID instance property should be present in `$\{MINION_HOME}/etc/custom.system.properties`.
 
 [source, sh]
 ----
 echo 'org.opennms.instance.id=MyNMS' > "$\{MINION_HOME}/etc/custom.system.properties"
 ----
 CAUTION: If you change the instance ID setting when using the embedded broker, you will need to update the authorization section in the broker's configuration to reflect the updated prefix.
-The configuration can be modified with the file `${OPENNMS_HOME}/etc/opennms-activemq.xml`:
+The configuration can be modified with the file `$\{OPENNMS_HOME}/etc/opennms-activemq.xml`:
 
 [source, xml]
 ----

--- a/docs/modules/reference/pages/configuration/tuning-kafka.adoc
+++ b/docs/modules/reference/pages/configuration/tuning-kafka.adoc
@@ -40,7 +40,7 @@ Disabling Single topic must be configured on both Minion and OpenNMS.
 .Disable single topic on Minion
 [source, shell]
 ----
-echo 'single-topic=false' >> "$MINION_HOME/etc/org.opennms.core.ipc.rpc.kafka.cfg"
+echo 'single-topic=false' >> "${MINION_HOME}/etc/org.opennms.core.ipc.rpc.kafka.cfg"
 ----
 
 On OpenNMS, disable single topic by setting the `org.opennms.core.ipc.rpc.kafka.single-topic` system property to false.


### PR DESCRIPTION
Fix the following doc build warnings:

```
asciidoctor: WARNING: skipping reference to missing attribute: minion_home
asciidoctor: WARNING: skipping reference to missing attribute: opennms_home
asciidoctor: WARNING: HostResourceSWRunDetector.adoc: line 11: section title out of sequence: expected level 1, got level 3
asciidoctor: WARNING: HostResourceSWRunDetector.adoc: line 18: section title out of sequence: expected level 1, got level 3
asciidoctor: WARNING: HostResourceSWRunDetector.adoc: line 28: section title out of sequence: expected level 1, got level 3
```

