### PR TITLE
NMS-13779: Remove links to the wiki

### DIFF
--- a/opennms-webapp/src/main/webapp/WEB-INF/jsp/admin/rancid/rancidAdmin.jsp
+++ b/opennms-webapp/src/main/webapp/WEB-INF/jsp/admin/rancid/rancidAdmin.jsp
@@ -335,7 +335,6 @@
             Set to <em>true</em> the opennms.rancidIntegrationUseOnlyRancidAdapter property in <em>opennms.properties</em> 
             if you want use only the RancidAdapter to provision nodes to Rancid.
         </p>
-        <p>Detailed Documentation on all options can be found on <a title="The OpenNMS Project wiki" href="http://www.opennms.org" target="new">the OpenNMS wiki</a>.
         </p>
           <p><b>Select Group </b>: select the <em>Rancid group</em> to work on</p>
         

--- a/opennms-webapp/src/main/webapp/WEB-INF/jsp/admin/storage/storageAdmin.jsp
+++ b/opennms-webapp/src/main/webapp/WEB-INF/jsp/admin/storage/storageAdmin.jsp
@@ -254,7 +254,6 @@
         <span>Descriptions</span>
       </div>
       <div class="card-body">
-        <p>Detailed Documentation on all options can be found on <a title="The OpenNMS Project wiki" href="http://www.opennms.org" target="new">the OpenNMS wiki</a>.
         </p>
           <p><b>(Delete) Bucket Item</b>: Delete the specified image file from <em>bucket</em>.</p>
 

--- a/opennms-webapp/src/main/webapp/admin/index.jsp
+++ b/opennms-webapp/src/main/webapp/admin/index.jsp
@@ -264,7 +264,6 @@
         <span>Descriptions</span>
       </div>
       <div class="card-body">
-        <p>Detailed Documentation on all options can be found on <a title="The OpenNMS Project wiki" href="http://wiki.opennms.org" target="new">the OpenNMS wiki</a>.
         </p>
 
         <p><b>Configure Users, Groups and On-Call Roles</b>: Add, modify or delete


### PR DESCRIPTION
### All Contributors

We have in our global Web UI the "Help" menu which is always available and guides you to the official documentation. I don't think we have to tell on every other place where you can go to the documentation to get more detailed information :)

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-13779

