### PR TITLE
NMS-13747: split out wsman asset plugin

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -198,7 +198,7 @@ Description: Enterprise-grade Open-source Network Management Platform (Contrib)
 
 Package: opennms-plugins
 Architecture: all
-Depends: opennms-plugin-northbounder-jms (=${binary:Version}), opennms-plugin-provisioning-dns (=${binary:Version}), opennms-plugin-provisioning-reverse-dns (=${binary:Version}), opennms-plugin-provisioning-rancid (=${binary:Version}), opennms-plugin-provisioning-snmp-asset (=${binary:Version}), opennms-plugin-provisioning-snmp-hardware-inventory (=${binary:Version}), opennms-plugin-protocol-cifs (=${binary:Version}), opennms-plugin-protocol-nsclient (=${binary:Version}), opennms-plugin-protocol-radius (=${binary:Version}), opennms-plugin-protocol-xmp (=${binary:Version}), opennms-plugin-collector-vtdxml-handler (=${binary:Version}), opennms-plugin-ticketer-jira (=${binary:Version}), opennms-plugin-ticketer-otrs (=${binary:Version}), opennms-plugin-ticketer-rt (=${binary:Version})
+Depends: opennms-plugin-northbounder-jms (=${binary:Version}), opennms-plugin-provisioning-dns (=${binary:Version}), opennms-plugin-provisioning-reverse-dns (=${binary:Version}), opennms-plugin-provisioning-rancid (=${binary:Version}), opennms-plugin-provisioning-snmp-asset (=${binary:Version}), opennms-plugin-provisioning-snmp-hardware-inventory (=${binary:Version}), opennms-plugin-provisioning-wsman-asset (=${binary:Version}), opennms-plugin-protocol-cifs (=${binary:Version}), opennms-plugin-protocol-nsclient (=${binary:Version}), opennms-plugin-protocol-radius (=${binary:Version}), opennms-plugin-protocol-xmp (=${binary:Version}), opennms-plugin-collector-vtdxml-handler (=${binary:Version}), opennms-plugin-ticketer-jira (=${binary:Version}), opennms-plugin-ticketer-otrs (=${binary:Version}), opennms-plugin-ticketer-rt (=${binary:Version})
 Description: Enterprise-grade Open-source Network Management Platform (All Plugins)
  OpenNMS is an enterprise-grade network management system written in Java.
  .
@@ -306,6 +306,22 @@ Description: Enterprise-grade Open-source Network Management Platform (SNMP Hard
  The SNMP Hardware Inventory provisioning adapter responds to provisioning events by
  updating hardware fields with data fetched from the ENTITY-MIB and vendor extensions
  of this MIB.
+
+Package: opennms-plugin-provisioning-wsman-asset
+Architecture: all
+Depends: opennms-server (=${binary:Version})
+Replaces: opennms-common (<<${binary:Version}), , opennms-plugin-provisioning-snmp-asset (<<${binary:Version})
+Description: Enterprise-grade Open-source Network Management Platform (WS-Man Asset Provisioning Adapter)
+ OpenNMS is an enterprise-grade network management system written in Java.
+ .
+ OpenNMS can monitor various network services to determine status and service
+ level availability.  Data collection is performed using protocols such as SNMP
+ to generate reports and alert on thresholds.  An extensible event management
+ and notification system handles both internally and externally generated
+ events (such as SNMP traps), and generates notices via email, pager, SMS, etc.
+ .
+ The WSMan asset provisioning adapter responds to provisioning events by updating asset
+ fields with data fetched from WSMan requests.
 
 Package: opennms-plugin-protocol-cifs
 Architecture: all

--- a/debian/rules
+++ b/debian/rules
@@ -108,17 +108,18 @@ install: build
 	##
 	## Setup the provision adapter packages
 	##
-	install -d -m 755 debian/opennms-plugin-provisioning-{dns,link,map,rancid,reverse-dns,snmp-asset,snmp-hardware-inventory}/usr/share/java/opennms
-	install -d -m 755 debian/opennms-plugin-provisioning-{link,map,snmp-asset,snmp-hardware-inventory}/etc/opennms
-	install -d -m 755 debian/opennms-plugin-provisioning-{link,map,snmp-asset,snmp-hardware-inventory}/var/lib/opennms/etc-pristine
+	install -d -m 755 debian/opennms-plugin-provisioning-{dns,link,map,rancid,reverse-dns,snmp-asset,snmp-hardware-inventory,wsman-asset}/usr/share/java/opennms
+	install -d -m 755 debian/opennms-plugin-provisioning-{link,map,snmp-asset,snmp-hardware-inventory,wsman-asset}/etc/opennms
+	install -d -m 755 debian/opennms-plugin-provisioning-{link,map,snmp-asset,snmp-hardware-inventory,wsman-asset}/var/lib/opennms/etc-pristine
 	mv debian/temp/lib/opennms-dns-provisioning-adapter*.jar                 debian/opennms-plugin-provisioning-dns/usr/share/java/opennms/
 	mv debian/temp/lib/opennms-reverse-dns-provisioning-adapter*.jar         debian/opennms-plugin-provisioning-reverse-dns/usr/share/java/opennms/
 	mv debian/temp/lib/opennms-rancid-provisioning-adapter*.jar              debian/opennms-plugin-provisioning-rancid/usr/share/java/opennms/
 	mv debian/temp/lib/opennms-snmp-asset-provisioning-adapter*.jar          debian/opennms-plugin-provisioning-snmp-asset/usr/share/java/opennms/
-	mv debian/temp/lib/opennms-wsman-asset-provisioning-adapter*.jar         debian/opennms-plugin-provisioning-snmp-asset/usr/share/java/opennms/
 	mv debian/temp/lib/opennms-snmp-hardware-inventory-provisioning-adapter*.jar  debian/opennms-plugin-provisioning-snmp-hardware-inventory/usr/share/java/opennms/
+	mv debian/temp/lib/opennms-wsman-asset-provisioning-adapter*.jar         debian/opennms-plugin-provisioning-wsman-asset/usr/share/java/opennms/
 	mv debian/temp/etc/snmp-asset-adapter-configuration.xml                  debian/opennms-plugin-provisioning-snmp-asset/etc/opennms/
 	mv debian/temp/etc/snmp-hardware-inventory-adapter-configuration.xml     debian/opennms-plugin-provisioning-snmp-hardware-inventory/etc/opennms/
+	mv debian/temp/etc/wsman-asset-adapter-configuration.xml                 debian/opennms-plugin-provisioning-wsman-asset/etc/opennms/
 	find debian/opennms-plugin*/etc/opennms -type f -execdir chmod 644 {} \;
 	sed -e 's,@PACKAGE@,opennms-plugin-provisioning-dns,g' debian/package-permissions.sh > debian/opennms-plugin-provisioning-dns.postinst
 	sed -e 's,@PACKAGE@,opennms-plugin-provisioning-link,g' debian/package-permissions.sh > debian/opennms-plugin-provisioning-link.postinst
@@ -127,10 +128,12 @@ install: build
 	sed -e 's,@PACKAGE@,opennms-plugin-provisioning-reverse-dns,g' debian/package-permissions.sh > debian/opennms-plugin-provisioning-reverse-dns.postinst
 	sed -e 's,@PACKAGE@,opennms-plugin-provisioning-snmp-asset,g' debian/package-permissions.sh > debian/opennms-plugin-provisioning-snmp-asset.postinst
 	sed -e 's,@PACKAGE@,opennms-plugin-provisioning-snmp-hardware-inventory,g' debian/package-permissions.sh > debian/opennms-plugin-provisioning-snmp-hardware-inventory.postinst
+	sed -e 's,@PACKAGE@,opennms-plugin-provisioning-wsman-asset,g' debian/package-permissions.sh > debian/opennms-plugin-provisioning-wsman-asset.postinst
 	
 	# etc-pristine version
 	mv debian/opennms-common/var/lib/opennms/etc-pristine/snmp-asset-adapter-configuration.xml debian/opennms-plugin-provisioning-snmp-asset/var/lib/opennms/etc-pristine/
 	mv debian/opennms-common/var/lib/opennms/etc-pristine/snmp-hardware-inventory-adapter-configuration.xml debian/opennms-plugin-provisioning-snmp-hardware-inventory/var/lib/opennms/etc-pristine/
+	mv debian/opennms-common/var/lib/opennms/etc-pristine/wsman-asset-adapter-configuration.xml debian/opennms-plugin-provisioning-wsman-asset/var/lib/opennms/etc-pristine/
 	
 	##
 	## Setup the protocol packages


### PR DESCRIPTION
This PR splits the WSMan asset plugin into its own package, like the RPMs.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-13747
