### PR TITLE
NMS-13812: Add default RRD package for BMP telemetry persistence

### DIFF
--- a/opennms-base-assembly/src/main/filtered/etc/telemetryd-configuration.xml
+++ b/opennms-base-assembly/src/main/filtered/etc/telemetryd-configuration.xml
@@ -167,6 +167,15 @@
         </adapter>
 
         <adapter name="BMP-Telemetry-Adapter" class-name="org.opennms.netmgt.telemetry.protocols.bmp.adapter.BmpTelemetryAdapter" enabled="false">
+           <package name="BMP-Default">
+              <rrd step="300">
+                 <rra>RRA:AVERAGE:0.5:1:2016</rra>
+                 <rra>RRA:AVERAGE:0.5:12:1488</rra>
+                 <rra>RRA:AVERAGE:0.5:288:366</rra>
+                 <rra>RRA:MAX:0.5:288:366</rra>
+                 <rra>RRA:MIN:0.5:288:366</rra>
+              </rrd>
+           </package>
         </adapter>
 
         <adapter name="BMP-OpenBMP-Integration-Adapter" class-name="org.opennms.netmgt.telemetry.protocols.bmp.adapter.openbmp.BmpIntegrationAdapter" enabled="false">


### PR DESCRIPTION
### All Contributors

* [x] Have you read our [Contribution Guidelines](https://github.com/OpenNMS/opennms/blob/develop/CONTRIBUTING.md)?
* [x] Have you (electronically) signed the [OpenNMS Contributor Agreement](https://cla-assistant.io/OpenNMS/opennms)?

## Reviewers hint

I have targeted the PR for foundation-2021 cause this is the first release we introduced our own implementation for persisting BMP telemetry data and is a bug in our default shipped configuration. We can easily move it forward to release-29.x branch if it is not important enough to break our point release policy for Meridian and config changes.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-13812

