### PR TITLE
NMS-13736: fix xargs interaction with chown and ARG_MAX

### DIFF
--- a/opennms-base-assembly/src/main/filtered/bin/fix-permissions
+++ b/opennms-base-assembly/src/main/filtered/bin/fix-permissions
@@ -70,7 +70,10 @@ do_sudo() {
   if [ -x "$SUDO" ]; then
     "$SUDO" "$@"
   else
-    # if no sudo, fall back to running and hope for the best
+    # if no sudo, fall back to running as the current user
+    if [ "$(id -u -n)" != "root" ]; then
+      echo "WARNING: sudo was not located, but this script is not being run as root. This will probably fail."
+    fi
     "$@"
   fi
 }

--- a/opennms-base-assembly/src/main/filtered/bin/fix-permissions
+++ b/opennms-base-assembly/src/main/filtered/bin/fix-permissions
@@ -66,6 +66,15 @@ fi
 
 SUDO="$(command -v sudo 2>/dev/null || which sudo 2>/dev/null || :)"
 
+do_sudo() {
+  if [ -x "$SUDO" ]; then
+    "$SUDO" "$@"
+  else
+    # if no sudo, fall back to running and hope for the best
+    "$@"
+  fi
+}
+
 do_chown() {
   _mypath="$1"
 
@@ -75,18 +84,13 @@ do_chown() {
     exit 1
   fi
 
-  _chown=("chown")
-  if [ -x "$SUDO" ]; then
-    _chown=("$SUDO" "chown")
-  fi
-
   echo "* fixing ownership of ${_mypath}"
-  "${_chown[@]}" -h "${RUNAS_UID}:${RUNAS_GID}" "${_mypath}"
+  do_sudo chown -h "${RUNAS_UID}:${RUNAS_GID}" "${_mypath}"
   if [ "$RECURSE" -eq 1 ]; then
     echo "* fixing ownership of ${_mypath} contents"
     _count="$(find -L "${_mypath}" -mount ! -user "${RUNAS_UID}" | wc -l)"
     if [ "${_count}" -ge 1 ]; then
-      find -L "${_mypath}" -mount ! -user "${RUNAS_UID}" -print0 | xargs -0 "${_chown[@]}" "${RUNAS_UID}:${RUNAS_GID}"
+      find -L "${_mypath}" -mount ! -user "${RUNAS_UID}" -print0 | do_sudo xargs -0 chown "${RUNAS_UID}:${RUNAS_GID}"
     fi
   fi
 }

--- a/opennms-base-assembly/src/main/filtered/bin/update-package-permissions
+++ b/opennms-base-assembly/src/main/filtered/bin/update-package-permissions
@@ -43,19 +43,22 @@ if [ -z "${RUNAS_UID}" ] || [ -z "${RUNAS_GID}" ]; then
 fi
 
 SUDO="$(command -v sudo 2>/dev/null || which sudo 2>/dev/null || :)"
-CHOWN="chown ${RUNAS_UID}:${RUNAS_GID}"
-if [ -x "$SUDO" ]; then
-  CHOWN="$SUDO $CHOWN"
-fi
+
+do_sudo() {
+  if [ -x "$SUDO" ]; then
+    "$SUDO" "$@"
+  else
+    # if no sudo, fall back to running and hope for the best
+    "$@"
+  fi
+}
 
 # shellcheck disable=SC2086
 (if [ -e /etc/debian_version ]; then
   dpkg --listfiles "$PACKAGE";
 elif [ -e /etc/redhat-release ]; then
   rpm -ql "$PACKAGE";
-fi) | grep /opennms | while read -r FILE; do
-  $CHOWN "$FILE"
-done
+fi) | grep /opennms | do_sudo xargs chown "${RUNAS_UID}:${RUNAS_GID}"
 
 if [ ! -e /etc/debian_version ] && [ ! -e /etc/redhat-release ]; then
   echo "WARNING: not a Debian/Ubuntu or RedHat system -- check the contents of $OPENNMS_HOME is owned by $RUNAS."

--- a/opennms-base-assembly/src/main/filtered/bin/update-package-permissions
+++ b/opennms-base-assembly/src/main/filtered/bin/update-package-permissions
@@ -48,7 +48,10 @@ do_sudo() {
   if [ -x "$SUDO" ]; then
     "$SUDO" "$@"
   else
-    # if no sudo, fall back to running and hope for the best
+    # if no sudo, fall back to running as the current user
+    if [ "$(id -u -n)" != "root" ]; then
+      echo "WARNING: sudo was not located, but this script is not being run as root. This will probably fail."
+    fi
     "$@"
   fi
 }


### PR DESCRIPTION
@christianpape ran into a weird issue with "argument list too long" when running `chown` on the opennms share directory.
It turns out this comes from a strange interaction between argument limits when running `sudo` inside `xargs`, instead of the other way around.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-13736
