### PR TITLE
NMS-13268: Karaf: Globally Prevent AutoRefresh Cascade on Feature Install

### DIFF
--- a/container/karaf/src/main/filtered-resources/etc/org.apache.karaf.features.cfg
+++ b/container/karaf/src/main/filtered-resources/etc/org.apache.karaf.features.cfg
@@ -143,6 +143,11 @@ featuresBoot = ( \
 featuresBootAsynchronous=false
 
 #
+# Define if the feature service automatically refreshes bundles
+#
+autoRefresh=false
+
+#
 # Service requirements enforcement
 #
 # By default, the feature resolver checks the service requirements/capabilities of

--- a/container/shared/src/main/filtered-resources/etc/org.apache.karaf.features.cfg
+++ b/container/shared/src/main/filtered-resources/etc/org.apache.karaf.features.cfg
@@ -78,6 +78,11 @@ featuresBoot = \
 featuresBootAsynchronous=false
 
 #
+# Define if the feature service automatically refreshes bundles
+#
+autoRefresh=false
+
+#
 # Service requirements enforcement
 #
 # By default, the feature resolver checks the service requirements/capabilities of

--- a/features/container/sentinel/src/main/filtered-resources/etc/org.apache.karaf.features.cfg
+++ b/features/container/sentinel/src/main/filtered-resources/etc/org.apache.karaf.features.cfg
@@ -75,6 +75,11 @@ featuresBoot = \
 featuresBootAsynchronous=false
 
 #
+# Define if the feature service automatically refreshes bundles
+#
+autoRefresh=false
+
+#
 # Service requirements enforcement
 #
 # By default, the feature resolver checks the service requirements/capabilities of

--- a/src/assembly/source.xml
+++ b/src/assembly/source.xml
@@ -20,6 +20,7 @@
         <exclude>**/.settings/**/*</exclude>
         <exclude>**/.DS_Store</exclude>
         <exclude>**/.idea</exclude>
+        <exclude>**/*.iml</exclude>
         <exclude>**/target</exclude>
         <exclude>**/target/**/*</exclude>
       </excludes>


### PR DESCRIPTION
Issue: https://issues.opennms.org/browse/NMS-13268

This PR configures Karaf such that bundles are not refreshed when features are installed. Without that change a bundle is stopped / started if a newly installed feature brings an optional dependency or a newer version of a dependency of that bundle. That seems to be unnecessary in case of OpenNMS Karaf setups.

In addition, this PR reformats two lines of code where the flaky `BMSTopologyIT.canChangeFocusWhenInSimulationMode` test randomly fails with a NPE. Next time that test failes, more precise NPE information may help to fix the flakiness of that test.