### PR TITLE
NMS-13580: cancel on-going classification engine reloads

### DIFF
--- a/features/flows/classification/engine/api/src/main/java/org/opennms/netmgt/flows/classification/ClassificationEngine.java
+++ b/features/flows/classification/engine/api/src/main/java/org/opennms/netmgt/flows/classification/ClassificationEngine.java
@@ -37,5 +37,5 @@ public interface ClassificationEngine {
 
     List<Rule> getInvalidRules();
 
-    void reload();
+    void reload() throws InterruptedException;
 }

--- a/features/flows/classification/engine/impl/pom.xml
+++ b/features/flows/classification/engine/impl/pom.xml
@@ -110,5 +110,11 @@
       <groupId>org.openjdk.jmh</groupId>
       <artifactId>jmh-generator-annprocess</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <version>3.1.6</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/features/flows/classification/engine/impl/src/main/java/org/opennms/netmgt/flows/classification/internal/ClassificationEngineInitializer.java
+++ b/features/flows/classification/engine/impl/src/main/java/org/opennms/netmgt/flows/classification/internal/ClassificationEngineInitializer.java
@@ -30,15 +30,23 @@ package org.opennms.netmgt.flows.classification.internal;
 
 import org.opennms.netmgt.dao.api.SessionUtils;
 import org.opennms.netmgt.flows.classification.ClassificationEngine;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 // Is required to initialize the classification engine properly, as it requires a transaction to load correctly.
 // While starting the bundle, the initialization occurs from within the blueprint container, thus no transaction is available
 // This bean wraps the loading in a transaction, ensuring loading can occurr correctly
 public class ClassificationEngineInitializer {
 
+    private static final Logger LOG = LoggerFactory.getLogger(ClassificationEngineInitializer.class);
+
     public ClassificationEngineInitializer(ClassificationEngine engine, SessionUtils sessionUtils) {
         sessionUtils.withReadOnlyTransaction(() -> {
-            engine.reload();
+            try {
+                engine.reload();
+            } catch (InterruptedException e) {
+                LOG.error("reload was interrupted", e);
+            }
             return null;
         });
     }

--- a/features/flows/classification/engine/impl/src/main/java/org/opennms/netmgt/flows/classification/internal/ClassificationEngineReloader.java
+++ b/features/flows/classification/engine/impl/src/main/java/org/opennms/netmgt/flows/classification/internal/ClassificationEngineReloader.java
@@ -43,13 +43,17 @@ public class ClassificationEngineReloader {
 
     private final ScheduledExecutorService executorService = Executors.newScheduledThreadPool(1);
 
-    public ClassificationEngineReloader(Identity identity, ClassificationEngine engine, String reloadIntervalString) {
+    public ClassificationEngineReloader(Identity identity, ClassificationEngine engine, String reloadIntervalString){
         if (identity != null) {
             final int reloadInterval = Integer.parseInt(reloadIntervalString);
             LOG.debug("Scheduling reload of classification engine every {} seconds", reloadInterval);
             executorService.scheduleWithFixedDelay(() -> {
                 LOG.debug("Performing reload of Classification Engine...");
-                engine.reload();
+                try {
+                    engine.reload();
+                } catch (InterruptedException e) {
+                    LOG.error("reload was interrupted", e);
+                }
                 LOG.debug("Reload of Classification Engine performed. Next reload will be in {} seconds", reloadInterval);
             }, reloadInterval, reloadInterval, TimeUnit.SECONDS);
         }

--- a/features/flows/classification/engine/impl/src/main/java/org/opennms/netmgt/flows/classification/internal/DefaultClassificationEngine.java
+++ b/features/flows/classification/engine/impl/src/main/java/org/opennms/netmgt/flows/classification/internal/DefaultClassificationEngine.java
@@ -60,11 +60,11 @@ public class DefaultClassificationEngine implements ClassificationEngine {
     private final ClassificationRuleProvider ruleProvider;
     private final FilterService filterService;
 
-    public DefaultClassificationEngine(final ClassificationRuleProvider ruleProvider, final FilterService filterService) {
+    public DefaultClassificationEngine(final ClassificationRuleProvider ruleProvider, final FilterService filterService) throws InterruptedException {
         this(ruleProvider, filterService, true);
     }
 
-    public DefaultClassificationEngine(final ClassificationRuleProvider ruleProvider, final FilterService filterService, final boolean initialize) {
+    public DefaultClassificationEngine(final ClassificationRuleProvider ruleProvider, final FilterService filterService, final boolean initialize) throws InterruptedException {
         this.ruleProvider = Objects.requireNonNull(ruleProvider);
         this.filterService = Objects.requireNonNull(filterService);
         if (initialize) {
@@ -73,7 +73,7 @@ public class DefaultClassificationEngine implements ClassificationEngine {
     }
 
     @Override
-    public void reload() {
+    public void reload() throws InterruptedException {
         var start = System.currentTimeMillis();
         var invalid = new ArrayList<Rule>();
 

--- a/features/flows/classification/engine/impl/src/main/java/org/opennms/netmgt/flows/classification/internal/DefaultClassificationService.java
+++ b/features/flows/classification/engine/impl/src/main/java/org/opennms/netmgt/flows/classification/internal/DefaultClassificationService.java
@@ -55,8 +55,12 @@ import org.opennms.netmgt.flows.classification.persistence.api.ClassificationGro
 import org.opennms.netmgt.flows.classification.persistence.api.ClassificationRuleDao;
 import org.opennms.netmgt.flows.classification.persistence.api.Group;
 import org.opennms.netmgt.flows.classification.persistence.api.Rule;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class DefaultClassificationService implements ClassificationService {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DefaultClassificationService.class);
 
     private final ClassificationRuleDao classificationRuleDao;
 
@@ -322,7 +326,11 @@ public class DefaultClassificationService implements ClassificationService {
 
     private <T> T runInTransactionAndThenReload(Supplier<T> supplier) {
         T res = runInTransaction(supplier);
-        classificationEngine.reload();
+        try {
+            classificationEngine.reload();
+        } catch (InterruptedException e) {
+            LOG.error("reload was interrupted", e);
+        }
         return res;
     }
 

--- a/features/flows/classification/engine/impl/src/main/java/org/opennms/netmgt/flows/classification/internal/TimingClassificationEngine.java
+++ b/features/flows/classification/engine/impl/src/main/java/org/opennms/netmgt/flows/classification/internal/TimingClassificationEngine.java
@@ -60,7 +60,7 @@ public class TimingClassificationEngine implements ClassificationEngine {
     }
 
     @Override
-    public void reload() {
+    public void reload() throws InterruptedException {
         try (final Timer.Context ctx = reloadTimer.time()) {
             delegate.reload();
         }

--- a/features/flows/classification/engine/impl/src/main/java/org/opennms/netmgt/flows/classification/internal/decision/Tree.java
+++ b/features/flows/classification/engine/impl/src/main/java/org/opennms/netmgt/flows/classification/internal/decision/Tree.java
@@ -64,11 +64,15 @@ public abstract class Tree {
      * Recursively constructs a decision tree consisting of nodes that split the given rules by thresholds
      * and leaves that contain the classifiers that were selected by the thresholds of their ancestor nodes.
      */
-    public static Tree of(List<PreprocessedRule> rules, FilterService filterService) {
+    public static Tree of(List<PreprocessedRule> rules, FilterService filterService) throws InterruptedException  {
         return of(rules, Bounds.ANY, 0, filterService);
     }
 
-    private static Tree of(List<PreprocessedRule> rules, Bounds bounds, int depth, FilterService filterService) {
+    private static Tree of(List<PreprocessedRule> rules, Bounds bounds, int depth, FilterService filterService) throws InterruptedException {
+        if (Thread.interrupted()) {
+            throw new InterruptedException();
+        }
+
         final var ruleSetSize = rules.size();
         if (ruleSetSize <= 1) {
             LOG.trace("Leaf - depth: " + depth + "; rules: " + ruleSetSize);

--- a/features/flows/classification/engine/impl/src/test/java/org/opennms/netmgt/flows/classification/internal/AsyncReloadClassificationEngineTest.java
+++ b/features/flows/classification/engine/impl/src/test/java/org/opennms/netmgt/flows/classification/internal/AsyncReloadClassificationEngineTest.java
@@ -1,0 +1,110 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2018-2021 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.netmgt.flows.classification.internal;
+
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.Test;
+import org.opennms.netmgt.flows.classification.ClassificationEngine;
+import org.opennms.netmgt.flows.classification.ClassificationRequest;
+import org.opennms.netmgt.flows.classification.persistence.api.Rule;
+
+public class AsyncReloadClassificationEngineTest {
+
+    @Test
+    public void reloadsAreInterrupted() {
+
+        var started = new AtomicInteger();
+        var interrupted = new AtomicInteger();
+        var sleep = new AtomicBoolean(true);
+        var completed = new AtomicBoolean(false);
+
+        ClassificationEngine ce = new ClassificationEngine() {
+            @Override
+            public String classify(ClassificationRequest classificationRequest) {
+                return null;
+            }
+
+            @Override
+            public List<Rule> getInvalidRules() {
+                return null;
+            }
+
+            @Override
+            public void reload() throws InterruptedException {
+                started.incrementAndGet();
+                try {
+                    while (sleep.get()) Thread.sleep(1000);
+                    completed.set(true);
+                } catch (InterruptedException e) {
+                    interrupted.incrementAndGet();
+                    throw e;
+                }
+            }
+        };
+
+        var x = new AsyncReloadingClassificationEngine(ce);
+
+        // first reload is triggered right away
+        await().untilAsserted(() -> assertThat(started.get(), is(1)));
+        await().untilAsserted(() -> assertThat(interrupted.get(), is(0)));
+
+        x.reload();
+        await().untilAsserted(() -> assertThat(started.get(), is(2)));
+        // if a load process is under way then a reload triggers an interruption
+        await().untilAsserted(() -> assertThat(interrupted.get(), is(1)));
+
+        x.reload();
+        await().untilAsserted(() -> assertThat(started.get(), is(3)));
+        await().untilAsserted(() -> assertThat(interrupted.get(), is(2)));
+        x.reload();
+        await().untilAsserted(() -> assertThat(started.get(), is(4)));
+        await().untilAsserted(() -> assertThat(interrupted.get(), is(3)));
+
+        sleep.set(false);
+        await().untilAsserted(() -> assertThat(completed.get(), is(true)));
+
+        sleep.set(true);
+
+        x.reload();
+        await().untilAsserted(() -> assertThat(started.get(), is(5)));
+        await().untilAsserted(() -> assertThat(interrupted.get(), is(3)));
+        x.reload();
+        await().untilAsserted(() -> assertThat(started.get(), is(6)));
+        await().untilAsserted(() -> assertThat(interrupted.get(), is(4)));
+        sleep.set(false);
+
+    }
+}

--- a/features/flows/classification/engine/impl/src/test/java/org/opennms/netmgt/flows/classification/internal/ClassificationEngineBenchmark.java
+++ b/features/flows/classification/engine/impl/src/test/java/org/opennms/netmgt/flows/classification/internal/ClassificationEngineBenchmark.java
@@ -97,7 +97,7 @@ public class ClassificationEngineBenchmark {
         private List<ClassificationRequest> classificationRequests;
 
         @Setup
-        public void setup() {
+        public void setup() throws InterruptedException {
             var rules = getRules(ruleSet);
             classificationEngine = new DefaultClassificationEngine(() -> rules, createNiceMock(FilterService.class));
             classificationRequests = RandomClassificationEngineTest.streamOfclassificationRequests(rules, 123456l).skip(index * BATCH_SIZE).limit(BATCH_SIZE).collect(Collectors.toList());

--- a/features/flows/classification/engine/impl/src/test/java/org/opennms/netmgt/flows/classification/internal/DefaultClassificationEngineIT.java
+++ b/features/flows/classification/engine/impl/src/test/java/org/opennms/netmgt/flows/classification/internal/DefaultClassificationEngineIT.java
@@ -122,7 +122,7 @@ public class DefaultClassificationEngineIT {
     }
 
     @Test
-    public void verifyRuleFilter() {
+    public void verifyRuleFilter() throws InterruptedException {
         final ClassificationEngine classificationEngine = new DefaultClassificationEngine(() -> ruleDao.findAllEnabledRules(), new DefaultFilterService(filterDao));
 
         // Create request, that matches rule1

--- a/features/flows/classification/engine/impl/src/test/java/org/opennms/netmgt/flows/classification/internal/DefaultClassificationEngineTest.java
+++ b/features/flows/classification/engine/impl/src/test/java/org/opennms/netmgt/flows/classification/internal/DefaultClassificationEngineTest.java
@@ -59,7 +59,7 @@ public class DefaultClassificationEngineTest {
     }
 
     @Test
-    public void verifyRuleEngineBasic() {
+    public void verifyRuleEngineBasic() throws InterruptedException {
         DefaultClassificationEngine engine = new DefaultClassificationEngine(() ->
             Lists.newArrayList(
                     new RuleBuilder().withName("rule1").withPosition(1).withSrcPort(80).build(),
@@ -75,7 +75,7 @@ public class DefaultClassificationEngineTest {
     }
 
     @Test
-    public void verifyRuleEngineWithOmnidirectionals() {
+    public void verifyRuleEngineWithOmnidirectionals() throws InterruptedException {
         DefaultClassificationEngine engine = new DefaultClassificationEngine(() ->
                 Lists.newArrayList(
                         new RuleBuilder().withName("rule1").withSrcPort(80).withOmnidirectional(true).build(),
@@ -102,7 +102,7 @@ public class DefaultClassificationEngineTest {
     }
 
     @Test
-    public void verifyRuleEngineExtended() {
+    public void verifyRuleEngineExtended() throws InterruptedException {
         // Define Rule set
         DefaultClassificationEngine engine = new DefaultClassificationEngine(() -> Lists.newArrayList(
                 new RuleBuilder().withName("SSH").withDstPort("22").withPosition(1).build(),
@@ -188,7 +188,7 @@ public class DefaultClassificationEngineTest {
     }
 
     @Test
-    public void verifyAddressRuleWins() {
+    public void verifyAddressRuleWins() throws InterruptedException {
         final ClassificationEngine engine = new DefaultClassificationEngine(() -> Lists.newArrayList(
             new RuleBuilder().withName("HTTP").withDstPort(80).withPosition(1).build(),
             new RuleBuilder().withName("XXX2").withSrcAddress("192.168.2.1").withSrcPort(4789).build(),
@@ -206,7 +206,7 @@ public class DefaultClassificationEngineTest {
     }
 
     @Test
-    public void verifyAllPortsToEnsureEngineIsProperlyInitialized() {
+    public void verifyAllPortsToEnsureEngineIsProperlyInitialized() throws InterruptedException {
         final ClassificationEngine classificationEngine = new DefaultClassificationEngine(() -> new ArrayList<>(), FilterService.NOOP);
         for (int i=Rule.MIN_PORT_VALUE; i<Rule.MAX_PORT_VALUE; i++) {
             classificationEngine.classify(classificationRequest("Default", 0, null, i, "127.0.0.1", ProtocolType.TCP));
@@ -215,7 +215,7 @@ public class DefaultClassificationEngineTest {
 
     // See NMS-12429
     @Test
-    public void verifyDoesNotRunOutOfMemory() {
+    public void verifyDoesNotRunOutOfMemory() throws InterruptedException {
         final List<Rule> rules = Lists.newArrayList();
         for (int i=0; i<100; i++) {
             final Rule rule = new RuleBuilder().withName("rule1").withPosition(i+1).withProtocol("UDP").withDstAddress("192.168.0." + i).build();
@@ -226,7 +226,7 @@ public class DefaultClassificationEngineTest {
     }
 
     @Test(timeout=5000)
-    public void verifyInitializesQuickly() {
+    public void verifyInitializesQuickly() throws InterruptedException {
         new DefaultClassificationEngine(() -> Lists.newArrayList(new Rule("Test", "0-10000")), FilterService.NOOP);
     }
 }

--- a/features/flows/classification/engine/impl/src/test/java/org/opennms/netmgt/flows/classification/internal/DefaultClassificationServiceIT.java
+++ b/features/flows/classification/engine/impl/src/test/java/org/opennms/netmgt/flows/classification/internal/DefaultClassificationServiceIT.java
@@ -91,7 +91,7 @@ public class DefaultClassificationServiceIT {
     private Group userGroupCsv; // the user group that is not attached to hibernate
 
     @Before
-    public void setUp() {
+    public void setUp() throws InterruptedException {
         FilterService filterService = new DefaultFilterService(filterDao);
         classificationService = new DefaultClassificationService(
                 ruleDao,

--- a/features/flows/classification/engine/impl/src/test/java/org/opennms/netmgt/flows/classification/internal/ExampleRulesTest.java
+++ b/features/flows/classification/engine/impl/src/test/java/org/opennms/netmgt/flows/classification/internal/ExampleRulesTest.java
@@ -43,11 +43,11 @@ import org.opennms.netmgt.flows.classification.internal.decision.Tree;
 public class ExampleRulesTest {
 
     @Test
-    public void exampleRuleSet() {
+    public void exampleRuleSet() throws InterruptedException {
         testRuleSet("/example-rules.csv");
     }
 
-    public void testRuleSet(String resource) {
+    public void testRuleSet(String resource) throws InterruptedException {
         var rules = ClassificationEngineBenchmark.getRules(resource);
         var classificationEngine = new DefaultClassificationEngine(() -> rules, createNiceMock(FilterService.class));
 

--- a/features/flows/classification/engine/impl/src/test/java/org/opennms/netmgt/flows/classification/internal/RandomClassificationEngineTest.java
+++ b/features/flows/classification/engine/impl/src/test/java/org/opennms/netmgt/flows/classification/internal/RandomClassificationEngineTest.java
@@ -118,7 +118,7 @@ public class RandomClassificationEngineTest {
     @Property
     public boolean test(
             @ForAll("rulesAndRequests") Tuple.Tuple2<List<Rule>, List<ClassificationRequest>> rulesAndRequests
-    ) {
+    ) throws InterruptedException {
         LOG.debug("construct decision tree");
         if (LOG.isDebugEnabled()) {
             rulesAndRequests.get1().forEach(r -> {

--- a/features/flows/elastic/src/test/java/org/opennms/netmgt/flows/elastic/DocumentEnricherTest.java
+++ b/features/flows/elastic/src/test/java/org/opennms/netmgt/flows/elastic/DocumentEnricherTest.java
@@ -53,7 +53,7 @@ import com.google.common.collect.Lists;
 public class DocumentEnricherTest {
 
     @Test
-    public void verifyCacheUsage() {
+    public void verifyCacheUsage() throws InterruptedException {
         final MockDocumentEnricherFactory factory = new MockDocumentEnricherFactory();
         final DocumentEnricher enricher = factory.getEnricher();
         final NodeDao nodeDao = factory.getNodeDao();
@@ -118,7 +118,7 @@ public class DocumentEnricherTest {
     }
 
     @Test
-    public void testCreateClassificationRequest() {
+    public void testCreateClassificationRequest() throws InterruptedException {
         final MockDocumentEnricherFactory factory = new MockDocumentEnricherFactory();
         final DocumentEnricher enricher = factory.getEnricher();
 
@@ -147,7 +147,7 @@ public class DocumentEnricherTest {
     }
 
     @Test
-    public void testDirection() {
+    public void testDirection() throws InterruptedException {
         final MockDocumentEnricherFactory factory = new MockDocumentEnricherFactory();
         final DocumentEnricher enricher = factory.getEnricher();
 
@@ -196,7 +196,7 @@ public class DocumentEnricherTest {
     }
 
     @Test
-    public void testClockCorrection() {
+    public void testClockCorrection() throws InterruptedException {
         final MockDocumentEnricherFactory factory = new MockDocumentEnricherFactory(2400_000L);
         final DocumentEnricher enricher = factory.getEnricher();
 

--- a/features/flows/elastic/src/test/java/org/opennms/netmgt/flows/elastic/FlowDocumentTest.java
+++ b/features/flows/elastic/src/test/java/org/opennms/netmgt/flows/elastic/FlowDocumentTest.java
@@ -66,7 +66,7 @@ public class FlowDocumentTest {
     private DocumentEnricher enricher;
 
     @Before
-    public void setUp() {
+    public void setUp() throws InterruptedException {
         final MockDocumentEnricherFactory factory = new MockDocumentEnricherFactory();
         enricher = factory.getEnricher();
 

--- a/features/flows/elastic/src/test/java/org/opennms/netmgt/flows/elastic/MockDocumentEnricherFactory.java
+++ b/features/flows/elastic/src/test/java/org/opennms/netmgt/flows/elastic/MockDocumentEnricherFactory.java
@@ -64,11 +64,11 @@ public class MockDocumentEnricherFactory {
 
     private final AtomicInteger nodeDaoGetCounter = new AtomicInteger(0);
 
-    public MockDocumentEnricherFactory() {
+    public MockDocumentEnricherFactory() throws InterruptedException {
         this(0);
     }
 
-    public MockDocumentEnricherFactory(final long clockSkewCorrectionThreshold) {
+    public MockDocumentEnricherFactory(final long clockSkewCorrectionThreshold) throws InterruptedException {
         nodeDao = createNodeDao();
         interfaceToNodeCache = new MockInterfaceToNodeCache();
         assetRecordDao = new MockAssetRecordDao();

--- a/features/flows/itests/src/test/java/org/opennms/netmgt/flows/elastic/ElasticFlowRepositoryIT.java
+++ b/features/flows/itests/src/test/java/org/opennms/netmgt/flows/elastic/ElasticFlowRepositoryIT.java
@@ -60,7 +60,7 @@ public class ElasticFlowRepositoryIT {
     public WireMockRule wireMockRule = new WireMockRule(WireMockConfiguration.options().dynamicPort());
 
     @Test(expected=PersistenceException.class)
-    public void verifyThrowsPersistenceException() throws IOException, FlowException {
+    public void verifyThrowsPersistenceException() throws IOException, FlowException, InterruptedException {
         // Stub request
         stubFor(post("/_bulk")
                     .willReturn(aResponse()

--- a/features/flows/itests/src/test/java/org/opennms/netmgt/flows/elastic/NodeIdentificationIT.java
+++ b/features/flows/itests/src/test/java/org/opennms/netmgt/flows/elastic/NodeIdentificationIT.java
@@ -105,7 +105,7 @@ public class NodeIdentificationIT {
     }
 
     @Test
-    public void testSomething() {
+    public void testSomething() throws InterruptedException {
         final ClassificationEngine classificationEngine = new DefaultClassificationEngine(() -> Collections.emptyList(), FilterService.NOOP);
         final DocumentEnricher documentEnricher = new DocumentEnricher(
                 new MetricRegistry(), databasePopulator.getNodeDao(), interfaceToNodeCache, sessionUtils, classificationEngine,


### PR DESCRIPTION
Issue: https://issues.opennms.org/browse/NMS-13580

This PR cancels on-going flow classification engine reloads when another reload is requested and starts the new reload immediately. This improves responsiveness when editing classification rules.