### PR TITLE
NMS-13478: Add bulking to elastic flow repository

### DIFF
--- a/docs/modules/operation/pages/elasticsearch/introduction.adoc
+++ b/docs/modules/operation/pages/elasticsearch/introduction.adoc
@@ -45,9 +45,9 @@ You can set the following properties:
 | readTimeout                            | 30000                           | Defines the read timeout in ms.
 | bulkRetryCount                         | 5                               | Defines the number of retries performed before a bulk operation is considered failed.
                                                                              When bulk operations fail, only the failed items are retried.
-| bulkSize                               | 0                               | Number of flow documents to collect into a bulk operation before committing.
+| bulkSize                               | 1000                            | Number of flow documents to collect into a bulk operation before committing.
                                                                              This is per thread. Set to `0` to disable bulking.
-| bulkFlushMs                            | 0                               | Timeout to flush bulk even if `bulkSize` wasn't reached.
+| bulkFlushMs                            | 500                             | Timeout to flush bulk even if `bulkSize` wasn't reached.
                                                                              This is per thread. Set to `0` to disable flushing.
 | settings.index.number_of_shards        | none                            | The number of primary shards that an index should have.
                                                                              Refer to link:https://www.elastic.co/guide/en/elasticsearch/reference/current/index-modules.html#index-modules-setting[Elasticsearch Reference -> Index Modules] for more details.

--- a/docs/modules/operation/pages/elasticsearch/introduction.adoc
+++ b/docs/modules/operation/pages/elasticsearch/introduction.adoc
@@ -45,6 +45,10 @@ You can set the following properties:
 | readTimeout                            | 30000                           | Defines the read timeout in ms.
 | bulkRetryCount                         | 5                               | Defines the number of retries performed before a bulk operation is considered failed.
                                                                              When bulk operations fail, only the failed items are retried.
+| bulkSize                               | 0                               | Number of flow documents to collect into a bulk operation before committing.
+                                                                             This is per thread. Set to `0` to disable bulking.
+| bulkFlushMs                            | 0                               | Timeout to flush bulk even if `bulkSize` wasn't reached.
+                                                                             This is per thread. Set to `0` to disable flushing.
 | settings.index.number_of_shards        | none                            | The number of primary shards that an index should have.
                                                                              Refer to link:https://www.elastic.co/guide/en/elasticsearch/reference/current/index-modules.html#index-modules-setting[Elasticsearch Reference -> Index Modules] for more details.
 | settings.index.number_of_replicas      | none                            | The number of replicas each primary shard has.

--- a/features/flows/elastic/src/main/java/org/opennms/netmgt/flows/elastic/ElasticFlowRepository.java
+++ b/features/flows/elastic/src/main/java/org/opennms/netmgt/flows/elastic/ElasticFlowRepository.java
@@ -223,6 +223,16 @@ public class ElasticFlowRepository implements FlowRepository {
         });
     }
 
+    public ElasticFlowRepository(final MetricRegistry metricRegistry, final JestClient jestClient, final IndexStrategy indexStrategy,
+                                 final DocumentEnricher documentEnricher, final SessionUtils sessionUtils, final NodeDao nodeDao,
+                                 final SnmpInterfaceDao snmpInterfaceDao, final Identity identity, final TracerRegistry tracerRegistry,
+                                 final EnrichedFlowForwarder enrichedFlowForwarder, final IndexSettings indexSettings, final int bulkSize,
+                                 final int bulkFlushMs) {
+        this(metricRegistry, jestClient, indexStrategy, documentEnricher, sessionUtils, nodeDao, snmpInterfaceDao, identity, tracerRegistry, enrichedFlowForwarder, indexSettings);
+        this.bulkSize = bulkSize;
+        this.bulkFlushMs = bulkFlushMs;
+    }
+
     private void startTimer() {
         if (flushTimer != null) {
             return;

--- a/features/flows/elastic/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/features/flows/elastic/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -33,7 +33,8 @@
             <cm:property name="nodeCache.recordStats" value="true"/> <!-- Set to false to not expose cache statistics via jmx -->
             <cm:property name="skipElasticsearchPersistence" value="false"/> <!-- Set to false to disable persisting flows to ES. -->
 
-            <!-- Bulk Action Retry settings -->
+            <!-- Bulk Action settings -->
+            <cm:property name="bulkSize" value="1000" /> <!-- Number of flow document collected into a bulk operation -->
             <cm:property name="bulkRetryCount" value="5" /> <!-- Number of retries until a bulk operation is considered failed -->
 
             <!-- Index settings -->
@@ -206,7 +207,7 @@
 
     <!-- The repository -->
     <bean id="elasticFlowRepository" class="org.opennms.netmgt.flows.elastic.ElasticFlowRepository"
-          init-method="start">
+          init-method="start" destroy-method="stop">
         <argument ref="flowRepositoryMetricRegistry"/>
         <argument ref="jestClient"/>
         <argument ref="rawIndexStrategy"/>
@@ -222,6 +223,7 @@
         <property name="enableFlowForwarding" value="${enableForwarding}"/>
         <property name="bulkRetryCount" value="${bulkRetryCount}"/>
         <property name="skipElasticsearchPersistence" value="${skipElasticsearchPersistence}"/>
+        <property name="bulkSize" value="${bulkRetryCount}"/>
     </bean>
 
     <!-- Proxy it, to ensure initialization on first call of any method -->

--- a/features/flows/elastic/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/features/flows/elastic/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -34,9 +34,9 @@
             <cm:property name="skipElasticsearchPersistence" value="false"/> <!-- Set to false to disable persisting flows to ES. -->
 
             <!-- Bulk Action settings -->
-            <cm:property name="bulkSize" value="0" /> <!-- Number of flow document collected into a bulk operation -->
+            <cm:property name="bulkSize" value="1000" /> <!-- Number of flow document collected into a bulk operation -->
             <cm:property name="bulkRetryCount" value="5" /> <!-- Number of retries until a bulk operation is considered failed -->
-            <cm:property name="bulkFlushMs" value="0" /> <!-- Timeout to flush incomplete bulks -->
+            <cm:property name="bulkFlushMs" value="500" /> <!-- Timeout to flush incomplete bulks -->
 
             <!-- Index settings -->
             <!-- https://www.elastic.co/guide/en/elasticsearch/reference/current/index-modules.html#index-modules-settings -->

--- a/features/flows/elastic/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/features/flows/elastic/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -34,8 +34,9 @@
             <cm:property name="skipElasticsearchPersistence" value="false"/> <!-- Set to false to disable persisting flows to ES. -->
 
             <!-- Bulk Action settings -->
-            <cm:property name="bulkSize" value="1000" /> <!-- Number of flow document collected into a bulk operation -->
+            <cm:property name="bulkSize" value="0" /> <!-- Number of flow document collected into a bulk operation -->
             <cm:property name="bulkRetryCount" value="5" /> <!-- Number of retries until a bulk operation is considered failed -->
+            <cm:property name="bulkFlushMs" value="0" /> <!-- Timeout to flush incomplete bulks -->
 
             <!-- Index settings -->
             <!-- https://www.elastic.co/guide/en/elasticsearch/reference/current/index-modules.html#index-modules-settings -->
@@ -223,7 +224,8 @@
         <property name="enableFlowForwarding" value="${enableForwarding}"/>
         <property name="bulkRetryCount" value="${bulkRetryCount}"/>
         <property name="skipElasticsearchPersistence" value="${skipElasticsearchPersistence}"/>
-        <property name="bulkSize" value="${bulkRetryCount}"/>
+        <property name="bulkSize" value="${bulkSize}"/>
+        <property name="bulkFlushMs" value="${bulkFlushMs}"/>
     </bean>
 
     <!-- Proxy it, to ensure initialization on first call of any method -->

--- a/features/flows/itests/src/test/java/org/opennms/netmgt/flows/elastic/AggregatedFlowQueryIT.java
+++ b/features/flows/itests/src/test/java/org/opennms/netmgt/flows/elastic/AggregatedFlowQueryIT.java
@@ -154,7 +154,7 @@ public class AggregatedFlowQueryIT {
 
         flowRepository = new ElasticFlowRepository(metricRegistry, client, IndexStrategy.MONTHLY, documentEnricher,
             new MockSessionUtils(), new MockNodeDao(), new MockSnmpInterfaceDao(),
-            new MockIdentity(), new MockTracerRegistry(), documentForwarder, rawIndexSettings);
+            new MockIdentity(), new MockTracerRegistry(), documentForwarder, rawIndexSettings, 0, 0);
         flowRepository.setEnableFlowForwarding(true);
 
         // The repository should be empty

--- a/features/flows/itests/src/test/java/org/opennms/netmgt/flows/elastic/BulkingIT.java
+++ b/features/flows/itests/src/test/java/org/opennms/netmgt/flows/elastic/BulkingIT.java
@@ -1,0 +1,235 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2021 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 2021-2021 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.flows.elastic;
+
+import com.codahale.metrics.MetricRegistry;
+import com.google.common.collect.Lists;
+import io.searchbox.client.JestClient;
+import io.searchbox.core.Search;
+import io.searchbox.core.SearchResult;
+import org.junit.Rule;
+import org.junit.Test;
+import org.opennms.core.test.elastic.ElasticSearchRule;
+import org.opennms.core.test.elastic.ElasticSearchServerConfig;
+import org.opennms.features.jest.client.RestClientFactory;
+import org.opennms.features.jest.client.SearchResultUtils;
+import org.opennms.features.jest.client.index.IndexStrategy;
+import org.opennms.features.jest.client.template.IndexSettings;
+import org.opennms.netmgt.dao.mock.MockNodeDao;
+import org.opennms.netmgt.dao.mock.MockSessionUtils;
+import org.opennms.netmgt.dao.mock.MockSnmpInterfaceDao;
+import org.opennms.netmgt.flows.api.Flow;
+import org.opennms.netmgt.flows.api.FlowRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static com.jayway.awaitility.Awaitility.with;
+import static java.util.concurrent.TimeUnit.*;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class BulkingIT {
+    private static Logger LOG = LoggerFactory.getLogger(BulkingIT.class);
+
+    @Rule
+    public ElasticSearchRule elasticSearchRule = new ElasticSearchRule(new ElasticSearchServerConfig()
+            .withStartDelay(0)
+            .withManualStartup()
+    );
+
+    private List<Flow> createMockedFlows(final int count) {
+        final List<Flow> flows = new ArrayList<>(count);
+        for (int i = 0; i < count; i++) {
+            final Flow flow = mock(Flow.class);
+            when(flow.getNetflowVersion()).thenReturn(Flow.NetflowVersion.V5);
+            when(flow.getIpProtocolVersion()).thenReturn(4);
+            when(flow.getSrcAddr()).thenReturn("192.168." + i / 256 + "." + i % 256);
+            when(flow.getDstAddr()).thenReturn("192.168." + i / 256 + "." + i % 256);
+            when(flow.getSrcAddrHostname()).thenReturn(Optional.empty());
+            when(flow.getDstAddrHostname()).thenReturn(Optional.empty());
+            when(flow.getNextHopHostname()).thenReturn(Optional.empty());
+            when(flow.getVlan()).thenReturn(null);
+            flows.add(flow);
+        }
+        return flows;
+    }
+
+    private FlowRepository createFlowRepository(final JestClient jestClient, final DocumentEnricher documentEnricher, int bulkSize, int bulkFlushMs) {
+        final ElasticFlowRepository elasticFlowRepository = new ElasticFlowRepository(new MetricRegistry(), jestClient,
+                IndexStrategy.MONTHLY, documentEnricher, new MockSessionUtils(), new MockNodeDao(), new MockSnmpInterfaceDao(),
+                new MockIdentity(), new MockTracerRegistry(), new MockDocumentForwarder(), new IndexSettings());
+        elasticFlowRepository.setBulkSize(bulkSize);
+        elasticFlowRepository.setBulkFlushMs(bulkFlushMs);
+        return new InitializingFlowRepository(elasticFlowRepository, jestClient);
+    }
+
+    /**
+     * Tests that small bulk will be persisted after the given timeout of 1000ms (bulkFlushMs).
+     */
+    @Test
+    public void testFlushTimeout() throws Exception {
+        elasticSearchRule.startServer();
+
+        final RestClientFactory restClientFactory = new RestClientFactory(elasticSearchRule.getUrl());
+
+        try (final JestClient jestClient = restClientFactory.createClient()) {
+            final MockDocumentEnricherFactory mockDocumentEnricherFactory = new MockDocumentEnricherFactory();
+            final DocumentEnricher documentEnricher = mockDocumentEnricherFactory.getEnricher();
+            final FlowRepository flowRepository = createFlowRepository(jestClient, documentEnricher, 1000, 1000);
+
+            final long[] persists = new long[2];
+
+            // send full bulk in order to estimate last persist
+            flowRepository.persist(Lists.newArrayList(createMockedFlows(1000)), FlowDocumentTest.getMockFlowSource());
+
+            with().pollInterval(25, MILLISECONDS).await().atMost(10, SECONDS).until(() -> {
+                final SearchResult searchResult = jestClient.execute(new Search.Builder("").addIndex("netflow-*").build());
+                LOG.info("Response: {} {} ", searchResult.isSucceeded() ? "Success" : "Failure", SearchResultUtils.getTotal(searchResult));
+                // record the initial persist
+                persists[0] = System.currentTimeMillis();
+                return SearchResultUtils.getTotal(searchResult) == 1000L;
+            });
+
+            // send small bulks
+            flowRepository.persist(Lists.newArrayList(createMockedFlows(30)), FlowDocumentTest.getMockFlowSource());
+            flowRepository.persist(Lists.newArrayList(createMockedFlows(30)), FlowDocumentTest.getMockFlowSource());
+            flowRepository.persist(Lists.newArrayList(createMockedFlows(30)), FlowDocumentTest.getMockFlowSource());
+
+            // these 90 flows should not be visible yet
+            with().pollInterval(25, MILLISECONDS).await().atMost(10, SECONDS).until(() -> {
+                final SearchResult searchResult = jestClient.execute(new Search.Builder("").addIndex("netflow-*").build());
+                LOG.info("Response: {} {} ", searchResult.isSucceeded() ? "Success" : "Failure", SearchResultUtils.getTotal(searchResult));
+                return SearchResultUtils.getTotal(searchResult) == 1000L;
+            });
+
+            // now wait for the flows to appear
+            with().pollInterval(25, MILLISECONDS).await().atMost(10, SECONDS).until(() -> {
+                final SearchResult searchResult = jestClient.execute(new Search.Builder("").addIndex("netflow-*").build());
+                LOG.info("Response: {} {} ", searchResult.isSucceeded() ? "Success" : "Failure", SearchResultUtils.getTotal(searchResult));
+                // record the final persist
+                persists[1] = System.currentTimeMillis();
+                return SearchResultUtils.getTotal(searchResult) == 1090L;
+            });
+
+            long timePassed = (persists[1] - persists[0]);
+            LOG.info("Time between persists is {}ms", timePassed);
+            assertTrue(timePassed >= 1000);
+        }
+
+        // stop ES
+        elasticSearchRule.stopServer();
+    }
+
+    /**
+     * Tests that large bulk will be persisted immediately.
+     */
+    @Test
+    public void testSingleLargeBulk() throws Exception {
+        elasticSearchRule.startServer();
+
+        final RestClientFactory restClientFactory = new RestClientFactory(elasticSearchRule.getUrl());
+
+        try (final JestClient jestClient = restClientFactory.createClient()) {
+            final MockDocumentEnricherFactory mockDocumentEnricherFactory = new MockDocumentEnricherFactory();
+            final DocumentEnricher documentEnricher = mockDocumentEnricherFactory.getEnricher();
+            final FlowRepository flowRepository = createFlowRepository(jestClient, documentEnricher, 1000, 300000);
+            flowRepository.persist(Lists.newArrayList(createMockedFlows(1000)), FlowDocumentTest.getMockFlowSource());
+
+            // these results should appear immediately since the bulk size of 1000 was reached
+            with().pollInterval(250, MILLISECONDS).await().atMost(10, SECONDS).until(() -> {
+                final SearchResult searchResult = jestClient.execute(new Search.Builder("").addIndex("netflow-*").build());
+                LOG.info("Response: {} {} ", searchResult.isSucceeded() ? "Success" : "Failure", SearchResultUtils.getTotal(searchResult));
+                return SearchResultUtils.getTotal(searchResult) == 1000L;
+            });
+        }
+
+        // stop ES
+        elasticSearchRule.stopServer();
+    }
+
+    /**
+     * Tests that small bulks sum up and will be persisted when bulkSize is reached.
+     */
+    @Test
+    public void testSmallBulks() throws Exception {
+        elasticSearchRule.startServer();
+
+        final RestClientFactory restClientFactory = new RestClientFactory(elasticSearchRule.getUrl());
+
+        try (final JestClient jestClient = restClientFactory.createClient()) {
+            final MockDocumentEnricherFactory mockDocumentEnricherFactory = new MockDocumentEnricherFactory();
+            final DocumentEnricher documentEnricher = mockDocumentEnricherFactory.getEnricher();
+            final FlowRepository flowRepository = createFlowRepository(jestClient, documentEnricher, 1000, 300000);
+
+            flowRepository.persist(Lists.newArrayList(createMockedFlows(1000)), FlowDocumentTest.getMockFlowSource());
+
+            // these results should appear immediately since the bulk size of 1000 was reached
+            with().pollInterval(250, MILLISECONDS).await().atMost(10, SECONDS).until(() -> {
+                final SearchResult searchResult = jestClient.execute(new Search.Builder("").addIndex("netflow-*").build());
+                LOG.info("Response: {} {} ", searchResult.isSucceeded() ? "Success" : "Failure", SearchResultUtils.getTotal(searchResult));
+                return SearchResultUtils.getTotal(searchResult) == 1000L;
+            });
+
+            flowRepository.persist(Lists.newArrayList(createMockedFlows(500)), FlowDocumentTest.getMockFlowSource());
+
+            // these results should not appear immediately since the bulk size is only 500
+            with().pollInterval(250, MILLISECONDS).await().atMost(10, SECONDS).until(() -> {
+                final SearchResult searchResult = jestClient.execute(new Search.Builder("").addIndex("netflow-*").build());
+                LOG.info("Response: {} {} ", searchResult.isSucceeded() ? "Success" : "Failure", SearchResultUtils.getTotal(searchResult));
+                return SearchResultUtils.getTotal(searchResult) == 1000L;
+            });
+
+            flowRepository.persist(Lists.newArrayList(createMockedFlows(400)), FlowDocumentTest.getMockFlowSource());
+
+            // these results should not appear immediately since the bulk size is only 900
+            with().pollInterval(250, MILLISECONDS).await().atMost(10, SECONDS).until(() -> {
+                final SearchResult searchResult = jestClient.execute(new Search.Builder("").addIndex("netflow-*").build());
+                LOG.info("Response: {} {} ", searchResult.isSucceeded() ? "Success" : "Failure", SearchResultUtils.getTotal(searchResult));
+                return SearchResultUtils.getTotal(searchResult) == 1000L;
+            });
+
+            flowRepository.persist(Lists.newArrayList(createMockedFlows(100)), FlowDocumentTest.getMockFlowSource());
+
+            // these results should now appear immediately since the bulk size of 1000 was reached
+            with().pollInterval(250, MILLISECONDS).await().atMost(10, SECONDS).until(() -> {
+                final SearchResult searchResult = jestClient.execute(new Search.Builder("").addIndex("netflow-*").build());
+                LOG.info("Response: {} {} ", searchResult.isSucceeded() ? "Success" : "Failure", SearchResultUtils.getTotal(searchResult));
+                return SearchResultUtils.getTotal(searchResult) == 2000L;
+            });
+        }
+
+        // stop ES
+        elasticSearchRule.stopServer();
+    }
+}

--- a/features/flows/itests/src/test/java/org/opennms/netmgt/flows/elastic/BulkingIT.java
+++ b/features/flows/itests/src/test/java/org/opennms/netmgt/flows/elastic/BulkingIT.java
@@ -106,7 +106,7 @@ public class BulkingIT {
         try (final JestClient jestClient = restClientFactory.createClient()) {
             final MockDocumentEnricherFactory mockDocumentEnricherFactory = new MockDocumentEnricherFactory();
             final DocumentEnricher documentEnricher = mockDocumentEnricherFactory.getEnricher();
-            final FlowRepository flowRepository = createFlowRepository(jestClient, documentEnricher, 1000, 1000);
+            final FlowRepository flowRepository = createFlowRepository(jestClient, documentEnricher, 1000, 5000);
 
             final long[] persists = new long[2];
 
@@ -127,7 +127,7 @@ public class BulkingIT {
             flowRepository.persist(Lists.newArrayList(createMockedFlows(30)), FlowDocumentTest.getMockFlowSource());
 
             // these 90 flows should not be visible yet
-            with().pollInterval(25, MILLISECONDS).await().atMost(10, SECONDS).until(() -> {
+            with().pollInterval(2, SECONDS).await().atMost(10, SECONDS).until(() -> {
                 final SearchResult searchResult = jestClient.execute(new Search.Builder("").addIndex("netflow-*").build());
                 LOG.info("Response: {} {} ", searchResult.isSucceeded() ? "Success" : "Failure", SearchResultUtils.getTotal(searchResult));
                 return SearchResultUtils.getTotal(searchResult) == 1000L;
@@ -144,7 +144,7 @@ public class BulkingIT {
 
             long timePassed = (persists[1] - persists[0]);
             LOG.info("Time between persists is {}ms", timePassed);
-            assertTrue(timePassed >= 1000);
+            assertTrue(timePassed >= 5000);
         }
 
         // stop ES

--- a/features/flows/itests/src/test/java/org/opennms/netmgt/flows/elastic/ElasticFlowRepositoryIT.java
+++ b/features/flows/itests/src/test/java/org/opennms/netmgt/flows/elastic/ElasticFlowRepositoryIT.java
@@ -78,7 +78,7 @@ public class ElasticFlowRepositoryIT {
             final ElasticFlowRepository elasticFlowRepository = new ElasticFlowRepository(new MetricRegistry(),
                     client, IndexStrategy.MONTHLY, documentEnricher,
                     new MockSessionUtils(), new MockNodeDao(), new MockSnmpInterfaceDao(),
-                    new MockIdentity(), new MockTracerRegistry(), new MockDocumentForwarder(), new IndexSettings());
+                    new MockIdentity(), new MockTracerRegistry(), new MockDocumentForwarder(), new IndexSettings(), 0, 0);
 
             // It does not matter what we persist here, as the response is fixed.
             // We only have to ensure that the list is not empty

--- a/features/flows/itests/src/test/java/org/opennms/netmgt/flows/elastic/FlowQueryIT.java
+++ b/features/flows/itests/src/test/java/org/opennms/netmgt/flows/elastic/FlowQueryIT.java
@@ -127,7 +127,7 @@ public class FlowQueryIT {
         smartQueryService.setAlwaysUseRawForQueries(true); // Always use RAW values for these tests
         flowRepository = new ElasticFlowRepository(metricRegistry, client, IndexStrategy.MONTHLY, documentEnricher,
                 new MockSessionUtils(), new MockNodeDao(), new MockSnmpInterfaceDao(),
-                new MockIdentity(), new MockTracerRegistry(), new MockDocumentForwarder(), settings);
+                new MockIdentity(), new MockTracerRegistry(), new MockDocumentForwarder(), settings, 0, 0);
 
         final RawIndexInitializer initializer = new RawIndexInitializer(client, settings);
 


### PR DESCRIPTION
The elastic flow repository now collects flow documents for batch
insertion across multiple logs. Each worker thread has its own
bulk storage.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-13478

