### PR TITLE
NMS-13573: Backporting cassandra confd config allowing arbitrary key/values pairs

### DIFF
--- a/opennms-container/horizon/CONFD_README.md
+++ b/opennms-container/horizon/CONFD_README.md
@@ -55,8 +55,6 @@ opennms:
     port: 9042
     username: cassandra
     password: cassandra
-  replication:
-    factor: factor
 ```
 
 Config specified will be written to `etc/opennms.properties.d/_confd.newts.properties`. 

--- a/opennms-container/horizon/CONFD_README.md
+++ b/opennms-container/horizon/CONFD_README.md
@@ -42,3 +42,21 @@ opennms:
 ```
 
 Config specified will be written to `etc/opennms.properties.d/_confd.mattermost.properties`. Check the docs for detailed information about the Mattermost configuration parameters.
+
+
+### Newts
+
+```
+---
+opennms:
+  cassandra: 
+    hostnames: localhost 
+    keyspace: newts
+    port: 9042
+    username: cassandra
+    password: cassandra
+  replication:
+    factor: factor
+```
+
+Config specified will be written to `etc/opennms.properties.d/_confd.newts.properties`. 

--- a/opennms-container/horizon/container-fs/confd/conf.d/newts.properties.toml
+++ b/opennms-container/horizon/container-fs/confd/conf.d/newts.properties.toml
@@ -3,9 +3,5 @@ src = "newts.properties.tpl"
 dest = "/opt/opennms/etc/opennms.properties.d/_confd.newts.properties"
 keys = [
     "replication/factor",
-    "opennms/cassandra/hostnames",
-    "opennms/cassandra/keyspace",
-    "opennms/cassandra/port",
-    "opennms/cassandra/username",
-    "opennms/cassandra/password"
+    "opennms/cassandra",
 ]

--- a/opennms-container/horizon/container-fs/confd/templates/newts.properties.tpl
+++ b/opennms-container/horizon/container-fs/confd/templates/newts.properties.tpl
@@ -1,9 +1,11 @@
 #
 # DON'T EDIT THIS FILE :: GENERATED WITH CONFD
 #
-org.opennms.newts.config.replication.factor={{getv "/replication/factor" "localhost"}}
-org.opennms.newts.config.hostname={{getv "/opennms/cassandra/hostnames" "localhost"}}
-org.opennms.newts.config.keyspace={{getv "/opennms/cassandra/keyspace" "newts"}}
-org.opennms.newts.config.port={{getv "/opennms/cassandra/port" "9042"}}
-org.opennms.newts.config.username={{getv "/opennms/cassandra/username" "cassandra"}}
-org.opennms.newts.config.password={{getv "/opennms/cassandra/password" "cassandra"}}
+
+{{$cassandraPath := "/opennms/cassandra/" -}}
+
+org.opennms.newts.config.hostname={{getv (print $cassandraPath "hostname") "hostname"}}
+org.opennms.newts.config.keyspace={{getv (print $cassandraPath "keyspace") "newts"}}
+org.opennms.newts.config.port={{getv (print $cassandraPath "port") "9042"}}
+org.opennms.newts.config.username={{getv (print $cassandraPath "username") "cassandra"}}
+org.opennms.newts.config.password={{getv (print $cassandraPath "password") "cassandra"}}

--- a/opennms-container/horizon/container-fs/confd/templates/newts.properties.tpl
+++ b/opennms-container/horizon/container-fs/confd/templates/newts.properties.tpl
@@ -1,6 +1,7 @@
 #
 # DON'T EDIT THIS FILE :: GENERATED WITH CONFD
 #
+org.opennms.newts.config.replication.factor={{getv "/replication/factor" "localhost"}}
 org.opennms.newts.config.hostname={{getv "/opennms/cassandra/hostnames" "localhost"}}
 org.opennms.newts.config.keyspace={{getv "/opennms/cassandra/keyspace" "newts"}}
 org.opennms.newts.config.port={{getv "/opennms/cassandra/port" "9042"}}


### PR DESCRIPTION
This PR merges a few small commits related to cassandra and confd that didn't make it into Foundation 2021.  As far as I can tell, there's nothing else (besides the JMX prometheus work, that won't be backported).

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-13573