### PR TITLE
get rid of log message initializing MockLogger

### DIFF
--- a/core/test-api/lib/src/main/java/org/opennms/core/test/MockLogger.java
+++ b/core/test-api/lib/src/main/java/org/opennms/core/test/MockLogger.java
@@ -123,7 +123,7 @@ public class MockLogger extends MarkerIgnoringBase {
     // Load properties file, if found.
     // Override with system properties.
     static void init() {
-        System.err.println("Initializing MockLogger.");
+        // System.err.println("Initializing MockLogger.");
 
         INITIALIZED = true;
         loadProperties();


### PR DESCRIPTION
I don't think this part is going to fail, given the 17 billion times it's been run, and it sure does add junk to the logs.