### PR TITLE
NMS-13633: Geo-Map: Render "Log Message" as HTML

### DIFF
--- a/geomap/src/views/map/MapAlarmsGrid.vue
+++ b/geomap/src/views/map/MapAlarmsGrid.vue
@@ -262,8 +262,14 @@ const columnDefs = ref([
     field: "logMessage",
     headerTooltip: "Log Message",
     cellRenderer: (data: any) => {
-            return data.value;
-        }
+      let newData = `<style type = "text/css">
+            p
+            {
+                margin: 0px;
+            }
+        </style> ${data.value}`;
+      return newData;
+      }
   },
 ]
 )


### PR DESCRIPTION
Render alarm "Log Message" data as html. End up quite simple : )

Before rendering html:
![Screen Shot 2021-10-29 at 10 45 39 AM](https://user-images.githubusercontent.com/4617120/139455534-940633ce-3999-4253-811b-81776ef29307.png)

Before adding css:
![Screen Shot 2021-10-29 at 10 36 19 AM](https://user-images.githubusercontent.com/4617120/139455211-a1ac3304-955b-41f5-8cb1-42561d1fdb78.png)

After rendering html and adding css:
![Screen Shot 2021-10-29 at 10 35 48 AM](https://user-images.githubusercontent.com/4617120/139455183-2bf258f4-e64c-4b42-a63d-707982237f00.png)


### External References

* JIRA (Issue Tracker): https://issues.opennms.org/browse/NMS-13633

