### PR TITLE
NMS-13568: backport docker content trust minion builds to Foundation 2021

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,6 +63,9 @@ aliases:
         "release-"*)
            MINION_IMAGE_VERSION="release-candidate"
           ;;
+        "foundation-"20[1-2][0-9])
+           MINION_IMAGE_VERSION="${CIRCLE_BRANCH}"
+          ;;
         "develop")
            MINION_IMAGE_VERSION="bleeding"
           ;;

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,6 +52,42 @@ defaults: &defaults
       type: string
       default: release-28.x
 
+aliases:
+  - &setup_dct_env
+    name: Setup DCT environment
+    command: |
+      case "${CIRCLE_BRANCH}" in
+        "master-"*)
+           MINION_IMAGE_VERSION="$(~/project/.circleci/scripts/pom2version.sh ~/project/pom.xml)"
+          ;;
+        "release-"*)
+           MINION_IMAGE_VERSION="release-candidate"
+          ;;
+        "develop")
+           MINION_IMAGE_VERSION="bleeding"
+          ;;
+        *)
+          MINION_IMAGE_VERSION=b<< pipeline.number >>
+          ;;
+      esac
+      echo "export DOCKER_CONTENT_TRUST=1" >> $BASH_ENV
+      echo "export DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE=\"$DCT_DELEGATE_KEY_PASSPHRASE\"" >> $BASH_ENV
+      echo "export MINION_IMAGE=docker.io/opennms/minion" >> $BASH_ENV
+      echo "export MINION_IMAGE_VERSION=\"$MINION_IMAGE_VERSION\"" >> $BASH_ENV
+  - &setup_dct_key
+    name: Setup DCT key
+    command: |
+      KEY_FOLDER=~/.docker/trust/private
+      mkdir -p $KEY_FOLDER
+      # the key that is used to sign single-arch images
+      echo "$DCT_DELEGATE_KEY" | base64 -d > $KEY_FOLDER/$DCT_DELEGATE_KEY_NAME.key
+      # the key that is used by Notary to sign the multi-arch minion image
+      echo "$DCT_REPO_MINION_KEY" | base64 -d > $KEY_FOLDER/$DCT_REPO_MINION_KEY_NAME.key
+      chmod 600 $KEY_FOLDER/*
+      # setup_dct_env must have been run first because it provide DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE
+      # that is required for loading the
+      docker trust key load $KEY_FOLDER/$DCT_DELEGATE_KEY_NAME.key
+
 docker_container_config: &docker_container_config
   executor: docker-executor
 
@@ -321,8 +357,18 @@ commands:
     steps:
       - update-maven-cache
       - run:
+          name: Monitor JVM processes
+          background: true
+          command: |
+            .circleci/scripts/jvmprocmon-start.sh
+      - run:
+          name: Monitor memory usage
+          background: true
+          command: |
+            free -m -c 500 -s 30
+      - run:
           name: Integration Tests
-          no_output_timeout: 1.0h
+          no_output_timeout: 30m
           command: |
             export CCI_CODE_COVERAGE=<< parameters.run-code-coverage >>
             export CCI_RERUN_FAILTEST=<< parameters.rerun-failtest-count >>
@@ -334,8 +380,8 @@ commands:
           when: always
           command: |
             mkdir -p ~/test-results/junit
-            find . -type f -regex ".*/target/surefire-reports-[0-9]+/.*xml" -exec cp {} ~/test-results/junit/ \;
-            find . -type f -regex ".*/target/failsafe-reports-[0-9]+/.*xml" -exec cp {} ~/test-results/junit/ \;
+            find . -type f -regex ".*/target/.*-reports-[0-9]+/.*xml" -exec cp {} ~/test-results/junit/ \;
+            find . -type f -regex ".*/target/.*-reports-[0-9]+/.*dump.*" -exec cp {} ~/test-results/junit/ \;
       - run:
           name: Gather tests
           when: always
@@ -356,12 +402,26 @@ commands:
                 root: ~/
                 paths:
                   - code-coverage
+      - run:
+          name: Gather system logs
+          when: always
+          command: |
+            mkdir -p ~/build-results/system-logs
+            (dmesg || :) > ~/build-results/system-logs/dmesg 2>&1
+            (ps auxf || :) > ~/build-results/system-logs/ps 2>&1
+            (free -m || :) > ~/build-results/system-logs/free 2>&1
+            (docker stats --no-stream || :) > ~/build-results/system-logs/docker_stats 2>&1
+            cp -R /tmp/jvmprocmon ~/build-results/system-logs/ || :
       - store_test_results:
           path: ~/test-results
       - store_artifacts:
           when: always
           path: ~/test-results
           destination: test-results
+      - store_artifacts:
+          when: always
+          path: ~/build-results
+          destination: build-results
       - store_artifacts:
           when: always
           path: ~/generated-tests
@@ -514,6 +574,30 @@ workflows:
       - tarball-assembly:
           requires:
             - build
+      - minion-image-single-arch:
+          matrix:
+            parameters:
+              architecture: [linux/amd64,linux/arm64,linux/arm/v7]
+          context: "docker-content-trust"
+          requires:
+            - tarball-assembly
+            - smoke-test-minion
+          filters:
+            branches:
+              only:
+                - develop
+                - /^master-.*/
+                - /^release-.*/
+      - minion-image-multi-arch:
+          context: "docker-content-trust"
+          requires:
+            - minion-image-single-arch
+          filters:
+            branches:
+              only:
+                - develop
+                - /^master-.*/
+                - /^release-.*/
       - horizon-rpm-build:
           requires:
             - build
@@ -779,11 +863,12 @@ jobs:
     machine:
       image: ubuntu-2004:202010-01
       docker_layer_caching: true
+    resource_class: large
     environment:
       DOCKER_CLI_EXPERIMENTAL: enabled
     parameters:
       number-vcpu:
-        default: 2
+        default: 4
         type: integer
       vaadin-javamaxmem:
         default: 1g
@@ -806,6 +891,7 @@ jobs:
           command: |
             export MAVEN_OPTS="-Xmx4g -Xms4g"
             # general assembly
+            date
             ./compile.pl -DskipTests=true -Dbuild.skip.tarball=false \
               -DupdatePolicy=never \
               -Daether.connector.resumeDownloads=false \
@@ -818,6 +904,7 @@ jobs:
               -Dopennms.home=/opt/opennms \
               install --batch-mode
             # javadoc
+            date
             ./compile.pl -DskipTests=true -Dbuild.skip.tarball=false \
               -DupdatePolicy=never \
               -Daether.connector.resumeDownloads=false \
@@ -829,6 +916,7 @@ jobs:
               -Prun-expensive-tasks \
               -Dopennms.home=/opt/opennms \
               javadoc:aggregate --batch-mode
+            date
       - run:
           name: Build Minion OCI
           command: |
@@ -841,38 +929,6 @@ jobs:
                  BUILD_NUMBER="${CIRCLE_BUILD_NUM}" \
                  BUILD_URL="${CIRCLE_BUILD_URL}" \
                  BUILD_BRANCH="${CIRCLE_BRANCH}"
-
-            # Build for multiple architectures only in release branches and push images with manifest to a registry
-            # For develop we set a floating tag "bleeding" instead the x.y.z-SNAPSHOT version number
-            case "${CIRCLE_BRANCH}" in
-              "master-"*)
-                make DOCKER_ARCH="linux/amd64,linux/arm/v7,linux/arm64" \
-                     DOCKER_FLAGS=--push \
-                     VERSION="$(../pom2version.py ../../pom.xml)" \
-                     BUILD_NUMBER="${CIRCLE_BUILD_NUM}" \
-                     BUILD_URL="${CIRCLE_BUILD_URL}" \
-                     BUILD_BRANCH="${CIRCLE_BRANCH}"
-                ;;
-              "release-"*)
-                make DOCKER_ARCH="linux/amd64,linux/arm/v7,linux/arm64" \
-                     DOCKER_FLAGS=--push \
-                     VERSION="release-candidate" \
-                     BUILD_NUMBER="${CIRCLE_BUILD_NUM}" \
-                     BUILD_URL="${CIRCLE_BUILD_URL}" \
-                     BUILD_BRANCH="${CIRCLE_BRANCH}"
-                ;;
-              "develop")
-                make DOCKER_ARCH="linux/amd64,linux/arm/v7,linux/arm64" \
-                     DOCKER_FLAGS=--push \
-                     VERSION="bleeding" \
-                     BUILD_NUMBER="${CIRCLE_BUILD_NUM}" \
-                     BUILD_URL="${CIRCLE_BUILD_URL}" \
-                     BUILD_BRANCH="${CIRCLE_BRANCH}"
-                ;;
-              *)
-                echo "No branch to push to registry."
-                ;;
-            esac
       - run:
           name: Collect Artifacts
           command: |
@@ -908,6 +964,94 @@ jobs:
       - cache-oci:
           key: minion
           path: opennms-container/minion/images/
+      - persist_to_workspace:
+          root: ~/
+          paths:
+            - project/opennms-assemblies/minion/target/org.opennms.assemblies.minion-*-minion.tar.gz
+
+  minion-image-single-arch:
+    parameters:
+      architecture:
+        type: string
+    machine:
+      image: ubuntu-2004:202010-01
+    environment:
+      DOCKER_CLI_EXPERIMENTAL: enabled
+    steps:
+      - attach_workspace:
+          at: ~/
+      - run:
+          name: multiarch/qemu-user-static
+          command: docker run --privileged multiarch/qemu-user-static --reset -p yes
+      - run:
+          name: Install Docker buildx
+          command: |
+            sudo wget https://github.com/docker/buildx/releases/download/v0.5.1/buildx-v0.5.1.linux-amd64 -O /usr/local/bin/docker-buildx
+            sudo chmod a+x /usr/local/bin/docker-buildx
+            sudo systemctl restart docker
+      - dockerhub-login
+      - run: *setup_dct_env
+      - run: *setup_dct_key
+      - run:
+          name: Single-arch build & push
+          command: |
+            cd opennms-container/minion
+            ARCH="$(printf "<< parameters.architecture >>" | tr / -)"
+            TAG="${MINION_IMAGE_VERSION}-${ARCH}"
+            make DOCKER_ARCH="<< parameters.architecture >>" \
+                 DOCKER_FLAGS=--load \
+                 VERSION="${TAG}" \
+                 BUILD_NUMBER="${CIRCLE_BUILD_NUM}" \
+                 BUILD_URL="${CIRCLE_BUILD_URL}" \
+                 BUILD_BRANCH="${CIRCLE_BRANCH}"
+            docker push ${MINION_IMAGE}:${TAG}
+
+  minion-image-multi-arch:
+    machine:
+      image: ubuntu-2004:202010-01
+    environment:
+      DOCKER_CLI_EXPERIMENTAL: enabled
+    steps:
+      - attach_workspace:
+          at: ~/
+      - dockerhub-login
+      - run: *setup_dct_env
+      - run: *setup_dct_key
+      - run:
+          name: Install notary
+          command: |
+            sudo wget https://github.com/theupdateframework/notary/releases/download/v0.6.1/notary-Linux-amd64 -O /usr/local/bin/notary
+            sudo chmod a+x /usr/local/bin/notary
+      - run:
+          name: Create & push multi-arch manifest
+          command: |
+            IMAGE_REF="${MINION_IMAGE}:${MINION_IMAGE_VERSION}"
+            docker manifest create ${IMAGE_REF} \
+              ${IMAGE_REF}-linux-amd64 \
+              ${IMAGE_REF}-linux-arm64 \
+              ${IMAGE_REF}-linux-arm-v7 \
+              --amend
+            SHA_256="$(docker manifest push "${IMAGE_REF}" --purge | cut -d ':' -f 2)"
+            echo "Manifest SHA-256: ${SHA_256}"
+            echo "Image-Ref: ${IMAGE_REF}"
+            MANIFEST_FROM_REG="$(docker manifest inspect "${IMAGE_REF}" -v)";
+            BYTES_SIZE="$(printf "${MANIFEST_FROM_REG}" | jq -r '.[].Descriptor.size' | uniq)";
+            echo "Manifest-inspect BYTES: ${BYTES_SIZE}";
+            echo "Manifest contents:\n";
+            printf "${MANIFEST_FROM_REG}" | jq -r '.[].Descriptor | "Architecture: " + .platform.architecture + .platform.variant + ", digest: " + .digest';
+            export NOTARY_AUTH="$(printf "${DOCKERHUB_LOGIN}:${DOCKERHUB_PASS}" | base64 -w0)"
+            echo "Sign ${SHA_256} with the notary"
+            # when the multi-arch image is signed by the delegate key then docker pull reports "No valid trust data..."
+            # -> the following lines can not be used:
+            #
+            # export NOTARY_DELEGATION_PASSPHRASE="${DCT_DELEGATE_KEY_PASSPHRASE}"
+            # notary -d ~/.docker/trust/ -s https://notary.docker.io addhash "${MINION_IMAGE}" "${MINION_IMAGE_VERSION}" 946 --sha256 "${SHA_256}" --roles targets/opennms-circle-delegate --publish --verbose
+            #
+            # -> use the targets key of the minion repository to sign the multi-arch image instead
+            export NOTARY_TARGETS_PASSPHRASE="${DCT_REPO_MINION_KEY_PASSPHRASE}"
+            notary -d ~/.docker/trust/ -s https://notary.docker.io addhash "${MINION_IMAGE}" "${MINION_IMAGE_VERSION}" "${BYTES_SIZE}" --sha256 "${SHA_256}" --publish --verbose
+            echo "Done!"
+            # notary -s https://notary.docker.io list "${IMAGE}"
 
   horizon-rpm-build:
     executor: centos-build-executor

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,7 @@ aliases:
            MINION_IMAGE_VERSION="bleeding"
           ;;
         *)
-          MINION_IMAGE_VERSION=b<< pipeline.number >>
+          MINION_IMAGE_VERSION="${CIRCLE_BRANCH//\//-}"
           ;;
       esac
       echo "export DOCKER_CONTENT_TRUST=1" >> $BASH_ENV

--- a/opennms-container/minion/Dockerfile
+++ b/opennms-container/minion/Dockerfile
@@ -4,7 +4,7 @@
 # To avoid issues, we rearrange the directories in pre-stage to avoid injecting these
 # as addtional layers into the final image.
 ##
-ARG BASE_IMAGE="opennms/deploy-base:jre-1.2.0.b58"
+ARG BASE_IMAGE="opennms/deploy-base:jre-1.2.0.b105"
 
 FROM ${BASE_IMAGE} as minion-base
 

--- a/opennms-container/minion/Makefile
+++ b/opennms-container/minion/Makefile
@@ -8,7 +8,7 @@
 VERSION                 := localbuild
 SHELL                   := /bin/bash -o nounset -o pipefail -o errexit
 BUILD_DATE              := $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
-BASE_IMAGE              := opennms/deploy-base:jre-1.2.0.b58
+BASE_IMAGE              := opennms/deploy-base:jre-1.2.0.b105
 DOCKER_CLI_EXPERIMENTAL := enabled
 DOCKERX_INSTANCE        := env-minion-oci
 DOCKER_REGISTRY         := docker.io
@@ -76,9 +76,8 @@ build: test minion-config-schema.yml
 	@echo "Copy Minion tarball to Docker context ..."
 	@find ../../opennms-assemblies/minion/target -name "*.tar.gz" -type f -not -iname '*source*' -exec cp {} ./tarball/minion.tar.gz \;
 	@echo "Initialize builder instance ..."
-	# If we don't have a builder instance create it, otherwise use the existing one
-	@if ! docker-buildx inspect $(DOCKERX_INSTANCE); then docker-buildx create --name $(DOCKERX_INSTANCE); fi;
-	@docker-buildx use $(DOCKERX_INSTANCE)
+	if ! docker-buildx inspect $(DOCKERX_INSTANCE); then docker-buildx create --name $(DOCKERX_INSTANCE); fi;
+	docker-buildx use $(DOCKERX_INSTANCE)
 	@echo "Build container image for architecture: $(DOCKER_ARCH) ..."
 	docker-buildx build --platform=$(DOCKER_ARCH) \
 	  --build-arg BASE_IMAGE=$(BASE_IMAGE) \

--- a/opennms-container/minion/container-fs/entrypoint.sh
+++ b/opennms-container/minion/container-fs/entrypoint.sh
@@ -163,6 +163,14 @@ applyConfd() {
   fi
 }
 
+applyOpennmsPropertiesD() {
+  find "${MINION_HOME}/etc/opennms.properties.d" -name '*.properties' | while IFS= read -r filename; do
+    echo "appending to custom.system.properties: $filename"
+    echo "" >> ${MINION_HOME}/etc/custom.system.properties
+    cat "$filename" >> ${MINION_HOME}/etc/custom.system.properties
+  done
+}
+
 start() {
     export KARAF_EXEC="exec"
     cd ${MINION_HOME}/bin
@@ -187,6 +195,7 @@ runConfd() {
 configure() {
   initConfig
   applyConfd
+  applyOpennmsPropertiesD
   applyOverlayConfig
   if [[ -f "$MINION_PROCESS_ENV_CFG" ]]; then
     while read assignment; do


### PR DESCRIPTION
This is the first half of the work to backport DCT to foundation 2021 for use in Meridian Minion.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-13568

