### PR TITLE
NMS-13486: Do not alter FIRST_SWITCHED or LAST_SWITCHED by option record if already set by data record

### DIFF
--- a/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/transport/Netflow9MessageBuilder.java
+++ b/features/telemetry/protocols/netflow/parser/src/main/java/org/opennms/netmgt/telemetry/protocols/netflow/parser/transport/Netflow9MessageBuilder.java
@@ -251,17 +251,19 @@ public class Netflow9MessageBuilder implements MessageBuilder {
 
         if (firstSwitched != null) {
             builder.setFirstSwitched(setLongValue(firstSwitched + bootTime));
+        } else {
+            // Some Cisco platforms also support absolute timestamps in NetFlow v9 (like defined in IPFIX). See NMS-13006
+            if (flowStartMilliseconds != null) {
+                builder.setFirstSwitched(setLongValue(flowStartMilliseconds));
+            }
         }
         if(lastSwitched != null) {
             builder.setLastSwitched(setLongValue(lastSwitched + bootTime));
-        }
-
-        // Some Cisco platforms also support absolute timestamps in NetFlow v9 (like defined in IPFIX). See NMS-13006
-        if (flowStartMilliseconds != null) {
-            builder.setFirstSwitched(setLongValue(flowStartMilliseconds));
-        }
-        if (flowEndMilliseconds != null) {
-            builder.setLastSwitched(setLongValue(flowEndMilliseconds));
+        } else {
+            // Some Cisco platforms also support absolute timestamps in NetFlow v9 (like defined in IPFIX). See NMS-13006
+            if (flowEndMilliseconds != null) {
+                builder.setLastSwitched(setLongValue(flowEndMilliseconds));
+            }
         }
 
         // Set Destination address and host name.


### PR DESCRIPTION
* JIRA: https://issues.opennms.org/browse/NMS-13486

The PCAP file showed a pretty uncommon Option Template with a observation id scope (system scope) and defined values for absolute timestamps (information element 152 and 153) and the observation domain name. As far as I understand this means something like this: the system identified by the observation domain id X is named Y during the period of time between W and Z. But in this case I would expect the timestamps to be part of the scope. But something like this isn’t really defined in the RFC, since scopes are matched value by value and no intervals are checked at all. This also means that each an every flow that matches the system id will be set the two timestamps given in the option template. We now assure, that these values set by the data record are not overwritten by option record data.

This will lead to wrong flow data with incorrect timestamps and intervals that are longer than the defined FLOW_ACTIVE_TIMEOUT or FLOW_INACTIVE_TIMEOUT. In the case of the provided PCAP the duration was approximately 50 minutes to 1 hour. Maybe this will cause problems in the overall processing of flows.

I can not tell whether this will solve all the observed and reported problems but this will at least correct false data that could probably introduce problems in our processing pipeline.
