### PR TITLE
NMS-13469: fix ReST queries for OnmsIpInterface snmpPrimary

### DIFF
--- a/features/enlinkd/persistence/api/src/main/java/org/opennms/netmgt/enlinkd/model/IpInterfaceTopologyEntity.java
+++ b/features/enlinkd/persistence/api/src/main/java/org/opennms/netmgt/enlinkd/model/IpInterfaceTopologyEntity.java
@@ -58,7 +58,7 @@ public class IpInterfaceTopologyEntity {
     }
 
     public IpInterfaceTopologyEntity(Integer id,
-            InetAddress ipAddress, String isManaged, Character snmpPrimary, Integer nodeId,
+            InetAddress ipAddress, String isManaged, String snmpPrimary, Integer nodeId,
             Integer snmpInterfaceId){
         this(id, ipAddress, isManaged, PrimaryType.get(snmpPrimary), nodeId, snmpInterfaceId);
     }

--- a/features/enlinkd/persistence/api/src/main/java/org/opennms/netmgt/enlinkd/model/IpInterfaceTopologyEntity.java
+++ b/features/enlinkd/persistence/api/src/main/java/org/opennms/netmgt/enlinkd/model/IpInterfaceTopologyEntity.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2018 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2018 The OpenNMS Group, Inc.
+ * Copyright (C) 2018-2021 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -57,6 +57,17 @@ public class IpInterfaceTopologyEntity {
         this.snmpInterfaceId = snmpInterfaceId;
     }
 
+    public IpInterfaceTopologyEntity(Integer id,
+            InetAddress ipAddress, String isManaged, Character snmpPrimary, Integer nodeId,
+            Integer snmpInterfaceId){
+        this.id = id;
+        this.ipAddress = ipAddress;
+        this.isManaged = isManaged;
+        this.isSnmpPrimary = PrimaryType.get(snmpPrimary);
+        this.nodeId = nodeId;
+        this.snmpInterfaceId = snmpInterfaceId;
+    }
+
     public static IpInterfaceTopologyEntity create(OnmsIpInterface ipInterface) {
         return new IpInterfaceTopologyEntity(
                 ipInterface.getId(),
@@ -88,6 +99,10 @@ public class IpInterfaceTopologyEntity {
 
     public boolean isManaged() {
         return "M".equals(getIsManaged());
+    }
+
+    public char snmpPrimary() {
+        return isSnmpPrimary.getCharCode();
     }
 
     public PrimaryType getIsSnmpPrimary() {

--- a/features/enlinkd/persistence/api/src/main/java/org/opennms/netmgt/enlinkd/model/IpInterfaceTopologyEntity.java
+++ b/features/enlinkd/persistence/api/src/main/java/org/opennms/netmgt/enlinkd/model/IpInterfaceTopologyEntity.java
@@ -60,12 +60,7 @@ public class IpInterfaceTopologyEntity {
     public IpInterfaceTopologyEntity(Integer id,
             InetAddress ipAddress, String isManaged, Character snmpPrimary, Integer nodeId,
             Integer snmpInterfaceId){
-        this.id = id;
-        this.ipAddress = ipAddress;
-        this.isManaged = isManaged;
-        this.isSnmpPrimary = PrimaryType.get(snmpPrimary);
-        this.nodeId = nodeId;
-        this.snmpInterfaceId = snmpInterfaceId;
+        this(id, ipAddress, isManaged, PrimaryType.get(snmpPrimary), nodeId, snmpInterfaceId);
     }
 
     public static IpInterfaceTopologyEntity create(OnmsIpInterface ipInterface) {

--- a/features/enlinkd/persistence/impl/src/main/java/org/opennms/netmgt/enlinkd/persistence/impl/TopologyEntityDaoHibernate.java
+++ b/features/enlinkd/persistence/impl/src/main/java/org/opennms/netmgt/enlinkd/persistence/impl/TopologyEntityDaoHibernate.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2018 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2018 The OpenNMS Group, Inc.
+ * Copyright (C) 2018-2021 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -89,7 +89,7 @@ public class TopologyEntityDaoHibernate extends HibernateDaoSupport implements T
     public List<IpInterfaceTopologyEntity> getIpTopologyEntities() {
         return (List<IpInterfaceTopologyEntity>)getHibernateTemplate().find(
                 "select new org.opennms.netmgt.enlinkd.model.IpInterfaceTopologyEntity(" +
-                        "i.id, i.ipAddress, i.isManaged, i.isSnmpPrimary, i.node.id, i.snmpInterface.id) " +
+                        "i.id, i.ipAddress, i.isManaged, i.snmpPrimary, i.node.id, i.snmpInterface.id) " +
                         "from org.opennms.netmgt.model.OnmsIpInterface i");
     }
 

--- a/features/enlinkd/service/impl/src/main/java/org/opennms/netmgt/enlinkd/service/impl/NodeTopologyServiceImpl.java
+++ b/features/enlinkd/service/impl/src/main/java/org/opennms/netmgt/enlinkd/service/impl/NodeTopologyServiceImpl.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2014-2021 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -59,8 +59,8 @@ public class NodeTopologyServiceImpl extends TopologyServiceImpl implements Node
                                                                   "iface",
                                                                   JoinType.LEFT_JOIN) }));
         criteria.addRestriction(new EqRestriction("type", NodeType.ACTIVE));
-        criteria.addRestriction(new EqRestriction("iface.isSnmpPrimary",
-                                                  PrimaryType.PRIMARY));
+        criteria.addRestriction(new EqRestriction("iface.snmpPrimary",
+                                                  PrimaryType.PRIMARY.getCharCode()));
         for (final OnmsNode node : m_nodeDao.findMatching(criteria)) {
             nodes.add(new Node(node.getId(), node.getLabel(),
                                node.getPrimaryInterface().getIpAddress(),
@@ -78,8 +78,8 @@ public class NodeTopologyServiceImpl extends TopologyServiceImpl implements Node
                                                                   "iface",
                                                                   JoinType.LEFT_JOIN) }));
         criteria.addRestriction(new EqRestriction("type", NodeType.ACTIVE));
-        criteria.addRestriction(new EqRestriction("iface.isSnmpPrimary",
-                                                  PrimaryType.PRIMARY));
+        criteria.addRestriction(new EqRestriction("iface.snmpPrimary",
+                                                  PrimaryType.PRIMARY.getCharCode()));
         criteria.addRestriction(new EqRestriction("id", nodeid));
         final List<OnmsNode> nodes = m_nodeDao.findMatching(criteria);
 

--- a/features/topology-map/plugins/org.opennms.features.topology.plugins.browsers/src/main/java/org/opennms/features/topology/plugins/browsers/NodeDaoContainer.java
+++ b/features/topology-map/plugins/org.opennms.features.topology.plugins.browsers/src/main/java/org/opennms/features/topology/plugins/browsers/NodeDaoContainer.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2012-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2012-2021 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -75,7 +75,7 @@ public class NodeDaoContainer extends OnmsVaadinContainer<OnmsNode,Integer> {
         if (!doOrder) return;
         // We join the ipInterfaces table, to be able to sort on ipInterfaces.ipAddress.
         criteria.setAliases(Arrays.asList(new Alias[] {
-                new Alias("ipInterfaces", "ipInterfaces", Alias.JoinType.LEFT_JOIN, new EqRestriction("ipInterfaces.isSnmpPrimary", PrimaryType.PRIMARY))
+                new Alias("ipInterfaces", "ipInterfaces", Alias.JoinType.LEFT_JOIN, new EqRestriction("ipInterfaces.snmpPrimary", PrimaryType.PRIMARY.getCharCode()))
         }));
     }
 

--- a/opennms-dao/src/main/java/org/opennms/netmgt/dao/hibernate/IpInterfaceDaoHibernate.java
+++ b/opennms-dao/src/main/java/org/opennms/netmgt/dao/hibernate/IpInterfaceDaoHibernate.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2002-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2002-2021 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -132,7 +132,7 @@ public class IpInterfaceDaoHibernate extends AbstractDaoHibernate<OnmsIpInterfac
 
         // Add all primary addresses first
         @SuppressWarnings("unchecked")
-        List<Object[]> l = (List<Object[]>)getHibernateTemplate().find("select distinct ipInterface.ipAddress, ipInterface.node.id from OnmsIpInterface as ipInterface where ipInterface.isSnmpPrimary = 'P'");
+        List<Object[]> l = (List<Object[]>)getHibernateTemplate().find("select distinct ipInterface.ipAddress, ipInterface.node.id from OnmsIpInterface as ipInterface where ipInterface.snmpPrimary = 'P'");
         for (Object[] tuple : l) {
             InetAddress ip = (InetAddress) tuple[0];
             Integer nodeId = (Integer) tuple[1];
@@ -141,7 +141,7 @@ public class IpInterfaceDaoHibernate extends AbstractDaoHibernate<OnmsIpInterfac
 
         // Add all non-primary addresses only if those addresses doesn't exist on the map.
         @SuppressWarnings("unchecked")
-        List<Object[]> s = (List<Object[]>)getHibernateTemplate().find("select distinct ipInterface.ipAddress, ipInterface.node.id from OnmsIpInterface as ipInterface where ipInterface.isSnmpPrimary != 'P'");
+        List<Object[]> s = (List<Object[]>)getHibernateTemplate().find("select distinct ipInterface.ipAddress, ipInterface.node.id from OnmsIpInterface as ipInterface where ipInterface.snmpPrimary != 'P'");
         for (Object[] tuple : s) {
             InetAddress ip = (InetAddress) tuple[0];
             Integer nodeId = (Integer) tuple[1];
@@ -182,7 +182,7 @@ public class IpInterfaceDaoHibernate extends AbstractDaoHibernate<OnmsIpInterfac
         Assert.notNull(nodeId, "nodeId cannot be null");
         // SELECT ipaddr FROM ipinterface WHERE nodeid = ? AND issnmpprimary = 'P'
 
-        List<OnmsIpInterface> primaryInterfaces = find("from OnmsIpInterface as ipInterface where ipInterface.node.id = ? and ipInterface.isSnmpPrimary = 'P' order by ipLastCapsdPoll desc", nodeId);
+        List<OnmsIpInterface> primaryInterfaces = find("from OnmsIpInterface as ipInterface where ipInterface.node.id = ? and ipInterface.snmpPrimary = 'P' order by ipLastCapsdPoll desc", nodeId);
         if (primaryInterfaces.size() < 1) {
             return null;
         } else {

--- a/opennms-dao/src/main/java/org/opennms/netmgt/dao/hibernate/MonitoredServiceDaoHibernate.java
+++ b/opennms-dao/src/main/java/org/opennms/netmgt/dao/hibernate/MonitoredServiceDaoHibernate.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2002-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2002-2021 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -85,8 +85,8 @@ public class MonitoredServiceDaoHibernate extends AbstractDaoHibernate<OnmsMonit
     @Override
 	public OnmsMonitoredService getPrimaryService(Integer nodeId, String svcName) {
 	    return findUnique("from OnmsMonitoredService as svc " +
-	                      "where svc.ipInterface.node.id = ? and svc.ipInterface.isSnmpPrimary= ? and svc.serviceType.name = ?",
-	                     nodeId, PrimaryType.PRIMARY, svcName);
+	                      "where svc.ipInterface.node.id = ? and svc.ipInterface.snmpPrimary= ? and svc.serviceType.name = ?",
+	                     nodeId, PrimaryType.PRIMARY.getCharCode(), svcName);
 	}
 
     /** {@inheritDoc} */

--- a/opennms-dao/src/main/java/org/opennms/netmgt/dao/hibernate/NodeDaoHibernate.java
+++ b/opennms-dao/src/main/java/org/opennms/netmgt/dao/hibernate/NodeDaoHibernate.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2006-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2006-2021 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -463,13 +463,13 @@ public class NodeDaoHibernate extends AbstractDaoHibernate<OnmsNode, Integer> im
     @Override
     public List<OnmsIpInterface> findObsoleteIpInterfaces(Integer nodeId, Date scanStamp) {
         // we exclude the primary interface from the obsolete list since the only way for them to be obsolete is when we have snmp
-        return findObjects(OnmsIpInterface.class, "from OnmsIpInterface ipInterface where ipInterface.node.id = ? and ipInterface.isSnmpPrimary != 'P' and (ipInterface.ipLastCapsdPoll is null or ipInterface.ipLastCapsdPoll < ?)", nodeId, scanStamp);
+        return findObjects(OnmsIpInterface.class, "from OnmsIpInterface ipInterface where ipInterface.node.id = ? and ipInterface.snmpPrimary != 'P' and (ipInterface.ipLastCapsdPoll is null or ipInterface.ipLastCapsdPoll < ?)", nodeId, scanStamp);
     }
 
     /** {@inheritDoc} */
     @Override
     public void deleteObsoleteInterfaces(Integer nodeId, Date scanStamp) {
-        getHibernateTemplate().bulkUpdate("delete from OnmsIpInterface ipInterface where ipInterface.node.id = ? and ipInterface.isSnmpPrimary != 'P' and (ipInterface.ipLastCapsdPoll is null or ipInterface.ipLastCapsdPoll < ?)", new Object[] { nodeId, scanStamp });
+        getHibernateTemplate().bulkUpdate("delete from OnmsIpInterface ipInterface where ipInterface.node.id = ? and ipInterface.snmpPrimary != 'P' and (ipInterface.ipLastCapsdPoll is null or ipInterface.ipLastCapsdPoll < ?)", new Object[] { nodeId, scanStamp });
         getHibernateTemplate().bulkUpdate("delete from OnmsSnmpInterface snmpInterface where snmpInterface.node.id = ? and (snmpInterface.lastCapsdPoll is null or snmpInterface.lastCapsdPoll < ?)", new Object[] { nodeId, scanStamp });
     }
 

--- a/opennms-dao/src/test/java/org/opennms/netmgt/dao/IpInterfaceDaoIT.java
+++ b/opennms-dao/src/test/java/org/opennms/netmgt/dao/IpInterfaceDaoIT.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2002-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2002-2021 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -49,6 +49,7 @@ import org.hibernate.criterion.Restrictions;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.opennms.core.criteria.CriteriaBuilder;
 import org.opennms.core.spring.BeanUtils;
 import org.opennms.core.test.OpenNMSJUnit4ClassRunner;
 import org.opennms.core.test.db.annotations.JUnitTemporaryDatabase;
@@ -57,6 +58,7 @@ import org.opennms.netmgt.dao.api.IpInterfaceDao;
 import org.opennms.netmgt.model.OnmsCriteria;
 import org.opennms.netmgt.model.OnmsIpInterface;
 import org.opennms.netmgt.model.OnmsMonitoredService;
+import org.opennms.netmgt.model.PrimaryType;
 import org.opennms.test.JUnitConfigurationEnvironment;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -90,6 +92,18 @@ public class IpInterfaceDaoIT implements InitializingBean {
     @Before
     public void setUp() {
         m_databasePopulator.populateDatabase();
+    }
+
+    @Test
+    @Transactional
+    public void testPrimaryType() {
+        CriteriaBuilder cb = new CriteriaBuilder(OnmsIpInterface.class).eq("snmpPrimary", PrimaryType.PRIMARY.getCharCode());
+        Collection<OnmsIpInterface> ifaces = m_ipInterfaceDao.findMatching(cb.toCriteria());
+        assertEquals(Integer.valueOf(1), ifaces.iterator().next().getIfIndex());
+
+        cb = new CriteriaBuilder(OnmsIpInterface.class).eq("snmpPrimary", PrimaryType.NOT_ELIGIBLE.getCharCode());
+        ifaces = m_ipInterfaceDao.findMatching(cb.toCriteria());
+        assertEquals(Integer.valueOf(3), ifaces.iterator().next().getIfIndex());
     }
 
     @Test
@@ -171,6 +185,7 @@ public class IpInterfaceDaoIT implements InitializingBean {
 
     @Test
     @Transactional
+    @SuppressWarnings("unlikely-arg-type")
     public void testGetInterfacesForNodes() throws UnknownHostException {
         Map<InetAddress, Integer> interfaceNodes = m_ipInterfaceDao.getInterfacesForNodes();
         assertNotNull("interfaceNodes", interfaceNodes);

--- a/opennms-model/src/main/java/org/opennms/netmgt/model/CharacterUserType.java
+++ b/opennms-model/src/main/java/org/opennms/netmgt/model/CharacterUserType.java
@@ -1,0 +1,119 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2021 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.model;
+
+import java.io.Serializable;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Objects;
+
+import org.hibernate.HibernateException;
+import org.hibernate.type.CharacterType;
+import org.hibernate.usertype.UserType;
+
+public class CharacterUserType implements UserType {
+    private static final int[] SQL_TYPES = new int[] { java.sql.Types.CHAR };
+
+    /**
+     * A public default constructor is required by Hibernate.
+     */
+    public CharacterUserType() {}
+
+    @Override
+    public int[] sqlTypes() {
+        return SQL_TYPES;
+    }
+
+    @Override
+    public Class<String> returnedClass() {
+        return String.class;
+    }
+
+    @Override
+    public boolean equals(final Object x, final Object y) throws HibernateException {
+        return Objects.equals(x, y);
+    }
+
+    @Override
+    public int hashCode(final Object x) throws HibernateException {
+        return x == null? 0 : x.hashCode();
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public Object nullSafeGet(final ResultSet rs, final String[] names, final Object owner) throws HibernateException, SQLException {
+        final Character c = CharacterType.INSTANCE.nullSafeGet(rs, names[0]);
+        return c == null? null : String.valueOf(c);
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public void nullSafeSet(final PreparedStatement st, final Object value, final int index) throws HibernateException, SQLException {
+        if (value == null) {
+            CharacterType.INSTANCE.nullSafeSet(st, null, index);
+        } else if (value instanceof Character) {
+            CharacterType.INSTANCE.nullSafeSet(st, (Character)value, index);
+        } else if (value instanceof String) {
+            CharacterType.INSTANCE.nullSafeSet(st, ((String)value).charAt(0), index);
+        }
+    }
+
+    @Override
+    public Object deepCopy(final Object value) throws HibernateException {
+        if (value == null) {
+            return null;
+        } else if (value instanceof String) {
+            return ((String) value).intern();
+        } else {
+            throw new IllegalArgumentException("Unexpected type that is mapped with " + this.getClass().getSimpleName() + ": " + value.getClass().getName());
+        }
+    }
+
+    @Override
+    public boolean isMutable() {
+        return false;
+    }
+
+    @Override
+    public Serializable disassemble(Object value) throws HibernateException {
+        return (Serializable)deepCopy(value);
+    }
+
+    @Override
+    public Object assemble(final Serializable cached, final Object owner) throws HibernateException {
+        return deepCopy(cached);
+    }
+
+    @Override
+    public Object replace(final Object original, final Object target, final Object owner) throws HibernateException {
+        return original;
+    }
+
+}

--- a/opennms-model/src/main/java/org/opennms/netmgt/model/CharacterUserType.java
+++ b/opennms-model/src/main/java/org/opennms/netmgt/model/CharacterUserType.java
@@ -70,7 +70,7 @@ public class CharacterUserType implements UserType {
     @SuppressWarnings("deprecation")
     public Object nullSafeGet(final ResultSet rs, final String[] names, final Object owner) throws HibernateException, SQLException {
         final Character c = CharacterType.INSTANCE.nullSafeGet(rs, names[0]);
-        return c == null? null : String.valueOf(c);
+        return c == null ? null : String.valueOf(c);
     }
 
     @Override

--- a/opennms-model/src/main/java/org/opennms/netmgt/model/OnmsIpInterface.java
+++ b/opennms-model/src/main/java/org/opennms/netmgt/model/OnmsIpInterface.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2006-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2006-2021 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -314,34 +314,27 @@ public class OnmsIpInterface extends OnmsEntity implements Serializable {
         m_ipLastCapsdPoll = iplastcapsdpoll;
     }
 
-    /**
-     * <p>getPrimaryString</p>
-     *
-     * @return a {@link java.lang.String} object.
-     */
-    @Transient
+    @Column(name="isSnmpPrimary", length=1)
     @XmlAttribute(name="snmpPrimary")
-    public String getPrimaryString() {
-        return m_isSnmpPrimary == null? null : m_isSnmpPrimary.toString();
+    @Type(type="org.opennms.netmgt.model.CharacterUserType")
+    public String getSnmpPrimary() {
+        final PrimaryType type = m_isSnmpPrimary == null? PrimaryType.NOT_ELIGIBLE : m_isSnmpPrimary;
+        return type.getCode();
     }
-    /**
-     * <p>setPrimaryString</p>
-     *
-     * @param primaryType a {@link java.lang.String} object.
-     */
-    public void setPrimaryString(String primaryType) {
-        m_isSnmpPrimary = new PrimaryType(primaryType.charAt(0));
+
+    public void setSnmpPrimary(final String primary) {
+        this.m_isSnmpPrimary = PrimaryType.get(primary);
     }
-    
+
     /**
      * <p>getIsSnmpPrimary</p>
      *
      * @return a {@link org.opennms.netmgt.model.PrimaryType} object.
      */
-    @Column(name="isSnmpPrimary", length=1)
     @XmlTransient
+    @Transient
     public PrimaryType getIsSnmpPrimary() {
-        return m_isSnmpPrimary;
+        return m_isSnmpPrimary == null? PrimaryType.NOT_ELIGIBLE : m_isSnmpPrimary;
     }
 
     /**
@@ -352,7 +345,7 @@ public class OnmsIpInterface extends OnmsEntity implements Serializable {
     public void setIsSnmpPrimary(PrimaryType issnmpprimary) {
         m_isSnmpPrimary = issnmpprimary;
     }
-    
+
     /**
      * <p>isPrimary</p>
      *
@@ -361,7 +354,7 @@ public class OnmsIpInterface extends OnmsEntity implements Serializable {
     @Transient
     @XmlTransient
     public boolean isPrimary(){
-        return m_isSnmpPrimary.equals(PrimaryType.PRIMARY);
+        return PrimaryType.PRIMARY.equals(m_isSnmpPrimary);
     }
 
     @Transient
@@ -488,9 +481,6 @@ public class OnmsIpInterface extends OnmsEntity implements Serializable {
         m_monitoredServices = ifServices;
     }
 
-    // TODO: Why are these annotations here?
-    @Transient
-    @JsonIgnore
     public void addMonitoredService(final OnmsMonitoredService svc) {
         m_monitoredServices.add(svc);
     }
@@ -534,7 +524,7 @@ public class OnmsIpInterface extends OnmsEntity implements Serializable {
         .add("netMask", InetAddressUtils.str(m_netMask))
         .add("ipHostName", m_ipHostName)
         .add("isManaged", m_isManaged)
-        .add("isSnmpPrimary", m_isSnmpPrimary)
+        .add("snmpPrimary", m_isSnmpPrimary)
         .add("ipLastCapsdPoll", m_ipLastCapsdPoll)
         .add("nodeId", getNodeId())
         .toString();

--- a/opennms-model/src/main/java/org/opennms/netmgt/model/PrimaryType.java
+++ b/opennms-model/src/main/java/org/opennms/netmgt/model/PrimaryType.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2012-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2012-2021 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -32,7 +32,6 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.persistence.Column;
 import javax.persistence.Embeddable;
 import javax.persistence.Transient;
 
@@ -55,7 +54,8 @@ public class PrimaryType implements Comparable<PrimaryType>, Serializable {
         return String.valueOf(m_collType);
     }
 
-    @Column(name="isSnmpPrimary")
+    /* this needs to be marked transient because we're not using it embedded anymore */
+    @Transient
     public char getCharCode() {
         return m_collType;
     }
@@ -125,17 +125,20 @@ public class PrimaryType implements Comparable<PrimaryType>, Serializable {
         }
     }
 
-    public static PrimaryType get(final String code) {
+    public static PrimaryType get(final Object code) {
         if (code == null) {
             return NOT_ELIGIBLE;
-        }
-        final String codeText = code.trim();
-        if (codeText.length() < 1) {
-            return NOT_ELIGIBLE;
-        } else if (codeText.length() > 1) {
-            throw new IllegalArgumentException("Cannot convert string '"+codeText+"' to a collType");
+        } else if (code instanceof Character) {
+            return get(((Character) code).charValue());
         } else {
-            return get(codeText.charAt(0));
+            final String codeText = code.toString().trim();
+            if (codeText.length() < 1) {
+                return NOT_ELIGIBLE;
+            } else if (codeText.length() > 1) {
+                throw new IllegalArgumentException("Cannot convert string '"+codeText+"' to a collType");
+            } else {
+                return get(codeText.charAt(0));
+            }
         }
     }
 

--- a/opennms-model/src/main/java/org/opennms/netmgt/model/PrimaryTypeAdapter.java
+++ b/opennms-model/src/main/java/org/opennms/netmgt/model/PrimaryTypeAdapter.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2012-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2012-2021 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -26,11 +26,9 @@
  *     http://www.opennms.com/
  *******************************************************************************/
 
-package org.opennms.netmgt.provision.persist;
+package org.opennms.netmgt.model;
 
 import javax.xml.bind.annotation.adapters.XmlAdapter;
-
-import org.opennms.netmgt.model.PrimaryType;
 
 public class PrimaryTypeAdapter extends XmlAdapter<String, PrimaryType> {
 

--- a/opennms-model/src/main/java/org/opennms/netmgt/model/PrimaryTypeUserType.java
+++ b/opennms-model/src/main/java/org/opennms/netmgt/model/PrimaryTypeUserType.java
@@ -1,0 +1,127 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2021 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.model;
+
+import java.io.Serializable;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Objects;
+
+import org.hibernate.HibernateException;
+import org.hibernate.type.CharacterType;
+import org.hibernate.usertype.UserType;
+
+public class PrimaryTypeUserType implements UserType {
+    private static final int[] SQL_TYPES = new int[] { java.sql.Types.CHAR };
+
+    /**
+     * A public default constructor is required by Hibernate.
+     */
+    public PrimaryTypeUserType() {}
+
+    @Override
+    public int[] sqlTypes() {
+        return SQL_TYPES;
+    }
+
+    @Override
+    public Class<PrimaryType> returnedClass() {
+        return PrimaryType.class;
+    }
+
+    @Override
+    public boolean equals(final Object x, final Object y) throws HibernateException {
+        return Objects.equals(x, y);
+    }
+
+    @Override
+    public int hashCode(final Object x) throws HibernateException {
+        return x == null? 0 : x.hashCode();
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public Object nullSafeGet(final ResultSet rs, final String[] names, final Object owner) throws HibernateException, SQLException {
+        final Character c = CharacterType.INSTANCE.nullSafeGet(rs, names[0]);
+        return PrimaryType.get(c);
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public void nullSafeSet(final PreparedStatement st, final Object value, final int index) throws HibernateException, SQLException {
+        if (value == null) {
+            CharacterType.INSTANCE.nullSafeSet(st, null, index);
+        } else if (value instanceof PrimaryType) {
+            CharacterType.INSTANCE.nullSafeSet(st, ((PrimaryType)value).getCharCode(), index);
+        } else if (value instanceof Character) {
+            CharacterType.INSTANCE.nullSafeSet(st, (Character)value, index);
+        } else if (value instanceof String) {
+            // let PrimaryType validate it as a "good" value
+            CharacterType.INSTANCE.nullSafeSet(st, PrimaryType.get((String)value).getCharCode(), index);
+        }
+    }
+
+    /**
+     * Since {@link PrimaryType} is immutable, we just return the original
+     * value without copying it.
+     */
+    @Override
+    public Object deepCopy(final Object value) throws HibernateException {
+        if (value == null) {
+            return null;
+        } else if (value instanceof PrimaryType) {
+            // PrimaryType is immutable so return the value without copying it
+            return value;
+        } else {
+            throw new IllegalArgumentException("Unexpected type that is mapped with " + this.getClass().getSimpleName() + ": " + value.getClass().getName());
+        }
+    }
+
+    @Override
+    public boolean isMutable() {
+        return false;
+    }
+
+    @Override
+    public Serializable disassemble(Object value) throws HibernateException {
+        return (Serializable)deepCopy(value);
+    }
+
+    @Override
+    public Object assemble(final Serializable cached, final Object owner) throws HibernateException {
+        return deepCopy(cached);
+    }
+
+    @Override
+    public Object replace(final Object original, final Object target, final Object owner) throws HibernateException {
+        return original;
+    }
+
+}

--- a/opennms-provision/opennms-provision-persistence/src/main/java/org/opennms/netmgt/provision/persist/requisition/RequisitionInterface.java
+++ b/opennms-provision/opennms-provision-persistence/src/main/java/org/opennms/netmgt/provision/persist/requisition/RequisitionInterface.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2009-2017 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
+ * Copyright (C) 2009-2021 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -55,7 +55,7 @@ import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import org.apache.commons.lang.builder.CompareToBuilder;
 import org.opennms.core.utils.InetAddressUtils;
 import org.opennms.netmgt.model.PrimaryType;
-import org.opennms.netmgt.provision.persist.PrimaryTypeAdapter;
+import org.opennms.netmgt.model.PrimaryTypeAdapter;
 
 
 /**

--- a/opennms-provision/opennms-provisiond/src/main/java/org/opennms/netmgt/provision/service/Provisioner.java
+++ b/opennms-provision/opennms-provisiond/src/main/java/org/opennms/netmgt/provision/service/Provisioner.java
@@ -801,7 +801,7 @@ public class Provisioner implements SpringServiceDaemon {
 
         OnmsIpInterface iface = new OnmsIpInterface(addr(ipAddr), node);
         iface.setIsManaged("M");
-        iface.setPrimaryString("N");
+        iface.setSnmpPrimary("N");
 
         m_provisionService.insertNode(node);
 

--- a/opennms-services/src/main/java/org/opennms/netmgt/snmpinterfacepoller/DefaultPollContext.java
+++ b/opennms-services/src/main/java/org/opennms/netmgt/snmpinterfacepoller/DefaultPollContext.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2009-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2009-2021 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -242,14 +242,14 @@ public class DefaultPollContext implements PollContext {
 	@Override
 	public List<OnmsIpInterface> getPollableNodesByIp(String ipaddr) {
                 CriteriaBuilder builder = new CriteriaBuilder(OnmsIpInterface.class);
-                builder.eq("ipAddress", InetAddressUtils.addr(ipaddr)).eq("isSnmpPrimary", PrimaryType.PRIMARY).eq("isManaged", "M");
+                builder.eq("ipAddress", InetAddressUtils.addr(ipaddr)).eq("snmpPrimary", PrimaryType.PRIMARY.getCharCode()).eq("isManaged", "M");
 		return getIpInterfaceDao().findMatching(builder.toCriteria());
 	}
 
 	@Override
 	public List<OnmsIpInterface> getPollableNodes() {
                 CriteriaBuilder builder = new CriteriaBuilder(OnmsIpInterface.class);
-                builder.eq("isSnmpPrimary", PrimaryType.PRIMARY).eq("isManaged", "M");
+                builder.eq("snmpPrimary", PrimaryType.PRIMARY.getCharCode()).eq("isManaged", "M");
 		return getIpInterfaceDao().findMatching(builder.toCriteria());
 	}
 

--- a/opennms-tools/access-point-monitor/src/main/java/org/opennms/netmgt/accesspointmonitor/DefaultPollingContext.java
+++ b/opennms-tools/access-point-monitor/src/main/java/org/opennms/netmgt/accesspointmonitor/DefaultPollingContext.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2012-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2012-2021 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -321,7 +321,7 @@ public class DefaultPollingContext implements PollingContext {
         OnmsIpInterfaceList ifaces = new OnmsIpInterfaceList();
         // Only poll the primary interface
         final Criteria criteria = new Criteria(OnmsIpInterface.class);
-        criteria.addRestriction(new EqRestriction("isSnmpPrimary", PrimaryType.PRIMARY));
+        criteria.addRestriction(new EqRestriction("snmpPrimary", PrimaryType.PRIMARY));
 
         List<OnmsIpInterface> allValidIfaces = getIpInterfaceDao().findMatching(criteria);
         for (OnmsIpInterface iface : allValidIfaces) {

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/CriteriaBehaviors.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/CriteriaBehaviors.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2017 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
+ * Copyright (C) 2017-2021 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -28,6 +28,7 @@
 
 package org.opennms.web.rest.support;
 
+import static org.opennms.web.rest.support.CriteriaValueConverters.CHARACTER_CONVERTER;
 import static org.opennms.web.rest.support.CriteriaValueConverters.DATE_CONVERTER;
 import static org.opennms.web.rest.support.CriteriaValueConverters.FLOAT_CONVERTER;
 import static org.opennms.web.rest.support.CriteriaValueConverters.INET_ADDRESS_CONVERTER;
@@ -293,6 +294,7 @@ public abstract class CriteriaBehaviors {
         IP_INTERFACE_BEHAVIORS.put("ipLastCapsdPoll", new CriteriaBehavior<Date>(DATE_CONVERTER));
         IP_INTERFACE_BEHAVIORS.put("ipAddress", new CriteriaBehavior<InetAddress>(INET_ADDRESS_CONVERTER));
         IP_INTERFACE_BEHAVIORS.put("netMask", new CriteriaBehavior<InetAddress>(INET_ADDRESS_CONVERTER));
+        IP_INTERFACE_BEHAVIORS.put("snmpPrimary", new CriteriaBehavior<Character>(CHARACTER_CONVERTER));
 
         MONITORED_SERVICE_BEHAVIORS.put("id", new CriteriaBehavior<Integer>(INT_CONVERTER));
         MONITORED_SERVICE_BEHAVIORS.put("lastFail", new CriteriaBehavior<Date>(DATE_CONVERTER));

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/CriteriaValueConverters.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/CriteriaValueConverters.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2017-2017 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2017 The OpenNMS Group, Inc.
+ * Copyright (C) 2017-2021 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -55,6 +55,22 @@ public abstract class CriteriaValueConverters {
         @Override
         public String toString() {
             return "DATE_CONVERTER";
+        }
+    };
+
+    public static final Function<String,Character> CHARACTER_CONVERTER = new Function<String,Character>() {
+        @Override
+        public Character apply(final String t) {
+            return t.charAt(0);
+        }
+
+        /**
+         * Override {@link #toString()} on this functional interface
+         * to make it identifiable inside a debugger.
+         */
+        @Override
+        public String toString() {
+            return "CHARACTER_CONVERTER";
         }
     };
 

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/SearchProperties.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/support/SearchProperties.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2017-2020 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2020 The OpenNMS Group, Inc.
+ * Copyright (C) 2017-2021 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -62,6 +62,7 @@ import org.opennms.netmgt.model.OnmsOutage;
 import org.opennms.netmgt.model.OnmsServiceType;
 import org.opennms.netmgt.model.OnmsSeverity;
 import org.opennms.netmgt.model.OnmsSnmpInterface;
+import org.opennms.netmgt.model.PrimaryType;
 import org.opennms.netmgt.model.minion.OnmsMinion;
 import org.opennms.netmgt.model.monitoringLocations.OnmsMonitoringLocation;
 
@@ -285,7 +286,12 @@ public abstract class SearchProperties {
 		new SearchProperty(OnmsIpInterface.class, "netMask", "Network Mask", IP_ADDRESS),
 		new SearchProperty(OnmsIpInterface.class, "ipHostName", "Hostname", STRING),
 		new SearchProperty(OnmsIpInterface.class, "ipLastCapsdPoll", "Last Provisioning Scan", TIMESTAMP),
-		new SearchProperty(OnmsIpInterface.class, "isManaged", "Management Status", STRING)
+		new SearchProperty(OnmsIpInterface.class, "isManaged", "Management Status", STRING),
+		new SearchProperty(OnmsIpInterface.class, "snmpPrimary", "Primary SNMP Interface Status", STRING, ImmutableMap.<String,String>builder()
+				.put(PrimaryType.PRIMARY.getCode(), PrimaryType.PRIMARY.getCode())
+				.put(PrimaryType.SECONDARY.getCode(), PrimaryType.SECONDARY.getCode())
+				.put(PrimaryType.NOT_ELIGIBLE.getCode(), PrimaryType.NOT_ELIGIBLE.getCode())
+				.build()),
 	}));
 
 	static final SortedSet<SearchProperty> LOCATION_PROPERTIES = new TreeSet<>(Arrays.asList(new SearchProperty[] {

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/IpInterfaceRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/IpInterfaceRestService.java
@@ -134,7 +134,9 @@ public class IpInterfaceRestService extends AbstractDaoRestService<OnmsIpInterfa
         if (addresses.isEmpty()) {
             return null;
         } else if (addresses.size() == 1) {
-            return addresses.get(0);
+            final OnmsIpInterface iface = addresses.get(0);
+            getDao().initialize(iface.getSnmpInterface());
+			return iface;
         }
         throw new WebApplicationException("More than one IP address matches " + ipAddress, Status.BAD_REQUEST);
     }

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NodeIpInterfacesRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NodeIpInterfacesRestService.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2008-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2008-2021 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -29,12 +29,10 @@
 package org.opennms.web.rest.v2;
 
 import java.util.Collection;
+import java.util.Set;
 import java.util.stream.Collectors;
 
-import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
@@ -52,7 +50,6 @@ import org.opennms.core.criteria.CriteriaBuilder;
 import org.opennms.netmgt.dao.api.IpInterfaceDao;
 import org.opennms.netmgt.model.OnmsIpInterface;
 import org.opennms.netmgt.model.OnmsIpInterfaceList;
-import org.opennms.netmgt.model.OnmsMetaData;
 import org.opennms.netmgt.model.OnmsMetaDataList;
 import org.opennms.netmgt.model.OnmsNode;
 import org.opennms.netmgt.model.events.EventUtils;
@@ -61,6 +58,8 @@ import org.opennms.web.api.RestUtils;
 import org.opennms.web.rest.support.Aliases;
 import org.opennms.web.rest.support.MultivaluedMapImpl;
 import org.opennms.web.rest.support.RedirectHelper;
+import org.opennms.web.rest.support.SearchProperties;
+import org.opennms.web.rest.support.SearchProperty;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -93,10 +92,16 @@ public class NodeIpInterfacesRestService extends AbstractNodeDependentRestServic
     }
 
     @Override
+    protected Set<SearchProperty> getQueryProperties() {
+        return SearchProperties.IP_INTERFACE_SERVICE_PROPERTIES;
+    }
+
+    @Override
     protected CriteriaBuilder getCriteriaBuilder(final UriInfo uriInfo) {
         final CriteriaBuilder builder = new CriteriaBuilder(getDaoClass());
 
         // 1st level JOINs
+        builder.alias("snmpInterface", Aliases.snmpInterface.toString(), JoinType.LEFT_JOIN);
         // TODO: Only add this alias when filtering so that we can specify a join condition
         builder.alias("monitoredServices", Aliases.monitoredService.toString(), JoinType.LEFT_JOIN);
 
@@ -159,7 +164,11 @@ public class NodeIpInterfacesRestService extends AbstractNodeDependentRestServic
     @Override
     protected OnmsIpInterface doGet(UriInfo uriInfo, String ipAddress) {
         final OnmsNode node = getNode(uriInfo);
-        return node == null ? null : node.getIpInterfaceByIpAddress(ipAddress);
+        final OnmsIpInterface iface = node == null ? null : node.getIpInterfaceByIpAddress(ipAddress);
+        if (iface != null) {
+            getDao().initialize(iface.getSnmpInterface());
+        }
+		return iface;
     }
 
     @Path("{id}/services")

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NodeRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NodeRestService.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2008-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2008-2021 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -34,10 +34,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
@@ -57,7 +54,6 @@ import org.opennms.core.criteria.restrictions.Restrictions;
 import org.opennms.netmgt.dao.api.MonitoringLocationDao;
 import org.opennms.netmgt.dao.api.NodeDao;
 import org.opennms.netmgt.events.api.EventProxy;
-import org.opennms.netmgt.model.OnmsMetaData;
 import org.opennms.netmgt.model.OnmsMetaDataList;
 import org.opennms.netmgt.model.OnmsNode;
 import org.opennms.netmgt.model.OnmsNodeList;

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v2/IpInterfaceRestServiceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v2/IpInterfaceRestServiceIT.java
@@ -83,6 +83,7 @@ public class IpInterfaceRestServiceIT extends AbstractSpringJerseyRestTestCase {
 
         LOG.warn(sendRequest(GET, url, parseParamData("_s=ipAddress==10.10.10.10"), 200));
         LOG.warn(sendRequest(GET, url, parseParamData("_s=node.label==*1"), 200));
+        LOG.warn(sendRequest(GET, url, parseParamData("_s=snmpPrimary==P"), 200));
     }
 
     @Test

--- a/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v2/NodeRestServiceIT.java
+++ b/opennms-webapp-rest/src/test/java/org/opennms/web/rest/v2/NodeRestServiceIT.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2008-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2008-2021 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -33,6 +33,7 @@ import static org.junit.Assert.assertTrue;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.Collections;
 
 import javax.ws.rs.core.MediaType;
 
@@ -97,6 +98,10 @@ public class NodeRestServiceIT extends AbstractSpringJerseyRestTestCase {
         LOG.warn(sendRequest(GET, url, parseParamData("_s=assetRecord.id==2"), 200));
         LOG.warn(sendRequest(GET, url, parseParamData("_s=node.label==*2;assetRecord.id==2"), 200));
         LOG.warn(sendRequest(GET, url, parseParamData("_s=(node.label==*2;assetRecord.id==2),(node.label==*1)"), 200));
+        LOG.warn(sendRequest(GET, url, parseParamData("_s=ipInterface.ipAddress==10.10.10.10"), 204));
+        LOG.warn(sendRequest(GET, url, parseParamData("_s=ipInterface.snmpPrimary==P"), 204));
+        LOG.warn(sendRequest(GET, url + "/1/ipinterfaces", Collections.emptyMap(), 204));
+        LOG.warn(sendRequest(GET, url + "/1/ipinterfaces", parseParamData("_s=snmpPrimary==P"), 204));
 
         // Use "Hello, Handsome" as a value to test CXF 'search.decode.values' property which will
         // URL-decode FIQL search values

--- a/opennms-webapp/src/main/java/org/opennms/web/element/NetworkElementFactory.java
+++ b/opennms-webapp/src/main/java/org/opennms/web/element/NetworkElementFactory.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2002-2016 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * Copyright (C) 2002-2021 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -229,7 +229,7 @@ public class NetworkElementFactory implements InitializingBean, NetworkElementFa
     @Override
     public String getIpPrimaryAddress(int nodeId) {
         final CriteriaBuilder cb = new CriteriaBuilder(OnmsIpInterface.class);
-        cb.and(new EqRestriction("node.id", nodeId), new EqRestriction("isSnmpPrimary", PrimaryType.PRIMARY));
+        cb.and(new EqRestriction("node.id", nodeId), new EqRestriction("snmpPrimary", PrimaryType.PRIMARY.getCharCode()));
         
         final List<OnmsIpInterface> ifaces = m_ipInterfaceDao.findMatching(cb.toCriteria());
         


### PR DESCRIPTION
This PR does a bunch of plumbing work to fix querying nodes and interfaces based on their SNMP primary status.  Note: this work is necessary to complete the work for HELM-188.

- add `OnmsIpInterface#getSnmpPrimary` and move the hibernate annotation to it to make ReST mapping happy, `#getIsSnmpPrimary` is left in place so that a bunch of code doesn't need changing (including end-user groovy code); this includes creating a `CharacterUserType` adapter for Hibernate
- change PrimaryType to not be an `Embedded` Hibernate column, instead just make it a property of `OnmsIpInterface` to avoid API changes
- refactor `PrimaryTypeAdapter` from Provisiond into `opennms-model` so it can be live with other type adapters
- fix internal HQL queries to use `.snmpPrimary` rather than `.isSnmpPrimary`
- update `PrimaryType#get` to accept a String _or_ Character/char
- add "snmpPrimary" checks to both the `NodeRestServiceIT` and `IpInterfaceRestServiceIT`
- add search properties for PrimaryType so Helm displays the choices

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-13469