### PR TITLE
NMS-13714: allow PostgreSQL 14.x

### DIFF
--- a/core/schema/src/main/java/org/opennms/core/schema/Migrator.java
+++ b/core/schema/src/main/java/org/opennms/core/schema/Migrator.java
@@ -80,7 +80,7 @@ public class Migrator {
     private static final Logger LOG = LoggerFactory.getLogger(Migrator.class);
     private static final Pattern POSTGRESQL_VERSION_PATTERN = Pattern.compile("^(?:PostgreSQL|EnterpriseDB) (\\d+\\.\\d+)");
     private static final float POSTGRESQL_MIN_VERSION_INCLUSIVE = Float.parseFloat(System.getProperty("opennms.postgresql.minVersion", "10.0"));
-    private static final float POSTGRESQL_MAX_VERSION_EXCLUSIVE = Float.parseFloat(System.getProperty("opennms.postgresql.maxVersion", "14.0"));
+    private static final float POSTGRESQL_MAX_VERSION_EXCLUSIVE = Float.parseFloat(System.getProperty("opennms.postgresql.maxVersion", "15.0"));
 
     private static final String IPLIKE_SQL_RESOURCE = "iplike.sql";
 

--- a/debian/control
+++ b/debian/control
@@ -39,7 +39,7 @@ Description: Enterprise-grade Open-source Network Management Platform (Source)
 
 Package: opennms-db
 Architecture: all
-Depends: opennms-common (=${binary:Version}), postgresql-13 | postgresql-12 | postgresql-11 | postgresql-10, iplike-pgsql13 (>= 2.3.0) | iplike-pgsql12 (>= 2.3.0) | iplike-pgsql11 (>= 2.3.0) | iplike-pgsql10 (>= 2.3.0), debconf
+Depends: opennms-common (=${binary:Version}), postgresql-14 | postgresql-13 | postgresql-12 | postgresql-11 | postgresql-10, iplike-pgsql14 (>= 2.3.0) | iplike-pgsql13 (>= 2.3.0) | iplike-pgsql12 (>= 2.3.0) | iplike-pgsql11 (>= 2.3.0) | iplike-pgsql10 (>= 2.3.0), debconf
 Description: Enterprise-grade Open-source Network Management Platform (Database)
  OpenNMS is an enterprise-grade network management system written in Java.
  .
@@ -57,7 +57,7 @@ Description: Enterprise-grade Open-source Network Management Platform (Database)
 Package: opennms-server
 Architecture: all
 Depends: opennms-common (=${binary:Version}), libopennms-java (=${binary:Version}), libopennmsdeps-java (=${binary:Version}), mailx
-Suggests: jrrd2, rrdtool (>= 1.4.8), postgresql-client-13 | postgresql-client-12 | postgresql-client-11 | postgresql-client-10
+Suggests: jrrd2, rrdtool (>= 1.4.8), postgresql-client-14 | postgresql-client-13 | postgresql-client-12 | postgresql-client-11 | postgresql-client-10
 Recommends: haveged
 Description: Enterprise-grade Open-source Network Management Platform (Daemon)
  OpenNMS is an enterprise-grade network management system written in Java.

--- a/docs/modules/releasenotes/pages/whatsnew.adoc
+++ b/docs/modules/releasenotes/pages/whatsnew.adoc
@@ -6,7 +6,7 @@
 == System Requirements
 
 * *Java 11*: OpenNMS Horizon 29 runs on JDK 11.
-* *PostgreSQL 10 or higher*: Horizon 29 requires any supported version of PostgreSQL from 10 up to (and including) 13.
+* *PostgreSQL 10 or higher*: Horizon 29 requires any supported version of PostgreSQL from 10 up to (and including) 14.
 
 == Breaking Changes
 


### PR DESCRIPTION
This PR adds PostgreSQL 14 to the allowed/supported versions.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-13714