### PR TITLE
NMS-13655: Remove locking from the critical path when verifying users.

### DIFF
--- a/opennms-config/src/main/java/org/opennms/netmgt/config/UserManager.java
+++ b/opennms-config/src/main/java/org/opennms/netmgt/config/UserManager.java
@@ -1173,13 +1173,8 @@ public abstract class UserManager implements UserConfig {
      */
     protected abstract void doUpdate() throws IOException, FileNotFoundException;
 
-    public final void update() throws IOException, FileNotFoundException {
-        m_writeLock.lock();
-        try {
-            doUpdate();
-        } finally {
-            m_writeLock.unlock();
-        }
+    public final void update() throws IOException {
+        doUpdate();
     }
     
     /**


### PR DESCRIPTION
JIRA: https://issues.opennms.org/browse/NMS-13655

Introduce a 1 sec delay between attempts to verify if the file needs to be reloaded, and remove the requirement to hold a write lock when verifying whether or not to verify :)
