### PR TITLE
NMS-13592: add --tag argument to health-check command

### DIFF
--- a/core/health/shell/src/main/java/org/opennms/core/health/shell/HealthCheckCommand.java
+++ b/core/health/shell/src/main/java/org/opennms/core/health/shell/HealthCheckCommand.java
@@ -28,6 +28,7 @@
 
 package org.opennms.core.health.shell;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
@@ -37,9 +38,11 @@ import java.util.stream.Collectors;
 
 import org.apache.karaf.shell.api.action.Action;
 import org.apache.karaf.shell.api.action.Command;
+import org.apache.karaf.shell.api.action.Completion;
 import org.apache.karaf.shell.api.action.Option;
 import org.apache.karaf.shell.api.action.lifecycle.Reference;
 import org.apache.karaf.shell.api.action.lifecycle.Service;
+import org.apache.karaf.shell.support.completers.StringsCompleter;
 import org.opennms.core.health.api.Context;
 import org.opennms.core.health.api.Health;
 import org.opennms.core.health.api.HealthCheck;
@@ -58,6 +61,10 @@ public class HealthCheckCommand implements Action {
 
     @Option(name = "-t", description = "Maximum number of milliseconds to wait before failing when waiting for a check to complete (e.g. try to establish a JMS session.")
     public long timeout = 5L * 1000L;
+
+    @Option(name = "--tag", multiValued = true, description = "Tags of the health checks that are executed. If unset then all checks are executed.")
+    @Completion(HealthCheckTagCompleter.class)
+    public List<String> tags = new ArrayList<>();
 
     @Reference
     private BundleContext bundleContext;
@@ -114,7 +121,7 @@ public class HealthCheckCommand implements Action {
                             }
                             System.out.println();
                         },
-                        null);
+                        tags);
         return future;
     }
 

--- a/core/health/shell/src/main/java/org/opennms/core/health/shell/HealthCheckCommand.java
+++ b/core/health/shell/src/main/java/org/opennms/core/health/shell/HealthCheckCommand.java
@@ -42,7 +42,6 @@ import org.apache.karaf.shell.api.action.Completion;
 import org.apache.karaf.shell.api.action.Option;
 import org.apache.karaf.shell.api.action.lifecycle.Reference;
 import org.apache.karaf.shell.api.action.lifecycle.Service;
-import org.apache.karaf.shell.support.completers.StringsCompleter;
 import org.opennms.core.health.api.Context;
 import org.opennms.core.health.api.Health;
 import org.opennms.core.health.api.HealthCheck;

--- a/core/health/shell/src/main/java/org/opennms/core/health/shell/HealthCheckTagCompleter.java
+++ b/core/health/shell/src/main/java/org/opennms/core/health/shell/HealthCheckTagCompleter.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2018-2021 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.core.health.shell;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.apache.karaf.shell.api.action.lifecycle.Reference;
+import org.apache.karaf.shell.api.action.lifecycle.Service;
+import org.apache.karaf.shell.api.console.CommandLine;
+import org.apache.karaf.shell.api.console.Completer;
+import org.apache.karaf.shell.api.console.Session;
+import org.apache.karaf.shell.support.completers.StringsCompleter;
+import org.opennms.core.health.api.HealthCheck;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.InvalidSyntaxException;
+
+@Service
+public class HealthCheckTagCompleter implements Completer {
+
+    @Reference
+    private BundleContext bundleContext;
+
+    @Override
+    public int complete(Session session, CommandLine commandLine, List<String> candidates) {
+        try {
+            var tags = bundleContext
+                    .getServiceReferences(HealthCheck.class, null)
+                    .stream()
+                    .flatMap(s -> bundleContext.getService(s).getTags().stream())
+                    .collect(Collectors.toSet());
+            StringsCompleter delegate = new StringsCompleter();
+            delegate.getStrings().addAll(tags);
+            return delegate.complete(session, commandLine, candidates);
+        } catch (InvalidSyntaxException e) {
+            throw new RuntimeException("could not retrieve tags", e);
+        }
+    }
+
+}


### PR DESCRIPTION
issue: https://issues.opennms.org/browse/NMS-13592

For auto-completion the tags of all know health checks are collected.