### PR TITLE
NMS-13449: bump jetty to 9.4.43.v20210629

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1410,7 +1410,7 @@
     <jasperreportsMavenPluginVersion>1.0-beta-4-OPENNMS-20160912-1</jasperreportsMavenPluginVersion>
     <jcifsVersion>1.3.14</jcifsVersion>
     <jcommonVersion>1.0.23</jcommonVersion>
-    <jettyVersion>9.4.38.v20210224</jettyVersion>
+    <jettyVersion>9.4.43.v20210629</jettyVersion>
     <jfreechartVersion>1.0.19</jfreechartVersion>
     <jinteropVersion>2.0.8</jinteropVersion>
     <jldapVersion>4.3</jldapVersion>


### PR DESCRIPTION
This PR bumps our Jetty dependency to the latest version in the 9.x series.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-13449
