### PR TITLE
NMS-13858: fix logging dependencies (Foundation 2019)

### DIFF
--- a/container/karaf/pom.xml
+++ b/container/karaf/pom.xml
@@ -107,6 +107,46 @@
                 </configuration>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                      <phase>prepare-package</phase>
+                      <goals>
+                          <goal>copy</goal>
+                      </goals>
+                      <configuration>
+                          <artifactItems>
+                              <artifactItem>
+                                  <groupId>org.ops4j.pax.logging</groupId>
+                                  <artifactId>pax-logging-api</artifactId>
+                                  <version>${paxLoggingVersion}</version>
+                                  <overWrite>true</overWrite>
+                                  <outputDirectory>${project.build.directory}/assembly/system/org/ops4j/pax/logging/pax-logging-api/1.10.2</outputDirectory>
+                                  <destFileName>pax-logging-api-1.10.2.jar</destFileName>
+                              </artifactItem>
+                              <artifactItem>
+                                  <groupId>org.ops4j.pax.logging</groupId>
+                                  <artifactId>pax-logging-log4j2</artifactId>
+                                  <version>${paxLoggingVersion}</version>
+                                  <overWrite>true</overWrite>
+                                  <outputDirectory>${project.build.directory}/assembly/system/org/ops4j/pax/logging/pax-logging-log4j2/1.10.2</outputDirectory>
+                                  <destFileName>pax-logging-log4j2-1.10.2.jar</destFileName>
+                              </artifactItem>
+                              <artifactItem>
+                                  <groupId>org.ops4j.pax.logging</groupId>
+                                  <artifactId>pax-logging-logback</artifactId>
+                                  <version>${paxLoggingVersion}</version>
+                                  <overWrite>true</overWrite>
+                                  <outputDirectory>${project.build.directory}/assembly/system/org/ops4j/pax/logging/pax-logging-logback/1.10.2</outputDirectory>
+                                  <destFileName>pax-logging-logback-1.10.2.jar</destFileName>
+                              </artifactItem>
+                          </artifactItems>
+                      </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>net.nicoulaj.maven.plugins</groupId>
                 <artifactId>checksum-maven-plugin</artifactId>
                 <executions>

--- a/container/shared/pom.xml
+++ b/container/shared/pom.xml
@@ -107,6 +107,46 @@
                 </configuration>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                      <phase>prepare-package</phase>
+                      <goals>
+                          <goal>copy</goal>
+                      </goals>
+                      <configuration>
+                          <artifactItems>
+                              <artifactItem>
+                                  <groupId>org.ops4j.pax.logging</groupId>
+                                  <artifactId>pax-logging-api</artifactId>
+                                  <version>${paxLoggingVersion}</version>
+                                  <overWrite>true</overWrite>
+                                  <outputDirectory>${project.build.directory}/assembly/system/org/ops4j/pax/logging/pax-logging-api/1.10.2</outputDirectory>
+                                  <destFileName>pax-logging-api-1.10.2.jar</destFileName>
+                              </artifactItem>
+                              <artifactItem>
+                                  <groupId>org.ops4j.pax.logging</groupId>
+                                  <artifactId>pax-logging-log4j2</artifactId>
+                                  <version>${paxLoggingVersion}</version>
+                                  <overWrite>true</overWrite>
+                                  <outputDirectory>${project.build.directory}/assembly/system/org/ops4j/pax/logging/pax-logging-log4j2/1.10.2</outputDirectory>
+                                  <destFileName>pax-logging-log4j2-1.10.2.jar</destFileName>
+                              </artifactItem>
+                              <artifactItem>
+                                  <groupId>org.ops4j.pax.logging</groupId>
+                                  <artifactId>pax-logging-logback</artifactId>
+                                  <version>${paxLoggingVersion}</version>
+                                  <overWrite>true</overWrite>
+                                  <outputDirectory>${project.build.directory}/assembly/system/org/ops4j/pax/logging/pax-logging-logback/1.10.2</outputDirectory>
+                                  <destFileName>pax-logging-logback-1.10.2.jar</destFileName>
+                              </artifactItem>
+                          </artifactItems>
+                      </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <artifactId>maven-clean-plugin</artifactId>
                 <executions>
                     <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -1450,6 +1450,7 @@
     <netty4Version>4.1.48.Final</netty4Version>
     <newtsVersion>1.5.5</newtsVersion>
     <paxExamVersion>4.13.1</paxExamVersion>
+    <paxLoggingVersion>1.11.11</paxLoggingVersion>
     <paxSwissboxVersion>1.8.2</paxSwissboxVersion>
     <paxWebVersion>7.2.8</paxWebVersion>
     <protobufVersion>3.6.1</protobufVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -1442,7 +1442,7 @@
     <liquibaseVersion>3.6.3</liquibaseVersion>
     <lmaxDisruptorVersion>3.3.2</lmaxDisruptorVersion>
     <log4jVersion>99.99.99-use-log4j2</log4jVersion>
-    <log4j2Version>2.15.0</log4j2Version>
+    <log4j2Version>2.16.0</log4j2Version>
     <logbackClassicVersion>1.2.3</logbackClassicVersion>
     <mapstructVersion>1.3.0.Final</mapstructVersion>
     <minaVersion>2.0.16</minaVersion>


### PR DESCRIPTION
This PR fixes logging dependencies both inside and outside of Karaf.

### External References

* JIRA (Issue Tracker): http://issues.opennms.org/browse/NMS-13858

