### PR TITLE
NMS-13479: Reload classification decision tree asynchronously in DefaultClassificationService

### DIFF
--- a/features/flows/classification/engine/impl/src/main/java/org/opennms/netmgt/flows/classification/internal/AsyncReloadingClassificationEngine.java
+++ b/features/flows/classification/engine/impl/src/main/java/org/opennms/netmgt/flows/classification/internal/AsyncReloadingClassificationEngine.java
@@ -1,0 +1,168 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2018-2018 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2018 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.flows.classification.internal;
+
+import java.util.List;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import org.opennms.netmgt.flows.classification.ClassificationEngine;
+import org.opennms.netmgt.flows.classification.ClassificationRequest;
+import org.opennms.netmgt.flows.classification.persistence.api.Rule;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A classification engine that does reloads asynchronously.
+ * <p>
+ * Reloads are triggered oftentimes while editing classification rules. In addition, reloads may take a couple of seconds
+ * depending on the enabled rules. In order to keep the front-end responsive, reloads are done asynchronously.
+ * Usages of the classification engine are blocked until ongoing reloads did finish. If a reload fails then
+ * future usages of this classification engine also fail until a following reload succeeds.
+ */
+public class AsyncReloadingClassificationEngine implements ClassificationEngine {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AsyncReloadingClassificationEngine.class);
+
+    private enum State {
+        READY, RELOADING, NEED_ANOTHER_RELOAD, FAILED
+    }
+
+    private final ClassificationEngine delegate;
+
+    // uses at most one additional thread; if the thread is not used for 60 seconds then it is terminated
+    // -> uses no additional resources while being idle
+    private final ExecutorService executorService = new ThreadPoolExecutor(0, 1,
+            60L, TimeUnit.SECONDS,
+            new ArrayBlockingQueue<>(1),
+            runnable -> new Thread(runnable, "AsyncReloadingClassificationEngine")
+    );
+
+    private State state = State.READY;
+    private Exception reloadException;
+
+    public AsyncReloadingClassificationEngine(ClassificationEngine delegate) {
+        this.delegate = delegate;
+        // trigger reload
+        // -> blocks classification requests until classification engine is ready
+        reload();
+    }
+
+    private void setState(State newState) {
+        state = newState;
+        notifyAll();
+    }
+
+    private void waitUntilReadyOrFailed() {
+        while (true) {
+            switch (state) {
+                case READY:
+                    return;
+                case FAILED:
+                    throw new RuntimeException("classification engine can not be used because last reload failed", reloadException);
+            }
+            try {
+                wait();
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    private void doReload() {
+        // this method must not modify the state because it not synchronized
+        try {
+            LOG.debug("reload classification engine");
+            delegate.reload();
+            if (onReloadSucceeded()) {
+                LOG.debug("another classification engine reload is required");
+                doReload();
+            } else {
+                LOG.debug("classification engine reloaded");
+            }
+        } catch (Exception e) {
+            LOG.error("reload of classification engine failed", e);
+            if (onReloadFailed(e)) {
+                LOG.debug("another classification engine reload is required");
+                doReload();
+            } else {
+                LOG.debug("classification engine reloaded");
+            }
+        }
+    }
+
+    private synchronized boolean onReloadSucceeded() {
+        if (state == State.NEED_ANOTHER_RELOAD) {
+            setState(State.RELOADING);
+            return true;
+        } else {
+            setState(State.READY);
+            return false;
+        }
+    }
+
+    private synchronized boolean onReloadFailed(Exception e) {
+        if (state == State.NEED_ANOTHER_RELOAD) {
+            setState(State.RELOADING);
+            return true;
+        } else {
+            reloadException = e;
+            setState(State.FAILED);
+            return false;
+        }
+    }
+
+    @Override
+    public synchronized String classify(ClassificationRequest classificationRequest) {
+        waitUntilReadyOrFailed();
+        return delegate.classify(classificationRequest);
+    }
+
+    @Override
+    public synchronized List<Rule> getInvalidRules() {
+        waitUntilReadyOrFailed();
+        return delegate.getInvalidRules();
+    }
+
+    @Override
+    public synchronized void reload() {
+        switch (state) {
+            case READY:
+            case FAILED:
+                setState(State.RELOADING);
+                executorService.submit(this::doReload);
+                break;
+            case RELOADING:
+                setState(State.NEED_ANOTHER_RELOAD);
+                break;
+        }
+    }
+}

--- a/features/flows/classification/engine/impl/src/main/java/org/opennms/netmgt/flows/classification/internal/DefaultClassificationEngine.java
+++ b/features/flows/classification/engine/impl/src/main/java/org/opennms/netmgt/flows/classification/internal/DefaultClassificationEngine.java
@@ -110,9 +110,9 @@ public class DefaultClassificationEngine implements ClassificationEngine {
                     .append("minComp  : " + tree.info.minComp).append('\n')
                     .append("maxComp  : " + tree.info.maxComp).append('\n')
                     .append("avgComp  : " + (double) tree.info.sumComp / tree.info.leaves).append('\n')
-                    .append("minRuleSetSize :" + tree.info.minRuleSetSize).append('\n')
-                    .append("maxRuleSetSize :" + tree.info.maxRuleSetSize).append('\n')
-                    .append("avgRuleSetSize :" + (double) tree.info.sumRuleSetSize / tree.info.leaves).append('\n');
+                    .append("minLeafSize : " + tree.info.minLeafSize).append('\n')
+                    .append("maxLeafSize : " + tree.info.maxLeafSize).append('\n')
+                    .append("avgLeafSize : " + (double) tree.info.sumLeafSize / tree.info.leaves).append('\n');
             LOG.info(sb.toString());
         }
 

--- a/features/flows/classification/engine/impl/src/main/java/org/opennms/netmgt/flows/classification/internal/DefaultClassificationService.java
+++ b/features/flows/classification/engine/impl/src/main/java/org/opennms/netmgt/flows/classification/internal/DefaultClassificationService.java
@@ -92,6 +92,9 @@ public class DefaultClassificationService implements ClassificationService {
         this.ruleValidator = new RuleValidator(filterService);
         this.groupValidator = new GroupValidator(classificationRuleDao);
         this.csvService = new CsvServiceImpl(ruleValidator);
+        // trigger reload
+        // -> blocks classification requests until classification engine is ready
+        this.classificationEngine.reload();
     }
 
     @Override

--- a/features/flows/classification/engine/impl/src/main/java/org/opennms/netmgt/flows/classification/internal/DefaultClassificationService.java
+++ b/features/flows/classification/engine/impl/src/main/java/org/opennms/netmgt/flows/classification/internal/DefaultClassificationService.java
@@ -428,12 +428,16 @@ public class DefaultClassificationService implements ClassificationService {
                 if (reloadSucceeded()) {
                     LOG.debug("another classification engine reload is required");
                     doReload();
+                } else {
+                    LOG.debug("classification engine reloaded");
                 }
             } catch (Exception e) {
                 LOG.error("reload of classification engine failed", e);
                 if (reloadFailed(e)) {
                     LOG.debug("another classification engine reload is required");
                     doReload();
+                } else {
+                    LOG.debug("classification engine reloaded");
                 }
             }
         }

--- a/features/flows/classification/engine/impl/src/main/java/org/opennms/netmgt/flows/classification/internal/decision/Tree.java
+++ b/features/flows/classification/engine/impl/src/main/java/org/opennms/netmgt/flows/classification/internal/decision/Tree.java
@@ -72,7 +72,7 @@ public abstract class Tree {
     private static Tree of(List<PreprocessedRule> rules, Bounds bounds, int depth, FilterService filterService) {
         final var ruleSetSize = rules.size();
         if (ruleSetSize <= 1) {
-            LOG.debug("Leaf - depth: " + depth + "; rules: " + ruleSetSize);
+            LOG.trace("Leaf - depth: " + depth + "; rules: " + ruleSetSize);
             return leaf(rules, filterService, bounds);
         }
 
@@ -90,7 +90,7 @@ public abstract class Tree {
                 .orElse(null);
 
         if (entry != null) {
-            LOG.debug("Node - depth: " + depth + "; rules: " + ruleSetSize + "; threshold: " + entry.getKey() + "; maximum child size: " + maximumSize(entry) +
+            LOG.trace("Node - depth: " + depth + "; rules: " + ruleSetSize + "; threshold: " + entry.getKey() + "; maximum child size: " + maximumSize(entry) +
                                "; lt: " + entry.getValue().lt.size() +
                                "; eq: " + entry.getValue().eq.size() + "; gt: " + entry.getValue().gt.size() + "; na: " + entry.getValue().na.size());
             var lt = of(entry.getValue().lt, entry.getKey().lt(bounds), depth + 1, filterService);
@@ -100,7 +100,7 @@ public abstract class Tree {
 
             return node(entry.getKey(), lt, eq, gt, na);
         } else {
-            LOG.debug("Leaf - depth: " + depth + "; rules: " + ruleSetSize);
+            LOG.trace("Leaf - depth: " + depth + "; rules: " + ruleSetSize);
             return leaf(rules, filterService, bounds);
         }
 

--- a/features/flows/classification/engine/impl/src/main/java/org/opennms/netmgt/flows/classification/internal/decision/Tree.java
+++ b/features/flows/classification/engine/impl/src/main/java/org/opennms/netmgt/flows/classification/internal/decision/Tree.java
@@ -42,6 +42,8 @@ import org.opennms.netmgt.flows.classification.FilterService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.annotations.VisibleForTesting;
+
 /**
  * Represents a decision tree for classifying flows.
  * <p>
@@ -146,19 +148,19 @@ public abstract class Tree {
         }
 
         public final int minDepth, maxDepth, sumDepth;
-        public final long minRuleSetSize, maxRuleSetSize, sumRuleSetSize;
+        public final long minLeafSize, maxLeafSize, sumLeafSize;
         public final int nodes;
         public final int leaves;
         public final int choices;
         public final int minComp, maxComp, sumComp;
 
-        public Info(int minDepth, int maxDepth, int sumDepth, long minRuleSetSize, long maxRuleSetSize, long sumRuleSetSize, int nodes, int leaves, int choices, int minComp, int maxComp, int sumComp) {
+        public Info(int minDepth, int maxDepth, int sumDepth, long minLeafSize, long maxLeafSize, long sumLeafSize, int nodes, int leaves, int choices, int minComp, int maxComp, int sumComp) {
             this.minDepth = minDepth;
             this.maxDepth = maxDepth;
             this.sumDepth = sumDepth;
-            this.minRuleSetSize = minRuleSetSize;
-            this.maxRuleSetSize = maxRuleSetSize;
-            this.sumRuleSetSize = sumRuleSetSize;
+            this.minLeafSize = minLeafSize;
+            this.maxLeafSize = maxLeafSize;
+            this.sumLeafSize = sumLeafSize;
             this.nodes = nodes;
             this.leaves = leaves;
             this.choices = choices;
@@ -167,8 +169,8 @@ public abstract class Tree {
             this.sumComp = sumComp;
         }
 
-        public Info(long ruleSetSize) {
-            this(0, 0, 0, ruleSetSize, ruleSetSize, ruleSetSize, 0, 1, 0, 0, 0, 0);
+        public Info(long leafSize) {
+            this(0, 0, 0, leafSize, leafSize, leafSize, 0, 1, 0, 0, 0, 0);
         }
 
         @Override
@@ -180,9 +182,9 @@ public abstract class Tree {
                    ", comp(min/max/avg)=" + minComp +
                    "/" + maxComp +
                    "/" + String.format("%.2f", (double)sumComp / leaves) +
-                   ", ruleSetSize(min/max/avg)=" + minRuleSetSize +
-                   "/" + maxRuleSetSize +
-                   "/" + String.format("%.2f", (double)sumRuleSetSize / leaves) +
+                   ", ruleSetSize(min/max/avg)=" + minLeafSize +
+                   "/" + maxLeafSize +
+                   "/" + String.format("%.2f", (double) sumLeafSize / leaves) +
                    ", nodes=" + nodes +
                    ", leaves=" + leaves +
                    ", choices=" + choices +
@@ -202,9 +204,9 @@ public abstract class Tree {
                     1 + Math.min(Math.min(lt.info.minDepth, eq.info.minDepth), gt.info.minDepth),
                     1 + Math.max(Math.max(lt.info.maxDepth, eq.info.maxDepth), gt.info.maxDepth),
                     leaves + lt.info.sumDepth + eq.info.sumDepth + gt.info.sumDepth,
-                    Math.min(Math.min(lt.info.minRuleSetSize, eq.info.minRuleSetSize), gt.info.minRuleSetSize),
-                    Math.max(Math.max(lt.info.maxRuleSetSize, eq.info.maxRuleSetSize), gt.info.maxRuleSetSize),
-                    lt.info.sumRuleSetSize + eq.info.sumRuleSetSize + gt.info.sumRuleSetSize,
+                    Math.min(Math.min(lt.info.minLeafSize, eq.info.minLeafSize), gt.info.minLeafSize),
+                    Math.max(Math.max(lt.info.maxLeafSize, eq.info.maxLeafSize), gt.info.maxLeafSize),
+                    lt.info.sumLeafSize + eq.info.sumLeafSize + gt.info.sumLeafSize,
                     1 + lt.info.nodes + eq.info.nodes + gt.info.nodes,
                     leaves,
                     lt.info.choices + eq.info.choices + gt.info.choices,
@@ -226,9 +228,9 @@ public abstract class Tree {
                     1 + Math.min(Math.min(Math.min(lt.info.minDepth, eq.info.minDepth), gt.info.minDepth), na.info.minDepth),
                     1 + Math.max(Math.max(Math.max(lt.info.maxDepth, eq.info.maxDepth), gt.info.maxDepth), na.info.maxDepth),
                     leaves + lt.info.sumDepth + eq.info.sumDepth + gt.info.sumDepth + na.info.sumDepth,
-                    Math.min(Math.min(Math.min(lt.info.minRuleSetSize, eq.info.minRuleSetSize), gt.info.minRuleSetSize), na.info.minRuleSetSize),
-                    Math.max(Math.max(Math.max(lt.info.maxRuleSetSize, eq.info.maxRuleSetSize), gt.info.maxRuleSetSize), na.info.maxRuleSetSize),
-                    lt.info.sumRuleSetSize + eq.info.sumRuleSetSize + gt.info.sumRuleSetSize + na.info.sumRuleSetSize,
+                    Math.min(Math.min(Math.min(lt.info.minLeafSize, eq.info.minLeafSize), gt.info.minLeafSize), na.info.minLeafSize),
+                    Math.max(Math.max(Math.max(lt.info.maxLeafSize, eq.info.maxLeafSize), gt.info.maxLeafSize), na.info.maxLeafSize),
+                    lt.info.sumLeafSize + eq.info.sumLeafSize + gt.info.sumLeafSize + na.info.sumLeafSize,
                     1 + lt.info.nodes + eq.info.nodes + gt.info.nodes + na.info.nodes,
                     leaves,
                     1 + lt.info.choices + eq.info.choices + gt.info.choices + na.info.choices,
@@ -452,11 +454,11 @@ public abstract class Tree {
         }
 
         public final static class WithClassifiers extends Leaf {
-            public final List<Classifier> classifiers;
+            public final Classifiers classifiers;
 
             public WithClassifiers(List<Classifier> classifiers) {
                 super(Info.forLeaf(classifiers.size()));
-                this.classifiers = classifiers;
+                this.classifiers = new Classifiers(true, classifiers);
             }
 
             public WithClassifiers(Classifier classifier) {
@@ -465,7 +467,12 @@ public abstract class Tree {
 
             @Override
             public Classifiers classifiers(ClassificationRequest request) {
-                return new Classifiers(true, classifiers);
+                return classifiers;
+            }
+
+            @VisibleForTesting
+            public Collection<Classifier> classifiers() {
+                return classifiers.classifiers;
             }
 
             @Override

--- a/features/flows/classification/engine/impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/features/flows/classification/engine/impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -56,6 +56,9 @@
         <argument ref="classificationMetricRegistry"/>
         <argument ref="defaultClassificationEngine" />
     </bean>
+    <bean id="asyncReloadingClassificationEngine" class="org.opennms.netmgt.flows.classification.internal.AsyncReloadingClassificationEngine">
+        <argument ref="timingClassificationEngine" />
+    </bean>
     <bean id="classificationEngineInitializer" class="org.opennms.netmgt.flows.classification.internal.ClassificationEngineInitializer">
         <argument ref="timingClassificationEngine"/>
         <argument ref="sessionUtils" />
@@ -81,7 +84,7 @@
         <bean class="org.opennms.netmgt.flows.classification.internal.DefaultClassificationService">
             <argument ref="classificationRuleDao"/>
             <argument ref="classificationGroupDao"/>
-            <argument ref="timingClassificationEngine"/>
+            <argument ref="asyncReloadingClassificationEngine"/>
             <argument ref="cachingFilterService" />
             <argument ref="sessionUtils"/>
         </bean>

--- a/features/flows/classification/engine/impl/src/test/java/org/opennms/netmgt/flows/classification/internal/ExampleRulesTest.java
+++ b/features/flows/classification/engine/impl/src/test/java/org/opennms/netmgt/flows/classification/internal/ExampleRulesTest.java
@@ -100,10 +100,10 @@ public class ExampleRulesTest {
 
             @Override
             public Void visit(Tree.Leaf.WithClassifiers leaf) {
-                if (leaf.classifiers.stream().anyMatch(c -> c.result.name.equals("Skype_Lync_Application_Sharing"))) {
+                if (leaf.classifiers().stream().anyMatch(c -> c.result.name.equals("Skype_Lync_Application_Sharing"))) {
 //                if (leaf.classifiers.size() >= 3) {
                     System.out.println(steps.stream().map(s -> "(" + s + ")").collect(Collectors.joining(", ")));
-                    leaf.classifiers.forEach(c -> System.out.println("  " + c));
+                    leaf.classifiers().forEach(c -> System.out.println("  " + c));
                 }
                 return null;
             }

--- a/smoke-test/src/test/java/org/opennms/smoketest/ClassificationRulePageIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/ClassificationRulePageIT.java
@@ -789,7 +789,7 @@ public class ClassificationRulePageIT extends OpenNMSSeleniumIT {
             return new RuleModal()
                     .open(() -> {
                         // Click add rule button
-                        findElementById("action.addRule").click();
+                        clickElement(By.id("action.addRule"));
                         new WebDriverWait(driver, 5).until(pageContainsText("Create Classification Rule"));
                     });
         }

--- a/smoke-test/src/test/java/org/opennms/smoketest/ClassificationRulePageIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/ClassificationRulePageIT.java
@@ -481,15 +481,19 @@ public class ClassificationRulePageIT extends OpenNMSSeleniumIT {
             // resulting in test failures. To avoid this, a bunch of seconds is waited before reading the value.
             // See HZN-1289.
 
+            String textAfterClassification = "";
+
+            // wait until the classification response value change to a non-empty string that is different from the value
+            // before classification was started
             for (int i = 0; i < 10; i++) {
                 sleep(DEFAULT_WAIT_TIME);
-                var text = execute(() -> findElementById("classification-response")).getText();
-                if (!Objects.equals(textBeforeClassification, text)) {
-                    return text;
+                textAfterClassification = execute(() -> findElementById("classification-response")).getText();
+                if (!"".equals(textAfterClassification) && !Objects.equals(textBeforeClassification, textAfterClassification)) {
+                    break;
                 }
             }
 
-            return textBeforeClassification;
+            return textAfterClassification;
         }
 
         private void setInput(String id, String text, boolean withEnter) {

--- a/smoke-test/src/test/java/org/opennms/smoketest/ClassificationRulePageIT.java
+++ b/smoke-test/src/test/java/org/opennms/smoketest/ClassificationRulePageIT.java
@@ -485,7 +485,7 @@ public class ClassificationRulePageIT extends OpenNMSSeleniumIT {
 
             // wait until the classification response value change to a non-empty string that is different from the value
             // before classification was started
-            for (int i = 0; i < 10; i++) {
+            for (int i = 0; i < 30; i++) {
                 sleep(DEFAULT_WAIT_TIME);
                 textAfterClassification = execute(() -> findElementById("classification-response")).getText();
                 if (!"".equals(textAfterClassification) && !Objects.equals(textBeforeClassification, textAfterClassification)) {


### PR DESCRIPTION
Issue: https://issues.opennms.org/browse/NMS-13479

While editing classification rules, reloads of the classification engine are triggered repeatedly. A reload may take a couple of seconds depending on rule set sizes. In order to avoid sluggish behavior, reloading is done asynchronously. Only when the classification engine is used calls are blocked until any ongoing reloads did finish.

These changes fix the tests in `ClassificationRulePageIT`.