### PR TITLE
NMS-13782: fix synchronization issue in InterfaceToNodeCache

### DIFF
--- a/features/api-layer/core/src/main/java/org/opennms/features/apilayer/dao/InterfaceToNodeCacheImpl.java
+++ b/features/api-layer/core/src/main/java/org/opennms/features/apilayer/dao/InterfaceToNodeCacheImpl.java
@@ -31,8 +31,6 @@ package org.opennms.features.apilayer.dao;
 import java.net.InetAddress;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
 
 import org.opennms.integration.api.v1.dao.InterfaceToNodeCache;
 
@@ -45,13 +43,8 @@ public class InterfaceToNodeCacheImpl implements InterfaceToNodeCache {
     }
 
     @Override
-    public Stream<Integer> getNodeIds(String location, InetAddress ipAddr) {
-        return StreamSupport.stream(cache.getNodeId(location, ipAddr).spliterator(), false);
-    }
-
-    @Override
     public Optional<Integer> getFirstNodeId(String location, InetAddress ipAddr) {
-        return getNodeIds(location, ipAddr).findFirst();
+        return cache.getFirstNodeId(location, ipAddr);
     }
 
     @Override

--- a/features/discovery/src/main/java/org/opennms/netmgt/discovery/UnmanagedInterfaceFilter.java
+++ b/features/discovery/src/main/java/org/opennms/netmgt/discovery/UnmanagedInterfaceFilter.java
@@ -34,8 +34,6 @@ import java.util.Objects;
 import org.opennms.core.utils.InetAddressUtils;
 import org.opennms.netmgt.dao.api.InterfaceToNodeCache;
 
-import com.google.common.collect.Iterables;
-
 /**
  * Given a list of managed IP addresses, this filter will match IP addresses not in that
  * list, hence it is an unmanaged IP address filter.
@@ -50,7 +48,7 @@ public class UnmanagedInterfaceFilter implements IpAddressFilter {
 
     @Override
     public boolean matches(String location, InetAddress address) {
-        return Iterables.isEmpty(interfaceToNodeCache.getNodeId(location, address));
+        return interfaceToNodeCache.getFirstNodeId(location, address).isEmpty();
     }
 
     @Override

--- a/opennms-dao-api/src/main/java/org/opennms/netmgt/dao/api/AbstractInterfaceToNodeCache.java
+++ b/opennms-dao-api/src/main/java/org/opennms/netmgt/dao/api/AbstractInterfaceToNodeCache.java
@@ -28,9 +28,6 @@
 
 package org.opennms.netmgt.dao.api;
 
-import java.net.InetAddress;
-import java.util.Iterator;
-import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
@@ -57,12 +54,4 @@ public abstract class AbstractInterfaceToNodeCache implements InterfaceToNodeCac
         return s_instance.get(); 
     }
 
-    public Optional<Integer> getFirstNodeId(String location, InetAddress ipAddr) {
-		final Iterator<Integer> it = this.getNodeId(location, ipAddr).iterator();
-		if (it.hasNext()) {
-			return Optional.of(it.next());
-		} else {
-			return Optional.empty();
-		}
-	}
 }

--- a/opennms-dao-api/src/main/java/org/opennms/netmgt/dao/api/InterfaceToNodeCache.java
+++ b/opennms-dao-api/src/main/java/org/opennms/netmgt/dao/api/InterfaceToNodeCache.java
@@ -35,8 +35,6 @@ public interface InterfaceToNodeCache {
 
 	void dataSourceSync();
 
-	Iterable<Integer> getNodeId(String location, InetAddress ipAddr);
-
 	boolean setNodeId(String location, InetAddress ipAddr, int nodeId);
 
 	boolean removeNodeId(String location, InetAddress ipAddr, int nodeId);

--- a/opennms-dao-mock/src/main/java/org/opennms/netmgt/dao/mock/MockInterfaceToNodeCache.java
+++ b/opennms-dao-mock/src/main/java/org/opennms/netmgt/dao/mock/MockInterfaceToNodeCache.java
@@ -29,10 +29,9 @@
 package org.opennms.netmgt.dao.mock;
 
 import java.net.InetAddress;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 
 import org.opennms.netmgt.dao.api.AbstractInterfaceToNodeCache;
 
@@ -53,12 +52,12 @@ public class MockInterfaceToNodeCache extends AbstractInterfaceToNodeCache {
     }
 
     @Override
-    public Iterable<Integer> getNodeId(String location, InetAddress ipAddr) {
+    public Optional<Integer> getFirstNodeId(String location, InetAddress ipAddr) {
         final Integer nodeId = keyToNodeId.get(new Key(location, ipAddr));
         if (nodeId != null) {
-            return Arrays.asList(nodeId);
+            return Optional.of(nodeId);
         }
-        return Collections.emptySet();
+        return Optional.empty();
     }
 
     @Override

--- a/opennms-dao/src/test/java/org/opennms/netmgt/dao/hibernate/InterfaceToNodeCacheDaoImplIT.java
+++ b/opennms-dao/src/test/java/org/opennms/netmgt/dao/hibernate/InterfaceToNodeCacheDaoImplIT.java
@@ -60,8 +60,6 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionOperations;
 
-import com.google.common.collect.Iterables;
-
 @RunWith(OpenNMSJUnit4ClassRunner.class)
 @ContextConfiguration(locations={
         "classpath:/META-INF/opennms/applicationContext-soa.xml",
@@ -180,10 +178,6 @@ public class InterfaceToNodeCacheDaoImplIT implements InitializingBean {
 
         // Different node ID must return true again
         Assert.assertEquals(true, m_cache.setNodeId(MonitoringLocationDao.DEFAULT_MONITORING_LOCATION_ID, iface.getIpAddress(), node.getId()));
-
-        // Cache must return both results
-        Assert.assertTrue(Iterables.contains(m_cache.getNodeId(MonitoringLocationDao.DEFAULT_MONITORING_LOCATION_ID, iface.getIpAddress()), node.getId()));
-        Assert.assertTrue(Iterables.contains(m_cache.getNodeId(MonitoringLocationDao.DEFAULT_MONITORING_LOCATION_ID, iface.getIpAddress()), m_databasePopulator.getNode1().getId()));
 
         // Primary must be first
         Assert.assertEquals(m_databasePopulator.getNode1().getId(), m_cache.getFirstNodeId(MonitoringLocationDao.DEFAULT_MONITORING_LOCATION_ID, iface.getIpAddress()).get());

--- a/pom.xml
+++ b/pom.xml
@@ -1470,8 +1470,8 @@
     <powermockVersion>2.0.9</powermockVersion>
     <okhttpVersion>3.10.0</okhttpVersion>
     <okioVersion>1.14.0</okioVersion>
-    <opennmsApiVersion>0.7.0-SNAPSHOT</opennmsApiVersion>
-    <opennmsApiVersionOsgi>0.7.0</opennmsApiVersionOsgi>
+    <opennmsApiVersion>0.8.0-SNAPSHOT</opennmsApiVersion>
+    <opennmsApiVersionOsgi>0.8.0.SNAPSHOT</opennmsApiVersionOsgi>
     <osgiVersion>7.0.0</osgiVersion>
     <osgiAnnotationVersion>7.0.0</osgiAnnotationVersion>
     <osgiCompendiumVersion>7.0.0</osgiCompendiumVersion>


### PR DESCRIPTION
Issue: https://issues.opennms.org/browse/NMS-13782

This PR prevents unsynchronized access to the mutable internal data structure of `InterfaceToNodeCache`.