### PR TITLE
NMS-13748: fix $RUNAS logic in a number of places

### DIFF
--- a/opennms-base-assembly/src/main/filtered/bin/ensure-user-ping.sh
+++ b/opennms-base-assembly/src/main/filtered/bin/ensure-user-ping.sh
@@ -32,9 +32,8 @@ fi
 if [ -e "${OPENNMS_HOME}/etc/opennms.conf" ]; then
   # shellcheck disable=SC1090,SC1091
   . "${OPENNMS_HOME}/etc/opennms.conf"
-else
-  [ -z "$RUNAS" ] && RUNAS=opennms
 fi
+[ -z "$RUNAS" ] && RUNAS=opennms
 
 if [ -z "$PING_USER" ]; then
 	PING_USER="$RUNAS"

--- a/opennms-base-assembly/src/main/filtered/bin/fix-permissions
+++ b/opennms-base-assembly/src/main/filtered/bin/fix-permissions
@@ -38,12 +38,11 @@ fi
 if [ -e "${OPENNMS_HOME}/etc/opennms.conf" ]; then
   # shellcheck disable=SC1090,SC1091
   . "${OPENNMS_HOME}/etc/opennms.conf"
-else
-  [ -z "$RUNAS" ] && RUNAS=opennms
 fi
+[ -z "$RUNAS" ] && RUNAS=opennms
 
-if [ -z "${RUNAS}" ]; then
-  echo "Something is very wrong, \$RUNAS is not set. Bailing."
+if ! id -u "${RUNAS}" >/dev/null 2>&1; then
+  echo "Something is very wrong, \$RUNAS=${RUNAS} but that user does not exist. Bailing."
   exit 1
 fi
 

--- a/opennms-base-assembly/src/main/filtered/bin/runjava
+++ b/opennms-base-assembly/src/main/filtered/bin/runjava
@@ -40,29 +40,29 @@ if [ ! -d "${opennms_home}" ]; then
     opennms_home="$OPENNMS_HOME"
 fi
 
+# The user to run as
+[ -z "$RUNAS" ] && RUNAS=opennms
+
 if [ -e "${opennms_home}/bin/_lib.sh" ]; then
-	# The user to run as
-	[ -z "$RUNAS" ] && RUNAS=opennms
+    # shellcheck disable=SC1090,SC1091
+    . "${opennms_home}/bin/_lib.sh"
 
-	# shellcheck disable=SC1090,SC1091
-	. "${opennms_home}/bin/_lib.sh"
+    # Load opennms.conf, if it exists, to override $RUNAS
+    if [ -f "${opennms_home}/etc/opennms.conf" ]; then
+        # shellcheck disable=SC1090
+        __onms_read_conf "${opennms_home}/etc/opennms.conf"
+    fi
 
-	# Load opennms.conf, if it exists, to override $RUNAS
-	if [ -f "${opennms_home}/etc/opennms.conf" ]; then
-	        # shellcheck disable=SC1090
-	        __onms_read_conf "${opennms_home}/etc/opennms.conf"
-	fi
-
-	SUDO="$(command -v sudo 2>/dev/null || which sudo 2>/dev/null || :)"
-	myuser="$(id -u -n)"
-	if [ "$myuser" != "$RUNAS" ]; then
-	        if [ "$myuser" = "root" ] && [ -n "$SUDO" ] && [ -x "$SUDO" ]; then
-	                _cmd=("$SUDO" "-u" "$RUNAS" "$0" "${INCOMING_ARGS[@]}");
-	                exec "${_cmd[@]}"
-	        fi
-	        echo "ERROR: you must run this script as ${RUNAS}, not '${myuser}'." >&2
-	        exit 4 # According to LSB: 4 - user had insufficient privileges
-	fi
+    SUDO="$(command -v sudo 2>/dev/null || which sudo 2>/dev/null || :)"
+    myuser="$(id -u -n)"
+    if [ "$myuser" != "$RUNAS" ]; then
+        if [ "$myuser" = "root" ] && [ -n "$SUDO" ] && [ -x "$SUDO" ]; then
+            _cmd=("$SUDO" "-u" "$RUNAS" "$0" "${INCOMING_ARGS[@]}");
+            exec "${_cmd[@]}"
+        fi
+        echo "ERROR: you must run this script as ${RUNAS}, not '${myuser}'." >&2
+        exit 4 # According to LSB: 4 - user had insufficient privileges
+    fi
 fi
 
 minimum_version="11.0"

--- a/opennms-base-assembly/src/main/filtered/bin/update-package-permissions
+++ b/opennms-base-assembly/src/main/filtered/bin/update-package-permissions
@@ -19,12 +19,11 @@ fi
 if [ -e "${OPENNMS_HOME}/etc/opennms.conf" ]; then
   # shellcheck disable=SC1090,SC1091
   . "${OPENNMS_HOME}/etc/opennms.conf"
-else
-  [ -z "$RUNAS" ] && RUNAS=opennms
 fi
+[ -z "$RUNAS" ] && RUNAS=opennms
 
-if [ -z "${RUNAS}" ]; then
-  echo "Something is very wrong, \$RUNAS is not set. Bailing."
+if ! id -u "${RUNAS}" >/dev/null 2>&1; then
+  echo "Something is very wrong, \$RUNAS=${RUNAS} but that user does not exist. Bailing."
   exit 1
 fi
 

--- a/opennms-base-assembly/src/main/filtered/bin/upgrade
+++ b/opennms-base-assembly/src/main/filtered/bin/upgrade
@@ -7,13 +7,18 @@ JAVA_OPTIONS="-Xmx512m"
 OPENNMS_HOME="${install.dir}"
 [ -z "$RUNAS" ] && RUNAS=opennms
 
+if [ -f "$OPENNMS_HOME/etc/opennms.conf" ]; then
+	# shellcheck disable=SC1090,SC1091
+	. "$OPENNMS_HOME/etc/opennms.conf"
+fi
+
 SUDO="$(command -v sudo 2>/dev/null || which sudo 2>/dev/null || :)"
 myuser="$(id -u -n)"
 if [ "$myuser" != "$RUNAS" ]; then
 	if [ "$myuser" = "root" ] && [ -n "$SUDO" ] && [ -x "$SUDO" ]; then
-	        echo "WARNING: relaunching as $RUNAS" >&2
-	        _cmd=("$SUDO" "-u" "$RUNAS" "$0" "${INCOMING_ARGS[@]}");
-	        exec "${_cmd[@]}"
+		echo "WARNING: relaunching as $RUNAS" >&2
+		_cmd=("$SUDO" "-u" "$RUNAS" "$0" "${INCOMING_ARGS[@]}");
+		exec "${_cmd[@]}"
 	fi
 	echo "ERROR: you must run this script as ${RUNAS}, not '${myuser}'." >&2
 	echo "       Create or edit ${OPENNMS_HOME}/etc/opennms.conf and set 'RUNAS=${myuser}'" >&2


### PR DESCRIPTION
On upgrade, there could be cases where `opennms.conf` exists but does not contain a `RUNAS=` line, which would cause it no not be set at all.  This PR fixes that, and also cleans up the logic in a couple of other files.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-13748
