### PR TITLE
NMS-13422: Always use full trapoid value for %trapoid% 

### DIFF
--- a/core/snmp/api/src/main/java/org/opennms/netmgt/snmp/TrapIdentity.java
+++ b/core/snmp/api/src/main/java/org/opennms/netmgt/snmp/TrapIdentity.java
@@ -154,7 +154,7 @@ public class TrapIdentity {
                 setTrapOID(snmpTrapOidValue);
             } else {
                 setEnterpriseId(snmpTrapOidValue.substring(0, lastIndex));
-                setTrapOID(getEnterpriseId());
+                setTrapOID(snmpTrapOidValue);
             }
         }
     }


### PR DESCRIPTION
For some of the Juniper Traps, sub-id may not be zero. 
Even for those cases, use full trapoid value for %trapoid%

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-13422

