### PR TITLE
NMS-13587: change how "$REVISION" is created by default

### DIFF
--- a/opennms-container/README.md
+++ b/opennms-container/README.md
@@ -45,7 +45,7 @@ The build can be customized with `--build-arg key=value`.
 | `BUILD_DATE`         | Date the image is created in [RFC 3339](https://tools.ietf.org/html/rfc3339#section-5.6) format | optional | `1970-01-01T00:00:00+0000`
 | `VERSION`            | Label for version number                                                      | optional | `-`
 | `SOURCE`             | Label for source code URL                                                     | optional | `-`
-| `REVISION`           | Label for revision, e.g. `git describe --always`                              | optional | `-`
+| `REVISION`           | Descriptive/unique label for the revision                                     | optional | `-`
 | `BUILD_JOB_ID`       | Label for build job from CI/CD                                                | optional | `-`
 | `BUILD_NUMBER`       | Label for build number from CI/CD                                             | optional | `-`
 | `BUILD_URL`          | Label for build URL from CI/CD                                                | optional | `-`

--- a/opennms-container/set-build-environment.sh
+++ b/opennms-container/set-build-environment.sh
@@ -5,9 +5,10 @@ TOPDIR="$(cd "$(dirname "$0")" || exit 1; pwd -P)"
 TOPDIR="$(echo "$TOPDIR" | sed -e 's,opennms-container/.*$,opennms-container,')"
 
 # Use version number from pom except from develop and features branches
+POM_VERSION="$("${TOPDIR}/pom2version.py" "${TOPDIR}/../pom.xml")"
 case "${CIRCLE_BRANCH}" in
   master-*)
-    VERSION="$("${TOPDIR}/pom2version.py" "${TOPDIR}/../pom.xml")"
+    VERSION="${POM_VERSION}"
     ;;
   develop)
     VERSION="bleeding"
@@ -22,15 +23,15 @@ if [ -z "$VERSION" ]; then
   VERSION="$("${TOPDIR}/pom2version.py" "${TOPDIR}/../pom.xml")"
 fi
 
+[ -n "${BUILD_BRANCH}"            ] || BUILD_BRANCH="${CIRCLE_BRANCH}"
+[ -n "${BUILD_BRANCH}"            ] || BUILD_BRANCH="$(git branch --show-current)"
 [ -n "${BUILD_NETWORK}"           ] || BUILD_NETWORK="opennms-build-network"
 [ -n "${BUILD_DATE}"              ] || BUILD_DATE="$(date -u "+%Y-%m-%dT%H:%M:%S%z")"
 [ -n "${SOURCE}"                  ] || SOURCE="${CIRCLE_REPOSITORY_URL:-local-build}"
-[ -n "${REVISION}"                ] || REVISION="$(git describe --always)"
+[ -n "${REVISION}"                ] || REVISION="${BUILD_BRANCH}-${POM_VERSION}-$(git rev-parse --short --verify HEAD)"
 [ -n "${BUILD_JOB_ID}"            ] || BUILD_JOB_ID="${CIRCLE_WORKFLOW_JOB_ID:-0}"
 [ -n "${BUILD_NUMBER}"            ] || BUILD_NUMBER="${CIRCLE_BUILD_NUM:-0}"
 [ -n "${BUILD_URL}"               ] || BUILD_URL="${CIRCLE_BUILD_URL}"
-[ -n "${BUILD_BRANCH}"            ] || BUILD_BRANCH="${CIRCLE_BRANCH}"
-[ -n "${BUILD_BRANCH}"            ] || BUILD_BRANCH="$(git branch --show-current)"
 
 [ -n "${YUM_CONTAINER_NAME}"      ] || YUM_CONTAINER_NAME="yum-repo"
 [ -n "${RPMDIR}"                  ] || RPMDIR="${TOPDIR}/../target/rpm/RPMS/noarch"


### PR DESCRIPTION
This PR changes how $REVISION is set for docker containers.
Currently it's running `git describe --always` which goes back into history looking for a related tag to be considered "base", and then adds the short hash to the end. As of now, this usually matches `meridian-foundation-2021.1.4` which is technically not wrong, and is unique, but is not a very intuitive value for, say, develop snapshots.

This change makes it be the branch name + pom version + short hash.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-13587
