### PR TITLE
NMS-13799: install all OpenNMS packages in the docker image by default

### DIFF
--- a/opennms-container/horizon/Dockerfile
+++ b/opennms-container/horizon/Dockerfile
@@ -43,7 +43,7 @@ RUN groupadd -g 10001 opennms && \
 FROM horizon-base
 
 # A default which installs the required OpenNMS Horizon packages
-ARG ONMS_PACKAGES="opennms-core opennms-webapp-jetty opennms-webapp-hawtio"
+ARG ONMS_PACKAGES="opennms opennms-core opennms-webapp-jetty opennms-webapp-hawtio"
 
 # Allow to install optional packages via YUM
 ARG ADD_YUM_PACKAGES

--- a/opennms-container/horizon/Dockerfile
+++ b/opennms-container/horizon/Dockerfile
@@ -43,7 +43,7 @@ RUN groupadd -g 10001 opennms && \
 FROM horizon-base
 
 # A default which installs the required OpenNMS Horizon packages
-ARG ONMS_PACKAGES="opennms opennms-core opennms-webapp-jetty opennms-webapp-hawtio"
+ARG ONMS_PACKAGES="opennms-core opennms-webapp-jetty opennms-webapp-hawtio opennms-plugins"
 
 # Allow to install optional packages via YUM
 ARG ADD_YUM_PACKAGES


### PR DESCRIPTION
The horizon docker images originally only installed a subset of RPMs under the assumption they wouldn't be used in production, and should be kept slimmer.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-13799
