### PR TITLE
NMS-13507: speed-up enlinkd link retrieval by bulk fetching and caching

### DIFF
--- a/features/enlinkd/persistence/api/src/main/java/org/opennms/netmgt/enlinkd/persistence/api/CdpElementDao.java
+++ b/features/enlinkd/persistence/api/src/main/java/org/opennms/netmgt/enlinkd/persistence/api/CdpElementDao.java
@@ -28,6 +28,8 @@
 
 package org.opennms.netmgt.enlinkd.persistence.api;
 
+import java.util.List;
+
 import org.opennms.netmgt.dao.api.OnmsDao;
 import org.opennms.netmgt.enlinkd.model.CdpElement;
 
@@ -39,6 +41,12 @@ public interface CdpElementDao extends OnmsDao<CdpElement, Integer> {
     public CdpElement findByNodeId(Integer id);
 
     public CdpElement findByGlobalDeviceId(String deviceId);
+
+    /**
+     * Returns all CdpElements that a have globalDeviceId that matches a cacheDeviceId of a CdpLink related to the given
+     * node. Used to retrieve all CdpElements that need to be accessed when finding cdp links of a node.
+     */
+    List<CdpElement> findByCacheDeviceIdOfCdpLinksOfNode(int nodeId);
 
     public void deleteByNodeId(Integer nodeId);
 }

--- a/features/enlinkd/persistence/api/src/main/java/org/opennms/netmgt/enlinkd/persistence/api/LldpElementDao.java
+++ b/features/enlinkd/persistence/api/src/main/java/org/opennms/netmgt/enlinkd/persistence/api/LldpElementDao.java
@@ -43,6 +43,13 @@ public interface LldpElementDao extends OnmsDao<LldpElement, Integer> {
 
     public List<LldpElement> findByChassisId(String chassisId, LldpChassisIdSubType type);
 
+    /**
+     * Returns all LldpElements that have a chassisId/chassisIdSubType that match the corresponding fields of a
+     * LldpElement that is related to the given node. Used to retrieve all LldpElements that need to be accessed when
+     * finding lldp links of a node.
+     */
+    List<LldpElement> findByChassisOfLldpLinksOfNode(int nodeId);
+
     public LldpElement findBySysname(String sysname);
 
     public void deleteByNodeId(Integer nodeid);

--- a/features/enlinkd/persistence/impl/src/main/java/org/opennms/netmgt/enlinkd/persistence/impl/CdpElementDaoHibernate.java
+++ b/features/enlinkd/persistence/impl/src/main/java/org/opennms/netmgt/enlinkd/persistence/impl/CdpElementDaoHibernate.java
@@ -73,6 +73,11 @@ public class CdpElementDaoHibernate extends AbstractDaoHibernate<CdpElement, Int
     }
 
     @Override
+    public List<CdpElement> findByCacheDeviceIdOfCdpLinksOfNode(int nodeId) {
+        return find("from CdpElement rec where rec.cdpGlobalDeviceId in (select l.cdpCacheDeviceId from CdpLink l where l.node.id = ?)", nodeId);
+    }
+
+    @Override
     public void deleteByNodeId(Integer nodeId) {
         getHibernateTemplate().bulkUpdate("delete from CdpElement rec where rec.node.id = ? ",
                                     new Object[] {nodeId});

--- a/features/enlinkd/persistence/impl/src/main/java/org/opennms/netmgt/enlinkd/persistence/impl/LldpElementDaoHibernate.java
+++ b/features/enlinkd/persistence/impl/src/main/java/org/opennms/netmgt/enlinkd/persistence/impl/LldpElementDaoHibernate.java
@@ -67,6 +67,12 @@ public class LldpElementDaoHibernate extends AbstractDaoHibernate<LldpElement, I
     }
 
     @Override
+    public List<LldpElement> findByChassisOfLldpLinksOfNode(int nodeId) {
+        return find("from LldpElement rec where exists (from LldpLink l where rec.lldpChassisId = l.lldpRemChassisId AND rec.lldpChassisIdSubType = l.lldpRemChassisIdSubType AND l.node.id = ?)",
+                nodeId);
+    }
+
+    @Override
     public LldpElement findBySysname(String sysname) {
         return findUnique("from LldpElement rec where rec.lldpSysname = ?",
                           sysname);

--- a/opennms-dao-api/src/main/java/org/opennms/netmgt/dao/api/NodeDao.java
+++ b/opennms-dao-api/src/main/java/org/opennms/netmgt/dao/api/NodeDao.java
@@ -298,4 +298,10 @@ public interface NodeDao extends LegacyOnmsDao<OnmsNode, Integer> {
     OnmsNode getDefaultFocusPoint();
 
     List<OnmsNode> findNodeWithMetaData(final String context, final String key, final String value);
+
+    /**
+     * Returns all OnmsNodes that have a sysname that matches remSysName of an lldp link that is related to the given
+     * node. Used to retrieve all OnmsNodes that need to be accessed when finding the lldp links of a node.
+     */
+    List<OnmsNode> findBySysNameOfLldpLinksOfNode(int nodeId);
 }

--- a/opennms-dao-mock/src/main/java/org/opennms/netmgt/dao/mock/MockNodeDao.java
+++ b/opennms-dao-mock/src/main/java/org/opennms/netmgt/dao/mock/MockNodeDao.java
@@ -190,6 +190,11 @@ public class MockNodeDao extends AbstractMockDao<OnmsNode, Integer> implements N
     }
 
     @Override
+    public List<OnmsNode> findBySysNameOfLldpLinksOfNode(int nodeId) {
+        return Collections.emptyList();
+    }
+
+    @Override
     public OnmsNode getHierarchy(final Integer id) {
         return get(id);
     }

--- a/opennms-dao/src/main/java/org/opennms/netmgt/dao/hibernate/NodeDaoHibernate.java
+++ b/opennms-dao/src/main/java/org/opennms/netmgt/dao/hibernate/NodeDaoHibernate.java
@@ -557,6 +557,11 @@ public class NodeDaoHibernate extends AbstractDaoHibernate<OnmsNode, Integer> im
     }
 
     @Override
+    public List<OnmsNode> findBySysNameOfLldpLinksOfNode(int nodeId) {
+        return find("from OnmsNode as n where n.sysName in (select l.lldpRemSysname from LldpLink l where l.node.id = ?)", nodeId);
+    }
+
+    @Override
     public OnmsNode getDefaultFocusPoint() {
         // getting the node which has the most ifspeed
         final String query2 = "select node.id from OnmsSnmpInterface as snmp join snmp.node as node group by node order by sum(snmp.ifSpeed) desc";

--- a/opennms-web-api/src/main/java/org/opennms/web/enlinkd/EnLinkdElementFactoryInterface.java
+++ b/opennms-web-api/src/main/java/org/opennms/web/enlinkd/EnLinkdElementFactoryInterface.java
@@ -28,13 +28,12 @@
 
 package org.opennms.web.enlinkd;
 
-import java.util.Collection;
 import java.util.List;
 
 public interface EnLinkdElementFactoryInterface {
 
 	List<BridgeElementNode> getBridgeElements(int nodeId);
-	Collection<BridgeLinkNode> getBridgeLinks(int nodeId);
+	List<BridgeLinkNode> getBridgeLinks(int nodeId);
 
 	IsisElementNode getIsisElement(int nodeId);
 	List<IsisLinkNode> getIsisLinks(int nodeId);
@@ -45,7 +44,35 @@ public interface EnLinkdElementFactoryInterface {
 	OspfElementNode getOspfElement(int nodeId);
 	List<OspfLinkNode> getOspfLinks(int nodeId);
 
-        CdpElementNode getCdpElement(int nodeId);
+    CdpElementNode getCdpElement(int nodeId);
 	List<CdpLinkNode> getCdpLinks(int nodeId);
 
+	ElementsAndLinks getAll(int nodeId);
+
+	class ElementsAndLinks {
+
+		public final List<BridgeElementNode> bridgeElements;
+		public final List<BridgeLinkNode> bridgeLinks;
+		public final IsisElementNode isisElement;
+		public final List<IsisLinkNode> isisLinks;
+		public final LldpElementNode lldpElement;
+		public final List<LldpLinkNode> lldpLinks;
+		public final OspfElementNode ospfElement;
+		public final List<OspfLinkNode> ospfLinks;
+		public final CdpElementNode cdpElement;
+		public final List<CdpLinkNode> cdpLinks;
+
+		public ElementsAndLinks(List<BridgeElementNode> bridgeElements, List<BridgeLinkNode> bridgeLinks, IsisElementNode isisElement, List<IsisLinkNode> isisLinks, LldpElementNode lldpElement, List<LldpLinkNode> lldpLinks, OspfElementNode ospfElement, List<OspfLinkNode> ospfLinks, CdpElementNode cdpElement, List<CdpLinkNode> cdpLinks) {
+			this.bridgeElements = bridgeElements;
+			this.bridgeLinks = bridgeLinks;
+			this.isisElement = isisElement;
+			this.isisLinks = isisLinks;
+			this.lldpElement = lldpElement;
+			this.lldpLinks = lldpLinks;
+			this.ospfElement = ospfElement;
+			this.ospfLinks = ospfLinks;
+			this.cdpElement = cdpElement;
+			this.cdpLinks = cdpLinks;
+		}
+	}
 }

--- a/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NodeLinkRestService.java
+++ b/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v2/NodeLinkRestService.java
@@ -30,6 +30,7 @@ package org.opennms.web.rest.v2;
 
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import org.opennms.netmgt.dao.api.NodeDao;
@@ -77,20 +78,25 @@ public class NodeLinkRestService implements NodeLinkRestApi {
         this.m_nodeDao = m_nodeDao;
     }
 
+    private static <F, T> List<T> map(List<F> from, Function<F, T> f) {
+        return from.stream().map(f).collect(Collectors.toList());
+    }
+
     @Override
     public EnlinkdDTO getEnlinkd(String nodeCriteria) {
         int nodeId = getNodeIdInDB(nodeCriteria);
+        var r = enLinkdElementFactory.getAll(nodeId);
         return new EnlinkdDTO()
-                .withLldpLinkNodeDTOs(getLldpLinks(nodeId))
-                .withBridgeLinkNodeDTOS(getBridgeLinks(nodeId))
-                .withCdpLinkNodeDTOS(getCdpLinks(nodeId))
-                .withOspfLinkNodeDTOS(getOspfLinks(nodeId))
-                .withIsisLinkNodeDTOS(getIsisLinks(nodeId))
-                .withLldpElementNodeDTO(getLldpElem(nodeId))
-                .withBridgeElementNodeDTOS(getBridgeElem(nodeId))
-                .withCdpElementNodeDTO(getCdpElem(nodeId))
-                .withOspfElementNodeDTO(getOspfelem(nodeId))
-                .withIsisElementNodeDTO(getIsisElem(nodeId));
+                .withLldpLinkNodeDTOs(map(r.lldpLinks, this::mapLldpLindNodeToDTO))
+                .withBridgeLinkNodeDTOS(map(r.bridgeLinks, this::mapBridgeLinkNodeToDTO))
+                .withCdpLinkNodeDTOS(map(r.cdpLinks, this::mapCdpLinkNodeToDTO))
+                .withOspfLinkNodeDTOS(map(r.ospfLinks, this::mapOspfLinkNodeToDTO))
+                .withIsisLinkNodeDTOS(map(r.isisLinks, this::mapIsisLinkNodeToDTO))
+                .withLldpElementNodeDTO(mapLldElementNodeToDTO(r.lldpElement))
+                .withBridgeElementNodeDTOS(map(r.bridgeElements, this::mapBridgeElementNodeToDTO))
+                .withCdpElementNodeDTO(mapCdpElementNodeToDTO(r.cdpElement))
+                .withOspfElementNodeDTO(mapOspfElementNodeToDTO(r.ospfElement))
+                .withIsisElementNodeDTO(mapIsisElementNodeToDTO(r.isisElement));
     }
 
     @Override


### PR DESCRIPTION
Issue: https://issues.opennms.org/browse/NMS-13507

This PR adds more bulk fetches and share caches for `BridgeElement` and `OnmsSnmpInterface` instances between different subtasks when all kinds of links are retrieved.

The results returned changed slightly because in the original implementation there was a bug in the `EnLinkdElementFactory.getFromCdpCacheDevicePort` method. The constructed `where` clause was not correct. The fix results in more specific cdp link information being retrieved.