### PR TITLE
NMS-13850: update to Log4j2 2.15.0 (foundation-2018)

### DIFF
--- a/features/poller/remote/src/main/java/org/opennms/netmgt/poller/remote/support/Log4j2StringAppender.java
+++ b/features/poller/remote/src/main/java/org/opennms/netmgt/poller/remote/support/Log4j2StringAppender.java
@@ -29,7 +29,6 @@
 package org.opennms.netmgt.poller.remote.support;
 
 import java.io.ByteArrayOutputStream;
-import java.io.IOException;
 import java.io.Serializable;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.io.IOException;


### PR DESCRIPTION
Foundation 2018 version of pr #3985

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/${JIRA-ISSUE-NUMBER}

