### PR TITLE
NMS-13579: Fix link for release notes in about page

### DIFF
--- a/opennms-webapp/src/main/webapp/about/index.jsp
+++ b/opennms-webapp/src/main/webapp/about/index.jsp
@@ -76,7 +76,7 @@
 <table class="table table-sm">
   <tr>
     <th>Version:</th>
-    <td><a href="http://docs.opennms.org/opennms/releases/<%=Vault.getProperty("version.display")%>/releasenotes/releasenotes.html" target="_blank" title="Release Notes"><%=Vault.getProperty("version.display")%></a></td>
+    <td><a href="https://docs.opennms.com/horizon/<%=Vault.getProperty("version.display")%>/releasenotes/whatsnew.html" target="_blank" title="Release Notes"><%=Vault.getProperty("version.display")%></a></td>
   </tr>
 
   <tr>


### PR DESCRIPTION
### All Contributors

* [x] Have you read our [Contribution Guidelines](https://github.com/OpenNMS/opennms/blob/develop/CONTRIBUTING.md)?
* [x] Have you (electronically) signed the [OpenNMS Contributor Agreement](https://cla-assistant.io/OpenNMS/opennms)?

### Contribution Checklist

* Please [make an issue in the OpenNMS issue tracker](https://issues.opennms.org) if there isn't one already.<br />Once there is an issue, please:
  1. update the title of this PR to be in the format: `${JIRA-ISSUE-NUMBER}: subject of pull request`
  2. update the JIRA link at the bottom of this comment to refer to the real issue number
  3. prefix your commit messages with the issue number, if possible
  4. once you've created this PR, please link to it in a comment in the JIRA issue
  Don't worry if this sounds like a lot, we can help you get things set up properly.
* If this is a new or updated feature, is there documentation for the new behavior?
* If this is new code, are there unit and/or integration tests?
* If this PR targets a `foundation-*` branch, does it try to avoid changing files in `$OPENNMS_HOME/etc/`?

Fix version link to release notes in the about page.

### Reviewer hint

@RangerRick If we merge this to opennms-prime we have to rename horizon -> meridian in the link.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-13579

