### PR TITLE
NMS-13663: Add health check for Kafka Twin

### DIFF
--- a/core/ipc/twin/kafka/subscriber/src/main/resources/OSGI-INF/blueprint/blueprint-twin-subscriber.xml
+++ b/core/ipc/twin/kafka/subscriber/src/main/resources/OSGI-INF/blueprint/blueprint-twin-subscriber.xml
@@ -30,4 +30,14 @@
     </bean>
 
     <service ref="kafkaTwinSubscriber" interface="org.opennms.core.ipc.twin.api.TwinSubscriber"/>
+
+    <!-- Kafka HealthCheck for Twin -->
+
+    <service interface="org.opennms.core.health.api.HealthCheck">
+        <bean class="org.opennms.core.ipc.common.kafka.KafkaHealthCheck" >
+            <argument ref="kafkaConfigProvider"/>
+            <argument value="Twin" />
+        </bean>
+    </service>
+
 </blueprint>


### PR DESCRIPTION
This should help to check if `org.opennms.core.ipc.twin.kafka.cfg` configured with right `bootstrap.servers`

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-13663
