### PR TITLE
NMS-13436: fix handling of permissions/ownership when running as root

### DIFF
--- a/opennms-bootstrap/src/main/java/org/opennms/bootstrap/FilesystemPermissionException.java
+++ b/opennms-bootstrap/src/main/java/org/opennms/bootstrap/FilesystemPermissionException.java
@@ -41,7 +41,7 @@ public class FilesystemPermissionException extends Exception {
     }
 
     public FilesystemPermissionException(final Path path, final String user, final Exception e) {
-        super("Failed to validate " + path + " (or its contents) for ownership by " + user, e);
+        super("Failed to validate " + path + " (or its contents) for read/write by " + user, e);
         this.path = path;
         this.user = user;
     }

--- a/opennms-container/horizon/Dockerfile
+++ b/opennms-container/horizon/Dockerfile
@@ -71,7 +71,7 @@ RUN echo "installing packages for build ${REVISION} (${BUILD_DATE})"; \
     if [[ "$(ls -1 /tmp/tarball/*.tar.gz 2>/dev/null | wc -l)" != 0 ]]; then \
         mkdir -p /opt/opennms && \
         tar -xzf /tmp/tarball/opennms-*.tar.gz -C /opt/opennms && \
-        chown -R 0:0 /opt/opennms && \
+        chown -R 10001:0 /opt/opennms && \
         cp -r /opt/opennms/etc /opt/opennms/share/etc-pristine; \
     elif [[ "$(ls -1 /tmp/rpms/*.rpm 2>/dev/null | wc -l)" != 0 ]]; then \
         echo "installing local RPMs from filesystem" && \

--- a/opennms-container/horizon/container-fs/entrypoint.sh
+++ b/opennms-container/horizon/container-fs/entrypoint.sh
@@ -23,6 +23,16 @@ OPENNMS_OVERLAY_JETTY_WEBINF="/opt/opennms-jetty-webinf-overlay"
 E_ILLEGAL_ARGS=126
 E_INIT_CONFIG=127
 
+MYID="$(id -u)"
+MYUSER="$(getent passwd "${MYID}" | cut -d: -f1)"
+
+export RUNAS="${MYUSER}"
+
+if [ "$MYID" -eq 0 ]; then
+  echo "RUNAS=${MYUSER}" >> /opt/opennms/etc/opennms.conf
+  chown "$MYUSER" /opt/opennms/etc/opennms.conf
+fi
+
 # Help function used in error messages and -h option
 usage() {
   echo ""

--- a/opennms-install/src/main/java/org/opennms/install/Installer.java
+++ b/opennms-install/src/main/java/org/opennms/install/Installer.java
@@ -591,7 +591,7 @@ public class Installer {
         try {
             validator.validate(user, opennmsHome);
         } catch (final FilesystemPermissionException e) {
-            LOG.error("OpenNMS is configured to run as '{}' but '{}' is not owned by that account.", user, e.path);
+            LOG.error("OpenNMS is configured to run as '{}' but '{}' is not writable by that account.", user, e.path);
             LOG.error("To fix permissions, run '{}/bin/fix-permissions' as root", m_opennms_home);
             System.out.println();
 

--- a/tools/packages/opennms/opennms.spec
+++ b/tools/packages/opennms/opennms.spec
@@ -984,7 +984,9 @@ echo "done"
 if [ ! -e "$ROOT_INST/etc/java.conf" ]; then
 	"$ROOT_INST/bin/runjava" "-s"
 fi
-"${ROOT_INST}/bin/fix-permissions" -R "${ROOT_INST}/etc/java.conf"
+if [ -e "${ROOT_INST}/etc/java.conf" ]; then
+	"${ROOT_INST}/bin/fix-permissions" -R "${ROOT_INST}/etc/java.conf"
+fi
 
 "${ROOT_INST}/bin/update-package-permissions" "%{name}-core"
 "${ROOT_INST}/bin/ensure-user-ping.sh" || echo "WARNING: Unable to enable ping by the opennms user. Try running /usr/share/opennms/bin/ensure-user-ping.sh manually."


### PR DESCRIPTION
This PR changes the Horizon Docker image to use `rsync` for all overlay operations, including using `--chown` to make the ownership match the container user.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-13436
