### PR TITLE
NMS-13850: update to Log4j2 2.15.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1442,7 +1442,7 @@
     <liquibaseVersion>3.6.3</liquibaseVersion>
     <lmaxDisruptorVersion>3.3.2</lmaxDisruptorVersion>
     <log4jVersion>99.99.99-use-log4j2</log4jVersion>
-    <log4j2Version>2.13.2</log4j2Version>
+    <log4j2Version>2.15.0</log4j2Version>
     <logbackClassicVersion>1.2.3</logbackClassicVersion>
     <mapstructVersion>1.3.0.Final</mapstructVersion>
     <minaVersion>2.0.16</minaVersion>


### PR DESCRIPTION
This PR bumps to the latest version of log4j2.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-13850

