### PR TITLE
NMS-13452: Update Jackson 2 Dependencies

### DIFF
--- a/container/features/src/main/resources/features-sentinel.xml
+++ b/container/features/src/main/resources/features-sentinel.xml
@@ -202,8 +202,8 @@
     <feature name="zookeeper-dependencies" version="${zookeeperVersion}" description="ZooKeeper Dependencies">
         <bundle dependency="true">mvn:org.apache.zookeeper/zookeeper/${zookeeperVersion}</bundle>
         <bundle dependency="true">mvn:com.google.guava/guava/16.0.1</bundle>
-        <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-core/2.10.0</bundle>
-        <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-databind/2.10.0</bundle>
+        <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-core/${jackson2Version}</bundle>
+        <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-databind/${jackson2Version}</bundle>
         <bundle dependency="true">mvn:org.apache.curator/curator-client/2.9.1</bundle>
         <bundle dependency="true">mvn:org.apache.curator/curator-framework/2.9.1</bundle>
         <bundle dependency="true">mvn:org.apache.curator/curator-recipes/2.9.1</bundle>

--- a/container/features/src/main/resources/karaf/spring-legacy.xml
+++ b/container/features/src/main/resources/karaf/spring-legacy.xml
@@ -767,9 +767,9 @@
         <feature version="[5.1,6)">spring-tx</feature>
         <feature version="[5.1,6)">spring-web</feature>
         <bundle dependency="true">mvn:javax.annotation/javax.annotation-api/1.3</bundle>
-        <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-core/2.10.5</bundle>
-        <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-annotations/2.10.5</bundle>
-        <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-databind/2.10.5</bundle>
+        <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-core/${jackson2Version}</bundle>
+        <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-annotations/${jackson2Version}</bundle>
+        <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-databind/${jackson2Version}</bundle>
         <bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.aspectj/1.9.5_1</bundle>
         <bundle start-level="30">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.spring-security-core/5.3.1.RELEASE_1</bundle>
         <bundle start-level="30">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.spring-security-config/5.3.1.RELEASE_1</bundle>

--- a/container/features/src/main/resources/karaf/spring.xml
+++ b/container/features/src/main/resources/karaf/spring.xml
@@ -109,9 +109,9 @@
         <feature version="[5.2,6)">spring-tx</feature>
         <feature version="[5.2,6)">spring-web</feature>
         <bundle dependency="true">mvn:javax.annotation/javax.annotation-api/1.3</bundle>
-        <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-core/2.10.5</bundle>
-        <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-annotations/2.10.5</bundle>
-        <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-databind/2.10.5</bundle>
+        <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-core/${jackson2Version}</bundle>
+        <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-annotations/${jackson2Version}</bundle>
+        <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-databind/${jackson2Version}</bundle>
         <bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.aspectj/1.9.5_1</bundle>
         <bundle start-level="30">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.spring-security-core/5.4.2_1</bundle>
         <bundle start-level="30">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.spring-security-config/5.4.2_1</bundle>
@@ -125,9 +125,9 @@
         <feature version="[5.1,6)">spring-jdbc</feature>
         <feature version="[5.1,6)">spring-tx</feature>
         <feature version="[5.1,6)">spring-web</feature>
-        <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-core/2.10.5</bundle>
-        <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-annotations/2.10.5</bundle>
-        <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-databind/2.10.5</bundle>
+        <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-core/${jackson2Version}</bundle>
+        <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-annotations/${jackson2Version}</bundle>
+        <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-databind/${jackson2Version}</bundle>
         <bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.aspectj/1.9.5_1</bundle>
         <bundle start-level="30">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.spring-security-core/5.1.5.RELEASE_1</bundle>
         <bundle start-level="30">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.spring-security-config/5.1.5.RELEASE_1</bundle>

--- a/docs/modules/releasenotes/pages/changelog.adoc
+++ b/docs/modules/releasenotes/pages/changelog.adoc
@@ -8,7 +8,7 @@
 
 Release 28.0.1 contains a bunch of bug fixes and enhancements, plus a few security updates.
 
-The codename for Horizon 28.0.1 is $$https://wikipedia.org/wiki/Optimus_Prime$$[_Optimus Prime_].
+The codename for Horizon 28.0.1 is https://wikipedia.org/wiki/$$Optimus_Prime$$[_Optimus Prime_].
 
 === Bug
 
@@ -61,7 +61,7 @@ The codename for Horizon 28.0.1 is $$https://wikipedia.org/wiki/Optimus_Prime$$[
 Release 28.0.0 is the first in the Horizon 28 series, introducing a requirement of Java 11,
 enhancements to flow aggregation to support DSCP ToS/QoS, and more.
 
-The codename for Horizon 28.0.0 is $$https://wikipedia.org/wiki/Jazz_(Transformers)$$[_Jazz_].
+The codename for Horizon 28.0.0 is https://wikipedia.org/wiki/$$Jazz_(Transformers)$$[_Jazz_].
 
 === Bug
 

--- a/features/distributed/coordination/zookeeper/pom.xml
+++ b/features/distributed/coordination/zookeeper/pom.xml
@@ -13,7 +13,7 @@
     <name>OpenNMS :: Features :: Distributed :: Coordination :: Zookeeper</name>
     <properties>
         <guava16.version>16.0.1</guava16.version>
-        <jackson.version>2.10.0</jackson.version>
+        <jackson.version>2.12.4</jackson.version>
         <curator.version>2.9.1</curator.version>
     </properties>
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -1399,7 +1399,7 @@
     <httpclientVersion>4.5.13</httpclientVersion>
     <httpasyncclientVersion>4.1.3</httpasyncclientVersion>
     <jacksonVersion>1.9.13</jacksonVersion>
-    <jackson2Version>2.10.5</jackson2Version>
+    <jackson2Version>2.12.4</jackson2Version>
     <jacocoVersion>0.8.5</jacocoVersion>
     <jasperreportsVersion>6.3.0</jasperreportsVersion>
     <jasperreportsMavenPluginVersion>1.0-beta-4-OPENNMS-20160912-1</jasperreportsMavenPluginVersion>
@@ -3737,6 +3737,11 @@
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.dataformat</groupId>
+        <artifactId>jackson-dataformat-csv</artifactId>
+        <version>${jackson2Version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.dataformat</groupId>
         <artifactId>jackson-dataformat-smile</artifactId>
         <version>${jackson2Version}</version>
       </dependency>
@@ -3748,6 +3753,11 @@
       <dependency>
         <groupId>com.fasterxml.jackson.datatype</groupId>
         <artifactId>jackson-datatype-guava</artifactId>
+        <version>${jackson2Version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.datatype</groupId>
+        <artifactId>jackson-datatype-jdk8</artifactId>
         <version>${jackson2Version}</version>
       </dependency>
       <dependency>
@@ -3763,6 +3773,16 @@
       <dependency>
         <groupId>com.fasterxml.jackson.module</groupId>
         <artifactId>jackson-module-jaxb-annotations</artifactId>
+        <version>${jackson2Version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.module</groupId>
+        <artifactId>jackson-module-scala_2.12</artifactId>
+        <version>${jackson2Version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.module</groupId>
+        <artifactId>jackson-module-paranamer</artifactId>
         <version>${jackson2Version}</version>
       </dependency>
       <dependency>

--- a/smoke-test/pom.xml
+++ b/smoke-test/pom.xml
@@ -12,7 +12,7 @@
     <camelVersion>2.19.1</camelVersion>
     <failsafeVersion>2.22.2</failsafeVersion>
     <frontendPluginVersion>0.0.29</frontendPluginVersion>
-    <jackson2Version>2.10.0</jackson2Version>
+    <jackson2Version>2.12.4</jackson2Version>
     <jersey.version>2.28</jersey.version>
     <karafVersion>4.2.11</karafVersion>
     <selenium.version>3.141.59</selenium.version>
@@ -246,6 +246,11 @@
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.dataformat</groupId>
+        <artifactId>jackson-dataformat-csv</artifactId>
+        <version>${jackson2Version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.dataformat</groupId>
         <artifactId>jackson-dataformat-smile</artifactId>
         <version>${jackson2Version}</version>
       </dependency>
@@ -257,6 +262,11 @@
       <dependency>
         <groupId>com.fasterxml.jackson.datatype</groupId>
         <artifactId>jackson-datatype-guava</artifactId>
+        <version>${jackson2Version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.datatype</groupId>
+        <artifactId>jackson-datatype-jdk8</artifactId>
         <version>${jackson2Version}</version>
       </dependency>
       <dependency>
@@ -272,6 +282,16 @@
       <dependency>
         <groupId>com.fasterxml.jackson.module</groupId>
         <artifactId>jackson-module-jaxb-annotations</artifactId>
+        <version>${jackson2Version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.module</groupId>
+        <artifactId>jackson-module-scala_2.12</artifactId>
+        <version>${jackson2Version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.module</groupId>
+        <artifactId>jackson-module-paranamer</artifactId>
         <version>${jackson2Version}</version>
       </dependency>
     </dependencies>


### PR DESCRIPTION
This PR bumps Jackson to 2.12.x.

Tests all pass, but it's probably worth looking into some of the lesser-used bits that this touches -- especially the features.xml files -- I'm not convinced everything gets coverage.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-13452