### PR TITLE
NMS-13850: update to Log4j2 2.15.0 (foundation-2017)

### DIFF
--- a/features/poller/remote/src/main/java/org/opennms/netmgt/poller/remote/support/Log4j2StringAppender.java
+++ b/features/poller/remote/src/main/java/org/opennms/netmgt/poller/remote/support/Log4j2StringAppender.java
@@ -29,6 +29,7 @@
 package org.opennms.netmgt.poller.remote.support;
 
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.io.Serializable;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -106,8 +107,12 @@ public class Log4j2StringAppender extends AbstractOutputStreamAppender<Log4j2Str
 	}
 
 	public String getOutput() {
-		getManager().flush();
-		return new String(getManager().getByteArrayOutputStream().toByteArray());
+		try {
+			getManager().flush();
+			return new String(getManager().getByteArrayOutputStream().toByteArray());
+		} catch (IOException e) {
+			return new String();
+		}
 	}
 
 	public static class ByteArrayOutputStreamManager extends OutputStreamManager {
@@ -115,7 +120,7 @@ public class Log4j2StringAppender extends AbstractOutputStreamAppender<Log4j2Str
 			super(new ByteArrayOutputStream(), ByteArrayOutputStreamManager.class.getName(), layout, true);
 		}
 
-		public ByteArrayOutputStream getByteArrayOutputStream() {
+		public ByteArrayOutputStream getByteArrayOutputStream() throws IOException {
 			return (ByteArrayOutputStream)getOutputStream();
 		}
 	}

--- a/pom.xml
+++ b/pom.xml
@@ -1414,7 +1414,7 @@
     <liquibaseVersion>2.0.5-ONMS20160524b</liquibaseVersion>
     <lmaxDisruptorVersion>3.3.2</lmaxDisruptorVersion>
     <log4jVersion>99.99.99-use-log4j2</log4jVersion>
-    <log4j2Version>2.5</log4j2Version>
+    <log4j2Version>2.15.0</log4j2Version>
     <minaVersion>2.0.16</minaVersion>
     <mapstructVersion>1.2.0.CR1</mapstructVersion>
     <minionKarafVersion>4.0.5</minionKarafVersion>


### PR DESCRIPTION
This PR bumps to the latest version of log4j2.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-13850
