### PR TITLE
NMS-13507: Speedup node link derivations

### DIFF
--- a/features/enlinkd/persistence/api/src/main/java/org/opennms/netmgt/enlinkd/persistence/api/IpNetToMediaDao.java
+++ b/features/enlinkd/persistence/api/src/main/java/org/opennms/netmgt/enlinkd/persistence/api/IpNetToMediaDao.java
@@ -62,5 +62,5 @@ public interface IpNetToMediaDao extends OnmsDao<IpNetToMedia, Integer> {
      * @param nodeId
      * @return
      */
-    List<IpNetToMedia> findByMacLinkOfNode(Integer nodeId);
+    List<IpNetToMedia> findByMacLinksOfNode(Integer nodeId);
 }

--- a/features/enlinkd/persistence/api/src/main/java/org/opennms/netmgt/enlinkd/persistence/api/IpNetToMediaDao.java
+++ b/features/enlinkd/persistence/api/src/main/java/org/opennms/netmgt/enlinkd/persistence/api/IpNetToMediaDao.java
@@ -56,4 +56,11 @@ public interface IpNetToMediaDao extends OnmsDao<IpNetToMedia, Integer> {
     
     public void deleteBySourceNodeId(Integer nodeId);
 
+    /**
+     * Finds all {@link IpNetToMedia} instances that have a physical address that is equal to the mac address
+     * of a {@code BridgeMacLink} of the addressed {@code node}.
+     * @param nodeId
+     * @return
+     */
+    List<IpNetToMedia> findByMacLinkOfNode(Integer nodeId);
 }

--- a/features/enlinkd/persistence/impl/src/main/java/org/opennms/netmgt/enlinkd/persistence/impl/IpNetToMediaDaoHibernate.java
+++ b/features/enlinkd/persistence/impl/src/main/java/org/opennms/netmgt/enlinkd/persistence/impl/IpNetToMediaDaoHibernate.java
@@ -32,9 +32,9 @@ import java.net.InetAddress;
 import java.util.Date;
 import java.util.List;
 
-import org.opennms.netmgt.enlinkd.persistence.api.IpNetToMediaDao;
 import org.opennms.netmgt.dao.hibernate.AbstractDaoHibernate;
 import org.opennms.netmgt.enlinkd.model.IpNetToMedia;
+import org.opennms.netmgt.enlinkd.persistence.api.IpNetToMediaDao;
 
 
 public class IpNetToMediaDaoHibernate extends AbstractDaoHibernate<IpNetToMedia, Integer> implements IpNetToMediaDao {
@@ -79,6 +79,8 @@ public class IpNetToMediaDaoHibernate extends AbstractDaoHibernate<IpNetToMedia,
 		return find("from IpNetToMedia rec where rec.netAddress = ? ", netAddress);
 	}
 
-
-
+	@Override
+	public List<IpNetToMedia> findByMacLinkOfNode(Integer nodeId) {
+		return find("from IpNetToMedia m where m.physAddress in (select l.macAddress from BridgeMacLink l where l.node.id = ?)",  nodeId);
+	}
 }

--- a/features/enlinkd/persistence/impl/src/main/java/org/opennms/netmgt/enlinkd/persistence/impl/IpNetToMediaDaoHibernate.java
+++ b/features/enlinkd/persistence/impl/src/main/java/org/opennms/netmgt/enlinkd/persistence/impl/IpNetToMediaDaoHibernate.java
@@ -80,7 +80,7 @@ public class IpNetToMediaDaoHibernate extends AbstractDaoHibernate<IpNetToMedia,
 	}
 
 	@Override
-	public List<IpNetToMedia> findByMacLinkOfNode(Integer nodeId) {
+	public List<IpNetToMedia> findByMacLinksOfNode(Integer nodeId) {
 		return find("from IpNetToMedia m where m.physAddress in (select l.macAddress from BridgeMacLink l where l.node.id = ?)",  nodeId);
 	}
 }

--- a/opennms-config/src/main/java/org/opennms/netmgt/filter/JdbcFilterDao.java
+++ b/opennms-config/src/main/java/org/opennms/netmgt/filter/JdbcFilterDao.java
@@ -380,7 +380,7 @@ public class JdbcFilterDao implements FilterDao, InitializingBean {
             d.cleanUp();
         }
 
-        LOG.debug("Filter.getIPAddressList({}): resultList = {}", rule, resultList);
+        LOG.debug("Filter.getIPAddressList({}): resultList.size = {}", rule, resultList.size());
         return resultList;
     }
 

--- a/opennms-dao-api/src/main/java/org/opennms/netmgt/dao/api/IpInterfaceDao.java
+++ b/opennms-dao-api/src/main/java/org/opennms/netmgt/dao/api/IpInterfaceDao.java
@@ -90,6 +90,14 @@ public interface IpInterfaceDao extends LegacyOnmsDao<OnmsIpInterface, Integer> 
     List<OnmsIpInterface> findByNodeId(Integer nodeId);
 
     /**
+     * Finds all {@link OnmsIpInterface} instances that have an {@code ipAddress} that is related to a physical
+     * address that is equal to the mac address of a {@code BridgeMacLink} of the addressed {@code node}.
+     * @param nodeId
+     * @return
+     */
+    List<OnmsIpInterface> findByMacLinkOfNode(Integer nodeId);
+
+    /**
      * <p>findByServiceType</p>
      *
      * @param svcName a {@link java.lang.String} object.

--- a/opennms-dao-api/src/main/java/org/opennms/netmgt/dao/api/IpInterfaceDao.java
+++ b/opennms-dao-api/src/main/java/org/opennms/netmgt/dao/api/IpInterfaceDao.java
@@ -95,7 +95,7 @@ public interface IpInterfaceDao extends LegacyOnmsDao<OnmsIpInterface, Integer> 
      * @param nodeId
      * @return
      */
-    List<OnmsIpInterface> findByMacLinkOfNode(Integer nodeId);
+    List<OnmsIpInterface> findByMacLinksOfNode(Integer nodeId);
 
     /**
      * <p>findByServiceType</p>

--- a/opennms-dao-api/src/main/java/org/opennms/netmgt/dao/api/SnmpInterfaceDao.java
+++ b/opennms-dao-api/src/main/java/org/opennms/netmgt/dao/api/SnmpInterfaceDao.java
@@ -51,6 +51,8 @@ public interface SnmpInterfaceDao extends LegacyOnmsDao<OnmsSnmpInterface, Integ
      */
     OnmsSnmpInterface findByNodeIdAndIfIndex(Integer nodeId, Integer ifIndex);
 
+    List<OnmsSnmpInterface> findByNodeId(Integer nodeId);
+
     /**
      * <p>findByForeignKeyAndIfIndex</p>
      *

--- a/opennms-dao-api/src/main/java/org/opennms/netmgt/dao/api/SnmpInterfaceDao.java
+++ b/opennms-dao-api/src/main/java/org/opennms/netmgt/dao/api/SnmpInterfaceDao.java
@@ -53,6 +53,8 @@ public interface SnmpInterfaceDao extends LegacyOnmsDao<OnmsSnmpInterface, Integ
 
     List<OnmsSnmpInterface> findByNodeId(Integer nodeId);
 
+    List<OnmsSnmpInterface> findByMacLinksOfNode(Integer nodeId);
+
     /**
      * <p>findByForeignKeyAndIfIndex</p>
      *

--- a/opennms-dao-mock/src/main/java/org/opennms/netmgt/dao/mock/MockIpInterfaceDao.java
+++ b/opennms-dao-mock/src/main/java/org/opennms/netmgt/dao/mock/MockIpInterfaceDao.java
@@ -197,7 +197,7 @@ public class MockIpInterfaceDao extends AbstractMockDao<OnmsIpInterface, Integer
     }
 
     @Override
-    public List<OnmsIpInterface> findByMacLinkOfNode(Integer nodeId) {
+    public List<OnmsIpInterface> findByMacLinksOfNode(Integer nodeId) {
         throw new UnsupportedOperationException("Not yet implemented!");
     }
 }

--- a/opennms-dao-mock/src/main/java/org/opennms/netmgt/dao/mock/MockIpInterfaceDao.java
+++ b/opennms-dao-mock/src/main/java/org/opennms/netmgt/dao/mock/MockIpInterfaceDao.java
@@ -196,4 +196,8 @@ public class MockIpInterfaceDao extends AbstractMockDao<OnmsIpInterface, Integer
         throw new UnsupportedOperationException("Not yet implemented!");
     }
 
+    @Override
+    public List<OnmsIpInterface> findByMacLinkOfNode(Integer nodeId) {
+        throw new UnsupportedOperationException("Not yet implemented!");
+    }
 }

--- a/opennms-dao-mock/src/main/java/org/opennms/netmgt/dao/mock/MockSnmpInterfaceDao.java
+++ b/opennms-dao-mock/src/main/java/org/opennms/netmgt/dao/mock/MockSnmpInterfaceDao.java
@@ -101,6 +101,11 @@ public class MockSnmpInterfaceDao extends AbstractMockDao<OnmsSnmpInterface, Int
     }
 
     @Override
+    public List<OnmsSnmpInterface> findByMacLinksOfNode(Integer nodeId) {
+        return Collections.emptyList();
+    }
+
+    @Override
     public OnmsSnmpInterface findByForeignKeyAndIfIndex(final String foreignSource, final String foreignId, final Integer ifIndex) {
         for (final OnmsSnmpInterface iface : findAll()) {
             final OnmsNode node = iface.getNode();

--- a/opennms-dao-mock/src/main/java/org/opennms/netmgt/dao/mock/MockSnmpInterfaceDao.java
+++ b/opennms-dao-mock/src/main/java/org/opennms/netmgt/dao/mock/MockSnmpInterfaceDao.java
@@ -32,6 +32,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 
 import org.opennms.netmgt.dao.api.SnmpInterfaceDao;
 import org.opennms.netmgt.model.OnmsNode;
@@ -92,6 +93,11 @@ public class MockSnmpInterfaceDao extends AbstractMockDao<OnmsSnmpInterface, Int
             }
         }
         return null;
+    }
+
+    @Override
+    public List<OnmsSnmpInterface> findByNodeId(final Integer nodeId) {
+        return findAll().stream().filter(itf -> itf.getNode().getId().equals(nodeId)).collect(Collectors.toList());
     }
 
     @Override

--- a/opennms-dao/src/main/java/org/opennms/netmgt/dao/hibernate/IpInterfaceDaoHibernate.java
+++ b/opennms-dao/src/main/java/org/opennms/netmgt/dao/hibernate/IpInterfaceDaoHibernate.java
@@ -84,7 +84,7 @@ public class IpInterfaceDaoHibernate extends AbstractDaoHibernate<OnmsIpInterfac
 
     /** {@inheritDoc} */
     @Override
-    public List<OnmsIpInterface> findByMacLinkOfNode(Integer nodeId) {
+    public List<OnmsIpInterface> findByMacLinksOfNode(Integer nodeId) {
         Assert.notNull(nodeId, "nodeId cannot be null");
         return find("from OnmsIpInterface ipInterface where ipInterface.ipAddress in (select ipNetToMedia.netAddress from IpNetToMedia ipNetToMedia where ipNetToMedia.physAddress in (select l.macAddress from BridgeMacLink l where l.node.id = ?))", nodeId);
     }

--- a/opennms-dao/src/main/java/org/opennms/netmgt/dao/hibernate/IpInterfaceDaoHibernate.java
+++ b/opennms-dao/src/main/java/org/opennms/netmgt/dao/hibernate/IpInterfaceDaoHibernate.java
@@ -84,6 +84,13 @@ public class IpInterfaceDaoHibernate extends AbstractDaoHibernate<OnmsIpInterfac
 
     /** {@inheritDoc} */
     @Override
+    public List<OnmsIpInterface> findByMacLinkOfNode(Integer nodeId) {
+        Assert.notNull(nodeId, "nodeId cannot be null");
+        return find("from OnmsIpInterface ipInterface where ipInterface.ipAddress in (select ipNetToMedia.netAddress from IpNetToMedia ipNetToMedia where ipNetToMedia.physAddress in (select l.macAddress from BridgeMacLink l where l.node.id = ?))", nodeId);
+    }
+
+    /** {@inheritDoc} */
+    @Override
     public OnmsIpInterface findByNodeIdAndIpAddress(Integer nodeId, String ipAddress) {
         return findUnique("select ipInterface from OnmsIpInterface as ipInterface where ipInterface.node.id = ? and ipInterface.ipAddress = ?", 
                           nodeId, 

--- a/opennms-dao/src/main/java/org/opennms/netmgt/dao/hibernate/SnmpInterfaceDaoHibernate.java
+++ b/opennms-dao/src/main/java/org/opennms/netmgt/dao/hibernate/SnmpInterfaceDaoHibernate.java
@@ -47,7 +47,7 @@ public class SnmpInterfaceDaoHibernate extends AbstractDaoHibernate<OnmsSnmpInte
     public OnmsSnmpInterface findByNodeIdAndIfIndex(Integer nodeId, Integer ifIndex) {
         Assert.notNull(nodeId, "nodeId may not be null");
         Assert.notNull(ifIndex, "ifIndex may not be null");
-        return findUnique("select distinct snmpIf from OnmsSnmpInterface as snmpIf where snmpIf.node.id = ? and snmpIf.ifIndex = ?", 
+        return findUnique("select snmpIf from OnmsSnmpInterface as snmpIf where snmpIf.node.id = ? and snmpIf.ifIndex = ?",
                           nodeId, 
                           ifIndex);
         
@@ -56,7 +56,7 @@ public class SnmpInterfaceDaoHibernate extends AbstractDaoHibernate<OnmsSnmpInte
     @Override
     public List<OnmsSnmpInterface> findByNodeId(Integer nodeId) {
         Assert.notNull(nodeId, "nodeId may not be null");
-        return find("select distinct snmpIf from OnmsSnmpInterface as snmpIf where snmpIf.node.id = ?",
+        return find("select snmpIf from OnmsSnmpInterface as snmpIf where snmpIf.node.id = ?",
                 nodeId);
 
     }
@@ -74,7 +74,7 @@ public class SnmpInterfaceDaoHibernate extends AbstractDaoHibernate<OnmsSnmpInte
         Assert.notNull(foreignSource, "foreignSource may not be null");
         Assert.notNull(foreignId, "foreignId may not be null");
         Assert.notNull(ifIndex, "ifIndex may not be null");
-        return findUnique("select distinct snmpIf from OnmsSnmpInterface as snmpIf join snmpIf.node as node where node.foreignSource = ? and node.foreignId = ? and node.type = 'A' and snmpIf.ifIndex = ?", 
+        return findUnique("select snmpIf from OnmsSnmpInterface as snmpIf join snmpIf.node as node where node.foreignSource = ? and node.foreignId = ? and node.type = 'A' and snmpIf.ifIndex = ?",
                           foreignSource, 
                           foreignId, 
                           ifIndex);
@@ -85,7 +85,7 @@ public class SnmpInterfaceDaoHibernate extends AbstractDaoHibernate<OnmsSnmpInte
         Assert.notNull(nodeId, "nodeId may not be null");
         Assert.notNull(description, "description may not be null");
 
-        return findUnique("SELECT DISTINCT snmpIf FROM OnmsSnmpInterface AS snmpIf WHERE snmpIf.node.id = ? AND (LOWER(snmpIf.ifDescr) = LOWER(?) OR LOWER(snmpIf.ifName) = LOWER(?))", 
+        return findUnique("SELECT snmpIf FROM OnmsSnmpInterface AS snmpIf WHERE snmpIf.node.id = ? AND (LOWER(snmpIf.ifDescr) = LOWER(?) OR LOWER(snmpIf.ifName) = LOWER(?))",
             nodeId, 
             description,
             description

--- a/opennms-dao/src/main/java/org/opennms/netmgt/dao/hibernate/SnmpInterfaceDaoHibernate.java
+++ b/opennms-dao/src/main/java/org/opennms/netmgt/dao/hibernate/SnmpInterfaceDaoHibernate.java
@@ -62,6 +62,14 @@ public class SnmpInterfaceDaoHibernate extends AbstractDaoHibernate<OnmsSnmpInte
     }
 
     @Override
+    public List<OnmsSnmpInterface> findByMacLinksOfNode(Integer nodeId) {
+        Assert.notNull(nodeId, "nodeId may not be null");
+        return find("from OnmsSnmpInterface snmpIf where snmpIf.physAddr in (select l.macAddress from BridgeMacLink l where l.node.id = ?)",
+                nodeId);
+
+    }
+
+    @Override
     public OnmsSnmpInterface findByForeignKeyAndIfIndex(String foreignSource, String foreignId, Integer ifIndex) {
         Assert.notNull(foreignSource, "foreignSource may not be null");
         Assert.notNull(foreignId, "foreignId may not be null");

--- a/opennms-dao/src/main/java/org/opennms/netmgt/dao/hibernate/SnmpInterfaceDaoHibernate.java
+++ b/opennms-dao/src/main/java/org/opennms/netmgt/dao/hibernate/SnmpInterfaceDaoHibernate.java
@@ -54,6 +54,14 @@ public class SnmpInterfaceDaoHibernate extends AbstractDaoHibernate<OnmsSnmpInte
     }
 
     @Override
+    public List<OnmsSnmpInterface> findByNodeId(Integer nodeId) {
+        Assert.notNull(nodeId, "nodeId may not be null");
+        return find("select distinct snmpIf from OnmsSnmpInterface as snmpIf where snmpIf.node.id = ?",
+                nodeId);
+
+    }
+
+    @Override
     public OnmsSnmpInterface findByForeignKeyAndIfIndex(String foreignSource, String foreignId, Integer ifIndex) {
         Assert.notNull(foreignSource, "foreignSource may not be null");
         Assert.notNull(foreignId, "foreignId may not be null");

--- a/opennms-web-api/src/main/java/org/opennms/web/enlinkd/EnLinkdElementFactory.java
+++ b/opennms-web-api/src/main/java/org/opennms/web/enlinkd/EnLinkdElementFactory.java
@@ -43,26 +43,15 @@ import javax.servlet.ServletContext;
 
 import org.opennms.core.criteria.Alias.JoinType;
 import org.opennms.core.criteria.Criteria;
+import org.opennms.core.criteria.CriteriaBuilder;
 import org.opennms.core.criteria.restrictions.EqRestriction;
 import org.opennms.core.criteria.restrictions.SqlRestriction.Type;
-import org.opennms.core.criteria.CriteriaBuilder;
 import org.opennms.core.spring.BeanUtils;
+import org.opennms.core.sysprops.SystemProperties;
 import org.opennms.core.utils.LldpUtils.LldpChassisIdSubType;
 import org.opennms.core.utils.LldpUtils.LldpPortIdSubType;
-import org.opennms.core.sysprops.SystemProperties;
-import org.opennms.netmgt.enlinkd.persistence.api.BridgeElementDao;
-import org.opennms.netmgt.enlinkd.service.api.BridgeTopologyService;
-import org.opennms.netmgt.enlinkd.persistence.api.CdpElementDao;
-import org.opennms.netmgt.enlinkd.persistence.api.CdpLinkDao;
 import org.opennms.netmgt.dao.api.IpInterfaceDao;
-import org.opennms.netmgt.enlinkd.persistence.api.IpNetToMediaDao;
-import org.opennms.netmgt.enlinkd.persistence.api.IsIsElementDao;
-import org.opennms.netmgt.enlinkd.persistence.api.IsIsLinkDao;
-import org.opennms.netmgt.enlinkd.persistence.api.LldpElementDao;
-import org.opennms.netmgt.enlinkd.persistence.api.LldpLinkDao;
 import org.opennms.netmgt.dao.api.NodeDao;
-import org.opennms.netmgt.enlinkd.persistence.api.OspfElementDao;
-import org.opennms.netmgt.enlinkd.persistence.api.OspfLinkDao;
 import org.opennms.netmgt.dao.api.SnmpInterfaceDao;
 import org.opennms.netmgt.enlinkd.model.BridgeElement;
 import org.opennms.netmgt.enlinkd.model.BridgeElement.BridgeDot1dBaseType;
@@ -79,16 +68,27 @@ import org.opennms.netmgt.enlinkd.model.IsIsLink.IsisISAdjNeighSysType;
 import org.opennms.netmgt.enlinkd.model.IsIsLink.IsisISAdjState;
 import org.opennms.netmgt.enlinkd.model.LldpElement;
 import org.opennms.netmgt.enlinkd.model.LldpLink;
-import org.opennms.netmgt.model.OnmsIpInterface;
-import org.opennms.netmgt.model.OnmsNode;
-import org.opennms.netmgt.model.OnmsSnmpInterface;
 import org.opennms.netmgt.enlinkd.model.OspfElement;
 import org.opennms.netmgt.enlinkd.model.OspfElement.Status;
 import org.opennms.netmgt.enlinkd.model.OspfElement.TruthValue;
 import org.opennms.netmgt.enlinkd.model.OspfLink;
+import org.opennms.netmgt.enlinkd.persistence.api.BridgeElementDao;
+import org.opennms.netmgt.enlinkd.persistence.api.CdpElementDao;
+import org.opennms.netmgt.enlinkd.persistence.api.CdpLinkDao;
+import org.opennms.netmgt.enlinkd.persistence.api.IpNetToMediaDao;
+import org.opennms.netmgt.enlinkd.persistence.api.IsIsElementDao;
+import org.opennms.netmgt.enlinkd.persistence.api.IsIsLinkDao;
+import org.opennms.netmgt.enlinkd.persistence.api.LldpElementDao;
+import org.opennms.netmgt.enlinkd.persistence.api.LldpLinkDao;
+import org.opennms.netmgt.enlinkd.persistence.api.OspfElementDao;
+import org.opennms.netmgt.enlinkd.persistence.api.OspfLinkDao;
 import org.opennms.netmgt.enlinkd.service.api.BridgePort;
 import org.opennms.netmgt.enlinkd.service.api.BridgeTopologyException;
+import org.opennms.netmgt.enlinkd.service.api.BridgeTopologyService;
 import org.opennms.netmgt.enlinkd.service.api.SharedSegment;
+import org.opennms.netmgt.model.OnmsIpInterface;
+import org.opennms.netmgt.model.OnmsNode;
+import org.opennms.netmgt.model.OnmsSnmpInterface;
 import org.opennms.web.api.Util;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -243,7 +243,6 @@ public class EnLinkdElementFactory implements InitializingBean,
 
     }
 
-    @Transactional
     public OspfLinkNode convertFromModel(int nodeid, OspfLink link) {
         OspfLinkNode linknode = create(nodeid, link);
 
@@ -368,7 +367,6 @@ public class EnLinkdElementFactory implements InitializingBean,
         return linknode;
     }        
         
-    @Transactional
     public CdpLinkNode convertFromModel(int nodeid, CdpLink link) {
         CdpLinkNode linknode = create(nodeid, link);
         linknode.setCdpCacheDevice(link.getCdpCacheDeviceId());
@@ -443,7 +441,6 @@ public class EnLinkdElementFactory implements InitializingBean,
         return linknode;
     }
     
-    @Transactional
     private LldpLinkNode convertFromModel(int nodeid, LldpLink link) {
         LldpLinkNode linknode = create(nodeid, link);
 
@@ -520,7 +517,6 @@ public class EnLinkdElementFactory implements InitializingBean,
         return nodelinks;
     }
 
-    @Transactional
     private IsisLinkNode convertFromModel(int nodeid, IsIsLink link) {
         IsisLinkNode linknode = new IsisLinkNode();
         linknode.setIsisCircIfIndex(link.getIsisCircIfIndex());
@@ -606,7 +602,6 @@ public class EnLinkdElementFactory implements InitializingBean,
         return bridgeNode;
     }
     
-    @Transactional
     private BridgeLinkNode convertFromModel(Integer nodeid, SharedSegment segment) throws BridgeTopologyException {
         
         BridgeLinkNode linknode = new BridgeLinkNode();
@@ -629,7 +624,6 @@ public class EnLinkdElementFactory implements InitializingBean,
         return addBridgeRemotesNodes(nodeid, null, linknode, segment);
     }
 
-    @Transactional
     private BridgeLinkNode convertFromModel(Integer nodeid, String mac, List<OnmsIpInterface> ipaddrs, SharedSegment segment) {
         BridgeLinkNode linknode = new BridgeLinkNode();
         
@@ -654,7 +648,6 @@ public class EnLinkdElementFactory implements InitializingBean,
         return addBridgeRemotesNodes(nodeid, mac, linknode, segment);
     }
 
-    @Transactional
     private BridgeLinkNode addBridgeRemotesNodes(Integer nodeid, String mac, BridgeLinkNode linknode,
             SharedSegment segment) {
 

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NodeLinkRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NodeLinkRestService.java
@@ -47,10 +47,9 @@ import org.opennms.web.enlinkd.LldpLinkNode;
 import org.opennms.web.enlinkd.OspfElementNode;
 import org.opennms.web.enlinkd.OspfLinkNode;
 import org.opennms.web.rest.model.v2.BridgeElementNodeDTO;
-import org.opennms.web.rest.model.v2.CdpElementNodeDTO;
-import org.opennms.web.rest.v2.api.NodeLinkRestApi;
 import org.opennms.web.rest.model.v2.BridgeLinkNodeDTO;
 import org.opennms.web.rest.model.v2.BridgeLinkRemoteNodeDTO;
+import org.opennms.web.rest.model.v2.CdpElementNodeDTO;
 import org.opennms.web.rest.model.v2.CdpLinkNodeDTO;
 import org.opennms.web.rest.model.v2.EnlinkdDTO;
 import org.opennms.web.rest.model.v2.IsisElementNodeDTO;
@@ -59,12 +58,13 @@ import org.opennms.web.rest.model.v2.LldpElementNodeDTO;
 import org.opennms.web.rest.model.v2.LldpLinkNodeDTO;
 import org.opennms.web.rest.model.v2.OspfElementNodeDTO;
 import org.opennms.web.rest.model.v2.OspfLinkNodeDTO;
+import org.opennms.web.rest.v2.api.NodeLinkRestApi;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 @Component
-@Transactional
+@Transactional(readOnly = true)
 public class NodeLinkRestService implements NodeLinkRestApi {
 
     private EnLinkdElementFactoryInterface enLinkdElementFactory;


### PR DESCRIPTION
Issue: https://issues.opennms.org/browse/NMS-13507

The current implementation used hundreds of separate SQL selects to retrieve the information necessary to derive bridge links. On a customer database the request `http://localhost:8980/opennms/api/v2/enlinkd/bridge_links/1322` took tens of seconds.

This PR prefetches some of the required information by bulk selects and uses caches for other information that are also loaded by  bulk selects. In summary, the improvements sped up rest request to around 125 milliseconds.