### PR TITLE
NMS-13771: Use ipInterfaceId as exporter key

### DIFF
--- a/features/flows/elastic/src/main/java/org/opennms/netmgt/flows/elastic/DocumentEnricher.java
+++ b/features/flows/elastic/src/main/java/org/opennms/netmgt/flows/elastic/DocumentEnricher.java
@@ -29,7 +29,6 @@
 package org.opennms.netmgt.flows.elastic;
 
 import java.net.InetAddress;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -45,6 +44,7 @@ import org.opennms.core.cache.CacheConfigBuilder;
 import org.opennms.core.rpc.utils.mate.ContextKey;
 import org.opennms.core.utils.InetAddressUtils;
 import org.opennms.netmgt.dao.api.InterfaceToNodeCache;
+import org.opennms.netmgt.dao.api.IpInterfaceDao;
 import org.opennms.netmgt.dao.api.NodeDao;
 import org.opennms.netmgt.dao.api.SessionUtils;
 import org.opennms.netmgt.flows.api.Flow;
@@ -53,6 +53,7 @@ import org.opennms.netmgt.flows.classification.ClassificationEngine;
 import org.opennms.netmgt.flows.classification.ClassificationRequest;
 import org.opennms.netmgt.flows.classification.persistence.api.Protocols;
 import org.opennms.netmgt.model.OnmsCategory;
+import org.opennms.netmgt.model.OnmsIpInterface;
 import org.opennms.netmgt.model.OnmsNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -69,6 +70,8 @@ public class DocumentEnricher {
 
     private final NodeDao nodeDao;
 
+    private final IpInterfaceDao ipInterfaceDao;
+
     private final InterfaceToNodeCache interfaceToNodeCache;
 
     private final SessionUtils sessionUtils;
@@ -76,7 +79,7 @@ public class DocumentEnricher {
     private final ClassificationEngine classificationEngine;
 
     // Caches NodeDocument data for a given node Id.
-    private final Cache<Integer, Optional<NodeDocument>> nodeInfoCache;
+    private final Cache<InterfaceToNodeCache.Entry, Optional<NodeDocument>> nodeInfoCache;
 
     // Caches NodeDocument data for a given node metadata.
     private final Cache<NodeMetadataKey, Optional<NodeDocument>> nodeMetadataCache;
@@ -85,21 +88,26 @@ public class DocumentEnricher {
 
     private final long clockSkewCorrectionThreshold;
 
-    public DocumentEnricher(MetricRegistry metricRegistry, NodeDao nodeDao, InterfaceToNodeCache interfaceToNodeCache,
-                            SessionUtils sessionUtils, ClassificationEngine classificationEngine,
+    public DocumentEnricher(MetricRegistry metricRegistry,
+                            NodeDao nodeDao,
+                            IpInterfaceDao ipInterfaceDao,
+                            InterfaceToNodeCache interfaceToNodeCache,
+                            SessionUtils sessionUtils,
+                            ClassificationEngine classificationEngine,
                             CacheConfig cacheConfig,
                             final long clockSkewCorrectionThreshold) {
         this.nodeDao = Objects.requireNonNull(nodeDao);
+        this.ipInterfaceDao = Objects.requireNonNull(ipInterfaceDao);
         this.interfaceToNodeCache = Objects.requireNonNull(interfaceToNodeCache);
         this.sessionUtils = Objects.requireNonNull(sessionUtils);
         this.classificationEngine = Objects.requireNonNull(classificationEngine);
 
         this.nodeInfoCache = new CacheBuilder()
                 .withConfig(cacheConfig)
-                .withCacheLoader(new CacheLoader<Integer, Optional<NodeDocument>>() {
+                .withCacheLoader(new CacheLoader<InterfaceToNodeCache.Entry, Optional<NodeDocument>>() {
                     @Override
-                    public Optional<NodeDocument> load(Integer nodeId) {
-                        return getNodeInfo(nodeId);
+                    public Optional<NodeDocument> load(InterfaceToNodeCache.Entry entry) {
+                        return getNodeInfo(entry);
                     }
                 }).build();
 
@@ -190,7 +198,6 @@ public class DocumentEnricher {
     }
 
     private Optional<NodeDocument> getNodeInfoFromCache(final String location, final String ipAddress, final ContextKey contextKey, final String value) {
-
         Optional<NodeDocument> nodeDocument = Optional.empty();
         if (contextKey != null && !Strings.isNullOrEmpty(value)) {
             final NodeMetadataKey metadataKey = new NodeMetadataKey(contextKey, value);
@@ -205,10 +212,10 @@ public class DocumentEnricher {
             }
         }
 
-        final Optional<Integer> nodeId = interfaceToNodeCache.getFirstNodeId(location, InetAddressUtils.addr(ipAddress));
-        if(nodeId.isPresent()) {
+        final var entry = interfaceToNodeCache.getFirst(location, InetAddressUtils.addr(ipAddress));
+        if(entry.isPresent()) {
             try {
-                return nodeInfoCache.get(nodeId.get());
+                return nodeInfoCache.get(entry.get());
             } catch (ExecutionException e) {
                 LOG.error("Error while retrieving NodeDocument from NodeInfoCache: {}.", e.getMessage(), e);
                 throw new RuntimeException(e);
@@ -246,33 +253,45 @@ public class DocumentEnricher {
     }
 
     private Optional<NodeDocument> getNodeInfoFromMetadataContext(ContextKey contextKey, String value) {
-        List<OnmsNode> nodes = new ArrayList<>();
+        // First, try to find interface
+        final List<OnmsIpInterface> ifaces;
+        try (Timer.Context ctx = nodeLoadTimer.time()) {
+            ifaces = this.ipInterfaceDao.findInterfacesWithMetadata(contextKey.getContext(), contextKey.getKey(), value);
+        }
+        if (!ifaces.isEmpty()) {
+            final var iface = ifaces.get(0);
+            return mapOnmsNodeToNodeDocument(iface.getNode(), iface.getId());
+        }
+
+        // Alternatively, try to find node and chose primary interface
+        final List<OnmsNode> nodes;
         try (Timer.Context ctx = nodeLoadTimer.time()) {
             nodes = nodeDao.findNodeWithMetaData(contextKey.getContext(), contextKey.getKey(), value);
         }
-        if(nodes.isEmpty()) {
-            return Optional.empty();
+        if(!nodes.isEmpty()) {
+            final var node = nodes.get(0);
+            return mapOnmsNodeToNodeDocument(node, node.getPrimaryInterface().getId());
         }
-        return mapOnmsNodeToNodeDocument(nodes.get(0));
+
+        return Optional.empty();
     }
 
-    private Optional<NodeDocument> getNodeInfo(Integer nodeId) {
-        OnmsNode onmsNode = null;
+    private Optional<NodeDocument> getNodeInfo(final InterfaceToNodeCache.Entry entry) {
+        final OnmsNode onmsNode;
         try (Timer.Context ctx = nodeLoadTimer.time()) {
-            onmsNode = nodeDao.get(nodeId);
+            onmsNode = nodeDao.get(entry.nodeId);
         }
 
-        return mapOnmsNodeToNodeDocument(onmsNode);
-
+        return mapOnmsNodeToNodeDocument(onmsNode, entry.interfaceId);
     }
 
-    private Optional<NodeDocument> mapOnmsNodeToNodeDocument(OnmsNode onmsNode) {
-
+    private Optional<NodeDocument> mapOnmsNodeToNodeDocument(final OnmsNode onmsNode, final int interfaceId) {
         if(onmsNode != null) {
             final NodeDocument nodeDocument = new NodeDocument();
             nodeDocument.setForeignSource(onmsNode.getForeignSource());
             nodeDocument.setForeignId(onmsNode.getForeignId());
             nodeDocument.setNodeId(onmsNode.getId());
+            nodeDocument.setInterfaceId(interfaceId);
             nodeDocument.setCategories(onmsNode.getCategories().stream().map(OnmsCategory::getName).collect(Collectors.toList()));
 
             return Optional.of(nodeDocument);

--- a/features/flows/elastic/src/main/java/org/opennms/netmgt/flows/elastic/NodeDocument.java
+++ b/features/flows/elastic/src/main/java/org/opennms/netmgt/flows/elastic/NodeDocument.java
@@ -43,6 +43,9 @@ public class NodeDocument {
     @SerializedName("node_id")
     private Integer nodeId;
 
+    @SerializedName("interface_id")
+    private Integer interfaceId;
+
     @SerializedName("categories")
     private List<String> categories = new LinkedList<>();
 
@@ -68,6 +71,14 @@ public class NodeDocument {
 
     public void setNodeId(Integer nodeId) {
         this.nodeId = nodeId;
+    }
+
+    public Integer getInterfaceId() {
+        return this.interfaceId;
+    }
+
+    public void setInterfaceId(final Integer interfaceId) {
+        this.interfaceId = interfaceId;
     }
 
     public List<String> getCategories() {

--- a/features/flows/elastic/src/main/java/org/opennms/netmgt/flows/elastic/thresholding/ApplicationKey.java
+++ b/features/flows/elastic/src/main/java/org/opennms/netmgt/flows/elastic/thresholding/ApplicationKey.java
@@ -31,14 +31,14 @@ package org.opennms.netmgt.flows.elastic.thresholding;
 import java.util.Objects;
 
 public class ApplicationKey {
-    public final int nodeId;
+    public final ExporterKey exporterKey;
     public final int iface;
     public final String application;
 
-    public ApplicationKey(final int nodeId,
+    public ApplicationKey(final ExporterKey exporterKey,
                           final int iface,
                           final String application) {
-        this.nodeId = nodeId;
+        this.exporterKey = Objects.requireNonNull(exporterKey);
         this.iface = iface;
         this.application = Objects.requireNonNull(application);
     }
@@ -52,14 +52,14 @@ public class ApplicationKey {
             return false;
         }
         final ApplicationKey that = (ApplicationKey) o;
-        return Objects.equals(this.nodeId, that.nodeId) &&
+        return Objects.equals(this.exporterKey, that.exporterKey) &&
                Objects.equals(this.iface, that.iface) &&
                Objects.equals(this.application, that.application);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(this.nodeId,
+        return Objects.hash(this.exporterKey,
                             this.iface,
                             this.application);
     }

--- a/features/flows/elastic/src/main/java/org/opennms/netmgt/flows/elastic/thresholding/ExporterKey.java
+++ b/features/flows/elastic/src/main/java/org/opennms/netmgt/flows/elastic/thresholding/ExporterKey.java
@@ -30,13 +30,11 @@ package org.opennms.netmgt.flows.elastic.thresholding;
 
 import java.util.Objects;
 
-public class NodeInterfaceKey {
-    public final int nodeId;
-    public final String ifaceAddr;
+public class ExporterKey {
+    public final int interfaceId;
 
-    public NodeInterfaceKey(final int nodeId, final String ifaceAddr) {
-        this.nodeId = nodeId;
-        this.ifaceAddr = Objects.requireNonNull(ifaceAddr);
+    public ExporterKey(final int interfaceId) {
+        this.interfaceId = interfaceId;
     }
 
     @Override
@@ -44,16 +42,15 @@ public class NodeInterfaceKey {
         if (this == o) {
             return true;
         }
-        if (!(o instanceof NodeInterfaceKey)) {
+        if (!(o instanceof ExporterKey)) {
             return false;
         }
-        final NodeInterfaceKey that = (NodeInterfaceKey) o;
-        return Objects.equals(this.nodeId, that.nodeId) &&
-               Objects.equals(this.ifaceAddr, that.ifaceAddr);
+        final ExporterKey that = (ExporterKey) o;
+        return Objects.equals(this.interfaceId, that.interfaceId);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(this.nodeId, this.ifaceAddr);
+        return Objects.hash(this.interfaceId);
     }
 }

--- a/features/flows/elastic/src/main/java/org/opennms/netmgt/flows/elastic/thresholding/FlowThresholding.java
+++ b/features/flows/elastic/src/main/java/org/opennms/netmgt/flows/elastic/thresholding/FlowThresholding.java
@@ -29,6 +29,7 @@
 package org.opennms.netmgt.flows.elastic.thresholding;
 
 import java.util.Collections;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -56,6 +57,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Strings;
+import com.google.common.cache.CacheLoader;
 import com.google.common.collect.Maps;
 
 public class FlowThresholding {
@@ -90,6 +92,12 @@ public class FlowThresholding {
         //noinspection unchecked
         this.sessions = new CacheBuilder<ExporterKey, Session>()
                 .withConfig(sessionCacheConfig)
+                .withCacheLoader(new CacheLoader<ExporterKey, Session>() {
+                    @Override
+                    public Session load(final ExporterKey key) throws Exception {
+                        throw new IllegalStateException();
+                    }
+                })
                 .build();
     }
 
@@ -131,6 +139,7 @@ public class FlowThresholding {
                 final var appResource = new DeferredGenericTypeResource(nodeResource, RESOURCE_TYPE_NAME, document.getApplication());
 
                 final var collectionSetBuilder = new CollectionSetBuilder(session.collectionAgent)
+                        .withTimestamp(new Date(document.getTimestamp()))
                         .withCounter(appResource, document.getApplication(), "bytes", counter);
                 // TODO fooker: Set sequence number from flow to aid distributed thresholding
 

--- a/features/flows/elastic/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/features/flows/elastic/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -137,6 +137,7 @@
     <!-- Enrichment -->
     <reference id="interfaceToNodeCache" interface="org.opennms.netmgt.dao.api.InterfaceToNodeCache" availability="mandatory" />
     <reference id="nodeDao" interface="org.opennms.netmgt.dao.api.NodeDao" availability="mandatory" />
+    <reference id="ipInterfaceDao" interface="org.opennms.netmgt.dao.api.IpInterfaceDao" availability="mandatory" />
     <reference id="snmpInterfaceDao" interface="org.opennms.netmgt.dao.api.SnmpInterfaceDao" availability="mandatory" />
     <reference id="sessionUtils" interface="org.opennms.netmgt.dao.api.SessionUtils" availability="mandatory" />
     <reference id="classificationEngine" interface="org.opennms.netmgt.flows.classification.ClassificationEngine" availability="mandatory" />
@@ -226,6 +227,7 @@
     <bean id="flowThresholding" class="org.opennms.netmgt.flows.elastic.thresholding.FlowThresholding" >
         <argument ref="thresholdingService"/>
         <argument ref="collectionAgentFactory"/>
+        <argument ref="ipInterfaceDao"/>
         <argument ref="thresholdingCacheConfig"/>
     </bean>
 

--- a/features/flows/elastic/src/test/java/org/opennms/netmgt/flows/elastic/MockDocumentEnricherFactory.java
+++ b/features/flows/elastic/src/test/java/org/opennms/netmgt/flows/elastic/MockDocumentEnricherFactory.java
@@ -37,12 +37,14 @@ import org.opennms.core.soa.support.DefaultServiceRegistry;
 import org.opennms.netmgt.dao.api.AssetRecordDao;
 import org.opennms.netmgt.dao.api.CategoryDao;
 import org.opennms.netmgt.dao.api.InterfaceToNodeCache;
+import org.opennms.netmgt.dao.api.IpInterfaceDao;
 import org.opennms.netmgt.dao.api.NodeDao;
 import org.opennms.netmgt.dao.api.OnmsDao;
 import org.opennms.netmgt.dao.mock.AbstractMockDao;
 import org.opennms.netmgt.dao.mock.MockAssetRecordDao;
 import org.opennms.netmgt.dao.mock.MockCategoryDao;
 import org.opennms.netmgt.dao.mock.MockInterfaceToNodeCache;
+import org.opennms.netmgt.dao.mock.MockIpInterfaceDao;
 import org.opennms.netmgt.dao.mock.MockNodeDao;
 import org.opennms.netmgt.dao.mock.MockSessionUtils;
 import org.opennms.netmgt.flows.classification.ClassificationEngine;
@@ -56,6 +58,7 @@ import com.google.common.collect.Lists;
 public class MockDocumentEnricherFactory {
 
     private final NodeDao nodeDao;
+    private final IpInterfaceDao ipInterfaceDao;
     private final InterfaceToNodeCache interfaceToNodeCache;
     private final MockAssetRecordDao assetRecordDao;
     private final MockCategoryDao categoryDao;
@@ -70,6 +73,7 @@ public class MockDocumentEnricherFactory {
 
     public MockDocumentEnricherFactory(final long clockSkewCorrectionThreshold) throws InterruptedException {
         nodeDao = createNodeDao();
+        ipInterfaceDao = new MockIpInterfaceDao();
         interfaceToNodeCache = new MockInterfaceToNodeCache();
         assetRecordDao = new MockAssetRecordDao();
         categoryDao = new MockCategoryDao();
@@ -81,7 +85,9 @@ public class MockDocumentEnricherFactory {
                 new RuleBuilder().withName("https").withSrcPort("443").withProtocol("tcp,udp").build()
         ), FilterService.NOOP);
         enricher = new DocumentEnricher(
-                new MetricRegistry(), nodeDao, interfaceToNodeCache, new MockSessionUtils(), classificationEngine,
+                new MetricRegistry(),
+                nodeDao, ipInterfaceDao,
+                interfaceToNodeCache, new MockSessionUtils(), classificationEngine,
                 new CacheConfigBuilder()
                     .withName("flows.node")
                     .withMaximumSize(1000)

--- a/features/flows/elastic/src/test/resources/flow-document-netflow5.json
+++ b/features/flows/elastic/src/test/resources/flow-document-netflow5.json
@@ -46,6 +46,7 @@
     "foreign_source": "SomeRequisition",
     "foreign_id": "2",
     "node_id": 2,
+    "interface_id": 0,
     "categories": [
       "SomeCategory"
     ]
@@ -54,6 +55,7 @@
     "foreign_source": "SomeRequisition",
     "foreign_id": "3",
     "node_id": 3,
+    "interface_id": 0,
     "categories": [
       "SomeCategory"
     ]
@@ -62,6 +64,7 @@
     "foreign_source": "SomeRequisition",
     "foreign_id": "1",
     "node_id": 1,
+    "interface_id": 0,
     "categories": [
       "SomeCategory"
     ]

--- a/features/flows/itests/src/test/java/org/opennms/netmgt/flows/elastic/MarkerCacheIT.java
+++ b/features/flows/itests/src/test/java/org/opennms/netmgt/flows/elastic/MarkerCacheIT.java
@@ -58,6 +58,7 @@ import org.opennms.features.jest.client.index.IndexStrategy;
 import org.opennms.features.jest.client.template.IndexSettings;
 import org.opennms.netmgt.dao.DatabasePopulator;
 import org.opennms.netmgt.dao.api.InterfaceToNodeCache;
+import org.opennms.netmgt.dao.api.IpInterfaceDao;
 import org.opennms.netmgt.dao.api.MonitoringLocationDao;
 import org.opennms.netmgt.dao.api.NodeDao;
 import org.opennms.netmgt.dao.api.SessionUtils;
@@ -105,6 +106,9 @@ public class MarkerCacheIT {
 
     @Autowired
     private NodeDao nodeDao;
+
+    @Autowired
+    private IpInterfaceDao ipInterfaceDao;
 
     @Autowired
     private SnmpInterfaceDao snmpInterfaceDao;
@@ -158,7 +162,9 @@ public class MarkerCacheIT {
         ), FilterService.NOOP);
 
         final DocumentEnricher documentEnricher = new DocumentEnricher(
-                new MetricRegistry(), nodeDao, interfaceToNodeCache, sessionUtils, classificationEngine,
+                new MetricRegistry(),
+                nodeDao, ipInterfaceDao,
+                interfaceToNodeCache, sessionUtils, classificationEngine,
                 new CacheConfigBuilder()
                         .withName("flows.node")
                         .withMaximumSize(1000)
@@ -201,7 +207,9 @@ public class MarkerCacheIT {
         ), FilterService.NOOP);
 
         final DocumentEnricher documentEnricher = new DocumentEnricher(
-                new MetricRegistry(), nodeDao, interfaceToNodeCache, sessionUtils, classificationEngine,
+                new MetricRegistry(),
+                nodeDao, ipInterfaceDao,
+                interfaceToNodeCache, sessionUtils, classificationEngine,
                 new CacheConfigBuilder()
                         .withName("flows.node")
                         .withMaximumSize(1000)
@@ -245,7 +253,9 @@ public class MarkerCacheIT {
         ), FilterService.NOOP);
 
         final DocumentEnricher documentEnricher = new DocumentEnricher(
-                new MetricRegistry(), nodeDao, interfaceToNodeCache, sessionUtils, classificationEngine,
+                new MetricRegistry(),
+                nodeDao, ipInterfaceDao,
+                interfaceToNodeCache, sessionUtils, classificationEngine,
                 new CacheConfigBuilder()
                         .withName("flows.node")
                         .withMaximumSize(1000)

--- a/features/flows/itests/src/test/java/org/opennms/netmgt/flows/elastic/NodeIdentificationIT.java
+++ b/features/flows/itests/src/test/java/org/opennms/netmgt/flows/elastic/NodeIdentificationIT.java
@@ -108,7 +108,9 @@ public class NodeIdentificationIT {
     public void testSomething() throws InterruptedException {
         final ClassificationEngine classificationEngine = new DefaultClassificationEngine(() -> Collections.emptyList(), FilterService.NOOP);
         final DocumentEnricher documentEnricher = new DocumentEnricher(
-                new MetricRegistry(), databasePopulator.getNodeDao(), interfaceToNodeCache, sessionUtils, classificationEngine,
+                new MetricRegistry(),
+                databasePopulator.getNodeDao(), databasePopulator.getIpInterfaceDao(),
+                interfaceToNodeCache, sessionUtils, classificationEngine,
                 new CacheConfigBuilder()
                         .withName("flows.node")
                         .withMaximumSize(1000)

--- a/features/flows/itests/src/test/java/org/opennms/netmgt/flows/elastic/ThresholdingIT.java
+++ b/features/flows/itests/src/test/java/org/opennms/netmgt/flows/elastic/ThresholdingIT.java
@@ -55,17 +55,6 @@ import org.opennms.netmgt.collectd.DefaultResourceTypeMapper;
 import org.opennms.netmgt.collection.core.DefaultCollectionAgentFactory;
 import org.opennms.netmgt.config.dao.thresholding.api.OverrideableThreshdDao;
 import org.opennms.netmgt.config.dao.thresholding.api.OverrideableThresholdingDao;
-import org.opennms.netmgt.config.threshd.Filter;
-import org.opennms.netmgt.config.threshd.Group;
-import org.opennms.netmgt.config.threshd.IncludeRange;
-import org.opennms.netmgt.config.threshd.Package;
-import org.opennms.netmgt.config.threshd.Parameter;
-import org.opennms.netmgt.config.threshd.Service;
-import org.opennms.netmgt.config.threshd.ServiceStatus;
-import org.opennms.netmgt.config.threshd.ThreshdConfiguration;
-import org.opennms.netmgt.config.threshd.Threshold;
-import org.opennms.netmgt.config.threshd.ThresholdType;
-import org.opennms.netmgt.config.threshd.ThresholdingConfig;
 import org.opennms.netmgt.dao.DatabasePopulator;
 import org.opennms.netmgt.dao.api.InterfaceToNodeCache;
 import org.opennms.netmgt.dao.mock.MockEventIpcManager;
@@ -188,6 +177,7 @@ public class ThresholdingIT {
 
         final var documentEnricher = new DocumentEnricher(metricRegistry,
                                                           this.databasePopulator.getNodeDao(),
+                                                          this.databasePopulator.getIpInterfaceDao(),
                                                           this.interfaceToNodeCache,
                                                           sessionUtils,
                                                           classificationEngine,
@@ -214,6 +204,7 @@ public class ThresholdingIT {
                 .build();
         final var thresholding = new FlowThresholding(this.thresholdingService,
                                                       collectionAgentFactory,
+                                                      this.databasePopulator.getIpInterfaceDao(),
                                                       sessionCacheConfig);
 
         final var elasticFlowRepository = new ElasticFlowRepository(

--- a/features/flows/itests/src/test/java/org/opennms/netmgt/flows/elastic/ThresholdingIT.java
+++ b/features/flows/itests/src/test/java/org/opennms/netmgt/flows/elastic/ThresholdingIT.java
@@ -141,9 +141,12 @@ public class ThresholdingIT {
     }
 
     private List<Flow> createMockedFlows(final int count) {
+        final var now = System.currentTimeMillis();
+
         final List<Flow> flows = new ArrayList<>(count);
         for (int i = 0; i < count; i++) {
             final FlowDocument flowDocument = new FlowDocument();
+            flowDocument.setTimestamp(now + i * 1000L);
             flowDocument.setIpProtocolVersion(4);
             flowDocument.setInputSnmp(10);
             flowDocument.setOutputSnmp(20);
@@ -152,7 +155,7 @@ public class ThresholdingIT {
             flowDocument.setSrcPort(1);
             flowDocument.setDstPort(2);
             flowDocument.setProtocol(6);
-            flowDocument.setBytes(1024L);
+            flowDocument.setBytes(1024L * (count - i));
             flowDocument.setDirection(Direction.INGRESS);
 
             final TestFlow flow = new TestFlow(flowDocument);

--- a/opennms-dao-api/src/main/java/org/opennms/netmgt/dao/api/AbstractInterfaceToNodeCache.java
+++ b/opennms-dao-api/src/main/java/org/opennms/netmgt/dao/api/AbstractInterfaceToNodeCache.java
@@ -28,9 +28,6 @@
 
 package org.opennms.netmgt.dao.api;
 
-import java.net.InetAddress;
-import java.util.Iterator;
-import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
@@ -56,13 +53,4 @@ public abstract class AbstractInterfaceToNodeCache implements InterfaceToNodeCac
     public static InterfaceToNodeCache getInstance() {
         return s_instance.get(); 
     }
-
-    public Optional<Integer> getFirstNodeId(String location, InetAddress ipAddr) {
-		final Iterator<Integer> it = this.getNodeId(location, ipAddr).iterator();
-		if (it.hasNext()) {
-			return Optional.of(it.next());
-		} else {
-			return Optional.empty();
-		}
-	}
 }

--- a/opennms-dao-api/src/main/java/org/opennms/netmgt/dao/api/InterfaceToNodeCache.java
+++ b/opennms-dao-api/src/main/java/org/opennms/netmgt/dao/api/InterfaceToNodeCache.java
@@ -98,7 +98,7 @@ public interface InterfaceToNodeCache {
 		@Override
 		public int hashCode() {
 			return Objects.hash(this.nodeId,
-								this.interfaceId);
+			                    this.interfaceId);
 		}
 	}
 }

--- a/opennms-dao-mock/src/main/java/org/opennms/netmgt/dao/mock/MockInterfaceToNodeCache.java
+++ b/opennms-dao-mock/src/main/java/org/opennms/netmgt/dao/mock/MockInterfaceToNodeCache.java
@@ -40,23 +40,23 @@ import com.google.common.collect.Maps;
 
 public class MockInterfaceToNodeCache extends AbstractInterfaceToNodeCache {
 
-    private Map<Key, Integer> keyToNodeId = Maps.newHashMap();
+    private Map<Key, Entry> keyToEntry = Maps.newHashMap();
 
     @Override
     public boolean setNodeId(String location, InetAddress ipAddr, int nodeId) {
-        return keyToNodeId.put(new Key(location, ipAddr), nodeId) != null;
+        return keyToEntry.put(new Key(location, ipAddr), new Entry(nodeId, 0)) != null;
     }
 
     @Override
     public boolean removeNodeId(String location, InetAddress ipAddr, int nodeId) {
-        return keyToNodeId.remove(new Key(location, ipAddr)) != null;
+        return keyToEntry.remove(new Key(location, ipAddr)) != null;
     }
 
     @Override
-    public Iterable<Integer> getNodeId(String location, InetAddress ipAddr) {
-        final Integer nodeId = keyToNodeId.get(new Key(location, ipAddr));
-        if (nodeId != null) {
-            return Arrays.asList(nodeId);
+    public Iterable<Entry> get(String location, InetAddress ipAddr) {
+        final var entry = keyToEntry.get(new Key(location, ipAddr));
+        if (entry != null) {
+            return Arrays.asList(entry);
         }
         return Collections.emptySet();
     }
@@ -65,11 +65,11 @@ public class MockInterfaceToNodeCache extends AbstractInterfaceToNodeCache {
     public void dataSourceSync() {}
 
     @Override
-    public int size() { return keyToNodeId.size(); }
+    public int size() { return keyToEntry.size(); }
 
     @Override
     public void clear() {
-        keyToNodeId.clear();
+        keyToEntry.clear();
     }
 
     @Override

--- a/opennms-dao/src/main/java/org/opennms/netmgt/dao/hibernate/InterfaceToNodeCacheDaoImpl.java
+++ b/opennms-dao/src/main/java/org/opennms/netmgt/dao/hibernate/InterfaceToNodeCacheDaoImpl.java
@@ -377,7 +377,7 @@ public class InterfaceToNodeCacheDaoImpl extends AbstractInterfaceToNodeCache im
         m_lock.writeLock().lock();
         try {
             final Key key = new Key(location, address);
-            return !m_managedAddresses.removeAll(key).isEmpty();
+            return m_managedAddresses.get(key).removeIf(e -> e.nodeId == nodeId);
         } finally {
             m_lock.writeLock().unlock();
         }

--- a/opennms-dao/src/main/java/org/opennms/netmgt/dao/hibernate/InterfaceToNodeCacheDaoImpl.java
+++ b/opennms-dao/src/main/java/org/opennms/netmgt/dao/hibernate/InterfaceToNodeCacheDaoImpl.java
@@ -313,7 +313,7 @@ public class InterfaceToNodeCacheDaoImpl extends AbstractInterfaceToNodeCache im
      * management priority.
      *
      * @param address The IP Address to query.
-     * @return The Entry for the IP Address if known.
+     * @return The entry for the IP Address if known.
      */
     @Override
     public synchronized Iterable<Entry> get(final String location, final InetAddress address) {


### PR DESCRIPTION
This extends the InterfaceToNodeCache to store the actual ipInterfaceId
of the interface to be used to identify the node. In addition, the
interface ID is added to the elasticsearch document.

The ipInterfaceId ultimatively identifies an exporter and is therefor
used for per-exporter caching.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-13771

