### PR TITLE
NMS-13586: Add trapoid changes to SNMP V1 Traps

### DIFF
--- a/core/snmp/api/src/main/java/org/opennms/netmgt/snmp/TrapIdentity.java
+++ b/core/snmp/api/src/main/java/org/opennms/netmgt/snmp/TrapIdentity.java
@@ -29,7 +29,9 @@
 package org.opennms.netmgt.snmp;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -51,6 +53,8 @@ public class TrapIdentity {
      * The standard traps list
      */
     private static final List<SnmpObjId> GENERIC_TRAPS;
+
+    private static final Map<Integer, SnmpObjId> GENERIC_TRAPS_BY_GENERIC_ID;
     
     /**
      * The dot separator in an OID
@@ -83,6 +87,16 @@ public class TrapIdentity {
         GENERIC_TRAPS.add(new SnmpObjId("1.3.6.1.6.3.1.1.5.4")); // linkUp
         GENERIC_TRAPS.add(new SnmpObjId("1.3.6.1.6.3.1.1.5.5")); // authenticationFailure
         GENERIC_TRAPS.add(new SnmpObjId("1.3.6.1.6.3.1.1.5.6")); // egpNeighborLoss
+    }
+
+    static {
+        GENERIC_TRAPS_BY_GENERIC_ID = new HashMap<>();
+        GENERIC_TRAPS_BY_GENERIC_ID.put(0, new SnmpObjId("1.3.6.1.6.3.1.1.5.1")); // coldStart
+        GENERIC_TRAPS_BY_GENERIC_ID.put(1, new SnmpObjId("1.3.6.1.6.3.1.1.5.2")); // warmStart
+        GENERIC_TRAPS_BY_GENERIC_ID.put(2, new SnmpObjId("1.3.6.1.6.3.1.1.5.3")); // linkDown
+        GENERIC_TRAPS_BY_GENERIC_ID.put(3, new SnmpObjId("1.3.6.1.6.3.1.1.5.4")); // linkUp
+        GENERIC_TRAPS_BY_GENERIC_ID.put(4, new SnmpObjId("1.3.6.1.6.3.1.1.5.5")); // authenticationFailure
+        GENERIC_TRAPS_BY_GENERIC_ID.put(5, new SnmpObjId("1.3.6.1.6.3.1.1.5.6")); // egpNeighborLoss
     }
     
     public TrapIdentity(SnmpObjId snmpTrapOid, SnmpObjId lastVarBindOid, SnmpValue lastVarBindValue) {
@@ -120,7 +134,7 @@ public class TrapIdentity {
                 // snmpTraps value defined as in RFC 1907
                 setEnterpriseId(TrapIdentity.SNMP_TRAPS + "." + snmpTrapOidValue.charAt(snmpTrapOidValue.length() - 1));
             }
-            
+            setTrapOID(getEnterpriseId());
         } else // not standard trap
         {
             // set generic to 6
@@ -137,9 +151,10 @@ public class TrapIdentity {
                 // the last two subids
                 setEnterpriseId(snmpTrapOidValue.substring(0, nextToLastIndex));
                 // Parse full trap oid with sub-id
-                setTrapOID(snmpTrapOidValue.substring(0, snmpTrapOidValue.length()));
+                setTrapOID(snmpTrapOidValue);
             } else {
                 setEnterpriseId(snmpTrapOidValue.substring(0, lastIndex));
+                setTrapOID(getEnterpriseId());
             }
         }
     }
@@ -148,6 +163,17 @@ public class TrapIdentity {
         m_enterpriseId = entId.toString();
         m_generic = generic;
         m_specific = specific;
+        // SNMP V1
+        if (m_generic == 6) {
+            // Concatenate sub-id and specific with enterpriseId.
+            String trapOID = m_enterpriseId + "." + 0 + "." + m_specific;
+            setTrapOID(trapOID);
+        } else if (GENERIC_TRAPS_BY_GENERIC_ID.containsKey(m_generic)) {
+            SnmpObjId trapOID = GENERIC_TRAPS_BY_GENERIC_ID.get(m_generic);
+            setTrapOID(trapOID.toString());
+        } else {
+            setTrapOID(getEnterpriseId());
+        }
     }
 
     public int getGeneric() {

--- a/features/events/traps/src/test/java/org/opennms/netmgt/trapd/TrapdIT.java
+++ b/features/events/traps/src/test/java/org/opennms/netmgt/trapd/TrapdIT.java
@@ -29,7 +29,10 @@
 package org.opennms.netmgt.trapd;
 
 import static com.jayway.awaitility.Awaitility.await;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertTrue;
 
 import java.net.InetAddress;
 import java.util.List;
@@ -158,7 +161,7 @@ public class TrapdIT {
      * @throws Exception
      */
     @Test
-    public void testSnmpV2cTrapSendWithMatchingEventFromEventConf() throws Exception {
+    public void testSnmpV2cTrapWithTrapOID() throws Exception {
         SnmpObjId enterpriseId = SnmpObjId.get(".1.3.6.1.4.1.55.0.5");
         SnmpTrapBuilder pdu = SnmpUtils.getV2TrapBuilder();
         pdu.addVarBind(SnmpObjId.get(".1.3.6.1.2.1.1.3.0"), SnmpUtils.getValueFactory().getTimeTicks(0));
@@ -181,8 +184,38 @@ public class TrapdIT {
         List<Event> eventList = m_mockEventIpcManager.getEventAnticipator().getAnticipatedEventsReceived();
         Assert.assertThat(eventList.size(), Matchers.equalTo(2));
         Optional<Event> eventWithSnmp = eventList.stream().filter(event -> event.getSnmp() != null).findFirst();
-        Assert.assertTrue(eventWithSnmp.isPresent());
+        assertTrue(eventWithSnmp.isPresent());
         Assert.assertThat(eventWithSnmp.get().getSnmp().getTrapOID(), Matchers.equalTo(".1.3.6.1.4.1.55.0.5"));
+    }
+
+    @Test
+    public void testSnmpV1TrapWithTrapOID() throws Exception {
+        // Verify for SNMP V1 Trap
+        SnmpV1TrapBuilder pdu = SnmpUtils.getV1TrapBuilder();
+        pdu.setEnterprise(SnmpObjId.get(".1.3.6.1.4.1.9.9.276"));
+        pdu.setGeneric(6);
+        pdu.setSpecific(4);
+        pdu.setTimeStamp(0);
+        pdu.setAgentAddress(localAddr);
+
+        // eventconf.xml has a matching event with trapoid mask element.
+        EventBuilder defaultTrapBuilder = new EventBuilder("uei.opennms.org/IANA/Example/traps/exampleTrapOIDForSNMPV1", "trapd");
+        defaultTrapBuilder.setInterface(localAddr);
+        defaultTrapBuilder.setSnmpVersion("v1");
+        m_mockEventIpcManager.getEventAnticipator().anticipateEvent(defaultTrapBuilder.getEvent());
+        EventBuilder newSuspectBuilder = new EventBuilder(EventConstants.NEW_SUSPECT_INTERFACE_EVENT_UEI, "trapd");
+        newSuspectBuilder.setInterface(localAddr);
+        m_mockEventIpcManager.getEventAnticipator().anticipateEvent(newSuspectBuilder.getEvent());
+
+        pdu.send(localhost, m_trapdConfig.getSnmpTrapPort(), "public");
+
+        // Wait until we received the expected events
+        await().until(() -> m_mockEventIpcManager.getEventAnticipator().getAnticipatedEventsReceived(), hasSize(2));
+        List<Event> eventList = m_mockEventIpcManager.getEventAnticipator().getAnticipatedEventsReceived();
+        Assert.assertThat(eventList.size(), Matchers.equalTo(2));
+        Optional<Event> eventWithSnmp = eventList.stream().filter(event -> event.getSnmp() != null).findFirst();
+        assertTrue(eventWithSnmp.isPresent());
+        Assert.assertThat(eventWithSnmp.get().getSnmp().getTrapOID(), Matchers.equalTo(".1.3.6.1.4.1.9.9.276.0.4"));
     }
 
     /**

--- a/features/events/traps/src/test/resources/org/opennms/netmgt/trapd/eventconf.xml
+++ b/features/events/traps/src/test/resources/org/opennms/netmgt/trapd/eventconf.xml
@@ -235,4 +235,23 @@
     </logmsg>
     <severity>Warning</severity>
   </event>
+  <event>
+    <mask>
+      <maskelement>
+        <mename>trapoid</mename>
+        <mevalue>.1.3.6.1.4.1.9.9.276.0.4</mevalue>
+      </maskelement>
+    </mask>
+    <uei>uei.opennms.org/IANA/Example/traps/exampleTrapOIDForSNMPV1</uei>
+    <event-label>
+      IANA defined trap event: exampleEnterpriseTrap.
+    </event-label>
+    <descr>
+      This is an example trap with TrapOID = %trapoid%
+    </descr>
+    <logmsg dest='logndisplay'>
+      &lt;p&gt;IANA Event: Example trap.&lt;/p&gt;
+    </logmsg>
+    <severity>Warning</severity>
+  </event>
 </events>


### PR DESCRIPTION
Add  trapoid field for SNMP v1 Traps.
Always fill trapoid field by falling back to enterpriseId
### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-13586

